### PR TITLE
test(format): +11 cases for transport/memory/ARA hook stubs

### DIFF
--- a/test/test_memory_pressure.cpp
+++ b/test/test_memory_pressure.cpp
@@ -53,3 +53,49 @@ TEST_CASE("plugin receives pressure levels and can drop caches",
     REQUIRE(p.critical_calls == 1);
     REQUIRE(p.cache_size == 0);     // critical: drop
 }
+
+TEST_CASE("repeated advisory pressure never drops the working set",
+          "[processor][memory][advisory]") {
+    // iOS / Android memory-pressure contract: advisory is a
+    // suggestion for the plugin to release soft caches on its own
+    // schedule. Hammering it must not cumulatively force a critical
+    // drop — only a real Critical does.
+    CacheDroppingProcessor p;
+    for (int i = 0; i < 20; ++i) {
+        p.on_memory_pressure(Processor::MemoryPressure::Advisory);
+    }
+    REQUIRE(p.advisory_calls == 20);
+    REQUIRE(p.critical_calls == 0);
+    REQUIRE(p.cache_size == 1024);
+}
+
+TEST_CASE("critical-then-advisory sequence lets the plugin re-warm caches",
+          "[processor][memory][recovery]") {
+    // After a drop, the OS may come back with Advisory as memory
+    // pressure eases. The hook needs to convey that so a plugin can
+    // safely re-warm caches without the next Advisory clobbering them.
+    CacheDroppingProcessor p;
+    p.on_memory_pressure(Processor::MemoryPressure::Critical);
+    REQUIRE(p.cache_size == 0);
+
+    // Re-warm via an imaginary post-pressure path.
+    p.cache_size = 2048;
+
+    p.on_memory_pressure(Processor::MemoryPressure::Advisory);
+    REQUIRE(p.advisory_calls == 1);
+    REQUIRE(p.cache_size == 2048);   // advisory does not drop
+}
+
+TEST_CASE("memory pressure hook tolerates unknown enum values",
+          "[processor][memory][unknown]") {
+    // Simulate the OS surfacing a pressure level Pulp doesn't yet
+    // model. Plugins with a switch should fall through rather than
+    // crash — verify the hook dispatch itself doesn't explode and
+    // neither counter ticks.
+    CacheDroppingProcessor p;
+    auto unknown = static_cast<Processor::MemoryPressure>(99);
+    p.on_memory_pressure(unknown);
+    REQUIRE(p.advisory_calls == 0);
+    REQUIRE(p.critical_calls == 0);
+    REQUIRE(p.cache_size == 1024);
+}

--- a/test/test_processor_ara_hook.cpp
+++ b/test/test_processor_ara_hook.cpp
@@ -53,3 +53,67 @@ TEST_CASE("ARA-aware processor returns a working controller",
     REQUIRE(c->is_ara_supported());
     REQUIRE(c->ara_factory_name() == "MyAraFactory");
 }
+
+TEST_CASE("default AraDocumentController reports no ARA support and empty factory",
+          "[ara][processor-hook][defaults]") {
+    // The base AraDocumentController is what adapters see when a
+    // plugin doesn't override the hook — these defaults are what
+    // is_ara_supported-based gating reads. Pin them.
+    AraDocumentController base;
+    REQUIRE_FALSE(base.is_ara_supported());
+    REQUIRE(base.ara_factory_name().empty());
+    REQUIRE(base.supported_roles() == 0);
+    // Default begin/end editing + audio-source-notify are no-ops.
+    base.begin_editing();
+    base.end_editing();
+    base.notify_audio_source_content_changed(42);
+    SUCCEED("default AraDocumentController virtuals complete without UB");
+}
+
+TEST_CASE("repeated create_ara_document_controller calls yield distinct owned instances",
+          "[ara][processor-hook][ownership]") {
+    // ARA host contract: the controller is owned per-instance; creating
+    // one shouldn't alias a cached singleton. Catches a plausible
+    // future regression where a plugin caches the controller and
+    // returns the same pointer on every call.
+    AraProcessor p;
+    auto a = p.create_ara_document_controller();
+    auto b = p.create_ara_document_controller();
+    REQUIRE(a != nullptr);
+    REQUIRE(b != nullptr);
+    REQUIRE(a.get() != b.get());
+}
+
+TEST_CASE("Processor override that returns nullptr opts out of ARA",
+          "[ara][processor-hook][opt-out]") {
+    // A Processor may opt out of ARA at runtime (e.g. based on license
+    // state or host support). Returning nullptr from the hook must be
+    // reflected verbatim — adapters use nullptr to decide not to
+    // advertise ARA to the host.
+    class OptOutProcessor : public PlainProcessor {
+    public:
+        std::unique_ptr<AraDocumentController>
+        create_ara_document_controller() override {
+            return nullptr;
+        }
+    };
+    OptOutProcessor p;
+    REQUIRE(p.create_ara_document_controller() == nullptr);
+}
+
+TEST_CASE("AraRole enum encodes role bitmask as expected by hosts",
+          "[ara][roles]") {
+    // The ARA 2.x ABI uses AraRole as a bitmask. Adapter code ORs
+    // these values together; verify the numeric layout matches what
+    // an ARA SDK consumer would expect so a future refactor doesn't
+    // silently re-number them.
+    REQUIRE(static_cast<int>(AraRole::None) == 0);
+    REQUIRE(static_cast<int>(AraRole::PlaybackRenderer) == 1);
+    REQUIRE(static_cast<int>(AraRole::EditorRenderer) == 2);
+    REQUIRE(static_cast<int>(AraRole::EditorView) == 4);
+
+    int mask = static_cast<int>(AraRole::PlaybackRenderer)
+             | static_cast<int>(AraRole::EditorRenderer)
+             | static_cast<int>(AraRole::EditorView);
+    REQUIRE(mask == 7);
+}

--- a/test/test_transport_hook.cpp
+++ b/test/test_transport_hook.cpp
@@ -5,6 +5,8 @@
 #include <pulp/audio/buffer.hpp>
 #include <pulp/midi/buffer.hpp>
 
+#include <stdexcept>
+
 using namespace pulp::format;
 
 namespace {
@@ -58,4 +60,66 @@ TEST_CASE("overriding plugin receives play/stop + locate events",
     p.on_host_transport_changed(false, 10.5);  // stop
     REQUIRE(p.calls == 3);
     REQUIRE_FALSE(p.last_playing);
+}
+
+TEST_CASE("repeated locates within a single play span each land",
+          "[processor][transport][rapid]") {
+    // DAWs emit locate events as the user scrubs. Nothing in the hook
+    // contract debounces or coalesces — every change should reach the
+    // plugin so it can re-cue internal state.
+    TransportAwareProcessor p;
+    p.on_host_transport_changed(true, 0.0);
+    p.on_host_transport_changed(true, 1.0);
+    p.on_host_transport_changed(true, 5.0);
+    p.on_host_transport_changed(true, 5.5);
+    p.on_host_transport_changed(true, 12.25);
+    REQUIRE(p.calls == 5);
+    REQUIRE(p.last_playing);
+    REQUIRE(p.last_pos == 12.25);
+}
+
+TEST_CASE("on_host_transport_changed tolerates extreme and exotic positions",
+          "[processor][transport][edge]") {
+    TransportAwareProcessor p;
+
+    // DAW-style looping can produce negative positions (pre-roll),
+    // very-large positions (hours of session), and sub-sample
+    // fractions. The hook is specified as a plain double — plugins
+    // must get the exact value without saturation or truncation.
+    p.on_host_transport_changed(true, -1.5);
+    REQUIRE(p.last_pos == -1.5);
+    p.on_host_transport_changed(true, 1.0e12);
+    REQUIRE(p.last_pos == 1.0e12);
+    p.on_host_transport_changed(true, 1.0 / 3.0);
+    REQUIRE(p.last_pos == 1.0 / 3.0);
+    REQUIRE(p.calls == 3);
+}
+
+TEST_CASE("transport hook doesn't swallow play→stop→play transition",
+          "[processor][transport][state]") {
+    TransportAwareProcessor p;
+    p.on_host_transport_changed(true, 0.0);
+    p.on_host_transport_changed(false, 4.0);
+    REQUIRE_FALSE(p.last_playing);
+    p.on_host_transport_changed(true, 4.0);   // resume at stop point
+    REQUIRE(p.last_playing);
+    REQUIRE(p.last_pos == 4.0);
+    REQUIRE(p.calls == 3);
+}
+
+TEST_CASE("exception thrown by transport hook propagates to the caller",
+          "[processor][transport][exception]") {
+    // Contract: Pulp's base Processor declares the hook as a plain
+    // virtual, not noexcept. Callers (format adapters) must be
+    // prepared for implementations to throw. This case pins that
+    // behaviour so future changes (e.g. adding noexcept) become
+    // intentional.
+    class ThrowingProcessor : public PlainProcessor {
+    public:
+        void on_host_transport_changed(bool, double) override {
+            throw std::runtime_error("transport hook exploded");
+        }
+    };
+    ThrowingProcessor p;
+    REQUIRE_THROWS_AS(p.on_host_transport_changed(true, 0.0), std::runtime_error);
 }


### PR DESCRIPTION
Fifth coverage pass under #351 (after OSC #353 merged, DSL #360 + host #361 + runtime #362 in-flight). Three format-adapter hook tests were flagged by the alpha-hardening audit as 2-case stubs, each exercising only the default no-op + a single override. This expands each with contract-level edges + at least one behaviour change the adapter code actually relies on.

## Changes

### \`test/test_transport_hook.cpp\`  (+4 cases, 2 → 6)

- Repeated locates within a single play span each reach the plugin (DAWs emit locates as the user scrubs — the hook must not coalesce).
- Extreme and exotic positions (negative pre-roll, 1e12, 1/3) pass without saturation.
- Play → stop → play transition does not lose state.
- Exceptions from the hook propagate — pins the contract so a future \`noexcept\` change becomes intentional.

### \`test/test_memory_pressure.cpp\`  (+3 cases, 2 → 5)

- Repeated Advisory never drops the working set (iOS/Android contract: only Critical is mandatory drop).
- Critical → re-warm → Advisory lets the plugin rebuild caches without the next Advisory clobbering them.
- Out-of-range enum values don't crash the hook dispatch.

### \`test/test_processor_ara_hook.cpp\`  (+4 cases, 2 → 6)

- Default \`AraDocumentController\` pinned (\`is_ara_supported=false\`, empty factory_name, 0 roles, no-op lifecycle virtuals).
- Repeated \`create_ara_document_controller\` returns distinct owned instances — catches a future cached-singleton regression.
- Opt-out override returning \`nullptr\` is respected verbatim (adapter gate behaviour).
- \`AraRole\` enum bitmask values + combinations pinned to match the ARA 2.x ABI layout adapter code ORs together.

## Test plan

- [x] \`pulp-test-transport-hook\`: 20 assertions / 6 cases pass locally.
- [x] \`pulp-test-memory-pressure\`: 15 assertions / 5 cases pass locally.
- [x] \`pulp-test-processor-ara-hook\`: 17 assertions / 6 cases pass locally.
- [ ] CI: macOS + Namespace Linux + Namespace Windows.

## Follow-ups

Still queued under #351:
- task #43 platform I/O failure-path sweep.
- task #44 view triage.
- task #45 events expansion.
- task #46 ship CLI signing/notarize tests.
- task #47 tools/cli shell-out tests.

## Related

- #290 coverage umbrella
- #351 per-subsystem audit