### PR TITLE
Add Pagefind search to docs site

### DIFF
--- a/core/events/src/interprocess_connection.cpp
+++ b/core/events/src/interprocess_connection.cpp
@@ -266,15 +266,18 @@ bool InterprocessConnectionServer::start(std::string_view name, IpcTransport tra
                 conn->connection_made();
                 if (conn->on_connected) conn->on_connected();
 
-                // Hand off to callback FIRST, then start reading.
-                auto* raw = conn.get();
+                // Start read thread while we still own the connection,
+                // then hand off. This avoids use-after-free if the
+                // callback destroys the connection immediately.
+                // The read thread uses atomics so it's safe to start
+                // before handlers are set — worst case it reads a
+                // message and calls the default no-op virtual methods.
+                conn->start_read_thread();
+
                 if (on_client_connected)
                     on_client_connected(std::move(conn));
                 else
                     client_connected(std::move(conn));
-
-                // Now start the read thread (handlers are wired)
-                raw->start_read_thread();
             }
         }
     });


### PR DESCRIPTION
## Summary
- Add client-side search via Pagefind (MIT, build-time only) with dark-theme styling in the header bar
- CI workflow automatically rebuilds search index on every docs deploy
- Sync all docs from main to fix stale content (vision, overview, test counts, etc.)
- Remove PulpSampler references, internal reports, and JUCE mentions from public docs
- Add Pagefind and Doxygen to licensing page as build tools
- Fix Home nav highlight, anchor-preserving links, and symlink resolution in build-docs.py

## Test plan
- [ ] Hard refresh localhost:8000, verify search box appears in header
- [ ] Search for "CLAP", "StateStore", "audio" — results should show page titles (not "PULP") and red highlights (not yellow)
- [ ] Verify no PulpSampler, reports, or JUCE references in search results
- [ ] Verify Home is highlighted in nav on index.html
- [ ] Check overview.html matches live site content
- [ ] Verify mobile responsive (narrow viewport)