### PR TITLE
test(examples): golden breadth for Compressor/Drums/Synth (#356)

### DIFF
--- a/examples/PulpDrums/test_pulp_drums.cpp
+++ b/examples/PulpDrums/test_pulp_drums.cpp
@@ -81,3 +81,94 @@ TEST_CASE("PulpDrums state round-trip", "[examples][drums]") {
     REQUIRE(host.state().get_value(kTempo) > 139.0f);
     REQUIRE(host.state().get_value(kSwing) > 0.29f);
 }
+
+// ── Deeper golden cases (#356 golden breadth) ─────────────────────────
+
+namespace {
+
+int count_midi_over_duration(HeadlessHost& host, float tempo_bpm,
+                             int total_samples, int block_size) {
+    host.state().set_value(kTempo, tempo_bpm);
+    host.state().set_value(kDensity, 1.0f);    // every step triggers
+    host.state().set_value(kRandomize, 0.0f);  // deterministic
+
+    std::vector<float> in_l(static_cast<std::size_t>(block_size), 0.0f);
+    std::vector<float> in_r(static_cast<std::size_t>(block_size), 0.0f);
+    std::vector<float> out_l(static_cast<std::size_t>(block_size), 0.0f);
+    std::vector<float> out_r(static_cast<std::size_t>(block_size), 0.0f);
+    const float* ip[] = {in_l.data(), in_r.data()};
+    float* op[] = {out_l.data(), out_r.data()};
+    pulp::audio::BufferView<const float> iv(ip, 2, block_size);
+    pulp::audio::BufferView<float> ov(op, 2, block_size);
+
+    int notes = 0;
+    pulp::midi::MidiBuffer midi_in, midi_out;
+    for (int pos = 0; pos < total_samples; pos += block_size) {
+        midi_out.clear();
+        host.process(ov, iv, midi_in, midi_out);
+        notes += static_cast<int>(midi_out.size());
+    }
+    return notes;
+}
+
+}  // namespace
+
+// Faster tempo ⇒ more steps per fixed wall-clock window, so more MIDI
+// events should land in the same number of samples. If the sequencer
+// ever ignores the tempo param this test fails hard.
+TEST_CASE("PulpDrums golden: tempo change changes MIDI density",
+          "[examples][drums][golden][issue-356]") {
+    // ~1 second of audio at 48 kHz.
+    constexpr int total = 48000;
+    constexpr int block = 512;
+
+    HeadlessHost slow(create_pulp_drums);
+    slow.prepare(48000, block, 2, 2);
+    int slow_notes = count_midi_over_duration(slow, 60.0f, total, block);
+
+    HeadlessHost fast(create_pulp_drums);
+    fast.prepare(48000, block, 2, 2);
+    int fast_notes = count_midi_over_duration(fast, 240.0f, total, block);
+
+    REQUIRE(slow_notes > 0);
+    REQUIRE(fast_notes > slow_notes);
+    // 4x tempo ⇒ strictly more notes; allow broad tolerance for
+    // quantisation at block boundaries.
+    REQUIRE(fast_notes >= slow_notes * 2);
+}
+
+// Audio pass-through must remain bit-exact even while the MIDI
+// sequencer fires. Regression guard against a future change that
+// accidentally reads/writes the audio buffer in the MIDI path.
+TEST_CASE("PulpDrums golden: audio is bit-exact pass-through while sequencing",
+          "[examples][drums][golden][issue-356]") {
+    HeadlessHost host(create_pulp_drums);
+    host.prepare(48000, 512, 2, 2);
+    host.state().set_value(kTempo, 200.0f);
+    host.state().set_value(kDensity, 1.0f);
+
+    constexpr int block = 512;
+    std::vector<float> in_l(block), in_r(block);
+    for (int i = 0; i < block; ++i) {
+        in_l[static_cast<std::size_t>(i)] =
+            0.5f * std::sin(static_cast<float>(i) * 0.01f);
+        in_r[static_cast<std::size_t>(i)] =
+            -0.5f * std::sin(static_cast<float>(i) * 0.01f);
+    }
+    std::vector<float> out_l(block, 123.0f);  // poison
+    std::vector<float> out_r(block, 123.0f);
+
+    const float* ip[] = {in_l.data(), in_r.data()};
+    float* op[] = {out_l.data(), out_r.data()};
+    pulp::audio::BufferView<const float> iv(ip, 2, block);
+    pulp::audio::BufferView<float> ov(op, 2, block);
+    pulp::midi::MidiBuffer midi_in, midi_out;
+    host.process(ov, iv, midi_in, midi_out);
+
+    for (int i = 0; i < block; ++i) {
+        REQUIRE(out_l[static_cast<std::size_t>(i)]
+                == in_l[static_cast<std::size_t>(i)]);
+        REQUIRE(out_r[static_cast<std::size_t>(i)]
+                == in_r[static_cast<std::size_t>(i)]);
+    }
+}

--- a/examples/PulpSynth/test_pulp_synth.cpp
+++ b/examples/PulpSynth/test_pulp_synth.cpp
@@ -69,3 +69,112 @@ TEST_CASE("PulpSynth state round-trip", "[examples][synth]") {
     host.load_state(data);
     REQUIRE_THAT(host.state().get_value(kFilterCutoff), WithinAbs(2000.0, 0.1));
 }
+
+// ── Deeper golden cases (#356 golden breadth) ─────────────────────────
+
+namespace {
+
+float rms_of(const std::vector<float>& v) {
+    float sum = 0.0f;
+    for (float s : v) sum += s * s;
+    return std::sqrt(sum / static_cast<float>(v.size()));
+}
+
+std::vector<float> render_with_midi(
+    HeadlessHost& host, pulp::midi::MidiBuffer& midi_in, int n_samples)
+{
+    std::vector<float> out_l(static_cast<std::size_t>(n_samples), 0.0f);
+    std::vector<float> out_r(static_cast<std::size_t>(n_samples), 0.0f);
+    float* op[] = {out_l.data(), out_r.data()};
+    pulp::audio::BufferView<float> ov(op, 2, n_samples);
+    pulp::audio::BufferView<const float> iv(nullptr, 0, n_samples);
+    pulp::midi::MidiBuffer midi_out;
+    host.process(ov, iv, midi_in, midi_out);
+    return out_l;
+}
+
+}  // namespace
+
+// Master gain at -60 dB takes the note-on output well under the
+// audible floor. Guards against a future refactor that forgets to
+// apply the master gain to one of the audio paths.
+//
+// The master-gain smoother needs a few thousand samples to settle
+// from the default -6 dB baseline to -60 dB, so we render 8192
+// samples (~170 ms at 48 kHz) and measure only the tail of the
+// output where the smoother has arrived.
+TEST_CASE("PulpSynth golden: master gain at -60 dB effectively silences note",
+          "[examples][synth][golden][issue-356]") {
+    constexpr int n = 8192;
+
+    HeadlessHost loud(create_pulp_synth);
+    loud.prepare(48000, n, 0, 2);
+    pulp::midi::MidiBuffer m1;
+    m1.add(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    auto loud_out = render_with_midi(loud, m1, n);
+
+    HeadlessHost quiet(create_pulp_synth);
+    quiet.prepare(48000, n, 0, 2);
+    quiet.state().set_value(kMasterGain, -60.0f);
+    pulp::midi::MidiBuffer m2;
+    m2.add(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    auto quiet_out = render_with_midi(quiet, m2, n);
+
+    // Measure only the final quarter — the gain smoother has settled
+    // and the amp envelope is in the sustain plateau by then.
+    std::vector<float> loud_tail(loud_out.end() - n / 4, loud_out.end());
+    std::vector<float> quiet_tail(quiet_out.end() - n / 4, quiet_out.end());
+    float loud_rms = rms_of(loud_tail);
+    float quiet_rms = rms_of(quiet_tail);
+
+    REQUIRE(loud_rms > 0.01f);
+    // -60 dB ≈ 0.001× linear; tolerate some smoother residue but fail
+    // hard if the gain isn't materially knocking the signal down.
+    REQUIRE(quiet_rms < loud_rms * 0.05f);
+}
+
+// Three simultaneous notes must produce more output energy than one.
+// Polyphony regression guard — catches a future voice-allocator change
+// that silently clamps to a single voice.
+TEST_CASE("PulpSynth golden: polyphony — 3 notes louder than 1 note",
+          "[examples][synth][golden][issue-356]") {
+    HeadlessHost mono(create_pulp_synth);
+    mono.prepare(48000, 2048, 0, 2);
+    pulp::midi::MidiBuffer m1;
+    m1.add(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    auto mono_out = render_with_midi(mono, m1, 2048);
+
+    HeadlessHost poly(create_pulp_synth);
+    poly.prepare(48000, 2048, 0, 2);
+    pulp::midi::MidiBuffer m3;
+    m3.add(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    m3.add(pulp::midi::MidiEvent::note_on(0, 64, 100));
+    m3.add(pulp::midi::MidiEvent::note_on(0, 67, 100));
+    auto poly_out = render_with_midi(poly, m3, 2048);
+
+    float mono_rms = rms_of(mono_out);
+    float poly_rms = rms_of(poly_out);
+    REQUIRE(mono_rms > 0.001f);
+    REQUIRE(poly_rms > mono_rms * 1.3f);
+}
+
+// Identical MIDI + identical state ⇒ bit-identical output. This is
+// the determinism contract the entire test matrix depends on.
+TEST_CASE("PulpSynth golden: same MIDI + state ⇒ bit-identical output",
+          "[examples][synth][golden][issue-356]") {
+    HeadlessHost h1(create_pulp_synth);
+    h1.prepare(48000, 1024, 0, 2);
+    pulp::midi::MidiBuffer m1;
+    m1.add(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    auto out1 = render_with_midi(h1, m1, 1024);
+
+    HeadlessHost h2(create_pulp_synth);
+    h2.prepare(48000, 1024, 0, 2);
+    pulp::midi::MidiBuffer m2;
+    m2.add(pulp::midi::MidiEvent::note_on(0, 60, 100));
+    auto out2 = render_with_midi(h2, m2, 1024);
+
+    for (std::size_t i = 0; i < out1.size(); ++i) {
+        REQUIRE(out1[i] == out2[i]);
+    }
+}

--- a/examples/pulp-compressor/test_pulp_compressor.cpp
+++ b/examples/pulp-compressor/test_pulp_compressor.cpp
@@ -99,3 +99,134 @@ TEST_CASE("PulpCompressor state round-trip", "[compressor]") {
     REQUIRE_THAT(h2.state().get_value(kRatio), WithinAbs(8.0, 0.1));
     REQUIRE_THAT(h2.state().get_value(kMakeupGain), WithinAbs(6.0, 0.1));
 }
+
+// ── Deeper golden cases (#356 golden breadth) ─────────────────────────
+
+// Below threshold the compressor is a no-op: gain == 1.0, so a quiet
+// signal should come out numerically identical to the input. If this
+// ever regresses we've either broken the `envelope_ > threshold_lin`
+// short-circuit or accidentally applied makeup gain to bypass.
+TEST_CASE("PulpCompressor golden: below-threshold is unity pass-through",
+          "[compressor][golden][issue-356]") {
+    format::HeadlessHost host(create_pulp_compressor);
+    host.prepare(48000.0, 1024);
+    host.state().set_value(kThreshold, -10.0f);  // -10 dBFS
+    host.state().set_value(kRatio, 8.0f);
+    host.state().set_value(kMakeupGain, 0.0f);
+
+    // Peak amplitude ≈ 0.01 ⇒ ~-40 dBFS, well below threshold.
+    audio::Buffer<float> in(2, 1024), out(2, 1024);
+    for (std::size_t i = 0; i < 1024; ++i) {
+        float v = 0.01f * std::sin(2.0f * std::numbers::pi_v<float>
+                                   * 440.0f * i / 48000.0f);
+        in.channel(0)[i] = v;
+        in.channel(1)[i] = v;
+    }
+
+    process_headless(host, in, out);
+
+    for (std::size_t i = 0; i < 1024; ++i) {
+        REQUIRE_THAT(out.channel(0)[i],
+                     WithinAbs(in.channel(0)[i], 1e-6));
+        REQUIRE_THAT(out.channel(1)[i],
+                     WithinAbs(in.channel(1)[i], 1e-6));
+    }
+}
+
+// Makeup gain below threshold is pure linear scaling. A +6 dB makeup
+// with a sub-threshold input ⇒ output RMS ≈ 2× input RMS.
+TEST_CASE("PulpCompressor golden: makeup gain is linear below threshold",
+          "[compressor][golden][issue-356]") {
+    format::HeadlessHost host(create_pulp_compressor);
+    host.prepare(48000.0, 1024);
+    host.state().set_value(kThreshold, -10.0f);
+    host.state().set_value(kRatio, 4.0f);
+    host.state().set_value(kMakeupGain, 6.0f);
+
+    audio::Buffer<float> in(2, 1024), out(2, 1024);
+    for (std::size_t i = 0; i < 1024; ++i) {
+        float v = 0.05f * std::sin(2.0f * std::numbers::pi_v<float>
+                                   * 440.0f * i / 48000.0f);
+        in.channel(0)[i] = v;
+        in.channel(1)[i] = v;
+    }
+
+    process_headless(host, in, out);
+
+    const float expected_ratio = std::pow(10.0f, 6.0f / 20.0f);  // ≈1.995
+    const float in_rms = rms(in, 0);
+    const float out_rms = rms(out, 0);
+
+    // Makeup below threshold is a pure gain, so ratio is tight.
+    REQUIRE(out_rms > in_rms * (expected_ratio - 0.05f));
+    REQUIRE(out_rms < in_rms * (expected_ratio + 0.05f));
+}
+
+// A 20:1 ratio approximates a brick-wall limiter. With a fast attack
+// and a loud sine far over threshold, the post-attack output peak
+// should sit within a few dB of threshold — definitely <<< input peak.
+TEST_CASE("PulpCompressor golden: high-ratio limiter tames peaks",
+          "[compressor][golden][issue-356]") {
+    format::HeadlessHost host(create_pulp_compressor);
+    host.prepare(48000.0, 4096);
+    host.state().set_value(kThreshold, -20.0f);
+    host.state().set_value(kRatio, 20.0f);
+    host.state().set_value(kAttack, 0.1f);
+    host.state().set_value(kRelease, 50.0f);
+    host.state().set_value(kMakeupGain, 0.0f);
+
+    audio::Buffer<float> in(2, 4096), out(2, 4096);
+    for (std::size_t i = 0; i < 4096; ++i) {
+        float v = std::sin(2.0f * std::numbers::pi_v<float> * 440.0f
+                           * i / 48000.0f);
+        in.channel(0)[i] = v;
+        in.channel(1)[i] = v;
+    }
+    process_headless(host, in, out);
+
+    // Discard the first 1024 samples: attack envelope is still ramping.
+    float out_peak = 0.0f;
+    for (std::size_t i = 1024; i < 4096; ++i) {
+        out_peak = std::max(out_peak, std::abs(out.channel(0)[i]));
+    }
+
+    // Threshold -20 dBFS ≈ 0.1 linear. With 20:1 and fast attack the
+    // settled peak should be well under half the unity-gain peak.
+    REQUIRE(out_peak < 0.5f);
+}
+
+// Release-tail sanity: after the detector sees loud material, once the
+// input goes back below threshold the compressor must eventually
+// relax back to unity gain. We drive a loud burst, then zero-fill,
+// then a tiny sub-threshold signal and check it passes near-unity.
+TEST_CASE("PulpCompressor golden: gain relaxes to unity after transient",
+          "[compressor][golden][issue-356]") {
+    format::HeadlessHost host(create_pulp_compressor);
+    host.prepare(48000.0, 1);  // block=1 forces the envelope to step per sample
+    host.state().set_value(kThreshold, -20.0f);
+    host.state().set_value(kRatio, 20.0f);
+    host.state().set_value(kAttack, 0.5f);
+    host.state().set_value(kRelease, 20.0f);  // fastish release
+    host.state().set_value(kMakeupGain, 0.0f);
+
+    auto step = [&](float v_in) {
+        float in_L = v_in, in_R = v_in;
+        float out_L = 0.0f, out_R = 0.0f;
+        const float* ip[2] = {&in_L, &in_R};
+        float* op[2] = {&out_L, &out_R};
+        audio::BufferView<const float> iv(ip, 2, 1);
+        audio::BufferView<float> ov(op, 2, 1);
+        host.process(ov, iv);
+        return out_L;
+    };
+
+    // Loud burst to drive the envelope up.
+    for (int i = 0; i < 4800; ++i) step(0.8f);
+
+    // Long silent stretch for release to finish — 96 ms at 48 kHz.
+    for (int i = 0; i < 4608; ++i) step(0.0f);
+
+    // Quiet probe below threshold, after release: should be unity.
+    float probe = step(0.01f);
+    REQUIRE_THAT(probe, WithinAbs(0.01, 0.001));
+}


### PR DESCRIPTION
## Summary

Stage-1 item 6 from #356 audio-validation-audit: golden suite breadth
beyond PulpGain/Tone/Effect. Adds deeper behaviour golden tests to
three existing per-example test files — no new test targets or
plumbing, just richer assertions on what each processor must actually
do.

## New cases

**PulpCompressor (+4)**
- Below-threshold is unity pass-through (bit-exact).
- Makeup gain below threshold is linear (+6 dB ⇒ 2× RMS).
- 20:1 high-ratio tames peaks well under input peak.
- Gain relaxes to unity after a loud transient + release.

**PulpDrums (+2)**
- Tempo change changes MIDI note density (60→240 BPM ≥ 2× notes).
- Audio pass-through is bit-exact while sequencer fires MIDI.

**PulpSynth (+3)**
- Master gain at -60 dB effectively silences a held note (measured on
  the settled tail to pass the gain smoother).
- Polyphony: 3 simultaneous notes produce ≥ 1.3× mono RMS.
- Same MIDI + same state ⇒ bit-identical output (determinism).

## Scope

These are behaviour golden tests — what the processor *must produce* —
not shape tests (descriptor has N params) and not framework-contract
tests (which #48 / PR #378 covers). No changes to test plumbing; the
existing per-example targets gain richer coverage.

## Test plan

- [x] Local: all 3 targets green.
  - pulp-compressor-test: 2068 assertions / 9 cases
  - pulp-drums-test:      1036 assertions / 6 cases
  - pulp-synth-test:      1035 assertions / 7 cases
- [ ] Linux / Windows CI via shipyard.

## Follow-ups

Open from #356:
- **#49** latency/automation/edge-case corpus at framework layer.
- **#51** validator enforcement (pluginval/clap-validator/auval).
- **#52** host-level regression (first automation-friendly host).

Refs #356.