### PR TITLE
Add package manager README and removal guide

### DIFF
--- a/docs/guides/packages/README.md
+++ b/docs/guides/packages/README.md
@@ -1,0 +1,305 @@
+# Pulp Package Manager
+
+The Pulp package manager makes it easy to add vetted, license-compatible third-party audio libraries to a Pulp project. It handles discovery, fetching, CMake wiring, license checking, and platform compatibility -- so you can focus on building your plugin.
+
+**Status:** This is an evolving feature on the `develop/package-manager` branch. It is functional but still being refined. See the [Phase Roadmap](#phase-roadmap) at the bottom of this document.
+
+**Isolation guarantee:** The package manager is fully self-contained and removable. No core subsystem depends on it. No example project requires it. No format adapter references it. If you want to remove it entirely, see [REMOVAL.md](REMOVAL.md).
+
+---
+
+## What It Is
+
+Pulp's built-in `core/signal/` subsystem ships 30+ DSP processors (filters, delay, reverb, compressor, oscillators, FFT, and more). The package manager extends a project with capabilities beyond what ships natively -- pitch detection, time-stretching, sample rate conversion, neural network inference, physical modeling, and audio file decoding.
+
+It is not a general-purpose package manager. It is a curated registry of audio-focused libraries that have been evaluated for license compatibility (MIT/BSD/Apache only), platform support, and integration quality with Pulp's CMake build system.
+
+### Design Principles
+
+1. **Pulp is complete without packages.** Every example works without `pulp add`. The getting-started guide never mentions it. `core/signal/` is the primary DSP offering.
+2. **Fully optional, never imposed.** Developers who prefer manual CMake wiring can still use `FetchContent_Declare(...)` directly. The package manager does not own `external/` or prevent manual additions.
+3. **No API abstraction layer.** The package manager handles plumbing (discovery, fetch, license check, CMake wiring). It does not unify library APIs behind abstract interfaces.
+4. **Curation over breadth.** 10-100 tested, license-compatible audio packages is better than thousands of untested general-purpose ones.
+
+---
+
+## Architecture Overview
+
+### Registry
+
+The package registry lives at `tools/packages/registry.json`. It is a JSON file (v2 format) validated by `tools/packages/registry-schema.json`. Each package entry includes:
+
+- **Metadata**: name, version, description, license, category, URL
+- **Fetch info**: git repository, tag, method (FetchContent, header-only, or vendored)
+- **CMake info**: target names, header-only flag, include directory
+- **Platform support**: per-platform architecture lists with optional notes
+- **Audio-specific fields**: `rt_safe` flag, `provides` capabilities, `overlaps_with_builtin` mapping, `unique_value` description, `alternatives`, `migration_notes`
+- **Verification**: last verified date, build status per platform-arch pair
+
+The registry currently contains 10 packages across 4 categories:
+
+| Category | Packages |
+|----------|----------|
+| DSP | signalsmith-stretch, signalsmith-dsp, cycfi-q, pffft, daisysp |
+| Audio I/O | dr-libs, libsamplerate, r8brain-free-src |
+| ML | rtneural |
+| UI | fontaudio |
+
+### Lock File
+
+When you `pulp add` a package, the resolved version, git URL, integrity hash, and commit are recorded in `packages.lock.json` at the project root. The lock file schema is defined in `tools/packages/packages.lock.schema.json`.
+
+### CMake Generation
+
+`pulp add` generates `cmake/pulp-packages.cmake` in the project root. This file contains `FetchContent_Declare` / `FetchContent_MakeAvailable` calls for each added package. Your project's `CMakeLists.txt` includes this file, and packages are linked via `target_link_libraries`.
+
+For header-only packages, the generated CMake uses `target_include_directories` after fetching.
+
+### CLI Commands
+
+| Command | What It Does |
+|---------|-------------|
+| `pulp add <package>` | Add a package: license check, platform check, CMake wiring, metadata updates |
+| `pulp remove <package>` | Remove a package: clean lock file, CMake, and metadata |
+| `pulp list` | Show installed packages (human-readable or `--json`) |
+| `pulp search <query>` | Search registry by name, tags, description, or category |
+| `pulp update` | Check for and apply package updates |
+| `pulp suggest` | Context-aware package recommendations |
+| `pulp target` | Manage project platform targets in `pulp.toml` |
+| `pulp audit --packages` | Verify lock file integrity |
+| `pulp audit --platforms` | Check package/platform coverage |
+| `pulp audit --licenses` | Verify license compatibility |
+
+---
+
+## Quick Start
+
+### Add a package
+
+```bash
+pulp add signalsmith-stretch
+```
+
+This will:
+1. Check the license is compatible with Pulp's MIT license (reject GPL/LGPL/copyleft)
+2. Check platform support against your project's declared targets
+3. Warn if the package overlaps with Pulp built-in processors
+4. Generate or update `cmake/pulp-packages.cmake` with FetchContent declarations
+5. Update `packages.lock.json`, `DEPENDENCIES.md`, and `NOTICE.md`
+6. Print usage instructions (which target to link and which headers to include)
+
+### Search for packages
+
+```bash
+pulp search "pitch detection"
+pulp search dsp
+pulp search fft --format json
+```
+
+### Get recommendations
+
+```bash
+pulp suggest --description "I need pitch shifting"
+pulp suggest --analyze src/my_processor.cpp
+pulp suggest --alternative pffft
+```
+
+### List installed packages
+
+```bash
+pulp list
+pulp list --json
+```
+
+### Remove a package
+
+```bash
+pulp remove signalsmith-stretch
+```
+
+### Check for updates
+
+```bash
+pulp update            # dry-run: show available updates
+pulp update --apply    # apply updates and regenerate CMake
+```
+
+### Manage platform targets
+
+```bash
+pulp target list                  # show current targets
+pulp target add Windows-arm64     # add a target
+pulp target remove Linux-x64     # remove a target
+```
+
+Default targets (if none configured): `macOS-arm64`, `Windows-x64`, `Linux-x64`.
+
+---
+
+## What Files It Creates in a Project
+
+When you use the package manager, these files are created or modified in your project:
+
+| File | Created By | Purpose |
+|------|-----------|---------|
+| `cmake/pulp-packages.cmake` | `pulp add` | FetchContent declarations for all added packages |
+| `packages.lock.json` | `pulp add` | Exact resolved versions and integrity hashes |
+| `pulp.toml` (targets section) | `pulp target` | Platform targets for compatibility checking |
+| `DEPENDENCIES.md` entries | `pulp add` | New rows in the dependency table |
+| `NOTICE.md` entries | `pulp add` | Attribution entries for added packages |
+
+All of these are cleaned up by `pulp remove` when the last package is removed.
+
+---
+
+## Integration Points
+
+### CLI Integration
+
+The package manager adds seven top-level commands (`add`, `remove`, `list`, `search`, `update`, `suggest`, `target`) and three audit flags (`--packages`, `--platforms`, `--licenses`) to the `pulp` CLI. These are dispatched from `tools/cli/pulp_cli.cpp` and implemented in `tools/cli/package_commands.cpp` and `tools/cli/package_registry.cpp`.
+
+### Doctor Integration
+
+`pulp doctor` includes two package-related health checks:
+
+- **Package lock file**: checks if `packages.lock.json` exists and is consistent with the registry
+- **Package platform alignment**: checks that all installed packages support all project targets
+
+These checks pass silently when no packages are installed.
+
+### Claude Code Plugin / Agent Skill
+
+The `.agents/skills/packages/SKILL.md` skill teaches Claude Code and Codex agents how to use the package manager. It covers:
+
+- Package discovery and search
+- Category awareness (what each category provides)
+- Overlap detection (checking built-ins before suggesting packages)
+- License policy enforcement
+- The `pulp add` / `pulp search` / `pulp suggest` commands
+
+### CI Integration
+
+`.github/workflows/freshness-check.yml` runs weekly (Monday 06:00 UTC) to check package versions against upstream GitHub repos. It detects:
+
+- Newer versions available
+- Archived repositories
+- License changes
+
+A Tier 2 mode (manual trigger) runs full build validation with CMake stub projects for each package across macOS, Ubuntu, and Windows.
+
+---
+
+## How the Remote Registry Works
+
+The package registry supports both local and remote modes:
+
+- **Local registry**: `tools/packages/registry.json` in the Pulp repo. This is the source of truth for the curated package list.
+- **Remote registry**: Hosted at `https://raw.githubusercontent.com/danielraffel/pulp-packages/main/registry.json` (the `pulp-packages` public repo). `pulp search` can query this remote registry, with results cached locally with a configurable TTL (default: 24 hours).
+- **Cache management**: Remote registry data is cached in the default cache directory. Use `pulp search --refresh` to force a cache refresh.
+
+The remote registry follows the same v2 schema as the local registry. Package submissions to the remote registry go through PR review with automated validation (license, schema, build).
+
+---
+
+## How License Checking Works
+
+Every `pulp add` checks the package's SPDX license identifier against a policy:
+
+| Verdict | Licenses | Behavior |
+|---------|----------|----------|
+| **Allowed** | MIT, MIT-0, BSD-2-Clause, BSD-3-Clause, Apache-2.0, ISC, zlib, BSL-1.0, Unlicense, CC0-1.0 | Added without prompts |
+| **Review required** | MPL-2.0, other unlisted | Warning printed, `--license-override` flag required |
+| **Rejected** | GPL-2.0, GPL-3.0, LGPL-2.1, LGPL-3.0, AGPL-3.0, SSPL-1.0 (all variants) | Blocked. Cannot add. |
+
+The `--license-override commercial` flag can bypass review-required licenses for projects with commercial license agreements, but cannot bypass rejected licenses.
+
+License checking is also available standalone via `pulp audit --licenses` and the `tools/packages/validate_registry.py` script.
+
+---
+
+## Isolation Guarantees
+
+The package manager is designed for clean removal. Here is what it touches and what it does not:
+
+### What it touches
+
+- `tools/cli/pulp_cli.cpp` -- seven command dispatch lines, two include lines, doctor check block, audit flag block
+- `tools/cli/CMakeLists.txt` -- two source files in the build list
+- `tools/cli/package_commands.{hpp,cpp}` -- command implementations (own files)
+- `tools/cli/package_registry.{hpp,cpp}` -- registry data structures (own files)
+- `tools/packages/` -- entire directory is package-manager-specific
+- `docs/guides/packages/` -- entire directory is package-manager-specific
+- `docs/reference/cli.md` -- eight CLI reference sections
+- `docs/status/cli-commands.yaml` -- seven command entries
+- `.agents/skills/packages/` -- agent skill directory
+- `.github/workflows/freshness-check.yml` -- CI workflow
+
+### What it does NOT touch
+
+- No `core/` subsystem files
+- No `examples/` files
+- No format adapters (VST3, AU, CLAP)
+- No `external/` vendored dependencies
+- No build system root `CMakeLists.txt`
+- No test harness files
+- No shipping/signing code
+- No other CLI commands (build, test, validate, doctor logic beyond the two added checks, ship, etc.)
+
+For a complete removal checklist, see [REMOVAL.md](REMOVAL.md).
+
+---
+
+## Per-Package Guides
+
+Each package has a detailed integration guide in this directory:
+
+| Package | Guide |
+|---------|-------|
+| Signalsmith Stretch | [signalsmith-stretch.md](signalsmith-stretch.md) |
+| Signalsmith DSP | [signalsmith-dsp.md](signalsmith-dsp.md) |
+| Q (Cycfi) | [cycfi-q.md](cycfi-q.md) |
+| PFFFT | [pffft.md](pffft.md) |
+| DaisySP | [daisysp.md](daisysp.md) |
+| dr_libs | [dr-libs.md](dr-libs.md) |
+| libsamplerate | [libsamplerate.md](libsamplerate.md) |
+| r8brain-free-src | [r8brain-free-src.md](r8brain-free-src.md) |
+| RTNeural | [rtneural.md](rtneural.md) |
+| fontaudio | [fontaudio.md](fontaudio.md) |
+
+See also [index.md](index.md) for a categorized overview.
+
+---
+
+## Phase Roadmap
+
+The package manager is being built in phases. Each phase is self-contained and lands via PR to `develop/package-manager`, then merges to `main` at phase boundaries.
+
+### Phase 1: Integration Guides + Registry
+
+Registry format design, initial 10-package registry, per-package integration guides, JSON schema validation, Tier 1 freshness CI workflow, manual build verification across macOS/Windows/Linux.
+
+**Status:** Complete on `develop/package-manager`.
+
+### Phase 2: CLI + Claude Plugin Integration
+
+`pulp add/remove/list/search/update/suggest/target` commands, license checking, platform compatibility analysis, overlap detection, CMake generation, lock file management, `pulp doctor` checks, `pulp audit` extensions, Claude Code skill, Tier 2 build validation CI.
+
+**Status:** Complete on `develop/package-manager`.
+
+### Phase 3: Community Registry + Web Discovery
+
+`pulp-packages` public repo, community submission workflow, remote registry search with local caching, semver constraint resolution, static site generator for package browsing, quality scores, verification badges.
+
+**Status:** Partially implemented on `develop/package-manager` (remote search, semver, quality scores are in; web UI and community submission workflow are not yet started).
+
+### Phase 4: Extended Ecosystem
+
+LAION CLAP, UV/Python integration, yt-dlp/pydub, and other extended ecosystem packages.
+
+**Status:** Deferred. Revisit after Phases 1-3 prove the concept and there is user demand.
+
+### Phase 5: Future
+
+Dependency resolution (transitive dependencies), version conflict detection, workspace-level package management, package authoring tools.
+
+**Status:** Not planned. These would only be needed if the package count grows significantly.

--- a/docs/guides/packages/REMOVAL.md
+++ b/docs/guides/packages/REMOVAL.md
@@ -1,0 +1,240 @@
+# Package Manager Removal Guide
+
+This document lists every file, line change, CI workflow, skill, doc reference, and external resource that would need to be removed or reverted to completely excise the package manager feature from the Pulp codebase.
+
+The package manager was designed to be self-contained and removable. No core subsystem depends on it. No example project requires it. No format adapter references it. Removing it is a mechanical process.
+
+Work through each section as a checklist.
+
+---
+
+## 1. Files to Delete
+
+### CLI source files
+
+- [ ] `tools/cli/package_commands.hpp`
+- [ ] `tools/cli/package_commands.cpp`
+- [ ] `tools/cli/package_registry.hpp`
+- [ ] `tools/cli/package_registry.cpp`
+
+### Registry and tooling
+
+- [ ] `tools/packages/registry.json`
+- [ ] `tools/packages/registry-schema.json`
+- [ ] `tools/packages/packages.lock.schema.json`
+- [ ] `tools/packages/validate_registry.py`
+- [ ] `tools/packages/freshness_check.py`
+
+### Test stubs (entire directory tree)
+
+- [ ] `tools/packages/test-stubs/cycfi-q/CMakeLists.txt`
+- [ ] `tools/packages/test-stubs/cycfi-q/main.cpp`
+- [ ] `tools/packages/test-stubs/daisysp/CMakeLists.txt`
+- [ ] `tools/packages/test-stubs/daisysp/main.cpp`
+- [ ] `tools/packages/test-stubs/dr-libs/CMakeLists.txt`
+- [ ] `tools/packages/test-stubs/dr-libs/main.cpp`
+- [ ] `tools/packages/test-stubs/fontaudio/CMakeLists.txt`
+- [ ] `tools/packages/test-stubs/fontaudio/main.cpp`
+- [ ] `tools/packages/test-stubs/libsamplerate/CMakeLists.txt`
+- [ ] `tools/packages/test-stubs/libsamplerate/main.cpp`
+- [ ] `tools/packages/test-stubs/pffft/CMakeLists.txt`
+- [ ] `tools/packages/test-stubs/pffft/main.cpp`
+- [ ] `tools/packages/test-stubs/r8brain-free-src/CMakeLists.txt`
+- [ ] `tools/packages/test-stubs/r8brain-free-src/main.cpp`
+- [ ] `tools/packages/test-stubs/rtneural/CMakeLists.txt`
+- [ ] `tools/packages/test-stubs/rtneural/main.cpp`
+- [ ] `tools/packages/test-stubs/signalsmith-dsp/CMakeLists.txt`
+- [ ] `tools/packages/test-stubs/signalsmith-dsp/main.cpp`
+- [ ] `tools/packages/test-stubs/signalsmith-stretch/CMakeLists.txt`
+- [ ] `tools/packages/test-stubs/signalsmith-stretch/main.cpp`
+
+Or simply: `rm -rf tools/packages/`
+
+### Documentation guides
+
+- [ ] `docs/guides/packages/index.md`
+- [ ] `docs/guides/packages/cycfi-q.md`
+- [ ] `docs/guides/packages/daisysp.md`
+- [ ] `docs/guides/packages/dr-libs.md`
+- [ ] `docs/guides/packages/fontaudio.md`
+- [ ] `docs/guides/packages/libsamplerate.md`
+- [ ] `docs/guides/packages/pffft.md`
+- [ ] `docs/guides/packages/r8brain-free-src.md`
+- [ ] `docs/guides/packages/rtneural.md`
+- [ ] `docs/guides/packages/signalsmith-dsp.md`
+- [ ] `docs/guides/packages/signalsmith-stretch.md`
+- [ ] `docs/guides/packages/README.md` (this feature's README)
+- [ ] `docs/guides/packages/REMOVAL.md` (this file)
+
+Or simply: `rm -rf docs/guides/packages/`
+
+### Agent skill
+
+- [ ] `.agents/skills/packages/SKILL.md`
+
+Or simply: `rm -rf .agents/skills/packages/`
+
+### Planning documents (in the `planning/` submodule)
+
+- [ ] `planning/package-manager-status.md`
+- [ ] `planning/ralph-prompt-package-manager.md`
+- [ ] `planning/research/package-manager-proposal.md`
+
+### Generated project files (per-project, not in repo)
+
+These are created by `pulp add` in user projects. Not in the repo itself, but listed for completeness:
+
+- [ ] `cmake/pulp-packages.cmake` (generated CMake declarations)
+- [ ] `packages.lock.json` (lock file in project root)
+- [ ] Any `pulp.toml` `[targets]` section entries added by `pulp target`
+
+---
+
+## 2. Lines to Revert in Shared Files
+
+### `tools/cli/pulp_cli.cpp`
+
+**Includes (lines ~31-32):** Remove these two lines:
+
+```cpp
+#include "package_commands.hpp"
+#include "package_registry.hpp"
+```
+
+**Command dispatch (lines ~4730-4736):** Remove these seven lines from the main dispatch:
+
+```cpp
+if (command == "add")      return pulp::cli::pkg::cmd_add(args);
+if (command == "remove")   return pulp::cli::pkg::cmd_remove(args);
+if (command == "list")     return pulp::cli::pkg::cmd_list(args);
+if (command == "search")   return pulp::cli::pkg::cmd_search(args);
+if (command == "update")   return pulp::cli::pkg::cmd_update(args);
+if (command == "suggest")  return pulp::cli::pkg::cmd_suggest(args);
+if (command == "target")   return pulp::cli::pkg::cmd_target(args);
+```
+
+**Audit command extensions (lines ~4752-4771):** Remove the package-manager-specific audit flag handling block. This is the section that checks for `--packages`, `--platforms`, and `--licenses` flags and calls `pulp::cli::pkg::audit_*` functions. Leave the existing Python audit fallthrough intact.
+
+```cpp
+// Check for package-manager-specific flags
+bool pkg_flag = false, plat_flag = false, lic_flag = false;
+for (auto& a : args) {
+    if (a == "--packages") pkg_flag = true;
+    if (a == "--platforms") plat_flag = true;
+    if (a == "--licenses") lic_flag = true;
+}
+if (pkg_flag || plat_flag || lic_flag) {
+    auto root = find_project_root();
+    if (root.empty()) {
+        std::cerr << "Error: not in a Pulp project directory\n";
+        return 1;
+    }
+    int rc = 0;
+    if (pkg_flag) rc |= pulp::cli::pkg::audit_packages(root);
+    if (plat_flag) rc |= pulp::cli::pkg::audit_platforms(root);
+    if (lic_flag) rc |= pulp::cli::pkg::audit_licenses(root);
+    return rc;
+}
+```
+
+**Doctor checks (lines ~2330-2380):** Remove the "Package health checks" section that checks `packages.lock.json` and `registry.json`, including:
+- The "Package lock file" DoctorCheck block (~lines 2331-2358)
+- The "Package platform alignment" DoctorCheck block (~lines 2360-2380)
+
+### `tools/cli/CMakeLists.txt`
+
+**Source list (line ~3):** Remove `package_registry.cpp` and `package_commands.cpp` from the source file list:
+
+```
+package_registry.cpp package_commands.cpp
+```
+
+---
+
+## 3. CLI Docs Entries to Remove
+
+### `docs/reference/cli.md`
+
+Remove these sections entirely (lines ~685-783):
+
+- [ ] `### add` section (lines ~685-698)
+- [ ] `### remove` section (lines ~700-710)
+- [ ] `### list` section (lines ~712-721)
+- [ ] `### search` section (lines ~723-733)
+- [ ] `### update` section (lines ~737-744)
+- [ ] `### suggest` section (lines ~747-757)
+- [ ] `### target` section (lines ~759-770)
+- [ ] `### audit (package extensions)` section (lines ~772-783)
+
+### `docs/status/cli-commands.yaml`
+
+Remove these command entries:
+
+- [ ] `add` entry (lines ~388-405) -- the package add command, not to be confused with `add-component`
+- [ ] `remove` entry (lines ~407-415)
+- [ ] `list` entry (lines ~417-424)
+- [ ] `search` entry (lines ~426-437) -- the package search command, not `docs search`
+- [ ] `update` entry (lines ~439-446)
+- [ ] `suggest` entry (lines ~448-464)
+- [ ] `target` entry (lines ~466-478)
+
+---
+
+## 4. CI Workflows to Delete
+
+- [ ] `.github/workflows/freshness-check.yml` -- weekly package freshness check against upstream GitHub repos
+
+---
+
+## 5. Skills to Remove
+
+- [ ] `.agents/skills/packages/SKILL.md` -- the Claude/Codex package discovery and recommendation skill
+
+If this is the only file in the directory, remove the entire `.agents/skills/packages/` directory.
+
+Also check and update:
+
+- [ ] `CLAUDE.md` -- if the skills table was updated to include `packages`, remove that row. (As of this writing, the `packages` skill is not listed in the CLAUDE.md skills table on this branch.)
+
+---
+
+## 6. External Repos to Archive
+
+- [ ] `pulp-packages` GitHub repo (referenced in `package_registry.hpp` as the remote registry URL: `https://raw.githubusercontent.com/danielraffel/pulp-packages/main/registry.json`). Archive or delete this repo if it was created.
+
+---
+
+## 7. Branch Cleanup
+
+- [ ] Delete `develop/package-manager` branch (local and remote)
+- [ ] Delete any `feature/pkg-*` branches (e.g., `feature/pkg-prerequisites`, `feature/pkg-registry`, `feature/pkg-cli`, `feature/pkg-community`)
+- [ ] Remove any worktrees associated with these branches
+
+---
+
+## 8. Verification After Removal
+
+After completing all the above steps:
+
+1. [ ] `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` -- configure succeeds
+2. [ ] `cmake --build build -j$(sysctl -n hw.ncpu)` -- build succeeds with no missing includes or undefined symbols
+3. [ ] `ctest --test-dir build --output-on-failure` -- all tests pass
+4. [ ] `./build/tools/cli/pulp doctor` -- no package-related checks appear
+5. [ ] `./build/tools/cli/pulp help` -- no `add`, `remove`, `list`, `search`, `update`, `suggest`, `target` commands shown
+6. [ ] `python3 tools/deps/audit.py --strict` -- no references to package registry files
+7. [ ] `grep -r "package_commands\|package_registry\|pulp::cli::pkg" tools/cli/` -- no results
+
+---
+
+## What is NOT Affected by Removal
+
+The following are **not** part of the package manager and should be left intact:
+
+- `ship package` (`pulp ship package`) -- creates `.pkg` installers for plugin distribution. This is part of the shipping subsystem, completely unrelated.
+- `core/format/registry.hpp` / `core/format/src/registry.cpp` -- plugin format registry (VST3/AU/CLAP). Unrelated.
+- `core/audio/include/pulp/audio/format_registry.hpp` / `core/audio/src/format_registry.cpp` -- audio format codec registry. Unrelated.
+- `core/platform/include/pulp/platform/win/registry.hpp` / `core/platform/src/registry.cpp` -- Windows registry access. Unrelated.
+- `tools/audio/include/pulp/tools/audio/model_registry.hpp` / `tools/audio/src/model_registry.cpp` -- ML model registry for audio tools. Unrelated.
+- `tools/components/registry.yaml` -- UI component registry. Unrelated.
+- `apple/Package.swift` -- Swift Package Manager manifest. Unrelated.
+- `DEPENDENCIES.md` and `NOTICE.md` -- these may have entries added by `pulp add`, but the files themselves predate the package manager. Only remove entries that were added by the package manager, not the files.


### PR DESCRIPTION
Moves the README and REMOVAL.md from develop/package-manager to main, where all other package manager files already live.