### PR TITLE
docs: keep ALSA limitation scoped to ALSA behavior (#438 P2 / #437)

### DIFF
--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -36,7 +36,7 @@ The following section is auto-generated from the `limitations:` block of `docs/s
 | `audio_io.jack` | Dead code — factory always returns AlsaSystem; JACK is never selected at runtime. | [link](planning/production-readiness/02-audio-midi-io.md#2.2) |
 | `midi_io.coremidi` | UMP type-4 (MIDI 2.0 channel voice) packets are silently dropped in the input handler. | [link](planning/production-readiness/02-audio-midi-io.md#2.6) |
 | `midi_io.win32_midi` | Legacy mmeapi; no windows.devices.midi2, no hotplug. SysEx input routed via MIM_LONGDATA; WinRT MIDI runtime still pending. | [link](planning/production-readiness/02-audio-midi-io.md#2.4) |
-| `midi_io.alsa_midi` | Running status not handled; timestamps always 0; no hotplug. SysEx input accumulator landed; CoreMIDI SysEx7 reassembly still pending (#405). | [link](planning/production-readiness/02-audio-midi-io.md#2.5) |
+| `midi_io.alsa_midi` | Running status not handled; timestamps always 0; no hotplug. SysEx input accumulator landed. | [link](planning/production-readiness/02-audio-midi-io.md#2.5) |
 | `platform_maturity.accessibility.windows` | UIA provider tree and event emission pending (bootstrap in place via #283). | [link](planning/production-readiness/04-accessibility.md#4.1) |
 | `platform_maturity.accessibility.linux` | AT-SPI per-view accessible objects and events pending (bridge bootstrap in place via #280). | [link](planning/production-readiness/04-accessibility.md#4.2) |
 <!-- generated:end id=limitations -->

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -815,7 +815,7 @@ limitations:
     - text: "Legacy mmeapi; no windows.devices.midi2, no hotplug. SysEx input routed via MIM_LONGDATA; WinRT MIDI runtime still pending."
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.4"
   midi_io.alsa_midi:
-    - text: "Running status not handled; timestamps always 0; no hotplug. SysEx input accumulator landed; CoreMIDI SysEx7 reassembly still pending (#405)."
+    - text: "Running status not handled; timestamps always 0; no hotplug. SysEx input accumulator landed."
       tracked_in: "planning/production-readiness/02-audio-midi-io.md#2.5"
   platform_maturity.accessibility.windows:
     # UIA bootstrap landed in PR #283 (UIAutomationCore linked, session


### PR DESCRIPTION
Closes the #438 P2 item for #437 — removes the CoreMIDI SysEx7 cross-platform note from the ALSA row (CoreMIDI SysEx7 has since shipped via #405 anyway, and the note was misclassifying the remaining work). Regenerated `capabilities.md`.