### PR TITLE
Fix Android: force-keep TalkBack JNI symbols without whole-archiving pulp-view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,28 @@ if(ANDROID)
         $<TARGET_FILE:pulp-audio>
         $<$<TARGET_EXISTS:pulp-render>:$<TARGET_FILE:pulp-render>>
         -Wl,--no-whole-archive)
+
+    # TalkBack accessibility JNI entry points live in pulp-view
+    # (core/view/platform/android/accessibility_android.cpp). pulp-view is
+    # not whole-archived — whole-archiving it pulls in SDL3's JNI_OnLoad
+    # and duplicates ours (see closed PR #148). Instead, force-reference
+    # each Java_com_pulp_accessibility_* symbol so the linker keeps the
+    # containing object file. This preserves just the JNI exports without
+    # dragging SDL3 into the JNI closure. Without this the app hits
+    # UnsatisfiedLinkError the first time TalkBack walks the node tree.
+    foreach(_a11y_sym IN ITEMS
+        Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetAccessibilityNodeCount
+        Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeColumnCount
+        Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeLabel
+        Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeRangeMax
+        Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeRangeMin
+        Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeRole
+        Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeRowCount
+        Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativeGetNodeValue
+        Java_com_pulp_accessibility_PulpAccessibilityDelegate_nativePerformAction
+    )
+        target_link_options(pulp-jni PRIVATE "-Wl,--undefined=${_a11y_sym}")
+    endforeach()
 endif()
 
 # ── SDK Install Rules ──────────────────────────────────────────────────────

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -584,7 +584,16 @@ function(_pulp_add_au target name bundle_id version manufacturer category plugin
     _pulp_apply_ui_script_definition(${target}_AU "${PULP_${target}_UI_SCRIPT}")
     target_include_directories(${target}_AU PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+    # AudioUnitSDK 1.4 headers (`AUUtility.h`) use `std::expected` /
+    # `std::unexpected` (C++23). The host pulp-format static lib already
+    # marks `cxx_std_23` PUBLIC so downstream C++ TUs inherit it, but
+    # per-plugin `.mm` sources added directly to ${target}_AU compile with
+    # that target's own CXX_STANDARD. Apple clang's Objective-C++ mode
+    # only exposes <expected> at -std=c++23, so pin it explicitly here
+    # (same rationale as core/format/CMakeLists.txt L76).
     set_target_properties(${target}_AU PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
         BUNDLE TRUE
         BUNDLE_EXTENSION "component"
         OUTPUT_NAME "${name}"

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -594,6 +594,8 @@ function(_pulp_add_au target name bundle_id version manufacturer category plugin
     set_target_properties(${target}_AU PROPERTIES
         CXX_STANDARD 23
         CXX_STANDARD_REQUIRED ON
+        OBJCXX_STANDARD 23
+        OBJCXX_STANDARD_REQUIRED ON
         BUNDLE TRUE
         BUNDLE_EXTENSION "component"
         OUTPUT_NAME "${name}"


### PR DESCRIPTION
## Summary

Narrower retry of #148 (which was closed because whole-archiving `pulp-view` pulled in SDL3's `JNI_OnLoad`). Uses `-Wl,--undefined=<symbol>` for each of the nine `Java_com_pulp_accessibility_*` entry points to force-retain them without transitively dragging SDL3 into the JNI closure.

Addresses the P1 from PR #132 that was merged unresolved.

## Why the previous approach failed

`pulp-view` transitively links `libSDL3.a`, which defines its own `JNI_OnLoad` at `_deps/sdl3-src/src/core/android/SDL_android.c:549`. Adding `$<TARGET_FILE:pulp-view>` to the `--whole-archive` block in #148 forced the linker to include every object in every archive it touched, producing:

```
ld.lld: error: duplicate symbol: JNI_OnLoad
>>> defined at jni_bridge.cpp:41
>>> defined at SDL_android.c:549
```

## The narrower fix

`target_link_options(pulp-jni PRIVATE -Wl,--undefined=<sym>)` for each accessibility JNI export. `--undefined` tells the linker to treat the symbol as a required external, which (a) keeps the `accessibility_android.cpp` object file alive inside `libpulp-view.a` and (b) does *not* force any other objects in any other archive. SDL3's `JNI_OnLoad` stays weakly referenced through its normal path.

## Test plan

- [x] Namespace CI: macOS + Linux + Windows (these don't touch the JNI path, regression check only)
- [ ] Android CI: arm64-v8a + x86_64 should link cleanly (was the FAILURE mode in #148)
- [ ] Follow-up: manual TalkBack smoke on a device — swipe through app, no `UnsatisfiedLinkError` in logcat