### PR TITLE
ios: forward AVAudioSession notifications to native listener (#329)

### DIFF
--- a/apple/Sources/PulpSwift/PulpAudioSession.swift
+++ b/apple/Sources/PulpSwift/PulpAudioSession.swift
@@ -170,17 +170,26 @@ public final class PulpAudioSession: ObservableObject {
         case .began:
             state.isInterrupted = true
             onInterruptionBegan?()
+            emitNative(event: PULP_IOS_AUDIO_EVENT_INTERRUPTION_BEGAN, options: 0, reason: 0)
 
         case .ended:
             state.isInterrupted = false
             let shouldResume: Bool
+            var optionsBitfield: Int32 = 0
             if let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt {
                 let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
                 shouldResume = options.contains(.shouldResume)
+                if shouldResume {
+                    optionsBitfield |= Int32(PULP_IOS_INTERRUPTION_OPTION_SHOULD_RESUME.rawValue)
+                }
             } else {
                 shouldResume = false
             }
             onInterruptionEnded?(shouldResume)
+            emitNative(
+                event: PULP_IOS_AUDIO_EVENT_INTERRUPTION_ENDED,
+                options: optionsBitfield,
+                reason: 0)
 
         @unknown default:
             break
@@ -196,6 +205,10 @@ public final class PulpAudioSession: ObservableObject {
 
         refreshState()
         onRouteChanged?(reason)
+        emitNative(
+            event: PULP_IOS_AUDIO_EVENT_ROUTE_CHANGED,
+            options: 0,
+            reason: Self.mapRouteChangeReason(reason))
     }
 
     private func handleMediaServicesReset() {
@@ -204,6 +217,55 @@ public final class PulpAudioSession: ObservableObject {
         state.isActive = false
         state.isInterrupted = false
         refreshState()
+        emitNative(event: PULP_IOS_AUDIO_EVENT_MEDIA_SERVICES_RESET, options: 0, reason: 0)
+    }
+
+    // MARK: - Native C ABI forwarding
+
+    /// Build a PulpIosAudioSessionEvent from the current session state and
+    /// deliver it to the C ABI listener registered via
+    /// pulp_ios_audio_session_set_callback. No-op when no listener is
+    /// attached — pulp_ios_audio_session_emit handles that internally.
+    private func emitNative(event: PulpIosAudioEvent,
+                            options: Int32,
+                            reason: Int32) {
+        var payload = PulpIosAudioSessionEvent(
+            event: event,
+            reason: reason,
+            options: options,
+            sample_rate: session.sampleRate,
+            io_buffer_duration_seconds: session.ioBufferDuration,
+            output_channels: Int32(session.outputNumberOfChannels),
+            input_channels: Int32(session.inputNumberOfChannels))
+        pulp_ios_audio_session_emit(&payload)
+    }
+
+    /// Map AVAudioSession.RouteChangeReason → PulpIosRouteChangeReason so
+    /// native listeners can branch on the same taxonomy without linking
+    /// AVFoundation.
+    private static func mapRouteChangeReason(
+        _ reason: AVAudioSession.RouteChangeReason
+    ) -> Int32 {
+        switch reason {
+        case .unknown:
+            return Int32(PULP_IOS_ROUTE_CHANGE_UNKNOWN.rawValue)
+        case .newDeviceAvailable:
+            return Int32(PULP_IOS_ROUTE_CHANGE_NEW_DEVICE_AVAILABLE.rawValue)
+        case .oldDeviceUnavailable:
+            return Int32(PULP_IOS_ROUTE_CHANGE_OLD_DEVICE_UNAVAILABLE.rawValue)
+        case .categoryChange:
+            return Int32(PULP_IOS_ROUTE_CHANGE_CATEGORY_CHANGE.rawValue)
+        case .override:
+            return Int32(PULP_IOS_ROUTE_CHANGE_OVERRIDE.rawValue)
+        case .wakeFromSleep:
+            return Int32(PULP_IOS_ROUTE_CHANGE_WAKE_FROM_SLEEP.rawValue)
+        case .noSuitableRouteForCategory:
+            return Int32(PULP_IOS_ROUTE_CHANGE_NO_SUITABLE_ROUTE.rawValue)
+        case .routeConfigurationChange:
+            return Int32(PULP_IOS_ROUTE_CHANGE_CONFIGURATION_CHANGE.rawValue)
+        @unknown default:
+            return Int32(PULP_IOS_ROUTE_CHANGE_UNKNOWN.rawValue)
+        }
     }
 }
 

--- a/apple/Sources/PulpSwift/PulpBridge.h
+++ b/apple/Sources/PulpSwift/PulpBridge.h
@@ -7,6 +7,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// Pull in the iOS AVAudioSession C ABI so Swift (PulpAudioSession.swift)
+// can call pulp_ios_audio_session_emit() directly through this umbrella
+// header. Underlying declarations live with the format module so C++
+// consumers keep a clean <pulp/format/ios_audio_session.h> include path.
+#include <pulp/format/ios_audio_session.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Closes #329 — the 2026-04-17 parity audit flagged this as a pure bridging gap. \`PulpAudioSession.swift\` was observing interruption, route-change, and media-services-reset notifications, updating Swift state + firing the Swift closures (\`onInterruptionBegan\` / \`onInterruptionEnded\` / \`onRouteChanged\`), but never calling the C ABI emitter. Native processors, plugin hosts, and platform code subscribed via \`pulp_ios_audio_session_set_callback\` never saw any events.

## Changes

- \`PulpBridge.h\` pulls in \`<pulp/format/ios_audio_session.h>\` so the C ABI is reachable from Swift through the same umbrella header that already carries the \`pulp_param_*\` bindings.
- \`PulpAudioSession.swift\` now calls \`pulp_ios_audio_session_emit()\` from:
  - \`handleInterruption\` (began + ended, with \`shouldResume\` forwarded as \`PULP_IOS_INTERRUPTION_OPTION_SHOULD_RESUME\`)
  - \`handleRouteChange\` (with \`AVAudioSession.RouteChangeReason\` → \`PulpIosRouteChangeReason\` mapping so native consumers don't link AVFoundation)
  - \`handleMediaServicesReset\`
- Every emit builds the payload from the current session: sample_rate, io_buffer_duration, input/output channel counts. The native listener sees the same snapshot Swift just refreshed.

## Test plan

- [x] swiftc typecheck-clean against iphonesimulator26.2 SDK / arm64 iOS 16.4+ target; no new warnings (existing \`allowBluetooth\` deprecation is pre-existing and untouched).
- [x] C-side behaviour already covered by \`test_ios_audio_session\` (emit/listen contract) — nothing new needed for the bridge.
- [ ] Full iOS runtime end-to-end verification runs under #249 on-device validation and the AUv3 example (#218).

## Related

- #329 (this)
- #330 iOS GPU render loop (merged in #358)
- #331 unified permissions API (merged in #354)
- #218 AUv3 & iOS umbrella
- #249 iOS on-device validation