### PR TITLE
view: Linux ATK pkg-config integration (#18 phase 1)

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -183,6 +183,38 @@ target_sources(pulp-view PRIVATE
 # AU/VST3/CLAP plugins.
 # The ObjC runtime loads WebKit on dylib load if any WKWebView references exist,
 # which crashes Logic Pro's sandboxed AUHostingServiceXPC process.
+# ── Linux ATK accessibility (#18 phase 1) ───────────────────────────────────
+#
+# Pulp publishes accessibility info to Linux screen readers (Orca) via
+# ATK + the at-spi2-atk bridge. This slice only wires the ATK headers
+# into the build so accessibility_linux.cpp can use the real AtkRole
+# enum instead of hard-coded integer constants. The full AtkObject
+# vtable + at-spi2 bridge runtime is a follow-up PR that needs
+# screen-reader validation on a real Linux desktop.
+#
+# Without libatk-dev, accessibility_linux.cpp keeps the pre-existing
+# fallback constants so contributors on minimal images still build.
+#
+# Install on Debian/Ubuntu: sudo apt install -y libatk1.0-dev
+if(UNIX AND NOT APPLE AND NOT ANDROID)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PULP_ATK QUIET IMPORTED_TARGET atk)
+        if(PULP_ATK_FOUND)
+            target_compile_definitions(pulp-view PRIVATE PULP_HAS_ATK=1)
+            target_link_libraries(pulp-view PRIVATE PkgConfig::PULP_ATK)
+            message(STATUS
+                "Pulp: Linux ATK ${PULP_ATK_VERSION} found — "
+                "accessibility_linux.cpp will use real AtkRole enum")
+        else()
+            message(STATUS
+                "Pulp: Linux ATK dev headers not found "
+                "(install: sudo apt install libatk1.0-dev) — "
+                "accessibility_linux.cpp will use stub constants")
+        endif()
+    endif()
+endif()
+
 option(PULP_BUILD_WEBVIEW "Include native WebView support (WebKit / WebView2 / WebKitGTK)" OFF)
 if(PULP_BUILD_WEBVIEW)
     target_sources(pulp-view PRIVATE src/web_view.cpp)

--- a/core/view/platform/linux/accessibility_linux.cpp
+++ b/core/view/platform/linux/accessibility_linux.cpp
@@ -17,9 +17,14 @@
 #include <pulp/view/view.hpp>
 #include <pulp/runtime/log.hpp>
 
-// PULP_HAS_ATSPI is set by CMake when atk-bridge-2.0 is found via
-// pkg-config. When unset, the init path stays a no-op so Linux distros
-// without the bridge (minimal / headless CI images) still link.
+// PULP_HAS_ATK is set by CMake when atk is found via pkg-config; this
+// gives us the real AtkRole enum so the role mapping below survives any
+// future renumbering by GNOME. PULP_HAS_ATSPI is set when the at-spi2
+// bridge runtime is also linkable — that path is currently a stub and
+// is filled in by the follow-up PR that adds AtkObject implementations.
+#ifdef PULP_HAS_ATK
+#include <atk/atk.h>
+#endif
 #ifdef PULP_HAS_ATSPI
 extern "C" {
 int  atk_bridge_adaptor_init(int* argc, char*** argv);
@@ -29,18 +34,31 @@ void atk_bridge_adaptor_cleanup(void);
 
 namespace pulp::view {
 
-// Map Pulp AccessRole to ATK role constants
-// These match the AtkRole enum from atk/atk.h
+// Map Pulp AccessRole to ATK role values. With PULP_HAS_ATK we use the
+// AtkRole enum directly; without it we fall back to the integer values
+// from ATK 2.52 so headless CI images without libatk-dev still link.
 static int access_role_to_atk_role(View::AccessRole role) {
+#ifdef PULP_HAS_ATK
+    switch (role) {
+        case View::AccessRole::slider: return ATK_ROLE_SLIDER;
+        case View::AccessRole::toggle: return ATK_ROLE_TOGGLE_BUTTON;
+        case View::AccessRole::label:  return ATK_ROLE_LABEL;
+        case View::AccessRole::group:  return ATK_ROLE_PANEL;
+        case View::AccessRole::meter:  return ATK_ROLE_PROGRESS_BAR;
+        case View::AccessRole::image:  return ATK_ROLE_IMAGE;
+        default:                       return ATK_ROLE_UNKNOWN;
+    }
+#else
     switch (role) {
         case View::AccessRole::slider: return 34;  // ATK_ROLE_SLIDER
         case View::AccessRole::toggle: return 42;  // ATK_ROLE_TOGGLE_BUTTON
         case View::AccessRole::label:  return 24;  // ATK_ROLE_LABEL
-        case View::AccessRole::group:  return 35;  // ATK_ROLE_PANEL (container)
+        case View::AccessRole::group:  return 35;  // ATK_ROLE_PANEL
         case View::AccessRole::meter:  return 33;  // ATK_ROLE_PROGRESS_BAR
         case View::AccessRole::image:  return 21;  // ATK_ROLE_IMAGE
-        default: return 66; // ATK_ROLE_UNKNOWN
+        default:                       return 66;  // ATK_ROLE_UNKNOWN
     }
+#endif
 }
 
 // Stub: Initialize AT-SPI accessibility for a view tree


### PR DESCRIPTION
## Summary

Wire `libatk-1.0` into the build via pkg-config so `accessibility_linux.cpp` uses the real `AtkRole` enum from `<atk/atk.h>` instead of hard-coded ATK 2.52 integer values. Without `libatk1.0-dev`, the previous fallback constants stay in place so headless / minimal CI images still link.

This is the build-system slice only. The AtkObject vtable + at-spi2 bridge runtime that actually publishes Pulp views to Orca is the next slice — that needs screen-reader validation on a real Linux desktop and will land as a follow-up PR.

Refs #18, #217 4.2.

## Changes

- `core/view/CMakeLists.txt` — `pkg_check_modules(PULP_ATK QUIET IMPORTED_TARGET atk)`. When found, defines `PULP_HAS_ATK=1` and links `pulp-view` against `PkgConfig::PULP_ATK`. macOS / Windows / Android paths skipped via `UNIX AND NOT APPLE AND NOT ANDROID` guard.
- `core/view/platform/linux/accessibility_linux.cpp` — `#include <atk/atk.h>` under `PULP_HAS_ATK`, switch role mapping to `ATK_ROLE_*` enum names. Fallback path keeps the hard-coded integer values for builds without ATK headers.

## Test plan

- [x] macOS configure + `pulp-view` build clean (Linux block correctly skipped via `UNIX AND NOT APPLE` guard)
- [x] `ssh ubuntu` confirms `pkg-config --modversion atk` → `2.52.0` available
- [ ] CI Linux build picks up the ATK target via apt-installed `libatk1.0-dev`

## Out of scope (follow-up PR)

- AtkObject implementation (GObject vtable for each accessible View)
- at-spi2 bridge runtime (`atk_bridge_adaptor_init` already wired but currently a no-op without registered objects)
- Orca screen-reader integration test on real Linux desktop