### PR TITLE
Migrate ship, audio, and package CLI to ChildProcess

### DIFF
--- a/core/audio/src/system_volume.cpp
+++ b/core/audio/src/system_volume.cpp
@@ -1,4 +1,5 @@
 #include <pulp/audio/system_volume.hpp>
+#include <pulp/platform/child_process.hpp>
 
 #ifdef __APPLE__
 #include <CoreAudio/CoreAudio.h>
@@ -160,24 +161,18 @@ bool set_system_muted(bool) { return false; }
 
 // Linux: use amixer (ALSA) command-line tool
 std::optional<float> get_system_volume() {
-    FILE* pipe = popen("amixer sget Master 2>/dev/null | grep -oP '\\[\\d+%\\]' | head -1 | tr -d '[]%'", "r");
-    if (!pipe) return std::nullopt;
-
-    char buf[32];
-    if (fgets(buf, sizeof(buf), pipe)) {
-        pclose(pipe);
-        int pct = std::atoi(buf);
-        return static_cast<float>(pct) / 100.0f;
-    }
-    pclose(pipe);
-    return std::nullopt;
+    auto r = pulp::platform::exec("/bin/sh", {"-c",
+        "amixer sget Master 2>/dev/null | grep -oP '\\[\\d+%\\]' | head -1 | tr -d '[]%'"}, 5000);
+    if (r.exit_code != 0 || r.stdout_output.empty()) return std::nullopt;
+    int pct = std::atoi(r.stdout_output.c_str());
+    return static_cast<float>(pct) / 100.0f;
 }
 
 bool set_system_volume(float volume) {
     int pct = static_cast<int>(volume * 100.0f);
-    char cmd[64];
-    std::snprintf(cmd, sizeof(cmd), "amixer sset Master %d%% 2>/dev/null", pct);
-    return std::system(cmd) == 0;
+    std::string cmd = "amixer sset Master " + std::to_string(pct) + "% 2>/dev/null";
+    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, 5000);
+    return r.exit_code == 0;
 }
 
 std::optional<bool> is_system_muted() { return std::nullopt; }

--- a/ship/CMakeLists.txt
+++ b/ship/CMakeLists.txt
@@ -12,6 +12,8 @@ target_sources(pulp-ship PRIVATE
     src/appcast.cpp
 )
 
+target_link_libraries(pulp-ship PUBLIC pulp::platform)
+
 if(APPLE)
     target_sources(pulp-ship PRIVATE
         platform/mac/codesign_mac.mm

--- a/ship/platform/linux/package_linux.cpp
+++ b/ship/platform/linux/package_linux.cpp
@@ -2,6 +2,7 @@
 // API surface for .deb and AppImage creation
 
 #include <pulp/ship/codesign.hpp>
+#include <pulp/platform/child_process.hpp>
 
 #if defined(__linux__)
 
@@ -11,7 +12,8 @@
 namespace pulp::ship {
 
 static int exec_status(const std::string& cmd) {
-    return WEXITSTATUS(std::system(cmd.c_str()));
+    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, 60000);
+    return r.exit_code;
 }
 
 // Linux has no code signing equivalent

--- a/ship/platform/mac/codesign_mac.mm
+++ b/ship/platform/mac/codesign_mac.mm
@@ -1,4 +1,5 @@
 #include <pulp/ship/codesign.hpp>
+#include <pulp/platform/child_process.hpp>
 
 #ifdef __APPLE__
 
@@ -15,25 +16,16 @@ namespace pulp::ship {
 namespace fs = std::filesystem;
 
 static std::string exec_cmd(const std::string& cmd) {
-    std::string result;
-    FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) return {};
-    char buf[256];
-    while (fgets(buf, sizeof(buf), pipe))
-        result += buf;
-    pclose(pipe);
+    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, 120000);
+    auto result = r.stdout_output;
     while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
         result.pop_back();
     return result;
 }
 
 static int exec_status(const std::string& cmd) {
-    int ret = system(cmd.c_str());
-    if (ret == -1)
-        return -1;
-    if (WIFEXITED(ret))
-        return WEXITSTATUS(ret);
-    return ret;
+    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, 120000);
+    return r.exit_code;
 }
 
 static std::optional<fs::path> make_temp_dir(const std::string& prefix) {

--- a/ship/platform/win/codesign_win.cpp
+++ b/ship/platform/win/codesign_win.cpp
@@ -2,6 +2,7 @@
 // Uses signtool.exe when available
 
 #include <pulp/ship/codesign.hpp>
+#include <pulp/platform/child_process.hpp>
 
 #ifdef _WIN32
 
@@ -12,20 +13,16 @@
 namespace pulp::ship {
 
 static std::string exec_cmd(const std::string& cmd) {
-    std::string result;
-    FILE* pipe = _popen(cmd.c_str(), "r");
-    if (!pipe) return {};
-    char buf[256];
-    while (fgets(buf, sizeof(buf), pipe))
-        result += buf;
-    _pclose(pipe);
+    auto r = pulp::platform::exec("cmd", {"/c", cmd}, 120000);
+    auto result = r.stdout_output;
     while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
         result.pop_back();
     return result;
 }
 
 static int exec_status(const std::string& cmd) {
-    return std::system(cmd.c_str());
+    auto r = pulp::platform::exec("cmd", {"/c", cmd}, 120000);
+    return r.exit_code;
 }
 
 SigningInfo check_codesign(const std::string& path) {

--- a/ship/platform/win/installer_win.cpp
+++ b/ship/platform/win/installer_win.cpp
@@ -1,8 +1,8 @@
 #include <pulp/ship/installer.hpp>
+#include <pulp/platform/child_process.hpp>
 
 #include <fstream>
 #include <sstream>
-#include <cstdlib>
 #include <filesystem>
 
 namespace pulp::ship {
@@ -157,8 +157,8 @@ bool create_nsis_installer(const InstallerConfig& config) {
     }
 
     // Invoke makensis
-    std::string cmd = "makensis /V2 \"" + nsi_path.string() + "\"";
-    int result = std::system(cmd.c_str());
+    auto proc_result = pulp::platform::exec("makensis", {"/V2", nsi_path.string()}, 120000);
+    int result = proc_result.exit_code;
 
     // Clean up the .nsi file
     fs::remove(nsi_path);

--- a/tools/cli/package_registry.cpp
+++ b/tools/cli/package_registry.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include "package_registry.hpp"
+#include <pulp/platform/child_process.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -534,14 +535,13 @@ fs::path default_cache_dir() {
 
 static bool download_file(const std::string& url, const fs::path& dest) {
     fs::create_directories(dest.parent_path());
-    // Use curl on macOS/Linux, PowerShell on Windows
 #ifdef _WIN32
-    std::string cmd = "powershell -Command \"Invoke-WebRequest -Uri '" + url +
-                      "' -OutFile '" + dest.string() + "'\" 2>nul";
+    auto r = pulp::platform::exec("powershell", {"-Command",
+        "Invoke-WebRequest -Uri '" + url + "' -OutFile '" + dest.string() + "'"}, 60000);
 #else
-    std::string cmd = "curl -sSfL -o '" + dest.string() + "' '" + url + "' 2>/dev/null";
+    auto r = pulp::platform::exec("curl", {"-sSfL", "-o", dest.string(), url}, 60000);
 #endif
-    return std::system(cmd.c_str()) == 0;
+    return r.exit_code == 0;
 }
 
 static bool is_cache_fresh(const fs::path& cache_file, int ttl_hours) {


### PR DESCRIPTION
Replaces remaining popen/system() in ship (codesign, packaging, installer), audio (system_volume), and package registry (download) with ChildProcess. All behavior-preserving with added timeouts.