### PR TITLE
Replace indent-fragile marketplace version regex with real JSON parser

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "Dan Raffel"
       },

--- a/tools/cli/cmd_version.cpp
+++ b/tools/cli/cmd_version.cpp
@@ -2,6 +2,7 @@
 // Show, bump, and verify version consistency across all surfaces.
 
 #include "cli_common.hpp"
+#include "json_parser.hpp"
 
 #include <cstdlib>
 #include <fstream>
@@ -168,17 +169,18 @@ static int version_bump(const std::vector<std::string>& args) {
     return 0;
 }
 
-// Read the TOP-LEVEL "version" field from a JSON file via a tiny regex — we
-// intentionally avoid pulling in a JSON library here. The config files are
-// small and under our control. "Top-level" means two-space indentation (or
-// zero): `"version":` nested deeper (metadata.version, plugins[0].version)
-// is skipped because those are not the canonical version for the file.
+// Read the TOP-LEVEL "version" field from a JSON file using the in-repo
+// parser. Reformatting the file (different indent width, tabs, minification)
+// no longer breaks the check. Codex P2 on PR #152.
 static std::string read_json_version_field(const fs::path& path) {
     if (!fs::exists(path)) return {};
     auto content = read_file_contents(path);
-    std::regex re(R"#(^(?:  )?"version"\s*:\s*"([^"]+)")#", std::regex::multiline);
-    std::smatch m;
-    if (std::regex_search(content, m, re)) return m[1].str();
+    pulp::cli::pkg::JsonParser parser{content};
+    parser.skip_ws();
+    auto root = parser.parse_value();
+    if (auto* v = root.get("version"); v && v->type == pulp::cli::pkg::JsonValue::String) {
+        return v->str_val;
+    }
     return {};
 }
 
@@ -187,16 +189,22 @@ static std::string read_json_version_field(const fs::path& path) {
 // surfaces per plugin, so it has to stay in lockstep with plugin.json's
 // top-level `.version`. The top-level marketplace `.version` is the
 // MARKETPLACE format version and drifts independently.
+//
+// Uses the in-repo JSON parser so indentation changes don't silently
+// re-introduce the drift this check exists to catch (Codex P2 on #152).
 static std::string read_marketplace_plugin_entry_version(const fs::path& path) {
     if (!fs::exists(path)) return {};
     auto content = read_file_contents(path);
-    // Match the first occurrence of `"version": "x.y.z"` at 6 spaces of
-    // indentation (inside `plugins[0]`). If the file grows a second plugin
-    // entry, this still picks the first one — matching how scroll /
-    // marketplace listings render.
-    std::regex re(R"#(^      "version"\s*:\s*"([^"]+)")#", std::regex::multiline);
-    std::smatch m;
-    if (std::regex_search(content, m, re)) return m[1].str();
+    pulp::cli::pkg::JsonParser parser{content};
+    parser.skip_ws();
+    auto root = parser.parse_value();
+    auto* plugins = root.get("plugins");
+    if (!plugins || plugins->type != pulp::cli::pkg::JsonValue::Array) return {};
+    const auto& arr = plugins->arr();
+    if (arr.empty()) return {};
+    if (auto* v = arr.front().get("version"); v && v->type == pulp::cli::pkg::JsonValue::String) {
+        return v->str_val;
+    }
     return {};
 }
 


### PR DESCRIPTION
## Why

Codex P2 on #152 flagged that \`read_marketplace_plugin_entry_version\` anchored on exactly \`^      \"version\"\` (six leading spaces). Any reformatting of \`.claude-plugin/marketplace.json\` — tab reformat, 2/4-space flip, minification — would silently skip the check and let drift back in.

## What

Switched both \`read_json_version_field()\` and \`read_marketplace_plugin_entry_version()\` in \`tools/cli/cmd_version.cpp\` to use the in-repo \`tools/cli/json_parser.hpp\` (same parser the package subsystem uses). The check now walks the actual JSON object tree:

- top-level \`.version\` for \`plugin.json\` and \`marketplace.json\`
- \`plugins[0].version\` for the per-plugin entry inside marketplace's catalog

Indentation/formatting can't re-introduce drift.

## Bonus: fresh drift found

While verifying locally, the new parser caught **real drift already on main**: \`marketplace.json\` \`plugins[0].version\` was at 0.4.0 while \`plugin.json\` is at 0.5.0. One of the intermediate PRs bumped \`plugin.json\` without updating the nested plugin entry — exactly the class of drift this PR hardens against. Bumped to 0.5.0 in the same commit since the check now (correctly) refuses to pass without it.

## Test plan

- [x] Local build succeeds.
- [x] \`pulp version check\` reports both marketplace fields matching plugin.json.
- [ ] CI: version-skill-check + build matrix.