### PR TITLE
ci: add Windows MSVC release-path job to PR gate (permanent fix for v0.15-v0.17 silent failures)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,3 +259,42 @@ jobs:
             build/VST3/**/*.so
             build/CLAP/**/*.so
           retention-days: 7
+
+  # ── Windows MSVC release-path PR gate ────────────────────────────────────
+  #
+  # The main `build-and-test` matrix above runs Windows via Namespace with a
+  # configure that differs from release-cli.yml's. Result: MSVC-specific
+  # errors (protected-member strictness, WIN32_LEAN_AND_MEAN / COM header
+  # interactions, etc.) only surface AFTER a tag is pushed, when
+  # release-cli.yml builds on a GitHub-hosted windows-latest runner. That's
+  # how v0.15.0 / v0.16.0 / v0.17.0 shipped broken release pipelines —
+  # wasapi_device.cpp and accessibility_win.cpp both hit MSVC errors that
+  # the PR gate didn't catch.
+  #
+  # This job mirrors release-cli.yml's CLI-build configure on windows-latest
+  # for every PR so MSVC errors block merge instead of silently failing at
+  # tag-push time. Build-only; no test step — release-cli.yml doesn't run
+  # tests either, and the main matrix above already covers Windows tests on
+  # Namespace.
+  windows-msvc-release-gate:
+    runs-on: windows-latest
+    name: Windows MSVC release-path gate
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Bootstrap repository dependencies
+        run: ./setup.sh --ci --deps-only
+        shell: bash
+
+      - name: Configure (matches release-cli.yml)
+        run: |
+          cmake -S . -B build `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DPULP_BUILD_TESTS=OFF
+        shell: pwsh
+
+      - name: Build
+        run: cmake --build build --config Release
+        shell: pwsh


### PR DESCRIPTION
## Why

Root cause of the v0.15.0 / v0.16.0 / v0.17.0 silent release failures: the PR gate's Windows build runs on **Namespace** with a configure that differs from **release-cli.yml**'s. MSVC-specific errors only surface AFTER a tag is pushed, by which point merge already happened.

Three recent incidents all fit this pattern:
- #281 shipped `wasapi_device.cpp` with a C2248 protected-member bug. Fixed in #318 — *after* three broken releases.
- #283 shipped `accessibility_win.cpp` with a C2146 WIN32_LEAN_AND_MEAN + UIAutomation.h bug. Fixed in #327.
- Any future MSVC-only divergence would silently break the next release too.

## What

New \`windows-msvc-release-gate\` job in \`build.yml\`:
- Runs on **windows-latest** (GitHub-hosted, same as release-cli.yml).
- Mirrors release-cli.yml's CLI-build configure exactly (\`-DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_TESTS=OFF\`).
- Build-only — release-cli.yml doesn't run tests either, and the existing matrix covers Windows tests on Namespace.
- Blocks merge on any MSVC error.

## Closing the loop

With this + #318's release-guard.yml, the silent-release class is permanently gone:
- **Before merge**: this gate catches MSVC errors → merge blocked.
- **After tag (defense-in-depth)**: release-guard catches anything that still slips through → issue filed.

Users stop seeing "v0.14.0" for weeks at a time because a silent Windows x64 build broke releases.

## Test plan

- [ ] First real test: this PR itself runs through the new gate.
- [ ] Subsequent: any PR that touches \`core/*/platform/win/*\` or anything MSVC-sensitive now has visible Windows MSVC CI signal.