### PR TITLE
test(runtime): +12 cases for network_stream + websocket_channel

### DIFF
--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -113,3 +113,120 @@ TEST_CASE("HttpStream write is Invalid (read-only)", "[network_stream]") {
     REQUIRE_FALSE(w.ok());
     REQUIRE(w.error == StreamError::Invalid);
 }
+
+// ── TcpStream edge cases ────────────────────────────────────────────────
+
+TEST_CASE("TcpStream read on unconnected stream returns Closed",
+          "[network_stream][tcp][edge]") {
+    TcpStream stream;
+    REQUIRE_FALSE(stream.is_open());
+    std::uint8_t buf[4]{};
+    auto r = stream.read(buf, sizeof(buf));
+    REQUIRE_FALSE(r.ok());
+    // Stream contract: reading an unopened stream is Closed (EOF-equivalent)
+    // or Invalid (state error) — both are non-ok.
+    REQUIRE((r.closed() || r.error == StreamError::Invalid));
+}
+
+TEST_CASE("TcpStream write on unconnected stream is non-ok",
+          "[network_stream][tcp][edge]") {
+    TcpStream stream;
+    const std::uint8_t payload[] = {'x'};
+    auto w = stream.write(payload, sizeof(payload));
+    REQUIRE_FALSE(w.ok());
+}
+
+TEST_CASE("TcpStream connect to unreachable host:port fails fast",
+          "[network_stream][tcp][edge]") {
+    TcpStream stream;
+    // Port 1 on loopback is never bound in a default environment;
+    // the kernel returns ECONNREFUSED synchronously from connect().
+    REQUIRE_FALSE(stream.connect("127.0.0.1", 1));
+    REQUIRE_FALSE(stream.is_open());
+}
+
+TEST_CASE("TcpStream double-close is safe and idempotent",
+          "[network_stream][tcp][edge]") {
+    TcpStream stream;
+    stream.close();        // close on never-opened stream
+    stream.close();        // and again — must not crash/UB
+    REQUIRE_FALSE(stream.is_open());
+}
+
+TEST_CASE("TcpStream detects peer-close on the next read",
+          "[network_stream][tcp][peer-close]") {
+    Socket server;
+    REQUIRE(server.create(SocketType::TCP));
+
+    std::uint16_t port = 0;
+    for (std::uint16_t candidate = 45501; candidate < 45580; ++candidate) {
+        if (auto bound = try_bind_loopback(server, candidate)) {
+            port = *bound;
+            break;
+        }
+    }
+    if (port == 0) {
+        SUCCEED("could not bind loopback; skipping");
+        return;
+    }
+
+    std::atomic<bool> server_ready{false};
+    std::thread server_thread([&] {
+        server_ready.store(true);
+        auto client = server.accept();
+        if (!client) return;
+        client->close();  // immediate peer-close
+    });
+    while (!server_ready.load()) std::this_thread::sleep_for(1ms);
+
+    TcpStream stream;
+    REQUIRE(stream.connect("127.0.0.1", port));
+
+    // Read until the peer-close is observed. The first read may return
+    // WouldBlock on some platforms before the FIN propagates.
+    std::uint8_t buf[8]{};
+    bool saw_close = false;
+    auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto r = stream.read(buf, sizeof(buf));
+        if (r.closed()) { saw_close = true; break; }
+        if (r.ok() && r.bytes == 0) { saw_close = true; break; }
+        std::this_thread::sleep_for(5ms);
+    }
+    REQUIRE(saw_close);
+
+    stream.close();
+    server_thread.join();
+}
+
+// ── HttpStream edge cases ───────────────────────────────────────────────
+
+TEST_CASE("HttpStream with empty URL reports transport failure",
+          "[network_stream][http][edge]") {
+    HttpStream::Request req;
+    req.url = "";
+    req.timeout_seconds = 1;
+    HttpStream stream(req);
+
+    std::uint8_t buf[4]{};
+    auto r = stream.read(buf, sizeof(buf));
+    REQUIRE_FALSE(r.ok());
+}
+
+TEST_CASE("HttpStream with unsupported scheme reports transport failure",
+          "[network_stream][http][edge]") {
+    HttpStream::Request req;
+    req.url = "ftp://127.0.0.1/nope";
+    req.timeout_seconds = 1;
+    HttpStream stream(req);
+
+    std::uint8_t buf[4]{};
+    auto r = stream.read(buf, sizeof(buf));
+    REQUIRE_FALSE(r.ok());
+}
+
+TEST_CASE("HttpStream status_code is 0 before fetch",
+          "[network_stream][http][state]") {
+    HttpStream stream;
+    REQUIRE(stream.status_code() == 0);
+}

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -163,3 +163,142 @@ TEST_CASE("WebSocketChannel rejects handshake without upgrade header", "[websock
     client.close();
     server_thread.join();
 }
+
+// ── WebSocketChannel additional coverage ────────────────────────────────
+
+TEST_CASE("WebSocket accept_key rejects empty input gracefully",
+          "[websocket][handshake]") {
+    // A malformed/empty client key must not crash compute_accept_key.
+    // The RFC says the key must be 16 bytes base64-encoded (24 chars);
+    // we just require no UB + a deterministic non-empty output (or
+    // empty, depending on the implementation).
+    auto result = WebSocketChannel::compute_accept_key("");
+    // Whatever the implementation returns, it must be deterministic.
+    REQUIRE(result == WebSocketChannel::compute_accept_key(""));
+}
+
+TEST_CASE("WebSocketChannel connect fails gracefully on non-WS peer",
+          "[websocket][handshake]") {
+    // A peer that accepts the TCP connection but never sends a valid
+    // 101 Switching Protocols response must cause WebSocketChannel::connect
+    // to return nullptr — not crash, not hang beyond a reasonable limit.
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = bind_loopback(listener, 47001);
+    if (!port) { SUCCEED("could not bind loopback; skipping"); return; }
+
+    std::atomic<bool> ready{false};
+    std::thread server_thread([&] {
+        ready.store(true);
+        auto accepted = listener.accept();
+        // Reply with plain-text rubbish — not a valid HTTP response.
+        if (accepted) {
+            const char junk[] = "HELLO NOT WEBSOCKET\r\n\r\n";
+            accepted->send(reinterpret_cast<const std::uint8_t*>(junk),
+                           std::strlen(junk));
+            accepted->close();
+        }
+    });
+    while (!ready.load()) std::this_thread::sleep_for(1ms);
+
+    auto tcp = std::make_unique<TcpStream>();
+    REQUIRE(tcp->connect("127.0.0.1", *port));
+    auto ws = WebSocketChannel::connect(std::move(tcp), "127.0.0.1", "/");
+    REQUIRE(ws == nullptr);
+
+    server_thread.join();
+}
+
+TEST_CASE("WebSocketChannel close flips is_open to false",
+          "[websocket][lifecycle]") {
+    // Validate the close → is_open() transition via a real echo server
+    // so we exercise the same handshake the echo test does; this is
+    // additional assurance that close() doesn't just no-op.
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = bind_loopback(listener, 47101);
+    if (!port) { SUCCEED("could not bind loopback; skipping"); return; }
+
+    std::atomic<bool> ready{false};
+    std::unique_ptr<WebSocketChannel> server_ws;
+    std::thread server_thread([&] {
+        ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+        auto server_tcp = std::make_unique<TcpStream>(std::move(*accepted));
+        server_ws = WebSocketChannel::accept(std::move(server_tcp));
+    });
+    while (!ready.load()) std::this_thread::sleep_for(1ms);
+
+    auto client_tcp = std::make_unique<TcpStream>();
+    REQUIRE(client_tcp->connect("127.0.0.1", *port));
+    auto client = WebSocketChannel::connect(std::move(client_tcp), "127.0.0.1", "/");
+    REQUIRE(client != nullptr);
+    REQUIRE(client->is_open());
+
+    client->close();
+    REQUIRE_FALSE(client->is_open());
+
+    // Double-close is safe.
+    client->close();
+    REQUIRE_FALSE(client->is_open());
+
+    if (server_ws) server_ws->close();
+    server_thread.join();
+}
+
+TEST_CASE("WebSocketChannel echoes a >126-byte message (16-bit payload length)",
+          "[websocket][frame-length]") {
+    // Payload length 126 crosses the boundary where WS frames switch
+    // from 7-bit to 16-bit encoding (RFC 6455 §5.2). This case exercises
+    // that branch end-to-end.
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+    auto port = bind_loopback(listener, 47201);
+    if (!port) { SUCCEED("could not bind loopback; skipping"); return; }
+
+    std::atomic<bool> ready{false};
+    std::unique_ptr<WebSocketChannel> server_ws;
+    std::thread server_thread([&] {
+        ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+        auto server_tcp = std::make_unique<TcpStream>(std::move(*accepted));
+        server_ws = WebSocketChannel::accept(std::move(server_tcp));
+        if (server_ws) {
+            server_ws->on_message([&](const Message& m) {
+                server_ws->send_text(std::string(m.as_text()));
+            });
+        }
+    });
+    while (!ready.load()) std::this_thread::sleep_for(1ms);
+
+    auto client_tcp = std::make_unique<TcpStream>();
+    REQUIRE(client_tcp->connect("127.0.0.1", *port));
+    auto client = WebSocketChannel::connect(std::move(client_tcp), "127.0.0.1", "/");
+    REQUIRE(client != nullptr);
+
+    std::mutex mu;
+    std::vector<std::string> seen;
+    client->on_message([&](const Message& m) {
+        std::lock_guard<std::mutex> lock(mu);
+        seen.emplace_back(m.as_text());
+    });
+
+    std::string big(300, 'A');  // > 126 bytes → 16-bit payload length field
+    REQUIRE(client->send_text(big));
+
+    REQUIRE(wait_until([&] {
+        std::lock_guard<std::mutex> lock(mu);
+        return !seen.empty();
+    }));
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        REQUIRE(seen[0].size() == 300);
+        REQUIRE(seen[0] == big);
+    }
+
+    client->close();
+    if (server_ws) server_ws->close();
+    server_thread.join();
+}


### PR DESCRIPTION
Fourth coverage pass under #351 (after OSC #353, DSL #360, host #361 in-flight). The alpha-hardening audit flagged \`test_network_stream.cpp\` (3 cases) and \`test_websocket_channel.cpp\` (3 cases) as thin stubs for streams that underpin RTP-MIDI, remote-view, JSON-RPC, and the MessageChannel abstraction.

## Changes

### \`test/test_network_stream.cpp\`  (+8 cases, 3 → 11)

- TcpStream read on unconnected stream → Closed/Invalid.
- TcpStream write on unconnected stream → non-ok.
- TcpStream \`connect("127.0.0.1", 1)\` (unreachable port) fails fast.
- TcpStream double-close is safe and idempotent.
- TcpStream peer-close observed on next read via loopback server that accept()s then immediately close()s.
- HttpStream empty URL → transport failure.
- HttpStream unsupported scheme (\`ftp://\`) → transport failure.
- HttpStream \`status_code() == 0\` before fetch.

### \`test/test_websocket_channel.cpp\`  (+4 cases, 3 → 7)

- \`compute_accept_key("")\` tolerates empty input (deterministic output, no UB).
- \`connect\` fails gracefully when a peer sends plain-text junk instead of 101 Switching Protocols.
- \`close()\` flips \`is_open()\` to false; double-close is idempotent.
- Echo round-trip of a 300-byte payload — exercises the 7 → 16-bit payload-length transition at ≥126 bytes (RFC 6455 §5.2).

## Test plan

- [x] \`pulp-test-network-stream\`: 24 assertions / 11 cases pass locally.
- [x] \`pulp-test-websocket-channel\`: 33 assertions / 7 cases pass locally.
- [ ] CI: macOS + Namespace Linux + Namespace Windows.

## Follow-ups

Still queued under #351:
- task #42 format hook stubs (transport_hook, memory_pressure, processor_ara_hook).
- task #43 platform I/O failure-path sweep.
- task #44 view triage.

## Related

- #290 coverage umbrella
- #351 per-subsystem audit