### PR TITLE
Fix #94: Ship wgpu_native.lib in Windows SDK install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -780,10 +780,45 @@ if(PULP_HAS_WEBGPU AND DEFINED WEBGPU_RUNTIME_LIB AND TARGET webgpu)
         )
     endif()
 
-    if(WIN32 AND DEFINED WGPU_IMPLIB AND EXISTS "${WGPU_IMPLIB}")
-        install(FILES "${WGPU_IMPLIB}"
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        )
+    # Install the wgpu_native import library alongside the runtime DLL.
+    #
+    # The WebGPU-distribution CMake sets WGPU_IMPLIB as a local variable
+    # inside FetchWgpuNativePrecompiled.cmake, so by the time execution
+    # returns to this file the variable is out of scope — the original
+    # guard `if(DEFINED WGPU_IMPLIB ...)` always evaluated to FALSE and
+    # the .lib was silently skipped from the SDK. That's why scaffolded
+    # Windows plugins fail with "IMPORTED_IMPLIB not set for imported
+    # target 'webgpu'" (see #94).
+    #
+    # Read the path from the imported target directly. Prefer the
+    # config-specific property (some WebGPU-distribution versions only
+    # populate IMPORTED_IMPLIB_RELEASE) and fall back to the plain
+    # IMPORTED_IMPLIB.
+    if(WIN32)
+        set(_pulp_wgpu_implib_src "")
+        get_target_property(_pulp_wgpu_implib_release webgpu IMPORTED_IMPLIB_RELEASE)
+        get_target_property(_pulp_wgpu_implib_plain webgpu IMPORTED_IMPLIB)
+        if(_pulp_wgpu_implib_release AND EXISTS "${_pulp_wgpu_implib_release}")
+            set(_pulp_wgpu_implib_src "${_pulp_wgpu_implib_release}")
+        elseif(_pulp_wgpu_implib_plain AND EXISTS "${_pulp_wgpu_implib_plain}")
+            set(_pulp_wgpu_implib_src "${_pulp_wgpu_implib_plain}")
+        elseif(DEFINED WGPU_IMPLIB AND EXISTS "${WGPU_IMPLIB}")
+            # Legacy fallback for older WebGPU-distribution versions.
+            set(_pulp_wgpu_implib_src "${WGPU_IMPLIB}")
+        endif()
+        if(_pulp_wgpu_implib_src)
+            install(FILES "${_pulp_wgpu_implib_src}"
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            )
+        else()
+            message(WARNING
+                "Pulp: could not locate wgpu_native.lib for the Windows SDK "
+                "install. Downstream plugins will fail to link against webgpu. "
+                "Check that the webgpu imported target has IMPORTED_IMPLIB set.")
+        endif()
+        unset(_pulp_wgpu_implib_src)
+        unset(_pulp_wgpu_implib_release)
+        unset(_pulp_wgpu_implib_plain)
     endif()
 endif()
 

--- a/tools/cmake/PulpConfig.cmake.in
+++ b/tools/cmake/PulpConfig.cmake.in
@@ -43,6 +43,23 @@ if(PULP_LINUX)
     find_dependency(ALSA)
 endif()
 
+# The Pulp SDK is built and installed in the Release configuration only.
+# When a downstream plugin is built in Debug / MinSizeRel / RelWithDebInfo
+# (or the Visual Studio multi-config generator picks those configs), CMake
+# needs to know to use the Release configuration of Pulp's imported
+# targets. Without this, the Visual Studio generator errors with
+# "IMPORTED_IMPLIB not set for imported target 'webgpu' configuration
+# 'MinSizeRel'" etc.
+#
+# Set CMAKE_MAP_IMPORTED_CONFIG_<CONFIG>=Release for every non-Release
+# config unless the consuming project has already overridden it.
+foreach(_pulp_cfg Debug MinSizeRel RelWithDebInfo)
+    if(NOT DEFINED CMAKE_MAP_IMPORTED_CONFIG_${_pulp_cfg})
+        set(CMAKE_MAP_IMPORTED_CONFIG_${_pulp_cfg} "Release;")
+    endif()
+endforeach()
+unset(_pulp_cfg)
+
 set(_pulp_webgpu_runtime
     "${PULP_SDK_LIBRARY_DIR}/${PULP_SDK_SHARED_LIBRARY_PREFIX}wgpu_native${PULP_SDK_SHARED_LIBRARY_SUFFIX}")
 set(_pulp_webgpu_include_dir "${PULP_SDK_DIR}/external/webgpu/include")
@@ -50,20 +67,36 @@ set(_pulp_webgpu_include_dir "${PULP_SDK_DIR}/external/webgpu/include")
 if(NOT TARGET webgpu
    AND EXISTS "${_pulp_webgpu_runtime}"
    AND EXISTS "${_pulp_webgpu_include_dir}")
+
+    # On Windows, MSVC needs an import library (wgpu_native.lib) in
+    # addition to the runtime DLL. Fail fast with a clear message if the
+    # SDK install is broken (#94 was caused by this silently missing).
+    if(WIN32)
+        set(_pulp_webgpu_implib
+            "${PULP_SDK_LIBRARY_DIR}/${PULP_SDK_SHARED_LIBRARY_PREFIX}wgpu_native.lib")
+        if(NOT EXISTS "${_pulp_webgpu_implib}")
+            message(FATAL_ERROR
+                "Pulp SDK is missing wgpu_native.lib at ${_pulp_webgpu_implib}. "
+                "This is a broken SDK install — the runtime DLL is present "
+                "but the import library needed for linking is not. "
+                "Reinstall the Pulp SDK (v0.2.1 or newer) to pick up the fix "
+                "from https://github.com/danielraffel/pulp/issues/94.")
+        endif()
+    endif()
+
     add_library(webgpu SHARED IMPORTED)
     set_target_properties(webgpu PROPERTIES
         IMPORTED_LOCATION "${_pulp_webgpu_runtime}"
+        IMPORTED_LOCATION_RELEASE "${_pulp_webgpu_runtime}"
         INTERFACE_COMPILE_DEFINITIONS "WEBGPU_BACKEND_WGPU"
         INTERFACE_INCLUDE_DIRECTORIES
             "${_pulp_webgpu_include_dir};${_pulp_webgpu_include_dir}/webgpu"
     )
 
     if(WIN32)
-        set(_pulp_webgpu_implib
-            "${PULP_SDK_LIBRARY_DIR}/${PULP_SDK_SHARED_LIBRARY_PREFIX}wgpu_native.lib")
-        if(EXISTS "${_pulp_webgpu_implib}")
-            set_property(TARGET webgpu PROPERTY IMPORTED_IMPLIB "${_pulp_webgpu_implib}")
-        endif()
+        set_property(TARGET webgpu PROPERTY IMPORTED_IMPLIB "${_pulp_webgpu_implib}")
+        set_property(TARGET webgpu PROPERTY
+            IMPORTED_IMPLIB_RELEASE "${_pulp_webgpu_implib}")
     elseif(UNIX AND NOT APPLE)
         set_property(TARGET webgpu PROPERTY IMPORTED_NO_SONAME TRUE)
     endif()


### PR DESCRIPTION
## Summary
Root cause: the install block that was supposed to ship \`wgpu_native.lib\` with the Windows SDK was guarded on a \`WGPU_IMPLIB\` variable that's set inside the \`FetchWgpuNativePrecompiled.cmake\` subdir — out of scope at the top-level CMakeLists.txt. The guard always evaluated false, so the import library was silently skipped from every Windows SDK release. Downstream plugins scaffolded by \`pulp create\` on Windows then failed with "IMPORTED_IMPLIB not set for imported target 'webgpu'" when CMake-configuring against the SDK.

Confirmed by inspecting the v0.2.0 SDK on a real Windows ARM64 host: \`wgpu_native.dll\` was present in \`lib/\` but \`wgpu_native.lib\` was not.

## Changes
- **\`CMakeLists.txt\`**: read the implib path from the webgpu imported target (\`IMPORTED_IMPLIB_RELEASE\` → \`IMPORTED_IMPLIB\` → legacy \`WGPU_IMPLIB\`), warn loudly if none resolve.
- **\`PulpConfig.cmake.in\`**:
  - Fail fast with a clear \`FATAL_ERROR\` when \`wgpu_native.dll\` exists but \`wgpu_native.lib\` does not, so v0.2.0 users on a broken SDK install get a "reinstall" message instead of the confusing IMPORTED_IMPLIB error.
  - Set per-config IMPLIB + global \`CMAKE_MAP_IMPORTED_CONFIG_*=Release\` so the Visual Studio multi-config generator works with Pulp's Release-only exported targets.

## Second opinion
Reviewed with codex — confirmed the root-cause analysis and suggested the \`IMPORTED_IMPLIB_RELEASE\` fallback and fail-fast pattern applied here.

## Backwards compatibility
Already-installed v0.2.0 Windows SDKs are broken and cannot be patched with CMake alone (the \`.lib\` file does not exist on disk). Users must reinstall from the fixed release (v0.2.1).

## Test plan
- [x] macOS configure still works
- [ ] CI green on all platforms
- [ ] After merge: tag v0.2.1, re-run release workflow, verify Windows SDK tarball contains \`wgpu_native.lib\`
- [ ] Verify scaffolded plugin CMake-configures successfully against v0.2.1 Windows SDK

Closes #94