### PR TITLE
Android MIDI I/O Phase 1: lock-free FIFO + PulpApplication wiring

### DIFF
--- a/android/app/src/main/kotlin/com/pulp/PulpApplication.kt
+++ b/android/app/src/main/kotlin/com/pulp/PulpApplication.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.pulp.midi.PulpMidiManager
 
 class PulpApplication : Application(), LifecycleEventObserver {
 
@@ -24,6 +25,14 @@ class PulpApplication : Application(), LifecycleEventObserver {
             } catch (e: Throwable) {
                 android.util.Log.e(LOG_TAG, "PulpFileProvider init failed: ${e.message}")
             }
+            // Start MIDI device discovery (Phase 1 = USB MIDI input).
+            // PulpMidiManager registers for MidiManager device callbacks
+            // and forwards received bytes to C++ via nativeOnMidiReceived.
+            try {
+                midiManager = PulpMidiManager(this)
+            } catch (e: Throwable) {
+                android.util.Log.e(LOG_TAG, "PulpMidiManager init failed: ${e.message}")
+            }
         }
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
     }
@@ -31,6 +40,8 @@ class PulpApplication : Application(), LifecycleEventObserver {
     companion object {
         const val LOG_TAG = "Pulp"
         var nativeLoaded = false
+            private set
+        var midiManager: PulpMidiManager? = null
             private set
     }
 

--- a/core/midi/include/pulp/midi/android_midi_fifo.hpp
+++ b/core/midi/include/pulp/midi/android_midi_fifo.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+// Android MIDI input ring buffer.
+//
+// MIDI bytes arrive from the Kotlin side on the MidiReceiver callback
+// thread. They get pushed into this lock-free SPSC queue and the audio
+// thread drains them into a MidiBuffer at the start of each process
+// block, converting the monotonic nanosecond timestamp into a sample
+// offset within the current block.
+//
+// This is an INTERNAL Phase-1 API. External consumers should use
+// `pulp::midi::android::drain_into(MidiBuffer&, ...)` from the audio
+// thread.
+
+#if defined(__ANDROID__)
+
+#include <pulp/midi/buffer.hpp>
+#include <pulp/runtime/spsc_queue.hpp>
+
+#include <array>
+#include <cstdint>
+
+namespace pulp::midi::android {
+
+// A single MIDI event delivered from the Kotlin bridge.
+// `data` is the raw MIDI byte stream (bytestream MIDI 1.0); `size`
+// holds the number of valid bytes in `data`. `timestamp_ns` is the
+// Android monotonic timestamp the Kotlin receiver gave us.
+struct AndroidMidiEvent {
+    std::uint64_t timestamp_ns = 0;
+    std::uint8_t  size = 0;
+    // Long enough for any MIDI 1.0 message (SysEx is chunked externally).
+    std::array<std::uint8_t, 16> data{};
+};
+
+// Push raw MIDI bytes into the FIFO. Returns false if the queue is
+// full or if `count` > sizeof(AndroidMidiEvent::data) and the caller
+// should split the message. Safe to call from any thread (designed for
+// the Kotlin MidiReceiver thread).
+bool push_bytes(const std::uint8_t* bytes, int count, std::int64_t timestamp_ns);
+
+// Drain pending events into `buffer`, converting timestamps to sample
+// offsets relative to the current block. `block_start_ns` is the
+// monotonic timestamp of the first sample of the block (or 0 if
+// unknown, in which case every event maps to sample 0). `sample_rate`
+// is used to convert nanoseconds to samples. `block_size` clamps the
+// maximum sample offset so out-of-block events appear at the end of
+// the block (they will be applied next block if clamped to the last
+// sample — this is the simplest latency-correct behavior).
+//
+// Call from the audio thread.
+void drain_into(MidiBuffer& buffer,
+                std::int64_t block_start_ns,
+                double sample_rate,
+                int block_size);
+
+// Returns true if at least one event is currently queued. For
+// diagnostics only — do not use for control flow, since the producer
+// may push a new event between the check and a subsequent drain.
+bool has_pending();
+
+} // namespace pulp::midi::android
+
+#endif // __ANDROID__

--- a/core/midi/platform/android/android_midi.cpp
+++ b/core/midi/platform/android/android_midi.cpp
@@ -1,19 +1,32 @@
 #if defined(__ANDROID__)
 
+#include <pulp/midi/android_midi_fifo.hpp>
+#include <pulp/midi/buffer.hpp>
+#include <pulp/midi/message.hpp>
 #include <pulp/platform/android/jni.hpp>
+#include <pulp/runtime/spsc_queue.hpp>
+
 #include <android/log.h>
+#include <algorithm>
+#include <cstdint>
+#include <mutex>
+#include <atomic>
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <mutex>
-#include <atomic>
-#include <cstdint>
 
 #define PULP_LOG_TAG "Pulp"
 #define PULP_LOGI(...) __android_log_print(ANDROID_LOG_INFO, PULP_LOG_TAG, __VA_ARGS__)
 #define PULP_LOGW(...) __android_log_print(ANDROID_LOG_WARN, PULP_LOG_TAG, __VA_ARGS__)
 
 namespace pulp::midi {
+
+// Forward declaration — defined in the android namespace below. We need
+// this because dispatch_midi_data() calls android::push_bytes() before
+// the android namespace block is entered.
+namespace android {
+    bool push_bytes(const std::uint8_t* bytes, int count, std::int64_t timestamp_ns);
+}
 
 // ── Android MIDI Device Registry ──────────────────────────────────────────
 
@@ -75,9 +88,101 @@ static void dispatch_midi_data(int device_id, int port,
         g_midi_callback(device_id, port, data, offset, count, timestamp,
                         g_midi_callback_data);
     }
+    // Always push into the internal FIFO so audio-thread consumers
+    // can drain regardless of whether a user callback is set.
+    android::push_bytes(data + offset, count, timestamp);
 }
 
 } // namespace pulp::midi
+
+// ── Android MIDI input FIFO ────────────────────────────────────────────────
+// Lock-free ring buffer between the Kotlin MIDI receiver thread and the
+// audio thread. Capacity sized generously — 512 events is ~17 seconds of
+// typical keyboard input at 30 events/sec.
+
+namespace pulp::midi::android {
+
+static constexpr std::size_t kMidiFifoCapacity = 512;
+
+static pulp::runtime::SpscQueue<AndroidMidiEvent, kMidiFifoCapacity>&
+midi_fifo() {
+    static pulp::runtime::SpscQueue<AndroidMidiEvent, kMidiFifoCapacity> q;
+    return q;
+}
+
+// Drop counter — incremented when a push fails because the FIFO is full.
+// Exposed for diagnostics; no mechanism exists for the audio thread to
+// react to drops (a drop just means the player's input was lost).
+static std::atomic<std::uint64_t> g_drop_count{0};
+
+bool push_bytes(const std::uint8_t* bytes, int count, std::int64_t timestamp_ns) {
+    if (!bytes || count <= 0) return false;
+    AndroidMidiEvent ev;
+    ev.timestamp_ns = static_cast<std::uint64_t>(timestamp_ns);
+    ev.size = static_cast<std::uint8_t>(
+        std::min<int>(count, static_cast<int>(ev.data.size())));
+    std::copy_n(bytes, ev.size, ev.data.begin());
+    if (!midi_fifo().try_push(ev)) {
+        g_drop_count.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+    return true;
+}
+
+bool has_pending() {
+    return !midi_fifo().empty();
+}
+
+// Build a MidiEvent from raw bytes. Only handles short (1-3 byte)
+// channel voice messages in Phase 1. SysEx and longer messages are
+// skipped (the FIFO truncated them anyway).
+static MidiEvent decode_short(const std::uint8_t* bytes, int count) {
+    MidiEvent ev;
+    if (count >= 3) {
+        ev.message = choc::midi::ShortMessage(bytes[0], bytes[1], bytes[2]);
+    } else if (count == 2) {
+        ev.message = choc::midi::ShortMessage(bytes[0], bytes[1], 0);
+    } else if (count == 1) {
+        ev.message = choc::midi::ShortMessage(bytes[0], 0, 0);
+    }
+    return ev;
+}
+
+void drain_into(MidiBuffer& buffer,
+                std::int64_t block_start_ns,
+                double sample_rate,
+                int block_size) {
+    auto& fifo = midi_fifo();
+    while (auto opt = fifo.try_pop()) {
+        const auto& src = *opt;
+        if (src.size == 0) continue;
+        auto ev = decode_short(src.data.data(),
+                               static_cast<int>(src.size));
+        // Convert timestamp to a sample offset within the current block.
+        std::int64_t delta_ns = 0;
+        if (block_start_ns > 0) {
+            delta_ns = static_cast<std::int64_t>(src.timestamp_ns)
+                     - block_start_ns;
+        }
+        double sample_offset = 0.0;
+        if (sample_rate > 0.0) {
+            sample_offset = static_cast<double>(delta_ns) * sample_rate
+                          / 1'000'000'000.0;
+        }
+        // Clamp to [0, block_size - 1]. Events in the past land at 0,
+        // events in the future land at the end of the block (they'll be
+        // slightly late, but this is simpler than buffering future
+        // events and matches the latency profile of the audio thread).
+        int offset = static_cast<int>(sample_offset);
+        if (offset < 0) offset = 0;
+        if (block_size > 0 && offset >= block_size) offset = block_size - 1;
+        ev.sample_offset = offset;
+        ev.timestamp = 0.0;  // filled by consumer if needed
+        buffer.add(std::move(ev));
+    }
+}
+
+} // namespace pulp::midi::android
 
 // ── JNI Exports ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Completes the MIDI input path from USB MIDI controllers into the Pulp audio thread on Android. The existing scaffolding in \`core/midi/platform/android/android_midi.cpp\` and \`PulpMidiManager.kt\` was ~70% complete — what was missing:

1. **No lock-free queue** between the Kotlin MIDI receiver thread and the audio thread. The JNI dispatch callback existed but nothing stored the events.
2. **PulpMidiManager was never instantiated** — the device callbacks would never fire because no Kotlin object held the MidiManager listener registration.

## Changes
- New public header \`core/midi/include/pulp/midi/android_midi_fifo.hpp\` with \`push_bytes\` / \`drain_into\` / \`has_pending\`.
- \`core/midi/platform/android/android_midi.cpp\`:
  - \`SpscQueue<AndroidMidiEvent, 512>\` wrapping CHOC's \`SingleReaderSingleWriterFIFO\`.
  - \`dispatch_midi_data\` now pushes into the FIFO in addition to the optional external callback.
  - \`drain_into\` decodes bytes into \`MidiEvent\`, converts Android monotonic nanosecond timestamps into sample offsets relative to the current block, clamped to \`[0, block_size - 1]\`.
  - Drop counter on overflow (diagnostic only).
- \`android/.../kotlin/com/pulp/PulpApplication.kt\`: instantiate \`PulpMidiManager(this)\` in \`onCreate\` so device discovery runs.

## Scope
- **Phase 1 only**: USB MIDI bytestream (MIDI 1.0). Audio thread can now drain MIDI events via \`pulp::midi::android::drain_into(buffer, block_start_ns, sample_rate, block_size)\`.
- **Not included**: BLE MIDI (phase 2), virtual ports (phase 3), UMP MIDI 2.0. The Kotlin side scaffolds these but nothing in this PR wires them into the audio path.
- **Not verified runtime**: Requires an Android device with a USB MIDI controller — unavailable in this session. The \`android-build\` CI job cross-compiles the code and verifies no compile errors.

## Design notes
- Lock-free producer/consumer: the FIFO is SPSC. Producer is the single Kotlin MIDI receiver thread; consumer is the single audio thread. The existing dispatch callback hook (\`set_midi_data_callback\`) still works for non-audio-thread consumers.
- Timestamp conversion: Android gives nanosecond-precision monotonic timestamps. We subtract the block-start timestamp and scale by sample rate. Events with negative delta land at sample 0 (slightly late); events beyond block size land at the last sample of the block.
- Short-message decode only. The FIFO payload is 16 bytes, large enough for any MIDI 1.0 short message plus a small SysEx chunk; longer SysEx is currently truncated on the producer side.

Partial progress on #86 (Phase 1 USB MIDI only).

## Test plan
- [x] Host build (macOS) still clean — \`pulp-midi\` target links successfully
- [ ] \`android-build\` CI cross-compile green
- [ ] CI on all host platforms green
- [ ] Runtime verification on an Android device (follow-up, requires USB MIDI hardware)