### PR TITLE
midi: SysExAccumulator — shared F0/F7 aggregation state machine (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0220"></a>
+## [0.23.0]
+
 ## [0.22.0] - 2026-04-20
 
 - audio(android): wire Oboe input-stream frame read (#244) ([#478](https://github.com/danielraffel/pulp/pull/478))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.22.0
+    VERSION 0.23.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/sysex_accumulator.hpp
+++ b/core/midi/include/pulp/midi/sysex_accumulator.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+// SysExAccumulator (#86) — shared MIDI SysEx aggregation state machine.
+//
+// MIDI SysEx messages (F0 ... F7) can span multiple transport packets:
+// Android's MIDI API delivers raw bytes whenever they arrive, BLE MIDI
+// fragments into ~20-byte chunks, USB-MIDI sends 4-byte event packets,
+// etc. None of those transports guarantee a full sysex arrives in one
+// delivery. This accumulator buffers until F7 or an abort, then emits
+// the complete payload.
+//
+// State machine (per #406 + ALSA reference):
+//
+//   Idle     --[F0]-->   Buffering
+//   Buffering --[data]->  Buffering (append)
+//   Buffering --[F7]-->   emit complete, back to Idle
+//   Buffering --[status != F7, != realtime]--> emit aborted, retry with status
+//   Any       --[realtime (F8-FF except F7)]--> pass-through (realtime bytes
+//                         can interrupt sysex without terminating it per
+//                         the MIDI 1.0 spec — they're delivered outside
+//                         the sysex stream).
+//
+// The accumulator is not thread-safe; wrap it per-port. Android's MIDI
+// receiver is single-threaded per device, so the per-port model fits.
+//
+// Unit tests live in test/test_sysex_accumulator.cpp — see that file
+// for coverage of the edge cases referenced in the state machine above.
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace pulp::midi {
+
+/// Callback shape: receives the complete sysex payload (including the
+/// leading 0xF0 and trailing 0xF7) plus a flag indicating whether the
+/// message was properly terminated (`true`) or aborted by a new status
+/// byte (`false`). Callers typically ignore aborted messages or log
+/// them at debug level.
+using SysexEmitFn =
+    std::function<void(const std::vector<std::uint8_t>& payload, bool complete)>;
+
+class SysexAccumulator {
+public:
+    /// Feed a single byte through the state machine. Invokes `emit`
+    /// when a complete or aborted SysEx is assembled. Realtime bytes
+    /// (0xF8-0xFE) pass through without affecting state — they should
+    /// be handled as independent short messages by the caller.
+    ///
+    /// Returns the classification of the byte just consumed:
+    ///   - in_sysex: byte was buffered, no emit.
+    ///   - completed: SysEx just closed on F7; `emit` fired with complete=true.
+    ///   - aborted: SysEx interrupted by new non-F7 status; `emit` fired
+    ///              with complete=false and the aborter byte is NOT yet
+    ///              consumed — feed it again as a fresh status to let
+    ///              the caller route it normally.
+    ///   - passthrough: byte is outside a SysEx (or was a realtime byte)
+    ///                  and should be handled by the caller's regular
+    ///                  short-message path.
+    enum class Classification {
+        in_sysex,
+        completed,
+        aborted,
+        passthrough,
+    };
+
+    Classification feed(std::uint8_t byte, const SysexEmitFn& emit) {
+        // Realtime messages F8-FE are delivered asynchronously and
+        // don't participate in sysex framing. Pass them through.
+        if (is_realtime(byte)) return Classification::passthrough;
+
+        if (!in_sysex_) {
+            if (byte == 0xF0) {
+                in_sysex_ = true;
+                buffer_.clear();
+                buffer_.push_back(0xF0);
+                return Classification::in_sysex;
+            }
+            // Regular short-message byte — caller handles it.
+            return Classification::passthrough;
+        }
+
+        // In-sysex branch.
+        if (byte == 0xF7) {
+            buffer_.push_back(0xF7);
+            emit(buffer_, /*complete=*/true);
+            in_sysex_ = false;
+            buffer_.clear();
+            return Classification::completed;
+        }
+
+        if (is_status(byte)) {
+            // New status interrupted an unterminated F0. Flush the
+            // partial payload (without F7) and return without consuming
+            // the aborter — caller re-feeds it as a fresh status.
+            emit(buffer_, /*complete=*/false);
+            in_sysex_ = false;
+            buffer_.clear();
+            return Classification::aborted;
+        }
+
+        // Normal data byte inside an active sysex.
+        buffer_.push_back(byte);
+        return Classification::in_sysex;
+    }
+
+    /// Feed a run of bytes — convenience over a delivery boundary.
+    /// Handles the aborted-byte reclassification automatically.
+    void feed(const std::uint8_t* data, std::size_t count,
+              const SysexEmitFn& emit) {
+        for (std::size_t i = 0; i < count; ++i) {
+            auto cls = feed(data[i], emit);
+            if (cls == Classification::aborted) {
+                // Re-feed the aborter byte as a fresh status.
+                feed(data[i], emit);
+            }
+        }
+    }
+
+    /// True when buffer_ holds an open F0 without a matching F7.
+    bool in_progress() const noexcept { return in_sysex_; }
+
+    /// Clear any accumulated partial state. Intended for port-close
+    /// or shutdown paths — drops any partially-received message.
+    void reset() noexcept {
+        in_sysex_ = false;
+        buffer_.clear();
+    }
+
+    /// Size of the in-progress payload (0 when idle). Includes the
+    /// leading 0xF0 byte.
+    std::size_t partial_size() const noexcept { return buffer_.size(); }
+
+private:
+    static bool is_status(std::uint8_t b) noexcept { return (b & 0x80) != 0; }
+    static bool is_realtime(std::uint8_t b) noexcept {
+        // MIDI 1.0 System Realtime Messages: 0xF8 (Timing Clock),
+        // 0xFA-0xFC (Start/Continue/Stop), 0xFE (Active Sensing),
+        // 0xFF (System Reset). 0xF9 and 0xFD are undefined. 0xF7 is
+        // EOX and intentionally excluded (handled by feed() explicitly).
+        return b >= 0xF8 && b <= 0xFF && b != 0xF9 && b != 0xFD;
+    }
+
+    bool in_sysex_ = false;
+    std::vector<std::uint8_t> buffer_;
+};
+
+} // namespace pulp::midi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,6 +94,12 @@ add_executable(pulp-test-frame-fill test_frame_fill.cpp)
 target_link_libraries(pulp-test-frame-fill PRIVATE pulp::audio Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-frame-fill)
 
+# #86: SysExAccumulator — cross-platform MIDI SysEx aggregation state
+# machine shared by Android/ALSA/Windows/iOS MIDI backends. Header-only.
+add_executable(pulp-test-sysex-accumulator test_sysex_accumulator.cpp)
+target_link_libraries(pulp-test-sysex-accumulator PRIVATE pulp::midi Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-sysex-accumulator)
+
 # AsyncStream tests (Phase 2)
 add_executable(pulp-test-async-stream test_async_stream.cpp)
 target_link_libraries(pulp-test-async-stream PRIVATE pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_sysex_accumulator.cpp
+++ b/test/test_sysex_accumulator.cpp
@@ -1,0 +1,212 @@
+// Tests for SysExAccumulator (#86).
+//
+// Verifies the state machine handles the cases called out in the header
+// and referenced by the Codex audit on #406 (aborted F0 recovery):
+//
+//   - single-packet sysex
+//   - sysex spanning multiple feed() calls
+//   - aborted sysex (new status before F7)
+//   - realtime bytes interleaved with sysex
+//   - short messages outside sysex pass through
+//   - reset() drops partial state
+
+#include <pulp/midi/sysex_accumulator.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <vector>
+
+using pulp::midi::SysexAccumulator;
+using Classification = SysexAccumulator::Classification;
+
+namespace {
+
+struct Emit {
+    std::vector<std::vector<std::uint8_t>> complete;
+    std::vector<std::vector<std::uint8_t>> aborted;
+};
+
+auto make_callback(Emit& e) {
+    return [&](const std::vector<std::uint8_t>& payload, bool complete) {
+        if (complete) e.complete.push_back(payload);
+        else e.aborted.push_back(payload);
+    };
+}
+
+} // namespace
+
+TEST_CASE("SysexAccumulator: single-packet complete sysex",
+          "[midi][sysex][issue-86]") {
+    SysexAccumulator acc;
+    Emit e;
+    // Standard Universal Device Inquiry: F0 7E 7F 06 01 F7
+    std::uint8_t packet[] = {0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7};
+    acc.feed(packet, sizeof(packet), make_callback(e));
+    REQUIRE(e.complete.size() == 1);
+    REQUIRE(e.aborted.empty());
+    REQUIRE(e.complete[0].size() == 6);
+    REQUIRE(e.complete[0][0] == 0xF0);
+    REQUIRE(e.complete[0][5] == 0xF7);
+}
+
+TEST_CASE("SysexAccumulator: sysex spanning multiple feed calls",
+          "[midi][sysex][issue-86]") {
+    SysexAccumulator acc;
+    Emit e;
+    auto cb = make_callback(e);
+    std::uint8_t part1[] = {0xF0, 0x41, 0x10};
+    std::uint8_t part2[] = {0x42, 0x12, 0x40, 0x00, 0x7F};
+    std::uint8_t part3[] = {0x41, 0xF7};
+    acc.feed(part1, sizeof(part1), cb);
+    REQUIRE(e.complete.empty());
+    REQUIRE(acc.in_progress());
+    acc.feed(part2, sizeof(part2), cb);
+    REQUIRE(e.complete.empty());
+    REQUIRE(acc.in_progress());
+    acc.feed(part3, sizeof(part3), cb);
+    REQUIRE(e.complete.size() == 1);
+    REQUIRE_FALSE(acc.in_progress());
+    REQUIRE(e.complete[0].size() == 3 + 5 + 2);
+    REQUIRE(e.complete[0].back() == 0xF7);
+}
+
+TEST_CASE("SysexAccumulator: aborted by new status byte",
+          "[midi][sysex][issue-86]") {
+    SysexAccumulator acc;
+    Emit e;
+    auto cb = make_callback(e);
+    // F0 41 10 [Note On 90 3C 7F]  — the 0x90 aborts the sysex.
+    std::uint8_t packet[] = {0xF0, 0x41, 0x10, 0x90, 0x3C, 0x7F};
+    acc.feed(packet, sizeof(packet), cb);
+    REQUIRE(e.aborted.size() == 1);
+    REQUIRE(e.aborted[0].size() == 3);
+    REQUIRE(e.aborted[0][0] == 0xF0);
+    // After the abort the accumulator re-fed the status byte as a fresh
+    // classification — it should now be idle, with the Note On bytes
+    // classified as passthrough (short message for the caller).
+    REQUIRE_FALSE(acc.in_progress());
+    REQUIRE(e.complete.empty());
+}
+
+TEST_CASE("SysexAccumulator: realtime bytes pass through mid-sysex",
+          "[midi][sysex][issue-86]") {
+    SysexAccumulator acc;
+    Emit e;
+    auto cb = make_callback(e);
+
+    REQUIRE(acc.feed(0xF0, cb) == Classification::in_sysex);
+    REQUIRE(acc.feed(0x41, cb) == Classification::in_sysex);
+    // Timing Clock (0xF8) arrives — pass through, no effect on sysex.
+    REQUIRE(acc.feed(0xF8, cb) == Classification::passthrough);
+    REQUIRE(acc.in_progress());
+    REQUIRE(acc.feed(0x10, cb) == Classification::in_sysex);
+    REQUIRE(acc.feed(0xF7, cb) == Classification::completed);
+
+    REQUIRE(e.complete.size() == 1);
+    // Realtime 0xF8 was NOT buffered into the sysex payload.
+    REQUIRE(e.complete[0].size() == 4);
+    REQUIRE(e.complete[0][0] == 0xF0);
+    REQUIRE(e.complete[0][1] == 0x41);
+    REQUIRE(e.complete[0][2] == 0x10);
+    REQUIRE(e.complete[0][3] == 0xF7);
+}
+
+TEST_CASE("SysexAccumulator: short messages pass through when idle",
+          "[midi][sysex][issue-86]") {
+    SysexAccumulator acc;
+    Emit e;
+    auto cb = make_callback(e);
+    // Note On — not a sysex, no F0 to open.
+    REQUIRE(acc.feed(0x90, cb) == Classification::passthrough);
+    REQUIRE(acc.feed(0x3C, cb) == Classification::passthrough);
+    REQUIRE(acc.feed(0x7F, cb) == Classification::passthrough);
+    REQUIRE(e.complete.empty());
+    REQUIRE(e.aborted.empty());
+}
+
+TEST_CASE("SysexAccumulator: reset drops partial state",
+          "[midi][sysex][issue-86]") {
+    SysexAccumulator acc;
+    Emit e;
+    auto cb = make_callback(e);
+    acc.feed(0xF0, cb);
+    acc.feed(0x41, cb);
+    acc.feed(0x10, cb);
+    REQUIRE(acc.in_progress());
+    REQUIRE(acc.partial_size() == 3);
+    acc.reset();
+    REQUIRE_FALSE(acc.in_progress());
+    REQUIRE(acc.partial_size() == 0);
+    // After reset, subsequent F0 starts a fresh sysex.
+    std::uint8_t fresh[] = {0xF0, 0x7E, 0x7F, 0xF7};
+    acc.feed(fresh, sizeof(fresh), cb);
+    REQUIRE(e.complete.size() == 1);
+    REQUIRE(e.complete[0].size() == 4);
+}
+
+TEST_CASE("SysexAccumulator: back-to-back sysex messages",
+          "[midi][sysex][issue-86]") {
+    SysexAccumulator acc;
+    Emit e;
+    auto cb = make_callback(e);
+    std::uint8_t stream[] = {
+        0xF0, 0x41, 0x10, 0xF7,
+        0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7,
+        0xF0, 0x42, 0xF7
+    };
+    acc.feed(stream, sizeof(stream), cb);
+    REQUIRE(e.complete.size() == 3);
+    REQUIRE(e.complete[0].size() == 4);
+    REQUIRE(e.complete[1].size() == 6);
+    REQUIRE(e.complete[2].size() == 3);
+    REQUIRE_FALSE(acc.in_progress());
+}
+
+TEST_CASE("SysexAccumulator: empty sysex (F0 F7)",
+          "[midi][sysex][issue-86]") {
+    SysexAccumulator acc;
+    Emit e;
+    auto cb = make_callback(e);
+    std::uint8_t empty[] = {0xF0, 0xF7};
+    acc.feed(empty, sizeof(empty), cb);
+    REQUIRE(e.complete.size() == 1);
+    REQUIRE(e.complete[0].size() == 2);
+    REQUIRE(e.complete[0][0] == 0xF0);
+    REQUIRE(e.complete[0][1] == 0xF7);
+}
+
+TEST_CASE("SysexAccumulator: large sysex (>1KB) accumulates correctly",
+          "[midi][sysex][issue-86]") {
+    SysexAccumulator acc;
+    Emit e;
+    auto cb = make_callback(e);
+    std::vector<std::uint8_t> big;
+    big.push_back(0xF0);
+    for (int i = 0; i < 1500; ++i) {
+        big.push_back(static_cast<std::uint8_t>(i & 0x7F));
+    }
+    big.push_back(0xF7);
+    acc.feed(big.data(), big.size(), cb);
+    REQUIRE(e.complete.size() == 1);
+    REQUIRE(e.complete[0].size() == 1502);
+    REQUIRE(e.complete[0].front() == 0xF0);
+    REQUIRE(e.complete[0].back() == 0xF7);
+}
+
+TEST_CASE("SysexAccumulator: aborted then recovered sysex",
+          "[midi][sysex][issue-86]") {
+    SysexAccumulator acc;
+    Emit e;
+    auto cb = make_callback(e);
+    // Partial sysex interrupted by a Note On, then a fresh sysex.
+    std::uint8_t stream[] = {
+        0xF0, 0x41, 0x10,                   // partial
+        0x90, 0x3C, 0x7F,                   // Note On — aborts
+        0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7  // complete
+    };
+    acc.feed(stream, sizeof(stream), cb);
+    REQUIRE(e.aborted.size() == 1);
+    REQUIRE(e.aborted[0].size() == 3);  // F0 41 10 without F7
+    REQUIRE(e.complete.size() == 1);
+    REQUIRE(e.complete[0].size() == 6);
+}


### PR DESCRIPTION
Closes #86 (SysEx aggregation piece). Android's MIDI backend previously skipped sysex entirely; this PR adds the shared accumulator header + tests so android_midi.cpp, alsa, winmidi, iOS can all pull it in. State machine: Idle → Buffering on F0; append data; emit complete on F7; emit aborted on new status (F0 recovery per Codex #406); realtime bytes pass through. **10 Catch2 cases, 58 assertions, all pass locally.** Wiring into android_midi.cpp is a follow-up slice — this PR is the algorithm + tests so the logic can be reviewed in isolation.