### PR TITLE
Add rendering reference docs and update module descriptions

### DIFF
--- a/docs/reference/rendering.md
+++ b/docs/reference/rendering.md
@@ -1,0 +1,193 @@
+# Rendering Reference
+
+Pulp's rendering pipeline is GPU-accelerated via Dawn (WebGPU) and Skia Graphite. This page covers the rendering infrastructure added for visual parity with purpose-built GPU UI frameworks.
+
+## HDR Float Color
+
+`Color` uses 4x `float` channels (0.0–1.0, >1.0 for HDR). Supports multiple color spaces:
+
+```cpp
+auto c = Color::rgba(0.5f, 0.8f, 1.0f);       // sRGB float
+auto c = Color::rgba8(128, 200, 255);           // from uint8
+auto c = Color::hex(0x3B82F6);                  // from hex
+
+auto hsv = c.to_hsv();                          // Hue-Saturation-Value
+auto hsl = c.to_hsl();                          // Hue-Saturation-Lightness
+auto lch = c.to_oklch();                        // OKLCH (CSS Color Level 4)
+auto hdr = c.with_hdr_intensity(2.0f);          // HDR overbright
+auto mid = a.interpolate(b, 0.5f);              // Smooth blending
+```
+
+## SDF Shape Primitives
+
+14 GPU-accelerated shapes via SkSL shaders with pixel-perfect anti-aliasing:
+
+`rect`, `circle`, `rounded_rect`, `arc`, `diamond`, `squircle`, `triangle`, `ring`, `stadium`, `cross`, `flat_segment`, `rounded_segment`, `flat_arc`, `quadratic_bezier`
+
+```cpp
+Canvas::SDFStyle style;
+style.fill_color = Color::rgba(0.2f, 0.6f, 1.0f);
+style.corner_radius = 8.0f;
+canvas.draw_sdf_shape(Canvas::SDFShape::squircle, x, y, w, h, style);
+```
+
+## Compositing Layers
+
+Proper CSS opacity and filter:blur() via `save_layer()`:
+
+```cpp
+// Subtree paints into offscreen buffer, composited as single unit
+canvas.save_layer(x, y, w, h, opacity, blur_radius);
+// ... draw subtree ...
+canvas.restore();
+```
+
+Works on both Skia (SkCanvas::saveLayer) and CoreGraphics (CGContextBeginTransparencyLayer).
+
+## Post-Processing Effects
+
+```cpp
+view.set_effect(std::make_shared<GpuBlurEffect>());           // Gaussian blur
+view.set_effect(std::make_shared<GpuBloomEffect>());          // HDR bloom
+view.set_effect(std::make_shared<CustomShaderEffect>());      // Arbitrary SkSL
+view.set_effect(std::make_shared<EffectChain>());             // Compose multiple
+```
+
+## DirtyTracker
+
+Partial repaint optimization — only repaints changed regions:
+
+```cpp
+DirtyTracker tracker;
+tracker.set_viewport(width, height, 0.6f);  // Full repaint if >60% dirty
+tracker.invalidate(x, y, w, h);             // Mark region dirty
+if (tracker.needs_full_repaint()) { /* repaint all */ }
+else { for (auto& rect : tracker.dirty_rects()) { /* repaint rect */ } }
+tracker.clear();                             // After frame submit
+```
+
+## DrawBatcher
+
+Groups compatible draw calls to reduce GPU state changes:
+
+```cpp
+DrawBatcher batcher;
+batcher.begin();
+batcher.record(bounds, state_key);  // Record draws
+auto stats = batcher.end();         // stats.draws_before / draws_after
+```
+
+## Atlas Systems
+
+- **ImageAtlas**: Packs small images into shared GPU texture with ref counting
+- **GradientAtlas**: Caches evaluated gradient ramps by hash
+- **GlyphAtlas**: Per-font-size glyph cache (supplements Skia's internal cache)
+- **PathAtlas**: Caches rasterized vector paths
+- **BufferPool\<T\>**: Reuses std::vector allocations in hot paths
+
+## GPU Visualization
+
+Waveform and spectrum views use GPU shaders for anti-aliased rendering:
+
+```cpp
+Canvas::WaveformStyle style;
+style.line_color = wave_color;
+style.fill_color = fill_color;
+style.line_thickness = 2.0f;
+canvas.draw_waveform(samples, count, x, y, w, h, style);
+```
+
+## Gradients
+
+```cpp
+// Conic (sweep) gradient — CSS conic-gradient equivalent
+canvas.set_fill_gradient_conic(cx, cy, start_angle, colors, positions, count);
+
+// FillStyle unifies solid, linear, radial, conic
+FillStyle fill(ConicGradient{cx, cy, 0, stops});
+fill.set_tile_mode(GradientTileMode::repeat);
+```
+
+## SpriteStrip Animation
+
+Designer-created filmstrip knob/fader skins:
+
+```cpp
+auto strip = std::make_shared<SpriteStrip>();
+strip->load(data, size, width, height, frame_count);
+knob.set_sprite_strip(strip);  // Value selects frame
+```
+
+## Viewport-Relative Dimensions
+
+```cpp
+auto d = Dimension::parse("50vw");
+float px = d.resolve(parent_size, viewport_w, viewport_h, dpi_scale);
+// Units: px, %, vw, vh, vmin, vmax, auto
+```
+
+## ThemeEditor
+
+Live theme editing widget:
+
+```cpp
+ThemeEditor editor;
+editor.set_theme(Theme::dark());
+editor.on_color_changed = [](const std::string& token, Color c) { /* update */ };
+auto json = editor.export_json();
+```
+
+## Global Undo
+
+```cpp
+EditHistory history;
+history.perform([&]{ value = 42; }, [&]{ value = 0; }, "set value");
+history.undo();  // value = 0
+history.redo();  // value = 42
+// Coalescing: rapid changes with same description merge automatically
+```
+
+Integrates with parameter Bindings:
+```cpp
+binding.set_edit_history(&history);
+binding.begin_gesture();  // Captures start value
+// ... user drags knob ...
+binding.end_gesture();    // Pushes undo action
+```
+
+## Platform Features
+
+```cpp
+window->set_mouse_relative_mode(true);     // Infinite knob drag
+window->set_client_decoration(true);       // Custom title bar
+window->set_fixed_aspect_ratio(16.0f/9);   // Constrained resize
+window->set_always_on_top(true);           // Floating window
+float dpi = window->dpi_scale();           // HiDPI
+auto monitors = window->get_monitors();    // Multi-monitor enumeration
+```
+
+## PBR / 3D Pipeline
+
+Compute pipeline for Three.js PBR materials:
+
+- **Compute dispatch**: JS→C++ bridge creates Dawn compute pipelines and dispatches workgroups
+- **Storage buffers**: Bind group serialization with GPU buffer creation
+- **Cube textures**: 6-face textures with mip levels for environment maps
+- **DRACO**: Native C++ mesh decoder (Apache 2.0, optional via `PULP_ENABLE_DRACO`)
+- **KTX2**: Texture header parser with platform-optimal format detection (ASTC/BC7/ETC2)
+- **Binary transfer**: Native buffer registration for zero-copy GPU upload
+
+## Asset Embedding
+
+```cmake
+# In CMakeLists.txt:
+pulp_embed_files(my-plugin FILES fonts/Inter.ttf icons/logo.svg)
+```
+
+```cpp
+// In C++:
+auto* font = EmbeddedAsset::get("Inter.ttf");
+// font->data, font->size
+```
+
+Bundled fonts: Inter Regular, JetBrains Mono Regular (SIL OFL 1.1).

--- a/docs/status/modules.yaml
+++ b/docs/status/modules.yaml
@@ -33,7 +33,7 @@ modules:
     docs: reference/modules.md#signal
 
   - name: state
-    summary: Thread-safe parameters, reactive StateTree with JSON sync, PresetManager, PropertiesFile (JSON settings), undo/redo
+    summary: Thread-safe parameters, reactive StateTree with JSON sync, PresetManager, PropertiesFile (JSON settings), EditHistory (global undo/redo with coalescing, Binding integration)
     status: stable
     dependencies: [runtime]
     docs: reference/modules.md#state
@@ -52,38 +52,48 @@ modules:
 
   - name: canvas
     summary: >
-      2D GPU-accelerated drawing (CoreGraphics + Skia Graphite backends), path builder,
-      gradients, clipping, blend modes, SVG, TextShaper (PreText-style measure-once reflow-forever
-      with optional HarfBuzz via Skia), AttributedString with word-wrap, RectangleList for
-      clip regions, ImageConvolutionKernel (blur, sharpen, edge detect)
+      2D GPU-accelerated drawing (CoreGraphics + Skia Graphite backends). HDR float color
+      (HSV/HSL/OKLCH conversions). 14 SDF shape primitives with SkSL shaders (rect, circle,
+      rounded_rect, arc, diamond, squircle, triangle, ring, stadium, cross, segments, bezier).
+      Compositing layers (save_layer with opacity + blur on Skia and CoreGraphics).
+      ConicGradient, FillStyle, gradient tile modes. Path builder, clipping, 16 blend modes,
+      SVG, TextShaper, AttributedString with word-wrap, RectangleList, ImageConvolutionKernel.
+      ViewEffect system: GpuBlurEffect, GpuBloomEffect, ChromaticAberration, Vignette,
+      CustomShaderEffect (arbitrary SkSL), EffectChain.
     status: usable
     dependencies: [runtime]
-    docs: reference/modules.md#canvas
+    docs: reference/rendering.md#canvas
 
   - name: render
     summary: >
       GPU surface management (Dawn, Skia Graphite) — Metal, D3D12, Vulkan backends.
-      Includes experimental WebGPU compute pipeline for batch audio processing (>64K elements).
-      Compute is separate from rendering — not for real-time audio callbacks.
-    status: experimental
+      DirtyTracker for partial repaint optimization with rect coalescing.
+      DrawBatcher for draw call merging with overlap detection.
+      RenderPassManager for multi-pass frame ordering and budget tracking.
+      Atlas systems: ImageAtlas, GradientAtlas, GlyphAtlas, PathAtlas, BufferPool.
+      GPU graph renderers: GpuGraphRenderer (1D), GpuHeatMapRenderer (2D), GpuBarRenderer.
+      WebGPU compute pipeline for PMREM, PBR materials, and batch processing.
+      DRACO mesh decoder (native C++, optional). KTX2 texture decoder with platform
+      format detection (ASTC/BC7/ETC2). Binary transfer optimization.
+    status: usable
     dependencies: [runtime, canvas]
-    docs: reference/modules.md#render
+    docs: reference/rendering.md#render
 
   - name: view
     summary: >
       Full widget toolkit with CSS parity: flexbox, grid layout, transforms, animations,
-      backgrounds/gradients, filters, colors (CSS L4), text styling, positioned layout, z-index,
+      backgrounds/gradients, filters, colors (CSS L4), text styling, positioned layout, z-index.
+      SpriteStrip animation for designer-created knob/fader filmstrips.
+      ThemeEditor widget for live theme editing with swatch grid and JSON export.
+      TextDirection (LTR/RTL/vertical) and TextVerticalAlign on Label.
+      Viewport-relative dimensions (vw/vh/vmin/vmax/%) via DimensionUnit with Yoga integration.
+      View→WindowHost back-reference for widget access to platform features.
+      Mouse relative mode for infinite knob drag (macOS CGAssociate + SDL3).
+      Client-side window decoration, fixed aspect ratio, always-on-top, multi-monitor DPI.
       Canvas 2D (25 commands), ImageView, ListBox (virtualized), ComboBox, ScrollView, TextEditor
-      with IME, TreeView, ProgressBar, Tooltip. Web-compat JS prelude (document/Element/style/events/
-      StyleSheet/querySelector). FrameClock animation with motion tokens. Hot-reload, inspector,
-      app framework, design export. Multi-window framework (WindowManager): window registry,
-      parent-child cascading close, floating palettes, inspectors, popups, dialogs, shared theme
-      propagation, inter-window messaging, screen enumeration, window state save/restore, shared
-      GPU device for Dawn-backed rendering across windows. Platform: cursor management, Tab focus,
-      VoiceOver accessibility, context menus, keyboard shortcuts, file dialogs. Pointer events,
-      gestures, Apple Pencil.
-      JS engine abstraction: pluggable backend (QuickJS default, JavaScriptCore on Apple, V8 optional).
-      Build-time engine selection via PULP_JS_ENGINE, smart workload-based engine recommendation.
+      with IME, TreeView, ProgressBar, Tooltip. Web-compat JS prelude. FrameClock animation with
+      motion tokens. Hot-reload, inspector, app framework, design export. Multi-window framework.
+      Pointer events, gestures, Apple Pencil. JS engine abstraction (QuickJS/JSC/V8).
     status: usable
     dependencies: [canvas, events, state]
     docs: reference/modules.md#view


### PR DESCRIPTION
## Summary
Document all rendering capabilities added in PR #14.

### New: `docs/reference/rendering.md`
Comprehensive reference with code examples for:
- HDR Float Color (HSV/HSL/OKLCH)
- 14 SDF shape primitives
- Compositing layers (save_layer)
- Post-processing effects (blur, bloom, chromatic aberration, vignette, custom SkSL, chains)
- DirtyTracker, DrawBatcher
- Atlas systems (image, gradient, glyph, path, buffer pool)
- GPU waveform/spectrum visualization
- ConicGradient, FillStyle, gradient tile modes
- SpriteStrip animation
- Viewport-relative dimensions
- ThemeEditor widget
- EditHistory global undo with Binding integration
- Platform features (mouse relative, window decoration, DPI, monitors)
- PBR pipeline (compute, storage buffers, cube textures, DRACO, KTX2)
- Asset embedding (CMake + C++ API)

### Updated: `docs/status/modules.yaml`
- canvas: HDR color, 14 SDF shapes, compositing layers, ViewEffect system
- render: DirtyTracker, DrawBatcher, RenderPassManager, atlases, GPU viz, PBR, DRACO, KTX2
- view: SpriteStrip, ThemeEditor, TextDirection, dimensions, platform features
- state: EditHistory with coalescing

## Test plan
- [x] No code changes — docs only