### PR TITLE
Fix package stub CI: cycfi-q PortAudio, Windows paths

### DIFF
--- a/.github/workflows/freshness-check.yml
+++ b/.github/workflows/freshness-check.yml
@@ -85,15 +85,21 @@ jobs:
                 -B build-stub \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        shell: bash
 
       - name: Build stub
-        run: cmake --build build-stub
+        run: cmake --build build-stub --config Release
+        shell: bash
 
       - name: Run stub
         run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
+          if [ -f build-stub/Release/test-pkg.exe ]; then
             ./build-stub/Release/test-pkg.exe
-          else
+          elif [ -f build-stub/test-pkg ]; then
             ./build-stub/test-pkg
+          elif [ -f build-stub/test-pkg.exe ]; then
+            ./build-stub/test-pkg.exe
+          else
+            echo "Binary not found" && exit 1
           fi
         shell: bash

--- a/tools/packages/test-stubs/cycfi-q/CMakeLists.txt
+++ b/tools/packages/test-stubs/cycfi-q/CMakeLists.txt
@@ -9,6 +9,8 @@ FetchContent_Declare(
   GIT_TAG        version_1.0
   GIT_SHALLOW    TRUE
 )
+# Only build q_lib (pitch detection), not q_io (needs PortAudio)
+set(Q_BUILD_IO OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(q)
 
 add_executable(test-pkg main.cpp)


### PR DESCRIPTION
Fixes Tier 2 build validation failures: cycfi-q needs Q_BUILD_IO=OFF, Windows stubs need --config Release and flexible binary path detection.