### PR TITLE
test(tempo-hook): +6 cases — edge BPM, rapid changes, exception safety (#357)

### DIFF
--- a/test/test_tempo_hook.cpp
+++ b/test/test_tempo_hook.cpp
@@ -5,6 +5,10 @@
 #include <pulp/audio/buffer.hpp>
 #include <pulp/midi/buffer.hpp>
 
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
 using namespace pulp::format;
 
 namespace {
@@ -50,4 +54,86 @@ TEST_CASE("overriding plugin receives tempo updates",
     p.on_host_tempo_changed(174.0);
     REQUIRE(p.calls == 2);
     REQUIRE(p.last_bpm == 174.0);
+}
+
+// ── Edge BPM values ─────────────────────────────────────────────────────
+
+TEST_CASE("tempo hook tolerates zero and negative BPM values",
+          "[processor][tempo][edge]") {
+    // DAW buffer glitches can briefly surface 0.0 or negative BPM while
+    // the transport is switching modes. The hook contract is "receive
+    // the value verbatim" — plugins guard their own state; the hook
+    // must not saturate or clamp.
+    TempoAwareProcessor p;
+    p.on_host_tempo_changed(0.0);
+    REQUIRE(p.last_bpm == 0.0);
+    p.on_host_tempo_changed(-10.0);
+    REQUIRE(p.last_bpm == -10.0);
+    REQUIRE(p.calls == 2);
+}
+
+TEST_CASE("tempo hook preserves extreme BPM values without loss",
+          "[processor][tempo][edge]") {
+    TempoAwareProcessor p;
+    // Absurd lows and highs cover the usual "off-the-chart" fuzz cases.
+    p.on_host_tempo_changed(0.1);
+    REQUIRE(p.last_bpm == 0.1);
+    p.on_host_tempo_changed(9999.0);
+    REQUIRE(p.last_bpm == 9999.0);
+    p.on_host_tempo_changed(std::numeric_limits<double>::max());
+    REQUIRE(p.last_bpm == std::numeric_limits<double>::max());
+}
+
+TEST_CASE("tempo hook tolerates subnormal fractions without rounding",
+          "[processor][tempo][edge]") {
+    TempoAwareProcessor p;
+    // MIDI clock / tap-tempo paths can produce arbitrary fractions.
+    p.on_host_tempo_changed(120.3333333333);
+    REQUIRE(p.last_bpm == 120.3333333333);
+    p.on_host_tempo_changed(1.0 / 3.0);
+    REQUIRE(p.last_bpm == 1.0 / 3.0);
+}
+
+// ── Rapid / same-block changes ──────────────────────────────────────────
+
+TEST_CASE("rapid tempo changes within a single audio block each land",
+          "[processor][tempo][rapid]") {
+    // Automation lanes can emit many tempo updates within one buffer
+    // when the tempo curve is dense. Every change must reach the
+    // plugin — Pulp does not coalesce tempo events.
+    TempoAwareProcessor p;
+    const double values[] = {120.0, 120.5, 121.0, 121.5, 122.0, 122.5, 123.0};
+    for (double v : values) p.on_host_tempo_changed(v);
+    REQUIRE(p.calls == static_cast<int>(sizeof(values) / sizeof(values[0])));
+    REQUIRE(p.last_bpm == 123.0);
+}
+
+TEST_CASE("identical tempo re-notifications still fire the hook",
+          "[processor][tempo][idempotence]") {
+    // The hook contract doesn't promise de-duplication — some hosts
+    // re-notify on every process block regardless of change. A plugin
+    // that debounces internally depends on seeing every call.
+    TempoAwareProcessor p;
+    p.on_host_tempo_changed(120.0);
+    p.on_host_tempo_changed(120.0);
+    p.on_host_tempo_changed(120.0);
+    REQUIRE(p.calls == 3);
+    REQUIRE(p.last_bpm == 120.0);
+}
+
+// ── Exception safety ───────────────────────────────────────────────────
+
+TEST_CASE("exception thrown by tempo hook propagates to the caller",
+          "[processor][tempo][exception]") {
+    // Pins the current contract: the base declaration is a plain
+    // virtual, not noexcept. Future noexcept changes must be
+    // intentional — this test fails loudly if the hook is silenced.
+    class ThrowingProcessor : public PlainProcessor {
+    public:
+        void on_host_tempo_changed(double) override {
+            throw std::runtime_error("tempo hook blew up");
+        }
+    };
+    ThrowingProcessor p;
+    REQUIRE_THROWS_AS(p.on_host_tempo_changed(120.0), std::runtime_error);
 }


### PR DESCRIPTION
Tenth coverage pass under #290. \`test_tempo_hook.cpp\` was a 2-case stub per the #357 classification — same shape as \`test_transport_hook\` before PR #363.

## Changes — +6 cases (2 → 8)

- **Zero and negative BPM**: hook must not clamp or saturate; DAW buffer-glitch transients reach the plugin verbatim.
- **Extreme BPM**: 0.1 to \`std::numeric_limits<double>::max()\` preserved.
- **Subnormal fractions** (1/3, 120.3333…) preserved — MIDI clock and tap-tempo generate these.
- **Rapid changes within a single block**: every value reaches the plugin; the hook does NOT coalesce (matches the transport_hook contract).
- **Identical re-notifications** all fire — pin the no-debounce contract some hosts depend on.
- **Exception propagation**: current hook is plain virtual (not noexcept); future noexcept changes must be intentional.

## Test plan

- [x] \`pulp-test-tempo-hook\`: 18 assertions / 8 cases pass locally.
- [ ] CI: macOS + Namespace Linux + Namespace Windows.

## Related

- #290 coverage umbrella
- #357 placeholder-smell sweep (test_tempo_hook row)
- PR #363 transport_hook (sibling PR with matching rapid-change contract)