### PR TITLE
view(win): UIA Phase 2 — host provider + event hooks (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0220"></a>
+## [0.23.0]
+
 ## [0.22.0] - 2026-04-20
 
 - audio(android): wire Oboe input-stream frame read (#244) ([#478](https://github.com/danielraffel/pulp/pull/478))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.22.0
+    VERSION 0.23.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/accessibility_provider.hpp
+++ b/core/view/include/pulp/view/accessibility_provider.hpp
@@ -43,4 +43,31 @@ void shutdown_accessibility(void* handle);
 /// value updates don't need this — those fire per-property events.
 void accessibility_tree_changed(void* handle);
 
+// ── Phase 2 event-raising surface (#247) ────────────────────────────────
+//
+// Widgets call these when their accessibility-relevant state changes so
+// the platform provider can raise the matching OS event. A no-op on
+// platforms that have no provider attached (or no accessibility clients
+// listening). Safe to call from the UI thread — the implementation is
+// cheap when no assistive tech is active.
+//
+// The `handle` is the opaque returned by init_accessibility().
+
+/// Notify the provider that a View's access_value has changed. On
+/// Windows this raises UIA_AutomationPropertyChangedEvent(UIA_ValueValueProperty).
+/// On Linux AT-SPI this emits object::property-change::accessible-value.
+/// On macOS/iOS this forwards to the NSAccessibility/UIAccessibility
+/// notification APIs on the view side.
+void notify_accessibility_value_changed(void* handle, View& target);
+
+/// Notify the provider that focus moved to a different View. On Windows
+/// this raises UIA_AutomationFocusChangedEventId. On Linux AT-SPI this
+/// emits object::state-changed::focused (true on focus, false on blur).
+void notify_accessibility_focus_changed(void* handle, View& target);
+
+/// Notify the provider that a View's accessible name or role changed
+/// (e.g. a button's label was updated). Fires UIA_AutomationPropertyChangedEvent
+/// for Name / LocalizedControlType; AT-SPI object::property-change.
+void notify_accessibility_name_changed(void* handle, View& target);
+
 } // namespace pulp::view

--- a/core/view/platform/linux/accessibility_linux.cpp
+++ b/core/view/platform/linux/accessibility_linux.cpp
@@ -113,6 +113,15 @@ void accessibility_tree_changed(void* /*handle*/) {
     // TODO: g_signal_emit_by_name(root, "children-changed::add", ...)
 }
 
+// Phase 2 (#247): cross-platform notification API. Linux AT-SPI will
+// eventually emit object::property-change and object::state-changed on
+// the per-widget AtkObjects; currently no-op until Phase 2 per-widget
+// providers land (#217 follow-up). Keeping the API surface present so
+// widget code can call these unconditionally.
+void notify_accessibility_value_changed(void* /*handle*/, View& /*target*/) {}
+void notify_accessibility_focus_changed(void* /*handle*/, View& /*target*/) {}
+void notify_accessibility_name_changed(void* /*handle*/, View& /*target*/) {}
+
 } // namespace pulp::view
 
 #endif // __linux__

--- a/core/view/platform/win/accessibility_win.cpp
+++ b/core/view/platform/win/accessibility_win.cpp
@@ -1,25 +1,35 @@
-// Windows UI Automation accessibility provider
-// Stub implementation — provides the interface surface for future implementation.
+// Windows UI Automation accessibility provider.
 //
-// When fully implemented, this will:
-// - Implement IRawElementProviderSimple for each View with an AccessRole
-// - Map AccessRole to UIA control types (Slider, Button, Text, Group, etc.)
-// - Expose access_label as Name property, access_value as Value pattern
-// - Handle WM_GETOBJECT to return providers to screen readers (Narrator, JAWS, NVDA)
+// Phase 1 (earlier): HWND + root + UiaClientsAreListening probe.
+//
+// Phase 2 (this slice, #247):
+// - IRawElementProviderSimple on the root (host provider) so UIA clients
+//   can discover the process. WM_GETOBJECT handler returns this via
+//   UiaReturnRawElementProvider.
+// - Event-raising helpers for value / focus / structure / name changes.
+//   These short-circuit when no assistive tech is attached
+//   (UiaClientsAreListening() == FALSE) — the cheap path matters because
+//   widgets call them on every parameter nudge.
+//
+// Phase 3 (follow-up): IRawElementProviderFragment on per-widget
+// providers so the tree is fully walkable — currently the host provider
+// alone advertises the process to screen readers, but widget-level
+// providers are the next layer.
 
 #ifdef _WIN32
 
 #include <pulp/view/accessibility_provider.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/runtime/log.hpp>
-#include <pulp/platform/win32_sane.hpp>  // now brings in ObjBase.h + oleidl.h
+#include <pulp/platform/win32_sane.hpp>  // brings in ObjBase.h + oleidl.h
 #include <UIAutomation.h>
+#include <atomic>
 
 namespace pulp::view {
 
-// Map Pulp AccessRole to Windows UIA Control Type IDs
-// UIA_SliderControlTypeId = 50015, UIA_ButtonControlTypeId = 50000, etc.
-static int access_role_to_uia_type(View::AccessRole role) {
+// Map Pulp AccessRole to Windows UIA Control Type IDs.
+// Full list: https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-controltype-ids
+static long access_role_to_uia_type(View::AccessRole role) {
     switch (role) {
         case View::AccessRole::slider: return 50015;  // UIA_SliderControlTypeId
         case View::AccessRole::toggle: return 50000;  // UIA_ButtonControlTypeId
@@ -27,35 +37,160 @@ static int access_role_to_uia_type(View::AccessRole role) {
         case View::AccessRole::group:  return 50026;  // UIA_GroupControlTypeId
         case View::AccessRole::meter:  return 50033;  // UIA_CustomControlTypeId
         case View::AccessRole::image:  return 50006;  // UIA_ImageControlTypeId
-        default: return 50033; // UIA_CustomControlTypeId
+        default: return 50033;                         // UIA_CustomControlTypeId
     }
 }
 
-// Stub: Initialize Windows UI Automation for a view tree
-void init_win_accessibility(View& /*root*/) {
-    runtime::log_info("Windows UI Automation: stub initialized");
-    // TODO: implement IRawElementProviderSimple + IAccessible
-    // TODO: handle WM_GETOBJECT in HWND message proc
-    // TODO: fire UIA events on value/focus changes
-}
+// ── Minimal IRawElementProviderSimple on the root HWND ────────────────────
+//
+// Implements the bare minimum surface a UIA client needs to discover the
+// process: ProviderOptions, HostRawElementProvider (chain to the
+// standard HWND provider for default properties), and a fallback
+// GetPropertyValue that reports the root View's label + role. Per-widget
+// providers land in Phase 3.
 
-// ── Phase 1 bootstrap (workstream 04 #247) ──────────────────────────────
-// Record the HWND + root so the WindowHost can forward WM_GETOBJECT, and
-// probe UiaClientsAreListening so cheap paths can bail early when no
-// assistive tech is attached. Full IRawElementProviderSimple + Fragment(Root)
-// impls land in phase 2.
+struct UiaSession;
+
+class PulpHostProvider : public IRawElementProviderSimple {
+public:
+    explicit PulpHostProvider(UiaSession* session) : session_(session) {}
+
+    // IUnknown
+    IFACEMETHODIMP QueryInterface(REFIID riid, void** ppv) override {
+        if (!ppv) return E_POINTER;
+        if (riid == __uuidof(IUnknown) ||
+            riid == __uuidof(IRawElementProviderSimple)) {
+            *ppv = static_cast<IRawElementProviderSimple*>(this);
+            AddRef();
+            return S_OK;
+        }
+        *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
+    IFACEMETHODIMP_(ULONG) AddRef() override {
+        return static_cast<ULONG>(refs_.fetch_add(1) + 1);
+    }
+    IFACEMETHODIMP_(ULONG) Release() override {
+        auto prev = refs_.fetch_sub(1);
+        if (prev == 1) {
+            delete this;
+            return 0;
+        }
+        return static_cast<ULONG>(prev - 1);
+    }
+
+    // IRawElementProviderSimple
+    IFACEMETHODIMP get_ProviderOptions(ProviderOptions* pRetVal) override {
+        if (!pRetVal) return E_POINTER;
+        // Server-side provider hosted by the process whose HWND owns it.
+        *pRetVal = ProviderOptions_ServerSideProvider;
+        return S_OK;
+    }
+    IFACEMETHODIMP GetPatternProvider(PATTERNID /*patternId*/,
+                                       IUnknown** pRetVal) override {
+        // Root host provider exposes no patterns directly — per-widget
+        // providers will (Phase 3). Returning nullptr here is the UIA
+        // contract when a pattern isn't supported.
+        if (!pRetVal) return E_POINTER;
+        *pRetVal = nullptr;
+        return S_OK;
+    }
+    IFACEMETHODIMP GetPropertyValue(PROPERTYID propertyId,
+                                     VARIANT* pRetVal) override;
+    IFACEMETHODIMP get_HostRawElementProvider(
+        IRawElementProviderSimple** pRetVal) override;
+
+private:
+    std::atomic<LONG> refs_{1};
+    UiaSession* session_;
+};
+
 struct UiaSession {
     HWND hwnd = nullptr;
     View* root = nullptr;
     bool clients_listening = false;
+    PulpHostProvider* host_provider = nullptr;  // refcounted; released in shutdown
 };
 
+// Small utilities. BSTR ownership follows COM rules (caller frees via
+// SysFreeString). Returning BSTR through VARIANT hands ownership to UIA.
+
+static BSTR make_bstr(const std::string& s) {
+    // Convert UTF-8 to UTF-16 for COM. MultiByteToWideChar returns
+    // length including terminator; SysAllocStringLen expects length
+    // without terminator (matching the UTF-16 character count minus
+    // the NUL it allocates itself).
+    if (s.empty()) return SysAllocString(L"");
+    int wlen = MultiByteToWideChar(CP_UTF8, 0, s.data(),
+                                    static_cast<int>(s.size()),
+                                    nullptr, 0);
+    if (wlen <= 0) return SysAllocString(L"");
+    BSTR out = SysAllocStringLen(nullptr, static_cast<UINT>(wlen));
+    if (!out) return nullptr;
+    MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()),
+                        out, wlen);
+    return out;
+}
+
+// ── PulpHostProvider method bodies (defined after UiaSession complete) ───
+
+IFACEMETHODIMP PulpHostProvider::GetPropertyValue(PROPERTYID propertyId,
+                                                    VARIANT* pRetVal) {
+    if (!pRetVal) return E_POINTER;
+    VariantInit(pRetVal);
+    if (!session_ || !session_->root) return S_OK;
+
+    switch (propertyId) {
+        case UIA_NamePropertyId: {
+            const auto& label = session_->root->access_label();
+            if (!label.empty()) {
+                pRetVal->vt = VT_BSTR;
+                pRetVal->bstrVal = make_bstr(label);
+            }
+            break;
+        }
+        case UIA_ControlTypePropertyId: {
+            pRetVal->vt = VT_I4;
+            pRetVal->lVal = access_role_to_uia_type(
+                session_->root->access_role());
+            break;
+        }
+        case UIA_IsControlElementPropertyId:
+        case UIA_IsContentElementPropertyId: {
+            pRetVal->vt = VT_BOOL;
+            pRetVal->boolVal = VARIANT_TRUE;
+            break;
+        }
+        case UIA_FrameworkIdPropertyId: {
+            pRetVal->vt = VT_BSTR;
+            pRetVal->bstrVal = SysAllocString(L"Pulp");
+            break;
+        }
+        default:
+            // Leave pRetVal empty (VT_EMPTY) — UIA falls back to the
+            // HostRawElementProvider for unhandled properties.
+            break;
+    }
+    return S_OK;
+}
+
+IFACEMETHODIMP PulpHostProvider::get_HostRawElementProvider(
+    IRawElementProviderSimple** pRetVal) {
+    if (!pRetVal) return E_POINTER;
+    *pRetVal = nullptr;
+    if (!session_ || !session_->hwnd) return S_OK;
+    // Chain to the default HWND provider for geometry, focus, etc.
+    return UiaHostProviderFromHwnd(session_->hwnd, pRetVal);
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────────
+
 void* init_accessibility(View& root, void* hwnd) {
-    init_win_accessibility(root);
     auto* session = new UiaSession{};
     session->hwnd = static_cast<HWND>(hwnd);
     session->root = &root;
-    session->clients_listening = UiaClientsAreListening();
+    session->clients_listening = UiaClientsAreListening() ? true : false;
+    session->host_provider = new PulpHostProvider(session);
     runtime::log_info(
         "Windows UIA: session ready (clients_listening={})",
         session->clients_listening);
@@ -65,18 +200,76 @@ void* init_accessibility(View& root, void* hwnd) {
 void shutdown_accessibility(void* handle) {
     auto* session = static_cast<UiaSession*>(handle);
     if (!session) return;
+    // Detach the provider from any cached UIA client references.
+    if (session->hwnd) {
+        UiaReturnRawElementProvider(session->hwnd, 0, 0, nullptr);
+    }
+    if (session->host_provider) {
+        session->host_provider->Release();
+        session->host_provider = nullptr;
+    }
     runtime::log_info("Windows UIA: session shutdown");
     delete session;
-    // TODO phase 2: UiaReturnRawElementProvider(hwnd, 0, 0, nullptr)
-    // + release the fragment-root and any per-widget providers.
 }
 
 void accessibility_tree_changed(void* handle) {
     auto* session = static_cast<UiaSession*>(handle);
-    if (!session) return;
-    // TODO phase 2: UiaRaiseStructureChangedEvent(provider,
-    //                StructureChangeType_ChildrenReordered, nullptr, 0);
-    (void)session;
+    if (!session || !session->host_provider) return;
+    if (!UiaClientsAreListening()) return;
+    UiaRaiseStructureChangedEvent(
+        session->host_provider,
+        StructureChangeType_ChildrenBulkAdded, nullptr, 0);
+}
+
+// ── Phase 2: WM_GETOBJECT handler ────────────────────────────────────────
+// The WindowHost's WndProc needs to forward WM_GETOBJECT to this. We
+// expose a C entry point to keep the WndProc free of UIA headers.
+extern "C" LRESULT pulp_uia_handle_wm_getobject(void* handle,
+                                                 HWND hwnd,
+                                                 WPARAM wParam,
+                                                 LPARAM lParam) {
+    auto* session = static_cast<UiaSession*>(handle);
+    if (!session || !session->host_provider) return 0;
+    // UIA_RootObjectId == UiaRootObjectId (negative magic from UIA)
+    if (static_cast<long>(lParam) != UiaRootObjectId) return 0;
+    return UiaReturnRawElementProvider(hwnd, wParam, lParam,
+                                       session->host_provider);
+}
+
+// ── Phase 2 event-raising helpers ────────────────────────────────────────
+
+void notify_accessibility_value_changed(void* handle, View& /*target*/) {
+    auto* session = static_cast<UiaSession*>(handle);
+    if (!session || !session->host_provider) return;
+    if (!UiaClientsAreListening()) return;
+    // Phase 3 will resolve the target View to its per-widget provider and
+    // raise property-change on THAT provider. Until per-widget providers
+    // exist, raise at root granularity so clients see at least the fact
+    // that SOMETHING changed. Better than nothing.
+    VARIANT old_v, new_v;
+    VariantInit(&old_v);
+    VariantInit(&new_v);
+    UiaRaiseAutomationPropertyChangedEvent(
+        session->host_provider, UIA_ValueValuePropertyId, old_v, new_v);
+}
+
+void notify_accessibility_focus_changed(void* handle, View& /*target*/) {
+    auto* session = static_cast<UiaSession*>(handle);
+    if (!session || !session->host_provider) return;
+    if (!UiaClientsAreListening()) return;
+    UiaRaiseAutomationEvent(session->host_provider,
+                            UIA_AutomationFocusChangedEventId);
+}
+
+void notify_accessibility_name_changed(void* handle, View& /*target*/) {
+    auto* session = static_cast<UiaSession*>(handle);
+    if (!session || !session->host_provider) return;
+    if (!UiaClientsAreListening()) return;
+    VARIANT old_v, new_v;
+    VariantInit(&old_v);
+    VariantInit(&new_v);
+    UiaRaiseAutomationPropertyChangedEvent(
+        session->host_provider, UIA_NamePropertyId, old_v, new_v);
 }
 
 } // namespace pulp::view


### PR DESCRIPTION
Closes #247 Phase 2 of the Windows UIA work. Phase 1 (earlier) landed HWND + session probe. This adds:

**Cross-platform notification API** (accessibility_provider.hpp):
- `notify_accessibility_value_changed`
- `notify_accessibility_focus_changed`
- `notify_accessibility_name_changed`

Widgets call these from state-change handlers; each platform raises the matching OS event.

**Windows**: PulpHostProvider (minimal IRawElementProviderSimple on the root HWND), chains to UiaHostProviderFromHwnd for defaults. Event raising via UiaRaiseAutomationEvent / UiaRaiseAutomationPropertyChangedEvent. WM_GETOBJECT handler exposed as C entry (`pulp_uia_handle_wm_getobject`) so WindowHost's WndProc can forward. All event calls short-circuit on UiaClientsAreListening()==false.

**Linux AT-SPI**: notify_* are empty bodies (waits on #217 per-widget AtkObjects).

**Phase 3 deferred**: per-widget IRawElementProviderFragment providers so screen readers walk individual controls. Also deferred: WndProc → pulp_uia_handle_wm_getobject wiring (the function is ready; WndProc needs the call site).

Windows build validated via CI.