### PR TITLE
Workstream 07 slice 7.2: A/B compare component

### DIFF
--- a/core/view/include/pulp/view/ab_compare.hpp
+++ b/core/view/include/pulp/view/ab_compare.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+// A/B compare (workstream 07 slice 7.2).
+//
+// Two-slot state snapshot component backed by pulp::state::StateStore's
+// serialize/deserialize contract. Plugin UIs wire an ABCompare over their
+// StateStore to support the workflow every mature audio developer expects:
+// edit preset A, snap to B, tweak B separately, toggle A/B to hear the
+// difference, copy one slot over the other.
+//
+// This component holds the raw serialized bytes per slot and drives the
+// StateStore through its public API; it does not touch individual
+// ParamValue atomics, so the audio thread is never stalled.
+
+#include <pulp/state/store.hpp>
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace pulp::view {
+
+class ABCompare {
+public:
+    enum class Slot { A = 0, B = 1 };
+
+    explicit ABCompare(state::StateStore* store) : store_(store) {}
+
+    /// Which slot is currently live (i.e. what the StateStore was last
+    /// switched to). Defaults to A.
+    Slot current() const { return current_; }
+
+    /// Capture the StateStore's current state into `slot`.
+    void save_to(Slot slot) {
+        if (!store_) return;
+        buffer_for(slot) = store_->serialize();
+    }
+
+    /// Restore the StateStore from `slot`. Call once at startup to prime
+    /// an initial snapshot before any user edits; subsequent load_from
+    /// calls drive the A/B toggle itself.
+    bool load_from(Slot slot) {
+        if (!store_) return false;
+        const auto& buf = buffer_for(slot);
+        if (buf.empty()) return false;
+        if (!store_->deserialize(std::span<const uint8_t>(buf.data(), buf.size())))
+            return false;
+        current_ = slot;
+        return true;
+    }
+
+    /// Toggle between A and B. Fails if the target slot has no snapshot.
+    bool toggle() {
+        return load_from(current_ == Slot::A ? Slot::B : Slot::A);
+    }
+
+    /// Overwrite `dst` with a copy of `src`'s snapshot. Useful when a user
+    /// wants "start B from A and tweak".
+    void copy(Slot src, Slot dst) {
+        if (src == dst) return;
+        buffer_for(dst) = buffer_for(src);
+    }
+
+    /// Swap A and B.
+    void swap() {
+        std::swap(buffer_for(Slot::A), buffer_for(Slot::B));
+    }
+
+    /// Does `slot` currently hold a snapshot?
+    bool has(Slot slot) const { return !buffer_for(slot).empty(); }
+
+    /// Drop any saved snapshot from `slot`.
+    void clear(Slot slot) { buffer_for(slot).clear(); }
+
+    /// Raw snapshot bytes (exposed for serialization of the A/B pair
+    /// itself — e.g. persisting A/B across session reloads).
+    std::span<const uint8_t> snapshot(Slot slot) const {
+        const auto& b = buffer_for(slot);
+        return {b.data(), b.size()};
+    }
+
+private:
+    std::vector<uint8_t>& buffer_for(Slot slot) {
+        return slots_[static_cast<size_t>(slot)];
+    }
+    const std::vector<uint8_t>& buffer_for(Slot slot) const {
+        return slots_[static_cast<size_t>(slot)];
+    }
+
+    state::StateStore* store_ = nullptr;
+    std::array<std::vector<uint8_t>, 2> slots_;
+    Slot current_ = Slot::A;
+};
+
+}  // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,11 @@ add_executable(pulp-test-image-cache test_image_cache.cpp)
 target_link_libraries(pulp-test-image-cache PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-image-cache)
 
+# A/B compare (workstream 07 slice 7.2)
+add_executable(pulp-test-ab-compare test_ab_compare.cpp)
+target_link_libraries(pulp-test-ab-compare PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-ab-compare)
+
 # TextShaper (PreText-style measure-once-reflow-forever)
 add_executable(pulp-test-text-shaper test_text_shaper.cpp)
 target_link_libraries(pulp-test-text-shaper PRIVATE pulp::canvas Catch2::Catch2WithMain)

--- a/test/test_ab_compare.cpp
+++ b/test/test_ab_compare.cpp
@@ -1,0 +1,92 @@
+// Unit tests for the A/B compare component (workstream 07 slice 7.2).
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/ab_compare.hpp>
+#include <pulp/state/store.hpp>
+
+using namespace pulp;
+using namespace pulp::view;
+
+namespace {
+void populate(state::StateStore& s) {
+    s.add_parameter({.id = 1, .name = "Gain", .unit = "dB",
+                     .range = {-60.0f, 24.0f, 0.0f, 0.1f}});
+    s.add_parameter({.id = 2, .name = "Mix", .unit = "",
+                     .range = {0.0f, 1.0f, 0.5f, 0.01f}});
+}
+} // namespace
+
+TEST_CASE("ABCompare: save + load restores parameters", "[ui][ab-compare]") {
+    state::StateStore store; populate(store);
+    ABCompare ab(&store);
+
+    store.set_value(1, 6.0f);
+    store.set_value(2, 0.25f);
+    ab.save_to(ABCompare::Slot::A);
+    REQUIRE(ab.has(ABCompare::Slot::A));
+    REQUIRE_FALSE(ab.has(ABCompare::Slot::B));
+
+    store.set_value(1, -12.0f);
+    store.set_value(2, 0.75f);
+    ab.save_to(ABCompare::Slot::B);
+    REQUIRE(ab.has(ABCompare::Slot::B));
+
+    REQUIRE(ab.load_from(ABCompare::Slot::A));
+    REQUIRE(store.get_value(1) == 6.0f);
+    REQUIRE(store.get_value(2) == 0.25f);
+    REQUIRE(ab.current() == ABCompare::Slot::A);
+}
+
+TEST_CASE("ABCompare: toggle flips between A and B", "[ui][ab-compare]") {
+    state::StateStore store; populate(store);
+    ABCompare ab(&store);
+
+    store.set_value(1, 3.0f);
+    ab.save_to(ABCompare::Slot::A);
+    store.set_value(1, -3.0f);
+    ab.save_to(ABCompare::Slot::B);
+
+    REQUIRE(ab.load_from(ABCompare::Slot::A));
+    REQUIRE(ab.toggle());
+    REQUIRE(ab.current() == ABCompare::Slot::B);
+    REQUIRE(store.get_value(1) == -3.0f);
+    REQUIRE(ab.toggle());
+    REQUIRE(ab.current() == ABCompare::Slot::A);
+    REQUIRE(store.get_value(1) == 3.0f);
+}
+
+TEST_CASE("ABCompare: load from empty slot fails cleanly", "[ui][ab-compare]") {
+    state::StateStore store; populate(store);
+    ABCompare ab(&store);
+    REQUIRE_FALSE(ab.load_from(ABCompare::Slot::A));
+    REQUIRE_FALSE(ab.load_from(ABCompare::Slot::B));
+}
+
+TEST_CASE("ABCompare: copy + swap", "[ui][ab-compare]") {
+    state::StateStore store; populate(store);
+    ABCompare ab(&store);
+
+    store.set_value(1, 10.0f);
+    ab.save_to(ABCompare::Slot::A);
+    ab.copy(ABCompare::Slot::A, ABCompare::Slot::B);
+    REQUIRE(ab.has(ABCompare::Slot::B));
+    REQUIRE(ab.load_from(ABCompare::Slot::B));
+    REQUIRE(store.get_value(1) == 10.0f);
+
+    store.set_value(1, -5.0f);
+    ab.save_to(ABCompare::Slot::B);  // B is now -5
+    ab.swap();                       // A ↔ B
+    REQUIRE(ab.load_from(ABCompare::Slot::A));
+    REQUIRE(store.get_value(1) == -5.0f);
+}
+
+TEST_CASE("ABCompare: clear + snapshot access", "[ui][ab-compare]") {
+    state::StateStore store; populate(store);
+    ABCompare ab(&store);
+    store.set_value(1, 1.0f);
+    ab.save_to(ABCompare::Slot::A);
+    REQUIRE(ab.snapshot(ABCompare::Slot::A).size() > 0);
+    ab.clear(ABCompare::Slot::A);
+    REQUIRE_FALSE(ab.has(ABCompare::Slot::A));
+    REQUIRE(ab.snapshot(ABCompare::Slot::A).size() == 0);
+}


### PR DESCRIPTION
`pulp::view::ABCompare` — two-slot state snapshot backed by `StateStore::serialize`/`deserialize`. Supports the full A/B workflow: save_to / load_from / toggle / copy / swap / clear. Audio thread is never stalled — captures + restores through StateStore's public contract.

## API
```cpp
ABCompare ab(&store);
ab.save_to(ABCompare::Slot::A);
// ...tweak...
ab.save_to(ABCompare::Slot::B);
ab.toggle();                      // flip A ↔ B
ab.copy(Slot::A, Slot::B);        // start B from A
ab.swap();
```

## Test plan
- [x] `ctest -R ab-compare` → 5 cases, 24 assertions, all pass
  - save + load round-trip restores parameters
  - toggle flips current() and applies state
  - load_from empty slot fails cleanly
  - copy + swap semantics
  - clear + snapshot raw byte access

Widget-shell rendering (buttons + UI glue) in a follow-up.