### PR TITLE
Android: load synth_ui.js from APK assets via AAssetManager

### DIFF
--- a/android/app/src/main/assets/synth_ui.js
+++ b/android/app/src/main/assets/synth_ui.js
@@ -1,0 +1,147 @@
+// ── PULP SYNTH — JS-Scripted UI ─────────────────────────────────────────
+
+// Root layout
+const root = createCol("root");
+setFlex("root", "padding", 12);
+setFlex("root", "gap", 4);
+setBackground("root", "#1E1E2E");
+
+// ── Title ────────────────────────────────────────────────────────────────
+createLabel("title", "PULP SYNTH", "root");
+setFontSize("title", 22);
+setFontWeight("title", 700);
+setTextColor("title", "#CDD6F4");
+setFlex("title", "margin_bottom", 8);
+
+// ── OSCILLATOR ───────────────────────────────────────────────────────────
+createLabel("osc-label", "OSCILLATOR", "root");
+setFontSize("osc-label", 11);
+setTextColor("osc-label", "#A6ADC8");
+
+const oscRow = createRow("osc-row", "root");
+setFlex("osc-row", "justify_content", "space_evenly");
+setFlex("osc-row", "align_items", "center");
+setFlex("osc-row", "height", 56);
+setFlex("osc-row", "margin_left", 8);
+setFlex("osc-row", "margin_right", 8);
+
+const oscNames = ["Pitch", "Detune", "Mix", "Level"];
+const oscDefaults = [0.5, 0.3, 0.5, 0.6];
+for (let i = 0; i < 4; i++) {
+    const id = "osc-" + i;
+    createKnob(id, "osc-row");
+    setFlex(id, "width", 48);
+    setFlex(id, "height", 48);
+    setValue(id, oscDefaults[i]);
+    setLabel(id, oscNames[i]);
+}
+
+// ── TOGGLES ──────────────────────────────────────────────────────────────
+const toggleRow = createRow("toggle-row", "root");
+setFlex("toggle-row", "justify_content", "space_evenly");
+setFlex("toggle-row", "align_items", "center");
+setFlex("toggle-row", "height", 36);
+setFlex("toggle-row", "margin_top", 4);
+setFlex("toggle-row", "margin_left", 8);
+setFlex("toggle-row", "margin_right", 8);
+
+const toggleDefaults = [true, false, true, false];
+for (let i = 0; i < 4; i++) {
+    const id = "toggle-" + i;
+    createToggle(id, "toggle-row");
+    setFlex(id, "width", 48);
+    setFlex(id, "height", 28);
+    setValue(id, toggleDefaults[i] ? 1.0 : 0.0);
+}
+
+// ── XY PAD ───────────────────────────────────────────────────────────────
+createLabel("xy-label", "XY PAD", "root");
+setFontSize("xy-label", 11);
+setTextColor("xy-label", "#A6ADC8");
+setFlex("xy-label", "margin_top", 4);
+
+createXYPad("xy", "root");
+setFlex("xy", "height", 120);
+setFlex("xy", "margin_left", 8);
+setFlex("xy", "margin_right", 8);
+
+// ── FILTER ───────────────────────────────────────────────────────────────
+createLabel("filter-label", "FILTER", "root");
+setFontSize("filter-label", 11);
+setTextColor("filter-label", "#A6ADC8");
+setFlex("filter-label", "margin_top", 6);
+
+const filterRow = createRow("filter-row", "root");
+setFlex("filter-row", "justify_content", "space_evenly");
+setFlex("filter-row", "align_items", "center");
+setFlex("filter-row", "height", 52);
+setFlex("filter-row", "margin_left", 8);
+setFlex("filter-row", "margin_right", 8);
+
+const filterNames = ["Cutoff", "Reso", "Env"];
+const filterDefaults = [0.65, 0.35, 0.5];
+for (let i = 0; i < 3; i++) {
+    const id = "filter-" + i;
+    createKnob(id, "filter-row");
+    setFlex(id, "width", 44);
+    setFlex(id, "height", 44);
+    setValue(id, filterDefaults[i]);
+    setLabel(id, filterNames[i]);
+}
+
+// ── ENVELOPE ─────────────────────────────────────────────────────────────
+createLabel("env-label", "ENVELOPE", "root");
+setFontSize("env-label", 11);
+setTextColor("env-label", "#A6ADC8");
+setFlex("env-label", "margin_top", 4);
+
+const envRow = createRow("env-row", "root");
+setFlex("env-row", "justify_content", "space_evenly");
+setFlex("env-row", "align_items", "center");
+setFlex("env-row", "height", 48);
+setFlex("env-row", "margin_left", 8);
+setFlex("env-row", "margin_right", 8);
+
+const envNames = ["A", "D", "S", "R"];
+const envDefaults = [0.05, 0.3, 0.7, 0.4];
+for (let i = 0; i < 4; i++) {
+    const id = "env-" + i;
+    createKnob(id, "env-row");
+    setFlex(id, "width", 40);
+    setFlex(id, "height", 40);
+    setValue(id, envDefaults[i]);
+    setLabel(id, envNames[i]);
+}
+
+// ── MIXER ────────────────────────────────────────────────────────────────
+createLabel("mixer-label", "MIXER", "root");
+setFontSize("mixer-label", 11);
+setTextColor("mixer-label", "#A6ADC8");
+setFlex("mixer-label", "margin_top", 6);
+
+const mixDefaults = [0.75, 0.6, 0.4, 0.2];
+for (let i = 0; i < 4; i++) {
+    const id = "mix-" + i;
+    createFader(id, "horizontal", "root");
+    setFlex(id, "height", 22);
+    setFlex(id, "margin_left", 8);
+    setFlex(id, "margin_right", 8);
+    setFlex(id, "margin_top", i === 0 ? 0 : 4);
+    setValue(id, mixDefaults[i]);
+}
+
+// ── MASTER ───────────────────────────────────────────────────────────────
+createLabel("master-label", "MASTER", "root");
+setFontSize("master-label", 11);
+setTextColor("master-label", "#A6ADC8");
+setFlex("master-label", "margin_top", 6);
+
+createFader("master", "horizontal", "root");
+setFlex("master", "height", 26);
+setFlex("master", "margin_left", 8);
+setFlex("master", "margin_right", 8);
+setValue("master", 0.8);
+
+// Oscilloscope + VU meter are drawn directly by the C++ render loop
+// using GPU canvas drawing for crisp, animated waveform display.
+

--- a/android/app/src/main/kotlin/com/pulp/PulpApplication.kt
+++ b/android/app/src/main/kotlin/com/pulp/PulpApplication.kt
@@ -16,6 +16,15 @@ class PulpApplication : Application(), LifecycleEventObserver {
         } catch (e: UnsatisfiedLinkError) {
             android.util.Log.e(LOG_TAG, "Failed to load libpulp.so: ${e.message}")
         }
+        if (nativeLoaded) {
+            // Wire the C++ AAssetManager bridge so native code can read
+            // bundled assets (e.g., synth_ui.js) from the APK.
+            try {
+                PulpFileProvider(this).init()
+            } catch (e: Throwable) {
+                android.util.Log.e(LOG_TAG, "PulpFileProvider init failed: ${e.message}")
+            }
+        }
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
     }
 

--- a/core/platform/include/pulp/platform/android/jni.hpp
+++ b/core/platform/include/pulp/platform/android/jni.hpp
@@ -12,12 +12,24 @@
 #include <jni.h>
 #include <cassert>
 #include <atomic>
+#include <string>
+#include <vector>
 
 namespace pulp::android {
 
 // ── Global JVM Reference ──────────────────────────────────────────────────
 // Set in JNI_OnLoad, never changes. Safe to read from any thread.
 inline JavaVM* g_vm = nullptr;
+
+// ── APK Asset Reader ──────────────────────────────────────────────────────
+// Reads bundled assets from the APK via AAssetManager.
+// Must be initialized from Kotlin via PulpFileProvider.init() before use.
+// Thread-safe: AAssetManager is safe to use from any thread.
+
+void init_asset_manager(JNIEnv* env, jobject context);
+std::vector<uint8_t> read_asset(const std::string& path);
+std::string read_asset_text(const std::string& path);
+bool has_asset_manager();
 
 // ── Get JNIEnv for Current Thread ─────────────────────────────────────────
 // Auto-attaches non-Java threads via AttachCurrentThread.

--- a/core/platform/src/android/file_provider.cpp
+++ b/core/platform/src/android/file_provider.cpp
@@ -51,6 +51,16 @@ std::vector<uint8_t> read_asset(const std::string& path) {
     return data;
 }
 
+std::string read_asset_text(const std::string& path) {
+    auto bytes = read_asset(path);
+    if (bytes.empty()) return {};
+    return std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+}
+
+bool has_asset_manager() {
+    return g_asset_manager != nullptr;
+}
+
 // ── App Data Directory ────────────────────────────────────────────────────
 // Returns the app-private files directory (always writable with native I/O).
 // Must be queried from Kotlin on startup via context.filesDir.

--- a/core/render/platform/android/gpu_surface_android.cpp
+++ b/core/render/platform/android/gpu_surface_android.cpp
@@ -228,7 +228,22 @@ static bool create_js_ui(float dp_w, float dp_h) {
         g_widget_bridge = std::make_unique<WidgetBridge>(
             *g_script_engine, *g_root_view, g_state_store);
 
-        g_widget_bridge->load_script(kSynthUiScript);
+        // Prefer loading the JS UI from the APK via AAssetManager so the
+        // script can be edited without recompiling C++. Fall back to the
+        // embedded string if the asset manager is not initialized (e.g.,
+        // PulpFileProvider.init() was never called) or if the asset is
+        // missing from the APK.
+        std::string script;
+        if (pulp::android::has_asset_manager()) {
+            script = pulp::android::read_asset_text("synth_ui.js");
+        }
+        if (script.empty()) {
+            PULP_LOGI("synth_ui.js: loading embedded fallback (assets unavailable)");
+            script = kSynthUiScript;
+        } else {
+            PULP_LOGI("synth_ui.js: loaded from APK assets (%zu bytes)", script.size());
+        }
+        g_widget_bridge->load_script(script);
         g_root_view->layout_children();
 
         // Capture widget refs for synth param sync


### PR DESCRIPTION
## Summary
Replaces the embedded \`kSynthUiScript\` R-string in \`synth_ui.js.h\` with APK asset loading through the existing (but previously unused) AAssetManager bridge in \`core/platform/src/android/file_provider.cpp\`.

### Changes
- Copy \`synth_ui.js\` content to \`android/app/src/main/assets/synth_ui.js\`
- Expose \`read_asset\` / \`read_asset_text\` / \`has_asset_manager\` in \`pulp/platform/android/jni.hpp\` (previously only cpp-private)
- \`gpu_surface_android.cpp\` now prefers loading via \`pulp::android::read_asset_text(\"synth_ui.js\")\`, with the embedded string as fallback
- Wire \`PulpFileProvider.init()\` into \`PulpApplication.onCreate()\` — previously the class existed but was never called, so the asset manager was always null

### Why
- Enables editing the JS UI without recompiling the native library
- Lays groundwork for multi-asset loading (fonts, images, additional JS modules)
- Matches the pattern used by \`WebView\` UIs elsewhere in Pulp

### Backwards compatibility
The embedded fallback is retained, so older release APKs that ship without the asset (or that haven't called \`PulpFileProvider.init()\`) will continue to render.

Closes #82

## Test plan
- [x] Host build succeeds (Android code gated on \`#ifdef __ANDROID__\`)
- [ ] \`android-build\` CI produces an APK containing both \`assets/synth_ui.js\` and \`libpulp.so\`
- [ ] CI green on all platforms