### PR TITLE
iOS review fixes: clipboard + child_process + on_mouse_cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to Pulp are documented here.
 
+## [0.11.0]
+
 ## [0.10.0]
 
 ## [0.9.0]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.10.1
+    VERSION 0.11.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -319,7 +319,7 @@ public:
     /// Forward-declared so plugin TUs that don't implement ARA don't
     /// need to pull `pulp/format/ara.hpp`.
     virtual std::unique_ptr<class AraDocumentController>
-    create_ara_document_controller() { return nullptr; }
+    create_ara_document_controller();
 
     /// Access the parameter state store.
     /// Use state().get_value(id) to read parameter values in process().

--- a/core/format/src/ara.cpp
+++ b/core/format/src/ara.cpp
@@ -1,4 +1,5 @@
 #include <pulp/format/ara.hpp>
+#include <pulp/format/processor.hpp>
 
 #ifdef PULP_HAS_ARA
 #include <ARA_API/ARAInterface.h>
@@ -37,4 +38,12 @@ int ara_sdk_generation() {
 #endif
 }
 
+// Out-of-line default so processor.hpp can forward-declare
+// AraDocumentController without forcing every TU to include ara.hpp.
+// Defining it here ensures the unique_ptr deleter is instantiated
+// in a TU where the class is complete.
+std::unique_ptr<AraDocumentController>
+Processor::create_ara_document_controller() { return nullptr; }
+
 }  // namespace pulp::format
+

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -27,7 +27,13 @@ if(APPLE AND NOT IOS)
         "-framework UniformTypeIdentifiers"
     )
 elseif(IOS)
-    # iOS: no Cocoa, no child_process (sandboxed). Use stubs only.
+    # iOS: UIKit-backed clipboard; posix_spawn works (addchdir_np is
+    # gated inside child_process_posix.cpp via TargetConditionals).
+    # File dialogs and popup menus fall through to the stubs.
+    target_sources(pulp-platform PRIVATE
+        platform/ios/clipboard_ios.mm
+        platform/posix/child_process_posix.cpp
+    )
     target_link_libraries(pulp-platform PRIVATE
         "-framework UIKit"
         "-framework UniformTypeIdentifiers"

--- a/core/platform/platform/ios/clipboard_ios.mm
+++ b/core/platform/platform/ios/clipboard_ios.mm
@@ -1,0 +1,47 @@
+// iOS UIPasteboard-backed Clipboard
+#import <UIKit/UIKit.h>
+#include <pulp/platform/clipboard.hpp>
+
+namespace pulp::platform {
+
+bool Clipboard::set_text(const std::string& text) {
+    @autoreleasepool {
+        UIPasteboard* pb = [UIPasteboard generalPasteboard];
+        pb.string = [NSString stringWithUTF8String:text.c_str()];
+        return true;
+    }
+}
+
+std::optional<std::string> Clipboard::get_text() {
+    @autoreleasepool {
+        UIPasteboard* pb = [UIPasteboard generalPasteboard];
+        NSString* s = pb.string;
+        if (!s) return std::nullopt;
+        return std::string(s.UTF8String ? s.UTF8String : "");
+    }
+}
+
+bool Clipboard::has_text() {
+    @autoreleasepool { return [UIPasteboard generalPasteboard].hasStrings; }
+}
+
+bool Clipboard::set_data(const std::string& type, const std::vector<uint8_t>& data) {
+    @autoreleasepool {
+        UIPasteboard* pb = [UIPasteboard generalPasteboard];
+        NSData* nsdata = [NSData dataWithBytes:data.data() length:data.size()];
+        [pb setData:nsdata forPasteboardType:[NSString stringWithUTF8String:type.c_str()]];
+        return true;
+    }
+}
+
+std::optional<std::vector<uint8_t>> Clipboard::get_data(const std::string& type) {
+    @autoreleasepool {
+        UIPasteboard* pb = [UIPasteboard generalPasteboard];
+        NSData* d = [pb dataForPasteboardType:[NSString stringWithUTF8String:type.c_str()]];
+        if (!d) return std::nullopt;
+        const uint8_t* bytes = static_cast<const uint8_t*>(d.bytes);
+        return std::vector<uint8_t>(bytes, bytes + d.length);
+    }
+}
+
+} // namespace pulp::platform

--- a/core/platform/platform/posix/child_process_posix.cpp
+++ b/core/platform/platform/posix/child_process_posix.cpp
@@ -13,6 +13,9 @@
 #ifndef __ANDROID__
 #include <spawn.h>
 #endif
+#if defined(__APPLE__)
+#  include <TargetConditionals.h>
+#endif
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -148,10 +151,16 @@ bool ChildProcess::start(const std::string& command,
     posix_spawn_file_actions_addclose(&actions, impl_->stderr_pipe.read_end());
 
     // Working directory
+    // posix_spawn_file_actions_addchdir_np is available on macOS 10.15+
+    // and glibc 2.29+, but NOT on iOS/tvOS/watchOS simulators.
+#if (defined(__APPLE__) && !(TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_OS_WATCH)) \
+    || (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 29)
     if (!options.working_directory.empty()) {
-        // posix_spawn_file_actions_addchdir_np is available on macOS 10.15+ and glibc 2.29+
         posix_spawn_file_actions_addchdir_np(&actions, options.working_directory.c_str());
     }
+#else
+    // working_directory is silently ignored on iOS/older glibc
+#endif
 
     rc = posix_spawnp(&impl_->pid,
                           command.c_str(),

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -127,6 +127,11 @@ public:
     virtual void on_mouse_down(Point pos) { (void)pos; }
     virtual void on_mouse_up(Point pos) { (void)pos; }
     virtual void on_mouse_drag(Point pos) { (void)pos; }
+
+    /// Pointer / touch cancellation (iOS touchesCancelled, etc.).
+    /// Distinct from on_mouse_up so widgets can roll back in-progress
+    /// gestures. Default forwards to on_mouse_up for back-compat.
+    virtual void on_mouse_cancel(Point pos) { on_mouse_up(pos); }
     virtual void on_key_press(int key_code) { (void)key_code; }
 
     // ── Hover events ──────────────────────────────────────────────────────

--- a/core/view/platform/ios/plugin_view_host_ios.mm
+++ b/core/view/platform/ios/plugin_view_host_ios.mm
@@ -133,7 +133,7 @@
     for (UITouch *touch in touches) {
         auto me = [self mouseEventFromTouch:touch isDown:NO];
         me.is_cancelled = true;
-        self.rootView->on_mouse_up(me.position);
+        self.rootView->on_mouse_cancel(me.position);
         [self removeTouchId:touch];
     }
 }

--- a/core/view/platform/ios/window_host_ios.mm
+++ b/core/view/platform/ios/window_host_ios.mm
@@ -150,7 +150,7 @@ NSArray<UIAccessibilityElement *>* create_accessibility_elements(View& root, UIV
     for (UITouch *touch in touches) {
         auto me = [self mouseEventFromTouch:touch isDown:NO];
         me.is_cancelled = true;
-        self.rootView->on_mouse_up(me.position);
+        self.rootView->on_mouse_cancel(me.position);
         [self removeTouchId:touch];
     }
 }


### PR DESCRIPTION
## Summary
Addresses post-merge Codex review on #222/#223.

### P1 — linker symbols on iOS (#222, #223)
- Add \`platform/ios/clipboard_ios.mm\` (UIPasteboard-backed) so \`pulp::platform::Clipboard\` links on iOS.
- Re-add \`platform/posix/child_process_posix.cpp\` to the iOS branch. \`pulp::platform::exec\` is called from \`core/view/src/widget_bridge.cpp\`; without this TU the iOS link fails. \`posix_spawn\` works on iOS; the non-portable \`addchdir_np\` is already gated via TargetConditionals.

### P2 — preserve cancel semantics (#222)
- New virtual \`View::on_mouse_cancel(Point)\` with a default body that forwards to \`on_mouse_up\` for back-compat.
- iOS \`touchesCancelled\` now routes through \`on_mouse_cancel\` so widgets can roll back in-progress gestures without firing an accidental click.

### Versioning
SDK bumped 0.10.1 → 0.11.0 (additive public-API change on View).

## Test plan
- [x] macOS local build (unchanged surface)
- [ ] iOS Simulator configure still succeeds
- [ ] Namespace CI green

Closes feedback on #222, #223. Refs #218.