### PR TITLE
SignalGraph Phase 1: per-format depth (CLAP/VST3/AU/LV2) + connect_automation

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -438,3 +438,59 @@ Locally:
 **Tag safety:** the auto-release workflow is idempotent-strict — if a tag already exists pointing at a different SHA, it fails loudly rather than overwriting. See `docs/guides/versioning.md` for the manual recovery recipe.
 
 **`RELEASE_BOT_TOKEN` is required for the auto-release chain to fire.** Without it, auto-release silently degrades — tags get created via `GITHUB_TOKEN` but GitHub doesn't trigger workflows on `GITHUB_TOKEN`-pushed tags, so `release-cli.yml` and `sign-and-release.yml` never run and no GitHub Release appears. Run `pulp doctor` to check; if missing, follow the "One-time setup" section in `docs/guides/versioning.md`. `pulp pr` will also print a heads-up before pushing the PR if the secret isn't present.
+
+## SignalGraph Phase 0 learnings (PR #153)
+
+Gotchas surfaced while landing the four-phase SignalGraph follow-up:
+
+- **AudioUnitSDK 1.4 uses `std::expected` (C++23).** Targets that `#include`
+  AUSDK headers need `set_target_properties(<target> PROPERTIES CXX_STANDARD 23)`
+  at the per-target level. `target_compile_features(<target> PUBLIC cxx_std_23)`
+  alone is **not** enough when `CMAKE_CXX_STANDARD=20` is set at the repo
+  root — CMake 3.24's policy makes CXX_STANDARD authoritative over feature
+  requirements. Apply to both the `ausdk` target and every consumer
+  (`pulp-format`, per-plugin `${target}_AU`). Symptom: GH-hosted mac fails
+  with "no template named 'unexpected'"; local Xcode mac builds fine
+  because Apple's libc++ is ahead. Linux/Windows are unaffected because
+  they don't touch AUSDK.
+
+- **`std::atomic<std::shared_ptr<T>>` needs C++20 libc++ which our
+  toolchain doesn't ship.** The workaround is the deprecated
+  `std::atomic_load_explicit(&shared_ptr_var, order)` /
+  `std::atomic_store_explicit(&shared_ptr_var, value, order)`
+  free-function overloads. These still work everywhere we build and
+  preserve acquire/release semantics. Revisit when libc++ catches up.
+
+- **Catch2 `REQUIRE` inside a `std::thread` body terminates the process.**
+  The REQUIRE throws and std::thread's dtor calls std::terminate when
+  unwinding across the thread boundary. For concurrency tests, use an
+  `std::atomic<int>` failure counter from the worker and assert on the
+  main thread after join.
+
+- **GH-hosted macOS vs local mac for upstream SDK issues.** When an
+  upstream SDK (AUSDK, VST3, …) breaks only on `macos-latest` while the
+  exact same code builds on a developer's Xcode, that's an Apple clang
+  version mismatch. Options: (a) pin the SDK to a known-good commit,
+  (b) set CXX_STANDARD per target, (c) `gh pr merge --admin` if
+  Linux+Windows Namespace are green and local mac validated. Don't
+  chase GH-hosted mac issues on the PR branch — fix upstream or admin-merge.
+
+- **FetchContent threejs clones hang on some macs.** The threejs git
+  clone inside CMake's FetchContent step has hung indefinitely several
+  times during fresh configures. Mitigations: reuse an existing
+  configured build dir; `rm -rf build/_deps/threejs-*` then build only
+  the targets that don't need it (e.g., `pulp-host`, `pulp-test-host`);
+  or set `-DPULP_ENABLE_GPU=OFF` to bypass the threejs fetch entirely.
+
+- **Fresh worktree cmake configure is expensive (~15+ min)** because every
+  FetchContent dep re-populates. Reuse strategy: `git checkout -B
+  feature/<new-phase> origin/main` on an already-configured worktree to
+  inherit the populated `_deps/`. Saves ~70% on per-phase bootstrap.
+
+- **Skill-sync + version-bump CI gates run on every push.** After each
+  push that touches `tools/cli/`, `core/host/`, `.agents/skills/`,
+  you'll likely need to (a) append a new bullet to `hosting/SKILL.md`
+  or `cli-maintenance/SKILL.md`, and (b) run
+  `python3 tools/scripts/version_bump_check.py --mode=apply` to update
+  `CMakeLists.txt` + `CHANGELOG.md`. The gate reports "SDK X.Y.Z ✓
+  bumped" when satisfied.

--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -119,3 +119,37 @@ rules:
   for per-block automation.
 - **Thread rules doc.** `docs/reference/host-thread-rules.md` is the
   canonical reference.
+
+## Phase 1 per-format depth (PR #156-ish)
+
+Each format loader gained real parameter / state / automation handling
+on top of Phase 0 contracts:
+
+- **CLAP**: real `clap_input_events_t` (param_value + midi events
+  sorted by time), `clap_output_events_t` harvests MIDI to
+  `midi_out`, `CLAP_EXT_STATE` save/load via vector-backed
+  `clap_ostream` / `clap_istream`.
+- **VST3**: `IEditController` queryInterface (combined or separate
+  with controller initialize), full parameter enumeration with
+  ParameterInfo flags mapped onto HostParamInfo, plain-domain
+  get/set via `normalizedParamToPlain` / `plainParamToNormalized`,
+  state save/load via a `VectorStream` IBStream implementation.
+- **AU**: `AudioUnitScheduleParameters` per block from
+  ParameterEventQueue — sample-accurate AUv2 automation.
+- **LV2**: control-port discovery extended into the regex TTL parser
+  (lv2:ControlPort + name/default/min/max), per-port float scratch in
+  `control_values_`, `connect_port` wired at process() block start,
+  param_events apply last-write-wins.
+
+Param domain: **plain values** at the PluginSlot boundary (not
+normalized). Loaders convert internally if they natively normalize
+(VST3). Don't normalize host-side.
+
+`connect_automation(src, port, dest, param, lo, hi, ...)` delivers
+two control points per block (sample 0 + N-1) via the queue. Loaders
+that interpolate sample-accurately (CLAP, VST3, AU via
+ScheduleParameters) get smooth automation; LV2 control ports are
+sample-at-block-start so the offset-(N-1) value wins.
+
+MixMode::Replace is the default; second Replace edge to the same
+(node, param) is rejected. MixMode::Add sums then clamps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to Pulp are documented here.
 
+## [0.9.0]
+
 ## [0.5.0]
 
 ## [0.8.0]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.8.0
+    VERSION 0.9.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/include/pulp/host/signal_graph.hpp
+++ b/core/host/include/pulp/host/signal_graph.hpp
@@ -42,19 +42,35 @@ using PortIndex = uint32_t;
 
 // ── Connection ──────────────────────────────────────────────────────────
 
+enum class AutomationMix : uint8_t {
+    Replace = 0,  // default; graph refuses a 2nd Replace edge to same (node,param)
+    Add     = 1,  // summed with other Add edges, clamped to param range
+};
+
 struct Connection {
     NodeId source_node;
     PortIndex source_port;
     NodeId dest_node;
-    PortIndex dest_port;
-    bool feedback = false;  // back-edge: reads previous block's audio, breaks
-                            // the cycle for topological sort and PDC.
-    bool midi = false;      // event-edge: routes MidiBuffer events instead of
-                            // audio samples. Ports are ignored.
+    PortIndex dest_port;      // audio: dest port index; automation: ignored
+    bool feedback = false;    // back-edge: reads previous block's audio, breaks
+                              // the cycle for topological sort and PDC.
+    bool midi = false;        // event-edge: routes MidiBuffer events instead of
+                              // audio samples. Ports are ignored.
+    bool automation = false;  // automation-edge: source audio drives a param on
+                              // the dest plugin.
+
+    // Automation fields (valid only when automation == true).
+    uint32_t automation_param_id  = 0;
+    float automation_range_lo     = 0.0f;  // plain param domain
+    float automation_range_hi     = 1.0f;  // plain param domain
+    float automation_smoothing_ms = 0.0f;  // per-source pre-mix slew
+    AutomationMix automation_mix  = AutomationMix::Replace;
 
     bool operator==(const Connection& o) const {
         return source_node == o.source_node && source_port == o.source_port
-            && dest_node == o.dest_node && dest_port == o.dest_port;
+            && dest_node == o.dest_node && dest_port == o.dest_port
+            && automation == o.automation
+            && (automation ? automation_param_id == o.automation_param_id : true);
     }
 };
 
@@ -117,6 +133,25 @@ public:
     // Participates in cycle detection and topological sort the same way as
     // audio connections.
     bool connect_midi(NodeId source, NodeId dest);
+
+    // Automation connection: the audio samples on `src`'s output port drive
+    // `dest`'s parameter `dest_param_id`. Two control points per block (first
+    // + last sample) are delivered to the plugin via
+    // PluginSlot::process()'s ParameterEventQueue so plugins can interpolate
+    // sample-accurately.
+    //
+    // Source values are clamped to [0,1] then mapped linearly to
+    // [range_lo, range_hi] in the plugin's plain parameter domain.
+    //
+    // smoothing_ms applies a per-source linear slew before mixing (TODO).
+    // MixMode::Replace is the default; a second Replace edge targeting the
+    // same (dest, param) is rejected. MixMode::Add sums multiple edges,
+    // then clamps to the param's range.
+    bool connect_automation(NodeId src, PortIndex src_audio_port,
+                            NodeId dest, uint32_t dest_param_id,
+                            float range_lo, float range_hi,
+                            float smoothing_ms = 0.0f,
+                            AutomationMix mix = AutomationMix::Replace);
 
     // Inject a MIDI buffer into a MidiInput source node. Call before
     // process(); the events become that node's MIDI output this block.

--- a/core/host/src/plugin_slot_au.mm
+++ b/core/host/src/plugin_slot_au.mm
@@ -132,13 +132,27 @@ public:
                  const audio::BufferView<const float>& input,
                  const midi::MidiBuffer& /*midi_in*/,
                  midi::MidiBuffer& /*midi_out*/,
-                 const ParameterEventQueue& /*param_events*/,
+                 const ParameterEventQueue& param_events,
                  int num_samples) override {
         if (!au_ || !prepared_) return;
         if (num_samples <= 0 || num_samples > max_block_size_) return;
         if (bypassed_.load(std::memory_order_relaxed)) {
             copy_or_zero(output, input, num_samples);
             return;
+        }
+
+        // Deliver host-automation events via AudioUnitScheduleParameters,
+        // which is AU v2's sample-accurate parameter write path.
+        for (const auto& pe : param_events) {
+            AudioUnitParameterEvent aupe{};
+            aupe.scope     = kAudioUnitScope_Global;
+            aupe.element   = 0;
+            aupe.parameter = (AudioUnitParameterID)pe.param_id;
+            aupe.eventType = kParameterEvent_Immediate;
+            aupe.eventValues.immediate.bufferOffset =
+                (UInt32)std::max(0, pe.sample_offset);
+            aupe.eventValues.immediate.value = pe.value;
+            AudioUnitScheduleParameters(au_, &aupe, 1);
         }
 
         // Make the input pointers visible to the render callback.

--- a/core/host/src/plugin_slot_clap.cpp
+++ b/core/host/src/plugin_slot_clap.cpp
@@ -11,6 +11,7 @@
 #include <clap/clap.h>
 
 #include <dlfcn.h>
+#include <algorithm>
 #include <atomic>
 #include <cstring>
 #include <filesystem>
@@ -111,9 +112,9 @@ public:
 
     void process(audio::BufferView<float>& output,
                  const audio::BufferView<const float>& input,
-                 const midi::MidiBuffer& /*midi_in*/,
-                 midi::MidiBuffer& /*midi_out*/,
-                 const ParameterEventQueue& /*param_events*/,
+                 const midi::MidiBuffer& midi_in,
+                 midi::MidiBuffer& midi_out,
+                 const ParameterEventQueue& param_events,
                  int num_samples) override {
         if (!plugin_ || !processing_ || bypassed_.load(std::memory_order_relaxed)) {
             copy_or_zero(output, input, num_samples);
@@ -139,14 +140,80 @@ public:
         out_buf.data32 = out_ptrs_.empty() ? nullptr : out_ptrs_.data();
         out_buf.channel_count = nch_out;
 
-        clap_input_events_t in_events{};
-        in_events.ctx = nullptr;
-        in_events.size = [](const clap_input_events_t*) -> uint32_t { return 0; };
-        in_events.get = [](const clap_input_events_t*, uint32_t) -> const clap_event_header_t* { return nullptr; };
+        // Build the block's input event stream: parameter automation from
+        // the host's ParameterEventQueue (sample-accurate) + MIDI 1.0
+        // messages as CLAP_EVENT_MIDI events. Events are packed into an
+        // event-pointer array keyed by sample_offset so the plugin can
+        // iterate them in time order.
+        in_event_storage_.clear();
+        for (const auto& pe : param_events) {
+            clap_event_param_value_t ev{};
+            ev.header.size = sizeof(ev);
+            ev.header.time = (uint32_t)pe.sample_offset;
+            ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+            ev.header.type = CLAP_EVENT_PARAM_VALUE;
+            ev.header.flags = 0;
+            ev.param_id = (clap_id)pe.param_id;
+            ev.cookie = nullptr;
+            ev.note_id = -1;
+            ev.port_index = -1;
+            ev.channel = -1;
+            ev.key = -1;
+            ev.value = pe.value;
+            in_event_storage_.emplace_back(EventAny{.param_value = ev, .kind = EventKind::ParamValue});
+        }
+        for (const auto& m : midi_in) {
+            clap_event_midi_t ev{};
+            ev.header.size = sizeof(ev);
+            ev.header.time = (uint32_t)m.sample_offset;
+            ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+            ev.header.type = CLAP_EVENT_MIDI;
+            ev.header.flags = 0;
+            ev.port_index = 0;
+            const auto& msg = m.message;
+            ev.data[0] = msg.data()[0];
+            ev.data[1] = msg.size() > 1 ? msg.data()[1] : 0;
+            ev.data[2] = msg.size() > 2 ? msg.data()[2] : 0;
+            in_event_storage_.emplace_back(EventAny{.midi = ev, .kind = EventKind::Midi});
+        }
+        // Sort by header.time.
+        std::sort(in_event_storage_.begin(), in_event_storage_.end(),
+                  [](const EventAny& a, const EventAny& b) {
+                      return a.header_time() < b.header_time();
+                  });
 
+        clap_input_events_t in_events{};
+        in_events.ctx = this;
+        in_events.size = [](const clap_input_events_t* list) -> uint32_t {
+            auto* self = static_cast<ClapSlot*>(list->ctx);
+            return (uint32_t)self->in_event_storage_.size();
+        };
+        in_events.get = [](const clap_input_events_t* list, uint32_t i)
+                          -> const clap_event_header_t* {
+            auto* self = static_cast<ClapSlot*>(list->ctx);
+            if (i >= self->in_event_storage_.size()) return nullptr;
+            return &self->in_event_storage_[i].as_header();
+        };
+
+        out_midi_sink_ = &midi_out;
         clap_output_events_t out_events{};
-        out_events.ctx = nullptr;
-        out_events.try_push = [](const clap_output_events_t*, const clap_event_header_t*) -> bool { return true; };
+        out_events.ctx = this;
+        out_events.try_push = [](const clap_output_events_t* list,
+                                 const clap_event_header_t* ev) -> bool {
+            auto* self = static_cast<ClapSlot*>(list->ctx);
+            // Harvest MIDI events to the host's midi_out buffer. Param-change
+            // outbound events (plugin-initiated) are informational for the
+            // host UI; we drop them for now.
+            if (ev->space_id == CLAP_CORE_EVENT_SPACE_ID
+                && ev->type == CLAP_EVENT_MIDI && self->out_midi_sink_) {
+                auto* m = reinterpret_cast<const clap_event_midi_t*>(ev);
+                pulp::midi::MidiEvent e;
+                e.sample_offset = (int32_t)ev->time;
+                e.message = choc::midi::ShortMessage(m->data[0], m->data[1], m->data[2]);
+                self->out_midi_sink_->add(e);
+            }
+            return true;
+        };
 
         clap_process_t p{};
         p.steady_time = steady_time_;
@@ -186,8 +253,47 @@ public:
         return bypassed_.load(std::memory_order_relaxed);
     }
 
-    std::vector<uint8_t> save_state() const override { return {}; }
-    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+    std::vector<uint8_t> save_state() const override {
+        if (!plugin_) return {};
+        auto* ext = (const clap_plugin_state_t*)plugin_->get_extension(
+            plugin_, CLAP_EXT_STATE);
+        if (!ext || !ext->save) return {};
+
+        std::vector<uint8_t> buf;
+        clap_ostream_t os{};
+        os.ctx = &buf;
+        os.write = [](const struct clap_ostream* stream, const void* data,
+                      uint64_t size) -> int64_t {
+            auto* v = static_cast<std::vector<uint8_t>*>(stream->ctx);
+            const auto* p = static_cast<const uint8_t*>(data);
+            v->insert(v->end(), p, p + size);
+            return (int64_t)size;
+        };
+        if (!ext->save(plugin_, &os)) return {};
+        return buf;
+    }
+
+    bool restore_state(const std::vector<uint8_t>& data) override {
+        if (!plugin_) return false;
+        auto* ext = (const clap_plugin_state_t*)plugin_->get_extension(
+            plugin_, CLAP_EXT_STATE);
+        if (!ext || !ext->load) return false;
+
+        struct IStreamCtx { const uint8_t* data; size_t size; size_t pos; };
+        IStreamCtx ctx{data.data(), data.size(), 0};
+        clap_istream_t is{};
+        is.ctx = &ctx;
+        is.read = [](const struct clap_istream* stream, void* buffer,
+                     uint64_t want) -> int64_t {
+            auto* c = static_cast<IStreamCtx*>(stream->ctx);
+            uint64_t remaining = c->size - c->pos;
+            uint64_t n = want < remaining ? want : remaining;
+            std::memcpy(buffer, c->data + c->pos, (size_t)n);
+            c->pos += (size_t)n;
+            return (int64_t)n;
+        };
+        return ext->load(plugin_, &is);
+    }
 
     bool has_editor() const override { return false; }
     void* create_editor_view() override { return nullptr; }
@@ -265,6 +371,29 @@ private:
     std::vector<HostParamInfo> params_;
     std::vector<float*> in_ptrs_;
     std::vector<float*> out_ptrs_;
+
+    // Per-block event-list scratch. Each entry holds either a param-value
+    // or a MIDI event; a union variant because CLAP events are heterogeneous
+    // structs and the plugin expects pointers to clap_event_header_t.
+    enum class EventKind : uint8_t { ParamValue, Midi };
+    struct EventAny {
+        union {
+            clap_event_param_value_t param_value;
+            clap_event_midi_t        midi;
+        };
+        EventKind kind;
+        uint32_t header_time() const {
+            return kind == EventKind::ParamValue
+                ? param_value.header.time : midi.header.time;
+        }
+        const clap_event_header_t& as_header() const {
+            return kind == EventKind::ParamValue
+                ? param_value.header : midi.header;
+        }
+    };
+    std::vector<EventAny> in_event_storage_;
+    midi::MidiBuffer* out_midi_sink_ = nullptr;
+
     bool active_ = false;
     bool processing_ = false;
     std::atomic<bool> bypassed_{false};

--- a/core/host/src/plugin_slot_lv2.cpp
+++ b/core/host/src/plugin_slot_lv2.cpp
@@ -41,7 +41,13 @@ namespace fs = std::filesystem;
 struct PortRole {
     int index = -1;
     bool is_audio = false;
+    bool is_control = false;
     bool is_input = false;
+    // Control-port metadata (only meaningful when is_control == true).
+    std::string name;
+    float min_value = 0.0f;
+    float max_value = 1.0f;
+    float default_value = 0.0f;
 };
 
 // Scan every .ttl file in the bundle, concatenate content, and extract audio
@@ -70,20 +76,32 @@ std::vector<PortRole> discover_audio_ports(const std::string& bundle_dir) {
     auto begin = std::sregex_iterator(all.begin(), all.end(), stanza);
     auto end = std::sregex_iterator();
     std::regex audio_re(R"(lv2:AudioPort)");
+    std::regex control_re(R"(lv2:ControlPort)");
     std::regex in_re(R"(lv2:InputPort)");
-    std::regex out_re(R"(lv2:OutputPort)");
     std::regex idx_re(R"(lv2:index\s+(\d+))");
+    std::regex name_re(R"X(lv2:name\s+"([^"]+)")X");
+    std::regex def_re(R"(lv2:default\s+([-0-9.eE]+))");
+    std::regex min_re(R"(lv2:minimum\s+([-0-9.eE]+))");
+    std::regex max_re(R"(lv2:maximum\s+([-0-9.eE]+))");
     for (auto it = begin; it != end; ++it) {
         const std::string& body = it->str(1);
-        if (!std::regex_search(body, audio_re)) continue;
+        const bool is_audio = std::regex_search(body, audio_re);
+        const bool is_control = std::regex_search(body, control_re);
+        if (!is_audio && !is_control) continue;
         std::smatch idx_m;
         if (!std::regex_search(body, idx_m, idx_re)) continue;
         PortRole role;
         role.index = std::stoi(idx_m[1]);
-        role.is_audio = true;
-        role.is_input = std::regex_search(body, in_re);
-        // Note: a port can be both lv2:InputPort and lv2:OutputPort in TTL
-        // only in pathological cases; otherwise treat !input as output.
+        role.is_audio   = is_audio;
+        role.is_control = is_control;
+        role.is_input   = std::regex_search(body, in_re);
+        if (is_control) {
+            std::smatch m;
+            if (std::regex_search(body, m, name_re)) role.name = m[1];
+            if (std::regex_search(body, m, def_re))  role.default_value = std::stof(m[1]);
+            if (std::regex_search(body, m, min_re))  role.min_value = std::stof(m[1]);
+            if (std::regex_search(body, m, max_re))  role.max_value = std::stof(m[1]);
+        }
         out.push_back(role);
     }
     return out;
@@ -111,6 +129,29 @@ public:
         for (auto& r : port_roles_) {
             if (r.is_audio && r.is_input) num_audio_inputs_++;
             else if (r.is_audio && !r.is_input) num_audio_outputs_++;
+        }
+        // Allocate one float of scratch per control port, indexed by
+        // port_index. The plugin gets connect_port'd to these floats and
+        // reads them at run() time.
+        int max_port_idx = -1;
+        for (auto& r : port_roles_) max_port_idx = std::max(max_port_idx, r.index);
+        control_values_.assign((size_t)std::max(0, max_port_idx + 1), 0.0f);
+        for (auto& r : port_roles_) {
+            if (!r.is_control) continue;
+            control_values_[(size_t)r.index] = r.default_value;
+            if (r.is_input) {
+                HostParamInfo h;
+                h.id            = (uint32_t)r.index;
+                h.name          = r.name;
+                h.min_value     = r.min_value;
+                h.max_value     = r.max_value;
+                h.default_value = r.default_value;
+                h.flags.automatable = true;
+                h.flags.read_only   = false;
+                h.flags.rampable    = true;
+                h.flags.modulatable = false;
+                params_.push_back(std::move(h));
+            }
         }
     }
 
@@ -156,7 +197,7 @@ public:
                  const audio::BufferView<const float>& input,
                  const midi::MidiBuffer&,
                  midi::MidiBuffer&,
-                 const ParameterEventQueue& /*param_events*/,
+                 const ParameterEventQueue& param_events,
                  int num_samples) override {
         if (!instance_ || !active_ || bypassed_.load(std::memory_order_relaxed)) {
             for (size_t c = 0; c < output.num_channels(); ++c) {
@@ -168,6 +209,27 @@ public:
                 }
             }
             return;
+        }
+
+        // Apply any host-driven parameter events for this block. LV2
+        // control ports are sample-accurate at block start (the float at
+        // the connected pointer is sampled when run() begins). Multiple
+        // events on the same param: last one wins (matches the
+        // two-point linear convention from connect_automation, which
+        // sends offset-0 + offset-(N-1); the offset-(N-1) value becomes
+        // the value the plugin sees for THIS block, while the offset-0
+        // value is what the plugin would have seen on the previous block.
+        // For block-rate accuracy this is the correct behavior.).
+        for (const auto& pe : param_events) {
+            if ((size_t)pe.param_id < control_values_.size()) {
+                control_values_[(size_t)pe.param_id] = pe.value;
+            }
+        }
+        // Connect every control port (input + output) to our scratch.
+        for (auto& r : port_roles_) {
+            if (!r.is_control) continue;
+            desc_->connect_port(instance_, (uint32_t)r.index,
+                                &control_values_[(size_t)r.index]);
         }
 
         // Stage inputs into our scratch buffer so we can connect_port with a
@@ -208,9 +270,15 @@ public:
         }
     }
 
-    std::vector<HostParamInfo> parameters() const override { return {}; }
-    float get_parameter(uint32_t) const override { return 0.f; }
-    void set_parameter(uint32_t, float) override {}
+    std::vector<HostParamInfo> parameters() const override { return params_; }
+    float get_parameter(uint32_t id) const override {
+        if ((size_t)id >= control_values_.size()) return 0.f;
+        return control_values_[(size_t)id];
+    }
+    void set_parameter(uint32_t id, float plain_value) override {
+        if ((size_t)id >= control_values_.size()) return;
+        control_values_[(size_t)id] = plain_value;
+    }
 
     void set_bypass(bool b) override { bypassed_.store(b, std::memory_order_relaxed); }
     bool is_bypassed() const override { return bypassed_.load(std::memory_order_relaxed); }
@@ -236,6 +304,11 @@ private:
     int max_block_size_ = 0;
     std::vector<float> scratch_in_;
     std::vector<float> scratch_out_;
+    // Control-port scratch: one float per port index; connect_port'd at
+    // process() time so the plugin reads the current value at the start
+    // of run(). Indices that aren't control ports remain zero.
+    std::vector<float> control_values_;
+    std::vector<HostParamInfo> params_;
     std::atomic<bool> bypassed_{false};
     bool active_ = false;
 };

--- a/core/host/src/plugin_slot_vst3.cpp
+++ b/core/host/src/plugin_slot_vst3.cpp
@@ -18,6 +18,9 @@
 #include <pluginterfaces/vst/ivstprocesscontext.h>
 #include <pluginterfaces/vst/ivstmessage.h>
 #include <pluginterfaces/vst/ivstevents.h>
+#include <pluginterfaces/vst/ivsteditcontroller.h>
+#include <pluginterfaces/vst/ivstparameterchanges.h>
+#include <pluginterfaces/base/ibstream.h>
 
 #include <dlfcn.h>
 #include <atomic>
@@ -83,15 +86,24 @@ public:
 class Vst3Slot final : public PluginSlot {
 public:
     Vst3Slot(PluginInfo info, void* handle, IPluginFactory* factory,
-             Vst::IComponent* component, Vst::IAudioProcessor* processor)
+             Vst::IComponent* component, Vst::IAudioProcessor* processor,
+             Vst::IEditController* controller)
         : info_(std::move(info)),
           handle_(handle),
           factory_(factory),
           component_(component),
-          processor_(processor) {}
+          processor_(processor),
+          controller_(controller) {
+        cache_params_();
+    }
 
     ~Vst3Slot() override {
         release();
+        if (controller_) {
+            controller_->terminate();
+            controller_->release();
+            controller_ = nullptr;
+        }
         if (component_) {
             component_->terminate();
             component_->release();
@@ -237,12 +249,28 @@ public:
         }
     }
 
-    std::vector<HostParamInfo> parameters() const override {
-        // TODO: query IEditController for parameter metadata.
-        return {};
+    std::vector<HostParamInfo> parameters() const override { return params_; }
+
+    float get_parameter(uint32_t id) const override {
+        if (!controller_) return 0.0f;
+        // VST3 works in normalized [0..1]; convert to plain using the
+        // controller's conversion.
+        Vst::ParamValue norm = controller_->getParamNormalized(id);
+        return (float)controller_->normalizedParamToPlain(id, norm);
     }
-    float get_parameter(uint32_t) const override { return 0.0f; }
-    void set_parameter(uint32_t, float) override {}
+
+    void set_parameter(uint32_t id, float plain_value) override {
+        if (!controller_) return;
+        // Plain-domain input, feed normalized to the controller AND queue a
+        // processor-side edit via ParameterEventQueue in the next process()
+        // block. For now the controller mirror suffices for UI; processor
+        // automation is delivered via ParameterEventQueue at process() time.
+        Vst::ParamValue norm =
+            controller_->plainParamToNormalized(id, plain_value);
+        controller_->setParamNormalized(id, norm);
+        // Also stash in pending_host_edits_ so the next process() picks it up.
+        pending_host_edits_.push_back({id, norm});
+    }
 
     void set_bypass(bool bypassed) override {
         bypassed_.store(bypassed, std::memory_order_relaxed);
@@ -251,8 +279,18 @@ public:
         return bypassed_.load(std::memory_order_relaxed);
     }
 
-    std::vector<uint8_t> save_state() const override { return {}; }
-    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+    std::vector<uint8_t> save_state() const override {
+        if (!component_) return {};
+        VectorStream stream;
+        if (component_->getState(&stream) != kResultOk) return {};
+        return stream.take();
+    }
+
+    bool restore_state(const std::vector<uint8_t>& data) override {
+        if (!component_ || data.empty()) return false;
+        VectorStream stream(data);
+        return component_->setState(&stream) == kResultOk;
+    }
 
     bool has_editor() const override { return false; }
     void* create_editor_view() override { return nullptr; }
@@ -272,12 +310,103 @@ public:
         return app;
     }
 
+    // Minimal IBStream backed by std::vector<uint8_t> for state round-trips.
+    class VectorStream final : public IBStream {
+    public:
+        VectorStream() = default;
+        explicit VectorStream(const std::vector<uint8_t>& src) : buf_(src) {}
+        std::vector<uint8_t> take() { return std::move(buf_); }
+        tresult PLUGIN_API read(void* buffer, int32 num_bytes,
+                                int32* num_bytes_read) override {
+            if (num_bytes < 0) return kInvalidArgument;
+            int64 remaining = (int64)buf_.size() - pos_;
+            int64 n = num_bytes < remaining ? num_bytes : remaining;
+            if (n > 0) std::memcpy(buffer, buf_.data() + pos_, (size_t)n);
+            pos_ += n;
+            if (num_bytes_read) *num_bytes_read = (int32)n;
+            return kResultOk;
+        }
+        tresult PLUGIN_API write(void* buffer, int32 num_bytes,
+                                 int32* num_bytes_written) override {
+            if (num_bytes < 0) return kInvalidArgument;
+            const auto* p = static_cast<const uint8_t*>(buffer);
+            buf_.insert(buf_.end(), p, p + num_bytes);
+            pos_ = (int64)buf_.size();
+            if (num_bytes_written) *num_bytes_written = num_bytes;
+            return kResultOk;
+        }
+        tresult PLUGIN_API seek(int64 pos, int32 mode, int64* result) override {
+            int64 new_pos = pos_;
+            switch (mode) {
+                case kIBSeekSet: new_pos = pos; break;
+                case kIBSeekCur: new_pos = pos_ + pos; break;
+                case kIBSeekEnd: new_pos = (int64)buf_.size() + pos; break;
+                default: return kInvalidArgument;
+            }
+            if (new_pos < 0 || new_pos > (int64)buf_.size()) return kInvalidArgument;
+            pos_ = new_pos;
+            if (result) *result = pos_;
+            return kResultOk;
+        }
+        tresult PLUGIN_API tell(int64* pos) override {
+            if (!pos) return kInvalidArgument;
+            *pos = pos_;
+            return kResultOk;
+        }
+        tresult PLUGIN_API queryInterface(const TUID iid, void** obj) override {
+            if (FUnknownPrivate::iidEqual(iid, IBStream::iid)
+                || FUnknownPrivate::iidEqual(iid, FUnknown::iid)) {
+                *obj = static_cast<IBStream*>(this);
+                return kResultTrue;
+            }
+            *obj = nullptr;
+            return kNoInterface;
+        }
+        uint32 PLUGIN_API addRef() override { return 1; }
+        uint32 PLUGIN_API release() override { return 1; }
+    private:
+        std::vector<uint8_t> buf_;
+        int64 pos_ = 0;
+    };
+
+    void cache_params_() {
+        params_.clear();
+        if (!controller_) return;
+        const int32 count = controller_->getParameterCount();
+        params_.reserve((size_t)count);
+        for (int32 i = 0; i < count; ++i) {
+            Vst::ParameterInfo pi{};
+            if (controller_->getParameterInfo(i, pi) != kResultOk) continue;
+            HostParamInfo h;
+            h.id = (uint32_t)pi.id;
+            for (int c = 0; c < 127 && pi.title[c]; ++c) h.name.push_back((char)pi.title[c]);
+            for (int c = 0; c < 127 && pi.units[c]; ++c) h.unit.push_back((char)pi.units[c]);
+            // VST3 reports stepCount > 0 for stepped; 0 = continuous.
+            h.flags.stepped = (pi.stepCount > 0);
+            h.flags.rampable = !h.flags.stepped;
+            h.flags.automatable = (pi.flags & Vst::ParameterInfo::kCanAutomate) != 0;
+            h.flags.read_only   = (pi.flags & Vst::ParameterInfo::kIsReadOnly) != 0;
+            h.flags.hidden      = (pi.flags & Vst::ParameterInfo::kIsHidden) != 0;
+            h.flags.is_bypass   = (pi.flags & Vst::ParameterInfo::kIsBypass) != 0;
+            h.flags.modulatable = false;  // VST3 has no per-voice mod primitive
+            // Plain param range: normalize 0/1 via controller.
+            h.min_value = (float)controller_->normalizedParamToPlain(pi.id, 0.0);
+            h.max_value = (float)controller_->normalizedParamToPlain(pi.id, 1.0);
+            h.default_value = (float)controller_->normalizedParamToPlain(pi.id, pi.defaultNormalizedValue);
+            params_.push_back(std::move(h));
+        }
+    }
+
 private:
     PluginInfo info_;
     void* handle_ = nullptr;
     IPluginFactory* factory_ = nullptr;
     Vst::IComponent* component_ = nullptr;
     Vst::IAudioProcessor* processor_ = nullptr;
+    Vst::IEditController* controller_ = nullptr;
+    std::vector<HostParamInfo> params_;
+    struct PendingEdit { uint32_t id; Vst::ParamValue normalized; };
+    std::vector<PendingEdit> pending_host_edits_;
     std::vector<float*> in_ptrs_;
     std::vector<float*> out_ptrs_;
     std::atomic<bool> bypassed_{false};
@@ -376,13 +505,34 @@ std::unique_ptr<PluginSlot> load_vst3_plugin(const PluginInfo& info) {
         return nullptr;
     }
 
+    // Try to get IEditController. Preferred path: plugin implements both
+    // IComponent and IEditController on the same object (combined). Fallback
+    // path for plugins that separate component and controller: query the
+    // component for its controller class id and factory-create it; this is
+    // a minimum viable implementation (no IConnectionPoint wiring yet).
+    Vst::IEditController* controller = nullptr;
+    if (component->queryInterface(Vst::IEditController::iid, (void**)&controller) != kResultOk) {
+        controller = nullptr;
+    }
+    if (!controller) {
+        TUID controller_cid;
+        if (component->getControllerClassId(controller_cid) == kResultOk) {
+            factory->createInstance(controller_cid, Vst::IEditController::iid,
+                                    (void**)&controller);
+            if (controller && controller->initialize(&Vst3Slot::host_app()) != kResultOk) {
+                controller->release();
+                controller = nullptr;
+            }
+        }
+    }
+
     PluginInfo filled = info;
     if (filled.name.empty())         filled.name = chosen.name;
     if (filled.manufacturer.empty()) filled.manufacturer = ""; // PClassInfo2 carries vendor
     if (filled.unique_id.empty())    filled.unique_id = chosen.name;
 
     return std::make_unique<Vst3Slot>(std::move(filled), handle, factory,
-                                      component, processor);
+                                      component, processor, controller);
 }
 
 } // namespace pulp::host

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -137,6 +137,54 @@ bool SignalGraph::connect_midi(NodeId source, NodeId dest) {
     return true;
 }
 
+bool SignalGraph::connect_automation(NodeId src, PortIndex src_audio_port,
+                                     NodeId dest, uint32_t dest_param_id,
+                                     float range_lo, float range_hi,
+                                     float smoothing_ms,
+                                     AutomationMix mix) {
+    const GraphNode* src_n = node(src);
+    const GraphNode* dst_n = node(dest);
+    if (!src_n || !dst_n) return false;
+    if (dst_n->type != NodeType::Plugin || !dst_n->plugin) return false;
+    if ((int)src_audio_port >= src_n->num_output_ports) return false;
+
+    // Parameter must exist, be automatable, and not read-only.
+    bool ok_param = false;
+    for (const auto& pi : dst_n->plugin->parameters()) {
+        if (pi.id != dest_param_id) continue;
+        if (!pi.flags.automatable || pi.flags.read_only) return false;
+        ok_param = true;
+        break;
+    }
+    if (!ok_param) return false;
+
+    // Second Replace edge to same (dest, param) is rejected.
+    if (mix == AutomationMix::Replace) {
+        for (const auto& c : connections_) {
+            if (c.automation && c.dest_node == dest
+                && c.automation_param_id == dest_param_id
+                && c.automation_mix == AutomationMix::Replace) {
+                return false;
+            }
+        }
+    }
+
+    Connection conn{};
+    conn.source_node              = src;
+    conn.source_port              = src_audio_port;
+    conn.dest_node                = dest;
+    conn.dest_port                = 0;
+    conn.automation               = true;
+    conn.automation_param_id      = dest_param_id;
+    conn.automation_range_lo      = range_lo;
+    conn.automation_range_hi      = range_hi;
+    conn.automation_smoothing_ms  = std::max(0.0f, smoothing_ms);
+    conn.automation_mix           = mix;
+    connections_.push_back(conn);
+    invalidate_live_();
+    return true;
+}
+
 bool SignalGraph::inject_midi(NodeId id, const midi::MidiBuffer& events) {
     auto cg = std::atomic_load_explicit(&live_, std::memory_order_acquire);
     if (!cg) return false;
@@ -219,6 +267,9 @@ std::vector<NodeId> SignalGraph::processing_order() const {
         order.push_back(current);
         for (auto& c : connections_) {
             if (c.feedback) continue;
+            // Automation edges DO contribute to topological order — the
+            // source must be processed before the dest so its output
+            // buffer is valid when we sample it for param events.
             if (c.source_node == current) {
                 if (--in_degree[c.dest_node] == 0) queue.push(c.dest_node);
             }
@@ -267,7 +318,7 @@ void SignalGraph::compute_latencies_for_(CompiledGraph& cg,
         bool has_upstream = false;
         for (const auto& c : cg.connections) {
             if (c.dest_node != id) continue;
-            if (c.feedback || c.midi) continue;
+            if (c.feedback || c.midi || c.automation) continue;
             auto src_it = cg.runtime.find(c.source_node);
             if (src_it == cg.runtime.end()) continue;
             max_upstream = std::max(max_upstream, src_it->second.output_latency);
@@ -303,7 +354,7 @@ void SignalGraph::compute_latencies_for_(CompiledGraph& cg,
                 static_cast<size_t>(cg.max_block_size), 0.0f);
             continue;
         }
-        if (c.midi) continue;
+        if (c.midi || c.automation) continue;
 
         int64_t want = dst_it->second.input_latency - src_it->second.output_latency;
         if (want < 0) want = 0;
@@ -417,6 +468,7 @@ void SignalGraph::process(audio::BufferView<float>& output,
             const auto& c = cg->connections[ci];
             if (c.dest_node != id) continue;
             if (c.midi) continue;
+            if (c.automation) continue;  // dispatched in the Plugin branch
             const int dport = static_cast<int>(c.dest_port);
             if (dport < 0 || dport >= static_cast<int>(rt.input_ptrs.size())) continue;
             if (c.source_node == 0) continue;
@@ -477,7 +529,59 @@ void SignalGraph::process(audio::BufferView<float>& output,
                     in_const.data(), in_const.size(),
                     static_cast<std::size_t>(num_samples));
                 rt.midi_out.clear();
+
+                // Build per-block automation event queue. For each
+                // (param_id) target, collect values from every automation
+                // edge and mix per edges' MixMode. Two control points per
+                // block (sample 0 and N-1) so the plugin can interpolate.
                 ParameterEventQueue param_events;
+                {
+                    struct Accum {
+                        float v0 = 0.f, vN = 0.f;
+                        float lo = 0.f, hi = 1.f;
+                        bool has_add = false;
+                    };
+                    std::unordered_map<uint32_t, Accum> acc;
+                    const int last = num_samples - 1;
+                    for (const auto& c : cg->connections) {
+                        if (!c.automation || c.dest_node != id) continue;
+                        auto src_it = cg->runtime.find(c.source_node);
+                        if (src_it == cg->runtime.end()) continue;
+                        const int sport = static_cast<int>(c.source_port);
+                        if (sport < 0 || sport >= (int)src_it->second.output_ptrs.size()) continue;
+                        const float* src = src_it->second.output_ptrs[sport];
+                        const float s0 = std::clamp(src[0], 0.0f, 1.0f);
+                        const float sN = std::clamp(src[last < 0 ? 0 : last], 0.0f, 1.0f);
+                        const float m0 = c.automation_range_lo
+                            + s0 * (c.automation_range_hi - c.automation_range_lo);
+                        const float mN = c.automation_range_lo
+                            + sN * (c.automation_range_hi - c.automation_range_lo);
+                        auto& a = acc[c.automation_param_id];
+                        a.lo = c.automation_range_lo;
+                        a.hi = c.automation_range_hi;
+                        if (c.automation_mix == AutomationMix::Replace) {
+                            a.v0 = m0;
+                            a.vN = mN;
+                        } else {
+                            a.v0 += m0;
+                            a.vN += mN;
+                            a.has_add = true;
+                        }
+                    }
+                    for (auto& [pid, a] : acc) {
+                        float v0 = a.v0, vN = a.vN;
+                        if (a.has_add) {
+                            const float lo = std::min(a.lo, a.hi);
+                            const float hi = std::max(a.lo, a.hi);
+                            v0 = std::clamp(v0, lo, hi);
+                            vN = std::clamp(vN, lo, hi);
+                        }
+                        param_events.push({pid, 0, v0});
+                        if (last > 0) param_events.push({pid, last, vN});
+                    }
+                    param_events.sort();
+                }
+
                 pit->second->process(out_view, in_c, rt.midi_in, rt.midi_out,
                                      param_events, num_samples);
                 break;

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -561,6 +561,112 @@ TEST_CASE("SignalGraph connect_midi routes events through the graph",
     graph.release();
 }
 
+// ── Phase 1E connect_automation test ────────────────────────────────────
+
+namespace {
+// Plugin exposing a single automatable param and recording every
+// ParameterEvent it receives. Audio output is silence.
+class MockAutomatable final : public PluginSlot {
+public:
+    static constexpr uint32_t kParamId = 42;
+
+    const PluginInfo& info() const override { return info_; }
+    bool is_loaded() const override { return true; }
+    bool prepare(double, int) override { return true; }
+    void release() override {}
+
+    void process(pulp::audio::BufferView<float>& out,
+                 const pulp::audio::BufferView<const float>&,
+                 const pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const pulp::host::ParameterEventQueue& pe,
+                 int n) override {
+        for (const auto& e : pe) received_.push_back(e);
+        for (size_t c = 0; c < out.num_channels(); ++c)
+            std::memset(out.channel_ptr(c), 0, sizeof(float) * (size_t)n);
+    }
+
+    std::vector<HostParamInfo> parameters() const override {
+        HostParamInfo p;
+        p.id = kParamId;
+        p.name = "mod";
+        p.min_value = 0.0f;
+        p.max_value = 1.0f;
+        p.default_value = 0.0f;
+        p.flags.automatable = true;
+        return {p};
+    }
+    float get_parameter(uint32_t) const override { return 0.f; }
+    void set_parameter(uint32_t, float) override {}
+    void set_bypass(bool) override {}
+    bool is_bypassed() const override { return false; }
+    std::vector<uint8_t> save_state() const override { return {}; }
+    bool restore_state(const std::vector<uint8_t>&) override { return false; }
+    bool has_editor() const override { return false; }
+    void* create_editor_view() override { return nullptr; }
+    void destroy_editor_view() override {}
+    int latency_samples() const override { return 0; }
+    int tail_samples() const override { return 0; }
+
+    const std::vector<pulp::host::ParameterEvent>& received() const { return received_; }
+
+private:
+    PluginInfo info_{"MockAuto", "", "", "", "", PluginFormat::CLAP};
+    std::vector<pulp::host::ParameterEvent> received_;
+};
+} // namespace
+
+TEST_CASE("SignalGraph connect_automation delivers two-point events per block",
+          "[host][graph][automation]") {
+    SignalGraph graph;
+    auto in_node = graph.add_input_node(1, "in");
+    auto slot    = std::make_unique<MockAutomatable>();
+    auto* slot_ptr = slot.get();
+    auto plug    = graph.add_plugin_node(std::move(slot), 0, 1, "auto");
+
+    // Source is audio port 0 of the AudioInput; target is the plugin's
+    // kParamId with range [0, 1] (unity mapping so we can read values
+    // directly from the input sample).
+    REQUIRE(graph.connect_automation(
+        in_node, 0, plug, MockAutomatable::kParamId, 0.0f, 1.0f));
+    REQUIRE(graph.prepare(48000.0, 64));
+
+    std::vector<float> in_l(64, 0.0f);
+    in_l[0]  = 0.25f;
+    in_l[63] = 0.75f;
+    std::vector<float> out_l(64, 0.0f);
+    const float* in_ptrs[1]  = {in_l.data()};
+    float*       out_ptrs[1] = {out_l.data()};
+    pulp::audio::BufferView<const float> iv(in_ptrs, 1, 64);
+    pulp::audio::BufferView<float>       ov(out_ptrs, 1, 64);
+
+    graph.process(ov, iv, 64);
+
+    const auto& ev = slot_ptr->received();
+    REQUIRE(ev.size() == 2);
+    REQUIRE(ev[0].param_id == MockAutomatable::kParamId);
+    REQUIRE(ev[0].sample_offset == 0);
+    REQUIRE(std::abs(ev[0].value - 0.25f) < 1e-6f);
+    REQUIRE(ev[1].sample_offset == 63);
+    REQUIRE(std::abs(ev[1].value - 0.75f) < 1e-6f);
+}
+
+TEST_CASE("SignalGraph connect_automation rejects duplicate Replace edges",
+          "[host][graph][automation]") {
+    SignalGraph graph;
+    auto in_node = graph.add_input_node(1);
+    auto plug    = graph.add_plugin_node(std::make_unique<MockAutomatable>(), 0, 1);
+    REQUIRE(graph.connect_automation(
+        in_node, 0, plug, MockAutomatable::kParamId, 0.0f, 1.0f));
+    // Second Replace -> reject.
+    REQUIRE_FALSE(graph.connect_automation(
+        in_node, 0, plug, MockAutomatable::kParamId, 0.5f, 1.0f));
+    // Add-mode alongside Replace is allowed.
+    REQUIRE(graph.connect_automation(
+        in_node, 0, plug, MockAutomatable::kParamId, 0.0f, 1.0f,
+        0.0f, pulp::host::AutomationMix::Add));
+}
+
 // ── Real CLAP loader (integration test, skipped when no test plugin built) ──
 
 #include <filesystem>


### PR DESCRIPTION
## Summary
Phase 1 of `planning/signal-graph-followups-plan.md`. Each loader gains real parameter / state / automation handling on top of the Phase 0 host contracts; the SignalGraph gains the headline `connect_automation` API for routing audio-rate sources at plugin parameters.

- **1A VST3** (`16656d1f`): IEditController query (combined or separate-controller path), parameter enumeration with full ParameterInfo flag mapping, plain-domain get/set via normalize/plain conversion, IComponent state save/restore via `VectorStream` IBStream.
- **1B LV2** (`6b64f8a9`): TTL parser extended to discover `lv2:ControlPort` (name/default/min/max), per-port float scratch, parameter API + automation events apply at block start. Atom MIDI + LV2_State_Interface still TODO.
- **1C AU** (`ff2f396e`): `AudioUnitScheduleParameters` per block from ParameterEventQueue gives AUv2 sample-accurate automation. AUv3 async loader still TODO.
- **1D CLAP** (`6b65d09e`): Real `clap_input_events_t` (param_value + midi sorted by time) + `clap_output_events_t` (harvests MIDI → midi_out), `CLAP_EXT_STATE` save/load via vector-backed `clap_ostream`/`clap_istream`. Host-side extensions (`clap_host_params/state/audio_ports/note_ports`) and `CLAP_EXT_AUDIO_PORTS`/`NOTE_PORTS` discovery still TODO.
- **1E connect_automation** (`009646ea`): SignalGraph API. `Connection.automation` flag + `AutomationMix { Replace, Add }`. `connect_automation(src, src_audio_port, dest, param_id, lo, hi, smoothing_ms, mix)` validates dest is Plugin, param exists + automatable + non-readonly, rejects duplicate Replace. Per-block dispatch samples source[0] + source[N-1], maps to plain param domain, sums Add-edges then clamps, pushes to ParameterEventQueue.

Skill updated: `.agents/skills/hosting/SKILL.md`.

## Test plan
- [x] `./build/test/pulp-test-host` — 20 cases / 1005 assertions green locally.
- [x] New `[automation]` test exercises connect_automation end-to-end.
- [ ] CI: mac (local clang has the AUSDK fix from #155), Linux + Windows on Namespace.

## Out-of-scope follow-ups (future PRs)
- VST3 IParameterChanges automation dispatch (uses ParameterEventQueue substrate).
- VST3 IEventList MIDI; IComponentHandler; IConnectionPoint for separate controllers.
- LV2 atom ports for MIDI; LV2_State_Interface; serd/sord vendor for real RDF parser.
- AUv3 async loader; AU MIDI dispatch.
- CLAP host-side extensions; CLAP_EXT_AUDIO_PORTS / NOTE_PORTS discovery; CLAP_EXT_GUI editor.