### PR TITLE
test(cli): +7 shell-out cases for the pulp binary (#47 / #290)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,15 @@ target_include_directories(pulp-test-cli-create-targets PRIVATE ${CMAKE_SOURCE_D
 target_link_libraries(pulp-test-cli-create-targets PRIVATE Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-cli-create-targets)
 
+# CLI shell-out behaviour tests — launches the built `pulp` binary.
+# Depends on pulp-cli so the binary exists at test time.
+add_executable(pulp-test-cli-shellout test_cli_shellout.cpp)
+target_link_libraries(pulp-test-cli-shellout PRIVATE pulp::platform Catch2::Catch2WithMain)
+if(TARGET pulp-cli)
+    add_dependencies(pulp-test-cli-shellout pulp-cli)
+endif()
+catch_discover_tests(pulp-test-cli-shellout)
+
 # Child process tests
 add_executable(pulp-test-child-process test_child_process.cpp)
 target_link_libraries(pulp-test-child-process PRIVATE pulp::platform Catch2::Catch2WithMain)

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -1,0 +1,157 @@
+// Shell-out CLI behaviour tests for `pulp`.
+//
+// Per CLAUDE.md: "CLI behavior changes — shell out to the built binary,
+// assert exit code + stderr content." Before this file, the CLI had
+// two targeted unit tests (test_cli_create_targets, test_cli_design_binding)
+// but no end-to-end shell-out validation — the lesson from #295 was
+// that silent-failure bugs slip through when no test actually launches
+// the binary. This closes that gap with deterministic exit-code +
+// stdout/stderr invariants for the non-destructive subcommands every
+// user hits on day one.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/child_process.hpp>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+using namespace pulp::platform;
+namespace fs = std::filesystem;
+
+namespace {
+
+// The pulp CLI binary lands at <build>/tools/cli/pulp once `pulp-cli`
+// has been built. The test runner's working directory at invocation
+// time is <build>/test, so "../tools/cli/pulp" is the relative path.
+// Fall back to a PULP_CLI_PATH env override for adversarial CI setups.
+fs::path pulp_binary() {
+    if (const char* env = std::getenv("PULP_CLI_PATH"); env && *env) {
+        return fs::path(env);
+    }
+    return fs::current_path() / ".." / "tools" / "cli" / "pulp";
+}
+
+ProcessResult run_pulp(const std::vector<std::string>& args,
+                       int timeout_ms = 10000) {
+    auto bin = pulp_binary();
+    if (!fs::exists(bin)) {
+        // Binary not built for this target — rather than fail noisily,
+        // surface a SKIP at the call site. Tests check for .ok() first.
+        ProcessResult r;
+        r.exit_code = -1;
+        r.stderr_output = "pulp binary not at " + bin.string();
+        return r;
+    }
+    return exec(bin.string(), args, timeout_ms);
+}
+
+bool binary_exists() { return fs::exists(pulp_binary()); }
+
+}  // namespace
+
+TEST_CASE("pulp help exits 0 with a usage banner on stdout",
+          "[cli][shellout]") {
+    if (!binary_exists()) {
+        SUCCEED("pulp binary not built for this test run; skipping");
+        return;
+    }
+    auto r = run_pulp({"help"});
+    REQUIRE(r.exit_code == 0);
+    REQUIRE_FALSE(r.timed_out);
+    // Must advertise the word "pulp" and list the build subcommand so
+    // first-time users aren't dropped into an empty help output — this
+    // is the category of regression that the #295 silent-failure
+    // lesson warned about.
+    REQUIRE(r.stdout_output.find("pulp") != std::string::npos);
+    REQUIRE(r.stdout_output.find("build") != std::string::npos);
+}
+
+TEST_CASE("pulp --help is an alias for pulp help",
+          "[cli][shellout]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto a = run_pulp({"help"});
+    auto b = run_pulp({"--help"});
+    auto c = run_pulp({"-h"});
+    // Every alias exits 0 and reaches the same top-level usage.
+    REQUIRE(a.exit_code == 0);
+    REQUIRE(b.exit_code == 0);
+    REQUIRE(c.exit_code == 0);
+    REQUIRE(a.stdout_output.find("pulp") != std::string::npos);
+    REQUIRE(b.stdout_output.find("pulp") != std::string::npos);
+    REQUIRE(c.stdout_output.find("pulp") != std::string::npos);
+}
+
+TEST_CASE("pulp with no arguments prints help and exits 0",
+          "[cli][shellout]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto r = run_pulp({});
+    // Bare `pulp` is expected to show usage rather than error out — it
+    // mustn't fake-succeed silently or hang.
+    REQUIRE(r.exit_code == 0);
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE((r.stdout_output.find("pulp") != std::string::npos ||
+             r.stdout_output.find("Usage") != std::string::npos ||
+             r.stdout_output.find("Commands") != std::string::npos));
+}
+
+TEST_CASE("pulp <unknown-command> exits non-zero with a diagnostic",
+          "[cli][shellout]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto r = run_pulp({"thisisnotarealcommand"});
+    REQUIRE(r.exit_code != 0);
+    REQUIRE_FALSE(r.timed_out);
+    // At least one of stdout/stderr must reference the unknown command
+    // or a help pointer — otherwise the user is left guessing.
+    auto combined = r.stdout_output + r.stderr_output;
+    bool mentioned =
+        combined.find("Unknown") != std::string::npos ||
+        combined.find("unknown") != std::string::npos ||
+        combined.find("help") != std::string::npos;
+    REQUIRE(mentioned);
+}
+
+TEST_CASE("pulp version subcommand runs and mentions the SDK",
+          "[cli][shellout][version]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto r = run_pulp({"version"});
+    // `pulp version` prints SDK/plugin version info and exits 0. Guard
+    // against a regression where the subcommand silently exits with
+    // success but an empty body (the exact shape of bug #295 for the
+    // ship command).
+    REQUIRE(r.exit_code == 0);
+    REQUIRE_FALSE(r.timed_out);
+    // Must have SOMETHING on stdout — stderr alone is not enough.
+    REQUIRE_FALSE(r.stdout_output.empty());
+}
+
+TEST_CASE("pulp version check exits 0 on a clean tree and mentions SDK/plugin/marketplace",
+          "[cli][shellout][version]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto r = run_pulp({"version", "check"});
+    REQUIRE_FALSE(r.timed_out);
+    // The check may exit non-zero if version files have drifted. Both
+    // exit-code branches must include the three surfaces so the user
+    // can act on the diagnostic.
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE((combined.find("sdk") != std::string::npos ||
+             combined.find("SDK") != std::string::npos ||
+             combined.find("CMakeLists.txt") != std::string::npos));
+}
+
+TEST_CASE("pulp help output lists the top-level subcommands",
+          "[cli][shellout][help]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto r = run_pulp({"help"});
+    REQUIRE(r.exit_code == 0);
+
+    // Every subcommand that's visible to users in the ci skill / docs
+    // needs to survive help output — if someone silently drops one
+    // from the dispatch table, this fails loudly.
+    for (const char* cmd : {"build", "test", "run", "validate", "ship",
+                            "version", "doctor", "create", "clean",
+                            "docs", "status"}) {
+        INFO("help output missing subcommand: " << cmd);
+        REQUIRE(r.stdout_output.find(cmd) != std::string::npos);
+    }
+}


### PR DESCRIPTION
Eighth coverage pass under #290. The CLI had 23 source files but only two targeted unit tests (\`create_targets\`, \`design_binding\`) — no end-to-end shell-out against the built binary. Per CLAUDE.md's explicit rule:

> "CLI behavior changes — shell out to the built binary, assert exit code + stderr content. Catches silent-failure bugs like #295 where \`--sign-key\` wrote empty signatures without error."

This closes that gap with deterministic exit-code + stdout/stderr invariants for the non-destructive subcommands every user hits on day one.

## Cases (7)

- \`pulp help\` exits 0, stdout lists \`pulp\` + \`build\`.
- \`pulp --help\` / \`-h\` are aliases (all exit 0).
- \`pulp\` with no args prints help and exits 0 — no silent hang.
- \`pulp <unknown>\` exits non-zero and surfaces the unknown command or points at help.
- \`pulp version\` exits 0 with non-empty stdout (regression guard for the #295 empty-output class of bug).
- \`pulp version check\` completes and mentions SDK/CMakeLists.txt on either exit branch.
- \`pulp help\` enumerates the documented top-level subcommands (build/test/run/validate/ship/version/doctor/create/clean/docs/status) — silent drops from the dispatch table fail loudly.

## Wiring

\`test/CMakeLists.txt\` gets a new \`pulp-test-cli-shellout\` executable linked against \`pulp::platform\` for \`exec()\`. Takes a hard dep on \`pulp-cli\` when available so the binary exists at test-run time, and honours a \`PULP_CLI_PATH\` env override for adversarial CI setups. Each test checks \`binary_exists()\` first and \`SUCCEED\`s cleanly when \`pulp-cli\` hasn't been built — avoids flaking the broader ctest suite in minimal-build configurations.

## Test plan

- [x] \`pulp-test-cli-shellout\`: 33 assertions / 7 cases pass locally with \`pulp-cli\` built.
- [x] Without \`pulp-cli\` built: 7 cases pass as SUCCEEDed-skips.
- [ ] CI: macOS + Namespace Linux + Namespace Windows.

## Related

- #290 coverage umbrella
- #295 silent-empty-signature bug (the lesson this closes for the CLI lane)