### PR TITLE
ci: TSan hardening steps 4 + 5 — race hammer + path-gated trigger (#412)

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -7,8 +7,31 @@ name: Sanitizer Tests
 on:
   pull_request:
     branches: [main, develop]
+    # Path filter: only run sanitizers when the touched code can
+    # plausibly affect memory safety / threading. Docs-only and
+    # workflow-YAML-only PRs skip the 30-min matrix. #412 step 5.
+    paths:
+      - 'core/**'
+      - 'examples/**'
+      - 'tools/cli/**'
+      - 'test/**'
+      - 'CMakeLists.txt'
+      - 'tools/cmake/**'
+      - '.github/workflows/sanitizers.yml'
+      - 'setup.sh'
+      - 'external/**'
   push:
     branches: [main]
+    paths:
+      - 'core/**'
+      - 'examples/**'
+      - 'tools/cli/**'
+      - 'test/**'
+      - 'CMakeLists.txt'
+      - 'tools/cmake/**'
+      - '.github/workflows/sanitizers.yml'
+      - 'setup.sh'
+      - 'external/**'
   workflow_dispatch:
 
 concurrency:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -477,6 +477,14 @@ add_executable(pulp-test-runtime test_runtime.cpp)
 target_link_libraries(pulp-test-runtime PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-runtime)
 
+# Sync-primitive hammer (TSan-focused, #412 step 4).
+# Runs under the tag-scoped TSan subset via the [concurrent][race]
+# tags embedded in each TEST_CASE (matches the 'Race|Concurrent'
+# alternation in sanitizers.yml's --tests-regex).
+add_executable(pulp-test-sync-race-hammer test_sync_race_hammer.cpp)
+target_link_libraries(pulp-test-sync-race-hammer PRIVATE pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-sync-race-hammer)
+
 # Events tests
 add_executable(pulp-test-events test_events.cpp)
 target_link_libraries(pulp-test-events PRIVATE pulp::events Catch2::Catch2WithMain)

--- a/test/test_sync_race_hammer.cpp
+++ b/test/test_sync_race_hammer.cpp
@@ -1,0 +1,157 @@
+// Thread-sanitizer hammer test for Pulp's sync primitives.
+//
+// Each section spawns producer(s) + consumer(s) on the same sync
+// primitive and hammers it for a fixed wall-clock duration. TSan
+// flags any detectable race; ASan/UBSan also catch use-after-free
+// and UB in the primitives' fast paths.
+//
+// Runs under all three sanitizers per the tag-scoped TSan regex in
+// .github/workflows/sanitizers.yml (#412 step 3). Keep the hammer
+// duration short (500 ms) so the test finishes well under the 120s
+// per-test timeout.
+//
+// Primitives covered:
+//   TripleBuffer<T>  — single writer, single reader, latest-value
+//   SeqLock<T>       — single writer, multi-reader, coherent snapshot
+//   SpscQueue<T>     — single producer, single consumer, ordered
+//
+// #412 step 4: deterministic race-hammer harness. Complements the
+// individual unit tests in test_triple_buffer.cpp / test_seqlock.cpp
+// / test_spsc_queue.cpp which cover correctness of isolated ops.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/runtime/seqlock.hpp>
+#include <pulp/runtime/spsc_queue.hpp>
+#include <pulp/runtime/triple_buffer.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+using pulp::runtime::SeqLock;
+using pulp::runtime::SpscQueue;
+using pulp::runtime::TripleBuffer;
+
+namespace {
+
+struct Snapshot {
+    double tempo;
+    double position;
+    int    numerator;
+};
+
+constexpr auto kHammerDuration = 500ms;
+
+}  // namespace
+
+TEST_CASE("TripleBuffer hammer: writer + reader for 500ms", "[concurrent][race][triple_buffer]") {
+    TripleBuffer<int> buf;
+    std::atomic<bool> stop{false};
+    std::atomic<int>  read_count{0};
+    std::atomic<int>  write_count{0};
+
+    std::thread writer([&] {
+        int v = 0;
+        while (!stop.load(std::memory_order_acquire)) {
+            buf.write(++v);
+            write_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::thread reader([&] {
+        while (!stop.load(std::memory_order_acquire)) {
+            (void) buf.read();
+            read_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::this_thread::sleep_for(kHammerDuration);
+    stop.store(true, std::memory_order_release);
+    writer.join();
+    reader.join();
+
+    INFO("writes=" << write_count.load() << " reads=" << read_count.load());
+    REQUIRE(write_count.load() > 0);
+    REQUIRE(read_count.load() > 0);
+}
+
+TEST_CASE("SeqLock hammer: 1 writer + 2 readers for 500ms", "[concurrent][race][seqlock]") {
+    SeqLock<Snapshot> lock{Snapshot{120.0, 15.0, 4}};
+    std::atomic<bool> stop{false};
+    std::atomic<int>  read_count{0};
+    std::atomic<int>  write_count{0};
+
+    std::thread writer([&] {
+        double tempo = 120.0;
+        while (!stop.load(std::memory_order_acquire)) {
+            lock.write(Snapshot{tempo, tempo * 0.125, 4});
+            tempo += 0.001;
+            write_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    // Reader just exercises read() repeatedly. TSan is the verifier
+    // here — any race in SeqLock's byte-stripe write / seq-retry read
+    // protocol will trip the detector under -fsanitize=thread.
+    // (Avoid asserting a correctness invariant on the snapshot
+    // contents: floating-point recomputation in the writer makes any
+    // `position == tempo * k` relation subject to rounding drift that
+    // isn't a race but would flake the assertion.)
+    auto read_worker = [&] {
+        while (!stop.load(std::memory_order_acquire)) {
+            Snapshot snap = lock.read();
+            (void) snap;
+            read_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    };
+
+    std::thread reader_a(read_worker);
+    std::thread reader_b(read_worker);
+
+    std::this_thread::sleep_for(kHammerDuration);
+    stop.store(true, std::memory_order_release);
+    writer.join();
+    reader_a.join();
+    reader_b.join();
+
+    INFO("writes=" << write_count.load() << " reads=" << read_count.load());
+    REQUIRE(write_count.load() > 0);
+    REQUIRE(read_count.load() > 0);
+}
+
+TEST_CASE("SpscQueue hammer: producer + consumer for 500ms", "[concurrent][race][spsc_queue]") {
+    SpscQueue<int, 4096> q;
+    std::atomic<bool> stop{false};
+    std::atomic<int>  produced{0};
+    std::atomic<int>  consumed{0};
+
+    std::thread producer([&] {
+        int v = 0;
+        while (!stop.load(std::memory_order_acquire)) {
+            if (q.try_push(++v)) {
+                produced.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+
+    std::thread consumer([&] {
+        while (!stop.load(std::memory_order_acquire) || produced.load() != consumed.load()) {
+            if (auto item = q.try_pop()) {
+                (void) *item;
+                consumed.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+
+    std::this_thread::sleep_for(kHammerDuration);
+    stop.store(true, std::memory_order_release);
+    producer.join();
+    consumer.join();
+
+    INFO("produced=" << produced.load() << " consumed=" << consumed.load());
+    // Ordered SPSC: consumer should never see more than was produced,
+    // and when stop is observed by both they must agree.
+    REQUIRE(produced.load() > 0);
+    REQUIRE(consumed.load() == produced.load());
+}


### PR DESCRIPTION
Closes out the remaining two items in #412. Complementary to the 3 already shipped in #401 (timeout + tag-scope + suppressions).

## Step 4: sync-primitive race-hammer test

New `test/test_sync_race_hammer.cpp` — 3 cases, 500ms each:

- TripleBuffer: 1 writer + 1 reader
- SeqLock: 1 writer + 2 readers
- SpscQueue: 1 producer + 1 consumer (ordered drain-after-stop)

Counters verify the primitive was exercised; TSan is the correctness verifier — any race trips `-fsanitize=thread`. Test names align with the existing `--tests-regex` (`TripleBuffer|SeqLock|SpscQueue` already matched).

## Step 5: path-gated sanitizer trigger

`sanitizers.yml` now has `on.pull_request.paths` + `on.push.paths` filters. Docs-only / workflow-YAML-only PRs skip the 30-min sanitizer matrix. Paths: `core/`, `examples/`, `tools/cli/`, `test/`, `CMakeLists.txt`, `tools/cmake/`, `sanitizers.yml` itself, `setup.sh`, `external/`. `workflow_dispatch` stays unfiltered.

## Test plan

- [x] macOS Debug: 6 assertions / 3 cases pass
- [ ] CI runs clean under ASan/TSan/UBSan
- [ ] Path-gate verified: docs-only PR on a follow-up doesn't trigger sanitizers