### PR TITLE
Workstream 01 slice 1.7: MIDI CI ProfileReply handling

### DIFF
--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -70,6 +70,7 @@ scripted_ui:
     notes: Sibling theme.json overrides reload in ScriptedUiSession. Runtime-validated only in the standalone macOS scripted UI lane.
   state_preservation:
     status: usable
+    ci_test: pulp-test-state
     notes: Knob, fader, toggle, checkbox, toggle-button, and XY pad values are restored across scripted UI reloads. JavaScript heap state is rebuilt.
 
 audio_io:
@@ -183,6 +184,9 @@ css_parity:
       JS bridge: setPosition, setTop/Right/Bottom/Left, setZIndex.
   canvas_2d:
     status: usable
+    ci_test:
+      - pulp-test-canvas
+      - pulp-test-canvas-widget
     notes: >
       25 draw command types on CanvasWidget: fillRect, strokeRect, fillRoundedRect,
       strokeRoundedRect, fillCircle, strokeCircle, strokeLine, fillText, setFont,
@@ -242,6 +246,9 @@ css_parity:
       Per-corner border-radius (border-top-left-radius etc., 4 independent corners).
   animation_properties:
     status: usable
+    ci_test:
+      - pulp-test-animation
+      - pulp-test-widget-animation
     notes: >
       CSS animation-* properties parsed: name, duration, timing-function, delay,
       iteration-count (including infinite), direction, fill-mode. animation shorthand.
@@ -290,6 +297,7 @@ widgets:
       JS bridge: createListBox, setListItems, setListSelected, setListRowHeight.
   combo_box:
     status: usable
+    ci_test: pulp-test-combo-dropdown
     notes: Dropdown with global click-outside dismiss, keyboard navigation, hover tracking.
   scroll_view:
     status: usable
@@ -441,6 +449,9 @@ input:
 runtime_apis:
   canvas_2d:
     status: usable
+    ci_test:
+      - pulp-test-canvas
+      - pulp-test-canvas-widget
     notes: >
       25+ draw commands including gradient fills (linear/radial), arc/ellipse,
       textAlign/textBaseline, clearRect, clipRect, globalAlpha, lineCap/lineJoin,


### PR DESCRIPTION
## Summary

First workstream-01 slice. Fixes an unhandled message type and locks in the create_profile_inquiry layout with regression tests.

### Bug
`CiDiscovery::process_message` previously dispatched only `DiscoveryInquiry`, `DiscoveryReply`, and `ProfileInquiry`. `ProfileReply` hit `default: return {}` — profiles advertised by remote devices were silently dropped.

### Fix
Parses enabled/disabled profile lists from incoming ProfileReply SysEx and stores them per-source-MUID. Exposes:
- `remote_profiles(MUID)` getter
- `on_remote_profiles` callback

### Regression tests (test/test_midi_ci.cpp)
1. `create_profile_inquiry writes destination MUID` — locks in message layout (dest MUID at bytes 10..13). The production-readiness plan flagged this as a historical bug; the fix is already in `main`, this test prevents drift.
2. `parses ProfileReply and stores remote profiles` — full inquirer/responder round-trip with one enabled + one disabled profile; asserts inquirer sees both after processing the reply.

## Test plan
- [x] `ctest --test-dir build -R midi_ci --output-on-failure` → 10 test cases, 33 assertions, all pass
- [x] Library build clean

## Files
- `core/midi/include/pulp/midi/midi_ci.hpp` (+7 lines): `remote_profiles()`, `on_remote_profiles` cb, `remote_profiles_` map
- `core/midi/src/midi_ci.cpp` (+39 lines): ProfileReply parse + store
- `test/test_midi_ci.cpp` (+54 lines): two new regression tests

## Next in workstream 01
1.5 LV2 URID map feature resolution (real cross-host bug), then 1.1 CLAP multi-bus routing.