### PR TITLE
Add planning as private submodule, codify planning workflow

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -279,3 +279,4 @@ Keep hostnames and VM names local. Shared repo docs and skills should describe h
 ## Documentation
 
 Full setup guide: `docs/guides/local-ci.md`
+SSH key setup for Windows/Linux VMs: `docs/guides/local-ci.md` § "Set up SSH keys"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-# Planning and internal docs (committed to a separate private repo)
-/planning/
+# Planning and internal docs (private submodule)
 /.planning-repo/
 /research/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-# Planning and internal docs (private submodule)
+# Legacy planning paths (now a submodule at planning/)
 /.planning-repo/
-/research/
 
 # Build artifacts
 /build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "planning"]
+	path = planning
+	url = https://github.com/danielraffel/pulp-planning.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,8 +208,7 @@ pulp/
 Internal planning — capability assessments, feature specs, roadmaps, phase tracking, and design exploration — lives in the `planning/` submodule (private repo `pulp-planning`). This separation keeps the public repo focused on code, docs, and examples.
 
 ```
-planning/            # Private submodule — specs, assessments, roadmaps, phase tracking
-/research/           # Gitignored — research notes, reference material
+planning/            # Private submodule — specs, assessments, roadmaps, research, phase tracking
 ```
 
 When a phase completes, its spec moves to `planning/archive/`. Status is tracked in `planning/STATUS.md`. The `planning/` submodule is optional — external cloners can build and use Pulp without it.
@@ -279,7 +278,7 @@ The `planning/` directory is a private git submodule (`pulp-planning`). All inte
 - **Feature specs** — detailed plans for upcoming work
 - **Roadmaps and phase tracking** — STATUS.md, phase plans
 - **Design exploration** — architecture proposals, workflow designs
-- **Research notes** — reference material, technology evaluations
+- **Research notes** — reference material, technology evaluations, library reviews
 
 ### Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,20 +200,19 @@ pulp/
 ├── examples/              # Example projects
 ├── external/              # Third-party dependencies (vendored or fetched)
 ├── docs/                  # PUBLIC documentation (getting-started, API, guides)
-└── planning/              # LOCAL ONLY — gitignored, committed to a separate private repo
+└── planning/              # Private submodule (pulp-planning) — specs, roadmaps, assessments
 ```
 
-### What Does NOT Go in the Repo
+### What Does NOT Go in the Public Repo
 
-Planning documents, spec drafts, audit notes, phase tracking, and internal design exploration stay in `planning/` locally but are **gitignored** from this repo. They are committed to a separate private repository.
+Internal planning — capability assessments, feature specs, roadmaps, phase tracking, and design exploration — lives in the `planning/` submodule (private repo `pulp-planning`). This separation keeps the public repo focused on code, docs, and examples.
 
 ```
-# In .gitignore:
-/planning/           # Phase specs, status tracking, archived plans
-/research/           # Audit notes, competitive analysis
+planning/            # Private submodule — specs, assessments, roadmaps, phase tracking
+/research/           # Gitignored — research notes, reference material
 ```
 
-Planning docs live in `planning/` locally. When a phase completes, its spec moves to `planning/archive/`. Status is tracked in `planning/STATUS.md`. None of this is committed to this repo.
+When a phase completes, its spec moves to `planning/archive/`. Status is tracked in `planning/STATUS.md`. The `planning/` submodule is optional — external cloners can build and use Pulp without it.
 
 ---
 
@@ -266,10 +265,40 @@ Multiple explorations can run simultaneously. Multiple phases can be implemented
 
 ### Status Tracking
 
-Status is tracked locally in `planning/STATUS.md` (gitignored). Phase specs live in `planning/` with goals, deliverables, acceptance criteria, test plans, and notes.
+Status is tracked in `planning/STATUS.md` (private submodule). Phase specs live in `planning/` with goals, deliverables, acceptance criteria, test plans, and notes. After writing or updating files in `planning/`, always commit and push to the planning repo.
 
 ---
 
+## Planning & Internal Docs
+
+The `planning/` directory is a private git submodule (`pulp-planning`). All internal documents go here — never in the public repo.
+
+### What goes in `planning/`
+
+- **Capability assessments** — evaluating what Pulp needs to improve
+- **Feature specs** — detailed plans for upcoming work
+- **Roadmaps and phase tracking** — STATUS.md, phase plans
+- **Design exploration** — architecture proposals, workflow designs
+- **Research notes** — reference material, technology evaluations
+
+### Workflow
+
+When creating or updating planning documents:
+
+1. Write files to `planning/`
+2. Commit in the planning submodule: `cd planning && git add . && git commit`
+3. Push to the planning repo: `git push origin main`
+4. Optionally update the submodule pointer in the parent repo
+
+Never create branches or worktrees on the public repo for planning work. Write directly to the submodule.
+
+### Language guidelines
+
+Planning docs should use neutral, professional language:
+- "Capability assessment" not "competitive analysis"
+- "Feature evaluation" not "gap analysis against [project]"
+- "Reference implementation study" not "reverse engineering"
+- Focus on what Pulp needs, not on critiquing other projects
 
 ---
 
@@ -537,10 +566,25 @@ The CI skill (``.agents/skills/ci/SKILL.md``) is the single process for landing 
 
 PRs also trigger `.github/workflows/build.yml` which builds and tests on all three platforms via GitHub-hosted or Namespace runners. This is a redundant safety net — the local CI skill is the primary validation path.
 
-#### When to use what
+#### Runner priority (hard rule)
 
-- **Local CI (`local_ci.py`):** Primary. Always run before merging. Uses your Mac + SSH VMs.
-- **GitHub Actions:** Automatic on PR. Catches anything local CI missed. Required green before merge.
-- **Namespace:** Use for faster Ubuntu/Windows when local VMs are slow. Available via `workflow_dispatch` with `runner_provider: namespace`.
+**Always use Namespace for cloud CI. Never rely on GitHub-hosted runners as the primary path.**
+
+1. **Namespace** (default): `gh workflow run build.yml --ref <branch> -f runner_provider=namespace` — or use `python3 tools/local-ci/local_ci.py cloud run build <branch>` which respects the configured default.
+2. **Local VMs** (fallback): `ssh ubuntu`, `ssh win` via `local_ci.py run <branch>`
+3. **GitHub-hosted** (last resort): Only if both Namespace and local VMs are unavailable.
+
+macOS runs locally in parallel with Namespace Ubuntu/Windows builds.
+
+**The shared CI config MUST have Namespace as the default provider.** Verify with:
+```bash
+python3 tools/local-ci/local_ci.py cloud defaults
+# Should show: configured default provider: namespace
+```
+
+If it shows `github-hosted`, add this to `~/Library/Application Support/Pulp/local-ci/config.json`:
+```json
+{ "github_actions": { "defaults": { "provider": "namespace", "workflow": "build" } } }
+```
 
 See `docs/guides/local-ci.md` for setup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,11 +274,16 @@ The `planning/` directory is a private git submodule (`pulp-planning`). All inte
 
 ### What goes in `planning/`
 
-- **Capability assessments** — evaluating what Pulp needs to improve
 - **Feature specs** — detailed plans for upcoming work
 - **Roadmaps and phase tracking** — STATUS.md, phase plans
 - **Design exploration** — architecture proposals, workflow designs
-- **Research notes** — reference material, technology evaluations, library reviews
+
+### What goes in `planning/research/`
+
+- **Capability assessments** — evaluating what Pulp needs to improve
+- **Technology evaluations** — library reviews, framework studies
+- **Proposals** — package manager concepts, integration strategies
+- **Reference material** — notes from studying other implementations
 
 ### Workflow
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -119,6 +119,10 @@ pulp doctor --dry-run   # show what --fix would do
 
 In SDK mode, `pulp doctor` validates the generated project's `pulp.toml`, installed SDK location, checkout hint, and build state. In source-tree mode, it validates the active Pulp checkout and pinned external SDKs instead.
 
+### Cross-Platform CI (Optional)
+
+If you want to validate builds on macOS, Ubuntu, and Windows before merging, see the [Local CI guide](local-ci.md) — it covers SSH key setup for Windows and Linux VMs, host configuration, and the `pulp ci-local` runner.
+
 ## Project Structure
 
 A minimal Pulp plugin project:

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -383,18 +383,131 @@ If your Windows VM is Windows on ARM, you can either set `cmake_platform` to `"A
 
 ### 2. Set up SSH keys
 
-Each VM needs your public key in its `authorized_keys`. Standard procedure:
+Each VM needs your public key in its `authorized_keys`. The Linux path is
+straightforward; Windows requires extra steps because OpenSSH on Windows uses a
+separate file with strict ACLs for admin users.
+
+#### Find your public key (on your Mac)
+
+If your private key is `~/.ssh/id_ed25519`, your public key is:
+
+```bash
+cat ~/.ssh/id_ed25519.pub
+```
+
+Copy the output — you'll paste it on each VM. If you're running the VM in UTM
+or another hypervisor and can't copy/paste between host and guest, install the
+guest tools for your hypervisor first (e.g. SPICE guest tools for UTM/QEMU,
+VMware Tools, VirtualBox Guest Additions).
+
+#### Linux (Ubuntu)
+
+If `ssh-copy-id` is available and you can already reach the VM by password:
 
 ```bash
 ssh-copy-id ubuntu    # or whatever your host alias is
-ssh-copy-id win2
 ```
 
-Test that passwordless login works before proceeding:
+If you're setting up from scratch on a fresh VM, SSH into it (or open its
+console) and run:
+
+**1. Note the VM's IP address:**
+
+```bash
+ip addr show
+```
+
+Look for the `inet` line under your active adapter (usually `enp0s1` or `eth0`).
+
+**2. Install and enable the SSH server** (if not already running):
+
+```bash
+sudo apt update && sudo apt install -y openssh-server
+sudo systemctl enable --now ssh
+```
+
+**3. Add your public key:**
+
+```bash
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+echo "ssh-ed25519 AAAA...your-key-here..." >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+```
+
+**4. (Optional) Disable password auth** for tighter security:
+
+```bash
+sudo sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+sudo systemctl restart ssh
+```
+
+#### Windows
+
+On the Windows VM, open PowerShell **as Administrator** and run:
+
+**1. Note the VM's IP address** (you'll need it for SSH config later):
+
+```powershell
+ipconfig
+```
+
+Look for the `IPv4 Address` line under your active adapter.
+
+**2. Create the admin authorized_keys file and add your public key:**
+
+```powershell
+New-Item -Force -ItemType File -Path "C:\ProgramData\ssh\administrators_authorized_keys"
+Add-Content -Path "C:\ProgramData\ssh\administrators_authorized_keys" -Value "ssh-ed25519 AAAA...your-key-here..."
+```
+
+**3. Fix the ACL** (OpenSSH ignores the file if permissions are wrong):
+
+```powershell
+icacls "C:\ProgramData\ssh\administrators_authorized_keys" /inheritance:r /grant "SYSTEM:(F)" /grant "Administrators:(F)"
+```
+
+**4. Make sure sshd is running and set to auto-start:**
+
+```powershell
+Set-Service -Name sshd -StartupType Automatic
+Start-Service sshd
+```
+
+> **Why `administrators_authorized_keys`?** Windows OpenSSH uses
+> `C:\ProgramData\ssh\administrators_authorized_keys` for users in the
+> Administrators group, not `~/.ssh/authorized_keys`. The ACL step is required —
+> without it, sshd silently skips the file and falls back to password auth.
+
+#### Set up SSH config on your Mac
+
+Add entries to `~/.ssh/config` so you can type `ssh win` instead of remembering
+IPs and usernames:
+
+```
+Host win
+  HostName 192.168.64.5
+  User your-username
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
+  ConnectTimeout 5
+
+Host ubuntu
+  HostName 192.168.64.4
+  User your-username
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
+  ConnectTimeout 5
+```
+
+Replace the `HostName` values with the actual IPs from `ipconfig` (Windows) or
+`ip addr` (Linux). The host aliases here (`win`, `ubuntu`) are what you'll use
+in `hosts.local.json` for CI targets.
+
+#### Test passwordless login
 
 ```bash
 ssh ubuntu exit && echo "ok"
-ssh win2 exit && echo "ok"
+ssh win exit && echo "ok"
 ```
 
 ### 3. Clone the repo on each VM


### PR DESCRIPTION
## Summary
- Add `pulp-planning` as a git submodule at `planning/` (previously gitignored standalone repo)
- Add "Planning & Internal Docs" section to CLAUDE.md with workflow rules and language guidelines
- Consolidate `/research/` into `planning/` submodule
- External cloners without access to the private repo see an empty `planning/` dir — no functional impact

## Test plan
- [ ] `git submodule update --init` works for authorized users
- [ ] Build and tests unaffected (planning/ is not part of build)
- [ ] `python3 .private/audit-naming.py --check-source --check-docs` passes