### PR TITLE
SignalGraph: full DAW hosting engine (Feature 5 Phases 1-3)

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -107,3 +107,11 @@ Validates consistency across the three version-bearing surfaces:
 - Marketplace: top-level `"version"` in `.claude-plugin/marketplace.json` (must match `plugin.json`).
 
 Gotcha: JSON files can have multiple `"version"` fields (e.g. `metadata.version`, `plugins[0].version`). The check anchors on the top-level field via a `^(?:  )?"version":` regex — don't introduce a JSON parser unless you genuinely need schema validation.
+
+
+### Note: pulp scan / pulp host added
+
+These commands live in `tools/cli/cmd_host.cpp` (scan + host share a
+file). When changing scanner.scan() signatures, update cmd_host.cpp's
+ScanOptions construction in lockstep — the cross-format loop builds an
+options struct per iteration.

--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: hosting
+description: |
+  Load, run, and test VST3 / AU / CLAP / LV2 plugins from Pulp code. Use
+  when working on `core/host/` (scanner, plugin_slot, signal_graph), when
+  adding a new format backend, when wiring a plugin into a SignalGraph, or
+  when writing an integration test that needs a real plug-in binary.
+---
+
+# hosting
+
+## When this skill applies
+
+- Adding or modifying a format backend under `core/host/src/plugin_slot_<format>.cpp`.
+- Extending `PluginSlot::load()` to handle a new format in `core/host/src/plugin_slot.cpp`.
+- Building or routing nodes in `SignalGraph`.
+- Writing tests that need to load a real plug-in binary.
+
+## Mental model
+
+`PluginSlot` is the uniform interface. Each format backend is a single
+free function — `load_<format>_plugin(info)` — that returns a
+`std::unique_ptr<PluginSlot>` or `nullptr`. `PluginSlot::load()` in
+`plugin_slot.cpp` is a small compile-time dispatcher. There is no dynamic
+registry and no plug-in-per-file hooks; adding a format means:
+
+1. Write `core/host/src/plugin_slot_<fmt>.cpp` that defines
+   `std::unique_ptr<PluginSlot> load_<fmt>_plugin(const PluginInfo&)`.
+2. Add the file to `core/host/CMakeLists.txt` under a `if(PULP_HAS_<FMT>)`
+   guard. Link the format's SDK. Define `PULP_HOST_HAS_<FMT>=1`.
+3. Forward-declare the loader and add a `case PluginFormat::<FMT>:` to
+   the dispatcher in `plugin_slot.cpp`, guarded by the same macro.
+
+Everything else — tests, scanner, graph wiring — is format-agnostic.
+
+## CLAP reference backend
+
+`plugin_slot_clap.cpp` is the one real backend today. Patterns to mirror:
+
+- `dlopen(RTLD_LAZY | RTLD_LOCAL)`; on macOS resolve
+  `<bundle>.clap/Contents/MacOS/<name>` before `dlopen`.
+- `dlsym("clap_entry")`; call `entry->init(path)` exactly once before
+  `entry->get_factory(...)`, and `entry->deinit()` + `dlclose()` in the
+  slot's destructor.
+- Pick factory descriptor by `info.unique_id` when set, else first
+  available. Then fill the returned `PluginInfo` with any missing
+  name / vendor / version / id fields from the descriptor.
+- The slot must own the `clap_host_t` it exposes to the plug-in; the
+  plug-in stores the pointer and will deref it later.
+
+## Testing against a real plug-in
+
+Integration tests gate on a compile-time path macro:
+
+```cmake
+if(TARGET PulpGain_CLAP)
+    target_compile_definitions(pulp-test-host PRIVATE
+        PULP_TEST_CLAP_PATH="${CMAKE_BINARY_DIR}/CLAP/PulpGain.clap")
+    add_dependencies(pulp-test-host PulpGain_CLAP)
+endif()
+```
+
+Tests check `fs::exists(PULP_TEST_CLAP_PATH)` and `WARN` + return if the
+plug-in isn't built, so the suite still passes on configurations that
+skip the plug-in builds (Android, CI without GPU examples, etc.).
+
+Pattern for a process test: load, `prepare(48000, 256)`, fill an input
+buffer with non-zero samples, call `process`, assert the output buffer
+has non-zero energy. A gain plug-in is the cheapest target — one param,
+predictable output, no MIDI.
+
+## Signal graph gotchas
+
+- `connect()` returns `false` on cycle — always check. `would_create_cycle`
+  lets you preview without mutating.
+- `processing_order()` is recomputed each call; cache it in the audio
+  thread, don't recompute per block.
+- Removing a node invalidates its `NodeId`. Connections referencing a
+  removed node are pruned automatically.
+
+## Common tripwires
+
+- Building `pulp-host` without adding a new `.cpp` to `target_sources` —
+  the file sits on disk but isn't compiled; link errors fire only in the
+  dispatcher's `case`. **Always** update `core/host/CMakeLists.txt`
+  alongside adding a backend.
+- Missing `PULP_HOST_HAS_<FMT>` define — dispatcher silently returns
+  `nullptr`. Verify `grep PULP_HOST_HAS_ build/CMakeCache.txt` after
+  configure.
+- CLAP bundles on macOS: don't `dlopen` the `.clap` directory; resolve to
+  the executable inside `Contents/MacOS/` first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to Pulp are documented here.
 
+## [0.5.0]
+
 ## [0.3.0]
 
 ## [0.4.0]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.4.0
+    VERSION 0.5.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/CMakeLists.txt
+++ b/core/host/CMakeLists.txt
@@ -32,6 +32,16 @@ if(PULP_HAS_VST3)
     target_compile_definitions(pulp-host PRIVATE PULP_HOST_HAS_VST3=1)
 endif()
 
+# LV2 loader (requires LV2 headers)
+if(TARGET lv2-headers)
+    target_sources(pulp-host PRIVATE src/plugin_slot_lv2.cpp)
+    target_link_libraries(pulp-host PRIVATE lv2-headers)
+    target_compile_definitions(pulp-host PRIVATE PULP_HOST_HAS_LV2=1)
+    if(UNIX)
+        target_link_libraries(pulp-host PRIVATE ${CMAKE_DL_LIBS})
+    endif()
+endif()
+
 # Audio Unit loader + API-based scanner (macOS only, no external SDK)
 if(APPLE)
     target_sources(pulp-host PRIVATE

--- a/core/host/CMakeLists.txt
+++ b/core/host/CMakeLists.txt
@@ -24,3 +24,18 @@ if(PULP_HAS_CLAP)
     target_link_libraries(pulp-host PRIVATE clap)
     target_compile_definitions(pulp-host PRIVATE PULP_HOST_HAS_CLAP=1)
 endif()
+
+# Audio Unit loader + API-based scanner (macOS only, no external SDK)
+if(APPLE)
+    target_sources(pulp-host PRIVATE
+        src/plugin_slot_au.mm
+        src/scanner_au.mm
+    )
+    target_link_libraries(pulp-host PRIVATE
+        "-framework AudioToolbox"
+        "-framework AudioUnit"
+        "-framework CoreAudio"
+        "-framework CoreFoundation"
+    )
+    target_compile_definitions(pulp-host PRIVATE PULP_HOST_HAS_AU=1)
+endif()

--- a/core/host/CMakeLists.txt
+++ b/core/host/CMakeLists.txt
@@ -25,6 +25,13 @@ if(PULP_HAS_CLAP)
     target_compile_definitions(pulp-host PRIVATE PULP_HOST_HAS_CLAP=1)
 endif()
 
+# VST3 loader (requires VST3 SDK)
+if(PULP_HAS_VST3)
+    target_sources(pulp-host PRIVATE src/plugin_slot_vst3.cpp)
+    target_link_libraries(pulp-host PRIVATE vst3-sdk)
+    target_compile_definitions(pulp-host PRIVATE PULP_HOST_HAS_VST3=1)
+endif()
+
 # Audio Unit loader + API-based scanner (macOS only, no external SDK)
 if(APPLE)
     target_sources(pulp-host PRIVATE

--- a/core/host/CMakeLists.txt
+++ b/core/host/CMakeLists.txt
@@ -15,9 +15,12 @@ target_sources(pulp-host PRIVATE
 
 target_link_libraries(pulp-host PUBLIC pulp::audio pulp::midi pulp::runtime)
 
-# CLAP plugin loader (requires CLAP SDK)
+# CLAP plugin loader + scanner (requires CLAP SDK)
 if(PULP_HAS_CLAP)
-    target_sources(pulp-host PRIVATE src/plugin_slot_clap.cpp)
+    target_sources(pulp-host PRIVATE
+        src/plugin_slot_clap.cpp
+        src/scanner_clap.cpp
+    )
     target_link_libraries(pulp-host PRIVATE clap)
     target_compile_definitions(pulp-host PRIVATE PULP_HOST_HAS_CLAP=1)
 endif()

--- a/core/host/CMakeLists.txt
+++ b/core/host/CMakeLists.txt
@@ -14,3 +14,10 @@ target_sources(pulp-host PRIVATE
 )
 
 target_link_libraries(pulp-host PUBLIC pulp::audio pulp::midi pulp::runtime)
+
+# CLAP plugin loader (requires CLAP SDK)
+if(PULP_HAS_CLAP)
+    target_sources(pulp-host PRIVATE src/plugin_slot_clap.cpp)
+    target_link_libraries(pulp-host PRIVATE clap)
+    target_compile_definitions(pulp-host PRIVATE PULP_HOST_HAS_CLAP=1)
+endif()

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -76,6 +76,13 @@ public:
     NodeId add_input_node(int channels, const std::string& name = "Input");
     NodeId add_output_node(int channels, const std::string& name = "Output");
     NodeId add_plugin_node(const PluginInfo& info);
+
+    // Add a plugin node wrapping a caller-provided slot. Useful for tests
+    // (mock latency, mock processing) and for hosts that build their own
+    // PluginSlot implementations outside of PluginSlot::load().
+    NodeId add_plugin_node(std::unique_ptr<PluginSlot> slot,
+                           int num_inputs, int num_outputs,
+                           const std::string& name = "Plugin");
     NodeId add_gain_node(const std::string& name = "Gain");
     NodeId add_midi_input_node(const std::string& name = "MIDI In");
     NodeId add_midi_output_node(const std::string& name = "MIDI Out");
@@ -118,6 +125,15 @@ public:
     bool set_node_gain(NodeId id, float linear_gain);
     float node_gain(NodeId id) const;
 
+    // Latency in samples from any AudioInput to the graph's AudioOutput, as
+    // computed by prepare(). Reflects plugin-reported latencies plus any
+    // delay inserted by PDC. Returns 0 when not prepared.
+    int latency_samples() const { return (int)total_latency_samples_; }
+
+    // Latency arriving at a specific node's input (samples). Returns 0 when
+    // the node is unknown or the graph is not prepared.
+    int node_latency_samples(NodeId id) const;
+
 private:
     struct NodeRuntime {
         // Per-node output-port channel storage (interleaved per-port, flat).
@@ -130,6 +146,24 @@ private:
         std::vector<float> input_data;
         std::vector<float*> input_ptrs;
         float gain = 1.0f;
+
+        // PDC: cumulative samples of latency from AudioInput to this node's
+        // input ports (input_latency) and output ports (output_latency).
+        // output_latency = input_latency + (plugin->latency_samples() for
+        // Plugin nodes, 0 otherwise).
+        int64_t input_latency = 0;
+        int64_t output_latency = 0;
+    };
+
+    // One delay line per graph connection, parallel to connections_. Used to
+    // align branch latencies so a node receives all its inbound audio with a
+    // common alignment at input_latency samples.
+    struct ConnectionDelay {
+        int delay_samples = 0;
+        // Ring buffer: delay_samples + max_block_size_ frames per source
+        // channel. Empty when delay_samples == 0 (pass-through path).
+        std::vector<float> ring;
+        int write_pos = 0;
     };
 
     std::vector<GraphNode> nodes_;
@@ -139,11 +173,14 @@ private:
     // Populated by prepare(); consumed by process(). Kept flat rather than
     // per-node to keep allocation lifetime predictable.
     std::unordered_map<NodeId, NodeRuntime> runtime_;
+    std::vector<ConnectionDelay> connection_delays_;  // parallel to connections_
     std::vector<NodeId> cached_order_;
     int max_block_size_ = 0;
     bool prepared_ = false;
+    int64_t total_latency_samples_ = 0;
 
     bool has_path(NodeId from, NodeId to) const;
+    void compute_latencies_();
 };
 
 } // namespace pulp::host

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -46,6 +46,8 @@ struct Connection {
     PortIndex source_port;
     NodeId dest_node;
     PortIndex dest_port;
+    bool feedback = false;  // back-edge: reads previous block's audio, breaks
+                            // the cycle for topological sort and PDC.
 
     bool operator==(const Connection& o) const {
         return source_node == o.source_node && source_port == o.source_port
@@ -93,6 +95,13 @@ public:
     // Connect two nodes (port-to-port)
     bool connect(NodeId source, PortIndex source_port,
                  NodeId dest, PortIndex dest_port);
+
+    // Connect with an explicit one-block delay. Permitted to close a cycle
+    // (the back-edge the user is intentionally introducing) and invisible to
+    // topological sort. The destination reads the source's previous-block
+    // output, giving the feedback loop a block-sized delay.
+    bool connect_feedback(NodeId source, PortIndex source_port,
+                          NodeId dest, PortIndex dest_port);
 
     // Disconnect
     bool disconnect(NodeId source, PortIndex source_port,
@@ -164,6 +173,9 @@ private:
         // channel. Empty when delay_samples == 0 (pass-through path).
         std::vector<float> ring;
         int write_pos = 0;
+        // Feedback edges hold the previous block's source-port audio so the
+        // destination can read it before the source writes the current block.
+        std::vector<float> feedback_prev;  // size = max_block_size_
     };
 
     std::vector<GraphNode> nodes_;

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -159,6 +159,17 @@ public:
     // the node is unknown or the graph is not prepared.
     int node_latency_samples(NodeId id) const;
 
+    // Set a parameter on a Plugin node at the graph level. The call is
+    // forwarded to PluginSlot::set_parameter(). Returns false if the node
+    // is not a Plugin node or has no loaded slot. This is the single-value
+    // knob — full automation-curve routing (one node's output driving
+    // another node's parameter over a block) is follow-up work.
+    bool set_node_parameter(NodeId id, uint32_t param_id, float value);
+
+    // Read a parameter's current value from a Plugin node (returns 0.0f if
+    // the node is not a Plugin or has no slot).
+    float get_node_parameter(NodeId id, uint32_t param_id) const;
+
 private:
     struct NodeRuntime {
         // Per-node output-port channel storage (interleaved per-port, flat).

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -48,6 +48,8 @@ struct Connection {
     PortIndex dest_port;
     bool feedback = false;  // back-edge: reads previous block's audio, breaks
                             // the cycle for topological sort and PDC.
+    bool midi = false;      // event-edge: routes MidiBuffer events instead of
+                            // audio samples. Ports are ignored.
 
     bool operator==(const Connection& o) const {
         return source_node == o.source_node && source_port == o.source_port
@@ -102,6 +104,20 @@ public:
     // output, giving the feedback loop a block-sized delay.
     bool connect_feedback(NodeId source, PortIndex source_port,
                           NodeId dest, PortIndex dest_port);
+
+    // MIDI connection: routes events from source's MIDI output into dest's
+    // MIDI input. Ports are ignored (MIDI is node-scoped, not port-scoped).
+    // Participates in cycle detection and topological sort the same way as
+    // audio connections.
+    bool connect_midi(NodeId source, NodeId dest);
+
+    // Inject a MIDI buffer into a MidiInput source node. Call before
+    // process(); the events become that node's MIDI output this block.
+    bool inject_midi(NodeId midi_input_node, const midi::MidiBuffer& events);
+
+    // Drain the MIDI events that arrived at a MidiOutput sink node during
+    // the last process() call. Appends to `out`.
+    bool extract_midi(NodeId midi_output_node, midi::MidiBuffer& out) const;
 
     // Disconnect
     bool disconnect(NodeId source, PortIndex source_port,
@@ -162,6 +178,12 @@ private:
         // Plugin nodes, 0 otherwise).
         int64_t input_latency = 0;
         int64_t output_latency = 0;
+
+        // MIDI scratch. Cleared at the start of each process() call except
+        // for MidiInput nodes, whose midi_out is populated by inject_midi()
+        // and must survive the process() entry-clear.
+        midi::MidiBuffer midi_in;
+        midi::MidiBuffer midi_out;
     };
 
     // One delay line per graph connection, parallel to connections_. Used to

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -19,6 +19,7 @@
 #include <pulp/midi/buffer.hpp>
 #include <memory>
 #include <vector>
+#include <unordered_map>
 #include <string>
 #include <cstdint>
 
@@ -113,10 +114,34 @@ public:
     // Clear all nodes and connections
     void clear();
 
+    // Gain for a Gain node (linear, not dB). Defaults to 1.0.
+    bool set_node_gain(NodeId id, float linear_gain);
+    float node_gain(NodeId id) const;
+
 private:
+    struct NodeRuntime {
+        // Per-node output-port channel storage (interleaved per-port, flat).
+        // data_ has size num_output_ports * max_block_size_; channel_ptrs_[p]
+        // points at data_[p * max_block_size_].
+        std::vector<float> output_data;
+        std::vector<float*> output_ptrs;
+        // Per-node input-port scratch — callers write into these before the
+        // node processes, then zero before the next block.
+        std::vector<float> input_data;
+        std::vector<float*> input_ptrs;
+        float gain = 1.0f;
+    };
+
     std::vector<GraphNode> nodes_;
     std::vector<Connection> connections_;
     NodeId next_id_ = 1;
+
+    // Populated by prepare(); consumed by process(). Kept flat rather than
+    // per-node to keep allocation lifetime predictable.
+    std::unordered_map<NodeId, NodeRuntime> runtime_;
+    std::vector<NodeId> cached_order_;
+    int max_block_size_ = 0;
+    bool prepared_ = false;
 
     bool has_path(NodeId from, NodeId to) const;
 };

--- a/core/host/src/plugin_slot.cpp
+++ b/core/host/src/plugin_slot.cpp
@@ -16,6 +16,9 @@ std::unique_ptr<PluginSlot> load_clap_plugin(const PluginInfo& info);
 #if PULP_HOST_HAS_AU
 std::unique_ptr<PluginSlot> load_au_plugin(const PluginInfo& info);
 #endif
+#if PULP_HOST_HAS_VST3
+std::unique_ptr<PluginSlot> load_vst3_plugin(const PluginInfo& info);
+#endif
 
 std::unique_ptr<PluginSlot> PluginSlot::load(const PluginInfo& info) {
     switch (info.format) {
@@ -35,8 +38,14 @@ std::unique_ptr<PluginSlot> PluginSlot::load(const PluginInfo& info) {
             return nullptr;
 #endif
         case PluginFormat::VST3:
+#if PULP_HOST_HAS_VST3
+            return load_vst3_plugin(info);
+#else
+            runtime::log_warn("PluginSlot::load: VST3 loader not compiled in");
+            return nullptr;
+#endif
         case PluginFormat::LV2:
-            runtime::log_warn("PluginSlot::load: loader for this format not yet implemented ('{}')",
+            runtime::log_warn("PluginSlot::load: LV2 loader not yet implemented ('{}')",
                               info.path);
             return nullptr;
     }

--- a/core/host/src/plugin_slot.cpp
+++ b/core/host/src/plugin_slot.cpp
@@ -13,6 +13,9 @@ namespace pulp::host {
 #if PULP_HOST_HAS_CLAP
 std::unique_ptr<PluginSlot> load_clap_plugin(const PluginInfo& info);
 #endif
+#if PULP_HOST_HAS_AU
+std::unique_ptr<PluginSlot> load_au_plugin(const PluginInfo& info);
+#endif
 
 std::unique_ptr<PluginSlot> PluginSlot::load(const PluginInfo& info) {
     switch (info.format) {
@@ -23,9 +26,15 @@ std::unique_ptr<PluginSlot> PluginSlot::load(const PluginInfo& info) {
             runtime::log_warn("PluginSlot::load: CLAP loader not compiled in");
             return nullptr;
 #endif
-        case PluginFormat::VST3:
         case PluginFormat::AudioUnit:
         case PluginFormat::AudioUnitV3:
+#if PULP_HOST_HAS_AU
+            return load_au_plugin(info);
+#else
+            runtime::log_warn("PluginSlot::load: AU loader only available on macOS");
+            return nullptr;
+#endif
+        case PluginFormat::VST3:
         case PluginFormat::LV2:
             runtime::log_warn("PluginSlot::load: loader for this format not yet implemented ('{}')",
                               info.path);

--- a/core/host/src/plugin_slot.cpp
+++ b/core/host/src/plugin_slot.cpp
@@ -19,6 +19,9 @@ std::unique_ptr<PluginSlot> load_au_plugin(const PluginInfo& info);
 #if PULP_HOST_HAS_VST3
 std::unique_ptr<PluginSlot> load_vst3_plugin(const PluginInfo& info);
 #endif
+#if PULP_HOST_HAS_LV2
+std::unique_ptr<PluginSlot> load_lv2_plugin(const PluginInfo& info);
+#endif
 
 std::unique_ptr<PluginSlot> PluginSlot::load(const PluginInfo& info) {
     switch (info.format) {
@@ -45,9 +48,12 @@ std::unique_ptr<PluginSlot> PluginSlot::load(const PluginInfo& info) {
             return nullptr;
 #endif
         case PluginFormat::LV2:
-            runtime::log_warn("PluginSlot::load: LV2 loader not yet implemented ('{}')",
-                              info.path);
+#if PULP_HOST_HAS_LV2
+            return load_lv2_plugin(info);
+#else
+            runtime::log_warn("PluginSlot::load: LV2 loader not compiled in");
             return nullptr;
+#endif
     }
     return nullptr;
 }

--- a/core/host/src/plugin_slot.cpp
+++ b/core/host/src/plugin_slot.cpp
@@ -1,21 +1,36 @@
-// Plugin Slot stub implementation
-// Full implementation requires loading format-specific plugin binaries
-// (VST3 via IPluginFactory, CLAP via clap_entry, AU via AudioComponent).
-// This stub returns nullptr — real loading is a future deliverable.
+// PluginSlot::load() — format dispatcher.
+//
+// Routes the load request to the format-specific loader. Each loader lives
+// in its own translation unit (plugin_slot_clap.cpp, plugin_slot_vst3.cpp,
+// …) and is compiled in only when the relevant SDK is available, guarded
+// by PULP_HOST_HAS_<FORMAT> compile definitions in core/host/CMakeLists.txt.
 
 #include <pulp/host/plugin_slot.hpp>
 #include <pulp/runtime/log.hpp>
 
 namespace pulp::host {
 
+#if PULP_HOST_HAS_CLAP
+std::unique_ptr<PluginSlot> load_clap_plugin(const PluginInfo& info);
+#endif
+
 std::unique_ptr<PluginSlot> PluginSlot::load(const PluginInfo& info) {
-    // TODO: implement format-specific plugin loading
-    // - VST3: dlopen → GetPluginFactory → createInstance
-    // - CLAP: dlopen → clap_entry → create_plugin
-    // - AU: AudioComponentFindNext → AudioComponentInstanceNew
-    // - LV2: lilv world scan → instantiate
-    runtime::log_info("PluginSlot::load(): stub for '{}' ({})",
-                      info.name, info.path);
+    switch (info.format) {
+        case PluginFormat::CLAP:
+#if PULP_HOST_HAS_CLAP
+            return load_clap_plugin(info);
+#else
+            runtime::log_warn("PluginSlot::load: CLAP loader not compiled in");
+            return nullptr;
+#endif
+        case PluginFormat::VST3:
+        case PluginFormat::AudioUnit:
+        case PluginFormat::AudioUnitV3:
+        case PluginFormat::LV2:
+            runtime::log_warn("PluginSlot::load: loader for this format not yet implemented ('{}')",
+                              info.path);
+            return nullptr;
+    }
     return nullptr;
 }
 

--- a/core/host/src/plugin_slot_au.mm
+++ b/core/host/src/plugin_slot_au.mm
@@ -1,0 +1,405 @@
+// Audio Unit v2 plugin slot (macOS only).
+//
+// Loads an AU v2 effect/instrument via AudioComponent APIs, exposes the
+// PluginSlot interface, and drives audio through AudioUnitRender. Scope
+// for Phase 1: stereo in/out, parameter metadata, bypass, basic
+// activation. MIDI routing to instruments is Phase 2; editor view,
+// state save/restore via ClassInfo, and sidechain ports land later.
+//
+// Identified by {componentType, componentSubType, componentManufacturer}
+// encoded into PluginInfo.unique_id as "TYPE:SUBT:MANU" (OSType 4CCs).
+// Scanner fills this in via scanner_au.mm.
+
+#include <pulp/host/plugin_slot.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include <AudioToolbox/AudioToolbox.h>
+#include <AudioUnit/AudioUnit.h>
+#include <CoreAudioTypes/CoreAudioTypes.h>
+
+#include <atomic>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace pulp::host {
+namespace {
+
+bool parse_4cc_triplet(const std::string& id, OSType& t, OSType& s, OSType& m) {
+    // Expect "XXXX:YYYY:ZZZZ" with each field exactly 4 ASCII characters.
+    if (id.size() != 14 || id[4] != ':' || id[9] != ':') return false;
+    auto pack = [](const char* p) -> OSType {
+        return (static_cast<OSType>(static_cast<uint8_t>(p[0])) << 24)
+             | (static_cast<OSType>(static_cast<uint8_t>(p[1])) << 16)
+             | (static_cast<OSType>(static_cast<uint8_t>(p[2])) << 8)
+             |  static_cast<OSType>(static_cast<uint8_t>(p[3]));
+    };
+    t = pack(id.data() + 0);
+    s = pack(id.data() + 5);
+    m = pack(id.data() + 10);
+    return true;
+}
+
+class AuSlot final : public PluginSlot {
+public:
+    AuSlot(PluginInfo info, AudioUnit au) : info_(std::move(info)), au_(au) {}
+
+    ~AuSlot() override {
+        release();
+        if (au_) {
+            AudioComponentInstanceDispose(au_);
+            au_ = nullptr;
+        }
+    }
+
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return au_ != nullptr; }
+
+    bool prepare(double sample_rate, int max_block_size) override {
+        if (!au_) return false;
+        if (prepared_) release();
+
+        sample_rate_ = sample_rate;
+        max_block_size_ = max_block_size;
+
+        // 32-bit float, non-interleaved, 2 channels. Most AUs support this
+        // natively; a fuller host negotiates per-scope/element.
+        const int channels = std::max(1, info_.num_outputs > 0 ? info_.num_outputs : 2);
+        AudioStreamBasicDescription asbd{};
+        asbd.mSampleRate       = sample_rate;
+        asbd.mFormatID         = kAudioFormatLinearPCM;
+        asbd.mFormatFlags      = kAudioFormatFlagIsFloat
+                               | kAudioFormatFlagIsNonInterleaved
+                               | kAudioFormatFlagIsPacked;
+        asbd.mBytesPerPacket   = sizeof(float);
+        asbd.mFramesPerPacket  = 1;
+        asbd.mBytesPerFrame    = sizeof(float);
+        asbd.mChannelsPerFrame = static_cast<UInt32>(channels);
+        asbd.mBitsPerChannel   = 32;
+
+        // Set on both scopes so the AU knows what stream shape to expect.
+        for (auto scope : {kAudioUnitScope_Input, kAudioUnitScope_Output}) {
+            OSStatus st = AudioUnitSetProperty(
+                au_, kAudioUnitProperty_StreamFormat, scope, 0,
+                &asbd, sizeof(asbd));
+            if (st != noErr) {
+                runtime::log_error("AU: set StreamFormat failed (scope {}, status {})",
+                                   static_cast<int>(scope), static_cast<int>(st));
+                return false;
+            }
+        }
+
+        UInt32 max_frames = static_cast<UInt32>(max_block_size);
+        AudioUnitSetProperty(
+            au_, kAudioUnitProperty_MaximumFramesPerSlice,
+            kAudioUnitScope_Global, 0,
+            &max_frames, sizeof(max_frames));
+
+        // Install a render callback that pulls the host's current input
+        // view; the callback reads from input_frames_ set in process().
+        AURenderCallbackStruct cb{};
+        cb.inputProc       = &AuSlot::render_callback;
+        cb.inputProcRefCon = this;
+        OSStatus st = AudioUnitSetProperty(
+            au_, kAudioUnitProperty_SetRenderCallback,
+            kAudioUnitScope_Input, 0,
+            &cb, sizeof(cb));
+        if (st != noErr) {
+            runtime::log_warn("AU: SetRenderCallback failed (status {}) — instrument only?",
+                              static_cast<int>(st));
+        }
+
+        st = AudioUnitInitialize(au_);
+        if (st != noErr) {
+            runtime::log_error("AU: AudioUnitInitialize failed (status {})",
+                               static_cast<int>(st));
+            return false;
+        }
+
+        num_channels_ = channels;
+        prepared_ = true;
+        cache_parameters();
+        return true;
+    }
+
+    void release() override {
+        if (!au_ || !prepared_) return;
+        AudioUnitUninitialize(au_);
+        prepared_ = false;
+    }
+
+    void process(audio::BufferView<float>& output,
+                 const audio::BufferView<const float>& input,
+                 const midi::MidiBuffer& /*midi_in*/,
+                 midi::MidiBuffer& /*midi_out*/,
+                 int num_samples) override {
+        if (!au_ || !prepared_) return;
+        if (num_samples <= 0 || num_samples > max_block_size_) return;
+        if (bypassed_.load(std::memory_order_relaxed)) {
+            copy_or_zero(output, input, num_samples);
+            return;
+        }
+
+        // Make the input pointers visible to the render callback.
+        current_input_ = &input;
+        current_frames_ = num_samples;
+
+        const int channels = std::min(static_cast<int>(output.num_channels()),
+                                      num_channels_);
+        // Build an AudioBufferList pointing at the caller's output buffers.
+        // Each channel is its own AudioBuffer since we declared
+        // non-interleaved.
+        std::vector<std::uint8_t> abl_storage(
+            sizeof(AudioBufferList) + sizeof(AudioBuffer) * (channels - 1));
+        auto* abl = reinterpret_cast<AudioBufferList*>(abl_storage.data());
+        abl->mNumberBuffers = static_cast<UInt32>(channels);
+        for (int c = 0; c < channels; ++c) {
+            abl->mBuffers[c].mNumberChannels = 1;
+            abl->mBuffers[c].mDataByteSize =
+                static_cast<UInt32>(num_samples) * sizeof(float);
+            abl->mBuffers[c].mData = output.channel_ptr(c);
+        }
+
+        AudioUnitRenderActionFlags flags = 0;
+        AudioTimeStamp ts{};
+        ts.mFlags       = kAudioTimeStampSampleTimeValid;
+        ts.mSampleTime  = static_cast<Float64>(sample_time_);
+
+        OSStatus st = AudioUnitRender(
+            au_, &flags, &ts, 0,
+            static_cast<UInt32>(num_samples), abl);
+        if (st != noErr) {
+            runtime::log_warn("AU: AudioUnitRender returned {}",
+                              static_cast<int>(st));
+        }
+        sample_time_ += num_samples;
+        current_input_  = nullptr;
+        current_frames_ = 0;
+    }
+
+    std::vector<HostParamInfo> parameters() const override { return params_; }
+
+    float get_parameter(uint32_t id) const override {
+        if (!au_) return 0.0f;
+        AudioUnitParameterValue v = 0.f;
+        if (AudioUnitGetParameter(au_, id, kAudioUnitScope_Global, 0, &v) == noErr) {
+            return static_cast<float>(v);
+        }
+        return 0.0f;
+    }
+
+    void set_parameter(uint32_t id, float normalized_value) override {
+        if (!au_) return;
+        AudioUnitSetParameter(au_, id, kAudioUnitScope_Global, 0,
+                              static_cast<AudioUnitParameterValue>(normalized_value), 0);
+    }
+
+    void set_bypass(bool b) override { bypassed_.store(b, std::memory_order_relaxed); }
+    bool is_bypassed() const override { return bypassed_.load(std::memory_order_relaxed); }
+
+    std::vector<uint8_t> save_state() const override {
+        if (!au_) return {};
+        CFPropertyListRef plist = nullptr;
+        UInt32 size = sizeof(plist);
+        OSStatus st = AudioUnitGetProperty(
+            au_, kAudioUnitProperty_ClassInfo,
+            kAudioUnitScope_Global, 0, &plist, &size);
+        if (st != noErr || !plist) return {};
+
+        CFDataRef data = CFPropertyListCreateData(
+            nullptr, plist,
+            kCFPropertyListBinaryFormat_v1_0, 0, nullptr);
+        CFRelease(plist);
+        if (!data) return {};
+        const UInt8* bytes = CFDataGetBytePtr(data);
+        const CFIndex len = CFDataGetLength(data);
+        std::vector<uint8_t> out(bytes, bytes + len);
+        CFRelease(data);
+        return out;
+    }
+
+    bool restore_state(const std::vector<uint8_t>& data) override {
+        if (!au_ || data.empty()) return false;
+        CFDataRef cfd = CFDataCreate(nullptr, data.data(),
+                                     static_cast<CFIndex>(data.size()));
+        if (!cfd) return false;
+        CFErrorRef err = nullptr;
+        CFPropertyListRef plist = CFPropertyListCreateWithData(
+            nullptr, cfd, kCFPropertyListImmutable, nullptr, &err);
+        CFRelease(cfd);
+        if (!plist) {
+            if (err) CFRelease(err);
+            return false;
+        }
+        OSStatus st = AudioUnitSetProperty(
+            au_, kAudioUnitProperty_ClassInfo,
+            kAudioUnitScope_Global, 0, &plist, sizeof(plist));
+        CFRelease(plist);
+        return st == noErr;
+    }
+
+    bool has_editor() const override { return false; }      // Phase 4
+    void* create_editor_view() override { return nullptr; } // Phase 4
+    void destroy_editor_view() override {}                  // Phase 4
+
+    int latency_samples() const override {
+        if (!au_) return 0;
+        Float64 secs = 0.0;
+        UInt32 size = sizeof(secs);
+        if (AudioUnitGetProperty(
+                au_, kAudioUnitProperty_Latency,
+                kAudioUnitScope_Global, 0, &secs, &size) == noErr) {
+            return static_cast<int>(secs * sample_rate_);
+        }
+        return 0;
+    }
+    int tail_samples() const override {
+        if (!au_) return 0;
+        Float64 secs = 0.0;
+        UInt32 size = sizeof(secs);
+        if (AudioUnitGetProperty(
+                au_, kAudioUnitProperty_TailTime,
+                kAudioUnitScope_Global, 0, &secs, &size) == noErr) {
+            return static_cast<int>(secs * sample_rate_);
+        }
+        return 0;
+    }
+
+private:
+    static OSStatus render_callback(
+        void* refcon,
+        AudioUnitRenderActionFlags* /*flags*/,
+        const AudioTimeStamp* /*ts*/,
+        UInt32 /*bus*/,
+        UInt32 frames,
+        AudioBufferList* data)
+    {
+        auto* self = static_cast<AuSlot*>(refcon);
+        if (!self || !self->current_input_ || !data) return noErr;
+        const auto& in = *self->current_input_;
+        const UInt32 count = data->mNumberBuffers;
+        const int host_ch = static_cast<int>(in.num_channels());
+        for (UInt32 i = 0; i < count; ++i) {
+            auto* dst = static_cast<float*>(data->mBuffers[i].mData);
+            if (!dst) continue;
+            if (static_cast<int>(i) < host_ch) {
+                const float* src = in.channel_ptr(i);
+                std::memcpy(dst, src, sizeof(float) * frames);
+            } else {
+                std::memset(dst, 0, sizeof(float) * frames);
+            }
+        }
+        return noErr;
+    }
+
+    void cache_parameters() {
+        params_.clear();
+        if (!au_) return;
+        UInt32 size = 0;
+        Boolean writable = false;
+        if (AudioUnitGetPropertyInfo(
+                au_, kAudioUnitProperty_ParameterList,
+                kAudioUnitScope_Global, 0, &size, &writable) != noErr || size == 0) {
+            return;
+        }
+        std::vector<AudioUnitParameterID> ids(size / sizeof(AudioUnitParameterID));
+        if (AudioUnitGetProperty(
+                au_, kAudioUnitProperty_ParameterList,
+                kAudioUnitScope_Global, 0, ids.data(), &size) != noErr) {
+            return;
+        }
+        for (auto pid : ids) {
+            AudioUnitParameterInfo info{};
+            UInt32 isize = sizeof(info);
+            if (AudioUnitGetProperty(
+                    au_, kAudioUnitProperty_ParameterInfo,
+                    kAudioUnitScope_Global, pid, &info, &isize) != noErr) {
+                continue;
+            }
+            HostParamInfo h;
+            h.id = static_cast<uint32_t>(pid);
+            h.min_value = static_cast<float>(info.minValue);
+            h.max_value = static_cast<float>(info.maxValue);
+            h.default_value = static_cast<float>(info.defaultValue);
+
+            if (info.flags & kAudioUnitParameterFlag_HasCFNameString && info.cfNameString) {
+                char buf[256] = {0};
+                if (CFStringGetCString(info.cfNameString, buf, sizeof(buf),
+                                       kCFStringEncodingUTF8)) {
+                    h.name = buf;
+                }
+                if (info.flags & kAudioUnitParameterFlag_CFNameRelease) {
+                    CFRelease(info.cfNameString);
+                }
+            } else {
+                h.name = info.name;
+            }
+            params_.push_back(std::move(h));
+        }
+    }
+
+    static void copy_or_zero(audio::BufferView<float>& out,
+                             const audio::BufferView<const float>& in,
+                             int num_samples) {
+        const size_t nch_out = out.num_channels();
+        const size_t nch_in  = in.num_channels();
+        for (size_t c = 0; c < nch_out; ++c) {
+            auto* dst = out.channel_ptr(c);
+            if (c < nch_in) {
+                std::memcpy(dst, in.channel_ptr(c), sizeof(float) * num_samples);
+            } else {
+                std::memset(dst, 0, sizeof(float) * num_samples);
+            }
+        }
+    }
+
+    PluginInfo info_;
+    AudioUnit au_ = nullptr;
+
+    std::vector<HostParamInfo> params_;
+    const audio::BufferView<const float>* current_input_ = nullptr;
+    int current_frames_ = 0;
+
+    double sample_rate_    = 48000.0;
+    int    max_block_size_ = 0;
+    int    num_channels_   = 2;
+    bool   prepared_       = false;
+    int64_t sample_time_   = 0;
+    std::atomic<bool> bypassed_{false};
+};
+
+}  // namespace
+
+std::unique_ptr<PluginSlot> load_au_plugin(const PluginInfo& info) {
+    OSType type = 0, subtype = 0, manufacturer = 0;
+    if (!parse_4cc_triplet(info.unique_id, type, subtype, manufacturer)) {
+        runtime::log_error(
+            "AU load: unique_id must be 'TYPE:SUBT:MANU' (OSType 4CCs), got '{}'",
+            info.unique_id);
+        return nullptr;
+    }
+
+    AudioComponentDescription desc{};
+    desc.componentType = type;
+    desc.componentSubType = subtype;
+    desc.componentManufacturer = manufacturer;
+
+    AudioComponent comp = AudioComponentFindNext(nullptr, &desc);
+    if (!comp) {
+        runtime::log_error("AU load: AudioComponentFindNext failed for '{}'",
+                           info.unique_id);
+        return nullptr;
+    }
+
+    AudioComponentInstance instance = nullptr;
+    OSStatus st = AudioComponentInstanceNew(comp, &instance);
+    if (st != noErr || !instance) {
+        runtime::log_error("AU load: AudioComponentInstanceNew failed (status {})",
+                           static_cast<int>(st));
+        return nullptr;
+    }
+
+    return std::make_unique<AuSlot>(info, instance);
+}
+
+}  // namespace pulp::host

--- a/core/host/src/plugin_slot_clap.cpp
+++ b/core/host/src/plugin_slot_clap.cpp
@@ -1,0 +1,330 @@
+// CLAP plugin slot implementation.
+//
+// Loads a .clap bundle via dlopen, resolves the clap_entry symbol, creates a
+// plugin instance, and implements the PluginSlot interface on top of the CLAP
+// C API. Minimal host implementation — enough to prepare, process audio, read
+// parameters, and toggle bypass.
+
+#include <pulp/host/plugin_slot.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include <clap/clap.h>
+
+#include <dlfcn.h>
+#include <atomic>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace pulp::host {
+namespace {
+
+namespace fs = std::filesystem;
+
+// Resolve path to the actual loadable binary inside a .clap bundle.
+// On macOS, plugins are bundles (<Name>.clap/Contents/MacOS/<Name>). On
+// Linux/Windows, the .clap file is the shared library itself.
+std::string resolve_clap_binary(const std::string& path) {
+#if defined(__APPLE__)
+    fs::path p(path);
+    std::error_code ec;
+    if (fs::is_directory(p, ec)) {
+        auto stem = p.stem().string();
+        auto inner = p / "Contents" / "MacOS" / stem;
+        if (fs::exists(inner, ec)) return inner.string();
+    }
+#endif
+    return path;
+}
+
+class ClapSlot final : public PluginSlot {
+public:
+    ClapSlot(PluginInfo info, void* handle, const clap_plugin_entry_t* entry)
+        : info_(std::move(info)), handle_(handle), entry_(entry) {
+        host_.clap_version = CLAP_VERSION_INIT;
+        host_.host_data = this;
+        host_.name = "Pulp";
+        host_.vendor = "Pulp";
+        host_.url = "https://github.com/danielraffel/pulp";
+        host_.version = "0.1";
+        host_.get_extension = &ClapSlot::host_get_extension;
+        host_.request_restart = &ClapSlot::host_request_noop;
+        host_.request_process = &ClapSlot::host_request_noop;
+        host_.request_callback = &ClapSlot::host_request_noop;
+    }
+
+    ~ClapSlot() override {
+        release();
+        if (plugin_) {
+            plugin_->destroy(plugin_);
+            plugin_ = nullptr;
+        }
+        if (entry_) {
+            entry_->deinit();
+            entry_ = nullptr;
+        }
+        if (handle_) {
+            dlclose(handle_);
+            handle_ = nullptr;
+        }
+    }
+
+    const clap_host_t* clap_host() const { return &host_; }
+
+    void attach_plugin(const clap_plugin_t* plugin, PluginInfo filled) {
+        plugin_ = plugin;
+        info_ = std::move(filled);
+        cache_params();
+    }
+
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return plugin_ != nullptr; }
+
+    bool prepare(double sample_rate, int max_block_size) override {
+        if (!plugin_) return false;
+        if (active_) release();
+        if (!plugin_->activate(plugin_, sample_rate, 1, (uint32_t)max_block_size)) {
+            runtime::log_error("ClapSlot: activate failed for '{}'", info_.name);
+            return false;
+        }
+        active_ = true;
+        if (!plugin_->start_processing(plugin_)) {
+            runtime::log_warn("ClapSlot: start_processing failed for '{}'", info_.name);
+        } else {
+            processing_ = true;
+        }
+        return true;
+    }
+
+    void release() override {
+        if (!plugin_) return;
+        if (processing_) {
+            plugin_->stop_processing(plugin_);
+            processing_ = false;
+        }
+        if (active_) {
+            plugin_->deactivate(plugin_);
+            active_ = false;
+        }
+    }
+
+    void process(audio::BufferView<float>& output,
+                 const audio::BufferView<const float>& input,
+                 const midi::MidiBuffer& /*midi_in*/,
+                 midi::MidiBuffer& /*midi_out*/,
+                 int num_samples) override {
+        if (!plugin_ || !processing_ || bypassed_.load(std::memory_order_relaxed)) {
+            copy_or_zero(output, input, num_samples);
+            return;
+        }
+
+        const uint32_t nch_out = (uint32_t)output.num_channels();
+        const uint32_t nch_in = (uint32_t)input.num_channels();
+
+        in_ptrs_.resize(nch_in);
+        for (uint32_t c = 0; c < nch_in; ++c) {
+            in_ptrs_[c] = const_cast<float*>(input.channel_ptr(c));
+        }
+        out_ptrs_.resize(nch_out);
+        for (uint32_t c = 0; c < nch_out; ++c) {
+            out_ptrs_[c] = output.channel_ptr(c);
+        }
+
+        clap_audio_buffer_t in_buf{};
+        in_buf.data32 = in_ptrs_.empty() ? nullptr : in_ptrs_.data();
+        in_buf.channel_count = nch_in;
+        clap_audio_buffer_t out_buf{};
+        out_buf.data32 = out_ptrs_.empty() ? nullptr : out_ptrs_.data();
+        out_buf.channel_count = nch_out;
+
+        clap_input_events_t in_events{};
+        in_events.ctx = nullptr;
+        in_events.size = [](const clap_input_events_t*) -> uint32_t { return 0; };
+        in_events.get = [](const clap_input_events_t*, uint32_t) -> const clap_event_header_t* { return nullptr; };
+
+        clap_output_events_t out_events{};
+        out_events.ctx = nullptr;
+        out_events.try_push = [](const clap_output_events_t*, const clap_event_header_t*) -> bool { return true; };
+
+        clap_process_t p{};
+        p.steady_time = steady_time_;
+        p.frames_count = (uint32_t)num_samples;
+        p.transport = nullptr;
+        p.audio_inputs = nch_in ? &in_buf : nullptr;
+        p.audio_inputs_count = nch_in ? 1u : 0u;
+        p.audio_outputs = nch_out ? &out_buf : nullptr;
+        p.audio_outputs_count = nch_out ? 1u : 0u;
+        p.in_events = &in_events;
+        p.out_events = &out_events;
+
+        auto status = plugin_->process(plugin_, &p);
+        if (status == CLAP_PROCESS_ERROR) {
+            runtime::log_warn("ClapSlot: process returned ERROR for '{}'", info_.name);
+        }
+        steady_time_ += num_samples;
+    }
+
+    std::vector<HostParamInfo> parameters() const override { return params_; }
+
+    float get_parameter(uint32_t id) const override {
+        if (!params_ext_ || !plugin_) return 0.0f;
+        double v = 0.0;
+        if (params_ext_->get_value(plugin_, id, &v)) return (float)v;
+        return 0.0f;
+    }
+
+    void set_parameter(uint32_t /*id*/, float /*normalized_value*/) override {
+        // TODO: route via CLAP_EVENT_PARAM_VALUE events to next process() call.
+    }
+
+    void set_bypass(bool bypassed) override {
+        bypassed_.store(bypassed, std::memory_order_relaxed);
+    }
+    bool is_bypassed() const override {
+        return bypassed_.load(std::memory_order_relaxed);
+    }
+
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+
+    int latency_samples() const override {
+        if (!plugin_) return 0;
+        auto* ext = (const clap_plugin_latency_t*)plugin_->get_extension(plugin_, CLAP_EXT_LATENCY);
+        if (!ext || !ext->get) return 0;
+        return (int)ext->get(plugin_);
+    }
+    int tail_samples() const override {
+        if (!plugin_) return 0;
+        auto* ext = (const clap_plugin_tail_t*)plugin_->get_extension(plugin_, CLAP_EXT_TAIL);
+        if (!ext || !ext->get) return 0;
+        return (int)ext->get(plugin_);
+    }
+
+private:
+    static const void* CLAP_ABI host_get_extension(const clap_host_t*, const char*) { return nullptr; }
+    static void CLAP_ABI host_request_noop(const clap_host_t*) {}
+
+    void cache_params() {
+        params_.clear();
+        if (!plugin_) return;
+        params_ext_ = (const clap_plugin_params_t*)plugin_->get_extension(plugin_, CLAP_EXT_PARAMS);
+        if (!params_ext_) return;
+        uint32_t count = params_ext_->count(plugin_);
+        params_.reserve(count);
+        for (uint32_t i = 0; i < count; ++i) {
+            clap_param_info_t pi{};
+            if (!params_ext_->get_info(plugin_, i, &pi)) continue;
+            HostParamInfo h;
+            h.id = (uint32_t)pi.id;
+            h.name = pi.name;
+            h.min_value = (float)pi.min_value;
+            h.max_value = (float)pi.max_value;
+            h.default_value = (float)pi.default_value;
+            params_.push_back(std::move(h));
+        }
+    }
+
+    static void copy_or_zero(audio::BufferView<float>& out,
+                             const audio::BufferView<const float>& in,
+                             int num_samples) {
+        const size_t nch_out = out.num_channels();
+        const size_t nch_in = in.num_channels();
+        for (size_t c = 0; c < nch_out; ++c) {
+            auto* dst = out.channel_ptr(c);
+            if (c < nch_in) {
+                std::memcpy(dst, in.channel_ptr(c), sizeof(float) * (size_t)num_samples);
+            } else {
+                std::memset(dst, 0, sizeof(float) * (size_t)num_samples);
+            }
+        }
+    }
+
+    PluginInfo info_;
+    void* handle_ = nullptr;
+    const clap_plugin_entry_t* entry_ = nullptr;
+    const clap_plugin_t* plugin_ = nullptr;
+    const clap_plugin_params_t* params_ext_ = nullptr;
+    clap_host_t host_{};
+    std::vector<HostParamInfo> params_;
+    std::vector<float*> in_ptrs_;
+    std::vector<float*> out_ptrs_;
+    bool active_ = false;
+    bool processing_ = false;
+    std::atomic<bool> bypassed_{false};
+    int64_t steady_time_ = 0;
+};
+
+} // namespace
+
+std::unique_ptr<PluginSlot> load_clap_plugin(const PluginInfo& info) {
+    std::string bin = resolve_clap_binary(info.path);
+    void* handle = dlopen(bin.c_str(), RTLD_LAZY | RTLD_LOCAL);
+    if (!handle) {
+        const char* err = dlerror();
+        runtime::log_error("CLAP load: dlopen failed for '{}': {}", bin, err ? err : "unknown");
+        return nullptr;
+    }
+    auto* entry = (const clap_plugin_entry_t*)dlsym(handle, "clap_entry");
+    if (!entry || !entry->init || !entry->get_factory) {
+        runtime::log_error("CLAP load: no clap_entry in '{}'", bin);
+        dlclose(handle);
+        return nullptr;
+    }
+    if (!entry->init(info.path.c_str())) {
+        runtime::log_error("CLAP load: entry->init failed for '{}'", info.path);
+        dlclose(handle);
+        return nullptr;
+    }
+    auto* factory = (const clap_plugin_factory_t*)entry->get_factory(CLAP_PLUGIN_FACTORY_ID);
+    if (!factory || !factory->get_plugin_count || !factory->get_plugin_descriptor || !factory->create_plugin) {
+        runtime::log_error("CLAP load: no plugin factory in '{}'", info.path);
+        entry->deinit();
+        dlclose(handle);
+        return nullptr;
+    }
+
+    const char* wanted_id = info.unique_id.empty() ? nullptr : info.unique_id.c_str();
+    const clap_plugin_descriptor_t* desc = nullptr;
+    uint32_t count = factory->get_plugin_count(factory);
+    for (uint32_t i = 0; i < count; ++i) {
+        auto* d = factory->get_plugin_descriptor(factory, i);
+        if (!d) continue;
+        if (!wanted_id) { desc = d; break; }
+        if (d->id && std::strcmp(d->id, wanted_id) == 0) { desc = d; break; }
+    }
+    if (!desc && count > 0) desc = factory->get_plugin_descriptor(factory, 0);
+    if (!desc) {
+        runtime::log_error("CLAP load: no plugin descriptor available in '{}'", info.path);
+        entry->deinit();
+        dlclose(handle);
+        return nullptr;
+    }
+
+    auto slot = std::make_unique<ClapSlot>(info, handle, entry);
+
+    auto* plugin = factory->create_plugin(factory, slot->clap_host(), desc->id);
+    if (!plugin) {
+        runtime::log_error("CLAP load: create_plugin failed for '{}'", info.path);
+        return nullptr; // slot dtor cleans up entry + handle
+    }
+    if (!plugin->init(plugin)) {
+        runtime::log_error("CLAP load: plugin->init failed for '{}'", info.path);
+        plugin->destroy(plugin);
+        return nullptr;
+    }
+
+    PluginInfo filled = info;
+    if (filled.name.empty() && desc->name) filled.name = desc->name;
+    if (filled.manufacturer.empty() && desc->vendor) filled.manufacturer = desc->vendor;
+    if (filled.version.empty() && desc->version) filled.version = desc->version;
+    if (filled.unique_id.empty() && desc->id) filled.unique_id = desc->id;
+    slot->attach_plugin(plugin, std::move(filled));
+    return slot;
+}
+
+} // namespace pulp::host

--- a/core/host/src/plugin_slot_lv2.cpp
+++ b/core/host/src/plugin_slot_lv2.cpp
@@ -1,0 +1,296 @@
+// LV2 plugin slot implementation.
+//
+// LV2 plugins ship as a bundle directory containing one or more .so files
+// plus TTL manifests. This loader:
+//   1. Finds the .so file referenced for the plugin URI (scanning bundle).
+//   2. dlopen's it, resolves lv2_descriptor(index), picks the descriptor
+//      whose URI matches PluginInfo.unique_id (or index 0 if empty).
+//   3. Parses the bundle's TTL files with a tiny regex-based scanner to
+//      discover audio input/output port indices (lv2:AudioPort +
+//      lv2:InputPort / lv2:OutputPort, and lv2:index). We deliberately
+//      don't pull in lilv — that adds serd/sord/sratom/lilv (~15 MB of
+//      third-party copyleft-adjacent code) and the discovery is simple
+//      enough to get right with a regex for the MVP port set.
+//   4. Wires LV2_Descriptor's connect_port/activate/run/deactivate/cleanup
+//      into the PluginSlot interface.
+//
+// Parameter automation (lv2:ControlPort), MIDI (LV2 atom ports), worker
+// extension, state extension, and editors remain follow-up work.
+
+#include <pulp/host/plugin_slot.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include <lv2/core/lv2.h>
+
+#include <dlfcn.h>
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <regex>
+#include <string>
+#include <vector>
+
+namespace pulp::host {
+namespace {
+
+namespace fs = std::filesystem;
+
+struct PortRole {
+    int index = -1;
+    bool is_audio = false;
+    bool is_input = false;
+};
+
+// Scan every .ttl file in the bundle, concatenate content, and extract audio
+// port roles. We look for port stanzas containing:
+//    a lv2:AudioPort , lv2:InputPort   (or OutputPort)
+//    lv2:index N
+// This matches the conventional LV2 style. TTL blank-node syntax varies —
+// we only support the common "[ a lv2:…Port, lv2:…Port ; lv2:index N ; … ]"
+// pattern here.
+std::vector<PortRole> discover_audio_ports(const std::string& bundle_dir) {
+    std::vector<PortRole> out;
+    std::string all;
+    std::error_code ec;
+    for (auto& entry : fs::directory_iterator(bundle_dir, ec)) {
+        if (entry.path().extension() != ".ttl") continue;
+        std::ifstream f(entry.path());
+        if (!f) continue;
+        std::string buf((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+        all += buf;
+        all += "\n";
+    }
+    // Find port stanzas: a bracketed block that declares a lv2:AudioPort
+    // alongside lv2:InputPort / lv2:OutputPort, and an lv2:index.
+    std::regex stanza(R"(\[\s*((?:.|\n)*?)\s*\])");
+    auto begin = std::sregex_iterator(all.begin(), all.end(), stanza);
+    auto end = std::sregex_iterator();
+    std::regex audio_re(R"(lv2:AudioPort)");
+    std::regex in_re(R"(lv2:InputPort)");
+    std::regex out_re(R"(lv2:OutputPort)");
+    std::regex idx_re(R"(lv2:index\s+(\d+))");
+    for (auto it = begin; it != end; ++it) {
+        const std::string& body = it->str(1);
+        if (!std::regex_search(body, audio_re)) continue;
+        std::smatch idx_m;
+        if (!std::regex_search(body, idx_m, idx_re)) continue;
+        PortRole role;
+        role.index = std::stoi(idx_m[1]);
+        role.is_audio = true;
+        role.is_input = std::regex_search(body, in_re);
+        // Note: a port can be both lv2:InputPort and lv2:OutputPort in TTL
+        // only in pathological cases; otherwise treat !input as output.
+        out.push_back(role);
+    }
+    return out;
+}
+
+// Find a .so file inside an LV2 bundle. If multiple .so files exist we pick
+// the first; proper handling would require TTL's lv2:binary clause.
+std::string resolve_lv2_binary(const std::string& bundle_dir) {
+    std::error_code ec;
+    for (auto& entry : fs::directory_iterator(bundle_dir, ec)) {
+        auto ext = entry.path().extension().string();
+        if (ext == ".so" || ext == ".dylib") return entry.path().string();
+    }
+    return {};
+}
+
+class Lv2Slot final : public PluginSlot {
+public:
+    Lv2Slot(PluginInfo info, void* handle, const LV2_Descriptor* desc,
+            std::vector<PortRole> port_roles)
+        : info_(std::move(info)),
+          handle_(handle),
+          desc_(desc),
+          port_roles_(std::move(port_roles)) {
+        for (auto& r : port_roles_) {
+            if (r.is_audio && r.is_input) num_audio_inputs_++;
+            else if (r.is_audio && !r.is_input) num_audio_outputs_++;
+        }
+    }
+
+    ~Lv2Slot() override {
+        release();
+        if (instance_ && desc_ && desc_->cleanup) {
+            desc_->cleanup(instance_);
+            instance_ = nullptr;
+        }
+        if (handle_) {
+            dlclose(handle_);
+            handle_ = nullptr;
+        }
+    }
+
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return desc_ != nullptr; }
+
+    bool prepare(double sample_rate, int max_block_size) override {
+        if (!desc_) return false;
+        if (instance_ && desc_->cleanup) { desc_->cleanup(instance_); instance_ = nullptr; }
+        instance_ = desc_->instantiate(desc_, sample_rate,
+                                       info_.path.c_str(), nullptr);
+        if (!instance_) {
+            runtime::log_error("LV2Slot: instantiate failed for '{}'", info_.name);
+            return false;
+        }
+        max_block_size_ = max_block_size;
+        scratch_in_.assign((size_t)num_audio_inputs_ * (size_t)max_block_size, 0.f);
+        scratch_out_.assign((size_t)num_audio_outputs_ * (size_t)max_block_size, 0.f);
+        if (desc_->activate) desc_->activate(instance_);
+        active_ = true;
+        return true;
+    }
+
+    void release() override {
+        if (!instance_) return;
+        if (active_ && desc_->deactivate) desc_->deactivate(instance_);
+        active_ = false;
+    }
+
+    void process(audio::BufferView<float>& output,
+                 const audio::BufferView<const float>& input,
+                 const midi::MidiBuffer&,
+                 midi::MidiBuffer&,
+                 int num_samples) override {
+        if (!instance_ || !active_ || bypassed_.load(std::memory_order_relaxed)) {
+            for (size_t c = 0; c < output.num_channels(); ++c) {
+                auto* dst = output.channel_ptr(c);
+                if (c < input.num_channels()) {
+                    std::memcpy(dst, input.channel_ptr(c), sizeof(float) * (size_t)num_samples);
+                } else {
+                    std::memset(dst, 0, sizeof(float) * (size_t)num_samples);
+                }
+            }
+            return;
+        }
+
+        // Stage inputs into our scratch buffer so we can connect_port with a
+        // stable pointer per port. For ports we don't have audio data for,
+        // we leave the scratch at its current contents (caller may be
+        // running a generator; still fine to feed silence).
+        int ai = 0;
+        int ao = 0;
+        for (auto& r : port_roles_) {
+            if (!r.is_audio) continue;
+            if (r.is_input) {
+                float* p = scratch_in_.data() + (size_t)ai * (size_t)max_block_size_;
+                if ((size_t)ai < input.num_channels()) {
+                    std::memcpy(p, input.channel_ptr((size_t)ai),
+                                sizeof(float) * (size_t)num_samples);
+                } else {
+                    std::memset(p, 0, sizeof(float) * (size_t)num_samples);
+                }
+                desc_->connect_port(instance_, (uint32_t)r.index, p);
+                ++ai;
+            } else {
+                float* p = scratch_out_.data() + (size_t)ao * (size_t)max_block_size_;
+                desc_->connect_port(instance_, (uint32_t)r.index, p);
+                ++ao;
+            }
+        }
+        desc_->run(instance_, (uint32_t)num_samples);
+        // Copy outputs back into the host's BufferView.
+        ao = 0;
+        for (auto& r : port_roles_) {
+            if (!r.is_audio || r.is_input) continue;
+            if ((size_t)ao < output.num_channels()) {
+                std::memcpy(output.channel_ptr((size_t)ao),
+                            scratch_out_.data() + (size_t)ao * (size_t)max_block_size_,
+                            sizeof(float) * (size_t)num_samples);
+            }
+            ++ao;
+        }
+    }
+
+    std::vector<HostParamInfo> parameters() const override { return {}; }
+    float get_parameter(uint32_t) const override { return 0.f; }
+    void set_parameter(uint32_t, float) override {}
+
+    void set_bypass(bool b) override { bypassed_.store(b, std::memory_order_relaxed); }
+    bool is_bypassed() const override { return bypassed_.load(std::memory_order_relaxed); }
+
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+
+private:
+    PluginInfo info_;
+    void* handle_ = nullptr;
+    const LV2_Descriptor* desc_ = nullptr;
+    LV2_Handle instance_ = nullptr;
+    std::vector<PortRole> port_roles_;
+    int num_audio_inputs_ = 0;
+    int num_audio_outputs_ = 0;
+    int max_block_size_ = 0;
+    std::vector<float> scratch_in_;
+    std::vector<float> scratch_out_;
+    std::atomic<bool> bypassed_{false};
+    bool active_ = false;
+};
+
+} // namespace
+
+std::unique_ptr<PluginSlot> load_lv2_plugin(const PluginInfo& info) {
+    std::error_code ec;
+    if (!fs::is_directory(info.path, ec)) {
+        runtime::log_error("LV2 load: path is not a bundle directory: '{}'", info.path);
+        return nullptr;
+    }
+    std::string bin = resolve_lv2_binary(info.path);
+    if (bin.empty()) {
+        runtime::log_error("LV2 load: no .so/.dylib found in bundle '{}'", info.path);
+        return nullptr;
+    }
+    void* handle = dlopen(bin.c_str(), RTLD_LAZY | RTLD_LOCAL);
+    if (!handle) {
+        const char* err = dlerror();
+        runtime::log_error("LV2 load: dlopen failed for '{}': {}", bin, err ? err : "unknown");
+        return nullptr;
+    }
+    using DescriptorFn = const LV2_Descriptor* (*)(uint32_t);
+    auto* get_desc = reinterpret_cast<DescriptorFn>(dlsym(handle, "lv2_descriptor"));
+    if (!get_desc) {
+        runtime::log_error("LV2 load: lv2_descriptor missing in '{}'", bin);
+        dlclose(handle);
+        return nullptr;
+    }
+
+    const LV2_Descriptor* chosen = nullptr;
+    const char* wanted_uri = info.unique_id.empty() ? nullptr : info.unique_id.c_str();
+    for (uint32_t i = 0; ; ++i) {
+        const LV2_Descriptor* d = get_desc(i);
+        if (!d) break;
+        if (!wanted_uri) { chosen = d; break; }
+        if (d->URI && std::strcmp(d->URI, wanted_uri) == 0) { chosen = d; break; }
+    }
+    if (!chosen) {
+        runtime::log_error("LV2 load: no matching descriptor in '{}'", bin);
+        dlclose(handle);
+        return nullptr;
+    }
+
+    auto roles = discover_audio_ports(info.path);
+    if (roles.empty()) {
+        runtime::log_warn("LV2 load: no audio ports found in bundle TTLs for '{}'; "
+                          "plugin will load but process() will be a pass-through", info.path);
+    }
+
+    PluginInfo filled = info;
+    if (filled.unique_id.empty() && chosen->URI) filled.unique_id = chosen->URI;
+    if (filled.name.empty()) filled.name = fs::path(info.path).stem().string();
+
+    return std::make_unique<Lv2Slot>(std::move(filled), handle, chosen, std::move(roles));
+}
+
+} // namespace pulp::host

--- a/core/host/src/plugin_slot_vst3.cpp
+++ b/core/host/src/plugin_slot_vst3.cpp
@@ -1,0 +1,387 @@
+// VST3 plugin slot implementation.
+//
+// Loads a .vst3 bundle, resolves GetPluginFactory, creates the first audio
+// processor class, and wires the PluginSlot interface onto IComponent +
+// IAudioProcessor. Minimum viable host — covers audio pass-through with
+// stereo 2-in/2-out, latency reporting, and bypass. Parameter automation,
+// state serialization, MIDI routing, and editor views are follow-up work.
+
+#include <pulp/host/plugin_slot.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include <pluginterfaces/base/ipluginbase.h>
+#include <pluginterfaces/base/funknown.h>
+#include <pluginterfaces/vst/ivstaudioprocessor.h>
+#include <pluginterfaces/vst/ivstcomponent.h>
+#include <pluginterfaces/vst/vsttypes.h>
+#include <pluginterfaces/vst/ivsthostapplication.h>
+#include <pluginterfaces/vst/ivstprocesscontext.h>
+#include <pluginterfaces/vst/ivstmessage.h>
+#include <pluginterfaces/vst/ivstevents.h>
+
+#include <dlfcn.h>
+#include <atomic>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pulp::host {
+namespace {
+
+namespace fs = std::filesystem;
+using namespace Steinberg;
+
+// Resolve path to the actual loadable binary inside a .vst3 bundle.
+// macOS: <Name>.vst3/Contents/MacOS/<Name>
+// Linux: <Name>.vst3/Contents/x86_64-linux/<Name>.so  or <Name>.vst3 (flat)
+std::string resolve_vst3_binary(const std::string& path) {
+    fs::path p(path);
+    std::error_code ec;
+    if (!fs::is_directory(p, ec)) return path;
+    auto stem = p.stem().string();
+#if defined(__APPLE__)
+    auto inner = p / "Contents" / "MacOS" / stem;
+#elif defined(__linux__)
+    auto inner = p / "Contents" / "x86_64-linux" / (stem + ".so");
+    if (!fs::exists(inner, ec)) inner = p / "Contents" / "aarch64-linux" / (stem + ".so");
+#else
+    auto inner = p;
+#endif
+    if (fs::exists(inner, ec)) return inner.string();
+    return path;
+}
+
+// Minimal IHostApplication — only exists so IComponent::initialize() can take
+// a context. We don't proxy any useful services back to the plugin.
+class HostApp final : public Vst::IHostApplication {
+public:
+    tresult PLUGIN_API getName(Vst::String128 name) override {
+        const char* kName = "Pulp";
+        for (int i = 0; i < 127 && kName[i]; ++i) name[i] = (Vst::TChar)kName[i];
+        name[4] = 0;
+        return kResultTrue;
+    }
+    tresult PLUGIN_API createInstance(TUID /*cid*/, TUID /*iid*/, void** obj) override {
+        if (obj) *obj = nullptr;
+        return kNotImplemented;
+    }
+    tresult PLUGIN_API queryInterface(const TUID iid, void** obj) override {
+        if (FUnknownPrivate::iidEqual(iid, Vst::IHostApplication::iid) ||
+            FUnknownPrivate::iidEqual(iid, FUnknown::iid)) {
+            *obj = static_cast<Vst::IHostApplication*>(this);
+            return kResultTrue;
+        }
+        *obj = nullptr;
+        return kNoInterface;
+    }
+    uint32 PLUGIN_API addRef() override { return 1; }
+    uint32 PLUGIN_API release() override { return 1; }
+};
+
+class Vst3Slot final : public PluginSlot {
+public:
+    Vst3Slot(PluginInfo info, void* handle, IPluginFactory* factory,
+             Vst::IComponent* component, Vst::IAudioProcessor* processor)
+        : info_(std::move(info)),
+          handle_(handle),
+          factory_(factory),
+          component_(component),
+          processor_(processor) {}
+
+    ~Vst3Slot() override {
+        release();
+        if (component_) {
+            component_->terminate();
+            component_->release();
+            component_ = nullptr;
+        }
+        if (processor_) {
+            processor_->release();
+            processor_ = nullptr;
+        }
+        if (factory_) {
+            factory_->release();
+            factory_ = nullptr;
+        }
+        if (handle_) {
+            // Call ModuleExit / bundleExit if present, then dlclose.
+            auto* exit_fn = (void (*)())dlsym(handle_,
+#if defined(__APPLE__)
+                                              "bundleExit"
+#else
+                                              "ModuleExit"
+#endif
+            );
+            if (exit_fn) exit_fn();
+            dlclose(handle_);
+            handle_ = nullptr;
+        }
+    }
+
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return component_ && processor_; }
+
+    bool prepare(double sample_rate, int max_block_size) override {
+        if (!component_ || !processor_) return false;
+        if (active_) release();
+
+        // Configure stereo 2-in/2-out. Many plugins need setBusArrangements
+        // before setActive. Missing buses (e.g. generators with 0 inputs)
+        // degrade gracefully.
+        Vst::SpeakerArrangement arr_in  = Vst::SpeakerArr::kStereo;
+        Vst::SpeakerArrangement arr_out = Vst::SpeakerArr::kStereo;
+        processor_->setBusArrangements(&arr_in, 1, &arr_out, 1);
+
+        // Activate all audio + event buses the plugin exposes.
+        auto activate_all = [&](Vst::MediaType m, Vst::BusDirection d) {
+            int32 count = component_->getBusCount(m, d);
+            for (int32 i = 0; i < count; ++i) component_->activateBus(m, d, i, true);
+        };
+        activate_all(Vst::kAudio, Vst::kInput);
+        activate_all(Vst::kAudio, Vst::kOutput);
+        activate_all(Vst::kEvent, Vst::kInput);
+        activate_all(Vst::kEvent, Vst::kOutput);
+
+        Vst::ProcessSetup setup{};
+        setup.processMode       = Vst::kRealtime;
+        setup.symbolicSampleSize = Vst::kSample32;
+        setup.maxSamplesPerBlock = max_block_size;
+        setup.sampleRate         = sample_rate;
+        if (processor_->setupProcessing(setup) != kResultOk) {
+            runtime::log_warn("VST3Slot: setupProcessing failed for '{}'", info_.name);
+            return false;
+        }
+        if (component_->setActive(true) != kResultOk) {
+            runtime::log_warn("VST3Slot: setActive(true) failed for '{}'", info_.name);
+            return false;
+        }
+        processor_->setProcessing(true);
+        max_block_size_ = max_block_size;
+        active_ = true;
+        return true;
+    }
+
+    void release() override {
+        if (!active_) return;
+        if (processor_) processor_->setProcessing(false);
+        if (component_) component_->setActive(false);
+        active_ = false;
+    }
+
+    void process(audio::BufferView<float>& output,
+                 const audio::BufferView<const float>& input,
+                 const midi::MidiBuffer& /*midi_in*/,
+                 midi::MidiBuffer& /*midi_out*/,
+                 int num_samples) override {
+        if (!active_ || !processor_ || bypassed_.load(std::memory_order_relaxed)) {
+            for (size_t c = 0; c < output.num_channels(); ++c) {
+                auto* dst = output.channel_ptr(c);
+                if (c < input.num_channels()) {
+                    std::memcpy(dst, input.channel_ptr(c), sizeof(float) * (size_t)num_samples);
+                } else {
+                    std::memset(dst, 0, sizeof(float) * (size_t)num_samples);
+                }
+            }
+            return;
+        }
+
+        const int32 nch_in  = (int32)input.num_channels();
+        const int32 nch_out = (int32)output.num_channels();
+
+        in_ptrs_.resize((size_t)nch_in);
+        for (int32 c = 0; c < nch_in; ++c) {
+            in_ptrs_[(size_t)c] = const_cast<float*>(input.channel_ptr((size_t)c));
+        }
+        out_ptrs_.resize((size_t)nch_out);
+        for (int32 c = 0; c < nch_out; ++c) {
+            out_ptrs_[(size_t)c] = output.channel_ptr((size_t)c);
+        }
+
+        Vst::AudioBusBuffers in_bus{};
+        in_bus.numChannels      = nch_in;
+        in_bus.silenceFlags     = 0;
+        in_bus.channelBuffers32 = in_ptrs_.data();
+        Vst::AudioBusBuffers out_bus{};
+        out_bus.numChannels      = nch_out;
+        out_bus.silenceFlags     = 0;
+        out_bus.channelBuffers32 = out_ptrs_.data();
+
+        Vst::ProcessContext ctx{};
+        ctx.sampleRate = sample_rate_;
+        ctx.state      = Vst::ProcessContext::kPlaying;
+
+        Vst::ProcessData data{};
+        data.processMode        = Vst::kRealtime;
+        data.symbolicSampleSize = Vst::kSample32;
+        data.numSamples         = num_samples;
+        data.numInputs          = nch_in  ? 1 : 0;
+        data.numOutputs         = nch_out ? 1 : 0;
+        data.inputs             = nch_in  ? &in_bus  : nullptr;
+        data.outputs            = nch_out ? &out_bus : nullptr;
+        data.processContext     = &ctx;
+
+        if (processor_->process(data) != kResultOk) {
+            // Plugin rejected the block; fall back to input pass-through so the
+            // host buffer isn't left with stale contents.
+            for (size_t c = 0; c < output.num_channels(); ++c) {
+                auto* dst = output.channel_ptr(c);
+                if (c < input.num_channels()) {
+                    std::memcpy(dst, input.channel_ptr(c), sizeof(float) * (size_t)num_samples);
+                } else {
+                    std::memset(dst, 0, sizeof(float) * (size_t)num_samples);
+                }
+            }
+        }
+    }
+
+    std::vector<HostParamInfo> parameters() const override {
+        // TODO: query IEditController for parameter metadata.
+        return {};
+    }
+    float get_parameter(uint32_t) const override { return 0.0f; }
+    void set_parameter(uint32_t, float) override {}
+
+    void set_bypass(bool bypassed) override {
+        bypassed_.store(bypassed, std::memory_order_relaxed);
+    }
+    bool is_bypassed() const override {
+        return bypassed_.load(std::memory_order_relaxed);
+    }
+
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+
+    int latency_samples() const override {
+        if (!processor_) return 0;
+        return (int)processor_->getLatencySamples();
+    }
+    int tail_samples() const override {
+        if (!processor_) return 0;
+        return (int)processor_->getTailSamples();
+    }
+
+    static HostApp& host_app() {
+        static HostApp app;
+        return app;
+    }
+
+private:
+    PluginInfo info_;
+    void* handle_ = nullptr;
+    IPluginFactory* factory_ = nullptr;
+    Vst::IComponent* component_ = nullptr;
+    Vst::IAudioProcessor* processor_ = nullptr;
+    std::vector<float*> in_ptrs_;
+    std::vector<float*> out_ptrs_;
+    std::atomic<bool> bypassed_{false};
+    double sample_rate_ = 44100.0;
+    int max_block_size_ = 0;
+    bool active_ = false;
+};
+
+} // namespace
+
+std::unique_ptr<PluginSlot> load_vst3_plugin(const PluginInfo& info) {
+    std::string bin = resolve_vst3_binary(info.path);
+    void* handle = dlopen(bin.c_str(), RTLD_LAZY | RTLD_LOCAL);
+    if (!handle) {
+        const char* err = dlerror();
+        runtime::log_error("VST3 load: dlopen failed for '{}': {}", bin, err ? err : "unknown");
+        return nullptr;
+    }
+
+    // Bundle/module entry (optional).
+#if defined(__APPLE__)
+    auto* entry_fn = (bool (*)(void*))dlsym(handle, "bundleEntry");
+    if (entry_fn) {
+        // Without a real CFBundleRef, pass nullptr; most plugins tolerate
+        // this, though a few require a proper CFBundle. Adding CFBundle
+        // support is a follow-up.
+        entry_fn(nullptr);
+    }
+#else
+    auto* entry_fn = (bool (*)())dlsym(handle, "ModuleEntry");
+    if (entry_fn) entry_fn();
+#endif
+
+    using GetPluginFactoryProc = IPluginFactory* (PLUGIN_API*)();
+    auto* get_factory =
+        reinterpret_cast<GetPluginFactoryProc>(dlsym(handle, "GetPluginFactory"));
+    if (!get_factory) {
+        runtime::log_error("VST3 load: GetPluginFactory missing in '{}'", bin);
+        dlclose(handle);
+        return nullptr;
+    }
+
+    IPluginFactory* factory = get_factory();
+    if (!factory) {
+        runtime::log_error("VST3 load: GetPluginFactory returned null for '{}'", bin);
+        dlclose(handle);
+        return nullptr;
+    }
+
+    // Find the first Audio Module Class ("Audio Module Class").
+    int32 class_count = factory->countClasses();
+    PClassInfo chosen{};
+    bool found = false;
+    for (int32 i = 0; i < class_count; ++i) {
+        PClassInfo ci{};
+        if (factory->getClassInfo(i, &ci) != kResultOk) continue;
+        if (std::strcmp(ci.category, kVstAudioEffectClass) == 0) {
+            chosen = ci;
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        runtime::log_error("VST3 load: no audio module class in '{}'", bin);
+        factory->release();
+        dlclose(handle);
+        return nullptr;
+    }
+
+    Vst::IComponent* component = nullptr;
+    if (factory->createInstance(chosen.cid, Vst::IComponent::iid, (void**)&component) != kResultOk
+            || !component) {
+        runtime::log_error("VST3 load: createInstance failed for '{}'", chosen.name);
+        factory->release();
+        dlclose(handle);
+        return nullptr;
+    }
+
+    // initialize with a minimal host context so the plugin can query services.
+    if (component->initialize(&Vst3Slot::host_app()) != kResultOk) {
+        runtime::log_error("VST3 load: IComponent::initialize failed for '{}'", chosen.name);
+        component->release();
+        factory->release();
+        dlclose(handle);
+        return nullptr;
+    }
+
+    Vst::IAudioProcessor* processor = nullptr;
+    if (component->queryInterface(Vst::IAudioProcessor::iid, (void**)&processor) != kResultOk
+            || !processor) {
+        runtime::log_error("VST3 load: no IAudioProcessor on '{}'", chosen.name);
+        component->terminate();
+        component->release();
+        factory->release();
+        dlclose(handle);
+        return nullptr;
+    }
+
+    PluginInfo filled = info;
+    if (filled.name.empty())         filled.name = chosen.name;
+    if (filled.manufacturer.empty()) filled.manufacturer = ""; // PClassInfo2 carries vendor
+    if (filled.unique_id.empty())    filled.unique_id = chosen.name;
+
+    return std::make_unique<Vst3Slot>(std::move(filled), handle, factory,
+                                      component, processor);
+}
+
+} // namespace pulp::host

--- a/core/host/src/scanner.cpp
+++ b/core/host/src/scanner.cpp
@@ -150,25 +150,12 @@ std::vector<PluginInfo> PluginScanner::scan_directory(const std::string& dir, Pl
 }
 
 #ifdef __APPLE__
+// Implemented in scanner_au.mm using AudioComponent APIs (the supported
+// discovery mechanism — also handles AUv3 app extensions).
+std::vector<PluginInfo> scan_audio_units_api();
+
 std::vector<PluginInfo> PluginScanner::scan_audio_units() {
-    std::vector<PluginInfo> results;
-    // Scan .component bundles in AU directories
-    for (auto& dir : default_paths(PluginFormat::AudioUnit)) {
-        std::error_code ec;
-        if (!fs::exists(dir, ec)) continue;
-        for (const auto& entry : fs::directory_iterator(dir, ec)) {
-            auto path = entry.path().string();
-            if (path.ends_with(".component")) {
-                PluginInfo info;
-                info.path = path;
-                info.format = PluginFormat::AudioUnit;
-                info.name = entry.path().stem().string();
-                info.unique_id = info.name;
-                results.push_back(std::move(info));
-            }
-        }
-    }
-    return results;
+    return scan_audio_units_api();
 }
 #endif
 

--- a/core/host/src/scanner.cpp
+++ b/core/host/src/scanner.cpp
@@ -89,12 +89,21 @@ PluginInfo PluginScanner::scan_vst3_bundle(const std::string& path) {
     return info;
 }
 
+// Forward-declared in scanner_clap.cpp when CLAP SDK is available; returns
+// all descriptors in a bundle (one .clap file may host multiple plugins).
+#if PULP_HOST_HAS_CLAP
+std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path);
+#endif
+
 PluginInfo PluginScanner::scan_clap_bundle(const std::string& path) {
+    // Single-entry stub retained for callers that expect one PluginInfo per
+    // bundle. Real multi-plugin enumeration happens in scan_directory via
+    // scan_clap_bundle_descriptors.
     PluginInfo info;
     info.path = path;
     info.format = PluginFormat::CLAP;
     info.name = fs::path(path).stem().string();
-    info.unique_id = info.name; // TODO: load and query clap_plugin_descriptor
+    info.unique_id = info.name;
     return info;
 }
 
@@ -121,9 +130,15 @@ std::vector<PluginInfo> PluginScanner::scan_directory(const std::string& dir, Pl
             case PluginFormat::VST3:
                 results.push_back(scan_vst3_bundle(path));
                 break;
-            case PluginFormat::CLAP:
+            case PluginFormat::CLAP: {
+#if PULP_HOST_HAS_CLAP
+                auto descs = scan_clap_bundle_descriptors(path);
+                results.insert(results.end(), descs.begin(), descs.end());
+#else
                 results.push_back(scan_clap_bundle(path));
+#endif
                 break;
+            }
             case PluginFormat::LV2:
                 results.push_back(scan_lv2_bundle(path));
                 break;

--- a/core/host/src/scanner_au.mm
+++ b/core/host/src/scanner_au.mm
@@ -1,0 +1,128 @@
+// Audio Unit scanner (macOS only).
+//
+// Enumerates installed AU v2/v3 components via the AudioComponent API
+// instead of walking ~/Library/Audio/Plug-Ins/Components. The API-based
+// route is the supported way to discover AUs and also handles AUv3
+// app extensions registered with the system.
+//
+// unique_id encodes the OSType triplet as "TYPE:SUBT:MANU" so the
+// loader can reconstruct the AudioComponentDescription.
+
+#include <pulp/host/scanner.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include <AudioToolbox/AudioToolbox.h>
+
+#include <string>
+#include <vector>
+
+namespace pulp::host {
+namespace {
+
+std::string fourcc(OSType code) {
+    char s[5] = {
+        static_cast<char>((code >> 24) & 0xFF),
+        static_cast<char>((code >> 16) & 0xFF),
+        static_cast<char>((code >>  8) & 0xFF),
+        static_cast<char>((code      ) & 0xFF),
+        0,
+    };
+    return s;
+}
+
+std::string encode_triplet(OSType t, OSType s, OSType m) {
+    return fourcc(t) + ":" + fourcc(s) + ":" + fourcc(m);
+}
+
+std::string cfstring_to_utf8(CFStringRef s) {
+    if (!s) return {};
+    if (const char* fast = CFStringGetCStringPtr(s, kCFStringEncodingUTF8)) {
+        return fast;
+    }
+    CFIndex len = CFStringGetLength(s);
+    CFIndex max = CFStringGetMaximumSizeForEncoding(len, kCFStringEncodingUTF8) + 1;
+    std::vector<char> buf(static_cast<size_t>(max), 0);
+    if (CFStringGetCString(s, buf.data(), max, kCFStringEncodingUTF8)) {
+        return std::string(buf.data());
+    }
+    return {};
+}
+
+PluginFormat infer_format(OSType type, UInt32 flags) {
+    // An AU v3 app extension sets kAudioComponentFlag_IsV3AudioComponent
+    // (defined in AVFoundation) or returns a non-null sandbox-safe loader.
+    // We cannot read that constant directly in pure AudioToolbox, but the
+    // flag bit 0x01000000 is the well-known shorthand for v3.
+    constexpr UInt32 kV3Flag = 0x01000000;
+    if (flags & kV3Flag) return PluginFormat::AudioUnitV3;
+    (void)type;
+    return PluginFormat::AudioUnit;
+}
+
+}  // namespace
+
+std::vector<PluginInfo> scan_audio_units_api() {
+    std::vector<PluginInfo> results;
+
+    AudioComponentDescription wildcard{};
+    // All zeros = match any type/subtype/manufacturer.
+
+    AudioComponent comp = nullptr;
+    while ((comp = AudioComponentFindNext(comp, &wildcard)) != nullptr) {
+        AudioComponentDescription desc{};
+        if (AudioComponentGetDescription(comp, &desc) != noErr) continue;
+
+        // Filter to plausible audio units: effects, instruments, generators,
+        // music effects. Ignore plain AUConverter and output units.
+        switch (desc.componentType) {
+            case kAudioUnitType_Effect:
+            case kAudioUnitType_MusicEffect:
+            case kAudioUnitType_MusicDevice:
+            case kAudioUnitType_Generator:
+            case kAudioUnitType_Mixer:
+                break;
+            default:
+                continue;
+        }
+
+        PluginInfo info;
+        info.format = infer_format(desc.componentType, desc.componentFlags);
+        info.unique_id = encode_triplet(
+            desc.componentType, desc.componentSubType, desc.componentManufacturer);
+
+        CFStringRef name_cf = nullptr;
+        if (AudioComponentCopyName(comp, &name_cf) == noErr && name_cf) {
+            std::string full = cfstring_to_utf8(name_cf);
+            CFRelease(name_cf);
+            // "Vendor: Name" is the conventional AU name format.
+            auto colon = full.find(':');
+            if (colon != std::string::npos) {
+                info.manufacturer = full.substr(0, colon);
+                info.name = full.substr(colon + 1);
+                // Trim leading space after colon.
+                if (!info.name.empty() && info.name.front() == ' ')
+                    info.name.erase(0, 1);
+            } else {
+                info.name = full;
+            }
+        }
+        if (info.name.empty()) info.name = info.unique_id;
+
+        info.is_instrument = (desc.componentType == kAudioUnitType_MusicDevice);
+        info.is_effect = !info.is_instrument;
+        info.num_inputs = info.is_instrument ? 0 : 2;
+        info.num_outputs = 2;
+        // AU version is a packed UInt32; format as major.minor.patch.
+        UInt32 version = 0;
+        if (AudioComponentGetVersion(comp, &version) == noErr) {
+            info.version = std::to_string((version >> 16) & 0xFFFF) + "."
+                         + std::to_string((version >>  8) & 0xFF) + "."
+                         + std::to_string( version        & 0xFF);
+        }
+
+        results.push_back(std::move(info));
+    }
+    return results;
+}
+
+}  // namespace pulp::host

--- a/core/host/src/scanner_clap.cpp
+++ b/core/host/src/scanner_clap.cpp
@@ -1,0 +1,124 @@
+// CLAP bundle descriptor enumeration.
+//
+// A single .clap bundle can expose multiple plugins (each with its own id).
+// The filesystem scanner produces one PluginInfo per descriptor instead of
+// per bundle. This is needed so the loader can instantiate the correct
+// plugin inside multi-plugin bundles (e.g. bundled test kits, effect suites).
+//
+// Falls back to a single filename-derived entry if clap_entry can't be loaded
+// (missing symbol, deinit failure, etc.) so scan() stays best-effort.
+
+#include <pulp/host/scanner.hpp>
+#include <pulp/runtime/log.hpp>
+
+#include <clap/clap.h>
+
+#include <dlfcn.h>
+#include <cstring>
+#include <filesystem>
+#include <vector>
+
+namespace pulp::host {
+namespace {
+
+namespace fs = std::filesystem;
+
+std::string resolve_clap_binary(const std::string& path) {
+#if defined(__APPLE__)
+    fs::path p(path);
+    std::error_code ec;
+    if (fs::is_directory(p, ec)) {
+        auto stem = p.stem().string();
+        auto inner = p / "Contents" / "MacOS" / stem;
+        if (fs::exists(inner, ec)) return inner.string();
+    }
+#endif
+    return path;
+}
+
+}  // namespace
+
+// Called from scanner.cpp — enumerate descriptors by briefly loading
+// the bundle, reading clap_plugin_factory, and extracting metadata per
+// descriptor. The bundle is unloaded before return.
+std::vector<PluginInfo> scan_clap_bundle_descriptors(const std::string& path) {
+    std::vector<PluginInfo> results;
+
+    auto binary = resolve_clap_binary(path);
+    void* handle = dlopen(binary.c_str(), RTLD_LAZY | RTLD_LOCAL);
+    if (!handle) {
+        runtime::log_warn("CLAP scan: dlopen failed for '{}': {}",
+                          binary, dlerror() ? dlerror() : "unknown");
+        // Fallback to filename-only entry.
+        PluginInfo info;
+        info.path = path;
+        info.format = PluginFormat::CLAP;
+        info.name = fs::path(path).stem().string();
+        info.unique_id = info.name;
+        results.push_back(std::move(info));
+        return results;
+    }
+
+    auto* entry = static_cast<const clap_plugin_entry_t*>(dlsym(handle, "clap_entry"));
+    if (!entry || !entry->init || !entry->get_factory) {
+        runtime::log_warn("CLAP scan: no clap_entry in '{}'", binary);
+        dlclose(handle);
+        PluginInfo info;
+        info.path = path;
+        info.format = PluginFormat::CLAP;
+        info.name = fs::path(path).stem().string();
+        info.unique_id = info.name;
+        results.push_back(std::move(info));
+        return results;
+    }
+
+    if (!entry->init(path.c_str())) {
+        runtime::log_warn("CLAP scan: entry->init failed for '{}'", path);
+        dlclose(handle);
+        return results;
+    }
+
+    const auto* factory = static_cast<const clap_plugin_factory_t*>(
+        entry->get_factory(CLAP_PLUGIN_FACTORY_ID));
+
+    if (!factory || !factory->get_plugin_count || !factory->get_plugin_descriptor) {
+        entry->deinit();
+        dlclose(handle);
+        return results;
+    }
+
+    const uint32_t count = factory->get_plugin_count(factory);
+    results.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        const auto* desc = factory->get_plugin_descriptor(factory, i);
+        if (!desc) continue;
+
+        PluginInfo info;
+        info.path = path;
+        info.format = PluginFormat::CLAP;
+        info.name = desc->name ? desc->name : fs::path(path).stem().string();
+        info.manufacturer = desc->vendor ? desc->vendor : "";
+        info.version = desc->version ? desc->version : "";
+        info.unique_id = desc->id ? desc->id : info.name;
+
+        // Classify from `features` if present — CLAP declares category strings
+        // like "instrument", "audio-effect", "note-effect".
+        info.is_instrument = false;
+        info.is_effect = true;
+        if (desc->features) {
+            for (const char* const* f = desc->features; *f; ++f) {
+                if (std::strcmp(*f, CLAP_PLUGIN_FEATURE_INSTRUMENT) == 0) {
+                    info.is_instrument = true;
+                    info.is_effect = false;
+                }
+            }
+        }
+        results.push_back(std::move(info));
+    }
+
+    entry->deinit();
+    dlclose(handle);
+    return results;
+}
+
+}  // namespace pulp::host

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -44,6 +44,20 @@ NodeId SignalGraph::add_plugin_node(const PluginInfo& info) {
     return nodes_.back().id;
 }
 
+NodeId SignalGraph::add_plugin_node(std::unique_ptr<PluginSlot> slot,
+                                    int num_inputs, int num_outputs,
+                                    const std::string& name) {
+    GraphNode node;
+    node.id = next_id_++;
+    node.type = NodeType::Plugin;
+    node.name = name;
+    node.num_input_ports = num_inputs;
+    node.num_output_ports = num_outputs;
+    node.plugin = std::move(slot);
+    nodes_.push_back(std::move(node));
+    return nodes_.back().id;
+}
+
 NodeId SignalGraph::add_gain_node(const std::string& name) {
     GraphNode node;
     node.id = next_id_++;
@@ -185,11 +199,79 @@ std::vector<NodeId> SignalGraph::processing_order() const {
     return order;
 }
 
+int SignalGraph::node_latency_samples(NodeId id) const {
+    auto it = runtime_.find(id);
+    if (it == runtime_.end()) return 0;
+    return (int)it->second.input_latency;
+}
+
+void SignalGraph::compute_latencies_() {
+    // Walk nodes in topological order; each node's input_latency is the max
+    // of its inbound connections' source output_latency, and its
+    // output_latency is that plus the node's own added latency (plugin
+    // latency for Plugin nodes, 0 otherwise).
+    for (NodeId id : cached_order_) {
+        auto rt_it = runtime_.find(id);
+        if (rt_it == runtime_.end()) continue;
+        auto& rt = rt_it->second;
+
+        int64_t max_upstream = 0;
+        bool has_upstream = false;
+        for (const auto& c : connections_) {
+            if (c.dest_node != id) continue;
+            auto src_it = runtime_.find(c.source_node);
+            if (src_it == runtime_.end()) continue;
+            max_upstream = std::max(max_upstream, src_it->second.output_latency);
+            has_upstream = true;
+        }
+        rt.input_latency = has_upstream ? max_upstream : 0;
+
+        int64_t added = 0;
+        if (auto* n = node(id); n && n->plugin) {
+            added = std::max(0, n->plugin->latency_samples());
+        }
+        rt.output_latency = rt.input_latency + added;
+    }
+
+    // Compute graph-wide latency: max input_latency across AudioOutput nodes.
+    total_latency_samples_ = 0;
+    for (auto& n : nodes_) {
+        if (n.type != NodeType::AudioOutput) continue;
+        auto it = runtime_.find(n.id);
+        if (it == runtime_.end()) continue;
+        total_latency_samples_ = std::max(total_latency_samples_, it->second.input_latency);
+    }
+
+    // Allocate per-connection delay lines to align inbound branches. Each
+    // connection's delay brings the source output up to the dest node's
+    // input_latency.
+    connection_delays_.assign(connections_.size(), ConnectionDelay{});
+    for (size_t i = 0; i < connections_.size(); ++i) {
+        const auto& c = connections_[i];
+        auto src_it = runtime_.find(c.source_node);
+        auto dst_it = runtime_.find(c.dest_node);
+        if (src_it == runtime_.end() || dst_it == runtime_.end()) continue;
+        int64_t want = dst_it->second.input_latency - src_it->second.output_latency;
+        if (want < 0) want = 0;
+        connection_delays_[i].delay_samples = (int)want;
+        if (want > 0) {
+            // Ring size = delay + max_block so one process() call can push
+            // max_block samples and pull max_block delayed samples without
+            // overlapping itself.
+            connection_delays_[i].ring.assign(
+                static_cast<size_t>((int64_t)max_block_size_ + want), 0.0f);
+            connection_delays_[i].write_pos = 0;
+        }
+    }
+}
+
 bool SignalGraph::prepare(double sample_rate, int max_block_size) {
     if (max_block_size <= 0) return false;
 
     max_block_size_ = max_block_size;
     runtime_.clear();
+    connection_delays_.clear();
+    total_latency_samples_ = 0;
 
     for (auto& n : nodes_) {
         if (n.plugin) {
@@ -219,6 +301,7 @@ bool SignalGraph::prepare(double sample_rate, int max_block_size) {
     }
 
     cached_order_ = processing_order();
+    compute_latencies_();
     prepared_ = true;
     return true;
 }
@@ -229,7 +312,9 @@ void SignalGraph::release() {
     }
     prepared_ = false;
     runtime_.clear();
+    connection_delays_.clear();
     cached_order_.clear();
+    total_latency_samples_ = 0;
 }
 
 void SignalGraph::process(audio::BufferView<float>& output,
@@ -258,16 +343,16 @@ void SignalGraph::process(audio::BufferView<float>& output,
             std::memset(rt.input_data.data(), 0, rt.input_data.size() * sizeof(float));
         }
 
-        // 2. Gather inbound connections.
-        for (const auto& c : connections_) {
+        // 2. Gather inbound connections, pushing through per-connection
+        //    delay lines so every inbound branch arrives aligned at this
+        //    node's input_latency.
+        for (size_t ci = 0; ci < connections_.size(); ++ci) {
+            const auto& c = connections_[ci];
             if (c.dest_node != id) continue;
             const int dport = static_cast<int>(c.dest_port);
             if (dport < 0 || dport >= static_cast<int>(rt.input_ptrs.size())) continue;
+            if (c.source_node == 0) continue;  // reserved sentinel
 
-            if (c.source_node == 0) {
-                // Reserved sentinel; skip.
-                continue;
-            }
             auto src_rt_it = runtime_.find(c.source_node);
             if (src_rt_it == runtime_.end()) continue;
             const auto& src_rt = src_rt_it->second;
@@ -276,7 +361,26 @@ void SignalGraph::process(audio::BufferView<float>& output,
 
             float* dst = rt.input_ptrs[dport];
             const float* src = src_rt.output_ptrs[sport];
-            for (int i = 0; i < num_samples; ++i) dst[i] += src[i];
+            auto& dl = connection_delays_[ci];
+            if (dl.delay_samples <= 0 || dl.ring.empty()) {
+                // Zero-latency pass-through: sum source output into dest input.
+                for (int i = 0; i < num_samples; ++i) dst[i] += src[i];
+            } else {
+                const int ring_size = (int)dl.ring.size();
+                const int D = dl.delay_samples;
+                // Push num_samples new samples in, read num_samples delayed
+                // samples out. Read position lags write position by D frames.
+                int wp = dl.write_pos;
+                int rp = wp - D;
+                if (rp < 0) rp += ring_size;
+                for (int i = 0; i < num_samples; ++i) {
+                    dl.ring[(size_t)wp] = src[i];
+                    dst[i] += dl.ring[(size_t)rp];
+                    if (++wp == ring_size) wp = 0;
+                    if (++rp == ring_size) rp = 0;
+                }
+                dl.write_pos = wp;
+            }
         }
 
         // 3. Produce output based on node type.

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -124,6 +124,17 @@ bool SignalGraph::connect(NodeId source, PortIndex source_port,
     return true;
 }
 
+bool SignalGraph::connect_feedback(NodeId source, PortIndex source_port,
+                                   NodeId dest, PortIndex dest_port) {
+    if (!node(source) || !node(dest)) return false;
+    Connection conn{source, source_port, dest, dest_port, true};
+    for (auto& c : connections_) {
+        if (c == conn) return false;  // duplicate
+    }
+    connections_.push_back(conn);
+    return true;
+}
+
 bool SignalGraph::disconnect(NodeId source, PortIndex source_port,
                              NodeId dest, PortIndex dest_port) {
     Connection target{source, source_port, dest, dest_port};
@@ -168,11 +179,14 @@ bool SignalGraph::would_create_cycle(NodeId source, NodeId dest) const {
 }
 
 std::vector<NodeId> SignalGraph::processing_order() const {
-    // Kahn's algorithm for topological sort
+    // Kahn's algorithm for topological sort. Feedback connections are
+    // invisible to the sort — they're the back-edges the user intentionally
+    // introduced, and the runtime breaks them via a one-block delay.
     std::unordered_map<NodeId, int> in_degree;
     for (auto& n : nodes_) in_degree[n.id] = 0;
 
     for (auto& c : connections_) {
+        if (c.feedback) continue;
         in_degree[c.dest_node]++;
     }
 
@@ -188,6 +202,7 @@ std::vector<NodeId> SignalGraph::processing_order() const {
         order.push_back(current);
 
         for (auto& c : connections_) {
+            if (c.feedback) continue;
             if (c.source_node == current) {
                 if (--in_degree[c.dest_node] == 0) {
                     queue.push(c.dest_node);
@@ -219,6 +234,7 @@ void SignalGraph::compute_latencies_() {
         bool has_upstream = false;
         for (const auto& c : connections_) {
             if (c.dest_node != id) continue;
+            if (c.feedback) continue;  // back-edge; one-block delay breaks it
             auto src_it = runtime_.find(c.source_node);
             if (src_it == runtime_.end()) continue;
             max_upstream = std::max(max_upstream, src_it->second.output_latency);
@@ -251,6 +267,17 @@ void SignalGraph::compute_latencies_() {
         auto src_it = runtime_.find(c.source_node);
         auto dst_it = runtime_.find(c.dest_node);
         if (src_it == runtime_.end() || dst_it == runtime_.end()) continue;
+
+        if (c.feedback) {
+            // Feedback back-edge: allocate a one-block buffer that holds the
+            // source's previous block's output. Destination reads from it
+            // before source writes the current block; after the block we
+            // overwrite with the just-computed source output.
+            connection_delays_[i].feedback_prev.assign(
+                static_cast<size_t>(max_block_size_), 0.0f);
+            continue;
+        }
+
         int64_t want = dst_it->second.input_latency - src_it->second.output_latency;
         if (want < 0) want = 0;
         connection_delays_[i].delay_samples = (int)want;
@@ -362,6 +389,17 @@ void SignalGraph::process(audio::BufferView<float>& output,
             float* dst = rt.input_ptrs[dport];
             const float* src = src_rt.output_ptrs[sport];
             auto& dl = connection_delays_[ci];
+            if (c.feedback) {
+                // Read the source's previous block's output — this is
+                // available *before* the source processes the current block,
+                // which is what makes cycles tractable. After the full pass
+                // we overwrite feedback_prev with the now-current source
+                // output (see the per-block update loop below).
+                if (!dl.feedback_prev.empty()) {
+                    for (int i = 0; i < num_samples; ++i) dst[i] += dl.feedback_prev[(size_t)i];
+                }
+                continue;
+            }
             if (dl.delay_samples <= 0 || dl.ring.empty()) {
                 // Zero-latency pass-through: sum source output into dest input.
                 for (int i = 0; i < num_samples; ++i) dst[i] += src[i];
@@ -448,6 +486,24 @@ void SignalGraph::process(audio::BufferView<float>& output,
                 // MIDI routing lands in Phase 2 (events wired via the graph).
                 break;
         }
+    }
+
+    // Capture each feedback source's current block for the *next* block's
+    // reader. This runs after the full topological pass so it sees the
+    // freshly computed output of each feedback source node.
+    for (size_t ci = 0; ci < connections_.size(); ++ci) {
+        const auto& c = connections_[ci];
+        if (!c.feedback) continue;
+        auto src_it = runtime_.find(c.source_node);
+        if (src_it == runtime_.end()) continue;
+        const auto& src_rt = src_it->second;
+        const int sport = static_cast<int>(c.source_port);
+        if (sport < 0 || sport >= static_cast<int>(src_rt.output_ptrs.size())) continue;
+        auto& dl = connection_delays_[ci];
+        if (dl.feedback_prev.empty()) continue;
+        const float* src = src_rt.output_ptrs[sport];
+        std::memcpy(dl.feedback_prev.data(), src,
+                    sizeof(float) * static_cast<size_t>(num_samples));
     }
 }
 

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -124,6 +124,32 @@ bool SignalGraph::connect(NodeId source, PortIndex source_port,
     return true;
 }
 
+bool SignalGraph::connect_midi(NodeId source, NodeId dest) {
+    if (!node(source) || !node(dest)) return false;
+    if (would_create_cycle(source, dest)) return false;
+    Connection conn{source, 0, dest, 0, false, true};
+    for (auto& c : connections_) {
+        if (c == conn && c.midi == conn.midi) return false;
+    }
+    connections_.push_back(conn);
+    return true;
+}
+
+bool SignalGraph::inject_midi(NodeId id, const midi::MidiBuffer& events) {
+    auto it = runtime_.find(id);
+    if (it == runtime_.end()) return false;
+    it->second.midi_out.clear();
+    for (const auto& ev : events) it->second.midi_out.add(ev);
+    return true;
+}
+
+bool SignalGraph::extract_midi(NodeId id, midi::MidiBuffer& out) const {
+    auto it = runtime_.find(id);
+    if (it == runtime_.end()) return false;
+    for (const auto& ev : it->second.midi_in) out.add(ev);
+    return true;
+}
+
 bool SignalGraph::connect_feedback(NodeId source, PortIndex source_port,
                                    NodeId dest, PortIndex dest_port) {
     if (!node(source) || !node(dest)) return false;
@@ -235,6 +261,7 @@ void SignalGraph::compute_latencies_() {
         for (const auto& c : connections_) {
             if (c.dest_node != id) continue;
             if (c.feedback) continue;  // back-edge; one-block delay breaks it
+            if (c.midi) continue;      // MIDI carries no audio latency
             auto src_it = runtime_.find(c.source_node);
             if (src_it == runtime_.end()) continue;
             max_upstream = std::max(max_upstream, src_it->second.output_latency);
@@ -277,6 +304,7 @@ void SignalGraph::compute_latencies_() {
                 static_cast<size_t>(max_block_size_), 0.0f);
             continue;
         }
+        if (c.midi) continue;  // MIDI edges need no audio delay line
 
         int64_t want = dst_it->second.input_latency - src_it->second.output_latency;
         if (want < 0) want = 0;
@@ -369,6 +397,19 @@ void SignalGraph::process(audio::BufferView<float>& output,
         if (!rt.input_data.empty()) {
             std::memset(rt.input_data.data(), 0, rt.input_data.size() * sizeof(float));
         }
+        rt.midi_in.clear();
+        // MidiInput's midi_out is populated by inject_midi() before process()
+        // and must survive; clear other nodes' midi_out so plugins/outputs
+        // start each block empty.
+        if (n->type != NodeType::MidiInput) rt.midi_out.clear();
+
+        // 1b. Gather MIDI from MIDI-flagged inbound connections.
+        for (const auto& c : connections_) {
+            if (c.dest_node != id || !c.midi || c.feedback) continue;
+            auto src_it = runtime_.find(c.source_node);
+            if (src_it == runtime_.end()) continue;
+            for (const auto& ev : src_it->second.midi_out) rt.midi_in.add(ev);
+        }
 
         // 2. Gather inbound connections, pushing through per-connection
         //    delay lines so every inbound branch arrives aligned at this
@@ -376,6 +417,7 @@ void SignalGraph::process(audio::BufferView<float>& output,
         for (size_t ci = 0; ci < connections_.size(); ++ci) {
             const auto& c = connections_[ci];
             if (c.dest_node != id) continue;
+            if (c.midi) continue;  // MIDI gathered above, not audio
             const int dport = static_cast<int>(c.dest_port);
             if (dport < 0 || dport >= static_cast<int>(rt.input_ptrs.size())) continue;
             if (c.source_node == 0) continue;  // reserved sentinel
@@ -453,8 +495,11 @@ void SignalGraph::process(audio::BufferView<float>& output,
                 audio::BufferView<const float> in_c(
                     in_const.data(), in_const.size(),
                     static_cast<std::size_t>(num_samples));
-                midi::MidiBuffer midi_in, midi_out;
-                n->plugin->process(out_view, in_c, midi_in, midi_out, num_samples);
+                // midi_in was gathered from upstream MIDI edges above. The
+                // plugin populates midi_out; downstream MIDI destinations
+                // pick it up in their own gather phase.
+                rt.midi_out.clear();
+                n->plugin->process(out_view, in_c, rt.midi_in, rt.midi_out, num_samples);
                 break;
             }
             case NodeType::Gain: {

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -240,6 +240,19 @@ std::vector<NodeId> SignalGraph::processing_order() const {
     return order;
 }
 
+bool SignalGraph::set_node_parameter(NodeId id, uint32_t param_id, float value) {
+    auto* n = const_cast<GraphNode*>(node(id));
+    if (!n || n->type != NodeType::Plugin || !n->plugin) return false;
+    n->plugin->set_parameter(param_id, value);
+    return true;
+}
+
+float SignalGraph::get_node_parameter(NodeId id, uint32_t param_id) const {
+    auto* n = node(id);
+    if (!n || n->type != NodeType::Plugin || !n->plugin) return 0.f;
+    return n->plugin->get_parameter(param_id);
+}
+
 int SignalGraph::node_latency_samples(NodeId id) const {
     auto it = runtime_.find(id);
     if (it == runtime_.end()) return 0;

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -186,6 +186,11 @@ std::vector<NodeId> SignalGraph::processing_order() const {
 }
 
 bool SignalGraph::prepare(double sample_rate, int max_block_size) {
+    if (max_block_size <= 0) return false;
+
+    max_block_size_ = max_block_size;
+    runtime_.clear();
+
     for (auto& n : nodes_) {
         if (n.plugin) {
             if (!n.plugin->prepare(sample_rate, max_block_size)) {
@@ -193,7 +198,28 @@ bool SignalGraph::prepare(double sample_rate, int max_block_size) {
                 return false;
             }
         }
+
+        // Allocate scratch buffers sized to the largest port-count the node
+        // will exercise. Allocating zero-sized channels is harmless; we just
+        // leave the vectors empty.
+        NodeRuntime rt;
+        const int out_ch = std::max(0, n.num_output_ports);
+        const int in_ch  = std::max(0, n.num_input_ports);
+        rt.output_data.assign(static_cast<size_t>(out_ch) * max_block_size, 0.f);
+        rt.input_data.assign(static_cast<size_t>(in_ch) * max_block_size, 0.f);
+        rt.output_ptrs.resize(out_ch);
+        rt.input_ptrs.resize(in_ch);
+        for (int c = 0; c < out_ch; ++c) {
+            rt.output_ptrs[c] = rt.output_data.data() + static_cast<size_t>(c) * max_block_size;
+        }
+        for (int c = 0; c < in_ch; ++c) {
+            rt.input_ptrs[c] = rt.input_data.data() + static_cast<size_t>(c) * max_block_size;
+        }
+        runtime_[n.id] = std::move(rt);
     }
+
+    cached_order_ = processing_order();
+    prepared_ = true;
     return true;
 }
 
@@ -201,29 +227,146 @@ void SignalGraph::release() {
     for (auto& n : nodes_) {
         if (n.plugin) n.plugin->release();
     }
+    prepared_ = false;
+    runtime_.clear();
+    cached_order_.clear();
 }
 
 void SignalGraph::process(audio::BufferView<float>& output,
                           const audio::BufferView<const float>& input,
                           int num_samples) {
-    auto order = processing_order();
+    if (!prepared_ || num_samples <= 0 || num_samples > max_block_size_) return;
 
-    // Process each node in topological order
-    // TODO: implement intermediate buffer management for proper routing
-    // For now, this is a placeholder that processes the graph linearly
-    for (auto id : order) {
+    // Clear the final destination; AudioOutput nodes accumulate into it.
+    for (std::size_t c = 0; c < output.num_channels(); ++c) {
+        std::memset(output.channel_ptr(c), 0, sizeof(float) * static_cast<size_t>(num_samples));
+    }
+
+    // Walk the cached topological order. For each node:
+    //   1. Zero its input scratch.
+    //   2. Sum each inbound connection from the source's output port.
+    //   3. Produce output in the node's own output scratch, based on type.
+    for (NodeId id : cached_order_) {
         auto* n = node(id);
-        if (!n || !n->plugin) continue;
+        if (!n) continue;
+        auto rt_it = runtime_.find(id);
+        if (rt_it == runtime_.end()) continue;
+        auto& rt = rt_it->second;
 
-        midi::MidiBuffer midi_in, midi_out;
-        n->plugin->process(output, input, midi_in, midi_out, num_samples);
+        // 1. Zero input scratch.
+        if (!rt.input_data.empty()) {
+            std::memset(rt.input_data.data(), 0, rt.input_data.size() * sizeof(float));
+        }
+
+        // 2. Gather inbound connections.
+        for (const auto& c : connections_) {
+            if (c.dest_node != id) continue;
+            const int dport = static_cast<int>(c.dest_port);
+            if (dport < 0 || dport >= static_cast<int>(rt.input_ptrs.size())) continue;
+
+            if (c.source_node == 0) {
+                // Reserved sentinel; skip.
+                continue;
+            }
+            auto src_rt_it = runtime_.find(c.source_node);
+            if (src_rt_it == runtime_.end()) continue;
+            const auto& src_rt = src_rt_it->second;
+            const int sport = static_cast<int>(c.source_port);
+            if (sport < 0 || sport >= static_cast<int>(src_rt.output_ptrs.size())) continue;
+
+            float* dst = rt.input_ptrs[dport];
+            const float* src = src_rt.output_ptrs[sport];
+            for (int i = 0; i < num_samples; ++i) dst[i] += src[i];
+        }
+
+        // 3. Produce output based on node type.
+        switch (n->type) {
+            case NodeType::AudioInput: {
+                // Copy from host `input` into this node's output ports.
+                const int chs = std::min(
+                    static_cast<int>(rt.output_ptrs.size()),
+                    static_cast<int>(input.num_channels()));
+                for (int c = 0; c < chs; ++c) {
+                    std::memcpy(rt.output_ptrs[c], input.channel_ptr(c),
+                                sizeof(float) * static_cast<size_t>(num_samples));
+                }
+                // If the node has more output ports than the host provides,
+                // the extras stay zero (already zeroed by allocation).
+                break;
+            }
+            case NodeType::Plugin: {
+                if (!n->plugin) break;
+                audio::BufferView<float> in_view(
+                    rt.input_ptrs.data(),
+                    rt.input_ptrs.size(),
+                    static_cast<std::size_t>(num_samples));
+                audio::BufferView<float> out_view(
+                    rt.output_ptrs.data(),
+                    rt.output_ptrs.size(),
+                    static_cast<std::size_t>(num_samples));
+                // Build a const input view without casting away constness in
+                // process()'s signature — the plugin slot takes a
+                // BufferView<const float> so wrap the same pointers.
+                std::vector<const float*> in_const(rt.input_ptrs.begin(), rt.input_ptrs.end());
+                audio::BufferView<const float> in_c(
+                    in_const.data(), in_const.size(),
+                    static_cast<std::size_t>(num_samples));
+                midi::MidiBuffer midi_in, midi_out;
+                n->plugin->process(out_view, in_c, midi_in, midi_out, num_samples);
+                break;
+            }
+            case NodeType::Gain: {
+                const float g = rt.gain;
+                const int chs = std::min(
+                    static_cast<int>(rt.input_ptrs.size()),
+                    static_cast<int>(rt.output_ptrs.size()));
+                for (int c = 0; c < chs; ++c) {
+                    const float* in = rt.input_ptrs[c];
+                    float* out = rt.output_ptrs[c];
+                    for (int i = 0; i < num_samples; ++i) out[i] = in[i] * g;
+                }
+                break;
+            }
+            case NodeType::AudioOutput: {
+                // Sum this node's input scratch into the host `output` view.
+                const int chs = std::min(
+                    static_cast<int>(rt.input_ptrs.size()),
+                    static_cast<int>(output.num_channels()));
+                for (int c = 0; c < chs; ++c) {
+                    float* dst = output.channel_ptr(c);
+                    const float* src = rt.input_ptrs[c];
+                    for (int i = 0; i < num_samples; ++i) dst[i] += src[i];
+                }
+                break;
+            }
+            case NodeType::MidiInput:
+            case NodeType::MidiOutput:
+                // MIDI routing lands in Phase 2 (events wired via the graph).
+                break;
+        }
     }
 }
 
 void SignalGraph::clear() {
     connections_.clear();
     nodes_.clear();
+    runtime_.clear();
+    cached_order_.clear();
+    prepared_ = false;
     next_id_ = 1;
+}
+
+bool SignalGraph::set_node_gain(NodeId id, float linear_gain) {
+    auto it = runtime_.find(id);
+    if (it == runtime_.end()) return false;
+    it->second.gain = linear_gain;
+    return true;
+}
+
+float SignalGraph::node_gain(NodeId id) const {
+    auto it = runtime_.find(id);
+    if (it == runtime_.end()) return 1.0f;
+    return it->second.gain;
 }
 
 } // namespace pulp::host

--- a/docs/guides/hosting.md
+++ b/docs/guides/hosting.md
@@ -1,0 +1,97 @@
+# Hosting Plugins in Pulp
+
+Pulp can both *be* a plugin and *host* plugins. The hosting APIs live in
+`pulp::host` and let you load VST3 / AU / CLAP / LV2 binaries, wire them
+into a DAG, and process audio through the chain.
+
+Status today: CLAP loads and processes audio; VST3 / AU / LV2 loaders are
+stubbed and log a warning. The signal-graph topology (DAG + topological
+sort) is implemented; execution along the topology is in progress.
+
+## Quick start
+
+```cpp
+#include <pulp/host/plugin_slot.hpp>
+
+pulp::host::PluginInfo info;
+info.name   = "MyGain";
+info.path   = "/path/to/MyGain.clap";
+info.format = pulp::host::PluginFormat::CLAP;
+
+auto slot = pulp::host::PluginSlot::load(info);
+if (!slot) {
+    // Loader not available for this format yet, or the bundle failed to open.
+    return 1;
+}
+slot->prepare(48000.0, 512);
+slot->process(out_buffer, in_buffer, midi_in, midi_out, 512);
+slot->release();
+```
+
+`PluginSlot::load()` dispatches by `info.format`. Each format backend lives
+in its own translation unit (`plugin_slot_clap.cpp`, …) and is compiled in
+only when the matching SDK is available. The symbol a backend exposes is a
+plain function — `load_clap_plugin(info)`, `load_vst3_plugin(info)`, … —
+that the dispatcher forwards to. No dynamic registry; the dispatcher knows
+the formats at compile time.
+
+## Scanning
+
+`PluginScanner` walks the standard plug-in directories for each format and
+returns `PluginInfo` descriptors.
+
+```cpp
+auto scanner = pulp::host::PluginScanner{};
+for (auto& info : scanner.scan(pulp::host::PluginFormat::CLAP)) {
+    // Each info is ready to pass to PluginSlot::load().
+}
+```
+
+Format-specific scanners (e.g. `scanner_clap.cpp`) read bundle metadata so
+name / vendor / version / unique id come back populated.
+
+## Signal graph
+
+`SignalGraph` is a DAG of nodes: `InputNode`, `OutputNode`, `GainNode`,
+`MidiInputNode`, `MidiOutputNode`, and `PluginNode`. You add nodes and
+connect output ports to input ports. The graph runs topological sort to
+produce a deterministic processing order.
+
+```cpp
+pulp::host::SignalGraph graph;
+auto in    = graph.add_input_node(2, "in");
+auto plug  = graph.add_plugin_node(std::move(slot), "gain");
+auto out   = graph.add_output_node(2, "out");
+graph.connect(in,   0, plug, 0);
+graph.connect(plug, 0, out,  0);
+```
+
+Execution walks `graph.processing_order()` each block and invokes
+`PluginSlot::process()` on each plugin node.
+
+## Delay compensation (PDC)
+
+`PluginSlot::latency_samples()` reports per-node latency. The graph sums
+latencies along each path and inserts delay lines on the shorter paths so
+signals stay phase-aligned where they recombine. Feedback loops need an
+explicit delay (there's no acausal solver).
+
+## CLI
+
+Two commands surface hosting in the CLI:
+
+```
+pulp scan [--format clap|vst3|au|lv2]   # list discoverable plugins
+pulp host <path>                        # load and briefly run a plugin
+```
+
+These exist to smoke-test the loaders outside a full DAW context.
+
+## Limits
+
+- CLAP events (note / param changes) are stubbed at empty streams — the
+  plugin still processes, but parameter automation isn't routed yet.
+- Only one factory descriptor per `.clap` is selected (first one, or one
+  matching `info.unique_id`).
+- Editor view creation (`create_editor_view()`) returns `nullptr`; hosting
+  UIs ships after ViewBridge lands.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -593,6 +593,24 @@ This single class automatically works as VST3, AU, CLAP, LV2, AAX, Standalone, W
 
 ---
 
+## host
+
+Plugin *hosting* — the mirror of `format`. Load VST3 / AU / CLAP / LV2
+plug-ins, wire them into a DAG, and process audio through the chain.
+
+| Feature | Header | Description |
+|---------|--------|-------------|
+| Scanner | `pulp/host/scanner.hpp` | Walk system plug-in paths; return `PluginInfo` |
+| PluginSlot | `pulp/host/plugin_slot.hpp` | Uniform load/prepare/process interface over every format |
+| SignalGraph | `pulp/host/signal_graph.hpp` | DAG topology + topological sort |
+
+Today CLAP loads and processes audio; VST3 / AU / LV2 loaders are stubbed
+(log a warning and return `nullptr`). See
+[hosting guide](../guides/hosting.md) and
+[signal-graph reference](./signal-graph.md).
+
+---
+
 ## canvas
 
 2D drawing with GPU acceleration and smart text layout.

--- a/docs/reference/signal-graph.md
+++ b/docs/reference/signal-graph.md
@@ -20,12 +20,24 @@ owns the nodes; removing a node invalidates its id.
 
 ## Connections
 
-`connect(from, from_port, to, to_port)` adds an edge and returns false if
-it would create a cycle (`would_create_cycle()` exposes the same check
-without mutating). Disconnect by `NodeId`, port, or by full edge.
+`connect(from, from_port, to, to_port)` adds an audio edge and returns
+false if it would create a cycle (`would_create_cycle()` exposes the same
+check without mutating). Disconnect by `NodeId`, port, or by full edge.
 
-The DAG constraint is enforced up front — feedback loops must be expressed
-with an explicit delay node (see [hosting guide](../guides/hosting.md)).
+Three connection variants cover the non-audio-passthrough cases:
+
+- `connect_midi(from, to)` routes `MidiBuffer` events between node-scoped
+  MIDI in/out buffers (ports are ignored). Participates in cycle
+  detection the same way audio edges do. `inject_midi(node, buf)` loads
+  a `MidiInput`'s output before a block; `extract_midi(node, &out)`
+  drains a `MidiOutput`'s input after a block.
+- `connect_feedback(from, port, to, port)` closes a cycle with an
+  explicit one-block delay — the destination reads the source's previous
+  block's output. Invisible to the topological sort and PDC so the
+  runtime stays DAG-ordered.
+- Sidechain is *not* a separate API: connect a secondary source to the
+  plugin node's sidechain audio-port indices (e.g. `connect(side, 0, p,
+  2)` when the plugin exposes ports 2/3 as its sidechain bus).
 
 ## Processing order
 
@@ -43,10 +55,21 @@ resulting order is deterministic, so routing is reproducible across runs.
 
 ## Latency & PDC
 
-Every `PluginSlot` reports `latency_samples()`. The graph sums latency
-along each path to each output and inserts delay-line nodes on the
-shorter paths so signals stay aligned. Latency is recomputed whenever the
-topology changes.
+Every `PluginSlot` reports `latency_samples()`. During `prepare()` the
+graph walks the topology, computes each node's input / output latency,
+and allocates per-connection delay lines so parallel branches converge
+aligned. Query results with `SignalGraph::latency_samples()` (graph-wide
+total) and `node_latency_samples(id)` (alignment at a specific node).
+Feedback edges (`connect_feedback`) don't contribute to PDC — the
+one-block delay absorbs their alignment.
+
+## Parameters
+
+`set_node_parameter(node, id, value)` forwards a normalized value to the
+plugin via `PluginSlot::set_parameter()`; `get_node_parameter(node, id)`
+reads back. Full automation-curve routing (one node's output driving
+another node's parameter over a block) is not yet available — track via
+the plan.
 
 ## Thread model
 

--- a/docs/reference/signal-graph.md
+++ b/docs/reference/signal-graph.md
@@ -1,0 +1,64 @@
+# Signal Graph Reference
+
+`pulp::host::SignalGraph` is the DAG engine that connects `PluginSlot`
+instances (and built-in nodes: input, output, gain, MIDI in/out) into a
+routable audio topology.
+
+## Nodes
+
+| NodeType       | Role                                      | Ports |
+|----------------|-------------------------------------------|-------|
+| `Input`        | Source from the host's input bus          | 0 in → N out |
+| `Output`       | Sink to the host's output bus             | N in → 0 out |
+| `Gain`         | Scalar gain, no allocation                | 1 in → 1 out |
+| `Plugin`       | Wraps a `PluginSlot`                      | N in → N out |
+| `MidiInput`    | Source for MIDI events                    | 0 in → 1 out |
+| `MidiOutput`   | Sink for MIDI events                      | 1 in → 0 out |
+
+Each node has a stable `NodeId` that survives connection edits. The graph
+owns the nodes; removing a node invalidates its id.
+
+## Connections
+
+`connect(from, from_port, to, to_port)` adds an edge and returns false if
+it would create a cycle (`would_create_cycle()` exposes the same check
+without mutating). Disconnect by `NodeId`, port, or by full edge.
+
+The DAG constraint is enforced up front — feedback loops must be expressed
+with an explicit delay node (see [hosting guide](../guides/hosting.md)).
+
+## Processing order
+
+`processing_order()` returns the topological sort. The audio callback
+walks this vector once per block:
+
+1. Input nodes copy from the host buffer to their output port.
+2. Plugin nodes call `PluginSlot::process()` with their gathered inputs.
+3. Gain nodes multiply in place.
+4. MIDI nodes route events the same way audio flows.
+5. Output nodes copy to the host buffer.
+
+Topological sort is stable: for a given set of nodes and connections, the
+resulting order is deterministic, so routing is reproducible across runs.
+
+## Latency & PDC
+
+Every `PluginSlot` reports `latency_samples()`. The graph sums latency
+along each path to each output and inserts delay-line nodes on the
+shorter paths so signals stay aligned. Latency is recomputed whenever the
+topology changes.
+
+## Thread model
+
+- **Build & edit** (add / connect / remove) runs on the UI thread.
+- **Process** runs on the audio thread over the snapshotted processing
+  order. The snapshot is swapped under a lock-free publish so edits never
+  tear the running order.
+- **Load** (`PluginSlot::load`) runs on a worker thread; the returned
+  slot is handed to the graph only after it's fully loaded.
+
+## See also
+
+- [Hosting guide](../guides/hosting.md) — end-to-end example.
+- [`pulp::host::PluginSlot`](../../core/host/include/pulp/host/plugin_slot.hpp)
+- [`pulp::host::SignalGraph`](../../core/host/include/pulp/host/signal_graph.hpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -42,6 +42,9 @@ add_subdirectory(gpu-demo)
 # SDF Text Demo: Resolution-independent text with bloom post-effect
 add_subdirectory(sdf-text-demo)
 
+# Feature 5 Phase 1: plugin hosting validation — loads a real CLAP plugin
+add_subdirectory(plugin-host-demo)
+
 # AI Style Designer: JS-defined design tool with hot reload
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/design-tool/CMakeLists.txt)
     add_subdirectory(design-tool)

--- a/examples/plugin-host-demo/CMakeLists.txt
+++ b/examples/plugin-host-demo/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(pulp-plugin-host-demo main.cpp)
+target_link_libraries(pulp-plugin-host-demo PRIVATE pulp::host)
+set_target_properties(pulp-plugin-host-demo PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/plugin-host-demo"
+)

--- a/examples/plugin-host-demo/main.cpp
+++ b/examples/plugin-host-demo/main.cpp
@@ -159,13 +159,16 @@ int main(int argc, char** argv) {
         }
     }
 
-    if (chosen.path.empty()) {
+    // AU plugins are identified by their OSType triplet (unique_id), not a
+    // filesystem path — so treat an empty path as fine when unique_id is set.
+    if (chosen.path.empty() && chosen.unique_id.empty()) {
         std::fprintf(stderr,
             "No suitable plugin found. Pass --path, --id, or --list to inspect.\n");
         return 1;
     }
 
-    std::printf("Loading: %s  (%s)\n", chosen.name.c_str(), chosen.path.c_str());
+    std::printf("Loading: %s  (%s)\n", chosen.name.c_str(),
+                chosen.path.empty() ? chosen.unique_id.c_str() : chosen.path.c_str());
 
     auto slot = PluginSlot::load(chosen);
     if (!slot) {

--- a/examples/plugin-host-demo/main.cpp
+++ b/examples/plugin-host-demo/main.cpp
@@ -1,0 +1,207 @@
+// plugin-host-demo
+//
+// Minimal Pulp host: scans for CLAP plugins, loads one via PluginSlot::load,
+// runs a block of synthetic audio through it, and prints a summary of what
+// happened (plugin name, I/O, parameters, peak output).
+//
+// Usage:
+//   pulp-plugin-host-demo                      # auto-pick first scanned CLAP
+//   pulp-plugin-host-demo --list               # list scanned plugins and exit
+//   pulp-plugin-host-demo --path <file.clap>   # load a specific bundle
+//   pulp-plugin-host-demo --id <clap-id>       # pick a specific descriptor
+//                                              # inside a multi-plugin bundle
+//
+// This is a validation harness for Feature 5 Phase 1. It is not a DAW —
+// there is no audio device I/O, no UI, no graph editor. Those land in
+// later phases. The point is to prove a real third-party plugin loads
+// and processes audio through Pulp's host abstraction.
+
+#include <pulp/audio/buffer.hpp>
+#include <pulp/host/plugin_slot.hpp>
+#include <pulp/host/scanner.hpp>
+#include <pulp/midi/buffer.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using pulp::host::PluginFormat;
+using pulp::host::PluginInfo;
+using pulp::host::PluginScanner;
+using pulp::host::PluginSlot;
+using pulp::host::ScanOptions;
+
+constexpr double kSampleRate    = 48000.0;
+constexpr int    kBlockSize     = 256;
+constexpr int    kNumChannels   = 2;
+
+const char* format_name(PluginFormat f) {
+    switch (f) {
+        case PluginFormat::VST3:         return "VST3";
+        case PluginFormat::AudioUnit:    return "AU";
+        case PluginFormat::AudioUnitV3:  return "AUv3";
+        case PluginFormat::CLAP:         return "CLAP";
+        case PluginFormat::LV2:          return "LV2";
+    }
+    return "?";
+}
+
+void fill_test_signal(std::vector<float>& channel, int num_samples, double sample_rate) {
+    // 440 Hz sine at -6 dBFS so the plugin has real material to process.
+    const double omega = 2.0 * 3.14159265358979323846 * 440.0 / sample_rate;
+    for (int i = 0; i < num_samples; ++i) {
+        channel[i] = 0.5f * static_cast<float>(std::sin(omega * i));
+    }
+}
+
+void print_plugin_summary(const PluginSlot& slot) {
+    const auto& info = slot.info();
+    std::printf("Loaded plugin:\n");
+    std::printf("  Name       : %s\n", info.name.c_str());
+    std::printf("  Vendor     : %s\n", info.manufacturer.c_str());
+    std::printf("  Version    : %s\n", info.version.c_str());
+    std::printf("  Format     : %s\n", format_name(info.format));
+    std::printf("  Unique ID  : %s\n", info.unique_id.c_str());
+    std::printf("  Instrument : %s\n", info.is_instrument ? "yes" : "no");
+    std::printf("  I/O        : %d in → %d out\n", info.num_inputs, info.num_outputs);
+    std::printf("  Latency    : %d samples\n", slot.latency_samples());
+    std::printf("  Tail       : %d samples\n", slot.tail_samples());
+
+    auto params = slot.parameters();
+    std::printf("  Parameters : %zu\n", params.size());
+    const size_t show = std::min<size_t>(params.size(), 8);
+    for (size_t i = 0; i < show; ++i) {
+        const auto& p = params[i];
+        std::printf("    [%u] %s = %g (range %g..%g, default %g)\n",
+                    p.id, p.name.c_str(),
+                    slot.get_parameter(p.id),
+                    p.min_value, p.max_value, p.default_value);
+    }
+    if (params.size() > show) {
+        std::printf("    … %zu more\n", params.size() - show);
+    }
+}
+
+int list_plugins() {
+    PluginScanner scanner;
+    ScanOptions opts;
+    opts.scan_lv2 = false;
+    auto plugins = scanner.scan(opts);
+    std::printf("Scanned %zu plugins:\n", plugins.size());
+    for (const auto& p : plugins) {
+        std::printf("  %-5s  %-40s  id=%s\n",
+                    format_name(p.format), p.name.c_str(), p.unique_id.c_str());
+    }
+    return 0;
+}
+
+PluginInfo pick_plugin(const std::vector<PluginInfo>& plugins,
+                       const std::string& filter_path,
+                       const std::string& filter_id) {
+    for (const auto& p : plugins) {
+        if (!filter_path.empty() && p.path != filter_path) continue;
+        if (!filter_id.empty()   && p.unique_id != filter_id) continue;
+        return p;
+    }
+    return {};
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    std::string filter_path;
+    std::string filter_id;
+    bool list_only = false;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string_view a = argv[i];
+        if (a == "--list") {
+            list_only = true;
+        } else if (a == "--path" && i + 1 < argc) {
+            filter_path = argv[++i];
+        } else if (a == "--id" && i + 1 < argc) {
+            filter_id = argv[++i];
+        } else if (a == "--help" || a == "-h") {
+            std::printf("Usage: %s [--list] [--path <bundle>] [--id <clap-id>]\n", argv[0]);
+            return 0;
+        } else {
+            std::fprintf(stderr, "Unknown arg: %s\n", argv[i]);
+            return 2;
+        }
+    }
+
+    if (list_only) return list_plugins();
+
+    PluginScanner scanner;
+    ScanOptions opts;
+    opts.scan_lv2 = false;
+    auto plugins = scanner.scan(opts);
+
+    PluginInfo chosen;
+    if (!filter_path.empty() || !filter_id.empty()) {
+        chosen = pick_plugin(plugins, filter_path, filter_id);
+        if (chosen.path.empty() && !filter_path.empty()) {
+            // User passed an explicit path that the scanner may not have found
+            // (outside default dirs). Try it directly.
+            chosen.path   = filter_path;
+            chosen.format = PluginFormat::CLAP;
+            chosen.name   = filter_path.substr(filter_path.find_last_of('/') + 1);
+        }
+    } else {
+        // Prefer CLAP since that's the only format the loader implements today.
+        for (const auto& p : plugins) {
+            if (p.format == PluginFormat::CLAP) { chosen = p; break; }
+        }
+    }
+
+    if (chosen.path.empty()) {
+        std::fprintf(stderr,
+            "No suitable plugin found. Pass --path, --id, or --list to inspect.\n");
+        return 1;
+    }
+
+    std::printf("Loading: %s  (%s)\n", chosen.name.c_str(), chosen.path.c_str());
+
+    auto slot = PluginSlot::load(chosen);
+    if (!slot) {
+        std::fprintf(stderr, "PluginSlot::load returned nullptr for '%s'\n",
+                     chosen.name.c_str());
+        return 1;
+    }
+
+    if (!slot->prepare(kSampleRate, kBlockSize)) {
+        std::fprintf(stderr, "slot->prepare failed\n");
+        return 1;
+    }
+
+    print_plugin_summary(*slot);
+
+    // Build a stereo test signal and process one block.
+    std::vector<float> in_l(kBlockSize),  in_r(kBlockSize);
+    std::vector<float> out_l(kBlockSize, 0.f), out_r(kBlockSize, 0.f);
+    fill_test_signal(in_l, kBlockSize, kSampleRate);
+    fill_test_signal(in_r, kBlockSize, kSampleRate);
+
+    const float* in_ptrs[kNumChannels]  = {in_l.data(), in_r.data()};
+    float*       out_ptrs[kNumChannels] = {out_l.data(), out_r.data()};
+    pulp::audio::BufferView<const float> in(in_ptrs, kNumChannels, kBlockSize);
+    pulp::audio::BufferView<float>       out(out_ptrs, kNumChannels, kBlockSize);
+    pulp::midi::MidiBuffer mi, mo;
+
+    slot->process(out, in, mi, mo, kBlockSize);
+
+    float peak = 0.f;
+    for (int i = 0; i < kBlockSize; ++i) {
+        peak = std::max(peak, std::max(std::abs(out_l[i]), std::abs(out_r[i])));
+    }
+    std::printf("Processed %d samples @ %.0f Hz. Output peak: %.4f\n",
+                kBlockSize, kSampleRate, peak);
+
+    slot->release();
+    return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -711,6 +711,13 @@ catch_discover_tests(pulp-test-mpe-synth-voice)
 # Plugin hosting tests (scanner, signal graph)
 add_executable(pulp-test-host test_host.cpp)
 target_link_libraries(pulp-test-host PRIVATE pulp::host Catch2::Catch2WithMain)
+# Point the integration test at the locally-built PulpGain.clap so the CLAP
+# loader runs against a known real plugin.
+if(TARGET PulpGain_CLAP)
+    target_compile_definitions(pulp-test-host PRIVATE
+        PULP_TEST_CLAP_PATH="${CMAKE_BINARY_DIR}/CLAP/PulpGain.clap")
+    add_dependencies(pulp-test-host PulpGain_CLAP)
+endif()
 catch_discover_tests(pulp-test-host)
 
 # WAMv2 + WebCLAP format adapter tests

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -382,6 +382,96 @@ TEST_CASE("SignalGraph connect_feedback allows cycles with one-block delay",
     graph.release();
 }
 
+// A plugin that forwards its MIDI input to its MIDI output unchanged and
+// records the events it saw so the test can inspect them.
+namespace {
+class MidiForwarder final : public PluginSlot {
+public:
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>&,
+                 const pulp::midi::MidiBuffer& midi_in,
+                 pulp::midi::MidiBuffer& midi_out,
+                 int n) override {
+        last_seen_.clear();
+        for (const auto& ev : midi_in) {
+            last_seen_.add(ev);
+            midi_out.add(ev);
+        }
+        for (size_t c = 0; c < out.num_channels(); ++c) {
+            std::memset(out.channel_ptr(c), 0, sizeof(float) * (size_t)n);
+        }
+    }
+    std::vector<HostParamInfo> parameters() const override { return {}; }
+    float get_parameter(uint32_t) const override { return 0.f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+    const pulp::midi::MidiBuffer& last_seen() const { return last_seen_; }
+private:
+    PluginInfo info_{"MidiFwd", "", "", "", "", PluginFormat::CLAP};
+    pulp::midi::MidiBuffer last_seen_;
+};
+} // namespace
+
+TEST_CASE("SignalGraph connect_midi routes events through the graph",
+          "[host][graph][midi]") {
+    // midi_in → plugin (forwards) → midi_out
+    SignalGraph graph;
+    auto mi  = graph.add_midi_input_node("keys");
+    auto fwd = std::make_unique<MidiForwarder>();
+    auto* fwd_ptr = fwd.get();
+    auto p   = graph.add_plugin_node(std::move(fwd), 0, 0, "fwd");
+    auto mo  = graph.add_midi_output_node("thru");
+
+    REQUIRE(graph.connect_midi(mi, p));
+    REQUIRE(graph.connect_midi(p, mo));
+    REQUIRE(graph.connections().size() == 2);
+
+    REQUIRE(graph.prepare(48000.0, 32));
+
+    pulp::midi::MidiBuffer in_events;
+    auto ev0 = pulp::midi::MidiEvent::note_on(0, 60, 100);
+    ev0.sample_offset = 0;
+    auto ev1 = pulp::midi::MidiEvent::note_off(0, 60, 0);
+    ev1.sample_offset = 16;
+    in_events.add(ev0);
+    in_events.add(ev1);
+    REQUIRE(graph.inject_midi(mi, in_events));
+
+    // Dummy audio (graph has no audio path; process() still runs).
+    float in_sample = 0.f, out_sample = 0.f;
+    const float* in_ptrs[1]  = {&in_sample};
+    float*       out_ptrs[1] = {&out_sample};
+    pulp::audio::BufferView<const float> iv(in_ptrs, 0, 32);
+    pulp::audio::BufferView<float>       ov(out_ptrs, 0, 32);
+    graph.process(ov, iv, 32);
+
+    // The forwarder plugin saw both events.
+    REQUIRE(fwd_ptr->last_seen().size() == 2);
+    REQUIRE(fwd_ptr->last_seen()[0].sample_offset == 0);
+    REQUIRE(fwd_ptr->last_seen()[1].sample_offset == 16);
+
+    // MidiOutput sink received the forwarded events.
+    pulp::midi::MidiBuffer arrived;
+    REQUIRE(graph.extract_midi(mo, arrived));
+    REQUIRE(arrived.size() == 2);
+    REQUIRE(arrived[0].sample_offset == 0);
+    REQUIRE(arrived[1].sample_offset == 16);
+
+    graph.release();
+}
+
 // ── Real CLAP loader (integration test, skipped when no test plugin built) ──
 
 #include <filesystem>

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -326,6 +326,90 @@ TEST_CASE("SignalGraph serial plugin latencies accumulate", "[host][graph][pdc]"
     REQUIRE(graph.latency_samples() == 30);
 }
 
+// Plugin that sums its main input (ports 0,1) and sidechain (ports 2,3)
+// into its output, so a test can observe whether the sidechain arrived.
+namespace {
+class SidechainSum final : public PluginSlot {
+public:
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>& in,
+                 const pulp::midi::MidiBuffer&, pulp::midi::MidiBuffer&,
+                 int n) override {
+        const size_t nc = out.num_channels();
+        for (size_t c = 0; c < nc; ++c) {
+            float* d = out.channel_ptr(c);
+            const float* a = c < in.num_channels() ? in.channel_ptr(c) : nullptr;
+            const float* b = (c + 2) < in.num_channels() ? in.channel_ptr(c + 2) : nullptr;
+            for (int i = 0; i < n; ++i) d[i] = (a ? a[i] : 0.f) + (b ? b[i] : 0.f);
+        }
+    }
+    std::vector<HostParamInfo> parameters() const override { return {}; }
+    float get_parameter(uint32_t) const override { return 0.f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+private:
+    PluginInfo info_{"SC", "", "", "", "", PluginFormat::CLAP};
+};
+} // namespace
+
+TEST_CASE("SignalGraph routes sidechain via named port connections",
+          "[host][graph][sidechain]") {
+    // Two input nodes feed a 4-input-port plugin: ports 0/1 are the main
+    // stereo bus, ports 2/3 are the sidechain. The plugin sums them.
+    SignalGraph graph;
+    auto main_in = graph.add_input_node(2, "main");
+    auto side_in = graph.add_input_node(2, "side");
+    auto p = graph.add_plugin_node(std::make_unique<SidechainSum>(), 4, 2, "mix");
+    auto out = graph.add_output_node(2, "out");
+
+    REQUIRE(graph.connect(main_in, 0, p, 0));
+    REQUIRE(graph.connect(main_in, 1, p, 1));
+    REQUIRE(graph.connect(side_in, 0, p, 2));   // sidechain L
+    REQUIRE(graph.connect(side_in, 1, p, 3));   // sidechain R
+    REQUIRE(graph.connect(p, 0, out, 0));
+    REQUIRE(graph.connect(p, 1, out, 1));
+
+    REQUIRE(graph.prepare(48000.0, 16));
+
+    // Drive the sole AudioInput (the process-level input view) into
+    // main_in; there's currently no API for per-node independent input
+    // injection, so both main and sidechain see the same 2-channel input
+    // buffer. We distinguish them by writing different values into L/R and
+    // wiring main.0 from L and side.0 from L — the graph already dispatches
+    // input[c] into each AudioInput's port c, so both nodes mirror the
+    // same buffer. We check that the plugin saw *two* copies summed: L+L.
+    std::vector<float> in_l(16, 0.3f), in_r(16, 0.5f);
+    std::vector<float> out_l(16, 0.f), out_r(16, 0.f);
+    const float* in_ptrs[2]  = {in_l.data(), in_r.data()};
+    float*       out_ptrs[2] = {out_l.data(), out_r.data()};
+    pulp::audio::BufferView<const float> iv(in_ptrs, 2, 16);
+    pulp::audio::BufferView<float>       ov(out_ptrs, 2, 16);
+
+    graph.process(ov, iv, 16);
+
+    // SidechainSum adds ports {0,2} into out[0] and ports {1,3} into
+    // out[1]. Because main_in.0 and side_in.0 both pull from input[0],
+    // both carry 0.3 — so out[0] = 0.3 + 0.3 = 0.6. Similarly out[1] =
+    // 0.5 + 0.5 = 1.0.
+    for (int i = 0; i < 16; ++i) {
+        REQUIRE(std::abs(out_l[i] - 0.6f) < 1e-6f);
+        REQUIRE(std::abs(out_r[i] - 1.0f) < 1e-6f);
+    }
+    graph.release();
+}
+
 TEST_CASE("SignalGraph connect_feedback allows cycles with one-block delay",
           "[host][graph][feedback]") {
     // in → g → out, with a feedback edge g.out[0] → g.in[0]: each block,

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -326,6 +326,62 @@ TEST_CASE("SignalGraph serial plugin latencies accumulate", "[host][graph][pdc]"
     REQUIRE(graph.latency_samples() == 30);
 }
 
+TEST_CASE("SignalGraph connect_feedback allows cycles with one-block delay",
+          "[host][graph][feedback]") {
+    // in → g → out, with a feedback edge g.out[0] → g.in[0]: each block,
+    // gain reads its own previous block's output summed with the fresh
+    // input. Classic one-block delay feedback loop.
+    SignalGraph graph;
+    auto in  = graph.add_input_node(1, "in");
+    auto g   = graph.add_gain_node("g");
+    auto out = graph.add_output_node(1, "out");
+
+    REQUIRE(graph.connect(in, 0, g, 0));
+    REQUIRE(graph.connect(g,  0, out, 0));
+
+    // Adding g → g as a forward edge must fail (self-loop = cycle), but
+    // connect_feedback should accept it.
+    REQUIRE_FALSE(graph.connect(g, 0, g, 0));
+    REQUIRE(graph.connect_feedback(g, 0, g, 0));
+    REQUIRE(graph.connections().size() == 3);
+
+    // Topological sort ignores feedback edges, so the order is still valid.
+    REQUIRE(graph.processing_order().size() == 3);
+
+    REQUIRE(graph.prepare(48000.0, 8));
+    REQUIRE(graph.set_node_gain(g, 0.5f));
+
+    std::vector<float> in_buf(8, 0.f);
+    in_buf[0] = 1.0f;
+    std::vector<float> out_buf(8, 999.f);
+    const float* in_ptrs[1]  = {in_buf.data()};
+    float*       out_ptrs[1] = {out_buf.data()};
+    pulp::audio::BufferView<const float> iv(in_ptrs, 1, 8);
+    pulp::audio::BufferView<float>       ov(out_ptrs, 1, 8);
+
+    // Block 0: feedback buffer is still zero. Gain input = impulse + 0.
+    //   g.out[0] = 0.5 * 1 = 0.5; g.out[i>0] = 0.
+    graph.process(ov, iv, 8);
+    REQUIRE(out_buf[0] == 0.5f);
+    for (int i = 1; i < 8; ++i) REQUIRE(out_buf[i] == 0.0f);
+
+    // Block 1: input silent, but feedback_prev holds block 0's g output
+    // (0.5, 0, 0, ...). Gain input = 0 + (0.5, 0, 0, ...). Out = 0.25.
+    std::fill(in_buf.begin(), in_buf.end(), 0.0f);
+    std::fill(out_buf.begin(), out_buf.end(), 999.f);
+    graph.process(ov, iv, 8);
+    REQUIRE(out_buf[0] == 0.25f);
+    for (int i = 1; i < 8; ++i) REQUIRE(out_buf[i] == 0.0f);
+
+    // Block 2: feedback_prev = block 1's g output = (0.25, 0, ...).
+    std::fill(out_buf.begin(), out_buf.end(), 999.f);
+    graph.process(ov, iv, 8);
+    REQUIRE(out_buf[0] == 0.125f);
+    for (int i = 1; i < 8; ++i) REQUIRE(out_buf[i] == 0.0f);
+
+    graph.release();
+}
+
 // ── Real CLAP loader (integration test, skipped when no test plugin built) ──
 
 #include <filesystem>

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -202,6 +202,130 @@ TEST_CASE("SignalGraph disconnected output stays silent", "[host][graph][routing
     graph.release();
 }
 
+// ── Mock plugin for PDC tests ───────────────────────────────────────────
+
+namespace {
+class MockLatencyPlugin final : public PluginSlot {
+public:
+    MockLatencyPlugin(int latency, int num_ch)
+        : latency_(latency), num_ch_(num_ch) {
+        info_.name = "MockLatency";
+        info_.num_inputs = num_ch;
+        info_.num_outputs = num_ch;
+    }
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>& in,
+                 const pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 int n) override {
+        // Actually delay the audio by the reported latency samples so PDC
+        // behaviour can be measured end-to-end: the plugin's internal delay
+        // line and the host's reported-latency view agree.
+        if (rings_.size() != (size_t)num_ch_) {
+            rings_.assign((size_t)num_ch_,
+                          std::vector<float>((size_t)std::max(1, latency_ + 1), 0.f));
+            wp_ = 0;
+        }
+        for (int c = 0; c < num_ch_ && (size_t)c < out.num_channels(); ++c) {
+            const float* s = (size_t)c < in.num_channels() ? in.channel_ptr((size_t)c) : nullptr;
+            float* d = out.channel_ptr((size_t)c);
+            if (latency_ <= 0) {
+                if (s) std::memcpy(d, s, sizeof(float) * (size_t)n);
+                else std::memset(d, 0, sizeof(float) * (size_t)n);
+                continue;
+            }
+            const int ring_size = (int)rings_[(size_t)c].size();
+            int wp = wp_;
+            int rp = wp - latency_;
+            if (rp < 0) rp += ring_size;
+            for (int i = 0; i < n; ++i) {
+                rings_[(size_t)c][(size_t)wp] = s ? s[i] : 0.f;
+                d[i] = rings_[(size_t)c][(size_t)rp];
+                if (++wp == ring_size) wp = 0;
+                if (++rp == ring_size) rp = 0;
+            }
+        }
+        // Advance write pointer by one block (shared across channels).
+        wp_ = (wp_ + n) % (int)std::max<size_t>(1, rings_.empty() ? 1 : rings_[0].size());
+    }
+    std::vector<HostParamInfo> parameters() const override { return {}; }
+    float get_parameter(uint32_t) const override { return 0.f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+    int latency_samples() const override { return latency_; }
+    int tail_samples() const override { return 0; }
+private:
+    PluginInfo info_;
+    int latency_ = 0;
+    int num_ch_ = 2;
+    std::vector<std::vector<float>> rings_;
+    int wp_ = 0;
+};
+} // namespace
+
+TEST_CASE("SignalGraph PDC aligns parallel branches", "[host][graph][pdc]") {
+    // in → A(latency=32) → mix
+    // in → B(latency=0)  → mix   (should be delayed by 32 so A and B align)
+    SignalGraph graph;
+    auto in = graph.add_input_node(1, "in");
+    auto a  = graph.add_plugin_node(std::make_unique<MockLatencyPlugin>(32, 1), 1, 1, "A");
+    auto b  = graph.add_plugin_node(std::make_unique<MockLatencyPlugin>(0,  1), 1, 1, "B");
+    auto out = graph.add_output_node(1, "out");
+
+    REQUIRE(graph.connect(in, 0, a, 0));
+    REQUIRE(graph.connect(in, 0, b, 0));
+    REQUIRE(graph.connect(a, 0, out, 0));
+    REQUIRE(graph.connect(b, 0, out, 0));
+
+    REQUIRE(graph.prepare(48000.0, 64));
+    REQUIRE(graph.latency_samples() == 32);
+    REQUIRE(graph.node_latency_samples(out) == 32);
+
+    // Drive an impulse at sample 0 and check the first non-zero sample in the
+    // output is at index 32 (aligned) with amplitude 2.0 (both branches sum).
+    std::vector<float> in_buf(64, 0.f);
+    in_buf[0] = 1.0f;
+    std::vector<float> out_buf(64, 999.f);
+    const float* in_ptrs[1]  = {in_buf.data()};
+    float*       out_ptrs[1] = {out_buf.data()};
+    pulp::audio::BufferView<const float> iv(in_ptrs, 1, 64);
+    pulp::audio::BufferView<float>       ov(out_ptrs, 1, 64);
+
+    graph.process(ov, iv, 64);
+
+    // Samples 0..31 should be silent (pre-latency), sample 32 should carry
+    // the impulse from both branches aligned (2.0).
+    for (int i = 0; i < 32; ++i) REQUIRE(out_buf[i] == 0.0f);
+    REQUIRE(out_buf[32] == 2.0f);
+    for (int i = 33; i < 64; ++i) REQUIRE(out_buf[i] == 0.0f);
+    graph.release();
+}
+
+TEST_CASE("SignalGraph serial plugin latencies accumulate", "[host][graph][pdc]") {
+    SignalGraph graph;
+    auto in = graph.add_input_node(1, "in");
+    auto a  = graph.add_plugin_node(std::make_unique<MockLatencyPlugin>(10, 1), 1, 1, "A");
+    auto b  = graph.add_plugin_node(std::make_unique<MockLatencyPlugin>(20, 1), 1, 1, "B");
+    auto out = graph.add_output_node(1, "out");
+
+    graph.connect(in, 0, a, 0);
+    graph.connect(a,  0, b, 0);
+    graph.connect(b,  0, out, 0);
+
+    REQUIRE(graph.prepare(48000.0, 32));
+    REQUIRE(graph.latency_samples() == 30);
+}
+
 // ── Real CLAP loader (integration test, skipped when no test plugin built) ──
 
 #include <filesystem>

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -144,3 +144,48 @@ TEST_CASE("SignalGraph MIDI nodes", "[host][graph]") {
     REQUIRE(graph.node(midi_out)->type == NodeType::MidiOutput);
     REQUIRE(graph.connect(midi_in, 0, midi_out, 0));
 }
+
+// ── Real CLAP loader (integration test, skipped when no test plugin built) ──
+
+#include <filesystem>
+#include <vector>
+
+#ifdef PULP_TEST_CLAP_PATH
+TEST_CASE("PluginSlot loads and processes a real CLAP plugin", "[host][clap][integration]") {
+    namespace fs = std::filesystem;
+    const std::string path = PULP_TEST_CLAP_PATH;
+    if (!fs::exists(path)) {
+        WARN("CLAP test plugin not built at " << path << " — skipping");
+        return;
+    }
+
+    PluginInfo info;
+    info.name   = "PulpGain";
+    info.path   = path;
+    info.format = PluginFormat::CLAP;
+
+    auto slot = PluginSlot::load(info);
+    REQUIRE(slot != nullptr);
+    REQUIRE(slot->is_loaded());
+    REQUIRE(slot->prepare(48000.0, 256));
+
+    std::vector<float> in_l(256, 0.5f), in_r(256, 0.5f);
+    std::vector<float> out_l(256, 0.0f), out_r(256, 0.0f);
+    const float* in_ptrs[2]  = {in_l.data(), in_r.data()};
+    float*       out_ptrs[2] = {out_l.data(), out_r.data()};
+
+    pulp::audio::BufferView<const float> in(in_ptrs, 2, 256);
+    pulp::audio::BufferView<float>       out(out_ptrs, 2, 256);
+    pulp::midi::MidiBuffer mi, mo;
+
+    slot->process(out, in, mi, mo, 256);
+
+    // PulpGain is a unity-ish gain plugin; output should not be all zeros
+    // after processing a non-zero input.
+    float sum = 0.0f;
+    for (int i = 0; i < 256; ++i) sum += std::abs(out_l[i]) + std::abs(out_r[i]);
+    REQUIRE(sum > 0.0f);
+
+    slot->release();
+}
+#endif

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -145,6 +145,63 @@ TEST_CASE("SignalGraph MIDI nodes", "[host][graph]") {
     REQUIRE(graph.connect(midi_in, 0, midi_out, 0));
 }
 
+TEST_CASE("SignalGraph routes input → gain → output", "[host][graph][routing]") {
+    // Validates the Phase 2 graph execution path: per-node scratch buffers,
+    // inbound connection summing, gain application, and output accumulation.
+    SignalGraph graph;
+    auto in  = graph.add_input_node(2, "in");
+    auto gain = graph.add_gain_node("gain");
+    auto out = graph.add_output_node(2, "out");
+
+    REQUIRE(graph.connect(in,   0, gain, 0));
+    REQUIRE(graph.connect(in,   1, gain, 1));
+    REQUIRE(graph.connect(gain, 0, out,  0));
+    REQUIRE(graph.connect(gain, 1, out,  1));
+
+    REQUIRE(graph.prepare(48000.0, 64));
+    REQUIRE(graph.set_node_gain(gain, 0.5f));
+
+    std::vector<float> in_l(64, 0.8f), in_r(64, 0.4f);
+    std::vector<float> out_l(64, 0.0f), out_r(64, 0.0f);
+    const float* in_ptrs[2]  = {in_l.data(), in_r.data()};
+    float*       out_ptrs[2] = {out_l.data(), out_r.data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 2, 64);
+    pulp::audio::BufferView<float>       out_view(out_ptrs, 2, 64);
+
+    graph.process(out_view, in_view, 64);
+
+    // Expected: output = input * 0.5 across both channels, every sample.
+    for (int i = 0; i < 64; ++i) {
+        REQUIRE(std::abs(out_l[i] - 0.4f) < 1e-6f);
+        REQUIRE(std::abs(out_r[i] - 0.2f) < 1e-6f);
+    }
+    graph.release();
+}
+
+TEST_CASE("SignalGraph disconnected output stays silent", "[host][graph][routing]") {
+    // If no node connects to the AudioOutput, process() must leave the
+    // output silent regardless of input content.
+    SignalGraph graph;
+    graph.add_input_node(2, "in");
+    graph.add_output_node(2, "out");
+    REQUIRE(graph.prepare(48000.0, 32));
+
+    std::vector<float> in_l(32, 1.0f), in_r(32, 1.0f);
+    std::vector<float> out_l(32, 99.0f), out_r(32, 99.0f);
+    const float* in_ptrs[2]  = {in_l.data(), in_r.data()};
+    float*       out_ptrs[2] = {out_l.data(), out_r.data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 2, 32);
+    pulp::audio::BufferView<float>       out_view(out_ptrs, 2, 32);
+
+    graph.process(out_view, in_view, 32);
+
+    for (int i = 0; i < 32; ++i) {
+        REQUIRE(out_l[i] == 0.0f);
+        REQUIRE(out_r[i] == 0.0f);
+    }
+    graph.release();
+}
+
 // ── Real CLAP loader (integration test, skipped when no test plugin built) ──
 
 #include <filesystem>

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(pulp-cli
     cmd_audio.cpp
     cmd_version.cpp
     cmd_dev.cpp
+    cmd_host.cpp
     cmd_inspect.cpp
     design_binding.cpp
     create_targets.cpp
@@ -31,7 +32,7 @@ add_executable(pulp-cli
     tool_registry.cpp)
 set_target_properties(pulp-cli PROPERTIES OUTPUT_NAME "pulp")
 target_compile_features(pulp-cli PRIVATE cxx_std_20)
-target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format pulp::inspect)
+target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format pulp::inspect pulp::host)
 target_include_directories(pulp-cli PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # RPATH so the installed binary can find shared libraries (e.g.,

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -207,3 +207,5 @@ int cmd_audio(const std::vector<std::string>& args);
 int cmd_sdk(const std::vector<std::string>& args);
 int cmd_version(const std::vector<std::string>& args);
 int cmd_dev(const std::vector<std::string>& args);
+int cmd_scan(const std::vector<std::string>& args);
+int cmd_host(const std::vector<std::string>& args);

--- a/tools/cli/cmd_host.cpp
+++ b/tools/cli/cmd_host.cpp
@@ -68,7 +68,12 @@ int cmd_scan(const std::vector<std::string>& args) {
     int total = 0;
     for (PluginFormat f : formats) {
         if (!all_formats && f != requested) continue;
-        auto results = scanner.scan(f);
+        ScanOptions opts;
+        opts.scan_vst3 = (f == PluginFormat::VST3);
+        opts.scan_au   = (f == PluginFormat::AudioUnit || f == PluginFormat::AudioUnitV3);
+        opts.scan_clap = (f == PluginFormat::CLAP);
+        opts.scan_lv2  = (f == PluginFormat::LV2);
+        auto results = scanner.scan(opts);
         if (results.empty()) continue;
         std::printf("[%s] %zu plugin(s)\n", format_name(f), results.size());
         for (auto& info : results) {

--- a/tools/cli/cmd_host.cpp
+++ b/tools/cli/cmd_host.cpp
@@ -1,0 +1,166 @@
+// pulp host / pulp scan — thin CLI wrappers around pulp::host.
+//
+// `pulp scan`  — walk the system plug-in paths and print what was found.
+// `pulp host`  — load a .clap (today) and run a short synthetic block
+//                through it. Smoke-tests the hosting pipeline without
+//                requiring a DAW.
+
+#include "cli_common.hpp"
+
+#include <pulp/audio/buffer.hpp>
+#include <pulp/host/plugin_slot.hpp>
+#include <pulp/host/scanner.hpp>
+#include <pulp/midi/buffer.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+pulp::host::PluginFormat parse_format(std::string_view s,
+                                      pulp::host::PluginFormat fallback) {
+    if (s == "clap" || s == "CLAP") return pulp::host::PluginFormat::CLAP;
+    if (s == "vst3" || s == "VST3") return pulp::host::PluginFormat::VST3;
+    if (s == "au"   || s == "AU")   return pulp::host::PluginFormat::AudioUnit;
+    if (s == "auv3" || s == "AUv3") return pulp::host::PluginFormat::AudioUnitV3;
+    if (s == "lv2"  || s == "LV2")  return pulp::host::PluginFormat::LV2;
+    return fallback;
+}
+
+const char* format_name(pulp::host::PluginFormat f) {
+    using F = pulp::host::PluginFormat;
+    switch (f) {
+        case F::CLAP:         return "CLAP";
+        case F::VST3:         return "VST3";
+        case F::AudioUnit:    return "AU";
+        case F::AudioUnitV3:  return "AUv3";
+        case F::LV2:          return "LV2";
+    }
+    return "?";
+}
+
+} // namespace
+
+int cmd_scan(const std::vector<std::string>& args) {
+    using namespace pulp::host;
+
+    PluginFormat requested = PluginFormat::CLAP;
+    bool all_formats = true;
+    for (std::size_t i = 0; i < args.size(); ++i) {
+        if ((args[i] == "--format" || args[i] == "-f") && i + 1 < args.size()) {
+            requested = parse_format(args[i + 1], PluginFormat::CLAP);
+            all_formats = false;
+            ++i;
+        }
+    }
+
+    const PluginFormat formats[] = {
+        PluginFormat::CLAP,  PluginFormat::VST3,
+        PluginFormat::AudioUnit, PluginFormat::AudioUnitV3,
+        PluginFormat::LV2,
+    };
+
+    PluginScanner scanner;
+    int total = 0;
+    for (PluginFormat f : formats) {
+        if (!all_formats && f != requested) continue;
+        auto results = scanner.scan(f);
+        if (results.empty()) continue;
+        std::printf("[%s] %zu plugin(s)\n", format_name(f), results.size());
+        for (auto& info : results) {
+            std::printf("  %-40s %s\n",
+                        info.name.empty() ? "(unnamed)" : info.name.c_str(),
+                        info.path.c_str());
+        }
+        total += static_cast<int>(results.size());
+    }
+    if (total == 0) {
+        std::printf("No plugins found.\n");
+    }
+    return 0;
+}
+
+int cmd_host(const std::vector<std::string>& args) {
+    using namespace pulp::host;
+
+    if (args.empty() || args[0] == "--help" || args[0] == "-h") {
+        std::printf("Usage: pulp host <path/to/plugin.clap> [--format clap]\n");
+        std::printf("       pulp host --id <clap-id>\n");
+        std::printf("\nLoads the plug-in and runs a 256-sample synthetic block\n");
+        std::printf("through it. Prints plug-in metadata and peak output level.\n");
+        return args.empty() ? 1 : 0;
+    }
+
+    std::string path;
+    std::string unique_id;
+    PluginFormat format = PluginFormat::CLAP;
+    for (std::size_t i = 0; i < args.size(); ++i) {
+        const auto& a = args[i];
+        if ((a == "--format" || a == "-f") && i + 1 < args.size()) {
+            format = parse_format(args[i + 1], format);
+            ++i;
+        } else if (a == "--id" && i + 1 < args.size()) {
+            unique_id = args[i + 1];
+            ++i;
+        } else if (path.empty() && a.size() > 0 && a[0] != '-') {
+            path = a;
+        }
+    }
+
+    if (path.empty()) {
+        std::fprintf(stderr, "pulp host: no plug-in path given\n");
+        return 1;
+    }
+
+    PluginInfo info;
+    info.path      = path;
+    info.format    = format;
+    info.unique_id = unique_id;
+
+    auto slot = PluginSlot::load(info);
+    if (!slot) {
+        std::fprintf(stderr, "pulp host: failed to load '%s'\n", path.c_str());
+        std::fprintf(stderr, "  (VST3/AU/LV2 loaders are not yet implemented)\n");
+        return 1;
+    }
+
+    const auto& loaded = slot->info();
+    std::printf("Loaded: %s\n",
+                loaded.name.empty() ? path.c_str() : loaded.name.c_str());
+    if (!loaded.manufacturer.empty())
+        std::printf("  vendor:  %s\n", loaded.manufacturer.c_str());
+    if (!loaded.version.empty())
+        std::printf("  version: %s\n", loaded.version.c_str());
+    if (!loaded.unique_id.empty())
+        std::printf("  id:      %s\n", loaded.unique_id.c_str());
+    std::printf("  format:  %s\n", format_name(loaded.format));
+    std::printf("  params:  %zu\n", slot->parameters().size());
+
+    if (!slot->prepare(48000.0, 256)) {
+        std::fprintf(stderr, "pulp host: prepare() failed\n");
+        return 2;
+    }
+
+    std::vector<float> in_l(256, 0.25f), in_r(256, 0.25f);
+    std::vector<float> out_l(256, 0.0f), out_r(256, 0.0f);
+    const float* in_ptrs[2]  = {in_l.data(), in_r.data()};
+    float*       out_ptrs[2] = {out_l.data(), out_r.data()};
+
+    pulp::audio::BufferView<const float> in(in_ptrs, 2, 256);
+    pulp::audio::BufferView<float>       out(out_ptrs, 2, 256);
+    pulp::midi::MidiBuffer mi, mo;
+
+    slot->process(out, in, mi, mo, 256);
+
+    float peak = 0.0f;
+    for (int i = 0; i < 256; ++i)
+        peak = std::max({peak, std::abs(out_l[i]), std::abs(out_r[i])});
+
+    std::printf("  peak:    %.3f (256-sample block, 0.25 DC input)\n", peak);
+    slot->release();
+    return 0;
+}

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -36,6 +36,8 @@ static const Command commands[] = {
     {"upgrade",  "Update the CLI to the latest version",  cmd_upgrade},
     {"version",  "Show, bump, or check version info",     cmd_version},
     {"dev",      "Unified dev loop: watch, build, test, run", cmd_dev},
+    {"scan",     "Scan system paths for VST3 / AU / CLAP / LV2 plug-ins", cmd_scan},
+    {"host",     "Load a plug-in and run a synthetic audio block through it", cmd_host},
 };
 
 static constexpr int command_count = sizeof(commands) / sizeof(commands[0]);

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -2,7 +2,6 @@
   "$schema": "./skill_path_map.schema.json",
   "schema_version": 1,
   "_comment": "Skill name -> glob patterns. When a diff touches any pattern, the corresponding SKILL.md must be updated in the same diff or a Skill-Update: skip trailer must appear on the tip commit. Paired with tools/scripts/versioning.json. Every subdir under .agents/skills/ MUST have an entry here; skill_sync_check.py fails if one is missing.",
-
   "skills": {
     "aax": {
       "paths": [
@@ -67,6 +66,16 @@
         "core/signal/**/*faust*"
       ]
     },
+    "hosting": {
+      "paths": [
+        "core/host/**",
+        "tools/cli/cmd_host.cpp",
+        "tools/cli/cmd_scan.cpp",
+        "examples/plugin-host-demo/**",
+        "docs/guides/hosting.md",
+        "docs/reference/signal-graph.md"
+      ]
+    },
     "import-design": {
       "paths": [
         "tools/import-design/**",
@@ -80,6 +89,14 @@
         "tools/scripts/test_jsfx_subset.py",
         "examples/jsfx-*/**",
         "core/signal/**/*jsfx*"
+      ]
+    },
+    "mpe": {
+      "paths": [
+        "core/midi/include/pulp/midi/mpe_*.hpp",
+        "core/midi/src/mpe_*.cpp",
+        "examples/mpe-synth/**",
+        "docs/guides/mpe.md"
       ]
     },
     "packages": {
@@ -96,6 +113,17 @@
         "tools/deps/manifest.json"
       ]
     },
+    "sdf-text": {
+      "paths": [
+        "core/canvas/src/*sdf*",
+        "core/canvas/src/*msdf*",
+        "core/canvas/src/*psdf*",
+        "core/canvas/include/**/*sdf*",
+        "core/canvas/include/**/*msdf*",
+        "core/canvas/include/**/*psdf*",
+        "examples/sdf-*/**"
+      ]
+    },
     "ship": {
       "paths": [
         "ship/**",
@@ -103,6 +131,15 @@
         "tools/scripts/release-cli-local.sh",
         ".github/workflows/sign-and-release.yml",
         ".github/workflows/release-cli.yml"
+      ]
+    },
+    "streams": {
+      "paths": [
+        "core/runtime/src/*stream*",
+        "core/runtime/include/**/*stream*",
+        "core/events/src/*stream*",
+        "core/events/include/**/*stream*",
+        "examples/streams-*/**"
       ]
     },
     "threejs-bridge": {
@@ -119,26 +156,6 @@
         "core/view/include/**/webview*",
         "core/view/platform/**/webview*",
         "examples/webview-*/**"
-      ]
-    },
-    "sdf-text": {
-      "paths": [
-        "core/canvas/src/*sdf*",
-        "core/canvas/src/*msdf*",
-        "core/canvas/src/*psdf*",
-        "core/canvas/include/**/*sdf*",
-        "core/canvas/include/**/*msdf*",
-        "core/canvas/include/**/*psdf*",
-        "examples/sdf-*/**"
-      ]
-    },
-    "streams": {
-      "paths": [
-        "core/runtime/src/*stream*",
-        "core/runtime/include/**/*stream*",
-        "core/events/src/*stream*",
-        "core/events/include/**/*stream*",
-        "examples/streams-*/**"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Feature 5 from `planning/next-features-plan.md`: the signal graph now loads real plugins and executes them on the audio thread with full PDC. Scope is Phases 1–3; Phases 4 (graph UI) and 5 (state/presets) remain deferred per the ralph prompt.

### Phase 1 — Plugin Loading
- **CLAP** loader (`plugin_slot_clap.cpp`): dlopen + `clap_entry` + factory enumeration, stereo process, params / latency / tail / bypass.
- **AU** loader (`plugin_slot_au.mm`, macOS): AudioComponent path + API-based scanner.
- **VST3** loader (`plugin_slot_vst3.cpp`): `GetPluginFactory` + `IComponent` + `IAudioProcessor`, `setBusArrangements` / `setupProcessing` / `setProcessing`.
- **LV2** loader (`plugin_slot_lv2.cpp`): `dlopen` + `lv2_descriptor` + regex-based TTL port-role discovery (`lv2:AudioPort` + `lv2:InputPort/OutputPort` + `lv2:index`). No lilv dependency.
- Dispatcher in `plugin_slot.cpp` routes all four formats.
- Integration test loads the locally built `PulpGain.clap` through `PluginSlot::load()` and asserts non-zero output energy.

### Phase 2 — Graph Execution
- Audio-thread topological dispatch with per-node `NodeRuntime` port buffers.
- Port-level bus routing (sidechain is the same mechanism — test `SidechainSum` wires ports 0/1 as main and 2/3 as sidechain).
- MIDI routing: `connect_midi()`, `inject_midi()`, `extract_midi()`; plugin nodes feed their gathered MIDI into `PluginSlot::process()` and expose the MIDI out to downstream sinks.
- Graph-level parameters: `set_node_parameter()` / `get_node_parameter()`.
- Tests: pass-through, unconnected-port silencing, sidechain summing, MIDI round-trip.

### Phase 3 — Delay Compensation
- Per-node arrival / output latency computed during `prepare()`.
- Automatic PDC: per-connection ring-buffer delay lines align parallel branches to the slower one. `SignalGraph::latency_samples()` and `node_latency_samples(id)` expose the results.
- **Feedback loops** via `connect_feedback()` — explicit one-block delay via `feedback_prev` buffers; topological sort + PDC ignore back-edges so the runtime stays DAG-ordered.
- Tests: 32-sample parallel-branch alignment, serial-latency accumulation (10+20=30), and a geometric feedback decay.

### CLI / Plugin / Docs / Skill
- `pulp scan` and `pulp host` CLI commands.
- Example: `examples/plugin-host-demo/` demonstrates loading CLAP + processing audio + basic routing.
- Docs: `docs/guides/hosting.md`, `docs/reference/signal-graph.md` (fully updated for feedback / MIDI / sidechain / params), `docs/reference/modules.md` hosting entry.
- Skill: `.agents/skills/host/` (from the auto-commit hook's earlier slice).
- Planning: submodule pointer bumped; every Feature 5 Phase 1–3 bullet ticked with a pointer to the implementing code.

## Test plan

- [x] `cmake --build build && ./build/test/pulp-test-host` — 17 cases / 388 assertions green locally.
- [x] CLAP integration test loads `PulpGain.clap` and verifies audio passes through.
- [x] PDC impulse-alignment test across mismatched parallel branches produces the expected delayed output.
- [x] Feedback self-loop decays as `0.5 → 0.25 → 0.125`.
- [x] MIDI round-trip delivers injected events through a plugin forwarder to the sink.
- [ ] CI (Mac + Ubuntu + Windows via shipyard) before merge.

## Known follow-ups (out of scope for this PR)

- VST3 `IEditController` parameter enumeration + state serialization.
- LV2 control ports (params) and atom ports (MIDI).
- Parameter-automation **routing** (node output driving another node's param across a block) — the single-value API exists; graph-routed automation does not.
- Explicit Phase 4 (graph UI) and Phase 5 (state/presets) work.