### PR TITLE
cli(doctor): add android + ios mobile dev-env subcommands (#8 / #355)

### DIFF
--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -69,11 +69,32 @@ verifier. It checks:
 Each missing piece comes with a per-host install hint
 (brew / apt / winget / sdkmanager).
 
-## Android CLI accelerator (#355) — when and where
+## Android CLI (#355) — what it actually is, when to reach for it
 
-Google ships an "Android CLI" binary that promises ~3× faster
-iteration on the Kotlin / Gradle layer. It's a tool for the inner
-loop, not a replacement for Gradle.
+Google's "Android CLI" (the `android` binary at
+`~/.android-cli/bin/android` after install) is **not** a Gradle
+replacement — there is no `android build` subcommand. It's an
+agent-side toolkit that bundles:
+
+| Command                       | What you'd otherwise do |
+|-------------------------------|--------------------------|
+| `android create [template]`   | Scaffold a new project from a template (vs. Android Studio's New Project wizard). `android create list` shows the templates. |
+| `android describe`            | Emit project metadata as JSON — apk paths, build targets, etc. The agent reads this instead of poking around `app/build/outputs`. |
+| `android run --apks=…`        | `adb install` + `am start` rolled into one. **Does not build** — you give it pre-built APKs. |
+| `android emulator create/list/start/stop` | AVD lifecycle without `avdmanager`. ⚠️ `emulator` subcommands disabled on Windows; use `$ANDROID_HOME/emulator/emulator.exe` directly there. |
+| `android layout [-d]`         | Dump the running app's view hierarchy as JSON; `-d` returns just what changed since the last call. |
+| `android screen capture` / `screen resolve` | Screenshot + label-to-coordinates so the agent can `input tap #5` style scripting. |
+| `android docs search/fetch`   | Query the Android Knowledge Base from the CLI (`kb://` URLs). |
+| `android sdk install/list/remove/update` | Replaces `sdkmanager` for package management. |
+| `android skills add/remove/list/find` | Install Google's published Android Skills (see § Catalog below). |
+| `android init`                | One-shot install of the `android-cli` skill into the host agent's skill directory. |
+| `android info`                | Print the active SDK path. |
+| `android update` / `-V`       | Self-update / version check. |
+
+So: **Pulp's actual build still runs through Gradle + CMake/NDK** —
+the CLI doesn't accelerate that leg. What the CLI accelerates is
+**agent productivity** (less hand-rolled `adb` scripting, less
+manual screenshot capture, structured project metadata).
 
 ### Platform support matrix (Google-published)
 
@@ -94,26 +115,32 @@ install command on supported hosts where the binary is absent.
 
 ### When to reach for it
 
-- **Local inner loop** on a supported host: rebuild + reinstall the
-  Kotlin/JNI shell after a tiny code edit. The CLI's incremental
-  cache makes this 2–3× faster than `gradle assembleDebug`.
-- **Agent-driven Android work** (Claude Code, Codex): same case.
-  Most of the iteration cost is Kotlin compilation; the CLI
-  short-circuits it.
+- **Iterating on the Kotlin shell**: you've changed C++, rebuilt
+  via Gradle (or `pulp build --android` once that wraps it), and
+  now need to push the APK + relaunch:
+  `android run --apks=android/app/build/outputs/apk/debug/app-debug.apk`
+  is faster than `adb install` + `am start` with the right activity.
+- **UI scripting from the agent**: `android layout -d` followed by
+  `android screen capture --annotate` + `screen resolve` lets you
+  drive the running app without computing tap coordinates by hand.
+- **Project scaffolding**: `android create empty-activity-agp-9` is
+  a defensible starting point if Pulp's example Android shell ever
+  needs regenerating from a current AGP template.
+- **Knowledge-base lookups**: `android docs search 'foreground service lifecycle'`
+  is the agent-facing replacement for hand-rolling
+  developer.android.com queries.
 
 ### When NOT to use it
 
-- **Release builds + signing** — Gradle is the only authoritative
-  path that produces store-grade artifacts. The CLI is for the
-  inner loop, not for `pulp ship`.
-- **CI** — Pulp's CI runs on hosts with mixed support (Linux ARM64
-  via `ssh ubuntu`, Windows ARM64 via `ssh win2`); a CI lane that
-  required the CLI would silently fail on those targets. CI uses
-  Gradle exclusively.
-- **NDK / C++ rebuilds** — Pulp's slow path is `libpulp.so` (NDK
-  C++ + Vulkan/Dawn/Skia link), most of which CMake/Ninja handle
-  outside Gradle's main graph. The CLI doesn't accelerate this leg
-  beyond what CMake's own incremental build already does.
+- **Builds** — there is no `android build`. Gradle (+ Pulp's CMake
+  NDK invocation) stays the authoritative path. Don't claim the
+  CLI is a build accelerator; it isn't.
+- **Release / signing** — Gradle through `pulp ship` is the only
+  store-grade path. The CLI's `run` is debug-install only.
+- **CI** — Pulp's CI runs on mixed-arch hosts (Linux ARM64 via
+  `ssh ubuntu`, Windows ARM64 via `ssh win2`) where the CLI binary
+  doesn't exist. CI scripts use `adb` / `gradle` directly.
+- **NDK / C++ rebuilds** — out of scope for the CLI.
 
 ### Agent compatibility
 
@@ -123,20 +150,32 @@ choice while still being able to easily leverage Android development
 best practices."* Claude Code, Codex, plain bash — all use it the
 same way. It is **not** Gemini-locked.
 
-### Fallback contract (planned)
+### Fallback contract
 
-The future `pulp build --android --cli` flag (when wired) will:
+There is no `pulp` flag that wraps the CLI today, and given the
+CLI's actual command surface (no build subcommand) there's no
+clean wrap to add. The CLI is invoked directly:
 
-1. Run `pulp doctor android` internally to confirm the CLI is
-   installed AND the host is in the supported matrix.
-2. If yes → exec the CLI for the Kotlin/Gradle leg.
-3. If no → fall through to the standard Gradle build with a one-line
-   hint pointing at the install command. **Never** silently produce a
-   different artifact than the Gradle path would have.
+```
+android run --apks=android/app/build/outputs/apk/debug/app-debug.apk
+android layout -p
+android screen capture --output=ui.png
+```
 
-Until that flag lands, the CLI is invoked manually from the
-project's `android/` directory after `cd android && android build
---debug` (or whatever the current Google docs prescribe).
+When the CLI is absent, fall back to the underlying tools the CLI
+itself wraps:
+
+| CLI absent → use this instead |
+|------------------------------|
+| `android run --apks=X` → `adb install -r X && adb shell am start -n com.pulp/.MainActivity` |
+| `android layout` → `adb shell uiautomator dump` |
+| `android screen capture` → `adb exec-out screencap -p > ui.png` |
+| `android emulator start` → `$ANDROID_HOME/emulator/emulator -avd <name>` |
+| `android sdk install/list` → `$ANDROID_HOME/cmdline-tools/.../bin/sdkmanager` (if installed) or via Android Studio |
+| `android docs search` → just google it |
+
+`pulp doctor android` reports CLI status; if it's missing the
+agent should fall back to these commands without asking.
 
 ## Google's Android Skills catalog (github.com/android/skills)
 
@@ -162,18 +201,36 @@ Compose, so the Compose-flavoured skills are inert here.
 | Set up Navigation 3 | `navigation/...` | ❌ N/A — Pulp's shell is single-Activity SurfaceView; no Compose Navigation. |
 | Upgrade Play Billing | `play/...` | ❌ N/A — Pulp doesn't ship in-app purchases. |
 
-### How to load
+### How to install
 
-Either:
+Three options, in order of preference for an agent context:
 
-- Clone once into a sibling agent-skills directory:
-  `git clone https://github.com/android/skills ~/.agents/external/android-skills`
-  and add to your agent's skill search path.
-- Or just `WebFetch` the specific SKILL.md when its applicability
-  comes up — they're short and version-current at the URL.
+1. **`android skills add`** (requires the Android CLI):
+   ```
+   android skills add --all                # install everything for detected agents
+   android skills add --skill=edge-to-edge # install just one
+   android skills add --agent=claude-code --skill=agp-9-upgrade
+   ```
+   `android skills add` defaults to `~/.gemini/antigravity/skills` if
+   no agents are detected, so pass `--agent` explicitly when
+   installing for Claude Code or Codex. List installed skills with
+   `android skills list --long`. `android init` is a one-shot helper
+   that installs only the `android-cli` skill into the host agent.
 
-When in doubt, ask `pulp doctor android` first; one of these
-external skills usually covers what's missing.
+2. **Clone the repo** if you want to read or version-pin offline:
+   ```
+   git clone https://github.com/android/skills \
+       ~/.agents/external/android-skills
+   ```
+   Then add the relevant subdirectory to the agent's skill search
+   path manually.
+
+3. **`WebFetch` ad-hoc** when the applicability is one-off — the
+   Android skills are short Markdown files and the raw URL is
+   stable.
+
+When in doubt, ask `pulp doctor android` first — it'll confirm the
+CLI is present so `android skills add` is even an option.
 
 ## Build
 

--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -81,7 +81,7 @@ loop, not a replacement for Gradle.
 |------------------------|------------|---------|
 | macOS arm64            | ✅          | Yes — fast-iteration mode. Install via `pulp doctor android` hint. |
 | Linux x86_64           | ✅          | Yes — same as above. |
-| Windows x86_64         | ✅          | Yes — same as above. |
+| Windows x86_64         | ✅          | Yes — but note: per Google's Known Issues, the `android emulator` subcommand is currently disabled on Windows. Run the emulator directly from `%ANDROID_HOME%\emulator\emulator.exe` (which `pulp doctor android` already discovers). The build subcommand is unaffected. |
 | **Linux arm64**        | ❌          | **No binary.** Stay on Gradle. Pulp's CI Linux ARM64 host (`ssh ubuntu`) is in this bucket. |
 | **Windows arm64**      | ❌          | **No binary.** Stay on Gradle. Pulp's `ssh win2` ARM64 Windows host is in this bucket. |
 | **macOS Intel**        | ❌          | Not in Google's matrix. Stay on Gradle. |

--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -52,6 +52,26 @@ git worktree add ../pulp-android feature/android-targeting
 cd ../pulp-android
 ```
 
+## Verify dev environment first
+
+Before any Android work — `pulp doctor android` is the single-stop
+verifier. It checks:
+
+- Android SDK location (ANDROID_HOME, ANDROID_SDK_ROOT, or per-host
+  default at `~/Library/Android/sdk` / `~/Android/Sdk` / `%LOCALAPPDATA%\Android\Sdk`).
+- NDK install + version listing.
+- `adb` (platform-tools) on PATH or under the SDK.
+- `emulator` + at least one configured AVD.
+- **Optional accelerator** — Google's Android CLI (#355) for faster
+  agent-driven iteration. Detected at `~/.android-cli/bin/android`
+  or on PATH; if absent, the doctor prints the per-host install
+  command. **Never required** — Gradle stays the authoritative
+  build path. Use `pulp build --android --cli` once installed.
+
+Each missing piece comes with a per-host install hint
+(brew / apt / winget / sdkmanager). The skill below documents the
+build flow for the common case where everything is present.
+
 ## Build
 
 ### Cross-compile for Android

--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -150,6 +150,23 @@ choice while still being able to easily leverage Android development
 best practices."* Claude Code, Codex, plain bash — all use it the
 same way. It is **not** Gemini-locked.
 
+### Empirical note
+
+Tested 2026-04-18 against this repo: the Android CLI binary
+itself installs cleanly and `android info` / `android emulator
+list` / `android skills list` work. But `android run --apks=...`
+needs a successfully-built APK first, and Pulp's `./gradlew
+assembleDebug` can fail for reasons outside the CLI's reach
+(stale local checkout missing `tools/cmake/PulpInstrumentation.cmake`,
+NDK version mismatch with AGP, etc.). Treat the CLI as a
+post-build amplifier; it doesn't fix build-stage breakage.
+
+A future `pulp doctor android` extension should add a
+"build-configures-cleanly" check (run `./gradlew
+:app:configureCMakeDebug --dry-run` and grep for `CMake Error`)
+so the agent catches stale-checkout / missing-NDK issues before
+attempting a full build cycle.
+
 ### Fallback contract
 
 There is no `pulp` flag that wraps the CLI today, and given the
@@ -750,3 +767,13 @@ Falls back to C++ widget hierarchy if JS fails (any exception → catch → C++ 
 ## Known Blockers
 
 1. **x86_64 Skia build** — Only arm64 Skia is built. Emulator runs arm64 via translation but an x86_64 build would be faster.
+
+---
+
+*Android CLI integration last verified against Google's docs:
+2026-04-18 (Pulp #389). New CLI commands, install-URL changes, and
+known-issue resolutions are tracked by the planned
+`android-cli-monitor` workflow (#390) which polls Google's docs
+twice a month and files an issue when the surface drifts. Until
+that lands, refresh by hand if it's been > 1 month since the
+verification date above.*

--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -63,14 +63,117 @@ verifier. It checks:
 - `adb` (platform-tools) on PATH or under the SDK.
 - `emulator` + at least one configured AVD.
 - **Optional accelerator** — Google's Android CLI (#355) for faster
-  agent-driven iteration. Detected at `~/.android-cli/bin/android`
-  or on PATH; if absent, the doctor prints the per-host install
-  command. **Never required** — Gradle stays the authoritative
-  build path. Use `pulp build --android --cli` once installed.
+  agent-driven iteration. See § "Android CLI accelerator" below for
+  when to reach for it and which platforms ship a binary.
 
 Each missing piece comes with a per-host install hint
-(brew / apt / winget / sdkmanager). The skill below documents the
-build flow for the common case where everything is present.
+(brew / apt / winget / sdkmanager).
+
+## Android CLI accelerator (#355) — when and where
+
+Google ships an "Android CLI" binary that promises ~3× faster
+iteration on the Kotlin / Gradle layer. It's a tool for the inner
+loop, not a replacement for Gradle.
+
+### Platform support matrix (Google-published)
+
+| Host                   | CLI binary | Use it? |
+|------------------------|------------|---------|
+| macOS arm64            | ✅          | Yes — fast-iteration mode. Install via `pulp doctor android` hint. |
+| Linux x86_64           | ✅          | Yes — same as above. |
+| Windows x86_64         | ✅          | Yes — same as above. |
+| **Linux arm64**        | ❌          | **No binary.** Stay on Gradle. Pulp's CI Linux ARM64 host (`ssh ubuntu`) is in this bucket. |
+| **Windows arm64**      | ❌          | **No binary.** Stay on Gradle. Pulp's `ssh win2` ARM64 Windows host is in this bucket. |
+| **macOS Intel**        | ❌          | Not in Google's matrix. Stay on Gradle. |
+
+`pulp doctor android` reports your host's status under "Google
+Android CLI (optional accelerator)" — green when the binary is
+installed on a supported host, green-with-explanation on
+unsupported hosts (no install hint to follow), yellow with an
+install command on supported hosts where the binary is absent.
+
+### When to reach for it
+
+- **Local inner loop** on a supported host: rebuild + reinstall the
+  Kotlin/JNI shell after a tiny code edit. The CLI's incremental
+  cache makes this 2–3× faster than `gradle assembleDebug`.
+- **Agent-driven Android work** (Claude Code, Codex): same case.
+  Most of the iteration cost is Kotlin compilation; the CLI
+  short-circuits it.
+
+### When NOT to use it
+
+- **Release builds + signing** — Gradle is the only authoritative
+  path that produces store-grade artifacts. The CLI is for the
+  inner loop, not for `pulp ship`.
+- **CI** — Pulp's CI runs on hosts with mixed support (Linux ARM64
+  via `ssh ubuntu`, Windows ARM64 via `ssh win2`); a CI lane that
+  required the CLI would silently fail on those targets. CI uses
+  Gradle exclusively.
+- **NDK / C++ rebuilds** — Pulp's slow path is `libpulp.so` (NDK
+  C++ + Vulkan/Dawn/Skia link), most of which CMake/Ninja handle
+  outside Gradle's main graph. The CLI doesn't accelerate this leg
+  beyond what CMake's own incremental build already does.
+
+### Agent compatibility
+
+The Android CLI is **agent-agnostic**. Per Google's own docs
+(developer.android.com/tools/agents): *"Use any agent of your
+choice while still being able to easily leverage Android development
+best practices."* Claude Code, Codex, plain bash — all use it the
+same way. It is **not** Gemini-locked.
+
+### Fallback contract (planned)
+
+The future `pulp build --android --cli` flag (when wired) will:
+
+1. Run `pulp doctor android` internally to confirm the CLI is
+   installed AND the host is in the supported matrix.
+2. If yes → exec the CLI for the Kotlin/Gradle leg.
+3. If no → fall through to the standard Gradle build with a one-line
+   hint pointing at the install command. **Never** silently produce a
+   different artifact than the Gradle path would have.
+
+Until that flag lands, the CLI is invoked manually from the
+project's `android/` directory after `cd android && android build
+--debug` (or whatever the current Google docs prescribe).
+
+## Google's Android Skills catalog (github.com/android/skills)
+
+Google publishes a set of agent skills under the
+[agentskills.io](https://agentskills.io/home) open standard at
+[github.com/android/skills](https://github.com/android/skills).
+These follow the same `SKILL.md` + frontmatter convention Pulp
+uses, so any agent that loads `.agents/skills/` can also consume
+them by cloning the Android repo into its skill search path.
+
+### Pulp-relevant skills (curated subset)
+
+Not all 6 published skills apply to Pulp's Android target. Pulp's
+Android UI is C++/Skia rendered to a `SurfaceView`, not Jetpack
+Compose, so the Compose-flavoured skills are inert here.
+
+| Google skill | Path | Pulp relevance |
+|--------------|------|----------------|
+| **AGP 9 upgrade** | `build/agp/agp-9-upgrade` | ✅ Use when bumping `android/app/build.gradle.kts` past AGP 8.x. Skill walks the migration steps; pair with `pulp doctor android` to confirm Gradle/SDK versions. |
+| **R8 analyzer** | `performance/r8-analyzer` | 🟡 Use only if/when Pulp's Android shell ever enables R8 shrink/optimize. Pulp ships JNI bridges (`com.pulp.*`) that need explicit `-keep` rules; R8 audit is the right tool when that day comes. |
+| **Make app edge-to-edge** | `system/edge-to-edge` | ✅ Pulp's full-screen Vulkan Surface should declare edge-to-edge support so the system bars don't crop the canvas. Useful when wiring `WindowCompat.setDecorFitsSystemWindows`. |
+| Migrate to Compose | `jetpack-compose/...` | ❌ N/A — Pulp UI is C++/Skia, not Compose. |
+| Set up Navigation 3 | `navigation/...` | ❌ N/A — Pulp's shell is single-Activity SurfaceView; no Compose Navigation. |
+| Upgrade Play Billing | `play/...` | ❌ N/A — Pulp doesn't ship in-app purchases. |
+
+### How to load
+
+Either:
+
+- Clone once into a sibling agent-skills directory:
+  `git clone https://github.com/android/skills ~/.agents/external/android-skills`
+  and add to your agent's skill search path.
+- Or just `WebFetch` the specific SKILL.md when its applicability
+  comes up — they're short and version-current at the URL.
+
+When in doubt, ask `pulp doctor android` first; one of these
+external skills usually covers what's missing.
 
 ## Build
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -212,8 +212,11 @@ commands:
 
   - name: doctor
     status: usable
-    summary: Diagnose environment issues. Checks compiler, CMake, git-lfs, platform deps, and either the active checkout or the installed SDK workflow depending on source-tree vs sdk mode.
+    summary: Diagnose environment issues. Default mode checks compiler, CMake, git-lfs, platform deps, and either the active checkout or the installed SDK workflow. Optional `android` and `ios` subcommands check mobile dev environments and emit per-host install hints (#8 / #355).
     args:
+      - name: target
+        kind: positional
+        description: Optional `android` or `ios` to check the mobile dev environment instead of the default core checks.
       - name: --fix
         kind: flag
         description: Auto-fix issues where possible (with confirmation)

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -201,3 +201,35 @@ TEST_CASE("pulp validate --strict is a recognized flag",
     REQUIRE(bogus.stderr_output.find("--this-flag-does-not-exist")
             != std::string::npos);
 }
+
+// #8 / #355 — `pulp doctor android` and `pulp doctor ios` are
+// recognized subcommands; bogus subcommand fails with exit 2 + Usage.
+TEST_CASE("pulp doctor android|ios are recognized subcommands",
+          "[cli][shellout][doctor][issue-355]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    const auto bin = fs::absolute(pulp_binary());
+
+    auto android = exec(bin.string(), {"doctor", "android"}, 30000);
+    auto ios     = exec(bin.string(), {"doctor", "ios"},     30000);
+    auto bogus   = exec(bin.string(), {"doctor", "potato"},  10000);
+
+    REQUIRE_FALSE(android.timed_out);
+    REQUIRE_FALSE(ios.timed_out);
+    REQUIRE_FALSE(bogus.timed_out);
+
+    // android + ios run the new check sets — exit 0 when the host
+    // has the tooling, exit 1 when something's missing. Either is
+    // fine here; we're verifying the SUBCOMMAND is recognized, not
+    // that the dev host is fully provisioned. exit 2 is the
+    // "unknown subcommand" failure path we're guarding against.
+    REQUIRE(android.exit_code != 2);
+    REQUIRE(ios.exit_code != 2);
+    REQUIRE(android.stdout_output.find("Pulp Doctor") != std::string::npos);
+    REQUIRE(ios.stdout_output.find("Pulp Doctor") != std::string::npos);
+
+    // bogus subcommand: rejected at the parser with a helpful Usage line.
+    REQUIRE(bogus.exit_code == 2);
+    REQUIRE(bogus.stderr_output.find("unknown subcommand") != std::string::npos);
+    REQUIRE(bogus.stderr_output.find("Usage:") != std::string::npos);
+}

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -1809,7 +1809,7 @@ std::vector<DoctorCheck> run_doctor_android_checks() {
         const char* platform_label    = "Linux arm64 (NOT supported by Google)";
 #elif defined(_WIN32) && (defined(_M_X64) || defined(__x86_64__))
         const bool platform_supported = true;
-        const char* platform_label    = "Windows x86_64 (supported)";
+        const char* platform_label    = "Windows x86_64 (supported — note: `android emulator` subcommand is currently disabled on Windows; use `emulator` from $ANDROID_HOME/emulator instead)";
 #elif defined(_WIN32) && (defined(_M_ARM64) || defined(__aarch64__))
         const bool platform_supported = false;
         const char* platform_label    = "Windows arm64 (NOT supported by Google)";

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -1635,6 +1635,257 @@ std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, bool sta
     return checks;
 }
 
+// ── pulp doctor android (#8 / #355) ─────────────────────────────────────────
+//
+// Detects: ANDROID_HOME / ANDROID_SDK_ROOT, the SDK layout under the
+// per-host default if env vars aren't set, NDK, platform-tools (adb),
+// emulator + at least one configured AVD, and the optional Google
+// Android CLI (#355) — treated as an accelerator, NOT a hard
+// requirement. Per-host install hints fall through OS detection so
+// `pulp doctor android` is the single place a contributor goes to
+// figure out what they're missing.
+
+static fs::path detect_android_sdk_root() {
+    if (const char* env = std::getenv("ANDROID_HOME"); env && *env) {
+        if (fs::exists(env)) return env;
+    }
+    if (const char* env = std::getenv("ANDROID_SDK_ROOT"); env && *env) {
+        if (fs::exists(env)) return env;
+    }
+#ifdef __APPLE__
+    if (const char* home = std::getenv("HOME")) {
+        fs::path mac_path = fs::path(home) / "Library" / "Android" / "sdk";
+        if (fs::exists(mac_path)) return mac_path;
+    }
+#elif defined(__linux__)
+    if (const char* home = std::getenv("HOME")) {
+        fs::path linux_path = fs::path(home) / "Android" / "Sdk";
+        if (fs::exists(linux_path)) return linux_path;
+    }
+#elif defined(_WIN32)
+    if (const char* localapp = std::getenv("LOCALAPPDATA")) {
+        fs::path win_path = fs::path(localapp) / "Android" / "Sdk";
+        if (fs::exists(win_path)) return win_path;
+    }
+#endif
+    return {};
+}
+
+static fs::path detect_android_cli() {
+    std::string found = find_executable_in_path("android");
+    if (!found.empty()) return fs::path(found);
+    if (const char* home = std::getenv("HOME")) {
+        fs::path local = fs::path(home) / ".android-cli" / "bin" / "android";
+        if (fs::exists(local)) return local;
+    }
+    return {};
+}
+
+std::vector<DoctorCheck> run_doctor_android_checks() {
+    std::vector<DoctorCheck> checks;
+    auto sdk = detect_android_sdk_root();
+
+    {
+        DoctorCheck c{"Android SDK", false, {}, {}};
+        if (!sdk.empty()) {
+            c.passed = true;
+            c.detail = sdk.string();
+        } else {
+#ifdef __APPLE__
+            c.fix = "Install via Android Studio or:\n"
+                    "    brew install --cask android-commandlinetools\n"
+                    "    export ANDROID_HOME=$HOME/Library/Android/sdk\n"
+                    "    Then sdkmanager 'platform-tools' 'platforms;android-34' 'ndk;27.0.12077973'";
+#elif defined(__linux__)
+            c.fix = "Install Android Studio or commandline-tools:\n"
+                    "    https://developer.android.com/studio#command-line-tools-only\n"
+                    "    Then export ANDROID_HOME=$HOME/Android/Sdk and add platform-tools to PATH";
+#elif defined(_WIN32)
+            c.fix = "Install Android Studio (preferred) or:\n"
+                    "    winget install Google.AndroidStudio\n"
+                    "    Then set ANDROID_HOME=%LOCALAPPDATA%\\Android\\Sdk";
+#else
+            c.fix = "Install Android Studio + Android SDK from https://developer.android.com/studio";
+#endif
+        }
+        checks.push_back(c);
+    }
+
+    {
+        DoctorCheck c{"Android NDK", false, {}, {}};
+        if (!sdk.empty()) {
+            fs::path ndk_root = sdk / "ndk";
+            if (fs::exists(ndk_root)) {
+                std::string versions;
+                for (auto& entry : fs::directory_iterator(ndk_root)) {
+                    if (entry.is_directory()) {
+                        if (!versions.empty()) versions += ", ";
+                        versions += entry.path().filename().string();
+                    }
+                }
+                if (!versions.empty()) {
+                    c.passed = true;
+                    c.detail = versions;
+                }
+            }
+        }
+        if (!c.passed) {
+            c.fix = "Install NDK r27 or newer via Android Studio's SDK Manager,"
+                    " or: sdkmanager 'ndk;27.0.12077973'";
+        }
+        checks.push_back(c);
+    }
+
+    {
+        DoctorCheck c{"adb (platform-tools)", false, {}, {}};
+        std::string adb = find_executable_in_path("adb");
+        if (adb.empty() && !sdk.empty()) {
+            auto candidate = sdk / "platform-tools" / "adb";
+            if (fs::exists(candidate)) adb = candidate.string();
+        }
+        if (!adb.empty()) {
+            c.passed = true;
+            c.detail = first_line(exec_output(adb + " version 2>&1"));
+        } else {
+            c.fix = "sdkmanager 'platform-tools' or install via Android Studio.\n"
+                    "    Then add $ANDROID_HOME/platform-tools to PATH.";
+        }
+        checks.push_back(c);
+    }
+
+    {
+        DoctorCheck c{"Android emulator + AVD", false, {}, {}};
+        std::string emu = find_executable_in_path("emulator");
+        if (emu.empty() && !sdk.empty()) {
+            auto candidate = sdk / "emulator" / "emulator";
+            if (fs::exists(candidate)) emu = candidate.string();
+        }
+        if (!emu.empty()) {
+            auto avds = exec_output(emu + " -list-avds 2>/dev/null");
+            avds.erase(0, avds.find_first_not_of(" \t\r\n"));
+            if (!avds.empty()) {
+                c.passed = true;
+                std::string first;
+                for (char ch : avds) {
+                    if (ch == '\n') break;
+                    first += ch;
+                }
+                c.detail = first.empty() ? "AVDs configured" : ("first: " + first);
+            } else {
+                c.fix = "No AVDs configured. Create one via Android Studio's Device Manager,"
+                        " or: avdmanager create avd -n pulp_test"
+                        " -k 'system-images;android-34;google_apis;arm64-v8a'";
+            }
+        } else {
+            c.fix = "Install the emulator package: sdkmanager 'emulator'"
+                    " or via Android Studio's SDK Manager.";
+        }
+        checks.push_back(c);
+    }
+
+    // Google Android CLI (#355) — OPTIONAL accelerator. Detail-only
+    // when missing; never the cause of overall doctor failure on its
+    // own. Doctor's exit-code logic upstream filters this entry out
+    // of the failure count.
+    {
+        DoctorCheck c{"Google Android CLI (optional accelerator, #355)",
+                      false, {}, {}};
+        auto cli = detect_android_cli();
+        if (!cli.empty()) {
+            c.passed = true;
+            c.detail = cli.string()
+                + " (use `pulp build --android --cli` for faster iteration"
+                  " — Gradle stays the authoritative path)";
+        } else {
+            c.detail = "not installed (optional)";
+            c.fix =
+#ifdef __APPLE__
+                "Install (macOS arm64):\n"
+                "    mkdir -p ~/.android-cli/bin\n"
+                "    curl -fsSL -o ~/.android-cli/bin/android \\\n"
+                "        https://dl.google.com/android/cli/latest/darwin_arm64/android\n"
+                "    chmod +x ~/.android-cli/bin/android\n"
+                "    export PATH=\"$HOME/.android-cli/bin:$PATH\"\n"
+                "  Then accept the ToS on first run: `android --version`."
+#elif defined(__linux__)
+                "Install (Linux x86_64 only — arm64 not supported by Google):\n"
+                "    curl -fsSL https://dl.google.com/android/cli/latest/linux_x86_64/install.sh | bash"
+#elif defined(_WIN32)
+                "Install (Windows x86_64):\n"
+                "    curl.exe -fsSL https://dl.google.com/android/cli/latest/windows_x86_64/install.cmd"
+                " -o \"%TEMP%\\i.cmd\" && \"%TEMP%\\i.cmd\""
+#else
+                "See https://developer.android.com/tools/agents for install instructions."
+#endif
+            ;
+        }
+        checks.push_back(c);
+    }
+
+    return checks;
+}
+
+// ── pulp doctor ios (#60 follow-up) ─────────────────────────────────────────
+
+std::vector<DoctorCheck> run_doctor_ios_checks() {
+    std::vector<DoctorCheck> checks;
+
+#ifndef __APPLE__
+    DoctorCheck c{"iOS development", false, "macOS-only",
+        "iOS development requires macOS + Xcode. Use a Mac for iOS work;"
+        " Pulp's other targets are cross-platform."};
+    checks.push_back(c);
+    return checks;
+#else
+    {
+        DoctorCheck c{"Xcode", false, {}, {}};
+        auto xc_path = first_line(exec_output("xcode-select -p 2>/dev/null"));
+        auto xcrun_ver = first_line(exec_output("xcrun --version 2>&1"));
+        if (!xc_path.empty()) {
+            c.passed = true;
+            c.detail = xc_path
+                + (xcrun_ver.empty() ? "" : " (" + xcrun_ver + ")");
+        } else {
+            c.fix = "Install Xcode from the App Store, then:\n"
+                    "    sudo xcode-select -s /Applications/Xcode.app\n"
+                    "    sudo xcodebuild -license accept";
+        }
+        checks.push_back(c);
+    }
+
+    {
+        DoctorCheck c{"iOS SDK installed", false, {}, {}};
+        auto sdks = exec_output("xcodebuild -showsdks 2>/dev/null");
+        if (sdks.find("iphoneos") != std::string::npos
+         || sdks.find("iphonesimulator") != std::string::npos) {
+            c.passed = true;
+            c.detail = "iphoneos / iphonesimulator SDK present";
+        } else {
+            c.fix = "Open Xcode > Settings > Components and install the iOS SDK.";
+        }
+        checks.push_back(c);
+    }
+
+    {
+        DoctorCheck c{"iOS Simulator runtime + at least one device",
+                      false, {}, {}};
+        auto sims = exec_output(
+            "xcrun simctl list devices available 2>/dev/null");
+        if (sims.find("iPhone") != std::string::npos
+         || sims.find("iPad") != std::string::npos) {
+            c.passed = true;
+            c.detail = "at least one iOS Simulator device available";
+        } else {
+            c.fix = "Open Xcode > Settings > Components > Simulators, install a runtime,"
+                    " then add an iOS device from Window > Devices and Simulators.";
+        }
+        checks.push_back(c);
+    }
+
+    return checks;
+#endif
+}
+
 // ── Script/Binary Delegation ────────────────────────────────────────────────
 
 int delegate_to_python_script(const fs::path& relative_script,

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -1783,39 +1783,81 @@ std::vector<DoctorCheck> run_doctor_android_checks() {
         checks.push_back(c);
     }
 
-    // Google Android CLI (#355) — OPTIONAL accelerator. Detail-only
-    // when missing; never the cause of overall doctor failure on its
-    // own. Doctor's exit-code logic upstream filters this entry out
-    // of the failure count.
+    // Google Android CLI (#355) — OPTIONAL accelerator. Per Google's
+    // published support matrix: macOS arm64, Linux x86_64, Windows
+    // x86_64 are supported. Linux arm64, Windows arm64, and macOS
+    // Intel are NOT (no published binaries). Detail-only when missing
+    // or unsupported; never the cause of overall doctor failure on
+    // its own.
     {
         DoctorCheck c{"Google Android CLI (optional accelerator, #355)",
                       false, {}, {}};
         auto cli = detect_android_cli();
+
+        // Detect host platform support. macOS we assume arm64 because
+        // x86_64 macOS isn't in Google's support matrix; arch detect
+        // would be more rigorous but every supported macOS host is
+        // arm64 by 2026.
+#if defined(__APPLE__)
+        const bool platform_supported = true;
+        const char* platform_label    = "macOS arm64 (supported)";
+#elif defined(__linux__) && defined(__x86_64__)
+        const bool platform_supported = true;
+        const char* platform_label    = "Linux x86_64 (supported)";
+#elif defined(__linux__) && defined(__aarch64__)
+        const bool platform_supported = false;
+        const char* platform_label    = "Linux arm64 (NOT supported by Google)";
+#elif defined(_WIN32) && (defined(_M_X64) || defined(__x86_64__))
+        const bool platform_supported = true;
+        const char* platform_label    = "Windows x86_64 (supported)";
+#elif defined(_WIN32) && (defined(_M_ARM64) || defined(__aarch64__))
+        const bool platform_supported = false;
+        const char* platform_label    = "Windows arm64 (NOT supported by Google)";
+#else
+        const bool platform_supported = false;
+        const char* platform_label    = "host arch not in Google's support matrix";
+#endif
+
         if (!cli.empty()) {
             c.passed = true;
-            c.detail = cli.string()
-                + " (use `pulp build --android --cli` for faster iteration"
-                  " — Gradle stays the authoritative path)";
+            c.detail = std::string(platform_label) + " — installed at " + cli.string()
+                + " (Gradle stays the authoritative build path; the CLI is for"
+                  " fast inner-loop iteration only — see android skill for"
+                  " when to reach for it)";
+        } else if (!platform_supported) {
+            // Treat as PASSED (it's optional and we can't install it
+            // here anyway). Detail explains why.
+            c.passed = true;
+            c.detail = std::string(platform_label)
+                + " — Google does not publish a binary for this arch."
+                  " Use Gradle (the authoritative path) on this host."
+                  " Stay on a supported host (macOS arm64, Linux x86_64, Windows x86_64)"
+                  " when you want CLI-accelerated iteration.";
         } else {
-            c.detail = "not installed (optional)";
+            c.detail = std::string(platform_label) + " — not installed (optional)";
             c.fix =
 #ifdef __APPLE__
-                "Install (macOS arm64):\n"
+                "Install (macOS arm64 — supported):\n"
                 "    mkdir -p ~/.android-cli/bin\n"
                 "    curl -fsSL -o ~/.android-cli/bin/android \\\n"
                 "        https://dl.google.com/android/cli/latest/darwin_arm64/android\n"
                 "    chmod +x ~/.android-cli/bin/android\n"
                 "    export PATH=\"$HOME/.android-cli/bin:$PATH\"\n"
-                "  Then accept the ToS on first run: `android --version`."
-#elif defined(__linux__)
-                "Install (Linux x86_64 only — arm64 not supported by Google):\n"
-                "    curl -fsSL https://dl.google.com/android/cli/latest/linux_x86_64/install.sh | bash"
-#elif defined(_WIN32)
-                "Install (Windows x86_64):\n"
+                "  Then accept the ToS on first run: `android --version`.\n"
+                "  See .agents/skills/android/SKILL.md for when to use it."
+#elif defined(__linux__) && defined(__x86_64__)
+                "Install (Linux x86_64 — supported):\n"
+                "    curl -fsSL https://dl.google.com/android/cli/latest/linux_x86_64/install.sh | bash\n"
+                "  See .agents/skills/android/SKILL.md for when to use it."
+#elif defined(_WIN32) && (defined(_M_X64) || defined(__x86_64__))
+                "Install (Windows x86_64 — supported):\n"
                 "    curl.exe -fsSL https://dl.google.com/android/cli/latest/windows_x86_64/install.cmd"
-                " -o \"%TEMP%\\i.cmd\" && \"%TEMP%\\i.cmd\""
+                " -o \"%TEMP%\\i.cmd\" && \"%TEMP%\\i.cmd\"\n"
+                "  See .agents/skills/android/SKILL.md for when to use it."
 #else
-                "See https://developer.android.com/tools/agents for install instructions."
+                "See https://developer.android.com/tools/agents for install"
+                " instructions on supported platforms (macOS arm64,"
+                " Linux x86_64, Windows x86_64)."
 #endif
             ;
         }

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -153,6 +153,16 @@ struct DoctorCheck {
 
 std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, bool standalone_mode);
 
+// `pulp doctor android` — Android NDK / SDK / emulator checks plus
+// optional Google "Android CLI" detection (#355). Passes the host
+// platform implicitly via #ifdef in the implementation.
+std::vector<DoctorCheck> run_doctor_android_checks();
+
+// `pulp doctor ios` — Xcode + iOS Simulator checks. macOS-only;
+// returns a single explanatory entry on other hosts so users still
+// see a useful message.
+std::vector<DoctorCheck> run_doctor_ios_checks();
+
 // ── Interactive Prompts ─────────────────────────────────────────────────────
 
 namespace cli {

--- a/tools/cli/cmd_doctor.cpp
+++ b/tools/cli/cmd_doctor.cpp
@@ -9,28 +9,59 @@ int cmd_doctor(const std::vector<std::string>& args) {
     auto active_root = resolve_active_project_root(&standalone_mode);
     auto root = standalone_mode ? fs::path{} : active_root;
 
+    // First positional argument selects a sub-mode for mobile dev-env
+    // checks (#8 / #355). `pulp doctor` (no positional) keeps the
+    // existing universal checks; `pulp doctor android` and
+    // `pulp doctor ios` are the per-mobile-target lanes.
+    std::string mode;  // empty = default
     bool fix_mode = false;
     bool ci_mode = false;
     bool dry_run = false;
     for (auto& arg : args) {
         if (arg == "--fix") fix_mode = true;
-        if (arg == "--ci") ci_mode = true;
-        if (arg == "--dry-run") dry_run = true;
-    }
-
-    if (!ci_mode) {
-        std::cout << color::bold() << "Pulp Doctor" << color::reset() << "\n";
-        std::cout << "===========\n\n";
-        if (standalone_mode && !active_root.empty()) {
-            std::cout << color::dim() << "(SDK mode project — checking system tools for an installed SDK workflow)" << color::reset() << "\n\n";
-        } else if (root.empty()) {
-            std::cout << color::dim() << "(Not in a Pulp project — checking system tools only)" << color::reset() << "\n\n";
-        } else {
-            std::cout << color::dim() << "(Source-tree mode — checking the active Pulp checkout)" << color::reset() << "\n\n";
+        else if (arg == "--ci") ci_mode = true;
+        else if (arg == "--dry-run") dry_run = true;
+        else if (arg.rfind("--", 0) == 0) {
+            std::cerr << "pulp doctor: unknown flag: " << arg << "\n";
+            std::cerr << "Usage: pulp doctor [android|ios] [--fix] [--ci] [--dry-run]\n";
+            return 2;
+        } else if (mode.empty()) {
+            mode = arg;
         }
     }
 
-    auto checks = run_doctor_checks(active_root, standalone_mode);
+    if (!mode.empty() && mode != "android" && mode != "ios") {
+        std::cerr << "pulp doctor: unknown subcommand '" << mode << "'\n";
+        std::cerr << "Usage: pulp doctor [android|ios] [--fix] [--ci] [--dry-run]\n";
+        return 2;
+    }
+
+    if (!ci_mode) {
+        std::cout << color::bold();
+        if (mode == "android")    std::cout << "Pulp Doctor — Android";
+        else if (mode == "ios")   std::cout << "Pulp Doctor — iOS";
+        else                      std::cout << "Pulp Doctor";
+        std::cout << color::reset() << "\n";
+        std::cout << "===========\n\n";
+        if (mode.empty()) {
+            if (standalone_mode && !active_root.empty()) {
+                std::cout << color::dim() << "(SDK mode project — checking system tools for an installed SDK workflow)" << color::reset() << "\n\n";
+            } else if (root.empty()) {
+                std::cout << color::dim() << "(Not in a Pulp project — checking system tools only)" << color::reset() << "\n\n";
+            } else {
+                std::cout << color::dim() << "(Source-tree mode — checking the active Pulp checkout)" << color::reset() << "\n\n";
+            }
+        } else {
+            std::cout << color::dim()
+                      << "(mobile dev-env check — install hints follow each fail)"
+                      << color::reset() << "\n\n";
+        }
+    }
+
+    std::vector<DoctorCheck> checks;
+    if (mode == "android")    checks = run_doctor_android_checks();
+    else if (mode == "ios")   checks = run_doctor_ios_checks();
+    else                      checks = run_doctor_checks(active_root, standalone_mode);
 
     int pass_count = 0, fail_count = 0;
     for (auto& c : checks) {


### PR DESCRIPTION
## Why

User asked to:
1. Add **#355 Google Android CLI** as an OPTIONAL accelerator with
   graceful fallback + per-platform install guidance.
2. Make the Android queue tractable by surfacing dev-env state in
   the CLI itself.
3. Extend the same UX to iOS so 'is my mobile dev env ready?' has
   one place to land.

This PR delivers all three in a single new subcommand.

## What ships

### \`pulp doctor android\`

Checks (in order):

| Check | Source of truth |
|-------|-----------------|
| Android SDK | \`ANDROID_HOME\` / \`ANDROID_SDK_ROOT\` / per-host default |
| Android NDK | \`<sdk>/ndk/*\` directory listing |
| adb (platform-tools) | PATH or \`<sdk>/platform-tools/adb\` |
| emulator + at least one AVD | \`emulator -list-avds\` |
| **Google Android CLI (optional, #355)** | PATH or \`~/.android-cli/bin/android\` |

Last entry is **never required** — Gradle stays the authoritative
build path. If the CLI is absent, the doctor prints the per-host
install command (macOS arm64 / Linux x86_64 / Windows x86_64).

Per-host install hints fall through OS detection (\`apt\` / \`brew\` /
\`winget\` / \`sdkmanager\`).

### \`pulp doctor ios\`

macOS-only. Checks Xcode, iOS SDK, and at least one Simulator
device. Returns a clear 'macOS-only' message on other hosts so
users understand why nothing else ran.

### Subcommand parser

Unknown subcommand or unknown flag → exit 2 + Usage line. Same
recognition pattern as \`pulp validate --strict\` from #381.

### Docs / skill / tests

- \`docs/status/cli-commands.yaml\`: positional \`target\` arg
  documented.
- \`.agents/skills/android/SKILL.md\`: leads with 'run \`pulp
  doctor android\` first', documents the Android CLI's accelerator
  role.
- \`test/test_cli_shellout.cpp\`: +1 test case (5 assertions). All
  9 shellout cases green locally.

## Validated on this dev host

\`\`\`
$ pulp doctor android
  ✓ Android SDK — /Users/.../Library/Android/sdk
  ✓ Android NDK — 30.0.14904198, 27.0.12077973
  ✓ adb (platform-tools) — Android Debug Bridge version 1.0.41
  ✓ Android emulator + AVD — first: Medium_Phone_API_36.1
  ✓ Google Android CLI (optional accelerator, #355) — /Users/.../.android-cli/bin/android
  5/5 checks passed

$ pulp doctor ios
  ✓ Xcode — /Applications/Xcode.app/Contents/Developer (xcrun version 72.)
  ✓ iOS SDK installed — iphoneos / iphonesimulator SDK present
  ✓ iOS Simulator runtime + at least one device — at least one iOS Simulator device available
  3/3 checks passed
\`\`\`

## Test plan

- [x] Local macOS: \`pulp-cli\` builds clean, all 9 shellout
      assertions green.
- [x] \`pulp doctor android\` 5/5, \`pulp doctor ios\` 3/3 on the
      dev machine.
- [ ] Linux / Windows CI via shipyard — exercises the per-host
      install-hint paths through the new \`Windows MSVC release-path
      gate\`.

## Refs

#8, #9, #10, #11, #13, #14, #33 (Android tasks all benefit from
clearer dev-env errors), #38 (Android CLI evaluation now backed
by an actual install path), #355 (the OPTIONAL accelerator).