### PR TITLE
docs(support-matrix): reflect shipped Win32 + ALSA sysex

### DIFF
--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -35,8 +35,8 @@ The following section is auto-generated from the `limitations:` block of `docs/s
 | `audio_io.alsa` | Hardcoded sample-rate list; no real enumeration. | [link](planning/production-readiness/02-audio-midi-io.md#2.2) |
 | `audio_io.jack` | Dead code — factory always returns AlsaSystem; JACK is never selected at runtime. | [link](planning/production-readiness/02-audio-midi-io.md#2.2) |
 | `midi_io.coremidi` | UMP type-4 (MIDI 2.0 channel voice) packets are silently dropped in the input handler. | [link](planning/production-readiness/02-audio-midi-io.md#2.6) |
-| `midi_io.win32_midi` | Legacy mmeapi; no windows.devices.midi2, no hotplug, no SysEx input. | [link](planning/production-readiness/02-audio-midi-io.md#2.4) |
-| `midi_io.alsa_midi` | Running status not handled; timestamps always 0; no hotplug; no SysEx. | [link](planning/production-readiness/02-audio-midi-io.md#2.5) |
+| `midi_io.win32_midi` | Legacy mmeapi; no windows.devices.midi2, no hotplug. SysEx input routed via MIM_LONGDATA; WinRT MIDI runtime still pending. | [link](planning/production-readiness/02-audio-midi-io.md#2.4) |
+| `midi_io.alsa_midi` | Running status not handled; timestamps always 0; no hotplug. SysEx input accumulator landed; CoreMIDI SysEx7 reassembly still pending (#405). | [link](planning/production-readiness/02-audio-midi-io.md#2.5) |
 | `platform_maturity.accessibility.windows` | UIA provider tree and event emission pending (bootstrap in place via #283). | [link](planning/production-readiness/04-accessibility.md#4.1) |
 | `platform_maturity.accessibility.linux` | AT-SPI per-view accessible objects and events pending (bridge bootstrap in place via #280). | [link](planning/production-readiness/04-accessibility.md#4.2) |
 <!-- generated:end id=limitations -->

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -812,10 +812,10 @@ limitations:
     - text: "UMP type-4 (MIDI 2.0 channel voice) packets are silently dropped in the input handler."
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.6"
   midi_io.win32_midi:
-    - text: "Legacy mmeapi; no windows.devices.midi2, no hotplug, no SysEx input."
+    - text: "Legacy mmeapi; no windows.devices.midi2, no hotplug. SysEx input routed via MIM_LONGDATA; WinRT MIDI runtime still pending."
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.4"
   midi_io.alsa_midi:
-    - text: "Running status not handled; timestamps always 0; no hotplug; no SysEx."
+    - text: "Running status not handled; timestamps always 0; no hotplug. SysEx input accumulator landed; CoreMIDI SysEx7 reassembly still pending (#405)."
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.5"
   platform_maturity.accessibility.windows:
     # UIA bootstrap landed in PR #283 (UIAutomationCore linked, session


### PR DESCRIPTION
## Summary

Two MIDI-platform rows in \`docs/status/support-matrix.yaml\` still
claimed \"no SysEx input\" / \"no SysEx\" after the fixes actually
landed. Updates both rows + regenerated \`capabilities.md\` so the
public capability table matches the code.

- \`midi_io.win32_midi\` — #388 (e9c7b469) shipped MIM_LONGDATA SysEx input
- \`midi_io.alsa_midi\` — #406 shipped the raw-midi SysEx accumulator

CoreMIDI SysEx7 reassembly (#405) is still pending and is explicitly
called out as the remaining piece.

## Test plan

- [x] \`tools/check-docs.sh\` passes (only pre-existing warnings)
- [x] \`tools/docs_generate.py\` regenerates \`capabilities.md\` with the new wording
- [x] YAML still parses via the existing loader in \`tools/docs_generate.py\`