### PR TITLE
test(cli-ship): +7 shell-out cases for pulp ship (#46 / #290)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,15 @@ if(TARGET pulp-cli)
 endif()
 catch_discover_tests(pulp-test-cli-shellout)
 
+# CLI ship shell-out behaviour tests — launches the built `pulp` binary
+# for the non-destructive ship subcommand branches.
+add_executable(pulp-test-cli-ship-shellout test_cli_ship_shellout.cpp)
+target_link_libraries(pulp-test-cli-ship-shellout PRIVATE pulp::platform Catch2::Catch2WithMain)
+if(TARGET pulp-cli)
+    add_dependencies(pulp-test-cli-ship-shellout pulp-cli)
+endif()
+catch_discover_tests(pulp-test-cli-ship-shellout)
+
 # Child process tests
 add_executable(pulp-test-child-process test_child_process.cpp)
 target_link_libraries(pulp-test-child-process PRIVATE pulp::platform Catch2::Catch2WithMain)

--- a/test/test_cli_ship_shellout.cpp
+++ b/test/test_cli_ship_shellout.cpp
@@ -1,0 +1,128 @@
+// Shell-out CLI behaviour tests for `pulp ship`.
+//
+// Per CLAUDE.md the #295 lesson (silent empty Ed25519 signature) came
+// from the CLI ship path never being exercised end-to-end. This file
+// shells to the built binary for the non-destructive ship branches
+// that are safe to run in CI without real signing material.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/child_process.hpp>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+using namespace pulp::platform;
+namespace fs = std::filesystem;
+
+namespace {
+
+fs::path pulp_binary() {
+    if (const char* env = std::getenv("PULP_CLI_PATH"); env && *env) {
+        return fs::path(env);
+    }
+    return fs::current_path() / ".." / "tools" / "cli" / "pulp";
+}
+
+bool binary_exists() { return fs::exists(pulp_binary()); }
+
+ProcessResult run_pulp_in(const fs::path& cwd,
+                          const std::vector<std::string>& args,
+                          int timeout_ms = 10000) {
+    auto bin = pulp_binary();
+    ProcessOptions opts;
+    opts.timeout_ms = timeout_ms;
+    opts.working_directory = cwd.string();
+    return ChildProcess::run(bin.string(), args, opts);
+}
+
+bool contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+}  // namespace
+
+TEST_CASE("pulp ship outside a project directory errors out",
+          "[cli][shellout][ship]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto r = run_pulp_in(fs::temp_directory_path(), {"ship"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+    auto combined = r.stdout_output + r.stderr_output;
+    // The handler early-exits with "not in a Pulp project directory"
+    // — that wording is the contract hosts/users rely on.
+    REQUIRE(contains(combined, "Pulp project"));
+}
+
+TEST_CASE("pulp ship sign outside a project directory errors cleanly",
+          "[cli][shellout][ship]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto r = run_pulp_in(fs::temp_directory_path(),
+                         {"ship", "sign", "--identity", "fake-id"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+    // Must not fake-succeed: before #295 was closed, similar silent
+    // paths let bad CLI args write empty artifacts.
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(contains(combined, "Pulp project"));
+}
+
+TEST_CASE("pulp ship appcast outside a project errors cleanly",
+          "[cli][shellout][ship]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto r = run_pulp_in(fs::temp_directory_path(),
+                         {"ship", "appcast"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+}
+
+TEST_CASE("pulp ship notarize outside a project errors cleanly",
+          "[cli][shellout][ship]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto r = run_pulp_in(fs::temp_directory_path(), {"ship", "notarize"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+}
+
+TEST_CASE("pulp ship check outside a project errors cleanly",
+          "[cli][shellout][ship]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto r = run_pulp_in(fs::temp_directory_path(), {"ship", "check"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+}
+
+TEST_CASE("pulp ship package outside a project errors cleanly",
+          "[cli][shellout][ship]") {
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto r = run_pulp_in(fs::temp_directory_path(),
+                         {"ship", "package", "--version", "1.0.0"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+}
+
+TEST_CASE("pulp ship help (or default) enumerates every subcommand",
+          "[cli][shellout][ship][help]") {
+    // Run from the build tree — find_project_root() walks up to the
+    // worktree root, and build/CMakeCache.txt exists since the test
+    // harness itself was built. That puts us in the fallthrough help
+    // branch regardless of whether we pass "help" or bogus args.
+    if (!binary_exists()) { SUCCEED("pulp binary not built"); return; }
+    auto r = run_pulp_in(fs::current_path(), {"ship"});
+    REQUIRE_FALSE(r.timed_out);
+
+    // If the current-path walk doesn't find the project (some CI
+    // layouts drop tests outside the tree), we accept the non-zero
+    // branch provided the stderr mentions the project — that's the
+    // same invariant the other cases assert.
+    auto combined = r.stdout_output + r.stderr_output;
+    if (r.exit_code == 0) {
+        // Help branch reached — every shipping subcommand must be listed.
+        for (const char* sub : {"sign", "notarize", "package", "appcast", "check"}) {
+            INFO("ship help missing subcommand: " << sub);
+            REQUIRE(contains(r.stdout_output, sub));
+        }
+    } else {
+        REQUIRE(contains(combined, "Pulp project"));
+    }
+}


### PR DESCRIPTION
Ninth coverage pass under #290. CLAUDE.md explicitly cites **#295** (silent empty Ed25519 signature) as the motivating lesson for shell-out tests on CLI behaviour — but the \`ship\` path itself had **no shell-out coverage**. PR #367 handles top-level CLI; this PR handles \`pulp ship\` specifically, which is where #295 lived.

## Changes — 7 cases

Runs from \`/tmp\` to force the outside-project guard:
- \`pulp ship\` → exit 1, "Pulp project" diagnostic.
- \`pulp ship sign --identity fake\` → exit non-zero (does not fake-succeed — exactly the #295 class of bug).
- \`pulp ship appcast\` (missing required --url) → non-zero.
- \`pulp ship notarize\` → non-zero.
- \`pulp ship check\` → non-zero.
- \`pulp ship package --version 1.0.0\` → non-zero.

Runs from the built project cwd:
- \`pulp ship\` (default → help branch) enumerates all 5 subcommands (sign / notarize / package / appcast / check). The case accepts either exit branch — if \`find_project_root\` walked outside the tree, it still requires the "Pulp project" diagnostic, matching the invariant of the other cases.

## Wiring

Same pattern as #367: new \`pulp-test-cli-ship-shellout\` executable depends on \`pulp-cli\` when available; honours \`PULP_CLI_PATH\` override; every case \`binary_exists()\`-checks first so minimal-build configs don't flake.

## Test plan

- [x] \`pulp-test-cli-ship-shellout\`: 20 assertions / 7 cases pass locally.
- [ ] CI: macOS + Namespace Linux + Namespace Windows.

## Related

- #290 coverage umbrella
- #295 the silent-signature bug this closes for the ship lane