### PR TITLE
docs: GitHub issue templates (bug report + feature request) (#413)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,114 @@
+name: Bug report
+description: Pulp crashed, misbehaved, or produced wrong output
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for filing a bug. The more specific the repro, the faster
+        someone can land a fix. If you'd like Pulp to collect a diagnostic
+        bundle (anonymized; you see every file before upload), run
+        `pulp report bug` and attach the resulting bundle — the CLI
+        redacts your home directory, username, hostname, IPs, MAC
+        addresses, and common secret patterns before producing anything.
+
+  - type: input
+    id: summary
+    attributes:
+      label: One-line summary
+      placeholder: "e.g. CLAP adapter drops first MIDI note on every process() call"
+    validations:
+      required: true
+
+  - type: input
+    id: pulp_version
+    attributes:
+      label: Pulp version
+      description: Run `pulp version` if you have the CLI, or paste the commit SHA for a from-source build.
+      placeholder: "e.g. 0.20.0 or commit abc1234"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS + version
+      placeholder: "macOS 15.2 (arm64) / Ubuntu 24.04 / Windows 11 24H2 / iPadOS 18 / Android 14"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: format
+    attributes:
+      label: Plugin format(s) in use
+      multiple: true
+      options:
+        - Standalone
+        - VST3
+        - Audio Unit (AU v2)
+        - Audio Unit (AU v3 / AUv3)
+        - CLAP
+        - AAX
+        - LV2
+        - Other / N/A
+    validations:
+      required: true
+
+  - type: input
+    id: host
+    attributes:
+      label: Host / DAW + version
+      description: Leave blank if the bug reproduces in standalone.
+      placeholder: "e.g. Logic Pro 11.1 / Ableton Live 12.0.5 / REAPER 7.30"
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The tighter the repro, the faster the fix.
+      placeholder: |
+        1. Open Pulp standalone
+        2. Load Pulp Compressor preset "FX bus"
+        3. Start playback
+        4. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_actual
+    attributes:
+      label: Expected vs actual behavior
+      placeholder: |
+        Expected: meter stays at -18 dBFS
+        Actual:   meter reads 0 dBFS after ~3 seconds
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / stack trace
+      description: >
+        Paste any crash log, stderr output, or `pulp doctor` output.
+        If you'd rather share a Pulp diagnostic bundle with automatic
+        anonymization, run `pulp report bug --attach` and drag the bundle
+        in below.
+      render: shell
+
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: Before filing
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: I'm on a supported platform per `docs/reference/capabilities.md`.
+          required: false
+
+  - type: markdown
+    attributes:
+      value: >
+        _Reference: JUCE's Projucer diagnostic bundle is prior art for the
+        CLI-side anonymization. Pulp's `report` subcommand is designed to be
+        agent- and CI-friendly — see #413 for the full scope._

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion / question / help
+    url: https://github.com/danielraffel/pulp/discussions
+    about: >
+      For open-ended questions, design conversations, or help using Pulp —
+      please open a discussion instead of an issue.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,120 @@
+name: Feature request
+description: Propose a new capability or improvement, and optionally volunteer to help
+title: "[feat]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Feature requests are how we prioritize. Clear proposals with concrete
+        use-cases land faster than wishlist items. If you're open to helping
+        build or test the feature — even a small slice — please say so
+        below. Pulp is agent- and human-friendly; both count.
+
+  - type: input
+    id: summary
+    attributes:
+      label: One-line summary
+      placeholder: "e.g. Expose per-parameter smoothing time on Binding"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: >
+        Describe the pain, the use-case, or the gap. Real workflows beat
+        abstract wishes.
+      placeholder: |
+        When building a synth with an envelope-shaped parameter, I want per-
+        param smoothing that follows the attack curve, but today all params
+        smooth on the same global time constant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API / UX / behavior
+      description: >
+        How should it work from the caller's perspective? Rough API sketches
+        are welcome. "I don't know, suggest one" is also a valid answer.
+      placeholder: |
+        Binding::set_smoothing_time(ms) on a per-binding basis, defaulting
+        to the StateStore global; UI would pick this up via Binding::poll().
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you try or think about? Why wasn't it enough?
+      placeholder: |
+        Tried wrapping Binding in a custom smoother, but then the UI side
+        doesn't know what the effective value is and meters lag.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Which area(s) of Pulp?
+      multiple: true
+      options:
+        - Plugin formats (VST3 / AU / CLAP / AAX / LV2)
+        - DSP / signal
+        - State / parameters
+        - UI / View / Canvas
+        - MIDI / MIDI CI
+        - Audio I/O / device layer
+        - Mobile (iOS / Android)
+        - Desktop standalone
+        - Web / WASM
+        - CLI / dev tooling
+        - Docs / examples
+        - CI / test infrastructure
+        - Accessibility
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: volunteer
+    attributes:
+      label: Would you like to help build or test this?
+      description: >
+        Completely optional — feature requests are welcome whether or not
+        you plan to contribute. If you're interested, saying so here helps
+        maintainers reach out and scope work with you.
+      options:
+        - "No — just requesting"
+        - "I could test a prototype or provide feedback"
+        - "I could help design the API"
+        - "I could write a patch with guidance"
+        - "I could drive the implementation end-to-end"
+    validations:
+      required: true
+
+  - type: input
+    id: timebox
+    attributes:
+      label: How urgent is this for you?
+      description: Rough deadline or project context, if any — helps with triage.
+      placeholder: "e.g. blocking my v1 release in June / nice-to-have"
+
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: Before filing
+      options:
+        - label: I searched existing issues and discussions and didn't find a duplicate.
+          required: true
+        - label: I've skimmed `VISION.md` and this request aligns with Pulp's direction (or I'm explicitly proposing a directional change).
+          required: false
+
+  - type: markdown
+    attributes:
+      value: >
+        _Pulp keeps a "help wanted" label and a low-friction PR flow — see
+        `CONTRIBUTING.md`. Volunteering is never a commitment; we'll always
+        confirm scope with you before assigning._


### PR DESCRIPTION
## Summary

Closes the issue-template portion of #413 — the bug report form references
`pulp report bug` for anonymized diagnostic bundle donation (redacts \$HOME,
username, hostname, IPs, MACs, and common secret patterns before upload),
and the feature request form volunteers a checkbox ladder (\"I could test a
prototype\" → \"I could drive implementation end-to-end\") so contributors
can opt in without it feeling like a commitment.

`config.yml` disables blank issues and points open-ended questions to the
Discussions tab, keeping Issues focused on actionable bugs/features.

## Test plan

- [x] YAML parses locally (`yq`/issue-form YAML, standard GitHub form spec)
- [ ] Merge to `main` and confirm GitHub renders the forms in the \"New issue\" flow
- [ ] File one sample issue per template to confirm labels (`bug` / `enhancement`) and the \"Discussions\" contact link behave as expected

## Relates

- Implements bug-report + feature-request templates for #413
- The CLI `pulp report bug` anonymization flow referenced in the bug template is tracked separately (also in #413)