### PR TITLE
test(platform): I/O failure-path sweep (+10 cases)

### DIFF
--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -78,6 +78,35 @@ TEST_CASE("find_on_path finds known binary", "[child_process]") {
     REQUIRE(p.has_value());
 }
 
+TEST_CASE("find_on_path returns nullopt for missing binary",
+          "[child_process][edge]") {
+    auto p = find_on_path("pulp-does-not-exist-xyz-12345");
+    REQUIRE_FALSE(p.has_value());
+}
+
+TEST_CASE("exec with a binary that does not exist reports failure",
+          "[child_process][edge]") {
+    auto r = exec("pulp-also-does-not-exist-xyz", {}, 1000);
+    // Implementations report this as non-zero exit + empty stdout;
+    // must not time out and must not claim success.
+    REQUIRE(r.exit_code != 0);
+    REQUIRE_FALSE(r.timed_out);
+}
+
+TEST_CASE("exec captures empty-stdout cleanly", "[child_process][edge]") {
+#ifdef _WIN32
+    auto r = exec("cmd", {"/c", "rem nothing"}, 5000);
+#else
+    auto r = exec("/bin/sh", {"-c", ":"}, 5000);  // ':' = no-op builtin
+#endif
+    REQUIRE(r.exit_code == 0);
+    // Accept zero-length or whitespace-only output; the key invariant
+    // is that the capture path doesn't crash on a zero-byte read.
+    for (char c : r.stdout_output) {
+        REQUIRE((c == ' ' || c == '\t' || c == '\r' || c == '\n'));
+    }
+}
+
 TEST_CASE("find_on_path returns nullopt for nonexistent", "[child_process]") {
     auto p = find_on_path("this_binary_definitely_does_not_exist_xyz123");
     REQUIRE_FALSE(p.has_value());

--- a/test/test_clipboard.cpp
+++ b/test/test_clipboard.cpp
@@ -1,6 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/platform/clipboard.hpp>
 
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
 using namespace pulp::platform;
 
 // #300 — tests no longer assume every platform has a real clipboard.
@@ -59,6 +63,40 @@ TEST_CASE("Clipboard binary data — mac/win supported, others explicit unsuppor
 TEST_CASE("Clipboard missing data returns nullopt", "[platform][clipboard]") {
     auto result = Clipboard::get_data("com.pulp.nonexistent.type");
     REQUIRE_FALSE(result.has_value());
+}
+
+TEST_CASE("Clipboard empty-string text is honest — round-trip or unsupported",
+          "[platform][clipboard][edge]") {
+    // An explicit empty string is a legitimate value. The set call
+    // must either (a) accept it and round-trip an empty string, or
+    // (b) return false on a platform that doesn't support clipboard
+    // at all. It must not fake-succeed and round-trip our prior
+    // non-empty payload.
+    const bool ok = Clipboard::set_text("");
+    if (!ok) return;
+    auto text = Clipboard::get_text();
+    REQUIRE(text.has_value());
+    REQUIRE(text.value().empty());
+}
+
+TEST_CASE("Clipboard large binary payload round-trips byte-for-byte",
+          "[platform][clipboard][edge]") {
+    // 128 KiB of deterministic bytes exercises the scatter/copy path.
+    // Skip if binary clipboard is unsupported on this platform (Linux
+    // / Android return false — the round-trip test already pins that).
+    std::vector<uint8_t> big(128 * 1024);
+    for (std::size_t i = 0; i < big.size(); ++i) {
+        big[i] = static_cast<uint8_t>((i * 31) ^ 0xA5);
+    }
+    const bool ok = Clipboard::set_data("com.pulp.bigblob", big);
+    if (!ok) {
+        SUCCEED("binary clipboard unsupported on this platform");
+        return;
+    }
+    auto got = Clipboard::get_data("com.pulp.bigblob");
+    REQUIRE(got.has_value());
+    REQUIRE(got->size() == big.size());
+    REQUIRE(std::equal(got->begin(), got->end(), big.begin()));
 }
 
 // #300: Android-bridge registration API is public on every platform

--- a/test/test_progress_parser.cpp
+++ b/test/test_progress_parser.cpp
@@ -56,6 +56,44 @@ TEST_CASE("ProgressParser handles multiple events", "[progress_parser]") {
     REQUIRE(events[2].payload == "5:Network timeout");
 }
 
+TEST_CASE("ProgressParser rejects malformed prefix variants", "[progress_parser][edge]") {
+    // Prefixes that look like PROGRESS but aren't: must not emit events.
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });
+
+    parser.feed_line("PROGRESSsomething");      // no colon separator
+    parser.feed_line("progress:type");          // lowercase, not the sentinel
+    parser.feed_line(" PROGRESS:type");         // leading whitespace
+    parser.feed_line("PROGRES:type");           // typo
+    REQUIRE(events.empty());
+}
+
+TEST_CASE("ProgressParser handles lone PROGRESS: prefix with empty type", "[progress_parser][edge]") {
+    // The implementation parses PROGRESS:<type>[:<payload>]. "PROGRESS:"
+    // alone means a zero-length type — either drop or emit with "".
+    // Accept both; just make sure we don't crash or spray events.
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });
+
+    parser.feed_line("PROGRESS:");
+    REQUIRE(events.size() <= 1);
+    if (events.size() == 1) {
+        REQUIRE(events[0].type.empty());
+        REQUIRE(events[0].payload.empty());
+    }
+}
+
+TEST_CASE("ProgressParser drops whitespace-only and empty-string inputs", "[progress_parser][edge]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });
+
+    parser.feed_line("");
+    parser.feed_line(" ");
+    parser.feed_line("\t");
+    parser.feed_line("   \t   ");
+    REQUIRE(events.empty());
+}
+
 TEST_CASE("ProgressParser works with ChildProcess line callback", "[progress_parser]") {
     std::vector<ProgressEvent> events;
     ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });


### PR DESCRIPTION
Sixth coverage pass under #351 (after OSC #353 and DSL #360 merged; host #361 + runtime #362 + format #363 in CI). The alpha-hardening audit ranked \`platform\` highest-risk-with-low-coverage by src-to-test ratio (19 src / 5 test files).

## Changes

### \`test/test_progress_parser.cpp\`  (+3 cases, 5 → 8)

- Malformed prefix variants reject cleanly: \`PROGRESSsomething\`, lowercase \`progress:\`, leading whitespace, typo \`PROGRES:\`.
- Lone \`PROGRESS:\` with empty type — accept emit-or-drop but never crash; assert shape when emitted.
- Whitespace-only / empty strings drop silently.

### \`test/test_clipboard.cpp\`  (+2 cases, 6 → 8)

- Empty-string set/get round-trips honestly (no stale fake-success from a prior test's payload).
- 128 KiB binary payload round-trips byte-for-byte on platforms that accept binary clipboard; skips cleanly elsewhere.

### \`test/test_child_process.cpp\`  (+3 cases, 9 → 12)

- \`find_on_path\` returns nullopt for a guaranteed-missing binary.
- \`exec\` on a missing binary reports failure (non-zero exit, not \`timed_out\`, not silent-success).
- \`exec\` captures empty-stdout cleanly (zero-byte read path).

## Test plan

- [x] \`pulp-test-clipboard\`: 21 assertions / 8 cases pass locally.
- [x] \`pulp-test-progress-parser\`: 24 assertions / 8 cases pass locally.
- [x] \`pulp-test-child-process\`: 21 assertions / 12 cases pass locally.
- [x] \`pulp-test-file-dialog\`: 2 cases (unchanged).
- [ ] CI: macOS + Namespace Linux + Namespace Windows.

## Follow-ups

Still queued under #351 / #290:
- task #44 view triage (diffuse surface, defer).
- task #45 events (EventLoop/Timer/AsyncUpdater/ChildProcessManager/VolumeDetector).
- task #46 ship CLI signing/notarize/appcast tests.
- task #47 tools/cli shell-out tests.

## Related

- #290 coverage umbrella
- #351 per-subsystem audit