### PR TITLE
audio: cross-platform AudioFocusRegistry + Android JNI wiring (#334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0220"></a>
+## [0.23.0]
+
 ## [0.22.0] - 2026-04-20
 
 - audio(android): wire Oboe input-stream frame read (#244) ([#478](https://github.com/danielraffel/pulp/pull/478))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.22.0
+    VERSION 0.23.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/CMakeLists.txt
+++ b/core/audio/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(pulp-audio
 
 target_sources(pulp-audio PRIVATE
     src/audio_file.cpp
+    src/audio_focus.cpp
     src/window_enumerator.cpp
     src/format_registry.cpp
     src/codecs.c

--- a/core/audio/include/pulp/audio/audio_focus.hpp
+++ b/core/audio/include/pulp/audio/audio_focus.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+// Cross-platform audio-focus registry (#334).
+//
+// Android's AudioManager.OnAudioFocusChangeListener fires lost / duck /
+// gained / lost-transient events when another app grabs the speaker
+// (phone call, navigation prompt, another DAW). The plugin / app needs
+// to pause output on full loss, attenuate on duck, and resume on gain.
+//
+// AndroidManifest-level wiring lives in android/app/src/main/kotlin/
+// com/pulp/audio/PulpAudioFocus.kt, which forwards events over JNI
+// (core/platform/src/android/jni_bridge.cpp) into this registry.
+//
+// Listeners subscribe with an RAII token. The publish path is lock-free
+// on the hot side (atomic snapshot); subscribe/unsubscribe take a mutex
+// but neither is ever called from the audio thread.
+//
+// Shape mirrors pulp::platform::Environment so clients see a consistent
+// observer pattern across system-signal surfaces. iOS support goes
+// through AVAudioSession interruption notifications in a future slice;
+// on platforms without an OS-level audio-focus concept (desktop
+// macOS/Linux/Windows) the registry stays idle and reports `gained`.
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <vector>
+
+namespace pulp::audio {
+
+/// Audio-focus state reported to listeners.
+///
+/// `gained` is the default / idle state on platforms without an OS
+/// focus model. `duck` is a non-fatal attenuation request (reduce
+/// output ~6 dB) that persists until the next `gained`. `lost` is a
+/// full output stop; listeners should stop pushing non-silence
+/// until the next `gained`. `lost_transient` is a short-lived loss
+/// (e.g. an incoming call) — listeners may pause-and-resume rather
+/// than drop state.
+enum class AudioFocusState : std::uint8_t {
+    gained = 0,
+    duck = 1,
+    lost = 2,
+    lost_transient = 3,
+};
+
+class AudioFocusRegistry {
+public:
+    using Callback = std::function<void(AudioFocusState)>;
+
+    /// RAII subscription token. Move-only; destruction unsubscribes.
+    class Token {
+    public:
+        Token() = default;
+        explicit Token(int id) : id_(id) {}
+        Token(Token&& other) noexcept : id_(other.id_) { other.id_ = 0; }
+        Token& operator=(Token&& other) noexcept {
+            if (this != &other) {
+                reset();
+                id_ = other.id_;
+                other.id_ = 0;
+            }
+            return *this;
+        }
+        Token(const Token&) = delete;
+        Token& operator=(const Token&) = delete;
+        ~Token() { reset(); }
+        void reset() noexcept;
+        int id() const noexcept { return id_; }
+    private:
+        int id_ = 0;
+    };
+
+    static AudioFocusRegistry& instance();
+
+    /// Subscribe a callback. Callback fires on the thread that calls
+    /// publish() — typically the JNI thread for Android, main thread
+    /// on iOS. Callbacks must be cheap and must not block the audio
+    /// thread; the usual pattern is to stash the state in an atomic
+    /// and read it from the audio callback.
+    Token subscribe(Callback cb);
+
+    /// Publish a new state. Dispatches to all current subscribers
+    /// OUTSIDE the internal mutex so a listener that drops its own
+    /// token (and re-enters unsubscribe) does not deadlock.
+    void publish(AudioFocusState state);
+
+    /// Snapshot the last published state. Lock-free. Safe to call
+    /// from the audio thread.
+    AudioFocusState current() const noexcept {
+        return static_cast<AudioFocusState>(
+            current_.load(std::memory_order_acquire));
+    }
+
+    /// Reset for tests — clears all subscribers + state.
+    void reset_for_test();
+
+private:
+    friend class Token;
+    void unsubscribe(int id) noexcept;
+
+    AudioFocusRegistry() = default;
+
+    mutable std::mutex mtx_;
+    int next_id_ = 1;
+    std::vector<std::pair<int, Callback>> cbs_;
+    std::atomic<std::uint8_t> current_{
+        static_cast<std::uint8_t>(AudioFocusState::gained)};
+};
+
+} // namespace pulp::audio

--- a/core/audio/src/audio_focus.cpp
+++ b/core/audio/src/audio_focus.cpp
@@ -1,0 +1,64 @@
+#include <pulp/audio/audio_focus.hpp>
+
+namespace pulp::audio {
+
+// ── Token ──────────────────────────────────────────────────────────────────
+
+void AudioFocusRegistry::Token::reset() noexcept {
+    if (id_ != 0) {
+        AudioFocusRegistry::instance().unsubscribe(id_);
+        id_ = 0;
+    }
+}
+
+// ── Registry ───────────────────────────────────────────────────────────────
+
+AudioFocusRegistry& AudioFocusRegistry::instance() {
+    static AudioFocusRegistry reg;
+    return reg;
+}
+
+AudioFocusRegistry::Token AudioFocusRegistry::subscribe(Callback cb) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    int id = next_id_++;
+    cbs_.emplace_back(id, std::move(cb));
+    return Token{id};
+}
+
+void AudioFocusRegistry::unsubscribe(int id) noexcept {
+    std::lock_guard<std::mutex> lock(mtx_);
+    for (auto it = cbs_.begin(); it != cbs_.end(); ++it) {
+        if (it->first == id) {
+            cbs_.erase(it);
+            return;
+        }
+    }
+}
+
+void AudioFocusRegistry::publish(AudioFocusState state) {
+    current_.store(static_cast<std::uint8_t>(state), std::memory_order_release);
+
+    // Copy the callback list under the lock so we can dispatch outside
+    // it. A callback that drops its own token (and re-enters
+    // unsubscribe) would otherwise deadlock on mtx_. Snapshot cost is
+    // O(subscribers) but the number is tiny in practice (one per
+    // audio stream + one or two tools).
+    std::vector<std::pair<int, Callback>> snapshot;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        snapshot = cbs_;
+    }
+    for (auto& [id, cb] : snapshot) {
+        cb(state);
+    }
+}
+
+void AudioFocusRegistry::reset_for_test() {
+    std::lock_guard<std::mutex> lock(mtx_);
+    cbs_.clear();
+    next_id_ = 1;
+    current_.store(static_cast<std::uint8_t>(AudioFocusState::gained),
+                   std::memory_order_release);
+}
+
+} // namespace pulp::audio

--- a/core/platform/src/android/jni_bridge.cpp
+++ b/core/platform/src/android/jni_bridge.cpp
@@ -1,5 +1,6 @@
 #if defined(__ANDROID__)
 
+#include <pulp/audio/audio_focus.hpp>
 #include <pulp/platform/android/jni.hpp>
 #include <pulp/platform/environment.hpp>
 #include <android/log.h>
@@ -285,22 +286,30 @@ Java_com_pulp_PulpActivity_nativeOnKeyboardChanged(
 
 // ── Audio Focus JNI Callbacks ─────────────────────────────────────────────
 
+// #334: forward AudioManager.OnAudioFocusChangeListener events into the
+// cross-platform AudioFocusRegistry. Subscribers (OboeDevice, standalone
+// adapter, tooling) react without caring whether the signal came from JNI,
+// AVAudioSession, or a desktop stub — same observer pattern as Environment.
+
 extern "C" JNIEXPORT void JNICALL
 Java_com_pulp_audio_PulpAudioFocus_nativeOnAudioFocusLost(JNIEnv*, jobject) {
     PULP_LOGI("Audio focus lost");
-    // TODO: pause synth output
+    pulp::audio::AudioFocusRegistry::instance().publish(
+        pulp::audio::AudioFocusState::lost);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_pulp_audio_PulpAudioFocus_nativeOnAudioFocusDuck(JNIEnv*, jobject) {
     PULP_LOGI("Audio focus duck");
-    // TODO: reduce volume
+    pulp::audio::AudioFocusRegistry::instance().publish(
+        pulp::audio::AudioFocusState::duck);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_pulp_audio_PulpAudioFocus_nativeOnAudioFocusGained(JNIEnv*, jobject) {
     PULP_LOGI("Audio focus gained");
-    // TODO: resume synth output
+    pulp::audio::AudioFocusRegistry::instance().publish(
+        pulp::audio::AudioFocusState::gained);
 }
 
 #endif // __ANDROID__

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,6 +88,13 @@ add_executable(pulp-test-stream test_stream.cpp)
 target_link_libraries(pulp-test-stream PRIVATE pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-stream)
 
+# #334: AudioFocusRegistry — cross-platform observer for OS audio-focus
+# signals (Android AudioManager.OnAudioFocusChangeListener,
+# AVAudioSession interruptions). Pure C++ unit tests — no platform deps.
+add_executable(pulp-test-audio-focus test_audio_focus.cpp)
+target_link_libraries(pulp-test-audio-focus PRIVATE pulp::audio Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-audio-focus)
+
 # #244: zero-fill helper for the Oboe input-frame-read short-read path.
 # Header-only math, so no library link required beyond Catch2.
 add_executable(pulp-test-frame-fill test_frame_fill.cpp)

--- a/test/test_audio_focus.cpp
+++ b/test/test_audio_focus.cpp
@@ -1,0 +1,180 @@
+// AudioFocusRegistry tests (#334).
+//
+// The registry is the cross-platform fan-out for OS audio-focus signals
+// (Android's AudioManager.OnAudioFocusChangeListener today; iOS
+// AVAudioSession interruptions in a future slice). Exercise the contract
+// with a pure observer-pattern test — no JNI, no real audio device.
+
+#include <pulp/audio/audio_focus.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using pulp::audio::AudioFocusRegistry;
+using pulp::audio::AudioFocusState;
+
+TEST_CASE("AudioFocusRegistry: default state is gained",
+          "[audio][focus][issue-334]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    REQUIRE(AudioFocusRegistry::instance().current() == AudioFocusState::gained);
+}
+
+TEST_CASE("AudioFocusRegistry: publish updates current() snapshot",
+          "[audio][focus][issue-334]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    REQUIRE(AudioFocusRegistry::instance().current() == AudioFocusState::duck);
+    AudioFocusRegistry::instance().publish(AudioFocusState::lost);
+    REQUIRE(AudioFocusRegistry::instance().current() == AudioFocusState::lost);
+    AudioFocusRegistry::instance().publish(AudioFocusState::gained);
+    REQUIRE(AudioFocusRegistry::instance().current() == AudioFocusState::gained);
+}
+
+TEST_CASE("AudioFocusRegistry: subscribers see every publish",
+          "[audio][focus][issue-334]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    std::vector<AudioFocusState> observed;
+    auto token = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState s) { observed.push_back(s); });
+
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    AudioFocusRegistry::instance().publish(AudioFocusState::lost);
+    AudioFocusRegistry::instance().publish(AudioFocusState::gained);
+
+    REQUIRE(observed.size() == 3);
+    REQUIRE(observed[0] == AudioFocusState::duck);
+    REQUIRE(observed[1] == AudioFocusState::lost);
+    REQUIRE(observed[2] == AudioFocusState::gained);
+}
+
+TEST_CASE("AudioFocusRegistry: RAII token unsubscribes on scope exit",
+          "[audio][focus][issue-334]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    int count = 0;
+    {
+        auto token = AudioFocusRegistry::instance().subscribe(
+            [&](AudioFocusState) { ++count; });
+        AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+        REQUIRE(count == 1);
+    }
+    // Token destructed → listener unsubscribed.
+    AudioFocusRegistry::instance().publish(AudioFocusState::lost);
+    REQUIRE(count == 1);
+}
+
+TEST_CASE("AudioFocusRegistry: token move transfers ownership",
+          "[audio][focus][issue-334]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    int count = 0;
+    AudioFocusRegistry::Token outer;
+    {
+        auto inner = AudioFocusRegistry::instance().subscribe(
+            [&](AudioFocusState) { ++count; });
+        outer = std::move(inner);
+    }
+    // Inner destructed but ownership moved — subscription still live.
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    REQUIRE(count == 1);
+    outer.reset();
+    AudioFocusRegistry::instance().publish(AudioFocusState::gained);
+    REQUIRE(count == 1);  // outer now dropped → no more callbacks
+}
+
+TEST_CASE("AudioFocusRegistry: callback that drops its own token does not deadlock",
+          "[audio][focus][issue-334]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    std::unique_ptr<AudioFocusRegistry::Token> token;
+    token = std::make_unique<AudioFocusRegistry::Token>(
+        AudioFocusRegistry::instance().subscribe(
+            [&](AudioFocusState) { token.reset(); }));
+
+    // If publish held the mutex during dispatch, token.reset() would
+    // re-enter unsubscribe() and deadlock. The copy-and-dispatch-out-of-
+    // lock pattern in publish() prevents that.
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    SUCCEED("no deadlock");
+}
+
+TEST_CASE("AudioFocusRegistry: multiple subscribers all receive the signal",
+          "[audio][focus][issue-334]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    int count_a = 0, count_b = 0, count_c = 0;
+    auto ta = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState) { ++count_a; });
+    auto tb = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState) { ++count_b; });
+    auto tc = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState) { ++count_c; });
+
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    REQUIRE(count_a == 1);
+    REQUIRE(count_b == 1);
+    REQUIRE(count_c == 1);
+}
+
+TEST_CASE("AudioFocusRegistry: current() is lock-free / audio-thread safe",
+          "[audio][focus][issue-334]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    std::atomic<bool> stop{false};
+    std::atomic<int> samples{0};
+
+    // Reader thread simulating the audio callback: spin on current()
+    // while a publisher thread thrashes the state. This would hang or
+    // tear if current() weren't an atomic snapshot.
+    std::thread reader([&] {
+        while (!stop.load(std::memory_order_acquire)) {
+            auto s = AudioFocusRegistry::instance().current();
+            (void)s;
+            samples.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+    std::thread writer([&] {
+        for (int i = 0; i < 10'000; ++i) {
+            AudioFocusRegistry::instance().publish(
+                (i & 1) ? AudioFocusState::duck : AudioFocusState::gained);
+        }
+    });
+    writer.join();
+    stop.store(true, std::memory_order_release);
+    reader.join();
+    REQUIRE(samples.load() > 0);
+}
+
+TEST_CASE("AudioFocusRegistry: lost_transient state roundtrips",
+          "[audio][focus][issue-334]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    std::vector<AudioFocusState> observed;
+    auto token = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState s) { observed.push_back(s); });
+
+    AudioFocusRegistry::instance().publish(AudioFocusState::lost_transient);
+    AudioFocusRegistry::instance().publish(AudioFocusState::gained);
+
+    REQUIRE(observed.size() == 2);
+    REQUIRE(observed[0] == AudioFocusState::lost_transient);
+    REQUIRE(observed[1] == AudioFocusState::gained);
+}
+
+TEST_CASE("AudioFocusRegistry: reset_for_test clears subscribers and state",
+          "[audio][focus][issue-334]") {
+    int count = 0;
+    auto token = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState) { ++count; });
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    REQUIRE(count == 1);
+
+    AudioFocusRegistry::instance().reset_for_test();
+    REQUIRE(AudioFocusRegistry::instance().current() == AudioFocusState::gained);
+
+    AudioFocusRegistry::instance().publish(AudioFocusState::lost);
+    // count should not increment — reset cleared subscribers.
+    REQUIRE(count == 1);
+    // The stale token's dtor is a no-op at this point (reset cleared cbs_
+    // so unsubscribe can't find its id); just don't crash.
+    token.reset();
+    SUCCEED("no crash on stale token reset");
+}


### PR DESCRIPTION
## Summary

Closes #334. Android's \`AudioManager.OnAudioFocusChangeListener\` was wired on the Kotlin side and forwarded over JNI to three native bridges — but the bridges were stubs (\`TODO: pause synth output\` etc.). This PR wires them to a cross-platform registry so audio code can react to focus changes without caring whether the signal came from JNI, AVAudioSession, or a desktop stub.

## Shape

Mirrors \`pulp::platform::Environment\` (#342) — same RAII Token + subscribe/publish pattern, same callback-drops-its-own-token deadlock prevention (copy subscribers under lock, dispatch outside).

**New public surface**: \`core/audio/include/pulp/audio/audio_focus.hpp\`
- \`enum class AudioFocusState { gained, duck, lost, lost_transient }\`
- \`AudioFocusRegistry::instance()\`, \`subscribe/publish/current/reset_for_test\`
- \`Token\` — RAII, move-only

## Test plan

- [x] 10 Catch2 cases, **24 assertions**. Local run: 10/10 pass.
  - default state is gained
  - publish updates current() snapshot
  - subscribers see every publish
  - RAII token unsubscribes on scope exit
  - token move transfers ownership
  - callback that drops its own token does not deadlock
  - multiple subscribers all receive the signal
  - current() is lock-free / audio-thread safe (hammer test: 10k concurrent publishes + reads)
  - lost_transient state roundtrips
  - reset_for_test clears subscribers and state
- [ ] CI cross-platform sweep.

## Next slices
- OboeDevice subscribes + applies duck/lost at the audio callback level (follow-up)
- iOS AVAudioSession interruption handling hooks same registry (follow-up)