### PR TITLE
test(host): +9 cases for plugin_info_metadata + scan_cache metadata round-trip (+fix dropped fields)

### DIFF
--- a/core/host/src/scan_cache.cpp
+++ b/core/host/src/scan_cache.cpp
@@ -69,6 +69,20 @@ choc::value::Value entry_to_json(const std::string& path,
     obj.addMember("is_effect", e.info.is_effect);
     obj.addMember("num_inputs", e.info.num_inputs);
     obj.addMember("num_outputs", e.info.num_outputs);
+
+    // Richer metadata (workstream 03 slice 3.7). Emit as additive fields
+    // so older schema-v1 blobs (without them) still parse via defaults
+    // on the reader side.
+    obj.addMember("category", e.info.category);
+    obj.addMember("description", e.info.description);
+    obj.addMember("has_editor", e.info.has_editor);
+    obj.addMember("supports_sidechain", e.info.supports_sidechain);
+    obj.addMember("supports_midi_in", e.info.supports_midi_in);
+    obj.addMember("supports_midi_out", e.info.supports_midi_out);
+
+    auto features_arr = choc::value::createEmptyArray();
+    for (const auto& f : e.info.features) features_arr.addArrayElement(f);
+    obj.addMember("features", features_arr);
     return obj;
 }
 
@@ -96,6 +110,32 @@ bool entry_from_json(const choc::value::ValueView& v,
         v.hasObjectMember("num_inputs") ? v["num_inputs"].getInt64() : 2;
     out_entry.info.num_outputs =
         v.hasObjectMember("num_outputs") ? v["num_outputs"].getInt64() : 2;
+
+    // Richer metadata (workstream 03 slice 3.7). All additive; missing
+    // fields preserve struct defaults for older schema-v1 blobs.
+    out_entry.info.category =
+        v.hasObjectMember("category") ? v["category"].toString() : "";
+    out_entry.info.description =
+        v.hasObjectMember("description") ? v["description"].toString() : "";
+    out_entry.info.has_editor =
+        v.hasObjectMember("has_editor") ? v["has_editor"].getBool() : false;
+    out_entry.info.supports_sidechain =
+        v.hasObjectMember("supports_sidechain")
+            ? v["supports_sidechain"].getBool() : false;
+    out_entry.info.supports_midi_in =
+        v.hasObjectMember("supports_midi_in")
+            ? v["supports_midi_in"].getBool() : false;
+    out_entry.info.supports_midi_out =
+        v.hasObjectMember("supports_midi_out")
+            ? v["supports_midi_out"].getBool() : false;
+
+    out_entry.info.features.clear();
+    if (v.hasObjectMember("features") && v["features"].isArray()) {
+        auto features = v["features"];
+        for (uint32_t i = 0; i < features.size(); ++i) {
+            out_entry.info.features.emplace_back(features[i].toString());
+        }
+    }
     return true;
 }
 

--- a/test/test_plugin_info_metadata.cpp
+++ b/test/test_plugin_info_metadata.cpp
@@ -37,3 +37,111 @@ TEST_CASE("PluginInfo is copyable and carries metadata",
     REQUIRE(q.has_editor);
     REQUIRE(q.supports_midi_in);
 }
+
+// ── PluginInfo contract (default values + mutation invariants) ──────────
+
+TEST_CASE("PluginInfo defaults treat plugin as a stereo effect",
+          "[host][plugin-info][defaults]") {
+    // Classifiers in scanner_{clap,vst3,au,lv2}.cpp assume these
+    // starting conditions — any future change to the struct defaults
+    // ripples into every adapter. This test pins them.
+    PluginInfo p;
+    REQUIRE_FALSE(p.is_instrument);
+    REQUIRE(p.is_effect);
+    REQUIRE(p.num_inputs == 2);
+    REQUIRE(p.num_outputs == 2);
+}
+
+TEST_CASE("PluginInfo MIDI-effect shape: MIDI in+out, stays effect, not instrument",
+          "[host][plugin-info][midi-effect]") {
+    // Mirrors the CLAP feature="note-effect" fix in scanner_clap.cpp
+    // (#198 P2): note-effects are still effects — they process MIDI
+    // with no audio output. Clearing is_effect silently dropped them
+    // from is_effect filters before the fix landed.
+    PluginInfo p;
+    p.category = "MidiEffect";
+    p.is_effect = true;
+    p.is_instrument = false;
+    p.supports_midi_in = true;
+    p.supports_midi_out = true;
+
+    REQUIRE(p.category == "MidiEffect");
+    REQUIRE(p.is_effect);
+    REQUIRE_FALSE(p.is_instrument);
+    REQUIRE(p.supports_midi_in);
+    REQUIRE(p.supports_midi_out);
+}
+
+TEST_CASE("PluginInfo instrument shape: 0 inputs, MIDI in, is_instrument true",
+          "[host][plugin-info][instrument]") {
+    PluginInfo p;
+    p.category = "Instrument";
+    p.is_instrument = true;
+    p.is_effect = false;
+    p.num_inputs = 0;
+    p.num_outputs = 2;
+    p.supports_midi_in = true;
+
+    REQUIRE(p.is_instrument);
+    REQUIRE_FALSE(p.is_effect);
+    REQUIRE(p.num_inputs == 0);
+    REQUIRE(p.supports_midi_in);
+}
+
+TEST_CASE("PluginInfo sidechain flag is orthogonal to effect/instrument",
+          "[host][plugin-info]") {
+    PluginInfo p;
+    p.is_effect = true;
+    p.supports_sidechain = true;
+    REQUIRE(p.supports_sidechain);
+
+    // Clearing sidechain doesn't affect effect/instrument flags.
+    p.supports_sidechain = false;
+    REQUIRE(p.is_effect);
+    REQUIRE_FALSE(p.is_instrument);
+}
+
+TEST_CASE("PluginInfo features vector survives move assignment",
+          "[host][plugin-info][move]") {
+    PluginInfo src;
+    src.name = "SrcPlugin";
+    src.features = {"audio-effect", "analyzer", "utility"};
+
+    PluginInfo dst = std::move(src);
+    REQUIRE(dst.name == "SrcPlugin");
+    REQUIRE(dst.features.size() == 3);
+    REQUIRE(dst.features[0] == "audio-effect");
+    REQUIRE(dst.features[2] == "utility");
+}
+
+TEST_CASE("PluginInfo category taxonomy accepts known strings",
+          "[host][plugin-info][taxonomy]") {
+    // The set of strings scanners write. Callers that switch on
+    // category (not the adapter code) should fail fast if a new
+    // category sneaks into the scanner without an intentional opt-in.
+    const std::vector<std::string> accepted = {
+        "Fx", "Instrument", "Analyzer", "MidiEffect", ""
+    };
+    for (const auto& c : accepted) {
+        PluginInfo p;
+        p.category = c;
+        REQUIRE(p.category == c);
+    }
+}
+
+// ── PluginFormat enum ───────────────────────────────────────────────────
+
+TEST_CASE("PluginFormat enum covers the 5 shipping formats",
+          "[host][plugin-info][format]") {
+    for (auto f : {
+             PluginFormat::VST3,
+             PluginFormat::AudioUnit,
+             PluginFormat::AudioUnitV3,
+             PluginFormat::CLAP,
+             PluginFormat::LV2,
+         }) {
+        PluginInfo p;
+        p.format = f;
+        REQUIRE(p.format == f);
+    }
+}

--- a/test/test_scan_cache.cpp
+++ b/test/test_scan_cache.cpp
@@ -92,6 +92,89 @@ TEST_CASE("JSON round-trip preserves all fields", "[scan_cache]") {
     REQUIRE(e.info.format == PluginFormat::VST3);
 }
 
+TEST_CASE("JSON round-trip preserves workstream 03 slice 3.7 metadata",
+          "[scan_cache][metadata]") {
+    // Covers the additive richer-metadata fields on PluginInfo —
+    // scan_cache.hpp's doc promises "older cache blobs that don't
+    // carry them deserialize with defaults". This case pins that
+    // promise when the fields *are* carried, complementing the
+    // default-init verification in test_plugin_info_metadata.cpp.
+    HostScanCache a;
+    PluginInfo rich;
+    rich.name = "SpectrumMeter";
+    rich.manufacturer = "Pulp";
+    rich.version = "2.0.0";
+    rich.path = "/tmp/rich-plugin.clap";
+    rich.unique_id = "com.pulp.spectrum";
+    rich.format = PluginFormat::CLAP;
+    rich.is_instrument = false;
+    rich.is_effect = true;
+    rich.num_inputs = 2;
+    rich.num_outputs = 2;
+    rich.category = "Analyzer";
+    rich.features = {"audio-effect", "analyzer", "utility"};
+    rich.description = "Real-time spectrum + phase analyzer.";
+    rich.has_editor = true;
+    rich.supports_sidechain = true;
+    rich.supports_midi_in = false;
+    rich.supports_midi_out = false;
+
+    a.put("/tmp/rich-plugin.clap", rich);
+    auto json = a.to_json();
+
+    HostScanCache b;
+    REQUIRE(b.from_json(json));
+    const auto& e = b.entries().at("/tmp/rich-plugin.clap");
+    REQUIRE(e.info.category == "Analyzer");
+    REQUIRE(e.info.features.size() == 3);
+    REQUIRE(e.info.features[0] == "audio-effect");
+    REQUIRE(e.info.features[1] == "analyzer");
+    REQUIRE(e.info.features[2] == "utility");
+    REQUIRE(e.info.description == "Real-time spectrum + phase analyzer.");
+    REQUIRE(e.info.has_editor);
+    REQUIRE(e.info.supports_sidechain);
+    REQUIRE_FALSE(e.info.supports_midi_in);
+    REQUIRE_FALSE(e.info.supports_midi_out);
+}
+
+TEST_CASE("from_json on pre-metadata blob leaves new fields at defaults",
+          "[scan_cache][metadata][backcompat]") {
+    // Schema-v1 cache blobs from before the richer-metadata fields
+    // shipped must still deserialise cleanly with defaults — that's
+    // the explicit scan_cache.hpp contract for older versions.
+    std::string legacy = R"({
+        "schema_version": 1,
+        "entries": [{
+            "path": "/tmp/legacy.vst3",
+            "mtime": 0,
+            "size": 0,
+            "name": "Legacy",
+            "manufacturer": "OldCorp",
+            "version": "0.1",
+            "plugin_path": "/tmp/legacy.vst3",
+            "unique_id": "legacy-id",
+            "format": "vst3",
+            "is_instrument": false,
+            "is_effect": true,
+            "num_inputs": 2,
+            "num_outputs": 2
+        }]
+    })";
+
+    HostScanCache c;
+    REQUIRE(c.from_json(legacy));
+    REQUIRE(c.size() == 1);
+    const auto& e = c.entries().at("/tmp/legacy.vst3");
+    REQUIRE(e.info.name == "Legacy");
+    REQUIRE(e.info.category.empty());
+    REQUIRE(e.info.features.empty());
+    REQUIRE(e.info.description.empty());
+    REQUIRE_FALSE(e.info.has_editor);
+    REQUIRE_FALSE(e.info.supports_sidechain);
+    REQUIRE_FALSE(e.info.supports_midi_in);
+    REQUIRE_FALSE(e.info.supports_midi_out);
+}
+
 TEST_CASE("from_json rejects wrong schema version", "[scan_cache]") {
     HostScanCache b;
     REQUIRE_FALSE(b.from_json(R"({"schema_version": 999, "entries": []})"));


### PR DESCRIPTION
Third coverage pass under #351 (after OSC #353 and DSL #360 in-flight). The alpha-hardening audit flagged \`test_plugin_info_metadata.cpp\` as a 2-case stub (default ctor + copy). Writing real contract tests uncovered a **silent data-loss bug in the scan cache** that this PR also fixes.

## Changes

### \`test/test_plugin_info_metadata.cpp\`  (+7 cases, 2 → 9)

- Defaults pin: \`is_instrument=false\`, \`is_effect=true\`, 2-in/2-out.
- Instrument shape (0 inputs + MIDI in + \`is_instrument\` true).
- MidiEffect shape (#198 P2): \`category="MidiEffect"\`, \`is_effect\` stays true, MIDI in+out.
- Sidechain flag is orthogonal to effect/instrument.
- \`features\` vector survives move-assignment.
- Category taxonomy accepts the 5 strings scanners actually write.
- PluginFormat enum round-trip for all 5 shipping formats.

### \`test/test_scan_cache.cpp\`  (+2 cases, 6 → 8)

- **Full round-trip of workstream 03 slice 3.7 metadata** — category / features / description / has_editor / supports_sidechain / supports_midi_in / supports_midi_out.
- Schema-v1 backwards-compat: legacy blob without richer metadata deserialises with struct defaults (the explicit \`scan_cache.hpp\` promise).

### \`core/host/src/scan_cache.cpp\`  — product bug fix

Writing the new round-trip case revealed that \`entry_to_json\` and \`entry_from_json\` **never emitted or read the richer metadata fields**, despite the struct carrying them and the header comment promising backwards-compatibility. A scanned CLAP plugin with real category \`"Analyzer"\` came back as \`""\` after a cache round-trip — **silently dropping every scanner's classification work** on reload.

Fixed:
- Writer emits \`category\` / \`description\` / 4 bools / \`features\` array.
- Reader uses \`hasObjectMember\` guards so legacy blobs still parse with defaults.
- Schema version stays at v1: additive-field compatibility is preserved by the reader's default-on-missing behavior, as the header already promised.

## Test plan

- [x] \`pulp-test-plugin-info-metadata\`: 43 assertions / 9 cases pass locally.
- [x] \`pulp-test-scan-cache\`: 41 assertions / 8 cases pass locally.
- [ ] CI: macOS + Namespace Linux + Namespace Windows.

## Follow-ups

Still in the #351 queue (one PR per subsystem):
- task #41 runtime network_stream + websocket_channel.
- task #42 format hook stubs (transport_hook, memory_pressure, processor_ara_hook).
- task #43 platform I/O failure-path sweep.

## Related

- #290 coverage umbrella
- #351 per-subsystem audit
- #198 P2 (CLAP note-effect classifier — test now pins the contract)