### PR TITLE
fix(events): Timer sentinel race — move alive_ reassignment from stop() to start() (#414)

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -100,7 +100,7 @@ jobs:
           ctest --test-dir build --output-on-failure -j1 \
             --timeout 120 \
             --tests-regex 'AudioWorkgroup|EventLoop|StateStore|Timer|TripleBuffer|SeqLock|SpscQueue|ParamValue|MidiBuffer|MpeTracker|UmpCursor|AsyncUpdater|InterprocessConnection|ChildProcessManager|Atomic|Mutex|Concurrent|Race|Workgroup|AudioBridge|RingBuffer|Lockfree' \
-            --exclude-regex 'AudioWorkgroup|Timer basic operation'  # Timer race tracked in #414
+            --exclude-regex 'AudioWorkgroup'  # Timer race fixed by the Timer::start/stop shared_ptr fix (#414)
 
   ubsan:
     runs-on: macos-14

--- a/core/events/src/timer.cpp
+++ b/core/events/src/timer.cpp
@@ -16,6 +16,19 @@ Timer::~Timer() {
 }
 
 void Timer::start() {
+    // Fresh sentinel for this lifecycle. Safe to reassign alive_ here
+    // because start() runs on the owner thread — no in-flight dispatch
+    // lambda can be copying alive_ concurrently at this point; any
+    // prior-cycle lambdas hold their own shared_ptr copies captured
+    // before stop() flipped them to false.
+    //
+    // Previously this reassignment lived in stop(), racing with
+    // schedule_next()'s `auto alive = alive_;` copy on the event-loop
+    // thread — std::shared_ptr is NOT thread-safe for concurrent
+    // read/write of the same instance. TSan caught it as a
+    // std::swap-of-atomic<bool>* race in test_events.cpp "Timer basic
+    // operation". Issue #414.
+    alive_ = std::make_shared<std::atomic<bool>>(true);
     active_.store(true, std::memory_order_release);
     schedule_next();
 }
@@ -23,8 +36,11 @@ void Timer::start() {
 void Timer::stop() {
     active_.store(false, std::memory_order_release);
     alive_->store(false, std::memory_order_release);
-    // Create a new sentinel for potential reuse
-    alive_ = std::make_shared<std::atomic<bool>>(true);
+    // Don't replace alive_ here. In-flight dispatch lambdas still
+    // hold a shared_ptr copy to this sentinel and correctly see the
+    // false value set above; the old sentinel is reclaimed when the
+    // last in-flight lambda drops its ref. start() allocates a fresh
+    // sentinel for the next lifecycle.
 }
 
 void Timer::set_interval(Duration interval) {


### PR DESCRIPTION
Closes #414.

TSan caught a race on `std::shared_ptr<std::atomic<bool>> Timer::alive_`. `stop()` reassigned the shared_ptr on the owner thread while `schedule_next()` on the event-loop thread was copy-constructing from the same member — `std::shared_ptr` is NOT thread-safe for concurrent read/write of the same instance.

## Fix

Move the sentinel reassignment from `stop()` to `start()`:
- `start()` is always called from the owner thread, so reassigning `alive_` there races with nothing.
- `stop()` still flips the sentinel's atomic_bool to false so in-flight lambdas early-return.
- Old sentinels are naturally reclaimed when the last in-flight lambda drops its shared_ptr copy.

## Test exclusion removed

Also removes `Timer basic operation` from the TSan `--exclude-regex` — the test can now run clean under instrumentation. Previously excluded in #401 when we didn't have a fix yet.

## Test plan

- [x] Diagnosis (posted on #414) matches shared_ptr thread-safety contract
- [ ] TSan job runs clean on this PR (the verification gate)
- [ ] test_events.cpp Timer tests still pass under ASan + UBSan (no behavior change)