### PR TITLE
cli: delegate 'pulp pr' to 'shipyard pr' by default; --native preserves fallback (#352)

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -81,22 +81,46 @@ Same as above, focus on steps 2, 4, 5, 6, 7. Key risks:
 - [ ] Search CLAUDE.md
 - [ ] Run sync check
 
-## `pulp pr` — one-shot PR orchestrator
+## `pulp pr` — shim over `shipyard pr`
 
-The canonical way to ship a branch. `cmd_pr.cpp` chains skill-sync → version-bump apply → commit → push → `gh pr create` → `shipyard ship`. The `/pr` slash command and the natural-language triggers in the `ci` skill both route here.
+By default `pulp pr` now delegates to `shipyard pr` (on PATH), forwarding
+argv. Shipyard owns skill-sync, version-bump, PR creation, and cross-host
+validation; `pulp pr` exists so the old invocation, the `/pr` slash command,
+and the natural-language triggers in the `ci` skill all continue to work.
 
 Invariants:
 
-- `pulp pr` refuses to run on `main` (feature branch required).
-- `pulp pr` refuses to create the PR if the worktree isn't clean after the bump commit.
-- Never fan out to `gh pr create` + `shipyard ship` separately. One command, one orchestrator.
-- The only inputs that require human judgment are the commit trailers (`Version-Bump`, `Skill-Update`, `Release`). Everything else is automatic.
+- When `shipyard` is on PATH, `pulp pr` execs `shipyard pr <args>` and exits
+  with shipyard's status. Do NOT add pre/post-processing in `cmd_pr.cpp` —
+  shipyard is the single source of truth.
+- When `shipyard` is NOT on PATH, `pulp pr` prints an install hint pointing
+  at `tools/install-shipyard.sh` and exits non-zero. Update the hint text
+  in `cmd_pr.cpp::print_install_shipyard_hint()` when the install path
+  changes.
+- `--native` keeps the legacy in-process orchestrator (skill-sync →
+  version-bump apply → commit → push → `gh pr create` → `shipyard ship`)
+  for forensic/debugging use. Do not use it as the default path and do not
+  document it as the primary surface — the shim IS the primary surface.
+- `pulp pr` (shim or `--native`) still refuses to run on `main`.
 
 Gotchas:
 
-- **Don't call the Python scripts by hand.** `pulp pr` invokes them in the right order with the right flags. Direct invocation skips the commit trailer parsing and the PR-body rendering.
-- **Bump level is per-surface.** A plugin-only `feat:` in a commit subject does not upgrade the SDK. The `Version-Bump: <surface>=<level>` trailer is authoritative and surface-scoped.
-- **`pulp version check --with-bump-check`** is the fast sanity check to run *before* `pulp pr` if you want to see what the gate will say. Same script, `--mode=report`.
+- **Changing `cmd_pr.cpp` triggers the cli-maintenance skill-sync gate.**
+  If you're modifying the shim, the install hint, or `--native` logic,
+  add a bullet here and you're covered. If the change is mechanical (e.g.
+  renaming a helper) and genuinely doesn't need skill documentation, add a
+  `Skill-Update: skip skill=cli-maintenance reason="..."` trailer on the
+  tip commit.
+- **Don't call the Python scripts (`skill_sync_check.py`,
+  `version_bump_check.py`) by hand.** `shipyard pr` calls them with the
+  right flags via the shim. Direct invocation skips the commit-trailer
+  parsing and the PR-body rendering.
+- **Bump level is per-surface.** A plugin-only `feat:` in a commit subject
+  does not upgrade the SDK. The `Version-Bump: <surface>=<level>` trailer
+  is authoritative and surface-scoped.
+- **`pulp version check --with-bump-check`** is the fast sanity check to
+  run *before* `pulp pr` if you want to see what the gate will say. Same
+  script, `--mode=report`.
 
 ## `pulp version check`
 

--- a/tools/cli/cmd_pr.cpp
+++ b/tools/cli/cmd_pr.cpp
@@ -1,7 +1,16 @@
 // cmd_pr.cpp — `pulp pr` subcommand.
 //
-// One-shot "push a PR" orchestrator. Wraps the three things that used to be
-// three separate human actions:
+// Primary behavior: delegate to `shipyard pr` when shipyard is installed.
+// Shipyard is Pulp's single-source-of-truth ship orchestrator; keeping a
+// parallel native implementation in two tools is how drift starts. See
+// issue #352.
+//
+// Fallback: if shipyard is not on PATH, print a concise install guide
+// (tools/install-shipyard.sh + PATH hint) and exit 2. `--native` forces
+// the in-CLI implementation below, which stays as a diagnostic fallback
+// when shipyard itself is broken or under debug.
+//
+// The in-CLI fallback does the same 4 steps shipyard pr does:
 //
 //   1. Skill-sync gate — hard-fails if a mapped path is touched without
 //      updating the corresponding SKILL.md (or a Skill-Update trailer on
@@ -248,16 +257,107 @@ void print_usage() {
 
 // ── Entry point ─────────────────────────────────────────────────────────
 
+namespace {
+
+// Resolve `shipyard` on PATH without depending on platform shell helpers.
+// Honours PATH env; matches how `find_on_path` works in platform/, but
+// local so cmd_pr.cpp keeps no new link-level dependencies.
+std::string locate_shipyard() {
+    const char* path = std::getenv("PATH");
+    if (!path) return {};
+#if defined(_WIN32)
+    const char sep = ';';
+    const char* exe = "shipyard.exe";
+#else
+    const char sep = ':';
+    const char* exe = "shipyard";
+#endif
+    std::string pathstr(path);
+    std::string::size_type start = 0;
+    while (start <= pathstr.size()) {
+        auto end = pathstr.find(sep, start);
+        auto dir = pathstr.substr(start, end - start);
+        if (!dir.empty()) {
+            fs::path candidate = fs::path(dir) / exe;
+            std::error_code ec;
+            if (fs::exists(candidate, ec) && !ec) {
+                return candidate.string();
+            }
+        }
+        if (end == std::string::npos) break;
+        start = end + 1;
+    }
+    return {};
+}
+
+void print_install_shipyard_hint() {
+    std::cerr <<
+        "pulp pr: shipyard is not on PATH, and the ship flow is the one source\n"
+        "of truth across pulp + shipyard.\n\n"
+        "Install shipyard in a Pulp checkout:\n"
+        "  ./tools/install-shipyard.sh           # downloads the pinned binary\n"
+        "  export PATH=\"$HOME/.pulp/bin:$PATH\"   # add to your shell rc once\n\n"
+        "Re-run `pulp pr` after install. If you're debugging the native\n"
+        "pulp-cli implementation of the same flow, re-run with:\n"
+        "  pulp pr --native\n";
+}
+
+int exec_shipyard_pr(const std::string& shipyard_bin,
+                     const std::vector<std::string>& args) {
+    std::ostringstream cmd;
+    // Quote the binary path in case it sits under a space-containing path.
+    cmd << '\'' << shipyard_bin << "' pr";
+    for (const auto& a : args) {
+        cmd << " '" << a << '\'';
+    }
+    // run_passthrough streams stdio through the shell so the user sees
+    // shipyard's colored output live.
+    return run_passthrough(cmd.str());
+}
+
+}  // namespace
+
 int cmd_pr(const std::vector<std::string>& args) {
+    // Filter out `--native` before any other option lookup so the shim
+    // decision is independent of the native parser's flags.
+    bool force_native = false;
+    std::vector<std::string> forward;
+    forward.reserve(args.size());
+    for (const auto& a : args) {
+        if (a == "--native") { force_native = true; continue; }
+        forward.push_back(a);
+    }
+
+    if (!force_native) {
+        if (!forward.empty() && (forward[0] == "--help" || forward[0] == "-h")) {
+            // `pulp pr --help` always shows the shim's help too, so the
+            // user learns about --native. Then fall through to shipyard's
+            // own help when available.
+            std::cout <<
+                "Usage: pulp pr [--native] [<shipyard pr options>]\n"
+                "\n"
+                "By default this delegates to `shipyard pr`, the canonical\n"
+                "push-a-PR orchestrator. Pass --native to run the in-CLI\n"
+                "fallback implementation instead (for diagnostics).\n\n";
+        }
+        auto shipyard = locate_shipyard();
+        if (!shipyard.empty()) {
+            return exec_shipyard_pr(shipyard, forward);
+        }
+        print_install_shipyard_hint();
+        return 2;
+    }
+
+    // ── Native fallback (pre-shipyard behaviour) ────────────────────────
     Options opt;
-    for (size_t i = 0; i < args.size(); ++i) {
-        const auto& a = args[i];
+    for (size_t i = 0; i < forward.size(); ++i) {
+        const auto& a = forward[i];
         if (a == "--help" || a == "-h") { print_usage(); return 0; }
         else if (a == "--dry-run") opt.dry_run = true;
         else if (a == "--no-ship") opt.no_ship = true;
         else if (a == "--no-push") opt.no_push = true;
-        else if (a == "--base"  && i + 1 < args.size()) opt.base  = args[++i];
-        else if (a == "--title" && i + 1 < args.size()) opt.title = args[++i];
+        else if (a == "--base"  && i + 1 < forward.size()) opt.base  = forward[++i];
+        else if (a == "--title" && i + 1 < forward.size()) opt.title = forward[++i];
         else { std::cerr << "pulp pr: unknown option '" << a << "'\n"; print_usage(); return 2; }
     }
 


### PR DESCRIPTION
Closes the consolidation half of #352. Per the user's preferred option-B plan in the issue thread:

- \`pulp pr\` now locates shipyard on PATH and \`exec\`s \`shipyard pr <forwarded args>\` when available. Shipyard becomes the single source of truth for the push-a-PR orchestrator; the parallel in-CLI implementation stays as an explicit fallback.
- When shipyard is **not** on PATH, \`pulp pr\` prints a concise install guide pointing at \`tools/install-shipyard.sh\` + the \`~/.pulp/bin\` PATH hint, and exits 2.
- \`pulp pr --native\` forces the in-CLI implementation. This keeps the 384-line native flow available as a diagnostic fallback when shipyard itself is broken or under debug — same behavior as before this change, just no longer the default.

The natural-language triggers ("push a PR" / "ship this") stay routed through \`pulp pr\` per CLAUDE.md and the ci skill — **no doc churn required**. The native flow's \`--dry-run\` / \`--no-ship\` / \`--no-push\` options still work via \`--native\`.

## Verification

Smoke-tested on the built binary:

- \`pulp pr --help\` with shipyard on PATH → shipyard's help prints.
- \`pulp pr\` with shipyard NOT on PATH (\`PATH=/tmp\`) → install hint + exit 2.
- \`pulp pr --native --help\` → native pulp-cli help prints.

## Not done in this PR

The \`pulp upgrade\` 404 fix (wrong asset filename template) is still open in #352 as a separate sub-task. Will follow in its own PR since the fix is in \`cmd_upgrade.cpp\` and the flows don't overlap.

## Related

- #352 (closes the consolidation; \`pulp upgrade\` 404 sub-task stays open)