### PR TITLE
fix(midi): ALSA sysex accumulator recovers from aborted F0 (#438 P2 / #406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0200"></a>
+## [0.21.0]
+
 ## [0.20.0] - 2026-04-18
 
 - midi(win): MIM_LONGDATA SysEx + QPC timestamps (#19 / #245 partial) ([#388](https://github.com/danielraffel/pulp/pull/388))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.20.0
+    VERSION 0.21.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/raw_midi_parser.hpp
+++ b/core/midi/include/pulp/midi/raw_midi_parser.hpp
@@ -1,0 +1,132 @@
+// Raw-MIDI byte-stream parser — pulls short messages, sysex, and
+// realtime bytes out of a best-effort byte stream.
+//
+// Extracted into a pure helper so ALSA raw-midi, WinMM MIM_LONGDATA,
+// and any future raw-byte MIDI transport can share the same
+// accumulator logic and — more importantly — share a test suite.
+//
+// Not a public API; consumed from:
+//   core/midi/platform/linux/alsa_midi_device.cpp
+//   test/test_raw_midi_parser.cpp
+//
+// Design notes
+// ────────────
+// Sysex (F0..F7) is variable-length and can span multiple read() calls,
+// so the accumulator state (sysex_buffer / sysex_in_progress) lives on
+// the caller's RawMidiParserState and survives between invocations.
+//
+// MIDI 1.0 §3.1 allows real-time bytes (F8..FF) inside a sysex; they
+// are emitted inline and do NOT terminate the accumulator.
+//
+// A non-realtime status byte (0x80..0xF7, excluding 0xF7 itself which
+// terminates sysex) arriving mid-sysex means the device aborted the
+// F0 stream without sending F7 — common on disconnect or firmware
+// glitches. We drop the partial buffer and parse that status byte
+// as the start of a new message, rather than silently consuming the
+// next real message as sysex payload (#406 Codex P2).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace pulp::midi {
+
+// Typical device sysex dumps fit comfortably under 64 KB. If the
+// accumulator collects more without seeing F7, assume the device is
+// misbehaving and drop the buffer to cap memory use.
+inline constexpr std::size_t kRawMidiSysexLimit = 64 * 1024;
+
+struct RawMidiParserState {
+    std::vector<uint8_t> sysex_buffer;
+    bool sysex_in_progress = false;
+};
+
+// Short message = status byte + 0..2 data bytes (channel voice /
+// system common, excluding realtime and sysex).
+using RawMidiShortCallback =
+    std::function<void(uint8_t status, uint8_t d1, uint8_t d2)>;
+
+// Sysex callback fires once per complete F0..F7 run. The buffer passed
+// in includes the leading F0 and trailing F7.
+using RawMidiSysexCallback =
+    std::function<void(const std::vector<uint8_t>& buf)>;
+
+// Feed `n` bytes from `buf` into the parser. `state` holds cross-call
+// sysex accumulator state and must be preserved between calls. `on_short`
+// and `on_sysex` may be empty; callers that don't care about either
+// stream pass a null std::function.
+inline void parse_raw_midi_bytes(const uint8_t* buf,
+                                 std::size_t n,
+                                 RawMidiParserState& state,
+                                 const RawMidiShortCallback& on_short,
+                                 const RawMidiSysexCallback& on_sysex) {
+    for (std::size_t i = 0; i < n; ++i) {
+        const uint8_t b = buf[i];
+
+        // Real-time (F8..FF) passes through unconditionally, even
+        // inside a sysex run.
+        if (b >= 0xF8) {
+            if (on_short) on_short(b, 0, 0);
+            continue;
+        }
+
+        if (state.sysex_in_progress) {
+            if (b == 0xF7) {
+                state.sysex_buffer.push_back(b);
+                if (on_sysex) on_sysex(state.sysex_buffer);
+                state.sysex_buffer.clear();
+                state.sysex_in_progress = false;
+                continue;
+            }
+            // A new non-realtime status byte means the F0 stream was
+            // aborted. Drop the partial buffer and fall through so
+            // this byte can be parsed as the start of a new message.
+            if ((b & 0x80) != 0) {
+                state.sysex_buffer.clear();
+                state.sysex_in_progress = false;
+                // fall through
+            } else {
+                state.sysex_buffer.push_back(b);
+                if (state.sysex_buffer.size() > kRawMidiSysexLimit) {
+                    state.sysex_buffer.clear();
+                    state.sysex_in_progress = false;
+                }
+                continue;
+            }
+        }
+
+        if (b == 0xF0) {
+            state.sysex_buffer.clear();
+            state.sysex_buffer.push_back(b);
+            state.sysex_in_progress = true;
+            continue;
+        }
+
+        if ((b & 0x80) == 0) continue; // stray data byte
+
+        std::size_t msg_len = 3;
+        if ((b & 0xF0) == 0xC0 || (b & 0xF0) == 0xD0) {
+            msg_len = 2; // Program Change, Channel Pressure
+        } else if (b == 0xF1 || b == 0xF3) {
+            msg_len = 2; // MTC Quarter Frame, Song Select
+        } else if (b == 0xF2) {
+            msg_len = 3; // Song Position Pointer
+        } else if (b == 0xF6 || b == 0xF7) {
+            msg_len = 1; // Tune Request, stray End-of-Exclusive
+        }
+
+        if (i + msg_len <= n) {
+            if (on_short) {
+                on_short(b,
+                         msg_len > 1 ? buf[i + 1] : 0,
+                         msg_len > 2 ? buf[i + 2] : 0);
+            }
+            i += msg_len - 1; // outer ++i advances past the last byte
+        }
+    }
+}
+
+} // namespace pulp::midi

--- a/core/midi/platform/linux/alsa_midi_device.cpp
+++ b/core/midi/platform/linux/alsa_midi_device.cpp
@@ -1,4 +1,5 @@
 #include <pulp/midi/device.hpp>
+#include <pulp/midi/raw_midi_parser.hpp>
 #include <pulp/runtime/log.hpp>
 
 #ifndef __linux__
@@ -72,88 +73,30 @@ private:
                 break; // Error
             }
 
-            // Parse raw MIDI bytes into events. Sysex (F0..F7) is
-            // variable-length and can span multiple snd_rawmidi_read
-            // calls, so the accumulator state lives on the instance
-            // (sysex_buffer_, sysex_in_progress_). A real-time message
-            // (F8..FF) may appear INSIDE a sysex without terminating it
-            // — MIDI 1.0 §3.1 allows that for clock/start/stop. We emit
-            // the real-time message inline and keep collecting sysex
-            // bytes. #239.
-            for (ssize_t i = 0; i < n; ++i) {
-                uint8_t b = buf[i];
-
-                // Real-time messages (F8..FF) pass through unconditionally.
-                if (b >= 0xF8) {
+            // Parse raw MIDI bytes. Shared helper keeps the accumulator
+            // logic testable across ALSA and any future raw-byte MIDI
+            // transport (see raw_midi_parser.hpp). #239 / #406.
+            parse_raw_midi_bytes(
+                reinterpret_cast<const uint8_t*>(buf),
+                static_cast<std::size_t>(n),
+                parser_state_,
+                [this](uint8_t status, uint8_t d1, uint8_t d2) {
+                    if (!callback_) return;
                     MidiEvent evt;
-                    evt.message = choc::midi::ShortMessage(b, 0, 0);
+                    evt.message = choc::midi::ShortMessage(status, d1, d2);
                     evt.timestamp = 0.0;
-                    if (callback_) callback_(evt);
-                    continue;
-                }
-
-                // Inside a sysex: append until F7 terminator.
-                if (sysex_in_progress_) {
-                    sysex_buffer_.push_back(b);
-                    if (b == 0xF7) {
-                        if (sysex_callback_) {
-                            sysex_callback_(sysex_buffer_, 0.0);
-                        }
-                        sysex_buffer_.clear();
-                        sysex_in_progress_ = false;
-                    } else if (sysex_buffer_.size() > kSysexLimit) {
-                        // Runaway — drop rather than leak indefinitely.
-                        sysex_buffer_.clear();
-                        sysex_in_progress_ = false;
-                    }
-                    continue;
-                }
-
-                // Sysex start — begin accumulating.
-                if (b == 0xF0) {
-                    sysex_buffer_.clear();
-                    sysex_buffer_.push_back(b);
-                    sysex_in_progress_ = true;
-                    continue;
-                }
-
-                // Short message parsing (status + 1 or 2 data bytes).
-                if ((b & 0x80) == 0) continue; // stray data byte
-                int msg_len = 3;
-                if ((b & 0xF0) == 0xC0 || (b & 0xF0) == 0xD0) {
-                    msg_len = 2; // Program Change, Channel Pressure
-                } else if (b == 0xF1 || b == 0xF3) {
-                    msg_len = 2; // MTC Quarter Frame, Song Select
-                } else if (b == 0xF2) {
-                    msg_len = 3; // Song Position Pointer
-                } else if (b == 0xF6 || b == 0xF7) {
-                    msg_len = 1; // Tune Request, stray End-of-Exclusive
-                }
-
-                if (i + msg_len <= n) {
-                    MidiEvent evt;
-                    evt.message = choc::midi::ShortMessage(
-                        b,
-                        msg_len > 1 ? buf[i + 1] : 0,
-                        msg_len > 2 ? buf[i + 2] : 0);
-                    evt.timestamp = 0.0;
-                    if (callback_) callback_(evt);
-                    i += msg_len - 1; // loop's ++i advances past the last byte
-                }
-            }
+                    callback_(evt);
+                },
+                [this](const std::vector<uint8_t>& sysex) {
+                    if (sysex_callback_) sysex_callback_(sysex, 0.0);
+                });
         }
     }
-
-    // Runaway-guard: typical device sysex dumps fit comfortably under
-    // 64 KB. If we somehow collect more without seeing F7, assume the
-    // device is misbehaving and drop the accumulator.
-    static constexpr size_t kSysexLimit = 64 * 1024;
 
     snd_rawmidi_t* handle_ = nullptr;
     MidiInputCallback callback_;
     MidiSysexCallback sysex_callback_;
-    std::vector<uint8_t> sysex_buffer_;
-    bool sysex_in_progress_ = false;
+    RawMidiParserState parser_state_;
     bool is_open_ = false;
     std::atomic<bool> running_{false};
     std::thread read_thread_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -241,6 +241,13 @@ catch_discover_tests(pulp-test-midi-buffer-ump)
 add_executable(pulp-test-midi-buffer-sysex test_midi_buffer_sysex.cpp)
 target_link_libraries(pulp-test-midi-buffer-sysex PRIVATE pulp::midi Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-midi-buffer-sysex)
+# Raw MIDI byte-stream parser — shared by ALSA raw-midi and any future
+# raw-byte MIDI transport. Tests aborted-sysex recovery (#406 codex P2),
+# realtime-inside-sysex passthrough (#239), runaway cap, and multi-read
+# accumulator state.
+add_executable(pulp-test-raw-midi-parser test_raw_midi_parser.cpp)
+target_link_libraries(pulp-test-raw-midi-parser PRIVATE pulp::midi Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-raw-midi-parser)
 # Win MIDI MIM_LONGDATA SysEx + QPC timestamps (#19 / #245 partial).
 # Cross-platform — compiles everywhere; Windows-specific cases are
 # guarded behind #ifdef _WIN32.

--- a/test/test_raw_midi_parser.cpp
+++ b/test/test_raw_midi_parser.cpp
@@ -1,0 +1,152 @@
+// Tests for pulp::midi::parse_raw_midi_bytes — the shared raw-MIDI
+// byte-stream parser used by ALSA (and future transports).
+//
+// The canonical happy-path cases (single-packet sysex, short messages,
+// realtime passthrough) are covered by the higher-level ALSA path
+// when real hardware is present; these tests focus on behaviors that
+// can only be exercised with a synthetic byte stream:
+//
+//   - multi-read sysex spanning separate parse() calls
+//   - realtime bytes interleaved INSIDE a sysex run (MIDI 1.0 §3.1)
+//   - aborted sysex recovery (#406 Codex P2): a non-realtime status
+//     byte arriving mid-F0 must not swallow the next real message
+//   - runaway sysex cap (kRawMidiSysexLimit)
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/midi/raw_midi_parser.hpp>
+
+using namespace pulp::midi;
+
+namespace {
+
+struct Captured {
+    struct Short { uint8_t status, d1, d2; };
+    std::vector<Short> shorts;
+    std::vector<std::vector<uint8_t>> sysex;
+};
+
+Captured parse(std::initializer_list<uint8_t> bytes) {
+    Captured c;
+    RawMidiParserState state;
+    std::vector<uint8_t> buf(bytes);
+    parse_raw_midi_bytes(
+        buf.data(), buf.size(), state,
+        [&c](uint8_t s, uint8_t d1, uint8_t d2) {
+            c.shorts.push_back({s, d1, d2});
+        },
+        [&c](const std::vector<uint8_t>& sx) { c.sysex.push_back(sx); });
+    return c;
+}
+
+} // namespace
+
+TEST_CASE("raw_midi_parser emits short messages cleanly",
+          "[midi][raw_midi_parser]") {
+    // Note On + Program Change (2-byte) + Song Position (3-byte)
+    auto c = parse({0x90, 0x40, 0x7F,
+                    0xC0, 0x05,
+                    0xF2, 0x10, 0x20});
+    REQUIRE(c.shorts.size() == 3);
+    REQUIRE(c.shorts[0].status == 0x90);
+    REQUIRE(c.shorts[0].d1 == 0x40);
+    REQUIRE(c.shorts[0].d2 == 0x7F);
+    REQUIRE(c.shorts[1].status == 0xC0);
+    REQUIRE(c.shorts[1].d1 == 0x05);
+    REQUIRE(c.shorts[1].d2 == 0x00);
+    REQUIRE(c.shorts[2].status == 0xF2);
+    REQUIRE(c.shorts[2].d1 == 0x10);
+    REQUIRE(c.shorts[2].d2 == 0x20);
+    REQUIRE(c.sysex.empty());
+}
+
+TEST_CASE("raw_midi_parser accumulates sysex across calls",
+          "[midi][raw_midi_parser][issue-406]") {
+    RawMidiParserState state;
+    Captured c;
+    auto on_short = [&c](uint8_t s, uint8_t d1, uint8_t d2) {
+        c.shorts.push_back({s, d1, d2});
+    };
+    auto on_sysex = [&c](const std::vector<uint8_t>& sx) {
+        c.sysex.push_back(sx);
+    };
+
+    uint8_t chunk1[] = {0xF0, 0x7E, 0x00, 0x06};
+    uint8_t chunk2[] = {0x01, 0x02, 0xF7};
+    parse_raw_midi_bytes(chunk1, sizeof(chunk1), state, on_short, on_sysex);
+    REQUIRE(c.sysex.empty());
+    REQUIRE(state.sysex_in_progress);
+
+    parse_raw_midi_bytes(chunk2, sizeof(chunk2), state, on_short, on_sysex);
+    REQUIRE(c.sysex.size() == 1);
+    REQUIRE(c.sysex[0].size() == 7);
+    REQUIRE(c.sysex[0].front() == 0xF0);
+    REQUIRE(c.sysex[0].back() == 0xF7);
+    REQUIRE_FALSE(state.sysex_in_progress);
+}
+
+TEST_CASE("raw_midi_parser emits realtime inside sysex without terminating",
+          "[midi][raw_midi_parser][issue-239]") {
+    // F0 7E <clock F8 interleaved> 05 F7
+    auto c = parse({0xF0, 0x7E, 0xF8, 0x05, 0xF7});
+    REQUIRE(c.sysex.size() == 1);
+    REQUIRE(c.sysex[0] == std::vector<uint8_t>{0xF0, 0x7E, 0x05, 0xF7});
+    REQUIRE(c.shorts.size() == 1);
+    REQUIRE(c.shorts[0].status == 0xF8); // MIDI Clock
+}
+
+TEST_CASE("raw_midi_parser recovers from aborted sysex (#406 codex P2)",
+          "[midi][raw_midi_parser][issue-406]") {
+    // Device sends F0 7E <partial> then sends a Note On (0x90) without
+    // ever emitting F7. Before the fix, the Note On + its data bytes
+    // got swallowed as sysex payload until the NEXT F7 arrived. After
+    // the fix, the aborted F0 is dropped and the Note On fires normally.
+    auto c = parse({0xF0, 0x7E, 0x00,         // aborted sysex start
+                    0x90, 0x40, 0x7F,         // Note On 0x90 that used to be eaten
+                    0xF0, 0x01, 0xF7});       // clean sysex afterwards
+    REQUIRE(c.shorts.size() == 1);
+    REQUIRE(c.shorts[0].status == 0x90);
+    REQUIRE(c.shorts[0].d1 == 0x40);
+    REQUIRE(c.shorts[0].d2 == 0x7F);
+    REQUIRE(c.sysex.size() == 1);
+    REQUIRE(c.sysex[0] == std::vector<uint8_t>{0xF0, 0x01, 0xF7});
+}
+
+TEST_CASE("raw_midi_parser aborted sysex handles system-common too",
+          "[midi][raw_midi_parser][issue-406]") {
+    // 0xF1 (MTC Quarter Frame) is a 2-byte system-common status that
+    // also aborts an in-progress sysex. Ensure its single data byte is
+    // parsed correctly after the abort.
+    auto c = parse({0xF0, 0x7E,         // F0 stream, never terminated
+                    0xF1, 0x55,         // MTC quarter frame after abort
+                    0x90, 0x40, 0x7F}); // Note On afterwards
+    REQUIRE(c.shorts.size() == 2);
+    REQUIRE(c.shorts[0].status == 0xF1);
+    REQUIRE(c.shorts[0].d1 == 0x55);
+    REQUIRE(c.shorts[1].status == 0x90);
+}
+
+TEST_CASE("raw_midi_parser caps runaway sysex at kRawMidiSysexLimit",
+          "[midi][raw_midi_parser]") {
+    RawMidiParserState state;
+    Captured c;
+    auto on_short = [&c](uint8_t s, uint8_t d1, uint8_t d2) {
+        c.shorts.push_back({s, d1, d2});
+    };
+    auto on_sysex = [&c](const std::vector<uint8_t>& sx) {
+        c.sysex.push_back(sx);
+    };
+
+    // Feed F0 + kRawMidiSysexLimit bytes with no F7 — accumulator must
+    // drop the run rather than grow unbounded.
+    std::vector<uint8_t> huge;
+    huge.reserve(kRawMidiSysexLimit + 2);
+    huge.push_back(0xF0);
+    for (std::size_t i = 0; i < kRawMidiSysexLimit + 1; ++i) {
+        huge.push_back(0x42);
+    }
+    parse_raw_midi_bytes(huge.data(), huge.size(), state, on_short, on_sysex);
+
+    REQUIRE(c.sysex.empty());
+    REQUIRE_FALSE(state.sysex_in_progress);
+    REQUIRE(state.sysex_buffer.empty());
+}


### PR DESCRIPTION
## Summary

Codex review on #406 flagged that the ALSA raw-midi sysex accumulator
never checks for a fresh status byte arriving mid-F0. If a device
drops or glitches between F0 and F7, the current code keeps
appending bytes forever — silently consuming the next real Note On
(and every message after it) as sysex payload, until a stray F7
finally arrives.

## What changed

- Extract the byte-stream parser into a platform-agnostic helper
  (\`core/midi/include/pulp/midi/raw_midi_parser.hpp\`) so ALSA and
  any future raw-byte MIDI transport share the same accumulator logic.
- ALSA raw-midi path now consumes the helper instead of inlining.
- New \`test/test_raw_midi_parser.cpp\` with 6 Catch2 test cases.

The parser treats any non-realtime status byte (0x80..0xF6, i.e.
channel voice + system common except F7 and the F8..FF realtime
range) arriving mid-sysex as an abort signal: drop the partial
buffer, then parse that status byte as the start of a new message.
Realtime bytes (F8..FF) continue to pass through inline per
MIDI 1.0 §3.1.

## Test plan

- [x] \`pulp-test-raw-midi-parser\` builds locally
- [x] All 6 test cases pass (35 assertions):
  - short-message emission
  - multi-read sysex spanning parse() calls
  - realtime inside sysex passthrough (#239)
  - **aborted-sysex recovery** (the #406 P2 case)
  - aborted sysex with system-common byte (F1)
  - runaway cap at \`kRawMidiSysexLimit\`
- [ ] ALSA integration still works end-to-end on Linux (no
  behavior change for the happy path; the parser is a refactor with
  the added abort branch)

## Relates

- Closes the #438 P2 item for #406
- Builds on #406 / #239 (ALSA sysex and the broader SysEx sweep)
- Sets up the shared parser helper that Win32 MIM_LONGDATA (#388) could
  also consolidate onto in a future cleanup