### PR TITLE
ci: retry transient git ops + capture Android diagnostic on failure (#418)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -60,6 +60,9 @@ jobs:
         shell: bash
         run: |
           APK=android/app/build/outputs/apk/debug/app-debug.apk
+          echo "--- APK full contents ---"
+          unzip -l "$APK" || echo "(APK unreadable)"
+          echo "---"
           if unzip -l "$APK" | grep -q "libpulp.so"; then
             echo "✅ libpulp.so found in APK"
             unzip -l "$APK" | grep "\.so"
@@ -67,6 +70,26 @@ jobs:
             echo "❌ libpulp.so NOT found in APK"
             exit 1
           fi
+
+      # Always upload APK + Gradle/NDK logs so a failed "Verify APK"
+      # step (historically flaky on windows-latest — #403, #418) can
+      # be diagnosed from artifacts instead of requiring a close/reopen
+      # retry cycle. The `if: always()` ensures this runs even when the
+      # verify step above fails.
+      - name: Upload APK + build logs (diagnostic)
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: pulp-android-${{ matrix.os }}-diag
+          path: |
+            android/app/build/outputs/apk/debug/app-debug.apk
+            android/app/build/outputs/logs/**
+            android/app/.cxx/**/build.ninja
+            android/app/.cxx/**/CMakeCache.txt
+            android/app/.cxx/**/CMakeFiles/CMakeOutput.log
+            android/app/.cxx/**/CMakeFiles/CMakeError.log
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v5

--- a/setup.sh
+++ b/setup.sh
@@ -309,6 +309,31 @@ ensure_shared_archive_source() {
     )
 }
 
+# Retry a git network command up to 3 times with exponential backoff.
+# GitHub occasionally returns 5xx on git-over-https; without retry any
+# transient outage fails the whole CI job. Applies to clone/fetch/
+# submodule-update (the VST3 SDK in particular has five sub-submodules,
+# any of which failing aborts the lot). See #418.
+retry_git() {
+    local label="$1"
+    shift
+    local attempts=3
+    local sleep_s=5
+    local i
+    for i in $(seq 1 $attempts); do
+        if "$@"; then
+            return 0
+        fi
+        if [ "$i" -lt "$attempts" ]; then
+            info "$label git attempt $i/$attempts failed; retrying in ${sleep_s}s..."
+            sleep "$sleep_s"
+            sleep_s=$((sleep_s * 2))
+        fi
+    done
+    warn "$label git command failed after $attempts attempts"
+    return 1
+}
+
 ensure_shared_git_source() {
     local label="$1"
     local repo="$2"
@@ -351,9 +376,9 @@ ensure_shared_git_source() {
                     fi
                 fi
             elif ! dry "git clone --filter=blob:none $repo $target"; then
-                if ! git clone --filter=blob:none "$repo" "$target" >/dev/null 2>&1; then
-                    git clone "$repo" "$target"
-                fi
+                # Network clone: retry to tolerate transient GitHub blips.
+                retry_git "$label clone" \
+                    git clone --filter=blob:none "$repo" "$target"
             fi
 
             current_remote="$(git -C "$target" remote get-url origin 2>/dev/null || true)"
@@ -365,12 +390,14 @@ ensure_shared_git_source() {
 
         if ! git -C "$target" cat-file -e "${ref}^{commit}" 2>/dev/null; then
             info "Updating shared $label source cache to include $ref..."
-            dry "git -C $target fetch --tags origin" || git -C "$target" fetch --tags origin
+            dry "git -C $target fetch --tags origin" || \
+                retry_git "$label fetch --tags" git -C "$target" fetch --tags origin
         fi
 
         if ! git -C "$target" cat-file -e "${ref}^{commit}" 2>/dev/null; then
             info "Fetching explicit shared $label ref $ref..."
-            dry "git -C $target fetch --force origin $ref" || git -C "$target" fetch --force origin "$ref"
+            dry "git -C $target fetch --force origin $ref" || \
+                retry_git "$label fetch $ref" git -C "$target" fetch --force origin "$ref"
             checkout_ref="FETCH_HEAD"
         fi
 
@@ -381,8 +408,12 @@ ensure_shared_git_source() {
         fi
 
         if [ -f "$target/.gitmodules" ]; then
+            # submodule update fetches over the network per sub-submodule
+            # (e.g. VST3 SDK has 5 sub-submodules). Retry the whole thing
+            # so one transient failure doesn't cost a full CI cycle (#402).
             dry "git -c protocol.file.allow=always -C $target submodule update --init --recursive" || \
-                git -c protocol.file.allow=always -C "$target" submodule update --init --recursive
+                retry_git "$label submodule update" \
+                    git -c protocol.file.allow=always -C "$target" submodule update --init --recursive
         fi
     )
 }


### PR DESCRIPTION
Addresses #418 (two of three subfixes — third turned out agent-side, not CI).

## 1. setup.sh — retry transient git operations

`retry_git()` wrapper around clone / fetch / submodule update in `ensure_shared_git_source()`. 3 attempts, exponential backoff (5/10/20s).

**Why:** PR #402's ASan run failed because VST3 SDK has 5 sub-submodules and any transient GitHub blip aborted the lot. The close/reopen fix-up cycle cost ~30 min. One-line retry self-heals.

## 2. android.yml — diagnostic artifacts on failure

New `if: always()` step uploads APK + Gradle logs + .cxx CMake output/error logs before the normal APK artifact step. Verify step also dumps the full APK contents to the job log before grepping.

**Why:** PR #403's windows-latest android build reported 'libpulp.so NOT found' with zero context. Root cause (NDK compile? CMake fetch? Gradle packaging?) was opaque. Retry papered over it. Next failure now leaves diagnostics in artifacts.

## Dropped: subfix 3 (gh api retry)

The `gh api` / `gh pr` timeouts I kept hitting today were interactive from my terminal, not in CI workflows. No CI script calls gh api. Agent-side retry (or a shell alias) handles that — out of scope for pulp.

## Test plan

- [x] `bash -n setup.sh` syntax-clean
- [x] workflow YAML lints
- [ ] Next setup.sh failure retries cleanly (will verify in first re-run that hits a transient)
- [ ] Next android Windows failure leaves useful logs in artifacts