### PR TITLE
Fix Windows SDK consumption: implib filename + standalone link

### DIFF
--- a/tools/cmake/PulpConfig.cmake.in
+++ b/tools/cmake/PulpConfig.cmake.in
@@ -68,18 +68,33 @@ if(NOT TARGET webgpu
    AND EXISTS "${_pulp_webgpu_runtime}"
    AND EXISTS "${_pulp_webgpu_include_dir}")
 
-    # On Windows, MSVC needs an import library (wgpu_native.lib) in
-    # addition to the runtime DLL. Fail fast with a clear message if the
-    # SDK install is broken (#94 was caused by this silently missing).
+    # On Windows, MSVC needs an import library in addition to the
+    # runtime DLL. Modern wgpu-native builds ship the import library
+    # as `wgpu_native.dll.lib` (the MSVC IMPLIB convention since
+    # wgpu-native v0.19+); older builds shipped `wgpu_native.lib`.
+    # Look for either name. Fail fast with a clear message if neither
+    # is present so a broken SDK install (#94) gives a useful error
+    # instead of a confusing "IMPORTED_IMPLIB not set" later.
     if(WIN32)
-        set(_pulp_webgpu_implib
+        set(_pulp_webgpu_implib_candidates
+            "${PULP_SDK_LIBRARY_DIR}/wgpu_native.dll.lib"
+            "${PULP_SDK_LIBRARY_DIR}/wgpu_native.lib"
             "${PULP_SDK_LIBRARY_DIR}/${PULP_SDK_SHARED_LIBRARY_PREFIX}wgpu_native.lib")
-        if(NOT EXISTS "${_pulp_webgpu_implib}")
+        set(_pulp_webgpu_implib "")
+        foreach(_pulp_candidate IN LISTS _pulp_webgpu_implib_candidates)
+            if(EXISTS "${_pulp_candidate}")
+                set(_pulp_webgpu_implib "${_pulp_candidate}")
+                break()
+            endif()
+        endforeach()
+        unset(_pulp_candidate)
+        if(NOT _pulp_webgpu_implib)
             message(FATAL_ERROR
-                "Pulp SDK is missing wgpu_native.lib at ${_pulp_webgpu_implib}. "
+                "Pulp SDK is missing the wgpu_native import library. "
+                "Looked for: ${_pulp_webgpu_implib_candidates}. "
                 "This is a broken SDK install — the runtime DLL is present "
                 "but the import library needed for linking is not. "
-                "Reinstall the Pulp SDK (v0.2.1 or newer) to pick up the fix "
+                "Reinstall the Pulp SDK (v0.2.2 or newer) to pick up the fix "
                 "from https://github.com/danielraffel/pulp/issues/94.")
         endif()
     endif()

--- a/tools/templates/standalone/app/CMakeLists.txt.template
+++ b/tools/templates/standalone/app/CMakeLists.txt.template
@@ -18,10 +18,10 @@ list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(Catch)
 
 add_executable({{TARGET_NAME}} main.cpp)
-target_link_libraries({{TARGET_NAME}} PRIVATE Pulp::format)
+target_link_libraries({{TARGET_NAME}} PRIVATE Pulp::standalone Pulp::format)
 target_include_directories({{TARGET_NAME}} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable({{TARGET_NAME}}-test test_{{LOWER_NAME}}.cpp)
-target_link_libraries({{TARGET_NAME}}-test PRIVATE Pulp::format Catch2::Catch2WithMain)
+target_link_libraries({{TARGET_NAME}}-test PRIVATE Pulp::standalone Pulp::format Catch2::Catch2WithMain)
 target_include_directories({{TARGET_NAME}}-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 catch_discover_tests({{TARGET_NAME}}-test)

--- a/tools/templates/standalone/bare/CMakeLists.txt.template
+++ b/tools/templates/standalone/bare/CMakeLists.txt.template
@@ -18,10 +18,10 @@ list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(Catch)
 
 add_executable({{TARGET_NAME}} main.cpp)
-target_link_libraries({{TARGET_NAME}} PRIVATE Pulp::format)
+target_link_libraries({{TARGET_NAME}} PRIVATE Pulp::standalone Pulp::format)
 target_include_directories({{TARGET_NAME}} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable({{TARGET_NAME}}-test test_{{LOWER_NAME}}.cpp)
-target_link_libraries({{TARGET_NAME}}-test PRIVATE Pulp::format Catch2::Catch2WithMain)
+target_link_libraries({{TARGET_NAME}}-test PRIVATE Pulp::standalone Pulp::format Catch2::Catch2WithMain)
 target_include_directories({{TARGET_NAME}}-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 catch_discover_tests({{TARGET_NAME}}-test)


### PR DESCRIPTION
## Summary
End-to-end verification of v0.2.1 on Windows turned up two follow-on bugs that #95 missed:

### 1. wgpu_native import library has a different filename
v0.2.1 ships the import lib as \`wgpu_native.dll.lib\` (the modern MSVC IMPLIB convention since wgpu-native v0.19+), but \`PulpConfig.cmake.in\` only checked for \`wgpu_native.lib\` and triggered the fail-fast error from #95 against a SDK that was actually fine.

\`PulpConfig.cmake.in\` now looks for any of:
- \`wgpu_native.dll.lib\` (modern)
- \`wgpu_native.lib\` (older)
- \`\${PULP_SDK_SHARED_LIBRARY_PREFIX}wgpu_native.lib\` (legacy historical)

and uses whichever exists. The error message now lists every name it tried.

### 2. bare/app standalone templates were missing \`Pulp::standalone\`
The bare and app templates only linked \`Pulp::format\`, but \`pulp::format::StandaloneApp\` lives in \`libpulp-standalone.a\` / \`pulp-standalone.lib\`. On Windows MSVC this produced:

\`\`\`
LNK2019: unresolved external symbol "public: __cdecl pulp::format::StandaloneApp::~StandaloneApp(void)"
LNK2019: unresolved external symbol "public: bool __cdecl pulp::format::StandaloneApp::run_with_editor(bool)"
LNK1120: 3 unresolved externals
\`\`\`

for any project scaffolded with \`--type bare\` or \`--type app\`. The effect/instrument templates wrap the link inside \`pulp_add_plugin\` so they were not affected.

Both templates now link \`Pulp::standalone Pulp::format\` explicitly.

## Verification
End-to-end on Windows ARM64 (with x64 cross-compile via VS 2022 Build Tools):

\`\`\`
$ pulp.exe create VerifyV021 --type bare --no-build --ci ...
$ cmake -S . -B build -G "Visual Studio 17 2022" -A x64 \\
    -DCMAKE_PREFIX_PATH=~/.pulp/sdk/0.2.1
-- Configuring done
$ cmake --build build --config Release
  VerifyV021.vcxproj -> Release/VerifyV021.exe
  VerifyV021-test.vcxproj -> Release/VerifyV021-test.exe
$ Release/VerifyV021-test.exe
All tests passed (1 assertion in 1 test case)
\`\`\`

Both binaries built (\`VerifyV021.exe\` 1.3 MB, \`VerifyV021-test.exe\` 480 KB), tests pass.

## Test plan
- [x] Configure succeeds with \`Visual Studio 17 2022\` generator on Windows ARM64
- [x] Both \`add_executable\` targets link successfully
- [x] Test runner exits 0
- [ ] CI green on all platforms
- [ ] After merge: cut v0.2.2 patch release, re-verify