### PR TITLE
ci(tooling): coverage-fail propagation + C compiler check + run_ubsan.sh (#317 P2s)

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -9,7 +9,7 @@ builds are unaffected.
 | **Coverage** | `-DPULP_ENABLE_COVERAGE=ON` | Measure what the test suite actually exercises | Non-blocking artifact |
 | **AddressSanitizer + UBSan** | `-DPULP_SANITIZER=address` | Heap/stack overflow, use-after-free, UB | Blocking (when enabled) |
 | **ThreadSanitizer** | `-DPULP_SANITIZER=thread` | Data races, lock ordering | Advisory |
-| UndefinedBehaviorSanitizer | `-DPULP_SANITIZER=undefined` | Signed overflow, null deref, alignment | On-demand |
+| UndefinedBehaviorSanitizer | `-DPULP_SANITIZER=undefined` | Signed overflow, null deref, alignment | On-demand (`scripts/run_ubsan.sh`) |
 | MemorySanitizer | `-DPULP_SANITIZER=memory` | Uninitialized reads (Clang only; requires all-deps instrumented) | Manual |
 | RealtimeSanitizer | `-DPULP_SANITIZER=realtime` | Malloc / lock / syscall inside an RT section (Clang 18+) | Manual |
 

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -58,10 +58,20 @@ echo "=== Running tests with LLVM_PROFILE_FILE ==="
 mkdir -p "${PROFRAW_DIR}"
 cd "${BUILD_DIR}"
 export LLVM_PROFILE_FILE="${PROFRAW_DIR}/pulp-%p-%m.profraw"
+
+# #317 Codex P2: track test-suite outcome without aborting the
+# coverage report. A broken test run should still upload its
+# partial coverage (so reviewers can see what DID exercise), but
+# the script MUST exit non-zero so CI flags the failure —
+# silently swallowing test failures hid real regressions.
+CTEST_RC=0
 if [[ -n "${TESTS_REGEX}" ]]; then
-    ctest -R "${TESTS_REGEX}" --output-on-failure || true
+    ctest -R "${TESTS_REGEX}" --output-on-failure || CTEST_RC=$?
 else
-    ctest --output-on-failure || true
+    ctest --output-on-failure || CTEST_RC=$?
+fi
+if [[ "${CTEST_RC}" -ne 0 ]]; then
+    echo "=== ctest failed with exit ${CTEST_RC} — coverage report WILL be generated from partial profile data, then the script will exit with that code. ==="
 fi
 
 echo "=== Merging profiles ==="
@@ -102,3 +112,10 @@ llvm-cov show \
 echo ""
 echo "HTML report: ${REPORT_DIR}/index.html"
 echo "Summary:     ${REPORT_DIR}/summary.txt"
+
+# Propagate test-suite failure to callers/CI.
+if [[ "${CTEST_RC}" -ne 0 ]]; then
+    echo ""
+    echo "=== FAIL: ctest exited non-zero (${CTEST_RC}). Coverage report above is based on partial profile data from tests that did run. ==="
+    exit "${CTEST_RC}"
+fi

--- a/scripts/run_ubsan.sh
+++ b/scripts/run_ubsan.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# run_ubsan.sh — UndefinedBehaviorSanitizer-only build + test run.
+#
+# run_asan.sh already enables UBSan alongside ASan (via
+# -fsanitize=address,undefined), which is the usual case. This
+# separate wrapper exists for two reasons (Codex P2 on #317):
+# 1. ASan has higher overhead and can mask signed-overflow / null-
+#    deref patterns that UBSan alone catches faster.
+# 2. Some UBSan checks collide with ASan's shadow memory; running
+#    UBSan alone gives cleaner reports for those classes.
+#
+# Uses the existing Sanitizers.cmake path (PULP_SANITIZER=undefined).
+#
+# Usage:
+#   scripts/run_ubsan.sh [--jobs N] [--tests REGEX]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build-ubsan"
+JOBS=$(command -v nproc >/dev/null 2>&1 && nproc || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+TESTS_REGEX=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --jobs) JOBS="$2"; shift 2 ;;
+        --tests) TESTS_REGEX="$2"; shift 2 ;;
+        *) echo "unknown arg: $1"; exit 2 ;;
+    esac
+done
+
+echo "=== Configuring UBSan build in ${BUILD_DIR} ==="
+cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DPULP_SANITIZER=undefined
+
+echo "=== Building ==="
+cmake --build "${BUILD_DIR}" -j"${JOBS}"
+
+# halt_on_error=1 + print_stacktrace=1 → fail on first UB, with trace.
+export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1:symbolize=1"
+
+echo "=== Running tests under UBSan ==="
+cd "${BUILD_DIR}"
+if [[ -n "${TESTS_REGEX}" ]]; then
+    ctest -R "${TESTS_REGEX}" --output-on-failure
+else
+    ctest --output-on-failure
+fi

--- a/tools/cmake/PulpInstrumentation.cmake
+++ b/tools/cmake/PulpInstrumentation.cmake
@@ -28,12 +28,23 @@ if(NOT PULP_ENABLE_COVERAGE)
     return()
 endif()
 
-# Coverage requires Clang.
+# Coverage requires Clang for BOTH C and C++ compilers. If CC is
+# gcc while CXX is clang++, the coverage flags produce incompatible
+# profraw shapes and llvm-cov can't merge them. #317 Codex P2.
 if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
     message(FATAL_ERROR
-        "PULP_ENABLE_COVERAGE requires Clang (GCC gcov is not supported "
-        "in year 1 — shape differences between llvm-cov and gcovr "
-        "would confuse the per-subsystem summary table).")
+        "PULP_ENABLE_COVERAGE requires Clang for C++ "
+        "(CMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}). "
+        "GCC gcov is not supported in year 1 — shape differences "
+        "between llvm-cov and gcovr would confuse the per-subsystem "
+        "summary table.")
+endif()
+if(NOT (CMAKE_C_COMPILER_ID MATCHES "Clang"))
+    message(FATAL_ERROR
+        "PULP_ENABLE_COVERAGE requires Clang for C "
+        "(CMAKE_C_COMPILER_ID=${CMAKE_C_COMPILER_ID}). "
+        "Mixing gcc for .c and clang++ for .cpp produces profraw "
+        "shape incompatibilities that llvm-cov can't merge.")
 endif()
 
 # Warn on Release.


### PR DESCRIPTION
Codex P2 on merged #317: (1) run_coverage.sh no longer swallows test failures — tracks exit code, still generates partial report, propagates non-zero at end. (2) PulpInstrumentation.cmake checks both CXX AND C compiler IDs (prevents CC=gcc CXX=clang++ profraw incompatibility). (3) New scripts/run_ubsan.sh for UBSan-only runs.