### PR TITLE
view(ios): wire Skia paint + CADisplayLink for GPU window/plugin hosts (#330)

### DIFF
--- a/core/view/platform/ios/plugin_view_host_ios.mm
+++ b/core/view/platform/ios/plugin_view_host_ios.mm
@@ -7,6 +7,7 @@
 
 #include <pulp/canvas/cg_canvas.hpp>
 #import <UIKit/UIKit.h>
+#include <atomic>
 #include <unordered_map>
 
 // ── PulpPluginUIView: UIView subclass for DAW embedding on iOS ──────────────
@@ -220,6 +221,10 @@ private:
 #import <QuartzCore/CAMetalLayer.h>
 #import <Metal/Metal.h>
 
+class IOSGpuPluginViewHost;
+
+}  // namespace pulp::view
+
 // Metal-backed UIView for GPU rendering in AUv3 hosts
 @interface PulpMetalPluginView : UIView
 @end
@@ -229,6 +234,14 @@ private:
 - (CAMetalLayer *)metalLayer { return (CAMetalLayer *)self.layer; }
 @end
 
+// CADisplayLink target — relays the vsync tick to the C++ host.
+@interface PulpIOSPluginDisplayLinkTarget : NSObject
+@property (nonatomic, assign) pulp::view::IOSGpuPluginViewHost* host;
+- (void)tick:(CADisplayLink*)link;
+@end
+
+namespace pulp::view {
+
 class IOSGpuPluginViewHost : public PluginViewHost {
 public:
     IOSGpuPluginViewHost(View& root, const Options& opts)
@@ -237,6 +250,8 @@ public:
             CGRect frame = CGRectMake(0, 0, opts.size.width, opts.size.height);
             metal_view_ = [[PulpMetalPluginView alloc] initWithFrame:frame];
             metal_view_.multipleTouchEnabled = YES;
+            metal_view_.autoresizingMask =
+                UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
             CGFloat scale = UIScreen.mainScreen.scale;
             uint32_t pw = static_cast<uint32_t>(opts.size.width * scale);
@@ -273,20 +288,39 @@ public:
         }
     }
 
+    ~IOSGpuPluginViewHost() override {
+        stop_display_link();
+    }
+
     NativeViewHandle native_handle() override { return (__bridge void*)metal_view_; }
 
     void attach_to_parent(NativeViewHandle parent) override {
         @autoreleasepool {
             UIView* pv = (__bridge UIView*)parent;
-            if (pv && metal_view_) [pv addSubview:metal_view_];
+            if (pv && metal_view_) {
+                [pv addSubview:metal_view_];
+                start_display_link();
+                needs_repaint_.store(true, std::memory_order_relaxed);
+            }
         }
     }
 
     void detach() override {
-        @autoreleasepool { [metal_view_ removeFromSuperview]; }
+        @autoreleasepool {
+            stop_display_link();
+            [metal_view_ removeFromSuperview];
+        }
     }
 
-    void repaint() override { /* TODO: trigger render via CADisplayLink */ }
+    void repaint() override {
+        needs_repaint_.store(true, std::memory_order_relaxed);
+    }
+
+    void tick() {
+        if (needs_repaint_.exchange(false, std::memory_order_relaxed)) {
+            render_frame();
+        }
+    }
 
     void set_size(uint32_t w, uint32_t h) override {
         size_ = {w, h};
@@ -294,7 +328,13 @@ public:
             metal_view_.frame = CGRectMake(0, 0, w, h);
             CGFloat scale = UIScreen.mainScreen.scale;
             [metal_view_ metalLayer].drawableSize = CGSizeMake(w * scale, h * scale);
+            if (skia_surface_) {
+                skia_surface_->resize(static_cast<uint32_t>(w * scale),
+                                      static_cast<uint32_t>(h * scale),
+                                      static_cast<float>(scale));
+            }
         }
+        needs_repaint_.store(true, std::memory_order_relaxed);
     }
 
     Size get_size() const override { return size_; }
@@ -305,7 +345,65 @@ private:
     PulpMetalPluginView* metal_view_ = nil;
     std::unique_ptr<render::GpuSurface> gpu_surface_;
     std::unique_ptr<render::SkiaSurface> skia_surface_;
+    std::atomic<bool> needs_repaint_{false};
+    CADisplayLink* display_link_ = nil;
+    PulpIOSPluginDisplayLinkTarget* display_link_target_ = nil;
+
+    void start_display_link() {
+        if (display_link_) return;
+        @autoreleasepool {
+            display_link_target_ = [[PulpIOSPluginDisplayLinkTarget alloc] init];
+            display_link_target_.host = this;
+            display_link_ = [CADisplayLink displayLinkWithTarget:display_link_target_
+                                                        selector:@selector(tick:)];
+            [display_link_ addToRunLoop:[NSRunLoop mainRunLoop]
+                                forMode:NSRunLoopCommonModes];
+        }
+    }
+
+    void stop_display_link() {
+        @autoreleasepool {
+            if (display_link_) {
+                [display_link_ invalidate];
+                display_link_ = nil;
+            }
+            display_link_target_ = nil;
+        }
+    }
+
+    void render_frame() {
+        if (!gpu_surface_ || !skia_surface_) return;
+        if (!gpu_surface_->begin_frame()) return;
+
+        auto* cv = skia_surface_->begin_frame();
+        if (cv) {
+            root_.set_bounds({0, 0,
+                              static_cast<float>(size_.width),
+                              static_cast<float>(size_.height)});
+            root_.layout_children();
+            cv->set_fill_color(canvas::Color::rgba8(30, 30, 46));
+            cv->fill_rect(0, 0,
+                          static_cast<float>(size_.width),
+                          static_cast<float>(size_.height));
+            root_.paint_all(*cv);
+            View::paint_overlays(*cv);
+        }
+
+        skia_surface_->end_frame();
+        gpu_surface_->end_frame();
+    }
 };
+
+}  // namespace pulp::view
+
+@implementation PulpIOSPluginDisplayLinkTarget
+- (void)tick:(CADisplayLink*)link {
+    (void)link;
+    if (_host) _host->tick();
+}
+@end
+
+namespace pulp::view {
 
 #endif // PULP_HAS_SKIA
 

--- a/core/view/platform/ios/window_host_ios.mm
+++ b/core/view/platform/ios/window_host_ios.mm
@@ -7,6 +7,7 @@
 
 #include <pulp/canvas/cg_canvas.hpp>
 #import <UIKit/UIKit.h>
+#include <atomic>
 #include <unordered_map>
 
 // ── PulpRootView: UIView subclass that paints the View tree ─────────────────
@@ -291,6 +292,29 @@ private:
 #include <pulp/render/gpu_surface.hpp>
 #include <pulp/render/skia_surface.hpp>
 
+// Forward decl for the display-link bridge.
+class IOSGpuWindowHost;
+
+}  // namespace pulp::view
+
+// Metal-backed UIView — file-local class so we don't depend on the
+// private PulpMetalView in metal_surface_ios.mm.
+@interface PulpMetalWindowView : UIView
+@end
+
+@implementation PulpMetalWindowView
++ (Class)layerClass { return [CAMetalLayer class]; }
+- (CAMetalLayer *)metalLayer { return (CAMetalLayer *)self.layer; }
+@end
+
+// CADisplayLink target — relays the vsync tick to the C++ host.
+@interface PulpIOSDisplayLinkTarget : NSObject
+@property (nonatomic, assign) pulp::view::IOSGpuWindowHost* host;
+- (void)tick:(CADisplayLink*)link;
+@end
+
+namespace pulp::view {
+
 class IOSGpuWindowHost : public WindowHost {
 public:
     IOSGpuWindowHost(View& root, const WindowOptions& options)
@@ -299,6 +323,7 @@ public:
     }
 
     ~IOSGpuWindowHost() override {
+        stop_display_link();
         skia_surface_.reset();
         gpu_surface_.reset();
     }
@@ -309,7 +334,13 @@ public:
     render::GpuSurface* gpu_surface() const override { return gpu_surface_.get(); }
 
     void repaint() override {
-        needs_repaint_ = true;
+        needs_repaint_.store(true, std::memory_order_relaxed);
+    }
+
+    void tick() {
+        if (needs_repaint_.exchange(false, std::memory_order_relaxed)) {
+            render_frame();
+        }
     }
 
     void set_close_callback(std::function<void()> cb) override {
@@ -333,7 +364,7 @@ public:
             }
 
             // Create Metal-backed view
-            metal_view_ = [[PulpMetalView alloc] initWithFrame:window_.bounds];
+            metal_view_ = [[PulpMetalWindowView alloc] initWithFrame:window_.bounds];
             metal_view_.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
             metal_view_.multipleTouchEnabled = YES;
 
@@ -374,6 +405,9 @@ public:
             window_.rootViewController = vc;
             [window_ makeKeyAndVisible];
 
+            start_display_link();
+            needs_repaint_.store(true, std::memory_order_relaxed);
+
             runtime::log_info("iOS GPU: window host ready ({}x{} physical)", pw, ph);
         }
     }
@@ -381,29 +415,75 @@ public:
 private:
     View& root_;
     UIWindow* window_ = nil;
-    PulpMetalView* metal_view_ = nil;
+    PulpMetalWindowView* metal_view_ = nil;
     std::unique_ptr<render::GpuSurface> gpu_surface_;
     std::unique_ptr<render::SkiaSurface> skia_surface_;
     std::function<void()> close_callback_;
-    bool needs_repaint_ = false;
+    std::atomic<bool> needs_repaint_{false};
+    CADisplayLink* display_link_ = nil;
+    PulpIOSDisplayLinkTarget* display_link_target_ = nil;
+
+    void start_display_link() {
+        if (display_link_) return;
+        @autoreleasepool {
+            display_link_target_ = [[PulpIOSDisplayLinkTarget alloc] init];
+            display_link_target_.host = this;
+            display_link_ = [CADisplayLink displayLinkWithTarget:display_link_target_
+                                                        selector:@selector(tick:)];
+            [display_link_ addToRunLoop:[NSRunLoop mainRunLoop]
+                                forMode:NSRunLoopCommonModes];
+        }
+    }
+
+    void stop_display_link() {
+        @autoreleasepool {
+            if (display_link_) {
+                [display_link_ invalidate];
+                display_link_ = nil;
+            }
+            display_link_target_ = nil;
+        }
+    }
 
     void render_frame() {
         if (!gpu_surface_ || !skia_surface_) return;
         if (!gpu_surface_->begin_frame()) return;
 
-        auto* canvas = skia_surface_->begin_frame(gpu_surface_->current_texture_handle());
+        auto* canvas = skia_surface_->begin_frame();
         if (canvas) {
-            // Paint the view tree
             auto b = root_.bounds();
-            root_.set_bounds({0, 0, b.width, b.height});
+            // Keep bounds aligned with logical window size, not the
+            // pixel-scaled GPU surface. paint_all() handles content scale.
+            CGSize logical = window_.bounds.size;
+            root_.set_bounds({0, 0,
+                              static_cast<float>(logical.width),
+                              static_cast<float>(logical.height)});
             root_.layout_children();
-            // TODO: wrap SkCanvas in SkiaCanvas adapter and call root_.paint_all()
+
+            canvas->set_fill_color(canvas::Color::rgba8(30, 30, 46));
+            canvas->fill_rect(0, 0,
+                              static_cast<float>(logical.width),
+                              static_cast<float>(logical.height));
+            root_.paint_all(*canvas);
+            View::paint_overlays(*canvas);
+            (void)b;
         }
 
         skia_surface_->end_frame();
         gpu_surface_->end_frame();
     }
 };
+
+}  // namespace pulp::view
+
+@implementation PulpIOSDisplayLinkTarget
+- (void)tick:(CADisplayLink*)link {
+    (void)link;
+    if (_host) _host->tick();
+}
+@end
+
+namespace pulp::view {
 
 #endif // PULP_HAS_SKIA
 


### PR DESCRIPTION
Closes the two TODOs flagged by #330 in the iOS GPU host paths.

## What was broken

### window_host_ios.mm
- \`IOSGpuWindowHost::render_frame()\` called a stale \`SkiaSurface::begin_frame(texture_handle)\` signature (the API now takes no args).
- Never actually painted the tree (\`// TODO: wrap SkCanvas in SkiaCanvas adapter and call root_.paint_all()\`).
- Referenced an undefined \`PulpMetalView\` class (lives file-locally in \`metal_surface_ios.mm\`).

### plugin_view_host_ios.mm
- \`IOSGpuPluginViewHost::repaint()\` was a no-op (\`/* TODO: trigger render via CADisplayLink */\`).
- The host never called \`root_.paint_all()\` at all — Skia surface was initialized but the tree was never drawn.

## What this PR does

- Declares a file-local \`PulpMetalWindowView\` in \`window_host_ios.mm\` so it stops depending on the private \`PulpMetalView\` in \`metal_surface_ios.mm\`.
- Adds \`PulpIOSDisplayLinkTarget\` / \`PulpIOSPluginDisplayLinkTarget\` — small Obj-C shims that forward the vsync tick into each C++ host via a pointer property.
- Replaces the stale \`begin_frame(handle)\` call with the current \`SkiaSurface::begin_frame()\` API and runs the standard paint sequence (matching mac's \`paint_scene()\`):
  \`root_.set_bounds()\` → \`layout_children()\` → \`fill_rect(bg)\` → \`root_.paint_all(*canvas)\` → \`View::paint_overlays(*canvas)\`.
- Wires a \`CADisplayLink\` on both hosts driving \`render_frame()\` every vsync. Each host holds an \`std::atomic<bool> needs_repaint_\` that \`repaint()\` sets and the tick consumes — no re-rendering on idle frames.
- Plugin host: routes \`set_size()\` through \`SkiaSurface::resize()\` so DAW resize events take effect.
- \`@autoreleasepool\` guards the start/stop_display_link pair and invalidates the link in dtors (plus \`detach()\` on the plugin host) to avoid leaking the \`CADisplayLink\`.

## Test plan

- [x] \`clang -x objective-c++ -target arm64-apple-ios16.4-simulator\` compiles both edited files standalone (confirms no syntax/lookup errors under the iOS toolchain).
- [x] \`xcodebuild -target pulp-view -sdk iphonesimulator\` reaches \`window_host_ios.mm\` compile and produces \`window_host_ios.o\`.
- [ ] CI: macOS + Namespace Linux + Namespace Windows (non-iOS builds exercise the \`#ifdef PULP_HAS_SKIA\` gate closed; this PR touches iOS-only code paths so the non-iOS matrix should be no-op).

## Known non-issues (pre-existing; explicitly out of scope)

1. **\`choc/platform/choc_FileWatcher.h\` fails on iOS** (FSEventStreamRef unavailable) — the last known blocker for a full \`pulp-view\` iOS build, documented in \`.agents/skills/ios/SKILL.md\` § "Follow-ups / Known Gaps". Hit downstream of my files; not caused by this PR.

2. **\`wgpu-native\` has no iOS binaries shipped** — configuring with \`PULP_ENABLE_GPU=ON -DCMAKE_SYSTEM_NAME=iOS\` fails in \`FetchWgpuNativePrecompiled.cmake\` with *"Platform system 'iOS' not supported"*. Code is correct; runtime validation waits on that story. I'll file a follow-up issue for the wgpu-native iOS build.

## Related

- #330 (this — code-complete at the iOS GPU host paint + CADisplayLink layer)
- #249 iOS Metal on-device validation (gets one step closer after hot_reload + wgpu-native iOS blockers clear)
- #218 AUv3 & iOS mobile umbrella