### PR TITLE
android: audio focus follow-ups — transient routing + stop-race (#500)

### DIFF
--- a/android/app/src/main/kotlin/com/pulp/audio/PulpAudioController.kt
+++ b/android/app/src/main/kotlin/com/pulp/audio/PulpAudioController.kt
@@ -105,14 +105,19 @@ class PulpAudioController(private val context: Context) {
         // unbind so the service can be reaped when no other clients
         // hold it.
         context.startService(intent)
-        if (bound) {
-            try {
-                context.unbindService(connection)
-            } catch (e: IllegalArgumentException) {
-                // Already unbound — fine.
-            }
-            bound = false
+        // #500: Always attempt unbindService when running was true, not
+        // only when `bound` flipped true. `bound` is set by the async
+        // onServiceConnected callback; a start→stop sequence that races
+        // faster than the system dispatches the connection callback
+        // would leak the binding forever. unbindService throws
+        // IllegalArgumentException if no matching registration exists —
+        // catch-and-ignore is the documented safe pattern.
+        try {
+            context.unbindService(connection)
+        } catch (e: IllegalArgumentException) {
+            // Already unbound, or bind never registered — fine.
         }
+        bound = false
         service = null
         Log.i(PulpApplication.LOG_TAG,
             "PulpAudioController: stop requested")

--- a/android/app/src/main/kotlin/com/pulp/audio/PulpAudioFocus.kt
+++ b/android/app/src/main/kotlin/com/pulp/audio/PulpAudioFocus.kt
@@ -32,8 +32,15 @@ class PulpAudioFocus(context: Context) {
                     if (PulpApplication.nativeLoaded) nativeOnAudioFocusLost()
                 }
                 AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
-                    Log.i(TAG, "Audio focus lost transiently — ducking")
-                    if (PulpApplication.nativeLoaded) nativeOnAudioFocusDuck()
+                    // Non-ducking transient loss: the listener should pause
+                    // output (phone call, navigation prompt). Distinct from
+                    // LOSS_TRANSIENT_CAN_DUCK, which just attenuates.
+                    // #500: previously both variants collapsed into duck(),
+                    // so AudioFocusState::lost_transient was unreachable
+                    // via the Android path. Route to the dedicated JNI
+                    // entry so subscribers can distinguish pause vs duck.
+                    Log.i(TAG, "Audio focus lost transiently — pausing")
+                    if (PulpApplication.nativeLoaded) nativeOnAudioFocusLostTransient()
                 }
                 AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
                     Log.i(TAG, "Audio focus can duck")
@@ -64,6 +71,7 @@ class PulpAudioFocus(context: Context) {
     fun hasFocus(): Boolean = hasAudioFocus
 
     private external fun nativeOnAudioFocusLost()
+    private external fun nativeOnAudioFocusLostTransient()
     private external fun nativeOnAudioFocusDuck()
     private external fun nativeOnAudioFocusGained()
 

--- a/core/platform/src/android/jni_bridge.cpp
+++ b/core/platform/src/android/jni_bridge.cpp
@@ -298,6 +298,18 @@ Java_com_pulp_audio_PulpAudioFocus_nativeOnAudioFocusLost(JNIEnv*, jobject) {
         pulp::audio::AudioFocusState::lost);
 }
 
+// #500: previously AUDIOFOCUS_LOSS_TRANSIENT in Kotlin collapsed into
+// nativeOnAudioFocusDuck, so AudioFocusState::lost_transient was
+// unreachable from the Android path. Dedicated entry point now routes
+// it correctly so subscribers can differentiate pause-transiently (we
+// WILL get focus back shortly) from duck (attenuate but keep playing).
+extern "C" JNIEXPORT void JNICALL
+Java_com_pulp_audio_PulpAudioFocus_nativeOnAudioFocusLostTransient(JNIEnv*, jobject) {
+    PULP_LOGI("Audio focus lost transiently");
+    pulp::audio::AudioFocusRegistry::instance().publish(
+        pulp::audio::AudioFocusState::lost_transient);
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_com_pulp_audio_PulpAudioFocus_nativeOnAudioFocusDuck(JNIEnv*, jobject) {
     PULP_LOGI("Audio focus duck");


### PR DESCRIPTION
## Summary

Two related Android audio-lifecycle fixes from the #500 rollup sweep.

### 1. Transient focus-loss routing

`PulpAudioFocus.kt` was routing `AUDIOFOCUS_LOSS_TRANSIENT` (phone call, navigation prompt) through `nativeOnAudioFocusDuck()`. This collapsed it into the duck path and made `AudioFocusState::lost_transient` unreachable from the Android side.

`LOSS_TRANSIENT` is a non-ducking pause signal, semantically distinct from `LOSS_TRANSIENT_CAN_DUCK` (attenuate but keep playing). Added a dedicated `nativeOnAudioFocusLostTransient()` entry and a matching JNI bridge that publishes `AudioFocusState::lost_transient`.

### 2. stopAudio() unbind race

`PulpAudioController.stopAudio()` only called `unbindService` when the `bound` flag was true. That flag is set by the async `onServiceConnected` callback, so a fast start→stop cycle (tap stop before the system dispatches the connection) would skip unbind entirely and permanently leak the ServiceConnection.

Fix: always attempt `unbindService` when `running` was true; catch `IllegalArgumentException` for the no-registration case, which is the documented Android pattern.

## Test plan

- [x] Registry-level `lost_transient` coverage already in `test_audio_focus.cpp` — the bug was purely Kotlin→JNI routing
- [x] Compiles clean with existing Android build targets
- [ ] CI green on macOS / Ubuntu / Windows

Refs #500.