### PR TITLE
view(win): UIA shutdown UAF — disconnect provider before delete (#500)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -50,6 +50,12 @@ period (see danielraffel/pulp#120).
 # Primary: Shipyard
 shipyard run                              # validate current branch
 shipyard ship                             # PR + validate + merge on green
+shipyard ship --resume                    # pick up an interrupted ship (v0.3.0+)
+shipyard ship --no-resume                 # discard stale state, start fresh
+shipyard ship-state list                  # in-flight ships (title, url, sha)
+shipyard ship-state show <pr>             # full state for one PR
+shipyard ship-state discard <pr>          # archive stale state
+shipyard cleanup --ship-state --apply     # prune closed-PR + aged state
 shipyard run --targets windows --smoke    # fast Windows-only check
 shipyard run --resume-from test           # skip configure+build, run tests only
 shipyard cloud run build <branch>         # dispatch to Namespace
@@ -66,6 +72,19 @@ shipyard config profiles                  # list profiles + active
 python3 tools/local-ci/local_ci.py run
 python3 tools/local-ci/local_ci.py ship
 ```
+
+### Resuming an interrupted ship (v0.3.0+)
+
+If a ship was interrupted (laptop closed, session ended, OS restart),
+run `shipyard ship` again — it auto-resumes from a per-PR state file
+at `<state_dir>/ship/<pr>.json` without re-dispatching. Shipyard
+refuses to resume if the PR head SHA or merge policy changed since
+the state was written; re-run with `--no-resume` to discard and ship
+fresh.
+
+`shipyard ship-state list` is the self-describing inventory (PR,
+title, URL, tip commit subject, dispatched-run IDs). Come back to
+a week-old laptop state and still know what you were shipping.
 
 ### Fast test iteration on SSH targets
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.12.0
+    VERSION 0.18.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C
@@ -74,8 +74,12 @@ if(WIN32)
     add_compile_definitions(NOMINMAX WIN32_LEAN_AND_MEAN)
 endif()
 
-# ── Sanitizers (optional) ──────────────────────────────────────────────────
+# ── Instrumentation (optional) ─────────────────────────────────────────────
+# Sanitizers via PULP_SANITIZER=address|thread|undefined|memory|realtime
+# Coverage via PULP_ENABLE_COVERAGE=ON (Clang only, mutually exclusive
+# with PULP_SANITIZER).
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/Sanitizers.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpInstrumentation.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/PulpAAX.cmake)
 pulp_configure_aax_sdk()
 

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -30,18 +30,27 @@
 # bumps this pin.
 
 [shipyard]
-# v0.2.0 is the first major feature release after the migration
-# validation (Part 13 Stages 1-6, completed April 2026). Adds:
-#   - Incremental bundles: delta instead of full 443 MB uploads
-#   - --resume-from for SSH targets: skip to test phase (~2 min vs 15)
-#   - shipyard targets: list/test/add/remove targets from CLI
-#   - shipyard config: show merged config, switch profiles
-#   - Cloud polling timeout (60 min default, configurable)
-#   - EncodedCommand transport for Windows SSH (since v0.1.13)
-#   - Bundle skip when remote has SHA (since v0.1.14)
-#   - ssh-based upload replacing scp/SFTP (since v0.1.16)
-#   - Stale queue recovery on startup (since v0.1.16)
-version = "v0.2.0"
+# v0.3.0 introduces durable ship resume — Phase 1 of the close-the-
+# laptop work (see shipyard/planning → pulp-planning/
+# shipyard-routines-integration-proposal-2026-04-15.md). Adds:
+#   - shipyard ship --resume / --no-resume: an interrupted ship now
+#     persists per-PR state to disk on every material event, so a
+#     fresh session picks up from the same cloud run IDs without
+#     re-dispatching. Survives closed laptops, OS restarts, and
+#     agent-to-agent handoffs (Claude Code → Codex and back). Refuses
+#     to resume on SHA or merge-policy drift.
+#   - shipyard ship-state list | show <pr> | discard <pr>: inspect
+#     and manage in-flight ship state. The list/show output is self-
+#     describing — PR title, GitHub URL, tip commit subject are
+#     recorded alongside run IDs, so a week-old state file tells you
+#     what you were shipping.
+#   - shipyard cleanup --ship-state: opt-in pruning. Archived files
+#     older than 30 days and active files older than 14 days for
+#     closed/merged PRs are removed; open PRs are always preserved.
+# v0.2.0 (Part 13 Stages 1-6) also remains in this release with:
+#   - Incremental bundles, --resume-from SSH, shipyard targets/config,
+#     cloud polling timeout, ssh upload, stale queue recovery.
+version = "v0.3.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
## Summary

`PulpHostProvider` holds a raw `UiaSession*`, and `shutdown_accessibility` called `host_provider->Release()` then `delete session`. Screen readers cache provider pointers, so any in-flight method call reached the freed `session_` → UAF, crash risk under re-attach.

Fix: call `UiaDisconnectProvider(host_provider)` before `Release()`. This is the Windows-documented shutdown barrier — it waits for in-flight UIA calls to drain and rejects subsequent calls. After it returns, no UIA-originated call can reach the provider, so session deletion is safe.

Flagged by Codex as part of the #485 review, rolled up under #500.

## Test plan

- [x] Extended `test_accessibility_provider.cpp` with a 32-cycle init+shutdown hammer test that exercises the new barrier path
- [x] Existing 2-cycle test kept
- [ ] CI green on macOS / Ubuntu / Windows (Windows path is the one that actually drives the real UIA barrier)

Refs #500, #485.