### PR TITLE
Add iOS VoiceOver accessibility via UIAccessibility

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -230,6 +230,7 @@ if(APPLE)
         target_sources(pulp-view PRIVATE
             platform/ios/window_host_ios.mm
             platform/ios/plugin_view_host_ios.mm
+            platform/ios/accessibility_ios.mm
         )
         target_link_libraries(pulp-view PRIVATE
             "-framework UIKit"

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -194,6 +194,10 @@ public:
     void set_access_value(std::string value) { access_value_ = std::move(value); }
     const std::string& access_value() const { return access_value_; }
 
+    /// Called by platform accessibility when VoiceOver increment/decrement is triggered.
+    /// Delta is typically ±0.05 (5% step). Override in widgets to adjust the value.
+    virtual void on_accessibility_adjust(float delta) { (void)delta; }
+
     // ── Identity ─────────────────────────────────────────────────────────
 
     void set_id(std::string id) { id_ = std::move(id); }

--- a/core/view/platform/ios/accessibility_ios.mm
+++ b/core/view/platform/ios/accessibility_ios.mm
@@ -1,5 +1,9 @@
 // iOS VoiceOver accessibility provider
-// Maps Pulp View accessibility properties to UIAccessibility.
+// Maps Pulp View accessibility properties to UIAccessibility protocol.
+//
+// Each View with an AccessRole is exposed as a UIAccessibilityElement.
+// The hosting UIView implements UIAccessibilityContainer to provide
+// a flat list of accessible elements to VoiceOver.
 
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
@@ -10,21 +14,30 @@
 
 namespace pulp::view {
 
+// ── Role mapping ────────────────────────────────────────────────────────
+
 static UIAccessibilityTraits access_role_to_traits(View::AccessRole role) {
     switch (role) {
-        case View::AccessRole::slider: return UIAccessibilityTraitAdjustable;
-        case View::AccessRole::toggle: return UIAccessibilityTraitButton;
-        case View::AccessRole::label:  return UIAccessibilityTraitStaticText;
-        case View::AccessRole::meter:  return UIAccessibilityTraitUpdatesFrequently;
-        case View::AccessRole::image:  return UIAccessibilityTraitImage;
-        default: return UIAccessibilityTraitNone;
+        case View::AccessRole::slider:
+            return UIAccessibilityTraitAdjustable;
+        case View::AccessRole::toggle:
+            return UIAccessibilityTraitButton;
+        case View::AccessRole::label:
+            return UIAccessibilityTraitStaticText;
+        case View::AccessRole::group:
+            return UIAccessibilityTraitNone;
+        case View::AccessRole::meter:
+            return UIAccessibilityTraitUpdatesFrequently;
+        case View::AccessRole::image:
+            return UIAccessibilityTraitImage;
+        default:
+            return UIAccessibilityTraitNone;
     }
 }
 
-}  // namespace pulp::view
+// ── PulpAccessibilityElement ────────────────────────────────────────────
 
-/// Bridges a Pulp View to UIAccessibility with proper screen-space frame
-/// and adjustable increment/decrement for slider roles.
+/// Bridges a Pulp View to UIAccessibility.
 @interface PulpAccessibilityElement : UIAccessibilityElement
 @property (nonatomic, assign) pulp::view::View* pulpView;
 @property (nonatomic, weak) UIView* hostView;
@@ -92,28 +105,33 @@ static UIAccessibilityTraits access_role_to_traits(View::AccessRole role) {
 
 @end
 
-namespace pulp::view {
+// ── Helper: collect accessible views ────────────────────────────────────
+
+static void collect_accessible_views(View& root, std::vector<View*>& out) {
+    for (size_t i = 0; i < root.child_count(); ++i) {
+        auto* child = root.child_at(i);
+        if (child->access_role() != View::AccessRole::none)
+            out.push_back(const_cast<View*>(child));
+        collect_accessible_views(*const_cast<View*>(child), out);
+    }
+}
 
 /// Create accessibility elements for all accessible views in the tree.
-/// The hosting UIView should call this and implement UIAccessibilityContainer.
+/// Called by the hosting UIView to populate its accessibility container.
 NSArray<UIAccessibilityElement *>* create_accessibility_elements(
     View& root, UIView* hostView) {
 
-    NSMutableArray* elements = [NSMutableArray array];
+    std::vector<View*> accessible;
+    collect_accessible_views(root, accessible);
 
-    std::function<void(View&)> collect = [&](View& view) {
-        if (view.access_role() != View::AccessRole::none) {
-            PulpAccessibilityElement* element =
-                [[PulpAccessibilityElement alloc] initWithAccessibilityContainer:hostView];
-            element.pulpView = &view;
-            element.hostView = hostView;
-            [elements addObject:element];
-        }
-        for (size_t i = 0; i < view.child_count(); ++i)
-            collect(*const_cast<View*>(view.child_at(i)));
-    };
-
-    collect(root);
+    NSMutableArray* elements = [NSMutableArray arrayWithCapacity:accessible.size()];
+    for (auto* view : accessible) {
+        PulpAccessibilityElement* element =
+            [[PulpAccessibilityElement alloc] initWithAccessibilityContainer:hostView];
+        element.pulpView = view;
+        element.hostView = hostView;
+        [elements addObject:element];
+    }
     return elements;
 }
 

--- a/core/view/platform/ios/accessibility_ios.mm
+++ b/core/view/platform/ios/accessibility_ios.mm
@@ -40,7 +40,6 @@ static UIAccessibilityTraits access_role_to_traits(View::AccessRole role) {
 /// Bridges a Pulp View to UIAccessibility.
 @interface PulpAccessibilityElement : UIAccessibilityElement
 @property (nonatomic, assign) pulp::view::View* pulpView;
-@property (nonatomic, weak) UIView* hostView;
 @end
 
 @implementation PulpAccessibilityElement
@@ -63,24 +62,23 @@ static UIAccessibilityTraits access_role_to_traits(View::AccessRole role) {
 }
 
 - (CGRect)accessibilityFrame {
-    if (!_pulpView || !_hostView) return CGRectZero;
-
-    // Convert view-local bounds to screen coordinates
+    if (!_pulpView) return CGRectZero;
     auto bounds = _pulpView->bounds();
-    CGRect localRect = CGRectMake(bounds.x, bounds.y, bounds.width, bounds.height);
-
-    // Walk up the Pulp view hierarchy to accumulate parent offsets
-    auto* current = _pulpView->parent();
-    while (current) {
-        auto pb = current->bounds();
-        localRect.origin.x += pb.x;
-        localRect.origin.y += pb.y;
-        current = current->parent();
+    // Convert view-local bounds to screen coordinates by walking up the hierarchy
+    float ox = bounds.x, oy = bounds.y;
+    auto* parent = _pulpView->parent();
+    while (parent) {
+        ox += parent->bounds().x;
+        oy += parent->bounds().y;
+        parent = parent->parent();
     }
-
-    // Convert from host UIView coordinates to screen coordinates
-    CGRect screenRect = [_hostView convertRect:localRect toCoordinateSpace:_hostView.window.screen.coordinateSpace];
-    return screenRect;
+    CGRect localRect = CGRectMake(ox, oy, bounds.width, bounds.height);
+    // Convert from container view coordinates to screen coordinates
+    UIView* container = (UIView*)self.accessibilityContainer;
+    if (container) {
+        return UIAccessibilityConvertFrameToScreenCoordinates(localRect, container);
+    }
+    return localRect;
 }
 
 - (BOOL)isAccessibilityElement {
@@ -91,16 +89,12 @@ static UIAccessibilityTraits access_role_to_traits(View::AccessRole role) {
 
 - (void)accessibilityIncrement {
     if (!_pulpView) return;
-    // Simulate an increment: post a synthetic drag-up event
-    // The widget's on_mouse_drag handler will process the value change
-    pulp::view::Point p = {0, -5};  // Up = increase for vertical sliders
-    _pulpView->on_mouse_drag(p);
+    _pulpView->on_accessibility_adjust(0.05f);  // +5% step
 }
 
 - (void)accessibilityDecrement {
     if (!_pulpView) return;
-    pulp::view::Point p = {0, 5};   // Down = decrease
-    _pulpView->on_mouse_drag(p);
+    _pulpView->on_accessibility_adjust(-0.05f);  // -5% step
 }
 
 @end
@@ -119,7 +113,7 @@ static void collect_accessible_views(View& root, std::vector<View*>& out) {
 /// Create accessibility elements for all accessible views in the tree.
 /// Called by the hosting UIView to populate its accessibility container.
 NSArray<UIAccessibilityElement *>* create_accessibility_elements(
-    View& root, UIView* hostView) {
+    View& root, UIView* container) {
 
     std::vector<View*> accessible;
     collect_accessible_views(root, accessible);
@@ -127,9 +121,8 @@ NSArray<UIAccessibilityElement *>* create_accessibility_elements(
     NSMutableArray* elements = [NSMutableArray arrayWithCapacity:accessible.size()];
     for (auto* view : accessible) {
         PulpAccessibilityElement* element =
-            [[PulpAccessibilityElement alloc] initWithAccessibilityContainer:hostView];
+            [[PulpAccessibilityElement alloc] initWithAccessibilityContainer:container];
         element.pulpView = view;
-        element.hostView = hostView;
         [elements addObject:element];
     }
     return elements;

--- a/core/view/platform/ios/window_host_ios.mm
+++ b/core/view/platform/ios/window_host_ios.mm
@@ -11,9 +11,15 @@
 
 // ── PulpRootView: UIView subclass that paints the View tree ─────────────────
 
+// Forward declaration from accessibility_ios.mm
+namespace pulp::view {
+NSArray<UIAccessibilityElement *>* create_accessibility_elements(View& root, UIView* container);
+}
+
 @interface PulpRootView : UIView {
     std::unordered_map<void*, int> _touchIdMap;
     int _nextTouchId;
+    NSArray<UIAccessibilityElement *>* _cachedAccessibilityElements;
 }
 @property (nonatomic, assign) pulp::view::View* rootView;
 @end
@@ -27,6 +33,7 @@
         self.multipleTouchEnabled = YES;
         self.contentMode = UIViewContentModeRedraw;
         _nextTouchId = 0;
+        _cachedAccessibilityElements = nil;
         [self setupHoverIfAvailable];
     }
     return self;
@@ -171,6 +178,33 @@
         self.rootView->simulate_hover({-1, -1});
     }
     [self setNeedsDisplay];
+}
+
+// ── UIAccessibilityContainer ────────────────────────────────────────────
+
+- (BOOL)isAccessibilityElement {
+    return NO;  // Container, not an element itself
+}
+
+- (NSArray *)accessibilityElements {
+    if (!_rootView) return @[];
+    // Rebuild on each query — VoiceOver caches this per focus change
+    _cachedAccessibilityElements = pulp::view::create_accessibility_elements(*_rootView, self);
+    return _cachedAccessibilityElements;
+}
+
+- (NSInteger)accessibilityElementCount {
+    return [[self accessibilityElements] count];
+}
+
+- (id)accessibilityElementAtIndex:(NSInteger)index {
+    NSArray* elements = [self accessibilityElements];
+    if (index >= 0 && index < (NSInteger)elements.count) return elements[index];
+    return nil;
+}
+
+- (NSInteger)indexOfAccessibilityElement:(id)element {
+    return [[self accessibilityElements] indexOfObject:element];
 }
 
 @end


### PR DESCRIPTION
Maps Pulp View AccessRole to UIAccessibilityTraits. PulpAccessibilityElement bridges View to UIKit. Compiled only on iOS.