### PR TITLE
Fix Codex P1 review comments on signal-graph PRs (#143/#153/#158)

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -153,3 +153,16 @@ sample-at-block-start so the offset-(N-1) value wins.
 
 MixMode::Replace is the default; second Replace edge to the same
 (node, param) is rejected. MixMode::Add sums then clamps.
+
+## Phase 1 P1 follow-ups (PR #159)
+
+Four bugs caught in Codex review of the Phase 0/1 series:
+
+- `connect_automation` rejects cycles via `would_create_cycle` (automation
+  edges contribute to topo order so back-edges are invalid).
+- `Vst3Slot` dtor only calls `terminate()` once on combined
+  IComponent + IEditController objects (FUnknown-pointer equality check).
+- `SignalGraph::process()` returns immediately on `num_samples <= 0`
+  rather than memset'ing with a wrapped size_t.
+- MidiInput nodes' `midi_out` is drained at the END of `process()`, not
+  the start. Hosts call `inject_midi()` before each `process()` to refill.

--- a/core/host/src/plugin_slot_vst3.cpp
+++ b/core/host/src/plugin_slot_vst3.cpp
@@ -99,11 +99,21 @@ public:
 
     ~Vst3Slot() override {
         release();
-        if (controller_) {
+        // Combined plugins implement IComponent + IEditController on the
+        // same object — terminating both pointers would call IPluginBase
+        // ::terminate() twice. Detect by raw-pointer equality on the
+        // FUnknown side and only terminate once.
+        const bool combined = (controller_ != nullptr
+            && static_cast<FUnknown*>(controller_) == static_cast<FUnknown*>(component_));
+        if (controller_ && !combined) {
             controller_->terminate();
             controller_->release();
-            controller_ = nullptr;
+        } else if (controller_) {
+            // Combined: just drop the extra reference; component branch
+            // handles terminate.
+            controller_->release();
         }
+        controller_ = nullptr;
         if (component_) {
             component_->terminate();
             component_->release();

--- a/core/host/src/signal_graph.cpp
+++ b/core/host/src/signal_graph.cpp
@@ -148,6 +148,12 @@ bool SignalGraph::connect_automation(NodeId src, PortIndex src_audio_port,
     if (dst_n->type != NodeType::Plugin || !dst_n->plugin) return false;
     if ((int)src_audio_port >= src_n->num_output_ports) return false;
 
+    // Reject automation edges that would introduce a cycle. Automation
+    // edges contribute to topological order (the source must be processed
+    // before the dest), so a back-edge here would make the graph
+    // un-orderable. Use the same has_path check as connect().
+    if (would_create_cycle(src, dest)) return false;
+
     // Parameter must exist, be automatable, and not read-only.
     bool ok_param = false;
     for (const auto& pi : dst_n->plugin->parameters()) {
@@ -428,7 +434,10 @@ void SignalGraph::process(audio::BufferView<float>& output,
                           const audio::BufferView<const float>& input,
                           int num_samples) {
     auto cg = std::atomic_load_explicit(&live_, std::memory_order_acquire);
-    if (!cg || num_samples <= 0 || num_samples > cg->max_block_size) {
+    // Negative or zero block sizes mean "nothing to do" — return without
+    // touching output (a memset with size_t(negative) wraps to a huge size).
+    if (num_samples <= 0) return;
+    if (!cg || num_samples > cg->max_block_size) {
         for (std::size_t c = 0; c < output.num_channels(); ++c)
             std::memset(output.channel_ptr(c), 0,
                         sizeof(float) * static_cast<size_t>(num_samples));
@@ -629,6 +638,16 @@ void SignalGraph::process(audio::BufferView<float>& output,
         const float* src = src_rt.output_ptrs[sport];
         std::memcpy(dl.feedback_prev.data(), src,
                     sizeof(float) * static_cast<size_t>(num_samples));
+    }
+
+    // Drain MidiInput nodes' midi_out so events injected for THIS block
+    // don't get re-consumed next block. inject_midi() runs before the
+    // next process() call to refill them.
+    for (auto& [nid, rt] : cg->runtime) {
+        auto sit = cg->shapes.find(nid);
+        if (sit != cg->shapes.end() && sit->second.type == NodeType::MidiInput) {
+            rt.midi_out.clear();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Addresses the four P1-flagged Codex review comments accumulated across the SignalGraph PR series:

1. **PR #158** — `connect_automation` rejects cycles via `would_create_cycle`. Automation edges contribute to topo order, so back-edges break ordering.
2. **PR #158** — `Vst3Slot` dtor no longer double-`terminate()`s combined `IComponent` + `IEditController` objects. Detect by FUnknown-pointer equality.
3. **PR #153** — `SignalGraph::process()` returns immediately on `num_samples <= 0` instead of falling through to a memset whose size_t cast wraps catastrophically.
4. **PR #143** — `MidiInput` `midi_out` is drained at the END of `process()` so events injected for one block don't leak into the next when the host doesn't re-inject.

## Test plan
- [x] 20 host cases / 1005 assertions still green locally
- [ ] CI green on mac / Linux / Windows