### PR TITLE
cli(upgrade): fix 404 — drop version from tarball filename (#352)

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -122,6 +122,34 @@ Gotchas:
   run *before* `pulp pr` if you want to see what the gate will say. Same
   script, `--mode=report`.
 
+## `pulp upgrade` — self-update
+
+Lives in `tools/cli/cmd_misc.cpp` and calls `pulp::cli::pulp_upgrade_url_for()`
+from `tools/cli/upgrade_url.hpp`. The URL/asset-name convention is **pinned
+by the release workflow** (`.github/workflows/release-cli.yml`) and guarded
+by `test/test_cli_upgrade_url.cpp` — both need to agree.
+
+Convention (don't drift):
+
+```
+Asset = "pulp-<platform>-<arch>.<ext>"  (NO version in the filename)
+URL   = ".../releases/download/v<version>/<asset>"
+arch  = "arm64" | "x64"                  (NOT "x86_64")
+ext   = "zip" for windows, "tar.gz" otherwise
+```
+
+Gotchas:
+
+- **Don't bake the version into the asset filename.** The version sits in
+  the release *tag* (path segment `v<version>`), not in the file name.
+  PR #377 / issue #352 was the bug where the filename contained the
+  version and every upgrade 404'd. `test_cli_upgrade_url.cpp` explicitly
+  fails if the version reappears in the filename.
+- **Use `x64`, not `x86_64`.** The release workflow uploads under `x64`.
+- **If you change `upgrade_url.hpp`, update the regression test in the
+  same PR.** Both live at HEAD; drift between them is the whole reason
+  the header exists.
+
 ## `pulp version check`
 
 Validates consistency across the three version-bearing surfaces:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,14 @@ if(TARGET pulp-cli)
 endif()
 catch_discover_tests(pulp-test-cli-ship-shellout)
 
+# CLI upgrade URL regression test (#352): asset filename stays
+# "pulp-<platform>-<arch>.<ext>" — the version sits in the release tag.
+# Test includes tools/cli/upgrade_url.hpp directly, no link deps needed.
+add_executable(pulp-test-cli-upgrade-url test_cli_upgrade_url.cpp)
+target_include_directories(pulp-test-cli-upgrade-url PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(pulp-test-cli-upgrade-url PRIVATE Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-cli-upgrade-url)
+
 # Child process tests
 add_executable(pulp-test-child-process test_child_process.cpp)
 target_link_libraries(pulp-test-child-process PRIVATE pulp::platform Catch2::Catch2WithMain)

--- a/test/test_cli_upgrade_url.cpp
+++ b/test/test_cli_upgrade_url.cpp
@@ -1,0 +1,59 @@
+// Regression guard for the `pulp upgrade` release-asset URL template.
+//
+// Before #352 closed this, the CLI computed asset names as
+// "pulp-<version>-<platform>-<arch>.<ext>" and every `pulp upgrade`
+// 404'd on the download step because the release workflow uploads
+// assets under "pulp-<platform>-<arch>.<ext>" (no version in the name).
+// This test pins the expected URL shape against real v0.14.0 assets
+// so the same drift cannot recur silently.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "tools/cli/upgrade_url.hpp"
+
+using pulp::cli::pulp_upgrade_url_for;
+
+TEST_CASE("pulp upgrade URL: darwin arm64 asset name matches release workflow",
+          "[cli][upgrade][url][issue-352]") {
+    auto r = pulp_upgrade_url_for("0.14.0", "darwin", "arm64");
+    REQUIRE(r.asset == "pulp-darwin-arm64.tar.gz");
+    REQUIRE(r.url ==
+            "https://github.com/danielraffel/pulp/releases/download/"
+            "v0.14.0/pulp-darwin-arm64.tar.gz");
+}
+
+TEST_CASE("pulp upgrade URL: linux x64 uses 'x64' not 'x86_64'",
+          "[cli][upgrade][url][issue-352]") {
+    auto r = pulp_upgrade_url_for("0.14.0", "linux", "x64");
+    REQUIRE(r.asset == "pulp-linux-x64.tar.gz");
+    REQUIRE(r.url.find("/v0.14.0/pulp-linux-x64.tar.gz") != std::string::npos);
+}
+
+TEST_CASE("pulp upgrade URL: linux arm64 asset", "[cli][upgrade][url]") {
+    auto r = pulp_upgrade_url_for("0.14.0", "linux", "arm64");
+    REQUIRE(r.asset == "pulp-linux-arm64.tar.gz");
+}
+
+TEST_CASE("pulp upgrade URL: windows uses .zip extension",
+          "[cli][upgrade][url][windows]") {
+    auto r = pulp_upgrade_url_for("0.14.0", "windows", "x64");
+    REQUIRE(r.asset == "pulp-windows-x64.zip");
+    auto arm = pulp_upgrade_url_for("0.14.0", "windows", "arm64");
+    REQUIRE(arm.asset == "pulp-windows-arm64.zip");
+}
+
+TEST_CASE("pulp upgrade URL: version appears only in the release path, not the filename",
+          "[cli][upgrade][url][issue-352]") {
+    // The precise bug #352 captured: the version was baked into the
+    // filename. Any future refactor that re-introduces the version in
+    // the asset name fails here.
+    auto r = pulp_upgrade_url_for("9.99.0", "darwin", "arm64");
+    REQUIRE(r.asset.find("9.99.0") == std::string::npos);
+    REQUIRE(r.url.find("v9.99.0/") != std::string::npos);
+}
+
+TEST_CASE("pulp upgrade URL: version field flows into the release tag verbatim",
+          "[cli][upgrade][url]") {
+    auto r = pulp_upgrade_url_for("1.2.3-rc.1", "darwin", "arm64");
+    REQUIRE(r.url.find("v1.2.3-rc.1/") != std::string::npos);
+}

--- a/tools/cli/cmd_misc.cpp
+++ b/tools/cli/cmd_misc.cpp
@@ -1,6 +1,7 @@
 // cmd_misc.cpp — pulp test, status, clean, cache, upgrade commands
 
 #include "cli_common.hpp"
+#include "upgrade_url.hpp"
 
 #include <fstream>
 #include <iostream>
@@ -297,6 +298,11 @@ int cmd_cache(const std::vector<std::string>& args) {
 
 // ── cmd_upgrade ─────────────────────────────────────────────────────────────
 
+// URL / asset-name logic lives in upgrade_url.hpp so the regression test
+// can link against it without pulling cmd_misc's transitive CLI deps.
+// Release workflow this mirrors: .github/workflows/release-cli.yml.
+// Issue: #352.
+
 int cmd_upgrade(const std::vector<std::string>& args) {
     std::string target_version;
     for (size_t i = 0; i < args.size(); ++i) {
@@ -338,7 +344,10 @@ int cmd_upgrade(const std::vector<std::string>& args) {
 #if defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
     arch = "arm64";
 #elif defined(__x86_64__) || defined(_M_X64)
-    arch = "x86_64";
+    // Release assets use "x64" (not "x86_64"). Keep this in sync with the
+    // release workflow in .github/workflows/release-cli.yml — otherwise
+    // `pulp upgrade` 404s on the download step.
+    arch = "x64";
 #else
     arch = "unknown";
 #endif
@@ -353,9 +362,7 @@ int cmd_upgrade(const std::vector<std::string>& args) {
 
     auto install_dir = fs::path(self_path).parent_path();
 
-    std::string ext = (platform == "windows") ? "zip" : "tar.gz";
-    std::string tarball = "pulp-" + version + "-" + platform + "-" + arch + "." + ext;
-    std::string url = "https://github.com/danielraffel/pulp/releases/download/v" + version + "/" + tarball;
+    auto [tarball, url] = pulp::cli::pulp_upgrade_url_for(version, platform, arch);
 
     std::cout << "  Downloading " << tarball << "...\n";
 

--- a/tools/cli/upgrade_url.hpp
+++ b/tools/cli/upgrade_url.hpp
@@ -1,0 +1,38 @@
+// upgrade_url.hpp — build the `pulp upgrade` release-asset name + URL
+// for a given version + target triple.
+//
+// Header-only so tests can pin the URL shape without pulling cmd_misc's
+// transitive CLI deps. The convention must stay in sync with
+// .github/workflows/release-cli.yml — the #352 regression was that the
+// CLI baked the version into the filename and every upgrade 404'd on
+// the download step.
+//
+// Convention:
+//   Asset  = "pulp-<platform>-<arch>.<ext>"  (no version in the filename)
+//   URL    = ".../releases/download/v<version>/<asset>"
+//   ext    = "zip" for windows, "tar.gz" otherwise
+//   arch   = "arm64" | "x64"  (NOT "x86_64" — release assets use x64)
+
+#pragma once
+
+#include <string>
+
+namespace pulp::cli {
+
+struct UpgradeUrlPair {
+    std::string asset;
+    std::string url;
+};
+
+inline UpgradeUrlPair pulp_upgrade_url_for(const std::string& version,
+                                           const std::string& platform,
+                                           const std::string& arch) {
+    const std::string ext = (platform == "windows") ? "zip" : "tar.gz";
+    const std::string asset = "pulp-" + platform + "-" + arch + "." + ext;
+    const std::string url =
+        "https://github.com/danielraffel/pulp/releases/download/v"
+        + version + "/" + asset;
+    return {asset, url};
+}
+
+}  // namespace pulp::cli


### PR DESCRIPTION
## Summary

`pulp upgrade` 404'd on every run because the CLI built download URLs
using `pulp-<version>-<platform>-<arch>.<ext>` and `x86_64`, while the
release workflow uploads assets as `pulp-<platform>-<arch>.<ext>` with
`x64`. This PR pins the URL shape to the release workflow and adds a
Catch2 regression guard so the two can't drift silently again.

This is the second half of #352; the first half (`pulp pr` → `shipyard pr`
shim) is in-flight as #376. Fixing both gets `pulp upgrade` and `pulp pr`
back to parity with their documented behavior.

## Changes

- **tools/cli/upgrade_url.hpp** — new header-only URL/asset builder so
  the regression test can pin the naming convention without linking
  cmd_misc's transitive CLI deps.
- **tools/cli/cmd_misc.cpp** — replace the local helper (which baked
  the version into the filename and used `x86_64`) with a call into
  `pulp::cli::pulp_upgrade_url_for()`.
- **test/test_cli_upgrade_url.cpp** — 6 Catch2 cases against real
  v0.14.0 release naming, including one that explicitly fails if a
  future refactor re-introduces the version in the filename.

### Convention (pinned by the header + tests)

```
Asset = "pulp-<platform>-<arch>.<ext>"   (no version in the filename)
URL   = ".../releases/download/v<version>/<asset>"
arch  = "arm64" | "x64"                   (NOT "x86_64")
ext   = "zip" for windows, "tar.gz" otherwise
```

Mirrors `.github/workflows/release-cli.yml`.

## Test plan

- [x] New `pulp-test-cli-upgrade-url` runs green locally (10 assertions,
      6 cases).
- [x] `cmake --build build --target pulp-cli` succeeds (refactor
      compiles end-to-end).
- [ ] CI green on macOS / Ubuntu / Windows via shipyard.
- [ ] Manual spot check post-merge: `pulp upgrade` against a real
      release downloads successfully.

Closes #352.