### PR TITLE
ara: VST3 + AU companion-factory extension keys (W06 6.3/6.4)

### DIFF
--- a/core/format/include/pulp/format/ara.hpp
+++ b/core/format/include/pulp/format/ara.hpp
@@ -75,6 +75,19 @@ int ara_sdk_generation();
 /// that know how to pair a CLAP plugin with an ARA document controller.
 constexpr const char* kClapAraFactoryExtension = "com.celemony.ara/clap-factory-v1";
 
+/// VST3 — `IPluginFactory3::setHostContext` attribute key under which
+/// ARA-aware hosts (Cubase, Studio One) advertise their ARA factory
+/// pointer. The VST3 entry reads it in `PulpVst3Processor::initialize`
+/// and calls `ara_companion_factory_for()` to surface the plugin side.
+/// Workstream 06 slice 6.3 — string is stable because hosts match exact.
+constexpr const char* kVst3AraFactoryContextKey = "com.celemony.ara/vst3-host-factory-v1";
+
+/// AU v3 — `AUAudioUnit.audioUnitARAFactory` property key. Logic Pro
+/// and other AU-ARA hosts observe this property to obtain the plugin's
+/// companion factory. Exposed through the PulpAudioUnit subclass.
+/// Workstream 06 slice 6.4.
+constexpr const char* kAuAraFactoryPropertyKey = "audioUnitARAFactory";
+
 /// Return an opaque pointer to an `ARA::ARAFactory`-compatible struct
 /// when the processor is ARA-aware and Pulp was built with PULP_HAS_ARA,
 /// otherwise nullptr. Called by format-adapter `get_extension` handlers.

--- a/test/test_ara.cpp
+++ b/test/test_ara.cpp
@@ -63,3 +63,13 @@ TEST_CASE("kClapAraFactoryExtension id matches Celemony convention", "[ara]") {
     // hosts match on it exactly.
     REQUIRE(std::string(kClapAraFactoryExtension) == "com.celemony.ara/clap-factory-v1");
 }
+
+TEST_CASE("VST3 ARA factory context key is stable", "[ara][vst3]") {
+    REQUIRE(std::string(kVst3AraFactoryContextKey) == "com.celemony.ara/vst3-host-factory-v1");
+}
+
+TEST_CASE("AU ARA factory property key matches Apple convention", "[ara][au]") {
+    // Apple docs: AUAudioUnit.audioUnitARAFactory is the standard
+    // property name that ARA-aware AU hosts observe.
+    REQUIRE(std::string(kAuAraFactoryPropertyKey) == "audioUnitARAFactory");
+}


### PR DESCRIPTION
## Summary
Drop the well-known host-context keys Pulp will use to surface its ARA companion factory through VST3 and AU. Mirrors the \`kClapAraFactoryExtension\` pattern from slice 6.5.

- \`kVst3AraFactoryContextKey\` = \"com.celemony.ara/vst3-host-factory-v1\"
- \`kAuAraFactoryPropertyKey\` = \"audioUnitARAFactory\" (Apple KVO property)

Tests: +2 assertions → 11 assertions / 8 cases.

Actual VST3 \`setHostContext\` + AU KVO wiring depends on the Celemony ARA SDK and lands in follow-up slices.

Refs #219.