### PR TITLE
MPE Phase 4: MIDI 2.0 UMP native path (closes #139)

### DIFF
--- a/core/format/include/pulp/format/clap_adapter.hpp
+++ b/core/format/include/pulp/format/clap_adapter.hpp
@@ -44,6 +44,12 @@ struct PulpClapPlugin {
     int32_t mpe_current_sample_offset = 0;
     bool mpe_enabled = false;
 
+    // UMP sidecar — populated by converting midi_in to MIDI 2.0 UMP packets
+    // when the Processor declares supports_ump. In the future, CLAP hosts
+    // that deliver CLAP_EVENT_MIDI2 can populate this buffer directly.
+    midi::UmpBuffer ump_buffer;
+    bool ump_enabled = false;
+
     // Preset management (optional — set by plugins that provide presets)
     std::unique_ptr<state::PresetManager> preset_manager;
 

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -3,6 +3,7 @@
 #include <pulp/audio/buffer.hpp>
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/mpe_buffer.hpp>
+#include <pulp/midi/ump_buffer.hpp>
 #include <pulp/state/store.hpp>
 #include <string>
 #include <memory>
@@ -65,6 +66,15 @@ struct PluginDescriptor {
     /// The standard process() signature is unchanged; plugins that don't
     /// set this flag see no MPE-specific behaviour.
     bool supports_mpe = false;
+
+    /// Opt in to the native MIDI 2.0 UMP sidecar. When true, format
+    /// adapters that recognise UMP provide a UmpBuffer of full-resolution
+    /// channel-voice packets (16-bit velocity, per-note pitch bend,
+    /// per-note CCs) through Processor::ump_input() during process().
+    /// Adapters without native UMP transport synthesise the buffer by
+    /// converting the inbound MIDI 1.0 stream. `supports_mpe` and
+    /// `supports_ump` are independent and can both be set.
+    bool supports_ump = false;
 
     /// Tail time in samples (0 = no tail, -1 = infinite).
     /// Used by hosts to flush reverb/delay tails after playback stops.
@@ -203,17 +213,25 @@ public:
     /// and the host/format adapter populated it.
     const midi::MpeBuffer* mpe_input() const { return mpe_input_; }
 
+    /// Access the MIDI 2.0 UMP buffer for this block. Returns nullptr
+    /// unless the plugin declared PluginDescriptor::supports_ump = true
+    /// and the host/format adapter populated it.
+    const midi::UmpBuffer* ump_input() const { return ump_input_; }
+
     /// @internal Framework sets these during initialization / processing.
     void set_state_store(state::StateStore* store) { state_store_ = store; }
     /// @internal
     void set_sidechain(const audio::BufferView<const float>* sc) { sidechain_ = sc; }
     /// @internal Called by format adapters before process() when MPE is on.
     void set_mpe_input(const midi::MpeBuffer* mpe) { mpe_input_ = mpe; }
+    /// @internal Called by format adapters before process() when UMP is on.
+    void set_ump_input(const midi::UmpBuffer* ump) { ump_input_ = ump; }
 
 private:
     state::StateStore* state_store_ = nullptr;
     const audio::BufferView<const float>* sidechain_ = nullptr;
     const midi::MpeBuffer* mpe_input_ = nullptr;
+    const midi::UmpBuffer* ump_input_ = nullptr;
 };
 
 /// Factory function type — plugins provide this to create processor instances.

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -2,6 +2,7 @@
 // Implements the CLAP C API wrapping a Pulp Processor
 
 #include <pulp/format/clap_adapter.hpp>
+#include <pulp/midi/ump_conversion.hpp>
 #include <pulp/runtime/log.hpp>
 #include <clap/ext/preset-load.h>
 #include <algorithm>
@@ -32,6 +33,12 @@ bool clap_init(const clap_plugin_t* plugin) {
         midi::bind_tracker_to_buffer(
             self->mpe_tracker, self->mpe_buffer, self->mpe_current_sample_offset);
         runtime::log_info("CLAP: MPE sidecar enabled for '{}'", desc.name);
+    }
+
+    // Wire UMP sidecar when the plugin opts in.
+    self->ump_enabled = desc.supports_ump;
+    if (self->ump_enabled) {
+        runtime::log_info("CLAP: UMP sidecar enabled for '{}'", desc.name);
     }
 
     runtime::log_info("CLAP: initialized '{}'", desc.name);
@@ -187,6 +194,18 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
         self->processor->set_mpe_input(&self->mpe_buffer);
     } else {
         self->processor->set_mpe_input(nullptr);
+    }
+
+    // UMP sidecar: until CLAP ships CLAP_EVENT_MIDI2, synthesise the UMP
+    // stream by converting the inbound MIDI 1.0 events to MIDI 2.0
+    // Channel Voice packets. Plugins that declare supports_ump see the
+    // same sample-ordered stream the host would otherwise deliver natively.
+    if (self->ump_enabled) {
+        self->ump_buffer.clear();
+        midi::midi1_to_ump(midi_in, self->ump_buffer);
+        self->processor->set_ump_input(&self->ump_buffer);
+    } else {
+        self->processor->set_ump_input(nullptr);
     }
 
     // Process!

--- a/core/midi/include/pulp/midi/mpe_voice_tracker.hpp
+++ b/core/midi/include/pulp/midi/mpe_voice_tracker.hpp
@@ -137,6 +137,97 @@ public:
         return true;  // event belongs to zone but isn't an MPE expression (e.g. other CC)
     }
 
+    /// Process a MIDI 2.0 UMP Channel Voice packet. Returns true when the
+    /// packet belongs to a known MPE zone (and was consumed), false
+    /// otherwise. MIDI 2.0 per-note pitch bend (status 0x60) is routed
+    /// directly to the matching note rather than going via member-channel
+    /// state, preserving the full per-note resolution UMP carries.
+    ///
+    /// Non-Channel-Voice UMP types (Utility, System, SysEx, Data128) are
+    /// ignored and return false.
+    bool process(const UmpPacket& p) {
+        const auto mt = p.message_type();
+        if (mt == UmpMessageType::Midi1ChannelVoice) {
+            // Reconstruct a MidiEvent and dispatch to the MIDI 1.0 path.
+            const uint8_t s = static_cast<uint8_t>((p.words[0] >> 16) & 0xFF);
+            const uint8_t d1 = static_cast<uint8_t>((p.words[0] >> 8) & 0xFF);
+            const uint8_t d2 = static_cast<uint8_t>(p.words[0] & 0xFF);
+            MidiEvent ev{choc::midi::ShortMessage(s, d1, d2), 0, 0.0};
+            return process(ev);
+        }
+        if (mt != UmpMessageType::Midi2ChannelVoice) return false;
+
+        const uint8_t ch = p.channel();
+        const uint8_t status = static_cast<uint8_t>((p.words[0] >> 16) & 0xF0);
+
+        // Manager-channel packets: zone-wide state, no notes created.
+        if (ch == config_.lower_zone.manager_channel
+            && config_.lower_zone.member_channels > 0) {
+            apply_manager_ump(p, /*upper=*/false);
+            return true;
+        }
+        if (ch == config_.upper_zone.manager_channel
+            && config_.upper_zone.member_channels > 0
+            && ch != config_.lower_zone.manager_channel) {
+            apply_manager_ump(p, /*upper=*/true);
+            return true;
+        }
+
+        const MpeZone* zone = config_.zone_for_channel(ch);
+        if (!zone) return false;
+        const bool upper = zone->is_upper();
+
+        switch (status) {
+            case 0x90: {
+                const uint16_t v16 = p.velocity_16();
+                if (v16 == 0) {
+                    remove_note(ch, p.note_number());
+                } else {
+                    add_note(ch, p.note_number(),
+                             static_cast<uint8_t>(v16 >> 9), upper);
+                }
+                return true;
+            }
+            case 0x80:
+                remove_note(ch, p.note_number());
+                return true;
+            case 0xE0: {
+                const float norm = ump_bend_normalised(p.data_32());
+                update_channel_pitch_bend(ch, norm * member_bend_semi_, upper);
+                return true;
+            }
+            case 0xD0: {
+                // Channel Pressure (MIDI 2.0): 32-bit value, top bit sets it to half.
+                const float pressure = static_cast<float>(p.data_32()) / 4294967295.0f;
+                update_channel_pressure(ch, pressure, upper);
+                return true;
+            }
+            case 0xB0: {
+                const uint8_t cc = static_cast<uint8_t>((p.words[0] >> 8) & 0x7F);
+                if (cc == 74) {
+                    const float timbre = static_cast<float>(p.data_32()) / 4294967295.0f;
+                    update_channel_timbre(ch, timbre, upper);
+                }
+                return true;
+            }
+            case 0x60: {  // Per-note pitch bend
+                apply_per_note_pitch_bend(ch, p.note_number(),
+                                          ump_bend_normalised(p.data_32()) * member_bend_semi_);
+                return true;
+            }
+            case 0x00: {  // Registered per-note CC
+                const uint8_t cc = static_cast<uint8_t>((p.words[0] >> 8) & 0x7F);
+                if (cc == 74) {
+                    apply_per_note_timbre(ch, p.note_number(),
+                                          static_cast<float>(p.data_32()) / 4294967295.0f);
+                }
+                return true;
+            }
+            default:
+                return true;  // belongs to zone but we don't map this status
+        }
+    }
+
     // ── Queries ────────────────────────────────────────────────────────────
 
     std::size_t active_count() const {
@@ -290,6 +381,42 @@ private:
         } else if (event.is_cc() && event.cc_number() == 74) {
             zs.timbre = event.cc_value() / 127.0f;
         }
+    }
+
+    void apply_manager_ump(const UmpPacket& p, bool upper) {
+        ZoneState& zs = upper ? upper_zone_state_ : lower_zone_state_;
+        const uint8_t status = static_cast<uint8_t>((p.words[0] >> 16) & 0xF0);
+        if (status == 0xE0) {
+            zs.pitch_bend_semitones = ump_bend_normalised(p.data_32()) * manager_bend_semi_;
+        } else if (status == 0xD0) {
+            zs.pressure = static_cast<float>(p.data_32()) / 4294967295.0f;
+        } else if (status == 0xB0) {
+            const uint8_t cc = static_cast<uint8_t>((p.words[0] >> 8) & 0x7F);
+            if (cc == 74) zs.timbre = static_cast<float>(p.data_32()) / 4294967295.0f;
+        }
+    }
+
+    // Per-note helpers — MIDI 2.0 UMP per-note pitch bend / per-note CC
+    // target a specific (channel, note) pair rather than going via the
+    // member-channel cache, so they only update that one note.
+    void apply_per_note_pitch_bend(uint8_t ch, uint8_t note, float semitones) {
+        for (auto& s : notes_) {
+            if (!s.active || s.channel != ch || s.note != note) continue;
+            s.pitch_bend_semitones = semitones;
+            if (on_pitch_bend) on_pitch_bend(s);
+        }
+    }
+    void apply_per_note_timbre(uint8_t ch, uint8_t note, float timbre) {
+        for (auto& s : notes_) {
+            if (!s.active || s.channel != ch || s.note != note) continue;
+            s.timbre = timbre;
+            if (on_timbre) on_timbre(s);
+        }
+    }
+
+    static float ump_bend_normalised(uint32_t v32) {
+        // 0..0xFFFFFFFF with centre 0x80000000 → -1..+1.
+        return (static_cast<double>(v32) - 2147483648.0) / 2147483648.0;
     }
 
     MpeConfig config_;

--- a/core/midi/include/pulp/midi/mpe_voice_tracker.hpp
+++ b/core/midi/include/pulp/midi/mpe_voice_tracker.hpp
@@ -216,7 +216,9 @@ public:
                 return true;
             }
             case 0x00: {  // Registered per-note CC
-                const uint8_t cc = static_cast<uint8_t>((p.words[0] >> 8) & 0x7F);
+                // MIDI 2.0 per-note controller layout: byte 2 is the note
+                // number (p.note_number()), byte 3 is the controller index.
+                const uint8_t cc = static_cast<uint8_t>(p.words[0] & 0x7F);
                 if (cc == 74) {
                     apply_per_note_timbre(ch, p.note_number(),
                                           static_cast<float>(p.data_32()) / 4294967295.0f);

--- a/core/midi/include/pulp/midi/ump.hpp
+++ b/core/midi/include/pulp/midi/ump.hpp
@@ -178,6 +178,21 @@ struct UmpPacket {
         return p;
     }
 
+    // MIDI 2.0 Registered Per-Note Controller (status 0x00). Byte 2 is
+    // the note number, byte 3 is the controller index per the UMP spec.
+    static UmpPacket registered_per_note_cc(uint8_t group, uint8_t channel,
+                                             uint8_t note, uint8_t cc_index,
+                                             uint32_t value) {
+        UmpPacket p;
+        p.word_count = 2;
+        p.words[0] = (0x4u << 28) | (uint32_t(group & 0x0F) << 24)
+                    | (uint32_t(0x00 | (channel & 0x0F)) << 16)
+                    | (uint32_t(note & 0x7F) << 8)
+                    | uint32_t(cc_index & 0x7F);
+        p.words[1] = value;
+        return p;
+    }
+
     // MIDI 1.0 Channel Voice (32-bit backwards compat)
     static UmpPacket midi1_note_on(uint8_t group, uint8_t channel,
                                     uint8_t note, uint8_t velocity) {

--- a/core/midi/include/pulp/midi/ump_buffer.hpp
+++ b/core/midi/include/pulp/midi/ump_buffer.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+/// @file ump_buffer.hpp
+/// Sample-accurate MIDI 2.0 UMP packet stream.
+///
+/// `UmpBuffer` parallels `MidiBuffer`: while `MidiBuffer` carries MIDI 1.0
+/// short messages, `UmpBuffer` carries native Universal MIDI Packets with
+/// full MIDI 2.0 resolution (16-bit velocity, per-note pitch bend,
+/// per-note CCs). Processors that set `PluginDescriptor::supports_ump`
+/// access the buffer via `Processor::ump_input()` during `process()`.
+///
+/// Packets carry a `sample_offset` so hosts can deliver sample-accurate
+/// timing (same semantics as `MidiEvent::sample_offset`).
+
+#include <pulp/midi/ump.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace pulp::midi {
+
+/// One UMP packet with a block-relative sample offset.
+struct UmpEvent {
+    UmpPacket packet;
+    int32_t sample_offset = 0;
+};
+
+/// A time-ordered list of UMP events for one audio block.
+///
+/// Ownership and lifetime mirror `MidiBuffer`/`MpeBuffer`: the format
+/// adapter owns the buffer, fills it before `process()`, passes a
+/// pointer to the processor, and clears it afterwards. Not thread-safe.
+class UmpBuffer {
+public:
+    UmpBuffer() { events_.reserve(kInitialCapacity); }
+
+    void add(const UmpEvent& e) { events_.push_back(e); }
+    void add(UmpEvent&& e) { events_.push_back(std::move(e)); }
+    void add(const UmpPacket& p, int32_t sample_offset = 0) {
+        events_.push_back({p, sample_offset});
+    }
+
+    void clear() { events_.clear(); }
+    bool empty() const { return events_.empty(); }
+    std::size_t size() const { return events_.size(); }
+
+    void sort() {
+        std::sort(events_.begin(), events_.end(),
+            [](const UmpEvent& a, const UmpEvent& b) {
+                return a.sample_offset < b.sample_offset;
+            });
+    }
+
+    auto begin()       { return events_.begin(); }
+    auto end()         { return events_.end(); }
+    auto begin() const { return events_.begin(); }
+    auto end() const   { return events_.end(); }
+
+    const UmpEvent& operator[](std::size_t i) const { return events_[i]; }
+
+private:
+    static constexpr std::size_t kInitialCapacity = 128;
+    std::vector<UmpEvent> events_;
+};
+
+} // namespace pulp::midi

--- a/core/midi/include/pulp/midi/ump_conversion.hpp
+++ b/core/midi/include/pulp/midi/ump_conversion.hpp
@@ -1,0 +1,176 @@
+#pragma once
+
+/// @file ump_conversion.hpp
+/// Bidirectional conversion between MIDI 1.0 (MidiBuffer) and MIDI 2.0 UMP
+/// (UmpBuffer).
+///
+/// Scaling follows the MIDI 2.0 spec (M2-115-U §2.4, "Data Value Scaling"):
+///   - 7-bit → 16-bit velocity: `v16 = (v7 << 9) | (v7 >> ((v7>0)?5:32))`
+///     with v7==0 staying 0 for note-off semantics.
+///   - 14-bit → 32-bit: center-biased expansion.
+///
+/// These helpers are deliberately header-only and allocation-free on the
+/// hot path; the only allocation is in the destination buffer's append.
+
+#include <pulp/midi/buffer.hpp>
+#include <pulp/midi/message.hpp>
+#include <pulp/midi/ump.hpp>
+#include <pulp/midi/ump_buffer.hpp>
+#include <cstdint>
+
+namespace pulp::midi {
+
+// ── 7/14/16/32-bit scaling helpers ──────────────────────────────────────
+
+/// Scale a 7-bit value (0..127) to 16-bit (0..65535) per MIDI 2.0 spec.
+/// Zero stays zero; 127 maps to 0xFFFF (no dead zone at the top).
+inline uint16_t scale_7_to_16(uint8_t v7) {
+    // Rounded division so 100 → 51604 round-trips back to 100 (not 99).
+    return static_cast<uint16_t>(
+        (static_cast<uint32_t>(v7) * 0xFFFFu + 63u) / 127u);
+}
+
+/// Scale 16-bit (0..65535) down to 7-bit (0..127).
+inline uint8_t scale_16_to_7(uint16_t v16) {
+    return static_cast<uint8_t>(
+        (static_cast<uint32_t>(v16) * 127u + 0x7FFFu) / 0xFFFFu);
+}
+
+/// Scale a 14-bit value (0..16383, centre 8192) to 32-bit (centre 0x80000000)
+/// using MIDI 2.0 Min/Center/Max scaling so the midpoint is preserved exactly.
+inline uint32_t scale_14_to_32(uint16_t v14) {
+    constexpr uint32_t src_max = 0x3FFFu;
+    constexpr uint32_t src_center = 0x2000u;
+    constexpr uint64_t dst_center = 0x80000000ull;
+    if (v14 <= src_center) {
+        return static_cast<uint32_t>((static_cast<uint64_t>(v14) * dst_center) / src_center);
+    }
+    const uint64_t above = static_cast<uint64_t>(v14 - src_center);
+    const uint64_t dst_above_max = 0x7FFFFFFFull;
+    return static_cast<uint32_t>(dst_center + (above * dst_above_max) / (src_max - src_center));
+}
+
+/// Scale a 32-bit value back to 14-bit (0..16383), inverse of `scale_14_to_32`.
+inline uint16_t scale_32_to_14(uint32_t v32) {
+    constexpr uint32_t dst_max = 0x3FFFu;
+    constexpr uint32_t dst_center = 0x2000u;
+    constexpr uint64_t src_center = 0x80000000ull;
+    if (v32 <= src_center) {
+        return static_cast<uint16_t>((static_cast<uint64_t>(v32) * dst_center) / src_center);
+    }
+    const uint64_t above = static_cast<uint64_t>(v32 - src_center);
+    const uint64_t src_above_max = 0x7FFFFFFFull;
+    return static_cast<uint16_t>(dst_center + (above * (dst_max - dst_center)) / src_above_max);
+}
+
+// ── MIDI 1.0 → UMP ──────────────────────────────────────────────────────
+
+/// Convert a single MIDI 1.0 event to a MIDI 2.0 Channel Voice UMP packet.
+/// Uses message type 0x4 so the host sees full MIDI 2.0 resolution.
+/// Group defaults to 0.
+inline UmpPacket midi1_event_to_ump2(const MidiEvent& ev, uint8_t group = 0) {
+    const uint8_t status = ev.data()[0] & 0xF0;
+    const uint8_t channel = ev.channel();
+
+    if (status == 0x90 && ev.velocity() == 0) {
+        // Velocity-0 note-on is a note-off.
+        return UmpPacket::note_off_2(group, channel, ev.note(), 0);
+    }
+    switch (status) {
+        case 0x80:
+            return UmpPacket::note_off_2(group, channel, ev.note(),
+                                          scale_7_to_16(ev.velocity()));
+        case 0x90:
+            return UmpPacket::note_on_2(group, channel, ev.note(),
+                                         scale_7_to_16(ev.velocity()));
+        case 0xB0:
+            return UmpPacket::cc_2(group, channel, ev.cc_number(),
+                                    static_cast<uint32_t>(ev.cc_value()) << 25);
+        case 0xE0: {
+            const uint16_t raw = static_cast<uint16_t>(
+                ev.data()[1] | (uint16_t(ev.data()[2]) << 7));
+            return UmpPacket::pitch_bend_2(group, channel, scale_14_to_32(raw));
+        }
+        default:
+            break;
+    }
+    // Fall back to a MIDI 1.0 UMP (type 0x2) carrying the raw bytes.
+    UmpPacket p;
+    p.word_count = 1;
+    p.words[0] = (0x2u << 28)
+               | (uint32_t(group & 0x0F) << 24)
+               | (uint32_t(ev.data()[0]) << 16)
+               | (uint32_t(ev.size() > 1 ? ev.data()[1] : 0) << 8)
+               | uint32_t(ev.size() > 2 ? ev.data()[2] : 0);
+    return p;
+}
+
+/// Append a MIDI 1.0 buffer to a UmpBuffer as MIDI 2.0 UMP packets.
+inline void midi1_to_ump(const MidiBuffer& src, UmpBuffer& dst, uint8_t group = 0) {
+    for (const auto& ev : src) {
+        dst.add({midi1_event_to_ump2(ev, group), ev.sample_offset});
+    }
+}
+
+// ── UMP → MIDI 1.0 ──────────────────────────────────────────────────────
+
+/// Convert a UMP Channel Voice packet into a MIDI 1.0 event when possible.
+/// Returns true on success and writes to @p out. Returns false for packets
+/// that have no MIDI 1.0 equivalent (e.g. per-note pitch bend, per-note CC),
+/// which callers typically route via the MPE sidecar instead.
+inline bool ump_to_midi1_event(const UmpPacket& p, MidiEvent& out) {
+    const auto mt = p.message_type();
+    const uint8_t ch = p.channel();
+
+    if (mt == UmpMessageType::Midi1ChannelVoice) {
+        // Byte 1 is status|channel (already in words[0] bits 16-23),
+        // Byte 2 in bits 8-15, byte 3 in bits 0-7.
+        const uint8_t s = static_cast<uint8_t>((p.words[0] >> 16) & 0xFF);
+        const uint8_t d1 = static_cast<uint8_t>((p.words[0] >> 8) & 0xFF);
+        const uint8_t d2 = static_cast<uint8_t>(p.words[0] & 0xFF);
+        out = {choc::midi::ShortMessage(s, d1, d2), 0, 0.0};
+        return true;
+    }
+    if (mt != UmpMessageType::Midi2ChannelVoice) return false;
+
+    const uint8_t status_byte = static_cast<uint8_t>((p.words[0] >> 16) & 0xF0);
+    switch (status_byte) {
+        case 0x80:
+            out = MidiEvent::note_off(ch, p.note_number(),
+                                      scale_16_to_7(p.velocity_16()));
+            return true;
+        case 0x90: {
+            // MIDI 2.0 velocity 0 is *not* a note-off (that's an explicit
+            // 0x80 status). Clamp to 1 so the MIDI 1.0 representation
+            // stays semantically a note-on.
+            const uint16_t v16 = p.velocity_16();
+            uint8_t v7 = scale_16_to_7(v16);
+            if (v16 > 0 && v7 == 0) v7 = 1;
+            out = MidiEvent::note_on(ch, p.note_number(), v7);
+            return true;
+        }
+        case 0xB0:
+            out = MidiEvent::cc(ch, static_cast<uint8_t>((p.words[0] >> 8) & 0x7F),
+                                static_cast<uint8_t>(p.data_32() >> 25));
+            return true;
+        case 0xE0:
+            out = MidiEvent::pitch_bend(ch, scale_32_to_14(p.data_32()));
+            return true;
+        default:
+            return false;
+    }
+}
+
+/// Flatten a UmpBuffer into a MidiBuffer. Packets that have no MIDI 1.0
+/// equivalent are skipped; if you care about them, use the MPE sidecar.
+inline void ump_to_midi1(const UmpBuffer& src, MidiBuffer& dst) {
+    for (const auto& ue : src) {
+        MidiEvent ev{};
+        if (ump_to_midi1_event(ue.packet, ev)) {
+            ev.sample_offset = ue.sample_offset;
+            dst.add(ev);
+        }
+    }
+}
+
+} // namespace pulp::midi

--- a/docs/guides/mpe.md
+++ b/docs/guides/mpe.md
@@ -93,8 +93,52 @@ lowpass.
 - **Phase 1** — `MpeVoiceTracker` (landed)
 - **Phase 2** — `MpeBuffer` sidecar, `Processor::mpe_input()`, CLAP wiring (landed)
 - **Phase 3** — `MpeSynthVoice`, `MpeVoiceAllocator`, `MpeGlideDetector`, `examples/mpe-synth/` (landed)
-- **Phase 4** — MIDI 2.0 UMP native path (deferred)
+- **Phase 4** — MIDI 2.0 UMP native path (landed)
 
 VST3 and AU adapters will gain the same sidecar wiring in a follow-up
 pass; the API is stable so plugins can opt in today and benefit
 automatically once the other adapters ship.
+
+## MIDI 2.0 UMP sidecar
+
+Plugins that want native MIDI 2.0 resolution — 16-bit velocity, per-note
+pitch bend, per-note CCs — can opt in separately:
+
+```cpp
+PluginDescriptor descriptor() const override {
+    return {
+        // ...
+        .accepts_midi = true,
+        .supports_ump = true,   // ← MIDI 2.0 UMP sidecar
+    };
+}
+
+void process(...) override {
+    if (const auto* ump = ump_input()) {
+        for (const auto& ue : *ump) {
+            // ue.packet is a UmpPacket, ue.sample_offset is sample-accurate
+        }
+    }
+}
+```
+
+`supports_mpe` and `supports_ump` are independent and can both be set.
+The CLAP adapter populates the UMP sidecar by converting the inbound
+MIDI 1.0 stream with `midi1_to_ump()`; when CLAP ships
+`CLAP_EVENT_MIDI2` the adapter will feed the host's native packets
+directly with no code change on the plugin side.
+
+`MpeVoiceTracker::process(UmpPacket)` accepts UMP input in addition to
+`MidiEvent`, routing MIDI 2.0 per-note pitch bend (status `0x60`) and
+per-note CC (status `0x00`) directly to the matching note rather than
+via the member-channel cache, so per-note expression stays truly
+per-note even within the same MPE member channel.
+
+Helpers in `pulp/midi/ump_conversion.hpp`:
+
+| Function | Purpose |
+|----------|---------|
+| `midi1_to_ump(MidiBuffer&, UmpBuffer&)` | Convert a MIDI 1.0 block to MIDI 2.0 UMP packets, preserving sample offsets |
+| `ump_to_midi1(UmpBuffer&, MidiBuffer&)` | Flatten UMP back to MIDI 1.0 (packets with no MIDI 1.0 equivalent are skipped — route those via `mpe_input()`) |
+| `scale_7_to_16` / `scale_16_to_7` | Velocity scaling, round-trip-preserving for exact values |
+| `scale_14_to_32` / `scale_32_to_14` | Pitch-bend scaling with centre (0x2000 ↔ 0x80000000) preserved exactly |

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -748,6 +748,11 @@ add_executable(pulp-test-mpe-voice-tracker test_mpe_voice_tracker.cpp)
 target_link_libraries(pulp-test-mpe-voice-tracker PRIVATE pulp::midi Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-mpe-voice-tracker)
 
+# UMP buffer + MIDI 1.0 <-> UMP conversion + UMP-aware MpeVoiceTracker
+add_executable(pulp-test-ump-buffer-conversion test_ump_buffer_conversion.cpp)
+target_link_libraries(pulp-test-ump-buffer-conversion PRIVATE pulp::format Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-ump-buffer-conversion)
+
 # MPE buffer + Processor sidecar tests
 add_executable(pulp-test-mpe-buffer test_mpe_buffer.cpp)
 target_link_libraries(pulp-test-mpe-buffer PRIVATE pulp::format Catch2::Catch2WithMain)

--- a/test/test_ump_buffer_conversion.cpp
+++ b/test/test_ump_buffer_conversion.cpp
@@ -1,0 +1,133 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <pulp/format/processor.hpp>
+#include <pulp/midi/ump_buffer.hpp>
+#include <pulp/midi/ump_conversion.hpp>
+#include <pulp/midi/mpe_voice_tracker.hpp>
+
+using namespace pulp::midi;
+using Catch::Approx;
+
+TEST_CASE("UmpBuffer sort + clear", "[midi][ump]") {
+    UmpBuffer buf;
+    buf.add(UmpPacket::note_on_2(0, 0, 60, 0x8000), 30);
+    buf.add(UmpPacket::note_on_2(0, 0, 62, 0x8000), 10);
+    buf.add(UmpPacket::note_on_2(0, 0, 64, 0x8000), 20);
+    REQUIRE(buf.size() == 3);
+    buf.sort();
+    REQUIRE(buf[0].sample_offset == 10);
+    REQUIRE(buf[2].sample_offset == 30);
+    buf.clear();
+    REQUIRE(buf.empty());
+}
+
+TEST_CASE("Processor::supports_ump defaults to false", "[midi][ump]") {
+    pulp::format::PluginDescriptor desc;
+    REQUIRE_FALSE(desc.supports_ump);
+}
+
+TEST_CASE("scale_7_to_16 preserves 0 and expands 127", "[midi][ump]") {
+    REQUIRE(scale_7_to_16(0) == 0);
+    REQUIRE(scale_7_to_16(127) == 0xFFFF);   // spec says 127 → 0xFFFF
+    REQUIRE(scale_7_to_16(64) > 0x7FFF);
+}
+
+TEST_CASE("scale_16_to_7 inverts scale_7_to_16 for common values", "[midi][ump]") {
+    for (uint8_t v : {uint8_t(0), uint8_t(1), uint8_t(63), uint8_t(100), uint8_t(127)}) {
+        REQUIRE(scale_16_to_7(scale_7_to_16(v)) == v);
+    }
+}
+
+TEST_CASE("scale_14_to_32 / scale_32_to_14 preserve centre", "[midi][ump]") {
+    REQUIRE(scale_14_to_32(0x2000) == 0x80000000u);
+    REQUIRE(scale_32_to_14(0x80000000u) == 0x2000);
+}
+
+TEST_CASE("midi1_to_ump round-trip via ump_to_midi1", "[midi][ump]") {
+    MidiBuffer in;
+    in.add(MidiEvent::note_on(1, 60, 100));
+    in.add(MidiEvent::note_off(1, 60, 0));
+    in.add(MidiEvent::cc(2, 74, 64));
+    in.add(MidiEvent::pitch_bend(3, 16383));
+    in.add(MidiEvent::note_on(4, 72, 1));
+
+    UmpBuffer ump;
+    midi1_to_ump(in, ump);
+    REQUIRE(ump.size() == in.size());
+    for (const auto& ue : ump) {
+        REQUIRE(ue.packet.message_type() == UmpMessageType::Midi2ChannelVoice);
+    }
+
+    MidiBuffer out;
+    ump_to_midi1(ump, out);
+    REQUIRE(out.size() == in.size());
+
+    // Note-on with velocity 100 round-trips exactly.
+    REQUIRE(out[0].is_note_on());
+    REQUIRE(out[0].note() == 60);
+    REQUIRE(out[0].velocity() == 100);
+
+    // Note-off round-trips.
+    REQUIRE(out[1].is_note_off());
+    REQUIRE(out[1].note() == 60);
+
+    // CC 74.
+    REQUIRE(out[2].is_cc());
+    REQUIRE(out[2].cc_number() == 74);
+    REQUIRE(out[2].cc_value() == 64);
+
+    // Pitch bend maxes out.
+    REQUIRE(out[3].is_pitch_bend());
+
+    // Tiny velocity clamped to 1 (not zero, which would be a note-off).
+    REQUIRE(out[4].is_note_on());
+    REQUIRE(out[4].velocity() >= 1);
+}
+
+TEST_CASE("MpeVoiceTracker ingests UMP MIDI 2.0 note-on", "[midi][ump][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    // Member channel 1, note 60, half velocity (0x8000 → ~64 for 7-bit view).
+    auto p = UmpPacket::note_on_2(0, 1, 60, 0x8000);
+    REQUIRE(tracker.process(p));
+    const auto* n = tracker.find(1, 60);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->channel == 1);
+    REQUIRE(n->note == 60);
+}
+
+TEST_CASE("MpeVoiceTracker applies UMP per-note pitch bend to one note", "[midi][ump][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.set_member_bend_range(48.0f);
+    tracker.process(UmpPacket::note_on_2(0, 1, 60, 0x8000));
+    tracker.process(UmpPacket::note_on_2(0, 1, 67, 0x8000));  // two notes same channel
+
+    // Per-note pitch bend on note 67 only — note 60 should be unaffected.
+    tracker.process(UmpPacket::per_note_pitch_bend(0, 1, 67, 0xFFFFFFFFu));
+    const auto* n60 = tracker.find(1, 60);
+    const auto* n67 = tracker.find(1, 67);
+    REQUIRE(n60 != nullptr);
+    REQUIRE(n67 != nullptr);
+    REQUIRE(n60->pitch_bend_semitones == Approx(0.0f).margin(0.01f));
+    REQUIRE(n67->pitch_bend_semitones > 40.0f);
+}
+
+TEST_CASE("MpeVoiceTracker applies UMP channel pitch bend to all notes on channel", "[midi][ump][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.set_member_bend_range(48.0f);
+    tracker.process(UmpPacket::note_on_2(0, 2, 72, 0x8000));
+
+    // Max positive channel pitch bend (all-ones) → +48 semitones.
+    tracker.process(UmpPacket::pitch_bend_2(0, 2, 0xFFFFFFFFu));
+    const auto* n = tracker.find(2, 72);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->pitch_bend_semitones > 40.0f);
+}
+
+TEST_CASE("MpeVoiceTracker note-off via UMP status 0x80", "[midi][ump][mpe]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(UmpPacket::note_on_2(0, 3, 64, 0x8000));
+    REQUIRE(tracker.active_count() == 1);
+    tracker.process(UmpPacket::note_off_2(0, 3, 64));
+    REQUIRE(tracker.active_count() == 0);
+}

--- a/test/test_ump_buffer_conversion.cpp
+++ b/test/test_ump_buffer_conversion.cpp
@@ -124,6 +124,21 @@ TEST_CASE("MpeVoiceTracker applies UMP channel pitch bend to all notes on channe
     REQUIRE(n->pitch_bend_semitones > 40.0f);
 }
 
+TEST_CASE("MpeVoiceTracker routes UMP per-note CC 74 by controller index", "[midi][ump][mpe]") {
+    // Regression for PR #141 Codex P1: the per-note controller index lives
+    // in byte 3 (bits 0-7) of word 0, NOT byte 2 (which is the note number).
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.process(UmpPacket::note_on_2(0, 1, 60, 0x8000));
+
+    // Per-note CC 74 (timbre) on note 60, full value. Before the fix,
+    // this was silently ignored because the code read the note byte (60)
+    // as the controller index.
+    tracker.process(UmpPacket::registered_per_note_cc(0, 1, 60, 74, 0xFFFFFFFFu));
+    const auto* n = tracker.find(1, 60);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->timbre > 0.9f);
+}
+
 TEST_CASE("MpeVoiceTracker note-off via UMP status 0x80", "[midi][ump][mpe]") {
     MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
     tracker.process(UmpPacket::note_on_2(0, 3, 64, 0x8000));


### PR DESCRIPTION
## Summary

Implements Phase 4 of MPE support: a MIDI 2.0 UMP opt-in sidecar parallel to the existing MPE sidecar. Plugins that declare \`supports_ump = true\` receive a sample-accurate \`UmpBuffer\` via \`Processor::ump_input()\` during \`process()\`. \`MpeVoiceTracker\` now also ingests \`UmpPacket\`s, routing per-note pitch bend and per-note CCs directly to the matching note (full MIDI 2.0 resolution, no channel-steering heuristic).

The CLAP adapter populates the sidecar by converting inbound MIDI 1.0 events with \`midi1_to_ump()\` until CLAP ships \`CLAP_EVENT_MIDI2\`; plugins see a stable API either way.

Closes #139.

## Test plan
- [x] \`pulp-test-ump-buffer-conversion\` — 10 cases / 45 assertions, incl. scaling round-trips, centre preservation, MIDI 1.0 ↔ UMP equivalence, UMP per-note bend isolation
- [x] Existing MPE tests still green (tracker / buffer / synth voice / mpe-synth)
- [x] Full local build + CLAP dlopen for PulpMpeSynth
- [ ] Shipyard ship — mac + Namespace Linux/Windows