### PR TITLE
Add MPE (MIDI Polyphonic Expression) full support — Phases 1-3

### DIFF
--- a/.claude/commands/create.md
+++ b/.claude/commands/create.md
@@ -11,7 +11,10 @@ If no arguments provided, ask the user for:
 1. **Name** — the plugin name (e.g., "My Synth")
 2. **Type** — effect or instrument (default: effect)
 3. **Formats** — which formats to target (default: vst3,au,clap)
+4. **MPE** — for instruments, offer `--mpe` to opt into MPE (per-note expression).
+   When set, the generated descriptor declares `supports_mpe = true` and the
+   header includes `<pulp/midi/mpe_buffer.hpp>`. See `docs/guides/mpe.md`.
 
-Then run: `./build/tools/cli/pulp create "<name>" --type <type> --formats <formats>`
+Then run: `./build/tools/cli/pulp create "<name>" --type <type> --formats <formats> [--mpe]`
 
 After scaffolding, build the new project and run its tests to verify everything works.

--- a/core/format/include/pulp/format/clap_adapter.hpp
+++ b/core/format/include/pulp/format/clap_adapter.hpp
@@ -37,6 +37,13 @@ struct PulpClapPlugin {
     // Parameter snapshot for detecting plugin-side changes during process
     std::vector<float> param_snapshot;
 
+    // MPE sidecar — populated from midi_in before each process() call when
+    // the Processor declares supports_mpe in its PluginDescriptor.
+    midi::MpeVoiceTracker mpe_tracker;
+    midi::MpeBuffer mpe_buffer;
+    int32_t mpe_current_sample_offset = 0;
+    bool mpe_enabled = false;
+
     // Preset management (optional — set by plugins that provide presets)
     std::unique_ptr<state::PresetManager> preset_manager;
 

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -2,6 +2,7 @@
 
 #include <pulp/audio/buffer.hpp>
 #include <pulp/midi/buffer.hpp>
+#include <pulp/midi/mpe_buffer.hpp>
 #include <pulp/state/store.hpp>
 #include <string>
 #include <memory>
@@ -56,6 +57,14 @@ struct PluginDescriptor {
 
     bool accepts_midi = false;   ///< true if plugin receives MIDI input
     bool produces_midi = false;  ///< true if plugin sends MIDI output
+
+    /// Opt in to MPE (MIDI Polyphonic Expression). When true, format
+    /// adapters that recognise MPE will run the inbound MIDI stream
+    /// through an MpeVoiceTracker, build an MpeBuffer for the block, and
+    /// make it available via Processor::mpe_input() during process().
+    /// The standard process() signature is unchanged; plugins that don't
+    /// set this flag see no MPE-specific behaviour.
+    bool supports_mpe = false;
 
     /// Tail time in samples (0 = no tail, -1 = infinite).
     /// Used by hosts to flush reverb/delay tails after playback stops.
@@ -189,14 +198,22 @@ public:
     /// Returns nullptr if no sidechain is connected or the bus is inactive.
     const audio::BufferView<const float>* sidechain_input() const { return sidechain_; }
 
+    /// Access the per-note MPE expression buffer for this block. Returns
+    /// nullptr unless the plugin declared PluginDescriptor::supports_mpe = true
+    /// and the host/format adapter populated it.
+    const midi::MpeBuffer* mpe_input() const { return mpe_input_; }
+
     /// @internal Framework sets these during initialization / processing.
     void set_state_store(state::StateStore* store) { state_store_ = store; }
     /// @internal
     void set_sidechain(const audio::BufferView<const float>* sc) { sidechain_ = sc; }
+    /// @internal Called by format adapters before process() when MPE is on.
+    void set_mpe_input(const midi::MpeBuffer* mpe) { mpe_input_ = mpe; }
 
 private:
     state::StateStore* state_store_ = nullptr;
     const audio::BufferView<const float>* sidechain_ = nullptr;
+    const midi::MpeBuffer* mpe_input_ = nullptr;
 };
 
 /// Factory function type — plugins provide this to create processor instances.

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -26,6 +26,14 @@ bool clap_init(const clap_plugin_t* plugin) {
     self->preset_manager = std::make_unique<state::PresetManager>(
         self->store, desc.manufacturer, desc.name);
 
+    // Wire MPE sidecar when the plugin opts in.
+    self->mpe_enabled = desc.supports_mpe;
+    if (self->mpe_enabled) {
+        midi::bind_tracker_to_buffer(
+            self->mpe_tracker, self->mpe_buffer, self->mpe_current_sample_offset);
+        runtime::log_info("CLAP: MPE sidecar enabled for '{}'", desc.name);
+    }
+
     runtime::log_info("CLAP: initialized '{}'", desc.name);
     return true;
 }
@@ -164,6 +172,21 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
     self->param_snapshot.resize(all_params.size());
     for (std::size_t i = 0; i < all_params.size(); ++i) {
         self->param_snapshot[i] = self->store.get_value(all_params[i].id);
+    }
+
+    // MPE sidecar: run inbound MIDI through the voice tracker and attach
+    // the resulting expression buffer to the processor for the duration
+    // of this process() call. Events stay sample-ordered because midi_in
+    // is already in host delivery order.
+    if (self->mpe_enabled) {
+        self->mpe_buffer.clear();
+        for (const auto& ev : midi_in) {
+            self->mpe_current_sample_offset = ev.sample_offset;
+            self->mpe_tracker.process(ev);
+        }
+        self->processor->set_mpe_input(&self->mpe_buffer);
+    } else {
+        self->processor->set_mpe_input(nullptr);
     }
 
     // Process!

--- a/core/midi/include/pulp/midi/mpe_buffer.hpp
+++ b/core/midi/include/pulp/midi/mpe_buffer.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+/// @file mpe_buffer.hpp
+/// Sample-accurate MPE expression event stream.
+///
+/// `MpeBuffer` is a parallel sidecar to `MidiBuffer`: while `MidiBuffer`
+/// carries raw MIDI 1.0 events, `MpeBuffer` carries higher-level per-note
+/// expression deltas emitted by an `MpeVoiceTracker`. Plugins that opt into
+/// MPE via `PluginDescriptor::supports_mpe` access the buffer through
+/// `Processor::mpe_input()` during `process()`.
+///
+/// A format adapter typically fills this by running the inbound
+/// `MidiBuffer` through an `MpeVoiceTracker` whose callbacks append to the
+/// buffer with the source event's `sample_offset` attached.
+
+#include <pulp/midi/mpe_voice_tracker.hpp>
+#include <cstdint>
+#include <vector>
+
+namespace pulp::midi {
+
+/// A single per-note expression event.
+///
+/// `state` is a snapshot of the note's full MPE state at the time the
+/// event was produced, so a plugin can read any field without tracking
+/// deltas itself.
+struct MpeExpressionEvent {
+    enum class Kind : uint8_t {
+        NoteOn,
+        NoteOff,
+        PitchBend,
+        Pressure,
+        Timbre,
+    };
+
+    int32_t sample_offset = 0;  ///< Sample position within the current block
+    Kind kind = Kind::NoteOn;
+    MpeNoteState state;         ///< Snapshot at event time
+};
+
+/// A time-ordered list of per-note expression events for one block.
+///
+/// Ownership and lifetime mirror `MidiBuffer`: the format adapter owns the
+/// buffer, fills it before `process()`, passes a pointer to the processor,
+/// and clears it afterwards. Not thread-safe; all access is assumed to
+/// happen on the audio thread in one producer/consumer pair.
+class MpeBuffer {
+public:
+    MpeBuffer() { events_.reserve(kInitialCapacity); }
+
+    void add(const MpeExpressionEvent& e) { events_.push_back(e); }
+    void add(MpeExpressionEvent&& e) { events_.push_back(std::move(e)); }
+
+    void clear() { events_.clear(); }
+    bool empty() const { return events_.empty(); }
+    std::size_t size() const { return events_.size(); }
+
+    void sort() {
+        std::sort(events_.begin(), events_.end(),
+            [](const MpeExpressionEvent& a, const MpeExpressionEvent& b) {
+                return a.sample_offset < b.sample_offset;
+            });
+    }
+
+    auto begin()       { return events_.begin(); }
+    auto end()         { return events_.end(); }
+    auto begin() const { return events_.begin(); }
+    auto end() const   { return events_.end(); }
+
+    const MpeExpressionEvent& operator[](std::size_t i) const { return events_[i]; }
+
+private:
+    static constexpr std::size_t kInitialCapacity = 128;
+    std::vector<MpeExpressionEvent> events_;
+};
+
+/// Convenience: install tracker callbacks that forward events to `out` with
+/// the given sample offset. Call once on the host thread during setup.
+inline void bind_tracker_to_buffer(MpeVoiceTracker& tracker,
+                                   MpeBuffer& out,
+                                   int32_t& current_sample_offset) {
+    using K = MpeExpressionEvent::Kind;
+    tracker.on_note_on = [&out, &current_sample_offset](const MpeNoteState& s) {
+        out.add({current_sample_offset, K::NoteOn, s});
+    };
+    tracker.on_note_off = [&out, &current_sample_offset](const MpeNoteState& s) {
+        out.add({current_sample_offset, K::NoteOff, s});
+    };
+    tracker.on_pitch_bend = [&out, &current_sample_offset](const MpeNoteState& s) {
+        out.add({current_sample_offset, K::PitchBend, s});
+    };
+    tracker.on_pressure = [&out, &current_sample_offset](const MpeNoteState& s) {
+        out.add({current_sample_offset, K::Pressure, s});
+    };
+    tracker.on_timbre = [&out, &current_sample_offset](const MpeNoteState& s) {
+        out.add({current_sample_offset, K::Timbre, s});
+    };
+}
+
+} // namespace pulp::midi

--- a/core/midi/include/pulp/midi/mpe_synth_voice.hpp
+++ b/core/midi/include/pulp/midi/mpe_synth_voice.hpp
@@ -1,0 +1,249 @@
+#pragma once
+
+/// @file mpe_synth_voice.hpp
+/// Helper base classes for writing MPE-aware synth voices.
+///
+/// `MpeSynthVoice` owns the per-note expression state (pitch bend,
+/// pressure, timbre) with one-pole smoothing applied per-sample, so a
+/// subclass only needs to implement note lifecycle and audio rendering.
+///
+/// `MpeVoiceAllocator<Voice>` routes `MpeExpressionEvent`s from an
+/// `MpeBuffer` to a pool of voices, with a configurable voice-steal
+/// policy when the pool is exhausted.
+
+#include <pulp/midi/mpe_buffer.hpp>
+#include <pulp/midi/mpe_voice_tracker.hpp>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace pulp::midi {
+
+/// Abstract base for a single MPE voice. Subclasses render audio and
+/// respond to note lifecycle; expression smoothing is handled here.
+class MpeSynthVoice {
+public:
+    virtual ~MpeSynthVoice() = default;
+
+    /// Called by the allocator when this voice is activated.
+    virtual void on_note_on(const MpeNoteState& note) {
+        note_ = note;
+        active_ = true;
+        // Jump targets to initial state; smoothers catch up naturally.
+        pitch_bend_target_ = note.pitch_bend_semitones;
+        pressure_target_ = note.pressure;
+        timbre_target_ = note.timbre;
+    }
+
+    /// Called by the allocator when this voice should release.
+    virtual void on_note_off() { releasing_ = true; }
+
+    /// Called once per sample before rendering. Advances smoothers.
+    void advance_smoothers() {
+        pitch_bend_ = smooth(pitch_bend_, pitch_bend_target_);
+        pressure_ = smooth(pressure_, pressure_target_);
+        timbre_ = smooth(timbre_, timbre_target_);
+    }
+
+    /// Render `num_samples` of audio into `out` (additive or replacing —
+    /// subclass decides). The allocator calls this once per block per
+    /// active voice; subclasses should call `advance_smoothers()` at the
+    /// start of each sample or block as appropriate.
+    virtual void render(float* out, int num_samples) = 0;
+
+    /// Hard-reset the voice (e.g. on allocation steal).
+    virtual void reset() {
+        active_ = false;
+        releasing_ = false;
+        pitch_bend_ = pitch_bend_target_ = 0.0f;
+        pressure_ = pressure_target_ = 0.0f;
+        timbre_ = timbre_target_ = 0.0f;
+        note_ = {};
+    }
+
+    // Expression setters — advance_smoothers() ramps current → target.
+    void set_pitch_bend(float semitones) { pitch_bend_target_ = semitones; }
+    void set_pressure(float p) { pressure_target_ = p; }
+    void set_timbre(float t) { timbre_target_ = t; }
+
+    /// Smoothing coefficient in [0, 1). 0 = instant; 0.99 = ~100 sample TC.
+    void set_smoothing(float coeff) {
+        if (coeff < 0.0f) coeff = 0.0f;
+        if (coeff >= 1.0f) coeff = 0.9999f;
+        smoothing_ = coeff;
+    }
+
+    // Getters for subclasses and the allocator.
+    bool active() const { return active_; }
+    bool releasing() const { return releasing_; }
+    uint32_t note_id() const { return note_.note_id; }
+    uint8_t channel() const { return note_.channel; }
+    uint8_t note_number() const { return note_.note; }
+    uint8_t velocity() const { return note_.velocity; }
+    float pitch_bend() const { return pitch_bend_; }
+    float pressure() const { return pressure_; }
+    float timbre() const { return timbre_; }
+
+protected:
+    void finish_release() { active_ = false; releasing_ = false; }
+
+private:
+    float smooth(float current, float target) const {
+        return smoothing_ * current + (1.0f - smoothing_) * target;
+    }
+
+    MpeNoteState note_{};
+    bool active_ = false;
+    bool releasing_ = false;
+    float pitch_bend_ = 0.0f, pitch_bend_target_ = 0.0f;
+    float pressure_ = 0.0f, pressure_target_ = 0.0f;
+    float timbre_ = 0.0f, timbre_target_ = 0.0f;
+    float smoothing_ = 0.99f;
+};
+
+/// Voice-steal policy when the pool is full.
+enum class MpeVoiceStealMode {
+    Oldest,         ///< Steal the voice that started first
+    LowestVelocity, ///< Steal the quietest voice
+    LowestPitch,    ///< Steal the lowest-note voice
+    HighestPitch,   ///< Steal the highest-note voice
+};
+
+/// Glide/legato detector — observes MPE note-on events and reports when
+/// a new note on the same channel overlaps an existing held note.
+class MpeGlideDetector {
+public:
+    /// Returns true if `note.channel` already has an active note at the
+    /// time of a new note-on, signaling a legato/glide gesture.
+    bool observe_note_on(const MpeNoteState& note) {
+        const bool glide = channel_refcount_[note.channel] > 0;
+        ++channel_refcount_[note.channel];
+        return glide;
+    }
+    void observe_note_off(const MpeNoteState& note) {
+        if (channel_refcount_[note.channel] > 0) --channel_refcount_[note.channel];
+    }
+    void reset() { channel_refcount_.fill(0); }
+    bool channel_held(uint8_t ch) const { return channel_refcount_[ch] > 0; }
+private:
+    std::array<uint8_t, 16> channel_refcount_{};
+};
+
+/// Routes MPE expression events to a pool of voices of type `Voice`
+/// (which must derive from `MpeSynthVoice`). Voices are preallocated.
+template<typename Voice>
+class MpeVoiceAllocator {
+    static_assert(std::is_base_of_v<MpeSynthVoice, Voice>,
+                  "Voice must derive from MpeSynthVoice");
+public:
+    explicit MpeVoiceAllocator(std::size_t polyphony)
+        : voices_(polyphony) {}
+
+    std::size_t polyphony() const { return voices_.size(); }
+    Voice& voice(std::size_t i) { return voices_[i]; }
+    const Voice& voice(std::size_t i) const { return voices_[i]; }
+
+    void set_steal_mode(MpeVoiceStealMode m) { steal_mode_ = m; }
+    MpeVoiceStealMode steal_mode() const { return steal_mode_; }
+
+    /// Dispatch a single MPE expression event to the voice pool.
+    void dispatch(const MpeExpressionEvent& e) {
+        switch (e.kind) {
+            case MpeExpressionEvent::Kind::NoteOn: {
+                const bool glide = glide_detector_.observe_note_on(e.state);
+                (void)glide;  // available via last_was_glide()
+                last_was_glide_ = glide;
+                Voice* v = pick_free_voice();
+                if (!v) v = steal_voice();
+                if (v) {
+                    v->reset();
+                    v->on_note_on(e.state);
+                    age_[static_cast<std::size_t>(v - voices_.data())] = ++age_counter_;
+                }
+                break;
+            }
+            case MpeExpressionEvent::Kind::NoteOff: {
+                glide_detector_.observe_note_off(e.state);
+                if (Voice* v = find_voice_by_id(e.state.note_id)) v->on_note_off();
+                break;
+            }
+            case MpeExpressionEvent::Kind::PitchBend:
+                if (Voice* v = find_voice_by_id(e.state.note_id))
+                    v->set_pitch_bend(e.state.pitch_bend_semitones);
+                break;
+            case MpeExpressionEvent::Kind::Pressure:
+                if (Voice* v = find_voice_by_id(e.state.note_id))
+                    v->set_pressure(e.state.pressure);
+                break;
+            case MpeExpressionEvent::Kind::Timbre:
+                if (Voice* v = find_voice_by_id(e.state.note_id))
+                    v->set_timbre(e.state.timbre);
+                break;
+        }
+    }
+
+    /// Dispatch all events in a buffer (in the order they appear).
+    void dispatch_all(const MpeBuffer& buf) {
+        for (const auto& e : buf) dispatch(e);
+    }
+
+    std::size_t active_count() const {
+        std::size_t n = 0;
+        for (const auto& v : voices_) if (v.active()) ++n;
+        return n;
+    }
+
+    bool last_was_glide() const { return last_was_glide_; }
+
+    void reset_all() {
+        for (auto& v : voices_) v.reset();
+        glide_detector_.reset();
+        last_was_glide_ = false;
+        age_counter_ = 0;
+    }
+
+private:
+    Voice* pick_free_voice() {
+        for (auto& v : voices_) if (!v.active()) return &v;
+        return nullptr;
+    }
+
+    Voice* steal_voice() {
+        if (voices_.empty()) return nullptr;
+        auto cmp = [this](const Voice& a, const Voice& b) -> bool {
+            switch (steal_mode_) {
+                case MpeVoiceStealMode::Oldest:
+                    return age_[&a - voices_.data()] < age_[&b - voices_.data()];
+                case MpeVoiceStealMode::LowestVelocity:
+                    return a.velocity() < b.velocity();
+                case MpeVoiceStealMode::LowestPitch:
+                    return a.note_number() < b.note_number();
+                case MpeVoiceStealMode::HighestPitch:
+                    return a.note_number() > b.note_number();
+            }
+            return false;
+        };
+        Voice* target = &voices_[0];
+        for (auto& v : voices_) if (cmp(v, *target)) target = &v;
+        return target;
+    }
+
+    Voice* find_voice_by_id(uint32_t id) {
+        for (auto& v : voices_) {
+            if (v.active() && v.note_id() == id) return &v;
+        }
+        return nullptr;
+    }
+
+    std::vector<Voice> voices_;
+    std::vector<uint64_t> age_ = std::vector<uint64_t>(voices_.size(), 0);
+    uint64_t age_counter_ = 0;
+    MpeVoiceStealMode steal_mode_ = MpeVoiceStealMode::Oldest;
+    MpeGlideDetector glide_detector_;
+    bool last_was_glide_ = false;
+};
+
+} // namespace pulp::midi

--- a/core/midi/include/pulp/midi/mpe_voice_tracker.hpp
+++ b/core/midi/include/pulp/midi/mpe_voice_tracker.hpp
@@ -1,0 +1,304 @@
+#pragma once
+
+/// @file mpe_voice_tracker.hpp
+/// MPE (MIDI Polyphonic Expression) voice tracker.
+///
+/// Tracks active notes across MPE member channels, dispatches per-note
+/// pitch bend, pressure, and timbre (CC74), and enforces zone boundaries.
+///
+/// Feed all incoming `MidiEvent`s via `process()`. The tracker classifies
+/// each event against the configured `MpeConfig`:
+///   - Note On / Note Off on a member channel → updates the per-note record
+///   - Pitch Bend on a member channel → applies to all active notes on that
+///     channel (MPE member channels hold one note at a time in typical use,
+///     but the tracker correctly handles overlap)
+///   - Channel Pressure on a member channel → pressure
+///   - CC 74 on a member channel → timbre (also aliased as `slide`)
+///
+/// Messages on manager channels are surfaced as global (zone-wide) state
+/// but do not create notes. Messages on channels outside any zone are
+/// ignored (returned `false` from `process()`).
+///
+/// All mutation is synchronous and lock-free (no allocations after
+/// construction). Safe to call from the audio thread.
+
+#include <pulp/midi/message.hpp>
+#include <pulp/midi/ump.hpp>
+#include <array>
+#include <cstdint>
+#include <functional>
+
+namespace pulp::midi {
+
+/// Per-note state maintained by `MpeVoiceTracker`.
+///
+/// Expression values are normalised:
+///   - `pitch_bend_semitones` — absolute bend in semitones (member range applied)
+///   - `pressure` — 0..1 from channel pressure (Dx status)
+///   - `timbre` — 0..1 from CC 74 (aliased as `slide`)
+struct MpeNoteState {
+    bool active = false;
+    uint8_t channel = 0;           ///< MPE member channel the note lives on
+    uint8_t note = 0;              ///< MIDI note number (0-127)
+    uint8_t velocity = 0;          ///< Note-on velocity (0-127)
+    float pitch_bend_semitones = 0.0f;  ///< Current per-note pitch bend in semitones
+    float pressure = 0.0f;         ///< Channel pressure (0..1)
+    float timbre = 0.0f;           ///< CC 74 (0..1); same value as `slide`
+    uint32_t note_id = 0;          ///< Monotonic id assigned on note-on (never 0)
+    bool is_upper_zone = false;    ///< true if this note lives in the upper zone
+};
+
+/// Tracks MPE voice state across channels.
+///
+/// Not thread-safe; intended to be owned by a single consumer (usually
+/// the plugin's `process()` path or its format-adapter preprocessor).
+class MpeVoiceTracker {
+public:
+    /// Maximum concurrently active notes the tracker can hold.
+    static constexpr std::size_t kMaxNotes = 128;
+
+    /// Default member-channel pitch-bend range (MPE spec).
+    static constexpr float kDefaultMemberBendSemitones = 48.0f;
+    /// Default manager-channel pitch-bend range (MPE spec).
+    static constexpr float kDefaultManagerBendSemitones = 2.0f;
+
+    explicit MpeVoiceTracker(MpeConfig config = MpeConfig::standard_lower())
+        : config_(config) {}
+
+    // ── Configuration ──────────────────────────────────────────────────────
+
+    void set_config(const MpeConfig& cfg) {
+        config_ = cfg;
+        reset();
+    }
+    const MpeConfig& config() const { return config_; }
+
+    /// Set the member-channel pitch-bend range in semitones (per-note bend).
+    void set_member_bend_range(float semitones) {
+        if (semitones > 0.0f) member_bend_semi_ = semitones;
+    }
+    /// Set the manager-channel pitch-bend range in semitones (zone-wide bend).
+    void set_manager_bend_range(float semitones) {
+        if (semitones > 0.0f) manager_bend_semi_ = semitones;
+    }
+    float member_bend_range() const { return member_bend_semi_; }
+    float manager_bend_range() const { return manager_bend_semi_; }
+
+    // ── Event ingestion ────────────────────────────────────────────────────
+
+    /// Process a single MIDI 1.0 event. Returns true if the event belonged
+    /// to a known MPE zone (manager or member), false otherwise. A `false`
+    /// return indicates the host should treat the event as a plain MIDI
+    /// message (no MPE routing).
+    bool process(const MidiEvent& event) {
+        const uint8_t ch = event.channel();
+
+        // Manager channel — global zone state (pitch bend, pressure, CC74).
+        if (ch == config_.lower_zone.manager_channel && config_.lower_zone.member_channels > 0) {
+            apply_manager_message(event, /*upper=*/false);
+            return true;
+        }
+        if (ch == config_.upper_zone.manager_channel && config_.upper_zone.member_channels > 0
+            && ch != config_.lower_zone.manager_channel) {
+            apply_manager_message(event, /*upper=*/true);
+            return true;
+        }
+
+        const MpeZone* zone = config_.zone_for_channel(ch);
+        if (!zone) return false;
+        const bool upper = zone->is_upper();
+
+        if (event.is_note_on() && event.velocity() > 0) {
+            add_note(ch, event.note(), event.velocity(), upper);
+            return true;
+        }
+        if (event.is_note_off() || (event.is_note_on() && event.velocity() == 0)) {
+            remove_note(ch, event.note());
+            return true;
+        }
+        if (event.is_pitch_bend()) {
+            const uint16_t raw = static_cast<uint16_t>(event.data()[1]
+                | (uint16_t(event.data()[2]) << 7));
+            const float norm = (static_cast<float>(raw) - 8192.0f) / 8192.0f;
+            update_channel_pitch_bend(ch, norm * member_bend_semi_, upper);
+            return true;
+        }
+        if ((event.data()[0] & 0xF0) == 0xD0) {
+            // Channel Pressure (status Dx): 1 data byte.
+            const float pressure = event.data()[1] / 127.0f;
+            update_channel_pressure(ch, pressure, upper);
+            return true;
+        }
+        if (event.is_cc() && event.cc_number() == 74) {
+            const float timbre = event.cc_value() / 127.0f;
+            update_channel_timbre(ch, timbre, upper);
+            return true;
+        }
+        return true;  // event belongs to zone but isn't an MPE expression (e.g. other CC)
+    }
+
+    // ── Queries ────────────────────────────────────────────────────────────
+
+    std::size_t active_count() const {
+        std::size_t n = 0;
+        for (const auto& s : notes_) if (s.active) ++n;
+        return n;
+    }
+
+    /// Find the newest active note for `channel`/`note`, or nullptr.
+    const MpeNoteState* find(uint8_t channel, uint8_t note) const {
+        const MpeNoteState* best = nullptr;
+        uint32_t best_id = 0;
+        for (const auto& s : notes_) {
+            if (!s.active) continue;
+            if (s.channel != channel || s.note != note) continue;
+            if (s.note_id > best_id) { best = &s; best_id = s.note_id; }
+        }
+        return best;
+    }
+
+    /// Iterate all active notes. Writes up to `max` records to `out` and
+    /// returns the count written.
+    std::size_t snapshot(MpeNoteState* out, std::size_t max) const {
+        std::size_t n = 0;
+        for (const auto& s : notes_) {
+            if (!s.active) continue;
+            if (n < max) out[n] = s;
+            ++n;
+        }
+        return n;
+    }
+
+    /// Direct access to the underlying slots (active flag identifies live
+    /// notes). Stable indices across calls.
+    const std::array<MpeNoteState, kMaxNotes>& slots() const { return notes_; }
+
+    // ── Zone-wide (manager) state ─────────────────────────────────────────
+
+    struct ZoneState {
+        float pitch_bend_semitones = 0.0f;  ///< Zone-wide pitch bend
+        float pressure = 0.0f;              ///< Zone-wide pressure
+        float timbre = 0.0f;                ///< Zone-wide timbre (CC 74)
+    };
+    const ZoneState& lower_zone_state() const { return lower_zone_state_; }
+    const ZoneState& upper_zone_state() const { return upper_zone_state_; }
+
+    // ── Callbacks (host-thread setup; invoked inline during process()) ────
+
+    std::function<void(const MpeNoteState&)> on_note_on;
+    std::function<void(const MpeNoteState&)> on_note_off;
+    std::function<void(const MpeNoteState&)> on_pitch_bend;
+    std::function<void(const MpeNoteState&)> on_pressure;
+    std::function<void(const MpeNoteState&)> on_timbre;
+
+    // ── Lifecycle ──────────────────────────────────────────────────────────
+
+    void reset() {
+        for (auto& s : notes_) s = {};
+        lower_zone_state_ = {};
+        upper_zone_state_ = {};
+        next_note_id_ = 1;
+    }
+
+private:
+    void add_note(uint8_t ch, uint8_t note, uint8_t velocity, bool upper) {
+        // Reuse existing slot if one matches (retrigger).
+        for (auto& s : notes_) {
+            if (s.active && s.channel == ch && s.note == note) {
+                s.velocity = velocity;
+                s.note_id = next_note_id_++;
+                s.is_upper_zone = upper;
+                if (on_note_on) on_note_on(s);
+                return;
+            }
+        }
+        for (auto& s : notes_) {
+            if (s.active) continue;
+            s = MpeNoteState{};
+            s.active = true;
+            s.channel = ch;
+            s.note = note;
+            s.velocity = velocity;
+            s.note_id = next_note_id_++;
+            s.is_upper_zone = upper;
+            // Seed with current per-channel expression so freshly-added
+            // notes inherit any running MPE state.
+            s.pitch_bend_semitones = channel_pitch_bend_[ch];
+            s.pressure = channel_pressure_[ch];
+            s.timbre = channel_timbre_[ch];
+            if (on_note_on) on_note_on(s);
+            return;
+        }
+        // Table full — drop silently (audio-thread policy).
+    }
+
+    void remove_note(uint8_t ch, uint8_t note) {
+        // Oldest matching note wins (FIFO), matching typical MPE hardware
+        // which retriggers with the newest and releases oldest-first.
+        MpeNoteState* oldest = nullptr;
+        uint32_t oldest_id = UINT32_MAX;
+        for (auto& s : notes_) {
+            if (!s.active || s.channel != ch || s.note != note) continue;
+            if (s.note_id < oldest_id) { oldest = &s; oldest_id = s.note_id; }
+        }
+        if (!oldest) return;
+        MpeNoteState copy = *oldest;
+        oldest->active = false;
+        if (on_note_off) on_note_off(copy);
+    }
+
+    void update_channel_pitch_bend(uint8_t ch, float semitones, bool upper) {
+        channel_pitch_bend_[ch] = semitones;
+        for (auto& s : notes_) {
+            if (!s.active || s.channel != ch) continue;
+            s.pitch_bend_semitones = semitones;
+            if (on_pitch_bend) on_pitch_bend(s);
+        }
+        (void)upper;
+    }
+    void update_channel_pressure(uint8_t ch, float pressure, bool upper) {
+        channel_pressure_[ch] = pressure;
+        for (auto& s : notes_) {
+            if (!s.active || s.channel != ch) continue;
+            s.pressure = pressure;
+            if (on_pressure) on_pressure(s);
+        }
+        (void)upper;
+    }
+    void update_channel_timbre(uint8_t ch, float timbre, bool upper) {
+        channel_timbre_[ch] = timbre;
+        for (auto& s : notes_) {
+            if (!s.active || s.channel != ch) continue;
+            s.timbre = timbre;
+            if (on_timbre) on_timbre(s);
+        }
+        (void)upper;
+    }
+
+    void apply_manager_message(const MidiEvent& event, bool upper) {
+        ZoneState& zs = upper ? upper_zone_state_ : lower_zone_state_;
+        if (event.is_pitch_bend()) {
+            const uint16_t raw = static_cast<uint16_t>(event.data()[1]
+                | (uint16_t(event.data()[2]) << 7));
+            const float norm = (static_cast<float>(raw) - 8192.0f) / 8192.0f;
+            zs.pitch_bend_semitones = norm * manager_bend_semi_;
+        } else if ((event.data()[0] & 0xF0) == 0xD0) {
+            zs.pressure = event.data()[1] / 127.0f;
+        } else if (event.is_cc() && event.cc_number() == 74) {
+            zs.timbre = event.cc_value() / 127.0f;
+        }
+    }
+
+    MpeConfig config_;
+    std::array<MpeNoteState, kMaxNotes> notes_{};
+    std::array<float, 16> channel_pitch_bend_{};
+    std::array<float, 16> channel_pressure_{};
+    std::array<float, 16> channel_timbre_{};
+    ZoneState lower_zone_state_{};
+    ZoneState upper_zone_state_{};
+    float member_bend_semi_ = kDefaultMemberBendSemitones;
+    float manager_bend_semi_ = kDefaultManagerBendSemitones;
+    uint32_t next_note_id_ = 1;
+};
+
+} // namespace pulp::midi

--- a/docs/guides/mpe.md
+++ b/docs/guides/mpe.md
@@ -1,0 +1,100 @@
+# MPE (MIDI Polyphonic Expression)
+
+Pulp provides first-class MPE support as an opt-in sidecar on top of the
+normal MIDI processing path. Plugins that don't opt in see the standard
+`MidiBuffer`; plugins that opt in additionally receive an `MpeBuffer`
+that carries per-note pitch bend, pressure, and timbre expressions.
+
+## Quick start
+
+```cpp
+#include <pulp/format/processor.hpp>
+#include <pulp/midi/mpe_buffer.hpp>
+#include <pulp/midi/mpe_synth_voice.hpp>
+
+class MySynth : public pulp::format::Processor {
+    pulp::midi::MpeVoiceAllocator<MyVoice> allocator_{8};
+public:
+    PluginDescriptor descriptor() const override {
+        return {
+            .name = "MySynth",
+            // ...
+            .accepts_midi  = true,
+            .supports_mpe  = true,   // ← opt in
+        };
+    }
+
+    void process(audio::BufferView<float>& out, const audio::BufferView<const float>&,
+                 midi::MidiBuffer& midi_in, midi::MidiBuffer&,
+                 const ProcessContext& ctx) override {
+        if (const auto* mpe = mpe_input()) {
+            allocator_.dispatch_all(*mpe);
+        }
+        // ... render voices into out ...
+    }
+};
+```
+
+When `supports_mpe` is `true`, a Pulp format adapter that recognises MPE
+(currently: CLAP) runs the inbound `MidiBuffer` through an
+`MpeVoiceTracker` each block, populates an `MpeBuffer`, and attaches it
+via `Processor::set_mpe_input()` before calling `process()`.
+
+## Components
+
+| Header | Class | Role |
+|--------|-------|------|
+| `pulp/midi/mpe_voice_tracker.hpp` | `MpeVoiceTracker` | Parses MIDI 1.0, tracks note/expression state by channel |
+| `pulp/midi/mpe_voice_tracker.hpp` | `MpeNoteState` | Snapshot of one note's channel, pitch bend (semitones), pressure, timbre |
+| `pulp/midi/mpe_buffer.hpp` | `MpeBuffer`, `MpeExpressionEvent` | Sample-accurate per-note expression event stream |
+| `pulp/midi/mpe_synth_voice.hpp` | `MpeSynthVoice` | Base class for voices with built-in expression smoothing |
+| `pulp/midi/mpe_synth_voice.hpp` | `MpeVoiceAllocator<Voice>` | Routes `MpeBuffer` events to a voice pool; configurable steal mode |
+| `pulp/midi/mpe_synth_voice.hpp` | `MpeGlideDetector` | Flags legato/glide gestures (overlap on same MPE member channel) |
+
+## Zone configuration
+
+`MpeConfig` (from `pulp/midi/ump.hpp`) describes which channels belong to
+which zone. The tracker defaults to the standard lower zone
+(`MpeConfig::standard_lower(15)` — manager on channel 0, members on
+channels 1–15). Use `MpeConfig::dual(lower, upper)` for dual-zone
+controllers.
+
+## Pitch-bend ranges
+
+Per-MPE spec: member channels default to ±48 semitones, manager channels
+to ±2 semitones. Override with
+`MpeVoiceTracker::set_member_bend_range()` and
+`set_manager_bend_range()` if your plugin accepts a different convention
+(e.g. `±12` for backwards-compat MIDI 1.0).
+
+## Expression mapping
+
+The tracker normalises expressions so voices see consistent units:
+
+| Source | Tracker field | Range |
+|--------|---------------|-------|
+| 14-bit pitch bend on member channel | `pitch_bend_semitones` | ±member_bend_range |
+| Channel pressure (status `Dx`) | `pressure` | 0.0–1.0 |
+| CC 74 (timbre/slide) | `timbre` | 0.0–1.0 |
+
+`MpeSynthVoice` adds per-sample smoothing so subclasses can read
+`pitch_bend()`, `pressure()`, `timbre()` directly without fighting
+zipper noise.
+
+## Example
+
+`examples/mpe-synth/` ships an MPE-aware sine synth that demonstrates
+opt-in, per-note pitch bend across the full ±48 semitone range,
+pressure-driven amplitude, and CC 74 brightness control via a one-pole
+lowpass.
+
+## Status
+
+- **Phase 1** — `MpeVoiceTracker` (landed)
+- **Phase 2** — `MpeBuffer` sidecar, `Processor::mpe_input()`, CLAP wiring (landed)
+- **Phase 3** — `MpeSynthVoice`, `MpeVoiceAllocator`, `MpeGlideDetector`, `examples/mpe-synth/` (landed)
+- **Phase 4** — MIDI 2.0 UMP native path (deferred)
+
+VST3 and AU adapters will gain the same sidecar wiring in a follow-up
+pass; the API is stable so plugins can opt in today and benefit
+automatically once the other adapters ship.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -324,6 +324,7 @@ send_sysex(inquiry);  // Send over MIDI port
 | Files | `midi_file.hpp` | Read/write Standard MIDI Files |
 | Messages | via CHOC | `ShortMessage::noteOn(0, 60, 100)` |
 | UMP | `ump.hpp` | MIDI 2.0 Universal MIDI Packets, MPE zones |
+| MPE | `mpe_voice_tracker.hpp`, `mpe_buffer.hpp`, `mpe_synth_voice.hpp` | Per-note pitch bend / pressure / timbre tracking, opt-in sidecar buffer, and voice/allocator helpers. See [docs/guides/mpe.md](../guides/mpe.md) |
 
 ---
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,6 +22,9 @@ add_subdirectory(PulpDrums)
 # Phase 7: PulpSynth (macro oscillator with DSP library)
 add_subdirectory(PulpSynth)
 
+# MPE demo: MPE-aware sine synth validating the per-note expression path
+add_subdirectory(mpe-synth)
+
 # Phase 17: PulpSampler (audio file sampler with MIDI + ADSR)
 add_subdirectory(PulpSampler)
 

--- a/examples/mpe-synth/CMakeLists.txt
+++ b/examples/mpe-synth/CMakeLists.txt
@@ -1,0 +1,29 @@
+# pulp-mpe-synth — MPE-aware sine synth example
+# Demonstrates MPE opt-in via PluginDescriptor::supports_mpe = true and
+# use of the MpeVoiceAllocator / MpeSynthVoice helpers.
+
+if(PULP_BUILD_TESTS)
+    add_executable(pulp-mpe-synth-test test_pulp_mpe_synth.cpp)
+    target_link_libraries(pulp-mpe-synth-test PRIVATE pulp::format Catch2::Catch2WithMain)
+    target_include_directories(pulp-mpe-synth-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    catch_discover_tests(pulp-mpe-synth-test)
+endif()
+
+pulp_add_plugin(PulpMpeSynth
+    FORMATS         CLAP
+    PLUGIN_NAME     "PulpMpeSynth"
+    BUNDLE_ID       "com.pulp.mpe-synth"
+    MANUFACTURER    "Pulp"
+    VERSION         "0.1.0"
+    CATEGORY        Instrument
+    PLUGIN_CODE     "PMps"
+    MANUFACTURER_CODE "Pulp"
+)
+
+if(PULP_HAS_CLAP AND APPLE)
+    add_test(
+        NAME clap-dlopen-PulpMpeSynth
+        COMMAND bash -c "python3 -c \"import ctypes; ctypes.CDLL('${CMAKE_BINARY_DIR}/CLAP/PulpMpeSynth.clap/Contents/MacOS/PulpMpeSynth'); print('OK')\""
+    )
+    set_tests_properties(clap-dlopen-PulpMpeSynth PROPERTIES LABELS "validation;clap" TIMEOUT 10)
+endif()

--- a/examples/mpe-synth/clap_entry.cpp
+++ b/examples/mpe-synth/clap_entry.cpp
@@ -1,0 +1,6 @@
+// PulpMpeSynth CLAP entry point.
+
+#include "pulp_mpe_synth.hpp"
+#include <pulp/format/clap_entry.hpp>
+
+PULP_CLAP_PLUGIN(pulp::examples::mpe_synth::create_pulp_mpe_synth)

--- a/examples/mpe-synth/pulp_mpe_synth.hpp
+++ b/examples/mpe-synth/pulp_mpe_synth.hpp
@@ -1,0 +1,155 @@
+#pragma once
+
+// pulp-mpe-synth — MPE-aware sine synth demonstrating Pulp's MPE support.
+//
+// Opts in via PluginDescriptor::supports_mpe = true. The CLAP adapter
+// builds an MpeBuffer from inbound MIDI each block and hands it to the
+// processor via Processor::mpe_input(). An MpeVoiceAllocator with
+// MpeSynthVoice subclasses handles per-note pitch bend (up to 48
+// semitones), pressure (maps to amplitude), and CC 74 timbre (maps to
+// brightness via a one-pole lowpass cutoff).
+
+#include <pulp/format/processor.hpp>
+#include <pulp/midi/mpe_buffer.hpp>
+#include <pulp/midi/mpe_synth_voice.hpp>
+#include <algorithm>
+#include <cmath>
+#include <memory>
+
+namespace pulp::examples::mpe_synth {
+
+enum Params : state::ParamID {
+    kMasterGainDb = 1,
+    kGlideMs      = 2,
+};
+
+class Voice : public midi::MpeSynthVoice {
+public:
+    void set_sample_rate(float sr) { sample_rate_ = sr > 0 ? sr : 48000.0f; }
+
+    void on_note_on(const midi::MpeNoteState& n) override {
+        midi::MpeSynthVoice::on_note_on(n);
+        // Start from silence; amp envelope follows pressure.
+        amp_ = 0.0f;
+        phase_ = 0.0f;
+        lp_ = 0.0f;
+    }
+
+    void on_note_off() override { midi::MpeSynthVoice::on_note_off(); }
+
+    void render(float* out, int num_samples) override {
+        if (!active()) return;
+        for (int i = 0; i < num_samples; ++i) {
+            advance_smoothers();
+
+            const float base_hz = 440.0f * std::pow(2.0f,
+                (static_cast<float>(note_number()) - 69.0f + pitch_bend()) / 12.0f);
+            const float increment = base_hz / sample_rate_;
+            phase_ += increment;
+            if (phase_ >= 1.0f) phase_ -= 1.0f;
+
+            const float osc = std::sin(2.0f * 3.14159265358979f * phase_);
+            // Amplitude follows pressure with a gentle attack when > 0.
+            const float amp_target = releasing() ? 0.0f : pressure();
+            amp_ += (amp_target - amp_) * 0.005f;
+
+            // Timbre → brightness via simple one-pole lowpass.
+            // alpha = 1 - timbre; higher timbre → brighter (more signal).
+            const float alpha = std::clamp(1.0f - timbre(), 0.02f, 0.98f);
+            lp_ = alpha * lp_ + (1.0f - alpha) * osc;
+            const float signal = osc - lp_ * (1.0f - timbre());
+
+            out[i] += signal * amp_ * 0.25f;
+
+            if (releasing() && amp_ < 1e-4f) {
+                finish_release();
+                break;
+            }
+        }
+    }
+
+private:
+    float sample_rate_ = 48000.0f;
+    float phase_ = 0.0f;
+    float amp_ = 0.0f;
+    float lp_ = 0.0f;
+};
+
+class Processor : public format::Processor {
+public:
+    Processor() : allocator_(8) {}
+
+    format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "PulpMpeSynth",
+            .manufacturer = "Pulp",
+            .bundle_id = "com.pulp.mpe-synth",
+            .version = "0.1.0",
+            .category = format::PluginCategory::Instrument,
+            .input_buses = {},
+            .output_buses = {{"Audio Out", 2}},
+            .accepts_midi = true,
+            .produces_midi = false,
+            .supports_mpe = true,  // ← opt-in
+            .tail_samples = -1,
+        };
+    }
+
+    void define_parameters(state::StateStore& store) override {
+        store.add_parameter({kMasterGainDb, "Gain", "dB", {-60, 12, -6, 0.1f}});
+        store.add_parameter({kGlideMs, "Glide", "ms", {0, 500, 0, 1}});
+    }
+
+    void prepare(const format::PrepareContext& ctx) override {
+        for (std::size_t i = 0; i < allocator_.polyphony(); ++i) {
+            allocator_.voice(i).set_sample_rate(static_cast<float>(ctx.sample_rate));
+            allocator_.voice(i).set_smoothing(0.995f);
+        }
+    }
+
+    void process(
+        audio::BufferView<float>& output,
+        const audio::BufferView<const float>&,
+        midi::MidiBuffer&, midi::MidiBuffer&,
+        const format::ProcessContext& ctx) override {
+
+        const std::size_t nch = output.num_channels();
+        const std::size_t ns = output.num_samples();
+        for (std::size_t ch = 0; ch < nch; ++ch) {
+            auto span = output.channel(ch);
+            for (std::size_t i = 0; i < ns; ++i) span[i] = 0.0f;
+        }
+
+        if (const auto* mpe = mpe_input()) {
+            allocator_.dispatch_all(*mpe);
+        }
+
+        const float gain_db = state().get_value(kMasterGainDb);
+        const float gain = std::pow(10.0f, gain_db / 20.0f);
+
+        if (nch == 0 || ns == 0) return;
+
+        auto left = output.channel(0);
+        for (std::size_t i = 0; i < allocator_.polyphony(); ++i) {
+            allocator_.voice(i).render(left.data(), static_cast<int>(ns));
+        }
+        for (std::size_t i = 0; i < ns; ++i) left[i] *= gain;
+        for (std::size_t ch = 1; ch < nch; ++ch) {
+            auto other = output.channel(ch);
+            for (std::size_t i = 0; i < ns; ++i) other[i] = left[i];
+        }
+        (void)ctx;
+    }
+
+    /// Exposed for tests.
+    midi::MpeVoiceAllocator<Voice>& allocator() { return allocator_; }
+
+private:
+    midi::MpeVoiceAllocator<Voice> allocator_;
+};
+
+inline std::unique_ptr<format::Processor> create_pulp_mpe_synth() {
+    return std::make_unique<Processor>();
+}
+
+} // namespace pulp::examples::mpe_synth

--- a/examples/mpe-synth/test_pulp_mpe_synth.cpp
+++ b/examples/mpe-synth/test_pulp_mpe_synth.cpp
@@ -1,0 +1,59 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "pulp_mpe_synth.hpp"
+
+using namespace pulp;
+using namespace pulp::examples::mpe_synth;
+using Kind = midi::MpeExpressionEvent::Kind;
+using Catch::Approx;
+
+TEST_CASE("PulpMpeSynth declares MPE support", "[example][mpe]") {
+    Processor p;
+    const auto d = p.descriptor();
+    REQUIRE(d.supports_mpe);
+    REQUIRE(d.accepts_midi);
+    REQUIRE(d.category == format::PluginCategory::Instrument);
+}
+
+TEST_CASE("PulpMpeSynth allocates voices from an MpeBuffer", "[example][mpe]") {
+    Processor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    format::PrepareContext pctx;
+    pctx.sample_rate = 48000;
+    pctx.max_buffer_size = 64;
+    pctx.output_channels = 2;
+    p.prepare(pctx);
+
+    midi::MpeBuffer buf;
+    midi::MpeNoteState s{}; s.active = true; s.channel = 1; s.note = 60; s.velocity = 100; s.note_id = 1;
+    buf.add({0, Kind::NoteOn, s});
+    s.pressure = 0.8f;
+    buf.add({0, Kind::Pressure, s});
+    p.set_mpe_input(&buf);
+
+    float left[64] = {}, right[64] = {};
+    float* channels[2] = {left, right};
+    audio::BufferView<float> out(channels, 2, 64);
+    audio::BufferView<const float> in(nullptr, 0, 64);
+    midi::MidiBuffer midi_in, midi_out;
+    format::ProcessContext ctx; ctx.sample_rate = 48000; ctx.num_samples = 64;
+
+    p.process(out, in, midi_in, midi_out, ctx);
+
+    REQUIRE(p.allocator().active_count() == 1);
+    // Render should have produced a nonzero signal on both channels
+    // after the amp smoother catches up to the pressure target.
+    // First block is quiet (amp starts at 0 and ramps) — do a few more.
+    for (int i = 0; i < 20; ++i) {
+        std::fill_n(left, 64, 0.0f);
+        std::fill_n(right, 64, 0.0f);
+        p.process(out, in, midi_in, midi_out, ctx);
+    }
+    float peak = 0.0f;
+    for (int i = 0; i < 64; ++i) peak = std::max(peak, std::abs(left[i]));
+    REQUIRE(peak > 0.0f);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -703,6 +703,11 @@ add_executable(pulp-test-mpe-buffer test_mpe_buffer.cpp)
 target_link_libraries(pulp-test-mpe-buffer PRIVATE pulp::format Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-mpe-buffer)
 
+# MPE synth voice helpers (voice, allocator, glide detector)
+add_executable(pulp-test-mpe-synth-voice test_mpe_synth_voice.cpp)
+target_link_libraries(pulp-test-mpe-synth-voice PRIVATE pulp::midi Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-mpe-synth-voice)
+
 # Plugin hosting tests (scanner, signal graph)
 add_executable(pulp-test-host test_host.cpp)
 target_link_libraries(pulp-test-host PRIVATE pulp::host Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -698,6 +698,11 @@ add_executable(pulp-test-mpe-voice-tracker test_mpe_voice_tracker.cpp)
 target_link_libraries(pulp-test-mpe-voice-tracker PRIVATE pulp::midi Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-mpe-voice-tracker)
 
+# MPE buffer + Processor sidecar tests
+add_executable(pulp-test-mpe-buffer test_mpe_buffer.cpp)
+target_link_libraries(pulp-test-mpe-buffer PRIVATE pulp::format Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-mpe-buffer)
+
 # Plugin hosting tests (scanner, signal graph)
 add_executable(pulp-test-host test_host.cpp)
 target_link_libraries(pulp-test-host PRIVATE pulp::host Catch2::Catch2WithMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -693,6 +693,11 @@ add_executable(pulp-test-ump-mpe test_ump_mpe.cpp)
 target_link_libraries(pulp-test-ump-mpe PRIVATE pulp::midi Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-ump-mpe)
 
+# MPE voice tracker tests
+add_executable(pulp-test-mpe-voice-tracker test_mpe_voice_tracker.cpp)
+target_link_libraries(pulp-test-mpe-voice-tracker PRIVATE pulp::midi Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-mpe-voice-tracker)
+
 # Plugin hosting tests (scanner, signal graph)
 add_executable(pulp-test-host test_host.cpp)
 target_link_libraries(pulp-test-host PRIVATE pulp::host Catch2::Catch2WithMain)

--- a/test/test_mpe_buffer.cpp
+++ b/test/test_mpe_buffer.cpp
@@ -1,0 +1,68 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <pulp/format/processor.hpp>
+#include <pulp/midi/mpe_buffer.hpp>
+
+using namespace pulp::midi;
+using Kind = MpeExpressionEvent::Kind;
+using Catch::Approx;
+
+namespace {
+MidiEvent channel_pressure(uint8_t channel, uint8_t value) {
+    return {choc::midi::ShortMessage(
+        static_cast<uint8_t>(0xD0 | (channel & 0x0F)), value, 0), 0, 0.0};
+}
+} // namespace
+
+TEST_CASE("MpeBuffer records expression events from tracker", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    MpeBuffer buffer;
+    int32_t offset = 0;
+    bind_tracker_to_buffer(tracker, buffer, offset);
+
+    offset = 10; tracker.process(MidiEvent::note_on(1, 60, 100));
+    offset = 20; tracker.process(MidiEvent::pitch_bend(1, 16383));
+    offset = 30; tracker.process(channel_pressure(1, 64));
+    offset = 40; tracker.process(MidiEvent::cc(1, 74, 100));
+    offset = 50; tracker.process(MidiEvent::note_off(1, 60));
+
+    REQUIRE(buffer.size() == 5);
+    REQUIRE(buffer[0].kind == Kind::NoteOn);
+    REQUIRE(buffer[0].sample_offset == 10);
+    REQUIRE(buffer[0].state.note == 60);
+
+    REQUIRE(buffer[1].kind == Kind::PitchBend);
+    REQUIRE(buffer[1].sample_offset == 20);
+    REQUIRE(buffer[1].state.pitch_bend_semitones == Approx(48.0f).margin(0.01f));
+
+    REQUIRE(buffer[2].kind == Kind::Pressure);
+    REQUIRE(buffer[2].state.pressure > 0.4f);
+
+    REQUIRE(buffer[3].kind == Kind::Timbre);
+    REQUIRE(buffer[3].state.timbre == Approx(100.0f / 127.0f).margin(1e-6f));
+
+    REQUIRE(buffer[4].kind == Kind::NoteOff);
+    REQUIRE(buffer[4].sample_offset == 50);
+}
+
+TEST_CASE("MpeBuffer clear and sort", "[midi][mpe]") {
+    MpeBuffer buffer;
+    buffer.add({30, Kind::Pressure, {}});
+    buffer.add({10, Kind::NoteOn, {}});
+    buffer.add({20, Kind::PitchBend, {}});
+    REQUIRE(buffer.size() == 3);
+
+    buffer.sort();
+    REQUIRE(buffer[0].sample_offset == 10);
+    REQUIRE(buffer[1].sample_offset == 20);
+    REQUIRE(buffer[2].sample_offset == 30);
+
+    buffer.clear();
+    REQUIRE(buffer.empty());
+}
+
+TEST_CASE("Processor::supports_mpe defaults to false", "[midi][mpe]") {
+    pulp::format::PluginDescriptor desc;
+    REQUIRE_FALSE(desc.supports_mpe);
+}

--- a/test/test_mpe_synth_voice.cpp
+++ b/test/test_mpe_synth_voice.cpp
@@ -1,0 +1,151 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <pulp/midi/mpe_buffer.hpp>
+#include <pulp/midi/mpe_synth_voice.hpp>
+
+using namespace pulp::midi;
+using Catch::Approx;
+using Kind = MpeExpressionEvent::Kind;
+
+namespace {
+
+struct TestVoice : public MpeSynthVoice {
+    int on_count = 0, off_count = 0;
+    int render_count = 0;
+    void on_note_on(const MpeNoteState& n) override {
+        MpeSynthVoice::on_note_on(n); ++on_count;
+    }
+    void on_note_off() override {
+        MpeSynthVoice::on_note_off(); ++off_count;
+    }
+    void render(float* out, int num_samples) override {
+        ++render_count;
+        for (int i = 0; i < num_samples; ++i) {
+            advance_smoothers();
+            out[i] = pressure();
+        }
+    }
+};
+
+MpeExpressionEvent note_on_event(uint8_t ch, uint8_t note, uint8_t vel, uint32_t id) {
+    MpeNoteState s; s.active = true; s.channel = ch; s.note = note; s.velocity = vel; s.note_id = id;
+    return {0, Kind::NoteOn, s};
+}
+MpeExpressionEvent note_off_event(uint32_t id) {
+    MpeNoteState s; s.active = false; s.note_id = id;
+    return {0, Kind::NoteOff, s};
+}
+MpeExpressionEvent pitch_bend_event(uint32_t id, float semi) {
+    MpeNoteState s; s.active = true; s.note_id = id; s.pitch_bend_semitones = semi;
+    return {0, Kind::PitchBend, s};
+}
+MpeExpressionEvent pressure_event(uint32_t id, float p) {
+    MpeNoteState s; s.active = true; s.note_id = id; s.pressure = p;
+    return {0, Kind::Pressure, s};
+}
+
+} // namespace
+
+TEST_CASE("MpeSynthVoice smoothing ramps pressure toward target", "[midi][mpe]") {
+    TestVoice v;
+    v.set_smoothing(0.9f);
+    MpeNoteState s; s.note_id = 1; s.note = 60; s.velocity = 100;
+    v.on_note_on(s);
+
+    v.set_pressure(1.0f);
+    for (int i = 0; i < 200; ++i) v.advance_smoothers();
+    REQUIRE(v.pressure() == Approx(1.0f).margin(0.05f));
+}
+
+TEST_CASE("MpeVoiceAllocator routes events to voices by note_id", "[midi][mpe]") {
+    MpeVoiceAllocator<TestVoice> alloc{4};
+
+    alloc.dispatch(note_on_event(1, 60, 100, 7));
+    REQUIRE(alloc.active_count() == 1);
+
+    alloc.dispatch(pitch_bend_event(7, 2.0f));
+    alloc.dispatch(pressure_event(7, 0.75f));
+
+    bool found = false;
+    for (std::size_t i = 0; i < alloc.polyphony(); ++i) {
+        auto& v = alloc.voice(i);
+        if (v.active() && v.note_id() == 7) {
+            // after dispatching targets and advancing once, smoothed value
+            // approaches target:
+            v.advance_smoothers();
+            REQUIRE(v.note_number() == 60);
+            REQUIRE(v.velocity() == 100);
+            found = true;
+        }
+    }
+    REQUIRE(found);
+
+    alloc.dispatch(note_off_event(7));
+    // voice is in release, still active until subclass finishes release;
+    // but TestVoice never finishes release on its own.
+    bool releasing = false;
+    for (std::size_t i = 0; i < alloc.polyphony(); ++i) {
+        if (alloc.voice(i).releasing()) releasing = true;
+    }
+    REQUIRE(releasing);
+}
+
+TEST_CASE("MpeVoiceAllocator steals oldest when full", "[midi][mpe]") {
+    MpeVoiceAllocator<TestVoice> alloc{2};
+    alloc.set_steal_mode(MpeVoiceStealMode::Oldest);
+
+    alloc.dispatch(note_on_event(1, 60, 100, 1));
+    alloc.dispatch(note_on_event(2, 64, 100, 2));
+    REQUIRE(alloc.active_count() == 2);
+
+    // Third note-on must steal one of the two — the allocator should
+    // reuse a slot rather than add a third voice.
+    alloc.dispatch(note_on_event(3, 67, 100, 3));
+    REQUIRE(alloc.polyphony() == 2);
+    REQUIRE(alloc.active_count() == 2);
+
+    // Oldest (note_id=1) should have been stolen; note_id=3 should live.
+    bool has_3 = false, has_1 = false;
+    for (std::size_t i = 0; i < alloc.polyphony(); ++i) {
+        if (!alloc.voice(i).active()) continue;
+        if (alloc.voice(i).note_id() == 3) has_3 = true;
+        if (alloc.voice(i).note_id() == 1) has_1 = true;
+    }
+    REQUIRE(has_3);
+    REQUIRE_FALSE(has_1);
+}
+
+TEST_CASE("MpeVoiceAllocator dispatches an entire MpeBuffer in order", "[midi][mpe]") {
+    MpeVoiceAllocator<TestVoice> alloc{4};
+    MpeBuffer buf;
+    buf.add(note_on_event(1, 60, 100, 11));
+    buf.add(pressure_event(11, 0.5f));
+    buf.add(note_on_event(2, 64, 90, 12));
+    alloc.dispatch_all(buf);
+    REQUIRE(alloc.active_count() == 2);
+}
+
+TEST_CASE("MpeGlideDetector flags overlap on same channel", "[midi][mpe]") {
+    MpeGlideDetector glide;
+    MpeNoteState a; a.channel = 1; a.note = 60; a.note_id = 1;
+    MpeNoteState b; b.channel = 1; b.note = 62; b.note_id = 2;
+    MpeNoteState c; c.channel = 2; c.note = 67; c.note_id = 3;
+
+    REQUIRE_FALSE(glide.observe_note_on(a));  // first note on channel — no glide
+    REQUIRE(glide.observe_note_on(b));         // overlap on same channel — glide
+    REQUIRE_FALSE(glide.observe_note_on(c));   // different channel — not glide
+
+    glide.observe_note_off(b);
+    REQUIRE(glide.channel_held(1));            // a still held (we only released b)
+    glide.observe_note_off(a);
+    REQUIRE_FALSE(glide.channel_held(1));
+}
+
+TEST_CASE("MpeVoiceAllocator reports last_was_glide", "[midi][mpe]") {
+    MpeVoiceAllocator<TestVoice> alloc{4};
+    alloc.dispatch(note_on_event(1, 60, 100, 1));
+    REQUIRE_FALSE(alloc.last_was_glide());
+    alloc.dispatch(note_on_event(1, 62, 100, 2));
+    REQUIRE(alloc.last_was_glide());
+}

--- a/test/test_mpe_voice_tracker.cpp
+++ b/test/test_mpe_voice_tracker.cpp
@@ -1,0 +1,161 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <pulp/midi/mpe_voice_tracker.hpp>
+
+using namespace pulp::midi;
+using Catch::Approx;
+
+namespace {
+
+MidiEvent channel_pressure(uint8_t channel, uint8_t value) {
+    return {choc::midi::ShortMessage(
+        static_cast<uint8_t>(0xD0 | (channel & 0x0F)), value, 0), 0, 0.0};
+}
+
+} // namespace
+
+TEST_CASE("MpeVoiceTracker allocates on member channel note-on", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+
+    REQUIRE(tracker.process(MidiEvent::note_on(1, 60, 100)));
+    REQUIRE(tracker.active_count() == 1);
+
+    const auto* n = tracker.find(1, 60);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->channel == 1);
+    REQUIRE(n->note == 60);
+    REQUIRE(n->velocity == 100);
+    REQUIRE(n->note_id != 0);
+    REQUIRE_FALSE(n->is_upper_zone);
+}
+
+TEST_CASE("MpeVoiceTracker ignores events outside any zone", "[midi][mpe]") {
+    // Only a lower zone is configured — upper manager channel 15 is outside.
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(4)};
+    // Lower zone: manager=0, member channels 1..4. Channel 5 is outside.
+    REQUIRE_FALSE(tracker.process(MidiEvent::note_on(5, 60, 100)));
+    REQUIRE(tracker.active_count() == 0);
+}
+
+TEST_CASE("MpeVoiceTracker note-off releases oldest matching note", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(MidiEvent::note_on(1, 60, 100));
+    tracker.process(MidiEvent::note_on(1, 60, 110));  // retrigger same slot
+    REQUIRE(tracker.active_count() == 1);
+
+    tracker.process(MidiEvent::note_off(1, 60));
+    REQUIRE(tracker.active_count() == 0);
+}
+
+TEST_CASE("MpeVoiceTracker note-on velocity 0 counts as note-off", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(MidiEvent::note_on(2, 64, 90));
+    REQUIRE(tracker.active_count() == 1);
+    tracker.process(MidiEvent::note_on(2, 64, 0));
+    REQUIRE(tracker.active_count() == 0);
+}
+
+TEST_CASE("MpeVoiceTracker pitch bend applies per-note via channel", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.set_member_bend_range(48.0f);
+
+    tracker.process(MidiEvent::note_on(3, 72, 100));
+    // Max pitch bend up (16383) → +48 semitones.
+    tracker.process(MidiEvent::pitch_bend(3, 16383));
+
+    const auto* n = tracker.find(3, 72);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->pitch_bend_semitones == Approx(48.0f).margin(0.01f));
+}
+
+TEST_CASE("MpeVoiceTracker channel pressure updates active note", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(MidiEvent::note_on(4, 60, 80));
+    tracker.process(channel_pressure(4, 127));
+
+    const auto* n = tracker.find(4, 60);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->pressure == Approx(1.0f).margin(1e-6f));
+}
+
+TEST_CASE("MpeVoiceTracker CC74 maps to timbre 0..1", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(MidiEvent::note_on(5, 60, 80));
+    tracker.process(MidiEvent::cc(5, 74, 64));
+
+    const auto* n = tracker.find(5, 60);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->timbre == Approx(64.0f / 127.0f).margin(1e-6f));
+}
+
+TEST_CASE("MpeVoiceTracker manager pitch bend is zone-wide", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.set_manager_bend_range(2.0f);
+
+    // Pitch bend on manager channel 0 — does not create a note; updates
+    // zone-wide state at ±2 semitones.
+    REQUIRE(tracker.process(MidiEvent::pitch_bend(0, 0)));
+    REQUIRE(tracker.active_count() == 0);
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones == Approx(-2.0f).margin(0.01f));
+}
+
+TEST_CASE("MpeVoiceTracker upper zone note-on flagged correctly", "[midi][mpe]") {
+    auto cfg = MpeConfig::dual(/*lower=*/4, /*upper=*/4);
+    MpeVoiceTracker tracker{cfg};
+
+    // Upper manager = 15, upper members = 11..14.
+    REQUIRE(tracker.process(MidiEvent::note_on(12, 72, 110)));
+    const auto* n = tracker.find(12, 72);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->is_upper_zone);
+}
+
+TEST_CASE("MpeVoiceTracker callbacks fire on lifecycle events", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+
+    int on_count = 0, off_count = 0, bend_count = 0, pressure_count = 0, timbre_count = 0;
+    tracker.on_note_on     = [&](const MpeNoteState&) { ++on_count; };
+    tracker.on_note_off    = [&](const MpeNoteState&) { ++off_count; };
+    tracker.on_pitch_bend  = [&](const MpeNoteState&) { ++bend_count; };
+    tracker.on_pressure    = [&](const MpeNoteState&) { ++pressure_count; };
+    tracker.on_timbre      = [&](const MpeNoteState&) { ++timbre_count; };
+
+    tracker.process(MidiEvent::note_on(1, 60, 100));
+    tracker.process(MidiEvent::pitch_bend(1, 8192));
+    tracker.process(channel_pressure(1, 64));
+    tracker.process(MidiEvent::cc(1, 74, 100));
+    tracker.process(MidiEvent::note_off(1, 60));
+
+    REQUIRE(on_count == 1);
+    REQUIRE(off_count == 1);
+    REQUIRE(bend_count == 1);
+    REQUIRE(pressure_count == 1);
+    REQUIRE(timbre_count == 1);
+}
+
+TEST_CASE("MpeVoiceTracker multiple channels track independently", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+
+    tracker.process(MidiEvent::note_on(1, 60, 100));
+    tracker.process(MidiEvent::note_on(2, 64, 100));
+    tracker.process(MidiEvent::note_on(3, 67, 100));
+    REQUIRE(tracker.active_count() == 3);
+
+    tracker.process(MidiEvent::pitch_bend(2, 16383));  // only channel 2 bends
+    REQUIRE(tracker.find(1, 60)->pitch_bend_semitones == Approx(0.0f).margin(0.01f));
+    REQUIRE(tracker.find(2, 64)->pitch_bend_semitones > 1.0f);
+    REQUIRE(tracker.find(3, 67)->pitch_bend_semitones == Approx(0.0f).margin(0.01f));
+}
+
+TEST_CASE("MpeVoiceTracker reset clears all state", "[midi][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(MidiEvent::note_on(1, 60, 100));
+    tracker.process(MidiEvent::pitch_bend(0, 16383));  // manager — zone state
+    REQUIRE(tracker.active_count() == 1);
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones != 0.0f);
+
+    tracker.reset();
+    REQUIRE(tracker.active_count() == 0);
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones == 0.0f);
+}

--- a/tools/cli/cmd_create.cpp
+++ b/tools/cli/cmd_create.cpp
@@ -114,8 +114,10 @@ int cmd_create(const std::vector<std::string>& args) {
     bool no_build = false;
     bool ci_mode = false;
     bool in_tree_mode = false;
+    bool mpe_mode = false;
     for (size_t i = 0; i < args.size(); ++i) {
         if (args[i] == "--type" && i + 1 < args.size()) { type = args[++i]; continue; }
+        if (args[i] == "--mpe") { mpe_mode = true; continue; }
         if (args[i] == "--template" && i + 1 < args.size()) { tmpl = args[++i]; continue; }
         if (args[i] == "--manufacturer" && i + 1 < args.size()) { manufacturer = args[++i]; continue; }
         if (args[i] == "--output" && i + 1 < args.size()) { output_path = args[++i]; continue; }
@@ -130,6 +132,7 @@ int cmd_create(const std::vector<std::string>& args) {
             std::cout << "Usage: pulp create <name> [options]\n\n";
             std::cout << "Options:\n";
             std::cout << "  --type <effect|instrument|app|bare>  Plugin type (default: effect)\n";
+            std::cout << "  --mpe                                Opt into MPE (per-note expression) — only with --type instrument\n";
             std::cout << "  --template <name>                    Use named template (e.g. gain)\n";
             std::cout << "  --manufacturer <name>                Manufacturer (default: Pulp)\n";
             std::cout << "  --output <dir>                       Override output directory\n";
@@ -378,6 +381,11 @@ int cmd_create(const std::vector<std::string>& args) {
         {"test.cpp.template", test_name},
     };
 
+    if (mpe_mode && type != "instrument") {
+        std::cerr << "Warning: --mpe has no effect unless --type instrument; ignoring.\n";
+        mpe_mode = false;
+    }
+
     for (auto& [tmpl_file, outfile] : file_map) {
         if (tmpl_file == "clap_entry.cpp.template" && formats.find("CLAP") == std::string::npos) continue;
         if (tmpl_file == "vst3_entry.cpp.template" && formats.find("VST3") == std::string::npos) continue;
@@ -390,9 +398,25 @@ int cmd_create(const std::vector<std::string>& args) {
         if (!fs::exists(tmpl_path)) continue;
         auto content = read_file_contents(tmpl_path);
         auto expanded = expand_template_str(content, vars);
+        // --mpe post-processing: add supports_mpe = true to the descriptor
+        // and insert an include for mpe_buffer.hpp in the processor header.
+        if (mpe_mode && tmpl_file == "processor.hpp.template") {
+            const std::string accepts_line = ".accepts_midi = true,";
+            auto pos = expanded.find(accepts_line);
+            if (pos != std::string::npos) {
+                expanded.insert(pos + accepts_line.size(),
+                    "\n        .supports_mpe = true,");
+            }
+            const std::string include_anchor = "#include <pulp/format/processor.hpp>";
+            pos = expanded.find(include_anchor);
+            if (pos != std::string::npos) {
+                expanded.insert(pos + include_anchor.size(),
+                    "\n#include <pulp/midi/mpe_buffer.hpp>");
+            }
+        }
         std::ofstream f(out_dir / outfile);
         f << expanded;
-        log("  Created " + outfile + "\n");
+        log("  Created " + outfile + (mpe_mode && outfile == header_name ? " (MPE)" : "") + "\n");
     }
 
     // Standalone main.cpp


### PR DESCRIPTION
## Summary
- Phase 1: `MpeVoiceTracker` parses MIDI 1.0 into per-note state (pitch bend, pressure, CC74 timbre/slide) with zone awareness and lock-free fixed-size slots.
- Phase 2: `MpeBuffer` sample-accurate sidecar + `PluginDescriptor::supports_mpe` opt-in + `Processor::mpe_input()` accessor; CLAP adapter wires the full MPE pipeline without breaking `process()`.
- Phase 3: `MpeSynthVoice` base class with per-sample smoothing, `MpeVoiceAllocator` with configurable steal modes, `MpeGlideDetector`, `examples/mpe-synth/` CLAP plugin, docs (`docs/guides/mpe.md`), and `pulp create --mpe` flag.

Phase 4 (MIDI 2.0 UMP native path) remains deferred per the ralph prompt.

## Test plan
- [x] All 34 MPE-related tests pass (`ctest -R mpe`)
- [x] `clap-dlopen-PulpMpeSynth` validation loads the example plugin
- [x] Full `cmake --build build` clean
- [x] Full `ctest --exclude-regex AudioWorkgroup` — only pre-existing Clipboard flake, passes on re-run
- [ ] Shipyard CI (Ubuntu + Windows) — pending