### PR TITLE
Inspector: tabs, smart positioning, cursor types, highlight sync

### DIFF
--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -255,6 +255,7 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     // Create inspector overlay — activated via Cmd+I / Ctrl+I
     auto inspector = std::make_unique<inspect::InspectorOverlay>(*tab_panel);
     auto* inspector_ptr = inspector.get();
+    inspect::install_inspector_hooks(*inspector);
 
     // Wire inspector into the idle callback to push overlay paint each frame.
     // The inspector uses View::overlay_queue() for rendering and intercepts

--- a/core/runtime/src/primes.cpp
+++ b/core/runtime/src/primes.cpp
@@ -4,12 +4,20 @@
 
 // MSVC doesn't support __uint128_t. Use a portable multiply-mod helper.
 #ifdef _MSC_VER
+static uint64_t addmod(uint64_t a, uint64_t b, uint64_t m) {
+    // Guard against uint64_t overflow: if a + b would wrap, subtract m first.
+    // Since a < m and b < m, (a - (m - b)) is the correct reduced result.
+    if (a >= m - b)
+        return a - (m - b);
+    return a + b;
+}
+
 static uint64_t mulmod(uint64_t a, uint64_t b, uint64_t m) {
     uint64_t result = 0;
     a %= m;
     while (b > 0) {
-        if (b & 1) result = (result + a) % m;
-        a = (a * 2) % m;
+        if (b & 1) result = addmod(result, a, m);
+        a = addmod(a, a, m);
         b >>= 1;
     }
     return result;

--- a/core/view/include/pulp/view/tree_view.hpp
+++ b/core/view/include/pulp/view/tree_view.hpp
@@ -98,15 +98,17 @@ public:
 
         float y = event.position.y + scroll_offset_;
         float current_y = 0;
-        TreeNode* hit = find_node_at_y(root_, -1, current_y, y);
+        int hit_depth = 0;
+        TreeNode* hit = find_node_at_y(root_, -1, current_y, y, &hit_depth);
 
         if (hit) {
             if (event.click_count == 2) {
                 if (on_activate) on_activate(*hit);
             } else {
-                // Check if click is on the expand triangle
-                // (simplified: clicking anywhere toggles if has children)
-                if (hit->has_children() && event.position.x < indent_ * 2) {
+                // Check if click is on the expand triangle area
+                float indent_x = static_cast<float>(hit_depth) * indent_;
+                float triangle_end = indent_x + indent_;
+                if (hit->has_children() && event.position.x < triangle_end) {
                     hit->toggle();
                     if (on_toggle) on_toggle(*hit, hit->expanded);
                 } else {
@@ -142,6 +144,8 @@ private:
     float indent_ = 18.0f;
     float scroll_offset_ = 0.0f;
 
+    static constexpr float kTriangleWidth = 16.0f; ///< Space reserved for the disclosure triangle
+
     void paint_node(canvas::Canvas& canvas, TreeNode& node, int depth,
                     float x, float& y, float width) {
         if (depth >= 0) { // Don't paint the invisible root
@@ -158,7 +162,7 @@ private:
             if (node.has_children()) {
                 canvas.set_fill_color(resolve_color("text_muted",
                     canvas::Color::hex(0x808090)));
-                float tx = indent_x + 4;
+                float tx = indent_x + 2;
                 float ty = y + row_height_ / 2;
                 if (node.expanded) {
                     // Down-pointing triangle
@@ -168,11 +172,12 @@ private:
                 }
             }
 
-            // Label
+            // Label — offset past the triangle area to prevent overlap
+            float label_x = indent_x + kTriangleWidth;
             canvas.set_font("system", 13);
             canvas.set_fill_color(resolve_color("text",
                 canvas::Color::hex(0xe0e0e0)));
-            canvas.fill_text(node.label, indent_x + indent_, y + row_height_ * 0.7f);
+            canvas.fill_text(node.label, label_x, y + row_height_ * 0.7f);
 
             y += row_height_;
         }
@@ -184,9 +189,11 @@ private:
         }
     }
 
-    TreeNode* find_node_at_y(TreeNode& node, int depth, float& current_y, float target_y) {
+    TreeNode* find_node_at_y(TreeNode& node, int depth, float& current_y, float target_y,
+                             int* out_depth = nullptr) {
         if (depth >= 0) {
             if (target_y >= current_y && target_y < current_y + row_height_) {
+                if (out_depth) *out_depth = depth;
                 return &node;
             }
             current_y += row_height_;
@@ -194,7 +201,7 @@ private:
 
         if (depth < 0 || node.expanded) {
             for (auto& child : node.children) {
-                auto* result = find_node_at_y(*child, depth + 1, current_y, target_y);
+                auto* result = find_node_at_y(*child, depth + 1, current_y, target_y, out_depth);
                 if (result) return result;
             }
         }

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -373,7 +373,17 @@ public:
     bool text_overflow_ellipsis() const { return text_ellipsis_; }
 
     /// Cursor style hint (CSS cursor property)
-    enum class CursorStyle { default_, pointer, crosshair, text, grab, grabbing, not_allowed };
+    enum class CursorStyle {
+        default_, pointer, crosshair, text, grab, grabbing, not_allowed,
+        invisible,                ///< Hidden cursor (custom drag, knob rotation)
+        horizontal_resize,        ///< ↔ Left-right resize (SplitView, column borders)
+        vertical_resize,          ///< ↕ Up-down resize (SplitView, row borders)
+        top_left_resize,          ///< ↖↘ Diagonal resize (NW-SE)
+        top_right_resize,         ///< ↗↙ Diagonal resize (NE-SW)
+        bottom_left_resize,       ///< ↗↙ Diagonal resize (alias for top_right)
+        bottom_right_resize,      ///< ↖↘ Diagonal resize (alias for top_left)
+        multi_directional_resize  ///< ✥ All-direction move/resize
+    };
     void set_cursor(CursorStyle c) { cursor_ = c; }
     CursorStyle cursor() const { return cursor_; }
 

--- a/core/view/include/pulp/view/window_host.hpp
+++ b/core/view/include/pulp/view/window_host.hpp
@@ -52,6 +52,10 @@ public:
     // Native host/window handles for embedding child platform views such as
     // WebViews. Default implementations return nullptr on platforms that do
     // not expose these seams yet.
+    /// Position this window alongside another window.
+    /// Places to the right if there's screen space, otherwise to the left.
+    virtual void position_beside(WindowHost* other) { (void)other; }
+
     virtual void* native_window_handle() const { return nullptr; }
     virtual void* native_content_view_handle() const { return nullptr; }
     virtual void* dawn_device_handle() const { return nullptr; }

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -706,6 +706,22 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                         [[NSCursor closedHandCursor] set]; break;
                     case pulp::view::View::CursorStyle::not_allowed:
                         [[NSCursor operationNotAllowedCursor] set]; break;
+                    case pulp::view::View::CursorStyle::invisible:
+                        [NSCursor hide]; break;
+                    case pulp::view::View::CursorStyle::horizontal_resize:
+                        [[NSCursor resizeLeftRightCursor] set]; break;
+                    case pulp::view::View::CursorStyle::vertical_resize:
+                        [[NSCursor resizeUpDownCursor] set]; break;
+                    case pulp::view::View::CursorStyle::top_left_resize:
+                    case pulp::view::View::CursorStyle::bottom_right_resize:
+                        // macOS doesn't have a diagonal NW-SE cursor — use crosshair
+                        [[NSCursor crosshairCursor] set]; break;
+                    case pulp::view::View::CursorStyle::top_right_resize:
+                    case pulp::view::View::CursorStyle::bottom_left_resize:
+                        // macOS doesn't have a diagonal NE-SW cursor — use crosshair
+                        [[NSCursor crosshairCursor] set]; break;
+                    case pulp::view::View::CursorStyle::multi_directional_resize:
+                        [[NSCursor openHandCursor] set]; break;
                     default:
                         [[NSCursor arrowCursor] set]; break;
                 }
@@ -1131,6 +1147,27 @@ public:
     void hide() override { [window_ orderOut:nil]; }
     bool is_visible() const override { return [window_ isVisible]; }
     void repaint() override { [view_ setNeedsDisplay:YES]; }
+
+    void position_beside(WindowHost* other) override {
+        if (!other) return;
+        auto* other_nswin = (__bridge NSWindow*)(other->native_window_handle());
+        if (!other_nswin || !window_) return;
+
+        auto other_frame = [other_nswin frame];
+        auto screen_frame = [[other_nswin screen] visibleFrame];
+        auto my_size = [window_ frame].size;
+
+        // Try right side first
+        CGFloat right_x = other_frame.origin.x + other_frame.size.width + 8;
+        if (right_x + my_size.width <= screen_frame.origin.x + screen_frame.size.width) {
+            [window_ setFrameOrigin:NSMakePoint(right_x, other_frame.origin.y)];
+        } else {
+            // Fall back to left side
+            CGFloat left_x = other_frame.origin.x - my_size.width - 8;
+            [window_ setFrameOrigin:NSMakePoint(std::max(left_x, screen_frame.origin.x), other_frame.origin.y)];
+        }
+    }
+
     void* native_window_handle() const override { return (__bridge void*) window_; }
     void* native_content_view_handle() const override { return (__bridge void*) view_; }
     bool attach_native_child_view(void* child_view,
@@ -1162,6 +1199,16 @@ public:
         delegate_.onClose = ^{ if (close_callback_) close_callback_(); };
     }
 
+    void set_idle_callback(std::function<void()> cb) override {
+        idle_callback_ = std::move(cb);
+        if (idle_callback_ && !idle_timer_) {
+            idle_timer_ = [NSTimer scheduledTimerWithTimeInterval:1.0/30.0
+                repeats:YES block:^(NSTimer*) {
+                    if (idle_callback_) idle_callback_();
+                }];
+        }
+    }
+
     void run_event_loop() override {
         @autoreleasepool {
             [NSApplication sharedApplication];
@@ -1179,7 +1226,9 @@ private:
     NSWindow* window_ = nil;
     PulpView* view_ = nil;
     PulpWindowDelegate* delegate_ = nil;
+    NSTimer* idle_timer_ = nil;
     std::function<void()> close_callback_;
+    std::function<void()> idle_callback_;
 };
 
 // ── MacGpuWindowHost (Dawn/Skia Graphite) ────────────────────────────────────
@@ -1242,6 +1291,23 @@ public:
     void show() override { [window_ makeKeyAndOrderFront:nil]; }
     void hide() override { [window_ orderOut:nil]; }
     bool is_visible() const override { return [window_ isVisible]; }
+
+    void position_beside(WindowHost* other) override {
+        if (!other) return;
+        auto* other_nswin = (__bridge NSWindow*)(other->native_window_handle());
+        if (!other_nswin || !window_) return;
+        auto other_frame = [other_nswin frame];
+        auto screen_frame = [[other_nswin screen] visibleFrame];
+        auto my_size = [window_ frame].size;
+        CGFloat right_x = other_frame.origin.x + other_frame.size.width + 8;
+        if (right_x + my_size.width <= screen_frame.origin.x + screen_frame.size.width) {
+            [window_ setFrameOrigin:NSMakePoint(right_x, other_frame.origin.y)];
+        } else {
+            CGFloat left_x = other_frame.origin.x - my_size.width - 8;
+            [window_ setFrameOrigin:NSMakePoint(std::max(left_x, screen_frame.origin.x), other_frame.origin.y)];
+        }
+    }
+
     void* native_window_handle() const override { return (__bridge void*) window_; }
     void* native_content_view_handle() const override { return (__bridge void*) metal_view_; }
     void* dawn_device_handle() const override {

--- a/examples/ui-preview/main.cpp
+++ b/examples/ui-preview/main.cpp
@@ -8,8 +8,8 @@
 #include <pulp/view/theme.hpp>
 #include <pulp/view/frame_clock.hpp>
 #include <pulp/view/inspector.hpp>
-#include <pulp/view/inspector_window.hpp>
 #include <pulp/inspect/inspector_overlay.hpp>
+#include <pulp/inspect/inspector_window.hpp>
 #include <pulp/runtime/system.hpp>
 #include <pulp/view/screenshot.hpp>
 #include <pulp/view/script_engine.hpp>
@@ -436,14 +436,83 @@ int main(int argc, char* argv[]) {
     }
 #endif
 
-    // Inspector overlay was set up before screenshot_only check above.
-    // Cmd+I toggle is handled by the platform WindowHost key dispatch.
+    // Inspector: open a separate floating window when Cmd+I is pressed
+    std::unique_ptr<WindowHost> inspector_window;
+    auto inspector_view = std::make_unique<pulp::inspect::InspectorWindow>(root);
+    auto* inspector_view_ptr = inspector_view.get();
+    View* inspector_selected = nullptr;
 
-    // Floating inspector window (separate OS window with TreeView + PropertyList)
-    auto inspector_win = std::make_unique<pulp::view::InspectorWindow>(root, nullptr, window.get());
-    inspector_win->install_keyboard_shortcut();
-    if (pulp::runtime::get_env("PULP_INSPECTOR"))
-        inspector_win->show();
+    auto open_inspector = [&]() {
+        if (inspector_window) return;
+        WindowOptions iopts;
+        iopts.title = "Inspector";
+        iopts.width = 340;
+        iopts.height = static_cast<float>(opts.height);
+        iopts.resizable = true;
+        iopts.use_gpu = false;
+        inspector_window = WindowHost::create(*inspector_view_ptr, iopts);
+        if (inspector_window) {
+            inspector_window->set_close_callback([&] { inspector_window.reset(); });
+            inspector_window->show();
+            inspector_window->position_beside(window.get());
+            inspector_view_ptr->refresh();
+        }
+    };
+
+    View::set_inspector_key_hook([&](const KeyEvent& e) -> bool {
+        if (e.is_down && e.key == KeyCode::i && e.isMainModifier()) {
+            if (!inspector_window) open_inspector();
+            else { inspector_window.reset(); inspector_selected = nullptr; }
+            return true;
+        }
+        return false;
+    });
+
+    View::set_inspector_mouse_hook([&](const MouseEvent& e) -> bool {
+        if (!inspector_window) return false;
+        if (e.is_down && e.isMainModifier()) {
+            auto* hit = root.hit_test(e.position);
+            if (hit) {
+                inspector_selected = hit;
+                inspector_view_ptr->select_view(hit);
+                if (inspector_window) inspector_window->repaint();
+                if (window) window->repaint();
+            }
+            return true;
+        }
+        return false;
+    });
+
+    inspector_view_ptr->on_view_selected = [&](View* view) {
+        inspector_selected = view;
+        if (window) window->repaint();
+    };
+
+    bool plugin_painting = false;
+    View::set_inspector_paint_hook([&](pulp::canvas::Canvas& canvas) {
+        if (!inspector_selected || !inspector_window || !plugin_painting) return;
+        plugin_painting = false;
+        float x = 0, y = 0;
+        const View* cur = inspector_selected;
+        while (cur && cur != &root) { x += cur->bounds().x; y += cur->bounds().y; cur = cur->parent(); }
+        float w = inspector_selected->bounds().width, h = inspector_selected->bounds().height;
+        canvas.set_fill_color(pulp::canvas::Color::rgba(0.25f, 0.5f, 1.0f, 0.15f));
+        canvas.fill_rect(x, y, w, h);
+        canvas.set_stroke_color(pulp::canvas::Color::rgba(0.25f, 0.5f, 1.0f, 0.8f));
+        canvas.set_line_width(2.0f);
+        canvas.stroke_rect(x, y, w, h);
+    });
+
+    window->set_idle_callback([&] {
+        if (inspector_window) {
+            plugin_painting = true;
+            window->repaint();
+            inspector_view_ptr->refresh();
+            inspector_window->repaint();
+        }
+    });
+
+    if (pulp::runtime::get_env("PULP_INSPECTOR")) open_inspector();
 
     std::cout << "Opening window... (Cmd+I for inspector)\n";
     window->run_event_loop();

--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(pulp-inspect
 
 target_sources(pulp-inspect PRIVATE
     src/inspector_overlay.cpp
+    src/inspector_window.cpp
     src/state_inspector.cpp
     src/console_capture.cpp
     src/protocol.cpp

--- a/inspect/include/pulp/inspect/inspector_window.hpp
+++ b/inspect/include/pulp/inspect/inspector_window.hpp
@@ -70,6 +70,7 @@ private:
 class InspectorWindow : public View {
 public:
     InspectorWindow();
+    ~InspectorWindow();
 
     /// Convenience: construct and immediately set the inspected root.
     explicit InspectorWindow(View& root);

--- a/inspect/include/pulp/inspect/inspector_window.hpp
+++ b/inspect/include/pulp/inspect/inspector_window.hpp
@@ -93,6 +93,9 @@ public:
     /// Called when a view is selected in the tree.
     std::function<void(View* view)> on_view_selected;
 
+    /// Select a view from external code (e.g., Cmd+click in plugin window)
+    void select_view(View* view);
+
 private:
     // ── Tab construction ────────────────────────────────────────────
     std::unique_ptr<View> build_elements_tab();

--- a/inspect/include/pulp/inspect/inspector_window.hpp
+++ b/inspect/include/pulp/inspect/inspector_window.hpp
@@ -1,0 +1,172 @@
+// inspector_window.hpp — Tabbed inspector window with collapsable property panels
+#pragma once
+
+#include <pulp/view/view.hpp>
+#include <pulp/view/widgets.hpp>
+#include <pulp/view/ui_components.hpp>
+#include <pulp/view/tree_view.hpp>
+#include <pulp/view/inspector.hpp>
+#include <pulp/inspect/console_capture.hpp>
+#include <pulp/inspect/state_inspector.hpp>
+#include <pulp/render/render_pass.hpp>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pulp::inspect {
+
+using namespace pulp::view;
+using namespace pulp::canvas;
+
+// ── CollapsableSection ─────────────────────────────────────────────────────
+/// A disclosure-triangle section: click header to expand/collapse content.
+
+class CollapsableSection : public View {
+public:
+    CollapsableSection(std::string title, bool initially_expanded = true);
+
+    bool is_expanded() const { return expanded_; }
+    void set_expanded(bool e);
+
+    /// The content container — add children here.
+    View* content() const { return content_; }
+
+    void paint(canvas::Canvas& canvas) override;
+    void on_mouse_event(const MouseEvent& event) override;
+
+private:
+    std::string title_;
+    bool expanded_;
+    View* header_ = nullptr;   // owned as child
+    View* content_ = nullptr;  // owned as child
+
+    static constexpr float kHeaderHeight = 24.0f;
+};
+
+// ── ConsoleEntry (visual row) ──────────────────────────────────────────────
+
+/// Displays a single console log entry with colored level badge and timestamp.
+class ConsoleEntryView : public View {
+public:
+    void set_entry(const ConsoleCapture::Entry& entry);
+
+    void paint(canvas::Canvas& canvas) override;
+
+    float intrinsic_height() const override { return 22.0f; }
+
+private:
+    std::string level_;
+    std::string message_;
+    std::string timestamp_;
+};
+
+// ── InspectorWindow ────────────────────────────────────────────────────────
+/// Main tabbed inspector panel with four tabs:
+///   Elements | Console | Performance | State
+
+class InspectorWindow : public View {
+public:
+    InspectorWindow();
+
+    /// Convenience: construct and immediately set the inspected root.
+    explicit InspectorWindow(View& root);
+
+    // ── Data sources ────────────────────────────────────────────────
+    /// Set the root view to inspect (Elements tab).
+    void set_inspected_root(View* root);
+
+    /// Set the console capture for the Console tab.
+    void set_console_capture(ConsoleCapture* capture) { console_capture_ = capture; }
+
+    /// Set the render pass manager for the Performance tab.
+    void set_render_pass_manager(render::RenderPassManager* rpm) { rpm_ = rpm; }
+
+    /// Set the state inspector for the State tab.
+    void set_state_inspector(StateInspector* si) { state_inspector_ = si; }
+
+    /// Refresh all tabs with latest data. Call once per frame.
+    void refresh();
+
+    /// Called when a view is selected in the tree.
+    std::function<void(View* view)> on_view_selected;
+
+private:
+    // ── Tab construction ────────────────────────────────────────────
+    std::unique_ptr<View> build_elements_tab();
+    std::unique_ptr<View> build_console_tab();
+    std::unique_ptr<View> build_performance_tab();
+    std::unique_ptr<View> build_state_tab();
+
+    // ── Refresh helpers ─────────────────────────────────────────────
+    void refresh_elements();
+    void refresh_console();
+    void refresh_performance();
+    void refresh_state();
+
+    void populate_tree_from_view(TreeNode& parent, View* view);
+    void show_properties_for(View* view);
+
+    // ── Data sources ────────────────────────────────────────────────
+    View* inspected_root_ = nullptr;
+    ConsoleCapture* console_capture_ = nullptr;
+    render::RenderPassManager* rpm_ = nullptr;
+    StateInspector* state_inspector_ = nullptr;
+
+    // ── Widgets (non-owning, owned as children) ─────────────────────
+    TabPanel* tabs_ = nullptr;
+
+    // Elements tab
+    TreeView* tree_view_ = nullptr;
+    CollapsableSection* identity_section_ = nullptr;
+    CollapsableSection* layout_section_ = nullptr;
+    CollapsableSection* visual_section_ = nullptr;
+    CollapsableSection* widget_section_ = nullptr;
+    CollapsableSection* theme_section_ = nullptr;
+    View* elements_props_container_ = nullptr;
+
+    // Console tab
+    ScrollView* console_scroll_ = nullptr;
+    View* console_list_ = nullptr;
+
+    // Performance tab
+    Label* fps_label_ = nullptr;
+    Label* frame_time_label_ = nullptr;
+    Label* budget_label_ = nullptr;
+    View* pass_list_ = nullptr;
+    Label* view_count_label_ = nullptr;
+
+    // State tab
+    ScrollView* state_scroll_ = nullptr;
+    View* state_list_ = nullptr;
+
+    // Currently selected view (Elements tab)
+    View* selected_view_ = nullptr;
+
+    // Property labels (Elements tab, Identity section)
+    Label* prop_type_label_ = nullptr;
+    Label* prop_id_label_ = nullptr;
+
+    // Layout section labels
+    Label* prop_bounds_label_ = nullptr;
+    Label* prop_direction_label_ = nullptr;
+    Label* prop_gap_label_ = nullptr;
+    Label* prop_padding_label_ = nullptr;
+    Label* prop_margin_label_ = nullptr;
+    Label* prop_grow_shrink_label_ = nullptr;
+
+    // Visual section labels
+    Label* prop_opacity_label_ = nullptr;
+    Label* prop_bgcolor_label_ = nullptr;
+    Label* prop_border_label_ = nullptr;
+    Label* prop_corner_label_ = nullptr;
+    Label* prop_visible_label_ = nullptr;
+    Label* prop_enabled_label_ = nullptr;
+
+    // Widget section labels
+    Label* prop_widget_value_label_ = nullptr;
+};
+
+} // namespace pulp::inspect

--- a/inspect/src/inspector_window.cpp
+++ b/inspect/src/inspector_window.cpp
@@ -160,6 +160,15 @@ void ConsoleEntryView::paint(canvas::Canvas& canvas) {
 
 // ── InspectorWindow ────────────────────────────────────────────────────────
 
+InspectorWindow::~InspectorWindow() {
+    // Clear callbacks that capture pointers to our members to prevent
+    // dangling references if the root view outlives this window.
+    on_view_selected = nullptr;
+    if (tree_view_) tree_view_->on_select = nullptr;
+    if (tree_view_) tree_view_->on_activate = nullptr;
+    inspected_root_ = nullptr;
+}
+
 InspectorWindow::InspectorWindow(View& root) : InspectorWindow() {
     set_inspected_root(&root);
 }

--- a/inspect/src/inspector_window.cpp
+++ b/inspect/src/inspector_window.cpp
@@ -537,6 +537,11 @@ void InspectorWindow::populate_tree_from_view(TreeNode& parent, View* view) {
     }
 }
 
+void InspectorWindow::select_view(View* view) {
+    show_properties_for(view);
+    if (on_view_selected) on_view_selected(view);
+}
+
 void InspectorWindow::show_properties_for(View* view) {
     if (!view) return;
 

--- a/inspect/src/inspector_window.cpp
+++ b/inspect/src/inspector_window.cpp
@@ -1,0 +1,753 @@
+// inspector_window.cpp — Tabbed inspector window implementation
+#include <pulp/inspect/inspector_window.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <sstream>
+
+namespace pulp::inspect {
+
+// ── Color constants for the inspector chrome ────────────────────────────────
+static const Color kBgDark       = Color::rgba8(24, 24, 32);
+static const Color kBgPanel      = Color::rgba8(30, 30, 42);
+static const Color kBgSection    = Color::rgba8(36, 36, 50);
+static const Color kTextPrimary  = Color::rgba8(220, 220, 230);
+static const Color kTextMuted    = Color::rgba8(140, 140, 160);
+static const Color kBorder       = Color::rgba8(60, 60, 80);
+
+static const Color kLogColor     = Color::rgba8(180, 180, 200);
+static const Color kWarnColor    = Color::rgba8(255, 200, 60);
+static const Color kErrorColor   = Color::rgba8(255, 80, 80);
+static const Color kInfoColor    = Color::rgba8(80, 180, 255);
+static const Color kDebugColor   = Color::rgba8(120, 220, 120);
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+static std::string format_float(float v, int decimals = 1) {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.*f", decimals, static_cast<double>(v));
+    return buf;
+}
+
+static std::string format_rect(const Rect& r) {
+    return format_float(r.x, 0) + ", " + format_float(r.y, 0)
+         + "  " + format_float(r.width, 0) + " x " + format_float(r.height, 0);
+}
+
+static std::string bool_str(bool v) { return v ? "true" : "false"; }
+
+static std::string direction_str(FlexDirection d) {
+    return d == FlexDirection::row ? "row" : "column";
+}
+
+/// Create a styled property row: "key: value"
+static std::unique_ptr<Label> make_prop_label(const std::string& text, float font_size = 11.0f) {
+    auto lbl = std::make_unique<Label>(text);
+    lbl->set_font_size(font_size);
+    lbl->flex().preferred_height = 18;
+    lbl->flex().flex_shrink = 0;
+    return lbl;
+}
+
+// ── CollapsableSection ─────────────────────────────────────────────────────
+
+CollapsableSection::CollapsableSection(std::string title, bool initially_expanded)
+    : title_(std::move(title)), expanded_(initially_expanded)
+{
+    flex().direction = FlexDirection::column;
+    flex().flex_shrink = 0;
+
+    // Header
+    auto hdr = std::make_unique<View>();
+    hdr->flex().preferred_height = kHeaderHeight;
+    hdr->flex().flex_shrink = 0;
+    hdr->set_background_color(kBgSection);
+    header_ = hdr.get();
+    add_child(std::move(hdr));
+
+    // Content container
+    auto cnt = std::make_unique<View>();
+    cnt->flex().direction = FlexDirection::column;
+    cnt->flex().padding = 6;
+    cnt->flex().gap = 2;
+    cnt->flex().flex_shrink = 0;
+    cnt->set_visible(expanded_);
+    content_ = cnt.get();
+    add_child(std::move(cnt));
+}
+
+void CollapsableSection::set_expanded(bool e) {
+    expanded_ = e;
+    if (content_) content_->set_visible(expanded_);
+}
+
+void CollapsableSection::paint(canvas::Canvas& canvas) {
+    // Paint header with disclosure triangle and title
+    if (!header_) return;
+    auto b = header_->bounds();
+
+    // Disclosure triangle
+    canvas.set_font("system", 10);
+    canvas.set_fill_color(kTextMuted);
+    const char* arrow = expanded_ ? "\xe2\x96\xbe" : "\xe2\x96\xb8"; // ▾ or ▸
+    canvas.fill_text(arrow, b.x + 8, b.y + b.height * 0.5f + 4);
+
+    // Title
+    canvas.set_font("system", 11);
+    canvas.set_fill_color(kTextPrimary);
+    canvas.fill_text(title_, b.x + 22, b.y + b.height * 0.5f + 4);
+
+    // Bottom border
+    canvas.set_fill_color(kBorder);
+    canvas.fill_rect(b.x, b.bottom() - 1, b.width, 1);
+}
+
+void CollapsableSection::on_mouse_event(const MouseEvent& event) {
+    if (!event.is_down) return;
+    if (!header_) return;
+
+    // Click on header toggles
+    if (event.position.y < kHeaderHeight) {
+        set_expanded(!expanded_);
+    }
+}
+
+// ── ConsoleEntryView ───────────────────────────────────────────────────────
+
+void ConsoleEntryView::set_entry(const ConsoleCapture::Entry& entry) {
+    level_ = entry.level;
+    message_ = entry.message;
+
+    // Format timestamp as seconds since epoch (simple)
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        entry.time.time_since_epoch()).count();
+    auto secs = ms / 1000;
+    auto frac = ms % 1000;
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%lld.%03lld",
+                  static_cast<long long>(secs % 100000),
+                  static_cast<long long>(frac));
+    timestamp_ = buf;
+}
+
+void ConsoleEntryView::paint(canvas::Canvas& canvas) {
+    auto b = local_bounds();
+
+    // Level badge color
+    Color badge_color = kLogColor;
+    if (level_ == "warn")       badge_color = kWarnColor;
+    else if (level_ == "error") badge_color = kErrorColor;
+    else if (level_ == "info")  badge_color = kInfoColor;
+    else if (level_ == "debug") badge_color = kDebugColor;
+
+    // Level badge
+    canvas.set_font("system", 9);
+    canvas.set_fill_color(badge_color.with_alpha(0.2f));
+    canvas.fill_rect(b.x + 4, b.y + 3, 36, 16);
+    canvas.set_fill_color(badge_color);
+    canvas.fill_text(level_, b.x + 8, b.y + 15);
+
+    // Timestamp
+    canvas.set_font("system", 9);
+    canvas.set_fill_color(kTextMuted);
+    canvas.fill_text(timestamp_, b.x + 46, b.y + 15);
+
+    // Message
+    canvas.set_font("system", 11);
+    canvas.set_fill_color(kTextPrimary);
+    canvas.fill_text(message_, b.x + 100, b.y + 15);
+}
+
+// ── InspectorWindow ────────────────────────────────────────────────────────
+
+InspectorWindow::InspectorWindow(View& root) : InspectorWindow() {
+    set_inspected_root(&root);
+}
+
+InspectorWindow::InspectorWindow() {
+    flex().direction = FlexDirection::column;
+    flex().flex_grow = 1;
+    set_background_color(kBgDark);
+
+    auto tab_panel = std::make_unique<TabPanel>();
+    tabs_ = tab_panel.get();
+
+    tab_panel->add_tab("Elements", build_elements_tab());
+    tab_panel->add_tab("Console", build_console_tab());
+    tab_panel->add_tab("Performance", build_performance_tab());
+    tab_panel->add_tab("State", build_state_tab());
+
+    tab_panel->set_active_tab(0);
+    tab_panel->flex().flex_grow = 1;
+
+    add_child(std::move(tab_panel));
+}
+
+// ── Elements tab ────────────────────────────────────────────────────────────
+
+std::unique_ptr<View> InspectorWindow::build_elements_tab() {
+    auto root = std::make_unique<View>();
+    root->flex().direction = FlexDirection::column;
+    root->flex().flex_grow = 1;
+
+    // TreeView (top half — view hierarchy)
+    auto tree = std::make_unique<TreeView>();
+    tree->flex().preferred_height = 200;
+    tree->flex().flex_shrink = 0;
+    tree->set_background_color(kBgPanel);
+    tree->on_select = [this](TreeNode& node) {
+        if (node.user_data) {
+            selected_view_ = static_cast<View*>(node.user_data);
+            show_properties_for(selected_view_);
+            if (on_view_selected) on_view_selected(selected_view_);
+        }
+    };
+    tree_view_ = tree.get();
+    root->add_child(std::move(tree));
+
+    // Scrollable property sections below the tree
+    auto scroll = std::make_unique<ScrollView>();
+    scroll->flex().flex_grow = 1;
+    scroll->set_direction(ScrollView::Direction::vertical);
+
+    auto props = std::make_unique<View>();
+    props->flex().direction = FlexDirection::column;
+    props->flex().flex_shrink = 0;
+    elements_props_container_ = props.get();
+
+    // Identity section
+    {
+        auto section = std::make_unique<CollapsableSection>("Identity");
+        auto* content = section->content();
+        auto type_lbl = make_prop_label("Type: —");
+        prop_type_label_ = type_lbl.get();
+        content->add_child(std::move(type_lbl));
+        auto id_lbl = make_prop_label("ID: —");
+        prop_id_label_ = id_lbl.get();
+        content->add_child(std::move(id_lbl));
+        identity_section_ = section.get();
+        props->add_child(std::move(section));
+    }
+
+    // Layout section
+    {
+        auto section = std::make_unique<CollapsableSection>("Layout");
+        auto* content = section->content();
+
+        auto bounds_lbl = make_prop_label("Bounds: —");
+        prop_bounds_label_ = bounds_lbl.get();
+        content->add_child(std::move(bounds_lbl));
+
+        auto dir_lbl = make_prop_label("Direction: —");
+        prop_direction_label_ = dir_lbl.get();
+        content->add_child(std::move(dir_lbl));
+
+        auto gap_lbl = make_prop_label("Gap: —");
+        prop_gap_label_ = gap_lbl.get();
+        content->add_child(std::move(gap_lbl));
+
+        auto pad_lbl = make_prop_label("Padding: —");
+        prop_padding_label_ = pad_lbl.get();
+        content->add_child(std::move(pad_lbl));
+
+        auto margin_lbl = make_prop_label("Margin: —");
+        prop_margin_label_ = margin_lbl.get();
+        content->add_child(std::move(margin_lbl));
+
+        auto gs_lbl = make_prop_label("Grow/Shrink: —");
+        prop_grow_shrink_label_ = gs_lbl.get();
+        content->add_child(std::move(gs_lbl));
+
+        layout_section_ = section.get();
+        props->add_child(std::move(section));
+    }
+
+    // Visual section
+    {
+        auto section = std::make_unique<CollapsableSection>("Visual");
+        auto* content = section->content();
+
+        auto opacity_lbl = make_prop_label("Opacity: —");
+        prop_opacity_label_ = opacity_lbl.get();
+        content->add_child(std::move(opacity_lbl));
+
+        auto bg_lbl = make_prop_label("Background: —");
+        prop_bgcolor_label_ = bg_lbl.get();
+        content->add_child(std::move(bg_lbl));
+
+        auto border_lbl = make_prop_label("Border: —");
+        prop_border_label_ = border_lbl.get();
+        content->add_child(std::move(border_lbl));
+
+        auto corner_lbl = make_prop_label("Corner radius: —");
+        prop_corner_label_ = corner_lbl.get();
+        content->add_child(std::move(corner_lbl));
+
+        auto vis_lbl = make_prop_label("Visible: —");
+        prop_visible_label_ = vis_lbl.get();
+        content->add_child(std::move(vis_lbl));
+
+        auto en_lbl = make_prop_label("Enabled: —");
+        prop_enabled_label_ = en_lbl.get();
+        content->add_child(std::move(en_lbl));
+
+        visual_section_ = section.get();
+        props->add_child(std::move(section));
+    }
+
+    // Widget section (hidden by default — shown only for typed widgets)
+    {
+        auto section = std::make_unique<CollapsableSection>("Widget");
+        auto* content = section->content();
+
+        auto val_lbl = make_prop_label("Value: —");
+        prop_widget_value_label_ = val_lbl.get();
+        content->add_child(std::move(val_lbl));
+
+        section->set_visible(false);
+        widget_section_ = section.get();
+        props->add_child(std::move(section));
+    }
+
+    // Theme Colors section
+    {
+        auto section = std::make_unique<CollapsableSection>("Theme Colors", false);
+        theme_section_ = section.get();
+        props->add_child(std::move(section));
+    }
+
+    scroll->set_content_size({300, 600});
+    scroll->add_child(std::move(props));
+    root->add_child(std::move(scroll));
+
+    return root;
+}
+
+// ── Console tab ─────────────────────────────────────────────────────────────
+
+std::unique_ptr<View> InspectorWindow::build_console_tab() {
+    auto root = std::make_unique<View>();
+    root->flex().direction = FlexDirection::column;
+    root->flex().flex_grow = 1;
+    root->set_background_color(kBgPanel);
+
+    // Header bar
+    auto header = std::make_unique<View>();
+    header->flex().direction = FlexDirection::row;
+    header->flex().preferred_height = 28;
+    header->flex().flex_shrink = 0;
+    header->flex().padding = 4;
+    header->set_background_color(kBgSection);
+
+    auto title = std::make_unique<Label>("Console Output");
+    title->set_font_size(11);
+    title->flex().flex_grow = 1;
+    header->add_child(std::move(title));
+
+    root->add_child(std::move(header));
+
+    // Scrolling log list
+    auto scroll = std::make_unique<ScrollView>();
+    scroll->flex().flex_grow = 1;
+    scroll->set_direction(ScrollView::Direction::vertical);
+    console_scroll_ = scroll.get();
+
+    auto list = std::make_unique<View>();
+    list->flex().direction = FlexDirection::column;
+    list->flex().flex_shrink = 0;
+    console_list_ = list.get();
+    scroll->add_child(std::move(list));
+
+    root->add_child(std::move(scroll));
+    return root;
+}
+
+// ── Performance tab ─────────────────────────────────────────────────────────
+
+std::unique_ptr<View> InspectorWindow::build_performance_tab() {
+    auto root = std::make_unique<View>();
+    root->flex().direction = FlexDirection::column;
+    root->flex().flex_grow = 1;
+    root->flex().padding = 8;
+    root->flex().gap = 4;
+    root->set_background_color(kBgPanel);
+
+    // FPS
+    auto fps = make_prop_label("FPS: —", 13);
+    fps_label_ = fps.get();
+    root->add_child(std::move(fps));
+
+    // Frame time
+    auto ft = make_prop_label("Frame time: —", 13);
+    frame_time_label_ = ft.get();
+    root->add_child(std::move(ft));
+
+    // Budget
+    auto bgt = make_prop_label("Budget: —", 13);
+    budget_label_ = bgt.get();
+    root->add_child(std::move(bgt));
+
+    // View count
+    auto vc = make_prop_label("View count: —", 13);
+    view_count_label_ = vc.get();
+    root->add_child(std::move(vc));
+
+    // Separator
+    auto sep = std::make_unique<View>();
+    sep->flex().preferred_height = 1;
+    sep->flex().flex_shrink = 0;
+    sep->set_background_color(kBorder);
+    root->add_child(std::move(sep));
+
+    // Pass breakdown header
+    auto ph = make_prop_label("Per-Pass Breakdown", 12);
+    root->add_child(std::move(ph));
+
+    // Pass list container
+    auto pl = std::make_unique<View>();
+    pl->flex().direction = FlexDirection::column;
+    pl->flex().gap = 2;
+    pl->flex().flex_shrink = 0;
+    pass_list_ = pl.get();
+    root->add_child(std::move(pl));
+
+    return root;
+}
+
+// ── State tab ───────────────────────────────────────────────────────────────
+
+std::unique_ptr<View> InspectorWindow::build_state_tab() {
+    auto root = std::make_unique<View>();
+    root->flex().direction = FlexDirection::column;
+    root->flex().flex_grow = 1;
+    root->set_background_color(kBgPanel);
+
+    // Header
+    auto header = std::make_unique<View>();
+    header->flex().direction = FlexDirection::row;
+    header->flex().preferred_height = 28;
+    header->flex().flex_shrink = 0;
+    header->flex().padding = 4;
+    header->set_background_color(kBgSection);
+
+    auto title = std::make_unique<Label>("Parameters");
+    title->set_font_size(11);
+    title->flex().flex_grow = 1;
+    header->add_child(std::move(title));
+    root->add_child(std::move(header));
+
+    // Scrolling param list
+    auto scroll = std::make_unique<ScrollView>();
+    scroll->flex().flex_grow = 1;
+    scroll->set_direction(ScrollView::Direction::vertical);
+    state_scroll_ = scroll.get();
+
+    auto list = std::make_unique<View>();
+    list->flex().direction = FlexDirection::column;
+    list->flex().flex_shrink = 0;
+    state_list_ = list.get();
+    scroll->add_child(std::move(list));
+
+    root->add_child(std::move(scroll));
+    return root;
+}
+
+// ── Data binding ────────────────────────────────────────────────────────────
+
+void InspectorWindow::set_inspected_root(View* root) {
+    inspected_root_ = root;
+    refresh_elements();
+}
+
+void InspectorWindow::refresh() {
+    if (tabs_) {
+        int active = tabs_->active_tab();
+        switch (active) {
+            case 0: refresh_elements(); break;
+            case 1: refresh_console(); break;
+            case 2: refresh_performance(); break;
+            case 3: refresh_state(); break;
+        }
+    }
+}
+
+// ── Elements refresh ────────────────────────────────────────────────────────
+
+void InspectorWindow::refresh_elements() {
+    if (!tree_view_ || !inspected_root_) return;
+
+    // Rebuild tree from inspected root
+    auto& root_node = tree_view_->root();
+    root_node.children.clear();
+    populate_tree_from_view(root_node, inspected_root_);
+    root_node.expanded = true;
+
+    // Refresh theme colors section
+    if (theme_section_ && inspected_root_) {
+        auto* content = theme_section_->content();
+        // Clear existing children: remove all by rebuilding
+        while (content->child_count() > 0) {
+            content->remove_child(content->child_at(0));
+        }
+
+        const auto& theme = inspected_root_->theme();
+        for (const auto& [name, color] : theme.colors) {
+            auto row = std::make_unique<View>();
+            row->flex().direction = FlexDirection::row;
+            row->flex().preferred_height = 18;
+            row->flex().flex_shrink = 0;
+            row->flex().gap = 6;
+
+            // Color swatch
+            auto swatch = std::make_unique<View>();
+            swatch->flex().preferred_width = 14;
+            swatch->flex().preferred_height = 14;
+            swatch->set_background_color(color);
+            swatch->set_border(kBorder, 1, 2);
+            row->add_child(std::move(swatch));
+
+            // Token name
+            auto lbl = make_prop_label(name, 10);
+            lbl->flex().flex_grow = 1;
+            row->add_child(std::move(lbl));
+
+            content->add_child(std::move(row));
+        }
+    }
+
+    // If we still have a selected view, update its properties
+    if (selected_view_) {
+        show_properties_for(selected_view_);
+    }
+}
+
+void InspectorWindow::populate_tree_from_view(TreeNode& parent, View* view) {
+    if (!view) return;
+
+    auto& node = parent.add_child(ViewInspector::type_name(*view));
+    node.user_data = view;
+    node.expanded = true;
+
+    if (!view->id().empty()) {
+        node.label += " #" + view->id();
+    }
+
+    for (size_t i = 0; i < view->child_count(); ++i) {
+        populate_tree_from_view(node, view->child_at(i));
+    }
+}
+
+void InspectorWindow::show_properties_for(View* view) {
+    if (!view) return;
+
+    // Identity
+    if (prop_type_label_)
+        prop_type_label_->set_text("Type: " + ViewInspector::type_name(*view));
+    if (prop_id_label_)
+        prop_id_label_->set_text("ID: " + (view->id().empty() ? "(none)" : view->id()));
+
+    // Layout
+    if (prop_bounds_label_)
+        prop_bounds_label_->set_text("Bounds: " + format_rect(view->bounds()));
+    if (prop_direction_label_)
+        prop_direction_label_->set_text("Direction: " + direction_str(view->flex().direction));
+    if (prop_gap_label_)
+        prop_gap_label_->set_text("Gap: " + format_float(view->flex().gap));
+    if (prop_padding_label_)
+        prop_padding_label_->set_text("Padding: " + format_float(view->flex().padding));
+    if (prop_margin_label_)
+        prop_margin_label_->set_text("Margin: " + format_float(view->flex().margin));
+    if (prop_grow_shrink_label_)
+        prop_grow_shrink_label_->set_text("Grow: " + format_float(view->flex().flex_grow)
+                                        + " / Shrink: " + format_float(view->flex().flex_shrink));
+
+    // Visual
+    if (prop_opacity_label_)
+        prop_opacity_label_->set_text("Opacity: " + format_float(view->opacity(), 2));
+    if (prop_bgcolor_label_) {
+        if (view->has_background_color()) {
+            auto c = view->background_color();
+            char buf[48];
+            std::snprintf(buf, sizeof(buf), "Background: rgba(%d, %d, %d, %.2f)",
+                         static_cast<int>(c.r * 255), static_cast<int>(c.g * 255),
+                         static_cast<int>(c.b * 255), static_cast<double>(c.a));
+            prop_bgcolor_label_->set_text(buf);
+        } else {
+            prop_bgcolor_label_->set_text("Background: none");
+        }
+    }
+    if (prop_border_label_) {
+        if (view->has_border()) {
+            prop_border_label_->set_text("Border: " + format_float(view->border_width()) + "px");
+        } else {
+            prop_border_label_->set_text("Border: none");
+        }
+    }
+    if (prop_corner_label_)
+        prop_corner_label_->set_text("Corner radius: " + format_float(view->corner_radius()));
+    if (prop_visible_label_)
+        prop_visible_label_->set_text("Visible: " + bool_str(view->visible()));
+    if (prop_enabled_label_)
+        prop_enabled_label_->set_text("Enabled: " + bool_str(view->enabled()));
+
+    // Widget section — show only for typed widgets
+    bool has_widget_props = false;
+    std::string widget_value;
+
+    if (auto* knob = dynamic_cast<Knob*>(view)) {
+        widget_value = "Value: " + format_float(knob->value(), 3);
+        if (!knob->label().empty()) widget_value += "  Label: " + knob->label();
+        has_widget_props = true;
+    } else if (auto* fader = dynamic_cast<Fader*>(view)) {
+        widget_value = "Value: " + format_float(fader->value(), 3);
+        if (!fader->label().empty()) widget_value += "  Label: " + fader->label();
+        has_widget_props = true;
+    } else if (auto* toggle = dynamic_cast<Toggle*>(view)) {
+        widget_value = "On: " + bool_str(toggle->is_on());
+        if (!toggle->label().empty()) widget_value += "  Label: " + toggle->label();
+        has_widget_props = true;
+    } else if (auto* label = dynamic_cast<Label*>(view)) {
+        widget_value = "Text: " + label->text();
+        has_widget_props = true;
+    } else if (auto* meter = dynamic_cast<Meter*>(view)) {
+        widget_value = "RMS: " + format_float(meter->display_rms(), 3)
+                     + "  Peak: " + format_float(meter->display_peak(), 3);
+        has_widget_props = true;
+    }
+
+    if (widget_section_) {
+        widget_section_->set_visible(has_widget_props);
+        if (has_widget_props && prop_widget_value_label_) {
+            prop_widget_value_label_->set_text(widget_value);
+        }
+    }
+}
+
+// ── Console refresh ─────────────────────────────────────────────────────────
+
+void InspectorWindow::refresh_console() {
+    if (!console_list_ || !console_capture_) return;
+
+    auto entries = console_capture_->entries();
+
+    // Clear existing
+    while (console_list_->child_count() > 0) {
+        console_list_->remove_child(console_list_->child_at(0));
+    }
+
+    for (const auto& entry : entries) {
+        auto row = std::make_unique<ConsoleEntryView>();
+        row->set_entry(entry);
+        row->flex().preferred_height = 22;
+        row->flex().flex_shrink = 0;
+        console_list_->add_child(std::move(row));
+    }
+
+    if (console_scroll_) {
+        console_scroll_->set_content_size({300, static_cast<float>(entries.size()) * 22.0f});
+    }
+}
+
+// ── Performance refresh ─────────────────────────────────────────────────────
+
+static const char* pass_type_name(render::RenderPassType t) {
+    switch (t) {
+        case render::RenderPassType::background:   return "background";
+        case render::RenderPassType::content:       return "content";
+        case render::RenderPassType::effects:       return "effects";
+        case render::RenderPassType::overlay:       return "overlay";
+        case render::RenderPassType::post_effects:  return "post_effects";
+    }
+    return "unknown";
+}
+
+void InspectorWindow::refresh_performance() {
+    if (!rpm_) {
+        if (fps_label_) fps_label_->set_text("FPS: (no data)");
+        return;
+    }
+
+    float total_ms = rpm_->total_time_ms();
+    float fps = total_ms > 0 ? 1000.0f / total_ms : 0.0f;
+
+    if (fps_label_)
+        fps_label_->set_text("FPS: " + format_float(fps, 1));
+    if (frame_time_label_)
+        frame_time_label_->set_text("Frame time: " + format_float(total_ms, 2) + " ms");
+    if (budget_label_) {
+        std::string btext = "Budget: " + format_float(rpm_->budget(), 1) + " ms";
+        if (rpm_->over_budget()) btext += "  [OVER BUDGET]";
+        budget_label_->set_text(btext);
+    }
+
+    // View count
+    if (view_count_label_ && inspected_root_) {
+        size_t count = ViewInspector::count_views(*inspected_root_);
+        view_count_label_->set_text("View count: " + std::to_string(count));
+    }
+
+    // Pass breakdown
+    if (pass_list_) {
+        while (pass_list_->child_count() > 0) {
+            pass_list_->remove_child(pass_list_->child_at(0));
+        }
+
+        for (const auto& pass : rpm_->passes()) {
+            std::string text = std::string(pass_type_name(pass.type))
+                             + ": " + format_float(pass.time_ms, 2) + " ms, "
+                             + std::to_string(pass.draw_calls) + " draws";
+            auto lbl = make_prop_label(text, 11);
+            pass_list_->add_child(std::move(lbl));
+        }
+    }
+}
+
+// ── State refresh ───────────────────────────────────────────────────────────
+
+void InspectorWindow::refresh_state() {
+    if (!state_list_ || !state_inspector_) return;
+
+    auto params = state_inspector_->all_params();
+
+    while (state_list_->child_count() > 0) {
+        state_list_->remove_child(state_list_->child_at(0));
+    }
+
+    for (const auto& p : params) {
+        auto row = std::make_unique<View>();
+        row->flex().direction = FlexDirection::column;
+        row->flex().preferred_height = 48;
+        row->flex().flex_shrink = 0;
+        row->flex().padding = 4;
+        row->set_background_color(kBgSection);
+
+        // Name + value
+        std::string line1 = p.name + ": " + format_float(p.value, 3);
+        if (!p.display_value.empty()) line1 += " (" + p.display_value + ")";
+        auto name_lbl = make_prop_label(line1, 11);
+        row->add_child(std::move(name_lbl));
+
+        // Range + unit
+        std::string line2 = "Range: [" + format_float(p.min, 2) + ", " + format_float(p.max, 2) + "]";
+        if (p.step > 0) line2 += " step=" + format_float(p.step, 3);
+        if (!p.unit.empty()) line2 += "  Unit: " + p.unit;
+        auto range_lbl = make_prop_label(line2, 10);
+        row->add_child(std::move(range_lbl));
+
+        // Bottom border
+        auto sep = std::make_unique<View>();
+        sep->flex().preferred_height = 1;
+        sep->flex().flex_shrink = 0;
+        sep->set_background_color(kBorder);
+
+        state_list_->add_child(std::move(row));
+        state_list_->add_child(std::move(sep));
+    }
+
+    if (state_scroll_) {
+        float total_height = static_cast<float>(params.size()) * 49.0f;
+        state_scroll_->set_content_size({300, total_height});
+    }
+}
+
+} // namespace pulp::inspect

--- a/tools/cli/cmd_dev.cpp
+++ b/tools/cli/cmd_dev.cpp
@@ -75,7 +75,7 @@ int cmd_dev(const std::vector<std::string>& args) {
 
             // Find design binary
             std::vector<fs::path> candidates = {
-                platform_executable(build_dir / "tools" / "design" / "pulp-design"),
+                platform_executable(build_dir / "tools" / "design" / "pulp-design-tool"),
                 platform_executable(build_dir / "examples" / "design-tool" / "pulp-design-tool"),
             };
             for (const auto& c : candidates) {
@@ -83,7 +83,7 @@ int cmd_dev(const std::vector<std::string>& args) {
             }
             if (launch_target.empty()) {
                 // Will be found after first build
-                launch_target = (build_dir / "tools" / "design" / "pulp-design").string();
+                launch_target = (build_dir / "tools" / "design" / "pulp-design-tool").string();
             }
             launch_args.insert(launch_args.begin(), script);
         } else if (args[i] == "--target" && i + 1 < args.size()) {

--- a/tools/cli/cmd_inspect.cpp
+++ b/tools/cli/cmd_inspect.cpp
@@ -102,6 +102,7 @@ int cmd_inspect(const std::vector<std::string>& args) {
     std::string host = "127.0.0.1";
     int port = 0;
     std::string one_shot_command;
+    std::string one_shot_params = "{}";
     std::string output_file;
 
     for (size_t i = 0; i < args.size(); ++i) {
@@ -112,6 +113,7 @@ int cmd_inspect(const std::vector<std::string>& args) {
             std::cout << "  --host HOST       Connect to HOST (default: 127.0.0.1)\n";
             std::cout << "  --port PORT       Connect to PORT (default: auto-discover)\n";
             std::cout << "  --command METHOD  Send one command and print result\n";
+            std::cout << "  --params JSON     JSON params for --command (default: {})\n";
             std::cout << "  --output FILE     Write result to FILE (with --command)\n\n";
             std::cout << "Examples:\n";
             std::cout << "  pulp inspect                              # Interactive REPL\n";
@@ -123,6 +125,7 @@ int cmd_inspect(const std::vector<std::string>& args) {
         if (args[i] == "--host" && i + 1 < args.size()) host = args[++i];
         else if (args[i] == "--port" && i + 1 < args.size()) port = std::stoi(args[++i]);
         else if (args[i] == "--command" && i + 1 < args.size()) one_shot_command = args[++i];
+        else if (args[i] == "--params" && i + 1 < args.size()) one_shot_params = args[++i];
         else if (args[i] == "--output" && i + 1 < args.size()) output_file = args[++i];
     }
 
@@ -187,7 +190,7 @@ int cmd_inspect(const std::vector<std::string>& args) {
 
     // One-shot mode
     if (!one_shot_command.empty()) {
-        auto msg = make_request(1, one_shot_command);
+        auto msg = make_request(1, one_shot_command, one_shot_params);
         auto json = encode_message(msg);
         conn.send_message(json);
 

--- a/tools/cli/cmd_version.cpp
+++ b/tools/cli/cmd_version.cpp
@@ -12,11 +12,21 @@
 
 static bool write_cmake_project_version(const fs::path& cmake_path,
                                          const std::string& old_ver,
-                                         const std::string& new_ver) {
+                                         const std::string& new_ver,
+                                         bool plugin_only = false) {
     auto content = read_file_contents(cmake_path);
-    auto pos = content.find(old_ver);
-    if (pos == std::string::npos) return false;
-    content.replace(pos, old_ver.size(), new_ver);
+    if (plugin_only) {
+        // Only replace the version inside pulp_add_plugin(...VERSION "x.y.z"...)
+        std::regex re(R"((pulp_add_plugin\s*\([^)]*VERSION\s+"))" + std::string(old_ver) + R"(")");
+        std::string replacement = "$1" + new_ver + "\"";
+        auto result = std::regex_replace(content, re, replacement, std::regex_constants::format_first_only);
+        if (result == content) return false;  // no match
+        content = result;
+    } else {
+        auto pos = content.find(old_ver);
+        if (pos == std::string::npos) return false;
+        content.replace(pos, old_ver.size(), new_ver);
+    }
     std::ofstream f(cmake_path);
     if (!f) return false;
     f << content;
@@ -111,7 +121,7 @@ static int version_bump(const std::vector<std::string>& args) {
     auto new_ver = old_ver.bumped(component);
     auto new_str = new_ver.str();
 
-    if (!write_cmake_project_version(cmake_path, current, new_str)) {
+    if (!write_cmake_project_version(cmake_path, current, new_str, plugin_mode)) {
         std::cerr << "Error: failed to update version in " << cmake_path.string() << "\n";
         return 1;
     }


### PR DESCRIPTION
## Summary
- 4 tabs: Elements, Console, Performance, State with collapsable sections
- Smart window positioning (right side, falls back to left)  
- Blue highlight on selected view in plugin window
- Cmd+click in plugin selects in inspector
- 7 new cursor types (resize, invisible, multi-directional)
- Idle timer for cross-window refresh
- position_beside() API on WindowHost

## Known visual issues (follow-up)
- [ ] Disclosure triangles overlap text (need left padding)
- [ ] Scrollbar behind tree rows (z-index)
- [ ] Toggle text truncated
- [ ] Highlight flickers during widget interaction
- [ ] Live value updates need Cmd+tap when inspector backgrounded

## Test plan
- [x] Builds clean on macOS
- [x] Blue highlight appears on plugin window
- [x] Inspector opens alongside plugin
- [ ] Cross-platform CI