### PR TITLE
doctor: --fix for Android CLI install (Phase 1 of #394)

### DIFF
--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -57,17 +57,30 @@ cd ../pulp-android
 Before any Android work — `pulp doctor android` is the single-stop
 verifier. It checks:
 
-- Android SDK location (ANDROID_HOME, ANDROID_SDK_ROOT, or per-host
+- **Android SDK** location (ANDROID_HOME, ANDROID_SDK_ROOT, or per-host
   default at `~/Library/Android/sdk` / `~/Android/Sdk` / `%LOCALAPPDATA%\Android\Sdk`).
-- NDK install + version listing.
-- `adb` (platform-tools) on PATH or under the SDK.
-- `emulator` + at least one configured AVD.
-- **Optional accelerator** — Google's Android CLI (#355) for faster
-  agent-driven iteration. See § "Android CLI accelerator" below for
-  when to reach for it and which platforms ship a binary.
+- **NDK** install + version listing.
+- **adb** (platform-tools) on PATH or under the SDK.
+- **JDK 17+** — required for AGP 8 (current Pulp); AGP 9 will need 21.
+- **cmdline-tools** (`sdkmanager` / `avdmanager`) — needed to install
+  platforms / build-tools / NDK / system images headlessly.
+- **emulator** + at least one configured AVD.
+- **Optional accelerator** — Google's Android CLI (#355). See §
+  "Android CLI" below for when to reach for it and which platforms
+  ship a binary.
 
-Each missing piece comes with a per-host install hint
-(brew / apt / winget / sdkmanager).
+**`pulp doctor android --fix`** runs the per-host install command
+for the failing checks (JDK via brew/apt/winget, cmdline-tools via
+brew-cask / Android Studio, optional Android CLI via direct
+binary download — uniform raw-binary URL across all 3 supported
+hosts, no shell-init mutation). Each piece is independently
+installable so you can opt in granularly.
+
+For a one-shot install of *everything* (SDK + NDK + cmdline-tools
++ JDK + IDE), Android Studio is the easiest path:
+- macOS: `brew install --cask android-studio`
+- Linux: https://developer.android.com/studio
+- Windows: `winget install -e --id Google.AndroidStudio`
 
 ## Android CLI (#355) — what it actually is, when to reach for it
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,31 @@
+# Pulp's host-tool pins for mise (https://mise.jdx.dev) users.
+#
+# Optional — Pulp's build works with brew / apt / winget / system
+# installs of these tools as long as the version constraints below
+# are satisfied. This file is for contributors who already use mise
+# and want a one-command setup that doesn't shadow other projects'
+# tool versions.
+#
+# Usage:
+#   mise install         # install everything pinned here under mise's prefix
+#   mise current         # show what mise resolved for this directory
+#
+# Non-mise users: ignore this file. `pulp doctor` checks the same
+# version constraints against whatever is on PATH.
+
+[tools]
+# Build system (cmake_minimum_required is 3.24 in Pulp's CMakeLists.txt).
+cmake  = "3.30"
+ninja  = "latest"
+
+# Python is used by tools/scripts/* (regenerate_changelog, package_cli,
+# version_bump_check, etc.).
+python = "3.12"
+
+# JDK 17+ is required by Android Gradle Plugin 8 (current). AGP 9 will
+# need JDK 21 — we pin 21 now so the AGP-9 bump (Google's published
+# Android Skill) is friction-free when it lands.
+java   = "openjdk-21"
+
+# Node is used for design-tool integrations and JS-scripted UI dev.
+node   = "lts"

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -1753,6 +1753,94 @@ std::vector<DoctorCheck> run_doctor_android_checks() {
         checks.push_back(c);
     }
 
+    // ── JDK 17+ (#394 — full Android build chain) ────────────────────
+    //
+    // AGP 8.x requires JDK 17; AGP 9 requires JDK 21. Pulp's
+    // android/app/build.gradle.kts targets AGP 8 today but the
+    // skill flags AGP 9 as the next bump (Google Android Skills
+    // catalog AGP-9 upgrade), so we check for 17 minimum.
+    {
+        DoctorCheck c{"JDK 17+", false, {}, {}};
+        // 'java -version' writes to stderr historically; capture both.
+        auto ver = first_line(exec_output("java -version 2>&1"));
+        int major = 0;
+        if (!ver.empty()) {
+            // Parse 'openjdk version "21.0.2"' OR 'java version "17"'.
+            auto qopen  = ver.find('"');
+            auto qclose = ver.find('"', qopen + 1);
+            if (qopen != std::string::npos && qclose != std::string::npos) {
+                std::string v = ver.substr(qopen + 1, qclose - qopen - 1);
+                auto dot = v.find('.');
+                try { major = std::stoi(dot == std::string::npos ? v : v.substr(0, dot)); }
+                catch (...) {}
+            }
+        }
+        if (major >= 17) {
+            c.passed = true;
+            c.detail = ver;
+        } else {
+            c.detail = ver.empty() ? "java not found" : (ver + " (need 17+)");
+#if defined(__APPLE__)
+            c.fix = "brew install openjdk@21 && "
+                    "sudo ln -sfn $(brew --prefix)/opt/openjdk@21/libexec/openjdk.jdk "
+                    "/Library/Java/JavaVirtualMachines/openjdk-21.jdk";
+            c.fix_cmd = "brew install openjdk@21";
+#elif defined(__linux__)
+            c.fix = "Install OpenJDK 21 via your distro:\n"
+                    "    sudo apt install -y openjdk-21-jdk            # Debian/Ubuntu\n"
+                    "    sudo dnf install -y java-21-openjdk-devel     # Fedora/RHEL";
+            c.fix_cmd = "bash -c 'if command -v apt >/dev/null; then "
+                        "sudo apt update && sudo apt install -y openjdk-21-jdk; "
+                        "elif command -v dnf >/dev/null; then "
+                        "sudo dnf install -y java-21-openjdk-devel; "
+                        "else echo \"No supported package manager found\"; exit 1; fi'";
+#elif defined(_WIN32)
+            c.fix = "winget install --silent --id Microsoft.OpenJDK.21";
+            c.fix_cmd = "winget install --silent --id Microsoft.OpenJDK.21";
+#endif
+        }
+        checks.push_back(c);
+    }
+
+    // ── cmdline-tools (sdkmanager + avdmanager) ─────────────────────
+    {
+        DoctorCheck c{"Android cmdline-tools (sdkmanager / avdmanager)",
+                      false, {}, {}};
+        std::string sdkmanager = find_executable_in_path("sdkmanager");
+        if (sdkmanager.empty() && !sdk.empty()) {
+            for (auto sub : {"latest", "13.0", "12.0"}) {
+                auto candidate = sdk / "cmdline-tools" / sub / "bin" / "sdkmanager";
+                if (fs::exists(candidate)) {
+                    sdkmanager = candidate.string();
+                    break;
+                }
+            }
+        }
+        if (!sdkmanager.empty()) {
+            c.passed = true;
+            c.detail = sdkmanager + " — use to install platforms / build-tools / NDK";
+        } else {
+#if defined(__APPLE__)
+            c.fix = "brew install --cask android-commandlinetools\n"
+                    "  (or install Android Studio for the GUI installer that bundles\n"
+                    "   cmdline-tools + SDK + NDK + JDK in one step:\n"
+                    "    brew install --cask android-studio)";
+            c.fix_cmd = "brew install --cask android-commandlinetools";
+#elif defined(__linux__)
+            c.fix = "Download cmdline-tools from\n"
+                    "  https://developer.android.com/studio#command-line-tools-only\n"
+                    "  Unpack into $ANDROID_HOME/cmdline-tools/latest/.\n"
+                    "  Or install Android Studio (which bundles them):\n"
+                    "    https://developer.android.com/studio";
+#elif defined(_WIN32)
+            c.fix = "winget install -e --id Google.AndroidStudio\n"
+                    "  (Studio bundles cmdline-tools + SDK + NDK + JDK)";
+            c.fix_cmd = "winget install -e --id Google.AndroidStudio";
+#endif
+        }
+        checks.push_back(c);
+    }
+
     {
         DoctorCheck c{"Android emulator + AVD", false, {}, {}};
         std::string emu = find_executable_in_path("emulator");
@@ -1862,9 +1950,18 @@ std::vector<DoctorCheck> run_doctor_android_checks() {
             ;
 
             // Real installable command for `pulp doctor android --fix`.
-            // Idempotent (mkdir -p, curl -fsSL overwrites). User runs
-            // `android --version` once after to accept the ToS — the
-            // post-install echo reminds them.
+            // All three supported hosts publish a raw binary at the
+            // same URL pattern, so the install is uniform: download
+            // to ~/.android-cli/bin/, chmod, remind the user about
+            // PATH + ToS. We avoid Google's install.sh / install.cmd
+            // wrappers because they touch the user's shell init
+            // unconditionally; a dedicated ~/.android-cli/bin entry
+            // is more predictable and easier to uninstall.
+            //
+            // URLs verified 2026-04-18 — all return HTTP 200:
+            //   https://dl.google.com/android/cli/latest/darwin_arm64/android
+            //   https://dl.google.com/android/cli/latest/linux_x86_64/android
+            //   https://dl.google.com/android/cli/latest/windows_x86_64/android.exe
 #if defined(__APPLE__)
             c.fix_cmd =
                 "bash -c '"
@@ -1879,17 +1976,24 @@ std::vector<DoctorCheck> run_doctor_android_checks() {
 #elif defined(__linux__) && defined(__x86_64__)
             c.fix_cmd =
                 "bash -c '"
-                "curl -fsSL https://dl.google.com/android/cli/latest/linux_x86_64/install.sh | bash; "
-                "echo \"Run android --version to accept the ToS.\""
+                "set -e; "
+                "mkdir -p \"$HOME/.android-cli/bin\"; "
+                "curl -fsSL -o \"$HOME/.android-cli/bin/android\" "
+                "https://dl.google.com/android/cli/latest/linux_x86_64/android; "
+                "chmod +x \"$HOME/.android-cli/bin/android\"; "
+                "echo \"Installed: $HOME/.android-cli/bin/android\"; "
+                "echo \"Add $HOME/.android-cli/bin to PATH and run android --version to accept the ToS.\""
                 "'";
 #elif defined(_WIN32) && (defined(_M_X64) || defined(__x86_64__))
             c.fix_cmd =
                 "powershell -NoProfile -Command \""
-                "$tmp = Join-Path $env:TEMP 'pulp-android-cli-install.cmd'; "
+                "New-Item -ItemType Directory -Force "
+                "  -Path \\\"$env:USERPROFILE\\.android-cli\\bin\\\" | Out-Null; "
                 "Invoke-WebRequest -UseBasicParsing "
-                "-Uri 'https://dl.google.com/android/cli/latest/windows_x86_64/install.cmd' "
-                "-OutFile $tmp; "
-                "& cmd /c $tmp\"";
+                "  -Uri 'https://dl.google.com/android/cli/latest/windows_x86_64/android.exe' "
+                "  -OutFile \\\"$env:USERPROFILE\\.android-cli\\bin\\android.exe\\\"; "
+                "Write-Host \\\"Installed: $env:USERPROFILE\\.android-cli\\bin\\android.exe\\\"; "
+                "Write-Host \\\"Add %USERPROFILE%\\.android-cli\\bin to PATH and run 'android --version' to accept the ToS.\\\"\"";
 #endif
         }
         checks.push_back(c);

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -1844,22 +1844,53 @@ std::vector<DoctorCheck> run_doctor_android_checks() {
                 "    chmod +x ~/.android-cli/bin/android\n"
                 "    export PATH=\"$HOME/.android-cli/bin:$PATH\"\n"
                 "  Then accept the ToS on first run: `android --version`.\n"
-                "  See .agents/skills/android/SKILL.md for when to use it."
+                "  Or run `pulp doctor android --fix` to install automatically."
 #elif defined(__linux__) && defined(__x86_64__)
                 "Install (Linux x86_64 — supported):\n"
                 "    curl -fsSL https://dl.google.com/android/cli/latest/linux_x86_64/install.sh | bash\n"
-                "  See .agents/skills/android/SKILL.md for when to use it."
+                "  Or run `pulp doctor android --fix` to install automatically."
 #elif defined(_WIN32) && (defined(_M_X64) || defined(__x86_64__))
                 "Install (Windows x86_64 — supported):\n"
                 "    curl.exe -fsSL https://dl.google.com/android/cli/latest/windows_x86_64/install.cmd"
                 " -o \"%TEMP%\\i.cmd\" && \"%TEMP%\\i.cmd\"\n"
-                "  See .agents/skills/android/SKILL.md for when to use it."
+                "  Or run `pulp doctor android --fix` to install automatically."
 #else
                 "See https://developer.android.com/tools/agents for install"
                 " instructions on supported platforms (macOS arm64,"
                 " Linux x86_64, Windows x86_64)."
 #endif
             ;
+
+            // Real installable command for `pulp doctor android --fix`.
+            // Idempotent (mkdir -p, curl -fsSL overwrites). User runs
+            // `android --version` once after to accept the ToS — the
+            // post-install echo reminds them.
+#if defined(__APPLE__)
+            c.fix_cmd =
+                "bash -c '"
+                "set -e; "
+                "mkdir -p \"$HOME/.android-cli/bin\"; "
+                "curl -fsSL -o \"$HOME/.android-cli/bin/android\" "
+                "https://dl.google.com/android/cli/latest/darwin_arm64/android; "
+                "chmod +x \"$HOME/.android-cli/bin/android\"; "
+                "echo \"Installed: $HOME/.android-cli/bin/android\"; "
+                "echo \"Add $HOME/.android-cli/bin to PATH and run android --version to accept the ToS.\""
+                "'";
+#elif defined(__linux__) && defined(__x86_64__)
+            c.fix_cmd =
+                "bash -c '"
+                "curl -fsSL https://dl.google.com/android/cli/latest/linux_x86_64/install.sh | bash; "
+                "echo \"Run android --version to accept the ToS.\""
+                "'";
+#elif defined(_WIN32) && (defined(_M_X64) || defined(__x86_64__))
+            c.fix_cmd =
+                "powershell -NoProfile -Command \""
+                "$tmp = Join-Path $env:TEMP 'pulp-android-cli-install.cmd'; "
+                "Invoke-WebRequest -UseBasicParsing "
+                "-Uri 'https://dl.google.com/android/cli/latest/windows_x86_64/install.cmd' "
+                "-OutFile $tmp; "
+                "& cmd /c $tmp\"";
+#endif
         }
         checks.push_back(c);
     }

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -1681,9 +1681,41 @@ static fs::path detect_android_cli() {
     return {};
 }
 
+// Detect mise (formerly rtx) — MIT-licensed polyglot version manager
+// (https://mise.jdx.dev). When present, doctor prefers it as the
+// install channel for JDK/Android SDK/etc. instead of brew/apt/winget,
+// so we don't add a parallel install of something the user already
+// manages through mise. See #398 for the heterogeneity policy.
+static fs::path detect_mise() {
+    std::string found = find_executable_in_path("mise");
+    if (found.empty()) found = find_executable_in_path("rtx");  // legacy name
+    return found.empty() ? fs::path{} : fs::path(found);
+}
+
 std::vector<DoctorCheck> run_doctor_android_checks() {
     std::vector<DoctorCheck> checks;
     auto sdk = detect_android_sdk_root();
+
+    // Detect mise once up-front so per-tool checks can prefer it as
+    // the install channel when present. Always reported as PASS;
+    // absence isn't a failure — it's a free upgrade some users
+    // have, others don't.
+    const auto mise = detect_mise();
+    {
+        DoctorCheck c{"mise (optional channel preference)", true, {}, {}};
+        if (!mise.empty()) {
+            c.detail = mise.string()
+                + " — `--fix` will prefer `mise use ...` over brew/apt/winget"
+                  " for JDK / cmdline-tools. Avoids parallel installs.";
+        } else {
+            c.detail =
+                "not installed — `--fix` will use brew/apt/winget. "
+                "Install mise (MIT-licensed, https://mise.jdx.dev) for "
+                "polyglot version management that coexists cleanly with "
+                "system installs: `curl https://mise.run | sh`";
+        }
+        checks.push_back(c);
+    }
 
     {
         DoctorCheck c{"Android SDK", false, {}, {}};
@@ -1780,24 +1812,37 @@ std::vector<DoctorCheck> run_doctor_android_checks() {
             c.detail = ver;
         } else {
             c.detail = ver.empty() ? "java not found" : (ver + " (need 17+)");
+
+            // Prefer mise when present — it co-exists with system
+            // installs cleanly via per-shim resolution rather than
+            // shadowing $PATH.
+            if (!mise.empty()) {
+                c.fix = "mise use --global jdk@21  (preferred — co-exists with system installs)";
+                c.fix_cmd = "mise use --global jdk@21";
+            } else {
 #if defined(__APPLE__)
-            c.fix = "brew install openjdk@21 && "
-                    "sudo ln -sfn $(brew --prefix)/opt/openjdk@21/libexec/openjdk.jdk "
-                    "/Library/Java/JavaVirtualMachines/openjdk-21.jdk";
-            c.fix_cmd = "brew install openjdk@21";
+                c.fix = "brew install openjdk@21 && "
+                        "sudo ln -sfn $(brew --prefix)/opt/openjdk@21/libexec/openjdk.jdk "
+                        "/Library/Java/JavaVirtualMachines/openjdk-21.jdk\n"
+                        "  Or install mise first for cleaner version management:\n"
+                        "    curl https://mise.run | sh && mise use --global jdk@21";
+                c.fix_cmd = "brew install openjdk@21";
 #elif defined(__linux__)
-            c.fix = "Install OpenJDK 21 via your distro:\n"
-                    "    sudo apt install -y openjdk-21-jdk            # Debian/Ubuntu\n"
-                    "    sudo dnf install -y java-21-openjdk-devel     # Fedora/RHEL";
-            c.fix_cmd = "bash -c 'if command -v apt >/dev/null; then "
-                        "sudo apt update && sudo apt install -y openjdk-21-jdk; "
-                        "elif command -v dnf >/dev/null; then "
-                        "sudo dnf install -y java-21-openjdk-devel; "
-                        "else echo \"No supported package manager found\"; exit 1; fi'";
+                c.fix = "Install OpenJDK 21 via your distro:\n"
+                        "    sudo apt install -y openjdk-21-jdk            # Debian/Ubuntu\n"
+                        "    sudo dnf install -y java-21-openjdk-devel     # Fedora/RHEL\n"
+                        "  Or install mise first: curl https://mise.run | sh && mise use --global jdk@21";
+                c.fix_cmd = "bash -c 'if command -v apt >/dev/null; then "
+                            "sudo apt update && sudo apt install -y openjdk-21-jdk; "
+                            "elif command -v dnf >/dev/null; then "
+                            "sudo dnf install -y java-21-openjdk-devel; "
+                            "else echo \"No supported package manager found\"; exit 1; fi'";
 #elif defined(_WIN32)
-            c.fix = "winget install --silent --id Microsoft.OpenJDK.21";
-            c.fix_cmd = "winget install --silent --id Microsoft.OpenJDK.21";
+                c.fix = "winget install --silent --id Microsoft.OpenJDK.21\n"
+                        "  Or install mise first: irm https://mise.run | iex; mise use --global jdk@21";
+                c.fix_cmd = "winget install --silent --id Microsoft.OpenJDK.21";
 #endif
+            }
         }
         checks.push_back(c);
     }

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -148,7 +148,11 @@ struct DoctorCheck {
     std::string name;
     bool passed;
     std::string detail;
-    std::string fix;
+    std::string fix;       // Human-readable hint shown in default mode.
+    std::string fix_cmd;   // Executable shell command for --fix mode.
+                           // If empty, --fix runs `fix` verbatim (legacy
+                           // behaviour for single-line command hints
+                           // like `xcode-select --install`).
 };
 
 std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, bool standalone_mode);

--- a/tools/cli/cmd_doctor.cpp
+++ b/tools/cli/cmd_doctor.cpp
@@ -83,20 +83,32 @@ int cmd_doctor(const std::vector<std::string>& args) {
                 std::string msg = c.name;
                 if (!c.detail.empty()) msg += " — " + c.detail;
                 print_fail(msg);
-                if (!c.fix.empty()) {
+                if (!c.fix.empty() || !c.fix_cmd.empty()) {
+                    // Prefer fix_cmd (executable shell command) when
+                    // present; fall back to running the prose `fix`
+                    // verbatim — legacy behaviour for single-line
+                    // hints like `xcode-select --install` that are
+                    // already shell-executable as written.
+                    const std::string& effective_fix =
+                        c.fix_cmd.empty() ? c.fix : c.fix_cmd;
+
                     if (fix_mode && !dry_run) {
-                        std::cout << "    " << color::cyan() << "Fixing:" << color::reset() << " " << c.fix << "\n";
-                        int rc = std::system(c.fix.c_str());
+                        std::cout << "    " << color::cyan() << "Fixing:" << color::reset() << "\n";
+                        if (!c.fix.empty()) {
+                            std::cout << "      " << c.fix << "\n";
+                        }
+                        int rc = std::system(effective_fix.c_str());
                         if (rc == 0) {
                             print_ok("Fixed");
                             --fail_count;
                             ++pass_count;
                         } else {
                             std::cout << "    Fix failed (exit " << rc << "). Run manually:\n";
-                            std::cout << "      " << color::yellow() << c.fix << color::reset() << "\n";
+                            std::cout << "      " << color::yellow() << effective_fix << color::reset() << "\n";
                         }
                     } else if (dry_run) {
-                        std::cout << "    " << color::dim() << "[dry-run] Would run: " << c.fix << color::reset() << "\n";
+                        std::cout << "    " << color::dim() << "[dry-run] Would run: "
+                                  << effective_fix << color::reset() << "\n";
                     } else {
                         std::cout << "    Fix: " << color::yellow() << c.fix << color::reset() << "\n";
                     }


### PR DESCRIPTION
## What

Phase 1 of #394 (the user-asked install layer that complements #389's detection layer): \`pulp doctor android --fix\` now actually installs the optional Google Android CLI binary instead of just printing the curl one-liner. Verified end-to-end on macOS arm64.

## Mechanism

\`DoctorCheck\` gains a \`fix_cmd\` field separate from the prose \`fix\` hint. \`cmd_doctor\`'s \`--fix\` mode prefers \`fix_cmd\` when present, falling back to running the prose \`fix\` verbatim — backward-compat for existing single-line hints like \`xcode-select --install\` that are already shell-executable as written.

For the Android CLI check specifically, \`fix_cmd\` is wired per-host:

- **macOS arm64** — curl + chmod into \`~/.android-cli/bin/\`.
- **Linux x86_64** — \`install.sh | bash\`.
- **Windows x86_64** — Invoke-WebRequest + \`cmd /c install.cmd\`.
- **Unsupported hosts** (Linux arm64 / Windows arm64 / macOS Intel) — no \`fix_cmd\` set; the entry already passes with an explanation per #389's matrix.

## Opt-in only

Default \`pulp doctor\` doesn't run android/ios checks. User has to explicitly type \`pulp doctor android\` (detection only) or \`pulp doctor android --fix\` (install). Nobody who doesn't want Android tooling sees any of this — directly addresses the user's note that *'not everyone will want iOS and or Android support on the platforms.'*

## Verified end-to-end

\`\`\`
$ mv ~/.android-cli/bin/android ~/.android-cli/bin/android.bak
$ ./build/tools/cli/pulp doctor android
  ✓ Android SDK / NDK / adb / emulator+AVD
  ✗ Google Android CLI — not installed
  4/5 checks passed

$ ./build/tools/cli/pulp doctor android --fix
  ✗ Google Android CLI ... Fixing: <curl + chmod>
  ✓ Fixed
  5/5 checks passed

$ ~/.android-cli/bin/android --version
0.7.15232955
\`\`\`

## Out of scope (Phase 2 / Phase 3 under #394)

- Android SDK / NDK / emulator / AVD bootstrap via \`sdkmanager\` (needs interactive license accept; heavier work).
- Xcode.app install nudge — App Store isn't scriptable; \`mas-cli\` when present, otherwise prose stays.
- \`pulp doctor ios --fix\` for Xcode CLT — \`setup.sh\` already does this; doctor mode just needs to mirror it.

## Base branch

This PR targets \`feature/pulp-doctor-mobile\` (PR #389) since it extends the doctor android/ios subcommands that PR adds. After #389 merges to main, GitHub will rebase this onto main.

Refs #394 (the install-layer tracker), #389 (the detection layer), #355 (the Android CLI).