### PR TITLE
test: delete placeholder test_showcase + test_token_diff (#357)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -999,11 +999,6 @@ target_include_directories(pulp-test-web-demos PRIVATE
 )
 catch_discover_tests(pulp-test-web-demos)
 
-# AI Designer: token diff tests
-add_executable(pulp-test-token-diff test_token_diff.cpp)
-target_link_libraries(pulp-test-token-diff PRIVATE pulp::view Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-token-diff)
-
 # AI Designer: design tool layout/parity tests
 add_executable(pulp-test-design-tool-layout test_design_tool_layout.cpp)
 target_link_libraries(pulp-test-design-tool-layout PRIVATE pulp::view pulp::state Catch2::Catch2WithMain)
@@ -1014,13 +1009,13 @@ add_executable(pulp-test-style-pack test_style_pack.cpp)
 target_link_libraries(pulp-test-style-pack PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-style-pack)
 
-# AI Designer: showcase tests
-add_executable(pulp-test-showcase test_showcase.cpp)
-target_link_libraries(pulp-test-showcase PRIVATE pulp::view Catch2::Catch2WithMain)
-target_include_directories(pulp-test-showcase PRIVATE
-    ${CMAKE_SOURCE_DIR}/tools/design
-)
-catch_discover_tests(pulp-test-showcase)
+# Removed: pulp-test-token-diff (test_token_diff.cpp) and pulp-test-showcase
+# (test_showcase.cpp) were placeholder TEST_CASE("...") { REQUIRE(true); }
+# stubs for design-tool C++ classes that never shipped. The design tool
+# landed as JS via core/view/js/web-compat* and widget_bridge's
+# applyTokenDiff JS binding; there is no C++ surface to verify here.
+# Removed in PR #290/#357 follow-up; file a new focused test if a C++
+# token-diff or Showcase class is ever added.
 
 # WindowManager multi-window framework tests (Phase 6)
 add_executable(pulp-test-window-manager test_window_manager.cpp)

--- a/test/test_showcase.cpp
+++ b/test/test_showcase.cpp
@@ -1,6 +1,0 @@
-// Placeholder for showcase tests — will be populated when design tool merges
-#include <catch2/catch_test_macros.hpp>
-
-TEST_CASE("Showcase placeholder", "[design]") {
-    REQUIRE(true);
-}

--- a/test/test_token_diff.cpp
+++ b/test/test_token_diff.cpp
@@ -1,2 +1,0 @@
-#include <catch2/catch_test_macros.hpp>
-TEST_CASE("Placeholder test_token_diff", "[placeholder]") { REQUIRE(true); }


### PR DESCRIPTION
#357 classification flagged both files as literal placeholders — each a single-line \`TEST_CASE("…") { REQUIRE(true); }\` pending C++ design-tool + token-diff classes that **were never added**. The design tool shipped as JS under \`core/view/js/web-compat*\` and widget_bridge's \`applyTokenDiff\` JS binding; there is no C++ surface to verify here.

Leaving placeholder tests in the build is actively harmful: they advertise coverage that does not exist and were flagged as the #295 class of silent-success risk by the alpha-hardening audit.

## Changes

- Removed \`test/test_showcase.cpp\`.
- Removed \`test/test_token_diff.cpp\`.
- Dropped the \`pulp-test-showcase\` + \`pulp-test-token-diff\` executables from \`test/CMakeLists.txt\` (the sibling AI Designer tests for \`design_tool_layout\` and \`style_pack\` stay — they have real coverage).
- Left a short rationale comment at the removal site so the motivation survives.

If a C++ \`Showcase\` or \`TokenDiff\` class is ever added, file a new focused test against its public API.

## Test plan

- [x] CMake configure/build still work with these targets removed.
- [ ] CI: macOS + Namespace Linux + Namespace Windows.

## Related

- #290 coverage umbrella
- #357 placeholder-smell sweep (closes the "placeholder" rows for both files)