### PR TITLE
fix(view): rename app_framework Toolbar → NativeToolbar to remove ODR violation (#411)

### DIFF
--- a/core/view/include/pulp/view/app_framework.hpp
+++ b/core/view/include/pulp/view/app_framework.hpp
@@ -139,14 +139,20 @@ private:
     std::vector<Menu> menus_;
 };
 
-// ── Toolbar ──────────────────────────────────────────────────────────────
+// ── NativeToolbar ────────────────────────────────────────────────────────
 
-/// Cross-platform toolbar abstraction.
+/// Native-toolbar descriptor — a lightweight config struct for host-level
+/// toolbars (macOS NSToolbar, Windows/Linux custom native). Separate from
+/// pulp::view::Toolbar (core/view/include/pulp/view/toolbar.hpp), which is
+/// a full View subclass with custom paint/hit-testing. Previously both
+/// types were named `Toolbar` in the same namespace — an ODR violation
+/// that UBSan caught on macos-arm64 (test #460 BUS, issue #411).
 ///
-/// On macOS, creates a native NSToolbar. On Windows/Linux, renders custom.
-class Toolbar {
+/// On macOS, `install_native()` builds an NSToolbar from these items.
+/// On Windows/Linux the view-layer pulp::view::Toolbar is used instead.
+class NativeToolbar {
 public:
-    struct ToolbarItem {
+    struct Item {
         std::string id;
         std::string label;
         std::string icon_name;     ///< SF Symbol name (macOS) or icon path
@@ -154,16 +160,16 @@ public:
         bool is_separator = false;
     };
 
-    void add_item(ToolbarItem item);
+    void add_item(Item item);
     void add_separator();
 
     /// Install as native toolbar (macOS: NSToolbar on the window).
     void install_native(void* native_window);
 
-    const std::vector<ToolbarItem>& items() const { return items_; }
+    const std::vector<Item>& items() const { return items_; }
 
 private:
-    std::vector<ToolbarItem> items_;
+    std::vector<Item> items_;
 };
 
 // ── AppSettings ──────────────────────────────────────────────────────────

--- a/core/view/src/app_framework.cpp
+++ b/core/view/src/app_framework.cpp
@@ -171,17 +171,17 @@ void MenuBar::install_native() {
     // Platform-specific: implemented in platform/mac/menu_bar_mac.mm etc.
 }
 
-// ── Toolbar ──────────────────────────────────────────────────────────────
+// ── NativeToolbar ────────────────────────────────────────────────────────
 
-void Toolbar::add_item(ToolbarItem item) {
+void NativeToolbar::add_item(Item item) {
     items_.push_back(std::move(item));
 }
 
-void Toolbar::add_separator() {
+void NativeToolbar::add_separator() {
     items_.push_back({"", "", "", {}, true});
 }
 
-void Toolbar::install_native(void*) {
+void NativeToolbar::install_native(void*) {
     // Platform-specific: implemented in platform/mac/toolbar_mac.mm etc.
 }
 

--- a/core/view/src/toolbar.cpp
+++ b/core/view/src/toolbar.cpp
@@ -22,7 +22,11 @@ void Toolbar::add_toggle(std::string id, std::string label, std::function<void(b
     items_.push_back(std::move(item));
 }
 
-// add_separator() is defined in app_framework.cpp
+void Toolbar::add_separator() {
+    ToolbarItem item;
+    item.type = ToolbarItemType::Separator;
+    items_.push_back(std::move(item));
+}
 
 void Toolbar::add_spacer() {
     ToolbarItem item;

--- a/test/test_app_framework.cpp
+++ b/test/test_app_framework.cpp
@@ -153,10 +153,10 @@ TEST_CASE("MenuBar set_key_mapping populates from commands", "[view][menu]") {
     REQUIRE(menu.menus().size() == 2);
 }
 
-// ── Toolbar ──────────────────────────────────────────────────────────────
+// ── NativeToolbar ────────────────────────────────────────────────────────
 
-TEST_CASE("Toolbar add items and separator", "[view][toolbar]") {
-    Toolbar tb;
+TEST_CASE("NativeToolbar add items and separator", "[view][toolbar]") {
+    NativeToolbar tb;
     tb.add_item({"play", "Play", "play.fill", [] {}});
     tb.add_separator();
     tb.add_item({"stop", "Stop", "stop.fill", [] {}});

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -73,7 +73,7 @@ TEST_CASE("TableListBox column management", "[gui][table]") {
 
 // ── Toolbar ─────────────────────────────────────────────────────────────
 
-TEST_CASE("Toolbar add items", "[gui][toolbar][!mayfail][!mayfail]") {
+TEST_CASE("Toolbar add items", "[gui][toolbar]") {
     Toolbar toolbar;
     REQUIRE(toolbar.item_count() == 0);
 
@@ -85,7 +85,7 @@ TEST_CASE("Toolbar add items", "[gui][toolbar][!mayfail][!mayfail]") {
     REQUIRE(toolbar.item_count() == 4);
 }
 
-TEST_CASE("Toolbar toggle state", "[gui][toolbar][!mayfail]") {
+TEST_CASE("Toolbar toggle state", "[gui][toolbar]") {
     Toolbar toolbar;
     toolbar.add_toggle("mute", "Mute", [](bool) {});
 
@@ -94,7 +94,7 @@ TEST_CASE("Toolbar toggle state", "[gui][toolbar][!mayfail]") {
     REQUIRE(toolbar.is_toggled("mute"));
 }
 
-TEST_CASE("Toolbar enable/disable", "[gui][toolbar][!mayfail]") {
+TEST_CASE("Toolbar enable/disable", "[gui][toolbar]") {
     Toolbar toolbar;
     bool clicked = false;
     toolbar.add_button("save", "Save", [&]() { clicked = true; });
@@ -103,7 +103,7 @@ TEST_CASE("Toolbar enable/disable", "[gui][toolbar][!mayfail]") {
     // Disabled items shouldn't trigger (tested via on_mouse_down in real usage)
 }
 
-TEST_CASE("Toolbar remove item", "[gui][toolbar][!mayfail]") {
+TEST_CASE("Toolbar remove item", "[gui][toolbar]") {
     Toolbar toolbar;
     toolbar.add_button("a", "A", []() {});
     toolbar.add_button("b", "B", []() {});


### PR DESCRIPTION
Closes #411. Real root cause is an **ODR violation**, not a libc++ alignment issue.

## Two classes, same name, same namespace

- `core/view/include/pulp/view/app_framework.hpp:147` — `class Toolbar` (descriptor for native NSToolbar)
- `core/view/include/pulp/view/toolbar.hpp:37` — `class Toolbar : public View` (full view subclass)

Both in `pulp::view`. Different layouts. No translation unit included both headers, so each compiled cleanly, but the linker picked ONE `Toolbar::add_separator()` definition (the one in `app_framework.cpp`) and applied it to both types. Calls through toolbar.hpp's `Toolbar` reached app_framework.cpp's add_separator which wrote an app_framework-layout `ToolbarItem` into a `vector<toolbar.hpp ToolbarItem>`. Layout mismatch → vector reallocation's move-ctor walks off the end → **BUS on unaligned write** is exactly what UBSan saw.

Smoking gun: `core/view/src/toolbar.cpp:25` literally had the comment `// add_separator() is defined in app_framework.cpp`.

## Fix

Rename the descriptor class: `app_framework::Toolbar` → `app_framework::NativeToolbar` with nested struct `ToolbarItem` → `Item`. Move `add_separator` back into `toolbar.cpp` so the rich view-based `Toolbar` owns its own definitions. Update `test_app_framework.cpp` to use the new name. Drop `[!mayfail]` from `test_gui_components.cpp` — these tests now pass clean.

Verified locally:
- `pulp-test-gui-components [toolbar]` — 6 assertions / 4 cases, all pass
- `pulp-test-app-framework [toolbar]` — 2 assertions / 1 case, pass

## Follow-up

Once this lands, remove `--exclude-regex 'Toolbar add items'` from `.github/workflows/sanitizers.yml`. Its presence dates to #401 when we thought this was a libc++ bug.

## Why sdk=skip, not minor

The renamed type had exactly one caller (the companion `test_app_framework.cpp` in the same change). There were no external consumers because the symbol was a linker-aliased ODR violation — the API never actually worked as declared.