### PR TITLE
fix(doctor): optional checks don't drive exit code + Windows .exe suffixes (#438 P1+P2 / #389)

### DIFF
--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -1740,8 +1740,13 @@ std::vector<DoctorCheck> run_doctor_android_checks() {
         DoctorCheck c{"adb (platform-tools)", false, {}, {}};
         std::string adb = find_executable_in_path("adb");
         if (adb.empty() && !sdk.empty()) {
+            // Default Android SDK installs ship adb.exe on Windows,
+            // adb on macOS / Linux — probe both so the fallback
+            // doesn't miss a perfectly valid SDK. #438 P2 for #389.
             auto candidate = sdk / "platform-tools" / "adb";
-            if (fs::exists(candidate)) adb = candidate.string();
+            auto candidate_exe = sdk / "platform-tools" / "adb.exe";
+            if (fs::exists(candidate_exe)) adb = candidate_exe.string();
+            else if (fs::exists(candidate))  adb = candidate.string();
         }
         if (!adb.empty()) {
             c.passed = true;
@@ -1758,7 +1763,9 @@ std::vector<DoctorCheck> run_doctor_android_checks() {
         std::string emu = find_executable_in_path("emulator");
         if (emu.empty() && !sdk.empty()) {
             auto candidate = sdk / "emulator" / "emulator";
-            if (fs::exists(candidate)) emu = candidate.string();
+            auto candidate_exe = sdk / "emulator" / "emulator.exe";
+            if (fs::exists(candidate_exe)) emu = candidate_exe.string();
+            else if (fs::exists(candidate))  emu = candidate.string();
         }
         if (!emu.empty()) {
             auto avds = exec_output(emu + " -list-avds 2>/dev/null");
@@ -1791,7 +1798,7 @@ std::vector<DoctorCheck> run_doctor_android_checks() {
     // its own.
     {
         DoctorCheck c{"Google Android CLI (optional accelerator, #355)",
-                      false, {}, {}};
+                      false, {}, {}, /*optional=*/true};
         auto cli = detect_android_cli();
 
         // Detect host platform support. macOS we assume arm64 because

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -149,6 +149,11 @@ struct DoctorCheck {
     bool passed;
     std::string detail;
     std::string fix;
+    // Optional checks report remediation advice but don't contribute
+    // to the overall doctor exit code when they fail. Used for e.g.
+    // the Google Android CLI accelerator (#355) which is a speedup,
+    // not a requirement. See #438 P1 for #389.
+    bool optional = false;
 };
 
 std::vector<DoctorCheck> run_doctor_checks(const fs::path& active_root, bool standalone_mode);

--- a/tools/cli/cmd_doctor.cpp
+++ b/tools/cli/cmd_doctor.cpp
@@ -63,7 +63,7 @@ int cmd_doctor(const std::vector<std::string>& args) {
     else if (mode == "ios")   checks = run_doctor_ios_checks();
     else                      checks = run_doctor_checks(active_root, standalone_mode);
 
-    int pass_count = 0, fail_count = 0;
+    int pass_count = 0, fail_count = 0, optional_skipped = 0;
     for (auto& c : checks) {
         if (c.passed) {
             ++pass_count;
@@ -73,6 +73,24 @@ int cmd_doctor(const std::vector<std::string>& args) {
                 print_ok(msg);
             }
         } else {
+            // Optional checks report advice but don't count toward
+            // fail_count, so `pulp doctor android` returns 0 when
+            // only optional accelerators (e.g. Google Android CLI,
+            // #355) are missing. See #438 P1 for #389.
+            if (c.optional) {
+                ++optional_skipped;
+                if (!ci_mode) {
+                    std::string msg = c.name;
+                    if (!c.detail.empty()) msg += " — " + c.detail;
+                    print_warn(msg);
+                    if (!c.fix.empty()) {
+                        std::cout << "    Install (optional): "
+                                  << color::yellow() << c.fix
+                                  << color::reset() << "\n";
+                    }
+                }
+                continue;
+            }
             ++fail_count;
             if (ci_mode) {
                 std::cerr << "FAIL: " << c.name;
@@ -108,6 +126,9 @@ int cmd_doctor(const std::vector<std::string>& args) {
     if (!ci_mode) {
         std::cout << "\n  " << color::bold() << pass_count << "/" << (pass_count + fail_count)
                   << " checks passed" << color::reset();
+        if (optional_skipped > 0) {
+            std::cout << " (+" << optional_skipped << " optional skipped)";
+        }
         if (fail_count > 0) {
             std::cout << " — run " << color::cyan() << "`pulp doctor --fix`" << color::reset() << " to resolve";
         }


### PR DESCRIPTION
## Summary

Two Codex findings on #389, shipped together (same file, related behavior).

**P1 — treat optional Android CLI as non-failing**

The \`Google Android CLI (#355)\` check is declared as an *optional*
accelerator, but when missing it was emitted with \`passed=false\` and
\`cmd_doctor\` counts every failed check toward the exit code. That
made \`pulp doctor android\` return failure on hosts correctly
configured for the default Gradle workflow, contradicting the
command's own contract and breaking scripts that gate on zero exit.

Adds an \`optional\` flag to \`DoctorCheck\`. Optional checks print
as a ⚠ warning with install hints but don't count toward
\`fail_count\`. Summary line shows \`4/4 checks passed (+1 optional skipped)\`
when only optional accelerators are missing; exit code stays 0.

**P2 — Windows .exe suffix for SDK fallback tools**

The adb + emulator PATH-fallback probes checked
\`<sdk>/platform-tools/adb\` and \`<sdk>/emulator/emulator\` without
the Windows \`.exe\` suffix. Default Android SDK installs on Windows
ship \`adb.exe\` / \`emulator.exe\`, so the fallback missed valid SDKs.
Probe both.

## Test plan

- [x] On a normal macOS host with android CLI installed:
      \`5/5 checks passed\` → exit 0
- [x] Hide \`~/.android-cli\` and rerun:
      \`4/4 checks passed (+1 optional skipped)\` → exit 0
- [x] Hide ANDROID_HOME entirely so emulator check fails:
      \`0/4 checks passed — run \`pulp doctor --fix\`\` → exit 1
- [ ] Windows CI run should now detect \`adb.exe\` in a fresh SDK install

## Relates

- Closes the #438 P1 + P2 items for #389