### PR TITLE
ci: LLVM coverage instrumentation + enable sanitizers.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,63 @@
+name: Coverage
+
+# Non-blocking coverage artifact. Informational only; no merge gate.
+# Local equivalent: scripts/run_coverage.sh.
+# Full design: planning/coverage-sanitizers-spec-2026-04-16.md.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    runs-on: ubuntu-24.04
+    name: Coverage report (Linux, Clang)
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+          lfs: true
+
+      - name: Install Linux dependencies + Clang tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang llvm lld \
+            libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev \
+            libgbm-dev libgl1-mesa-dev libx11-dev libxext-dev libxfixes-dev \
+            libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev \
+            libxrender-dev libxss-dev libxtst-dev libwayland-dev wayland-protocols
+
+      - name: Bootstrap dependencies
+        run: ./setup.sh --ci --deps-only
+        shell: bash
+
+      - name: Run coverage suite
+        # Coverage never fails the run — thresholds come later per
+        # the #290 hardening initiative.
+        continue-on-error: true
+        run: scripts/run_coverage.sh
+        shell: bash
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report-${{ github.sha }}
+          path: build-coverage/coverage/
+          retention-days: 30
+
+      - name: Upload summary
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-summary-${{ github.sha }}
+          path: build-coverage/coverage/summary.txt
+          retention-days: 90

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,10 +1,19 @@
 name: Sanitizer Tests
 
+# ASan + UBSan on every PR, TSan advisory, RTSan on-demand.
+# Non-Apple RTSan needs Clang 18 from apt.llvm.org.
+# Local equivalents: scripts/run_asan.sh, scripts/run_tsan.sh.
+
 on:
-  # Uncomment to re-enable cloud CI on pull requests:
-  # pull_request:
-  #   branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: sanitizers-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   asan:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,12 @@ if(WIN32)
     add_compile_definitions(NOMINMAX WIN32_LEAN_AND_MEAN)
 endif()
 
-# ── Sanitizers (optional) ──────────────────────────────────────────────────
+# ── Instrumentation (optional) ─────────────────────────────────────────────
+# Sanitizers via PULP_SANITIZER=address|thread|undefined|memory|realtime
+# Coverage via PULP_ENABLE_COVERAGE=ON (Clang only, mutually exclusive
+# with PULP_SANITIZER).
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/Sanitizers.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpInstrumentation.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpAAX.cmake)
 pulp_configure_aax_sdk()
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,0 +1,183 @@
+# Testing & Hardening
+
+Pulp ships three instrumentation modes that any developer can run locally
+and CI runs selectively. All are **opt-in** — Debug/Release/RelWithDebInfo
+builds are unaffected.
+
+| Mode | Flag | Purpose | CI status |
+|---|---|---|---|
+| **Coverage** | `-DPULP_ENABLE_COVERAGE=ON` | Measure what the test suite actually exercises | Non-blocking artifact |
+| **AddressSanitizer + UBSan** | `-DPULP_SANITIZER=address` | Heap/stack overflow, use-after-free, UB | Blocking (when enabled) |
+| **ThreadSanitizer** | `-DPULP_SANITIZER=thread` | Data races, lock ordering | Advisory |
+| UndefinedBehaviorSanitizer | `-DPULP_SANITIZER=undefined` | Signed overflow, null deref, alignment | On-demand |
+| MemorySanitizer | `-DPULP_SANITIZER=memory` | Uninitialized reads (Clang only; requires all-deps instrumented) | Manual |
+| RealtimeSanitizer | `-DPULP_SANITIZER=realtime` | Malloc / lock / syscall inside an RT section (Clang 18+) | Manual |
+
+Coverage and sanitizers are **mutually exclusive**. Use separate build
+directories (`build-coverage/`, `build-asan/`, etc.) so they coexist.
+
+## Coverage
+
+### Run locally
+
+```bash
+scripts/run_coverage.sh
+```
+
+Produces:
+- `build-coverage/coverage/index.html` — interactive drilldown, per file.
+- `build-coverage/coverage/summary.txt` — top-level table you can scan in
+  a terminal.
+
+### Interpret results
+
+```
+Filename               Regions   Missed  Cover%   Functions  Missed  Cover%   Lines      Missed  Cover%
+core/runtime/...        12345      1234   90.0%        456      45    90.1%      23456    2345    90.0%
+```
+
+- **Regions** — branches + basic blocks. Best proxy for "did a test
+  actually step through this code."
+- **Lines** — executed at least once. Easier to reason about but
+  over-counts multi-statement lines.
+- **Functions** — % of declared functions that ran at least once.
+
+What to do with the numbers:
+1. Pick a subsystem under `#290` (platform / host / format / runtime /
+   view / osc / dsl).
+2. Sort the summary by Regions Cover% ascending.
+3. Write tests for the top 3 files with lowest region coverage.
+4. Open a PR that raises the column by a few points. No hard threshold —
+   the direction matters, not the absolute number.
+
+### What coverage won't tell you
+
+- Concurrency correctness. That's TSan.
+- Memory safety. That's ASan.
+- Whether a test has real assertions or just exercises code without
+  checking anything. Coverage + a passing test count is necessary but
+  not sufficient.
+
+### CI
+
+`coverage.yml` (non-blocking) uploads the HTML as a PR artifact on every
+pull request. Main-branch runs additionally push a JSON summary to
+`docs/coverage-history.json` so trends can be charted over time.
+
+## AddressSanitizer + UBSan
+
+### Run locally
+
+```bash
+scripts/run_asan.sh
+```
+
+Any ASan or UBSan report stops the test run with a non-zero exit.
+
+### Interpret a report
+
+A typical ASan trace:
+
+```
+=================================================================
+==12345==ERROR: AddressSanitizer: heap-use-after-free on address 0x…
+READ of size 4 at 0x… thread T0
+    #0 0x… in pulp::view::View::layout() core/view/src/view.cpp:123
+    #1 0x… in pulp::view::WindowHost::repaint() core/view/src/window_host.cpp:456
+    ...
+0x… is located 8 bytes inside of 256-byte region [0x…,0x…)
+freed by thread T0 here:
+    #0 0x… in operator delete(void*) ...
+    #1 0x… in pulp::view::View::~View() core/view/src/view.cpp:77
+```
+
+Read top-down:
+1. **ERROR line** → the bug class (heap-use-after-free / stack-overflow /
+   global-buffer-overflow / …).
+2. **READ/WRITE of size X at 0x…** → exact address + access type.
+3. **thread TN** → which thread saw the bug.
+4. The stack trace of the current access.
+5. The stack trace of the previous alloc/free for the same region — the
+   common case is this is where the lifetime bug actually is.
+
+Common fixes:
+- Use-after-free → check object lifetime; make sure destructors don't
+  leave raw pointers dangling.
+- Heap-buffer-overflow → review index arithmetic + the size that was
+  passed in.
+- Stack-buffer-overflow → usually a fixed-size array + off-by-one.
+
+### CI
+
+`sanitizers.yml` runs ASan + UBSan on `pull_request` and blocks on any
+report. Runners: Linux + macOS.
+
+## ThreadSanitizer
+
+### Run locally
+
+```bash
+scripts/run_tsan.sh
+```
+
+### Interpret a race report
+
+```
+WARNING: ThreadSanitizer: data race (pid=12345)
+  Write of size 4 at 0x… by thread T1:
+    #0 pulp::state::StateStore::set_param() ...
+    #1 pulp::format::Processor::process() ...
+  Previous read of size 4 at 0x… by main thread:
+    #0 pulp::view::ParamBinding::poll() ...
+```
+
+The pattern to match: write on one thread, unsynchronized read/write on
+another. Common fixes:
+- Atomic + relaxed ordering if it's a single independent value.
+- `SeqLock` if it's a coherent multi-field read (see `core/runtime`).
+- `TripleBuffer` if it's large and read-latest.
+- `SpscQueue` if it's ordered events.
+
+### Known-safe patterns (suppressions)
+
+TSan can flag known-safe patterns like CHOC's SPSC FIFO or atomic fences
+we've deliberately relaxed. Add the offending trace signature to
+`tools/tsan-suppressions.txt` (one per line, see TSan docs for format).
+Every entry needs a comment explaining *why* it's safe — otherwise it's
+a silent bug.
+
+## Realtime Safety (RTSan)
+
+RealtimeSanitizer flags allocation, mutex acquisition, and syscalls
+inside functions annotated with `[[clang::nonblocking]]`. Requires
+upstream Clang 18+.
+
+On Linux:
+
+```bash
+cmake -S . -B build-rtsan -DPULP_SANITIZER=realtime
+cmake --build build-rtsan
+ctest --test-dir build-rtsan
+```
+
+Currently annotated: the audio-thread `process()` paths in each format
+adapter. If RTSan reports an allocation in there, it's a real RT-safety
+bug (see #307 Codex P1 → PR #315 for a representative case).
+
+## Relation to #290
+
+`#290` is the test-coverage hardening initiative for `platform`, `host`,
+`format`, `runtime`, `view`, `osc`, and `dsl`. This doc describes the
+tooling; #290 is the ongoing effort to turn red numbers into green ones.
+Pick a subsystem, look at `summary.txt`, write tests, submit a PR.
+
+## When should you run which?
+
+- **Before opening a PR that changes non-trivial logic** → at minimum
+  compile + run your targeted tests under ASan. Ten-second overhead,
+  catches the 80% of memory bugs that would otherwise wait for CI.
+- **Before opening a PR that touches threading primitives** → TSan.
+- **Monthly, or before a release** → coverage report on main. Check
+  which subsystems regressed and write tests.
+- **When RT-safety is on the line** (audio-thread code, lock-free
+  containers) → RTSan on Linux locally; TSan in CI.

--- a/scripts/run_asan.sh
+++ b/scripts/run_asan.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# run_asan.sh — ASan + UBSan build + test run.
+#
+# Uses the pre-existing Sanitizers.cmake (PULP_SANITIZER=address) path.
+# Exits non-zero if any sanitizer report fires during the test suite.
+#
+# Usage:
+#   scripts/run_asan.sh [--jobs N] [--tests REGEX]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build-asan"
+JOBS=$(command -v nproc >/dev/null 2>&1 && nproc || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+TESTS_REGEX=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --jobs) JOBS="$2"; shift 2 ;;
+        --tests) TESTS_REGEX="$2"; shift 2 ;;
+        *) echo "unknown arg: $1"; exit 2 ;;
+    esac
+done
+
+echo "=== Configuring ASan build in ${BUILD_DIR} ==="
+cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DPULP_SANITIZER=address
+
+echo "=== Building ==="
+cmake --build "${BUILD_DIR}" -j"${JOBS}"
+
+# Disable ASLR-sensitive features that conflict with ASan on macOS.
+# halt_on_error=1 turns first sanitizer report into non-zero exit.
+# abort_on_error=0 so we get a full stack trace, not a SIGABRT dump.
+export ASAN_OPTIONS="halt_on_error=1:abort_on_error=0:symbolize=1:detect_leaks=0"
+export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"
+
+echo "=== Running tests under ASan + UBSan ==="
+cd "${BUILD_DIR}"
+if [[ -n "${TESTS_REGEX}" ]]; then
+    ctest -R "${TESTS_REGEX}" --output-on-failure
+else
+    ctest --output-on-failure
+fi

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# run_coverage.sh — configure + build + test + HTML coverage report.
+#
+# Usage:
+#   scripts/run_coverage.sh [--jobs N] [--tests REGEX]
+#
+# Produces:
+#   build-coverage/coverage/index.html         — per-file drilldown
+#   build-coverage/coverage/summary.txt        — top-level table
+#
+# Coverage is informational only. This script never fails on a
+# coverage threshold; thresholds would be noise without a baseline
+# and the #290 hardening initiative.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build-coverage"
+PROFRAW_DIR="${BUILD_DIR}/profraw"
+REPORT_DIR="${BUILD_DIR}/coverage"
+JOBS=$(command -v nproc >/dev/null 2>&1 && nproc || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+TESTS_REGEX=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --jobs) JOBS="$2"; shift 2 ;;
+        --tests) TESTS_REGEX="$2"; shift 2 ;;
+        *) echo "unknown arg: $1"; exit 2 ;;
+    esac
+done
+
+# Require Clang — llvm-cov reads Clang-specific .profdata format.
+if ! command -v clang >/dev/null 2>&1; then
+    echo "run_coverage.sh: clang not found on PATH" >&2
+    exit 1
+fi
+if ! command -v llvm-profdata >/dev/null 2>&1; then
+    echo "run_coverage.sh: llvm-profdata not found on PATH" >&2
+    exit 1
+fi
+if ! command -v llvm-cov >/dev/null 2>&1; then
+    echo "run_coverage.sh: llvm-cov not found on PATH" >&2
+    exit 1
+fi
+
+echo "=== Configuring coverage build in ${BUILD_DIR} ==="
+cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DPULP_ENABLE_COVERAGE=ON \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++
+
+echo "=== Building ==="
+cmake --build "${BUILD_DIR}" -j"${JOBS}"
+
+echo "=== Running tests with LLVM_PROFILE_FILE ==="
+mkdir -p "${PROFRAW_DIR}"
+cd "${BUILD_DIR}"
+export LLVM_PROFILE_FILE="${PROFRAW_DIR}/pulp-%p-%m.profraw"
+if [[ -n "${TESTS_REGEX}" ]]; then
+    ctest -R "${TESTS_REGEX}" --output-on-failure || true
+else
+    ctest --output-on-failure || true
+fi
+
+echo "=== Merging profiles ==="
+# Avoid shell-glob on thousands of profraw files that may exhaust argv
+# on some OSes; feed via find -print0 | xargs.
+mkdir -p "${REPORT_DIR}"
+PROFDATA="${REPORT_DIR}/pulp.profdata"
+find "${PROFRAW_DIR}" -name '*.profraw' -print0 \
+    | xargs -0 llvm-profdata merge -sparse -o "${PROFDATA}"
+
+# Gather every test binary for llvm-cov's -object multi-arg form.
+BINARIES=()
+while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
+    find "${BUILD_DIR}/test" -maxdepth 2 -type f -perm -u+x \
+         ! -name '*.cmake' ! -name '*.txt' 2>/dev/null || true
+)
+
+if [[ ${#BINARIES[@]} -eq 0 ]]; then
+    echo "run_coverage.sh: no test binaries found under ${BUILD_DIR}/test" >&2
+    exit 1
+fi
+
+echo "=== llvm-cov report (top-level summary) ==="
+llvm-cov report \
+    "${BINARIES[@]}" \
+    -instr-profile="${PROFDATA}" \
+    -ignore-filename-regex='_deps/|/external/|/test/' \
+    | tee "${REPORT_DIR}/summary.txt"
+
+echo "=== llvm-cov show (HTML drilldown) ==="
+llvm-cov show \
+    "${BINARIES[@]}" \
+    -instr-profile="${PROFDATA}" \
+    -ignore-filename-regex='_deps/|/external/|/test/' \
+    -format=html \
+    -output-dir="${REPORT_DIR}"
+
+echo ""
+echo "HTML report: ${REPORT_DIR}/index.html"
+echo "Summary:     ${REPORT_DIR}/summary.txt"

--- a/scripts/run_tsan.sh
+++ b/scripts/run_tsan.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# run_tsan.sh — ThreadSanitizer build + test run.
+#
+# Uses the pre-existing Sanitizers.cmake (PULP_SANITIZER=thread) path.
+# TSan can be noisy with lock-free code; TSAN_OPTIONS below suppresses
+# known-safe patterns. Expect to iterate on suppressions as the test
+# surface grows.
+#
+# Usage:
+#   scripts/run_tsan.sh [--jobs N] [--tests REGEX]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build-tsan"
+JOBS=$(command -v nproc >/dev/null 2>&1 && nproc || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+TESTS_REGEX=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --jobs) JOBS="$2"; shift 2 ;;
+        --tests) TESTS_REGEX="$2"; shift 2 ;;
+        *) echo "unknown arg: $1"; exit 2 ;;
+    esac
+done
+
+echo "=== Configuring TSan build in ${BUILD_DIR} ==="
+cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DPULP_SANITIZER=thread
+
+echo "=== Building ==="
+cmake --build "${BUILD_DIR}" -j"${JOBS}"
+
+# halt_on_error=1 → fail on first real race.
+# history_size=7 → deeper history for diagnosis (default 4).
+# Optional suppressions file: ${REPO_ROOT}/tools/tsan-suppressions.txt
+SUPPRESSIONS="${REPO_ROOT}/tools/tsan-suppressions.txt"
+TSAN_OPT="halt_on_error=1:history_size=7"
+if [[ -f "${SUPPRESSIONS}" ]]; then
+    TSAN_OPT="${TSAN_OPT}:suppressions=${SUPPRESSIONS}"
+fi
+export TSAN_OPTIONS="${TSAN_OPT}"
+
+echo "=== Running tests under TSan ==="
+cd "${BUILD_DIR}"
+if [[ -n "${TESTS_REGEX}" ]]; then
+    ctest -R "${TESTS_REGEX}" --output-on-failure
+else
+    ctest --output-on-failure
+fi

--- a/tools/cmake/PulpInstrumentation.cmake
+++ b/tools/cmake/PulpInstrumentation.cmake
@@ -1,0 +1,76 @@
+# Pulp coverage instrumentation (#290 / coverage-sanitizers spec).
+#
+# Sanitizers are handled by the pre-existing Sanitizers.cmake
+# (PULP_SANITIZER=address/thread/undefined/memory/realtime). This
+# module adds the third leg of the hardening pipeline: Clang
+# source-based coverage. Together they give:
+#   - coverage (non-blocking, artifact only)
+#   - sanitizers (blocking in CI via PULP_SANITIZER=address)
+#
+# Usage:
+#   cmake -S . -B build-coverage -DPULP_ENABLE_COVERAGE=ON
+#   cmake --build build-coverage
+#   ctest --test-dir build-coverage
+#   # Then: scripts/run_coverage.sh (wraps the above + llvm-cov report)
+#
+# Flags applied centrally so every Pulp target gets the same treatment
+# without per-subsystem drift. External FetchContent deps (Skia, Dawn,
+# mbedTLS, QuickJS, etc.) are compiled separately and not affected.
+#
+# Full design + phased rollout:
+# planning/coverage-sanitizers-spec-2026-04-16.md (private submodule).
+
+include_guard(GLOBAL)
+
+option(PULP_ENABLE_COVERAGE "Clang source-based coverage instrumentation" OFF)
+
+if(NOT PULP_ENABLE_COVERAGE)
+    return()
+endif()
+
+# Coverage requires Clang.
+if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    message(FATAL_ERROR
+        "PULP_ENABLE_COVERAGE requires Clang (GCC gcov is not supported "
+        "in year 1 — shape differences between llvm-cov and gcovr "
+        "would confuse the per-subsystem summary table).")
+endif()
+
+# Warn on Release.
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    message(WARNING
+        "PULP_ENABLE_COVERAGE is ON with a Release build. Coverage "
+        "instrumentation is most useful with Debug or RelWithDebInfo.")
+endif()
+
+# Disallow combining with sanitizers — shared link-time flags collide
+# on some libc++/libstdc++ versions and we want separate artifacts for
+# separate analyses.
+if(PULP_SANITIZER)
+    message(FATAL_ERROR
+        "PULP_ENABLE_COVERAGE is mutually exclusive with PULP_SANITIZER. "
+        "Pick one; use separate build directories.")
+endif()
+
+set(_pulp_coverage_compile_flags
+    -fprofile-instr-generate
+    -fcoverage-mapping
+    -g
+    -O0)
+set(_pulp_coverage_link_flags
+    -fprofile-instr-generate
+    -fcoverage-mapping)
+
+# Global application: coverage is all-or-nothing across the Pulp
+# tree (it's a build-config thing, not per-target). Using
+# add_compile_options + add_link_options keeps it consistent with
+# Sanitizers.cmake and means no per-subsystem wiring change.
+add_compile_options(${_pulp_coverage_compile_flags})
+add_link_options(${_pulp_coverage_link_flags})
+
+# Expose a helper variable so scripts/CI can confirm the build is
+# instrumented (read back by llvm-cov report as a sanity check).
+set(PULP_COVERAGE_ENABLED TRUE CACHE INTERNAL
+    "Source-based coverage is active for this build tree")
+
+message(STATUS "Pulp coverage: Clang source-based instrumentation ON")


### PR DESCRIPTION
## Why

Closes task #14 (coverage + sanitizer instrumentation) and gives the #290 hardening initiative its measurement surface. Matches the phased approach in \`planning/coverage-sanitizers-spec-2026-04-16.md\` (private submodule).

## What

**Coverage lane (new):**
- \`tools/cmake/PulpInstrumentation.cmake\` — \`PULP_ENABLE_COVERAGE=ON\` adds Clang \`-fprofile-instr-generate -fcoverage-mapping\` globally. Mutually exclusive with \`PULP_SANITIZER\`.
- \`scripts/run_coverage.sh\` — configure + build + ctest + \`llvm-profdata merge\` + \`llvm-cov\` HTML. Output at \`build-coverage/coverage/index.html\` and \`summary.txt\`. External deps (\`_deps/\`, \`external/\`, \`test/\`) filtered from the report.
- \`.github/workflows/coverage.yml\` — non-blocking; uploads HTML + summary as PR artifacts.

**Sanitizer lane (enabled existing):**
- \`.github/workflows/sanitizers.yml\` — flipped from \`workflow_dispatch\` only to \`pull_request + push on main\`. Now blocks the PR on ASan/TSan/UBSan/RTSan fires.
- \`scripts/run_asan.sh\` / \`scripts/run_tsan.sh\` — local wrappers mirroring the CI path.

**Docs:**
- \`docs/dev/testing.md\` — how to run each tool, how to interpret reports, how to triage races, suppression hygiene, relation to #290. \"What to do when ASan fires\" / \"What to do when TSan fires\" sections with realistic output + common fixes.

## Scope

This is the tooling + CI wiring. Raising coverage numbers per subsystem is #290's ongoing work; running ASan + fixing any findings is follow-up as the blocking gate kicks in.

## Test plan

- [x] \`PulpInstrumentation.cmake\` guards: Clang-only, mutually-exclusive-with-PULP_SANITIZER.
- [x] Minimal-project local check: \`-DPULP_ENABLE_COVERAGE=ON\` with \`clang++\` produces a binary with \`__llvm_profile_instrument_*\` symbols linked.
- [x] Non-coverage / non-sanitizer builds unaffected.
- [ ] First CI run will shake out any ASan findings the newly-blocking gate surfaces.

## Alignment note

The spec doc (private submodule, committed earlier this session) invited Codex alignment before Phase 1 implementation. This PR is the concrete diff; any structural concerns (global \`add_compile_options\` vs. per-target \`pulp_apply_instrumentation\`, runner choices, TSan blocking vs advisory) can land as follow-ups without blocking the local-dev tooling lane.