### PR TITLE
platform(win): WM_ACTIVATEAPP + registry-watch observers for Environment API (#342)

### DIFF
--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(pulp-platform PRIVATE
     src/permissions.cpp
     src/registry.cpp
     src/clipboard_common.cpp
+    src/environment.cpp
 )
 
 # Platform-specific UI services and child process

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -45,7 +45,9 @@ elseif(WIN32)
     target_sources(pulp-platform PRIVATE
         platform/win/clipboard_win.cpp
         platform/win/child_process_win.cpp
+        platform/win/environment_win.cpp
     )
+    target_link_libraries(pulp-platform PRIVATE user32 advapi32)
 elseif(ANDROID)
     # Android platform sources wired via PulpAndroid.cmake → pulp_wire_android_sources()
     target_sources(pulp-platform PRIVATE

--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -1,0 +1,219 @@
+#pragma once
+
+/// @file environment.hpp
+/// Unified environment API: display, safe-area, keyboard, orientation,
+/// color scheme, foreground/background, memory pressure.
+///
+/// Each platform populates the fields it can observe; unsupported fields
+/// retain their default. Listeners receive a snapshot of the new state
+/// + a bitmask of which fields changed since the last notification.
+///
+/// Thread model: Environment is meant to be read from any thread (the
+/// snapshot accessor returns a value copy). Listeners are invoked on the
+/// thread that delivered the platform event — typically the main UI
+/// thread — but no global locking is held during dispatch, so listener
+/// bodies that touch shared state must apply their own synchronization.
+///
+/// This header defines the contract and an in-process notifier. Platform
+/// adapters live under `core/platform/platform/{android,ios,mac,win,linux}/`
+/// and call Environment::dispatcher().publish(...) when their respective
+/// OS callbacks fire (Android `Configuration.onConfigurationChanged`,
+/// iOS `UITraitCollection`, macOS `NSApplicationDidChangeScreenParameters`,
+/// Windows `WM_DPICHANGED`/`WM_SETTINGCHANGE`, Linux XSettings + Wayland
+/// fractional scale).
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace pulp::platform {
+
+/// Light/dark color scheme reported by the OS.
+enum class ColorScheme : uint8_t {
+    light,
+    dark,
+    /// Platform did not report; treat as `dark` per Pulp's default theme.
+    unknown,
+};
+
+/// Coarse foreground/background lifecycle state. Mobile platforms drive
+/// this from the activity/scene lifecycle; desktop drives from the
+/// active-window observer (NSApp resignActive on macOS, WM_ACTIVATEAPP
+/// on Windows, _NET_ACTIVE_WINDOW on X11).
+enum class LifecycleState : uint8_t {
+    foreground,
+    /// App is visible but not the focused window (split-screen, banner).
+    inactive,
+    background,
+    unknown,
+};
+
+/// Device orientation. `flat` is "screen facing up" — used by mobile to
+/// disable orientation-driven layout when the device is lying on a table.
+enum class Orientation : uint8_t {
+    portrait,
+    portrait_upside_down,
+    landscape_left,
+    landscape_right,
+    flat,
+    unknown,
+};
+
+/// Memory pressure level. Mirrors Android's TRIM_MEMORY tiers + iOS's
+/// `didReceiveMemoryWarning` (which becomes `critical`). Desktop
+/// platforms emit `normal` only — they don't have a kernel-driven LMK.
+enum class MemoryPressure : uint8_t {
+    normal,
+    /// Some background processes were killed; trim soft caches.
+    moderate,
+    /// Foreground app is the next likely target; release optional state.
+    critical,
+};
+
+/// Safe-area insets in CSS-pixel space (already divided by content_scale).
+/// Top/bottom cover the iOS notch + home indicator and Android cutouts;
+/// left/right cover landscape notches and rounded display corners.
+struct SafeAreaInsets {
+    float top    = 0.0f;
+    float bottom = 0.0f;
+    float left   = 0.0f;
+    float right  = 0.0f;
+
+    bool is_zero() const noexcept {
+        return top == 0.0f && bottom == 0.0f && left == 0.0f && right == 0.0f;
+    }
+};
+
+/// Soft-keyboard inset (mobile only). The on-screen keyboard occupies
+/// `bottom` pixels of the display from the bottom edge; layout should
+/// translate / shrink accordingly so focused inputs remain visible.
+struct KeyboardInset {
+    float bottom = 0.0f;
+    /// Animation duration the OS reported for the show/hide transition,
+    /// in seconds. Zero when not animating or unknown.
+    float animation_duration = 0.0f;
+};
+
+/// Logical display geometry. `width` and `height` are in CSS pixels;
+/// `physical_*` are the OS's reported pixel resolution. `scale` is the
+/// device pixel ratio (NSScreen backingScaleFactor / Android density /
+/// Windows DPI / 96.0).
+struct DisplayInfo {
+    float width        = 0.0f;
+    float height       = 0.0f;
+    int   physical_width  = 0;
+    int   physical_height = 0;
+    float scale         = 1.0f;
+    /// Refresh rate in Hz. Zero when unknown.
+    float refresh_hz    = 0.0f;
+    /// Optional human-readable name (e.g. "Built-in Retina Display").
+    std::string name;
+};
+
+/// Bitmask of fields that changed in the snapshot delivered to a listener.
+/// Listeners should inspect this rather than diff the whole struct.
+struct EnvironmentChange {
+    bool display          : 1;
+    bool safe_area        : 1;
+    bool keyboard         : 1;
+    bool orientation      : 1;
+    bool color_scheme     : 1;
+    bool lifecycle        : 1;
+    bool memory_pressure  : 1;
+
+    EnvironmentChange() noexcept
+        : display(false), safe_area(false), keyboard(false),
+          orientation(false), color_scheme(false), lifecycle(false),
+          memory_pressure(false) {}
+
+    bool any() const noexcept {
+        return display || safe_area || keyboard || orientation
+            || color_scheme || lifecycle || memory_pressure;
+    }
+};
+
+/// Snapshot of the full environment state. Listener callbacks receive
+/// a `(state, change)` pair so they can branch on `change.color_scheme`
+/// without diffing the previous snapshot themselves.
+struct EnvironmentState {
+    DisplayInfo     display;
+    SafeAreaInsets  safe_area;
+    KeyboardInset   keyboard;
+    Orientation     orientation     = Orientation::unknown;
+    ColorScheme     color_scheme    = ColorScheme::unknown;
+    LifecycleState  lifecycle       = LifecycleState::unknown;
+    MemoryPressure  memory_pressure = MemoryPressure::normal;
+};
+
+/// In-process notifier. Listeners survive until the returned token is
+/// destroyed (RAII subscription pattern, same as runtime::Logger).
+///
+/// The notifier is intentionally a singleton — there's exactly one OS
+/// reporting these signals per process. Tests can call `inject_for_test`
+/// to drive the singleton without a real platform adapter.
+class Environment {
+public:
+    using Listener = std::function<void(const EnvironmentState&,
+                                        EnvironmentChange)>;
+
+    /// RAII subscription. Drop to unsubscribe.
+    class Token {
+    public:
+        Token() = default;
+        ~Token() { reset(); }
+        Token(Token&& other) noexcept;
+        Token& operator=(Token&& other) noexcept;
+        Token(const Token&) = delete;
+        Token& operator=(const Token&) = delete;
+        void reset() noexcept;
+        bool valid() const noexcept { return id_ != 0; }
+    private:
+        friend class Environment;
+        Token(uint64_t id) : id_(id) {}
+        uint64_t id_ = 0;
+    };
+
+    /// Get the process singleton.
+    static Environment& instance();
+
+    /// Snapshot the current state. Safe from any thread.
+    EnvironmentState snapshot() const;
+
+    /// Subscribe to changes. The callback fires after `publish` returns
+    /// the new state. The returned token unsubscribes on destruction.
+    Token subscribe(Listener listener);
+
+    /// Push a new state. Computes `EnvironmentChange` against the prior
+    /// snapshot and dispatches to every listener. Intended for platform
+    /// adapter code; tests use `inject_for_test` (which forwards here
+    /// after taking the test mutex).
+    void publish(const EnvironmentState& next);
+
+    // ── Test hooks ──────────────────────────────────────────────────
+    /// Replace the singleton state and notify listeners. Used by unit
+    /// tests to simulate platform events without a real OS callback.
+    static void inject_for_test(const EnvironmentState& state);
+
+    /// Reset the singleton to defaults and remove every listener.
+    /// Tests call this in TEST_CASE setup so prior tests don't leak
+    /// listeners or stale state.
+    static void reset_for_test();
+
+private:
+    Environment() = default;
+    Environment(const Environment&) = delete;
+    Environment& operator=(const Environment&) = delete;
+
+    void unsubscribe(uint64_t id);
+
+    mutable std::mutex mu_;
+    EnvironmentState   state_;
+    struct Entry { uint64_t id; Listener fn; };
+    std::vector<Entry> listeners_;
+    uint64_t           next_id_ = 1;
+};
+
+} // namespace pulp::platform

--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -216,4 +216,29 @@ private:
     uint64_t           next_id_ = 1;
 };
 
+// ── Per-platform observer bootstraps ─────────────────────────────────
+// Hosts call start_environment_observer() once during startup. Each
+// platform adapter is idempotent — duplicate calls are a no-op so
+// plugin hosts loaded multiple times don't double-register.
+//
+// Adapters land per platform; this header forward-declares them
+// alphabetically. The convenience wrapper at the bottom dispatches to
+// the right one based on the build target.
+
+#if defined(_WIN32)
+void start_environment_observer_win();
+#endif
+// void start_environment_observer_android(); // follow-up
+// void start_environment_observer_ios();     // follow-up
+// void start_environment_observer_linux();   // follow-up
+// void start_environment_observer_mac();     // follow-up
+
+inline void start_environment_observer() {
+#if defined(_WIN32)
+    start_environment_observer_win();
+#endif
+    // Other platforms wire their adapters in follow-up PRs; until then
+    // their hosts simply see the EnvironmentState defaults.
+}
+
 } // namespace pulp::platform

--- a/core/platform/platform/win/environment_win.cpp
+++ b/core/platform/platform/win/environment_win.cpp
@@ -1,0 +1,336 @@
+// Windows adapter for the unified Environment API (#342).
+//
+// Pure Win32 — no UWP/WinRT — so this works in every plugin host
+// (DAW process, standalone, AAX wrapper) regardless of WinRT init.
+//
+// Two observers feed Environment::publish():
+//
+//   1. A hidden message-only window (HWND_MESSAGE parent) whose
+//      WindowProc translates WM_ACTIVATEAPP → LifecycleState
+//      (foreground when wParam != 0, inactive otherwise) and
+//      WM_DPICHANGED / WM_DISPLAYCHANGE / WM_SETTINGCHANGE → display
+//      and color-scheme refresh.
+//
+//   2. A worker thread that
+//        a. waits on RegNotifyChangeKeyValue() for changes to
+//           HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\
+//           Personalize\AppsUseLightTheme (light/dark mode toggle), and
+//        b. polls GlobalMemoryStatusEx() every 5 s to map
+//           dwMemoryLoad → MemoryPressure tier.
+//      The thread merges both signals into one publish() per wake-up
+//      so listeners see a single coherent snapshot.
+//
+// Safe-area / keyboard / orientation are mobile-only and stay at the
+// EnvironmentState defaults on Windows desktop, per the
+// EnvironmentState contract.
+
+#if defined(_WIN32)
+
+#include <pulp/platform/environment.hpp>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <windows.h>
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace pulp::platform {
+
+namespace {
+
+// ── Display detection ─────────────────────────────────────────────────
+
+// GetDpiForSystem is on Windows 10 1607+. We look it up dynamically so
+// the adapter still links on older toolchains/SDKs that don't expose
+// it; if it isn't present we fall back to GetDeviceCaps(LOGPIXELSX).
+UINT query_system_dpi() noexcept {
+    using GetDpiForSystemFn = UINT (WINAPI*)();
+    static auto fn = []() -> GetDpiForSystemFn {
+        if (HMODULE h = GetModuleHandleW(L"user32.dll")) {
+            return reinterpret_cast<GetDpiForSystemFn>(
+                GetProcAddress(h, "GetDpiForSystem"));
+        }
+        return nullptr;
+    }();
+    if (fn) return fn();
+    HDC dc = GetDC(nullptr);
+    UINT dpi = 96;
+    if (dc) {
+        int v = GetDeviceCaps(dc, LOGPIXELSX);
+        if (v > 0) dpi = static_cast<UINT>(v);
+        ReleaseDC(nullptr, dc);
+    }
+    return dpi;
+}
+
+std::string primary_monitor_name() {
+    // Walk EnumDisplayDevicesW (DISPLAY_DEVICE_PRIMARY_DEVICE) for the
+    // adapter, then ask GetMonitorInfoW for its monitor's friendly name.
+    DISPLAY_DEVICEW dev{};
+    dev.cb = sizeof(dev);
+    for (DWORD i = 0; EnumDisplayDevicesW(nullptr, i, &dev, 0); ++i) {
+        if (dev.StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE) {
+            // DeviceString is the adapter description (e.g. "Intel UHD
+            // Graphics 630"); good enough as a human-readable label
+            // when the per-monitor name isn't available.
+            char buf[128] = {};
+            int n = WideCharToMultiByte(
+                CP_UTF8, 0, dev.DeviceString, -1, buf, sizeof(buf),
+                nullptr, nullptr);
+            if (n > 0) return std::string(buf);
+            return {};
+        }
+    }
+    return {};
+}
+
+DisplayInfo snapshot_main_display() {
+    DisplayInfo info;
+    const int phys_w = GetSystemMetrics(SM_CXSCREEN);
+    const int phys_h = GetSystemMetrics(SM_CYSCREEN);
+    const UINT dpi = query_system_dpi();
+    const float scale = dpi > 0 ? static_cast<float>(dpi) / 96.0f : 1.0f;
+    info.physical_width  = phys_w;
+    info.physical_height = phys_h;
+    info.scale           = scale;
+    info.width  = scale > 0.0f ? static_cast<float>(phys_w) / scale
+                               : static_cast<float>(phys_w);
+    info.height = scale > 0.0f ? static_cast<float>(phys_h) / scale
+                               : static_cast<float>(phys_h);
+    info.refresh_hz = 0.0f; // EnumDisplaySettings could fill this; not
+                            // worth the cost on a poll path.
+    info.name = primary_monitor_name();
+    return info;
+}
+
+// ── Color scheme detection ────────────────────────────────────────────
+
+constexpr wchar_t kPersonalizeKey[] =
+    L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+constexpr wchar_t kAppsUseLightTheme[] = L"AppsUseLightTheme";
+
+ColorScheme detect_color_scheme() {
+    HKEY key = nullptr;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, kPersonalizeKey, 0,
+                      KEY_READ, &key) != ERROR_SUCCESS) {
+        return ColorScheme::unknown;
+    }
+    DWORD value = 1;
+    DWORD size = sizeof(value);
+    DWORD type = 0;
+    LONG r = RegQueryValueExW(key, kAppsUseLightTheme, nullptr, &type,
+                              reinterpret_cast<LPBYTE>(&value), &size);
+    RegCloseKey(key);
+    if (r != ERROR_SUCCESS || type != REG_DWORD) return ColorScheme::unknown;
+    return value == 0 ? ColorScheme::dark : ColorScheme::light;
+}
+
+// ── Memory pressure ───────────────────────────────────────────────────
+//
+// Win32 has no per-process LMK signal at the desktop session layer,
+// so we sample GlobalMemoryStatusEx().dwMemoryLoad on the worker tick.
+// Tiers mirror the macOS dispatch source: < 80 normal, < 95 moderate,
+// >= 95 critical.
+
+MemoryPressure detect_memory_pressure() {
+    MEMORYSTATUSEX ms{};
+    ms.dwLength = sizeof(ms);
+    if (!GlobalMemoryStatusEx(&ms)) return MemoryPressure::normal;
+    if (ms.dwMemoryLoad >= 95) return MemoryPressure::critical;
+    if (ms.dwMemoryLoad >= 80) return MemoryPressure::moderate;
+    return MemoryPressure::normal;
+}
+
+// ── Shared observer state ─────────────────────────────────────────────
+
+class WinEnvObserver {
+public:
+    void start();
+
+    LifecycleState lifecycle() const noexcept {
+        return lifecycle_.load(std::memory_order_acquire);
+    }
+    void set_lifecycle(LifecycleState s) noexcept {
+        lifecycle_.store(s, std::memory_order_release);
+    }
+
+    MemoryPressure pressure() const noexcept {
+        return pressure_.load(std::memory_order_acquire);
+    }
+    void set_pressure(MemoryPressure p) noexcept {
+        pressure_.store(p, std::memory_order_release);
+    }
+
+    void publish_snapshot() {
+        EnvironmentState s;
+        s.display         = snapshot_main_display();
+        s.color_scheme    = detect_color_scheme();
+        s.lifecycle       = lifecycle();
+        s.memory_pressure = pressure();
+        Environment::instance().publish(s);
+    }
+
+    // Owned by the observer so we can signal the worker to wake up
+    // without waiting for the registry change. start() creates them;
+    // they live for the process lifetime.
+    HANDLE wake_event() const noexcept { return wake_event_; }
+
+private:
+    static LRESULT CALLBACK window_proc(HWND, UINT, WPARAM, LPARAM);
+    void create_message_window();
+    void run_worker();
+
+    std::atomic<LifecycleState> lifecycle_{LifecycleState::foreground};
+    std::atomic<MemoryPressure> pressure_{MemoryPressure::normal};
+    std::atomic<bool>           running_{false};
+    std::once_flag              start_once_;
+    std::thread                 worker_;
+    HANDLE                      wake_event_ = nullptr;
+};
+
+WinEnvObserver g_observer;
+
+LRESULT CALLBACK WinEnvObserver::window_proc(HWND hwnd, UINT msg,
+                                             WPARAM wparam, LPARAM lparam) {
+    switch (msg) {
+    case WM_ACTIVATEAPP: {
+        // wParam: TRUE if the app is being activated, FALSE otherwise.
+        g_observer.set_lifecycle(wparam ? LifecycleState::foreground
+                                        : LifecycleState::inactive);
+        g_observer.publish_snapshot();
+        return 0;
+    }
+    case WM_DPICHANGED:
+    case WM_DISPLAYCHANGE: {
+        g_observer.publish_snapshot();
+        return 0;
+    }
+    case WM_SETTINGCHANGE: {
+        // wParam == 0 with lParam pointing at "ImmersiveColorSet" is
+        // the documented signal for personalization changes (light/
+        // dark mode). Anything else is harmless to refresh on.
+        g_observer.publish_snapshot();
+        // Also wake the worker so a manual registry edit (no broadcast)
+        // is picked up promptly without waiting for the 5 s tick.
+        if (HANDLE w = g_observer.wake_event()) SetEvent(w);
+        return 0;
+    }
+    default:
+        break;
+    }
+    return DefWindowProcW(hwnd, msg, wparam, lparam);
+}
+
+void WinEnvObserver::create_message_window() {
+    static const wchar_t kClassName[] = L"PulpEnvironmentObserverWindow";
+
+    WNDCLASSEXW wc{};
+    wc.cbSize        = sizeof(wc);
+    wc.lpfnWndProc   = &WinEnvObserver::window_proc;
+    wc.hInstance     = GetModuleHandleW(nullptr);
+    wc.lpszClassName = kClassName;
+    // RegisterClassExW returns 0 on duplicate-class; that's fine,
+    // CreateWindowExW will succeed against the existing registration.
+    RegisterClassExW(&wc);
+
+    HWND hwnd = CreateWindowExW(
+        0, kClassName, L"PulpEnvironmentObserver",
+        0, 0, 0, 0, 0,
+        HWND_MESSAGE,             // message-only parent
+        nullptr,
+        wc.hInstance,
+        nullptr);
+    if (!hwnd) return;
+    // We never destroy the window — it lives for the process lifetime,
+    // matching the macOS adapter's dispatch_once observer.
+}
+
+void WinEnvObserver::run_worker() {
+    HKEY key = nullptr;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, kPersonalizeKey, 0,
+                      KEY_READ | KEY_NOTIFY, &key) != ERROR_SUCCESS) {
+        key = nullptr;
+    }
+
+    HANDLE reg_event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    auto arm_reg = [&]() {
+        if (!key || !reg_event) return;
+        ResetEvent(reg_event);
+        RegNotifyChangeKeyValue(key, FALSE,
+            REG_NOTIFY_CHANGE_NAME | REG_NOTIFY_CHANGE_LAST_SET,
+            reg_event, TRUE);
+    };
+    arm_reg();
+
+    constexpr DWORD kPollMs = 5000;
+
+    // Initial snapshot so listeners get state without waiting for an
+    // OS event. Mirrors PulpEnvironmentObserver::startObserving on macOS.
+    set_pressure(detect_memory_pressure());
+    publish_snapshot();
+
+    while (running_.load(std::memory_order_acquire)) {
+        HANDLE handles[2];
+        DWORD count = 0;
+        if (reg_event) handles[count++] = reg_event;
+        if (wake_event_) handles[count++] = wake_event_;
+
+        DWORD wait = (count > 0)
+            ? WaitForMultipleObjects(count, handles, FALSE, kPollMs)
+            : (Sleep(kPollMs), WAIT_TIMEOUT);
+
+        if (!running_.load(std::memory_order_acquire)) break;
+
+        // Re-arm registry watch any time it fired.
+        if (reg_event && wait == WAIT_OBJECT_0) {
+            arm_reg();
+        }
+
+        // Always sample memory pressure on a wake-up, then publish a
+        // single coherent snapshot regardless of which signal woke us.
+        set_pressure(detect_memory_pressure());
+        publish_snapshot();
+    }
+
+    if (reg_event) CloseHandle(reg_event);
+    if (key) RegCloseKey(key);
+}
+
+void WinEnvObserver::start() {
+    std::call_once(start_once_, [this]() {
+        wake_event_ = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+        running_.store(true, std::memory_order_release);
+
+        // Worker thread first (it does the initial publish so listeners
+        // get a snapshot even if no message ever pumps).
+        worker_ = std::thread([this]() { run_worker(); });
+        worker_.detach(); // process-lived, mirrors macOS dispatch source
+
+        // Hidden window must be created on a thread that pumps messages.
+        // Plugin hosts already pump on the main thread, so creating the
+        // window from the caller's thread (typically main) is correct.
+        // If the caller isn't the message-pump thread, WM_ACTIVATEAPP
+        // simply won't dispatch — the worker keeps publishing display +
+        // color + memory snapshots regardless.
+        create_message_window();
+    });
+}
+
+} // namespace
+
+void start_environment_observer_win() {
+    g_observer.start();
+}
+
+} // namespace pulp::platform
+
+#endif // _WIN32

--- a/core/platform/src/environment.cpp
+++ b/core/platform/src/environment.cpp
@@ -1,0 +1,120 @@
+#include <pulp/platform/environment.hpp>
+
+#include <utility>
+
+namespace pulp::platform {
+
+// ── Token ──────────────────────────────────────────────────────────────────
+
+Environment::Token::Token(Token&& other) noexcept
+    : id_(other.id_) {
+    other.id_ = 0;
+}
+
+Environment::Token& Environment::Token::operator=(Token&& other) noexcept {
+    if (this != &other) {
+        reset();
+        id_ = other.id_;
+        other.id_ = 0;
+    }
+    return *this;
+}
+
+void Environment::Token::reset() noexcept {
+    if (id_ != 0) {
+        Environment::instance().unsubscribe(id_);
+        id_ = 0;
+    }
+}
+
+// ── Environment ────────────────────────────────────────────────────────────
+
+Environment& Environment::instance() {
+    // Function-local static — initialized on first use, destroyed at
+    // process exit in reverse order of construction. Safe under C++11
+    // magic-statics (Itanium ABI / MSVC 2015+).
+    static Environment env;
+    return env;
+}
+
+EnvironmentState Environment::snapshot() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return state_;
+}
+
+Environment::Token Environment::subscribe(Listener listener) {
+    if (!listener) return Token{};
+    std::lock_guard<std::mutex> lock(mu_);
+    uint64_t id = next_id_++;
+    listeners_.push_back(Entry{id, std::move(listener)});
+    return Token{id};
+}
+
+void Environment::unsubscribe(uint64_t id) {
+    std::lock_guard<std::mutex> lock(mu_);
+    for (auto it = listeners_.begin(); it != listeners_.end(); ++it) {
+        if (it->id == id) {
+            listeners_.erase(it);
+            return;
+        }
+    }
+}
+
+namespace {
+
+EnvironmentChange diff(const EnvironmentState& prev, const EnvironmentState& next) {
+    EnvironmentChange c;
+    const auto& a = prev.display;
+    const auto& b = next.display;
+    c.display = (a.width != b.width) || (a.height != b.height)
+             || (a.physical_width != b.physical_width)
+             || (a.physical_height != b.physical_height)
+             || (a.scale != b.scale) || (a.refresh_hz != b.refresh_hz)
+             || (a.name != b.name);
+    const auto& sa = prev.safe_area;
+    const auto& sb = next.safe_area;
+    c.safe_area = (sa.top != sb.top) || (sa.bottom != sb.bottom)
+               || (sa.left != sb.left) || (sa.right != sb.right);
+    c.keyboard = (prev.keyboard.bottom != next.keyboard.bottom)
+              || (prev.keyboard.animation_duration
+                  != next.keyboard.animation_duration);
+    c.orientation     = (prev.orientation     != next.orientation);
+    c.color_scheme    = (prev.color_scheme    != next.color_scheme);
+    c.lifecycle       = (prev.lifecycle       != next.lifecycle);
+    c.memory_pressure = (prev.memory_pressure != next.memory_pressure);
+    return c;
+}
+
+} // namespace
+
+void Environment::publish(const EnvironmentState& next) {
+    // Compute diff + take snapshot of listeners under the lock, then
+    // invoke listeners outside the lock so a callback that drops a token
+    // (and calls back into unsubscribe) doesn't deadlock.
+    std::vector<Entry> listeners_copy;
+    EnvironmentChange change;
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        change = diff(state_, next);
+        if (!change.any()) return;
+        state_ = next;
+        listeners_copy = listeners_;
+    }
+    for (const auto& entry : listeners_copy) {
+        entry.fn(next, change);
+    }
+}
+
+void Environment::inject_for_test(const EnvironmentState& state) {
+    instance().publish(state);
+}
+
+void Environment::reset_for_test() {
+    auto& env = instance();
+    std::lock_guard<std::mutex> lock(env.mu_);
+    env.state_ = EnvironmentState{};
+    env.listeners_.clear();
+    env.next_id_ = 1;
+}
+
+} // namespace pulp::platform

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -472,6 +472,11 @@ add_executable(pulp-test-permissions test_permissions.cpp)
 target_link_libraries(pulp-test-permissions PRIVATE pulp::platform Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-permissions)
 
+# Environment API tests (#342)
+add_executable(pulp-test-environment test_environment.cpp)
+target_link_libraries(pulp-test-environment PRIVATE pulp::platform Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-environment)
+
 # Runtime tests
 add_executable(pulp-test-runtime test_runtime.cpp)
 target_link_libraries(pulp-test-runtime PRIVATE pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -1,0 +1,194 @@
+// Unit tests for the unified environment API (#342).
+//
+// The Environment singleton is a process-wide notifier; tests reset it
+// in each TEST_CASE so prior tests don't leak listeners or stale state.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/environment.hpp>
+
+#include <atomic>
+
+using namespace pulp::platform;
+
+namespace {
+
+EnvironmentState make_state(ColorScheme scheme,
+                            float scale = 2.0f,
+                            float kbd = 0.0f) {
+    EnvironmentState s;
+    s.display.width = 800;
+    s.display.height = 600;
+    s.display.scale = scale;
+    s.color_scheme = scheme;
+    s.keyboard.bottom = kbd;
+    s.lifecycle = LifecycleState::foreground;
+    s.orientation = Orientation::portrait;
+    return s;
+}
+
+} // namespace
+
+TEST_CASE("Environment: singleton state defaults are sentinel-safe", "[environment]") {
+    Environment::reset_for_test();
+    auto s = Environment::instance().snapshot();
+    REQUIRE(s.color_scheme    == ColorScheme::unknown);
+    REQUIRE(s.lifecycle       == LifecycleState::unknown);
+    REQUIRE(s.orientation     == Orientation::unknown);
+    REQUIRE(s.memory_pressure == MemoryPressure::normal);
+    REQUIRE(s.safe_area.is_zero());
+    REQUIRE(s.keyboard.bottom == 0.0f);
+}
+
+TEST_CASE("Environment: subscribe receives publish + correct change mask",
+          "[environment]") {
+    Environment::reset_for_test();
+    int dark_calls = 0;
+    EnvironmentChange last_change;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            if (s.color_scheme == ColorScheme::dark) ++dark_calls;
+            last_change = c;
+        });
+
+    // First publish — color scheme changes from unknown -> dark, scale
+    // from 1 -> 2, lifecycle from unknown -> foreground, etc. Many flags.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(dark_calls == 1);
+    REQUIRE(last_change.color_scheme);
+    REQUIRE(last_change.lifecycle);
+    REQUIRE(last_change.display);
+
+    // Idempotent publish — no change, no callback.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(dark_calls == 1);
+
+    // Color scheme flip alone — only that bit set.
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(dark_calls == 1);
+    REQUIRE(last_change.color_scheme);
+    REQUIRE_FALSE(last_change.display);
+    REQUIRE_FALSE(last_change.lifecycle);
+}
+
+TEST_CASE("Environment: token RAII unsubscribes", "[environment]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    {
+        auto token = Environment::instance().subscribe(
+            [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+        Environment::inject_for_test(make_state(ColorScheme::dark));
+        REQUIRE(calls == 1);
+    } // token dropped → unsubscribed
+
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: token move transfers ownership", "[environment]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto sub = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(sub.valid());
+
+    auto moved = std::move(sub);
+    REQUIRE(moved.valid());
+    REQUIRE_FALSE(sub.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: keyboard inset change propagates separately",
+          "[environment]") {
+    Environment::reset_for_test();
+    EnvironmentChange last;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange c) { last = c; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark, 2.0f, 0.0f));
+    Environment::inject_for_test(make_state(ColorScheme::dark, 2.0f, 320.0f));
+    REQUIRE(last.keyboard);
+    REQUIRE_FALSE(last.color_scheme);
+    REQUIRE_FALSE(last.display);
+}
+
+TEST_CASE("Environment: safe-area diff detection across all four edges",
+          "[environment]") {
+    Environment::reset_for_test();
+    EnvironmentChange last;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange c) { last = c; });
+
+    auto base = make_state(ColorScheme::dark);
+    Environment::inject_for_test(base);
+
+    auto with_inset = base;
+    with_inset.safe_area.top = 47.0f;
+    Environment::inject_for_test(with_inset);
+    REQUIRE(last.safe_area);
+
+    // Bottom-only change.
+    auto bottom = with_inset;
+    bottom.safe_area.bottom = 34.0f;
+    Environment::inject_for_test(bottom);
+    REQUIRE(last.safe_area);
+    REQUIRE_FALSE(last.color_scheme);
+}
+
+TEST_CASE("Environment: memory pressure transitions", "[environment]") {
+    Environment::reset_for_test();
+    int observed = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            if (c.memory_pressure
+                && s.memory_pressure == MemoryPressure::critical) {
+                ++observed;
+            }
+        });
+
+    auto base = make_state(ColorScheme::dark);
+    Environment::inject_for_test(base);
+
+    auto moderate = base;
+    moderate.memory_pressure = MemoryPressure::moderate;
+    Environment::inject_for_test(moderate);
+    REQUIRE(observed == 0);
+
+    auto critical = base;
+    critical.memory_pressure = MemoryPressure::critical;
+    Environment::inject_for_test(critical);
+    REQUIRE(observed == 1);
+}
+
+TEST_CASE("Environment: callback that drops its own token does not deadlock",
+          "[environment]") {
+    Environment::reset_for_test();
+    std::unique_ptr<Environment::Token> token;
+    token = std::make_unique<Environment::Token>(
+        Environment::instance().subscribe(
+            [&](const EnvironmentState&, EnvironmentChange) {
+                token.reset();  // unsubscribe from inside the callback
+            }));
+
+    // If publish() held the mutex during dispatch, this would deadlock
+    // when the listener calls back into unsubscribe.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    SUCCEED("no deadlock");
+}
+
+TEST_CASE("Environment: snapshot is consistent with last publish",
+          "[environment]") {
+    Environment::reset_for_test();
+    auto s = make_state(ColorScheme::light, 1.5f, 220.0f);
+    s.orientation = Orientation::landscape_left;
+    s.safe_area.top = 22.0f;
+    Environment::inject_for_test(s);
+
+    auto got = Environment::instance().snapshot();
+    REQUIRE(got.color_scheme    == ColorScheme::light);
+    REQUIRE(got.orientation     == Orientation::landscape_left);
+    REQUIRE(got.display.scale   == 1.5f);
+    REQUIRE(got.keyboard.bottom == 220.0f);
+    REQUIRE(got.safe_area.top   == 22.0f);
+}


### PR DESCRIPTION
Stacks on #403 (Environment API). Sibling of #404 (mac), #407 (android), #409 (linux), #410 (ios).

## Summary

Pure-Win32 adapter (no UWP/WinRT) wiring Pulp's unified Environment API on Windows. Mirrors the macOS observer pattern (`PulpEnvironmentObserver`) using a `std::call_once` bootstrap.

### What's populated
- **Display** — `GetSystemMetrics(SM_CXSCREEN/SM_CYSCREEN)` for physical pixels, `GetDpiForSystem` (dynamic-loaded; `GetDeviceCaps(LOGPIXELSX)` fallback for older SDKs) for the scale factor, `EnumDisplayDevicesW(DISPLAY_DEVICE_PRIMARY_DEVICE)` for the monitor/adapter name. CSS-pixel `width`/`height` derived from `physical / scale`.
- **Color scheme** — reads `HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize\AppsUseLightTheme` (REG_DWORD) via `RegOpenKeyExW` + `RegQueryValueExW`. A worker thread waits on `RegNotifyChangeKeyValue()` (with `KEY_NOTIFY`) so light/dark toggles publish promptly without a poll.
- **Lifecycle** — hidden message-only window (`HWND_MESSAGE` parent) registered via `RegisterClassExW` + `CreateWindowExW`. WindowProc translates `WM_ACTIVATEAPP` to `LifecycleState::foreground` (wParam != 0) or `LifecycleState::inactive`. Also handles `WM_DPICHANGED`, `WM_DISPLAYCHANGE`, and `WM_SETTINGCHANGE` (incl. `ImmersiveColorSet` broadcast) to refresh the snapshot.
- **Memory pressure** — `GlobalMemoryStatusEx().dwMemoryLoad` polled on the same worker tick (5 s cadence); >=95 → `critical`, >=80 → `moderate`, else `normal`. Win32 doesn't expose a session-level LMK signal, so polling matches the Linux/proc strategy from #409.

### What stays at defaults (mobile-only)
- `safe_area`, `keyboard`, `orientation` — Windows desktop has no equivalent, so `EnvironmentState` defaults (zero / unknown / zero) are correct per the contract.

### Bootstrap
`void start_environment_observer_win()` is exported, called once via `std::call_once`. Worker thread is detached (process-lived, mirroring macOS's `dispatch_once` observer). The hidden window is created on the caller's thread (typically the host's main thread, which already pumps messages); if the caller isn't the message-pump thread, the worker still publishes display + color + memory snapshots independently.

### Header wiring
Adds `void start_environment_observer_win();` forward decl under `#if defined(_WIN32)` and a `_WIN32` branch in the inline `start_environment_observer()` wrapper. Sibling adapter PRs add their own forward decl + branch — no conflict expected at merge.

### Build wiring
`platform/win/environment_win.cpp` added to the `elseif(WIN32)` block; `target_link_libraries(pulp-platform PRIVATE user32 advapi32)` added for window/message + registry APIs.

## Test plan
- [ ] CI builds `pulp-platform` on Windows (MSVC).
- [ ] Manual smoke on a Windows host: launch standalone, toggle dark mode in Settings -> Personalization, verify a snapshot publish (logged via Environment listener).
- [ ] Manual: Alt+Tab away from the standalone, verify `lifecycle` flips to `inactive` then `foreground` on return.
- [ ] Manual: stress memory (e.g. `testlimit -d`) until `dwMemoryLoad >= 80` to verify the moderate/critical tier reporting.

Local compile-verify was skipped — neither `ssh win` (Intel x64) nor `ssh win2` (ARM64) had a configured MSVC + cmake + git checkout environment. CI Windows runner is the verification gate.