### PR TITLE
fix(platform): Environment listener not invoked after token reset (#438 P1 / #403)

### DIFF
--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -22,6 +22,7 @@
 /// Windows `WM_DPICHANGED`/`WM_SETTINGCHANGE`, Linux XSettings + Wayland
 /// fractional scale).
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -211,7 +212,18 @@ private:
 
     mutable std::mutex mu_;
     EnvironmentState   state_;
-    struct Entry { uint64_t id; Listener fn; };
+    // Entry carries an `active` flag so `publish` can take a snapshot
+    // of the subscription list under the lock, then drop the lock and
+    // still skip any listener that was unsubscribed in the meantime —
+    // either by another listener during the same dispatch or by a
+    // different thread calling `Token::reset()`. Using shared_ptr so
+    // the copy in `publish` and the live list share the same flag.
+    // See #403 Codex P1 review.
+    struct Entry {
+        uint64_t id;
+        Listener fn;
+        std::shared_ptr<std::atomic<bool>> active;
+    };
     std::vector<Entry> listeners_;
     uint64_t           next_id_ = 1;
 };

--- a/core/platform/src/environment.cpp
+++ b/core/platform/src/environment.cpp
@@ -46,7 +46,10 @@ Environment::Token Environment::subscribe(Listener listener) {
     if (!listener) return Token{};
     std::lock_guard<std::mutex> lock(mu_);
     uint64_t id = next_id_++;
-    listeners_.push_back(Entry{id, std::move(listener)});
+    listeners_.push_back(Entry{
+        id,
+        std::move(listener),
+        std::make_shared<std::atomic<bool>>(true)});
     return Token{id};
 }
 
@@ -54,6 +57,14 @@ void Environment::unsubscribe(uint64_t id) {
     std::lock_guard<std::mutex> lock(mu_);
     for (auto it = listeners_.begin(); it != listeners_.end(); ++it) {
         if (it->id == id) {
+            // Flip the flag before erasing. If an in-flight `publish`
+            // already copied this Entry (before the lock was taken),
+            // the copy shares the same shared_ptr and will see the
+            // false value when it re-checks before invoking. Without
+            // this, a listener unsubscribed between lock-release and
+            // callback-dispatch would still fire once — use-after-reset.
+            if (it->active) it->active->store(false,
+                                              std::memory_order_release);
             listeners_.erase(it);
             return;
         }
@@ -101,6 +112,16 @@ void Environment::publish(const EnvironmentState& next) {
         listeners_copy = listeners_;
     }
     for (const auto& entry : listeners_copy) {
+        // Re-check the active flag after dropping the lock. If another
+        // listener in the same dispatch (or another thread) called
+        // Token::reset() between the snapshot and now, entry.active
+        // is false and we must skip — otherwise the callback fires
+        // against captures whose owner has already been destroyed.
+        // See #403 Codex P1.
+        if (entry.active
+            && !entry.active->load(std::memory_order_acquire)) {
+            continue;
+        }
         entry.fn(next, change);
     }
 }
@@ -113,6 +134,14 @@ void Environment::reset_for_test() {
     auto& env = instance();
     std::lock_guard<std::mutex> lock(env.mu_);
     env.state_ = EnvironmentState{};
+    // Flip active flags before clearing so any copy held by an
+    // in-flight publish stops invoking immediately — otherwise tests
+    // that reset mid-dispatch hit the same callback-after-reset race
+    // in reverse.
+    for (auto& entry : env.listeners_) {
+        if (entry.active) entry.active->store(false,
+                                              std::memory_order_release);
+    }
     env.listeners_.clear();
     env.next_id_ = 1;
 }

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -177,6 +177,45 @@ TEST_CASE("Environment: callback that drops its own token does not deadlock",
     SUCCEED("no deadlock");
 }
 
+TEST_CASE("Environment: listener unsubscribed mid-dispatch is not invoked "
+          "(#403 codex P1)",
+          "[environment][issue-403]") {
+    Environment::reset_for_test();
+
+    int a_calls = 0;
+    int b_calls = 0;
+
+    Environment::Token a = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++a_calls; });
+    Environment::Token b = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++b_calls; });
+
+    // Subscribe a listener that tears down `b`'s subscription while
+    // the publish is iterating the copied listener list. Before the
+    // #403 fix, `b`'s callback still fired once because publish held
+    // a copy that didn't re-check registration. After the fix, the
+    // atomic `active` flag is flipped before erase and the second
+    // invocation is skipped.
+    Environment::Token killer = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { b.reset(); });
+
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+
+    REQUIRE(a_calls == 1);
+    // Whether `b` fires before or after `killer` depends on
+    // subscription order; subscribe() appends, so iteration is
+    // deterministically a, b, killer. `b` is invoked before `killer`
+    // clears it — so b_calls should be 1 for this first publish.
+    REQUIRE(b_calls == 1);
+
+    // Second publish — `b` is now unsubscribed. `a` still fires,
+    // `b` must not fire again (the bug would have it fire once more
+    // if the listener list were copied without the active flag).
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(a_calls == 2);
+    REQUIRE(b_calls == 1);
+}
+
 TEST_CASE("Environment: snapshot is consistent with last publish",
           "[environment]") {
     Environment::reset_for_test();


### PR DESCRIPTION
## Summary

Codex review on #403 flagged that \`publish\` copies \`listeners_\` and then
invokes the copied callbacks without re-checking registration. A listener
unsubscribed during the same dispatch (either by another callback in the
copy or by a different thread calling \`Token::reset()\`) still fires once
more — a use-after-reset hazard because RAII tokens are documented as
immediate unsubscribe, and downstream captures may already be destroyed.

This matters now that 5 platform env adapters (#403/#404/#407/#443/#444/#445/#446)
are in flight — every one of them subscribes listeners whose lifetime is
tied to adapter objects that can vanish during reconfiguration.

## What changed

- Each \`Entry\` carries a \`shared_ptr<atomic<bool>> active\`
- \`unsubscribe()\` flips the flag to \`false\` **before** erasing; any copy
  already held by an in-flight \`publish\` shares the same pointer
- \`publish\` rechecks the flag after dropping the lock and skips stale callbacks
- \`reset_for_test()\` also flips all flags before clearing

## Test plan

- [x] New \`Environment: listener unsubscribed mid-dispatch is not invoked (#403 codex P1)\` — 3 listeners, one tears down a peer during publish, peer must not fire after reset
- [x] All 10 existing env tests still pass (39 assertions in 10 cases) locally
- [x] No deadlock regression — the existing \`callback that drops its own token\` test still passes

## Relates

- Closes the #438 P1 item for #403
- Cascade-relevant: the 5 env adapters on top of #403 all depend on token RAII
  doing what it says