### PR TITLE
Fix 3 P1 review issues + update modules.md with 8 missing items

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -172,11 +172,11 @@ Pulp started primarily for one end customer — the original author — with the
 
 | Platform | Audio | MIDI | Plugin Formats | UI | GPU | Swift |
 |----------|-------|------|----------------|-----|-----|-------|
-| macOS (ARM64) | CoreAudio | CoreMIDI | VST3, AU, AUv3, CLAP, AAX, Standalone | JS + GPU | Metal | Yes |
-| Windows (x64) | WASAPI | Win32 MIDI | VST3, CLAP, AAX, Standalone | JS + GPU | D3D12 | — |
-| Linux (x64) | ALSA, JACK | ALSA MIDI | VST3, CLAP, LV2, Standalone | JS + GPU | Vulkan | — |
 | iOS (ARM64) | AVAudioSession | CoreMIDI | AUv3, Standalone | JS + GPU | Metal | Yes |
+| Linux (x64, ARM64) | ALSA, JACK | ALSA MIDI | VST3, CLAP, LV2, Standalone | JS + GPU | Vulkan | — |
+| macOS (ARM64) | CoreAudio | CoreMIDI | VST3, AU, AUv3, CLAP, AAX, LV2, Standalone | JS + GPU | Metal | Yes |
 | Web (WASM) | Web Audio | Web MIDI | — | JS + WebGPU | WebGPU | — |
+| Windows (x64, ARM64) | WASAPI | Win32 MIDI | VST3, CLAP, AAX, Standalone | JS + GPU | D3D12 | — |
 
 ASIO on Windows supported when developers provide the Steinberg SDK independently. AAX requires the Avid SDK from Avid.
 

--- a/core/format/CMakeLists.txt
+++ b/core/format/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(pulp-format PRIVATE
     src/validation_harness.cpp
     src/aax_model.cpp
     src/host_type.cpp
+    src/ara.cpp
 )
 
 target_link_libraries(pulp-format

--- a/core/format/src/ara.cpp
+++ b/core/format/src/ara.cpp
@@ -1,0 +1,11 @@
+#include <pulp/format/ara.hpp>
+
+namespace pulp::format {
+
+bool host_supports_ara() {
+    // ARA 2.0 requires the ARA SDK and host-side support.
+    // Without the SDK integrated, ARA is not available.
+    return false;
+}
+
+}  // namespace pulp::format

--- a/core/runtime/src/system_info.cpp
+++ b/core/runtime/src/system_info.cpp
@@ -110,27 +110,33 @@ static SystemInfo query_system_info() {
         info.total_memory_mb = (si.totalram * si.mem_unit) / (1024 * 1024);
 #endif
 
-    // CPU features
+    // CPU features — runtime detection (not compile-time)
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
-    // x86: check via compiler built-ins or CPUID
-    #ifdef __SSE2__
-    info.has_sse2 = true;
-    #endif
-    #ifdef __SSE4_1__
-    info.has_sse4_1 = true;
-    #endif
-    #ifdef __AVX__
-    info.has_avx = true;
-    #endif
-    #ifdef __AVX2__
-    info.has_avx2 = true;
-    #endif
-    #ifdef __AVX512F__
-    info.has_avx512 = true;
-    #endif
-    #ifdef __FMA__
-    info.has_fma = true;
-    #endif
+    // x86: detect via CPUID at runtime
+    {
+        #ifdef _MSC_VER
+        int cpuinfo[4] = {};
+        __cpuid(cpuinfo, 1);
+        int ecx1 = cpuinfo[2];
+        int edx1 = cpuinfo[3];
+        __cpuid(cpuinfo, 7);
+        int ebx7 = cpuinfo[1];
+        #else
+        unsigned int eax, ebx, ecx, edx;
+        __asm__ __volatile__("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(1));
+        int ecx1 = static_cast<int>(ecx);
+        int edx1 = static_cast<int>(edx);
+        __asm__ __volatile__("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(7), "c"(0));
+        int ebx7 = static_cast<int>(ebx);
+        #endif
+
+        info.has_sse2    = (edx1 >> 26) & 1;
+        info.has_sse4_1  = (ecx1 >> 19) & 1;
+        info.has_avx     = (ecx1 >> 28) & 1;
+        info.has_fma     = (ecx1 >> 12) & 1;
+        info.has_avx2    = (ebx7 >>  5) & 1;
+        info.has_avx512  = (ebx7 >> 16) & 1;
+    }
 #elif defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
     info.has_neon = true;  // Always available on arm64
 #endif

--- a/core/view/src/file_browser.cpp
+++ b/core/view/src/file_browser.cpp
@@ -1,5 +1,6 @@
 #include <pulp/view/file_browser.hpp>
 #include <algorithm>
+#include <fstream>
 
 namespace pulp::view {
 
@@ -136,32 +137,58 @@ void FileTree::paint(canvas::Canvas& canvas) {
 }
 
 // ── ContentSharer ──────────────────────────────────────────────────────
+// Uses safe process-launch APIs (no shell interpretation of user input).
 
 #ifdef __APPLE__
-// macOS implementation is in a separate .mm file if available.
-// Fallback: open the file with the system default handler.
-#include <cstdlib>
+#include <spawn.h>
+extern "C" { extern char** environ; }
+
 void ContentSharer::share_file(const std::filesystem::path& file, void*) {
-    std::string cmd = "open \"" + file.string() + "\"";
-    std::system(cmd.c_str());
+    // Use posix_spawn with /usr/bin/open — no shell, no injection
+    std::string path = file.string();
+    const char* argv[] = {"/usr/bin/open", path.c_str(), nullptr};
+    pid_t pid;
+    posix_spawn(&pid, "/usr/bin/open", nullptr, nullptr,
+                const_cast<char**>(argv), environ);
 }
 
 void ContentSharer::share_text(const std::string& text, void*) {
-    // Copy to clipboard as a share fallback
-    std::string cmd = "echo '" + text + "' | pbcopy";
-    std::system(cmd.c_str());
+    // Write to a temp file and open it — avoids shell with user text
+    auto tmp = std::filesystem::temp_directory_path() / "pulp_share.txt";
+    {
+        std::ofstream f(tmp);
+        f << text;
+    }
+    share_file(tmp, nullptr);
 }
+
 #elif defined(_WIN32)
+#include <windows.h>
+#include <shellapi.h>
+
 void ContentSharer::share_file(const std::filesystem::path& file, void*) {
-    std::string cmd = "start \"\" \"" + file.string() + "\"";
-    std::system(cmd.c_str());
+    // ShellExecuteW — safe, no shell interpretation
+    std::wstring wpath = file.wstring();
+    ShellExecuteW(nullptr, L"open", wpath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 }
-void ContentSharer::share_text(const std::string&, void*) {}
+
+void ContentSharer::share_text(const std::string&, void*) {
+    // Windows: no universal text share API; would need UWP DataTransferManager
+}
+
 #else
+#include <spawn.h>
+extern "C" { extern char** environ; }
+
 void ContentSharer::share_file(const std::filesystem::path& file, void*) {
-    std::string cmd = "xdg-open \"" + file.string() + "\"";
-    std::system(cmd.c_str());
+    // posix_spawn with xdg-open — no shell
+    std::string path = file.string();
+    const char* argv[] = {"/usr/bin/xdg-open", path.c_str(), nullptr};
+    pid_t pid;
+    posix_spawn(&pid, "/usr/bin/xdg-open", nullptr, nullptr,
+                const_cast<char**>(argv), environ);
 }
+
 void ContentSharer::share_text(const std::string&, void*) {}
 #endif
 

--- a/docs/reference/licensing.md
+++ b/docs/reference/licensing.md
@@ -12,8 +12,8 @@ Pulp builds on excellent open-source software. Every dependency that Pulp bundle
 
 | Name | License | Purpose | Link |
 |------|---------|---------|------|
-| **CHOC** | ISC | JS engine, MIDI utilities, audio file I/O, WebView, networking | [github.com/Tracktion/choc](https://github.com/Tracktion/choc) |
 | **Catch2** | BSL-1.0 | Unit testing framework | [github.com/catchorg/Catch2](https://github.com/catchorg/Catch2) |
+| **CHOC** | ISC | JS engine, MIDI utilities, audio file I/O, WebView, networking | [github.com/Tracktion/choc](https://github.com/Tracktion/choc) |
 | **nanosvg** | zlib | SVG parsing and rasterization | [github.com/memononen/nanosvg](https://github.com/memononen/nanosvg) |
 | **Yoga** | MIT | Layout engine for Flexbox/Grid-style native UI | [github.com/facebook/yoga](https://github.com/facebook/yoga) |
 
@@ -21,10 +21,10 @@ Pulp builds on excellent open-source software. Every dependency that Pulp bundle
 
 | Name | License | Purpose | Link |
 |------|---------|---------|------|
-| **CLAP** | MIT | CLAP plugin format headers | [github.com/free-audio/clap](https://github.com/free-audio/clap) |
-| **VST3 SDK** | MIT | VST3 plugin format (pluginterfaces + base) | [github.com/steinbergmedia/vst3sdk](https://github.com/steinbergmedia/vst3sdk) |
 | **AudioUnitSDK** | Apache-2.0 | AU v2 plugin format adapter | [github.com/apple/AudioUnitSDK](https://github.com/apple/AudioUnitSDK) |
+| **CLAP** | MIT | CLAP plugin format headers | [github.com/free-audio/clap](https://github.com/free-audio/clap) |
 | **LV2** | ISC | LV2 plugin format headers | [github.com/lv2/lv2](https://github.com/lv2/lv2) |
+| **VST3 SDK** | MIT | VST3 plugin format (pluginterfaces + base) | [github.com/steinbergmedia/vst3sdk](https://github.com/steinbergmedia/vst3sdk) |
 
 ## Optional Vendor SDK Integrations
 
@@ -43,17 +43,17 @@ See [AAX Setup](../guides/aax.md) for the supported local workflow.
 | Name | License | Purpose | Link |
 |------|---------|---------|------|
 | **Dawn** | BSD-3-Clause | WebGPU implementation (Metal, D3D12, Vulkan) | [dawn.googlesource.com](https://dawn.googlesource.com/dawn) |
-| **Skia Graphite** | BSD-3-Clause | 2D GPU rendering engine | [skia.org](https://skia.org) |
 | **SDL3** | zlib | Cross-platform windowing and input | [github.com/libsdl-org/SDL](https://github.com/libsdl-org/SDL) |
+| **Skia Graphite** | BSD-3-Clause | 2D GPU rendering engine | [skia.org](https://skia.org) |
 | **WebGPU-distribution** | MIT | WebGPU C API wrapper for Dawn | [github.com/eliemichel/WebGPU-distribution](https://github.com/eliemichel/WebGPU-distribution) |
 
 ### Optional Dependencies
 
 | Name | License | Purpose | Link |
 |------|---------|---------|------|
-| **pybind11** | BSD-3-Clause | Python bindings for HeadlessHost | [github.com/pybind/pybind11](https://github.com/pybind/pybind11) |
-| **node-addon-api** | MIT | Node.js bindings via Node-API | [github.com/niclamusic/node-addon-api](https://github.com/niclamusic/node-addon-api) |
 | **Emscripten** | MIT | C++ to WebAssembly compiler (for WAMv2/WebCLAP) | [emscripten.org](https://emscripten.org) |
+| **node-addon-api** | MIT | Node.js bindings via Node-API | [github.com/niclamusic/node-addon-api](https://github.com/niclamusic/node-addon-api) |
+| **pybind11** | BSD-3-Clause | Python bindings for HeadlessHost | [github.com/pybind/pybind11](https://github.com/pybind/pybind11) |
 
 ## Standards and Specifications
 
@@ -61,26 +61,25 @@ Pulp implements or builds on these open standards:
 
 | Standard | Organization | Purpose |
 |----------|-------------|---------|
-| [CLAP](https://cleveraudio.org) | Clever Audio | Plugin format specification |
-| [VST3](https://steinbergmedia.github.io/vst3_dev_portal/) | Steinberg | Plugin format specification |
 | [Audio Unit](https://developer.apple.com/documentation/audiounit) | Apple | Plugin format specification |
+| [CLAP](https://cleveraudio.org) | Clever Audio | Plugin format specification |
 | [LV2](https://lv2plug.in) | LV2 Community | Plugin format specification |
+| [MIDI 2.0 UMP](https://www.midi.org/specifications) | MIDI Association | Universal MIDI Packet format |
+| [OSC 1.0](https://opensoundcontrol.stanford.edu) | CNMAT | Open Sound Control messaging |
+| [VST3](https://steinbergmedia.github.io/vst3_dev_portal/) | Steinberg | Plugin format specification |
 | [WAMv2](https://www.webaudiomodules.com) | Web Audio Modules | Web plugin standard |
-| [WebCLAP](https://github.com/WebCLAP) | WebCLAP | Portable CLAP plugins via WebAssembly |
+| [WASI](https://wasi.dev) | WebAssembly CG | System interface for WebAssembly |
 | [Web Audio API](https://www.w3.org/TR/webaudio/) | W3C | Browser audio processing |
 | [Web MIDI API](https://www.w3.org/TR/webmidi/) | W3C | Browser MIDI access |
+| [WebCLAP](https://github.com/WebCLAP) | WebCLAP | Portable CLAP plugins via WebAssembly |
 | [WebGPU](https://www.w3.org/TR/webgpu/) | W3C | GPU rendering API |
-| [WASI](https://wasi.dev) | WebAssembly CG | System interface for WebAssembly |
-| [OSC 1.0](https://opensoundcontrol.stanford.edu) | CNMAT | Open Sound Control messaging |
-| [MIDI 2.0 UMP](https://www.midi.org/specifications) | MIDI Association | Universal MIDI Packet format |
 
 ## Projects That Inspired Pulp
 
-
 | Project | License | What We Learned |
 |---------|---------|-----------------|
-| [iPlug2](https://github.com/iPlug2/iPlug2) | zlib-like | Multi-format adapter architecture, graphics abstraction |
 | [AudioKit](https://github.com/AudioKit/AudioKit) | MIT | Swift audio patterns, Apple platform integration |
+| [iPlug2](https://github.com/iPlug2/iPlug2) | zlib-like | Multi-format adapter architecture, graphics abstraction |
 | [SignalKit](https://github.com/niclamusic/signalkit) | MIT | Real-time DSP patterns in Swift |
 | [signalsmith-clap-cpp](https://github.com/geraintluff/signalsmith-clap-cpp) | MIT | WCLAP build pipeline, webview extension patterns |
 | [Visage](https://github.com/VitalAudio/visage) | MIT | SDF-first rendering, dirty region tracking, shape batching, and a high bar for visual quality in audio plugin interfaces |

--- a/docs/reference/licensing.md
+++ b/docs/reference/licensing.md
@@ -83,6 +83,7 @@ Pulp implements or builds on these open standards:
 | [AudioKit](https://github.com/AudioKit/AudioKit) | MIT | Swift audio patterns, Apple platform integration |
 | [SignalKit](https://github.com/niclamusic/signalkit) | MIT | Real-time DSP patterns in Swift |
 | [signalsmith-clap-cpp](https://github.com/geraintluff/signalsmith-clap-cpp) | MIT | WCLAP build pipeline, webview extension patterns |
+| [Visage](https://github.com/VitalAudio/visage) | MIT | SDF-first rendering, dirty region tracking, shape batching, and a high bar for visual quality in audio plugin interfaces |
 
 ## Discipline
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -32,6 +32,8 @@ Pulp is organized into independent subsystems under `core/`. Each is a separate 
 | System Info | `system.hpp` | CPU model, cores, RAM, OS version, architecture |
 | Range | `range.hpp` | Templated interval with intersection, union, constrain |
 | Text Diff | `text_diff.hpp` | LCS-based line diff with formatted output |
+| Primes | `primes.hpp` | Miller-Rabin primality test, prime generation, Eratosthenes sieve |
+| Expression | `expression.hpp` | Math evaluator with variables, functions (sin/cos/sqrt/min/max), constants |
 | Scope Guard | `scope_guard.hpp` | RAII cleanup — `PULP_ON_SCOPE_EXIT(...)` |
 | Identity | `identity.hpp` | UUIDv4 generation, typed IDs (SessionId, ObjectId, RunId) |
 
@@ -91,6 +93,9 @@ Pulp is organized into independent subsystems under `core/`. Each is a separate 
 | Offline Processor | `offline_processor.hpp` | Batch-process files through a callback — bouncing, golden files |
 | Buffering Reader | `buffering_reader.hpp` | Background-thread ring buffer for gapless streaming |
 | System Volume | `system_volume.hpp` | Get/set system output volume and mute (all platforms) |
+| Streaming Writer | `streaming_writer.hpp` | Chunked WAV write — open, write_frames N times, close (16/24/32-bit) |
+| Memory-Mapped Reader | `mmap_reader.hpp` | Zero-copy audio file access via mmap + FormatRegistry |
+| Subsection Reader | `subsection_reader.hpp` | Read a frame range from audio data without copying |
 | Format Registry | `format_registry.hpp` | Extensible codec registry — register custom readers/writers |
 | Load Measurer | `load_measurer.hpp` | Real-time CPU usage tracking for audio callbacks |
 
@@ -107,6 +112,7 @@ Pulp is organized into independent subsystems under `core/`. Each is a separate 
 | MIDI Files | `midi_file.hpp` | Read/write Standard MIDI Files |
 | UMP | `ump.hpp` | Universal MIDI Packets (MIDI 2.0), MPE zones |
 | MIDI CI | `midi_ci.hpp` | Device discovery, profile management, property exchange |
+| MIDI Sequence | `midi_message_sequence.hpp` | Ordered timestamped events with note pairing, range queries |
 | CoreMIDI | platform/mac | macOS MIDI device I/O |
 | WinMIDI | platform/win | Windows MIDI device I/O |
 | ALSA MIDI | platform/linux | Linux MIDI device I/O |
@@ -149,6 +155,7 @@ Pulp is organized into independent subsystems under `core/`. Each is a separate 
 | Limiter | `compressor.hpp` | Brickwall with instant attack |
 | Noise Gate | `noise_gate.hpp` | Threshold-based gate |
 | DryWetMixer | `dry_wet_mixer.hpp` | Latency-compensated blend (linear or equal-power) |
+| Bias | `bias.hpp` | Add constant DC offset to signal |
 
 **Generators & Math:**
 
@@ -204,6 +211,13 @@ Pulp is organized into independent subsystems under `core/`. Each is a separate 
 | Standalone | ✓ Stable | Desktop app with device selector |
 | WAM | ✓ Experimental | Web Audio Module for browsers |
 | WCLAP | ✓ Experimental | Web CLAP for browsers |
+
+**Other format features:**
+
+| Feature | Header | What It Does |
+|---------|--------|-------------|
+| Host Detection | `host_type.hpp` | Detect DAW from process name (Logic, Reaper, Ableton, etc.) |
+| ARA | `ara.hpp` | Audio Random Access document controller stub |
 
 ---
 

--- a/docs/status/modules.yaml
+++ b/docs/status/modules.yaml
@@ -15,7 +15,7 @@ modules:
     docs: reference/modules.md#events
 
   - name: audio
-    summary: Multi-platform device I/O (CoreAudio, WASAPI, ALSA, JACK, Web Audio), format registry (WAV, FLAC, MP3, OGG, AIFF, AAC/ALAC), surround (5.1/7.1/Atmos), offline processing, system volume
+    summary: Multi-platform device I/O (CoreAudio, WASAPI, ALSA, JACK, Web Audio), read WAV/FLAC/MP3/OGG/AIFF/AAC, write WAV/AIFF, streaming writer, surround (5.1/7.1/Atmos), offline processing, system volume
     status: usable
     dependencies: [runtime]
     docs: reference/modules.md#audio


### PR DESCRIPTION
## P1 Fixes
1. ARA: add missing host_supports_ara() definition
2. SystemStats: runtime CPUID instead of compile-time macros
3. ContentSharer: posix_spawn/ShellExecuteW instead of std::system()

## Docs
modules.md updated with: StreamingWriter, MemoryMappedAudioReader, SubsectionReader, MidiMessageSequence, Bias, Primes, Expression, HostType, ARA

<!-- whence {"labels": ["claude", "m5", "Design async execution…", "Resume Apogee driver…"]} -->

---
### 🔎 Provenance
**Agent** `claude`  ·  **Machine** `m5`  
**Workspace** `Design async execution primitive for Pulp audio framework`  ·  **Tab** `Resume Apogee driver kit Thunderbolt extension work`  
**Session** `a5f42c57-2b9c-4635-ba06-592f94fca868`  
**Resume** `claude --resume a5f42c57-2b9c-4635-ba06-592f94fca868`  
**Restore URL** https://claude.ai/code/session_01H957K2jZjntbbrWVAQgH4k  
**Jump to this tab** `cmux surface focus 09ABB646-4377-4DDA-AF6C-CD033910050B`  
**Relaunch (any agent)** `cmux surface resume get --surface 09ABB646-4377-4DDA-AF6C-CD033910050B`  
<sub>stamped 2026-07-13 06:54 UTC</sub>
<!-- /whence -->