### PR TITLE
fix(audio): ALSA capture drops before join to unblock snd_pcm_readi (#438 P1 / #387)

### DIFF
--- a/core/audio/platform/linux/alsa_device.cpp
+++ b/core/audio/platform/linux/alsa_device.cpp
@@ -152,13 +152,24 @@ void AlsaDevice::stop() {
 
     is_running_.store(false, std::memory_order_release);
 
+    // On capture we MUST drop BEFORE joining — snd_pcm_readi blocks
+    // inside the io thread until frames arrive, so the thread never
+    // reaches its loop-check on a quiet input device. snd_pcm_drop
+    // aborts any outstanding read from this side of the stream so the
+    // thread unwinds immediately. On playback the existing join-then-
+    // drain order is fine because the render thread exits on its own
+    // fill cycle. See #438 P1 Codex review on #387.
+    if (pcm_ && stream_ == SND_PCM_STREAM_CAPTURE) {
+        snd_pcm_drop(pcm_);
+    }
+
     if (io_thread_.joinable()) io_thread_.join();
 
     if (pcm_) {
         // Drain only on playback — drain on capture blocks until the
-        // ring buffer empties, which is meaningless for input.
+        // ring buffer empties, which is meaningless for input. Capture
+        // was already dropped above before join.
         if (stream_ == SND_PCM_STREAM_PLAYBACK) snd_pcm_drain(pcm_);
-        else                                    snd_pcm_drop(pcm_);
     }
 
     callback_ = nullptr;


### PR DESCRIPTION
## Summary

Codex review on #387 flagged that the capture \`stop()\` path joins
\`io_thread_\` before calling \`snd_pcm_drop()\`, but the io thread blocks
inside \`snd_pcm_readi\` waiting for frames. On a quiet input device the
thread never reaches its loop-check and \`stop()\` hangs forever — user-
facing shutdown stall.

## What changed

- On capture streams, call \`snd_pcm_drop()\` **before** joining. Drop
  aborts the outstanding read; the io thread's \`readi\` returns
  immediately, sees \`is_running_ == false\`, and exits.
- Playback keeps the existing join-then-drain order — the render
  thread exits on its own fill cycle and has nothing to break out of.

## Test plan

- [x] Compiles (capture-only path change on Linux)
- [ ] Integration: open+close a capture stream on a quiet device on Linux
  CI; stop() must return within a few ms, not hang

## Relates

- Closes the #438 P1 item for #387 (capture-shutdown). #387's other P1
  (playback-probe-failure masquerading as capture-only) will ship in a
  follow-up