### PR TITLE
Workstream 01 slice 1.5: LV2 URID feature resolution

### DIFF
--- a/core/format/include/pulp/format/lv2_adapter.hpp
+++ b/core/format/include/pulp/format/lv2_adapter.hpp
@@ -11,6 +11,11 @@
 
 #include <pulp/format/processor.hpp>
 
+#include <lv2/core/lv2.h>
+#include <lv2/urid/urid.h>
+
+#include <cstdint>
+
 namespace pulp::format::lv2_adapter {
 
 static constexpr int kMaxChannels = 8;
@@ -35,7 +40,22 @@ struct PulpLv2Instance {
     int num_audio_outputs = 0;
     int num_params = 0;
     std::vector<state::ParamID> param_ids;  // Maps control port index → ParamID
+
+    // URID feature resolution (workstream 01 slice 1.5). The LV2 host passes
+    // an LV2_URID_Map feature in instantiate(); we cache the map function
+    // plus the URIDs we need at runtime so inner-loop code does not call
+    // map() on hot paths. All fields are 0 when the feature is absent —
+    // instantiate() returns nullptr in that case, so real plugin code
+    // always sees non-zero values here.
+    LV2_URID_Map* urid_map = nullptr;
+    LV2_URID urid_midi_event = 0;      // LV2_MIDI__MidiEvent
+    LV2_URID urid_atom_sequence = 0;   // LV2_ATOM__Sequence
+    LV2_URID urid_atom_chunk = 0;      // LV2_ATOM__Chunk
 };
+
+/// Resolve LV2_URID_Map from a features array.
+/// Returns nullptr if the feature is absent. Exposed for unit testing.
+LV2_URID_Map* find_urid_map(const LV2_Feature* const* features);
 
 // Generate an LV2 TTL manifest string for a plugin
 // This creates the plugin.ttl content with port definitions

--- a/core/format/include/pulp/format/lv2_entry.hpp
+++ b/core/format/include/pulp/format/lv2_entry.hpp
@@ -14,6 +14,9 @@
 #include <pulp/runtime/log.hpp>
 
 #include <lv2/core/lv2.h>
+#include <lv2/atom/atom.h>
+#include <lv2/midi/midi.h>
+#include <lv2/urid/urid.h>
 
 #include <cstring>
 #include <vector>
@@ -30,13 +33,29 @@ inline LV2_Handle instantiate(
     const LV2_Descriptor*,
     double sample_rate,
     const char*,
-    const LV2_Feature* const*)
+    const LV2_Feature* const* features)
 {
     if (!g_factory) return nullptr;
+
+    // Resolve LV2_URID_Map — required by any real LV2 host. Pre-production
+    // fix (workstream 01 slice 1.5): we previously ignored the features
+    // array entirely, which would cause real hosts to fail to load the
+    // plugin in surprising ways. Now we fail instantiation loudly and
+    // return nullptr so the host surfaces a clear error.
+    LV2_URID_Map* urid_map = lv2_adapter::find_urid_map(features);
+    if (!urid_map) {
+        pulp::runtime::log_warn(
+            "lv2: host did not provide LV2_URID__map; refusing to instantiate");
+        return nullptr;
+    }
 
     auto* inst = new lv2_adapter::PulpLv2Instance();
     inst->factory = g_factory;
     inst->sample_rate = sample_rate;
+    inst->urid_map = urid_map;
+    inst->urid_midi_event = urid_map->map(urid_map->handle, LV2_MIDI__MidiEvent);
+    inst->urid_atom_sequence = urid_map->map(urid_map->handle, LV2_ATOM__Sequence);
+    inst->urid_atom_chunk = urid_map->map(urid_map->handle, LV2_ATOM__Chunk);
     inst->processor = g_factory();
     if (!inst->processor) {
         delete inst;

--- a/core/format/src/lv2_adapter.cpp
+++ b/core/format/src/lv2_adapter.cpp
@@ -11,6 +11,18 @@
 
 namespace pulp::format::lv2_adapter {
 
+// ── URID feature resolution (workstream 01 slice 1.5) ────────────────────
+
+LV2_URID_Map* find_urid_map(const LV2_Feature* const* features) {
+    if (!features) return nullptr;
+    for (const LV2_Feature* const* f = features; *f != nullptr; ++f) {
+        if ((*f)->URI && std::strcmp((*f)->URI, LV2_URID__map) == 0) {
+            return static_cast<LV2_URID_Map*>((*f)->data);
+        }
+    }
+    return nullptr;
+}
+
 // ── TTL Generation ───────────────────────────────────────────────────────
 
 std::string generate_plugin_ttl(const PluginDescriptor& desc,

--- a/test/test_lv2_adapter.cpp
+++ b/test/test_lv2_adapter.cpp
@@ -119,3 +119,36 @@ TEST_CASE("LV2 TTL port indices are sequential", "[format][lv2]") {
     REQUIRE_THAT(ttl, ContainsSubstring("lv2:index 4"));
     REQUIRE_THAT(ttl, ContainsSubstring("lv2:index 5"));
 }
+
+// ── URID feature resolution (workstream 01 slice 1.5) ─────────────────────
+
+static LV2_URID fake_map(LV2_URID_Map_Handle handle, const char* uri) {
+    // Simple table: return stable IDs per URI, starting at 100.
+    auto* table = static_cast<std::vector<std::string>*>(handle);
+    for (size_t i = 0; i < table->size(); ++i) {
+        if ((*table)[i] == uri) return static_cast<LV2_URID>(100 + i);
+    }
+    table->push_back(uri);
+    return static_cast<LV2_URID>(100 + table->size() - 1);
+}
+
+TEST_CASE("find_urid_map locates LV2_URID__map in features", "[format][lv2]") {
+    std::vector<std::string> table;
+    LV2_URID_Map map{&table, &fake_map};
+    LV2_Feature feat_map{LV2_URID__map, &map};
+    LV2_Feature feat_other{"http://example.com/irrelevant", nullptr};
+
+    // Feature array must be NULL-terminated.
+    const LV2_Feature* features[] = {&feat_other, &feat_map, nullptr};
+    REQUIRE(find_urid_map(features) == &map);
+}
+
+TEST_CASE("find_urid_map returns nullptr when feature absent", "[format][lv2]") {
+    LV2_Feature feat_other{"http://example.com/irrelevant", nullptr};
+    const LV2_Feature* features[] = {&feat_other, nullptr};
+    REQUIRE(find_urid_map(features) == nullptr);
+    REQUIRE(find_urid_map(nullptr) == nullptr);
+    // Empty array (only sentinel)
+    const LV2_Feature* empty[] = {nullptr};
+    REQUIRE(find_urid_map(empty) == nullptr);
+}


### PR DESCRIPTION
## Summary

Fix LV2 `instantiate()` to resolve `LV2_URID__map` instead of silently ignoring the features array. Prerequisite for atom-MIDI routing (lands separately).

### Bug
`instantiate()` took `const LV2_Feature* const*` with an unnamed parameter and never resolved `LV2_URID__map`. Real LV2 hosts require this feature; without it, a plugin that later wires atom MIDI ports would silently drop all MIDI events or fail opaquely at load time in strict hosts.

### Fix
- New `find_urid_map(features)` walks the NULL-terminated feature array, exposed for unit tests
- `PulpLv2Instance` gains cached `urid_map` + three URIDs (`LV2_MIDI__MidiEvent`, `LV2_ATOM__Sequence`, `LV2_ATOM__Chunk`) mapped up-front so hot paths never call `map()`
- `instantiate()` returns `nullptr` and logs a warning when the feature is absent — hosts now surface a clear error instead of a latent one

## Test plan
- [x] `ctest --test-dir build -R lv2-adapter` → 6 cases, 31 assertions, all pass
- [x] New tests: `find_urid_map` finds feature in middle of array; returns nullptr for absent / null / sentinel-only arrays
- [x] `pulp-format` library links clean

## Follow-up (not this PR)
Atom MIDI port parsing in `connect_port` + `run` — now unblocked by having URIDs cached on the instance.