### PR TITLE
ci: skip RTSan selector resolution outside workflow_dispatch (#438 P2 / #424)

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -120,11 +120,22 @@ jobs:
             EXPLICIT_UBSAN_RUNNER_SELECTOR_JSON \
             UBSAN_RUNS_ON_JSON \
             macos-14)
-          rtsan=$(resolve \
-            "RealtimeSanitizer (Linux x86_64)" \
-            EXPLICIT_RTSAN_RUNNER_SELECTOR_JSON \
-            RTSAN_RUNS_ON_JSON \
-            ubuntu-24.04)
+          # RTSan only runs on workflow_dispatch (see rtsan job's
+          # if:), so skip its selector resolution on pull_request/push
+          # runs. Previously a malformed `PULP_SANITIZER_RTSAN_RUNS_ON_JSON`
+          # (or a debugging mistake on the var) would fail resolve-runners
+          # entirely and block ASan/TSan/UBSan for every PR — turning a
+          # dispatch-only knob into a required-check outage.
+          # See #438 P2 Codex review on #424.
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            rtsan=$(resolve \
+              "RealtimeSanitizer (Linux x86_64)" \
+              EXPLICIT_RTSAN_RUNNER_SELECTOR_JSON \
+              RTSAN_RUNS_ON_JSON \
+              ubuntu-24.04)
+          else
+            rtsan='"ubuntu-24.04"'
+          fi
           {
             echo "asan_runs_on=${asan}"
             echo "tsan_runs_on=${tsan}"


### PR DESCRIPTION
## Summary

Codex review on #424 flagged that \`resolve-runners\` always resolves
\`RTSAN_RUNS_ON_JSON\` — even on \`pull_request\`/\`push\` runs where the
\`rtsan\` job is gated behind
\`if: github.event_name == 'workflow_dispatch'\`. A malformed
\`PULP_SANITIZER_RTSAN_RUNS_ON_JSON\` (or one temporarily set to bad JSON
during debugging) fails \`resolve-runners\` on every PR, blocking
ASan/TSan/UBSan downstream — a dispatch-only knob becomes a required-
check outage.

## What changed

- RTSan resolve call is now gated on \`GITHUB_EVENT_NAME == workflow_dispatch\`.
- On other event types, emit a dummy runs-on value (the rtsan job is
  skipped anyway).

## Relates

- Closes the #438 P2 item for #424