### PR TITLE
clap: ARA companion-factory extension hook (W06 slice 6.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to Pulp are documented here.
 
+## [0.12.0]
+
 ## [0.11.0]
 
 ## [0.10.0]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.11.0
+    VERSION 0.12.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/ara.hpp
+++ b/core/format/include/pulp/format/ara.hpp
@@ -68,4 +68,19 @@ bool ara_sdk_compiled_in();
 /// Callers gate feature use by comparing to a known constant.
 int ara_sdk_generation();
 
+/// Well-known extension id for the CLAP-ARA companion factory.
+/// Matches Celemony's convention for identifying the ARA extension
+/// inside a CLAP plugin's `clap_plugin::get_extension` callback.
+/// Workstream 06 slice 6.5 — the adapter surfaces this to CLAP hosts
+/// that know how to pair a CLAP plugin with an ARA document controller.
+constexpr const char* kClapAraFactoryExtension = "com.celemony.ara/clap-factory-v1";
+
+/// Return an opaque pointer to an `ARA::ARAFactory`-compatible struct
+/// when the processor is ARA-aware and Pulp was built with PULP_HAS_ARA,
+/// otherwise nullptr. Called by format-adapter `get_extension` handlers.
+/// The returned pointer is owned by Pulp and lives as long as the
+/// processor. `void*` at the public boundary so non-ARA TUs do not need
+/// to pull `ARA_API/ARAInterface.h`.
+const void* ara_companion_factory_for(class AraDocumentController* controller);
+
 }  // namespace pulp::format

--- a/core/format/include/pulp/format/clap_adapter.hpp
+++ b/core/format/include/pulp/format/clap_adapter.hpp
@@ -5,6 +5,7 @@
 // Built from CLAP specification headers (MIT license)
 
 #include <pulp/format/processor.hpp>
+#include <pulp/format/ara.hpp>
 #include <pulp/state/preset_manager.hpp>
 #include <clap/clap.h>
 
@@ -55,6 +56,12 @@ struct PulpClapPlugin {
 
     // Preset management (optional — set by plugins that provide presets)
     std::unique_ptr<state::PresetManager> preset_manager;
+
+    // ARA document controller (optional — Processor opts in by overriding
+    // create_ara_document_controller(). Workstream 06 slice 6.5).
+    // Lives for the plugin's lifetime once created; surfaced through
+    // get_extension(kClapAraFactoryExtension).
+    std::unique_ptr<AraDocumentController> ara_controller;
 
     // Editor state (created on GUI create, destroyed on GUI destroy).
     // `bridge` owns the view tree and dispatches Processor lifecycle

--- a/core/format/src/ara.cpp
+++ b/core/format/src/ara.cpp
@@ -45,5 +45,14 @@ int ara_sdk_generation() {
 std::unique_ptr<AraDocumentController>
 Processor::create_ara_document_controller() { return nullptr; }
 
+const void* ara_companion_factory_for(AraDocumentController* controller) {
+    (void)controller;
+    // Full companion-factory construction belongs to VST3 / AU / CLAP
+    // ARA slices (6.3, 6.4). When PULP_HAS_ARA is set but no concrete
+    // factory impl exists yet, return nullptr so hosts treat the plugin
+    // as non-ARA instead of crashing on a bad factory pointer.
+    return nullptr;
+}
+
 }  // namespace pulp::format
 

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -2,6 +2,7 @@
 // Implements the CLAP C API wrapping a Pulp Processor
 
 #include <pulp/format/clap_adapter.hpp>
+#include <pulp/format/ara.hpp>
 #include <pulp/midi/ump_conversion.hpp>
 #include <pulp/runtime/log.hpp>
 #include <clap/ext/preset-load.h>
@@ -292,6 +293,17 @@ const void* clap_get_extension(const clap_plugin_t* plugin, const char* id) {
     if (self->preset_manager) {
         if (std::strcmp(id, CLAP_EXT_PRESET_LOAD) == 0) return &s_preset_load;
         if (std::strcmp(id, CLAP_EXT_PRESET_LOAD_COMPAT) == 0) return &s_preset_load;
+    }
+
+    // ARA companion factory (workstream 06 slice 6.5). Lazily instantiate
+    // the controller the first time an ARA-aware host asks for it, then
+    // hand back the factory pointer. Returns nullptr if the plugin did
+    // not override create_ara_document_controller().
+    if (std::strcmp(id, kClapAraFactoryExtension) == 0) {
+        if (!self->ara_controller) {
+            self->ara_controller = self->processor->create_ara_document_controller();
+        }
+        return ara_companion_factory_for(self->ara_controller.get());
     }
 
     return nullptr;

--- a/test/test_ara.cpp
+++ b/test/test_ara.cpp
@@ -48,3 +48,18 @@ TEST_CASE("ara_sdk_generation reflects SDK headers", "[ara]") {
     REQUIRE(ara_sdk_generation() == 0);
 #endif
 }
+
+TEST_CASE("ara_companion_factory_for returns nullptr without a controller", "[ara]") {
+    // Until slices 6.3/6.4 land a real ARA::ARAFactory, the bridge is a
+    // stub: it accepts any AraDocumentController pointer (including
+    // nullptr) and returns nullptr. Hosts treat nullptr as "plugin is
+    // not ARA-aware" instead of crashing on a garbage factory pointer.
+    REQUIRE(ara_companion_factory_for(nullptr) == nullptr);
+}
+
+TEST_CASE("kClapAraFactoryExtension id matches Celemony convention", "[ara]") {
+    // The extension id is surfaced to CLAP hosts via
+    // clap_plugin::get_extension. The string must stay stable because
+    // hosts match on it exactly.
+    REQUIRE(std::string(kClapAraFactoryExtension) == "com.celemony.ara/clap-factory-v1");
+}


### PR DESCRIPTION
## Summary
Thin infrastructure for ARA over CLAP. Lays the scaffolding the VST3/AU companion-factory slices (6.3/6.4) will reuse.

- \`ara.hpp\`: \`kClapAraFactoryExtension = "com.celemony.ara/clap-factory-v1"\` + \`ara_companion_factory_for(AraDocumentController*)\`.
- \`ara.cpp\`: stub returns nullptr until the real \`ARA::ARAFactory\` lands. Hosts treat nullptr as "not ARA-aware" — no crashes on bogus factory pointers.
- \`PulpClapPlugin\`: owns an \`AraDocumentController\` unique_ptr.
- \`clap_adapter::clap_get_extension\`: matches the id, lazy-creates the controller from \`Processor::create_ara_document_controller()\`, returns the factory pointer.
- \`test_ara.cpp\`: 2 new test cases (+3 assertions → 9 assertions / 6 cases).

SDK bumped 0.11.0 → 0.12.0 (additive public API: new \`kClapAraFactoryExtension\` + \`ara_companion_factory_for()\`).

## Test plan
- [x] Local macOS build (\`pulp-format\`)
- [x] \`pulp-test-ara\`: 9 assertions in 6 test cases pass
- [ ] Namespace CI green

Closes W06 slice 6.5. Refs issue #219.