### PR TITLE
audio(android): oboe — clean up input stream on output-start failure (#500)

### DIFF
--- a/core/audio/platform/android/oboe_device.cpp
+++ b/core/audio/platform/android/oboe_device.cpp
@@ -106,7 +106,20 @@ public:
         // Start output AFTER input buffer is provisioned. The audio
         // callback will now observe a fully-constructed input_buffer_ on
         // its first tick, not an in-progress resize.
-        if (output_stream_->requestStart() != oboe::Result::OK) return false;
+        if (output_stream_->requestStart() != oboe::Result::OK) {
+            // #500 / #480: if we already started the input stream above,
+            // a failed output start left it running — every retry then
+            // leaked another input stream. Tear it down before returning
+            // failure so the caller sees a clean slate.
+            if (input_stream_) {
+                input_stream_->requestStop();
+                input_stream_->close();
+                input_stream_.reset();
+                input_buffer_.clear();
+                current_input_channels_ = 0;
+            }
+            return false;
+        }
 
         return true;
     }


### PR DESCRIPTION
## Summary

When \`open()\` successfully started the input stream but then \`output_stream_->requestStart()\` failed, the early return bailed without stopping or closing the already-started input stream. Every retry leaked another input stream — on flaky devices users hit a soft resource cap after a few reconnect cycles.

Fix mirrors the existing input-start-failure cleanup block: on output-start failure, \`requestStop\` + \`close\` + \`reset\` the input stream, clear the buffer, and reset channel count.

Flagged by Codex on #480; rolled up under #500.

## Test plan

- [x] 14-line self-contained change mirroring existing cleanup path
- [ ] No unit test — oboe_device.cpp calls real Oboe hardware APIs with no existing test infrastructure. Tracked under #290 coverage hardening
- [ ] CI green on macOS / Ubuntu / Windows (this path is Android-only, builds only on Android NDK lane)

Refs #500.