### PR TITLE
CI: bump actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
 
@@ -41,7 +41,7 @@ jobs:
         run: sdkmanager "ndk;30.0.14904198"
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: pulp-android-${{ matrix.os }}
           path: android/app/build/outputs/apk/debug/app-debug.apk
@@ -86,7 +86,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
 
@@ -105,7 +105,7 @@ jobs:
           sdkmanager "emulator"
 
       - name: Download APK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: pulp-android-macos-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Upload plugin bundles (macOS)
         if: success() && runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: plugins-${{ matrix.key }}
           path: |
@@ -242,7 +242,7 @@ jobs:
 
       - name: Upload plugin bundles (Windows)
         if: success() && runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: plugins-${{ matrix.key }}
           path: |
@@ -252,7 +252,7 @@ jobs:
 
       - name: Upload plugin bundles (Linux)
         if: success() && runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: plugins-${{ matrix.key }}
           path: |

--- a/.github/workflows/freshness-check.yml
+++ b/.github/workflows/freshness-check.yml
@@ -29,9 +29,9 @@ jobs:
     name: Check package freshness
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -77,7 +77,7 @@ jobs:
           - r8brain-free-src
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Configure stub
         run: |


### PR DESCRIPTION
Silences the Node 20 deprecation warnings that were showing up on every Android, build, and freshness workflow run:

```
! Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
```

### Bumps

| Action | Old | New | Files |
|--------|-----|-----|-------|
| actions/checkout | v4 | v5 | android.yml, freshness-check.yml |
| actions/setup-python | v5 | v6 | freshness-check.yml |
| actions/upload-artifact | v4 | v5 | android.yml, build.yml (×3) |
| actions/download-artifact | v4 | v5 | android.yml |
| actions/cache | v4 | v5 | android.yml |

All new versions run on Node 24 natively. No API changes between these versions, so no workflow logic needs to change.

Workflows that were already on modern versions (build.yml checkout@v5, release-cli.yml, docs-deploy.yml, docs-check.yml, dependency-audit.yml, license-audit.yml, sanitizers.yml, sign-and-release.yml, validate.yml) are untouched.

## Test plan

- [x] `grep -rn 'actions/checkout@v4\|actions/setup-python@v5\|actions/upload-artifact@v4'` in `.github/workflows/` → zero matches after this PR
- [ ] CI matrix