### PR TITLE
Workstream 02 slice 2.2: Linux factory selects JACK when running

### DIFF
--- a/core/audio/platform/linux/alsa_device.cpp
+++ b/core/audio/platform/linux/alsa_device.cpp
@@ -290,16 +290,22 @@ DeviceInfo AlsaSystem::default_input_device() {
 
 } // namespace pulp::audio::linux_platform
 
-// Factory function — prefers JACK when available (lower latency, PipeWire compatible)
-namespace pulp::audio {
-
 #ifdef PULP_HAS_JACK
-// Forward declaration — implemented in jack_device.cpp
-namespace linux_platform { bool jack_is_available(); }
+#include "jack_device.hpp"  // JackSystem + jack_is_available
 #endif
 
+// Factory function — prefers JACK when a running server is detected.
+// Workstream 02 slice 2.2: previously unconditionally returned AlsaSystem
+// even when the JACK backend was compiled in, so JACK was dead code.
+namespace pulp::audio {
+
 std::unique_ptr<AudioSystem> create_audio_system() {
-    // ALSA is always the fallback — works everywhere including PipeWire/PulseAudio
+#ifdef PULP_HAS_JACK
+    if (linux_platform::jack_is_available()) {
+        return std::make_unique<linux_platform::JackSystem>();
+    }
+#endif
+    // ALSA fallback — works everywhere including PipeWire/PulseAudio.
     return std::make_unique<linux_platform::AlsaSystem>();
 }
 

--- a/core/audio/platform/linux/jack_device.cpp
+++ b/core/audio/platform/linux/jack_device.cpp
@@ -217,4 +217,45 @@ bool jack_is_available() {
     return false;
 }
 
+// ── JackSystem (workstream 02 slice 2.2) ───────────────────────────────
+
+std::vector<DeviceInfo> JackSystem::enumerate_devices() {
+    // JACK exposes a single logical "server" as the device. Sample rate
+    // and buffer size come from the running server; probe once to read
+    // real values rather than hard-coded guesses.
+    DeviceInfo info;
+    info.id = "jack";
+    info.name = "JACK Audio Server";
+    info.max_input_channels = 64;
+    info.max_output_channels = 64;
+    info.default_sample_rate = 48000.0;
+    info.buffer_sizes = {64, 128, 256, 512, 1024};
+    info.is_default = true;
+    jack_status_t status;
+    if (jack_client_t* probe = jack_client_open(
+            "pulp_enum", JackNoStartServer, &status)) {
+        info.default_sample_rate =
+            static_cast<double>(jack_get_sample_rate(probe));
+        int bs = static_cast<int>(jack_get_buffer_size(probe));
+        if (bs > 0) info.buffer_sizes = {bs};
+        jack_client_close(probe);
+    }
+    return {info};
+}
+
+std::unique_ptr<AudioDevice> JackSystem::create_device(const std::string& device_id) {
+    (void)device_id;
+    return std::make_unique<JackDevice>("pulp");
+}
+
+DeviceInfo JackSystem::default_output_device() {
+    auto devs = enumerate_devices();
+    return devs.empty() ? DeviceInfo{} : devs.front();
+}
+
+DeviceInfo JackSystem::default_input_device() {
+    auto devs = enumerate_devices();
+    return devs.empty() ? DeviceInfo{} : devs.front();
+}
+
 } // namespace pulp::audio::linux_platform

--- a/core/audio/platform/linux/jack_device.hpp
+++ b/core/audio/platform/linux/jack_device.hpp
@@ -50,4 +50,16 @@ private:
 // Check if a JACK server is available
 bool jack_is_available();
 
+/// AudioSystem wrapper that routes create_device() to JackDevice.
+/// Workstream 02 slice 2.2 — previously no JackSystem existed, so the
+/// Linux factory unconditionally returned AlsaSystem even when a JACK
+/// server was running.
+class JackSystem : public AudioSystem {
+public:
+    std::vector<DeviceInfo> enumerate_devices() override;
+    std::unique_ptr<AudioDevice> create_device(const std::string& device_id) override;
+    DeviceInfo default_output_device() override;
+    DeviceInfo default_input_device() override;
+};
+
 } // namespace pulp::audio::linux_platform


### PR DESCRIPTION
**Before:** `create_audio_system()` on Linux unconditionally returned `AlsaSystem`. Even with `PULP_HAS_JACK` on and `jack_device.cpp` compiled in, the Pulp standalone app never used JACK — `JackSystem` didn't exist, so `JackDevice` couldn't be wrapped as an `AudioSystem`.

**After:**
- New `JackSystem` class implementing `AudioSystem`. `enumerate_devices()` probes a throwaway `pulp_enum` client (`JackNoStartServer`) so reported sample rate + buffer size come from the running server.
- Factory calls `jack_is_available()` first; returns `JackSystem` if a server is running, falls back to `AlsaSystem` otherwise. `jack_client_open` with `JackNoStartServer` fails in single-digit milliseconds when absent — acceptable fallback cost.

Fixes the audit's flagged dead-code JACK path.

## Test plan
- [x] `pulp-audio` builds clean on macOS (Linux-only files gated at CMake level)
- [ ] Linux VM build + standalone launch with + without JACK server running