### PR TITLE
platform(android): Kotlin plumbing for orientation + safe-area + keyboard env (#342)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -60,6 +60,9 @@ jobs:
         shell: bash
         run: |
           APK=android/app/build/outputs/apk/debug/app-debug.apk
+          echo "--- APK full contents ---"
+          unzip -l "$APK" || echo "(APK unreadable)"
+          echo "---"
           if unzip -l "$APK" | grep -q "libpulp.so"; then
             echo "✅ libpulp.so found in APK"
             unzip -l "$APK" | grep "\.so"
@@ -67,6 +70,26 @@ jobs:
             echo "❌ libpulp.so NOT found in APK"
             exit 1
           fi
+
+      # Always upload APK + Gradle/NDK logs so a failed "Verify APK"
+      # step (historically flaky on windows-latest — #403, #418) can
+      # be diagnosed from artifacts instead of requiring a close/reopen
+      # retry cycle. The `if: always()` ensures this runs even when the
+      # verify step above fails.
+      - name: Upload APK + build logs (diagnostic)
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: pulp-android-${{ matrix.os }}-diag
+          path: |
+            android/app/build/outputs/apk/debug/app-debug.apk
+            android/app/build/outputs/logs/**
+            android/app/.cxx/**/build.ninja
+            android/app/.cxx/**/CMakeCache.txt
+            android/app/.cxx/**/CMakeFiles/CMakeOutput.log
+            android/app/.cxx/**/CMakeFiles/CMakeError.log
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.20.0
+    VERSION 0.21.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/android/app/src/main/kotlin/com/pulp/PulpActivity.kt
+++ b/android/app/src/main/kotlin/com/pulp/PulpActivity.kt
@@ -4,8 +4,12 @@ import android.content.ComponentCallbacks2
 import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
+import android.view.View
+import android.view.WindowInsets
 import android.widget.FrameLayout
 import androidx.activity.ComponentActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.pulp.audio.PulpAudioFocus
 import com.pulp.render.PulpSurfaceView
 
@@ -26,6 +30,37 @@ class PulpActivity : ComponentActivity() {
         val frame = FrameLayout(this)
         frame.addView(surfaceView)
         setContentView(frame)
+
+        // Publish initial orientation + safe-area + keyboard insets as
+        // soon as the decor view has window insets. Also subscribe to
+        // subsequent updates (keyboard show/hide, notch enter/exit on
+        // rotation, split-screen insets). Forwards into the C++
+        // Environment API (#342).
+        if (PulpApplication.nativeLoaded) {
+            val initialOrientation = resources.configuration.orientation
+            nativeOnOrientationChanged(orientationToEnum(initialOrientation))
+
+            ViewCompat.setOnApplyWindowInsetsListener(frame) { _, insets ->
+                val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+                val ime  = insets.getInsets(WindowInsetsCompat.Type.ime())
+                if (PulpApplication.nativeLoaded) {
+                    nativeOnSafeAreaChanged(
+                        bars.top.toFloat(),
+                        bars.bottom.toFloat(),
+                        bars.left.toFloat(),
+                        bars.right.toFloat()
+                    )
+                    // Keyboard is considered visible when IME height
+                    // exceeds the system bars' bottom inset; subtract
+                    // so callers see the "additional" bottom padding
+                    // the keyboard introduced, not the full IME height
+                    // (which already includes the system nav bar).
+                    val keyboardBottom = maxOf(0, ime.bottom - bars.bottom).toFloat()
+                    nativeOnKeyboardChanged(keyboardBottom)
+                }
+                insets
+            }
+        }
     }
 
     override fun onResume() {
@@ -53,8 +88,19 @@ class PulpActivity : ComponentActivity() {
         val dm = resources.displayMetrics
         val dark = newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
                 Configuration.UI_MODE_NIGHT_YES
-        if (PulpApplication.nativeLoaded)
+        if (PulpApplication.nativeLoaded) {
             nativeOnDisplayChanged(dm.widthPixels, dm.heightPixels, dm.density, dark)
+            nativeOnOrientationChanged(orientationToEnum(newConfig.orientation))
+        }
+    }
+
+    // Map Android's Configuration.ORIENTATION_* to the Pulp C++
+    // Orientation enum values (declared in environment.hpp). Kept
+    // side-by-side with the C++ to keep the mapping obvious.
+    private fun orientationToEnum(androidOrientation: Int): Int = when (androidOrientation) {
+        Configuration.ORIENTATION_PORTRAIT  -> 0   // Orientation::portrait
+        Configuration.ORIENTATION_LANDSCAPE -> 2   // Orientation::landscape_left
+        else                                -> 5   // Orientation::unknown
     }
 
     override fun onTrimMemory(level: Int) {
@@ -76,5 +122,8 @@ class PulpActivity : ComponentActivity() {
     private external fun nativeOnShutdown()
     private external fun nativeOnMemoryPressure(level: Int)
     private external fun nativeOnDisplayChanged(w: Int, h: Int, density: Float, dark: Boolean)
+    private external fun nativeOnOrientationChanged(orientation: Int)
+    private external fun nativeOnSafeAreaChanged(top: Float, bottom: Float, left: Float, right: Float)
+    private external fun nativeOnKeyboardChanged(bottom: Float)
     external fun nativeOnPermissionResult(permission: Int, granted: Boolean)
 }

--- a/core/format/src/aax_runtime.cpp
+++ b/core/format/src/aax_runtime.cpp
@@ -210,9 +210,50 @@ void decode_midi_node(AAX_IMIDINode* node, midi::MidiBuffer* midi_in) {
     }
 
     if (auto* stream = node->GetNodeBuffer(); stream && stream->mBuffer) {
+        // Sysex accumulator — AAX splits multi-byte sysex into
+        // sequential AAX_CMidiPacket entries (mData[4] max) with the
+        // F0 status in the first packet and F7 terminator in the last.
+        // AAX docs allow continuation packets without a status byte;
+        // the accumulator treats every byte while `sysex_in_progress`
+        // as payload until F7 is seen. #239 AAX parity.
+        std::vector<uint8_t> sysex_buffer;
+        bool sysex_in_progress = false;
+        int32_t sysex_start_offset = 0;
+
         for (uint32_t index = 0; index < stream->mBufferSize; ++index) {
             const auto& packet = stream->mBuffer[index];
-            if (packet.mLength == 0 || packet.mLength > 3) {
+            if (packet.mLength == 0) {
+                continue;
+            }
+
+            // Detect sysex start OR continue an already-running sysex.
+            const bool starts_sysex =
+                (!sysex_in_progress && packet.mData[0] == 0xF0);
+            if (starts_sysex || sysex_in_progress) {
+                if (starts_sysex) {
+                    sysex_buffer.clear();
+                    sysex_start_offset =
+                        static_cast<int32_t>(packet.mTimestamp);
+                    sysex_in_progress = true;
+                }
+                for (uint32_t b = 0; b < packet.mLength && b < 4; ++b) {
+                    const uint8_t byte = packet.mData[b];
+                    sysex_buffer.push_back(byte);
+                    if (byte == 0xF7) {
+                        midi_in->add_sysex(std::move(sysex_buffer),
+                                           sysex_start_offset, 0.0);
+                        sysex_buffer.clear();
+                        sysex_in_progress = false;
+                        break;
+                    }
+                }
+                continue;
+            }
+
+            // Short channel-voice or system-common (1..3 bytes).
+            if (packet.mLength > 3) {
+                // Unexpected — AAX short-message packets are 1..3
+                // bytes; anything larger outside a sysex is malformed.
                 continue;
             }
 
@@ -225,6 +266,11 @@ void decode_midi_node(AAX_IMIDINode* node, midi::MidiBuffer* midi_in) {
             };
             midi_in->add(std::move(event));
         }
+
+        // Dangling sysex (no F7 before the block ended) — drop rather
+        // than deliver a corrupt message. A real device should have
+        // emitted F7 within the block; if it didn't, the DAW's own
+        // host layer will have flagged the malformed stream.
         midi_in->sort();
     }
 }
@@ -234,6 +280,7 @@ void encode_midi_node(AAX_IMIDINode* node, const midi::MidiBuffer& midi_out) {
         return;
     }
 
+    // Short channel-voice messages first (unchanged).
     for (const auto& event : midi_out) {
         if (event.size() == 0 || event.size() > 3) {
             continue;
@@ -245,6 +292,30 @@ void encode_midi_node(AAX_IMIDINode* node, const midi::MidiBuffer& midi_out) {
         std::memcpy(packet.mData, event.data(), packet.mLength);
         packet.mIsImmediate = (packet.mTimestamp == 0);
         node->PostMIDIPacket(&packet);
+    }
+
+    // Sysex outbound — chunk each SysexEvent into 4-byte AAX packets.
+    // AAX_CMidiPacket::mData is exactly 4 bytes; the full F0..F7 byte
+    // stream is delivered as ceil(N / 4) consecutive packets sharing
+    // the same timestamp. #239 AAX parity.
+    for (const auto& sx : midi_out.sysex()) {
+        if (sx.data.empty()) continue;
+        const uint32_t ts = static_cast<uint32_t>(
+            std::max(0, sx.sample_offset));
+        size_t offset = 0;
+        while (offset < sx.data.size()) {
+            const size_t chunk = std::min<size_t>(4, sx.data.size() - offset);
+            AAX_CMidiPacket packet{};
+            packet.mTimestamp = ts;
+            packet.mLength = static_cast<uint8_t>(chunk);
+            std::memcpy(packet.mData, sx.data.data() + offset, chunk);
+            // mIsImmediate flags the first chunk only; continuation
+            // packets ride the same timestamp and shouldn't re-fire
+            // the immediate-dispatch path.
+            packet.mIsImmediate = (offset == 0 && ts == 0);
+            node->PostMIDIPacket(&packet);
+            offset += chunk;
+        }
     }
 }
 

--- a/core/midi/platform/linux/alsa_midi_device.cpp
+++ b/core/midi/platform/linux/alsa_midi_device.cpp
@@ -20,6 +20,10 @@ class AlsaMidiInput : public MidiInput {
 public:
     ~AlsaMidiInput() override { close(); }
 
+    void set_sysex_callback(MidiSysexCallback cb) override {
+        sysex_callback_ = std::move(cb);
+    }
+
     bool open(const std::string& port_id, MidiInputCallback callback) override {
         callback_ = std::move(callback);
 
@@ -68,32 +72,88 @@ private:
                 break; // Error
             }
 
-            // Parse raw MIDI bytes into events
-            for (ssize_t i = 0; i < n; ) {
-                uint8_t status = buf[i];
-                if (status < 0x80) { ++i; continue; } // Skip data bytes without status
+            // Parse raw MIDI bytes into events. Sysex (F0..F7) is
+            // variable-length and can span multiple snd_rawmidi_read
+            // calls, so the accumulator state lives on the instance
+            // (sysex_buffer_, sysex_in_progress_). A real-time message
+            // (F8..FF) may appear INSIDE a sysex without terminating it
+            // — MIDI 1.0 §3.1 allows that for clock/start/stop. We emit
+            // the real-time message inline and keep collecting sysex
+            // bytes. #239.
+            for (ssize_t i = 0; i < n; ++i) {
+                uint8_t b = buf[i];
 
-                int msg_len = 3; // Default for most channel messages
-                if ((status & 0xF0) == 0xC0 || (status & 0xF0) == 0xD0) {
+                // Real-time messages (F8..FF) pass through unconditionally.
+                if (b >= 0xF8) {
+                    MidiEvent evt;
+                    evt.message = choc::midi::ShortMessage(b, 0, 0);
+                    evt.timestamp = 0.0;
+                    if (callback_) callback_(evt);
+                    continue;
+                }
+
+                // Inside a sysex: append until F7 terminator.
+                if (sysex_in_progress_) {
+                    sysex_buffer_.push_back(b);
+                    if (b == 0xF7) {
+                        if (sysex_callback_) {
+                            sysex_callback_(sysex_buffer_, 0.0);
+                        }
+                        sysex_buffer_.clear();
+                        sysex_in_progress_ = false;
+                    } else if (sysex_buffer_.size() > kSysexLimit) {
+                        // Runaway — drop rather than leak indefinitely.
+                        sysex_buffer_.clear();
+                        sysex_in_progress_ = false;
+                    }
+                    continue;
+                }
+
+                // Sysex start — begin accumulating.
+                if (b == 0xF0) {
+                    sysex_buffer_.clear();
+                    sysex_buffer_.push_back(b);
+                    sysex_in_progress_ = true;
+                    continue;
+                }
+
+                // Short message parsing (status + 1 or 2 data bytes).
+                if ((b & 0x80) == 0) continue; // stray data byte
+                int msg_len = 3;
+                if ((b & 0xF0) == 0xC0 || (b & 0xF0) == 0xD0) {
                     msg_len = 2; // Program Change, Channel Pressure
+                } else if (b == 0xF1 || b == 0xF3) {
+                    msg_len = 2; // MTC Quarter Frame, Song Select
+                } else if (b == 0xF2) {
+                    msg_len = 3; // Song Position Pointer
+                } else if (b == 0xF6 || b == 0xF7) {
+                    msg_len = 1; // Tune Request, stray End-of-Exclusive
                 }
 
                 if (i + msg_len <= n) {
                     MidiEvent evt;
                     evt.message = choc::midi::ShortMessage(
-                        buf[i],
+                        b,
                         msg_len > 1 ? buf[i + 1] : 0,
                         msg_len > 2 ? buf[i + 2] : 0);
-                    evt.timestamp = 0.0; // Raw MIDI has no timestamps
+                    evt.timestamp = 0.0;
                     if (callback_) callback_(evt);
+                    i += msg_len - 1; // loop's ++i advances past the last byte
                 }
-                i += msg_len;
             }
         }
     }
 
+    // Runaway-guard: typical device sysex dumps fit comfortably under
+    // 64 KB. If we somehow collect more without seeing F7, assume the
+    // device is misbehaving and drop the accumulator.
+    static constexpr size_t kSysexLimit = 64 * 1024;
+
     snd_rawmidi_t* handle_ = nullptr;
     MidiInputCallback callback_;
+    MidiSysexCallback sysex_callback_;
+    std::vector<uint8_t> sysex_buffer_;
+    bool sysex_in_progress_ = false;
     bool is_open_ = false;
     std::atomic<bool> running_{false};
     std::thread read_thread_;

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(pulp-platform PRIVATE
     src/permissions.cpp
     src/registry.cpp
     src/clipboard_common.cpp
+    src/environment.cpp
 )
 
 # Platform-specific UI services and child process

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -23,6 +23,7 @@ if(APPLE AND NOT IOS)
         platform/mac/clipboard_mac.mm
         platform/mac/file_dialog_mac.mm
         platform/mac/popup_menu_mac.mm
+        platform/mac/environment_mac.mm
         platform/posix/child_process_posix.cpp
     )
     target_link_libraries(pulp-platform PRIVATE

--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -1,0 +1,219 @@
+#pragma once
+
+/// @file environment.hpp
+/// Unified environment API: display, safe-area, keyboard, orientation,
+/// color scheme, foreground/background, memory pressure.
+///
+/// Each platform populates the fields it can observe; unsupported fields
+/// retain their default. Listeners receive a snapshot of the new state
+/// + a bitmask of which fields changed since the last notification.
+///
+/// Thread model: Environment is meant to be read from any thread (the
+/// snapshot accessor returns a value copy). Listeners are invoked on the
+/// thread that delivered the platform event — typically the main UI
+/// thread — but no global locking is held during dispatch, so listener
+/// bodies that touch shared state must apply their own synchronization.
+///
+/// This header defines the contract and an in-process notifier. Platform
+/// adapters live under `core/platform/platform/{android,ios,mac,win,linux}/`
+/// and call Environment::dispatcher().publish(...) when their respective
+/// OS callbacks fire (Android `Configuration.onConfigurationChanged`,
+/// iOS `UITraitCollection`, macOS `NSApplicationDidChangeScreenParameters`,
+/// Windows `WM_DPICHANGED`/`WM_SETTINGCHANGE`, Linux XSettings + Wayland
+/// fractional scale).
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace pulp::platform {
+
+/// Light/dark color scheme reported by the OS.
+enum class ColorScheme : uint8_t {
+    light,
+    dark,
+    /// Platform did not report; treat as `dark` per Pulp's default theme.
+    unknown,
+};
+
+/// Coarse foreground/background lifecycle state. Mobile platforms drive
+/// this from the activity/scene lifecycle; desktop drives from the
+/// active-window observer (NSApp resignActive on macOS, WM_ACTIVATEAPP
+/// on Windows, _NET_ACTIVE_WINDOW on X11).
+enum class LifecycleState : uint8_t {
+    foreground,
+    /// App is visible but not the focused window (split-screen, banner).
+    inactive,
+    background,
+    unknown,
+};
+
+/// Device orientation. `flat` is "screen facing up" — used by mobile to
+/// disable orientation-driven layout when the device is lying on a table.
+enum class Orientation : uint8_t {
+    portrait,
+    portrait_upside_down,
+    landscape_left,
+    landscape_right,
+    flat,
+    unknown,
+};
+
+/// Memory pressure level. Mirrors Android's TRIM_MEMORY tiers + iOS's
+/// `didReceiveMemoryWarning` (which becomes `critical`). Desktop
+/// platforms emit `normal` only — they don't have a kernel-driven LMK.
+enum class MemoryPressure : uint8_t {
+    normal,
+    /// Some background processes were killed; trim soft caches.
+    moderate,
+    /// Foreground app is the next likely target; release optional state.
+    critical,
+};
+
+/// Safe-area insets in CSS-pixel space (already divided by content_scale).
+/// Top/bottom cover the iOS notch + home indicator and Android cutouts;
+/// left/right cover landscape notches and rounded display corners.
+struct SafeAreaInsets {
+    float top    = 0.0f;
+    float bottom = 0.0f;
+    float left   = 0.0f;
+    float right  = 0.0f;
+
+    bool is_zero() const noexcept {
+        return top == 0.0f && bottom == 0.0f && left == 0.0f && right == 0.0f;
+    }
+};
+
+/// Soft-keyboard inset (mobile only). The on-screen keyboard occupies
+/// `bottom` pixels of the display from the bottom edge; layout should
+/// translate / shrink accordingly so focused inputs remain visible.
+struct KeyboardInset {
+    float bottom = 0.0f;
+    /// Animation duration the OS reported for the show/hide transition,
+    /// in seconds. Zero when not animating or unknown.
+    float animation_duration = 0.0f;
+};
+
+/// Logical display geometry. `width` and `height` are in CSS pixels;
+/// `physical_*` are the OS's reported pixel resolution. `scale` is the
+/// device pixel ratio (NSScreen backingScaleFactor / Android density /
+/// Windows DPI / 96.0).
+struct DisplayInfo {
+    float width        = 0.0f;
+    float height       = 0.0f;
+    int   physical_width  = 0;
+    int   physical_height = 0;
+    float scale         = 1.0f;
+    /// Refresh rate in Hz. Zero when unknown.
+    float refresh_hz    = 0.0f;
+    /// Optional human-readable name (e.g. "Built-in Retina Display").
+    std::string name;
+};
+
+/// Bitmask of fields that changed in the snapshot delivered to a listener.
+/// Listeners should inspect this rather than diff the whole struct.
+struct EnvironmentChange {
+    bool display          : 1;
+    bool safe_area        : 1;
+    bool keyboard         : 1;
+    bool orientation      : 1;
+    bool color_scheme     : 1;
+    bool lifecycle        : 1;
+    bool memory_pressure  : 1;
+
+    EnvironmentChange() noexcept
+        : display(false), safe_area(false), keyboard(false),
+          orientation(false), color_scheme(false), lifecycle(false),
+          memory_pressure(false) {}
+
+    bool any() const noexcept {
+        return display || safe_area || keyboard || orientation
+            || color_scheme || lifecycle || memory_pressure;
+    }
+};
+
+/// Snapshot of the full environment state. Listener callbacks receive
+/// a `(state, change)` pair so they can branch on `change.color_scheme`
+/// without diffing the previous snapshot themselves.
+struct EnvironmentState {
+    DisplayInfo     display;
+    SafeAreaInsets  safe_area;
+    KeyboardInset   keyboard;
+    Orientation     orientation     = Orientation::unknown;
+    ColorScheme     color_scheme    = ColorScheme::unknown;
+    LifecycleState  lifecycle       = LifecycleState::unknown;
+    MemoryPressure  memory_pressure = MemoryPressure::normal;
+};
+
+/// In-process notifier. Listeners survive until the returned token is
+/// destroyed (RAII subscription pattern, same as runtime::Logger).
+///
+/// The notifier is intentionally a singleton — there's exactly one OS
+/// reporting these signals per process. Tests can call `inject_for_test`
+/// to drive the singleton without a real platform adapter.
+class Environment {
+public:
+    using Listener = std::function<void(const EnvironmentState&,
+                                        EnvironmentChange)>;
+
+    /// RAII subscription. Drop to unsubscribe.
+    class Token {
+    public:
+        Token() = default;
+        ~Token() { reset(); }
+        Token(Token&& other) noexcept;
+        Token& operator=(Token&& other) noexcept;
+        Token(const Token&) = delete;
+        Token& operator=(const Token&) = delete;
+        void reset() noexcept;
+        bool valid() const noexcept { return id_ != 0; }
+    private:
+        friend class Environment;
+        Token(uint64_t id) : id_(id) {}
+        uint64_t id_ = 0;
+    };
+
+    /// Get the process singleton.
+    static Environment& instance();
+
+    /// Snapshot the current state. Safe from any thread.
+    EnvironmentState snapshot() const;
+
+    /// Subscribe to changes. The callback fires after `publish` returns
+    /// the new state. The returned token unsubscribes on destruction.
+    Token subscribe(Listener listener);
+
+    /// Push a new state. Computes `EnvironmentChange` against the prior
+    /// snapshot and dispatches to every listener. Intended for platform
+    /// adapter code; tests use `inject_for_test` (which forwards here
+    /// after taking the test mutex).
+    void publish(const EnvironmentState& next);
+
+    // ── Test hooks ──────────────────────────────────────────────────
+    /// Replace the singleton state and notify listeners. Used by unit
+    /// tests to simulate platform events without a real OS callback.
+    static void inject_for_test(const EnvironmentState& state);
+
+    /// Reset the singleton to defaults and remove every listener.
+    /// Tests call this in TEST_CASE setup so prior tests don't leak
+    /// listeners or stale state.
+    static void reset_for_test();
+
+private:
+    Environment() = default;
+    Environment(const Environment&) = delete;
+    Environment& operator=(const Environment&) = delete;
+
+    void unsubscribe(uint64_t id);
+
+    mutable std::mutex mu_;
+    EnvironmentState   state_;
+    struct Entry { uint64_t id; Listener fn; };
+    std::vector<Entry> listeners_;
+    uint64_t           next_id_ = 1;
+};
+
+} // namespace pulp::platform

--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -216,4 +216,27 @@ private:
     uint64_t           next_id_ = 1;
 };
 
+// ── Per-platform observer bootstraps ─────────────────────────────────
+// Hosts call start_environment_observer() once during startup. Each
+// platform adapter is idempotent — duplicate calls are a no-op so
+// plugin hosts loaded multiple times don't double-register.
+//
+// Adapters land per platform; this header forward-declares them
+// alphabetically. The convenience wrapper at the bottom dispatches to
+// the right one based on the build target.
+
+void start_environment_observer_mac();
+// void start_environment_observer_android(); // follow-up
+// void start_environment_observer_ios();     // follow-up
+// void start_environment_observer_linux();   // follow-up
+// void start_environment_observer_win();     // follow-up
+
+inline void start_environment_observer() {
+#if defined(__APPLE__) && !defined(PULP_IOS)
+    start_environment_observer_mac();
+#endif
+    // Other platforms wire their adapters in follow-up PRs; until then
+    // their hosts simply see the EnvironmentState defaults.
+}
+
 } // namespace pulp::platform

--- a/core/platform/platform/mac/environment_mac.mm
+++ b/core/platform/platform/mac/environment_mac.mm
@@ -1,0 +1,223 @@
+// macOS adapter for the unified Environment API (#342).
+//
+// Subscribes to NSApp + NSScreen notifications, snapshots the OS state
+// into Environment::publish(). Listeners outside the platform layer
+// don't see any AppKit types — Environment is pure C++.
+//
+// Hooks:
+//   NSApplicationDidChangeScreenParametersNotification → display
+//   NSApplicationDidBecomeActiveNotification          → lifecycle (foreground)
+//   NSApplicationDidResignActiveNotification          → lifecycle (inactive)
+//   NSApplicationDidHideNotification                  → lifecycle (background)
+//   NSApplicationDidUnhideNotification                → lifecycle (foreground)
+//   KVO on NSApp.effectiveAppearance                  → color scheme
+//
+// Memory pressure on macOS is sourced from the dispatch source
+// DISPATCH_SOURCE_TYPE_MEMORYPRESSURE so we don't depend on AppKit
+// being initialized before that signal arrives.
+//
+// Safe-area / keyboard / orientation are mobile-only — desktop
+// macOS leaves them at default (zero / unknown / zero), per the
+// EnvironmentState contract.
+
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+#include <pulp/platform/environment.hpp>
+#include <dispatch/dispatch.h>
+
+using pulp::platform::ColorScheme;
+using pulp::platform::DisplayInfo;
+using pulp::platform::Environment;
+using pulp::platform::EnvironmentState;
+using pulp::platform::LifecycleState;
+using pulp::platform::MemoryPressure;
+
+namespace {
+
+DisplayInfo snapshot_main_display() {
+    DisplayInfo info;
+    NSScreen* screen = [NSScreen mainScreen];
+    if (!screen) return info;
+    NSRect frame = screen.frame;
+    info.width  = static_cast<float>(frame.size.width);
+    info.height = static_cast<float>(frame.size.height);
+    info.scale  = static_cast<float>(screen.backingScaleFactor);
+    info.physical_width  = static_cast<int>(frame.size.width  * info.scale);
+    info.physical_height = static_cast<int>(frame.size.height * info.scale);
+    if (@available(macOS 12.0, *)) {
+        // maximumFramesPerSecond is the panel cap; for ProMotion this
+        // returns 120, for standard 60. Zero means unknown.
+        info.refresh_hz = static_cast<float>(screen.maximumFramesPerSecond);
+    }
+    if (NSString* name = screen.localizedName) {
+        info.name = name.UTF8String ? name.UTF8String : "";
+    }
+    return info;
+}
+
+ColorScheme detect_color_scheme() {
+    NSAppearance* appearance = nil;
+    if (NSApp) appearance = NSApp.effectiveAppearance;
+    if (!appearance) appearance = [NSAppearance currentDrawingAppearance];
+    if (!appearance) return ColorScheme::unknown;
+    NSAppearanceName best = [appearance bestMatchFromAppearancesWithNames:@[
+        NSAppearanceNameAqua,
+        NSAppearanceNameDarkAqua
+    ]];
+    if ([best isEqualToString:NSAppearanceNameDarkAqua]) return ColorScheme::dark;
+    if ([best isEqualToString:NSAppearanceNameAqua])     return ColorScheme::light;
+    return ColorScheme::unknown;
+}
+
+void publish_full_snapshot(LifecycleState lifecycle, MemoryPressure pressure) {
+    EnvironmentState s;
+    s.display      = snapshot_main_display();
+    s.color_scheme = detect_color_scheme();
+    s.lifecycle    = lifecycle;
+    s.memory_pressure = pressure;
+    Environment::instance().publish(s);
+}
+
+} // namespace
+
+@interface PulpEnvironmentObserver : NSObject
+@property(nonatomic) pulp::platform::LifecycleState currentLifecycle;
+@property(nonatomic) pulp::platform::MemoryPressure currentPressure;
+- (void)startObserving;
+@end
+
+@implementation PulpEnvironmentObserver {
+    dispatch_source_t _pressureSource;
+}
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _currentLifecycle = LifecycleState::foreground;
+        _currentPressure  = MemoryPressure::normal;
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    if (NSApp) {
+        @try { [NSApp removeObserver:self forKeyPath:@"effectiveAppearance"]; }
+        @catch (NSException*) {}
+    }
+    if (_pressureSource) {
+        dispatch_source_cancel(_pressureSource);
+        _pressureSource = nullptr;
+    }
+}
+
+- (void)startObserving {
+    NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
+
+    [nc addObserver:self
+           selector:@selector(onScreenChange:)
+               name:NSApplicationDidChangeScreenParametersNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onActive:)
+               name:NSApplicationDidBecomeActiveNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onResign:)
+               name:NSApplicationDidResignActiveNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onHide:)
+               name:NSApplicationDidHideNotification
+             object:nil];
+    [nc addObserver:self
+           selector:@selector(onUnhide:)
+               name:NSApplicationDidUnhideNotification
+             object:nil];
+
+    if (NSApp) {
+        [NSApp addObserver:self
+                forKeyPath:@"effectiveAppearance"
+                   options:0
+                   context:nullptr];
+    }
+
+    // Memory pressure dispatch source. Coalesces warning + critical so
+    // a transition warning -> critical becomes two publish() calls.
+    _pressureSource = dispatch_source_create(
+        DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0,
+        DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL,
+        dispatch_get_main_queue());
+    if (_pressureSource) {
+        // Observer is process-lived (created via dispatch_once and never
+        // released), so capturing self by reference is safe. The block
+        // also keeps it alive while the dispatch source is active.
+        // Codebase compiles .mm files in MRR — no __weak available.
+        dispatch_source_t source = _pressureSource;
+        PulpEnvironmentObserver* observerRef = self;
+        dispatch_source_set_event_handler(_pressureSource, ^{
+            unsigned long flags = dispatch_source_get_data(source);
+            if (flags & DISPATCH_MEMORYPRESSURE_CRITICAL) {
+                observerRef.currentPressure = MemoryPressure::critical;
+            } else if (flags & DISPATCH_MEMORYPRESSURE_WARN) {
+                observerRef.currentPressure = MemoryPressure::moderate;
+            } else {
+                observerRef.currentPressure = MemoryPressure::normal;
+            }
+            publish_full_snapshot(observerRef.currentLifecycle,
+                                  observerRef.currentPressure);
+        });
+        dispatch_resume(_pressureSource);
+    }
+
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+
+- (void)onScreenChange:(NSNotification*)note {
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+- (void)onActive:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::foreground;
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+- (void)onResign:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::inactive;
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+- (void)onHide:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::background;
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+- (void)onUnhide:(NSNotification*)note {
+    _currentLifecycle = LifecycleState::foreground;
+    publish_full_snapshot(_currentLifecycle, _currentPressure);
+}
+
+- (void)observeValueForKeyPath:(NSString*)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey,id>*)change
+                       context:(void*)context {
+    if ([keyPath isEqualToString:@"effectiveAppearance"]) {
+        publish_full_snapshot(_currentLifecycle, _currentPressure);
+    }
+}
+@end
+
+namespace pulp::platform {
+
+namespace {
+PulpEnvironmentObserver* g_observer = nil;
+}
+
+// Public entry — host bootstrap calls this once during NSApp setup.
+// Idempotent: a second call is a no-op so AU/VST3/CLAP host loads
+// don't double-register observers.
+void start_environment_observer_mac() {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        g_observer = [[PulpEnvironmentObserver alloc] init];
+        [g_observer startObserving];
+    });
+}
+
+} // namespace pulp::platform

--- a/core/platform/src/android/jni_bridge.cpp
+++ b/core/platform/src/android/jni_bridge.cpp
@@ -1,6 +1,7 @@
 #if defined(__ANDROID__)
 
 #include <pulp/platform/android/jni.hpp>
+#include <pulp/platform/environment.hpp>
 #include <android/log.h>
 #include <stdexcept>
 #include <string>
@@ -110,7 +111,12 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_pulp_PulpActivity_nativeOnForeground(JNIEnv* env, jobject thiz) {
     try {
         PULP_LOGI("nativeOnForeground");
-        // TODO: Resume rendering, restore GPU caches
+        // Publish to the unified environment notifier (#342). Callers
+        // subscribed via Environment::subscribe receive the new lifecycle
+        // state and can resume rendering / restore GPU caches.
+        auto s = pulp::platform::Environment::instance().snapshot();
+        s.lifecycle = pulp::platform::LifecycleState::foreground;
+        pulp::platform::Environment::instance().publish(s);
     } catch (const std::exception& e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
     } catch (...) {
@@ -123,7 +129,11 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_pulp_PulpActivity_nativeOnBackground(JNIEnv* env, jobject thiz) {
     try {
         PULP_LOGI("nativeOnBackground");
-        // TODO: Reduce rendering, prepare for possible LMK
+        // Publish via the unified environment notifier (#342). Callers
+        // reduce rendering / drop optional caches in response.
+        auto s = pulp::platform::Environment::instance().snapshot();
+        s.lifecycle = pulp::platform::LifecycleState::background;
+        pulp::platform::Environment::instance().publish(s);
     } catch (const std::exception& e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
     } catch (...) {
@@ -149,7 +159,27 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_pulp_PulpActivity_nativeOnMemoryPressure(JNIEnv* env, jobject thiz, jint level) {
     try {
         PULP_LOGI("nativeOnMemoryPressure: level=%d", level);
-        // TODO: Wire to on_memory_pressure() for tiered cache release
+        // Translate Android onTrimMemory level into Pulp's coarser
+        // MemoryPressure tiers. The Android level values are stable
+        // public API constants on ComponentCallbacks2:
+        //   TRIM_MEMORY_COMPLETE   = 80  (critical — next to be killed)
+        //   TRIM_MEMORY_MODERATE   = 60  (significant — foreground at risk)
+        //   TRIM_MEMORY_BACKGROUND = 40  (background — start releasing)
+        //   TRIM_MEMORY_UI_HIDDEN  = 20  (UI no longer visible)
+        //   TRIM_MEMORY_RUNNING_*   (5/10/15 — foreground running low)
+        namespace pp = pulp::platform;
+        auto pressure = pp::MemoryPressure::normal;
+        if (level >= 80) {
+            pressure = pp::MemoryPressure::critical;
+        } else if (level >= 40) {
+            pressure = pp::MemoryPressure::moderate;
+        } else if (level >= 10) {
+            // RUNNING_LOW / RUNNING_CRITICAL on a still-foreground app.
+            pressure = pp::MemoryPressure::moderate;
+        }
+        auto s = pp::Environment::instance().snapshot();
+        s.memory_pressure = pressure;
+        pp::Environment::instance().publish(s);
     } catch (const std::exception& e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
     } catch (...) {
@@ -164,7 +194,22 @@ Java_com_pulp_PulpActivity_nativeOnDisplayChanged(
     try {
         PULP_LOGI("nativeOnDisplayChanged: %dx%d density=%.1f dark=%d",
                   width, height, density, darkMode);
-        // TODO: Update view hierarchy layout and theme
+        // Publish display + color scheme together (#342). width/height
+        // from the Kotlin side arrive as CSS-pixel equivalents: Android
+        // reports physical pixels, so we divide by density for the
+        // logical size and keep physical_* for the raw resolution.
+        namespace pp = pulp::platform;
+        auto s = pp::Environment::instance().snapshot();
+        s.display.physical_width  = static_cast<int>(width);
+        s.display.physical_height = static_cast<int>(height);
+        s.display.scale = density > 0.0f ? static_cast<float>(density) : 1.0f;
+        s.display.width  = s.display.scale > 0.0f
+            ? static_cast<float>(width)  / s.display.scale : static_cast<float>(width);
+        s.display.height = s.display.scale > 0.0f
+            ? static_cast<float>(height) / s.display.scale : static_cast<float>(height);
+        s.color_scheme = darkMode ? pp::ColorScheme::dark
+                                  : pp::ColorScheme::light;
+        pp::Environment::instance().publish(s);
     } catch (const std::exception& e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
     } catch (...) {

--- a/core/platform/src/android/jni_bridge.cpp
+++ b/core/platform/src/android/jni_bridge.cpp
@@ -218,6 +218,71 @@ Java_com_pulp_PulpActivity_nativeOnDisplayChanged(
     }
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_pulp_PulpActivity_nativeOnOrientationChanged(
+    JNIEnv* env, jobject thiz, jint orientation) {
+    try {
+        PULP_LOGI("nativeOnOrientationChanged: %d", orientation);
+        // Kotlin side's orientationToEnum() maps Android's
+        // Configuration.ORIENTATION_* into Pulp's Orientation enum
+        // (declared in environment.hpp). The mapping is documented
+        // there; this is just a numeric pass-through.
+        namespace pp = pulp::platform;
+        auto s = pp::Environment::instance().snapshot();
+        s.orientation = static_cast<pp::Orientation>(orientation);
+        pp::Environment::instance().publish(s);
+    } catch (const std::exception& e) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    } catch (...) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"),
+                      "Unknown C++ exception in nativeOnOrientationChanged");
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_pulp_PulpActivity_nativeOnSafeAreaChanged(
+    JNIEnv* env, jobject thiz,
+    jfloat top, jfloat bottom, jfloat left, jfloat right) {
+    try {
+        PULP_LOGI("nativeOnSafeAreaChanged: top=%.1f bottom=%.1f left=%.1f right=%.1f",
+                  top, bottom, left, right);
+        namespace pp = pulp::platform;
+        auto s = pp::Environment::instance().snapshot();
+        s.safe_area.top    = static_cast<float>(top);
+        s.safe_area.bottom = static_cast<float>(bottom);
+        s.safe_area.left   = static_cast<float>(left);
+        s.safe_area.right  = static_cast<float>(right);
+        pp::Environment::instance().publish(s);
+    } catch (const std::exception& e) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    } catch (...) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"),
+                      "Unknown C++ exception in nativeOnSafeAreaChanged");
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_pulp_PulpActivity_nativeOnKeyboardChanged(
+    JNIEnv* env, jobject thiz, jfloat bottom) {
+    try {
+        PULP_LOGI("nativeOnKeyboardChanged: bottom=%.1f", bottom);
+        namespace pp = pulp::platform;
+        auto s = pp::Environment::instance().snapshot();
+        s.keyboard.bottom = static_cast<float>(bottom);
+        // Android's basic WindowInsetsCompat doesn't surface animation
+        // duration here — that lives on WindowInsetsAnimationCompat,
+        // which is a frame-by-frame callback API. Leave 0 until the
+        // animation plumbing is added in a follow-up PR.
+        s.keyboard.animation_duration = 0.0f;
+        pp::Environment::instance().publish(s);
+    } catch (const std::exception& e) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    } catch (...) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"),
+                      "Unknown C++ exception in nativeOnKeyboardChanged");
+    }
+}
+
 // ── Audio Focus JNI Callbacks ─────────────────────────────────────────────
 
 extern "C" JNIEXPORT void JNICALL

--- a/core/platform/src/environment.cpp
+++ b/core/platform/src/environment.cpp
@@ -1,0 +1,120 @@
+#include <pulp/platform/environment.hpp>
+
+#include <utility>
+
+namespace pulp::platform {
+
+// ── Token ──────────────────────────────────────────────────────────────────
+
+Environment::Token::Token(Token&& other) noexcept
+    : id_(other.id_) {
+    other.id_ = 0;
+}
+
+Environment::Token& Environment::Token::operator=(Token&& other) noexcept {
+    if (this != &other) {
+        reset();
+        id_ = other.id_;
+        other.id_ = 0;
+    }
+    return *this;
+}
+
+void Environment::Token::reset() noexcept {
+    if (id_ != 0) {
+        Environment::instance().unsubscribe(id_);
+        id_ = 0;
+    }
+}
+
+// ── Environment ────────────────────────────────────────────────────────────
+
+Environment& Environment::instance() {
+    // Function-local static — initialized on first use, destroyed at
+    // process exit in reverse order of construction. Safe under C++11
+    // magic-statics (Itanium ABI / MSVC 2015+).
+    static Environment env;
+    return env;
+}
+
+EnvironmentState Environment::snapshot() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return state_;
+}
+
+Environment::Token Environment::subscribe(Listener listener) {
+    if (!listener) return Token{};
+    std::lock_guard<std::mutex> lock(mu_);
+    uint64_t id = next_id_++;
+    listeners_.push_back(Entry{id, std::move(listener)});
+    return Token{id};
+}
+
+void Environment::unsubscribe(uint64_t id) {
+    std::lock_guard<std::mutex> lock(mu_);
+    for (auto it = listeners_.begin(); it != listeners_.end(); ++it) {
+        if (it->id == id) {
+            listeners_.erase(it);
+            return;
+        }
+    }
+}
+
+namespace {
+
+EnvironmentChange diff(const EnvironmentState& prev, const EnvironmentState& next) {
+    EnvironmentChange c;
+    const auto& a = prev.display;
+    const auto& b = next.display;
+    c.display = (a.width != b.width) || (a.height != b.height)
+             || (a.physical_width != b.physical_width)
+             || (a.physical_height != b.physical_height)
+             || (a.scale != b.scale) || (a.refresh_hz != b.refresh_hz)
+             || (a.name != b.name);
+    const auto& sa = prev.safe_area;
+    const auto& sb = next.safe_area;
+    c.safe_area = (sa.top != sb.top) || (sa.bottom != sb.bottom)
+               || (sa.left != sb.left) || (sa.right != sb.right);
+    c.keyboard = (prev.keyboard.bottom != next.keyboard.bottom)
+              || (prev.keyboard.animation_duration
+                  != next.keyboard.animation_duration);
+    c.orientation     = (prev.orientation     != next.orientation);
+    c.color_scheme    = (prev.color_scheme    != next.color_scheme);
+    c.lifecycle       = (prev.lifecycle       != next.lifecycle);
+    c.memory_pressure = (prev.memory_pressure != next.memory_pressure);
+    return c;
+}
+
+} // namespace
+
+void Environment::publish(const EnvironmentState& next) {
+    // Compute diff + take snapshot of listeners under the lock, then
+    // invoke listeners outside the lock so a callback that drops a token
+    // (and calls back into unsubscribe) doesn't deadlock.
+    std::vector<Entry> listeners_copy;
+    EnvironmentChange change;
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        change = diff(state_, next);
+        if (!change.any()) return;
+        state_ = next;
+        listeners_copy = listeners_;
+    }
+    for (const auto& entry : listeners_copy) {
+        entry.fn(next, change);
+    }
+}
+
+void Environment::inject_for_test(const EnvironmentState& state) {
+    instance().publish(state);
+}
+
+void Environment::reset_for_test() {
+    auto& env = instance();
+    std::lock_guard<std::mutex> lock(env.mu_);
+    env.state_ = EnvironmentState{};
+    env.listeners_.clear();
+    env.next_id_ = 1;
+}
+
+} // namespace pulp::platform

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -183,6 +183,38 @@ target_sources(pulp-view PRIVATE
 # AU/VST3/CLAP plugins.
 # The ObjC runtime loads WebKit on dylib load if any WKWebView references exist,
 # which crashes Logic Pro's sandboxed AUHostingServiceXPC process.
+# ── Linux ATK accessibility (#18 phase 1) ───────────────────────────────────
+#
+# Pulp publishes accessibility info to Linux screen readers (Orca) via
+# ATK + the at-spi2-atk bridge. This slice only wires the ATK headers
+# into the build so accessibility_linux.cpp can use the real AtkRole
+# enum instead of hard-coded integer constants. The full AtkObject
+# vtable + at-spi2 bridge runtime is a follow-up PR that needs
+# screen-reader validation on a real Linux desktop.
+#
+# Without libatk-dev, accessibility_linux.cpp keeps the pre-existing
+# fallback constants so contributors on minimal images still build.
+#
+# Install on Debian/Ubuntu: sudo apt install -y libatk1.0-dev
+if(UNIX AND NOT APPLE AND NOT ANDROID)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PULP_ATK QUIET IMPORTED_TARGET atk)
+        if(PULP_ATK_FOUND)
+            target_compile_definitions(pulp-view PRIVATE PULP_HAS_ATK=1)
+            target_link_libraries(pulp-view PRIVATE PkgConfig::PULP_ATK)
+            message(STATUS
+                "Pulp: Linux ATK ${PULP_ATK_VERSION} found — "
+                "accessibility_linux.cpp will use real AtkRole enum")
+        else()
+            message(STATUS
+                "Pulp: Linux ATK dev headers not found "
+                "(install: sudo apt install libatk1.0-dev) — "
+                "accessibility_linux.cpp will use stub constants")
+        endif()
+    endif()
+endif()
+
 option(PULP_BUILD_WEBVIEW "Include native WebView support (WebKit / WebView2 / WebKitGTK)" OFF)
 if(PULP_BUILD_WEBVIEW)
     target_sources(pulp-view PRIVATE src/web_view.cpp)

--- a/core/view/platform/linux/accessibility_linux.cpp
+++ b/core/view/platform/linux/accessibility_linux.cpp
@@ -17,9 +17,14 @@
 #include <pulp/view/view.hpp>
 #include <pulp/runtime/log.hpp>
 
-// PULP_HAS_ATSPI is set by CMake when atk-bridge-2.0 is found via
-// pkg-config. When unset, the init path stays a no-op so Linux distros
-// without the bridge (minimal / headless CI images) still link.
+// PULP_HAS_ATK is set by CMake when atk is found via pkg-config; this
+// gives us the real AtkRole enum so the role mapping below survives any
+// future renumbering by GNOME. PULP_HAS_ATSPI is set when the at-spi2
+// bridge runtime is also linkable — that path is currently a stub and
+// is filled in by the follow-up PR that adds AtkObject implementations.
+#ifdef PULP_HAS_ATK
+#include <atk/atk.h>
+#endif
 #ifdef PULP_HAS_ATSPI
 extern "C" {
 int  atk_bridge_adaptor_init(int* argc, char*** argv);
@@ -29,18 +34,31 @@ void atk_bridge_adaptor_cleanup(void);
 
 namespace pulp::view {
 
-// Map Pulp AccessRole to ATK role constants
-// These match the AtkRole enum from atk/atk.h
+// Map Pulp AccessRole to ATK role values. With PULP_HAS_ATK we use the
+// AtkRole enum directly; without it we fall back to the integer values
+// from ATK 2.52 so headless CI images without libatk-dev still link.
 static int access_role_to_atk_role(View::AccessRole role) {
+#ifdef PULP_HAS_ATK
+    switch (role) {
+        case View::AccessRole::slider: return ATK_ROLE_SLIDER;
+        case View::AccessRole::toggle: return ATK_ROLE_TOGGLE_BUTTON;
+        case View::AccessRole::label:  return ATK_ROLE_LABEL;
+        case View::AccessRole::group:  return ATK_ROLE_PANEL;
+        case View::AccessRole::meter:  return ATK_ROLE_PROGRESS_BAR;
+        case View::AccessRole::image:  return ATK_ROLE_IMAGE;
+        default:                       return ATK_ROLE_UNKNOWN;
+    }
+#else
     switch (role) {
         case View::AccessRole::slider: return 34;  // ATK_ROLE_SLIDER
         case View::AccessRole::toggle: return 42;  // ATK_ROLE_TOGGLE_BUTTON
         case View::AccessRole::label:  return 24;  // ATK_ROLE_LABEL
-        case View::AccessRole::group:  return 35;  // ATK_ROLE_PANEL (container)
+        case View::AccessRole::group:  return 35;  // ATK_ROLE_PANEL
         case View::AccessRole::meter:  return 33;  // ATK_ROLE_PROGRESS_BAR
         case View::AccessRole::image:  return 21;  // ATK_ROLE_IMAGE
-        default: return 66; // ATK_ROLE_UNKNOWN
+        default:                       return 66;  // ATK_ROLE_UNKNOWN
     }
+#endif
 }
 
 // Stub: Initialize AT-SPI accessibility for a view tree

--- a/setup.sh
+++ b/setup.sh
@@ -309,6 +309,31 @@ ensure_shared_archive_source() {
     )
 }
 
+# Retry a git network command up to 3 times with exponential backoff.
+# GitHub occasionally returns 5xx on git-over-https; without retry any
+# transient outage fails the whole CI job. Applies to clone/fetch/
+# submodule-update (the VST3 SDK in particular has five sub-submodules,
+# any of which failing aborts the lot). See #418.
+retry_git() {
+    local label="$1"
+    shift
+    local attempts=3
+    local sleep_s=5
+    local i
+    for i in $(seq 1 $attempts); do
+        if "$@"; then
+            return 0
+        fi
+        if [ "$i" -lt "$attempts" ]; then
+            info "$label git attempt $i/$attempts failed; retrying in ${sleep_s}s..."
+            sleep "$sleep_s"
+            sleep_s=$((sleep_s * 2))
+        fi
+    done
+    warn "$label git command failed after $attempts attempts"
+    return 1
+}
+
 ensure_shared_git_source() {
     local label="$1"
     local repo="$2"
@@ -351,9 +376,9 @@ ensure_shared_git_source() {
                     fi
                 fi
             elif ! dry "git clone --filter=blob:none $repo $target"; then
-                if ! git clone --filter=blob:none "$repo" "$target" >/dev/null 2>&1; then
-                    git clone "$repo" "$target"
-                fi
+                # Network clone: retry to tolerate transient GitHub blips.
+                retry_git "$label clone" \
+                    git clone --filter=blob:none "$repo" "$target"
             fi
 
             current_remote="$(git -C "$target" remote get-url origin 2>/dev/null || true)"
@@ -365,12 +390,14 @@ ensure_shared_git_source() {
 
         if ! git -C "$target" cat-file -e "${ref}^{commit}" 2>/dev/null; then
             info "Updating shared $label source cache to include $ref..."
-            dry "git -C $target fetch --tags origin" || git -C "$target" fetch --tags origin
+            dry "git -C $target fetch --tags origin" || \
+                retry_git "$label fetch --tags" git -C "$target" fetch --tags origin
         fi
 
         if ! git -C "$target" cat-file -e "${ref}^{commit}" 2>/dev/null; then
             info "Fetching explicit shared $label ref $ref..."
-            dry "git -C $target fetch --force origin $ref" || git -C "$target" fetch --force origin "$ref"
+            dry "git -C $target fetch --force origin $ref" || \
+                retry_git "$label fetch $ref" git -C "$target" fetch --force origin "$ref"
             checkout_ref="FETCH_HEAD"
         fi
 
@@ -381,8 +408,12 @@ ensure_shared_git_source() {
         fi
 
         if [ -f "$target/.gitmodules" ]; then
+            # submodule update fetches over the network per sub-submodule
+            # (e.g. VST3 SDK has 5 sub-submodules). Retry the whole thing
+            # so one transient failure doesn't cost a full CI cycle (#402).
             dry "git -c protocol.file.allow=always -C $target submodule update --init --recursive" || \
-                git -c protocol.file.allow=always -C "$target" submodule update --init --recursive
+                retry_git "$label submodule update" \
+                    git -c protocol.file.allow=always -C "$target" submodule update --init --recursive
         fi
     )
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -472,6 +472,11 @@ add_executable(pulp-test-permissions test_permissions.cpp)
 target_link_libraries(pulp-test-permissions PRIVATE pulp::platform Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-permissions)
 
+# Environment API tests (#342)
+add_executable(pulp-test-environment test_environment.cpp)
+target_link_libraries(pulp-test-environment PRIVATE pulp::platform Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-environment)
+
 # Runtime tests
 add_executable(pulp-test-runtime test_runtime.cpp)
 target_link_libraries(pulp-test-runtime PRIVATE pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -1,0 +1,194 @@
+// Unit tests for the unified environment API (#342).
+//
+// The Environment singleton is a process-wide notifier; tests reset it
+// in each TEST_CASE so prior tests don't leak listeners or stale state.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/environment.hpp>
+
+#include <atomic>
+
+using namespace pulp::platform;
+
+namespace {
+
+EnvironmentState make_state(ColorScheme scheme,
+                            float scale = 2.0f,
+                            float kbd = 0.0f) {
+    EnvironmentState s;
+    s.display.width = 800;
+    s.display.height = 600;
+    s.display.scale = scale;
+    s.color_scheme = scheme;
+    s.keyboard.bottom = kbd;
+    s.lifecycle = LifecycleState::foreground;
+    s.orientation = Orientation::portrait;
+    return s;
+}
+
+} // namespace
+
+TEST_CASE("Environment: singleton state defaults are sentinel-safe", "[environment]") {
+    Environment::reset_for_test();
+    auto s = Environment::instance().snapshot();
+    REQUIRE(s.color_scheme    == ColorScheme::unknown);
+    REQUIRE(s.lifecycle       == LifecycleState::unknown);
+    REQUIRE(s.orientation     == Orientation::unknown);
+    REQUIRE(s.memory_pressure == MemoryPressure::normal);
+    REQUIRE(s.safe_area.is_zero());
+    REQUIRE(s.keyboard.bottom == 0.0f);
+}
+
+TEST_CASE("Environment: subscribe receives publish + correct change mask",
+          "[environment]") {
+    Environment::reset_for_test();
+    int dark_calls = 0;
+    EnvironmentChange last_change;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            if (s.color_scheme == ColorScheme::dark) ++dark_calls;
+            last_change = c;
+        });
+
+    // First publish — color scheme changes from unknown -> dark, scale
+    // from 1 -> 2, lifecycle from unknown -> foreground, etc. Many flags.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(dark_calls == 1);
+    REQUIRE(last_change.color_scheme);
+    REQUIRE(last_change.lifecycle);
+    REQUIRE(last_change.display);
+
+    // Idempotent publish — no change, no callback.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(dark_calls == 1);
+
+    // Color scheme flip alone — only that bit set.
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(dark_calls == 1);
+    REQUIRE(last_change.color_scheme);
+    REQUIRE_FALSE(last_change.display);
+    REQUIRE_FALSE(last_change.lifecycle);
+}
+
+TEST_CASE("Environment: token RAII unsubscribes", "[environment]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    {
+        auto token = Environment::instance().subscribe(
+            [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+        Environment::inject_for_test(make_state(ColorScheme::dark));
+        REQUIRE(calls == 1);
+    } // token dropped → unsubscribed
+
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: token move transfers ownership", "[environment]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto sub = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(sub.valid());
+
+    auto moved = std::move(sub);
+    REQUIRE(moved.valid());
+    REQUIRE_FALSE(sub.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: keyboard inset change propagates separately",
+          "[environment]") {
+    Environment::reset_for_test();
+    EnvironmentChange last;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange c) { last = c; });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark, 2.0f, 0.0f));
+    Environment::inject_for_test(make_state(ColorScheme::dark, 2.0f, 320.0f));
+    REQUIRE(last.keyboard);
+    REQUIRE_FALSE(last.color_scheme);
+    REQUIRE_FALSE(last.display);
+}
+
+TEST_CASE("Environment: safe-area diff detection across all four edges",
+          "[environment]") {
+    Environment::reset_for_test();
+    EnvironmentChange last;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange c) { last = c; });
+
+    auto base = make_state(ColorScheme::dark);
+    Environment::inject_for_test(base);
+
+    auto with_inset = base;
+    with_inset.safe_area.top = 47.0f;
+    Environment::inject_for_test(with_inset);
+    REQUIRE(last.safe_area);
+
+    // Bottom-only change.
+    auto bottom = with_inset;
+    bottom.safe_area.bottom = 34.0f;
+    Environment::inject_for_test(bottom);
+    REQUIRE(last.safe_area);
+    REQUIRE_FALSE(last.color_scheme);
+}
+
+TEST_CASE("Environment: memory pressure transitions", "[environment]") {
+    Environment::reset_for_test();
+    int observed = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            if (c.memory_pressure
+                && s.memory_pressure == MemoryPressure::critical) {
+                ++observed;
+            }
+        });
+
+    auto base = make_state(ColorScheme::dark);
+    Environment::inject_for_test(base);
+
+    auto moderate = base;
+    moderate.memory_pressure = MemoryPressure::moderate;
+    Environment::inject_for_test(moderate);
+    REQUIRE(observed == 0);
+
+    auto critical = base;
+    critical.memory_pressure = MemoryPressure::critical;
+    Environment::inject_for_test(critical);
+    REQUIRE(observed == 1);
+}
+
+TEST_CASE("Environment: callback that drops its own token does not deadlock",
+          "[environment]") {
+    Environment::reset_for_test();
+    std::unique_ptr<Environment::Token> token;
+    token = std::make_unique<Environment::Token>(
+        Environment::instance().subscribe(
+            [&](const EnvironmentState&, EnvironmentChange) {
+                token.reset();  // unsubscribe from inside the callback
+            }));
+
+    // If publish() held the mutex during dispatch, this would deadlock
+    // when the listener calls back into unsubscribe.
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    SUCCEED("no deadlock");
+}
+
+TEST_CASE("Environment: snapshot is consistent with last publish",
+          "[environment]") {
+    Environment::reset_for_test();
+    auto s = make_state(ColorScheme::light, 1.5f, 220.0f);
+    s.orientation = Orientation::landscape_left;
+    s.safe_area.top = 22.0f;
+    Environment::inject_for_test(s);
+
+    auto got = Environment::instance().snapshot();
+    REQUIRE(got.color_scheme    == ColorScheme::light);
+    REQUIRE(got.orientation     == Orientation::landscape_left);
+    REQUIRE(got.display.scale   == 1.5f);
+    REQUIRE(got.keyboard.bottom == 220.0f);
+    REQUIRE(got.safe_area.top   == 22.0f);
+}


### PR DESCRIPTION
Stacked on #403 (env API). Completes the orientation/safe-area/keyboard plumbing flagged as follow-up in #407.

## Kotlin side (PulpActivity.kt)

- `onCreate` publishes initial orientation + safe-area + keyboard insets
- `ViewCompat.setOnApplyWindowInsetsListener` catches:
  - systemBars insets (notch, status/nav bars, split-screen) → safe-area
  - ime inset bottom minus systemBars bottom → keyboard additional padding
- `onConfigurationChanged` re-publishes orientation

## JNI additions

- `nativeOnOrientationChanged(Int)`
- `nativeOnSafeAreaChanged(Float, Float, Float, Float)`
- `nativeOnKeyboardChanged(Float)`

All forward into `Environment::publish` via snapshot/mutate/publish.

## Out of scope

Keyboard `animation_duration` stays 0. WindowInsetsAnimationCompat is a per-frame callback (not a single event) — separate follow-up.

## Test plan

- [x] macOS Debug builds unaffected (file is `#ifdef __ANDROID__` gated)
- [ ] CI Android build links the new JNI entry points
- [ ] Manual: rotate device + open soft keyboard in the demo app, confirm C++ env listener gets callbacks with expected values