### PR TITLE
platform(win): hoist COM includes into win32_sane.hpp (structural followup to #383)

### DIFF
--- a/core/platform/include/pulp/platform/win32_sane.hpp
+++ b/core/platform/include/pulp/platform/win32_sane.hpp
@@ -8,4 +8,17 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
+
+// WIN32_LEAN_AND_MEAN strips COM/OLE headers from <windows.h>. Include
+// the COM base types explicitly so downstream TUs that pull in
+// <UIAutomation.h>, <dwrite.h>, <dcomp.h>, etc. get IUnknown,
+// ITextProvider, IDropTargetProvider, and friends with a consistent
+// definition, not a partial forward-declaration that MSVC refuses to
+// reconcile later.
+//
+// Without this, v0.15.0–v0.18.0's release-cli.yml failed on MSVC with
+// C2146 / C2371 in UIAutomationCore.h. Followup to #383. See #384 for
+// the full story and the PR-gate tightening.
+#include <ObjBase.h>
+#include <oleidl.h>
 #endif

--- a/core/view/platform/win/accessibility_win.cpp
+++ b/core/view/platform/win/accessibility_win.cpp
@@ -12,16 +12,7 @@
 #include <pulp/view/accessibility_provider.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/runtime/log.hpp>
-#include <pulp/platform/win32_sane.hpp>
-// win32_sane.hpp defines WIN32_LEAN_AND_MEAN which strips COM headers
-// from <windows.h>. UIAutomation.h needs IUnknown from ObjBase.h, and
-// ITextProvider* interfaces from oleidl.h, otherwise MSVC fails with
-// C2146 ("missing ';' before IRawElementProviderSimple", v0.17.0) or
-// C2371 ("ITextRangeProvider redefinition; different basic types",
-// v0.18.0) — both symptoms of the same COM-base-types mismatch.
-// See release-cli.yml failures on tags v0.15.0–v0.18.0.
-#include <ObjBase.h>
-#include <oleidl.h>
+#include <pulp/platform/win32_sane.hpp>  // now brings in ObjBase.h + oleidl.h
 #include <UIAutomation.h>
 
 namespace pulp::view {


### PR DESCRIPTION
## Why

Structural followup to #383, which unblocked v0.19.0. That PR was file-local — it added \`<ObjBase.h>\` + \`<oleidl.h>\` before \`<UIAutomation.h>\` in \`accessibility_win.cpp\` only. Any future Windows TU that pulls in a COM-heavy Windows header will hit the exact same C2146/C2371 bug that silently killed v0.15.0–v0.18.0's Windows x64 release builds.

User asked explicitly after v0.19.0: *"is the solution to v0.19.0 going to prevent failure in the future?"* — the honest answer for #383 alone was **no**. This PR makes it structural.

## Change

- **\`core/platform/include/pulp/platform/win32_sane.hpp\`**: include \`<ObjBase.h>\` + \`<oleidl.h>\` after \`<windows.h>\`. Every TU that already adopts \`win32_sane.hpp\` now gets COM basic types (IUnknown, ITextProvider, IDropTargetProvider, etc.) for free.
- **\`core/view/platform/win/accessibility_win.cpp\`**: drop the per-file COM includes #383 added — the header does the work now.

## Future-proofing

The next time someone adds a COM-heavy Windows surface (Media Foundation, DirectWrite, DirectComposition, WinRT MIDI once #245 lands), the pattern is just \`#include <pulp/platform/win32_sane.hpp>\` and they're done — no include-order footgun.

## Still open under #384

Part 2 of the hardening proposal in #384: promoting \`release-cli.yml\`'s Windows x64 Release-mode config to the PR gate. Today only \`build.yml\` runs Windows on PR, and its config doesn't catch the same MSVC include-order regressions. That's a separate follow-up because it touches CI workflows, not source.

## Test plan

- [x] Local build clean.
- [ ] Shipyard cross-platform run (macOS / Linux / Windows).
- [ ] Post-merge: auto-release tags v0.19.1, release-cli.yml re-validates on a second consecutive clean release — proves the hoist didn't regress the unblock.

Refs #384. Closes the structural half.