### PR TITLE
Fix #92: Move Windows platform includes outside pulp::view namespace

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -28,13 +28,9 @@ jobs:
           - os: windows-latest
             platform: windows-x64
             artifact: pulp.exe
-          # windows-arm64 temporarily disabled — pre-existing compile failure
-          # in core/view on Windows ARM64 where winbase.h _Interlocked*
-          # intrinsics leak into the pulp::view namespace. Tracked in a
-          # follow-up issue.
-          # - os: windows-11-arm
-          #   platform: windows-arm64
-          #   artifact: pulp.exe
+          - os: windows-11-arm
+            platform: windows-arm64
+            artifact: pulp.exe
 
     runs-on: ${{ matrix.os }}
     name: CLI ${{ matrix.platform }}

--- a/core/view/src/file_browser.cpp
+++ b/core/view/src/file_browser.cpp
@@ -2,6 +2,19 @@
 #include <algorithm>
 #include <fstream>
 
+// Platform-specific includes must live outside the pulp::view namespace.
+// Previously windows.h was included inside the namespace, which on Windows
+// ARM64 leaked winbase.h's _Interlocked* intrinsics into pulp::view and
+// caused "'pulp::view::_InterlockedCompareExchange': no overloaded
+// function could convert all the argument types" build failures. See #92.
+#if defined(__APPLE__) || defined(__linux__)
+    #include <spawn.h>
+    extern "C" { extern char** environ; }
+#elif defined(_WIN32)
+    #include <windows.h>
+    #include <shellapi.h>
+#endif
+
 namespace pulp::view {
 
 // ── FileBrowser ────────────────────────────────────────────────────────
@@ -140,8 +153,6 @@ void FileTree::paint(canvas::Canvas& canvas) {
 // Uses safe process-launch APIs (no shell interpretation of user input).
 
 #ifdef __APPLE__
-#include <spawn.h>
-extern "C" { extern char** environ; }
 
 void ContentSharer::share_file(const std::filesystem::path& file, void*) {
     // Use posix_spawn with /usr/bin/open — no shell, no injection
@@ -164,8 +175,6 @@ void ContentSharer::share_text(const std::string& text, void*) {
 }
 
 #elif defined(_WIN32)
-#include <windows.h>
-#include <shellapi.h>
 
 void ContentSharer::share_file(const std::filesystem::path& file, void*) {
     // ShellExecuteW — safe, no shell interpretation
@@ -182,8 +191,6 @@ void ContentSharer::share_text(const std::string&, void*) {
 void ContentSharer::share_file(const std::filesystem::path&, void*) {}
 void ContentSharer::share_text(const std::string&, void*) {}
 #else
-#include <spawn.h>
-extern "C" { extern char** environ; }
 
 void ContentSharer::share_file(const std::filesystem::path& file, void*) {
     // posix_spawnp with xdg-open — uses PATH lookup, no hardcoded path


### PR DESCRIPTION
## Summary
Moves \`#include <windows.h>\` and \`#include <shellapi.h>\` in \`core/view/src/file_browser.cpp\` from inside the \`namespace pulp::view { ... }\` block to the top of the file, outside any namespace.

## Root cause
On Windows ARM64, the ContentSharer platform implementations had platform-specific includes wrapped inside the \`pulp::view\` namespace. \`windows.h\` transitively pulls in \`winbase.h\`, which defines inline \`_InterlockedCompareExchange\` / \`_InterlockedIncrement\` / etc. intrinsics. When these inline definitions appeared inside \`pulp::view\`, they were parsed as members of \`pulp::view::_InterlockedCompareExchange\` rather than the global namespace, and later STL / Windows header uses tried to call them with the wrong signatures, producing:

\`\`\`
error C2665: 'pulp::view::_InterlockedCompareExchange': no overloaded function could convert all the argument types
  while trying to match the argument list '(volatile long *, long, long)'
\`\`\`

This did not fire on Windows x64 because the x64 winbase.h uses a different overload set that happened to resolve correctly even when scoped into a namespace. ARM64's inline intrinsic set triggered the conflict.

## Fix
Move \`#include <windows.h>\`, \`#include <shellapi.h>\`, and \`#include <spawn.h>\` (plus the \`extern "C" { extern char** environ; }\` declaration) to the top of \`file_browser.cpp\`, before \`namespace pulp::view\` is opened. Function bodies stay inside the namespace unchanged.

Also re-enables \`windows-arm64\` in \`.github/workflows/release-cli.yml\` (previously disabled in #93 to unblock v0.2.0).

## Verification
Compiled \`file_browser.cpp\` directly on a Windows ARM64 host using \`cl.exe /std:c++20 /EHsc\` via the branch clone. Exit code 0, no errors, no warnings.

\`\`\`
file_browser.cpp
EXIT_CODE=0
\`\`\`

Also verified the macOS \`pulp-view\` target still builds clean.

Closes #92

## Test plan
- [x] Direct \`cl.exe\` compile on Windows ARM64 succeeds
- [x] macOS \`pulp-view\` target builds clean
- [ ] CI green on all platforms
- [ ] After merge: release workflow re-enables windows-arm64 in v0.2.1 release