### PR TITLE
Fix review round 4: reset exit_cached, header-only platform guard

### DIFF
--- a/core/platform/platform/posix/child_process_posix.cpp
+++ b/core/platform/platform/posix/child_process_posix.cpp
@@ -105,6 +105,8 @@ bool ChildProcess::start(const std::string& command,
     impl_->stdout_lines_buf.clear();
     impl_->stderr_lines_buf.clear();
     impl_->finished = false;
+    impl_->exit_cached = false;
+    impl_->cached_exit_status = -1;
 
     if (!impl_->stdout_pipe.create() || !impl_->stderr_pipe.create()) {
         impl_->result.exit_code = -1;

--- a/tools/cli/package_commands.cpp
+++ b/tools/cli/package_commands.cpp
@@ -701,6 +701,15 @@ int cmd_add(const std::vector<std::string>& args) {
                 os << "    GIT_SHALLOW    TRUE\n";
                 os << "  )\n";
                 os << "  FetchContent_MakeAvailable(" << pkg.id << ")\n";
+                // Header-only packages need INTERFACE target + include dir
+                if (pkg.cmake.header_only && !pkg.cmake.targets.empty()) {
+                    os << "  add_library(" << pkg.cmake.targets[0] << " INTERFACE)\n";
+                    os << "  target_include_directories(" << pkg.cmake.targets[0]
+                       << " INTERFACE ${" << pkg.id << "_SOURCE_DIR}";
+                    if (!pkg.cmake.include_dir.empty() && pkg.cmake.include_dir != ".")
+                        os << "/" << pkg.cmake.include_dir;
+                    os << ")\n";
+                }
                 auto upper_id = pkg.id;
                 std::transform(upper_id.begin(), upper_id.end(), upper_id.begin(),
                     [](unsigned char c) { return c == '-' ? '_' : std::toupper(c); });


### PR DESCRIPTION
Reset cached exit state on ChildProcess reuse. Preserve header-only INTERFACE target setup in platform-guarded CMake blocks.