### PR TITLE
platform: narrow FileDialog::has_backend=true to macOS only (#316 P2)

### DIFF
--- a/core/platform/src/file_dialog_stub.cpp
+++ b/core/platform/src/file_dialog_stub.cpp
@@ -14,6 +14,13 @@
 
 #include <mutex>
 
+// TargetConditionals provides TARGET_OS_OSX / TARGET_OS_IOS macros
+// so has_backend() can narrow its unconditional-true to macOS only
+// (Apple has no built-in file_dialog impl on iOS yet — #316 P2).
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
 namespace pulp::platform {
 
 namespace {
@@ -35,12 +42,14 @@ void FileDialog::clear_backend() {
 }
 
 bool FileDialog::has_backend() {
-    // #312 Codex P2: on Apple platforms the native file_dialog_mac.mm /
-    // UIDocumentPicker impl is always available, so "has a working
-    // dialog backend" is unconditionally true. Non-Apple platforms
-    // report the host-registered state. This keeps callers' "probe
-    // before calling" checks meaningful across platforms.
-#if defined(__APPLE__)
+    // #312 + #316 Codex P2s: report "true" only on platforms where a
+    // real native dialog impl is compiled in. macOS ships
+    // file_dialog_mac.mm; iOS does NOT have a built-in file_dialog
+    // impl yet (UIDocumentPicker wiring is a follow-up). Narrow the
+    // unconditional-true to macOS only; iOS and everyone else
+    // reflect the host-registered state so callers get honest
+    // "unsupported" signaling until the iOS impl lands.
+#if defined(__APPLE__) && TARGET_OS_OSX
     return true;
 #else
     std::lock_guard lock(g_backend_mu);

--- a/test/test_file_dialog.cpp
+++ b/test/test_file_dialog.cpp
@@ -13,18 +13,22 @@
 #include <string>
 #include <vector>
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
 using pulp::platform::FileDialog;
 using pulp::platform::FileFilter;
 
 TEST_CASE("FileDialog has_backend reflects native vs host-registered availability",
-          "[platform][file-dialog][issue-301][issue-312]") {
+          "[platform][file-dialog][issue-301][issue-312][issue-316]") {
     // Clean host-registered state — test suite may run in any order.
-    // Post-#312 (Codex P2) semantics: Apple reports has_backend() == true
-    // unconditionally because the native NSOpenPanel/UIDocumentPicker
-    // impl is always available. Non-Apple reflects the host-registered
-    // state, which is false here after clear_backend().
+    // Post-#312 + #316 (Codex P2s): has_backend() reports true
+    // unconditionally ONLY on macOS, which ships file_dialog_mac.mm.
+    // iOS and non-Apple reflect the host-registered state until their
+    // native impls land.
     FileDialog::clear_backend();
-#if defined(__APPLE__)
+#if defined(__APPLE__) && TARGET_OS_OSX
     REQUIRE(FileDialog::has_backend());
 #else
     REQUIRE_FALSE(FileDialog::has_backend());
@@ -121,9 +125,9 @@ TEST_CASE("FileDialog backend registration is safe to call on any platform",
     };
     FileDialog::set_backend(b);
     FileDialog::clear_backend();
-    // Post-#312: has_backend() is true on Apple (native impl), reflects
-    // host-registered state on non-Apple.
-#if defined(__APPLE__)
+    // Post-#312 + #316: has_backend() is true only on macOS (native
+    // impl); iOS and non-Apple reflect host-registered state.
+#if defined(__APPLE__) && TARGET_OS_OSX
     REQUIRE(FileDialog::has_backend());
 #else
     REQUIRE_FALSE(FileDialog::has_backend());


### PR DESCRIPTION
Codex P2 on merged #316. has_backend() returned true on every Apple platform but file_dialog_mac.mm only builds on macOS — iOS had no dialog impl yet. Narrowed via TARGET_OS_OSX. iOS/tvOS/watchOS fall through to host-registered state. Tests updated, 2/2 local macOS pass.