### PR TITLE
matrix(prod-readiness 08): 16 widget rows (8.1 widget batch)

### DIFF
--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -309,6 +309,58 @@ widgets:
   tooltip:
     status: usable
     notes: Fade-in/out tooltip attached to any view.
+  # Audio / music-domain widgets.
+  meter:
+    status: usable
+    notes: Meter, MultiMeter, CorrelationMeter — peak/RMS level bars with ballistics. See core/view/include/pulp/view/widgets.hpp.
+  spectrum_view:
+    status: usable
+    notes: Real-time FFT spectrum display with log/linear frequency axis. See core/view/include/pulp/view/widgets.hpp.
+  spectrogram_view:
+    status: usable
+    notes: Scrolling STFT spectrogram. See core/view/include/pulp/view/widgets.hpp.
+  waveform_view:
+    status: usable
+    notes: WaveformView for rendering audio buffers. See core/view/include/pulp/view/widgets.hpp.
+  waveform_editor:
+    status: usable
+    notes: Selection, zoom, region-based editor built on WaveformView. See core/view/include/pulp/view/widgets/waveform_editor.hpp.
+  midi_keyboard:
+    status: usable
+    notes: Display + interaction keyboard; note-on/off events routed through Binding. See core/view/include/pulp/view/widgets/midi_keyboard.hpp.
+  preset_browser:
+    status: usable
+    notes: Searchable, category-grouped preset browser with keyboard navigation. See core/view/include/pulp/view/widgets/preset_browser.hpp.
+  eq_curve_view:
+    status: usable
+    notes: Draggable EQ band handles with live curve render. See core/view/include/pulp/view/widgets/eq_curve_view.hpp.
+  graph_editor_view:
+    status: usable
+    ci_test: pulp-test-graph-serializer
+    notes: Canvas-based node editor on top of pulp::canvas; renders a SignalGraph as a draggable, connectable graph. See core/view/include/pulp/view/widgets/graph_editor_view.hpp.
+  # General-purpose UI widgets surfaced by the audit as missing rows.
+  file_browser:
+    status: usable
+    notes: FileBrowser + FileDropZone. See core/view/include/pulp/view/widgets/file_browser.hpp.
+  color_picker:
+    status: usable
+    notes: HSV + hex color picker with live swatch. See core/view/include/pulp/view/widgets/color_picker.hpp.
+  concertina_panel:
+    status: usable
+    notes: Stacked accordion-style panel with expand/collapse per section. See core/view/include/pulp/view/widgets/concertina_panel.hpp.
+  split_view:
+    status: usable
+    notes: Draggable splitter between two views; horizontal and vertical. See core/view/include/pulp/view/widgets/split_view.hpp.
+  breadcrumb:
+    status: usable
+    notes: Breadcrumb trail navigation. See core/view/include/pulp/view/widgets/breadcrumb.hpp.
+  lasso:
+    status: usable
+    notes: Marquee / drag-to-select overlay. See core/view/include/pulp/view/widgets/lasso.hpp.
+  code_editor:
+    status: usable
+    ci_test: pulp-test-code-editor
+    notes: Syntax-highlighted text editor with gutter and line numbers. See core/view/include/pulp/view/widgets/code_editor.hpp.
 
 js_authoring:
   web_compat_layer:


### PR DESCRIPTION
## Summary

Production-readiness workstream 08 sub-deliverable 8.1. Fills in structured `widgets:` entries for widgets that ship in `core/view/include/pulp/view/` but had no row in `support-matrix.yaml`.

## Widgets added

**Audio / music-domain:** meter, spectrum_view, spectrogram_view, waveform_view, waveform_editor, midi_keyboard, preset_browser, eq_curve_view, graph_editor_view

**General-purpose:** file_browser, color_picker, concertina_panel, split_view, breadcrumb, lasso, code_editor

Two entries pick up `ci_test:` mappings:
- `graph_editor_view` → `pulp-test-graph-serializer`
- `code_editor` → `pulp-test-code-editor`

The rest enter the report-mode ladder-violation bucket until paired test targets exist or a consolidated widget-test lane lands.

## Rationale

Addresses audit item 5.9 finding that `capabilities.md` widget inventory was partly stale. The `capabilities.md` widget-table refresh landed in #164; this PR mirrors that into the authoritative `support-matrix.yaml`.

## Test plan

- [x] `check_status_ladder.py` parses cleanly
- [x] `bash tools/check-docs.sh` clean
- [ ] CI green on Linux + Windows + macOS

Production-readiness workstream 08 sub-deliverable 8.1 (widget batch).

Version-Bump: skip reason="docs schema augmentation; no SDK/CLI surface change"