### PR TITLE
ci: reusable retry composite action + wrap apt-llvm-org flake sites

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -1,0 +1,56 @@
+name: 'Retry a shell command'
+description: >
+  Runs a shell command with automatic retry on non-zero exit.
+  Tolerates transient network failures (apt.llvm.org 5xx,
+  GitHub git-clone blips, Homebrew bottle-fetch timeouts) without
+  needing the whole workflow to close/reopen to retrigger.
+  Standard pattern across all long-running Pulp workflows.
+
+inputs:
+  run:
+    description: Shell command to execute
+    required: true
+  attempts:
+    description: Maximum attempts (including first run)
+    default: '3'
+  initial-delay-seconds:
+    description: Wait before the first retry (doubles each subsequent retry)
+    default: '15'
+  shell:
+    description: Shell to use (bash|pwsh|sh)
+    default: 'bash'
+  label:
+    description: Human-readable step label used in log messages
+    default: 'command'
+
+runs:
+  using: composite
+  steps:
+    - name: Run with retry
+      shell: ${{ inputs.shell }}
+      env:
+        RETRY_ATTEMPTS: ${{ inputs.attempts }}
+        RETRY_INITIAL_DELAY: ${{ inputs.initial-delay-seconds }}
+        RETRY_LABEL: ${{ inputs.label }}
+        RETRY_SCRIPT: ${{ inputs.run }}
+      run: |
+        set +e
+        attempt=1
+        delay="${RETRY_INITIAL_DELAY}"
+        while : ; do
+          echo "::group::${RETRY_LABEL} (attempt ${attempt}/${RETRY_ATTEMPTS})"
+          bash -c "${RETRY_SCRIPT}"
+          status=$?
+          echo "::endgroup::"
+          if [ "${status}" -eq 0 ]; then
+            exit 0
+          fi
+          if [ "${attempt}" -ge "${RETRY_ATTEMPTS}" ]; then
+            echo "::error::${RETRY_LABEL} failed after ${RETRY_ATTEMPTS} attempts (exit ${status})"
+            exit "${status}"
+          fi
+          echo "${RETRY_LABEL} exited ${status}; retrying in ${delay}s..."
+          sleep "${delay}"
+          attempt=$((attempt + 1))
+          delay=$((delay * 2))
+        done

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -159,24 +159,31 @@ jobs:
           lfs: true
 
       - name: Install Clang 18
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 18
-          sudo apt-get install -y clang-18 lld-18
+        # apt.llvm.org intermittently 5xx's during release cuts; retry
+        # the whole install rather than bubble a transient up. #418.
+        uses: ./.github/actions/retry
+        with:
+          label: 'Install Clang 18'
+          run: |
+            wget https://apt.llvm.org/llvm.sh
+            chmod +x llvm.sh
+            sudo ./llvm.sh 18
+            sudo apt-get install -y clang-18 lld-18
 
       - name: Install Linux dev headers
         # setup.sh --ci hard-fails when ALSA/X11/Wayland dev headers are
-        # missing (✗ ALSA dev headers not found, etc.). Mirrors the
-        # apt-install step in build.yml + release-cli.yml; without it
-        # the rtsan job dies before configure.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev \
-            libgbm-dev libgl1-mesa-dev libx11-dev libxext-dev libxfixes-dev \
-            libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev \
-            libxrender-dev libxss-dev libxtst-dev libwayland-dev wayland-protocols
+        # missing. apt-get update + install can flake on mirror 5xx;
+        # retry rather than rebuild the whole workflow.
+        uses: ./.github/actions/retry
+        with:
+          label: 'Install Linux dev headers (rtsan)'
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y \
+              libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev \
+              libgbm-dev libgl1-mesa-dev libx11-dev libxext-dev libxfixes-dev \
+              libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev \
+              libxrender-dev libxss-dev libxtst-dev libwayland-dev wayland-protocols
 
       - name: Bootstrap repository dependencies
         run: ./setup.sh --ci --deps-only


### PR DESCRIPTION
Part of #419 speedup roster. Eliminates the close/reopen dance we've done ~10 times today for apt.llvm.org 5xx during the `Install Clang 18` step on rtsan.

## New: .github/actions/retry/

Composite action wrapping any shell command in exponential-backoff retry. Inputs: `run`, `attempts` (default 3), `initial-delay-seconds` (default 15, doubles). Logs each attempt as a `::group::` for readable CI output.

## Wired sites

- rtsan job `Install Clang 18` — apt.llvm.org 5xx hits us repeatedly
- rtsan job `Install Linux dev headers` — apt mirror flakes

## Not wrapped

Bootstrap (`setup.sh --ci`) — already has `retry_git` internally from #425; outer retry would mask real config failures.

## Test plan

- [ ] Action YAML valid on this PR's CI run
- [ ] Next apt.llvm.org 5xx self-heals instead of closing/reopening the PR