### PR TITLE
ci: post-merge fixes to orphan/deps/ruleset drift workflows (P1 + 3×P2)

### DIFF
--- a/.github/workflows/deps-drift-check.yml
+++ b/.github/workflows/deps-drift-check.yml
@@ -194,11 +194,14 @@ jobs:
           repo='${{ github.repository }}'
           title="${TRACKING_TITLE}"
 
-          # Find any open issue with this exact title in this repo.
+          # Find any issue (open OR closed) with this exact title. --state all
+          # ensures we reopen the same tracker instead of creating a new one
+          # when drift reappears after a clean run; otherwise history
+          # fragments across multiple closed issues.
           existing=$(
               gh issue list \
                   --repo "$repo" \
-                  --state open \
+                  --state all \
                   --search "in:title \"${title}\"" \
                   --json number,title \
                   --jq "[.[] | select(.title == \"${title}\")] | first | .number // empty"

--- a/.github/workflows/orphan-branch-sweep.yml
+++ b/.github/workflows/orphan-branch-sweep.yml
@@ -122,9 +122,14 @@ jobs:
               fi
 
               # Get the tip commit's committer date to apply the age filter.
+              # URL-encode the branch name — `feature/stream`-style names are
+              # dominant in this repo and unencoded slashes break the path
+              # segment, so the request 404s and the orphan gets silently
+              # skipped. python3 --quote preserves unreserved chars.
+              branch_enc=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$branch")
               tip_iso=$(
                   gh api -H "Accept: application/vnd.github+json" \
-                      "/repos/${repo}/branches/${branch}" \
+                      "/repos/${repo}/branches/${branch_enc}" \
                       --jq '.commit.commit.committer.date' \
                       2>/dev/null || echo ''
               )
@@ -217,12 +222,15 @@ jobs:
           repo='${{ github.repository }}'
           title="${TRACKING_TITLE}"
 
-          # Find any open issue with this exact title authored by anyone.
-          # Restrict the search to this repo to avoid global matches.
+          # Find any issue (open OR closed) with this exact title. If we
+          # only look at --state open, a previous sweep that closed the
+          # tracker will cause a new tracking issue to be created when
+          # orphans reappear, fragmenting history. --state all lets us
+          # reopen the existing tracker instead.
           existing=$(
               gh issue list \
                   --repo "$repo" \
-                  --state open \
+                  --state all \
                   --search "in:title \"${title}\"" \
                   --json number,title \
                   --jq "[.[] | select(.title == \"${title}\")] | first | .number // empty"

--- a/.github/workflows/ruleset-drift-check.yml
+++ b/.github/workflows/ruleset-drift-check.yml
@@ -80,13 +80,16 @@ jobs:
 
           repo='${{ github.repository }}'
 
-          # List all rulesets on the repo. The list endpoint returns summaries;
-          # we have to fetch the full ruleset by id to see the `rules` payload.
+          # List repo-scoped rulesets only. The default /rulesets response
+          # includes inherited org-level rulesets — if any of those share a
+          # name with our repo ruleset, `ids[0]` could pick the org-level one
+          # and falsely report drift. Filter to source_type == "Repository"
+          # so we only diff against the one actually defined in this repo.
           gh api -H "Accept: application/vnd.github+json" \
-              "/repos/${repo}/rulesets" > rulesets-list.json
+              "/repos/${repo}/rulesets?includes_parents=false" > rulesets-list.json
 
           ruleset_id=$(
-              python3 -c "import json,sys,os; name=os.environ['RULESET_NAME']; data=json.load(open('rulesets-list.json')); ids=[r['id'] for r in data if r.get('name')==name]; print(ids[0] if ids else '')"
+              python3 -c "import json,os; name=os.environ['RULESET_NAME']; data=json.load(open('rulesets-list.json')); ids=[r['id'] for r in data if r.get('name')==name and r.get('source_type')=='Repository']; print(ids[0] if ids else '')"
           )
 
           if [ -z "${ruleset_id}" ]; then
@@ -210,7 +213,11 @@ jobs:
           echo "----"
 
       - name: Comment on PR with drift report
-        if: github.event_name == 'pull_request'
+        # Skip fork/Dependabot PRs — GITHUB_TOKEN is read-only on fork heads
+        # so gh pr comment fails with 403 and hard-fails the workflow even
+        # though PR-mode drift is meant to be advisory. The artifact upload
+        # still runs, so drift reports remain accessible.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Follow-up to Codex review of today's #469/#470/#471. Four findings, one P1 (URL-encode branch names in orphan sweep — currently silently skips every slash-named branch, making the just-landed workflow inert for this repo) + three P2 (two tracking-issue --state open bugs, one ruleset parent-scope bug, one fork-PR comment gate). See commit body for each finding's details.