### PR TITLE
Fix SDF atlas font manager + add --screenshot to demo

### DIFF
--- a/core/canvas/src/sdf_atlas.cpp
+++ b/core/canvas/src/sdf_atlas.cpp
@@ -28,6 +28,17 @@
     #include "include/core/SkColor.h"
     #include "include/core/SkFont.h"
     #include "include/core/SkFontMgr.h"
+    #ifdef __APPLE__
+        #include "include/ports/SkFontMgr_mac_ct.h"
+    #elif defined(_WIN32)
+        #include "include/ports/SkFontMgr_directory.h"
+    #elif defined(__ANDROID__)
+        #include "include/ports/SkFontMgr_android.h"
+        #include "include/ports/SkFontScanner_FreeType.h"
+    #elif defined(__linux__)
+        #include "include/ports/SkFontMgr_fontconfig.h"
+        #include "include/ports/SkFontScanner_FreeType.h"
+    #endif
     #include "include/core/SkPaint.h"
     #include "include/core/SkTypeface.h"
     #include "include/core/SkImageInfo.h"
@@ -154,7 +165,18 @@ std::vector<std::uint8_t> rasterize_skia(const std::string& font_family,
                                           char32_t codepoint,
                                           int base_size,
                                           int w, int h, int padding) {
-    auto mgr = SkFontMgr::RefDefault();
+    // Use the platform-specific font manager — matches skia_canvas.cpp
+#ifdef __APPLE__
+    auto mgr = SkFontMgr_New_CoreText(nullptr);
+#elif defined(_WIN32)
+    auto mgr = SkFontMgr_New_DirectWrite();
+#elif defined(__ANDROID__)
+    auto mgr = SkFontMgr_New_Android(nullptr, SkFontScanner_Make_FreeType());
+#elif defined(__linux__)
+    auto mgr = SkFontMgr_New_FontConfig(nullptr, SkFontScanner_Make_FreeType());
+#else
+    sk_sp<SkFontMgr> mgr;
+#endif
     if (!mgr) return {};
 
     sk_sp<SkTypeface> face;

--- a/examples/sdf-text-demo/main.cpp
+++ b/examples/sdf-text-demo/main.cpp
@@ -154,20 +154,39 @@ private:
 
 // ── Main ────────────────────────────────────────────────────────────────
 
+#include <pulp/view/screenshot.hpp>
+
 #ifndef PULP_SDF_DEMO_NO_MAIN
 
-int main() {
-    auto panel = std::make_unique<SdfTextPanel>();
-    panel->set_bounds({0, 0, 800, 900});
+int main(int argc, char* argv[]) {
+    // --screenshot: render headless to PNG and exit
+    bool screenshot_mode = false;
+    std::string screenshot_path = "/tmp/pulp-sdf-text-demo.png";
+    for (int i = 1; i < argc; ++i) {
+        if (std::string(argv[i]) == "--screenshot") {
+            screenshot_mode = true;
+            if (i + 1 < argc) screenshot_path = argv[++i];
+        }
+    }
 
-    WindowHost::Options opts;
+    SdfTextPanel panel;
+    panel.set_bounds({0, 0, 800, 900});
+
+    if (screenshot_mode) {
+        if (render_to_file(panel, 800, 900, screenshot_path)) {
+            return 0;
+        }
+        return 1;
+    }
+
+    WindowOptions opts;
     opts.title = "Pulp SDF Text Demo";
     opts.width = 800;
     opts.height = 900;
     opts.resizable = true;
+    opts.use_gpu = true;
 
-    auto host = WindowHost::create(opts);
-    host->set_root(std::move(panel));
+    auto host = WindowHost::create(panel, opts);
     host->show();
     host->run_event_loop();
 


### PR DESCRIPTION
## Summary
- Fix SDF atlas font manager: use platform-specific SkFontMgr factories (CoreText/DirectWrite/FreeType) instead of deprecated SkFontMgr::RefDefault()
- Add --screenshot mode to SDF text demo for headless CI validation

## Verified
Screenshot captured headlessly on macOS (Metal + Skia Graphite), saved to planning/screenshots/sdf-text-demo-macos.png