### PR TITLE
fix(env): include NORMAL in macOS memory-pressure source mask (#438 P2 / #404)

### DIFF
--- a/core/platform/platform/mac/environment_mac.mm
+++ b/core/platform/platform/mac/environment_mac.mm
@@ -142,11 +142,15 @@ void publish_full_snapshot(LifecycleState lifecycle, MemoryPressure pressure) {
                    context:nullptr];
     }
 
-    // Memory pressure dispatch source. Coalesces warning + critical so
-    // a transition warning -> critical becomes two publish() calls.
+    // Memory pressure dispatch source. Includes NORMAL so apps receive a
+    // memory_pressure = normal recovery event after WARN/CRITICAL clears
+    // (otherwise listeners that released caches on pressure never know
+    // it's safe to repopulate them).
     _pressureSource = dispatch_source_create(
         DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0,
-        DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL,
+        DISPATCH_MEMORYPRESSURE_NORMAL
+            | DISPATCH_MEMORYPRESSURE_WARN
+            | DISPATCH_MEMORYPRESSURE_CRITICAL,
         dispatch_get_main_queue());
     if (_pressureSource) {
         // Observer is process-lived (created via dispatch_once and never

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -161,6 +161,30 @@ TEST_CASE("Environment: memory pressure transitions", "[environment]") {
     REQUIRE(observed == 1);
 }
 
+TEST_CASE("Environment: memory pressure recovery to normal fires diff",
+          "[environment][issue-404]") {
+    Environment::reset_for_test();
+    EnvironmentChange last_change{};
+    EnvironmentState  last_state{};
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState& s, EnvironmentChange c) {
+            last_change = c;
+            last_state  = s;
+        });
+
+    auto base = make_state(ColorScheme::dark);
+    base.memory_pressure = MemoryPressure::critical;
+    Environment::inject_for_test(base);
+
+    last_change = {};
+    auto recovered = base;
+    recovered.memory_pressure = MemoryPressure::normal;
+    Environment::inject_for_test(recovered);
+
+    REQUIRE(last_change.memory_pressure);
+    REQUIRE(last_state.memory_pressure == MemoryPressure::normal);
+}
+
 TEST_CASE("Environment: callback that drops its own token does not deadlock",
           "[environment]") {
     Environment::reset_for_test();


### PR DESCRIPTION
## Summary

Codex P2 review of the Environment API rollout (#438 → #404) flagged that `core/platform/platform/mac/environment_mac.mm` subscribes the dispatch source to `DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL` but omits `DISPATCH_MEMORYPRESSURE_NORMAL`. Without NORMAL in the mask, the kernel never delivers a recovery event after pressure clears, so listeners that released caches on a WARN/CRITICAL signal never get a `MemoryPressure::normal` notification telling them it's safe to repopulate.

This PR adds `DISPATCH_MEMORYPRESSURE_NORMAL` to the mask. The existing handler already maps `flags & CRITICAL` → critical, `flags & WARN` → moderate, and otherwise → normal — so adding NORMAL to the mask is sufficient; no handler changes needed.

## Test plan

- [x] New Catch2 case in test/test_environment.cpp ([environment][issue-404]) — injects critical, then normal, asserts publish() emits the recovery diff with state.memory_pressure == normal.
- [ ] CI cross-platform sweep on macOS/Linux/Windows.

## References
- Tracker: #438 (Codex P2 bucket) / #404 / #342 / #403