### PR TITLE
Add `pulp create --targets android` experimental scaffold

### DIFF
--- a/tools/cli/cmd_create.cpp
+++ b/tools/cli/cmd_create.cpp
@@ -110,7 +110,7 @@ int cmd_create(const std::vector<std::string>& args) {
     }
 
     // Parse args
-    std::string name, type = "effect", manufacturer = "Pulp", output_path, tmpl;
+    std::string name, type = "effect", manufacturer = "Pulp", output_path, tmpl, targets_arg;
     bool no_build = false;
     bool ci_mode = false;
     bool in_tree_mode = false;
@@ -119,6 +119,9 @@ int cmd_create(const std::vector<std::string>& args) {
         if (args[i] == "--template" && i + 1 < args.size()) { tmpl = args[++i]; continue; }
         if (args[i] == "--manufacturer" && i + 1 < args.size()) { manufacturer = args[++i]; continue; }
         if (args[i] == "--output" && i + 1 < args.size()) { output_path = args[++i]; continue; }
+        if ((args[i] == "--targets" || args[i] == "--target") && i + 1 < args.size()) {
+            targets_arg = args[++i]; continue;
+        }
         if (args[i] == "--in-tree" || args[i] == "--example") { in_tree_mode = true; continue; }
         if (args[i] == "--no-build") { no_build = true; continue; }
         if (args[i] == "--no-interactive" || args[i] == "--ci") { ci_mode = true; continue; }
@@ -130,6 +133,7 @@ int cmd_create(const std::vector<std::string>& args) {
             std::cout << "  --template <name>                    Use named template (e.g. gain)\n";
             std::cout << "  --manufacturer <name>                Manufacturer (default: Pulp)\n";
             std::cout << "  --output <dir>                       Override output directory\n";
+            std::cout << "  --targets <list>                     Comma-separated extra targets (e.g. android)\n";
             std::cout << "  --in-tree, --example                 Add the project to examples/ using the local Pulp checkout\n";
             std::cout << "  --no-build                           Skip build after scaffolding\n";
             std::cout << "  --no-interactive, --ci               Non-interactive mode (use defaults)\n";
@@ -139,6 +143,27 @@ int cmd_create(const std::vector<std::string>& args) {
             return 0;
         }
         if (name.empty() && !args[i].empty() && args[i][0] != '-') { name = args[i]; continue; }
+    }
+
+    // Parse --targets list (comma-separated, case-insensitive)
+    bool want_android = false;
+    if (!targets_arg.empty()) {
+        std::string buf;
+        auto flush = [&]() {
+            std::string lower;
+            for (char c : buf) lower += static_cast<char>(std::tolower(c));
+            lower = trim(lower);
+            if (lower == "android") want_android = true;
+            // Desktop targets (vst3/au/clap/standalone) are already handled via
+            // default_create_formats() — accepting them here is a no-op so the
+            // flag can be used uniformly.
+            buf.clear();
+        };
+        for (char c : targets_arg) {
+            if (c == ',' || c == ' ') flush();
+            else buf += c;
+        }
+        flush();
     }
 
     if (name.empty()) {
@@ -416,6 +441,47 @@ int cmd_create(const std::vector<std::string>& args) {
             f << "sdk_checkout = \"" << root.generic_string() << "\"\n";
         }
         log("  Created pulp.toml\n");
+    }
+
+    // Android target scaffold (experimental — see issue #83)
+    if (want_android) {
+        auto android_tmpl_dir = templates_base / "android";
+        if (!fs::exists(android_tmpl_dir) && !root.empty()) {
+            android_tmpl_dir = root / "tools" / "templates" / "android";
+        }
+        if (!fs::exists(android_tmpl_dir)) {
+            print_warn("Android template directory not found — skipping Android scaffold");
+        } else {
+            auto android_out = out_dir / "android";
+            fs::create_directories(android_out);
+            log("\nScaffolding Android project (experimental)...\n");
+
+            // Walk the template tree and expand every .template file.
+            for (auto& entry : fs::recursive_directory_iterator(android_tmpl_dir)) {
+                if (!entry.is_regular_file()) continue;
+                auto rel = fs::relative(entry.path(), android_tmpl_dir);
+                auto rel_str = rel.generic_string();
+                std::string out_rel = rel_str;
+                if (out_rel.size() > 9 && out_rel.substr(out_rel.size() - 9) == ".template") {
+                    out_rel = out_rel.substr(0, out_rel.size() - 9);
+                }
+                // Rename MainActivity placeholder path to real namespace package.
+                // Template lives at app/src/main/java/MainActivity.kt.template;
+                // put it under app/src/main/java/<namespace>/MainActivity.kt
+                if (out_rel == "app/src/main/java/MainActivity.kt") {
+                    out_rel = "app/src/main/java/" + ns + "/MainActivity.kt";
+                }
+                auto out_path = android_out / out_rel;
+                fs::create_directories(out_path.parent_path());
+                auto content = read_file_contents(entry.path());
+                auto expanded = expand_template_str(content, vars);
+                std::ofstream f(out_path);
+                f << expanded;
+                log("  Created android/" + out_rel + "\n");
+            }
+            log("\n  Android scaffold is experimental. See android/README.md for\n"
+                "  build instructions and current limitations.\n");
+        }
     }
 
     // Add to examples/CMakeLists.txt (in-tree mode only)

--- a/tools/templates/android/README.md.template
+++ b/tools/templates/android/README.md.template
@@ -1,0 +1,34 @@
+# {{PLUGIN_NAME}} — Android
+
+Scaffolded Android project for the {{PLUGIN_NAME}} Pulp plugin.
+
+## Build
+
+Requires:
+- Android Studio (or the standalone Android SDK) with SDK 35 + NDK 27.0.12077973 installed
+- Java 17+
+- Access to a Pulp source tree (the SDK does not yet ship Android libraries)
+
+```bash
+cd android
+./gradlew assembleDebug
+```
+
+The resulting APK will be at `android/app/build/outputs/apk/debug/app-debug.apk`.
+
+## Status
+
+This Android scaffold is **experimental**. It wires the plugin's native
+CMakeLists.txt into the Gradle build via `externalNativeBuild.cmake.path`.
+For Android builds to succeed you currently need:
+
+- A local Pulp source tree referenced from the plugin's `CMakeLists.txt`
+- Skia prebuilt for Android (see `tools/build-skia-android.sh` in the Pulp repo)
+
+Future work will ship Android libraries in the Pulp SDK so standalone
+Android builds are self-contained.
+
+See also:
+- https://github.com/danielraffel/pulp/issues/81 (x86_64 Skia)
+- https://github.com/danielraffel/pulp/issues/82 (APK asset loading)
+- https://github.com/danielraffel/pulp/issues/83 (this scaffold)

--- a/tools/templates/android/app/build.gradle.kts.template
+++ b/tools/templates/android/app/build.gradle.kts.template
@@ -1,0 +1,70 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.{{NAMESPACE}}"
+    compileSdk = 35
+
+    ndkVersion = "27.0.12077973"
+
+    defaultConfig {
+        applicationId = "{{BUNDLE_ID}}"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "{{VERSION}}"
+
+        ndk {
+            // Default to arm64-v8a. For x86_64 emulator testing, add "x86_64".
+            abiFilters += listOf("arm64-v8a")
+        }
+
+        externalNativeBuild {
+            cmake {
+                cppFlags += listOf("-std=c++20", "-fexceptions", "-frtti")
+                arguments += listOf(
+                    "-DANDROID_STL=c++_shared",
+                    "-DANDROID_ARM_NEON=TRUE",
+                    "-DPULP_BUILD_TESTS=OFF",
+                    "-DPULP_BUILD_EXAMPLES=OFF",
+                    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+                )
+            }
+        }
+    }
+
+    // Points at the plugin's CMakeLists.txt one directory up. The plugin
+    // is expected to link against Pulp via the SDK or an in-tree checkout.
+    externalNativeBuild {
+        cmake {
+            path = file("../../CMakeLists.txt")
+            version = "3.24.0+"
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+}

--- a/tools/templates/android/app/src/main/AndroidManifest.xml.template
+++ b/tools/templates/android/app/src/main/AndroidManifest.xml.template
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-feature android:name="android.hardware.audio.low_latency" android:required="false" />
+    <uses-feature android:name="android.hardware.audio.pro" android:required="false" />
+
+    <application
+        android:allowBackup="true"
+        android:label="{{PLUGIN_NAME}}"
+        android:supportsRtl="true"
+        android:theme="@android:style/Theme.Material.NoActionBar">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:configChanges="orientation|screenSize|keyboardHidden">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/tools/templates/android/app/src/main/java/MainActivity.kt.template
+++ b/tools/templates/android/app/src/main/java/MainActivity.kt.template
@@ -1,0 +1,26 @@
+package com.{{NAMESPACE}}
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.TextView
+
+class MainActivity : Activity() {
+
+    companion object {
+        init {
+            // Load the native library produced by the plugin's CMakeLists.
+            // The library name matches the {{CLASS_NAME}} target in CMakeLists.txt.
+            System.loadLibrary("{{LOWER_NAME}}")
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val label = TextView(this).apply {
+            text = "{{PLUGIN_NAME}} — Pulp Android scaffold"
+            textSize = 20f
+            setPadding(48, 48, 48, 48)
+        }
+        setContentView(label)
+    }
+}

--- a/tools/templates/android/build.gradle.kts.template
+++ b/tools/templates/android/build.gradle.kts.template
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+}

--- a/tools/templates/android/gradle.properties.template
+++ b/tools/templates/android/gradle.properties.template
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/tools/templates/android/settings.gradle.kts.template
+++ b/tools/templates/android/settings.gradle.kts.template
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "{{CLASS_NAME}}"
+include(":app")


### PR DESCRIPTION
## Summary
Adds \`--targets\` (aliased \`--target\`) flag to \`pulp create\` that accepts a comma-separated list of extra targets. When \`android\` is present, scaffolds an experimental Android Gradle project under \`<project>/android/\`.

### Generated files
- \`android/settings.gradle.kts\`
- \`android/build.gradle.kts\`
- \`android/gradle.properties\`
- \`android/app/build.gradle.kts\`
- \`android/app/src/main/AndroidManifest.xml\`
- \`android/app/src/main/java/<namespace>/MainActivity.kt\`
- \`android/README.md\`

### Template system
Templates live at \`tools/templates/android/\` and reuse the existing \`{{CLASS_NAME}}\`/\`{{NAMESPACE}}\`/\`{{BUNDLE_ID}}\` substitution infrastructure. \`MainActivity.kt\` is rerouted to the correct package path during expansion.

### Status: experimental
The generated Gradle project wires the plugin's \`CMakeLists.txt\` into \`externalNativeBuild\`, but full Android builds still require a local Pulp source tree — the SDK does not yet ship Android libraries. The scaffold README documents this and links to follow-up issues.

Closes #83
Related: #81 (x86_64 Skia), #82 (APK asset loading)

## Test plan
- [x] \`pulp create MyPlug --targets android --type bare --no-build --ci --in-tree\` produces the expected file tree
- [x] Template substitution places MainActivity.kt under the correct package dir
- [x] Template substitution fills in \`{{PLUGIN_NAME}}\`, \`{{CLASS_NAME}}\`, \`{{BUNDLE_ID}}\`, \`{{VERSION}}\`
- [ ] CI green on all platforms