### PR TITLE
view(win): UIA shutdown UAF — disconnect provider before delete (#500)

### DIFF
--- a/core/view/platform/win/accessibility_win.cpp
+++ b/core/view/platform/win/accessibility_win.cpp
@@ -205,6 +205,19 @@ void shutdown_accessibility(void* handle) {
         UiaReturnRawElementProvider(session->hwnd, 0, 0, nullptr);
     }
     if (session->host_provider) {
+        // #500 / #485: PulpHostProvider holds a raw UiaSession*, but
+        // UIA clients cache provider pointers and can make method
+        // calls on them asynchronously. If we simply Release() our ref
+        // and delete session, a cached client could call any provider
+        // method (e.g. get_HostRawElementProvider, GetPropertyValue)
+        // and dereference the now-freed session_ → UAF.
+        //
+        // UiaDisconnectProvider is the officially-sanctioned shutdown
+        // barrier: it waits for in-flight UIA calls to drain AND
+        // rejects all subsequent calls (returning UIA_E_ELEMENTNOTAVAILABLE).
+        // After it returns, no UIA-originated call can reach the
+        // provider, so our session deletion below is safe.
+        UiaDisconnectProvider(session->host_provider);
         session->host_provider->Release();
         session->host_provider = nullptr;
     }

--- a/test/test_accessibility_provider.cpp
+++ b/test/test_accessibility_provider.cpp
@@ -33,6 +33,25 @@ TEST_CASE("accessibility_tree_changed tolerates a null handle",
     accessibility_tree_changed(nullptr);
     SUCCEED();
 }
+
+TEST_CASE("shutdown_accessibility: repeated init+shutdown cycles are safe",
+          "[a11y][provider][issue-500]") {
+    // #500 / #485: earlier shutdown ordering released our ref before
+    // UIA clients were disconnected from the provider, creating a
+    // UAF window if a cached client called any provider method after
+    // we deleted the session. The fix calls UiaDisconnectProvider
+    // before releasing our ref so in-flight calls drain and no new
+    // ones can land. Exercise many cycles to surface refcount or
+    // lifetime regressions; on Windows this drives the real UIA
+    // shutdown barrier, on Linux it exercises the stub.
+    View root;
+    for (int i = 0; i < 32; ++i) {
+        void* h = init_accessibility(root, nullptr);
+        REQUIRE(h != nullptr);
+        shutdown_accessibility(h);
+    }
+    SUCCEED("no crash across repeated attach/detach");
+}
 #else
 TEST_CASE("accessibility_provider is a no-op on this platform",
           "[a11y][provider]") {


### PR DESCRIPTION
## Summary

`PulpHostProvider` holds a raw `UiaSession*`, and `shutdown_accessibility` called `host_provider->Release()` then `delete session`. Screen readers cache provider pointers, so any in-flight method call reached the freed `session_` → UAF, crash risk under re-attach.

Fix: call `UiaDisconnectProvider(host_provider)` before `Release()`. This is the Windows-documented shutdown barrier — it waits for in-flight UIA calls to drain and rejects subsequent calls. After it returns, no UIA-originated call can reach the provider, so session deletion is safe.

Flagged by Codex as part of the #485 review, rolled up under #500.

## Test plan

- [x] Extended `test_accessibility_provider.cpp` with a 32-cycle init+shutdown hammer test that exercises the new barrier path
- [x] Existing 2-cycle test kept
- [ ] CI green on macOS / Ubuntu / Windows (Windows path is the one that actually drives the real UIA barrier)

Refs #500, #485.