### PR TITLE
Adopt Shipyard v0.1.4 governance profiles (solo) + bump pin

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -12,22 +12,43 @@ requires:
 
 Validate branches and ship code safely. This skill handles all CI workflows for Pulp across local machines and VMs.
 
-## Tool selection: Shipyard (preferred) or local_ci.py (fallback)
+## Tool selection: `local_ci.py` for validation, Shipyard for governance
 
-Pulp is migrating from `tools/local-ci/local_ci.py` to **Shipyard** — a
-reusable CI controller pinned in `tools/shipyard.toml`. Both tools are
-supported during the transition. Detect which one to use:
+Pulp is migrating from `tools/local-ci/local_ci.py` to
+[Shipyard](https://github.com/danielraffel/Shipyard) — the
+reusable CI controller extracted from `local_ci.py`. The
+migration is **partial today**:
+
+| Concern | Today's primary tool |
+|---------|---------------------|
+| Pre-PR validation (`run`) | `local_ci.py` — still the battle-tested path |
+| PR ship-through-CI (`ship`) | `local_ci.py` — still the battle-tested path |
+| Cloud dispatch to Namespace | `local_ci.py cloud run` |
+| Branch protection + governance state | **Shipyard** (`.shipyard/config.toml` + `shipyard governance apply`) |
+| Governance drift detection | **Shipyard** (`shipyard doctor` + `shipyard governance status`) |
+| Disaster recovery / snapshot | **Shipyard** (`governance export` + `apply --from`) |
+
+**For validation (`run` / `ship`), use `local_ci.py`** until the
+Part 13 validation stages confirm `shipyard run` + `shipyard ship`
+match on Pulp's target matrix. Then the CI skill flips the
+preference; the switchover is tracked by a task in the planning
+repo.
+
+**For governance, always use Shipyard.** Never edit branch
+protection through the GitHub UI directly — the source of truth
+is `.shipyard/config.toml`, and UI changes will show as drift in
+`shipyard governance status` and be overwritten on the next
+`apply`.
 
 ```bash
-if command -v shipyard >/dev/null 2>&1; then
-    # Preferred: Shipyard, pinned via tools/shipyard.toml
-    shipyard run     # validate current branch
-    shipyard ship    # PR + validate + merge on green
-else
-    # Fallback: legacy local_ci.py
-    python3 tools/local-ci/local_ci.py run     # validate current branch
-    python3 tools/local-ci/local_ci.py ship    # PR + validate + merge on green
-fi
+# Validation (pre-PR and ship flow)
+python3 tools/local-ci/local_ci.py run     # validate current branch
+python3 tools/local-ci/local_ci.py ship    # PR + validate + merge on green
+
+# Governance (any time the declared config changes or doctor flags drift)
+shipyard governance status       # declared vs live drift
+shipyard governance apply        # idempotent fix
+shipyard doctor                  # core + governance health in one call
 ```
 
 To install Shipyard locally for the first time:
@@ -42,12 +63,6 @@ After install, every Pulp checkout that has `~/.pulp/bin` on PATH gets
 the same pinned Shipyard version automatically. The pin lives in
 `tools/shipyard.toml` and is bumped via PR after each Shipyard release
 that passes Pulp's CI matrix.
-
-The two tools cover the same target matrix (mac local + Linux SSH +
-Windows SSH + Namespace cloud) and accept the same `--base` flag for
-develop branches. Shipyard adds evidence-gated merge that checks
-per-platform proof for the exact merge-candidate SHA, which is stricter
-than `local_ci.py`'s `job.passed` check.
 
 ## Prerequisites Check
 

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -373,6 +373,26 @@ Key fields:
 
 Keep hostnames and VM names local. Shared repo docs and skills should describe how to choose a target, not which personal alias to use.
 
+## Cross-platform SSH gotchas (hard-won)
+
+### Windows SSH → PowerShell transport
+
+**Always send multi-line PowerShell scripts via `-EncodedCommand` (base64 UTF-16LE).** The two "obvious" alternatives are both silently broken on Windows and produce false-greens (rc=0 with empty stdout):
+
+1. **Inline argv** (`powershell -Command "<script>"`): Windows OpenSSH flattens remote argv to a single command string via cmd.exe, which interprets newlines as command separators. Only the first line of the script ever runs. A multi-line mutex wrapper executes `$ErrorActionPreference = 'Stop'`, produces no output, exits 0 → reported as "pass" in 0.9 seconds with an empty log.
+
+2. **Stdin transport** (`powershell -Command -` + script on stdin): PowerShell reads stdin one line at a time and treats each line as a separate command pipeline. Multi-line constructs (`try { ... } catch`, function definitions, `& { ... }` script blocks) parse as incomplete commands and produce zero stdout. Also rc=0. Looks plausible because it matches the pattern in some older code, but that older code was itself silently broken and returning None.
+
+3. **EncodedCommand** (`powershell -EncodedCommand <base64>`): the payload is a single opaque argv token that neither cmd.exe nor PowerShell's line-based stdin parser can mangle. This is what Shipyard v0.1.13+ uses everywhere.
+
+### Windows host platform detection
+
+The default `ssh win` host in Pulp's setup is **ARM64 Windows**, not x64. If `detect_vs_toolchain` returns None (or falls back to defaults), CMake builds target x64 and either fail or run through slow emulation. Shipyard v0.1.13 fixed a years-old latent bug where this detection was silently broken and returning None on every run. If another tool in the chain bypasses Shipyard and talks to the Windows host directly, it must either call `detect_vs_toolchain`-equivalent logic or hard-code `-A ARM64` for that host.
+
+### Verify cross-platform CI fixes against the real host
+
+**Unit tests cannot catch transport-layer bugs.** Any fix that touches SSH, PowerShell, subprocess, or remote-exec must be verified end-to-end against a real host before merging — not just "tests pass." Two consecutive fixes for the same root cause shipped with green unit tests and still produced false-greens before the third fix was verified against the win VM. See `planning/shipyard-migration-status.md` live log for the full history.
+
 ## Documentation
 
 Full setup guide: `docs/guides/local-ci.md`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,9 +183,18 @@ jobs:
       matrix: ${{ fromJSON(needs.resolve-provider.outputs.matrix_json) }}
 
     runs-on: ${{ fromJSON(matrix.runs_on_json) }}
-    name: ${{ matrix.name }} [${{ matrix.provider }}]
+    # Job name is stable across providers so branch protection
+    # doesn't need to be re-applied every time the runner provider
+    # changes. The provider is still visible in the first step's
+    # summary annotation below.
+    name: ${{ matrix.name }}
 
     steps:
+      - name: Show runner provider
+        run: |
+          echo "Runner provider for ${{ matrix.name }}: ${{ matrix.provider }}"
+          echo "::notice title=Runner provider::${{ matrix.name }} ran on ${{ matrix.provider }}"
+
       - uses: actions/checkout@v5
         with:
           lfs: true

--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -17,6 +17,30 @@ name      = "pulp"
 type      = "cmake"
 platforms = ["macos", "linux", "windows"]
 
+# Governance profile — determines the defaults for branch protection,
+# review requirements, and other merge gates. Pulp is a single-
+# maintainer project today, so "solo" is the right fit: require PRs
+# and status checks to prevent `git push origin main` accidents, but
+# do NOT require strict status (no rebase tax), reviews (can't
+# review your own PR), or admin enforcement (3 AM hotfix path needs
+# to exist). See Shipyard's docs for the full profile matrix.
+profile   = "solo"
+
+# ── Governance defaults ────────────────────────────────────────────────────
+# Required status check names MUST match the job names GitHub
+# Actions actually produces. Pulp's `.github/workflows/build.yml`
+# names include the runner provider suffix, so the list is:
+#   macOS (ARM64) [github-hosted], Linux (x64) [namespace],
+#   Windows (x64) [namespace]
+# Keep this in sync if the workflow job names ever change.
+
+[governance]
+required_status_checks = [
+    "macOS (ARM64) [github-hosted]",
+    "Linux (x64) [namespace]",
+    "Windows (x64) [namespace]",
+]
+
 # ── Validation pipeline ────────────────────────────────────────────────────
 # Each stage maps to a step in tools/validate-build.sh. Shipyard runs
 # them in order; stage failure short-circuits the pipeline.

--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -29,16 +29,22 @@ profile   = "solo"
 # ── Governance defaults ────────────────────────────────────────────────────
 # Required status check names MUST match the job names GitHub
 # Actions actually produces. Pulp's `.github/workflows/build.yml`
-# names include the runner provider suffix, so the list is:
-#   macOS (ARM64) [github-hosted], Linux (x64) [namespace],
-#   Windows (x64) [namespace]
-# Keep this in sync if the workflow job names ever change.
+# emits provider-neutral job names — no `[github-hosted]` or
+# `[namespace]` suffix — so switching runner providers does not
+# require re-running `shipyard governance apply`. The provider
+# information still surfaces in each job's first step via a
+# `::notice::` annotation, so failures are traceable to the
+# specific runner pool that produced them.
+#
+# If build.yml's job names ever change (e.g. adding a new
+# platform or renaming an existing one), update this list and
+# run `shipyard governance apply` to refresh branch protection.
 
 [governance]
 required_status_checks = [
-    "macOS (ARM64) [github-hosted]",
-    "Linux (x64) [namespace]",
-    "Windows (x64) [namespace]",
+    "macOS (ARM64)",
+    "Linux (x64)",
+    "Windows (x64)",
 ]
 
 # ── Validation pipeline ────────────────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -646,3 +646,39 @@ If it shows `github-hosted`, add this to `~/Library/Application Support/Pulp/loc
 ```
 
 See `docs/guides/local-ci.md` for setup.
+
+#### Branch protection + governance (Shipyard)
+
+The CI **validation path** is still `local_ci.py`, but branch
+protection and governance state are declared in
+`.shipyard/config.toml` and managed by Shipyard. The declared
+shape is `[project].profile = "solo"` — single-maintainer
+defaults: require PRs + required status checks, no rebase tax,
+no required reviews, admins not enforced. The required status
+check names are `macOS (ARM64)`, `Linux (x64)`, `Windows (x64)`
+(provider-neutral — the runner provider is visible in each
+job's first step annotation, not in the job name).
+
+Useful commands (pinned via `tools/shipyard.toml`):
+
+```bash
+shipyard doctor                  # governance + core tools health
+shipyard governance status       # declared vs live drift on main
+shipyard governance apply        # fix drift from the config (idempotent)
+shipyard governance export > snap.toml      # snapshot live state
+shipyard governance apply --from snap.toml  # restore from snapshot
+```
+
+Changing governance rules means editing
+`.shipyard/config.toml`, committing, and running
+`shipyard governance apply`. Never change branch protection
+through the GitHub UI directly — the TOML file is the source of
+truth and UI changes will be reported as drift by
+`governance status` and overwritten on the next `apply`.
+
+`shipyard run` / `shipyard ship` are installed but are **not yet
+the primary CI path**. The full cut-over is blocked on Part 13
+validation stages (see `planning/develop-branch-and-shipyard-migration.md`
+in the private planning submodule). Until then, continue using
+`local_ci.py` for validation and use Shipyard only for
+governance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,16 @@ Pulp is currently a **single-maintainer project**. Contributors should expect:
 - **Release tags are immutable.** Once a `v*` tag is published, it cannot be force-pushed, deleted, or updated. This guarantees the cryptographic identity of every published artifact.
 - **The maintainer signs releases.** macOS plugin bundles use Developer ID code signing; release artifacts will gain Sigstore attestations in a future release for cryptographic provenance.
 
-Pulp's CI controller is migrating from `tools/local-ci/local_ci.py` to [Shipyard](https://github.com/danielraffel/Shipyard) — the reusable CI tool extracted from `local_ci.py`. Both tools accept the same workflows during the transition.
+Pulp uses [Shipyard](https://github.com/danielraffel/Shipyard) —
+the reusable CI controller extracted from Pulp's original
+`tools/local-ci/local_ci.py` — to manage **branch protection,
+tag protection, and governance state declaratively**. The rules
+live in `.shipyard/config.toml` (`[project].profile = "solo"` +
+`[governance].required_status_checks`) and are applied with
+`shipyard governance apply`. Validation of individual PRs still
+runs through `local_ci.py` + GitHub Actions today; the full
+switchover to `shipyard run` / `shipyard ship` as the primary
+validation path is in progress.
 
 If you're interested in the rationale behind these rules, see [Astral's open-source security post](https://astral.sh/blog/open-source-security-at-astral) — Pulp adopts several of the practices documented there.
 
@@ -20,8 +29,8 @@ If you're interested in the rationale behind these rules, see [Astral's open-sou
 
 1. Fork the repo (or create a feature branch if you have write access).
 2. Make your changes on a branch named `feature/short-description` or `fix/short-description`.
-3. **Pre-PR validation** (optional but recommended): `shipyard run` (preferred, when shipyard is on PATH) or `python3 tools/local-ci/local_ci.py run` (fallback). This validates on macOS + Linux + Windows without creating a PR.
-4. Open the PR with `git push` + `gh pr create`, or use `shipyard ship` / `python3 tools/local-ci/local_ci.py ship` to push, open the PR, validate, and merge on green automatically.
+3. **Pre-PR validation** (optional but recommended): `python3 tools/local-ci/local_ci.py run` validates on macOS + Linux + Windows without creating a PR. `shipyard run` is also available but hasn't finished cross-validation against Pulp's VM topology yet.
+4. Open the PR with `git push` + `gh pr create`, or use `python3 tools/local-ci/local_ci.py ship` to push, open the PR, validate, and merge on green automatically.
 5. CI will run automatically on macOS, Linux, and Windows.
 6. The maintainer will merge the PR after CI passes. If anything is unclear, leave a comment.
 

--- a/README.md
+++ b/README.md
@@ -173,17 +173,15 @@ Every change goes through: **branch → CI → PR → merge on green**. Pulp acc
 
 ```bash
 # Validate on macOS + Ubuntu + Windows before creating a PR
-shipyard run                               # preferred (when shipyard is on PATH)
-python3 tools/local-ci/local_ci.py run     # fallback
+python3 tools/local-ci/local_ci.py run     # current primary validation path
 
 # Or use the CI skill: "validate this"
 #
 # When you're ready to open a PR + merge on green automatically:
-shipyard ship                              # creates the PR, waits for CI, merges
-python3 tools/local-ci/local_ci.py ship    # fallback
+python3 tools/local-ci/local_ci.py ship    # creates the PR, waits for CI, merges
 ```
 
-Pulp's CI controller is migrating from `local_ci.py` to [Shipyard](https://github.com/danielraffel/Shipyard). The CI skill detects which one is on PATH and prefers Shipyard; both tools cover the same target matrix (macOS local + Linux SSH + Windows SSH + Namespace cloud). See [docs/guides/local-ci.md](docs/guides/local-ci.md) for setup and [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor expectations.
+Pulp is migrating from `local_ci.py` to [Shipyard](https://github.com/danielraffel/Shipyard) — the reusable CI controller extracted from it. **Governance** (branch protection, tag protection, doctor drift detection, snapshot/restore) has already moved to Shipyard and is declared in [.shipyard/config.toml](.shipyard/config.toml). **Validation** (`run` and `ship`) is still going through `local_ci.py` while Shipyard's validation path is cross-checked against Pulp's VM topology. Both tools accept the same target matrix (macOS local + Linux SSH + Windows SSH + Namespace cloud). See [docs/guides/local-ci.md](docs/guides/local-ci.md) for setup and [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor expectations.
 
 ### Security & CI policy
 

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -2,6 +2,17 @@
 
 Local CI lets you validate branches on your Mac and cross-platform VMs before merging, without spending money on cloud CI minutes.
 
+> **Migration note.** `local_ci.py` is still Pulp's primary validation
+> tool today. Pulp is migrating validation to
+> [Shipyard](https://github.com/danielraffel/Shipyard) — the reusable
+> CI controller extracted from this script. Governance
+> (branch protection, tag protection, `doctor` drift detection) has
+> already moved to Shipyard and is declared in `.shipyard/config.toml`.
+> Validation (`run` / `ship`) stays on `local_ci.py` until the
+> Shipyard validation path is cross-checked against Pulp's VM
+> topology. When that cut-over happens, the CI skill flips its
+> preference and this guide will be updated.
+
 ## Required Merge Process (All Agents)
 
 Every change to `main` must go through this workflow — no exceptions, regardless of which AI agent or human is doing the work:

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -30,8 +30,8 @@
 # bumps this pin.
 
 [shipyard]
-# Pinned to the Shipyard release that bundles Phase 5 capability
-# parity with local_ci.py plus Phase 6 governance (full surface):
+# Pinned to the Shipyard release with the complete Phase 5 +
+# Phase 6 surface:
 #   - validation contract markers (__PULP_VALIDATION__:smoke|full)
 #   - prepared-state reuse keyed by (sha, target, mode)
 #   - Windows host mutex + Visual Studio auto-detection
@@ -39,13 +39,15 @@
 #   - Governance profiles (solo/multi/custom) + status/diff/apply
 #   - governance use <profile> (profile switch)
 #   - governance export + apply --from <snapshot> (disaster recovery)
+#   - branch apply --create (new branch + rules in one command)
+#   - ship --base develop/foo auto-create-base (auto-on for
+#     develop/* and release/* patterns)
 #   - doctor drift integration with honest immutable-releases row
 #
 # v0.1.1 was a no-op stub on macOS — do not pin to anything older
-# than v0.1.2. v0.1.5 is the first Shipyard release that runs
-# Pulp's Part 13 validation Stages 4 and 5 cleanly (drift detection
-# + recreation drill with snapshot restore).
-version = "v0.1.5"
+# than v0.1.2. v0.1.6 is the Phase 6 complete release — nothing in
+# the original Phase 6 follow-up plan remains deferred.
+version = "v0.1.6"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -50,7 +50,7 @@
 # resolves the base SHA from the remote instead of local
 # tracking refs, and ship --json no longer leaks human text from
 # the auto-create-base helper.
-version = "v0.1.11"
+version = "v0.1.12"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -50,7 +50,7 @@
 # resolves the base SHA from the remote instead of local
 # tracking refs, and ship --json no longer leaks human text from
 # the auto-create-base helper.
-version = "v0.1.7"
+version = "v0.1.8"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -50,7 +50,7 @@
 # resolves the base SHA from the remote instead of local
 # tracking refs, and ship --json no longer leaks human text from
 # the auto-create-base helper.
-version = "v0.1.8"
+version = "v0.1.9"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -30,17 +30,19 @@
 # bumps this pin.
 
 [shipyard]
-# Pinned to the first Shipyard release that bundles Phase 5's
-# capability-parity features with Pulp's local_ci.py:
+# Pinned to the first Shipyard release that bundles Phase 6's
+# minimum governance surface on top of Phase 5 capability parity:
 #   - validation contract markers (__PULP_VALIDATION__:smoke|full)
 #   - prepared-state reuse keyed by (sha, target, mode)
 #   - Windows host mutex + Visual Studio auto-detection
 #   - SSH→cloud auto-failover via [failover.cloud_auto]
+#   - Governance profiles (solo/multi/custom) + branch protection
+#     status/apply/diff CLI + doctor drift integration
 #
 # v0.1.1 was a no-op stub on macOS — do not pin to anything older
-# than v0.1.2. v0.1.3 is the first release Pulp actually depends on
-# for feature parity.
-version = "v0.1.3"
+# than v0.1.2. v0.1.3 added Phase 5; v0.1.4 adds Phase 6 minimum,
+# which is the first version with `shipyard governance`.
+version = "v0.1.4"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -45,9 +45,12 @@
 #   - doctor drift integration with honest immutable-releases row
 #
 # v0.1.1 was a no-op stub on macOS — do not pin to anything older
-# than v0.1.2. v0.1.6 is the Phase 6 complete release — nothing in
-# the original Phase 6 follow-up plan remains deferred.
-version = "v0.1.6"
+# than v0.1.2. v0.1.7 adds the first wave of dogfood-driven fixes:
+# all executors accept resume_from + mode kwargs, branch create
+# resolves the base SHA from the remote instead of local
+# tracking refs, and ship --json no longer leaks human text from
+# the auto-create-base helper.
+version = "v0.1.7"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -50,7 +50,7 @@
 # resolves the base SHA from the remote instead of local
 # tracking refs, and ship --json no longer leaks human text from
 # the auto-create-base helper.
-version = "v0.1.9"
+version = "v0.1.10"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -50,7 +50,7 @@
 # resolves the base SHA from the remote instead of local
 # tracking refs, and ship --json no longer leaks human text from
 # the auto-create-base helper.
-version = "v0.1.10"
+version = "v0.1.11"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -50,7 +50,7 @@
 # resolves the base SHA from the remote instead of local
 # tracking refs, and ship --json no longer leaks human text from
 # the auto-create-base helper.
-version = "v0.1.12"
+version = "v0.1.13"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -30,19 +30,22 @@
 # bumps this pin.
 
 [shipyard]
-# Pinned to the first Shipyard release that bundles Phase 6's
-# minimum governance surface on top of Phase 5 capability parity:
+# Pinned to the Shipyard release that bundles Phase 5 capability
+# parity with local_ci.py plus Phase 6 governance (full surface):
 #   - validation contract markers (__PULP_VALIDATION__:smoke|full)
 #   - prepared-state reuse keyed by (sha, target, mode)
 #   - Windows host mutex + Visual Studio auto-detection
 #   - SSH→cloud auto-failover via [failover.cloud_auto]
-#   - Governance profiles (solo/multi/custom) + branch protection
-#     status/apply/diff CLI + doctor drift integration
+#   - Governance profiles (solo/multi/custom) + status/diff/apply
+#   - governance use <profile> (profile switch)
+#   - governance export + apply --from <snapshot> (disaster recovery)
+#   - doctor drift integration with honest immutable-releases row
 #
 # v0.1.1 was a no-op stub on macOS — do not pin to anything older
-# than v0.1.2. v0.1.3 added Phase 5; v0.1.4 adds Phase 6 minimum,
-# which is the first version with `shipyard governance`.
-version = "v0.1.4"
+# than v0.1.2. v0.1.5 is the first Shipyard release that runs
+# Pulp's Part 13 validation Stages 4 and 5 cleanly (drift detection
+# + recreation drill with snapshot restore).
+version = "v0.1.5"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Closing — superseded by the Shipyard migration work (Stages 1-6 complete, v0.3.0 released via shipyard ship). The governance config, Windows fixes, test fixes, and pin bumps were all landed through the Stage 2 ship cycles (PRs #113-#118) and the v0.3.0 release (PR #119).