### PR TITLE
Add develop/* branch support for CI and workflow

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -85,15 +85,21 @@ Creates a PR, runs CI, and merges on green. This is the default when someone say
 
 1. Ensure all changes are committed
 2. Push the branch to origin with `-u`
-3. Create a PR to main via `gh pr create`
+3. Create a PR via `gh pr create` (to main, or to a develop branch if specified)
 4. Run local CI: `python3 tools/local-ci/local_ci.py run <branch>`
 5. If ALL targets pass → `gh pr merge <PR#> --squash --delete-branch`
 6. If ANY target fails → report failures, leave PR open
 7. Notify when done (terminal bell)
 
 ```bash
-python3 tools/local-ci/local_ci.py run [branch]
+# Ship to main (default)
+python3 tools/local-ci/local_ci.py ship [branch]
+
+# Ship to a develop branch (for multi-piece features)
+python3 tools/local-ci/local_ci.py ship [branch] --base develop/package-manager
 ```
+
+**Develop branch workflow:** When working on complex features that use a `develop/*` integration branch, PRs target the develop branch instead of main. The develop branch itself merges to main at phase boundaries. Use `--base` to specify the target.
 
 ### `run [branch]` — Just validate, no PR
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'develop/**']
   workflow_dispatch:
     inputs:
       runner_provider:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,11 +222,12 @@ When a phase completes, its spec moves to `planning/archive/`. Status is tracked
 - **`main`** — always clean, always builds, always passes tests. Every commit on main should be something we're proud of.
 - **`explore/*`** — exploration branches for prototyping uncertain ideas. Created in worktrees. Never merged directly to main.
 - **`feature/*`** — the default branch for non-trivial implementation work. Use this for focused features, fixes, and polish slices.
+- **`develop/*`** — integration branches for complex, multi-piece features that need extended testing before merging to main. Feature branches merge to the develop branch first via PR; the develop branch merges to main at phase boundaries after full CI validation. Same quality bar as main.
 - **`phase/*`** — optional name for a larger, spec-driven feature branch tied to a concrete planning document. This is a special case of feature work, not a separate workflow.
 
 ### Default Branch Discipline
 
-- Default to a branch for any non-trivial change. Use `feature/*` unless the work is large enough to deserve a spec-driven `phase/*` branch.
+- Default to a branch for any non-trivial change. Use `feature/*` unless the work is large enough to deserve a spec-driven `phase/*` branch or a `develop/*` integration branch.
 - Treat `main` as a landing branch, not a scratch branch.
 - **Never push directly to main. No exceptions.** Every change must go through: branch → PR → CI green → merge.
 - Before merging to `main`, have high confidence the slice is stable: targeted tests pass, higher-risk changes get a clean detached validation pass with `./validate-build.sh`, and docs/status stay in sync.

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -584,6 +584,20 @@ pulp ci-local cleanup --apply --include-prepared
 
 `pulp ci-local run` is the most common command. It enqueues the current `HEAD`, joins the machine-global queue, and waits until that exact job finishes.
 
+### Develop branch workflow
+
+For complex, multi-piece features that use a `develop/*` integration branch, PRs target the develop branch instead of `main`. The `ship` command supports this via `--base`:
+
+```bash
+# Ship a feature to the develop branch (not main)
+pulp ci-local ship feature/pkg-registry --base develop/package-manager
+
+# The develop branch itself ships to main at phase boundaries
+pulp ci-local ship develop/package-manager
+```
+
+GitHub Actions CI triggers on PRs to both `main` and `develop/**` branches, so CI runs automatically regardless of the target.
+
 If you pass a branch name explicitly, for example `pulp ci-local run feature/my-branch`, local CI resolves and records that branch tip's exact SHA immediately. This prevents a stale launching checkout from accidentally queuing its own `HEAD` while you intended to validate a different branch.
 
 Before queueing, local CI now also records:


### PR DESCRIPTION
## Summary
- Enable PR-triggered CI for `develop/**` branches in `build.yml`
- Add `develop/*` as a permanent branch prefix in CLAUDE.md branch model
- Document `--base` flag for shipping PRs to develop branches in CI skill
- Add develop branch workflow section to `docs/guides/local-ci.md`

This is Phase 0 infrastructure for the package manager work, but the develop branch pattern is a permanent addition usable by any future complex feature.

## Test plan
- [ ] CI triggers on PRs to `develop/**` branches
- [ ] Existing CI behavior for PRs to `main` unchanged
- [ ] `ship --base develop/foo` creates PR targeting the develop branch