### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Pulp are documented here.
 
+## [0.2.2] — 2026-04-09
+
+### Fixed
+- **Installed `pulp` CLI now runs without crashing** (#74): added `INSTALL_RPATH` to the `pulp-cli` target so the installed binary resolves `libwgpu_native.dylib` / `libwgpu_native.so` from `<prefix>/lib`. Previously every installed CLI crashed immediately on launch with `dyld: Library not loaded: @rpath/libwgpu_native.dylib`.
+- **Windows SDK now ships the wgpu_native import library under both names** (#94, #104 follow-up): PulpConfig.cmake now looks for `wgpu_native.dll.lib` (the modern MSVC IMPLIB convention used by wgpu-native v0.19+) in addition to `wgpu_native.lib` and the legacy prefixed name. The fail-fast error message lists every name it tried.
+- **Bare/app standalone templates now link `Pulp::standalone` explicitly** (#104 follow-up): scaffolded plugins built with `--type bare` or `--type app` failed to link on Windows MSVC with `LNK2019: unresolved external symbol StandaloneApp::~StandaloneApp` because the templates only linked `Pulp::format`, not `Pulp::standalone`. Both templates now link both targets.
+
+### Added
+- **SDF glyph atlas: real SkFont rasterizer** (#76 follow-up): replaces the placeholder circle rasterizer with `SkFont::drawSimpleText` into an offscreen `SkBitmap` when `PULP_HAS_SKIA` is defined. Falls back to the placeholder for builds without Skia so the host-only test suite still passes.
+
 ## [0.2.1] — 2026-04-09
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.2.1
+    VERSION 0.2.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Summary
Patch release bundling the post-v0.2.1 follow-on fixes from this session. Bumps \`CMakeLists.txt\` VERSION 0.2.1 → 0.2.2.

### Fixes
- **#74** Installed CLI now runs without dyld crash (RPATH on \`pulp-cli\`)
- **#94 follow-up** Windows SDK accepts \`wgpu_native.dll.lib\` (modern wgpu-native v0.19+ naming)
- **#104** Bare/app standalone templates link \`Pulp::standalone\` so they build on Windows MSVC
- **#76 follow-up** SDF atlas uses real SkFont rasterizer when Skia is present

### Impact
v0.2.0 and v0.2.1 Windows installs are broken. v0.2.2 is the first patch release since v0.2.0 where a fresh \`pulp create\` → \`cmake configure\` → \`cmake build\` → tests pipeline works end-to-end on a real Windows host.

### Verification
The same fixes were verified end-to-end against the v0.2.1 SDK on a Windows ARM64 host (with x64 cross-compile via VS 2022). \`VerifyV021.exe\` and \`VerifyV021-test.exe\` both built; test runner passed. v0.2.2 just ships the fixes via the release workflow so users do not need to manually patch the installed SDK.

## Test plan
- [x] Version bumped in CMakeLists.txt
- [x] CHANGELOG entry added
- [ ] CI green on all 5 platforms
- [ ] After merge: tag v0.2.2, release-cli.yml publishes artifacts
- [ ] Verify v0.2.2 Windows SDK end-to-end (download fresh, scaffold, configure, build, test)