### PR TITLE
Package manager mobile hardening: Android + iOS platform support

### DIFF
--- a/tools/cli/package_registry.cpp
+++ b/tools/cli/package_registry.cpp
@@ -204,10 +204,10 @@ std::vector<PlatformTarget> default_targets() {
 
 bool is_valid_target(const PlatformTarget& t) {
     static const std::vector<std::string> platforms = {
-        "macOS", "Windows", "Linux", "iOS", "WASM"
+        "macOS", "Windows", "Linux", "iOS", "Android", "WASM"
     };
     static const std::vector<std::string> archs = {
-        "arm64", "x64", "x86", "wasm32"
+        "arm64", "arm64-v8a", "x64", "x86_64", "x86", "wasm32"
     };
     bool plat_ok = std::find(platforms.begin(), platforms.end(), t.platform) != platforms.end();
     bool arch_ok = std::find(archs.begin(), archs.end(), t.arch) != archs.end();
@@ -474,6 +474,7 @@ std::vector<PlatformTarget> read_project_targets(const fs::path& project_root) {
             // Expand platform to default arch
             std::string arch = "x64";
             if (val == "macOS" || val == "iOS") arch = "arm64";
+            if (val == "Android") arch = "arm64-v8a";
             if (val == "WASM") arch = "wasm32";
             auto t = PlatformTarget::parse(val + "-" + arch);
             if (t) result.push_back(*t);

--- a/tools/packages/registry-schema.json
+++ b/tools/packages/registry-schema.json
@@ -92,11 +92,15 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["arm64", "x64", "wasm32"]
+            "enum": ["arm64", "arm64-v8a", "x64", "x86_64", "x86", "wasm32"]
           },
           "minItems": 1
         },
-        "notes": { "type": "string" }
+        "notes": { "type": "string" },
+        "min_api": { "type": "integer" },
+        "ndk_compatible": { "type": "boolean" },
+        "min_version": { "type": "string" },
+        "requires_jni": { "type": "boolean" }
       }
     },
     "verification": {

--- a/tools/packages/registry.json
+++ b/tools/packages/registry.json
@@ -37,6 +37,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Header-only, pure C++"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Header-only, pure C++"
         }
       },
       "rt_safe": true,
@@ -109,6 +125,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Header-only, pure C++"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Header-only, pure C++"
         }
       },
       "rt_safe": true,
@@ -189,6 +221,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Eigen backend requires NDK r25+"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Eigen backend works on arm64"
         }
       },
       "rt_safe": true,
@@ -261,6 +309,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Core libq works; q_io (audio I/O) requires PortAudio stub"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Core libq works; q_io (audio I/O) requires PortAudio stub"
         }
       },
       "rt_safe": true,
@@ -331,6 +395,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Pure C"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Pure C"
         }
       },
       "rt_safe": false,
@@ -403,6 +483,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Single header, public domain C"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Single header, public domain C"
         }
       },
       "rt_safe": false,
@@ -482,6 +578,22 @@
             "arm64"
           ],
           "notes": "SSE on x64, NEON on arm64"
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Pure C with NEON support"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Pure C with NEON support"
         }
       },
       "rt_safe": true,
@@ -558,6 +670,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Pure C++ DSP"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Pure C++ DSP"
         }
       },
       "rt_safe": true,
@@ -649,6 +777,15 @@
           "architectures": [
             "wasm32"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Font asset, platform-independent"
         }
       },
       "rt_safe": true,
@@ -718,6 +855,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Pure C++"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Pure C++"
         }
       },
       "rt_safe": false,
@@ -810,7 +963,8 @@
       },
       "unique_value": "250+ MIR algorithms including beat/onset detection, key detection, melody extraction, and audio classification",
       "alternatives": [
-        "Q (Cycfi, MIT) for pitch detection only"
+        "Q (Cycfi, MIT) for pitch detection only",
+        "For mobile: use Q (Cycfi, MIT) for pitch detection + Aubio for beat/onset detection"
       ],
       "migration_notes": {},
       "verification": {
@@ -857,6 +1011,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Build without FFTW for minimal mobile build"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Build without FFTW for minimal mobile build"
         }
       },
       "rt_safe": true,
@@ -919,6 +1089,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Large; consider PFFFT for mobile"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Large; consider PFFFT for mobile"
         }
       },
       "rt_safe": true,
@@ -985,6 +1171,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Build with minimal deps (no libsndfile, no FFTW)"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Build with minimal deps (no libsndfile, no FFTW)"
         }
       },
       "rt_safe": true,
@@ -1052,6 +1254,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Pure C"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Pure C"
         }
       },
       "rt_safe": false,
@@ -1121,6 +1339,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Pure C++ with NEON optimizations"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Pure C++ with NEON optimizations"
         }
       },
       "rt_safe": true,
@@ -1203,7 +1437,8 @@
       "overlaps_with_builtin": {},
       "unique_value": "Full SoundFont 2 synthesis engine \u2014 load .sf2 files for instrument playback",
       "alternatives": [
-        "FluidLite (MIT \u2014 minimal SF2 subset)"
+        "FluidLite (MIT \u2014 minimal SF2 subset)",
+        "For mobile: FluidLite (MIT) has no glib dependency and supports basic SF2 playback"
       ],
       "migration_notes": {},
       "verification": {
@@ -1250,6 +1485,22 @@
             "x64",
             "arm64"
           ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Pure C++ SIMD with NEON support"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Pure C++ SIMD with NEON support"
         }
       },
       "rt_safe": true,

--- a/tools/packages/validate_registry.py
+++ b/tools/packages/validate_registry.py
@@ -89,6 +89,12 @@ def validate_structural(registry: dict) -> tuple[list[str], list[str]]:
             if not BUILD_STATUS_KEY_PATTERN.match(key):
                 warnings.append(f"  {slug}: build_status key '{key}' should be Platform-arch format")
 
+        # Mobile platform coverage check
+        has_android = "Android" in platforms
+        has_ios = "iOS" in platforms
+        if not has_android and not has_ios:
+            warnings.append(f"  {slug}: no Android or iOS platform entries — consider adding mobile support")
+
     return errors, warnings
 
 


### PR DESCRIPTION
## Summary

Adds Android and iOS as first-class platforms in the package manager:

**Schema:**
- `arm64-v8a`, `x86_64` added to architecture enum
- `min_api`, `ndk_compatible`, `min_version`, `requires_jni` fields for mobile metadata

**Registry (18 packages audited):**
- 16 packages get Android (arm64-v8a + x86_64) and iOS (arm64) entries
- 2 packages (Essentia, FluidSynth) documented as mobile-incompatible with alternatives
- Platform-specific notes for caveats (RTNeural NDK r25+, cycfi-q core-only, etc.)

**C++ code:**
- `"Android"` added to valid platforms
- `"arm64-v8a"`, `"x86_64"` added to valid architectures
- Android → arm64-v8a default arch mapping

**Validator:**
- Warns when packages lack Android/iOS entries

**Blocks:** Android platform plan Phase 6 (Integration)

## Test plan
- [x] Registry validates (all 18 packages OK)
- [x] Naming audit passes
- [ ] CI green on all platforms