### PR TITLE
ci: ruleset-as-code for main branch protection (#462)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -182,28 +182,6 @@ macOS runs locally in parallel with Namespace Ubuntu/Windows.
 
 **Common mistake:** Pushing a branch and waiting for the auto-triggered GitHub Actions PR checks. Those use GitHub-hosted runners and are slow. Instead: cancel the auto-triggered run and dispatch on Namespace.
 
-### Runner selection is repo-variable driven (no code change needed)
-
-Every `runs-on:` decision in `.github/workflows/*.yml` routes through
-`tools/scripts/resolve_runs_on.py` and a per-target `PULP_*_RUNS_ON_JSON`
-repo variable. When every variable is unset the workflows resolve to
-their hard-coded defaults (backwards-compatible). Setting one variable
-moves one job — no workflow edit, no full-matrix re-run. The full
-variable list and `gh variable set` examples live in
-`docs/guides/local-ci.md` § "Switching a job's runner without a code
-change".
-
-Practical use case: if a sanitizer is slow on a GitHub-hosted runner
-(TSan on `macos-14` routinely exceeds 45 min), flip it to a self-hosted
-runner with `gh variable set PULP_SANITIZER_TSAN_RUNS_ON_JSON --body
-'["self-hosted","macos","arm64","sanitizer"]'`. The next sanitizer
-run picks up the new runner automatically.
-
-Sanitizer per-job `workflow_dispatch` inputs (`asan_runner_selector_json`
-/ `tsan_runner_selector_json` / `ubsan_runner_selector_json` /
-`rtsan_runner_selector_json`) are the equivalent one-off overrides for
-a single manual run.
-
 ```bash
 # Cancel auto-triggered GitHub-hosted run
 gh run cancel <run_id> --repo danielraffel/pulp
@@ -460,6 +438,48 @@ Keep hostnames and VM names local. Shared repo docs and skills should describe h
 
 Full setup guide: `docs/guides/local-ci.md`
 SSH key setup for Windows/Linux VMs: `docs/guides/local-ci.md` § "Set up SSH keys"
+
+## Required-check ruleset (issue #462)
+
+The branch-protection ruleset for `main` is checked into the repo at
+`.github/rulesets/main-protection.json` so drift between the GitHub
+ruleset UI and repo intent is visible in PR review. Pattern inspired
+by [Astral's ruleset-as-code approach](https://gist.github.com/woodruffw/643a6cf70ad72d404ce6f9f333181cf8).
+
+**Fast lane — required (blocks merge):**
+
+- `macos` — macOS build+test leg of `.github/workflows/build.yml`
+- `linux` — Linux (x64) build+test leg of `.github/workflows/build.yml`
+- `windows` — Windows (x64) build+test leg of `.github/workflows/build.yml`
+- `Enforce version & skill sync` — `.github/workflows/version-skill-check.yml`
+
+The three platform names are intentionally declared as **stable aliases**
+so the merge contract survives runner-provider swaps (github-hosted ↔
+namespace). The concrete context strings in `build.yml` today resolve
+to e.g. `macOS (ARM64) [namespace]`, which is not stable; landing the
+alias layer is part of #462.
+
+**Slow lane — advisory (does NOT block merge):**
+
+- `AddressSanitizer (macOS ARM64)`
+- `ThreadSanitizer (macOS ARM64)`
+- `UndefinedBehaviorSanitizer (macOS ARM64)`
+- `RealtimeSanitizer (Linux x86_64, Clang 18)`
+
+These run via `.github/workflows/sanitizers.yml` on `workflow_dispatch`
+only and are tracked in the checked-in JSON under `advisory_status_checks`
+for visibility/drift, never inside `rules[].required_status_checks`.
+
+**Drift enforcement:** `.github/workflows/ruleset-drift-check.yml` runs
+on PR (when `.github/rulesets/**` changes) and weekly on cron. It fetches
+the live ruleset via `gh api /repos/{owner}/{repo}/rulesets` and diffs
+against the checked-in JSON. PR runs post/update a single comment; the
+cron job fails loudly on drift so it shows up as a red check on `main`.
+
+**Making a change to required checks:** always edit the JSON first, open
+a PR, and let the drift-check workflow confirm the plan. Then mirror the
+change in the GitHub ruleset UI (or reapply via `gh api PUT`). Never edit
+the live ruleset in isolation — the next scheduled drift run will fail.
 
 ## Versioning & Skill-Sync gates (Layer 3)
 

--- a/.github/rulesets/main-protection.json
+++ b/.github/rulesets/main-protection.json
@@ -1,0 +1,100 @@
+{
+  "_comment": [
+    "Branch-protection ruleset for `main`, checked in as code so drift between",
+    "the GitHub ruleset UI and repo intent is visible in PR review.",
+    "",
+    "Tracked by Pulp issue #462 (formalize required-check fast/slow split).",
+    "Drift is detected by .github/workflows/ruleset-drift-check.yml, which",
+    "diffs this file against the live ruleset returned by",
+    "`gh api /repos/{owner}/{repo}/rulesets`.",
+    "",
+    "Schema reference (do NOT fetch at runtime): https://docs.github.com/en/rest/repos/rules",
+    "",
+    "Required-check contract (fast lane, blocks merge):",
+    "  - macos   : macOS build+test leg of .github/workflows/build.yml",
+    "  - linux   : Linux (x64) build+test leg of .github/workflows/build.yml",
+    "  - windows : Windows (x64) build+test leg of .github/workflows/build.yml",
+    "  - Enforce version & skill sync : .github/workflows/version-skill-check.yml",
+    "",
+    "The three platform names are intended as *stable aliases* that survive",
+    "runner-provider swaps (github-hosted <-> namespace). The concrete job",
+    "names in build.yml today resolve to e.g. `macOS (ARM64) [namespace]`,",
+    "which is not a stable contract. Landing the alias layer is part of #462;",
+    "until then, the drift workflow should be run with an alias map that maps",
+    "alias -> current context so the diff stays meaningful.",
+    "",
+    "Advisory (slow lane, does NOT block merge) — tracked here for visibility",
+    "and drift enforcement only. Do NOT move these into `required_status_checks`",
+    "without an explicit policy change, because they currently run on",
+    "workflow_dispatch only (see .github/workflows/sanitizers.yml):",
+    "  - AddressSanitizer (macOS ARM64)",
+    "  - ThreadSanitizer (macOS ARM64)",
+    "  - UndefinedBehaviorSanitizer (macOS ARM64)",
+    "  - RealtimeSanitizer (Linux x86_64, Clang 18)",
+    "",
+    "Pattern inspired by Astral's ruleset-as-code approach:",
+    "  https://gist.github.com/woodruffw/643a6cf70ad72d404ce6f9f333181cf8"
+  ],
+  "name": "main-protection",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "macos",
+            "integration_id": null
+          },
+          {
+            "context": "linux",
+            "integration_id": null
+          },
+          {
+            "context": "windows",
+            "integration_id": null
+          },
+          {
+            "context": "Enforce version & skill sync",
+            "integration_id": null
+          }
+        ]
+      }
+    }
+  ],
+  "advisory_status_checks": {
+    "_comment": "Not part of the GitHub rulesets schema. Consumed only by .github/workflows/ruleset-drift-check.yml so advisory drift is visible alongside required drift. Never copy into `rules[].required_status_checks`.",
+    "checks": [
+      { "context": "AddressSanitizer (macOS ARM64)" },
+      { "context": "ThreadSanitizer (macOS ARM64)" },
+      { "context": "UndefinedBehaviorSanitizer (macOS ARM64)" },
+      { "context": "RealtimeSanitizer (Linux x86_64, Clang 18)" }
+    ]
+  }
+}

--- a/.github/workflows/ruleset-drift-check.yml
+++ b/.github/workflows/ruleset-drift-check.yml
@@ -1,0 +1,270 @@
+name: Ruleset Drift Check
+
+# Issue #462. Detects drift between the checked-in branch-protection intent
+# (.github/rulesets/main-protection.json) and the live ruleset configured on
+# GitHub. Keeps the UI and the repo honest.
+#
+# Behavior:
+#   - On pull requests that touch .github/rulesets/** or this workflow:
+#       * Fetch the live ruleset via `gh api /repos/{owner}/{repo}/rulesets`.
+#       * Diff `rules[].required_status_checks` against the checked-in JSON.
+#       * Post/update a single PR comment summarizing any drift.
+#       * Job still passes on drift — PR-time behavior is advisory so authors
+#         can intentionally update the JSON alongside the GitHub UI.
+#   - Weekly cron (and workflow_dispatch):
+#       * Same diff, but drift on `main` is a hard failure so the next human
+#         looking at the repo sees a red check.
+#
+# The required vs. advisory split lives in the checked-in JSON:
+#   - rules[].parameters.required_status_checks -> merge-blocking
+#   - advisory_status_checks.checks             -> visibility/drift only
+#
+# Schema reference (do NOT fetch at runtime):
+#   https://docs.github.com/en/rest/repos/rules
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/rulesets/**'
+      - '.github/workflows/ruleset-drift-check.yml'
+  schedule:
+    # Tuesdays at 14:00 UTC (~07:00 PT). One business day after the orphan
+    # sweep so the two janitorial signals don't land on the same morning.
+    - cron: '0 14 * * 2'
+  workflow_dispatch:
+    inputs:
+      fail_on_drift:
+        description: 'If true, fail the job when drift is detected (default: schedule=true, pr=false)'
+        required: false
+        default: ''
+
+concurrency:
+  group: ruleset-drift-check-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read         # read checked-in ruleset JSON
+  pull-requests: write   # post/update the drift comment on PRs
+  # Note: reading org/repo rulesets via `gh api /repos/{owner}/{repo}/rulesets`
+  # requires the default GITHUB_TOKEN to have `administration: read`. If the
+  # workflow returns 403, grant the token that scope in repo settings or swap
+  # GH_TOKEN for a PAT/RELEASE_BOT_TOKEN with admin:read.
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    name: Diff checked-in ruleset against live GitHub ruleset
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CHECKED_IN_PATH: .github/rulesets/main-protection.json
+      RULESET_NAME: main-protection
+
+    steps:
+      - name: Checkout (shallow)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Fetch live rulesets
+        id: fetch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          repo='${{ github.repository }}'
+
+          # List all rulesets on the repo. The list endpoint returns summaries;
+          # we have to fetch the full ruleset by id to see the `rules` payload.
+          gh api -H "Accept: application/vnd.github+json" \
+              "/repos/${repo}/rulesets" > rulesets-list.json
+
+          ruleset_id=$(
+              python3 -c "import json,sys,os; name=os.environ['RULESET_NAME']; data=json.load(open('rulesets-list.json')); ids=[r['id'] for r in data if r.get('name')==name]; print(ids[0] if ids else '')"
+          )
+
+          if [ -z "${ruleset_id}" ]; then
+              echo "No live ruleset named '${RULESET_NAME}' found on ${repo}."
+              echo "found=false" >> "$GITHUB_OUTPUT"
+              echo '{}' > live-ruleset.json
+          else
+              echo "Found live ruleset #${ruleset_id} named '${RULESET_NAME}'."
+              echo "found=true" >> "$GITHUB_OUTPUT"
+              gh api -H "Accept: application/vnd.github+json" \
+                  "/repos/${repo}/rulesets/${ruleset_id}" > live-ruleset.json
+          fi
+
+      - name: Diff required and advisory checks
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY' > drift-report.md
+          import json
+          import os
+          import pathlib
+          import sys
+
+          checked_in_path = pathlib.Path(os.environ['CHECKED_IN_PATH'])
+          live_path = pathlib.Path('live-ruleset.json')
+
+          checked_in = json.loads(checked_in_path.read_text())
+          live = json.loads(live_path.read_text()) if live_path.exists() else {}
+
+          def required_contexts(doc: dict) -> list[str]:
+              out: list[str] = []
+              for rule in doc.get('rules', []) or []:
+                  if rule.get('type') != 'required_status_checks':
+                      continue
+                  params = rule.get('parameters', {}) or {}
+                  for check in params.get('required_status_checks', []) or []:
+                      ctx = check.get('context')
+                      if ctx:
+                          out.append(ctx)
+              return sorted(out)
+
+          def advisory_contexts(doc: dict) -> list[str]:
+              out: list[str] = []
+              advisory = doc.get('advisory_status_checks') or {}
+              for check in advisory.get('checks', []) or []:
+                  ctx = check.get('context')
+                  if ctx:
+                      out.append(ctx)
+              return sorted(out)
+
+          checked_required = required_contexts(checked_in)
+          live_required = required_contexts(live) if live else []
+          checked_advisory = advisory_contexts(checked_in)
+
+          missing_on_github = [c for c in checked_required if c not in live_required]
+          extra_on_github = [c for c in live_required if c not in checked_required]
+
+          drift_found = bool(missing_on_github or extra_on_github) or not live
+
+          def fmt(items: list[str]) -> str:
+              return '\n'.join(f'- `{x}`' for x in items) if items else '_(none)_'
+
+          lines = []
+          lines.append('## Ruleset drift report')
+          lines.append('')
+          lines.append(f'_Checked-in intent: `{checked_in_path}`_')
+          lines.append(f'_Live ruleset name: `{os.environ["RULESET_NAME"]}`_')
+          lines.append('')
+
+          if not live:
+              lines.append('**No live ruleset with the expected name was found on this repo.**')
+              lines.append('')
+              lines.append('Either the ruleset has not been created yet, or `GITHUB_TOKEN`')
+              lines.append('does not have `administration: read`. Create the ruleset via the')
+              lines.append('GitHub UI using the contexts listed below, or grant the workflow')
+              lines.append('token admin-read.')
+              lines.append('')
+
+          lines.append('### Required checks (merge-blocking)')
+          lines.append('')
+          lines.append('**Checked in:**')
+          lines.append(fmt(checked_required))
+          lines.append('')
+          lines.append('**Live on GitHub:**')
+          lines.append(fmt(live_required))
+          lines.append('')
+
+          if missing_on_github:
+              lines.append('**Missing on GitHub (declared in repo, not enforced live):**')
+              lines.append(fmt(missing_on_github))
+              lines.append('')
+          if extra_on_github:
+              lines.append('**Extra on GitHub (enforced live, not declared in repo):**')
+              lines.append(fmt(extra_on_github))
+              lines.append('')
+
+          lines.append('### Advisory checks (visibility only, never required)')
+          lines.append('')
+          lines.append(fmt(checked_advisory))
+          lines.append('')
+
+          lines.append('---')
+          if drift_found:
+              lines.append('**Drift detected.** Update `.github/rulesets/main-protection.json`')
+              lines.append('to match intent, or update the ruleset on GitHub to match the file.')
+          else:
+              lines.append('No drift detected. Required checks match the checked-in intent.')
+
+          print('\n'.join(lines))
+
+          out_path = pathlib.Path(os.environ['GITHUB_OUTPUT'])
+          with out_path.open('a', encoding='utf-8') as handle:
+              handle.write(f'drift={"true" if drift_found else "false"}\n')
+          PY
+
+          echo "Rendered drift report:"
+          echo "----"
+          cat drift-report.md
+          echo "----"
+
+      - name: Comment on PR with drift report
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: '<!-- ruleset-drift-check -->'
+        run: |
+          set -euo pipefail
+
+          repo='${{ github.repository }}'
+          body="${MARKER}"$'\n'"$(cat drift-report.md)"
+
+          # Find an existing bot-authored comment with our marker, if any.
+          existing=$(
+              gh api -H "Accept: application/vnd.github+json" \
+                  "/repos/${repo}/issues/${PR_NUMBER}/comments" \
+                  --paginate \
+                  --jq "[.[] | select(.body != null and (.body | contains(\"${MARKER}\")))] | first | .id // empty"
+          )
+
+          if [ -z "${existing:-}" ]; then
+              echo "Creating drift comment on PR #${PR_NUMBER}."
+              printf '%s' "$body" | gh pr comment "$PR_NUMBER" --repo "$repo" --body-file -
+          else
+              echo "Updating drift comment #${existing} on PR #${PR_NUMBER}."
+              gh api \
+                  --method PATCH \
+                  -H "Accept: application/vnd.github+json" \
+                  "/repos/${repo}/issues/comments/${existing}" \
+                  -f body="$body" >/dev/null
+          fi
+
+      - name: Upload drift report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruleset-drift-report
+          path: |
+            drift-report.md
+            live-ruleset.json
+            ${{ env.CHECKED_IN_PATH }}
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Fail on drift (scheduled/manual runs)
+        if: steps.diff.outputs.drift == 'true' && github.event_name != 'pull_request'
+        shell: bash
+        env:
+          FAIL_OVERRIDE: ${{ inputs.fail_on_drift }}
+        run: |
+          # Scheduled runs on `main` treat drift as a hard failure so it
+          # surfaces as a red check without blocking in-flight PRs.
+          # workflow_dispatch honors the `fail_on_drift` input if provided.
+          if [ "${FAIL_OVERRIDE:-}" = "false" ]; then
+              echo "Drift detected, but fail_on_drift=false was requested — leaving job green."
+              exit 0
+          fi
+          echo "Drift detected on ${{ github.ref }} — failing the job."
+          exit 1


### PR DESCRIPTION
Closes #462. Formalizes the fast/slow required-check split from #419 as a checked-in JSON ruleset + drift-check workflow. Required (block merge): macos, linux, windows aliases + version/skill sync. Advisory (don't block): sanitizer jobs. Drift between GitHub ruleset UI and repo policy shows up as a PR comment or hard-fail on cron. Also updates the ci skill with a 'Required-check ruleset' section.