### PR TITLE
Phase 4: Tool registry, UV/ffmpeg/Deno manager, model download, extended entitlements

### DIFF
--- a/ship/templates/entitlements-extended.plist
+++ b/ship/templates/entitlements-extended.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Standard audio plugin entitlements -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <!-- Extended: file access for plugins that download/process audio -->
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+</dict>
+</plist>

--- a/tools/audio/include/pulp/tools/audio/model_registry.hpp
+++ b/tools/audio/include/pulp/tools/audio/model_registry.hpp
@@ -11,10 +11,19 @@ struct RegisteredModel {
     std::string model_id;
     std::string display_name;
     std::string backend;
-    std::string checkpoint_ref;
+    std::string checkpoint_ref;       // e.g., "hf://user/repo/file.pt"
     std::vector<std::string> task_tags;
     std::uint64_t size_bytes = 0;
+
+    // Phase 4 additions
+    std::string download_url;         // Direct HTTPS URL (resolved from checkpoint_ref)
+    std::string sha256;               // Expected hash of the checkpoint file
+    bool auto_downloadable = true;    // false if manual steps required
 };
+
+/// Resolve a checkpoint_ref to a direct download URL.
+/// "hf://user/repo/file" → "https://huggingface.co/user/repo/resolve/main/file"
+std::string resolve_checkpoint_url(const std::string& checkpoint_ref);
 
 const std::vector<RegisteredModel>& registered_models();
 const RegisteredModel* find_registered_model(std::string_view model_id);

--- a/tools/audio/src/model_registry.cpp
+++ b/tools/audio/src/model_registry.cpp
@@ -10,6 +10,9 @@ const std::vector<RegisteredModel>& registered_models() {
         .checkpoint_ref = "hf://lukewys/laion_clap/music.pt",
         .task_tags = {"music", "excerpt_find"},
         .size_bytes = 2523293286ULL,
+        .download_url = "https://huggingface.co/lukewys/laion_clap/resolve/main/music.pt",
+        .sha256 = "",  // Populated after first verified download
+        .auto_downloadable = true,
     }};
     return models;
 }
@@ -19,6 +22,21 @@ const RegisteredModel* find_registered_model(std::string_view model_id) {
         if (model.model_id == model_id) return &model;
     }
     return nullptr;
+}
+
+std::string resolve_checkpoint_url(const std::string& checkpoint_ref) {
+    // Handle hf:// protocol
+    if (checkpoint_ref.starts_with("hf://")) {
+        auto path = checkpoint_ref.substr(5);  // after "hf://"
+        return "https://huggingface.co/" + path.substr(0, path.find('/')) + "/"
+             + path.substr(path.find('/') + 1, path.rfind('/') - path.find('/') - 1)
+             + "/resolve/main/"
+             + path.substr(path.rfind('/') + 1);
+    }
+    // Handle direct URLs
+    if (checkpoint_ref.starts_with("http://") || checkpoint_ref.starts_with("https://"))
+        return checkpoint_ref;
+    return {};
 }
 
 } // namespace pulp::tools::audio

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -1,6 +1,6 @@
 # pulp CLI tool
 add_executable(pulp-cli pulp_cli.cpp design_binding.cpp create_targets.cpp
-    package_registry.cpp package_commands.cpp)
+    package_registry.cpp package_commands.cpp tool_registry.cpp)
 set_target_properties(pulp-cli PROPERTIES OUTPUT_NAME "pulp")
 target_compile_features(pulp-cli PRIVATE cxx_std_20)
 target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format)

--- a/tools/cli/json_parser.hpp
+++ b/tools/cli/json_parser.hpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+// Minimal JSON parser for registry files. Handles objects, arrays,
+// strings, numbers, booleans, null. No external dependencies.
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace pulp::cli::pkg {
+
+struct JsonValue {
+    enum Type { Null, Bool, Number, String, Array, Object };
+    Type type = Null;
+    bool bool_val = false;
+    double num_val = 0;
+    std::string str_val;
+    std::vector<JsonValue> arr;
+    std::vector<std::pair<std::string, JsonValue>> obj;
+
+    const JsonValue* get(const std::string& key) const {
+        if (type != Object) return nullptr;
+        for (auto& [k, v] : obj)
+            if (k == key) return &v;
+        return nullptr;
+    }
+
+    std::string as_string() const {
+        return type == String ? str_val : std::string{};
+    }
+
+    bool as_bool() const { return type == Bool && bool_val; }
+    int as_int() const { return type == Number ? static_cast<int>(num_val) : 0; }
+
+    std::vector<std::string> as_string_array() const {
+        std::vector<std::string> r;
+        if (type == Array)
+            for (auto& v : arr)
+                if (v.type == String) r.push_back(v.str_val);
+        return r;
+    }
+};
+
+struct JsonParser {
+    const std::string& src;
+    size_t pos = 0;
+
+    void skip_ws() {
+        while (pos < src.size() && (src[pos] == ' ' || src[pos] == '\t' ||
+               src[pos] == '\n' || src[pos] == '\r'))
+            ++pos;
+    }
+
+    char peek() { skip_ws(); return pos < src.size() ? src[pos] : '\0'; }
+    char next() { skip_ws(); return pos < src.size() ? src[pos++] : '\0'; }
+
+    std::string parse_string() {
+        if (next() != '"') return {};
+        std::string r;
+        while (pos < src.size()) {
+            char c = src[pos++];
+            if (c == '"') return r;
+            if (c == '\\' && pos < src.size()) {
+                c = src[pos++];
+                switch (c) {
+                    case '"': r += '"'; break;
+                    case '\\': r += '\\'; break;
+                    case '/': r += '/'; break;
+                    case 'n': r += '\n'; break;
+                    case 'r': r += '\r'; break;
+                    case 't': r += '\t'; break;
+                    case 'u': pos += 4; r += '?'; break;
+                    default: r += c;
+                }
+            } else {
+                r += c;
+            }
+        }
+        return r;
+    }
+
+    JsonValue parse_value() {
+        char c = peek();
+        if (c == '"') return {JsonValue::String, false, 0, parse_string(), {}, {}};
+        if (c == '{') return parse_object();
+        if (c == '[') return parse_array();
+        if (c == 't' || c == 'f') {
+            bool val = (c == 't');
+            pos += val ? 4 : 5;
+            return {JsonValue::Bool, val, 0, {}, {}, {}};
+        }
+        if (c == 'n') { pos += 4; return {}; }
+        size_t start = pos;
+        skip_ws(); start = pos;
+        while (pos < src.size() && (src[pos] >= '0' && src[pos] <= '9' ||
+               src[pos] == '-' || src[pos] == '+' || src[pos] == '.' ||
+               src[pos] == 'e' || src[pos] == 'E'))
+            ++pos;
+        double val = 0;
+        try { val = std::stod(src.substr(start, pos - start)); } catch (...) {}
+        return {JsonValue::Number, false, val, {}, {}, {}};
+    }
+
+    JsonValue parse_object() {
+        JsonValue r; r.type = JsonValue::Object;
+        next();
+        if (peek() == '}') { next(); return r; }
+        while (true) {
+            auto key = parse_string();
+            next();
+            auto val = parse_value();
+            r.obj.push_back({key, val});
+            if (peek() == '}') { next(); return r; }
+            next();
+        }
+    }
+
+    JsonValue parse_array() {
+        JsonValue r; r.type = JsonValue::Array;
+        next();
+        if (peek() == ']') { next(); return r; }
+        while (true) {
+            r.arr.push_back(parse_value());
+            if (peek() == ']') { next(); return r; }
+            next();
+        }
+    }
+
+    JsonValue parse() { return parse_value(); }
+};
+
+}  // namespace pulp::cli::pkg

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -30,6 +30,7 @@
 #include "create_targets.hpp"
 #include "package_commands.hpp"
 #include "package_registry.hpp"
+#include "tool_registry.hpp"
 #include "design_binding.hpp"
 #include <pulp/ship/installer.hpp>
 #include <pulp/view/screenshot.hpp>
@@ -4734,6 +4735,7 @@ int main(int argc, char* argv[]) {
     if (command == "update")   return pulp::cli::pkg::cmd_update(args);
     if (command == "suggest")  return pulp::cli::pkg::cmd_suggest(args);
     if (command == "target")   return pulp::cli::pkg::cmd_target(args);
+    if (command == "tool")     return pulp::cli::tools::cmd_tool(args);
     if (command == "add-component") {
         auto root = find_project_root();
         if (root.empty()) {

--- a/tools/cli/tool_registry.cpp
+++ b/tools/cli/tool_registry.cpp
@@ -1,0 +1,670 @@
+// SPDX-License-Identifier: MIT
+#include "tool_registry.hpp"
+#include "json_parser.hpp"
+#include <pulp/platform/child_process.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+namespace pulp::cli::tools {
+
+// ── Colors ──
+
+static std::string green(const std::string& s) { return "\033[32m" + s + "\033[0m"; }
+static std::string red(const std::string& s) { return "\033[31m" + s + "\033[0m"; }
+static std::string yellow(const std::string& s) { return "\033[33m" + s + "\033[0m"; }
+static std::string dim(const std::string& s) { return "\033[2m" + s + "\033[0m"; }
+
+static void print_ok(const std::string& msg) { std::cout << green("✓") << " " << msg << "\n"; }
+static void print_fail(const std::string& msg) { std::cerr << red("✗") << " " << msg << "\n"; }
+static void print_warn(const std::string& msg) { std::cout << yellow("⚠") << " " << msg << "\n"; }
+
+// ── File Helpers ──
+
+static std::string read_file(const fs::path& path) {
+    std::ifstream f(path);
+    if (!f) return {};
+    return {std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>()};
+}
+
+static bool write_file(const fs::path& path, const std::string& content) {
+    fs::create_directories(path.parent_path());
+    std::ofstream f(path);
+    if (!f) return false;
+    f << content;
+    return f.good();
+}
+
+// ── Pulp Home ──
+
+fs::path pulp_home() {
+    if (auto env = std::getenv("PULP_HOME")) return env;
+#ifdef __APPLE__
+    if (auto home = std::getenv("HOME")) return fs::path(home) / ".pulp";
+#elif defined(_WIN32)
+    if (auto appdata = std::getenv("LOCALAPPDATA")) return fs::path(appdata) / "Pulp";
+#else
+    if (auto home = std::getenv("HOME")) return fs::path(home) / ".pulp";
+#endif
+    return fs::temp_directory_path() / "pulp";
+}
+
+fs::path tools_dir() { return pulp_home() / "tools"; }
+
+// ── Platform Detection ──
+
+std::string current_platform_key() {
+#if defined(__APPLE__)
+#if defined(__aarch64__)
+    return "macOS-arm64";
+#else
+    return "macOS-x64";
+#endif
+#elif defined(_WIN32)
+#if defined(_M_ARM64)
+    return "Windows-arm64";
+#else
+    return "Windows-x64";
+#endif
+#elif defined(__linux__)
+#if defined(__aarch64__)
+    return "Linux-arm64";
+#else
+    return "Linux-x64";
+#endif
+#else
+    return "unknown";
+#endif
+}
+
+// ── Registry Loading ──
+
+using pulp::cli::pkg::JsonParser;
+using pulp::cli::pkg::JsonValue;
+
+ToolRegistryLoadResult load_tool_registry(const fs::path& path) {
+    ToolRegistryLoadResult result;
+    auto content = read_file(path);
+    if (content.empty()) {
+        result.error = "Cannot read tool registry: " + path.string();
+        return result;
+    }
+
+    JsonParser parser{content};
+    auto root = parser.parse();
+    if (root.type != JsonValue::Object) {
+        result.error = "Tool registry is not a valid JSON object";
+        return result;
+    }
+
+    if (auto v = root.get("schema_version"))
+        result.registry.schema_version = v->as_int();
+
+    if (auto tools = root.get("tools"); tools && tools->type == JsonValue::Object) {
+        for (auto& [id, val] : tools->obj) {
+            ToolDescriptor tool;
+            tool.id = id;
+            if (auto v = val.get("display_name")) tool.display_name = v->as_string();
+            if (auto v = val.get("category")) tool.category = v->as_string();
+            if (auto v = val.get("description")) tool.description = v->as_string();
+            if (auto v = val.get("license")) tool.license = v->as_string();
+            if (auto v = val.get("install_method")) tool.install_method = v->as_string();
+            if (auto v = val.get("pip_package")) tool.pip_package = v->as_string();
+            if (auto v = val.get("pinned_version")) tool.pinned_version = v->as_string();
+            if (auto v = val.get("requires_tools")) tool.requires_tools = v->as_string_array();
+            if (auto v = val.get("managed_by_pulp")) tool.managed_by_pulp = v->as_bool();
+            if (auto v = val.get("bundleable")) tool.bundleable = v->as_bool();
+
+            if (auto bs = val.get("binary_sources"); bs && bs->type == JsonValue::Object) {
+                for (auto& [platform, src] : bs->obj) {
+                    BinarySource s;
+                    if (auto v = src.get("url_template")) s.url_template = v->as_string();
+                    if (auto v = src.get("archive_format")) s.archive_format = v->as_string();
+                    if (auto v = src.get("binary_name")) s.binary_name = v->as_string();
+                    tool.binary_sources[platform] = s;
+                }
+            }
+
+            result.registry.tools[id] = tool;
+        }
+    }
+
+    return result;
+}
+
+// ── URL Template Expansion ──
+
+static std::string expand_url(const std::string& tmpl, const std::string& version) {
+    std::string url = tmpl;
+    auto pos = url.find("${version}");
+    if (pos != std::string::npos)
+        url.replace(pos, 10, version);
+    return url;
+}
+
+// ── Archive Extraction ──
+
+bool extract_archive(const fs::path& archive, const fs::path& dest,
+                     const std::string& format) {
+    fs::create_directories(dest);
+    std::string cmd;
+
+#ifdef _WIN32
+    if (format == "zip") {
+        cmd = "powershell -Command \"Expand-Archive -Force -Path '"
+              + archive.string() + "' -DestinationPath '" + dest.string() + "'\"";
+    } else if (format == "tar.gz" || format == "tar.xz") {
+        cmd = "tar xf \"" + archive.string() + "\" -C \"" + dest.string() + "\"";
+    }
+    auto r = pulp::platform::exec("cmd", {"/c", cmd}, 120000);
+#else
+    if (format == "zip") {
+        cmd = "unzip -o -q '" + archive.string() + "' -d '" + dest.string() + "'";
+    } else if (format == "tar.gz") {
+        cmd = "tar xzf '" + archive.string() + "' -C '" + dest.string() + "'";
+    } else if (format == "tar.xz") {
+        cmd = "tar xJf '" + archive.string() + "' -C '" + dest.string() + "'";
+    }
+    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, 120000);
+#endif
+
+    return r.exit_code == 0;
+}
+
+// ── Tool Location ──
+
+ToolLocateResult locate_tool(const ToolDescriptor& tool) {
+    ToolLocateResult result;
+
+    // Check pulp-managed location first
+    auto managed_dir = tools_dir() / tool.id;
+    if (fs::exists(managed_dir)) {
+        // Find the binary in the managed directory tree
+        auto platform = current_platform_key();
+        auto it = tool.binary_sources.find(platform);
+        std::string binary_name = tool.id;
+        if (it != tool.binary_sources.end())
+            binary_name = it->second.binary_name;
+
+        // Search recursively for the binary
+        for (auto& entry : fs::recursive_directory_iterator(managed_dir)) {
+            if (entry.path().filename() == binary_name) {
+                result.found = true;
+                result.path = entry.path();
+                result.source = "pulp-managed";
+                return result;
+            }
+        }
+    }
+
+    // Check for python_pip tools
+    if (tool.install_method == "python_pip") {
+        auto venv_dir = tools_dir() / "python-envs" / tool.id;
+#ifdef _WIN32
+        auto wrapper = venv_dir / "run.bat";
+#else
+        auto wrapper = venv_dir / "run.sh";
+#endif
+        if (fs::exists(wrapper)) {
+            result.found = true;
+            result.path = wrapper;
+            result.source = "pulp-managed";
+            return result;
+        }
+    }
+
+    // Fall back to system PATH
+    auto sys_path = pulp::platform::find_on_path(tool.id);
+    if (sys_path) {
+        result.found = true;
+        result.path = *sys_path;
+        result.source = "system-path";
+        return result;
+    }
+
+    result.source = "not-found";
+    return result;
+}
+
+// ── Binary Tool Install ──
+
+ToolInstallResult install_binary_tool(const ToolDescriptor& tool, bool force) {
+    ToolInstallResult result;
+
+    if (!force) {
+        auto existing = locate_tool(tool);
+        if (existing.found && existing.source == "pulp-managed") {
+            result.ok = true;
+            result.binary_path = existing.path;
+            result.installed_version = tool.pinned_version;
+            return result;
+        }
+    }
+
+    auto platform = current_platform_key();
+    auto it = tool.binary_sources.find(platform);
+    if (it == tool.binary_sources.end()) {
+        result.error = tool.display_name + " is not available for " + platform;
+        return result;
+    }
+
+    auto& source = it->second;
+    auto url = expand_url(source.url_template, tool.pinned_version);
+    auto download_dir = tools_dir() / ".downloads";
+    fs::create_directories(download_dir);
+
+    // Determine download filename
+    std::string ext = source.archive_format == "zip" ? ".zip" :
+                      source.archive_format == "tar.gz" ? ".tar.gz" : ".tar.xz";
+    auto archive_path = download_dir / (tool.id + "-" + tool.pinned_version + ext);
+
+    // Download
+    std::cout << "  Downloading " << tool.display_name << " " << tool.pinned_version << "...\n";
+#ifdef _WIN32
+    auto dl = pulp::platform::exec("powershell", {"-Command",
+        "Invoke-WebRequest -Uri '" + url + "' -OutFile '" + archive_path.string() + "'"}, 300000);
+#else
+    auto dl = pulp::platform::exec("curl", {"-sSfL", "-o", archive_path.string(), url}, 300000);
+#endif
+
+    if (dl.exit_code != 0) {
+        result.error = "Download failed: " + url;
+        return result;
+    }
+
+    // Extract
+    auto extract_dir = download_dir / (tool.id + "-extract");
+    fs::remove_all(extract_dir);
+    if (!extract_archive(archive_path, extract_dir, source.archive_format)) {
+        result.error = "Failed to extract " + archive_path.string();
+        return result;
+    }
+
+    // Find the binary in extracted contents
+    fs::path binary_path;
+    for (auto& entry : fs::recursive_directory_iterator(extract_dir)) {
+        if (entry.path().filename() == source.binary_name) {
+            binary_path = entry.path();
+            break;
+        }
+    }
+
+    if (binary_path.empty()) {
+        result.error = "Binary '" + source.binary_name + "' not found in archive";
+        return result;
+    }
+
+    // Install to managed directory
+    auto install_dir = tools_dir() / tool.id / tool.pinned_version;
+    fs::create_directories(install_dir);
+    auto dest_path = install_dir / source.binary_name;
+    fs::copy_file(binary_path, dest_path, fs::copy_options::overwrite_existing);
+
+#ifndef _WIN32
+    // Make executable
+    fs::permissions(dest_path, fs::perms::owner_exec | fs::perms::group_exec | fs::perms::others_exec,
+                    fs::perm_options::add);
+    // Remove quarantine on macOS
+    pulp::platform::exec("xattr", {"-d", "com.apple.quarantine", dest_path.string()}, 5000);
+#endif
+
+    // Write manifest
+    std::ostringstream manifest;
+    manifest << "{\n"
+             << "  \"tool_id\": \"" << tool.id << "\",\n"
+             << "  \"version\": \"" << tool.pinned_version << "\",\n"
+             << "  \"platform\": \"" << platform << "\",\n"
+             << "  \"binary_path\": \"" << dest_path.string() << "\"\n"
+             << "}\n";
+    write_file(install_dir / "manifest.json", manifest.str());
+
+    // Cleanup
+    fs::remove_all(extract_dir);
+    fs::remove(archive_path);
+
+    result.ok = true;
+    result.binary_path = dest_path;
+    result.installed_version = tool.pinned_version;
+    return result;
+}
+
+// ── Python Tool Install ──
+
+ToolInstallResult install_python_tool(const ToolDescriptor& tool,
+                                       const ToolRegistry& registry,
+                                       bool force) {
+    ToolInstallResult result;
+
+    // Ensure UV is installed first
+    auto uv_it = registry.tools.find("uv");
+    if (uv_it == registry.tools.end()) {
+        result.error = "UV not found in tool registry";
+        return result;
+    }
+
+    auto uv_loc = locate_tool(uv_it->second);
+    if (!uv_loc.found) {
+        std::cout << "  Installing UV (required for Python tools)...\n";
+        auto uv_result = install_binary_tool(uv_it->second);
+        if (!uv_result.ok) {
+            result.error = "Failed to install UV: " + uv_result.error;
+            return result;
+        }
+        uv_loc.path = uv_result.binary_path;
+    }
+
+    auto venv_dir = tools_dir() / "python-envs" / tool.id;
+    auto venv_path = venv_dir / ".venv";
+
+    if (!force && fs::exists(venv_path)) {
+        // Already installed
+#ifdef _WIN32
+        result.binary_path = venv_dir / "run.bat";
+#else
+        result.binary_path = venv_dir / "run.sh";
+#endif
+        result.ok = fs::exists(result.binary_path);
+        result.installed_version = tool.pinned_version;
+        return result;
+    }
+
+    // Create venv
+    fs::create_directories(venv_dir);
+    std::cout << "  Creating Python environment for " << tool.display_name << "...\n";
+    auto venv_result = pulp::platform::exec(
+        uv_loc.path.string(), {"venv", venv_path.string(), "--python", "3.12"}, 120000);
+
+    if (venv_result.exit_code != 0) {
+        result.error = "Failed to create venv: " + venv_result.stderr_output;
+        return result;
+    }
+
+    // Install pip package
+    std::string pip_spec = tool.pip_package + "==" + tool.pinned_version;
+    std::cout << "  Installing " << pip_spec << "...\n";
+
+#ifdef _WIN32
+    auto python_path = (venv_path / "Scripts" / "python.exe").string();
+#else
+    auto python_path = (venv_path / "bin" / "python").string();
+#endif
+
+    auto pip_result = pulp::platform::exec(
+        uv_loc.path.string(),
+        {"pip", "install", "--python", python_path, pip_spec}, 300000);
+
+    if (pip_result.exit_code != 0) {
+        result.error = "Failed to install " + tool.pip_package + ": " + pip_result.stderr_output;
+        return result;
+    }
+
+    // Create wrapper script
+#ifdef _WIN32
+    auto wrapper_path = venv_dir / "run.bat";
+    std::string wrapper = "@echo off\n\"" + python_path + "\" -m "
+                        + tool.pip_package + " %*\n";
+#else
+    auto wrapper_path = venv_dir / "run.sh";
+    std::string wrapper = "#!/bin/sh\nexec '" + python_path + "' -m "
+                        + tool.pip_package + " \"$@\"\n";
+#endif
+
+    write_file(wrapper_path, wrapper);
+#ifndef _WIN32
+    fs::permissions(wrapper_path, fs::perms::owner_exec | fs::perms::group_exec,
+                    fs::perm_options::add);
+#endif
+
+    // Write manifest
+    std::ostringstream manifest;
+    manifest << "{\n"
+             << "  \"tool_id\": \"" << tool.id << "\",\n"
+             << "  \"version\": \"" << tool.pinned_version << "\",\n"
+             << "  \"method\": \"python_pip\",\n"
+             << "  \"pip_package\": \"" << tool.pip_package << "\",\n"
+             << "  \"venv_path\": \"" << venv_path.string() << "\"\n"
+             << "}\n";
+    write_file(venv_dir / "manifest.json", manifest.str());
+
+    result.ok = true;
+    result.binary_path = wrapper_path;
+    result.installed_version = tool.pinned_version;
+    return result;
+}
+
+// ── Uninstall ──
+
+bool uninstall_tool(const std::string& tool_id) {
+    auto dir = tools_dir() / tool_id;
+    if (fs::exists(dir)) {
+        fs::remove_all(dir);
+        return true;
+    }
+    auto venv_dir = tools_dir() / "python-envs" / tool_id;
+    if (fs::exists(venv_dir)) {
+        fs::remove_all(venv_dir);
+        return true;
+    }
+    return false;
+}
+
+// ── CLI Command: pulp tool ──
+
+static fs::path find_tool_registry() {
+    auto cwd = fs::current_path();
+    while (true) {
+        auto p = cwd / "tools" / "packages" / "tool-registry.json";
+        if (fs::exists(p)) return p;
+        if (cwd.has_parent_path() && cwd.parent_path() != cwd)
+            cwd = cwd.parent_path();
+        else break;
+    }
+    return {};
+}
+
+int cmd_tool(const std::vector<std::string>& args) {
+    if (args.empty()) {
+        std::cout << "Usage: pulp tool <command> [options]\n\n"
+                  << "Commands:\n"
+                  << "  list                    Show available and installed tools\n"
+                  << "  install <tool>          Download and install a tool\n"
+                  << "  install --all           Install all tools for current platform\n"
+                  << "  uninstall <tool>        Remove a pulp-managed tool\n"
+                  << "  path <tool>             Print path to a tool's binary\n"
+                  << "  run <tool> [args]       Run a tool with arguments\n"
+                  << "  doctor                  Check tool health\n";
+        return 0;
+    }
+
+    auto reg_path = find_tool_registry();
+    if (reg_path.empty()) {
+        print_fail("Tool registry not found at tools/packages/tool-registry.json");
+        return 1;
+    }
+
+    auto [reg, err] = load_tool_registry(reg_path);
+    if (!err.empty()) {
+        print_fail(err);
+        return 1;
+    }
+
+    auto subcmd = args[0];
+
+    if (subcmd == "list") {
+        auto platform = current_platform_key();
+        std::cout << "Available tools " << dim("(" + platform + ")") << ":\n\n";
+        for (auto& [id, tool] : reg.tools) {
+            auto loc = locate_tool(tool);
+            std::string status;
+            if (loc.found && loc.source == "pulp-managed")
+                status = green("installed");
+            else if (loc.found)
+                status = yellow("system (" + loc.path.string() + ")");
+            else if (tool.binary_sources.count(platform) || tool.install_method == "python_pip")
+                status = dim("available");
+            else
+                status = red("not available for " + platform);
+
+            std::cout << "  " << id;
+            int pad = std::max(1, 20 - static_cast<int>(id.size()));
+            std::cout << std::string(pad, ' ') << status;
+            std::cout << "  " << dim(tool.description) << "\n";
+        }
+        return 0;
+    }
+
+    if (subcmd == "install") {
+        if (args.size() < 2) {
+            print_fail("Usage: pulp tool install <tool-id> [--force]");
+            return 1;
+        }
+
+        bool force = false;
+        bool all = false;
+        std::string tool_id;
+        for (size_t i = 1; i < args.size(); ++i) {
+            if (args[i] == "--force") force = true;
+            else if (args[i] == "--all") all = true;
+            else tool_id = args[i];
+        }
+
+        auto install_one = [&](const std::string& id) -> int {
+            auto it = reg.tools.find(id);
+            if (it == reg.tools.end()) {
+                print_fail("Tool '" + id + "' not found in registry");
+                return 1;
+            }
+
+            auto& tool = it->second;
+
+            // Install dependencies first
+            for (auto& dep : tool.requires_tools) {
+                auto dep_it = reg.tools.find(dep);
+                if (dep_it == reg.tools.end()) continue;
+                auto dep_loc = locate_tool(dep_it->second);
+                if (!dep_loc.found) {
+                    std::cout << "  Installing dependency: " << dep << "\n";
+                    if (dep_it->second.install_method == "binary_download")
+                        install_binary_tool(dep_it->second);
+                    else if (dep_it->second.install_method == "python_pip")
+                        install_python_tool(dep_it->second, reg);
+                }
+            }
+
+            ToolInstallResult result;
+            if (tool.install_method == "binary_download")
+                result = install_binary_tool(tool, force);
+            else if (tool.install_method == "python_pip")
+                result = install_python_tool(tool, reg, force);
+            else {
+                print_fail("Unknown install method: " + tool.install_method);
+                return 1;
+            }
+
+            if (result.ok) {
+                print_ok("Installed " + tool.display_name + " " + result.installed_version);
+                std::cout << "  " << dim(result.binary_path.string()) << "\n";
+                return 0;
+            } else {
+                print_fail(result.error);
+                return 1;
+            }
+        };
+
+        if (all) {
+            int rc = 0;
+            for (auto& [id, tool] : reg.tools) rc |= install_one(id);
+            return rc;
+        }
+        return install_one(tool_id);
+    }
+
+    if (subcmd == "uninstall") {
+        if (args.size() < 2) {
+            print_fail("Usage: pulp tool uninstall <tool-id>");
+            return 1;
+        }
+        if (uninstall_tool(args[1])) {
+            print_ok("Uninstalled " + args[1]);
+            return 0;
+        }
+        print_fail(args[1] + " is not installed (pulp-managed)");
+        return 1;
+    }
+
+    if (subcmd == "path") {
+        if (args.size() < 2) {
+            print_fail("Usage: pulp tool path <tool-id>");
+            return 1;
+        }
+        auto it = reg.tools.find(args[1]);
+        if (it == reg.tools.end()) {
+            print_fail("Tool '" + args[1] + "' not found");
+            return 1;
+        }
+        auto loc = locate_tool(it->second);
+        if (loc.found) {
+            std::cout << loc.path.string() << "\n";
+            return 0;
+        }
+        print_fail(args[1] + " not installed");
+        return 1;
+    }
+
+    if (subcmd == "run") {
+        if (args.size() < 2) {
+            print_fail("Usage: pulp tool run <tool-id> [args...]");
+            return 1;
+        }
+        auto it = reg.tools.find(args[1]);
+        if (it == reg.tools.end()) {
+            print_fail("Tool '" + args[1] + "' not found");
+            return 1;
+        }
+        auto loc = locate_tool(it->second);
+        if (!loc.found) {
+            print_fail(args[1] + " not installed. Run: pulp tool install " + args[1]);
+            return 1;
+        }
+
+        // Build command with remaining args
+        std::vector<std::string> tool_args(args.begin() + 2, args.end());
+        auto result = pulp::platform::ChildProcess::run(
+            loc.path.string(), tool_args, {});
+        std::cout << result.stdout_output;
+        if (!result.stderr_output.empty())
+            std::cerr << result.stderr_output;
+        return result.exit_code;
+    }
+
+    if (subcmd == "doctor") {
+        auto platform = current_platform_key();
+        std::cout << "Tool Health " << dim("(" + platform + ")") << ":\n\n";
+        int issues = 0;
+        for (auto& [id, tool] : reg.tools) {
+            auto loc = locate_tool(tool);
+            if (loc.found) {
+                print_ok(tool.display_name + " — " + loc.source + " (" + loc.path.string() + ")");
+            } else {
+                bool available = tool.binary_sources.count(platform) || tool.install_method == "python_pip";
+                if (available) {
+                    std::cout << "  " << yellow("–") << " " << tool.display_name
+                              << " — not installed " << dim("(pulp tool install " + id + ")") << "\n";
+                } else {
+                    std::cout << "  " << red("✗") << " " << tool.display_name
+                              << " — not available for " << platform << "\n";
+                    ++issues;
+                }
+            }
+        }
+        return issues > 0 ? 1 : 0;
+    }
+
+    print_fail("Unknown tool subcommand: " + subcmd);
+    return 1;
+}
+
+}  // namespace pulp::cli::tools

--- a/tools/cli/tool_registry.hpp
+++ b/tools/cli/tool_registry.hpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pulp::cli::tools {
+
+namespace fs = std::filesystem;
+
+// ── Tool Descriptor ──
+
+struct BinarySource {
+    std::string url_template;    // with ${version} placeholder
+    std::string archive_format;  // "tar.gz", "zip", "tar.xz"
+    std::string binary_name;     // e.g., "uv", "ffmpeg.exe"
+};
+
+struct ToolDescriptor {
+    std::string id;
+    std::string display_name;
+    std::string category;        // "runtime", "binary", "python_tool"
+    std::string description;
+    std::string license;
+    std::string install_method;  // "binary_download", "python_pip"
+    std::map<std::string, BinarySource> binary_sources;
+    std::string pip_package;     // for python_pip
+    std::string pinned_version;
+    std::vector<std::string> requires_tools;
+    bool managed_by_pulp = true;
+    bool bundleable = false;
+};
+
+// ── Tool Registry ──
+
+struct ToolRegistry {
+    int schema_version = 0;
+    std::map<std::string, ToolDescriptor> tools;
+};
+
+struct ToolRegistryLoadResult {
+    ToolRegistry registry;
+    std::string error;
+};
+
+ToolRegistryLoadResult load_tool_registry(const fs::path& path);
+
+// ── Tool Status ──
+
+enum class ToolStatus {
+    not_installed,
+    installed,
+    outdated,
+    missing_dependency,
+    unavailable,
+};
+
+struct ToolLocateResult {
+    bool found = false;
+    fs::path path;
+    std::string source;  // "pulp-managed", "system-path", "not-found"
+    std::string version;
+};
+
+struct ToolInstallResult {
+    bool ok = false;
+    fs::path binary_path;
+    std::string installed_version;
+    std::string error;
+};
+
+// ── Pulp Home ──
+
+fs::path pulp_home();
+fs::path tools_dir();
+
+// ── Current Platform ──
+
+std::string current_platform_key();
+
+// ── Tool Operations ──
+
+ToolLocateResult locate_tool(const ToolDescriptor& tool);
+ToolInstallResult install_binary_tool(const ToolDescriptor& tool, bool force = false);
+ToolInstallResult install_python_tool(const ToolDescriptor& tool,
+                                       const ToolRegistry& registry,
+                                       bool force = false);
+bool uninstall_tool(const std::string& tool_id);
+
+// ── Archive Extraction ──
+
+bool extract_archive(const fs::path& archive, const fs::path& dest,
+                     const std::string& format);
+
+// ── CLI Command ──
+
+int cmd_tool(const std::vector<std::string>& args);
+
+}  // namespace pulp::cli::tools

--- a/tools/packages/tool-registry.json
+++ b/tools/packages/tool-registry.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": 1,
+  "tools": {
+    "uv": {
+      "display_name": "UV (Python package manager)",
+      "category": "runtime",
+      "description": "Fast Python package installer and resolver",
+      "upstream_url": "https://github.com/astral-sh/uv",
+      "license": "MIT OR Apache-2.0",
+      "install_method": "binary_download",
+      "binary_sources": {
+        "macOS-arm64": {
+          "url_template": "https://github.com/astral-sh/uv/releases/download/${version}/uv-aarch64-apple-darwin.tar.gz",
+          "archive_format": "tar.gz",
+          "binary_name": "uv"
+        },
+        "Windows-x64": {
+          "url_template": "https://github.com/astral-sh/uv/releases/download/${version}/uv-x86_64-pc-windows-msvc.zip",
+          "archive_format": "zip",
+          "binary_name": "uv.exe"
+        },
+        "Linux-x64": {
+          "url_template": "https://github.com/astral-sh/uv/releases/download/${version}/uv-x86_64-unknown-linux-gnu.tar.gz",
+          "archive_format": "tar.gz",
+          "binary_name": "uv"
+        },
+        "Linux-arm64": {
+          "url_template": "https://github.com/astral-sh/uv/releases/download/${version}/uv-aarch64-unknown-linux-gnu.tar.gz",
+          "archive_format": "tar.gz",
+          "binary_name": "uv"
+        }
+      },
+      "pinned_version": "0.6.14",
+      "requires_tools": [],
+      "managed_by_pulp": true,
+      "bundleable": false
+    },
+    "ffmpeg": {
+      "display_name": "FFmpeg",
+      "category": "binary",
+      "description": "Audio/video transcoding and format conversion",
+      "upstream_url": "https://ffmpeg.org",
+      "license": "LGPL-2.1-or-later",
+      "license_note": "Used as a separate process, not linked. LGPL applies to ffmpeg itself, not to plugins invoking it.",
+      "install_method": "binary_download",
+      "binary_sources": {
+        "macOS-arm64": {
+          "url_template": "https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip",
+          "archive_format": "zip",
+          "binary_name": "ffmpeg"
+        },
+        "Windows-x64": {
+          "url_template": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip",
+          "archive_format": "zip",
+          "binary_name": "ffmpeg.exe"
+        },
+        "Linux-x64": {
+          "url_template": "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz",
+          "archive_format": "tar.xz",
+          "binary_name": "ffmpeg"
+        }
+      },
+      "pinned_version": "7.1",
+      "requires_tools": [],
+      "managed_by_pulp": true,
+      "bundleable": true,
+      "bundle_note": "Can be included in standalone app installers for audio conversion"
+    },
+    "yt-dlp": {
+      "display_name": "yt-dlp",
+      "category": "python_tool",
+      "description": "Audio/video downloader supporting 1000+ sites",
+      "upstream_url": "https://github.com/yt-dlp/yt-dlp",
+      "license": "Unlicense",
+      "install_method": "python_pip",
+      "pip_package": "yt-dlp",
+      "pinned_version": "2025.3.31",
+      "requires_tools": ["uv", "ffmpeg", "deno"],
+      "managed_by_pulp": true,
+      "bundleable": false,
+      "bundle_note": "Development-time only. Plugins should pre-process audio."
+    },
+    "pydub": {
+      "display_name": "pydub",
+      "category": "python_tool",
+      "description": "Simple audio manipulation (trim, convert, effects)",
+      "upstream_url": "https://github.com/jiaaro/pydub",
+      "license": "MIT",
+      "install_method": "python_pip",
+      "pip_package": "pydub",
+      "pinned_version": "0.25.1",
+      "requires_tools": ["uv", "ffmpeg"],
+      "managed_by_pulp": true,
+      "bundleable": false
+    },
+    "deno": {
+      "display_name": "Deno",
+      "category": "runtime",
+      "description": "JavaScript/TypeScript runtime (required by yt-dlp for YouTube)",
+      "upstream_url": "https://deno.land",
+      "license": "MIT",
+      "install_method": "binary_download",
+      "binary_sources": {
+        "macOS-arm64": {
+          "url_template": "https://github.com/denoland/deno/releases/download/v${version}/deno-aarch64-apple-darwin.zip",
+          "archive_format": "zip",
+          "binary_name": "deno"
+        },
+        "Windows-x64": {
+          "url_template": "https://github.com/denoland/deno/releases/download/v${version}/deno-x86_64-pc-windows-msvc.zip",
+          "archive_format": "zip",
+          "binary_name": "deno.exe"
+        },
+        "Linux-x64": {
+          "url_template": "https://github.com/denoland/deno/releases/download/v${version}/deno-x86_64-unknown-linux-gnu.zip",
+          "archive_format": "zip",
+          "binary_name": "deno"
+        }
+      },
+      "pinned_version": "2.2.0",
+      "requires_tools": [],
+      "managed_by_pulp": true,
+      "bundleable": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

**Tool Registry** (`tool-registry.json`):
5 tools (UV, ffmpeg, yt-dlp, pydub, Deno) with per-platform binary sources, dependency chains, and version pinning.

**Tool Manager** (`tool_registry.cpp`):
- Binary download via curl/PowerShell with archive extraction (tar.gz, zip, tar.xz)
- Python/UV bootstrapping: venv creation, pip install, wrapper scripts
- Tool location: pulp-managed → system PATH fallback
- macOS quarantine removal

**CLI: `pulp tool`**:
install, uninstall, list, path, run, doctor subcommands with dependency resolution.

**Model Download**:
- `download_url` and `sha256` on RegisteredModel
- `resolve_checkpoint_url()` for hf:// protocol
- CLAP model with direct HuggingFace URL

**Extended Entitlements**:
`entitlements-extended.plist` for plugins that download/process audio files.

**Shared JSON Parser**:
Extracted to `json_parser.hpp` for reuse across package and tool registries.

## Test plan
- [x] CI green on all 3 platforms
- [x] Naming audit passes