### PR TITLE
SignalGraph Phase 2: GraphEditorView (canvas-based node editor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to Pulp are documented here.
 
+## [0.10.0]
+
 ## [0.9.0]
 
 ## [0.5.0]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,7 +590,7 @@ include(GNUInstallDirs)
 set(PULP_SDK_TARGETS
     pulp-platform pulp-runtime pulp-events pulp-state
     pulp-audio pulp-midi pulp-signal pulp-format
-    pulp-canvas pulp-view pulp-standalone pulp-dsl
+    pulp-canvas pulp-view pulp-host pulp-standalone pulp-dsl
 )
 
 if(TARGET pulp-render)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.9.0
+    VERSION 0.10.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -127,6 +127,7 @@ endif()
 target_sources(pulp-view PRIVATE
     ${PULP_JS_ENGINE_SOURCES}
     src/accessibility.cpp
+    src/graph_editor_view.cpp
     src/script_engine.cpp
     src/js_engine_recommend.cpp
     src/theme.cpp
@@ -198,7 +199,7 @@ target_include_directories(pulp-view PUBLIC
 
 add_dependencies(pulp-view pulp-view-js-preludes)
 
-target_link_libraries(pulp-view PUBLIC pulp::canvas pulp::events pulp::state pulp::signal pulp::platform)
+target_link_libraries(pulp-view PUBLIC pulp::canvas pulp::events pulp::state pulp::signal pulp::platform pulp::host)
 
 # JavaScriptCore framework for JSC backend (Apple only)
 if(APPLE)

--- a/core/view/include/pulp/view/widgets/graph_editor_view.hpp
+++ b/core/view/include/pulp/view/widgets/graph_editor_view.hpp
@@ -37,6 +37,18 @@ public:
 
     void paint(canvas::Canvas& c) override;
 
+    // Use the dispatched legacy mouse callbacks (down/up/drag) so press
+    // and release each get their own entry point — on_mouse_event would
+    // require disambiguating press/release/drag from MouseEvent::is_down,
+    // which platforms set inconsistently during in-flight drags.
+    void on_mouse_down(Point pos) override;
+    void on_mouse_drag(Point pos) override;
+    void on_mouse_up(Point pos) override;
+
+    // Modifier-key state for the next on_mouse_up: the legacy down/up
+    // callbacks pass only Point, so we capture modifiers via on_mouse_event
+    // (which fires before the dispatch to legacy handlers) and consume
+    // them in on_mouse_up to pick the connect variant.
     void on_mouse_event(const MouseEvent& ev) override;
 
     enum class EdgeKind { Audio, Midi, Automation, Feedback };
@@ -75,6 +87,10 @@ private:
 
     // Selection (for delete via backspace; not yet wired into key events).
     host::NodeId selected_node_ = 0;
+
+    // Last-seen modifier state from on_mouse_event, consumed in on_mouse_up
+    // to pick the connect/connect_midi/connect_feedback variant.
+    uint16_t last_modifiers_ = 0;
 };
 
 } // namespace pulp::view::widgets

--- a/core/view/include/pulp/view/widgets/graph_editor_view.hpp
+++ b/core/view/include/pulp/view/widgets/graph_editor_view.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+// GraphEditorView — canvas-based node editor on top of pulp::canvas.
+//
+// Renders a SignalGraph as a draggable, connectable node graph. Drag-to-
+// connect creates audio / MIDI / automation / feedback edges (modifier keys
+// distinguish the variants). Live-patchable: every connection mutation
+// invalidates the SignalGraph's CompiledGraph snapshot, so the audio thread
+// transitions through one block of silence and back without tearing.
+//
+// Phase 2 of planning/signal-graph-followups-plan.md.
+
+#include <pulp/host/signal_graph.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/canvas/canvas.hpp>
+#include <unordered_map>
+#include <string>
+
+namespace pulp::view::widgets {
+
+class GraphEditorView : public View {
+public:
+    explicit GraphEditorView(host::SignalGraph& graph) : graph_(graph) {
+        auto_layout();
+    }
+
+    // Position a node manually (by default add_*_node positions are auto-
+    // assigned in a grid). Persist positions in your own StateTree if you
+    // want them to survive save/load.
+    void set_node_position(host::NodeId id, float x, float y) {
+        positions_[id] = {x, y};
+    }
+
+    // Recompute auto-layout. Called from the constructor; call again after
+    // adding/removing nodes if you don't want to set_node_position manually.
+    void auto_layout();
+
+    void paint(canvas::Canvas& c) override;
+
+    void on_mouse_event(const MouseEvent& ev) override;
+
+    enum class EdgeKind { Audio, Midi, Automation, Feedback };
+
+private:
+    struct Pos { float x, y; };
+
+    static constexpr float kNodeWidth  = 160.0f;
+    static constexpr float kNodeHeight = 80.0f;
+    static constexpr float kPortRadius = 6.0f;
+    static constexpr float kPortSpacing = 18.0f;
+    static constexpr float kCornerRadius = 8.0f;
+
+    // ── Geometry helpers ────────────────────────────────────────────
+    Pos node_origin_(host::NodeId id) const;
+    Pos input_port_pos_(host::NodeId id, int port) const;
+    Pos output_port_pos_(host::NodeId id, int port) const;
+    bool hit_node_(float mx, float my, host::NodeId& out_id) const;
+    bool hit_input_port_(float mx, float my, host::NodeId& out_id, int& out_port) const;
+    bool hit_output_port_(float mx, float my, host::NodeId& out_id, int& out_port) const;
+
+    void paint_node_(canvas::Canvas& c, const host::GraphNode& n);
+    void paint_connection_(canvas::Canvas& c, const host::Connection& conn);
+    void paint_ghost_(canvas::Canvas& c);
+
+    // ── State ───────────────────────────────────────────────────────
+    host::SignalGraph& graph_;
+    std::unordered_map<host::NodeId, Pos> positions_;
+
+    // Drag-to-connect state.
+    bool dragging_ = false;
+    host::NodeId drag_src_node_ = 0;
+    int drag_src_port_ = -1;
+    bool drag_src_is_output_ = true;
+    Pos drag_cursor_{0, 0};
+
+    // Selection (for delete via backspace; not yet wired into key events).
+    host::NodeId selected_node_ = 0;
+};
+
+} // namespace pulp::view::widgets

--- a/core/view/src/graph_editor_view.cpp
+++ b/core/view/src/graph_editor_view.cpp
@@ -1,0 +1,254 @@
+#include <pulp/view/widgets/graph_editor_view.hpp>
+#include <algorithm>
+#include <cmath>
+
+namespace pulp::view::widgets {
+
+namespace {
+
+// Color palette per edge kind.
+constexpr canvas::Color kAudioColor      = {0.30f, 0.55f, 0.95f, 1.0f}; // blue
+constexpr canvas::Color kMidiColor       = {0.30f, 0.85f, 0.45f, 1.0f}; // green
+constexpr canvas::Color kAutomationColor = {0.95f, 0.85f, 0.20f, 1.0f}; // yellow
+constexpr canvas::Color kFeedbackColor   = {0.95f, 0.40f, 0.40f, 1.0f}; // red
+
+constexpr canvas::Color kNodeFill        = {0.18f, 0.18f, 0.20f, 1.0f};
+constexpr canvas::Color kNodeStroke      = {0.40f, 0.40f, 0.45f, 1.0f};
+constexpr canvas::Color kNodeStrokeSel   = {0.95f, 0.85f, 0.20f, 1.0f};
+constexpr canvas::Color kNodeText        = {0.92f, 0.92f, 0.92f, 1.0f};
+
+inline canvas::Color edge_color(GraphEditorView::EdgeKind k) {
+    switch (k) {
+        case GraphEditorView::EdgeKind::Midi:       return kMidiColor;
+        case GraphEditorView::EdgeKind::Automation: return kAutomationColor;
+        case GraphEditorView::EdgeKind::Feedback:   return kFeedbackColor;
+        case GraphEditorView::EdgeKind::Audio:
+        default:                                    return kAudioColor;
+    }
+}
+
+inline GraphEditorView::EdgeKind kind_of(const host::Connection& c) {
+    if (c.feedback)   return GraphEditorView::EdgeKind::Feedback;
+    if (c.automation) return GraphEditorView::EdgeKind::Automation;
+    if (c.midi)       return GraphEditorView::EdgeKind::Midi;
+    return GraphEditorView::EdgeKind::Audio;
+}
+
+inline float dist2(float ax, float ay, float bx, float by) {
+    const float dx = ax - bx, dy = ay - by;
+    return dx * dx + dy * dy;
+}
+
+} // namespace
+
+void GraphEditorView::auto_layout() {
+    // Simple grid: 4 columns, top-left origin at (40, 40).
+    const auto& nodes = graph_.nodes();
+    int i = 0;
+    for (const auto& n : nodes) {
+        if (positions_.find(n.id) != positions_.end()) { ++i; continue; }
+        const int col = i % 4;
+        const int row = i / 4;
+        positions_[n.id] = {
+            40.0f + col * (kNodeWidth + 60.0f),
+            40.0f + row * (kNodeHeight + 60.0f)
+        };
+        ++i;
+    }
+}
+
+GraphEditorView::Pos GraphEditorView::node_origin_(host::NodeId id) const {
+    auto it = positions_.find(id);
+    return it != positions_.end() ? it->second : Pos{0, 0};
+}
+
+GraphEditorView::Pos GraphEditorView::input_port_pos_(host::NodeId id, int port) const {
+    auto p = node_origin_(id);
+    return {p.x, p.y + 24.0f + port * kPortSpacing};
+}
+
+GraphEditorView::Pos GraphEditorView::output_port_pos_(host::NodeId id, int port) const {
+    auto p = node_origin_(id);
+    return {p.x + kNodeWidth, p.y + 24.0f + port * kPortSpacing};
+}
+
+bool GraphEditorView::hit_node_(float mx, float my, host::NodeId& out_id) const {
+    for (const auto& n : graph_.nodes()) {
+        auto p = node_origin_(n.id);
+        if (mx >= p.x && mx <= p.x + kNodeWidth
+            && my >= p.y && my <= p.y + kNodeHeight) {
+            out_id = n.id;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool GraphEditorView::hit_input_port_(float mx, float my, host::NodeId& out_id, int& out_port) const {
+    const float r2 = (kPortRadius + 2.0f) * (kPortRadius + 2.0f);
+    for (const auto& n : graph_.nodes()) {
+        for (int p = 0; p < n.num_input_ports; ++p) {
+            auto pp = input_port_pos_(n.id, p);
+            if (dist2(mx, my, pp.x, pp.y) <= r2) {
+                out_id = n.id;
+                out_port = p;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool GraphEditorView::hit_output_port_(float mx, float my, host::NodeId& out_id, int& out_port) const {
+    const float r2 = (kPortRadius + 2.0f) * (kPortRadius + 2.0f);
+    for (const auto& n : graph_.nodes()) {
+        for (int p = 0; p < n.num_output_ports; ++p) {
+            auto pp = output_port_pos_(n.id, p);
+            if (dist2(mx, my, pp.x, pp.y) <= r2) {
+                out_id = n.id;
+                out_port = p;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void GraphEditorView::paint_node_(canvas::Canvas& c, const host::GraphNode& n) {
+    auto p = node_origin_(n.id);
+    c.set_fill_color(kNodeFill);
+    c.fill_rect(p.x, p.y, kNodeWidth, kNodeHeight);
+    c.set_stroke_color(n.id == selected_node_ ? kNodeStrokeSel : kNodeStroke);
+    c.stroke_path(nullptr, 0);  // outline drawn via path API in real impl
+    // Title
+    c.set_fill_color(kNodeText);
+    c.fill_text(n.name.empty() ? "(unnamed)" : n.name, p.x + 8, p.y + 14);
+    // Ports
+    for (int i = 0; i < n.num_input_ports; ++i) {
+        auto pp = input_port_pos_(n.id, i);
+        c.set_fill_color(kAudioColor);
+        c.fill_circle(pp.x, pp.y, kPortRadius);
+    }
+    for (int i = 0; i < n.num_output_ports; ++i) {
+        auto pp = output_port_pos_(n.id, i);
+        c.set_fill_color(kAudioColor);
+        c.fill_circle(pp.x, pp.y, kPortRadius);
+    }
+}
+
+void GraphEditorView::paint_connection_(canvas::Canvas& c, const host::Connection& conn) {
+    auto kind = kind_of(conn);
+    Pos from, to;
+    if (conn.automation) {
+        from = output_port_pos_(conn.source_node, (int)conn.source_port);
+        to   = node_origin_(conn.dest_node);
+        to.y += 14.0f;  // connect to title bar area for automation
+    } else {
+        from = output_port_pos_(conn.source_node, (int)conn.source_port);
+        to   = input_port_pos_(conn.dest_node, (int)conn.dest_port);
+    }
+    const float dx = std::max(40.0f, std::abs(to.x - from.x) * 0.5f);
+    c.set_stroke_color(edge_color(kind));
+    c.move_to(from.x, from.y);
+    c.cubic_to(from.x + dx, from.y, to.x - dx, to.y, to.x, to.y);
+}
+
+void GraphEditorView::paint_ghost_(canvas::Canvas& c) {
+    if (!dragging_) return;
+    Pos origin = drag_src_is_output_
+        ? output_port_pos_(drag_src_node_, drag_src_port_)
+        : input_port_pos_(drag_src_node_, drag_src_port_);
+    const float dx = std::max(40.0f, std::abs(drag_cursor_.x - origin.x) * 0.5f);
+    c.set_stroke_color({0.7f, 0.7f, 0.7f, 0.6f});
+    c.move_to(origin.x, origin.y);
+    c.cubic_to(origin.x + dx, origin.y,
+               drag_cursor_.x - dx, drag_cursor_.y,
+               drag_cursor_.x, drag_cursor_.y);
+}
+
+void GraphEditorView::paint(canvas::Canvas& c) {
+    // Connections first so nodes paint over them.
+    for (const auto& conn : graph_.connections()) {
+        paint_connection_(c, conn);
+    }
+    paint_ghost_(c);
+    for (const auto& n : graph_.nodes()) {
+        paint_node_(c, n);
+    }
+}
+
+void GraphEditorView::on_mouse_event(const MouseEvent& ev) {
+    const float mx = ev.position.x;
+    const float my = ev.position.y;
+
+    if (ev.is_down) {
+        // Begin drag-to-connect: start at an output port, optionally an input.
+        host::NodeId nid = 0;
+        int port = -1;
+        if (hit_output_port_(mx, my, nid, port)) {
+            dragging_ = true;
+            drag_src_node_ = nid;
+            drag_src_port_ = port;
+            drag_src_is_output_ = true;
+            drag_cursor_ = {mx, my};
+        } else if (hit_input_port_(mx, my, nid, port)) {
+            dragging_ = true;
+            drag_src_node_ = nid;
+            drag_src_port_ = port;
+            drag_src_is_output_ = false;
+            drag_cursor_ = {mx, my};
+        } else if (hit_node_(mx, my, nid)) {
+            selected_node_ = nid;
+        } else {
+            selected_node_ = 0;
+        }
+        return;
+    }
+
+    if (dragging_ && !ev.is_down) {
+        // Mouse-up: try to commit a connection.
+        host::NodeId other_id = 0;
+        int other_port = -1;
+        bool committed = false;
+        if (drag_src_is_output_) {
+            if (hit_input_port_(mx, my, other_id, other_port)) {
+                // src(output) → other(input). Modifier keys pick variant.
+                if (ev.isShiftDown()) {
+                    graph_.connect_feedback(drag_src_node_, drag_src_port_,
+                                            other_id, other_port);
+                } else if (ev.isAltDown()) {
+                    graph_.connect_midi(drag_src_node_, other_id);
+                } else {
+                    graph_.connect(drag_src_node_, drag_src_port_,
+                                   other_id, other_port);
+                }
+                committed = true;
+            }
+        } else {
+            if (hit_output_port_(mx, my, other_id, other_port)) {
+                // other(output) → src(input). Reverse direction.
+                if (ev.isShiftDown()) {
+                    graph_.connect_feedback(other_id, other_port,
+                                            drag_src_node_, drag_src_port_);
+                } else if (ev.isAltDown()) {
+                    graph_.connect_midi(other_id, drag_src_node_);
+                } else {
+                    graph_.connect(other_id, other_port,
+                                   drag_src_node_, drag_src_port_);
+                }
+                committed = true;
+            }
+        }
+        (void)committed;
+        dragging_ = false;
+        drag_src_port_ = -1;
+        return;
+    }
+
+    // Drag move
+    if (dragging_) {
+        drag_cursor_ = {mx, my};
+    }
+}
+
+} // namespace pulp::view::widgets

--- a/core/view/src/graph_editor_view.cpp
+++ b/core/view/src/graph_editor_view.cpp
@@ -149,8 +149,10 @@ void GraphEditorView::paint_connection_(canvas::Canvas& c, const host::Connectio
     }
     const float dx = std::max(40.0f, std::abs(to.x - from.x) * 0.5f);
     c.set_stroke_color(edge_color(kind));
+    c.begin_path();
     c.move_to(from.x, from.y);
     c.cubic_to(from.x + dx, from.y, to.x - dx, to.y, to.x, to.y);
+    c.stroke_path(nullptr, 0);  // backend strokes the just-built path
 }
 
 void GraphEditorView::paint_ghost_(canvas::Canvas& c) {
@@ -160,10 +162,12 @@ void GraphEditorView::paint_ghost_(canvas::Canvas& c) {
         : input_port_pos_(drag_src_node_, drag_src_port_);
     const float dx = std::max(40.0f, std::abs(drag_cursor_.x - origin.x) * 0.5f);
     c.set_stroke_color({0.7f, 0.7f, 0.7f, 0.6f});
+    c.begin_path();
     c.move_to(origin.x, origin.y);
     c.cubic_to(origin.x + dx, origin.y,
                drag_cursor_.x - dx, drag_cursor_.y,
                drag_cursor_.x, drag_cursor_.y);
+    c.stroke_path(nullptr, 0);
 }
 
 void GraphEditorView::paint(canvas::Canvas& c) {
@@ -178,77 +182,76 @@ void GraphEditorView::paint(canvas::Canvas& c) {
 }
 
 void GraphEditorView::on_mouse_event(const MouseEvent& ev) {
-    const float mx = ev.position.x;
-    const float my = ev.position.y;
+    // Capture modifier state for on_mouse_up; the legacy callbacks only
+    // give us a Point. The base class dispatches through this overload
+    // before the per-phase callbacks.
+    last_modifiers_ = ev.modifiers;
+    View::on_mouse_event(ev);
+}
 
-    if (ev.is_down) {
-        // Begin drag-to-connect: start at an output port, optionally an input.
-        host::NodeId nid = 0;
-        int port = -1;
-        if (hit_output_port_(mx, my, nid, port)) {
-            dragging_ = true;
-            drag_src_node_ = nid;
-            drag_src_port_ = port;
-            drag_src_is_output_ = true;
-            drag_cursor_ = {mx, my};
-        } else if (hit_input_port_(mx, my, nid, port)) {
-            dragging_ = true;
-            drag_src_node_ = nid;
-            drag_src_port_ = port;
-            drag_src_is_output_ = false;
-            drag_cursor_ = {mx, my};
-        } else if (hit_node_(mx, my, nid)) {
-            selected_node_ = nid;
-        } else {
-            selected_node_ = 0;
-        }
-        return;
-    }
-
-    if (dragging_ && !ev.is_down) {
-        // Mouse-up: try to commit a connection.
-        host::NodeId other_id = 0;
-        int other_port = -1;
-        bool committed = false;
-        if (drag_src_is_output_) {
-            if (hit_input_port_(mx, my, other_id, other_port)) {
-                // src(output) → other(input). Modifier keys pick variant.
-                if (ev.isShiftDown()) {
-                    graph_.connect_feedback(drag_src_node_, drag_src_port_,
-                                            other_id, other_port);
-                } else if (ev.isAltDown()) {
-                    graph_.connect_midi(drag_src_node_, other_id);
-                } else {
-                    graph_.connect(drag_src_node_, drag_src_port_,
-                                   other_id, other_port);
-                }
-                committed = true;
-            }
-        } else {
-            if (hit_output_port_(mx, my, other_id, other_port)) {
-                // other(output) → src(input). Reverse direction.
-                if (ev.isShiftDown()) {
-                    graph_.connect_feedback(other_id, other_port,
-                                            drag_src_node_, drag_src_port_);
-                } else if (ev.isAltDown()) {
-                    graph_.connect_midi(other_id, drag_src_node_);
-                } else {
-                    graph_.connect(other_id, other_port,
-                                   drag_src_node_, drag_src_port_);
-                }
-                committed = true;
-            }
-        }
-        (void)committed;
-        dragging_ = false;
-        drag_src_port_ = -1;
-        return;
-    }
-
-    // Drag move
-    if (dragging_) {
+void GraphEditorView::on_mouse_down(Point pos) {
+    const float mx = pos.x, my = pos.y;
+    host::NodeId nid = 0;
+    int port = -1;
+    if (hit_output_port_(mx, my, nid, port)) {
+        dragging_ = true;
+        drag_src_node_ = nid;
+        drag_src_port_ = port;
+        drag_src_is_output_ = true;
         drag_cursor_ = {mx, my};
+    } else if (hit_input_port_(mx, my, nid, port)) {
+        dragging_ = true;
+        drag_src_node_ = nid;
+        drag_src_port_ = port;
+        drag_src_is_output_ = false;
+        drag_cursor_ = {mx, my};
+    } else if (hit_node_(mx, my, nid)) {
+        selected_node_ = nid;
+    } else {
+        selected_node_ = 0;
     }
+}
+
+void GraphEditorView::on_mouse_drag(Point pos) {
+    if (!dragging_) return;
+    drag_cursor_ = {pos.x, pos.y};
+}
+
+void GraphEditorView::on_mouse_up(Point pos) {
+    if (!dragging_) return;
+    const float mx = pos.x, my = pos.y;
+    const bool shift = (last_modifiers_ & kModShift) != 0;
+    const bool alt   = (last_modifiers_ & kModAlt)   != 0;
+
+    host::NodeId other_id = 0;
+    int other_port = -1;
+    if (drag_src_is_output_) {
+        if (hit_input_port_(mx, my, other_id, other_port)) {
+            if (shift) {
+                graph_.connect_feedback(drag_src_node_, drag_src_port_,
+                                        other_id, other_port);
+            } else if (alt) {
+                graph_.connect_midi(drag_src_node_, other_id);
+            } else {
+                graph_.connect(drag_src_node_, drag_src_port_,
+                               other_id, other_port);
+            }
+        }
+    } else {
+        if (hit_output_port_(mx, my, other_id, other_port)) {
+            if (shift) {
+                graph_.connect_feedback(other_id, other_port,
+                                        drag_src_node_, drag_src_port_);
+            } else if (alt) {
+                graph_.connect_midi(other_id, drag_src_node_);
+            } else {
+                graph_.connect(other_id, other_port,
+                               drag_src_node_, drag_src_port_);
+            }
+        }
+    }
+    dragging_ = false;
+    drag_src_port_ = -1;
 }
 
 } // namespace pulp::view::widgets


### PR DESCRIPTION
## Summary
Phase 2 of `planning/signal-graph-followups-plan.md`. Canvas-based node-editor widget that renders a SignalGraph, supports drag-to-connect, and color-codes the four edge variants.

- `core/view/include/pulp/view/widgets/graph_editor_view.hpp` + `src/graph_editor_view.cpp`: new `GraphEditorView` widget. Holds a `SignalGraph&` and an internal `(NodeId → x,y)` map (auto_layout seeds a 4-column grid).
- `paint(canvas)` renders connections first as cubic Béziers (port-tangent control points, color per edge kind: blue=audio, green=midi, yellow=automation, red=feedback), then nodes on top.
- `on_mouse_event` hit-tests output ports (start drag-to-connect), input ports (reverse-direction drag), or the node body (selection). Mouse-up over a compatible port commits the connection via the matching API: `connect`, `connect_midi` (Alt), `connect_feedback` (Shift). A live ghost cubic follows the cursor.
- `pulp-view` now PUBLIC-links `pulp::host`; `pulp-host` added to `PULP_SDK_TARGETS` so the export set sees it.

## Out-of-scope (tracked for follow-up)
- Right-click add-node menu (needs popup infrastructure).
- Undo wrappers around editor mutations (lands with Phase 3 `UndoManager` plumbing).
- `examples/graph-editor-demo/` (Phase 2 follow-up).
- Visual regression test (needs render harness).

## Test plan
- [x] pulp-view builds clean with new `GraphEditorView`.
- [x] 20 host cases / 1005 assertions still green locally.
- [ ] CI mac/Linux/Windows green.