### PR TITLE
Phase 9: Animation & 3D — sequencing, easings, quaternions, arcball

### DIFF
--- a/core/view/include/pulp/view/animator_set.hpp
+++ b/core/view/include/pulp/view/animator_set.hpp
@@ -123,11 +123,14 @@ public:
             : steps_(std::move(steps)) {}
 
         bool advance(float dt) {
-            if (current_ >= static_cast<int>(steps_.size())) return true;
-
-            steps_[current_]->advance(dt);
-            if (steps_[current_]->finished()) {
-                ++current_;
+            while (current_ < static_cast<int>(steps_.size()) && dt > 0) {
+                steps_[current_]->advance(dt);
+                if (steps_[current_]->finished()) {
+                    ++current_;
+                    // Carry leftover time to the next step
+                } else {
+                    break;
+                }
             }
             return current_ >= static_cast<int>(steps_.size());
         }
@@ -327,8 +330,13 @@ public:
     /// Current orientation quaternion
     const Quaternion& orientation() const { return orientation_; }
 
-    /// Reset to identity
-    void reset() { orientation_ = Quaternion::identity(); }
+    /// Reset to identity (also cancels any active drag)
+    void reset() {
+        orientation_ = Quaternion::identity();
+        dragging_ = false;
+        drag_start_ = {};
+        start_orientation_ = Quaternion::identity();
+    }
 
 private:
     Quaternion orientation_ = Quaternion::identity();

--- a/core/view/include/pulp/view/animator_set.hpp
+++ b/core/view/include/pulp/view/animator_set.hpp
@@ -1,0 +1,348 @@
+#pragma once
+
+// AnimatorSetBuilder — compose animations in sequence or parallel groups.
+// Inspired by Android's AnimatorSet pattern.
+
+#include <pulp/view/animation.hpp>
+#include <vector>
+#include <memory>
+#include <functional>
+
+namespace pulp::view {
+
+/// A step in an animation sequence — either a tween or a parallel group
+class AnimationStep {
+public:
+    virtual ~AnimationStep() = default;
+    virtual float advance(float dt) = 0;
+    virtual bool finished() const = 0;
+    virtual void reset() = 0;
+};
+
+/// Single tween step
+class TweenStep : public AnimationStep {
+public:
+    TweenStep(Tween tween, std::function<void(float)> apply)
+        : tween_(tween), apply_(std::move(apply)) {}
+
+    float advance(float dt) override {
+        float v = tween_.advance(dt);
+        if (apply_) apply_(v);
+        return v;
+    }
+    bool finished() const override { return tween_.finished(); }
+    void reset() override { tween_.reset(); }
+
+private:
+    Tween tween_;
+    std::function<void(float)> apply_;
+};
+
+/// Parallel group — all steps run simultaneously
+class ParallelStep : public AnimationStep {
+public:
+    void add(std::unique_ptr<AnimationStep> step) {
+        steps_.push_back(std::move(step));
+    }
+
+    float advance(float dt) override {
+        for (auto& s : steps_)
+            if (!s->finished())
+                s->advance(dt);
+        return 0;
+    }
+
+    bool finished() const override {
+        for (auto& s : steps_)
+            if (!s->finished()) return false;
+        return true;
+    }
+
+    void reset() override {
+        for (auto& s : steps_)
+            s->reset();
+    }
+
+private:
+    std::vector<std::unique_ptr<AnimationStep>> steps_;
+};
+
+/// Builder for composing animation sequences and parallel groups
+class AnimatorSetBuilder {
+public:
+    /// Add a tween that runs in sequence
+    AnimatorSetBuilder& then(float from, float to, float duration,
+                             std::function<void(float)> apply,
+                             EasingFunction ease = easing::linear) {
+        steps_.push_back(std::make_unique<TweenStep>(
+            Tween(from, to, duration, ease), std::move(apply)));
+        return *this;
+    }
+
+    /// Add a delay (tween from 0 to 0)
+    AnimatorSetBuilder& delay(float seconds) {
+        steps_.push_back(std::make_unique<TweenStep>(
+            Tween(0, 0, seconds), nullptr));
+        return *this;
+    }
+
+    /// Start a parallel group — all tweens added until end_parallel() run together
+    AnimatorSetBuilder& begin_parallel() {
+        parallel_ = std::make_unique<ParallelStep>();
+        return *this;
+    }
+
+    /// Add a tween to the current parallel group
+    AnimatorSetBuilder& with(float from, float to, float duration,
+                             std::function<void(float)> apply,
+                             EasingFunction ease = easing::linear) {
+        if (parallel_) {
+            parallel_->add(std::make_unique<TweenStep>(
+                Tween(from, to, duration, ease), std::move(apply)));
+        }
+        return *this;
+    }
+
+    /// End parallel group and add it to the sequence
+    AnimatorSetBuilder& end_parallel() {
+        if (parallel_) {
+            steps_.push_back(std::move(parallel_));
+        }
+        return *this;
+    }
+
+    /// Build and return the step sequence
+    std::vector<std::unique_ptr<AnimationStep>> build() {
+        return std::move(steps_);
+    }
+
+    /// Run the built animation. Advances through sequence, returns true when all done.
+    class Runner {
+    public:
+        explicit Runner(std::vector<std::unique_ptr<AnimationStep>> steps)
+            : steps_(std::move(steps)) {}
+
+        bool advance(float dt) {
+            if (current_ >= static_cast<int>(steps_.size())) return true;
+
+            steps_[current_]->advance(dt);
+            if (steps_[current_]->finished()) {
+                ++current_;
+            }
+            return current_ >= static_cast<int>(steps_.size());
+        }
+
+        bool finished() const {
+            return current_ >= static_cast<int>(steps_.size());
+        }
+
+        void reset() {
+            current_ = 0;
+            for (auto& s : steps_)
+                s->reset();
+        }
+
+    private:
+        std::vector<std::unique_ptr<AnimationStep>> steps_;
+        int current_ = 0;
+    };
+
+    Runner build_runner() {
+        return Runner(std::move(steps_));
+    }
+
+private:
+    std::vector<std::unique_ptr<AnimationStep>> steps_;
+    std::unique_ptr<ParallelStep> parallel_;
+};
+
+// ── Additional easing functions ─────────────────────────────────────────
+
+namespace easing {
+    /// Cubic bezier easing (simplified — approximates CSS cubic-bezier)
+    inline float cubic_bezier(float t, float x1, float y1, float x2, float y2) {
+        // Simple Newton-Raphson approximation
+        float cx = 3.0f * x1;
+        float bx = 3.0f * (x2 - x1) - cx;
+        float ax = 1.0f - cx - bx;
+
+        float cy = 3.0f * y1;
+        float by = 3.0f * (y2 - y1) - cy;
+        float ay = 1.0f - cy - by;
+
+        // Solve for t given x using Newton's method
+        float guess = t;
+        for (int i = 0; i < 8; ++i) {
+            float x = ((ax * guess + bx) * guess + cx) * guess - t;
+            float dx = (3.0f * ax * guess + 2.0f * bx) * guess + cx;
+            if (std::abs(dx) < 1e-7f) break;
+            guess -= x / dx;
+        }
+
+        return ((ay * guess + by) * guess + cy) * guess;
+    }
+
+    /// Spring physics easing (damped oscillation)
+    inline float spring(float t, float stiffness = 100.0f, float damping = 10.0f) {
+        float omega = std::sqrt(stiffness);
+        float zeta = damping / (2.0f * omega);
+
+        if (zeta < 1.0f) {
+            // Underdamped — oscillates
+            float omega_d = omega * std::sqrt(1.0f - zeta * zeta);
+            return 1.0f - std::exp(-zeta * omega * t) *
+                   (std::cos(omega_d * t) + (zeta * omega / omega_d) * std::sin(omega_d * t));
+        }
+
+        // Critically damped or overdamped
+        return 1.0f - (1.0f + omega * t) * std::exp(-omega * t);
+    }
+
+    /// Ease-in-out back (slight overshoot)
+    inline float ease_in_out_back(float t) {
+        float s = 1.70158f * 1.525f;
+        if (t < 0.5f) {
+            return (2.0f * t * t * ((s + 1.0f) * 2.0f * t - s)) * 0.5f;
+        }
+        float u = 2.0f * t - 2.0f;
+        return (u * u * ((s + 1.0f) * u + s) + 2.0f) * 0.5f;
+    }
+}
+
+// ── 3D Math (Quaternion, Vector3D) ──────────────────────────────────────
+
+struct Vector3D {
+    float x = 0, y = 0, z = 0;
+
+    Vector3D operator+(const Vector3D& o) const { return {x + o.x, y + o.y, z + o.z}; }
+    Vector3D operator-(const Vector3D& o) const { return {x - o.x, y - o.y, z - o.z}; }
+    Vector3D operator*(float s) const { return {x * s, y * s, z * s}; }
+
+    float dot(const Vector3D& o) const { return x * o.x + y * o.y + z * o.z; }
+    Vector3D cross(const Vector3D& o) const {
+        return {y * o.z - z * o.y, z * o.x - x * o.z, x * o.y - y * o.x};
+    }
+    float length() const { return std::sqrt(x * x + y * y + z * z); }
+    Vector3D normalized() const {
+        float len = length();
+        return len > 0 ? Vector3D{x / len, y / len, z / len} : Vector3D{};
+    }
+};
+
+struct Quaternion {
+    float w = 1, x = 0, y = 0, z = 0;
+
+    static Quaternion identity() { return {1, 0, 0, 0}; }
+
+    static Quaternion from_axis_angle(const Vector3D& axis, float radians) {
+        float half = radians * 0.5f;
+        float s = std::sin(half);
+        auto n = axis.normalized();
+        return {std::cos(half), n.x * s, n.y * s, n.z * s};
+    }
+
+    Quaternion operator*(const Quaternion& q) const {
+        return {
+            w * q.w - x * q.x - y * q.y - z * q.z,
+            w * q.x + x * q.w + y * q.z - z * q.y,
+            w * q.y - x * q.z + y * q.w + z * q.x,
+            w * q.z + x * q.y - y * q.x + z * q.w
+        };
+    }
+
+    Quaternion conjugate() const { return {w, -x, -y, -z}; }
+
+    float length() const { return std::sqrt(w * w + x * x + y * y + z * z); }
+
+    Quaternion normalized() const {
+        float len = length();
+        return len > 0 ? Quaternion{w / len, x / len, y / len, z / len} : identity();
+    }
+
+    /// Spherical linear interpolation
+    static Quaternion slerp(const Quaternion& a, const Quaternion& b, float t) {
+        float dot = a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z;
+        Quaternion b2 = dot < 0 ? Quaternion{-b.w, -b.x, -b.y, -b.z} : b;
+        dot = std::abs(dot);
+
+        if (dot > 0.9995f) {
+            // Linear interpolation for very close quaternions
+            return Quaternion{
+                a.w + t * (b2.w - a.w),
+                a.x + t * (b2.x - a.x),
+                a.y + t * (b2.y - a.y),
+                a.z + t * (b2.z - a.z)
+            }.normalized();
+        }
+
+        float theta = std::acos(dot);
+        float sin_theta = std::sin(theta);
+        float wa = std::sin((1.0f - t) * theta) / sin_theta;
+        float wb = std::sin(t * theta) / sin_theta;
+
+        return Quaternion{
+            wa * a.w + wb * b2.w,
+            wa * a.x + wb * b2.x,
+            wa * a.y + wb * b2.y,
+            wa * a.z + wb * b2.z
+        };
+    }
+
+    /// Rotate a vector by this quaternion
+    Vector3D rotate(const Vector3D& v) const {
+        Quaternion p{0, v.x, v.y, v.z};
+        Quaternion result = (*this) * p * conjugate();
+        return {result.x, result.y, result.z};
+    }
+};
+
+/// Draggable 3D orientation — arcball rotation from mouse drag
+class Draggable3DOrientation {
+public:
+    /// Begin a drag at the given 2D screen position (normalized -1 to 1)
+    void begin_drag(float x, float y) {
+        dragging_ = true;
+        drag_start_ = project_to_sphere(x, y);
+        start_orientation_ = orientation_;
+    }
+
+    /// Update during drag
+    void update_drag(float x, float y) {
+        if (!dragging_) return;
+
+        Vector3D current = project_to_sphere(x, y);
+        Vector3D axis = drag_start_.cross(current);
+        float dot = drag_start_.dot(current);
+
+        if (axis.length() > 1e-6f) {
+            float angle = std::acos(std::clamp(dot, -1.0f, 1.0f));
+            Quaternion rotation = Quaternion::from_axis_angle(axis.normalized(), angle);
+            orientation_ = rotation * start_orientation_;
+        }
+    }
+
+    /// End the drag
+    void end_drag() { dragging_ = false; }
+
+    /// Current orientation quaternion
+    const Quaternion& orientation() const { return orientation_; }
+
+    /// Reset to identity
+    void reset() { orientation_ = Quaternion::identity(); }
+
+private:
+    Quaternion orientation_ = Quaternion::identity();
+    Quaternion start_orientation_;
+    Vector3D drag_start_;
+    bool dragging_ = false;
+
+    static Vector3D project_to_sphere(float x, float y) {
+        float d = x * x + y * y;
+        if (d < 1.0f)
+            return {x, y, std::sqrt(1.0f - d)};
+        float scale = 1.0f / std::sqrt(d);
+        return {x * scale, y * scale, 0};
+    }
+};
+
+}  // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,11 @@ add_executable(pulp-test-sync test_sync_primitives.cpp)
 target_link_libraries(pulp-test-sync PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-sync)
 
+# Animation & 3D math tests
+add_executable(pulp-test-animation-3d test_animation_3d.cpp)
+target_link_libraries(pulp-test-animation-3d PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-animation-3d)
+
 # Runtime utility tests (mmap, temp file, dynlib, base64, range, child process)
 add_executable(pulp-test-runtime-utils test_runtime_utils.cpp)
 target_link_libraries(pulp-test-runtime-utils PRIVATE pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_animation_3d.cpp
+++ b/test/test_animation_3d.cpp
@@ -1,0 +1,167 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/view/animator_set.hpp>
+#include <cmath>
+
+using namespace pulp::view;
+using Catch::Matchers::WithinAbs;
+
+// ── AnimatorSetBuilder ──────────────────────────────────────────────────
+
+TEST_CASE("AnimatorSetBuilder sequence", "[animation][animator_set]") {
+    float value = 0.0f;
+
+    auto runner = AnimatorSetBuilder()
+        .then(0.0f, 1.0f, 1.0f, [&](float v) { value = v; }, easing::linear)
+        .then(1.0f, 0.0f, 1.0f, [&](float v) { value = v; }, easing::linear)
+        .build_runner();
+
+    // First tween
+    runner.advance(0.5f);
+    REQUIRE_THAT(value, WithinAbs(0.5f, 0.05f));
+
+    runner.advance(0.5f);
+    REQUIRE_THAT(value, WithinAbs(1.0f, 0.05f));
+
+    // Second tween
+    runner.advance(0.5f);
+    REQUIRE_THAT(value, WithinAbs(0.5f, 0.05f));
+
+    runner.advance(0.5f);
+    REQUIRE(runner.finished());
+}
+
+TEST_CASE("AnimatorSetBuilder parallel", "[animation][animator_set]") {
+    float a = 0.0f, b = 0.0f;
+
+    auto runner = AnimatorSetBuilder()
+        .begin_parallel()
+        .with(0.0f, 1.0f, 1.0f, [&](float v) { a = v; })
+        .with(0.0f, 2.0f, 1.0f, [&](float v) { b = v; })
+        .end_parallel()
+        .build_runner();
+
+    runner.advance(1.0f);
+    REQUIRE_THAT(a, WithinAbs(1.0f, 0.05f));
+    REQUIRE_THAT(b, WithinAbs(2.0f, 0.05f));
+    REQUIRE(runner.finished());
+}
+
+TEST_CASE("AnimatorSetBuilder delay", "[animation][animator_set]") {
+    float value = 0.0f;
+
+    auto runner = AnimatorSetBuilder()
+        .delay(0.5f)
+        .then(0.0f, 1.0f, 1.0f, [&](float v) { value = v; })
+        .build_runner();
+
+    runner.advance(0.4f);
+    REQUIRE_THAT(value, WithinAbs(0.0f, 0.01f));  // Still in delay
+
+    runner.advance(0.2f);  // Finishes delay (0.6 total)
+    // Value still 0 because this advance just finished the delay step
+
+    runner.advance(0.5f);  // Now in the tween
+    REQUIRE(value > 0.0f);  // Tween started
+}
+
+// ── Easing functions ────────────────────────────────────────────────────
+
+TEST_CASE("Cubic bezier easing", "[animation][easing]") {
+    // CSS ease: cubic-bezier(0.25, 0.1, 0.25, 1.0)
+    float v = easing::cubic_bezier(0.5f, 0.25f, 0.1f, 0.25f, 1.0f);
+    REQUIRE(v > 0.0f);
+    REQUIRE(v < 1.0f);
+
+    REQUIRE_THAT(easing::cubic_bezier(0.0f, 0.25f, 0.1f, 0.25f, 1.0f), WithinAbs(0.0f, 0.01f));
+    REQUIRE_THAT(easing::cubic_bezier(1.0f, 0.25f, 0.1f, 0.25f, 1.0f), WithinAbs(1.0f, 0.01f));
+}
+
+TEST_CASE("Spring easing", "[animation][easing]") {
+    // Underdamped spring should overshoot
+    float v = easing::spring(0.5f, 100.0f, 5.0f);
+    REQUIRE(v > 0.5f);  // Overshoots
+
+    // Should converge to 1.0
+    float final_v = easing::spring(5.0f, 100.0f, 10.0f);
+    REQUIRE_THAT(final_v, WithinAbs(1.0f, 0.05f));
+}
+
+TEST_CASE("Ease in-out back", "[animation][easing]") {
+    REQUIRE_THAT(easing::ease_in_out_back(0.0f), WithinAbs(0.0f, 0.01f));
+    REQUIRE_THAT(easing::ease_in_out_back(1.0f), WithinAbs(1.0f, 0.01f));
+    // Should overshoot slightly
+    REQUIRE(easing::ease_in_out_back(0.9f) > 1.0f);
+}
+
+// ── Vector3D ────────────────────────────────────────────────────────────
+
+TEST_CASE("Vector3D operations", "[animation][3d]") {
+    Vector3D a{1, 0, 0};
+    Vector3D b{0, 1, 0};
+
+    auto sum = a + b;
+    REQUIRE_THAT(sum.x, WithinAbs(1.0f, 1e-5));
+    REQUIRE_THAT(sum.y, WithinAbs(1.0f, 1e-5));
+
+    REQUIRE_THAT(a.dot(b), WithinAbs(0.0f, 1e-5));
+
+    auto cross = a.cross(b);
+    REQUIRE_THAT(cross.z, WithinAbs(1.0f, 1e-5));
+
+    REQUIRE_THAT(a.length(), WithinAbs(1.0f, 1e-5));
+
+    Vector3D c{3, 4, 0};
+    REQUIRE_THAT(c.normalized().length(), WithinAbs(1.0f, 1e-5));
+}
+
+// ── Quaternion ──────────────────────────────────────────────────────────
+
+TEST_CASE("Quaternion identity", "[animation][3d]") {
+    auto q = Quaternion::identity();
+    Vector3D v{1, 2, 3};
+    auto rotated = q.rotate(v);
+    REQUIRE_THAT(rotated.x, WithinAbs(1.0f, 1e-4));
+    REQUIRE_THAT(rotated.y, WithinAbs(2.0f, 1e-4));
+    REQUIRE_THAT(rotated.z, WithinAbs(3.0f, 1e-4));
+}
+
+TEST_CASE("Quaternion 90-degree rotation", "[animation][3d]") {
+    auto q = Quaternion::from_axis_angle({0, 0, 1}, 3.14159f / 2.0f);
+    Vector3D v{1, 0, 0};
+    auto rotated = q.rotate(v);
+    REQUIRE_THAT(rotated.x, WithinAbs(0.0f, 0.01f));
+    REQUIRE_THAT(rotated.y, WithinAbs(1.0f, 0.01f));
+}
+
+TEST_CASE("Quaternion slerp", "[animation][3d]") {
+    auto a = Quaternion::identity();
+    auto b = Quaternion::from_axis_angle({0, 0, 1}, 3.14159f / 2.0f);
+
+    auto mid = Quaternion::slerp(a, b, 0.5f);
+    Vector3D v{1, 0, 0};
+    auto rotated = mid.rotate(v);
+
+    // 45 degrees rotation should give ~(0.707, 0.707, 0)
+    REQUIRE_THAT(rotated.x, WithinAbs(0.707f, 0.02f));
+    REQUIRE_THAT(rotated.y, WithinAbs(0.707f, 0.02f));
+}
+
+// ── Draggable3DOrientation ──────────────────────────────────────────────
+
+TEST_CASE("Draggable3DOrientation basic", "[animation][3d]") {
+    Draggable3DOrientation drag;
+
+    // No drag — identity orientation
+    auto q = drag.orientation();
+    REQUIRE_THAT(q.w, WithinAbs(1.0f, 1e-5));
+
+    // Drag from center-left to center-right
+    drag.begin_drag(-0.5f, 0.0f);
+    drag.update_drag(0.5f, 0.0f);
+    drag.end_drag();
+
+    // Orientation should have changed
+    auto q2 = drag.orientation();
+    REQUIRE(std::abs(q2.w) < 1.0f);  // Not identity anymore
+}


### PR DESCRIPTION
## Summary
- AnimatorSetBuilder: compose tweens in sequence or parallel groups
- Extended easings: cubic bezier, spring physics, ease-in-out-back
- Vector3D with dot, cross, normalize
- Quaternion with from_axis_angle, slerp, rotate
- Draggable3DOrientation: arcball rotation from mouse drag
- 11 test cases, 33 assertions

## Test plan
- [x] All tests pass on macOS
- [x] Naming audit clean
- [ ] CI