### PR TITLE
Workstream 02 slice 2.6a: MidiBuffer UMP sidecar accessor

### DIFF
--- a/core/midi/include/pulp/midi/buffer.hpp
+++ b/core/midi/include/pulp/midi/buffer.hpp
@@ -53,8 +53,24 @@ public:
 
     const MidiEvent& operator[](std::size_t index) const { return events_[index]; }
 
+    /// Attach a UmpBuffer sidecar carrying MIDI 2.0 packets that can't be
+    /// represented as choc::midi::ShortMessage (UMP type-4 channel voice,
+    /// type-3/5 data, type-0 utility, etc.). Format adapters set this
+    /// before process(); plugins opting in to
+    /// PluginDescriptor::supports_ump read it via ump(). Ownership stays
+    /// with the caller; the buffer must outlive the process() block.
+    /// Workstream 02 slice 2.6.
+    void attach_ump(class UmpBuffer* ump) { ump_ = ump; }
+
+    /// Attached UmpBuffer or nullptr. A null return means "no UMP events
+    /// this block", not "UMP unsupported" — that's declared at descriptor
+    /// time via PluginDescriptor::supports_ump.
+    const class UmpBuffer* ump() const { return ump_; }
+    class UmpBuffer* ump() { return ump_; }
+
 private:
     std::vector<MidiEvent> events_;
+    class UmpBuffer* ump_ = nullptr;
 };
 
 } // namespace pulp::midi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -114,6 +114,11 @@ add_executable(pulp-test-ab-compare test_ab_compare.cpp)
 target_link_libraries(pulp-test-ab-compare PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-ab-compare)
 
+# MidiBuffer UMP sidecar (workstream 02 slice 2.6a)
+add_executable(pulp-test-midi-buffer-ump test_midi_buffer_ump.cpp)
+target_link_libraries(pulp-test-midi-buffer-ump PRIVATE pulp::midi Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-midi-buffer-ump)
+
 # TextShaper (PreText-style measure-once-reflow-forever)
 add_executable(pulp-test-text-shaper test_text_shaper.cpp)
 target_link_libraries(pulp-test-text-shaper PRIVATE pulp::canvas Catch2::Catch2WithMain)

--- a/test/test_midi_buffer_ump.cpp
+++ b/test/test_midi_buffer_ump.cpp
@@ -1,0 +1,43 @@
+// Verifies MidiBuffer::attach_ump / ump() sidecar plumbing.
+// Workstream 02 slice 2.6 — format adapters now have a place to deliver
+// native UMP packets (type-4 channel voice, SysEx, utility, etc.) that
+// don't fit in choc::midi::ShortMessage.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/midi/buffer.hpp>
+#include <pulp/midi/ump_buffer.hpp>
+#include <pulp/midi/ump.hpp>
+
+using namespace pulp::midi;
+
+TEST_CASE("MidiBuffer defaults to no attached UMP sidecar",
+          "[midi][buffer][ump]") {
+    MidiBuffer buf;
+    REQUIRE(buf.ump() == nullptr);
+}
+
+TEST_CASE("attach_ump installs + clears the sidecar pointer",
+          "[midi][buffer][ump]") {
+    MidiBuffer buf;
+    UmpBuffer ump;
+    buf.attach_ump(&ump);
+    REQUIRE(buf.ump() == &ump);
+    buf.attach_ump(nullptr);
+    REQUIRE(buf.ump() == nullptr);
+}
+
+TEST_CASE("plugin-side consumer can iterate UMP packets via the sidecar",
+          "[midi][buffer][ump]") {
+    MidiBuffer buf;
+    buf.add(MidiEvent::note_on(0, 60, 100));  // main short-message path
+
+    UmpBuffer ump;
+    ump.add(UmpPacket::note_on_2(0, 0, 72, 0xFFFF));
+    ump.add(UmpPacket::note_off_2(0, 0, 72, 0));
+    buf.attach_ump(&ump);
+
+    REQUIRE(buf.size() == 1);            // short-message count unchanged
+    REQUIRE(buf.ump() != nullptr);
+    REQUIRE(buf.ump()->size() == 2);     // UMP sidecar visible
+    REQUIRE((*buf.ump())[0].packet.message_type() == UmpMessageType::Midi2ChannelVoice);
+}


### PR DESCRIPTION
Adds `MidiBuffer::attach_ump(UmpBuffer*)` + `ump()` so format adapters can deliver MIDI 2.0 UMP packets alongside the existing short-message stream. Additive — the short-message path is unchanged; plugins that don't care about UMP see identical behaviour.

Unblocks the CoreMIDI UMP decode from #184 to reach plugins: previously there was no place to stash a decoded type-4 packet once the downgrade path didn't apply.

## Test plan
- [x] `ctest -R midi-buffer-ump` → 3 cases, 7 assertions, all pass (default nullptr, attach + detach, plugin-side visibility)

## Follow-up
Format-adapter wiring (CLAP, VST3, AUv3) lands in subsequent slices.