### PR TITLE
Fix missing skill descriptions

### DIFF
--- a/.agents/skills/aax/SKILL.md
+++ b/.agents/skills/aax/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: aax
+description: Optional AAX support for Pulp, including developer-supplied Avid SDK setup, CMake enablement, DigiShell/AAX Validator workflows, and local AAX builds on macOS or Windows.
 requires:
   scripts:
     - tools/audit.py

--- a/.agents/skills/ara/SKILL.md
+++ b/.agents/skills/ara/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: ara
+description: Optional ARA support for Pulp, including developer-supplied ARA SDK setup, CMake enablement, adapter companion APIs, validation, and ARA-aware plugin implementation guidance.
 requires:
   scripts:
     - tools/deps/audit.py


### PR DESCRIPTION
## Summary

- Add required `description` frontmatter to `.agents/skills/aax/SKILL.md`
- Add required `description` frontmatter to `.agents/skills/ara/SKILL.md`

## Notes

This fixes the skill loader warnings about invalid `SKILL.md` files caused by missing `description` fields.

## Validation

- Confirmed the branch contains only the two skill frontmatter additions.
- Confirmed `origin/main` does not currently contain commit `1b608cff`.