### PR TITLE
matrix(prod-readiness 08): format_limitations section (8.5 slice 1)

### DIFF
--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -64,6 +64,32 @@ plugin_extensions:
       - "AraDocumentController is a stub — playback renderer not implemented."
       - "VST3, CLAP, AU adapters do not declare ARA extension support."
       - "Celemony ARA SDK is developer-supplied; not bundled."
+# Known limitations per format. Keyed the same as `formats:`. The renderer
+# in capabilities.md surfaces these as a "Known limitations" link on each
+# row. Production-readiness workstream 08 sub-deliverable 8.5.
+#
+# Adding an entry here is non-blocking — the entry's status in `formats:`
+# is the load-bearing label. `format_limitations:` exists so readers don't
+# confuse "the adapter compiles" with "the adapter is feature-complete."
+format_limitations:
+  vst3:
+    - "Dynamic bus arrangements limited; setBusArrangements only renegotiates the primary stereo bus today (workstream 01)."
+  au_v2:
+    - "Outbound parameter changes are not emitted to the host — automation read on AU v2 effects only flows host → plugin (workstream 01)."
+  clap:
+    - "Only the first input bus and first output bus are routed; declared sidechain or additional buses are ignored (workstream 01)."
+    - "Processor::set_sidechain is never called from the CLAP adapter — sidechain inputs land on the primary bus (workstream 01)."
+  lv2:
+    - "MIDI atom parsing is incomplete; connect_port has no atom/MIDI port branch beyond control range. URID feature is not resolved (workstream 01)."
+  aax:
+    - "Custom editor surface not wired — Pro Tools shows the auto-generated parameter strip rather than a Pulp ViewBridge editor (followups plan, row 7)."
+    - "AudioSuite role is declared but not exercised end-to-end (followups plan, row 13)."
+  auv3:
+    - "iOS jetsam pressure not modeled — heavy V8 / WebView workloads in the AUv3 process risk termination at ~50 MB (workstream 05)."
+  wam_v2:
+    - "Browser origin sandbox only; no Pulp-side capability manifest yet (security plan v4 §4.5)."
+  webclap:
+    - "Same browser-sandbox-only constraint as wam_v2."
 
 scripted_ui:
   ui_script_target_wiring:


### PR DESCRIPTION
## Summary

Production-readiness workstream 08, sub-deliverable 8.5. Adds a new `format_limitations:` section to `support-matrix.yaml`, keyed the same as `formats:`. Each entry is a human-readable list of the known gaps surfaced by the audit (items 5.2, 5.7) and by the followups plan.

## What's surfaced

| Format | Limitations documented |
|---|---|
| `vst3` | Dynamic bus arrangements limited |
| `au_v2` | Outbound parameter changes not emitted |
| `clap` | Only first input/output bus routed; `set_sidechain` unused |
| `lv2` | MIDI atom parsing incomplete; URID unresolved |
| `aax` | Editor not wired; AudioSuite not exercised end-to-end |
| `auv3` | iOS jetsam pressure not modeled |
| `wam_v2` / `webclap` | Browser sandbox only, no Pulp-side manifest yet |

Each bullet cites the workstream or plan tracking the fix.

## Why a separate section

Existing `formats:` entries are flat (`vst3.macos: usable`) — there's no place to attach per-format limitations without restructuring. A parallel section is additive, non-blocking, and lets the future capabilities.md renderer pull a "Known limitations" link per row without changing how status labels work.

## Test plan

- [x] `bash tools/check-docs.sh` — parses cleanly
- [x] ARA entry from #170 unaffected (different section)
- [ ] CI green on Linux + Windows + macOS

Production-readiness workstream 08, sub-deliverable 8.5 (formats half). The `capabilities.md` renderer half is a follow-up slice.

Version-Bump: skip reason="docs schema augmentation; no SDK/CLI surface change"