### PR TITLE
platform: unified Environment API for display/safe-area/keyboard/scheme/lifecycle/memory (#342)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.20.0
+    VERSION 0.21.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(pulp-platform PRIVATE
     src/permissions.cpp
     src/registry.cpp
     src/clipboard_common.cpp
+    src/environment.cpp
 )
 
 # Platform-specific UI services and child process

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -23,6 +23,7 @@ if(APPLE AND NOT IOS)
         platform/mac/clipboard_mac.mm
         platform/mac/file_dialog_mac.mm
         platform/mac/popup_menu_mac.mm
+        platform/mac/environment_mac.mm
         platform/posix/child_process_posix.cpp
     )
     target_link_libraries(pulp-platform PRIVATE

--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -1,0 +1,219 @@
+#pragma once
+
+/// @file environment.hpp
+/// Unified environment API: display, safe-area, keyboard, orientation,
+/// color scheme, foreground/background, memory pressure.
+///
+/// Each platform populates the fields it can observe; unsupported fields
+/// retain their default. Listeners receive a snapshot of the new state
+/// + a bitmask of which fields changed since the last notification.
+///
+/// Thread model: Environment is meant to be read from any thread (the
+/// snapshot accessor returns a value copy). Listeners are invoked on the
+/// thread that delivered the platform event — typically the main UI
+/// thread — but no global locking is held during dispatch, so listener
+/// bodies that touch shared state must apply their own synchronization.
+///
+/// This header defines the contract and an in-process notifier. Platform
+/// adapters live under `core/platform/platform/{android,ios,mac,win,linux}/`
+/// and call Environment::dispatcher().publish(...) when their respective
+/// OS callbacks fire (Android `Configuration.onConfigurationChanged`,
+/// iOS `UITraitCollection`, macOS `NSApplicationDidChangeScreenParameters`,
+/// Windows `WM_DPICHANGED`/`WM_SETTINGCHANGE`, Linux XSettings + Wayland
+/// fractional scale).
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace pulp::platform {
+
+/// Light/dark color scheme reported by the OS.
+enum class ColorScheme : uint8_t {
+    light,
+    dark,
+    /// Platform did not report; treat as `dark` per Pulp's default theme.
+    unknown,
+};
+
+/// Coarse foreground/background lifecycle state. Mobile platforms drive
+/// this from the activity/scene lifecycle; desktop drives from the
+/// active-window observer (NSApp resignActive on macOS, WM_ACTIVATEAPP
+/// on Windows, _NET_ACTIVE_WINDOW on X11).
+enum class LifecycleState : uint8_t {
+    foreground,
+    /// App is visible but not the focused window (split-screen, banner).
+    inactive,
+    background,
+    unknown,
+};
+
+/// Device orientation. `flat` is "screen facing up" — used by mobile to
+/// disable orientation-driven layout when the device is lying on a table.
+enum class Orientation : uint8_t {
+    portrait,
+    portrait_upside_down,
+    landscape_left,
+    landscape_right,
+    flat,
+    unknown,
+};
+
+/// Memory pressure level. Mirrors Android's TRIM_MEMORY tiers + iOS's
+/// `didReceiveMemoryWarning` (which becomes `critical`). Desktop
+/// platforms emit `normal` only — they don't have a kernel-driven LMK.
+enum class MemoryPressure : uint8_t {
+    normal,
+    /// Some background processes were killed; trim soft caches.
+    moderate,
+    /// Foreground app is the next likely target; release optional state.
+    critical,
+};
+
+/// Safe-area insets in CSS-pixel space (already divided by content_scale).
+/// Top/bottom cover the iOS notch + home indicator and Android cutouts;
+/// left/right cover landscape notches and rounded display corners.
+struct SafeAreaInsets {
+    float top    = 0.0f;
+    float bottom = 0.0f;
+    float left   = 0.0f;
+    float right  = 0.0f;
+
+    bool is_zero() const noexcept {
+        return top == 0.0f && bottom == 0.0f && left == 0.0f && right == 0.0f;
+    }
+};
+
+/// Soft-keyboard inset (mobile only). The on-screen keyboard occupies
+/// `bottom` pixels of the display from the bottom edge; layout should
+/// translate / shrink accordingly so focused inputs remain visible.
+struct KeyboardInset {
+    float bottom = 0.0f;
+    /// Animation duration the OS reported for the show/hide transition,
+    /// in seconds. Zero when not animating or unknown.
+    float animation_duration = 0.0f;
+};
+
+/// Logical display geometry. `width` and `height` are in CSS pixels;
+/// `physical_*` are the OS's reported pixel resolution. `scale` is the
+/// device pixel ratio (NSScreen backingScaleFactor / Android density /
+/// Windows DPI / 96.0).
+struct DisplayInfo {
+    float width        = 0.0f;
+    float height       = 0.0f;
+    int   physical_width  = 0;
+    int   physical_height = 0;
+    float scale         = 1.0f;
+    /// Refresh rate in Hz. Zero when unknown.
+    float refresh_hz    = 0.0f;
+    /// Optional human-readable name (e.g. "Built-in Retina Display").
+    std::string name;
+};
+
+/// Bitmask of fields that changed in the snapshot delivered to a listener.
+/// Listeners should inspect this rather than diff the whole struct.
+struct EnvironmentChange {
+    bool display          : 1;
+    bool safe_area        : 1;
+    bool keyboard         : 1;
+    bool orientation      : 1;
+    bool color_scheme     : 1;
+    bool lifecycle        : 1;
+    bool memory_pressure  : 1;
+
+    EnvironmentChange() noexcept
+        : display(false), safe_area(false), keyboard(false),
+          orientation(false), color_scheme(false), lifecycle(false),
+          memory_pressure(false) {}
+
+    bool any() const noexcept {
+        return display || safe_area || keyboard || orientation
+            || color_scheme || lifecycle || memory_pressure;
+    }
+};
+
+/// Snapshot of the full environment state. Listener callbacks receive
+/// a `(state, change)` pair so they can branch on `change.color_scheme`
+/// without diffing the previous snapshot themselves.
+struct EnvironmentState {
+    DisplayInfo     display;
+    SafeAreaInsets  safe_area;
+    KeyboardInset   keyboard;
+    Orientation     orientation     = Orientation::unknown;
+    ColorScheme     color_scheme    = ColorScheme::unknown;
+    LifecycleState  lifecycle       = LifecycleState::unknown;
+    MemoryPressure  memory_pressure = MemoryPressure::normal;
+};
+
+/// In-process notifier. Listeners survive until the returned token is
+/// destroyed (RAII subscription pattern, same as runtime::Logger).
+///
+/// The notifier is intentionally a singleton — there's exactly one OS
+/// reporting these signals per process. Tests can call `inject_for_test`
+/// to drive the singleton without a real platform adapter.
+class Environment {
+public:
+    using Listener = std::function<void(const EnvironmentState&,
+                                        EnvironmentChange)>;
+
+    /// RAII subscription. Drop to unsubscribe.
+    class Token {
+    public:
+        Token() = default;
+        ~Token() { reset(); }
+        Token(Token&& other) noexcept;
+        Token& operator=(Token&& other) noexcept;
+        Token(const Token&) = delete;
+        Token& operator=(const Token&) = delete;
+        void reset() noexcept;
+        bool valid() const noexcept { return id_ != 0; }
+    private:
+        friend class Environment;
+        Token(uint64_t id) : id_(id) {}
+        uint64_t id_ = 0;
+    };
+
+    /// Get the process singleton.
+    static Environment& instance();
+
+    /// Snapshot the current state. Safe from any thread.
+    EnvironmentState snapshot() const;
+
+    /// Subscribe to changes. The callback fires after `publish` returns
+    /// the new state. The returned token unsubscribes on destruction.
+    Token subscribe(Listener listener);
+
+    /// Push a new state. Computes `EnvironmentChange` against the prior
+    /// snapshot and dispatches to every listener. Intended for platform
+    /// adapter code; tests use `inject_for_test` (which forwards here
+    /// after taking the test mutex).
+    void publish(const EnvironmentState& next);
+
+    // ── Test hooks ──────────────────────────────────────────────────
+    /// Replace the singleton state and notify listeners. Used by unit
+    /// tests to simulate platform events without a real OS callback.
+    static void inject_for_test(const EnvironmentState& state);
+
+    /// Reset the singleton to defaults and remove every listener.
+    /// Tests call this in TEST_CASE setup so prior tests don't leak
+    /// listeners or stale state.
+    static void reset_for_test();
+
+private:
+    Environment() = default;
+    Environment(const Environment&) = delete;
+    Environment& operator=(const Environment&) = delete;
+
+    void unsubscribe(uint64_t id);
+
+    mutable std::mutex mu_;
+    EnvironmentState   state_;
+    struct Entry { uint64_t id; Listener fn; };
+    std::vector<Entry> listeners_;
+    uint64_t           next_id_ = 1;
+};
+
+} // namespace pulp::platform

--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -216,4 +216,27 @@ private:
     uint64_t           next_id_ = 1;
 };
 
+// ── Per-platform observer bootstraps ─────────────────────────────────
+// Hosts call start_environment_observer() once during startup. Each
+// platform adapter is idempotent — duplicate calls are a no-op so
+// plugin hosts loaded multiple times don't double-register.
+//
+// Adapters land per platform; this header forward-declares them
+// alphabetically. The convenience wrapper at the bottom dispatches to
+// the right one based on the build target.
+
+void start_environment_observer_mac();
+// void start_environment_observer_android(); // follow-up
+// void start_environment_observer_ios();     // follow-up
+// void start_environment_observer_linux();   // follow-up
+// void start_environment_observer_win();     // follow-up
+
+inline void start_environment_observer() {
+#if defined(__APPLE__) && !defined(PULP_IOS)
+    start_environment_observer_mac();
+#endif
+    // Other platforms wire their adapters in follow-up PRs; until then
+    // their hosts simply see the EnvironmentState defaults.
+}
+
 } // namespace pulp::platform

--- a/core/platform/platform/mac/environment_mac.mm
+++ b/core/platform/platform/mac/environment_mac.mm
@@ -1,0 +1,223 @@
+// macOS adapter for the unified Environment API (#342).
+//
+// Subscribes to NSApp + NSScreen notifications, snapshots the OS state
+// into Environment::publish(). Listeners outside the platform layer
+// don't see any AppKit types — Environment is pure C++.
+//
+// Hooks:
+//   NSApplicationDidChangeScreenParametersNotification → display
+//   NSApplicationDidBecomeActiveNotification          → lifecycle (foreground)
+//   NSApplicationDidResignActiveNotification          → lifecycle (inactive)
+//   NSApplicationDidHideNotification                  → lifecycle (background)
+//   NSApplicationDidUnhideNotification                → lifecycle (foreground)
+//   KVO on NSApp.effectiveAppearance                  → color scheme
+//
+// Memory pressure on macOS is sourced from the dispatch source
+// DISPATCH_SOURCE_TYPE_MEMORYPRESSURE so we don't depend on AppKit
+// being initialized before that signal arrives.
+//
+// Safe-area / keyboard / orientation are mobile-only — desktop
+// macOS leaves them at default (zero / unknown / zero), per the
+// EnvironmentState contract.
+
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+#include <pulp/platform/environment.hpp>
+#include <dispatch/dispatch.h>
+
+using pulp::platform::ColorScheme;
+using pulp::platform::DisplayInfo;
+using pulp::platform::Environment;
+using pulp::platform::EnvironmentState;
+using pulp::platform::LifecycleState;
+using pulp::platform::MemoryPressure;
+
+namespace {
+
+DisplayInfo snapshot_main_display() {
+    DisplayInfo info;
+    NSScreen* screen = [NSScreen mainScreen];
+    if (!screen) return info;
+    NSRect frame = screen.frame;
+    info.width  = static_cast<float>(frame.size.width);
+    info.height = static_cast<float>(frame.size.height);
+    info.scale  = static_cast<float>(screen.backingScaleFactor);
+    info.physical_width  = static_cast<int>(frame.size.width  * info.scale);
+    info.physical_height = static_cast<int>(frame.size.height * info.scale);
+    if (@available(macOS 12.0, *)) {
+        // maximumFramesPerSecond is the panel cap; for ProMotion this
+        // returns 120, for standard 60. Zero means unknown.
+        info.refresh_hz = static_cast<float>(screen.maximumFramesPerSecond);
+    }
+    if (NSString* name = screen.localizedName) {
+        info.name = name.UTF8String ? name.UTF8String : "";
+    }
+    return info;
+}
+
+ColorScheme detect_color_scheme() {
+    NSAppearance* appearance = nil;
+    if (NSApp) appearance = NSApp.effectiveAppearance;
+    if (!appearance) appearance = [NSAppearance currentDrawingAppearance];
+    if (!appearance) return ColorScheme::unknown;
+    NSAppearanceName best = [appearance bestMatchFromAppearancesWithNames:@[
+        NSAppearanceNameAqua,
+        NSAppearanceNameDarkAqua
+    ]];
+    if ([best isEqualToString:NSAppearanceNameDarkAqua]) return ColorScheme::dark;
+    if ([best isEqualToString:NSAppearanceNameAqua])     return ColorScheme::light;
+    return ColorScheme::unknown;
+}
+
+void publish_full_snapshot(LifecycleState lifecycle, MemoryPressure pressure) {
+    EnvironmentState s;
+    s.display      = snapshot_main_display();
+    s.color_scheme = detect_color_scheme();
+    s.lifecycle    = lifecycle;
+    s.memory_pressure = pressure;
+    Environment::instance().publish(s);
+}
+
+} // namespace
+
+@interface PulpEnvironmentObserver : NSObject
+@property(nonatomic) pulp::platform::LifecycleState currentLifecycle;
+@property(nonatomic) pulp::platform::MemoryPressure currentPressure;
+- (void)startObserving;
+@end
+
+@implementation PulpEnvironmentObserver {
+    dispatch_source_t _pressureSource;
+}
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _currentLifecycle = LifecycleState::foreground;
+        _currentPressure  = MemoryPressure::normal;
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    if (NSApp) {
+        @try { [NSApp removeObserver:self forKeyPath:@"effectiveAppearance"]; }
+        @catch (NSException*) {}
+    }
+    if (_pressureSource) {
+        dispatch_source_cancel(_pressureSource);
+        _pressureSource = nullptr;
+    }
+}
+
+- (void)startObserving {
+    NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
+
+    [nc addObserver:self
+           selector:@selector(onScreenChange:)
+               name:NSApplicationDidChangeScreenParametersNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onActive:)
+               name:NSApplicationDidBecomeActiveNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onResign:)
+               name:NSApplicationDidResignActiveNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onHide:)
+               name:NSApplicationDidHideNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onUnhide:)
+               name:NSApplicationDidUnhideNotification
+             object:nil];
+
+    if (NSApp) {
+        [NSApp addObserver:self
+                forKeyPath:@"effectiveAppearance"
+                   options:0
+                   context:nullptr];
+    }
+
+    // Memory pressure dispatch source. Coalesces warning + critical so
+    // a transition warning -> critical becomes two publish() calls.
+    _pressureSource = dispatch_source_create(
+        DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0,
+        DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL,
+        dispatch_get_main_queue());
+    if (_pressureSource) {
+        // Observer is process-lived (created via dispatch_once and never
+        // released), so capturing self by reference is safe. The block
+        // also keeps it alive while the dispatch source is active.
+        // Codebase compiles .mm files in MRR — no __weak available.
+        dispatch_source_t source = _pressureSource;
+        PulpEnvironmentObserver* observerRef = self;
+        dispatch_source_set_event_handler(_pressureSource, ^{
+            unsigned long flags = dispatch_source_get_data(source);
+            if (flags & DISPATCH_MEMORYPRESSURE_CRITICAL) {
+                observerRef.currentPressure = MemoryPressure::critical;
+            } else if (flags & DISPATCH_MEMORYPRESSURE_WARN) {
+                observerRef.currentPressure = MemoryPressure::moderate;
+            } else {
+                observerRef.currentPressure = MemoryPressure::normal;
+            }
+            publish_full_snapshot(observerRef.currentLifecycle,
+                                  observerRef.currentPressure);
+        });
+        dispatch_resume(_pressureSource);
+    }
+
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+
+- (void)onScreenChange:(NSNotification*)note {
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+- (void)onActive:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::foreground;
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+- (void)onResign:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::inactive;
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+- (void)onHide:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::background;
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+- (void)onUnhide:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::foreground;
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+
+- (void)observeValueForKeyPath:(NSString*)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey,id>*)change
+                       context:(void*)context {
+    if ([keyPath isEqualToString:@"effectiveAppearance"]) {
+        publish_full_snapshot(_currentLifecycle, _currentPressure);
+    }
+}
+@end
+
+namespace pulp::platform {
+
+namespace {
+PulpEnvironmentObserver* g_observer = nil;
+}
+
+// Public entry — host bootstrap calls this once during NSApp setup.
+// Idempotent: a second call is a no-op so AU/VST3/CLAP host loads
+// don't double-register observers.
+void start_environment_observer_mac() {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        g_observer = [[PulpEnvironmentObserver alloc] init];
+        [g_observer startObserving];
+    });
+}
+
+} // namespace pulp::platform

--- a/core/platform/src/android/jni_bridge.cpp
+++ b/core/platform/src/android/jni_bridge.cpp
@@ -1,6 +1,7 @@
 #if defined(__ANDROID__)
 
 #include <pulp/platform/android/jni.hpp>
+#include <pulp/platform/environment.hpp>
 #include <android/log.h>
 #include <stdexcept>
 #include <string>
@@ -110,7 +111,12 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_pulp_PulpActivity_nativeOnForeground(JNIEnv* env, jobject thiz) {
     try {
         PULP_LOGI("nativeOnForeground");
-        // TODO: Resume rendering, restore GPU caches
+        // Publish to the unified environment notifier (#342). Callers
+        // subscribed via Environment::subscribe receive the new lifecycle
+        // state and can resume rendering / restore GPU caches.
+        auto s = pulp::platform::Environment::instance().snapshot();
+        s.lifecycle = pulp::platform::LifecycleState::foreground;
+        pulp::platform::Environment::instance().publish(s);
     } catch (const std::exception& e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
     } catch (...) {
@@ -123,7 +129,11 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_pulp_PulpActivity_nativeOnBackground(JNIEnv* env, jobject thiz) {
     try {
         PULP_LOGI("nativeOnBackground");
-        // TODO: Reduce rendering, prepare for possible LMK
+        // Publish via the unified environment notifier (#342). Callers
+        // reduce rendering / drop optional caches in response.
+        auto s = pulp::platform::Environment::instance().snapshot();
+        s.lifecycle = pulp::platform::LifecycleState::background;
+        pulp::platform::Environment::instance().publish(s);
     } catch (const std::exception& e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
     } catch (...) {
@@ -149,7 +159,27 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_pulp_PulpActivity_nativeOnMemoryPressure(JNIEnv* env, jobject thiz, jint level) {
     try {
         PULP_LOGI("nativeOnMemoryPressure: level=%d", level);
-        // TODO: Wire to on_memory_pressure() for tiered cache release
+        // Translate Android onTrimMemory level into Pulp's coarser
+        // MemoryPressure tiers. The Android level values are stable
+        // public API constants on ComponentCallbacks2:
+        //   TRIM_MEMORY_COMPLETE   = 80  (critical — next to be killed)
+        //   TRIM_MEMORY_MODERATE   = 60  (significant — foreground at risk)
+        //   TRIM_MEMORY_BACKGROUND = 40  (background — start releasing)
+        //   TRIM_MEMORY_UI_HIDDEN  = 20  (UI no longer visible)
+        //   TRIM_MEMORY_RUNNING_*   (5/10/15 — foreground running low)
+        namespace pp = pulp::platform;
+        auto pressure = pp::MemoryPressure::normal;
+        if (level >= 80) {
+            pressure = pp::MemoryPressure::critical;
+        } else if (level >= 40) {
+            pressure = pp::MemoryPressure::moderate;
+        } else if (level >= 10) {
+            // RUNNING_LOW / RUNNING_CRITICAL on a still-foreground app.
+            pressure = pp::MemoryPressure::moderate;
+        }
+        auto s = pp::Environment::instance().snapshot();
+        s.memory_pressure = pressure;
+        pp::Environment::instance().publish(s);
     } catch (const std::exception& e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
     } catch (...) {
@@ -164,7 +194,22 @@ Java_com_pulp_PulpActivity_nativeOnDisplayChanged(
     try {
         PULP_LOGI("nativeOnDisplayChanged: %dx%d density=%.1f dark=%d",
                   width, height, density, darkMode);
-        // TODO: Update view hierarchy layout and theme
+        // Publish display + color scheme together (#342). width/height
+        // from the Kotlin side arrive as CSS-pixel equivalents: Android
+        // reports physical pixels, so we divide by density for the
+        // logical size and keep physical_* for the raw resolution.
+        namespace pp = pulp::platform;
+        auto s = pp::Environment::instance().snapshot();
+        s.display.physical_width  = static_cast<int>(width);
+        s.display.physical_height = static_cast<int>(height);
+        s.display.scale = density > 0.0f ? static_cast<float>(density) : 1.0f;
+        s.display.width  = s.display.scale > 0.0f
+            ? static_cast<float>(width)  / s.display.scale : static_cast<float>(width);
+        s.display.height = s.display.scale > 0.0f
+            ? static_cast<float>(height) / s.display.scale : static_cast<float>(height);
+        s.color_scheme = darkMode ? pp::ColorScheme::dark
+                                  : pp::ColorScheme::light;
+        pp::Environment::instance().publish(s);
     } catch (const std::exception& e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
     } catch (...) {

--- a/core/platform/src/environment.cpp
+++ b/core/platform/src/environment.cpp
@@ -1,0 +1,120 @@
+#include <pulp/platform/environment.hpp>
+
+#include <utility>
+
+namespace pulp::platform {
+
+// ── Token ──────────────────────────────────────────────────────────────────
+
+Environment::Token::Token(Token&& other) noexcept
+    : id_(other.id_) {
+    other.id_ = 0;
+}
+
+Environment::Token& Environment::Token::operator=(Token&& other) noexcept {
+    if (this != &other) {
+        reset();
+        id_ = other.id_;
+        other.id_ = 0;
+    }
+    return *this;
+}
+
+void Environment::Token::reset() noexcept {
+    if (id_ != 0) {
+        Environment::instance().unsubscribe(id_);
+        id_ = 0;
+    }
+}
+
+// ── Environment ────────────────────────────────────────────────────────────
+
+Environment& Environment::instance() {
+    // Function-local static — initialized on first use, destroyed at
+    // process exit in reverse order of construction. Safe under C++11
+    // magic-statics (Itanium ABI / MSVC 2015+).
+    static Environment env;
+    return env;
+}
+
+EnvironmentState Environment::snapshot() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return state_;
+}
+
+Environment::Token Environment::subscribe(Listener listener) {
+    if (!listener) return Token{};
+    std::lock_guard<std::mutex> lock(mu_);
+    uint64_t id = next_id_++;
+    listeners_.push_back(Entry{id, std::move(listener)});
+    return Token{id};
+}
+
+void Environment::unsubscribe(uint64_t id) {
+    std::lock_guard<std::mutex> lock(mu_);
+    for (auto it = listeners_.begin(); it != listeners_.end(); ++it) {
+        if (it->id == id) {
+            listeners_.erase(it);
+            return;
+        }
+    }
+}
+
+namespace {
+
+EnvironmentChange diff(const EnvironmentState& prev, const EnvironmentState& next) {
+    EnvironmentChange c;
+    const auto& a = prev.display;
+    const auto& b = next.display;
+    c.display = (a.width != b.width) || (a.height != b.height)
+             || (a.physical_width != b.physical_width)
+             || (a.physical_height != b.physical_height)
+             || (a.scale != b.scale) || (a.refresh_hz != b.refresh_hz)
+             || (a.name != b.name);
+    const auto& sa = prev.safe_area;
+    const auto& sb = next.safe_area;
+    c.safe_area = (sa.top != sb.top) || (sa.bottom != sb.bottom)
+               || (sa.left != sb.left) || (sa.right != sb.right);
+    c.keyboard = (prev.keyboard.bottom != next.keyboard.bottom)
+              || (prev.keyboard.animation_duration
+                  != next.keyboard.animation_duration);
+    c.orientation     = (prev.orientation     != next.orientation);
+    c.color_scheme    = (prev.color_scheme    != next.color_scheme);
+    c.lifecycle       = (prev.lifecycle       != next.lifecycle);
+    c.memory_pressure = (prev.memory_pressure != next.memory_pressure);
+    return c;
+}
+
+} // namespace
+
+void Environment::publish(const EnvironmentState& next) {
+    // Compute diff + take snapshot of listeners under the lock, then
+    // invoke listeners outside the lock so a callback that drops a token
+    // (and calls back into unsubscribe) doesn't deadlock.
+    std::vector<Entry> listeners_copy;
+    EnvironmentChange change;
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        change = diff(state_, next);
+        if (!change.any()) return;
+        state_ = next;
+        listeners_copy = listeners_;
+    }
+    for (const auto& entry : listeners_copy) {
+        entry.fn(next, change);
+    }
+}
+
+void Environment::inject_for_test(const EnvironmentState& state) {
+    instance().publish(state);
+}
+
+void Environment::reset_for_test() {
+    auto& env = instance();
+    std::lock_guard<std::mutex> lock(env.mu_);
+    env.state_ = EnvironmentState{};
+    env.listeners_.clear();
+    env.next_id_ = 1;
+}
+
+} // namespace pulp::platform

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -472,6 +472,11 @@ add_executable(pulp-test-permissions test_permissions.cpp)
 target_link_libraries(pulp-test-permissions PRIVATE pulp::platform Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-permissions)
 
+# Environment API tests (#342)
+add_executable(pulp-test-environment test_environment.cpp)
+target_link_libraries(pulp-test-environment PRIVATE pulp::platform Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-environment)
+
 # Runtime tests
 add_executable(pulp-test-runtime test_runtime.cpp)
 target_link_libraries(pulp-test-runtime PRIVATE pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -1,0 +1,194 @@
+// Unit tests for the unified environment API (#342).
+//
+// The Environment singleton is a process-wide notifier; tests reset it
+// in each TEST_CASE so prior tests don't leak listeners or stale state.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/environment.hpp>
+
+#include <atomic>
+
+using namespace pulp::platform;
+
+namespace {
+
+EnvironmentState make_state(ColorScheme scheme,
+                            float scale = 2.0f,
+                            float kbd = 0.0f) {
+    EnvironmentState s;
+    s.display.width = 800;
+    s.display.height = 600;
+    s.display.scale = scale;
+    s.color_scheme = scheme;
+    s.keyboard.bottom = kbd;
+    s.lifecycle = LifecycleState::foreground;
+    s.orientation = Orientation::portrait;
+    return s;
+}
+
+} // namespace
+
+TEST_CASE("Environment: singleton state defaults are sentinel-safe", "[environment]") {
+    Environment::reset_for_test();
+    auto s = Environment::instance().snapshot();
+    REQUIRE(s.color_scheme    == ColorScheme::unknown);
+    REQUIRE(s.lifecycle       == LifecycleState::unknown);
+    REQUIRE(s.orientation     == Orientation::unknown);
+    REQUIRE(s.memory_pressure == MemoryPressure::normal);
+    REQUIRE(s.safe_area.is_zero());
+    REQUIRE(s.keyboard.bottom == 0.0f);
+}
+
+TEST_CASE("Environment: subscribe receives publish + correct change mask",
+          "[environment]") {
+    Environment::reset_for_test();
+    int dark_calls = 0;
+    EnvironmentChange last_change;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            if (s.color_scheme == ColorScheme::dark) ++dark_calls;
+            last_change = c;
+        });
+
+    // First publish — color scheme changes from unknown -> dark, scale
+    // from 1 -> 2, lifecycle from unknown -> foreground, etc. Many flags.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(dark_calls == 1);
+    REQUIRE(last_change.color_scheme);
+    REQUIRE(last_change.lifecycle);
+    REQUIRE(last_change.display);
+
+    // Idempotent publish — no change, no callback.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(dark_calls == 1);
+
+    // Color scheme flip alone — only that bit set.
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(dark_calls == 1);
+    REQUIRE(last_change.color_scheme);
+    REQUIRE_FALSE(last_change.display);
+    REQUIRE_FALSE(last_change.lifecycle);
+}
+
+TEST_CASE("Environment: token RAII unsubscribes", "[environment]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    {
+        auto token = Environment::instance().subscribe(
+            [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+        Environment::inject_for_test(make_state(ColorScheme::dark));
+        REQUIRE(calls == 1);
+    } // token dropped → unsubscribed
+
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: token move transfers ownership", "[environment]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto sub = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(sub.valid());
+
+    auto moved = std::move(sub);
+    REQUIRE(moved.valid());
+    REQUIRE_FALSE(sub.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: keyboard inset change propagates separately",
+          "[environment]") {
+    Environment::reset_for_test();
+    EnvironmentChange last;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange c) { last = c; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark, 2.0f, 0.0f));
+    Environment::inject_for_test(make_state(ColorScheme::dark, 2.0f, 320.0f));
+    REQUIRE(last.keyboard);
+    REQUIRE_FALSE(last.color_scheme);
+    REQUIRE_FALSE(last.display);
+}
+
+TEST_CASE("Environment: safe-area diff detection across all four edges",
+          "[environment]") {
+    Environment::reset_for_test();
+    EnvironmentChange last;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange c) { last = c; });
+
+    auto base = make_state(ColorScheme::dark);
+    Environment::inject_for_test(base);
+
+    auto with_inset = base;
+    with_inset.safe_area.top = 47.0f;
+    Environment::inject_for_test(with_inset);
+    REQUIRE(last.safe_area);
+
+    // Bottom-only change.
+    auto bottom = with_inset;
+    bottom.safe_area.bottom = 34.0f;
+    Environment::inject_for_test(bottom);
+    REQUIRE(last.safe_area);
+    REQUIRE_FALSE(last.color_scheme);
+}
+
+TEST_CASE("Environment: memory pressure transitions", "[environment]") {
+    Environment::reset_for_test();
+    int observed = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            if (c.memory_pressure
+                && s.memory_pressure == MemoryPressure::critical) {
+                ++observed;
+            }
+        });
+
+    auto base = make_state(ColorScheme::dark);
+    Environment::inject_for_test(base);
+
+    auto moderate = base;
+    moderate.memory_pressure = MemoryPressure::moderate;
+    Environment::inject_for_test(moderate);
+    REQUIRE(observed == 0);
+
+    auto critical = base;
+    critical.memory_pressure = MemoryPressure::critical;
+    Environment::inject_for_test(critical);
+    REQUIRE(observed == 1);
+}
+
+TEST_CASE("Environment: callback that drops its own token does not deadlock",
+          "[environment]") {
+    Environment::reset_for_test();
+    std::unique_ptr<Environment::Token> token;
+    token = std::make_unique<Environment::Token>(
+        Environment::instance().subscribe(
+            [&](const EnvironmentState&, EnvironmentChange) {
+                token.reset();  // unsubscribe from inside the callback
+            }));
+
+    // If publish() held the mutex during dispatch, this would deadlock
+    // when the listener calls back into unsubscribe.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    SUCCEED("no deadlock");
+}
+
+TEST_CASE("Environment: snapshot is consistent with last publish",
+          "[environment]") {
+    Environment::reset_for_test();
+    auto s = make_state(ColorScheme::light, 1.5f, 220.0f);
+    s.orientation = Orientation::landscape_left;
+    s.safe_area.top = 22.0f;
+    Environment::inject_for_test(s);
+
+    auto got = Environment::instance().snapshot();
+    REQUIRE(got.color_scheme    == ColorScheme::light);
+    REQUIRE(got.orientation     == Orientation::landscape_left);
+    REQUIRE(got.display.scale   == 1.5f);
+    REQUIRE(got.keyboard.bottom == 220.0f);
+    REQUIRE(got.safe_area.top   == 22.0f);
+}


### PR DESCRIPTION
## Summary

Defines the cross-platform contract that lets sample views adapt to OS environment signals without per-platform conditional code. One header, one notifier singleton, RAII listener tokens. Adapter implementations land per platform in follow-up PRs.

## API surface

`core/platform/include/pulp/platform/environment.hpp`:

- **`EnvironmentState`** — snapshot of all signals: `DisplayInfo` (CSS + physical pixels, scale, refresh, name), `SafeAreaInsets` (top/bottom/left/right), `KeyboardInset` (mobile soft-keyboard), `Orientation`, `ColorScheme`, `LifecycleState`, `MemoryPressure`.
- **`EnvironmentChange`** — bitmask of which fields flipped, passed to listeners so they don't have to diff snapshots themselves.
- **`Environment::subscribe(Listener)`** — RAII registration; drop the returned `Token` to unsubscribe.
- **`Environment::publish(state)`** — what platform adapters call from their OS callbacks.
- **`Environment::inject_for_test` / `reset_for_test`** — drive the singleton from unit tests.

## Implementation notes

- Singleton via Meyers static; thread-safe snapshot reads.
- `publish()` takes the diff under the lock, then dispatches outside the lock — a listener that drops its own token (re-entering `unsubscribe`) does NOT deadlock. Pinned by a unit test.

## Adapter PRs to follow

| Platform | Source / OS hook |
|----------|------------------|
| Android  | jni_bridge.cpp Configuration + onTrimMemory |
| iOS      | Scene + UITraitCollection observers |
| macOS    | NSApplicationDidChangeScreenParameters + NSApp.effectiveAppearance |
| Windows  | WM_DPICHANGED + WM_SETTINGCHANGE + WM_ACTIVATEAPP |
| Linux    | XSettings + Wayland fractional scale + _NET_ACTIVE_WINDOW |

## Test plan

- [x] macOS Debug: pulp-test-environment 9 cases / 35 assertions all pass
- [x] Defaults sentinel-safe; idempotent publish; RAII unsubscribe + move
- [x] Per-field diff (keyboard-only, safe-area edges, memory pressure)
- [x] Callback-reentrant unsubscribe doesn't deadlock