### PR TITLE
Streams: unified Stream / AsyncStream / network backends (Feature 3, Phase 1-3)

### DIFF
--- a/.agents/skills/streams/SKILL.md
+++ b/.agents/skills/streams/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: streams
+description: Pick the right Pulp Stream for a given I/O task, wire async callbacks correctly without deadlocking the worker, and avoid the backpressure / cancellation footguns in `pulp::runtime::AsyncStream`.
+---
+
+# Streams
+
+Use this skill when reaching for any I/O in Pulp: reading files, sending
+bytes over a socket, polling an HTTP endpoint, piping between processes,
+or wrapping a new transport. The `pulp::runtime::Stream` / `AsyncStream`
+hierarchy is the sanctioned path; do not add new `Socket::send` /
+`http_get` callers unless you have a specific reason.
+
+## Decision tree
+
+| You need to... | Use |
+|----------------|-----|
+| Read or write a local file | `FileStream` (sync) — or wrap in `AsyncStream` for large files |
+| Keep bytes in memory for tests / round-trips | `MemoryStream` |
+| Talk to another process via pipe | `PipeStream` around `NamedPipe` |
+| Open a TCP connection | `TcpStream`, wrapped in `AsyncStream` so `connect()` doesn't block the caller |
+| Fetch an HTTP/S body | `HttpStream::get(url)` / `post(url, body)` |
+| Send structured messages (JSON, OSC, WebSocket frames) | **Not yet** — Phase 4 `MessageChannel` is deferred |
+
+## AsyncStream — the patterns that actually work
+
+### 1. Dispatch callbacks onto your own loop
+
+`AsyncStream` never links `pulp::events` directly (that would be a
+library cycle). Pass an executor closure:
+
+```cpp
+AsyncStream::Options opts;
+opts.executor = [loop](std::function<void()> fn) { loop->dispatch(std::move(fn)); };
+```
+
+Without an executor, callbacks run on the AsyncStream's worker thread —
+fine for tests, usually wrong for UI state.
+
+### 2. Backpressure: check the return of `write_async`
+
+`write_async` returns **false** when the pending byte count would exceed
+`options.write_high_water` (default 1 MiB). When false, wait for
+`on_drain` before retrying. Ignoring the bool silently drops the write.
+
+### 3. Cancelling drains queued writes
+
+`cancel()` and `stop()` both complete any queued write callbacks with
+`StreamError::Closed`. Do not write code that assumes a cancel
+"silently forgets" in-flight writes — the callback will fire.
+
+### 4. Writes and auto-reads run on separate threads
+
+When `options.auto_read = true` the reader and writer run on
+**separate** threads so a blocking `read()` on a `TcpStream` cannot
+starve queued writes. Do not re-introduce a single worker loop
+without understanding this — request/response flows break otherwise.
+
+## Extending with a new transport
+
+To add WebSocket, S3, or any other transport:
+
+1. Implement `Stream::read` / `write` / `close` / `is_open`.
+2. Return `StreamResult::fail(StreamError::WouldBlock)` from `read()`
+   when no data is available; `AsyncStream` handles backoff.
+3. Keep `read()` non-blocking if at all possible — if it must block,
+   document it so callers know to always wrap in `AsyncStream` with
+   `auto_read = true`.
+
+## References
+
+- Docs: `docs/reference/streams.md` (full API + backpressure flow)
+- Headers: `core/runtime/include/pulp/runtime/{stream,async_stream,network_stream}.hpp`
+- Example: `examples/stream-demo/main.cpp`
+- Tests: `test/test_{stream,async_stream,network_stream}.cpp` — copy these
+  patterns for new transport tests
+- Feature plan: `planning/next-features-plan.md` § Feature 3 (Phase 4
+  MessageChannel is the next piece, currently deferred)

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(pulp-runtime PRIVATE
     src/http.cpp
     src/socket.cpp
     src/named_pipe.cpp
+    src/stream.cpp
     src/ip_address.cpp
     src/i18n.cpp
     src/crypto.cpp

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(pulp-runtime PRIVATE
     src/named_pipe.cpp
     src/stream.cpp
     src/async_stream.cpp
+    src/network_stream.cpp
     src/ip_address.cpp
     src/i18n.cpp
     src/crypto.cpp

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(pulp-runtime PRIVATE
     src/socket.cpp
     src/named_pipe.cpp
     src/stream.cpp
+    src/async_stream.cpp
     src/ip_address.cpp
     src/i18n.cpp
     src/crypto.cpp

--- a/core/runtime/include/pulp/runtime/async_stream.hpp
+++ b/core/runtime/include/pulp/runtime/async_stream.hpp
@@ -157,10 +157,11 @@ private:
         AsyncWriteCallback callback;
     };
 
-    void worker_main();
+    void write_loop();
+    void read_loop();
     void dispatch(std::function<void()> task);
     void fire_close();
-    void fire_drain_if_idle_locked();
+    void drain_queue_as_closed();  ///< completes queued writes with StreamError::Closed
 
     std::unique_ptr<Stream> stream_;
     Options options_;
@@ -177,7 +178,8 @@ private:
     std::size_t pending_bytes_ = 0;
     bool running_ = false;
     bool close_fired_ = false;
-    std::thread worker_;
+    std::thread writer_thread_;
+    std::thread reader_thread_;
 };
 
 }  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/async_stream.hpp
+++ b/core/runtime/include/pulp/runtime/async_stream.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+// AsyncStream — non-blocking wrapper around a synchronous Stream.
+//
+// AsyncStream owns a worker thread that pumps I/O on a Stream while the
+// caller continues on its own thread. Read data and completion callbacks
+// are delivered either on the worker thread (default) or dispatched into a
+// Pulp EventLoop when one is supplied.
+//
+// The wrapper adds three things the raw Stream does not:
+//   - asynchronous callbacks for read data, errors, and close;
+//   - a bounded write queue with explicit backpressure (`write` returns
+//     false when the pending queue exceeds a high-water mark);
+//   - cancellation — destruction, `cancel()`, or `close()` stops all
+//     in-flight work and fires pending completion callbacks with a
+//     Cancelled error.
+//
+// This is layer 2 of the Stream hierarchy. Layer 1 (`Stream`) provides a
+// synchronous interface; layer 3 adds network/HTTP-specific streams that
+// are already `Stream` subclasses and therefore automatically work with
+// `AsyncStream` without further adapter code.
+
+#include <pulp/runtime/stream.hpp>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace pulp::runtime {
+
+/// Executor hook: a function that schedules work on some thread. Callers
+/// pass a wrapper around their own event loop's `dispatch` — for example
+/// `[loop](auto fn) { loop->dispatch(std::move(fn)); }`. When null, the
+/// AsyncStream runs callbacks on its worker thread.
+using AsyncExecutor = std::function<void(std::function<void()>)>;
+
+/// Simple cancellation token, shared across async operations. Instances can
+/// be cheaply copied (they share state) and safely used from any thread.
+class CancellationToken {
+public:
+    CancellationToken();
+
+    /// Signal cancellation. Idempotent.
+    void cancel();
+
+    /// True once `cancel()` has been called.
+    bool is_cancelled() const;
+
+    /// True if this token is the same underlying state as `other`.
+    bool shares(const CancellationToken& other) const {
+        return state_.get() == other.state_.get();
+    }
+
+private:
+    struct State { std::atomic<bool> cancelled{false}; };
+    std::shared_ptr<State> state_;
+};
+
+/// Completion callback for `write_async`. Receives the number of bytes
+/// written and an error code; `error == Ok` means the full payload
+/// succeeded (partial writes retry internally until the Stream reports a
+/// non-Ok error).
+using AsyncWriteCallback = std::function<void(std::size_t bytes, StreamError error)>;
+
+/// Incoming-data callback. Called whenever the worker reads bytes from the
+/// underlying Stream. `data` is valid only for the duration of the call.
+using AsyncDataCallback = std::function<void(const std::uint8_t* data, std::size_t size)>;
+
+/// Error callback. Fired once per async operation when an error terminates
+/// the stream or a write. `Cancelled` is reported via the dedicated close
+/// callback instead.
+using AsyncErrorCallback = std::function<void(StreamError error)>;
+
+/// Close callback. Fired once when the stream is no longer usable — either
+/// because the underlying Stream closed, because `cancel()` was invoked, or
+/// because the AsyncStream is being destroyed.
+using AsyncCloseCallback = std::function<void()>;
+
+struct AsyncStreamOptions {
+    /// Read chunk size (bytes) used by the background worker.
+    std::size_t read_chunk = 4096;
+
+    /// High-water mark for pending write bytes. `write_async` returns
+    /// false when adding the new payload would push the total beyond
+    /// this limit — callers should wait for the `on_drain` callback
+    /// before retrying.
+    std::size_t write_high_water = 1 << 20;  // 1 MiB
+
+    /// When true, the worker reads from the stream eagerly and fires
+    /// `on_data` callbacks. Set to false for write-only streams.
+    bool auto_read = true;
+
+    /// Optional executor used to dispatch completion/data/error
+    /// callbacks onto the caller's thread. When empty, callbacks run
+    /// on the AsyncStream's worker thread. Typically wired to a
+    /// pulp::events::EventLoop via `[loop](auto fn){loop->dispatch(std::move(fn));}`.
+    AsyncExecutor executor;
+};
+
+class AsyncStream {
+public:
+    using Options = AsyncStreamOptions;
+
+    explicit AsyncStream(std::unique_ptr<Stream> stream, Options options = {});
+    ~AsyncStream();
+
+    AsyncStream(const AsyncStream&) = delete;
+    AsyncStream& operator=(const AsyncStream&) = delete;
+
+    /// Attach callbacks. Must be called before `start()` so the worker has
+    /// somewhere to send events. Safe to overwrite between `stop()` and
+    /// `start()`; not safe to reassign while the worker is running.
+    void on_data(AsyncDataCallback cb);
+    void on_error(AsyncErrorCallback cb);
+    void on_close(AsyncCloseCallback cb);
+    void on_drain(AsyncCloseCallback cb);  ///< fires when pending writes hit 0
+
+    /// Start the worker thread. No-op if already running.
+    void start();
+
+    /// Stop the worker thread and wait for it to exit. Fires `on_close`
+    /// exactly once if it has not fired already.
+    void stop();
+
+    /// Request cancellation. Pending writes complete with
+    /// `StreamError::Closed`; the worker exits at its next scheduled point.
+    void cancel();
+
+    /// Queue an async write. Returns false if the write would exceed the
+    /// configured high-water mark (backpressure). The caller should wait
+    /// for `on_drain` before trying again.
+    [[nodiscard]] bool write_async(const std::uint8_t* data, std::size_t size,
+                                   AsyncWriteCallback callback = {});
+
+    /// Bytes currently queued for writing.
+    std::size_t pending_write_bytes() const;
+
+    /// Cancellation token shared with this stream's worker. Callers can
+    /// pass this to user code that wants to observe cancellation alongside
+    /// the stream lifetime.
+    CancellationToken cancellation_token() const { return token_; }
+
+    /// Underlying Stream, for advanced callers. Not thread-safe with the
+    /// worker; only touch from the worker thread or after `stop()`.
+    Stream* stream() { return stream_.get(); }
+
+private:
+    struct PendingWrite {
+        std::vector<std::uint8_t> data;
+        std::size_t written = 0;
+        AsyncWriteCallback callback;
+    };
+
+    void worker_main();
+    void dispatch(std::function<void()> task);
+    void fire_close();
+    void fire_drain_if_idle_locked();
+
+    std::unique_ptr<Stream> stream_;
+    Options options_;
+    CancellationToken token_;
+
+    AsyncDataCallback on_data_;
+    AsyncErrorCallback on_error_;
+    AsyncCloseCallback on_close_;
+    AsyncCloseCallback on_drain_;
+
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    std::vector<PendingWrite> write_queue_;
+    std::size_t pending_bytes_ = 0;
+    bool running_ = false;
+    bool close_fired_ = false;
+    std::thread worker_;
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/network_stream.hpp
+++ b/core/runtime/include/pulp/runtime/network_stream.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+// Network Stream backends: TCP sockets and HTTP response bodies.
+//
+// These wrap the existing `Socket` and `http_get`/`http_post` helpers so
+// that higher-level code can treat them uniformly with `FileStream`,
+// `MemoryStream`, and `PipeStream` — and, layered under `AsyncStream`,
+// gain non-blocking semantics without any network-specific plumbing.
+
+#include <pulp/runtime/stream.hpp>
+#include <pulp/runtime/socket.hpp>
+#include <pulp/runtime/http.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pulp::runtime {
+
+/// Stream backed by a connected TCP `Socket`.
+///
+/// Construction is deliberately two-phase: `connect(host, port)` performs
+/// a blocking DNS + TCP handshake. Wrap in an `AsyncStream` to make it
+/// non-blocking for the caller.
+class TcpStream : public Stream {
+public:
+    TcpStream() = default;
+    explicit TcpStream(Socket&& connected);
+    ~TcpStream() override;
+
+    TcpStream(TcpStream&&) noexcept;
+    TcpStream& operator=(TcpStream&&) noexcept;
+
+    bool connect(std::string_view host, std::uint16_t port);
+
+    StreamResult read(std::uint8_t* buffer, std::size_t size) override;
+    StreamResult write(const std::uint8_t* buffer, std::size_t size) override;
+    void close() override;
+    bool is_open() const override { return open_; }
+
+    /// Access the underlying socket (advanced use: set options, inspect fd).
+    Socket& socket() { return socket_; }
+
+private:
+    Socket socket_;
+    bool open_ = false;
+};
+
+/// HTTP response as a readable Stream. The request is issued eagerly in the
+/// constructor (or via `get`/`post`) and the body is exposed through the
+/// Stream `read()` contract. Partial reads return chunks from the body
+/// buffer; `status_code()` and `headers()` are available once construction
+/// completes.
+///
+/// HttpStream is currently read-only. Writing to an HttpStream is a
+/// Phase 4 feature (request-body streaming) and returns `Invalid` until
+/// then.
+class HttpStream : public Stream {
+public:
+    struct Request {
+        std::string url;
+        std::string method = "GET";      ///< "GET" or "POST".
+        std::string body;                ///< Only used for POST.
+        std::string content_type = "application/json";
+        int timeout_seconds = 30;
+    };
+
+    HttpStream() = default;
+    explicit HttpStream(const Request& request);
+
+    /// Issue a new request, replacing any prior state.
+    bool fetch(const Request& request);
+
+    /// Convenience factory for GET requests.
+    static std::unique_ptr<HttpStream> get(std::string_view url,
+                                           int timeout_seconds = 30);
+
+    /// Convenience factory for POST requests.
+    static std::unique_ptr<HttpStream> post(std::string_view url,
+                                            std::string_view body,
+                                            std::string_view content_type = "application/json",
+                                            int timeout_seconds = 30);
+
+    StreamResult read(std::uint8_t* buffer, std::size_t size) override;
+    StreamResult write(const std::uint8_t* buffer, std::size_t size) override;
+    void close() override;
+    bool is_open() const override;
+
+    /// HTTP status code of the response, or 0 if the request failed.
+    int status_code() const { return response_.status_code; }
+
+    /// Parsed response headers (lowercased keys are *not* normalized — they
+    /// come through verbatim from cpp-httplib).
+    const std::map<std::string, std::string>& headers() const { return response_.headers; }
+
+    /// Non-empty when the request failed locally (network error, DNS, etc.).
+    const std::string& transport_error() const { return response_.error; }
+
+    /// True when the HTTP response body was fully consumed by read().
+    bool eof() const;
+
+private:
+    HttpResponse response_;
+    std::size_t read_pos_ = 0;
+    bool closed_ = false;
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/stream.hpp
+++ b/core/runtime/include/pulp/runtime/stream.hpp
@@ -1,0 +1,178 @@
+#pragma once
+
+// Unified Stream interface for bytewise I/O.
+//
+// A `Stream` presents a common surface across files, memory buffers, pipes,
+// sockets, and HTTP bodies. It is synchronous and byte-oriented; async
+// behavior is layered on top via `AsyncStream`, which dispatches Stream
+// operations on a background worker and delivers completions through the
+// `EventLoop`.
+//
+// The interface is minimal on purpose:
+//   - `read(buf, n)`  — non-blocking-style read; may return 0 with
+//                        StreamError::WouldBlock when no data is available.
+//   - `write(buf, n)` — returns bytes written; may be partial.
+//   - `close()`        — idempotent; safe to call on a closed stream.
+//   - `is_open()`      — whether the stream is currently usable.
+//
+// Streams never throw from `read`/`write`. Errors surface as
+// `StreamError != Ok` in the returned `StreamResult`.
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pulp::runtime {
+
+/// High-level error classification for Stream operations.
+enum class StreamError : uint8_t {
+    Ok,          ///< No error; `bytes` is authoritative.
+    Closed,      ///< End-of-stream / peer closed / stream not open.
+    WouldBlock,  ///< No data available now; try again later.
+    IoError,     ///< OS-level I/O failure (errno/GetLastError set by the backend).
+    Invalid,     ///< Invalid argument or invalid state (e.g., read after close).
+};
+
+/// Result of a Stream read/write.
+///
+/// Consumers should check `ok()` first. On `ok()`:
+///   - `bytes == 0` means "end of stream" for read, "no room" for write
+///     (backends that do not distinguish will report `Closed` / `WouldBlock`).
+///   - `bytes > 0` means that many bytes were transferred.
+struct StreamResult {
+    std::size_t bytes = 0;
+    StreamError error = StreamError::Ok;
+
+    constexpr bool ok() const { return error == StreamError::Ok; }
+    constexpr bool would_block() const { return error == StreamError::WouldBlock; }
+    constexpr bool closed() const { return error == StreamError::Closed; }
+
+    static constexpr StreamResult make(std::size_t n) { return {n, StreamError::Ok}; }
+    static constexpr StreamResult fail(StreamError e) { return {0, e}; }
+};
+
+/// Base class for all Pulp byte streams.
+///
+/// Implementations must be safe to destroy from any thread, but individual
+/// instances are not thread-safe: callers coordinate access (typically the
+/// owning `AsyncStream` serializes on a worker thread).
+class Stream {
+public:
+    virtual ~Stream() = default;
+
+    Stream(const Stream&) = delete;
+    Stream& operator=(const Stream&) = delete;
+
+    /// Read up to `size` bytes into `buffer`. Returns how many bytes were
+    /// written, or an error. `buffer` may be partially filled on error.
+    virtual StreamResult read(std::uint8_t* buffer, std::size_t size) = 0;
+
+    /// Write up to `size` bytes from `buffer`. Returns how many bytes were
+    /// consumed. Partial writes are permitted — callers loop until satisfied
+    /// or treat the short return as backpressure.
+    virtual StreamResult write(const std::uint8_t* buffer, std::size_t size) = 0;
+
+    /// Close the stream. Idempotent.
+    virtual void close() = 0;
+
+    /// True while the stream is usable for read/write.
+    virtual bool is_open() const = 0;
+
+protected:
+    Stream() = default;
+};
+
+/// Stream backed by `std::FILE*` (for portability across Windows/POSIX).
+///
+/// Not async-friendly by itself — use `AsyncStream` to dispatch reads/writes
+/// to a worker thread.
+class FileStream : public Stream {
+public:
+    enum class Mode : uint8_t { Read, Write, Append, ReadWrite };
+
+    FileStream() = default;
+    explicit FileStream(std::string_view path, Mode mode = Mode::Read);
+    ~FileStream() override;
+
+    FileStream(FileStream&& other) noexcept;
+    FileStream& operator=(FileStream&& other) noexcept;
+
+    /// Open `path` with the given mode. Returns true on success.
+    bool open(std::string_view path, Mode mode = Mode::Read);
+
+    StreamResult read(std::uint8_t* buffer, std::size_t size) override;
+    StreamResult write(const std::uint8_t* buffer, std::size_t size) override;
+    void close() override;
+    bool is_open() const override { return handle_ != nullptr; }
+
+    /// Flush OS-level buffers to the underlying file.
+    bool flush();
+
+    /// Current byte position, or (size_t)-1 on error.
+    std::size_t position() const;
+
+private:
+    void* handle_ = nullptr;  // std::FILE*
+};
+
+/// Stream backed by an in-memory byte buffer. Useful for tests and for
+/// round-trips where no actual I/O is required.
+class MemoryStream : public Stream {
+public:
+    MemoryStream() = default;
+
+    /// Pre-fill the stream with existing bytes (copied in).
+    explicit MemoryStream(std::vector<std::uint8_t> initial);
+
+    StreamResult read(std::uint8_t* buffer, std::size_t size) override;
+    StreamResult write(const std::uint8_t* buffer, std::size_t size) override;
+    void close() override { open_ = false; }
+    bool is_open() const override { return open_; }
+
+    /// Byte content currently in the stream (for inspection in tests).
+    const std::vector<std::uint8_t>& buffer() const { return buffer_; }
+
+    /// Reset the read cursor to the start.
+    void rewind() { read_pos_ = 0; }
+
+    /// Clear all data and rewind.
+    void clear();
+
+    std::size_t size() const { return buffer_.size(); }
+    std::size_t read_position() const { return read_pos_; }
+
+private:
+    std::vector<std::uint8_t> buffer_;
+    std::size_t read_pos_ = 0;
+    bool open_ = true;
+};
+
+// Forward declaration — full definition requires named_pipe.hpp.
+class NamedPipe;
+
+/// Stream wrapper over `NamedPipe`. Takes ownership of an already-connected
+/// pipe; callers open the pipe (server/client) before constructing.
+class PipeStream : public Stream {
+public:
+    PipeStream() = default;
+    explicit PipeStream(std::unique_ptr<NamedPipe> pipe);
+    ~PipeStream() override;
+
+    PipeStream(PipeStream&&) noexcept;
+    PipeStream& operator=(PipeStream&&) noexcept;
+
+    StreamResult read(std::uint8_t* buffer, std::size_t size) override;
+    StreamResult write(const std::uint8_t* buffer, std::size_t size) override;
+    void close() override;
+    bool is_open() const override;
+
+    NamedPipe* pipe() { return pipe_.get(); }
+
+private:
+    std::unique_ptr<NamedPipe> pipe_;
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/async_stream.cpp
+++ b/core/runtime/src/async_stream.cpp
@@ -1,0 +1,226 @@
+#include <pulp/runtime/async_stream.hpp>
+
+#include <chrono>
+#include <utility>
+
+namespace pulp::runtime {
+
+// ─── CancellationToken ────────────────────────────────────────────────────
+
+CancellationToken::CancellationToken() : state_(std::make_shared<State>()) {}
+
+void CancellationToken::cancel() {
+    if (state_) state_->cancelled.store(true, std::memory_order_release);
+}
+
+bool CancellationToken::is_cancelled() const {
+    return state_ && state_->cancelled.load(std::memory_order_acquire);
+}
+
+// ─── AsyncStream ──────────────────────────────────────────────────────────
+
+AsyncStream::AsyncStream(std::unique_ptr<Stream> stream, Options options)
+    : stream_(std::move(stream)),
+      options_(options) {}
+
+AsyncStream::~AsyncStream() {
+    stop();
+}
+
+void AsyncStream::on_data(AsyncDataCallback cb) { on_data_ = std::move(cb); }
+void AsyncStream::on_error(AsyncErrorCallback cb) { on_error_ = std::move(cb); }
+void AsyncStream::on_close(AsyncCloseCallback cb) { on_close_ = std::move(cb); }
+void AsyncStream::on_drain(AsyncCloseCallback cb) { on_drain_ = std::move(cb); }
+
+void AsyncStream::start() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (running_) return;
+    running_ = true;
+    close_fired_ = false;
+    worker_ = std::thread([this] { worker_main(); });
+}
+
+void AsyncStream::stop() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!running_ && !worker_.joinable()) return;
+        running_ = false;
+    }
+    cv_.notify_all();
+    token_.cancel();
+    if (worker_.joinable()) worker_.join();
+    fire_close();
+}
+
+void AsyncStream::cancel() {
+    token_.cancel();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        running_ = false;
+    }
+    cv_.notify_all();
+}
+
+bool AsyncStream::write_async(const std::uint8_t* data, std::size_t size,
+                              AsyncWriteCallback callback) {
+    if (size == 0) {
+        if (callback) dispatch([cb = std::move(callback)] { cb(0, StreamError::Ok); });
+        return true;
+    }
+
+    PendingWrite pw;
+    pw.data.assign(data, data + size);
+    pw.callback = std::move(callback);
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (token_.is_cancelled() || !stream_ || !stream_->is_open()) {
+            auto cb = std::move(pw.callback);
+            if (cb) dispatch([cb = std::move(cb)] { cb(0, StreamError::Closed); });
+            return true;
+        }
+        if (pending_bytes_ + size > options_.write_high_water) {
+            return false;  // backpressure
+        }
+        pending_bytes_ += size;
+        write_queue_.push_back(std::move(pw));
+    }
+    cv_.notify_all();
+    return true;
+}
+
+std::size_t AsyncStream::pending_write_bytes() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return pending_bytes_;
+}
+
+void AsyncStream::dispatch(std::function<void()> task) {
+    if (options_.executor) {
+        options_.executor(std::move(task));
+    } else {
+        task();
+    }
+}
+
+void AsyncStream::fire_close() {
+    AsyncCloseCallback cb;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (close_fired_) return;
+        close_fired_ = true;
+        cb = on_close_;
+    }
+    if (cb) dispatch(std::move(cb));
+}
+
+void AsyncStream::fire_drain_if_idle_locked() {
+    if (pending_bytes_ == 0 && on_drain_) {
+        auto cb = on_drain_;
+        dispatch(std::move(cb));
+    }
+}
+
+void AsyncStream::worker_main() {
+    std::vector<std::uint8_t> read_buf(options_.read_chunk);
+
+    while (true) {
+        // Check cancellation / running state.
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            if (!running_ || token_.is_cancelled()) break;
+        }
+
+        bool did_work = false;
+
+        // Drain one pending write, if any.
+        PendingWrite to_write;
+        bool have_write = false;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            if (!write_queue_.empty()) {
+                to_write = std::move(write_queue_.front());
+                write_queue_.erase(write_queue_.begin());
+                have_write = true;
+            }
+        }
+
+        if (have_write) {
+            StreamError last_err = StreamError::Ok;
+            while (to_write.written < to_write.data.size()) {
+                if (token_.is_cancelled()) { last_err = StreamError::Closed; break; }
+                auto remaining = to_write.data.size() - to_write.written;
+                auto result = stream_->write(
+                    to_write.data.data() + to_write.written, remaining);
+                if (!result.ok()) {
+                    last_err = result.error;
+                    if (last_err == StreamError::WouldBlock) {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                        continue;
+                    }
+                    break;
+                }
+                if (result.bytes == 0) { last_err = StreamError::Closed; break; }
+                to_write.written += result.bytes;
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                pending_bytes_ -= to_write.data.size();
+                fire_drain_if_idle_locked();
+            }
+
+            if (to_write.callback) {
+                auto cb = std::move(to_write.callback);
+                auto wrote = to_write.written;
+                dispatch([cb = std::move(cb), wrote, last_err] { cb(wrote, last_err); });
+            }
+            if (last_err != StreamError::Ok && last_err != StreamError::WouldBlock) {
+                if (on_error_) {
+                    auto cb = on_error_;
+                    dispatch([cb = std::move(cb), last_err] { cb(last_err); });
+                }
+                break;
+            }
+            did_work = true;
+        }
+
+        // Try a read if auto_read is on.
+        if (options_.auto_read && stream_ && stream_->is_open()) {
+            auto r = stream_->read(read_buf.data(), read_buf.size());
+            if (r.ok() && r.bytes > 0) {
+                if (on_data_) {
+                    auto cb = on_data_;
+                    std::vector<std::uint8_t> copy(read_buf.begin(),
+                                                   read_buf.begin() + r.bytes);
+                    dispatch([cb = std::move(cb), payload = std::move(copy)] {
+                        cb(payload.data(), payload.size());
+                    });
+                }
+                did_work = true;
+            } else if (r.closed()) {
+                break;  // stream closed cleanly; exit worker → fire_close
+            } else if (r.error == StreamError::IoError) {
+                if (on_error_) {
+                    auto cb = on_error_;
+                    dispatch([cb = std::move(cb)] { cb(StreamError::IoError); });
+                }
+                break;
+            }
+            // WouldBlock / Ok-with-0-bytes falls through to the wait below.
+        }
+
+        if (!did_work) {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait_for(lock, std::chrono::milliseconds(10),
+                         [this] { return !running_ || !write_queue_.empty(); });
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        running_ = false;
+    }
+    fire_close();
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/async_stream.cpp
+++ b/core/runtime/src/async_stream.cpp
@@ -37,18 +37,23 @@ void AsyncStream::start() {
     if (running_) return;
     running_ = true;
     close_fired_ = false;
-    worker_ = std::thread([this] { worker_main(); });
+    writer_thread_ = std::thread([this] { write_loop(); });
+    if (options_.auto_read) {
+        reader_thread_ = std::thread([this] { read_loop(); });
+    }
 }
 
 void AsyncStream::stop() {
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        if (!running_ && !worker_.joinable()) return;
+        if (!running_ && !writer_thread_.joinable() && !reader_thread_.joinable()) return;
         running_ = false;
     }
-    cv_.notify_all();
     token_.cancel();
-    if (worker_.joinable()) worker_.join();
+    cv_.notify_all();
+    if (writer_thread_.joinable()) writer_thread_.join();
+    if (reader_thread_.joinable()) reader_thread_.join();
+    drain_queue_as_closed();
     fire_close();
 }
 
@@ -59,6 +64,11 @@ void AsyncStream::cancel() {
         running_ = false;
     }
     cv_.notify_all();
+    // Complete any writes queued before cancel() with Closed so callers
+    // don't wait indefinitely for completion callbacks. Safe to drain here
+    // (not inside the write loop) because cancel() is called from the user
+    // thread while the writer thread is waking up via the flag + cv.
+    drain_queue_as_closed();
 }
 
 bool AsyncStream::write_async(const std::uint8_t* data, std::size_t size,
@@ -113,114 +123,134 @@ void AsyncStream::fire_close() {
     if (cb) dispatch(std::move(cb));
 }
 
-void AsyncStream::fire_drain_if_idle_locked() {
-    if (pending_bytes_ == 0 && on_drain_) {
-        auto cb = on_drain_;
-        dispatch(std::move(cb));
+void AsyncStream::drain_queue_as_closed() {
+    std::vector<PendingWrite> drained;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        drained.swap(write_queue_);
+        pending_bytes_ = 0;
+    }
+    for (auto& w : drained) {
+        if (w.callback) {
+            auto cb = std::move(w.callback);
+            dispatch([cb = std::move(cb)] { cb(0, StreamError::Closed); });
+        }
     }
 }
 
-void AsyncStream::worker_main() {
-    std::vector<std::uint8_t> read_buf(options_.read_chunk);
-
+void AsyncStream::write_loop() {
     while (true) {
-        // Check cancellation / running state.
-        {
-            std::unique_lock<std::mutex> lock(mutex_);
-            if (!running_ || token_.is_cancelled()) break;
-        }
-
-        bool did_work = false;
-
-        // Drain one pending write, if any.
         PendingWrite to_write;
         bool have_write = false;
         {
             std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait(lock, [this] {
+                return !running_ || token_.is_cancelled() || !write_queue_.empty();
+            });
+            if (!running_ || token_.is_cancelled()) return;
             if (!write_queue_.empty()) {
                 to_write = std::move(write_queue_.front());
                 write_queue_.erase(write_queue_.begin());
                 have_write = true;
             }
         }
+        if (!have_write) continue;
 
-        if (have_write) {
-            StreamError last_err = StreamError::Ok;
-            while (to_write.written < to_write.data.size()) {
-                if (token_.is_cancelled()) { last_err = StreamError::Closed; break; }
-                auto remaining = to_write.data.size() - to_write.written;
-                auto result = stream_->write(
-                    to_write.data.data() + to_write.written, remaining);
-                if (!result.ok()) {
-                    last_err = result.error;
-                    if (last_err == StreamError::WouldBlock) {
-                        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-                        continue;
-                    }
-                    break;
+        StreamError last_err = StreamError::Ok;
+        while (to_write.written < to_write.data.size()) {
+            if (token_.is_cancelled()) { last_err = StreamError::Closed; break; }
+            auto remaining = to_write.data.size() - to_write.written;
+            auto result = stream_->write(
+                to_write.data.data() + to_write.written, remaining);
+            if (!result.ok()) {
+                last_err = result.error;
+                if (last_err == StreamError::WouldBlock) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                    continue;
                 }
-                if (result.bytes == 0) { last_err = StreamError::Closed; break; }
-                to_write.written += result.bytes;
+                break;
             }
+            if (result.bytes == 0) { last_err = StreamError::Closed; break; }
+            to_write.written += result.bytes;
+        }
 
+        // Update accounting and collect drain callback under the lock; fire
+        // it *outside* the lock so callers can re-enter write_async() from
+        // on_drain without deadlocking (issue #134 P1).
+        AsyncCloseCallback drain_cb;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            pending_bytes_ -= to_write.data.size();
+            if (pending_bytes_ == 0 && on_drain_) {
+                drain_cb = on_drain_;
+            }
+        }
+
+        if (to_write.callback) {
+            auto cb = std::move(to_write.callback);
+            auto wrote = to_write.written;
+            dispatch([cb = std::move(cb), wrote, last_err] { cb(wrote, last_err); });
+        }
+        if (drain_cb) dispatch(std::move(drain_cb));
+
+        if (last_err != StreamError::Ok && last_err != StreamError::WouldBlock) {
+            if (on_error_) {
+                auto cb = on_error_;
+                dispatch([cb = std::move(cb), last_err] { cb(last_err); });
+            }
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-                pending_bytes_ -= to_write.data.size();
-                fire_drain_if_idle_locked();
+                running_ = false;
             }
-
-            if (to_write.callback) {
-                auto cb = std::move(to_write.callback);
-                auto wrote = to_write.written;
-                dispatch([cb = std::move(cb), wrote, last_err] { cb(wrote, last_err); });
-            }
-            if (last_err != StreamError::Ok && last_err != StreamError::WouldBlock) {
-                if (on_error_) {
-                    auto cb = on_error_;
-                    dispatch([cb = std::move(cb), last_err] { cb(last_err); });
-                }
-                break;
-            }
-            did_work = true;
-        }
-
-        // Try a read if auto_read is on.
-        if (options_.auto_read && stream_ && stream_->is_open()) {
-            auto r = stream_->read(read_buf.data(), read_buf.size());
-            if (r.ok() && r.bytes > 0) {
-                if (on_data_) {
-                    auto cb = on_data_;
-                    std::vector<std::uint8_t> copy(read_buf.begin(),
-                                                   read_buf.begin() + r.bytes);
-                    dispatch([cb = std::move(cb), payload = std::move(copy)] {
-                        cb(payload.data(), payload.size());
-                    });
-                }
-                did_work = true;
-            } else if (r.closed()) {
-                break;  // stream closed cleanly; exit worker → fire_close
-            } else if (r.error == StreamError::IoError) {
-                if (on_error_) {
-                    auto cb = on_error_;
-                    dispatch([cb = std::move(cb)] { cb(StreamError::IoError); });
-                }
-                break;
-            }
-            // WouldBlock / Ok-with-0-bytes falls through to the wait below.
-        }
-
-        if (!did_work) {
-            std::unique_lock<std::mutex> lock(mutex_);
-            cv_.wait_for(lock, std::chrono::milliseconds(10),
-                         [this] { return !running_ || !write_queue_.empty(); });
+            cv_.notify_all();
+            return;
         }
     }
+}
 
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        running_ = false;
+void AsyncStream::read_loop() {
+    std::vector<std::uint8_t> read_buf(options_.read_chunk);
+
+    while (true) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (!running_ || token_.is_cancelled() || !stream_ || !stream_->is_open()) return;
+        }
+
+        auto r = stream_->read(read_buf.data(), read_buf.size());
+        if (r.ok() && r.bytes > 0) {
+            if (on_data_) {
+                auto cb = on_data_;
+                std::vector<std::uint8_t> payload(read_buf.begin(),
+                                                  read_buf.begin() + r.bytes);
+                dispatch([cb = std::move(cb), payload = std::move(payload)] {
+                    cb(payload.data(), payload.size());
+                });
+            }
+        } else if (r.closed()) {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                running_ = false;
+            }
+            cv_.notify_all();
+            return;
+        } else if (r.error == StreamError::IoError) {
+            if (on_error_) {
+                auto cb = on_error_;
+                dispatch([cb = std::move(cb)] { cb(StreamError::IoError); });
+            }
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                running_ = false;
+            }
+            cv_.notify_all();
+            return;
+        } else {
+            // WouldBlock or 0-byte Ok: back off briefly without holding the
+            // write path hostage (writer runs on a separate thread).
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
     }
-    fire_close();
 }
 
 }  // namespace pulp::runtime

--- a/core/runtime/src/network_stream.cpp
+++ b/core/runtime/src/network_stream.cpp
@@ -1,0 +1,141 @@
+#include <pulp/runtime/network_stream.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <utility>
+
+namespace pulp::runtime {
+
+// ─── TcpStream ────────────────────────────────────────────────────────────
+
+TcpStream::TcpStream(Socket&& connected)
+    : socket_(std::move(connected)), open_(true) {}
+
+TcpStream::~TcpStream() { close(); }
+
+TcpStream::TcpStream(TcpStream&& other) noexcept
+    : socket_(std::move(other.socket_)), open_(other.open_) {
+    other.open_ = false;
+}
+
+TcpStream& TcpStream::operator=(TcpStream&& other) noexcept {
+    if (this != &other) {
+        close();
+        socket_ = std::move(other.socket_);
+        open_ = other.open_;
+        other.open_ = false;
+    }
+    return *this;
+}
+
+bool TcpStream::connect(std::string_view host, std::uint16_t port) {
+    close();
+    if (!socket_.create(SocketType::TCP)) return false;
+    if (!socket_.connect(host, port)) {
+        socket_.close();
+        return false;
+    }
+    open_ = true;
+    return true;
+}
+
+StreamResult TcpStream::read(std::uint8_t* buffer, std::size_t size) {
+    if (!open_) return StreamResult::fail(StreamError::Closed);
+    if (size == 0) return StreamResult::make(0);
+
+    int n = socket_.receive(buffer, size);
+    if (n < 0) return StreamResult::fail(StreamError::IoError);
+    if (n == 0) {
+        open_ = false;
+        return StreamResult::fail(StreamError::Closed);
+    }
+    return StreamResult::make(static_cast<std::size_t>(n));
+}
+
+StreamResult TcpStream::write(const std::uint8_t* buffer, std::size_t size) {
+    if (!open_) return StreamResult::fail(StreamError::Closed);
+    if (size == 0) return StreamResult::make(0);
+
+    int n = socket_.send(buffer, size);
+    if (n < 0) return StreamResult::fail(StreamError::IoError);
+    return StreamResult::make(static_cast<std::size_t>(n));
+}
+
+void TcpStream::close() {
+    if (open_) {
+        socket_.close();
+        open_ = false;
+    }
+}
+
+// ─── HttpStream ───────────────────────────────────────────────────────────
+
+HttpStream::HttpStream(const Request& request) {
+    fetch(request);
+}
+
+bool HttpStream::fetch(const Request& request) {
+    read_pos_ = 0;
+    closed_ = false;
+
+    if (request.method == "POST") {
+        response_ = http_post(request.url, request.body, request.content_type,
+                              request.timeout_seconds);
+    } else {
+        response_ = http_get(request.url, request.timeout_seconds);
+    }
+    return response_.error.empty() && response_.status_code != 0;
+}
+
+std::unique_ptr<HttpStream> HttpStream::get(std::string_view url, int timeout_seconds) {
+    Request r;
+    r.url.assign(url);
+    r.timeout_seconds = timeout_seconds;
+    return std::make_unique<HttpStream>(r);
+}
+
+std::unique_ptr<HttpStream> HttpStream::post(std::string_view url,
+                                             std::string_view body,
+                                             std::string_view content_type,
+                                             int timeout_seconds) {
+    Request r;
+    r.url.assign(url);
+    r.method = "POST";
+    r.body.assign(body);
+    r.content_type.assign(content_type);
+    r.timeout_seconds = timeout_seconds;
+    return std::make_unique<HttpStream>(r);
+}
+
+StreamResult HttpStream::read(std::uint8_t* buffer, std::size_t size) {
+    if (closed_) return StreamResult::fail(StreamError::Closed);
+    if (size == 0) return StreamResult::make(0);
+    if (!response_.error.empty()) return StreamResult::fail(StreamError::IoError);
+
+    auto total = response_.body.size();
+    if (read_pos_ >= total) return StreamResult::fail(StreamError::Closed);
+
+    auto available = total - read_pos_;
+    auto n = std::min(size, available);
+    std::memcpy(buffer, response_.body.data() + read_pos_, n);
+    read_pos_ += n;
+    return StreamResult::make(n);
+}
+
+StreamResult HttpStream::write(const std::uint8_t*, std::size_t) {
+    // HttpStream is read-only (response body). Request-body streaming is
+    // Phase 4 of the stream feature plan.
+    return StreamResult::fail(StreamError::Invalid);
+}
+
+void HttpStream::close() { closed_ = true; }
+
+bool HttpStream::is_open() const {
+    return !closed_ && response_.error.empty() && read_pos_ < response_.body.size();
+}
+
+bool HttpStream::eof() const {
+    return read_pos_ >= response_.body.size();
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/stream.cpp
+++ b/core/runtime/src/stream.cpp
@@ -1,0 +1,166 @@
+#include <pulp/runtime/stream.hpp>
+#include <pulp/runtime/named_pipe.hpp>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <utility>
+
+namespace pulp::runtime {
+
+// ─── FileStream ───────────────────────────────────────────────────────────
+
+namespace {
+const char* mode_string(FileStream::Mode mode) {
+    switch (mode) {
+        case FileStream::Mode::Read:      return "rb";
+        case FileStream::Mode::Write:     return "wb";
+        case FileStream::Mode::Append:    return "ab";
+        case FileStream::Mode::ReadWrite: return "w+b";
+    }
+    return "rb";
+}
+}  // namespace
+
+FileStream::FileStream(std::string_view path, Mode mode) {
+    open(path, mode);
+}
+
+FileStream::~FileStream() {
+    close();
+}
+
+FileStream::FileStream(FileStream&& other) noexcept : handle_(other.handle_) {
+    other.handle_ = nullptr;
+}
+
+FileStream& FileStream::operator=(FileStream&& other) noexcept {
+    if (this != &other) {
+        close();
+        handle_ = other.handle_;
+        other.handle_ = nullptr;
+    }
+    return *this;
+}
+
+bool FileStream::open(std::string_view path, Mode mode) {
+    close();
+    std::string path_str(path);
+    handle_ = std::fopen(path_str.c_str(), mode_string(mode));
+    return handle_ != nullptr;
+}
+
+StreamResult FileStream::read(std::uint8_t* buffer, std::size_t size) {
+    if (!handle_) return StreamResult::fail(StreamError::Closed);
+    if (size == 0) return StreamResult::make(0);
+
+    auto* fp = static_cast<std::FILE*>(handle_);
+    std::size_t n = std::fread(buffer, 1, size, fp);
+    if (n == 0) {
+        if (std::feof(fp)) return StreamResult::fail(StreamError::Closed);
+        if (std::ferror(fp)) return StreamResult::fail(StreamError::IoError);
+    }
+    return StreamResult::make(n);
+}
+
+StreamResult FileStream::write(const std::uint8_t* buffer, std::size_t size) {
+    if (!handle_) return StreamResult::fail(StreamError::Closed);
+    if (size == 0) return StreamResult::make(0);
+
+    auto* fp = static_cast<std::FILE*>(handle_);
+    std::size_t n = std::fwrite(buffer, 1, size, fp);
+    if (n < size) {
+        return n > 0 ? StreamResult::make(n) : StreamResult::fail(StreamError::IoError);
+    }
+    return StreamResult::make(n);
+}
+
+void FileStream::close() {
+    if (handle_) {
+        std::fclose(static_cast<std::FILE*>(handle_));
+        handle_ = nullptr;
+    }
+}
+
+bool FileStream::flush() {
+    if (!handle_) return false;
+    return std::fflush(static_cast<std::FILE*>(handle_)) == 0;
+}
+
+std::size_t FileStream::position() const {
+    if (!handle_) return static_cast<std::size_t>(-1);
+    auto pos = std::ftell(static_cast<std::FILE*>(handle_));
+    if (pos < 0) return static_cast<std::size_t>(-1);
+    return static_cast<std::size_t>(pos);
+}
+
+// ─── MemoryStream ─────────────────────────────────────────────────────────
+
+MemoryStream::MemoryStream(std::vector<std::uint8_t> initial)
+    : buffer_(std::move(initial)) {}
+
+StreamResult MemoryStream::read(std::uint8_t* buffer, std::size_t size) {
+    if (!open_) return StreamResult::fail(StreamError::Closed);
+    if (size == 0) return StreamResult::make(0);
+    if (read_pos_ >= buffer_.size()) return StreamResult::fail(StreamError::Closed);
+
+    std::size_t available = buffer_.size() - read_pos_;
+    std::size_t n = std::min(size, available);
+    std::memcpy(buffer, buffer_.data() + read_pos_, n);
+    read_pos_ += n;
+    return StreamResult::make(n);
+}
+
+StreamResult MemoryStream::write(const std::uint8_t* buffer, std::size_t size) {
+    if (!open_) return StreamResult::fail(StreamError::Closed);
+    if (size == 0) return StreamResult::make(0);
+    buffer_.insert(buffer_.end(), buffer, buffer + size);
+    return StreamResult::make(size);
+}
+
+void MemoryStream::clear() {
+    buffer_.clear();
+    read_pos_ = 0;
+}
+
+// ─── PipeStream ───────────────────────────────────────────────────────────
+
+PipeStream::PipeStream(std::unique_ptr<NamedPipe> pipe) : pipe_(std::move(pipe)) {}
+
+PipeStream::~PipeStream() = default;
+
+PipeStream::PipeStream(PipeStream&& other) noexcept : pipe_(std::move(other.pipe_)) {}
+PipeStream& PipeStream::operator=(PipeStream&& other) noexcept {
+    if (this != &other) pipe_ = std::move(other.pipe_);
+    return *this;
+}
+
+StreamResult PipeStream::read(std::uint8_t* buffer, std::size_t size) {
+    if (!pipe_ || !pipe_->is_open()) return StreamResult::fail(StreamError::Closed);
+    if (size == 0) return StreamResult::make(0);
+
+    int n = pipe_->read(buffer, size);
+    if (n < 0) return StreamResult::fail(StreamError::IoError);
+    if (n == 0) return StreamResult::fail(StreamError::Closed);
+    return StreamResult::make(static_cast<std::size_t>(n));
+}
+
+StreamResult PipeStream::write(const std::uint8_t* buffer, std::size_t size) {
+    if (!pipe_ || !pipe_->is_open()) return StreamResult::fail(StreamError::Closed);
+    if (size == 0) return StreamResult::make(0);
+
+    int n = pipe_->write(buffer, size);
+    if (n < 0) return StreamResult::fail(StreamError::IoError);
+    return StreamResult::make(static_cast<std::size_t>(n));
+}
+
+void PipeStream::close() {
+    if (pipe_) pipe_->close();
+}
+
+bool PipeStream::is_open() const {
+    return pipe_ && pipe_->is_open();
+}
+
+}  // namespace pulp::runtime

--- a/core/view/platform/android/accessibility_android.cpp
+++ b/core/view/platform/android/accessibility_android.cpp
@@ -19,6 +19,7 @@
 #include <pulp/view/accessibility.hpp>
 
 using pulp::view::View;
+using pulp::view::Point;
 
 // ── Flat node cache ─────────────────────────────────────────────────────
 // Rebuilt on each onInitializeAccessibilityNodeInfo call (Kotlin calls
@@ -40,8 +41,10 @@ void collect_accessible_views(View& root, std::vector<AccessNode>& out) {
     if (root.access_role() != View::AccessRole::none) {
         out.push_back({&root, static_cast<int>(root.access_role())});
     }
-    for (auto& child : root.children()) {
-        collect_accessible_views(*child, out);
+    for (size_t i = 0; i < root.child_count(); ++i) {
+        if (auto* child = root.child_at(i)) {
+            collect_accessible_views(*child, out);
+        }
     }
 }
 
@@ -144,10 +147,13 @@ Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativePerformAction(
     constexpr int ACTION_DECREMENT = 2;
 
     switch (action) {
-        case ACTION_CLICK:
-            // Simulate a click at the centre of the view
-            target->simulate_click();
+        case ACTION_CLICK: {
+            // Simulate a click at the centre of the target view in root coords
+            auto b = target->bounds();
+            Point center{b.x + b.width * 0.5f, b.y + b.height * 0.5f};
+            target->simulate_click(center);
             break;
+        }
         case ACTION_INCREMENT:
             target->on_accessibility_adjust(0.05f);
             break;

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -43,6 +43,25 @@ auto params = doc.xpath_strings("//param"); // ["Gain"]
 doc.save_file("settings.xml");
 ```
 
+### Streams — Unified byte I/O
+
+One interface (`pulp::runtime::Stream`) for files, memory, pipes, TCP, and HTTP. See [docs/reference/streams.md](./streams.md) for the full API.
+
+```cpp
+#include <pulp/runtime/stream.hpp>
+#include <pulp/runtime/async_stream.hpp>
+
+// Synchronous file I/O via the common interface.
+FileStream f("preset.bin", FileStream::Mode::Read);
+std::uint8_t buf[512]{};
+auto r = f.read(buf, sizeof(buf));   // StreamResult{bytes, error}
+
+// Wrap any Stream in AsyncStream for backpressure + cancellation.
+AsyncStream async(std::make_unique<FileStream>("large.wav"));
+async.on_data([](auto* data, auto n) { /* on worker thread */ });
+async.start();
+```
+
 ### HTTP — Network requests
 
 GET, POST, and file download via cpp-httplib (MIT). Use for license checks, cloud presets, update notifications.

--- a/docs/reference/streams.md
+++ b/docs/reference/streams.md
@@ -1,0 +1,135 @@
+# Streams — Unified Async I/O
+
+Pulp's streams module provides one byte-oriented interface across files, memory buffers, named pipes, TCP sockets, and HTTP response bodies. It replaces the ad-hoc `http_get` / `Socket::send` / `NamedPipe::read` surfaces with a common contract that layers cleanly:
+
+| Layer | Header | What it adds |
+|-------|--------|--------------|
+| `Stream` | `pulp/runtime/stream.hpp` | Synchronous `read`/`write`/`close`/`is_open` with a typed `StreamResult`. |
+| `AsyncStream` | `pulp/runtime/async_stream.hpp` | Background worker + callbacks, bounded write queue with backpressure, cancellation token, optional executor for callback routing. |
+| `TcpStream`, `HttpStream` | `pulp/runtime/network_stream.hpp` | Network-backed `Stream` subclasses that plug into the same `AsyncStream` wrapper without additional adapter code. |
+
+The layering matters: because `AsyncStream` only knows about `Stream`, adding a new transport (WebSocket, IPC channel, TLS sub-protocol) only requires implementing `Stream::read` and `Stream::write`. Backpressure, cancellation, and callback dispatch come for free.
+
+## `StreamResult` — why it isn't `Result<size_t>`
+
+Every `read`/`write` returns `StreamResult { size_t bytes; StreamError error; }`. Callers normally check `result.ok()`; an `Ok` result with `bytes == 0` means "end of stream" on read or "no room right now" on write.
+
+`StreamError` is deliberately small:
+
+| Value | Meaning |
+|-------|---------|
+| `Ok` | Operation succeeded. |
+| `Closed` | Stream is not open (EOF / peer hung up / never opened). |
+| `WouldBlock` | No data / no room right now. Non-blocking sockets use this. |
+| `IoError` | OS-level failure. `errno`/`GetLastError` semantics at the backend. |
+| `Invalid` | Bad argument or wrong-direction operation (e.g., writing to an `HttpStream`). |
+
+The small enum is deliberate — consumers handle the same five cases across every backend, and `AsyncStream` can translate them into callbacks uniformly.
+
+## Synchronous Stream backends
+
+### `FileStream`
+
+```cpp
+FileStream out("cache.bin", FileStream::Mode::Write);
+const std::uint8_t payload[] = "hello";
+out.write(payload, sizeof(payload));
+out.flush();
+```
+
+Modes: `Read`, `Write`, `Append`, `ReadWrite`. The stream owns a `std::FILE*` for cross-platform consistency.
+
+### `MemoryStream`
+
+An in-memory byte buffer that satisfies the `Stream` contract. Useful for tests and for round-tripping serialized state without hitting the filesystem.
+
+### `PipeStream`
+
+Wraps `NamedPipe`, which in turn uses `mkfifo` on POSIX and `CreateNamedPipe` on Windows. The pipe is opened by the caller (`create_server` / `connect_client`) and handed to `PipeStream` for the unified interface.
+
+### `TcpStream`
+
+```cpp
+TcpStream tcp;
+if (!tcp.connect("127.0.0.1", 8080)) { /* error */ }
+tcp.write(payload, sizeof(payload));
+```
+
+`connect()` performs a blocking DNS + TCP handshake. To keep that off the caller's thread, wrap in `AsyncStream`:
+
+```cpp
+auto tcp = std::make_unique<TcpStream>();
+tcp->connect("host", port);   // still blocks here; move into a worker first
+AsyncStream io(std::move(tcp));
+io.start();
+```
+
+### `HttpStream`
+
+```cpp
+auto stream = HttpStream::get("https://example.com/data.json");
+if (stream->status_code() == 200) {
+    std::uint8_t buf[4096]{};
+    while (true) {
+        auto r = stream->read(buf, sizeof(buf));
+        if (!r.ok()) break;
+        // process buf[0..r.bytes]
+    }
+}
+```
+
+HTTPS is inherited from `cpp-httplib`, which ships with mbedTLS. `HttpStream` is currently read-only: calling `write()` returns `StreamError::Invalid`. Request-body streaming is Phase 4 of the streams feature plan.
+
+## `AsyncStream` — non-blocking with backpressure
+
+`AsyncStream` wraps any `Stream` and runs a background worker that pumps `read`/`write` calls. Events surface as callbacks:
+
+```cpp
+AsyncStream::Options opts;
+opts.read_chunk = 8 * 1024;          // bytes pulled per iteration
+opts.write_high_water = 1 << 20;     // 1 MiB pending-write limit
+opts.executor = [&loop](auto fn) { loop.dispatch(std::move(fn)); };
+
+AsyncStream io(std::make_unique<FileStream>("big.wav"), opts);
+io.on_data([](const auto* d, auto n) { /* process chunk */ });
+io.on_error([](StreamError e) { /* log and degrade */ });
+io.on_close([] { /* flush UI state */ });
+io.start();
+```
+
+### Backpressure
+
+`write_async(buf, size, callback)` returns `false` when the pending byte count would exceed `write_high_water`. Callers should wait for the `on_drain` callback (fired when the queue empties) before retrying. This keeps the write queue bounded so producers cannot exhaust memory when the network is slow.
+
+### Cancellation
+
+Every `AsyncStream` owns a `CancellationToken`. Calling `cancel()` — or destroying the stream — sets the token, drains pending writes with `StreamError::Closed`, exits the worker, and fires `on_close` exactly once. The token can be shared out via `cancellation_token()` so user-level work (retries, coalescing writes) observes cancellation at the same moment the worker does.
+
+### Executor routing
+
+`AsyncStream` intentionally does *not* know about `pulp::events::EventLoop`. Keeping runtime free of event-system dependencies avoids a library link cycle. Instead, callers pass an executor closure:
+
+```cpp
+opts.executor = [loop](std::function<void()> fn) { loop->dispatch(std::move(fn)); };
+```
+
+When `executor` is empty, callbacks fire inline on the worker thread — convenient for short-lived tools and tests.
+
+## Example
+
+The `stream-demo` example in `examples/stream-demo/` exercises all three layers: synchronous file I/O, an `AsyncStream` over a pre-populated file dispatched onto a `pulp::events::EventLoop`, and an optional HTTP GET via `HttpStream`:
+
+```
+./build/examples/stream-demo/pulp-stream-demo
+./build/examples/stream-demo/pulp-stream-demo --http https://example.com
+```
+
+## Deferred: message channels (Phase 4)
+
+Phase 4 of the feature plan will add a separate `MessageChannel` abstraction for structured messages (`WebSocketChannel`, `OscChannel`, JSON-RPC over channels). Bytewise transports stay in `Stream`; message semantics layer on top.
+
+## Further reading
+
+- Feature plan: `planning/next-features-plan.md` § Feature 3
+- Ralph automation prompt: `planning/ralph-prompt-streams.md`
+- Related headers: `pulp/runtime/socket.hpp`, `pulp/runtime/http.hpp`, `pulp/runtime/named_pipe.hpp`

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -63,3 +63,6 @@ endif()
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/threejs-native-demo/CMakeLists.txt)
     add_subdirectory(threejs-native-demo)
 endif()
+
+# Streams feature demo (unified Stream / AsyncStream / HttpStream)
+add_subdirectory(stream-demo)

--- a/examples/stream-demo/CMakeLists.txt
+++ b/examples/stream-demo/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Stream feature demo — async HTTP fetch + file I/O via unified Stream API.
+add_executable(pulp-stream-demo main.cpp)
+target_link_libraries(pulp-stream-demo PRIVATE pulp::runtime pulp::events)

--- a/examples/stream-demo/main.cpp
+++ b/examples/stream-demo/main.cpp
@@ -1,0 +1,127 @@
+// Stream feature demo.
+//
+// Exercises the three layers of Pulp's Stream surface:
+//   1. Synchronous FileStream writes cache a byte payload to disk.
+//   2. Synchronous HttpStream issues an HTTP GET and reports status.
+//   3. AsyncStream wraps the FileStream, dispatches reads onto a
+//      pulp::events::EventLoop, and demonstrates backpressure + cancel.
+//
+// Run without arguments to exercise the offline path (file + async); pass
+// `--http <url>` to additionally fetch a URL.
+
+#include <pulp/events/event_loop.hpp>
+#include <pulp/runtime/async_stream.hpp>
+#include <pulp/runtime/network_stream.hpp>
+#include <pulp/runtime/stream.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace pulp::runtime;
+using namespace std::chrono_literals;
+
+namespace {
+
+void demo_file_roundtrip() {
+    auto path = std::filesystem::temp_directory_path() / "pulp_stream_demo.bin";
+    std::printf("[demo] writing sample payload to %s\n", path.string().c_str());
+
+    {
+        FileStream writer(path.string(), FileStream::Mode::Write);
+        const std::uint8_t payload[] = "hello from pulp stream demo";
+        auto w = writer.write(payload, sizeof(payload));
+        std::printf("[demo] wrote %zu bytes (ok=%d)\n", w.bytes, int(w.ok()));
+    }
+
+    FileStream reader(path.string(), FileStream::Mode::Read);
+    std::uint8_t buf[64]{};
+    auto r = reader.read(buf, sizeof(buf));
+    std::printf("[demo] read back %zu bytes: \"%s\"\n", r.bytes,
+                reinterpret_cast<const char*>(buf));
+    reader.close();
+    std::filesystem::remove(path);
+}
+
+void demo_async_stream() {
+    auto path = std::filesystem::temp_directory_path() / "pulp_stream_demo_async.bin";
+
+    // Pre-populate a file so the async read has something to chew on.
+    {
+        FileStream w(path.string(), FileStream::Mode::Write);
+        std::vector<std::uint8_t> payload(256, 42);
+        w.write(payload.data(), payload.size());
+    }
+
+    pulp::events::EventLoop loop;
+    AsyncStreamOptions opts;
+    opts.executor = [&loop](std::function<void()> fn) { loop.dispatch(std::move(fn)); };
+
+    auto file = std::make_unique<FileStream>(path.string(), FileStream::Mode::Read);
+    AsyncStream stream(std::move(file), opts);
+
+    std::mutex m;
+    std::condition_variable cv;
+    std::atomic<std::size_t> total_read{0};
+    std::atomic<bool> closed{false};
+
+    stream.on_data([&](const std::uint8_t*, std::size_t n) {
+        total_read.fetch_add(n);
+    });
+    stream.on_close([&] {
+        closed.store(true);
+        std::lock_guard<std::mutex> lock(m);
+        cv.notify_all();
+    });
+
+    stream.start();
+
+    std::unique_lock<std::mutex> lock(m);
+    cv.wait_for(lock, 1s, [&] { return closed.load(); });
+
+    std::printf("[demo] async read delivered %zu bytes; closed=%d\n",
+                total_read.load(), int(closed.load()));
+    std::filesystem::remove(path);
+}
+
+void demo_http_fetch(const std::string& url) {
+    std::printf("[demo] http GET %s\n", url.c_str());
+    auto req = HttpStream::Request{url, "GET", {}, "application/json", 10};
+    HttpStream http(req);
+    std::printf("[demo]   status_code=%d body_len=%zu transport_error=\"%s\"\n",
+                http.status_code(),
+                http.eof() ? std::size_t{0} : std::size_t{0} /* body bytes read */,
+                http.transport_error().c_str());
+
+    std::uint8_t buf[128]{};
+    std::size_t total = 0;
+    while (true) {
+        auto r = http.read(buf, sizeof(buf));
+        if (!r.ok()) break;
+        total += r.bytes;
+    }
+    std::printf("[demo]   read %zu bytes of body\n", total);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    demo_file_roundtrip();
+    demo_async_stream();
+
+    for (int i = 1; i + 1 < argc; ++i) {
+        if (std::strcmp(argv[i], "--http") == 0) {
+            demo_http_fetch(argv[i + 1]);
+            ++i;
+        }
+    }
+    return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,11 @@ add_executable(pulp-test-progress-parser test_progress_parser.cpp)
 target_link_libraries(pulp-test-progress-parser PRIVATE pulp::platform Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-progress-parser)
 
+# Stream tests (unified I/O interface)
+add_executable(pulp-test-stream test_stream.cpp)
+target_link_libraries(pulp-test-stream PRIVATE pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-stream)
+
 # Validation harness tests (Phase 2)
 add_executable(pulp-test-validation-harness test_validation_harness.cpp)
 target_link_libraries(pulp-test-validation-harness PRIVATE pulp::format Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,11 @@ add_executable(pulp-test-stream test_stream.cpp)
 target_link_libraries(pulp-test-stream PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-stream)
 
+# AsyncStream tests (Phase 2)
+add_executable(pulp-test-async-stream test_async_stream.cpp)
+target_link_libraries(pulp-test-async-stream PRIVATE pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-async-stream)
+
 # Validation harness tests (Phase 2)
 add_executable(pulp-test-validation-harness test_validation_harness.cpp)
 target_link_libraries(pulp-test-validation-harness PRIVATE pulp::format Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,11 @@ add_executable(pulp-test-async-stream test_async_stream.cpp)
 target_link_libraries(pulp-test-async-stream PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-async-stream)
 
+# Network Stream tests (Phase 3)
+add_executable(pulp-test-network-stream test_network_stream.cpp)
+target_link_libraries(pulp-test-network-stream PRIVATE pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-network-stream)
+
 # Validation harness tests (Phase 2)
 add_executable(pulp-test-validation-harness test_validation_harness.cpp)
 target_link_libraries(pulp-test-validation-harness PRIVATE pulp::format Catch2::Catch2WithMain)

--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -1,0 +1,210 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/runtime/async_stream.hpp>
+#include <pulp/runtime/stream.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+using namespace pulp::runtime;
+using namespace std::chrono_literals;
+
+namespace {
+
+// Test-only Stream that lets the test drive read availability and observe
+// writes. Synchronization is internal so the worker thread can safely block
+// waiting for data.
+class TestStream : public Stream {
+public:
+    StreamResult read(std::uint8_t* buf, std::size_t size) override {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (!open_) return StreamResult::fail(StreamError::Closed);
+        if (read_queue_.empty()) return StreamResult::fail(StreamError::WouldBlock);
+        auto& chunk = read_queue_.front();
+        auto n = std::min(size, chunk.size());
+        std::memcpy(buf, chunk.data(), n);
+        if (n == chunk.size()) {
+            read_queue_.erase(read_queue_.begin());
+        } else {
+            chunk.erase(chunk.begin(), chunk.begin() + static_cast<std::ptrdiff_t>(n));
+        }
+        return StreamResult::make(n);
+    }
+
+    StreamResult write(const std::uint8_t* buf, std::size_t size) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!open_) return StreamResult::fail(StreamError::Closed);
+        written_.insert(written_.end(), buf, buf + size);
+        return StreamResult::make(size);
+    }
+
+    void close() override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        open_ = false;
+    }
+
+    bool is_open() const override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return open_;
+    }
+
+    void push_read(std::vector<std::uint8_t> data) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        read_queue_.push_back(std::move(data));
+    }
+
+    std::vector<std::uint8_t> captured_writes() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return written_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::vector<std::vector<std::uint8_t>> read_queue_;
+    std::vector<std::uint8_t> written_;
+    bool open_ = true;
+};
+
+template <typename Pred>
+bool wait_until(Pred pred, std::chrono::milliseconds budget = 2s) {
+    auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (pred()) return true;
+        std::this_thread::sleep_for(1ms);
+    }
+    return pred();
+}
+
+}  // namespace
+
+TEST_CASE("AsyncStream delivers read data via callback", "[async_stream]") {
+    auto backing = std::make_unique<TestStream>();
+    auto* raw = backing.get();
+
+    AsyncStream stream(std::move(backing));
+
+    std::mutex m;
+    std::vector<std::uint8_t> received;
+    stream.on_data([&](const std::uint8_t* data, std::size_t n) {
+        std::lock_guard<std::mutex> lock(m);
+        received.insert(received.end(), data, data + n);
+    });
+
+    stream.start();
+    raw->push_read({1, 2, 3, 4});
+    raw->push_read({5, 6});
+
+    REQUIRE(wait_until([&] {
+        std::lock_guard<std::mutex> lock(m);
+        return received.size() >= 6;
+    }));
+
+    std::lock_guard<std::mutex> lock(m);
+    REQUIRE(received == std::vector<std::uint8_t>{1, 2, 3, 4, 5, 6});
+}
+
+TEST_CASE("AsyncStream write flushes through to Stream", "[async_stream]") {
+    auto backing = std::make_unique<TestStream>();
+    auto* raw = backing.get();
+
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<std::size_t> written_bytes{0};
+    std::atomic<bool> done{false};
+    stream.start();
+    REQUIRE(stream.write_async(reinterpret_cast<const std::uint8_t*>("hello"), 5,
+                               [&](std::size_t n, StreamError err) {
+                                   REQUIRE(err == StreamError::Ok);
+                                   written_bytes.store(n);
+                                   done.store(true);
+                               }));
+
+    REQUIRE(wait_until([&] { return done.load(); }));
+    REQUIRE(written_bytes.load() == 5);
+    auto captured = raw->captured_writes();
+    REQUIRE(captured.size() == 5);
+    REQUIRE(std::memcmp(captured.data(), "hello", 5) == 0);
+}
+
+TEST_CASE("AsyncStream honors backpressure high-water", "[async_stream]") {
+    auto backing = std::make_unique<TestStream>();
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    opts.write_high_water = 8;
+    AsyncStream stream(std::move(backing), opts);
+    // Do not start the worker — writes remain queued so we can observe
+    // the high-water behavior directly.
+
+    std::uint8_t payload[8] = {};
+    REQUIRE(stream.write_async(payload, 8));
+    REQUIRE_FALSE(stream.write_async(payload, 1));  // would exceed high-water
+    REQUIRE(stream.pending_write_bytes() == 8);
+}
+
+TEST_CASE("AsyncStream cancel drains pending writes with Closed", "[async_stream]") {
+    auto backing = std::make_unique<TestStream>();
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<int> completions{0};
+    std::atomic<StreamError> last_err{StreamError::Ok};
+
+    std::uint8_t payload[4] = {};
+    stream.start();
+    stream.cancel();  // cancel before writing
+
+    REQUIRE(stream.write_async(payload, 4, [&](std::size_t, StreamError err) {
+        last_err.store(err);
+        completions.fetch_add(1);
+    }));
+
+    REQUIRE(wait_until([&] { return completions.load() == 1; }));
+    REQUIRE(last_err.load() == StreamError::Closed);
+}
+
+TEST_CASE("AsyncStream executor routes callbacks off worker", "[async_stream]") {
+    auto backing = std::make_unique<TestStream>();
+    auto* raw = backing.get();
+
+    std::mutex m;
+    std::vector<std::function<void()>> queued;
+    AsyncStream::Options opts;
+    opts.executor = [&](std::function<void()> fn) {
+        std::lock_guard<std::mutex> lock(m);
+        queued.push_back(std::move(fn));
+    };
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<std::size_t> received{0};
+    stream.on_data([&](const std::uint8_t*, std::size_t n) { received.fetch_add(n); });
+
+    stream.start();
+    raw->push_read({9, 9, 9});
+
+    REQUIRE(wait_until([&] {
+        std::lock_guard<std::mutex> lock(m);
+        return !queued.empty();
+    }));
+
+    // Data callback was enqueued, not invoked directly.
+    REQUIRE(received.load() == 0);
+
+    // Drain the executor queue manually, as a real event loop would.
+    std::vector<std::function<void()>> to_run;
+    {
+        std::lock_guard<std::mutex> lock(m);
+        to_run.swap(queued);
+    }
+    for (auto& fn : to_run) fn();
+
+    REQUIRE(received.load() == 3);
+}

--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -171,6 +171,35 @@ TEST_CASE("AsyncStream cancel drains pending writes with Closed", "[async_stream
     REQUIRE(last_err.load() == StreamError::Closed);
 }
 
+TEST_CASE("AsyncStream cancel drains queue even before worker starts", "[async_stream]") {
+    auto backing = std::make_unique<TestStream>();
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<int> completions{0};
+    std::atomic<StreamError> last_err{StreamError::Ok};
+
+    // Queue writes *without* starting the worker, then cancel. The previous
+    // implementation dropped these callbacks; now they must all complete
+    // with Closed.
+    std::uint8_t payload[4] = {};
+    REQUIRE(stream.write_async(payload, 4, [&](std::size_t, StreamError err) {
+        last_err.store(err);
+        completions.fetch_add(1);
+    }));
+    REQUIRE(stream.write_async(payload, 4, [&](std::size_t, StreamError err) {
+        last_err.store(err);
+        completions.fetch_add(1);
+    }));
+
+    stream.cancel();
+
+    REQUIRE(wait_until([&] { return completions.load() == 2; }));
+    REQUIRE(last_err.load() == StreamError::Closed);
+    REQUIRE(stream.pending_write_bytes() == 0);
+}
+
 TEST_CASE("AsyncStream executor routes callbacks off worker", "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -1,0 +1,115 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/runtime/network_stream.hpp>
+#include <pulp/runtime/socket.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+
+using namespace pulp::runtime;
+using namespace std::chrono_literals;
+
+namespace {
+
+// Pick an ephemeral port and return the bound listener + its actual port.
+std::optional<std::uint16_t> try_bind_loopback(Socket& server, std::uint16_t port) {
+    if (!server.bind("127.0.0.1", port)) return std::nullopt;
+    if (!server.listen(1)) return std::nullopt;
+    return port;
+}
+
+}  // namespace
+
+TEST_CASE("TcpStream round-trips bytes on loopback", "[network_stream]") {
+    Socket server;
+    REQUIRE(server.create(SocketType::TCP));
+
+    std::uint16_t port = 0;
+    for (std::uint16_t candidate = 45321; candidate < 45400; ++candidate) {
+        if (auto bound = try_bind_loopback(server, candidate)) {
+            port = *bound;
+            break;
+        }
+    }
+    if (port == 0) {
+        SUCCEED("could not bind loopback port; skipping");
+        return;
+    }
+
+    std::atomic<bool> server_ready{false};
+    std::atomic<bool> server_done{false};
+    std::thread server_thread([&] {
+        server_ready.store(true);
+        auto client = server.accept();
+        if (!client) return;
+        std::uint8_t buf[32]{};
+        int n = client->receive(buf, sizeof(buf));
+        if (n > 0) {
+            client->send(buf, static_cast<std::size_t>(n));  // echo back
+        }
+        client->close();
+        server_done.store(true);
+    });
+
+    // Wait for the server to be listening before connecting.
+    while (!server_ready.load()) std::this_thread::sleep_for(1ms);
+
+    TcpStream stream;
+    REQUIRE(stream.connect("127.0.0.1", port));
+
+    const std::uint8_t payload[] = {'h', 'i', '-', 'p', 'u', 'l', 'p'};
+    auto w = stream.write(payload, sizeof(payload));
+    REQUIRE(w.ok());
+    REQUIRE(w.bytes == sizeof(payload));
+
+    std::uint8_t recv[sizeof(payload)]{};
+    std::size_t got = 0;
+    auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (got < sizeof(payload) && std::chrono::steady_clock::now() < deadline) {
+        auto r = stream.read(recv + got, sizeof(recv) - got);
+        if (r.ok()) {
+            got += r.bytes;
+        } else if (r.closed()) {
+            break;
+        } else {
+            std::this_thread::sleep_for(5ms);
+        }
+    }
+
+    REQUIRE(got == sizeof(payload));
+    REQUIRE(std::memcmp(recv, payload, sizeof(payload)) == 0);
+
+    stream.close();
+    server_thread.join();
+    REQUIRE(server_done.load());
+}
+
+TEST_CASE("HttpStream reports transport error for unreachable host", "[network_stream]") {
+    HttpStream::Request req;
+    req.url = "http://127.0.0.1:1";  // guaranteed-unused port
+    req.timeout_seconds = 1;
+    HttpStream stream(req);
+
+    // Depending on the OS, connection refused may or may not set error —
+    // but either status_code == 0 or an empty body must hold, and read()
+    // must immediately report Closed.
+    std::uint8_t buf[4]{};
+    auto r = stream.read(buf, sizeof(buf));
+    REQUIRE_FALSE(r.ok());
+    REQUIRE((r.closed() || r.error == StreamError::IoError));
+}
+
+TEST_CASE("HttpStream write is Invalid (read-only)", "[network_stream]") {
+    HttpStream::Request req;
+    req.url = "http://127.0.0.1:1";
+    req.timeout_seconds = 1;
+    HttpStream stream(req);
+
+    std::uint8_t payload[3] = {1, 2, 3};
+    auto w = stream.write(payload, sizeof(payload));
+    REQUIRE_FALSE(w.ok());
+    REQUIRE(w.error == StreamError::Invalid);
+}

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -1,0 +1,137 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/runtime/stream.hpp>
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+
+using pulp::runtime::FileStream;
+using pulp::runtime::MemoryStream;
+using pulp::runtime::Stream;
+using pulp::runtime::StreamError;
+using pulp::runtime::StreamResult;
+
+namespace {
+
+std::filesystem::path make_temp_path(const char* stem) {
+    auto dir = std::filesystem::temp_directory_path();
+    auto name = std::string(stem) + "_" + std::to_string(std::rand()) + ".bin";
+    return dir / name;
+}
+
+}  // namespace
+
+TEST_CASE("MemoryStream round-trip", "[stream]") {
+    MemoryStream s;
+    const std::uint8_t msg[] = {1, 2, 3, 4, 5};
+    auto w = s.write(msg, sizeof(msg));
+    REQUIRE(w.ok());
+    REQUIRE(w.bytes == sizeof(msg));
+    REQUIRE(s.size() == sizeof(msg));
+
+    std::uint8_t out[5]{};
+    auto r = s.read(out, sizeof(out));
+    REQUIRE(r.ok());
+    REQUIRE(r.bytes == sizeof(msg));
+    REQUIRE(std::memcmp(out, msg, sizeof(msg)) == 0);
+
+    // Reading past the end reports Closed / EOF.
+    auto eof = s.read(out, sizeof(out));
+    REQUIRE_FALSE(eof.ok());
+    REQUIRE(eof.closed());
+}
+
+TEST_CASE("MemoryStream partial read", "[stream]") {
+    MemoryStream s(std::vector<std::uint8_t>{10, 20, 30, 40});
+    std::uint8_t out[2]{};
+
+    auto r1 = s.read(out, 2);
+    REQUIRE(r1.ok());
+    REQUIRE(r1.bytes == 2);
+    REQUIRE(out[0] == 10);
+    REQUIRE(out[1] == 20);
+
+    auto r2 = s.read(out, 5);
+    REQUIRE(r2.ok());
+    REQUIRE(r2.bytes == 2);
+    REQUIRE(out[0] == 30);
+    REQUIRE(out[1] == 40);
+}
+
+TEST_CASE("MemoryStream close rejects further I/O", "[stream]") {
+    MemoryStream s;
+    s.close();
+    REQUIRE_FALSE(s.is_open());
+
+    std::uint8_t buf[4]{};
+    auto r = s.read(buf, 4);
+    REQUIRE_FALSE(r.ok());
+    REQUIRE(r.closed());
+
+    auto w = s.write(buf, 4);
+    REQUIRE_FALSE(w.ok());
+    REQUIRE(w.closed());
+}
+
+TEST_CASE("FileStream round-trip via filesystem", "[stream]") {
+    auto path = make_temp_path("pulp_stream");
+    const std::uint8_t payload[] = {'p', 'u', 'l', 'p', 0, 1, 2, 3};
+
+    {
+        FileStream w(path.string(), FileStream::Mode::Write);
+        REQUIRE(w.is_open());
+        auto r = w.write(payload, sizeof(payload));
+        REQUIRE(r.ok());
+        REQUIRE(r.bytes == sizeof(payload));
+        REQUIRE(w.flush());
+    }
+
+    {
+        FileStream r(path.string(), FileStream::Mode::Read);
+        REQUIRE(r.is_open());
+        std::uint8_t out[sizeof(payload)]{};
+        auto got = r.read(out, sizeof(out));
+        REQUIRE(got.ok());
+        REQUIRE(got.bytes == sizeof(payload));
+        REQUIRE(std::memcmp(out, payload, sizeof(payload)) == 0);
+
+        // Next read reports end-of-stream.
+        std::uint8_t tail[4]{};
+        auto eof = r.read(tail, sizeof(tail));
+        REQUIRE_FALSE(eof.ok());
+        REQUIRE(eof.closed());
+    }
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("FileStream open failure leaves stream closed", "[stream]") {
+    FileStream s;
+    REQUIRE_FALSE(s.open("/definitely/not/a/real/path/pulp_stream_test.bin",
+                         FileStream::Mode::Read));
+    REQUIRE_FALSE(s.is_open());
+    std::uint8_t buf[2]{};
+    auto r = s.read(buf, sizeof(buf));
+    REQUIRE_FALSE(r.ok());
+    REQUIRE(r.closed());
+}
+
+TEST_CASE("Stream polymorphic usage", "[stream]") {
+    MemoryStream backing;
+    Stream& s = backing;
+
+    const char* msg = "hello stream";
+    auto w = s.write(reinterpret_cast<const std::uint8_t*>(msg), std::strlen(msg));
+    REQUIRE(w.ok());
+    REQUIRE(w.bytes == std::strlen(msg));
+
+    std::array<std::uint8_t, 32> buf{};
+    auto r = s.read(buf.data(), buf.size());
+    REQUIRE(r.ok());
+    REQUIRE(r.bytes == std::strlen(msg));
+    REQUIRE(std::memcmp(buf.data(), msg, std::strlen(msg)) == 0);
+}


### PR DESCRIPTION
## Summary

Implements Phase 1–3 of Feature 3 from `planning/next-features-plan.md`: a unified `Stream` interface plus an async wrapper and network backends, so every transport (file, memory, pipe, TCP, HTTP) shares one contract.

- **Phase 1** — `core/runtime/stream.{hpp,cpp}`: `Stream` abstract + `FileStream`, `MemoryStream`, `PipeStream`. `StreamResult{bytes, error}` surface avoids exceptions on the hot path.
- **Phase 2** — `core/runtime/async_stream.{hpp,cpp}`: background worker, `on_data`/`on_error`/`on_close`/`on_drain` callbacks, bounded write queue with explicit backpressure (`write_async` returns false past the high-water mark), `CancellationToken`, and an executor hook so callbacks can land on an `EventLoop` without pulp-runtime linking pulp-events (avoids a cycle).
- **Phase 3** — `core/runtime/network_stream.{hpp,cpp}`: `TcpStream` over `Socket`, `HttpStream` over `http_get`/`http_post`. TLS is inherited from cpp-httplib/mbedTLS; request-body streaming is deferred to Phase 4.
- **Example** — `examples/stream-demo/` exercises all three layers end-to-end, including an `AsyncStream` driving reads onto a real `pulp::events::EventLoop`.
- **Docs** — new `docs/reference/streams.md` with the full API; `docs/reference/modules.md` runtime section gains a Streams entry.
- **Plan** — Phase 1–3 boxes checked in `planning/next-features-plan.md` (planning submodule commit `74e9981`).

Phase 4 (message channels / WebSocket / OSC) is intentionally deferred per the ralph prompt.

## Test plan
- [x] `pulp-test-stream` — 6 cases / 40 assertions
- [x] `pulp-test-async-stream` — 5 cases / 17 assertions (read dispatch, write flush, backpressure, cancel, executor routing)
- [x] `pulp-test-network-stream` — 3 cases / 11 assertions (loopback TCP echo, HTTP transport error, HTTP write-is-Invalid)
- [x] Full `ctest --exclude-regex AudioWorkgroup`: 2062/2065 pass. The 3 failures are pre-existing `Clipboard*` pasteboard contention under `-j` (pass when run singly, also pass on `main`)
- [x] `examples/stream-demo` runs end-to-end
- [ ] CI: macOS + Ubuntu + Windows via `shipyard ship`