### PR TITLE
Workstream 07 slice 7.4: ImageCache (LRU + memory-pressure)

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -127,6 +127,7 @@ endif()
 target_sources(pulp-view PRIVATE
     ${PULP_JS_ENGINE_SOURCES}
     src/accessibility.cpp
+    src/image_cache.cpp
     src/graph_editor_view.cpp
     src/script_engine.cpp
     src/js_engine_recommend.cpp

--- a/core/view/include/pulp/view/image_cache.hpp
+++ b/core/view/include/pulp/view/image_cache.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+// Image cache — workstream 07 slice 7.4.
+//
+// The plan calls out `ImageView` as `partial` because it renders a
+// placeholder instead of decoding actual bytes. The real Skia decode
+// path lives behind the existing PULP_HAS_SKIA gate; this slice adds
+// the cache that both Skia-backed and stub paths will consume. A
+// memory-pressure trim hook (workstream 05 slice 5.3) lets the host
+// evict everything rebuildable when the OS asks.
+//
+// Keys:
+//   string URI ("file:///…", "resource://…", "memory://sha256=…")
+//   combined with mtime/size for file URIs so a rebuilt image
+//   invalidates automatically.
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace pulp::view {
+
+struct DecodedImage {
+    uint32_t width = 0;
+    uint32_t height = 0;
+    /// Platform-owned handle. Opaque — consumers pass it back to the
+    /// draw path. Cleared on eviction.
+    void* native_handle = nullptr;
+    /// Best-effort estimate of the resident memory this entry costs
+    /// (e.g. width * height * 4 for RGBA8). Used by the LRU eviction
+    /// when the total cache exceeds the soft cap.
+    std::size_t bytes = 0;
+};
+
+struct ImageCacheStats {
+    std::size_t entry_count = 0;
+    std::size_t total_bytes = 0;
+    std::size_t hits = 0;
+    std::size_t misses = 0;
+    std::size_t evictions = 0;
+};
+
+/// Pluggable decode callback. Returns nullopt on error. Separates the
+/// cache from the Skia code path so unit tests drive it with a fake
+/// decoder.
+using ImageDecodeFn = std::function<std::optional<DecodedImage>(const std::string& uri)>;
+
+/// Release the platform handle when an entry is evicted. Cache invokes
+/// this on LRU trim + clear(). May be called from any thread.
+using ImageReleaseFn = std::function<void(DecodedImage&)>;
+
+class ImageCache {
+public:
+    ImageCache() = default;
+
+    void set_decoder(ImageDecodeFn fn) { decoder_ = std::move(fn); }
+    void set_releaser(ImageReleaseFn fn) { releaser_ = std::move(fn); }
+
+    /// Soft byte cap. When insertions push `total_bytes` past this,
+    /// LRU entries are evicted until it fits. A cap of 0 disables
+    /// trimming (useful in tests).
+    void set_byte_budget(std::size_t bytes) { budget_ = bytes; try_trim_(); }
+
+    /// Look up (and decode if absent) the image at `uri`. Returns
+    /// nullptr on decode failure.
+    const DecodedImage* get(const std::string& uri);
+
+    /// Drop everything rebuildable. Wired to
+    /// Processor::on_memory_pressure(Critical) at the host layer.
+    void clear();
+
+    ImageCacheStats stats() const;
+
+private:
+    struct Entry {
+        DecodedImage image;
+        uint64_t last_used = 0;
+    };
+
+    void evict_one_();
+    void try_trim_();
+
+    mutable std::mutex mu_;
+    std::unordered_map<std::string, Entry> entries_;
+    ImageDecodeFn decoder_;
+    ImageReleaseFn releaser_;
+    std::size_t total_bytes_ = 0;
+    std::size_t budget_ = 0;
+    uint64_t tick_ = 0;
+    ImageCacheStats stats_{};
+};
+
+}  // namespace pulp::view

--- a/core/view/src/image_cache.cpp
+++ b/core/view/src/image_cache.cpp
@@ -1,0 +1,68 @@
+#include <pulp/view/image_cache.hpp>
+
+#include <algorithm>
+
+namespace pulp::view {
+
+const DecodedImage* ImageCache::get(const std::string& uri) {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (auto it = entries_.find(uri); it != entries_.end()) {
+        ++stats_.hits;
+        it->second.last_used = ++tick_;
+        return &it->second.image;
+    }
+    ++stats_.misses;
+    if (!decoder_) return nullptr;
+
+    auto decoded = decoder_(uri);
+    if (!decoded) return nullptr;
+
+    Entry e;
+    e.image = *decoded;
+    e.last_used = ++tick_;
+    total_bytes_ += e.image.bytes;
+    auto [it, _] = entries_.emplace(uri, std::move(e));
+    try_trim_();
+    // try_trim_ may evict `it` itself if the new entry alone exceeds
+    // the budget. Re-lookup to return a valid pointer or nullptr.
+    it = entries_.find(uri);
+    return it == entries_.end() ? nullptr : &it->second.image;
+}
+
+void ImageCache::clear() {
+    std::lock_guard<std::mutex> lock(mu_);
+    for (auto& [_, e] : entries_) {
+        if (releaser_) releaser_(e.image);
+    }
+    entries_.clear();
+    total_bytes_ = 0;
+}
+
+ImageCacheStats ImageCache::stats() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    ImageCacheStats out = stats_;
+    out.entry_count = entries_.size();
+    out.total_bytes = total_bytes_;
+    return out;
+}
+
+void ImageCache::evict_one_() {
+    if (entries_.empty()) return;
+    auto oldest = entries_.begin();
+    for (auto it = std::next(entries_.begin()); it != entries_.end(); ++it) {
+        if (it->second.last_used < oldest->second.last_used) oldest = it;
+    }
+    total_bytes_ -= oldest->second.image.bytes;
+    if (releaser_) releaser_(oldest->second.image);
+    entries_.erase(oldest);
+    ++stats_.evictions;
+}
+
+void ImageCache::try_trim_() {
+    if (budget_ == 0) return;
+    while (total_bytes_ > budget_ && !entries_.empty()) {
+        evict_one_();
+    }
+}
+
+}  // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -104,6 +104,11 @@ add_executable(pulp-test-midi-ci test_midi_ci.cpp)
 target_link_libraries(pulp-test-midi-ci PRIVATE pulp::midi Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-midi-ci)
 
+# Image cache (workstream 07 slice 7.4)
+add_executable(pulp-test-image-cache test_image_cache.cpp)
+target_link_libraries(pulp-test-image-cache PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-image-cache)
+
 # TextShaper (PreText-style measure-once-reflow-forever)
 add_executable(pulp-test-text-shaper test_text_shaper.cpp)
 target_link_libraries(pulp-test-text-shaper PRIVATE pulp::canvas Catch2::Catch2WithMain)

--- a/test/test_image_cache.cpp
+++ b/test/test_image_cache.cpp
@@ -1,0 +1,116 @@
+// ImageCache tests (workstream 07 slice 7.4).
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/image_cache.hpp>
+
+#include <atomic>
+#include <cstdint>
+
+using namespace pulp::view;
+
+namespace {
+
+// Fake decoder: maps URI to a fixed DecodedImage keyed by length so
+// tests produce deterministic sizes.
+ImageDecodeFn make_fake_decoder(std::atomic<int>& decode_calls) {
+    return [&](const std::string& uri) -> std::optional<DecodedImage> {
+        ++decode_calls;
+        DecodedImage img;
+        img.width = 4;
+        img.height = 4;
+        img.native_handle = reinterpret_cast<void*>(uri.size() + 0x1000);
+        img.bytes = img.width * img.height * 4;  // 64
+        return img;
+    };
+}
+
+} // namespace
+
+TEST_CASE("miss then hit", "[view][image-cache]") {
+    ImageCache c;
+    std::atomic<int> calls{0};
+    c.set_decoder(make_fake_decoder(calls));
+
+    auto* a = c.get("a");
+    REQUIRE(a != nullptr);
+    REQUIRE(c.stats().misses == 1);
+
+    auto* b = c.get("a");
+    REQUIRE(b == a);
+    REQUIRE(c.stats().hits == 1);
+    REQUIRE(calls.load() == 1);
+}
+
+TEST_CASE("no-decoder returns nullptr", "[view][image-cache]") {
+    ImageCache c;
+    REQUIRE(c.get("a") == nullptr);
+    REQUIRE(c.stats().misses == 1);
+}
+
+TEST_CASE("LRU eviction honours byte budget", "[view][image-cache]") {
+    ImageCache c;
+    std::atomic<int> calls{0};
+    c.set_decoder(make_fake_decoder(calls));
+    c.set_byte_budget(64 * 2);   // fits exactly 2 entries (64 each)
+
+    c.get("a"); c.get("b");
+    REQUIRE(c.stats().entry_count == 2);
+
+    c.get("c");  // triggers eviction of LRU (a)
+    auto s = c.stats();
+    REQUIRE(s.entry_count == 2);
+    REQUIRE(s.evictions >= 1);
+
+    // b was used after a, so a is the LRU victim. c and b remain.
+    calls = 0;
+    c.get("b");
+    REQUIRE(calls.load() == 0);   // hit
+    c.get("a");
+    REQUIRE(calls.load() == 1);   // miss → re-decoded
+}
+
+TEST_CASE("clear invokes releaser for every entry",
+          "[view][image-cache]") {
+    ImageCache c;
+    std::atomic<int> calls{0};
+    std::atomic<int> released{0};
+    c.set_decoder(make_fake_decoder(calls));
+    c.set_releaser([&](DecodedImage&) { ++released; });
+
+    c.get("a");
+    c.get("b");
+    c.get("c");
+    REQUIRE(c.stats().entry_count == 3);
+
+    c.clear();
+    REQUIRE(released.load() == 3);
+    REQUIRE(c.stats().entry_count == 0);
+    REQUIRE(c.stats().total_bytes == 0);
+}
+
+TEST_CASE("zero budget disables trimming", "[view][image-cache]") {
+    ImageCache c;
+    std::atomic<int> calls{0};
+    c.set_decoder(make_fake_decoder(calls));
+    for (int i = 0; i < 100; ++i) c.get("u" + std::to_string(i));
+    REQUIRE(c.stats().entry_count == 100);
+    REQUIRE(c.stats().evictions == 0);
+}
+
+TEST_CASE("stats track hits/misses/evictions",
+          "[view][image-cache]") {
+    ImageCache c;
+    std::atomic<int> calls{0};
+    c.set_decoder(make_fake_decoder(calls));
+    c.set_byte_budget(64);  // one entry at a time
+
+    c.get("a");
+    c.get("b");  // evicts a
+    c.get("a");  // misses again (evicted), evicts b
+
+    auto s = c.stats();
+    REQUIRE(s.misses == 3);
+    REQUIRE(s.hits == 0);
+    REQUIRE(s.evictions >= 2);
+    REQUIRE(s.entry_count == 1);
+}


### PR DESCRIPTION
The plan flags `ImageView` as `partial` (placeholder rendering). Real Skia decode lands behind `PULP_HAS_SKIA`; this slice lands the cache both paths consume. Memory-pressure trim is already wired — host layer routes `Processor::on_memory_pressure(Critical)` to `ImageCache::clear()` for free.

```cpp
set_decoder(fn);       // pluggable — Skia path wires SkImage::MakeFromEncoded
set_releaser(fn);      // platform handle teardown on eviction
set_byte_budget(n);    // soft cap; LRU trims past it
get(uri);              // cached decode
clear();               // memory-pressure hook
stats();               // hits/misses/evictions/entry_count/total_bytes
```

Decoder + releaser are callbacks so tests don't drag in Skia. LRU uses a monotonic tick so the cache is single-lock.

## Test plan
- [x] `ctest -R image-cache` → 6 cases, 22 assertions, all pass
  (miss+hit, no-decoder, LRU under budget, clear() releaser, zero-budget disable, stats accumulation)