### PR TITLE
midi(win): WinRT MIDI 2.0 backend skeleton behind PULP_HAS_WINRT_MIDI (#245)

### DIFF
--- a/core/midi/CMakeLists.txt
+++ b/core/midi/CMakeLists.txt
@@ -33,10 +33,22 @@ if(APPLE AND NOT IOS)
 elseif(WIN32)
     target_sources(pulp-midi PRIVATE
         platform/win/winmidi_device.cpp
+        platform/win/winrt_midi_device.cpp
     )
     target_link_libraries(pulp-midi PRIVATE
         winmm
     )
+    # Workstream 02 #245 — opt-in WinRT MIDI 2.0 backend.
+    # Enable with -DPULP_HAS_WINRT_MIDI=ON once Windows 11 SDK 10.0.22621+
+    # and the cppwinrt tool are installed. Linker adds the WinRT import
+    # libs; the TU itself compiles empty unless the flag is set.
+    if(PULP_HAS_WINRT_MIDI)
+        target_compile_definitions(pulp-midi PRIVATE PULP_HAS_WINRT_MIDI=1)
+        # runtimeobject is the C++/WinRT activation runtime; future work
+        # will add the generated headers dir to the include path here.
+        target_link_libraries(pulp-midi PRIVATE runtimeobject)
+        message(STATUS "Pulp: WinRT MIDI 2.0 backend enabled")
+    endif()
 elseif(UNIX AND NOT APPLE AND NOT ANDROID)
     target_sources(pulp-midi PRIVATE
         platform/linux/alsa_midi_device.cpp

--- a/core/midi/platform/win/winrt_midi_device.cpp
+++ b/core/midi/platform/win/winrt_midi_device.cpp
@@ -1,0 +1,55 @@
+// WinRT MIDI 2.0 backend — workstream 02 #245 phase 1.
+//
+// Windows 11's `Windows.Devices.Midi2` namespace exposes real MIDI 2.0
+// endpoints, DeviceWatcher hotplug, QueryPerformanceCounter timestamps,
+// and MIM_LONGDATA-style sysex via native buffers. The existing
+// winmidi_device.cpp uses the legacy mmeapi path, which truncates MIDI
+// 2.0 UMP, has no hotplug, and requires manual sysex assembly.
+//
+// This TU is the skeleton the real WinRT consumer code will live in.
+// It is only compiled when PULP_HAS_WINRT_MIDI is set — a build flag
+// the user opts into after installing the Windows 11 SDK 10.0.22621+
+// and the `cppwinrt` tool. Without the flag, the linker never sees
+// this object and the existing mmeapi backend stays authoritative.
+//
+// Why gate rather than auto-detect: cppwinrt requires generated headers
+// that live in %VCINSTALLDIR%\… and vary per SDK version; the hassle of
+// cross-compile + CI matrix support argues for opt-in today.
+
+#if defined(_WIN32) && defined(PULP_HAS_WINRT_MIDI)
+
+#include <pulp/midi/device.hpp>
+#include <pulp/runtime/log.hpp>
+
+// When the real path lands, uncomment:
+//   #include <winrt/Windows.Foundation.h>
+//   #include <winrt/Windows.Devices.Midi2.h>
+//   using namespace winrt::Windows::Devices::Midi2;
+
+namespace pulp::midi::win::winrt {
+
+// Placeholder API surface. Real impl will:
+//   * Midi2Endpoint::CreateForConnection → wrap the endpoint.
+//   * MidiMessageReceivedEventArgs → push to MidiBuffer + UmpBuffer.
+//   * QueryPerformanceCounter timestamps on the receive event.
+//   * DeviceWatcher → fire_device_change on the owning AudioSystem.
+bool winrt_midi_available() {
+    // Stub: presence of the build flag means the dev chose to link the
+    // WinRT SDK; availability of Midi2 at runtime requires Windows 11
+    // build 22621+. Full runtime detection lands with the real client.
+    runtime::log_info("WinRT MIDI 2.0 backend compiled in (skeleton)");
+    return false;  // keeps callers on the legacy mmeapi path for now
+}
+
+}  // namespace pulp::midi::win::winrt
+
+#else
+
+// When PULP_HAS_WINRT_MIDI is unset the fallback stub keeps the symbol
+// resolved so callers that branch on winrt_midi_available() do not
+// need their own _WIN32 gate.
+namespace pulp::midi::win::winrt {
+bool winrt_midi_available() { return false; }
+}  // namespace pulp::midi::win::winrt
+
+#endif


### PR DESCRIPTION
Phase 1 of #245. Skeleton TU unconditionally compiled; real cppwinrt consumer lights up under -DPULP_HAS_WINRT_MIDI=ON. Gives #245 a stable symbol for callers to branch against.