### PR TITLE
Workstream 02 slice 2.7: AudioSystem hotplug callback base plumbing

### DIFF
--- a/core/audio/include/pulp/audio/device.hpp
+++ b/core/audio/include/pulp/audio/device.hpp
@@ -76,7 +76,31 @@ public:
     /// The callback may fire on an OS thread — callers should dispatch to the
     /// main/UI thread if needed. Pass nullptr to unregister.
     using DeviceChangeCallback = std::function<void()>;
-    virtual void set_device_change_callback(DeviceChangeCallback) {}
+
+    /// Default implementation stores the callback in a base-class slot.
+    /// Non-macOS backends that gain real hotplug probing in later slices
+    /// (workstream 02 — WASAPI IMMNotificationClient, ALSA udev monitor,
+    /// Win32 MIDI DeviceWatcher, ALSA seq monitor) call `fire_device_change()`
+    /// when a change is detected. Backends with richer semantics can still
+    /// override this entirely.
+    virtual void set_device_change_callback(DeviceChangeCallback cb) {
+        device_change_callback_ = std::move(cb);
+    }
+
+protected:
+    /// Dispatch a stored device-change callback. Safe to call from any
+    /// thread; the callback itself is responsible for UI-thread marshalling.
+    void fire_device_change() {
+        if (device_change_callback_) device_change_callback_();
+    }
+    /// Accessible to subclasses that want to observe whether a caller
+    /// registered a callback.
+    bool has_device_change_callback() const {
+        return static_cast<bool>(device_change_callback_);
+    }
+
+private:
+    DeviceChangeCallback device_change_callback_;
 };
 
 // Create the platform-appropriate audio system

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -114,6 +114,11 @@ add_executable(pulp-test-ab-compare test_ab_compare.cpp)
 target_link_libraries(pulp-test-ab-compare PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-ab-compare)
 
+# AudioSystem hotplug base plumbing (workstream 02 slice 2.7)
+add_executable(pulp-test-audio-system-hotplug test_audio_system_hotplug.cpp)
+target_link_libraries(pulp-test-audio-system-hotplug PRIVATE pulp::audio Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-audio-system-hotplug)
+
 # TextShaper (PreText-style measure-once-reflow-forever)
 add_executable(pulp-test-text-shaper test_text_shaper.cpp)
 target_link_libraries(pulp-test-text-shaper PRIVATE pulp::canvas Catch2::Catch2WithMain)

--- a/test/test_audio_system_hotplug.cpp
+++ b/test/test_audio_system_hotplug.cpp
@@ -1,0 +1,58 @@
+// Verifies AudioSystem's base-class hotplug plumbing (workstream 02 slice 2.7).
+// A non-macOS backend can now store a callback via the default
+// set_device_change_callback() and fire it via fire_device_change()
+// without having to reimplement the storage in each subclass.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/audio/device.hpp>
+
+#include <atomic>
+
+using namespace pulp::audio;
+
+namespace {
+
+// Minimal AudioSystem that exposes the protected fire_device_change()
+// for testing. Simulates a non-macOS backend using base-class storage.
+class StubSystem : public AudioSystem {
+public:
+    std::vector<DeviceInfo> enumerate_devices() override { return {}; }
+    std::unique_ptr<AudioDevice> create_device(const std::string&) override {
+        return nullptr;
+    }
+    DeviceInfo default_output_device() override { return {}; }
+    DeviceInfo default_input_device() override { return {}; }
+    // expose protected helpers for the test
+    using AudioSystem::fire_device_change;
+    using AudioSystem::has_device_change_callback;
+};
+
+} // namespace
+
+TEST_CASE("base class stores + fires the callback", "[audio][hotplug]") {
+    StubSystem sys;
+    std::atomic<int> calls{0};
+    REQUIRE_FALSE(sys.has_device_change_callback());
+    sys.set_device_change_callback([&] { ++calls; });
+    REQUIRE(sys.has_device_change_callback());
+    sys.fire_device_change();
+    sys.fire_device_change();
+    REQUIRE(calls.load() == 2);
+}
+
+TEST_CASE("fire is a no-op with no callback", "[audio][hotplug]") {
+    StubSystem sys;
+    sys.fire_device_change();   // must not crash
+    SUCCEED("fire_device_change returned cleanly with no callback");
+}
+
+TEST_CASE("nullptr unregisters the callback", "[audio][hotplug]") {
+    StubSystem sys;
+    int calls = 0;
+    sys.set_device_change_callback([&] { ++calls; });
+    sys.fire_device_change();
+    sys.set_device_change_callback(nullptr);
+    REQUIRE_FALSE(sys.has_device_change_callback());
+    sys.fire_device_change();
+    REQUIRE(calls == 1);
+}


### PR DESCRIPTION
Moves device-change callback storage + dispatch into `AudioSystem` base. Non-macOS backends (WASAPI, ALSA, future Win32 MIDI, ALSA seq) no longer have to reimplement the storage slot when they gain real hotplug probes — they just call `fire_device_change()`.

## API
```cpp
virtual void set_device_change_callback(cb);     // stores cb (default impl)
protected void fire_device_change();             // null-safe dispatch
protected bool has_device_change_callback() const;
```

The macOS `CoreAudioSystem` keeps its existing override because it additionally wires NSWorkspace notifications — path unchanged.

## Test plan
- [x] `ctest -R audio-system-hotplug` → 3 cases, 6 assertions, all pass
  (storage + fire, no-op with no callback, nullptr unregister)
- [x] `pulp-audio` library builds clean on Apple clang