### PR TITLE
fix(platform): use TARGET_OS_IPHONE for iOS observer dispatch (#438 P1 / #445)

### DIFF
--- a/core/platform/include/pulp/platform/environment.hpp
+++ b/core/platform/include/pulp/platform/environment.hpp
@@ -237,8 +237,15 @@ private:
 // alphabetically. The convenience wrapper at the bottom dispatches to
 // the right one based on the build target.
 
-void start_environment_observer_mac();
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
 void start_environment_observer_ios();
+#elif defined(__APPLE__)
+void start_environment_observer_mac();
+#endif
 #if defined(__linux__) && !defined(__ANDROID__)
 void start_environment_observer_linux();
 #endif
@@ -247,8 +254,16 @@ void start_environment_observer_win();
 #endif
 // void start_environment_observer_android(); // follow-up
 
+// Use Apple's TargetConditionals.h macro rather than the CMake-defined
+// PULP_IOS variable — the CMake iOS branch adds environment_ios.mm to
+// pulp-platform but does not define PULP_IOS for the target, so before
+// this change an iOS build would fall through to the macOS branch and
+// try to link start_environment_observer_mac() (which is not in the
+// iOS source set). TARGET_OS_IPHONE is always defined on Apple via
+// TargetConditionals.h and is 1 only for iOS/tvOS/watchOS.
+// See #438 P1 Codex review on #445.
 inline void start_environment_observer() {
-#if defined(__APPLE__) && defined(PULP_IOS)
+#if defined(__APPLE__) && TARGET_OS_IPHONE
     start_environment_observer_ios();
 #elif defined(__APPLE__)
     start_environment_observer_mac();


### PR DESCRIPTION
## Summary

Codex review on #445 flagged that \`start_environment_observer()\` only
dispatched to iOS when \`PULP_IOS\` was defined, but the iOS branch in
\`core/platform/CMakeLists.txt\` adds \`environment_ios.mm\` to
\`pulp-platform\` **without** defining \`PULP_IOS\` for the target. Any
iOS caller built without that macro takes the \`#elif defined(__APPLE__)\`
branch and references \`start_environment_observer_mac()\`, which is
NOT in the iOS source set — link failure or misroute.

## What changed

- Include \`<TargetConditionals.h>\` on Apple and gate iOS dispatch on
  \`TARGET_OS_IPHONE\`, which is always defined on Apple and is 1 only
  for iOS / tvOS / watchOS.
- Forward declarations are also now gated so iOS doesn't see the mac
  proto and vice versa — matches the CMake source set exactly.

No CMake change needed.

## Test plan

- [x] macOS build still links (mac observer proto visible, iOS proto hidden)
- [ ] iOS Simulator build links cleanly (next CI run)

## Relates

- Closes the #438 P1 item for #445. P2 items (trait-flip color scheme,
  foreground-inactive safe-area) deferred — each needs iOS simulator
  runtime verification to land a real test.