### PR TITLE
ci: preserve fail-fast semantics in retry composite action (#438 P1 / #432)

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -39,7 +39,12 @@ runs:
         delay="${RETRY_INITIAL_DELAY}"
         while : ; do
           echo "::group::${RETRY_LABEL} (attempt ${attempt}/${RETRY_ATTEMPTS})"
-          bash -c "${RETRY_SCRIPT}"
+          # -euo pipefail preserves fail-fast semantics across the whole
+          # RETRY_SCRIPT. Without this, a transient early-command failure
+          # (e.g. apt-get update or wget) gets masked if a later command
+          # in the same multi-line script exits 0, and the action doesn't
+          # actually retry. See #438 P1 Codex review on #432.
+          bash -euo pipefail -c "${RETRY_SCRIPT}"
           status=$?
           echo "::endgroup::"
           if [ "${status}" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Codex review on #432 flagged that \`bash -c \"\${RETRY_SCRIPT}\"\` runs without
\`-e\`/\`pipefail\`, so in a multi-line script only the LAST command's exit
code controls success. A transient early-command failure (e.g. \`wget\` of
apt.llvm.org or \`apt-get update\`) gets masked by a later zero-exit
command in the same script, and the retry action **doesn't retry** — the
job continues with a partially failed setup.

## What changed

- Inner \`bash -c\` now passes \`-euo pipefail\`, restoring the same failure
  contract the original hand-rolled \`run:\` steps had before they were
  wrapped in the retry action.

No semantic change for single-command usages; only multi-line retry
scripts (which is the common case at the sanitizers.yml call sites) get
the fix.

## Test plan

- [x] YAML still parses (composite action structure unchanged)
- [ ] Next sanitizer CI run on an adjacent PR picks up the new action and
  exercises the fail-fast path

## Relates

- Closes the #438 P1 item for #432