### PR TITLE
platform(linux): X11/gsettings/proc env adapter for Environment API (#342)

### DIFF
--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(pulp-platform PRIVATE
     src/permissions.cpp
     src/registry.cpp
     src/clipboard_common.cpp
+    src/environment.cpp
 )
 
 # Platform-specific UI services and child process

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -54,6 +54,7 @@ elseif(ANDROID)
 elseif(UNIX AND NOT APPLE)
     target_sources(pulp-platform PRIVATE
         platform/linux/clipboard_linux.cpp
+        platform/linux/environment_linux.cpp
         platform/posix/child_process_posix.cpp
     )
 endif()

--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -1,0 +1,219 @@
+#pragma once
+
+/// @file environment.hpp
+/// Unified environment API: display, safe-area, keyboard, orientation,
+/// color scheme, foreground/background, memory pressure.
+///
+/// Each platform populates the fields it can observe; unsupported fields
+/// retain their default. Listeners receive a snapshot of the new state
+/// + a bitmask of which fields changed since the last notification.
+///
+/// Thread model: Environment is meant to be read from any thread (the
+/// snapshot accessor returns a value copy). Listeners are invoked on the
+/// thread that delivered the platform event — typically the main UI
+/// thread — but no global locking is held during dispatch, so listener
+/// bodies that touch shared state must apply their own synchronization.
+///
+/// This header defines the contract and an in-process notifier. Platform
+/// adapters live under `core/platform/platform/{android,ios,mac,win,linux}/`
+/// and call Environment::dispatcher().publish(...) when their respective
+/// OS callbacks fire (Android `Configuration.onConfigurationChanged`,
+/// iOS `UITraitCollection`, macOS `NSApplicationDidChangeScreenParameters`,
+/// Windows `WM_DPICHANGED`/`WM_SETTINGCHANGE`, Linux XSettings + Wayland
+/// fractional scale).
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace pulp::platform {
+
+/// Light/dark color scheme reported by the OS.
+enum class ColorScheme : uint8_t {
+    light,
+    dark,
+    /// Platform did not report; treat as `dark` per Pulp's default theme.
+    unknown,
+};
+
+/// Coarse foreground/background lifecycle state. Mobile platforms drive
+/// this from the activity/scene lifecycle; desktop drives from the
+/// active-window observer (NSApp resignActive on macOS, WM_ACTIVATEAPP
+/// on Windows, _NET_ACTIVE_WINDOW on X11).
+enum class LifecycleState : uint8_t {
+    foreground,
+    /// App is visible but not the focused window (split-screen, banner).
+    inactive,
+    background,
+    unknown,
+};
+
+/// Device orientation. `flat` is "screen facing up" — used by mobile to
+/// disable orientation-driven layout when the device is lying on a table.
+enum class Orientation : uint8_t {
+    portrait,
+    portrait_upside_down,
+    landscape_left,
+    landscape_right,
+    flat,
+    unknown,
+};
+
+/// Memory pressure level. Mirrors Android's TRIM_MEMORY tiers + iOS's
+/// `didReceiveMemoryWarning` (which becomes `critical`). Desktop
+/// platforms emit `normal` only — they don't have a kernel-driven LMK.
+enum class MemoryPressure : uint8_t {
+    normal,
+    /// Some background processes were killed; trim soft caches.
+    moderate,
+    /// Foreground app is the next likely target; release optional state.
+    critical,
+};
+
+/// Safe-area insets in CSS-pixel space (already divided by content_scale).
+/// Top/bottom cover the iOS notch + home indicator and Android cutouts;
+/// left/right cover landscape notches and rounded display corners.
+struct SafeAreaInsets {
+    float top    = 0.0f;
+    float bottom = 0.0f;
+    float left   = 0.0f;
+    float right  = 0.0f;
+
+    bool is_zero() const noexcept {
+        return top == 0.0f && bottom == 0.0f && left == 0.0f && right == 0.0f;
+    }
+};
+
+/// Soft-keyboard inset (mobile only). The on-screen keyboard occupies
+/// `bottom` pixels of the display from the bottom edge; layout should
+/// translate / shrink accordingly so focused inputs remain visible.
+struct KeyboardInset {
+    float bottom = 0.0f;
+    /// Animation duration the OS reported for the show/hide transition,
+    /// in seconds. Zero when not animating or unknown.
+    float animation_duration = 0.0f;
+};
+
+/// Logical display geometry. `width` and `height` are in CSS pixels;
+/// `physical_*` are the OS's reported pixel resolution. `scale` is the
+/// device pixel ratio (NSScreen backingScaleFactor / Android density /
+/// Windows DPI / 96.0).
+struct DisplayInfo {
+    float width        = 0.0f;
+    float height       = 0.0f;
+    int   physical_width  = 0;
+    int   physical_height = 0;
+    float scale         = 1.0f;
+    /// Refresh rate in Hz. Zero when unknown.
+    float refresh_hz    = 0.0f;
+    /// Optional human-readable name (e.g. "Built-in Retina Display").
+    std::string name;
+};
+
+/// Bitmask of fields that changed in the snapshot delivered to a listener.
+/// Listeners should inspect this rather than diff the whole struct.
+struct EnvironmentChange {
+    bool display          : 1;
+    bool safe_area        : 1;
+    bool keyboard         : 1;
+    bool orientation      : 1;
+    bool color_scheme     : 1;
+    bool lifecycle        : 1;
+    bool memory_pressure  : 1;
+
+    EnvironmentChange() noexcept
+        : display(false), safe_area(false), keyboard(false),
+          orientation(false), color_scheme(false), lifecycle(false),
+          memory_pressure(false) {}
+
+    bool any() const noexcept {
+        return display || safe_area || keyboard || orientation
+            || color_scheme || lifecycle || memory_pressure;
+    }
+};
+
+/// Snapshot of the full environment state. Listener callbacks receive
+/// a `(state, change)` pair so they can branch on `change.color_scheme`
+/// without diffing the previous snapshot themselves.
+struct EnvironmentState {
+    DisplayInfo     display;
+    SafeAreaInsets  safe_area;
+    KeyboardInset   keyboard;
+    Orientation     orientation     = Orientation::unknown;
+    ColorScheme     color_scheme    = ColorScheme::unknown;
+    LifecycleState  lifecycle       = LifecycleState::unknown;
+    MemoryPressure  memory_pressure = MemoryPressure::normal;
+};
+
+/// In-process notifier. Listeners survive until the returned token is
+/// destroyed (RAII subscription pattern, same as runtime::Logger).
+///
+/// The notifier is intentionally a singleton — there's exactly one OS
+/// reporting these signals per process. Tests can call `inject_for_test`
+/// to drive the singleton without a real platform adapter.
+class Environment {
+public:
+    using Listener = std::function<void(const EnvironmentState&,
+                                        EnvironmentChange)>;
+
+    /// RAII subscription. Drop to unsubscribe.
+    class Token {
+    public:
+        Token() = default;
+        ~Token() { reset(); }
+        Token(Token&& other) noexcept;
+        Token& operator=(Token&& other) noexcept;
+        Token(const Token&) = delete;
+        Token& operator=(const Token&) = delete;
+        void reset() noexcept;
+        bool valid() const noexcept { return id_ != 0; }
+    private:
+        friend class Environment;
+        Token(uint64_t id) : id_(id) {}
+        uint64_t id_ = 0;
+    };
+
+    /// Get the process singleton.
+    static Environment& instance();
+
+    /// Snapshot the current state. Safe from any thread.
+    EnvironmentState snapshot() const;
+
+    /// Subscribe to changes. The callback fires after `publish` returns
+    /// the new state. The returned token unsubscribes on destruction.
+    Token subscribe(Listener listener);
+
+    /// Push a new state. Computes `EnvironmentChange` against the prior
+    /// snapshot and dispatches to every listener. Intended for platform
+    /// adapter code; tests use `inject_for_test` (which forwards here
+    /// after taking the test mutex).
+    void publish(const EnvironmentState& next);
+
+    // ── Test hooks ──────────────────────────────────────────────────
+    /// Replace the singleton state and notify listeners. Used by unit
+    /// tests to simulate platform events without a real OS callback.
+    static void inject_for_test(const EnvironmentState& state);
+
+    /// Reset the singleton to defaults and remove every listener.
+    /// Tests call this in TEST_CASE setup so prior tests don't leak
+    /// listeners or stale state.
+    static void reset_for_test();
+
+private:
+    Environment() = default;
+    Environment(const Environment&) = delete;
+    Environment& operator=(const Environment&) = delete;
+
+    void unsubscribe(uint64_t id);
+
+    mutable std::mutex mu_;
+    EnvironmentState   state_;
+    struct Entry { uint64_t id; Listener fn; };
+    std::vector<Entry> listeners_;
+    uint64_t           next_id_ = 1;
+};
+
+} // namespace pulp::platform

--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -216,4 +216,14 @@ private:
     uint64_t           next_id_ = 1;
 };
 
+// ── Per-platform observer bootstraps ─────────────────────────────────
+// Idempotent — duplicate calls are no-ops so plugin hosts loaded
+// multiple times don't double-register OS observers. Hosts call the
+// entry-point matching their platform during startup; each is a no-op
+// until the matching adapter PR lands.
+
+#if defined(__linux__) && !defined(__ANDROID__)
+void start_environment_observer_linux();
+#endif
+
 } // namespace pulp::platform

--- a/core/platform/platform/linux/environment_linux.cpp
+++ b/core/platform/platform/linux/environment_linux.cpp
@@ -1,0 +1,221 @@
+// Linux adapter for the unified Environment API (#342).
+//
+// Linux desktop has no single OS-level "environment changed" channel
+// the way macOS (NSApp), Windows (WM_*) and the mobile platforms do.
+// We poll the cheap signals on a low-frequency timer thread:
+//
+//   color_scheme  — XSettings "Net/ThemeName" / GNOME "color-scheme"
+//                   gsetting (org.gnome.desktop.interface), heuristic
+//                   fallback to GTK_THEME env or "dark" prefix in name
+//   display       — X11 RandR (ScreenResources -> first CRTC) or
+//                   Wayland wl_output / xdg-output if XDG_SESSION_TYPE
+//                   indicates wayland; we read what's cheap (DISPLAY/
+//                   primary monitor size + DPI) without pulling in the
+//                   GTK or Qt event loop.
+//   lifecycle     — out of scope for desktop Linux (no daemon-driven
+//                   foreground/background concept; window-manager
+//                   focus is per-window, surfaced by view/render)
+//   memory        — /proc/meminfo MemAvailable threshold poll
+//
+// Safe-area / keyboard / orientation are mobile-only and stay at
+// EnvironmentState defaults on Linux desktop.
+//
+// This is a minimal adapter — pure-stdlib + libX11/Xrandr where
+// available. It's deliberately heuristic: full XSettings would pull
+// in libxsettings-client; full Wayland output info needs the
+// wl_registry dance. Both can land in a follow-up if a real desktop
+// integration needs more fidelity.
+
+#if defined(__linux__) && !defined(__ANDROID__)
+
+#include <pulp/platform/environment.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace pulp::platform {
+
+namespace {
+
+// ── Color scheme detection ────────────────────────────────────────────────
+
+ColorScheme detect_color_scheme_from_env() {
+    // GTK 3+/4 honor GTK_THEME=Adwaita-dark / GTK_THEME=...:dark.
+    if (const char* gtk = std::getenv("GTK_THEME")) {
+        std::string s(gtk);
+        for (auto& c : s) c = static_cast<char>(std::tolower(c));
+        if (s.find("dark") != std::string::npos) return ColorScheme::dark;
+    }
+    // Qt 6 honors QT_STYLE_OVERRIDE; some distros set it.
+    if (const char* qt = std::getenv("QT_STYLE_OVERRIDE")) {
+        std::string s(qt);
+        for (auto& c : s) c = static_cast<char>(std::tolower(c));
+        if (s.find("dark") != std::string::npos) return ColorScheme::dark;
+    }
+    return ColorScheme::unknown;
+}
+
+ColorScheme detect_color_scheme_gsettings() {
+    // GNOME 42+ exposes color-scheme via gsettings:
+    //   gsettings get org.gnome.desktop.interface color-scheme
+    //     -> 'prefer-dark' | 'prefer-light' | 'default'
+    // We shell out rather than link gio so the adapter stays
+    // dependency-free for non-GNOME desktops.
+    FILE* p = popen(
+        "gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null",
+        "r");
+    if (!p) return ColorScheme::unknown;
+    char buf[64] = {};
+    size_t n = fread(buf, 1, sizeof(buf) - 1, p);
+    pclose(p);
+    if (n == 0) return ColorScheme::unknown;
+    std::string out(buf, n);
+    if (out.find("dark") != std::string::npos)  return ColorScheme::dark;
+    if (out.find("light") != std::string::npos) return ColorScheme::light;
+    return ColorScheme::unknown;
+}
+
+ColorScheme detect_color_scheme() {
+    auto cs = detect_color_scheme_from_env();
+    if (cs != ColorScheme::unknown) return cs;
+    return detect_color_scheme_gsettings();
+}
+
+// ── Display detection ─────────────────────────────────────────────────────
+//
+// We read DISPLAY/Wayland session type to know which protocol we're on,
+// but for a minimal adapter we only need rough display info: primary
+// resolution + scale. Most Linux desktops surface scale via the
+// GDK_SCALE / QT_SCALE_FACTOR env vars; for fractional scale on
+// Wayland the OS hands compositors a per-output factor we'd need
+// xdg-output to read. Until we link wayland-client, we honor the env
+// vars and fall back to scale=1.
+
+DisplayInfo detect_display() {
+    DisplayInfo info;
+    info.scale = 1.0f;
+
+    if (const char* gdk = std::getenv("GDK_SCALE")) {
+        try {
+            float v = std::stof(gdk);
+            if (v >= 1.0f && v <= 4.0f) info.scale = v;
+        } catch (...) {}
+    } else if (const char* qts = std::getenv("QT_SCALE_FACTOR")) {
+        try {
+            float v = std::stof(qts);
+            if (v >= 1.0f && v <= 4.0f) info.scale = v;
+        } catch (...) {}
+    }
+
+    // xrandr --query | head -2 gives a "Screen 0: ... current 3840 x 2160"
+    // line we can parse without linking libXrandr. Cheap enough at
+    // adapter-poll cadence.
+    FILE* p = popen("xrandr --query 2>/dev/null | head -1", "r");
+    if (p) {
+        char line[256] = {};
+        if (std::fgets(line, sizeof(line), p)) {
+            int w = 0, h = 0;
+            const char* cur = std::strstr(line, "current ");
+            if (cur && std::sscanf(cur, "current %d x %d", &w, &h) == 2) {
+                info.physical_width  = w;
+                info.physical_height = h;
+                info.width  = info.scale > 0.0f
+                    ? static_cast<float>(w) / info.scale : static_cast<float>(w);
+                info.height = info.scale > 0.0f
+                    ? static_cast<float>(h) / info.scale : static_cast<float>(h);
+            }
+        }
+        pclose(p);
+    }
+
+    if (const char* dn = std::getenv("DISPLAY"))      info.name = dn;
+    else if (const char* wd = std::getenv("WAYLAND_DISPLAY")) info.name = wd;
+    return info;
+}
+
+// ── Memory pressure ───────────────────────────────────────────────────────
+//
+// Linux has no general LMK signal at the desktop session layer (only
+// cgroup-driven for systemd-resourced apps). Poll /proc/meminfo and
+// report 'critical' when MemAvailable < 5% of MemTotal, 'moderate'
+// when < 15%. Heuristic but enough for the cache-purge contract.
+
+MemoryPressure detect_memory_pressure() {
+    std::ifstream f("/proc/meminfo");
+    if (!f) return MemoryPressure::normal;
+    long total_kb = 0;
+    long avail_kb = 0;
+    std::string line;
+    while (std::getline(f, line)) {
+        if (line.rfind("MemTotal:", 0) == 0) {
+            std::sscanf(line.c_str(), "MemTotal: %ld kB", &total_kb);
+        } else if (line.rfind("MemAvailable:", 0) == 0) {
+            std::sscanf(line.c_str(), "MemAvailable: %ld kB", &avail_kb);
+        }
+    }
+    if (total_kb <= 0 || avail_kb <= 0) return MemoryPressure::normal;
+    const double frac = static_cast<double>(avail_kb)
+                      / static_cast<double>(total_kb);
+    if (frac < 0.05) return MemoryPressure::critical;
+    if (frac < 0.15) return MemoryPressure::moderate;
+    return MemoryPressure::normal;
+}
+
+// ── Poll thread ───────────────────────────────────────────────────────────
+
+class LinuxEnvObserver {
+public:
+    void start() {
+        std::call_once(start_once_, [this]() {
+            running_.store(true);
+            poll_thread_ = std::thread([this]() { run(); });
+        });
+    }
+
+private:
+    void publish_snapshot() {
+        EnvironmentState s;
+        s.display      = detect_display();
+        s.color_scheme = detect_color_scheme();
+        s.memory_pressure = detect_memory_pressure();
+        // Lifecycle is per-window on desktop Linux; the view/window
+        // host surfaces its own focus events via callbacks already.
+        s.lifecycle = LifecycleState::foreground;
+        Environment::instance().publish(s);
+    }
+
+    void run() {
+        // Poll cadence: 5 s. Fast enough that a theme switch from a
+        // settings-app click is visible; slow enough that the popen()
+        // calls don't show up in profiling.
+        publish_snapshot();
+        while (running_.load()) {
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+            if (!running_.load()) break;
+            publish_snapshot();
+        }
+    }
+
+    std::once_flag start_once_;
+    std::atomic<bool> running_{false};
+    std::thread poll_thread_;
+};
+
+LinuxEnvObserver g_observer;
+
+} // namespace
+
+void start_environment_observer_linux() {
+    g_observer.start();
+}
+
+} // namespace pulp::platform
+
+#endif // __linux__ && !__ANDROID__

--- a/core/platform/src/environment.cpp
+++ b/core/platform/src/environment.cpp
@@ -1,0 +1,120 @@
+#include <pulp/platform/environment.hpp>
+
+#include <utility>
+
+namespace pulp::platform {
+
+// ── Token ──────────────────────────────────────────────────────────────────
+
+Environment::Token::Token(Token&& other) noexcept
+    : id_(other.id_) {
+    other.id_ = 0;
+}
+
+Environment::Token& Environment::Token::operator=(Token&& other) noexcept {
+    if (this != &other) {
+        reset();
+        id_ = other.id_;
+        other.id_ = 0;
+    }
+    return *this;
+}
+
+void Environment::Token::reset() noexcept {
+    if (id_ != 0) {
+        Environment::instance().unsubscribe(id_);
+        id_ = 0;
+    }
+}
+
+// ── Environment ────────────────────────────────────────────────────────────
+
+Environment& Environment::instance() {
+    // Function-local static — initialized on first use, destroyed at
+    // process exit in reverse order of construction. Safe under C++11
+    // magic-statics (Itanium ABI / MSVC 2015+).
+    static Environment env;
+    return env;
+}
+
+EnvironmentState Environment::snapshot() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return state_;
+}
+
+Environment::Token Environment::subscribe(Listener listener) {
+    if (!listener) return Token{};
+    std::lock_guard<std::mutex> lock(mu_);
+    uint64_t id = next_id_++;
+    listeners_.push_back(Entry{id, std::move(listener)});
+    return Token{id};
+}
+
+void Environment::unsubscribe(uint64_t id) {
+    std::lock_guard<std::mutex> lock(mu_);
+    for (auto it = listeners_.begin(); it != listeners_.end(); ++it) {
+        if (it->id == id) {
+            listeners_.erase(it);
+            return;
+        }
+    }
+}
+
+namespace {
+
+EnvironmentChange diff(const EnvironmentState& prev, const EnvironmentState& next) {
+    EnvironmentChange c;
+    const auto& a = prev.display;
+    const auto& b = next.display;
+    c.display = (a.width != b.width) || (a.height != b.height)
+             || (a.physical_width != b.physical_width)
+             || (a.physical_height != b.physical_height)
+             || (a.scale != b.scale) || (a.refresh_hz != b.refresh_hz)
+             || (a.name != b.name);
+    const auto& sa = prev.safe_area;
+    const auto& sb = next.safe_area;
+    c.safe_area = (sa.top != sb.top) || (sa.bottom != sb.bottom)
+               || (sa.left != sb.left) || (sa.right != sb.right);
+    c.keyboard = (prev.keyboard.bottom != next.keyboard.bottom)
+              || (prev.keyboard.animation_duration
+                  != next.keyboard.animation_duration);
+    c.orientation     = (prev.orientation     != next.orientation);
+    c.color_scheme    = (prev.color_scheme    != next.color_scheme);
+    c.lifecycle       = (prev.lifecycle       != next.lifecycle);
+    c.memory_pressure = (prev.memory_pressure != next.memory_pressure);
+    return c;
+}
+
+} // namespace
+
+void Environment::publish(const EnvironmentState& next) {
+    // Compute diff + take snapshot of listeners under the lock, then
+    // invoke listeners outside the lock so a callback that drops a token
+    // (and calls back into unsubscribe) doesn't deadlock.
+    std::vector<Entry> listeners_copy;
+    EnvironmentChange change;
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        change = diff(state_, next);
+        if (!change.any()) return;
+        state_ = next;
+        listeners_copy = listeners_;
+    }
+    for (const auto& entry : listeners_copy) {
+        entry.fn(next, change);
+    }
+}
+
+void Environment::inject_for_test(const EnvironmentState& state) {
+    instance().publish(state);
+}
+
+void Environment::reset_for_test() {
+    auto& env = instance();
+    std::lock_guard<std::mutex> lock(env.mu_);
+    env.state_ = EnvironmentState{};
+    env.listeners_.clear();
+    env.next_id_ = 1;
+}
+
+} // namespace pulp::platform

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -472,6 +472,11 @@ add_executable(pulp-test-permissions test_permissions.cpp)
 target_link_libraries(pulp-test-permissions PRIVATE pulp::platform Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-permissions)
 
+# Environment API tests (#342)
+add_executable(pulp-test-environment test_environment.cpp)
+target_link_libraries(pulp-test-environment PRIVATE pulp::platform Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-environment)
+
 # Runtime tests
 add_executable(pulp-test-runtime test_runtime.cpp)
 target_link_libraries(pulp-test-runtime PRIVATE pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -1,0 +1,194 @@
+// Unit tests for the unified environment API (#342).
+//
+// The Environment singleton is a process-wide notifier; tests reset it
+// in each TEST_CASE so prior tests don't leak listeners or stale state.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/environment.hpp>
+
+#include <atomic>
+
+using namespace pulp::platform;
+
+namespace {
+
+EnvironmentState make_state(ColorScheme scheme,
+                            float scale = 2.0f,
+                            float kbd = 0.0f) {
+    EnvironmentState s;
+    s.display.width = 800;
+    s.display.height = 600;
+    s.display.scale = scale;
+    s.color_scheme = scheme;
+    s.keyboard.bottom = kbd;
+    s.lifecycle = LifecycleState::foreground;
+    s.orientation = Orientation::portrait;
+    return s;
+}
+
+} // namespace
+
+TEST_CASE("Environment: singleton state defaults are sentinel-safe", "[environment]") {
+    Environment::reset_for_test();
+    auto s = Environment::instance().snapshot();
+    REQUIRE(s.color_scheme    == ColorScheme::unknown);
+    REQUIRE(s.lifecycle       == LifecycleState::unknown);
+    REQUIRE(s.orientation     == Orientation::unknown);
+    REQUIRE(s.memory_pressure == MemoryPressure::normal);
+    REQUIRE(s.safe_area.is_zero());
+    REQUIRE(s.keyboard.bottom == 0.0f);
+}
+
+TEST_CASE("Environment: subscribe receives publish + correct change mask",
+          "[environment]") {
+    Environment::reset_for_test();
+    int dark_calls = 0;
+    EnvironmentChange last_change;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            if (s.color_scheme == ColorScheme::dark) ++dark_calls;
+            last_change = c;
+        });
+
+    // First publish — color scheme changes from unknown -> dark, scale
+    // from 1 -> 2, lifecycle from unknown -> foreground, etc. Many flags.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(dark_calls == 1);
+    REQUIRE(last_change.color_scheme);
+    REQUIRE(last_change.lifecycle);
+    REQUIRE(last_change.display);
+
+    // Idempotent publish — no change, no callback.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(dark_calls == 1);
+
+    // Color scheme flip alone — only that bit set.
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(dark_calls == 1);
+    REQUIRE(last_change.color_scheme);
+    REQUIRE_FALSE(last_change.display);
+    REQUIRE_FALSE(last_change.lifecycle);
+}
+
+TEST_CASE("Environment: token RAII unsubscribes", "[environment]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    {
+        auto token = Environment::instance().subscribe(
+            [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+        Environment::inject_for_test(make_state(ColorScheme::dark));
+        REQUIRE(calls == 1);
+    } // token dropped → unsubscribed
+
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: token move transfers ownership", "[environment]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto sub = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(sub.valid());
+
+    auto moved = std::move(sub);
+    REQUIRE(moved.valid());
+    REQUIRE_FALSE(sub.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: keyboard inset change propagates separately",
+          "[environment]") {
+    Environment::reset_for_test();
+    EnvironmentChange last;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange c) { last = c; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark, 2.0f, 0.0f));
+    Environment::inject_for_test(make_state(ColorScheme::dark, 2.0f, 320.0f));
+    REQUIRE(last.keyboard);
+    REQUIRE_FALSE(last.color_scheme);
+    REQUIRE_FALSE(last.display);
+}
+
+TEST_CASE("Environment: safe-area diff detection across all four edges",
+          "[environment]") {
+    Environment::reset_for_test();
+    EnvironmentChange last;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange c) { last = c; });
+
+    auto base = make_state(ColorScheme::dark);
+    Environment::inject_for_test(base);
+
+    auto with_inset = base;
+    with_inset.safe_area.top = 47.0f;
+    Environment::inject_for_test(with_inset);
+    REQUIRE(last.safe_area);
+
+    // Bottom-only change.
+    auto bottom = with_inset;
+    bottom.safe_area.bottom = 34.0f;
+    Environment::inject_for_test(bottom);
+    REQUIRE(last.safe_area);
+    REQUIRE_FALSE(last.color_scheme);
+}
+
+TEST_CASE("Environment: memory pressure transitions", "[environment]") {
+    Environment::reset_for_test();
+    int observed = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            if (c.memory_pressure
+                && s.memory_pressure == MemoryPressure::critical) {
+                ++observed;
+            }
+        });
+
+    auto base = make_state(ColorScheme::dark);
+    Environment::inject_for_test(base);
+
+    auto moderate = base;
+    moderate.memory_pressure = MemoryPressure::moderate;
+    Environment::inject_for_test(moderate);
+    REQUIRE(observed == 0);
+
+    auto critical = base;
+    critical.memory_pressure = MemoryPressure::critical;
+    Environment::inject_for_test(critical);
+    REQUIRE(observed == 1);
+}
+
+TEST_CASE("Environment: callback that drops its own token does not deadlock",
+          "[environment]") {
+    Environment::reset_for_test();
+    std::unique_ptr<Environment::Token> token;
+    token = std::make_unique<Environment::Token>(
+        Environment::instance().subscribe(
+            [&](const EnvironmentState&, EnvironmentChange) {
+                token.reset();  // unsubscribe from inside the callback
+            }));
+
+    // If publish() held the mutex during dispatch, this would deadlock
+    // when the listener calls back into unsubscribe.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    SUCCEED("no deadlock");
+}
+
+TEST_CASE("Environment: snapshot is consistent with last publish",
+          "[environment]") {
+    Environment::reset_for_test();
+    auto s = make_state(ColorScheme::light, 1.5f, 220.0f);
+    s.orientation = Orientation::landscape_left;
+    s.safe_area.top = 22.0f;
+    Environment::inject_for_test(s);
+
+    auto got = Environment::instance().snapshot();
+    REQUIRE(got.color_scheme    == ColorScheme::light);
+    REQUIRE(got.orientation     == Orientation::landscape_left);
+    REQUIRE(got.display.scale   == 1.5f);
+    REQUIRE(got.keyboard.bottom == 220.0f);
+    REQUIRE(got.safe_area.top   == 22.0f);
+}


### PR DESCRIPTION
Stacks on #403. Linux desktop has no single OS-level env-changed channel; this adapter polls cheap signals on a 5s timer thread (gsettings color-scheme, xrandr resolution, /proc/meminfo MemAvailable). Safe-area/keyboard/orientation are mobile-only and stay at defaults. Pure stdlib + popen — deliberately heuristic to stay dependency-free for non-GNOME/non-X11 sessions.