### PR TITLE
fix(ci): auto-release.yml YAML indent — every run since #501 failed silently

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -135,21 +135,29 @@ jobs:
           # Python helper: strict-greater semver compare. Returns "gt",
           # "eq", or "lt". Empty strings behave like "missing" — treat
           # as "lt" so HEAD always wins over nothing.
+          #
+          # #501 shipped this with the Python body at column 1, which
+          # broke the YAML `run: |` block scalar (any line less-indented
+          # than the block ends the scalar). GitHub rejected the workflow
+          # file with "workflow file issue" on every push since — every
+          # auto-release run silently failed, so v0.23.1 never tagged.
+          # Fix: use a heredoc that python3 reads from stdin so script
+          # indentation is divorced from YAML indentation.
           semver_cmp() {
-              python3 -c '
-import sys
-a, b = sys.argv[1], sys.argv[2]
-def parse(v):
-    if not v: return None
-    return tuple(int(x) for x in v.split("."))
-pa, pb = parse(a), parse(b)
-if pa is None and pb is None: print("eq")
-elif pa is None: print("lt")
-elif pb is None: print("gt")
-elif pa > pb: print("gt")
-elif pa < pb: print("lt")
-else: print("eq")
-' "$1" "$2"
+              python3 - "$1" "$2" <<'PYEOF'
+          import sys
+          a, b = sys.argv[1], sys.argv[2]
+          def parse(v):
+              if not v: return None
+              return tuple(int(x) for x in v.split("."))
+          pa, pb = parse(a), parse(b)
+          if pa is None and pb is None: print("eq")
+          elif pa is None: print("lt")
+          elif pb is None: print("gt")
+          elif pa > pb: print("gt")
+          elif pa < pb: print("lt")
+          else: print("eq")
+          PYEOF
           }
 
           # event.before — the push's immediate ancestor.


### PR DESCRIPTION
## Summary — P0, blocks all releases

#501 introduced a \`semver_cmp\` bash function with embedded Python code starting at column 1, nested inside a YAML \`run: |\` block indented 10 spaces. Any content line less-indented than the block terminates the scalar — so from YAML's perspective the Python body was outside the \`run\` mapping entirely. GitHub rejected the workflow file on every push with "this run likely failed because of a workflow file issue."

**Impact:** Every \`auto-release.yml\` run since #501 merged (#503, #505, #507, #508, #509) failed silently with 0 jobs dispatched — no logs, no annotations, just \`failure\` conclusion. That's why v0.23.1 never auto-tagged after #509 landed.

## Fix

Switch from \`python3 -c '…'\` inline to heredoc-from-stdin (\`python3 - "$1" "$2" <<'PYEOF' … PYEOF\`). Heredoc content is indented to match the YAML block, so YAML strips the leading 10 spaces and bash receives the terminator at column 0 — valid for both parsers.

## Verified

- YAML parses cleanly (previously failed at line 141 with "could not find expected ':'")
- Helper round-trips via local bash execution:
  - 0.24.0 vs 0.23.0 → \`gt\`
  - 0.23.0 vs 0.23.0 → \`eq\`
  - 0.22.0 vs 0.23.0 → \`lt\`
  - empty-string handling preserved

## Follow-up (not this PR)

Add \`yaml-parse-check.yml\` CI lane on every .github/workflows/* change so this class of bug fails the PR instead of shipping silent.

## Test plan

- [ ] Merge this → next push to main triggers auto-release.yml successfully
- [ ] v0.23.1 tag gets created retroactively on the merge
- [ ] Release CLI + Sign-and-Release workflows fire on the tag