### PR TITLE
Fix Android: whole-archive pulp-view for accessibility JNI symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,11 +533,15 @@ if(ANDROID)
     # Ensure JNI exports from static libs are included in the shared lib.
     # Without --whole-archive, the linker strips "unused" JNI_OnLoad and
     # Java_* functions since nothing in the .so itself references them.
+    # pulp-view contains accessibility_android.cpp (TalkBack JNI entry
+    # points Java_com_pulp_accessibility_*); its only references are from
+    # the Kotlin side, so it must be whole-archived too.
     target_link_options(pulp-jni PRIVATE
         -Wl,--whole-archive
         $<TARGET_FILE:pulp-platform>
         $<TARGET_FILE:pulp-audio>
         $<$<TARGET_EXISTS:pulp-render>:$<TARGET_FILE:pulp-render>>
+        $<TARGET_FILE:pulp-view>
         -Wl,--no-whole-archive)
 endif()
 


### PR DESCRIPTION
## Summary

Resolves the P1 Codex finding from PR #132 that was merged unresolved: `pulp-view` needs to be wrapped in `--whole-archive` so the `Java_com_pulp_accessibility_*` JNI entry points survive the Android linker's dead-code elimination.

## Why this is still an issue on main

`core/view/platform/android/accessibility_android.cpp` defines every TalkBack JNI entry point (`nativeGetAccessibilityNodeCount`, `nativeGetNodeRole`, `nativePerformAction`, etc.). The only callers are in `android/app/src/main/kotlin/com/pulp/accessibility/PulpAccessibility.kt` — nothing inside `libpulp.so` references them. `CMakeLists.txt` L536-541 currently wraps only `pulp-platform`, `pulp-audio`, and `pulp-render` in `--whole-archive`; `pulp-view` is absent. The linker is therefore free to strip the JNI symbols, producing `UnsatisfiedLinkError` the first time TalkBack queries the node tree.

Compile-time CI passes because the symbols are emitted into `libpulp-view.a`; the failure only surfaces at runtime on a device with accessibility services enabled.

## Fix

Add `$<TARGET_FILE:pulp-view>` to the existing `--whole-archive` block in `CMakeLists.txt`. Mirrors the pattern already used for `pulp-platform`/`pulp-audio`/`pulp-render`.

## Test plan

- [x] CI build on macos-latest + windows-latest Android builds
- [ ] Manual TalkBack smoke: enable TalkBack on an Android device, install the app, swipe through — no UnsatisfiedLinkError in logcat