### PR TITLE
ci: concurrency cancel-in-progress on PR workflows (#421)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,6 +16,14 @@ on:
       - 'tools/cmake/PulpAndroid.cmake'
       - 'CMakeLists.txt'
 
+# Cancel superseded PR runs when a new commit lands on the same ref.
+# Main-branch pushes share `refs/heads/main` so consecutive main runs
+# still serialize under the same group — acceptable: Android-on-main
+# is a background signal, not a release gate.
+concurrency:
+  group: android-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   android-build:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,15 @@ on:
         default: ""
         type: string
 
+# Cancel superseded runs when a new commit lands on the same PR.
+# Stops stale build matrix runs (20-30 min each) from eating runner
+# capacity when a PR accumulates fixup commits. workflow_dispatch
+# runs share the same group so a manual retrigger cancels any
+# auto-triggered run in flight.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   resolve-provider:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -36,6 +36,10 @@ on:
         default: ""
         type: string
 
+concurrency:
+  group: docs-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   resolve-provider:
     runs-on: ubuntu-latest

--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: license-audit-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -10,6 +10,14 @@ on:
         description: 'Version tag (e.g., v0.1.0)'
         required: true
 
+# Never cancel an in-flight release. If two tags push back-to-back,
+# serialize rather than cancel — interrupting a binary build halfway
+# through leaves partial artifacts on the runner and can miss
+# publishing the earlier tag's release.
+concurrency:
+  group: release-cli-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-cli:
     strategy:

--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags: ['v*']
 
+# Never cancel in-flight signing/notarization. Partial notarization
+# artifacts are hard to recover; serialize instead.
+concurrency:
+  group: sign-and-release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   BUILD_TYPE: Release
 


### PR DESCRIPTION
Closes #421. Adds per-workflow concurrency groups so new pushes cancel superseded PR runs.

## Change

**Cancellable** (PR-path, safe to kill):
- android.yml, build.yml, docs-check.yml, license-audit.yml — cancel-in-progress: true

**Non-cancellable** (release-path, partial artifacts hard to recover):
- release-cli.yml, sign-and-release.yml — cancel-in-progress: false

**Already had** (no change): auto-release.yml, coverage.yml, docs-deploy.yml, sanitizers.yml, version-skill-check.yml

## Expected impact

Halves runner queue pressure. The #401 cascade saw 8 commits per PR, each retriggering the full ~30-min matrix — stale runs stay queued and eat capacity. Cancel-in-progress means a new push immediately frees the old slots.

No trigger changes. No job-shape changes. Pure workflow YAML add.

## Test plan

- [x] Every workflow lints as valid YAML
- [ ] CI matrix runs on this PR and cancels cleanly if I push a fix-up commit (self-test)