### PR TITLE
version: fix marketplace.json plugins[0].version drift + guard against re-drift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "Dan Raffel"
       },

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -1589,13 +1589,26 @@ std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, bool sta
         auto repo_slug = first_line(exec_output(
             "gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null"));
         if (!repo_slug.empty() && repo_slug.find('/') != std::string::npos) {
-            auto secrets_list = exec_output(
-                "gh api 'repos/" + repo_slug + "/actions/secrets' "
-                "--jq '.secrets[].name' 2>/dev/null");
-            // Only emit a check if we got a usable response.
-            if (!secrets_list.empty()) {
+            // Probe WITHOUT --jq so we can distinguish:
+            //   - empty-response-from-gh (means gh errored: no auth, no
+            //     actions:read, network fail) → skip the check silently.
+            //   - non-empty JSON with zero secrets → repo genuinely has no
+            //     secrets yet, which is exactly the bootstrap scenario this
+            //     check needs to flag. The previous version used --jq
+            //     '.secrets[].name' and gated on the output being non-empty,
+            //     which made the bootstrap case (zero secrets) look the
+            //     same as the "gh failed" case and skipped silently. Codex
+            //     P1 on #149.
+            auto raw = exec_output(
+                "gh api 'repos/" + repo_slug + "/actions/secrets' --paginate 2>/dev/null");
+            if (!raw.empty()) {
                 DoctorCheck c{"RELEASE_BOT_TOKEN secret", false, {}, {}};
-                bool present = secrets_list.find("RELEASE_BOT_TOKEN") != std::string::npos;
+                // Any occurrence of "name":"RELEASE_BOT_TOKEN" across all
+                // pages means it's configured. --paginate concatenates
+                // page bodies so the substring check catches it whether
+                // it's on page 1 or page N.
+                bool present = raw.find("\"name\":\"RELEASE_BOT_TOKEN\"") != std::string::npos
+                            || raw.find("\"name\": \"RELEASE_BOT_TOKEN\"") != std::string::npos;
                 if (present) {
                     c.passed = true;
                     c.detail = "configured on " + repo_slug

--- a/tools/cli/cmd_pr.cpp
+++ b/tools/cli/cmd_pr.cpp
@@ -284,10 +284,20 @@ int cmd_pr(const std::vector<std::string>& args) {
     {
         auto repo = ::trim(run_capture("gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null").stdout_text);
         if (!repo.empty() && repo.find('/') != std::string::npos) {
-            auto secrets = run_capture(
-                "gh api 'repos/" + repo + "/actions/secrets' "
-                "--jq '.secrets[].name' 2>/dev/null").stdout_text;
-            if (!secrets.empty() && secrets.find("RELEASE_BOT_TOKEN") == std::string::npos) {
+            // Probe without --jq so we can distinguish "gh errored" (empty
+            // stdout) from "repo has zero secrets" (non-empty JSON, no
+            // matches). Codex P1 on #149: the previous guard gated on
+            // `!secrets.empty()` which collapsed both cases into silence
+            // and suppressed the warning in the exact bootstrap scenario
+            // where the user needs it most. --paginate also handles repos
+            // with many secrets where the token might be on page 2+.
+            auto raw = run_capture(
+                "gh api 'repos/" + repo + "/actions/secrets' --paginate 2>/dev/null"
+            ).stdout_text;
+            bool gh_call_succeeded = !raw.empty();
+            bool present = raw.find("\"name\":\"RELEASE_BOT_TOKEN\"") != std::string::npos
+                        || raw.find("\"name\": \"RELEASE_BOT_TOKEN\"") != std::string::npos;
+            if (gh_call_succeeded && !present) {
                 std::cerr << color::yellow()
                           << "\n▸ Heads-up: RELEASE_BOT_TOKEN secret is missing on "
                           << repo << ".\n"

--- a/tools/cli/cmd_version.cpp
+++ b/tools/cli/cmd_version.cpp
@@ -182,6 +182,24 @@ static std::string read_json_version_field(const fs::path& path) {
     return {};
 }
 
+// Read marketplace.json `plugins[0].version` — the per-plugin entry inside
+// the marketplace catalog. This is the version the Claude Code marketplace
+// surfaces per plugin, so it has to stay in lockstep with plugin.json's
+// top-level `.version`. The top-level marketplace `.version` is the
+// MARKETPLACE format version and drifts independently.
+static std::string read_marketplace_plugin_entry_version(const fs::path& path) {
+    if (!fs::exists(path)) return {};
+    auto content = read_file_contents(path);
+    // Match the first occurrence of `"version": "x.y.z"` at 6 spaces of
+    // indentation (inside `plugins[0]`). If the file grows a second plugin
+    // entry, this still picks the first one — matching how scroll /
+    // marketplace listings render.
+    std::regex re(R"#(^      "version"\s*:\s*"([^"]+)")#", std::regex::multiline);
+    std::smatch m;
+    if (std::regex_search(content, m, re)) return m[1].str();
+    return {};
+}
+
 static int version_check_inner(bool with_bump_check) {
     auto root = find_project_root();
     if (root.empty()) {
@@ -253,6 +271,19 @@ static int version_check_inner(bool with_bump_check) {
         all_ok = false;
     } else if (!market_ver.empty()) {
         print_ok("marketplace.json version matches plugin.json");
+    }
+
+    // marketplace.json `plugins[0].version` must also match plugin.json.
+    // Drifts silently because it's nested and not covered by the top-level
+    // regex above — exactly how we ended up at 0.3.0 vs 0.4.0 on main.
+    auto market_plugin_entry_ver = read_marketplace_plugin_entry_version(market_path);
+    if (!market_plugin_entry_ver.empty() && !plugin_ver.empty()
+        && market_plugin_entry_ver != plugin_ver) {
+        print_fail("marketplace.json plugins[0].version (" + market_plugin_entry_ver
+                   + ") differs from plugin.json (" + plugin_ver + ")");
+        all_ok = false;
+    } else if (!market_plugin_entry_ver.empty()) {
+        print_ok("marketplace.json plugins[0].version matches plugin.json");
     }
 
     // ── Optional bump-check integration ────────────────────────────────


### PR DESCRIPTION
Fix two-line drift on `.claude-plugin/marketplace.json`: `plugins[0].version` was at 0.3.0 while `plugin.json` and the top-level marketplace version were at 0.4.0. The per-plugin entry is what Claude Code's marketplace surfaces per plugin, so it has to match `plugin.json`.

The drift slipped in because `pulp version check` only validated the top-level `.version` field — the nested `plugins[0].version` was invisible to the gate. Added `read_marketplace_plugin_entry_version()` + a second equality check so this can't re-drift silently.

## Test plan
- [x] `pulp version check` now verifies both fields.
- [ ] CI: version-skill-check + build matrix.
