### PR TITLE
docs: codify 'tests ship with fixes' as non-negotiable CLAUDE.md rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,6 +374,31 @@ DEPENDENCIES.md and NOTICE.md entries are always sorted **alphabetically by name
 
 If it's not tested, it doesn't work. Every subsystem has tests. Every feature has acceptance criteria. Every phase has a validation plan.
 
+### Tests ship with fixes — NON-NEGOTIABLE
+
+**Every correctness fix, stub fill-in, or feature slice lands in the same PR as the test that covers it. This is not optional. "CI built green" is not a test — it means the compiler agreed, not that the behavior works.**
+
+Applies to:
+
+- **Parsers / state machines** — UMP sysex reassembly, Atom sequence walking, VST3 event queues, ARA callback sequences, any binary-format decoder. Deterministic input vector → expected output, asserted with Catch2.
+- **Threading / lock-free code** — atomic refcounts, SPSC/triple-buffer flush, audio-thread ↔ UI-thread handoff. N-thread hammer test + assert final state. A race-condition bug the CI matrix will not catch.
+- **Stub fill-ins** — the acceptance criterion for "implement stub X" is "round-trip test through X using the real path", not "X now compiles." E.g. wiring CLAP `set_parameter` means a test that calls it and reads `get_parameter` back.
+- **CLI behavior changes** — shell out to the built binary, assert exit code + stderr content. Catches silent-failure bugs like #295 where `--sign-key` wrote empty signatures without error.
+- **Platform-specific backends** — clipboard, file dialogs, screenshot hosts, mDNS. Even if the platform path only runs on one OS, write the test to run on that OS in CI. Cross-platform parity means the test runs on every supported OS too.
+
+What "CI green is enough" cost us on 2026-04-16: a UMP-cursor-advance P1 bug (`#292`), an atomic-refcount P1 bug (`#281`), and a silent-empty-Ed25519-signature P0 bug (`#295`) — all caught by Codex review comments *after* merge because the PRs had no dedicated unit test. A 20-line Catch2 fixture would have caught each of them during PR development.
+
+**The only acceptable "no test in this PR" justification** is: pre-existing historical coverage gap in a subsystem you are not modifying. In that case, file a follow-up issue linked to `#290` and reference it in the commit trailer. Anything else — ship the test.
+
+**Test hygiene:**
+
+- Catch2 tag names cannot contain `#` (reserved). Use `[issue-NNN]` not `[#NNN]`.
+- Place tests next to existing `test/test_<subsystem>.cpp` files where one exists; only create a new file for a genuinely new surface.
+- Tests that need a runtime binary (CLI, validator) can shell out — don't skip them because the infrastructure is "too heavy."
+- Parser tests should exercise the edge cases the fix actually addresses (e.g., the #292 UMP test must include "second word's top nibble is 0x3" specifically, not just happy-path single-packet sysex).
+
+**Subsystems under active coverage hardening** (tracked by `#290`): `platform`, `host`, `format`, `runtime`, `view`, `osc`, `dsl`. When touching any of these, grow the test surface — do not leave the coverage number where you found it.
+
 ### Test Layers
 
 | Layer | What | Tool | When |


### PR DESCRIPTION
## Why

The 2026-04-16 session shipped three correctness bugs without dedicated tests — all caught by Codex review *after* merge:

| PR | Bug | Severity | What a test would have caught |
|---|---|---|---|
| #292 | UMP cursor advanced by 1 word instead of 2 | P1 | Two type-3 UMPs back-to-back where the second word's top nibble is 0x3 |
| #281 | IMMNotificationClient non-atomic refcount | P1 | N-thread AddRef/Release hammer test |
| #295 | \`--sign-key\` silently wrote empty signatures | P0 | CLI shell-out + exit-code + stderr assert |

Each would have been caught by a 20-line Catch2 fixture during PR development. The common failure mode was treating "CI matrix built green" as sufficient validation when it only means the compiler agreed — not that the behavior works.

## What

New CLAUDE.md subsection ("Tests ship with fixes — NON-NEGOTIABLE") immediately after the Philosophy paragraph in the Testing and Validation section. Covers:

- Categories that **must** have a test (parsers, threading, stub fill-ins, CLI behavior, platform backends)
- The *only* acceptable \"no test in this PR\" justification (pre-existing subsystem gap tracked under #290)
- Test hygiene (Catch2 tag rules, file placement conventions)
- Active coverage-hardening subsystems per #290 (platform, host, format, runtime, view, osc, dsl)

## Scope

Policy change only. Both Claude Code (reads CLAUDE.md) and Codex (reads AGENTS.md → CLAUDE.md) pick this up automatically.

Enforcement stays at the existing layers (pre-push hook, CI skill-sync gate). This PR does NOT add a new CI check — the policy is authoritative for reviewers (human + agent) rather than mechanically gated. A future follow-up could add a heuristic gate like \"PR with >20 LOC code change must also touch test/\", but that's out of scope here.

## Test plan

- [x] Policy language is explicit and unambiguous
- [x] Historical bugs cited so rationale is legible to a reader who wasn't in that session
- [x] Cross-references #290 for coverage hardening
- [ ] Docs-check passes on CI