### PR TITLE
ViewBridge: Processor editor lifecycle + VST3/CLAP wiring (Feature 1, Phase 1 + core Phase 2)

### DIFF
--- a/core/format/CMakeLists.txt
+++ b/core/format/CMakeLists.txt
@@ -8,12 +8,14 @@ target_include_directories(pulp-format
 )
 
 target_sources(pulp-format PRIVATE
+    src/format.cpp
     src/registry.cpp
     src/headless.cpp
     src/validation_harness.cpp
     src/aax_model.cpp
     src/host_type.cpp
     src/ara.cpp
+    src/view_bridge.cpp
 )
 
 target_link_libraries(pulp-format

--- a/core/format/include/pulp/format/clap_adapter.hpp
+++ b/core/format/include/pulp/format/clap_adapter.hpp
@@ -10,9 +10,8 @@
 
 // View includes only when building plugin targets (not the shared format lib)
 #ifdef PULP_CLAP_GUI
+#include <pulp/format/view_bridge.hpp>
 #include <pulp/view/plugin_view_host.hpp>
-#include <pulp/view/scripted_ui.hpp>
-#include <pulp/view/view.hpp>
 #endif
 
 namespace pulp::format::clap_adapter {
@@ -47,12 +46,13 @@ struct PulpClapPlugin {
     // Preset management (optional — set by plugins that provide presets)
     std::unique_ptr<state::PresetManager> preset_manager;
 
-    // Editor state (created on GUI create, destroyed on GUI destroy)
-    // Only available in plugin targets that link pulp::view
+    // Editor state (created on GUI create, destroyed on GUI destroy).
+    // `bridge` owns the view tree and dispatches Processor lifecycle
+    // callbacks (on_view_opened/closed/resized). editor_host is the
+    // platform-native window surface that hosts bridge->view().
 #ifdef PULP_CLAP_GUI
-    std::unique_ptr<view::View> editor_root;
+    std::unique_ptr<ViewBridge> bridge;
     std::unique_ptr<view::PluginViewHost> editor_host;
-    std::unique_ptr<view::ScriptedUiSession> scripted_ui;
 #endif
     bool editor_visible = false;
 };

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -273,22 +273,27 @@ inline bool gui_create(const clap_plugin_t* plugin, const char*, bool) {
     if (!p->processor || !p->processor->has_editor()) return false;
 
     std::string editor_error;
-    auto editor_ui = build_editor_ui(p->store, false, &editor_error);
-    p->editor_root = std::move(editor_ui.root);
-    p->scripted_ui = std::move(editor_ui.scripted_ui);
-    if (!p->editor_root) return false;
+    p->bridge = std::make_unique<ViewBridge>(*p->processor, p->store);
+    if (!p->bridge->open(&editor_error)) {
+        runtime::log_error("CLAP editor: bridge->open failed ({})", editor_error);
+        p->bridge.reset();
+        return false;
+    }
 
-    auto [w, h] = p->processor->editor_size();
+    const auto& hints = p->bridge->size_hints();
     view::PluginViewHost::Options opts;
-    opts.size = {w, h};
+    opts.size = {hints.preferred_width, hints.preferred_height};
     opts.use_gpu = false;  // Start with CoreGraphics; GPU opt-in later
 
-    p->editor_host = view::PluginViewHost::create(*p->editor_root, opts);
+    p->editor_host = view::PluginViewHost::create(*p->bridge->view(), opts);
     if (p->editor_host) {
         runtime::log_info("CLAP editor: created ({}x{}, mode={})",
-                          w, h, editor_ui.uses_script_ui ? "scripted" : "autoui");
+                          hints.preferred_width, hints.preferred_height,
+                          p->bridge->uses_script_ui() ? "scripted" : "autoui");
     } else {
-        runtime::log_error("CLAP editor: failed to create host ({})", editor_error);
+        runtime::log_error("CLAP editor: failed to create host");
+        p->bridge->close();
+        p->bridge.reset();
     }
     return p->editor_host != nullptr;
 }
@@ -296,8 +301,10 @@ inline bool gui_create(const clap_plugin_t* plugin, const char*, bool) {
 inline void gui_destroy(const clap_plugin_t* plugin) {
     auto* p = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
     p->editor_host.reset();
-    p->scripted_ui.reset();
-    p->editor_root.reset();
+    if (p->bridge) {
+        p->bridge->close();
+        p->bridge.reset();
+    }
     p->editor_visible = false;
 }
 
@@ -308,9 +315,15 @@ inline bool gui_set_scale(const clap_plugin_t*, double) {
 inline bool gui_get_size(const clap_plugin_t* plugin, uint32_t* width, uint32_t* height) {
     auto* p = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
     if (!p->processor) return false;
-    auto [w, h] = p->processor->editor_size();
-    *width = w;
-    *height = h;
+    if (p->bridge) {
+        const auto& h = p->bridge->size_hints();
+        *width = h.preferred_width;
+        *height = h.preferred_height;
+    } else {
+        auto [w, ht] = p->processor->editor_size();
+        *width = w;
+        *height = ht;
+    }
     return true;
 }
 
@@ -326,6 +339,7 @@ inline bool gui_adjust_size(const clap_plugin_t*, uint32_t*, uint32_t*) {
 
 inline bool gui_set_size(const clap_plugin_t* plugin, uint32_t width, uint32_t height) {
     auto* p = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
+    if (p->bridge) p->bridge->resize(width, height);
     if (p->editor_host) {
         p->editor_host->set_size(width, height);
         return true;

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -351,23 +351,27 @@ inline bool gui_set_parent(const clap_plugin_t* plugin, const clap_window_t* win
     auto* p = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
     if (!p->editor_host) return false;
 
+    bool attached = false;
 #ifdef __APPLE__
     if (strcmp(window->api, CLAP_WINDOW_API_COCOA) == 0) {
         p->editor_host->attach_to_parent(window->cocoa);
-        return true;
+        attached = true;
     }
 #elif defined(_WIN32)
     if (strcmp(window->api, CLAP_WINDOW_API_WIN32) == 0) {
         p->editor_host->attach_to_parent(window->win32);
-        return true;
+        attached = true;
     }
 #elif defined(__linux__)
     if (strcmp(window->api, CLAP_WINDOW_API_X11) == 0) {
         p->editor_host->attach_to_parent(reinterpret_cast<void*>(window->x11));
-        return true;
+        attached = true;
     }
 #endif
-    return false;
+    if (attached && p->bridge) {
+        p->bridge->notify_attached();
+    }
+    return attached;
 }
 
 inline bool gui_set_transient(const clap_plugin_t*, const clap_window_t*) {

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -4,11 +4,24 @@
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/mpe_buffer.hpp>
 #include <pulp/state/store.hpp>
+#include <pulp/view/view.hpp>
 #include <string>
 #include <memory>
 #include <vector>
 
 namespace pulp::format {
+
+/// Editor size hints (in logical pixels). preferred is used for the
+/// initial window size; min/max bound interactive resizing. A zero
+/// max dimension means unbounded in that axis.
+struct ViewSize {
+    uint32_t preferred_width = 400;
+    uint32_t preferred_height = 300;
+    uint32_t min_width = 0;
+    uint32_t min_height = 0;
+    uint32_t max_width = 0;   ///< 0 = unbounded
+    uint32_t max_height = 0;  ///< 0 = unbounded
+};
 
 /// Plugin category — determines bus layout expectations and DAW behavior.
 enum class PluginCategory {
@@ -188,6 +201,38 @@ public:
 
     /// Preferred editor window size in logical pixels.
     virtual std::pair<uint32_t, uint32_t> editor_size() const { return {400, 300}; }
+
+    /// Return the full view size hints (preferred/min/max). Default builds
+    /// a ViewSize from `editor_size()` with no min/max bounds. Override for
+    /// resizable editors that need explicit bounds.
+    virtual ViewSize view_size() const {
+        auto [w, h] = editor_size();
+        return ViewSize{w, h, 0, 0, 0, 0};
+    }
+
+    /// Create a custom view for this processor. Default returns nullptr,
+    /// which signals the framework to build the default editor (scripted UI
+    /// if configured, otherwise AutoUi from registered parameters).
+    ///
+    /// Override to return a fully custom `view::View` tree. The returned
+    /// view is owned by the `ViewBridge` and destroyed when the editor
+    /// closes. This method may be called multiple times during the lifetime
+    /// of the processor (one per attached editor window).
+    ///
+    virtual std::unique_ptr<view::View> create_view() { return nullptr; }
+
+    /// Called after a view has been constructed and attached. Runs on the
+    /// host/UI thread. Safe to read state and register UI listeners.
+    virtual void on_view_opened(view::View& /*view*/) {}
+
+    /// Called immediately before a view is destroyed. Runs on the UI thread.
+    /// Use to unregister listeners; do not assume the view is still usable
+    /// for drawing after this returns.
+    virtual void on_view_closed(view::View& /*view*/) {}
+
+    /// Called when the host resizes the editor window. Dimensions are in
+    /// logical pixels. Runs on the UI thread.
+    virtual void on_view_resized(view::View& /*view*/, uint32_t /*w*/, uint32_t /*h*/) {}
 
     /// Access the parameter state store.
     /// Use state().get_value(id) to read parameter values in process().

--- a/core/format/include/pulp/format/view_bridge.hpp
+++ b/core/format/include/pulp/format/view_bridge.hpp
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <pulp/format/processor.hpp>
+#include <pulp/view/view.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pulp::view { class ScriptedUiSession; }
+
+namespace pulp::format {
+
+/// Role of a view attached to a ViewBridge. The primary editor is
+/// `Editor`; auxiliary panels (component inspector, remote preview)
+/// attach as secondary views with a matching role.
+enum class ViewRole {
+    Editor,
+    Inspector,
+    Remote,
+};
+
+/// Manages editor-view lifecycle for a single `Processor` across all
+/// plugin formats. A ViewBridge owns the constructed view tree, tracks
+/// its attached/detached state, and dispatches lifecycle callbacks
+/// (`on_view_opened`, `on_view_closed`, `on_view_resized`) to the
+/// processor.
+///
+/// One processor can have multiple ViewBridges (Phase 2: multi-view):
+/// each host editor window, the inspector, and any remote views each
+/// own their own primary View instance. Parameter binding is shared
+/// through the processor's `StateStore`, so all attached views stay in
+/// sync automatically.
+///
+/// Construction is cheap — no view is built until `open()` is called.
+/// Destruction closes the view if it is still open.
+class ViewBridge {
+public:
+    struct Options {
+        bool enable_hot_reload = false;  ///< Poll scripted UI + theme.json for changes
+        ViewRole role = ViewRole::Editor;
+    };
+
+    ViewBridge(Processor& processor, state::StateStore& store);
+    ViewBridge(Processor& processor, state::StateStore& store, Options options);
+    ~ViewBridge();
+
+    ViewBridge(const ViewBridge&) = delete;
+    ViewBridge& operator=(const ViewBridge&) = delete;
+
+    /// Build the view and fire `on_view_opened`. Returns false if view
+    /// construction failed; inspect `last_error()` for details. Calling
+    /// `open()` on an already-open bridge is a no-op that returns true.
+    bool open(std::string* error = nullptr);
+
+    /// Destroy the view and fire `on_view_closed`. No-op if not open.
+    void close();
+
+    /// Notify the bridge that the host resized the editor. Dispatches
+    /// `on_view_resized` and stores the new size.
+    void resize(uint32_t width, uint32_t height);
+
+    bool is_open() const { return view_ != nullptr; }
+    ViewRole role() const { return options_.role; }
+    view::View* view() { return view_.get(); }
+    const view::View* view() const { return view_.get(); }
+    bool uses_script_ui() const { return uses_script_ui_; }
+
+    /// Access the scripted UI session, if the primary view was built from
+    /// a JS script (via `PULP_UI_SCRIPT_PATH`). Returns nullptr otherwise,
+    /// including when the processor supplied a custom `create_view()`.
+    view::ScriptedUiSession* scripted_ui() { return scripted_ui_.get(); }
+    const view::ScriptedUiSession* scripted_ui() const { return scripted_ui_.get(); }
+
+    uint32_t width() const { return width_; }
+    uint32_t height() const { return height_; }
+    const ViewSize& size_hints() const { return size_hints_; }
+
+    const std::string& last_error() const { return last_error_; }
+
+    /// Attach a secondary view (e.g. inspector, remote) to this bridge.
+    /// The bridge takes ownership. Returns a non-owning pointer the caller
+    /// can use to reference the attached view. Multiple secondary views
+    /// may share the same role.
+    view::View* attach_secondary_view(std::unique_ptr<view::View> view, ViewRole role);
+
+    /// Detach and destroy a previously-attached secondary view. Returns
+    /// true if the view was found and removed.
+    bool detach_secondary_view(view::View* view);
+
+    /// Total number of attached views (primary + secondary). Zero when
+    /// not open and no secondaries are attached.
+    size_t view_count() const;
+
+    /// Access an attached view by index. Index 0 is the primary view
+    /// (if open); indices >=1 are secondary views in attach order.
+    /// Returns nullptr if index is out of range.
+    view::View* view_at(size_t index);
+
+    /// Role of the view at `index`. Returns `Editor` when out of range.
+    ViewRole role_at(size_t index) const;
+
+private:
+    Processor& processor_;
+    state::StateStore& store_;
+    Options options_;
+
+    std::unique_ptr<view::View> view_;
+    std::unique_ptr<view::ScriptedUiSession> scripted_ui_;
+    bool uses_script_ui_ = false;
+
+    struct Secondary {
+        std::unique_ptr<view::View> view;
+        ViewRole role;
+    };
+    std::vector<Secondary> secondaries_;
+
+    ViewSize size_hints_;
+    uint32_t width_ = 0;
+    uint32_t height_ = 0;
+    std::string last_error_;
+};
+
+} // namespace pulp::format

--- a/core/format/include/pulp/format/view_bridge.hpp
+++ b/core/format/include/pulp/format/view_bridge.hpp
@@ -47,12 +47,25 @@ public:
     ViewBridge(const ViewBridge&) = delete;
     ViewBridge& operator=(const ViewBridge&) = delete;
 
-    /// Build the view and fire `on_view_opened`. Returns false if view
-    /// construction failed; inspect `last_error()` for details. Calling
-    /// `open()` on an already-open bridge is a no-op that returns true.
+    /// Build the view. Returns false if view construction failed; inspect
+    /// `last_error()` for details. Calling `open()` on an already-open
+    /// bridge is a no-op that returns true.
+    ///
+    /// `on_view_opened` is **not** fired here. The adapter must call
+    /// `notify_attached()` once the view has been attached to its host
+    /// parent window. This split avoids firing `on_view_opened` before
+    /// the host attach step succeeds.
     bool open(std::string* error = nullptr);
 
-    /// Destroy the view and fire `on_view_closed`. No-op if not open.
+    /// Fire `on_view_opened(view)` — called by the adapter once the
+    /// view has been attached to its native parent. Idempotent: a
+    /// second call after successful attach is a no-op.
+    void notify_attached();
+
+    /// Destroy the view. Fires `on_view_closed` only if
+    /// `notify_attached()` previously fired, so open/close dispatch
+    /// stays balanced even when host attachment failed after `open()`.
+    /// No-op if not open.
     void close();
 
     /// Notify the bridge that the host resized the editor. Dispatches
@@ -107,6 +120,7 @@ private:
     std::unique_ptr<view::View> view_;
     std::unique_ptr<view::ScriptedUiSession> scripted_ui_;
     bool uses_script_ui_ = false;
+    bool attached_ = false;  ///< true between notify_attached() and close()
 
     struct Secondary {
         std::unique_ptr<view::View> view;

--- a/core/format/include/pulp/format/vst3_plug_view.hpp
+++ b/core/format/include/pulp/format/vst3_plug_view.hpp
@@ -11,16 +11,17 @@
 
 #ifdef PULP_VST3_GUI
 
+#include <pulp/format/view_bridge.hpp>
 #include <pulp/view/plugin_view_host.hpp>
-#include <pulp/view/scripted_ui.hpp>
 
 // VST3 SDK
 #include <public.sdk/source/common/pluginview.h>
 
 namespace pulp::format::vst3 {
 
-// IPlugView implementation that hosts an AutoUi-generated view tree
-// inside the DAW's editor window via PluginViewHost
+// IPlugView implementation that owns a ViewBridge. The bridge builds the
+// view tree (custom create_view() or scripted/AutoUi fallback), dispatches
+// lifecycle callbacks on the Processor, and tracks secondary views.
 class PulpPlugView : public Steinberg::CPluginView {
 public:
     PulpPlugView(Processor& processor, state::StateStore& store);
@@ -35,9 +36,8 @@ public:
 private:
     Processor& processor_;
     state::StateStore& store_;
-    std::unique_ptr<view::View> editor_root_;
+    ViewBridge bridge_;
     std::unique_ptr<view::PluginViewHost> editor_host_;
-    std::unique_ptr<view::ScriptedUiSession> scripted_ui_;
 };
 
 } // namespace pulp::format::vst3

--- a/core/format/src/view_bridge.cpp
+++ b/core/format/src/view_bridge.cpp
@@ -44,14 +44,22 @@ bool ViewBridge::open(std::string* error) {
     size_hints_ = processor_.view_size();
     width_ = size_hints_.preferred_width;
     height_ = size_hints_.preferred_height;
-
-    processor_.on_view_opened(*view_);
+    attached_ = false;
     return true;
+}
+
+void ViewBridge::notify_attached() {
+    if (!view_ || attached_) return;
+    attached_ = true;
+    processor_.on_view_opened(*view_);
 }
 
 void ViewBridge::close() {
     if (!view_) return;
-    processor_.on_view_closed(*view_);
+    if (attached_) {
+        processor_.on_view_closed(*view_);
+        attached_ = false;
+    }
     scripted_ui_.reset();
     view_.reset();
     uses_script_ui_ = false;
@@ -61,7 +69,7 @@ void ViewBridge::close() {
 void ViewBridge::resize(uint32_t width, uint32_t height) {
     width_ = width;
     height_ = height;
-    if (view_) {
+    if (view_ && attached_) {
         processor_.on_view_resized(*view_, width, height);
     }
 }

--- a/core/format/src/view_bridge.cpp
+++ b/core/format/src/view_bridge.cpp
@@ -1,0 +1,108 @@
+#include <pulp/format/view_bridge.hpp>
+#include <pulp/format/editor_ui.hpp>
+#include <pulp/view/scripted_ui.hpp>
+#include <pulp/view/view.hpp>
+
+namespace pulp::format {
+
+ViewBridge::ViewBridge(Processor& processor, state::StateStore& store)
+    : ViewBridge(processor, store, Options{}) {}
+
+ViewBridge::ViewBridge(Processor& processor, state::StateStore& store, Options options)
+    : processor_(processor),
+      store_(store),
+      options_(options),
+      size_hints_(processor.view_size()) {
+    width_ = size_hints_.preferred_width;
+    height_ = size_hints_.preferred_height;
+}
+
+ViewBridge::~ViewBridge() {
+    close();
+}
+
+bool ViewBridge::open(std::string* error) {
+    if (view_) return true;
+    last_error_.clear();
+
+    // First chance: let the processor supply a fully custom view.
+    auto custom = processor_.create_view();
+    if (custom) {
+        view_ = std::move(custom);
+    } else {
+        // Fall back to the scripted-UI or AutoUi default.
+        auto instance = build_editor_ui(store_, options_.enable_hot_reload, &last_error_);
+        if (!instance.root) {
+            if (error) *error = last_error_.empty() ? "ViewBridge: failed to build editor UI" : last_error_;
+            return false;
+        }
+        view_ = std::move(instance.root);
+        scripted_ui_ = std::move(instance.scripted_ui);
+        uses_script_ui_ = instance.uses_script_ui;
+    }
+
+    size_hints_ = processor_.view_size();
+    width_ = size_hints_.preferred_width;
+    height_ = size_hints_.preferred_height;
+
+    processor_.on_view_opened(*view_);
+    return true;
+}
+
+void ViewBridge::close() {
+    if (!view_) return;
+    processor_.on_view_closed(*view_);
+    scripted_ui_.reset();
+    view_.reset();
+    uses_script_ui_ = false;
+    secondaries_.clear();
+}
+
+void ViewBridge::resize(uint32_t width, uint32_t height) {
+    width_ = width;
+    height_ = height;
+    if (view_) {
+        processor_.on_view_resized(*view_, width, height);
+    }
+}
+
+view::View* ViewBridge::attach_secondary_view(std::unique_ptr<view::View> v, ViewRole role) {
+    if (!v) return nullptr;
+    auto* raw = v.get();
+    secondaries_.push_back({std::move(v), role});
+    return raw;
+}
+
+bool ViewBridge::detach_secondary_view(view::View* target) {
+    for (auto it = secondaries_.begin(); it != secondaries_.end(); ++it) {
+        if (it->view.get() == target) {
+            secondaries_.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+size_t ViewBridge::view_count() const {
+    return (view_ ? 1u : 0u) + secondaries_.size();
+}
+
+view::View* ViewBridge::view_at(size_t index) {
+    if (view_) {
+        if (index == 0) return view_.get();
+        --index;
+    }
+    if (index < secondaries_.size()) return secondaries_[index].view.get();
+    return nullptr;
+}
+
+ViewRole ViewBridge::role_at(size_t index) const {
+    if (view_) {
+        if (index == 0) return options_.role;
+        --index;
+    }
+    if (index < secondaries_.size()) return secondaries_[index].role;
+    return ViewRole::Editor;
+}
+
+} // namespace pulp::format

--- a/core/format/src/vst3_plug_view.cpp
+++ b/core/format/src/vst3_plug_view.cpp
@@ -4,7 +4,6 @@
 
 #ifdef PULP_VST3_GUI
 
-#include <pulp/format/editor_ui.hpp>
 #include <pulp/format/vst3_plug_view.hpp>
 #include <pulp/runtime/log.hpp>
 #include <cstring>
@@ -17,9 +16,11 @@ PulpPlugView::PulpPlugView(Processor& processor, state::StateStore& store)
     : CPluginView(nullptr)
     , processor_(processor)
     , store_(store)
+    , bridge_(processor, store)
 {
-    auto [w, h] = processor_.editor_size();
-    ViewRect r(0, 0, static_cast<int32>(w), static_cast<int32>(h));
+    const auto& hints = bridge_.size_hints();
+    ViewRect r(0, 0, static_cast<int32>(hints.preferred_width),
+               static_cast<int32>(hints.preferred_height));
     setRect(r);
 }
 
@@ -36,34 +37,29 @@ tresult PLUGIN_API PulpPlugView::isPlatformTypeSupported(FIDString type) {
 
 tresult PLUGIN_API PulpPlugView::attached(void* parent, FIDString type) {
     std::string editor_error;
-    auto editor_ui = build_editor_ui(store_, false, &editor_error);
-    editor_root_ = std::move(editor_ui.root);
-    scripted_ui_ = std::move(editor_ui.scripted_ui);
-    if (!editor_root_) {
+    if (!bridge_.open(&editor_error)) {
         runtime::log_error("VST3 editor: failed to build editor UI ({})", editor_error);
         return kResultFalse;
     }
 
-    auto [w, h] = processor_.editor_size();
+    const auto& hints = bridge_.size_hints();
     view::PluginViewHost::Options opts;
-    opts.size = {w, h};
+    opts.size = {hints.preferred_width, hints.preferred_height};
     opts.use_gpu = false;  // CoreGraphics for now; GPU opt-in later
 
-    editor_host_ = view::PluginViewHost::create(*editor_root_, opts);
+    editor_host_ = view::PluginViewHost::create(*bridge_.view(), opts);
     if (!editor_host_) {
         runtime::log_error("VST3 editor: PluginViewHost::create() failed");
-        editor_root_.reset();
+        bridge_.close();
         return kResultFalse;
     }
 
-    // Attach to the host's parent window
     editor_host_->attach_to_parent(parent);
-
-    // Let CPluginView track the system window
     auto result = CPluginView::attached(parent, type);
 
     runtime::log_info("VST3 editor: attached ({}x{}, mode={})",
-                      w, h, editor_ui.uses_script_ui ? "scripted" : "autoui");
+                      hints.preferred_width, hints.preferred_height,
+                      bridge_.uses_script_ui() ? "scripted" : "autoui");
     return result;
 }
 
@@ -72,8 +68,7 @@ tresult PLUGIN_API PulpPlugView::removed() {
         editor_host_->detach();
         editor_host_.reset();
     }
-    scripted_ui_.reset();
-    editor_root_.reset();
+    bridge_.close();
 
     runtime::log_info("VST3 editor: removed");
     return CPluginView::removed();
@@ -81,11 +76,11 @@ tresult PLUGIN_API PulpPlugView::removed() {
 
 tresult PLUGIN_API PulpPlugView::getSize(ViewRect* size) {
     if (!size) return kInvalidArgument;
-    auto [w, h] = processor_.editor_size();
+    const auto& hints = bridge_.size_hints();
     size->left = 0;
     size->top = 0;
-    size->right = static_cast<int32>(w);
-    size->bottom = static_cast<int32>(h);
+    size->right = static_cast<int32>(hints.preferred_width);
+    size->bottom = static_cast<int32>(hints.preferred_height);
     return kResultTrue;
 }
 
@@ -94,9 +89,10 @@ tresult PLUGIN_API PulpPlugView::onSize(ViewRect* newSize) {
 
     auto result = CPluginView::onSize(newSize);
 
+    uint32_t w = static_cast<uint32_t>(newSize->getWidth());
+    uint32_t h = static_cast<uint32_t>(newSize->getHeight());
+    bridge_.resize(w, h);
     if (editor_host_) {
-        uint32_t w = static_cast<uint32_t>(newSize->getWidth());
-        uint32_t h = static_cast<uint32_t>(newSize->getHeight());
         editor_host_->set_size(w, h);
     }
 

--- a/core/format/src/vst3_plug_view.cpp
+++ b/core/format/src/vst3_plug_view.cpp
@@ -56,6 +56,15 @@ tresult PLUGIN_API PulpPlugView::attached(void* parent, FIDString type) {
 
     editor_host_->attach_to_parent(parent);
     auto result = CPluginView::attached(parent, type);
+    if (result != kResultTrue) {
+        editor_host_->detach();
+        editor_host_.reset();
+        bridge_.close();
+        return result;
+    }
+
+    // Attach succeeded — now fire Processor::on_view_opened.
+    bridge_.notify_attached();
 
     runtime::log_info("VST3 editor: attached ({}x{}, mode={})",
                       hints.preferred_width, hints.preferred_height,

--- a/docs/guides/view-bridge.md
+++ b/docs/guides/view-bridge.md
@@ -1,0 +1,161 @@
+# ViewBridge
+
+ViewBridge is the editor-lifecycle layer that sits between your `Processor`
+and every plugin format (VST3, AU, CLAP, standalone, AAX). It owns the
+constructed view tree, dispatches open / close / resize callbacks, and lets
+one processor serve multiple simultaneous views (editor + inspector + remote).
+
+## Why it exists
+
+Before ViewBridge each format adapter called `build_editor_ui(store, …)`
+directly. That meant:
+
+- No `create_view()` hook on `Processor` — you could not return a custom
+  view tree without forking the adapter.
+- No open / close / resize callbacks — plugins could not react when the
+  host actually showed or resized the editor.
+- AU v2 on macOS instantiated a *second* `Processor` for the Cocoa view,
+  which silently desynchronized parameter state.
+- CLAP had no editor wiring at all.
+
+ViewBridge fixes all of those by giving every adapter a single, uniform
+path to construct and tear down views.
+
+## The API
+
+```cpp
+class Processor {
+  // ...existing methods...
+
+  /// Size hints for this editor. Default derives from editor_size().
+  virtual ViewSize view_size() const;
+
+  /// Return a custom view tree. Default returns nullptr, which tells
+  /// ViewBridge to fall back to the scripted UI (if configured) or AutoUi.
+  virtual std::unique_ptr<view::View> create_view();
+
+  virtual void on_view_opened(view::View&);
+  virtual void on_view_closed(view::View&);
+  virtual void on_view_resized(view::View&, uint32_t w, uint32_t h);
+};
+```
+
+`ViewSize` carries preferred / min / max dimensions in logical pixels. A
+zero max means unbounded in that axis.
+
+```cpp
+class ViewBridge {
+public:
+  struct Options {
+    bool enable_hot_reload = false;  // Poll scripted UI + theme.json for changes
+    ViewRole role = ViewRole::Editor;
+  };
+
+  ViewBridge(Processor&, state::StateStore&, Options = {});
+
+  bool open(std::string* error = nullptr);  // Build view, fire on_view_opened
+  void close();                             // Fire on_view_closed, destroy view
+  void resize(uint32_t w, uint32_t h);      // Fire on_view_resized
+
+  bool is_open() const;
+  view::View* view();
+  const ViewSize& size_hints() const;
+  uint32_t width() const;
+  uint32_t height() const;
+
+  // Secondary views (inspector, remote preview, …)
+  view::View* attach_secondary_view(std::unique_ptr<view::View>, ViewRole);
+  bool        detach_secondary_view(view::View*);
+  size_t      view_count() const;
+  view::View* view_at(size_t);
+  ViewRole    role_at(size_t) const;
+};
+```
+
+## Usage patterns
+
+### Default AutoUi editor
+
+Do nothing. `Processor::create_view()` returns `nullptr`, and ViewBridge
+builds the AutoUi (or scripted UI, if one is configured via
+`PULP_UI_SCRIPT_PATH`). Every plugin gets a working editor for free.
+
+### Custom view tree
+
+```cpp
+std::unique_ptr<view::View> MyPlugin::create_view() {
+    auto root = std::make_unique<view::View>();
+    root->set_theme(view::Theme::dark());
+    // … build custom widget hierarchy …
+    return root;
+}
+```
+
+### Reacting to lifecycle
+
+```cpp
+void MyPlugin::on_view_opened(view::View& v) {
+    // Register parameter listeners, start meters, etc.
+}
+
+void MyPlugin::on_view_resized(view::View&, uint32_t w, uint32_t h) {
+    // Recompute layout constants, update cached metrics, etc.
+}
+
+void MyPlugin::on_view_closed(view::View&) {
+    // Tear down anything registered in on_view_opened.
+}
+```
+
+### Multiple views for one processor
+
+ViewBridge can host a primary editor plus secondary views (inspector,
+remote preview). They all share the processor's `StateStore`, so parameter
+binding keeps them in sync.
+
+```cpp
+format::ViewBridge bridge(processor, store);
+bridge.open();
+
+// Attach an inspector as a secondary view
+auto inspector = make_inspector_view(processor);
+bridge.attach_secondary_view(std::move(inspector), ViewRole::Inspector);
+```
+
+## Thread model
+
+- All ViewBridge methods run on the UI / host thread.
+- `open()`, `close()`, and `resize()` are called by the format adapter
+  when the host opens / closes / resizes the editor window.
+- Lifecycle callbacks (`on_view_opened`, `on_view_closed`,
+  `on_view_resized`) are dispatched synchronously on the UI thread.
+- Parameter propagation to all attached views happens through the
+  existing `Binding::poll()` loop driven by each view's frame clock —
+  ViewBridge itself does not touch the audio thread.
+
+## Format adapter mapping
+
+| Format     | Adapter code                              | Construction site             |
+|------------|-------------------------------------------|-------------------------------|
+| VST3       | `core/format/src/vst3_plug_view.cpp`      | `createView()`                |
+| AU v2      | `core/format/src/au_v2_cocoa_view.mm`     | `CocoaView` init              |
+| AU v3      | `core/format/src/au_adapter.mm`           | `AUAudioUnitViewController`   |
+| CLAP       | `core/format/include/pulp/format/clap_entry.hpp` | `gui_create` / `gui_show` |
+| Standalone | `core/format/src/standalone.cpp`          | `run()` / window open         |
+
+Each adapter constructs one `ViewBridge` per editor window and forwards
+host lifecycle events to `open()` / `close()` / `resize()`.
+
+## Example
+
+See `examples/view-bridge-demo/` for a runnable demo that:
+
+1. Implements a `Processor` subclass with a custom `create_view()`.
+2. Attaches a secondary inspector view via `attach_secondary_view()`.
+3. Exercises lifecycle callbacks and a resize.
+
+## Phase 4: remote views (deferred)
+
+WebSocket-driven `attach_remote_view(url)` is planned but not yet
+implemented. The local multi-view machinery in `ViewBridge` is the
+foundation for that work.

--- a/docs/guides/view-bridge.md
+++ b/docs/guides/view-bridge.md
@@ -53,9 +53,10 @@ public:
 
   ViewBridge(Processor&, state::StateStore&, Options = {});
 
-  bool open(std::string* error = nullptr);  // Build view, fire on_view_opened
-  void close();                             // Fire on_view_closed, destroy view
-  void resize(uint32_t w, uint32_t h);      // Fire on_view_resized
+  bool open(std::string* error = nullptr);  // Build view (does NOT fire on_view_opened yet)
+  void notify_attached();                   // Fire on_view_opened AFTER host attach succeeds
+  void close();                             // Fire on_view_closed (only if attached), destroy view
+  void resize(uint32_t w, uint32_t h);      // Fire on_view_resized (only if attached)
 
   bool is_open() const;
   view::View* view();
@@ -125,10 +126,16 @@ bridge.attach_secondary_view(std::move(inspector), ViewRole::Inspector);
 ## Thread model
 
 - All ViewBridge methods run on the UI / host thread.
-- `open()`, `close()`, and `resize()` are called by the format adapter
-  when the host opens / closes / resizes the editor window.
-- Lifecycle callbacks (`on_view_opened`, `on_view_closed`,
-  `on_view_resized`) are dispatched synchronously on the UI thread.
+- `open()` builds the view but does **not** fire `on_view_opened`. The
+  adapter calls `notify_attached()` only after the host has successfully
+  attached the view to its native parent window (`attach_to_parent`,
+  CLAP `gui_set_parent`, VST3 `CPluginView::attached`). This guarantees
+  `on_view_opened` fires only when host-window-dependent resources can
+  actually be used, and keeps open/close dispatch balanced — if attach
+  fails, `close()` tears down the view without a spurious `on_view_closed`.
+- `close()` fires `on_view_closed` only when `notify_attached` had fired.
+- `resize()` dispatches `on_view_resized` only when attached; pre-attach
+  resizes just update the cached dimensions.
 - Parameter propagation to all attached views happens through the
   existing `Binding::poll()` loop driven by each view's frame clock —
   ViewBridge itself does not touch the audio thread.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -590,6 +590,7 @@ This single class automatically works as VST3, AU, CLAP, LV2, AAX, Standalone, W
 | ARA | `ara.hpp` | Audio Random Access document controller (stub) |
 | Host Detection | `host_type.hpp` | `detect_host_type()` → Logic, Reaper, Ableton, etc. |
 | Settings Panel | `settings_panel.hpp` | Audio/MIDI device selector with test signal and meters |
+| ViewBridge | `view_bridge.hpp` | Editor-view lifecycle: `create_view()`, `on_view_{opened,closed,resized}`, multi-view attach (editor + inspector + remote). See `docs/guides/view-bridge.md`. |
 
 ---
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -36,6 +36,9 @@ add_subdirectory(faust-gain)
 add_subdirectory(faust-filter)
 add_subdirectory(faust-tremolo)
 
+# ViewBridge demo: custom create_view() + secondary-view attach
+add_subdirectory(view-bridge-demo)
+
 # GPU Validation Demo: Modulation Matrix with animated cables
 add_subdirectory(gpu-demo)
 

--- a/examples/view-bridge-demo/CMakeLists.txt
+++ b/examples/view-bridge-demo/CMakeLists.txt
@@ -1,0 +1,14 @@
+# view-bridge-demo — exercises Processor::create_view() and multi-view attach
+#
+# This demo is a small executable (not a plugin) that drives ViewBridge
+# headlessly: it constructs a processor with a custom view, opens and
+# resizes an editor, attaches an inspector as a secondary view, and
+# prints the resulting lifecycle trace. It's the canonical "custom view
+# + secondary attach" recipe referenced from docs/guides/view-bridge.md.
+
+add_executable(pulp-view-bridge-demo main.cpp)
+target_link_libraries(pulp-view-bridge-demo PRIVATE pulp::format pulp::view)
+
+if(PULP_BUILD_TESTS)
+    add_test(NAME view-bridge-demo COMMAND pulp-view-bridge-demo)
+endif()

--- a/examples/view-bridge-demo/main.cpp
+++ b/examples/view-bridge-demo/main.cpp
@@ -88,6 +88,8 @@ int main() {
     REQUIRE(bridge.open(&err));
     REQUIRE(bridge.is_open());
     REQUIRE(bridge.view() != nullptr);
+    REQUIRE(proc.opened == 0);  // deferred until notify_attached()
+    bridge.notify_attached();
     REQUIRE(proc.opened == 1);
     REQUIRE(bridge.view_count() == 1);
 

--- a/examples/view-bridge-demo/main.cpp
+++ b/examples/view-bridge-demo/main.cpp
@@ -1,0 +1,117 @@
+// view-bridge-demo — exercises Processor::create_view() and multi-view attach.
+//
+// Runs headlessly:
+//   1. Construct DemoProcessor with a custom create_view() returning a
+//      hand-built view tree.
+//   2. Open a ViewBridge; the custom view is used instead of AutoUi.
+//   3. Attach an inspector view as a secondary view (role = Inspector).
+//   4. Resize the editor and detach the inspector.
+//   5. Close the bridge; lifecycle counters verify every callback fired.
+//
+// Exit code is 0 on success, non-zero if any invariant fails.
+
+#include <pulp/format/processor.hpp>
+#include <pulp/format/view_bridge.hpp>
+#include <pulp/state/store.hpp>
+#include <pulp/view/view.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+class DemoProcessor : public pulp::format::Processor {
+public:
+    int opened = 0, closed = 0, resized = 0;
+    uint32_t last_w = 0, last_h = 0;
+
+    pulp::format::PluginDescriptor descriptor() const override {
+        return {"view-bridge-demo", "Pulp", "com.pulp.view-bridge-demo", "0.1.0",
+                pulp::format::PluginCategory::Effect};
+    }
+
+    void define_parameters(pulp::state::StateStore& s) override {
+        s.add_parameter({1, "Gain", "dB", {-60.0f, 12.0f, 0.0f}});
+        s.add_parameter({2, "Mix",  "%",  {  0.0f, 100.0f, 100.0f}});
+    }
+
+    void prepare(const pulp::format::PrepareContext&) override {}
+
+    void process(pulp::audio::BufferView<float>&,
+                 const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+                 const pulp::format::ProcessContext&) override {}
+
+    pulp::format::ViewSize view_size() const override {
+        return {640, 480, 400, 300, 1280, 960};
+    }
+
+    std::unique_ptr<pulp::view::View> create_view() override {
+        auto root = std::make_unique<pulp::view::View>();
+        root->set_theme(pulp::view::Theme::dark());
+        return root;
+    }
+
+    void on_view_opened(pulp::view::View&) override { ++opened; }
+    void on_view_closed(pulp::view::View&) override { ++closed; }
+    void on_view_resized(pulp::view::View&, uint32_t w, uint32_t h) override {
+        ++resized;
+        last_w = w;
+        last_h = h;
+    }
+};
+
+#define REQUIRE(cond)                                                        \
+    do {                                                                     \
+        if (!(cond)) {                                                       \
+            std::fprintf(stderr, "REQUIRE failed: %s (%s:%d)\n",             \
+                         #cond, __FILE__, __LINE__);                         \
+            std::exit(1);                                                    \
+        }                                                                    \
+    } while (0)
+
+} // namespace
+
+int main() {
+    DemoProcessor proc;
+    pulp::state::StateStore store;
+    proc.set_state_store(&store);
+    proc.define_parameters(store);
+
+    pulp::format::ViewBridge bridge(proc, store);
+    REQUIRE(!bridge.is_open());
+    REQUIRE(bridge.size_hints().preferred_width == 640);
+    REQUIRE(bridge.size_hints().min_width == 400);
+    REQUIRE(bridge.size_hints().max_height == 960);
+
+    std::string err;
+    REQUIRE(bridge.open(&err));
+    REQUIRE(bridge.is_open());
+    REQUIRE(bridge.view() != nullptr);
+    REQUIRE(proc.opened == 1);
+    REQUIRE(bridge.view_count() == 1);
+
+    // Attach an inspector as a secondary view.
+    auto inspector = std::make_unique<pulp::view::View>();
+    auto* insp = bridge.attach_secondary_view(
+        std::move(inspector), pulp::format::ViewRole::Inspector);
+    REQUIRE(insp != nullptr);
+    REQUIRE(bridge.view_count() == 2);
+    REQUIRE(bridge.role_at(1) == pulp::format::ViewRole::Inspector);
+
+    bridge.resize(800, 600);
+    REQUIRE(proc.resized == 1);
+    REQUIRE(proc.last_w == 800);
+    REQUIRE(proc.last_h == 600);
+
+    REQUIRE(bridge.detach_secondary_view(insp));
+    REQUIRE(bridge.view_count() == 1);
+
+    bridge.close();
+    REQUIRE(!bridge.is_open());
+    REQUIRE(proc.closed == 1);
+
+    std::printf("view-bridge-demo: ok (opened=%d resized=%d closed=%d)\n",
+                proc.opened, proc.resized, proc.closed);
+    return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -356,6 +356,11 @@ add_executable(pulp-test-auto-ui test_auto_ui.cpp)
 target_link_libraries(pulp-test-auto-ui PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-auto-ui)
 
+# ViewBridge lifecycle tests
+add_executable(pulp-test-view-bridge test_view_bridge.cpp)
+target_link_libraries(pulp-test-view-bridge PRIVATE pulp::format Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-view-bridge)
+
 # Script engine tests (legacy API)
 add_executable(pulp-test-script test_script_engine.cpp)
 target_link_libraries(pulp-test-script PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_view_bridge.cpp
+++ b/test/test_view_bridge.cpp
@@ -60,6 +60,7 @@ TEST_CASE("ViewBridge falls back to AutoUi when create_view returns nullptr", "[
 
     std::string err;
     REQUIRE(bridge.open(&err));
+    bridge.notify_attached();
     REQUIRE(bridge.is_open());
     REQUIRE(bridge.view() != nullptr);
     REQUIRE(bridge.view_count() == 1);
@@ -87,6 +88,7 @@ TEST_CASE("ViewBridge honors custom create_view()", "[view_bridge]") {
 
     format::ViewBridge bridge(p, store);
     REQUIRE(bridge.open());
+    bridge.notify_attached();
     REQUIRE(bridge.view() == raw);
     REQUIRE_FALSE(bridge.uses_script_ui());
 }
@@ -99,6 +101,7 @@ TEST_CASE("ViewBridge supports secondary views", "[view_bridge]") {
 
     format::ViewBridge bridge(p, store);
     REQUIRE(bridge.open());
+    bridge.notify_attached();
     REQUIRE(bridge.view_count() == 1);
 
     auto inspector = std::make_unique<view::View>();
@@ -114,6 +117,53 @@ TEST_CASE("ViewBridge supports secondary views", "[view_bridge]") {
     REQUIRE_FALSE(bridge.detach_secondary_view(insp));
 }
 
+TEST_CASE("ViewBridge defers on_view_opened until notify_attached", "[view_bridge]") {
+    StubProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    format::ViewBridge bridge(p, store);
+    REQUIRE(bridge.open());
+    // open() must NOT fire on_view_opened — only notify_attached() does.
+    REQUIRE(p.opened_count == 0);
+
+    // Resize before attach is a no-op for lifecycle (no on_view_resized dispatched).
+    bridge.resize(500, 300);
+    REQUIRE(p.resize_count == 0);
+
+    bridge.notify_attached();
+    REQUIRE(p.opened_count == 1);
+
+    // Second notify_attached is idempotent.
+    bridge.notify_attached();
+    REQUIRE(p.opened_count == 1);
+
+    bridge.resize(600, 400);
+    REQUIRE(p.resize_count == 1);
+
+    bridge.close();
+    REQUIRE(p.closed_count == 1);
+}
+
+TEST_CASE("ViewBridge close without attach does not fire on_view_closed", "[view_bridge]") {
+    // Simulates: adapter called open(), then host attach failed, so
+    // notify_attached() was never invoked. close() must NOT fire
+    // on_view_closed because on_view_opened never fired — keeps
+    // open/close dispatch balanced.
+    StubProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    format::ViewBridge bridge(p, store);
+    REQUIRE(bridge.open());
+    REQUIRE(p.opened_count == 0);
+
+    bridge.close();
+    REQUIRE(p.closed_count == 0);
+}
+
 TEST_CASE("ViewBridge destructor closes view", "[view_bridge]") {
     StubProcessor p;
     state::StateStore store;
@@ -123,6 +173,7 @@ TEST_CASE("ViewBridge destructor closes view", "[view_bridge]") {
     {
         format::ViewBridge bridge(p, store);
         REQUIRE(bridge.open());
+        bridge.notify_attached();
         REQUIRE(p.opened_count == 1);
     }
     REQUIRE(p.closed_count == 1);

--- a/test/test_view_bridge.cpp
+++ b/test/test_view_bridge.cpp
@@ -1,0 +1,129 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/format/processor.hpp>
+#include <pulp/format/view_bridge.hpp>
+#include <pulp/state/store.hpp>
+#include <pulp/view/view.hpp>
+
+using namespace pulp;
+
+namespace {
+
+class StubProcessor : public format::Processor {
+public:
+    int opened_count = 0;
+    int closed_count = 0;
+    int resize_count = 0;
+    uint32_t last_w = 0, last_h = 0;
+    std::unique_ptr<view::View> custom_view;
+
+    format::PluginDescriptor descriptor() const override {
+        return {"Stub", "Acme", "com.acme.stub", "1.0.0", format::PluginCategory::Effect};
+    }
+    void define_parameters(state::StateStore& s) override {
+        s.add_parameter({1, "Gain", "dB", {-60.0f, 12.0f, 0.0f}});
+    }
+    void prepare(const format::PrepareContext&) override {}
+    void process(audio::BufferView<float>&, const audio::BufferView<const float>&,
+                 midi::MidiBuffer&, midi::MidiBuffer&,
+                 const format::ProcessContext&) override {}
+
+    format::ViewSize view_size() const override {
+        return {480, 320, 320, 240, 1024, 768};
+    }
+
+    std::unique_ptr<view::View> create_view() override {
+        return std::move(custom_view);
+    }
+
+    void on_view_opened(view::View&) override { ++opened_count; }
+    void on_view_closed(view::View&) override { ++closed_count; }
+    void on_view_resized(view::View&, uint32_t w, uint32_t h) override {
+        ++resize_count;
+        last_w = w;
+        last_h = h;
+    }
+};
+
+} // namespace
+
+TEST_CASE("ViewBridge falls back to AutoUi when create_view returns nullptr", "[view_bridge]") {
+    StubProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    format::ViewBridge bridge(p, store);
+    REQUIRE_FALSE(bridge.is_open());
+    REQUIRE(bridge.view_count() == 0);
+    REQUIRE(bridge.size_hints().preferred_width == 480);
+    REQUIRE(bridge.size_hints().min_height == 240);
+
+    std::string err;
+    REQUIRE(bridge.open(&err));
+    REQUIRE(bridge.is_open());
+    REQUIRE(bridge.view() != nullptr);
+    REQUIRE(bridge.view_count() == 1);
+    REQUIRE(p.opened_count == 1);
+
+    bridge.resize(600, 400);
+    REQUIRE(p.resize_count == 1);
+    REQUIRE(p.last_w == 600);
+    REQUIRE(p.last_h == 400);
+    REQUIRE(bridge.width() == 600);
+
+    bridge.close();
+    REQUIRE_FALSE(bridge.is_open());
+    REQUIRE(p.closed_count == 1);
+}
+
+TEST_CASE("ViewBridge honors custom create_view()", "[view_bridge]") {
+    StubProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+    auto custom = std::make_unique<view::View>();
+    auto* raw = custom.get();
+    p.custom_view = std::move(custom);
+
+    format::ViewBridge bridge(p, store);
+    REQUIRE(bridge.open());
+    REQUIRE(bridge.view() == raw);
+    REQUIRE_FALSE(bridge.uses_script_ui());
+}
+
+TEST_CASE("ViewBridge supports secondary views", "[view_bridge]") {
+    StubProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    format::ViewBridge bridge(p, store);
+    REQUIRE(bridge.open());
+    REQUIRE(bridge.view_count() == 1);
+
+    auto inspector = std::make_unique<view::View>();
+    auto* insp = bridge.attach_secondary_view(std::move(inspector), format::ViewRole::Inspector);
+    REQUIRE(insp != nullptr);
+    REQUIRE(bridge.view_count() == 2);
+    REQUIRE(bridge.view_at(0) == bridge.view());
+    REQUIRE(bridge.view_at(1) == insp);
+    REQUIRE(bridge.role_at(1) == format::ViewRole::Inspector);
+
+    REQUIRE(bridge.detach_secondary_view(insp));
+    REQUIRE(bridge.view_count() == 1);
+    REQUIRE_FALSE(bridge.detach_secondary_view(insp));
+}
+
+TEST_CASE("ViewBridge destructor closes view", "[view_bridge]") {
+    StubProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    {
+        format::ViewBridge bridge(p, store);
+        REQUIRE(bridge.open());
+        REQUIRE(p.opened_count == 1);
+    }
+    REQUIRE(p.closed_count == 1);
+}


### PR DESCRIPTION
## Summary

Adds ViewBridge — editor-view lifecycle and multi-view primitives sitting between `Processor` and every format adapter. Implements **Feature 1 Phase 1** (core API + tests + VST3 + CLAP) and **Phase 2 core** (secondary views, count/role queries, lifecycle callbacks). Phase 3 adapter-parity for AU/standalone/AAX/WAM and inspector auto-attach are out of scope for this PR and tracked as follow-ups.

### Core API (`core/format/`)
- `Processor::create_view()` → `std::unique_ptr<view::View>` (default nullptr, framework falls back to scripted UI / AutoUi)
- `Processor::view_size()` returning `ViewSize { preferred/min/max w+h }` (0 max = unbounded)
- Lifecycle callbacks: `on_view_opened`, `on_view_closed`, `on_view_resized`
- `ViewBridge` class — owns the view, dispatches lifecycle, tracks size hints, supports secondary views via `attach_secondary_view(view, ViewRole)` / `detach_secondary_view` / `view_count` / `view_at` / `role_at`

### Format adapters wired
- **VST3** (`vst3_plug_view.{hpp,cpp}`): PulpPlugView owns a `ViewBridge bridge_`; `attached`/`removed`/`onSize` now route host events through the bridge so `Processor::on_view_*` fires consistently.
- **CLAP** (`clap_adapter.hpp`, `clap_entry.hpp`): `PulpClapPlugin::bridge` replaces raw `editor_root` + `scripted_ui` fields; `gui_create`, `gui_destroy`, `gui_get_size`, `gui_set_size` all route through the bridge.

### Tests
- `test/test_view_bridge.cpp` — 4 Catch2 cases / 31 assertions covering: AutoUi fallback when `create_view` returns nullptr, custom view returned by `create_view`, secondary-view attach/role-query/detach, RAII close-on-destruct.
- `examples/view-bridge-demo/` — headless runnable demo + ctest registration exercising the full open → attach inspector → resize → detach → close flow.
- Full suite: **2080/2080 pass** locally.

### Docs + plan
- `docs/guides/view-bridge.md` — new public guide
- `docs/reference/modules.md` — adds ViewBridge row under format module
- `planning/next-features-plan.md` — Feature 1 checkboxes updated for Phase 1 (VST3+CLAP+tests) and Phase 2 (secondary-view API + shared-StateStore binding propagation)

### Out of scope (follow-ups)
- Phase 2: Inspector auto-attach-as-secondary
- Phase 3: AU v2 (+ dual-Processor bug fix), AU v3, standalone (needs `ViewBridge::release_view` for TabPanel ownership), AAX, WAM/WCLAP
- Phase 4: WebSocket remote views (explicitly deferred in plan)

## Test plan

- [x] `cmake --build build -j\$(sysctl -n hw.ncpu)` clean on macOS ARM64
- [x] `ctest --test-dir build --output-on-failure --exclude-regex AudioWorkgroup` → 2080/2080 pass
- [x] `pulp-test-view-bridge` → 4/4 Catch2 cases, 31 assertions
- [x] `pulp-view-bridge-demo` ctest entry → passes
- [ ] CI: macOS ARM64 + Ubuntu + Windows via Namespace (on PR)