### PR TITLE
release-cli: disable windows-arm64 matrix (unblock v0.2.0)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -28,9 +28,13 @@ jobs:
           - os: windows-latest
             platform: windows-x64
             artifact: pulp.exe
-          - os: windows-11-arm
-            platform: windows-arm64
-            artifact: pulp.exe
+          # windows-arm64 temporarily disabled — pre-existing compile failure
+          # in core/view on Windows ARM64 where winbase.h _Interlocked*
+          # intrinsics leak into the pulp::view namespace. Tracked in a
+          # follow-up issue.
+          # - os: windows-11-arm
+          #   platform: windows-arm64
+          #   artifact: pulp.exe
 
     runs-on: ${{ matrix.os }}
     name: CLI ${{ matrix.platform }}


### PR DESCRIPTION
## Summary
Temporarily disables the \`windows-arm64\` entry in \`release-cli.yml\` matrix. Windows ARM64 has a pre-existing compile failure in \`core/view\` where \`winbase.h\` \`_Interlocked*\` intrinsics leak into the \`pulp::view\` namespace. Tracked as #92.

Unblocks the v0.2.0 release so the other four platforms can publish.

Closes: nothing (unblocks release of v0.2.0)
Related: #92

## Test plan
- [ ] CI green
- [ ] After merge: re-push v0.2.0 tag, release-cli.yml completes with 4/4 successful builds