### PR TITLE
midi(mac): CoreMIDI SysEx7 reassembly (#239)

### DIFF
--- a/core/midi/platform/mac/coremidi_device.mm
+++ b/core/midi/platform/mac/coremidi_device.mm
@@ -59,8 +59,77 @@ public:
                                     static_cast<double>(packet->timeStamp) / 1e9;
                                 if (this->callback_) this->callback_(evt);
                             }
+                        } else if (type == 0x03) {
+                            // SysEx7 (UMP type 3) — reassemble multi-
+                            // packet payloads into a single sysex
+                            // callback. Status nibble (bits 20-23 of
+                            // word 0) indicates which packet of the
+                            // logical message this is:
+                            //   0x0 = complete single-packet sysex
+                            //   0x1 = start
+                            //   0x2 = continue
+                            //   0x3 = end
+                            // Mirrors the AU adapter's in-process
+                            // reassembler (#239 / #292). Without this,
+                            // sysex from a CoreMIDI device source
+                            // (Pulp standalone or DAW host on macOS)
+                            // would be silently dropped.
+                            const uint32_t word1 =
+                                packet->words[wordIdx + 1];
+                            const uint8_t status =
+                                static_cast<uint8_t>((word >> 20) & 0x0F);
+                            const uint32_t size  =
+                                static_cast<uint32_t>((word >> 16) & 0x0F);
+                            const double ts_sec =
+                                static_cast<double>(packet->timeStamp) / 1e9;
+
+                            auto extract = [](uint32_t w0, uint32_t w1,
+                                              uint32_t sz,
+                                              std::vector<uint8_t>& out) {
+                                const uint8_t buf[6] = {
+                                    static_cast<uint8_t>((w0 >>  8) & 0xFF),
+                                    static_cast<uint8_t>((w0 >>  0) & 0xFF),
+                                    static_cast<uint8_t>((w1 >> 24) & 0xFF),
+                                    static_cast<uint8_t>((w1 >> 16) & 0xFF),
+                                    static_cast<uint8_t>((w1 >>  8) & 0xFF),
+                                    static_cast<uint8_t>((w1 >>  0) & 0xFF),
+                                };
+                                for (uint32_t e = 0; e < sz && e < 6; ++e)
+                                    out.push_back(buf[e]);
+                            };
+
+                            if (status == 0x0) {
+                                std::vector<uint8_t> p;
+                                extract(word, word1, size, p);
+                                if (!p.empty() && this->sysex_callback_) {
+                                    this->sysex_callback_(p, ts_sec);
+                                }
+                            } else if (status == 0x1) {
+                                this->sysex_payload_.clear();
+                                extract(word, word1, size,
+                                        this->sysex_payload_);
+                                this->sysex_in_progress_ = true;
+                            } else if (status == 0x2
+                                       && this->sysex_in_progress_) {
+                                extract(word, word1, size,
+                                        this->sysex_payload_);
+                            } else if (status == 0x3
+                                       && this->sysex_in_progress_) {
+                                extract(word, word1, size,
+                                        this->sysex_payload_);
+                                if (!this->sysex_payload_.empty()
+                                    && this->sysex_callback_) {
+                                    this->sysex_callback_(
+                                        this->sysex_payload_, ts_sec);
+                                }
+                                this->sysex_payload_.clear();
+                                this->sysex_in_progress_ = false;
+                            }
+                            // 0x2 / 0x3 without an earlier 0x1 means we
+                            // missed the start; drop silently rather
+                            // than emit a corrupt sysex (#292 P2).
                         }
-                        // Other UMP types (utility, system, SysEx7/8,
+                        // Other UMP types (utility, system, SysEx8,
                         // stream, flex) intentionally skipped this slice.
                         wordIdx += words_in_message;
                     }
@@ -108,10 +177,21 @@ public:
 
     bool is_open() const override { return is_open_; }
 
+    void set_sysex_callback(MidiSysexCallback cb) override {
+        sysex_callback_ = std::move(cb);
+    }
+
 private:
     MIDIClientRef client_ = 0;
     MIDIPortRef port_ = 0;
     MidiInputCallback callback_;
+    MidiSysexCallback sysex_callback_;
+    // SysEx7 (UMP type 0x03) reassembly state. The OS callback fires
+    // once per MIDIEventList delivery, so a multi-packet sysex (start
+    // → continue* → end) spans callback invocations and accumulates
+    // here.
+    std::vector<uint8_t> sysex_payload_;
+    bool sysex_in_progress_ = false;
     bool is_open_ = false;
 };
 


### PR DESCRIPTION
## Summary

CoreMIDI driver was explicitly skipping UMP type 0x03 (SysEx7) with the comment *SysEx7/8, stream, flex intentionally skipped this slice* — meaning any sysex from a CoreMIDI device source (controllers, hardware synths, DAWs on macOS) was silently dropped on the way into Pulp standalone hosts.

Ports the AU adapter's already-shipped SysEx7 reassembler into `CoreMidiInput`. Status nibble (bits 20-23 of word 0):

| Nibble | Meaning |
|--------|---------|
| 0x0 | Complete single-packet sysex |
| 0x1 | Start |
| 0x2 | Continue |
| 0x3 | End |

Multi-packet payloads accumulate across the OS callback boundary in per-port state (`sysex_payload_` + `sysex_in_progress_`). The aggregated `F0..F7` byte stream is delivered via `MidiInput::set_sysex_callback` (already defined in `device.hpp`; was a no-op default until now).

## #239 status after this PR

- [x] CLAP CLAP_EVENT_MIDI_SYSEX (already on main, lines 198-205 of clap_adapter.cpp)
- [x] VST3 kData/kMidiSysEx (already on main, lines 355-369 of vst3_adapter.cpp)
- [x] AU adapter UMP SysEx7 reassembly (already on main)
- [x] **CoreMIDI device-source SysEx7 reassembly (this PR)**
- [ ] Win mmeapi MIM_LONGDATA aggregator
- [ ] ALSA SND_SEQ_EVENT_SYSEX aggregator

## Test plan

- [x] macOS Debug: pulp-midi builds clean
- [ ] Functional verification with a real device sending sysex (out of scope for this PR — needs hardware)
- [ ] CI matrix