### PR TITLE
Add notarize, appcast, and Android packaging to ship CLI

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: ship
+description: Sign, notarize, package, and distribute Pulp plugins and apps across macOS, Windows, and Android
+triggers:
+  - ship
+  - sign
+  - notarize
+  - package
+  - appcast
+  - keystore
+  - code signing
+  - Play Store
+  - release
+  - distribute
+  - installer
+---
+
+# Ship Skill — Signing, Packaging, and Distribution
+
+## Overview
+
+The `pulp ship` command handles the full distribution pipeline: code signing, Apple notarization, platform-specific packaging, update feed generation, and Android APK/AAB builds.
+
+## Subcommands
+
+| Command | Platform | What It Does |
+|---------|----------|-------------|
+| `sign` | macOS, Windows, Android | Sign plugin bundles or APK/AAB |
+| `notarize` | macOS only | Submit to Apple notarization, poll, staple |
+| `package` | All | Create .pkg (macOS), NSIS (Windows), APK+AAB (Android) |
+| `appcast` | All | Generate Sparkle-compatible XML update feed |
+| `check` | All | Verify signing status of built artifacts |
+
+## Configuration
+
+Settings are resolved in order: **CLI flag > environment variable > ~/.pulp/config.toml**
+
+### Setup
+
+```bash
+pulp config init                    # Create config from template
+pulp config set signing.apple.identity "Developer ID Application: Name (TEAMID)"
+pulp config set signing.apple.team_id "ABCDE12345"
+pulp config set signing.apple.apple_id "you@example.com"
+pulp config set signing.android.keystore "~/keystores/release.jks"
+```
+
+### Config file location
+
+`~/.pulp/config.toml` (or `$PULP_HOME/config.toml`)
+
+See `config.example.toml` in the repo root for all options with documentation.
+
+## Workflows
+
+### macOS: Sign → Notarize → Package
+
+```bash
+pulp ship sign                                          # Uses identity from config
+pulp ship notarize                                      # Uses apple_id/team_id from config
+pulp ship package --version 1.0.0                       # Creates .pkg in artifacts/
+pulp ship appcast --url https://example.com/Plugin.pkg --version 1.0.0
+```
+
+### Android: Package → Sign → Verify
+
+```bash
+pulp ship package --target android --keystore ~/key.jks # Build APK+AAB via Gradle
+pulp ship sign --target android                         # Uses keystore from config
+pulp ship check --target android                        # Verify APK/AAB signatures
+```
+
+### Windows: Sign → Package
+
+```bash
+pulp ship sign --identity "Your Company"                # Uses signtool
+pulp ship package --version 1.0.0                       # Creates NSIS .exe installer
+```
+
+## Android-Specific
+
+### ABI Selection
+
+```bash
+--abi arm64-v8a     # Default — ARM64 phones + tablets
+--abi x86_64        # Emulator / Chromebook
+--abi all           # arm64-v8a + x86_64 + armeabi-v7a
+```
+
+### Tablet Support
+
+No special flags needed. ARM64 covers phones and tablets. AAB with split APKs handles screen density automatically.
+
+### Keystore Creation
+
+```bash
+keytool -genkey -v -keystore release.jks -keyalg RSA -keysize 2048 -validity 10000
+```
+
+### Password Security
+
+Never store passwords in plaintext config. Use environment variable references:
+```toml
+store_pass = "@env:ANDROID_STORE_PASS"
+```
+
+## Common Issues
+
+### "No signing identity specified"
+
+Run `security find-identity -v -p codesigning` (macOS) to find your identity, then:
+```bash
+pulp config set signing.apple.identity "Developer ID Application: ..."
+```
+
+### "Android SDK not found"
+
+Install Android Studio or set `ANDROID_HOME`:
+```bash
+export ANDROID_HOME=~/Library/Android/sdk  # macOS
+```
+
+### "Notarization failed"
+
+- Check that your app-specific password is valid (regenerate at https://appleid.apple.com)
+- Ensure the bundle is properly signed with a Developer ID certificate (not just a development cert)
+- Check the notarization log: `xcrun notarytool log <UUID>`
+
+### "Gradle build failed"
+
+- Run `pulp doctor` to check Android SDK/NDK/Java versions
+- Ensure `android/` project exists (`pulp create --targets android`)
+- Check Gradle output in the terminal for specific errors
+
+## Doctor Checks
+
+`pulp doctor` validates Android toolchain:
+- Android SDK location
+- NDK version (r26+ required for C++20)
+- Java version (17+ required for AGP 8+)
+- Build-tools availability (apksigner, zipalign)

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -47,32 +47,45 @@ pulp config set signing.android.keystore "~/keystores/release.jks"
 
 ### Config file location
 
-`~/.pulp/config.toml` (or `$PULP_HOME/config.toml`)
+`~/.pulp/config.toml` (override with `$PULP_HOME`)
 
 See `config.example.toml` in the repo root for all options with documentation.
 
+## Interactive safety contract
+
+Before executing any signing, notarization, or packaging action, the `/ship` command uses AskUserQuestion to:
+1. Show resolved config values (identity, keystore, credentials) and their source (CLI/env/config.toml)
+2. Let the user review, edit, or cancel before proceeding
+3. Offer to save new values with `pulp config set`
+
+When invoked via skill trigger (not slash command), apply the same pattern: always show what will happen and confirm before executing.
+
 ## Workflows
 
-### macOS: Sign → Notarize → Package
+### macOS: Build → Sign → Notarize → Package → Appcast
 
 ```bash
+pulp build                                              # Must build first
 pulp ship sign                                          # Uses identity from config
 pulp ship notarize                                      # Uses apple_id/team_id from config
 pulp ship package --version 1.0.0                       # Creates .pkg in artifacts/
 pulp ship appcast --url https://example.com/Plugin.pkg --version 1.0.0
 ```
 
-### Android: Package → Sign → Verify
+### Android: Build → Package (includes Gradle build + optional signing) → Verify
 
 ```bash
-pulp ship package --target android --keystore ~/key.jks # Build APK+AAB via Gradle
-pulp ship sign --target android                         # Uses keystore from config
+pulp build --target android                             # Build native libs
+pulp ship package --target android --keystore ~/key.jks # Gradle build + sign APK/AAB
 pulp ship check --target android                        # Verify APK/AAB signatures
 ```
 
-### Windows: Sign → Package
+Note: `pulp ship package --target android` invokes Gradle which builds AND signs in one step when a keystore is provided. Use `pulp ship sign --target android` only to re-sign existing artifacts in `artifacts/`.
+
+### Windows: Build → Sign → Package
 
 ```bash
+pulp build                                              # Must build first
 pulp ship sign --identity "Your Company"                # Uses signtool
 pulp ship package --version 1.0.0                       # Creates NSIS .exe installer
 ```

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,21 +1,32 @@
 ---
 name: ship
 description: "Sign, package, notarize, and distribute Pulp plugins and apps across macOS, Windows, and Android. Handles code signing (codesign, signtool, apksigner), Apple notarization, installers (.pkg, NSIS, APK, AAB), Sparkle appcast feeds, and signing status checks."
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - AskUserQuestion
 ---
 
 Ship a Pulp plugin or app — sign, notarize, package, and generate update feeds.
 
 ## Before running any ship command
 
-Check prerequisites for the target platform:
+1. Run `pulp config show` to check saved credentials.
+2. If no config exists, use AskUserQuestion to offer setup:
+   - "No signing config found. Would you like to set up signing credentials now?"
+   - Options: "Yes, set up macOS signing" / "Yes, set up Android signing" / "Skip for now"
+   - If yes, walk through `pulp config set` for each required field.
 
-**macOS:** Run `security find-identity -v -p codesigning` to verify signing identity exists. Check `pulp config show` for saved credentials.
+3. Check prerequisites for the target platform:
+   - **macOS:** Run `security find-identity -v -p codesigning` to verify identity exists.
+   - **Android:** Verify `ANDROID_HOME` is set. Verify keystore file exists. Verify `android/` Gradle project exists.
+   - **Windows:** Verify signing certificate is installed. Verify NSIS is on PATH.
 
-**Android:** Verify `ANDROID_HOME` is set (`pulp doctor` checks this). Verify keystore file exists. Verify `android/` Gradle project exists.
-
-**Windows:** Verify signing certificate is installed. Verify NSIS is on PATH for packaging.
-
-If credentials are missing, the CLI shows rich error messages with setup guidance. Credentials can be saved globally via `pulp config set` so they carry across projects.
+4. If prerequisites are missing, use AskUserQuestion to offer solutions:
+   - "Android SDK not found. Would you like help setting it up?"
+   - Options: "Show install instructions" / "I'll set it up myself" / "Skip Android"
 
 ## Standard workflow order
 
@@ -75,6 +86,55 @@ pulp config set signing.apple.team_id "ABCDE12345"
 pulp config set signing.android.keystore "~/keystores/release.jks"
 pulp config show                    # Show current values
 ```
+
+## Interactive review pattern
+
+Before executing destructive or external actions (signing, notarizing, uploading), show a summary of what will happen and use AskUserQuestion to confirm:
+
+```
+Ready to sign 3 bundles with:
+  Identity: Developer ID Application: Dan Raffel (ABCDE12345)  (from: config.toml)
+  Bundles:  PulpGain.vst3, PulpGain.clap, PulpGain.component
+
+Proceed?
+  - Yes, sign all
+  - Edit signing identity first
+  - Cancel
+```
+
+If the user chooses "Edit signing identity first", show the current value and let them provide a new one, then offer to save it with `pulp config set`.
+
+Similarly for notarize:
+```
+Ready to notarize 3 bundles:
+  Apple ID: dan@example.com  (from: config.toml)
+  Team ID:  ABCDE12345       (from: config.toml)
+  Password: @keychain:AC_PASSWORD
+
+Proceed?
+  - Yes, submit for notarization
+  - Edit credentials first
+  - Cancel
+```
+
+And for Android packaging:
+```
+Ready to build Android package:
+  Gradle project: android/
+  ABIs: arm64-v8a (phones + tablets)
+  Signing: debug (no keystore configured)
+
+Proceed?
+  - Yes, build with debug signing
+  - Set up release keystore first
+  - Cancel
+```
+
+This "show then confirm" pattern applies to:
+- `pulp ship sign` — show identity/keystore and bundles
+- `pulp ship notarize` — show credentials and bundles
+- `pulp ship package` — show target, version, and signing mode
+- `pulp ship package --target android` — show ABIs, keystore, Gradle project
 
 Run the appropriate subcommand based on $ARGUMENTS. If no arguments, show signing status first with `pulp ship check`, then suggest the next step in the workflow.
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,14 +1,32 @@
 ---
 name: ship
-description: Sign, package, and distribute a Pulp plugin
+description: Sign, package, notarize, and distribute a Pulp plugin or app
 ---
 
-Ship a Pulp plugin — sign, notarize, and package for distribution.
+Ship a Pulp plugin or app — sign, notarize, package, and generate update feeds.
 
 Available subcommands:
-- `pulp ship sign --identity "Developer ID Application: ..."` — code sign the plugin
-- `pulp ship package --version 1.0.0` — create installer (DMG/PKG on macOS, NSIS on Windows)
-- `pulp ship check` — show current signing status
+
+**Signing:**
+- `pulp ship sign --identity "Developer ID Application: ..."` — macOS/Windows code sign
+- `pulp ship sign --target android --keystore key.jks --key-alias mykey` — Android APK/AAB signing
+
+**Packaging:**
+- `pulp ship package --version 1.0.0` — create installer (.pkg on macOS, NSIS on Windows)
+- `pulp ship package --target android --keystore key.jks` — build Android APK + AAB via Gradle
+- `pulp ship package --target android --abi all` — build for all ABIs (arm64-v8a, x86_64, armeabi-v7a)
+- `pulp ship package --target android --aab-only` — AAB only (for Play Store)
+
+**Notarization (macOS):**
+- `pulp ship notarize --apple-id you@example.com --team-id ABCDE12345` — submit + staple
+- `pulp ship notarize --staple` — staple only (already submitted)
+
+**Update feeds:**
+- `pulp ship appcast --url https://example.com/Plugin-1.0.pkg --version 1.0.0 --notes "..."` — Sparkle XML
+
+**Status:**
+- `pulp ship check` — desktop plugin signing status
+- `pulp ship check --target android` — Android APK/AAB signing status
 
 Run the appropriate subcommand based on $ARGUMENTS. If no arguments, show signing status first with `pulp ship check`.
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,33 +1,81 @@
 ---
 name: ship
-description: Sign, package, notarize, and distribute a Pulp plugin or app
+description: "Sign, package, notarize, and distribute Pulp plugins and apps across macOS, Windows, and Android. Handles code signing (codesign, signtool, apksigner), Apple notarization, installers (.pkg, NSIS, APK, AAB), Sparkle appcast feeds, and signing status checks."
 ---
 
 Ship a Pulp plugin or app — sign, notarize, package, and generate update feeds.
 
-Available subcommands:
+## Before running any ship command
+
+Check prerequisites for the target platform:
+
+**macOS:** Run `security find-identity -v -p codesigning` to verify signing identity exists. Check `pulp config show` for saved credentials.
+
+**Android:** Verify `ANDROID_HOME` is set (`pulp doctor` checks this). Verify keystore file exists. Verify `android/` Gradle project exists.
+
+**Windows:** Verify signing certificate is installed. Verify NSIS is on PATH for packaging.
+
+If credentials are missing, the CLI shows rich error messages with setup guidance. Credentials can be saved globally via `pulp config set` so they carry across projects.
+
+## Standard workflow order
+
+1. **Build** — `pulp build` (must complete before signing)
+2. **Sign** — `pulp ship sign` (must sign before notarizing)
+3. **Notarize** — `pulp ship notarize` (macOS only, after signing)
+4. **Package** — `pulp ship package` (creates installer from signed bundles)
+5. **Appcast** — `pulp ship appcast` (generate update feed pointing to packaged artifact)
+
+## Subcommands
 
 **Signing:**
-- `pulp ship sign --identity "Developer ID Application: ..."` — macOS/Windows code sign
-- `pulp ship sign --target android --keystore key.jks --key-alias mykey` — Android APK/AAB signing
+- `pulp ship sign` — uses identity from `~/.pulp/config.toml` (macOS/Windows)
+- `pulp ship sign --identity "Developer ID Application: ..."` — explicit identity
+- `pulp ship sign --target android` — uses keystore from config
+- `pulp ship sign --target android --keystore key.jks --key-alias mykey --store-pass @env:PASS`
+
+**Notarization (macOS only):**
+- `pulp ship notarize` — uses apple_id/team_id from config
+- `pulp ship notarize --apple-id you@example.com --team-id ABCDE12345 --password @keychain:AC_PASSWORD`
+- `pulp ship notarize --staple` — staple only (skip submission)
 
 **Packaging:**
-- `pulp ship package --version 1.0.0` — create installer (.pkg on macOS, NSIS on Windows)
-- `pulp ship package --target android --keystore key.jks` — build Android APK + AAB via Gradle
-- `pulp ship package --target android --abi all` — build for all ABIs (arm64-v8a, x86_64, armeabi-v7a)
+- `pulp ship package --version 1.0.0` — .pkg (macOS) or NSIS .exe (Windows)
+- `pulp ship package --target android --keystore key.jks` — APK + AAB via Gradle
+- `pulp ship package --target android --abi all` — all ABIs (arm64-v8a, x86_64, armeabi-v7a)
 - `pulp ship package --target android --aab-only` — AAB only (for Play Store)
-
-**Notarization (macOS):**
-- `pulp ship notarize --apple-id you@example.com --team-id ABCDE12345` — submit + staple
-- `pulp ship notarize --staple` — staple only (already submitted)
+- `pulp ship package --target android --apk-only` — APK only (for direct distribution)
+- `pulp ship package --per-user` — per-user NSIS install (Windows, no admin)
 
 **Update feeds:**
-- `pulp ship appcast --url https://example.com/Plugin-1.0.pkg --version 1.0.0 --notes "..."` — Sparkle XML
+- `pulp ship appcast --url https://example.com/Plugin.pkg --version 1.0.0 --notes "Bug fixes"`
+- `pulp ship appcast --sign-key ~/keys/ed25519_private.key` — EdDSA-signed for Sparkle
+- `pulp ship appcast --output appcast.xml --title "My Plugin" --min-os 12.0`
 
 **Status:**
 - `pulp ship check` — desktop plugin signing status
-- `pulp ship check --target android` — Android APK/AAB signing status
+- `pulp ship check --target android` — Android APK/AAB signing status (v2/v3 scheme, signer CN)
 
-Run the appropriate subcommand based on $ARGUMENTS. If no arguments, show signing status first with `pulp ship check`.
+## Common errors
+
+- **"No signing identity"** → Run `security find-identity -v -p codesigning` or `pulp config set signing.apple.identity "..."`
+- **"No Android keystore"** → Create one: `keytool -genkey -v -keystore release.jks -keyalg RSA -keysize 2048 -validity 10000`
+- **"Android SDK not found"** → Install Android Studio or `export ANDROID_HOME=~/Library/Android/sdk`
+- **"Notarization failed"** → Ensure hardened runtime is enabled and using Developer ID (not development) cert. Check log: `xcrun notarytool log <UUID>`
+- **"NSIS not found"** → Install NSIS and add to PATH (Windows only)
+- **"Gradle build failed"** → Run `pulp doctor` to check SDK/NDK/Java versions
+
+## Config
+
+All signing credentials fall back to `~/.pulp/config.toml` (CLI flag > env var > config file):
+
+```bash
+pulp config init                    # Create from template
+pulp config set signing.apple.identity "Developer ID Application: ..."
+pulp config set signing.apple.team_id "ABCDE12345"
+pulp config set signing.android.keystore "~/keystores/release.jks"
+pulp config show                    # Show current values
+```
+
+Run the appropriate subcommand based on $ARGUMENTS. If no arguments, show signing status first with `pulp ship check`, then suggest the next step in the workflow.
 
 For full CI-driven shipping (PR + validate + merge + release), use the `ci` skill instead: say "ship this" or use `/ci ship`.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -42,7 +42,9 @@ Ship a Pulp plugin or app — sign, notarize, package, and generate update feeds
 - `pulp ship sign` — uses identity from `~/.pulp/config.toml` (macOS/Windows)
 - `pulp ship sign --identity "Developer ID Application: ..."` — explicit identity
 - `pulp ship sign --target android` — uses keystore from config
-- `pulp ship sign --target android --keystore key.jks --key-alias mykey --store-pass @env:PASS`
+- `pulp ship sign --target android --keystore key.jks --key-alias mykey --store-pass @env:PASS --key-pass @env:KEY_PASS`
+
+Note: `--key-pass` defaults to `--store-pass` if omitted. `sign --target android` operates on existing APK/AAB files in `artifacts/` — use `package --target android` to build from Gradle.
 
 **Notarization (macOS only):**
 - `pulp ship notarize` — uses apple_id/team_id from config

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -14,7 +14,7 @@ Ship a Pulp plugin or app — sign, notarize, package, and generate update feeds
 ## Before running any ship command
 
 1. Run `pulp config show` to check saved credentials.
-2. If no config exists, use AskUserQuestion to offer setup:
+2. If no config exists, OR if the config file exists but all signing fields are commented out (only section headers shown), use AskUserQuestion to offer setup:
    - "No signing config found. Would you like to set up signing credentials now?"
    - Options: "Yes, set up macOS signing" / "Yes, set up Android signing" / "Skip for now"
    - If yes, walk through `pulp config set` for each required field.
@@ -104,7 +104,7 @@ Proceed?
   - Cancel
 ```
 
-If the user chooses "Edit signing identity first", show the current value and let them provide a new one, then offer to save it with `pulp config set`.
+If the user chooses "Edit signing identity first", use AskUserQuestion to collect the new value (show the current value as context), then offer to save it with `pulp config set`.
 
 Similarly for notarize:
 ```
@@ -138,6 +138,10 @@ This "show then confirm" pattern applies to:
 - `pulp ship package` — show target, version, and signing mode
 - `pulp ship package --target android` — show ABIs, keystore, Gradle project
 
-Run the appropriate subcommand based on $ARGUMENTS. If no arguments, show signing status first with `pulp ship check`, then suggest the next step in the workflow.
+Run the appropriate subcommand based on $ARGUMENTS. If no arguments, run `pulp ship check` to show current signing status, then use AskUserQuestion to suggest next steps:
+- "Sign plugin bundles" (if unsigned bundles found)
+- "Set up signing credentials" (if no config)
+- "Package for distribution" (if bundles are signed)
+- "Generate appcast update feed" (if packages exist in artifacts/)
 
 For full CI-driven shipping (PR + validate + merge + release), use the `ci` skill instead: say "ship this" or use `/ci ship`.

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,108 @@
+# ============================================================================
+# Pulp Developer Configuration
+# ============================================================================
+#
+# Copy this file to ~/.pulp/config.toml to set your developer defaults.
+# These settings persist across all Pulp projects on your machine.
+#
+# Quick setup:
+#   pulp config init          # copies this template to ~/.pulp/config.toml
+#   pulp config set KEY VALUE # set a single value
+#
+# Or set PULP_HOME to use a different config directory (default: ~/.pulp)
+#
+# Precedence: CLI flags > environment variables > project pulp.toml > this file
+# ============================================================================
+
+
+# ── Developer Identity ─────────────────────────────────────────────────────
+# Used in plugin metadata, bundle IDs, and installer publisher fields.
+
+[developer]
+# name = "Your Name"
+# company = "My Company"              # Optional — overrides name for publisher
+
+
+# ── Apple Code Signing (macOS) ─────────────────────────────────────────────
+# Required for: pulp ship sign, pulp ship notarize
+#
+# To find your signing identity, run:
+#   security find-identity -v -p codesigning
+# Or open: Keychain Access → My Certificates
+
+[signing.apple]
+# identity = "Developer ID Application: Your Name (TEAMID)"
+# installer_identity = "Developer ID Installer: Your Name (TEAMID)"
+
+# Apple Developer Team ID
+# Find yours at: https://developer.apple.com/account → Membership → Team ID
+# team_id = "ABCDE12345"
+
+# Apple ID (email) for notarization
+# apple_id = "you@example.com"
+
+# App-specific password for notarization (NEVER use your Apple ID password)
+# Generate one at: https://appleid.apple.com → Sign-In and Security → App-Specific Passwords
+# Then store in Keychain:
+#   security add-generic-password -s AC_PASSWORD -a you@example.com -w "xxxx-xxxx-xxxx-xxxx"
+# password = "@keychain:AC_PASSWORD"
+
+
+# ── Android Signing ────────────────────────────────────────────────────────
+# Required for: pulp ship sign --target android, pulp ship package --target android
+#
+# To create a release keystore:
+#   keytool -genkey -v -keystore release.jks -keyalg RSA -keysize 2048 -validity 10000
+#
+# Install Android Studio for SDK + NDK:
+#   https://developer.android.com/studio
+#
+# Then install required SDK components:
+#   sdkmanager "platform-tools" "build-tools;34.0.0" "ndk;27.0.12077973" "platforms;android-34"
+
+[signing.android]
+# keystore = "~/keystores/release.jks"
+# key_alias = "release"
+
+# Use environment variables for passwords — never store plaintext
+# Set the env var: export ANDROID_STORE_PASS="your-password"
+# store_pass = "@env:ANDROID_STORE_PASS"
+# key_pass = "@env:ANDROID_KEY_PASS"    # Defaults to store_pass if omitted
+
+
+# ── Windows Code Signing ───────────────────────────────────────────────────
+# Required for: pulp ship sign (on Windows)
+#
+# Options:
+#   A) Traditional Authenticode — buy a certificate from DigiCert, Sectigo, or GlobalSign
+#      Export as .pfx, then use pfx_path below
+#   B) Azure Trusted Signing — cloud-based, ~$10/month, instant SmartScreen reputation
+#      See: https://learn.microsoft.com/en-us/azure/trusted-signing/
+
+[signing.windows]
+# identity = "Your Company"
+# pfx_path = "~/certs/codesign.pfx"
+# pfx_password = "@env:WINDOWS_PFX_PASS"
+
+
+# ── Project Creation Defaults ──────────────────────────────────────────────
+# Used by: pulp create
+
+[create]
+# projects_dir = "~/Code"                       # Where new projects are created
+# default_formats = "VST3 CLAP AU Standalone"   # Plugin formats to scaffold
+
+
+# ── Appcast / Update Feed ─────────────────────────────────────────────────
+# Used by: pulp ship appcast
+#
+# Generate an Ed25519 signing key:
+#   openssl genpkey -algorithm ed25519 -out ed25519_private.key
+#   openssl pkey -in ed25519_private.key -pubout -out ed25519_public.key
+#
+# For Sparkle (macOS): embed the public key in your app's Info.plist
+# For WinSparkle (Windows): embed in the updater configuration
+
+[appcast]
+# title = "My Plugins"
+# sign_key = "~/keys/ed25519_private.key"

--- a/config.example.toml
+++ b/config.example.toml
@@ -11,7 +11,8 @@
 #
 # Or set PULP_HOME to use a different config directory (default: ~/.pulp)
 #
-# Precedence: CLI flags > environment variables > project pulp.toml > this file
+# Precedence: CLI flags > environment variables > this file
+# (Future: project pulp.toml will override this file for per-project settings)
 # ============================================================================
 
 

--- a/docs/reference/licensing.md
+++ b/docs/reference/licensing.md
@@ -79,10 +79,12 @@ Pulp implements or builds on these open standards:
 
 | Project | License | What We Learned |
 |---------|---------|-----------------|
-| [iPlug2](https://github.com/iPlug2/iPlug2) | zlib-like | Multi-format adapter architecture, graphics abstraction |
 | [AudioKit](https://github.com/AudioKit/AudioKit) | MIT | Swift audio patterns, Apple platform integration |
+| [iPlug2](https://github.com/iPlug2/iPlug2) | zlib-like | Multi-format adapter architecture, graphics abstraction |
+| [PreText](https://github.com/chenglou/pretext) | MIT | Measure-once, reflow-forever text layout — the two-phase prepare/layout pattern that separates expensive font shaping from cheap arithmetic line breaking |
 | [SignalKit](https://github.com/niclamusic/signalkit) | MIT | Real-time DSP patterns in Swift |
 | [signalsmith-clap-cpp](https://github.com/geraintluff/signalsmith-clap-cpp) | MIT | WCLAP build pipeline, webview extension patterns |
+| [Visage](https://github.com/VitalAudio/visage) | MIT | SDF-first rendering, dirty region tracking, shape batching |
 
 ## Discipline
 

--- a/docs/reference/licensing.md
+++ b/docs/reference/licensing.md
@@ -12,9 +12,14 @@ Pulp builds on excellent open-source software. Every dependency that Pulp bundle
 
 | Name | License | Purpose | Link |
 |------|---------|---------|------|
-| **CHOC** | ISC | JS engine, MIDI utilities, audio file I/O, WebView, networking | [github.com/Tracktion/choc](https://github.com/Tracktion/choc) |
 | **Catch2** | BSL-1.0 | Unit testing framework | [github.com/catchorg/Catch2](https://github.com/catchorg/Catch2) |
+| **CHOC** | ISC | JS engine, MIDI utilities, audio file I/O, WebView, networking | [github.com/Tracktion/choc](https://github.com/Tracktion/choc) |
+| **cpp-httplib** | MIT | HTTP client (GET, POST, download) | [github.com/yhirose/cpp-httplib](https://github.com/yhirose/cpp-httplib) |
+| **Google Highway** | Apache-2.0 | SIMD dispatch (SSE2, AVX2, NEON) | [github.com/google/highway](https://github.com/google/highway) |
+| **Mbed TLS** | Apache-2.0 | Crypto: SHA-256, AES-256-CBC, RSA via MPI | [github.com/Mbed-TLS/mbedtls](https://github.com/Mbed-TLS/mbedtls) |
+| **miniz** | MIT | ZIP/GZIP compression | [github.com/richgel999/miniz](https://github.com/richgel999/miniz) |
 | **nanosvg** | zlib | SVG parsing and rasterization | [github.com/memononen/nanosvg](https://github.com/memononen/nanosvg) |
+| **pugixml** | MIT | XML parsing with XPath | [github.com/zeux/pugixml](https://github.com/zeux/pugixml) |
 | **Yoga** | MIT | Layout engine for Flexbox/Grid-style native UI | [github.com/facebook/yoga](https://github.com/facebook/yoga) |
 
 ### Plugin Format SDKs

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -10,16 +10,16 @@ Pulp is organized into independent subsystems under `core/`. Each is a separate 
 
 | Feature | Header | What It Does |
 |---------|--------|-------------|
-| SIMD | `simd.hpp` | Portable SSE/NEON/AVX via Google Highway — add, mul, fma, reduce, clamp |
-| XML | `xml.hpp` | Parse/generate XML via pugixml — XPath queries, file I/O |
-| ZIP/GZIP | `zip.hpp` | Compress/decompress via miniz — archives, state blobs |
-| HTTP | `http.hpp` | GET, POST, download via cpp-httplib — license checks, cloud presets |
+| SIMD | `simd.hpp` | Portable [SSE2](https://en.wikipedia.org/wiki/SSE2)/[NEON](https://developer.arm.com/Architectures/Neon)/[AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX2) via [Google Highway](https://github.com/google/highway) — add, mul, fma, reduce, clamp |
+| XML | `xml.hpp` | Parse/generate XML via [pugixml](https://github.com/zeux/pugixml) — XPath queries, file I/O |
+| ZIP/GZIP | `zip.hpp` | Compress/decompress via [miniz](https://github.com/richgel999/miniz) — archives, state blobs |
+| HTTP | `http.hpp` | GET, POST, download via [cpp-httplib](https://github.com/yhirose/cpp-httplib) — license checks, cloud presets |
 | Sockets | `socket.hpp` | TCP/UDP client and server |
 | Named Pipes | `named_pipe.hpp` | Cross-platform IPC pipes (mkfifo / CreateNamedPipe) |
 | IP Address | `ip_address.hpp` | IPv4 validation, local address queries, hostname |
-| Crypto | `crypto.hpp` | SHA-256, MD5, AES-256-CBC via Mbed TLS — hashing, encryption |
+| Crypto | `crypto.hpp` | SHA-256, MD5, AES-256-CBC via [Mbed TLS](https://github.com/Mbed-TLS/mbedtls) — hashing, encryption |
 | Licensing | `license.hpp` | RSA signature verification, key generation, online activation |
-| BigInteger | `big_integer.hpp` | Arbitrary-precision arithmetic via Mbed TLS MPI — for RSA |
+| BigInteger | `big_integer.hpp` | Arbitrary-precision arithmetic via [Mbed TLS](https://github.com/Mbed-TLS/mbedtls) MPI — for RSA |
 | i18n | `i18n.hpp` | String translation — .strings, .po, .json file loaders, `tr()` helper |
 | Analytics | `analytics.hpp` | Thread-safe event tracking with pluggable file/HTTP destinations |
 | Base64 | `base64.hpp` | Encode/decode binary ↔ text |
@@ -77,9 +77,9 @@ Pulp is organized into independent subsystems under `core/`. Each is a separate 
 | Format | Read | Write | Backend |
 |--------|:----:|:-----:|---------|
 | WAV | ✓ | ✓ | CHOC |
-| FLAC | ✓ | — | dr_flac |
-| MP3 | ✓ | — | dr_mp3 |
-| OGG Vorbis | ✓ | — | stb_vorbis |
+| FLAC | ✓ | — | [dr_flac](https://github.com/mackron/dr_libs) |
+| MP3 | ✓ | — | [dr_mp3](https://github.com/mackron/dr_libs) |
+| OGG Vorbis | ✓ | — | [stb_vorbis](https://github.com/nothings/stb) |
 | AIFF / AIFF-C | ✓ | ✓ | Native (8/16/24/32-bit) |
 | AAC / ALAC / CAF | ✓ | — | ExtAudioFile (macOS only) |
 
@@ -214,20 +214,20 @@ Pulp is organized into independent subsystems under `core/`. Each is a separate 
 | Feature | Header | What It Does |
 |---------|--------|-------------|
 | Canvas API | `canvas.hpp` | 25+ draw commands — rect, rounded rect, path, arc, text, image |
-| Skia Backend | `src/skia_canvas.cpp` | GPU-accelerated via Skia Graphite (Metal/Vulkan/D3D12) |
+| Skia Backend | `src/skia_canvas.cpp` | GPU-accelerated via [Skia Graphite](https://skia.org) (Metal/Vulkan/D3D12) |
 | CoreGraphics | `platform/mac/cg_canvas.mm` | Native macOS/iOS rendering |
-| TextShaper | `text_shaper.hpp` | **Measure once, reflow forever** — PreText-style layout engine |
+| TextShaper | `text_shaper.hpp` | **Measure once, reflow forever** — [PreText](https://github.com/chenglou/pretext)-style layout engine |
 | Attributed String | `attributed_string.hpp` | Rich text spans with font, color, weight, decoration |
 | Text Layout | `text_layout.hpp` | Multi-line layout with word wrapping |
 | Rectangle List | `rectangle_list.hpp` | Clip regions with add/subtract/intersect |
 | Image Convolution | `image_convolution.hpp` | Blur, sharpen, edge detect, emboss kernels |
-| SVG | `svg.hpp` | SVG loading and rendering via nanosvg |
+| SVG | `svg.hpp` | SVG loading and rendering via [nanosvg](https://github.com/memononen/nanosvg) |
 | Effects | `effects.hpp` | Drop shadow, bloom, blur, color adjust |
 | Recording Canvas | `recording_canvas.hpp` | Record draw calls for replay/serialization |
 
 **Text shaping option:** `PULP_TEXT_SHAPING` (CMake)
 - Default: **ON** when GPU enabled, **OFF** without
-- ON: Uses SkFont/HarfBuzz (bundled in Skia) for real font metrics
+- ON: Uses SkFont/[HarfBuzz](https://github.com/harfbuzz/harfbuzz) (bundled in Skia) for real font metrics
 - OFF: Falls back to character-width estimation
 - Same API either way — only measurement accuracy differs
 
@@ -277,11 +277,11 @@ Pulp is organized into independent subsystems under `core/`. Each is a separate 
 | SplashScreen | Borderless window with fade animation |
 | LiveConstantEditor | Debug overlay for tweaking numeric constants |
 
-**Layout:** Yoga flexbox + CSS Grid, absolute/fixed positioning, intrinsic sizing.
+**Layout:** [Yoga](https://github.com/facebook/yoga) flexbox + CSS Grid, absolute/fixed positioning, intrinsic sizing.
 
 **Theming:** Token-based design system (`"bg.surface"`, `"control.border"`), contrast-aware, theme presets.
 
-**JS Scripting:** QuickJS (default), JavaScriptCore (Apple), V8 (optional). Hot-reload. Full `WidgetBridge` + `AudioBridge` for parameter access from JS.
+**JS Scripting:** [QuickJS](https://bellard.org/quickjs/) (default), [JavaScriptCore](https://developer.apple.com/documentation/javascriptcore) (Apple), [V8](https://v8.dev) (optional). Hot-reload. Full `WidgetBridge` + `AudioBridge` for parameter access from JS.
 
 **Accessibility:** AccessRole, value/text/table/cell interfaces, VoiceOver (macOS), UIA (Windows), AT-SPI (Linux).
 
@@ -307,8 +307,8 @@ Pulp is organized into independent subsystems under `core/`. Each is a separate 
 
 | Feature | What It Does |
 |---------|-------------|
-| Dawn/WebGPU | Cross-platform GPU abstraction (Metal, Vulkan, D3D12, OpenGL) |
-| Skia Graphite | 2D rendering engine on top of Dawn |
+| [Dawn](https://dawn.googlesource.com/dawn)/[WebGPU](https://www.w3.org/TR/webgpu/) | Cross-platform GPU abstraction (Metal, Vulkan, D3D12, OpenGL) |
+| [Skia Graphite](https://skia.org) | 2D rendering engine on top of Dawn |
 | GPU Compute | Experimental batch audio processing (>64K elements) |
 
 ---

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -214,6 +214,30 @@ commands:
     summary: Remove the build directory.
     docs: reference/cli.md#clean
 
+  - name: config
+    status: usable
+    summary: Manage global developer configuration (~/.pulp/config.toml).
+    subcommands:
+      - name: init
+        summary: Create config from template (safe — never overwrites)
+        args:
+          - name: --force
+            required: false
+      - name: set
+        summary: Set a config value (e.g., signing.apple.identity)
+        args:
+          - name: key
+            kind: positional
+            required: true
+          - name: value
+            kind: positional
+            required: true
+      - name: show
+        summary: Show current non-comment config values
+      - name: path
+        summary: Print config file path
+    docs: reference/cli.md#config
+
   - name: design
     status: experimental
     summary: Build and launch the local AI-powered design tool for token and style iteration, binding to the current checkout or the SDK/build next to the CLI binary.

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -44,23 +44,68 @@ commands:
     docs: reference/cli.md#validate
 
   - name: ship
-    status: experimental
-    summary: Signing and packaging subcommands (sign, package, check). macOS only.
+    status: usable
+    summary: Sign, notarize, package, and generate update feeds for all platforms.
     subcommands:
       - name: sign
-        summary: Code-sign all built plugin bundles
+        summary: Code-sign plugin bundles (macOS/Windows) or Android APK/AAB
         args:
           - name: --identity
-            required: true
+            required: false
           - name: --entitlements
             required: false
+          - name: --target
+            required: false
+          - name: --keystore
+            required: false
+          - name: --key-alias
+            required: false
+          - name: --store-pass
+            required: false
+      - name: notarize
+        summary: Submit signed bundles for Apple notarization (macOS)
+        args:
+          - name: --apple-id
+            required: true
+          - name: --team-id
+            required: true
+          - name: --password
+            required: false
+          - name: --staple
+            required: false
       - name: package
-        summary: Create .pkg installers
+        summary: Create installers (.pkg, NSIS, APK/AAB)
         args:
           - name: --version
             required: false
+          - name: --target
+            required: false
+          - name: --keystore
+            required: false
+          - name: --abi
+            required: false
+          - name: --apk-only
+            required: false
+          - name: --aab-only
+            required: false
+      - name: appcast
+        summary: Generate Sparkle-compatible XML update feed
+        args:
+          - name: --url
+            required: true
+          - name: --version
+            required: false
+          - name: --notes
+            required: false
+          - name: --output
+            required: false
+          - name: --sign-key
+            required: false
       - name: check
-        summary: Check signing status of built plugins
+        summary: Check signing status of built plugins or Android artifacts
+        args:
+          - name: --target
+            required: false
     docs: reference/cli.md#ship
 
   - name: docs

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -62,6 +62,8 @@ commands:
             required: false
           - name: --store-pass
             required: false
+          - name: --key-pass
+            required: false
       - name: notarize
         summary: Submit signed bundles for Apple notarization (macOS)
         args:
@@ -82,11 +84,19 @@ commands:
             required: false
           - name: --keystore
             required: false
+          - name: --key-alias
+            required: false
+          - name: --store-pass
+            required: false
+          - name: --key-pass
+            required: false
           - name: --abi
             required: false
           - name: --apk-only
             required: false
           - name: --aab-only
+            required: false
+          - name: --per-user
             required: false
       - name: appcast
         summary: Generate Sparkle-compatible XML update feed

--- a/ship/CMakeLists.txt
+++ b/ship/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(pulp-ship
 # Cross-platform sources
 target_sources(pulp-ship PRIVATE
     src/appcast.cpp
+    platform/android/package_android.cpp
 )
 
 target_link_libraries(pulp-ship PUBLIC pulp::platform)

--- a/ship/include/pulp/ship/android.hpp
+++ b/ship/include/pulp/ship/android.hpp
@@ -67,4 +67,26 @@ bool aab_to_apks(const std::filesystem::path& aab_path,
                  const std::filesystem::path& output_apks,
                  const AndroidKeystoreConfig* keystore = nullptr);
 
+// ── SDK discovery (host-side — used by doctor checks and ship commands) ──────
+
+// Minimum versions for Android toolchain
+constexpr int PULP_ANDROID_MIN_NDK = 26;
+constexpr int PULP_ANDROID_MIN_JAVA = 17;
+inline const char* PULP_ANDROID_MIN_BUILD_TOOLS = "30.0.0";
+
+// Find Android SDK root (ANDROID_HOME → ANDROID_SDK_ROOT → platform defaults)
+std::filesystem::path detect_android_sdk();
+
+// Find Android NDK (ANDROID_NDK_HOME → <sdk>/ndk/<latest>/)
+std::filesystem::path find_android_ndk();
+
+// Find a build-tools binary (apksigner, zipalign) in the latest build-tools dir
+std::filesystem::path find_android_build_tool(const std::string& name);
+
+// Get the installed build-tools version string (e.g., "34.0.0")
+std::string android_build_tools_version();
+
+// Detect Java version from `java -version` output (e.g., "21.0.2")
+std::string detect_java_version();
+
 } // namespace pulp::ship

--- a/ship/include/pulp/ship/android.hpp
+++ b/ship/include/pulp/ship/android.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <cstdint>
+#include <filesystem>
+
+namespace pulp::ship {
+
+// Keystore configuration for Android signing
+struct AndroidKeystoreConfig {
+    std::filesystem::path keystore_path;   // Path to .jks or .keystore file
+    std::string store_password;            // Store password (or @env:VAR_NAME)
+    std::string key_alias;                 // Key alias within the keystore
+    std::string key_password;              // Key password (defaults to store_password)
+};
+
+// Result of checking an APK/AAB's signing status
+struct AndroidSigningInfo {
+    bool is_signed = false;
+    bool v2_signed = false;       // APK Signature Scheme v2
+    bool v3_signed = false;       // APK Signature Scheme v3
+    std::string signer_cn;        // Certificate Common Name
+    std::string error;
+};
+
+// Result of a build + package operation
+struct AndroidPackageResult {
+    bool success = false;
+    std::filesystem::path apk_path;       // Release APK (if built)
+    std::filesystem::path aab_path;       // Release AAB (if built)
+    std::string error;
+};
+
+// ── Core signing operations ─────────────────────────────────────────────────
+
+// Align an APK (must happen before signing)
+bool zipalign_apk(const std::filesystem::path& input_apk,
+                  const std::filesystem::path& output_apk);
+
+// Sign an APK with apksigner (v2 + v3 schemes)
+bool sign_apk(const std::filesystem::path& apk_path,
+              const AndroidKeystoreConfig& keystore);
+
+// Sign an AAB with jarsigner (Play Store re-signs with Play App Signing)
+bool sign_aab(const std::filesystem::path& aab_path,
+              const AndroidKeystoreConfig& keystore);
+
+// Verify signing status of an APK or AAB
+AndroidSigningInfo check_android_signing(const std::filesystem::path& path);
+
+// ── High-level packaging ────────────────────────────────────────────────────
+
+// Build APK and/or AAB via Gradle
+// gradle_project_dir: the android/ subdir of the Pulp project
+// keystore: null = debug signing
+AndroidPackageResult build_android_package(
+    const std::filesystem::path& gradle_project_dir,
+    const std::vector<std::string>& abis,
+    const AndroidKeystoreConfig* keystore = nullptr,
+    bool build_aab = true,
+    bool build_apk = true);
+
+// Convert AAB to split APKs for local device testing via bundletool
+bool aab_to_apks(const std::filesystem::path& aab_path,
+                 const std::filesystem::path& output_apks,
+                 const AndroidKeystoreConfig* keystore = nullptr);
+
+} // namespace pulp::ship

--- a/ship/platform/android/package_android.cpp
+++ b/ship/platform/android/package_android.cpp
@@ -51,6 +51,46 @@ static int exec_status_win(const std::string& cmd, int timeout_ms = 120000) {
 }
 #endif
 
+// Shell-quote a string to protect spaces and metacharacters
+static std::string shell_quote(const std::string& s) {
+#ifdef _WIN32
+    // Windows: wrap in double quotes, escape internal double quotes
+    std::string result = "\"";
+    for (char c : s) {
+        if (c == '"') result += "\\\"";
+        else result += c;
+    }
+    result += "\"";
+    return result;
+#else
+    // POSIX: wrap in single quotes, escape internal single quotes
+    std::string result = "'";
+    for (char c : s) {
+        if (c == '\'') result += "'\\''";
+        else result += c;
+    }
+    result += "'";
+    return result;
+#endif
+}
+
+// Platform-aware command execution
+static std::string run_cmd(const std::string& cmd, int timeout_ms = 120000) {
+#ifdef _WIN32
+    return exec_cmd_win(cmd, timeout_ms);
+#else
+    return exec_cmd(cmd, timeout_ms);
+#endif
+}
+
+static int run_status(const std::string& cmd, int timeout_ms = 120000) {
+#ifdef _WIN32
+    return exec_status_win(cmd, timeout_ms);
+#else
+    return exec_status(cmd, timeout_ms);
+#endif
+}
+
 static std::string resolve_password(const std::string& password) {
     // Support @env:VAR_NAME syntax
     if (password.size() > 5 && password.substr(0, 5) == "@env:") {
@@ -159,7 +199,7 @@ std::string android_build_tools_version() {
 }
 
 std::string detect_java_version() {
-    auto output = exec_cmd("java -version 2>&1 | head -1");
+    auto output = run_cmd("java -version 2>&1 | head -1");
     // Parse: openjdk version "17.0.2" or java version "21.0.2"
     auto q1 = output.find('"');
     if (q1 == std::string::npos) return {};
@@ -186,11 +226,7 @@ bool zipalign_apk(const fs::path& input_apk, const fs::path& output_apk) {
 
     std::string cmd = "\"" + tool.string() + "\" -f 4 \""
         + input_apk.string() + "\" \"" + output_apk.string() + "\"";
-#ifdef _WIN32
-    return exec_status_win(cmd) == 0;
-#else
-    return exec_status(cmd) == 0;
-#endif
+    return run_status(cmd) == 0;
 }
 
 bool sign_apk(const fs::path& apk_path, const AndroidKeystoreConfig& keystore) {
@@ -204,16 +240,12 @@ bool sign_apk(const fs::path& apk_path, const AndroidKeystoreConfig& keystore) {
     std::string cmd = "\"" + tool.string() + "\" sign"
         " --ks \"" + keystore.keystore_path.string() + "\""
         " --ks-key-alias \"" + keystore.key_alias + "\""
-        " --ks-pass pass:" + store_pass +
-        " --key-pass pass:" + key_pass +
+        " --ks-pass pass:" + shell_quote(store_pass) +
+        " --key-pass pass:" + shell_quote(key_pass) +
         " --v2-signing-enabled true"
         " --v3-signing-enabled true"
         " \"" + apk_path.string() + "\"";
-#ifdef _WIN32
-    return exec_status_win(cmd) == 0;
-#else
-    return exec_status(cmd) == 0;
-#endif
+    return run_status(cmd) == 0;
 }
 
 bool sign_aab(const fs::path& aab_path, const AndroidKeystoreConfig& keystore) {
@@ -224,15 +256,11 @@ bool sign_aab(const fs::path& aab_path, const AndroidKeystoreConfig& keystore) {
     // AABs use jarsigner (Google re-signs with Play App Signing)
     std::string cmd = "jarsigner"
         " -keystore \"" + keystore.keystore_path.string() + "\""
-        " -storepass " + store_pass +
-        " -keypass " + key_pass +
+        " -storepass " + shell_quote(store_pass) +
+        " -keypass " + shell_quote(key_pass) +
         " \"" + aab_path.string() + "\""
         " \"" + keystore.key_alias + "\"";
-#ifdef _WIN32
-    return exec_status_win(cmd) == 0;
-#else
-    return exec_status(cmd) == 0;
-#endif
+    return run_status(cmd) == 0;
 }
 
 AndroidSigningInfo check_android_signing(const fs::path& path) {
@@ -240,8 +268,8 @@ AndroidSigningInfo check_android_signing(const fs::path& path) {
 
     auto ext = path.extension().string();
     if (ext == ".aab") {
-        // AABs: use jarsigner -verify
-        auto output = exec_cmd("jarsigner -verify \"" + path.string() + "\" 2>&1");
+        // AABs: use jarsigner -verify (platform-aware)
+        auto output = run_cmd("jarsigner -verify \"" + path.string() + "\" 2>&1");
         info.is_signed = output.find("jar verified") != std::string::npos;
         if (!info.is_signed)
             info.error = output;
@@ -255,8 +283,8 @@ AndroidSigningInfo check_android_signing(const fs::path& path) {
         return info;
     }
 
-    auto output = exec_cmd("\"" + tool.string() + "\" verify --print-certs --verbose \""
-                           + path.string() + "\" 2>&1");
+    auto output = run_cmd("\"" + tool.string() + "\" verify --print-certs --verbose \""
+                          + path.string() + "\" 2>&1");
 
     info.is_signed = output.find("Verified using") != std::string::npos;
     info.v2_signed = output.find("Verified using v2 scheme") != std::string::npos
@@ -320,17 +348,13 @@ AndroidPackageResult build_android_package(
         auto key_pass = resolve_password(
             keystore->key_password.empty() ? keystore->store_password : keystore->key_password);
         cmd += " -Pandroid.injected.signing.store.file=\"" + keystore->keystore_path.string() + "\"";
-        cmd += " -Pandroid.injected.signing.store.password=" + store_pass;
+        cmd += " -Pandroid.injected.signing.store.password=" + shell_quote(store_pass);
         cmd += " -Pandroid.injected.signing.key.alias=" + keystore->key_alias;
-        cmd += " -Pandroid.injected.signing.key.password=" + key_pass;
+        cmd += " -Pandroid.injected.signing.key.password=" + shell_quote(key_pass);
     }
 
     // Run Gradle (can take minutes for a full build)
-#ifdef _WIN32
-    int rc = exec_status_win(cmd, 600000);
-#else
-    int rc = exec_status(cmd, 600000);
-#endif
+    int rc = run_status(cmd, 600000);
     if (rc != 0) {
         result.error = "Gradle build failed (exit code " + std::to_string(rc) + ")";
         return result;
@@ -392,15 +416,11 @@ bool aab_to_apks(const fs::path& aab_path,
             keystore->key_password.empty() ? keystore->store_password : keystore->key_password);
         cmd += " --ks=\"" + keystore->keystore_path.string() + "\"";
         cmd += " --ks-key-alias=" + keystore->key_alias;
-        cmd += " --ks-pass=pass:" + store_pass;
-        cmd += " --key-pass=pass:" + key_pass;
+        cmd += " --ks-pass=pass:" + shell_quote(store_pass);
+        cmd += " --key-pass=pass:" + shell_quote(key_pass);
     }
 
-#ifdef _WIN32
-    return exec_status_win(cmd) == 0;
-#else
-    return exec_status(cmd) == 0;
-#endif
+    return run_status(cmd) == 0;
 }
 
 } // namespace pulp::ship

--- a/ship/platform/android/package_android.cpp
+++ b/ship/platform/android/package_android.cpp
@@ -62,7 +62,9 @@ static std::string resolve_password(const std::string& password) {
     return password;
 }
 
-static fs::path find_sdk_root() {
+// ── Public SDK discovery API ────────────────────────────────────────────────
+
+fs::path detect_android_sdk() {
     // Check environment variables first
     if (auto env = get_env("ANDROID_HOME")) {
         auto p = fs::path(*env);
@@ -103,13 +105,36 @@ static fs::path find_latest_build_tools(const fs::path& sdk) {
     }
     if (versions.empty()) return {};
 
-    // Sort by version string (lexicographic works for semver with same digit count)
     std::sort(versions.begin(), versions.end());
     return versions.back();
 }
 
-static fs::path find_build_tool(const std::string& name) {
-    auto sdk = find_sdk_root();
+fs::path find_android_ndk() {
+    // Check dedicated env var first
+    if (auto env = get_env("ANDROID_NDK_HOME")) {
+        auto p = fs::path(*env);
+        if (fs::exists(p / "ndk-build") || fs::exists(p / "toolchains"))
+            return p;
+    }
+
+    auto sdk = detect_android_sdk();
+    if (sdk.empty()) return {};
+
+    auto ndk_dir = sdk / "ndk";
+    if (!fs::exists(ndk_dir)) return {};
+
+    std::vector<fs::path> versions;
+    for (auto& entry : fs::directory_iterator(ndk_dir)) {
+        if (entry.is_directory())
+            versions.push_back(entry.path());
+    }
+    if (versions.empty()) return {};
+    std::sort(versions.begin(), versions.end());
+    return versions.back();
+}
+
+fs::path find_android_build_tool(const std::string& name) {
+    auto sdk = detect_android_sdk();
     if (sdk.empty()) return {};
     auto bt = find_latest_build_tools(sdk);
     if (bt.empty()) return {};
@@ -125,6 +150,24 @@ static fs::path find_build_tool(const std::string& name) {
     return {};
 }
 
+std::string android_build_tools_version() {
+    auto sdk = detect_android_sdk();
+    if (sdk.empty()) return {};
+    auto bt = find_latest_build_tools(sdk);
+    if (bt.empty()) return {};
+    return bt.filename().string();
+}
+
+std::string detect_java_version() {
+    auto output = exec_cmd("java -version 2>&1 | head -1");
+    // Parse: openjdk version "17.0.2" or java version "21.0.2"
+    auto q1 = output.find('"');
+    if (q1 == std::string::npos) return {};
+    auto q2 = output.find('"', q1 + 1);
+    if (q2 == std::string::npos) return {};
+    return output.substr(q1 + 1, q2 - q1 - 1);
+}
+
 static fs::path find_gradlew(const fs::path& project_dir) {
 #ifdef _WIN32
     auto gradlew = project_dir / "gradlew.bat";
@@ -138,7 +181,7 @@ static fs::path find_gradlew(const fs::path& project_dir) {
 // ── Core operations ─────────────────────────────────────────────────────────
 
 bool zipalign_apk(const fs::path& input_apk, const fs::path& output_apk) {
-    auto tool = find_build_tool("zipalign");
+    auto tool = find_android_build_tool("zipalign");
     if (tool.empty()) return false;
 
     std::string cmd = "\"" + tool.string() + "\" -f 4 \""
@@ -151,7 +194,7 @@ bool zipalign_apk(const fs::path& input_apk, const fs::path& output_apk) {
 }
 
 bool sign_apk(const fs::path& apk_path, const AndroidKeystoreConfig& keystore) {
-    auto tool = find_build_tool("apksigner");
+    auto tool = find_android_build_tool("apksigner");
     if (tool.empty()) return false;
 
     auto store_pass = resolve_password(keystore.store_password);
@@ -206,7 +249,7 @@ AndroidSigningInfo check_android_signing(const fs::path& path) {
     }
 
     // APKs: use apksigner verify
-    auto tool = find_build_tool("apksigner");
+    auto tool = find_android_build_tool("apksigner");
     if (tool.empty()) {
         info.error = "apksigner not found — install Android SDK Build Tools";
         return info;

--- a/ship/platform/android/package_android.cpp
+++ b/ship/platform/android/package_android.cpp
@@ -1,0 +1,363 @@
+// Android signing and packaging for Pulp
+// Host-side tool — runs on macOS/Windows/Linux dev machine, not on Android device.
+// Shells out to Android SDK build-tools (apksigner, zipalign, bundletool)
+// and Gradle for APK/AAB generation.
+
+#include <pulp/ship/android.hpp>
+#include <pulp/platform/child_process.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <optional>
+#include <regex>
+#include <sstream>
+
+namespace pulp::ship {
+namespace fs = std::filesystem;
+
+static std::optional<std::string> get_env(const std::string& name) {
+    auto val = std::getenv(name.c_str());
+    if (val) return std::string(val);
+    return std::nullopt;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+static std::string exec_cmd(const std::string& cmd, int timeout_ms = 120000) {
+    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, timeout_ms);
+    auto result = r.stdout_output;
+    while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
+        result.pop_back();
+    return result;
+}
+
+static int exec_status(const std::string& cmd, int timeout_ms = 120000) {
+    auto r = pulp::platform::exec("/bin/sh", {"-c", cmd}, timeout_ms);
+    return r.exit_code;
+}
+
+#ifdef _WIN32
+static std::string exec_cmd_win(const std::string& cmd, int timeout_ms = 120000) {
+    auto r = pulp::platform::exec("cmd.exe", {"/c", cmd}, timeout_ms);
+    auto result = r.stdout_output;
+    while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
+        result.pop_back();
+    return result;
+}
+static int exec_status_win(const std::string& cmd, int timeout_ms = 120000) {
+    auto r = pulp::platform::exec("cmd.exe", {"/c", cmd}, timeout_ms);
+    return r.exit_code;
+}
+#endif
+
+static std::string resolve_password(const std::string& password) {
+    // Support @env:VAR_NAME syntax
+    if (password.size() > 5 && password.substr(0, 5) == "@env:") {
+        auto var = password.substr(5);
+        if (auto val = get_env(var))
+            return *val;
+        return {};  // env var not set
+    }
+    return password;
+}
+
+static fs::path find_sdk_root() {
+    // Check environment variables first
+    if (auto env = get_env("ANDROID_HOME")) {
+        auto p = fs::path(*env);
+        if (fs::exists(p / "build-tools")) return p;
+    }
+    if (auto env = get_env("ANDROID_SDK_ROOT")) {
+        auto p = fs::path(*env);
+        if (fs::exists(p / "build-tools")) return p;
+    }
+
+    // Platform defaults
+    auto home_opt = get_env("HOME");
+    if (!home_opt) home_opt = get_env("USERPROFILE");
+    if (!home_opt) return {};
+    auto home = fs::path(*home_opt);
+
+#ifdef __APPLE__
+    auto candidate = home / "Library" / "Android" / "sdk";
+#elif defined(_WIN32)
+    auto localappdata = get_env("LOCALAPPDATA");
+    auto candidate = localappdata ? fs::path(*localappdata) / "Android" / "Sdk"
+                                  : home / "AppData" / "Local" / "Android" / "Sdk";
+#else
+    auto candidate = home / "Android" / "Sdk";
+#endif
+    if (fs::exists(candidate / "build-tools")) return candidate;
+    return {};
+}
+
+static fs::path find_latest_build_tools(const fs::path& sdk) {
+    auto bt_dir = sdk / "build-tools";
+    if (!fs::exists(bt_dir)) return {};
+
+    std::vector<fs::path> versions;
+    for (auto& entry : fs::directory_iterator(bt_dir)) {
+        if (entry.is_directory())
+            versions.push_back(entry.path());
+    }
+    if (versions.empty()) return {};
+
+    // Sort by version string (lexicographic works for semver with same digit count)
+    std::sort(versions.begin(), versions.end());
+    return versions.back();
+}
+
+static fs::path find_build_tool(const std::string& name) {
+    auto sdk = find_sdk_root();
+    if (sdk.empty()) return {};
+    auto bt = find_latest_build_tools(sdk);
+    if (bt.empty()) return {};
+
+    auto tool = bt / name;
+#ifdef _WIN32
+    auto tool_bat = bt / (name + ".bat");
+    if (fs::exists(tool_bat)) return tool_bat;
+    auto tool_exe = bt / (name + ".exe");
+    if (fs::exists(tool_exe)) return tool_exe;
+#endif
+    if (fs::exists(tool)) return tool;
+    return {};
+}
+
+static fs::path find_gradlew(const fs::path& project_dir) {
+#ifdef _WIN32
+    auto gradlew = project_dir / "gradlew.bat";
+#else
+    auto gradlew = project_dir / "gradlew";
+#endif
+    if (fs::exists(gradlew)) return gradlew;
+    return {};
+}
+
+// ── Core operations ─────────────────────────────────────────────────────────
+
+bool zipalign_apk(const fs::path& input_apk, const fs::path& output_apk) {
+    auto tool = find_build_tool("zipalign");
+    if (tool.empty()) return false;
+
+    std::string cmd = "\"" + tool.string() + "\" -f 4 \""
+        + input_apk.string() + "\" \"" + output_apk.string() + "\"";
+#ifdef _WIN32
+    return exec_status_win(cmd) == 0;
+#else
+    return exec_status(cmd) == 0;
+#endif
+}
+
+bool sign_apk(const fs::path& apk_path, const AndroidKeystoreConfig& keystore) {
+    auto tool = find_build_tool("apksigner");
+    if (tool.empty()) return false;
+
+    auto store_pass = resolve_password(keystore.store_password);
+    auto key_pass = resolve_password(
+        keystore.key_password.empty() ? keystore.store_password : keystore.key_password);
+
+    std::string cmd = "\"" + tool.string() + "\" sign"
+        " --ks \"" + keystore.keystore_path.string() + "\""
+        " --ks-key-alias \"" + keystore.key_alias + "\""
+        " --ks-pass pass:" + store_pass +
+        " --key-pass pass:" + key_pass +
+        " --v2-signing-enabled true"
+        " --v3-signing-enabled true"
+        " \"" + apk_path.string() + "\"";
+#ifdef _WIN32
+    return exec_status_win(cmd) == 0;
+#else
+    return exec_status(cmd) == 0;
+#endif
+}
+
+bool sign_aab(const fs::path& aab_path, const AndroidKeystoreConfig& keystore) {
+    auto store_pass = resolve_password(keystore.store_password);
+    auto key_pass = resolve_password(
+        keystore.key_password.empty() ? keystore.store_password : keystore.key_password);
+
+    // AABs use jarsigner (Google re-signs with Play App Signing)
+    std::string cmd = "jarsigner"
+        " -keystore \"" + keystore.keystore_path.string() + "\""
+        " -storepass " + store_pass +
+        " -keypass " + key_pass +
+        " \"" + aab_path.string() + "\""
+        " \"" + keystore.key_alias + "\"";
+#ifdef _WIN32
+    return exec_status_win(cmd) == 0;
+#else
+    return exec_status(cmd) == 0;
+#endif
+}
+
+AndroidSigningInfo check_android_signing(const fs::path& path) {
+    AndroidSigningInfo info;
+
+    auto ext = path.extension().string();
+    if (ext == ".aab") {
+        // AABs: use jarsigner -verify
+        auto output = exec_cmd("jarsigner -verify \"" + path.string() + "\" 2>&1");
+        info.is_signed = output.find("jar verified") != std::string::npos;
+        if (!info.is_signed)
+            info.error = output;
+        return info;
+    }
+
+    // APKs: use apksigner verify
+    auto tool = find_build_tool("apksigner");
+    if (tool.empty()) {
+        info.error = "apksigner not found — install Android SDK Build Tools";
+        return info;
+    }
+
+    auto output = exec_cmd("\"" + tool.string() + "\" verify --print-certs --verbose \""
+                           + path.string() + "\" 2>&1");
+
+    info.is_signed = output.find("Verified using") != std::string::npos;
+    info.v2_signed = output.find("Verified using v2 scheme") != std::string::npos
+                  || output.find("v2 scheme (APK Signature Scheme v2): true") != std::string::npos;
+    info.v3_signed = output.find("Verified using v3 scheme") != std::string::npos
+                  || output.find("v3 scheme (APK Signature Scheme v3): true") != std::string::npos;
+
+    // Parse signer CN
+    std::regex cn_re("CN=([^,\\n]+)");
+    std::smatch match;
+    if (std::regex_search(output, match, cn_re))
+        info.signer_cn = match[1].str();
+
+    if (!info.is_signed)
+        info.error = output;
+
+    return info;
+}
+
+// ── High-level packaging ────────────────────────────────────────────────────
+
+AndroidPackageResult build_android_package(
+    const fs::path& gradle_project_dir,
+    const std::vector<std::string>& abis,
+    const AndroidKeystoreConfig* keystore,
+    bool build_aab,
+    bool build_apk) {
+
+    AndroidPackageResult result;
+
+    auto gradlew = find_gradlew(gradle_project_dir);
+    if (gradlew.empty()) {
+        result.error = "gradlew not found in " + gradle_project_dir.string();
+        return result;
+    }
+
+    // Build Gradle tasks
+    std::string tasks;
+    if (build_apk) tasks += " assembleRelease";
+    if (build_aab) tasks += " bundleRelease";
+
+    // Set ABI filter via Gradle property
+    std::string abi_filter;
+    if (!abis.empty()) {
+        for (size_t i = 0; i < abis.size(); ++i) {
+            if (i > 0) abi_filter += ",";
+            abi_filter += abis[i];
+        }
+    }
+
+    // Build command
+    std::string cmd = "cd \"" + gradle_project_dir.string() + "\" && \""
+        + gradlew.string() + "\"" + tasks;
+
+    if (!abi_filter.empty())
+        cmd += " -Pandroid.injected.build.abi=" + abi_filter;
+
+    // Pass signing config via Gradle properties if keystore provided
+    if (keystore) {
+        auto store_pass = resolve_password(keystore->store_password);
+        auto key_pass = resolve_password(
+            keystore->key_password.empty() ? keystore->store_password : keystore->key_password);
+        cmd += " -Pandroid.injected.signing.store.file=\"" + keystore->keystore_path.string() + "\"";
+        cmd += " -Pandroid.injected.signing.store.password=" + store_pass;
+        cmd += " -Pandroid.injected.signing.key.alias=" + keystore->key_alias;
+        cmd += " -Pandroid.injected.signing.key.password=" + key_pass;
+    }
+
+    // Run Gradle (can take minutes for a full build)
+#ifdef _WIN32
+    int rc = exec_status_win(cmd, 600000);
+#else
+    int rc = exec_status(cmd, 600000);
+#endif
+    if (rc != 0) {
+        result.error = "Gradle build failed (exit code " + std::to_string(rc) + ")";
+        return result;
+    }
+
+    // Collect artifacts
+    auto outputs = gradle_project_dir / "app" / "build" / "outputs";
+
+    if (build_apk) {
+        auto apk_dir = outputs / "apk" / "release";
+        if (fs::exists(apk_dir)) {
+            for (auto& entry : fs::directory_iterator(apk_dir)) {
+                if (entry.path().extension() == ".apk"
+                    && entry.path().filename().string().find("unsigned") == std::string::npos) {
+                    result.apk_path = entry.path();
+                    break;
+                }
+            }
+        }
+    }
+
+    if (build_aab) {
+        auto aab_dir = outputs / "bundle" / "release";
+        if (fs::exists(aab_dir)) {
+            for (auto& entry : fs::directory_iterator(aab_dir)) {
+                if (entry.path().extension() == ".aab") {
+                    result.aab_path = entry.path();
+                    break;
+                }
+            }
+        }
+    }
+
+    result.success = (!build_apk || !result.apk_path.empty())
+                  && (!build_aab || !result.aab_path.empty());
+
+    if (!result.success && result.error.empty())
+        result.error = "Build succeeded but expected artifacts not found in " + outputs.string();
+
+    return result;
+}
+
+bool aab_to_apks(const fs::path& aab_path,
+                 const fs::path& output_apks,
+                 const AndroidKeystoreConfig* keystore) {
+    // bundletool must be on PATH or at BUNDLETOOL env var
+    std::string bundletool = "bundletool";
+    if (auto env = get_env("BUNDLETOOL"))
+        bundletool = *env;
+
+    std::string cmd = bundletool + " build-apks"
+        " --bundle=\"" + aab_path.string() + "\""
+        " --output=\"" + output_apks.string() + "\""
+        " --overwrite";
+
+    if (keystore) {
+        auto store_pass = resolve_password(keystore->store_password);
+        auto key_pass = resolve_password(
+            keystore->key_password.empty() ? keystore->store_password : keystore->key_password);
+        cmd += " --ks=\"" + keystore->keystore_path.string() + "\"";
+        cmd += " --ks-key-alias=" + keystore->key_alias;
+        cmd += " --ks-pass=pass:" + store_pass;
+        cmd += " --key-pass=pass:" + key_pass;
+    }
+
+#ifdef _WIN32
+    return exec_status_win(cmd) == 0;
+#else
+    return exec_status(cmd) == 0;
+#endif
+}
+
+} // namespace pulp::ship

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -1799,6 +1799,202 @@ static int cmd_validate(const std::vector<std::string>& args) {
     return failed > 0 ? 1 : 0;
 }
 
+// ── Config command ──────────────────────────────────────────────────────────
+
+static int cmd_config(const std::vector<std::string>& args) {
+    auto config_path = pulp_home() / "config.toml";
+    std::string sub = args.empty() ? "show" : args[0];
+
+    if (sub == "init") {
+        bool force = false;
+        for (auto& a : args) if (a == "--force") force = true;
+
+        if (fs::exists(config_path) && !force) {
+            std::cout << "Config already exists at " << config_path.string() << " — no changes made.\n";
+            std::cout << "Use --force to overwrite (will ask for confirmation).\n";
+            return 0;
+        }
+
+        if (fs::exists(config_path) && force) {
+            std::cout << "This will overwrite " << config_path.string() << ". Continue? [y/N] ";
+            std::string response;
+            std::getline(std::cin, response);
+            if (response.empty() || (response[0] != 'y' && response[0] != 'Y')) {
+                std::cout << "Cancelled.\n";
+                return 0;
+            }
+        }
+
+        // Find config.example.toml in the repo
+        auto root = find_project_root();
+        fs::path template_path;
+        if (!root.empty()) template_path = root / "config.example.toml";
+
+        // Also check relative to the binary
+        if (template_path.empty() || !fs::exists(template_path)) {
+            auto bin_root = source_checkout_root_from_current_binary();
+            if (!bin_root.empty()) template_path = bin_root / "config.example.toml";
+        }
+
+        fs::create_directories(config_path.parent_path());
+
+        if (!template_path.empty() && fs::exists(template_path)) {
+            fs::copy_file(template_path, config_path, fs::copy_options::overwrite_existing);
+            std::cout << "Config template copied to " << config_path.string() << "\n";
+            std::cout << "Edit it to add your developer signing credentials.\n";
+        } else {
+            // Write a minimal config
+            std::ofstream out(config_path);
+            out << "# Pulp Developer Configuration\n"
+                << "# See config.example.toml in the Pulp repo for all options.\n\n"
+                << "[developer]\n"
+                << "# name = \"Your Name\"\n\n"
+                << "[signing.apple]\n"
+                << "# identity = \"Developer ID Application: Your Name (TEAMID)\"\n"
+                << "# team_id = \"ABCDE12345\"\n"
+                << "# apple_id = \"you@example.com\"\n\n"
+                << "[signing.android]\n"
+                << "# keystore = \"~/keystores/release.jks\"\n"
+                << "# key_alias = \"release\"\n"
+                << "# store_pass = \"@env:ANDROID_STORE_PASS\"\n";
+            std::cout << "Config created at " << config_path.string() << "\n";
+        }
+        return 0;
+    }
+
+    if (sub == "set" && args.size() >= 3) {
+        auto dotted_key = args[1];
+        auto value = args[2];
+
+        // Parse "signing.apple.identity" → section="signing.apple", key="identity"
+        auto last_dot = dotted_key.rfind('.');
+        if (last_dot == std::string::npos) {
+            std::cerr << "Error: key must be in section.key format (e.g., signing.apple.identity)\n";
+            return 1;
+        }
+        auto section = dotted_key.substr(0, last_dot);
+        auto key = dotted_key.substr(last_dot + 1);
+
+        // If config doesn't exist, create from template first
+        if (!fs::exists(config_path)) {
+            std::vector<std::string> init_args = {"init"};
+            cmd_config(init_args);
+        }
+
+        // Read all lines, find and replace or append
+        std::vector<std::string> lines;
+        {
+            std::ifstream in(config_path);
+            std::string line;
+            while (std::getline(in, line)) lines.push_back(line);
+        }
+
+        std::string section_header = "[" + section + "]";
+        int section_line = -1;
+        int key_line = -1;
+        std::string current_section;
+
+        for (int i = 0; i < static_cast<int>(lines.size()); ++i) {
+            auto trimmed = trim(lines[i]);
+            if (trimmed.empty() || trimmed[0] == '#') {
+                // Check if it's a commented-out version of our key
+                if (current_section == section && !trimmed.empty() && trimmed[0] == '#') {
+                    auto pos = trimmed.find_first_not_of("# ");
+                    if (pos != std::string::npos) {
+                        auto uncommented = trim(trimmed.substr(pos));
+                        auto eq = uncommented.find('=');
+                        if (eq != std::string::npos && trim(uncommented.substr(0, eq)) == key) {
+                            key_line = i;  // Replace the commented-out line
+                        }
+                    }
+                }
+                continue;
+            }
+            if (trimmed.front() == '[' && trimmed.back() == ']') {
+                current_section = trim(trimmed.substr(1, trimmed.size() - 2));
+                if (current_section == section) section_line = i;
+                continue;
+            }
+            if (current_section == section) {
+                auto eq = trimmed.find('=');
+                if (eq != std::string::npos && trim(trimmed.substr(0, eq)) == key) {
+                    key_line = i;
+                }
+            }
+        }
+
+        std::string new_line = key + " = \"" + value + "\"";
+
+        if (key_line >= 0) {
+            lines[key_line] = new_line;
+        } else if (section_line >= 0) {
+            // Insert after section header
+            lines.insert(lines.begin() + section_line + 1, new_line);
+        } else {
+            // Section doesn't exist — append
+            lines.push_back("");
+            lines.push_back(section_header);
+            lines.push_back(new_line);
+        }
+
+        // Write back
+        std::ofstream out(config_path);
+        for (auto& l : lines) out << l << "\n";
+
+        std::cout << "Set " << section << "." << key << " in " << config_path.string() << "\n";
+        return 0;
+    }
+
+    if (sub == "show" || sub == "path") {
+        if (sub == "path") {
+            std::cout << config_path.string() << "\n";
+            return 0;
+        }
+        if (!fs::exists(config_path)) {
+            std::cout << "No config file found at " << config_path.string() << "\n";
+            std::cout << "Run `pulp config init` to create one from the template.\n";
+            return 0;
+        }
+        // Show non-comment, non-empty lines
+        std::ifstream in(config_path);
+        std::string line;
+        while (std::getline(in, line)) {
+            auto trimmed = trim(line);
+            if (!trimmed.empty() && trimmed[0] != '#')
+                std::cout << line << "\n";
+        }
+        return 0;
+    }
+
+    std::cout << "pulp config — manage developer configuration\n\n";
+    std::cout << "Subcommands:\n";
+    std::cout << "  init                               Create ~/.pulp/config.toml from template\n";
+    std::cout << "  set <section.key> <value>           Set a config value\n";
+    std::cout << "  show                                Show current config (non-comment lines)\n";
+    std::cout << "  path                                Print config file path\n\n";
+    std::cout << "Examples:\n";
+    std::cout << "  pulp config init\n";
+    std::cout << "  pulp config set signing.apple.identity \"Developer ID Application: ...\"\n";
+    std::cout << "  pulp config set signing.android.keystore ~/keystores/release.jks\n";
+    return 0;
+}
+
+// ── Config fallback helpers for ship commands ───────────────────────────────
+
+// Read a ship config value: CLI flag → env var → project pulp.toml → global config.toml
+static std::string ship_config(const std::string& cli_val,
+                                const std::string& env_name,
+                                const std::string& section,
+                                const std::string& key) {
+    if (!cli_val.empty()) return cli_val;
+    if (!env_name.empty()) {
+        if (auto env = pulp::runtime::get_env(env_name))
+            if (!env->empty()) return *env;
+    }
+    // TODO: project pulp.toml override (future)
+    return read_user_config_value(section, key);
+}
+
 static int cmd_ship(const std::vector<std::string>& args) {
     auto root = find_project_root();
     if (root.empty()) {
@@ -1826,8 +2022,22 @@ static int cmd_ship(const std::vector<std::string>& args) {
         }
 
         if (target == "android") {
+            // Fall back to config for Android signing
+            keystore_path = ship_config(keystore_path, "", "signing.android", "keystore");
+            key_alias = ship_config(key_alias, "", "signing.android", "key_alias");
+            store_pass = ship_config(store_pass, "ANDROID_STORE_PASS", "signing.android", "store_pass");
+            key_pass = ship_config(key_pass, "ANDROID_KEY_PASS", "signing.android", "key_pass");
+
             if (keystore_path.empty()) {
-                std::cerr << "Usage: pulp ship sign --target android --keystore key.jks --key-alias mykey\n";
+                std::cerr << "Error: No Android keystore specified.\n\n";
+                std::cerr << "  pulp ship sign --target android --keystore ~/keystores/release.jks --key-alias release\n\n";
+                std::cerr << "  To create a release keystore:\n";
+                std::cerr << "    keytool -genkey -v -keystore release.jks -keyalg RSA -keysize 2048 -validity 10000\n\n";
+                std::cerr << "  To save for next time, add to ~/.pulp/config.toml:\n";
+                std::cerr << "    [signing.android]\n";
+                std::cerr << "    keystore  = \"~/keystores/release.jks\"\n";
+                std::cerr << "    key_alias = \"release\"\n";
+                std::cerr << "    store_pass = \"@env:ANDROID_STORE_PASS\"\n";
                 return 1;
             }
             pulp::ship::AndroidKeystoreConfig ks;
@@ -1863,10 +2073,23 @@ static int cmd_ship(const std::vector<std::string>& args) {
             return signed_count > 0 ? 0 : 1;
         }
 
-        // Desktop signing (macOS/Windows)
+        // Desktop signing (macOS/Windows) — fall back to config
+        identity = ship_config(identity, "PULP_SIGN_IDENTITY", "signing.apple", "identity");
+
         if (identity.empty()) {
-            std::cerr << "Usage: pulp ship sign --identity \"Developer ID Application: ...\"\n";
-            std::cerr << "       pulp ship sign --target android --keystore key.jks\n";
+            std::cerr << "Error: No signing identity specified.\n\n";
+            std::cerr << "  pulp ship sign --identity \"Developer ID Application: Your Name (TEAMID)\"\n\n";
+            std::cerr << "  To find your identity:\n";
+#ifdef __APPLE__
+            std::cerr << "    security find-identity -v -p codesigning\n";
+            std::cerr << "    Or: Keychain Access → My Certificates\n\n";
+#else
+            std::cerr << "    Check your certificate store for a code signing certificate.\n\n";
+#endif
+            std::cerr << "  To save for next time, add to ~/.pulp/config.toml:\n";
+            std::cerr << "    [signing.apple]\n";
+            std::cerr << "    identity = \"Developer ID Application: Your Name (TEAMID)\"\n\n";
+            std::cerr << "  Or run: pulp config set signing.apple.identity \"Developer ID Application: ...\"\n";
             return 1;
         }
 
@@ -2128,8 +2351,25 @@ static int cmd_ship(const std::vector<std::string>& args) {
             return stapled == static_cast<int>(bundles.size()) ? 0 : 1;
         }
 
+        // Fall back to config
+        apple_id = ship_config(apple_id, "PULP_APPLE_ID", "signing.apple", "apple_id");
+        team_id = ship_config(team_id, "PULP_TEAM_ID", "signing.apple", "team_id");
+        password = ship_config(password, "", "signing.apple", "password");
+
         if (apple_id.empty() || team_id.empty()) {
-            std::cerr << "Usage: pulp ship notarize --apple-id you@example.com --team-id ABCDE12345\n";
+            std::cerr << "Error: Apple ID and Team ID required for notarization.\n\n";
+            std::cerr << "  pulp ship notarize --apple-id you@example.com --team-id ABCDE12345\n\n";
+            std::cerr << "  Where to find these:\n";
+            std::cerr << "    Apple ID:  Your Apple Developer account email\n";
+            std::cerr << "    Team ID:   https://developer.apple.com/account → Membership → Team ID\n";
+            std::cerr << "    Password:  https://appleid.apple.com → Sign-In and Security → App-Specific Passwords\n";
+            std::cerr << "               Then store in Keychain:\n";
+            std::cerr << "               security add-generic-password -s AC_PASSWORD -a you@example.com -w\n\n";
+            std::cerr << "  To save for next time, add to ~/.pulp/config.toml:\n";
+            std::cerr << "    [signing.apple]\n";
+            std::cerr << "    apple_id = \"you@example.com\"\n";
+            std::cerr << "    team_id  = \"ABCDE12345\"\n";
+            std::cerr << "    password = \"@keychain:AC_PASSWORD\"\n";
             return 1;
         }
         if (password.empty()) password = "@keychain:AC_PASSWORD";
@@ -2568,6 +2808,46 @@ static std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, b
         checks.push_back(c);
     }
 #endif
+
+    // Android toolchain (optional — needed for `pulp ship package --target android`)
+    {
+        DoctorCheck c{"Android SDK (optional)", true, {}, {}};
+        auto sdk = pulp::ship::detect_android_sdk();
+        if (!sdk.empty()) {
+            c.detail = sdk.string();
+        } else {
+            c.detail = "Not configured — install Android Studio (https://developer.android.com/studio) or set ANDROID_HOME";
+        }
+        checks.push_back(c);
+    }
+    {
+        DoctorCheck c{"Android NDK (optional)", true, {}, {}};
+        auto ndk = pulp::ship::find_android_ndk();
+        if (!ndk.empty()) {
+            c.detail = ndk.filename().string();
+        } else {
+            c.detail = "Not installed — install via Android Studio SDK Manager or sdkmanager";
+        }
+        checks.push_back(c);
+    }
+    {
+        DoctorCheck c{"Java (optional, for Android)", true, {}, {}};
+        auto ver = pulp::ship::detect_java_version();
+        if (!ver.empty()) {
+            c.detail = "Java " + ver;
+            auto dot = ver.find('.');
+            auto major_str = (dot != std::string::npos) ? ver.substr(0, dot) : ver;
+            try {
+                int major = std::stoi(major_str);
+                if (major < pulp::ship::PULP_ANDROID_MIN_JAVA) {
+                    c.detail += " (Java " + std::to_string(pulp::ship::PULP_ANDROID_MIN_JAVA) + "+ recommended)";
+                }
+            } catch (...) {}
+        } else {
+            c.detail = "Not found — install JDK 17+ for Android builds";
+        }
+        checks.push_back(c);
+    }
 
     if (!active_root.empty()) {
         DoctorCheck c{"Build configured", false, {}, {}};
@@ -4978,6 +5258,7 @@ int main(int argc, char* argv[]) {
     if (command == "validate") return cmd_validate(args);
     if (command == "doctor")   return cmd_doctor(args);
     if (command == "upgrade")  return cmd_upgrade(args);
+    if (command == "config")   return cmd_config(args);
     if (command == "ship")     return cmd_ship(args);
     if (command == "docs")     return cmd_docs(args);
     if (command == "clean")    return cmd_clean(args);

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -32,6 +32,9 @@
 #include "package_registry.hpp"
 #include "tool_registry.hpp"
 #include "design_binding.hpp"
+#include <pulp/ship/android.hpp>
+#include <pulp/ship/appcast.hpp>
+#include <pulp/ship/codesign.hpp>
 #include <pulp/ship/installer.hpp>
 #include <pulp/view/screenshot.hpp>
 #include <pulp/format/editor_ui.hpp>
@@ -1804,26 +1807,66 @@ static int cmd_ship(const std::vector<std::string>& args) {
     }
 
     auto build_dir = root / "build";
-    if (!fs::exists(build_dir / "CMakeCache.txt")) {
-        std::cerr << "Build directory not found. Run `pulp build` first.\n";
-        return 1;
-    }
 
     // Parse subcommand
     std::string sub = args.empty() ? "help" : args[0];
 
+    // ── sign ────────────────────────────────────────────────────────────────
     if (sub == "sign") {
-        // Sign all plugin bundles
-        std::string identity;
+        std::string target, identity, keystore_path, key_alias, store_pass, key_pass;
         std::string entitlements = (root / "ship" / "templates" / "entitlements.plist").string();
         for (size_t i = 1; i < args.size(); ++i) {
-            if (args[i] == "--identity" && i + 1 < args.size())
-                identity = args[++i];
-            else if (args[i] == "--entitlements" && i + 1 < args.size())
-                entitlements = args[++i];
+            if (args[i] == "--target" && i + 1 < args.size()) target = args[++i];
+            else if (args[i] == "--identity" && i + 1 < args.size()) identity = args[++i];
+            else if (args[i] == "--entitlements" && i + 1 < args.size()) entitlements = args[++i];
+            else if (args[i] == "--keystore" && i + 1 < args.size()) keystore_path = args[++i];
+            else if (args[i] == "--key-alias" && i + 1 < args.size()) key_alias = args[++i];
+            else if (args[i] == "--store-pass" && i + 1 < args.size()) store_pass = args[++i];
+            else if (args[i] == "--key-pass" && i + 1 < args.size()) key_pass = args[++i];
         }
+
+        if (target == "android") {
+            if (keystore_path.empty()) {
+                std::cerr << "Usage: pulp ship sign --target android --keystore key.jks --key-alias mykey\n";
+                return 1;
+            }
+            pulp::ship::AndroidKeystoreConfig ks;
+            ks.keystore_path = keystore_path;
+            ks.key_alias = key_alias.empty() ? "key0" : key_alias;
+            ks.store_password = store_pass;
+            ks.key_password = key_pass;
+
+            auto artifacts = root / "artifacts";
+            int signed_count = 0;
+            if (fs::exists(artifacts)) {
+                for (auto& entry : fs::directory_iterator(artifacts)) {
+                    auto ext = entry.path().extension().string();
+                    if (ext == ".apk") {
+                        std::cout << "Signing " << entry.path().filename().string() << "...\n";
+                        auto aligned = entry.path().parent_path()
+                            / (entry.path().stem().string() + "-aligned.apk");
+                        if (pulp::ship::zipalign_apk(entry.path(), aligned)) {
+                            fs::rename(aligned, entry.path());
+                            if (pulp::ship::sign_apk(entry.path(), ks)) ++signed_count;
+                            else std::cerr << "  Sign FAILED\n";
+                        } else {
+                            std::cerr << "  zipalign FAILED\n";
+                        }
+                    } else if (ext == ".aab") {
+                        std::cout << "Signing " << entry.path().filename().string() << "...\n";
+                        if (pulp::ship::sign_aab(entry.path(), ks)) ++signed_count;
+                        else std::cerr << "  Sign FAILED\n";
+                    }
+                }
+            }
+            std::cout << "Signed " << signed_count << " Android artifacts.\n";
+            return signed_count > 0 ? 0 : 1;
+        }
+
+        // Desktop signing (macOS/Windows)
         if (identity.empty()) {
             std::cerr << "Usage: pulp ship sign --identity \"Developer ID Application: ...\"\n";
+            std::cerr << "       pulp ship sign --target android --keystore key.jks\n";
             return 1;
         }
 
@@ -1848,30 +1891,79 @@ static int cmd_ship(const std::vector<std::string>& args) {
         return 0;
     }
 
+    // ── package ─────────────────────────────────────────────────────────────
     if (sub == "package") {
         auto artifacts = root / "artifacts";
         fs::create_directories(artifacts);
 
-        std::string version = "0.1.0";
-        bool per_user = false;
+        std::string version = "0.1.0", target, keystore_path, key_alias, store_pass, key_pass, abi_arg;
+        bool per_user = false, apk_only = false, aab_only = false;
         for (size_t i = 1; i < args.size(); ++i) {
-            if (args[i] == "--version" && i + 1 < args.size())
-                version = args[++i];
-            if (args[i] == "--per-user")
-                per_user = true;
+            if (args[i] == "--version" && i + 1 < args.size()) version = args[++i];
+            else if (args[i] == "--target" && i + 1 < args.size()) target = args[++i];
+            else if (args[i] == "--keystore" && i + 1 < args.size()) keystore_path = args[++i];
+            else if (args[i] == "--key-alias" && i + 1 < args.size()) key_alias = args[++i];
+            else if (args[i] == "--store-pass" && i + 1 < args.size()) store_pass = args[++i];
+            else if (args[i] == "--key-pass" && i + 1 < args.size()) key_pass = args[++i];
+            else if (args[i] == "--abi" && i + 1 < args.size()) abi_arg = args[++i];
+            else if (args[i] == "--apk-only") apk_only = true;
+            else if (args[i] == "--aab-only") aab_only = true;
+            else if (args[i] == "--per-user") per_user = true;
+        }
+
+        if (target == "android") {
+            auto android_dir = root / "android";
+            if (!fs::exists(android_dir / "build.gradle.kts")
+                && !fs::exists(android_dir / "build.gradle")) {
+                std::cerr << "No android/ project found. Run `pulp create --targets android` first.\n";
+                return 1;
+            }
+
+            std::vector<std::string> abis;
+            if (abi_arg == "all") abis = {"arm64-v8a", "x86_64", "armeabi-v7a"};
+            else if (!abi_arg.empty()) abis = {abi_arg};
+            else abis = {"arm64-v8a"};
+
+            std::unique_ptr<pulp::ship::AndroidKeystoreConfig> ks;
+            if (!keystore_path.empty()) {
+                ks = std::make_unique<pulp::ship::AndroidKeystoreConfig>();
+                ks->keystore_path = keystore_path;
+                ks->key_alias = key_alias.empty() ? "key0" : key_alias;
+                ks->store_password = store_pass;
+                ks->key_password = key_pass;
+            }
+
+            bool build_apk = !aab_only, build_aab = !apk_only;
+            std::cout << "Building Android package...\n";
+            auto result = pulp::ship::build_android_package(
+                android_dir, abis, ks.get(), build_aab, build_apk);
+
+            if (!result.success) {
+                std::cerr << "Android build failed: " << result.error << "\n";
+                return 1;
+            }
+
+            if (!result.apk_path.empty()) {
+                auto dest = artifacts / result.apk_path.filename();
+                fs::copy_file(result.apk_path, dest, fs::copy_options::overwrite_existing);
+                std::cout << "  APK: " << dest.string() << "\n";
+            }
+            if (!result.aab_path.empty()) {
+                auto dest = artifacts / result.aab_path.filename();
+                fs::copy_file(result.aab_path, dest, fs::copy_options::overwrite_existing);
+                std::cout << "  AAB: " << dest.string() << "\n";
+            }
+            std::cout << "Android package created in " << artifacts.string() << "\n";
+            return 0;
         }
 
 #ifdef _WIN32
-        // Windows: use NSIS installer
-        // Check for makensis
+        // Windows: NSIS installer
         if (std::system("where makensis >nul 2>&1") != 0) {
             std::cerr << "Error: makensis not found on PATH\n";
-            std::cerr << "  Install NSIS from https://nsis.sourceforge.io/\n";
-            std::cerr << "  Then add its directory to PATH\n";
             return 1;
         }
 
-        // Discover product name from the first plugin found
         std::string product_name;
         pulp::ship::InstallerConfig config;
         config.version = version;
@@ -1882,15 +1974,11 @@ static int cmd_ship(const std::vector<std::string>& args) {
             if (!fs::exists(dir)) continue;
             std::string format_lower = dir_name;
             for (auto& c : format_lower) c = static_cast<char>(std::tolower(c));
-
             for (auto& entry : fs::directory_iterator(dir)) {
                 auto ext = entry.path().extension().string();
                 if (ext == ".vst3" || ext == ".clap") {
-                    if (product_name.empty())
-                        product_name = entry.path().stem().string();
-                    config.plugins.push_back({
-                        entry.path().string(), "", format_lower
-                    });
+                    if (product_name.empty()) product_name = entry.path().stem().string();
+                    config.plugins.push_back({entry.path().string(), "", format_lower});
                 }
             }
         }
@@ -1903,7 +1991,6 @@ static int cmd_ship(const std::vector<std::string>& args) {
         config.product_name = product_name;
         config.publisher = "Pulp";
         config.output_path = (artifacts / (product_name + "-" + version + "-setup.exe")).string();
-
         auto license = root / "LICENSE.md";
         if (fs::exists(license)) config.license_path = license.string();
 
@@ -1916,27 +2003,24 @@ static int cmd_ship(const std::vector<std::string>& args) {
         }
         return 0;
 #else
-        // macOS/Linux: use pkgbuild (macOS) or deb (Linux)
+        // macOS/Linux: pkgbuild
         int pkg_count = 0;
         for (auto dir_name : {"VST3", "CLAP", "AU"}) {
             auto dir = build_dir / dir_name;
             if (!fs::exists(dir)) continue;
             std::string format_lower = dir_name;
             for (auto& c : format_lower) c = static_cast<char>(std::tolower(c));
-
             for (auto& entry : fs::directory_iterator(dir)) {
                 auto ext = entry.path().extension().string();
                 if (ext == ".vst3" || ext == ".clap" || ext == ".component") {
                     auto name = entry.path().stem().string();
                     auto pkg_name = name + "-" + dir_name + "-" + version + ".pkg";
                     auto pkg_path = artifacts / pkg_name;
-
                     std::string install_loc = "/Library/Audio/Plug-Ins/";
                     if (ext == ".vst3") install_loc += "VST3/";
                     else if (ext == ".clap") install_loc += "CLAP/";
                     else install_loc = pulp::runtime::get_env("HOME").value_or("~")
                                      + "/Library/Audio/Plug-Ins/Components/";
-
                     std::cout << "Packaging " << name << " (" << dir_name << ")...\n";
                     std::string cmd = "pkgbuild --component \"" + entry.path().string() + "\""
                         + " --identifier \"com.pulp." + name + "." + format_lower + "\""
@@ -1953,8 +2037,39 @@ static int cmd_ship(const std::vector<std::string>& args) {
 #endif
     }
 
+    // ── check ───────────────────────────────────────────────────────────────
     if (sub == "check") {
-        // Check signing status of all built plugins
+        std::string target;
+        for (size_t i = 1; i < args.size(); ++i)
+            if (args[i] == "--target" && i + 1 < args.size()) target = args[++i];
+
+        if (target == "android") {
+            auto art_dir = root / "artifacts";
+            if (!fs::exists(art_dir)) {
+                std::cerr << "No artifacts/ directory. Run `pulp ship package --target android` first.\n";
+                return 1;
+            }
+            for (auto& entry : fs::directory_iterator(art_dir)) {
+                auto ext = entry.path().extension().string();
+                if (ext == ".apk" || ext == ".aab") {
+                    std::cout << entry.path().filename().string() << ": ";
+                    auto info = pulp::ship::check_android_signing(entry.path());
+                    if (info.is_signed) {
+                        std::cout << "signed";
+                        if (ext == ".apk") {
+                            if (info.v2_signed) std::cout << " v2";
+                            if (info.v3_signed) std::cout << " v3";
+                        }
+                        if (!info.signer_cn.empty()) std::cout << " (" << info.signer_cn << ")";
+                        std::cout << "\n";
+                    } else {
+                        std::cout << "unsigned\n";
+                    }
+                }
+            }
+            return 0;
+        }
+
         for (auto dir_name : {"VST3", "CLAP", "AU"}) {
             auto dir = build_dir / dir_name;
             if (!fs::exists(dir)) continue;
@@ -1971,15 +2086,153 @@ static int cmd_ship(const std::vector<std::string>& args) {
         return 0;
     }
 
-    // Help
-    std::cout << "pulp ship — signing and packaging commands\n\n";
+    // ── notarize ────────────────────────────────────────────────────────────
+    if (sub == "notarize") {
+#ifndef __APPLE__
+        std::cerr << "Notarization is only available on macOS.\n";
+        return 1;
+#else
+        std::string apple_id, team_id, password;
+        bool staple_only = false;
+        for (size_t i = 1; i < args.size(); ++i) {
+            if (args[i] == "--apple-id" && i + 1 < args.size()) apple_id = args[++i];
+            else if (args[i] == "--team-id" && i + 1 < args.size()) team_id = args[++i];
+            else if (args[i] == "--password" && i + 1 < args.size()) password = args[++i];
+            else if (args[i] == "--staple") staple_only = true;
+        }
+
+        std::vector<std::string> bundles;
+        for (auto dir_name : {"VST3", "CLAP", "AU"}) {
+            auto dir = build_dir / dir_name;
+            if (!fs::exists(dir)) continue;
+            for (auto& entry : fs::directory_iterator(dir)) {
+                auto ext = entry.path().extension().string();
+                if (ext == ".vst3" || ext == ".clap" || ext == ".component")
+                    bundles.push_back(entry.path().string());
+            }
+        }
+
+        if (bundles.empty()) {
+            std::cerr << "No plugin bundles found.\n";
+            return 1;
+        }
+
+        if (staple_only) {
+            int stapled = 0;
+            for (auto& path : bundles) {
+                std::cout << "Stapling " << fs::path(path).filename().string() << "...\n";
+                if (pulp::ship::notarize_staple(path)) ++stapled;
+                else std::cerr << "  FAILED\n";
+            }
+            std::cout << "Stapled " << stapled << "/" << bundles.size() << " bundles.\n";
+            return stapled == static_cast<int>(bundles.size()) ? 0 : 1;
+        }
+
+        if (apple_id.empty() || team_id.empty()) {
+            std::cerr << "Usage: pulp ship notarize --apple-id you@example.com --team-id ABCDE12345\n";
+            return 1;
+        }
+        if (password.empty()) password = "@keychain:AC_PASSWORD";
+
+        int success_count = 0;
+        for (auto& path : bundles) {
+            auto name = fs::path(path).filename().string();
+            std::cout << "Submitting " << name << " for notarization...\n";
+            auto uuid = pulp::ship::notarize_submit(path, apple_id, team_id, password);
+            if (!uuid) { std::cerr << "  Submission FAILED\n"; continue; }
+            std::cout << "  Request UUID: " << *uuid << "\n";
+            auto status = pulp::ship::notarize_check(*uuid);
+            if (status.success) {
+                std::cout << "  Notarization succeeded. Stapling...\n";
+                if (pulp::ship::notarize_staple(path)) std::cout << "  Stapled " << name << "\n";
+                else std::cerr << "  Staple FAILED\n";
+                ++success_count;
+            } else {
+                std::cerr << "  Notarization FAILED: " << status.message << "\n";
+            }
+        }
+        std::cout << "Notarized " << success_count << "/" << bundles.size() << " bundles.\n";
+        return success_count == static_cast<int>(bundles.size()) ? 0 : 1;
+#endif
+    }
+
+    // ── appcast ─────────────────────────────────────────────────────────────
+    if (sub == "appcast") {
+        std::string version, notes, url, output_path, title, sign_key, min_os;
+        for (size_t i = 1; i < args.size(); ++i) {
+            if (args[i] == "--version" && i + 1 < args.size()) version = args[++i];
+            else if (args[i] == "--notes" && i + 1 < args.size()) notes = args[++i];
+            else if (args[i] == "--url" && i + 1 < args.size()) url = args[++i];
+            else if (args[i] == "--output" && i + 1 < args.size()) output_path = args[++i];
+            else if (args[i] == "--title" && i + 1 < args.size()) title = args[++i];
+            else if (args[i] == "--sign-key" && i + 1 < args.size()) sign_key = args[++i];
+            else if (args[i] == "--min-os" && i + 1 < args.size()) min_os = args[++i];
+        }
+
+        if (version.empty()) version = "0.1.0";
+        if (url.empty()) {
+            std::cerr << "Usage: pulp ship appcast --url https://example.com/Plugin-1.0.pkg --version 1.0.0\n";
+            return 1;
+        }
+        if (output_path.empty()) output_path = (root / "artifacts" / "appcast.xml").string();
+
+        // Load existing appcast to append
+        pulp::ship::Appcast feed;
+        {
+            std::ifstream existing(output_path);
+            if (existing.good()) {
+                std::string xml((std::istreambuf_iterator<char>(existing)),
+                                std::istreambuf_iterator<char>());
+                if (auto parsed = pulp::ship::Appcast::from_xml(xml)) feed = std::move(*parsed);
+            }
+        }
+
+        if (title.empty() && feed.title.empty()) title = "Plugin Updates";
+        if (!title.empty()) feed.title = title;
+
+        pulp::ship::AppcastItem item;
+        item.version = version;
+        item.title = "Version " + version;
+        item.description = notes.empty() ? "" : "<p>" + notes + "</p>";
+        item.download_url = url;
+        if (!min_os.empty()) item.minimum_os = min_os;
+
+        auto url_as_path = fs::path(url);
+        if (fs::exists(url_as_path)) {
+            item.file_size = fs::file_size(url_as_path);
+            if (!sign_key.empty())
+                item.ed_signature = pulp::ship::sign_file_ed25519(url_as_path.string(), sign_key);
+        }
+
+        { auto now = std::time(nullptr); char buf[64];
+          std::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S %z", std::localtime(&now));
+          item.pub_date = buf; }
+
+        feed.items.insert(feed.items.begin(), std::move(item));
+        fs::create_directories(fs::path(output_path).parent_path());
+        std::ofstream out(output_path);
+        if (!out) { std::cerr << "Error: cannot write to " << output_path << "\n"; return 1; }
+        out << feed.to_xml();
+        std::cout << "Appcast written to " << output_path << " (" << feed.items.size() << " items)\n";
+        return 0;
+    }
+
+    // ── help ────────────────────────────────────────────────────────────────
+    std::cout << "pulp ship — signing, notarization, packaging, and update feeds\n\n";
     std::cout << "Subcommands:\n";
-    std::cout << "  sign     Sign all plugin bundles\n";
-    std::cout << "           --identity \"Developer ID Application: ...\"\n";
-    std::cout << "           --entitlements path/to/entitlements.plist\n";
-    std::cout << "  package  Create .pkg installers for all built plugins\n";
-    std::cout << "           --version 1.0.0\n";
-    std::cout << "  check    Check signing status of built plugins\n";
+    std::cout << "  sign       Sign plugin bundles or Android artifacts\n";
+    std::cout << "             --identity \"Developer ID Application: ...\"  (macOS/Windows)\n";
+    std::cout << "             --target android --keystore key.jks  (Android)\n";
+    std::cout << "  notarize   Submit signed bundles for Apple notarization (macOS)\n";
+    std::cout << "             --apple-id you@example.com --team-id ABCDE12345\n";
+    std::cout << "             --staple  (staple only, skip submission)\n";
+    std::cout << "  package    Create installers for the target platform\n";
+    std::cout << "             --version 1.0.0\n";
+    std::cout << "             --target android --keystore key.jks --abi arm64-v8a|x86_64|all\n";
+    std::cout << "  appcast    Generate Sparkle-compatible update feed\n";
+    std::cout << "             --url https://... --version 1.0.0 --notes \"...\"\n";
+    std::cout << "  check      Check signing status of built plugins\n";
+    std::cout << "             --target android  (check APK/AAB in artifacts/)\n";
     return 0;
 }
 

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -2110,8 +2110,11 @@ static int cmd_ship(const std::vector<std::string>& args) {
                 }
             }
         }
-        std::cout << "Signed " << signed_count << " bundles.\n";
-        return 0;
+        if (signed_count == 0)
+            std::cerr << "No plugin bundles found to sign. Run `pulp build` first.\n";
+        else
+            std::cout << "Signed " << signed_count << " bundles.\n";
+        return signed_count > 0 ? 0 : 1;
     }
 
     // ── package ─────────────────────────────────────────────────────────────
@@ -2378,9 +2381,12 @@ static int cmd_ship(const std::vector<std::string>& args) {
         for (auto& path : bundles) {
             auto name = fs::path(path).filename().string();
             std::cout << "Submitting " << name << " for notarization...\n";
+            // notarize_submit uses `xcrun notarytool submit --wait` which blocks
+            // for up to 20 minutes until notarization completes
             auto uuid = pulp::ship::notarize_submit(path, apple_id, team_id, password);
             if (!uuid) { std::cerr << "  Submission FAILED\n"; continue; }
             std::cout << "  Request UUID: " << *uuid << "\n";
+            // Verify final status (submit --wait already blocked until completion)
             auto status = pulp::ship::notarize_check(*uuid);
             if (status.success) {
                 std::cout << "  Notarization succeeded. Stapling...\n";


### PR DESCRIPTION
## Summary
- Wire existing `notarize` API into CLI: submit → poll → staple via `xcrun notarytool`
- Wire existing `appcast` API into CLI: generate/append Sparkle-compatible XML update feeds
- Add Android APK/AAB signing and packaging as first-class ship target
  - `pulp ship package --target android --keystore key.jks`
  - `pulp ship sign --target android --keystore key.jks`
  - `pulp ship check --target android`
  - Supports `--abi arm64-v8a|x86_64|all` for phones and tablets
  - apksigner v2+v3, jarsigner for AAB, zipalign, Gradle build integration
- Update `/ship` Claude Code plugin command with all new subcommands
- Update docs and cli-commands.yaml manifests

### New files
- `ship/include/pulp/ship/android.hpp` — Android signing/packaging API
- `ship/platform/android/package_android.cpp` — Implementation (host-side, shells out to SDK tools)

### Ship subcommands (5 total)
| Command | Description |
|---------|-------------|
| `sign` | macOS codesign / Windows signtool / Android apksigner+jarsigner |
| `notarize` | Apple notarization via xcrun notarytool (macOS only) |
| `package` | .pkg (macOS), NSIS (Windows), APK+AAB (Android) |
| `appcast` | Sparkle XML update feed generation with EdDSA signing |
| `check` | Verify signing status of desktop plugins or Android artifacts |

## Test plan
- [x] `cmake --build build --target pulp-ship` compiles
- [x] `cmake --build build --target pulp-cli` compiles and links
- [x] `pulp ship help` shows all 5 subcommands with Android flags
- [x] `ctest -R codesign` passes
- [x] `pulp-test-appcast` passes (20 assertions)
- [ ] CI green on macOS + Ubuntu + Windows