### PR TITLE
chore: bump SDK to v0.23.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.23.0
+    VERSION 0.23.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Summary

Patch bump covering today's bug-fix cascade since v0.23.0:

- #501 — auto-release skip-trailer + revert regression fix
- #502 — post-merge review sweep workflow (new)
- #503 — OSC \`Receiver::stop()\` FD-reuse UB race
- #505 — Android audio focus \`LOSS_TRANSIENT\` routing + \`stopAudio\` unbind race
- #507 — Android oboe input-stream leak on output-start failure
- #508 — Windows UIA shutdown UAF — disconnect provider before delete

All fixes; no new public API or behavior changes. Plugin version unchanged at 0.6.0.

\`auto-release.yml\` will pick this up on merge and publish \`v0.23.1\` via the existing tag-triggered Release CLI workflow.

## Test plan

- [x] Single-line version change in \`CMakeLists.txt\`
- [ ] CI green (this is effectively a docs-class change; compiles unchanged)
- [ ] auto-release.yml fires on merge and tags v0.23.1