### PR TITLE
audio(win): WASAPI capture endpoint + flow-aware device routing (#243)

### DIFF
--- a/core/audio/platform/win/wasapi_device.cpp
+++ b/core/audio/platform/win/wasapi_device.cpp
@@ -13,8 +13,8 @@ namespace pulp::audio::win {
 
 // ── WasapiDevice ─────────────────────────────────────────────────────────
 
-WasapiDevice::WasapiDevice(IMMDevice* device)
-    : device_(device)
+WasapiDevice::WasapiDevice(IMMDevice* device, EDataFlow flow)
+    : device_(device), flow_(flow)
 {
     // Caller has already AddRef'd
 }
@@ -46,9 +46,15 @@ bool WasapiDevice::open(const DeviceConfig& config) {
         return false;
     }
 
-    // Use the device's native format in shared mode
-    // Record the actual channel count and sample rate
-    actual_channels_ = std::min(static_cast<int>(mix_format->nChannels), config_.output_channels);
+    // Use the device's native format in shared mode. Pick the channel
+    // budget based on direction — capture uses input_channels, render
+    // uses output_channels.
+    const int requested_channels = (flow_ == eCapture)
+        ? config_.input_channels
+        : config_.output_channels;
+    actual_channels_ = std::min(
+        static_cast<int>(mix_format->nChannels),
+        std::max(requested_channels, 1));
     config_.sample_rate = static_cast<double>(mix_format->nSamplesPerSec);
 
     // Calculate buffer duration from requested buffer size
@@ -100,37 +106,57 @@ bool WasapiDevice::open(const DeviceConfig& config) {
     }
     config_.buffer_size = static_cast<int>(buffer_frames_);
 
-    // Get the render client interface
-    hr = audio_client_->GetService(
-        __uuidof(IAudioRenderClient),
-        reinterpret_cast<void**>(&render_client_));
-    if (FAILED(hr)) {
-        runtime::log_error("WASAPI: could not get render client (0x{:08x})", static_cast<unsigned>(hr));
-        close();
-        return false;
+    // Get the direction-specific service interface.
+    if (flow_ == eCapture) {
+        hr = audio_client_->GetService(
+            __uuidof(IAudioCaptureClient),
+            reinterpret_cast<void**>(&capture_client_));
+        if (FAILED(hr)) {
+            runtime::log_error(
+                "WASAPI: could not get capture client (0x{:08x})",
+                static_cast<unsigned>(hr));
+            close();
+            return false;
+        }
+    } else {
+        hr = audio_client_->GetService(
+            __uuidof(IAudioRenderClient),
+            reinterpret_cast<void**>(&render_client_));
+        if (FAILED(hr)) {
+            runtime::log_error(
+                "WASAPI: could not get render client (0x{:08x})",
+                static_cast<unsigned>(hr));
+            close();
+            return false;
+        }
     }
 
-    // Pre-allocate deinterleave buffers
+    // Pre-allocate planar channel buffers (used as output destinations
+    // for render and as the input the user sees in BufferView<const>
+    // for capture).
     channel_buffers_.resize(actual_channels_);
-    output_ptrs_.resize(actual_channels_);
+    channel_ptrs_.resize(actual_channels_);
     for (int ch = 0; ch < actual_channels_; ++ch) {
         channel_buffers_[ch].resize(buffer_frames_, 0.0f);
-        output_ptrs_[ch] = channel_buffers_[ch].data();
+        channel_ptrs_[ch] = channel_buffers_[ch].data();
     }
 
     is_open_ = true;
-    runtime::log_info("WASAPI: opened device '{}' at {} Hz, buffer {} frames, {} channels",
+    runtime::log_info(
+        "WASAPI: opened {} device '{}' at {} Hz, buffer {} frames, {} channels",
+        flow_ == eCapture ? "capture" : "render",
         info().name, config_.sample_rate, buffer_frames_, actual_channels_);
     return true;
 }
 
 void WasapiDevice::close() {
-    if (render_client_) { render_client_->Release(); render_client_ = nullptr; }
-    if (audio_client_) { audio_client_->Release(); audio_client_ = nullptr; }
-    if (buffer_event_) { CloseHandle(buffer_event_); buffer_event_ = nullptr; }
-    if (stop_event_) { CloseHandle(stop_event_); stop_event_ = nullptr; }
+    if (render_client_)  { render_client_->Release();  render_client_  = nullptr; }
+    if (capture_client_) { capture_client_->Release(); capture_client_ = nullptr; }
+    if (audio_client_)   { audio_client_->Release();   audio_client_   = nullptr; }
+    if (buffer_event_)   { CloseHandle(buffer_event_); buffer_event_   = nullptr; }
+    if (stop_event_)     { CloseHandle(stop_event_);   stop_event_     = nullptr; }
     channel_buffers_.clear();
-    output_ptrs_.clear();
+    channel_ptrs_.clear();
     is_open_ = false;
 }
 
@@ -142,25 +168,34 @@ bool WasapiDevice::start(AudioCallback callback) {
     // Reset stop event
     ResetEvent(stop_event_);
 
-    // Pre-fill the buffer with silence before starting
-    BYTE* data = nullptr;
-    HRESULT hr = render_client_->GetBuffer(buffer_frames_, &data);
-    if (SUCCEEDED(hr)) {
-        std::memset(data, 0, buffer_frames_ * actual_channels_ * sizeof(float));
-        render_client_->ReleaseBuffer(buffer_frames_, 0);
+    // Pre-fill render buffer with silence so the first event fires
+    // promptly. Capture has nothing to pre-fill; the first capture
+    // packet arrives once Start() returns.
+    if (flow_ == eRender) {
+        BYTE* data = nullptr;
+        HRESULT hr = render_client_->GetBuffer(buffer_frames_, &data);
+        if (SUCCEEDED(hr)) {
+            std::memset(data, 0,
+                buffer_frames_ * actual_channels_ * sizeof(float));
+            render_client_->ReleaseBuffer(buffer_frames_, 0);
+        }
     }
 
     // Start the audio stream
-    hr = audio_client_->Start();
+    HRESULT hr = audio_client_->Start();
     if (FAILED(hr)) {
-        runtime::log_error("WASAPI: could not start audio client (0x{:08x})", static_cast<unsigned>(hr));
+        runtime::log_error("WASAPI: could not start audio client (0x{:08x})",
+            static_cast<unsigned>(hr));
         return false;
     }
 
     is_running_.store(true, std::memory_order_release);
 
-    // Launch the render thread
-    render_thread_ = std::thread([this] { render_thread_func(); });
+    // Launch the direction-specific I/O thread
+    io_thread_ = std::thread([this] {
+        if (flow_ == eCapture) capture_thread_func();
+        else                    render_thread_func();
+    });
 
     return true;
 }
@@ -168,14 +203,11 @@ bool WasapiDevice::start(AudioCallback callback) {
 void WasapiDevice::stop() {
     if (!is_running_.load(std::memory_order_acquire)) return;
 
-    // Signal the render thread to stop
+    // Signal the I/O thread to stop
     is_running_.store(false, std::memory_order_release);
     if (stop_event_) SetEvent(stop_event_);
 
-    // Wait for the render thread to finish
-    if (render_thread_.joinable()) {
-        render_thread_.join();
-    }
+    if (io_thread_.joinable()) io_thread_.join();
 
     if (audio_client_) {
         audio_client_->Stop();
@@ -233,15 +265,15 @@ void WasapiDevice::render_thread_func() {
             for (int ch = 0; ch < actual_channels_; ++ch) {
                 if (channel_buffers_[ch].size() < available) {
                     channel_buffers_[ch].resize(available);
-                    output_ptrs_[ch] = channel_buffers_[ch].data();
+                    channel_ptrs_[ch] = channel_buffers_[ch].data();
                 }
                 // Clear the buffers
-                std::memset(output_ptrs_[ch], 0, available * sizeof(float));
+                std::memset(channel_ptrs_[ch], 0, available * sizeof(float));
             }
 
             // Call the user callback with non-interleaved buffers
-            BufferView<const float> input_view;  // No input for now
-            BufferView<float> output_view(output_ptrs_.data(),
+            BufferView<const float> input_view;  // No input on render path
+            BufferView<float> output_view(channel_ptrs_.data(),
                 static_cast<size_t>(actual_channels_), available);
 
             CallbackContext ctx;
@@ -254,7 +286,7 @@ void WasapiDevice::render_thread_func() {
             // Interleave the output into WASAPI's buffer
             for (UINT32 frame = 0; frame < available; ++frame) {
                 for (int ch = 0; ch < actual_channels_; ++ch) {
-                    interleaved[frame * actual_channels_ + ch] = output_ptrs_[ch][frame];
+                    interleaved[frame * actual_channels_ + ch] = channel_ptrs_[ch][frame];
                 }
             }
         } else {
@@ -264,6 +296,106 @@ void WasapiDevice::render_thread_func() {
 
         render_client_->ReleaseBuffer(available, 0);
         sample_position_ += available;
+    }
+}
+
+// ── Capture thread (issue #243) ─────────────────────────────────────
+//
+// WASAPI capture is event-driven the same way render is: the buffer
+// event fires when a packet is ready. Each iteration we drain every
+// available packet, deinterleave it into the per-channel buffers,
+// and hand the user the input BufferView. There's no output to fill,
+// so the user's output buffer is empty.
+//
+// Discontinuity / silent packets are reported via the AUDCLNT_BUFFERFLAGS
+// returned by GetBuffer; we honour AUDCLNT_BUFFERFLAGS_SILENT by
+// memset-ing the input to zero rather than copying garbage.
+void WasapiDevice::capture_thread_func() {
+    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+
+    HANDLE wait_handles[] = { buffer_event_, stop_event_ };
+
+    while (is_running_.load(std::memory_order_relaxed)) {
+        DWORD result = WaitForMultipleObjects(2, wait_handles, FALSE, 2000);
+
+        if (result == WAIT_OBJECT_0 + 1) break;          // stop event
+        if (result == WAIT_TIMEOUT)      continue;
+        if (result != WAIT_OBJECT_0) {
+            runtime::log_error("WASAPI capture: wait failed ({})", result);
+            break;
+        }
+
+        // Drain all packets that arrived while we were sleeping. WASAPI
+        // returns packets one at a time; we keep going until
+        // GetNextPacketSize == 0.
+        UINT32 packet_frames = 0;
+        HRESULT hr = capture_client_->GetNextPacketSize(&packet_frames);
+        if (FAILED(hr)) continue;
+
+        while (packet_frames > 0 && is_running_.load(std::memory_order_relaxed)) {
+            BYTE*  data         = nullptr;
+            UINT32 frames       = 0;
+            DWORD  flags        = 0;
+
+            hr = capture_client_->GetBuffer(&data, &frames, &flags, nullptr, nullptr);
+            if (FAILED(hr) || frames == 0) {
+                if (SUCCEEDED(hr)) capture_client_->ReleaseBuffer(frames);
+                break;
+            }
+
+            // Resize per-channel buffers if the packet is bigger than
+            // we pre-allocated for.
+            for (int ch = 0; ch < actual_channels_; ++ch) {
+                if (channel_buffers_[ch].size() < frames) {
+                    channel_buffers_[ch].resize(frames);
+                    channel_ptrs_[ch] = channel_buffers_[ch].data();
+                }
+            }
+
+            const bool silent = (flags & AUDCLNT_BUFFERFLAGS_SILENT) != 0;
+            if (silent || data == nullptr) {
+                for (int ch = 0; ch < actual_channels_; ++ch) {
+                    std::memset(channel_ptrs_[ch], 0, frames * sizeof(float));
+                }
+            } else {
+                // Deinterleave WASAPI's packed format into planar
+                // per-channel buffers. WASAPI gives us the device's
+                // mix format which we already negotiated to float.
+                auto* src = reinterpret_cast<const float*>(data);
+                for (UINT32 frame = 0; frame < frames; ++frame) {
+                    for (int ch = 0; ch < actual_channels_; ++ch) {
+                        channel_ptrs_[ch][frame] =
+                            src[frame * actual_channels_ + ch];
+                    }
+                }
+            }
+
+            capture_client_->ReleaseBuffer(frames);
+
+            if (callback_) {
+                // Capture has no output buffer to fill — the user gets
+                // an empty BufferView<float>. They can still react
+                // (forwarding to a render device, recording to disk,
+                // running analysis) — same model as portaudio's
+                // input-only callback.
+                BufferView<const float> input_view(
+                    const_cast<const float**>(channel_ptrs_.data()),
+                    static_cast<size_t>(actual_channels_), frames);
+                BufferView<float> output_view;
+
+                CallbackContext ctx;
+                ctx.sample_rate = config_.sample_rate;
+                ctx.buffer_size = static_cast<int>(frames);
+                ctx.sample_position = sample_position_;
+
+                callback_(input_view, output_view, ctx);
+            }
+
+            sample_position_ += frames;
+
+            hr = capture_client_->GetNextPacketSize(&packet_frames);
+            if (FAILED(hr)) break;
+        }
     }
 }
 
@@ -508,7 +640,20 @@ std::unique_ptr<AudioDevice> WasapiSystem::create_device(const std::string& devi
         }
     }
 
-    return std::make_unique<WasapiDevice>(device);
+    // Query the endpoint's data flow so the WasapiDevice knows whether
+    // to take the render or capture path. Default to render if the
+    // query fails (matches the prior behaviour and the empty-id branch
+    // above).
+    EDataFlow flow = eRender;
+    IMMEndpoint* endpoint = nullptr;
+    if (SUCCEEDED(device->QueryInterface(__uuidof(IMMEndpoint),
+                                         reinterpret_cast<void**>(&endpoint)))
+        && endpoint) {
+        endpoint->GetDataFlow(&flow);
+        endpoint->Release();
+    }
+
+    return std::make_unique<WasapiDevice>(device, flow);
 }
 
 DeviceInfo WasapiSystem::default_output_device() {

--- a/core/audio/platform/win/wasapi_device.hpp
+++ b/core/audio/platform/win/wasapi_device.hpp
@@ -21,10 +21,16 @@
 
 namespace pulp::audio::win {
 
-// WASAPI shared-mode audio device with event-driven rendering
+// WASAPI shared-mode audio device with event-driven I/O.
+//
+// A single instance wraps EITHER a render endpoint OR a capture
+// endpoint; the EDataFlow passed at construction selects which path
+// open() / start() take. Duplex callers open two devices and
+// synchronise externally — same model as the rest of the AudioSystem
+// interface, which is direction-agnostic at the device level.
 class WasapiDevice : public AudioDevice {
 public:
-    explicit WasapiDevice(IMMDevice* device);  // Takes ownership (AddRef'd by caller)
+    explicit WasapiDevice(IMMDevice* device, EDataFlow flow = eRender);
     ~WasapiDevice() override;
 
     bool open(const DeviceConfig& config) override;
@@ -38,16 +44,22 @@ public:
     double sample_rate() const override { return config_.sample_rate; }
     int buffer_size() const override { return config_.buffer_size; }
 
+    /// Direction this device wraps. eRender = output, eCapture = input.
+    EDataFlow flow() const { return flow_; }
+
     // Shared helpers used by WasapiSystem during device enumeration.
     static std::wstring get_device_name(IMMDevice* device);
     static std::string wide_to_utf8(const std::wstring& wide);
 
 private:
     void render_thread_func();
+    void capture_thread_func();
 
-    IMMDevice* device_ = nullptr;
-    IAudioClient* audio_client_ = nullptr;
-    IAudioRenderClient* render_client_ = nullptr;
+    IMMDevice*           device_         = nullptr;
+    EDataFlow            flow_           = eRender;
+    IAudioClient*        audio_client_   = nullptr;
+    IAudioRenderClient*  render_client_  = nullptr;  // populated when flow_ == eRender
+    IAudioCaptureClient* capture_client_ = nullptr;  // populated when flow_ == eCapture
     HANDLE buffer_event_ = nullptr;
     HANDLE stop_event_ = nullptr;
 
@@ -59,11 +71,13 @@ private:
     UINT32 buffer_frames_ = 0;
     int actual_channels_ = 0;
 
-    std::thread render_thread_;
+    std::thread io_thread_;
 
-    // Deinterleave buffer for callback
+    // Deinterleave / planar buffers for the callback.  For render
+    // direction these are output channels; for capture they're the
+    // input channels we hand to the user via BufferView<const float>.
     std::vector<std::vector<float>> channel_buffers_;
-    std::vector<float*> output_ptrs_;
+    std::vector<float*> channel_ptrs_;
 };
 
 class WasapiNotificationClient;  // fwd, issue #243 hotplug

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -262,6 +262,14 @@ catch_discover_tests(pulp-test-uia-mapping)
 add_executable(pulp-test-audio-system-hotplug test_audio_system_hotplug.cpp)
 target_link_libraries(pulp-test-audio-system-hotplug PRIVATE pulp::audio Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-audio-system-hotplug)
+
+# WASAPI capture path (#243). Windows-only; cross-platform stub keeps
+# CI green elsewhere. Skips at runtime on hosts without a default
+# capture endpoint.
+add_executable(pulp-test-wasapi-input test_wasapi_input.cpp)
+target_link_libraries(pulp-test-wasapi-input PRIVATE pulp::audio Catch2::Catch2WithMain)
+target_include_directories(pulp-test-wasapi-input PRIVATE ${CMAKE_SOURCE_DIR})
+catch_discover_tests(pulp-test-wasapi-input)
 # Processor on_host_tempo_changed hook (workstream 01 slice 1.10)
 add_executable(pulp-test-tempo-hook test_tempo_hook.cpp)
 target_link_libraries(pulp-test-tempo-hook PRIVATE pulp::format Catch2::Catch2WithMain)

--- a/test/test_wasapi_input.cpp
+++ b/test/test_wasapi_input.cpp
@@ -1,0 +1,129 @@
+// WASAPI capture path tests (issue #243). Windows-only; gracefully
+// skips when run on a host without any active capture endpoint
+// (headless VMs, CI runners with no audio device, etc.) so the suite
+// stays green on every platform without losing the validation when
+// real input hardware IS present.
+
+#include <catch2/catch_test_macros.hpp>
+
+#ifdef _WIN32
+
+#include <pulp/audio/device.hpp>
+#include "../core/audio/platform/win/wasapi_device.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace pulp::audio;
+using namespace pulp::audio::win;
+
+namespace {
+
+bool has_default_capture(WasapiSystem& sys) {
+    return !sys.default_input_device().id.empty();
+}
+
+}  // namespace
+
+TEST_CASE("WASAPI capture: default input device discovers when present",
+          "[audio][wasapi][capture][issue-243]") {
+    WasapiSystem sys;
+    auto info = sys.default_input_device();
+    if (info.id.empty()) {
+        SUCCEED("no default capture endpoint on this host; skipping");
+        return;
+    }
+    REQUIRE(info.is_default_input);
+    REQUIRE(info.max_input_channels > 0);
+    REQUIRE_FALSE(info.id.empty());
+    REQUIRE_FALSE(info.name.empty());
+}
+
+TEST_CASE("WASAPI capture: create_device on input id returns eCapture device",
+          "[audio][wasapi][capture][issue-243]") {
+    WasapiSystem sys;
+    auto info = sys.default_input_device();
+    if (info.id.empty()) {
+        SUCCEED("no default capture endpoint; skipping");
+        return;
+    }
+    auto device = sys.create_device(info.id);
+    REQUIRE(device != nullptr);
+    auto* wasapi = dynamic_cast<WasapiDevice*>(device.get());
+    REQUIRE(wasapi != nullptr);
+    REQUIRE(wasapi->flow() == eCapture);
+}
+
+TEST_CASE("WASAPI capture: open + start + stop is leak-free and terminates",
+          "[audio][wasapi][capture][issue-243]") {
+    WasapiSystem sys;
+    auto info = sys.default_input_device();
+    if (info.id.empty()) {
+        SUCCEED("no default capture endpoint; skipping");
+        return;
+    }
+    auto device = sys.create_device(info.id);
+    REQUIRE(device != nullptr);
+
+    DeviceConfig cfg;
+    cfg.device_id = info.id;
+    cfg.sample_rate = 48000.0;
+    cfg.buffer_size = 256;
+    cfg.input_channels = 2;
+    cfg.output_channels = 0;
+
+    REQUIRE(device->open(cfg));
+    REQUIRE(device->is_open());
+
+    std::atomic<int> callbacks{0};
+    REQUIRE(device->start([&](const auto& in, auto& out, const auto&) {
+        // Capture path hands us non-empty input + empty output. We
+        // only count invocations — verifying frame counts is platform-
+        // dependent and brittle.
+        (void)in;
+        (void)out;
+        callbacks.fetch_add(1, std::memory_order_relaxed);
+    }));
+    REQUIRE(device->is_running());
+
+    // Run for ~50ms — enough for several capture packets at 256 frames
+    // / 48 kHz (~5.3ms each), small enough to keep the test snappy.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    device->stop();
+    REQUIRE_FALSE(device->is_running());
+    device->close();
+    REQUIRE_FALSE(device->is_open());
+
+    // We don't assert callbacks > 0 because some headless hosts route
+    // a capture endpoint that never produces packets (e.g. virtual
+    // mic with no driver). The leak-free start/stop path is the
+    // contract under test; any callback is a bonus signal.
+}
+
+TEST_CASE("WASAPI capture: render device still constructs as eRender",
+          "[audio][wasapi][capture][issue-243][regression]") {
+    // Regression guard: the new EDataFlow plumbing must not break the
+    // existing render path. WasapiSystem::create_device() with an
+    // empty id picks the default render device, which must still come
+    // back as eRender.
+    WasapiSystem sys;
+    auto device = sys.create_device("");
+    if (!device) {
+        SUCCEED("no default render endpoint on this host; skipping");
+        return;
+    }
+    auto* wasapi = dynamic_cast<WasapiDevice*>(device.get());
+    REQUIRE(wasapi != nullptr);
+    REQUIRE(wasapi->flow() == eRender);
+}
+
+#else  // !_WIN32
+
+TEST_CASE("WASAPI capture tests build on non-Windows but no-op",
+          "[audio][wasapi][capture]") {
+    SUCCEED("WASAPI tests are Windows-only; this stub keeps CI happy.");
+}
+
+#endif


### PR DESCRIPTION
## Summary

WASAPI was render-only. This PR adds the capture path in parallel,
following the same shared-mode event-driven model the existing render
thread uses. Closes the W02-2.1 capture half of #243; exclusive-mode
flag and AVRT thread priority left as follow-ups.

## What lands

- **\`WasapiDevice\`**: now carries an \`EDataFlow\` tag set at
  construction. \`open()\` routes to \`IAudioCaptureClient\` or
  \`IAudioRenderClient\` based on the tag. \`start()\` launches a
  direction-specific thread (\`render_thread_func\` /
  \`capture_thread_func\`).
- **\`capture_thread_func\`**: drains every packet that arrives on
  the buffer event, deinterleaves into the planar channel buffers,
  honours \`AUDCLNT_BUFFERFLAGS_SILENT\` (zero-fill instead of garbage),
  and hands the user a populated \`BufferView<const float>\` input
  with an empty output (capture-only callback shape, portaudio-style).
- **\`WasapiSystem::create_device\`**: queries
  \`IMMEndpoint::GetDataFlow\` on the IMMDevice and threads the result
  through. Empty \`device_id\` still picks the default render endpoint,
  so existing render-only callers are bit-compat.

## What this PR does NOT do

- **Exclusive-mode** initialisation behind a flag — follow-up.
- **AVRT** (\`avrt.lib\`) thread priority — currently still
  \`THREAD_PRIORITY_TIME_CRITICAL\` for both directions.
- Hotplug for capture devices was already wired via the existing
  \`IMMNotificationClient\` (added under the same #243 issue earlier);
  capture endpoints surface through the same OnDeviceAdded /
  OnDeviceStateChanged path with no additional work needed.

## Tests

\`test/test_wasapi_input.cpp\` — Windows-only, gracefully skips on hosts
without a default capture endpoint (headless VMs / CI runners without
audio hardware) so it stays green everywhere. Coverage:

1. Default input device discovery returns a non-empty info when a
   capture endpoint exists.
2. \`create_device\` on an input device id returns a \`WasapiDevice\`
   whose \`flow() == eCapture\`.
3. \`open()\` + \`start()\` + \`stop()\` is leak-free and terminates within
   ~50ms (callback may or may not fire depending on host audio).
4. **Regression guard**: empty \`device_id\` still produces an
   \`eRender\` device — existing render call sites unchanged.

## Validation plan

- [x] Local macOS: stub path compiles + runs (1 assertion).
- [ ] Windows x64 via Namespace shipyard build — exercises real WASAPI
      MSVC compile and the new \`Windows MSVC release-path gate\`.
- [ ] \`ssh win\` (Intel x64) — actual capture invocations on a host
      with real audio hardware.

Closes the capture half of #243.