### PR TITLE
platform(ios): scene + UITraitCollection observers for Environment API (#342)

### DIFF
--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(pulp-platform PRIVATE
     src/permissions.cpp
     src/registry.cpp
     src/clipboard_common.cpp
+    src/environment.cpp
 )
 
 # Platform-specific UI services and child process

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -35,6 +35,7 @@ elseif(IOS)
     # File dialogs and popup menus fall through to the stubs.
     target_sources(pulp-platform PRIVATE
         platform/ios/clipboard_ios.mm
+        platform/ios/environment_ios.mm
         platform/posix/child_process_posix.cpp
     )
     target_link_libraries(pulp-platform PRIVATE

--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -1,0 +1,219 @@
+#pragma once
+
+/// @file environment.hpp
+/// Unified environment API: display, safe-area, keyboard, orientation,
+/// color scheme, foreground/background, memory pressure.
+///
+/// Each platform populates the fields it can observe; unsupported fields
+/// retain their default. Listeners receive a snapshot of the new state
+/// + a bitmask of which fields changed since the last notification.
+///
+/// Thread model: Environment is meant to be read from any thread (the
+/// snapshot accessor returns a value copy). Listeners are invoked on the
+/// thread that delivered the platform event — typically the main UI
+/// thread — but no global locking is held during dispatch, so listener
+/// bodies that touch shared state must apply their own synchronization.
+///
+/// This header defines the contract and an in-process notifier. Platform
+/// adapters live under `core/platform/platform/{android,ios,mac,win,linux}/`
+/// and call Environment::dispatcher().publish(...) when their respective
+/// OS callbacks fire (Android `Configuration.onConfigurationChanged`,
+/// iOS `UITraitCollection`, macOS `NSApplicationDidChangeScreenParameters`,
+/// Windows `WM_DPICHANGED`/`WM_SETTINGCHANGE`, Linux XSettings + Wayland
+/// fractional scale).
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace pulp::platform {
+
+/// Light/dark color scheme reported by the OS.
+enum class ColorScheme : uint8_t {
+    light,
+    dark,
+    /// Platform did not report; treat as `dark` per Pulp's default theme.
+    unknown,
+};
+
+/// Coarse foreground/background lifecycle state. Mobile platforms drive
+/// this from the activity/scene lifecycle; desktop drives from the
+/// active-window observer (NSApp resignActive on macOS, WM_ACTIVATEAPP
+/// on Windows, _NET_ACTIVE_WINDOW on X11).
+enum class LifecycleState : uint8_t {
+    foreground,
+    /// App is visible but not the focused window (split-screen, banner).
+    inactive,
+    background,
+    unknown,
+};
+
+/// Device orientation. `flat` is "screen facing up" — used by mobile to
+/// disable orientation-driven layout when the device is lying on a table.
+enum class Orientation : uint8_t {
+    portrait,
+    portrait_upside_down,
+    landscape_left,
+    landscape_right,
+    flat,
+    unknown,
+};
+
+/// Memory pressure level. Mirrors Android's TRIM_MEMORY tiers + iOS's
+/// `didReceiveMemoryWarning` (which becomes `critical`). Desktop
+/// platforms emit `normal` only — they don't have a kernel-driven LMK.
+enum class MemoryPressure : uint8_t {
+    normal,
+    /// Some background processes were killed; trim soft caches.
+    moderate,
+    /// Foreground app is the next likely target; release optional state.
+    critical,
+};
+
+/// Safe-area insets in CSS-pixel space (already divided by content_scale).
+/// Top/bottom cover the iOS notch + home indicator and Android cutouts;
+/// left/right cover landscape notches and rounded display corners.
+struct SafeAreaInsets {
+    float top    = 0.0f;
+    float bottom = 0.0f;
+    float left   = 0.0f;
+    float right  = 0.0f;
+
+    bool is_zero() const noexcept {
+        return top == 0.0f && bottom == 0.0f && left == 0.0f && right == 0.0f;
+    }
+};
+
+/// Soft-keyboard inset (mobile only). The on-screen keyboard occupies
+/// `bottom` pixels of the display from the bottom edge; layout should
+/// translate / shrink accordingly so focused inputs remain visible.
+struct KeyboardInset {
+    float bottom = 0.0f;
+    /// Animation duration the OS reported for the show/hide transition,
+    /// in seconds. Zero when not animating or unknown.
+    float animation_duration = 0.0f;
+};
+
+/// Logical display geometry. `width` and `height` are in CSS pixels;
+/// `physical_*` are the OS's reported pixel resolution. `scale` is the
+/// device pixel ratio (NSScreen backingScaleFactor / Android density /
+/// Windows DPI / 96.0).
+struct DisplayInfo {
+    float width        = 0.0f;
+    float height       = 0.0f;
+    int   physical_width  = 0;
+    int   physical_height = 0;
+    float scale         = 1.0f;
+    /// Refresh rate in Hz. Zero when unknown.
+    float refresh_hz    = 0.0f;
+    /// Optional human-readable name (e.g. "Built-in Retina Display").
+    std::string name;
+};
+
+/// Bitmask of fields that changed in the snapshot delivered to a listener.
+/// Listeners should inspect this rather than diff the whole struct.
+struct EnvironmentChange {
+    bool display          : 1;
+    bool safe_area        : 1;
+    bool keyboard         : 1;
+    bool orientation      : 1;
+    bool color_scheme     : 1;
+    bool lifecycle        : 1;
+    bool memory_pressure  : 1;
+
+    EnvironmentChange() noexcept
+        : display(false), safe_area(false), keyboard(false),
+          orientation(false), color_scheme(false), lifecycle(false),
+          memory_pressure(false) {}
+
+    bool any() const noexcept {
+        return display || safe_area || keyboard || orientation
+            || color_scheme || lifecycle || memory_pressure;
+    }
+};
+
+/// Snapshot of the full environment state. Listener callbacks receive
+/// a `(state, change)` pair so they can branch on `change.color_scheme`
+/// without diffing the previous snapshot themselves.
+struct EnvironmentState {
+    DisplayInfo     display;
+    SafeAreaInsets  safe_area;
+    KeyboardInset   keyboard;
+    Orientation     orientation     = Orientation::unknown;
+    ColorScheme     color_scheme    = ColorScheme::unknown;
+    LifecycleState  lifecycle       = LifecycleState::unknown;
+    MemoryPressure  memory_pressure = MemoryPressure::normal;
+};
+
+/// In-process notifier. Listeners survive until the returned token is
+/// destroyed (RAII subscription pattern, same as runtime::Logger).
+///
+/// The notifier is intentionally a singleton — there's exactly one OS
+/// reporting these signals per process. Tests can call `inject_for_test`
+/// to drive the singleton without a real platform adapter.
+class Environment {
+public:
+    using Listener = std::function<void(const EnvironmentState&,
+                                        EnvironmentChange)>;
+
+    /// RAII subscription. Drop to unsubscribe.
+    class Token {
+    public:
+        Token() = default;
+        ~Token() { reset(); }
+        Token(Token&& other) noexcept;
+        Token& operator=(Token&& other) noexcept;
+        Token(const Token&) = delete;
+        Token& operator=(const Token&) = delete;
+        void reset() noexcept;
+        bool valid() const noexcept { return id_ != 0; }
+    private:
+        friend class Environment;
+        Token(uint64_t id) : id_(id) {}
+        uint64_t id_ = 0;
+    };
+
+    /// Get the process singleton.
+    static Environment& instance();
+
+    /// Snapshot the current state. Safe from any thread.
+    EnvironmentState snapshot() const;
+
+    /// Subscribe to changes. The callback fires after `publish` returns
+    /// the new state. The returned token unsubscribes on destruction.
+    Token subscribe(Listener listener);
+
+    /// Push a new state. Computes `EnvironmentChange` against the prior
+    /// snapshot and dispatches to every listener. Intended for platform
+    /// adapter code; tests use `inject_for_test` (which forwards here
+    /// after taking the test mutex).
+    void publish(const EnvironmentState& next);
+
+    // ── Test hooks ──────────────────────────────────────────────────
+    /// Replace the singleton state and notify listeners. Used by unit
+    /// tests to simulate platform events without a real OS callback.
+    static void inject_for_test(const EnvironmentState& state);
+
+    /// Reset the singleton to defaults and remove every listener.
+    /// Tests call this in TEST_CASE setup so prior tests don't leak
+    /// listeners or stale state.
+    static void reset_for_test();
+
+private:
+    Environment() = default;
+    Environment(const Environment&) = delete;
+    Environment& operator=(const Environment&) = delete;
+
+    void unsubscribe(uint64_t id);
+
+    mutable std::mutex mu_;
+    EnvironmentState   state_;
+    struct Entry { uint64_t id; Listener fn; };
+    std::vector<Entry> listeners_;
+    uint64_t           next_id_ = 1;
+};
+
+} // namespace pulp::platform

--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -216,4 +216,29 @@ private:
     uint64_t           next_id_ = 1;
 };
 
+// ── Per-platform observer bootstraps ─────────────────────────────────
+// Hosts call start_environment_observer() once during startup. Each
+// platform adapter is idempotent — duplicate calls are a no-op so
+// plugin hosts loaded multiple times don't double-register.
+//
+// Adapters land per platform; this header forward-declares them
+// alphabetically. The convenience wrapper at the bottom dispatches to
+// the right one based on the build target.
+
+void start_environment_observer_ios();
+void start_environment_observer_mac();
+// void start_environment_observer_android(); // follow-up
+// void start_environment_observer_linux();   // follow-up
+// void start_environment_observer_win();     // follow-up
+
+inline void start_environment_observer() {
+#if defined(__APPLE__) && defined(PULP_IOS)
+    start_environment_observer_ios();
+#elif defined(__APPLE__)
+    start_environment_observer_mac();
+#endif
+    // Other platforms wire their adapters in follow-up PRs; until then
+    // their hosts simply see the EnvironmentState defaults.
+}
+
 } // namespace pulp::platform

--- a/core/platform/platform/ios/environment_ios.mm
+++ b/core/platform/platform/ios/environment_ios.mm
@@ -1,0 +1,350 @@
+// iOS adapter for the unified Environment API (#342).
+//
+// Subscribes to UIApplication / UIScreen / UIDevice notifications and
+// snapshots the OS state into Environment::publish(). Listeners outside
+// the platform layer don't see any UIKit types — Environment is pure C++.
+//
+// Hooks:
+//   UIApplicationDidBecomeActiveNotification     → lifecycle (foreground)
+//   UIApplicationWillResignActiveNotification    → lifecycle (inactive)
+//   UIApplicationDidEnterBackgroundNotification  → lifecycle (background)
+//   UIApplicationWillEnterForegroundNotification → lifecycle (inactive)
+//   UIApplicationDidReceiveMemoryWarningNotification → memory pressure (critical)
+//   UIDeviceOrientationDidChangeNotification     → orientation
+//   UIKeyboardWillShowNotification               → keyboard inset
+//   UIKeyboardWillHideNotification               → keyboard inset (zeroed)
+//   KVO on UITraitCollection (via traitCollectionDidChange) is owned by
+//   the host's root view controller; we observe color scheme by reading
+//   UIScreen.mainScreen.traitCollection on every publish so any layout
+//   relayout that nudges us picks up the latest value too.
+//
+// Display geometry is read from UIScreen.mainScreen on every publish.
+// Safe-area insets come from the application's key window. Keyboard
+// inset comes from the UIKeyboard* notifications' userInfo dictionaries.
+//
+// Codebase compiles .mm files in MRR — no ARC, no __weak. The observer
+// is a process-lived singleton created via dispatch_once and never
+// released, so capturing self by reference inside blocks is safe.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#include <pulp/platform/environment.hpp>
+
+using pulp::platform::ColorScheme;
+using pulp::platform::DisplayInfo;
+using pulp::platform::Environment;
+using pulp::platform::EnvironmentState;
+using pulp::platform::KeyboardInset;
+using pulp::platform::LifecycleState;
+using pulp::platform::MemoryPressure;
+using pulp::platform::Orientation;
+using pulp::platform::SafeAreaInsets;
+
+namespace {
+
+DisplayInfo snapshot_main_display() {
+    DisplayInfo info;
+    // [UIScreen mainScreen] is deprecated in iOS 26 in favor of
+    // view.window.windowScene.screen, but the Environment observer is
+    // a process-level singleton with no view context — falling back to
+    // the main screen matches every other multi-window iOS API and is
+    // accurate for single-screen apps (the only configuration iOS
+    // currently supports outside Stage Manager).
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    UIScreen* screen = [UIScreen mainScreen];
+#pragma clang diagnostic pop
+    if (!screen) return info;
+    CGRect bounds = screen.bounds;
+    info.width  = static_cast<float>(bounds.size.width);
+    info.height = static_cast<float>(bounds.size.height);
+    info.scale  = static_cast<float>(screen.nativeScale);
+    info.physical_width  = static_cast<int>(bounds.size.width  * info.scale);
+    info.physical_height = static_cast<int>(bounds.size.height * info.scale);
+    // maximumFramesPerSecond is the panel cap; ProMotion devices report
+    // 120, standard panels 60. Zero means unknown.
+    info.refresh_hz = static_cast<float>(screen.maximumFramesPerSecond);
+    // UIScreen has no localizedName equivalent; leave info.name empty.
+    return info;
+}
+
+ColorScheme detect_color_scheme() {
+    UITraitCollection* traits = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    UIScreen* screen = [UIScreen mainScreen];
+#pragma clang diagnostic pop
+    if (screen) traits = screen.traitCollection;
+    if (!traits) return ColorScheme::unknown;
+    switch (traits.userInterfaceStyle) {
+        case UIUserInterfaceStyleDark:  return ColorScheme::dark;
+        case UIUserInterfaceStyleLight: return ColorScheme::light;
+        default:                        return ColorScheme::unknown;
+    }
+}
+
+UIWindow* key_window() {
+    // UIApplication.keyWindow is deprecated; iterate scenes' windows.
+    UIApplication* app = [UIApplication sharedApplication];
+    if (!app) return nil;
+    if (@available(iOS 13.0, *)) {
+        for (UIScene* scene in app.connectedScenes) {
+            if (scene.activationState != UISceneActivationStateForegroundActive)
+                continue;
+            if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+            UIWindowScene* ws = (UIWindowScene*)scene;
+            for (UIWindow* w in ws.windows) {
+                if (w.isKeyWindow) return w;
+            }
+            // Fall back to the first window of the active scene.
+            if (ws.windows.count > 0) return ws.windows.firstObject;
+        }
+    }
+    // Last resort for pre-iOS 13 builds: iterate top-level windows.
+    // UIApplication.windows is deprecated in iOS 15 but the @available
+    // block above already covers iOS 13+; this branch is unreachable on
+    // any supported iOS deployment target.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    for (UIWindow* w in app.windows) {
+        if (w.isKeyWindow) return w;
+    }
+    return app.windows.firstObject;
+#pragma clang diagnostic pop
+}
+
+SafeAreaInsets snapshot_safe_area() {
+    SafeAreaInsets insets;
+    UIWindow* w = key_window();
+    if (!w) return insets;
+    UIEdgeInsets ei = w.safeAreaInsets;
+    insets.top    = static_cast<float>(ei.top);
+    insets.bottom = static_cast<float>(ei.bottom);
+    insets.left   = static_cast<float>(ei.left);
+    insets.right  = static_cast<float>(ei.right);
+    return insets;
+}
+
+Orientation map_orientation(UIDeviceOrientation o) {
+    switch (o) {
+        case UIDeviceOrientationPortrait:           return Orientation::portrait;
+        case UIDeviceOrientationPortraitUpsideDown: return Orientation::portrait_upside_down;
+        case UIDeviceOrientationLandscapeLeft:      return Orientation::landscape_left;
+        case UIDeviceOrientationLandscapeRight:     return Orientation::landscape_right;
+        case UIDeviceOrientationFaceUp:
+        case UIDeviceOrientationFaceDown:           return Orientation::flat;
+        case UIDeviceOrientationUnknown:
+        default:                                    return Orientation::unknown;
+    }
+}
+
+Orientation snapshot_orientation() {
+    UIDevice* device = [UIDevice currentDevice];
+    if (!device) return Orientation::unknown;
+    return map_orientation(device.orientation);
+}
+
+} // namespace
+
+@interface PulpEnvironmentObserverIos : NSObject
+@property(nonatomic) pulp::platform::LifecycleState  currentLifecycle;
+@property(nonatomic) pulp::platform::MemoryPressure  currentPressure;
+@property(nonatomic) pulp::platform::KeyboardInset   currentKeyboard;
+- (void)startObserving;
+- (void)publishSnapshot;
+@end
+
+@implementation PulpEnvironmentObserverIos
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _currentLifecycle = LifecycleState::foreground;
+        _currentPressure  = MemoryPressure::normal;
+        _currentKeyboard  = KeyboardInset{};
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    UIDevice* device = [UIDevice currentDevice];
+    if (device && device.isGeneratingDeviceOrientationNotifications) {
+        [device endGeneratingDeviceOrientationNotifications];
+    }
+    [super dealloc];
+}
+
+- (void)startObserving {
+    NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
+
+    // Lifecycle.
+    [nc addObserver:self
+           selector:@selector(onDidBecomeActive:)
+               name:UIApplicationDidBecomeActiveNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onWillResignActive:)
+               name:UIApplicationWillResignActiveNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onDidEnterBackground:)
+               name:UIApplicationDidEnterBackgroundNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onWillEnterForeground:)
+               name:UIApplicationWillEnterForegroundNotification
+             object:nil];
+
+    // Memory pressure (iOS surfaces only "critical" via this notification).
+    [nc addObserver:self
+           selector:@selector(onMemoryWarning:)
+               name:UIApplicationDidReceiveMemoryWarningNotification
+             object:nil];
+
+    // Orientation. iOS only emits these once we explicitly start
+    // generating them; the host might already have asked, in which case
+    // a second beginGenerating... call still nests safely (refcounted).
+    UIDevice* device = [UIDevice currentDevice];
+    if (device) {
+        [device beginGeneratingDeviceOrientationNotifications];
+        [nc addObserver:self
+               selector:@selector(onOrientationChange:)
+                   name:UIDeviceOrientationDidChangeNotification
+                 object:nil];
+    }
+
+    // Keyboard.
+    [nc addObserver:self
+           selector:@selector(onKeyboardWillShow:)
+               name:UIKeyboardWillShowNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onKeyboardWillHide:)
+               name:UIKeyboardWillHideNotification
+             object:nil];
+
+    // Display: UIScreenModeDidChange + brightness aren't strict matches
+    // for "geometry changed", but bounds shifts always coincide with
+    // either an orientation change or a window scene resize. We snapshot
+    // display on every publish, so orientation/keyboard events also pick
+    // up new geometry without an extra observer.
+
+    [self publishSnapshot];
+}
+
+- (void)publishSnapshot {
+    EnvironmentState s;
+    s.display         = snapshot_main_display();
+    s.safe_area       = snapshot_safe_area();
+    s.keyboard        = _currentKeyboard;
+    s.orientation     = snapshot_orientation();
+    s.color_scheme    = detect_color_scheme();
+    s.lifecycle       = _currentLifecycle;
+    s.memory_pressure = _currentPressure;
+    Environment::instance().publish(s);
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────
+- (void)onDidBecomeActive:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::foreground;
+    [self publishSnapshot];
+}
+- (void)onWillResignActive:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::inactive;
+    [self publishSnapshot];
+}
+- (void)onDidEnterBackground:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::background;
+    [self publishSnapshot];
+}
+- (void)onWillEnterForeground:(NSNotification*)note {
+    // The corresponding DidBecomeActive will follow shortly and clamp
+    // us back to foreground; report inactive in the interim so layout
+    // can react before the activation completes.
+    _currentLifecycle = LifecycleState::inactive;
+    [self publishSnapshot];
+}
+
+// ── Memory pressure ─────────────────────────────────────────────────
+- (void)onMemoryWarning:(NSNotification*)note {
+    // iOS only emits a single "critical" tier via this notification.
+    // We keep the field at critical until the next publish overrides
+    // it (e.g. on the next lifecycle/orientation event), matching
+    // Android's didReceiveMemoryWarning semantics.
+    _currentPressure = MemoryPressure::critical;
+    [self publishSnapshot];
+    // Reset so future snapshots don't keep reporting critical forever.
+    _currentPressure = MemoryPressure::normal;
+}
+
+// ── Orientation ─────────────────────────────────────────────────────
+- (void)onOrientationChange:(NSNotification*)note {
+    [self publishSnapshot];
+}
+
+// ── Keyboard ────────────────────────────────────────────────────────
+- (void)onKeyboardWillShow:(NSNotification*)note {
+    NSDictionary* info = note.userInfo;
+    if (!info) {
+        [self publishSnapshot];
+        return;
+    }
+    NSValue* frameValue = info[UIKeyboardFrameEndUserInfoKey];
+    NSNumber* duration  = info[UIKeyboardAnimationDurationUserInfoKey];
+    KeyboardInset k;
+    if (frameValue) {
+        CGRect endFrame = frameValue.CGRectValue;
+        // The keyboard frame is in screen coordinates; its height is the
+        // bottom inset for layout purposes.
+        k.bottom = static_cast<float>(endFrame.size.height);
+    }
+    if (duration) {
+        k.animation_duration = static_cast<float>(duration.doubleValue);
+    }
+    _currentKeyboard = k;
+    [self publishSnapshot];
+}
+
+- (void)onKeyboardWillHide:(NSNotification*)note {
+    NSDictionary* info = note.userInfo;
+    KeyboardInset k;
+    if (info) {
+        NSNumber* duration = info[UIKeyboardAnimationDurationUserInfoKey];
+        if (duration) {
+            k.animation_duration = static_cast<float>(duration.doubleValue);
+        }
+    }
+    _currentKeyboard = k; // bottom defaults to 0
+    [self publishSnapshot];
+}
+@end
+
+namespace pulp::platform {
+
+namespace {
+PulpEnvironmentObserverIos* g_observer = nil;
+}
+
+// Public entry — host bootstrap calls this once during UIApplication
+// setup. Idempotent: a second call is a no-op so AUv3/standalone host
+// loads don't double-register observers.
+void start_environment_observer_ios() {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        // The observer is process-lived; we deliberately never release
+        // it. dispatch_once guarantees a single instance per process.
+        void (^bootstrap)(void) = ^{
+            g_observer = [[PulpEnvironmentObserverIos alloc] init];
+            [g_observer startObserving];
+        };
+        if ([NSThread isMainThread]) {
+            bootstrap();
+        } else {
+            // UIKit observers must be installed on the main thread.
+            dispatch_sync(dispatch_get_main_queue(), bootstrap);
+        }
+    });
+}
+
+} // namespace pulp::platform

--- a/core/platform/src/environment.cpp
+++ b/core/platform/src/environment.cpp
@@ -1,0 +1,120 @@
+#include <pulp/platform/environment.hpp>
+
+#include <utility>
+
+namespace pulp::platform {
+
+// ── Token ──────────────────────────────────────────────────────────────────
+
+Environment::Token::Token(Token&& other) noexcept
+    : id_(other.id_) {
+    other.id_ = 0;
+}
+
+Environment::Token& Environment::Token::operator=(Token&& other) noexcept {
+    if (this != &other) {
+        reset();
+        id_ = other.id_;
+        other.id_ = 0;
+    }
+    return *this;
+}
+
+void Environment::Token::reset() noexcept {
+    if (id_ != 0) {
+        Environment::instance().unsubscribe(id_);
+        id_ = 0;
+    }
+}
+
+// ── Environment ────────────────────────────────────────────────────────────
+
+Environment& Environment::instance() {
+    // Function-local static — initialized on first use, destroyed at
+    // process exit in reverse order of construction. Safe under C++11
+    // magic-statics (Itanium ABI / MSVC 2015+).
+    static Environment env;
+    return env;
+}
+
+EnvironmentState Environment::snapshot() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return state_;
+}
+
+Environment::Token Environment::subscribe(Listener listener) {
+    if (!listener) return Token{};
+    std::lock_guard<std::mutex> lock(mu_);
+    uint64_t id = next_id_++;
+    listeners_.push_back(Entry{id, std::move(listener)});
+    return Token{id};
+}
+
+void Environment::unsubscribe(uint64_t id) {
+    std::lock_guard<std::mutex> lock(mu_);
+    for (auto it = listeners_.begin(); it != listeners_.end(); ++it) {
+        if (it->id == id) {
+            listeners_.erase(it);
+            return;
+        }
+    }
+}
+
+namespace {
+
+EnvironmentChange diff(const EnvironmentState& prev, const EnvironmentState& next) {
+    EnvironmentChange c;
+    const auto& a = prev.display;
+    const auto& b = next.display;
+    c.display = (a.width != b.width) || (a.height != b.height)
+             || (a.physical_width != b.physical_width)
+             || (a.physical_height != b.physical_height)
+             || (a.scale != b.scale) || (a.refresh_hz != b.refresh_hz)
+             || (a.name != b.name);
+    const auto& sa = prev.safe_area;
+    const auto& sb = next.safe_area;
+    c.safe_area = (sa.top != sb.top) || (sa.bottom != sb.bottom)
+               || (sa.left != sb.left) || (sa.right != sb.right);
+    c.keyboard = (prev.keyboard.bottom != next.keyboard.bottom)
+              || (prev.keyboard.animation_duration
+                  != next.keyboard.animation_duration);
+    c.orientation     = (prev.orientation     != next.orientation);
+    c.color_scheme    = (prev.color_scheme    != next.color_scheme);
+    c.lifecycle       = (prev.lifecycle       != next.lifecycle);
+    c.memory_pressure = (prev.memory_pressure != next.memory_pressure);
+    return c;
+}
+
+} // namespace
+
+void Environment::publish(const EnvironmentState& next) {
+    // Compute diff + take snapshot of listeners under the lock, then
+    // invoke listeners outside the lock so a callback that drops a token
+    // (and calls back into unsubscribe) doesn't deadlock.
+    std::vector<Entry> listeners_copy;
+    EnvironmentChange change;
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        change = diff(state_, next);
+        if (!change.any()) return;
+        state_ = next;
+        listeners_copy = listeners_;
+    }
+    for (const auto& entry : listeners_copy) {
+        entry.fn(next, change);
+    }
+}
+
+void Environment::inject_for_test(const EnvironmentState& state) {
+    instance().publish(state);
+}
+
+void Environment::reset_for_test() {
+    auto& env = instance();
+    std::lock_guard<std::mutex> lock(env.mu_);
+    env.state_ = EnvironmentState{};
+    env.listeners_.clear();
+    env.next_id_ = 1;
+}
+
+} // namespace pulp::platform

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -472,6 +472,11 @@ add_executable(pulp-test-permissions test_permissions.cpp)
 target_link_libraries(pulp-test-permissions PRIVATE pulp::platform Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-permissions)
 
+# Environment API tests (#342)
+add_executable(pulp-test-environment test_environment.cpp)
+target_link_libraries(pulp-test-environment PRIVATE pulp::platform Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-environment)
+
 # Runtime tests
 add_executable(pulp-test-runtime test_runtime.cpp)
 target_link_libraries(pulp-test-runtime PRIVATE pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -1,0 +1,194 @@
+// Unit tests for the unified environment API (#342).
+//
+// The Environment singleton is a process-wide notifier; tests reset it
+// in each TEST_CASE so prior tests don't leak listeners or stale state.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/environment.hpp>
+
+#include <atomic>
+
+using namespace pulp::platform;
+
+namespace {
+
+EnvironmentState make_state(ColorScheme scheme,
+                            float scale = 2.0f,
+                            float kbd = 0.0f) {
+    EnvironmentState s;
+    s.display.width = 800;
+    s.display.height = 600;
+    s.display.scale = scale;
+    s.color_scheme = scheme;
+    s.keyboard.bottom = kbd;
+    s.lifecycle = LifecycleState::foreground;
+    s.orientation = Orientation::portrait;
+    return s;
+}
+
+} // namespace
+
+TEST_CASE("Environment: singleton state defaults are sentinel-safe", "[environment]") {
+    Environment::reset_for_test();
+    auto s = Environment::instance().snapshot();
+    REQUIRE(s.color_scheme    == ColorScheme::unknown);
+    REQUIRE(s.lifecycle       == LifecycleState::unknown);
+    REQUIRE(s.orientation     == Orientation::unknown);
+    REQUIRE(s.memory_pressure == MemoryPressure::normal);
+    REQUIRE(s.safe_area.is_zero());
+    REQUIRE(s.keyboard.bottom == 0.0f);
+}
+
+TEST_CASE("Environment: subscribe receives publish + correct change mask",
+          "[environment]") {
+    Environment::reset_for_test();
+    int dark_calls = 0;
+    EnvironmentChange last_change;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            if (s.color_scheme == ColorScheme::dark) ++dark_calls;
+            last_change = c;
+        });
+
+    // First publish — color scheme changes from unknown -> dark, scale
+    // from 1 -> 2, lifecycle from unknown -> foreground, etc. Many flags.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(dark_calls == 1);
+    REQUIRE(last_change.color_scheme);
+    REQUIRE(last_change.lifecycle);
+    REQUIRE(last_change.display);
+
+    // Idempotent publish — no change, no callback.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(dark_calls == 1);
+
+    // Color scheme flip alone — only that bit set.
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(dark_calls == 1);
+    REQUIRE(last_change.color_scheme);
+    REQUIRE_FALSE(last_change.display);
+    REQUIRE_FALSE(last_change.lifecycle);
+}
+
+TEST_CASE("Environment: token RAII unsubscribes", "[environment]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    {
+        auto token = Environment::instance().subscribe(
+            [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+        Environment::inject_for_test(make_state(ColorScheme::dark));
+        REQUIRE(calls == 1);
+    } // token dropped → unsubscribed
+
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: token move transfers ownership", "[environment]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto sub = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(sub.valid());
+
+    auto moved = std::move(sub);
+    REQUIRE(moved.valid());
+    REQUIRE_FALSE(sub.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: keyboard inset change propagates separately",
+          "[environment]") {
+    Environment::reset_for_test();
+    EnvironmentChange last;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange c) { last = c; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark, 2.0f, 0.0f));
+    Environment::inject_for_test(make_state(ColorScheme::dark, 2.0f, 320.0f));
+    REQUIRE(last.keyboard);
+    REQUIRE_FALSE(last.color_scheme);
+    REQUIRE_FALSE(last.display);
+}
+
+TEST_CASE("Environment: safe-area diff detection across all four edges",
+          "[environment]") {
+    Environment::reset_for_test();
+    EnvironmentChange last;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange c) { last = c; });
+
+    auto base = make_state(ColorScheme::dark);
+    Environment::inject_for_test(base);
+
+    auto with_inset = base;
+    with_inset.safe_area.top = 47.0f;
+    Environment::inject_for_test(with_inset);
+    REQUIRE(last.safe_area);
+
+    // Bottom-only change.
+    auto bottom = with_inset;
+    bottom.safe_area.bottom = 34.0f;
+    Environment::inject_for_test(bottom);
+    REQUIRE(last.safe_area);
+    REQUIRE_FALSE(last.color_scheme);
+}
+
+TEST_CASE("Environment: memory pressure transitions", "[environment]") {
+    Environment::reset_for_test();
+    int observed = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            if (c.memory_pressure
+                && s.memory_pressure == MemoryPressure::critical) {
+                ++observed;
+            }
+        });
+
+    auto base = make_state(ColorScheme::dark);
+    Environment::inject_for_test(base);
+
+    auto moderate = base;
+    moderate.memory_pressure = MemoryPressure::moderate;
+    Environment::inject_for_test(moderate);
+    REQUIRE(observed == 0);
+
+    auto critical = base;
+    critical.memory_pressure = MemoryPressure::critical;
+    Environment::inject_for_test(critical);
+    REQUIRE(observed == 1);
+}
+
+TEST_CASE("Environment: callback that drops its own token does not deadlock",
+          "[environment]") {
+    Environment::reset_for_test();
+    std::unique_ptr<Environment::Token> token;
+    token = std::make_unique<Environment::Token>(
+        Environment::instance().subscribe(
+            [&](const EnvironmentState&, EnvironmentChange) {
+                token.reset();  // unsubscribe from inside the callback
+            }));
+
+    // If publish() held the mutex during dispatch, this would deadlock
+    // when the listener calls back into unsubscribe.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    SUCCEED("no deadlock");
+}
+
+TEST_CASE("Environment: snapshot is consistent with last publish",
+          "[environment]") {
+    Environment::reset_for_test();
+    auto s = make_state(ColorScheme::light, 1.5f, 220.0f);
+    s.orientation = Orientation::landscape_left;
+    s.safe_area.top = 22.0f;
+    Environment::inject_for_test(s);
+
+    auto got = Environment::instance().snapshot();
+    REQUIRE(got.color_scheme    == ColorScheme::light);
+    REQUIRE(got.orientation     == Orientation::landscape_left);
+    REQUIRE(got.display.scale   == 1.5f);
+    REQUIRE(got.keyboard.bottom == 220.0f);
+    REQUIRE(got.safe_area.top   == 22.0f);
+}


### PR DESCRIPTION
## Summary

iOS adapter for the unified Environment API introduced in #403. Mirrors the macOS adapter shipped in #404 — same MRR/no-ARC style, same `dispatch_once` singleton, same publish-full-snapshot pattern so the platform-agnostic `Environment` notifier sees one coherent state per OS event.

This PR stacks on **#403** and complements **#404** (macOS) and **#407** (Android JNI bridge).

### Hooks

| OS notification | EnvironmentState field |
|---|---|
| `UIApplicationDidBecomeActiveNotification`     | `lifecycle = foreground` |
| `UIApplicationWillResignActiveNotification`    | `lifecycle = inactive` |
| `UIApplicationDidEnterBackgroundNotification`  | `lifecycle = background` |
| `UIApplicationWillEnterForegroundNotification` | `lifecycle = inactive` (until `DidBecomeActive` follows) |
| `UIApplicationDidReceiveMemoryWarningNotification` | `memory_pressure = critical` (single-shot, then resets to `normal`) |
| `UIDeviceOrientationDidChangeNotification`     | `orientation` (after `beginGeneratingDeviceOrientationNotifications`) |
| `UIKeyboardWillShowNotification`               | `keyboard.bottom` + `keyboard.animation_duration` (from `UIKeyboardFrameEndUserInfoKey` + `UIKeyboardAnimationDurationUserInfoKey`) |
| `UIKeyboardWillHideNotification`               | `keyboard` zeroed (preserves animation duration) |

### Fields populated on every publish

- `display` — `[UIScreen mainScreen]` bounds (CSS px), `nativeScale`, `maximumFramesPerSecond`
- `safe_area` — key-window `safeAreaInsets` resolved through `UIWindowScene` on iOS 13+ with `UIApplication.windows` as a pre-iOS-13 fallback
- `color_scheme` — `UIScreen.mainScreen.traitCollection.userInterfaceStyle` (`Dark` / `Light` / `unknown`)
- `orientation` — `UIDevice.currentDevice.orientation` mapped to the cross-platform enum (face-up/down both report `flat`)

### Bootstrap

Hosts call `pulp::platform::start_environment_observer()`, which dispatches to `start_environment_observer_ios()` under `__APPLE__ && PULP_IOS`. Idempotent via `dispatch_once`; UIKit observers are installed on the main thread (the bootstrap forwards to the main queue if called from a background thread).

The header's `start_environment_observer()` wrapper now branches on `PULP_IOS`; the existing macOS branch is unchanged.

### Verification

- `clang++ -fno-objc-arc -std=gnu++20 -Wall -Wextra -Werror` against both iPhoneOS 26.2 and iPhoneSimulator 26.2 SDKs — clean compile (zero warnings).
- Full CMake configure/build for iOS not run: `wgpu-native` is the first iOS-unsupported FetchContent in the tree (`Platform system 'iOS' not supported by this release of WebGPU`), unrelated to this change.

## Test plan

- [ ] Per-platform CI on macOS / Ubuntu / Windows still passes (this file only compiles when `IOS` is true, so the cross-platform matrix is a no-op for the new source)
- [ ] Follow-up: wire `start_environment_observer_ios()` into the iOS app/AUv3 host bootstrap once the iOS host target lands
- [ ] Follow-up: integration test that drives `UIApplication` notifications and asserts an `EnvironmentChange` is observed