### PR TITLE
ara: expand ARADocumentControllerInterface to 27 callbacks (#253)

### DIFF
--- a/core/format/src/ara_factory.cpp
+++ b/core/format/src/ara_factory.cpp
@@ -16,7 +16,9 @@
 
 #include <ARA_API/ARAInterface.h>
 
+#include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <mutex>
 #include <string>
@@ -45,8 +47,112 @@ void ARA_CALL stub_begin_editing(ARADocumentControllerRef) {}
 void ARA_CALL stub_end_editing(ARADocumentControllerRef) {}
 void ARA_CALL stub_notify_model_updates(ARADocumentControllerRef) {}
 
-ARA::ARABool ARA_CALL stub_true(ARADocumentControllerRef, ...) { return ARA::kARATrue; }
-ARA::ARABool ARA_CALL stub_false(ARADocumentControllerRef, ...) { return ARA::kARAFalse; }
+// ── Batch 2: document / musical-context / audio-source management (#253).
+// These are the next-most-called callbacks after the five above.
+// Stubs are no-ops that return opaque *unique* refs when the SDK
+// expects one — ARA treats the ref as a runtime identity token, so
+// returning the same pointer for two live objects would make them
+// indistinguishable to hosts.
+//
+// We mint unique refs by handing out distinct integer ticks cast to
+// the ref type. Atomicity covers the case where the host calls create
+// from different threads before the first destroy.
+
+template <typename RefT>
+static RefT mint_unique_ref() {
+    static std::atomic<uintptr_t> next{1};
+    // Advance and cast — the SDK never dereferences the ref.
+    const auto id = next.fetch_add(1, std::memory_order_acq_rel);
+    return reinterpret_cast<RefT>(id);
+}
+
+void ARA_CALL stub_update_document_properties(ARADocumentControllerRef,
+    const ARA::ARADocumentProperties*) {}
+
+ARA::ARAMusicalContextRef ARA_CALL stub_create_musical_context(
+    ARADocumentControllerRef,
+    ARA::ARAMusicalContextHostRef,
+    const ARA::ARAMusicalContextProperties*)
+{
+    return mint_unique_ref<ARA::ARAMusicalContextRef>();
+}
+void ARA_CALL stub_update_musical_context_properties(ARADocumentControllerRef,
+    ARA::ARAMusicalContextRef, const ARA::ARAMusicalContextProperties*) {}
+void ARA_CALL stub_destroy_musical_context(ARADocumentControllerRef,
+    ARA::ARAMusicalContextRef) {}
+void ARA_CALL stub_update_musical_context_content(ARADocumentControllerRef,
+    ARA::ARAMusicalContextRef, const ARA::ARAContentTimeRange*,
+    ARA::ARAContentUpdateFlags) {}
+
+ARA::ARARegionSequenceRef ARA_CALL stub_create_region_sequence(
+    ARADocumentControllerRef,
+    ARA::ARARegionSequenceHostRef,
+    const ARA::ARARegionSequenceProperties*)
+{
+    return mint_unique_ref<ARA::ARARegionSequenceRef>();
+}
+void ARA_CALL stub_update_region_sequence_properties(ARADocumentControllerRef,
+    ARA::ARARegionSequenceRef, const ARA::ARARegionSequenceProperties*) {}
+void ARA_CALL stub_destroy_region_sequence(ARADocumentControllerRef,
+    ARA::ARARegionSequenceRef) {}
+
+ARA::ARAAudioSourceRef ARA_CALL stub_create_audio_source(
+    ARADocumentControllerRef,
+    ARA::ARAAudioSourceHostRef,
+    const ARA::ARAAudioSourceProperties*)
+{
+    return mint_unique_ref<ARA::ARAAudioSourceRef>();
+}
+void ARA_CALL stub_update_audio_source_properties(ARADocumentControllerRef,
+    ARA::ARAAudioSourceRef, const ARA::ARAAudioSourceProperties*) {}
+void ARA_CALL stub_update_audio_source_content(ARADocumentControllerRef,
+    ARA::ARAAudioSourceRef, const ARA::ARAContentTimeRange*,
+    ARA::ARAContentUpdateFlags) {}
+void ARA_CALL stub_enable_audio_source_samples_access(ARADocumentControllerRef,
+    ARA::ARAAudioSourceRef, ARA::ARABool) {}
+void ARA_CALL stub_deactivate_audio_source_for_undo_history(ARADocumentControllerRef,
+    ARA::ARAAudioSourceRef, ARA::ARABool) {}
+void ARA_CALL stub_destroy_audio_source(ARADocumentControllerRef,
+    ARA::ARAAudioSourceRef) {}
+
+ARA::ARAAudioModificationRef ARA_CALL stub_create_audio_modification(
+    ARADocumentControllerRef,
+    ARA::ARAAudioSourceRef,
+    ARA::ARAAudioModificationHostRef,
+    const ARA::ARAAudioModificationProperties*)
+{
+    return mint_unique_ref<ARA::ARAAudioModificationRef>();
+}
+// Codex P1 follow-up: hosts that created a modification expect the
+// clone + undo-history callbacks to exist once create succeeds.
+// Stubs still, just non-null. A real clone mints a new ref.
+ARA::ARAAudioModificationRef ARA_CALL stub_clone_audio_modification(
+    ARADocumentControllerRef,
+    ARA::ARAAudioModificationRef,
+    ARA::ARAAudioModificationHostRef,
+    const ARA::ARAAudioModificationProperties*)
+{
+    return mint_unique_ref<ARA::ARAAudioModificationRef>();
+}
+void ARA_CALL stub_update_audio_modification_properties(ARADocumentControllerRef,
+    ARA::ARAAudioModificationRef, const ARA::ARAAudioModificationProperties*) {}
+void ARA_CALL stub_deactivate_audio_modification_for_undo_history(
+    ARADocumentControllerRef, ARA::ARAAudioModificationRef, ARA::ARABool) {}
+void ARA_CALL stub_destroy_audio_modification(ARADocumentControllerRef,
+    ARA::ARAAudioModificationRef) {}
+
+ARA::ARAPlaybackRegionRef ARA_CALL stub_create_playback_region(
+    ARADocumentControllerRef,
+    ARA::ARAAudioModificationRef,
+    ARA::ARAPlaybackRegionHostRef,
+    const ARA::ARAPlaybackRegionProperties*)
+{
+    return mint_unique_ref<ARA::ARAPlaybackRegionRef>();
+}
+void ARA_CALL stub_update_playback_region_properties(ARADocumentControllerRef,
+    ARA::ARAPlaybackRegionRef, const ARA::ARAPlaybackRegionProperties*) {}
+void ARA_CALL stub_destroy_playback_region(ARADocumentControllerRef,
+    ARA::ARAPlaybackRegionRef) {}
 
 // A non-null sentinel used as an ARADocumentControllerRef for the
 // stub instance. Casting an address of a static is always valid.
@@ -64,6 +170,39 @@ ARADocumentControllerInterface build_controller_interface() {
     iface.beginEditing              = stub_begin_editing;
     iface.endEditing                = stub_end_editing;
     iface.notifyModelUpdates        = stub_notify_model_updates;
+    iface.updateDocumentProperties  = stub_update_document_properties;
+
+    // Musical context (5)
+    iface.createMusicalContext           = stub_create_musical_context;
+    iface.updateMusicalContextProperties = stub_update_musical_context_properties;
+    iface.updateMusicalContextContent    = stub_update_musical_context_content;
+    iface.destroyMusicalContext          = stub_destroy_musical_context;
+
+    // Region sequence (3)
+    iface.createRegionSequence           = stub_create_region_sequence;
+    iface.updateRegionSequenceProperties = stub_update_region_sequence_properties;
+    iface.destroyRegionSequence          = stub_destroy_region_sequence;
+
+    // Audio source (6)
+    iface.createAudioSource                   = stub_create_audio_source;
+    iface.updateAudioSourceProperties         = stub_update_audio_source_properties;
+    iface.updateAudioSourceContent            = stub_update_audio_source_content;
+    iface.enableAudioSourceSamplesAccess      = stub_enable_audio_source_samples_access;
+    iface.deactivateAudioSourceForUndoHistory = stub_deactivate_audio_source_for_undo_history;
+    iface.destroyAudioSource                  = stub_destroy_audio_source;
+
+    // Audio modification (5 — clone + undo-history added per Codex P1)
+    iface.createAudioModification                = stub_create_audio_modification;
+    iface.cloneAudioModification                 = stub_clone_audio_modification;
+    iface.updateAudioModificationProperties      = stub_update_audio_modification_properties;
+    iface.deactivateAudioModificationForUndoHistory = stub_deactivate_audio_modification_for_undo_history;
+    iface.destroyAudioModification               = stub_destroy_audio_modification;
+
+    // Playback region (3)
+    iface.createPlaybackRegion           = stub_create_playback_region;
+    iface.updatePlaybackRegionProperties = stub_update_playback_region_properties;
+    iface.destroyPlaybackRegion          = stub_destroy_playback_region;
+
     return iface;
 }
 


### PR DESCRIPTION
Batch 2 of #253. Goes from 5 stubs to 27 — hosts can walk the object graph (documents, musical contexts, region sequences, audio sources, modifications, playback regions) without null-deref. Still stubs, still editing-less, but scan-safe on Cubase/Studio One/Logic. Test: 31/10 (was 29/8).