### PR TITLE
fix(host): dlfcn.h Windows shim — unblock release-cli builds (row 17)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.10.0
+    VERSION 0.10.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/include/pulp/host/dl_shim.hpp
+++ b/core/host/include/pulp/host/dl_shim.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+// Dynamic-loader shim for Windows/POSIX parity.
+//
+// The host plugin loaders (`plugin_slot_{clap,vst3,lv2}.cpp`,
+// `scanner_clap.cpp`) use `<dlfcn.h>` to dlopen plugin bundles. Windows
+// does not ship `<dlfcn.h>`; the release-cli build broke on every v0.4.0
+// and later tag because of that. This header papers over the split by
+// exposing a `dlopen` / `dlsym` / `dlclose` / `dlerror` surface that
+// forwards to the platform-native loader.
+//
+// Scope is deliberately minimal: only the symbols the host loaders
+// actually call. If callers need more of POSIX `<dlfcn.h>`, extend the
+// Windows branch rather than reaching for a third-party port.
+
+#if defined(_WIN32)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
+// POSIX flag constants — no-ops on Windows, kept so call sites don't
+// need #ifdefs at every use.
+#ifndef RTLD_LAZY
+#define RTLD_LAZY 0
+#endif
+#ifndef RTLD_LOCAL
+#define RTLD_LOCAL 0
+#endif
+#ifndef RTLD_NOW
+#define RTLD_NOW 0
+#endif
+
+namespace pulp::host::detail {
+
+inline void* dl_open(const char* path, int /*flags*/) {
+    // LoadLibraryA returns NULL on failure. Caller inspects return value.
+    return reinterpret_cast<void*>(::LoadLibraryA(path));
+}
+
+inline void* dl_sym(void* handle, const char* name) {
+    return reinterpret_cast<void*>(
+        ::GetProcAddress(reinterpret_cast<HMODULE>(handle), name));
+}
+
+inline int dl_close(void* handle) {
+    // POSIX dlclose returns 0 on success; Windows FreeLibrary returns
+    // non-zero on success. Normalize to POSIX.
+    return ::FreeLibrary(reinterpret_cast<HMODULE>(handle)) ? 0 : -1;
+}
+
+inline const char* dl_error() {
+    // Windows does not have a dlerror equivalent that returns a stable
+    // thread-local string. Call sites already log the path; this stub
+    // lets them keep compiling. Returning nullptr is safe — existing
+    // call sites already guard with `err ? err : "unknown"`.
+    return nullptr;
+}
+
+} // namespace pulp::host::detail
+
+// POSIX-style entry points in the global namespace so call sites don't
+// change.
+inline void* dlopen(const char* path, int flags) {
+    return ::pulp::host::detail::dl_open(path, flags);
+}
+inline void* dlsym(void* handle, const char* name) {
+    return ::pulp::host::detail::dl_sym(handle, name);
+}
+inline int dlclose(void* handle) {
+    return ::pulp::host::detail::dl_close(handle);
+}
+inline const char* dlerror() {
+    return ::pulp::host::detail::dl_error();
+}
+
+#else // !_WIN32
+
+#include <dlfcn.h>
+
+#endif // _WIN32

--- a/core/host/src/plugin_slot_clap.cpp
+++ b/core/host/src/plugin_slot_clap.cpp
@@ -10,7 +10,7 @@
 
 #include <clap/clap.h>
 
-#include <dlfcn.h>
+#include <pulp/host/dl_shim.hpp>
 #include <algorithm>
 #include <atomic>
 #include <cstring>

--- a/core/host/src/plugin_slot_lv2.cpp
+++ b/core/host/src/plugin_slot_lv2.cpp
@@ -22,7 +22,7 @@
 
 #include <lv2/core/lv2.h>
 
-#include <dlfcn.h>
+#include <pulp/host/dl_shim.hpp>
 #include <algorithm>
 #include <atomic>
 #include <cstring>

--- a/core/host/src/plugin_slot_vst3.cpp
+++ b/core/host/src/plugin_slot_vst3.cpp
@@ -22,7 +22,7 @@
 #include <pluginterfaces/vst/ivstparameterchanges.h>
 #include <pluginterfaces/base/ibstream.h>
 
-#include <dlfcn.h>
+#include <pulp/host/dl_shim.hpp>
 #include <atomic>
 #include <cstring>
 #include <filesystem>

--- a/core/host/src/scanner_clap.cpp
+++ b/core/host/src/scanner_clap.cpp
@@ -13,7 +13,7 @@
 
 #include <clap/clap.h>
 
-#include <dlfcn.h>
+#include <pulp/host/dl_shim.hpp>
 #include <cstring>
 #include <filesystem>
 #include <vector>


### PR DESCRIPTION
## Summary

**Release-pipeline hotfix.** \`release-cli.yml\` has been broken since v0.3.0 (April 11). Tags v0.4.0 through v0.10.0 all pushed; **no GitHub Release published** for any of them. \`pulp install --version latest\` is stuck on v0.3.0.

### Root cause

\`core/host/src/{plugin_slot_clap, plugin_slot_vst3, plugin_slot_lv2, scanner_clap}.cpp\` unconditionally \`#include <dlfcn.h>\`. Windows has no \`<dlfcn.h>\`. \`build.yml\` on the Namespace Windows runner doesn't build this TU configuration, so the split only surfaces on tag-triggered release builds.

### Fix

New \`core/host/include/pulp/host/dl_shim.hpp\`:
- On POSIX: forwards to \`<dlfcn.h>\` — zero behavior change.
- On Windows: defines \`dlopen/dlsym/dlclose/dlerror\` backed by \`LoadLibraryA\`/\`GetProcAddress\`/\`FreeLibrary\`; provides no-op \`RTLD_LAZY\` / \`RTLD_LOCAL\` macros so call sites stay identical.

All four loader TUs swap \`#include <dlfcn.h>\` for \`#include <pulp/host/dl_shim.hpp>\`. No other call-site changes.

### Version bump

SDK 0.10.0 → 0.10.1 (patch). Once merged, \`auto-release.yml\` tags v0.10.1 and \`release-cli.yml\` publishes — the first working binary release since April 11.

## Test plan

- [x] macOS local — \`cmake --build build --target pulp-host pulp-test-host pulp-test-graph-serializer\` — all targets link
- [x] \`pulp-test-host\` — 1019 assertions / 21 cases pass
- [x] \`pulp-test-graph-serializer\` — 34 assertions / 6 cases pass
- [ ] Shipyard green on Linux / Windows (**primary interest** — Windows is the broken platform)
- [ ] \`release-cli.yml\` on the resulting v0.10.1 tag — verify binaries publish

Closes row 17 of \`planning/signalgraph-and-bridge-followups-plan.md\`.

Version-Bump: sdk=patch reason="release-pipeline hotfix: Windows dlfcn shim"