### PR TITLE
platform: introduce pulp::platform::Permissions API + desktop backend (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0170"></a>
+## [0.18.0]
+
 ## [0.17.0] - 2026-04-17
 
 - audio: fix MSVC C2248 on fire_device_change + add release-guard.yml ([#318](https://github.com/danielraffel/pulp/pull/318))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.17.0
+    VERSION 0.18.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(pulp-platform PRIVATE
     src/platform.cpp
     src/file_dialog_stub.cpp
     src/popup_menu_stub.cpp
+    src/permissions.cpp
     src/registry.cpp
     src/clipboard_common.cpp
 )

--- a/core/platform/include/pulp/platform/permissions.hpp
+++ b/core/platform/include/pulp/platform/permissions.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+// Cross-platform runtime permission queries and requests.
+//
+// Mobile platforms (iOS, Android) require explicit user consent for
+// microphone, camera, Bluetooth, and notifications. Desktop platforms
+// usually don't gate these through an app-level permission prompt, so
+// their backends treat most classes as `Granted` and some as
+// `Restricted` (e.g. Android's `ForegroundService`).
+//
+// The contract deliberately stays small:
+//   query(p)    — synchronous, never blocks, never prompts.
+//   request(p)  — async, always invokes the callback exactly once.
+//
+// Tests can redirect the backend with `PermissionsOverride` without
+// touching the platform implementation.
+
+#include <functional>
+
+namespace pulp::platform {
+
+enum class Permission {
+    Microphone,         // iOS mic, Android RECORD_AUDIO
+    Camera,             // iOS/Android camera
+    BluetoothMidi,      // iOS NSBluetoothAlwaysUsageDescription, Android BLUETOOTH_*
+    LocalNetwork,       // iOS NSLocalNetworkUsageDescription (RTP-MIDI, bonjour)
+    Notifications,      // iOS UNUserNotificationCenter, Android POST_NOTIFICATIONS
+    BackgroundAudio,    // iOS UIBackgroundModes=audio capability
+    ForegroundService,  // Android FOREGROUND_SERVICE / FOREGROUND_SERVICE_MICROPHONE
+};
+
+enum class PermissionState {
+    NotDetermined,  // Never asked. On platforms without a prompt, backends use Granted instead.
+    Granted,        // User (or OS policy) granted it.
+    Denied,         // User denied; may be re-askable depending on platform.
+    Restricted,     // Policy / parental-control / unsupported-on-platform.
+};
+
+using RequestCallback = std::function<void(PermissionState)>;
+
+/// Current state. Never blocks, never shows UI.
+PermissionState query(Permission p);
+
+/// Async request. `cb` is invoked exactly once with the resolved state.
+/// On backends with no UI gate, the callback fires synchronously with
+/// the same value `query()` would return.
+void request(Permission p, RequestCallback cb);
+
+/// True when a real platform backend is wired (iOS / Android). False
+/// when the desktop / unsupported backend is active — useful for
+/// diagnostics and feature gating.
+bool has_platform_backend();
+
+/// Test helper: scope-guarded override. While alive, `query()` and
+/// `request()` return the mapped state for overridden permissions and
+/// fall through to the real backend for the rest.
+///
+/// Not thread-safe on purpose — tests are single-threaded.
+class PermissionsOverride {
+public:
+    PermissionsOverride();
+    ~PermissionsOverride();
+
+    PermissionsOverride(const PermissionsOverride&) = delete;
+    PermissionsOverride& operator=(const PermissionsOverride&) = delete;
+
+    /// Map this permission to `state` for the lifetime of the guard.
+    void set(Permission p, PermissionState state);
+
+    /// Remove any override for `p`. Subsequent queries fall through.
+    void clear(Permission p);
+
+private:
+    struct Impl;
+    Impl* impl_;
+};
+
+}  // namespace pulp::platform

--- a/core/platform/src/permissions.cpp
+++ b/core/platform/src/permissions.cpp
@@ -1,0 +1,127 @@
+#include <pulp/platform/permissions.hpp>
+
+#include <array>
+#include <optional>
+#include <vector>
+
+namespace pulp::platform {
+
+namespace {
+
+// Per-call default that a no-backend (desktop, unsupported) platform
+// returns. iOS and Android replace these wholesale in their own backends.
+constexpr PermissionState desktop_default(Permission p) {
+    switch (p) {
+        case Permission::Microphone:
+        case Permission::Camera:
+        case Permission::BluetoothMidi:
+        case Permission::LocalNetwork:
+        case Permission::Notifications:
+            // Desktop OSes don't gate these behind an app-level prompt.
+            return PermissionState::Granted;
+
+        case Permission::BackgroundAudio:
+        case Permission::ForegroundService:
+            // Mobile-only lifecycle capabilities. On desktop, the
+            // caller shouldn't be asking, so signal unsupported rather
+            // than pretending we granted.
+            return PermissionState::Restricted;
+    }
+    return PermissionState::Restricted;
+}
+
+// Number of enum values. Kept in the cpp so adding new permissions
+// fails a compile-time check below rather than silently growing the
+// override table.
+constexpr std::size_t kPermissionCount =
+    static_cast<std::size_t>(Permission::ForegroundService) + 1;
+
+static_assert(kPermissionCount == 7,
+    "Update kPermissionCount (and desktop_default) when adding permissions.");
+
+// Override registry. Single-threaded on purpose — tests hold the
+// PermissionsOverride guard on the test thread; real platform backends
+// don't consult the registry.
+//
+// Nested guards stack. Each push() snapshots the current `entries`
+// so the inner guard can mutate freely and pop() reverts to the
+// outer state.
+struct OverrideRegistry {
+    using Snapshot = std::array<std::optional<PermissionState>, kPermissionCount>;
+
+    Snapshot entries{};
+    std::vector<Snapshot> stack;  // saved entries per live guard
+
+    void push() { stack.push_back(entries); }
+    void pop() {
+        if (stack.empty()) return;
+        entries = stack.back();
+        stack.pop_back();
+    }
+
+    bool active() const { return !stack.empty(); }
+};
+
+OverrideRegistry& registry() {
+    static OverrideRegistry r;
+    return r;
+}
+
+}  // namespace
+
+#if !defined(PULP_PERMISSIONS_HAS_BACKEND)
+// Default implementation — desktop and any platform that hasn't been
+// taught to answer permission prompts. Mobile backends provide their
+// own TU and define PULP_PERMISSIONS_HAS_BACKEND to suppress this one.
+
+PermissionState query(Permission p) {
+    auto& reg = registry();
+    if (reg.active()) {
+        auto idx = static_cast<std::size_t>(p);
+        if (idx < reg.entries.size() && reg.entries[idx].has_value()) {
+            return *reg.entries[idx];
+        }
+    }
+    return desktop_default(p);
+}
+
+void request(Permission p, RequestCallback cb) {
+    auto state = query(p);
+    if (cb) cb(state);
+}
+
+bool has_platform_backend() { return false; }
+
+#endif  // !PULP_PERMISSIONS_HAS_BACKEND
+
+// ── PermissionsOverride ──────────────────────────────────────────────
+
+struct PermissionsOverride::Impl {
+    OverrideRegistry* reg;
+};
+
+PermissionsOverride::PermissionsOverride()
+    : impl_(new Impl{&registry()}) {
+    impl_->reg->push();
+}
+
+PermissionsOverride::~PermissionsOverride() {
+    impl_->reg->pop();
+    delete impl_;
+}
+
+void PermissionsOverride::set(Permission p, PermissionState state) {
+    auto idx = static_cast<std::size_t>(p);
+    if (idx < impl_->reg->entries.size()) {
+        impl_->reg->entries[idx] = state;
+    }
+}
+
+void PermissionsOverride::clear(Permission p) {
+    auto idx = static_cast<std::size_t>(p);
+    if (idx < impl_->reg->entries.size()) {
+        impl_->reg->entries[idx].reset();
+    }
+}
+
+}  // namespace pulp::platform

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -400,6 +400,11 @@ add_executable(pulp-test-platform test_platform.cpp)
 target_link_libraries(pulp-test-platform PRIVATE pulp::platform Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-platform)
 
+# Permissions tests
+add_executable(pulp-test-permissions test_permissions.cpp)
+target_link_libraries(pulp-test-permissions PRIVATE pulp::platform Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-permissions)
+
 # Runtime tests
 add_executable(pulp-test-runtime test_runtime.cpp)
 target_link_libraries(pulp-test-runtime PRIVATE pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_permissions.cpp
+++ b/test/test_permissions.cpp
@@ -1,0 +1,140 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/permissions.hpp>
+
+#include <atomic>
+
+using pulp::platform::Permission;
+using pulp::platform::PermissionState;
+using pulp::platform::PermissionsOverride;
+using pulp::platform::has_platform_backend;
+using pulp::platform::query;
+using pulp::platform::request;
+
+TEST_CASE("query returns a concrete state for every permission class",
+          "[platform][permissions]") {
+    for (auto p : {
+             Permission::Microphone,
+             Permission::Camera,
+             Permission::BluetoothMidi,
+             Permission::LocalNetwork,
+             Permission::Notifications,
+             Permission::BackgroundAudio,
+             Permission::ForegroundService,
+         }) {
+        auto state = query(p);
+        // Never NotDetermined on the desktop no-op backend — callers
+        // must be able to make a decision without prompting.
+        if (!has_platform_backend()) {
+            REQUIRE(state != PermissionState::NotDetermined);
+        }
+    }
+}
+
+TEST_CASE("desktop backend reports mobile-only classes as Restricted",
+          "[platform][permissions]") {
+    if (has_platform_backend()) {
+        SUCCEED("platform backend active; skipping desktop default assertions");
+        return;
+    }
+    REQUIRE(query(Permission::BackgroundAudio) == PermissionState::Restricted);
+    REQUIRE(query(Permission::ForegroundService) == PermissionState::Restricted);
+}
+
+TEST_CASE("desktop backend reports generic classes as Granted",
+          "[platform][permissions]") {
+    if (has_platform_backend()) {
+        SUCCEED("platform backend active; skipping desktop default assertions");
+        return;
+    }
+    REQUIRE(query(Permission::Microphone) == PermissionState::Granted);
+    REQUIRE(query(Permission::Camera) == PermissionState::Granted);
+    REQUIRE(query(Permission::BluetoothMidi) == PermissionState::Granted);
+    REQUIRE(query(Permission::LocalNetwork) == PermissionState::Granted);
+    REQUIRE(query(Permission::Notifications) == PermissionState::Granted);
+}
+
+TEST_CASE("request() invokes the callback exactly once and forwards query state",
+          "[platform][permissions]") {
+    std::atomic<int> calls{0};
+    PermissionState seen = PermissionState::NotDetermined;
+    request(Permission::Microphone, [&](PermissionState s) {
+        ++calls;
+        seen = s;
+    });
+    REQUIRE(calls.load() == 1);
+    REQUIRE(seen == query(Permission::Microphone));
+}
+
+TEST_CASE("request() tolerates an empty callback",
+          "[platform][permissions]") {
+    // Must not crash or invoke UB when the caller doesn't need a result.
+    request(Permission::Microphone, {});
+    SUCCEED();
+}
+
+TEST_CASE("PermissionsOverride redirects query and request",
+          "[platform][permissions][override]") {
+    PermissionsOverride guard;
+    guard.set(Permission::Microphone, PermissionState::Denied);
+    guard.set(Permission::Camera, PermissionState::NotDetermined);
+
+    REQUIRE(query(Permission::Microphone) == PermissionState::Denied);
+    REQUIRE(query(Permission::Camera) == PermissionState::NotDetermined);
+
+    PermissionState seen_mic = PermissionState::Granted;
+    request(Permission::Microphone, [&](PermissionState s) { seen_mic = s; });
+    REQUIRE(seen_mic == PermissionState::Denied);
+
+    // Un-overridden permissions keep falling through to the real backend.
+    if (!has_platform_backend()) {
+        REQUIRE(query(Permission::Notifications) == PermissionState::Granted);
+    }
+}
+
+TEST_CASE("PermissionsOverride::clear removes one entry without tearing down others",
+          "[platform][permissions][override]") {
+    PermissionsOverride guard;
+    guard.set(Permission::Microphone, PermissionState::Denied);
+    guard.set(Permission::Camera, PermissionState::Denied);
+
+    guard.clear(Permission::Microphone);
+    if (!has_platform_backend()) {
+        REQUIRE(query(Permission::Microphone) == PermissionState::Granted);
+    }
+    REQUIRE(query(Permission::Camera) == PermissionState::Denied);
+}
+
+TEST_CASE("PermissionsOverride unwinds state when guard leaves scope",
+          "[platform][permissions][override]") {
+    {
+        PermissionsOverride guard;
+        guard.set(Permission::Microphone, PermissionState::Denied);
+        REQUIRE(query(Permission::Microphone) == PermissionState::Denied);
+    }
+    if (!has_platform_backend()) {
+        REQUIRE(query(Permission::Microphone) == PermissionState::Granted);
+    }
+}
+
+TEST_CASE("PermissionsOverride guards nest — outer state restores after inner exits",
+          "[platform][permissions][override]") {
+    PermissionsOverride outer;
+    outer.set(Permission::Microphone, PermissionState::Denied);
+    REQUIRE(query(Permission::Microphone) == PermissionState::Denied);
+    {
+        PermissionsOverride inner;
+        inner.set(Permission::Microphone, PermissionState::Granted);
+        REQUIRE(query(Permission::Microphone) == PermissionState::Granted);
+    }
+    // Inner guard popped — outer "Denied" must still hold.
+    REQUIRE(query(Permission::Microphone) == PermissionState::Denied);
+}
+
+TEST_CASE("has_platform_backend reports truthfully for the current target",
+          "[platform][permissions]") {
+#if defined(PULP_PERMISSIONS_HAS_BACKEND)
+    REQUIRE(has_platform_backend());
+#else
+    REQUIRE_FALSE(has_platform_backend());
+#endif
+}


### PR DESCRIPTION
## Summary

Closes #331. Adds the small cross-platform permission surface the 2026-04-17 parity audit called for. Unblocks #332 (Android request flow), #244 (Oboe input gated on RECORD_AUDIO), #86 (Android MIDI over Bluetooth), #329 (iOS AVAudioSession forwarding).

Before this change, permission plumbing lived only in `core/platform/src/android/permissions.cpp` — a single global JNI callback and a private enum nobody else could include. Every subsystem that needed a runtime grant had to reinvent the pattern.

### Public API

```cpp
namespace pulp::platform {

enum class Permission { Microphone, Camera, BluetoothMidi, LocalNetwork,
                        Notifications, BackgroundAudio, ForegroundService };
enum class PermissionState { NotDetermined, Granted, Denied, Restricted };

PermissionState query(Permission p);                  // sync, no UI
void request(Permission p, RequestCallback cb);       // async, exactly-once cb
bool has_platform_backend();                          // diagnostics

class PermissionsOverride { ... };                    // scope-guarded test hook
}
```

### Backends

- **Desktop / unsupported** — default backend in `core/platform/src/permissions.cpp`. Generic classes (mic, camera, BT MIDI, local network, notifications) resolve to `Granted` because desktop OSes don't gate these through an app-level prompt. Mobile-only classes (`BackgroundAudio`, `ForegroundService`) resolve to `Restricted` so callers don't pretend the capability works.
- **iOS / Android** — out of scope for this PR. These backends will define `PULP_PERMISSIONS_HAS_BACKEND` in their own TU to suppress the default and provide query/request/has_platform_backend. Wiring tracked in:
  - #332 — Android `ActivityResultContracts.RequestPermission` consumer of the existing `nativeOnPermissionResult` path.
  - #329 — iOS `AVAudioSession` / `AVCaptureDevice` / `UNUserNotificationCenter` / `CBCentralManager`.

### Override semantics

`PermissionsOverride` is a nested stack snapshot. Each constructor snapshots current entries; each destructor restores. Tests can nest (outer Denied → inner Granted → outer Denied after inner exits) without leaking state. Single-threaded on purpose — tests hold the guard on the test thread.

### Test plan

`test/test_permissions.cpp` — 10 cases, 29 assertions. All pass locally.

- [x] Every enum value yields a concrete state (no `NotDetermined` on desktop).
- [x] Desktop defaults: generic classes Granted, mobile-only Restricted.
- [x] `request()` fires callback exactly once; tolerates empty callback.
- [x] `PermissionsOverride` redirects query + request; un-overridden permissions pass through to the real backend.
- [x] `PermissionsOverride::clear` removes one entry without tearing down others.
- [x] Guard scope unwind.
- [x] Nested guards: outer restored after inner pops.
- [x] `has_platform_backend()` is truthful per compile-time flag.
- [ ] CI: macOS + Namespace Linux + Namespace Windows.

## Out of scope

- Android / iOS native query + request backends (#332, #329).
- Flipping existing subsystems (audio engine start, MIDI device open, foreground service start) to consume the new API — separate PRs once the platform backends land.

## Related

- #331 (this)
- #332 Android permission request flow
- #244 Android Oboe input frame read (RECORD_AUDIO gate)
- #86 Android MIDI over Bluetooth
- #329 iOS AVAudioSession native listener forwarding