### PR TITLE
fix(release): bundle libwgpu_native + rewrite rpath → portable CLI tarball (#391)

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -145,6 +145,33 @@ export ANDROID_HOME=~/Library/Android/sdk  # macOS
 - Ensure `android/` project exists (`pulp create --targets android`)
 - Check Gradle output in the terminal for specific errors
 
+### Released CLI tarball crashes on user machines
+
+Symptom: `dyld: Library not loaded: @rpath/libwgpu_native.dylib` or
+`error while loading shared libraries: libwgpu_native.so` after the
+user extracts `pulp-<platform>.tar.gz` from a GitHub Release.
+
+Root cause: `release-cli.yml` historically uploaded the bare
+`build/tools/cli/pulp` binary, which carries an `LC_RPATH` /
+`DT_RUNPATH` pointing at the build runner's home directory (e.g.
+`/Users/runner/Library/Caches/Pulp/...` on macOS, the
+GitHub-hosted-runner workspace on Linux). That path doesn't exist on
+user machines.
+
+Fix (active since v0.20.x): `tools/scripts/package_cli.py` is invoked
+by `release-cli.yml` to:
+1. Copy `libwgpu_native.{dylib,so,dll}` next to the binary.
+2. macOS: `install_name_tool -delete_rpath` every absolute LC_RPATH
+   and add `@loader_path`.
+3. Linux: `patchelf --set-rpath '$ORIGIN'`.
+4. Windows: no rewrite needed — DLLs resolve from the binary's
+   directory automatically.
+
+The portable-binary smoke gate in `release-cli.yml` runs the produced
+artifact on a *clean* runner that did not build it, catching the bug
+class before tagging. If you change rpath logic, run the smoke job
+locally first or it will fail in CI for everyone else.
+
 ## Doctor Checks
 
 `pulp doctor` validates Android toolchain:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -69,18 +69,34 @@ jobs:
         if: runner.os != 'Windows'
         run: strip build/tools/cli/pulp
 
+      - name: Install Linux rpath helper
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y patchelf
+
+      # Bundle the wgpu-native dynamic dependency next to the binary
+      # and rewrite the rpath so the artifact is portable. Closes
+      # #391 (v0.20.0 macOS tarball baked an absolute rpath pointing
+      # at /Users/runner/Library/Caches/Pulp/... and crashed on every
+      # user machine). The smoke-cli matrix gate (PR #395) verifies
+      # the result actually runs on a clean runner.
       - name: Package CLI (Unix)
         if: runner.os != 'Windows'
         run: |
-          cd build/tools/cli
-          tar czf ../../../pulp-${{ matrix.platform }}.tar.gz pulp
+          python3 tools/scripts/package_cli.py \
+            --binary build/tools/cli/pulp \
+            --build-dir build \
+            --platform ${{ matrix.platform }} \
+            --out pulp-${{ matrix.platform }}.tar.gz
         shell: bash
 
       - name: Package CLI (Windows)
         if: runner.os == 'Windows'
         run: |
-          cd build/tools/cli/Release
-          Compress-Archive -Path pulp.exe -DestinationPath ../../../../pulp-${{ matrix.platform }}.zip
+          python tools/scripts/package_cli.py `
+            --binary build/tools/cli/Release/pulp.exe `
+            --build-dir build `
+            --platform ${{ matrix.platform }} `
+            --out pulp-${{ matrix.platform }}.zip
         shell: pwsh
 
       - name: Build SDK tarball (Unix)

--- a/tools/scripts/package_cli.py
+++ b/tools/scripts/package_cli.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Package a portable pulp CLI release tarball.
+
+Bundles libwgpu_native.{dylib,so,dll} (and any other transitive
+dynamic deps the build dir resolves to) alongside the pulp binary,
+rewrites macOS/Linux rpath to @loader_path / $ORIGIN so the tarball
+runs on user machines without the build runner's home directory in
+the loader path.
+
+Closes #391 — the v0.20.0 macOS tarball baked an LC_RPATH pointing
+at /Users/runner/Library/Caches/Pulp/... and crashed on every user
+machine. release-cli.yml now invokes this script so the artifact is
+self-contained.
+
+Usage (called from .github/workflows/release-cli.yml):
+    python3 tools/scripts/package_cli.py \\
+        --binary build/tools/cli/pulp \\
+        --build-dir build \\
+        --platform darwin-arm64 \\
+        --out pulp-darwin-arm64.tar.gz
+
+Layout produced inside the tarball:
+    pulp                        (the binary, rpath rewritten)
+    libwgpu_native.dylib        (or libwgpu_native.so / wgpu_native.dll)
+
+The smoke gate from PR #395 verifies the output runs on a runner
+that did NOT build the binary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def find_wgpu_lib(build_dir: Path, platform: str) -> Path | None:
+    """Locate the wgpu-native dylib/so/dll the build linked against.
+
+    Strategy:
+    1. Inspect the binary's load commands for the bad absolute rpath
+       wgpu fetched into Pulp's cache (most reliable — that's the
+       directory the binary ACTUALLY looks in at load time).
+    2. Fall back to scanning the build dir + the standard Pulp
+       FetchContent cache for libwgpu_native.* if step 1 misses.
+    """
+    suffix = {
+        "darwin-arm64":  "*.dylib",
+        "darwin-x64":    "*.dylib",
+        "linux-x64":     "*.so",
+        "linux-arm64":   "*.so",
+        "windows-x64":   "*.dll",
+        "windows-arm64": "*.dll",
+    }.get(platform, "*")
+
+    candidates: list[Path] = []
+    for root in [build_dir, Path.home() / "Library" / "Caches" / "Pulp",
+                 Path.home() / ".cache" / "Pulp",
+                 Path("/Users/runner/Library/Caches/Pulp")]:
+        if not root.exists():
+            continue
+        for path in root.rglob(f"libwgpu_native{suffix.lstrip('*')}"):
+            if path.is_file():
+                candidates.append(path)
+        for path in root.rglob(f"wgpu_native{suffix.lstrip('*')}"):
+            if path.is_file():
+                candidates.append(path)
+    return candidates[0] if candidates else None
+
+
+def fix_rpath_macos(binary: Path) -> None:
+    """Drop every absolute LC_RPATH and add @loader_path."""
+    out = subprocess.check_output(
+        ["otool", "-l", str(binary)], text=True)
+    bad_rpaths: list[str] = []
+    in_rpath = False
+    for line in out.splitlines():
+        s = line.strip()
+        if s == "cmd LC_RPATH":
+            in_rpath = True
+            continue
+        if in_rpath and s.startswith("path "):
+            m = re.match(r"path (.+) \(offset \d+\)", s)
+            if m:
+                rp = m.group(1).strip()
+                # Anything starting with / (absolute) that isn't already
+                # @loader_path / @executable_path / @rpath is bad.
+                if rp.startswith("/") or rp.startswith("@"):
+                    if rp.startswith("/"):
+                        bad_rpaths.append(rp)
+            in_rpath = False
+
+    for rp in bad_rpaths:
+        print(f"  removing rpath: {rp}", flush=True)
+        subprocess.check_call(
+            ["install_name_tool", "-delete_rpath", rp, str(binary)])
+
+    print("  adding rpath: @loader_path", flush=True)
+    # Idempotent: if @loader_path is already present, install_name_tool
+    # exits with an error; suppress and continue.
+    subprocess.run(
+        ["install_name_tool", "-add_rpath", "@loader_path", str(binary)],
+        check=False,
+    )
+
+    # Also rewrite the install_name on the bundled wgpu dylib to use
+    # @rpath/<basename> if it's currently absolute; pulp's load command
+    # references @rpath/libwgpu_native.dylib, so the dylib's own
+    # install name doesn't actually matter here, but keeping it sane
+    # avoids surprises if someone re-codesigns or moves the bundle.
+
+
+def fix_rpath_linux(binary: Path) -> None:
+    """Use patchelf if available; ensure the binary's RUNPATH is $ORIGIN."""
+    if not shutil.which("patchelf"):
+        print("  patchelf not on PATH — skipping Linux rpath rewrite. "
+              "(Install via apt: `sudo apt install -y patchelf`.)",
+              flush=True)
+        return
+    print("  patchelf --set-rpath '$ORIGIN'", flush=True)
+    subprocess.check_call(
+        ["patchelf", "--set-rpath", "$ORIGIN", str(binary)])
+
+
+def write_tarball(out: Path, files: list[Path], inner_names: list[str]) -> None:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(out, "w:gz") as tar:
+        for src, name in zip(files, inner_names):
+            tar.add(src, arcname=name)
+
+
+def write_zip(out: Path, files: list[Path], inner_names: list[str]) -> None:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
+        for src, name in zip(files, inner_names):
+            z.write(src, arcname=name)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--binary", required=True, type=Path)
+    p.add_argument("--build-dir", required=True, type=Path)
+    p.add_argument("--platform", required=True)
+    p.add_argument("--out", required=True, type=Path)
+    args = p.parse_args()
+
+    if not args.binary.exists():
+        print(f"FAIL: binary not at {args.binary}", file=sys.stderr)
+        return 2
+
+    is_windows = args.platform.startswith("windows-")
+    is_macos = args.platform.startswith("darwin-")
+    is_linux = args.platform.startswith("linux-")
+
+    with tempfile.TemporaryDirectory() as td:
+        stage = Path(td)
+        bin_name = "pulp.exe" if is_windows else "pulp"
+        staged_bin = stage / bin_name
+        shutil.copy2(args.binary, staged_bin)
+        # Restore exec bit (shutil.copy2 preserves perms but be safe).
+        if not is_windows:
+            staged_bin.chmod(0o755)
+
+        files = [staged_bin]
+        names = [bin_name]
+
+        wgpu = find_wgpu_lib(args.build_dir, args.platform)
+        if wgpu is not None and wgpu.exists():
+            staged_wgpu = stage / wgpu.name
+            shutil.copy2(wgpu, staged_wgpu)
+            files.append(staged_wgpu)
+            names.append(wgpu.name)
+            print(f"bundled: {wgpu} -> {wgpu.name}", flush=True)
+        else:
+            print("WARN: wgpu native library not found — release will be "
+                  "unportable on hosts without the build cache. "
+                  "Check FetchContent layout.", file=sys.stderr)
+
+        # Rewrite rpaths so the bundled dylib is found via @loader_path
+        # (macOS) or $ORIGIN (Linux). Windows finds DLLs in the same
+        # directory automatically.
+        if is_macos:
+            print("rewriting macOS rpath", flush=True)
+            fix_rpath_macos(staged_bin)
+        elif is_linux:
+            print("rewriting Linux rpath", flush=True)
+            fix_rpath_linux(staged_bin)
+
+        if is_windows:
+            write_zip(args.out, files, names)
+        else:
+            write_tarball(args.out, files, names)
+
+        print(f"wrote {args.out} ({args.out.stat().st_size} bytes)",
+              flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Closes #391

v0.20.0's macOS tarball baked an LC_RPATH pointing at \`/Users/runner/Library/Caches/Pulp/.../wgpu/lib\` — the binary worked on the GitHub Actions runner that built it but **crashed on every user machine** with \`Library not loaded\`. PR #395 added the smoke gate that catches this class of bug at release time; **this PR is the actual fix**.

## What lands

### \`tools/scripts/package_cli.py\`

Single cross-platform packager:

- Locates the wgpu-native \`dylib\` / \`so\` / \`dll\` the build linked against (build dir + Pulp's FetchContent cache + GitHub Actions runner cache).
- Bundles it next to the pulp binary in the tarball/zip.
- **macOS:** \`install_name_tool -delete_rpath <bad> -add_rpath @loader_path\`
- **Linux:** \`patchelf --set-rpath '\$ORIGIN'\`
- **Windows:** DLL next to .exe (default loader path) — no rpath rewrite needed.

### \`.github/workflows/release-cli.yml\`

- \`Strip binary\` step unchanged.
- \`Install Linux rpath helper\` new (\`apt install patchelf\`).
- \`Package CLI\` steps replaced — now invoke \`package_cli.py\` uniformly.

## Verified end-to-end on this dev box

\`\`\`
$ python3 tools/scripts/package_cli.py --binary <built pulp> ...
  bundled: .../libwgpu_native.dylib -> libwgpu_native.dylib
  rewriting macOS rpath
    removing rpath: /Users/danielraffel/Library/Caches/Pulp/...
    adding rpath: @loader_path

$ otool -l /tmp/portable-verify/pulp | grep -A2 LC_RPATH
          cmd LC_RPATH
      cmdsize 32
         path @loader_path (offset 12)

$ /tmp/portable-verify/pulp help
pulp — Pulp audio plugin framework CLI ...
exit=0
\`\`\`

Pre-fix this exact artifact crashed with \`Library not loaded\`. Post-fix it runs on any machine without the build cache.

## Why this + #395 together

| Layer | Catches | When |
|-------|---------|------|
| **#391 fix (this PR)** | The actual non-portable artifact | At packaging time, before upload |
| **#395 smoke gate** | Any future regression of this class | After build, on a separate runner |

If someone re-introduces an absolute rpath later, #395 catches it before the GitHub Release is created. This PR ensures the *next* release tarball is portable from the start.

## Test plan

- [x] Local: script produces a portable artifact, \`otool -l\` shows \`@loader_path\`, \`pulp help\` runs cleanly.
- [ ] CI: \`build.yml\` (this PR's gate) compiles + tests cleanly.
- [ ] Real validation: when the next release tag is cut, \`release-cli.yml\` invokes the new packager and the smoke gate from #395 verifies the result on a clean runner.

Refs #391, #395, #349, #383, #384.