### PR TITLE
fix(cli): Windows popen/pclose — unblock release-cli.yml

### DIFF
--- a/tools/cli/cmd_pr.cpp
+++ b/tools/cli/cmd_pr.cpp
@@ -36,6 +36,14 @@
 #if !defined(_WIN32)
 #  include <sys/wait.h>
 #else
+// Windows MSVC ships POSIX-named shims under leading-underscore names:
+// _popen / _pclose live in <stdio.h>. Map the POSIX spellings onto them
+// so the TU below compiles unchanged on both toolchains. This was the
+// root cause of every release-cli.yml run v0.4.0..v0.13.0 failing on
+// the CLI windows-x64 and CLI windows-arm64 jobs.
+#  include <stdio.h>
+#  define popen  _popen
+#  define pclose _pclose
 #  ifndef WIFEXITED
 #    define WIFEXITED(status)   (true)
 #  endif


### PR DESCRIPTION
`tools/cli/cmd_pr.cpp` calls POSIX `popen`/`pclose` unconditionally; MSVC wants `_popen`/`_pclose`. Every `release-cli.yml` run from v0.4.0 through v0.13.0 failed on Windows with `error C3861: 'popen': identifier not found`.

Alias popen→_popen and pclose→_pclose on `_WIN32` so the TU compiles on both toolchains.

Once this lands, the next SDK bump will tag v0.14.0 and release-cli should finally produce binaries — catching the Releases page up to the actual SDK on main.

Closes the "Releases page stuck at v0.3.0" thread from 2026-04-16.