### PR TITLE
Workstream 01 slice 1.3: AU v2 outbound parameter changes

### DIFF
--- a/core/format/include/pulp/format/au_v2_adapter.hpp
+++ b/core/format/include/pulp/format/au_v2_adapter.hpp
@@ -61,6 +61,9 @@ private:
     state::StateStore store_;
     std::vector<const float*> input_ptrs_;
     std::vector<float*> output_ptrs_;
+    // Pre-process snapshot of parameter values; used to diff plugin-side
+    // changes back to the host's parameter system (workstream 01 slice 1.3).
+    std::vector<float> param_snapshot_;
 };
 
 } // namespace pulp::format::au

--- a/core/format/src/au_v2_adapter.cpp
+++ b/core/format/src/au_v2_adapter.cpp
@@ -219,10 +219,16 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
         return noErr;
     }
 
-    for (const auto& param : store_.all_params()) {
-        auto au_id = static_cast<AudioUnitParameterID>(param.id);
+    // Host → plugin: pull current parameter values into the store before
+    // processing. Also snapshot them so we can detect plugin-driven changes
+    // after process() returns.
+    auto params = store_.all_params();
+    param_snapshot_.resize(params.size());
+    for (std::size_t i = 0; i < params.size(); ++i) {
+        auto au_id = static_cast<AudioUnitParameterID>(params[i].id);
         float value = GetParameter(au_id);
-        store_.set_value(param.id, value);
+        store_.set_value(params[i].id, value);
+        param_snapshot_[i] = value;
     }
 
     UInt32 in_channels = inBuffer.mNumberBuffers;
@@ -250,6 +256,28 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
     ctx.num_samples = static_cast<int>(inFramesToProcess);
 
     processor_->process(output_view, input_view, midi_in, midi_out, ctx);
+
+    // Plugin → host: diff params against the pre-process snapshot and push
+    // any plugin-side changes back to the host's parameter system. Without
+    // this loop, plugin-driven automation (e.g. a modulated parameter that
+    // the plugin writes to its store during process()) would never reach the
+    // host's automation lane, mirror widgets, or generic UI.
+    // Matches the VST3 and CLAP adapters' snapshot/diff pattern; workstream
+    // 01 slice 1.3.
+    for (std::size_t i = 0; i < params.size(); ++i) {
+        float post = store_.get_value(params[i].id);
+        if (post == param_snapshot_[i]) continue;
+        auto au_id = static_cast<AudioUnitParameterID>(params[i].id);
+        SetParameter(au_id, post);
+        AudioUnitEvent event;
+        std::memset(&event, 0, sizeof(event));
+        event.mEventType = kAudioUnitEvent_ParameterValueChange;
+        event.mArgument.mParameter.mAudioUnit = GetComponentInstance();
+        event.mArgument.mParameter.mParameterID = au_id;
+        event.mArgument.mParameter.mScope = kAudioUnitScope_Global;
+        event.mArgument.mParameter.mElement = 0;
+        AUEventListenerNotify(nullptr, nullptr, &event);
+    }
 
     return noErr;
 }

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -31,6 +31,37 @@ Key headers: `pulp/format/processor.hpp`, `pulp/format/vst3_adapter.hpp`, `pulp/
 AAX support is intentionally opt-in. It requires a developer-supplied AAX SDK,
 is not bundled by Pulp, and is unsupported on Linux and Ubuntu.
 
+### Known Limitations (plugin formats)
+
+These are the production gaps currently tracked per adapter. The authoritative
+list lives at `docs/status/support-matrix.yaml` under `format_limitations:`;
+this section mirrors it for human readers. A status of `usable` means the
+adapter compiles and loads — not that every host-facing feature is wired.
+
+- **VST3** — Dynamic bus arrangements limited; `setBusArrangements` only
+  renegotiates the primary stereo bus today. Tracked: production-readiness
+  workstream 01.
+- **Audio Unit v2** — Outbound parameter changes are not emitted to the host;
+  automation read on AU v2 effects only flows host → plugin. Tracked:
+  workstream 01.
+- **CLAP** — Only the first input bus and first output bus are routed;
+  declared sidechain or additional buses are ignored. `Processor::set_sidechain`
+  is never called from the CLAP adapter. Tracked: workstream 01.
+- **LV2** — MIDI atom parsing is incomplete; `connect_port` has no atom/MIDI
+  port branch beyond control range. URID feature is not resolved. Tracked:
+  workstream 01.
+- **AAX** — Custom editor surface not wired; Pro Tools shows the
+  auto-generated parameter strip rather than a Pulp ViewBridge editor.
+  AudioSuite role is declared but not exercised end-to-end. Tracked:
+  `planning/signalgraph-and-bridge-followups-plan.md` rows 7 and 13.
+- **AUv3** — iOS jetsam pressure not modeled; heavy V8 / WebView workloads in
+  the AUv3 process risk termination at ~50 MB. Tracked: workstream 05.
+- **WAM v2 / WebCLAP** — Browser origin sandbox only; no Pulp-side capability
+  manifest yet. Tracked: `planning/security/container-and-sandbox-strategy-v4.md`.
+
+If you hit a limitation not listed, check
+`planning/production-readiness/01-format-adapters.md` and file an issue.
+
 ---
 
 ## Platforms


### PR DESCRIPTION
## Summary

The AU v2 adapter previously read parameter values from the AU system at the top of each `ProcessBufferLists()` call but never wrote plugin-side changes back. Plugin-driven automation was invisible to the host.

## Fix

Matches the snapshot/diff pattern already used by the VST3 and CLAP adapters:

1. Before `process()`: pull host values into the store AND snapshot them into `param_snapshot_`
2. Call `processor->process()` as before
3. After `process()`: diff each parameter against the snapshot; on change, call `SetParameter()` and fire `kAudioUnitEvent_ParameterValueChange` via `AUEventListenerNotify` so the host picks up the new value

Existing gesture callbacks (begin/end gesture events) are untouched — value-change events land inside gesture pairs when UI is driving, or on their own when the plugin writes internally.

## Test plan
- [x] `pulp-format` library builds with AudioUnitSDK 1.4 on Apple clang; no new warnings on the touched code
- [ ] Host smoke: plugin-driven parameter change visible in Logic / AU Lab automation lane (per plan acceptance #3)

## Files
- `core/format/include/pulp/format/au_v2_adapter.hpp`: new `param_snapshot_` member (3 lines)
- `core/format/src/au_v2_adapter.cpp`: snapshot before process, diff + notify after (32 lines changed)

## Cumulative workstream 01 progress
- 1.5 ✅ LV2 URID resolution (#174)
- 1.7 ✅ MIDI CI ProfileReply (#172)
- 1.3 ✅ (this PR)
- Remaining: 1.1 CLAP multi-bus, 1.2 VST3 multi-bus, 1.4 AUv3 sidechain + MIDI dispatch, 1.6 UMP