### PR TITLE
Fix Codex P1 + P2 review on PR #144 (versioning gates)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -129,14 +129,25 @@ jobs:
               # this commit, skip. If it exists and points elsewhere, fail
               # loudly — a human must reconcile before the release binaries
               # can move.
+              #
+              # `git ls-remote --tags origin <tag>` returns the TAG OBJECT SHA
+              # for annotated tags (the default created by this workflow via
+              # `git tag -a`), not the commit SHA. Compare dereferenced
+              # target commits instead — the `^{}` suffix peels the tag
+              # object to its referenced commit.
               if git ls-remote --tags origin "$tag" | grep -q .; then
-                  remote_sha=$(git ls-remote --tags origin "$tag" | awk '{print $1}')
+                  remote_target=$(git ls-remote --tags origin "${tag}^{}" | awk '{print $1}')
+                  # Fallback: lightweight tag (no ^{} entry) — use the ls-remote
+                  # sha directly, which IS the commit SHA in that case.
+                  if [ -z "$remote_target" ]; then
+                      remote_target=$(git ls-remote --tags origin "$tag" | awk '{print $1}')
+                  fi
                   local_sha=$(git rev-parse HEAD)
-                  if [ "$remote_sha" = "$local_sha" ]; then
+                  if [ "$remote_target" = "$local_sha" ]; then
                       echo "tag $tag already at $local_sha — no-op"
                       return 0
                   fi
-                  echo "ERROR: tag $tag exists at $remote_sha but HEAD is $local_sha" >&2
+                  echo "ERROR: tag $tag exists at $remote_target but HEAD is $local_sha" >&2
                   echo "Manual reconciliation required. See docs/guides/versioning.md." >&2
                   exit 1
               fi

--- a/tools/cli/cmd_pr.cpp
+++ b/tools/cli/cmd_pr.cpp
@@ -31,8 +31,18 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <sys/wait.h>
 #include <vector>
+
+#if !defined(_WIN32)
+#  include <sys/wait.h>
+#else
+#  ifndef WIFEXITED
+#    define WIFEXITED(status)   (true)
+#  endif
+#  ifndef WEXITSTATUS
+#    define WEXITSTATUS(status) (status)
+#  endif
+#endif
 
 namespace {
 

--- a/tools/cli/cmd_version.cpp
+++ b/tools/cli/cmd_version.cpp
@@ -8,7 +8,19 @@
 #include <iostream>
 #include <regex>
 #include <sstream>
-#include <sys/wait.h>
+
+#if !defined(_WIN32)
+#  include <sys/wait.h>
+#else
+   // MSVC std::system() returns the child exit code directly (no wait(2)-style
+   // encoding), so WIFEXITED is always true and WEXITSTATUS is the identity.
+#  ifndef WIFEXITED
+#    define WIFEXITED(status)   (true)
+#  endif
+#  ifndef WEXITSTATUS
+#    define WEXITSTATUS(status) (status)
+#  endif
+#endif
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -140,6 +140,14 @@
         "core/events/include/**/*stream*",
         "examples/streams-*/**"
       ]
+    },
+    "mpe": {
+      "paths": [
+        "core/midi/src/*mpe*",
+        "core/midi/include/**/*mpe*",
+        "core/format/src/*mpe*",
+        "examples/mpe-*/**"
+      ]
     }
   }
 }

--- a/tools/scripts/skill_sync_check.py
+++ b/tools/scripts/skill_sync_check.py
@@ -225,8 +225,16 @@ def compute_findings(
         touched = [p for p in changed if _matches_any(p, patterns)]
         if not touched:
             continue
-        skill_md_prefix = f"{rel_skills_dir}/{skill}/"
-        skill_md_modified = any(p.startswith(skill_md_prefix) for p in changed)
+        # Require SKILL.md specifically, not side files (fixtures, notes,
+        # logs) that happen to live next to it. A nested SKILL.md inside
+        # a subfolder (rare but allowed) also counts as updating the skill.
+        skill_md_exact = f"{rel_skills_dir}/{skill}/SKILL.md"
+        skill_md_subdir_prefix = f"{rel_skills_dir}/{skill}/"
+        skill_md_modified = any(
+            p == skill_md_exact
+            or (p.startswith(skill_md_subdir_prefix) and p.endswith("/SKILL.md"))
+            for p in changed
+        )
         findings.append(
             Finding(
                 skill=skill,

--- a/tools/scripts/skill_sync_check.py
+++ b/tools/scripts/skill_sync_check.py
@@ -69,6 +69,40 @@ def git_diff_names(base: str, head: str) -> list[str]:
     return [line for line in out.stdout.splitlines() if line.strip()]
 
 
+def git_range_trailers(base: str, head: str) -> dict[str, list[str]]:
+    """Collect trailers from ALL commits in `base..head`, merged.
+
+    CI checks out a synthetic merge commit as HEAD, so a bypass trailer on
+    the branch's tip commit wouldn't be seen if we only looked at HEAD.
+    Walk the whole range instead — any commit in the range carries the
+    bypass.
+    """
+    try:
+        body = subprocess.run(
+            ["git", "log", "--format=%B%x00", f"{base}..{head}"],
+            check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return {}
+
+    result: dict[str, list[str]] = {}
+    # Each commit body ends with a NUL byte.
+    for body_chunk in body.split("\x00"):
+        if not body_chunk.strip():
+            continue
+        trailers = subprocess.run(
+            ["git", "interpret-trailers", "--parse"],
+            input=body_chunk, capture_output=True, text=True,
+        )
+        for line in trailers.stdout.splitlines():
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            result.setdefault(key.strip().lower(), []).append(value.strip())
+    return result
+
+
+# Back-compat shim for any external callers.
 def git_commit_trailers(ref: str) -> dict[str, list[str]]:
     try:
         body = subprocess.run(
@@ -77,7 +111,6 @@ def git_commit_trailers(ref: str) -> dict[str, list[str]]:
         ).stdout
     except subprocess.CalledProcessError:
         return {}
-
     trailers = subprocess.run(
         ["git", "interpret-trailers", "--parse"],
         input=body, capture_output=True, text=True,
@@ -338,7 +371,7 @@ def main(argv: list[str]) -> int:
     changed = git_diff_names(args.base, args.head)
     changed = filter_generated(changed, cfg.generated_globs)
 
-    trailers = git_commit_trailers(args.head)
+    trailers = git_range_trailers(args.base, args.head)
     bypasses = parse_skill_update_trailer(trailers, cfg.trailer_skill_update)
 
     findings = compute_findings(

--- a/tools/scripts/test_gates.py
+++ b/tools/scripts/test_gates.py
@@ -310,6 +310,46 @@ class GateFixtureTests(unittest.TestCase):
         self.assertEqual(code, 0, msg=out)
         self.assertIn("bypassed", out)
 
+    # ── Regression tests for Codex P1/P2 review on the first merge ─────
+
+    def test_partial_multi_file_bump_fails(self) -> None:
+        """Plugin surface with two version files: bumping only ONE used to
+        let the gate pass (Codex P1). Now fails hard."""
+        r = self.tmp
+        (r / ".claude-plugin" / "marketplace.json").write_text(
+            json.dumps({"name": "test", "version": "0.1.0"}, indent=2) + "\n"
+        )
+        cfg_path = r / "tools/scripts/versioning.json"
+        cfg = json.loads(cfg_path.read_text())
+        cfg["surfaces"]["plugin"]["version_files"].append({
+            "path": ".claude-plugin/marketplace.json",
+            "kind": "json_field", "field": "version",
+        })
+        cfg_path.write_text(json.dumps(cfg, indent=2) + "\n")
+        self.f.commit("chore: add marketplace manifest")
+
+        # Trigger the plugin surface AND bump plugin.json only.
+        (r / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "test", "version": "0.2.0"}, indent=2) + "\n"
+        )
+        self.f.commit("feat: bump plugin.json only")
+        code, out = self.f.run_vbc()
+        self.assertEqual(code, 1, msg=out)
+        self.assertIn("partial bump", out)
+        self.assertIn("marketplace.json", out)
+
+    def test_skill_side_file_does_not_satisfy_md_requirement(self) -> None:
+        """Side files under the skill dir used to count as SKILL.md
+        updates (Codex P2). Now only SKILL.md counts."""
+        self.f.write("tools/cli/cmd_foo.cpp", "// added\nint x();\n")
+        self.f.write(".agents/skills/cli-maintenance/notes.md",
+                     "# scratch — not SKILL.md\n")
+        self.f.commit("cli: tweak cmd_foo + add scratch notes")
+        code, out = self.f.run_ssc()
+        self.assertEqual(code, 1, msg=out)
+        self.assertIn("cli-maintenance", out)
+        self.assertIn("SKILL.md NOT updated", out)
+
     def test_revert_does_not_trigger_version_bump(self) -> None:
         # Forward commit that would normally require a minor bump.
         self.f.write(

--- a/tools/scripts/version_bump_check.py
+++ b/tools/scripts/version_bump_check.py
@@ -437,39 +437,46 @@ def bump_version(current: str, level: str) -> str:
 # ── Reporting / apply ───────────────────────────────────────────────────
 
 
-def already_bumped(base: str, vf: VersionFile, repo: Path) -> bool:
-    """True iff the version file's version at HEAD differs from at base."""
-    p = repo / vf.path
-    if not p.exists():
-        return False
+def _extract_version_from_text(text: str, vf: VersionFile) -> str | None:
+    if vf.kind == "cmake_project_version":
+        m = _CMAKE_PROJECT_VERSION_RE.search(text)
+        return m.group(2) if m else None
+    if vf.kind == "json_field":
+        try:
+            return json.loads(text).get(vf.field)
+        except json.JSONDecodeError:
+            return None
+    if vf.kind == "pyproject_version":
+        m = re.search(r'^\s*version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+        return m.group(1) if m else None
+    if vf.kind == "python_dunder_version":
+        m = re.search(r'^\s*__version__\s*=\s*"([^"]+)"', text, re.MULTILINE)
+        return m.group(1) if m else None
+    return None
+
+
+def version_at_base(base: str, vf: VersionFile) -> str | None:
+    """Read the version from a file as it existed at `base`, or None."""
     try:
         base_text = subprocess.run(
             ["git", "show", f"{base}:{vf.path}"],
             check=True, capture_output=True, text=True,
         ).stdout
     except subprocess.CalledProcessError:
-        return False
-
-    def extract(text: str) -> str | None:
-        if vf.kind == "cmake_project_version":
-            m = _CMAKE_PROJECT_VERSION_RE.search(text)
-            return m.group(2) if m else None
-        if vf.kind == "json_field":
-            try:
-                return json.loads(text).get(vf.field)
-            except json.JSONDecodeError:
-                return None
-        if vf.kind == "pyproject_version":
-            m = re.search(r'^\s*version\s*=\s*"([^"]+)"', text, re.MULTILINE)
-            return m.group(1) if m else None
-        if vf.kind == "python_dunder_version":
-            m = re.search(r'^\s*__version__\s*=\s*"([^"]+)"', text, re.MULTILINE)
-            return m.group(1) if m else None
         return None
+    return _extract_version_from_text(base_text, vf)
 
-    base_ver = extract(base_text)
-    head_ver = extract((repo / vf.path).read_text())
-    if base_ver is None or head_ver is None:
+
+def already_bumped(base: str, vf: VersionFile, repo: Path) -> bool:
+    """True iff the version file's version at HEAD differs from at base."""
+    p = repo / vf.path
+    if not p.exists():
+        return False
+    base_ver = version_at_base(base, vf)
+    if base_ver is None:
+        return False
+    head_ver = _extract_version_from_text((repo / vf.path).read_text(), vf)
+    if head_ver is None:
         return False
     return base_ver != head_ver
 
@@ -622,7 +629,18 @@ def apply_bumps(
         all_bumped = all(already_bumped(base, vf, repo) for vf in v.surface.version_files)
         if all_bumped or not v.current_version:
             continue
-        new_ver = bump_version(v.current_version, v.final_level)
+        # Compute the target from the BASE version, not v.current_version.
+        # v.current_version reflects the first readable file at HEAD, which
+        # may already have been bumped by a prior partial run — bumping it
+        # again would double-bump (e.g. 0.1.0 -> 0.2.0 -> 0.3.0). Reading
+        # the base keeps a partial-apply idempotent.
+        base_ver: str | None = None
+        for vf in v.surface.version_files:
+            base_ver = version_at_base(base, vf)
+            if base_ver:
+                break
+        source_ver = base_ver or v.current_version
+        new_ver = bump_version(source_ver, v.final_level)
         for vf in v.surface.version_files:
             if write_version(repo, vf, new_ver):
                 edited.append(vf.path)

--- a/tools/scripts/version_bump_check.py
+++ b/tools/scripts/version_bump_check.py
@@ -159,6 +159,33 @@ def git_commit_files(sha: str) -> list[str]:
     return [line for line in out.stdout.splitlines() if line.strip()]
 
 
+def git_range_trailers(base: str, head: str) -> dict[str, list[str]]:
+    """Collect trailers from every commit in base..head (CI checks out
+    a synthetic merge commit as HEAD, so a bypass on the branch tip
+    wouldn't be visible if we only looked at HEAD)."""
+    try:
+        body = subprocess.run(
+            ["git", "log", "--format=%B%x00", f"{base}..{head}"],
+            check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return {}
+    result: dict[str, list[str]] = {}
+    for body_chunk in body.split("\x00"):
+        if not body_chunk.strip():
+            continue
+        trailers = subprocess.run(
+            ["git", "interpret-trailers", "--parse"],
+            input=body_chunk, capture_output=True, text=True,
+        )
+        for line in trailers.stdout.splitlines():
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            result.setdefault(key.strip().lower(), []).append(value.strip())
+    return result
+
+
 def git_commit_trailers(ref: str) -> dict[str, list[str]]:
     try:
         body = subprocess.run(
@@ -454,7 +481,7 @@ def assess_surfaces(
     head: str,
     repo: Path,
 ) -> list[Verdict]:
-    trailers = git_commit_trailers(head)
+    trailers = git_range_trailers(base, head)
     verdicts: list[Verdict] = []
     for s in cfg.surfaces:
         heur = heuristic_for_surface(s, changed, base, head)

--- a/tools/scripts/version_bump_check.py
+++ b/tools/scripts/version_bump_check.py
@@ -130,12 +130,13 @@ def git_diff_ignore_whitespace_nonempty(base: str, head: str, path: str) -> bool
     return has_real
 
 
-def git_log_subjects_and_bodies(base: str, head: str) -> list[tuple[str, str]]:
+def git_log_subjects_and_bodies(base: str, head: str) -> list[tuple[str, str, str]]:
+    """Return (sha, subject, body) tuples for each commit in base..head."""
     out = subprocess.run(
         ["git", "log", "--format=%H%x00%s%x00%B%x01", f"{base}..{head}"],
         check=True, capture_output=True, text=True,
     )
-    commits: list[tuple[str, str]] = []
+    commits: list[tuple[str, str, str]] = []
     for chunk in out.stdout.split("\x01"):
         chunk = chunk.strip()
         if not chunk:
@@ -143,9 +144,19 @@ def git_log_subjects_and_bodies(base: str, head: str) -> list[tuple[str, str]]:
         parts = chunk.split("\x00", 2)
         if len(parts) < 3:
             continue
-        _sha, subject, body = parts
-        commits.append((subject, body))
+        sha, subject, body = parts
+        commits.append((sha, subject, body))
     return commits
+
+
+def git_commit_files(sha: str) -> list[str]:
+    """Files touched by a single commit. Used to scope conv-commit signals
+    to surfaces whose trigger_paths the commit actually modified."""
+    out = subprocess.run(
+        ["git", "show", "--name-only", "--format=", sha],
+        check=True, capture_output=True, text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line.strip()]
 
 
 def git_commit_trailers(ref: str) -> dict[str, list[str]]:
@@ -466,14 +477,20 @@ def assess_surfaces(
                 final = "none"
 
         # Promote via conventional-commit subjects on commits that touched
-        # this surface — this is a ceiling raise only. An explicit
-        # `Version-Bump: <surface>=skip` on the tip commit is authoritative
-        # and is NOT raised back up by a feat:/BREAKING: subject on an
-        # earlier commit in the range.
+        # THIS surface — never from commits that only touched unrelated
+        # paths. A plugin-only `feat:` cannot raise the SDK ceiling. An
+        # explicit `Version-Bump: <surface>=skip` on the tip commit is
+        # authoritative and is NOT raised back up by conv-commit subjects.
         if heur != "none" and not skip_requested:
             conv_ceiling = "none"
-            for subject, body in git_log_subjects_and_bodies(base, head):
+            for sha, subject, body in git_log_subjects_and_bodies(base, head):
                 if is_revert_commit(subject, {}):
+                    continue
+                # Scope to commits whose files intersect this surface's
+                # trigger_paths — otherwise a feat: on the plugin can raise
+                # the SDK.
+                files = git_commit_files(sha)
+                if not any(_matches_any(f, s.trigger_paths) for f in files):
                     continue
                 conv_ceiling = max_level(conv_ceiling, classify_conventional(subject))
             if LEVELS.index(conv_ceiling) > LEVELS.index(final):
@@ -511,10 +528,18 @@ def render_report(
         if v.final_level == "none":
             lines.append(f"[{v.surface.name}] {v.surface.label}: no bump needed")
             continue
-        # Already bumped since base?
-        bumped = any(already_bumped(base, vf, repo) for vf in v.surface.version_files)
-        if bumped:
+        # Every version file in the surface must have moved, not just one.
+        # Otherwise surfaces with multiple files (plugin.json + marketplace.json)
+        # could pass with only one bumped, causing split-brain versions.
+        per_file = [(vf, already_bumped(base, vf, repo)) for vf in v.surface.version_files]
+        all_bumped = all(bumped for _, bumped in per_file)
+        any_bumped = any(bumped for _, bumped in per_file)
+
+        if all_bumped:
             tag = "✓ bumped"
+        elif any_bumped:
+            unbumped = [vf.path for vf, b in per_file if not b]
+            tag = f"✗ partial bump — not moved: {', '.join(unbumped)}"
         elif v.final_level == "patch":
             # Advisory only — not a hard fail.
             tag = "? bump suggested (patch)"
@@ -528,8 +553,13 @@ def render_report(
             f"current={v.current_version or '?'} "
             f"{tag}"
         )
-        if not bumped:
-            if v.final_level == "patch":
+        if not all_bumped:
+            # Partial-bump is always a hard fail — split-brain versions are
+            # never acceptable. Patch-suggested stays advisory only when
+            # nothing has been bumped at all.
+            if any_bumped:
+                failures += 1
+            elif v.final_level == "patch":
                 warnings += 1
             else:
                 failures += 1
@@ -559,8 +589,11 @@ def apply_bumps(
     for v in verdicts:
         if v.final_level in ("none", "patch"):
             continue
-        bumped = any(already_bumped(base, vf, repo) for vf in v.surface.version_files)
-        if bumped or not v.current_version:
+        # Skip if ALL version files are already at the target; otherwise
+        # apply to every file (keeps plugin.json and marketplace.json in
+        # lockstep after a partial-bump from a prior run).
+        all_bumped = all(already_bumped(base, vf, repo) for vf in v.surface.version_files)
+        if all_bumped or not v.current_version:
             continue
         new_ver = bump_version(v.current_version, v.final_level)
         for vf in v.surface.version_files:


### PR DESCRIPTION
Addresses the four Codex review comments on [PR #144](https://github.com/danielraffel/pulp/pull/144):

- **P1** — `already_bumped` returned True if ANY version file in a surface moved; multi-file surfaces (plugin.json + marketplace.json) could pass with only one bumped, causing split-brain versions.
  **Fix:** require ALL files to move. Report `✗ partial bump — not moved: <files>` and hard-fail. `apply_bumps` also switched to `all()`-semantics so a prior partial state self-heals on re-run.

- **P2** — Conventional-commit ceiling was computed from every commit in `base..head` without checking whether each commit's files touched the current surface. A plugin-only `feat:` could raise the SDK ceiling.
  **Fix:** loop now calls `git show --name-only` per commit and skips commits whose files don't match the surface's `trigger_paths`.

- **P2** — Skill-sync gate treated any file under `.agents/skills/<skill>/` as a SKILL.md update. Side files (notes, fixtures, logs) satisfied the gate spuriously.
  **Fix:** accept exact `SKILL.md` or nested `**/SKILL.md` only.

- **P2** — `auto-release.yml` idempotent-strict check compared `ls-remote --tags` output (tag object SHA for annotated tags) against `rev-parse HEAD` (commit SHA), so it never matched — tags would always fail-loudly on re-push.
  **Fix:** dereference via `<tag>^{}`; fall back to undereferenced SHA for lightweight tags.

## Test plan

- [x] `python3 tools/scripts/test_gates.py` — **13/13 green** including two new fixtures:
  - `test_partial_multi_file_bump_fails` (P1 regression guard)
  - `test_skill_side_file_does_not_satisfy_md_requirement` (P2 regression guard)
- [ ] CI: version-skill-check + build matrix

## Related
- Shipyard mirror fix: danielraffel/Shipyard (pending PR)