### PR TITLE
Address Codex P2 review on PR #135 (MPE)

### DIFF
--- a/core/midi/include/pulp/midi/mpe_synth_voice.hpp
+++ b/core/midi/include/pulp/midi/mpe_synth_voice.hpp
@@ -154,10 +154,21 @@ public:
         switch (e.kind) {
             case MpeExpressionEvent::Kind::NoteOn: {
                 const bool glide = glide_detector_.observe_note_on(e.state);
-                (void)glide;  // available via last_was_glide()
                 last_was_glide_ = glide;
                 Voice* v = pick_free_voice();
-                if (!v) v = steal_voice();
+                if (!v) {
+                    v = steal_voice();
+                    // Stealing ends the stolen note's lifetime; decrement
+                    // the glide refcount so later note-ons on its channel
+                    // aren't misclassified as legato.
+                    if (v && v->active()) {
+                        MpeNoteState released{};
+                        released.channel = v->channel();
+                        released.note = v->note_number();
+                        released.note_id = v->note_id();
+                        glide_detector_.observe_note_off(released);
+                    }
+                }
                 if (v) {
                     v->reset();
                     v->on_note_on(e.state);

--- a/core/midi/include/pulp/midi/mpe_synth_voice.hpp
+++ b/core/midi/include/pulp/midi/mpe_synth_voice.hpp
@@ -177,8 +177,14 @@ public:
                 break;
             }
             case MpeExpressionEvent::Kind::NoteOff: {
-                glide_detector_.observe_note_off(e.state);
-                if (Voice* v = find_voice_by_id(e.state.note_id)) v->on_note_off();
+                // Only decrement the glide refcount if the note is still
+                // tracked. Stolen notes were already retired (and their
+                // channel refcount decremented) in the NoteOn steal path;
+                // decrementing here again would double-count.
+                if (Voice* v = find_voice_by_id(e.state.note_id)) {
+                    glide_detector_.observe_note_off(e.state);
+                    v->on_note_off();
+                }
                 break;
             }
             case MpeExpressionEvent::Kind::PitchBend:

--- a/core/midi/include/pulp/midi/mpe_voice_tracker.hpp
+++ b/core/midi/include/pulp/midi/mpe_voice_tracker.hpp
@@ -195,6 +195,9 @@ public:
 
     void reset() {
         for (auto& s : notes_) s = {};
+        channel_pitch_bend_.fill(0.0f);
+        channel_pressure_.fill(0.0f);
+        channel_timbre_.fill(0.0f);
         lower_zone_state_ = {};
         upper_zone_state_ = {};
         next_note_id_ = 1;

--- a/test/test_mpe_synth_voice.cpp
+++ b/test/test_mpe_synth_voice.cpp
@@ -150,6 +150,28 @@ TEST_CASE("MpeVoiceAllocator reports last_was_glide", "[midi][mpe]") {
     REQUIRE(alloc.last_was_glide());
 }
 
+TEST_CASE("MpeVoiceAllocator steal does not double-decrement glide on later note-off", "[midi][mpe]") {
+    // Regression for PR #138 Codex P2: if a voice is stolen mid-life, the
+    // deferred NoteOff for that note must not decrement the glide
+    // refcount again (its channel is already released by the steal path).
+    MpeVoiceAllocator<TestVoice> alloc{1};
+    alloc.set_steal_mode(MpeVoiceStealMode::Oldest);
+
+    // note_id=1 on channel 1; gets stolen by note_id=2 on the same channel.
+    alloc.dispatch(note_on_event(1, 60, 100, 1));
+    alloc.dispatch(note_on_event(1, 62, 100, 2));   // steals id=1, legato
+    REQUIRE(alloc.last_was_glide());
+
+    // Host now delivers the note-off for the stolen note (id=1). It must
+    // not drive the channel refcount below the live note's contribution.
+    alloc.dispatch(note_off_event(1));
+
+    // A further note-on on the same channel while id=2 is still held
+    // must still be flagged as glide.
+    alloc.dispatch(note_on_event(1, 64, 100, 3));
+    REQUIRE(alloc.last_was_glide());
+}
+
 TEST_CASE("MpeVoiceAllocator steal path decrements glide refcount", "[midi][mpe]") {
     // Regression for Codex P2: when a steal retires a held note on some
     // channel, subsequent note-ons on that channel must not be flagged as

--- a/test/test_mpe_synth_voice.cpp
+++ b/test/test_mpe_synth_voice.cpp
@@ -149,3 +149,19 @@ TEST_CASE("MpeVoiceAllocator reports last_was_glide", "[midi][mpe]") {
     alloc.dispatch(note_on_event(1, 62, 100, 2));
     REQUIRE(alloc.last_was_glide());
 }
+
+TEST_CASE("MpeVoiceAllocator steal path decrements glide refcount", "[midi][mpe]") {
+    // Regression for Codex P2: when a steal retires a held note on some
+    // channel, subsequent note-ons on that channel must not be flagged as
+    // glide because the stolen note's refcount stayed elevated.
+    MpeVoiceAllocator<TestVoice> alloc{1};
+    alloc.set_steal_mode(MpeVoiceStealMode::Oldest);
+
+    alloc.dispatch(note_on_event(3, 60, 100, 1));   // held on channel 3
+    alloc.dispatch(note_on_event(4, 64, 100, 2));   // steals id=1, channel 3 no longer held
+    REQUIRE(alloc.active_count() == 1);
+
+    // Now a note on channel 3 should be fresh, not flagged as glide.
+    alloc.dispatch(note_on_event(3, 67, 100, 3));
+    REQUIRE_FALSE(alloc.last_was_glide());
+}

--- a/test/test_mpe_voice_tracker.cpp
+++ b/test/test_mpe_voice_tracker.cpp
@@ -159,3 +159,20 @@ TEST_CASE("MpeVoiceTracker reset clears all state", "[midi][mpe]") {
     REQUIRE(tracker.active_count() == 0);
     REQUIRE(tracker.lower_zone_state().pitch_bend_semitones == 0.0f);
 }
+
+TEST_CASE("MpeVoiceTracker reset clears per-channel expression caches", "[midi][mpe]") {
+    // Regression for Codex P2: notes added after reset() must not inherit
+    // stale bend/pressure/timbre values from a previous session.
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(MidiEvent::pitch_bend(1, 16383));  // member pitch bend
+    tracker.process(channel_pressure(1, 127));
+    tracker.process(MidiEvent::cc(1, 74, 127));
+    tracker.reset();
+
+    tracker.process(MidiEvent::note_on(1, 60, 100));
+    const auto* n = tracker.find(1, 60);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->pitch_bend_semitones == Approx(0.0f).margin(1e-6f));
+    REQUIRE(n->pressure == Approx(0.0f).margin(1e-6f));
+    REQUIRE(n->timbre == Approx(0.0f).margin(1e-6f));
+}


### PR DESCRIPTION
## Summary
Two small correctness fixes Codex flagged on the MPE PR after it merged.

1. **`MpeVoiceTracker::reset()` now clears per-channel expression caches.** Without this, notes added after `reset()` or `set_config()` inherited stale bend/pressure/timbre.
2. **`MpeVoiceAllocator::dispatch()` NoteOn steal path notifies the glide detector** of the stolen note's channel release. Otherwise subsequent note-ons on that channel were misclassified as legato.

## Test plan
- [x] `pulp-test-mpe-voice-tracker` — 13 cases / 43 assertions, incl. new "reset clears per-channel expression caches"
- [x] `pulp-test-mpe-synth-voice` — 7 cases / 21 assertions, incl. new "steal path decrements glide refcount"
- [ ] Shipyard ship — mac + Namespace Linux/Windows