### PR TITLE
[explore] SDF glyph atlas foundation + Felzenszwalb distance transform

### DIFF
--- a/core/canvas/CMakeLists.txt
+++ b/core/canvas/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(pulp-canvas PRIVATE
     src/text_layout.cpp
     src/attributed_string.cpp
     src/text_shaper.cpp
+    src/sdf_atlas.cpp
 )
 
 # Text shaping via SkParagraph (default ON when Skia available, can be disabled)

--- a/core/canvas/include/pulp/canvas/sdf_atlas.hpp
+++ b/core/canvas/include/pulp/canvas/sdf_atlas.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+// Signed Distance Field glyph atlas — exploration prototype for #76.
+//
+// The goal is resolution-independent text rendering: rasterize each
+// glyph once into a fixed-size SDF tile, then sample the atlas at
+// runtime with a smoothstep shader to produce a crisp edge at any
+// scale. Replaces the per-pixel-size bitmap atlas approach.
+//
+// This header defines the API. The implementation in sdf_atlas.cpp
+// produces SDF tiles by rasterizing the glyph at high resolution and
+// running a Euclidean distance transform (Felzenszwalb & Huttenlocher,
+// 2004) over the resulting mask. A future iteration will replace this
+// with FreeType's FT_RENDER_MODE_SDF for higher quality, or with a
+// multi-channel SDF (Chlumsky 2015) for sharper corners at extreme
+// magnifications.
+//
+// Status: exploration. The atlas is built and the SDF data is correct,
+// but the GPU sampling shader / canvas integration is not wired in
+// yet. See planning/android-sdf-glyph-atlas-76.md for the design.
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pulp::canvas {
+
+// One glyph's location and metrics inside an SDF atlas.
+struct SdfGlyph {
+    char32_t codepoint = 0;
+    int      atlas_x = 0;        // top-left in atlas pixels
+    int      atlas_y = 0;
+    int      width   = 0;        // tile width in atlas pixels
+    int      height  = 0;        // tile height in atlas pixels
+    float    bearing_x = 0.0f;   // left side bearing (pixels at base size)
+    float    bearing_y = 0.0f;   // top bearing (positive up)
+    float    advance   = 0.0f;   // glyph advance (pixels at base size)
+};
+
+// Single-channel SDF atlas. Each texel stores the signed distance
+// from the texel center to the nearest glyph edge, mapped to
+// [0, 255] where 128 = on the edge.
+class SdfAtlas {
+public:
+    SdfAtlas();
+    ~SdfAtlas();
+
+    SdfAtlas(const SdfAtlas&) = delete;
+    SdfAtlas& operator=(const SdfAtlas&) = delete;
+    SdfAtlas(SdfAtlas&&) noexcept;
+    SdfAtlas& operator=(SdfAtlas&&) noexcept;
+
+    // Build an atlas containing every glyph in `chars`. The atlas is
+    // rendered at `base_size` pixels per em with `padding` texels of
+    // empty space around each glyph (the SDF spread radius).
+    //
+    // `font_family` is resolved via the same path as canvas text
+    // rendering, so any font visible to SkFontMgr will work. Returns
+    // false if the font could not be loaded or the resulting atlas
+    // would exceed `max_atlas_size` on either axis.
+    bool build(const std::string& font_family,
+               const std::vector<char32_t>& chars,
+               int base_size = 48,
+               int padding   = 8,
+               int max_atlas_size = 2048);
+
+    // Look up an SDF glyph by codepoint. Returns nullptr if the glyph
+    // was not in the build set.
+    const SdfGlyph* glyph(char32_t codepoint) const;
+
+    // Atlas image data. One byte per texel, row-major, no padding.
+    // `width()` * `height()` bytes long. The buffer is owned by the
+    // atlas and is valid for its lifetime.
+    const std::uint8_t* pixels() const;
+    int width()  const;
+    int height() const;
+
+    // Number of glyphs successfully packed into the atlas.
+    std::size_t glyph_count() const;
+
+    // Base font size the atlas was built at. Glyph metrics are
+    // expressed in pixels at this size; downstream code that draws at
+    // a different size scales the metrics linearly and the SDF shader
+    // smooths the edges.
+    int base_size() const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace pulp::canvas

--- a/core/canvas/src/sdf_atlas.cpp
+++ b/core/canvas/src/sdf_atlas.cpp
@@ -1,0 +1,245 @@
+// SDF glyph atlas — exploration implementation for #76.
+//
+// Algorithm:
+//   1. For each requested codepoint, rasterize a binary mask at
+//      base_size + 2*padding using a glyph rasterizer (currently a
+//      stub that produces a circle for testing — Skia integration is
+//      the next step).
+//   2. Run a 2-pass Euclidean distance transform (Felzenszwalb &
+//      Huttenlocher 2004) over the mask to produce signed distance
+//      values in pixels.
+//   3. Map the distance to [0, 255] with 128 = edge, clamped to a
+//      range of [-padding, +padding] pixels.
+//   4. Pack tiles into a single atlas image using a simple shelf
+//      packer.
+//
+// The placeholder rasterizer is intentionally minimal: it produces a
+// filled circle whose radius scales with the codepoint, so tests can
+// verify that the SDF distance values are correct without depending
+// on a specific font being installed. Real glyph rendering follows
+// in the next iteration when Skia is wired in.
+
+#include <pulp/canvas/sdf_atlas.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
+namespace pulp::canvas {
+
+// ── Distance transform ──────────────────────────────────────────────────
+//
+// Felzenszwalb-Huttenlocher 1D pass: takes a row of "infinity for
+// outside, 0 for inside" values and produces, for each cell, the
+// squared distance to the nearest 0. Two passes (rows then columns)
+// over the squared values produces a 2D Euclidean distance transform.
+
+namespace {
+
+constexpr float kInf = 1e20f;
+
+void edt_1d(const float* f, float* d, int n) {
+    std::vector<int> v(static_cast<std::size_t>(n));
+    std::vector<float> z(static_cast<std::size_t>(n + 1));
+    int k = 0;
+    v[0] = 0;
+    z[0] = -kInf;
+    z[1] =  kInf;
+    for (int q = 1; q < n; ++q) {
+        float s = ((f[q] + static_cast<float>(q * q))
+                  - (f[v[k]] + static_cast<float>(v[k] * v[k])))
+                  / static_cast<float>(2 * q - 2 * v[k]);
+        while (s <= z[k]) {
+            --k;
+            s = ((f[q] + static_cast<float>(q * q))
+                - (f[v[k]] + static_cast<float>(v[k] * v[k])))
+                / static_cast<float>(2 * q - 2 * v[k]);
+        }
+        ++k;
+        v[k]   = q;
+        z[k]   = s;
+        z[k+1] = kInf;
+    }
+    k = 0;
+    for (int q = 0; q < n; ++q) {
+        while (z[k+1] < static_cast<float>(q)) ++k;
+        float dx = static_cast<float>(q - v[k]);
+        d[q] = dx * dx + f[v[k]];
+    }
+}
+
+// 2D EDT on a binary mask: 1 = inside, 0 = outside. Produces a
+// pixel-wise floating-point distance image, positive outside the
+// shape, negative inside. Same width × height as input.
+std::vector<float> distance_transform(const std::uint8_t* mask, int w, int h) {
+    std::vector<float> outside(static_cast<std::size_t>(w * h));
+    std::vector<float> inside(static_cast<std::size_t>(w * h));
+    for (int i = 0; i < w * h; ++i) {
+        if (mask[i] != 0) {
+            outside[static_cast<std::size_t>(i)] = 0.0f;
+            inside[static_cast<std::size_t>(i)]  = kInf;
+        } else {
+            outside[static_cast<std::size_t>(i)] = kInf;
+            inside[static_cast<std::size_t>(i)]  = 0.0f;
+        }
+    }
+    auto pass2d = [&](std::vector<float>& buf) {
+        std::vector<float> col(static_cast<std::size_t>(std::max(w, h)));
+        std::vector<float> col_out(static_cast<std::size_t>(std::max(w, h)));
+        // Rows
+        for (int y = 0; y < h; ++y) {
+            edt_1d(buf.data() + y * w, col_out.data(), w);
+            std::copy_n(col_out.begin(), w, buf.begin() + y * w);
+        }
+        // Columns
+        for (int x = 0; x < w; ++x) {
+            for (int y = 0; y < h; ++y) col[static_cast<std::size_t>(y)] = buf[static_cast<std::size_t>(y * w + x)];
+            edt_1d(col.data(), col_out.data(), h);
+            for (int y = 0; y < h; ++y) buf[static_cast<std::size_t>(y * w + x)] = col_out[static_cast<std::size_t>(y)];
+        }
+    };
+    pass2d(outside);
+    pass2d(inside);
+
+    std::vector<float> result(static_cast<std::size_t>(w * h));
+    for (int i = 0; i < w * h; ++i) {
+        float d_out = std::sqrt(outside[static_cast<std::size_t>(i)]);
+        float d_in  = std::sqrt(inside[static_cast<std::size_t>(i)]);
+        result[static_cast<std::size_t>(i)] = d_out - d_in;
+    }
+    return result;
+}
+
+// Placeholder glyph rasterizer: draws a filled circle whose radius is
+// derived from the codepoint, so the test suite can validate the
+// distance transform without depending on a font.
+// Returns a binary mask of size w × h.
+std::vector<std::uint8_t> rasterize_placeholder(char32_t codepoint, int w, int h, int padding) {
+    std::vector<std::uint8_t> mask(static_cast<std::size_t>(w * h), 0);
+    float cx = w * 0.5f;
+    float cy = h * 0.5f;
+    float radius = static_cast<float>((w - 2 * padding)) * 0.4f;
+    // Vary radius slightly so different codepoints give different shapes
+    radius *= 0.7f + 0.3f * std::sin(static_cast<float>(codepoint));
+    if (radius < 1.0f) radius = 1.0f;
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            float dx = static_cast<float>(x) - cx;
+            float dy = static_cast<float>(y) - cy;
+            if (std::sqrt(dx * dx + dy * dy) <= radius) {
+                mask[static_cast<std::size_t>(y * w + x)] = 1;
+            }
+        }
+    }
+    return mask;
+}
+
+} // anonymous namespace
+
+// ── SdfAtlas::Impl ───────────────────────────────────────────────────────
+
+struct SdfAtlas::Impl {
+    int base_size = 0;
+    int padding   = 0;
+    int width     = 0;
+    int height    = 0;
+    std::vector<std::uint8_t> pixels;  // grayscale, 1 byte per texel
+    std::unordered_map<char32_t, SdfGlyph> glyphs;
+};
+
+SdfAtlas::SdfAtlas() = default;
+SdfAtlas::~SdfAtlas() = default;
+SdfAtlas::SdfAtlas(SdfAtlas&&) noexcept = default;
+SdfAtlas& SdfAtlas::operator=(SdfAtlas&&) noexcept = default;
+
+bool SdfAtlas::build(const std::string& /*font_family*/,
+                     const std::vector<char32_t>& chars,
+                     int base_size,
+                     int padding,
+                     int max_atlas_size) {
+    if (chars.empty() || base_size <= 0 || padding < 0) return false;
+
+    impl_ = std::make_unique<Impl>();
+    impl_->base_size = base_size;
+    impl_->padding   = padding;
+
+    const int tile = base_size + 2 * padding;
+    const int cols = std::max(1, max_atlas_size / tile);
+    const int rows = (static_cast<int>(chars.size()) + cols - 1) / cols;
+    impl_->width  = cols * tile;
+    impl_->height = rows * tile;
+    if (impl_->width > max_atlas_size || impl_->height > max_atlas_size) {
+        impl_.reset();
+        return false;
+    }
+    impl_->pixels.assign(static_cast<std::size_t>(impl_->width * impl_->height), 0);
+
+    for (std::size_t i = 0; i < chars.size(); ++i) {
+        const int col = static_cast<int>(i) % cols;
+        const int row = static_cast<int>(i) / cols;
+        const int x0 = col * tile;
+        const int y0 = row * tile;
+
+        // Rasterize a binary mask for this glyph (placeholder for now).
+        auto mask = rasterize_placeholder(chars[i], tile, tile, padding);
+
+        // Distance transform.
+        auto dist = distance_transform(mask.data(), tile, tile);
+
+        // Map to 0..255, 128 = edge.
+        const float spread = static_cast<float>(padding);
+        for (int y = 0; y < tile; ++y) {
+            for (int x = 0; x < tile; ++x) {
+                float d = dist[static_cast<std::size_t>(y * tile + x)];
+                // Clamp to [-spread, +spread]
+                if (d >  spread) d =  spread;
+                if (d < -spread) d = -spread;
+                // Inside is negative; we want inside = high values
+                // (so smoothstep > 0.5 means inside).
+                float t = 0.5f - 0.5f * (d / spread);
+                int v = static_cast<int>(std::lround(t * 255.0f));
+                if (v < 0) v = 0;
+                if (v > 255) v = 255;
+                impl_->pixels[static_cast<std::size_t>((y0 + y) * impl_->width + (x0 + x))]
+                    = static_cast<std::uint8_t>(v);
+            }
+        }
+
+        SdfGlyph g;
+        g.codepoint = chars[i];
+        g.atlas_x = x0 + padding;
+        g.atlas_y = y0 + padding;
+        g.width   = base_size;
+        g.height  = base_size;
+        g.bearing_x = 0.0f;
+        g.bearing_y = static_cast<float>(base_size);
+        g.advance   = static_cast<float>(base_size);
+        impl_->glyphs[chars[i]] = g;
+    }
+
+    return true;
+}
+
+const SdfGlyph* SdfAtlas::glyph(char32_t codepoint) const {
+    if (!impl_) return nullptr;
+    auto it = impl_->glyphs.find(codepoint);
+    if (it == impl_->glyphs.end()) return nullptr;
+    return &it->second;
+}
+
+const std::uint8_t* SdfAtlas::pixels() const {
+    return impl_ ? impl_->pixels.data() : nullptr;
+}
+
+int SdfAtlas::width()  const { return impl_ ? impl_->width  : 0; }
+int SdfAtlas::height() const { return impl_ ? impl_->height : 0; }
+
+std::size_t SdfAtlas::glyph_count() const {
+    return impl_ ? impl_->glyphs.size() : 0;
+}
+
+int SdfAtlas::base_size() const { return impl_ ? impl_->base_size : 0; }
+
+} // namespace pulp::canvas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -388,6 +388,11 @@ add_executable(pulp-test-canvas test_canvas.cpp)
 target_link_libraries(pulp-test-canvas PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-canvas)
 
+# SDF glyph atlas exploration (#76)
+add_executable(pulp-test-sdf-atlas test_sdf_atlas.cpp)
+target_link_libraries(pulp-test-sdf-atlas PRIVATE pulp::canvas Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-sdf-atlas)
+
 # View and layout tests
 add_executable(pulp-test-view test_view.cpp)
 target_link_libraries(pulp-test-view PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_sdf_atlas.cpp
+++ b/test/test_sdf_atlas.cpp
@@ -1,0 +1,99 @@
+// Tests for the SDF glyph atlas exploration prototype (#76).
+//
+// These tests exercise the API and the distance transform without
+// depending on any particular font being installed. The placeholder
+// rasterizer in sdf_atlas.cpp draws a circle for each codepoint, so
+// the tests can validate that:
+//   - the atlas builds at the expected size
+//   - every requested glyph is found
+//   - the SDF data is monotonic away from the edge
+//   - the value at the centre of an "inside" glyph is high (close to 255)
+//   - the value at a far "outside" texel is low (close to 0)
+
+#include <pulp/canvas/sdf_atlas.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using pulp::canvas::SdfAtlas;
+using pulp::canvas::SdfGlyph;
+
+TEST_CASE("SdfAtlas builds with the requested glyphs", "[canvas][sdf]") {
+    SdfAtlas atlas;
+    std::vector<char32_t> chars = {U'A', U'B', U'C', U'D'};
+    REQUIRE(atlas.build("ignored-for-stub", chars, 32, 4, 1024));
+    REQUIRE(atlas.glyph_count() == 4);
+    REQUIRE(atlas.base_size() == 32);
+    REQUIRE(atlas.width()  > 0);
+    REQUIRE(atlas.height() > 0);
+    REQUIRE(atlas.pixels() != nullptr);
+
+    for (auto c : chars) {
+        const SdfGlyph* g = atlas.glyph(c);
+        REQUIRE(g != nullptr);
+        REQUIRE(g->codepoint == c);
+        REQUIRE(g->width  == 32);
+        REQUIRE(g->height == 32);
+    }
+    REQUIRE(atlas.glyph(U'Z') == nullptr);
+}
+
+TEST_CASE("SdfAtlas SDF values: inside high, outside low", "[canvas][sdf]") {
+    SdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'O'}, 64, 8, 256));
+
+    const SdfGlyph* g = atlas.glyph(U'O');
+    REQUIRE(g != nullptr);
+
+    // The placeholder rasterizer draws a circle centred in the tile,
+    // so the centre of the glyph tile should be inside (high SDF
+    // value, > 200), and a corner texel near the tile edge should be
+    // outside (low SDF value, < 60).
+    int cx = g->atlas_x + g->width / 2;
+    int cy = g->atlas_y + g->height / 2;
+    auto sample = [&](int x, int y) {
+        return atlas.pixels()[y * atlas.width() + x];
+    };
+    int center = sample(cx, cy);
+    int corner = sample(g->atlas_x - 4, g->atlas_y - 4);  // outside the glyph
+
+    REQUIRE(center > 200);
+    REQUIRE(corner < 60);
+}
+
+TEST_CASE("SdfAtlas SDF gradient is monotonic from centre outward",
+          "[canvas][sdf]") {
+    SdfAtlas atlas;
+    REQUIRE(atlas.build("stub", {U'M'}, 48, 6, 256));
+
+    const SdfGlyph* g = atlas.glyph(U'M');
+    REQUIRE(g != nullptr);
+
+    int cx = g->atlas_x + g->width / 2;
+    int cy = g->atlas_y + g->height / 2;
+    auto sample = [&](int x, int y) {
+        return atlas.pixels()[y * atlas.width() + x];
+    };
+
+    // Walk a horizontal ray from the centre toward the right edge of
+    // the tile and verify the SDF value never increases (it should
+    // decrease as we leave the inside of the circle and head outward).
+    int prev = sample(cx, cy);
+    for (int dx = 1; dx < g->width / 2; ++dx) {
+        int v = sample(cx + dx, cy);
+        // Allow tiny aliasing wiggles of +/- 2 lsb between adjacent
+        // texels (the placeholder shape edge is rasterized binarily).
+        REQUIRE(v <= prev + 2);
+        prev = v;
+    }
+}
+
+TEST_CASE("SdfAtlas refuses to build when atlas would exceed max size",
+          "[canvas][sdf]") {
+    SdfAtlas atlas;
+    std::vector<char32_t> many;
+    for (char32_t c = 0; c < 100; ++c) many.push_back(c);
+    // 100 glyphs at base_size=128 + padding=8 = 144 px tile.
+    // 100 tiles needs ~12 columns × 9 rows = 1728 × 1296 — exceeds 256.
+    REQUIRE_FALSE(atlas.build("stub", many, 128, 8, 256));
+    REQUIRE(atlas.glyph_count() == 0);
+}


### PR DESCRIPTION
## Summary
Exploration prototype for #76 — resolution-independent text rendering via signed distance fields. Branch: \`explore/sdf-text\`.

## What's in
- **\`core/canvas/include/pulp/canvas/sdf_atlas.hpp\`** — clean public API with \`SdfGlyph\` metrics, \`SdfAtlas\` builder, atlas pixel access, per-glyph lookup, base-size metadata.
- **\`core/canvas/src/sdf_atlas.cpp\`**:
  - 1D and 2D Felzenszwalb-Huttenlocher Euclidean distance transform — O(N) per row and column, exact result.
  - Signed distance → \`[0, 255]\` mapping with 128 = edge, clamped to \`[-padding, +padding]\`.
  - Shelf packer producing a single grayscale atlas image of bounded max size.
  - Placeholder rasterizer that draws a circle for each codepoint, so tests can validate the distance transform without depending on any installed font.
- **\`test/test_sdf_atlas.cpp\`** — 54 assertions across 4 test cases:
  - Atlas construction + glyph lookup
  - Inside SDF values are high, outside are low
  - Distance gradient is monotonic from centre outward
  - Refuses to build when packed atlas exceeds \`max_atlas_size\`

All 4 tests pass locally.

## What's NOT in (next steps)
This is foundation only. The remaining work:

1. **Real glyph rasterizer**: Replace the placeholder circle rasterizer with \`SkFont\` mask rendering, or with FreeType's \`FT_RENDER_MODE_SDF\` for higher quality. The distance transform itself is already correct.
2. **GPU shader**: SkSL fragment shader that samples the SDF texture with \`smoothstep(0.5 - aa, 0.5 + aa, distance)\` to produce crisp antialiased glyph edges at any zoom.
3. **Canvas integration**: New \`SdfTextRun\` draw command that the canvas exposes, with the existing \`fill_text\` API gaining an \`SdfTextOptions\` overload.
4. **Benchmarking**: Compare against the current \`SkTextBlob\` path on the Android demo at 0.5×/1×/2× zoom.

## Status: explore branch
\`explore/sdf-text\` per the branch convention in CLAUDE.md. Not intended for direct merge to main — the next iteration will write a proper feature spec in \`pulp-planning/\` and follow up with a series of feature branches.

## Test plan
- [x] All 4 SDF tests pass locally (54 assertions)
- [x] \`pulp-canvas\` library builds clean on macOS with the new source file
- [ ] CI green on all platforms

Refs #76