### PR TITLE
audio(android): wire Oboe input-stream frame read (#244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0210"></a>
+## [0.22.0]
+
 ## [0.21.0] - 2026-04-19
 
 - platform: unified Environment API for display/safe-area/keyboard/scheme/lifecycle/memory (#342) ([#403](https://github.com/danielraffel/pulp/pull/403))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.21.0
+    VERSION 0.22.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/include/pulp/audio/frame_fill.hpp
+++ b/core/audio/include/pulp/audio/frame_fill.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+// Small, platform-independent helpers for handling partial-read input
+// buffers in the audio callback. Extracted from the Android Oboe device
+// (#244) so the fill math is unit-testable without pulling in Oboe.
+
+#include <cstddef>
+#include <cstring>
+
+namespace pulp::audio {
+
+/// Zero-fill the trailing samples of an interleaved input buffer after a
+/// short read. The caller has populated [0, frames_read) from the input
+/// stream; this routine zeros the range [frames_read, total_frames) so
+/// the downstream processor sees a deterministic, full-size buffer.
+///
+/// buf: interleaved float frames (total_frames × channels samples).
+/// frames_read: number of frames actually populated (>= 0, <= total_frames).
+/// total_frames: number of frames requested for the callback.
+/// channels: interleaving factor (1 = mono, 2 = stereo, ...).
+///
+/// Safe to call with frames_read == total_frames (no-op) and with
+/// frames_read == 0 (zeroes the whole buffer). Does nothing if any
+/// argument is non-positive or buf is null.
+inline void zero_fill_short_read(float* buf,
+                                 int frames_read,
+                                 int total_frames,
+                                 int channels) noexcept {
+    if (buf == nullptr) return;
+    if (channels <= 0) return;
+    if (total_frames <= 0) return;
+    if (frames_read < 0) frames_read = 0;
+    if (frames_read > total_frames) frames_read = total_frames;
+    const std::size_t samples_read =
+        static_cast<std::size_t>(frames_read) * static_cast<std::size_t>(channels);
+    const std::size_t samples_total =
+        static_cast<std::size_t>(total_frames) * static_cast<std::size_t>(channels);
+    if (samples_read >= samples_total) return;
+    std::memset(buf + samples_read, 0,
+                sizeof(float) * (samples_total - samples_read));
+}
+
+} // namespace pulp::audio

--- a/core/audio/platform/android/oboe_device.cpp
+++ b/core/audio/platform/android/oboe_device.cpp
@@ -1,13 +1,16 @@
 #if defined(__ANDROID__)
 
 #include <oboe/Oboe.h>
+#include <pulp/audio/frame_fill.hpp>
 #include <pulp/platform/android/jni.hpp>
 #include <pulp/midi/buffer.hpp>
 #include <pulp/midi/android_midi_fifo.hpp>
 #include <android/log.h>
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstring>
+#include <vector>
 
 #define PULP_LOG_TAG "Pulp"
 #define PULP_LOGI(...) __android_log_print(ANDROID_LOG_INFO, PULP_LOG_TAG, __VA_ARGS__)
@@ -61,6 +64,23 @@ public:
                 PULP_LOGW("Oboe: input-stream start failed");
                 input_stream_->close();
                 input_stream_.reset();
+                input_buffer_.clear();
+                current_input_channels_ = 0;
+            } else {
+                // Size the persistent input buffer to the effective burst
+                // size × channel count. Allocation happens here (main
+                // thread) so the audio callback stays malloc-free. We
+                // overprovision to 4× the negotiated burst to absorb any
+                // catch-up reads when the two streams drift briefly.
+                current_input_channels_ = input_stream_->getChannelCount();
+                const int32_t capacity_frames = std::max(
+                    current_buffer_size_ * 4, input_stream_->getFramesPerBurst() * 4);
+                input_buffer_.assign(
+                    static_cast<size_t>(capacity_frames) *
+                        static_cast<size_t>(current_input_channels_),
+                    0.0f);
+                PULP_LOGI("Oboe: input buffer provisioned for %d frames × %d ch",
+                          capacity_frames, current_input_channels_);
             }
         }
         return true;
@@ -79,6 +99,9 @@ public:
             input_stream_->close();
             input_stream_.reset();
         }
+        input_buffer_.clear();
+        input_buffer_.shrink_to_fit();
+        current_input_channels_ = 0;
     }
 
     // -- State --
@@ -88,6 +111,18 @@ public:
     int32_t channel_count() const { return current_channels_; }
     int64_t xrun_count() const { return xrun_count_.load(std::memory_order_relaxed); }
     bool is_bluetooth_active() const { return bluetooth_active_.load(std::memory_order_acquire); }
+
+    // #244: input-stream diagnostics. short_reads increments when
+    // onAudioReady drains fewer frames than requested (warm-up, transient
+    // drift); read_errors increments on a hard read failure that zero-filled
+    // the block. Both are useful for UI-level input-health indicators.
+    int32_t input_channel_count() const { return current_input_channels_; }
+    int64_t input_short_read_count() const {
+        return input_short_reads_.load(std::memory_order_relaxed);
+    }
+    int64_t input_read_error_count() const {
+        return input_read_errors_.load(std::memory_order_relaxed);
+    }
 
     /// MIDI buffer for the current audio block. Drained from the
     /// lock-free FIFO at the start of each onAudioReady callback.
@@ -144,9 +179,46 @@ private:
 #endif
 
         if (callback_) {
-            // Input: read from input stream if available (non-blocking, lock-free)
+            // #244: Drain the input stream on the same callback tick. Oboe's
+            // recommended full-duplex pattern is to do a non-blocking read
+            // on the output-stream callback — AAudio keeps the two streams
+            // in step on a shared device period in practice.
+            //
+            // Non-blocking = timeoutNanos 0. Short-read (fewer frames
+            // available than num_frames) is expected on the first few
+            // callbacks while the input stream warms up; we zero-fill the
+            // tail so the Processor sees a deterministic buffer shape.
+            //
+            // All allocation happens in start() / on_input_config_changed();
+            // this path is lock-free and malloc-free.
             const float* input_data = nullptr;
-            // TODO: Read from input_stream_ if open
+            if (input_stream_ && !input_buffer_.empty()) {
+                const int32_t in_channels = current_input_channels_;
+                const size_t samples_needed =
+                    static_cast<size_t>(num_frames) * static_cast<size_t>(in_channels);
+                float* buf = input_buffer_.data();
+
+                auto result = input_stream_->read(buf, num_frames, /*timeoutNanos=*/0);
+                if (result == oboe::Result::OK) {
+                    int32_t frames_read = result.value();
+                    if (frames_read < num_frames) {
+                        // Zero-fill the tail so the callback sees a
+                        // full-sized buffer with silence for the
+                        // unavailable frames.
+                        pulp::audio::zero_fill_short_read(
+                            buf, frames_read, num_frames, in_channels);
+                        input_short_reads_.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    input_data = buf;
+                } else {
+                    // Read failure (stream disconnected mid-callback): zero
+                    // the buffer and surface nullptr so the Processor knows
+                    // input isn't available this block. onErrorAfterClose
+                    // will trigger a reopen out-of-band.
+                    std::memset(buf, 0, sizeof(float) * samples_needed);
+                    input_read_errors_.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
 
             callback_(output, input_data, num_frames, current_channels_, user_data_);
         } else {
@@ -292,10 +364,18 @@ private:
     int32_t current_sample_rate_ = 48000;
     int32_t current_buffer_size_ = 256;
     int32_t current_channels_ = 2;
+    int32_t current_input_channels_ = 0;  // #244
 
     std::atomic<int64_t> xrun_count_{0};
     int32_t last_reported_xruns_ = 0;
     std::atomic<int64_t> last_callback_duration_ns_{0};
+
+    // #244: persistent input-frame buffer. Allocated in start() (main
+    // thread); sized to cover 4× the burst so onAudioReady can drain
+    // without allocating. Accessed only on the audio thread.
+    std::vector<float> input_buffer_;
+    std::atomic<int64_t> input_short_reads_{0};
+    std::atomic<int64_t> input_read_errors_{0};
 
     // Per-block MIDI buffer, drained from the lock-free FIFO each callback.
     pulp::midi::MidiBuffer midi_buffer_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,6 +88,12 @@ add_executable(pulp-test-stream test_stream.cpp)
 target_link_libraries(pulp-test-stream PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-stream)
 
+# #244: zero-fill helper for the Oboe input-frame-read short-read path.
+# Header-only math, so no library link required beyond Catch2.
+add_executable(pulp-test-frame-fill test_frame_fill.cpp)
+target_link_libraries(pulp-test-frame-fill PRIVATE pulp::audio Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-frame-fill)
+
 # AsyncStream tests (Phase 2)
 add_executable(pulp-test-async-stream test_async_stream.cpp)
 target_link_libraries(pulp-test-async-stream PRIVATE pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_frame_fill.cpp
+++ b/test/test_frame_fill.cpp
@@ -1,0 +1,90 @@
+// Tests for the short-read zero-fill helper used by the Oboe Android
+// input-frame-read path (#244). The Android Oboe callback can get a
+// partial read while the input stream warms up; the helper zeroes the
+// tail so downstream code sees a deterministic, full-sized buffer.
+
+#include <pulp/audio/frame_fill.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <vector>
+
+using pulp::audio::zero_fill_short_read;
+
+namespace {
+
+std::vector<float> make_poisoned(int total_frames, int channels) {
+    std::vector<float> buf(static_cast<std::size_t>(total_frames) *
+                           static_cast<std::size_t>(channels),
+                           0.5f);  // non-zero sentinel
+    return buf;
+}
+
+} // namespace
+
+TEST_CASE("zero_fill_short_read: full read is a no-op",
+          "[audio][frame-fill][issue-244]") {
+    auto buf = make_poisoned(8, 2);
+    zero_fill_short_read(buf.data(), /*frames_read=*/8, /*total=*/8, /*ch=*/2);
+    for (float v : buf) REQUIRE(v == 0.5f);
+}
+
+TEST_CASE("zero_fill_short_read: partial read zeros the tail, keeps head",
+          "[audio][frame-fill][issue-244]") {
+    auto buf = make_poisoned(8, 2);
+    // Simulate frames 0..3 populated (4 frames × 2 ch = 8 samples), tail zeros.
+    zero_fill_short_read(buf.data(), /*frames_read=*/4, /*total=*/8, /*ch=*/2);
+    for (int i = 0; i < 8; ++i) REQUIRE(buf[i] == 0.5f);
+    for (int i = 8; i < 16; ++i) REQUIRE(buf[i] == 0.0f);
+}
+
+TEST_CASE("zero_fill_short_read: frames_read == 0 zeros the whole buffer",
+          "[audio][frame-fill][issue-244]") {
+    auto buf = make_poisoned(4, 2);
+    zero_fill_short_read(buf.data(), /*frames_read=*/0, /*total=*/4, /*ch=*/2);
+    for (float v : buf) REQUIRE(v == 0.0f);
+}
+
+TEST_CASE("zero_fill_short_read: handles mono (single channel)",
+          "[audio][frame-fill][issue-244]") {
+    auto buf = make_poisoned(8, 1);
+    zero_fill_short_read(buf.data(), /*frames_read=*/3, /*total=*/8, /*ch=*/1);
+    for (int i = 0; i < 3; ++i) REQUIRE(buf[i] == 0.5f);
+    for (int i = 3; i < 8; ++i) REQUIRE(buf[i] == 0.0f);
+}
+
+TEST_CASE("zero_fill_short_read: negative frames_read clamped to 0",
+          "[audio][frame-fill][issue-244]") {
+    auto buf = make_poisoned(4, 2);
+    zero_fill_short_read(buf.data(), /*frames_read=*/-1, /*total=*/4, /*ch=*/2);
+    for (float v : buf) REQUIRE(v == 0.0f);
+}
+
+TEST_CASE("zero_fill_short_read: over-reported frames_read clamped to total",
+          "[audio][frame-fill][issue-244]") {
+    auto buf = make_poisoned(4, 2);
+    zero_fill_short_read(buf.data(), /*frames_read=*/99, /*total=*/4, /*ch=*/2);
+    // No zeroing — frames_read >= total is treated as a full read.
+    for (float v : buf) REQUIRE(v == 0.5f);
+}
+
+TEST_CASE("zero_fill_short_read: null buffer is a no-op",
+          "[audio][frame-fill][issue-244]") {
+    // Would crash if not guarded.
+    zero_fill_short_read(nullptr, 1, 8, 2);
+    SUCCEED("no crash");
+}
+
+TEST_CASE("zero_fill_short_read: zero channels is a no-op",
+          "[audio][frame-fill][issue-244]") {
+    auto buf = make_poisoned(4, 1);
+    zero_fill_short_read(buf.data(), 2, 4, /*ch=*/0);
+    for (float v : buf) REQUIRE(v == 0.5f);
+}
+
+TEST_CASE("zero_fill_short_read: zero total_frames is a no-op",
+          "[audio][frame-fill][issue-244]") {
+    float buf[4] = {0.5f, 0.5f, 0.5f, 0.5f};
+    zero_fill_short_read(buf, 0, /*total=*/0, 2);
+    for (float v : buf) REQUIRE(v == 0.5f);
+}


### PR DESCRIPTION
## Summary

Closes #244. \`OboeDevice\` already opened an input stream when \`requested_input_channels_ > 0\`, but the \`onAudioReady\` audio callback had a \`// TODO\` where the actual read should happen — \`input_data\` passed to the user callback was always \`nullptr\`.

## What changed

### \`core/audio/platform/android/oboe_device.cpp\`

- Persistent \`input_buffer_\` allocated in \`start()\` on the main thread; sized to \`max(4× current_buffer_size_, 4× input burst) × input_channel_count\`. The audio callback stays malloc-free.
- \`current_input_channels_\` captured from the opened stream (may differ from output — e.g. mono mic + stereo out).
- Non-blocking read (\`timeoutNanos = 0\`) on every \`onAudioReady\` from the OUTPUT callback — Oboe's recommended full-duplex pattern.
- Short-reads: zero-fill the tail via \`zero_fill_short_read()\`, increment \`input_short_reads_\`. Expected during stream warm-up.
- Read failure: zero buffer, increment \`input_read_errors_\`, surface \`nullptr\` to the user callback. \`onErrorAfterClose\` reopens out-of-band.
- \`stop()\` releases the buffer + resets channel count.

### \`core/audio/include/pulp/audio/frame_fill.hpp\` (new)

- \`zero_fill_short_read(buf, frames_read, total_frames, channels)\` — the arithmetic used to zero the trailing samples of a partial read. Extracted as a free function so it's unit-testable without pulling in Oboe/JNI.
- Handles: null buf, 0 channels, 0 total_frames, negative / over-reported frames_read.

### Diagnostics surface (for future input-health UI)

- \`input_channel_count()\` — 0 when no input stream active
- \`input_short_read_count()\` — cumulative short-read count
- \`input_read_error_count()\` — cumulative hard-failure count

## Test plan

- [x] **Unit tests**: \`test/test_frame_fill.cpp\` — 9 Catch2 cases, 73 assertions. Local run (\`clang++ + libCatch2d.a\`): all pass.
- [x] **NDK syntax check**: \`clang --target=aarch64-none-linux-android28 -fsyntax-only\` against the real NDK sysroot — clean.
- [ ] **CI cross-platform**: macOS/Linux/Windows build + test (this PR)
- [ ] **Emulator verification**: deferred to the next Android device-gated slice. The free-function test covers the short-read math (the piece at risk of off-by-one bugs); the wiring itself (stream lifetime, malloc-free callback) is best exercised on hardware.

## References

- Issue #244
- Workstream 02 (original input-stream scaffolding)
- Oboe full-duplex pattern: https://github.com/google/oboe/blob/main/docs/FullDuplexStream.md