### PR TITLE
fix(docs): Pagefind results drawer as anchored overlay (#472)

### DIFF
--- a/tools/build-docs.py
+++ b/tools/build-docs.py
@@ -535,6 +535,7 @@ h4:hover .permalink {{ opacity: 0.6; }}
   flex: 1;
   max-width: 360px;
   margin: 0 16px;
+  position: relative;     /* anchor the absolutely-positioned drawer */
 }}
 .header-search .pagefind-ui {{
   --pagefind-ui-scale: 0.7;
@@ -546,6 +547,29 @@ h4:hover .permalink {{ opacity: 0.6; }}
   --pagefind-ui-border-width: 1px;
   --pagefind-ui-border-radius: 6px;
   --pagefind-ui-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}}
+/* Detach the results drawer from the fixed-height header so it opens
+   as an overlay below the input instead of pushing the input up and
+   rendering transparently over the page body. */
+.header-search .pagefind-ui__drawer {{
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  max-height: calc(100vh - 96px);
+  overflow-y: auto;
+  background: #0d1117;
+  border: 1px solid #2a2a4a;
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6);
+  z-index: 101;           /* header is 100; drawer sits above its siblings */
+  padding: 8px 12px;
+}}
+/* When the drawer is empty (no input yet) keep it fully collapsed so
+   the empty overlay box doesn't ghost under the input. */
+.header-search .pagefind-ui__drawer:empty,
+.header-search .pagefind-ui__drawer.pagefind-ui__hidden {{
+  display: none;
 }}
 .pagefind-ui--reset mark,
 .pagefind-ui mark {{


### PR DESCRIPTION
## Summary

Closes #472. Three bugs from the #461 Pagefind restore:

1. **Input disappeared on focus** — the results drawer expanded inside the \`position: fixed; height: 48px\` header, pushing the input out of its flex row.
2. **Results detached from input** — drawer rendered far below the query with no visual anchor to the search box.
3. **Transparent panel** — no background on the drawer, so body content (and Pagefind's own page-body \`<mark>\` highlights) bled through.

## Fix (CSS only, \`tools/build-docs.py\`)

- \`.header-search { position: relative }\` — anchor for the drawer
- \`.pagefind-ui__drawer\`:
  - \`position: absolute; top: calc(100% + 6px); left: 0; right: 0\`
  - \`background: #0d1117\` (site surface) + border + border-radius + box-shadow
  - \`z-index: 101\` (header is 100)
  - \`max-height: calc(100vh - 96px); overflow-y: auto\`
  - \`padding: 8px 12px\`
- \`.pagefind-ui__drawer:empty\` / \`.pagefind-ui__hidden { display: none }\` — no ghost panel when no query

## Test plan

- [x] Local build verified: \`python3 tools/build-docs.py --output /tmp/pulp-docs-test --base-url /pulp/ --branch main\` → 68 pages, required CSS rules present in \`index.html\`.
- [ ] Production deploy test after merge — type in search, confirm:
  - Input stays at its position inside the header
  - Results open as opaque dropdown directly below input
  - Query text + typed characters remain visible

## References
- Issue #472 / original restore #461