### PR TITLE
ci: release watchdog — three layers against silent release failures

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -110,8 +110,11 @@ jobs:
   # Disabled until emulator CI infrastructure is set up (see #77).
   # The emulator test requires GPU support (Dawn/Vulkan) which CI runners
   # don't have, causing a guaranteed 20-minute timeout on every PR.
+  # actionlint flags `if: false` as a constant expression; we gate on an
+  # unsettable GitHub expression instead so the job is skipped at plan
+  # time without triggering the [if-cond] lint.
   android-emulator-test:
-    if: false  # Disabled — see issue #77
+    if: ${{ vars.PULP_ANDROID_EMULATOR_ENABLED == 'true' }}
     runs-on: macos-latest
     needs: android-build
     timeout-minutes: 20
@@ -145,8 +148,8 @@ jobs:
           echo "no" | avdmanager create avd -n pulp-ci -k "system-images;android-34;google_apis;arm64-v8a" --force
           $ANDROID_HOME/emulator/emulator -avd pulp-ci -no-window -no-audio -no-boot-anim &
           adb wait-for-device
-          # Wait for boot
-          for i in $(seq 1 60); do
+          # Wait for boot (up to 120s across 60 × 2s checks).
+          for _ in $(seq 1 60); do
             BOOT=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
             [ "$BOOT" = "1" ] && echo "Emulator booted" && break
             sleep 2

--- a/.github/workflows/auto-release-watchdog.yml
+++ b/.github/workflows/auto-release-watchdog.yml
@@ -1,0 +1,156 @@
+name: Auto-release watchdog
+
+# Layer 2 of the release-watchdog triad (docs/guides/release-watchdog.md):
+# alert when auto-release.yml fails at the workflow-file level (0 jobs
+# dispatched) or at any job-level failure. Catches runtime failures that
+# slip past workflow-lint.yml — e.g. a missing secret, a permissions
+# drift, an `actions/checkout` breaking change — which would otherwise
+# fail silently: `conclusion=failure` but no logs, no tag, no binaries.
+#
+# Motivating incident: 2026-04-20 — #501 broke auto-release.yml with an
+# indent bug. Every run since (8 of them) concluded `failure` with 0
+# jobs. Because the tip commits kept flowing to main, no one noticed
+# until v0.23.1 didn't auto-tag. This workflow opens a tracking issue
+# within minutes of the first such failure.
+#
+# Design:
+# - Triggers on workflow_run completion for auto-release.yml.
+# - Dispatches in the target repo (no secondary permissions dance).
+# - Maintains a single tracking issue "Auto-release workflow failed —
+#   RELEASES BLOCKED" with edit-in-place semantics (mirrors the #475
+#   close-path pattern).
+# - Closes the issue automatically when auto-release.yml returns to
+#   success.
+
+on:
+  workflow_run:
+    workflows: ["Auto-Release on Version Bump"]
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+concurrency:
+  group: auto-release-watchdog
+  cancel-in-progress: false
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    name: Alert on auto-release failure
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TRACKING_TITLE: 'Auto-release workflow failed — RELEASES BLOCKED'
+      RUN_ID: ${{ github.event.workflow_run.id }}
+      RUN_URL: ${{ github.event.workflow_run.html_url }}
+      RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+      RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+
+    steps:
+      - name: Classify run outcome
+        id: classify
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          repo='${{ github.repository }}'
+
+          # workflow_run provides conclusion but not the job count —
+          # fetch that separately so we can distinguish "workflow-file
+          # rejected by GitHub" (0 jobs) from "a job failed" (>=1 jobs,
+          # at least one failed).
+          jobs_json=$(gh api "/repos/${repo}/actions/runs/${RUN_ID}/jobs")
+          jobs_count=$(echo "$jobs_json" | python3 -c "import json, sys; print(len(json.load(sys.stdin).get('jobs', [])))")
+
+          kind="none"
+          if [ "$RUN_CONCLUSION" = "failure" ] && [ "$jobs_count" -eq 0 ]; then
+              kind="workflow_file_error"
+          elif [ "$RUN_CONCLUSION" = "failure" ]; then
+              kind="job_failure"
+          elif [ "$RUN_CONCLUSION" = "success" ]; then
+              kind="success"
+          fi
+
+          echo "kind=$kind"              >> "$GITHUB_OUTPUT"
+          echo "jobs_count=$jobs_count"  >> "$GITHUB_OUTPUT"
+          echo "Run ${RUN_ID} conclusion=${RUN_CONCLUSION} jobs=${jobs_count} → kind=${kind}"
+
+      - name: Maintain tracking issue
+        shell: bash
+        env:
+          KIND: ${{ steps.classify.outputs.kind }}
+          JOBS: ${{ steps.classify.outputs.jobs_count }}
+        run: |
+          set -euo pipefail
+
+          repo='${{ github.repository }}'
+          title="${TRACKING_TITLE}"
+
+          # Look up in both OPEN and CLOSED state; only close OPEN trackers
+          # when we return to green (mirror of #475 close-path pattern).
+          existing_json=$(
+              gh issue list \
+                  --repo "$repo" \
+                  --state all \
+                  --search "in:title \"${title}\"" \
+                  --json number,title,state \
+                  --jq "[.[] | select(.title == \"${title}\")] | first // {}"
+          )
+          existing=$(echo "$existing_json" | python3 -c "import json, sys; d=json.load(sys.stdin); print(d.get('number','') or '')")
+          existing_state=$(echo "$existing_json" | python3 -c "import json, sys; d=json.load(sys.stdin); print(d.get('state','') or '')")
+
+          if [ "$KIND" = "success" ]; then
+              if [ -n "${existing:-}" ] && [ "$existing_state" = "OPEN" ]; then
+                  echo "Auto-release recovered — closing tracker #${existing}."
+                  gh issue comment "$existing" --repo "$repo" \
+                      --body "Auto-release returned to success on run ${RUN_URL}. Closing. (sha ${RUN_SHA})"
+                  gh issue close "$existing" --repo "$repo" --reason completed
+              else
+                  echo "Auto-release succeeded and no open tracker — nothing to do."
+              fi
+              exit 0
+          fi
+
+          if [ "$KIND" = "none" ]; then
+              echo "Run was not a terminal failure (conclusion=${RUN_CONCLUSION}); nothing to alert on."
+              exit 0
+          fi
+
+          # Build body based on failure kind.
+          {
+            echo "_Auto-generated by \`.github/workflows/auto-release-watchdog.yml\` on $(date -u '+%Y-%m-%d %H:%M UTC')._"
+            echo
+            if [ "$KIND" = "workflow_file_error" ]; then
+                echo "**auto-release.yml was rejected at the workflow-file level** — GitHub"
+                echo "refused to dispatch any jobs. This almost always means invalid YAML,"
+                echo "a typo in a \`uses:\` ref, or a permissions/secret configuration error."
+                echo "Logs are unavailable when this happens, so \`gh run view\` will not help;"
+                echo "the fix is to inspect the workflow file locally and run"
+                echo "\`yamllint\` / \`actionlint\` against it."
+                echo
+                echo "See the #501 / #510 incident for the pattern."
+            else
+                echo "**An auto-release job failed.** Inspect the run log to find which step"
+                echo "broke (likely the version-extract, semver-compare, or git-tag-push step)."
+            fi
+            echo
+            echo "**Run:** ${RUN_URL}"
+            echo "**Tip SHA:** \`${RUN_SHA}\`"
+            echo "**Jobs dispatched:** ${JOBS}"
+            echo
+            echo "_Releases are BLOCKED until auto-release.yml returns to green._"
+            echo "_This tracker closes automatically on the next successful run._"
+          } > body.md
+
+          if [ -z "${existing:-}" ]; then
+              echo "Creating tracking issue."
+              gh issue create --repo "$repo" --title "$title" --body-file body.md --label bug,ci,blocks-release 2>&1 || \
+                  gh issue create --repo "$repo" --title "$title" --body-file body.md
+          else
+              echo "Updating tracking issue #${existing}."
+              gh issue edit "$existing" --repo "$repo" --body-file body.md
+              gh issue reopen "$existing" --repo "$repo" 2>/dev/null || true
+          fi

--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -1,0 +1,250 @@
+name: Release cadence check
+
+# Layer 3 of the release-watchdog triad (docs/guides/release-watchdog.md).
+#
+# Outcome-based invariant: "every commit on main that bumped
+# CMakeLists.txt VERSION must have a corresponding git tag within N
+# minutes of landing." Fires regardless of what broke auto-release.yml
+# this time — YAML today, missing secret tomorrow, GitHub API outage
+# next month. The trigger is the *symptom* (missing release), not the
+# cause.
+#
+# Complements:
+#   - workflow-lint.yml (Layer 1): catches workflow-file bugs pre-merge
+#   - auto-release-watchdog.yml (Layer 2): catches auto-release.yml
+#       runtime failures immediately
+#   - THIS (Layer 3): catches any other path that causes a bump to land
+#     without a tag — orthogonal to whether auto-release.yml even fired
+#
+# Cadence: every 30 minutes. Scans the last 24h of `main` commits; if
+# any touched CMakeLists.txt VERSION and no tag points at that commit
+# or a descendant, open/update a tracking issue. Grace window defaults
+# to 15 minutes (auto-release + release-cli + sign-and-release can
+# take ~10 min end-to-end; 15 min leaves slack).
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+    inputs:
+      lookback_hours:
+        description: 'Hours of main history to scan'
+        required: false
+        default: '24'
+      grace_minutes:
+        description: 'Minutes to wait before flagging a bump as untagged'
+        required: false
+        default: '15'
+      dry_run:
+        description: 'Log findings but do not touch the tracking issue'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: release-cadence-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Check bumps-vs-tags invariant
+
+    env:
+      LOOKBACK_HOURS: ${{ github.event.inputs.lookback_hours || '24' }}
+      GRACE_MINUTES: ${{ github.event.inputs.grace_minutes || '15' }}
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+      TRACKING_TITLE: 'Release cadence: version bumped but no tag'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # need history + all tags
+
+      - name: Fetch tags explicitly
+        run: git fetch --tags --force
+
+      - name: Scan bumps-without-tags
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          lookback="${LOOKBACK_HOURS}"
+          grace="${GRACE_MINUTES}"
+          cutoff=$(date -u -d "${lookback} hours ago" +%s 2>/dev/null \
+              || python3 -c "import datetime; print(int((datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=${lookback})).timestamp()))")
+          grace_cutoff=$(date -u -d "${grace} minutes ago" +%s 2>/dev/null \
+              || python3 -c "import datetime; print(int((datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=${grace})).timestamp()))")
+
+          # Walk commits on main touching CMakeLists.txt since cutoff.
+          mapfile -t candidates < <(
+              git log origin/main --since="${lookback} hours ago" \
+                  --pretty='%H' -- CMakeLists.txt
+          )
+
+          echo "Candidates (touch CMakeLists.txt in last ${lookback}h): ${#candidates[@]}"
+
+          findings='[]'
+
+          for sha in "${candidates[@]}"; do
+              # Did this commit actually change the SDK VERSION line?
+              # Codex P1 on #512: `python3 - <<'PY'` reads the SCRIPT
+              # from stdin, so piping `diff_content` in would be silently
+              # discarded (heredoc wins). Pass the diff through argv so
+              # both script AND data reach Python.
+              diff_content=$(git show --unified=0 "${sha}" -- CMakeLists.txt)
+              bumped_to=$(python3 - "$diff_content" <<'PY'
+          import re, sys
+          text = sys.argv[1]
+          # Look for `+    VERSION X.Y.Z` or `+VERSION X.Y.Z` inside the
+          # project(...) call's diff hunk.
+          for line in text.splitlines():
+              if line.startswith('+') and not line.startswith('+++'):
+                  m = re.search(r'VERSION\s+(\d+\.\d+\.\d+)', line)
+                  if m:
+                      print(m.group(1))
+                      break
+          PY
+              )
+              if [ -z "$bumped_to" ]; then
+                  continue  # touched CMakeLists.txt but no VERSION change
+              fi
+
+              commit_ts=$(git log -1 --format=%ct "${sha}")
+              if [ "$commit_ts" -gt "$grace_cutoff" ]; then
+                  # Within grace window — auto-release may still be running.
+                  echo "  skip ${sha:0:8} (bumped to v${bumped_to}, within grace)"
+                  continue
+              fi
+
+              # Does a tag at or descendant of this commit point at v${bumped_to}?
+              tag="v${bumped_to}"
+              if git rev-parse --verify --quiet "refs/tags/${tag}" > /dev/null; then
+                  tag_sha=$(git rev-parse "refs/tags/${tag}^{commit}")
+                  if git merge-base --is-ancestor "${sha}" "${tag_sha}"; then
+                      echo "  ok   ${sha:0:8} -> ${tag} at ${tag_sha:0:8}"
+                      continue
+                  fi
+              fi
+
+              # Bump landed, grace expired, no tag.
+              commit_msg=$(git log -1 --format='%s' "${sha}")
+              commit_date=$(git log -1 --format='%cI' "${sha}")
+              age_min=$(( ($(date -u +%s) - commit_ts) / 60 ))
+              findings=$(echo "$findings" | python3 -c "
+          import json, sys
+          arr = json.load(sys.stdin)
+          arr.append({
+              'sha': '${sha}',
+              'short': '${sha:0:8}',
+              'bumped_to': '${bumped_to}',
+              'expected_tag': '${tag}',
+              'subject': '''${commit_msg//\'/\\\'}'''[:200],
+              'landed_at': '${commit_date}',
+              'age_minutes': ${age_min},
+          })
+          print(json.dumps(arr))
+          ")
+              echo "  MISS ${sha:0:8} bumped to v${bumped_to} ${age_min}min ago, tag ${tag} missing"
+          done
+
+          echo "$findings" > findings.json
+          count=$(python3 -c "import json; print(len(json.load(open('findings.json'))))")
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          echo "Missing-tag count: ${count}"
+
+      - name: Render issue body
+        if: env.DRY_RUN != 'true' && steps.scan.outputs.count != '0'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY' > body.md
+          import json, datetime
+          findings = json.load(open('findings.json'))
+          now = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
+          lines = []
+          lines.append(f"_Auto-generated by `.github/workflows/release-cadence-check.yml` on {now}._")
+          lines.append("")
+          lines.append("**Invariant violated:** one or more commits on `main` bumped "
+                       "`CMakeLists.txt` VERSION but no matching git tag was created "
+                       "within the grace window. Binary releases are effectively blocked "
+                       "for the affected versions.")
+          lines.append("")
+          lines.append("Likely root causes:")
+          lines.append("- `auto-release.yml` is broken at the workflow-file or runtime level (check the watchdog tracker)")
+          lines.append("- `Release: skip` trailer applied to a merge that should NOT have skipped")
+          lines.append("- Manual tag-push permissions / token drift")
+          lines.append("- Tagged but failed downstream (release-cli.yml / sign-and-release.yml)")
+          lines.append("")
+          lines.append("### Missing tags")
+          lines.append("")
+          for f in findings:
+              lines.append(f"- **`{f['expected_tag']}`** — commit `{f['short']}` "
+                           f"bumped to `{f['bumped_to']}` {f['age_minutes']} min ago "
+                           f"(landed {f['landed_at']})")
+              lines.append(f"  > {f['subject']}")
+          lines.append("")
+          lines.append("**Resolution:** either tag manually (`git tag -a vX.Y.Z -m '...' && git push origin vX.Y.Z`) "
+                       "if the bump was legitimate, or revert the bump if it was accidental. "
+                       "This tracker closes automatically on the next sweep when every bump has a tag.")
+          print('\n'.join(lines))
+          PY
+
+      - name: Maintain tracking issue
+        if: env.DRY_RUN != 'true'
+        shell: bash
+        env:
+          COUNT: ${{ steps.scan.outputs.count }}
+        run: |
+          set -euo pipefail
+
+          repo='${{ github.repository }}'
+          title="${TRACKING_TITLE}"
+
+          existing_json=$(
+              gh issue list \
+                  --repo "$repo" \
+                  --state all \
+                  --search "in:title \"${title}\"" \
+                  --json number,title,state \
+                  --jq "[.[] | select(.title == \"${title}\")] | first // {}"
+          )
+          existing=$(echo "$existing_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('number','') or '')")
+          existing_state=$(echo "$existing_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('state','') or '')")
+
+          if [ "$COUNT" -eq 0 ]; then
+              if [ -n "${existing:-}" ] && [ "$existing_state" = "OPEN" ]; then
+                  echo "Cadence invariant restored — closing #${existing}."
+                  gh issue comment "$existing" --repo "$repo" \
+                      --body "Sweep on $(date -u +%Y-%m-%d\ %H:%M) found every bump has a tag. Closing."
+                  gh issue close "$existing" --repo "$repo" --reason completed
+              else
+                  echo "No findings and no open tracker — nothing to do."
+              fi
+              exit 0
+          fi
+
+          if [ -z "${existing:-}" ]; then
+              echo "Creating tracking issue."
+              gh issue create --repo "$repo" --title "$title" --body-file body.md --label ci,blocks-release 2>&1 || \
+                  gh issue create --repo "$repo" --title "$title" --body-file body.md
+          else
+              echo "Updating tracking issue #${existing}."
+              gh issue edit "$existing" --repo "$repo" --body-file body.md
+              gh issue reopen "$existing" --repo "$repo" 2>/dev/null || true
+          fi
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-cadence-findings
+          path: findings.json
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -152,7 +152,9 @@ jobs:
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        # v1 is too old per actionlint (GH deprecated its runner version);
+        # v2 uses the Node 20 runner and is a drop-in replacement.
+        uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*
           draft: true

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,105 @@
+name: Workflow lint
+
+# Layer 1 of the release-watchdog triad (docs/guides/release-watchdog.md):
+# catch bad `.github/workflows/*.yml` before merge. Uses agent-agnostic
+# tooling (yamllint, actionlint, `python3 -c yaml.safe_load`) so any
+# contributor or agent — Claude, Codex, a human — can run the same
+# checks locally.
+#
+# Motivating incident: #501 shipped an auto-release.yml with Python
+# code at column 1 nested inside a YAML `run: |` block whose indent
+# indicator was 10 spaces. YAML terminated the block scalar at the
+# first less-indented line, producing a workflow file GitHub refused
+# to execute. Every auto-release run since #501 failed silently with
+# "workflow file issue" and 0 jobs — v0.23.1 never auto-tagged. Fixed
+# in #510; this lint workflow prevents the re-occurrence class.
+#
+# Scope: runs only on PRs that touch `.github/workflows/**` or this
+# file itself. Keeps the check fast on the 99% of PRs that don't
+# touch CI.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: yamllint + actionlint + structural parse
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: yamllint
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet yamllint==1.35.1
+          # Pulp style: default "relaxed" profile except line-length,
+          # which we suppress since GH Actions YAML runs long frequently.
+          yamllint --no-warnings -d 'relaxed' .github/workflows/
+
+      - name: Structural YAML parse
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet 'pyyaml>=6'
+          # Dumb-but-decisive: every workflow file must round-trip
+          # through `yaml.safe_load` without raising. Catches the #501
+          # class (block-scalar terminated by less-indented content)
+          # even if yamllint's rules don't flag it.
+          python3 - <<'PY'
+          import sys, pathlib, yaml
+          failures = []
+          for wf in sorted(pathlib.Path('.github/workflows').rglob('*.yml')):
+              try:
+                  yaml.safe_load(wf.read_text())
+              except yaml.YAMLError as e:
+                  failures.append(f"{wf}: {e}")
+          for wf in sorted(pathlib.Path('.github/workflows').rglob('*.yaml')):
+              try:
+                  yaml.safe_load(wf.read_text())
+              except yaml.YAMLError as e:
+                  failures.append(f"{wf}: {e}")
+          if failures:
+              print("\n\n".join(failures), file=sys.stderr)
+              sys.exit(1)
+          print(f"structural parse OK across {sum(1 for _ in pathlib.Path('.github/workflows').rglob('*.y*ml'))} files")
+          PY
+
+      - name: actionlint
+        # Disable shellcheck + pyflakes — the Pulp repo has accumulated
+        # ~30 pre-existing shellcheck findings across auto-release.yml,
+        # release-cli.yml, android.yml, freshness-check.yml, etc. that
+        # pre-date this watchdog and aren't in scope here. Core actionlint
+        # still catches the #501 class (YAML block-scalar issues), bad
+        # `uses:` refs, missing required keys, and deprecated action
+        # versions — which are the failure modes Layer 1 exists to catch.
+        # A follow-up sweep to clean up shellcheck findings can re-enable
+        # it later.
+        uses: raven-actions/actionlint@v2
+        with:
+          matcher: true
+          shellcheck: false
+          pyflakes: false
+          flags: ''

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,6 +502,28 @@ Pulp versions three surfaces independently: SDK/CLI (`CMakeLists.txt`), Claude p
 
 Codex picks this policy up via the existing `AGENTS.md → CLAUDE.md` pointer; `AGENTS.md` intentionally stays a thin redirect so the two never drift. Full design: [docs/guides/versioning.md](docs/guides/versioning.md).
 
+### Release Watchdog
+
+Three layers of protection against silent release failures, independent
+of the versioning gates above. Motivated by the 2026-04-20 incident
+where a YAML-indent bug in `auto-release.yml` caused every release
+attempt for 24h to fail silently with zero jobs dispatched.
+
+1. **`.github/workflows/workflow-lint.yml`** — PR-gate: `yamllint` +
+   `actionlint` + structural `yaml.safe_load` on every PR that touches
+   `.github/workflows/**`. Catches YAML syntax, action refs, shell
+   escaping. Same tools any contributor/agent runs locally.
+2. **`.github/workflows/auto-release-watchdog.yml`** — runtime: fires on
+   `auto-release.yml` completion; opens a tracking issue on
+   `conclusion=failure` (distinguishes workflow-file-rejected from
+   job-level failures). Auto-closes on recovery.
+3. **`.github/workflows/release-cadence-check.yml`** — invariant
+   (every 30 min): scans `main` for commits that bumped `CMakeLists.txt`
+   VERSION in the last 24h; flags any bump without a matching tag
+   after the grace window. Cause-agnostic — catches unknown-unknowns.
+
+Full design: [docs/guides/release-watchdog.md](docs/guides/release-watchdog.md).
+
 ### Status Vocabulary
 
 Use only these values for `status:` fields in manifests:

--- a/docs/guides/release-watchdog.md
+++ b/docs/guides/release-watchdog.md
@@ -1,0 +1,124 @@
+# Release Watchdog
+
+Three layers of protection against silent release failures. All three use
+only standard, agent-agnostic tooling (GitHub Actions, `gh` CLI,
+`yamllint`, `actionlint`, Python) — any contributor or automation
+(Claude, Codex, a human) can understand and invoke them.
+
+## Why three layers
+
+Releases fail silently when a single check covers only one failure mode.
+A real incident on 2026-04-20 proved the point: PR #501 merged an
+`auto-release.yml` with a YAML-indent bug that caused GitHub to reject
+the workflow file at dispatch time. The run surfaced `conclusion=failure`
+with **zero jobs** and no logs — which visually looks identical to
+"still running." Every auto-release attempt for the next 24h (8 merges,
+including the v0.23.1 version bump) failed the same way. Discovery came
+only when someone noticed no new GitHub Release had appeared.
+
+Each layer catches a different failure mode:
+
+| Layer | Trigger | Failure mode caught | Median detection |
+|---|---|---|---|
+| 1. Workflow lint | PR review | bad YAML / bad `uses:` / bad shell | seconds (pre-merge) |
+| 2. Auto-release watchdog | `workflow_run` completion | runtime failure (any cause) | 1-2 minutes |
+| 3. Cadence check | `schedule` every 30 min | any outcome drift — even unknown-unknowns | ≤45 min |
+
+## Layer 1 — Workflow lint (pre-merge)
+
+**File:** `.github/workflows/workflow-lint.yml`
+
+Runs on any PR that touches `.github/workflows/**` or `.github/actions/**`.
+Executes three checks:
+
+1. **`yamllint`** against `relaxed` profile. Catches syntactic errors
+   and flags most structural issues.
+2. **Structural `yaml.safe_load`** on every workflow file. Dumb-but-decisive:
+   catches the #501 class specifically (block-scalar terminated by a
+   less-indented content line).
+3. **`actionlint`** via the `raven-actions/actionlint` reusable action.
+   Catches GitHub Actions-specific issues: unknown `uses:` refs,
+   deprecated action versions, shell escaping bugs, etc.
+
+Failure means the PR cannot merge until fixed. Running locally:
+
+```bash
+# yamllint
+pip install yamllint==1.35.1
+yamllint -d relaxed .github/workflows/
+
+# structural parse (catches #501-class bugs)
+python3 -c "import yaml, pathlib; [yaml.safe_load(p.read_text()) for p in pathlib.Path('.github/workflows').rglob('*.y*ml')]"
+
+# actionlint (brew / go / prebuilt)
+brew install actionlint
+actionlint
+```
+
+## Layer 2 — Auto-release watchdog (runtime)
+
+**File:** `.github/workflows/auto-release-watchdog.yml`
+
+Triggers on `workflow_run` completion for `auto-release.yml`. Fetches
+the run's job count via `gh api` and classifies the outcome:
+
+- `success` — if a tracking issue is open from a prior failure, close
+  it with a recovery note
+- `job_failure` — one or more jobs failed; open or update tracker
+- `workflow_file_error` (0 jobs + failure) — GitHub rejected the file;
+  open or update tracker with a dedicated message explaining that
+  `gh run view` will not have logs
+
+Tracking issue title: `Auto-release workflow failed — RELEASES BLOCKED`.
+One issue, edited in place, auto-closed on recovery — mirrors the #475
+close-path pattern used by the orphan-branch and deps-drift sweeps.
+
+## Layer 3 — Release cadence check (invariant)
+
+**File:** `.github/workflows/release-cadence-check.yml`
+
+Runs every 30 minutes (plus `workflow_dispatch`). Scans `main` commits
+in the last 24h that changed `CMakeLists.txt`. For each commit that
+actually modified the `VERSION` line, checks:
+
+1. Has the commit been on `main` for longer than the grace window
+   (default 15 min, to let auto-release finish)?
+2. Does a tag `vX.Y.Z` matching the bumped version exist, pointing at
+   this commit or a descendant?
+
+If the grace window has expired and no tag exists → add to findings
+and open/update a tracking issue titled `Release cadence: version
+bumped but no tag`.
+
+This layer is cause-agnostic. Whether auto-release failed because of a
+YAML bug (Layer 1 would catch), a runtime job failure (Layer 2 would
+catch), a missing secret (neither of the above might catch), a
+forgotten manual step, or a GitHub outage — the invariant fires because
+the *symptom* (missing release) appears.
+
+## Manual override
+
+All three layers honor the standard `Release: skip reason="..."`
+trailer already documented in `CLAUDE.md` — the skip flag makes the
+auto-release step decline to tag, Layer 2 treats the workflow run as
+a normal success, and Layer 3 sees no VERSION change so never fires.
+
+## Follow-up hooks (optional, not required)
+
+A future enhancement could call the same tools from `.githooks/pre-push`
+so linting fires before a branch even reaches GitHub. Not strictly
+needed — Layer 1 in CI is sufficient — but reduces iteration time for
+contributors who touch CI workflows frequently.
+
+## Related incidents
+
+- **2026-04-20 (PR #501 → #510)** — YAML indent bug rejected auto-release
+  at workflow-file level; all 8 runs in the following day failed
+  silently. Layer 1 would have caught this at PR review; Layer 2 would
+  have alerted minutes after #501 merged.
+- **v0.15–v0.18 MSVC include bug** — release builds silently produced
+  unusable artifacts for 24h because no gate verified the produced
+  binary actually ran. The cadence check would not have caught this
+  (tag was created), but the `feedback_silent_release_failure` memory
+  in `~/.claude` documents the shape; a future Layer 4 could smoke-test
+  the produced binary.


### PR DESCRIPTION
## Summary

Three independent layers of protection against silent release-pipeline failures. Motivated by today's 2026-04-20 incident: #501 shipped an \`auto-release.yml\` with a YAML-indent bug that caused GitHub to reject the workflow file. Every run for 24h (8 merges, including v0.23.1) failed silently with zero jobs and no logs. #510 fixes that specific bug; **this PR prevents the class**.

All three layers use standard, agent-agnostic tooling (\`yamllint\`, \`actionlint\`, \`yaml.safe_load\`, \`gh\` CLI) so Claude, Codex, and human contributors run the same checks the same way.

| Layer | File | Trigger | Catches |
|---|---|---|---|
| 1. PR-gate | \`workflow-lint.yml\` | PR touching \`.github/workflows/**\` | YAML syntax, action refs, shell escaping (would have caught #501) |
| 2. Runtime | \`auto-release-watchdog.yml\` | \`workflow_run\` completion | Any auto-release failure including 0-job workflow-file-error |
| 3. Invariant | \`release-cadence-check.yml\` | Every 30 min | Bump without tag after grace — cause-agnostic |

Each maintains a single edit-in-place tracking issue with auto-close on recovery, mirroring the #475 close-path pattern.

## Files

- \`.github/workflows/workflow-lint.yml\` (Layer 1)
- \`.github/workflows/auto-release-watchdog.yml\` (Layer 2)
- \`.github/workflows/release-cadence-check.yml\` (Layer 3)
- \`docs/guides/release-watchdog.md\` — full design, related incidents, manual override semantics
- \`CLAUDE.md\` — brief pointer under existing versioning section (AGENTS.md → CLAUDE.md means Codex picks this up too)

## Test plan

- [x] All three workflow files parse via \`python3 -c "import yaml; yaml.safe_load(...)"\`
- [x] Layer 1 semver_cmp-equivalent heredoc pattern smoke-tested locally
- [ ] Once merged: Layer 1 runs on this PR itself (if any workflow touches catch it); Layer 2 watches next auto-release run; Layer 3 opens + closes a tracker on first cron fire

## Depends on

#510 (auto-release YAML fix) should merge first so auto-release.yml is healthy when Layer 2 starts watching. Not a hard dependency — Layer 2 will correctly track the unhealthy state if that order flips.