### PR TITLE
Bump Shipyard pin to v0.1.3 (Phase 5 capability parity)

### DIFF
--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -30,11 +30,17 @@
 # bumps this pin.
 
 [shipyard]
-# Pinned to the first Shipyard release that bundles Phases 1-4
-# (multi-backend dispatch + preflight + cloud CLI + progress) and the
-# PyInstaller entrypoint fix. v0.1.1 was a no-op stub on macOS — do
-# not pin to anything older than v0.1.2.
-version = "v0.1.2"
+# Pinned to the first Shipyard release that bundles Phase 5's
+# capability-parity features with Pulp's local_ci.py:
+#   - validation contract markers (__PULP_VALIDATION__:smoke|full)
+#   - prepared-state reuse keyed by (sha, target, mode)
+#   - Windows host mutex + Visual Studio auto-detection
+#   - SSH→cloud auto-failover via [failover.cloud_auto]
+#
+# v0.1.1 was a no-op stub on macOS — do not pin to anything older
+# than v0.1.2. v0.1.3 is the first release Pulp actually depends on
+# for feature parity.
+version = "v0.1.3"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
## Summary

Bumps \`tools/shipyard.toml\` from v0.1.2 → v0.1.3. v0.1.3 is the first Shipyard release that matches \`local_ci.py\` on the four capability-parity items Pulp depends on:

- **Validation contract markers** — enforce \`__PULP_VALIDATION__:smoke\` / \`:full\` via \`[validation.contract]\`
- **Prepared-state reuse** — per-stage \`(sha, target, mode)\` cache with \`config_hash\` invalidation
- **Windows host mutex + VS auto-detection** — concurrent-run serialization + \`vswhere.exe\` probe for \`\$env:SHIPYARD_CMAKE_PLATFORM\` and \`\$env:SHIPYARD_CMAKE_GENERATOR_INSTANCE\`
- **SSH→cloud auto-failover** — implicit cloud fallback via \`[failover.cloud_auto]\`

Shipyard release: [danielraffel/Shipyard v0.1.3](https://github.com/danielraffel/Shipyard/releases/tag/v0.1.3). PRs in that release: danielraffel/Shipyard#3 danielraffel/Shipyard#4 danielraffel/Shipyard#5 danielraffel/Shipyard#6 danielraffel/Shipyard#7. Full suite passing across macOS, Linux, Windows on every PR.

## Test plan

- [x] \`./tools/install-shipyard.sh\` — verified SHA-256 and installed v0.1.3
- [x] \`shipyard --version\` reports 0.1.3
- [x] \`shipyard --help\` lists all commands (queue, run, ship, cloud, doctor, evidence, init, etc.)
- [x] Pulp's existing \`.shipyard/config.toml\` is forwards-compatible (new \`[validation.contract]\`, \`[validation.prepared_state]\`, \`[failover.cloud_auto]\` sections are opt-in)
- [ ] Full Pulp CI matrix on this PR (macOS + Linux + Windows build + tests)
- [ ] Follow-up (not in this PR): opt into the new config sections on a Pulp \`develop/shipyard-migration\` branch and dogfood them