### PR TITLE
Migrate validation harness + JS bridge to ChildProcess, add ProgressParser

### DIFF
--- a/core/format/src/validation_harness.cpp
+++ b/core/format/src/validation_harness.cpp
@@ -304,7 +304,11 @@ ReportEntry ValidationHarness::run_validator(
     }
 
     // Run the validator via ChildProcess (with 30s timeout)
+#ifdef _WIN32
+    auto result = pulp::platform::exec("cmd", {"/c", cmd}, 30000);
+#else
     auto result = pulp::platform::exec("/bin/sh", {"-c", cmd}, 30000);
+#endif
     {
         auto end = std::chrono::steady_clock::now();
         entry.duration_ms = std::chrono::duration<double, std::milli>(end - start).count();
@@ -336,9 +340,6 @@ ReportEntry ValidationHarness::run_validator(
                 << "\"stderr\": \"\""
                 << "}";
         entry.payload_json = payload.str();
-    } else {
-        entry.status = ValidationStatus::error;
-        entry.error_message = "Failed to execute " + tool;
     }
 
     entries_.push_back(entry);

--- a/core/format/src/validation_harness.cpp
+++ b/core/format/src/validation_harness.cpp
@@ -2,22 +2,13 @@
 /// Implementation of the deterministic validation harness.
 
 #include <pulp/format/validation_harness.hpp>
+#include <pulp/platform/child_process.hpp>
 #include <pulp/platform/platform.hpp>
 #include <chrono>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <sstream>
-
-#ifdef _WIN32
-#define PULP_POPEN _popen
-#define PULP_PCLOSE _pclose
-#include <io.h>
-#else
-#define PULP_POPEN popen
-#define PULP_PCLOSE pclose
-#include <sys/wait.h>
-#endif
 
 namespace pulp::format {
 
@@ -269,21 +260,8 @@ ReportEntry ValidationHarness::run_validator(
     }
 
     // Check if the tool is available
-#ifdef _WIN32
-    std::string which_cmd = "where " + tool + " 2>NUL";
-#else
-    std::string which_cmd = "which " + tool + " 2>/dev/null";
-#endif
-    FILE* pipe = PULP_POPEN(which_cmd.c_str(), "r");
-    std::string tool_path;
-    if (pipe) {
-        char buf[256];
-        while (fgets(buf, sizeof(buf), pipe)) tool_path += buf;
-        PULP_PCLOSE(pipe);
-    }
-    // Trim
-    while (!tool_path.empty() && (tool_path.back() == '\n' || tool_path.back() == '\r'))
-        tool_path.pop_back();
+    auto tool_found = pulp::platform::find_on_path(tool);
+    std::string tool_path = tool_found ? tool_found->string() : std::string{};
 
     if (tool_path.empty()) {
         entry.status = ValidationStatus::skip;
@@ -325,37 +303,27 @@ ReportEntry ValidationHarness::run_validator(
         return entry;
     }
 
-    // Run the validator
-    std::string output;
-    pipe = PULP_POPEN(cmd.c_str(), "r");
-    if (pipe) {
-        char buf[1024];
-        while (fgets(buf, sizeof(buf), pipe)) output += buf;
-        int exit_code = PULP_PCLOSE(pipe);
-        // On POSIX, pclose returns waitpid status; extract exit code.
-        // On Windows, _pclose returns the process exit code directly.
-#ifndef _WIN32
-        exit_code = WIFEXITED(exit_code) ? WEXITSTATUS(exit_code) : -1;
-#endif
-
+    // Run the validator via ChildProcess (with 30s timeout)
+    auto result = pulp::platform::exec("/bin/sh", {"-c", cmd}, 30000);
+    {
         auto end = std::chrono::steady_clock::now();
         entry.duration_ms = std::chrono::duration<double, std::milli>(end - start).count();
+        int exit_code = result.exit_code;
+        std::string output = result.stdout_output + result.stderr_output;
+
         entry.status = (exit_code == 0) ? ValidationStatus::pass : ValidationStatus::fail;
-        if (exit_code != 0) {
+        if (result.timed_out) {
+            entry.status = ValidationStatus::fail;
+            entry.error_message = tool + " timed out after 30 seconds";
+        } else if (exit_code != 0) {
             entry.error_message = tool + " exited with code " + std::to_string(exit_code);
         }
 
         // Get tool version
-        std::string version_cmd = tool + " --version 2>&1";
-        std::string version;
-        FILE* vpipe = PULP_POPEN(version_cmd.c_str(), "r");
-        if (vpipe) {
-            char vbuf[256];
-            while (fgets(vbuf, sizeof(vbuf), vpipe)) version += vbuf;
-            PULP_PCLOSE(vpipe);
-            while (!version.empty() && (version.back() == '\n' || version.back() == '\r'))
-                version.pop_back();
-        }
+        auto ver_result = pulp::platform::exec(tool, {"--version"}, 5000);
+        std::string version = ver_result.stdout_output;
+        while (!version.empty() && (version.back() == '\n' || version.back() == '\r'))
+            version.pop_back();
 
         std::ostringstream payload;
         payload << "{"

--- a/core/platform/include/pulp/platform/progress_parser.hpp
+++ b/core/platform/include/pulp/platform/progress_parser.hpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <functional>
+#include <string>
+#include <string_view>
+
+namespace pulp::platform {
+
+/// A structured progress event parsed from a PROGRESS:TYPE:PAYLOAD line.
+struct ProgressEvent {
+    std::string type;     ///< e.g., "DOWNLOAD_START", "OVERALL", "ERROR"
+    std::string payload;  ///< Everything after PROGRESS:TYPE:
+};
+
+/// Parses lines matching the PROGRESS:TYPE:PAYLOAD protocol and fires a
+/// callback for each match. Lines that don't match are silently ignored.
+///
+/// Usage with ChildProcess:
+/// @code
+/// ProgressParser parser([&](const ProgressEvent& e) {
+///     progress_queue.push(e);  // SpscQueue for UI delivery
+/// });
+/// ProcessOptions opts;
+/// opts.on_stdout_line = [&](std::string_view line) { parser.feed_line(line); };
+/// auto result = ChildProcess::run("python3", {"script.py"}, opts);
+/// @endcode
+class ProgressParser {
+public:
+    using Callback = std::function<void(const ProgressEvent&)>;
+
+    explicit ProgressParser(Callback cb) : callback_(std::move(cb)) {}
+
+    /// Feed a line of output. If it matches PROGRESS:TYPE:PAYLOAD, fires the
+    /// callback. Otherwise does nothing.
+    void feed_line(std::string_view line) {
+        if (!line.starts_with("PROGRESS:")) return;
+        auto rest = line.substr(9);  // after "PROGRESS:"
+        auto colon = rest.find(':');
+        if (colon == std::string_view::npos) {
+            // PROGRESS:TYPE (no payload)
+            if (callback_) callback_({std::string(rest), {}});
+        } else {
+            // PROGRESS:TYPE:PAYLOAD
+            if (callback_) callback_({
+                std::string(rest.substr(0, colon)),
+                std::string(rest.substr(colon + 1))
+            });
+        }
+    }
+
+private:
+    Callback callback_;
+};
+
+}  // namespace pulp::platform

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -194,7 +194,7 @@ target_include_directories(pulp-view PUBLIC
 
 add_dependencies(pulp-view pulp-view-js-preludes)
 
-target_link_libraries(pulp-view PUBLIC pulp::canvas pulp::events pulp::state pulp::signal)
+target_link_libraries(pulp-view PUBLIC pulp::canvas pulp::events pulp::state pulp::signal pulp::platform)
 
 # JavaScriptCore framework for JSC backend (Apple only)
 if(APPLE)
@@ -202,10 +202,7 @@ if(APPLE)
 endif()
 
 if(WIN32)
-    target_compile_definitions(pulp-view PRIVATE
-        popen=_popen
-        pclose=_pclose
-    )
+    # Note: popen/pclose defines removed — using pulp::platform::ChildProcess instead
 endif()
 
 # Yoga layout engine (MIT)

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -37,13 +37,7 @@
 #include "include/gpu/graphite/Image.h"
 #endif
 
-#if defined(_WIN32)
-#define PULP_POPEN _popen
-#define PULP_PCLOSE _pclose
-#else
-#define PULP_POPEN popen
-#define PULP_PCLOSE pclose
-#endif
+#include <pulp/platform/child_process.hpp>
 
 namespace pulp::view {
 namespace {
@@ -3002,13 +2996,12 @@ void WidgetBridge::register_api() {
         auto cmd = args.get<std::string>(0, "");
         if (cmd.empty()) return choc::value::createString("");
         auto full_cmd = build_shell_command(cmd);
-        std::string r;
-        FILE* p = PULP_POPEN(full_cmd.c_str(), "r");
-        if (!p) return choc::value::createString("");
-        char buf[4096];
-        while (fgets(buf, sizeof(buf), p)) r += buf;
-        PULP_PCLOSE(p);
-        return choc::value::createString(r);
+#ifdef _WIN32
+        auto result = pulp::platform::exec("cmd", {"/c", full_cmd}, 30000);
+#else
+        auto result = pulp::platform::exec("/bin/sh", {"-c", full_cmd}, 30000);
+#endif
+        return choc::value::createString(result.stdout_output);
     });
 
     // execAsync(cmd, callbackId) — non-blocking shell command
@@ -3023,16 +3016,14 @@ void WidgetBridge::register_api() {
         auto async_results = async_exec_results_;
         auto async_mutex = async_exec_mutex_;
         std::thread([alive, async_results, async_mutex, full_cmd, cbId]() {
-            std::string r;
-            FILE* p = PULP_POPEN(full_cmd.c_str(), "r");
-            if (p) {
-                char buf[4096];
-                while (fgets(buf, sizeof(buf), p)) r += buf;
-                PULP_PCLOSE(p);
-            }
+#ifdef _WIN32
+            auto result = pulp::platform::exec("cmd", {"/c", full_cmd}, 60000);
+#else
+            auto result = pulp::platform::exec("/bin/sh", {"-c", full_cmd}, 60000);
+#endif
             if (!alive || !alive->load(std::memory_order_acquire)) return;
             std::lock_guard<std::mutex> lock(*async_mutex);
-            async_results->push_back({cbId, std::move(r)});
+            async_results->push_back({cbId, std::move(result.stdout_output)});
         }).detach();
         return choc::value::Value();
     });

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,11 @@ add_executable(pulp-test-child-process test_child_process.cpp)
 target_link_libraries(pulp-test-child-process PRIVATE pulp::platform Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-child-process)
 
+# Progress parser tests
+add_executable(pulp-test-progress-parser test_progress_parser.cpp)
+target_link_libraries(pulp-test-progress-parser PRIVATE pulp::platform Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-progress-parser)
+
 # Validation harness tests (Phase 2)
 add_executable(pulp-test-validation-harness test_validation_harness.cpp)
 target_link_libraries(pulp-test-validation-harness PRIVATE pulp::format Catch2::Catch2WithMain)

--- a/test/test_progress_parser.cpp
+++ b/test/test_progress_parser.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/child_process.hpp>
 #include <pulp/platform/progress_parser.hpp>
 
 #include <string>

--- a/test/test_progress_parser.cpp
+++ b/test/test_progress_parser.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/progress_parser.hpp>
+
+#include <string>
+#include <vector>
+
+using namespace pulp::platform;
+
+TEST_CASE("ProgressParser parses basic event", "[progress_parser]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });
+
+    parser.feed_line("PROGRESS:DOWNLOAD_START:0:ambient sounds");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].type == "DOWNLOAD_START");
+    REQUIRE(events[0].payload == "0:ambient sounds");
+}
+
+TEST_CASE("ProgressParser ignores non-progress lines", "[progress_parser]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });
+
+    parser.feed_line("Some regular output");
+    parser.feed_line("");
+    parser.feed_line("Downloading file...");
+    REQUIRE(events.empty());
+}
+
+TEST_CASE("ProgressParser handles type-only (no payload)", "[progress_parser]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });
+
+    parser.feed_line("PROGRESS:DONE");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].type == "DONE");
+    REQUIRE(events[0].payload.empty());
+}
+
+TEST_CASE("ProgressParser handles multiple events", "[progress_parser]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });
+
+    parser.feed_line("PROGRESS:OVERALL:3:16");
+    parser.feed_line("Some log output");
+    parser.feed_line("PROGRESS:SAMPLE_COMPLETE:2:/tmp/sample.wav");
+    parser.feed_line("PROGRESS:ERROR:5:Network timeout");
+
+    REQUIRE(events.size() == 3);
+    REQUIRE(events[0].type == "OVERALL");
+    REQUIRE(events[0].payload == "3:16");
+    REQUIRE(events[1].type == "SAMPLE_COMPLETE");
+    REQUIRE(events[1].payload == "2:/tmp/sample.wav");
+    REQUIRE(events[2].type == "ERROR");
+    REQUIRE(events[2].payload == "5:Network timeout");
+}
+
+TEST_CASE("ProgressParser works with ChildProcess line callback", "[progress_parser]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });
+
+    ProcessOptions opts;
+    opts.timeout_ms = 5000;
+    opts.on_stdout_line = [&](std::string_view line) { parser.feed_line(line); };
+
+#ifdef _WIN32
+    auto r = ChildProcess::run("cmd", {"/c",
+        "echo PROGRESS:START:test& echo normal output& echo PROGRESS:END"}, opts);
+#else
+    auto r = ChildProcess::run("/bin/sh", {"-c",
+        "echo PROGRESS:START:test; echo normal output; echo PROGRESS:END"}, opts);
+#endif
+
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(events.size() == 2);
+    REQUIRE(events[0].type == "START");
+    REQUIRE(events[0].payload == "test");
+    REQUIRE(events[1].type == "END");
+}


### PR DESCRIPTION
## Summary

**Phase 2 (Migration):**
- validation_harness.cpp: Replace popen with find_on_path() + exec(), add 30s timeout
- widget_bridge.cpp: Replace PULP_POPEN in exec/execAsync with ChildProcess, add timeouts
- Remove PULP_POPEN/PULP_PCLOSE defines and popen=_popen CMake compatibility hack

**Phase 3 (Progress Protocol):**
- `progress_parser.hpp`: Header-only parser for PROGRESS:TYPE:PAYLOAD lines
- Composable with ChildProcess via on_stdout_line callback
- Designed for SpscQueue delivery to UI thread

## CI Note
Build failures are from pre-existing `test_signal.cpp` (DryWetMixer not in scope) — same failures on recent main builds. Our files compile clean with zero errors.

## Test plan
- [x] ProgressParser tests: basic parsing, non-progress ignored, type-only, multiple events, integration with ChildProcess
- [x] Naming audit passes
- [ ] CI: our files compile clean; pre-existing test_signal.cpp failure on all branches