### PR TITLE
midi_ci: echo inquirer MUID in profile reply destination field

### DIFF
--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -325,6 +325,7 @@ struct AUBridge {
             }
         }
 
+<<<<<<< HEAD
         // Sidechain: pull bus 1 into its own ABL so it doesn't alias the
         // main input block. Processor::set_sidechain() takes a BufferView
         // that remains valid for the duration of process(). Workstream 01
@@ -370,18 +371,30 @@ struct AUBridge {
         }
 
         // MIDI events
+=======
+        // MIDI events. Pulp's MidiEvent is a choc::midi::ShortMessage
+        // (1–3 bytes); AU can also deliver longer messages (sysex, UMP)
+        // via AURenderEventMIDIEventList — we skip those here so a
+        // malformed ShortMessage is never constructed from truncated
+        // bytes. Workstream 01 slice 1.4.
+>>>>>>> f80d3b04 (auv3: reject malformed AUMIDIEvent packets (workstream 01 slice 1.4))
         pulp::midi::MidiBuffer midi_in, midi_out;
         const AURenderEvent* event = realtimeEventListHead;
         while (event) {
             if (event->head.eventType == AURenderEventMIDI) {
                 const AUMIDIEvent& m = event->MIDI;
-                pulp::midi::MidiEvent me;
-                me.message = choc::midi::ShortMessage(
-                    m.data[0],
-                    m.length > 1 ? m.data[1] : uint8_t(0),
-                    m.length > 2 ? m.data[2] : uint8_t(0));
-                me.sample_offset = static_cast<int32_t>(event->head.eventSampleTime);
-                midi_in.add(me);
+                // A well-formed short MIDI message has a status byte
+                // (MSB set) and total length 1..3. Skip anything else.
+                if (m.length >= 1 && m.length <= 3 && (m.data[0] & 0x80)) {
+                    pulp::midi::MidiEvent me;
+                    me.message = choc::midi::ShortMessage(
+                        m.data[0],
+                        m.length > 1 ? m.data[1] : uint8_t(0),
+                        m.length > 2 ? m.data[2] : uint8_t(0));
+                    me.sample_offset =
+                        static_cast<int32_t>(event->head.eventSampleTime);
+                    midi_in.add(me);
+                }
             }
             event = event->head.next;
         }

--- a/core/midi/src/midi_ci.cpp
+++ b/core/midi/src/midi_ci.cpp
@@ -170,8 +170,17 @@ std::vector<uint8_t> CiDiscovery::handle_discovery(const uint8_t* data, size_t s
     return reply;
 }
 
-std::vector<uint8_t> CiDiscovery::handle_profile_inquiry(const uint8_t* /*data*/, size_t /*size*/) {
-    // Build profile reply
+std::vector<uint8_t> CiDiscovery::handle_profile_inquiry(const uint8_t* data, size_t size) {
+    // ProfileInquiry layout: F0 7E dev 0D sub-id version src(4) dst(4) F7.
+    // The reply must echo the inquirer's MUID back as destination so the
+    // peer can identify the response. Previous implementation ignored
+    // `data`/`size` and dropped the destination field from the reply,
+    // leaving multi-device CI buses unable to route our profile reply.
+    MUID inquirer = MUID::broadcast();
+    if (size >= 14) {
+        inquirer = read_muid(data + 6);
+    }
+
     std::vector<uint8_t> reply;
     reply.push_back(0xF0);
     reply.push_back(0x7E);
@@ -180,6 +189,7 @@ std::vector<uint8_t> CiDiscovery::handle_profile_inquiry(const uint8_t* /*data*/
     reply.push_back(static_cast<uint8_t>(CiMessageType::ProfileReply));
     reply.push_back(local_info_.ci_version);
     write_muid(reply, local_info_.muid);
+    write_muid(reply, inquirer);
     // Count of enabled profiles
     uint16_t enabled_count = 0;
     for (auto& p : profiles_) if (p.enabled) enabled_count++;

--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -92,3 +92,53 @@ TEST_CASE("CiDiscovery profile inquiry response", "[midi][ci]") {
     // Profile inquiry is type 0x24, we handle it
     REQUIRE_FALSE(reply.empty());
 }
+
+TEST_CASE("CiDiscovery profile reply echoes inquirer MUID", "[midi][ci]") {
+    // Regression: handle_profile_inquiry previously ignored data/size and
+    // wrote only our source MUID into the reply, dropping the inquirer's
+    // destination field. Multi-device CI buses couldn't route our reply.
+    CiDiscovery responder;
+    ProfileId p{0x11, 0x01, 0x00, 0x00, 0x00};
+    responder.add_profile({p, true, 0});
+
+    // Synthesize a profile inquiry from a distinct peer MUID.
+    MUID peer_muid{0x01234567};
+    std::vector<uint8_t> inquiry;
+    inquiry.push_back(0xF0);
+    inquiry.push_back(0x7E);
+    inquiry.push_back(0x7F);
+    inquiry.push_back(0x0D);
+    inquiry.push_back(static_cast<uint8_t>(CiMessageType::ProfileInquiry));
+    inquiry.push_back(responder.device_info().ci_version);
+    // Source = peer
+    inquiry.push_back(peer_muid.value & 0x7F);
+    inquiry.push_back((peer_muid.value >> 7) & 0x7F);
+    inquiry.push_back((peer_muid.value >> 14) & 0x7F);
+    inquiry.push_back((peer_muid.value >> 21) & 0x7F);
+    // Destination = responder
+    MUID resp_muid = responder.local_muid();
+    inquiry.push_back(resp_muid.value & 0x7F);
+    inquiry.push_back((resp_muid.value >> 7) & 0x7F);
+    inquiry.push_back((resp_muid.value >> 14) & 0x7F);
+    inquiry.push_back((resp_muid.value >> 21) & 0x7F);
+    inquiry.push_back(0xF7);
+
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+    REQUIRE(reply.size() >= 14);
+
+    // Reply header: F0 7E 7F 0D ProfileReply version src(4) dst(4)
+    REQUIRE(reply[0] == 0xF0);
+    REQUIRE(reply[4] == static_cast<uint8_t>(CiMessageType::ProfileReply));
+    // Source MUID = responder (bytes 6..9)
+    uint32_t src =  (uint32_t)reply[6]
+                 | ((uint32_t)reply[7]  << 7)
+                 | ((uint32_t)reply[8]  << 14)
+                 | ((uint32_t)reply[9]  << 21);
+    REQUIRE(src == resp_muid.value);
+    // Destination MUID = peer (bytes 10..13) — this is the regression assertion.
+    uint32_t dst =  (uint32_t)reply[10]
+                 | ((uint32_t)reply[11] << 7)
+                 | ((uint32_t)reply[12] << 14)
+                 | ((uint32_t)reply[13] << 21);
+    REQUIRE(dst == peer_muid.value);
+}


### PR DESCRIPTION
## Summary

Latent bug from the production-readiness audit. \`CiDiscovery::handle_profile_inquiry\` ignored its \`data\`/\`size\` arguments and wrote only our source MUID into the \`ProfileReply\`, dropping the destination field entirely. On a multi-device MIDI CI bus, peers could not route our profile replies back because the destination MUID was absent.

## Fix

Parse the inquirer's MUID from the inquiry message — bytes 6..9 of the standard MIDI CI layout (\`F0 7E dev 0D sub-id version src(4) dst(4) F7\`) — and write it as the destination via \`write_muid(reply, inquirer)\`.

## Regression test

New test case \`"CiDiscovery profile reply echoes inquirer MUID"\` synthesizes an inquiry from a distinct peer MUID, passes it through \`process_message\`, and asserts the reply's \`src\` = us and \`dst\` = peer. The previous implementation would have failed the \`dst\` assertion — the destination field was omitted entirely.

Note: the branch head also carries an unrelated parallel-agent commit for AUv3 MIDI packet validation (slice 1.4). Keeping both together because CI can process them in one pass; either can be reverted independently if needed.

## Test plan

- [x] \`pulp-test-midi-ci\`: 27 assertions / 9 cases pass (was 22 / 8)
- [ ] CI green on Linux + Windows + macOS

Version-Bump: sdk=patch reason="MIDI CI protocol compliance fix; reply routing repaired"