### PR TITLE
Production-readiness plan + docs-drift fixes (workstream 08)

### DIFF
--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -171,7 +171,18 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | XYPad, WaveformView, SpectrumView | usable | [view](modules.md#view) | |
 | ImageView | usable | [view](modules.md#view) | Placeholder rendering |
 | TreeView, Tooltip, Panel, Icon | usable | [view](modules.md#view) | |
+| SpectrogramView (scrolling STFT) | usable | [view](modules.md#view) | |
+| MultiMeter, CorrelationMeter | usable | [view](modules.md#view) | |
+| PresetBrowser (search, categories, nav) | usable | [view](modules.md#view) | |
+| MidiKeyboard (display + interaction) | usable | [view](modules.md#view) | |
+| WaveformEditor (selection, zoom, regions) | usable | [view](modules.md#view) | |
+| EqCurveView (draggable band handles) | usable | [view](modules.md#view) | |
+| FileBrowser, FileDropZone | usable | [view](modules.md#view) | |
+| GraphEditorView (canvas-based node editor) | usable | [view](modules.md#view) | SignalGraph UI |
+| ConcertinaPanel, SplitView, Breadcrumb, Toolbar | usable | [view](modules.md#view) | |
+| ColorPicker, Lasso, PropertyList, CodeEditor | usable | [view](modules.md#view) | |
 | CanvasWidget (25 draw commands) | usable | [view](modules.md#view) | [custom-rendering](../guides/custom-rendering.md) |
+| ModulationMatrix, A/B compare, sortable TableView | planned | [view](modules.md#view) | Production-readiness workstream 07 |
 
 ### Web-Compat Layer
 
@@ -196,6 +207,10 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | Cursor management (7 styles) | usable | macOS | NSCursor in mouseMoved |
 | Tab focus traversal | usable | all | Tab/Shift+Tab cycles focusable views |
 | VoiceOver accessibility | usable | macOS | NSAccessibilityElement + AccessRole |
+| VoiceOver accessibility | usable | iOS | UIAccessibilityElement with slider increment/decrement |
+| TalkBack accessibility | usable | Android | JNI bridge: role, label, value, table metadata, actions |
+| UIA accessibility | partial | Windows | Role map only; provider pending (production-readiness 04) |
+| AT-SPI accessibility | partial | Linux | Role map only; D-Bus registration pending (production-readiness 04) |
 | IME composition (marked text) | usable | macOS | Full NSTextInputClient |
 | Right-click context menu | usable | macOS | on_context_menu + PopupMenu |
 | Keyboard shortcuts | usable | all | registerShortcut bridge |

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -375,12 +375,18 @@ platform_maturity:
     macos:
       status: usable
       notes: VoiceOver via NSAccessibilityElement. AccessRole maps to NSAccessibilityRole.
+    ios:
+      status: usable
+      notes: VoiceOver via UIAccessibilityElement with accessibilityIncrement/Decrement for sliders. See core/view/platform/ios/accessibility_ios.mm.
+    android:
+      status: usable
+      notes: TalkBack via JNI bridge exposing role, label, value, table metadata, and click/increment/decrement actions. See core/view/platform/android/accessibility_android.cpp.
     windows:
       status: partial
-      notes: UIA stub — role mapping defined, provider not yet implemented.
+      notes: UIA stub — role mapping defined, IRawElementProviderSimple/WM_GETOBJECT/event firing pending. See production-readiness workstream 04.
     linux:
       status: partial
-      notes: AT-SPI stub — role mapping defined, D-Bus registration not yet implemented.
+      notes: AT-SPI stub — role mapping defined, D-Bus registration pending. See production-readiness workstream 04.
   ime_composition:
     status: usable
     platform: macos


### PR DESCRIPTION
## Summary

Launches the production-readiness initiative addressing external audit items 5.2-5.9, plus the first concrete slice (workstream 08 sub-deliverable 8.7: docs-drift fixes).

### Plan (via planning submodule bump)
- `planning/production-readiness/README.md` — umbrella with ground-truth corrections to the audit
- `planning/production-readiness/01..08-*.md` — per-area specs with acceptance criteria
- `planning/production-readiness/ralph-loop-prompt.md` — iteration template

### Drift fixes in this commit
- `docs/status/support-matrix.yaml`: add iOS + Android accessibility rows (code in `accessibility_ios.mm`, `accessibility_android.cpp` was implemented but absent from the matrix); note workstream 04 on Windows UIA / Linux AT-SPI stubs
- `docs/reference/capabilities.md` widgets table: surface PresetBrowser, MidiKeyboard, WaveformEditor, EqCurveView, FileBrowser, GraphEditorView, SpectrogramView, MultiMeter, CorrelationMeter, ConcertinaPanel, SplitView, Breadcrumb, Toolbar, ColorPicker, Lasso, PropertyList, CodeEditor — all already implemented
- `docs/reference/capabilities.md` platform-maturity table: add iOS VoiceOver, Android TalkBack, Windows UIA (partial), Linux AT-SPI (partial)

## Test plan
- [x] `bash tools/check-docs.sh` — passes (warnings pre-existing)
- [ ] Follow-up slices of workstream 08 add `check-docs-consistency.py` + status ladder enforcement