### PR TITLE
format: guard compare_screenshots against filesystem exceptions (#308 Codex P1)

### DIFF
--- a/core/format/src/validation_harness.cpp
+++ b/core/format/src/validation_harness.cpp
@@ -245,8 +245,47 @@ ReportEntry ValidationHarness::compare_screenshots(
     // codec becomes available to the format layer (#298 follow-up).
     // Produces pass/fail — never skip — so callers can't confuse
     // "images differ" with "comparison not available."
-    std::uintmax_t ref_size = std::filesystem::file_size(reference);
-    std::uintmax_t ren_size = std::filesystem::file_size(rendered);
+    // #308 Codex P1: std::filesystem::file_size throws on non-regular
+    // files (e.g. a directory accidentally passed as an argument) and
+    // on some I/O failures. Use the non-throwing overload + is_regular_file
+    // so the harness can always return a report entry with
+    // ValidationStatus::error instead of propagating an exception that
+    // aborts the whole validation run.
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(reference, ec) || ec) {
+        entry.status = ValidationStatus::error;
+        entry.error_message =
+            "Reference path is not a regular file: " + reference.string();
+        entries_.push_back(entry);
+        return entry;
+    }
+    ec.clear();
+    if (!std::filesystem::is_regular_file(rendered, ec) || ec) {
+        entry.status = ValidationStatus::error;
+        entry.error_message =
+            "Rendered path is not a regular file: " + rendered.string();
+        entries_.push_back(entry);
+        return entry;
+    }
+    ec.clear();
+    const std::uintmax_t ref_size = std::filesystem::file_size(reference, ec);
+    if (ec) {
+        entry.status = ValidationStatus::error;
+        entry.error_message =
+            "Failed to stat reference: " + ec.message();
+        entries_.push_back(entry);
+        return entry;
+    }
+    ec.clear();
+    const std::uintmax_t ren_size = std::filesystem::file_size(rendered, ec);
+    if (ec) {
+        entry.status = ValidationStatus::error;
+        entry.error_message =
+            "Failed to stat rendered: " + ec.message();
+        entries_.push_back(entry);
+        return entry;
+    }
+
     double similarity = 0.0;
     bool identical = false;
     if (ref_size == ren_size) {

--- a/test/test_validation_harness.cpp
+++ b/test/test_validation_harness.cpp
@@ -378,6 +378,34 @@ TEST_CASE("ValidationHarness compare_screenshots differing files → fail",
     std::filesystem::remove(b);
 }
 
+// #308 Codex P1: compare_screenshots must NOT throw filesystem_error
+// when a caller passes a directory or other non-regular path. It must
+// return a ValidationStatus::error entry so the harness's report-
+// first behavior is preserved under bad input.
+TEST_CASE("ValidationHarness compare_screenshots directory input → error, not throw",
+          "[harness][phase2][issue-308]") {
+    pulp::format::ValidationHarness harness(create_test_gain);
+    harness.configure({});
+
+    auto dir = std::filesystem::temp_directory_path() / "harness-dir-input";
+    std::filesystem::create_directories(dir);
+    auto file = std::filesystem::temp_directory_path() / "harness-file-input.bin";
+    std::ofstream(file) << "some content";
+
+    // reference is a directory — must error, not throw.
+    auto entry = harness.compare_screenshots(dir, file);
+    REQUIRE(entry.status == pulp::format::ValidationStatus::error);
+    REQUIRE_THAT(entry.error_message, ContainsSubstring("regular file"));
+
+    // rendered is a directory — must error, not throw.
+    entry = harness.compare_screenshots(file, dir);
+    REQUIRE(entry.status == pulp::format::ValidationStatus::error);
+    REQUIRE_THAT(entry.error_message, ContainsSubstring("regular file"));
+
+    std::filesystem::remove_all(dir);
+    std::filesystem::remove(file);
+}
+
 // ── Clear entries ───────────────────────────────────────────────────────────
 
 TEST_CASE("ValidationHarness clear_entries resets accumulator", "[harness][phase2]") {


### PR DESCRIPTION
## Why

Codex P1 on the just-merged #308: \`compare_screenshots\` called \`std::filesystem::file_size\` unguarded, but that overload throws \`filesystem_error\` on non-regular paths (directories, special files) and on some I/O failures. An unguarded throw at that call site aborted the whole validation run instead of returning a \`ValidationStatus::error\` entry, breaking the harness's report-first contract.

## What

- \`is_regular_file(path, ec)\` check for both reference and rendered before touching \`file_size\` — a directory, socket, or broken symlink now produces a clean error entry instead of a throw.
- \`file_size(path, ec)\` overload replaces the throwing version so any remaining stat failure converts to an error entry.
- Error messages include the offending path and \`ec.message()\` so callers can diagnose without a stack trace.

## Test plan

New \`[issue-308]\` case: pass a directory as reference, then as rendered — must produce \`ValidationStatus::error\`, must not throw. 4 assertions.

Local: issue-308 selector runs 4/4, full harness suite 20/20 cases green.