### PR TITLE
Add separate floating inspector window with TreeView and PropertyList

### DIFF
--- a/core/audio/src/aac_writer.cpp
+++ b/core/audio/src/aac_writer.cpp
@@ -4,6 +4,7 @@
 
 #ifdef PULP_HAS_FDK_AAC
 
+#include <algorithm>
 #include <pulp/audio/format_registry.hpp>
 #include <fdk-aac/aacenc_lib.h>
 #include <vector>

--- a/core/audio/src/alac_writer.cpp
+++ b/core/audio/src/alac_writer.cpp
@@ -8,6 +8,7 @@
 
 #ifdef PULP_HAS_ALAC
 
+#include <algorithm>
 #include <pulp/audio/format_registry.hpp>
 #include <ALACEncoder.h>
 #include <ALACBitUtilities.h>

--- a/core/audio/src/flac_writer.cpp
+++ b/core/audio/src/flac_writer.cpp
@@ -4,6 +4,7 @@
 
 #ifdef PULP_HAS_LIBFLAC
 
+#include <algorithm>
 #include <pulp/audio/format_registry.hpp>
 #include <FLAC/stream_encoder.h>
 #include <vector>

--- a/core/audio/src/mp3_writer.cpp
+++ b/core/audio/src/mp3_writer.cpp
@@ -4,6 +4,7 @@
 
 #ifdef PULP_HAS_LAME
 
+#include <algorithm>
 #include <pulp/audio/format_registry.hpp>
 #include <lame/lame.h>
 #include <vector>

--- a/core/canvas/src/color.cpp
+++ b/core/canvas/src/color.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <pulp/canvas/canvas.hpp>
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -1,7 +1,9 @@
+#include <algorithm>
 #include <pulp/canvas/skia_canvas.hpp>
 
 #ifdef PULP_HAS_SKIA
 
+#include <algorithm>
 #include "include/core/SkCanvas.h"
 #include "include/core/SkPaint.h"
 #include "include/core/SkPath.h"

--- a/core/runtime/src/expression.cpp
+++ b/core/runtime/src/expression.cpp
@@ -1,4 +1,5 @@
 #include <pulp/runtime/expression.hpp>
+#include <algorithm>
 #include <cmath>
 #include <cctype>
 #include <stdexcept>

--- a/core/signal/include/pulp/signal/gain.hpp
+++ b/core/signal/include/pulp/signal/gain.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 
 namespace pulp::signal {

--- a/core/signal/include/pulp/signal/phaser.hpp
+++ b/core/signal/include/pulp/signal/phaser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <array>
 

--- a/core/signal/include/pulp/signal/reverb.hpp
+++ b/core/signal/include/pulp/signal/reverb.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <pulp/signal/delay_line.hpp>
 #include <array>
 #include <cmath>

--- a/core/state/src/store.cpp
+++ b/core/state/src/store.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <pulp/state/store.hpp>
+#include <algorithm>
 #include <pulp/runtime/assert.hpp>
 #include <choc/memory/choc_Endianness.h>
 

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -167,6 +167,7 @@ target_sources(pulp-view PRIVATE
     src/concertina_panel.cpp
     src/splash_screen.cpp
     src/live_constant_editor.cpp
+    src/inspector_window.cpp
 )
 
 # WebView support — compiled separately to avoid platform WebView runtime

--- a/core/view/include/pulp/view/animator_set.hpp
+++ b/core/view/include/pulp/view/animator_set.hpp
@@ -3,6 +3,7 @@
 // AnimatorSetBuilder — compose animations in sequence or parallel groups.
 // Inspired by Android's AnimatorSet pattern.
 
+#include <algorithm>
 #include <pulp/view/animation.hpp>
 #include <vector>
 #include <memory>

--- a/core/view/include/pulp/view/inspector.hpp
+++ b/core/view/include/pulp/view/inspector.hpp
@@ -2,7 +2,10 @@
 
 #include <pulp/view/view.hpp>
 #include <pulp/view/widgets.hpp>
+#include <pulp/view/tree_view.hpp>
+#include <pulp/view/property_list.hpp>
 #include <string>
+#include <vector>
 
 namespace pulp::view {
 
@@ -21,6 +24,19 @@ public:
 
     // Get the type name of a view (e.g., "Knob", "Fader", "View")
     static std::string type_name(const View& view);
+
+    // ── Inspector window helpers ────────────────────────────────────────
+
+    /// Recursively populate a TreeNode hierarchy from a View tree.
+    /// Sets label = type_name + id, user_data = View*.
+    static void populate_tree(TreeNode& parent, const View& root);
+
+    /// Build a list of properties for display in a PropertyList.
+    /// Categories: Identity, Layout, Visual, Widget.
+    static std::vector<PropertyList::Property> view_properties(const View& view);
+
+    /// Compute absolute bounds by walking the parent chain.
+    static Rect absolute_bounds(const View& view);
 };
 
 } // namespace pulp::view

--- a/core/view/include/pulp/view/inspector_window.hpp
+++ b/core/view/include/pulp/view/inspector_window.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+/// @file inspector_window.hpp
+/// Separate floating inspector window with TreeView and PropertyList.
+/// Opens alongside the plugin window via Cmd+I (macOS) / Ctrl+I (others).
+/// Uses existing multi-window infrastructure (WindowManager, WindowType::inspector).
+
+#include <pulp/view/view.hpp>
+#include <pulp/view/inspector.hpp>
+#include <pulp/view/tree_view.hpp>
+#include <pulp/view/property_list.hpp>
+#include <pulp/view/split_view.hpp>
+#include <pulp/view/window_host.hpp>
+#include <pulp/view/window_manager.hpp>
+#include <memory>
+
+namespace pulp::view {
+
+/// Highlight overlay added to the target root to visualize the selected view bounds.
+/// Draws a semi-transparent blue rectangle. Not hit-testable.
+class InspectorHighlight : public View {
+public:
+    InspectorHighlight();
+
+    /// Set the rectangle to highlight (in root coordinates).
+    void set_highlight_rect(Rect r);
+
+    /// Clear the highlight.
+    void clear();
+
+    void paint(canvas::Canvas& canvas) override;
+
+private:
+    Rect highlight_rect_{};
+    bool has_rect_ = false;
+};
+
+/// Floating inspector window that displays the view hierarchy and properties
+/// of a target view tree in a separate OS window.
+class InspectorWindow {
+public:
+    /// Construct an inspector targeting the given root view.
+    /// @param target_root  The root of the view tree to inspect.
+    /// @param mgr          Optional WindowManager for registration.
+    /// @param parent        Optional parent WindowHost (positions relative to it).
+    InspectorWindow(View& target_root, WindowManager* mgr = nullptr,
+                    WindowHost* parent = nullptr);
+    ~InspectorWindow();
+
+    InspectorWindow(const InspectorWindow&) = delete;
+    InspectorWindow& operator=(const InspectorWindow&) = delete;
+
+    /// Show the inspector window.
+    void show();
+
+    /// Hide the inspector window.
+    void hide();
+
+    /// Toggle visibility.
+    void toggle();
+
+    /// Whether the inspector window is currently visible.
+    bool is_visible() const;
+
+    /// Refresh the tree and properties from the target root.
+    void refresh();
+
+    /// Select a specific view and update the property list.
+    void select_view(View* view);
+
+    /// Install Cmd+I / Ctrl+I keyboard shortcut on the target root's on_global_key.
+    void install_keyboard_shortcut();
+
+private:
+    View& target_root_;
+    WindowManager* manager_ = nullptr;
+    WindowHost* parent_host_ = nullptr;
+
+    // Inspector window's own view tree
+    std::unique_ptr<View> inspector_root_;
+    TreeView* tree_view_ = nullptr;
+    PropertyList* property_list_ = nullptr;
+    Label* header_label_ = nullptr;
+
+    // The actual OS window
+    std::unique_ptr<WindowHost> window_host_;
+    WindowId window_id_ = 0;
+
+    // Highlight overlay on the target root
+    std::unique_ptr<InspectorHighlight> highlight_;
+    InspectorHighlight* highlight_ptr_ = nullptr;
+
+    View* selected_view_ = nullptr;
+
+    void build_ui();
+    void on_tree_select(TreeNode& node);
+    void update_highlight();
+};
+
+} // namespace pulp::view

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -290,6 +290,10 @@ public:
     /// Global click callback (fires on any view click with widget id). Set on root.
     std::function<void(const std::string& id, uint16_t modifiers)> on_global_click;
 
+    /// Global key callback. If set on root, called before normal key dispatch.
+    /// Return true to consume the event.
+    std::function<bool(const KeyEvent&)> on_global_key;
+
     /// CSS position property
     enum class Position { static_, relative, absolute, fixed, sticky };
     void set_position(Position p) { position_ = p; }

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <pulp/view/geometry.hpp>
 #include <pulp/view/input_events.hpp>
 #include <pulp/view/theme.hpp>

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <pulp/view/view.hpp>
 #include <pulp/view/audio_bridge.hpp>
 #include <pulp/view/animation.hpp>

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -517,6 +517,19 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             return;
         }
 
+        // Global key callback — checked after inspector but before tab/escape
+        if (self.rootView && self.rootView->on_global_key) {
+            pulp::view::KeyEvent gke;
+            gke.key = key;
+            gke.modifiers = mods;
+            gke.is_down = true;
+            gke.is_repeat = event.isARepeat;
+            if (self.rootView->on_global_key(gke)) {
+                [self setNeedsDisplay:YES];
+                return;
+            }
+        }
+
         if (key == pulp::view::KeyCode::escape && self.rootView) {
             if (auto* modal = find_topmost_modal(self.rootView)) {
                 pulp::view::KeyEvent ke;

--- a/core/view/src/color_picker.cpp
+++ b/core/view/src/color_picker.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <pulp/view/color_picker.hpp>
+#include <algorithm>
 #include <cstdio>
 #include <cmath>
 

--- a/core/view/src/inspector.cpp
+++ b/core/view/src/inspector.cpp
@@ -93,4 +93,75 @@ std::string ViewInspector::type_name(const View& view) {
     return "View";
 }
 
+// ── Inspector window helpers ────────────────────────────────────────────────
+
+void ViewInspector::populate_tree(TreeNode& parent, const View& root) {
+    std::string label = type_name(root);
+    if (!root.id().empty())
+        label += " #" + root.id();
+
+    auto& node = parent.add_child(label);
+    node.user_data = const_cast<View*>(&root);
+    node.expanded = true;
+
+    for (size_t i = 0; i < root.child_count(); ++i)
+        populate_tree(node, *root.child_at(i));
+}
+
+std::vector<PropertyList::Property> ViewInspector::view_properties(const View& view) {
+    std::vector<PropertyList::Property> props;
+    using PV = PropertyList::PropertyValue;
+
+    // Identity
+    props.push_back({"type", "Type", PV{type_name(view)}, true, "Identity"});
+    props.push_back({"id", "ID", PV{view.id().empty() ? std::string("(none)") : view.id()}, true, "Identity"});
+
+    // Layout
+    auto b = view.bounds();
+    props.push_back({"x", "X", PV{b.x}, true, "Layout"});
+    props.push_back({"y", "Y", PV{b.y}, true, "Layout"});
+    props.push_back({"width", "Width", PV{b.width}, true, "Layout"});
+    props.push_back({"height", "Height", PV{b.height}, true, "Layout"});
+    props.push_back({"visible", "Visible", PV{view.visible()}, true, "Layout"});
+
+    // Visual
+    props.push_back({"opacity", "Opacity", PV{view.opacity()}, true, "Visual"});
+    props.push_back({"has_bg", "Background", PV{view.has_background_color()}, true, "Visual"});
+    if (view.has_border())
+        props.push_back({"border_w", "Border Width", PV{view.border_width()}, true, "Visual"});
+    props.push_back({"corner_r", "Corner Radius", PV{view.corner_radius()}, true, "Visual"});
+    props.push_back({"hit_testable", "Hit-Testable", PV{view.hit_testable()}, true, "Visual"});
+
+    // Widget-specific
+    if (auto* knob = dynamic_cast<const Knob*>(&view)) {
+        props.push_back({"value", "Value", PV{static_cast<float>(knob->value())}, true, "Widget"});
+        props.push_back({"label", "Label", PV{knob->label()}, true, "Widget"});
+    } else if (auto* fader = dynamic_cast<const Fader*>(&view)) {
+        props.push_back({"value", "Value", PV{static_cast<float>(fader->value())}, true, "Widget"});
+        props.push_back({"label", "Label", PV{fader->label()}, true, "Widget"});
+    } else if (auto* toggle = dynamic_cast<const Toggle*>(&view)) {
+        props.push_back({"on", "On", PV{toggle->is_on()}, true, "Widget"});
+        props.push_back({"label", "Label", PV{toggle->label()}, true, "Widget"});
+    } else if (auto* lbl = dynamic_cast<const Label*>(&view)) {
+        props.push_back({"text", "Text", PV{lbl->text()}, true, "Widget"});
+        props.push_back({"font_size", "Font Size", PV{lbl->font_size()}, true, "Widget"});
+    } else if (auto* meter = dynamic_cast<const Meter*>(&view)) {
+        props.push_back({"rms", "RMS", PV{static_cast<float>(meter->display_rms())}, true, "Widget"});
+        props.push_back({"peak", "Peak", PV{static_cast<float>(meter->display_peak())}, true, "Widget"});
+    }
+
+    return props;
+}
+
+Rect ViewInspector::absolute_bounds(const View& view) {
+    Rect abs = view.bounds();
+    const View* current = view.parent();
+    while (current) {
+        abs.x += current->bounds().x;
+        abs.y += current->bounds().y;
+        current = current->parent();
+    }
+    return abs;
+}
+
 } // namespace pulp::view

--- a/core/view/src/inspector_window.cpp
+++ b/core/view/src/inspector_window.cpp
@@ -1,0 +1,245 @@
+#include <pulp/view/inspector_window.hpp>
+#include <pulp/view/input_events.hpp>
+
+namespace pulp::view {
+
+// ── InspectorHighlight ─────────────────────────────────────────────────────
+
+InspectorHighlight::InspectorHighlight() {
+    set_hit_testable(false);
+    set_visible(true);
+    set_id("inspector-highlight");
+}
+
+void InspectorHighlight::set_highlight_rect(Rect r) {
+    highlight_rect_ = r;
+    has_rect_ = true;
+}
+
+void InspectorHighlight::clear() {
+    has_rect_ = false;
+}
+
+void InspectorHighlight::paint(canvas::Canvas& canvas) {
+    if (!has_rect_) return;
+
+    // Semi-transparent blue fill
+    canvas.set_fill_color(canvas::Color{50, 100, 255, 40});
+    canvas.fill_rect(highlight_rect_.x, highlight_rect_.y,
+                     highlight_rect_.width, highlight_rect_.height);
+
+    // Blue border
+    canvas.set_stroke_color(canvas::Color{50, 100, 255, 180});
+    canvas.set_line_width(1.5f);
+    canvas.stroke_rect(highlight_rect_.x, highlight_rect_.y,
+                       highlight_rect_.width, highlight_rect_.height);
+}
+
+// ── InspectorWindow ────────────────────────────────────────────────────────
+
+InspectorWindow::InspectorWindow(View& target_root, WindowManager* mgr,
+                                 WindowHost* parent)
+    : target_root_(target_root)
+    , manager_(mgr)
+    , parent_host_(parent)
+{
+    build_ui();
+
+    // Add highlight overlay to the target root
+    highlight_ = std::make_unique<InspectorHighlight>();
+    highlight_ptr_ = highlight_.get();
+    // Position it to cover the entire target root
+    highlight_ptr_->set_bounds(target_root_.local_bounds());
+    highlight_ptr_->set_position(View::Position::absolute);
+    highlight_ptr_->set_top(0);
+    highlight_ptr_->set_left(0);
+    highlight_ptr_->set_visible(false);
+    target_root_.add_child(std::move(highlight_));
+}
+
+InspectorWindow::~InspectorWindow() {
+    // Remove highlight from target root
+    if (highlight_ptr_) {
+        target_root_.remove_child(highlight_ptr_);
+        highlight_ptr_ = nullptr;
+    }
+
+    // Unregister from window manager
+    if (manager_ && window_id_ != 0) {
+        manager_->unregister_window(window_id_);
+    }
+}
+
+void InspectorWindow::build_ui() {
+    inspector_root_ = std::make_unique<View>();
+    inspector_root_->set_id("inspector-window-root");
+    inspector_root_->flex().direction = FlexDirection::column;
+    inspector_root_->set_background_color(canvas::Color{30, 30, 36, 255});
+
+    // Header row
+    auto header = std::make_unique<View>();
+    header->flex().direction = FlexDirection::row;
+    header->flex().padding = 8;
+    header->flex().preferred_height = 32;
+    header->set_background_color(canvas::Color{40, 40, 50, 255});
+    header->set_border_bottom(canvas::Color{60, 60, 70, 255}, 1);
+
+    auto title = std::make_unique<Label>("Inspector");
+    title->set_font_size(13.0f);
+    title->set_font_weight(600);
+    title->flex().flex_grow = 1;
+    header_label_ = title.get();
+    header->add_child(std::move(title));
+
+    inspector_root_->add_child(std::move(header));
+
+    // SplitView: TreeView (left/top) | PropertyList (right/bottom)
+    auto split = std::make_unique<SplitView>();
+    split->set_orientation(SplitView::Orientation::vertical);
+    split->set_split_fraction(0.5f);
+    split->set_min_first_size(80);
+    split->set_min_second_size(80);
+    split->flex().flex_grow = 1;
+
+    // TreeView
+    auto tree = std::make_unique<TreeView>();
+    tree->set_id("inspector-tree");
+    tree->set_row_height(20);
+    tree->set_indent(14);
+    tree_view_ = tree.get();
+
+    tree_view_->on_select = [this](TreeNode& node) {
+        on_tree_select(node);
+    };
+
+    split->set_first(std::move(tree));
+
+    // PropertyList
+    auto props = std::make_unique<PropertyList>();
+    props->set_id("inspector-props");
+    props->set_show_categories(true);
+    props->set_row_height(22);
+    property_list_ = props.get();
+
+    split->set_second(std::move(props));
+
+    inspector_root_->add_child(std::move(split));
+}
+
+void InspectorWindow::show() {
+    if (window_host_ && window_host_->is_visible()) return;
+
+    refresh();
+
+    if (!window_host_) {
+        WindowOptions opts;
+        opts.title = "Inspector";
+        opts.width = 320;
+        opts.height = 500;
+        opts.resizable = true;
+
+        WindowType type = WindowType::inspector;
+        opts.window_type = &type;
+
+        if (parent_host_)
+            opts.parent_native_handle = parent_host_->native_window_handle();
+
+        window_host_ = WindowHost::create(*inspector_root_, opts);
+        window_host_->set_close_callback([this]() {
+            if (highlight_ptr_)
+                highlight_ptr_->set_visible(false);
+        });
+
+        if (manager_) {
+            window_id_ = manager_->register_window(
+                window_host_.get(), inspector_root_.get(),
+                WindowType::inspector);
+        }
+    }
+
+    window_host_->show();
+
+    if (highlight_ptr_)
+        highlight_ptr_->set_visible(true);
+}
+
+void InspectorWindow::hide() {
+    if (window_host_)
+        window_host_->hide();
+
+    if (highlight_ptr_)
+        highlight_ptr_->set_visible(false);
+}
+
+void InspectorWindow::toggle() {
+    if (is_visible())
+        hide();
+    else
+        show();
+}
+
+bool InspectorWindow::is_visible() const {
+    return window_host_ && window_host_->is_visible();
+}
+
+void InspectorWindow::refresh() {
+    if (!tree_view_) return;
+
+    // Clear and rebuild the tree
+    tree_view_->root().children.clear();
+    tree_view_->root().label = "Root";
+    tree_view_->root().expanded = true;
+
+    ViewInspector::populate_tree(tree_view_->root(), target_root_);
+
+    // Update highlight bounds to match current target root size
+    if (highlight_ptr_)
+        highlight_ptr_->set_bounds(target_root_.local_bounds());
+}
+
+void InspectorWindow::select_view(View* view) {
+    selected_view_ = view;
+
+    if (view && property_list_) {
+        auto props = ViewInspector::view_properties(*view);
+        property_list_->set_properties(std::move(props));
+    } else if (property_list_) {
+        property_list_->set_properties({});
+    }
+
+    update_highlight();
+}
+
+void InspectorWindow::install_keyboard_shortcut() {
+    target_root_.on_global_key = [this](const KeyEvent& event) -> bool {
+        if (!event.is_down) return false;
+
+        // Cmd+I on macOS, Ctrl+I elsewhere
+        if (event.isMainModifier() && event.key == KeyCode::i) {
+            toggle();
+            return true;
+        }
+        return false;
+    };
+}
+
+void InspectorWindow::on_tree_select(TreeNode& node) {
+    auto* view = static_cast<View*>(node.user_data);
+    select_view(view);
+}
+
+void InspectorWindow::update_highlight() {
+    if (!highlight_ptr_) return;
+
+    if (!selected_view_) {
+        highlight_ptr_->clear();
+        return;
+    }
+
+    Rect abs = ViewInspector::absolute_bounds(*selected_view_);
+    highlight_ptr_->set_highlight_rect(abs);
+    highlight_ptr_->set_bounds(target_root_.local_bounds());
+    highlight_ptr_->set_visible(is_visible());
+}
+
+} // namespace pulp::view

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <pulp/view/widgets.hpp>
+#include <algorithm>
 #include <pulp/view/animation.hpp>
 #include <pulp/view/frame_clock.hpp>
 #include <pulp/view/window_host.hpp>

--- a/examples/ui-preview/main.cpp
+++ b/examples/ui-preview/main.cpp
@@ -8,6 +8,7 @@
 #include <pulp/view/theme.hpp>
 #include <pulp/view/frame_clock.hpp>
 #include <pulp/view/inspector.hpp>
+#include <pulp/view/inspector_window.hpp>
 #include <pulp/inspect/inspector_overlay.hpp>
 #include <pulp/runtime/system.hpp>
 #include <pulp/view/screenshot.hpp>
@@ -435,8 +436,14 @@ int main(int argc, char* argv[]) {
     }
 #endif
 
-    // Inspector was set up before screenshot_only check above.
+    // Inspector overlay was set up before screenshot_only check above.
     // Cmd+I toggle is handled by the platform WindowHost key dispatch.
+
+    // Floating inspector window (separate OS window with TreeView + PropertyList)
+    auto inspector_win = std::make_unique<pulp::view::InspectorWindow>(root, nullptr, window.get());
+    inspector_win->install_keyboard_shortcut();
+    if (pulp::runtime::get_env("PULP_INSPECTOR"))
+        inspector_win->show();
 
     std::cout << "Opening window... (Cmd+I for inspector)\n";
     window->run_event_loop();


### PR DESCRIPTION
## Summary
The inspector now opens as a separate floating window alongside the plugin (Chrome DevTools / Melatonin style) instead of an overlay panel inside the plugin window.

### New: InspectorWindow
- Cmd+I opens a floating inspector window next to the plugin
- Built with real Pulp widgets: TreeView (hierarchy), PropertyList (properties), SplitView (layout)
- InspectorHighlight overlay on the plugin shows selected view bounds
- Plugin window interaction is unaffected when inspector is open
- Hide-on-close (preserves state across toggles)
- Uses existing WindowManager/WindowType::inspector infrastructure

### New: ViewInspector helpers
- `populate_tree()` — builds TreeNode hierarchy from View tree
- `view_properties()` — extracts structured property data for PropertyList
- `absolute_bounds()` — computes root-space bounds

### New: View::on_global_key
- Root-level keyboard shortcut hook (checked before focused-view dispatch)
- Enables Cmd+I and future global shortcuts without platform code changes

Also includes MSVC portability fix (#include <algorithm> across 16 files).

## Test plan
- [x] All 2,024 tests pass
- [x] Build clean on macOS
- [x] Headless screenshot renders correctly
- [ ] Cross-platform CI