### PR TITLE
docs: refresh support matrix + capabilities after v0.17–v0.18 provider contracts (#348)

### DIFF
--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -13,7 +13,7 @@ See [docs/guides/status-ladder.md](../guides/status-ladder.md) for the evidence 
 The following section is auto-generated from the `limitations:` block of `docs/status/support-matrix.yaml`. Run `python3 tools/docs_generate.py generate` to refresh.
 
 <!-- generated:start id=limitations -->
-### Known limitations (23 items across 13 capabilities)
+### Known limitations (22 items across 13 capabilities)
 
 | Capability | Limitation | Tracked in |
 |---|---|---|
@@ -31,15 +31,14 @@ The following section is auto-generated from the `limitations:` block of `docs/s
 | `formats.lv2` | LV2_URID_Map feature never resolved in instantiate(); real hosts may fail to load. | [link](planning/production-readiness/01-format-adapters.md#1.5) |
 | `audio_io.wasapi` | Shared mode only; no exclusive mode. | [link](planning/production-readiness/02-audio-midi-io.md#2.1) |
 | `audio_io.wasapi` | Input capture not wired — input_view is always empty. | [link](planning/production-readiness/02-audio-midi-io.md#2.1) |
-| `audio_io.wasapi` | No IMMNotificationClient hotplug; device-change callback is inert. | [link](planning/production-readiness/02-audio-midi-io.md#2.1) |
 | `audio_io.alsa` | No input capture path. | [link](planning/production-readiness/02-audio-midi-io.md#2.2) |
 | `audio_io.alsa` | Hardcoded sample-rate list; no real enumeration. | [link](planning/production-readiness/02-audio-midi-io.md#2.2) |
 | `audio_io.jack` | Dead code — factory always returns AlsaSystem; JACK is never selected at runtime. | [link](planning/production-readiness/02-audio-midi-io.md#2.2) |
 | `midi_io.coremidi` | UMP type-4 (MIDI 2.0 channel voice) packets are silently dropped in the input handler. | [link](planning/production-readiness/02-audio-midi-io.md#2.6) |
 | `midi_io.win32_midi` | Legacy mmeapi; no windows.devices.midi2, no hotplug, no SysEx input. | [link](planning/production-readiness/02-audio-midi-io.md#2.4) |
 | `midi_io.alsa_midi` | Running status not handled; timestamps always 0; no hotplug; no SysEx. | [link](planning/production-readiness/02-audio-midi-io.md#2.5) |
-| `platform_maturity.accessibility.windows` | UIA provider is a stub — IRawElementProviderSimple/WM_GETOBJECT/event firing pending. | [link](planning/production-readiness/04-accessibility.md#4.1) |
-| `platform_maturity.accessibility.linux` | AT-SPI registration is a stub — D-Bus bridge not yet connected. | [link](planning/production-readiness/04-accessibility.md#4.2) |
+| `platform_maturity.accessibility.windows` | UIA provider tree and event emission pending (bootstrap in place via #283). | [link](planning/production-readiness/04-accessibility.md#4.1) |
+| `platform_maturity.accessibility.linux` | AT-SPI per-view accessible objects and events pending (bridge bootstrap in place via #280). | [link](planning/production-readiness/04-accessibility.md#4.2) |
 <!-- generated:end id=limitations -->
 
 ---

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -122,12 +122,23 @@ audio_io:
   avaudiosession:
     status: experimental
     platform: ios
+    notes: >-
+      AVAudioSession category / interruption / route-change / media-services-reset
+      all observed in Swift and forwarded to native listeners via
+      pulp_ios_audio_session_emit (#329 / PR #374). Runtime validation
+      still waits on iOS on-device smoke (#249).
   wasapi:
     status: experimental
     platform: windows
+    notes: >-
+      Shared-mode playback with IMMNotificationClient hotplug (landed
+      PR #281). Input capture + exclusive-mode paths tracked in #243.
   alsa:
     status: experimental
     platform: linux
+    notes: >-
+      Output path works. Input capture and real device-metadata
+      enumeration tracked under #215 child issue.
   jack:
     status: planned
     platform: linux
@@ -508,8 +519,13 @@ platform_maturity:
     status: usable
     notes: registerShortcut bridge function, shortcuts checked before global key dispatch.
   file_dialogs:
-    status: usable
-    notes: showOpenDialog, showSaveDialog, chooseFolder bridge functions via native NSOpenPanel/NSSavePanel.
+    status: partial
+    notes: >-
+      macOS native (NSOpenPanel/NSSavePanel) — `usable`. Non-Apple
+      platforms route through a host-registered backend with honest
+      has_backend() — PRs #312/#316. No native provider ships yet
+      for Windows/Linux/Android; callers register their own backend
+      or receive explicit no-selection. #338/#339.
 
 input:
   pointer_events:
@@ -561,7 +577,13 @@ runtime_apis:
   clipboard:
     status: usable
     ci_test: pulp-test-clipboard
-    notes: navigator.clipboard.readText/writeText via platform::Clipboard C++ API.
+    notes: >-
+      navigator.clipboard.readText/writeText via platform::Clipboard C++ API.
+      macOS/iOS/Windows use native pasteboard APIs. Linux uses
+      xclip/wl-copy (#309 / PR #320) — set_text returns false honestly
+      when neither is on PATH. Android routes through a host-registered
+      bridge (Clipboard::set_android_bridge / clear_android_bridge);
+      generated app wiring tracked in #345.
   local_storage:
     status: usable
     notes: localStorage.getItem/setItem/removeItem — file-backed in temp directory.
@@ -775,8 +797,9 @@ limitations:
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.1"
     - text: "Input capture not wired — input_view is always empty."
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.1"
-    - text: "No IMMNotificationClient hotplug; device-change callback is inert."
-      tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.1"
+    # Hotplug: IMMNotificationClient device-change callbacks landed in
+    # PR #281; stale stub entry removed on 2026-04-18 during parity-audit
+    # docs refresh (#348).
   audio_io.alsa:
     - text: "No input capture path."
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.2"
@@ -795,10 +818,16 @@ limitations:
     - text: "Running status not handled; timestamps always 0; no hotplug; no SysEx."
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.5"
   platform_maturity.accessibility.windows:
-    - text: "UIA provider is a stub — IRawElementProviderSimple/WM_GETOBJECT/event firing pending."
+    # UIA bootstrap landed in PR #283 (UIAutomationCore linked, session
+    # init wired). Remaining: IRawElementProviderSimple provider tree +
+    # WM_GETOBJECT integration + value/focus/selection event emission
+    # — tracked in #247.
+    - text: "UIA provider tree and event emission pending (bootstrap in place via #283)."
       tracked_in: "planning/production-readiness/04-accessibility.md#4.1"
   platform_maturity.accessibility.linux:
-    - text: "AT-SPI registration is a stub — D-Bus bridge not yet connected."
+    # AT-SPI D-Bus bridge bootstrap landed in PR #280. Remaining:
+    # per-view AtkObject model + value/text/focus event emission.
+    - text: "AT-SPI per-view accessible objects and events pending (bridge bootstrap in place via #280)."
       tracked_in: "planning/production-readiness/04-accessibility.md#4.2"
 
 # ── Schema-v2 additions (workstream 08 slice 8.1) ─────────────────────────────


### PR DESCRIPTION
Sweep of stale rows in \`docs/status/support-matrix.yaml\` now that the parity-audit PRs have rewired several platform surfaces. Addresses the "support matrix + capabilities refresh" scope in #348.

## Updates

- \`audio_io.avaudiosession\` — notes the Swift→C ABI forwarding landed in #329 / PR #374; runtime validation still waits on #249.
- \`audio_io.wasapi\` — notes IMMNotificationClient hotplug landed in PR #281; remaining scope narrowed to input + exclusive mode (#243). Stale "no hotplug" limitation row removed.
- \`audio_io.alsa\` — notes output path working; input + device-metadata enumeration tracked under #215.
- \`services.file_dialogs\` — demoted from \`usable\` to \`partial\` with honest per-platform breakdown (macOS native; non-Apple routes through a host-registered backend per #312/#316; no native Windows/Linux/Android provider ships yet; #338/#339).
- \`runtime_apis.clipboard\` — expanded notes: macOS/iOS/Windows native, Linux xclip/wl-copy with honest false on PATH miss (#309/#320), Android bridge-registered with generated-app wiring in #345.
- \`platform_maturity.accessibility.{windows,linux}\` — rephrased as "provider tree and event emission pending" since the bootstrap landed in PR #283 and PR #280 respectively.

## Generated output

- \`docs/reference/capabilities.md\` regenerated via \`python3 tools/docs_generate.py generate\` to match the new limitations table.

## Verification

- \`tools/check-docs.sh\` → **PASSED** (drift gone; 29 warnings are pre-existing missing-index entries unrelated to this PR).

## Related

- #348 (this — closes the support matrix refresh lane).
- PR #281 (WASAPI hotplug), #312/#316 (file dialog backend), #309/#320 (clipboard), #283 (UIA), #280 (AT-SPI), #374 (iOS AVAudioSession forwarding, in CI).