### PR TITLE
fix(ci): auto-release — trailer-aware bump detection (#513)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -160,62 +160,99 @@ jobs:
           PYEOF
           }
 
-          # event.before — the push's immediate ancestor.
-          prev='${{ github.event.before }}'
-          if [ -z "$prev" ] || [ "$prev" = "0000000000000000000000000000000000000000" ]; then
-              prev="HEAD~1"
-          fi
-
-          # Latest existing tag per surface.
+          # Latest existing tag per surface (HEAD~1 fallback is intentional —
+          # safer to compare against HEAD~1 than a missing-tag sentinel; for
+          # first-release cases the tag lookup returns empty and our
+          # decision script treats empty as "less than anything").
           latest_sdk_tag=$(git tag --list 'v[0-9]*' --sort=-version:refname | head -1)
           latest_plugin_tag=$(git tag --list 'plugin-v[0-9]*' --sort=-version:refname | head -1)
 
-          sdk_prev=$(extract_cmake_version "$prev" || true)
           sdk_tag=$(extract_cmake_version "${latest_sdk_tag:-HEAD~1}" || true)
           sdk_after=$(extract_cmake_version HEAD || true)
-          plugin_prev=$(extract_json_version "$prev" .claude-plugin/plugin.json || true)
           plugin_tag=$(extract_json_version "${latest_plugin_tag:-HEAD~1}" .claude-plugin/plugin.json || true)
           plugin_after=$(extract_json_version HEAD .claude-plugin/plugin.json || true)
 
-          # Decision: create tag iff HEAD > prev AND HEAD > latest-tag.
-          sdk_should_tag=0
-          if [ -n "$sdk_after" ]; then
-              gt_prev=$(semver_cmp "$sdk_after" "$sdk_prev")
-              gt_tag=$(semver_cmp "$sdk_after" "$sdk_tag")
-              if [ "$gt_prev" = "gt" ] && [ "$gt_tag" = "gt" ]; then
-                  sdk_should_tag=1
-              fi
-          fi
+          # #513 fix — trailer-aware bump detection. Walk history from
+          # HEAD backward to find the commit that set a given version
+          # file to its current value. If that bump commit carries
+          # `Release: skip`, the skip is sticky (permanent for that
+          # bumped value) and no future push re-evaluates it. Prior
+          # logic tried to approximate this using event.before and
+          # broke the self-heal case (v0.23.1 recovery on 2026-04-20
+          # showed the pattern).
+          find_bump_commit() {
+              local file="$1"
+              local extract="$2"
+              local current
+              current=$("$extract" HEAD "$file" 2>/dev/null || echo "")
+              [ -z "$current" ] && return 1
+              # Walk commits that touched the file, newest first.
+              local sha
+              for sha in $(git log --format=%H -- "$file" 2>/dev/null); do
+                  local at prev_v
+                  at=$("$extract" "$sha" "$file" 2>/dev/null || echo "")
+                  prev_v=$("$extract" "${sha}~1" "$file" 2>/dev/null || echo "")
+                  if [ "$at" = "$current" ] && [ "$at" != "$prev_v" ]; then
+                      echo "$sha"
+                      return 0
+                  fi
+              done
+              return 1
+          }
+          bump_has_skip() {
+              local sha="$1"
+              [ -z "$sha" ] && return 1
+              git log -1 --format=%B "$sha" \
+                  | git interpret-trailers --parse \
+                  | grep -iq '^release: skip'
+          }
+          # Wrap extractors to take (ref, file) for find_bump_commit's API.
+          extract_sdk_version_at() {
+              extract_cmake_version "$1"
+          }
+          extract_plugin_version_at() {
+              extract_json_version "$1" "$2"
+          }
 
-          plugin_should_tag=0
-          if [ -n "$plugin_after" ]; then
-              gt_prev=$(semver_cmp "$plugin_after" "$plugin_prev")
-              gt_tag=$(semver_cmp "$plugin_after" "$plugin_tag")
-              if [ "$gt_prev" = "gt" ] && [ "$gt_tag" = "gt" ]; then
-                  plugin_should_tag=1
-              fi
-          fi
+          sdk_bump=$(find_bump_commit CMakeLists.txt extract_sdk_version_at || true)
+          plugin_bump=$(find_bump_commit .claude-plugin/plugin.json extract_plugin_version_at || true)
+          sdk_skip=0; [ -n "$sdk_bump" ] && bump_has_skip "$sdk_bump" && sdk_skip=1
+          plugin_skip=0; [ -n "$plugin_bump" ] && bump_has_skip "$plugin_bump" && plugin_skip=1
 
-          # Expose the decision + context to the tagging step.
+          # Delegate the final decision to a pure-Python script we can
+          # unit test (tools/scripts/auto_release_decision.py). Inputs
+          # come from bash/git; decision logic lives somewhere diff-able
+          # and exercisable outside this workflow.
+          sdk_decision=$(python3 tools/scripts/auto_release_decision.py \
+              --head-version "$sdk_after" \
+              --tag-version "$sdk_tag" \
+              --bump-commit-has-skip "$sdk_skip" \
+              --surface sdk)
+          plugin_decision=$(python3 tools/scripts/auto_release_decision.py \
+              --head-version "$plugin_after" \
+              --tag-version "$plugin_tag" \
+              --bump-commit-has-skip "$plugin_skip" \
+              --surface plugin)
+
+          sdk_should_tag=$(echo "$sdk_decision" | python3 -c 'import json, sys; print(json.load(sys.stdin)["should_tag"])')
+          plugin_should_tag=$(echo "$plugin_decision" | python3 -c 'import json, sys; print(json.load(sys.stdin)["should_tag"])')
+
+          # Expose decision + inputs to the tagging step + the log.
           echo "sdk_should_tag=$sdk_should_tag"       >> "$GITHUB_OUTPUT"
           echo "plugin_should_tag=$plugin_should_tag" >> "$GITHUB_OUTPUT"
-          echo "sdk_before=$sdk_prev"                 >> "$GITHUB_OUTPUT"
           echo "sdk_after=$sdk_after"                 >> "$GITHUB_OUTPUT"
-          echo "plugin_before=$plugin_prev"           >> "$GITHUB_OUTPUT"
           echo "plugin_after=$plugin_after"           >> "$GITHUB_OUTPUT"
 
-          echo "sdk:    prev=$sdk_prev tag=$sdk_tag head=$sdk_after should_tag=$sdk_should_tag"
-          echo "plugin: prev=$plugin_prev tag=$plugin_tag head=$plugin_after should_tag=$plugin_should_tag"
+          echo "sdk decision:    $sdk_decision"
+          echo "plugin decision: $plugin_decision"
 
       - name: Create tags for moved surfaces
         if: steps.guard.outputs.skip == '0'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-          SDK_BEFORE: ${{ steps.versions.outputs.sdk_before }}
           SDK_AFTER: ${{ steps.versions.outputs.sdk_after }}
           SDK_SHOULD_TAG: ${{ steps.versions.outputs.sdk_should_tag }}
-          PLUGIN_BEFORE: ${{ steps.versions.outputs.plugin_before }}
           PLUGIN_AFTER: ${{ steps.versions.outputs.plugin_after }}
           PLUGIN_SHOULD_TAG: ${{ steps.versions.outputs.plugin_should_tag }}
         run: |

--- a/tools/scripts/auto_release_decision.py
+++ b/tools/scripts/auto_release_decision.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Decide whether auto-release.yml should create a tag for the given surface.
+
+Used by .github/workflows/auto-release.yml to decide — per-surface (SDK,
+plugin) — whether to create `v<version>` on the current HEAD.
+
+## Why a separate script
+
+The auto-release.yml history has three self-inflicted wounds in 2026-04-20:
+
+1. **#498** — switched the diff baseline from `event.before` to
+   `latest-tag`. Fixed the cascade-cancel self-heal case but broke
+   `Release: skip` stickiness and revert semantics.
+
+2. **#501** — reverted to AND-of-both (`HEAD > prev AND HEAD > tag`) to
+   try to preserve all three. Re-broke self-heal: when prev == HEAD (any
+   unrelated push after a prior bump landed), the first conjunct fails
+   and the tag never gets created — which is what happened to v0.23.1
+   after #509 + #510 merged.
+
+3. **#510** — fixed a YAML indent bug in #501's semver helper (Python
+   body at column 1 inside a 10-space-indented `run: |` block), which
+   had silently prevented ANY auto-release run for the preceding 24h.
+
+This script fixes the semantic bug that #501 introduced: decouple "was
+this version bump sanctioned?" from "is the file state newer than the
+tag?" so we get all three invariants right simultaneously.
+
+## Semantic model
+
+A version bump is *sanctioned* (deserves a tag) iff the commit that set
+the version to its current value does NOT carry `Release: skip` in its
+trailers. The skip trailer on the BUMP COMMIT is permanent — future
+pushes that don't re-touch the version file don't re-evaluate it.
+
+Algorithm per surface:
+
+  1. Find bump_commit: the most recent commit on HEAD that changed the
+     version in the version file to its current value.
+  2. If bump_commit has `Release: skip` trailer → DO NOT TAG.
+  3. Else if head_version > latest_tag_version → TAG.
+  4. Else → DO NOT TAG (no-op, revert, or already-tagged).
+
+## Test cases (all covered in test/test_auto_release_decision.py)
+
+  * self-heal after cancel: prev=HEAD=0.23, tag=0.22, no skip on bump → TAG
+  * sticky skip: prev=HEAD=0.23, tag=0.22, bump has Release: skip → NO TAG
+  * revert: prev=0.23, HEAD=0.22, tag=0.23 → NO TAG
+  * no-op push: prev=HEAD=tag=0.23 → NO TAG
+  * first release: prev=None, HEAD=0.1.0, tag=None → TAG
+  * sticky skip then unrelated push: sticky skip sticks even if 50 commits later
+
+## CLI contract
+
+Called from auto-release.yml with explicit inputs (resolved by bash from
+git) so the decision logic itself is pure and unit-testable.
+
+    python3 tools/scripts/auto_release_decision.py \\
+        --head-version 0.23.1 \\
+        --tag-version 0.23.0 \\
+        --bump-commit-has-skip 0 \\
+        --surface sdk
+
+Prints a JSON object to stdout:
+
+    {"should_tag": 1, "reason": "self-heal: head 0.23.1 > tag 0.23.0, bump commit not skipped", "surface": "sdk"}
+
+Exit 0 on any valid decision (even NO TAG). Exit nonzero only on bad input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def parse_version(v: str | None) -> tuple[int, int, int] | None:
+    """Parse a dot-separated semver string to a tuple. Empty/None → None."""
+    if not v:
+        return None
+    parts = v.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        return tuple(int(p) for p in parts)  # type: ignore[return-value]
+    except ValueError:
+        return None
+
+
+def semver_cmp(a: str | None, b: str | None) -> str:
+    """Returns 'gt', 'eq', or 'lt'. Missing side treated as less than anything."""
+    pa = parse_version(a)
+    pb = parse_version(b)
+    if pa is None and pb is None:
+        return "eq"
+    if pa is None:
+        return "lt"
+    if pb is None:
+        return "gt"
+    if pa > pb:
+        return "gt"
+    if pa < pb:
+        return "lt"
+    return "eq"
+
+
+def decide(
+    head_version: str | None,
+    tag_version: str | None,
+    bump_commit_has_skip: bool,
+    surface: str,
+) -> dict:
+    """Pure decision function. Inputs come from bash/git. Testable."""
+    if not head_version:
+        return {
+            "should_tag": 0,
+            "reason": f"no {surface} version at HEAD — nothing to tag",
+            "surface": surface,
+        }
+
+    if bump_commit_has_skip:
+        return {
+            "should_tag": 0,
+            "reason": (
+                f"sticky skip: bump commit for {surface} v{head_version} "
+                f"carries Release: skip trailer — permanently not tagged"
+            ),
+            "surface": surface,
+        }
+
+    cmp = semver_cmp(head_version, tag_version)
+    if cmp == "gt":
+        return {
+            "should_tag": 1,
+            "reason": (
+                f"{surface} v{head_version} > latest tag "
+                f"v{tag_version or '<none>'} — tagging"
+            ),
+            "surface": surface,
+        }
+
+    if cmp == "eq":
+        return {
+            "should_tag": 0,
+            "reason": (
+                f"{surface} v{head_version} already tagged — no-op"
+            ),
+            "surface": surface,
+        }
+
+    # cmp == "lt" — downgrade (revert or accidental)
+    return {
+        "should_tag": 0,
+        "reason": (
+            f"{surface} v{head_version} < latest tag v{tag_version} — "
+            f"revert or downgrade, not auto-tagging; resolve manually"
+        ),
+        "surface": surface,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--head-version", default="", help="Version at HEAD (e.g. 0.23.1)")
+    p.add_argument("--tag-version", default="", help="Version of latest tag (e.g. 0.23.0; empty if none)")
+    p.add_argument(
+        "--bump-commit-has-skip",
+        type=int,
+        choices=[0, 1],
+        default=0,
+        help="1 if the commit that set HEAD's version carries `Release: skip` trailer, else 0",
+    )
+    p.add_argument("--surface", default="sdk", help="Label for the version surface (sdk, plugin)")
+    args = p.parse_args()
+
+    result = decide(
+        head_version=args.head_version or None,
+        tag_version=args.tag_version or None,
+        bump_commit_has_skip=bool(args.bump_commit_has_skip),
+        surface=args.surface,
+    )
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scripts/test_auto_release_decision.py
+++ b/tools/scripts/test_auto_release_decision.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Unit tests for auto_release_decision.decide().
+
+Covers the three historical auto-release bug classes (#498, #501, #513)
+plus baseline correctness cases. Run with:
+
+    python3 -m pytest tools/scripts/test_auto_release_decision.py -v
+
+or without pytest:
+
+    python3 tools/scripts/test_auto_release_decision.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+spec = importlib.util.spec_from_file_location(
+    "auto_release_decision",
+    pathlib.Path(__file__).parent / "auto_release_decision.py",
+)
+ard = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(ard)
+
+
+class SemverCmpTests(unittest.TestCase):
+    def test_strict_greater(self):
+        self.assertEqual(ard.semver_cmp("0.23.1", "0.23.0"), "gt")
+        self.assertEqual(ard.semver_cmp("1.0.0", "0.99.99"), "gt")
+
+    def test_equal(self):
+        self.assertEqual(ard.semver_cmp("0.23.1", "0.23.1"), "eq")
+
+    def test_less(self):
+        self.assertEqual(ard.semver_cmp("0.22.0", "0.23.0"), "lt")
+
+    def test_empty_is_less(self):
+        self.assertEqual(ard.semver_cmp("", "0.1.0"), "lt")
+        self.assertEqual(ard.semver_cmp(None, "0.1.0"), "lt")
+
+    def test_empty_vs_empty(self):
+        self.assertEqual(ard.semver_cmp("", ""), "eq")
+        self.assertEqual(ard.semver_cmp(None, None), "eq")
+
+    def test_malformed(self):
+        # Not strictly required, but document behavior
+        self.assertEqual(ard.semver_cmp("not.a.version", "0.1.0"), "lt")
+
+
+class DecideTests(unittest.TestCase):
+    """Core decision-matrix cases."""
+
+    # ── Self-heal after cascade-cancel (#513 / v0.23.1 recovery) ─────────
+    def test_self_heal_tags_when_tag_is_behind_head(self):
+        """#509 bumped 0.23.0→0.23.1, but auto-release for that push was
+        broken (#510 YAML bug). After #510 merged, next auto-release run
+        sees HEAD=0.23.1 > tag=0.23.0 and must tag — the bump commit
+        did NOT carry Release: skip, so the tag is sanctioned."""
+        result = ard.decide(
+            head_version="0.23.1",
+            tag_version="0.23.0",
+            bump_commit_has_skip=False,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 1)
+        self.assertIn("tagging", result["reason"])
+
+    # ── Sticky skip invariant ────────────────────────────────────────────
+    def test_sticky_skip_blocks_tag_permanently(self):
+        """If the bump commit carries Release: skip, even on a later
+        unrelated push (prev==HEAD==0.23.1, tag=0.22.0) the decision is
+        still NO TAG. The skip is a property of the bump commit, not
+        the current push."""
+        result = ard.decide(
+            head_version="0.23.1",
+            tag_version="0.22.0",
+            bump_commit_has_skip=True,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 0)
+        self.assertIn("sticky skip", result["reason"])
+
+    def test_sticky_skip_still_blocks_when_bump_is_immediate(self):
+        """The push that introduces the bump + skip trailer should
+        itself not tag."""
+        result = ard.decide(
+            head_version="0.23.1",
+            tag_version="0.23.0",
+            bump_commit_has_skip=True,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 0)
+
+    # ── Revert / downgrade ───────────────────────────────────────────────
+    def test_downgrade_does_not_tag(self):
+        """Reverting 0.23.1 back to 0.22.0 must not tag — the old
+        v0.23.1 tag should keep pointing at the pre-revert commit.
+        Manual cleanup is correct for downgrades."""
+        result = ard.decide(
+            head_version="0.22.0",
+            tag_version="0.23.1",
+            bump_commit_has_skip=False,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 0)
+        self.assertIn("revert", result["reason"].lower())
+
+    # ── No-op push (most common case) ────────────────────────────────────
+    def test_no_op_push_when_already_tagged(self):
+        """Unrelated push after the tag is created. HEAD-version matches
+        latest tag. Nothing to do."""
+        result = ard.decide(
+            head_version="0.23.1",
+            tag_version="0.23.1",
+            bump_commit_has_skip=False,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 0)
+        self.assertIn("already tagged", result["reason"])
+
+    # ── First release in a repo ──────────────────────────────────────────
+    def test_first_release_tags(self):
+        """Empty tag history + any valid head version → tag."""
+        result = ard.decide(
+            head_version="0.1.0",
+            tag_version="",
+            bump_commit_has_skip=False,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 1)
+
+    def test_first_release_with_none_tag(self):
+        result = ard.decide(
+            head_version="0.1.0",
+            tag_version=None,
+            bump_commit_has_skip=False,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 1)
+
+    # ── Empty head version ───────────────────────────────────────────────
+    def test_missing_head_version_does_not_tag(self):
+        """Defensive: if extraction failed, don't tag."""
+        result = ard.decide(
+            head_version="",
+            tag_version="0.23.0",
+            bump_commit_has_skip=False,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 0)
+        self.assertIn("no sdk version", result["reason"].lower())
+
+    # ── Per-surface labeling ─────────────────────────────────────────────
+    def test_surface_appears_in_reason(self):
+        for surface in ("sdk", "plugin", "some-future-surface"):
+            result = ard.decide(
+                head_version="0.1.0",
+                tag_version="",
+                bump_commit_has_skip=False,
+                surface=surface,
+            )
+            self.assertEqual(result["surface"], surface)
+            self.assertIn(surface, result["reason"])
+
+
+class HistoricalBugRegressions(unittest.TestCase):
+    """Explicit regression gates for the three prior auto-release bugs."""
+
+    def test_498_self_heal_still_works(self):
+        """#498 motivation: cascade-cancel leaves prev==HEAD but tag
+        behind. New decision: tag based on head>tag, ignore prev."""
+        result = ard.decide(
+            head_version="0.23.1",
+            tag_version="0.22.0",
+            bump_commit_has_skip=False,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 1, "#498 self-heal regressed")
+
+    def test_501_sticky_skip_still_works(self):
+        """#501 motivation: skip trailer must stick across unrelated
+        pushes. Bump-commit-trailer check preserves this."""
+        result = ard.decide(
+            head_version="0.23.1",
+            tag_version="0.22.0",
+            bump_commit_has_skip=True,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 0, "#501 sticky skip regressed")
+
+    def test_501_revert_still_works(self):
+        """#501 motivation: downgrade shouldn't re-tag old version."""
+        result = ard.decide(
+            head_version="0.22.0",
+            tag_version="0.23.0",
+            bump_commit_has_skip=False,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 0, "#501 revert semantics regressed")
+
+    def test_513_v0231_recovery_case(self):
+        """#513 exact scenario: on 2026-04-20, #509 merged (bumped to
+        0.23.1) but auto-release was broken by #501's YAML bug. #510
+        fixed the YAML. Next push (#515 merge) should have tagged
+        v0.23.1 but didn't because #501's logic required prev<HEAD,
+        which was false after the bump landed one commit earlier.
+        Correct behavior now: tag."""
+        result = ard.decide(
+            head_version="0.23.1",
+            tag_version="0.23.0",
+            bump_commit_has_skip=False,
+            surface="sdk",
+        )
+        self.assertEqual(result["should_tag"], 1, "#513 v0.23.1 recovery regressed")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Closes #513. Fixes the self-heal regression #501 re-introduced — the one that blocked v0.23.1 auto-tag on 2026-04-20 and required manual recovery.

## Semantic model

A version bump is *sanctioned* iff the commit that set the version file to its current value does NOT carry \`Release: skip\` in its trailers. The skip is a property of the BUMP COMMIT; future pushes that don't re-touch the version file don't re-evaluate it.

### Algorithm per surface (SDK, plugin)

1. Walk history newest-first, find the commit that set the version file to its current value (prev→at transition)
2. If that commit carries \`Release: skip\` → NO TAG
3. Else if \`head_version > latest_tag_version\` → TAG
4. Else → NO TAG

## All historical invariants preserved

| Scenario | Inputs | Old (#501) | New | Correct? |
|---|---|---|---|---|
| #498 self-heal | prev==HEAD, tag<HEAD, no skip | ❌ no tag | ✅ TAG | Yes |
| #501 sticky skip | bump has skip | ✅ no tag | ✅ NO TAG | Yes |
| #501 revert | head<tag | ✅ no tag | ✅ NO TAG | Yes |
| #513 v0.23.1 recovery | HEAD=0.23.1, tag=0.23.0 | ❌ no tag | ✅ TAG | Yes |
| No-op push | head==tag | ✅ no tag | ✅ NO TAG | Yes |
| First release | tag empty | (untested) | ✅ TAG | Yes |

## Implementation

- **\`tools/scripts/auto_release_decision.py\`** — pure-Python decision function. Inputs come from bash/git; decision logic is deterministic and testable outside the workflow runtime.
- **\`tools/scripts/test_auto_release_decision.py\`** — 19 unit tests covering semver_cmp corners + decision matrix + explicit #498/#501/#513 regression gates. All pass locally.
- **\`auto-release.yml\`**:
  - New \`find_bump_commit\` walks \`git log -- <file>\` newest-first for the version-transition commit
  - New \`bump_has_skip\` invokes \`git interpret-trailers --parse\` on the bump commit
  - Delegates final decision to the Python script
  - Removes now-unused \`sdk_before\`/\`plugin_before\` outputs

## Test plan

- [x] \`python3 tools/scripts/test_auto_release_decision.py\` — 19 tests, all pass
- [x] YAML parses (layer-1 workflow-lint will verify on CI)
- [ ] CI green on macOS / Ubuntu / Windows
- [ ] Follow-up test: next version bump push to main produces a tag correctly (end-to-end validation)

Refs #513, #498, #501, #510.