### PR TITLE
docs: defer pulp report bug guidance until CLI ships (#438 P2 / #435)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -7,11 +7,11 @@ body:
     attributes:
       value: >
         Thanks for filing a bug. The more specific the repro, the faster
-        someone can land a fix. If you'd like Pulp to collect a diagnostic
-        bundle (anonymized; you see every file before upload), run
-        `pulp report bug` and attach the resulting bundle — the CLI
-        redacts your home directory, username, hostname, IPs, MAC
-        addresses, and common secret patterns before producing anything.
+        someone can land a fix. Logs, stack traces, and `pulp doctor`
+        output are the most useful attachments today; an automated
+        diagnostic-bundle CLI (`pulp report bug`) is on the roadmap
+        (tracking in #413) and this template will point at it once it
+        ships.
 
   - type: input
     id: summary
@@ -91,9 +91,7 @@ body:
       label: Logs / stack trace
       description: >
         Paste any crash log, stderr output, or `pulp doctor` output.
-        If you'd rather share a Pulp diagnostic bundle with automatic
-        anonymization, run `pulp report bug --attach` and drag the bundle
-        in below.
+        Redact paths or other sensitive content before pasting if needed.
       render: shell
 
   - type: checkboxes


### PR DESCRIPTION
## Summary

Codex review on #435 flagged that the bug template told filers to run
\`pulp report bug\` / \`pulp report bug --attach\`, but the \`report\`
subcommand isn't shipped yet (no entry in \`tools/cli/pulp_cli.cpp\`).
Following the instruction yields an unknown-subcommand error — the
opposite of the friction reduction the template should provide.

## What changed

- Replace \`pulp report bug\` instructions with \`pulp doctor\` output
  guidance (which exists and is useful).
- Note that the automated diagnostic-bundle CLI is roadmap-tracked
  in #413; template will point at it once it lands.

## Relates

- Closes the #438 P2 item for #435