### PR TITLE
a11y(linux): register AT-SPI bridge when atk-bridge-2.0 present (#248)

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -293,6 +293,18 @@ elseif(UNIX)
         src/window_host_stub.cpp
         platform/linux/accessibility_linux.cpp
     )
+    # Linux AT-SPI bridge (workstream 04 #248). Optional: linking atk-
+    # bridge-2.0 when pkg-config finds it enables screen-reader
+    # (Orca) registration via atk_bridge_adaptor_init. Skipped on
+    # minimal/headless distros so the library still loads.
+    if(PkgConfig_FOUND OR PKG_CONFIG_FOUND)
+        pkg_check_modules(ATK_BRIDGE IMPORTED_TARGET atk-bridge-2.0)
+        if(ATK_BRIDGE_FOUND)
+            target_compile_definitions(pulp-view PRIVATE PULP_HAS_ATSPI=1)
+            target_link_libraries(pulp-view PRIVATE PkgConfig::ATK_BRIDGE)
+            message(STATUS "Pulp: AT-SPI bridge enabled (atk-bridge-2.0)")
+        endif()
+    endif()
 endif()
 
 # Link against render for native GPU bridge (Three.js, WebGPU canvas)

--- a/core/view/platform/linux/accessibility_linux.cpp
+++ b/core/view/platform/linux/accessibility_linux.cpp
@@ -17,6 +17,16 @@
 #include <pulp/view/view.hpp>
 #include <pulp/runtime/log.hpp>
 
+// PULP_HAS_ATSPI is set by CMake when atk-bridge-2.0 is found via
+// pkg-config. When unset, the init path stays a no-op so Linux distros
+// without the bridge (minimal / headless CI images) still link.
+#ifdef PULP_HAS_ATSPI
+extern "C" {
+int  atk_bridge_adaptor_init(int* argc, char*** argv);
+void atk_bridge_adaptor_cleanup(void);
+}
+#endif
+
 namespace pulp::view {
 
 // Map Pulp AccessRole to ATK role constants
@@ -43,17 +53,42 @@ void init_atspi_accessibility(View& /*root*/) {
     // TODO: support AtkValue for Knob/Fader/Slider widgets
 }
 
-// Cross-platform entry — see accessibility_provider.hpp. Today these
-// route to the existing AT-SPI stub; a future commit wires atk_bridge
-// + GdkDisplay signalling per window.
+// Cross-platform entry — see accessibility_provider.hpp.
+//
+// Phase 1 (this commit, issue #248): when CMake finds atk-bridge-2.0
+// via pkg-config we register the bridge with D-Bus so Orca + other
+// AT-SPI clients can discover the process at all. AtkObject-per-widget
+// creation lands when an AtkObject subclass for View is added next.
+// Without PULP_HAS_ATSPI we keep the pre-#248 no-op so headless/minimal
+// Linux installations still load pulp-view.
 void* init_accessibility(View& root, void* /*gdk_surface*/) {
     init_atspi_accessibility(root);
+#ifdef PULP_HAS_ATSPI
+    // atk_bridge_adaptor_init takes argc/argv the same way glib does
+    // for main-thread bootstrap; pass nullptrs so it uses the process's
+    // existing GLib main context. Safe to call twice — the bridge
+    // refuses re-init with a warning rather than crashing.
+    int argc = 0;
+    char** argv = nullptr;
+    if (atk_bridge_adaptor_init(&argc, &argv) != 0) {
+        runtime::log_warn("Linux AT-SPI: atk_bridge_adaptor_init failed; "
+                          "screen readers may not see this process");
+    } else {
+        runtime::log_info("Linux AT-SPI: bridge registered with D-Bus");
+    }
     return reinterpret_cast<void*>(static_cast<uintptr_t>(1));
+#else
+    return reinterpret_cast<void*>(static_cast<uintptr_t>(1));
+#endif
 }
 
 void shutdown_accessibility(void* /*handle*/) {
+#ifdef PULP_HAS_ATSPI
+    atk_bridge_adaptor_cleanup();
+    runtime::log_info("Linux AT-SPI: bridge cleaned up");
+#else
     runtime::log_info("Linux AT-SPI: shutdown (stub)");
-    // TODO: g_object_unref the AtkObject root + unregister D-Bus name.
+#endif
 }
 
 void accessibility_tree_changed(void* /*handle*/) {


### PR DESCRIPTION
Phase 1 of #248. When `atk-bridge-2.0` is on the system (Ubuntu desktop installs have it by default), Pulp now registers with the AT-SPI bus so Orca + other screen readers can see the process. Gated: minimal distros without the bridge keep the prior no-op.

AtkObject-per-widget (phase 2) + AtkValue/AtkText interfaces land in follow-up slices. Closes #258 playbook criterion (first VM-lane slice landed per the documented workflow).

Closes #248 phase 1.