### PR TITLE
fix(audio): WASAPI capture uses engine stride, not actual_channels (#438 P1 / #386)

### DIFF
--- a/core/audio/platform/win/wasapi_device.cpp
+++ b/core/audio/platform/win/wasapi_device.cpp
@@ -55,6 +55,12 @@ bool WasapiDevice::open(const DeviceConfig& config) {
     actual_channels_ = std::min(
         static_cast<int>(mix_format->nChannels),
         std::max(requested_channels, 1));
+    // engine_channels_ is the WASAPI packet stride (mix-format channel
+    // count negotiated in Initialize). Capture packets are interleaved
+    // at this stride regardless of what the user asked for, so the
+    // deinterleave loop must use it as the per-frame source step.
+    // See #438 P1 Codex review on #386.
+    engine_channels_ = static_cast<int>(mix_format->nChannels);
     config_.sample_rate = static_cast<double>(mix_format->nSamplesPerSec);
 
     // Calculate buffer duration from requested buffer size
@@ -362,10 +368,14 @@ void WasapiDevice::capture_thread_func() {
                 // per-channel buffers. WASAPI gives us the device's
                 // mix format which we already negotiated to float.
                 auto* src = reinterpret_cast<const float*>(data);
+                // Source stride is engine_channels_ (the WASAPI mix
+                // format), even when the user asked for fewer channels.
+                // Copy only actual_channels_ into the planar output;
+                // any extra source channels are intentionally dropped.
                 for (UINT32 frame = 0; frame < frames; ++frame) {
                     for (int ch = 0; ch < actual_channels_; ++ch) {
                         channel_ptrs_[ch][frame] =
-                            src[frame * actual_channels_ + ch];
+                            src[frame * engine_channels_ + ch];
                     }
                 }
             }

--- a/core/audio/platform/win/wasapi_device.hpp
+++ b/core/audio/platform/win/wasapi_device.hpp
@@ -69,7 +69,8 @@ private:
     std::atomic<bool> is_running_{false};
     uint64_t sample_position_ = 0;
     UINT32 buffer_frames_ = 0;
-    int actual_channels_ = 0;
+    int actual_channels_ = 0;     ///< channels delivered to the user callback
+    int engine_channels_ = 0;     ///< channels in the WASAPI packet stride
 
     std::thread io_thread_;
 


### PR DESCRIPTION
## Summary

Codex review on #386 flagged that \`capture_thread_func\` indexed packet
data with \`actual_channels_\`, but WASAPI packet layout uses the
stream/mix channel count negotiated in \`Initialize\`
(\`mix_format->nChannels\` from \`GetMixFormat\`). When the device exposes
more channels than requested (e.g. stereo endpoint with
\`input_channels=1\`), the loop reads \`src[frame * actual_channels +
ch]\` and gets the wrong sample — captured audio is corrupted.

## What changed

- New member \`engine_channels_\` set from \`mix_format->nChannels\`
  after \`Initialize\`.
- Capture deinterleave loop uses \`frame * engine_channels_ + ch\` as
  the source step, copying only \`actual_channels_\` channels into the
  user-facing planar buffers (extra source channels intentionally
  dropped).

## Test plan

- [x] Compiles
- [ ] Manual: open a stereo input device requesting 1 channel on
  Windows; verify the capture buffer matches L only (not L,R-mixed-in)

## Relates

- Closes the #438 P1 item for #386