### PR TITLE
midi(linux): ALSA raw-midi sysex accumulator (#239)

### DIFF
--- a/core/midi/platform/linux/alsa_midi_device.cpp
+++ b/core/midi/platform/linux/alsa_midi_device.cpp
@@ -20,6 +20,10 @@ class AlsaMidiInput : public MidiInput {
 public:
     ~AlsaMidiInput() override { close(); }
 
+    void set_sysex_callback(MidiSysexCallback cb) override {
+        sysex_callback_ = std::move(cb);
+    }
+
     bool open(const std::string& port_id, MidiInputCallback callback) override {
         callback_ = std::move(callback);
 
@@ -68,32 +72,88 @@ private:
                 break; // Error
             }
 
-            // Parse raw MIDI bytes into events
-            for (ssize_t i = 0; i < n; ) {
-                uint8_t status = buf[i];
-                if (status < 0x80) { ++i; continue; } // Skip data bytes without status
+            // Parse raw MIDI bytes into events. Sysex (F0..F7) is
+            // variable-length and can span multiple snd_rawmidi_read
+            // calls, so the accumulator state lives on the instance
+            // (sysex_buffer_, sysex_in_progress_). A real-time message
+            // (F8..FF) may appear INSIDE a sysex without terminating it
+            // — MIDI 1.0 §3.1 allows that for clock/start/stop. We emit
+            // the real-time message inline and keep collecting sysex
+            // bytes. #239.
+            for (ssize_t i = 0; i < n; ++i) {
+                uint8_t b = buf[i];
 
-                int msg_len = 3; // Default for most channel messages
-                if ((status & 0xF0) == 0xC0 || (status & 0xF0) == 0xD0) {
+                // Real-time messages (F8..FF) pass through unconditionally.
+                if (b >= 0xF8) {
+                    MidiEvent evt;
+                    evt.message = choc::midi::ShortMessage(b, 0, 0);
+                    evt.timestamp = 0.0;
+                    if (callback_) callback_(evt);
+                    continue;
+                }
+
+                // Inside a sysex: append until F7 terminator.
+                if (sysex_in_progress_) {
+                    sysex_buffer_.push_back(b);
+                    if (b == 0xF7) {
+                        if (sysex_callback_) {
+                            sysex_callback_(sysex_buffer_, 0.0);
+                        }
+                        sysex_buffer_.clear();
+                        sysex_in_progress_ = false;
+                    } else if (sysex_buffer_.size() > kSysexLimit) {
+                        // Runaway — drop rather than leak indefinitely.
+                        sysex_buffer_.clear();
+                        sysex_in_progress_ = false;
+                    }
+                    continue;
+                }
+
+                // Sysex start — begin accumulating.
+                if (b == 0xF0) {
+                    sysex_buffer_.clear();
+                    sysex_buffer_.push_back(b);
+                    sysex_in_progress_ = true;
+                    continue;
+                }
+
+                // Short message parsing (status + 1 or 2 data bytes).
+                if ((b & 0x80) == 0) continue; // stray data byte
+                int msg_len = 3;
+                if ((b & 0xF0) == 0xC0 || (b & 0xF0) == 0xD0) {
                     msg_len = 2; // Program Change, Channel Pressure
+                } else if (b == 0xF1 || b == 0xF3) {
+                    msg_len = 2; // MTC Quarter Frame, Song Select
+                } else if (b == 0xF2) {
+                    msg_len = 3; // Song Position Pointer
+                } else if (b == 0xF6 || b == 0xF7) {
+                    msg_len = 1; // Tune Request, stray End-of-Exclusive
                 }
 
                 if (i + msg_len <= n) {
                     MidiEvent evt;
                     evt.message = choc::midi::ShortMessage(
-                        buf[i],
+                        b,
                         msg_len > 1 ? buf[i + 1] : 0,
                         msg_len > 2 ? buf[i + 2] : 0);
-                    evt.timestamp = 0.0; // Raw MIDI has no timestamps
+                    evt.timestamp = 0.0;
                     if (callback_) callback_(evt);
+                    i += msg_len - 1; // loop's ++i advances past the last byte
                 }
-                i += msg_len;
             }
         }
     }
 
+    // Runaway-guard: typical device sysex dumps fit comfortably under
+    // 64 KB. If we somehow collect more without seeing F7, assume the
+    // device is misbehaving and drop the accumulator.
+    static constexpr size_t kSysexLimit = 64 * 1024;
+
     snd_rawmidi_t* handle_ = nullptr;
     MidiInputCallback callback_;
+    MidiSysexCallback sysex_callback_;
+    std::vector<uint8_t> sysex_buffer_;
+    bool sysex_in_progress_ = false;
     bool is_open_ = false;
     std::atomic<bool> running_{false};
     std::thread read_thread_;


### PR DESCRIPTION
## Summary

ALSA raw-midi driver's parser hard-coded `msg_len=3` for every status byte `>=0x80` and **silently dropped sysex**: `F0` was treated as a 3-byte channel message, the payload was re-interpreted as stray status bytes, and the `F7` terminator leaked into the next loop iteration. No sysex ever reached `MidiInput::set_sysex_callback`.

## Fix

Rewrites the byte-level parser so:

- `F0` starts accumulation into `sysex_buffer_`; bytes append until `F7`.
- `F7` flushes the buffer to `sysex_callback_(bytes, 0.0)`.
- Real-time (`F8..FF`) emits inline without breaking sysex — MIDI 1.0 §3.1 allows clock/start/stop interleaved with sysex.
- System-common `F1`/`F2`/`F3` now use correct lengths (2/3/2) instead of silently being treated as channel messages.
- `F6` (Tune Request) and stray `F7` use `msg_len=1`.
- Runaway protection: 64 KB hard-cap resets the accumulator if a device fails to emit `F7`.

Sysex state lives on the instance so it spans `snd_rawmidi_read` calls.

## #239 status after this PR

- [x] CLAP `CLAP_EVENT_MIDI_SYSEX` (already on main)
- [x] VST3 `kData/kMidiSysEx` (already on main)
- [x] AU adapter UMP SysEx7 reassembly (already on main)
- [x] CoreMIDI device-source SysEx7 reassembly (#405)
- [x] Win mmeapi `MIM_LONGDATA` (already on main)
- [x] **ALSA raw-midi sysex accumulator (this PR)** ← closes #239

## Test plan

- [x] macOS Debug: n/a — file is `#ifndef __linux__` gated
- [ ] Linux build on ssh ubuntu / CI matrix (pending)
- [ ] Functional test with a real device sending sysex — hardware needed, out of scope