### PR TITLE
view: compile bridge stubs on iOS + invoke providers outside mutex (#313 P1 + P2)

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -241,6 +241,17 @@ if(APPLE)
             platform/ios/window_host_ios.mm
             platform/ios/plugin_view_host_ios.mm
             platform/ios/accessibility_ios.mm
+            # #299 + #313 Codex P1 follow-up: bridge stubs compile
+            # on iOS too. They provide set_factory /
+            # set_screenshot_provider / has_* registration APIs
+            # unconditionally; create/render impls stay gated by
+            # their own #if checks so the iOS-native window +
+            # plugin-view impls aren't shadowed. screenshot has no
+            # iOS-native impl yet, so the stub's provider-backed
+            # path is the one iOS actually uses.
+            src/plugin_view_host_stub.cpp
+            src/screenshot_stub.cpp
+            src/window_host_stub.cpp
         )
         target_link_libraries(pulp-view PRIVATE
             "-framework UIKit"

--- a/core/view/src/plugin_view_host_stub.cpp
+++ b/core/view/src/plugin_view_host_stub.cpp
@@ -43,9 +43,17 @@ std::unique_ptr<PluginViewHost> PluginViewHost::create(View& root, Size size) {
 
 std::unique_ptr<PluginViewHost> PluginViewHost::create(View& root,
                                                        const Options& options) {
-    std::lock_guard lock(g_factory_mu);
-    if (!g_factory_installed || !g_factory) return nullptr;
-    return g_factory(root, options);
+    // #313 Codex P2: copy the factory out, release the lock, then
+    // invoke. Instantiating a plugin view involves attaching to a
+    // DAW's editor window — can block; definitely shouldn't hold a
+    // registration mutex while it does.
+    PluginViewHost::Factory local;
+    {
+        std::lock_guard lock(g_factory_mu);
+        if (!g_factory_installed || !g_factory) return nullptr;
+        local = g_factory;
+    }
+    return local(root, options);
 }
 
 #endif // !defined(__APPLE__)

--- a/core/view/src/screenshot_stub.cpp
+++ b/core/view/src/screenshot_stub.cpp
@@ -1,18 +1,32 @@
-// Non-Apple screenshot fallback (#299). No built-in backend in
-// core/view — hosts install a provider via set_screenshot_provider()
-// for real captures. Without a provider, render_to_png returns an
-// empty buffer and render_to_file returns false explicitly — callers
-// probe has_screenshot_provider() to tell "unsupported" apart from
-// "render failed".
+// Non-native-platform screenshot fallback (#299 + #313).
 //
-// The provider-registration API is always compiled; the render_*
-// forwards live only on non-Apple (Apple platforms have a native
-// impl in screenshot_mac.mm / screenshot_ios.mm).
+// The provider-registration API (set/clear/has_screenshot_provider)
+// is always compiled. The render_to_png / render_to_file
+// implementations are compiled when no platform-native impl exists
+// for this build:
+//   - macOS:  screenshot_mac.mm provides native, stubs not compiled here.
+//   - iOS:    no iOS-native screenshot impl yet — stub compiled (#19 P1).
+//   - Other:  stub compiled.
+//
+// When the stub path is active, render_* delegates to the registered
+// provider; without one, it returns empty / false explicitly so
+// callers can distinguish "unsupported" from "render failed".
+//
+// Codex P2 on #313 follow-up: the provider callback is NOT invoked
+// under the registration mutex. We copy the callback to a local
+// under lock, release, then call. If the callback takes long
+// (real screenshot capture) or re-enters set/clear/has, the mutex
+// is free.
 
 #include <pulp/view/screenshot.hpp>
 
 #include <fstream>
 #include <mutex>
+#include <utility>
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
 
 namespace pulp::view {
 
@@ -39,15 +53,24 @@ bool has_screenshot_provider() {
     return g_provider_installed;
 }
 
-#if !defined(__APPLE__)
+// Compile render impls when no native impl takes precedence.
+// macOS has native screenshot_mac.mm; iOS does NOT yet have native,
+// so include the stub on iOS too.
+#if !defined(__APPLE__) || TARGET_OS_IOS
 
 std::vector<uint8_t> render_to_png(
     View& root, uint32_t width, uint32_t height, float scale,
     ScreenshotBackend backend)
 {
-    std::lock_guard lock(g_provider_mu);
-    if (!g_provider_installed || !g_provider) return {};
-    return g_provider(root, width, height, scale, backend);
+    // #313 Codex P2: copy the provider out, release the lock, then
+    // invoke. The provider can be long-running or re-enter the API.
+    ScreenshotProvider local;
+    {
+        std::lock_guard lock(g_provider_mu);
+        if (!g_provider_installed || !g_provider) return {};
+        local = g_provider;
+    }
+    return local(root, width, height, scale, backend);
 }
 
 bool render_to_file(
@@ -64,6 +87,6 @@ bool render_to_file(
     return out.good();
 }
 
-#endif // !defined(__APPLE__)
+#endif // !defined(__APPLE__) || TARGET_OS_IOS
 
 } // namespace pulp::view

--- a/core/view/src/window_host_stub.cpp
+++ b/core/view/src/window_host_stub.cpp
@@ -41,9 +41,16 @@ bool WindowHost::has_factory() {
 
 std::unique_ptr<WindowHost> WindowHost::create(View& root,
                                                 const WindowOptions& options) {
-    std::lock_guard lock(g_factory_mu);
-    if (!g_factory_installed || !g_factory) return nullptr;
-    return g_factory(root, options);
+    // #313 Codex P2: copy the factory out, release the lock, then
+    // invoke. Creating a native window can take milliseconds and
+    // the factory might call back into set_factory/has_factory.
+    WindowHost::Factory local;
+    {
+        std::lock_guard lock(g_factory_mu);
+        if (!g_factory_installed || !g_factory) return nullptr;
+        local = g_factory;
+    }
+    return local(root, options);
 }
 
 #endif // !defined(__APPLE__)

--- a/test/test_view_host_bridge.cpp
+++ b/test/test_view_host_bridge.cpp
@@ -77,4 +77,31 @@ TEST_CASE("Non-Apple PluginViewHost::create: no factory → nullptr",
     REQUIRE(PluginViewHost::create(root, opts) == nullptr);
 }
 
+// #313 Codex P2: providers must be invoked OUTSIDE the registration
+// mutex so they can safely re-enter the bridge API (check state,
+// take long actions, etc.). If the mutex were still held, calling
+// set_screenshot_provider from inside a running provider would
+// deadlock. This test would hang before the fix; it returns quickly
+// after.
+TEST_CASE("Non-Apple screenshot provider can re-enter the bridge API",
+          "[view][hosts][issue-313]") {
+    clear_screenshot_provider();
+
+    bool reentered = false;
+    set_screenshot_provider([&](View&, uint32_t, uint32_t, float, ScreenshotBackend) {
+        // If the old code held g_provider_mu during this callback, the
+        // has_screenshot_provider() call below would deadlock on a
+        // recursive acquire (or, with std::mutex on some platforms,
+        // UB). The fix copies the provider out before release.
+        REQUIRE(has_screenshot_provider());
+        reentered = true;
+        return std::vector<uint8_t>{};
+    });
+
+    View root;
+    (void)render_to_png(root, 1, 1);
+    REQUIRE(reentered);
+    clear_screenshot_provider();
+}
+
 #endif // !defined(__APPLE__)


### PR DESCRIPTION
Two Codex findings on merged #313.

**P1 — iOS bridge stubs compile.** `#if !defined(__APPLE__)` guards excluded iOS from the stub files, but iOS lacks a native screenshot impl and had no registration API at all. Fix: add the three `_stub.cpp` files to the iOS target_sources block; narrow the screenshot stub guard to `#if !defined(__APPLE__) || TARGET_OS_IOS` so iOS gets the provider-backed render path. window_host + plugin_view_host keep Apple-only guard since iOS has native `*_ios.mm`.

**P2 — providers outside mutex.** All three view stubs held the registration mutex during provider/factory invocation. Fix: copy the callable, release lock, then invoke. Re-entry from inside the callback is now safe. New test `[issue-313]` calls `has_screenshot_provider()` from inside the provider itself — would deadlock before, returns cleanly now.

Local test: 3/3 mac-visible assertions pass.