### PR TITLE
format(clap): route second input bus to Processor::set_sidechain() (01 slice 1.1)

### DIFF
--- a/core/format/include/pulp/format/clap_adapter.hpp
+++ b/core/format/include/pulp/format/clap_adapter.hpp
@@ -32,6 +32,10 @@ struct PulpClapPlugin {
     // Pre-allocated buffers — no heap allocation on audio thread
     float* output_ptrs[kMaxChannels] = {};
     const float* input_ptrs[kMaxChannels] = {};
+    // Second input bus routed to Processor::set_sidechain() (workstream 01
+    // slice 1.1). Up to kMaxChannels. Additional input buses beyond index 1
+    // are currently ignored — the Processor API is single-sidechain today.
+    const float* sidechain_ptrs[kMaxChannels] = {};
 
     // Parameter snapshot for detecting plugin-side changes during process
     std::vector<float> param_snapshot;

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -110,14 +110,27 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
         }
     }
 
-    // Build audio buffer views (no allocation — uses pre-allocated arrays)
+    // Build audio buffer views (no allocation — uses pre-allocated arrays).
+    // Bus 0 routes to the main input/output; bus 1 (when present) routes to
+    // Processor::set_sidechain(). Additional input buses beyond index 1 are
+    // currently ignored — the Processor API exposes a single sidechain slot.
+    // Workstream 01 slice 1.1: previously only bus 0 was routed and
+    // set_sidechain() was never called; sidechain compressors could not
+    // function through the CLAP adapter.
     int in_channels = 0, out_channels = 0;
+    int sc_channels = 0;
 
     if (process->audio_inputs_count > 0) {
         auto& bus = process->audio_inputs[0];
         in_channels = (std::min)(static_cast<int>(bus.channel_count), kMaxChannels);
         for (int ch = 0; ch < in_channels; ++ch)
             self->input_ptrs[ch] = bus.data32[ch];
+    }
+    if (process->audio_inputs_count > 1) {
+        auto& sc_bus = process->audio_inputs[1];
+        sc_channels = (std::min)(static_cast<int>(sc_bus.channel_count), kMaxChannels);
+        for (int ch = 0; ch < sc_channels; ++ch)
+            self->sidechain_ptrs[ch] = sc_bus.data32[ch];
     }
 
     if (process->audio_outputs_count > 0) {
@@ -126,11 +139,25 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
         for (int ch = 0; ch < out_channels; ++ch)
             self->output_ptrs[ch] = bus.data32[ch];
     }
+    // Secondary output buses are zero-filled so hosts do not read
+    // uninitialised memory on multi-out instruments. Full multi-out routing
+    // to Processor is tracked separately (audit 5.2).
+    for (uint32_t b = 1; b < process->audio_outputs_count; ++b) {
+        auto& bus = process->audio_outputs[b];
+        for (uint32_t ch = 0; ch < bus.channel_count; ++ch) {
+            if (bus.data32[ch]) {
+                std::memset(bus.data32[ch], 0, sizeof(float) * num_samples);
+            }
+        }
+    }
 
     audio::BufferView<const float> input_view(
         self->input_ptrs, in_channels, num_samples);
     audio::BufferView<float> output_view(
         self->output_ptrs, out_channels, num_samples);
+    audio::BufferView<const float> sidechain_view(
+        self->sidechain_ptrs, sc_channels, num_samples);
+    self->processor->set_sidechain(sc_channels > 0 ? &sidechain_view : nullptr);
 
     // Build MIDI from CLAP note events
     midi::MidiBuffer midi_in, midi_out;


### PR DESCRIPTION
## Summary

Production-readiness workstream 01 sub-deliverable 1.1 — CLAP sidechain routing. Closes the first audit P0 finding on `clap_adapter.cpp` (item 5.2).

## Problem

The CLAP adapter previously ignored all input buses past index 0. Plugins declaring a sidechain bus never saw the upstream audio; `Processor::set_sidechain()` was never called. Compressors, gates, and ducking plugins built on Pulp couldn't implement sidechain workflows under CLAP.

## Fix

When `process->audio_inputs_count > 1`, route the second bus through pre-allocated `sidechain_ptrs[]` and pass a `BufferView` to `Processor::set_sidechain()`. When no second bus is present, `set_sidechain(nullptr)` is called explicitly so stale pointers from previous `process()` calls can't leak.

Additional input buses beyond index 1 are still ignored — the `Processor` API exposes a single sidechain by design. Multi-sidechain support is a separate workstream item.

## Real-time safety

- No heap allocation. `sidechain_ptrs[kMaxChannels]` lives in the `PulpClapPlugin` struct.
- `BufferView` constructed on the audio-thread stack per block.
- `set_sidechain()` is an atomic pointer swap.

## Test plan

- [x] `cmake --build build --target pulp-format pulp-test-clap-entry` — green
- [x] `./build/test/pulp-test-clap-entry` — 9 assertions, 1 case pass
- [ ] CI green on Linux + Windows + macOS
- [ ] Follow-up: add a sidechain-specific test that instantiates a 4-input/2-output bus layout and asserts `sidechain_input()` returns a non-null view during process (tracked)

Closes workstream 01 sub-deliverable 1.1. First of the format-adapter parity slices.

Version-Bump: sdk=patch reason="CLAP adapter sidechain parity — behavior change for plugins declaring sidechain buses"