### PR TITLE
Fix MSVC portability: add missing #include <algorithm> across 16 files

### DIFF
--- a/core/audio/src/aac_writer.cpp
+++ b/core/audio/src/aac_writer.cpp
@@ -4,6 +4,7 @@
 
 #ifdef PULP_HAS_FDK_AAC
 
+#include <algorithm>
 #include <pulp/audio/format_registry.hpp>
 #include <fdk-aac/aacenc_lib.h>
 #include <vector>

--- a/core/audio/src/alac_writer.cpp
+++ b/core/audio/src/alac_writer.cpp
@@ -8,6 +8,7 @@
 
 #ifdef PULP_HAS_ALAC
 
+#include <algorithm>
 #include <pulp/audio/format_registry.hpp>
 #include <ALACEncoder.h>
 #include <ALACBitUtilities.h>

--- a/core/audio/src/flac_writer.cpp
+++ b/core/audio/src/flac_writer.cpp
@@ -4,6 +4,7 @@
 
 #ifdef PULP_HAS_LIBFLAC
 
+#include <algorithm>
 #include <pulp/audio/format_registry.hpp>
 #include <FLAC/stream_encoder.h>
 #include <vector>

--- a/core/audio/src/mp3_writer.cpp
+++ b/core/audio/src/mp3_writer.cpp
@@ -4,6 +4,7 @@
 
 #ifdef PULP_HAS_LAME
 
+#include <algorithm>
 #include <pulp/audio/format_registry.hpp>
 #include <lame/lame.h>
 #include <vector>

--- a/core/canvas/src/color.cpp
+++ b/core/canvas/src/color.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <pulp/canvas/canvas.hpp>
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -1,7 +1,9 @@
+#include <algorithm>
 #include <pulp/canvas/skia_canvas.hpp>
 
 #ifdef PULP_HAS_SKIA
 
+#include <algorithm>
 #include "include/core/SkCanvas.h"
 #include "include/core/SkPaint.h"
 #include "include/core/SkPath.h"

--- a/core/runtime/src/expression.cpp
+++ b/core/runtime/src/expression.cpp
@@ -1,4 +1,5 @@
 #include <pulp/runtime/expression.hpp>
+#include <algorithm>
 #include <cmath>
 #include <cctype>
 #include <stdexcept>

--- a/core/signal/include/pulp/signal/gain.hpp
+++ b/core/signal/include/pulp/signal/gain.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 
 namespace pulp::signal {

--- a/core/signal/include/pulp/signal/phaser.hpp
+++ b/core/signal/include/pulp/signal/phaser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <array>
 

--- a/core/signal/include/pulp/signal/reverb.hpp
+++ b/core/signal/include/pulp/signal/reverb.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <pulp/signal/delay_line.hpp>
 #include <array>
 #include <cmath>

--- a/core/state/src/store.cpp
+++ b/core/state/src/store.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <pulp/state/store.hpp>
+#include <algorithm>
 #include <pulp/runtime/assert.hpp>
 #include <choc/memory/choc_Endianness.h>
 

--- a/core/view/include/pulp/view/animator_set.hpp
+++ b/core/view/include/pulp/view/animator_set.hpp
@@ -3,6 +3,7 @@
 // AnimatorSetBuilder — compose animations in sequence or parallel groups.
 // Inspired by Android's AnimatorSet pattern.
 
+#include <algorithm>
 #include <pulp/view/animation.hpp>
 #include <vector>
 #include <memory>

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <pulp/view/geometry.hpp>
 #include <pulp/view/input_events.hpp>
 #include <pulp/view/theme.hpp>

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <pulp/view/view.hpp>
 #include <pulp/view/audio_bridge.hpp>
 #include <pulp/view/animation.hpp>

--- a/core/view/src/color_picker.cpp
+++ b/core/view/src/color_picker.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <pulp/view/color_picker.hpp>
+#include <algorithm>
 #include <cstdio>
 #include <cmath>
 

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <pulp/view/widgets.hpp>
+#include <algorithm>
 #include <pulp/view/animation.hpp>
 #include <pulp/view/frame_clock.hpp>
 #include <pulp/view/window_host.hpp>


### PR DESCRIPTION
Fixes Windows CI build failures. MSVC doesn't transitively include <algorithm> like GCC/Clang. All 16 files using std::clamp/min/max now have the explicit include.