### PR TITLE
Package manager Phase 1: Registry, guides, verification stubs, freshness CI

### DIFF
--- a/.github/workflows/freshness-check.yml
+++ b/.github/workflows/freshness-check.yml
@@ -1,0 +1,57 @@
+name: Package Freshness Check
+
+on:
+  schedule:
+    # Weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: 'Check tier (1 = metadata only, 2 = full build)'
+        required: false
+        default: '1'
+        type: choice
+        options:
+          - '1'
+          - '2'
+      package:
+        description: 'Single package slug (blank = all)'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  freshness:
+    name: Check package freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run Tier 1 freshness check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARGS="--format markdown"
+          if [ -n "${{ inputs.package }}" ]; then
+            ARGS="$ARGS --package ${{ inputs.package }}"
+          fi
+          python3 tools/packages/freshness_check.py $ARGS > freshness-report.md 2>&1 || true
+          cat freshness-report.md
+
+      - name: Create issue if stale packages found
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Package freshness: $(date +%Y-%m-%d) — updates available" \
+            --body "$(cat freshness-report.md)" \
+            --label "dependencies"

--- a/docs/guides/packages/cycfi-q.md
+++ b/docs/guides/packages/cycfi-q.md
@@ -1,0 +1,69 @@
+# Q (Cycfi)
+
+Pitch detection via bitstream autocorrelation.
+
+| | |
+|---|---|
+| **License** | MIT |
+| **URL** | https://github.com/cycfi/q |
+| **Version** | version_1.0 |
+| **Integration** | CMake (FetchContent) |
+| **RT-safe** | Yes |
+| **Platforms** | macOS (arm64), Windows (x64), Linux (x64, arm64) |
+
+## What It Does
+
+Fast, accurate monophonic pitch detection using a bitstream autocorrelation algorithm. Also provides DSP primitives (filters, envelope followers, zero-crossing detection). The pitch detector is the primary draw — there is no MIT-licensed equivalent with this accuracy.
+
+**Platform note:** Windows arm64 is not verified. x64 works on all three platforms.
+
+## CMake Integration
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  q
+  GIT_REPOSITORY https://github.com/cycfi/q.git
+  GIT_TAG        version_1.0
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(q)
+target_link_libraries(MyPlugin PRIVATE cycfi::q)
+```
+
+Q depends on `cycfi::infra` which is fetched automatically by its CMakeLists.txt.
+
+## Example Usage
+
+```cpp
+#include <q/pitch/pitch_detector.hpp>
+#include <q/support/literals.hpp>
+
+class TunerPlugin : public pulp::Processor {
+    using namespace cycfi::q::literals;
+    cycfi::q::pitch_detector pd { 50_Hz, 4000_Hz, 48000, -30_dB };
+
+    void process(pulp::BufferView<float> buffer) override {
+        auto* data = buffer.channel(0);
+        for (int i = 0; i < buffer.num_samples(); ++i) {
+            bool ready = pd(data[i]);
+            if (ready) {
+                float freq = pd.get_frequency();
+                // Use detected frequency (tuner display, pitch correction, etc.)
+            }
+        }
+    }
+};
+```
+
+## Pulp Overlap
+
+None. Pulp does not have built-in pitch detection.
+
+## Attribution
+
+Add to `DEPENDENCIES.md` and `NOTICE.md`:
+
+```
+Q (Cycfi) — MIT — https://github.com/cycfi/q
+```

--- a/docs/guides/packages/cycfi-q.md
+++ b/docs/guides/packages/cycfi-q.md
@@ -28,7 +28,7 @@ FetchContent_Declare(
   GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(q)
-target_link_libraries(MyPlugin PRIVATE cycfi::q)
+target_link_libraries(MyPlugin PRIVATE libq)
 ```
 
 Q depends on `cycfi::infra` which is fetched automatically by its CMakeLists.txt.

--- a/docs/guides/packages/daisysp.md
+++ b/docs/guides/packages/daisysp.md
@@ -1,0 +1,92 @@
+# DaisySP
+
+DSP library with oscillators, filters, effects, and physical modeling.
+
+| | |
+|---|---|
+| **License** | MIT |
+| **URL** | https://github.com/electro-smith/DaisySP |
+| **Version** | V1.0.0 |
+| **Integration** | CMake (FetchContent) |
+| **RT-safe** | Yes |
+| **Platforms** | macOS (arm64), Windows (x64, arm64), Linux (x64, arm64) |
+
+## What It Does
+
+Originally built for the Daisy embedded audio platform, DaisySP is a portable DSP library with a focus on synthesis and physical modeling:
+
+- **Physical modeling:** Karplus-Strong, modal synthesis, plucked string
+- **Drum synthesis:** analog kick, snare, hi-hat models
+- **Oscillators:** FM, formant, harmonic, particle noise
+- **Effects:** bitcrush, decimator, flanger, tremolo, fold
+- **Filters:** ladder, Moog-style, comb, allpass
+- **Utilities:** compressor, limiter, crossfade, sample-and-hold
+
+## CMake Integration
+
+DaisySP does not ship a CMakeLists.txt for desktop use. Create a wrapper:
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  DaisySP
+  GIT_REPOSITORY https://github.com/electro-smith/DaisySP.git
+  GIT_TAG        V1.0.0
+  GIT_SHALLOW    TRUE
+)
+FetchContent_Populate(DaisySP)
+
+file(GLOB_RECURSE DAISYSP_SOURCES "${daisysp_SOURCE_DIR}/Source/**/*.cpp")
+add_library(DaisySP STATIC ${DAISYSP_SOURCES})
+target_include_directories(DaisySP PUBLIC "${daisysp_SOURCE_DIR}/Source")
+target_link_libraries(MyPlugin PRIVATE DaisySP)
+```
+
+## Example Usage
+
+```cpp
+#include "Synthesis/modalvoice.h"
+#include "Drums/analogbassdrum.h"
+
+class PhysicalSynth : public pulp::Processor {
+    daisysp::ModalVoice modal;
+    daisysp::AnalogBassDrum kick;
+
+    void prepare(double sample_rate, int max_block) override {
+        modal.Init(static_cast<float>(sample_rate));
+        kick.Init(static_cast<float>(sample_rate));
+
+        modal.SetFreq(440.0f);
+        kick.SetFreq(60.0f);
+    }
+
+    void process(pulp::BufferView<float> buffer) override {
+        auto* out = buffer.channel(0);
+        for (int i = 0; i < buffer.num_samples(); ++i) {
+            out[i] = modal.Process(false) + kick.Process(false);
+        }
+    }
+};
+```
+
+## Pulp Overlap
+
+DaisySP has significant overlap with Pulp built-ins:
+
+| DaisySP | Pulp Built-in | When to Use DaisySP |
+|---------|---------------|---------------------|
+| Oscillators | `signal/oscillator.hpp` | For FM, formant, harmonic, particle oscillators |
+| Biquad filters | `signal/biquad.hpp` | Only if you need DaisySP's ladder/Moog filters |
+| ADSR | `signal/adsr.hpp` | Generally prefer Pulp's built-in |
+| Reverb | `signal/reverb.hpp` | Generally prefer Pulp's built-in |
+| Compressor | `signal/compressor.hpp` | Generally prefer Pulp's built-in |
+
+**Use DaisySP for:** Physical modeling (Karplus-Strong, modal), drum synthesis, and exotic oscillators. **Use Pulp built-ins for:** Standard filters, envelopes, reverb, and compression.
+
+## Attribution
+
+Add to `DEPENDENCIES.md` and `NOTICE.md`:
+
+```
+DaisySP — MIT — https://github.com/electro-smith/DaisySP
+```

--- a/docs/guides/packages/dr-libs.md
+++ b/docs/guides/packages/dr-libs.md
@@ -1,0 +1,77 @@
+# dr_libs
+
+Single-file WAV, FLAC, and MP3 decoding.
+
+| | |
+|---|---|
+| **License** | MIT-0 (public domain equivalent) |
+| **URL** | https://github.com/mackron/dr_libs |
+| **Version** | wav-0.14.5 |
+| **Integration** | Header-only (single file per format) |
+| **RT-safe** | No (file I/O) |
+| **Platforms** | macOS (arm64), Windows (x64, arm64), Linux (x64, arm64) |
+
+## What It Does
+
+Zero-dependency single-header decoders for common audio formats:
+
+- **dr_wav.h** — WAV reading and writing
+- **dr_flac.h** — FLAC decoding
+- **dr_mp3.h** — MP3 decoding
+
+Each header is independent — include only what you need. Decode-only for FLAC and MP3 (WAV supports writing too).
+
+**Note:** dr_libs uses per-header version tags (`wav-0.14.5`, `mp3-0.7.3`, `flac-0.13.3`). The registry pins to the WAV tag as the primary reference.
+
+## CMake Integration
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  dr_libs
+  GIT_REPOSITORY https://github.com/mackron/dr_libs.git
+  GIT_TAG        wav-0.14.5
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(dr_libs)
+
+# Header-only — add include path
+target_include_directories(MyPlugin PRIVATE
+  ${dr_libs_SOURCE_DIR}
+)
+```
+
+## Example Usage
+
+```cpp
+// In exactly ONE .cpp file, define the implementation:
+#define DR_WAV_IMPLEMENTATION
+#include "dr_wav.h"
+
+#define DR_MP3_IMPLEMENTATION
+#include "dr_mp3.h"
+
+// Then use anywhere:
+std::vector<float> load_wav(const char* path) {
+    unsigned int channels, sample_rate;
+    drwav_uint64 frame_count;
+    float* data = drwav_open_file_and_read_pcm_frames_f32(
+        path, &channels, &sample_rate, &frame_count, nullptr);
+
+    std::vector<float> result(data, data + frame_count * channels);
+    drwav_free(data, nullptr);
+    return result;
+}
+```
+
+## Pulp Overlap
+
+None directly. CHOC provides WAV read/write via `choc::audio::AudioFileFormat`, which may be sufficient for basic WAV needs. dr_libs adds FLAC and MP3 decoding.
+
+## Attribution
+
+Add to `DEPENDENCIES.md` and `NOTICE.md`:
+
+```
+dr_libs — MIT-0 — https://github.com/mackron/dr_libs
+```

--- a/docs/guides/packages/fontaudio.md
+++ b/docs/guides/packages/fontaudio.md
@@ -1,0 +1,67 @@
+# fontaudio
+
+Audio-specific icon font with 200+ icons for plugin UIs.
+
+| | |
+|---|---|
+| **License** | MIT |
+| **URL** | https://github.com/fefanto/fontaudio |
+| **Version** | 1.1 |
+| **Integration** | Font file (header-only codepoints) |
+| **RT-safe** | N/A (UI asset) |
+| **Platforms** | All (macOS, Windows, Linux, iOS, WASM) |
+
+## What It Does
+
+A TrueType font containing 200+ audio-specific icons: knobs, faders, waveforms, speakers, MIDI connectors, plugin format logos, transport controls, and more. Designed specifically for audio software UIs.
+
+The font file (`fontaudio.ttf`) can be loaded by any text rendering system. The companion header provides Unicode codepoint constants.
+
+## CMake Integration
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  fontaudio
+  GIT_REPOSITORY https://github.com/fefanto/fontaudio.git
+  GIT_TAG        1.1
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(fontaudio)
+
+# Copy the font file to your resources
+file(COPY ${fontaudio_SOURCE_DIR}/font/fontaudio.ttf
+     DESTINATION ${CMAKE_BINARY_DIR}/resources)
+
+# Include the codepoint header
+target_include_directories(MyPlugin PRIVATE
+  ${fontaudio_SOURCE_DIR}/src
+)
+```
+
+## Example Usage
+
+```cpp
+#include "fontaudio/IconHelper.h"
+
+// In your UI drawing code:
+void draw_transport(pulp::Canvas& canvas) {
+    // Load fontaudio.ttf as a font resource, then draw icons by codepoint
+    canvas.set_font("fontaudio", 24.0f);
+    canvas.draw_text(fontaudio::IconName::fad_play, 10, 10);
+    canvas.draw_text(fontaudio::IconName::fad_stop, 40, 10);
+    canvas.draw_text(fontaudio::IconName::fad_record, 70, 10);
+}
+```
+
+## Pulp Overlap
+
+None. Pulp does not ship an audio icon font.
+
+## Attribution
+
+Add to `DEPENDENCIES.md` and `NOTICE.md`:
+
+```
+fontaudio — MIT — https://github.com/fefanto/fontaudio
+```

--- a/docs/guides/packages/index.md
+++ b/docs/guides/packages/index.md
@@ -1,0 +1,68 @@
+# Package Integration Guides
+
+Pulp's built-in `core/signal/` subsystem covers 30+ DSP processors. These guides help you add third-party libraries for capabilities beyond what ships natively.
+
+## Before You Add a Package
+
+1. **Check built-ins first.** Pulp may already cover your need — see `docs/reference/modules.md` for the signal subsystem inventory.
+2. **License matters.** Only MIT/BSD/Apache/ISC/zlib/BSL/public-domain libraries are compatible with Pulp's MIT license. The package registry enforces this.
+3. **Platform coverage.** If your plugin targets macOS + Windows + Linux, prefer libraries that work on all three. Each guide lists platform support.
+
+## Categories
+
+### DSP (Filters, Effects, Analysis, Synthesis)
+
+| Package | What It Provides | Integration |
+|---------|-----------------|-------------|
+| [Signalsmith Stretch](signalsmith-stretch.md) | Polyphonic pitch/time stretching | Header-only |
+| [Signalsmith DSP](signalsmith-dsp.md) | Filters, FFT, envelopes, spectral tools | Header-only |
+| [Q (Cycfi)](cycfi-q.md) | Pitch detection via bitstream autocorrelation | CMake |
+| [PFFFT](pffft.md) | SIMD-optimized FFT | CMake |
+| [DaisySP](daisysp.md) | Physical modeling, effects, drum synthesis | CMake |
+
+### Audio I/O (File Formats, Resampling)
+
+| Package | What It Provides | Integration |
+|---------|-----------------|-------------|
+| [dr_libs](dr-libs.md) | WAV, FLAC, MP3 decoding (single-header) | Header-only |
+| [libsamplerate](libsamplerate.md) | High-quality sample rate conversion | CMake |
+| [r8brain-free-src](r8brain-free-src.md) | Audiophile-grade resampling | CMake |
+
+### Machine Learning
+
+| Package | What It Provides | Integration |
+|---------|-----------------|-------------|
+| [RTNeural](rtneural.md) | Real-time neural network inference | CMake |
+
+### UI
+
+| Package | What It Provides | Integration |
+|---------|-----------------|-------------|
+| [fontaudio](fontaudio.md) | Audio-specific icon font (200+ icons) | Font file |
+
+## Search Tips
+
+Looking for a capability? Use `pulp search` (Phase 2) or check the registry directly:
+
+```bash
+python3 tools/packages/validate_registry.py  # verify registry integrity
+cat tools/packages/registry.json | python3 -m json.tool  # browse packages
+```
+
+## Adding a Library Manually
+
+Each guide provides the exact CMake code. The general pattern:
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  <name>
+  GIT_REPOSITORY https://github.com/<org>/<repo>.git
+  GIT_TAG        <version>
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(<name>)
+target_link_libraries(MyPlugin PRIVATE <target>)
+```
+
+Header-only libraries can alternatively be added with `target_include_directories` after fetching.

--- a/docs/guides/packages/libsamplerate.md
+++ b/docs/guides/packages/libsamplerate.md
@@ -1,0 +1,81 @@
+# libsamplerate
+
+High-quality sample rate conversion (Secret Rabbit Code).
+
+| | |
+|---|---|
+| **License** | BSD-2-Clause |
+| **URL** | https://github.com/libsndfile/libsamplerate |
+| **Version** | 0.2.2 |
+| **Integration** | CMake (FetchContent) |
+| **RT-safe** | No (allocates internally) |
+| **Platforms** | macOS (arm64), Windows (x64, arm64), Linux (x64, arm64) |
+
+## What It Does
+
+Industry-standard sample rate conversion with multiple quality modes:
+
+- **SRC_SINC_BEST_QUALITY** — highest quality, highest CPU
+- **SRC_SINC_MEDIUM_QUALITY** — good balance
+- **SRC_SINC_FASTEST** — fast sinc interpolation
+- **SRC_LINEAR** — linear interpolation
+- **SRC_ZERO_ORDER_HOLD** — zero-order hold
+
+Use for offline resampling, format conversion, or prepare-time sample rate adaptation. Not suitable for real-time audio thread use due to internal allocations.
+
+## CMake Integration
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  libsamplerate
+  GIT_REPOSITORY https://github.com/libsndfile/libsamplerate.git
+  GIT_TAG        0.2.2
+  GIT_SHALLOW    TRUE
+)
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(libsamplerate)
+target_link_libraries(MyPlugin PRIVATE SampleRate::samplerate)
+```
+
+## Example Usage
+
+```cpp
+#include <samplerate.h>
+
+class Resampler {
+public:
+    std::vector<float> resample(const float* input, long frames_in,
+                                double src_ratio, int quality = SRC_SINC_MEDIUM_QUALITY) {
+        long frames_out = static_cast<long>(frames_in * src_ratio) + 1;
+        std::vector<float> output(frames_out);
+
+        SRC_DATA data{};
+        data.data_in = input;
+        data.input_frames = frames_in;
+        data.data_out = output.data();
+        data.output_frames = frames_out;
+        data.src_ratio = src_ratio;
+
+        src_simple(&data, quality, 1);
+        output.resize(data.output_frames_gen);
+        return output;
+    }
+};
+```
+
+## Pulp Overlap
+
+None. Pulp does not have built-in sample rate conversion.
+
+## See Also
+
+- [r8brain-free-src](r8brain-free-src.md) — alternative with different quality/latency tradeoffs
+
+## Attribution
+
+Add to `DEPENDENCIES.md` and `NOTICE.md`:
+
+```
+libsamplerate — BSD-2-Clause — https://github.com/libsndfile/libsamplerate
+```

--- a/docs/guides/packages/pffft.md
+++ b/docs/guides/packages/pffft.md
@@ -28,13 +28,13 @@ FetchContent_Declare(
   GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(pffft)
-target_link_libraries(MyPlugin PRIVATE pffft)
+target_link_libraries(MyPlugin PRIVATE PFFFT)
 ```
 
 ## Example Usage
 
 ```cpp
-#include "pffft.h"
+#include <pffft/pffft.h>
 
 class FastSpectrum {
     PFFFT_Setup* setup = nullptr;

--- a/docs/guides/packages/pffft.md
+++ b/docs/guides/packages/pffft.md
@@ -1,0 +1,86 @@
+# PFFFT
+
+SIMD-optimized FFT for real and complex transforms.
+
+| | |
+|---|---|
+| **License** | BSD-3-Clause |
+| **URL** | https://github.com/marton78/pffft |
+| **Version** | v1.1.0 |
+| **Integration** | CMake (FetchContent) |
+| **RT-safe** | Yes |
+| **Platforms** | macOS (arm64, NEON), Windows (x64 SSE, arm64 NEON), Linux (x64 SSE, arm64 NEON) |
+
+## What It Does
+
+A small, fast FFT library that uses SIMD instructions (SSE on x64, NEON on ARM) for power-of-two size transforms. Significantly faster than general-purpose FFT implementations for typical audio buffer sizes (256–8192).
+
+This is the marton78 fork which adds CMake support and maintains compatibility with the original PFFFT.
+
+## CMake Integration
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  pffft
+  GIT_REPOSITORY https://github.com/marton78/pffft.git
+  GIT_TAG        v1.1.0
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(pffft)
+target_link_libraries(MyPlugin PRIVATE pffft)
+```
+
+## Example Usage
+
+```cpp
+#include "pffft.h"
+
+class FastSpectrum {
+    PFFFT_Setup* setup = nullptr;
+    float* work = nullptr;
+    int fft_size = 0;
+
+public:
+    void init(int size) {
+        fft_size = size;
+        setup = pffft_new_setup(size, PFFFT_REAL);
+        work = static_cast<float*>(pffft_aligned_malloc(size * sizeof(float)));
+    }
+
+    void forward(const float* input, float* output) {
+        pffft_transform_ordered(setup, input, output, work, PFFFT_FORWARD);
+    }
+
+    void inverse(const float* input, float* output) {
+        pffft_transform_ordered(setup, input, output, work, PFFFT_BACKWARD);
+    }
+
+    ~FastSpectrum() {
+        if (setup) pffft_destroy_setup(setup);
+        if (work) pffft_aligned_free(work);
+    }
+};
+```
+
+## Pulp Overlap
+
+PFFFT overlaps with `signal/fft.hpp`. Use PFFFT when:
+
+- You need maximum FFT throughput on a known power-of-two size
+- You're doing heavy spectral processing (vocoder, convolution, analysis)
+- Benchmarks show Pulp's built-in FFT is a bottleneck
+
+Use Pulp's built-in FFT when:
+
+- You need a simple FFT without managing PFFFT setup/teardown
+- FFT performance is not the bottleneck
+- You want zero additional dependencies
+
+## Attribution
+
+Add to `DEPENDENCIES.md` and `NOTICE.md`:
+
+```
+PFFFT — BSD-3-Clause — https://github.com/marton78/pffft
+```

--- a/docs/guides/packages/r8brain-free-src.md
+++ b/docs/guides/packages/r8brain-free-src.md
@@ -1,0 +1,75 @@
+# r8brain-free-src
+
+High-quality sample rate converter with low latency mode.
+
+| | |
+|---|---|
+| **License** | MIT |
+| **URL** | https://github.com/avaneev/r8brain-free-src |
+| **Version** | version-6.5 |
+| **Integration** | CMake (FetchContent) |
+| **RT-safe** | No (allocates internally) |
+| **Platforms** | macOS (arm64), Windows (x64, arm64), Linux (x64, arm64) |
+
+## What It Does
+
+An audiophile-grade sample rate converter with configurable quality/latency tradeoffs. Achieves very high SNR (>200 dB for best quality mode) with options for low-latency operation suitable for real-time pipelines (though not for audio-thread use due to allocations).
+
+Key quality modes:
+- **Best quality** — highest SNR, highest latency
+- **Normal** — good balance for most applications
+- **Low latency** — suitable for real-time pipelines with moderate quality
+
+## CMake Integration
+
+r8brain-free-src does not ship a standard CMakeLists.txt. Create a wrapper:
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  r8brain
+  GIT_REPOSITORY https://github.com/avaneev/r8brain-free-src.git
+  GIT_TAG        version-6.5
+  GIT_SHALLOW    TRUE
+)
+FetchContent_Populate(r8brain)
+
+add_library(r8brain STATIC "${r8brain_SOURCE_DIR}/r8bbase.cpp")
+target_include_directories(r8brain PUBLIC "${r8brain_SOURCE_DIR}")
+target_link_libraries(MyPlugin PRIVATE r8brain)
+```
+
+## Example Usage
+
+```cpp
+#include "CDSPResampler.h"
+
+class HighQualityResampler {
+public:
+    std::vector<double> resample(const double* input, int frames,
+                                  double src_rate, double dst_rate) {
+        r8b::CDSPResampler24 resampler(src_rate, dst_rate, frames);
+
+        double* output = nullptr;
+        int out_frames = resampler.process(input, frames, output);
+
+        return std::vector<double>(output, output + out_frames);
+    }
+};
+```
+
+## Pulp Overlap
+
+None. Pulp does not have built-in sample rate conversion.
+
+## See Also
+
+- [libsamplerate](libsamplerate.md) — alternative with different API style and quality profile
+
+## Attribution
+
+Add to `DEPENDENCIES.md` and `NOTICE.md`:
+
+```
+r8brain-free-src — MIT — https://github.com/avaneev/r8brain-free-src
+```

--- a/docs/guides/packages/rtneural.md
+++ b/docs/guides/packages/rtneural.md
@@ -1,0 +1,75 @@
+# RTNeural
+
+Real-time neural network inference optimized for audio.
+
+| | |
+|---|---|
+| **License** | BSD-3-Clause |
+| **URL** | https://github.com/jatinchowdhury18/RTNeural |
+| **Version** | 1fb1f075 (untagged, pinned commit) |
+| **Integration** | CMake (FetchContent) |
+| **RT-safe** | Yes |
+| **Platforms** | macOS (arm64), Windows (x64, arm64), Linux (x64, arm64) |
+
+## What It Does
+
+A lightweight neural network inference library designed for real-time audio. Supports common layer types (Dense, Conv1D, GRU, LSTM, BatchNorm) with compile-time or runtime model sizing. Used widely for guitar amp modeling and audio effect emulation.
+
+## CMake Integration
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  RTNeural
+  GIT_REPOSITORY https://github.com/jatinchowdhury18/RTNeural.git
+  GIT_TAG        1fb1f075
+)
+FetchContent_MakeAvailable(RTNeural)
+target_link_libraries(MyPlugin PRIVATE RTNeural)
+```
+
+To use the header-only mode instead:
+
+```cmake
+target_compile_definitions(MyPlugin PRIVATE RTNEURAL_USE_EIGEN=1)
+```
+
+## Example Usage
+
+```cpp
+#include <RTNeural/RTNeural.h>
+
+class AmpModel : public pulp::Processor {
+    // Compile-time model: input=1, Dense(8), tanh, Dense(1)
+    RTNeural::ModelT<float, 1, 1,
+        RTNeural::DenseT<float, 1, 8>,
+        RTNeural::TanhActivationT<float, 8>,
+        RTNeural::DenseT<float, 8, 1>
+    > model;
+
+    void prepare(double sample_rate, int max_block) override {
+        model.reset();
+        // Load weights from JSON — see RTNeural docs
+    }
+
+    void process(pulp::BufferView<float> buffer) override {
+        auto* data = buffer.channel(0);
+        for (int i = 0; i < buffer.num_samples(); ++i) {
+            float input[] = { data[i] };
+            data[i] = model.forward(input);
+        }
+    }
+};
+```
+
+## Pulp Overlap
+
+None. Pulp has no built-in neural network inference.
+
+## Attribution
+
+Add to `DEPENDENCIES.md` and `NOTICE.md`:
+
+```
+RTNeural — BSD-3-Clause — https://github.com/jatinchowdhury18/RTNeural
+```

--- a/docs/guides/packages/signalsmith-dsp.md
+++ b/docs/guides/packages/signalsmith-dsp.md
@@ -36,7 +36,7 @@ target_include_directories(MyPlugin PRIVATE
 ## Example Usage
 
 ```cpp
-#include "signalsmith-dsp/dsp/spectral.h"
+#include "spectral.h"
 
 class SpectralProcessor : public pulp::Processor {
     signalsmith::spectral::STFT<float> stft;

--- a/docs/guides/packages/signalsmith-dsp.md
+++ b/docs/guides/packages/signalsmith-dsp.md
@@ -1,0 +1,78 @@
+# Signalsmith DSP
+
+Filters, envelopes, FFT, delay, and spectral processing tools.
+
+| | |
+|---|---|
+| **License** | MIT |
+| **URL** | https://github.com/Signalsmith-Audio/dsp |
+| **Version** | v1.7.1 |
+| **Integration** | Header-only |
+| **RT-safe** | Yes |
+| **Platforms** | macOS (arm64), Windows (x64, arm64), Linux (x64, arm64) |
+
+## What It Does
+
+A comprehensive DSP toolkit: filters (biquad, SVF, crossovers), envelope followers, FFT with spectral processing, delay lines with interpolation, and windowing functions. Well-documented, designed for real-time audio.
+
+## CMake Integration
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  signalsmith-dsp
+  GIT_REPOSITORY https://github.com/Signalsmith-Audio/dsp.git
+  GIT_TAG        v1.7.1
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(signalsmith-dsp)
+
+# Header-only — add include path
+target_include_directories(MyPlugin PRIVATE
+  ${signalsmith-dsp_SOURCE_DIR}
+)
+```
+
+## Example Usage
+
+```cpp
+#include "signalsmith-dsp/dsp/spectral.h"
+
+class SpectralProcessor : public pulp::Processor {
+    signalsmith::spectral::STFT<float> stft;
+
+    void prepare(double sample_rate, int max_block) override {
+        stft.setSize(2048);
+    }
+
+    void process(pulp::BufferView<float> buffer) override {
+        auto* data = buffer.channel(0);
+        int n = buffer.num_samples();
+
+        stft.analyseBlock(data, n);
+        // Manipulate frequency bins in stft.spectrum()
+        stft.synthesiseBlock(data, n);
+    }
+};
+```
+
+## Pulp Overlap
+
+Signalsmith DSP overlaps with several Pulp built-ins:
+
+| Signalsmith | Pulp Built-in | When to Use Signalsmith |
+|-------------|---------------|------------------------|
+| Biquad filters | `signal/biquad.hpp` | When you need Signalsmith's specific filter topologies |
+| SVF | `signal/svf.hpp` | When you need the combined spectral toolkit |
+| Delay line | `signal/delay_line.hpp` | When you need interpolated delay with specific modes |
+| FFT | `signal/fft.hpp` | When you need integrated STFT with spectral processing |
+
+If you only need one of these capabilities, prefer Pulp's built-in. Use Signalsmith DSP when you need its spectral processing pipeline or multiple components together.
+
+## Attribution
+
+Add to `DEPENDENCIES.md` and `NOTICE.md`:
+
+```
+Signalsmith DSP — MIT — https://github.com/Signalsmith-Audio/dsp
+```

--- a/docs/guides/packages/signalsmith-stretch.md
+++ b/docs/guides/packages/signalsmith-stretch.md
@@ -1,0 +1,70 @@
+# Signalsmith Stretch
+
+Polyphonic pitch and time stretching.
+
+| | |
+|---|---|
+| **License** | MIT |
+| **URL** | https://github.com/Signalsmith-Audio/signalsmith-stretch |
+| **Version** | 1.1.0 |
+| **Integration** | Header-only |
+| **RT-safe** | Yes |
+| **Platforms** | macOS (arm64), Windows (x64, arm64), Linux (x64, arm64) |
+
+## What It Does
+
+High-quality polyphonic pitch shifting and time stretching. Handles complex audio material (chords, drums, vocals) without the phase artifacts common in simpler algorithms. MIT-licensed alternative to Rubber Band (GPL).
+
+## CMake Integration
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+  signalsmith-stretch
+  GIT_REPOSITORY https://github.com/Signalsmith-Audio/signalsmith-stretch.git
+  GIT_TAG        1.1.0
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(signalsmith-stretch)
+
+# Header-only — add include path
+target_include_directories(MyPlugin PRIVATE
+  ${signalsmith-stretch_SOURCE_DIR}
+)
+```
+
+## Example Usage
+
+```cpp
+#include "signalsmith-stretch.h"
+
+class PitchShifter : public pulp::Processor {
+    signalsmith::stretch::SignalsmithStretch<float> stretch;
+
+    void prepare(double sample_rate, int max_block) override {
+        stretch.presetDefault(2, static_cast<float>(sample_rate));
+    }
+
+    void process(pulp::BufferView<float> buffer) override {
+        // Shift pitch up by 2 semitones
+        stretch.setTransposeSemitones(2.0f);
+
+        float* inputs[2]  = { buffer.channel(0), buffer.channel(1) };
+        float* outputs[2] = { buffer.channel(0), buffer.channel(1) };
+
+        stretch.process(inputs, buffer.num_samples(), outputs, buffer.num_samples());
+    }
+};
+```
+
+## Pulp Overlap
+
+None. Pulp does not have built-in pitch/time stretching.
+
+## Attribution
+
+Add to `DEPENDENCIES.md` and `NOTICE.md`:
+
+```
+Signalsmith Stretch — MIT — https://github.com/Signalsmith-Audio/signalsmith-stretch
+```

--- a/tools/packages/freshness_check.py
+++ b/tools/packages/freshness_check.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Check package registry freshness against upstream GitHub repos.
+
+Tier 1 checks (metadata only, no builds):
+- Latest tag/release vs pinned version
+- Last commit date on default branch
+- Archived status
+- License file hash (detect license changes)
+
+Exits non-zero if any package has issues.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = ROOT / "tools" / "packages" / "registry.json"
+
+
+@dataclass
+class CheckResult:
+    package: str
+    pinned_version: str
+    latest_version: str | None = None
+    last_commit_date: str | None = None
+    archived: bool = False
+    license_changed: bool = False
+    issues: list[str] | None = None
+
+    def __post_init__(self):
+        if self.issues is None:
+            self.issues = []
+
+
+def run_gh(args: list[str]) -> dict | list | None:
+    """Run a gh api command and return parsed JSON."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", *args],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            return None
+        return json.loads(result.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        return None
+
+
+def extract_owner_repo(url: str) -> tuple[str, str] | None:
+    """Extract owner/repo from a GitHub URL."""
+    url = url.rstrip("/").removesuffix(".git")
+    parts = url.split("/")
+    if "github.com" in parts:
+        idx = parts.index("github.com")
+        if idx + 2 < len(parts):
+            return parts[idx + 1], parts[idx + 2]
+    return None
+
+
+def check_package(slug: str, pkg: dict) -> CheckResult:
+    result = CheckResult(package=slug, pinned_version=pkg["version"])
+
+    git_url = pkg.get("fetch", {}).get("git_repository", "")
+    parsed = extract_owner_repo(git_url)
+    if not parsed:
+        result.issues.append(f"Cannot parse GitHub URL: {git_url}")
+        return result
+
+    owner, repo = parsed
+
+    # Check repo metadata (archived status, last push)
+    repo_data = run_gh([f"repos/{owner}/{repo}"])
+    if repo_data is None:
+        result.issues.append("Cannot reach GitHub API")
+        return result
+
+    result.archived = repo_data.get("archived", False)
+    if result.archived:
+        result.issues.append("Repository is archived")
+
+    pushed_at = repo_data.get("pushed_at", "")
+    result.last_commit_date = pushed_at[:10] if pushed_at else None
+
+    # Check latest release/tag
+    releases = run_gh([f"repos/{owner}/{repo}/releases?per_page=1"])
+    if releases and isinstance(releases, list) and len(releases) > 0:
+        result.latest_version = releases[0].get("tag_name")
+    else:
+        # Fall back to tags
+        tags = run_gh([f"repos/{owner}/{repo}/tags?per_page=1"])
+        if tags and isinstance(tags, list) and len(tags) > 0:
+            result.latest_version = tags[0].get("name")
+
+    if result.latest_version and result.latest_version != pkg["version"]:
+        result.issues.append(
+            f"Newer version available: {result.latest_version} (pinned: {pkg['version']})"
+        )
+
+    # Check license
+    license_data = run_gh([f"repos/{owner}/{repo}/license"])
+    if license_data:
+        spdx = license_data.get("license", {}).get("spdx_id", "")
+        if spdx and spdx != "NOASSERTION" and spdx != pkg.get("license"):
+            result.license_changed = True
+            result.issues.append(
+                f"License mismatch: registry says {pkg['license']}, GitHub says {spdx}"
+            )
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check package registry freshness")
+    parser.add_argument("--package", help="Check a single package by slug")
+    parser.add_argument("--format", choices=["text", "json", "markdown"], default="text")
+    args = parser.parse_args()
+
+    registry = json.loads(REGISTRY.read_text())
+    packages = registry.get("packages", {})
+
+    if args.package:
+        if args.package not in packages:
+            print(f"ERROR: Package '{args.package}' not in registry", file=sys.stderr)
+            return 1
+        packages = {args.package: packages[args.package]}
+
+    results: list[CheckResult] = []
+    issues_found = 0
+
+    for slug, pkg in packages.items():
+        print(f"Checking {slug}...", file=sys.stderr)
+        result = check_package(slug, pkg)
+        results.append(result)
+        issues_found += len(result.issues)
+
+    if args.format == "json":
+        out = [
+            {
+                "package": r.package,
+                "pinned": r.pinned_version,
+                "latest": r.latest_version,
+                "last_commit": r.last_commit_date,
+                "archived": r.archived,
+                "license_changed": r.license_changed,
+                "issues": r.issues,
+            }
+            for r in results
+        ]
+        print(json.dumps(out, indent=2))
+    elif args.format == "markdown":
+        print("| Package | Pinned | Latest | Last Commit | Issues |")
+        print("|---------|--------|--------|-------------|--------|")
+        for r in results:
+            status = " / ".join(r.issues) if r.issues else "OK"
+            print(
+                f"| {r.package} | {r.pinned_version} | {r.latest_version or '?'} "
+                f"| {r.last_commit_date or '?'} | {status} |"
+            )
+    else:
+        for r in results:
+            if r.issues:
+                print(f"  {r.package} {'.' * max(1, 30 - len(r.package))} ISSUES")
+                for issue in r.issues:
+                    print(f"    - {issue}")
+            else:
+                print(f"  {r.package} {'.' * max(1, 30 - len(r.package))} OK")
+
+    print(f"\n{len(results)} packages checked, {issues_found} issues.", file=sys.stderr)
+    return 1 if issues_found > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/packages/packages.lock.schema.json
+++ b/tools/packages/packages.lock.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Pulp Package Lock File",
+  "description": "Schema for packages.lock.json — records exact resolved versions and integrity hashes",
+  "type": "object",
+  "required": ["lockfile_version", "packages"],
+  "additionalProperties": false,
+  "properties": {
+    "lockfile_version": {
+      "const": 1
+    },
+    "packages": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/definitions/locked-package" }
+    }
+  },
+  "definitions": {
+    "locked-package": {
+      "type": "object",
+      "required": ["version", "resolved", "integrity", "commit"],
+      "additionalProperties": false,
+      "properties": {
+        "version":   { "type": "string", "minLength": 1 },
+        "resolved":  { "type": "string", "format": "uri" },
+        "integrity": { "type": "string", "pattern": "^sha256-" },
+        "commit":    { "type": "string", "minLength": 7 }
+      }
+    }
+  }
+}

--- a/tools/packages/registry-schema.json
+++ b/tools/packages/registry-schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Pulp Package Registry",
+  "description": "Schema for the Pulp package registry (v2 format)",
+  "type": "object",
+  "required": ["registry_version", "packages"],
+  "additionalProperties": false,
+  "properties": {
+    "registry_version": {
+      "const": 2
+    },
+    "packages": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9][a-z0-9-]*$": { "$ref": "#/definitions/package" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "definitions": {
+    "package": {
+      "type": "object",
+      "required": [
+        "name", "version", "description", "license", "category", "url",
+        "fetch", "cmake", "platforms", "rt_safe", "tags", "provides",
+        "overlaps_with_builtin", "unique_value", "alternatives",
+        "migration_notes", "verification"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name":        { "type": "string", "minLength": 1 },
+        "version":     { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "license":     { "type": "string", "minLength": 1 },
+        "category": {
+          "type": "string",
+          "enum": ["dsp", "audio-io", "music-theory", "ui", "ml", "networking", "utilities"]
+        },
+        "url":  { "type": "string", "format": "uri" },
+        "fetch": { "$ref": "#/definitions/fetch" },
+        "cmake": { "$ref": "#/definitions/cmake" },
+        "platforms": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "$ref": "#/definitions/platform-entry" }
+        },
+        "rt_safe":              { "type": "boolean" },
+        "tags":                 { "type": "array", "items": { "type": "string" } },
+        "provides":             { "type": "array", "items": { "type": "string" } },
+        "overlaps_with_builtin": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "unique_value":   { "type": "string" },
+        "alternatives":   { "type": "array", "items": { "type": "string" } },
+        "migration_notes": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "verification": { "$ref": "#/definitions/verification" }
+      }
+    },
+    "fetch": {
+      "type": "object",
+      "required": ["method", "git_repository", "git_tag"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": ["FetchContent", "header-only", "vendored"]
+        },
+        "git_repository": { "type": "string", "format": "uri" },
+        "git_tag":        { "type": "string", "minLength": 1 }
+      }
+    },
+    "cmake": {
+      "type": "object",
+      "required": ["targets", "header_only", "include_dir"],
+      "additionalProperties": false,
+      "properties": {
+        "targets":     { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "header_only": { "type": "boolean" },
+        "include_dir": { "type": "string" }
+      }
+    },
+    "platform-entry": {
+      "type": "object",
+      "required": ["architectures"],
+      "additionalProperties": false,
+      "properties": {
+        "architectures": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["arm64", "x64", "wasm32"]
+          },
+          "minItems": 1
+        },
+        "notes": { "type": "string" }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "required": ["last_verified", "verified_version", "upstream_commit", "upstream_latest", "pulp_commit", "build_status"],
+      "additionalProperties": false,
+      "properties": {
+        "last_verified":   { "type": "string", "format": "date" },
+        "verified_version": { "type": "string" },
+        "upstream_commit":  { "type": "string" },
+        "upstream_latest":  { "type": "string" },
+        "pulp_commit":      { "type": "string" },
+        "build_status": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["pass", "fail", "untested"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/packages/registry.json
+++ b/tools/packages/registry.json
@@ -1,0 +1,469 @@
+{
+  "registry_version": 2,
+  "packages": {
+    "signalsmith-stretch": {
+      "name": "Signalsmith Stretch",
+      "version": "1.1.0",
+      "description": "Polyphonic pitch and time stretching",
+      "license": "MIT",
+      "category": "dsp",
+      "url": "https://github.com/Signalsmith-Audio/signalsmith-stretch",
+      "fetch": {
+        "method": "header-only",
+        "git_repository": "https://github.com/Signalsmith-Audio/signalsmith-stretch.git",
+        "git_tag": "1.1.0"
+      },
+      "cmake": {
+        "targets": ["signalsmith-stretch"],
+        "header_only": true,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS":   { "architectures": ["arm64"] },
+        "Windows": { "architectures": ["x64", "arm64"] },
+        "Linux":   { "architectures": ["x64", "arm64"] }
+      },
+      "rt_safe": true,
+      "tags": ["pitch-shifting", "time-stretching", "spectral", "polyphonic"],
+      "provides": ["pitch-shift", "time-stretch"],
+      "overlaps_with_builtin": {},
+      "unique_value": "High-quality polyphonic pitch/time stretching with no GPL dependency",
+      "alternatives": ["Rubber Band (GPL — requires commercial license)"],
+      "migration_notes": {
+        "from:rubber-band": "Signalsmith Stretch is MIT-licensed and header-only; API differs but covers similar use cases"
+      },
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "1.1.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "1.1.0",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "signalsmith-dsp": {
+      "name": "Signalsmith DSP",
+      "version": "v1.7.1",
+      "description": "Filters, envelopes, FFT, delay, spectral processing tools",
+      "license": "MIT",
+      "category": "dsp",
+      "url": "https://github.com/Signalsmith-Audio/dsp",
+      "fetch": {
+        "method": "header-only",
+        "git_repository": "https://github.com/Signalsmith-Audio/dsp.git",
+        "git_tag": "v1.7.1"
+      },
+      "cmake": {
+        "targets": ["signalsmith-dsp"],
+        "header_only": true,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS":   { "architectures": ["arm64"] },
+        "Windows": { "architectures": ["x64", "arm64"] },
+        "Linux":   { "architectures": ["x64", "arm64"] }
+      },
+      "rt_safe": true,
+      "tags": ["filters", "fft", "envelopes", "delay", "spectral", "windowing"],
+      "provides": ["filters", "fft", "envelopes", "delay", "spectral-processing"],
+      "overlaps_with_builtin": {
+        "signal/biquad.hpp": "biquad filters",
+        "signal/svf.hpp": "state variable filter",
+        "signal/delay_line.hpp": "delay line",
+        "signal/fft.hpp": "FFT"
+      },
+      "unique_value": "Comprehensive DSP toolkit with spectral processing and advanced envelope designs beyond Pulp built-ins",
+      "alternatives": ["KFR (GPL — requires commercial license)"],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "v1.7.1",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v1.7.1",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "rtneural": {
+      "name": "RTNeural",
+      "version": "1fb1f075",
+      "description": "Real-time neural network inference optimized for audio",
+      "license": "BSD-3-Clause",
+      "category": "ml",
+      "url": "https://github.com/jatinchowdhury18/RTNeural",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/jatinchowdhury18/RTNeural.git",
+        "git_tag": "1fb1f075"
+      },
+      "cmake": {
+        "targets": ["RTNeural"],
+        "header_only": false,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS":   { "architectures": ["arm64"] },
+        "Windows": { "architectures": ["x64", "arm64"] },
+        "Linux":   { "architectures": ["x64", "arm64"] }
+      },
+      "rt_safe": true,
+      "tags": ["neural-network", "ml", "inference", "amp-modeling", "real-time"],
+      "provides": ["neural-network-inference", "ml-inference"],
+      "overlaps_with_builtin": {},
+      "unique_value": "Real-time safe neural network inference for amp modeling, vocal processing, and intelligent audio effects",
+      "alternatives": ["ONNX Runtime (MIT — heavier, more general)", "nn-inference-template (MIT — template for multiple backends)"],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "1fb1f075",
+        "upstream_commit": "unknown",
+        "upstream_latest": "1fb1f075",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "cycfi-q": {
+      "name": "Q (Cycfi)",
+      "version": "version_1.0",
+      "description": "Pitch detection via bitstream autocorrelation and DSP primitives",
+      "license": "MIT",
+      "category": "dsp",
+      "url": "https://github.com/cycfi/q",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/cycfi/q.git",
+        "git_tag": "version_1.0"
+      },
+      "cmake": {
+        "targets": ["cycfi::q"],
+        "header_only": false,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS":   { "architectures": ["arm64"] },
+        "Windows": { "architectures": ["x64"], "notes": "arm64 not verified" },
+        "Linux":   { "architectures": ["x64", "arm64"] }
+      },
+      "rt_safe": true,
+      "tags": ["pitch-detection", "autocorrelation", "frequency", "tuner"],
+      "provides": ["pitch-detection", "frequency-analysis"],
+      "overlaps_with_builtin": {},
+      "unique_value": "Fast, accurate pitch detection using bitstream autocorrelation — no equivalent in Pulp built-ins",
+      "alternatives": ["Aubio (GPL — requires commercial license)", "Essentia (AGPL — incompatible)"],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "version_1.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "version_1.0",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "libsamplerate": {
+      "name": "libsamplerate",
+      "version": "0.2.2",
+      "description": "High-quality sample rate conversion (Secret Rabbit Code)",
+      "license": "BSD-2-Clause",
+      "category": "audio-io",
+      "url": "https://github.com/libsndfile/libsamplerate",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/libsndfile/libsamplerate.git",
+        "git_tag": "0.2.2"
+      },
+      "cmake": {
+        "targets": ["SampleRate::samplerate"],
+        "header_only": false,
+        "include_dir": "include"
+      },
+      "platforms": {
+        "macOS":   { "architectures": ["arm64"] },
+        "Windows": { "architectures": ["x64", "arm64"] },
+        "Linux":   { "architectures": ["x64", "arm64"] }
+      },
+      "rt_safe": false,
+      "tags": ["resampling", "sample-rate", "conversion", "interpolation"],
+      "provides": ["sample-rate-conversion", "resampling"],
+      "overlaps_with_builtin": {},
+      "unique_value": "Industry-standard sample rate conversion with multiple quality modes (sinc best, sinc medium, sinc fastest, linear, zero-order-hold)",
+      "alternatives": ["r8brain-free-src (MIT — different quality tradeoffs)"],
+      "migration_notes": {
+        "from:libsndfile": "libsamplerate handles resampling only, not file I/O — use dr-libs for file decoding"
+      },
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "0.2.2",
+        "upstream_commit": "unknown",
+        "upstream_latest": "0.2.2",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "dr-libs": {
+      "name": "dr_libs",
+      "version": "wav-0.14.5",
+      "description": "Single-file WAV, FLAC, and MP3 decoding",
+      "license": "MIT-0",
+      "category": "audio-io",
+      "url": "https://github.com/mackron/dr_libs",
+      "fetch": {
+        "method": "header-only",
+        "git_repository": "https://github.com/mackron/dr_libs.git",
+        "git_tag": "wav-0.14.5"
+      },
+      "cmake": {
+        "targets": ["dr_libs"],
+        "header_only": true,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS":   { "architectures": ["arm64"] },
+        "Windows": { "architectures": ["x64", "arm64"] },
+        "Linux":   { "architectures": ["x64", "arm64"] }
+      },
+      "rt_safe": false,
+      "tags": ["wav", "flac", "mp3", "decoding", "audio-file", "single-header"],
+      "provides": ["wav-decoding", "flac-decoding", "mp3-decoding"],
+      "overlaps_with_builtin": {},
+      "unique_value": "Zero-dependency single-header audio file decoding for WAV, FLAC, and MP3",
+      "alternatives": ["miniaudio (MIT-0 — includes device I/O too)", "libsndfile (LGPL — copyleft)"],
+      "migration_notes": {
+        "from:libsndfile": "dr_libs is MIT-0 and header-only but decode-only — no encode support for FLAC/MP3"
+      },
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "wav-0.14.5",
+        "upstream_commit": "unknown",
+        "upstream_latest": "wav-0.14.5",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "pffft": {
+      "name": "PFFFT",
+      "version": "v1.1.0",
+      "description": "SIMD-optimized FFT (SSE on x64, NEON on arm64)",
+      "license": "BSD-3-Clause",
+      "category": "dsp",
+      "url": "https://github.com/marton78/pffft",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/marton78/pffft.git",
+        "git_tag": "v1.1.0"
+      },
+      "cmake": {
+        "targets": ["pffft"],
+        "header_only": false,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS":   { "architectures": ["arm64"], "notes": "NEON path" },
+        "Windows": { "architectures": ["x64", "arm64"], "notes": "SSE on x64, NEON on arm64" },
+        "Linux":   { "architectures": ["x64", "arm64"], "notes": "SSE on x64, NEON on arm64" }
+      },
+      "rt_safe": true,
+      "tags": ["fft", "simd", "sse", "neon", "spectral"],
+      "provides": ["fft", "simd-fft"],
+      "overlaps_with_builtin": {
+        "signal/fft.hpp": "FFT"
+      },
+      "unique_value": "SIMD-optimized FFT significantly faster than general-purpose implementations for power-of-two sizes",
+      "alternatives": ["KissFFT (BSD-3 — portable but not SIMD-optimized)", "FFTW (GPL — requires commercial license)"],
+      "migration_notes": {
+        "from:fftw": "PFFFT is BSD-licensed and lighter; covers real and complex FFT for power-of-two sizes"
+      },
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "v1.1.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v1.1.0",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "daisysp": {
+      "name": "DaisySP",
+      "version": "V1.0.0",
+      "description": "DSP library with oscillators, filters, effects, and physical modeling",
+      "license": "MIT",
+      "category": "dsp",
+      "url": "https://github.com/electro-smith/DaisySP",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/electro-smith/DaisySP.git",
+        "git_tag": "V1.0.0"
+      },
+      "cmake": {
+        "targets": ["DaisySP"],
+        "header_only": false,
+        "include_dir": "Source"
+      },
+      "platforms": {
+        "macOS":   { "architectures": ["arm64"] },
+        "Windows": { "architectures": ["x64", "arm64"] },
+        "Linux":   { "architectures": ["x64", "arm64"] }
+      },
+      "rt_safe": true,
+      "tags": ["oscillators", "filters", "effects", "physical-modeling", "synthesis", "drums"],
+      "provides": ["physical-modeling", "karplus-strong", "modal-synthesis", "fm-synthesis"],
+      "overlaps_with_builtin": {
+        "signal/oscillator.hpp": "oscillators",
+        "signal/biquad.hpp": "biquad filters",
+        "signal/adsr.hpp": "ADSR envelope",
+        "signal/reverb.hpp": "reverb",
+        "signal/compressor.hpp": "compressor"
+      },
+      "unique_value": "Physical modeling synthesis (Karplus-Strong, modal, pluck) and drum synthesis not available in Pulp built-ins",
+      "alternatives": ["STK (MIT with patent caveats — more physical models)", "Maximilian (MIT — teaching-oriented)"],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "V1.0.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "V1.0.0",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "fontaudio": {
+      "name": "fontaudio",
+      "version": "1.1",
+      "description": "Audio-specific icon font with 200+ icons for plugin UIs",
+      "license": "MIT",
+      "category": "ui",
+      "url": "https://github.com/fefanto/fontaudio",
+      "fetch": {
+        "method": "header-only",
+        "git_repository": "https://github.com/fefanto/fontaudio.git",
+        "git_tag": "1.1"
+      },
+      "cmake": {
+        "targets": ["fontaudio"],
+        "header_only": true,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS":   { "architectures": ["arm64"] },
+        "Windows": { "architectures": ["x64", "arm64"] },
+        "Linux":   { "architectures": ["x64", "arm64"] },
+        "iOS":     { "architectures": ["arm64"] },
+        "WASM":    { "architectures": ["wasm32"] }
+      },
+      "rt_safe": true,
+      "tags": ["icons", "font", "ui", "audio-icons", "svg"],
+      "provides": ["audio-icons", "icon-font"],
+      "overlaps_with_builtin": {},
+      "unique_value": "Purpose-built audio icon font — knob, fader, waveform, speaker, MIDI, and plugin format icons",
+      "alternatives": [],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "1.1",
+        "upstream_commit": "unknown",
+        "upstream_latest": "1.1",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "r8brain-free-src": {
+      "name": "r8brain-free-src",
+      "version": "version-6.5",
+      "description": "High-quality sample rate converter with low latency mode",
+      "license": "MIT",
+      "category": "audio-io",
+      "url": "https://github.com/avaneev/r8brain-free-src",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/avaneev/r8brain-free-src.git",
+        "git_tag": "version-6.5"
+      },
+      "cmake": {
+        "targets": ["r8brain"],
+        "header_only": false,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS":   { "architectures": ["arm64"] },
+        "Windows": { "architectures": ["x64", "arm64"] },
+        "Linux":   { "architectures": ["x64", "arm64"] }
+      },
+      "rt_safe": false,
+      "tags": ["resampling", "sample-rate", "conversion", "high-quality", "low-latency"],
+      "provides": ["sample-rate-conversion", "resampling"],
+      "overlaps_with_builtin": {},
+      "unique_value": "Audiophile-grade sample rate conversion with configurable quality/latency tradeoffs",
+      "alternatives": ["libsamplerate (BSD-2 — industry standard, different quality profile)"],
+      "migration_notes": {
+        "from:libsamplerate": "r8brain offers different quality/latency tradeoffs — benchmark both for your use case"
+      },
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "version-6.5",
+        "upstream_commit": "unknown",
+        "upstream_latest": "version-6.5",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    }
+  }
+}

--- a/tools/packages/registry.json
+++ b/tools/packages/registry.json
@@ -153,7 +153,7 @@
         "git_tag": "version_1.0"
       },
       "cmake": {
-        "targets": ["cycfi::q"],
+        "targets": ["libq"],
         "header_only": false,
         "include_dir": "."
       },
@@ -288,7 +288,7 @@
         "git_tag": "v1.1.0"
       },
       "cmake": {
-        "targets": ["pffft"],
+        "targets": ["PFFFT"],
         "header_only": false,
         "include_dir": "."
       },

--- a/tools/packages/test-stubs/cycfi-q/CMakeLists.txt
+++ b/tools/packages/test-stubs/cycfi-q/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-cycfi-q CXX)
+set(CMAKE_CXX_STANDARD 20)
+
+include(FetchContent)
+FetchContent_Declare(
+  q
+  GIT_REPOSITORY https://github.com/cycfi/q.git
+  GIT_TAG        version_1.0
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(q)
+
+add_executable(test-pkg main.cpp)
+target_link_libraries(test-pkg PRIVATE libq)

--- a/tools/packages/test-stubs/cycfi-q/main.cpp
+++ b/tools/packages/test-stubs/cycfi-q/main.cpp
@@ -1,0 +1,10 @@
+#include <q/pitch/pitch_detector.hpp>
+#include <q/support/literals.hpp>
+#include <cstdio>
+
+int main() {
+    using namespace cycfi::q::literals;
+    cycfi::q::pitch_detector pd(50_Hz, 4000_Hz, 48000, -30_dB);
+    std::printf("cycfi-q: OK (pitch detector created)\n");
+    return 0;
+}

--- a/tools/packages/test-stubs/daisysp/CMakeLists.txt
+++ b/tools/packages/test-stubs/daisysp/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-daisysp CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(
+  DaisySP
+  GIT_REPOSITORY https://github.com/electro-smith/DaisySP.git
+  GIT_TAG        V1.0.0
+  GIT_SHALLOW    TRUE
+)
+FetchContent_Populate(DaisySP)
+
+file(GLOB_RECURSE DAISYSP_SOURCES "${daisysp_SOURCE_DIR}/Source/**/*.cpp")
+add_library(DaisySP STATIC ${DAISYSP_SOURCES})
+# DaisySP uses flat includes across subdirectories
+file(GLOB DAISYSP_SUBDIRS LIST_DIRECTORIES true "${daisysp_SOURCE_DIR}/Source/*")
+target_include_directories(DaisySP PUBLIC "${daisysp_SOURCE_DIR}/Source")
+foreach(subdir ${DAISYSP_SUBDIRS})
+  if(IS_DIRECTORY ${subdir})
+    target_include_directories(DaisySP PUBLIC ${subdir})
+  endif()
+endforeach()
+
+add_executable(test-pkg main.cpp)
+target_link_libraries(test-pkg PRIVATE DaisySP)

--- a/tools/packages/test-stubs/daisysp/main.cpp
+++ b/tools/packages/test-stubs/daisysp/main.cpp
@@ -1,0 +1,12 @@
+#include "Synthesis/oscillator.h"
+#include <cstdio>
+
+int main() {
+    daisysp::Oscillator osc;
+    osc.Init(48000.0f);
+    osc.SetFreq(440.0f);
+    osc.SetWaveform(daisysp::Oscillator::WAVE_SIN);
+    float sample = osc.Process();
+    std::printf("daisysp: OK (sine osc output=%.4f)\n", sample);
+    return 0;
+}

--- a/tools/packages/test-stubs/dr-libs/CMakeLists.txt
+++ b/tools/packages/test-stubs/dr-libs/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-dr-libs CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(
+  dr_libs
+  GIT_REPOSITORY https://github.com/mackron/dr_libs.git
+  GIT_TAG        wav-0.14.5
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(dr_libs)
+
+add_executable(test-pkg main.cpp)
+target_include_directories(test-pkg PRIVATE ${dr_libs_SOURCE_DIR})

--- a/tools/packages/test-stubs/dr-libs/main.cpp
+++ b/tools/packages/test-stubs/dr-libs/main.cpp
@@ -1,0 +1,14 @@
+#define DR_WAV_IMPLEMENTATION
+#include "dr_wav.h"
+#include <cstdio>
+
+int main() {
+    drwav_data_format fmt{};
+    fmt.container = drwav_container_riff;
+    fmt.format = DR_WAVE_FORMAT_PCM;
+    fmt.channels = 1;
+    fmt.sampleRate = 48000;
+    fmt.bitsPerSample = 16;
+    std::printf("dr-libs: OK (drwav format configured)\n");
+    return 0;
+}

--- a/tools/packages/test-stubs/fontaudio/CMakeLists.txt
+++ b/tools/packages/test-stubs/fontaudio/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-fontaudio CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(
+  fontaudio
+  GIT_REPOSITORY https://github.com/fefanto/fontaudio.git
+  GIT_TAG        1.1
+  GIT_SHALLOW    TRUE
+)
+FetchContent_Populate(fontaudio)
+
+# fontaudio is a font asset — verify font file exists
+if(NOT EXISTS "${fontaudio_SOURCE_DIR}/font/fontaudio.ttf")
+  message(FATAL_ERROR "fontaudio.ttf not found")
+endif()
+
+add_executable(test-pkg main.cpp)
+target_compile_definitions(test-pkg PRIVATE
+  FONTAUDIO_TTF="${fontaudio_SOURCE_DIR}/font/fontaudio.ttf"
+)

--- a/tools/packages/test-stubs/fontaudio/main.cpp
+++ b/tools/packages/test-stubs/fontaudio/main.cpp
@@ -1,0 +1,14 @@
+#include <cstdio>
+#include <fstream>
+
+int main() {
+    // Verify the font file exists and is non-empty
+    std::ifstream f(FONTAUDIO_TTF, std::ios::binary | std::ios::ate);
+    if (f.good() && f.tellg() > 0) {
+        std::printf("fontaudio: OK (ttf size=%lld bytes)\n",
+                    static_cast<long long>(f.tellg()));
+        return 0;
+    }
+    std::printf("fontaudio: FAIL (ttf not found or empty)\n");
+    return 1;
+}

--- a/tools/packages/test-stubs/libsamplerate/CMakeLists.txt
+++ b/tools/packages/test-stubs/libsamplerate/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.20)
+cmake_policy(SET CMP0177 NEW)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE STRING "" FORCE)
+project(test-libsamplerate C CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(
+  libsamplerate
+  GIT_REPOSITORY https://github.com/libsndfile/libsamplerate.git
+  GIT_TAG        0.2.2
+  GIT_SHALLOW    TRUE
+)
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(libsamplerate)
+
+add_executable(test-pkg main.cpp)
+target_link_libraries(test-pkg PRIVATE SampleRate::samplerate)

--- a/tools/packages/test-stubs/libsamplerate/main.cpp
+++ b/tools/packages/test-stubs/libsamplerate/main.cpp
@@ -1,0 +1,8 @@
+#include <samplerate.h>
+#include <cstdio>
+
+int main() {
+    const char* name = src_get_name(SRC_SINC_BEST_QUALITY);
+    std::printf("libsamplerate: OK (best quality = %s)\n", name);
+    return 0;
+}

--- a/tools/packages/test-stubs/pffft/CMakeLists.txt
+++ b/tools/packages/test-stubs/pffft/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-pffft C CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(
+  pffft
+  GIT_REPOSITORY https://github.com/marton78/pffft.git
+  GIT_TAG        v1.1.0
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(pffft)
+
+add_executable(test-pkg main.cpp)
+target_link_libraries(test-pkg PRIVATE PFFFT)

--- a/tools/packages/test-stubs/pffft/main.cpp
+++ b/tools/packages/test-stubs/pffft/main.cpp
@@ -1,0 +1,14 @@
+#include <pffft/pffft.h>
+#include <cstdio>
+
+int main() {
+    PFFFT_Setup* setup = pffft_new_setup(1024, PFFFT_REAL);
+    if (setup) {
+        std::printf("pffft: OK (1024-point real FFT created)\n");
+        pffft_destroy_setup(setup);
+    } else {
+        std::printf("pffft: FAIL (setup returned null)\n");
+        return 1;
+    }
+    return 0;
+}

--- a/tools/packages/test-stubs/r8brain-free-src/CMakeLists.txt
+++ b/tools/packages/test-stubs/r8brain-free-src/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-r8brain CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(
+  r8brain
+  GIT_REPOSITORY https://github.com/avaneev/r8brain-free-src.git
+  GIT_TAG        version-6.5
+  GIT_SHALLOW    TRUE
+)
+FetchContent_Populate(r8brain)
+
+add_library(r8brain STATIC "${r8brain_SOURCE_DIR}/r8bbase.cpp")
+target_include_directories(r8brain PUBLIC "${r8brain_SOURCE_DIR}")
+
+add_executable(test-pkg main.cpp)
+target_link_libraries(test-pkg PRIVATE r8brain)

--- a/tools/packages/test-stubs/r8brain-free-src/main.cpp
+++ b/tools/packages/test-stubs/r8brain-free-src/main.cpp
@@ -1,0 +1,8 @@
+#include "CDSPResampler.h"
+#include <cstdio>
+
+int main() {
+    r8b::CDSPResampler24 resampler(44100.0, 48000.0, 1024);
+    std::printf("r8brain-free-src: OK (44100->48000 resampler created)\n");
+    return 0;
+}

--- a/tools/packages/test-stubs/rtneural/CMakeLists.txt
+++ b/tools/packages/test-stubs/rtneural/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-rtneural CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(
+  RTNeural
+  GIT_REPOSITORY https://github.com/jatinchowdhury18/RTNeural.git
+  GIT_TAG        1fb1f075
+)
+FetchContent_MakeAvailable(RTNeural)
+
+add_executable(test-pkg main.cpp)
+target_link_libraries(test-pkg PRIVATE RTNeural)

--- a/tools/packages/test-stubs/rtneural/main.cpp
+++ b/tools/packages/test-stubs/rtneural/main.cpp
@@ -1,0 +1,15 @@
+#include <RTNeural/RTNeural.h>
+#include <cstdio>
+
+int main() {
+    RTNeural::ModelT<float, 1, 1,
+        RTNeural::DenseT<float, 1, 4>,
+        RTNeural::TanhActivationT<float, 4>,
+        RTNeural::DenseT<float, 4, 1>
+    > model;
+    model.reset();
+    float input[] = { 0.5f };
+    float output = model.forward(input);
+    std::printf("rtneural: OK (forward output=%.4f)\n", output);
+    return 0;
+}

--- a/tools/packages/test-stubs/signalsmith-dsp/CMakeLists.txt
+++ b/tools/packages/test-stubs/signalsmith-dsp/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-signalsmith-dsp CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(
+  signalsmith-dsp
+  GIT_REPOSITORY https://github.com/Signalsmith-Audio/dsp.git
+  GIT_TAG        v1.7.1
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(signalsmith-dsp)
+
+add_executable(test-pkg main.cpp)
+target_include_directories(test-pkg PRIVATE ${signalsmith-dsp_SOURCE_DIR})

--- a/tools/packages/test-stubs/signalsmith-dsp/main.cpp
+++ b/tools/packages/test-stubs/signalsmith-dsp/main.cpp
@@ -1,0 +1,10 @@
+#include "filters.h"
+#include <cstdio>
+
+int main() {
+    signalsmith::filters::BiquadStatic<float> bq;
+    bq.lowpass(1000.0f / 48000.0f, 0.707f);
+    float sample = bq(1.0f);
+    std::printf("signalsmith-dsp: OK (lowpass output=%.4f)\n", sample);
+    return 0;
+}

--- a/tools/packages/test-stubs/signalsmith-stretch/CMakeLists.txt
+++ b/tools/packages/test-stubs/signalsmith-stretch/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-signalsmith-stretch CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+include(FetchContent)
+FetchContent_Declare(
+  signalsmith-stretch
+  GIT_REPOSITORY https://github.com/Signalsmith-Audio/signalsmith-stretch.git
+  GIT_TAG        1.1.0
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(signalsmith-stretch)
+
+add_executable(test-pkg main.cpp)
+target_include_directories(test-pkg PRIVATE ${signalsmith-stretch_SOURCE_DIR})

--- a/tools/packages/test-stubs/signalsmith-stretch/main.cpp
+++ b/tools/packages/test-stubs/signalsmith-stretch/main.cpp
@@ -1,0 +1,9 @@
+#include "signalsmith-stretch.h"
+#include <cstdio>
+
+int main() {
+    signalsmith::stretch::SignalsmithStretch<float> stretch;
+    stretch.presetDefault(2, 48000.0f);
+    std::printf("signalsmith-stretch: OK (channels=2, rate=48000)\n");
+    return 0;
+}

--- a/tools/packages/validate_registry.py
+++ b/tools/packages/validate_registry.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Validate the Pulp package registry against its JSON schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = ROOT / "tools" / "packages" / "registry.json"
+SCHEMA = ROOT / "tools" / "packages" / "registry-schema.json"
+
+SLUG_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+ALLOWED_LICENSES = {
+    "MIT", "MIT-0", "BSD-2-Clause", "BSD-3-Clause", "Apache-2.0",
+    "ISC", "zlib", "BSL-1.0", "Unlicense", "CC0-1.0",
+}
+
+REJECTED_LICENSES = {
+    "GPL-2.0", "GPL-2.0-only", "GPL-2.0-or-later",
+    "GPL-3.0", "GPL-3.0-only", "GPL-3.0-or-later",
+    "LGPL-2.1", "LGPL-2.1-only", "LGPL-2.1-or-later",
+    "LGPL-3.0", "LGPL-3.0-only", "LGPL-3.0-or-later",
+    "AGPL-3.0", "AGPL-3.0-only", "AGPL-3.0-or-later",
+    "SSPL-1.0",
+}
+
+BUILD_STATUS_KEY_PATTERN = re.compile(r"^[A-Za-z]+-[a-z0-9]+$")
+
+
+def load_json(path: Path) -> dict:
+    if not path.exists():
+        print(f"ERROR: {path} not found", file=sys.stderr)
+        sys.exit(1)
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"ERROR: {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def validate_schema(registry: dict, schema: dict) -> list[str]:
+    try:
+        import jsonschema
+    except ImportError:
+        print(
+            "WARNING: jsonschema not installed — skipping schema validation.\n"
+            "  Install with: pip install jsonschema",
+            file=sys.stderr,
+        )
+        return []
+
+    errors = []
+    validator = jsonschema.Draft7Validator(schema)
+    for error in sorted(validator.iter_errors(registry), key=lambda e: list(e.path)):
+        path = ".".join(str(p) for p in error.absolute_path) or "(root)"
+        errors.append(f"  {path}: {error.message}")
+    return errors
+
+
+def validate_structural(registry: dict) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if registry.get("registry_version") != 2:
+        errors.append("registry_version must be 2")
+
+    packages = registry.get("packages", {})
+    for slug, pkg in packages.items():
+        if not SLUG_PATTERN.match(slug):
+            errors.append(f"  {slug}: invalid slug (must match [a-z0-9][a-z0-9-]*)")
+
+        ver = pkg.get("verification", {})
+        if ver.get("verified_version") != pkg.get("version"):
+            warnings.append(
+                f"  {slug}: verification.verified_version ({ver.get('verified_version')}) "
+                f"!= version ({pkg.get('version')})"
+            )
+
+        platforms = pkg.get("platforms", {})
+        if not platforms:
+            errors.append(f"  {slug}: must have at least one platform")
+
+        for key in ver.get("build_status", {}):
+            if not BUILD_STATUS_KEY_PATTERN.match(key):
+                warnings.append(f"  {slug}: build_status key '{key}' should be Platform-arch format")
+
+    return errors, warnings
+
+
+def validate_licenses(registry: dict) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    for slug, pkg in registry.get("packages", {}).items():
+        lic = pkg.get("license", "")
+        if lic in REJECTED_LICENSES:
+            errors.append(f"  {slug}: license '{lic}' is incompatible with Pulp's MIT license")
+        elif lic not in ALLOWED_LICENSES:
+            warnings.append(f"  {slug}: license '{lic}' not in known-allowed list — review required")
+
+    return errors, warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate the Pulp package registry")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero on warnings")
+    parser.add_argument("--check-licenses", action="store_true", help="Verify license compatibility")
+    args = parser.parse_args()
+
+    registry = load_json(REGISTRY)
+    schema = load_json(SCHEMA)
+
+    packages = registry.get("packages", {})
+    pkg_count = len(packages)
+    version = registry.get("registry_version", "?")
+    print(f"Validating registry.json ({pkg_count} packages, registry v{version})...")
+
+    all_errors: list[str] = []
+    all_warnings: list[str] = []
+
+    schema_errors = validate_schema(registry, schema)
+    if schema_errors:
+        print("\nSchema validation errors:")
+        for e in schema_errors:
+            print(e)
+        all_errors.extend(schema_errors)
+
+    struct_errors, struct_warnings = validate_structural(registry)
+    all_errors.extend(struct_errors)
+    all_warnings.extend(struct_warnings)
+
+    if args.check_licenses:
+        lic_errors, lic_warnings = validate_licenses(registry)
+        all_errors.extend(lic_errors)
+        all_warnings.extend(lic_warnings)
+
+    for slug, pkg in packages.items():
+        overlaps = len(pkg.get("overlaps_with_builtin", {}))
+        note = f" ({overlaps} built-in overlaps noted)" if overlaps else ""
+        status = "FAIL" if any(slug in e for e in all_errors) else "OK"
+        print(f"  {slug} {'.' * max(1, 30 - len(slug))} {status}{note}")
+
+    if struct_errors:
+        print("\nStructural errors:")
+        for e in struct_errors:
+            print(e)
+
+    if struct_warnings:
+        print("\nWarnings:")
+        for w in struct_warnings:
+            print(w)
+
+    if args.check_licenses:
+        if lic_errors:
+            print("\nLicense errors:")
+            for e in lic_errors:
+                print(e)
+        if lic_warnings:
+            print("\nLicense warnings:")
+            for w in lic_warnings:
+                print(w)
+
+    error_count = len(all_errors)
+    warning_count = len(all_warnings)
+    print(f"\n{pkg_count} packages validated, {error_count} errors, {warning_count} warnings.")
+
+    if error_count > 0:
+        return 1
+    if args.strict and warning_count > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Registry format (v2):** `tools/packages/registry.json` with 10 Tier 1 audio packages (Signalsmith Stretch, Signalsmith DSP, RTNeural, Q/Cycfi, libsamplerate, dr_libs, PFFFT, DaisySP, fontaudio, r8brain-free-src)
- **JSON Schema:** `registry-schema.json` + `packages.lock.schema.json` for automated validation
- **Validation script:** `validate_registry.py` with schema validation, structural checks, and license enforcement
- **Integration guides:** 11 docs covering CMake integration, example usage, platform support, overlap analysis, and attribution for each package
- **Build verification stubs:** Standalone CMake+main.cpp per package — all 10 pass on macOS arm64 with verified CMake targets and include paths
- **Freshness CI:** `freshness-check.yml` (weekly) + `freshness_check.py` checking upstream versions, archive status, and license drift

## Corrections from verification

- PFFFT: CMake target is `PFFFT` (uppercase), include path is `<pffft/pffft.h>`
- cycfi-q: CMake target is `libq`, requires C++20
- Signalsmith DSP: headers at repo root, not `dsp/` subdir
- DaisySP: needs per-subdirectory include paths for desktop builds
- fontaudio: font asset only (no standalone C++ API)

## Test plan

- [x] Registry passes schema + license validation (`--strict`)
- [x] All 10 stubs build and run on macOS arm64
- [x] Freshness check runs successfully against all 10 packages
- [x] Naming audit passes
- [ ] CI green on all platforms (macOS, Ubuntu, Windows)