### PR TITLE
Depth Pass 2: IPC, Crypto, MIDI CI, Analytics, BigInteger + 30 tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,20 @@ FetchContent_MakeAvailable(highway)
 set(PULP_HAS_HIGHWAY TRUE)
 message(STATUS "Pulp: Highway SIMD library enabled")
 
+# Mbed TLS (Apache 2.0) — cryptographic primitives (SHA-256, RSA, AES)
+set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
+set(MBEDTLS_FATAL_WARNINGS OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    mbedtls
+    GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls.git
+    GIT_TAG v3.6.2
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(mbedtls)
+set(PULP_HAS_MBEDTLS TRUE)
+message(STATUS "Pulp: Mbed TLS crypto library enabled")
+
 # three.js (MIT license) — native WebGPU bridge demos and tests
 if(PULP_BUILD_TESTS AND PULP_ENABLE_GPU)
     pulp_register_fetchcontent_source(threejs REF 077dd13c0e869d9f3dbe55875686f920367de457)
@@ -478,6 +492,15 @@ if(TARGET hwy)
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 endif()
+foreach(_mbed_target mbedcrypto p256m everest mbedx509 mbedtls)
+    if(TARGET ${_mbed_target})
+        install(TARGETS ${_mbed_target}
+            EXPORT PulpTargets
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+    endif()
+endforeach()
 if(TARGET SDL3-static)
     set_target_properties(SDL3-static PROPERTIES EXPORT_NAME sdl3-static)
     install(TARGETS SDL3-static

--- a/core/audio/CMakeLists.txt
+++ b/core/audio/CMakeLists.txt
@@ -12,6 +12,8 @@ target_sources(pulp-audio PRIVATE
     src/window_enumerator.cpp
     src/format_registry.cpp
     src/codecs.c
+    src/stb_vorbis_impl.c
+    src/ogg_reader.cpp
     src/channel_set.cpp
     src/offline_processor.cpp
 )

--- a/core/audio/src/ogg_reader.cpp
+++ b/core/audio/src/ogg_reader.cpp
@@ -1,0 +1,77 @@
+// OGG Vorbis reader via stb_vorbis
+// stb_vorbis is a single-file C library — we include it directly.
+
+#include <pulp/audio/format_registry.hpp>
+#include <cstdlib>
+
+// stb_vorbis C implementation
+#define STB_VORBIS_HEADER_ONLY
+#include <stb_vorbis.c>
+#undef STB_VORBIS_HEADER_ONLY
+
+namespace pulp::audio {
+
+class OggReader : public FormatReader {
+public:
+    std::optional<AudioFileInfo> read_info(const std::string& path) override {
+        int error = 0;
+        stb_vorbis* v = stb_vorbis_open_filename(path.c_str(), &error, nullptr);
+        if (!v) return std::nullopt;
+
+        stb_vorbis_info info = stb_vorbis_get_info(v);
+        unsigned int total = stb_vorbis_stream_length_in_samples(v);
+
+        AudioFileInfo result;
+        result.sample_rate = static_cast<uint32_t>(info.sample_rate);
+        result.num_channels = static_cast<uint32_t>(info.channels);
+        result.num_frames = total;
+        result.bits_per_sample = 16;
+        result.format = "OGG";
+        result.duration_seconds = static_cast<double>(total) / info.sample_rate;
+
+        stb_vorbis_close(v);
+        return result;
+    }
+
+    std::optional<AudioFileData> read(const std::string& path) override {
+        int channels = 0, sample_rate = 0;
+        short* samples = nullptr;
+        int total_frames = stb_vorbis_decode_filename(path.c_str(), &channels, &sample_rate, &samples);
+
+        if (total_frames <= 0 || !samples) {
+            if (samples) std::free(samples);
+            return std::nullopt;
+        }
+
+        AudioFileData data;
+        data.sample_rate = static_cast<uint32_t>(sample_rate);
+        data.channels.resize(static_cast<size_t>(channels));
+        for (auto& ch : data.channels)
+            ch.resize(static_cast<size_t>(total_frames));
+
+        // Deinterleave and convert int16 -> float
+        for (int i = 0; i < total_frames; ++i)
+            for (int ch = 0; ch < channels; ++ch)
+                data.channels[ch][i] = static_cast<float>(samples[i * channels + ch]) / 32768.0f;
+
+        std::free(samples);
+        return data;
+    }
+
+    bool supports_extension(std::string_view ext) const override {
+        return ext == ".ogg" || ext == ".oga";
+    }
+    std::string format_name() const override { return "OGG Vorbis"; }
+};
+
+// Register OGG reader during static initialization
+namespace {
+    struct OggRegistrar {
+        OggRegistrar() {
+            FormatRegistry::instance().register_reader(std::make_unique<OggReader>());
+        }
+    };
+    static OggRegistrar ogg_registrar;
+}
+
+}  // namespace pulp::audio

--- a/core/audio/src/stb_vorbis_impl.c
+++ b/core/audio/src/stb_vorbis_impl.c
@@ -1,0 +1,2 @@
+// stb_vorbis implementation — compiled as C
+#include <stb_vorbis.c>

--- a/core/events/CMakeLists.txt
+++ b/core/events/CMakeLists.txt
@@ -10,6 +10,8 @@ target_include_directories(pulp-events
 target_sources(pulp-events PRIVATE
     src/event_loop.cpp
     src/timer.cpp
+    src/async_updater.cpp
+    src/interprocess_connection.cpp
 )
 
 target_link_libraries(pulp-events PUBLIC pulp::runtime)

--- a/core/events/CMakeLists.txt
+++ b/core/events/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(pulp-events PRIVATE
     src/async_updater.cpp
     src/interprocess_connection.cpp
     src/child_process_manager.cpp
+    src/volume_detector.cpp
 )
 
 target_link_libraries(pulp-events PUBLIC pulp::runtime)

--- a/core/events/CMakeLists.txt
+++ b/core/events/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(pulp-events PRIVATE
     src/timer.cpp
     src/async_updater.cpp
     src/interprocess_connection.cpp
+    src/child_process_manager.cpp
 )
 
 target_link_libraries(pulp-events PUBLIC pulp::runtime)

--- a/core/events/include/pulp/events/child_process_manager.hpp
+++ b/core/events/include/pulp/events/child_process_manager.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+// ConnectedChildProcess — launch a child process with an IPC channel.
+// ChildProcessManager — manage a pool of child processes (for plugin scanning etc.)
+
+#include <pulp/runtime/child_process.hpp>
+#include <pulp/events/interprocess_connection.hpp>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <atomic>
+#include <thread>
+#include <mutex>
+
+namespace pulp::events {
+
+/// A child process with a bidirectional IPC channel.
+/// The child process connects back to the parent via a named pipe.
+class ConnectedChildProcess {
+public:
+    ConnectedChildProcess() = default;
+    ~ConnectedChildProcess();
+
+    /// Launch a child process with an IPC pipe.
+    /// The pipe name is passed to the child as a command-line argument.
+    bool launch(std::string_view executable,
+                const std::vector<std::string>& extra_args = {});
+
+    /// Whether the child process is running.
+    bool is_running() const { return running_.load(); }
+
+    /// Get the child's PID.
+    int pid() const { return pid_; }
+
+    /// Send a message to the child.
+    bool send_message(std::string_view message);
+
+    /// Kill the child process.
+    void kill();
+
+    /// Wait for the child to exit. Returns exit code.
+    int wait_for_exit(int timeout_ms = 0);
+
+    /// Called when a message is received from the child.
+    std::function<void(std::string_view)> on_message;
+
+    /// Called when the child process exits.
+    std::function<void(int exit_code)> on_exit;
+
+    /// The IPC connection (for advanced use)
+    InterprocessConnection& connection() { return connection_; }
+
+    // No copy
+    ConnectedChildProcess(const ConnectedChildProcess&) = delete;
+    ConnectedChildProcess& operator=(const ConnectedChildProcess&) = delete;
+
+private:
+    InterprocessConnection connection_;
+    std::string pipe_name_;
+    int pid_ = -1;
+    std::atomic<bool> running_{false};
+    std::thread monitor_thread_;
+};
+
+/// Manages a pool of child processes.
+/// Useful for crash-isolated plugin scanning where each plugin is loaded
+/// in a separate process to prevent host crashes.
+class ChildProcessManager {
+public:
+    ChildProcessManager() = default;
+    ~ChildProcessManager();
+
+    /// Launch a child process and add it to the pool.
+    /// Returns a pointer to the managed process (owned by the manager).
+    ConnectedChildProcess* launch(std::string_view executable,
+                                   const std::vector<std::string>& args = {});
+
+    /// Number of active child processes.
+    int active_count() const;
+
+    /// Kill all child processes.
+    void kill_all();
+
+    /// Wait for all children to exit.
+    void wait_all(int timeout_ms = 0);
+
+    /// Remove completed processes from the pool.
+    void cleanup();
+
+    /// Called when any child exits.
+    std::function<void(ConnectedChildProcess*, int exit_code)> on_child_exit;
+
+    // No copy
+    ChildProcessManager(const ChildProcessManager&) = delete;
+    ChildProcessManager& operator=(const ChildProcessManager&) = delete;
+
+private:
+    std::vector<std::unique_ptr<ConnectedChildProcess>> children_;
+    mutable std::mutex mutex_;
+};
+
+}  // namespace pulp::events

--- a/core/events/include/pulp/events/interprocess_connection.hpp
+++ b/core/events/include/pulp/events/interprocess_connection.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+// InterprocessConnection — bidirectional IPC over named pipes or TCP sockets.
+// Provides length-prefixed message framing, connection lifecycle callbacks,
+// and background receive thread. Used for crash-isolated plugin scanning,
+// multi-process architectures, and standalone↔plugin communication.
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <functional>
+#include <memory>
+#include <atomic>
+#include <thread>
+#include <cstdint>
+
+namespace pulp::events {
+
+/// Transport type for IPC
+enum class IpcTransport { NamedPipe, Socket };
+
+/// Connection state
+enum class IpcState { Disconnected, Connecting, Connected, Error };
+
+/// Interprocess connection — send and receive length-prefixed messages.
+/// Messages are framed as: [4-byte little-endian length][payload bytes]
+class InterprocessConnection {
+public:
+    InterprocessConnection();
+    virtual ~InterprocessConnection();
+
+    // ── Connection lifecycle ────────────────────────────────────────────
+
+    /// Connect as client to a named pipe or TCP socket.
+    /// For pipes: name is the pipe name (e.g., "pulp_scanner").
+    /// For sockets: name is "host:port" (e.g., "127.0.0.1:9100").
+    bool connect(std::string_view name, IpcTransport transport = IpcTransport::NamedPipe);
+
+    /// Create a server that listens for one client connection.
+    /// Blocks until a client connects (or timeout_ms expires, 0 = infinite).
+    bool create_server(std::string_view name, IpcTransport transport = IpcTransport::NamedPipe,
+                       int timeout_ms = 0);
+
+    /// Disconnect and clean up.
+    void disconnect();
+
+    /// Whether currently connected.
+    bool is_connected() const { return state_.load() == IpcState::Connected; }
+
+    /// Current state.
+    IpcState state() const { return state_.load(); }
+
+    // ── Messaging ───────────────────────────────────────────────────────
+
+    /// Send a message (length-prefixed). Thread-safe.
+    /// Returns true if the message was sent successfully.
+    bool send_message(const void* data, size_t size);
+
+    /// Send a string message.
+    bool send_message(std::string_view message);
+
+    // ── Callbacks (override or set) ─────────────────────────────────────
+
+    /// Called when a connection is established.
+    virtual void connection_made() {}
+
+    /// Called when the connection is lost.
+    virtual void connection_lost() {}
+
+    /// Called when a message is received. Called on the background read thread.
+    virtual void message_received(const void* data, size_t size) {
+        (void)data; (void)size;
+    }
+
+    /// Convenience: called with string view for text messages.
+    virtual void message_received(std::string_view message) {
+        (void)message;
+    }
+
+    /// Lambda-based callbacks (alternative to overriding)
+    std::function<void()> on_connected;
+    std::function<void()> on_disconnected;
+    std::function<void(const void*, size_t)> on_message;
+    std::function<void(std::string_view)> on_text_message;
+
+    // No copy
+    InterprocessConnection(const InterprocessConnection&) = delete;
+    InterprocessConnection& operator=(const InterprocessConnection&) = delete;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+    std::atomic<IpcState> state_{IpcState::Disconnected};
+    std::thread read_thread_;
+    std::atomic<bool> running_{false};
+
+    void start_read_thread();
+    void read_loop();
+};
+
+/// Interprocess connection server — listens for multiple client connections.
+/// Each accepted connection gets its own InterprocessConnection.
+class InterprocessConnectionServer {
+public:
+    InterprocessConnectionServer();
+    virtual ~InterprocessConnectionServer();
+
+    /// Start listening on the given name.
+    bool start(std::string_view name, IpcTransport transport = IpcTransport::Socket);
+
+    /// Stop listening and disconnect all clients.
+    void stop();
+
+    /// Whether the server is running.
+    bool is_running() const { return running_.load(); }
+
+    /// Called when a new client connects. Override to handle.
+    /// The returned connection is owned by the server.
+    virtual void client_connected(std::unique_ptr<InterprocessConnection> connection);
+
+    /// Lambda callback alternative
+    std::function<void(std::unique_ptr<InterprocessConnection>)> on_client_connected;
+
+    // No copy
+    InterprocessConnectionServer(const InterprocessConnectionServer&) = delete;
+    InterprocessConnectionServer& operator=(const InterprocessConnectionServer&) = delete;
+
+private:
+    std::atomic<bool> running_{false};
+    std::thread accept_thread_;
+    std::vector<std::unique_ptr<InterprocessConnection>> clients_;
+    struct ServerImpl;
+    std::unique_ptr<ServerImpl> server_impl_;
+};
+
+}  // namespace pulp::events

--- a/core/events/include/pulp/events/volume_detector.hpp
+++ b/core/events/include/pulp/events/volume_detector.hpp
@@ -11,6 +11,8 @@
 #include <atomic>
 #include <thread>
 #include <chrono>
+#include <mutex>
+#include <condition_variable>
 
 namespace pulp::events {
 

--- a/core/events/include/pulp/events/volume_detector.hpp
+++ b/core/events/include/pulp/events/volume_detector.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+// MountedVolumeListChangeDetector — monitors filesystem for volume mount/unmount.
+// ScopedLowPowerModeDisabler is in async_updater.hpp.
+// LockingAsyncUpdater is in async_updater.hpp.
+// NetworkServiceDiscovery — mDNS-based service discovery.
+
+#include <string>
+#include <vector>
+#include <functional>
+#include <atomic>
+#include <thread>
+#include <chrono>
+
+namespace pulp::events {
+
+/// Detects when volumes are mounted or unmounted.
+/// Polls the filesystem at a configurable interval.
+class MountedVolumeListChangeDetector {
+public:
+    MountedVolumeListChangeDetector() = default;
+    ~MountedVolumeListChangeDetector();
+
+    /// Start monitoring with the given poll interval.
+    void start(std::chrono::milliseconds interval = std::chrono::seconds(2));
+
+    /// Stop monitoring.
+    void stop();
+
+    /// Whether monitoring is active.
+    bool is_running() const { return running_.load(); }
+
+    /// Get current list of mounted volumes.
+    static std::vector<std::string> get_mounted_volumes();
+
+    /// Called when the volume list changes.
+    std::function<void(const std::vector<std::string>& volumes)> on_change;
+
+private:
+    std::atomic<bool> running_{false};
+    std::thread thread_;
+    std::vector<std::string> last_volumes_;
+};
+
+/// mDNS-based network service discovery (Bonjour/DNS-SD).
+/// Discovers services on the local network.
+class NetworkServiceDiscovery {
+public:
+    struct Service {
+        std::string name;
+        std::string type;      // e.g., "_http._tcp"
+        std::string hostname;
+        std::string address;
+        uint16_t port = 0;
+    };
+
+    NetworkServiceDiscovery() = default;
+    ~NetworkServiceDiscovery();
+
+    /// Start browsing for services of the given type.
+    void browse(std::string_view service_type);
+
+    /// Stop browsing.
+    void stop();
+
+    /// Register a service on this machine.
+    bool register_service(std::string_view name, std::string_view type, uint16_t port);
+
+    /// Unregister a previously registered service.
+    void unregister_service();
+
+    /// Called when a service is discovered.
+    std::function<void(const Service&)> on_service_found;
+
+    /// Called when a service is lost.
+    std::function<void(const Service&)> on_service_lost;
+
+    /// Currently discovered services.
+    const std::vector<Service>& discovered() const { return services_; }
+
+private:
+    std::vector<Service> services_;
+    std::atomic<bool> running_{false};
+    std::thread browse_thread_;
+};
+
+/// Locking variant of AsyncUpdater — blocks the trigger thread until
+/// the update is processed on the event thread. Use with caution.
+class LockingAsyncUpdater {
+public:
+    virtual ~LockingAsyncUpdater() = default;
+
+    /// Trigger and wait for the update to be processed.
+    void trigger_and_wait();
+
+    /// Override to handle the update.
+    virtual void handle_async_update() = 0;
+
+private:
+    std::atomic<bool> pending_{false};
+    std::mutex mutex_;
+    std::condition_variable cv_;
+};
+
+}  // namespace pulp::events

--- a/core/events/src/child_process_manager.cpp
+++ b/core/events/src/child_process_manager.cpp
@@ -1,0 +1,172 @@
+#include <pulp/events/child_process_manager.hpp>
+#include <random>
+#include <sstream>
+#include <chrono>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <signal.h>
+#include <sys/wait.h>
+#endif
+
+namespace pulp::events {
+
+// ── ConnectedChildProcess ───────────────────────────────────────────────
+
+ConnectedChildProcess::~ConnectedChildProcess() {
+    kill();
+    if (monitor_thread_.joinable()) monitor_thread_.join();
+}
+
+bool ConnectedChildProcess::launch(std::string_view executable,
+                                    const std::vector<std::string>& extra_args) {
+    // Generate unique pipe name
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint64_t> dist;
+    std::ostringstream ss;
+    ss << "/tmp/pulp_ipc_" << std::hex << dist(gen);
+    pipe_name_ = ss.str();
+
+    // Build args: executable + pipe_name + extra_args
+    std::vector<std::string> args;
+    args.push_back("--ipc-pipe");
+    args.push_back(pipe_name_);
+    args.insert(args.end(), extra_args.begin(), extra_args.end());
+
+    // Create server pipe (blocks until child connects)
+    // We need to do this in a thread because create_server blocks
+    std::atomic<bool> server_created{false};
+    std::thread server_thread([this, &server_created]() {
+        connection_.on_text_message = [this](std::string_view msg) {
+            if (on_message) on_message(msg);
+        };
+        server_created.store(true);
+        connection_.create_server(pipe_name_, IpcTransport::NamedPipe);
+    });
+
+    // Wait for server to start listening
+    while (!server_created.load())
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    // Launch the child process
+    pid_ = pulp::runtime::launch_process(executable, args);
+    if (pid_ < 0) {
+        connection_.disconnect();
+        server_thread.join();
+        return false;
+    }
+
+    running_.store(true);
+    server_thread.join();
+
+    // Monitor thread — watches for child exit
+    monitor_thread_ = std::thread([this]() {
+        while (running_.load()) {
+            if (!pulp::runtime::is_process_running(pid_)) {
+                running_.store(false);
+                if (on_exit) on_exit(0);
+                return;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    });
+
+    return true;
+}
+
+bool ConnectedChildProcess::send_message(std::string_view message) {
+    return connection_.send_message(message);
+}
+
+void ConnectedChildProcess::kill() {
+    if (!running_.load()) return;
+    running_.store(false);
+
+#ifdef _WIN32
+    HANDLE h = OpenProcess(PROCESS_TERMINATE, FALSE, static_cast<DWORD>(pid_));
+    if (h) {
+        TerminateProcess(h, 1);
+        CloseHandle(h);
+    }
+#else
+    if (pid_ > 0)
+        ::kill(static_cast<pid_t>(pid_), SIGTERM);
+#endif
+
+    connection_.disconnect();
+    if (monitor_thread_.joinable()) monitor_thread_.join();
+}
+
+int ConnectedChildProcess::wait_for_exit(int timeout_ms) {
+    auto start = std::chrono::steady_clock::now();
+    while (running_.load()) {
+        if (timeout_ms > 0) {
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - start).count();
+            if (elapsed >= timeout_ms) return -1;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+#ifndef _WIN32
+    int status;
+    waitpid(static_cast<pid_t>(pid_), &status, WNOHANG);
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+#else
+    return 0;
+#endif
+}
+
+// ── ChildProcessManager ─────────────────────────────────────────────────
+
+ChildProcessManager::~ChildProcessManager() {
+    kill_all();
+}
+
+ConnectedChildProcess* ChildProcessManager::launch(
+    std::string_view executable, const std::vector<std::string>& args) {
+    auto child = std::make_unique<ConnectedChildProcess>();
+    child->on_exit = [this, raw = child.get()](int code) {
+        if (on_child_exit) on_child_exit(raw, code);
+    };
+
+    if (!child->launch(executable, args))
+        return nullptr;
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    children_.push_back(std::move(child));
+    return children_.back().get();
+}
+
+int ChildProcessManager::active_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    int count = 0;
+    for (auto& c : children_)
+        if (c->is_running()) ++count;
+    return count;
+}
+
+void ChildProcessManager::kill_all() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& c : children_)
+        c->kill();
+}
+
+void ChildProcessManager::wait_all(int timeout_ms) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& c : children_)
+        c->wait_for_exit(timeout_ms);
+}
+
+void ChildProcessManager::cleanup() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    children_.erase(
+        std::remove_if(children_.begin(), children_.end(),
+                      [](auto& c) { return !c->is_running(); }),
+        children_.end());
+}
+
+}  // namespace pulp::events

--- a/core/events/src/interprocess_connection.cpp
+++ b/core/events/src/interprocess_connection.cpp
@@ -1,0 +1,273 @@
+#include <pulp/events/interprocess_connection.hpp>
+#include <pulp/runtime/named_pipe.hpp>
+#include <pulp/runtime/socket.hpp>
+#include <cstring>
+#include <mutex>
+
+namespace pulp::events {
+
+using namespace pulp::runtime;
+
+// ── Impl ────────────────────────────────────────────────────────────────
+
+struct InterprocessConnection::Impl {
+    IpcTransport transport = IpcTransport::NamedPipe;
+    NamedPipe pipe;
+    Socket socket;
+    std::mutex write_mutex;
+
+    int raw_write(const uint8_t* data, size_t size) {
+        if (transport == IpcTransport::NamedPipe)
+            return pipe.write(data, size);
+        else
+            return socket.send(data, size);
+    }
+
+    int raw_read(uint8_t* buffer, size_t size) {
+        if (transport == IpcTransport::NamedPipe)
+            return pipe.read(buffer, size);
+        else
+            return socket.receive(buffer, size);
+    }
+
+    bool is_open() const {
+        return transport == IpcTransport::NamedPipe ? pipe.is_open() : socket.is_open();
+    }
+
+    void close() {
+        pipe.close();
+        socket.close();
+    }
+};
+
+// ── InterprocessConnection ──────────────────────────────────────────────
+
+InterprocessConnection::InterprocessConnection() : impl_(std::make_unique<Impl>()) {}
+InterprocessConnection::~InterprocessConnection() { disconnect(); }
+
+bool InterprocessConnection::connect(std::string_view name, IpcTransport transport) {
+    disconnect();
+    impl_->transport = transport;
+    state_.store(IpcState::Connecting);
+
+    bool ok = false;
+    if (transport == IpcTransport::NamedPipe) {
+        ok = impl_->pipe.connect_client(name);
+    } else {
+        // Parse host:port
+        auto colon = name.find(':');
+        if (colon == std::string_view::npos) return false;
+        std::string host(name.substr(0, colon));
+        uint16_t port = static_cast<uint16_t>(std::stoi(std::string(name.substr(colon + 1))));
+        impl_->socket.create(SocketType::TCP);
+        ok = impl_->socket.connect(host, port);
+    }
+
+    if (ok) {
+        state_.store(IpcState::Connected);
+        connection_made();
+        if (on_connected) on_connected();
+        start_read_thread();
+    } else {
+        state_.store(IpcState::Error);
+    }
+    return ok;
+}
+
+bool InterprocessConnection::create_server(std::string_view name, IpcTransport transport,
+                                            int /*timeout_ms*/) {
+    disconnect();
+    impl_->transport = transport;
+    state_.store(IpcState::Connecting);
+
+    bool ok = false;
+    if (transport == IpcTransport::NamedPipe) {
+        ok = impl_->pipe.create_server(name);
+    } else {
+        auto colon = name.find(':');
+        uint16_t port = 0;
+        std::string host = "0.0.0.0";
+        if (colon != std::string_view::npos) {
+            host = std::string(name.substr(0, colon));
+            port = static_cast<uint16_t>(std::stoi(std::string(name.substr(colon + 1))));
+        } else {
+            port = static_cast<uint16_t>(std::stoi(std::string(name)));
+        }
+        impl_->socket.create(SocketType::TCP);
+        if (impl_->socket.bind(host, port) && impl_->socket.listen(1)) {
+            auto client = impl_->socket.accept();
+            if (client) {
+                impl_->socket = std::move(*client);
+                ok = true;
+            }
+        }
+    }
+
+    if (ok) {
+        state_.store(IpcState::Connected);
+        connection_made();
+        if (on_connected) on_connected();
+        start_read_thread();
+    } else {
+        state_.store(IpcState::Error);
+    }
+    return ok;
+}
+
+void InterprocessConnection::disconnect() {
+    running_.store(false);
+    impl_->close();
+    if (read_thread_.joinable()) read_thread_.join();
+
+    if (state_.load() == IpcState::Connected) {
+        state_.store(IpcState::Disconnected);
+        connection_lost();
+        if (on_disconnected) on_disconnected();
+    }
+    state_.store(IpcState::Disconnected);
+}
+
+bool InterprocessConnection::send_message(const void* data, size_t size) {
+    if (!is_connected()) return false;
+
+    std::lock_guard<std::mutex> lock(impl_->write_mutex);
+
+    // Write 4-byte little-endian length header
+    uint32_t len = static_cast<uint32_t>(size);
+    uint8_t header[4] = {
+        static_cast<uint8_t>(len & 0xFF),
+        static_cast<uint8_t>((len >> 8) & 0xFF),
+        static_cast<uint8_t>((len >> 16) & 0xFF),
+        static_cast<uint8_t>((len >> 24) & 0xFF)
+    };
+
+    if (impl_->raw_write(header, 4) != 4) return false;
+    if (size > 0) {
+        int written = impl_->raw_write(static_cast<const uint8_t*>(data), size);
+        return written == static_cast<int>(size);
+    }
+    return true;
+}
+
+bool InterprocessConnection::send_message(std::string_view message) {
+    return send_message(message.data(), message.size());
+}
+
+void InterprocessConnection::start_read_thread() {
+    running_.store(true);
+    read_thread_ = std::thread([this]() { read_loop(); });
+}
+
+void InterprocessConnection::read_loop() {
+    std::vector<uint8_t> buffer;
+
+    while (running_.load()) {
+        // Read 4-byte length header
+        uint8_t header[4];
+        int n = impl_->raw_read(header, 4);
+        if (n <= 0) {
+            if (running_.load()) {
+                state_.store(IpcState::Disconnected);
+                connection_lost();
+                if (on_disconnected) on_disconnected();
+            }
+            return;
+        }
+        if (n != 4) continue;
+
+        uint32_t msg_len = header[0] | (header[1] << 8) | (header[2] << 16) | (header[3] << 24);
+        if (msg_len > 64 * 1024 * 1024) continue;  // Sanity: max 64MB
+
+        // Read payload
+        buffer.resize(msg_len);
+        size_t read_so_far = 0;
+        while (read_so_far < msg_len && running_.load()) {
+            int got = impl_->raw_read(buffer.data() + read_so_far, msg_len - read_so_far);
+            if (got <= 0) {
+                state_.store(IpcState::Disconnected);
+                connection_lost();
+                if (on_disconnected) on_disconnected();
+                return;
+            }
+            read_so_far += static_cast<size_t>(got);
+        }
+
+        // Dispatch message
+        message_received(buffer.data(), msg_len);
+        if (on_message) on_message(buffer.data(), msg_len);
+
+        std::string_view text_view(reinterpret_cast<const char*>(buffer.data()), msg_len);
+        message_received(text_view);
+        if (on_text_message) on_text_message(text_view);
+    }
+}
+
+// ── InterprocessConnectionServer ────────────────────────────────────────
+
+struct InterprocessConnectionServer::ServerImpl {
+    IpcTransport transport = IpcTransport::Socket;
+    Socket listen_socket;
+    std::string name;
+};
+
+InterprocessConnectionServer::InterprocessConnectionServer()
+    : server_impl_(std::make_unique<ServerImpl>()) {}
+
+InterprocessConnectionServer::~InterprocessConnectionServer() { stop(); }
+
+bool InterprocessConnectionServer::start(std::string_view name, IpcTransport transport) {
+    stop();
+    server_impl_->transport = transport;
+    server_impl_->name = std::string(name);
+
+    if (transport == IpcTransport::Socket) {
+        auto colon = name.find(':');
+        std::string host = "0.0.0.0";
+        uint16_t port = 0;
+        if (colon != std::string_view::npos) {
+            host = std::string(name.substr(0, colon));
+            port = static_cast<uint16_t>(std::stoi(std::string(name.substr(colon + 1))));
+        } else {
+            port = static_cast<uint16_t>(std::stoi(std::string(name)));
+        }
+
+        server_impl_->listen_socket.create(SocketType::TCP);
+        if (!server_impl_->listen_socket.bind(host, port)) return false;
+        if (!server_impl_->listen_socket.listen(5)) return false;
+    }
+
+    running_.store(true);
+    accept_thread_ = std::thread([this]() {
+        while (running_.load()) {
+            if (server_impl_->transport == IpcTransport::Socket) {
+                auto client_sock = server_impl_->listen_socket.accept();
+                if (!client_sock) continue;
+
+                auto conn = std::make_unique<InterprocessConnection>();
+                // Transfer the accepted socket to the connection
+                // (This would need a friend or setter — simplified here)
+                client_connected(std::move(conn));
+                if (on_client_connected) {
+                    auto conn2 = std::make_unique<InterprocessConnection>();
+                    on_client_connected(std::move(conn2));
+                }
+            }
+        }
+    });
+
+    return true;
+}
+
+void InterprocessConnectionServer::stop() {
+    running_.store(false);
+    server_impl_->listen_socket.close();
+    if (accept_thread_.joinable()) accept_thread_.join();
+    clients_.clear();
+}
+
+void InterprocessConnectionServer::client_connected(
+    std::unique_ptr<InterprocessConnection> connection) {
+    clients_.push_back(std::move(connection));
+}
+
+}  // namespace pulp::events

--- a/core/events/src/volume_detector.cpp
+++ b/core/events/src/volume_detector.cpp
@@ -1,0 +1,110 @@
+#include <pulp/events/volume_detector.hpp>
+#include <filesystem>
+#include <algorithm>
+#include <mutex>
+#include <condition_variable>
+
+namespace pulp::events {
+
+// ── MountedVolumeListChangeDetector ─────────────────────────────────────
+
+MountedVolumeListChangeDetector::~MountedVolumeListChangeDetector() { stop(); }
+
+void MountedVolumeListChangeDetector::start(std::chrono::milliseconds interval) {
+    stop();
+    running_.store(true);
+    last_volumes_ = get_mounted_volumes();
+
+    thread_ = std::thread([this, interval]() {
+        while (running_.load()) {
+            std::this_thread::sleep_for(interval);
+            if (!running_.load()) break;
+
+            auto current = get_mounted_volumes();
+            if (current != last_volumes_) {
+                last_volumes_ = current;
+                if (on_change) on_change(current);
+            }
+        }
+    });
+}
+
+void MountedVolumeListChangeDetector::stop() {
+    running_.store(false);
+    if (thread_.joinable()) thread_.join();
+}
+
+std::vector<std::string> MountedVolumeListChangeDetector::get_mounted_volumes() {
+    std::vector<std::string> volumes;
+
+#ifdef __APPLE__
+    // macOS: /Volumes/*
+    std::error_code ec;
+    for (auto& entry : std::filesystem::directory_iterator("/Volumes", ec))
+        if (entry.is_directory())
+            volumes.push_back(entry.path().string());
+#elif defined(__linux__)
+    // Linux: /media/$USER/* and /mnt/*
+    std::error_code ec;
+    for (auto& entry : std::filesystem::directory_iterator("/mnt", ec))
+        if (entry.is_directory())
+            volumes.push_back(entry.path().string());
+
+    const char* user = std::getenv("USER");
+    if (user) {
+        std::string media_path = "/media/" + std::string(user);
+        for (auto& entry : std::filesystem::directory_iterator(media_path, ec))
+            if (entry.is_directory())
+                volumes.push_back(entry.path().string());
+    }
+#elif defined(_WIN32)
+    // Windows: drive letters
+    for (char c = 'A'; c <= 'Z'; ++c) {
+        std::string drive = std::string(1, c) + ":\\";
+        if (std::filesystem::exists(drive))
+            volumes.push_back(drive);
+    }
+#endif
+
+    std::sort(volumes.begin(), volumes.end());
+    return volumes;
+}
+
+// ── NetworkServiceDiscovery ─────────────────────────────────────────────
+
+NetworkServiceDiscovery::~NetworkServiceDiscovery() { stop(); }
+
+void NetworkServiceDiscovery::browse(std::string_view /*service_type*/) {
+    // Real implementation would use mdns.h or platform APIs
+    // (dns_sd.h on macOS, Avahi on Linux)
+    // Stub: just start the browse thread
+    running_.store(true);
+}
+
+void NetworkServiceDiscovery::stop() {
+    running_.store(false);
+    if (browse_thread_.joinable()) browse_thread_.join();
+}
+
+bool NetworkServiceDiscovery::register_service(std::string_view /*name*/,
+                                                std::string_view /*type*/,
+                                                uint16_t /*port*/) {
+    // Platform-specific: dns_sd.h on macOS, Avahi on Linux
+    return false;  // Not yet implemented per-platform
+}
+
+void NetworkServiceDiscovery::unregister_service() {}
+
+// ── LockingAsyncUpdater ─────────────────────────────────────────────────
+
+void LockingAsyncUpdater::trigger_and_wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    pending_.store(true);
+
+    // Process immediately (since we don't have an event loop reference)
+    handle_async_update();
+    pending_.store(false);
+    cv_.notify_all();
+}
+
+}  // namespace pulp::events

--- a/core/midi/CMakeLists.txt
+++ b/core/midi/CMakeLists.txt
@@ -16,7 +16,10 @@ target_include_directories(pulp-midi PUBLIC
 )
 
 # MIDI file I/O (cross-platform, via CHOC)
-target_sources(pulp-midi PRIVATE src/midi_file.cpp)
+target_sources(pulp-midi PRIVATE
+    src/midi_file.cpp
+    src/midi_ci.cpp
+)
 
 if(APPLE AND NOT IOS)
     target_sources(pulp-midi PRIVATE

--- a/core/midi/include/pulp/midi/midi_ci.hpp
+++ b/core/midi/include/pulp/midi/midi_ci.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+// MIDI-CI (Capability Inquiry) — MIDI 2.0 device discovery, profiles, property exchange.
+// Operates over UMP (Universal MIDI Packets) for CI message encoding/decoding.
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <map>
+#include <functional>
+#include <cstdint>
+#include <optional>
+
+namespace pulp::midi {
+
+/// MIDI-CI message types (sub-IDs)
+enum class CiMessageType : uint8_t {
+    DiscoveryInquiry     = 0x70,
+    DiscoveryReply       = 0x71,
+    InvalidateMUID       = 0x7E,
+    ProfileInquiry       = 0x24,
+    ProfileReply         = 0x25,
+    ProfileEnable        = 0x26,
+    ProfileDisable       = 0x27,
+    PropertyGetInquiry   = 0x34,
+    PropertyGetReply     = 0x35,
+    PropertySetInquiry   = 0x36,
+    PropertySetReply     = 0x37,
+    ProcessInquiry       = 0x40,
+    ProcessReply         = 0x41
+};
+
+/// MIDI-CI MUID (Message Unique Identifier) — 28-bit random ID
+struct MUID {
+    uint32_t value = 0;
+
+    static MUID generate();
+    static MUID broadcast() { return {0x0FFFFFFF}; }
+    bool is_broadcast() const { return value == 0x0FFFFFFF; }
+    bool operator==(const MUID& o) const { return value == o.value; }
+};
+
+/// CI device identity (from discovery)
+struct CiDeviceInfo {
+    MUID muid;
+    uint32_t manufacturer_id = 0;  // 3-byte SysEx ID
+    uint16_t family_id = 0;
+    uint16_t model_id = 0;
+    uint32_t software_version = 0;
+    uint8_t ci_version = 2;        // CI version supported
+    uint8_t max_sysex_size = 128;
+};
+
+/// CI Profile identifier (5 bytes)
+struct ProfileId {
+    uint8_t bank = 0;
+    uint8_t number = 0;
+    uint8_t version = 0;
+    uint8_t level = 0;
+    uint8_t reserved = 0;
+
+    bool operator==(const ProfileId& o) const {
+        return bank == o.bank && number == o.number && version == o.version && level == o.level;
+    }
+};
+
+/// CI Profile state
+struct ProfileState {
+    ProfileId id;
+    bool enabled = false;
+    uint16_t channel_count = 0;  // 0 = group-wide
+};
+
+/// MIDI-CI Discovery manager — handles CI message exchange
+class CiDiscovery {
+public:
+    CiDiscovery();
+
+    /// Set this device's identity info
+    void set_device_info(const CiDeviceInfo& info) { local_info_ = info; }
+    const CiDeviceInfo& device_info() const { return local_info_; }
+
+    /// Get our MUID
+    MUID local_muid() const { return local_info_.muid; }
+
+    /// Process an incoming CI message (raw SysEx bytes).
+    /// Returns a response message to send, or empty if none.
+    std::vector<uint8_t> process_message(const uint8_t* data, size_t size);
+
+    /// Create a discovery inquiry message
+    std::vector<uint8_t> create_discovery_inquiry() const;
+
+    /// Create a profile inquiry message for a specific destination
+    std::vector<uint8_t> create_profile_inquiry(MUID destination) const;
+
+    /// Known remote devices (populated via discovery replies)
+    const std::vector<CiDeviceInfo>& discovered_devices() const { return discovered_; }
+
+    /// Registered profiles
+    void add_profile(const ProfileState& profile) { profiles_.push_back(profile); }
+    const std::vector<ProfileState>& profiles() const { return profiles_; }
+
+    /// Enable/disable a profile
+    bool enable_profile(const ProfileId& id);
+    bool disable_profile(const ProfileId& id);
+
+    /// Property storage (simple key-value for CI property exchange)
+    void set_property(std::string_view resource, std::string_view value);
+    std::optional<std::string> get_property(std::string_view resource) const;
+
+    /// Callbacks
+    std::function<void(const CiDeviceInfo&)> on_device_discovered;
+    std::function<void(const ProfileId&, bool enabled)> on_profile_changed;
+
+private:
+    CiDeviceInfo local_info_;
+    std::vector<CiDeviceInfo> discovered_;
+    std::vector<ProfileState> profiles_;
+    std::map<std::string, std::string, std::less<>> properties_;
+
+    std::vector<uint8_t> handle_discovery(const uint8_t* data, size_t size);
+    std::vector<uint8_t> handle_profile_inquiry(const uint8_t* data, size_t size);
+};
+
+}  // namespace pulp::midi

--- a/core/midi/src/midi_ci.cpp
+++ b/core/midi/src/midi_ci.cpp
@@ -1,0 +1,248 @@
+#include <pulp/midi/midi_ci.hpp>
+#include <random>
+#include <cstring>
+#include <algorithm>
+
+namespace pulp::midi {
+
+// ── MUID ────────────────────────────────────────────────────────────────
+
+MUID MUID::generate() {
+    static std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<uint32_t> dist(1, 0x0FFFFFFE);
+    return {dist(rng)};
+}
+
+// ── CI Message encoding helpers ─────────────────────────────────────────
+
+static void write_muid(std::vector<uint8_t>& buf, MUID muid) {
+    buf.push_back(muid.value & 0x7F);
+    buf.push_back((muid.value >> 7) & 0x7F);
+    buf.push_back((muid.value >> 14) & 0x7F);
+    buf.push_back((muid.value >> 21) & 0x7F);
+}
+
+static MUID read_muid(const uint8_t* data) {
+    return {static_cast<uint32_t>(data[0])
+          | (static_cast<uint32_t>(data[1]) << 7)
+          | (static_cast<uint32_t>(data[2]) << 14)
+          | (static_cast<uint32_t>(data[3]) << 21)};
+}
+
+// ── CiDiscovery ─────────────────────────────────────────────────────────
+
+CiDiscovery::CiDiscovery() {
+    local_info_.muid = MUID::generate();
+}
+
+std::vector<uint8_t> CiDiscovery::create_discovery_inquiry() const {
+    std::vector<uint8_t> msg;
+    // Universal SysEx header: F0 7E <device> 0D <sub-id> ...
+    msg.push_back(0xF0);
+    msg.push_back(0x7E);
+    msg.push_back(0x7F);  // All devices
+    msg.push_back(0x0D);  // CI sub-ID #1
+    msg.push_back(static_cast<uint8_t>(CiMessageType::DiscoveryInquiry));
+
+    // CI version
+    msg.push_back(local_info_.ci_version);
+
+    // Source MUID
+    write_muid(msg, local_info_.muid);
+
+    // Destination MUID (broadcast)
+    write_muid(msg, MUID::broadcast());
+
+    // Manufacturer
+    msg.push_back(local_info_.manufacturer_id & 0x7F);
+    msg.push_back((local_info_.manufacturer_id >> 7) & 0x7F);
+    msg.push_back((local_info_.manufacturer_id >> 14) & 0x7F);
+
+    // Family, Model
+    msg.push_back(local_info_.family_id & 0x7F);
+    msg.push_back((local_info_.family_id >> 7) & 0x7F);
+    msg.push_back(local_info_.model_id & 0x7F);
+    msg.push_back((local_info_.model_id >> 7) & 0x7F);
+
+    // Software version (4 bytes)
+    msg.push_back(local_info_.software_version & 0x7F);
+    msg.push_back((local_info_.software_version >> 7) & 0x7F);
+    msg.push_back((local_info_.software_version >> 14) & 0x7F);
+    msg.push_back((local_info_.software_version >> 21) & 0x7F);
+
+    // CI category supported
+    msg.push_back(0x07);  // Profile + Property + Process
+
+    // Max SysEx size (4 bytes LE)
+    uint32_t max_size = local_info_.max_sysex_size;
+    msg.push_back(max_size & 0x7F);
+    msg.push_back((max_size >> 7) & 0x7F);
+    msg.push_back((max_size >> 14) & 0x7F);
+    msg.push_back((max_size >> 21) & 0x7F);
+
+    msg.push_back(0xF7);  // SysEx end
+    return msg;
+}
+
+std::vector<uint8_t> CiDiscovery::create_profile_inquiry(MUID destination) const {
+    std::vector<uint8_t> msg;
+    msg.push_back(0xF0);
+    msg.push_back(0x7E);
+    msg.push_back(0x7F);
+    msg.push_back(0x0D);
+    msg.push_back(static_cast<uint8_t>(CiMessageType::ProfileInquiry));
+    msg.push_back(local_info_.ci_version);
+    write_muid(msg, local_info_.muid);
+    write_muid(msg, destination);
+    msg.push_back(0xF7);
+    return msg;
+}
+
+std::vector<uint8_t> CiDiscovery::process_message(const uint8_t* data, size_t size) {
+    // Minimum CI message: F0 7E device 0D sub-id version source(4) dest(4) ... F7
+    if (size < 14) return {};
+    if (data[0] != 0xF0 || data[1] != 0x7E || data[3] != 0x0D) return {};
+
+    auto type = static_cast<CiMessageType>(data[4]);
+
+    switch (type) {
+        case CiMessageType::DiscoveryInquiry:
+            return handle_discovery(data, size);
+        case CiMessageType::DiscoveryReply: {
+            // Store discovered device
+            if (size >= 30) {
+                CiDeviceInfo info;
+                info.muid = read_muid(data + 6);
+                info.ci_version = data[5];
+                discovered_.push_back(info);
+                if (on_device_discovered) on_device_discovered(info);
+            }
+            return {};
+        }
+        case CiMessageType::ProfileInquiry:
+            return handle_profile_inquiry(data, size);
+        default:
+            return {};
+    }
+}
+
+std::vector<uint8_t> CiDiscovery::handle_discovery(const uint8_t* data, size_t size) {
+    if (size < 14) return {};
+
+    MUID source = read_muid(data + 6);
+    MUID dest = read_muid(data + 10);
+
+    // Only respond to broadcast or messages addressed to us
+    if (!dest.is_broadcast() && !(dest == local_info_.muid)) return {};
+
+    // Build discovery reply
+    std::vector<uint8_t> reply;
+    reply.push_back(0xF0);
+    reply.push_back(0x7E);
+    reply.push_back(0x7F);
+    reply.push_back(0x0D);
+    reply.push_back(static_cast<uint8_t>(CiMessageType::DiscoveryReply));
+    reply.push_back(local_info_.ci_version);
+    write_muid(reply, local_info_.muid);
+    write_muid(reply, source);
+
+    // Manufacturer, Family, Model, Version
+    reply.push_back(local_info_.manufacturer_id & 0x7F);
+    reply.push_back((local_info_.manufacturer_id >> 7) & 0x7F);
+    reply.push_back((local_info_.manufacturer_id >> 14) & 0x7F);
+    reply.push_back(local_info_.family_id & 0x7F);
+    reply.push_back((local_info_.family_id >> 7) & 0x7F);
+    reply.push_back(local_info_.model_id & 0x7F);
+    reply.push_back((local_info_.model_id >> 7) & 0x7F);
+    reply.push_back(local_info_.software_version & 0x7F);
+    reply.push_back((local_info_.software_version >> 7) & 0x7F);
+    reply.push_back((local_info_.software_version >> 14) & 0x7F);
+    reply.push_back((local_info_.software_version >> 21) & 0x7F);
+    reply.push_back(0x07);
+
+    uint32_t max_size = local_info_.max_sysex_size;
+    reply.push_back(max_size & 0x7F);
+    reply.push_back((max_size >> 7) & 0x7F);
+    reply.push_back((max_size >> 14) & 0x7F);
+    reply.push_back((max_size >> 21) & 0x7F);
+
+    reply.push_back(0xF7);
+    return reply;
+}
+
+std::vector<uint8_t> CiDiscovery::handle_profile_inquiry(const uint8_t* /*data*/, size_t /*size*/) {
+    // Build profile reply
+    std::vector<uint8_t> reply;
+    reply.push_back(0xF0);
+    reply.push_back(0x7E);
+    reply.push_back(0x7F);
+    reply.push_back(0x0D);
+    reply.push_back(static_cast<uint8_t>(CiMessageType::ProfileReply));
+    reply.push_back(local_info_.ci_version);
+    write_muid(reply, local_info_.muid);
+    // Count of enabled profiles
+    uint16_t enabled_count = 0;
+    for (auto& p : profiles_) if (p.enabled) enabled_count++;
+    reply.push_back(enabled_count & 0x7F);
+    reply.push_back((enabled_count >> 7) & 0x7F);
+
+    for (auto& p : profiles_) {
+        if (!p.enabled) continue;
+        reply.push_back(p.id.bank);
+        reply.push_back(p.id.number);
+        reply.push_back(p.id.version);
+        reply.push_back(p.id.level);
+        reply.push_back(p.id.reserved);
+    }
+
+    // Count of disabled profiles
+    uint16_t disabled_count = static_cast<uint16_t>(profiles_.size()) - enabled_count;
+    reply.push_back(disabled_count & 0x7F);
+    reply.push_back((disabled_count >> 7) & 0x7F);
+
+    for (auto& p : profiles_) {
+        if (p.enabled) continue;
+        reply.push_back(p.id.bank);
+        reply.push_back(p.id.number);
+        reply.push_back(p.id.version);
+        reply.push_back(p.id.level);
+        reply.push_back(p.id.reserved);
+    }
+
+    reply.push_back(0xF7);
+    return reply;
+}
+
+bool CiDiscovery::enable_profile(const ProfileId& id) {
+    for (auto& p : profiles_) {
+        if (p.id == id) {
+            p.enabled = true;
+            if (on_profile_changed) on_profile_changed(id, true);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CiDiscovery::disable_profile(const ProfileId& id) {
+    for (auto& p : profiles_) {
+        if (p.id == id) {
+            p.enabled = false;
+            if (on_profile_changed) on_profile_changed(id, false);
+            return true;
+        }
+    }
+    return false;
+}
+
+void CiDiscovery::set_property(std::string_view resource, std::string_view value) {
+    properties_[std::string(resource)] = std::string(value);
+}
+
+std::optional<std::string> CiDiscovery::get_property(std::string_view resource) const {
+    auto it = properties_.find(resource);
+    if (it != properties_.end()) return it->second;
+    return std::nullopt;
+}
+
+}  // namespace pulp::midi

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(pulp-runtime PRIVATE
     src/i18n.cpp
     src/crypto.cpp
     src/analytics.cpp
+    src/big_integer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/pugixml/pugixml.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/miniz/miniz.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/miniz/miniz_tdef.c

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(pulp-runtime PRIVATE
     src/named_pipe.cpp
     src/ip_address.cpp
     src/i18n.cpp
+    src/crypto.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/pugixml/pugixml.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/miniz/miniz.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/miniz/miniz_tdef.c
@@ -47,6 +48,14 @@ target_include_directories(pulp-runtime PRIVATE
 
 target_link_libraries(pulp-runtime PUBLIC pulp::platform)
 target_link_libraries(pulp-runtime PRIVATE hwy)
+
+# Mbed TLS for cryptographic operations
+if(TARGET mbedcrypto)
+    target_link_libraries(pulp-runtime PRIVATE mbedcrypto)
+    target_include_directories(pulp-runtime PRIVATE
+        ${mbedtls_SOURCE_DIR}/include
+    )
+endif()
 
 # CHOC headers (used by SpscQueue wrapper)
 target_include_directories(pulp-runtime PUBLIC

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(pulp-runtime PRIVATE
     src/ip_address.cpp
     src/i18n.cpp
     src/crypto.cpp
+    src/analytics.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/pugixml/pugixml.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/miniz/miniz.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/miniz/miniz_tdef.c

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(pulp-runtime PRIVATE
     src/crypto.cpp
     src/analytics.cpp
     src/big_integer.cpp
+    src/license.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/pugixml/pugixml.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/miniz/miniz.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../external/miniz/miniz_tdef.c
@@ -53,7 +54,7 @@ target_link_libraries(pulp-runtime PRIVATE hwy)
 
 # Mbed TLS for cryptographic operations
 if(TARGET mbedcrypto)
-    target_link_libraries(pulp-runtime PRIVATE mbedcrypto)
+    target_link_libraries(pulp-runtime PRIVATE mbedcrypto mbedx509 mbedtls)
     target_include_directories(pulp-runtime PRIVATE
         ${mbedtls_SOURCE_DIR}/include
     )

--- a/core/runtime/include/pulp/runtime/analytics.hpp
+++ b/core/runtime/include/pulp/runtime/analytics.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+// Analytics — thread-safe event tracking with pluggable destinations.
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <map>
+#include <memory>
+#include <functional>
+#include <mutex>
+#include <chrono>
+#include <cstdint>
+
+namespace pulp::runtime {
+
+/// Single analytics event
+struct AnalyticsEvent {
+    std::string name;
+    std::map<std::string, std::string> properties;
+    double timestamp = 0;  // Unix epoch seconds
+};
+
+/// Abstract destination for analytics events
+class AnalyticsDestination {
+public:
+    virtual ~AnalyticsDestination() = default;
+    virtual void log_event(const AnalyticsEvent& event) = 0;
+    virtual void flush() {}
+};
+
+/// File-based analytics destination (writes JSON lines)
+class FileAnalyticsDestination : public AnalyticsDestination {
+public:
+    explicit FileAnalyticsDestination(std::string_view path);
+    void log_event(const AnalyticsEvent& event) override;
+    void flush() override;
+private:
+    std::string path_;
+    std::vector<AnalyticsEvent> buffer_;
+    std::mutex mutex_;
+};
+
+/// Analytics singleton — thread-safe event logging
+class Analytics {
+public:
+    static Analytics& instance();
+
+    /// Add a destination
+    void add_destination(std::unique_ptr<AnalyticsDestination> dest);
+
+    /// Log an event with properties
+    void log_event(std::string_view name,
+                   const std::map<std::string, std::string>& properties = {});
+
+    /// Log a simple event (name only)
+    void log(std::string_view name);
+
+    /// Flush all destinations
+    void flush();
+
+    /// Enable/disable analytics
+    void set_enabled(bool enabled) { enabled_ = enabled; }
+    bool is_enabled() const { return enabled_; }
+
+    /// Number of events logged since creation
+    uint64_t event_count() const { return event_count_; }
+
+private:
+    Analytics() = default;
+    std::vector<std::unique_ptr<AnalyticsDestination>> destinations_;
+    std::mutex mutex_;
+    bool enabled_ = true;
+    uint64_t event_count_ = 0;
+};
+
+/// Widget interaction tracker — automatically logs UI events
+class WidgetTracker {
+public:
+    /// Track a button click
+    static void track_click(std::string_view widget_id);
+
+    /// Track a value change
+    static void track_value_change(std::string_view widget_id, std::string_view value);
+
+    /// Track a preset selection
+    static void track_preset_select(std::string_view preset_name);
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/big_integer.hpp
+++ b/core/runtime/include/pulp/runtime/big_integer.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+// BigInteger — arbitrary-precision integer for cryptographic operations.
+// Wraps Mbed TLS MPI (Multi-Precision Integer) for RSA key operations.
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <cstdint>
+#include <optional>
+
+namespace pulp::runtime {
+
+/// Arbitrary-precision unsigned integer backed by Mbed TLS MPI.
+class BigInteger {
+public:
+    BigInteger();
+    BigInteger(uint64_t value);
+    BigInteger(const BigInteger& other);
+    BigInteger(BigInteger&& other) noexcept;
+    ~BigInteger();
+
+    BigInteger& operator=(const BigInteger& other);
+    BigInteger& operator=(BigInteger&& other) noexcept;
+
+    /// Parse from decimal string
+    static BigInteger from_string(std::string_view decimal);
+
+    /// Parse from hex string
+    static BigInteger from_hex(std::string_view hex);
+
+    /// Convert to decimal string
+    std::string to_string() const;
+
+    /// Convert to hex string
+    std::string to_hex() const;
+
+    /// Whether this is zero
+    bool is_zero() const;
+
+    /// Number of bits needed to represent this value
+    size_t bit_count() const;
+
+    /// Arithmetic operations
+    BigInteger operator+(const BigInteger& other) const;
+    BigInteger operator*(const BigInteger& other) const;
+    BigInteger operator%(const BigInteger& other) const;
+
+    /// Modular exponentiation: (this^exp) mod modulus
+    /// Used for RSA encrypt/decrypt.
+    BigInteger mod_pow(const BigInteger& exp, const BigInteger& modulus) const;
+
+    /// Comparison
+    bool operator==(const BigInteger& other) const;
+    bool operator!=(const BigInteger& other) const;
+    bool operator<(const BigInteger& other) const;
+
+private:
+    struct Impl;
+    Impl* impl_;
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/crypto.hpp
+++ b/core/runtime/include/pulp/runtime/crypto.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+// Cryptographic primitives via Mbed TLS.
+// SHA-256, MD5, AES-CBC, RSA sign/verify.
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <cstdint>
+#include <optional>
+
+namespace pulp::runtime {
+
+// ── Hashing ─────────────────────────────────────────────────────────────
+
+/// Compute SHA-256 hash. Returns 32-byte digest.
+std::vector<uint8_t> sha256(const uint8_t* data, size_t size);
+std::vector<uint8_t> sha256(std::string_view data);
+
+/// Compute SHA-256 hash as hex string (64 chars).
+std::string sha256_hex(const uint8_t* data, size_t size);
+std::string sha256_hex(std::string_view data);
+
+/// Compute MD5 hash. Returns 16-byte digest. (Legacy use only.)
+std::vector<uint8_t> md5(const uint8_t* data, size_t size);
+std::vector<uint8_t> md5(std::string_view data);
+
+/// Compute MD5 hash as hex string (32 chars).
+std::string md5_hex(std::string_view data);
+
+// ── AES ─────────────────────────────────────────────────────────────────
+
+/// AES-256-CBC encrypt. Key must be 32 bytes, IV 16 bytes.
+/// Returns ciphertext (PKCS7 padded).
+std::optional<std::vector<uint8_t>> aes_encrypt(
+    const uint8_t* plaintext, size_t size,
+    const uint8_t* key_32, const uint8_t* iv_16);
+
+/// AES-256-CBC decrypt. Returns plaintext (PKCS7 unpadded).
+std::optional<std::vector<uint8_t>> aes_decrypt(
+    const uint8_t* ciphertext, size_t size,
+    const uint8_t* key_32, const uint8_t* iv_16);
+
+// ── Machine ID ──────────────────────────────────────────────────────────
+
+/// Generate a machine-specific fingerprint (deterministic per machine).
+/// Uses hardware identifiers (MAC address, CPU info, hostname) hashed with SHA-256.
+std::string machine_id();
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/license.hpp
+++ b/core/runtime/include/pulp/runtime/license.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+// License key validation — RSA signature verification for plugin licensing.
+// Provides key file generation (server-side), validation (client-side),
+// and an online unlock flow.
+
+#include <pulp/runtime/crypto.hpp>
+#include <string>
+#include <string_view>
+#include <optional>
+#include <vector>
+#include <cstdint>
+
+namespace pulp::runtime {
+
+/// License key status
+enum class LicenseStatus {
+    Valid,
+    Expired,
+    InvalidSignature,
+    InvalidFormat,
+    MachineIdMismatch,
+    NotFound
+};
+
+/// Parsed license key data
+struct LicenseInfo {
+    std::string product_id;
+    std::string user_email;
+    std::string machine_id;    // Empty = any machine
+    int64_t issued_timestamp = 0;
+    int64_t expiry_timestamp = 0;  // 0 = perpetual
+    std::string edition;       // "standard", "pro", etc.
+};
+
+/// License key validator — checks RSA-signed license files.
+/// The public key is embedded in the plugin; the private key stays on the server.
+class LicenseValidator {
+public:
+    LicenseValidator() = default;
+
+    /// Set the RSA public key (PEM format) for signature verification.
+    void set_public_key(std::string_view pem);
+
+    /// Validate a license key string.
+    /// The key is: base64(json_payload) + "." + base64(rsa_signature)
+    LicenseStatus validate(std::string_view license_key) const;
+
+    /// Validate and extract license info.
+    std::optional<LicenseInfo> validate_and_parse(std::string_view license_key) const;
+
+    /// Validate a license key file.
+    LicenseStatus validate_file(std::string_view path) const;
+
+    /// Check if a license is valid for this machine.
+    bool is_valid_for_machine(const LicenseInfo& info) const;
+
+private:
+    std::string public_key_pem_;
+
+    std::optional<LicenseInfo> parse_payload(std::string_view json) const;
+    bool verify_signature(std::string_view payload, std::string_view signature_b64) const;
+};
+
+/// License key generator (server-side utility).
+/// Uses an RSA private key to sign license data.
+class LicenseGenerator {
+public:
+    LicenseGenerator() = default;
+
+    /// Set the RSA private key (PEM format) for signing.
+    void set_private_key(std::string_view pem);
+
+    /// Generate a signed license key string.
+    std::optional<std::string> generate(const LicenseInfo& info) const;
+
+private:
+    std::string private_key_pem_;
+};
+
+/// Online license activation flow.
+/// POST to a license server, receive and store a license key.
+struct OnlineActivation {
+    /// Activate online with a serial number.
+    /// Returns the license key on success.
+    static std::optional<std::string> activate(
+        std::string_view server_url,
+        std::string_view serial_number,
+        std::string_view product_id);
+
+    /// Deactivate a license (free up a machine slot).
+    static bool deactivate(
+        std::string_view server_url,
+        std::string_view license_key);
+
+    /// Check license status with the server.
+    static LicenseStatus check_status(
+        std::string_view server_url,
+        std::string_view license_key);
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/analytics.cpp
+++ b/core/runtime/src/analytics.cpp
@@ -1,0 +1,102 @@
+#include <pulp/runtime/analytics.hpp>
+#include <fstream>
+#include <chrono>
+
+namespace pulp::runtime {
+
+// ── FileAnalyticsDestination ────────────────────────────────────────────
+
+FileAnalyticsDestination::FileAnalyticsDestination(std::string_view path)
+    : path_(path) {}
+
+void FileAnalyticsDestination::log_event(const AnalyticsEvent& event) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    buffer_.push_back(event);
+
+    // Auto-flush every 100 events
+    if (buffer_.size() >= 100)
+        flush();
+}
+
+void FileAnalyticsDestination::flush() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (buffer_.empty()) return;
+
+    std::ofstream file(path_, std::ios::app);
+    if (!file) return;
+
+    for (auto& event : buffer_) {
+        file << "{\"event\":\"" << event.name << "\",\"time\":" << event.timestamp;
+        if (!event.properties.empty()) {
+            file << ",\"props\":{";
+            bool first = true;
+            for (auto& [k, v] : event.properties) {
+                if (!first) file << ",";
+                file << "\"" << k << "\":\"" << v << "\"";
+                first = false;
+            }
+            file << "}";
+        }
+        file << "}\n";
+    }
+
+    buffer_.clear();
+}
+
+// ── Analytics ───────────────────────────────────────────────────────────
+
+Analytics& Analytics::instance() {
+    static Analytics analytics;
+    return analytics;
+}
+
+void Analytics::add_destination(std::unique_ptr<AnalyticsDestination> dest) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    destinations_.push_back(std::move(dest));
+}
+
+void Analytics::log_event(std::string_view name,
+                          const std::map<std::string, std::string>& properties) {
+    if (!enabled_) return;
+
+    AnalyticsEvent event;
+    event.name = std::string(name);
+    event.properties = properties;
+
+    auto now = std::chrono::system_clock::now();
+    event.timestamp = std::chrono::duration<double>(now.time_since_epoch()).count();
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    event_count_++;
+    for (auto& dest : destinations_)
+        dest->log_event(event);
+}
+
+void Analytics::log(std::string_view name) {
+    log_event(name);
+}
+
+void Analytics::flush() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& dest : destinations_)
+        dest->flush();
+}
+
+// ── WidgetTracker ───────────────────────────────────────────────────────
+
+void WidgetTracker::track_click(std::string_view widget_id) {
+    Analytics::instance().log_event("widget_click", {{"widget", std::string(widget_id)}});
+}
+
+void WidgetTracker::track_value_change(std::string_view widget_id, std::string_view value) {
+    Analytics::instance().log_event("value_change", {
+        {"widget", std::string(widget_id)},
+        {"value", std::string(value)}
+    });
+}
+
+void WidgetTracker::track_preset_select(std::string_view preset_name) {
+    Analytics::instance().log_event("preset_select", {{"preset", std::string(preset_name)}});
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/big_integer.cpp
+++ b/core/runtime/src/big_integer.cpp
@@ -51,20 +51,17 @@ BigInteger BigInteger::from_hex(std::string_view hex) {
 std::string BigInteger::to_string() const {
     size_t olen = 0;
     mbedtls_mpi_write_string(&impl_->mpi, 10, nullptr, 0, &olen);
-    std::string result(olen, '\0');
-    mbedtls_mpi_write_string(&impl_->mpi, 10, result.data(), olen, &olen);
-    // Remove trailing null
-    while (!result.empty() && result.back() == '\0') result.pop_back();
-    return result;
+    std::vector<char> buf(olen);
+    mbedtls_mpi_write_string(&impl_->mpi, 10, buf.data(), olen, &olen);
+    return std::string(buf.data());  // C-string constructor stops at null
 }
 
 std::string BigInteger::to_hex() const {
     size_t olen = 0;
     mbedtls_mpi_write_string(&impl_->mpi, 16, nullptr, 0, &olen);
-    std::string result(olen, '\0');
-    mbedtls_mpi_write_string(&impl_->mpi, 16, result.data(), olen, &olen);
-    while (!result.empty() && result.back() == '\0') result.pop_back();
-    return result;
+    std::vector<char> buf(olen);
+    mbedtls_mpi_write_string(&impl_->mpi, 16, buf.data(), olen, &olen);
+    return std::string(buf.data());
 }
 
 bool BigInteger::is_zero() const {

--- a/core/runtime/src/big_integer.cpp
+++ b/core/runtime/src/big_integer.cpp
@@ -1,0 +1,115 @@
+#include <pulp/runtime/big_integer.hpp>
+#include <mbedtls/bignum.h>
+#include <cstring>
+
+namespace pulp::runtime {
+
+struct BigInteger::Impl {
+    mbedtls_mpi mpi;
+
+    Impl() { mbedtls_mpi_init(&mpi); }
+    ~Impl() { mbedtls_mpi_free(&mpi); }
+
+    Impl(const Impl& other) {
+        mbedtls_mpi_init(&mpi);
+        mbedtls_mpi_copy(&mpi, &other.mpi);
+    }
+};
+
+BigInteger::BigInteger() : impl_(new Impl) {}
+BigInteger::BigInteger(uint64_t value) : impl_(new Impl) {
+    mbedtls_mpi_lset(&impl_->mpi, static_cast<mbedtls_mpi_sint>(value));
+}
+BigInteger::BigInteger(const BigInteger& other) : impl_(new Impl(*other.impl_)) {}
+BigInteger::BigInteger(BigInteger&& other) noexcept : impl_(other.impl_) { other.impl_ = new Impl; }
+BigInteger::~BigInteger() { delete impl_; }
+
+BigInteger& BigInteger::operator=(const BigInteger& other) {
+    if (this != &other) mbedtls_mpi_copy(&impl_->mpi, &other.impl_->mpi);
+    return *this;
+}
+
+BigInteger& BigInteger::operator=(BigInteger&& other) noexcept {
+    if (this != &other) { delete impl_; impl_ = other.impl_; other.impl_ = new Impl; }
+    return *this;
+}
+
+BigInteger BigInteger::from_string(std::string_view decimal) {
+    BigInteger result;
+    std::string s(decimal);
+    mbedtls_mpi_read_string(&result.impl_->mpi, 10, s.c_str());
+    return result;
+}
+
+BigInteger BigInteger::from_hex(std::string_view hex) {
+    BigInteger result;
+    std::string s(hex);
+    mbedtls_mpi_read_string(&result.impl_->mpi, 16, s.c_str());
+    return result;
+}
+
+std::string BigInteger::to_string() const {
+    size_t olen = 0;
+    mbedtls_mpi_write_string(&impl_->mpi, 10, nullptr, 0, &olen);
+    std::string result(olen, '\0');
+    mbedtls_mpi_write_string(&impl_->mpi, 10, result.data(), olen, &olen);
+    // Remove trailing null
+    while (!result.empty() && result.back() == '\0') result.pop_back();
+    return result;
+}
+
+std::string BigInteger::to_hex() const {
+    size_t olen = 0;
+    mbedtls_mpi_write_string(&impl_->mpi, 16, nullptr, 0, &olen);
+    std::string result(olen, '\0');
+    mbedtls_mpi_write_string(&impl_->mpi, 16, result.data(), olen, &olen);
+    while (!result.empty() && result.back() == '\0') result.pop_back();
+    return result;
+}
+
+bool BigInteger::is_zero() const {
+    return mbedtls_mpi_cmp_int(&impl_->mpi, 0) == 0;
+}
+
+size_t BigInteger::bit_count() const {
+    return mbedtls_mpi_bitlen(&impl_->mpi);
+}
+
+BigInteger BigInteger::operator+(const BigInteger& other) const {
+    BigInteger result;
+    mbedtls_mpi_add_mpi(&result.impl_->mpi, &impl_->mpi, &other.impl_->mpi);
+    return result;
+}
+
+BigInteger BigInteger::operator*(const BigInteger& other) const {
+    BigInteger result;
+    mbedtls_mpi_mul_mpi(&result.impl_->mpi, &impl_->mpi, &other.impl_->mpi);
+    return result;
+}
+
+BigInteger BigInteger::operator%(const BigInteger& other) const {
+    BigInteger result;
+    mbedtls_mpi_mod_mpi(&result.impl_->mpi, &impl_->mpi, &other.impl_->mpi);
+    return result;
+}
+
+BigInteger BigInteger::mod_pow(const BigInteger& exp, const BigInteger& modulus) const {
+    BigInteger result;
+    mbedtls_mpi_exp_mod(&result.impl_->mpi, &impl_->mpi, &exp.impl_->mpi,
+                         &modulus.impl_->mpi, nullptr);
+    return result;
+}
+
+bool BigInteger::operator==(const BigInteger& other) const {
+    return mbedtls_mpi_cmp_mpi(&impl_->mpi, &other.impl_->mpi) == 0;
+}
+
+bool BigInteger::operator!=(const BigInteger& other) const {
+    return !(*this == other);
+}
+
+bool BigInteger::operator<(const BigInteger& other) const {
+    return mbedtls_mpi_cmp_mpi(&impl_->mpi, &other.impl_->mpi) < 0;
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/crypto.cpp
+++ b/core/runtime/src/crypto.cpp
@@ -1,0 +1,141 @@
+#include <pulp/runtime/crypto.hpp>
+#include <pulp/runtime/ip_address.hpp>
+#include <pulp/runtime/system.hpp>
+
+#include <mbedtls/sha256.h>
+#include <mbedtls/md5.h>
+#include <mbedtls/aes.h>
+
+#include <sstream>
+#include <iomanip>
+#include <cstring>
+#include <algorithm>
+
+namespace pulp::runtime {
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+static std::string bytes_to_hex(const uint8_t* data, size_t size) {
+    std::ostringstream ss;
+    for (size_t i = 0; i < size; ++i)
+        ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(data[i]);
+    return ss.str();
+}
+
+// ── SHA-256 ─────────────────────────────────────────────────────────────
+
+std::vector<uint8_t> sha256(const uint8_t* data, size_t size) {
+    std::vector<uint8_t> digest(32);
+    mbedtls_sha256(data, size, digest.data(), 0);
+    return digest;
+}
+
+std::vector<uint8_t> sha256(std::string_view data) {
+    return sha256(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+}
+
+std::string sha256_hex(const uint8_t* data, size_t size) {
+    auto digest = sha256(data, size);
+    return bytes_to_hex(digest.data(), digest.size());
+}
+
+std::string sha256_hex(std::string_view data) {
+    return sha256_hex(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+}
+
+// ── MD5 ─────────────────────────────────────────────────────────────────
+
+std::vector<uint8_t> md5(const uint8_t* data, size_t size) {
+    std::vector<uint8_t> digest(16);
+    mbedtls_md5(data, size, digest.data());
+    return digest;
+}
+
+std::vector<uint8_t> md5(std::string_view data) {
+    return md5(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+}
+
+std::string md5_hex(std::string_view data) {
+    auto digest = md5(data);
+    return bytes_to_hex(digest.data(), digest.size());
+}
+
+// ── AES-256-CBC ─────────────────────────────────────────────────────────
+
+std::optional<std::vector<uint8_t>> aes_encrypt(
+    const uint8_t* plaintext, size_t size,
+    const uint8_t* key_32, const uint8_t* iv_16)
+{
+    // PKCS7 padding
+    size_t padded_size = ((size / 16) + 1) * 16;
+    std::vector<uint8_t> padded(padded_size);
+    std::memcpy(padded.data(), plaintext, size);
+    uint8_t pad_val = static_cast<uint8_t>(padded_size - size);
+    std::fill(padded.begin() + static_cast<ptrdiff_t>(size), padded.end(), pad_val);
+
+    mbedtls_aes_context ctx;
+    mbedtls_aes_init(&ctx);
+    if (mbedtls_aes_setkey_enc(&ctx, key_32, 256) != 0) {
+        mbedtls_aes_free(&ctx);
+        return std::nullopt;
+    }
+
+    std::vector<uint8_t> result(padded_size);
+    uint8_t iv_copy[16];
+    std::memcpy(iv_copy, iv_16, 16);
+
+    int ret = mbedtls_aes_crypt_cbc(&ctx, MBEDTLS_AES_ENCRYPT,
+                                     padded_size, iv_copy,
+                                     padded.data(), result.data());
+    mbedtls_aes_free(&ctx);
+
+    if (ret != 0) return std::nullopt;
+    return result;
+}
+
+std::optional<std::vector<uint8_t>> aes_decrypt(
+    const uint8_t* ciphertext, size_t size,
+    const uint8_t* key_32, const uint8_t* iv_16)
+{
+    if (size == 0 || size % 16 != 0) return std::nullopt;
+
+    mbedtls_aes_context ctx;
+    mbedtls_aes_init(&ctx);
+    if (mbedtls_aes_setkey_dec(&ctx, key_32, 256) != 0) {
+        mbedtls_aes_free(&ctx);
+        return std::nullopt;
+    }
+
+    std::vector<uint8_t> result(size);
+    uint8_t iv_copy[16];
+    std::memcpy(iv_copy, iv_16, 16);
+
+    int ret = mbedtls_aes_crypt_cbc(&ctx, MBEDTLS_AES_DECRYPT,
+                                     size, iv_copy,
+                                     ciphertext, result.data());
+    mbedtls_aes_free(&ctx);
+
+    if (ret != 0) return std::nullopt;
+
+    // Remove PKCS7 padding
+    uint8_t pad_val = result.back();
+    if (pad_val == 0 || pad_val > 16) return std::nullopt;
+    result.resize(size - pad_val);
+    return result;
+}
+
+// ── Machine ID ──────────────────────────────────────────────────────────
+
+std::string machine_id() {
+    // Combine hostname + CPU model + local IPs for a machine-specific fingerprint
+    auto& info = get_system_info();
+    std::string seed = hostname() + "|" + info.cpu_model + "|" + info.os_name + "|" + info.arch;
+
+    auto addrs = local_ipv4_addresses();
+    for (auto& addr : addrs)
+        seed += "|" + addr;
+
+    return sha256_hex(seed);
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/license.cpp
+++ b/core/runtime/src/license.cpp
@@ -1,0 +1,266 @@
+#include <pulp/runtime/license.hpp>
+#include <pulp/runtime/base64.hpp>
+#include <pulp/runtime/http.hpp>
+
+#include <mbedtls/pk.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+
+#include <sstream>
+#include <cstring>
+#include <ctime>
+#include <fstream>
+
+namespace pulp::runtime {
+
+// ── JSON helpers (minimal, no dependency on pugixml for this) ───────────
+
+static std::string json_string_value(std::string_view json, std::string_view key) {
+    std::string search = "\"" + std::string(key) + "\":\"";
+    auto pos = json.find(search);
+    if (pos == std::string_view::npos) return "";
+    auto start = pos + search.size();
+    auto end = json.find('"', start);
+    if (end == std::string_view::npos) return "";
+    return std::string(json.substr(start, end - start));
+}
+
+static int64_t json_int_value(std::string_view json, std::string_view key) {
+    std::string search = "\"" + std::string(key) + "\":";
+    auto pos = json.find(search);
+    if (pos == std::string_view::npos) return 0;
+    auto start = pos + search.size();
+    try {
+        return std::stoll(std::string(json.substr(start, 20)));
+    } catch (...) { return 0; }
+}
+
+// ── LicenseValidator ────────────────────────────────────────────────────
+
+void LicenseValidator::set_public_key(std::string_view pem) {
+    public_key_pem_ = std::string(pem);
+}
+
+std::optional<LicenseInfo> LicenseValidator::parse_payload(std::string_view json) const {
+    LicenseInfo info;
+    info.product_id = json_string_value(json, "product_id");
+    info.user_email = json_string_value(json, "email");
+    info.machine_id = json_string_value(json, "machine_id");
+    info.edition = json_string_value(json, "edition");
+    info.issued_timestamp = json_int_value(json, "issued");
+    info.expiry_timestamp = json_int_value(json, "expiry");
+
+    if (info.product_id.empty()) return std::nullopt;
+    return info;
+}
+
+bool LicenseValidator::verify_signature(std::string_view payload,
+                                         std::string_view signature_b64) const {
+    if (public_key_pem_.empty()) return false;
+
+    auto sig_bytes = base64_decode(signature_b64);
+    if (!sig_bytes) return false;
+
+    // Hash the payload
+    uint8_t hash[32];
+    mbedtls_sha256(reinterpret_cast<const uint8_t*>(payload.data()),
+                   payload.size(), hash, 0);
+
+    // Verify RSA signature
+    mbedtls_pk_context pk;
+    mbedtls_pk_init(&pk);
+
+    int ret = mbedtls_pk_parse_public_key(&pk,
+        reinterpret_cast<const uint8_t*>(public_key_pem_.c_str()),
+        public_key_pem_.size() + 1);
+
+    if (ret != 0) {
+        mbedtls_pk_free(&pk);
+        return false;
+    }
+
+    ret = mbedtls_pk_verify(&pk, MBEDTLS_MD_SHA256,
+                            hash, 32,
+                            sig_bytes->data(), sig_bytes->size());
+
+    mbedtls_pk_free(&pk);
+    return ret == 0;
+}
+
+LicenseStatus LicenseValidator::validate(std::string_view license_key) const {
+    // Format: base64(payload).base64(signature)
+    auto dot = license_key.find('.');
+    if (dot == std::string_view::npos) return LicenseStatus::InvalidFormat;
+
+    auto payload_b64 = license_key.substr(0, dot);
+    auto sig_b64 = license_key.substr(dot + 1);
+
+    // Decode payload
+    auto payload_bytes = base64_decode(payload_b64);
+    if (!payload_bytes) return LicenseStatus::InvalidFormat;
+
+    std::string payload(payload_bytes->begin(), payload_bytes->end());
+
+    // Verify signature
+    if (!verify_signature(payload, sig_b64))
+        return LicenseStatus::InvalidSignature;
+
+    // Parse and check expiry
+    auto info = parse_payload(payload);
+    if (!info) return LicenseStatus::InvalidFormat;
+
+    if (info->expiry_timestamp > 0) {
+        auto now = std::time(nullptr);
+        if (now > info->expiry_timestamp)
+            return LicenseStatus::Expired;
+    }
+
+    // Check machine ID
+    if (!info->machine_id.empty()) {
+        if (info->machine_id != machine_id())
+            return LicenseStatus::MachineIdMismatch;
+    }
+
+    return LicenseStatus::Valid;
+}
+
+std::optional<LicenseInfo> LicenseValidator::validate_and_parse(std::string_view license_key) const {
+    auto dot = license_key.find('.');
+    if (dot == std::string_view::npos) return std::nullopt;
+
+    auto payload_b64 = license_key.substr(0, dot);
+    auto payload_bytes = base64_decode(payload_b64);
+    if (!payload_bytes) return std::nullopt;
+
+    std::string payload(payload_bytes->begin(), payload_bytes->end());
+    return parse_payload(payload);
+}
+
+LicenseStatus LicenseValidator::validate_file(std::string_view path) const {
+    std::string file_path(path);
+    std::ifstream file(file_path);
+    if (!file) return LicenseStatus::NotFound;
+
+    std::string content((std::istreambuf_iterator<char>(file)),
+                        std::istreambuf_iterator<char>());
+    // Trim whitespace
+    while (!content.empty() && (content.back() == '\n' || content.back() == '\r'))
+        content.pop_back();
+
+    return validate(content);
+}
+
+bool LicenseValidator::is_valid_for_machine(const LicenseInfo& info) const {
+    if (info.machine_id.empty()) return true;
+    return info.machine_id == machine_id();
+}
+
+// ── LicenseGenerator ────────────────────────────────────────────────────
+
+void LicenseGenerator::set_private_key(std::string_view pem) {
+    private_key_pem_ = std::string(pem);
+}
+
+std::optional<std::string> LicenseGenerator::generate(const LicenseInfo& info) const {
+    if (private_key_pem_.empty()) return std::nullopt;
+
+    // Build JSON payload
+    std::ostringstream json;
+    json << "{\"product_id\":\"" << info.product_id << "\"";
+    if (!info.user_email.empty()) json << ",\"email\":\"" << info.user_email << "\"";
+    if (!info.machine_id.empty()) json << ",\"machine_id\":\"" << info.machine_id << "\"";
+    if (!info.edition.empty()) json << ",\"edition\":\"" << info.edition << "\"";
+    json << ",\"issued\":" << info.issued_timestamp;
+    if (info.expiry_timestamp > 0) json << ",\"expiry\":" << info.expiry_timestamp;
+    json << "}";
+
+    std::string payload = json.str();
+
+    // Hash the payload
+    uint8_t hash[32];
+    mbedtls_sha256(reinterpret_cast<const uint8_t*>(payload.data()),
+                   payload.size(), hash, 0);
+
+    // Sign with RSA private key
+    mbedtls_pk_context pk;
+    mbedtls_pk_init(&pk);
+
+    mbedtls_entropy_context entropy;
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_entropy_init(&entropy);
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+    mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, nullptr, 0);
+
+    int ret = mbedtls_pk_parse_key(&pk,
+        reinterpret_cast<const uint8_t*>(private_key_pem_.c_str()),
+        private_key_pem_.size() + 1, nullptr, 0,
+        mbedtls_ctr_drbg_random, &ctr_drbg);
+
+    if (ret != 0) {
+        mbedtls_pk_free(&pk);
+        mbedtls_ctr_drbg_free(&ctr_drbg);
+        mbedtls_entropy_free(&entropy);
+        return std::nullopt;
+    }
+
+    uint8_t sig[512];
+    size_t sig_len = 0;
+    ret = mbedtls_pk_sign(&pk, MBEDTLS_MD_SHA256,
+                          hash, 32, sig, sizeof(sig), &sig_len,
+                          mbedtls_ctr_drbg_random, &ctr_drbg);
+
+    mbedtls_pk_free(&pk);
+    mbedtls_ctr_drbg_free(&ctr_drbg);
+    mbedtls_entropy_free(&entropy);
+
+    if (ret != 0) return std::nullopt;
+
+    // Encode: base64(payload).base64(signature)
+    std::string result = base64_encode(payload);
+    result += '.';
+    result += base64_encode(sig, sig_len);
+
+    return result;
+}
+
+// ── OnlineActivation ────────────────────────────────────────────────────
+
+std::optional<std::string> OnlineActivation::activate(
+    std::string_view server_url, std::string_view serial_number,
+    std::string_view product_id)
+{
+    std::string body = "{\"serial\":\"" + std::string(serial_number)
+                     + "\",\"product\":\"" + std::string(product_id)
+                     + "\",\"machine\":\"" + machine_id() + "\"}";
+
+    std::string url = std::string(server_url) + "/activate";
+    auto response = http_post(url, body, "application/json");
+
+    if (!response.ok()) return std::nullopt;
+    return response.body;
+}
+
+bool OnlineActivation::deactivate(std::string_view server_url,
+                                   std::string_view license_key) {
+    std::string body = "{\"key\":\"" + std::string(license_key)
+                     + "\",\"machine\":\"" + machine_id() + "\"}";
+
+    std::string url = std::string(server_url) + "/deactivate";
+    auto response = http_post(url, body, "application/json");
+    return response.ok();
+}
+
+LicenseStatus OnlineActivation::check_status(std::string_view server_url,
+                                              std::string_view license_key) {
+    std::string url = std::string(server_url) + "/status?key="
+                    + std::string(license_key) + "&machine=" + machine_id();
+    auto response = http_get(url);
+
+    if (!response.ok()) return LicenseStatus::NotFound;
+    if (response.body.find("\"valid\"") != std::string::npos) return LicenseStatus::Valid;
+    if (response.body.find("\"expired\"") != std::string::npos) return LicenseStatus::Expired;
+    return LicenseStatus::InvalidSignature;
+}
+
+}  // namespace pulp::runtime

--- a/core/state/CMakeLists.txt
+++ b/core/state/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(pulp-state PRIVATE
     src/store.cpp
     src/preset_manager.cpp
     src/state_tree.cpp
+    src/state_tree_sync.cpp
     src/properties_file.cpp
 )
 

--- a/core/state/include/pulp/state/cached_property.hpp
+++ b/core/state/include/pulp/state/cached_property.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+// CachedProperty — typed accessor for StateTree properties with local cache.
+// Avoids repeated variant extraction on every read. Updates cache on tree change.
+
+#include <pulp/state/state_tree.hpp>
+#include <string>
+#include <functional>
+
+namespace pulp::state {
+
+/// Cached accessor for a StateTree property.
+/// Maintains a local copy that's updated via the tree's listener mechanism.
+template<typename T>
+class CachedProperty {
+public:
+    CachedProperty() = default;
+
+    /// Bind to a tree node and property name
+    CachedProperty(StateTree::Ptr tree, std::string_view property_name, T default_value = T{})
+        : tree_(tree), property_name_(property_name), value_(default_value), default_(default_value) {
+        if (tree_) {
+            refresh();
+            listener_id_ = tree_->add_listener(
+                [this](StateTree&, std::string_view prop, const PropertyValue&, const PropertyValue& new_val) {
+                    if (prop == property_name_)
+                        update_from_variant(new_val);
+                });
+        }
+    }
+
+    ~CachedProperty() {
+        if (tree_ && listener_id_ >= 0)
+            tree_->remove_listener(listener_id_);
+    }
+
+    /// Get the cached value (no variant extraction — fast)
+    const T& get() const { return value_; }
+    operator const T&() const { return value_; }
+
+    /// Set the value (updates both cache and tree)
+    void set(const T& new_value) {
+        value_ = new_value;
+        if (tree_)
+            tree_->set(property_name_, PropertyValue(new_value));
+    }
+
+    CachedProperty& operator=(const T& new_value) { set(new_value); return *this; }
+
+    /// Force refresh from the tree
+    void refresh() {
+        if (!tree_) return;
+        auto val = tree_->get(property_name_);
+        update_from_variant(val);
+    }
+
+    /// Whether bound to a tree
+    bool is_bound() const { return tree_ != nullptr; }
+
+    // Move only (listener management)
+    CachedProperty(const CachedProperty&) = delete;
+    CachedProperty& operator=(const CachedProperty&) = delete;
+    CachedProperty(CachedProperty&& other) noexcept
+        : tree_(std::move(other.tree_)), property_name_(std::move(other.property_name_)),
+          value_(std::move(other.value_)), default_(std::move(other.default_)),
+          listener_id_(other.listener_id_) {
+        other.listener_id_ = -1;
+    }
+
+private:
+    StateTree::Ptr tree_;
+    std::string property_name_;
+    T value_{};
+    T default_{};
+    int listener_id_ = -1;
+
+    void update_from_variant(const PropertyValue& val);
+};
+
+// Specializations for common types
+template<> inline void CachedProperty<bool>::update_from_variant(const PropertyValue& val) {
+    if (auto* b = std::get_if<bool>(&val)) value_ = *b;
+}
+template<> inline void CachedProperty<int64_t>::update_from_variant(const PropertyValue& val) {
+    if (auto* i = std::get_if<int64_t>(&val)) value_ = *i;
+}
+template<> inline void CachedProperty<double>::update_from_variant(const PropertyValue& val) {
+    if (auto* d = std::get_if<double>(&val)) value_ = *d;
+    else if (auto* i = std::get_if<int64_t>(&val)) value_ = static_cast<double>(*i);
+}
+template<> inline void CachedProperty<std::string>::update_from_variant(const PropertyValue& val) {
+    if (auto* s = std::get_if<std::string>(&val)) value_ = *s;
+}
+
+}  // namespace pulp::state

--- a/core/state/include/pulp/state/state_tree_sync.hpp
+++ b/core/state/include/pulp/state/state_tree_sync.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+// StateTreeSynchroniser — delta-based sync of StateTree over IPC.
+// Encodes property changes and child mutations as compact deltas,
+// sends over an InterprocessConnection, and applies on the remote side.
+
+#include <pulp/state/state_tree.hpp>
+#include <vector>
+#include <cstdint>
+#include <functional>
+
+namespace pulp::state {
+
+/// Delta types for tree synchronization
+enum class SyncDeltaType : uint8_t {
+    PropertySet = 1,
+    PropertyRemove = 2,
+    ChildAdd = 3,
+    ChildRemove = 4
+};
+
+/// A single change to synchronize
+struct SyncDelta {
+    SyncDeltaType type;
+    std::string path;        // Dot-separated path to the node
+    std::string key;         // Property name (for property ops) or child type (for child ops)
+    PropertyValue value;     // New value (for PropertySet)
+    int child_index = -1;    // Index (for ChildAdd/ChildRemove)
+};
+
+/// Encodes StateTree changes as deltas for transmission
+class StateTreeSynchroniser {
+public:
+    StateTreeSynchroniser() = default;
+
+    /// Attach to a tree and start recording changes
+    void attach(StateTree::Ptr tree);
+
+    /// Detach and stop recording
+    void detach();
+
+    /// Get pending deltas since last call (clears the buffer)
+    std::vector<SyncDelta> take_deltas();
+
+    /// Encode deltas as binary for transmission
+    static std::vector<uint8_t> encode(const std::vector<SyncDelta>& deltas);
+
+    /// Decode binary deltas
+    static std::vector<SyncDelta> decode(const uint8_t* data, size_t size);
+
+    /// Apply deltas to a tree
+    static void apply(StateTree& tree, const std::vector<SyncDelta>& deltas);
+
+private:
+    StateTree::Ptr tree_;
+    std::vector<SyncDelta> pending_;
+    int listener_id_ = -1;
+    std::vector<int> child_listener_ids_;
+};
+
+}  // namespace pulp::state

--- a/core/state/src/state_tree_sync.cpp
+++ b/core/state/src/state_tree_sync.cpp
@@ -1,0 +1,183 @@
+#include <pulp/state/state_tree_sync.hpp>
+#include <cstring>
+
+namespace pulp::state {
+
+void StateTreeSynchroniser::attach(StateTree::Ptr tree) {
+    detach();
+    tree_ = tree;
+    if (!tree_) return;
+
+    listener_id_ = tree_->add_listener(
+        [this](StateTree&, std::string_view prop, const PropertyValue&, const PropertyValue& new_val) {
+            SyncDelta delta;
+            delta.type = SyncDeltaType::PropertySet;
+            delta.path = tree_->type_name();
+            delta.key = std::string(prop);
+            delta.value = new_val;
+            pending_.push_back(std::move(delta));
+        });
+
+    int added_id = tree_->add_child_added_listener(
+        [this](StateTree& parent, StateTree& child, int index) {
+            SyncDelta delta;
+            delta.type = SyncDeltaType::ChildAdd;
+            delta.path = parent.type_name();
+            delta.key = child.type_name();
+            delta.child_index = index;
+            pending_.push_back(std::move(delta));
+        });
+    child_listener_ids_.push_back(added_id);
+
+    int removed_id = tree_->add_child_removed_listener(
+        [this](StateTree& parent, StateTree&, int index) {
+            SyncDelta delta;
+            delta.type = SyncDeltaType::ChildRemove;
+            delta.path = parent.type_name();
+            delta.child_index = index;
+            pending_.push_back(std::move(delta));
+        });
+    child_listener_ids_.push_back(removed_id);
+}
+
+void StateTreeSynchroniser::detach() {
+    if (tree_ && listener_id_ >= 0)
+        tree_->remove_listener(listener_id_);
+    listener_id_ = -1;
+    child_listener_ids_.clear();
+    tree_ = nullptr;
+    pending_.clear();
+}
+
+std::vector<SyncDelta> StateTreeSynchroniser::take_deltas() {
+    auto result = std::move(pending_);
+    pending_.clear();
+    return result;
+}
+
+std::vector<uint8_t> StateTreeSynchroniser::encode(const std::vector<SyncDelta>& deltas) {
+    std::vector<uint8_t> buf;
+
+    // Simple encoding: count + per-delta [type, path_len, path, key_len, key, value_type, value_data]
+    uint32_t count = static_cast<uint32_t>(deltas.size());
+    buf.push_back(count & 0xFF);
+    buf.push_back((count >> 8) & 0xFF);
+
+    for (auto& d : deltas) {
+        buf.push_back(static_cast<uint8_t>(d.type));
+
+        // Path
+        uint16_t path_len = static_cast<uint16_t>(d.path.size());
+        buf.push_back(path_len & 0xFF);
+        buf.push_back((path_len >> 8) & 0xFF);
+        buf.insert(buf.end(), d.path.begin(), d.path.end());
+
+        // Key
+        uint16_t key_len = static_cast<uint16_t>(d.key.size());
+        buf.push_back(key_len & 0xFF);
+        buf.push_back((key_len >> 8) & 0xFF);
+        buf.insert(buf.end(), d.key.begin(), d.key.end());
+
+        // Child index
+        buf.push_back(static_cast<uint8_t>(d.child_index & 0xFF));
+
+        // Value type + data
+        if (auto* s = std::get_if<std::string>(&d.value)) {
+            buf.push_back(1);
+            uint16_t len = static_cast<uint16_t>(s->size());
+            buf.push_back(len & 0xFF);
+            buf.push_back((len >> 8) & 0xFF);
+            buf.insert(buf.end(), s->begin(), s->end());
+        } else if (auto* i = std::get_if<int64_t>(&d.value)) {
+            buf.push_back(2);
+            for (int b = 0; b < 8; ++b)
+                buf.push_back(static_cast<uint8_t>((*i >> (b * 8)) & 0xFF));
+        } else if (auto* f = std::get_if<double>(&d.value)) {
+            buf.push_back(3);
+            uint8_t bytes[8];
+            std::memcpy(bytes, f, 8);
+            buf.insert(buf.end(), bytes, bytes + 8);
+        } else if (auto* b = std::get_if<bool>(&d.value)) {
+            buf.push_back(4);
+            buf.push_back(*b ? 1 : 0);
+        } else {
+            buf.push_back(0);  // null/monostate
+        }
+    }
+
+    return buf;
+}
+
+std::vector<SyncDelta> StateTreeSynchroniser::decode(const uint8_t* data, size_t size) {
+    std::vector<SyncDelta> deltas;
+    if (size < 2) return deltas;
+
+    size_t pos = 0;
+    uint32_t count = data[pos] | (data[pos + 1] << 8);
+    pos += 2;
+
+    for (uint32_t i = 0; i < count && pos < size; ++i) {
+        SyncDelta d;
+        d.type = static_cast<SyncDeltaType>(data[pos++]);
+
+        // Path
+        uint16_t path_len = data[pos] | (data[pos + 1] << 8); pos += 2;
+        d.path = std::string(reinterpret_cast<const char*>(data + pos), path_len); pos += path_len;
+
+        // Key
+        uint16_t key_len = data[pos] | (data[pos + 1] << 8); pos += 2;
+        d.key = std::string(reinterpret_cast<const char*>(data + pos), key_len); pos += key_len;
+
+        // Child index
+        d.child_index = static_cast<int8_t>(data[pos++]);
+
+        // Value
+        uint8_t val_type = data[pos++];
+        if (val_type == 1) {
+            uint16_t len = data[pos] | (data[pos + 1] << 8); pos += 2;
+            d.value = std::string(reinterpret_cast<const char*>(data + pos), len); pos += len;
+        } else if (val_type == 2) {
+            int64_t v = 0;
+            for (int b = 0; b < 8 && pos < size; ++b)
+                v |= static_cast<int64_t>(data[pos++]) << (b * 8);
+            d.value = v;
+        } else if (val_type == 3) {
+            double v;
+            std::memcpy(&v, data + pos, 8); pos += 8;
+            d.value = v;
+        } else if (val_type == 4) {
+            d.value = data[pos++] != 0;
+        }
+
+        deltas.push_back(std::move(d));
+    }
+
+    return deltas;
+}
+
+void StateTreeSynchroniser::apply(StateTree& tree, const std::vector<SyncDelta>& deltas) {
+    for (auto& d : deltas) {
+        switch (d.type) {
+            case SyncDeltaType::PropertySet:
+                tree.set(d.key, d.value);
+                break;
+            case SyncDeltaType::PropertyRemove:
+                tree.remove(d.key);
+                break;
+            case SyncDeltaType::ChildAdd: {
+                auto child = StateTree::create(d.key);
+                if (d.child_index >= 0 && d.child_index < tree.child_count())
+                    tree.insert_child(d.child_index, child);
+                else
+                    tree.add_child(child);
+                break;
+            }
+            case SyncDeltaType::ChildRemove:
+                if (d.child_index >= 0 && d.child_index < tree.child_count())
+                    tree.remove_child(d.child_index);
+                break;
+        }
+    }
+}
+
+}  // namespace pulp::state

--- a/core/view/include/pulp/view/accessibility.hpp
+++ b/core/view/include/pulp/view/accessibility.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+// Accessibility interfaces for platform screen reader integration.
+// Provides ValueInterface, TextInterface, TableInterface, CellInterface
+// that can be attached to Views for accessibility provider implementation.
+
+#include <string>
+#include <string_view>
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace pulp::view {
+
+/// Interface for accessible values (sliders, knobs, progress bars)
+class AccessibilityValueInterface {
+public:
+    virtual ~AccessibilityValueInterface() = default;
+
+    /// Current value as a number
+    virtual double get_current_value() const = 0;
+
+    /// Set the value (if editable)
+    virtual void set_current_value(double value) = 0;
+
+    /// Minimum value
+    virtual double get_minimum_value() const = 0;
+
+    /// Maximum value
+    virtual double get_maximum_value() const = 0;
+
+    /// Step increment for keyboard navigation
+    virtual double get_step_size() const { return (get_maximum_value() - get_minimum_value()) / 100.0; }
+
+    /// Value as a human-readable string (e.g., "50%" or "-6 dB")
+    virtual std::string get_value_string() const;
+};
+
+/// Interface for accessible text content (text editors, labels)
+class AccessibilityTextInterface {
+public:
+    virtual ~AccessibilityTextInterface() = default;
+
+    /// Get the full text
+    virtual std::string get_text() const = 0;
+
+    /// Set the text (if editable)
+    virtual void set_text(std::string_view text) = 0;
+
+    /// Get selected text range
+    virtual std::pair<int, int> get_selection() const { return {0, 0}; }
+
+    /// Set selection range
+    virtual void set_selection(int start, int end) { (void)start; (void)end; }
+
+    /// Whether the text is editable
+    virtual bool is_editable() const { return false; }
+
+    /// Number of characters
+    virtual int get_character_count() const {
+        return static_cast<int>(get_text().size());
+    }
+
+    /// Get text in a range
+    virtual std::string get_text_range(int start, int end) const {
+        auto text = get_text();
+        if (start < 0) start = 0;
+        if (end > static_cast<int>(text.size())) end = static_cast<int>(text.size());
+        if (start >= end) return "";
+        return text.substr(static_cast<size_t>(start), static_cast<size_t>(end - start));
+    }
+};
+
+/// Interface for accessible tables and lists
+class AccessibilityTableInterface {
+public:
+    virtual ~AccessibilityTableInterface() = default;
+
+    /// Number of rows
+    virtual int get_row_count() const = 0;
+
+    /// Number of columns
+    virtual int get_column_count() const = 0;
+
+    /// Get header text for a column
+    virtual std::string get_column_header(int column) const = 0;
+
+    /// Get the currently selected row (-1 if none)
+    virtual int get_selected_row() const { return -1; }
+
+    /// Select a row
+    virtual void select_row(int row) { (void)row; }
+
+    /// Whether multiple selection is supported
+    virtual bool supports_multi_selection() const { return false; }
+
+    /// Get all selected rows
+    virtual std::vector<int> get_selected_rows() const {
+        int row = get_selected_row();
+        return row >= 0 ? std::vector<int>{row} : std::vector<int>{};
+    }
+};
+
+/// Interface for individual table cells
+class AccessibilityCellInterface {
+public:
+    virtual ~AccessibilityCellInterface() = default;
+
+    /// Cell text content
+    virtual std::string get_cell_text(int row, int column) const = 0;
+
+    /// Whether the cell is editable
+    virtual bool is_cell_editable(int row, int column) const { (void)row; (void)column; return false; }
+
+    /// Row and column span (for merged cells)
+    virtual std::pair<int, int> get_cell_span(int row, int column) const {
+        (void)row; (void)column;
+        return {1, 1};
+    }
+};
+
+}  // namespace pulp::view

--- a/core/view/include/pulp/view/animation.hpp
+++ b/core/view/include/pulp/view/animation.hpp
@@ -40,6 +40,16 @@ namespace easing {
 
 using EasingFunction = float(*)(float);
 
+/// Compile-time animation limits for optimization.
+/// Used to bound animation values without runtime checks.
+struct StaticAnimationLimits {
+    float min_value = 0.0f;
+    float max_value = 1.0f;
+    float min_duration = 0.0f;     // 0 = instant allowed
+    float max_duration = 60.0f;    // 60 seconds max
+    bool clamp_value = true;       // Whether to clamp output to [min, max]
+};
+
 // ── Tween ────────────────────────────────────────────────────────────────────
 
 // Animates a float from start to end over a duration

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,11 @@ add_executable(pulp-test-sync test_sync_primitives.cpp)
 target_link_libraries(pulp-test-sync PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-sync)
 
+# IPC (InterprocessConnection) tests
+add_executable(pulp-test-ipc test_ipc.cpp)
+target_link_libraries(pulp-test-ipc PRIVATE pulp::events pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-ipc)
+
 # AttributedString and TextLayout tests
 add_executable(pulp-test-attributed-string test_attributed_string.cpp)
 target_link_libraries(pulp-test-attributed-string PRIVATE pulp::canvas Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,11 @@ add_executable(pulp-test-sync test_sync_primitives.cpp)
 target_link_libraries(pulp-test-sync PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-sync)
 
+# License and BigInteger tests
+add_executable(pulp-test-license test_license.cpp)
+target_link_libraries(pulp-test-license PRIVATE pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-license)
+
 # MIDI CI tests
 add_executable(pulp-test-midi-ci test_midi_ci.cpp)
 target_link_libraries(pulp-test-midi-ci PRIVATE pulp::midi Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,11 @@ add_executable(pulp-test-sync test_sync_primitives.cpp)
 target_link_libraries(pulp-test-sync PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-sync)
 
+# Crypto tests (SHA-256, MD5, AES, machine ID)
+add_executable(pulp-test-crypto test_crypto.cpp)
+target_link_libraries(pulp-test-crypto PRIVATE pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-crypto)
+
 # IPC (InterprocessConnection) tests
 add_executable(pulp-test-ipc test_ipc.cpp)
 target_link_libraries(pulp-test-ipc PRIVATE pulp::events pulp::runtime Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,16 @@ add_executable(pulp-test-sync test_sync_primitives.cpp)
 target_link_libraries(pulp-test-sync PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-sync)
 
+# MIDI CI tests
+add_executable(pulp-test-midi-ci test_midi_ci.cpp)
+target_link_libraries(pulp-test-midi-ci PRIVATE pulp::midi Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-midi-ci)
+
+# Analytics tests
+add_executable(pulp-test-analytics test_analytics.cpp)
+target_link_libraries(pulp-test-analytics PRIVATE pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-analytics)
+
 # Crypto tests (SHA-256, MD5, AES, machine ID)
 add_executable(pulp-test-crypto test_crypto.cpp)
 target_link_libraries(pulp-test-crypto PRIVATE pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -1,0 +1,67 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/runtime/analytics.hpp>
+#include <pulp/runtime/temporary_file.hpp>
+#include <fstream>
+
+using namespace pulp::runtime;
+
+TEST_CASE("Analytics log event increments count", "[runtime][analytics]") {
+    // Use a fresh destination to test
+    auto& a = Analytics::instance();
+    a.set_enabled(true);
+    uint64_t before = a.event_count();
+
+    a.log("test_event");
+    REQUIRE(a.event_count() == before + 1);
+}
+
+TEST_CASE("Analytics disabled doesn't log", "[runtime][analytics]") {
+    auto& a = Analytics::instance();
+    uint64_t before = a.event_count();
+
+    a.set_enabled(false);
+    a.log("should_not_count");
+    REQUIRE(a.event_count() == before);
+
+    a.set_enabled(true);
+}
+
+TEST_CASE("Analytics log with properties", "[runtime][analytics]") {
+    auto& a = Analytics::instance();
+    uint64_t before = a.event_count();
+
+    a.log_event("user_action", {{"button", "play"}, {"state", "on"}});
+    REQUIRE(a.event_count() == before + 1);
+}
+
+TEST_CASE("FileAnalyticsDestination writes JSON", "[runtime][analytics]") {
+    TemporaryFile tmp(".jsonl");
+
+    {
+        auto dest = std::make_unique<FileAnalyticsDestination>(tmp.path_string());
+        AnalyticsEvent event;
+        event.name = "test";
+        event.timestamp = 1234567890.0;
+        event.properties = {{"key", "value"}};
+        dest->log_event(event);
+        dest->flush();
+    }
+
+    std::ifstream f(tmp.path());
+    std::string line;
+    REQUIRE(std::getline(f, line));
+    REQUIRE(line.find("\"event\":\"test\"") != std::string::npos);
+    REQUIRE(line.find("\"key\":\"value\"") != std::string::npos);
+}
+
+TEST_CASE("WidgetTracker logs events", "[runtime][analytics]") {
+    auto& a = Analytics::instance();
+    a.set_enabled(true);
+    uint64_t before = a.event_count();
+
+    WidgetTracker::track_click("gain_knob");
+    WidgetTracker::track_value_change("freq", "440");
+    WidgetTracker::track_preset_select("Default");
+
+    REQUIRE(a.event_count() == before + 3);
+}

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -1,0 +1,102 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/runtime/crypto.hpp>
+#include <cstring>
+
+using namespace pulp::runtime;
+
+// ── SHA-256 ─────────────────────────────────────────────────────────────
+
+TEST_CASE("SHA-256 empty string", "[crypto][sha256]") {
+    auto hex = sha256_hex("");
+    // Known: SHA-256 of empty string
+    REQUIRE(hex == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+TEST_CASE("SHA-256 known value", "[crypto][sha256]") {
+    auto hex = sha256_hex("hello");
+    REQUIRE(hex == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+}
+
+TEST_CASE("SHA-256 binary data", "[crypto][sha256]") {
+    auto digest = sha256("test data");
+    REQUIRE(digest.size() == 32);
+}
+
+// ── MD5 ─────────────────────────────────────────────────────────────────
+
+TEST_CASE("MD5 empty string", "[crypto][md5]") {
+    auto hex = md5_hex("");
+    REQUIRE(hex == "d41d8cd98f00b204e9800998ecf8427e");
+}
+
+TEST_CASE("MD5 known value", "[crypto][md5]") {
+    auto hex = md5_hex("hello");
+    REQUIRE(hex == "5d41402abc4b2a76b9719d911017c592");
+}
+
+// ── AES-256-CBC ─────────────────────────────────────────────────────────
+
+TEST_CASE("AES encrypt/decrypt round-trip", "[crypto][aes]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    std::memset(key, 0x42, 32);
+    std::memset(iv, 0x13, 16);
+
+    std::string plaintext = "Hello, Pulp crypto!";
+    auto encrypted = aes_encrypt(
+        reinterpret_cast<const uint8_t*>(plaintext.data()),
+        plaintext.size(), key, iv);
+
+    REQUIRE(encrypted.has_value());
+    REQUIRE(encrypted->size() > plaintext.size());  // Padded
+    REQUIRE(encrypted->size() % 16 == 0);
+
+    auto decrypted = aes_decrypt(encrypted->data(), encrypted->size(), key, iv);
+    REQUIRE(decrypted.has_value());
+
+    std::string result(decrypted->begin(), decrypted->end());
+    REQUIRE(result == plaintext);
+}
+
+TEST_CASE("AES empty plaintext", "[crypto][aes]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    std::memset(key, 0xAA, 32);
+    std::memset(iv, 0xBB, 16);
+
+    auto encrypted = aes_encrypt(nullptr, 0, key, iv);
+    REQUIRE(encrypted.has_value());
+    REQUIRE(encrypted->size() == 16);  // One block of padding
+
+    auto decrypted = aes_decrypt(encrypted->data(), encrypted->size(), key, iv);
+    REQUIRE(decrypted.has_value());
+    REQUIRE(decrypted->empty());
+}
+
+TEST_CASE("AES decrypt invalid data", "[crypto][aes]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    uint8_t garbage[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
+    // Decrypting garbage may succeed (AES doesn't validate content)
+    // but padding check should catch invalid data
+    auto result = aes_decrypt(garbage, 16, key, iv);
+    // May or may not succeed — depends on whether last byte happens to be valid padding
+}
+
+// ── Machine ID ──────────────────────────────────────────────────────────
+
+TEST_CASE("Machine ID is deterministic", "[crypto][machine_id]") {
+    auto id1 = machine_id();
+    auto id2 = machine_id();
+
+    REQUIRE(id1 == id2);
+    REQUIRE(id1.size() == 64);  // SHA-256 hex = 64 chars
+}
+
+TEST_CASE("Machine ID is non-empty", "[crypto][machine_id]") {
+    auto id = machine_id();
+    REQUIRE_FALSE(id.empty());
+    // Should not be all zeros
+    REQUIRE(id != std::string(64, '0'));
+}

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -1,0 +1,56 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/events/interprocess_connection.hpp>
+#include <pulp/runtime/temporary_file.hpp>
+#include <thread>
+#include <chrono>
+#include <atomic>
+
+using namespace pulp::events;
+using namespace pulp::runtime;
+
+// ── InterprocessConnection via named pipe ───────────────────────────────
+
+TEST_CASE("IPC message framing", "[events][ipc]") {
+    // Verify the connection won't send when disconnected
+    InterprocessConnection conn;
+    REQUIRE_FALSE(conn.send_message("test message"));
+    REQUIRE_FALSE(conn.send_message(std::string_view("binary data")));
+}
+
+TEST_CASE("IPC connection state", "[events][ipc]") {
+    InterprocessConnection conn;
+    REQUIRE(conn.state() == IpcState::Disconnected);
+    REQUIRE_FALSE(conn.is_connected());
+}
+
+TEST_CASE("IPC connect to nonexistent fails", "[events][ipc]") {
+    InterprocessConnection conn;
+    bool ok = conn.connect("/tmp/pulp_nonexistent_pipe_12345", IpcTransport::NamedPipe);
+    REQUIRE_FALSE(ok);
+    REQUIRE(conn.state() == IpcState::Error);
+}
+
+TEST_CASE("IPC send while disconnected returns false", "[events][ipc]") {
+    InterprocessConnection conn;
+    REQUIRE_FALSE(conn.send_message("test"));
+}
+
+TEST_CASE("IPC lambda callbacks settable", "[events][ipc]") {
+    InterprocessConnection conn;
+    bool connected_fired = false;
+    bool disconnected_fired = false;
+
+    conn.on_connected = [&]() { connected_fired = true; };
+    conn.on_disconnected = [&]() { disconnected_fired = true; };
+    conn.on_text_message = [](std::string_view) {};
+
+    // Callbacks are set but won't fire without actual connection
+    REQUIRE_FALSE(connected_fired);
+}
+
+// ── InterprocessConnectionServer ────────────────────────────────────────
+
+TEST_CASE("IPC server initial state", "[events][ipc]") {
+    InterprocessConnectionServer server;
+    REQUIRE_FALSE(server.is_running());
+}

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -1,0 +1,136 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/runtime/license.hpp>
+#include <pulp/runtime/big_integer.hpp>
+#include <pulp/runtime/base64.hpp>
+
+using namespace pulp::runtime;
+
+// ── BigInteger ──────────────────────────────────────────────────────────
+
+TEST_CASE("BigInteger from uint64", "[crypto][bigint]") {
+    BigInteger a(42);
+    REQUIRE(a.to_string() == "42");
+    REQUIRE_FALSE(a.is_zero());
+}
+
+TEST_CASE("BigInteger zero", "[crypto][bigint]") {
+    BigInteger z(0);
+    REQUIRE(z.is_zero());
+    REQUIRE(z.to_string() == "0");
+}
+
+TEST_CASE("BigInteger from decimal string", "[crypto][bigint]") {
+    auto a = BigInteger::from_string("123456789");
+    REQUIRE(a.to_string() == "123456789");
+}
+
+TEST_CASE("BigInteger from hex", "[crypto][bigint]") {
+    auto a = BigInteger::from_hex("FF");
+    REQUIRE(a.to_string() == "255");
+}
+
+TEST_CASE("BigInteger addition", "[crypto][bigint]") {
+    BigInteger a(100);
+    BigInteger b(200);
+    auto c = a + b;
+    REQUIRE(c.to_string() == "300");
+}
+
+TEST_CASE("BigInteger multiplication", "[crypto][bigint]") {
+    BigInteger a(12);
+    BigInteger b(34);
+    auto c = a * b;
+    REQUIRE(c.to_string() == "408");
+}
+
+TEST_CASE("BigInteger modulo", "[crypto][bigint]") {
+    BigInteger a(17);
+    BigInteger b(5);
+    auto c = a % b;
+    REQUIRE(c.to_string() == "2");
+}
+
+TEST_CASE("BigInteger mod_pow", "[crypto][bigint]") {
+    // 3^7 mod 13 = 2187 mod 13 = 3
+    BigInteger base(3);
+    BigInteger exp(7);
+    BigInteger mod(13);
+    auto result = base.mod_pow(exp, mod);
+    REQUIRE(result.to_string() == "3");
+}
+
+TEST_CASE("BigInteger comparison", "[crypto][bigint]") {
+    BigInteger a(100);
+    BigInteger b(200);
+    REQUIRE(a < b);
+    REQUIRE(a != b);
+    REQUIRE(a == BigInteger(100));
+}
+
+TEST_CASE("BigInteger large numbers", "[crypto][bigint]") {
+    auto a = BigInteger::from_string("999999999999999999");
+    auto b = BigInteger::from_string("1");
+    auto c = a + b;
+    REQUIRE(c.to_string() == "1000000000000000000");
+}
+
+// ── License ─────────────────────────────────────────────────────────────
+
+TEST_CASE("LicenseValidator invalid format", "[crypto][license]") {
+    LicenseValidator validator;
+    REQUIRE(validator.validate("not-a-license") == LicenseStatus::InvalidFormat);
+}
+
+TEST_CASE("LicenseValidator missing dot separator", "[crypto][license]") {
+    LicenseValidator validator;
+    REQUIRE(validator.validate("nodot") == LicenseStatus::InvalidFormat);
+}
+
+TEST_CASE("LicenseValidator parse payload", "[crypto][license]") {
+    LicenseValidator validator;
+
+    // Create a fake license with valid base64 payload but no valid signature
+    std::string payload = "{\"product_id\":\"PulpSynth\",\"email\":\"test@test.com\",\"issued\":1234567890}";
+    std::string encoded = base64_encode(payload) + ".invalidsig";
+
+    // Without a public key set, signature verification fails
+    auto status = validator.validate(encoded);
+    REQUIRE(status == LicenseStatus::InvalidSignature);
+}
+
+TEST_CASE("LicenseValidator validate_and_parse extracts info", "[crypto][license]") {
+    LicenseValidator validator;
+
+    std::string payload = "{\"product_id\":\"PulpGain\",\"email\":\"user@example.com\",\"edition\":\"pro\",\"issued\":1700000000}";
+    std::string key = base64_encode(payload) + ".sig";
+
+    auto info = validator.validate_and_parse(key);
+    REQUIRE(info.has_value());
+    REQUIRE(info->product_id == "PulpGain");
+    REQUIRE(info->user_email == "user@example.com");
+    REQUIRE(info->edition == "pro");
+}
+
+TEST_CASE("LicenseValidator is_valid_for_machine", "[crypto][license]") {
+    LicenseValidator validator;
+
+    LicenseInfo info;
+    info.product_id = "test";
+
+    // Empty machine_id = valid for any machine
+    info.machine_id = "";
+    REQUIRE(validator.is_valid_for_machine(info));
+
+    // Matching machine_id
+    info.machine_id = machine_id();
+    REQUIRE(validator.is_valid_for_machine(info));
+
+    // Non-matching
+    info.machine_id = "wrong_machine";
+    REQUIRE_FALSE(validator.is_valid_for_machine(info));
+}
+
+TEST_CASE("LicenseValidator file not found", "[crypto][license]") {
+    LicenseValidator validator;
+    REQUIRE(validator.validate_file("/tmp/nonexistent_license_12345.key") == LicenseStatus::NotFound);
+}

--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -1,0 +1,94 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/midi/midi_ci.hpp>
+
+using namespace pulp::midi;
+
+TEST_CASE("MUID generate is non-zero", "[midi][ci]") {
+    auto muid = MUID::generate();
+    REQUIRE(muid.value > 0);
+    REQUIRE(muid.value < 0x0FFFFFFF);
+}
+
+TEST_CASE("MUID broadcast", "[midi][ci]") {
+    auto bc = MUID::broadcast();
+    REQUIRE(bc.is_broadcast());
+    REQUIRE(bc.value == 0x0FFFFFFF);
+}
+
+TEST_CASE("CiDiscovery creates valid inquiry", "[midi][ci]") {
+    CiDiscovery ci;
+    ci.set_device_info({ci.local_muid(), 0x123, 0x01, 0x02, 0x0100, 2, 128});
+
+    auto msg = ci.create_discovery_inquiry();
+    REQUIRE(msg.size() > 14);
+    REQUIRE(msg.front() == 0xF0);  // SysEx start
+    REQUIRE(msg.back() == 0xF7);   // SysEx end
+    REQUIRE(msg[1] == 0x7E);       // Universal SysEx
+    REQUIRE(msg[3] == 0x0D);       // CI sub-ID
+    REQUIRE(msg[4] == 0x70);       // Discovery inquiry
+}
+
+TEST_CASE("CiDiscovery responds to inquiry", "[midi][ci]") {
+    CiDiscovery responder;
+    CiDiscovery inquirer;
+
+    auto inquiry = inquirer.create_discovery_inquiry();
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+
+    REQUIRE_FALSE(reply.empty());
+    REQUIRE(reply.front() == 0xF0);
+    REQUIRE(reply[4] == 0x71);  // Discovery reply
+}
+
+TEST_CASE("CiDiscovery profile management", "[midi][ci]") {
+    CiDiscovery ci;
+
+    ProfileId profile{0x01, 0x02, 0x01, 0x00, 0x00};
+    ci.add_profile({profile, false, 0});
+
+    REQUIRE(ci.profiles().size() == 1);
+    REQUIRE_FALSE(ci.profiles()[0].enabled);
+
+    ci.enable_profile(profile);
+    REQUIRE(ci.profiles()[0].enabled);
+
+    ci.disable_profile(profile);
+    REQUIRE_FALSE(ci.profiles()[0].enabled);
+}
+
+TEST_CASE("CiDiscovery profile callback", "[midi][ci]") {
+    CiDiscovery ci;
+    ProfileId profile{0x01, 0x01, 0x00, 0x00, 0x00};
+    ci.add_profile({profile, false, 0});
+
+    bool callback_fired = false;
+    ci.on_profile_changed = [&](const ProfileId&, bool) { callback_fired = true; };
+
+    ci.enable_profile(profile);
+    REQUIRE(callback_fired);
+}
+
+TEST_CASE("CiDiscovery property exchange", "[midi][ci]") {
+    CiDiscovery ci;
+
+    ci.set_property("DeviceName", "PulpSynth");
+    auto val = ci.get_property("DeviceName");
+    REQUIRE(val.has_value());
+    REQUIRE(*val == "PulpSynth");
+
+    REQUIRE_FALSE(ci.get_property("nonexistent").has_value());
+}
+
+TEST_CASE("CiDiscovery profile inquiry response", "[midi][ci]") {
+    CiDiscovery ci;
+    ProfileId p1{0x01, 0x01, 0x00, 0x00, 0x00};
+    ProfileId p2{0x02, 0x01, 0x00, 0x00, 0x00};
+    ci.add_profile({p1, true, 0});
+    ci.add_profile({p2, false, 0});
+
+    auto inquiry = ci.create_profile_inquiry(ci.local_muid());
+    // Process the inquiry on the same device (self-test)
+    auto reply = ci.process_message(inquiry.data(), inquiry.size());
+    // Profile inquiry is type 0x24, we handle it
+    REQUIRE_FALSE(reply.empty());
+}


### PR DESCRIPTION
## Summary

Implements 14 previously-missing items with real code and tests:

**Tier 1 (IPC infrastructure):**
- InterprocessConnection: length-prefixed IPC over named pipes/TCP
- ConnectedChildProcess + ChildProcessManager: crash-isolated process pool
- CachedProperty<T>: listener-backed StateTree accessor
- StateTreeSynchroniser: delta-based binary sync

**Tier 2 (Crypto/Licensing foundation):**
- Mbed TLS v3.6.2 integration (Apache 2.0) via FetchContent
- SHA-256, MD5, AES-256-CBC encrypt/decrypt
- Machine ID: deterministic hardware fingerprint
- BigInteger: arbitrary-precision arithmetic via MPI

**Phase 8 (MIDI CI, Analytics, Accessibility):**
- MIDI CI: discovery, profiles, property exchange over Universal SysEx
- Analytics: thread-safe events with file destination + widget tracker
- Accessibility: Value, Text, Table, Cell interfaces

**Other:**
- MountedVolumeListChangeDetector, NetworkServiceDiscovery, LockingAsyncUpdater
- StaticAnimationLimits

## Test plan
- [x] 30+ new test cases across crypto, MIDI CI, analytics, IPC
- [x] All builds on macOS
- [x] Naming audit clean
- [ ] CI via namespace