### PR TITLE
Workstream 01 slice 1.4: AUv3 MIDI sanitization

### DIFF
--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -370,18 +370,28 @@ struct AUBridge {
         }
 
         // MIDI events
+        // MIDI events. Pulp's MidiEvent is a choc::midi::ShortMessage
+        // (1–3 bytes); AU can also deliver longer messages (sysex, UMP)
+        // via AURenderEventMIDIEventList — we skip those here so a
+        // malformed ShortMessage is never constructed from truncated
+        // bytes. Workstream 01 slice 1.4.
         pulp::midi::MidiBuffer midi_in, midi_out;
         const AURenderEvent* event = realtimeEventListHead;
         while (event) {
             if (event->head.eventType == AURenderEventMIDI) {
                 const AUMIDIEvent& m = event->MIDI;
-                pulp::midi::MidiEvent me;
-                me.message = choc::midi::ShortMessage(
-                    m.data[0],
-                    m.length > 1 ? m.data[1] : uint8_t(0),
-                    m.length > 2 ? m.data[2] : uint8_t(0));
-                me.sample_offset = static_cast<int32_t>(event->head.eventSampleTime);
-                midi_in.add(me);
+                // A well-formed short MIDI message has a status byte
+                // (MSB set) and total length 1..3. Skip anything else.
+                if (m.length >= 1 && m.length <= 3 && (m.data[0] & 0x80)) {
+                    pulp::midi::MidiEvent me;
+                    me.message = choc::midi::ShortMessage(
+                        m.data[0],
+                        m.length > 1 ? m.data[1] : uint8_t(0),
+                        m.length > 2 ? m.data[2] : uint8_t(0));
+                    me.sample_offset =
+                        static_cast<int32_t>(event->head.eventSampleTime);
+                    midi_in.add(me);
+                }
             }
             event = event->head.next;
         }


### PR DESCRIPTION
## Summary

The AUv3 render block accepted any `AURenderEventMIDI` record and stuffed the first three bytes into a `choc::midi::ShortMessage` without validation, so SysEx, UMP, and packets with no status byte produced malformed short messages that downstream parsers would read as legitimate note/CC/pitchbend events.

## Fix
Construct the ShortMessage only when the packet is a well-formed short MIDI message: `length ∈ [1,3]` AND `data[0] & 0x80` (status byte). Longer packets are skipped cleanly until Pulp's `MidiEvent` gains sysex/UMP support (separate slice under audit 5.2 / workstream 01.6).

## Scope notes
This slice deliberately keeps scope tight. Two items from the full 1.4 deliverable land in follow-ups:
1. AUv3 sidechain bus — requires extending `_inputBusArray` with a second `AUAudioUnitBus` at init time
2. AUv3 MIDI-out via `MIDIOutputEventBlock` — plugin-side outbound path

## Test plan
- [x] `PulpGain_AU` builds clean; no new warnings on the touched code
- [ ] Host-smoke validation in AU Lab (AUv3) per planning acceptance

## Files
- `core/format/src/au_adapter.mm` (+17/-8 lines)