### PR TITLE
lv2: serialize midi_out back to atom output port (#491)

### DIFF
--- a/core/format/include/pulp/format/lv2_adapter.hpp
+++ b/core/format/include/pulp/format/lv2_adapter.hpp
@@ -59,6 +59,16 @@ struct PulpLv2Instance {
     // feeds them to the Processor.
     bool accepts_midi = false;
     void* midi_in_atom = nullptr;
+
+    // #491: parallel output-atom port for plugins that emit MIDI. The
+    // TTL manifest already declared this port when produces_midi was
+    // set, but run() never serialized the Processor's midi_out buffer
+    // into it — silently dropping every outgoing event. The host pre-
+    // sizes the buffer via lv2:minimumSize and signals capacity in the
+    // atom.size field on entry to run(); the plugin overwrites the
+    // sequence using the lv2_atom_sequence_clear + append_event helpers.
+    bool produces_midi = false;
+    void* midi_out_atom = nullptr;
 };
 
 /// Resolve LV2_URID_Map from a features array.

--- a/core/format/include/pulp/format/lv2_entry.hpp
+++ b/core/format/include/pulp/format/lv2_entry.hpp
@@ -87,6 +87,7 @@ inline LV2_Handle instantiate(
         inst->num_audio_outputs += bus.default_channels;
     }
     inst->accepts_midi = desc.accepts_midi;
+    inst->produces_midi = desc.produces_midi;
 
     // Prepare the processor
     format::PrepareContext ctx;
@@ -106,6 +107,10 @@ inline void connect_port(LV2_Handle handle, uint32_t port, void* data) {
     // MIDI atom ports follow control ports. A plug-in with accepts_midi
     // gets one atom input port at index control_end. Workstream 01 #241.
     int atom_in_end = control_end + (inst->accepts_midi ? 1 : 0);
+    // #491: plug-ins with produces_midi get one atom output port right
+    // after the (optional) input. TTL emits these in the same order in
+    // generate_plugin_ttl(), so the host's port index matches.
+    int atom_out_end = atom_in_end + (inst->produces_midi ? 1 : 0);
 
     int idx = static_cast<int>(port);
 
@@ -118,11 +123,54 @@ inline void connect_port(LV2_Handle handle, uint32_t port, void* data) {
     } else if (idx < atom_in_end) {
         // LV2 atom input port — host hands us an LV2_Atom_Sequence buffer.
         inst->midi_in_atom = data;
+    } else if (idx < atom_out_end) {
+        // LV2 atom output port — host pre-allocates an LV2_Atom_Sequence
+        // buffer sized by lv2:minimumSize in the TTL. run() writes
+        // outgoing MIDI events into it.
+        inst->midi_out_atom = data;
     }
 }
 
 inline void activate(LV2_Handle) {
     // Nothing needed — processor is prepared at instantiation
+}
+
+// #491: write a MidiBuffer into an LV2_Atom_Sequence output port. Uses
+// the standard lv2_atom_sequence_clear + append_event helpers. On entry
+// the host's out_seq->atom.size carries the buffer capacity; clear()
+// resets it to sizeof(body) and append_event() increments it per event.
+// Events that don't fit are dropped, not truncated — matches every
+// other format adapter's overflow behavior. Exposed non-static for unit
+// testing; all arguments validated so missing URIDs are a no-op.
+inline void write_midi_out_to_sequence(
+    LV2_Atom_Sequence* out_seq,
+    LV2_URID urid_atom_sequence,
+    LV2_URID urid_midi_event,
+    const midi::MidiBuffer& midi_out) {
+    if (!out_seq || urid_atom_sequence == 0 || urid_midi_event == 0) return;
+    const uint32_t capacity = out_seq->atom.size;
+    out_seq->atom.type = urid_atom_sequence;
+    out_seq->body.unit = 0;  // frames
+    out_seq->body.pad = 0;
+    lv2_atom_sequence_clear(out_seq);
+
+    for (const auto& ev : midi_out) {
+        const uint32_t msg_size = ev.size();
+        if (msg_size == 0 || msg_size > 3) continue;
+        // Pack LV2_Atom_Event header + up to 3 MIDI bytes on the stack;
+        // append_event copies into out_seq.
+        struct alignas(8) {
+            LV2_Atom_Event hdr;
+            uint8_t payload[3];
+        } pkt{};
+        pkt.hdr.time.frames = ev.sample_offset;
+        pkt.hdr.body.type = urid_midi_event;
+        pkt.hdr.body.size = msg_size;
+        std::memcpy(pkt.payload, ev.data(), msg_size);
+        if (!lv2_atom_sequence_append_event(out_seq, capacity, &pkt.hdr)) {
+            break;  // out of capacity — drop remaining events
+        }
+    }
 }
 
 inline void run(LV2_Handle handle, uint32_t n_samples) {
@@ -183,6 +231,16 @@ inline void run(LV2_Handle handle, uint32_t n_samples) {
     proc_ctx.num_samples = static_cast<int>(n_samples);
 
     inst->processor->process(output, input, midi_in, midi_out, proc_ctx);
+
+    // #491: serialize outgoing MIDI back to the LV2 atom output port.
+    // Prior to this, any Processor that populated midi_out (arpeggiator,
+    // note generator, MIDI-effect passthrough) had its events silently
+    // dropped when hosted via LV2.
+    write_midi_out_to_sequence(
+        static_cast<LV2_Atom_Sequence*>(inst->midi_out_atom),
+        inst->urid_atom_sequence,
+        inst->urid_midi_event,
+        midi_out);
 }
 
 inline void deactivate(LV2_Handle) {

--- a/test/test_lv2_adapter.cpp
+++ b/test/test_lv2_adapter.cpp
@@ -1,8 +1,14 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <pulp/format/lv2_adapter.hpp>
+#include <pulp/format/lv2_entry.hpp>
 #include <pulp/format/processor.hpp>
+#include <pulp/midi/buffer.hpp>
+#include <pulp/midi/message.hpp>
 #include <pulp/state/store.hpp>
+
+#include <array>
+#include <cstring>
 
 using namespace pulp;
 using namespace pulp::format;
@@ -151,4 +157,128 @@ TEST_CASE("find_urid_map returns nullptr when feature absent", "[format][lv2]") 
     // Empty array (only sentinel)
     const LV2_Feature* empty[] = {nullptr};
     REQUIRE(find_urid_map(empty) == nullptr);
+}
+
+// ── #491: LV2 MIDI output port serialization ─────────────────────────────
+//
+// Regression guard for the silent-drop bug: the LV2 adapter declared the
+// atom:AtomPort output in TTL for plugins with produces_midi, but run()
+// never serialized midi_out back into the host's sequence buffer — so
+// every outgoing MIDI event vanished. These tests exercise the extracted
+// helper write_midi_out_to_sequence() directly; full run()-level
+// integration is tested via format-validator lanes in CI.
+
+namespace {
+constexpr LV2_URID kUridAtomSeq = 1;
+constexpr LV2_URID kUridMidiEvt = 2;
+
+// Allocate an output Atom_Sequence buffer with host-style capacity encoding:
+// atom.size initially holds the usable body capacity (per LV2 spec the
+// plugin overwrites it in run()).
+struct LV2SequenceBuffer {
+    std::array<uint8_t, 512> storage{};
+    LV2_Atom_Sequence* as_seq() {
+        return reinterpret_cast<LV2_Atom_Sequence*>(storage.data());
+    }
+    void prepare_as_output_port() {
+        std::memset(storage.data(), 0, storage.size());
+        // Host sets atom.size to the body capacity on entry to run().
+        as_seq()->atom.size = static_cast<uint32_t>(
+            storage.size() - sizeof(LV2_Atom));
+        as_seq()->atom.type = 0;
+    }
+};
+} // namespace
+
+TEST_CASE("write_midi_out_to_sequence emits MIDI events in order",
+          "[format][lv2][issue-491]") {
+    LV2SequenceBuffer buf;
+    buf.prepare_as_output_port();
+
+    midi::MidiBuffer midi_out;
+    auto note_on = midi::MidiEvent::note_on(0, 60, 100);
+    note_on.sample_offset = 8;
+    midi_out.add(note_on);
+    auto note_off = midi::MidiEvent::note_off(0, 60, 0);
+    note_off.sample_offset = 48;
+    midi_out.add(note_off);
+
+    lv2_generic::write_midi_out_to_sequence(
+        buf.as_seq(), kUridAtomSeq, kUridMidiEvt, midi_out);
+
+    // Header: type rewritten to sequence URID, unit = 0 (frames).
+    REQUIRE(buf.as_seq()->atom.type == kUridAtomSeq);
+    REQUIRE(buf.as_seq()->body.unit == 0);
+    REQUIRE(buf.as_seq()->body.pad == 0);
+
+    // Walk the emitted sequence and verify both events landed intact.
+    std::vector<std::tuple<int64_t, LV2_URID, uint32_t, uint8_t, uint8_t, uint8_t>> seen;
+    LV2_ATOM_SEQUENCE_FOREACH(buf.as_seq(), ev) {
+        const auto* data = reinterpret_cast<const uint8_t*>(ev + 1);
+        seen.emplace_back(ev->time.frames, ev->body.type, ev->body.size,
+                          data[0], data[1], data[2]);
+    }
+    REQUIRE(seen.size() == 2);
+    REQUIRE(std::get<0>(seen[0]) == 8);
+    REQUIRE(std::get<1>(seen[0]) == kUridMidiEvt);
+    REQUIRE(std::get<2>(seen[0]) == 3);
+    REQUIRE(std::get<3>(seen[0]) == 0x90);  // note-on, ch0
+    REQUIRE(std::get<4>(seen[0]) == 60);
+    REQUIRE(std::get<5>(seen[0]) == 100);
+    REQUIRE(std::get<0>(seen[1]) == 48);
+    REQUIRE(std::get<3>(seen[1]) == 0x80);  // note-off, ch0
+}
+
+TEST_CASE("write_midi_out_to_sequence is a no-op on null/missing URIDs",
+          "[format][lv2][issue-491]") {
+    LV2SequenceBuffer buf;
+    buf.prepare_as_output_port();
+    midi::MidiBuffer midi_out;
+    midi_out.add(midi::MidiEvent::note_on(0, 60, 100));
+
+    // Null out_seq — function returns without touching anything.
+    lv2_generic::write_midi_out_to_sequence(
+        nullptr, kUridAtomSeq, kUridMidiEvt, midi_out);
+    SUCCEED("no crash on null out_seq");
+
+    // Missing atom-sequence URID — function bails before mutating buf.
+    const auto snapshot = buf.storage;
+    lv2_generic::write_midi_out_to_sequence(
+        buf.as_seq(), 0, kUridMidiEvt, midi_out);
+    REQUIRE(buf.storage == snapshot);
+
+    // Missing midi-event URID — same guard.
+    lv2_generic::write_midi_out_to_sequence(
+        buf.as_seq(), kUridAtomSeq, 0, midi_out);
+    REQUIRE(buf.storage == snapshot);
+}
+
+TEST_CASE("write_midi_out_to_sequence drops events that overflow capacity",
+          "[format][lv2][issue-491]") {
+    // Undersized buffer: only room for a couple of events before append fails.
+    struct TinyBuf {
+        std::array<uint8_t, 64> storage{};
+        LV2_Atom_Sequence* as_seq() {
+            return reinterpret_cast<LV2_Atom_Sequence*>(storage.data());
+        }
+    } buf;
+    std::memset(buf.storage.data(), 0, buf.storage.size());
+    buf.as_seq()->atom.size = static_cast<uint32_t>(
+        buf.storage.size() - sizeof(LV2_Atom));
+
+    midi::MidiBuffer midi_out;
+    for (int i = 0; i < 20; ++i) {
+        auto ev = midi::MidiEvent::note_on(0, static_cast<uint8_t>(60 + i), 100);
+        ev.sample_offset = i * 4;
+        midi_out.add(ev);
+    }
+
+    lv2_generic::write_midi_out_to_sequence(
+        buf.as_seq(), kUridAtomSeq, kUridMidiEvt, midi_out);
+
+    // At least one event must have landed; overflow drops the remainder.
+    int count = 0;
+    LV2_ATOM_SEQUENCE_FOREACH(buf.as_seq(), ev) { (void)ev; ++count; }
+    REQUIRE(count >= 1);
+    REQUIRE(count < 20);  // drop happened, no crash/corruption
 }


### PR DESCRIPTION
## Summary

Plugins declared with \`produces_midi = true\` via \`PULP_LV2_PLUGIN\` had a declared-but-undriven output atom port. The TTL generator emitted \`lv2:OutputPort/atom:AtomPort\` at the correct index, but the generic \`run()\` created a local \`MidiBuffer\`, let the Processor fill it, then dropped it on the floor. Any Pulp instrument / arpeggiator / MIDI-effect hosted via LV2 sent **zero** outgoing MIDI events.

Same class as the AU v2 MIDI output bug #179 fixed pre-merge, but for LV2. Flagged by the 2026-04-20 hardening sweep (#491 bullet 3).

## Changes

- \`PulpLv2Instance\` gains \`produces_midi\` + \`midi_out_atom\` fields; \`instantiate()\` sets them from the descriptor
- \`connect_port\` gets an extra port-index branch for the output atom port (ordering matches TTL gen)
- New \`write_midi_out_to_sequence()\` helper uses \`lv2_atom_sequence_clear\` + \`lv2_atom_sequence_append_event\` with null/missing-URID guards
- \`run()\` calls the helper after \`process()\`

## Test plan

- [x] 3 new Catch2 cases, 17 assertions — all pass locally:
  - note-on + note-off emit in order with correct time/URID/bytes
  - null \`out_seq\` / missing URIDs = no-op, buffer untouched
  - oversized \`MidiBuffer\`: at least one event lands, remainder dropped, no crash
- [ ] CI green on macOS / Ubuntu / Windows

Refs #491.