### PR TITLE
docs(aax skill): document sysex accumulator pattern #408 landed

### DIFF
--- a/.agents/skills/aax/SKILL.md
+++ b/.agents/skills/aax/SKILL.md
@@ -112,6 +112,38 @@ Notes:
 - On Linux or Ubuntu, explain that AAX is unsupported and remove `AAX` from `FORMATS`.
 - If validation reports that a bundle exists but the plugin binary is missing, build the target before validating it.
 
+## Gotchas
+
+### MIDI sysex accumulator
+
+AAX splits multi-byte sysex (F0 … F7) across sequential `AAX_CMidiPacket`
+entries — the first packet carries the F0 status byte, continuation
+packets can appear with no status byte, and the final packet carries F7.
+Each packet's `mData` field is at most 4 bytes. A single-packet decoder
+will silently drop everything after the first 4 sysex bytes, and the
+host will never see the real message.
+
+The correct shape is a per-node accumulator:
+
+```cpp
+std::vector<uint8_t> sysex_buffer;
+bool sysex_in_progress = false;
+int32_t sysex_start_offset = 0;
+// for each packet in the node's buffer:
+//   if byte == 0xF0 → start accumulator, capture start_offset from mTimestamp
+//   while sysex_in_progress → append every payload byte (no status-byte requirement)
+//   if byte == 0xF7 → flush accumulator as one MidiEvent, reset
+```
+
+This matches the shape used for CLAP/VST3/AU/CoreMIDI/ALSA sysex (#239).
+See `core/format/src/aax_runtime.cpp::decode_midi_node` for the canonical
+implementation landed in #408.
+
+When adding or changing any AAX MIDI input path, exercise this against a
+multi-packet sysex vector (at least one packet across the 4-byte boundary
+and one terminator-only packet) in a unit test. Shipping without the test
+is the #290 "tests ship with fixes" rule.
+
 ## Review Checklist
 
 After any AAX-related change:


### PR DESCRIPTION
## Summary

Captures the non-obvious shape of AAX's MIDI sysex delivery so the next
agent or human touching an AAX MIDI path doesn't silently drop bytes
past the first 4-byte packet. Adds a \`## Gotchas\` section to the AAX
skill with:

- How AAX fragments F0…F7 across \`AAX_CMidiPacket\` entries
- The \`sysex_in_progress\` accumulator shape the #408 fix adopted
- A pointer at \`core/format/src/aax_runtime.cpp::decode_midi_node\`
- A reminder that any new AAX MIDI input path needs a multi-packet
  sysex unit test (per the \`tests ship with fixes\` rule #290)

Triggered by the \`feedback_aax_parity\` rule: when we fix CLAP/VST3/AU
or platform MIDI drivers, we should leave the AAX knowledge capture
trail behind us, not just the code.

## Test plan

- [x] Skill-sync check passes locally (aax skill counted as updated)
- [ ] Skill still renders correctly in the agent surface (plain markdown)