### PR TITLE
Streams Phase 4: MessageChannel + WebSocket + OSC + JSON-RPC (closes Feature 3)

### DIFF
--- a/.agents/skills/streams/SKILL.md
+++ b/.agents/skills/streams/SKILL.md
@@ -20,7 +20,10 @@ hierarchy is the sanctioned path; do not add new `Socket::send` /
 | Talk to another process via pipe | `PipeStream` around `NamedPipe` |
 | Open a TCP connection | `TcpStream`, wrapped in `AsyncStream` so `connect()` doesn't block the caller |
 | Fetch an HTTP/S body | `HttpStream::get(url)` / `post(url, body)` |
-| Send structured messages (JSON, OSC, WebSocket frames) | **Not yet** — Phase 4 `MessageChannel` is deferred |
+| Send structured WebSocket frames | `WebSocketChannel::connect()` / `::accept()` over a `TcpStream` |
+| Send/receive OSC messages | `OscChannel::open(host, remote_port, local_port)` |
+| RPC-style request/response over any transport | `JsonRpcPeer` wrapping any `MessageChannel` |
+| In-process message bridge (tests, inspector) | `MemoryMessageChannel::make_pair()` |
 
 ## AsyncStream — the patterns that actually work
 
@@ -67,12 +70,34 @@ To add WebSocket, S3, or any other transport:
    document it so callers know to always wrap in `AsyncStream` with
    `auto_read = true`.
 
+## Message channels (Phase 4)
+
+`MessageChannel` is the structured-message layer: one `send()` = one
+delivered message. Use it when the peer protocol doesn't tolerate
+partial reads (WebSocket, OSC, JSON-RPC, etc.). Callback dispatch
+follows the same executor contract as `AsyncStream`.
+
+Patterns that are easy to get wrong:
+
+1. **WebSocket handshake failure returns `nullptr`.** `WebSocketChannel::connect`
+   and `::accept` both return an empty unique_ptr on a bad handshake — do not
+   dereference blindly.
+2. **OSC is UDP; packets can be dropped or reordered.** For anything that
+   needs reliability, layer `JsonRpcPeer` over `WebSocketChannel`, not
+   `OscChannel`.
+3. **`JsonRpcPeer` is symmetric.** Either side can register methods, send
+   requests, and fire notifications; a client/server split is only a
+   convention.
+4. **JSON-RPC params are JSON strings, not choc values.** This keeps the
+   public surface free of CHOC types. Format with `choc::json::toString`
+   on the way in and `choc::json::parse` on the way out if you need
+   structured access.
+
 ## References
 
-- Docs: `docs/reference/streams.md` (full API + backpressure flow)
-- Headers: `core/runtime/include/pulp/runtime/{stream,async_stream,network_stream}.hpp`
+- Docs: `docs/reference/streams.md` (full API + backpressure flow + MessageChannel)
+- Headers: `core/runtime/include/pulp/runtime/{stream,async_stream,network_stream,message_channel,websocket_channel,memory_message_channel,json_rpc}.hpp`, `core/osc/include/pulp/osc/osc_channel.hpp`
 - Example: `examples/stream-demo/main.cpp`
-- Tests: `test/test_{stream,async_stream,network_stream}.cpp` — copy these
+- Tests: `test/test_{stream,async_stream,network_stream,websocket_channel,osc_channel,json_rpc}.cpp` — copy these
   patterns for new transport tests
-- Feature plan: `planning/next-features-plan.md` § Feature 3 (Phase 4
-  MessageChannel is the next piece, currently deferred)
+- Feature plan: `planning/next-features-plan.md` § Feature 3 (Phase 1–4 landed)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.5.0
+    VERSION 0.6.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/osc/CMakeLists.txt
+++ b/core/osc/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(pulp-osc PRIVATE
     src/osc.cpp
     src/osc_udp.cpp
     src/bundle.cpp
+    src/osc_channel.cpp
 )
 
 target_link_libraries(pulp-osc PUBLIC pulp::runtime)

--- a/core/osc/include/pulp/osc/osc.hpp
+++ b/core/osc/include/pulp/osc/osc.hpp
@@ -57,6 +57,11 @@ public:
     // Send a message
     bool send(const Message& msg);
 
+    // Send a raw, already-encoded OSC datagram (e.g., a #bundle or any
+    // byte-exact payload the caller has pre-built). Returns true if the
+    // full payload was sent.
+    bool send_raw(const uint8_t* data, size_t size);
+
     // Disconnect
     void disconnect();
 

--- a/core/osc/include/pulp/osc/osc_channel.hpp
+++ b/core/osc/include/pulp/osc/osc_channel.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+// OscChannel — adapts pulp::osc Sender/Receiver to the runtime
+// MessageChannel contract.
+//
+// Each incoming UDP packet is delivered as a `Message{Binary, bytes}`.
+// The bytes are the raw OSC-encoded packet; callers can decode with
+// `pulp::osc::decode()` if they want the structured form. Outgoing
+// messages are treated the same way — `send(bytes)` transmits the
+// bytes verbatim, or the overload `send(const osc::Message&)` encodes
+// first.
+//
+// This wrapper is not a replacement for `osc::Sender` / `osc::Receiver`
+// — it lets higher-level code (JSON-RPC transport, remote-control,
+// MCP bridges) treat OSC as "just another MessageChannel" so a single
+// consumer can swap transports without branching.
+
+#include <pulp/osc/osc.hpp>
+#include <pulp/runtime/message_channel.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+
+namespace pulp::osc {
+
+struct OscChannelOptions {
+    /// Dispatch executor (same semantics as other channels). When empty,
+    /// callbacks run on the Receiver's internal thread.
+    pulp::runtime::MessageExecutor executor;
+};
+
+class OscChannel : public pulp::runtime::MessageChannel {
+public:
+    /// Construct a bidirectional channel: sender targets (host, remote_port)
+    /// and the receiver listens on local_port. Returns nullptr if either
+    /// endpoint fails to open.
+    static std::unique_ptr<OscChannel> open(
+        std::string_view host, std::uint16_t remote_port,
+        std::uint16_t local_port,
+        OscChannelOptions options = {});
+
+    ~OscChannel() override;
+
+    // MessageChannel
+    bool send(const std::uint8_t* data, std::size_t size) override;
+    void on_message(pulp::runtime::MessageCallback callback) override;
+    void on_closed(pulp::runtime::ChannelClosedCallback callback) override;
+    void on_error(pulp::runtime::ChannelErrorCallback callback) override;
+    void close() override;
+    bool is_open() const override { return open_.load(); }
+
+    /// Convenience — encode and send a structured OSC message.
+    bool send(const Message& msg);
+
+private:
+    OscChannel(OscChannelOptions options);
+
+    void dispatch_message(const Message& msg);
+    void dispatch(std::function<void()> fn);
+
+    OscChannelOptions options_;
+    Sender sender_;
+    Receiver receiver_;
+    std::atomic<bool> open_{false};
+    std::atomic<bool> closed_fired_{false};
+
+    std::mutex mutex_;
+    pulp::runtime::MessageCallback on_message_;
+    pulp::runtime::ChannelClosedCallback on_closed_;
+    pulp::runtime::ChannelErrorCallback on_error_;
+};
+
+}  // namespace pulp::osc

--- a/core/osc/src/osc_channel.cpp
+++ b/core/osc/src/osc_channel.cpp
@@ -29,9 +29,10 @@ OscChannel::~OscChannel() { close(); }
 
 bool OscChannel::send(const std::uint8_t* data, std::size_t size) {
     if (!open_.load() || !sender_.is_connected() || size == 0) return false;
-    Message msg = decode(data, size);
-    if (msg.address.empty()) return false;
-    return sender_.send(msg);
+    // Preserve the caller's bytes verbatim — bundles (#bundle), custom
+    // encodings, or payloads this module doesn't yet decode must pass
+    // through unmodified. Structured sends can use the Message overload.
+    return sender_.send_raw(data, size);
 }
 
 bool OscChannel::send(const Message& msg) {

--- a/core/osc/src/osc_channel.cpp
+++ b/core/osc/src/osc_channel.cpp
@@ -1,0 +1,102 @@
+#include <pulp/osc/osc_channel.hpp>
+
+#include <utility>
+
+namespace pulp::osc {
+
+std::unique_ptr<OscChannel> OscChannel::open(
+    std::string_view host, std::uint16_t remote_port,
+    std::uint16_t local_port,
+    OscChannelOptions options) {
+    std::unique_ptr<OscChannel> chan(new OscChannel(std::move(options)));
+
+    if (!chan->sender_.connect(std::string(host), remote_port)) {
+        return nullptr;
+    }
+    const bool listen_ok = chan->receiver_.listen(local_port,
+        [raw = chan.get()](const Message& m) { raw->dispatch_message(m); });
+    if (!listen_ok) {
+        chan->sender_.disconnect();
+        return nullptr;
+    }
+    chan->open_.store(true);
+    return chan;
+}
+
+OscChannel::OscChannel(OscChannelOptions options) : options_(std::move(options)) {}
+
+OscChannel::~OscChannel() { close(); }
+
+bool OscChannel::send(const std::uint8_t* data, std::size_t size) {
+    if (!open_.load() || !sender_.is_connected() || size == 0) return false;
+    Message msg = decode(data, size);
+    if (msg.address.empty()) return false;
+    return sender_.send(msg);
+}
+
+bool OscChannel::send(const Message& msg) {
+    if (!open_.load() || !sender_.is_connected()) return false;
+    return sender_.send(msg);
+}
+
+void OscChannel::on_message(pulp::runtime::MessageCallback cb) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_message_ = std::move(cb);
+}
+
+void OscChannel::on_closed(pulp::runtime::ChannelClosedCallback cb) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_closed_ = std::move(cb);
+}
+
+void OscChannel::on_error(pulp::runtime::ChannelErrorCallback cb) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_error_ = std::move(cb);
+}
+
+void OscChannel::close() {
+    if (!open_.exchange(false)) {
+        if (!closed_fired_.exchange(true)) {
+            pulp::runtime::ChannelClosedCallback cb;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                cb = on_closed_;
+            }
+            if (cb) dispatch(std::move(cb));
+        }
+        return;
+    }
+    receiver_.stop();
+    sender_.disconnect();
+    if (!closed_fired_.exchange(true)) {
+        pulp::runtime::ChannelClosedCallback cb;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            cb = on_closed_;
+        }
+        if (cb) dispatch(std::move(cb));
+    }
+}
+
+void OscChannel::dispatch_message(const Message& msg) {
+    auto bytes = encode(msg);
+    pulp::runtime::Message m{
+        pulp::runtime::MessageKind::Binary,
+        std::move(bytes)
+    };
+    pulp::runtime::MessageCallback cb;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        cb = on_message_;
+    }
+    if (cb) {
+        dispatch([cb = std::move(cb), m = std::move(m)] { cb(m); });
+    }
+}
+
+void OscChannel::dispatch(std::function<void()> fn) {
+    if (options_.executor) options_.executor(std::move(fn));
+    else fn();
+}
+
+}  // namespace pulp::osc

--- a/core/osc/src/osc_udp.cpp
+++ b/core/osc/src/osc_udp.cpp
@@ -121,15 +121,19 @@ bool Sender::connect(const std::string& host, uint16_t port) {
 }
 
 bool Sender::send(const Message& msg) {
-    if (!impl_->connected) return false;
     auto data = encode(msg);
+    return send_raw(data.data(), data.size());
+}
+
+bool Sender::send_raw(const uint8_t* data, size_t size) {
+    if (!impl_->connected || data == nullptr || size == 0) return false;
     auto sent = sendto(impl_->sock,
-                       reinterpret_cast<const char*>(data.data()),
-                       static_cast<int>(data.size()),
+                       reinterpret_cast<const char*>(data),
+                       static_cast<int>(size),
                        0,
                        reinterpret_cast<sockaddr*>(&impl_->dest),
                        static_cast<SockLen>(sizeof(impl_->dest)));
-    return sent == static_cast<int>(data.size());
+    return sent == static_cast<int>(size);
 }
 
 void Sender::disconnect() {

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -28,6 +28,9 @@ target_sources(pulp-runtime PRIVATE
     src/stream.cpp
     src/async_stream.cpp
     src/network_stream.cpp
+    src/memory_message_channel.cpp
+    src/websocket_channel.cpp
+    src/json_rpc.cpp
     src/ip_address.cpp
     src/i18n.cpp
     src/crypto.cpp

--- a/core/runtime/include/pulp/runtime/crypto.hpp
+++ b/core/runtime/include/pulp/runtime/crypto.hpp
@@ -21,6 +21,11 @@ std::vector<uint8_t> sha256(std::string_view data);
 std::string sha256_hex(const uint8_t* data, size_t size);
 std::string sha256_hex(std::string_view data);
 
+/// Compute SHA-1 hash. Returns 20-byte digest. (Legacy protocols only —
+/// e.g., WebSocket handshake per RFC 6455.)
+std::vector<uint8_t> sha1(const uint8_t* data, size_t size);
+std::vector<uint8_t> sha1(std::string_view data);
+
 /// Compute MD5 hash. Returns 16-byte digest. (Legacy use only.)
 std::vector<uint8_t> md5(const uint8_t* data, size_t size);
 std::vector<uint8_t> md5(std::string_view data);

--- a/core/runtime/include/pulp/runtime/json_rpc.hpp
+++ b/core/runtime/include/pulp/runtime/json_rpc.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+// JSON-RPC 2.0 over MessageChannel.
+//
+// `JsonRpcPeer` is symmetric: any peer can send requests, receive
+// requests, emit notifications, and receive notifications. One peer
+// plus one MessageChannel equals one side of a JSON-RPC session.
+//
+// Wire format is pure JSON text (per the spec). The peer serializes
+// into the channel via `send_text()`, so transports that distinguish
+// text from binary (WebSocket) will carry it as text frames.
+//
+// Error semantics follow JSON-RPC 2.0 §5:
+//   -32700 Parse error
+//   -32600 Invalid Request
+//   -32601 Method not found
+//   -32602 Invalid params
+//   -32603 Internal error
+// User code can return custom codes from request handlers.
+
+#include <pulp/runtime/message_channel.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace pulp::runtime {
+
+/// Structured JSON-RPC error. Matches spec §5.1.
+struct JsonRpcError {
+    int code = 0;
+    std::string message;
+    std::string data_json;  ///< Optional JSON-encoded error.data (empty → omit)
+
+    static JsonRpcError parse_error()       { return {-32700, "Parse error", ""}; }
+    static JsonRpcError invalid_request()   { return {-32600, "Invalid Request", ""}; }
+    static JsonRpcError method_not_found()  { return {-32601, "Method not found", ""}; }
+    static JsonRpcError invalid_params()    { return {-32602, "Invalid params", ""}; }
+    static JsonRpcError internal_error()    { return {-32603, "Internal error", ""}; }
+};
+
+/// Result of a request handler: success JSON (result field) or error.
+struct JsonRpcResult {
+    std::string result_json;  ///< JSON-encoded result (e.g., "42" or "\"ok\"")
+    std::optional<JsonRpcError> error;
+
+    static JsonRpcResult ok(std::string result_json) {
+        return {std::move(result_json), std::nullopt};
+    }
+    static JsonRpcResult fail(JsonRpcError err) {
+        return {"", std::move(err)};
+    }
+};
+
+/// Request handler: given a JSON-encoded params string (empty if omitted),
+/// return a JsonRpcResult. Runs on whichever thread the underlying channel
+/// dispatches on.
+using JsonRpcMethodHandler =
+    std::function<JsonRpcResult(std::string_view params_json)>;
+
+/// Notification handler (incoming notifications carry no id and expect
+/// no response).
+using JsonRpcNotificationHandler =
+    std::function<void(std::string_view params_json)>;
+
+/// Callback for the response to a request we sent.
+using JsonRpcResponseCallback =
+    std::function<void(const JsonRpcResult& response)>;
+
+class JsonRpcPeer {
+public:
+    /// Wrap a message channel. The peer installs an `on_message` handler
+    /// on the channel; do not replace it after construction.
+    explicit JsonRpcPeer(MessageChannel& channel);
+    ~JsonRpcPeer();
+
+    JsonRpcPeer(const JsonRpcPeer&) = delete;
+    JsonRpcPeer& operator=(const JsonRpcPeer&) = delete;
+
+    /// Register a method handler. Replacing a handler with nullptr
+    /// unregisters.
+    void register_method(std::string_view name, JsonRpcMethodHandler handler);
+
+    /// Register a notification handler.
+    void on_notification(std::string_view name, JsonRpcNotificationHandler handler);
+
+    /// Send a request. `params_json` must be a JSON-encoded array or
+    /// object (or empty for no params). The callback fires exactly once
+    /// with the response. Returns false if the channel is closed.
+    bool send_request(std::string_view method,
+                      std::string_view params_json,
+                      JsonRpcResponseCallback callback);
+
+    /// Emit a notification.
+    bool notify(std::string_view method, std::string_view params_json);
+
+private:
+    void handle_message(const Message& msg);
+    void handle_object(std::string_view obj_json);
+    void dispatch_response(std::string_view response_json);
+    void dispatch_request(std::string_view request_json);
+
+    MessageChannel* channel_;
+    std::atomic<std::uint64_t> next_id_{1};
+
+    std::mutex mutex_;
+    std::unordered_map<std::string, JsonRpcMethodHandler> methods_;
+    std::unordered_map<std::string, JsonRpcNotificationHandler> notifications_;
+    std::unordered_map<std::uint64_t, JsonRpcResponseCallback> pending_;
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/memory_message_channel.hpp
+++ b/core/runtime/include/pulp/runtime/memory_message_channel.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+// In-memory MessageChannel pair. Primarily for tests and for local
+// message-driven code that wants to talk to itself (plugins ↔ inspector
+// in the same process, for example) without a socket hop.
+//
+// Usage:
+//   auto [a, b] = MemoryMessageChannel::make_pair();
+//   a->send(...);      // delivered to b->on_message
+//   b->send(...);      // delivered to a->on_message
+
+#include <pulp/runtime/message_channel.hpp>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+namespace pulp::runtime {
+
+class MemoryMessageChannel : public MessageChannel {
+public:
+    /// Create a connected pair. Each side delivers sends to the other's
+    /// on_message.
+    static std::pair<std::unique_ptr<MemoryMessageChannel>,
+                     std::unique_ptr<MemoryMessageChannel>>
+    make_pair();
+
+    ~MemoryMessageChannel() override;
+
+    // MessageChannel
+    bool send(const std::uint8_t* data, std::size_t size) override;
+    bool send_text(std::string_view text) override;
+    void on_message(MessageCallback callback) override;
+    void on_closed(ChannelClosedCallback callback) override;
+    void on_error(ChannelErrorCallback callback) override;
+    void close() override;
+    bool is_open() const override { return open_.load() && peer_alive(); }
+
+private:
+    MemoryMessageChannel() = default;
+
+    bool peer_alive() const;
+    void deliver(Message msg);
+
+    std::weak_ptr<MemoryMessageChannel*> peer_;  // weak-pointer to a raw* so
+                                                 // destruction breaks the link
+    std::shared_ptr<MemoryMessageChannel*> self_;
+    std::atomic<bool> open_{true};
+
+    std::mutex mutex_;
+    MessageCallback on_message_;
+    ChannelClosedCallback on_closed_;
+    ChannelErrorCallback on_error_;
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/message_channel.hpp
+++ b/core/runtime/include/pulp/runtime/message_channel.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+// MessageChannel — structured-message layer on top of byte streams.
+//
+// `Stream` and `AsyncStream` deal in raw bytes. MessageChannel deals in
+// whole messages: one `send()` transmits one message, one `on_message`
+// callback fires per received message. This is the right abstraction for
+// WebSocket, OSC, JSON-RPC, and similar request/response protocols where
+// a partial read is always meaningless.
+//
+// Layering:
+//   byte transport  →  Stream / AsyncStream
+//   framing         →  MessageChannel implementations
+//   protocol        →  JsonRpcClient, remote-control, user code
+//
+// All MessageChannel methods are thread-safe unless documented otherwise.
+// Callback dispatch follows the same executor contract as AsyncStream: if
+// a `MessageExecutor` is supplied at construction, callbacks land on that
+// executor; otherwise they run on whichever thread the implementation uses
+// internally (usually its reader thread).
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pulp::runtime {
+
+/// Classification of a delivered message. Transports that do not
+/// distinguish (OSC, JSON-RPC) report Binary.
+enum class MessageKind : uint8_t {
+    Binary,  ///< opaque bytes
+    Text,    ///< UTF-8 text (WebSocket text frames, JSON-RPC envelopes)
+};
+
+/// A single structured message as delivered by the channel.
+struct Message {
+    MessageKind kind = MessageKind::Binary;
+    std::vector<std::uint8_t> payload;
+
+    /// View the payload as a text string. Only meaningful for
+    /// `kind == MessageKind::Text`.
+    std::string_view as_text() const {
+        return {reinterpret_cast<const char*>(payload.data()), payload.size()};
+    }
+};
+
+/// Called when the channel receives a complete message.
+using MessageCallback = std::function<void(const Message& message)>;
+
+/// Called once when the channel transitions to a closed state — either
+/// the peer closed, the transport errored, or `close()` was invoked.
+using ChannelClosedCallback = std::function<void()>;
+
+/// Called when a transport-level error occurs. After an error callback
+/// fires, the channel is no longer usable and a close callback will
+/// follow.
+using ChannelErrorCallback = std::function<void(std::string_view reason)>;
+
+/// Executor used to dispatch callbacks off whichever worker thread the
+/// channel runs internally. Same shape as `AsyncExecutor`.
+using MessageExecutor = std::function<void(std::function<void()>)>;
+
+/// Abstract base for message-oriented channels.
+///
+/// Implementations never throw from send/receive paths; errors surface as
+/// the return value of `send()` or through the error callback.
+class MessageChannel {
+public:
+    virtual ~MessageChannel() = default;
+
+    MessageChannel(const MessageChannel&) = delete;
+    MessageChannel& operator=(const MessageChannel&) = delete;
+
+    /// Send a message. Returns true if the payload was accepted for
+    /// transmission (queued or written); false if the channel is closed,
+    /// errored, or the payload was rejected (e.g., frame too large).
+    ///
+    /// The default overload sends binary; override `send_text` if the
+    /// transport distinguishes text from binary.
+    virtual bool send(const std::uint8_t* data, std::size_t size) = 0;
+
+    bool send(std::string_view text) {
+        return send_text(text);
+    }
+
+    virtual bool send_text(std::string_view text) {
+        // Default: transports that don't distinguish just send bytes.
+        return send(reinterpret_cast<const std::uint8_t*>(text.data()), text.size());
+    }
+
+    /// Install / replace callbacks. Safe to call at any time; callbacks
+    /// installed during send-processing apply to subsequent messages.
+    virtual void on_message(MessageCallback callback) = 0;
+    virtual void on_closed(ChannelClosedCallback callback) = 0;
+    virtual void on_error(ChannelErrorCallback callback) = 0;
+
+    /// Close the channel. Idempotent. Fires the closed callback.
+    virtual void close() = 0;
+
+    /// Whether the channel is currently usable.
+    virtual bool is_open() const = 0;
+
+protected:
+    MessageChannel() = default;
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/include/pulp/runtime/websocket_channel.hpp
+++ b/core/runtime/include/pulp/runtime/websocket_channel.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+// WebSocketChannel — RFC 6455 MessageChannel over TcpStream.
+//
+// Scope (Phase 4 of the Stream feature plan):
+//   - Client handshake: `Upgrade: websocket`, Sec-WebSocket-Key / Accept
+//     validation (SHA-1 + base64 via pulp::runtime::crypto).
+//   - Server handshake: parse client upgrade, echo a 101 Switching
+//     Protocols with the correct Sec-WebSocket-Accept.
+//   - Frames: text (0x1), binary (0x2), close (0x8), ping (0x9),
+//     pong (0xA). Control frames (close/ping/pong) are handled
+//     internally; ping triggers an automatic pong response.
+//   - 7/16/64-bit payload length. Client frames are masked (per the
+//     RFC "MUST"); server frames are unmasked.
+//
+// Out of scope:
+//   - Extension negotiation (permessage-deflate etc.)
+//   - Fragmented messages across multiple frames (accepted but not
+//     emitted; see implementation notes)
+//   - TLS — for `wss://`, feed a TLS-wrapped TcpStream or use the
+//     forthcoming SecureTcpStream work.
+//
+// Threading: the channel spins up one reader thread that dispatches
+// completed messages via the provided `MessageExecutor` (or inline on
+// the reader thread when none is set). `send()` is thread-safe and
+// serializes writes to the underlying TcpStream via an internal mutex.
+
+#include <pulp/runtime/message_channel.hpp>
+#include <pulp/runtime/network_stream.hpp>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+
+namespace pulp::runtime {
+
+/// Options for WebSocketChannel construction.
+struct WebSocketOptions {
+    /// Executor used to dispatch `on_message`, `on_closed`, `on_error`.
+    /// When empty, callbacks run on the reader thread.
+    MessageExecutor executor;
+
+    /// Maximum inbound payload size (bytes). Frames larger than this
+    /// trigger an error + close. Default 16 MiB — enough for normal
+    /// control traffic while bounding pathological peers.
+    std::size_t max_payload = 16u * 1024u * 1024u;
+};
+
+class WebSocketChannel : public MessageChannel {
+public:
+    /// Perform a client handshake over `tcp`, then start the reader.
+    /// `host` and `path` populate the HTTP/1.1 upgrade request
+    /// (`Host:` header + request-URI). Returns nullptr on failure.
+    static std::unique_ptr<WebSocketChannel> connect(
+        std::unique_ptr<TcpStream> tcp,
+        std::string_view host,
+        std::string_view path = "/",
+        WebSocketOptions options = {});
+
+    /// Perform a server-side handshake over an already-accepted `tcp`
+    /// connection. Reads the HTTP upgrade request, validates the key,
+    /// writes a 101 Switching Protocols response, and starts the
+    /// reader. Returns nullptr on failure.
+    static std::unique_ptr<WebSocketChannel> accept(
+        std::unique_ptr<TcpStream> tcp,
+        WebSocketOptions options = {});
+
+    ~WebSocketChannel() override;
+
+    // MessageChannel interface
+    bool send(const std::uint8_t* data, std::size_t size) override;
+    bool send_text(std::string_view text) override;
+    void on_message(MessageCallback callback) override;
+    void on_closed(ChannelClosedCallback callback) override;
+    void on_error(ChannelErrorCallback callback) override;
+    void close() override;
+    bool is_open() const override;
+
+    /// Expose the handshake Sec-WebSocket-Accept for debugging and for
+    /// tests that want to verify RFC 6455 compliance.
+    static std::string compute_accept_key(std::string_view client_key);
+
+private:
+    enum class Role : uint8_t { Client, Server };
+
+    WebSocketChannel(std::unique_ptr<TcpStream> tcp, Role role,
+                     WebSocketOptions options);
+
+    bool send_frame(uint8_t opcode, const std::uint8_t* data, std::size_t size);
+    void reader_main();
+    void fire_error(std::string_view reason);
+    void fire_closed();
+    void dispatch(std::function<void()> task);
+
+    std::unique_ptr<TcpStream> tcp_;
+    Role role_;
+    WebSocketOptions options_;
+
+    mutable std::mutex mutex_;
+    std::mutex write_mutex_;  ///< serializes frame writes
+    std::atomic<bool> open_{false};
+    std::atomic<bool> closed_fired_{false};
+    std::thread reader_;
+
+    MessageCallback on_message_;
+    ChannelClosedCallback on_closed_;
+    ChannelErrorCallback on_error_;
+};
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/crypto.cpp
+++ b/core/runtime/src/crypto.cpp
@@ -3,6 +3,7 @@
 #include <pulp/runtime/system.hpp>
 
 #include <mbedtls/sha256.h>
+#include <mbedtls/sha1.h>
 #include <mbedtls/md5.h>
 #include <mbedtls/aes.h>
 
@@ -41,6 +42,18 @@ std::string sha256_hex(const uint8_t* data, size_t size) {
 
 std::string sha256_hex(std::string_view data) {
     return sha256_hex(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+}
+
+// ── SHA-1 (legacy protocols only) ───────────────────────────────────────
+
+std::vector<uint8_t> sha1(const uint8_t* data, size_t size) {
+    std::vector<uint8_t> digest(20);
+    mbedtls_sha1(data, size, digest.data());
+    return digest;
+}
+
+std::vector<uint8_t> sha1(std::string_view data) {
+    return sha1(reinterpret_cast<const uint8_t*>(data.data()), data.size());
 }
 
 // ── MD5 ─────────────────────────────────────────────────────────────────

--- a/core/runtime/src/json_rpc.cpp
+++ b/core/runtime/src/json_rpc.cpp
@@ -90,7 +90,15 @@ bool JsonRpcPeer::send_request(std::string_view method,
         std::lock_guard<std::mutex> lock(mutex_);
         pending_[id] = std::move(callback);
     }
-    return channel_->send_text(make_request(id, method, params_json));
+    if (!channel_->send_text(make_request(id, method, params_json))) {
+        // Write failed — reclaim the pending slot so the callback is not
+        // leaked indefinitely. A retry from the caller will allocate a
+        // fresh id rather than piling on stale entries.
+        std::lock_guard<std::mutex> lock(mutex_);
+        pending_.erase(id);
+        return false;
+    }
+    return true;
 }
 
 bool JsonRpcPeer::notify(std::string_view method, std::string_view params_json) {
@@ -120,9 +128,19 @@ void JsonRpcPeer::handle_object(std::string_view obj_json) {
     try {
         root = choc::json::parse(std::string(obj_json));
     } catch (...) {
+        // RFC 4.2: malformed JSON → respond with a -32700 Parse error and
+        // id: null so senders don't hang waiting for a reply.
+        if (channel_) {
+            channel_->send_text(make_error("null", JsonRpcError::parse_error()));
+        }
         return;
     }
-    if (!root.isObject()) return;
+    if (!root.isObject()) {
+        if (channel_) {
+            channel_->send_text(make_error("null", JsonRpcError::invalid_request()));
+        }
+        return;
+    }
 
     const bool has_method = root.hasObjectMember("method");
     const bool has_id = root.hasObjectMember("id");

--- a/core/runtime/src/json_rpc.cpp
+++ b/core/runtime/src/json_rpc.cpp
@@ -1,0 +1,238 @@
+#include <pulp/runtime/json_rpc.hpp>
+
+#include <choc/text/choc_JSON.h>
+#include <choc/containers/choc_Value.h>
+
+#include <sstream>
+#include <utility>
+
+namespace pulp::runtime {
+
+namespace {
+
+std::string value_to_json(const choc::value::ValueView& v) {
+    return choc::json::toString(v);
+}
+
+// Build a JSON-RPC response envelope. `id_json` is already JSON (null,
+// a number, or a quoted string). `result_json` is already JSON.
+std::string make_response(std::string_view id_json, std::string_view result_json) {
+    std::ostringstream ss;
+    ss << R"({"jsonrpc":"2.0","id":)" << id_json
+       << R"(,"result":)" << result_json << "}";
+    return ss.str();
+}
+
+std::string make_error(std::string_view id_json, const JsonRpcError& err) {
+    std::ostringstream ss;
+    ss << R"({"jsonrpc":"2.0","id":)" << id_json
+       << R"(,"error":{"code":)" << err.code
+       << R"(,"message":)" << choc::json::getEscapedQuotedString(err.message);
+    if (!err.data_json.empty()) {
+        ss << R"(,"data":)" << err.data_json;
+    }
+    ss << "}}";
+    return ss.str();
+}
+
+std::string make_request(std::uint64_t id, std::string_view method,
+                         std::string_view params_json) {
+    std::ostringstream ss;
+    ss << R"({"jsonrpc":"2.0","id":)" << id
+       << R"(,"method":)" << choc::json::getEscapedQuotedString(std::string(method));
+    if (!params_json.empty()) {
+        ss << R"(,"params":)" << params_json;
+    }
+    ss << "}";
+    return ss.str();
+}
+
+std::string make_notification(std::string_view method, std::string_view params_json) {
+    std::ostringstream ss;
+    ss << R"({"jsonrpc":"2.0","method":)"
+       << choc::json::getEscapedQuotedString(std::string(method));
+    if (!params_json.empty()) {
+        ss << R"(,"params":)" << params_json;
+    }
+    ss << "}";
+    return ss.str();
+}
+
+}  // namespace
+
+JsonRpcPeer::JsonRpcPeer(MessageChannel& channel) : channel_(&channel) {
+    channel_->on_message([this](const Message& m) { handle_message(m); });
+}
+
+JsonRpcPeer::~JsonRpcPeer() {
+    if (channel_) channel_->on_message({});
+}
+
+void JsonRpcPeer::register_method(std::string_view name, JsonRpcMethodHandler handler) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!handler) methods_.erase(std::string(name));
+    else methods_[std::string(name)] = std::move(handler);
+}
+
+void JsonRpcPeer::on_notification(std::string_view name,
+                                  JsonRpcNotificationHandler handler) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!handler) notifications_.erase(std::string(name));
+    else notifications_[std::string(name)] = std::move(handler);
+}
+
+bool JsonRpcPeer::send_request(std::string_view method,
+                               std::string_view params_json,
+                               JsonRpcResponseCallback callback) {
+    if (!channel_ || !channel_->is_open()) return false;
+    const std::uint64_t id = next_id_.fetch_add(1);
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        pending_[id] = std::move(callback);
+    }
+    return channel_->send_text(make_request(id, method, params_json));
+}
+
+bool JsonRpcPeer::notify(std::string_view method, std::string_view params_json) {
+    if (!channel_ || !channel_->is_open()) return false;
+    return channel_->send_text(make_notification(method, params_json));
+}
+
+void JsonRpcPeer::handle_message(const Message& msg) {
+    std::string_view text(
+        reinterpret_cast<const char*>(msg.payload.data()),
+        msg.payload.size());
+    // JSON-RPC supports batching (top-level array) but we accept only
+    // single objects for Phase 4. A simple sniff: find first non-space.
+    std::size_t i = 0;
+    while (i < text.size() && std::isspace(static_cast<unsigned char>(text[i]))) ++i;
+    if (i >= text.size()) return;
+    if (text[i] == '[') {
+        // Batching deferred; a well-behaved peer can still send a single
+        // object. Ignore silently.
+        return;
+    }
+    handle_object(text);
+}
+
+void JsonRpcPeer::handle_object(std::string_view obj_json) {
+    choc::value::Value root;
+    try {
+        root = choc::json::parse(std::string(obj_json));
+    } catch (...) {
+        return;
+    }
+    if (!root.isObject()) return;
+
+    const bool has_method = root.hasObjectMember("method");
+    const bool has_id = root.hasObjectMember("id");
+    const bool has_result = root.hasObjectMember("result");
+    const bool has_error = root.hasObjectMember("error");
+
+    if (has_method && has_id) {
+        dispatch_request(obj_json);
+    } else if (has_method && !has_id) {
+        // Notification
+        auto method = root["method"].getWithDefault<std::string>("");
+        JsonRpcNotificationHandler handler;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = notifications_.find(method);
+            if (it != notifications_.end()) handler = it->second;
+        }
+        if (handler) {
+            std::string params_json;
+            if (root.hasObjectMember("params")) {
+                params_json = choc::json::toString(root["params"]);
+            }
+            handler(params_json);
+        }
+    } else if (has_result || has_error) {
+        dispatch_response(obj_json);
+    }
+}
+
+void JsonRpcPeer::dispatch_request(std::string_view request_json) {
+    choc::value::Value root;
+    try {
+        root = choc::json::parse(std::string(request_json));
+    } catch (...) {
+        return;
+    }
+
+    const auto method = root["method"].getWithDefault<std::string>("");
+    std::string params_json;
+    if (root.hasObjectMember("params")) {
+        params_json = choc::json::toString(root["params"]);
+    }
+
+    // id can be a number, a string, or null. Carry it through as raw JSON.
+    std::string id_json = "null";
+    if (root.hasObjectMember("id")) {
+        id_json = choc::json::toString(root["id"]);
+    }
+
+    JsonRpcMethodHandler handler;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = methods_.find(method);
+        if (it != methods_.end()) handler = it->second;
+    }
+
+    if (!handler) {
+        channel_->send_text(make_error(id_json, JsonRpcError::method_not_found()));
+        return;
+    }
+
+    JsonRpcResult result;
+    try {
+        result = handler(params_json);
+    } catch (...) {
+        result = JsonRpcResult::fail(JsonRpcError::internal_error());
+    }
+
+    if (result.error) {
+        channel_->send_text(make_error(id_json, *result.error));
+    } else {
+        const auto payload = result.result_json.empty() ? std::string("null")
+                                                        : result.result_json;
+        channel_->send_text(make_response(id_json, payload));
+    }
+}
+
+void JsonRpcPeer::dispatch_response(std::string_view response_json) {
+    choc::value::Value root;
+    try {
+        root = choc::json::parse(std::string(response_json));
+    } catch (...) {
+        return;
+    }
+    if (!root.hasObjectMember("id")) return;
+    auto id_view = root["id"];
+    if (!id_view.isInt()) return;
+    const std::uint64_t id = static_cast<std::uint64_t>(id_view.getInt64());
+
+    JsonRpcResponseCallback cb;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = pending_.find(id);
+        if (it == pending_.end()) return;
+        cb = std::move(it->second);
+        pending_.erase(it);
+    }
+
+    JsonRpcResult result;
+    if (root.hasObjectMember("error")) {
+        auto err = root["error"];
+        JsonRpcError e;
+        if (err.hasObjectMember("code")) e.code = static_cast<int>(err["code"].getInt64());
+        if (err.hasObjectMember("message")) e.message = err["message"].getWithDefault<std::string>("");
+        if (err.hasObjectMember("data")) e.data_json = choc::json::toString(err["data"]);
+        result = JsonRpcResult::fail(std::move(e));
+    } else if (root.hasObjectMember("result")) {
+        result = JsonRpcResult::ok(choc::json::toString(root["result"]));
+    }
+    if (cb) cb(result);
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/memory_message_channel.cpp
+++ b/core/runtime/src/memory_message_channel.cpp
@@ -80,11 +80,16 @@ void MemoryMessageChannel::close() {
         self_closed = std::move(on_closed_);
     }
 
+    // Transition the peer to closed too and consume its callback so that
+    // peer->close() (which frequently happens via the destructor) does
+    // not fire on_closed a second time — ChannelClosedCallback is
+    // contractually called exactly once per channel.
     if (auto p = peer_.lock(); p && *p) {
         MemoryMessageChannel* peer = *p;
+        peer->open_.store(false);
         {
             std::lock_guard<std::mutex> lock(peer->mutex_);
-            peer_closed = peer->on_closed_;
+            peer_closed = std::move(peer->on_closed_);
         }
     }
     if (self_closed) self_closed();

--- a/core/runtime/src/memory_message_channel.cpp
+++ b/core/runtime/src/memory_message_channel.cpp
@@ -1,0 +1,94 @@
+#include <pulp/runtime/memory_message_channel.hpp>
+
+namespace pulp::runtime {
+
+std::pair<std::unique_ptr<MemoryMessageChannel>,
+          std::unique_ptr<MemoryMessageChannel>>
+MemoryMessageChannel::make_pair() {
+    auto a = std::unique_ptr<MemoryMessageChannel>(new MemoryMessageChannel);
+    auto b = std::unique_ptr<MemoryMessageChannel>(new MemoryMessageChannel);
+    a->self_ = std::make_shared<MemoryMessageChannel*>(a.get());
+    b->self_ = std::make_shared<MemoryMessageChannel*>(b.get());
+    a->peer_ = b->self_;
+    b->peer_ = a->self_;
+    return {std::move(a), std::move(b)};
+}
+
+MemoryMessageChannel::~MemoryMessageChannel() {
+    close();
+}
+
+bool MemoryMessageChannel::peer_alive() const {
+    auto p = peer_.lock();
+    return p && *p != nullptr;
+}
+
+bool MemoryMessageChannel::send(const std::uint8_t* data, std::size_t size) {
+    if (!open_.load()) return false;
+    auto p = peer_.lock();
+    if (!p || *p == nullptr) return false;
+    Message m{MessageKind::Binary, std::vector<std::uint8_t>(data, data + size)};
+    (*p)->deliver(std::move(m));
+    return true;
+}
+
+bool MemoryMessageChannel::send_text(std::string_view text) {
+    if (!open_.load()) return false;
+    auto p = peer_.lock();
+    if (!p || *p == nullptr) return false;
+    Message m{MessageKind::Text,
+              std::vector<std::uint8_t>(
+                  reinterpret_cast<const std::uint8_t*>(text.data()),
+                  reinterpret_cast<const std::uint8_t*>(text.data() + text.size()))};
+    (*p)->deliver(std::move(m));
+    return true;
+}
+
+void MemoryMessageChannel::deliver(Message msg) {
+    MessageCallback cb;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        cb = on_message_;
+    }
+    if (cb) cb(msg);
+}
+
+void MemoryMessageChannel::on_message(MessageCallback cb) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_message_ = std::move(cb);
+}
+
+void MemoryMessageChannel::on_closed(ChannelClosedCallback cb) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_closed_ = std::move(cb);
+}
+
+void MemoryMessageChannel::on_error(ChannelErrorCallback cb) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_error_ = std::move(cb);
+}
+
+void MemoryMessageChannel::close() {
+    if (!open_.exchange(false)) return;
+    // Break the pointer so peer.send() fails cleanly.
+    if (self_) *self_ = nullptr;
+
+    ChannelClosedCallback self_closed;
+    ChannelClosedCallback peer_closed;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        self_closed = std::move(on_closed_);
+    }
+
+    if (auto p = peer_.lock(); p && *p) {
+        MemoryMessageChannel* peer = *p;
+        {
+            std::lock_guard<std::mutex> lock(peer->mutex_);
+            peer_closed = peer->on_closed_;
+        }
+    }
+    if (self_closed) self_closed();
+    if (peer_closed) peer_closed();
+}
+
+}  // namespace pulp::runtime

--- a/core/runtime/src/websocket_channel.cpp
+++ b/core/runtime/src/websocket_channel.cpp
@@ -1,0 +1,444 @@
+#include <pulp/runtime/websocket_channel.hpp>
+#include <pulp/runtime/base64.hpp>
+#include <pulp/runtime/crypto.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstring>
+#include <random>
+#include <sstream>
+
+namespace pulp::runtime {
+
+namespace {
+
+constexpr const char* kMagicGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+constexpr uint8_t kOpCont = 0x0;
+constexpr uint8_t kOpText = 0x1;
+constexpr uint8_t kOpBinary = 0x2;
+constexpr uint8_t kOpClose = 0x8;
+constexpr uint8_t kOpPing = 0x9;
+constexpr uint8_t kOpPong = 0xA;
+
+// Read exactly `n` bytes from the stream into `out`. Returns false on
+// close or error. Loops over short reads — the Stream contract allows
+// them and sockets frequently produce them.
+bool read_exactly(Stream& s, std::uint8_t* out, std::size_t n) {
+    std::size_t read = 0;
+    while (read < n) {
+        auto r = s.read(out + read, n - read);
+        if (!r.ok()) {
+            if (r.would_block()) continue;  // spin; simple but works for tests
+            return false;
+        }
+        if (r.bytes == 0) return false;
+        read += r.bytes;
+    }
+    return true;
+}
+
+bool write_all(Stream& s, const std::uint8_t* data, std::size_t n) {
+    std::size_t written = 0;
+    while (written < n) {
+        auto r = s.write(data + written, n - written);
+        if (!r.ok()) return false;
+        if (r.bytes == 0) return false;
+        written += r.bytes;
+    }
+    return true;
+}
+
+std::string make_client_key() {
+    std::array<uint8_t, 16> nonce{};
+    std::random_device rd;
+    std::mt19937 eng(rd());
+    for (auto& b : nonce) b = static_cast<uint8_t>(eng() & 0xFF);
+    return base64_encode(nonce.data(), nonce.size());
+}
+
+std::string lowercase(std::string_view s) {
+    std::string out(s);
+    std::transform(out.begin(), out.end(), out.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return out;
+}
+
+/// Read an HTTP-style header block (until "\r\n\r\n"). Returns the raw
+/// text. On failure returns std::nullopt.
+std::optional<std::string> read_http_headers(Stream& s, std::size_t limit = 16 * 1024) {
+    std::string buf;
+    buf.reserve(512);
+    std::uint8_t ch = 0;
+    while (buf.size() < limit) {
+        auto r = s.read(&ch, 1);
+        if (!r.ok() || r.bytes == 0) return std::nullopt;
+        buf.push_back(static_cast<char>(ch));
+        if (buf.size() >= 4 &&
+            buf.compare(buf.size() - 4, 4, "\r\n\r\n") == 0) {
+            return buf;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> find_header(std::string_view block, std::string_view name) {
+    auto lower_block = lowercase(block);
+    auto lower_name = lowercase(name);
+    std::size_t pos = 0;
+    while (pos < lower_block.size()) {
+        auto line_end = lower_block.find("\r\n", pos);
+        if (line_end == std::string::npos) break;
+        auto line = lower_block.substr(pos, line_end - pos);
+        auto colon = line.find(':');
+        if (colon != std::string::npos && line.substr(0, colon) == lower_name) {
+            std::string_view original(block);
+            auto value = original.substr(pos + colon + 1, line_end - pos - colon - 1);
+            // trim leading/trailing whitespace
+            while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())))
+                value.remove_prefix(1);
+            while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())))
+                value.remove_suffix(1);
+            return std::string(value);
+        }
+        pos = line_end + 2;
+    }
+    return std::nullopt;
+}
+
+}  // namespace
+
+// ─── compute_accept_key ───────────────────────────────────────────────────
+
+std::string WebSocketChannel::compute_accept_key(std::string_view client_key) {
+    std::string concat(client_key);
+    concat.append(kMagicGuid);
+    auto digest = sha1(concat);
+    return base64_encode(digest.data(), digest.size());
+}
+
+// ─── connect (client) ─────────────────────────────────────────────────────
+
+std::unique_ptr<WebSocketChannel> WebSocketChannel::connect(
+    std::unique_ptr<TcpStream> tcp,
+    std::string_view host,
+    std::string_view path,
+    WebSocketOptions options) {
+    if (!tcp || !tcp->is_open()) return nullptr;
+
+    const std::string key = make_client_key();
+    std::ostringstream req;
+    req << "GET " << path << " HTTP/1.1\r\n"
+        << "Host: " << host << "\r\n"
+        << "Upgrade: websocket\r\n"
+        << "Connection: Upgrade\r\n"
+        << "Sec-WebSocket-Key: " << key << "\r\n"
+        << "Sec-WebSocket-Version: 13\r\n\r\n";
+    auto request = req.str();
+
+    if (!write_all(*tcp, reinterpret_cast<const std::uint8_t*>(request.data()),
+                   request.size())) {
+        return nullptr;
+    }
+
+    auto resp = read_http_headers(*tcp);
+    if (!resp) return nullptr;
+    if (resp->find("101") == std::string::npos) return nullptr;
+
+    auto accept = find_header(*resp, "Sec-WebSocket-Accept");
+    if (!accept || *accept != compute_accept_key(key)) return nullptr;
+
+    std::unique_ptr<WebSocketChannel> chan(
+        new WebSocketChannel(std::move(tcp), Role::Client, std::move(options)));
+    chan->open_.store(true);
+    chan->reader_ = std::thread([raw = chan.get()] { raw->reader_main(); });
+    return chan;
+}
+
+// ─── accept (server) ──────────────────────────────────────────────────────
+
+std::unique_ptr<WebSocketChannel> WebSocketChannel::accept(
+    std::unique_ptr<TcpStream> tcp,
+    WebSocketOptions options) {
+    if (!tcp || !tcp->is_open()) return nullptr;
+
+    auto req = read_http_headers(*tcp);
+    if (!req) return nullptr;
+
+    auto upgrade = find_header(*req, "Upgrade");
+    if (!upgrade || lowercase(*upgrade) != "websocket") return nullptr;
+
+    auto key = find_header(*req, "Sec-WebSocket-Key");
+    if (!key) return nullptr;
+
+    const std::string accept_key = compute_accept_key(*key);
+    std::ostringstream resp;
+    resp << "HTTP/1.1 101 Switching Protocols\r\n"
+         << "Upgrade: websocket\r\n"
+         << "Connection: Upgrade\r\n"
+         << "Sec-WebSocket-Accept: " << accept_key << "\r\n\r\n";
+    auto response = resp.str();
+
+    if (!write_all(*tcp, reinterpret_cast<const std::uint8_t*>(response.data()),
+                   response.size())) {
+        return nullptr;
+    }
+
+    std::unique_ptr<WebSocketChannel> chan(
+        new WebSocketChannel(std::move(tcp), Role::Server, std::move(options)));
+    chan->open_.store(true);
+    chan->reader_ = std::thread([raw = chan.get()] { raw->reader_main(); });
+    return chan;
+}
+
+// ─── instance ─────────────────────────────────────────────────────────────
+
+WebSocketChannel::WebSocketChannel(std::unique_ptr<TcpStream> tcp, Role role,
+                                   WebSocketOptions options)
+    : tcp_(std::move(tcp)), role_(role), options_(std::move(options)) {}
+
+WebSocketChannel::~WebSocketChannel() {
+    close();
+    if (reader_.joinable()) reader_.join();
+}
+
+void WebSocketChannel::on_message(MessageCallback cb) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_message_ = std::move(cb);
+}
+
+void WebSocketChannel::on_closed(ChannelClosedCallback cb) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_closed_ = std::move(cb);
+}
+
+void WebSocketChannel::on_error(ChannelErrorCallback cb) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_error_ = std::move(cb);
+}
+
+bool WebSocketChannel::is_open() const { return open_.load(); }
+
+void WebSocketChannel::close() {
+    if (!open_.exchange(false)) {
+        fire_closed();
+        return;
+    }
+    // Best-effort send a 1000 Normal Closure frame; ignore failures.
+    std::uint8_t close_payload[2] = {0x03, 0xE8};  // 1000 big-endian
+    send_frame(kOpClose, close_payload, 2);
+    if (tcp_) tcp_->close();
+    fire_closed();
+}
+
+bool WebSocketChannel::send(const std::uint8_t* data, std::size_t size) {
+    if (!open_.load()) return false;
+    return send_frame(kOpBinary, data, size);
+}
+
+bool WebSocketChannel::send_text(std::string_view text) {
+    if (!open_.load()) return false;
+    return send_frame(kOpText,
+                      reinterpret_cast<const std::uint8_t*>(text.data()),
+                      text.size());
+}
+
+bool WebSocketChannel::send_frame(uint8_t opcode, const std::uint8_t* data, std::size_t size) {
+    std::lock_guard<std::mutex> lock(write_mutex_);
+    if (!tcp_ || !tcp_->is_open()) return false;
+
+    std::vector<std::uint8_t> hdr;
+    hdr.reserve(14);
+    hdr.push_back(static_cast<std::uint8_t>(0x80 | (opcode & 0x0F)));  // FIN=1
+
+    const bool mask = (role_ == Role::Client);
+    const std::uint8_t mask_bit = mask ? 0x80 : 0x00;
+
+    if (size < 126) {
+        hdr.push_back(mask_bit | static_cast<std::uint8_t>(size));
+    } else if (size <= 0xFFFF) {
+        hdr.push_back(mask_bit | 126);
+        hdr.push_back(static_cast<std::uint8_t>((size >> 8) & 0xFF));
+        hdr.push_back(static_cast<std::uint8_t>(size & 0xFF));
+    } else {
+        hdr.push_back(mask_bit | 127);
+        for (int i = 7; i >= 0; --i) {
+            hdr.push_back(static_cast<std::uint8_t>((static_cast<uint64_t>(size) >> (i * 8)) & 0xFF));
+        }
+    }
+
+    std::array<std::uint8_t, 4> mask_key{};
+    if (mask) {
+        std::random_device rd;
+        std::mt19937 eng(rd());
+        for (auto& b : mask_key) b = static_cast<std::uint8_t>(eng() & 0xFF);
+        hdr.insert(hdr.end(), mask_key.begin(), mask_key.end());
+    }
+
+    if (!write_all(*tcp_, hdr.data(), hdr.size())) return false;
+
+    if (!mask) {
+        return size == 0 || write_all(*tcp_, data, size);
+    }
+
+    // Client side: XOR with mask_key before writing. Stream in chunks to
+    // bound stack/heap pressure for large frames.
+    std::array<std::uint8_t, 4096> buf{};
+    std::size_t off = 0;
+    while (off < size) {
+        const std::size_t chunk = std::min<std::size_t>(buf.size(), size - off);
+        for (std::size_t i = 0; i < chunk; ++i) {
+            buf[i] = data[off + i] ^ mask_key[(off + i) & 0x3];
+        }
+        if (!write_all(*tcp_, buf.data(), chunk)) return false;
+        off += chunk;
+    }
+    return true;
+}
+
+void WebSocketChannel::reader_main() {
+    std::vector<std::uint8_t> assembled;
+    MessageKind assembled_kind = MessageKind::Binary;
+
+    while (open_.load()) {
+        std::uint8_t hdr[2];
+        if (!read_exactly(*tcp_, hdr, 2)) {
+            fire_error("read header failed");
+            break;
+        }
+        const bool fin = (hdr[0] & 0x80) != 0;
+        const std::uint8_t opcode = hdr[0] & 0x0F;
+        const bool masked = (hdr[1] & 0x80) != 0;
+        std::uint64_t len = hdr[1] & 0x7F;
+
+        if (len == 126) {
+            std::uint8_t ext[2];
+            if (!read_exactly(*tcp_, ext, 2)) { fire_error("read len16"); break; }
+            len = (std::uint64_t(ext[0]) << 8) | ext[1];
+        } else if (len == 127) {
+            std::uint8_t ext[8];
+            if (!read_exactly(*tcp_, ext, 8)) { fire_error("read len64"); break; }
+            len = 0;
+            for (int i = 0; i < 8; ++i) len = (len << 8) | ext[i];
+        }
+
+        if (len > options_.max_payload) {
+            fire_error("payload exceeds max_payload");
+            break;
+        }
+
+        std::array<std::uint8_t, 4> mask_key{};
+        if (masked) {
+            if (!read_exactly(*tcp_, mask_key.data(), 4)) {
+                fire_error("read mask");
+                break;
+            }
+        }
+
+        std::vector<std::uint8_t> payload(len);
+        if (len > 0 && !read_exactly(*tcp_, payload.data(), len)) {
+            fire_error("read payload");
+            break;
+        }
+        if (masked) {
+            for (std::size_t i = 0; i < payload.size(); ++i) {
+                payload[i] ^= mask_key[i & 0x3];
+            }
+        }
+
+        switch (opcode) {
+            case kOpClose:
+                // Echo a close frame and shut down.
+                send_frame(kOpClose, payload.data(), payload.size());
+                open_.store(false);
+                break;
+            case kOpPing:
+                send_frame(kOpPong, payload.data(), payload.size());
+                break;
+            case kOpPong:
+                break;  // nothing to do
+            case kOpText:
+            case kOpBinary: {
+                if (opcode == kOpText) assembled_kind = MessageKind::Text;
+                else assembled_kind = MessageKind::Binary;
+                if (fin) {
+                    if (!assembled.empty()) {
+                        assembled.insert(assembled.end(), payload.begin(), payload.end());
+                        payload.swap(assembled);
+                        assembled.clear();
+                    }
+                    MessageCallback cb;
+                    {
+                        std::lock_guard<std::mutex> lock(mutex_);
+                        cb = on_message_;
+                    }
+                    if (cb) {
+                        Message m{assembled_kind, std::move(payload)};
+                        dispatch([cb = std::move(cb), m = std::move(m)]() mutable {
+                            cb(m);
+                        });
+                    }
+                } else {
+                    assembled.insert(assembled.end(), payload.begin(), payload.end());
+                }
+                break;
+            }
+            case kOpCont:
+                if (fin && !assembled.empty()) {
+                    assembled.insert(assembled.end(), payload.begin(), payload.end());
+                    MessageCallback cb;
+                    {
+                        std::lock_guard<std::mutex> lock(mutex_);
+                        cb = on_message_;
+                    }
+                    if (cb) {
+                        Message m{assembled_kind, std::move(assembled)};
+                        assembled.clear();
+                        dispatch([cb = std::move(cb), m = std::move(m)]() mutable {
+                            cb(m);
+                        });
+                    }
+                } else {
+                    assembled.insert(assembled.end(), payload.begin(), payload.end());
+                }
+                break;
+            default:
+                fire_error("unknown opcode");
+                open_.store(false);
+                break;
+        }
+    }
+
+    open_.store(false);
+    fire_closed();
+}
+
+void WebSocketChannel::fire_error(std::string_view reason) {
+    ChannelErrorCallback cb;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        cb = on_error_;
+    }
+    if (cb) {
+        std::string copy(reason);
+        dispatch([cb = std::move(cb), copy = std::move(copy)] { cb(copy); });
+    }
+}
+
+void WebSocketChannel::fire_closed() {
+    if (closed_fired_.exchange(true)) return;
+    ChannelClosedCallback cb;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        cb = on_closed_;
+    }
+    if (cb) dispatch(std::move(cb));
+}
+
+void WebSocketChannel::dispatch(std::function<void()> task) {
+    if (options_.executor) options_.executor(std::move(task));
+    else task();
+}
+
+}  // namespace pulp::runtime

--- a/docs/reference/streams.md
+++ b/docs/reference/streams.md
@@ -124,12 +124,75 @@ The `stream-demo` example in `examples/stream-demo/` exercises all three layers:
 ./build/examples/stream-demo/pulp-stream-demo --http https://example.com
 ```
 
-## Deferred: message channels (Phase 4)
+## Message channels (Phase 4)
 
-Phase 4 of the feature plan will add a separate `MessageChannel` abstraction for structured messages (`WebSocketChannel`, `OscChannel`, JSON-RPC over channels). Bytewise transports stay in `Stream`; message semantics layer on top.
+Bytewise transports stay in `Stream`. Structured messages — where one `send` matches one delivered message — live behind `pulp::runtime::MessageChannel`:
+
+```cpp
+class MessageChannel {
+    virtual bool send(const uint8_t* data, size_t size);
+    virtual bool send_text(std::string_view);
+    virtual void on_message(MessageCallback);
+    virtual void on_closed(ChannelClosedCallback);
+    virtual void on_error(ChannelErrorCallback);
+    virtual void close();
+    virtual bool is_open() const;
+};
+```
+
+Four implementations ship with this phase:
+
+| Channel | Header | Transport |
+|---------|--------|-----------|
+| `WebSocketChannel` | `pulp/runtime/websocket_channel.hpp` | RFC 6455 over `TcpStream`; client handshake, server handshake, text/binary frames, ping/pong/close. |
+| `OscChannel` | `pulp/osc/osc_channel.hpp` | UDP via the existing `pulp::osc::Sender` / `Receiver`. Messages are carried as encoded OSC packets. |
+| `MemoryMessageChannel` | `pulp/runtime/memory_message_channel.hpp` | In-process pair for tests and intra-process bridges. |
+| `JsonRpcPeer` | `pulp/runtime/json_rpc.hpp` | JSON-RPC 2.0 *over* any `MessageChannel` — symmetric peer that can send/serve requests and notifications. |
+
+### WebSocket
+
+```cpp
+auto tcp = std::make_unique<TcpStream>();
+tcp->connect("example.com", 80);
+auto ws = WebSocketChannel::connect(std::move(tcp), "example.com", "/chat");
+ws->on_message([](const Message& m) { /* m.kind is Text or Binary */ });
+ws->send_text("hello");
+```
+
+- TLS is not currently handled at the channel layer — for `wss://`, supply a TLS-wrapped TCP stream (future `SecureTcpStream`).
+- Control frames (ping/pong/close) are handled internally; ping triggers an automatic pong.
+- Payloads up to `options.max_payload` (default 16 MiB) are accepted; larger frames fire `on_error` and close the channel.
+
+### OSC
+
+```cpp
+auto osc = OscChannel::open("127.0.0.1", /*remote=*/8000, /*local=*/9000);
+osc->on_message([](const Message& m) {
+    auto decoded = pulp::osc::decode(m.payload.data(), m.payload.size());
+});
+osc->send(pulp::osc::Message("/synth/freq").add(440.f));
+```
+
+### JSON-RPC
+
+`JsonRpcPeer` is symmetric — either side can send requests, serve requests, emit notifications, and subscribe to notifications. It works over any `MessageChannel`:
+
+```cpp
+JsonRpcPeer peer(*ws);
+peer.register_method("add", [](std::string_view params) {
+    // params is a JSON-encoded array/object; return a JSON-encoded result
+    return JsonRpcResult::ok("42");
+});
+peer.send_request("echo", R"(["hi"])", [](const JsonRpcResult& r) {
+    if (r.error) { /* handle */ } else { /* r.result_json */ }
+});
+peer.notify("progress", R"({"percent":50})");
+```
+
+Errors follow JSON-RPC 2.0 §5: `-32601` is reported for unknown methods, `-32603` for handler exceptions, and custom codes can be returned via `JsonRpcResult::fail`.
 
 ## Further reading
 
 - Feature plan: `planning/next-features-plan.md` § Feature 3
 - Ralph automation prompt: `planning/ralph-prompt-streams.md`
-- Related headers: `pulp/runtime/socket.hpp`, `pulp/runtime/http.hpp`, `pulp/runtime/named_pipe.hpp`
+- Related headers: `pulp/runtime/socket.hpp`, `pulp/runtime/http.hpp`, `pulp/runtime/named_pipe.hpp`, `pulp/runtime/message_channel.hpp`, `pulp/osc/osc_channel.hpp`

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,19 @@ add_executable(pulp-test-network-stream test_network_stream.cpp)
 target_link_libraries(pulp-test-network-stream PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-network-stream)
 
+# MessageChannel tests (Phase 4)
+add_executable(pulp-test-websocket-channel test_websocket_channel.cpp)
+target_link_libraries(pulp-test-websocket-channel PRIVATE pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-websocket-channel)
+
+add_executable(pulp-test-osc-channel test_osc_channel.cpp)
+target_link_libraries(pulp-test-osc-channel PRIVATE pulp::osc Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-osc-channel)
+
+add_executable(pulp-test-json-rpc test_json_rpc.cpp)
+target_link_libraries(pulp-test-json-rpc PRIVATE pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-json-rpc)
+
 # Validation harness tests (Phase 2)
 add_executable(pulp-test-validation-harness test_validation_harness.cpp)
 target_link_libraries(pulp-test-validation-harness PRIVATE pulp::format Catch2::Catch2WithMain)

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -71,6 +71,24 @@ TEST_CASE("JsonRpcPeer returns method_not_found for unknown methods", "[json_rpc
     REQUIRE(err->code == -32601);
 }
 
+TEST_CASE("JsonRpcPeer emits parse error for malformed input", "[json_rpc]") {
+    auto pair = MemoryMessageChannel::make_pair();
+    // Raw receiver — no JsonRpcPeer on the right side, so we can observe
+    // the error envelope our side emits when fed garbage.
+    std::string reply;
+    pair.second->on_message([&](const Message& m) {
+        reply.assign(m.as_text());
+    });
+    JsonRpcPeer client(*pair.first);
+
+    // Feed the client peer's channel malformed JSON directly.
+    const char* garbage = "{not valid json";
+    pair.second->send_text(garbage);
+
+    REQUIRE(reply.find("-32700") != std::string::npos);
+    REQUIRE(reply.find("\"id\":null") != std::string::npos);
+}
+
 TEST_CASE("JsonRpcPeer fires notification handler and expects no response", "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -1,0 +1,95 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/runtime/json_rpc.hpp>
+#include <pulp/runtime/memory_message_channel.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
+
+using namespace pulp::runtime;
+using namespace std::chrono_literals;
+
+TEST_CASE("JsonRpcPeer request/response over an in-memory channel", "[json_rpc]") {
+    auto pair = MemoryMessageChannel::make_pair();
+    JsonRpcPeer client(*pair.first);
+    JsonRpcPeer server(*pair.second);
+
+    server.register_method("add", [](std::string_view params) {
+        // params is expected to be a JSON array like [2,3]
+        // For the Phase 4 smoke test we just echo back a sum of two ints
+        // via a trivial regex-free parse.
+        int a = 0, b = 0;
+        std::sscanf(std::string(params).c_str(), "[%d,%d]", &a, &b);
+        return JsonRpcResult::ok(std::to_string(a + b));
+    });
+
+    std::atomic<bool> done{false};
+    std::string response_payload;
+    std::optional<JsonRpcError> err;
+
+    REQUIRE(client.send_request("add", "[2,3]", [&](const JsonRpcResult& r) {
+        response_payload = r.result_json;
+        err = r.error;
+        done.store(true);
+    }));
+
+    // Memory channel dispatches synchronously, so the response should
+    // already be settled by the time send_request returns. Still do a
+    // short wait to be safe under sanitizer runs.
+    auto deadline = std::chrono::steady_clock::now() + 500ms;
+    while (!done.load() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    REQUIRE(done.load());
+    REQUIRE_FALSE(err.has_value());
+    REQUIRE(response_payload == "5");
+}
+
+TEST_CASE("JsonRpcPeer returns method_not_found for unknown methods", "[json_rpc]") {
+    auto pair = MemoryMessageChannel::make_pair();
+    JsonRpcPeer client(*pair.first);
+    JsonRpcPeer server(*pair.second);
+
+    std::atomic<bool> done{false};
+    std::optional<JsonRpcError> err;
+
+    REQUIRE(client.send_request("nope", "[]", [&](const JsonRpcResult& r) {
+        err = r.error;
+        done.store(true);
+    }));
+
+    auto deadline = std::chrono::steady_clock::now() + 500ms;
+    while (!done.load() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    REQUIRE(done.load());
+    REQUIRE(err.has_value());
+    REQUIRE(err->code == -32601);
+}
+
+TEST_CASE("JsonRpcPeer fires notification handler and expects no response", "[json_rpc]") {
+    auto pair = MemoryMessageChannel::make_pair();
+    JsonRpcPeer client(*pair.first);
+    JsonRpcPeer server(*pair.second);
+
+    std::atomic<int> notify_count{0};
+    std::string last_params;
+    server.on_notification("ping", [&](std::string_view params) {
+        last_params = std::string(params);
+        notify_count.fetch_add(1);
+    });
+
+    REQUIRE(client.notify("ping", "[\"hi\"]"));
+    REQUIRE(client.notify("ping", "[\"again\"]"));
+
+    auto deadline = std::chrono::steady_clock::now() + 500ms;
+    while (notify_count.load() < 2 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    REQUIRE(notify_count.load() == 2);
+    REQUIRE(last_params == "[\"again\"]");
+}

--- a/test/test_osc_channel.cpp
+++ b/test/test_osc_channel.cpp
@@ -1,0 +1,70 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/osc/osc_channel.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace pulp::osc;
+using namespace std::chrono_literals;
+
+namespace {
+
+template <typename Pred>
+bool wait_until(Pred pred, std::chrono::milliseconds budget = 2s) {
+    auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (pred()) return true;
+        std::this_thread::sleep_for(1ms);
+    }
+    return pred();
+}
+
+}  // namespace
+
+TEST_CASE("OscChannel round-trips an OSC message over UDP loopback", "[osc_channel]") {
+    // Two channels pointed at each other on loopback.
+    auto a = OscChannel::open("127.0.0.1", 49901, 49902);
+    auto b = OscChannel::open("127.0.0.1", 49902, 49901);
+    if (!a || !b) {
+        SUCCEED("could not open loopback UDP pair; skipping");
+        return;
+    }
+
+    std::mutex mu;
+    std::vector<pulp::runtime::Message> a_got, b_got;
+    a->on_message([&](const pulp::runtime::Message& m) {
+        std::lock_guard<std::mutex> lock(mu);
+        a_got.push_back(m);
+    });
+    b->on_message([&](const pulp::runtime::Message& m) {
+        std::lock_guard<std::mutex> lock(mu);
+        b_got.push_back(m);
+    });
+
+    Message msg("/synth/freq");
+    msg.add(440.0f).add(std::string("sine"));
+    REQUIRE(a->send(msg));
+
+    REQUIRE(wait_until([&] {
+        std::lock_guard<std::mutex> lock(mu);
+        return !b_got.empty();
+    }));
+
+    // The bytes b received round-trip back to the same OSC message.
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        auto decoded = pulp::osc::decode(b_got[0].payload.data(),
+                                         b_got[0].payload.size());
+        REQUIRE(decoded.address == "/synth/freq");
+        REQUIRE(decoded.get_float(0) == 440.0f);
+        REQUIRE(decoded.get_string(1) == "sine");
+    }
+
+    a->close();
+    b->close();
+}

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -1,0 +1,152 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/runtime/network_stream.hpp>
+#include <pulp/runtime/socket.hpp>
+#include <pulp/runtime/websocket_channel.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+
+using namespace pulp::runtime;
+using namespace std::chrono_literals;
+
+namespace {
+
+std::optional<std::uint16_t> bind_loopback(Socket& server, std::uint16_t start) {
+    for (std::uint16_t port = start; port < start + 400; ++port) {
+        if (!server.bind("127.0.0.1", port)) continue;
+        if (!server.listen(1)) continue;
+        return port;
+    }
+    return std::nullopt;
+}
+
+template <typename Pred>
+bool wait_until(Pred pred, std::chrono::milliseconds budget = 3s) {
+    auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (pred()) return true;
+        std::this_thread::sleep_for(1ms);
+    }
+    return pred();
+}
+
+}  // namespace
+
+TEST_CASE("WebSocket accept_key follows RFC 6455 §4.2.2", "[websocket]") {
+    // Canonical example from the RFC:
+    //   client key = "dGhlIHNhbXBsZSBub25jZQ=="
+    //   accept     = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+    REQUIRE(WebSocketChannel::compute_accept_key("dGhlIHNhbXBsZSBub25jZQ==")
+            == "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+}
+
+TEST_CASE("WebSocketChannel echo round-trip on loopback", "[websocket]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = bind_loopback(listener, 46401);
+    if (!port) {
+        SUCCEED("could not bind loopback; skipping");
+        return;
+    }
+
+    std::atomic<bool> server_ready{false};
+    std::atomic<bool> server_done{false};
+    std::unique_ptr<WebSocketChannel> server_ws;
+    std::mutex server_mu;
+    std::vector<std::string> server_seen;
+
+    std::thread server_thread([&] {
+        server_ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+        auto server_tcp = std::make_unique<TcpStream>(std::move(*accepted));
+        server_ws = WebSocketChannel::accept(std::move(server_tcp));
+        if (!server_ws) return;
+        server_ws->on_message([&](const Message& m) {
+            {
+                std::lock_guard<std::mutex> lock(server_mu);
+                server_seen.emplace_back(m.as_text());
+            }
+            // echo back
+            server_ws->send_text(std::string("echo:") + std::string(m.as_text()));
+        });
+        server_done.store(true);
+    });
+
+    while (!server_ready.load()) std::this_thread::sleep_for(1ms);
+
+    auto client_tcp = std::make_unique<TcpStream>();
+    REQUIRE(client_tcp->connect("127.0.0.1", *port));
+    auto client = WebSocketChannel::connect(std::move(client_tcp), "127.0.0.1", "/");
+    REQUIRE(client != nullptr);
+    REQUIRE(client->is_open());
+
+    std::mutex client_mu;
+    std::vector<std::string> client_seen;
+    client->on_message([&](const Message& m) {
+        std::lock_guard<std::mutex> lock(client_mu);
+        client_seen.emplace_back(m.as_text());
+    });
+
+    REQUIRE(client->send_text("hello"));
+    REQUIRE(client->send_text("pulp"));
+
+    REQUIRE(wait_until([&] {
+        std::lock_guard<std::mutex> lock(client_mu);
+        return client_seen.size() >= 2;
+    }));
+
+    {
+        std::lock_guard<std::mutex> lock(client_mu);
+        REQUIRE(client_seen[0] == "echo:hello");
+        REQUIRE(client_seen[1] == "echo:pulp");
+    }
+    {
+        std::lock_guard<std::mutex> lock(server_mu);
+        REQUIRE(server_seen.size() == 2);
+        REQUIRE(server_seen[0] == "hello");
+    }
+
+    client->close();
+    if (server_ws) server_ws->close();
+    server_thread.join();
+}
+
+TEST_CASE("WebSocketChannel rejects handshake without upgrade header", "[websocket]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = bind_loopback(listener, 46801);
+    if (!port) {
+        SUCCEED("could not bind loopback; skipping");
+        return;
+    }
+
+    std::atomic<bool> ready{false};
+    std::thread server_thread([&] {
+        ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+        auto tcp = std::make_unique<TcpStream>(std::move(*accepted));
+        // Server should refuse the non-upgrade request.
+        auto ws = WebSocketChannel::accept(std::move(tcp));
+        REQUIRE(ws == nullptr);
+    });
+    while (!ready.load()) std::this_thread::sleep_for(1ms);
+
+    Socket client;
+    REQUIRE(client.create(SocketType::TCP));
+    REQUIRE(client.connect("127.0.0.1", *port));
+    const char plain_http[] = "GET / HTTP/1.1\r\nHost: x\r\n\r\n";
+    client.send(reinterpret_cast<const std::uint8_t*>(plain_http),
+                std::strlen(plain_http));
+    client.close();
+    server_thread.join();
+}


### PR DESCRIPTION
## Summary

Completes Feature 3 of `planning/next-features-plan.md`. Implements every Phase 4 item:

- **`MessageChannel`** (`core/runtime/message_channel.hpp`) — transport-agnostic contract: one `send` per message, callbacks per delivered message. Same executor-based callback dispatch model as `AsyncStream`, so wiring to an `EventLoop` doesn't pull `pulp-runtime` → `pulp-events` into the link graph.
- **`WebSocketChannel`** (`core/runtime/websocket_channel.hpp`) — RFC 6455 over `TcpStream`. Client + server handshake (with `Sec-WebSocket-Accept` validation against the RFC's SHA-1 + base64 of the magic GUID), masked client frames, 7/16/64-bit payload length, automatic pong on ping, close-frame echo. SHA-1 was added to `pulp::runtime::crypto` via mbedTLS since handshakes require it.
- **`OscChannel`** (`core/osc/osc_channel.hpp`) — adapts the existing `osc::Sender` / `osc::Receiver`. Exposes UDP OSC under the unified `MessageChannel` contract; carries raw encoded OSC packets as the message payload so callers can decode with `osc::decode`.
- **`MemoryMessageChannel`** (`core/runtime/memory_message_channel.hpp`) — in-process peer pair. Primarily for tests, but also gives the inspector and other same-process bridges a message bus without a socket hop.
- **`JsonRpcPeer`** (`core/runtime/json_rpc.hpp`) — symmetric JSON-RPC 2.0 peer over any `MessageChannel`. Methods register by name, request IDs are correlated internally, spec-conformant error codes (`-32601` method not found, `-32603` internal error, etc.). Supports both requests (with a completion callback) and notifications.

### Docs / skill updates

- `docs/reference/streams.md` — promoted the "Deferred: Phase 4" section to a full MessageChannel section with a table of backends and runnable examples for each.
- `.agents/skills/streams/SKILL.md` — added decision-tree rows for the four new message paths and gotcha notes (handshake-returns-nullptr, UDP unreliability, symmetric peer, params-are-JSON-strings).
- `planning/next-features-plan.md` — Feature 3 Phase 4 boxes all checked (planning submodule commit `0cc6917`).

### CLI / Claude plugin

No changes. These transports are library-level; no CLI command or slash-command warranted.

## Test plan

- [x] `pulp-test-websocket-channel` — 3 cases / 16 assertions: RFC 6455 §4.2.2 accept-key vector, loopback echo (client ↔ server both using `WebSocketChannel`), handshake failure for plain HTTP.
- [x] `pulp-test-osc-channel` — 1 case / 5 assertions: UDP round-trip with `osc::decode` on the far side recovering `/synth/freq 440.0 "sine"`.
- [x] `pulp-test-json-rpc` — 3 cases / 12 assertions: request/response over an in-memory channel, method-not-found, notification (no response expected).
- [x] Full `ctest --exclude-regex AudioWorkgroup|Clipboard`: **2124/2124 pass** locally.
- [ ] CI (Namespace + GitHub-hosted): macOS + Ubuntu + Windows on this PR.