### PR TITLE
fix(events): Timer::start() idempotent when already active (#438 P1 / #428)

### DIFF
--- a/core/events/src/timer.cpp
+++ b/core/events/src/timer.cpp
@@ -16,11 +16,21 @@ Timer::~Timer() {
 }
 
 void Timer::start() {
+    // Idempotent against concurrent schedule_next() lambdas copying
+    // alive_. If start() is called while the timer is already active,
+    // skipping the reassignment avoids an unsynchronized write to the
+    // shared_ptr that an in-flight event-loop copy is reading — the
+    // original #414 race pattern. See #438 P1 Codex review on #428.
+    if (active_.load(std::memory_order_acquire)) {
+        return;
+    }
+
     // Fresh sentinel for this lifecycle. Safe to reassign alive_ here
     // because start() runs on the owner thread — no in-flight dispatch
-    // lambda can be copying alive_ concurrently at this point; any
-    // prior-cycle lambdas hold their own shared_ptr copies captured
-    // before stop() flipped them to false.
+    // lambda can be copying alive_ concurrently at this point (active_
+    // is false, schedule_next() gated on it), and any prior-cycle
+    // lambdas hold their own shared_ptr copies captured before stop()
+    // flipped them to false.
     //
     // Previously this reassignment lived in stop(), racing with
     // schedule_next()'s `auto alive = alive_;` copy on the event-loop

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -145,6 +145,28 @@ TEST_CASE("Timer basic operation", "[events][timer]") {
         REQUIRE(wait_until([&] { return count.load() > captured; }, 500ms));
         timer.stop();
     }
+
+    SECTION("start() is idempotent when already running (#438 P1 / #428)") {
+        // Before the fix, an unconditional `alive_ = make_shared<>`
+        // in start() races against schedule_next()'s `auto alive = alive_;`
+        // if a second start() lands while the timer is already active.
+        // After the fix, start() early-returns when active_ is true.
+        //
+        // The test can't deterministically prove the race is gone (TSan
+        // does that on the CI sanitizer job), but it can assert that
+        // calling start() twice in a row doesn't break repeat behavior
+        // or double-schedule.
+        std::atomic<int> count{0};
+        Timer timer(loop, 10ms, [&] { count.fetch_add(1); }, true);
+        timer.start();
+        timer.start();  // second start — should no-op, not reschedule
+        REQUIRE(wait_until([&] { return count.load() >= 3; }, 500ms));
+        timer.stop();
+        auto captured = count.load();
+        std::this_thread::sleep_for(50ms);
+        // Still stopped after the double-start + single-stop pair:
+        REQUIRE(count.load() == captured);
+    }
 }
 
 // ── EventLoop lifecycle edges ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Codex review on #428 flagged that the unconditional \`alive_ = make_shared<>\`
in start() reintroduces the same shared_ptr read/write race #414 was
supposed to eliminate — if \`start()\` is called while the timer is already
running, \`schedule_next()\` on the event-loop thread may be copying
\`alive_\` exactly when the owner thread reassigns it.

## What changed

- \`Timer::start()\` early-returns when \`active_.load()\` is already true.

## Test plan

- [x] New \`Timer basic operation :: start() is idempotent when already running (#438 P1 / #428)\` section — double-start + single-stop produces no extra ticks, repeat semantics hold.
- [x] All 9 Timer assertions pass locally (\`./build/test/pulp-test-events \"Timer basic operation\"\`).
- [ ] TSan sanitizer workflow confirms no race at the start()/schedule_next() boundary.

## Relates

- Closes the #438 P1 item for #428