### PR TITLE
ci: widen windows alias to also gate on MSVC release-path (#438 P1, #416)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -347,16 +347,19 @@ jobs:
           fi
 
   windows:
-    needs: build
+    needs: [build, windows-msvc-release-gate]
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: Gate on build matrix
+      - name: Gate on build matrix + MSVC release-path
         run: |
-          if [ "${{ needs.build.result }}" = "success" ]; then
-            echo "build matrix succeeded — Windows gate ✓"
+          build_ok="${{ needs.build.result }}"
+          msvc_ok="${{ needs.windows-msvc-release-gate.result }}"
+          if [ "$build_ok" = "success" ] && [ "$msvc_ok" = "success" ]; then
+            echo "build matrix + MSVC release-path both green — Windows gate ✓"
             exit 0
           else
-            echo "build matrix result: ${{ needs.build.result }}"
+            echo "build matrix result: $build_ok"
+            echo "MSVC release-path result: $msvc_ok"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Addresses the P1 Codex review comment on #416 (see #438).

The stable-name \`windows\` alias currently only has \`needs: build\`,
which means a green build matrix + red \`Windows MSVC release-path gate\`
still reports \`windows\` ✓ to branch protection. That defeats the
entire point of the MSVC release-path gate — which existed specifically
because v0.15 / v0.16 / v0.17 shipped broken release pipelines after
MSVC-only errors slipped through the PR gate.

This PR expands the alias to depend on both the matrix and the MSVC
release-path gate, and fails if either is red.

## Test plan

- [x] YAML parses locally (actionlint-clean structure)
- [ ] On merge: verify \`windows\` alias now fires *after* \`Windows MSVC release-path gate\` completes (i.e. the alias run shows up later in the check list)
- [ ] On merge: intentionally-broken MSVC change on a test branch should turn the \`windows\` required context red

## Relates

- Closes the P1 item for #416 in #438
- Keeps \`linux\` + \`macos\` aliases unchanged (MSVC gate is Windows-only)