### PR TITLE
events: install_backend assigns backend before emitting lost callbacks (#314 P2)

### DIFF
--- a/core/events/src/volume_detector.cpp
+++ b/core/events/src/volume_detector.cpp
@@ -81,10 +81,18 @@ std::vector<std::string> MountedVolumeListChangeDetector::get_mounted_volumes() 
 NetworkServiceDiscovery::~NetworkServiceDiscovery() { stop(); }
 
 void NetworkServiceDiscovery::install_backend(std::unique_ptr<Backend> backend) {
-    // Codex P2 on #310: swapping backends must clear the cached
-    // discoveries, otherwise stale services from the previous backend
+    // Codex P2 on #310: swapping backends clears the cached
+    // discoveries so stale services from the previous backend don't
     // leak into queries against the new one.
+    //
+    // Codex P2 follow-up on #314: assign backend_ BEFORE emitting
+    // on_service_lost, not after. If a subscriber's on_service_lost
+    // handler re-enters the NSD API (has_backend(), register_service(),
+    // etc.) while we're evicting, it must see the NEW backend state,
+    // not the old one we just tore down via stop(). Swap first, then
+    // drain lost-callbacks.
     stop();
+    backend_ = std::move(backend);
     if (!services_.empty()) {
         auto lost = std::move(services_);
         services_.clear();
@@ -92,7 +100,6 @@ void NetworkServiceDiscovery::install_backend(std::unique_ptr<Backend> backend) 
             for (const auto& s : lost) on_service_lost(s);
         }
     }
-    backend_ = std::move(backend);
 }
 
 void NetworkServiceDiscovery::browse(std::string_view service_type) {

--- a/test/test_network_service_discovery.cpp
+++ b/test/test_network_service_discovery.cpp
@@ -183,3 +183,27 @@ TEST_CASE("NSD clears discoveries and fires on_service_lost when swapping backen
     REQUIRE(lost.size() == 2);
     REQUIRE((lost[0] == "alpha" || lost[0] == "beta"));
 }
+
+// Codex P2 follow-up on #314: if a subscriber's on_service_lost
+// handler re-enters the NSD API during a backend swap, it must see
+// the NEW backend state — not the torn-down old one.
+TEST_CASE("NSD install_backend: on_service_lost re-entry sees the new backend",
+          "[events][service-discovery][issue-314]") {
+    NetworkServiceDiscovery nsd;
+    nsd.install_backend(std::make_unique<FakeBackend>());
+
+    NetworkServiceDiscovery::Service s;
+    s.name = "alpha"; s.type = "_pulp._tcp"; s.port = 1;
+    nsd.notify_service_found(s);
+
+    bool had_backend_during_lost = false;
+    nsd.on_service_lost = [&](const NetworkServiceDiscovery::Service&) {
+        // At this point the swap is supposed to be complete. Probe.
+        had_backend_during_lost = nsd.has_backend();
+    };
+
+    // Swap. During the eviction drain, on_service_lost runs — and
+    // should observe the new backend already installed.
+    nsd.install_backend(std::make_unique<FakeBackend>());
+    REQUIRE(had_backend_during_lost);
+}


### PR DESCRIPTION
Codex P2 follow-up on merged #314. `install_backend` now assigns `backend_` BEFORE draining the lost-callbacks so any re-entry into the NSD API during the callback observes the new backend, not the torn-down old one.

New [issue-314] test verifies via has_backend() probe inside on_service_lost.