### PR TITLE
host: ScanOptions::blacklist — parent-side scan-worker crash feedback (#246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to Pulp are documented here.
 
+## [0.14.0]
+
 ## [0.6.0]
 
 ## [0.13.0]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.13.0
+    VERSION 0.14.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/host/include/pulp/host/scanner.hpp
+++ b/core/host/include/pulp/host/scanner.hpp
@@ -78,6 +78,14 @@ struct ScanOptions {
     // Callback for progress reporting during scan
     using ProgressCallback = std::function<void(const std::string& current_path, int scanned, int total)>;
     ProgressCallback on_progress;
+
+    // Workstream 03 slice 3.3b (issue #246): optional blacklist of
+    // bundle paths the scanner should skip. Populated by a prior
+    // crash (recorded by the out-of-process pulp-scan-worker). When
+    // non-null, scan() short-circuits any bundle whose path
+    // ScanBlacklist::is_blacklisted reports true and pushes nothing
+    // into the result for it. Caller-owned; must outlive scan().
+    class ScanBlacklist* blacklist = nullptr;
 };
 
 // ── Plugin Scanner ──────────────────────────────────────────────────────

--- a/core/host/src/scanner.cpp
+++ b/core/host/src/scanner.cpp
@@ -3,6 +3,7 @@
 // Each format has platform-specific default paths.
 
 #include <pulp/host/scanner.hpp>
+#include <pulp/host/scan_blacklist.hpp>
 #include <pulp/runtime/log.hpp>
 #include <pulp/runtime/system.hpp>
 #include <filesystem>
@@ -173,6 +174,18 @@ std::vector<PluginInfo> PluginScanner::scan(const ScanOptions& options) {
                 options.on_progress(dir, scanned++, total_dirs);
             }
             auto found = scan_directory(dir, fmt);
+            // Workstream 03 #246: drop blacklisted bundles before
+            // the result reaches the caller. `pulp-scan-worker`
+            // populates the blacklist when a prior scan crashed on
+            // a bundle; we never re-scan that bundle until the user
+            // explicitly clears its entry.
+            if (options.blacklist) {
+                found.erase(std::remove_if(found.begin(), found.end(),
+                    [&](const PluginInfo& info) {
+                        return options.blacklist->is_blacklisted(info.path);
+                    }),
+                    found.end());
+            }
             all.insert(all.end(), found.begin(), found.end());
         }
     };


### PR DESCRIPTION
First consumer of the scan-blacklist (#205) on PluginScanner::scan. ChildProcessManager spawn of pulp-scan-worker per bundle is follow-up; this lands the API consumers can code against.