### PR TITLE
test(env): static_assert macOS memory-pressure mask (#466 Codex test gap)

### DIFF
--- a/core/platform/platform/mac/environment_mac.mm
+++ b/core/platform/platform/mac/environment_mac.mm
@@ -145,12 +145,23 @@ void publish_full_snapshot(LifecycleState lifecycle, MemoryPressure pressure) {
     // Memory pressure dispatch source. Includes NORMAL so apps receive a
     // memory_pressure = normal recovery event after WARN/CRITICAL clears
     // (otherwise listeners that released caches on pressure never know
-    // it's safe to repopulate them).
+    // it's safe to repopulate them). The mask is named + static_asserted
+    // so a future refactor that drops NORMAL fails at compile time on
+    // macOS, not silently at runtime the way #404 did.
+    constexpr unsigned long kMemoryPressureMask =
+        DISPATCH_MEMORYPRESSURE_NORMAL
+        | DISPATCH_MEMORYPRESSURE_WARN
+        | DISPATCH_MEMORYPRESSURE_CRITICAL;
+    static_assert((kMemoryPressureMask & DISPATCH_MEMORYPRESSURE_NORMAL) != 0,
+                  "NORMAL required so apps get a recovery event after "
+                  "pressure clears (#404 / #466)");
+    static_assert((kMemoryPressureMask & DISPATCH_MEMORYPRESSURE_WARN) != 0,
+                  "WARN required for moderate-pressure signal");
+    static_assert((kMemoryPressureMask & DISPATCH_MEMORYPRESSURE_CRITICAL) != 0,
+                  "CRITICAL required for critical-pressure signal");
     _pressureSource = dispatch_source_create(
         DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0,
-        DISPATCH_MEMORYPRESSURE_NORMAL
-            | DISPATCH_MEMORYPRESSURE_WARN
-            | DISPATCH_MEMORYPRESSURE_CRITICAL,
+        kMemoryPressureMask,
         dispatch_get_main_queue());
     if (_pressureSource) {
         // Observer is process-lived (created via dispatch_once and never

--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -161,6 +161,12 @@ TEST_CASE("Environment: memory pressure transitions", "[environment]") {
     REQUIRE(observed == 1);
 }
 
+// Note: this case exercises the listener contract (diff is emitted
+// on normal-recovery) via inject_for_test, which bypasses the platform
+// dispatch source. The platform-side mask that makes that recovery
+// event actually fire on macOS is guarded by static_assert in
+// core/platform/platform/mac/environment_mac.mm — see #466 follow-up
+// for the layered coverage decision.
 TEST_CASE("Environment: memory pressure recovery to normal fires diff",
           "[environment][issue-404]") {
     Environment::reset_for_test();


### PR DESCRIPTION
Codex flagged that #466's Catch2 test uses inject_for_test() which bypasses the DISPATCH_SOURCE_TYPE_MEMORYPRESSURE mask the PR actually fixes. Runtime testing of dispatch sources is impractical; now guarded by compile-time static_assert in environment_mac.mm — any refactor that drops NORMAL fails the macOS build. Closes the 'CI green isn't a test' gap.