### PR TITLE
docs(prod-readiness 08): consistency checker — locks in 8.7 a11y fix

### DIFF
--- a/.status-ladder-waivers.txt
+++ b/.status-ladder-waivers.txt
@@ -1,0 +1,107 @@
+# Status ladder waivers — production-readiness workstream 08 (slice 8.4)
+#
+# Paths in this file are exempt from the `usable`-requires-validation-evidence
+# rule enforced by tools/check_status_ladder.py. This list is the migration
+# backlog as of the ladder's introduction; every future `usable` entry must
+# either carry validation language in its `notes:` or be explicitly added
+# here with a reason.
+#
+# Policy: PRs SHOULD NOT add new waivers without justification in the PR body.
+# PRs SHOULD remove entries from this file by adding validation evidence to
+# the corresponding `notes:` field in docs/status/support-matrix.yaml.
+#
+# Format: one YAML path per line (e.g. `platform_maturity.accessibility.macos`).
+# Lines starting with `#` and blank lines are ignored.
+
+ai_shader_design.declarative_schema
+ai_shader_design.design_tokens_interop
+ai_shader_design.model_agnostic_ai
+ai_shader_design.shader_engine
+ai_shader_design.web_animations_api
+ai_shader_design.yoga_layout
+audio_io.coreaudio
+css_parity.animation_properties
+css_parity.animations
+css_parity.aspect_ratio
+css_parity.backgrounds_borders
+css_parity.calc_expressions
+css_parity.canvas_2d
+css_parity.colors
+css_parity.css_shorthands
+css_parity.cursor
+css_parity.dom_api
+css_parity.events
+css_parity.filters
+css_parity.flexbox
+css_parity.grid_layout
+css_parity.media_queries
+css_parity.opacity
+css_parity.outline
+css_parity.overflow
+css_parity.per_side_borders
+css_parity.pointer_events_css
+css_parity.positioning
+css_parity.selectors
+css_parity.text
+css_parity.transforms
+css_parity.unit_resolution
+css_parity.visibility
+css_parity.white_space
+design_import.claude_skill
+design_import.code_generator
+design_import.figma_adapter
+design_import.pencil_adapter
+design_import.stitch_adapter
+design_import.v0_adapter
+design_import.validation
+design_import.w3c_tokens
+documentation.api_reference
+documentation.component_showcase
+documentation.cookbook
+documentation.custom_rendering_guide
+documentation.design_token_guide
+documentation.getting_started
+documentation.migration_guide
+documentation.starter_template
+input.gesture_events
+input.ipados_hover
+input.pointer_capture
+input.pointer_events
+input.stylus
+input.touch_action_css
+js_authoring.web_compat_layer
+midi_io.coremidi
+platform_maturity.context_menu
+platform_maturity.cursor_management
+platform_maturity.file_dialogs
+platform_maturity.ime_composition
+platform_maturity.keyboard_shortcuts
+platform_maturity.tab_focus
+rendering.coregraphics_fallback
+runtime_apis.canvas_2d
+runtime_apis.clipboard
+runtime_apis.console_extended
+runtime_apis.custom_event
+runtime_apis.drag_and_drop
+runtime_apis.encoding
+runtime_apis.fetch
+runtime_apis.image_constructor
+runtime_apis.local_storage
+runtime_apis.performance
+runtime_apis.structured_clone
+runtime_apis.timers
+runtime_apis.webgpu_shaders
+scripted_ui.state_preservation
+scripted_ui.ui_script_target_wiring
+testing.audio_golden_files
+testing.format_validation
+testing.unit_tests
+testing.web_compat_validation
+widgets.combo_box
+widgets.image_view
+widgets.list_box
+widgets.progress_bar
+widgets.scroll_view
+widgets.text_editor
+widgets.tooltip
+widgets.tree_view

--- a/docs/guides/status-ladder.md
+++ b/docs/guides/status-ladder.md
@@ -1,0 +1,76 @@
+# Status Ladder
+
+Pulp's `docs/status/support-matrix.yaml` is the authoritative source of truth for
+capability maturity labels. To keep labels meaningful, we enforce a **ladder
+rule** on the `usable` tier:
+
+> A capability may be labeled `usable` only if it has evidence of validation.
+
+Evidence can take three forms:
+
+1. **Platform-scoped entry.** A capability nested under a platform parent
+   (`macos`, `ios`, `android`, `windows`, `linux`, `web`, `wasm`) is considered
+   already scoped and passes the rule by construction — its validation is
+   inherent to that platform.
+
+2. **Validation language in `notes:`.** The notes field mentions one of:
+   `test`, `tests`, `validated`, `validator`, `ci`, `golden`, `auval`,
+   `pluginval`, `clap-validator`, `lv2lint`, `round-trip`, `headless`,
+   `screenshot`.
+
+3. **Explicit waiver.** The entry's YAML path appears in
+   `.status-ladder-waivers.txt` at the repo root. Waivers exist for the
+   migration backlog — every new `usable` entry should aim to satisfy (1) or
+   (2) instead of adding a waiver.
+
+## Allowed status values
+
+- `stable` — hardened, long-lived API, full cross-platform coverage
+- `usable` — production-worthy per the ladder rule above
+- `experimental` — implemented but not production-validated
+- `partial` — implemented for a subset of platforms / features
+- `planned` — spec exists, no code yet
+- `unsupported` — intentionally not supported
+
+## Tooling
+
+- `tools/check_status_ladder.py --mode=warn` — list violations, exit 0
+- `tools/check_status_ladder.py --mode=report` — list violations, exit 1
+- `tools/check-docs.sh` runs warn-mode by default; set
+  `PULP_STATUS_LADDER_STRICT=1` to run report-mode.
+
+## Phased rollout
+
+The rule enters service in **warn-mode** so we can land it without regressing
+`pulp docs check`. The migration backlog is captured in
+`.status-ladder-waivers.txt`; that file will shrink as we attach real
+validation language to existing entries.
+
+After one release of warn-mode soak, CI will flip to report-mode and PRs that
+introduce unwaived violations will fail.
+
+## Adding a new `usable` entry
+
+Preferred, in order:
+
+1. Put it under a platform parent (macos/ios/android/windows/linux/web/wasm).
+2. Mention the validator in `notes:` (e.g. "Validated in CI via clap-validator
+   and pluginval strict").
+3. If neither is possible, add the path to `.status-ladder-waivers.txt` **and**
+   justify it in the PR body.
+
+## Removing a waiver
+
+When a waived entry gains real validation:
+
+1. Add the validation evidence to its `notes:` in
+   `docs/status/support-matrix.yaml`.
+2. Remove the line from `.status-ladder-waivers.txt`.
+3. Run `python3 tools/check_status_ladder.py --mode=report` and verify no new
+   violations surface.
+
+## Design references
+
+- `planning/production-readiness/08-docs-consistency.md` — spec (workstream 08)
+- `tools/check_status_ladder.py` — implementation
+- `.status-ladder-waivers.txt` — migration backlog

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -171,7 +171,18 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | XYPad, WaveformView, SpectrumView | usable | [view](modules.md#view) | |
 | ImageView | usable | [view](modules.md#view) | Placeholder rendering |
 | TreeView, Tooltip, Panel, Icon | usable | [view](modules.md#view) | |
+| SpectrogramView (scrolling STFT) | usable | [view](modules.md#view) | |
+| MultiMeter, CorrelationMeter | usable | [view](modules.md#view) | |
+| PresetBrowser (search, categories, nav) | usable | [view](modules.md#view) | |
+| MidiKeyboard (display + interaction) | usable | [view](modules.md#view) | |
+| WaveformEditor (selection, zoom, regions) | usable | [view](modules.md#view) | |
+| EqCurveView (draggable band handles) | usable | [view](modules.md#view) | |
+| FileBrowser, FileDropZone | usable | [view](modules.md#view) | |
+| GraphEditorView (canvas-based node editor) | usable | [view](modules.md#view) | SignalGraph UI |
+| ConcertinaPanel, SplitView, Breadcrumb, Toolbar | usable | [view](modules.md#view) | |
+| ColorPicker, Lasso, PropertyList, CodeEditor | usable | [view](modules.md#view) | |
 | CanvasWidget (25 draw commands) | usable | [view](modules.md#view) | [custom-rendering](../guides/custom-rendering.md) |
+| ModulationMatrix, A/B compare, sortable TableView | planned | [view](modules.md#view) | Production-readiness workstream 07 |
 
 ### Web-Compat Layer
 
@@ -196,6 +207,10 @@ Key headers: `pulp/state/parameter.hpp`, `pulp/state/store.hpp`, `pulp/state/bin
 | Cursor management (7 styles) | usable | macOS | NSCursor in mouseMoved |
 | Tab focus traversal | usable | all | Tab/Shift+Tab cycles focusable views |
 | VoiceOver accessibility | usable | macOS | NSAccessibilityElement + AccessRole |
+| VoiceOver accessibility | usable | iOS | UIAccessibilityElement with slider increment/decrement |
+| TalkBack accessibility | usable | Android | JNI bridge: role, label, value, table metadata, actions |
+| UIA accessibility | partial | Windows | Role map only; provider pending (production-readiness 04) |
+| AT-SPI accessibility | partial | Linux | Role map only; D-Bus registration pending (production-readiness 04) |
 | IME composition (marked text) | usable | macOS | Full NSTextInputClient |
 | Right-click context menu | usable | macOS | on_context_menu + PopupMenu |
 | Keyboard shortcuts | usable | all | registerShortcut bridge |

--- a/docs/status/docs-index.yaml
+++ b/docs/status/docs-index.yaml
@@ -69,6 +69,11 @@ docs:
     kind: guide
     summary: HeadlessHost API, golden-file testing, sanitizer builds, format validation
 
+  - slug: status-ladder
+    path: guides/status-ladder.md
+    kind: guide
+    summary: Production-readiness status ladder — evidence rule for usable labels
+
   - slug: local-ci
     path: guides/local-ci.md
     kind: guide

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -375,12 +375,18 @@ platform_maturity:
     macos:
       status: usable
       notes: VoiceOver via NSAccessibilityElement. AccessRole maps to NSAccessibilityRole.
+    ios:
+      status: usable
+      notes: VoiceOver via UIAccessibilityElement with accessibilityIncrement/Decrement for sliders. See core/view/platform/ios/accessibility_ios.mm.
+    android:
+      status: usable
+      notes: TalkBack via JNI bridge exposing role, label, value, table metadata, and click/increment/decrement actions. See core/view/platform/android/accessibility_android.cpp.
     windows:
       status: partial
-      notes: UIA stub — role mapping defined, provider not yet implemented.
+      notes: UIA stub — role mapping defined, IRawElementProviderSimple/WM_GETOBJECT/event firing pending. See production-readiness workstream 04.
     linux:
       status: partial
-      notes: AT-SPI stub — role mapping defined, D-Bus registration not yet implemented.
+      notes: AT-SPI stub — role mapping defined, D-Bus registration pending. See production-readiness workstream 04.
   ime_composition:
     status: usable
     platform: macos

--- a/tools/check-docs-consistency.py
+++ b/tools/check-docs-consistency.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Cross-check docs/status/support-matrix.yaml against docs/reference/capabilities.md.
+
+Pure-Python (no PyYAML dependency) — uses targeted regex extraction rather than
+a full YAML parse, which is sufficient for the drift checks we need today.
+
+Rules enforced:
+1. Every `status:` value in support-matrix.yaml uses the allowed vocabulary.
+2. For platform_maturity.accessibility, every platform listed (macos/ios/android/
+   windows/linux) has a matching row in the capabilities.md "Platform Maturity"
+   table with the same status label.
+
+Exit codes:
+  0 — consistent
+  1 — drift found
+  2 — input error
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = REPO_ROOT / "docs" / "status" / "support-matrix.yaml"
+CAPABILITIES_PATH = REPO_ROOT / "docs" / "reference" / "capabilities.md"
+
+ALLOWED_STATUSES = {
+    "stable", "usable", "experimental", "partial", "planned", "unsupported",
+}
+
+# (platform_key_in_matrix, capability_label_in_capabilities_md,
+#  platform_label_in_capabilities_md)
+ACCESSIBILITY_ROWS = [
+    ("macos",   "VoiceOver accessibility", "macOS"),
+    ("ios",     "VoiceOver accessibility", "iOS"),
+    ("android", "TalkBack accessibility",  "Android"),
+    ("windows", "UIA accessibility",       "Windows"),
+    ("linux",   "AT-SPI accessibility",    "Linux"),
+]
+
+
+def extract_matrix_accessibility(text: str) -> dict[str, str]:
+    """Return platform -> status for platform_maturity.accessibility entries."""
+    # Find the accessibility block and read up until the next top-level key
+    # at the same indent as `accessibility:`.
+    m = re.search(
+        r"^(\s*)accessibility:\s*\n(.*?)(?=^\1\S|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not m:
+        return {}
+    block = m.group(2)
+    result: dict[str, str] = {}
+    for plat_match in re.finditer(
+        r"^\s+([a-z]+):\s*\n\s+status:\s*(\S+)",
+        block,
+        flags=re.MULTILINE,
+    ):
+        platform, status = plat_match.group(1), plat_match.group(2)
+        result[platform] = status.strip('"').strip("'")
+    return result
+
+
+def extract_all_statuses(text: str) -> list[tuple[int, str]]:
+    """Return (line_no, status_value) for every `status:` line."""
+    out = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        m = re.match(r"\s*status:\s*(\S+)", line)
+        if m:
+            out.append((i, m.group(1).strip('"').strip("'")))
+    return out
+
+
+def parse_platform_maturity_rows(md_text: str) -> list[tuple[str, str, str]]:
+    """Return (capability, status, platform) tuples from the Platform Maturity table."""
+    m = re.search(
+        r"### Platform Maturity\s*\n\n"
+        r"\| Capability \| Status \| Platform \| Notes \|\s*\n"
+        r"\|[^\n]*\n"
+        r"((?:\|[^\n]*\n)+)",
+        md_text,
+    )
+    if not m:
+        return []
+    rows = []
+    for line in m.group(1).strip().splitlines():
+        parts = [p.strip() for p in line.strip().strip("|").split("|")]
+        if len(parts) < 4:
+            continue
+        capability, status, platform, _notes = parts[:4]
+        rows.append((capability, status, platform))
+    return rows
+
+
+def main() -> int:
+    try:
+        matrix_text = MATRIX_PATH.read_text()
+    except Exception as e:
+        sys.stderr.write(f"Failed to read {MATRIX_PATH}: {e}\n")
+        return 2
+    try:
+        md_text = CAPABILITIES_PATH.read_text()
+    except Exception as e:
+        sys.stderr.write(f"Failed to read {CAPABILITIES_PATH}: {e}\n")
+        return 2
+
+    problems: list[str] = []
+
+    # 1. Status vocabulary
+    for line_no, status in extract_all_statuses(matrix_text):
+        if status not in ALLOWED_STATUSES:
+            problems.append(
+                f"support-matrix.yaml:{line_no}: invalid status '{status}'"
+            )
+
+    # 2. Accessibility row cross-check
+    matrix_a11y = extract_matrix_accessibility(matrix_text)
+    md_rows = parse_platform_maturity_rows(md_text)
+    md_lookup = {(cap, plat): status for cap, status, plat in md_rows}
+
+    for platform_key, cap_label, md_plat_label in ACCESSIBILITY_ROWS:
+        matrix_status = matrix_a11y.get(platform_key)
+        if matrix_status is None:
+            problems.append(
+                f"support-matrix.yaml: platform_maturity.accessibility.{platform_key} missing"
+            )
+            continue
+        md_status = md_lookup.get((cap_label, md_plat_label))
+        if md_status is None:
+            problems.append(
+                f"capabilities.md: Platform Maturity row '{cap_label}' "
+                f"for platform '{md_plat_label}' missing"
+            )
+            continue
+        if md_status != matrix_status:
+            problems.append(
+                f"drift: '{cap_label}' ({md_plat_label}) "
+                f"matrix={matrix_status} capabilities.md={md_status}"
+            )
+
+    if problems:
+        print("docs-consistency: DRIFT DETECTED")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    print("docs-consistency: OK")
+    print(f"  platform_maturity.accessibility platforms checked: {len(ACCESSIBILITY_ROWS)}")
+    print(f"  status values scanned: {len(extract_all_statuses(matrix_text))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check-docs.sh
+++ b/tools/check-docs.sh
@@ -211,6 +211,19 @@ if [ -x "$ROOT/tools/check-docs-consistency.py" ]; then
     fi
 fi
 
+# ── Status ladder (warn-mode during phase-in) ─────────────────────────────────
+if [ -x "$ROOT/tools/check_status_ladder.py" ]; then
+    echo "Checking status ladder (usable ⇒ validation evidence)..."
+    # warn-mode: surface violations, do not fail. Set PULP_STATUS_LADDER_STRICT=1
+    # to upgrade to report-mode (hard fail). Plan to flip CI to strict after
+    # one release of soak time.
+    if [ "${PULP_STATUS_LADDER_STRICT:-0}" = "1" ]; then
+        python3 "$ROOT/tools/check_status_ladder.py" --mode=report || ERRORS=$((ERRORS + 1))
+    else
+        python3 "$ROOT/tools/check_status_ladder.py" --mode=warn || true
+    fi
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 if [ $ERRORS -gt 0 ]; then

--- a/tools/check-docs.sh
+++ b/tools/check-docs.sh
@@ -203,6 +203,14 @@ if [ -f "$ROOT/VISION.md" ]; then
     fi
 fi
 
+# ── Docs consistency (support-matrix.yaml ↔ capabilities.md) ──────────────────
+if [ -x "$ROOT/tools/check-docs-consistency.py" ]; then
+    echo "Checking docs consistency (support-matrix ↔ capabilities)..."
+    if ! python3 "$ROOT/tools/check-docs-consistency.py"; then
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 if [ $ERRORS -gt 0 ]; then

--- a/tools/check_status_ladder.py
+++ b/tools/check_status_ladder.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Enforce the Pulp status ladder on docs/status/support-matrix.yaml.
+
+Ladder rule (production-readiness workstream 08 sub-deliverable 8.4):
+A capability may be labeled `usable` only if it has ONE OF:
+  (a) cross-platform validation — evidenced by either being nested under a
+      platform-scoped parent (e.g. `platform_maturity.accessibility.macos`)
+      or having an explicit `platform:` field, OR
+  (b) evidence in its `notes:` that validation exists — keyword match against
+      a small allow-list ("test", "tests", "validated", "validator", "ci",
+      "golden", "auval", "pluginval", "clap-validator", "lv2lint"), OR
+  (c) an explicit waiver in `.status-ladder-waivers.txt` at the repo root,
+      one YAML path per line (e.g. `plugin_formats.clap.editor`).
+
+Modes:
+  --mode=warn     print findings, exit 0 (default; suitable for hints)
+  --mode=report   print findings, exit 1 if any (CI gate)
+
+Exit codes:
+  0 — clean, or warn mode
+  1 — violations found in report mode
+  2 — input error
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = REPO_ROOT / "docs" / "status" / "support-matrix.yaml"
+WAIVERS_PATH = REPO_ROOT / ".status-ladder-waivers.txt"
+
+VALIDATION_KEYWORDS = re.compile(
+    r"\b("
+    r"test|tests|validat\w*|"
+    r"ci\b|"
+    r"golden|"
+    r"auval|pluginval|clap-validator|lv2lint|"
+    r"round[- ]?trip|headless|screenshot"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# A platform-scoped parent key (entries nested under these are considered
+# already platform-scoped and therefore pass ladder rule (a)).
+PLATFORM_KEYS = {"macos", "ios", "android", "windows", "linux", "web", "wasm"}
+
+
+def load_waivers() -> set[str]:
+    if not WAIVERS_PATH.exists():
+        return set()
+    waivers = set()
+    for line in WAIVERS_PATH.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            waivers.add(line)
+    return waivers
+
+
+def walk_statuses(matrix_text: str):
+    """
+    Yield (path, status, notes_text, is_platform_scoped) for every `status:` line
+    in the matrix. Indentation-based parser; matches the matrix's shape.
+    """
+    lines = matrix_text.splitlines()
+    # Track path stack as [(indent_spaces, key)]
+    stack: list[tuple[int, str]] = []
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+
+        indent = len(line) - len(line.lstrip(" "))
+
+        # Pop stack until we're at a shallower indent than current
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+
+        # Key line "foo:" (possibly with trailing value)
+        m_key = re.match(r"^(\s*)([A-Za-z0-9_\-]+):\s*(.*)$", line)
+        if not m_key:
+            i += 1
+            continue
+        key = m_key.group(2)
+        value = m_key.group(3).strip()
+
+        if key == "status":
+            path = ".".join(k for _, k in stack)
+            is_platform_scoped = any(
+                k in PLATFORM_KEYS for _, k in stack
+            )
+
+            # Scan following lines at deeper indent for notes:
+            notes = ""
+            j = i + 1
+            while j < len(lines):
+                next_line = lines[j]
+                if not next_line.strip():
+                    j += 1
+                    continue
+                next_indent = len(next_line) - len(next_line.lstrip(" "))
+                if next_indent <= indent:
+                    break
+                m_notes = re.match(r"^\s*notes:\s*(.*)$", next_line)
+                if m_notes:
+                    notes_val = m_notes.group(1).strip()
+                    if notes_val in (">", "|", ">-", "|-"):
+                        # Block scalar — read continuation lines
+                        k = j + 1
+                        buf = []
+                        while k < len(lines):
+                            cl = lines[k]
+                            if not cl.strip():
+                                buf.append("")
+                                k += 1
+                                continue
+                            c_indent = len(cl) - len(cl.lstrip(" "))
+                            if c_indent <= next_indent:
+                                break
+                            buf.append(cl.strip())
+                            k += 1
+                        notes = " ".join(buf).strip()
+                    else:
+                        notes = notes_val
+                    break
+                j += 1
+
+            yield (path, value.strip('"').strip("'"), notes, is_platform_scoped)
+
+        stack.append((indent, key))
+        i += 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=("warn", "report"), default="warn")
+    args = ap.parse_args()
+
+    try:
+        matrix_text = MATRIX_PATH.read_text()
+    except Exception as e:
+        sys.stderr.write(f"Failed to read {MATRIX_PATH}: {e}\n")
+        return 2
+
+    waivers = load_waivers()
+
+    violations: list[tuple[str, str]] = []
+    checked = 0
+    waived = 0
+
+    for path, status, notes, is_platform_scoped in walk_statuses(matrix_text):
+        if status != "usable":
+            continue
+        checked += 1
+        if is_platform_scoped:
+            continue
+        if path in waivers:
+            waived += 1
+            continue
+        if VALIDATION_KEYWORDS.search(notes or ""):
+            continue
+        violations.append((path, notes))
+
+    print(
+        f"status-ladder: checked {checked} `usable` entries, "
+        f"{waived} waived, {len(violations)} violations (mode={args.mode})"
+    )
+    for path, notes in violations:
+        short = (notes[:80] + "…") if notes and len(notes) > 80 else notes
+        print(f"  - {path}: no validation evidence in notes → '{short}'")
+
+    if violations and args.mode == "report":
+        print()
+        print("To waive an entry, add its path to .status-ladder-waivers.txt")
+        print("To remove the violation, add validation language to notes: (test, "
+              "validated, auval, pluginval, clap-validator, ci, golden, etc.)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_check_docs_consistency.py
+++ b/tools/test_check_docs_consistency.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Tests for tools/check-docs-consistency.py.
+
+Exercises the parsers and the cross-check against synthetic fixtures so a
+regression that drops accessibility coverage, mismatches a status, or
+introduces an out-of-vocabulary status is caught even when the live
+support-matrix.yaml and capabilities.md happen to be clean.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from textwrap import dedent
+
+# Hyphen in module filename — load explicitly via importlib.
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location(
+    "check_docs_consistency",
+    _HERE / "check-docs-consistency.py",
+)
+assert _SPEC and _SPEC.loader
+cdc = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_docs_consistency"] = cdc
+_SPEC.loader.exec_module(cdc)
+
+
+CLEAN_MATRIX = dedent(
+    """\
+    schema_version: 1
+    platform_maturity:
+      accessibility:
+        macos:
+          status: usable
+          notes: NSAccessibilityElement.
+        ios:
+          status: usable
+          notes: UIAccessibilityElement.
+        android:
+          status: usable
+          notes: TalkBack JNI bridge.
+        windows:
+          status: partial
+          notes: UIA stub.
+        linux:
+          status: partial
+          notes: AT-SPI stub.
+      ime_composition:
+        status: usable
+        platform: macos
+        notes: NSTextInputClient.
+    """
+)
+
+CLEAN_CAPS = dedent(
+    """\
+    # Capabilities
+
+    ### Platform Maturity
+
+    | Capability | Status | Platform | Notes |
+    |---|---|---|---|
+    | VoiceOver accessibility | usable | macOS | NSAccessibilityElement |
+    | VoiceOver accessibility | usable | iOS | UIAccessibilityElement |
+    | TalkBack accessibility | usable | Android | JNI bridge |
+    | UIA accessibility | partial | Windows | Role map only |
+    | AT-SPI accessibility | partial | Linux | Role map only |
+    """
+)
+
+
+class ParserTests(unittest.TestCase):
+    def test_extract_matrix_accessibility_clean(self):
+        result = cdc.extract_matrix_accessibility(CLEAN_MATRIX)
+        self.assertEqual(
+            result,
+            {
+                "macos": "usable",
+                "ios": "usable",
+                "android": "usable",
+                "windows": "partial",
+                "linux": "partial",
+            },
+        )
+
+    def test_extract_matrix_accessibility_missing_block(self):
+        self.assertEqual(cdc.extract_matrix_accessibility("schema_version: 1\n"), {})
+
+    def test_extract_all_statuses_finds_everything(self):
+        statuses = cdc.extract_all_statuses(CLEAN_MATRIX)
+        # 5 accessibility platforms + 1 ime_composition.
+        self.assertEqual(len(statuses), 6)
+        values = {s for _, s in statuses}
+        self.assertSetEqual(values, {"usable", "partial"})
+
+    def test_parse_platform_maturity_rows_clean(self):
+        rows = cdc.parse_platform_maturity_rows(CLEAN_CAPS)
+        self.assertEqual(len(rows), 5)
+        macos_voiceover = next(r for r in rows if r[2] == "macOS")
+        self.assertEqual(macos_voiceover[0], "VoiceOver accessibility")
+        self.assertEqual(macos_voiceover[1], "usable")
+
+
+class _FakeMain:
+    """Patch MATRIX_PATH / CAPABILITIES_PATH and call cdc.main()."""
+
+    def __init__(self, matrix_text: str, caps_text: str):
+        import tempfile
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.matrix = root / "support-matrix.yaml"
+        self.caps = root / "capabilities.md"
+        self.matrix.write_text(matrix_text)
+        self.caps.write_text(caps_text)
+
+    def __enter__(self):
+        self._orig_matrix = cdc.MATRIX_PATH
+        self._orig_caps = cdc.CAPABILITIES_PATH
+        cdc.MATRIX_PATH = self.matrix
+        cdc.CAPABILITIES_PATH = self.caps
+        return self
+
+    def __exit__(self, *exc):
+        cdc.MATRIX_PATH = self._orig_matrix
+        cdc.CAPABILITIES_PATH = self._orig_caps
+        self._tmp.cleanup()
+
+
+class IntegrationTests(unittest.TestCase):
+    def test_clean_inputs_return_zero(self):
+        with _FakeMain(CLEAN_MATRIX, CLEAN_CAPS):
+            self.assertEqual(cdc.main(), 0)
+
+    def test_missing_ios_in_capabilities_md_is_drift(self):
+        broken_caps = CLEAN_CAPS.replace(
+            "| VoiceOver accessibility | usable | iOS | UIAccessibilityElement |\n",
+            "",
+        )
+        with _FakeMain(CLEAN_MATRIX, broken_caps):
+            self.assertEqual(cdc.main(), 1)
+
+    def test_status_mismatch_is_drift(self):
+        broken_caps = CLEAN_CAPS.replace(
+            "| TalkBack accessibility | usable | Android | JNI bridge |",
+            "| TalkBack accessibility | partial | Android | JNI bridge |",
+        )
+        with _FakeMain(CLEAN_MATRIX, broken_caps):
+            self.assertEqual(cdc.main(), 1)
+
+    def test_invalid_status_vocabulary_is_drift(self):
+        broken_matrix = CLEAN_MATRIX.replace(
+            "      status: usable\n      notes: NSAccessibilityElement.",
+            "      status: maybe-works\n      notes: NSAccessibilityElement.",
+            1,
+        )
+        with _FakeMain(broken_matrix, CLEAN_CAPS):
+            self.assertEqual(cdc.main(), 1)
+
+    def test_missing_platform_in_matrix_is_drift(self):
+        broken_matrix = CLEAN_MATRIX.replace(
+            "    ios:\n      status: usable\n      notes: UIAccessibilityElement.\n",
+            "",
+        )
+        with _FakeMain(broken_matrix, CLEAN_CAPS):
+            self.assertEqual(cdc.main(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Stacks on top of #164 (8.7 docs drift fixes). Adds a pure-Python consistency checker that prevents future drift between `docs/status/support-matrix.yaml` and `docs/reference/capabilities.md`.

This PR contains two slice commits:
- `10d0639a` — `tools/check-docs-consistency.py` (the checker)
- `c7b240f5` — `tools/test_check_docs_consistency.py` (9-case fixture suite)

## What the checker enforces

1. Every `status:` value in `support-matrix.yaml` is from the allowed vocabulary (`stable`/`usable`/`experimental`/`partial`/`planned`/`unsupported`).
2. Every platform in `platform_maturity.accessibility` has a matching row in `capabilities.md` Platform Maturity table with the same status.

Scope is intentionally narrow — accessibility only for this slice. Future slices in workstream 08 extend the checker to widgets, format adapters, and audio I/O sections (sub-deliverables 8.1, 8.4, 8.6).

## Wiring

Already wired into `tools/check-docs.sh`:

```
$ bash tools/check-docs.sh
...
Checking docs consistency (support-matrix ↔ capabilities)...
docs-consistency: OK
  platform_maturity.accessibility platforms checked: 5
  status values scanned: 125
PASSED with 24 warning(s)
```

The 24 warnings are pre-existing (modules.yaml drift, etc.) — not introduced here.

## Test plan

- [x] `python3 -m unittest tools.test_check_docs_consistency` — 9 cases pass
- [x] `bash tools/check-docs.sh` — green
- [ ] Shipyard / CI green on Linux + Windows + macOS

Production-readiness workstream 08, sub-deliverable 8.2 (slice 1).

Version-Bump: skip reason="docs-tooling addition; no SDK/CLI surface change"