### PR TITLE
Phase 1 follow-up: glTF textures, NSIS fixes, issue #3 crash/mirror/run

### DIFF
--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -65,7 +65,9 @@ private:
     TestSignalSource test_signal_;
     view::AudioBridge input_meter_bridge_;
     audio::Buffer<float> test_buffer_;        // Pre-allocated for audio callback
+    audio::Buffer<float> silence_buffer_;    // Pre-allocated silence for missing input
     std::vector<float*> test_ptrs_;           // Pre-allocated channel pointers
+    std::vector<const float*> silence_ptrs_;  // Pre-allocated silence channel pointers
     std::vector<const float*> meter_ptrs_;    // Pre-allocated for meter analysis
 };
 

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -66,6 +66,13 @@ bool StandaloneApp::start() {
         test_ptrs_[static_cast<size_t>(c)] = test_buffer_.view().channel_ptr(static_cast<size_t>(c));
     meter_ptrs_.resize(static_cast<size_t>(std::max(test_ch, config_.input_channels)));
 
+    // Pre-allocate silence buffer for when no input device is available
+    int silence_ch = std::max(config_.output_channels, 2);
+    silence_buffer_.resize(static_cast<size_t>(silence_ch), static_cast<size_t>(config_.buffer_size));
+    silence_ptrs_.resize(static_cast<size_t>(silence_ch));
+    for (int c = 0; c < silence_ch; ++c)
+        silence_ptrs_[static_cast<size_t>(c)] = silence_buffer_.view().channel_ptr(static_cast<size_t>(c));
+
     // Set up MIDI input (optional)
     if (desc.accepts_midi) {
         midi_system_ = midi::create_midi_system();
@@ -110,6 +117,15 @@ bool StandaloneApp::start() {
                 const_cast<const float* const*>(test_ptrs_.data()),
                 test_ptrs_.size(), static_cast<size_t>(ctx.buffer_size));
             actual_input = &test_input_view;
+        }
+
+        // Provide silence when no input is available (prevents null-channel crash)
+        audio::BufferView<const float> silence_view;
+        if (actual_input->num_channels() == 0) {
+            silence_view = audio::BufferView<const float>(
+                silence_ptrs_.data(), silence_ptrs_.size(),
+                static_cast<size_t>(ctx.buffer_size));
+            actual_input = &silence_view;
         }
 
         // Push input meter data using pre-allocated pointer array

--- a/core/view/js/web-compat-document.js
+++ b/core/view/js/web-compat-document.js
@@ -679,8 +679,25 @@ function __createMockGPUQueue(init) {
         var sliceSize = size == null ? source.length - sliceOffset : size;
         buffer._bytes.set(source.slice(sliceOffset, sliceOffset + sliceSize), begin);
     };
-    queue.writeTexture = function() {};
-    queue.copyExternalImageToTexture = function() {};
+    queue.writeTexture = function(destination, data, dataLayout, size) {
+        if (!destination || !destination.texture) return;
+        var texture = destination.texture;
+        var source = __toUint8Array(data);
+        texture._bytes = source;
+        texture._bytesPerRow = dataLayout && dataLayout.bytesPerRow ? dataLayout.bytesPerRow : 0;
+        texture._rowsPerImage = dataLayout && dataLayout.rowsPerImage ? dataLayout.rowsPerImage : (size && size[1] ? size[1] : texture.height || 1);
+    };
+    queue.copyExternalImageToTexture = function(source, destination, copySize) {
+        if (!source || !destination || !destination.texture) return;
+        var imageBitmap = source.source;
+        if (!imageBitmap || !imageBitmap._decodedPixels) return;
+        var texture = destination.texture;
+        texture._bytes = imageBitmap._decodedPixels;
+        texture._bytesPerRow = imageBitmap.width * 4;
+        texture._rowsPerImage = imageBitmap.height;
+        texture.width = imageBitmap.width;
+        texture.height = imageBitmap.height;
+    };
     queue.onSubmittedWorkDone = function() {
         return Promise.resolve(undefined);
     };
@@ -1080,6 +1097,39 @@ PulpResponse.prototype.clone = function() {
 var __PulpResponse = typeof globalThis.Response !== "undefined" ? globalThis.Response : PulpResponse;
 if (typeof globalThis.Response === "undefined") {
     globalThis.Response = __PulpResponse;
+}
+
+function createImageBitmap(source) {
+    var bytes;
+    if (source && source._bytes) {
+        bytes = source._bytes;
+    } else if (source instanceof ArrayBuffer) {
+        bytes = new Uint8Array(source);
+    } else if (source instanceof Uint8Array) {
+        bytes = source;
+    } else {
+        return Promise.reject(new Error("createImageBitmap: unsupported source type"));
+    }
+
+    if (typeof __decodeImageDataImpl === "function") {
+        var payload = JSON.stringify({ data: Array.from(bytes) });
+        var result = __decodeImageDataImpl(payload);
+        if (result && result.ok) {
+            var bitmap = {
+                width: result.width,
+                height: result.height,
+                _decodedPixels: new Uint8Array(result.pixels),
+                close: function() {}
+            };
+            return Promise.resolve(bitmap);
+        }
+        return Promise.reject(new Error("createImageBitmap: failed to decode image"));
+    }
+
+    return Promise.reject(new Error("createImageBitmap: no native decoder available"));
+}
+if (typeof globalThis.createImageBitmap === "undefined") {
+    globalThis.createImageBitmap = createImageBitmap;
 }
 
 function PulpURL(url) {

--- a/core/view/platform/mac/plugin_view_host_mac.mm
+++ b/core/view/platform/mac/plugin_view_host_mac.mm
@@ -64,7 +64,7 @@
 
 @implementation PulpPluginView
 
-- (BOOL)isFlipped { return YES; }
+- (BOOL)isFlipped { return NO; }
 - (BOOL)isAccessibilityElement { return YES; }
 - (NSAccessibilityRole)accessibilityRole { return NSAccessibilityGroupRole; }
 - (NSString*)accessibilityLabel { return @"Plugin UI"; }
@@ -217,7 +217,7 @@ private:
     return self;
 }
 
-- (BOOL)isFlipped { return YES; }
+- (BOOL)isFlipped { return NO; }
 
 - (void)setFrameSize:(NSSize)newSize {
     [super setFrameSize:newSize];

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -30,6 +30,11 @@
 
 #ifdef PULP_HAS_SKIA
 #include "webgpu/webgpu_cpp.h"
+#include "include/core/SkData.h"
+#include "include/core/SkImage.h"
+#include "include/core/SkPixmap.h"
+#include "include/core/SkImageInfo.h"
+#include "include/gpu/graphite/Image.h"
 #endif
 
 #if defined(_WIN32)
@@ -3714,6 +3719,52 @@ void WidgetBridge::register_api() {
         state.configured = true;
         return choc::value::createString(texture_id);
 #endif
+    });
+
+    engine_.register_function("__decodeImageDataImpl", [](choc::javascript::ArgumentList args) {
+        auto result = choc::value::createObject("");
+        result.addMember("ok", choc::value::createBool(false));
+
+#ifdef PULP_HAS_SKIA
+        auto payload_json = args.get<std::string>(0, "");
+        if (payload_json.empty()) return result;
+
+        choc::value::Value payload;
+        try {
+            payload = choc::json::parse(payload_json);
+        } catch (...) {
+            return result;
+        }
+
+        if (!payload.hasObjectMember("data")) return result;
+        auto encoded_bytes = json_bytes_to_vector(payload["data"]);
+        if (encoded_bytes.empty()) return result;
+
+        auto sk_data = SkData::MakeWithoutCopy(encoded_bytes.data(), encoded_bytes.size());
+        auto image = SkImages::DeferredFromEncodedData(sk_data);
+        if (!image) return result;
+
+        auto width = image->width();
+        auto height = image->height();
+        if (width <= 0 || height <= 0) return result;
+
+        auto info = SkImageInfo::Make(width, height, kRGBA_8888_SkColorType, kUnpremul_SkAlphaType);
+        std::vector<uint8_t> pixels(static_cast<size_t>(width) * height * 4);
+        if (!image->readPixels(info, pixels.data(), static_cast<size_t>(width) * 4, 0, 0)) {
+            return result;
+        }
+
+        auto pixel_array = choc::value::createEmptyArray();
+        for (auto byte : pixels) {
+            pixel_array.addArrayElement(choc::value::createInt32(static_cast<int32_t>(byte)));
+        }
+
+        result.setMember("ok", choc::value::createBool(true));
+        result.addMember("width", choc::value::createInt32(width));
+        result.addMember("height", choc::value::createInt32(height));
+        result.addMember("pixels", pixel_array);
+#endif
+        return result;
     });
 
     engine_.register_function("__gpuDestroyTextureImpl", [this](choc::javascript::ArgumentList args) {

--- a/ship/platform/win/installer_win.cpp
+++ b/ship/platform/win/installer_win.cpp
@@ -27,7 +27,8 @@ std::string generate_nsis_script(const InstallerConfig& config) {
     nsi << "OutFile \"" << config.output_path << "\"\n";
     nsi << "InstallDir \"" << install_root << "\\" << config.publisher
         << "\\" << config.product_name << "\"\n";
-    nsi << "InstallDirRegKey HKCU \"Software\\" << config.publisher
+    std::string reg_hive = config.per_user_install ? "HKCU" : "HKLM";
+    nsi << "InstallDirRegKey " << reg_hive << " \"Software\\" << config.publisher
         << "\\" << config.product_name << "\" \"\"\n";
 
     if (config.per_user_install) {
@@ -57,6 +58,7 @@ std::string generate_nsis_script(const InstallerConfig& config) {
     if (!config.license_path.empty()) {
         nsi << "!insertmacro MUI_PAGE_LICENSE \"" << config.license_path << "\"\n";
     }
+    nsi << "!insertmacro MUI_PAGE_DIRECTORY\n";
     nsi << "!insertmacro MUI_PAGE_COMPONENTS\n";
     nsi << "!insertmacro MUI_PAGE_INSTFILES\n";
     nsi << "!insertmacro MUI_PAGE_FINISH\n\n";
@@ -119,20 +121,22 @@ std::string generate_nsis_script(const InstallerConfig& config) {
     }
     nsi << "  Delete \"$INSTDIR\\uninstall.exe\"\n";
     nsi << "  RMDir \"$INSTDIR\"\n";
-    nsi << "  DeleteRegKey HKCU \"Software\\" << config.publisher
+    nsi << "  DeleteRegKey " << reg_hive << " \"Software\\" << config.publisher
         << "\\" << config.product_name << "\"\n";
+    nsi << "  DeleteRegKey " << reg_hive << " \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
+        << config.product_name << "\"\n";
     nsi << "SectionEnd\n\n";
 
     // Write uninstaller during install
     nsi << "Section \"-Post\"\n";
     nsi << "  WriteUninstaller \"$INSTDIR\\uninstall.exe\"\n";
-    nsi << "  WriteRegStr HKCU \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
+    nsi << "  WriteRegStr " << reg_hive << " \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
         << config.product_name << "\" \"DisplayName\" \"" << config.product_name << "\"\n";
-    nsi << "  WriteRegStr HKCU \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
+    nsi << "  WriteRegStr " << reg_hive << " \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
         << config.product_name << "\" \"UninstallString\" \"$INSTDIR\\uninstall.exe\"\n";
-    nsi << "  WriteRegStr HKCU \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
+    nsi << "  WriteRegStr " << reg_hive << " \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
         << config.product_name << "\" \"DisplayVersion\" \"" << config.version << "\"\n";
-    nsi << "  WriteRegStr HKCU \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
+    nsi << "  WriteRegStr " << reg_hive << " \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\"
         << config.product_name << "\" \"Publisher\" \"" << config.publisher << "\"\n";
     nsi << "SectionEnd\n";
 

--- a/test/test_nsis_installer.cpp
+++ b/test/test_nsis_installer.cpp
@@ -55,13 +55,31 @@ TEST_CASE("NSIS script per-user install uses LOCALAPPDATA", "[ship][installer]")
     REQUIRE_THAT(script, ContainsSubstring("RequestExecutionLevel user"));
 }
 
-TEST_CASE("NSIS script admin install uses PROGRAMFILES", "[ship][installer]") {
+TEST_CASE("NSIS script admin install uses PROGRAMFILES and HKLM", "[ship][installer]") {
     auto config = make_test_config();
     config.per_user_install = false;
     auto script = generate_nsis_script(config);
 
     REQUIRE_THAT(script, ContainsSubstring("$PROGRAMFILES"));
     REQUIRE_THAT(script, ContainsSubstring("RequestExecutionLevel admin"));
+    REQUIRE_THAT(script, ContainsSubstring("InstallDirRegKey HKLM"));
+    REQUIRE_THAT(script, ContainsSubstring("WriteRegStr HKLM"));
+}
+
+TEST_CASE("NSIS script per-user install uses HKCU registry", "[ship][installer]") {
+    auto config = make_test_config();
+    config.per_user_install = true;
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("InstallDirRegKey HKCU"));
+    REQUIRE_THAT(script, ContainsSubstring("WriteRegStr HKCU"));
+}
+
+TEST_CASE("NSIS script includes directory selection page", "[ship][installer]") {
+    auto config = make_test_config();
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("MUI_PAGE_DIRECTORY"));
 }
 
 TEST_CASE("NSIS script includes license page when path set", "[ship][installer]") {

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -3217,6 +3217,30 @@ static int cmd_run(const std::vector<std::string>& args) {
     fs::path binary;
     auto app_search_root = standalone_mode ? (build_dir / "bin") : (build_dir / "examples");
 
+    // On macOS, also check for .app bundles in the build directory
+#ifdef __APPLE__
+    auto find_app_bundle = [&](const fs::path& search_dir) -> fs::path {
+        if (!fs::exists(search_dir)) return {};
+        for (auto& entry : fs::directory_iterator(search_dir)) {
+            if (!entry.is_directory()) continue;
+            auto name = entry.path().filename().string();
+            if (name.size() > 4 && name.substr(name.size() - 4) == ".app") {
+                auto macos_dir = entry.path() / "Contents" / "MacOS";
+                if (fs::exists(macos_dir)) {
+                    for (auto& exec_entry : fs::directory_iterator(macos_dir)) {
+                        if (!exec_entry.is_regular_file()) continue;
+                        auto st = fs::status(exec_entry.path());
+                        if ((st.permissions() & fs::perms::owner_exec) != fs::perms::none) {
+                            return exec_entry.path();
+                        }
+                    }
+                }
+            }
+        }
+        return {};
+    };
+#endif
+
     if (!target_name.empty()) {
         // Search for the named target
         if (standalone_mode) {
@@ -3294,6 +3318,17 @@ static int cmd_run(const std::vector<std::string>& args) {
                 if (!binary.empty()) break;
             }
         }
+        // Fallback: search for .app bundles on macOS
+#ifdef __APPLE__
+        if (binary.empty()) {
+            binary = find_app_bundle(build_dir);
+            // found .app bundle
+        }
+        if (binary.empty()) {
+            binary = find_app_bundle(app_search_root);
+            // found .app bundle
+        }
+#endif
         if (binary.empty()) {
             std::cerr << "Error: no standalone binary found in " << app_search_root.string() << "\n";
             std::cerr << "  Create one with: pulp create MyApp --type app\n";


### PR DESCRIPTION
## Summary
Follow-up to PR #2 (Phase 1 commercial readiness), addressing remaining items and bug fixes.

### Added
- **createImageBitmap()** — decodes PNG/JPEG/WebP via Skia into RGBA pixels for Three.js GLTFLoader texture support
- **copyExternalImageToTexture()** — copies decoded image data to GPU textures in the buffered draw pipeline
- **queue.writeTexture()** — stores texture data on JS texture objects for later GPU upload

### Fixed
- **Standalone crash** (closes #3) — audio callback received empty input BufferView when no input device was active; now provides pre-allocated silence buffer as fallback
- **Mirrored plugin UI** (closes #3) — plugin views declared isFlipped=YES while CoreGraphicsCanvas already applied Y-flip; set to NO to match standalone
- **pulp run path** (closes #3) — CLI now finds macOS .app bundles, not just bare executables in build/bin/
- **NSIS installer** — added directory selection page, fixed registry hive (HKLM for admin, HKCU for user), added uninstall registry cleanup

### Test results
- macOS: 1616/1616 tests pass
- NSIS: 25 assertions in 10 test cases

## Test plan
- [ ] Verify standalone launches without crash on macOS
- [ ] Verify plugin UI renders correctly (not mirrored) in a DAW
- [ ] Verify `pulp run` finds .app bundles
- [ ] CI green on macOS, Linux, Windows