### PR TITLE
Package manager Phase 2: CLI commands, plugin skill, doctor checks, Tier 2 CI

### DIFF
--- a/.agents/skills/packages/SKILL.md
+++ b/.agents/skills/packages/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: packages
+description: Search, suggest, add, and browse third-party audio packages. Handles "suggest packages", "add a package", "what packages are available", "search for pitch detection", and package browsing.
+requires:
+  scripts:
+    - tools/packages/registry.json
+    - tools/packages/validate_registry.py
+---
+
+# Package Manager Skill
+
+Help users discover, evaluate, and add third-party audio libraries to their Pulp projects.
+
+## When to Use
+
+- User asks about available packages or libraries
+- User needs a capability not in Pulp's built-in signal subsystem
+- User wants to add a third-party library
+- User asks about pitch detection, ML inference, resampling, etc.
+- User says "suggest packages", "find a library for X", "what's available for Y"
+
+## Package Discovery
+
+Search the registry for packages matching a need:
+
+```bash
+./build/tools/cli/pulp search "<query>"
+./build/tools/cli/pulp suggest --description "<what the user needs>"
+```
+
+Or read the registry directly for full details:
+
+```bash
+cat tools/packages/registry.json | python3 -m json.tool
+```
+
+## Package Categories
+
+| Category | Packages | What They Provide |
+|----------|----------|-------------------|
+| dsp | signalsmith-stretch, signalsmith-dsp, cycfi-q, pffft, daisysp | Pitch/time stretch, filters, FFT, pitch detection, physical modeling |
+| audio-io | dr-libs, libsamplerate, r8brain-free-src | File decoding, sample rate conversion |
+| ml | rtneural | Real-time neural network inference |
+| ui | fontaudio | Audio icon font |
+
+## Adding a Package
+
+```bash
+./build/tools/cli/pulp add <package-id>
+```
+
+This will:
+1. Check license compatibility (reject GPL/LGPL)
+2. Check platform support against project targets
+3. Warn about overlaps with Pulp built-ins
+4. Generate `cmake/pulp-packages.cmake` with FetchContent declarations
+5. Update `packages.lock.json`, `DEPENDENCIES.md`, `NOTICE.md`
+6. Print usage instructions (target_link_libraries + #include)
+
+## Overlap Awareness
+
+Before suggesting a package, check if Pulp's built-in `core/signal/` already covers the need:
+
+- **Filters**: biquad, SVF, TPT, Linkwitz-Riley, ladder, FIR — built-in
+- **FFT/STFT**: built-in (use PFFFT only if benchmarks show it's needed)
+- **Delay**: built-in
+- **Reverb, compressor, oscillator, ADSR**: built-in
+- **Pitch detection**: NOT built-in → suggest cycfi-q
+- **Pitch/time stretching**: NOT built-in → suggest signalsmith-stretch
+- **Neural network inference**: NOT built-in → suggest rtneural
+- **Sample rate conversion**: NOT built-in → suggest libsamplerate or r8brain-free-src
+- **Physical modeling**: NOT built-in → suggest daisysp
+
+## Browsing Guides
+
+Each package has a detailed integration guide:
+
+```
+docs/guides/packages/index.md          — category overview
+docs/guides/packages/<package-id>.md   — per-package guide
+```
+
+Read these to answer questions about specific packages.
+
+## License Policy
+
+Only MIT/BSD/Apache/ISC/zlib/BSL/public-domain packages are allowed. The registry enforces this. If a user asks about a GPL library, explain the incompatibility and suggest the MIT-licensed alternative from the registry.

--- a/.github/workflows/freshness-check.yml
+++ b/.github/workflows/freshness-check.yml
@@ -55,3 +55,45 @@ jobs:
             --title "Package freshness: $(date +%Y-%m-%d) — updates available" \
             --body "$(cat freshness-report.md)" \
             --label "dependencies"
+
+  # Tier 2: Full build validation (monthly or on-demand)
+  build-validation:
+    name: Build validation (${{ matrix.package }}) — ${{ matrix.os }}
+    if: inputs.tier == '2'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        package:
+          - signalsmith-stretch
+          - signalsmith-dsp
+          - rtneural
+          - cycfi-q
+          - libsamplerate
+          - dr-libs
+          - pffft
+          - daisysp
+          - fontaudio
+          - r8brain-free-src
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure stub
+        run: |
+          cmake -S tools/packages/test-stubs/${{ matrix.package }} \
+                -B build-stub \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+      - name: Build stub
+        run: cmake --build build-stub
+
+      - name: Run stub
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            ./build-stub/Release/test-pkg.exe
+          else
+            ./build-stub/test-pkg
+          fi
+        shell: bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -682,6 +682,105 @@ Print usage information.
 pulp help
 ```
 
+### add
+
+**Status**: usable
+
+Add a third-party package from the Pulp package registry.
+
+```bash
+pulp add signalsmith-stretch                       # add a package
+pulp add rtneural --license-override commercial    # accept a non-standard license
+pulp add some-lib --platform-guard                 # add with platform guard
+pulp add dr-libs --no-cmake                        # metadata only, skip CMake wiring
+```
+
+Performs license checking, platform compatibility analysis, overlap detection, CMake generation (`cmake/pulp-packages.cmake`), and updates `packages.lock.json`, `DEPENDENCIES.md`, and `NOTICE.md`.
+
+### remove
+
+**Status**: usable
+
+Remove a previously added package.
+
+```bash
+pulp remove signalsmith-stretch
+```
+
+Cleans up the lock file, CMake declarations, and metadata entries.
+
+### list
+
+**Status**: usable
+
+Show installed packages.
+
+```bash
+pulp list              # human-readable table
+pulp list --json       # JSON output
+```
+
+### search
+
+**Status**: usable
+
+Search the package registry.
+
+```bash
+pulp search "pitch detection"
+pulp search dsp
+pulp search fft --format json
+```
+
+### update
+
+**Status**: usable
+
+Check for and apply package updates.
+
+```bash
+pulp update            # dry-run: show available updates
+pulp update --apply    # apply updates and regenerate CMake
+```
+
+### suggest
+
+**Status**: usable
+
+Context-aware package recommendations.
+
+```bash
+pulp suggest --description "pitch shifting"
+pulp suggest --analyze src/my_processor.cpp
+pulp suggest --alternative pffft
+```
+
+### target
+
+**Status**: usable
+
+Manage project platform targets stored in `pulp.toml`.
+
+```bash
+pulp target list                  # show current targets
+pulp target add Windows-arm64     # add a target
+pulp target remove Linux-x64     # remove a target
+```
+
+Default targets (if none configured): `macOS-arm64`, `Windows-x64`, `Linux-x64`.
+
+### audit (package extensions)
+
+The existing `pulp audit` command now supports package-specific flags:
+
+```bash
+pulp audit --packages     # verify lock file integrity
+pulp audit --platforms    # check package/platform coverage
+pulp audit --licenses     # verify license compatibility
+```
+
+These flags are handled natively; without them, `pulp audit` delegates to the Python audit script as before.
+
 ## Global Flags
 
 | Flag | Description |

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -385,6 +385,98 @@ commands:
             summary: Launch an app and capture screenshot plus available UI state; supports shared source flags (--source-mode, --branch, --sha, --prepare-command, --prepare-timeout)
     docs: guides/local-ci.md
 
+  - name: add
+    status: usable
+    summary: Add a third-party package from the registry. License check, platform check, CMake wiring, metadata updates.
+    args:
+      - name: package
+        kind: positional
+        required: true
+        description: Package slug from tools/packages/registry.json
+      - name: --license-override
+        kind: option
+        description: "Accept a rejected license (value: commercial)"
+      - name: --platform-guard
+        kind: flag
+        description: Add with platform guard (skip prompt for unsupported targets)
+      - name: --no-cmake
+        kind: flag
+        description: Skip CMake wiring (metadata only)
+    docs: reference/cli.md#add
+
+  - name: remove
+    status: usable
+    summary: Remove a previously added package. Cleans lock file, CMake, and metadata.
+    args:
+      - name: package
+        kind: positional
+        required: true
+        description: Package slug to remove
+    docs: reference/cli.md#remove
+
+  - name: list
+    status: usable
+    summary: Show installed packages from packages.lock.json.
+    args:
+      - name: --json
+        kind: flag
+        description: Output as JSON
+    docs: reference/cli.md#list
+
+  - name: search
+    status: usable
+    summary: Search the package registry by name, tags, description, or category.
+    args:
+      - name: query
+        kind: positional
+        required: true
+        description: Search query string
+      - name: --format
+        kind: option
+        description: "Output format (text or json)"
+    docs: reference/cli.md#search
+
+  - name: update
+    status: usable
+    summary: Check for and apply package version updates.
+    args:
+      - name: --apply
+        kind: flag
+        description: Apply updates (default is dry-run)
+    docs: reference/cli.md#update
+
+  - name: suggest
+    status: usable
+    summary: Context-aware package recommendations.
+    args:
+      - name: --description
+        kind: option
+        description: Find packages matching a text description
+      - name: --analyze
+        kind: option
+        description: Scan a source file for package suggestions
+      - name: --alternative
+        kind: option
+        description: Find alternatives to a specific package
+      - name: --format
+        kind: option
+        description: "Output format (text or json)"
+    docs: reference/cli.md#suggest
+
+  - name: target
+    status: usable
+    summary: Manage project platform targets in pulp.toml.
+    args:
+      - name: subcommand
+        kind: positional
+        required: true
+        description: "list, add, or remove"
+      - name: target
+        kind: positional
+        required: false
+        description: "Platform-arch target (e.g., macOS-arm64, Windows-x64)"
+    docs: reference/cli.md#target
+
   - name: help
     status: usable
     summary: Print usage information.

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -1,5 +1,6 @@
 # pulp CLI tool
-add_executable(pulp-cli pulp_cli.cpp design_binding.cpp create_targets.cpp)
+add_executable(pulp-cli pulp_cli.cpp design_binding.cpp create_targets.cpp
+    package_registry.cpp package_commands.cpp)
 set_target_properties(pulp-cli PROPERTIES OUTPUT_NAME "pulp")
 target_compile_features(pulp-cli PRIVATE cxx_std_20)
 target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format)

--- a/tools/cli/package_commands.cpp
+++ b/tools/cli/package_commands.cpp
@@ -1,0 +1,1010 @@
+// SPDX-License-Identifier: MIT
+#include "package_commands.hpp"
+#include "package_registry.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <regex>
+#include <sstream>
+
+namespace pulp::cli::pkg {
+
+// ── Helpers ──
+
+static bool g_color = true;
+
+static std::string green(const std::string& s) {
+    return g_color ? ("\033[32m" + s + "\033[0m") : s;
+}
+static std::string red(const std::string& s) {
+    return g_color ? ("\033[31m" + s + "\033[0m") : s;
+}
+static std::string yellow(const std::string& s) {
+    return g_color ? ("\033[33m" + s + "\033[0m") : s;
+}
+static std::string dim(const std::string& s) {
+    return g_color ? ("\033[2m" + s + "\033[0m") : s;
+}
+
+static void print_ok(const std::string& msg) {
+    std::cout << green("✓") << " " << msg << "\n";
+}
+static void print_fail(const std::string& msg) {
+    std::cerr << red("✗") << " " << msg << "\n";
+}
+static void print_warn(const std::string& msg) {
+    std::cout << yellow("⚠") << " " << msg << "\n";
+}
+
+static fs::path find_project_root() {
+    auto dir = fs::current_path();
+    while (true) {
+        if (fs::exists(dir / "CMakeLists.txt") && fs::exists(dir / "core"))
+            return dir;
+        if (fs::exists(dir / "pulp.toml"))
+            return dir;
+        auto parent = dir.parent_path();
+        if (parent == dir) break;
+        dir = parent;
+    }
+    return {};
+}
+
+static fs::path find_registry_path(const fs::path& root) {
+    auto p = root / "tools" / "packages" / "registry.json";
+    if (fs::exists(p)) return p;
+    return {};
+}
+
+static std::string read_file(const fs::path& path) {
+    std::ifstream f(path);
+    if (!f) return {};
+    return {std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>()};
+}
+
+static bool write_file(const fs::path& path, const std::string& content) {
+    if (auto parent = path.parent_path(); !parent.empty())
+        fs::create_directories(parent);
+    std::ofstream f(path);
+    if (!f) return false;
+    f << content;
+    return f.good();
+}
+
+static std::string dots(const std::string& name, int width = 35) {
+    int n = std::max(1, width - static_cast<int>(name.size()));
+    return std::string(n, '.');
+}
+
+// ── CMake Generation ──
+
+static std::string generate_cmake_block(const PackageDescriptor& pkg,
+                                         bool platform_guard = false,
+                                         const std::string& guard_platform = "") {
+    std::ostringstream os;
+    os << "# ── " << pkg.id << " (" << pkg.version << ")";
+    if (platform_guard) os << " [" << guard_platform << " only]";
+    os << " ──\n";
+
+    if (platform_guard) {
+        if (guard_platform == "macOS") os << "if(APPLE)\n";
+        else if (guard_platform == "Windows") os << "if(WIN32)\n";
+        else if (guard_platform == "Linux") os << "if(UNIX AND NOT APPLE)\n";
+    }
+
+    std::string indent = platform_guard ? "  " : "";
+
+    if (pkg.fetch.method == "header-only") {
+        os << indent << "FetchContent_Declare(" << pkg.id << "\n";
+        os << indent << "  GIT_REPOSITORY " << pkg.fetch.git_repository << "\n";
+        os << indent << "  GIT_TAG        " << pkg.fetch.git_tag << "\n";
+        os << indent << "  GIT_SHALLOW    TRUE\n";
+        os << indent << ")\n";
+        os << indent << "FetchContent_MakeAvailable(" << pkg.id << ")\n";
+        if (!pkg.cmake.targets.empty()) {
+            os << indent << "add_library(" << pkg.cmake.targets[0] << " INTERFACE)\n";
+            os << indent << "target_include_directories(" << pkg.cmake.targets[0]
+               << " INTERFACE ${" << pkg.id << "_SOURCE_DIR}";
+            if (!pkg.cmake.include_dir.empty() && pkg.cmake.include_dir != ".")
+                os << "/" << pkg.cmake.include_dir;
+            os << ")\n";
+        }
+    } else {
+        os << indent << "FetchContent_Declare(" << pkg.id << "\n";
+        os << indent << "  GIT_REPOSITORY " << pkg.fetch.git_repository << "\n";
+        os << indent << "  GIT_TAG        " << pkg.fetch.git_tag << "\n";
+        os << indent << "  GIT_SHALLOW    TRUE\n";
+        os << indent << ")\n";
+        os << indent << "FetchContent_MakeAvailable(" << pkg.id << ")\n";
+    }
+
+    if (platform_guard) {
+        auto upper_id = pkg.id;
+        std::transform(upper_id.begin(), upper_id.end(), upper_id.begin(),
+                       [](unsigned char c) { return c == '-' ? '_' : std::toupper(c); });
+        os << "  target_compile_definitions(${PROJECT_NAME} PRIVATE PULP_HAS_"
+           << upper_id << "=1)\n";
+        os << "endif()\n";
+    }
+
+    os << "# ── end " << pkg.id << " ──\n";
+    return os.str();
+}
+
+static std::string generate_packages_cmake(const LockFile& lock, const Registry& reg,
+                                            const fs::path& project_root) {
+    std::ostringstream os;
+    os << "# Auto-generated by pulp package manager — do not edit manually\n";
+    os << "# Run 'pulp add <pkg>' or 'pulp remove <pkg>' to modify\n";
+    os << "include(FetchContent)\n\n";
+
+    for (auto& [id, lp] : lock.packages) {
+        auto it = reg.packages.find(id);
+        if (it == reg.packages.end()) continue;
+        os << generate_cmake_block(it->second) << "\n";
+    }
+
+    return os.str();
+}
+
+static void ensure_cmake_include(const fs::path& project_root) {
+    auto cml = project_root / "CMakeLists.txt";
+    auto content = read_file(cml);
+    if (content.find("cmake/pulp-packages.cmake") != std::string::npos)
+        return;
+
+    std::ofstream f(cml, std::ios::app);
+    f << "\n# Pulp package manager\n";
+    f << "include(cmake/pulp-packages.cmake OPTIONAL)\n";
+}
+
+// ── Metadata Updates ──
+
+static void update_dependencies_md(const fs::path& root, const PackageDescriptor& pkg,
+                                    bool add) {
+    auto path = root / "DEPENDENCIES.md";
+    auto content = read_file(path);
+    if (content.empty()) return;
+
+    std::string entry = "| " + pkg.name + " | " + pkg.version + " | " +
+                        pkg.license + " | FetchContent | " + pkg.description + " | 2026-04-07 |";
+
+    if (add) {
+        // Insert alphabetically in the table
+        std::istringstream stream(content);
+        std::ostringstream out;
+        std::string line;
+        bool inserted = false;
+        bool in_table = false;
+
+        while (std::getline(stream, line)) {
+            if (line.find("| Name") != std::string::npos || line.find("|---") != std::string::npos) {
+                in_table = true;
+                out << line << "\n";
+                continue;
+            }
+
+            if (in_table && !inserted && line.starts_with("| ")) {
+                // Extract name from table row for alphabetical comparison
+                auto end_name = line.find(" |", 2);
+                auto row_name = line.substr(2, end_name - 2);
+                // Trim the name
+                while (!row_name.empty() && row_name.back() == ' ') row_name.pop_back();
+
+                if (pkg.name < row_name) {
+                    out << entry << "\n";
+                    inserted = true;
+                }
+            }
+
+            if (in_table && !line.starts_with("| ") && !inserted) {
+                out << entry << "\n";
+                inserted = true;
+            }
+
+            out << line << "\n";
+        }
+
+        if (!inserted) out << entry << "\n";
+        write_file(path, out.str());
+    } else {
+        // Remove: find and delete the line containing this package name
+        std::istringstream stream(content);
+        std::ostringstream out;
+        std::string line;
+        while (std::getline(stream, line)) {
+            if (line.find("| " + pkg.name + " |") != std::string::npos) continue;
+            out << line << "\n";
+        }
+        write_file(path, out.str());
+    }
+}
+
+static void update_notice_md(const fs::path& root, const PackageDescriptor& pkg,
+                              bool add) {
+    auto path = root / "NOTICE.md";
+    auto content = read_file(path);
+
+    if (add) {
+        std::string block = "\n## " + pkg.name + "\n\n"
+                          + pkg.license + " — " + pkg.url + "\n";
+
+        // Insert alphabetically by finding the right position
+        auto pos = content.find("## ");
+        while (pos != std::string::npos) {
+            auto end_line = content.find('\n', pos);
+            auto section_name = content.substr(pos + 3, end_line - pos - 3);
+            if (pkg.name < section_name) {
+                content.insert(pos, block + "\n");
+                write_file(path, content);
+                return;
+            }
+            pos = content.find("## ", end_line);
+        }
+        // Append at end
+        content += block;
+        write_file(path, content);
+    } else {
+        // Remove the section for this package
+        auto header = "## " + pkg.name;
+        auto pos = content.find(header);
+        if (pos != std::string::npos) {
+            auto next = content.find("\n## ", pos + 1);
+            if (next == std::string::npos) next = content.size();
+            // Also remove leading blank line
+            if (pos > 0 && content[pos - 1] == '\n') pos--;
+            content.erase(pos, next - pos);
+            write_file(path, content);
+        }
+    }
+}
+
+// ── Commands ──
+
+int cmd_target(const std::vector<std::string>& args) {
+    if (args.empty()) {
+        std::cout << "Usage: pulp target <list|add|remove> [target]\n\n"
+                  << "Manage platform targets for your project.\n"
+                  << "Target format: Platform-arch (e.g., macOS-arm64, Windows-x64)\n\n"
+                  << "Commands:\n"
+                  << "  list              Show current project targets\n"
+                  << "  add <target>      Add a platform target\n"
+                  << "  remove <target>   Remove a platform target\n";
+        return 0;
+    }
+
+    auto root = find_project_root();
+    if (root.empty()) {
+        print_fail("Not in a Pulp project (no CMakeLists.txt or pulp.toml found)");
+        return 1;
+    }
+
+    auto subcmd = args[0];
+
+    if (subcmd == "list") {
+        auto targets = read_project_targets(root);
+        bool has_toml = fs::exists(root / "pulp.toml");
+        std::cout << "Project targets";
+        if (!has_toml) std::cout << " " << dim("(defaults — no pulp.toml)");
+        std::cout << ":\n";
+        for (auto& t : targets)
+            std::cout << "  " << t.to_string() << "\n";
+        return 0;
+    }
+
+    if (subcmd == "add") {
+        if (args.size() < 2) {
+            print_fail("Usage: pulp target add <Platform-arch>");
+            return 1;
+        }
+        auto parsed = PlatformTarget::parse(args[1]);
+        if (!parsed) {
+            print_fail("Invalid target: " + args[1]);
+            std::cout << "Valid platforms: macOS, Windows, Linux, iOS, WASM\n";
+            std::cout << "Valid architectures: arm64, x64, wasm32\n";
+            return 1;
+        }
+        auto targets = read_project_targets(root);
+        for (auto& t : targets) {
+            if (t == *parsed) {
+                print_warn("Target " + parsed->to_string() + " is already configured");
+                return 0;
+            }
+        }
+        targets.push_back(*parsed);
+        if (!write_project_targets(root, targets)) {
+            print_fail("Failed to write pulp.toml");
+            return 1;
+        }
+        print_ok("Added target: " + parsed->to_string());
+
+        // Check installed packages for compatibility
+        auto lock_path = root / "packages.lock.json";
+        if (fs::exists(lock_path)) {
+            auto reg_path = find_registry_path(root);
+            if (!reg_path.empty()) {
+                auto [reg, err] = load_registry(reg_path);
+                auto lock = load_lock_file(lock_path);
+                for (auto& [id, lp] : lock.packages) {
+                    auto it = reg.packages.find(id);
+                    if (it == reg.packages.end()) continue;
+                    auto unsup = unsupported_targets(it->second, {*parsed});
+                    if (!unsup.empty())
+                        print_warn(it->second.name + " does not support " + parsed->to_string());
+                }
+            }
+        }
+        return 0;
+    }
+
+    if (subcmd == "remove") {
+        if (args.size() < 2) {
+            print_fail("Usage: pulp target remove <Platform-arch>");
+            return 1;
+        }
+        auto parsed = PlatformTarget::parse(args[1]);
+        if (!parsed) {
+            print_fail("Invalid target: " + args[1]);
+            return 1;
+        }
+        auto targets = read_project_targets(root);
+        auto it = std::find(targets.begin(), targets.end(), *parsed);
+        if (it == targets.end()) {
+            print_fail("Target " + parsed->to_string() + " is not configured");
+            return 1;
+        }
+        if (targets.size() == 1) {
+            print_fail("Cannot remove the last target");
+            return 1;
+        }
+        targets.erase(it);
+        if (!write_project_targets(root, targets)) {
+            print_fail("Failed to write pulp.toml");
+            return 1;
+        }
+        print_ok("Removed target: " + parsed->to_string());
+        return 0;
+    }
+
+    print_fail("Unknown target subcommand: " + subcmd);
+    return 1;
+}
+
+int cmd_search(const std::vector<std::string>& args) {
+    if (args.empty()) {
+        std::cout << "Usage: pulp search <query>\n\n"
+                  << "Search the package registry by name, description, tags, or category.\n";
+        return 0;
+    }
+
+    auto root = find_project_root();
+    auto reg_path = root.empty() ? fs::path{} : find_registry_path(root);
+    if (reg_path.empty()) {
+        print_fail("Package registry not found at tools/packages/registry.json");
+        return 1;
+    }
+
+    auto [reg, err] = load_registry(reg_path);
+    if (!err.empty()) {
+        print_fail(err);
+        return 1;
+    }
+
+    std::string query;
+    bool json_output = false;
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (args[i] == "--format" && i + 1 < args.size() && args[i + 1] == "json") {
+            json_output = true;
+            ++i;
+        } else {
+            if (!query.empty()) query += " ";
+            query += args[i];
+        }
+    }
+
+    auto results = search(reg, query);
+    if (results.empty()) {
+        std::cout << "No packages found matching: " << query << "\n";
+        return 0;
+    }
+
+    if (json_output) {
+        std::cout << "[\n";
+        for (size_t i = 0; i < results.size(); ++i) {
+            auto& p = *results[i];
+            std::cout << "  {\"id\": \"" << p.id << "\", \"name\": \"" << p.name
+                      << "\", \"version\": \"" << p.version << "\", \"license\": \""
+                      << p.license << "\", \"description\": \"" << p.description << "\"}";
+            if (i + 1 < results.size()) std::cout << ",";
+            std::cout << "\n";
+        }
+        std::cout << "]\n";
+    } else {
+        std::cout << "Found " << results.size() << " package(s) matching \"" << query << "\":\n\n";
+        for (auto* p : results) {
+            auto verdict = check_license(p->license);
+            std::string lic_note;
+            if (verdict == LicenseVerdict::rejected) lic_note = red(" (license incompatible)");
+            else if (verdict == LicenseVerdict::review_required) lic_note = yellow(" (license review required)");
+
+            std::cout << "  " << green(p->id) << " " << dim("v" + p->version)
+                      << " " << dim("[" + p->license + "]") << lic_note << "\n";
+            std::cout << "    " << p->description << "\n\n";
+        }
+    }
+    return 0;
+}
+
+int cmd_list(const std::vector<std::string>& args) {
+    auto root = find_project_root();
+    if (root.empty()) {
+        print_fail("Not in a Pulp project");
+        return 1;
+    }
+
+    auto lock_path = root / "packages.lock.json";
+    if (!fs::exists(lock_path)) {
+        std::cout << "No packages installed.\n";
+        std::cout << dim("Use 'pulp add <package>' to add a package, or 'pulp search <query>' to find packages.") << "\n";
+        return 0;
+    }
+
+    auto lock = load_lock_file(lock_path);
+    if (lock.packages.empty()) {
+        std::cout << "No packages installed.\n";
+        return 0;
+    }
+
+    // Try to enrich with registry data
+    auto reg_path = find_registry_path(root);
+    Registry reg;
+    if (!reg_path.empty()) {
+        auto [r, e] = load_registry(reg_path);
+        if (e.empty()) reg = r;
+    }
+
+    bool json_output = std::find(args.begin(), args.end(), "--json") != args.end();
+
+    if (json_output) {
+        std::cout << "[\n";
+        bool first = true;
+        for (auto& [id, lp] : lock.packages) {
+            if (!first) std::cout << ",\n";
+            first = false;
+            std::cout << "  {\"id\": \"" << id << "\", \"version\": \"" << lp.version << "\"}";
+        }
+        std::cout << "\n]\n";
+    } else {
+        std::cout << "Installed packages (" << lock.packages.size() << "):\n\n";
+        for (auto& [id, lp] : lock.packages) {
+            auto it = reg.packages.find(id);
+            std::string name = it != reg.packages.end() ? it->second.name : id;
+            std::string license = it != reg.packages.end() ? it->second.license : "?";
+            std::string category = it != reg.packages.end() ? it->second.category : "?";
+
+            std::cout << "  " << name << " " << dots(name) << " "
+                      << dim("v" + lp.version) << " " << dim("[" + license + "]")
+                      << " " << dim(category) << "\n";
+        }
+    }
+    return 0;
+}
+
+int cmd_add(const std::vector<std::string>& args) {
+    if (args.empty()) {
+        std::cout << "Usage: pulp add <package> [options]\n\n"
+                  << "Options:\n"
+                  << "  --license-override commercial   Accept a rejected license\n"
+                  << "  --platform-guard                Add with platform guard (skip prompt)\n"
+                  << "  --no-cmake                      Skip CMake wiring\n";
+        return 0;
+    }
+
+    // Parse args
+    std::string package_id;
+    bool license_override = false;
+    bool platform_guard = false;
+    bool no_cmake = false;
+
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (args[i] == "--license-override" && i + 1 < args.size() && args[i + 1] == "commercial") {
+            license_override = true; ++i;
+        } else if (args[i] == "--platform-guard") {
+            platform_guard = true;
+        } else if (args[i] == "--no-cmake") {
+            no_cmake = true;
+        } else if (package_id.empty() && !args[i].starts_with("-")) {
+            package_id = args[i];
+        }
+    }
+
+    if (package_id.empty()) {
+        print_fail("No package specified");
+        return 1;
+    }
+
+    auto root = find_project_root();
+    if (root.empty()) {
+        print_fail("Not in a Pulp project");
+        return 1;
+    }
+
+    // Load registry
+    auto reg_path = find_registry_path(root);
+    if (reg_path.empty()) {
+        print_fail("Package registry not found at tools/packages/registry.json");
+        return 1;
+    }
+
+    auto [reg, reg_err] = load_registry(reg_path);
+    if (!reg_err.empty()) {
+        print_fail(reg_err);
+        return 1;
+    }
+
+    // Find package
+    auto it = reg.packages.find(package_id);
+    if (it == reg.packages.end()) {
+        print_fail("Package '" + package_id + "' not found in registry");
+        // Suggest similar
+        auto results = search(reg, package_id);
+        if (!results.empty()) {
+            std::cout << "\nDid you mean:\n";
+            for (size_t i = 0; i < std::min(results.size(), size_t(3)); ++i)
+                std::cout << "  " << results[i]->id << " — " << results[i]->description << "\n";
+        }
+        return 1;
+    }
+
+    auto& pkg = it->second;
+
+    // License check
+    auto verdict = check_license(pkg.license);
+    if (verdict == LicenseVerdict::rejected && !license_override) {
+        print_fail(pkg.name + " is " + pkg.license + " licensed, which is incompatible with Pulp's MIT license");
+        std::cout << "\n  If you have a commercial license, use:\n"
+                  << "  pulp add " << package_id << " --license-override commercial\n";
+        return 1;
+    }
+    if (verdict == LicenseVerdict::review_required) {
+        print_warn(pkg.name + " license (" + pkg.license + ") requires manual review");
+    }
+
+    // Check if already installed
+    auto lock_path = root / "packages.lock.json";
+    auto lock = load_lock_file(lock_path);
+    auto lock_it = lock.packages.find(package_id);
+    if (lock_it != lock.packages.end()) {
+        if (lock_it->second.version == pkg.version) {
+            std::cout << pkg.name << " v" << pkg.version << " is already installed.\n";
+            return 0;
+        }
+        print_warn(pkg.name + " is installed at v" + lock_it->second.version
+                   + ", registry has v" + pkg.version + ". Use 'pulp update' to upgrade.");
+        return 0;
+    }
+
+    // Platform check
+    auto targets = read_project_targets(root);
+    auto unsup = unsupported_targets(pkg, targets);
+    if (!unsup.empty()) {
+        print_warn(pkg.name + " does not support all your project targets:");
+        for (auto& t : unsup)
+            std::cout << "  " << red("✗") << " " << t.to_string() << "\n";
+
+        if (!platform_guard) {
+            std::cout << "\nOptions:\n"
+                      << "  1. Add with platform guard (compile only on supported platforms)\n"
+                      << "  2. Cancel\n"
+                      << "Use --platform-guard to skip this prompt.\n";
+            return 1;
+        }
+    }
+
+    // Overlap check
+    if (!pkg.overlaps_with_builtin.empty()) {
+        print_warn(pkg.name + " overlaps with Pulp built-ins:");
+        for (auto& [header, desc] : pkg.overlaps_with_builtin)
+            std::cout << "  " << dim(header) << " — " << desc << "\n";
+        std::cout << "  " << green("Unique value:") << " " << pkg.unique_value << "\n";
+    }
+
+    if (!no_cmake) {
+        // Generate/update cmake/pulp-packages.cmake
+        lock.packages[package_id] = {pkg.version, pkg.fetch.git_repository, "", pkg.fetch.git_tag};
+        auto cmake_content = generate_packages_cmake(lock, reg, root);
+        auto cmake_path = root / "cmake" / "pulp-packages.cmake";
+        if (!write_file(cmake_path, cmake_content)) {
+            print_fail("Failed to write " + cmake_path.string());
+            return 1;
+        }
+
+        // Ensure CMakeLists.txt includes the packages file
+        ensure_cmake_include(root);
+    }
+
+    // Update lock file
+    lock.packages[package_id] = {pkg.version, pkg.fetch.git_repository, "", pkg.fetch.git_tag};
+    if (!save_lock_file(lock_path, lock)) {
+        print_fail("Failed to write packages.lock.json");
+        return 1;
+    }
+
+    // Update metadata files
+    update_dependencies_md(root, pkg, true);
+    update_notice_md(root, pkg, true);
+
+    // Print success
+    print_ok("Added " + pkg.name + " v" + pkg.version);
+
+    if (!no_cmake && !pkg.cmake.targets.empty()) {
+        std::cout << "\n  Add to your CMakeLists.txt target:\n";
+        std::cout << "    target_link_libraries(YourTarget PRIVATE " << pkg.cmake.targets[0] << ")\n";
+    }
+
+    return 0;
+}
+
+int cmd_remove(const std::vector<std::string>& args) {
+    if (args.empty()) {
+        std::cout << "Usage: pulp remove <package>\n";
+        return 0;
+    }
+
+    auto root = find_project_root();
+    if (root.empty()) {
+        print_fail("Not in a Pulp project");
+        return 1;
+    }
+
+    auto package_id = args[0];
+    auto lock_path = root / "packages.lock.json";
+    auto lock = load_lock_file(lock_path);
+
+    if (lock.packages.find(package_id) == lock.packages.end()) {
+        print_fail("Package '" + package_id + "' is not installed");
+        return 1;
+    }
+
+    // Get package info for metadata cleanup
+    auto reg_path = find_registry_path(root);
+    PackageDescriptor pkg;
+    pkg.id = package_id;
+    if (!reg_path.empty()) {
+        auto [reg, err] = load_registry(reg_path);
+        auto it = reg.packages.find(package_id);
+        if (it != reg.packages.end()) pkg = it->second;
+    }
+
+    // Remove from lock file
+    lock.packages.erase(package_id);
+    save_lock_file(lock_path, lock);
+
+    // Regenerate cmake/pulp-packages.cmake
+    if (!reg_path.empty()) {
+        auto [reg, err] = load_registry(reg_path);
+        auto cmake_content = generate_packages_cmake(lock, reg, root);
+        auto cmake_path = root / "cmake" / "pulp-packages.cmake";
+        if (lock.packages.empty()) {
+            fs::remove(cmake_path);
+        } else {
+            write_file(cmake_path, cmake_content);
+        }
+    }
+
+    // Update metadata
+    if (!pkg.name.empty()) {
+        update_dependencies_md(root, pkg, false);
+        update_notice_md(root, pkg, false);
+    }
+
+    print_ok("Removed " + (pkg.name.empty() ? package_id : pkg.name));
+    std::cout << dim("  Remember to remove target_link_libraries and #include directives from your code.") << "\n";
+    return 0;
+}
+
+int cmd_update(const std::vector<std::string>& args) {
+    auto root = find_project_root();
+    if (root.empty()) {
+        print_fail("Not in a Pulp project");
+        return 1;
+    }
+
+    auto lock_path = root / "packages.lock.json";
+    if (!fs::exists(lock_path)) {
+        std::cout << "No packages installed.\n";
+        return 0;
+    }
+
+    auto reg_path = find_registry_path(root);
+    if (reg_path.empty()) {
+        print_fail("Package registry not found");
+        return 1;
+    }
+
+    auto [reg, err] = load_registry(reg_path);
+    if (!err.empty()) { print_fail(err); return 1; }
+
+    auto lock = load_lock_file(lock_path);
+    bool apply = std::find(args.begin(), args.end(), "--apply") != args.end();
+    bool has_updates = false;
+
+    for (auto& [id, lp] : lock.packages) {
+        auto it = reg.packages.find(id);
+        if (it == reg.packages.end()) continue;
+
+        if (lp.version != it->second.version) {
+            has_updates = true;
+            std::cout << "  " << it->second.name << ": "
+                      << dim(lp.version) << " → " << green(it->second.version) << "\n";
+            if (apply) {
+                lp.version = it->second.version;
+                lp.commit = it->second.fetch.git_tag;
+            }
+        }
+    }
+
+    if (!has_updates) {
+        print_ok("All packages are up to date");
+        return 0;
+    }
+
+    if (apply) {
+        save_lock_file(lock_path, lock);
+        auto cmake_content = generate_packages_cmake(lock, reg, root);
+        write_file(root / "cmake" / "pulp-packages.cmake", cmake_content);
+        print_ok("Updated packages and regenerated cmake/pulp-packages.cmake");
+    } else {
+        std::cout << "\nRun 'pulp update --apply' to apply these updates.\n";
+    }
+
+    return 0;
+}
+
+int cmd_suggest(const std::vector<std::string>& args) {
+    if (args.empty()) {
+        std::cout << "Usage: pulp suggest [options]\n\n"
+                  << "Options:\n"
+                  << "  --description \"<text>\"   Find packages matching a description\n"
+                  << "  --analyze <file>          Scan a source file for package suggestions\n"
+                  << "  --alternative <package>   Find alternatives to a package\n"
+                  << "  --format json             Output as JSON\n";
+        return 0;
+    }
+
+    auto root = find_project_root();
+    auto reg_path = root.empty() ? fs::path{} : find_registry_path(root);
+    if (reg_path.empty()) {
+        print_fail("Package registry not found");
+        return 1;
+    }
+
+    auto [reg, err] = load_registry(reg_path);
+    if (!err.empty()) { print_fail(err); return 1; }
+
+    // Parse mode
+    std::string mode, value;
+    bool json_output = false;
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (args[i] == "--description" && i + 1 < args.size()) {
+            mode = "description"; value = args[++i];
+        } else if (args[i] == "--analyze" && i + 1 < args.size()) {
+            mode = "analyze"; value = args[++i];
+        } else if (args[i] == "--alternative" && i + 1 < args.size()) {
+            mode = "alternative"; value = args[++i];
+        } else if (args[i] == "--format" && i + 1 < args.size() && args[i + 1] == "json") {
+            json_output = true; ++i;
+        }
+    }
+
+    if (mode == "description") {
+        auto results = search(reg, value);
+        if (results.empty()) {
+            std::cout << "No packages match that description.\n";
+            return 0;
+        }
+        std::cout << "Suggested packages for \"" << value << "\":\n\n";
+        for (size_t i = 0; i < std::min(results.size(), size_t(5)); ++i) {
+            auto& p = *results[i];
+            std::cout << "  " << green(p.id) << " " << dim("v" + p.version)
+                      << " " << dim("[" + p.license + "]") << "\n";
+            std::cout << "    " << p.description << "\n";
+            if (!p.overlaps_with_builtin.empty())
+                std::cout << "    " << yellow("Note:") << " overlaps with Pulp built-ins\n";
+            std::cout << "\n";
+        }
+        return 0;
+    }
+
+    if (mode == "analyze") {
+        auto content = read_file(value);
+        if (content.empty()) {
+            print_fail("Cannot read file: " + value);
+            return 1;
+        }
+
+        // Extract #include directives
+        std::regex include_re("#include\\s*[<\"]([^>\"]+)[>\"]");
+        std::sregex_iterator it(content.begin(), content.end(), include_re);
+        std::sregex_iterator end;
+
+        std::vector<std::string> includes;
+        for (; it != end; ++it)
+            includes.push_back((*it)[1].str());
+
+        // Check each include against registry
+        bool found_any = false;
+        for (auto& [id, pkg] : reg.packages) {
+            for (auto& inc : includes) {
+                bool match = false;
+                for (auto& tag : pkg.tags)
+                    if (inc.find(tag) != std::string::npos) { match = true; break; }
+                if (match) {
+                    if (!found_any) {
+                        std::cout << "Based on includes in " << value << ":\n\n";
+                        found_any = true;
+                    }
+                    std::cout << "  " << green(pkg.id) << " — " << pkg.description << "\n";
+                    break;
+                }
+            }
+        }
+        if (!found_any)
+            std::cout << "No package suggestions based on " << value << "\n";
+        return 0;
+    }
+
+    if (mode == "alternative") {
+        auto it = reg.packages.find(value);
+        if (it == reg.packages.end()) {
+            print_fail("Package '" + value + "' not found");
+            return 1;
+        }
+
+        auto& pkg = it->second;
+        std::cout << "Alternatives to " << pkg.name << ":\n\n";
+
+        // Search by provides
+        for (auto& provide : pkg.provides) {
+            for (auto& [id, other] : reg.packages) {
+                if (id == value) continue;
+                for (auto& op : other.provides) {
+                    if (op == provide) {
+                        std::cout << "  " << green(other.id) << " " << dim("[" + other.license + "]")
+                                  << " — " << other.description << "\n";
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!pkg.alternatives.empty()) {
+            std::cout << "\nAlso noted (may require commercial license):\n";
+            for (auto& alt : pkg.alternatives)
+                std::cout << "  " << dim(alt) << "\n";
+        }
+        return 0;
+    }
+
+    print_fail("Specify --description, --analyze, or --alternative");
+    return 1;
+}
+
+// ── Audit Extensions ──
+
+int audit_packages(const fs::path& project_root) {
+    auto lock_path = project_root / "packages.lock.json";
+    if (!fs::exists(lock_path)) {
+        std::cout << "No packages installed — nothing to audit.\n";
+        return 0;
+    }
+
+    auto lock = load_lock_file(lock_path);
+    auto reg_path = find_registry_path(project_root);
+    if (reg_path.empty()) {
+        print_fail("Package registry not found");
+        return 1;
+    }
+
+    auto [reg, err] = load_registry(reg_path);
+    if (!err.empty()) { print_fail(err); return 1; }
+
+    int issues = 0;
+    for (auto& [id, lp] : lock.packages) {
+        auto it = reg.packages.find(id);
+        if (it == reg.packages.end()) {
+            std::cout << "  " << id << " " << dots(id) << " " << red("NOT IN REGISTRY") << "\n";
+            ++issues;
+        } else {
+            std::cout << "  " << id << " " << dots(id) << " " << green("OK") << "\n";
+        }
+    }
+
+    std::cout << "\n" << lock.packages.size() << " packages audited, " << issues << " issues.\n";
+    return issues > 0 ? 1 : 0;
+}
+
+int audit_platforms(const fs::path& project_root) {
+    auto lock_path = project_root / "packages.lock.json";
+    if (!fs::exists(lock_path)) {
+        std::cout << "No packages installed.\n";
+        return 0;
+    }
+
+    auto lock = load_lock_file(lock_path);
+    auto reg_path = find_registry_path(project_root);
+    if (reg_path.empty()) { print_fail("Registry not found"); return 1; }
+
+    auto [reg, err] = load_registry(reg_path);
+    if (!err.empty()) { print_fail(err); return 1; }
+
+    auto targets = read_project_targets(project_root);
+    int issues = 0;
+
+    // Header
+    std::cout << std::setw(25) << std::left << "Package";
+    for (auto& t : targets) std::cout << " " << std::setw(15) << t.to_string();
+    std::cout << "\n";
+
+    for (auto& [id, lp] : lock.packages) {
+        auto it = reg.packages.find(id);
+        if (it == reg.packages.end()) continue;
+
+        std::cout << std::setw(25) << std::left << id;
+        auto unsup = unsupported_targets(it->second, targets);
+        for (auto& t : targets) {
+            bool ok = std::find(unsup.begin(), unsup.end(), t) == unsup.end();
+            std::cout << " " << std::setw(15) << (ok ? green("✓") : red("✗"));
+            if (!ok) ++issues;
+        }
+        std::cout << "\n";
+    }
+
+    if (issues > 0)
+        print_warn(std::to_string(issues) + " platform gap(s) found");
+    else
+        print_ok("All packages support all project targets");
+
+    return issues > 0 ? 1 : 0;
+}
+
+int audit_licenses(const fs::path& project_root) {
+    auto lock_path = project_root / "packages.lock.json";
+    if (!fs::exists(lock_path)) {
+        std::cout << "No packages installed.\n";
+        return 0;
+    }
+
+    auto lock = load_lock_file(lock_path);
+    auto reg_path = find_registry_path(project_root);
+    if (reg_path.empty()) { print_fail("Registry not found"); return 1; }
+
+    auto [reg, err] = load_registry(reg_path);
+    if (!err.empty()) { print_fail(err); return 1; }
+
+    int issues = 0;
+    for (auto& [id, lp] : lock.packages) {
+        auto it = reg.packages.find(id);
+        if (it == reg.packages.end()) continue;
+
+        auto verdict = check_license(it->second.license);
+        std::string label;
+        switch (verdict) {
+            case LicenseVerdict::allowed:
+                label = green(it->second.license + " OK"); break;
+            case LicenseVerdict::review_required:
+                label = yellow(it->second.license + " REVIEW"); ++issues; break;
+            case LicenseVerdict::rejected:
+                label = red(it->second.license + " REJECTED"); ++issues; break;
+        }
+        std::cout << "  " << id << " " << dots(id) << " " << label << "\n";
+    }
+
+    std::cout << "\n" << lock.packages.size() << " packages checked, " << issues << " issues.\n";
+    return issues > 0 ? 1 : 0;
+}
+
+}  // namespace pulp::cli::pkg

--- a/tools/cli/package_commands.hpp
+++ b/tools/cli/package_commands.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace pulp::cli::pkg {
+
+namespace fs = std::filesystem;
+
+int cmd_add(const std::vector<std::string>& args);
+int cmd_remove(const std::vector<std::string>& args);
+int cmd_list(const std::vector<std::string>& args);
+int cmd_search(const std::vector<std::string>& args);
+int cmd_update(const std::vector<std::string>& args);
+int cmd_suggest(const std::vector<std::string>& args);
+int cmd_target(const std::vector<std::string>& args);
+
+int audit_packages(const fs::path& project_root);
+int audit_platforms(const fs::path& project_root);
+int audit_licenses(const fs::path& project_root);
+
+}  // namespace pulp::cli::pkg

--- a/tools/cli/package_registry.cpp
+++ b/tools/cli/package_registry.cpp
@@ -1,0 +1,585 @@
+// SPDX-License-Identifier: MIT
+#include "package_registry.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <regex>
+#include <sstream>
+
+namespace pulp::cli::pkg {
+
+// ── Helpers ──
+
+static std::string read_file(const fs::path& path) {
+    std::ifstream f(path);
+    if (!f) return {};
+    return {std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>()};
+}
+
+static bool write_file(const fs::path& path, const std::string& content) {
+    std::ofstream f(path);
+    if (!f) return false;
+    f << content;
+    return f.good();
+}
+
+static std::string to_lower(const std::string& s) {
+    std::string r = s;
+    std::transform(r.begin(), r.end(), r.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return r;
+}
+
+static std::string trim(const std::string& s) {
+    auto start = s.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos) return {};
+    auto end = s.find_last_not_of(" \t\r\n");
+    return s.substr(start, end - start + 1);
+}
+
+// ── Minimal JSON Parser ──
+// Handles: objects, arrays, strings, numbers, booleans, null.
+// Sufficient for registry.json and packages.lock.json.
+
+struct JsonValue {
+    enum Type { Null, Bool, Number, String, Array, Object };
+    Type type = Null;
+    bool bool_val = false;
+    double num_val = 0;
+    std::string str_val;
+    std::vector<JsonValue> arr;
+    std::vector<std::pair<std::string, JsonValue>> obj;
+
+    const JsonValue* get(const std::string& key) const {
+        if (type != Object) return nullptr;
+        for (auto& [k, v] : obj)
+            if (k == key) return &v;
+        return nullptr;
+    }
+
+    std::string as_string() const {
+        return type == String ? str_val : std::string{};
+    }
+
+    bool as_bool() const { return type == Bool && bool_val; }
+
+    int as_int() const { return type == Number ? static_cast<int>(num_val) : 0; }
+
+    std::vector<std::string> as_string_array() const {
+        std::vector<std::string> r;
+        if (type == Array)
+            for (auto& v : arr)
+                if (v.type == String) r.push_back(v.str_val);
+        return r;
+    }
+};
+
+struct JsonParser {
+    const std::string& src;
+    size_t pos = 0;
+
+    void skip_ws() {
+        while (pos < src.size() && std::isspace(static_cast<unsigned char>(src[pos])))
+            ++pos;
+    }
+
+    char peek() { skip_ws(); return pos < src.size() ? src[pos] : '\0'; }
+    char next() { skip_ws(); return pos < src.size() ? src[pos++] : '\0'; }
+
+    std::string parse_string() {
+        if (next() != '"') return {};
+        std::string r;
+        while (pos < src.size()) {
+            char c = src[pos++];
+            if (c == '"') return r;
+            if (c == '\\' && pos < src.size()) {
+                c = src[pos++];
+                switch (c) {
+                    case '"': r += '"'; break;
+                    case '\\': r += '\\'; break;
+                    case '/': r += '/'; break;
+                    case 'n': r += '\n'; break;
+                    case 'r': r += '\r'; break;
+                    case 't': r += '\t'; break;
+                    case 'u': pos += 4; r += '?'; break;  // skip unicode escapes
+                    default: r += c;
+                }
+            } else {
+                r += c;
+            }
+        }
+        return r;
+    }
+
+    JsonValue parse_value() {
+        char c = peek();
+        if (c == '"') {
+            return {JsonValue::String, false, 0, parse_string(), {}, {}};
+        }
+        if (c == '{') return parse_object();
+        if (c == '[') return parse_array();
+        if (c == 't' || c == 'f') {
+            bool val = (c == 't');
+            pos += val ? 4 : 5;  // "true" or "false"
+            return {JsonValue::Bool, val, 0, {}, {}, {}};
+        }
+        if (c == 'n') { pos += 4; return {}; }  // null
+        // number
+        size_t start = pos;
+        skip_ws();
+        start = pos;
+        while (pos < src.size() && (std::isdigit(static_cast<unsigned char>(src[pos])) ||
+               src[pos] == '-' || src[pos] == '+' || src[pos] == '.' || src[pos] == 'e' || src[pos] == 'E'))
+            ++pos;
+        double val = 0;
+        try { val = std::stod(src.substr(start, pos - start)); } catch (...) {}
+        return {JsonValue::Number, false, val, {}, {}, {}};
+    }
+
+    JsonValue parse_object() {
+        JsonValue r;
+        r.type = JsonValue::Object;
+        next();  // skip '{'
+        if (peek() == '}') { next(); return r; }
+        while (true) {
+            auto key = parse_string();
+            next();  // skip ':'
+            auto val = parse_value();
+            r.obj.push_back({key, val});
+            if (peek() == '}') { next(); return r; }
+            next();  // skip ','
+        }
+    }
+
+    JsonValue parse_array() {
+        JsonValue r;
+        r.type = JsonValue::Array;
+        next();  // skip '['
+        if (peek() == ']') { next(); return r; }
+        while (true) {
+            r.arr.push_back(parse_value());
+            if (peek() == ']') { next(); return r; }
+            next();  // skip ','
+        }
+    }
+
+    JsonValue parse() { return parse_value(); }
+};
+
+static std::string json_escape(const std::string& s) {
+    std::string r;
+    for (char c : s) {
+        switch (c) {
+            case '"': r += "\\\""; break;
+            case '\\': r += "\\\\"; break;
+            case '\n': r += "\\n"; break;
+            case '\r': r += "\\r"; break;
+            case '\t': r += "\\t"; break;
+            default: r += c;
+        }
+    }
+    return r;
+}
+
+// ── Platform Targets ──
+
+std::optional<PlatformTarget> PlatformTarget::parse(const std::string& s) {
+    auto dash = s.find('-');
+    if (dash == std::string::npos || dash == 0 || dash == s.size() - 1)
+        return std::nullopt;
+
+    PlatformTarget t;
+    t.platform = s.substr(0, dash);
+    t.arch = s.substr(dash + 1);
+
+    if (!is_valid_target(t)) return std::nullopt;
+    return t;
+}
+
+std::vector<PlatformTarget> default_targets() {
+    return {{"macOS", "arm64"}, {"Windows", "x64"}, {"Linux", "x64"}};
+}
+
+bool is_valid_target(const PlatformTarget& t) {
+    static const std::vector<std::string> platforms = {
+        "macOS", "Windows", "Linux", "iOS", "WASM"
+    };
+    static const std::vector<std::string> archs = {
+        "arm64", "x64", "x86", "wasm32"
+    };
+    bool plat_ok = std::find(platforms.begin(), platforms.end(), t.platform) != platforms.end();
+    bool arch_ok = std::find(archs.begin(), archs.end(), t.arch) != archs.end();
+    return plat_ok && arch_ok;
+}
+
+// ── License Policy ──
+
+LicenseVerdict check_license(const std::string& spdx_id) {
+    static const std::vector<std::string> allowed = {
+        "MIT", "MIT-0", "BSD-2-Clause", "BSD-3-Clause", "Apache-2.0",
+        "ISC", "zlib", "BSL-1.0", "Unlicense", "CC0-1.0",
+    };
+    static const std::vector<std::string> rejected_prefixes = {
+        "GPL", "LGPL", "AGPL", "SSPL",
+    };
+
+    auto lower = to_lower(spdx_id);
+    for (auto& a : allowed)
+        if (to_lower(a) == lower) return LicenseVerdict::allowed;
+
+    for (auto& r : rejected_prefixes)
+        if (lower.find(to_lower(r)) == 0) return LicenseVerdict::rejected;
+
+    if (to_lower(spdx_id) == "mpl-2.0") return LicenseVerdict::review_required;
+    if (to_lower(spdx_id) == "proprietary") return LicenseVerdict::rejected;
+
+    return LicenseVerdict::review_required;
+}
+
+const char* license_verdict_label(LicenseVerdict v) {
+    switch (v) {
+        case LicenseVerdict::allowed: return "allowed";
+        case LicenseVerdict::review_required: return "review required";
+        case LicenseVerdict::rejected: return "rejected";
+    }
+    return "unknown";
+}
+
+// ── Registry Loading ──
+
+static PackageDescriptor parse_package(const std::string& id, const JsonValue& j) {
+    PackageDescriptor pkg;
+    pkg.id = id;
+    if (auto v = j.get("name")) pkg.name = v->as_string();
+    if (auto v = j.get("version")) pkg.version = v->as_string();
+    if (auto v = j.get("description")) pkg.description = v->as_string();
+    if (auto v = j.get("license")) pkg.license = v->as_string();
+    if (auto v = j.get("category")) pkg.category = v->as_string();
+    if (auto v = j.get("url")) pkg.url = v->as_string();
+    if (auto v = j.get("rt_safe")) pkg.rt_safe = v->as_bool();
+    if (auto v = j.get("unique_value")) pkg.unique_value = v->as_string();
+    if (auto v = j.get("tags")) pkg.tags = v->as_string_array();
+    if (auto v = j.get("provides")) pkg.provides = v->as_string_array();
+    if (auto v = j.get("alternatives")) pkg.alternatives = v->as_string_array();
+
+    if (auto f = j.get("fetch")) {
+        if (auto v = f->get("method")) pkg.fetch.method = v->as_string();
+        if (auto v = f->get("git_repository")) pkg.fetch.git_repository = v->as_string();
+        if (auto v = f->get("git_tag")) pkg.fetch.git_tag = v->as_string();
+    }
+
+    if (auto c = j.get("cmake")) {
+        if (auto v = c->get("targets")) pkg.cmake.targets = v->as_string_array();
+        if (auto v = c->get("header_only")) pkg.cmake.header_only = v->as_bool();
+        if (auto v = c->get("include_dir")) pkg.cmake.include_dir = v->as_string();
+    }
+
+    if (auto p = j.get("platforms"); p && p->type == JsonValue::Object) {
+        for (auto& [name, val] : p->obj) {
+            PlatformSupport ps;
+            if (auto a = val.get("architectures")) ps.architectures = a->as_string_array();
+            if (auto n = val.get("notes")) ps.notes = n->as_string();
+            pkg.platforms[name] = ps;
+        }
+    }
+
+    if (auto o = j.get("overlaps_with_builtin"); o && o->type == JsonValue::Object) {
+        for (auto& [k, v] : o->obj)
+            pkg.overlaps_with_builtin[k] = v.as_string();
+    }
+
+    if (auto ver = j.get("verification")) {
+        if (auto v = ver->get("last_verified")) pkg.verification.last_verified = v->as_string();
+        if (auto v = ver->get("verified_version")) pkg.verification.verified_version = v->as_string();
+        if (auto bs = ver->get("build_status"); bs && bs->type == JsonValue::Object) {
+            for (auto& [k, v] : bs->obj)
+                pkg.verification.build_status[k] = v.as_string();
+        }
+    }
+
+    return pkg;
+}
+
+RegistryLoadResult load_registry(const fs::path& registry_path) {
+    RegistryLoadResult result;
+
+    auto content = read_file(registry_path);
+    if (content.empty()) {
+        result.error = "Cannot read registry file: " + registry_path.string();
+        return result;
+    }
+
+    JsonParser parser{content};
+    auto root = parser.parse();
+    if (root.type != JsonValue::Object) {
+        result.error = "Registry file is not a valid JSON object";
+        return result;
+    }
+
+    if (auto v = root.get("registry_version"))
+        result.registry.version = v->as_int();
+
+    if (auto pkgs = root.get("packages"); pkgs && pkgs->type == JsonValue::Object) {
+        for (auto& [id, val] : pkgs->obj)
+            result.registry.packages[id] = parse_package(id, val);
+    }
+
+    return result;
+}
+
+// ── Lock File ──
+
+LockFile load_lock_file(const fs::path& path) {
+    LockFile lock;
+    auto content = read_file(path);
+    if (content.empty()) return lock;
+
+    JsonParser parser{content};
+    auto root = parser.parse();
+    if (root.type != JsonValue::Object) return lock;
+
+    if (auto v = root.get("lockfile_version")) lock.version = v->as_int();
+
+    if (auto pkgs = root.get("packages"); pkgs && pkgs->type == JsonValue::Object) {
+        for (auto& [id, val] : pkgs->obj) {
+            LockedPackage lp;
+            if (auto v = val.get("version")) lp.version = v->as_string();
+            if (auto v = val.get("resolved")) lp.resolved = v->as_string();
+            if (auto v = val.get("integrity")) lp.integrity = v->as_string();
+            if (auto v = val.get("commit")) lp.commit = v->as_string();
+            lock.packages[id] = lp;
+        }
+    }
+
+    return lock;
+}
+
+bool save_lock_file(const fs::path& path, const LockFile& lock) {
+    std::ostringstream os;
+    os << "{\n";
+    os << "  \"lockfile_version\": " << lock.version << ",\n";
+    os << "  \"packages\": {";
+
+    bool first = true;
+    for (auto& [id, lp] : lock.packages) {
+        if (!first) os << ",";
+        first = false;
+        os << "\n    \"" << json_escape(id) << "\": {\n";
+        os << "      \"version\": \"" << json_escape(lp.version) << "\",\n";
+        os << "      \"resolved\": \"" << json_escape(lp.resolved) << "\",\n";
+        os << "      \"integrity\": \"" << json_escape(lp.integrity) << "\",\n";
+        os << "      \"commit\": \"" << json_escape(lp.commit) << "\"\n";
+        os << "    }";
+    }
+
+    os << "\n  }\n}\n";
+    return write_file(path, os.str());
+}
+
+// ── Target Config (TOML) ──
+
+std::vector<PlatformTarget> read_project_targets(const fs::path& project_root) {
+    auto toml_path = project_root / "pulp.toml";
+    auto content = read_file(toml_path);
+    if (content.empty()) return default_targets();
+
+    // Find [project] section and targets/platforms array
+    std::istringstream stream(content);
+    std::string line;
+    bool in_project = false;
+    std::string targets_line;
+
+    while (std::getline(stream, line)) {
+        auto trimmed = trim(line);
+        if (trimmed.starts_with("[") && trimmed.ends_with("]")) {
+            in_project = (trimmed == "[project]");
+            continue;
+        }
+        if (in_project) {
+            if (trimmed.starts_with("targets") && trimmed.find('=') != std::string::npos) {
+                targets_line = trimmed;
+                // Collect multi-line array
+                while (targets_line.find(']') == std::string::npos && std::getline(stream, line))
+                    targets_line += " " + trim(line);
+                break;
+            }
+            if (trimmed.starts_with("platforms") && trimmed.find('=') != std::string::npos) {
+                targets_line = trimmed;
+                while (targets_line.find(']') == std::string::npos && std::getline(stream, line))
+                    targets_line += " " + trim(line);
+                break;
+            }
+        }
+    }
+
+    if (targets_line.empty()) return default_targets();
+
+    // Extract array items from TOML-style [...] array
+    auto bracket_start = targets_line.find('[');
+    auto bracket_end = targets_line.rfind(']');
+    if (bracket_start == std::string::npos || bracket_end == std::string::npos)
+        return default_targets();
+
+    auto array_content = targets_line.substr(bracket_start + 1, bracket_end - bracket_start - 1);
+    std::vector<PlatformTarget> result;
+    std::regex item_re("\"([^\"]+)\"");
+    std::sregex_iterator it(array_content.begin(), array_content.end(), item_re);
+    std::sregex_iterator end;
+
+    bool is_platforms = targets_line.starts_with("platforms");
+    for (; it != end; ++it) {
+        std::string val = (*it)[1].str();
+        if (is_platforms) {
+            // Expand platform to default arch
+            std::string arch = "x64";
+            if (val == "macOS" || val == "iOS") arch = "arm64";
+            if (val == "WASM") arch = "wasm32";
+            auto t = PlatformTarget::parse(val + "-" + arch);
+            if (t) result.push_back(*t);
+        } else {
+            auto t = PlatformTarget::parse(val);
+            if (t) result.push_back(*t);
+        }
+    }
+
+    return result.empty() ? default_targets() : result;
+}
+
+bool write_project_targets(const fs::path& project_root,
+                           const std::vector<PlatformTarget>& targets) {
+    auto toml_path = project_root / "pulp.toml";
+    auto content = read_file(toml_path);
+
+    // Build the targets array string
+    std::ostringstream arr;
+    arr << "targets = [\n";
+    for (size_t i = 0; i < targets.size(); ++i) {
+        arr << "  \"" << targets[i].to_string() << "\"";
+        if (i + 1 < targets.size()) arr << ",";
+        arr << "\n";
+    }
+    arr << "]";
+
+    if (content.empty()) {
+        // Create new file
+        std::ostringstream os;
+        os << "[project]\n" << arr.str() << "\n";
+        return write_file(toml_path, os.str());
+    }
+
+    // Find and replace/insert in [project] section
+    std::istringstream stream(content);
+    std::ostringstream out;
+    std::string line;
+    bool in_project = false;
+    bool replaced = false;
+    bool section_found = false;
+
+    while (std::getline(stream, line)) {
+        auto trimmed = trim(line);
+
+        if (trimmed.starts_with("[") && trimmed.ends_with("]")) {
+            if (in_project && !replaced) {
+                out << arr.str() << "\n";
+                replaced = true;
+            }
+            in_project = (trimmed == "[project]");
+            if (in_project) section_found = true;
+            out << line << "\n";
+            continue;
+        }
+
+        if (in_project && !replaced &&
+            (trimmed.starts_with("targets") || trimmed.starts_with("platforms")) &&
+            trimmed.find('=') != std::string::npos) {
+            // Skip old targets/platforms lines (including multi-line arrays)
+            if (trimmed.find(']') == std::string::npos) {
+                while (std::getline(stream, line)) {
+                    if (trim(line).find(']') != std::string::npos) break;
+                }
+            }
+            out << arr.str() << "\n";
+            replaced = true;
+            continue;
+        }
+
+        out << line << "\n";
+    }
+
+    if (!section_found) {
+        out << "\n[project]\n" << arr.str() << "\n";
+    } else if (in_project && !replaced) {
+        out << arr.str() << "\n";
+    }
+
+    return write_file(toml_path, out.str());
+}
+
+// ── Queries ──
+
+std::vector<PlatformTarget> unsupported_targets(
+    const PackageDescriptor& pkg,
+    const std::vector<PlatformTarget>& targets) {
+
+    std::vector<PlatformTarget> unsupported;
+    for (auto& t : targets) {
+        auto it = pkg.platforms.find(t.platform);
+        if (it == pkg.platforms.end()) {
+            unsupported.push_back(t);
+            continue;
+        }
+        auto& archs = it->second.architectures;
+        if (std::find(archs.begin(), archs.end(), t.arch) == archs.end())
+            unsupported.push_back(t);
+    }
+    return unsupported;
+}
+
+std::vector<const PackageDescriptor*> search(const Registry& reg,
+                                              const std::string& query) {
+    auto q = to_lower(query);
+
+    struct ScoredPkg {
+        const PackageDescriptor* pkg;
+        int score;
+    };
+    std::vector<ScoredPkg> results;
+
+    for (auto& [id, pkg] : reg.packages) {
+        int score = 0;
+
+        // Exact ID match
+        if (to_lower(id) == q) score += 100;
+        // ID contains query
+        else if (to_lower(id).find(q) != std::string::npos) score += 50;
+
+        // Name match
+        if (to_lower(pkg.name).find(q) != std::string::npos) score += 40;
+
+        // Category match
+        if (to_lower(pkg.category) == q) score += 30;
+
+        // Tags match
+        for (auto& tag : pkg.tags)
+            if (to_lower(tag).find(q) != std::string::npos) { score += 20; break; }
+
+        // Provides match
+        for (auto& p : pkg.provides)
+            if (to_lower(p).find(q) != std::string::npos) { score += 20; break; }
+
+        // Description match
+        if (to_lower(pkg.description).find(q) != std::string::npos) score += 10;
+
+        if (score > 0) results.push_back({&pkg, score});
+    }
+
+    std::sort(results.begin(), results.end(),
+              [](auto& a, auto& b) { return a.score > b.score; });
+
+    std::vector<const PackageDescriptor*> out;
+    for (auto& r : results) out.push_back(r.pkg);
+    return out;
+}
+
+}  // namespace pulp::cli::pkg

--- a/tools/cli/package_registry.hpp
+++ b/tools/cli/package_registry.hpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pulp::cli::pkg {
+
+namespace fs = std::filesystem;
+
+// ── Platform Targets ──
+
+struct PlatformTarget {
+    std::string platform;  // "macOS", "Windows", "Linux", "iOS", "WASM"
+    std::string arch;      // "arm64", "x64", "wasm32"
+
+    std::string to_string() const { return platform + "-" + arch; }
+    bool operator==(const PlatformTarget& o) const {
+        return platform == o.platform && arch == o.arch;
+    }
+    static std::optional<PlatformTarget> parse(const std::string& s);
+};
+
+std::vector<PlatformTarget> default_targets();
+bool is_valid_target(const PlatformTarget& t);
+
+// ── License Policy ──
+
+enum class LicenseVerdict { allowed, review_required, rejected };
+
+LicenseVerdict check_license(const std::string& spdx_id);
+const char* license_verdict_label(LicenseVerdict v);
+
+// ── Package Descriptor ──
+
+struct FetchInfo {
+    std::string method;          // "FetchContent", "header-only", "vendored"
+    std::string git_repository;
+    std::string git_tag;
+};
+
+struct CMakeInfo {
+    std::vector<std::string> targets;
+    bool header_only = false;
+    std::string include_dir;
+};
+
+struct PlatformSupport {
+    std::vector<std::string> architectures;
+    std::string notes;
+};
+
+struct VerificationInfo {
+    std::string last_verified;
+    std::string verified_version;
+    std::map<std::string, std::string> build_status;
+};
+
+struct PackageDescriptor {
+    std::string id;
+    std::string name;
+    std::string version;
+    std::string description;
+    std::string license;
+    std::string category;
+    std::string url;
+    FetchInfo fetch;
+    CMakeInfo cmake;
+    std::map<std::string, PlatformSupport> platforms;
+    bool rt_safe = false;
+    std::vector<std::string> tags;
+    std::vector<std::string> provides;
+    std::map<std::string, std::string> overlaps_with_builtin;
+    std::string unique_value;
+    std::vector<std::string> alternatives;
+    VerificationInfo verification;
+};
+
+// ── Registry ──
+
+struct Registry {
+    int version = 0;
+    std::map<std::string, PackageDescriptor> packages;
+};
+
+struct RegistryLoadResult {
+    Registry registry;
+    std::string error;
+};
+
+RegistryLoadResult load_registry(const fs::path& registry_path);
+
+// ── Lock File ──
+
+struct LockedPackage {
+    std::string version;
+    std::string resolved;
+    std::string integrity;
+    std::string commit;
+};
+
+struct LockFile {
+    int version = 1;
+    std::map<std::string, LockedPackage> packages;
+};
+
+LockFile load_lock_file(const fs::path& path);
+bool save_lock_file(const fs::path& path, const LockFile& lock);
+
+// ── Target Config ──
+
+std::vector<PlatformTarget> read_project_targets(const fs::path& project_root);
+bool write_project_targets(const fs::path& project_root,
+                           const std::vector<PlatformTarget>& targets);
+
+// ── Queries ──
+
+std::vector<PlatformTarget> unsupported_targets(
+    const PackageDescriptor& pkg,
+    const std::vector<PlatformTarget>& targets);
+
+std::vector<const PackageDescriptor*> search(const Registry& reg,
+                                              const std::string& query);
+
+}  // namespace pulp::cli::pkg

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -28,6 +28,7 @@
 #include <pulp/tools/audio/service.hpp>
 
 #include "create_targets.hpp"
+#include "package_commands.hpp"
 #include "design_binding.hpp"
 #include <pulp/ship/installer.hpp>
 #include <pulp/view/screenshot.hpp>
@@ -4671,7 +4672,14 @@ int main(int argc, char* argv[]) {
     if (command == "ship")     return cmd_ship(args);
     if (command == "docs")     return cmd_docs(args);
     if (command == "clean")    return cmd_clean(args);
-    if (command == "add") {
+    if (command == "add")      return pulp::cli::pkg::cmd_add(args);
+    if (command == "remove")   return pulp::cli::pkg::cmd_remove(args);
+    if (command == "list")     return pulp::cli::pkg::cmd_list(args);
+    if (command == "search")   return pulp::cli::pkg::cmd_search(args);
+    if (command == "update")   return pulp::cli::pkg::cmd_update(args);
+    if (command == "suggest")  return pulp::cli::pkg::cmd_suggest(args);
+    if (command == "target")   return pulp::cli::pkg::cmd_target(args);
+    if (command == "add-component") {
         auto root = find_project_root();
         if (root.empty()) {
             std::cerr << "Error: not in a Pulp project directory\n";
@@ -4687,6 +4695,26 @@ int main(int argc, char* argv[]) {
         return run(cmd);
     }
     if (command == "audit") {
+        // Check for package-manager-specific flags
+        bool pkg_flag = false, plat_flag = false, lic_flag = false;
+        for (auto& a : args) {
+            if (a == "--packages") pkg_flag = true;
+            if (a == "--platforms") plat_flag = true;
+            if (a == "--licenses") lic_flag = true;
+        }
+        if (pkg_flag || plat_flag || lic_flag) {
+            auto root = find_project_root();
+            if (root.empty()) {
+                std::cerr << "Error: not in a Pulp project directory\n";
+                return 1;
+            }
+            int rc = 0;
+            if (pkg_flag) rc |= pulp::cli::pkg::audit_packages(root);
+            if (plat_flag) rc |= pulp::cli::pkg::audit_platforms(root);
+            if (lic_flag) rc |= pulp::cli::pkg::audit_licenses(root);
+            return rc;
+        }
+        // Fall through to existing Python audit
         auto root = find_project_root();
         if (root.empty()) {
             std::cerr << "Error: not in a Pulp project directory\n";

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -2326,6 +2326,60 @@ static std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, b
         checks.push_back(c);
     }
 
+    // Package health checks
+    if (!active_root.empty()) {
+        auto lock_path = active_root / "packages.lock.json";
+        auto reg_path = active_root / "tools" / "packages" / "registry.json";
+
+        // Check: lock file freshness
+        {
+            DoctorCheck c{"Package lock file", false, {}, {}};
+            if (!fs::exists(lock_path)) {
+                c.passed = true;
+                c.detail = "No packages installed (OK)";
+            } else if (!fs::exists(reg_path)) {
+                c.passed = false;
+                c.detail = "Lock file exists but registry missing";
+            } else {
+                c.passed = true;
+                // Count packages
+                std::ifstream f(lock_path);
+                std::string content((std::istreambuf_iterator<char>(f)),
+                                     std::istreambuf_iterator<char>());
+                int count = 0;
+                std::string::size_type pos = 0;
+                while ((pos = content.find("\"version\"", pos)) != std::string::npos) {
+                    ++count; ++pos;
+                }
+                c.detail = std::to_string(count) + " package(s) installed";
+            }
+            checks.push_back(c);
+        }
+
+        // Check: package/platform alignment
+        if (fs::exists(lock_path) && fs::exists(reg_path)) {
+            DoctorCheck c{"Package platform alignment", false, {}, {}};
+            auto targets = pulp::cli::pkg::read_project_targets(active_root);
+            auto [reg, err] = pulp::cli::pkg::load_registry(reg_path);
+            auto lock = pulp::cli::pkg::load_lock_file(lock_path);
+            int gaps = 0;
+            for (auto& [id, lp] : lock.packages) {
+                auto it = reg.packages.find(id);
+                if (it == reg.packages.end()) continue;
+                auto unsup = pulp::cli::pkg::unsupported_targets(it->second, targets);
+                gaps += static_cast<int>(unsup.size());
+            }
+            if (gaps == 0) {
+                c.passed = true;
+                c.detail = "All packages support all project targets";
+            } else {
+                c.detail = std::to_string(gaps) + " platform gap(s)";
+                c.fix = "pulp audit --platforms";
+            }
+            checks.push_back(c);
+        }
+    }
+
     return checks;
 }
 

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -29,6 +29,7 @@
 
 #include "create_targets.hpp"
 #include "package_commands.hpp"
+#include "package_registry.hpp"
 #include "design_binding.hpp"
 #include <pulp/ship/installer.hpp>
 #include <pulp/view/screenshot.hpp>


### PR DESCRIPTION
## Summary

- **CLI commands**: `pulp add/remove/list/search/update/suggest/target` plus `audit --packages/--platforms/--licenses`
- **Package registry types**: JSON parser, TOML section R/W, license policy, platform targeting, scored search
- **CMake generation**: Auto-generated `cmake/pulp-packages.cmake` with FetchContent declarations and platform guards
- **Metadata management**: Automatic updates to `packages.lock.json`, `DEPENDENCIES.md`, `NOTICE.md`
- **Doctor integration**: Package lock file health and platform alignment checks
- **Claude plugin skill**: `.agents/skills/packages/SKILL.md` for discovery and recommendations
- **Tier 2 CI**: Build validation matrix across macOS/Ubuntu/Windows for all 10 packages
- **CLI docs**: Updated `docs/reference/cli.md` and `docs/status/cli-commands.yaml`

## Deferred items
- Package awareness in `/create` flow (create is Phase 14)
- Package awareness in `/build` error recovery (low priority)

## Test plan
- [x] Naming audit passes
- [x] Registry validation passes (strict mode)
- [ ] CI green on all platforms (macOS, Ubuntu, Windows)