### PR TITLE
Add Shipyard adoption: pinned binary + project config + CI skill update

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -12,6 +12,43 @@ requires:
 
 Validate branches and ship code safely. This skill handles all CI workflows for Pulp across local machines and VMs.
 
+## Tool selection: Shipyard (preferred) or local_ci.py (fallback)
+
+Pulp is migrating from `tools/local-ci/local_ci.py` to **Shipyard** — a
+reusable CI controller pinned in `tools/shipyard.toml`. Both tools are
+supported during the transition. Detect which one to use:
+
+```bash
+if command -v shipyard >/dev/null 2>&1; then
+    # Preferred: Shipyard, pinned via tools/shipyard.toml
+    shipyard run     # validate current branch
+    shipyard ship    # PR + validate + merge on green
+else
+    # Fallback: legacy local_ci.py
+    python3 tools/local-ci/local_ci.py run     # validate current branch
+    python3 tools/local-ci/local_ci.py ship    # PR + validate + merge on green
+fi
+```
+
+To install Shipyard locally for the first time:
+
+```bash
+./tools/install-shipyard.sh           # download + verify pinned binary
+./tools/install-shipyard.sh --status  # show installed vs pinned version
+export PATH="$HOME/.pulp/bin:$PATH"   # add ~/.pulp/bin to PATH (one-time)
+```
+
+After install, every Pulp checkout that has `~/.pulp/bin` on PATH gets
+the same pinned Shipyard version automatically. The pin lives in
+`tools/shipyard.toml` and is bumped via PR after each Shipyard release
+that passes Pulp's CI matrix.
+
+The two tools cover the same target matrix (mac local + Linux SSH +
+Windows SSH + Namespace cloud) and accept the same `--base` flag for
+develop branches. Shipyard adds evidence-gated merge that checks
+per-platform proof for the exact merge-candidate SHA, which is stricter
+than `local_ci.py`'s `job.passed` check.
+
 ## Prerequisites Check
 
 Before running any CI command, verify the required tooling AND provider config exists:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Legacy planning paths (now a submodule at planning/)
 /.planning-repo/
 
+# Per-machine Shipyard config (SSH host details, paths, secrets).
+# The committed template lives at .shipyard.local/config.toml.example.
+/.shipyard.local/config.toml
+
 # Build artifacts
 /build/
 /build-*/

--- a/.shipyard.local/config.toml.example
+++ b/.shipyard.local/config.toml.example
@@ -1,0 +1,27 @@
+# Per-machine Shipyard overrides for Pulp.
+#
+# This file is gitignored — it contains SSH host details, paths, and
+# anything else that varies between checkouts. Copy this to
+# .shipyard.local/config.toml on each machine and edit to match your
+# local SSH config.
+#
+# Shipyard merges this file on top of .shipyard/config.toml, so you
+# only need to declare the fields that differ from the project
+# defaults.
+
+[targets.ubuntu]
+host          = "ubuntu"            # ssh host alias
+repo_path     = "/home/<you>/pulp"  # absolute path on the remote
+fallback_host = "ubuntu2"           # optional, used when ubuntu is down
+
+[targets.windows]
+host          = "win"
+repo_path     = "C:\\Users\\<you>\\pulp"
+cmake_generator = "Visual Studio 17 2022"
+cmake_platform  = "x64"
+
+# Optional: per-host Namespace selectors if you want to override
+# Pulp's defaults from the workflow file.
+[cloud.namespace]
+linux_runner_selector_json   = '["nscloud-ubuntu-22.04-amd64-8x16"]'
+windows_runner_selector_json = '["nscloud-windows-amd64-8x32"]'

--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -1,0 +1,81 @@
+# Shipyard configuration for Pulp.
+#
+# This file declares Pulp's CI targets, validation pipeline, and merge
+# requirements in a form that Shipyard understands. Per-machine secrets
+# (SSH host details, runner credentials) live in .shipyard.local/
+# (gitignored) — see .shipyard.local/config.toml.example for the
+# template, and run `shipyard doctor` to verify everything is wired up.
+#
+# To use this config:
+#   ./tools/install-shipyard.sh   # install pinned Shipyard binary
+#   shipyard doctor               # verify reachability + config sanity
+#   shipyard run                  # validate the current branch
+#   shipyard ship                 # PR + validate + merge on green
+
+[project]
+name      = "pulp"
+type      = "cmake"
+platforms = ["macos", "linux", "windows"]
+
+# ── Validation pipeline ────────────────────────────────────────────────────
+# Each stage maps to a step in tools/validate-build.sh. Shipyard runs
+# them in order; stage failure short-circuits the pipeline.
+
+[validation.default]
+stages = ["setup", "configure", "build", "test"]
+setup     = "./setup.sh --ci --deps-only"
+configure = "cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug"
+build     = "cmake --build build -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+test      = "ctest --test-dir build --output-on-failure --exclude-regex AudioWorkgroup"
+
+[validation.smoke]
+# Lighter validation for develop-branch ships and quick sanity checks.
+# Builds without tests + GPU + examples; includes a downstream SDK
+# install + scaffold smoke pipeline.
+stages = ["setup", "configure", "build", "install", "smoke"]
+setup     = "./setup.sh --ci --deps-only"
+configure = "cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_BUILD_TESTS=OFF -DPULP_BUILD_EXAMPLES=OFF"
+build     = "cmake --build build"
+install   = "cmake --install build --prefix install"
+smoke     = "cmake -S tools/validation/sdk-smoke -B smoke/build -DCMAKE_PREFIX_PATH=$(pwd)/install && cmake --build smoke/build"
+
+# ── Targets ────────────────────────────────────────────────────────────────
+# Three platforms today: mac (local), ubuntu (SSH), windows (SSH).
+# Per-host details live in .shipyard.local/config.toml.
+
+[targets.mac]
+backend  = "local"
+platform = "macos-arm64"
+
+[targets.ubuntu]
+backend  = "ssh"
+platform = "linux-x64"
+# host and repo_path go in .shipyard.local/config.toml
+
+[targets.windows]
+backend  = "ssh-windows"
+platform = "windows-x64"
+# host, repo_path, cmake settings go in .shipyard.local/config.toml
+
+# ── Cloud dispatch (Namespace) ─────────────────────────────────────────────
+# Used when shipyard cloud run is invoked, and as the failover target
+# when an SSH host is unreachable in preflight.
+
+[cloud]
+provider   = "namespace"
+workflow   = "build"
+repository = "danielraffel/pulp"
+
+# ── Merge gating ───────────────────────────────────────────────────────────
+# Shipyard's can_merge() requires evidence (passing validation) for
+# every required platform on the exact merge-candidate SHA before
+# `shipyard ship` will merge. This is stricter than local_ci.py's
+# job.passed check, which only required the most recent run to pass.
+
+[merge]
+require_platforms = ["macos", "linux", "windows"]
+
+# ── Ship defaults ──────────────────────────────────────────────────────────
+
+[ship]
+base_branch = "main"

--- a/tools/install-shipyard.sh
+++ b/tools/install-shipyard.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# install-shipyard.sh — download and verify the pinned Shipyard release
+# declared in tools/shipyard.toml.
+#
+# Installs to ~/.pulp/shipyard/<version>/shipyard and symlinks
+# ~/.pulp/bin/shipyard → that file. Add ~/.pulp/bin to PATH once and
+# every Pulp checkout uses the pinned version automatically.
+#
+# Usage:
+#   ./tools/install-shipyard.sh           # install pinned version
+#   ./tools/install-shipyard.sh --status  # show installed vs pinned
+#   ./tools/install-shipyard.sh --force   # reinstall even if present
+#
+# Exit codes:
+#   0   success (or already installed and matching pin)
+#   1   user error (bad flag, missing tools)
+#   2   download / verification failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PULP_ROOT="$(dirname "$SCRIPT_DIR")"
+PIN_FILE="$SCRIPT_DIR/shipyard.toml"
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+
+MODE=install
+for arg in "$@"; do
+    case "$arg" in
+        --status)
+            MODE=status
+            ;;
+        --force)
+            MODE=force
+            ;;
+        -h|--help)
+            sed -n '2,18p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown argument '$arg'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Read the pinned version from tools/shipyard.toml ────────────────────────
+# Tiny TOML reader: extract `key = "value"` pairs from the [shipyard]
+# section without depending on a Python TOML library. Falls back to
+# python3 if grep+sed cannot do it.
+
+if ! [ -f "$PIN_FILE" ]; then
+    echo "Error: pin file not found at $PIN_FILE" >&2
+    exit 1
+fi
+
+read_toml_value() {
+    local key="$1"
+    sed -n "/^\\[shipyard\\]/,/^\\[/p" "$PIN_FILE" \
+        | sed -n "s/^${key}[[:space:]]*=[[:space:]]*\"\\(.*\\)\"$/\\1/p" \
+        | head -1
+}
+
+read_toml_asset() {
+    local platform="$1"
+    sed -n "/^\\[shipyard.assets\\]/,/^\\[/p" "$PIN_FILE" \
+        | sed -n "s/^${platform}[[:space:]]*=[[:space:]]*\"\\(.*\\)\"$/\\1/p" \
+        | head -1
+}
+
+VERSION="$(read_toml_value version)"
+REPO="$(read_toml_value repo)"
+CHECKSUMS_ASSET="$(read_toml_value checksums_asset)"
+
+if [ -z "$VERSION" ] || [ -z "$REPO" ] || [ -z "$CHECKSUMS_ASSET" ]; then
+    echo "Error: could not parse $PIN_FILE — missing version/repo/checksums_asset" >&2
+    exit 1
+fi
+
+# ── Detect host platform ────────────────────────────────────────────────────
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "$OS" in
+    Darwin)
+        case "$ARCH" in
+            arm64|aarch64) PLATFORM=darwin-arm64 ;;
+            x86_64)        PLATFORM=darwin-x64 ;;
+            *) echo "Error: unsupported macOS arch $ARCH" >&2; exit 1 ;;
+        esac
+        ;;
+    Linux)
+        case "$ARCH" in
+            aarch64|arm64) PLATFORM=linux-arm64 ;;
+            x86_64)        PLATFORM=linux-x64 ;;
+            *) echo "Error: unsupported Linux arch $ARCH" >&2; exit 1 ;;
+        esac
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        PLATFORM=windows-x64
+        ;;
+    *)
+        echo "Error: unsupported OS $OS" >&2
+        exit 1
+        ;;
+esac
+
+ASSET_NAME="$(read_toml_asset "$PLATFORM")"
+if [ -z "$ASSET_NAME" ]; then
+    echo "Error: no asset declared in tools/shipyard.toml for platform $PLATFORM" >&2
+    exit 1
+fi
+
+# ── Paths ───────────────────────────────────────────────────────────────────
+
+PULP_HOME="${PULP_HOME:-$HOME/.pulp}"
+SHIPYARD_DIR="$PULP_HOME/shipyard/$VERSION"
+SHIPYARD_BIN_DIR="$PULP_HOME/bin"
+INSTALL_BINARY_NAME="shipyard"
+case "$PLATFORM" in
+    windows-*) INSTALL_BINARY_NAME="shipyard.exe" ;;
+esac
+INSTALLED="$SHIPYARD_DIR/$INSTALL_BINARY_NAME"
+SYMLINK="$SHIPYARD_BIN_DIR/$INSTALL_BINARY_NAME"
+
+# ── Status mode: report and exit ────────────────────────────────────────────
+
+if [ "$MODE" = "status" ]; then
+    echo "Pinned (tools/shipyard.toml): $VERSION ($ASSET_NAME)"
+    if [ -x "$INSTALLED" ]; then
+        echo "Installed:                    $VERSION at $INSTALLED"
+    else
+        echo "Installed:                    (not installed — run ./tools/install-shipyard.sh)"
+    fi
+    if command -v shipyard >/dev/null 2>&1; then
+        echo "shipyard on PATH:             $(command -v shipyard)"
+        if shipyard --version 2>/dev/null; then :; fi
+    else
+        echo "shipyard on PATH:             (not on PATH — add $SHIPYARD_BIN_DIR to PATH)"
+    fi
+    exit 0
+fi
+
+# ── Skip if already installed and we're not forcing ─────────────────────────
+
+if [ "$MODE" = "install" ] && [ -x "$INSTALLED" ] && [ -L "$SYMLINK" ]; then
+    if [ "$(readlink "$SYMLINK")" = "$INSTALLED" ]; then
+        echo "Shipyard $VERSION already installed at $INSTALLED"
+        echo "Run with --force to reinstall."
+        exit 0
+    fi
+fi
+
+# ── Download + verify + install ─────────────────────────────────────────────
+
+mkdir -p "$SHIPYARD_DIR" "$SHIPYARD_BIN_DIR"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+
+echo "→ Downloading $ASSET_NAME from $BASE_URL/"
+curl -fsSL --retry 3 -o "$TMPDIR/$ASSET_NAME" "$BASE_URL/$ASSET_NAME"
+
+echo "→ Downloading $CHECKSUMS_ASSET"
+curl -fsSL --retry 3 -o "$TMPDIR/$CHECKSUMS_ASSET" "$BASE_URL/$CHECKSUMS_ASSET"
+
+echo "→ Verifying SHA-256"
+EXPECTED="$(grep -E "[[:space:]]\\*?${ASSET_NAME}\$" "$TMPDIR/$CHECKSUMS_ASSET" | awk '{print $1}' | head -1)"
+if [ -z "$EXPECTED" ]; then
+    echo "Error: $ASSET_NAME not listed in $CHECKSUMS_ASSET" >&2
+    exit 2
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL="$(sha256sum "$TMPDIR/$ASSET_NAME" | awk '{print $1}')"
+else
+    ACTUAL="$(shasum -a 256 "$TMPDIR/$ASSET_NAME" | awk '{print $1}')"
+fi
+
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "Error: SHA-256 mismatch for $ASSET_NAME" >&2
+    echo "  expected: $EXPECTED" >&2
+    echo "  actual:   $ACTUAL" >&2
+    exit 2
+fi
+
+echo "→ Installing to $INSTALLED"
+mv "$TMPDIR/$ASSET_NAME" "$INSTALLED"
+chmod +x "$INSTALLED"
+
+ln -sf "$INSTALLED" "$SYMLINK"
+echo "→ Symlinked $SYMLINK → $INSTALLED"
+
+# ── Final report ────────────────────────────────────────────────────────────
+
+echo ""
+echo "✓ Shipyard $VERSION installed."
+echo ""
+case ":$PATH:" in
+    *":$SHIPYARD_BIN_DIR:"*)
+        echo "$SHIPYARD_BIN_DIR is already on PATH — you can run \`shipyard\` now."
+        ;;
+    *)
+        echo "Add $SHIPYARD_BIN_DIR to your PATH to use \`shipyard\` from anywhere:"
+        echo ""
+        echo "    export PATH=\"$SHIPYARD_BIN_DIR:\$PATH\""
+        ;;
+esac

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -1,0 +1,41 @@
+# Pulp's pinned Shipyard release.
+#
+# Shipyard is the cross-platform CI controller Pulp uses for queue,
+# multi-platform validation, and merge gating. Pulp pins a specific
+# Shipyard release here so every checkout uses the same version.
+#
+# To install or upgrade:
+#   ./tools/install-shipyard.sh
+#
+# To check what's installed vs what's pinned:
+#   ./tools/install-shipyard.sh --status
+#
+# To bump the pin (after verifying a new Shipyard release works on
+# Pulp's CI matrix):
+#   1. Edit `version` below.
+#   2. Run `./tools/install-shipyard.sh` to download the new binary.
+#   3. Run `shipyard run` on a feature branch to verify.
+#   4. Open a PR with this file change and your verification notes.
+
+[shipyard]
+# Pinned to the first Shipyard release that bundles Phases 1-4
+# (multi-backend dispatch + preflight + cloud CLI + progress) and the
+# PyInstaller entrypoint fix. v0.1.1 was a no-op stub on macOS — do
+# not pin to anything older than v0.1.2.
+version = "v0.1.2"
+
+# Public release source. The bootstrap script downloads from
+# https://github.com/{repo}/releases/download/{version}/{asset}
+repo = "danielraffel/Shipyard"
+
+# SHA-256 verification asset name (downloaded alongside the binary).
+checksums_asset = "checksums.sha256"
+
+# Per-platform binary asset names. The bootstrap script picks the
+# right one for the current host.
+[shipyard.assets]
+darwin-arm64  = "shipyard-macos-arm64"
+darwin-x64    = "shipyard-macos-x64"
+linux-arm64   = "shipyard-linux-arm64"
+linux-x64     = "shipyard-linux-x64"
+windows-x64   = "shipyard-windows-x64.exe"


### PR DESCRIPTION
## Summary
Brings [Shipyard](https://github.com/danielraffel/Shipyard) into Pulp as a **pinned, opt-in CI tool**. Both Shipyard and \`local_ci.py\` coexist during the transition; the CI skill detects which one is on PATH and prefers Shipyard.

This PR delivers Parts 9-10 of \`planning/develop-branch-and-shipyard-migration.md\` — the "pinned drop-in adoption" path the user asked for.

## Files added

| File | Purpose |
|------|---------|
| \`tools/shipyard.toml\` | Pinned Shipyard release (\`v0.1.2\`). One-line bump on each upgrade. Same shape as \`tools/deps/manifest.json\`. |
| \`tools/install-shipyard.sh\` | Bootstrap script: reads pin, picks the right binary for the host platform, downloads from the GitHub release, verifies SHA-256, installs to \`~/.pulp/shipyard/<version>/\` with a symlink at \`~/.pulp/bin/shipyard\`. Idempotent. |
| \`.shipyard/config.toml\` | Pulp project config: 3 targets (mac local + ubuntu SSH + windows SSH), validate-build.sh stages, merge-gating, Namespace cloud failover. |
| \`.shipyard.local/config.toml.example\` | Template for the gitignored per-machine config (SSH host details). |
| \`.gitignore\` | Excludes \`.shipyard.local/config.toml\`. |
| \`.agents/skills/ci/SKILL.md\` | New top-of-skill block: \`if command -v shipyard; then shipyard run/ship; else python3 tools/local-ci/local_ci.py run/ship; fi\`. |

## Verification
End-to-end on this checkout (macOS arm64):

\`\`\`
$ ./tools/install-shipyard.sh
→ Downloading shipyard-macos-arm64
→ Verifying SHA-256
→ Installing to ~/.pulp/shipyard/v0.1.2/shipyard
✓ Shipyard v0.1.2 installed.

$ ~/.pulp/bin/shipyard --help
Usage: shipyard [OPTIONS] COMMAND [ARGS]...
  Shipyard — cross-platform CI coordination.
Commands: bump, cancel, cleanup, cloud, doctor, evidence, init, logs, queue, run, ship, status

$ shipyard doctor
Core:
  ✓ git    git version 2.51.0
  ✓ ssh    OpenSSH_10.2p1, LibreSSL 3.3.6
Cloud providers:
  ✓ gh     gh version 2.71.0
  ✓ nsc    version v0.0.493
Overall: ready
\`\`\`

## Backstory
Pulp's pinned version is **v0.1.2**, not v0.1.1. The v0.1.1 published binary was a no-op stub on macOS — the PyInstaller build was missing the \`main()\` entrypoint, so \`shipyard --version\` produced no output. The fix landed in danielraffel/Shipyard#1 and was tagged as v0.1.2 today. Do not pin to anything older than v0.1.2.

## What this PR does NOT do
- **Does not remove \`local_ci.py\`**. It stays as the recommended path until Shipyard Phase 5 (capability parity) ships and Pulp dogfoods it for one release cycle.
- **Does not switch the CI skill defaults**. The skill detects Shipyard on PATH and prefers it, but the fallback path still works for agents trained on \`local_ci.py\`.
- **Does not add Phase 5 behaviors** (configurable contract markers, prepared-state reuse, Windows host mutex, SSH→cloud failover). Those are upstream Shipyard work tracked in the migration plan.

## Test plan
- [x] Bootstrap script downloads + verifies + installs the pinned binary
- [x] \`shipyard --help\` lists all expected commands
- [x] \`shipyard doctor\` runs against the Pulp checkout and reports ready
- [ ] CI green on all 3 platforms (this PR doesn't touch CI infrastructure)
- [ ] Follow-up: dogfood \`shipyard ship\` against a real branch (\`develop/shipyard-migration\`)

See \`planning/develop-branch-and-shipyard-migration.md\` for the full migration plan (Parts 9-10).