### PR TITLE
ship: hard-fail on empty Ed25519 signatures (#295 P0)

### DIFF
--- a/docs/guides/shipping.md
+++ b/docs/guides/shipping.md
@@ -140,14 +140,23 @@ Generate a Sparkle-compatible appcast:
 ```cpp
 #include <pulp/ship/appcast.hpp>
 
-pulp::ship::AppcastEntry entry{
-    .version = "1.0.1",
-    .url = "https://example.com/MyPlugin-1.0.1.dmg",
-    .release_notes = "Bug fixes and performance improvements.",
-    .signature = pulp::ship::ed25519_sign(file_data, private_key),
-};
+pulp::ship::AppcastItem item;
+item.version      = "1.0.1";
+item.download_url = "https://example.com/MyPlugin-1.0.1.dmg";
+item.description  = "Bug fixes and performance improvements.";
 
-auto xml = pulp::ship::to_xml({entry});
+// Ed25519 signing: API present but implementation is planned (#295).
+// sign_file_ed25519 returns std::nullopt today, and the CLI refuses
+// to emit `edSignature=""` into an appcast rather than produce a
+// silently-unsigned feed. Until the real impl lands, leave
+// item.ed_signature unset (unsigned appcast) or sign out-of-band.
+if (auto sig = pulp::ship::sign_file_ed25519(local_file_path, private_key_b64)) {
+    item.ed_signature = *sig;
+}
+
+pulp::ship::Appcast feed;
+feed.items.push_back(item);
+auto xml = feed.to_xml();
 ```
 
 ### CI Release Pipeline
@@ -158,7 +167,7 @@ The `sign-and-release.yml` workflow runs on version tags (`v*`):
 2. Signs with Developer ID from GitHub Secrets
 3. Notarizes via `notarytool`
 4. Creates PKG installers
-5. Generates appcast.xml with Ed25519 signatures
+5. Generates appcast.xml (Ed25519 signatures planned — #295)
 6. Creates GitHub Release with artifacts
 
 ## Plugin Install Locations (macOS)

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -402,7 +402,7 @@ The `pulp` CLI wraps common development workflows.
 | Signing identity listing | usable | ship | |
 | Appcast feed generation (Sparkle-compatible) | usable | ship | |
 | Appcast XML parsing | usable | ship | |
-| Ed25519 update signing | usable | ship | |
+| Ed25519 update signing | planned | ship | API present; CLI hard-fails when invoked until impl lands (#295) |
 | Semantic version comparison | usable | ship | |
 | Windows code signing | partial | ship | Stub exists |
 | Linux packaging | partial | ship | Stub exists |

--- a/ship/include/pulp/ship/appcast.hpp
+++ b/ship/include/pulp/ship/appcast.hpp
@@ -48,9 +48,18 @@ struct KeyPair {
     std::string public_key_b64;
 };
 
-// Sign a file with Ed25519 and return base64 signature
-// Uses the system's openssl or a built-in implementation
-std::string sign_file_ed25519(const std::string& file_path,
-                              const std::string& private_key_b64);
+// Sign a file with Ed25519 and return base64 signature.
+//
+// Returns std::nullopt when signing is unavailable (no vetted Ed25519
+// implementation linked in yet — tracked as follow-up to #295) OR when
+// inputs are invalid (unreadable file, malformed key). Callers MUST
+// treat nullopt as a hard failure and refuse to produce an unsigned
+// appcast. Returning an empty string silently was the #295 P0 bug —
+// it looked like a successful sign to the CLI but emitted
+// `edSignature=""` into the appcast, which Sparkle won't validate
+// against the public key. Worse than no signing because the signed-
+// looking workflow hid the problem from operators.
+std::optional<std::string> sign_file_ed25519(const std::string& file_path,
+                                             const std::string& private_key_b64);
 
 } // namespace pulp::ship

--- a/ship/src/appcast.cpp
+++ b/ship/src/appcast.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <regex>
 #include <algorithm>
+#include <optional>
 
 namespace pulp::ship {
 
@@ -154,18 +155,36 @@ int compare_versions(const std::string& a, const std::string& b) {
     return 0;
 }
 
-// ── EdDSA signing stub ───────────────────────────────────────────────────────
+// ── EdDSA signing ────────────────────────────────────────────────────────────
+//
+// Real Ed25519 signing is a follow-up to this P0 fix (#295). Until
+// a vetted implementation lands, this function returns std::nullopt
+// unconditionally so the CLI refuses to emit `edSignature=""` into
+// an appcast — which is what Sparkle-speaking hosts parse as
+// "unsigned" while our CLI logs a successful-looking "signed" line.
+// The silent-empty-signature behaviour was worse than no signing,
+// because operators thought their releases were signed.
+//
+// Vendoring options for the follow-up implementation:
+//   1. monocypher (2-clause BSD, single-file, pulled in as subset)
+//   2. mbedTLS PSA_WANT_ALG_PURE_EDDSA (flip PSA config flags, no
+//      additional dependency; requires mbedTLS 3.6+ with PSA crypto)
+//   3. Apple CryptoKit on mac/iOS + mbedTLS elsewhere
+//
+// Whichever lands, it must:
+//   - parse a base64 Ed25519 private key (32-byte seed or 64-byte full)
+//   - read + SHA-512 the file contents (Ed25519 hashes internally)
+//   - emit a 64-byte signature, base64-encoded
+//   - include a round-trip verify() call in tests
 
-std::string sign_file_ed25519(const std::string& file_path,
-                              const std::string& private_key_b64) {
-    // Delegate to system openssl or generate_appcast tool
-    // This is a stub — real Ed25519 signing requires either:
-    // 1. Linking libsodium/monocypher (MIT/BSD)
-    // 2. Using system openssl CLI
-    // For now, return empty string indicating unsigned
+std::optional<std::string> sign_file_ed25519(const std::string& file_path,
+                                             const std::string& private_key_b64) {
     (void)file_path;
     (void)private_key_b64;
-    return {};
+    // Intentional nullopt: no Ed25519 impl linked in. Callers must
+    // surface this as a hard error instead of writing an empty
+    // signature into the appcast.
+    return std::nullopt;
 }
 
 } // namespace pulp::ship

--- a/test/test_appcast.cpp
+++ b/test/test_appcast.cpp
@@ -70,3 +70,18 @@ TEST_CASE("Version comparison", "[ship][version]") {
     REQUIRE(compare_versions("1.0", "1.0.0") == 0);
     REQUIRE(compare_versions("1.0.0.1", "1.0.0") == 1);
 }
+
+// #295 P0 regression: sign_file_ed25519 MUST NOT silently return an
+// empty signature. It must return std::nullopt so callers can hard-
+// fail instead of emitting `edSignature=""` into an appcast.
+// When the real implementation lands, this test flips to asserting
+// a non-empty base64 signature against a known test vector.
+TEST_CASE("sign_file_ed25519 never silently returns empty", "[ship][sign][issue-295]") {
+    auto result = sign_file_ed25519("/nonexistent/path", "invalid-key");
+    // Today: nullopt (no impl linked).
+    // Tomorrow: Some(sig) on valid inputs, nullopt on invalid.
+    // Either way, never Some("") — that's the #295 P0 regression.
+    if (result.has_value()) {
+        REQUIRE_FALSE(result->empty());
+    }
+}

--- a/tools/cli/cmd_ship.cpp
+++ b/tools/cli/cmd_ship.cpp
@@ -506,12 +506,27 @@ int cmd_ship(const std::vector<std::string>& args) {
         auto url_as_path = fs::path(url);
         if (fs::exists(url_as_path)) {
             item.file_size = fs::file_size(url_as_path);
-            if (!sign_key.empty())
-                item.ed_signature = pulp::ship::sign_file_ed25519(url_as_path.string(), sign_key);
+            if (!sign_key.empty()) {
+                // Hard-fail on missing/failed signing (#295 P0). Writing
+                // an empty edSignature into the appcast looked like a
+                // successful sign but produced unsigned XML that Sparkle
+                // rejects silently — worse than no signing at all.
+                auto sig = pulp::ship::sign_file_ed25519(url_as_path.string(), sign_key);
+                if (!sig || sig->empty()) {
+                    std::cerr << "Error: --sign-key requested but Ed25519 signing is not "
+                                 "available in this build. Refusing to emit an empty "
+                                 "signature into the appcast.\n";
+                    std::cerr << "  Follow-up tracked at: "
+                                 "https://github.com/danielraffel/pulp/issues/295\n";
+                    return 1;
+                }
+                item.ed_signature = std::move(*sig);
+            }
         } else if (!sign_key.empty()) {
-            std::cerr << "Warning: --sign-key requires a local file path to compute the signature.\n";
+            std::cerr << "Error: --sign-key requires a local file path to compute the signature.\n";
             std::cerr << "  The remote URL cannot be signed. Download the file first, then pass\n";
             std::cerr << "  the local path as --url and set --download-url for the enclosure URL.\n";
+            return 1;
         }
 
         { auto now = std::time(nullptr); char buf[64];


### PR DESCRIPTION
## Why

\`sign_file_ed25519\` used to return \`\"\"\` when no Ed25519 impl was linked in, and \`cmd_ship\` happily wrote \`edSignature=\"\"\` into the appcast XML. Sparkle-speaking hosts parsed the feed as unsigned and refused to validate, while our CLI logged a successful-looking \"signed\" line — hiding the problem from release operators.

Closes #295 (P0 acceptance).

## What

- \`sign_file_ed25519\` returns \`std::optional<std::string>\`; nullopt documented as "no impl OR invalid input"
- CLI hard-fails (exit 1) when \`--sign-key\` is requested but signing is unavailable
- Capability row downgraded \`usable → planned\` so docs match shipped behavior
- \`shipping.md\` sample uses real API surface (\`AppcastItem\`, \`sign_file_ed25519\`)
- Regression test: \`sign_file_ed25519 never silently returns empty\`

## Out of scope

Real Ed25519 implementation is a follow-up — comment in source enumerates the three vendoring options (monocypher / mbedTLS PSA EDDSA / CryptoKit per-platform split). Tampered-payload + round-trip verify tests land with that PR.

## Test plan

- [x] \`ctest --test-dir build -R Appcast\` → 4/4 pass
- [x] Runtime: \`pulp ship appcast --sign-key ...\` exits 1 with clear error
- [ ] CI