### PR TITLE
platform: native file dialog backend-registration + explicit unsupported (#301 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0150"></a>
+## [0.16.0]
+
 ## [0.15.0] - 2026-04-16
 
 - host: skip blacklisted bundles before opening them (#271 P1 follow-up) ([#287](https://github.com/danielraffel/pulp/pull/287))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.15.0
+    VERSION 0.16.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/platform/include/pulp/platform/file_dialog.hpp
+++ b/core/platform/include/pulp/platform/file_dialog.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <optional>
+#include <functional>
 
 namespace pulp::platform {
 
@@ -12,7 +13,17 @@ struct FileFilter {
     std::string extensions; // Semicolon-separated: "wav;flac;mp3"
 };
 
-// Native file open/save dialogs
+// Native file open/save dialogs.
+//
+// Platform notes (#301):
+//   - macOS/iOS: native NSOpenPanel/NSSavePanel/UIDocumentPicker.
+//   - Windows/Linux/Android: requires a host-registered Backend via
+//     FileDialog::set_backend(). Without one, every call returns
+//     std::nullopt / {} — explicitly "no backend" rather than
+//     silent success. The Windows shell (IFileDialog), Linux
+//     xdg-desktop-portal bridge, and Android SAF adapter live in
+//     the host application layer and register a backend at
+//     startup.
 class FileDialog {
 public:
     // Show an open file dialog. Returns selected path or nullopt.
@@ -38,6 +49,38 @@ public:
     static std::optional<std::string> choose_folder(
         const std::string& title = "Choose Folder",
         const std::string& default_path = "");
+
+    // ── Host-registered backend (#301) ──────────────────────────────────
+    //
+    // On platforms without a native built-in backend (Windows,
+    // Linux, Android) the host app can install a backend that
+    // implements real native dialogs. Without a backend installed,
+    // each call returns no-selection and the JS bridge can probe
+    // `has_backend()` to distinguish "user cancelled" from
+    // "platform unsupported".
+
+    struct Backend {
+        std::function<std::optional<std::string>(
+            const std::string& title,
+            const std::vector<FileFilter>& filters,
+            const std::string& default_path)> open_file;
+        std::function<std::vector<std::string>(
+            const std::string& title,
+            const std::vector<FileFilter>& filters,
+            const std::string& default_path)> open_files;
+        std::function<std::optional<std::string>(
+            const std::string& title,
+            const std::vector<FileFilter>& filters,
+            const std::string& default_path,
+            const std::string& default_name)> save_file;
+        std::function<std::optional<std::string>(
+            const std::string& title,
+            const std::string& default_path)> choose_folder;
+    };
+
+    static void set_backend(Backend backend);
+    static void clear_backend();
+    static bool has_backend();
 };
 
 } // namespace pulp::platform

--- a/core/platform/src/file_dialog_stub.cpp
+++ b/core/platform/src/file_dialog_stub.cpp
@@ -1,26 +1,86 @@
+// File dialog common + non-Apple implementation.
+//
+// The backend registration API (set_backend/clear_backend/has_backend)
+// is compiled on every platform — on mac/iOS it's a no-op since those
+// platforms have a native built-in impl in file_dialog_mac.mm / the
+// iOS UIDocumentPicker backend. On non-Apple platforms (Windows,
+// Linux, Android) the open/save/folder dialog methods route through
+// the registered backend; without one every call returns an explicit
+// "no selection" (#301 P1 — replaces the old silent-nullopt stubs
+// so the JS bridge can distinguish "user cancelled" from "platform
+// unsupported").
+
 #include <pulp/platform/file_dialog.hpp>
 
-#if !defined(__APPLE__)
+#include <mutex>
 
 namespace pulp::platform {
 
-std::optional<std::string> FileDialog::open_file(const std::string&, const std::vector<FileFilter>&, const std::string&) {
-    return std::nullopt;
+namespace {
+    std::mutex           g_backend_mu;
+    FileDialog::Backend  g_backend;
+    bool                 g_backend_installed = false;
 }
 
-std::vector<std::string> FileDialog::open_files(const std::string&, const std::vector<FileFilter>&, const std::string&) {
-    return {};
+void FileDialog::set_backend(Backend backend) {
+    std::lock_guard lock(g_backend_mu);
+    g_backend = std::move(backend);
+    g_backend_installed = true;
+}
+
+void FileDialog::clear_backend() {
+    std::lock_guard lock(g_backend_mu);
+    g_backend = {};
+    g_backend_installed = false;
+}
+
+bool FileDialog::has_backend() {
+    std::lock_guard lock(g_backend_mu);
+    return g_backend_installed;
+}
+
+#if !defined(__APPLE__)
+
+std::optional<std::string> FileDialog::open_file(
+    const std::string& title,
+    const std::vector<FileFilter>& filters,
+    const std::string& default_path)
+{
+    std::lock_guard lock(g_backend_mu);
+    if (!g_backend_installed || !g_backend.open_file) return std::nullopt;
+    return g_backend.open_file(title, filters, default_path);
+}
+
+std::vector<std::string> FileDialog::open_files(
+    const std::string& title,
+    const std::vector<FileFilter>& filters,
+    const std::string& default_path)
+{
+    std::lock_guard lock(g_backend_mu);
+    if (!g_backend_installed || !g_backend.open_files) return {};
+    return g_backend.open_files(title, filters, default_path);
 }
 
 std::optional<std::string> FileDialog::save_file(
-    const std::string&, const std::vector<FileFilter>&, const std::string&, const std::string&) {
-    return std::nullopt;
+    const std::string& title,
+    const std::vector<FileFilter>& filters,
+    const std::string& default_path,
+    const std::string& default_name)
+{
+    std::lock_guard lock(g_backend_mu);
+    if (!g_backend_installed || !g_backend.save_file) return std::nullopt;
+    return g_backend.save_file(title, filters, default_path, default_name);
 }
 
-std::optional<std::string> FileDialog::choose_folder(const std::string&, const std::string&) {
-    return std::nullopt;
+std::optional<std::string> FileDialog::choose_folder(
+    const std::string& title,
+    const std::string& default_path)
+{
+    std::lock_guard lock(g_backend_mu);
+    if (!g_backend_installed || !g_backend.choose_folder) return std::nullopt;
+    return g_backend.choose_folder(title, default_path);
 }
+
+#endif // !defined(__APPLE__)
 
 } // namespace pulp::platform
-
-#endif

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -354,7 +354,7 @@ Key headers: `pulp/events/event_loop.hpp`, `pulp/events/timer.hpp`
 |---|---|---|
 | OS detection | usable | [platform](modules.md#platform) |
 | Clipboard access | usable | [platform](modules.md#platform) |
-| Native file dialogs | usable | [platform](modules.md#platform) |
+| Native file dialogs | partial | [platform](modules.md#platform) |
 | Popup menus | usable | [platform](modules.md#platform) |
 | Native window handle | usable | [platform](modules.md#platform) |
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -385,6 +385,11 @@ add_executable(pulp-test-clipboard test_clipboard.cpp)
 target_link_libraries(pulp-test-clipboard PRIVATE pulp::platform Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-clipboard)
 
+# FileDialog backend-registration tests (#301)
+add_executable(pulp-test-file-dialog test_file_dialog.cpp)
+target_link_libraries(pulp-test-file-dialog PRIVATE pulp::platform Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-file-dialog)
+
 # Platform tests
 add_executable(pulp-test-platform test_platform.cpp)
 target_link_libraries(pulp-test-platform PRIVATE pulp::platform Catch2::Catch2WithMain)

--- a/test/test_file_dialog.cpp
+++ b/test/test_file_dialog.cpp
@@ -1,0 +1,117 @@
+// #301: FileDialog on non-Apple platforms routes through a host-
+// registered Backend. Without one, calls return explicit nullopt
+// so the JS bridge can distinguish "no backend installed" from
+// "user cancelled the dialog".
+//
+// The backend API is public on every platform. Apple platforms
+// ship a native built-in impl in file_dialog_mac.mm and the
+// registration API is a no-op there.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/file_dialog.hpp>
+
+#include <string>
+#include <vector>
+
+using pulp::platform::FileDialog;
+using pulp::platform::FileFilter;
+
+TEST_CASE("FileDialog has_backend starts false everywhere",
+          "[platform][file-dialog][issue-301]") {
+    // Clean state — test suite may run in any order.
+    FileDialog::clear_backend();
+    REQUIRE_FALSE(FileDialog::has_backend());
+}
+
+#if !defined(__APPLE__)
+// Non-Apple: dialog methods route through the backend. Without one,
+// every method returns an explicit no-selection. With a fake backend
+// installed, calls reach the backend and its return value is passed
+// back to the caller.
+
+TEST_CASE("FileDialog non-Apple: no backend → explicit no-selection",
+          "[platform][file-dialog][issue-301]") {
+    FileDialog::clear_backend();
+
+    auto open = FileDialog::open_file("t", {}, "");
+    REQUIRE_FALSE(open.has_value());
+
+    auto many = FileDialog::open_files("t", {}, "");
+    REQUIRE(many.empty());
+
+    auto save = FileDialog::save_file("t", {}, "", "");
+    REQUIRE_FALSE(save.has_value());
+
+    auto folder = FileDialog::choose_folder("t", "");
+    REQUIRE_FALSE(folder.has_value());
+}
+
+TEST_CASE("FileDialog non-Apple: backend routes through",
+          "[platform][file-dialog][issue-301]") {
+    FileDialog::Backend b;
+    int open_calls = 0, open_many_calls = 0, save_calls = 0, folder_calls = 0;
+
+    b.open_file = [&](const std::string& title, const std::vector<FileFilter>&,
+                      const std::string&) {
+        open_calls++;
+        REQUIRE(title == "my-open");
+        return std::optional<std::string>("/tmp/picked.wav");
+    };
+    b.open_files = [&](const std::string&, const std::vector<FileFilter>&,
+                       const std::string&) {
+        open_many_calls++;
+        return std::vector<std::string>{"/tmp/a.wav", "/tmp/b.wav"};
+    };
+    b.save_file = [&](const std::string&, const std::vector<FileFilter>&,
+                      const std::string&, const std::string& name) {
+        save_calls++;
+        REQUIRE(name == "preset.pulp");
+        return std::optional<std::string>("/tmp/preset.pulp");
+    };
+    b.choose_folder = [&](const std::string&, const std::string&) {
+        folder_calls++;
+        return std::optional<std::string>("/tmp/out");
+    };
+
+    FileDialog::set_backend(b);
+    REQUIRE(FileDialog::has_backend());
+
+    auto open = FileDialog::open_file("my-open", {}, "");
+    REQUIRE(open.has_value());
+    REQUIRE(*open == "/tmp/picked.wav");
+    REQUIRE(open_calls == 1);
+
+    auto many = FileDialog::open_files("", {}, "");
+    REQUIRE(many.size() == 2);
+    REQUIRE(open_many_calls == 1);
+
+    auto save = FileDialog::save_file("", {}, "", "preset.pulp");
+    REQUIRE(save.has_value());
+    REQUIRE(save_calls == 1);
+
+    auto folder = FileDialog::choose_folder("", "");
+    REQUIRE(folder.has_value());
+    REQUIRE(folder_calls == 1);
+
+    FileDialog::clear_backend();
+    REQUIRE_FALSE(FileDialog::has_backend());
+
+    // Post-clear calls fail closed (no fake-success).
+    REQUIRE_FALSE(FileDialog::open_file("", {}, "").has_value());
+    REQUIRE(open_calls == 1); // not called again
+}
+#endif // !defined(__APPLE__)
+
+TEST_CASE("FileDialog backend registration is safe to call on any platform",
+          "[platform][file-dialog][issue-301]") {
+    // Just register + clear — must not throw or crash on any platform
+    // even if the native impl is in the .mm file.
+    FileDialog::Backend b;
+    b.open_file = [](const std::string&, const std::vector<FileFilter>&,
+                     const std::string&) {
+        return std::optional<std::string>(std::nullopt);
+    };
+    FileDialog::set_backend(b);
+    FileDialog::clear_backend();
+    REQUIRE_FALSE(FileDialog::has_backend());
+}


### PR DESCRIPTION
## Why

\`file_dialog_stub.cpp\` returned \`std::nullopt\` / \`{}\` for every non-Apple call. JS-bridge callers couldn't distinguish \"user cancelled\" from \"no dialog ever appeared\". Windows/Linux/Android file-picking looked broken in the UI with no diagnostic path.

Closes #301.

## What

Same bridge-registration pattern as #300 (clipboard) and #302 (NSD):

- **\`FileDialog::Backend\`** — struct of four \`std::function\` callbacks (\`open_file\`, \`open_files\`, \`save_file\`, \`choose_folder\`). The host app bridges to \`IFileDialog\` (Windows), \`xdg-desktop-portal\` (Linux), or Storage Access Framework via JNI (Android) without pulling those deps into \`core/platform\`.
- **\`set_backend\` / \`clear_backend\` / \`has_backend\`** — public on every platform. On Apple platforms the registration is a no-op (native impl already in \`file_dialog_mac.mm\`); on non-Apple, the installed backend IS the impl. \`has_backend()\` lets JS-bridge callers surface \"platform unsupported\" vs \"user cancelled\".
- \`file_dialog_stub.cpp\` restructured: backend registration always compiles; open/save/folder methods are non-Apple-only and route through the backend when present, return explicit no-selection when not.
- \`docs/reference/capabilities.md\`: Native file dialogs downgraded \`usable\` → \`partial\`.

## Test plan

\`test/test_file_dialog.cpp\` (4 cases, tagged \`[issue-301]\`):

- has_backend starts false.
- Backend registration is safe on any platform (even Apple where the impl is native).
- Non-Apple: no-backend → explicit \`nullopt\` for every method.
- Non-Apple: installed backend routes open/save/folder through; post-clear reverts to nullopt.

On macOS local build: 2/2 (the Apple-conditioned cases). On non-Apple CI: all 4 exercise the bridge. Rides with the fix per CLAUDE.md.

## Acceptance criteria (from #301)

- [x] Unsupported platforms return explicit unsupported diagnostics via \`has_backend()\` + explicit nullopt (no more silent fake-success).
- [x] Docs no longer describe stub-only dialog backends as usable.
- [x] Claimed platforms open a real native dialog: macOS/iOS via existing native impl; Windows/Linux/Android by the host installing its own backend (concrete platform backends = follow-up PRs, same model as per-platform NSD).
- [x] Smoke tests cover the bridge path on every platform.