### PR TITLE
events: NSD refresh on re-announce + clear on backend swap (#310 Codex P2)

### DIFF
--- a/core/events/src/volume_detector.cpp
+++ b/core/events/src/volume_detector.cpp
@@ -81,7 +81,17 @@ std::vector<std::string> MountedVolumeListChangeDetector::get_mounted_volumes() 
 NetworkServiceDiscovery::~NetworkServiceDiscovery() { stop(); }
 
 void NetworkServiceDiscovery::install_backend(std::unique_ptr<Backend> backend) {
+    // Codex P2 on #310: swapping backends must clear the cached
+    // discoveries, otherwise stale services from the previous backend
+    // leak into queries against the new one.
     stop();
+    if (!services_.empty()) {
+        auto lost = std::move(services_);
+        services_.clear();
+        if (on_service_lost) {
+            for (const auto& s : lost) on_service_lost(s);
+        }
+    }
     backend_ = std::move(backend);
 }
 
@@ -114,10 +124,23 @@ void NetworkServiceDiscovery::unregister_service() {
 }
 
 void NetworkServiceDiscovery::notify_service_found(const Service& svc) {
-    // Deduplicate by (name, type) — common case is a backend re-
-    // reporting the same service on a cache refresh.
-    for (const auto& s : services_) {
-        if (s.name == svc.name && s.type == svc.type) return;
+    // Codex P2 on #310: re-announces from the same backend must
+    // refresh the cached entry (hostname/address/port can change
+    // when a service restarts on a new port or moves to a new IP)
+    // instead of silently dropping. Match by (name, type); replace
+    // the entry if anything else differs and fire on_service_found
+    // so subscribers learn about the change.
+    for (auto& existing : services_) {
+        if (existing.name == svc.name && existing.type == svc.type) {
+            const bool changed =
+                existing.hostname != svc.hostname
+                || existing.address  != svc.address
+                || existing.port     != svc.port;
+            if (!changed) return; // true duplicate — dedup silently
+            existing = svc;
+            if (on_service_found) on_service_found(svc);
+            return;
+        }
     }
     services_.push_back(svc);
     if (on_service_found) on_service_found(svc);

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -120,3 +120,66 @@ TEST_CASE("NSD forwards discovered services via on_service_found",
     nsd.notify_service_lost(s);
     REQUIRE(lost.size() == 1);
 }
+
+// Codex P2 on #310: re-announces with changed metadata must refresh
+// the cached entry and fire on_service_found, not silently drop.
+TEST_CASE("NSD refreshes cached entries when metadata changes on re-announce",
+          "[events][service-discovery][issue-310]") {
+    NetworkServiceDiscovery nsd;
+    nsd.install_backend(std::make_unique<FakeBackend>());
+
+    std::vector<uint16_t> found_ports;
+    nsd.on_service_found = [&](const NetworkServiceDiscovery::Service& s) {
+        found_ports.push_back(s.port);
+    };
+
+    NetworkServiceDiscovery::Service s;
+    s.name = "pulpd"; s.type = "_pulp._tcp";
+    s.address = "10.0.0.1"; s.port = 2222;
+    nsd.notify_service_found(s);
+
+    // Identical re-announce: dedup, no callback.
+    nsd.notify_service_found(s);
+    REQUIRE(found_ports == std::vector<uint16_t>{2222});
+
+    // Port change: refresh + callback.
+    s.port = 3333;
+    nsd.notify_service_found(s);
+    REQUIRE(found_ports == std::vector<uint16_t>{2222, 3333});
+    REQUIRE(nsd.discovered().size() == 1);
+    REQUIRE(nsd.discovered().front().port == 3333);
+
+    // Address change: refresh + callback.
+    s.address = "10.0.0.2";
+    nsd.notify_service_found(s);
+    REQUIRE(found_ports.size() == 3);
+    REQUIRE(nsd.discovered().front().address == "10.0.0.2");
+}
+
+// Codex P2 on #310: swapping backends must clear the cache so a
+// stale discovery from the previous backend doesn't leak into
+// queries against the new one. on_service_lost should fire for
+// each evicted entry so subscribers can react.
+TEST_CASE("NSD clears discoveries and fires on_service_lost when swapping backends",
+          "[events][service-discovery][issue-310]") {
+    NetworkServiceDiscovery nsd;
+    nsd.install_backend(std::make_unique<FakeBackend>());
+
+    std::vector<std::string> lost;
+    nsd.on_service_lost = [&](const NetworkServiceDiscovery::Service& s) {
+        lost.push_back(s.name);
+    };
+
+    NetworkServiceDiscovery::Service a, b;
+    a.name = "alpha"; a.type = "_pulp._tcp"; a.port = 1;
+    b.name = "beta";  b.type = "_pulp._tcp"; b.port = 2;
+    nsd.notify_service_found(a);
+    nsd.notify_service_found(b);
+    REQUIRE(nsd.discovered().size() == 2);
+
+    // Swap backends: both cached entries evicted, each fires lost.
+    nsd.install_backend(std::make_unique<FakeBackend>());
+    REQUIRE(nsd.discovered().empty());
+    REQUIRE(lost.size() == 2);
+    REQUIRE((lost[0] == "alpha" || lost[0] == "beta"));
+}


### PR DESCRIPTION
## Why

Two Codex P2 findings on the just-merged #310.

1. **Silent-dropped updates** — \`notify_service_found\` deduplicated by \`(name, type)\` and silently returned if a matching entry existed. Correct for true duplicates; incorrect for a service whose hostname/address/port changed — subscribers never saw the update.

2. **Stale cache on backend swap** — \`install_backend\` destroyed the old backend but left \`services_\` populated. Queries against the new backend returned ghosts from the previous one.

## What

1. \`notify_service_found\` now matches by \`(name, type)\` and, if any other field differs, replaces the cached entry and fires \`on_service_found\` again. True duplicates still dedup silently.

2. \`install_backend\` evicts every cached entry before swapping and fires \`on_service_lost\` for each so subscribers can react (close sockets, re-fetch fresh state).

## Test plan

\`test/test_network_service_discovery.cpp\` — 2 new \`[issue-310]\` cases:

- Refresh semantics: identical re-announce dedups; port change refreshes + callback; address change refreshes + callback; \`discovered()\` reflects the latest metadata.
- Backend-swap: two cached services, swap backend, \`discovered()\` empty, \`on_service_lost\` fires for each.

Full file: 5 cases, 29 assertions, all pass locally.