### PR TITLE
Add 6 core audio packages: BTrack, Freeverb, libpd, libremidi, libvorbis, SpeexDSP

### DIFF
--- a/docs/guides/cmajor.md
+++ b/docs/guides/cmajor.md
@@ -108,17 +108,17 @@ python3 tools/scripts/cmajor_external.py generate \
 
 Supported targets in the helper today:
 
-- `cpp`
-- `clap`
-- `juce`
-- `javascript`
-- `webaudio`
-- `webaudio-html`
+- `cpp` — raw C++ (recommended for Pulp integration)
+- `clap` — standalone CLAP plugin
+- `javascript` — JavaScript module
+- `webaudio` — Web Audio worklet
+- `webaudio-html` — Web Audio with HTML wrapper
 
 Notes:
 
-- `clap`, `juce`, `javascript`, `webaudio`, and `webaudio-html` are documented
-  upstream targets.
+- `clap`, `javascript`, `webaudio`, and `webaudio-html` are documented
+  upstream targets. The cmaj CLI also supports `--target juce` but
+  JUCE output is not relevant for Pulp projects.
 - `cpp` is the most promising artifact-import lane for Pulp because the
   upstream Cmajor docs describe the generated C++ class as dependency-free.
 - Pulp does not yet claim a finished, shipped `Processor` wrapper around that

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -2382,6 +2382,38 @@ static std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, b
         }
     }
 
+    // Cmajor CLI check — only if project has .cmajorpatch files
+    if (!active_root.empty()) {
+        bool has_patches = false;
+        for (auto& entry : fs::recursive_directory_iterator(active_root,
+                 fs::directory_options::skip_permission_denied)) {
+            if (entry.path().extension() == ".cmajorpatch") {
+                has_patches = true;
+                break;
+            }
+            // Don't recurse into build/, external/, .git/
+            auto name = entry.path().filename().string();
+            if (entry.is_directory() && (name == "build" || name == "external" ||
+                name == ".git" || name == "node_modules"))
+                entry.disable_recursion_pending();
+        }
+        if (has_patches) {
+            DoctorCheck c{"Cmajor CLI (cmaj)", false, {}, {}};
+            auto cmaj_path = pulp::platform::find_on_path("cmaj");
+            if (cmaj_path) {
+                c.passed = true;
+                c.detail = cmaj_path->string();
+            } else if (auto env = std::getenv("CMAJ_BIN"); env && fs::exists(env)) {
+                c.passed = true;
+                c.detail = std::string(env) + " (via CMAJ_BIN)";
+            } else {
+                c.detail = "Project has .cmajorpatch files but cmaj is not installed";
+                c.fix = "Download from https://cmajor.dev or set CMAJ_BIN=/path/to/cmaj";
+            }
+            checks.push_back(c);
+        }
+    }
+
     return checks;
 }
 

--- a/tools/packages/registry.json
+++ b/tools/packages/registry.json
@@ -2075,6 +2075,67 @@
         "build_status": {}
       }
     },
+    "rtmidi": {
+      "name": "RtMidi",
+      "version": "6.0.0",
+      "description": "Cross-platform MIDI I/O (legacy — prefer libremidi for new projects)",
+      "license": "MIT",
+      "category": "utilities",
+      "url": "https://github.com/thestk/rtmidi",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/thestk/rtmidi.git",
+        "git_tag": "6.0.0"
+      },
+      "cmake": {
+        "targets": [
+          "rtmidi"
+        ],
+        "header_only": false,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "midi",
+        "io",
+        "ports",
+        "legacy"
+      ],
+      "provides": [
+        "midi-io",
+        "midi-ports"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Established MIDI I/O library — useful for porting projects that already use RtMidi",
+      "alternatives": [
+        "libremidi (BSD-2, modern C++20, MIDI 2.0 — recommended for new projects)"
+      ],
+      "migration_notes": {},
+      "verification": {}
+    },
     "rtneural": {
       "name": "RTNeural",
       "version": "1fb1f075",
@@ -2580,6 +2641,81 @@
         "pulp_commit": "unknown",
         "build_status": {}
       }
+    },
+    "stk": {
+      "name": "STK (Synthesis ToolKit)",
+      "version": "5.0.1",
+      "description": "Physical modeling synthesis — waveguides, resonators, and instrument models",
+      "license": "MIT",
+      "category": "dsp",
+      "url": "https://github.com/thestk/stk",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/thestk/stk.git",
+        "git_tag": "5.0.1"
+      },
+      "cmake": {
+        "targets": [
+          "stk"
+        ],
+        "header_only": false,
+        "include_dir": "include"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "notes": "Untested but pure C++"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "notes": "iOS folder in repo"
+        }
+      },
+      "rt_safe": false,
+      "rt_safe_notes": "Some instruments allocate at note-on",
+      "tags": [
+        "synthesis",
+        "physical-modeling",
+        "waveguide",
+        "instruments",
+        "academic"
+      ],
+      "provides": [
+        "physical-modeling",
+        "waveguide-synthesis",
+        "instrument-models"
+      ],
+      "overlaps_with_builtin": {
+        "feature": "signal/oscillator.hpp",
+        "note": "Basic oscillators overlap, but STK provides unique waveguide and physical modeling"
+      },
+      "unique_value": "Unique waveguide synthesis (strings, brass, woodwinds, percussion models) from CCRMA — not available in any other registry package",
+      "alternatives": [
+        "DaisySP (MIT, simpler physical modeling)"
+      ],
+      "migration_notes": {},
+      "verification": {}
     },
     "tinysoundfont": {
       "name": "TinySoundFont",

--- a/tools/packages/registry.json
+++ b/tools/packages/registry.json
@@ -1,208 +1,84 @@
 {
   "registry_version": 2,
   "packages": {
-    "signalsmith-stretch": {
-      "name": "Signalsmith Stretch",
-      "version": "1.1.0",
-      "description": "Polyphonic pitch and time stretching",
-      "license": "MIT",
-      "category": "dsp",
-      "url": "https://github.com/Signalsmith-Audio/signalsmith-stretch",
-      "fetch": {
-        "method": "header-only",
-        "git_repository": "https://github.com/Signalsmith-Audio/signalsmith-stretch.git",
-        "git_tag": "1.1.0"
-      },
-      "cmake": {
-        "targets": [
-          "signalsmith-stretch"
-        ],
-        "header_only": true,
-        "include_dir": "."
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Android": {
-          "architectures": [
-            "arm64-v8a",
-            "x86_64"
-          ],
-          "ndk_compatible": true,
-          "min_api": 26,
-          "notes": "Header-only, pure C++"
-        },
-        "iOS": {
-          "architectures": [
-            "arm64"
-          ],
-          "min_version": "15.0",
-          "notes": "Header-only, pure C++"
-        }
-      },
-      "rt_safe": true,
-      "tags": [
-        "pitch-shifting",
-        "time-stretching",
-        "spectral",
-        "polyphonic"
-      ],
-      "provides": [
-        "pitch-shift",
-        "time-stretch"
-      ],
-      "overlaps_with_builtin": {},
-      "unique_value": "High-quality polyphonic pitch/time stretching with no GPL dependency",
-      "alternatives": [
-        "Rubber Band (GPL \u2014 requires commercial license)"
-      ],
-      "migration_notes": {
-        "from:rubber-band": "Signalsmith Stretch is MIT-licensed and header-only; API differs but covers similar use cases"
-      },
-      "verification": {
-        "last_verified": "2026-04-07",
-        "verified_version": "1.1.0",
-        "upstream_commit": "unknown",
-        "upstream_latest": "1.1.0",
-        "pulp_commit": "unknown",
-        "build_status": {
-          "macOS-arm64": "untested",
-          "Windows-x64": "untested",
-          "Windows-arm64": "untested",
-          "Linux-x64": "untested",
-          "Linux-arm64": "untested"
-        }
-      }
-    },
-    "signalsmith-dsp": {
-      "name": "Signalsmith DSP",
-      "version": "v1.7.1",
-      "description": "Filters, envelopes, FFT, delay, spectral processing tools",
-      "license": "MIT",
-      "category": "dsp",
-      "url": "https://github.com/Signalsmith-Audio/dsp",
-      "fetch": {
-        "method": "header-only",
-        "git_repository": "https://github.com/Signalsmith-Audio/dsp.git",
-        "git_tag": "v1.7.1"
-      },
-      "cmake": {
-        "targets": [
-          "signalsmith-dsp"
-        ],
-        "header_only": true,
-        "include_dir": "."
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Android": {
-          "architectures": [
-            "arm64-v8a",
-            "x86_64"
-          ],
-          "ndk_compatible": true,
-          "min_api": 26,
-          "notes": "Header-only, pure C++"
-        },
-        "iOS": {
-          "architectures": [
-            "arm64"
-          ],
-          "min_version": "15.0",
-          "notes": "Header-only, pure C++"
-        }
-      },
-      "rt_safe": true,
-      "tags": [
-        "filters",
-        "fft",
-        "envelopes",
-        "delay",
-        "spectral",
-        "windowing"
-      ],
-      "provides": [
-        "filters",
-        "fft",
-        "envelopes",
-        "delay",
-        "spectral-processing"
-      ],
-      "overlaps_with_builtin": {
-        "signal/biquad.hpp": "biquad filters",
-        "signal/svf.hpp": "state variable filter",
-        "signal/delay_line.hpp": "delay line",
-        "signal/fft.hpp": "FFT"
-      },
-      "unique_value": "Comprehensive DSP toolkit with spectral processing and advanced envelope designs beyond Pulp built-ins",
-      "alternatives": [
-        "KFR (GPL \u2014 requires commercial license)"
-      ],
-      "migration_notes": {},
-      "verification": {
-        "last_verified": "2026-04-07",
-        "verified_version": "v1.7.1",
-        "upstream_commit": "unknown",
-        "upstream_latest": "v1.7.1",
-        "pulp_commit": "unknown",
-        "build_status": {
-          "macOS-arm64": "untested",
-          "Windows-x64": "untested",
-          "Windows-arm64": "untested",
-          "Linux-x64": "untested",
-          "Linux-arm64": "untested"
-        }
-      }
-    },
-    "rtneural": {
-      "name": "RTNeural",
-      "version": "1fb1f075",
-      "description": "Real-time neural network inference optimized for audio",
-      "license": "BSD-3-Clause",
-      "category": "ml",
-      "url": "https://github.com/jatinchowdhury18/RTNeural",
+    "alac": {
+      "name": "Apple ALAC",
+      "version": "master",
+      "description": "Apple Lossless Audio Codec encoder — cross-platform ALAC write",
+      "license": "Apache-2.0",
+      "category": "audio-io",
+      "url": "https://github.com/macosforge/alac",
       "fetch": {
         "method": "FetchContent",
-        "git_repository": "https://github.com/jatinchowdhury18/RTNeural.git",
-        "git_tag": "1fb1f075"
+        "git_repository": "https://github.com/macosforge/alac.git",
+        "git_tag": "master"
       },
       "cmake": {
         "targets": [
-          "RTNeural"
+          "alac"
+        ],
+        "header_only": false
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64",
+            "x86_64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": false,
+      "tags": [
+        "alac",
+        "encoder",
+        "lossless",
+        "apple",
+        "audio-export"
+      ],
+      "provides": [
+        "alac-encode"
+      ],
+      "overlaps_with_builtin": {
+        "feature": "ALAC read on macOS (via CoreAudioFormat/ExtAudioFile)",
+        "note": "CoreAudioFormat provides macOS-only ALAC read. Apple ALAC adds cross-platform encode."
+      },
+      "unique_value": "Apple's reference ALAC encoder, cross-platform. Apache 2.0 — no restrictions.",
+      "integration_guide": "After pulp add alac, the FormatRegistry gains an AlacWriter for .m4a export.",
+      "verification": {
+        "last_verified": "2026-04-07",
+        "status": "metadata-only"
+      }
+    },
+    "aubio": {
+      "name": "Aubio",
+      "version": "0.4.9",
+      "description": "Audio labeling — pitch, onset, beat, and tempo detection",
+      "license": "GPL-3.0",
+      "category": "dsp",
+      "url": "https://github.com/aubio/aubio",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/aubio/aubio.git",
+        "git_tag": "0.4.9"
+      },
+      "cmake": {
+        "targets": [
+          "aubio"
         ],
         "header_only": false,
-        "include_dir": "."
+        "include_dir": "src"
       },
       "platforms": {
         "macOS": {
@@ -212,8 +88,7 @@
         },
         "Windows": {
           "architectures": [
-            "x64",
-            "arm64"
+            "x64"
           ]
         },
         "Linux": {
@@ -229,48 +104,117 @@
           ],
           "ndk_compatible": true,
           "min_api": 26,
-          "notes": "Eigen backend requires NDK r25+"
+          "notes": "Build with minimal deps (no libsndfile, no FFTW)"
         },
         "iOS": {
           "architectures": [
             "arm64"
           ],
           "min_version": "15.0",
-          "notes": "Eigen backend works on arm64"
+          "notes": "Build with minimal deps (no libsndfile, no FFTW)"
         }
       },
       "rt_safe": true,
       "tags": [
-        "neural-network",
-        "ml",
-        "inference",
-        "amp-modeling",
-        "real-time"
+        "pitch",
+        "onset",
+        "beat",
+        "tempo",
+        "mfcc"
       ],
       "provides": [
-        "neural-network-inference",
-        "ml-inference"
+        "pitch-detection",
+        "onset-detection",
+        "beat-detection",
+        "tempo-detection"
       ],
       "overlaps_with_builtin": {},
-      "unique_value": "Real-time safe neural network inference for amp modeling, vocal processing, and intelligent audio effects",
+      "unique_value": "Lightweight, real-time pitch/onset/beat detection with minimal dependencies",
       "alternatives": [
-        "ONNX Runtime (MIT \u2014 heavier, more general)",
-        "nn-inference-template (MIT \u2014 template for multiple backends)"
+        "Q (Cycfi, MIT) for pitch detection"
       ],
       "migration_notes": {},
       "verification": {
         "last_verified": "2026-04-07",
-        "verified_version": "1fb1f075",
+        "verified_version": "0.4.9",
         "upstream_commit": "unknown",
-        "upstream_latest": "1fb1f075",
+        "upstream_latest": "0.4.9",
         "pulp_commit": "unknown",
-        "build_status": {
-          "macOS-arm64": "untested",
-          "Windows-x64": "untested",
-          "Windows-arm64": "untested",
-          "Linux-x64": "untested",
-          "Linux-arm64": "untested"
+        "build_status": {}
+      }
+    },
+    "btrack": {
+      "name": "BTrack",
+      "version": "master",
+      "description": "Real-time beat tracking via onset detection",
+      "license": "MIT",
+      "category": "dsp",
+      "url": "https://github.com/adamstark/BTrack",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/adamstark/BTrack.git",
+        "git_tag": "master"
+      },
+      "cmake": {
+        "targets": [
+          "btrack"
+        ],
+        "header_only": false,
+        "include_dir": "src"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
         }
+      },
+      "rt_safe": true,
+      "tags": [
+        "beat-tracking",
+        "tempo",
+        "onset",
+        "rhythm"
+      ],
+      "provides": [
+        "beat-detection",
+        "tempo-detection"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "MIT-licensed beat tracking — alternative to GPL Aubio for tempo analysis",
+      "alternatives": [
+        "Aubio (GPL-3.0, more comprehensive)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "",
+        "verified_version": "master",
+        "upstream_commit": "unknown",
+        "upstream_latest": "master",
+        "pulp_commit": "unknown",
+        "build_status": {}
       }
     },
     "cycfi-q": {
@@ -339,10 +283,10 @@
         "frequency-analysis"
       ],
       "overlaps_with_builtin": {},
-      "unique_value": "Fast, accurate pitch detection using bitstream autocorrelation \u2014 no equivalent in Pulp built-ins",
+      "unique_value": "Fast, accurate pitch detection using bitstream autocorrelation — no equivalent in Pulp built-ins",
       "alternatives": [
-        "Aubio (GPL \u2014 requires commercial license)",
-        "Essentia (AGPL \u2014 incompatible)"
+        "Aubio (GPL — requires commercial license)",
+        "Essentia (AGPL — incompatible)"
       ],
       "migration_notes": {},
       "verification": {
@@ -354,281 +298,6 @@
         "build_status": {
           "macOS-arm64": "untested",
           "Windows-x64": "untested",
-          "Linux-x64": "untested",
-          "Linux-arm64": "untested"
-        }
-      }
-    },
-    "libsamplerate": {
-      "name": "libsamplerate",
-      "version": "0.2.2",
-      "description": "High-quality sample rate conversion (Secret Rabbit Code)",
-      "license": "BSD-2-Clause",
-      "category": "audio-io",
-      "url": "https://github.com/libsndfile/libsamplerate",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/libsndfile/libsamplerate.git",
-        "git_tag": "0.2.2"
-      },
-      "cmake": {
-        "targets": [
-          "SampleRate::samplerate"
-        ],
-        "header_only": false,
-        "include_dir": "include"
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Android": {
-          "architectures": [
-            "arm64-v8a",
-            "x86_64"
-          ],
-          "ndk_compatible": true,
-          "min_api": 26,
-          "notes": "Pure C"
-        },
-        "iOS": {
-          "architectures": [
-            "arm64"
-          ],
-          "min_version": "15.0",
-          "notes": "Pure C"
-        }
-      },
-      "rt_safe": false,
-      "tags": [
-        "resampling",
-        "sample-rate",
-        "conversion",
-        "interpolation"
-      ],
-      "provides": [
-        "sample-rate-conversion",
-        "resampling"
-      ],
-      "overlaps_with_builtin": {},
-      "unique_value": "Industry-standard sample rate conversion with multiple quality modes (sinc best, sinc medium, sinc fastest, linear, zero-order-hold)",
-      "alternatives": [
-        "r8brain-free-src (MIT \u2014 different quality tradeoffs)"
-      ],
-      "migration_notes": {
-        "from:libsndfile": "libsamplerate handles resampling only, not file I/O \u2014 use dr-libs for file decoding"
-      },
-      "verification": {
-        "last_verified": "2026-04-07",
-        "verified_version": "0.2.2",
-        "upstream_commit": "unknown",
-        "upstream_latest": "0.2.2",
-        "pulp_commit": "unknown",
-        "build_status": {
-          "macOS-arm64": "untested",
-          "Windows-x64": "untested",
-          "Windows-arm64": "untested",
-          "Linux-x64": "untested",
-          "Linux-arm64": "untested"
-        }
-      }
-    },
-    "dr-libs": {
-      "name": "dr_libs",
-      "version": "wav-0.14.5",
-      "description": "Single-file WAV, FLAC, and MP3 decoding",
-      "license": "MIT-0",
-      "category": "audio-io",
-      "url": "https://github.com/mackron/dr_libs",
-      "fetch": {
-        "method": "header-only",
-        "git_repository": "https://github.com/mackron/dr_libs.git",
-        "git_tag": "wav-0.14.5"
-      },
-      "cmake": {
-        "targets": [
-          "dr_libs"
-        ],
-        "header_only": true,
-        "include_dir": "."
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Android": {
-          "architectures": [
-            "arm64-v8a",
-            "x86_64"
-          ],
-          "ndk_compatible": true,
-          "min_api": 26,
-          "notes": "Single header, public domain C"
-        },
-        "iOS": {
-          "architectures": [
-            "arm64"
-          ],
-          "min_version": "15.0",
-          "notes": "Single header, public domain C"
-        }
-      },
-      "rt_safe": false,
-      "tags": [
-        "wav",
-        "flac",
-        "mp3",
-        "decoding",
-        "audio-file",
-        "single-header"
-      ],
-      "provides": [
-        "wav-decoding",
-        "flac-decoding",
-        "mp3-decoding"
-      ],
-      "overlaps_with_builtin": {},
-      "unique_value": "Zero-dependency single-header audio file decoding for WAV, FLAC, and MP3",
-      "alternatives": [
-        "miniaudio (MIT-0 \u2014 includes device I/O too)",
-        "libsndfile (LGPL \u2014 copyleft)"
-      ],
-      "migration_notes": {
-        "from:libsndfile": "dr_libs is MIT-0 and header-only but decode-only \u2014 no encode support for FLAC/MP3"
-      },
-      "verification": {
-        "last_verified": "2026-04-07",
-        "verified_version": "wav-0.14.5",
-        "upstream_commit": "unknown",
-        "upstream_latest": "wav-0.14.5",
-        "pulp_commit": "unknown",
-        "build_status": {
-          "macOS-arm64": "untested",
-          "Windows-x64": "untested",
-          "Windows-arm64": "untested",
-          "Linux-x64": "untested",
-          "Linux-arm64": "untested"
-        }
-      }
-    },
-    "pffft": {
-      "name": "PFFFT",
-      "version": "v1.1.0",
-      "description": "SIMD-optimized FFT (SSE on x64, NEON on arm64)",
-      "license": "BSD-3-Clause",
-      "category": "dsp",
-      "url": "https://github.com/marton78/pffft",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/marton78/pffft.git",
-        "git_tag": "v1.1.0"
-      },
-      "cmake": {
-        "targets": [
-          "PFFFT"
-        ],
-        "header_only": false,
-        "include_dir": "."
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64"
-          ],
-          "notes": "NEON path"
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ],
-          "notes": "SSE on x64, NEON on arm64"
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ],
-          "notes": "SSE on x64, NEON on arm64"
-        },
-        "Android": {
-          "architectures": [
-            "arm64-v8a",
-            "x86_64"
-          ],
-          "ndk_compatible": true,
-          "min_api": 26,
-          "notes": "Pure C with NEON support"
-        },
-        "iOS": {
-          "architectures": [
-            "arm64"
-          ],
-          "min_version": "15.0",
-          "notes": "Pure C with NEON support"
-        }
-      },
-      "rt_safe": true,
-      "tags": [
-        "fft",
-        "simd",
-        "sse",
-        "neon",
-        "spectral"
-      ],
-      "provides": [
-        "fft",
-        "simd-fft"
-      ],
-      "overlaps_with_builtin": {
-        "signal/fft.hpp": "FFT"
-      },
-      "unique_value": "SIMD-optimized FFT significantly faster than general-purpose implementations for power-of-two sizes",
-      "alternatives": [
-        "KissFFT (BSD-3 \u2014 portable but not SIMD-optimized)",
-        "FFTW (GPL \u2014 requires commercial license)"
-      ],
-      "migration_notes": {
-        "from:fftw": "PFFFT is BSD-licensed and lighter; covers real and complex FFT for power-of-two sizes"
-      },
-      "verification": {
-        "last_verified": "2026-04-07",
-        "verified_version": "v1.1.0",
-        "upstream_commit": "unknown",
-        "upstream_latest": "v1.1.0",
-        "pulp_commit": "unknown",
-        "build_status": {
-          "macOS-arm64": "untested",
-          "Windows-x64": "untested",
-          "Windows-arm64": "untested",
           "Linux-x64": "untested",
           "Linux-arm64": "untested"
         }
@@ -712,8 +381,8 @@
       },
       "unique_value": "Physical modeling synthesis (Karplus-Strong, modal, pluck) and drum synthesis not available in Pulp built-ins",
       "alternatives": [
-        "STK (MIT with patent caveats \u2014 more physical models)",
-        "Maximilian (MIT \u2014 teaching-oriented)"
+        "STK (MIT with patent caveats — more physical models)",
+        "Maximilian (MIT — teaching-oriented)"
       ],
       "migration_notes": {},
       "verification": {
@@ -731,21 +400,21 @@
         }
       }
     },
-    "fontaudio": {
-      "name": "fontaudio",
-      "version": "1.1",
-      "description": "Audio-specific icon font with 200+ icons for plugin UIs",
-      "license": "MIT",
-      "category": "ui",
-      "url": "https://github.com/fefanto/fontaudio",
+    "dr-libs": {
+      "name": "dr_libs",
+      "version": "wav-0.14.5",
+      "description": "Single-file WAV, FLAC, and MP3 decoding",
+      "license": "MIT-0",
+      "category": "audio-io",
+      "url": "https://github.com/mackron/dr_libs",
       "fetch": {
         "method": "header-only",
-        "git_repository": "https://github.com/fefanto/fontaudio.git",
-        "git_tag": "1.1"
+        "git_repository": "https://github.com/mackron/dr_libs.git",
+        "git_tag": "wav-0.14.5"
       },
       "cmake": {
         "targets": [
-          "fontaudio"
+          "dr_libs"
         ],
         "header_only": true,
         "include_dir": "."
@@ -768,16 +437,6 @@
             "arm64"
           ]
         },
-        "iOS": {
-          "architectures": [
-            "arm64"
-          ]
-        },
-        "WASM": {
-          "architectures": [
-            "wasm32"
-          ]
-        },
         "Android": {
           "architectures": [
             "arm64-v8a",
@@ -785,119 +444,44 @@
           ],
           "ndk_compatible": true,
           "min_api": 26,
-          "notes": "Font asset, platform-independent"
-        }
-      },
-      "rt_safe": true,
-      "tags": [
-        "icons",
-        "font",
-        "ui",
-        "audio-icons",
-        "svg"
-      ],
-      "provides": [
-        "audio-icons",
-        "icon-font"
-      ],
-      "overlaps_with_builtin": {},
-      "unique_value": "Purpose-built audio icon font \u2014 knob, fader, waveform, speaker, MIDI, and plugin format icons",
-      "alternatives": [],
-      "migration_notes": {},
-      "verification": {
-        "last_verified": "2026-04-07",
-        "verified_version": "1.1",
-        "upstream_commit": "unknown",
-        "upstream_latest": "1.1",
-        "pulp_commit": "unknown",
-        "build_status": {
-          "macOS-arm64": "untested",
-          "Windows-x64": "untested",
-          "Windows-arm64": "untested",
-          "Linux-x64": "untested",
-          "Linux-arm64": "untested"
-        }
-      }
-    },
-    "r8brain-free-src": {
-      "name": "r8brain-free-src",
-      "version": "version-6.5",
-      "description": "High-quality sample rate converter with low latency mode",
-      "license": "MIT",
-      "category": "audio-io",
-      "url": "https://github.com/avaneev/r8brain-free-src",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/avaneev/r8brain-free-src.git",
-        "git_tag": "version-6.5"
-      },
-      "cmake": {
-        "targets": [
-          "r8brain"
-        ],
-        "header_only": false,
-        "include_dir": "."
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Android": {
-          "architectures": [
-            "arm64-v8a",
-            "x86_64"
-          ],
-          "ndk_compatible": true,
-          "min_api": 26,
-          "notes": "Pure C++"
+          "notes": "Single header, public domain C"
         },
         "iOS": {
           "architectures": [
             "arm64"
           ],
           "min_version": "15.0",
-          "notes": "Pure C++"
+          "notes": "Single header, public domain C"
         }
       },
       "rt_safe": false,
       "tags": [
-        "resampling",
-        "sample-rate",
-        "conversion",
-        "high-quality",
-        "low-latency"
+        "wav",
+        "flac",
+        "mp3",
+        "decoding",
+        "audio-file",
+        "single-header"
       ],
       "provides": [
-        "sample-rate-conversion",
-        "resampling"
+        "wav-decoding",
+        "flac-decoding",
+        "mp3-decoding"
       ],
       "overlaps_with_builtin": {},
-      "unique_value": "Audiophile-grade sample rate conversion with configurable quality/latency tradeoffs",
+      "unique_value": "Zero-dependency single-header audio file decoding for WAV, FLAC, and MP3",
       "alternatives": [
-        "libsamplerate (BSD-2 \u2014 industry standard, different quality profile)"
+        "miniaudio (MIT-0 — includes device I/O too)",
+        "libsndfile (LGPL — copyleft)"
       ],
       "migration_notes": {
-        "from:libsamplerate": "r8brain offers different quality/latency tradeoffs \u2014 benchmark both for your use case"
+        "from:libsndfile": "dr_libs is MIT-0 and header-only but decode-only — no encode support for FLAC/MP3"
       },
       "verification": {
         "last_verified": "2026-04-07",
-        "verified_version": "version-6.5",
+        "verified_version": "wav-0.14.5",
         "upstream_commit": "unknown",
-        "upstream_latest": "version-6.5",
+        "upstream_latest": "wav-0.14.5",
         "pulp_commit": "unknown",
         "build_status": {
           "macOS-arm64": "untested",
@@ -976,34 +560,35 @@
         "build_status": {}
       }
     },
-    "rnnoise": {
-      "name": "RNNoise",
-      "version": "v0.2",
-      "description": "Neural network noise suppression for voice",
-      "license": "BSD-3-Clause",
-      "category": "dsp",
-      "url": "https://github.com/xiph/rnnoise",
+    "fdk-aac": {
+      "name": "FDK AAC",
+      "version": "2.0.3",
+      "description": "AAC encoder/decoder — Fraunhofer FDK AAC codec for AAC audio export",
+      "license": "FDK-AAC",
+      "category": "audio-io",
+      "url": "https://github.com/mstorsjo/fdk-aac",
       "fetch": {
         "method": "FetchContent",
-        "git_repository": "https://github.com/xiph/rnnoise.git",
-        "git_tag": "v0.2"
+        "git_repository": "https://github.com/mstorsjo/fdk-aac.git",
+        "git_tag": "v2.0.3"
       },
       "cmake": {
         "targets": [
-          "rnnoise"
+          "fdk-aac"
         ],
-        "header_only": false,
-        "include_dir": "include"
+        "header_only": false
       },
       "platforms": {
         "macOS": {
           "architectures": [
-            "arm64"
+            "arm64",
+            "x86_64"
           ]
         },
         "Windows": {
           "architectures": [
-            "x64"
+            "x64",
+            "arm64"
           ]
         },
         "Linux": {
@@ -1011,127 +596,35 @@
             "x64",
             "arm64"
           ]
-        },
-        "Android": {
-          "architectures": [
-            "arm64-v8a",
-            "x86_64"
-          ]
-        },
-        "iOS": {
-          "architectures": [
-            "arm64"
-          ]
         }
       },
-      "rt_safe": true,
+      "rt_safe": false,
       "tags": [
-        "noise-suppression",
-        "voice",
-        "neural-network",
-        "real-time"
+        "aac",
+        "encoder",
+        "decoder",
+        "lossy",
+        "audio-export"
       ],
       "provides": [
-        "noise-suppression",
-        "voice-enhancement"
+        "aac-encode",
+        "aac-decode"
       ],
-      "overlaps_with_builtin": {},
-      "unique_value": "Purpose-built neural noise suppression — removes keyboard, HVAC, crowd noise in real time",
-      "alternatives": [
-        "SpeexDSP (BSD-3, traditional AEC/NS — less effective but lighter)"
-      ],
-      "migration_notes": {},
+      "overlaps_with_builtin": {
+        "feature": "AAC read on macOS (via CoreAudioFormat/ExtAudioFile)",
+        "note": "CoreAudioFormat provides macOS-only AAC read. FDK adds cross-platform encode+decode."
+      },
+      "unique_value": "Cross-platform AAC encoder. FDK license has patent considerations — requires --accept-license.",
+      "integration_guide": "After pulp add fdk-aac --accept-license FDK-AAC, the FormatRegistry gains an AacWriter.",
       "verification": {
         "last_verified": "2026-04-07",
-        "verified_version": "v0.2",
-        "upstream_commit": "unknown",
-        "upstream_latest": "v0.2",
-        "pulp_commit": "unknown",
-        "build_status": {}
-      }
-    },
-    "rubber-band": {
-      "name": "Rubber Band",
-      "version": "v3.3.0",
-      "description": "High-quality time-stretching and pitch-shifting",
-      "license": "GPL-2.0",
-      "category": "dsp",
-      "url": "https://github.com/breakfastquay/rubberband",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/breakfastquay/rubberband.git",
-        "git_tag": "v3.3.0"
-      },
-      "cmake": {
-        "targets": [
-          "rubberband"
-        ],
-        "header_only": false,
-        "include_dir": "rubberband"
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Android": {
-          "architectures": [
-            "arm64-v8a",
-            "x86_64"
-          ],
-          "ndk_compatible": true,
-          "min_api": 26,
-          "notes": "Build without FFTW for minimal mobile build"
-        },
-        "iOS": {
-          "architectures": [
-            "arm64"
-          ],
-          "min_version": "15.0",
-          "notes": "Build without FFTW for minimal mobile build"
-        }
-      },
-      "rt_safe": true,
-      "tags": [
-        "time-stretching",
-        "pitch-shifting",
-        "spectral"
-      ],
-      "provides": [
-        "time-stretch",
-        "pitch-shift"
-      ],
-      "overlaps_with_builtin": {},
-      "unique_value": "Industry-standard time-stretching used in DAWs and production tools",
-      "alternatives": [
-        "Signalsmith Stretch (MIT \u2014 polyphonic, lighter)"
-      ],
-      "migration_notes": {},
-      "verification": {
-        "last_verified": "2026-04-07",
-        "verified_version": "v3.3.0",
-        "upstream_commit": "unknown",
-        "upstream_latest": "v3.3.0",
-        "pulp_commit": "unknown",
-        "build_status": {}
+        "status": "metadata-only"
       }
     },
     "fftw": {
       "name": "FFTW",
       "version": "3.3.10",
-      "description": "Fastest Fourier Transform in the West \u2014 highly optimized FFT",
+      "description": "Fastest Fourier Transform in the West — highly optimized FFT",
       "license": "GPL-2.0",
       "category": "dsp",
       "url": "https://www.fftw.org",
@@ -1195,10 +688,10 @@
       "overlaps_with_builtin": {
         "signal/fft.hpp": "FFT"
       },
-      "unique_value": "Highly optimized FFT with auto-tuning SIMD code generation \u2014 fastest available for large transforms",
+      "unique_value": "Highly optimized FFT with auto-tuning SIMD code generation — fastest available for large transforms",
       "alternatives": [
-        "PFFFT (BSD-3 \u2014 lighter, SIMD, power-of-two only)",
-        "KissFFT (BSD-3 \u2014 portable)"
+        "PFFFT (BSD-3 — lighter, SIMD, power-of-two only)",
+        "KissFFT (BSD-3 — portable)"
       ],
       "migration_notes": {},
       "verification": {
@@ -1210,24 +703,252 @@
         "build_status": {}
       }
     },
-    "aubio": {
-      "name": "Aubio",
-      "version": "0.4.9",
-      "description": "Audio labeling \u2014 pitch, onset, beat, and tempo detection",
-      "license": "GPL-3.0",
+    "fluidsynth": {
+      "name": "FluidSynth",
+      "version": "v2.4.0",
+      "description": "SoundFont 2 software synthesizer with MIDI support",
+      "license": "LGPL-2.1",
       "category": "dsp",
-      "url": "https://github.com/aubio/aubio",
+      "url": "https://github.com/FluidSynth/fluidsynth",
       "fetch": {
         "method": "FetchContent",
-        "git_repository": "https://github.com/aubio/aubio.git",
-        "git_tag": "0.4.9"
+        "git_repository": "https://github.com/FluidSynth/fluidsynth.git",
+        "git_tag": "v2.4.0"
       },
       "cmake": {
         "targets": [
-          "aubio"
+          "fluidsynth"
         ],
         "header_only": false,
-        "include_dir": "src"
+        "include_dir": "include"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": false,
+      "tags": [
+        "soundfont",
+        "sf2",
+        "synthesizer",
+        "midi",
+        "sampler"
+      ],
+      "provides": [
+        "soundfont-synthesis",
+        "sf2-playback",
+        "midi-synthesis"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Full SoundFont 2 synthesis engine — load .sf2 files for instrument playback",
+      "alternatives": [
+        "FluidLite (MIT — minimal SF2 subset)",
+        "For mobile: FluidLite (MIT) has no glib dependency and supports basic SF2 playback"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "v2.4.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v2.4.0",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "fontaudio": {
+      "name": "fontaudio",
+      "version": "1.1",
+      "description": "Audio-specific icon font with 200+ icons for plugin UIs",
+      "license": "MIT",
+      "category": "ui",
+      "url": "https://github.com/fefanto/fontaudio",
+      "fetch": {
+        "method": "header-only",
+        "git_repository": "https://github.com/fefanto/fontaudio.git",
+        "git_tag": "1.1"
+      },
+      "cmake": {
+        "targets": [
+          "fontaudio"
+        ],
+        "header_only": true,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "WASM": {
+          "architectures": [
+            "wasm32"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Font asset, platform-independent"
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "icons",
+        "font",
+        "ui",
+        "audio-icons",
+        "svg"
+      ],
+      "provides": [
+        "audio-icons",
+        "icon-font"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Purpose-built audio icon font — knob, fader, waveform, speaker, MIDI, and plugin format icons",
+      "alternatives": [],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "1.1",
+        "upstream_commit": "unknown",
+        "upstream_latest": "1.1",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "freeverb": {
+      "name": "Freeverb",
+      "version": "1.0.0",
+      "description": "Classic Schroeder reverb algorithm — public domain reference implementation",
+      "license": "Unlicense",
+      "category": "dsp",
+      "url": "https://github.com/sinshu/freeverb",
+      "fetch": {
+        "method": "header-only",
+        "git_repository": "https://github.com/sinshu/freeverb.git",
+        "git_tag": "1.0.0"
+      },
+      "cmake": {
+        "targets": [
+          "freeverb"
+        ],
+        "header_only": true,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "reverb",
+        "schroeder",
+        "spatial",
+        "room"
+      ],
+      "provides": [
+        "reverb"
+      ],
+      "overlaps_with_builtin": {
+        "signal/reverb.hpp": "reverb"
+      },
+      "unique_value": "Reference Schroeder reverb — public domain, zero dependencies, educational",
+      "alternatives": [],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "",
+        "verified_version": "1.0.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "1.0.0",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "kfr": {
+      "name": "KFR",
+      "version": "6.0.2",
+      "description": "Fast DSP framework with FFT, FIR/IIR, resampling, and SIMD",
+      "license": "GPL-2.0",
+      "category": "dsp",
+      "url": "https://github.com/kfrlib/kfr",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/kfrlib/kfr.git",
+        "git_tag": "6.0.2"
+      },
+      "cmake": {
+        "targets": [
+          "kfr"
+        ],
+        "header_only": false,
+        "include_dir": "include"
       },
       "platforms": {
         "macOS": {
@@ -1253,43 +974,476 @@
           ],
           "ndk_compatible": true,
           "min_api": 26,
-          "notes": "Build with minimal deps (no libsndfile, no FFTW)"
+          "notes": "Pure C++ SIMD with NEON support"
         },
         "iOS": {
           "architectures": [
             "arm64"
           ],
           "min_version": "15.0",
-          "notes": "Build with minimal deps (no libsndfile, no FFTW)"
+          "notes": "Pure C++ SIMD with NEON support"
         }
       },
       "rt_safe": true,
       "tags": [
-        "pitch",
-        "onset",
-        "beat",
-        "tempo",
-        "mfcc"
+        "fft",
+        "fir",
+        "iir",
+        "resampling",
+        "simd",
+        "dsp"
       ],
       "provides": [
-        "pitch-detection",
-        "onset-detection",
-        "beat-detection",
-        "tempo-detection"
+        "fft",
+        "filters",
+        "resampling",
+        "simd-dsp"
       ],
-      "overlaps_with_builtin": {},
-      "unique_value": "Lightweight, real-time pitch/onset/beat detection with minimal dependencies",
+      "overlaps_with_builtin": {
+        "signal/fft.hpp": "FFT",
+        "signal/biquad.hpp": "IIR filters"
+      },
+      "unique_value": "Comprehensive SIMD-optimized DSP with expression templates — faster than hand-written loops",
       "alternatives": [
-        "Q (Cycfi, MIT) for pitch detection"
+        "PFFFT (BSD-3) + Signalsmith DSP (MIT) for FFT + filters separately"
       ],
       "migration_notes": {},
       "verification": {
         "last_verified": "2026-04-07",
-        "verified_version": "0.4.9",
+        "verified_version": "6.0.2",
         "upstream_commit": "unknown",
-        "upstream_latest": "0.4.9",
+        "upstream_latest": "6.0.2",
         "pulp_commit": "unknown",
         "build_status": {}
+      }
+    },
+    "kissfft": {
+      "name": "KissFFT",
+      "version": "131.1.0",
+      "description": "Portable FFT for any size — not just power-of-two",
+      "license": "BSD-3-Clause",
+      "category": "dsp",
+      "url": "https://github.com/mborgerding/kissfft",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/mborgerding/kissfft.git",
+        "git_tag": "131.1.0"
+      },
+      "cmake": {
+        "targets": [
+          "kissfft"
+        ],
+        "header_only": false,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "fft",
+        "portable",
+        "arbitrary-size"
+      ],
+      "provides": [
+        "fft"
+      ],
+      "overlaps_with_builtin": {
+        "signal/fft.hpp": "FFT"
+      },
+      "unique_value": "Arbitrary-size FFT (not limited to power-of-two like PFFFT)",
+      "alternatives": [
+        "PFFFT (BSD-3, SIMD-optimized but power-of-two only)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "131.1.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "131.1.0",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "lame": {
+      "name": "LAME",
+      "version": "3.100",
+      "description": "MP3 encoder — high-quality MP3 encoding for audio export",
+      "license": "LGPL-2.0",
+      "category": "audio-io",
+      "url": "https://lame.sourceforge.io",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/lameproject/lame.git",
+        "git_tag": "RELEASE__3_100"
+      },
+      "cmake": {
+        "targets": [
+          "mp3lame"
+        ],
+        "header_only": false
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64",
+            "x86_64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": false,
+      "tags": [
+        "mp3",
+        "encoder",
+        "lossy",
+        "audio-export"
+      ],
+      "provides": [
+        "mp3-encode"
+      ],
+      "overlaps_with_builtin": {
+        "feature": "MP3 read (via dr_mp3)",
+        "note": "dr_mp3 provides decode only. LAME adds encode capability."
+      },
+      "unique_value": "The standard MP3 encoder. Required for MP3 export. LGPL — requires --accept-license.",
+      "integration_guide": "After pulp add lame --accept-license LGPL-2.0, the FormatRegistry automatically gains an Mp3Writer.",
+      "verification": {
+        "last_verified": "2026-04-07",
+        "status": "metadata-only"
+      }
+    },
+    "libflac": {
+      "name": "FLAC",
+      "version": "1.4.3",
+      "description": "FLAC encoder — lossless audio compression for high-quality export",
+      "license": "BSD-3-Clause",
+      "category": "audio-io",
+      "url": "https://github.com/xiph/flac",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/xiph/flac.git",
+        "git_tag": "1.4.3"
+      },
+      "cmake": {
+        "targets": [
+          "FLAC"
+        ],
+        "header_only": false
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64",
+            "x86_64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": false,
+      "tags": [
+        "flac",
+        "encoder",
+        "lossless",
+        "audio-export"
+      ],
+      "provides": [
+        "flac-encode"
+      ],
+      "overlaps_with_builtin": {
+        "feature": "FLAC read (via dr_flac)",
+        "note": "dr_flac provides decode only. libflac adds encode capability."
+      },
+      "unique_value": "Reference FLAC encoder — lossless, universally supported, BSD-3 licensed.",
+      "integration_guide": "After pulp add libflac, the FormatRegistry gains a FlacWriter for .flac export.",
+      "verification": {
+        "last_verified": "2026-04-07",
+        "status": "metadata-only"
+      }
+    },
+    "libpd": {
+      "name": "libpd",
+      "version": "0.14.2",
+      "description": "Embed Pure Data patches as audio processors",
+      "license": "BSD-3-Clause",
+      "category": "dsp",
+      "url": "https://github.com/libpd/libpd",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/libpd/libpd.git",
+        "git_tag": "0.14.2"
+      },
+      "cmake": {
+        "targets": [
+          "libpd"
+        ],
+        "header_only": false,
+        "include_dir": "libpd_wrapper"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": false,
+      "tags": [
+        "pure-data",
+        "patching",
+        "dataflow",
+        "synthesis"
+      ],
+      "provides": [
+        "patch-embedding",
+        "dataflow-dsp"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Only way to embed Pure Data patches — enables live audio patching and visual programming",
+      "alternatives": [],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "",
+        "verified_version": "0.14.2",
+        "upstream_commit": "unknown",
+        "upstream_latest": "0.14.2",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "libremidi": {
+      "name": "libremidi",
+      "version": "v5.4.3",
+      "description": "Modern C++20 MIDI I/O with MIDI 2.0 and mobile support",
+      "license": "BSD-2-Clause",
+      "category": "utilities",
+      "url": "https://github.com/jcelerier/libremidi",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/jcelerier/libremidi.git",
+        "git_tag": "v5.4.3"
+      },
+      "cmake": {
+        "targets": [
+          "libremidi"
+        ],
+        "header_only": false,
+        "include_dir": "include"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "midi",
+        "midi2",
+        "io",
+        "ports",
+        "c++20"
+      ],
+      "provides": [
+        "midi-io",
+        "midi-ports",
+        "midi2"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "C++20 native MIDI I/O with iOS+Android backends and MIDI 2.0 — replaces RtMidi",
+      "alternatives": [],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "",
+        "verified_version": "v5.4.3",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v5.4.3",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "libsamplerate": {
+      "name": "libsamplerate",
+      "version": "0.2.2",
+      "description": "High-quality sample rate conversion (Secret Rabbit Code)",
+      "license": "BSD-2-Clause",
+      "category": "audio-io",
+      "url": "https://github.com/libsndfile/libsamplerate",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/libsndfile/libsamplerate.git",
+        "git_tag": "0.2.2"
+      },
+      "cmake": {
+        "targets": [
+          "SampleRate::samplerate"
+        ],
+        "header_only": false,
+        "include_dir": "include"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Pure C"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Pure C"
+        }
+      },
+      "rt_safe": false,
+      "tags": [
+        "resampling",
+        "sample-rate",
+        "conversion",
+        "interpolation"
+      ],
+      "provides": [
+        "sample-rate-conversion",
+        "resampling"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Industry-standard sample rate conversion with multiple quality modes (sinc best, sinc medium, sinc fastest, linear, zero-order-hold)",
+      "alternatives": [
+        "r8brain-free-src (MIT — different quality tradeoffs)"
+      ],
+      "migration_notes": {
+        "from:libsndfile": "libsamplerate handles resampling only, not file I/O — use dr-libs for file decoding"
+      },
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "0.2.2",
+        "upstream_commit": "unknown",
+        "upstream_latest": "0.2.2",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
       }
     },
     "libsndfile": {
@@ -1366,7 +1520,7 @@
       "overlaps_with_builtin": {},
       "unique_value": "Full-featured audio file I/O supporting 20+ formats with read and write",
       "alternatives": [
-        "dr_libs (MIT-0 \u2014 decode only, fewer formats)"
+        "dr_libs (MIT-0 — decode only, fewer formats)"
       ],
       "migration_notes": {},
       "verification": {
@@ -1374,6 +1528,82 @@
         "verified_version": "1.2.2",
         "upstream_commit": "unknown",
         "upstream_latest": "1.2.2",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "libvorbis": {
+      "name": "libvorbis",
+      "version": "v1.3.8",
+      "description": "OGG Vorbis audio codec — encode and decode",
+      "license": "BSD-3-Clause",
+      "category": "audio-io",
+      "url": "https://github.com/xiph/vorbis",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/xiph/vorbis.git",
+        "git_tag": "v1.3.8"
+      },
+      "cmake": {
+        "targets": [
+          "vorbis",
+          "vorbisenc"
+        ],
+        "header_only": false,
+        "include_dir": "include"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": false,
+      "tags": [
+        "vorbis",
+        "ogg",
+        "codec",
+        "streaming",
+        "audio-file"
+      ],
+      "provides": [
+        "ogg-vorbis-codec",
+        "audio-encode",
+        "audio-decode"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Standard OGG Vorbis codec for streaming audio and sample banks — BSD licensed",
+      "alternatives": [],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "",
+        "verified_version": "v1.3.8",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v1.3.8",
         "pulp_commit": "unknown",
         "build_status": {}
       }
@@ -1587,6 +1817,614 @@
         "build_status": {}
       }
     },
+    "pffft": {
+      "name": "PFFFT",
+      "version": "v1.1.0",
+      "description": "SIMD-optimized FFT (SSE on x64, NEON on arm64)",
+      "license": "BSD-3-Clause",
+      "category": "dsp",
+      "url": "https://github.com/marton78/pffft",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/marton78/pffft.git",
+        "git_tag": "v1.1.0"
+      },
+      "cmake": {
+        "targets": [
+          "PFFFT"
+        ],
+        "header_only": false,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "notes": "NEON path"
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ],
+          "notes": "SSE on x64, NEON on arm64"
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ],
+          "notes": "SSE on x64, NEON on arm64"
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Pure C with NEON support"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Pure C with NEON support"
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "fft",
+        "simd",
+        "sse",
+        "neon",
+        "spectral"
+      ],
+      "provides": [
+        "fft",
+        "simd-fft"
+      ],
+      "overlaps_with_builtin": {
+        "signal/fft.hpp": "FFT"
+      },
+      "unique_value": "SIMD-optimized FFT significantly faster than general-purpose implementations for power-of-two sizes",
+      "alternatives": [
+        "KissFFT (BSD-3 — portable but not SIMD-optimized)",
+        "FFTW (GPL — requires commercial license)"
+      ],
+      "migration_notes": {
+        "from:fftw": "PFFFT is BSD-licensed and lighter; covers real and complex FFT for power-of-two sizes"
+      },
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "v1.1.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v1.1.0",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "r8brain-free-src": {
+      "name": "r8brain-free-src",
+      "version": "version-6.5",
+      "description": "High-quality sample rate converter with low latency mode",
+      "license": "MIT",
+      "category": "audio-io",
+      "url": "https://github.com/avaneev/r8brain-free-src",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/avaneev/r8brain-free-src.git",
+        "git_tag": "version-6.5"
+      },
+      "cmake": {
+        "targets": [
+          "r8brain"
+        ],
+        "header_only": false,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Pure C++"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Pure C++"
+        }
+      },
+      "rt_safe": false,
+      "tags": [
+        "resampling",
+        "sample-rate",
+        "conversion",
+        "high-quality",
+        "low-latency"
+      ],
+      "provides": [
+        "sample-rate-conversion",
+        "resampling"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Audiophile-grade sample rate conversion with configurable quality/latency tradeoffs",
+      "alternatives": [
+        "libsamplerate (BSD-2 — industry standard, different quality profile)"
+      ],
+      "migration_notes": {
+        "from:libsamplerate": "r8brain offers different quality/latency tradeoffs — benchmark both for your use case"
+      },
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "version-6.5",
+        "upstream_commit": "unknown",
+        "upstream_latest": "version-6.5",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "rnnoise": {
+      "name": "RNNoise",
+      "version": "v0.2",
+      "description": "Neural network noise suppression for voice",
+      "license": "BSD-3-Clause",
+      "category": "dsp",
+      "url": "https://github.com/xiph/rnnoise",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/xiph/rnnoise.git",
+        "git_tag": "v0.2"
+      },
+      "cmake": {
+        "targets": [
+          "rnnoise"
+        ],
+        "header_only": false,
+        "include_dir": "include"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "noise-suppression",
+        "voice",
+        "neural-network",
+        "real-time"
+      ],
+      "provides": [
+        "noise-suppression",
+        "voice-enhancement"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Purpose-built neural noise suppression — removes keyboard, HVAC, crowd noise in real time",
+      "alternatives": [
+        "SpeexDSP (BSD-3, traditional AEC/NS — less effective but lighter)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "v0.2",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v0.2",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "rtneural": {
+      "name": "RTNeural",
+      "version": "1fb1f075",
+      "description": "Real-time neural network inference optimized for audio",
+      "license": "BSD-3-Clause",
+      "category": "ml",
+      "url": "https://github.com/jatinchowdhury18/RTNeural",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/jatinchowdhury18/RTNeural.git",
+        "git_tag": "1fb1f075"
+      },
+      "cmake": {
+        "targets": [
+          "RTNeural"
+        ],
+        "header_only": false,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Eigen backend requires NDK r25+"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Eigen backend works on arm64"
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "neural-network",
+        "ml",
+        "inference",
+        "amp-modeling",
+        "real-time"
+      ],
+      "provides": [
+        "neural-network-inference",
+        "ml-inference"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Real-time safe neural network inference for amp modeling, vocal processing, and intelligent audio effects",
+      "alternatives": [
+        "ONNX Runtime (MIT — heavier, more general)",
+        "nn-inference-template (MIT — template for multiple backends)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "1fb1f075",
+        "upstream_commit": "unknown",
+        "upstream_latest": "1fb1f075",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "rubber-band": {
+      "name": "Rubber Band",
+      "version": "v3.3.0",
+      "description": "High-quality time-stretching and pitch-shifting",
+      "license": "GPL-2.0",
+      "category": "dsp",
+      "url": "https://github.com/breakfastquay/rubberband",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/breakfastquay/rubberband.git",
+        "git_tag": "v3.3.0"
+      },
+      "cmake": {
+        "targets": [
+          "rubberband"
+        ],
+        "header_only": false,
+        "include_dir": "rubberband"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Build without FFTW for minimal mobile build"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Build without FFTW for minimal mobile build"
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "time-stretching",
+        "pitch-shifting",
+        "spectral"
+      ],
+      "provides": [
+        "time-stretch",
+        "pitch-shift"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Industry-standard time-stretching used in DAWs and production tools",
+      "alternatives": [
+        "Signalsmith Stretch (MIT — polyphonic, lighter)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "v3.3.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v3.3.0",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "signalsmith-dsp": {
+      "name": "Signalsmith DSP",
+      "version": "v1.7.1",
+      "description": "Filters, envelopes, FFT, delay, spectral processing tools",
+      "license": "MIT",
+      "category": "dsp",
+      "url": "https://github.com/Signalsmith-Audio/dsp",
+      "fetch": {
+        "method": "header-only",
+        "git_repository": "https://github.com/Signalsmith-Audio/dsp.git",
+        "git_tag": "v1.7.1"
+      },
+      "cmake": {
+        "targets": [
+          "signalsmith-dsp"
+        ],
+        "header_only": true,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Header-only, pure C++"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Header-only, pure C++"
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "filters",
+        "fft",
+        "envelopes",
+        "delay",
+        "spectral",
+        "windowing"
+      ],
+      "provides": [
+        "filters",
+        "fft",
+        "envelopes",
+        "delay",
+        "spectral-processing"
+      ],
+      "overlaps_with_builtin": {
+        "signal/biquad.hpp": "biquad filters",
+        "signal/svf.hpp": "state variable filter",
+        "signal/delay_line.hpp": "delay line",
+        "signal/fft.hpp": "FFT"
+      },
+      "unique_value": "Comprehensive DSP toolkit with spectral processing and advanced envelope designs beyond Pulp built-ins",
+      "alternatives": [
+        "KFR (GPL — requires commercial license)"
+      ],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "v1.7.1",
+        "upstream_commit": "unknown",
+        "upstream_latest": "v1.7.1",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
+    "signalsmith-stretch": {
+      "name": "Signalsmith Stretch",
+      "version": "1.1.0",
+      "description": "Polyphonic pitch and time stretching",
+      "license": "MIT",
+      "category": "dsp",
+      "url": "https://github.com/Signalsmith-Audio/signalsmith-stretch",
+      "fetch": {
+        "method": "header-only",
+        "git_repository": "https://github.com/Signalsmith-Audio/signalsmith-stretch.git",
+        "git_tag": "1.1.0"
+      },
+      "cmake": {
+        "targets": [
+          "signalsmith-stretch"
+        ],
+        "header_only": true,
+        "include_dir": "."
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ],
+          "ndk_compatible": true,
+          "min_api": 26,
+          "notes": "Header-only, pure C++"
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ],
+          "min_version": "15.0",
+          "notes": "Header-only, pure C++"
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "pitch-shifting",
+        "time-stretching",
+        "spectral",
+        "polyphonic"
+      ],
+      "provides": [
+        "pitch-shift",
+        "time-stretch"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "High-quality polyphonic pitch/time stretching with no GPL dependency",
+      "alternatives": [
+        "Rubber Band (GPL — requires commercial license)"
+      ],
+      "migration_notes": {
+        "from:rubber-band": "Signalsmith Stretch is MIT-licensed and header-only; API differs but covers similar use cases"
+      },
+      "verification": {
+        "last_verified": "2026-04-07",
+        "verified_version": "1.1.0",
+        "upstream_commit": "unknown",
+        "upstream_latest": "1.1.0",
+        "pulp_commit": "unknown",
+        "build_status": {
+          "macOS-arm64": "untested",
+          "Windows-x64": "untested",
+          "Windows-arm64": "untested",
+          "Linux-x64": "untested",
+          "Linux-arm64": "untested"
+        }
+      }
+    },
     "soundtouch": {
       "name": "SoundTouch",
       "version": "2.4.0",
@@ -1653,9 +2491,9 @@
         "rate-change"
       ],
       "overlaps_with_builtin": {},
-      "unique_value": "Simple API for tempo/pitch/rate changes \u2014 widely used in media players",
+      "unique_value": "Simple API for tempo/pitch/rate changes — widely used in media players",
       "alternatives": [
-        "Signalsmith Stretch (MIT \u2014 more modern, polyphonic)"
+        "Signalsmith Stretch (MIT — more modern, polyphonic)"
       ],
       "migration_notes": {},
       "verification": {
@@ -1663,6 +2501,82 @@
         "verified_version": "2.4.0",
         "upstream_commit": "unknown",
         "upstream_latest": "2.4.0",
+        "pulp_commit": "unknown",
+        "build_status": {}
+      }
+    },
+    "speexdsp": {
+      "name": "SpeexDSP",
+      "version": "1.2.1",
+      "description": "Echo cancellation, noise suppression, AGC, and voice activity detection",
+      "license": "BSD-3-Clause",
+      "category": "dsp",
+      "url": "https://github.com/xiph/speexdsp",
+      "fetch": {
+        "method": "FetchContent",
+        "git_repository": "https://github.com/xiph/speexdsp.git",
+        "git_tag": "1.2.1"
+      },
+      "cmake": {
+        "targets": [
+          "speexdsp"
+        ],
+        "header_only": false,
+        "include_dir": "include"
+      },
+      "platforms": {
+        "macOS": {
+          "architectures": [
+            "arm64"
+          ]
+        },
+        "Windows": {
+          "architectures": [
+            "x64"
+          ]
+        },
+        "Linux": {
+          "architectures": [
+            "x64",
+            "arm64"
+          ]
+        },
+        "Android": {
+          "architectures": [
+            "arm64-v8a",
+            "x86_64"
+          ]
+        },
+        "iOS": {
+          "architectures": [
+            "arm64"
+          ]
+        }
+      },
+      "rt_safe": true,
+      "tags": [
+        "echo-cancellation",
+        "aec",
+        "agc",
+        "vad",
+        "noise-suppression",
+        "voice"
+      ],
+      "provides": [
+        "echo-cancellation",
+        "agc",
+        "vad",
+        "noise-suppression"
+      ],
+      "overlaps_with_builtin": {},
+      "unique_value": "Only permissive AEC library — essential for voice recording, podcasting, and communication plugins",
+      "alternatives": [],
+      "migration_notes": {},
+      "verification": {
+        "last_verified": "",
+        "verified_version": "1.2.1",
+        "upstream_commit": "unknown",
+        "upstream_latest": "1.2.1",
         "pulp_commit": "unknown",
         "build_status": {}
       }
@@ -1742,472 +2656,6 @@
         "upstream_latest": "master",
         "pulp_commit": "unknown",
         "build_status": {}
-      }
-    },
-    "fluidsynth": {
-      "name": "FluidSynth",
-      "version": "v2.4.0",
-      "description": "SoundFont 2 software synthesizer with MIDI support",
-      "license": "LGPL-2.1",
-      "category": "dsp",
-      "url": "https://github.com/FluidSynth/fluidsynth",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/FluidSynth/fluidsynth.git",
-        "git_tag": "v2.4.0"
-      },
-      "cmake": {
-        "targets": [
-          "fluidsynth"
-        ],
-        "header_only": false,
-        "include_dir": "include"
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        }
-      },
-      "rt_safe": false,
-      "tags": [
-        "soundfont",
-        "sf2",
-        "synthesizer",
-        "midi",
-        "sampler"
-      ],
-      "provides": [
-        "soundfont-synthesis",
-        "sf2-playback",
-        "midi-synthesis"
-      ],
-      "overlaps_with_builtin": {},
-      "unique_value": "Full SoundFont 2 synthesis engine \u2014 load .sf2 files for instrument playback",
-      "alternatives": [
-        "FluidLite (MIT \u2014 minimal SF2 subset)",
-        "For mobile: FluidLite (MIT) has no glib dependency and supports basic SF2 playback"
-      ],
-      "migration_notes": {},
-      "verification": {
-        "last_verified": "2026-04-07",
-        "verified_version": "v2.4.0",
-        "upstream_commit": "unknown",
-        "upstream_latest": "v2.4.0",
-        "pulp_commit": "unknown",
-        "build_status": {}
-      }
-    },
-    "kfr": {
-      "name": "KFR",
-      "version": "6.0.2",
-      "description": "Fast DSP framework with FFT, FIR/IIR, resampling, and SIMD",
-      "license": "GPL-2.0",
-      "category": "dsp",
-      "url": "https://github.com/kfrlib/kfr",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/kfrlib/kfr.git",
-        "git_tag": "6.0.2"
-      },
-      "cmake": {
-        "targets": [
-          "kfr"
-        ],
-        "header_only": false,
-        "include_dir": "include"
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Android": {
-          "architectures": [
-            "arm64-v8a",
-            "x86_64"
-          ],
-          "ndk_compatible": true,
-          "min_api": 26,
-          "notes": "Pure C++ SIMD with NEON support"
-        },
-        "iOS": {
-          "architectures": [
-            "arm64"
-          ],
-          "min_version": "15.0",
-          "notes": "Pure C++ SIMD with NEON support"
-        }
-      },
-      "rt_safe": true,
-      "tags": [
-        "fft",
-        "fir",
-        "iir",
-        "resampling",
-        "simd",
-        "dsp"
-      ],
-      "provides": [
-        "fft",
-        "filters",
-        "resampling",
-        "simd-dsp"
-      ],
-      "overlaps_with_builtin": {
-        "signal/fft.hpp": "FFT",
-        "signal/biquad.hpp": "IIR filters"
-      },
-      "unique_value": "Comprehensive SIMD-optimized DSP with expression templates \u2014 faster than hand-written loops",
-      "alternatives": [
-        "PFFFT (BSD-3) + Signalsmith DSP (MIT) for FFT + filters separately"
-      ],
-      "migration_notes": {},
-      "verification": {
-        "last_verified": "2026-04-07",
-        "verified_version": "6.0.2",
-        "upstream_commit": "unknown",
-        "upstream_latest": "6.0.2",
-        "pulp_commit": "unknown",
-        "build_status": {}
-      }
-    },
-    "kissfft": {
-      "name": "KissFFT",
-      "version": "131.1.0",
-      "description": "Portable FFT for any size — not just power-of-two",
-      "license": "BSD-3-Clause",
-      "category": "dsp",
-      "url": "https://github.com/mborgerding/kissfft",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/mborgerding/kissfft.git",
-        "git_tag": "131.1.0"
-      },
-      "cmake": {
-        "targets": [
-          "kissfft"
-        ],
-        "header_only": false,
-        "include_dir": "."
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Android": {
-          "architectures": [
-            "arm64-v8a",
-            "x86_64"
-          ]
-        },
-        "iOS": {
-          "architectures": [
-            "arm64"
-          ]
-        }
-      },
-      "rt_safe": true,
-      "tags": [
-        "fft",
-        "portable",
-        "arbitrary-size"
-      ],
-      "provides": [
-        "fft"
-      ],
-      "overlaps_with_builtin": {
-        "signal/fft.hpp": "FFT"
-      },
-      "unique_value": "Arbitrary-size FFT (not limited to power-of-two like PFFFT)",
-      "alternatives": [
-        "PFFFT (BSD-3, SIMD-optimized but power-of-two only)"
-      ],
-      "migration_notes": {},
-      "verification": {
-        "last_verified": "2026-04-07",
-        "verified_version": "131.1.0",
-        "upstream_commit": "unknown",
-        "upstream_latest": "131.1.0",
-        "pulp_commit": "unknown",
-        "build_status": {}
-      }
-    },
-    "lame": {
-      "name": "LAME",
-      "version": "3.100",
-      "description": "MP3 encoder \u2014 high-quality MP3 encoding for audio export",
-      "license": "LGPL-2.0",
-      "category": "audio-io",
-      "url": "https://lame.sourceforge.io",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/lameproject/lame.git",
-        "git_tag": "RELEASE__3_100"
-      },
-      "cmake": {
-        "targets": [
-          "mp3lame"
-        ],
-        "header_only": false
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64",
-            "x86_64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        }
-      },
-      "rt_safe": false,
-      "tags": [
-        "mp3",
-        "encoder",
-        "lossy",
-        "audio-export"
-      ],
-      "provides": [
-        "mp3-encode"
-      ],
-      "overlaps_with_builtin": {
-        "feature": "MP3 read (via dr_mp3)",
-        "note": "dr_mp3 provides decode only. LAME adds encode capability."
-      },
-      "unique_value": "The standard MP3 encoder. Required for MP3 export. LGPL \u2014 requires --accept-license.",
-      "integration_guide": "After pulp add lame --accept-license LGPL-2.0, the FormatRegistry automatically gains an Mp3Writer.",
-      "verification": {
-        "last_verified": "2026-04-07",
-        "status": "metadata-only"
-      }
-    },
-    "fdk-aac": {
-      "name": "FDK AAC",
-      "version": "2.0.3",
-      "description": "AAC encoder/decoder \u2014 Fraunhofer FDK AAC codec for AAC audio export",
-      "license": "FDK-AAC",
-      "category": "audio-io",
-      "url": "https://github.com/mstorsjo/fdk-aac",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/mstorsjo/fdk-aac.git",
-        "git_tag": "v2.0.3"
-      },
-      "cmake": {
-        "targets": [
-          "fdk-aac"
-        ],
-        "header_only": false
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64",
-            "x86_64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        }
-      },
-      "rt_safe": false,
-      "tags": [
-        "aac",
-        "encoder",
-        "decoder",
-        "lossy",
-        "audio-export"
-      ],
-      "provides": [
-        "aac-encode",
-        "aac-decode"
-      ],
-      "overlaps_with_builtin": {
-        "feature": "AAC read on macOS (via CoreAudioFormat/ExtAudioFile)",
-        "note": "CoreAudioFormat provides macOS-only AAC read. FDK adds cross-platform encode+decode."
-      },
-      "unique_value": "Cross-platform AAC encoder. FDK license has patent considerations \u2014 requires --accept-license.",
-      "integration_guide": "After pulp add fdk-aac --accept-license FDK-AAC, the FormatRegistry gains an AacWriter.",
-      "verification": {
-        "last_verified": "2026-04-07",
-        "status": "metadata-only"
-      }
-    },
-    "libflac": {
-      "name": "FLAC",
-      "version": "1.4.3",
-      "description": "FLAC encoder \u2014 lossless audio compression for high-quality export",
-      "license": "BSD-3-Clause",
-      "category": "audio-io",
-      "url": "https://github.com/xiph/flac",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/xiph/flac.git",
-        "git_tag": "1.4.3"
-      },
-      "cmake": {
-        "targets": [
-          "FLAC"
-        ],
-        "header_only": false
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64",
-            "x86_64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        }
-      },
-      "rt_safe": false,
-      "tags": [
-        "flac",
-        "encoder",
-        "lossless",
-        "audio-export"
-      ],
-      "provides": [
-        "flac-encode"
-      ],
-      "overlaps_with_builtin": {
-        "feature": "FLAC read (via dr_flac)",
-        "note": "dr_flac provides decode only. libflac adds encode capability."
-      },
-      "unique_value": "Reference FLAC encoder \u2014 lossless, universally supported, BSD-3 licensed.",
-      "integration_guide": "After pulp add libflac, the FormatRegistry gains a FlacWriter for .flac export.",
-      "verification": {
-        "last_verified": "2026-04-07",
-        "status": "metadata-only"
-      }
-    },
-    "alac": {
-      "name": "Apple ALAC",
-      "version": "master",
-      "description": "Apple Lossless Audio Codec encoder \u2014 cross-platform ALAC write",
-      "license": "Apache-2.0",
-      "category": "audio-io",
-      "url": "https://github.com/macosforge/alac",
-      "fetch": {
-        "method": "FetchContent",
-        "git_repository": "https://github.com/macosforge/alac.git",
-        "git_tag": "master"
-      },
-      "cmake": {
-        "targets": [
-          "alac"
-        ],
-        "header_only": false
-      },
-      "platforms": {
-        "macOS": {
-          "architectures": [
-            "arm64",
-            "x86_64"
-          ]
-        },
-        "Windows": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        },
-        "Linux": {
-          "architectures": [
-            "x64",
-            "arm64"
-          ]
-        }
-      },
-      "rt_safe": false,
-      "tags": [
-        "alac",
-        "encoder",
-        "lossless",
-        "apple",
-        "audio-export"
-      ],
-      "provides": [
-        "alac-encode"
-      ],
-      "overlaps_with_builtin": {
-        "feature": "ALAC read on macOS (via CoreAudioFormat/ExtAudioFile)",
-        "note": "CoreAudioFormat provides macOS-only ALAC read. Apple ALAC adds cross-platform encode."
-      },
-      "unique_value": "Apple's reference ALAC encoder, cross-platform. Apache 2.0 \u2014 no restrictions.",
-      "integration_guide": "After pulp add alac, the FormatRegistry gains an AlacWriter for .m4a export.",
-      "verification": {
-        "last_verified": "2026-04-07",
-        "status": "metadata-only"
       }
     }
   }

--- a/tools/scripts/cmajor_external.py
+++ b/tools/scripts/cmajor_external.py
@@ -17,11 +17,12 @@ DEFAULT_TARGET = "cpp"
 SUPPORTED_TARGETS = (
     "cpp",
     "clap",
-    "juce",
     "javascript",
     "webaudio",
     "webaudio-html",
 )
+# Note: cmaj also supports --target juce, but JUCE output is not
+# relevant for Pulp projects. Use "cpp" for Pulp integration.
 
 
 class CmajorExternalError(RuntimeError):


### PR DESCRIPTION
## Summary

6 new packages filling critical gaps:

| Package | License | Gap Filled |
|---------|---------|-----------|
| BTrack | MIT | Beat tracking (MIT alternative to GPL Aubio) |
| Freeverb | Unlicense | Public domain Schroeder reverb reference |
| libpd | BSD-3 | Pure Data patch embedding |
| libremidi | BSD-2 | C++20 MIDI I/O with iOS+Android + MIDI 2.0 |
| libvorbis | BSD-3 | OGG Vorbis codec for sample banks |
| SpeexDSP | BSD-3 | Echo cancellation, AGC, VAD |

Registry now has 34 packages total (16 MIT/BSD, 4 codec, 6 mobile, 8 copyleft).

## Test plan
- [x] Registry validates (all new packages OK)
- [x] Naming audit passes
- [ ] CI green