### PR TITLE
midi(win): MIM_LONGDATA SysEx + QPC timestamps (#19 / #245 partial)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.19.0
+    VERSION 0.20.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/device.hpp
+++ b/core/midi/include/pulp/midi/device.hpp
@@ -15,8 +15,12 @@ struct MidiPortInfo {
     bool is_output = false;
 };
 
-// Callback for received MIDI messages
+// Callback for received MIDI short (channel-voice / system-realtime)
+// messages. SysEx is delivered via MidiSysexCallback registered
+// separately so the open() signature stays bit-compat.
 using MidiInputCallback = std::function<void(const MidiEvent& event)>;
+using MidiSysexCallback = std::function<void(const std::vector<uint8_t>& bytes,
+                                             double timestamp_sec)>;
 
 // MIDI input port
 class MidiInput {
@@ -25,6 +29,13 @@ public:
     virtual bool open(const std::string& port_id, MidiInputCallback callback) = 0;
     virtual void close() = 0;
     virtual bool is_open() const = 0;
+
+    /// Optional SysEx delivery. Backends without SysEx support leave
+    /// this as a no-op; callers can still register safely. Backends
+    /// that DO support it (Win mmeapi MIM_LONGDATA, future CoreMIDI
+    /// reassembly, ALSA SND_SEQ_EVENT_SYSEX) call this BEFORE open()
+    /// to register the receiver. #19 / #239.
+    virtual void set_sysex_callback(MidiSysexCallback /*cb*/) {}
 };
 
 // MIDI output port

--- a/core/midi/platform/win/winmidi_device.cpp
+++ b/core/midi/platform/win/winmidi_device.cpp
@@ -32,6 +32,10 @@ class WinMidiInput : public MidiInput {
 public:
     ~WinMidiInput() override { close(); }
 
+    void set_sysex_callback(MidiSysexCallback cb) override {
+        sysex_callback_ = std::move(cb);
+    }
+
     bool open(const std::string& port_id, MidiInputCallback callback) override {
         callback_ = std::move(callback);
 
@@ -46,6 +50,13 @@ public:
             return false;
         }
 
+        // Snapshot QPC frequency + open-time tick so per-event
+        // timestamps are seconds-since-open with sub-millisecond
+        // resolution. mmeapi's param2 is only millisecond
+        // resolution — too coarse for high-rate sources.
+        QueryPerformanceFrequency(&qpc_freq_);
+        QueryPerformanceCounter(&qpc_open_);
+
         MMRESULT result = midiInOpen(&handle_, device_id,
             reinterpret_cast<DWORD_PTR>(midi_in_callback),
             reinterpret_cast<DWORD_PTR>(this),
@@ -55,9 +66,31 @@ public:
             return false;
         }
 
+        // Prepare and queue SysEx receive buffers (#19 / #239).
+        // Four 4 KB buffers — enough headroom for typical device
+        // dumps without flooding the driver. Driver returns each
+        // via MIM_LONGDATA when full or when an F7 arrives; we
+        // re-add it after firing the callback.
+        for (auto& slot : sysex_slots_) {
+            slot.bytes.resize(kSysexBufBytes);
+            ZeroMemory(&slot.hdr, sizeof(slot.hdr));
+            slot.hdr.lpData         = reinterpret_cast<LPSTR>(slot.bytes.data());
+            slot.hdr.dwBufferLength = static_cast<DWORD>(slot.bytes.size());
+            slot.hdr.dwUser         = reinterpret_cast<DWORD_PTR>(&slot);
+            if (midiInPrepareHeader(handle_, &slot.hdr, sizeof(slot.hdr))
+                    == MMSYSERR_NOERROR) {
+                midiInAddBuffer(handle_, &slot.hdr, sizeof(slot.hdr));
+            }
+        }
+
         result = midiInStart(handle_);
         if (result != MMSYSERR_NOERROR) {
             runtime::log_error("WinMIDI: could not start input (error {})", result);
+            for (auto& slot : sysex_slots_) {
+                if (slot.hdr.dwFlags & MHDR_PREPARED) {
+                    midiInUnprepareHeader(handle_, &slot.hdr, sizeof(slot.hdr));
+                }
+            }
             midiInClose(handle_);
             handle_ = nullptr;
             return false;
@@ -70,9 +103,21 @@ public:
     void close() override {
         if (handle_) {
             midiInStop(handle_);
+            // midiInReset returns any pending SysEx buffers via
+            // MIM_LONGDATA with dwBytesRecorded==0. Unprepare each
+            // header before closing the device.
             midiInReset(handle_);
+            for (auto& slot : sysex_slots_) {
+                if (slot.hdr.dwFlags & MHDR_PREPARED) {
+                    midiInUnprepareHeader(handle_, &slot.hdr, sizeof(slot.hdr));
+                }
+            }
             midiInClose(handle_);
             handle_ = nullptr;
+        }
+        for (auto& slot : sysex_slots_) {
+            slot.bytes.clear();
+            ZeroMemory(&slot.hdr, sizeof(slot.hdr));
         }
         is_open_ = false;
     }
@@ -80,32 +125,78 @@ public:
     bool is_open() const override { return is_open_; }
 
 private:
+    static constexpr int    kSysexSlots    = 4;
+    static constexpr size_t kSysexBufBytes = 4 * 1024;
+
+    struct SysexSlot {
+        MIDIHDR              hdr{};
+        std::vector<uint8_t> bytes;
+    };
+
     static void CALLBACK midi_in_callback(
         HMIDIIN, UINT msg, DWORD_PTR instance,
-        DWORD_PTR param1, DWORD_PTR param2)
+        DWORD_PTR param1, DWORD_PTR /*param2*/)
     {
-        if (msg != MIM_DATA) return;
-
         auto* self = reinterpret_cast<WinMidiInput*>(instance);
-        if (!self->callback_) return;
 
-        // param1 contains the MIDI message packed into a DWORD:
-        // low byte = status, next byte = data1, next byte = data2
-        auto status = static_cast<uint8_t>(param1 & 0xFF);
-        auto data1 = static_cast<uint8_t>((param1 >> 8) & 0xFF);
-        auto data2 = static_cast<uint8_t>((param1 >> 16) & 0xFF);
+        if (msg == MIM_DATA && self->callback_) {
+            auto status = static_cast<uint8_t>(param1 & 0xFF);
+            auto data1  = static_cast<uint8_t>((param1 >> 8) & 0xFF);
+            auto data2  = static_cast<uint8_t>((param1 >> 16) & 0xFF);
 
-        // param2 is the timestamp in milliseconds
-        MidiEvent evt;
-        evt.message = choc::midi::ShortMessage(status, data1, data2);
-        evt.timestamp = static_cast<double>(param2) / 1000.0;
+            MidiEvent evt;
+            evt.message   = choc::midi::ShortMessage(status, data1, data2);
+            evt.timestamp = self->qpc_seconds_since_open();
+            self->callback_(evt);
+            return;
+        }
 
-        self->callback_(evt);
+        if (msg == MIM_LONGDATA) {
+            auto* hdr = reinterpret_cast<LPMIDIHDR>(param1);
+            if (!hdr || hdr->dwBytesRecorded == 0) return;
+
+            if (self->sysex_callback_) {
+                std::vector<uint8_t> bytes(
+                    reinterpret_cast<const uint8_t*>(hdr->lpData),
+                    reinterpret_cast<const uint8_t*>(hdr->lpData)
+                        + hdr->dwBytesRecorded);
+                self->sysex_callback_(bytes,
+                    self->qpc_seconds_since_open());
+            }
+
+            // Re-arm the buffer for the next packet. dwBytesRecorded
+            // must be cleared first (driver populates it).
+            hdr->dwBytesRecorded = 0;
+            midiInAddBuffer(self->handle_, hdr, sizeof(*hdr));
+            return;
+        }
+
+        if (msg == MIM_LONGERROR) {
+            // Long packet was malformed — re-arm the buffer.
+            auto* hdr = reinterpret_cast<LPMIDIHDR>(param1);
+            if (hdr) {
+                hdr->dwBytesRecorded = 0;
+                midiInAddBuffer(self->handle_, hdr, sizeof(*hdr));
+            }
+        }
     }
 
-    HMIDIIN handle_ = nullptr;
-    MidiInputCallback callback_;
-    bool is_open_ = false;
+    double qpc_seconds_since_open() const {
+        if (qpc_freq_.QuadPart == 0) return 0.0;
+        LARGE_INTEGER now;
+        QueryPerformanceCounter(&now);
+        const auto ticks = now.QuadPart - qpc_open_.QuadPart;
+        return static_cast<double>(ticks)
+             / static_cast<double>(qpc_freq_.QuadPart);
+    }
+
+    HMIDIIN            handle_ = nullptr;
+    MidiInputCallback  callback_;
+    MidiSysexCallback  sysex_callback_;
+    bool               is_open_ = false;
+    LARGE_INTEGER      qpc_freq_{};
+    LARGE_INTEGER      qpc_open_{};
+    SysexSlot          sysex_slots_[kSysexSlots]{};
 };
 
 // ── WinMidiOutput ────────────────────────────────────────────────────────

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -241,6 +241,12 @@ catch_discover_tests(pulp-test-midi-buffer-ump)
 add_executable(pulp-test-midi-buffer-sysex test_midi_buffer_sysex.cpp)
 target_link_libraries(pulp-test-midi-buffer-sysex PRIVATE pulp::midi Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-midi-buffer-sysex)
+# Win MIDI MIM_LONGDATA SysEx + QPC timestamps (#19 / #245 partial).
+# Cross-platform — compiles everywhere; Windows-specific cases are
+# guarded behind #ifdef _WIN32.
+add_executable(pulp-test-winmidi-sysex test_winmidi_sysex.cpp)
+target_link_libraries(pulp-test-winmidi-sysex PRIVATE pulp::midi Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-winmidi-sysex)
 # Accessibility provider cross-platform entry (workstream 04 slices 4.1 + 4.2)
 add_executable(pulp-test-accessibility-provider test_accessibility_provider.cpp)
 target_link_libraries(pulp-test-accessibility-provider PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_winmidi_sysex.cpp
+++ b/test/test_winmidi_sysex.cpp
@@ -1,0 +1,56 @@
+// Win MIDI MIM_LONGDATA SysEx + QPC timestamp tests (#19 / #245 partial).
+// Windows-only; gracefully skips on hosts without a default input
+// device. The cross-platform stub ensures CI on macOS/Linux still
+// links + runs.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/midi/device.hpp>
+
+TEST_CASE("MidiInput: sysex callback API exists for every backend",
+          "[midi][sysex][issue-19]") {
+    // Compile-only contract: every backend's MidiInput must accept a
+    // sysex callback — no-op default for backends that don't yet
+    // support sysex (CoreMIDI / ALSA today), real handler for
+    // backends that do (Win MIDI as of this PR).
+    auto sys = pulp::midi::create_midi_system();
+    REQUIRE(sys != nullptr);
+    auto in = sys->create_input();
+    REQUIRE(in != nullptr);
+    in->set_sysex_callback([](const std::vector<uint8_t>&, double) {});
+    SUCCEED("set_sysex_callback compiles + accepts a real lambda");
+}
+
+#ifdef _WIN32
+
+TEST_CASE("WinMIDI: open + sysex callback registration leaks nothing",
+          "[midi][sysex][issue-19][windows]") {
+    auto sys = pulp::midi::create_midi_system();
+    REQUIRE(sys != nullptr);
+    auto inputs = sys->enumerate_inputs();
+    if (inputs.empty()) {
+        SUCCEED("no MIDI input devices on this host; skipping");
+        return;
+    }
+
+    auto in = sys->create_input();
+    REQUIRE(in != nullptr);
+    in->set_sysex_callback([](const std::vector<uint8_t>&, double) {
+        // Real-host validation requires a hardware sender; this is
+        // a register-only smoke test.
+    });
+
+    // open the first input port + immediately close. Validates that
+    // the SysEx buffer prepare/unprepare path is leak-free even when
+    // no SysEx packet ever arrives.
+    bool opened = in->open(inputs[0].id, [](const auto&) {});
+    if (!opened) {
+        SUCCEED("first input device couldn't open (probably busy); skipping");
+        return;
+    }
+    REQUIRE(in->is_open());
+    in->close();
+    REQUIRE_FALSE(in->is_open());
+}
+
+#endif  // _WIN32


### PR DESCRIPTION
## Scope

Closes the SysEx + high-resolution-timestamp half of #245 on the
existing legacy mmeapi (\`winmm.lib\`) backend. The WinRT MIDI 2.0
backend (\`windows.devices.midi2\` + DeviceWatcher hotplug) is the
remaining half — defers to a follow-up because cppwinrt projection
needs real-host validation effort, and the SysEx + QPC bits are
shippable today on the path that's already in production.

## Changes

### Cross-platform API (additive, default no-op)

\`core/midi/include/pulp/midi/device.hpp\` adds:

- \`MidiSysexCallback\` alias.
- \`MidiInput::set_sysex_callback()\` virtual with empty default.

Existing backends (CoreMIDI, ALSA, Android) keep working unchanged
— they just no-op the new method until #239 fills them in. Callers
register the SysEx receiver BEFORE \`open()\` so early packets aren't
lost.

### WinMidiInput

- Pre-allocates 4 × 4 KB \`MIDIHDR\` buffers, \`midiInPrepareHeader\` +
  \`midiInAddBuffer\` on open. Driver returns each via
  \`MIM_LONGDATA\` when full or on F7; we hand the bytes to the
  user's \`sysex_callback_\`, then re-arm the buffer (clear
  \`dwBytesRecorded\` first — driver populates it).
- \`MIM_LONGERROR\`: re-arm the buffer silently.
- \`close()\` drains via \`midiInReset\`, \`midiInUnprepareHeader\` each
  slot, then \`midiInClose\`. No leaked driver handles even when no
  SysEx packet ever arrives.
- **QPC timestamps**: \`QueryPerformanceFrequency\` + open-time tick
  snapshot during open(). Per-event timestamps are
  seconds-since-open with sub-millisecond resolution — replaces
  the prior \`param2 / 1000.0\` (millisecond-only) path.

## Tests

\`test/test_winmidi_sysex.cpp\`:

1. Cross-platform compile guard proving every backend's
   \`MidiInput\` accepts a sysex callback.
2. Windows-only register-and-open smoke test that gracefully
   skips when no input device is present (CI runners, headless
   VMs).

## Test plan

- [x] Local macOS: cross-platform stub compiles + 3 assertions pass.
- [ ] Windows x64 via Namespace shipyard build (exercises real
      MSVC compile of the new mmeapi prepare/unprepare path
      through the new \`Windows MSVC release-path gate\`).
- [ ] \`ssh win\` (Intel x64) — actual SysEx round-trip on a host
      with a real MIDI device.

## Out of scope (follow-ups)

- WinRT MIDI 2.0 backend (\`windows.devices.midi2\`) — full UMP
  support, MIDI 2.0 features. Substantial cppwinrt port.
- DeviceWatcher hotplug — current \`set_port_change_callback\`
  already handles legacy mmeapi hotplug.
- CoreMIDI / ALSA SysEx wiring — #239 will fill those backends'
  \`set_sysex_callback\` paths now that the cross-platform hook
  exists.

Refs #19, #245, #239.