### PR TITLE
Add plugin inspector: visual overlay, audio monitoring, TCP protocol, CLI client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,10 @@ if(TARGET pulp-render)
     list(APPEND PULP_SDK_TARGETS pulp-render)
 endif()
 
+if(TARGET pulp-inspect)
+    list(APPEND PULP_SDK_TARGETS pulp-inspect)
+endif()
+
 foreach(_sdk_target IN LISTS PULP_SDK_TARGETS)
     string(REPLACE "pulp-" "" _sdk_export_name "${_sdk_target}")
     set_target_properties(${_sdk_target} PROPERTIES EXPORT_NAME "${_sdk_export_name}")

--- a/core/format/CMakeLists.txt
+++ b/core/format/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(pulp-format
         pulp::midi
         pulp::state
         pulp::view
+        pulp::inspect
 )
 
 # VST3 adapter (when SDK is available)

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -2,7 +2,9 @@
 #include <pulp/format/editor_ui.hpp>
 #include <pulp/format/settings_panel.hpp>
 #include <pulp/view/window_host.hpp>
+#include <pulp/inspect/inspector_overlay.hpp>
 #include <pulp/runtime/log.hpp>
+#include <pulp/runtime/system.hpp>
 
 namespace pulp::format {
 
@@ -249,9 +251,51 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     }
 
     window->set_close_callback([this]() { stop(); });
+
+    // Create inspector overlay — activated via Cmd+I / Ctrl+I
+    auto inspector = std::make_unique<inspect::InspectorOverlay>(*tab_panel);
+    auto* inspector_ptr = inspector.get();
+
+    // Wire inspector into the idle callback to push overlay paint each frame.
+    // The inspector uses View::overlay_queue() for rendering and intercepts
+    // key events through the root view's on_global_click callback for Cmd+I.
+    if (editor_ui.scripted_ui) {
+        auto* scripted_ui_ptr = editor_ui.scripted_ui.get();
+        window->set_idle_callback([scripted_ui_ptr, settings_ptr, inspector_ptr, &tab_panel] {
+            if (scripted_ui_ptr) scripted_ui_ptr->poll();
+            if (settings_ptr) settings_ptr->poll();
+            if (inspector_ptr->is_active()) {
+                view::View::overlay_queue().push_back({
+                    [inspector_ptr](canvas::Canvas& canvas) {
+                        inspector_ptr->paint(canvas);
+                    },
+                    tab_panel.get()
+                });
+            }
+        });
+    } else {
+        window->set_idle_callback([settings_ptr, inspector_ptr, &tab_panel] {
+            if (settings_ptr) settings_ptr->poll();
+            if (inspector_ptr->is_active()) {
+                view::View::overlay_queue().push_back({
+                    [inspector_ptr](canvas::Canvas& canvas) {
+                        inspector_ptr->paint(canvas);
+                    },
+                    tab_panel.get()
+                });
+            }
+        });
+    }
+
+    // Enable inspector by default when PULP_INSPECTOR env var is set
+    if (runtime::get_env("PULP_INSPECTOR")) {
+        inspector_ptr->set_active(true);
+        runtime::log_info("Standalone: inspector enabled via PULP_INSPECTOR env var");
+    }
+
     window->show();
 
-    runtime::log_info("Standalone: editor window open ({}x{}, gpu={}, mode={})",
+    runtime::log_info("Standalone: editor window open ({}x{}, gpu={}, mode={}, inspector=ready)",
                       w, h, use_gpu, editor_ui.uses_script_ui ? "scripted" : "autoui");
 
     // Blocks until the window is closed

--- a/core/runtime/src/expression.cpp
+++ b/core/runtime/src/expression.cpp
@@ -1,4 +1,5 @@
 #include <pulp/runtime/expression.hpp>
+#include <algorithm>
 #include <cmath>
 #include <cctype>
 #include <stdexcept>

--- a/core/runtime/src/primes.cpp
+++ b/core/runtime/src/primes.cpp
@@ -2,6 +2,20 @@
 #include <cmath>
 #include <random>
 
+// MSVC doesn't support __uint128_t. Use a portable multiply-mod helper.
+#ifdef _MSC_VER
+static uint64_t mulmod(uint64_t a, uint64_t b, uint64_t m) {
+    uint64_t result = 0;
+    a %= m;
+    while (b > 0) {
+        if (b & 1) result = (result + a) % m;
+        a = (a * 2) % m;
+        b >>= 1;
+    }
+    return result;
+}
+#endif
+
 namespace pulp::runtime {
 
 bool is_prime(uint64_t n, int rounds) {
@@ -22,22 +36,37 @@ bool is_prime(uint64_t n, int rounds) {
         uint64_t a = dist(rng);
 
         // Compute a^d mod n using modular exponentiation
-        __uint128_t x = 1;
-        __uint128_t base = a;
+#ifdef _MSC_VER
+        uint64_t x = 1;
+        uint64_t base_val = a % n;
         uint64_t exp = d;
         while (exp > 0) {
-            if (exp & 1) x = (x * base) % n;
-            base = (base * base) % n;
+            if (exp & 1) x = mulmod(x, base_val, n);
+            base_val = mulmod(base_val, base_val, n);
             exp >>= 1;
         }
-
+        uint64_t result = x;
+#else
+        __uint128_t x = 1;
+        __uint128_t base_val = a;
+        uint64_t exp = d;
+        while (exp > 0) {
+            if (exp & 1) x = (x * base_val) % n;
+            base_val = (base_val * base_val) % n;
+            exp >>= 1;
+        }
         uint64_t result = static_cast<uint64_t>(x);
+#endif
         if (result == 1 || result == n - 1) continue;
 
         bool found = false;
         for (int j = 0; j < r - 1; ++j) {
-            x = (static_cast<__uint128_t>(result) * result) % n;
-            result = static_cast<uint64_t>(x);
+#ifdef _MSC_VER
+            result = mulmod(result, result, n);
+#else
+            __uint128_t xx = (static_cast<__uint128_t>(result) * result) % n;
+            result = static_cast<uint64_t>(xx);
+#endif
             if (result == n - 1) { found = true; break; }
         }
         if (!found) return false;

--- a/core/signal/include/pulp/signal/simd_buffer.hpp
+++ b/core/signal/include/pulp/signal/simd_buffer.hpp
@@ -9,6 +9,15 @@
 #include <memory>
 #include <algorithm>
 
+#ifdef _MSC_VER
+#include <malloc.h>
+inline void* pulp_aligned_alloc(size_t alignment, size_t size) { return _aligned_malloc(size, alignment); }
+inline void pulp_aligned_free(void* p) { _aligned_free(p); }
+#else
+inline void* pulp_aligned_alloc(size_t alignment, size_t size) { return std::aligned_alloc(alignment, size); }
+inline void pulp_aligned_free(void* p) { std::free(p); }
+#endif
+
 namespace pulp::signal {
 
 /// Alignment in bytes for SIMD operations (covers AVX-512)
@@ -24,12 +33,12 @@ public:
         if (num_samples > 0) {
             // Round up to alignment boundary
             size_t bytes = num_samples * sizeof(float);
-            data_ = static_cast<float*>(std::aligned_alloc(kSimdAlignment, align_up(bytes)));
+            data_ = static_cast<float*>(pulp_aligned_alloc(kSimdAlignment, align_up(bytes)));
             std::memset(data_, 0, align_up(bytes));
         }
     }
 
-    ~AlignedBuffer() { std::free(data_); }
+    ~AlignedBuffer() { pulp_aligned_free(data_); }
 
     // Move only
     AlignedBuffer(AlignedBuffer&& other) noexcept
@@ -40,7 +49,7 @@ public:
 
     AlignedBuffer& operator=(AlignedBuffer&& other) noexcept {
         if (this != &other) {
-            std::free(data_);
+            pulp_aligned_free(data_);
             data_ = other.data_;
             size_ = other.size_;
             other.data_ = nullptr;
@@ -74,12 +83,12 @@ public:
     /// Resize (reallocates, does not preserve data)
     void resize(size_t new_size) {
         if (new_size == size_) return;
-        std::free(data_);
+        pulp_aligned_free(data_);
         data_ = nullptr;
         size_ = new_size;
         if (new_size > 0) {
             size_t bytes = new_size * sizeof(float);
-            data_ = static_cast<float*>(std::aligned_alloc(kSimdAlignment, align_up(bytes)));
+            data_ = static_cast<float*>(pulp_aligned_alloc(kSimdAlignment, align_up(bytes)));
             std::memset(data_, 0, align_up(bytes));
         }
     }

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -43,7 +43,6 @@ target_include_directories(pulp-view
         $<INSTALL_INTERFACE:include>
     PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}  # For generated web_compat_preludes_gen.hpp
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../inspect/include>  # Inspector overlay header for platform key interception
 )
 
 # ── JS engine backend selection ──────────────────────────────────────────────

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -43,6 +43,7 @@ target_include_directories(pulp-view
         $<INSTALL_INTERFACE:include>
     PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}  # For generated web_compat_preludes_gen.hpp
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../inspect/include>  # Inspector overlay header for platform key/mouse interception
 )
 
 # ── JS engine backend selection ──────────────────────────────────────────────

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(pulp-view
         $<INSTALL_INTERFACE:include>
     PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}  # For generated web_compat_preludes_gen.hpp
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../inspect/include>  # Inspector overlay header for platform key/mouse interception
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../inspect/include>  # Inspector overlay header for platform key interception
 )
 
 # ── JS engine backend selection ──────────────────────────────────────────────

--- a/core/view/include/pulp/view/sprite_strip.hpp
+++ b/core/view/include/pulp/view/sprite_strip.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <vector>

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -278,9 +278,13 @@ public:
     static std::vector<OverlayRequest>& overlay_queue();
     static void paint_overlays(canvas::Canvas& canvas);
 
-    /// Set a paint hook called after all overlays. Used by the inspector module
-    /// to paint on top of everything without a circular dependency.
+    /// Inspector hooks — set by the inspector module to intercept input and paint
+    /// without a circular dependency (view doesn't link inspect).
     static void set_inspector_paint_hook(std::function<void(canvas::Canvas&)> hook);
+    static void set_inspector_key_hook(std::function<bool(const KeyEvent&)> hook);
+    static void set_inspector_mouse_hook(std::function<bool(const MouseEvent&)> hook);
+    static bool call_inspector_key_hook(const KeyEvent& e);
+    static bool call_inspector_mouse_hook(const MouseEvent& e);
 
     /// Global click callback (fires on any view click with widget id). Set on root.
     std::function<void(const std::string& id, uint16_t modifiers)> on_global_click;

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -278,6 +278,10 @@ public:
     static std::vector<OverlayRequest>& overlay_queue();
     static void paint_overlays(canvas::Canvas& canvas);
 
+    /// Set a paint hook called after all overlays. Used by the inspector module
+    /// to paint on top of everything without a circular dependency.
+    static void set_inspector_paint_hook(std::function<void(canvas::Canvas&)> hook);
+
     /// Global click callback (fires on any view click with widget id). Set on root.
     std::function<void(const std::string& id, uint16_t modifiers)> on_global_click;
 

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -5,7 +5,6 @@
 #include <pulp/view/ui_components.hpp>
 #include <pulp/view/text_editor.hpp>
 #include <pulp/view/modal.hpp>
-#include <pulp/inspect/inspector_overlay.hpp>
 
 #include <TargetConditionals.h>
 #if TARGET_OS_OSX
@@ -311,17 +310,15 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             auto pt = [self localPoint:event];
 
         // Inspector intercept — consume clicks when inspector is active
-        if (auto* inspector = pulp::inspect::g_active_inspector) {
-            if (inspector->is_active()) {
-                auto mods = modifiersFromNSFlags(event.modifierFlags);
-                pulp::view::MouseEvent me;
-                me.position = {pt.x, pt.y};
-                me.modifiers = mods;
-                me.is_down = true;
-                if (inspector->handle_mouse_event(me)) {
-                    [self setNeedsDisplay:YES];
-                    return;
-                }
+        {
+            auto mods = modifiersFromNSFlags(event.modifierFlags);
+            pulp::view::MouseEvent me;
+            me.position = {pt.x, pt.y};
+            me.modifiers = mods;
+            me.is_down = true;
+            if (pulp::view::View::call_inspector_mouse_hook(me)) {
+                [self setNeedsDisplay:YES];
+                return;
             }
         }
 
@@ -492,13 +489,13 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             auto mods = modifiersFromNSFlags(event.modifierFlags);
 
         // Inspector intercept — check before all other key handling
-        if (auto* inspector = pulp::inspect::g_active_inspector) {
+        {
             pulp::view::KeyEvent ike;
             ike.key = key;
             ike.modifiers = mods;
             ike.is_down = true;
             ike.is_repeat = event.isARepeat;
-            if (inspector->handle_key_event(ike)) {
+            if (pulp::view::View::call_inspector_key_hook(ike)) {
                 [self setNeedsDisplay:YES];
                 return;
             }
@@ -660,15 +657,12 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             auto pt = [self localPoint:event];
 
             // Inspector hover intercept
-            if (auto* inspector = pulp::inspect::g_active_inspector) {
-                if (inspector->is_active()) {
-                    pulp::view::MouseEvent me;
-                    me.position = {pt.x, pt.y};
-                    me.is_down = false;
-                    inspector->handle_mouse_event(me);
-                    [self setNeedsDisplay:YES];
-                    // Don't return — let normal hover handling continue for cursor changes
-                }
+            {
+                pulp::view::MouseEvent me;
+                me.position = {pt.x, pt.y};
+                me.is_down = false;
+                pulp::view::View::call_inspector_mouse_hook(me);
+                // Don't consume — let normal hover handling continue for cursor changes
             }
 
             if (pulp::view::ComboBox::active_popup_) {

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -848,6 +848,8 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
         self.rootView->layout_children();
         self.rootView->paint_all(canvas);
         pulp::view::View::paint_overlays(canvas);
+
+        // Inspector overlay is painted automatically via View::paint_overlays()
     }
 }
 
@@ -1504,6 +1506,8 @@ private:
 
         root_.paint_all(canvas);
         pulp::view::View::paint_overlays(canvas);
+
+        // Inspector overlay is painted automatically via View::paint_overlays()
     }
 
     bool render_frame(std::vector<uint8_t>* capture_pixels = nullptr,

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -5,6 +5,7 @@
 #include <pulp/view/ui_components.hpp>
 #include <pulp/view/text_editor.hpp>
 #include <pulp/view/modal.hpp>
+#include <pulp/inspect/inspector_overlay.hpp>
 
 #include <TargetConditionals.h>
 #if TARGET_OS_OSX
@@ -309,6 +310,21 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             }
             auto pt = [self localPoint:event];
 
+        // Inspector intercept — consume clicks when inspector is active
+        if (auto* inspector = pulp::inspect::g_active_inspector) {
+            if (inspector->is_active()) {
+                auto mods = modifiersFromNSFlags(event.modifierFlags);
+                pulp::view::MouseEvent me;
+                me.position = {pt.x, pt.y};
+                me.modifiers = mods;
+                me.is_down = true;
+                if (inspector->handle_mouse_event(me)) {
+                    [self setNeedsDisplay:YES];
+                    return;
+                }
+            }
+        }
+
         // Check if click is inside an active ComboBox dropdown overlay.
         // The dropdown renders as a paint overlay with no view backing, so
         // normal hit_test finds the view behind the dropdown. Route the click
@@ -475,6 +491,19 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             auto key = keyCodeFromNS(event.keyCode);
             auto mods = modifiersFromNSFlags(event.modifierFlags);
 
+        // Inspector intercept — check before all other key handling
+        if (auto* inspector = pulp::inspect::g_active_inspector) {
+            pulp::view::KeyEvent ike;
+            ike.key = key;
+            ike.modifiers = mods;
+            ike.is_down = true;
+            ike.is_repeat = event.isARepeat;
+            if (inspector->handle_key_event(ike)) {
+                [self setNeedsDisplay:YES];
+                return;
+            }
+        }
+
         if (key == pulp::view::KeyCode::tab && self.rootView) {
             auto* old = _focusedView;
             pulp::view::View* next = nullptr;
@@ -629,6 +658,18 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
         try {
             if (!self.rootView) return;
             auto pt = [self localPoint:event];
+
+            // Inspector hover intercept
+            if (auto* inspector = pulp::inspect::g_active_inspector) {
+                if (inspector->is_active()) {
+                    pulp::view::MouseEvent me;
+                    me.position = {pt.x, pt.y};
+                    me.is_down = false;
+                    inspector->handle_mouse_event(me);
+                    [self setNeedsDisplay:YES];
+                    // Don't return — let normal hover handling continue for cursor changes
+                }
+            }
 
             if (pulp::view::ComboBox::active_popup_) {
                 auto* combo = pulp::view::ComboBox::active_popup_;

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -1,4 +1,5 @@
 #include <pulp/view/view.hpp>
+#include <pulp/inspect/inspector_overlay.hpp>
 #include <algorithm>
 #include <numeric>
 #include <sstream>
@@ -288,6 +289,11 @@ void View::paint_overlays(canvas::Canvas& canvas) {
         if (req.paint_fn) req.paint_fn(canvas);
     }
     queue.clear();
+
+    // Inspector overlay — always paint last (on top of everything)
+    if (auto* inspector = inspect::g_active_inspector) {
+        inspector->paint(canvas);
+    }
 }
 
 Color View::resolve_color(const std::string& name, Color fallback) const {

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -282,12 +282,26 @@ std::vector<View::OverlayRequest>& View::overlay_queue() {
     return queue;
 }
 
-// Global inspector paint hook — set by the inspector module, called after overlays.
-// Uses a function pointer to avoid circular dependency (view → inspect).
+// Inspector hooks — set by the inspector module via function pointers
+// to avoid circular dependency (view → inspect).
 static std::function<void(canvas::Canvas&)> s_inspector_paint_hook;
+static std::function<bool(const KeyEvent&)> s_inspector_key_hook;
+static std::function<bool(const MouseEvent&)> s_inspector_mouse_hook;
 
 void View::set_inspector_paint_hook(std::function<void(canvas::Canvas&)> hook) {
     s_inspector_paint_hook = std::move(hook);
+}
+void View::set_inspector_key_hook(std::function<bool(const KeyEvent&)> hook) {
+    s_inspector_key_hook = std::move(hook);
+}
+void View::set_inspector_mouse_hook(std::function<bool(const MouseEvent&)> hook) {
+    s_inspector_mouse_hook = std::move(hook);
+}
+bool View::call_inspector_key_hook(const KeyEvent& e) {
+    return s_inspector_key_hook ? s_inspector_key_hook(e) : false;
+}
+bool View::call_inspector_mouse_hook(const MouseEvent& e) {
+    return s_inspector_mouse_hook ? s_inspector_mouse_hook(e) : false;
 }
 
 void View::paint_overlays(canvas::Canvas& canvas) {

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -1,5 +1,4 @@
 #include <pulp/view/view.hpp>
-#include <pulp/inspect/inspector_overlay.hpp>
 #include <algorithm>
 #include <numeric>
 #include <sstream>
@@ -283,6 +282,14 @@ std::vector<View::OverlayRequest>& View::overlay_queue() {
     return queue;
 }
 
+// Global inspector paint hook — set by the inspector module, called after overlays.
+// Uses a function pointer to avoid circular dependency (view → inspect).
+static std::function<void(canvas::Canvas&)> s_inspector_paint_hook;
+
+void View::set_inspector_paint_hook(std::function<void(canvas::Canvas&)> hook) {
+    s_inspector_paint_hook = std::move(hook);
+}
+
 void View::paint_overlays(canvas::Canvas& canvas) {
     auto& queue = overlay_queue();
     for (auto& req : queue) {
@@ -290,9 +297,9 @@ void View::paint_overlays(canvas::Canvas& canvas) {
     }
     queue.clear();
 
-    // Inspector overlay — always paint last (on top of everything)
-    if (auto* inspector = inspect::g_active_inspector) {
-        inspector->paint(canvas);
+    // Inspector paint hook — called after all overlays, topmost layer
+    if (s_inspector_paint_hook) {
+        s_inspector_paint_hook(canvas);
     }
 }
 

--- a/examples/ui-preview/CMakeLists.txt
+++ b/examples/ui-preview/CMakeLists.txt
@@ -4,5 +4,6 @@ if(APPLE)
     target_link_libraries(pulp-ui-preview PRIVATE
         pulp::view
         pulp::state
+        pulp::inspect
     )
 endif()

--- a/examples/ui-preview/main.cpp
+++ b/examples/ui-preview/main.cpp
@@ -306,6 +306,13 @@ int main(int argc, char* argv[]) {
         return true;
     };
 
+    // Set up inspector before screenshot so it renders in headless mode too
+    pulp::inspect::InspectorOverlay inspector(root);
+    pulp::inspect::g_active_inspector = &inspector;
+    if (pulp::runtime::get_env("PULP_INSPECTOR")) {
+        inspector.set_active(true);
+    }
+
     if (screenshot_only) {
         if (!emit_view_tree(render_w, render_h)) return 1;
         bool ok = render_to_file(
@@ -314,6 +321,7 @@ int main(int argc, char* argv[]) {
             static_cast<uint32_t>(render_h),
             screenshot_path.c_str());
         std::cout << (ok ? "Screenshot saved to " + screenshot_path + "\n" : "Screenshot failed\n");
+        pulp::inspect::g_active_inspector = nullptr;
         return ok ? 0 : 1;
     }
 
@@ -427,25 +435,8 @@ int main(int argc, char* argv[]) {
     }
 #endif
 
-    // Inspector overlay — toggle with Cmd+I, or pre-enable via PULP_INSPECTOR=1
-    pulp::inspect::InspectorOverlay inspector(root);
-    pulp::inspect::g_active_inspector = &inspector;
-    if (pulp::runtime::get_env("PULP_INSPECTOR")) {
-        inspector.set_active(true);
-        std::cout << "Inspector enabled (Cmd+I to toggle)\n";
-    }
-
-    // Wire inspector into idle callback — push overlay paint each frame
-    window->set_idle_callback([&inspector, &root] {
-        if (inspector.is_active()) {
-            View::overlay_queue().push_back({
-                [&inspector](pulp::canvas::Canvas& canvas) {
-                    inspector.paint(canvas);
-                },
-                &root
-            });
-        }
-    });
+    // Inspector was set up before screenshot_only check above.
+    // Cmd+I toggle is handled by the platform WindowHost key dispatch.
 
     std::cout << "Opening window... (Cmd+I for inspector)\n";
     window->run_event_loop();

--- a/examples/ui-preview/main.cpp
+++ b/examples/ui-preview/main.cpp
@@ -8,6 +8,8 @@
 #include <pulp/view/theme.hpp>
 #include <pulp/view/frame_clock.hpp>
 #include <pulp/view/inspector.hpp>
+#include <pulp/inspect/inspector_overlay.hpp>
+#include <pulp/runtime/system.hpp>
 #include <pulp/view/screenshot.hpp>
 #include <pulp/view/script_engine.hpp>
 #include <pulp/view/widget_bridge.hpp>
@@ -425,7 +427,26 @@ int main(int argc, char* argv[]) {
     }
 #endif
 
-    std::cout << "Opening window...\n";
+    // Inspector overlay — toggle with Cmd+I, or pre-enable via PULP_INSPECTOR=1
+    pulp::inspect::InspectorOverlay inspector(root);
+    if (pulp::runtime::get_env("PULP_INSPECTOR")) {
+        inspector.set_active(true);
+        std::cout << "Inspector enabled (Cmd+I to toggle)\n";
+    }
+
+    // Wire inspector into idle callback — push overlay paint each frame
+    window->set_idle_callback([&inspector, &root] {
+        if (inspector.is_active()) {
+            View::overlay_queue().push_back({
+                [&inspector](pulp::canvas::Canvas& canvas) {
+                    inspector.paint(canvas);
+                },
+                &root
+            });
+        }
+    });
+
+    std::cout << "Opening window... (Cmd+I for inspector)\n";
     window->run_event_loop();
     return automation_exit_code;
 }

--- a/examples/ui-preview/main.cpp
+++ b/examples/ui-preview/main.cpp
@@ -429,6 +429,7 @@ int main(int argc, char* argv[]) {
 
     // Inspector overlay — toggle with Cmd+I, or pre-enable via PULP_INSPECTOR=1
     pulp::inspect::InspectorOverlay inspector(root);
+    pulp::inspect::g_active_inspector = &inspector;
     if (pulp::runtime::get_env("PULP_INSPECTOR")) {
         inspector.set_active(true);
         std::cout << "Inspector enabled (Cmd+I to toggle)\n";

--- a/examples/ui-preview/main.cpp
+++ b/examples/ui-preview/main.cpp
@@ -308,7 +308,7 @@ int main(int argc, char* argv[]) {
 
     // Set up inspector before screenshot so it renders in headless mode too
     pulp::inspect::InspectorOverlay inspector(root);
-    pulp::inspect::g_active_inspector = &inspector;
+    pulp::inspect::install_inspector_hooks(inspector);
     if (pulp::runtime::get_env("PULP_INSPECTOR")) {
         inspector.set_active(true);
     }

--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(pulp-inspect PRIVATE
     src/console_capture.cpp
     src/protocol.cpp
     src/inspector_server.cpp
+    src/audio_inspector.cpp
 )
 
 target_link_libraries(pulp-inspect PUBLIC pulp::view pulp::render pulp::state pulp::events)

--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -11,6 +11,8 @@ target_sources(pulp-inspect PRIVATE
     src/inspector_overlay.cpp
     src/state_inspector.cpp
     src/console_capture.cpp
+    src/protocol.cpp
+    src/inspector_server.cpp
 )
 
-target_link_libraries(pulp-inspect PUBLIC pulp::view pulp::render pulp::state)
+target_link_libraries(pulp-inspect PUBLIC pulp::view pulp::render pulp::state pulp::events)

--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -8,11 +8,7 @@ target_include_directories(pulp-inspect
 )
 
 target_sources(pulp-inspect PRIVATE
-    src/placeholder.cpp
-)
-
-file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/src/placeholder.cpp
-    "// pulp-inspect: placeholder — replaced in Phase 6\nnamespace pulp::inspect {}\n"
+    src/inspector_overlay.cpp
 )
 
 target_link_libraries(pulp-inspect PUBLIC pulp::view pulp::render)

--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(pulp-inspect PRIVATE
     src/protocol.cpp
     src/inspector_server.cpp
     src/audio_inspector.cpp
+    src/domain_handler.cpp
 )
 
 target_link_libraries(pulp-inspect PUBLIC pulp::view pulp::render pulp::state pulp::events)

--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -9,6 +9,8 @@ target_include_directories(pulp-inspect
 
 target_sources(pulp-inspect PRIVATE
     src/inspector_overlay.cpp
+    src/state_inspector.cpp
+    src/console_capture.cpp
 )
 
-target_link_libraries(pulp-inspect PUBLIC pulp::view pulp::render)
+target_link_libraries(pulp-inspect PUBLIC pulp::view pulp::render pulp::state)

--- a/inspect/include/pulp/inspect/audio_inspector.hpp
+++ b/inspect/include/pulp/inspect/audio_inspector.hpp
@@ -1,0 +1,95 @@
+// audio_inspector.hpp — Audio domain monitoring for the inspector
+// Buffer underrun detection, per-channel metering, MIDI event logging.
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace pulp::inspect {
+
+/// Audio configuration snapshot
+struct AudioConfig {
+    double sample_rate = 0;
+    int buffer_size = 0;
+    int input_channels = 0;
+    int output_channels = 0;
+    int latency_samples = 0;
+};
+
+/// A single MIDI event for logging
+struct MidiLogEntry {
+    uint8_t status;
+    uint8_t data1;
+    uint8_t data2;
+    std::chrono::steady_clock::time_point time;
+    std::string description;  // e.g., "Note On C4 vel=100"
+};
+
+/// Buffer underrun event
+struct BufferUnderrun {
+    uint64_t frame;
+    float callback_time_ms;
+    float budget_ms;
+    std::chrono::steady_clock::time_point time;
+};
+
+/// Per-channel audio levels
+struct ChannelLevels {
+    float peak = 0;
+    float rms = 0;
+};
+
+/// Monitors audio thread performance and state for the inspector.
+/// All methods are thread-safe (called from audio thread, read from UI thread).
+class AudioInspector {
+public:
+    AudioInspector() = default;
+
+    // ── Configuration ───────────────────────────────────────────────
+    void set_config(const AudioConfig& config);
+    AudioConfig config() const;
+
+    // ── Callback timing (call from audio thread) ────────────────────
+    /// Call at the start/end of each audio callback to measure duration.
+    void begin_callback();
+    void end_callback(uint64_t frame_number);
+
+    // ── Metering (call from audio thread) ───────────────────────────
+    /// Report output levels for the current buffer.
+    void report_levels(const std::vector<ChannelLevels>& levels);
+
+    // ── MIDI logging (call from audio thread) ───────────────────────
+    void log_midi(uint8_t status, uint8_t data1, uint8_t data2,
+                  const std::string& description = {});
+
+    // ── Queries (call from any thread) ──────────────────────────────
+    std::vector<BufferUnderrun> recent_underruns() const;
+    std::vector<MidiLogEntry> recent_midi() const;
+    std::vector<ChannelLevels> latest_levels() const;
+    bool metering_enabled() const { return metering_enabled_; }
+    void set_metering_enabled(bool enabled) { metering_enabled_ = enabled; }
+
+private:
+    mutable std::mutex mutex_;
+    AudioConfig config_;
+    bool metering_enabled_ = false;
+
+    // Callback timing
+    std::chrono::steady_clock::time_point callback_start_;
+
+    // Underrun ring buffer
+    std::vector<BufferUnderrun> underruns_;
+    static constexpr size_t kMaxUnderruns = 50;
+
+    // MIDI ring buffer
+    std::vector<MidiLogEntry> midi_log_;
+    static constexpr size_t kMaxMidi = 200;
+
+    // Latest levels
+    std::vector<ChannelLevels> levels_;
+};
+
+} // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/console_capture.hpp
+++ b/inspect/include/pulp/inspect/console_capture.hpp
@@ -1,0 +1,42 @@
+// console_capture.hpp — JS console log interception for the inspector
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pulp::inspect {
+
+/// Captures JS console output (console.log/warn/error) for inspector display.
+/// Chains on an existing log callback — does not replace it.
+class ConsoleCapture {
+public:
+    /// A captured log entry
+    struct Entry {
+        std::string level;    // "log", "warn", "error", "info", "debug"
+        std::string message;
+        std::chrono::steady_clock::time_point time;
+    };
+
+    using LogCallback = std::function<void(std::string_view level, std::string_view message)>;
+
+    /// Install the capture. Chains with the previous callback.
+    /// Call with the ScriptEngine's set_log_callback: engine.set_log_callback(capture.callback());
+    LogCallback callback(LogCallback previous = {});
+
+    /// Get all captured entries (ring buffer, last 200)
+    std::vector<Entry> entries() const;
+
+    /// Clear all entries
+    void clear();
+
+private:
+    mutable std::mutex mutex_;
+    std::vector<Entry> entries_;
+    static constexpr size_t kMaxEntries = 200;
+};
+
+} // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/domain_handler.hpp
+++ b/inspect/include/pulp/inspect/domain_handler.hpp
@@ -1,0 +1,54 @@
+// domain_handler.hpp — Dispatches inspector protocol requests to data sources
+#pragma once
+
+#include <pulp/inspect/protocol.hpp>
+
+namespace pulp::view { class View; }
+namespace pulp::render { class RenderPassManager; }
+
+namespace pulp::inspect {
+
+class InspectorOverlay;
+class StateInspector;
+class ConsoleCapture;
+class AudioInspector;
+
+/// Handles inspector protocol requests by delegating to the appropriate
+/// inspector component. All data sources are optional — missing sources
+/// return error responses for their domain's methods.
+class DomainHandler {
+public:
+    DomainHandler() = default;
+
+    // ── Data sources (all optional) ─────────────────────────────────
+    void set_root_view(view::View* root) { root_ = root; }
+    void set_overlay(InspectorOverlay* overlay) { overlay_ = overlay; }
+    void set_state_inspector(StateInspector* state) { state_ = state; }
+    void set_console_capture(ConsoleCapture* console) { console_ = console; }
+    void set_audio_inspector(AudioInspector* audio) { audio_ = audio; }
+    void set_render_pass_manager(render::RenderPassManager* rpm) { rpm_ = rpm; }
+
+    /// Handle a protocol request. Returns a response message.
+    InspectorMessage handle(const InspectorMessage& request);
+
+private:
+    view::View* root_ = nullptr;
+    InspectorOverlay* overlay_ = nullptr;
+    StateInspector* state_ = nullptr;
+    ConsoleCapture* console_ = nullptr;
+    AudioInspector* audio_ = nullptr;
+    render::RenderPassManager* rpm_ = nullptr;
+
+    // Domain handlers
+    InspectorMessage handle_inspector(const InspectorMessage& req);
+    InspectorMessage handle_dom(const InspectorMessage& req);
+    InspectorMessage handle_css(const InspectorMessage& req);
+    InspectorMessage handle_performance(const InspectorMessage& req);
+    InspectorMessage handle_state(const InspectorMessage& req);
+    InspectorMessage handle_console(const InspectorMessage& req);
+    InspectorMessage handle_runtime(const InspectorMessage& req);
+    InspectorMessage handle_audio(const InspectorMessage& req);
+    InspectorMessage handle_capture(const InspectorMessage& req);
+};
+
+} // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -1,0 +1,99 @@
+// inspector_overlay.hpp — Visual inspector overlay for Pulp view trees
+// Renders highlight, property panel, and frame stats on top of the plugin UI.
+// Toggled via Cmd+I (macOS) / Ctrl+I (Windows/Linux).
+#pragma once
+
+#include <pulp/view/view.hpp>
+#include <pulp/view/input_events.hpp>
+#include <pulp/canvas/canvas.hpp>
+
+#include <functional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace pulp::render { class RenderPassManager; }
+
+namespace pulp::inspect {
+
+using namespace pulp::view;
+using namespace pulp::canvas;
+
+class InspectorOverlay {
+public:
+    explicit InspectorOverlay(View& root);
+
+    // ── Toggle ──────────────────────────────────────────────────────
+    bool is_active() const { return active_; }
+    void set_active(bool active);
+    void toggle() { set_active(!active_); }
+
+    // ── Input interception ──────────────────────────────────────────
+    // Call from host BEFORE dispatching to view tree.
+    // Returns true if the inspector consumed the event.
+    bool handle_key_event(const KeyEvent& event);
+    bool handle_mouse_event(const MouseEvent& event);
+
+    // ── Painting ────────────────────────────────────────────────────
+    // Call AFTER View::paint_overlays() to paint on top of everything.
+    void paint(Canvas& canvas);
+
+    // ── Data sources ────────────────────────────────────────────────
+    void set_render_pass_manager(render::RenderPassManager* rpm) { rpm_ = rpm; }
+
+    // ── Selection ───────────────────────────────────────────────────
+    View* selected_view() const { return selected_; }
+    View* hovered_view() const { return hovered_; }
+
+private:
+    View& root_;
+    bool active_ = false;
+
+    View* selected_ = nullptr;
+    View* hovered_ = nullptr;
+
+    // Distance measurement mode
+    View* distance_anchor_ = nullptr;
+
+    // Panel layout
+    float panel_width_ = 300.0f;
+    float tree_scroll_y_ = 0.0f;
+
+    // Tree expansion: collapsed nodes
+    std::unordered_set<const View*> collapsed_;
+
+    // Optional stats source
+    render::RenderPassManager* rpm_ = nullptr;
+
+    // ── Flat tree for rendering ─────────────────────────────────────
+    struct TreeItem {
+        const View* view;
+        int depth;
+    };
+    std::vector<TreeItem> flat_tree_;
+    void rebuild_flat_tree();
+
+    // ── Coordinate helpers ──────────────────────────────────────────
+    Rect view_bounds_in_root(const View* v) const;
+
+    // ── Paint helpers ───────────────────────────────────────────────
+    void paint_highlight(Canvas& canvas);
+    void paint_distance_lines(Canvas& canvas);
+    void paint_box_model(Canvas& canvas, const View* v);
+    void paint_panel(Canvas& canvas);
+    void paint_tree_section(Canvas& canvas, float x, float y, float w, float& cursor_y);
+    void paint_props_section(Canvas& canvas, float x, float y, float w, float h);
+    void paint_stats_bar(Canvas& canvas, float x, float y, float w);
+
+    // ── Panel hit testing ───────────────────────────────────────────
+    bool point_in_panel(Point p) const;
+    const TreeItem* tree_item_at_y(float panel_y) const;
+
+    // ── Constants ───────────────────────────────────────────────────
+    static constexpr float kRowHeight = 20.0f;
+    static constexpr float kIndent = 16.0f;
+    static constexpr float kFontSize = 11.0f;
+    static constexpr float kStatsBarHeight = 24.0f;
+};
+
+} // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -96,4 +96,10 @@ private:
     static constexpr float kStatsBarHeight = 24.0f;
 };
 
+/// Global inspector instance for the current window.
+/// Set by the host when creating the inspector. The platform WindowHost
+/// checks this to intercept key/mouse events before normal dispatch.
+/// Thread-safe: only accessed on the UI thread.
+inline InspectorOverlay* g_active_inspector = nullptr;
+
 } // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -104,6 +104,8 @@ inline InspectorOverlay* g_active_inspector = nullptr;
 
 /// Install the inspector into the View system's paint and input hooks.
 /// Call this after creating the InspectorOverlay and setting g_active_inspector.
+/// Installs paint hook, key intercept, and mouse intercept via function pointers
+/// so pulp-view doesn't need to link pulp-inspect.
 void install_inspector_hooks(InspectorOverlay& inspector);
 
 } // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -102,4 +102,8 @@ private:
 /// Thread-safe: only accessed on the UI thread.
 inline InspectorOverlay* g_active_inspector = nullptr;
 
+/// Install the inspector into the View system's paint and input hooks.
+/// Call this after creating the InspectorOverlay and setting g_active_inspector.
+void install_inspector_hooks(InspectorOverlay& inspector);
+
 } // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/inspector_server.hpp
+++ b/inspect/include/pulp/inspect/inspector_server.hpp
@@ -1,0 +1,60 @@
+// inspector_server.hpp — TCP server for remote inspector access
+// Accepts multiple clients, dispatches requests, broadcasts events.
+#pragma once
+
+#include <pulp/inspect/protocol.hpp>
+#include <pulp/events/interprocess_connection.hpp>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace pulp::inspect {
+
+using RequestHandler = std::function<InspectorMessage(const InspectorMessage& request)>;
+
+/// TCP server exposing the inspector protocol to external tools.
+/// Wraps InterprocessConnectionServer for multi-client support.
+class InspectorServer {
+public:
+    /// Create server. Does not start listening until start() is called.
+    InspectorServer();
+    ~InspectorServer();
+
+    /// Start listening on the given port. Returns true on success.
+    /// Default port: 9147. Configurable via PULP_INSPECTOR_PORT env var.
+    bool start(int port = 0);
+
+    /// Stop listening and disconnect all clients.
+    void stop();
+
+    /// Set the handler that processes incoming requests.
+    /// Called on a background thread — handler must be thread-safe or
+    /// marshal to UI thread internally.
+    void set_request_handler(RequestHandler handler);
+
+    /// Broadcast an event to all connected clients.
+    void broadcast(const InspectorMessage& event);
+
+    /// Number of connected clients.
+    int client_count() const;
+
+    /// The port we're actually listening on (may differ from requested if 0 was passed).
+    int port() const { return port_; }
+
+    /// Write port to discovery file so CLI tools can find us.
+    void advertise_port() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+    int port_ = 0;
+    RequestHandler handler_;
+    mutable std::mutex clients_mutex_;
+
+    void on_message_received(const std::string& data, events::InterprocessConnection* sender);
+};
+
+} // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -1,0 +1,85 @@
+// protocol.hpp — Inspector protocol: message types and JSON encoding
+// Modeled on Chrome DevTools Protocol with domain.method naming.
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace pulp::inspect {
+
+/// A single inspector protocol message (request, response, or event).
+struct InspectorMessage {
+    int64_t id = 0;             ///< Non-zero for request/response pairs. Zero for events.
+    std::string method;         ///< "Domain.method" — e.g. "DOM.getDocument"
+    std::string params_json;    ///< JSON object string (params for request, result for response)
+    bool is_error = false;      ///< True if this is an error response
+};
+
+// ── Encode / Decode ─────────────────────────────────────────────────────
+
+/// Serialize a message to a JSON string.
+std::string encode_message(const InspectorMessage& msg);
+
+/// Parse a JSON string into a message. Returns false on parse failure.
+bool decode_message(const std::string& json, InspectorMessage& out);
+
+// ── Factory helpers ─────────────────────────────────────────────────────
+
+InspectorMessage make_request(int64_t id, std::string method, std::string params_json = "{}");
+InspectorMessage make_response(int64_t id, std::string result_json);
+InspectorMessage make_error(int64_t id, std::string error_message);
+InspectorMessage make_event(std::string method, std::string params_json = "{}");
+
+// ── Method name constants ───────────────────────────────────────────────
+
+namespace methods {
+    // Inspector domain
+    constexpr auto kInspectorEnable    = "Inspector.enable";
+    constexpr auto kInspectorDisable   = "Inspector.disable";
+    constexpr auto kInspectorGetInfo   = "Inspector.getInfo";
+
+    // DOM domain
+    constexpr auto kDOMGetDocument     = "DOM.getDocument";
+    constexpr auto kDOMGetNodeById     = "DOM.getNodeById";
+    constexpr auto kDOMHighlightNode   = "DOM.highlightNode";
+    constexpr auto kDOMClearHighlight  = "DOM.clearHighlight";
+    constexpr auto kDOMSearch          = "DOM.search";
+    constexpr auto kDOMDocumentUpdated = "DOM.documentUpdated";
+
+    // CSS domain
+    constexpr auto kCSSGetComputedStyle = "CSS.getComputedStyle";
+    constexpr auto kCSSGetTheme         = "CSS.getTheme";
+    constexpr auto kCSSThemeChanged     = "CSS.themeChanged";
+
+    // Performance domain
+    constexpr auto kPerfGetMetrics      = "Performance.getMetrics";
+    constexpr auto kPerfEnableTracking  = "Performance.enableTracking";
+    constexpr auto kPerfMetrics         = "Performance.metrics";
+
+    // State domain
+    constexpr auto kStateGetParameters    = "State.getParameters";
+    constexpr auto kStateSetParameter     = "State.setParameter";
+    constexpr auto kStateParameterChanged = "State.parameterChanged";
+
+    // Console domain
+    constexpr auto kConsoleEnable       = "Console.enable";
+    constexpr auto kConsoleMessageAdded = "Console.messageAdded";
+
+    // Runtime domain
+    constexpr auto kRuntimeEvaluate          = "Runtime.evaluate";
+    constexpr auto kRuntimeGetHotReloadStatus = "Runtime.getHotReloadStatus";
+    constexpr auto kRuntimeHotReloaded       = "Runtime.hotReloaded";
+
+    // Audio domain
+    constexpr auto kAudioGetConfig       = "Audio.getConfig";
+    constexpr auto kAudioEnableMetering  = "Audio.enableMetering";
+    constexpr auto kAudioGetMidiLog      = "Audio.getMidiLog";
+    constexpr auto kAudioBufferUnderrun  = "Audio.bufferUnderrun";
+    constexpr auto kAudioLevels          = "Audio.levels";
+
+    // Capture domain
+    constexpr auto kCaptureScreenshot     = "Capture.screenshot";
+    constexpr auto kCaptureScreenshotNode = "Capture.screenshotNode";
+}
+
+} // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/state_inspector.hpp
+++ b/inspect/include/pulp/inspect/state_inspector.hpp
@@ -1,0 +1,62 @@
+// state_inspector.hpp — Parameter state monitoring and editing for the inspector
+#pragma once
+
+#include <pulp/state/store.hpp>
+#include <pulp/state/parameter.hpp>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace pulp::inspect {
+
+using namespace pulp::state;
+
+/// Monitors StateStore parameters for the inspector.
+/// Uses a shared_ptr alive guard since StateStore has no remove_listener.
+class StateInspector {
+public:
+    explicit StateInspector(StateStore& store);
+    ~StateInspector();
+
+    /// Parameter snapshot for display
+    struct ParamSnapshot {
+        ParamID id;
+        std::string name;
+        std::string unit;
+        float value;
+        float normalized;
+        float modulated;
+        float default_value;
+        float min, max, step;
+        std::string display_value;  // from to_string, if available
+    };
+
+    /// Recent change entry
+    struct ParamChange {
+        ParamID id;
+        float value;
+        std::chrono::steady_clock::time_point time;
+    };
+
+    /// Get snapshots of all parameters
+    std::vector<ParamSnapshot> all_params() const;
+
+    /// Get recent parameter changes (ring buffer, last 100)
+    std::vector<ParamChange> recent_changes() const;
+
+    /// Set a parameter value (for live editing from inspector)
+    void set_param(ParamID id, float value);
+
+private:
+    StateStore& store_;
+    std::shared_ptr<bool> alive_;  // guard for listener callback
+
+    mutable std::mutex changes_mutex_;
+    std::vector<ParamChange> changes_;
+    static constexpr size_t kMaxChanges = 100;
+};
+
+} // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/state_inspector.hpp
+++ b/inspect/include/pulp/inspect/state_inspector.hpp
@@ -52,10 +52,9 @@ public:
 
 private:
     StateStore& store_;
-    std::shared_ptr<bool> alive_;  // guard for listener callback
 
-    mutable std::mutex changes_mutex_;
-    std::vector<ParamChange> changes_;
+    struct SharedState;
+    std::shared_ptr<SharedState> shared_state_;
     static constexpr size_t kMaxChanges = 100;
 };
 

--- a/inspect/src/audio_inspector.cpp
+++ b/inspect/src/audio_inspector.cpp
@@ -1,0 +1,82 @@
+// audio_inspector.cpp — Audio domain monitoring
+
+#include <pulp/inspect/audio_inspector.hpp>
+
+namespace pulp::inspect {
+
+void AudioInspector::set_config(const AudioConfig& config) {
+    std::lock_guard lock(mutex_);
+    config_ = config;
+}
+
+AudioConfig AudioInspector::config() const {
+    std::lock_guard lock(mutex_);
+    return config_;
+}
+
+void AudioInspector::begin_callback() {
+    callback_start_ = std::chrono::steady_clock::now();
+}
+
+void AudioInspector::end_callback(uint64_t frame_number) {
+    auto elapsed = std::chrono::steady_clock::now() - callback_start_;
+    float elapsed_ms = std::chrono::duration<float, std::milli>(elapsed).count();
+
+    float budget_ms = 0;
+    {
+        std::lock_guard lock(mutex_);
+        if (config_.sample_rate > 0 && config_.buffer_size > 0)
+            budget_ms = static_cast<float>(config_.buffer_size) / static_cast<float>(config_.sample_rate) * 1000.0f;
+    }
+
+    if (budget_ms > 0 && elapsed_ms > budget_ms) {
+        BufferUnderrun underrun;
+        underrun.frame = frame_number;
+        underrun.callback_time_ms = elapsed_ms;
+        underrun.budget_ms = budget_ms;
+        underrun.time = std::chrono::steady_clock::now();
+
+        std::lock_guard lock(mutex_);
+        underruns_.push_back(underrun);
+        if (underruns_.size() > kMaxUnderruns)
+            underruns_.erase(underruns_.begin());
+    }
+}
+
+void AudioInspector::report_levels(const std::vector<ChannelLevels>& levels) {
+    if (!metering_enabled_) return;
+    std::lock_guard lock(mutex_);
+    levels_ = levels;
+}
+
+void AudioInspector::log_midi(uint8_t status, uint8_t data1, uint8_t data2,
+                               const std::string& description) {
+    MidiLogEntry entry;
+    entry.status = status;
+    entry.data1 = data1;
+    entry.data2 = data2;
+    entry.time = std::chrono::steady_clock::now();
+    entry.description = description;
+
+    std::lock_guard lock(mutex_);
+    midi_log_.push_back(std::move(entry));
+    if (midi_log_.size() > kMaxMidi)
+        midi_log_.erase(midi_log_.begin());
+}
+
+std::vector<BufferUnderrun> AudioInspector::recent_underruns() const {
+    std::lock_guard lock(mutex_);
+    return underruns_;
+}
+
+std::vector<MidiLogEntry> AudioInspector::recent_midi() const {
+    std::lock_guard lock(mutex_);
+    return midi_log_;
+}
+
+std::vector<ChannelLevels> AudioInspector::latest_levels() const {
+    std::lock_guard lock(mutex_);
+    return levels_;
+}
+
+} // namespace pulp::inspect

--- a/inspect/src/console_capture.cpp
+++ b/inspect/src/console_capture.cpp
@@ -1,0 +1,35 @@
+// console_capture.cpp — JS console log interception
+
+#include <pulp/inspect/console_capture.hpp>
+
+namespace pulp::inspect {
+
+ConsoleCapture::LogCallback ConsoleCapture::callback(LogCallback previous) {
+    return [this, prev = std::move(previous)](std::string_view level, std::string_view message) {
+        // Forward to previous callback first (preserve existing behavior)
+        if (prev) prev(level, message);
+
+        // Capture the entry
+        Entry entry;
+        entry.level = std::string(level);
+        entry.message = std::string(message);
+        entry.time = std::chrono::steady_clock::now();
+
+        std::lock_guard lock(mutex_);
+        entries_.push_back(std::move(entry));
+        if (entries_.size() > kMaxEntries)
+            entries_.erase(entries_.begin());
+    };
+}
+
+std::vector<ConsoleCapture::Entry> ConsoleCapture::entries() const {
+    std::lock_guard lock(mutex_);
+    return entries_;
+}
+
+void ConsoleCapture::clear() {
+    std::lock_guard lock(mutex_);
+    entries_.clear();
+}
+
+} // namespace pulp::inspect

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -1,0 +1,339 @@
+// domain_handler.cpp — Protocol request dispatch to inspector data sources
+
+#include <pulp/inspect/domain_handler.hpp>
+#include <pulp/inspect/inspector_overlay.hpp>
+#include <pulp/inspect/state_inspector.hpp>
+#include <pulp/inspect/console_capture.hpp>
+#include <pulp/inspect/audio_inspector.hpp>
+#include <pulp/view/inspector.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/render/render_pass.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+#include <sstream>
+#include <iomanip>
+
+namespace pulp::inspect {
+
+using namespace pulp::view;
+
+// ── Dispatch ────────────────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle(const InspectorMessage& req) {
+    auto dot = req.method.find('.');
+    if (dot == std::string::npos)
+        return make_error(req.id, "Invalid method: " + req.method);
+
+    auto domain = req.method.substr(0, dot);
+
+    if (domain == "Inspector")   return handle_inspector(req);
+    if (domain == "DOM")         return handle_dom(req);
+    if (domain == "CSS")         return handle_css(req);
+    if (domain == "Performance") return handle_performance(req);
+    if (domain == "State")       return handle_state(req);
+    if (domain == "Console")     return handle_console(req);
+    if (domain == "Runtime")     return handle_runtime(req);
+    if (domain == "Audio")       return handle_audio(req);
+    if (domain == "Capture")     return handle_capture(req);
+
+    return make_error(req.id, "Unknown domain: " + domain);
+}
+
+// ── Inspector domain ────────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
+    if (req.method == methods::kInspectorEnable) {
+        if (overlay_) overlay_->set_active(true);
+        return make_response(req.id, R"({"enabled":true})");
+    }
+    if (req.method == methods::kInspectorDisable) {
+        if (overlay_) overlay_->set_active(false);
+        return make_response(req.id, R"({"enabled":false})");
+    }
+    if (req.method == methods::kInspectorGetInfo) {
+        auto obj = choc::value::createObject("");
+        obj.addMember("framework", choc::value::createString("Pulp"));
+        if (root_) {
+            obj.addMember("view_count", choc::value::createInt64(
+                static_cast<int64_t>(ViewInspector::count_views(*root_))));
+        }
+        if (overlay_) {
+            obj.addMember("inspector_active", choc::value::createBool(overlay_->is_active()));
+        }
+        return make_response(req.id, choc::json::toString(obj, false));
+    }
+    return make_error(req.id, "Unknown Inspector method: " + req.method);
+}
+
+// ── DOM domain ──────────────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle_dom(const InspectorMessage& req) {
+    if (!root_) return make_error(req.id, "No root view attached");
+
+    if (req.method == methods::kDOMGetDocument) {
+        return make_response(req.id, ViewInspector::to_json(*root_));
+    }
+    if (req.method == methods::kDOMGetNodeById) {
+        try {
+            auto params = choc::json::parse(req.params_json);
+            auto node_id = std::string(params["id"].getString());
+            auto* found = ViewInspector::find_by_id(*root_, node_id);
+            if (!found) return make_error(req.id, "View not found: " + node_id);
+            // Return just this node's data (not recursive)
+            auto obj = choc::value::createObject("");
+            obj.addMember("type", choc::value::createString(ViewInspector::type_name(*found)));
+            obj.addMember("id", choc::value::createString(found->id()));
+            auto b = found->bounds();
+            auto bounds = choc::value::createObject("");
+            bounds.addMember("x", choc::value::createFloat64(b.x));
+            bounds.addMember("y", choc::value::createFloat64(b.y));
+            bounds.addMember("width", choc::value::createFloat64(b.width));
+            bounds.addMember("height", choc::value::createFloat64(b.height));
+            obj.addMember("bounds", bounds);
+            obj.addMember("visible", choc::value::createBool(found->visible()));
+            obj.addMember("opacity", choc::value::createFloat64(found->opacity()));
+            obj.addMember("child_count", choc::value::createInt64(static_cast<int64_t>(found->child_count())));
+            return make_response(req.id, choc::json::toString(obj, false));
+        } catch (...) {
+            return make_error(req.id, "Invalid params for DOM.getNodeById");
+        }
+    }
+    if (req.method == methods::kDOMHighlightNode) {
+        // Highlighting is handled by the overlay — we'd need to find the view and set it
+        // For now, return success (the CLI can highlight via the overlay)
+        return make_response(req.id, R"({"ok":true})");
+    }
+    if (req.method == methods::kDOMClearHighlight) {
+        return make_response(req.id, R"({"ok":true})");
+    }
+    if (req.method == methods::kDOMSearch) {
+        try {
+            auto params = choc::json::parse(req.params_json);
+            auto query = std::string(params["query"].getString());
+            // Simple search by id or type name
+            auto results = choc::value::createEmptyArray();
+            std::function<void(const View&)> search = [&](const View& v) {
+                auto type = ViewInspector::type_name(v);
+                auto vid = v.id();
+                if (type.find(query) != std::string::npos || vid.find(query) != std::string::npos) {
+                    auto entry = choc::value::createObject("");
+                    entry.addMember("id", choc::value::createString(vid));
+                    entry.addMember("type", choc::value::createString(type));
+                    results.addArrayElement(entry);
+                }
+                for (size_t i = 0; i < v.child_count(); ++i)
+                    search(*v.child_at(i));
+            };
+            search(*root_);
+            return make_response(req.id, choc::json::toString(results, false));
+        } catch (...) {
+            return make_error(req.id, "Invalid params for DOM.search");
+        }
+    }
+    return make_error(req.id, "Unknown DOM method: " + req.method);
+}
+
+// ── CSS domain ──────────────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle_css(const InspectorMessage& req) {
+    if (!root_) return make_error(req.id, "No root view attached");
+
+    if (req.method == methods::kCSSGetComputedStyle) {
+        try {
+            auto params = choc::json::parse(req.params_json);
+            auto node_id = std::string(params["id"].getString());
+            auto* found = ViewInspector::find_by_id(*root_, node_id);
+            if (!found) return make_error(req.id, "View not found: " + node_id);
+
+            auto obj = choc::value::createObject("");
+            auto& f = found->flex();
+            obj.addMember("direction", choc::value::createString(
+                f.direction == FlexDirection::row ? "row" : "column"));
+            obj.addMember("flex_grow", choc::value::createFloat64(f.flex_grow));
+            obj.addMember("flex_shrink", choc::value::createFloat64(f.flex_shrink));
+            obj.addMember("gap", choc::value::createFloat64(f.gap));
+            obj.addMember("padding", choc::value::createFloat64(f.padding));
+            obj.addMember("margin", choc::value::createFloat64(f.margin));
+            obj.addMember("opacity", choc::value::createFloat64(found->opacity()));
+            obj.addMember("visible", choc::value::createBool(found->visible()));
+
+            // Theme colors
+            auto colors = choc::value::createObject("");
+            for (auto& [name, color] : found->theme().colors) {
+                std::ostringstream hex;
+                hex << "#" << std::hex << std::setfill('0')
+                    << std::setw(2) << static_cast<int>(color.r * 255)
+                    << std::setw(2) << static_cast<int>(color.g * 255)
+                    << std::setw(2) << static_cast<int>(color.b * 255);
+                colors.addMember(name, choc::value::createString(hex.str()));
+            }
+            obj.addMember("theme_colors", colors);
+
+            return make_response(req.id, choc::json::toString(obj, false));
+        } catch (...) {
+            return make_error(req.id, "Invalid params for CSS.getComputedStyle");
+        }
+    }
+    if (req.method == methods::kCSSGetTheme) {
+        if (root_) {
+            return make_response(req.id, root_->theme().to_json());
+        }
+        return make_error(req.id, "No root view");
+    }
+    return make_error(req.id, "Unknown CSS method: " + req.method);
+}
+
+// ── Performance domain ──────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle_performance(const InspectorMessage& req) {
+    if (req.method == methods::kPerfGetMetrics) {
+        auto obj = choc::value::createObject("");
+        if (rpm_) {
+            obj.addMember("total_time_ms", choc::value::createFloat64(rpm_->total_time_ms()));
+            obj.addMember("frame_count", choc::value::createInt64(static_cast<int64_t>(rpm_->frame_count())));
+            obj.addMember("budget_ms", choc::value::createFloat64(rpm_->budget()));
+            obj.addMember("over_budget", choc::value::createBool(rpm_->over_budget()));
+
+            auto passes = choc::value::createEmptyArray();
+            for (auto& p : rpm_->passes()) {
+                auto pass = choc::value::createObject("");
+                pass.addMember("draw_calls", choc::value::createInt32(p.draw_calls));
+                pass.addMember("time_ms", choc::value::createFloat64(p.time_ms));
+                passes.addArrayElement(pass);
+            }
+            obj.addMember("passes", passes);
+        } else {
+            obj.addMember("available", choc::value::createBool(false));
+        }
+        return make_response(req.id, choc::json::toString(obj, false));
+    }
+    if (req.method == methods::kPerfEnableTracking) {
+        // Tracking is always on when RenderPassManager exists
+        return make_response(req.id, R"({"tracking":true})");
+    }
+    return make_error(req.id, "Unknown Performance method: " + req.method);
+}
+
+// ── State domain ────────────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle_state(const InspectorMessage& req) {
+    if (!state_) return make_error(req.id, "No StateStore attached");
+
+    if (req.method == methods::kStateGetParameters) {
+        auto params = state_->all_params();
+        auto arr = choc::value::createEmptyArray();
+        for (auto& p : params) {
+            auto obj = choc::value::createObject("");
+            obj.addMember("id", choc::value::createInt32(static_cast<int32_t>(p.id)));
+            obj.addMember("name", choc::value::createString(p.name));
+            obj.addMember("unit", choc::value::createString(p.unit));
+            obj.addMember("value", choc::value::createFloat64(p.value));
+            obj.addMember("normalized", choc::value::createFloat64(p.normalized));
+            obj.addMember("modulated", choc::value::createFloat64(p.modulated));
+            obj.addMember("default", choc::value::createFloat64(p.default_value));
+            obj.addMember("min", choc::value::createFloat64(p.min));
+            obj.addMember("max", choc::value::createFloat64(p.max));
+            if (!p.display_value.empty())
+                obj.addMember("display", choc::value::createString(p.display_value));
+            arr.addArrayElement(obj);
+        }
+        return make_response(req.id, choc::json::toString(arr, false));
+    }
+    if (req.method == methods::kStateSetParameter) {
+        try {
+            auto params = choc::json::parse(req.params_json);
+            auto pid = static_cast<uint32_t>(params["id"].getInt64());
+            auto value = static_cast<float>(params["value"].getFloat64());
+            state_->set_param(pid, value);
+            return make_response(req.id, R"({"ok":true})");
+        } catch (...) {
+            return make_error(req.id, "Invalid params for State.setParameter");
+        }
+    }
+    return make_error(req.id, "Unknown State method: " + req.method);
+}
+
+// ── Console domain ──────────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle_console(const InspectorMessage& req) {
+    if (req.method == methods::kConsoleEnable) {
+        if (console_) {
+            auto entries = console_->entries();
+            auto arr = choc::value::createEmptyArray();
+            for (auto& e : entries) {
+                auto obj = choc::value::createObject("");
+                obj.addMember("level", choc::value::createString(e.level));
+                obj.addMember("message", choc::value::createString(e.message));
+                arr.addArrayElement(obj);
+            }
+            return make_response(req.id, choc::json::toString(arr, false));
+        }
+        return make_response(req.id, "[]");
+    }
+    return make_error(req.id, "Unknown Console method: " + req.method);
+}
+
+// ── Runtime domain ──────────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle_runtime(const InspectorMessage& req) {
+    if (req.method == methods::kRuntimeEvaluate) {
+        // Would need a ScriptEngine reference — defer to future wiring
+        return make_error(req.id, "Runtime.evaluate not yet wired (needs ScriptEngine reference)");
+    }
+    if (req.method == methods::kRuntimeGetHotReloadStatus) {
+        return make_response(req.id, R"({"available":false})");
+    }
+    return make_error(req.id, "Unknown Runtime method: " + req.method);
+}
+
+// ── Audio domain ────────────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle_audio(const InspectorMessage& req) {
+    if (!audio_) return make_error(req.id, "No AudioInspector attached");
+
+    if (req.method == methods::kAudioGetConfig) {
+        auto cfg = audio_->config();
+        auto obj = choc::value::createObject("");
+        obj.addMember("sample_rate", choc::value::createFloat64(cfg.sample_rate));
+        obj.addMember("buffer_size", choc::value::createInt32(cfg.buffer_size));
+        obj.addMember("input_channels", choc::value::createInt32(cfg.input_channels));
+        obj.addMember("output_channels", choc::value::createInt32(cfg.output_channels));
+        obj.addMember("latency_samples", choc::value::createInt32(cfg.latency_samples));
+        return make_response(req.id, choc::json::toString(obj, false));
+    }
+    if (req.method == methods::kAudioEnableMetering) {
+        audio_->set_metering_enabled(true);
+        return make_response(req.id, R"({"metering":true})");
+    }
+    if (req.method == methods::kAudioGetMidiLog) {
+        auto events = audio_->recent_midi();
+        auto arr = choc::value::createEmptyArray();
+        for (auto& e : events) {
+            auto obj = choc::value::createObject("");
+            obj.addMember("status", choc::value::createInt32(e.status));
+            obj.addMember("data1", choc::value::createInt32(e.data1));
+            obj.addMember("data2", choc::value::createInt32(e.data2));
+            if (!e.description.empty())
+                obj.addMember("description", choc::value::createString(e.description));
+            arr.addArrayElement(obj);
+        }
+        return make_response(req.id, choc::json::toString(arr, false));
+    }
+    return make_error(req.id, "Unknown Audio method: " + req.method);
+}
+
+// ── Capture domain ──────────────────────────────────────────────────────────
+
+InspectorMessage DomainHandler::handle_capture(const InspectorMessage& req) {
+    if (req.method == methods::kCaptureScreenshot) {
+        // Would need WindowHost reference for capture_png()
+        return make_error(req.id, "Capture.screenshot not yet wired (needs WindowHost reference)");
+    }
+    if (req.method == methods::kCaptureScreenshotNode) {
+        return make_error(req.id, "Capture.screenshotNode not yet implemented");
+    }
+    return make_error(req.id, "Unknown Capture method: " + req.method);
+}
+
+} // namespace pulp::inspect

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -125,28 +125,32 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
         return true;  // consume all panel events
     }
 
-    // Mouse in view area — pick view under cursor
+    // Mouse in view area — pick view under cursor for highlighting
     auto* hit = root_.hit_test(pos);
     if (hit) {
         hovered_ = hit;
-        if (event.is_down) {
+    }
+
+    if (event.is_down) {
+        // Click: select the hovered view (consume click to prevent widget interaction)
+        if (hit) {
             if (event.modifiers & kModAlt) {
                 // Alt+click: distance measurement
                 if (!distance_anchor_) {
                     distance_anchor_ = hit;
                 } else {
-                    // Second click: we have both endpoints, keep showing
                     selected_ = hit;
-                    // distance_anchor_ stays set for display
                 }
             } else {
                 selected_ = hit;
                 distance_anchor_ = nullptr;
             }
         }
+        return true;  // consume clicks when inspector is active
     }
 
-    return true;  // consume all mouse events when inspector is active
+    // Hover events: don't consume — let normal hover effects work
+    return false;
 }
 
 bool InspectorOverlay::point_in_panel(Point p) const {

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -1,0 +1,507 @@
+// inspector_overlay.cpp — Visual inspector overlay implementation
+
+#include <pulp/inspect/inspector_overlay.hpp>
+#include <pulp/view/inspector.hpp>
+#include <pulp/render/render_pass.hpp>
+
+#include <algorithm>
+#include <sstream>
+#include <iomanip>
+#include <cmath>
+
+namespace pulp::inspect {
+
+// ── Colors ──────────────────────────────────────────────────────────────────
+
+static const Color kHighlightFill    = Color::rgba(0.25f, 0.5f, 1.0f, 0.12f);
+static const Color kHighlightStroke  = Color::rgba(0.25f, 0.5f, 1.0f, 0.7f);
+static const Color kSelectedFill     = Color::rgba(1.0f, 0.5f, 0.0f, 0.12f);
+static const Color kSelectedStroke   = Color::rgba(1.0f, 0.5f, 0.0f, 0.7f);
+static const Color kPanelBg          = Color::rgba(0.08f, 0.08f, 0.1f, 0.94f);
+static const Color kPanelText        = Color::rgba(0.85f, 0.85f, 0.9f, 1.0f);
+static const Color kPanelDim         = Color::rgba(0.5f, 0.5f, 0.55f, 1.0f);
+static const Color kPanelHighlight   = Color::rgba(0.25f, 0.5f, 1.0f, 0.25f);
+static const Color kTreeSelected     = Color::rgba(1.0f, 0.5f, 0.0f, 0.3f);
+static const Color kDistanceLine     = Color::rgba(1.0f, 0.2f, 0.3f, 0.8f);
+static const Color kPaddingColor     = Color::rgba(0.2f, 0.8f, 0.3f, 0.15f);
+static const Color kMarginColor      = Color::rgba(1.0f, 0.6f, 0.1f, 0.15f);
+static const Color kStatsBg          = Color::rgba(0.0f, 0.0f, 0.0f, 0.7f);
+static const Color kStatsText        = Color::rgba(0.6f, 1.0f, 0.6f, 1.0f);
+static const Color kStatsWarn        = Color::rgba(1.0f, 0.4f, 0.3f, 1.0f);
+
+// ── Constructor ─────────────────────────────────────────────────────────────
+
+InspectorOverlay::InspectorOverlay(View& root) : root_(root) {}
+
+void InspectorOverlay::set_active(bool active) {
+    active_ = active;
+    if (!active) {
+        selected_ = nullptr;
+        hovered_ = nullptr;
+        distance_anchor_ = nullptr;
+    }
+}
+
+// ── Coordinate helpers ──────────────────────────────────────────────────────
+
+Rect InspectorOverlay::view_bounds_in_root(const View* v) const {
+    if (!v) return {};
+    float x = 0, y = 0;
+    const View* cur = v;
+    while (cur && cur != &root_) {
+        x += cur->bounds().x;
+        y += cur->bounds().y;
+        cur = cur->parent();
+    }
+    return {x, y, v->bounds().width, v->bounds().height};
+}
+
+// ── Flat tree ───────────────────────────────────────────────────────────────
+
+void InspectorOverlay::rebuild_flat_tree() {
+    flat_tree_.clear();
+    std::function<void(const View*, int)> walk = [&](const View* v, int depth) {
+        flat_tree_.push_back({v, depth});
+        if (collapsed_.count(v)) return;
+        for (size_t i = 0; i < v->child_count(); ++i)
+            walk(v->child_at(i), depth + 1);
+    };
+    walk(&root_, 0);
+
+    // Validate selected/hovered still in tree
+    auto in_tree = [&](const View* v) {
+        if (!v) return true;
+        for (auto& item : flat_tree_)
+            if (item.view == v) return true;
+        return false;
+    };
+    if (!in_tree(selected_)) selected_ = nullptr;
+    if (!in_tree(hovered_)) hovered_ = nullptr;
+    if (!in_tree(distance_anchor_)) distance_anchor_ = nullptr;
+}
+
+// ── Input handling ──────────────────────────────────────────────────────────
+
+bool InspectorOverlay::handle_key_event(const KeyEvent& event) {
+    // Cmd+I (macOS) / Ctrl+I (Windows/Linux) toggles inspector
+    if (event.key == KeyCode::i && event.isMainModifier() && event.is_down) {
+        toggle();
+        return true;
+    }
+
+    // Escape exits inspector mode
+    if (active_ && event.key == KeyCode::escape && event.is_down) {
+        set_active(false);
+        return true;
+    }
+
+    return false;
+}
+
+bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
+    if (!active_) return false;
+
+    auto pos = event.position;
+
+    // Check if mouse is in the panel area
+    if (point_in_panel(pos)) {
+        if (event.is_down) {
+            // Click in tree area — select the view
+            float panel_x = root_.bounds().width - panel_width_;
+            float relative_y = pos.y - tree_scroll_y_;
+            auto* item = tree_item_at_y(relative_y);
+            if (item) {
+                if (pos.x < panel_x + item->depth * kIndent + 16.0f && item->view->child_count() > 0) {
+                    // Clicked on collapse toggle
+                    if (collapsed_.count(item->view))
+                        collapsed_.erase(item->view);
+                    else
+                        collapsed_.insert(item->view);
+                } else {
+                    selected_ = const_cast<View*>(item->view);
+                }
+            }
+        }
+        return true;  // consume all panel events
+    }
+
+    // Mouse in view area — pick view under cursor
+    auto* hit = root_.hit_test(pos);
+    if (hit) {
+        hovered_ = hit;
+        if (event.is_down) {
+            if (event.modifiers & kModAlt) {
+                // Alt+click: distance measurement
+                if (!distance_anchor_) {
+                    distance_anchor_ = hit;
+                } else {
+                    // Second click: we have both endpoints, keep showing
+                    selected_ = hit;
+                    // distance_anchor_ stays set for display
+                }
+            } else {
+                selected_ = hit;
+                distance_anchor_ = nullptr;
+            }
+        }
+    }
+
+    return true;  // consume all mouse events when inspector is active
+}
+
+bool InspectorOverlay::point_in_panel(Point p) const {
+    float panel_x = root_.bounds().width - panel_width_;
+    return p.x >= panel_x;
+}
+
+const InspectorOverlay::TreeItem* InspectorOverlay::tree_item_at_y(float y) const {
+    int index = static_cast<int>(y / kRowHeight);
+    if (index >= 0 && index < static_cast<int>(flat_tree_.size()))
+        return &flat_tree_[index];
+    return nullptr;
+}
+
+// ── Painting ────────────────────────────────────────────────────────────────
+
+void InspectorOverlay::paint(Canvas& canvas) {
+    if (!active_) return;
+
+    rebuild_flat_tree();
+    paint_highlight(canvas);
+    paint_distance_lines(canvas);
+    if (selected_) paint_box_model(canvas, selected_);
+    paint_panel(canvas);
+}
+
+void InspectorOverlay::paint_highlight(Canvas& canvas) {
+    // Hovered view highlight (blue)
+    if (hovered_ && hovered_ != selected_) {
+        auto r = view_bounds_in_root(hovered_);
+        canvas.set_fill_color(kHighlightFill);
+        canvas.fill_rect(r.x, r.y, r.width, r.height);
+        canvas.set_stroke_color(kHighlightStroke);
+        canvas.set_line_width(1.5f);
+        canvas.stroke_rect(r.x, r.y, r.width, r.height);
+
+        // Tooltip
+        auto type = ViewInspector::type_name(*hovered_);
+        auto label = type + " " + std::to_string(static_cast<int>(r.width))
+                   + "×" + std::to_string(static_cast<int>(r.height));
+        canvas.set_font("monospace", kFontSize);
+        canvas.set_fill_color(kPanelBg);
+        float tw = canvas.measure_text(label);
+        canvas.fill_rounded_rect(r.x, r.y - 18, tw + 8, 16, 3);
+        canvas.set_fill_color(kPanelText);
+        canvas.fill_text(label, r.x + 4, r.y - 5);
+    }
+
+    // Selected view highlight (orange)
+    if (selected_) {
+        auto r = view_bounds_in_root(selected_);
+        canvas.set_fill_color(kSelectedFill);
+        canvas.fill_rect(r.x, r.y, r.width, r.height);
+        canvas.set_stroke_color(kSelectedStroke);
+        canvas.set_line_width(2.0f);
+        canvas.stroke_rect(r.x, r.y, r.width, r.height);
+    }
+}
+
+void InspectorOverlay::paint_distance_lines(Canvas& canvas) {
+    if (!distance_anchor_ || !selected_) return;
+    if (distance_anchor_ == selected_) return;
+
+    auto a = view_bounds_in_root(distance_anchor_);
+    auto b = view_bounds_in_root(selected_);
+
+    float ax = a.x + a.width / 2;
+    float ay = a.y + a.height / 2;
+    float bx = b.x + b.width / 2;
+    float by = b.y + b.height / 2;
+
+    canvas.set_stroke_color(kDistanceLine);
+    canvas.set_line_width(1.0f);
+    canvas.stroke_line(ax, ay, bx, by);
+
+    // Distance label
+    float dx = bx - ax;
+    float dy = by - ay;
+    float dist = std::sqrt(dx * dx + dy * dy);
+    auto label = std::to_string(static_cast<int>(dist)) + "px";
+    float mx = (ax + bx) / 2;
+    float my = (ay + by) / 2;
+
+    canvas.set_font("monospace", kFontSize);
+    canvas.set_fill_color(kDistanceLine);
+    float tw = canvas.measure_text(label);
+    canvas.fill_rounded_rect(mx - tw / 2 - 4, my - 8, tw + 8, 16, 3);
+    canvas.set_fill_color(Color::rgba(1, 1, 1, 1));
+    canvas.fill_text(label, mx - tw / 2, my + 4);
+}
+
+void InspectorOverlay::paint_box_model(Canvas& canvas, const View* v) {
+    if (!v || !v->parent()) return;
+
+    auto r = view_bounds_in_root(v);
+    auto& f = v->flex();
+
+    // Padding (green, inside the view)
+    float pt = f.padding_top >= 0 ? f.padding_top : f.padding;
+    float pr = f.padding_right >= 0 ? f.padding_right : f.padding;
+    float pb = f.padding_bottom >= 0 ? f.padding_bottom : f.padding;
+    float pl = f.padding_left >= 0 ? f.padding_left : f.padding;
+    if (pt > 0 || pr > 0 || pb > 0 || pl > 0) {
+        canvas.set_fill_color(kPaddingColor);
+        if (pt > 0) canvas.fill_rect(r.x, r.y, r.width, pt);
+        if (pb > 0) canvas.fill_rect(r.x, r.y + r.height - pb, r.width, pb);
+        if (pl > 0) canvas.fill_rect(r.x, r.y + pt, pl, r.height - pt - pb);
+        if (pr > 0) canvas.fill_rect(r.x + r.width - pr, r.y + pt, pr, r.height - pt - pb);
+    }
+
+    // Margin (orange, outside the view)
+    float mt = f.margin_t();
+    float mr_ = f.margin_r();
+    float mb = f.margin_b();
+    float ml = f.margin_l();
+    if (mt > 0 || mr_ > 0 || mb > 0 || ml > 0) {
+        canvas.set_fill_color(kMarginColor);
+        if (mt > 0) canvas.fill_rect(r.x - ml, r.y - mt, r.width + ml + mr_, mt);
+        if (mb > 0) canvas.fill_rect(r.x - ml, r.y + r.height, r.width + ml + mr_, mb);
+        if (ml > 0) canvas.fill_rect(r.x - ml, r.y, ml, r.height);
+        if (mr_ > 0) canvas.fill_rect(r.x + r.width, r.y, mr_, r.height);
+    }
+
+    // Distance to parent
+    auto parent_r = view_bounds_in_root(v->parent());
+    float dist_top = r.y - parent_r.y;
+    float dist_left = r.x - parent_r.x;
+    float dist_bottom = (parent_r.y + parent_r.height) - (r.y + r.height);
+    float dist_right = (parent_r.x + parent_r.width) - (r.x + r.width);
+
+    canvas.set_font("monospace", 9.0f);
+    canvas.set_fill_color(kDistanceLine);
+    if (dist_top > 2) canvas.fill_text(std::to_string(static_cast<int>(dist_top)), r.x + r.width / 2, r.y - 3);
+    if (dist_left > 2) canvas.fill_text(std::to_string(static_cast<int>(dist_left)), r.x - 20, r.y + r.height / 2);
+    if (dist_bottom > 2) canvas.fill_text(std::to_string(static_cast<int>(dist_bottom)), r.x + r.width / 2, r.y + r.height + 10);
+    if (dist_right > 2) canvas.fill_text(std::to_string(static_cast<int>(dist_right)), r.x + r.width + 3, r.y + r.height / 2);
+}
+
+void InspectorOverlay::paint_panel(Canvas& canvas) {
+    float root_w = root_.bounds().width;
+    float root_h = root_.bounds().height;
+    float panel_x = root_w - panel_width_;
+
+    // Panel background
+    canvas.save();
+    canvas.set_fill_color(kPanelBg);
+    canvas.fill_rect(panel_x, 0, panel_width_, root_h);
+
+    // Divider line
+    canvas.set_stroke_color(Color::rgba(0.3f, 0.3f, 0.35f, 1.0f));
+    canvas.set_line_width(1.0f);
+    canvas.stroke_line(panel_x, 0, panel_x, root_h);
+
+    // Tree section (top half)
+    float tree_height = root_h * 0.5f;
+    float cursor_y = 4.0f;
+    paint_tree_section(canvas, panel_x + 8, 4, panel_width_ - 16, cursor_y);
+
+    // Divider
+    float props_y = tree_height;
+    canvas.set_stroke_color(Color::rgba(0.3f, 0.3f, 0.35f, 0.5f));
+    canvas.stroke_line(panel_x + 8, props_y, root_w - 8, props_y);
+
+    // Props section (middle)
+    float stats_y = root_h - kStatsBarHeight;
+    paint_props_section(canvas, panel_x + 8, props_y + 4, panel_width_ - 16, stats_y - props_y - 8);
+
+    // Stats bar (bottom)
+    paint_stats_bar(canvas, panel_x, stats_y, panel_width_);
+
+    canvas.restore();
+}
+
+void InspectorOverlay::paint_tree_section(Canvas& canvas, float x, float y, float w, float& cursor_y) {
+    canvas.set_font("monospace", kFontSize);
+    float tree_height = root_.bounds().height * 0.5f;
+
+    for (auto& item : flat_tree_) {
+        float row_y = y + cursor_y - tree_scroll_y_;
+        if (row_y < y - kRowHeight || row_y > y + tree_height) {
+            cursor_y += kRowHeight;
+            continue;
+        }
+
+        float indent = item.depth * kIndent;
+
+        // Highlight selected row
+        if (item.view == selected_) {
+            canvas.set_fill_color(kTreeSelected);
+            canvas.fill_rect(x, row_y, w, kRowHeight);
+        } else if (item.view == hovered_) {
+            canvas.set_fill_color(kPanelHighlight);
+            canvas.fill_rect(x, row_y, w, kRowHeight);
+        }
+
+        // Collapse indicator
+        if (item.view->child_count() > 0) {
+            canvas.set_fill_color(kPanelDim);
+            auto indicator = collapsed_.count(item.view) ? "\xe2\x96\xb6" : "\xe2\x96\xbc";
+            canvas.fill_text(indicator, x + indent, row_y + 14);
+        }
+
+        // Type name + optional ID
+        auto type = ViewInspector::type_name(*item.view);
+        auto id = item.view->id();
+        std::string label = type;
+        if (!id.empty()) label += " #" + id;
+
+        canvas.set_fill_color(kPanelText);
+        canvas.fill_text(label, x + indent + 14, row_y + 14);
+
+        cursor_y += kRowHeight;
+    }
+}
+
+void InspectorOverlay::paint_props_section(Canvas& canvas, float x, float y, float w, float h) {
+    if (!selected_) {
+        canvas.set_fill_color(kPanelDim);
+        canvas.set_font("monospace", kFontSize);
+        canvas.fill_text("Click a view to inspect", x, y + 16);
+        return;
+    }
+
+    canvas.set_font("monospace", kFontSize);
+    float line_y = y + 4;
+    float line_h = 15.0f;
+
+    auto draw_label = [&](const std::string& label, const std::string& value) {
+        if (line_y > y + h) return;
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text(label, x, line_y + 11);
+        canvas.set_fill_color(kPanelText);
+        canvas.fill_text(value, x + 80, line_y + 11);
+        line_y += line_h;
+    };
+
+    auto draw_heading = [&](const std::string& text) {
+        if (line_y > y + h) return;
+        line_y += 4;
+        canvas.set_fill_color(kHighlightStroke);
+        canvas.fill_text(text, x, line_y + 11);
+        line_y += line_h;
+    };
+
+    // Type and ID
+    auto type = ViewInspector::type_name(*selected_);
+    draw_heading(type + (selected_->id().empty() ? "" : " #" + selected_->id()));
+
+    // Bounds
+    auto r = selected_->bounds();
+    auto abs = view_bounds_in_root(selected_);
+    draw_label("bounds", std::to_string(static_cast<int>(r.x)) + ", " +
+               std::to_string(static_cast<int>(r.y)) + ", " +
+               std::to_string(static_cast<int>(r.width)) + " × " +
+               std::to_string(static_cast<int>(r.height)));
+    draw_label("absolute", std::to_string(static_cast<int>(abs.x)) + ", " +
+               std::to_string(static_cast<int>(abs.y)));
+
+    // Visibility
+    draw_label("visible", selected_->visible() ? "true" : "false");
+    if (selected_->opacity() < 1.0f)
+        draw_label("opacity", std::to_string(selected_->opacity()));
+
+    // Flex
+    auto& f = selected_->flex();
+    draw_heading("Layout");
+
+    auto dir_str = [](FlexDirection d) -> std::string {
+        switch (d) {
+            case FlexDirection::row: return "row";
+            case FlexDirection::column: return "column";
+        }
+        return "?";
+    };
+    draw_label("direction", dir_str(f.direction));
+
+    if (f.flex_grow > 0) draw_label("grow", std::to_string(f.flex_grow));
+    if (f.flex_shrink != 1.0f) draw_label("shrink", std::to_string(f.flex_shrink));
+    if (f.gap > 0) draw_label("gap", std::to_string(static_cast<int>(f.gap)));
+
+    float pt2 = f.padding_top >= 0 ? f.padding_top : f.padding;
+    float pr2 = f.padding_right >= 0 ? f.padding_right : f.padding;
+    float pb2 = f.padding_bottom >= 0 ? f.padding_bottom : f.padding;
+    float pl2 = f.padding_left >= 0 ? f.padding_left : f.padding;
+    if (pt2 > 0 || pr2 > 0 || pb2 > 0 || pl2 > 0) {
+        draw_label("padding", std::to_string(static_cast<int>(pt2)) + " " +
+                   std::to_string(static_cast<int>(pr2)) + " " +
+                   std::to_string(static_cast<int>(pb2)) + " " +
+                   std::to_string(static_cast<int>(pl2)));
+    }
+
+    // Theme colors (first 5)
+    auto& theme = selected_->theme();
+    if (!theme.colors.empty()) {
+        draw_heading("Theme Colors");
+        int shown = 0;
+        for (auto& [name, color] : theme.colors) {
+            if (shown >= 5) {
+                draw_label("", "... +" + std::to_string(theme.colors.size() - 5) + " more");
+                break;
+            }
+            // Color swatch
+            if (line_y <= y + h) {
+                canvas.set_fill_color(color);
+                canvas.fill_rounded_rect(x, line_y + 3, 10, 10, 2);
+                canvas.set_fill_color(kPanelDim);
+                canvas.fill_text(name, x + 16, line_y + 11);
+                line_y += line_h;
+            }
+            ++shown;
+        }
+    }
+}
+
+void InspectorOverlay::paint_stats_bar(Canvas& canvas, float x, float y, float w) {
+    canvas.set_fill_color(kStatsBg);
+    canvas.fill_rect(x, y, w, kStatsBarHeight);
+
+    canvas.set_font("monospace", 10.0f);
+
+    if (rpm_) {
+        float frame_ms = rpm_->total_time_ms();
+        float budget = rpm_->budget();
+        bool over = rpm_->over_budget();
+
+        std::ostringstream ss;
+        ss << std::fixed << std::setprecision(1) << frame_ms << "ms";
+        if (budget > 0) {
+            int fps = static_cast<int>(1000.0f / std::max(frame_ms, 0.1f));
+            ss << "  " << fps << "fps";
+        }
+
+        canvas.set_fill_color(over ? kStatsWarn : kStatsText);
+        canvas.fill_text(ss.str(), x + 8, y + 16);
+
+        // Pass breakdown
+        auto& passes = rpm_->passes();
+        if (!passes.empty()) {
+            std::string pass_info;
+            for (auto& p : passes) {
+                if (!pass_info.empty()) pass_info += " | ";
+                pass_info += std::to_string(p.draw_calls) + "dc";
+            }
+            canvas.set_fill_color(kPanelDim);
+            canvas.fill_text(pass_info, x + 140, y + 16);
+        }
+    } else {
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text("No render stats", x + 8, y + 16);
+    }
+
+    // View count
+    auto count = ViewInspector::count_views(root_);
+    canvas.set_fill_color(kPanelDim);
+    canvas.fill_text(std::to_string(count) + " views", x + w - 60, y + 16);
+}
+
+} // namespace pulp::inspect

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -35,9 +35,15 @@ InspectorOverlay::InspectorOverlay(View& root) : root_(root) {}
 
 void install_inspector_hooks(InspectorOverlay& inspector) {
     g_active_inspector = &inspector;
-    // Install paint hook via function pointer — no circular dependency
+    // Install all hooks via function pointers — no circular dependency
     View::set_inspector_paint_hook([&inspector](Canvas& canvas) {
         inspector.paint(canvas);
+    });
+    View::set_inspector_key_hook([&inspector](const KeyEvent& e) -> bool {
+        return inspector.handle_key_event(e);
+    });
+    View::set_inspector_mouse_hook([&inspector](const MouseEvent& e) -> bool {
+        return inspector.handle_mouse_event(e);
     });
 }
 

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -33,6 +33,14 @@ static const Color kStatsWarn        = Color::rgba(1.0f, 0.4f, 0.3f, 1.0f);
 
 InspectorOverlay::InspectorOverlay(View& root) : root_(root) {}
 
+void install_inspector_hooks(InspectorOverlay& inspector) {
+    g_active_inspector = &inspector;
+    // Install paint hook via function pointer — no circular dependency
+    View::set_inspector_paint_hook([&inspector](Canvas& canvas) {
+        inspector.paint(canvas);
+    });
+}
+
 void InspectorOverlay::set_active(bool active) {
     active_ = active;
     if (!active) {

--- a/inspect/src/inspector_server.cpp
+++ b/inspect/src/inspector_server.cpp
@@ -1,0 +1,143 @@
+// inspector_server.cpp — TCP server for remote inspector access
+
+#include <pulp/inspect/inspector_server.hpp>
+#include <pulp/runtime/system.hpp>
+
+#include <fstream>
+#include <iostream>
+
+#ifdef _WIN32
+#include <process.h>
+#define getpid _getpid
+#else
+#include <unistd.h>
+#endif
+
+namespace pulp::inspect {
+
+static constexpr int kDefaultPort = 9147;
+
+// ── Server implementation using InterprocessConnectionServer ────────────
+
+class InspectorServer::Impl {
+public:
+    events::InterprocessConnectionServer server;
+    std::vector<events::InterprocessConnection*> client_ptrs;
+    std::vector<std::unique_ptr<events::InterprocessConnection>> owned_clients;
+    std::mutex clients_mutex;
+
+    Impl() {
+        server.on_client_connected = [this](std::unique_ptr<events::InterprocessConnection> conn) {
+            auto* raw = conn.get();
+            raw->on_text_message = [this, raw](std::string_view msg) {
+                on_message(std::string(msg), raw);
+            };
+            raw->on_disconnected = [this, raw]() {
+                std::lock_guard lock(clients_mutex);
+                client_ptrs.erase(std::remove(client_ptrs.begin(), client_ptrs.end(), raw), client_ptrs.end());
+                // Remove owned connection
+                owned_clients.erase(
+                    std::remove_if(owned_clients.begin(), owned_clients.end(),
+                                   [raw](auto& c) { return c.get() == raw; }),
+                    owned_clients.end());
+            };
+            {
+                std::lock_guard lock(clients_mutex);
+                client_ptrs.push_back(raw);
+                owned_clients.push_back(std::move(conn));
+            }
+        };
+    }
+
+    std::function<void(const std::string&, events::InterprocessConnection*)> on_message;
+};
+
+InspectorServer::InspectorServer() : impl_(std::make_unique<Impl>()) {
+    impl_->on_message = [this](const std::string& data, events::InterprocessConnection* sender) {
+        on_message_received(data, sender);
+    };
+}
+
+InspectorServer::~InspectorServer() {
+    stop();
+}
+
+bool InspectorServer::start(int port) {
+    if (port == 0) {
+        // Check env var
+        if (auto env = pulp::runtime::get_env("PULP_INSPECTOR_PORT")) {
+            try { port = std::stoi(*env); } catch (...) {}
+        }
+        if (port == 0) port = kDefaultPort;
+    }
+
+    port_ = port;
+
+    if (!impl_->server.start(std::to_string(port), events::IpcTransport::Socket)) {
+        return false;
+    }
+
+    advertise_port();
+    return true;
+}
+
+void InspectorServer::stop() {
+    impl_->server.stop();
+}
+
+void InspectorServer::set_request_handler(RequestHandler handler) {
+    handler_ = std::move(handler);
+}
+
+void InspectorServer::broadcast(const InspectorMessage& event) {
+    auto json = encode_message(event);
+    std::lock_guard lock(impl_->clients_mutex);
+    for (auto* client : impl_->client_ptrs) {
+        client->send_message(json.data(), json.size());
+    }
+}
+
+int InspectorServer::client_count() const {
+    std::lock_guard lock(impl_->clients_mutex);
+    return static_cast<int>(impl_->client_ptrs.size());
+}
+
+void InspectorServer::advertise_port() const {
+    // Write port file so CLI tools can discover us
+    std::string tmp_dir;
+#ifdef _WIN32
+    if (auto env = pulp::runtime::get_env("TEMP")) tmp_dir = *env;
+    else tmp_dir = ".";
+#else
+    if (auto env = pulp::runtime::get_env("TMPDIR")) tmp_dir = *env;
+    else tmp_dir = "/tmp";
+#endif
+
+    auto port_file = tmp_dir + "/pulp-inspector-" + std::to_string(getpid()) + ".port";
+    std::ofstream f(port_file);
+    if (f.good()) {
+        f << port_;
+    }
+}
+
+void InspectorServer::on_message_received(const std::string& data,
+                                           events::InterprocessConnection* sender) {
+    InspectorMessage request;
+    if (!decode_message(data, request)) {
+        // Invalid JSON — send error
+        auto err = make_error(0, "Invalid JSON message");
+        auto json = encode_message(err);
+        sender->send_message(json.data(), json.size());
+        return;
+    }
+
+    if (handler_) {
+        auto response = handler_(request);
+        if (response.id != 0 || !response.method.empty()) {
+            auto json = encode_message(response);
+            sender->send_message(json.data(), json.size());
+        }
+    }
+}
+
+} // namespace pulp::inspect

--- a/inspect/src/placeholder.cpp
+++ b/inspect/src/placeholder.cpp
@@ -1,2 +1,0 @@
-// pulp-inspect: placeholder — replaced in Phase 6
-namespace pulp::inspect {}

--- a/inspect/src/protocol.cpp
+++ b/inspect/src/protocol.cpp
@@ -1,0 +1,86 @@
+// protocol.cpp — Inspector protocol JSON encoding/decoding
+
+#include <pulp/inspect/protocol.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+namespace pulp::inspect {
+
+std::string encode_message(const InspectorMessage& msg) {
+    auto obj = choc::value::createObject("");
+
+    if (msg.id != 0)
+        obj.addMember("id", choc::value::createInt64(msg.id));
+
+    if (!msg.method.empty())
+        obj.addMember("method", choc::value::createString(msg.method));
+
+    if (msg.is_error) {
+        auto error = choc::value::createObject("");
+        error.addMember("message", choc::value::createString(msg.params_json));
+        obj.addMember("error", error);
+    } else if (msg.id != 0 && msg.method.empty()) {
+        // Response — use "result" key
+        if (!msg.params_json.empty() && msg.params_json != "{}") {
+            try {
+                obj.addMember("result", choc::json::parse(msg.params_json));
+            } catch (...) {
+                obj.addMember("result", choc::value::createString(msg.params_json));
+            }
+        }
+    } else if (!msg.params_json.empty() && msg.params_json != "{}") {
+        // Request or event — use "params" key
+        try {
+            obj.addMember("params", choc::json::parse(msg.params_json));
+        } catch (...) {
+            obj.addMember("params", choc::value::createString(msg.params_json));
+        }
+    }
+
+    return choc::json::toString(obj, false);
+}
+
+bool decode_message(const std::string& json, InspectorMessage& out) {
+    try {
+        auto val = choc::json::parse(json);
+        out = {};
+
+        if (val.hasObjectMember("id"))
+            out.id = val["id"].getInt64();
+
+        if (val.hasObjectMember("method"))
+            out.method = std::string(val["method"].getString());
+
+        if (val.hasObjectMember("error")) {
+            out.is_error = true;
+            if (val["error"].hasObjectMember("message"))
+                out.params_json = std::string(val["error"]["message"].getString());
+        } else if (val.hasObjectMember("result")) {
+            out.params_json = choc::json::toString(val["result"], false);
+        } else if (val.hasObjectMember("params")) {
+            out.params_json = choc::json::toString(val["params"], false);
+        }
+
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+InspectorMessage make_request(int64_t id, std::string method, std::string params_json) {
+    return {id, std::move(method), std::move(params_json), false};
+}
+
+InspectorMessage make_response(int64_t id, std::string result_json) {
+    return {id, {}, std::move(result_json), false};
+}
+
+InspectorMessage make_error(int64_t id, std::string error_message) {
+    return {id, {}, std::move(error_message), true};
+}
+
+InspectorMessage make_event(std::string method, std::string params_json) {
+    return {0, std::move(method), std::move(params_json), false};
+}
+
+} // namespace pulp::inspect

--- a/inspect/src/state_inspector.cpp
+++ b/inspect/src/state_inspector.cpp
@@ -1,0 +1,63 @@
+// state_inspector.cpp — Parameter state monitoring and editing
+
+#include <pulp/inspect/state_inspector.hpp>
+
+namespace pulp::inspect {
+
+StateInspector::StateInspector(StateStore& store)
+    : store_(store)
+    , alive_(std::make_shared<bool>(true))
+{
+    // Register listener with weak_ptr guard for safe destruction
+    std::weak_ptr<bool> weak = alive_;
+    store_.add_listener([this, weak](ParamID id, float value) {
+        auto locked = weak.lock();
+        if (!locked) return;  // inspector destroyed
+
+        ParamChange change{id, value, std::chrono::steady_clock::now()};
+        std::lock_guard lock(changes_mutex_);
+        changes_.push_back(change);
+        if (changes_.size() > kMaxChanges)
+            changes_.erase(changes_.begin());
+    });
+}
+
+StateInspector::~StateInspector() {
+    // Invalidate the weak_ptr guard — listener will no-op after this
+    alive_.reset();
+}
+
+std::vector<StateInspector::ParamSnapshot> StateInspector::all_params() const {
+    std::vector<ParamSnapshot> result;
+    auto params = store_.all_params();
+    result.reserve(params.size());
+
+    for (auto& info : params) {
+        ParamSnapshot snap;
+        snap.id = info.id;
+        snap.name = info.name;
+        snap.unit = info.unit;
+        snap.value = store_.get_value(info.id);
+        snap.normalized = store_.get_normalized(info.id);
+        snap.modulated = store_.get_modulated(info.id);
+        snap.default_value = info.range.default_value;
+        snap.min = info.range.min;
+        snap.max = info.range.max;
+        snap.step = info.range.step;
+        snap.display_value = info.to_string ? info.to_string(snap.value) : "";
+        result.push_back(std::move(snap));
+    }
+
+    return result;
+}
+
+std::vector<StateInspector::ParamChange> StateInspector::recent_changes() const {
+    std::lock_guard lock(changes_mutex_);
+    return changes_;
+}
+
+void StateInspector::set_param(ParamID id, float value) {
+    store_.set_value(id, value);
+}
+
+} // namespace pulp::inspect

--- a/inspect/src/state_inspector.cpp
+++ b/inspect/src/state_inspector.cpp
@@ -4,27 +4,33 @@
 
 namespace pulp::inspect {
 
+struct StateInspector::SharedState {
+    std::mutex mutex;
+    std::vector<ParamChange> changes;
+    std::atomic<bool> alive{true};
+};
+
 StateInspector::StateInspector(StateStore& store)
     : store_(store)
-    , alive_(std::make_shared<bool>(true))
+    , shared_state_(std::make_shared<SharedState>())
 {
-    // Register listener with weak_ptr guard for safe destruction
-    std::weak_ptr<bool> weak = alive_;
-    store_.add_listener([this, weak](ParamID id, float value) {
-        auto locked = weak.lock();
-        if (!locked) return;  // inspector destroyed
+
+    auto state = shared_state_;  // copy shared_ptr for the lambda
+    store_.add_listener([state](ParamID id, float value) {
+        if (!state->alive.load(std::memory_order_acquire)) return;
 
         ParamChange change{id, value, std::chrono::steady_clock::now()};
-        std::lock_guard lock(changes_mutex_);
-        changes_.push_back(change);
-        if (changes_.size() > kMaxChanges)
-            changes_.erase(changes_.begin());
+        std::lock_guard lock(state->mutex);
+        state->changes.push_back(change);
+        if (state->changes.size() > kMaxChanges)
+            state->changes.erase(state->changes.begin());
     });
 }
 
 StateInspector::~StateInspector() {
-    // Invalidate the weak_ptr guard — listener will no-op after this
-    alive_.reset();
+    // Signal the shared state to stop accepting changes.
+    // In-flight callbacks will see alive=false and return.
+    if (shared_state_) shared_state_->alive.store(false, std::memory_order_release);
 }
 
 std::vector<StateInspector::ParamSnapshot> StateInspector::all_params() const {
@@ -52,8 +58,9 @@ std::vector<StateInspector::ParamSnapshot> StateInspector::all_params() const {
 }
 
 std::vector<StateInspector::ParamChange> StateInspector::recent_changes() const {
-    std::lock_guard lock(changes_mutex_);
-    return changes_;
+    if (!shared_state_) return {};
+    std::lock_guard lock(shared_state_->mutex);
+    return shared_state_->changes;
 }
 
 void StateInspector::set_param(ParamID id, float value) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -450,7 +450,7 @@ catch_discover_tests(pulp-test-hot-reload)
 
 # Inspector tests
 add_executable(pulp-test-inspector test_inspector.cpp)
-target_link_libraries(pulp-test-inspector PRIVATE pulp::view Catch2::Catch2WithMain)
+target_link_libraries(pulp-test-inspector PRIVATE pulp::view pulp::inspect pulp::state Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-inspector)
 
 # Widget bridge tests

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -168,7 +168,11 @@ TEST_CASE("InspectorOverlay: Cmd+I toggles") {
     InspectorOverlay overlay(root);
     KeyEvent ke;
     ke.key = KeyCode::i;
+#ifdef __APPLE__
     ke.modifiers = kModCmd;
+#else
+    ke.modifiers = kModCtrl;  // Ctrl+I on Linux/Windows
+#endif
     ke.is_down = true;
     REQUIRE(overlay.handle_key_event(ke));
     REQUIRE(overlay.is_active());

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -100,3 +100,211 @@ TEST_CASE("ViewInspector JSON includes widget values", "[view][inspector]") {
     REQUIRE(json.find("\"horizontal\"") != std::string::npos);
     REQUIRE(json.find("\"Hello\"") != std::string::npos);
 }
+
+// ── Protocol encode/decode ──────────────────────────────────────────────────
+
+#include <pulp/inspect/protocol.hpp>
+
+using namespace pulp::inspect;
+
+TEST_CASE("Protocol: encode request") {
+    auto msg = make_request(1, "DOM.getDocument", R"({"depth":1})");
+    auto json = encode_message(msg);
+    REQUIRE(json.find("\"id\"") != std::string::npos);
+    REQUIRE(json.find("DOM.getDocument") != std::string::npos);
+}
+
+TEST_CASE("Protocol: encode response") {
+    auto msg = make_response(1, R"({"root":{}})");
+    auto json = encode_message(msg);
+    REQUIRE(json.find("\"id\"") != std::string::npos);
+    REQUIRE(json.find("root") != std::string::npos);
+}
+
+TEST_CASE("Protocol: encode error") {
+    auto msg = make_error(1, "View not found");
+    auto json = encode_message(msg);
+    REQUIRE(json.find("error") != std::string::npos);
+    REQUIRE(json.find("View not found") != std::string::npos);
+}
+
+TEST_CASE("Protocol: encode event has no id") {
+    auto msg = make_event("DOM.documentUpdated");
+    auto json = encode_message(msg);
+    REQUIRE(json.find("DOM.documentUpdated") != std::string::npos);
+}
+
+TEST_CASE("Protocol: decode roundtrip") {
+    auto original = make_request(42, "State.getParameters", R"({"filter":"gain"})");
+    auto json = encode_message(original);
+
+    InspectorMessage decoded;
+    REQUIRE(decode_message(json, decoded));
+    REQUIRE(decoded.id == 42);
+    REQUIRE(decoded.method == "State.getParameters");
+}
+
+TEST_CASE("Protocol: decode invalid JSON") {
+    InspectorMessage msg;
+    REQUIRE_FALSE(decode_message("not json", msg));
+}
+
+// ── InspectorOverlay ────────────────────────────────────────────────────────
+
+#include <pulp/inspect/inspector_overlay.hpp>
+
+TEST_CASE("InspectorOverlay: toggle") {
+    View root;
+    InspectorOverlay overlay(root);
+    REQUIRE_FALSE(overlay.is_active());
+    overlay.set_active(true);
+    REQUIRE(overlay.is_active());
+    overlay.toggle();
+    REQUIRE_FALSE(overlay.is_active());
+}
+
+TEST_CASE("InspectorOverlay: Cmd+I toggles") {
+    View root;
+    InspectorOverlay overlay(root);
+    KeyEvent ke;
+    ke.key = KeyCode::i;
+    ke.modifiers = kModCmd;
+    ke.is_down = true;
+    REQUIRE(overlay.handle_key_event(ke));
+    REQUIRE(overlay.is_active());
+    REQUIRE(overlay.handle_key_event(ke));
+    REQUIRE_FALSE(overlay.is_active());
+}
+
+TEST_CASE("InspectorOverlay: Escape dismisses") {
+    View root;
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    KeyEvent ke;
+    ke.key = KeyCode::escape;
+    ke.is_down = true;
+    REQUIRE(overlay.handle_key_event(ke));
+    REQUIRE_FALSE(overlay.is_active());
+}
+
+TEST_CASE("InspectorOverlay: inactive ignores events") {
+    View root;
+    InspectorOverlay overlay(root);
+    KeyEvent ke;
+    ke.key = KeyCode::escape;
+    ke.is_down = true;
+    REQUIRE_FALSE(overlay.handle_key_event(ke));
+    MouseEvent me;
+    me.position = {10, 10};
+    me.is_down = true;
+    REQUIRE_FALSE(overlay.handle_mouse_event(me));
+}
+
+// ── ConsoleCapture ──────────────────────────────────────────────────────────
+
+#include <pulp/inspect/console_capture.hpp>
+
+TEST_CASE("ConsoleCapture: captures log entries") {
+    ConsoleCapture capture;
+    auto cb = capture.callback();
+    cb("log", "hello");
+    cb("warn", "caution");
+    cb("error", "fail");
+    auto entries = capture.entries();
+    REQUIRE(entries.size() == 3);
+    REQUIRE(entries[0].level == "log");
+    REQUIRE(entries[0].message == "hello");
+    REQUIRE(entries[2].level == "error");
+}
+
+TEST_CASE("ConsoleCapture: chains previous callback") {
+    std::string captured;
+    auto previous = [&](std::string_view level, std::string_view msg) {
+        captured = std::string(level) + ":" + std::string(msg);
+    };
+    ConsoleCapture capture;
+    auto cb = capture.callback(previous);
+    cb("log", "test");
+    REQUIRE(captured == "log:test");
+    REQUIRE(capture.entries().size() == 1);
+}
+
+TEST_CASE("ConsoleCapture: clear") {
+    ConsoleCapture capture;
+    auto cb = capture.callback();
+    cb("log", "a");
+    cb("log", "b");
+    capture.clear();
+    REQUIRE(capture.entries().empty());
+}
+
+// ── AudioInspector ──────────────────────────────────────────────────────────
+
+#include <pulp/inspect/audio_inspector.hpp>
+
+TEST_CASE("AudioInspector: config roundtrip") {
+    AudioInspector audio;
+    AudioConfig cfg;
+    cfg.sample_rate = 48000;
+    cfg.buffer_size = 256;
+    cfg.output_channels = 2;
+    audio.set_config(cfg);
+    auto read = audio.config();
+    REQUIRE(read.sample_rate == 48000);
+    REQUIRE(read.buffer_size == 256);
+}
+
+TEST_CASE("AudioInspector: MIDI logging") {
+    AudioInspector audio;
+    audio.log_midi(0x90, 60, 100, "Note On C4");
+    audio.log_midi(0x80, 60, 0, "Note Off C4");
+    auto events = audio.recent_midi();
+    REQUIRE(events.size() == 2);
+    REQUIRE(events[0].status == 0x90);
+    REQUIRE(events[0].description == "Note On C4");
+}
+
+// ── DomainHandler ───────────────────────────────────────────────────────────
+
+#include <pulp/inspect/domain_handler.hpp>
+#include <pulp/inspect/state_inspector.hpp>
+#include <pulp/state/store.hpp>
+
+TEST_CASE("DomainHandler: unknown domain") {
+    DomainHandler handler;
+    auto resp = handler.handle(make_request(1, "Bogus.method"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("DomainHandler: Inspector.getInfo") {
+    View root;
+    DomainHandler handler;
+    handler.set_root_view(&root);
+    auto resp = handler.handle(make_request(1, "Inspector.getInfo"));
+    REQUIRE_FALSE(resp.is_error);
+    REQUIRE(resp.params_json.find("Pulp") != std::string::npos);
+}
+
+TEST_CASE("DomainHandler: DOM.getDocument") {
+    View root;
+    auto child = std::make_unique<View>();
+    child->set_id("child1");
+    root.add_child(std::move(child));
+    DomainHandler handler;
+    handler.set_root_view(&root);
+    auto resp = handler.handle(make_request(1, "DOM.getDocument"));
+    REQUIRE_FALSE(resp.is_error);
+    REQUIRE(resp.params_json.find("child1") != std::string::npos);
+}
+
+TEST_CASE("DomainHandler: State.getParameters") {
+    StateStore store;
+    store.add_parameter({0, "Volume", "dB", {-60.0f, 6.0f, -12.0f}});
+    store.set_value(0, -6.0f);
+    StateInspector state_inspector(store);
+    DomainHandler handler;
+    handler.set_state_inspector(&state_inspector);
+    auto resp = handler.handle(make_request(1, "State.getParameters"));
+    REQUIRE_FALSE(resp.is_error);
+    REQUIRE(resp.params_json.find("Volume") != std::string::npos);
+}

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -1,9 +1,9 @@
 # pulp CLI tool
 add_executable(pulp-cli pulp_cli.cpp design_binding.cpp create_targets.cpp
-    package_registry.cpp package_commands.cpp tool_registry.cpp)
+    package_registry.cpp package_commands.cpp tool_registry.cpp cmd_inspect.cpp)
 set_target_properties(pulp-cli PROPERTIES OUTPUT_NAME "pulp")
 target_compile_features(pulp-cli PRIVATE cxx_std_20)
-target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format)
+target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format pulp::inspect)
 
 # Install into the active prefix so SDK installs do not try to write back into
 # the source checkout.

--- a/tools/cli/cmd_inspect.cpp
+++ b/tools/cli/cmd_inspect.cpp
@@ -144,14 +144,16 @@ int cmd_inspect(const std::vector<std::string>& args) {
 
     // Set up message handler
     std::atomic<bool> got_response{false};
+    std::atomic<bool> got_error{false};
     std::string last_response;
     conn.on_text_message = [&](std::string_view msg) {
         InspectorMessage response;
         if (decode_message(std::string(msg), response)) {
             if (!one_shot_command.empty()) {
-                // One-shot mode: print and exit
+                // One-shot mode: capture result
                 if (response.is_error) {
                     std::cerr << "Error: " << response.params_json << "\n";
+                    got_error = true;
                 } else {
                     last_response = response.params_json;
                 }
@@ -198,6 +200,8 @@ int cmd_inspect(const std::vector<std::string>& args) {
             std::cerr << "Error: no response received (timeout)\n";
             return 1;
         }
+
+        if (got_error) return 1;
 
         if (!output_file.empty()) {
             std::ofstream f(output_file);

--- a/tools/cli/cmd_inspect.cpp
+++ b/tools/cli/cmd_inspect.cpp
@@ -1,0 +1,246 @@
+// cmd_inspect.cpp — pulp inspect: connect to a running plugin's inspector server
+// Interactive REPL or one-shot command mode.
+
+#include <pulp/inspect/protocol.hpp>
+#include <pulp/events/interprocess_connection.hpp>
+#include <pulp/runtime/system.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <atomic>
+#include <vector>
+
+#ifdef _WIN32
+#include <process.h>
+#define getpid _getpid
+#else
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+
+// Minimal helpers (these exist in pulp_cli.cpp as static — we duplicate the tiny ones)
+static std::string inspect_trim(const std::string& s) {
+    auto start = s.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos) return {};
+    auto end = s.find_last_not_of(" \t\r\n");
+    return s.substr(start, end - start + 1);
+}
+
+// Simple color helpers for the inspect command
+static bool g_inspect_color = true;
+static std::string ic_dim()   { return g_inspect_color ? "\033[2m"  : ""; }
+static std::string ic_bold()  { return g_inspect_color ? "\033[1m"  : ""; }
+static std::string ic_cyan()  { return g_inspect_color ? "\033[36m" : ""; }
+static std::string ic_green() { return g_inspect_color ? "\033[32m" : ""; }
+static std::string ic_red()   { return g_inspect_color ? "\033[31m" : ""; }
+static std::string ic_reset() { return g_inspect_color ? "\033[0m"  : ""; }
+
+namespace {
+
+using namespace pulp::inspect;
+using namespace pulp::events;
+
+// Find the inspector port by reading discovery files
+static int discover_port() {
+    std::string tmp_dir;
+#ifdef _WIN32
+    if (auto env = pulp::runtime::get_env("TEMP")) tmp_dir = *env;
+    else tmp_dir = ".";
+#else
+    if (auto env = pulp::runtime::get_env("TMPDIR")) tmp_dir = *env;
+    else tmp_dir = "/tmp";
+#endif
+
+    // Look for pulp-inspector-*.port files, pick the most recent
+    int found_port = 0;
+    fs::file_time_type newest_time{};
+
+    for (auto& entry : fs::directory_iterator(tmp_dir)) {
+        auto name = entry.path().filename().string();
+        if (name.find("pulp-inspector-") == 0 && name.find(".port") != std::string::npos) {
+            std::ifstream f(entry.path());
+            int port = 0;
+            if (f >> port && port > 0) {
+                auto mtime = fs::last_write_time(entry.path());
+                if (mtime > newest_time || found_port == 0) {
+                    newest_time = mtime;
+                    found_port = port;
+                }
+            }
+        }
+    }
+
+    return found_port;
+}
+
+// Send a request and wait for response
+static std::string send_request(InterprocessConnection& conn, const std::string& method,
+                                 const std::string& params = "{}") {
+    static std::atomic<int64_t> next_id{1};
+    auto id = next_id++;
+    auto msg = make_request(id, method, params);
+    auto json = encode_message(msg);
+    conn.send_message(json);
+
+    // Wait for response (simple blocking — fine for CLI)
+    // The response will arrive via on_text_message
+    // For now, we use a simple sleep+poll approach
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    return "";  // Response handled by callback
+}
+
+} // anonymous namespace
+
+int cmd_inspect(const std::vector<std::string>& args) {
+    // Parse flags
+    std::string host = "127.0.0.1";
+    int port = 0;
+    std::string one_shot_command;
+    std::string output_file;
+
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (args[i] == "--help" || args[i] == "-h") {
+            std::cout << "pulp inspect — connect to a running plugin's inspector\n\n";
+            std::cout << "Usage: pulp inspect [options]\n\n";
+            std::cout << "Options:\n";
+            std::cout << "  --host HOST       Connect to HOST (default: 127.0.0.1)\n";
+            std::cout << "  --port PORT       Connect to PORT (default: auto-discover)\n";
+            std::cout << "  --command METHOD  Send one command and print result\n";
+            std::cout << "  --output FILE     Write result to FILE (with --command)\n\n";
+            std::cout << "Examples:\n";
+            std::cout << "  pulp inspect                              # Interactive REPL\n";
+            std::cout << "  pulp inspect --command DOM.getDocument     # One-shot query\n";
+            std::cout << "  pulp inspect --command Capture.screenshot --output shot.png\n";
+            std::cout << "  pulp inspect --host 192.168.1.42          # Remote debugging\n";
+            return 0;
+        }
+        if (args[i] == "--host" && i + 1 < args.size()) host = args[++i];
+        else if (args[i] == "--port" && i + 1 < args.size()) port = std::stoi(args[++i]);
+        else if (args[i] == "--command" && i + 1 < args.size()) one_shot_command = args[++i];
+        else if (args[i] == "--output" && i + 1 < args.size()) output_file = args[++i];
+    }
+
+    // Auto-discover port if not specified
+    if (port == 0) {
+        port = discover_port();
+        if (port == 0) {
+            std::cerr << "Error: no running Pulp inspector found.\n";
+            std::cerr << "  Launch a plugin with inspector enabled, or specify --port.\n";
+            return 1;
+        }
+        std::cout << ic_dim() << "Found inspector on port " << port << ic_reset() << "\n";
+    }
+
+    // Connect
+    InterprocessConnection conn;
+    auto address = host + ":" + std::to_string(port);
+    std::cout << "Connecting to " << address << "...\n";
+
+    // Set up message handler
+    std::atomic<bool> got_response{false};
+    std::string last_response;
+    conn.on_text_message = [&](std::string_view msg) {
+        InspectorMessage response;
+        if (decode_message(std::string(msg), response)) {
+            if (!one_shot_command.empty()) {
+                // One-shot mode: print and exit
+                if (response.is_error) {
+                    std::cerr << "Error: " << response.params_json << "\n";
+                } else {
+                    last_response = response.params_json;
+                }
+                got_response = true;
+            } else {
+                // REPL mode: print events and responses
+                if (!response.method.empty()) {
+                    // Event
+                    std::cout << ic_cyan() << "← " << response.method << ic_reset() << "\n";
+                    if (!response.params_json.empty() && response.params_json != "{}")
+                        std::cout << "  " << response.params_json << "\n";
+                } else {
+                    // Response
+                    if (response.is_error) {
+                        std::cout << ic_red() << "✗ Error: " << response.params_json << ic_reset() << "\n";
+                    } else {
+                        std::cout << ic_green() << "✓" << ic_reset() << " "
+                                  << response.params_json << "\n";
+                    }
+                }
+            }
+        }
+    };
+
+    if (!conn.connect(address, IpcTransport::Socket)) {
+        std::cerr << "Error: could not connect to " << address << "\n";
+        return 1;
+    }
+
+    std::cout << "  " << ic_green() << "\xe2\x9c\x93" << ic_reset() << " Connected to inspector\n";
+
+    // One-shot mode
+    if (!one_shot_command.empty()) {
+        auto msg = make_request(1, one_shot_command);
+        auto json = encode_message(msg);
+        conn.send_message(json);
+
+        // Wait for response
+        for (int i = 0; i < 50 && !got_response; ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+
+        if (!got_response) {
+            std::cerr << "Error: no response received (timeout)\n";
+            return 1;
+        }
+
+        if (!output_file.empty()) {
+            std::ofstream f(output_file);
+            f << last_response;
+            std::cout << "Written to " << output_file << "\n";
+        } else {
+            std::cout << last_response << "\n";
+        }
+
+        return 0;
+    }
+
+    // REPL mode
+    std::cout << "Inspector REPL. Type a method name (e.g., DOM.getDocument) or 'quit'.\n\n";
+
+    std::string line;
+    int64_t request_id = 1;
+    while (true) {
+        std::cout << ic_bold() << "inspect> " << ic_reset();
+        std::cout.flush();
+
+        if (!std::getline(std::cin, line)) break;
+        line = inspect_trim(line);
+        if (line.empty()) continue;
+        if (line == "quit" || line == "exit" || line == "q") break;
+
+        // Parse: METHOD [JSON_PARAMS]
+        std::string method = line;
+        std::string params = "{}";
+        auto space = line.find(' ');
+        if (space != std::string::npos) {
+            method = line.substr(0, space);
+            params = inspect_trim(line.substr(space + 1));
+        }
+
+        auto msg = make_request(request_id++, method, params);
+        auto json = encode_message(msg);
+        conn.send_message(json);
+
+        // Brief pause to receive response
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    conn.disconnect();
+    return 0;
+}

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -33,6 +33,9 @@
 #include "tool_registry.hpp"
 #include "design_binding.hpp"
 #include <pulp/ship/installer.hpp>
+
+// External command — implemented in cmd_inspect.cpp
+int cmd_inspect(const std::vector<std::string>& args);
 #include <pulp/view/screenshot.hpp>
 #include <pulp/format/editor_ui.hpp>
 
@@ -4849,21 +4852,7 @@ int main(int argc, char* argv[]) {
         for (auto& arg : args) cmd += " \"" + arg + "\"";
         return run(cmd);
     }
-    if (command == "inspect") {
-        auto root = find_project_root();
-        if (root.empty()) {
-            std::cerr << "Error: not in a Pulp project directory\n";
-            return 1;
-        }
-        auto screenshot_bin = root / "build" / "tools" / "screenshot" / "pulp-screenshot";
-        if (!fs::exists(screenshot_bin)) {
-            std::cerr << "Error: pulp-screenshot not built. Run `pulp build` first.\n";
-            return 1;
-        }
-        std::string cmd = screenshot_bin.string() + " --demo";
-        for (auto& arg : args) cmd += " " + arg;
-        return run(cmd);
-    }
+    if (command == "inspect") return cmd_inspect(args);
     if (command == "import-design" || command == "export-tokens") {
         auto root = find_project_root();
         if (root.empty()) {

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -2388,24 +2388,25 @@ static std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, b
     // Cmajor CLI check — only if project has .cmajorpatch files
     if (!active_root.empty()) {
         bool has_patches = false;
-        for (auto& entry : fs::recursive_directory_iterator(active_root,
-                 fs::directory_options::skip_permission_denied)) {
-            if (entry.path().extension() == ".cmajorpatch") {
+        auto dir_it = fs::recursive_directory_iterator(active_root,
+                 fs::directory_options::skip_permission_denied);
+        for (auto it = fs::begin(dir_it); it != fs::end(dir_it); ++it) {
+            if (it->path().extension() == ".cmajorpatch") {
                 has_patches = true;
                 break;
             }
             // Don't recurse into build/, external/, .git/
-            auto name = entry.path().filename().string();
-            if (entry.is_directory() && (name == "build" || name == "external" ||
+            auto name = it->path().filename().string();
+            if (it->is_directory() && (name == "build" || name == "external" ||
                 name == ".git" || name == "node_modules"))
-                entry.disable_recursion_pending();
+                it.disable_recursion_pending();
         }
         if (has_patches) {
             DoctorCheck c{"Cmajor CLI (cmaj)", false, {}, {}};
-            auto cmaj_path = pulp::platform::find_on_path("cmaj");
-            if (cmaj_path) {
+            auto cmaj_path = find_executable_in_path("cmaj");
+            if (!cmaj_path.empty()) {
                 c.passed = true;
-                c.detail = cmaj_path->string();
+                c.detail = cmaj_path;
             } else if (auto env = std::getenv("CMAJ_BIN"); env && fs::exists(env)) {
                 c.passed = true;
                 c.detail = std::string(env) + " (via CMAJ_BIN)";

--- a/tools/mcp/pulp_mcp.cpp
+++ b/tools/mcp/pulp_mcp.cpp
@@ -441,10 +441,15 @@ static std::string handle_request(const std::string& json) {
                  name == "pulp_inspect_performance" || name == "pulp_inspect_audio") {
             // Map MCP tool name to inspector protocol method
             std::string inspector_method;
+            std::string inspector_params;
             if (name == "pulp_inspect_dom")         inspector_method = "DOM.getDocument";
             else if (name == "pulp_inspect_params")  inspector_method = "State.getParameters";
             else if (name == "pulp_inspect_screenshot") inspector_method = "Capture.screenshot";
-            else if (name == "pulp_inspect_evaluate") inspector_method = "Runtime.evaluate";
+            else if (name == "pulp_inspect_evaluate") {
+                inspector_method = "Runtime.evaluate";
+                auto expr = extract_string(args_json, "expression");
+                if (!expr.empty()) inspector_params = " {\"expression\":" + json_string(expr) + "}";
+            }
             else if (name == "pulp_inspect_performance") inspector_method = "Performance.getMetrics";
             else if (name == "pulp_inspect_audio")   inspector_method = "Audio.getConfig";
 
@@ -453,10 +458,10 @@ static std::string handle_request(const std::string& json) {
                 result = "{\"content\":[{\"type\":\"text\",\"text\":\"Error: not in a Pulp project\"}]}";
             } else {
                 auto cli = (root / "build" / "tools" / "cli" / "pulp").string();
-                auto output = exec(cli + " inspect --command " + inspector_method + " 2>&1");
+                auto output = exec(cli + " inspect --command " + inspector_method + inspector_params + " 2>&1");
                 if (name == "pulp_inspect_screenshot") {
-                    // Screenshot returns base64 PNG
-                    result = "{\"content\":[{\"type\":\"image\",\"data\":\"" + output + "\",\"mimeType\":\"image/png\"}]}";
+                    // Screenshot returns base64 PNG — escape for safe JSON embedding
+                    result = "{\"content\":[{\"type\":\"image\",\"data\":" + json_string(output) + ",\"mimeType\":\"image/png\"}]}";
                 } else {
                     result = "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
                 }

--- a/tools/mcp/pulp_mcp.cpp
+++ b/tools/mcp/pulp_mcp.cpp
@@ -312,7 +312,13 @@ static std::string tools_list_json() {
 {"name":"pulp_get_view_tree","description":"Get the view tree as JSON for a demo UI","inputSchema":{"type":"object","properties":{}}},
 {"name":"pulp_create","description":"Scaffold a new plugin project from templates","inputSchema":{"type":"object","properties":{"name":{"type":"string","description":"Plugin name"},"type":{"type":"string","enum":["effect","instrument"],"description":"Plugin type"},"manufacturer":{"type":"string","description":"Manufacturer name"}}}},
 {"name":"pulp_docs_check","description":"Validate docs consistency against the codebase","inputSchema":{"type":"object","properties":{}}},
-{"name":"pulp_docs_search","description":"Search local docs for a query string","inputSchema":{"type":"object","properties":{"query":{"type":"string","description":"Search query"}}}}
+{"name":"pulp_docs_search","description":"Search local docs for a query string","inputSchema":{"type":"object","properties":{"query":{"type":"string","description":"Search query"}}}},
+{"name":"pulp_inspect_dom","description":"Get the view tree of a running plugin's UI via the inspector protocol","inputSchema":{"type":"object","properties":{}}},
+{"name":"pulp_inspect_params","description":"Get all parameter info and current values from a running plugin","inputSchema":{"type":"object","properties":{}}},
+{"name":"pulp_inspect_screenshot","description":"Capture a screenshot from a running plugin via the inspector","inputSchema":{"type":"object","properties":{}}},
+{"name":"pulp_inspect_evaluate","description":"Evaluate a JS expression in a running plugin's script engine","inputSchema":{"type":"object","properties":{"expression":{"type":"string","description":"JS expression to evaluate"}}}},
+{"name":"pulp_inspect_performance","description":"Get render performance metrics from a running plugin","inputSchema":{"type":"object","properties":{}}},
+{"name":"pulp_inspect_audio","description":"Get audio configuration and buffer underrun info from a running plugin","inputSchema":{"type":"object","properties":{}}}
 ]})JSON";
 }
 
@@ -426,6 +432,34 @@ static std::string handle_request(const std::string& json) {
             } else {
                 auto output = exec((root / "build" / "tools" / "cli" / "pulp").string() + " docs search \"" + query + "\" 2>&1");
                 result = "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
+            }
+        }
+        // Inspector tools — delegate to pulp inspect CLI for now
+        // (in the future these could connect directly via TCP)
+        else if (name == "pulp_inspect_dom" || name == "pulp_inspect_params" ||
+                 name == "pulp_inspect_screenshot" || name == "pulp_inspect_evaluate" ||
+                 name == "pulp_inspect_performance" || name == "pulp_inspect_audio") {
+            // Map MCP tool name to inspector protocol method
+            std::string inspector_method;
+            if (name == "pulp_inspect_dom")         inspector_method = "DOM.getDocument";
+            else if (name == "pulp_inspect_params")  inspector_method = "State.getParameters";
+            else if (name == "pulp_inspect_screenshot") inspector_method = "Capture.screenshot";
+            else if (name == "pulp_inspect_evaluate") inspector_method = "Runtime.evaluate";
+            else if (name == "pulp_inspect_performance") inspector_method = "Performance.getMetrics";
+            else if (name == "pulp_inspect_audio")   inspector_method = "Audio.getConfig";
+
+            auto root = find_project_root();
+            if (root.empty()) {
+                result = "{\"content\":[{\"type\":\"text\",\"text\":\"Error: not in a Pulp project\"}]}";
+            } else {
+                auto cli = (root / "build" / "tools" / "cli" / "pulp").string();
+                auto output = exec(cli + " inspect --command " + inspector_method + " 2>&1");
+                if (name == "pulp_inspect_screenshot") {
+                    // Screenshot returns base64 PNG
+                    result = "{\"content\":[{\"type\":\"image\",\"data\":\"" + output + "\",\"mimeType\":\"image/png\"}]}";
+                } else {
+                    result = "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
+                }
             }
         }
         else return json_error(id, -32601, "Unknown tool: " + name);


### PR DESCRIPTION
## Summary

Implements the most advanced audio plugin inspector in any framework — 16 new files, ~2,500 lines, replacing the `inspect/` placeholder.

### Tier 1: Visual Inspector
- `InspectorOverlay` — Cmd+I toggle, click-to-inspect, property panel
- Hover highlight (blue) + selected highlight (orange) via overlay_queue
- Box model visualization: padding (green), margin (orange), distance-to-parent
- Alt+click distance measurement between any two widgets
- FPS/frame-time counter from RenderPassManager
- Tree panel with collapse/expand, scroll, search
- Property panel: bounds, flex layout, theme color swatches

### Tier 2: Audio Plugin Advantages
- `StateInspector` — parameter monitoring with weak_ptr guard, live editing
- `ConsoleCapture` — JS console.log/warn/error interception (chained callbacks)
- Parameter metadata: name, value, range, unit, modulation, display string

### Tier 3: Protocol Layer
- `protocol.hpp/cpp` — JSON message format (Chrome DevTools-inspired)
- `InspectorServer` — TCP server via InterprocessConnectionServer
- `DomainHandler` — 9 domain handlers (Inspector, DOM, CSS, Performance, State, Console, Runtime, Audio, Capture)
- `AudioInspector` — buffer underrun detection, per-channel metering, MIDI log
- `cmd_inspect.cpp` — CLI client with REPL and one-shot modes
- MCP bridge — 6 new tools for AI agent integration

### Architecture
- Zero overhead when disabled (active_ flag, early return)
- Not a View subclass — paints via Canvas API after paint_overlays()
- Thread-safe: mutex-guarded state, weak_ptr callback guards
- Port discovery via ${TMPDIR}/pulp-inspector-*.port

## Test plan
- [x] All 2,005 tests pass (0 failures)
- [x] Full build succeeds (all targets)
- [x] `pulp inspect --help` works
- [x] Naming audit passes
- [ ] Interactive test: Cmd+I on standalone plugin
- [ ] `pulp inspect` connecting to running instance