### PR TITLE
Android TalkBack: wire C++ view tree to AccessibilityDelegate

### DIFF
--- a/android/app/src/main/kotlin/com/pulp/render/PulpSurfaceView.kt
+++ b/android/app/src/main/kotlin/com/pulp/render/PulpSurfaceView.kt
@@ -9,6 +9,7 @@ import android.view.SurfaceView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.pulp.PulpApplication
+import com.pulp.accessibility.PulpAccessibilityDelegate
 
 /**
  * SurfaceView that hosts the Vulkan/Dawn rendering surface.
@@ -29,6 +30,12 @@ class PulpSurfaceView(context: Context) : SurfaceView(context), SurfaceHolder.Ca
             Log.i(TAG, "Setting display density: $density")
             nativeSetDisplayDensity(density)
         }
+
+        // TalkBack: route accessibility queries into the C++ view
+        // hierarchy via PulpAccessibilityDelegate's JNI bridge (#87).
+        isFocusable = true
+        importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
+        accessibilityDelegate = PulpAccessibilityDelegate()
 
         // Pass system bar insets (status bar, nav bar) to C++ for safe area padding
         ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->

--- a/core/render/platform/android/gpu_surface_android.cpp
+++ b/core/render/platform/android/gpu_surface_android.cpp
@@ -9,6 +9,7 @@
 #include <pulp/view/input_events.hpp>
 #include <pulp/view/script_engine.hpp>
 #include <pulp/view/widget_bridge.hpp>
+#include <pulp/view/accessibility.hpp>
 #include <pulp/state/store.hpp>
 #include <pulp/platform/android/jni.hpp>
 #include "../../../../core/audio/platform/android/demo_synth.hpp"
@@ -1104,6 +1105,167 @@ Java_com_pulp_render_PulpSurfaceView_nativeOnTouchUp(
 JNIEXPORT void JNICALL
 Java_com_pulp_render_PulpSurfaceView_nativeOnTouchCancel(JNIEnv*, jobject) {
     pulp::render::g_captured_view = nullptr;
+}
+
+// ── Accessibility (TalkBack) ─────────────────────────────────────────────
+//
+// Walks the current C++ view tree and exposes a flat list of views with
+// a non-default AccessRole. The Kotlin PulpAccessibilityDelegate queries
+// this list to populate AccessibilityNodeInfo for TalkBack (#87).
+//
+// The list is rebuilt on every query so it stays in sync with UI changes
+// without needing explicit invalidation — TalkBack queries are
+// infrequent (typically on focus change), so the walk cost is
+// acceptable.
+//
+// Thread model: all accessibility JNI calls run on the main (UI)
+// thread. The view tree is also mutated on the main thread, so no
+// additional locking is required for Phase 1. If Pulp later mutates
+// the tree from other threads, this will need a lock or a snapshot.
+
+namespace {
+
+// Pulp AccessRole → Kotlin PulpAccessibilityDelegate ROLE_* constants.
+// Keep in sync with android/app/src/main/kotlin/com/pulp/accessibility/
+// PulpAccessibility.kt:107-111.
+static int android_role_for_view(pulp::view::View::AccessRole role) {
+    using R = pulp::view::View::AccessRole;
+    switch (role) {
+        case R::slider: return 1;  // ROLE_SLIDER
+        case R::toggle: return 3;  // ROLE_TOGGLE
+        case R::label:  return 2;  // ROLE_TEXT
+        case R::meter:  return 1;  // treat meters like read-only sliders
+        case R::group:  return 4;  // ROLE_LIST (closest approximation)
+        case R::image:  return 2;  // ROLE_TEXT with contentDescription
+        case R::none:
+        default:        return 0;  // ROLE_BUTTON (safe default)
+    }
+}
+
+static void collect_accessible_views(pulp::view::View* root,
+                                     std::vector<pulp::view::View*>& out) {
+    if (!root) return;
+    if (root->access_role() != pulp::view::View::AccessRole::none) {
+        out.push_back(root);
+    }
+    for (std::size_t i = 0; i < root->child_count(); ++i) {
+        collect_accessible_views(root->child_at(i), out);
+    }
+}
+
+static std::vector<pulp::view::View*>& accessibility_cache() {
+    static std::vector<pulp::view::View*> cache;
+    return cache;
+}
+
+static pulp::view::View* accessibility_node_at(int index) {
+    auto& cache = accessibility_cache();
+    if (index < 0 || static_cast<std::size_t>(index) >= cache.size()) {
+        return nullptr;
+    }
+    return cache[static_cast<std::size_t>(index)];
+}
+
+} // anonymous namespace
+
+JNIEXPORT jint JNICALL
+Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetAccessibilityNodeCount(
+    JNIEnv*, jobject) {
+    auto& cache = accessibility_cache();
+    cache.clear();
+    collect_accessible_views(pulp::render::g_root_view.get(), cache);
+    return static_cast<jint>(cache.size());
+}
+
+JNIEXPORT jint JNICALL
+Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeRole(
+    JNIEnv*, jobject, jint index) {
+    auto* view = accessibility_node_at(index);
+    if (!view) return 0;
+    return android_role_for_view(view->access_role());
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeLabel(
+    JNIEnv* env, jobject, jint index) {
+    auto* view = accessibility_node_at(index);
+    if (!view) return env->NewStringUTF("");
+    return env->NewStringUTF(view->access_label().c_str());
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeValue(
+    JNIEnv* env, jobject, jint index) {
+    auto* view = accessibility_node_at(index);
+    if (!view) return env->NewStringUTF("");
+    if (auto* val = dynamic_cast<pulp::view::AccessibilityValueInterface*>(view)) {
+        return env->NewStringUTF(val->get_value_string().c_str());
+    }
+    return env->NewStringUTF("");
+}
+
+JNIEXPORT jfloat JNICALL
+Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeRangeMin(
+    JNIEnv*, jobject, jint index) {
+    auto* view = accessibility_node_at(index);
+    if (auto* val = dynamic_cast<pulp::view::AccessibilityValueInterface*>(view)) {
+        return static_cast<jfloat>(val->get_minimum_value());
+    }
+    return 0.0f;
+}
+
+JNIEXPORT jfloat JNICALL
+Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeRangeMax(
+    JNIEnv*, jobject, jint index) {
+    auto* view = accessibility_node_at(index);
+    if (auto* val = dynamic_cast<pulp::view::AccessibilityValueInterface*>(view)) {
+        return static_cast<jfloat>(val->get_maximum_value());
+    }
+    return 1.0f;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeRowCount(
+    JNIEnv*, jobject, jint index) {
+    auto* view = accessibility_node_at(index);
+    if (auto* table = dynamic_cast<pulp::view::AccessibilityTableInterface*>(view)) {
+        return static_cast<jint>(table->get_row_count());
+    }
+    return 0;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeColumnCount(
+    JNIEnv*, jobject, jint index) {
+    auto* view = accessibility_node_at(index);
+    if (auto* table = dynamic_cast<pulp::view::AccessibilityTableInterface*>(view)) {
+        return static_cast<jint>(table->get_column_count());
+    }
+    return 0;
+}
+
+JNIEXPORT void JNICALL
+Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativePerformAction(
+    JNIEnv*, jobject, jint action, jint nodeIndex, jfloat value) {
+    auto* view = accessibility_node_at(nodeIndex);
+    if (!view) return;
+    // action values match the companion object in PulpAccessibility.kt:
+    //   ACTION_CLICK = 0, ACTION_INCREMENT = 1, ACTION_DECREMENT = 2
+    switch (action) {
+        case 0:  // click
+            if (auto* val = dynamic_cast<pulp::view::AccessibilityValueInterface*>(view)) {
+                val->set_current_value(static_cast<double>(value));
+            }
+            break;
+        case 1:  // increment
+            view->on_accessibility_adjust(1.0f);
+            break;
+        case 2:  // decrement
+            view->on_accessibility_adjust(-1.0f);
+            break;
+        default:
+            break;
+    }
 }
 
 } // extern "C"

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -126,6 +126,7 @@ endif()
 
 target_sources(pulp-view PRIVATE
     ${PULP_JS_ENGINE_SOURCES}
+    src/accessibility.cpp
     src/script_engine.cpp
     src/js_engine_recommend.cpp
     src/theme.cpp

--- a/core/view/include/pulp/view/accessibility.hpp
+++ b/core/view/include/pulp/view/accessibility.hpp
@@ -15,7 +15,10 @@ namespace pulp::view {
 /// Interface for accessible values (sliders, knobs, progress bars)
 class AccessibilityValueInterface {
 public:
-    virtual ~AccessibilityValueInterface() = default;
+    // Out-of-line in src/accessibility.cpp so the vtable + typeinfo
+    // anchors there — required for dynamic_cast on Android NDK builds
+    // that link with -Wl,--no-undefined.
+    virtual ~AccessibilityValueInterface();
 
     /// Current value as a number
     virtual double get_current_value() const = 0;
@@ -39,7 +42,7 @@ public:
 /// Interface for accessible text content (text editors, labels)
 class AccessibilityTextInterface {
 public:
-    virtual ~AccessibilityTextInterface() = default;
+    virtual ~AccessibilityTextInterface();
 
     /// Get the full text
     virtual std::string get_text() const = 0;
@@ -74,7 +77,7 @@ public:
 /// Interface for accessible tables and lists
 class AccessibilityTableInterface {
 public:
-    virtual ~AccessibilityTableInterface() = default;
+    virtual ~AccessibilityTableInterface();
 
     /// Number of rows
     virtual int get_row_count() const = 0;
@@ -104,7 +107,7 @@ public:
 /// Interface for individual table cells
 class AccessibilityCellInterface {
 public:
-    virtual ~AccessibilityCellInterface() = default;
+    virtual ~AccessibilityCellInterface();
 
     /// Cell text content
     virtual std::string get_cell_text(int row, int column) const = 0;

--- a/core/view/src/accessibility.cpp
+++ b/core/view/src/accessibility.cpp
@@ -1,0 +1,43 @@
+// Out-of-line definitions for the accessibility interfaces.
+//
+// The interfaces in pulp/view/accessibility.hpp are otherwise
+// header-only. Without an out-of-line virtual definition the compiler
+// has nowhere to emit the typeinfo / vtable, which makes
+// dynamic_cast<...InterfaceType*>(view) fail to link on builds with
+// -Wl,--no-undefined (e.g., the Android NDK toolchain). Anchoring
+// the vtables here is the standard fix.
+
+#include <pulp/view/accessibility.hpp>
+
+#include <sstream>
+
+namespace pulp::view {
+
+// Anchor the vtables. The out-of-line virtual destructor is enough —
+// = default in the .cpp ensures the typeinfo lands in this TU.
+AccessibilityValueInterface::~AccessibilityValueInterface() = default;
+AccessibilityTextInterface::~AccessibilityTextInterface() = default;
+AccessibilityTableInterface::~AccessibilityTableInterface() = default;
+AccessibilityCellInterface::~AccessibilityCellInterface() = default;
+
+// Default implementation: format the current value as a percentage of
+// the [min, max] range, falling back to a raw decimal if the range is
+// degenerate. Subclasses can override for unit-specific formatting
+// (e.g., "-6 dB", "440 Hz", "120 BPM").
+std::string AccessibilityValueInterface::get_value_string() const {
+    double v   = get_current_value();
+    double lo  = get_minimum_value();
+    double hi  = get_maximum_value();
+    std::ostringstream out;
+    if (hi > lo) {
+        double pct = ((v - lo) / (hi - lo)) * 100.0;
+        if (pct < 0.0) pct = 0.0;
+        if (pct > 100.0) pct = 100.0;
+        out << static_cast<int>(pct + 0.5) << "%";
+    } else {
+        out << v;
+    }
+    return out.str();
+}
+
+} // namespace pulp::view


### PR DESCRIPTION
## Summary
Implements the JNI bridge between the existing \`PulpAccessibilityDelegate.kt\` (which already declared the native method stubs) and the C++ view hierarchy. TalkBack queries the surface view → the delegate → the C++ view tree → role / label / value / range info for every view with a non-default \`AccessRole\`.

## Changes
- **\`gpu_surface_android.cpp\`** adds 9 JNI exports: \`nativeGetAccessibilityNodeCount\`, \`nativeGetNodeRole\`, \`nativeGetNodeLabel\`, \`nativeGetNodeValue\`, \`nativeGetNodeRangeMin\`, \`nativeGetNodeRangeMax\`, \`nativeGetNodeRowCount\`, \`nativeGetNodeColumnCount\`, \`nativePerformAction\`. The node list is rebuilt on every \`nativeGetAccessibilityNodeCount\` call via a depth-first walk of \`g_root_view\`. Subsequent per-index queries read from a cached flat vector until the next count.
- **\`PulpSurfaceView.kt\`** attaches \`PulpAccessibilityDelegate\`, marks the view \`isFocusable = true\` and \`importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES\` so TalkBack discovers it.
- Role mapping: Pulp's \`View::AccessRole\` enum (\`slider\`, \`toggle\`, \`label\`, \`group\`, \`meter\`, \`image\`, \`none\`) → Kotlin \`ROLE_*\` constants (\`BUTTON\`, \`SLIDER\`, \`TEXT\`, \`TOGGLE\`, \`LIST\`). Not a perfect 1:1; \`meter\` maps to read-only slider, \`group\` to list.
- Uses \`dynamic_cast\` into \`AccessibilityValueInterface\` / \`AccessibilityTableInterface\` to pull range and collection info when the view implements them.

## Scope
- **Phase 1**: flat list of accessible nodes. No hierarchical focus navigation — TalkBack can still swipe through individual nodes, but the tree structure is not exposed.
- **Not verified runtime**: requires an Android device with TalkBack enabled. CI's \`android-build\` job verifies the cross-compile.

## Threading
All accessibility JNI calls run on the main thread. The view tree is also mutated on the main thread, so no locking is required. If Pulp later mutates the tree from background threads, this bridge will need a lock or a snapshot.

Partial progress on #87.

## Test plan
- [x] Host build (macOS) — \`pulp-view\` links clean
- [ ] \`android-build\` CI cross-compile green
- [ ] CI on all host platforms green
- [ ] Runtime verification on Android device with TalkBack (follow-up)