### PR TITLE
Fix P1 review issues + add 6 mobile audio packages

### DIFF
--- a/core/platform/platform/posix/child_process_posix.cpp
+++ b/core/platform/platform/posix/child_process_posix.cpp
@@ -34,37 +34,36 @@ struct Pipe {
     int write_end() const { return fd[1]; }
 };
 
-// Read available bytes from a non-blocking fd. Appends to buffer,
-// fires callback for each complete line, returns bytes read.
-size_t drain_pipe(int fd, std::string& buffer, size_t max_bytes,
+// Read available bytes from a non-blocking fd.
+// Appends to full_output (for ProcessResult), and to line_buf (for
+// line-by-line callback splitting). The two buffers are independent.
+size_t drain_pipe(int fd, std::string& full_output, std::string& line_buf,
+                  size_t max_bytes,
                   const std::function<void(std::string_view)>& line_cb) {
     char chunk[4096];
     size_t total = 0;
     while (true) {
         auto n = read(fd, chunk, sizeof(chunk));
         if (n <= 0) break;
-        total += static_cast<size_t>(n);
-        if (buffer.size() < max_bytes)
-            buffer.append(chunk, std::min(static_cast<size_t>(n),
-                                          max_bytes - buffer.size()));
-        if (line_cb) {
-            // Find complete lines in the appended data
-            // We need to track the line start position
-            size_t search_from = buffer.size() >= static_cast<size_t>(n)
-                                     ? buffer.size() - static_cast<size_t>(n) : 0;
-            // Simplified: scan the whole buffer for lines
-        }
+        auto bytes = static_cast<size_t>(n);
+        total += bytes;
+        // Always accumulate into full_output (capped)
+        if (full_output.size() < max_bytes)
+            full_output.append(chunk, std::min(bytes, max_bytes - full_output.size()));
+        // If line callback, also accumulate into line_buf for splitting
+        if (line_cb)
+            line_buf.append(chunk, bytes);
     }
     // Fire callbacks for complete lines
-    if (line_cb) {
+    if (line_cb && !line_buf.empty()) {
         size_t pos = 0;
-        while (pos < buffer.size()) {
-            auto nl = buffer.find('\n', pos);
+        while (pos < line_buf.size()) {
+            auto nl = line_buf.find('\n', pos);
             if (nl == std::string::npos) break;
-            line_cb(std::string_view(buffer).substr(pos, nl - pos));
+            line_cb(std::string_view(line_buf).substr(pos, nl - pos));
             pos = nl + 1;
         }
-        if (pos > 0) buffer.erase(0, pos);
+        if (pos > 0) line_buf.erase(0, pos);
     }
     return total;
 }
@@ -76,9 +75,9 @@ struct ChildProcess::Impl {
     Pipe stdout_pipe;
     Pipe stderr_pipe;
     ProcessOptions options;
-    std::string stdout_buf;
-    std::string stderr_buf;
-    std::string stdout_lines_buf;  // partial line accumulator
+    std::string stdout_full;       // complete captured output for ProcessResult
+    std::string stderr_full;
+    std::string stdout_lines_buf;  // partial line accumulator for callbacks
     std::string stderr_lines_buf;
     bool started = false;
     bool finished = false;
@@ -99,8 +98,8 @@ bool ChildProcess::start(const std::string& command,
                          const std::vector<std::string>& args,
                          const ProcessOptions& options) {
     impl_->options = options;
-    impl_->stdout_buf.clear();
-    impl_->stderr_buf.clear();
+    impl_->stdout_full.clear();
+    impl_->stderr_full.clear();
     impl_->stdout_lines_buf.clear();
     impl_->stderr_lines_buf.clear();
     impl_->finished = false;
@@ -126,13 +125,8 @@ bool ChildProcess::start(const std::string& command,
 
     // Working directory
     if (!options.working_directory.empty()) {
-#ifdef __APPLE__
+        // posix_spawn_file_actions_addchdir_np is available on macOS 10.15+ and glibc 2.29+
         posix_spawn_file_actions_addchdir_np(&actions, options.working_directory.c_str());
-#else
-        // Linux: chdir_np may not be available on older glibc
-        // Fall back to changing before spawn (not ideal for thread safety)
-        // TODO: use posix_spawn_file_actions_addchdir_np when available
-#endif
     }
 
     int rc = posix_spawnp(&impl_->pid,
@@ -161,9 +155,9 @@ bool ChildProcess::start(const std::string& command,
 
 bool ChildProcess::is_running() const {
     if (!impl_->started || impl_->finished) return false;
-    int status = 0;
-    auto rc = waitpid(impl_->pid, &status, WNOHANG);
-    return rc == 0;  // 0 means still running
+    // Use kill(pid, 0) to check existence without reaping.
+    // waitpid with WNOHANG would reap the child, causing wait() to hang.
+    return kill(impl_->pid, 0) == 0;
 }
 
 void ChildProcess::cancel() {
@@ -173,9 +167,13 @@ void ChildProcess::cancel() {
     for (int i = 0; i < 100; ++i) {
         int status = 0;
         if (waitpid(impl_->pid, &status, WNOHANG) != 0) {
+            impl_->stdout_pipe.close_read();
+            impl_->stderr_pipe.close_read();
             impl_->finished = true;
             impl_->result.was_cancelled = true;
             impl_->result.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+            impl_->result.stdout_output = std::move(impl_->stdout_full);
+            impl_->result.stderr_output = std::move(impl_->stderr_full);
             return;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -183,9 +181,13 @@ void ChildProcess::cancel() {
     kill(impl_->pid, SIGKILL);
     int status = 0;
     waitpid(impl_->pid, &status, 0);
+    impl_->stdout_pipe.close_read();
+    impl_->stderr_pipe.close_read();
     impl_->finished = true;
     impl_->result.was_cancelled = true;
     impl_->result.exit_code = -1;
+    impl_->result.stdout_output = std::move(impl_->stdout_full);
+    impl_->result.stderr_output = std::move(impl_->stderr_full);
 }
 
 ProcessResult ChildProcess::wait() {
@@ -196,29 +198,22 @@ ProcessResult ChildProcess::wait() {
     auto max_bytes = impl_->options.max_output_bytes;
 
     while (true) {
-        // Drain pipes
-        drain_pipe(impl_->stdout_pipe.read_end(), impl_->stdout_lines_buf,
-                   max_bytes, impl_->options.on_stdout_line);
-        drain_pipe(impl_->stderr_pipe.read_end(), impl_->stderr_lines_buf,
-                   max_bytes, impl_->options.on_stderr_line);
-
-        // Accumulate for result (without line splitting)
-        // The drain_pipe modifies lines_buf in-place for line callbacks,
-        // so we maintain separate full-output buffers
-        {
-            char chunk[4096];
-            // stdout already drained by drain_pipe, data is in lines_buf
-        }
+        // Drain pipes — full output goes to stdout_full/stderr_full,
+        // line splitting goes to lines_buf (independent buffers)
+        drain_pipe(impl_->stdout_pipe.read_end(), impl_->stdout_full,
+                   impl_->stdout_lines_buf, max_bytes, impl_->options.on_stdout_line);
+        drain_pipe(impl_->stderr_pipe.read_end(), impl_->stderr_full,
+                   impl_->stderr_lines_buf, max_bytes, impl_->options.on_stderr_line);
 
         // Check if process exited
         int status = 0;
         auto rc = waitpid(impl_->pid, &status, WNOHANG);
         if (rc > 0) {
             // Process exited — drain remaining output
-            drain_pipe(impl_->stdout_pipe.read_end(), impl_->stdout_lines_buf,
-                       max_bytes, impl_->options.on_stdout_line);
-            drain_pipe(impl_->stderr_pipe.read_end(), impl_->stderr_lines_buf,
-                       max_bytes, impl_->options.on_stderr_line);
+            drain_pipe(impl_->stdout_pipe.read_end(), impl_->stdout_full,
+                       impl_->stdout_lines_buf, max_bytes, impl_->options.on_stdout_line);
+            drain_pipe(impl_->stderr_pipe.read_end(), impl_->stderr_full,
+                       impl_->stderr_lines_buf, max_bytes, impl_->options.on_stderr_line);
 
             impl_->finished = true;
             impl_->result.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
@@ -249,19 +244,19 @@ ProcessResult ChildProcess::wait() {
     impl_->stdout_pipe.close_read();
     impl_->stderr_pipe.close_read();
 
-    // Remaining partial lines become output
-    impl_->result.stdout_output = std::move(impl_->stdout_lines_buf);
-    impl_->result.stderr_output = std::move(impl_->stderr_lines_buf);
+    // Full captured output goes to result
+    impl_->result.stdout_output = std::move(impl_->stdout_full);
+    impl_->result.stderr_output = std::move(impl_->stderr_full);
 
     return impl_->result;
 }
 
 std::string ChildProcess::read_available_output() {
     if (!impl_->started) return {};
-    std::string buf;
-    drain_pipe(impl_->stdout_pipe.read_end(), buf,
+    std::string full, lines;
+    drain_pipe(impl_->stdout_pipe.read_end(), full, lines,
                impl_->options.max_output_bytes, nullptr);
-    return buf;
+    return full;
 }
 
 ProcessResult ChildProcess::run(const std::string& command,

--- a/ship/platform/mac/codesign_mac.mm
+++ b/ship/platform/mac/codesign_mac.mm
@@ -15,16 +15,16 @@
 namespace pulp::ship {
 namespace fs = std::filesystem;
 
-static std::string exec_cmd(const std::string& cmd) {
-    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, 120000);
+static std::string exec_cmd(const std::string& cmd, int timeout_ms = 120000) {
+    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, timeout_ms);
     auto result = r.stdout_output;
     while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
         result.pop_back();
     return result;
 }
 
-static int exec_status(const std::string& cmd) {
-    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, 120000);
+static int exec_status(const std::string& cmd, int timeout_ms = 120000) {
+    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, timeout_ms);
     return r.exit_code;
 }
 
@@ -110,7 +110,8 @@ std::optional<std::string> notarize_submit(const std::string& path,
         + " --password \"" + password + "\""
         + " --wait 2>&1";
 
-    auto output = exec_cmd(cmd);
+    // Notarization can take 5-15 minutes — use 20 min timeout
+    auto output = exec_cmd(cmd, 1200000);
     // Extract request UUID
     std::regex uuid_re("id: ([0-9a-f-]+)");
     std::smatch match;

--- a/tools/cli/package_commands.cpp
+++ b/tools/cli/package_commands.cpp
@@ -619,6 +619,11 @@ int cmd_add(const std::vector<std::string>& args) {
         }
     }
     if (verdict == LicenseVerdict::rejected && license_override) {
+        // Validate --accept-license matches the actual package license
+        if (!accepted_license.empty() && accepted_license != pkg.license) {
+            print_fail("--accept-license " + accepted_license + " does not match package license " + pkg.license);
+            return 1;
+        }
         print_warn("Installing " + pkg.license + " package — your distributed binary must comply with " + pkg.license);
     }
     if (verdict == LicenseVerdict::review_required) {

--- a/tools/packages/registry.json
+++ b/tools/packages/registry.json
@@ -976,6 +976,80 @@
         "build_status": {}
       }
     },
+    "rnnoise": {
+      "name": "RNNoise",
+      "version": "v0.2",
+      "description": "Neural network noise suppression for voice",
+      "license": "BSD-3-Clause",
+      "category": "dsp",
+      "url": "https://github.com/xiph/rnnoise",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/xiph/rnnoise.git",
+        "git_tag": "v0.2"
+      },
+      "cmake": {
+        "targets": [
+          "rnnoise"
+        ],
+        "header_only": false,
+        "include_dir": "include"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "noise-suppression",
+        "voice",
+        "neural-network",
+        "real-time"
+      ],
+      "provides": [
+        "noise-suppression",
+        "voice-enhancement"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Purpose-built neural noise suppression — removes keyboard, HVAC, crowd noise in real time",
+      "alternatives": [
+        "SpeexDSP (BSD-3, traditional AEC/NS — less effective but lighter)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "v0.2",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v0.2",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
     "rubber-band": {
       "name": "Rubber Band",
       "version": "v3.3.0",
@@ -1304,6 +1378,215 @@
         "build_status": {}
       }
     },
+    "miniaudio": {
+      "name": "miniaudio",
+      "version": "0.11.21",
+      "description": "Single-header audio playback, capture, and device I/O",
+      "license": "MIT-0",
+      "category": "audio-io",
+      "url": "https://github.com/mackron/miniaudio",
+      "fetch": {
+        "method": "header-only",
+        "git_repository": "https://github.com/mackron/miniaudio.git",
+        "git_tag": "0.11.21"
+      },
+      "cmake": {
+        "targets": [
+          "miniaudio"
+        ],
+        "header_only": true,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 27
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0"
+        }
+      },
+      "rt_safe": false,
+      "tags": [
+        "device-io",
+        "playback",
+        "capture",
+        "audio-backend",
+        "cross-platform"
+      ],
+      "provides": [
+        "audio-device-io",
+        "playback",
+        "capture"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Complete audio device layer for mobile — Core Audio on iOS, AAudio on Android, single-header",
+      "alternatives": [
+        "Oboe (Apache-2.0, Android-only)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "0.11.21",
+        "upstream_commit": "unknown",
+        "upstream_latest": "0.11.21",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "oboe": {
+      "name": "Oboe",
+      "version": "1.9.0",
+      "description": "Google's Android low-latency audio library",
+      "license": "Apache-2.0",
+      "category": "audio-io",
+      "url": "https://github.com/google/oboe",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/google/oboe.git",
+        "git_tag": "1.9.0"
+      },
+      "cmake": {
+        "targets": [
+          "oboe"
+        ],
+        "header_only": false,
+        "include_dir": "include"
+      },
+      "platforms": {
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 16
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "android",
+        "low-latency",
+        "aaudio",
+        "opensl"
+      ],
+      "provides": [
+        "android-audio-device"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Google-maintained Android audio with automatic AAudio/OpenSL selection for lowest latency",
+      "alternatives": [
+        "miniaudio (MIT-0, cross-platform but less Android-optimized)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "1.9.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "1.9.0",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "opus": {
+      "name": "Opus",
+      "version": "v1.5.2",
+      "description": "IETF standard low-latency audio codec (6-510 kbps)",
+      "license": "BSD-3-Clause",
+      "category": "audio-io",
+      "url": "https://github.com/xiph/opus",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/xiph/opus.git",
+        "git_tag": "v1.5.2"
+      },
+      "cmake": {
+        "targets": [
+          "opus"
+        ],
+        "header_only": false,
+        "include_dir": "include"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "codec",
+        "voice",
+        "streaming",
+        "voip",
+        "low-latency"
+      ],
+      "provides": [
+        "audio-codec",
+        "opus-encode",
+        "opus-decode"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "The standard audio codec for streaming, VOIP, and WebRTC — patent-free, royalty-free",
+      "alternatives": [],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "v1.5.2",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v1.5.2",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
     "soundtouch": {
       "name": "SoundTouch",
       "version": "2.4.0",
@@ -1380,6 +1663,83 @@
         "verified_version": "2.4.0",
         "upstream_commit": "unknown",
         "upstream_latest": "2.4.0",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "tinysoundfont": {
+      "name": "TinySoundFont",
+      "version": "master",
+      "description": "Single-header SoundFont2 synthesizer for MIDI playback",
+      "license": "MIT",
+      "category": "dsp",
+      "url": "https://github.com/schellingb/TinySoundFont",
+      "fetch": {
+        "method": "header-only",
+        "git_repository": "https://github.com/schellingb/TinySoundFont.git",
+        "git_tag": "master"
+      },
+      "cmake": {
+        "targets": [
+          "tinysoundfont"
+        ],
+        "header_only": true,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": false,
+      "tags": [
+        "soundfont",
+        "sf2",
+        "midi",
+        "synthesizer",
+        "general-midi"
+      ],
+      "provides": [
+        "soundfont-synthesis",
+        "sf2-playback",
+        "midi-synthesis"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "MIT-licensed SF2 synthesis — mobile-friendly alternative to FluidSynth (LGPL)",
+      "alternatives": [
+        "FluidSynth (LGPL-2.1, full-featured but heavy deps)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "master",
+        "upstream_commit": "unknown",
+        "upstream_latest": "master",
         "pulp_commit": "unknown",
         "build_status": {}
       }
@@ -1532,6 +1892,81 @@
         "verified_version": "6.0.2",
         "upstream_commit": "unknown",
         "upstream_latest": "6.0.2",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "kissfft": {
+      "name": "KissFFT",
+      "version": "131.1.0",
+      "description": "Portable FFT for any size — not just power-of-two",
+      "license": "BSD-3-Clause",
+      "category": "dsp",
+      "url": "https://github.com/mborgerding/kissfft",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/mborgerding/kissfft.git",
+        "git_tag": "131.1.0"
+      },
+      "cmake": {
+        "targets": [
+          "kissfft"
+        ],
+        "header_only": false,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "fft",
+        "portable",
+        "arbitrary-size"
+      ],
+      "provides": [
+        "fft"
+      ],
+      "overlaps_with_builtin": {
+        "signal/fft.hpp": "FFT"
+      },
+      "unique_value": "Arbitrary-size FFT (not limited to power-of-two like PFFFT)",
+      "alternatives": [
+        "PFFFT (BSD-3, SIMD-optimized but power-of-two only)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "131.1.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "131.1.0",
         "pulp_commit": "unknown",
         "build_status": {}
       }


### PR DESCRIPTION
## P1 Fixes

- **ChildProcess is_running()**: Use kill(pid,0) instead of waitpid to avoid reaping child
- **ChildProcess drain_pipe**: Separate full_output and line_buf buffers so callbacks don't erase captured output
- **ChildProcess cancel()**: Close pipe FDs, move output to result before returning
- **ChildProcess Linux working_directory**: Use posix_spawn_file_actions_addchdir_np
- **Notarization timeout**: 20 min for notarytool submit (was 120s, notarization takes 5-15 min)
- **--accept-license validation**: Verify SPDX matches actual package license

## 6 New Mobile Audio Packages

| Package | License | What It Adds |
|---------|---------|-------------|
| KissFFT | BSD-3 | Portable arbitrary-size FFT |
| miniaudio | MIT-0 | Device I/O on iOS + Android |
| Oboe | Apache-2.0 | Google's Android low-latency audio |
| Opus | BSD-3 | Standard audio codec |
| RNNoise | BSD-3 | Neural noise suppression |
| TinySoundFont | MIT | SF2 playback (FluidSynth alternative) |

Registry now has 28 packages total.

## Test plan
- [x] CI green on all 3 platforms
- [x] Registry validates
- [x] Naming audit passes