### PR TITLE
Fix #74: Add INSTALL_RPATH to pulp-cli for installed binaries

### DIFF
--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -34,6 +34,23 @@ target_compile_features(pulp-cli PRIVATE cxx_std_20)
 target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format pulp::inspect)
 target_include_directories(pulp-cli PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+# RPATH so the installed binary can find shared libraries (e.g.,
+# libwgpu_native.dylib / libwgpu_native.so) inside its install prefix.
+# Without this the installed CLI crashes immediately on launch with
+# "Library not loaded: @rpath/libwgpu_native.dylib — no LC_RPATH's
+# found" because the wgpu-native prebuilt sets @rpath but nothing
+# adds an LC_RPATH entry to pulp-cli (#74).
+if(APPLE)
+    set_target_properties(pulp-cli PROPERTIES
+        INSTALL_RPATH "@executable_path/../lib"
+        BUILD_WITH_INSTALL_RPATH FALSE
+        MACOSX_RPATH TRUE)
+elseif(UNIX)
+    set_target_properties(pulp-cli PROPERTIES
+        INSTALL_RPATH "$ORIGIN/../lib"
+        BUILD_WITH_INSTALL_RPATH FALSE)
+endif()
+
 # Install into the active prefix so SDK installs do not try to write back into
 # the source checkout.
 set(_pulp_cli_install_bindir "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
## Summary
Sets \`INSTALL_RPATH\` on the \`pulp-cli\` target so the installed binary resolves shared libraries (notably \`libwgpu_native.dylib\` / \`libwgpu_native.so\`) relative to its own location inside the install prefix.

## Root cause
The wgpu-native prebuilt declares its install name as \`@rpath/libwgpu_native.dylib\` and \`pulp-cli\` links it transitively, but \`pulp-cli\` had no \`INSTALL_RPATH\` set. After \`cmake --install\` the binary ended up with zero \`LC_RPATH\` entries, so the dynamic linker could not find the wgpu_native dylib in the adjacent \`lib/\` directory:

\`\`\`
dyld[5087]: Library not loaded: @rpath/libwgpu_native.dylib
  Referenced from: /path/to/bin/pulp
  Reason: no LC_RPATH's found
[1]    5087 abort      pulp build
\`\`\`

## Fix
\`\`\`cmake
if(APPLE)
    set_target_properties(pulp-cli PROPERTIES
        INSTALL_RPATH "@executable_path/../lib"
        BUILD_WITH_INSTALL_RPATH FALSE
        MACOSX_RPATH TRUE)
elseif(UNIX)
    set_target_properties(pulp-cli PROPERTIES
        INSTALL_RPATH "\$ORIGIN/../lib"
        BUILD_WITH_INSTALL_RPATH FALSE)
endif()
\`\`\`

Windows uses a different DLL search policy (DLLs in the same directory as the .exe, or on \`PATH\`) and is not affected by this particular bug.

## Verification
End-to-end on macOS:
\`\`\`
$ cmake --install build --prefix /tmp/pulp-rpath-test
$ /tmp/pulp-rpath-test/bin/pulp version
Pulp SDK version: 0.2.1                # was: dyld crash

$ otool -l /tmp/pulp-rpath-test/bin/pulp | grep -A2 LC_RPATH
          cmd LC_RPATH
      cmdsize 40
         path @executable_path/../lib (offset 12)
\`\`\`

Closes #74