### PR TITLE
Fix review round 3: ChildProcess pipe drain, Windows quoting, platform guards, cmaj recurse

### DIFF
--- a/core/platform/platform/posix/child_process_posix.cpp
+++ b/core/platform/platform/posix/child_process_posix.cpp
@@ -80,8 +80,10 @@ struct ChildProcess::Impl {
     std::string stdout_lines_buf;  // partial line accumulator for callbacks
     std::string stderr_lines_buf;
     bool started = false;
-    mutable bool finished = false;       // mutable: is_running() caches waitpid result
-    mutable ProcessResult result;        // mutable: is_running() stores exit code
+    bool finished = false;
+    mutable int cached_exit_status = -1; // cached by is_running() for wait()
+    mutable bool exit_cached = false;
+    ProcessResult result;
 };
 
 ChildProcess::ChildProcess() : impl_(std::make_unique<Impl>()) {}
@@ -155,18 +157,18 @@ bool ChildProcess::start(const std::string& command,
 
 bool ChildProcess::is_running() const {
     if (!impl_->started || impl_->finished) return false;
-    // Use waitpid WNOHANG — if child has exited, store the status so
-    // wait() doesn't hang. This handles zombies correctly (kill(pid,0)
-    // returns success for zombies, which is wrong).
+    if (impl_->exit_cached) return false;
+    // Use waitpid WNOHANG to detect exit including zombies.
+    // Cache the exit status but do NOT set finished — wait() still needs
+    // to drain pipes and build the full ProcessResult.
     int status = 0;
     auto rc = waitpid(impl_->pid, &status, WNOHANG);
     if (rc > 0) {
-        // Child exited — cache the result for wait()
-        impl_->finished = true;
-        impl_->result.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+        impl_->cached_exit_status = status;
+        impl_->exit_cached = true;
         return false;
     }
-    return rc == 0;  // 0 = still running, -1 = error
+    return rc == 0;
 }
 
 void ChildProcess::cancel() {
@@ -214,10 +216,17 @@ ProcessResult ChildProcess::wait() {
         drain_pipe(impl_->stderr_pipe.read_end(), impl_->stderr_full,
                    impl_->stderr_lines_buf, max_bytes, impl_->options.on_stderr_line);
 
-        // Check if process exited
+        // Check if process exited (use cached result from is_running() if available)
         int status = 0;
-        auto rc = waitpid(impl_->pid, &status, WNOHANG);
-        if (rc > 0) {
+        bool exited = false;
+        if (impl_->exit_cached) {
+            status = impl_->cached_exit_status;
+            exited = true;
+        } else {
+            auto rc = waitpid(impl_->pid, &status, WNOHANG);
+            exited = (rc > 0);
+        }
+        if (exited) {
             // Process exited — drain remaining output
             drain_pipe(impl_->stdout_pipe.read_end(), impl_->stdout_full,
                        impl_->stdout_lines_buf, max_bytes, impl_->options.on_stdout_line);

--- a/core/platform/platform/win/child_process_win.cpp
+++ b/core/platform/platform/win/child_process_win.cpp
@@ -101,21 +101,24 @@ bool ChildProcess::start(const std::string& command,
 
     if (!impl_->stdout_pipe.create() || !impl_->stderr_pipe.create()) return false;
 
-    // Build command line — handle quoting carefully.
-    // For cmd.exe /c, the command after /c should not be double-quoted
-    // as cmd.exe strips the outer quotes itself.
+    // Build command line with platform-appropriate quoting.
+    // Special case: cmd.exe /c passes everything after /c to the shell,
+    // so metacharacters and embedded quotes must be preserved.
+    bool is_cmd_c = (command == "cmd" || command == "cmd.exe") &&
+                    !args.empty() && (args[0] == "/c" || args[0] == "/C");
+
     std::string cmdline = "\"" + command + "\"";
-    for (auto& a : args) {
-        // Don't add extra quotes if the arg already contains quotes
-        // or if it's a shell command (contains spaces, pipes, redirects)
-        if (a.find('"') != std::string::npos || a.find('|') != std::string::npos ||
-            a.find('>') != std::string::npos || a.find('<') != std::string::npos ||
-            a.find('&') != std::string::npos) {
-            cmdline += " " + a;  // pass through as-is
-        } else if (a.find(' ') != std::string::npos) {
-            cmdline += " \"" + a + "\"";  // quote if has spaces
+    for (size_t i = 0; i < args.size(); ++i) {
+        auto& a = args[i];
+        if (a.empty()) {
+            cmdline += " \"\"";  // preserve empty args
+        } else if (is_cmd_c && i == args.size() - 1) {
+            // Last arg to cmd /c is the shell command — pass through raw
+            cmdline += " " + a;
+        } else if (a.find(' ') != std::string::npos && a.find('"') == std::string::npos) {
+            cmdline += " \"" + a + "\"";
         } else {
-            cmdline += " " + a;  // no quoting needed
+            cmdline += " " + a;
         }
     }
 

--- a/tools/cli/package_commands.cpp
+++ b/tools/cli/package_commands.cpp
@@ -674,20 +674,42 @@ int cmd_add(const std::vector<std::string>& args) {
         lock.packages[package_id] = {pkg.version, pkg.fetch.git_repository, "", pkg.fetch.git_tag};
 
         // If platform_guard is set and package doesn't support all targets,
-        // write a guarded cmake block for this specific package
+        // write a guarded cmake block covering all supported desktop platforms
         bool needs_guard = platform_guard && !unsup.empty();
         std::string guard_cmake;
         if (needs_guard) {
-            // Determine which platforms ARE supported
-            std::string guard_platform;
+            // Build a compound CMake guard for all supported desktop platforms
+            std::vector<std::string> conditions;
             for (auto& [name, ps] : pkg.platforms) {
-                if (name == "macOS" || name == "Windows" || name == "Linux") {
-                    guard_platform = name;
-                    break;
-                }
+                if (name == "macOS") conditions.push_back("APPLE");
+                else if (name == "Windows") conditions.push_back("WIN32");
+                else if (name == "Linux") conditions.push_back("UNIX AND NOT APPLE");
             }
-            if (!guard_platform.empty())
-                guard_cmake = generate_cmake_block(pkg, true, guard_platform);
+            if (!conditions.empty()) {
+                std::string guard_condition;
+                for (size_t i = 0; i < conditions.size(); ++i) {
+                    if (i > 0) guard_condition += " OR ";
+                    guard_condition += conditions[i];
+                }
+                // Generate block with custom compound guard
+                std::ostringstream os;
+                os << "# ── " << pkg.id << " (" << pkg.version << ") [platform guard] ──\n";
+                os << "if(" << guard_condition << ")\n";
+                os << "  FetchContent_Declare(" << pkg.id << "\n";
+                os << "    GIT_REPOSITORY " << pkg.fetch.git_repository << "\n";
+                os << "    GIT_TAG        " << pkg.fetch.git_tag << "\n";
+                os << "    GIT_SHALLOW    TRUE\n";
+                os << "  )\n";
+                os << "  FetchContent_MakeAvailable(" << pkg.id << ")\n";
+                auto upper_id = pkg.id;
+                std::transform(upper_id.begin(), upper_id.end(), upper_id.begin(),
+                    [](unsigned char c) { return c == '-' ? '_' : std::toupper(c); });
+                os << "  target_compile_definitions(${PROJECT_NAME} PRIVATE PULP_HAS_"
+                   << upper_id << "=1)\n";
+                os << "endif()\n";
+                os << "# ── end " << pkg.id << " ──\n";
+                guard_cmake = os.str();
+            }
         }
 
         auto cmake_content = generate_packages_cmake(lock, reg, root);

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -2385,17 +2385,20 @@ static std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, b
     // Cmajor CLI check — only if project has .cmajorpatch files
     if (!active_root.empty()) {
         bool has_patches = false;
-        // Check common locations for .cmajorpatch files
-        for (auto& dir : {".", "examples", "src"}) {
-            auto check_dir = active_root / dir;
-            if (!fs::exists(check_dir)) continue;
-            for (auto& entry : fs::directory_iterator(check_dir)) {
-                if (entry.path().extension() == ".cmajorpatch") {
-                    has_patches = true;
-                    break;
+        for (auto it = fs::recursive_directory_iterator(active_root,
+                 fs::directory_options::skip_permission_denied);
+             it != fs::recursive_directory_iterator(); ++it) {
+            if (it->is_directory()) {
+                auto name = it->path().filename().string();
+                if (name == "build" || name == "external" || name == ".git" || name == "node_modules") {
+                    it.disable_recursion_pending();
+                    continue;
                 }
             }
-            if (has_patches) break;
+            if (it->path().extension() == ".cmajorpatch") {
+                has_patches = true;
+                break;
+            }
         }
         if (has_patches) {
             DoctorCheck c{"Cmajor CLI (cmaj)", false, {}, {}};


### PR DESCRIPTION
Fixes is_running() pipe drain loss, Windows cmd /c metacharacter scoping, compound platform guard generation, and cmaj patch recursive search.