### PR TITLE
fix(aax): copy sysex in bypass MIDI-thru path (#438 P2 / #408)

### DIFF
--- a/core/format/src/aax_runtime.cpp
+++ b/core/format/src/aax_runtime.cpp
@@ -179,8 +179,18 @@ void copy_audio(float** output,
 }
 
 void copy_midi(const midi::MidiBuffer& in, midi::MidiBuffer& out) {
+    // Short MidiEvent entries (note/CC/pitchbend/etc).
     for (const auto& event : in) {
         out.add(event);
+    }
+    // Sysex entries — MidiBuffer splits short events and sysex into
+    // separate sidecar storage, so `for (event : in)` doesn't walk
+    // them. Without this the bypass MIDI-thru path silently drops
+    // every F0..F7 run while short MIDI passes through, which breaks
+    // bulk dumps and MIDI-CI workflows in bypass mode specifically.
+    // See #438 P2 Codex review on #408.
+    for (const auto& sx : in.sysex()) {
+        out.add_sysex(sx.data, sx.sample_offset, sx.timestamp);
     }
 }
 


### PR DESCRIPTION
## Summary

Codex review on #408 flagged that \`copy_midi\` only iterates the short
\`MidiEvent\` entries. \`MidiBuffer::sysex()\` contents are silently
dropped when bypass is enabled — note/CC traffic passes through but
F0..F7 bulk dumps and MIDI-CI workflows break specifically in bypass
mode.

## What changed

- \`copy_midi\` now also iterates \`in.sysex()\` and forwards each
  SysexEvent via \`add_sysex(data, sample_offset, timestamp)\`.

## Test plan

- [x] AAX build compiles
- [ ] Manual: toggle bypass in an AAX host while sending a sysex dump —
  verify it reaches the downstream plugin now (pre-fix it vanished)
- [ ] Follow-up to extract \`copy_midi\` into a pure header so a
  pulp-midi unit test can exercise both branches without the AAX SDK.
  Tracked in #438 P2 follow-ups.

## Relates

- Closes the #438 P2 item for #408