### PR TITLE
Fix IPC handoff ordering + wire iOS accessibility to CMakeLists

### DIFF
--- a/core/events/include/pulp/events/interprocess_connection.hpp
+++ b/core/events/include/pulp/events/interprocess_connection.hpp
@@ -88,8 +88,7 @@ public:
     InterprocessConnection(const InterprocessConnection&) = delete;
     InterprocessConnection& operator=(const InterprocessConnection&) = delete;
 
-    /// Adopt an already-connected socket (used by InterprocessConnectionServer).
-    void adopt_socket(runtime::Socket&& socket);
+    friend class InterprocessConnectionServer;  // Needs to inject accepted sockets
 
 private:
     struct Impl;

--- a/core/events/src/interprocess_connection.cpp
+++ b/core/events/src/interprocess_connection.cpp
@@ -166,15 +166,7 @@ bool InterprocessConnection::send_message(std::string_view message) {
     return send_message(message.data(), message.size());
 }
 
-void InterprocessConnection::adopt_socket(runtime::Socket&& socket) {
-    disconnect();
-    impl_->transport = IpcTransport::Socket;
-    impl_->socket = std::move(socket);
-    state_.store(IpcState::Connected);
-    connection_made();
-    if (on_connected) on_connected();
-    start_read_thread();
-}
+
 
 void InterprocessConnection::start_read_thread() {
     running_.store(true);
@@ -267,11 +259,22 @@ bool InterprocessConnectionServer::start(std::string_view name, IpcTransport tra
                 if (!client_sock) continue;
 
                 auto conn = std::make_unique<InterprocessConnection>();
-                conn->adopt_socket(std::move(*client_sock));
+                // Inject the accepted socket via friend access
+                conn->impl_->transport = IpcTransport::Socket;
+                conn->impl_->socket = std::move(*client_sock);
+                conn->state_.store(IpcState::Connected);
+                conn->connection_made();
+                if (conn->on_connected) conn->on_connected();
+
+                // Hand off to callback FIRST, then start reading.
+                auto* raw = conn.get();
                 if (on_client_connected)
                     on_client_connected(std::move(conn));
                 else
                     client_connected(std::move(conn));
+
+                // Now start the read thread (handlers are wired)
+                raw->start_read_thread();
             }
         }
     });

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -230,6 +230,7 @@ if(APPLE)
         target_sources(pulp-view PRIVATE
             platform/ios/window_host_ios.mm
             platform/ios/plugin_view_host_ios.mm
+            platform/ios/accessibility_ios.mm
         )
         target_link_libraries(pulp-view PRIVATE
             "-framework UIKit"


### PR DESCRIPTION
Fixes PR #52 review: connection handed to callback before read thread starts; iOS accessibility .mm added to build.