### PR TITLE
view(win): fix UIAutomationCore.h MSVC include order + unblock releases v0.19.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.18.0
+    VERSION 0.19.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/platform/win/accessibility_win.cpp
+++ b/core/view/platform/win/accessibility_win.cpp
@@ -13,6 +13,15 @@
 #include <pulp/view/view.hpp>
 #include <pulp/runtime/log.hpp>
 #include <pulp/platform/win32_sane.hpp>
+// win32_sane.hpp defines WIN32_LEAN_AND_MEAN which strips COM headers
+// from <windows.h>. UIAutomation.h needs IUnknown from ObjBase.h, and
+// ITextProvider* interfaces from oleidl.h, otherwise MSVC fails with
+// C2146 ("missing ';' before IRawElementProviderSimple", v0.17.0) or
+// C2371 ("ITextRangeProvider redefinition; different basic types",
+// v0.18.0) — both symptoms of the same COM-base-types mismatch.
+// See release-cli.yml failures on tags v0.15.0–v0.18.0.
+#include <ObjBase.h>
+#include <oleidl.h>
 #include <UIAutomation.h>
 
 namespace pulp::view {


### PR DESCRIPTION
## Why releases are stuck at v0.14.0

Addresses user's question: **\`release-cli.yml\` has been silently failing on Windows x64 for every tag since v0.14.0**.

- v0.14.0 (2026-04-16) — last successful release.
- v0.15.0, v0.16.0, v0.17.0, v0.18.0 — tags pushed by \`auto-release.yml\` but Windows x64 build in \`release-cli.yml\` failed, so no binaries published.
- GitHub Releases stops at v0.14.0 because that's the last tag whose \`release-cli.yml\` run completed successfully.

The divergence is specifically between \`build.yml\` (PR gate — passes on every recent PR) and \`release-cli.yml\` (tag-triggered release builder — fails on MSVC). They're the same source, different CMake config; something in the release path exposes the bug \`build.yml\` doesn't.

## Root cause

\`win32_sane.hpp\` defines \`WIN32_LEAN_AND_MEAN\`, which strips OLE/COM
headers from \`<windows.h>\`. When \`<UIAutomation.h>\` is then included,
its internal forward declarations at the top of UIAutomationCore.h
(ITextRangeProvider, ITextProvider, ITextProvider2,
IDropTargetProvider) get different COM basic types than the full
interface definitions later in the same header. MSVC refuses to
reconcile the two:

- **v0.17.0** (build log):  \`C2146 missing ';' before IRawElementProviderSimple\`
- **v0.18.0** (build log):  \`C2371 ITextRangeProvider: redefinition; different basic types\`

Both symptoms, one cause: COM base types aren't visible yet when
UIA's forward decls compile.

## Fix

Include \`<ObjBase.h>\` (\`IUnknown\` + COM basic types) and \`<oleidl.h>\`
(drop-target interfaces) explicitly BEFORE \`<UIAutomation.h>\` in
\`core/view/platform/win/accessibility_win.cpp\`. This restores the
same inclusion order a non-LEAN \`<windows.h>\` would have given us,
without reverting LEAN-AND-MEAN across the project.

## Why this PR also bumps SDK to 0.19.0

The version is already at 0.18.0 on main, but v0.18.0's \`release-cli.yml\`
failed. To actually re-run the release builder with the fix in source,
we need a new tag — hence the bump to 0.19.0.

- \`Version-Bump: sdk=minor\` trailer tells \`version_bump_check.py\`
  this bump is intentional.
- \`Release-Unblock:\` trailer documents the skipped-release context.

## Note re: PR #327

PR #327 had a similar fix but is stale (branched off when main was
at 0.17.0; carries extra CHANGELOG/CLAUDE.md/versioning.md churn).
This PR is a minimal, main-based alternative. Close #327 on merge.

## Test plan

- [x] \`build.yml\` Windows x64 already passes on every recent PR — this change is additive.
- [ ] Full Shipyard validation (macOS/Linux/Windows).
- [ ] **After merge + v0.19.0 tag**: watch \`release-cli.yml\` produce a complete artefact set on all 5 platforms.
- [ ] Verify v0.19.0 GitHub Release lists binaries for darwin-arm64 / darwin-x64 / linux-x64 / linux-arm64 / windows-x64.

Closes the release-pipeline drift that the user asked about.