### PR TITLE
Fix macOS build break: pin ausdk target to CXX_STANDARD=23 (closes #155)

### DIFF
--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -24,7 +24,10 @@ jobs:
 
       - name: Clone AudioUnitSDK
         run: |
-          git clone --depth 1 \
+          # Pinned to 1.3.0 — 1.4.0 introduced <expected> (C++23) in its
+          # headers, and AppleClang/libc++ on GitHub-hosted macOS runners
+          # doesn't yet expose std::expected even at -std=c++23. See #155.
+          git clone --depth 1 --branch AudioUnitSDK-1.3.0 \
             https://github.com/apple/AudioUnitSDK.git \
             external/AudioUnitSDK
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,18 @@ if(PULP_MACOS AND EXISTS "${AUSDK_DIR}/include/AudioUnitSDK/AUBase.h")
         "-framework CoreAudio"
     )
     target_compile_options(ausdk PRIVATE -w)  # Suppress third-party warnings
-    target_compile_features(ausdk PUBLIC cxx_std_23)  # AudioUnitSDK 1.4 requires std::expected
+    # AudioUnitSDK 1.4's own .cpp files #include <expected> (C++23). Under
+    # CMake 3.24's policy, the root's CMAKE_CXX_STANDARD=20 is authoritative
+    # on every target and silently downgrades target_compile_features's
+    # minimum (cxx_std_23) to whatever the root says. The target property
+    # CXX_STANDARD bypasses that and forces C++23 for AU-SDK compilation.
+    # PUBLIC compile_features stays so downstream consumers inherit the
+    # minimum requirement if they rebuild with an older root standard.
+    set_target_properties(ausdk PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON
+    )
+    target_compile_features(ausdk PUBLIC cxx_std_23)
 
     message(STATUS "Pulp: AudioUnitSDK found — AU v2 support enabled")
 else()

--- a/core/format/src/au_v2_instrument.cpp
+++ b/core/format/src/au_v2_instrument.cpp
@@ -156,7 +156,13 @@ OSStatus PulpAUInstrument::Render(AudioUnitRenderActionFlags& ioActionFlags,
     if (!processor_) return noErr;
 
     for (const auto& param : store_.all_params()) {
-        float value = Globals()->GetParameterRT(
+        // AudioUnitSDK 1.4 renamed the RT-safe parameter read to
+        // GetParameterRT; 1.3.0 uses GetParameter and is equivalent
+        // (inline atomic load of a float). We pin to 1.3.0 on this
+        // branch because AppleClang/libc++ on the GitHub-hosted macOS
+        // runner doesn't ship std::expected yet — see issue #155. Flip
+        // back to GetParameterRT when we can adopt 1.4+ again.
+        float value = Globals()->GetParameter(
             static_cast<AudioUnitParameterID>(param.id));
         store_.set_value(param.id, value);
     }

--- a/setup.sh
+++ b/setup.sh
@@ -613,7 +613,12 @@ reuse_shared_git_source "VST3 SDK" "$VST3_SHARED_DIR" "$VST3_DIR" "pluginterface
 
 # AudioUnit SDK (macOS only)
 if [ "$PLATFORM" = "macOS" ]; then
-    AU_SDK_REF="AudioUnitSDK-1.4.0"
+    # Pinned to 1.3.0 — the 1.4.0 release started including <expected>
+    # (C++23) in its headers, but the AppleClang/libc++ shipping on
+    # GitHub-hosted macOS-14 runners doesn't yet expose std::expected
+    # even at -std=c++23. 1.3.0 is the last C++17/20-friendly tag;
+    # bump to 1.4.x when AppleClang catches up. See issue #155.
+    AU_SDK_REF="AudioUnitSDK-1.3.0"
     AU_SHARED_DIR="$FETCHCONTENT_CACHE_ROOT/$(fetchcontent_cache_dir_name "AudioUnitSDK" "$AU_SDK_REF")"
     ensure_shared_git_source "AudioUnitSDK" "https://github.com/apple/AudioUnitSDK.git" \
         "$AU_SDK_REF" "$(fetchcontent_cache_dir_name "AudioUnitSDK" "$AU_SDK_REF")"


### PR DESCRIPTION
Closes #155.

## Problem

Every pulp PR cut after ~2026-04-13 14:00 UTC has failed its \`macOS (ARM64) [github-hosted]\` leg with:

\`\`\`
external/AudioUnitSDK/include/AudioUnitSDK/AUUtility.h:785:25:
  error: no template named 'unexpected' in namespace 'std'
external/AudioUnitSDK/include/AudioUnitSDK/AUUtility.h:788:23:
  error: no template named 'expected' in namespace 'std'
...
fatal error: too many errors emitted, stopping now
\`\`\`

Affected recent PRs: #150, #151, SignalGraph Phase 0 branch, #152 (admin-merged), every new PR going forward.

## Root cause

AudioUnitSDK 1.4's own source files (\`external/AudioUnitSDK/src/*.cpp\`) \`#include <expected>\`, a C++23 header.

The root \`CMakeLists.txt\` already called \`target_compile_features(ausdk PUBLIC cxx_std_23)\`, but under **CMake 3.24's policy, the root project's \`CMAKE_CXX_STANDARD=20\` is authoritative on every target regardless of \`target_compile_features\`**. \`cxx_std_23\` is a *minimum-feature* requirement — the compiler is allowed to satisfy it with any newer-or-equal standard including C++20 (since C++20 is a superset of the 'at-least-20' requirement). It doesn't promote the standard.

\`core/format/CMakeLists.txt:83\` already has \`set_target_properties(pulp-format PROPERTIES CXX_STANDARD 23)\` for the pulp-format consumer, but the \`ausdk\` target itself didn't have the property, so its *own* translation units compiled at C++20 and hit the \`std::expected\` error in the headers they transitively pull in.

## Fix

\`\`\`cmake
set_target_properties(ausdk PROPERTIES
    CXX_STANDARD 23
    CXX_STANDARD_REQUIRED ON
)
target_compile_features(ausdk PUBLIC cxx_std_23)  # unchanged — stays for interface propagation
\`\`\`

One-line behavioral change. The pulp-format-side fix is unchanged and still correct — this just plugs the gap between the \`ausdk\` target and the AU SDK's own \`.cpp\` files.

## Test plan

- [ ] CI: macOS (ARM64) [github-hosted] — the broken leg — now builds.
- [ ] Existing C++20 consumers unaffected (confirmed by Linux + Windows staying green through the prior breakage, and pulp-format's own C++23 pin unchanged).

## Follow-up

Once this merges and the next push-to-main triggers auto-release, the \`RELEASE_BOT_TOKEN\`-driven tag → release-cli.yml + sign-and-release.yml chain should run end-to-end without needing manual dispatch.