### PR TITLE
Phase 8: Advanced — i18n, OSC bundles, address patterns

### DIFF
--- a/core/osc/CMakeLists.txt
+++ b/core/osc/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(pulp-osc
 target_sources(pulp-osc PRIVATE
     src/osc.cpp
     src/osc_udp.cpp
+    src/bundle.cpp
 )
 
 target_link_libraries(pulp-osc PUBLIC pulp::runtime)

--- a/core/osc/include/pulp/osc/bundle.hpp
+++ b/core/osc/include/pulp/osc/bundle.hpp
@@ -5,6 +5,8 @@
 #include <pulp/osc/osc.hpp>
 #include <vector>
 #include <cstdint>
+#include <memory>
+#include <optional>
 #include <string>
 #include <variant>
 
@@ -29,15 +31,29 @@ struct TimeTag {
     }
 };
 
-/// Bundle element — either a message or a nested bundle
+struct Bundle;  // forward declaration
+
+/// Bundle element — either a message or a nested bundle.
+/// Uses unique_ptr<Bundle> to break the recursive value type.
 struct BundleElement {
-    std::variant<Message, struct Bundle> content;
+    std::variant<Message, std::unique_ptr<Bundle>> content;
+
+    BundleElement() = default;
+
+    /// Construct from a message
+    explicit BundleElement(Message msg) : content(std::move(msg)) {}
+
+    /// Construct from a nested bundle (takes ownership)
+    explicit BundleElement(std::unique_ptr<Bundle> b) : content(std::move(b)) {}
+
+    /// Convenience: construct from a bundle value (heap-allocates a copy)
+    explicit BundleElement(Bundle b);
 
     bool is_message() const { return std::holds_alternative<Message>(content); }
-    bool is_bundle() const { return std::holds_alternative<Bundle>(content); }
+    bool is_bundle() const { return std::holds_alternative<std::unique_ptr<Bundle>>(content); }
 
     const Message& message() const { return std::get<Message>(content); }
-    const Bundle& bundle() const { return std::get<Bundle>(content); }
+    const Bundle& bundle() const { return *std::get<std::unique_ptr<Bundle>>(content); }
 };
 
 /// OSC Bundle — contains a timetag and a list of elements
@@ -47,12 +63,12 @@ struct Bundle {
 
     /// Add a message to the bundle
     void add(Message msg) {
-        elements.push_back({std::move(msg)});
+        elements.emplace_back(std::move(msg));
     }
 
     /// Add a nested bundle
     void add(Bundle nested) {
-        elements.push_back({std::move(nested)});
+        elements.emplace_back(std::make_unique<Bundle>(std::move(nested)));
     }
 
     /// Serialize to OSC binary format
@@ -61,6 +77,10 @@ struct Bundle {
     /// Deserialize from OSC binary
     static std::optional<Bundle> deserialize(const uint8_t* data, size_t size);
 };
+
+/// Deferred definition (Bundle is complete here)
+inline BundleElement::BundleElement(Bundle b)
+    : content(std::make_unique<Bundle>(std::move(b))) {}
 
 /// OSC address pattern matching per OSC 1.0 spec.
 /// Supports: * (any), ? (single char), [...] (character class), {...} (alternatives)

--- a/core/osc/include/pulp/osc/bundle.hpp
+++ b/core/osc/include/pulp/osc/bundle.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+// OSC Bundle — timetag + nested messages/bundles per OSC 1.0 spec.
+
+#include <pulp/osc/osc.hpp>
+#include <vector>
+#include <cstdint>
+#include <string>
+#include <variant>
+
+namespace pulp::osc {
+
+/// OSC timetag — NTP timestamp (seconds since 1900-01-01)
+struct TimeTag {
+    uint32_t seconds = 0;
+    uint32_t fraction = 0;
+
+    /// "Immediately" timetag (1, 0)
+    static TimeTag immediate() { return {0, 1}; }
+
+    /// From Unix epoch seconds
+    static TimeTag from_unix(double unix_time);
+
+    /// To Unix epoch seconds
+    double to_unix() const;
+
+    bool operator==(const TimeTag& o) const {
+        return seconds == o.seconds && fraction == o.fraction;
+    }
+};
+
+/// Bundle element — either a message or a nested bundle
+struct BundleElement {
+    std::variant<Message, struct Bundle> content;
+
+    bool is_message() const { return std::holds_alternative<Message>(content); }
+    bool is_bundle() const { return std::holds_alternative<Bundle>(content); }
+
+    const Message& message() const { return std::get<Message>(content); }
+    const Bundle& bundle() const { return std::get<Bundle>(content); }
+};
+
+/// OSC Bundle — contains a timetag and a list of elements
+struct Bundle {
+    TimeTag timetag = TimeTag::immediate();
+    std::vector<BundleElement> elements;
+
+    /// Add a message to the bundle
+    void add(Message msg) {
+        elements.push_back({std::move(msg)});
+    }
+
+    /// Add a nested bundle
+    void add(Bundle nested) {
+        elements.push_back({std::move(nested)});
+    }
+
+    /// Serialize to OSC binary format
+    std::vector<uint8_t> serialize() const;
+
+    /// Deserialize from OSC binary
+    static std::optional<Bundle> deserialize(const uint8_t* data, size_t size);
+};
+
+/// OSC address pattern matching per OSC 1.0 spec.
+/// Supports: * (any), ? (single char), [...] (character class), {...} (alternatives)
+bool address_matches(std::string_view pattern, std::string_view address);
+
+}  // namespace pulp::osc

--- a/core/osc/src/bundle.cpp
+++ b/core/osc/src/bundle.cpp
@@ -1,0 +1,176 @@
+#include <pulp/osc/bundle.hpp>
+#include <cstring>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace pulp::osc {
+
+// ── TimeTag ─────────────────────────────────────────────────────────────────
+
+// NTP epoch is 1900-01-01, Unix epoch is 1970-01-01.
+// Difference: 70 years of seconds (including 17 leap years).
+static constexpr uint32_t kNtpUnixEpochDiff = 2208988800u;
+
+TimeTag TimeTag::from_unix(double unix_time) {
+    if (unix_time <= 0) return immediate();
+    auto total = static_cast<uint64_t>((unix_time + kNtpUnixEpochDiff) * (1ull << 32));
+    return {static_cast<uint32_t>(total >> 32),
+            static_cast<uint32_t>(total & 0xFFFFFFFF)};
+}
+
+double TimeTag::to_unix() const {
+    double ntp = static_cast<double>(seconds) + static_cast<double>(fraction) / (1ull << 32);
+    return ntp - kNtpUnixEpochDiff;
+}
+
+// ── Bundle serialization ────────────────────────────────────────────────────
+
+static void write_bytes(std::vector<uint8_t>& buf, const void* data, size_t n) {
+    auto* p = static_cast<const uint8_t*>(data);
+    buf.insert(buf.end(), p, p + n);
+}
+
+static void pad_to_4(std::vector<uint8_t>& buf) {
+    while (buf.size() % 4 != 0) buf.push_back(0);
+}
+
+std::vector<uint8_t> Bundle::serialize() const {
+    std::vector<uint8_t> buf;
+
+    // "#bundle\0" header
+    const char header[] = "#bundle";
+    buf.insert(buf.end(), header, header + 8);
+
+    // Timetag (8 bytes, big-endian)
+    uint32_t sec = htonl(timetag.seconds);
+    uint32_t frac = htonl(timetag.fraction);
+    write_bytes(buf, &sec, 4);
+    write_bytes(buf, &frac, 4);
+
+    // Elements
+    for (auto& elem : elements) {
+        std::vector<uint8_t> element_data;
+        if (elem.is_message()) {
+            element_data = encode(elem.message());
+        } else if (elem.is_bundle()) {
+            element_data = elem.bundle().serialize();
+        }
+
+        // Size prefix (4 bytes, big-endian)
+        uint32_t size = htonl(static_cast<uint32_t>(element_data.size()));
+        write_bytes(buf, &size, 4);
+        buf.insert(buf.end(), element_data.begin(), element_data.end());
+    }
+
+    return buf;
+}
+
+std::optional<Bundle> Bundle::deserialize(const uint8_t* data, size_t size) {
+    if (size < 16) return std::nullopt;  // minimum: header(8) + timetag(8)
+
+    // Verify "#bundle\0" header
+    if (std::memcmp(data, "#bundle", 8) != 0) return std::nullopt;
+
+    Bundle bundle;
+
+    // Read timetag
+    uint32_t sec, frac;
+    std::memcpy(&sec, data + 8, 4);
+    std::memcpy(&frac, data + 12, 4);
+    bundle.timetag.seconds = ntohl(sec);
+    bundle.timetag.fraction = ntohl(frac);
+
+    // Read elements
+    size_t offset = 16;
+    while (offset + 4 <= size) {
+        uint32_t elem_size;
+        std::memcpy(&elem_size, data + offset, 4);
+        elem_size = ntohl(elem_size);
+        offset += 4;
+
+        if (offset + elem_size > size) return std::nullopt;
+
+        // Nested bundle or message?
+        if (elem_size >= 8 && std::memcmp(data + offset, "#bundle", 8) == 0) {
+            auto nested = Bundle::deserialize(data + offset, elem_size);
+            if (nested) bundle.add(std::move(*nested));
+        } else {
+            auto msg = decode(data + offset, elem_size);
+            if (!msg.address.empty()) bundle.add(std::move(msg));
+        }
+
+        offset += elem_size;
+    }
+
+    return bundle;
+}
+
+// ── Address pattern matching ────────────────────────────────────────────────
+
+bool address_matches(std::string_view pattern, std::string_view address) {
+    size_t pi = 0, ai = 0;
+    while (pi < pattern.size() && ai < address.size()) {
+        char pc = pattern[pi];
+        if (pc == '*') {
+            // Match any sequence up to the next '/'
+            ++pi;
+            while (ai < address.size() && address[ai] != '/') ++ai;
+        } else if (pc == '?') {
+            // Match any single character except '/'
+            if (address[ai] == '/') return false;
+            ++pi; ++ai;
+        } else if (pc == '[') {
+            // Character class
+            ++pi;
+            bool negate = pi < pattern.size() && pattern[pi] == '!';
+            if (negate) ++pi;
+            bool matched = false;
+            while (pi < pattern.size() && pattern[pi] != ']') {
+                if (pi + 2 < pattern.size() && pattern[pi + 1] == '-') {
+                    if (address[ai] >= pattern[pi] && address[ai] <= pattern[pi + 2])
+                        matched = true;
+                    pi += 3;
+                } else {
+                    if (address[ai] == pattern[pi]) matched = true;
+                    ++pi;
+                }
+            }
+            if (pi < pattern.size()) ++pi;  // skip ']'
+            if (matched == negate) return false;
+            ++ai;
+        } else if (pc == '{') {
+            // Alternatives: {foo,bar,baz}
+            ++pi;
+            bool found = false;
+            while (pi < pattern.size() && pattern[pi] != '}') {
+                size_t start = pi;
+                while (pi < pattern.size() && pattern[pi] != ',' && pattern[pi] != '}') ++pi;
+                std::string_view alt = pattern.substr(start, pi - start);
+                if (address.substr(ai).starts_with(alt)) {
+                    ai += alt.size();
+                    found = true;
+                    // Skip to closing brace
+                    while (pi < pattern.size() && pattern[pi] != '}') ++pi;
+                    break;
+                }
+                if (pi < pattern.size() && pattern[pi] == ',') ++pi;
+            }
+            if (pi < pattern.size()) ++pi;  // skip '}'
+            if (!found) return false;
+        } else {
+            if (pc != address[ai]) return false;
+            ++pi; ++ai;
+        }
+    }
+    return pi == pattern.size() && ai == address.size();
+}
+
+}  // namespace pulp::osc

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(pulp-runtime PRIVATE
     src/socket.cpp
     src/named_pipe.cpp
     src/ip_address.cpp
+    src/i18n.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/pugixml/pugixml.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/miniz/miniz.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/miniz/miniz_tdef.c

--- a/core/runtime/include/pulp/runtime/i18n.hpp
+++ b/core/runtime/include/pulp/runtime/i18n.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+// Internationalization — string translation and locale management.
+// Supports .strings and .po file formats, positional argument substitution.
+
+#include <string>
+#include <string_view>
+#include <map>
+#include <optional>
+#include <vector>
+
+namespace pulp::runtime {
+
+/// Translation string lookup — maps keys to localized strings.
+class LocalisedStrings {
+public:
+    LocalisedStrings() = default;
+
+    /// Load translations from a .strings file (Apple format: "key" = "value";)
+    bool load_strings_file(std::string_view path);
+
+    /// Load translations from a .po file (gettext format)
+    bool load_po_file(std::string_view path);
+
+    /// Load translations from a JSON file ({"key": "value"})
+    bool load_json_file(std::string_view path);
+
+    /// Add a single translation
+    void add(std::string_view key, std::string_view value);
+
+    /// Look up a translation. Returns the key itself if not found.
+    std::string translate(std::string_view key) const;
+
+    /// Look up with positional argument substitution.
+    /// Replaces {0}, {1}, {2}, ... with the provided arguments.
+    std::string translate(std::string_view key, const std::vector<std::string>& args) const;
+
+    /// Shorthand: t("key") == translate("key")
+    std::string t(std::string_view key) const { return translate(key); }
+
+    /// Whether a key has a translation
+    bool has(std::string_view key) const;
+
+    /// Number of translations loaded
+    int count() const { return static_cast<int>(strings_.size()); }
+
+    /// Clear all translations
+    void clear() { strings_.clear(); }
+
+    /// The locale identifier (e.g., "en", "de", "ja")
+    const std::string& locale() const { return locale_; }
+    void set_locale(std::string_view loc) { locale_ = std::string(loc); }
+
+    // ── Global instance ─────────────────────────────────────────────────
+
+    /// Get the global translation instance
+    static LocalisedStrings& instance();
+
+    /// Detect the system locale
+    static std::string system_locale();
+
+private:
+    std::map<std::string, std::string, std::less<>> strings_;
+    std::string locale_ = "en";
+};
+
+/// Convenience: translate a key using the global instance
+inline std::string tr(std::string_view key) {
+    return LocalisedStrings::instance().translate(key);
+}
+
+/// Convenience: translate with arguments
+inline std::string tr(std::string_view key, const std::vector<std::string>& args) {
+    return LocalisedStrings::instance().translate(key, args);
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/i18n.cpp
+++ b/core/runtime/src/i18n.cpp
@@ -1,0 +1,182 @@
+#include <pulp/runtime/i18n.hpp>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+
+namespace pulp::runtime {
+
+// ── LocalisedStrings ────────────────────────────────────────────────────────
+
+bool LocalisedStrings::load_strings_file(std::string_view path) {
+    std::ifstream file(std::string(path));
+    if (!file.is_open()) return false;
+
+    std::string line;
+    while (std::getline(file, line)) {
+        // Apple .strings format: "key" = "value";
+        auto kstart = line.find('"');
+        if (kstart == std::string::npos) continue;
+        auto kend = line.find('"', kstart + 1);
+        if (kend == std::string::npos) continue;
+
+        auto vstart = line.find('"', kend + 1);
+        if (vstart == std::string::npos) continue;
+        auto vend = line.find('"', vstart + 1);
+        if (vend == std::string::npos) continue;
+
+        strings_[line.substr(kstart + 1, kend - kstart - 1)] =
+            line.substr(vstart + 1, vend - vstart - 1);
+    }
+    return true;
+}
+
+bool LocalisedStrings::load_po_file(std::string_view path) {
+    std::ifstream file(std::string(path));
+    if (!file.is_open()) return false;
+
+    std::string line, msgid, msgstr;
+    bool in_msgid = false, in_msgstr = false;
+
+    auto commit = [&]() {
+        if (!msgid.empty() && !msgstr.empty())
+            strings_[msgid] = msgstr;
+        msgid.clear();
+        msgstr.clear();
+    };
+
+    while (std::getline(file, line)) {
+        if (line.starts_with("msgid \"")) {
+            commit();
+            in_msgid = true; in_msgstr = false;
+            msgid = line.substr(7, line.size() - 8);
+        } else if (line.starts_with("msgstr \"")) {
+            in_msgid = false; in_msgstr = true;
+            msgstr = line.substr(8, line.size() - 9);
+        } else if (line.starts_with("\"") && line.ends_with("\"")) {
+            auto content = line.substr(1, line.size() - 2);
+            if (in_msgid) msgid += content;
+            else if (in_msgstr) msgstr += content;
+        }
+    }
+    commit();
+    return true;
+}
+
+bool LocalisedStrings::load_json_file(std::string_view path) {
+    std::ifstream file(std::string(path));
+    if (!file.is_open()) return false;
+
+    // Minimal JSON object parser for flat {"key":"value"} objects
+    std::string content((std::istreambuf_iterator<char>(file)),
+                         std::istreambuf_iterator<char>());
+
+    size_t pos = 0;
+    auto skip_ws = [&]() {
+        while (pos < content.size() && (content[pos] == ' ' || content[pos] == '\n' ||
+               content[pos] == '\r' || content[pos] == '\t'))
+            ++pos;
+    };
+    auto read_string = [&]() -> std::string {
+        if (pos >= content.size() || content[pos] != '"') return {};
+        ++pos;
+        std::string result;
+        while (pos < content.size() && content[pos] != '"') {
+            if (content[pos] == '\\' && pos + 1 < content.size()) {
+                ++pos;
+                if (content[pos] == 'n') result += '\n';
+                else if (content[pos] == 't') result += '\t';
+                else result += content[pos];
+            } else {
+                result += content[pos];
+            }
+            ++pos;
+        }
+        if (pos < content.size()) ++pos;  // skip closing quote
+        return result;
+    };
+
+    skip_ws();
+    if (pos >= content.size() || content[pos] != '{') return false;
+    ++pos;
+
+    while (pos < content.size()) {
+        skip_ws();
+        if (content[pos] == '}') break;
+        if (content[pos] == ',') { ++pos; continue; }
+
+        auto key = read_string();
+        skip_ws();
+        if (pos < content.size() && content[pos] == ':') ++pos;
+        skip_ws();
+        auto value = read_string();
+
+        if (!key.empty()) strings_[std::move(key)] = std::move(value);
+    }
+
+    return true;
+}
+
+void LocalisedStrings::add(std::string_view key, std::string_view value) {
+    strings_[std::string(key)] = std::string(value);
+}
+
+std::string LocalisedStrings::translate(std::string_view key) const {
+    auto it = strings_.find(key);
+    return it != strings_.end() ? it->second : std::string(key);
+}
+
+std::string LocalisedStrings::translate(std::string_view key,
+                                         const std::vector<std::string>& args) const {
+    std::string result = translate(key);
+
+    // Replace {0}, {1}, {2}, ... with arguments
+    for (size_t i = 0; i < args.size(); ++i) {
+        std::string placeholder = "{" + std::to_string(i) + "}";
+        size_t pos = 0;
+        while ((pos = result.find(placeholder, pos)) != std::string::npos) {
+            result.replace(pos, placeholder.size(), args[i]);
+            pos += args[i].size();
+        }
+    }
+
+    return result;
+}
+
+bool LocalisedStrings::has(std::string_view key) const {
+    return strings_.find(key) != strings_.end();
+}
+
+LocalisedStrings& LocalisedStrings::instance() {
+    static LocalisedStrings s_instance;
+    return s_instance;
+}
+
+std::string LocalisedStrings::system_locale() {
+    // Platform-specific locale detection
+#if defined(__APPLE__)
+    // Use CFLocale on Apple; simplified to env var fallback
+    if (const char* lang = std::getenv("LANG")) {
+        std::string locale(lang);
+        auto dot = locale.find('.');
+        if (dot != std::string::npos) locale = locale.substr(0, dot);
+        auto underscore = locale.find('_');
+        if (underscore != std::string::npos) locale = locale.substr(0, underscore);
+        return locale;
+    }
+#elif defined(_WIN32)
+    // Simplified: use GetUserDefaultLocaleName in a real implementation
+    if (const char* lang = std::getenv("LANG")) return std::string(lang);
+#else
+    if (const char* lang = std::getenv("LANG")) {
+        std::string locale(lang);
+        auto dot = locale.find('.');
+        if (dot != std::string::npos) locale = locale.substr(0, dot);
+        auto underscore = locale.find('_');
+        if (underscore != std::string::npos) locale = locale.substr(0, underscore);
+        return locale;
+    }
+#endif
+    return "en";
+}
+
+}  // namespace pulp::runtime


### PR DESCRIPTION
## Summary
- LocalisedStrings: i18n with .strings/.po/.json file support + arg substitution
- OSC Bundle: timetag + nested messages/bundles per OSC 1.0 spec
- OSC address pattern matching (wildcard, character class, alternatives)

Deferred: Crypto (mbedTLS), MIDI CI, Analytics, Accessibility interfaces

## Test plan
- [x] Naming audit clean
- [ ] CI