### PR TITLE
test + cli: address Codex P2s from PRs #378/#379/#381

### DIFF
--- a/examples/PulpDrums/test_pulp_drums.cpp
+++ b/examples/PulpDrums/test_pulp_drums.cpp
@@ -140,12 +140,19 @@ TEST_CASE("PulpDrums golden: tempo change changes MIDI density",
 // Audio pass-through must remain bit-exact even while the MIDI
 // sequencer fires. Regression guard against a future change that
 // accidentally reads/writes the audio buffer in the MIDI path.
+//
+// Codex P2 on PR #379: the old single-block version never fired a
+// step event (samples_per_step ≈ 3600 at 200 BPM 48 kHz, block=512),
+// so the "while sequencing" promise wasn't exercised. We now loop
+// blocks until midi_out has non-zero size at least once — and keep
+// asserting bit-exact pass-through on every block.
 TEST_CASE("PulpDrums golden: audio is bit-exact pass-through while sequencing",
           "[examples][drums][golden][issue-356]") {
     HeadlessHost host(create_pulp_drums);
     host.prepare(48000, 512, 2, 2);
     host.state().set_value(kTempo, 200.0f);
     host.state().set_value(kDensity, 1.0f);
+    host.state().set_value(kRandomize, 0.0f);
 
     constexpr int block = 512;
     std::vector<float> in_l(block), in_r(block);
@@ -155,20 +162,33 @@ TEST_CASE("PulpDrums golden: audio is bit-exact pass-through while sequencing",
         in_r[static_cast<std::size_t>(i)] =
             -0.5f * std::sin(static_cast<float>(i) * 0.01f);
     }
-    std::vector<float> out_l(block, 123.0f);  // poison
-    std::vector<float> out_r(block, 123.0f);
 
     const float* ip[] = {in_l.data(), in_r.data()};
-    float* op[] = {out_l.data(), out_r.data()};
     pulp::audio::BufferView<const float> iv(ip, 2, block);
-    pulp::audio::BufferView<float> ov(op, 2, block);
-    pulp::midi::MidiBuffer midi_in, midi_out;
-    host.process(ov, iv, midi_in, midi_out);
 
-    for (int i = 0; i < block; ++i) {
-        REQUIRE(out_l[static_cast<std::size_t>(i)]
-                == in_l[static_cast<std::size_t>(i)]);
-        REQUIRE(out_r[static_cast<std::size_t>(i)]
-                == in_r[static_cast<std::size_t>(i)]);
+    // ~20 blocks (≈213 ms @ 48 kHz) guarantees multiple steps at
+    // 200 BPM — samples_per_step is ~3600 so at block=512 we cross a
+    // step boundary roughly every 7 blocks.
+    bool midi_observed = false;
+    for (int b = 0; b < 20; ++b) {
+        std::vector<float> out_l(block, 123.0f);  // poison each block
+        std::vector<float> out_r(block, 123.0f);
+        float* op[] = {out_l.data(), out_r.data()};
+        pulp::audio::BufferView<float> ov(op, 2, block);
+
+        pulp::midi::MidiBuffer midi_in, midi_out;
+        host.process(ov, iv, midi_in, midi_out);
+        if (midi_out.size() > 0) midi_observed = true;
+
+        for (int i = 0; i < block; ++i) {
+            REQUIRE(out_l[static_cast<std::size_t>(i)]
+                    == in_l[static_cast<std::size_t>(i)]);
+            REQUIRE(out_r[static_cast<std::size_t>(i)]
+                    == in_r[static_cast<std::size_t>(i)]);
+        }
     }
+    // The "while sequencing" in the test name is load-bearing: if the
+    // sequencer never actually fired during this window, we haven't
+    // proven anything about audio integrity during a step event.
+    REQUIRE(midi_observed);
 }

--- a/test/test_audio_determinism_matrix.cpp
+++ b/test/test_audio_determinism_matrix.cpp
@@ -109,9 +109,13 @@ TEST_CASE("Audio matrix: PulpGain unity gain bit-exact across SR×block",
             pulp::format::HeadlessHost host(pulp::examples::create_pulp_gain);
             host.prepare(sr, block);
 
-            // 2048 samples is evenly divisible by every block size we
-            // sweep, so the last block is never short.
-            constexpr int total = 2048;
+            // 8192 is the smallest multiple of every block size we
+            // sweep (including 4096) that guarantees the largest cell
+            // runs at least two full-size blocks rather than short-
+            // blocking the last call to min(block, total-pos). Codex
+            // P2 on PR #378 flagged that the earlier total=2048
+            // silently short-blocked the 4096 cell.
+            constexpr int total = 8192;
             auto in_L = make_sine_vec(total, 440.0f, sr);
             auto in_R = make_sine_vec(total, 660.0f, sr);
 
@@ -138,7 +142,7 @@ TEST_CASE("Audio matrix: PulpGain silent-in → silent-out across SR×block",
             pulp::format::HeadlessHost host(pulp::examples::create_pulp_gain);
             host.prepare(sr, block);
 
-            constexpr int total = 2048;
+            constexpr int total = 8192;  // see unity-gain test for rationale
             std::vector<float> zeros(total, 0.0f);
             auto out = process_blocked(host, zeros, zeros, block);
 
@@ -154,10 +158,10 @@ TEST_CASE("Audio matrix: PulpGain silent-in → silent-out across SR×block",
 TEST_CASE("Audio matrix: PulpGain block-size invariance at unity",
           "[audio][matrix][determinism][issue-356]") {
     constexpr double sr = 48000.0;
-    constexpr int total = 2048;
+    constexpr int total = 8192;
 
-    pulp::format::HeadlessHost host_mono(pulp::examples::create_pulp_gain);
-    host_mono.prepare(sr, 2048);
+    pulp::format::HeadlessHost host_big(pulp::examples::create_pulp_gain);
+    host_big.prepare(sr, 4096);
 
     pulp::format::HeadlessHost host_tiny(pulp::examples::create_pulp_gain);
     host_tiny.prepare(sr, 1);
@@ -165,13 +169,15 @@ TEST_CASE("Audio matrix: PulpGain block-size invariance at unity",
     auto in_L = make_sine_vec(total, 440.0f, sr);
     auto in_R = make_sine_vec(total, 660.0f, sr);
 
-    auto out_mono = process_blocked(host_mono, in_L, in_R, 2048);
+    // block=4096 vs block=1 over 8192 samples: at least two full
+    // 4096-frame process calls against 8192 single-sample calls.
+    auto out_big  = process_blocked(host_big,  in_L, in_R, 4096);
     auto out_tiny = process_blocked(host_tiny, in_L, in_R, 1);
 
     // Unity gain is purely numeric — the host should be oblivious to
     // the block size it was prepared with for this particular path.
     for (int i = 0; i < total; ++i) {
-        REQUIRE(out_mono[static_cast<std::size_t>(i)]
+        REQUIRE(out_big[static_cast<std::size_t>(i)]
                 == out_tiny[static_cast<std::size_t>(i)]);
     }
 }
@@ -216,9 +222,11 @@ TEST_CASE("Audio matrix: PulpTone silence invariant across SR×block",
             pulp::format::HeadlessHost host(pulp::examples::create_pulp_tone);
             host.prepare(sr, block, /*inputs*/ 0, /*outputs*/ 2);
 
-            // Enough samples that any finite-grained envelope,
-            // oscillator, or DC-block state would show up as non-zero.
-            constexpr int total = 2048;
+            // 8192 samples, a clean multiple of every sweep block size
+            // including 4096 (no short last block). Any finite-grained
+            // envelope / oscillator / DC-block state would show up as
+            // non-zero over this window.
+            constexpr int total = 8192;
             std::vector<float> out_L(total, 0.0f);
             std::vector<float> out_R(total, 0.0f);
 

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -173,10 +173,16 @@ TEST_CASE("pulp validate --strict is a recognized flag",
     // Run from /tmp so resolve_active_project_root() bails with
     // "not in a Pulp project directory". Flag parsing runs first, so
     // --strict passes through cleanly and we hit exit 1, not 2.
+    //
+    // NB: resolve the absolute binary path up front. run_pulp's
+    // pulp_binary() is cwd-relative ("<cwd>/../tools/cli/pulp"), so
+    // if we swap cwd to /tmp first the lookup resolves to a path
+    // that doesn't exist and we never actually run the CLI.
+    const auto bin = fs::absolute(pulp_binary());
     auto cwd_saver = fs::current_path();
     fs::current_path(fs::temp_directory_path());
-    auto strict = run_pulp({"validate", "--strict"});
-    auto bogus = run_pulp({"validate", "--this-flag-does-not-exist"});
+    auto strict = exec(bin.string(), {"validate", "--strict"}, 10000);
+    auto bogus = exec(bin.string(), {"validate", "--this-flag-does-not-exist"}, 10000);
     fs::current_path(cwd_saver);
 
     REQUIRE_FALSE(strict.timed_out);

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -157,37 +157,41 @@ TEST_CASE("pulp help output lists the top-level subcommands",
 }
 
 // #51 / #356: `pulp validate --strict` is supposed to upgrade
-// skipped-because-missing-tool into a hard failure. Running it from
-// outside a Pulp project is the cheapest way to exercise the flag
-// parser — we know the command exits 1 early ("not in a Pulp project")
-// so all we're really asserting here is that `--strict` doesn't make
-// the CLI reject the invocation as an unknown flag or crash.
+// skipped-because-missing-tool into a hard failure.
 //
-// The full behaviour (advisory text + missing-tool enumeration + exit
-// code gating) is validated by hand in dev with a real build tree;
-// shell-out tests can't install/uninstall clap-validator.
+// cmd_validate now parses flags up-front and rejects unknown flags
+// with exit code 2 — that gives us a testable distinction between
+// "known flag, can't run because no project" and "unknown flag"
+// without needing a real build tree. Codex P2 on PR #381 correctly
+// flagged that the prior version of this test couldn't tell the two
+// apart: unknown flags were silently ignored, so the assertion would
+// pass even if --strict handling were removed.
 TEST_CASE("pulp validate --strict is a recognized flag",
           "[cli][shellout][validate][issue-356]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
 
-    // Run from /tmp so resolve_active_project_root() bails fast with
-    // "not in a Pulp project directory" rather than trying to validate
-    // anything real.
+    // Run from /tmp so resolve_active_project_root() bails with
+    // "not in a Pulp project directory". Flag parsing runs first, so
+    // --strict passes through cleanly and we hit exit 1, not 2.
     auto cwd_saver = fs::current_path();
     fs::current_path(fs::temp_directory_path());
-    auto r = run_pulp({"validate", "--strict"});
+    auto strict = run_pulp({"validate", "--strict"});
+    auto bogus = run_pulp({"validate", "--this-flag-does-not-exist"});
     fs::current_path(cwd_saver);
 
-    REQUIRE_FALSE(r.timed_out);
-    // Expected: non-zero exit ("not in a Pulp project"). The failure
-    // we're guarding against is --strict being rejected as unknown
-    // before reaching the project-root check.
-    REQUIRE(r.exit_code != 0);
-    // stderr should NOT say "unknown" / "unrecognized" for --strict.
-    // The CLI currently silently ignores unknown flags, so the best
-    // signal we have is the diagnostic mentioning the project state.
-    const bool unknown_flag_error =
-        r.stderr_output.find("unknown flag") != std::string::npos
-        || r.stderr_output.find("unrecognized") != std::string::npos;
-    REQUIRE_FALSE(unknown_flag_error);
+    REQUIRE_FALSE(strict.timed_out);
+    REQUIRE_FALSE(bogus.timed_out);
+
+    // --strict is known: flag parser accepts, we fall through to the
+    // project-root bail-out, exit 1.
+    REQUIRE(strict.exit_code == 1);
+    REQUIRE(strict.stderr_output.find("unknown flag") == std::string::npos);
+
+    // Unknown flag: rejected with exit 2 before the project-root check
+    // even runs. If cmd_validate ever silently swallows unknown flags
+    // again, this fails loudly and --strict handling is protected.
+    REQUIRE(bogus.exit_code == 2);
+    REQUIRE(bogus.stderr_output.find("unknown flag") != std::string::npos);
+    REQUIRE(bogus.stderr_output.find("--this-flag-does-not-exist")
+            != std::string::npos);
 }

--- a/tools/cli/cmd_validate.cpp
+++ b/tools/cli/cmd_validate.cpp
@@ -12,19 +12,11 @@
 #include <pulp/format/editor_ui.hpp>
 
 int cmd_validate(const std::vector<std::string>& args) {
-    auto root = resolve_active_project_root(nullptr);
-    if (root.empty()) {
-        std::cerr << "Error: not in a Pulp project directory\n";
-        return 1;
-    }
-
-    auto build_dir = root / "build";
-    if (!fs::exists(build_dir)) {
-        std::cerr << "Build directory not found. Run `pulp build` first.\n";
-        return 1;
-    }
-
-    // Parse flags
+    // Parse flags first so invalid flags fail loud before we do any
+    // project-root / build-dir work. Codex P2 on PR #381 flagged that
+    // the shellout test couldn't actually distinguish `--strict` from
+    // any other unknown flag because flag parsing ran after the
+    // project-root check bail-out.
     bool run_all = false;
     bool json_output = false;
     bool screenshot = false;
@@ -37,6 +29,24 @@ int cmd_validate(const std::vector<std::string>& args) {
         else if (args[i] == "--strict") strict = true;
         else if (args[i] == "--report" && i + 1 < args.size())
             report_path = args[++i];
+        else if (args[i].size() >= 2 && args[i].substr(0, 2) == "--") {
+            std::cerr << "pulp validate: unknown flag: " << args[i] << "\n";
+            std::cerr << "Known flags: --all --json --screenshot --strict "
+                         "--report <path>\n";
+            return 2;
+        }
+    }
+
+    auto root = resolve_active_project_root(nullptr);
+    if (root.empty()) {
+        std::cerr << "Error: not in a Pulp project directory\n";
+        return 1;
+    }
+
+    auto build_dir = root / "build";
+    if (!fs::exists(build_dir)) {
+        std::cerr << "Build directory not found. Run `pulp build` first.\n";
+        return 1;
     }
 
     int total = 0, passed = 0, failed = 0, skipped = 0;


### PR DESCRIPTION
## Summary

Three targeted follow-ups from Codex review comments on the audio
validation work that landed this session. All P2, all legitimate.

## PR #378 — audio determinism matrix

**Problem:** sweep advertised coverage for \`block=4096\` but
\`total=2048\` meant every 4096 cell short-blocked via
\`min(block, total-pos)\`. The full 4096-frame path was never actually
exercised. ([Codex comment](https://github.com/danielraffel/pulp/pull/378#discussion))

**Fix:** bump \`total\` to 8192 (smallest LCM-multiple of every
swept block size). 4096 cells now run two full blocks. Unity-gain,
silence sweeps, and the block-size-invariance test also use 4096 vs 1.

Assertion count: **248,833 → 992,257**.

## PR #379 — drums \"while sequencing\"

**Problem:** single 512-sample block at 200 BPM was < samples_per_step
(≈3600), so \`midi_out\` was always empty and the test never actually
exercised the "while sequencing" path it claimed to guard.

**Fix:** loop 20 blocks and \`REQUIRE(midi_observed)\`. Bit-exact
pass-through is asserted on every block, including the ones that
carry step events.

## PR #381 — cmd_validate flag parsing

**Problem:** flag parsing ran AFTER the project-root bail, and
unknown flags were silently ignored. The shellout test couldn't
distinguish \`--strict\` from \`--bogus-flag\`; it would have passed
even if \`--strict\` handling were removed entirely.

**Fix:** parse flags up front, reject unknown \`--foo\` with exit 2
and an explicit \"unknown flag\" diagnostic. Test now runs both
\`--strict\` (expects exit 1, no "unknown flag") and
\`--this-flag-does-not-exist\` (expects exit 2 with the name echoed).

## Test plan

- [x] \`pulp-test-audio-matrix\`: 992,257 assertions green.
- [x] \`pulp-drums-test\`: 6 cases / 20,493 assertions green.
- [x] \`pulp-test-cli-shellout\`: 8 cases green.
- [ ] Linux / Windows CI via shipyard.

## Skill trailer

The cmd_validate change is a flag-parsing reorder + unknown-flag
rejection. The cli-maintenance skill already covers the "exit code
follows failed > 0 first" contract, so there's no new policy to
document — using the skip trailer to audit that decision.