### PR TITLE
Add zero-crossing trigger to oscilloscope (WaveformView)

### DIFF
--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -455,18 +455,39 @@ private:
 
 class WaveformView : public View {
 public:
+    // Triggering mode for periodic signal display.
+    // free_run:     no triggering — caller is responsible for continuity
+    // rising_zero:  align to the first rising-edge zero crossing
+    // falling_zero: align to the first falling-edge zero crossing
+    enum class TriggerMode { free_run, rising_zero, falling_zero };
+
     WaveformView() = default;
 
-    // Set waveform data (normalized -1 to 1)
+    // Set waveform data (normalized -1 to 1). If a non-free_run trigger
+    // mode is active, the buffer is rotated so the first matching
+    // crossing becomes index 0, producing a stable display for periodic
+    // signals. If no crossing is found, the buffer is stored as-is.
     void set_data(const float* samples, size_t count);
     void set_data(std::vector<float> samples);
 
     size_t sample_count() const { return samples_.size(); }
 
+    void set_trigger_mode(TriggerMode mode) { trigger_mode_ = mode; }
+    TriggerMode trigger_mode() const { return trigger_mode_; }
+
+    // Locate the first crossing of `mode` in the buffer without mutating
+    // it. Returns the crossing index, or 0 if none is found or
+    // mode is free_run.
+    static size_t find_trigger_index(const float* samples, size_t count,
+                                     TriggerMode mode);
+
     void paint(canvas::Canvas& canvas) override;
 
 private:
+    void apply_trigger();
+
     std::vector<float> samples_;
+    TriggerMode trigger_mode_ = TriggerMode::free_run;
 };
 
 // ── SpectrumView ─────────────────────────────────────────────────────────────

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -994,12 +994,39 @@ void XYPad::paint(canvas::Canvas& canvas) {
 
 // ── WaveformView ─────────────────────────────────────────────────────────────
 
+size_t WaveformView::find_trigger_index(const float* samples, size_t count,
+                                         TriggerMode mode) {
+    if (mode == TriggerMode::free_run || count < 2) return 0;
+    const bool want_rising = (mode == TriggerMode::rising_zero);
+    for (size_t i = 1; i < count; ++i) {
+        float prev = samples[i - 1];
+        float curr = samples[i];
+        if (want_rising) {
+            if (prev <= 0.0f && curr > 0.0f) return i;
+        } else {
+            if (prev >= 0.0f && curr < 0.0f) return i;
+        }
+    }
+    return 0;
+}
+
+void WaveformView::apply_trigger() {
+    if (trigger_mode_ == TriggerMode::free_run || samples_.size() < 2) return;
+    size_t idx = find_trigger_index(samples_.data(), samples_.size(), trigger_mode_);
+    if (idx == 0) return;  // no crossing — leave as-is
+    std::rotate(samples_.begin(),
+                samples_.begin() + static_cast<std::ptrdiff_t>(idx),
+                samples_.end());
+}
+
 void WaveformView::set_data(const float* samples, size_t count) {
     samples_.assign(samples, samples + count);
+    apply_trigger();
 }
 
 void WaveformView::set_data(std::vector<float> samples) {
     samples_ = std::move(samples);
+    apply_trigger();
 }
 
 void WaveformView::paint(canvas::Canvas& canvas) {

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -242,6 +242,79 @@ TEST_CASE("WaveformView empty renders background only", "[view][widget]") {
     REQUIRE(canvas.count(DrawCommand::Type::stroke_line) == 0); // No waveform
 }
 
+TEST_CASE("WaveformView trigger — rising zero crossing", "[view][widget][trigger]") {
+    // Phase-shifted sine: starts at +0.5, crosses zero downward, crosses
+    // zero upward roughly at index N/2. With rising_zero trigger, the
+    // display should be rotated so the rising crossing is at index 0.
+    constexpr size_t N = 256;
+    std::vector<float> samples(N);
+    const float phase_offset = 3.14159f / 4.0f;  // start 45° into the cycle
+    for (size_t i = 0; i < N; ++i) {
+        samples[i] = std::sin(phase_offset + 2.0f * 3.14159f * i / N);
+    }
+
+    // Locate the expected trigger index in the raw buffer before triggering.
+    size_t expected = WaveformView::find_trigger_index(
+        samples.data(), samples.size(),
+        WaveformView::TriggerMode::rising_zero);
+    REQUIRE(expected > 0);
+    REQUIRE(expected < N);
+
+    WaveformView waveform;
+    waveform.set_trigger_mode(WaveformView::TriggerMode::rising_zero);
+    waveform.set_data(samples);  // copy so we can compare
+
+    REQUIRE(waveform.sample_count() == N);
+
+    // After triggering, index 0 should correspond to old index `expected`,
+    // which is the first sample > 0 following a sample <= 0.
+    // We can't directly read the rotated buffer, but we can observe
+    // stability: applying the same data twice should yield the same result.
+    WaveformView waveform2;
+    waveform2.set_trigger_mode(WaveformView::TriggerMode::rising_zero);
+    waveform2.set_data(samples);
+    REQUIRE(waveform2.sample_count() == N);
+}
+
+TEST_CASE("WaveformView trigger — free run leaves buffer unchanged", "[view][widget][trigger]") {
+    constexpr size_t N = 32;
+    std::vector<float> samples(N);
+    for (size_t i = 0; i < N; ++i) samples[i] = static_cast<float>(i);
+
+    WaveformView waveform;
+    REQUIRE(waveform.trigger_mode() == WaveformView::TriggerMode::free_run);
+    waveform.set_data(samples);
+    REQUIRE(waveform.sample_count() == N);
+    // In free_run mode, find_trigger_index should return 0 regardless
+    REQUIRE(WaveformView::find_trigger_index(
+        samples.data(), samples.size(),
+        WaveformView::TriggerMode::free_run) == 0);
+}
+
+TEST_CASE("WaveformView trigger — falling zero crossing", "[view][widget][trigger]") {
+    // A simple ramp that crosses zero downward at the midpoint.
+    std::vector<float> samples = {2, 1, 0.5f, 0, -0.5f, -1, -2, -1};
+    size_t idx = WaveformView::find_trigger_index(
+        samples.data(), samples.size(),
+        WaveformView::TriggerMode::falling_zero);
+    // prev=0 at i=3 is not > 0, so the first falling crossing is i=4 (prev=0, curr=-0.5)
+    REQUIRE(idx == 4);
+}
+
+TEST_CASE("WaveformView trigger — no crossing leaves buffer alone", "[view][widget][trigger]") {
+    // All positive samples — no rising zero crossing possible
+    std::vector<float> samples = {0.5f, 0.6f, 0.7f, 0.8f, 0.9f};
+    size_t idx = WaveformView::find_trigger_index(
+        samples.data(), samples.size(),
+        WaveformView::TriggerMode::rising_zero);
+    REQUIRE(idx == 0);
+
+    WaveformView waveform;
+    waveform.set_trigger_mode(WaveformView::TriggerMode::rising_zero);
+    waveform.set_data(samples);
+    REQUIRE(waveform.sample_count() == samples.size());
+}
+
 TEST_CASE("SpectrumView renders bars", "[view][widget]") {
     SpectrumView spectrum;
     spectrum.set_bounds({0, 0, 300, 100});


### PR DESCRIPTION
## Summary
Adds \`TriggerMode::{free_run, rising_zero, falling_zero}\` to \`WaveformView\`. When a non-free-run mode is active, \`set_data()\` rotates the buffer to begin at the first matching zero crossing, producing a visually stable display for periodic signals.

- Default remains \`free_run\` — existing examples are unchanged
- Static \`find_trigger_index()\` exposed for testing and reuse
- 4 new trigger tests added to \`test_widgets.cpp\`

Closes #84

## Test plan
- [x] All 26 widget tests pass locally (10 assertions in new trigger tests)
- [ ] CI green on all platforms