### PR TITLE
Disable android-emulator-test CI job (#77)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -76,7 +76,11 @@ jobs:
           retention-days: 7
 
   # Emulator test — only on macOS (KVM not available on GitHub Windows runners)
+  # Disabled until emulator CI infrastructure is set up (see #77).
+  # The emulator test requires GPU support (Dawn/Vulkan) which CI runners
+  # don't have, causing a guaranteed 20-minute timeout on every PR.
   android-emulator-test:
+    if: false  # Disabled — see issue #77
     runs-on: macos-latest
     needs: android-build
     timeout-minutes: 20


### PR DESCRIPTION
## Summary
Disable the `android-emulator-test` job that times out at 20 minutes on every PR. The job can't pass without GPU support in the CI runner, which neither GitHub-hosted nor Namespace runners provide.

Tracked in #77 for proper emulator/simulator CI infrastructure.

## Test plan
- [x] The 7 other CI checks continue to pass
- [x] No 20-minute timeout blocking PRs