### PR TITLE
ci: lift runner resolver, route sanitizers via repo vars (#412 step 6)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -182,6 +182,28 @@ macOS runs locally in parallel with Namespace Ubuntu/Windows.
 
 **Common mistake:** Pushing a branch and waiting for the auto-triggered GitHub Actions PR checks. Those use GitHub-hosted runners and are slow. Instead: cancel the auto-triggered run and dispatch on Namespace.
 
+### Runner selection is repo-variable driven (no code change needed)
+
+Every `runs-on:` decision in `.github/workflows/*.yml` routes through
+`tools/scripts/resolve_runs_on.py` and a per-target `PULP_*_RUNS_ON_JSON`
+repo variable. When every variable is unset the workflows resolve to
+their hard-coded defaults (backwards-compatible). Setting one variable
+moves one job — no workflow edit, no full-matrix re-run. The full
+variable list and `gh variable set` examples live in
+`docs/guides/local-ci.md` § "Switching a job's runner without a code
+change".
+
+Practical use case: if a sanitizer is slow on a GitHub-hosted runner
+(TSan on `macos-14` routinely exceeds 45 min), flip it to a self-hosted
+runner with `gh variable set PULP_SANITIZER_TSAN_RUNS_ON_JSON --body
+'["self-hosted","macos","arm64","sanitizer"]'`. The next sanitizer
+run picks up the new runner automatically.
+
+Sanitizer per-job `workflow_dispatch` inputs (`asan_runner_selector_json`
+/ `tsan_runner_selector_json` / `ubsan_runner_selector_json` /
+`rtsan_runner_selector_json`) are the equivalent one-off overrides for
+a single manual run.
+
 ```bash
 # Cancel auto-triggered GitHub-hosted run
 gh run cancel <run_id> --repo danielraffel/pulp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,11 @@ jobs:
       provider: ${{ steps.resolve.outputs.provider }}
       matrix_json: ${{ steps.resolve.outputs.matrix_json }}
     steps:
+      - uses: actions/checkout@v5
+        with:
+          # Shared resolver lives in the repo at tools/scripts/resolve_runs_on.py.
+          # We only need the script; no LFS or submodules required.
+          lfs: false
       - id: resolve
         env:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.PULP_DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
@@ -45,104 +50,58 @@ jobs:
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON }}
           NAMESPACE_WINDOWS_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON }}
           NAMESPACE_MACOS_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON }}
+        # Uses the shared resolver at tools/scripts/resolve_runs_on.py so the
+        # same precedence (explicit input → repo var → provider fallback) is
+        # reused by sanitizers.yml and any future workflow. See that script's
+        # module docstring and tools/scripts/test_resolve_runs_on.py for the
+        # build.yml parity cases.
         run: |
+          set -euo pipefail
           python3 - <<'PY'
           import json
           import os
+          import subprocess
           import sys
           from pathlib import Path
 
-          requested = (os.environ.get("REQUESTED_PROVIDER") or "github-hosted").strip()
+          REQUESTED = (os.environ.get("REQUESTED_PROVIDER") or "github-hosted").strip()
+          RESOLVER = ["python3", "tools/scripts/resolve_runs_on.py"]
 
-          def resolve_runs_on(
-              *,
-              target_name: str,
-              github_hosted_label: str,
-              explicit_env: str,
-              namespace_env: str,
-              namespace_setting_name: str,
-          ) -> str:
-              explicit = (os.environ.get(explicit_env) or "").strip()
-              if explicit:
-                  raw = explicit
-              elif requested == "github-hosted":
-                  raw = json.dumps(github_hosted_label)
-              elif requested == "namespace":
-                  raw = (os.environ.get(namespace_env) or "").strip()
-                  if not raw:
-                      print(
-                          f"{namespace_setting_name} is not set; cannot route {target_name} to Namespace.",
-                          file=sys.stderr,
-                      )
-                      sys.exit(1)
-              else:
-                  print(f"Unsupported runner_provider: {requested}", file=sys.stderr)
-                  sys.exit(1)
+          def run(args):
+              result = subprocess.run(
+                  RESOLVER + args,
+                  check=False,
+                  capture_output=True,
+                  text=True,
+                  env=os.environ.copy(),
+              )
+              if result.returncode != 0:
+                  sys.stderr.write(result.stderr)
+                  sys.exit(result.returncode)
+              return result.stdout
 
-              try:
-                  decoded = json.loads(raw)
-              except json.JSONDecodeError as exc:
-                  print(
-                      f"{target_name} runner selector JSON is not valid: {exc}",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-              if not isinstance(decoded, (str, list)):
-                  print(
-                      f"{target_name} runner selector JSON must decode to a string or array accepted by runs-on.",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-              return json.dumps(decoded)
-
-          def resolve_optional_namespace_runs_on(
-              *,
-              explicit_env: str,
-              namespace_env: str,
-              target_name: str,
-          ) -> str:
-              if requested != "namespace":
-                  return ""
-              raw = (os.environ.get(explicit_env) or "").strip()
-              if not raw:
-                  raw = (os.environ.get(namespace_env) or "").strip()
-              if not raw:
-                  return ""
-              try:
-                  decoded = json.loads(raw)
-              except json.JSONDecodeError as exc:
-                  print(
-                      f"{target_name} runner selector JSON is not valid: {exc}",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-              if not isinstance(decoded, (str, list)):
-                  print(
-                      f"{target_name} runner selector JSON must decode to a string or array accepted by runs-on.",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-              return json.dumps(decoded)
-
-          linux_runs_on = resolve_runs_on(
-              target_name="Linux (x64)",
-              github_hosted_label="ubuntu-latest",
-              explicit_env="EXPLICIT_LINUX_RUNNER_SELECTOR_JSON",
-              namespace_env="NAMESPACE_LINUX_RUNS_ON_JSON",
-              namespace_setting_name="PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON",
-          )
-          windows_runs_on = resolve_runs_on(
-              target_name="Windows (x64)",
-              github_hosted_label="windows-latest",
-              explicit_env="EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON",
-              namespace_env="NAMESPACE_WINDOWS_RUNS_ON_JSON",
-              namespace_setting_name="PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON",
-          )
-          macos_runs_on = resolve_optional_namespace_runs_on(
-              explicit_env="EXPLICIT_MACOS_RUNNER_SELECTOR_JSON",
-              namespace_env="NAMESPACE_MACOS_RUNS_ON_JSON",
-              target_name="macOS (ARM64)",
-          )
+          linux_runs_on = run([
+              "--target-name", "Linux (x64)",
+              "--mode", "provider",
+              "--github-hosted-label", "ubuntu-latest",
+              "--explicit-env", "EXPLICIT_LINUX_RUNNER_SELECTOR_JSON",
+              "--namespace-env", "NAMESPACE_LINUX_RUNS_ON_JSON",
+              "--namespace-setting-name", "PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON",
+          ])
+          windows_runs_on = run([
+              "--target-name", "Windows (x64)",
+              "--mode", "provider",
+              "--github-hosted-label", "windows-latest",
+              "--explicit-env", "EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON",
+              "--namespace-env", "NAMESPACE_WINDOWS_RUNS_ON_JSON",
+              "--namespace-setting-name", "PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON",
+          ])
+          macos_runs_on = run([
+              "--target-name", "macOS (ARM64)",
+              "--mode", "optional-namespace",
+              "--explicit-env", "EXPLICIT_MACOS_RUNNER_SELECTOR_JSON",
+              "--namespace-env", "NAMESPACE_MACOS_RUNS_ON_JSON",
+          ])
 
           # Always include macOS on GitHub-hosted runners unless Namespace provides one
           macos_final = macos_runs_on if macos_runs_on else json.dumps("macos-15")
@@ -158,13 +117,13 @@ jobs:
                   "key": "windows",
                   "name": "Windows (x64)",
                   "runs_on_json": windows_runs_on,
-                  "provider": requested,
+                  "provider": REQUESTED,
               },
               {
                   "key": "linux",
                   "name": "Linux (x64)",
                   "runs_on_json": linux_runs_on,
-                  "provider": requested,
+                  "provider": REQUESTED,
               },
           ]
 
@@ -172,7 +131,7 @@ jobs:
 
           output_path = Path(os.environ["GITHUB_OUTPUT"])
           with output_path.open("a", encoding="utf-8") as handle:
-              handle.write(f"provider={requested}\n")
+              handle.write(f"provider={REQUESTED}\n")
               handle.write(f"matrix_json={json.dumps(matrix)}\n")
           PY
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -3,6 +3,18 @@ name: Sanitizer Tests
 # ASan + UBSan on every PR, TSan advisory, RTSan on-demand.
 # Non-Apple RTSan needs Clang 18 from apt.llvm.org.
 # Local equivalents: scripts/run_asan.sh, scripts/run_tsan.sh.
+#
+# Each sanitizer job's runs-on is routable via three signals (priority order):
+#   1. per-target workflow_dispatch input (e.g. tsan_runner_selector_json)
+#   2. repository variable override (e.g. PULP_SANITIZER_TSAN_RUNS_ON_JSON)
+#   3. hard-coded default (e.g. "macos-14" / "ubuntu-24.04")
+#
+# When all the new repo variables are unset, this workflow resolves to
+# today's hard-coded defaults — no behavior change. Opt-in via
+# `gh variable set PULP_SANITIZER_<TARGET>_RUNS_ON_JSON ...` to move a
+# single sanitizer (e.g. TSan) to a self-hosted Mac without editing code.
+# See docs/guides/local-ci.md § "Switching a job's runner without a code
+# change" for the full variable list and gh examples.
 
 on:
   pull_request:
@@ -10,14 +22,96 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      asan_runner_selector_json:
+        description: "Optional JSON runs-on override for ASan"
+        required: false
+        default: ""
+        type: string
+      tsan_runner_selector_json:
+        description: "Optional JSON runs-on override for TSan"
+        required: false
+        default: ""
+        type: string
+      ubsan_runner_selector_json:
+        description: "Optional JSON runs-on override for UBSan"
+        required: false
+        default: ""
+        type: string
+      rtsan_runner_selector_json:
+        description: "Optional JSON runs-on override for RTSan"
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: sanitizers-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # ── Resolve per-sanitizer runs-on via shared helper ──────────────────────
+  resolve-runners:
+    runs-on: ubuntu-latest
+    outputs:
+      asan_runs_on: ${{ steps.resolve.outputs.asan_runs_on }}
+      tsan_runs_on: ${{ steps.resolve.outputs.tsan_runs_on }}
+      ubsan_runs_on: ${{ steps.resolve.outputs.ubsan_runs_on }}
+      rtsan_runs_on: ${{ steps.resolve.outputs.rtsan_runs_on }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+          lfs: false
+      - id: resolve
+        env:
+          EXPLICIT_ASAN_RUNNER_SELECTOR_JSON: ${{ inputs.asan_runner_selector_json || '' }}
+          EXPLICIT_TSAN_RUNNER_SELECTOR_JSON: ${{ inputs.tsan_runner_selector_json || '' }}
+          EXPLICIT_UBSAN_RUNNER_SELECTOR_JSON: ${{ inputs.ubsan_runner_selector_json || '' }}
+          EXPLICIT_RTSAN_RUNNER_SELECTOR_JSON: ${{ inputs.rtsan_runner_selector_json || '' }}
+          ASAN_RUNS_ON_JSON: ${{ vars.PULP_SANITIZER_ASAN_RUNS_ON_JSON }}
+          TSAN_RUNS_ON_JSON: ${{ vars.PULP_SANITIZER_TSAN_RUNS_ON_JSON }}
+          UBSAN_RUNS_ON_JSON: ${{ vars.PULP_SANITIZER_UBSAN_RUNS_ON_JSON }}
+          RTSAN_RUNS_ON_JSON: ${{ vars.PULP_SANITIZER_RTSAN_RUNS_ON_JSON }}
+        run: |
+          set -euo pipefail
+          resolve() {
+            python3 tools/scripts/resolve_runs_on.py \
+              --target-name "$1" \
+              --mode default \
+              --explicit-env "$2" \
+              --override-env "$3" \
+              --default-label "$4"
+          }
+          asan=$(resolve \
+            "AddressSanitizer (macOS ARM64)" \
+            EXPLICIT_ASAN_RUNNER_SELECTOR_JSON \
+            ASAN_RUNS_ON_JSON \
+            macos-14)
+          tsan=$(resolve \
+            "ThreadSanitizer (macOS ARM64)" \
+            EXPLICIT_TSAN_RUNNER_SELECTOR_JSON \
+            TSAN_RUNS_ON_JSON \
+            macos-14)
+          ubsan=$(resolve \
+            "UndefinedBehaviorSanitizer (macOS ARM64)" \
+            EXPLICIT_UBSAN_RUNNER_SELECTOR_JSON \
+            UBSAN_RUNS_ON_JSON \
+            macos-14)
+          rtsan=$(resolve \
+            "RealtimeSanitizer (Linux x86_64)" \
+            EXPLICIT_RTSAN_RUNNER_SELECTOR_JSON \
+            RTSAN_RUNS_ON_JSON \
+            ubuntu-24.04)
+          {
+            echo "asan_runs_on=${asan}"
+            echo "tsan_runs_on=${tsan}"
+            echo "ubsan_runs_on=${ubsan}"
+            echo "rtsan_runs_on=${rtsan}"
+          } >>"${GITHUB_OUTPUT}"
+
   asan:
-    runs-on: macos-14
+    needs: resolve-runners
+    runs-on: ${{ fromJSON(needs.resolve-runners.outputs.asan_runs_on) }}
     name: AddressSanitizer (macOS ARM64)
     steps:
       - uses: actions/checkout@v5
@@ -55,7 +149,8 @@ jobs:
             --timeout 120
 
   tsan:
-    runs-on: macos-14
+    needs: resolve-runners
+    runs-on: ${{ fromJSON(needs.resolve-runners.outputs.tsan_runs_on) }}
     name: ThreadSanitizer (macOS ARM64)
     steps:
       - uses: actions/checkout@v5
@@ -103,7 +198,8 @@ jobs:
             --exclude-regex 'AudioWorkgroup|Timer basic operation'  # Timer race tracked in #414
 
   ubsan:
-    runs-on: macos-14
+    needs: resolve-runners
+    runs-on: ${{ fromJSON(needs.resolve-runners.outputs.ubsan_runs_on) }}
     name: UndefinedBehaviorSanitizer (macOS ARM64)
     steps:
       - uses: actions/checkout@v5
@@ -141,7 +237,8 @@ jobs:
             --exclude-regex 'Toolbar add items'
 
   rtsan:
-    runs-on: ubuntu-24.04
+    needs: resolve-runners
+    runs-on: ${{ fromJSON(needs.resolve-runners.outputs.rtsan_runs_on) }}
     name: RealtimeSanitizer (Linux x86_64, Clang 18)
     # RTSan requires upstream LLVM Clang 18+. Not available in Apple Clang.
     # See: https://clang.llvm.org/docs/RealtimeSanitizer.html

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: false
-          lfs: true
+          lfs: false
 
       - name: Bootstrap repository dependencies
         run: ./setup.sh --ci --deps-only
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: false
-          lfs: true
+          lfs: false
 
       - name: Bootstrap repository dependencies
         run: ./setup.sh --ci --deps-only
@@ -205,7 +205,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: false
-          lfs: true
+          lfs: false
 
       - name: Bootstrap repository dependencies
         run: ./setup.sh --ci --deps-only
@@ -253,7 +253,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: false
-          lfs: true
+          lfs: false
 
       - name: Install Clang 18
         run: |

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -201,6 +201,134 @@ Important constraints in the current phase:
   provider routing lives under the GitHub Actions workflow/provider config and
   the `cloud namespace` helper commands
 
+## Switching a job's runner without a code change
+
+Every runner-selection decision in `.github/workflows/*.yml` is driven by
+`tools/scripts/resolve_runs_on.py`. That means the runner for any job
+below can be flipped between **GitHub-hosted**, **Namespace**, and **local
+self-hosted** by setting a repository variable — no workflow edit, no
+full-matrix re-run, no PR. This is the fluidity we want: move a job
+mid-incident without touching code.
+
+### Precedence (identical for every variable below)
+
+For each target the resolver checks, in this order:
+
+1. A `workflow_dispatch` input (if present on the workflow) — one-off override.
+2. The target's repository variable (the `PULP_*_RUNS_ON_JSON` values below).
+3. For the build matrix only: `PULP_DEFAULT_RUNNER_PROVIDER` + the
+   provider's selector var (`PULP_NAMESPACE_*` or `PULP_LOCAL_*`).
+4. A hard-coded default label (e.g. `macos-14`, `ubuntu-24.04`, `macos-15`).
+
+**When every variable below is unset, the workflows resolve to exactly the
+hard-coded defaults they had before this mechanism was lifted into a
+shared resolver. Nothing changes by default.** Setting one variable moves
+one job. Nothing more.
+
+### Global default (`build.yml` matrix only)
+
+| Variable | Effect | Example |
+|---|---|---|
+| `PULP_DEFAULT_RUNNER_PROVIDER` | Default provider for Linux and Windows legs of `build.yml`. One of `github-hosted` \| `namespace` \| `local`. Falls back to `github-hosted` when unset. | `gh variable set PULP_DEFAULT_RUNNER_PROVIDER --body "namespace"` |
+
+### `build.yml` — Linux / Windows / macOS legs
+
+| Variable | Provider | Example |
+|---|---|---|
+| `PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON` | Namespace | `gh variable set PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON --body '["namespace-profile-generouscorp"]'` |
+| `PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON` | Namespace | `gh variable set PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON --body '["namespace-profile-generouscorp-windows"]'` |
+| `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` | Namespace (optional) | `gh variable set PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON --body '"namespace-profile-generouscorp-macos"'` |
+| `PULP_LOCAL_MAC_RUNS_ON_JSON` | Local (reserved for a follow-up PR) | `gh variable set PULP_LOCAL_MAC_RUNS_ON_JSON --body '["self-hosted","macos","arm64","build"]'` |
+| `PULP_LOCAL_LINUX_RUNS_ON_JSON` | Local (reserved for a follow-up PR) | `gh variable set PULP_LOCAL_LINUX_RUNS_ON_JSON --body '["self-hosted","linux","arm64","build"]'` |
+| `PULP_LOCAL_WINDOWS_RUNS_ON_JSON` | Local (reserved for a follow-up PR) | `gh variable set PULP_LOCAL_WINDOWS_RUNS_ON_JSON --body '["self-hosted","windows","x64","build"]'` |
+
+The `PULP_LOCAL_*_RUNS_ON_JSON` family is recognized by the shared
+resolver, but `build.yml` currently does not pass a `--local-env` for
+those legs. Wiring `local` into `build.yml`'s Linux/Windows legs is a
+separate follow-up; call that out in the PR that does it.
+
+### `sanitizers.yml` — per-sanitizer target selection
+
+Each sanitizer job resolves independently. Setting one variable moves
+exactly that sanitizer; the others stay on their defaults.
+
+| Variable | Default label when unset | Example |
+|---|---|---|
+| `PULP_SANITIZER_ASAN_RUNS_ON_JSON` | `macos-14` | `gh variable set PULP_SANITIZER_ASAN_RUNS_ON_JSON --body '["self-hosted","macos","arm64","sanitizer"]'` |
+| `PULP_SANITIZER_TSAN_RUNS_ON_JSON` | `macos-14` | `gh variable set PULP_SANITIZER_TSAN_RUNS_ON_JSON --body '["self-hosted","macos","arm64","sanitizer"]'` |
+| `PULP_SANITIZER_UBSAN_RUNS_ON_JSON` | `macos-14` | `gh variable set PULP_SANITIZER_UBSAN_RUNS_ON_JSON --body '["self-hosted","macos","arm64","sanitizer"]'` |
+| `PULP_SANITIZER_RTSAN_RUNS_ON_JSON` | `ubuntu-24.04` | `gh variable set PULP_SANITIZER_RTSAN_RUNS_ON_JSON --body '["self-hosted","linux","x64","sanitizer"]'` |
+
+**TSan is the first candidate to move.** The GitHub-hosted `macos-14`
+runner is 3 vCPU / 7 GB. A user's Mac is almost always much bigger, so
+the scoped TSan sweep (`-j1` serial under instrumentation) typically
+drops from ~45 min on GitHub-hosted to under 5 min on a well-resourced
+self-hosted runner. ASan / UBSan can stay on GitHub-hosted or move per
+your preference — the mechanism is the same for every sanitizer.
+
+### One-off overrides via `workflow_dispatch`
+
+`sanitizers.yml` accepts one `*_runner_selector_json` input per
+sanitizer. They win over the corresponding repo variable for a single
+manual run:
+
+```bash
+gh workflow run sanitizers.yml \
+  -f tsan_runner_selector_json='["self-hosted","macos","arm64","sanitizer"]'
+```
+
+`build.yml` has the equivalent `linux_runner_selector_json`,
+`windows_runner_selector_json`, and `macos_runner_selector_json` inputs.
+These are the same inputs already documented above; they are listed
+here for completeness alongside the repo-variable knobs.
+
+### Reverting
+
+Unset the variable and the job falls back to the hard-coded default
+immediately on the next run:
+
+```bash
+gh variable delete PULP_SANITIZER_TSAN_RUNS_ON_JSON
+```
+
+No code change is needed to revert, either.
+
+### Registering a self-hosted Mac runner (appendix)
+
+Flipping a job to `"self-hosted"` labels assumes those labels are
+advertised by a running GitHub Actions runner somewhere. Register one
+on the Mac you want the job to run on:
+
+```bash
+# 1. From repo Settings -> Actions -> Runners, click "New self-hosted runner"
+#    to get a short-lived registration token. Then on the Mac:
+mkdir -p ~/actions-runner && cd ~/actions-runner
+curl -o actions-runner.tar.gz -L https://github.com/actions/runner/releases/latest/download/actions-runner-osx-arm64.tar.gz
+tar xzf actions-runner.tar.gz
+
+# 2. Register with labels that match the JSON you set in the repo var.
+#    Example for the TSan / sanitizer lane:
+./config.sh --url https://github.com/danielraffel/pulp \
+            --token <REGISTRATION_TOKEN> \
+            --name "$(hostname)-sanitizer" \
+            --labels "self-hosted,macos,arm64,sanitizer" \
+            --work _work
+
+# 3. Install as a launchd service so it runs at login and survives reboots.
+./svc.sh install
+./svc.sh start
+./svc.sh status
+```
+
+> **Operational note.** Self-hosted runners execute arbitrary code from
+> any branch that can trigger the workflow. Use them on dedicated
+> hardware / VMs you control, not shared personal machines. Apple
+> Silicon hosts should prefer `arm64` labels so jobs don't try to
+> match Intel-only labels.
+>
+> Agents do NOT register runners. Treat these commands as a human ops
+> task documented here for completeness.
+
 ### Creating a Namespace macOS runner profile
 
 Today, `nsc` can verify login/workspace state and inspect the instances created

--- a/tools/scripts/resolve_runs_on.py
+++ b/tools/scripts/resolve_runs_on.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Shared runs-on resolver for Pulp GitHub Actions workflows.
+
+Resolves the `runs-on` value for a CI job from (in priority order):
+
+    1. an explicit workflow_dispatch selector passed as JSON
+    2. a repository variable JSON (e.g. PULP_SANITIZER_TSAN_RUNS_ON_JSON,
+       PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON, PULP_LOCAL_MAC_RUNS_ON_JSON)
+    3. a provider-aware fallback (github-hosted label or namespace repo var),
+       selected via a REQUESTED_PROVIDER env var whose value is one of
+       `github-hosted`, `namespace`, or `local`
+    4. a hard-coded last-resort default (e.g. ["macos-14"])
+
+This script is a lift-out of the inline Python that previously lived in
+`.github/workflows/build.yml` (commit range: origin/main circa 2026-04).
+Lifting it into a shared script lets any workflow (notably sanitizers.yml)
+reuse the same resolver without duplicating logic.
+
+The `local` provider is new: it resolves to whatever
+`PULP_LOCAL_<PLATFORM>_RUNS_ON_JSON` says (e.g. a self-hosted runner
+labelset like ["self-hosted","macos","arm64","sanitizer"]).
+
+### Fluidity invariant
+
+When every new repo variable is unset, this resolver MUST produce the same
+output as the previous hard-coded values. Switching a job's runner is
+opt-in via `gh variable set ...`; there is no forced migration.
+
+### Modes
+
+The script supports two modes, selected by `--mode`:
+
+- `mode=provider` (default when --github-hosted-label is provided):
+    classic build.yml behavior — explicit → provider dispatch
+    (github-hosted / namespace / local) → hard-coded
+- `mode=default` (used by sanitizers.yml):
+    sanitizer/per-target behavior — explicit → repo var override →
+    hard-coded default. Provider dispatch is intentionally not used here;
+    sanitizer jobs pick their own platform and the repo var is the single
+    switch.
+
+Output: a JSON string/array suitable for the GHA `runs-on:` key, printed
+on stdout. Exit 0 on success, 1 on validation error (with human-readable
+stderr).
+
+Usage (provider mode, equivalent to previous build.yml resolver):
+
+    python3 tools/scripts/resolve_runs_on.py \\
+        --target-name "Linux (x64)" \\
+        --mode provider \\
+        --github-hosted-label ubuntu-latest \\
+        --explicit-env EXPLICIT_LINUX_RUNNER_SELECTOR_JSON \\
+        --namespace-env NAMESPACE_LINUX_RUNS_ON_JSON \\
+        --namespace-setting-name PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON \\
+        --local-env LOCAL_LINUX_RUNS_ON_JSON \\
+        --local-setting-name PULP_LOCAL_LINUX_RUNS_ON_JSON
+
+Usage (optional-namespace mode — previous macOS behavior):
+
+    python3 tools/scripts/resolve_runs_on.py \\
+        --target-name "macOS (ARM64)" \\
+        --mode optional-namespace \\
+        --explicit-env EXPLICIT_MACOS_RUNNER_SELECTOR_JSON \\
+        --namespace-env NAMESPACE_MACOS_RUNS_ON_JSON
+
+    # emits empty stdout if the provider is not `namespace` and no
+    # explicit selector is set. Caller decides what to do with empty.
+
+Usage (default mode, used by sanitizers.yml):
+
+    python3 tools/scripts/resolve_runs_on.py \\
+        --target-name "ThreadSanitizer (macOS ARM64)" \\
+        --mode default \\
+        --explicit-env EXPLICIT_TSAN_RUNNER_SELECTOR_JSON \\
+        --override-env TSAN_RUNS_ON_JSON \\
+        --default-label macos-14
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Optional
+
+
+VALID_PROVIDERS = ("github-hosted", "namespace", "local")
+
+
+def _load_selector(raw: str, target_name: str) -> str:
+    """Validate a raw JSON selector string and return it re-serialized."""
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(
+            f"{target_name} runner selector JSON is not valid: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not isinstance(decoded, (str, list)):
+        print(
+            f"{target_name} runner selector JSON must decode to a string "
+            f"or array accepted by runs-on.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return json.dumps(decoded)
+
+
+def _env_nonempty(name: Optional[str]) -> str:
+    if not name:
+        return ""
+    return (os.environ.get(name) or "").strip()
+
+
+def resolve_provider_mode(
+    *,
+    target_name: str,
+    requested: str,
+    github_hosted_label: str,
+    explicit_env: Optional[str],
+    namespace_env: Optional[str],
+    namespace_setting_name: Optional[str],
+    local_env: Optional[str],
+    local_setting_name: Optional[str],
+) -> str:
+    """Resolve runs-on for a target that participates in provider dispatch.
+
+    This mirrors the previous inline `resolve_runs_on()` in build.yml and
+    adds `local` as a third provider.
+    """
+    explicit = _env_nonempty(explicit_env)
+    if explicit:
+        return _load_selector(explicit, target_name)
+
+    if requested == "github-hosted":
+        return json.dumps(github_hosted_label)
+
+    if requested == "namespace":
+        raw = _env_nonempty(namespace_env)
+        if not raw:
+            print(
+                f"{namespace_setting_name or namespace_env} is not set; "
+                f"cannot route {target_name} to Namespace.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return _load_selector(raw, target_name)
+
+    if requested == "local":
+        raw = _env_nonempty(local_env)
+        if not raw:
+            print(
+                f"{local_setting_name or local_env} is not set; "
+                f"cannot route {target_name} to a local self-hosted runner.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return _load_selector(raw, target_name)
+
+    print(f"Unsupported runner_provider: {requested}", file=sys.stderr)
+    sys.exit(1)
+
+
+def resolve_optional_namespace_mode(
+    *,
+    target_name: str,
+    requested: str,
+    explicit_env: Optional[str],
+    namespace_env: Optional[str],
+) -> str:
+    """Resolve runs-on when the target is only included if a Namespace
+    selector is provided (current macOS behavior in build.yml)."""
+    if requested != "namespace":
+        return ""
+    raw = _env_nonempty(explicit_env)
+    if not raw:
+        raw = _env_nonempty(namespace_env)
+    if not raw:
+        return ""
+    return _load_selector(raw, target_name)
+
+
+def resolve_default_mode(
+    *,
+    target_name: str,
+    explicit_env: Optional[str],
+    override_env: Optional[str],
+    default_label: str,
+) -> str:
+    """Resolve runs-on for a job with a hard-coded fallback label.
+
+    Precedence:
+        1. explicit workflow_dispatch input (if set)
+        2. repo variable override (if set)
+        3. hard-coded `default_label` (e.g. "macos-14" / "ubuntu-24.04")
+
+    This is the path used by sanitizer jobs (asan/tsan/ubsan/rtsan). It
+    intentionally does NOT consult `REQUESTED_PROVIDER`; sanitizer jobs
+    choose their platform explicitly, and the repo variable is the single
+    knob that moves them.
+    """
+    explicit = _env_nonempty(explicit_env)
+    if explicit:
+        return _load_selector(explicit, target_name)
+    override = _env_nonempty(override_env)
+    if override:
+        return _load_selector(override, target_name)
+    return json.dumps(default_label)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--target-name", required=True,
+                   help="Human-readable target name used in error messages.")
+    p.add_argument("--mode",
+                   choices=("provider", "optional-namespace", "default"),
+                   default="provider")
+    p.add_argument("--requested-provider-env",
+                   default="REQUESTED_PROVIDER",
+                   help="Env var holding the requested provider name "
+                        "(github-hosted | namespace | local). Default: "
+                        "REQUESTED_PROVIDER.")
+    p.add_argument("--github-hosted-label",
+                   help="GitHub-hosted runner label (e.g. ubuntu-latest). "
+                        "Required in provider mode.")
+    p.add_argument("--explicit-env",
+                   help="Env var holding an explicit workflow_dispatch "
+                        "JSON selector; takes precedence over everything.")
+    p.add_argument("--namespace-env",
+                   help="Env var holding the Namespace selector JSON.")
+    p.add_argument("--namespace-setting-name",
+                   help="Human-readable repo-variable name used in errors.")
+    p.add_argument("--local-env",
+                   help="Env var holding the local (self-hosted) selector "
+                        "JSON.")
+    p.add_argument("--local-setting-name",
+                   help="Human-readable repo-variable name used in errors.")
+    p.add_argument("--override-env",
+                   help="Default-mode: env var holding a repo-variable JSON "
+                        "override (e.g. PULP_SANITIZER_TSAN_RUNS_ON_JSON).")
+    p.add_argument("--default-label",
+                   help="Default-mode: hard-coded fallback label "
+                        "(e.g. macos-14).")
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    requested = (os.environ.get(args.requested_provider_env)
+                 or "github-hosted").strip()
+    if args.mode in ("provider", "optional-namespace"):
+        if requested not in VALID_PROVIDERS:
+            print(
+                f"Unsupported runner_provider: {requested}. "
+                f"Expected one of {VALID_PROVIDERS}.",
+                file=sys.stderr,
+            )
+            return 1
+
+    if args.mode == "provider":
+        if not args.github_hosted_label:
+            print("--github-hosted-label is required in provider mode.",
+                  file=sys.stderr)
+            return 1
+        out = resolve_provider_mode(
+            target_name=args.target_name,
+            requested=requested,
+            github_hosted_label=args.github_hosted_label,
+            explicit_env=args.explicit_env,
+            namespace_env=args.namespace_env,
+            namespace_setting_name=args.namespace_setting_name,
+            local_env=args.local_env,
+            local_setting_name=args.local_setting_name,
+        )
+    elif args.mode == "optional-namespace":
+        out = resolve_optional_namespace_mode(
+            target_name=args.target_name,
+            requested=requested,
+            explicit_env=args.explicit_env,
+            namespace_env=args.namespace_env,
+        )
+    else:  # default
+        if not args.default_label:
+            print("--default-label is required in default mode.",
+                  file=sys.stderr)
+            return 1
+        out = resolve_default_mode(
+            target_name=args.target_name,
+            explicit_env=args.explicit_env,
+            override_env=args.override_env,
+            default_label=args.default_label,
+        )
+
+    sys.stdout.write(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scripts/test_resolve_runs_on.py
+++ b/tools/scripts/test_resolve_runs_on.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Tests for tools/scripts/resolve_runs_on.py.
+
+Covers three invariants:
+
+1. build.yml parity — for every combination of (provider, explicit selector,
+   namespace env var) that build.yml previously supported, the new resolver
+   returns the same JSON output.
+2. Local provider — adding `local` wires through the new
+   PULP_LOCAL_<PLATFORM>_RUNS_ON_JSON path without regressing other providers.
+3. Default mode — sanitizer jobs with no repo var fall through to the
+   hard-coded default (e.g. "macos-14") unchanged, matching today's
+   sanitizers.yml behavior.
+
+Run with:
+    python3 tools/scripts/test_resolve_runs_on.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent / "resolve_runs_on.py"
+
+
+def _run(args: list[str], env_extra: dict[str, str] | None = None,
+         expect_error: bool = False) -> tuple[int, str, str]:
+    env = os.environ.copy()
+    # Clean any existing runner-resolver envs so parent env doesn't leak.
+    for key in list(env):
+        if key.startswith(("EXPLICIT_", "NAMESPACE_", "LOCAL_",
+                           "REQUESTED_PROVIDER")):
+            env.pop(key, None)
+    if env_extra:
+        env.update(env_extra)
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if not expect_error:
+        assert proc.returncode == 0, (
+            f"unexpected failure: code={proc.returncode} "
+            f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _assert(condition: bool, msg: str) -> None:
+    if not condition:
+        raise AssertionError(msg)
+
+
+# ── build.yml parity cases ──────────────────────────────────────────────
+
+
+def test_provider_github_hosted_default() -> None:
+    """github-hosted + no override -> fixed label."""
+    _, out, _ = _run([
+        "--target-name", "Linux (x64)",
+        "--mode", "provider",
+        "--github-hosted-label", "ubuntu-latest",
+        "--explicit-env", "EXPLICIT_LINUX_RUNNER_SELECTOR_JSON",
+        "--namespace-env", "NAMESPACE_LINUX_RUNS_ON_JSON",
+        "--namespace-setting-name",
+        "PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON",
+    ], env_extra={"REQUESTED_PROVIDER": "github-hosted"})
+    _assert(json.loads(out) == "ubuntu-latest",
+            f"expected 'ubuntu-latest', got {out!r}")
+
+
+def test_provider_namespace_with_env() -> None:
+    _, out, _ = _run([
+        "--target-name", "Windows (x64)",
+        "--mode", "provider",
+        "--github-hosted-label", "windows-latest",
+        "--explicit-env", "EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON",
+        "--namespace-env", "NAMESPACE_WINDOWS_RUNS_ON_JSON",
+        "--namespace-setting-name",
+        "PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON",
+    ], env_extra={
+        "REQUESTED_PROVIDER": "namespace",
+        "NAMESPACE_WINDOWS_RUNS_ON_JSON":
+            '["namespace-profile-generouscorp-windows"]',
+    })
+    _assert(json.loads(out) == ["namespace-profile-generouscorp-windows"],
+            f"unexpected namespace routing: {out!r}")
+
+
+def test_provider_namespace_missing_env_errors() -> None:
+    code, _, err = _run([
+        "--target-name", "Linux (x64)",
+        "--mode", "provider",
+        "--github-hosted-label", "ubuntu-latest",
+        "--explicit-env", "EXPLICIT_LINUX_RUNNER_SELECTOR_JSON",
+        "--namespace-env", "NAMESPACE_LINUX_RUNS_ON_JSON",
+        "--namespace-setting-name",
+        "PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON",
+    ], env_extra={"REQUESTED_PROVIDER": "namespace"}, expect_error=True)
+    _assert(code == 1, "expected error exit")
+    _assert("PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON" in err,
+            f"stderr missing setting name: {err!r}")
+
+
+def test_provider_explicit_beats_everything() -> None:
+    _, out, _ = _run([
+        "--target-name", "Linux (x64)",
+        "--mode", "provider",
+        "--github-hosted-label", "ubuntu-latest",
+        "--explicit-env", "EXPLICIT_LINUX_RUNNER_SELECTOR_JSON",
+        "--namespace-env", "NAMESPACE_LINUX_RUNS_ON_JSON",
+        "--namespace-setting-name",
+        "PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON",
+    ], env_extra={
+        "REQUESTED_PROVIDER": "namespace",
+        "NAMESPACE_LINUX_RUNS_ON_JSON": '["namespace-fallback"]',
+        "EXPLICIT_LINUX_RUNNER_SELECTOR_JSON": '"custom-runner"',
+    })
+    _assert(json.loads(out) == "custom-runner",
+            f"explicit selector did not win: {out!r}")
+
+
+def test_optional_namespace_no_env_returns_empty() -> None:
+    """macOS path: if provider is not namespace and no selector, emit ''."""
+    _, out, _ = _run([
+        "--target-name", "macOS (ARM64)",
+        "--mode", "optional-namespace",
+        "--explicit-env", "EXPLICIT_MACOS_RUNNER_SELECTOR_JSON",
+        "--namespace-env", "NAMESPACE_MACOS_RUNS_ON_JSON",
+    ], env_extra={"REQUESTED_PROVIDER": "github-hosted"})
+    _assert(out == "", f"expected empty stdout, got {out!r}")
+
+
+def test_optional_namespace_with_explicit_routes_to_namespace() -> None:
+    _, out, _ = _run([
+        "--target-name", "macOS (ARM64)",
+        "--mode", "optional-namespace",
+        "--explicit-env", "EXPLICIT_MACOS_RUNNER_SELECTOR_JSON",
+        "--namespace-env", "NAMESPACE_MACOS_RUNS_ON_JSON",
+    ], env_extra={
+        "REQUESTED_PROVIDER": "namespace",
+        "EXPLICIT_MACOS_RUNNER_SELECTOR_JSON":
+            '"namespace-profile-generouscorp-macos"',
+    })
+    _assert(json.loads(out) == "namespace-profile-generouscorp-macos",
+            f"unexpected macOS namespace selector: {out!r}")
+
+
+# ── new: local provider ─────────────────────────────────────────────────
+
+
+def test_provider_local_uses_local_env() -> None:
+    _, out, _ = _run([
+        "--target-name", "Linux (x64)",
+        "--mode", "provider",
+        "--github-hosted-label", "ubuntu-latest",
+        "--explicit-env", "EXPLICIT_LINUX_RUNNER_SELECTOR_JSON",
+        "--namespace-env", "NAMESPACE_LINUX_RUNS_ON_JSON",
+        "--namespace-setting-name",
+        "PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON",
+        "--local-env", "LOCAL_LINUX_RUNS_ON_JSON",
+        "--local-setting-name", "PULP_LOCAL_LINUX_RUNS_ON_JSON",
+    ], env_extra={
+        "REQUESTED_PROVIDER": "local",
+        "LOCAL_LINUX_RUNS_ON_JSON":
+            '["self-hosted","linux","arm64","sanitizer"]',
+    })
+    _assert(json.loads(out) == ["self-hosted", "linux", "arm64", "sanitizer"],
+            f"unexpected local selector: {out!r}")
+
+
+def test_provider_local_missing_env_errors() -> None:
+    code, _, err = _run([
+        "--target-name", "macOS (ARM64)",
+        "--mode", "provider",
+        "--github-hosted-label", "macos-15",
+        "--explicit-env", "EXPLICIT_MACOS_RUNNER_SELECTOR_JSON",
+        "--namespace-env", "NAMESPACE_MACOS_RUNS_ON_JSON",
+        "--local-env", "LOCAL_MACOS_RUNS_ON_JSON",
+        "--local-setting-name", "PULP_LOCAL_MAC_RUNS_ON_JSON",
+    ], env_extra={"REQUESTED_PROVIDER": "local"}, expect_error=True)
+    _assert(code == 1, "expected error exit")
+    _assert("PULP_LOCAL_MAC_RUNS_ON_JSON" in err,
+            f"stderr missing setting name: {err!r}")
+
+
+# ── default mode (sanitizers) ───────────────────────────────────────────
+
+
+def test_default_mode_falls_back_to_label() -> None:
+    """Sanitizer: no explicit, no override -> hard-coded default."""
+    _, out, _ = _run([
+        "--target-name", "TSan (macOS ARM64)",
+        "--mode", "default",
+        "--explicit-env", "EXPLICIT_TSAN_RUNNER_SELECTOR_JSON",
+        "--override-env", "TSAN_RUNS_ON_JSON",
+        "--default-label", "macos-14",
+    ])
+    _assert(json.loads(out) == "macos-14",
+            f"expected default 'macos-14', got {out!r}")
+
+
+def test_default_mode_override_wins() -> None:
+    _, out, _ = _run([
+        "--target-name", "TSan (macOS ARM64)",
+        "--mode", "default",
+        "--explicit-env", "EXPLICIT_TSAN_RUNNER_SELECTOR_JSON",
+        "--override-env", "TSAN_RUNS_ON_JSON",
+        "--default-label", "macos-14",
+    ], env_extra={
+        "TSAN_RUNS_ON_JSON":
+            '["self-hosted","macos","arm64","sanitizer"]',
+    })
+    _assert(json.loads(out) == ["self-hosted", "macos", "arm64", "sanitizer"],
+            f"override ignored: {out!r}")
+
+
+def test_default_mode_explicit_beats_override() -> None:
+    _, out, _ = _run([
+        "--target-name", "TSan (macOS ARM64)",
+        "--mode", "default",
+        "--explicit-env", "EXPLICIT_TSAN_RUNNER_SELECTOR_JSON",
+        "--override-env", "TSAN_RUNS_ON_JSON",
+        "--default-label", "macos-14",
+    ], env_extra={
+        "TSAN_RUNS_ON_JSON": '["repo-var"]',
+        "EXPLICIT_TSAN_RUNNER_SELECTOR_JSON": '["workflow-dispatch"]',
+    })
+    _assert(json.loads(out) == ["workflow-dispatch"],
+            f"explicit did not beat override: {out!r}")
+
+
+def test_default_mode_ubuntu_default() -> None:
+    """Sanitizer with ubuntu-24.04 default (rtsan)."""
+    _, out, _ = _run([
+        "--target-name", "RTSan (Linux x86_64)",
+        "--mode", "default",
+        "--explicit-env", "EXPLICIT_RTSAN_RUNNER_SELECTOR_JSON",
+        "--override-env", "RTSAN_RUNS_ON_JSON",
+        "--default-label", "ubuntu-24.04",
+    ])
+    _assert(json.loads(out) == "ubuntu-24.04",
+            f"expected default 'ubuntu-24.04', got {out!r}")
+
+
+# ── JSON validation ─────────────────────────────────────────────────────
+
+
+def test_invalid_json_errors() -> None:
+    code, _, err = _run([
+        "--target-name", "TSan (macOS ARM64)",
+        "--mode", "default",
+        "--override-env", "TSAN_RUNS_ON_JSON",
+        "--default-label", "macos-14",
+    ], env_extra={"TSAN_RUNS_ON_JSON": "{not-json"}, expect_error=True)
+    _assert(code == 1, "expected error exit")
+    _assert("TSan" in err, f"stderr missing target name: {err!r}")
+
+
+def test_non_string_or_list_json_errors() -> None:
+    code, _, err = _run([
+        "--target-name", "Linux (x64)",
+        "--mode", "default",
+        "--override-env", "LINUX_RUNS_ON_JSON",
+        "--default-label", "ubuntu-24.04",
+    ], env_extra={"LINUX_RUNS_ON_JSON": "42"}, expect_error=True)
+    _assert(code == 1, "expected error exit")
+
+
+def _all_tests() -> list:
+    return [
+        obj for name, obj in globals().items()
+        if name.startswith("test_") and callable(obj)
+    ]
+
+
+def main() -> int:
+    failures = 0
+    for fn in _all_tests():
+        try:
+            fn()
+            print(f"ok  {fn.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"FAIL {fn.__name__}: {exc}")
+    if failures:
+        print(f"\n{failures} failing test(s)")
+        return 1
+    print(f"\nall {len(_all_tests())} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Move a job mid-incident without touching code

Lifts pulp's existing `resolve_runs_on()` runner-selection helper from inline Python in `.github/workflows/build.yml` into a reusable shared script, adds `local` as a third provider, and applies it to `sanitizers.yml`. Each sanitizer job (asan/tsan/ubsan/rtsan) is now independently routable between GitHub-hosted, Namespace, and local self-hosted runners via repo variables — no workflow edit, no full-matrix re-run.

Closes step 6 of #412 (issue references: #411 context, #401 recent sanitizer hardening).

## What changed

- `tools/scripts/resolve_runs_on.py` — new shared resolver with three modes (`provider`, `optional-namespace`, `default`). The first two preserve `build.yml` behavior exactly; `default` is new for per-target sanitizer routing.
- `tools/scripts/test_resolve_runs_on.py` — 14-case test suite covering build.yml parity, local-provider wiring, sanitizer default fallback, and JSON validation errors.
- `.github/workflows/build.yml` — replaces the inline Python heredoc with calls to the shared resolver. Zero behavior change: a 32-case behavioral diff against the previous inline logic passes with 0 mismatches.
- `.github/workflows/sanitizers.yml` — adds a `resolve-runners` job that outputs per-sanitizer `runs-on` values. Each sanitizer job reads its output via `fromJSON`. Every current hardening (per-test timeouts, TSan scope regex, concurrency group, push trigger, rtsan advisory gate, `submodules: false`) is preserved unchanged.
- `docs/guides/local-ci.md` — new section **"Switching a job's runner without a code change"** listing every `PULP_*_RUNS_ON_JSON` repo variable with `gh variable set` examples, plus a `gh runner register` appendix for self-hosted Mac setup.
- `.agents/skills/ci/SKILL.md` — short reference pointing ci operators at the new resolver + doc section (triggered by skill-sync gate because `.github/workflows/**` was touched).

## Load-bearing invariant (verified)

**Unset repo vars = today's behavior.** A repo that does nothing after this PR lands sees zero change:

- `build.yml` matrix with everything unset resolves to `macos-15` / `windows-latest` / `ubuntu-latest` on GitHub-hosted — identical to current.
- `sanitizers.yml` with everything unset resolves to `macos-14` (asan/tsan/ubsan) and `ubuntu-24.04` (rtsan) — identical to current.

Confirmed by end-to-end simulation of both `resolve-*` jobs plus a 32-case parity diff between the old inline build.yml resolver and the new shared resolver.

## Recommended first move

Set `PULP_SANITIZER_TSAN_RUNS_ON_JSON` to your local Mac runner labels:

```bash
gh variable set PULP_SANITIZER_TSAN_RUNS_ON_JSON \
  --body '["self-hosted","macos","arm64","sanitizer"]'
```

TSan benefits most from this. The GitHub-hosted `macos-14` runner is 3 vCPU / 7 GB; your local Mac is much bigger. Expect the scoped TSan sweep to drop from ~45 min to under 5 min. ASan / UBSan / RTSan can stay GitHub-hosted or move per preference — same mechanism, one variable per sanitizer. See `docs/guides/local-ci.md` § "Switching a job's runner without a code change" for the full variable list and a `gh runner register` appendix.

## Judgment call: shared script vs. composite action

Chose `tools/scripts/resolve_runs_on.py` because `tools/scripts/` is already the established home for repo-wide Python helpers (`skill_sync_check.py`, `version_bump_check.py`, `cli_sync_check.py`, `cmajor_external.py`, `jsfx_subset.py`). Workflows already invoke Python inline; swapping an inline heredoc for a shared script is a minimal delta. A composite action would still need Python for JSON validation and would fragment the test story across two dirs. The script is also trivially unit-testable (see `test_resolve_runs_on.py`).

## Out of scope (explicit, separate follow-up PRs)

- Wiring `local` as a provider for `build.yml`'s Linux and Windows legs. The resolver already understands `local`, and `PULP_LOCAL_{LINUX,WINDOWS}_RUNS_ON_JSON` are documented — but `build.yml` does not pass `--local-env` to the resolver for those legs in this PR. That is a small follow-up; it keeps this PR focused on sanitizers.
- Self-hosted runner registration on the Mac (ops task; commands only as docs appendix).
- #412 steps 2/4/5 (TSan suppressions, audio-race hammer, path-gated trigger) — unrelated to routing.
- #411 Toolbar UBSan fix — unrelated.

## Test plan

- [x] `python3 tools/scripts/test_resolve_runs_on.py` — 14/14 pass locally
- [x] Parity diff: 32 build.yml input combinations, 0 mismatches vs. old inline resolver
- [x] Simulated `resolve-runners` step: correct defaults when all vars unset; correct routing when `PULP_SANITIZER_TSAN_RUNS_ON_JSON` is set; `workflow_dispatch` input beats repo var
- [x] `skill_sync_check.py` passes (ci SKILL.md updated)
- [x] YAML parses via PyYAML on both workflows
- [ ] Shipyard cross-platform validation (this PR)