### PR TITLE
render: CMake gate for iOS Dawn-only path (#359)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,11 @@ FetchContent_MakeAvailable(choc)
 
 # WebGPU (Dawn) — cross-platform GPU abstraction (BSD-3-Clause)
 # Uses eliemichel/WebGPU-distribution for CMake-friendly integration
-# On Android, Dawn is bundled in Skia's pre-built libs — skip FetchContent.
-if(PULP_ENABLE_GPU AND NOT ANDROID)
+# On Android + iOS, Dawn is bundled in Skia's pre-built libs — skip
+# FetchContent. wgpu-native doesn't publish iOS prebuilds (tracked in
+# #359); pulp's render path is Dawn-only whenever Skia is the backend
+# anyway (pulp::render::GpuSurface uses Dawn's C++ API under PULP_HAS_SKIA).
+if(PULP_ENABLE_GPU AND NOT ANDROID AND NOT IOS)
     pulp_register_fetchcontent_source(webgpu REF 17dcd42a7683355e7a40ac4e97e77f36dff5b5ab)
     pulp_register_wgpu_native_precompiled_source(v24.0.3.1)
     FetchContent_Declare(
@@ -165,8 +168,13 @@ if(PULP_ENABLE_GPU)
     include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/FindSkia.cmake)
     if(SKIA_FOUND)
         set(PULP_HAS_SKIA TRUE)
-        # On Android, Dawn is bundled in Skia — set the flag so render subsystem builds
-        if(ANDROID)
+        # On Android + iOS, Dawn is bundled in Skia's pre-built libs.
+        # Set PULP_HAS_WEBGPU so the render subsystem builds without
+        # needing the desktop wgpu-native FetchContent path. iOS in
+        # particular has no wgpu-native prebuild and won't until #359
+        # is resolved — Dawn is the only viable backend, which matches
+        # how pulp::render uses Dawn when PULP_HAS_SKIA is set.
+        if(ANDROID OR IOS)
             set(PULP_HAS_WEBGPU TRUE)
         endif()
 


### PR DESCRIPTION
Two-line CMake gate that aligns iOS with Android's Dawn-bundled-in-Skia path.

## Change

- Skip wgpu-native FetchContent on iOS (`if(PULP_ENABLE_GPU AND NOT ANDROID AND NOT IOS)`). wgpu-native has no iOS prebuild.
- Set `PULP_HAS_WEBGPU=TRUE` for iOS when Skia is found (Dawn is bundled in Skia's pre-built libs).

## Why

Per #359 analysis, `pulp::render::GpuSurface` already uses Dawn's C++ API under `PULP_HAS_SKIA` — not wgpu-native. So iOS Dawn-only is already how pulp's render code works; this PR just makes the CMake gate recognize that fact for iOS.

## Out of scope

The iOS Skia + Dawn pre-built payload at `external/skia-build/ios-gpu/` is a separate artifact-drop PR that depends on skia-builder shipping the iOS variant. This PR unblocks the CMake side so that artifact can actually land without an infinite wgpu-native fetch loop.

## Test plan

- [x] Non-iOS builds unaffected (guard is `NOT IOS` addition only)
- [ ] iOS CMake configure succeeds once skia-builder iOS payload is in place (verified in follow-up)

Closes the CMake-gating half of #359.