### PR TITLE
platform(android): Kotlin plumbing for orientation + safe-area + keyboard env (#342)

### DIFF
--- a/android/app/src/main/kotlin/com/pulp/PulpActivity.kt
+++ b/android/app/src/main/kotlin/com/pulp/PulpActivity.kt
@@ -4,8 +4,12 @@ import android.content.ComponentCallbacks2
 import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
+import android.view.View
+import android.view.WindowInsets
 import android.widget.FrameLayout
 import androidx.activity.ComponentActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.pulp.audio.PulpAudioFocus
 import com.pulp.render.PulpSurfaceView
 
@@ -26,6 +30,37 @@ class PulpActivity : ComponentActivity() {
         val frame = FrameLayout(this)
         frame.addView(surfaceView)
         setContentView(frame)
+
+        // Publish initial orientation + safe-area + keyboard insets as
+        // soon as the decor view has window insets. Also subscribe to
+        // subsequent updates (keyboard show/hide, notch enter/exit on
+        // rotation, split-screen insets). Forwards into the C++
+        // Environment API (#342).
+        if (PulpApplication.nativeLoaded) {
+            val initialOrientation = resources.configuration.orientation
+            nativeOnOrientationChanged(orientationToEnum(initialOrientation))
+
+            ViewCompat.setOnApplyWindowInsetsListener(frame) { _, insets ->
+                val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+                val ime  = insets.getInsets(WindowInsetsCompat.Type.ime())
+                if (PulpApplication.nativeLoaded) {
+                    nativeOnSafeAreaChanged(
+                        bars.top.toFloat(),
+                        bars.bottom.toFloat(),
+                        bars.left.toFloat(),
+                        bars.right.toFloat()
+                    )
+                    // Keyboard is considered visible when IME height
+                    // exceeds the system bars' bottom inset; subtract
+                    // so callers see the "additional" bottom padding
+                    // the keyboard introduced, not the full IME height
+                    // (which already includes the system nav bar).
+                    val keyboardBottom = maxOf(0, ime.bottom - bars.bottom).toFloat()
+                    nativeOnKeyboardChanged(keyboardBottom)
+                }
+                insets
+            }
+        }
     }
 
     override fun onResume() {
@@ -53,8 +88,19 @@ class PulpActivity : ComponentActivity() {
         val dm = resources.displayMetrics
         val dark = newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
                 Configuration.UI_MODE_NIGHT_YES
-        if (PulpApplication.nativeLoaded)
+        if (PulpApplication.nativeLoaded) {
             nativeOnDisplayChanged(dm.widthPixels, dm.heightPixels, dm.density, dark)
+            nativeOnOrientationChanged(orientationToEnum(newConfig.orientation))
+        }
+    }
+
+    // Map Android's Configuration.ORIENTATION_* to the Pulp C++
+    // Orientation enum values (declared in environment.hpp). Kept
+    // side-by-side with the C++ to keep the mapping obvious.
+    private fun orientationToEnum(androidOrientation: Int): Int = when (androidOrientation) {
+        Configuration.ORIENTATION_PORTRAIT  -> 0   // Orientation::portrait
+        Configuration.ORIENTATION_LANDSCAPE -> 2   // Orientation::landscape_left
+        else                                -> 5   // Orientation::unknown
     }
 
     override fun onTrimMemory(level: Int) {
@@ -76,5 +122,8 @@ class PulpActivity : ComponentActivity() {
     private external fun nativeOnShutdown()
     private external fun nativeOnMemoryPressure(level: Int)
     private external fun nativeOnDisplayChanged(w: Int, h: Int, density: Float, dark: Boolean)
+    private external fun nativeOnOrientationChanged(orientation: Int)
+    private external fun nativeOnSafeAreaChanged(top: Float, bottom: Float, left: Float, right: Float)
+    private external fun nativeOnKeyboardChanged(bottom: Float)
     external fun nativeOnPermissionResult(permission: Int, granted: Boolean)
 }

--- a/core/platform/src/android/jni_bridge.cpp
+++ b/core/platform/src/android/jni_bridge.cpp
@@ -218,6 +218,71 @@ Java_com_pulp_PulpActivity_nativeOnDisplayChanged(
     }
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_pulp_PulpActivity_nativeOnOrientationChanged(
+    JNIEnv* env, jobject thiz, jint orientation) {
+    try {
+        PULP_LOGI("nativeOnOrientationChanged: %d", orientation);
+        // Kotlin side's orientationToEnum() maps Android's
+        // Configuration.ORIENTATION_* into Pulp's Orientation enum
+        // (declared in environment.hpp). The mapping is documented
+        // there; this is just a numeric pass-through.
+        namespace pp = pulp::platform;
+        auto s = pp::Environment::instance().snapshot();
+        s.orientation = static_cast<pp::Orientation>(orientation);
+        pp::Environment::instance().publish(s);
+    } catch (const std::exception& e) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    } catch (...) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"),
+                      "Unknown C++ exception in nativeOnOrientationChanged");
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_pulp_PulpActivity_nativeOnSafeAreaChanged(
+    JNIEnv* env, jobject thiz,
+    jfloat top, jfloat bottom, jfloat left, jfloat right) {
+    try {
+        PULP_LOGI("nativeOnSafeAreaChanged: top=%.1f bottom=%.1f left=%.1f right=%.1f",
+                  top, bottom, left, right);
+        namespace pp = pulp::platform;
+        auto s = pp::Environment::instance().snapshot();
+        s.safe_area.top    = static_cast<float>(top);
+        s.safe_area.bottom = static_cast<float>(bottom);
+        s.safe_area.left   = static_cast<float>(left);
+        s.safe_area.right  = static_cast<float>(right);
+        pp::Environment::instance().publish(s);
+    } catch (const std::exception& e) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    } catch (...) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"),
+                      "Unknown C++ exception in nativeOnSafeAreaChanged");
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_pulp_PulpActivity_nativeOnKeyboardChanged(
+    JNIEnv* env, jobject thiz, jfloat bottom) {
+    try {
+        PULP_LOGI("nativeOnKeyboardChanged: bottom=%.1f", bottom);
+        namespace pp = pulp::platform;
+        auto s = pp::Environment::instance().snapshot();
+        s.keyboard.bottom = static_cast<float>(bottom);
+        // Android's basic WindowInsetsCompat doesn't surface animation
+        // duration here — that lives on WindowInsetsAnimationCompat,
+        // which is a frame-by-frame callback API. Leave 0 until the
+        // animation plumbing is added in a follow-up PR.
+        s.keyboard.animation_duration = 0.0f;
+        pp::Environment::instance().publish(s);
+    } catch (const std::exception& e) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    } catch (...) {
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"),
+                      "Unknown C++ exception in nativeOnKeyboardChanged");
+    }
+}
+
 // ── Audio Focus JNI Callbacks ─────────────────────────────────────────────
 
 extern "C" JNIEXPORT void JNICALL


### PR DESCRIPTION
## Summary

Re-opened of the auto-closed #434 — GitHub closed it when #403's base branch was deleted on merge. Content is the single commit rebased cleanly onto current main.

Wires up the Android Kotlin side of the #342 Environment API:

- \`PulpActivity\` now subscribes to \`onApplyWindowInsetsListener\` and forwards safe-area (systemBars) + keyboard (ime) insets to C++ via \`nativeOnSafeAreaChanged\` / \`nativeOnKeyboardChanged\`.
- Orientation changes fire \`nativeOnOrientationChanged\` with values mapped from \`Configuration.ORIENTATION_*\` to Pulp's \`Orientation\` enum.
- JNI bridge in \`jni_bridge.cpp\` forwards all three into \`Environment::publish\`.

## Test plan

- [ ] Android emulator: rotate device, verify orientation enum flips
- [ ] Android emulator: open soft keyboard, verify keyboard inset fires (not full IME height, just the portion above nav bar)
- [ ] iPad-split or notched device: verify safe-area insets propagate
- [ ] Follow-up tracked separately: keyboard animation duration (Kotlin-side \`WindowInsetsAnimationCompat\`)

## Relates

- Part of #342 Environment API
- Recreated after base-branch auto-close when #403 merged