### PR TITLE
Document contributor expectations + security baseline + Shipyard migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,10 @@ If you're interested in the rationale behind these rules, see [Astral's open-sou
 
 1. Fork the repo (or create a feature branch if you have write access).
 2. Make your changes on a branch named `feature/short-description` or `fix/short-description`.
-3. Run CI locally before opening the PR: `shipyard ship` (preferred, when shipyard is on PATH) or `python3 tools/local-ci/local_ci.py ship` (fallback).
-4. Open the PR. CI will run automatically on macOS, Linux, and Windows.
-5. The maintainer will merge the PR after CI passes. If anything is unclear, leave a comment.
+3. **Pre-PR validation** (optional but recommended): `shipyard run` (preferred, when shipyard is on PATH) or `python3 tools/local-ci/local_ci.py run` (fallback). This validates on macOS + Linux + Windows without creating a PR.
+4. Open the PR with `git push` + `gh pr create`, or use `shipyard ship` / `python3 tools/local-ci/local_ci.py ship` to push, open the PR, validate, and merge on green automatically.
+5. CI will run automatically on macOS, Linux, and Windows.
+6. The maintainer will merge the PR after CI passes. If anything is unclear, leave a comment.
 
 ## Developer Certificate of Origin
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,28 @@
 
 We welcome contributions. Here's how to get started.
 
+## Contributor expectations
+
+Pulp is currently a **single-maintainer project**. Contributors should expect:
+
+- **Every PR runs CI on macOS, Linux, and Windows.** Your PR cannot merge until all three platform builds + tests are green. CI runs automatically on every PR via GitHub Actions; the maintainer also runs local CI on dedicated VMs.
+- **`main` is protected.** No force pushes, no deletions, no direct commits — every change goes through a PR.
+- **Reviews are not required (yet).** Solo project — the maintainer cannot review their own PRs, and there are no other reviewers. As Pulp grows, this expectation will change. Watch the README for updates.
+- **Release tags are immutable.** Once a `v*` tag is published, it cannot be force-pushed, deleted, or updated. This guarantees the cryptographic identity of every published artifact.
+- **The maintainer signs releases.** macOS plugin bundles use Developer ID code signing; release artifacts will gain Sigstore attestations in a future release for cryptographic provenance.
+
+Pulp's CI controller is migrating from `tools/local-ci/local_ci.py` to [Shipyard](https://github.com/danielraffel/Shipyard) — the reusable CI tool extracted from `local_ci.py`. Both tools accept the same workflows during the transition.
+
+If you're interested in the rationale behind these rules, see [Astral's open-source security post](https://astral.sh/blog/open-source-security-at-astral) — Pulp adopts several of the practices documented there.
+
+## How to submit a PR
+
+1. Fork the repo (or create a feature branch if you have write access).
+2. Make your changes on a branch named `feature/short-description` or `fix/short-description`.
+3. Run CI locally before opening the PR: `shipyard ship` (preferred, when shipyard is on PATH) or `python3 tools/local-ci/local_ci.py ship` (fallback).
+4. Open the PR. CI will run automatically on macOS, Linux, and Windows.
+5. The maintainer will merge the PR after CI passes. If anything is unclear, leave a comment.
+
 ## Developer Certificate of Origin
 
 All contributions must be signed off under the [Developer Certificate of Origin](https://developercertificate.org/) (DCO). This certifies that you have the right to submit the code under the project's MIT license.

--- a/README.md
+++ b/README.md
@@ -169,16 +169,26 @@ See [docs/guides/claude-code-plugin.md](docs/guides/claude-code-plugin.md) for s
 
 ## Contributing
 
-Every change goes through: **branch → local CI → PR → GitHub Actions → merge on green**.
+Every change goes through: **branch → CI → PR → merge on green**. Pulp accepts third-party PRs.
 
 ```bash
 # Validate on macOS + Ubuntu + Windows before creating a PR
-python3 tools/local-ci/local_ci.py run <branch>
+shipyard ship                              # preferred (when shipyard is on PATH)
+python3 tools/local-ci/local_ci.py ship    # fallback
 
 # Or use the CI skill: "ship this"
 ```
 
-Local CI runs on your Mac and validates cross-platform via SSH to Ubuntu/Windows VMs. GitHub Actions runs automatically on every PR as a backup gate. See [docs/guides/local-ci.md](docs/guides/local-ci.md) for setup.
+Pulp's CI controller is migrating from `local_ci.py` to [Shipyard](https://github.com/danielraffel/Shipyard). The CI skill detects which one is on PATH and prefers Shipyard; both tools cover the same target matrix (macOS local + Linux SSH + Windows SSH + Namespace cloud). See [docs/guides/local-ci.md](docs/guides/local-ci.md) for setup and [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor expectations.
+
+### Security & CI policy
+
+- Pulp's `main` branch is protected: every change must go through a PR, and a PR cannot merge until macOS, Linux, and Windows builds + tests are all green.
+- Release tags (`v*`) are immutable — once published they cannot be force-pushed, deleted, or updated.
+- The default CI workflow token is read-only; only the release workflow holds write access.
+- Pulp is currently a **single-maintainer project**, so the governance settings are tuned to a "solo profile". Settings will be revisited if/when Pulp gains co-maintainers — see [CONTRIBUTING.md](CONTRIBUTING.md) for the current contract.
+
+These practices follow patterns documented in [Astral's open-source security post](https://astral.sh/blog/open-source-security-at-astral) and are managed (or in the process of being managed) by [Shipyard](https://github.com/danielraffel/Shipyard).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -173,10 +173,14 @@ Every change goes through: **branch → CI → PR → merge on green**. Pulp acc
 
 ```bash
 # Validate on macOS + Ubuntu + Windows before creating a PR
-shipyard ship                              # preferred (when shipyard is on PATH)
-python3 tools/local-ci/local_ci.py ship    # fallback
+shipyard run                               # preferred (when shipyard is on PATH)
+python3 tools/local-ci/local_ci.py run     # fallback
 
-# Or use the CI skill: "ship this"
+# Or use the CI skill: "validate this"
+#
+# When you're ready to open a PR + merge on green automatically:
+shipyard ship                              # creates the PR, waits for CI, merges
+python3 tools/local-ci/local_ci.py ship    # fallback
 ```
 
 Pulp's CI controller is migrating from `local_ci.py` to [Shipyard](https://github.com/danielraffel/Shipyard). The CI skill detects which one is on PATH and prefers Shipyard; both tools cover the same target matrix (macOS local + Linux SSH + Windows SSH + Namespace cloud). See [docs/guides/local-ci.md](docs/guides/local-ci.md) for setup and [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor expectations.
@@ -185,7 +189,7 @@ Pulp's CI controller is migrating from `local_ci.py` to [Shipyard](https://githu
 
 - Pulp's `main` branch is protected: every change must go through a PR, and a PR cannot merge until macOS, Linux, and Windows builds + tests are all green.
 - Release tags (`v*`) are immutable — once published they cannot be force-pushed, deleted, or updated.
-- The default CI workflow token is read-only; only the release workflow holds write access.
+- The repository default for the CI workflow token is read-only. Workflows that need write access (the release workflow's `contents: write`, `auto-label-issues.yml`'s `issues: write`, `freshness-check.yml`'s `issues: write`, and `docs-deploy.yml`'s `pages: write` + `id-token: write`) declare those scopes explicitly per job rather than inheriting a broad default.
 - Pulp is currently a **single-maintainer project**, so the governance settings are tuned to a "solo profile". Settings will be revisited if/when Pulp gains co-maintainers — see [CONTRIBUTING.md](CONTRIBUTING.md) for the current contract.
 
 These practices follow patterns documented in [Astral's open-source security post](https://astral.sh/blog/open-source-security-at-astral) and are managed (or in the process of being managed) by [Shipyard](https://github.com/danielraffel/Shipyard).

--- a/docs/reference/licensing.md
+++ b/docs/reference/licensing.md
@@ -78,6 +78,7 @@ Pulp implements or builds on these open standards:
 
 | Project | License | What We Learned |
 |---------|---------|-----------------|
+| [Astral (uv, Ruff, ty)](https://astral.sh/) | Apache-2.0 / MIT | CI/CD security baseline, supply chain hardening, and release process discipline. We adopted several patterns from [their open-source security post](https://astral.sh/blog/open-source-security-at-astral) — immutable releases, tag protection, action SHA pinning, default read-only workflow tokens. |
 | [AudioKit](https://github.com/AudioKit/AudioKit) | MIT | Swift audio patterns, Apple platform integration |
 | [iPlug2](https://github.com/iPlug2/iPlug2) | zlib-like | Multi-format adapter architecture, graphics abstraction |
 | [SignalKit](https://github.com/niclamusic/signalkit) | MIT | Real-time DSP patterns in Swift |

--- a/docs/reference/licensing.md
+++ b/docs/reference/licensing.md
@@ -78,7 +78,7 @@ Pulp implements or builds on these open standards:
 
 | Project | License | What We Learned |
 |---------|---------|-----------------|
-| [Astral (uv, Ruff, ty)](https://astral.sh/) | Apache-2.0 / MIT | CI/CD security baseline, supply chain hardening, and release process discipline. We adopted several patterns from [their open-source security post](https://astral.sh/blog/open-source-security-at-astral) — immutable releases, tag protection, action SHA pinning, default read-only workflow tokens. |
+| [Astral (uv, Ruff, ty)](https://astral.sh/) | Apache-2.0 / MIT | CI/CD security baseline, supply chain hardening, and release process discipline. Pulp adopts several practices from [their open-source security post](https://astral.sh/blog/open-source-security-at-astral). **Already in place:** branch protection on `main`, tag protection on `v*`, default read-only workflow tokens, immutable release identity via tag protection. **In progress / planned:** action SHA pinning via Renovate, immutable release artifacts (UI checkbox), Sigstore release attestations, `zizmor` workflow lint in CI. Tracked in the private `pulp-planning` submodule. |
 | [AudioKit](https://github.com/AudioKit/AudioKit) | MIT | Swift audio patterns, Apple platform integration |
 | [iPlug2](https://github.com/iPlug2/iPlug2) | zlib-like | Multi-format adapter architecture, graphics abstraction |
 | [SignalKit](https://github.com/niclamusic/signalkit) | MIT | Real-time DSP patterns in Swift |

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -16,6 +16,18 @@
 #   2. Run `./tools/install-shipyard.sh` to download the new binary.
 #   3. Run `shipyard run` on a feature branch to verify.
 #   4. Open a PR with this file change and your verification notes.
+#
+# Lockstep docs:
+# When bumping the pin, also re-check that the following docs still
+# accurately describe what Shipyard provides at the new version:
+#   - README.md (Contributing + Security & CI policy section)
+#   - CONTRIBUTING.md (Contributor expectations section)
+#   - .agents/skills/ci/SKILL.md (tool-selection logic)
+#   - docs/guides/local-ci.md (cross-references between local_ci.py
+#     and shipyard, eventual removal once local_ci.py is retired)
+# If a Shipyard release introduces a new command, deprecates one, or
+# changes governance defaults, update those docs in the same PR that
+# bumps this pin.
 
 [shipyard]
 # Pinned to the first Shipyard release that bundles Phases 1-4


### PR DESCRIPTION
## Summary
Documents what's currently true about Pulp's CI/security baseline and the Shipyard migration in flight, so contributors and downstream users have a clear public reference.

## What changes

| File | Change |
|------|--------|
| **README.md** | New "Security & CI policy" subsection + updated Contributing block. Documents the four GitHub-side enforcement settings (branch protection, immutable v* tags, default read-only workflow tokens, solo profile) and links to Astral's security post for rationale. |
| **CONTRIBUTING.md** | New "Contributor expectations" section explicitly stating what a PR contributor should expect (CI on 3 platforms, no required reviews while solo, immutable release tags, Shipyard migration). Also adds a "How to submit a PR" walkthrough. |
| **docs/reference/licensing.md** | Adds Astral to "Projects That Inspired Pulp" with a brief line on which security practices Pulp adopted. |
| **tools/shipyard.toml** | New "Lockstep docs" comment listing the docs to re-check when bumping the Shipyard pin — guards against doc drift. |

## What this PR does NOT do
- **Does not document the Shipyard governance profile system.** That feature isn't shipped yet (Shipyard Phase 5/6 work). Once Shipyard v0.1.4 ships profiles, a follow-up PR will add the public-facing "Pulp uses solo profile" line and link to Shipyard's profile docs.
- **Does not commit the Astral-inspired security items that aren't yet applied** (Sigstore attestations, immutable releases checkbox, sensitive-branch ruleset, action SHA pinning). Those are tracked in \`security-hardening-stack-rank.md\` in the private planning submodule and will be added to the public docs when each item lands.

## Lockstep doc tracking
\`tools/shipyard.toml\` now lists the four docs that need to be re-verified when the Shipyard pin is bumped:
- README.md
- CONTRIBUTING.md
- .agents/skills/ci/SKILL.md
- docs/guides/local-ci.md

This is a manual checklist (not automated yet) but flags the dependency so future pin-bump PRs cannot quietly drift.

## Test plan
- [x] No code changes — pure docs
- [x] Markdown rendered preview reads correctly
- [ ] CI green (build/test/license-audit pass on docs-only changes)