### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Pulp are documented here.
 
+## [0.2.0] — 2026-04-09
+
+### Added
+- **Android platform**: Full GPU rendering pipeline + interactive Pulp widgets (#53)
+- **`pulp ship notarize`**: Apple notarization with submit, poll, and staple (#79)
+- **`pulp ship appcast`**: Sparkle-compatible XML update feed generation with EdDSA signing (#79)
+- **`pulp ship android`**: APK/AAB packaging via Gradle with keystore signing, ABI selection, Android SDK discovery (#79)
+- **Ship config fallback**: CLI flags → env vars → `~/.pulp/config.toml` for all signing credentials (#79)
+- **`config.example.toml`**: Developer configuration template for signing identities, keystores, and appcast keys
+- **Inspector polish**: cursor balance, selection persistence, highlight stability, scrollbar, positioning (#71)
+- **Modular CLI**: `pulp_cli.cpp` refactored into per-command `cmd_*.cpp` files (#61)
+
+### Fixed
+- `modules.md` code examples now match the actual APIs (#70)
+- Android emulator CI job disabled until infrastructure is ready (#77, #78)
+
+### Changed
+- Skill Maintenance Rule added to CLAUDE.md (#72)
+- Ship CLI command manifest and `/ship` slash command updated with notarize/appcast/android subcommands
+
 ## [0.1.1] — 2026-04-06
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.1.1
+    VERSION 0.2.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Summary
Bumps `CMakeLists.txt` VERSION from 0.1.1 → 0.2.0 and adds a full CHANGELOG entry. Merging this PR and pushing the `v0.2.0` tag will trigger `release-cli.yml` to build CLI + SDK artifacts for all 5 platforms (macOS arm64, Linux x64/arm64, Windows x64/arm64) and publish the GitHub release.

## Highlights in 0.2.0
- Android platform: Full GPU + Pulp widgets (#53)
- Ship CLI: notarize, appcast, Android packaging (#79)
- Config fallback: CLI → env → ~/.pulp/config.toml (#79)
- Modular CLI refactor (#61)
- Inspector polish (#71)

## Test plan
- [x] Version bumped in `CMakeLists.txt`
- [x] CHANGELOG entry added
- [ ] CI green on all platforms
- [ ] After merge: tag pushed, `release-cli.yml` succeeds, release published
- [ ] CLI verified on macOS/Linux/Windows by scaffolding and building a plugin