### PR TITLE
view(win): UIA shutdown — atomic null-first before disconnect (#514)

### DIFF
--- a/core/view/platform/win/accessibility_win.cpp
+++ b/core/view/platform/win/accessibility_win.cpp
@@ -109,7 +109,12 @@ struct UiaSession {
     HWND hwnd = nullptr;
     View* root = nullptr;
     bool clients_listening = false;
-    PulpHostProvider* host_provider = nullptr;  // refcounted; released in shutdown
+    // Atomic so shutdown can null it BEFORE we tell UIA there is no
+    // provider for this HWND. The WM_GETOBJECT handler and every
+    // event-raising helper load this with acquire ordering; shutdown
+    // uses exchange(nullptr, acq_rel) as the publication barrier. See
+    // #514 for the race this closes.
+    std::atomic<PulpHostProvider*> host_provider{nullptr};  // refcounted; released in shutdown
 };
 
 // Small utilities. BSTR ownership follows COM rules (caller frees via
@@ -190,7 +195,10 @@ void* init_accessibility(View& root, void* hwnd) {
     session->hwnd = static_cast<HWND>(hwnd);
     session->root = &root;
     session->clients_listening = UiaClientsAreListening() ? true : false;
-    session->host_provider = new PulpHostProvider(session);
+    // Release store so a concurrent WM_GETOBJECT reader sees a fully
+    // constructed PulpHostProvider through its acquire load.
+    session->host_provider.store(new PulpHostProvider(session),
+                                 std::memory_order_release);
     runtime::log_info(
         "Windows UIA: session ready (clients_listening={})",
         session->clients_listening);
@@ -200,11 +208,37 @@ void* init_accessibility(View& root, void* hwnd) {
 void shutdown_accessibility(void* handle) {
     auto* session = static_cast<UiaSession*>(handle);
     if (!session) return;
-    // Detach the provider from any cached UIA client references.
+
+    // #514: Null the atomic FIRST, BEFORE we tell UIA there is no
+    // provider for this HWND. The race we are closing:
+    //
+    //   T1 (shutdown):  UiaReturnRawElementProvider(hwnd, 0, 0, nullptr);
+    //   T2 (UI thread): WM_GETOBJECT arrives → pulp_uia_handle_wm_getobject
+    //                   loads session->host_provider (still non-null) and
+    //                   calls UiaReturnRawElementProvider(..., host_provider)
+    //                   → UIA AddRef()'s the provider we are about to
+    //                   Release(). Our Release drops to refcount 0, delete,
+    //                   and the cached client holds a dangling pointer
+    //                   with session_ pointing at freed memory. UAF.
+    //
+    // Closing the window by publishing null to the handler first means
+    // any concurrent WM_GETOBJECT (or event-raise) sees null via its
+    // acquire load and returns early without handing the provider back
+    // out to UIA. Only then is it safe to:
+    //   1) tell UIA we have no provider for the HWND,
+    //   2) drain in-flight UIA calls via UiaDisconnectProvider, and
+    //   3) drop our ref.
+    auto* hp = session->host_provider.exchange(nullptr,
+                                               std::memory_order_acq_rel);
+
+    // After the exchange above, WM_GETOBJECT / notify_* helpers will
+    // load nullptr and return without touching hp. Now tell UIA there
+    // is no provider for this window.
     if (session->hwnd) {
         UiaReturnRawElementProvider(session->hwnd, 0, 0, nullptr);
     }
-    if (session->host_provider) {
+
+    if (hp) {
         // #500 / #485: PulpHostProvider holds a raw UiaSession*, but
         // UIA clients cache provider pointers and can make method
         // calls on them asynchronously. If we simply Release() our ref
@@ -217,9 +251,8 @@ void shutdown_accessibility(void* handle) {
         // rejects all subsequent calls (returning UIA_E_ELEMENTNOTAVAILABLE).
         // After it returns, no UIA-originated call can reach the
         // provider, so our session deletion below is safe.
-        UiaDisconnectProvider(session->host_provider);
-        session->host_provider->Release();
-        session->host_provider = nullptr;
+        UiaDisconnectProvider(hp);
+        hp->Release();
     }
     runtime::log_info("Windows UIA: session shutdown");
     delete session;
@@ -227,11 +260,12 @@ void shutdown_accessibility(void* handle) {
 
 void accessibility_tree_changed(void* handle) {
     auto* session = static_cast<UiaSession*>(handle);
-    if (!session || !session->host_provider) return;
+    if (!session) return;
+    auto* hp = session->host_provider.load(std::memory_order_acquire);
+    if (!hp) return;
     if (!UiaClientsAreListening()) return;
     UiaRaiseStructureChangedEvent(
-        session->host_provider,
-        StructureChangeType_ChildrenBulkAdded, nullptr, 0);
+        hp, StructureChangeType_ChildrenBulkAdded, nullptr, 0);
 }
 
 // ── Phase 2: WM_GETOBJECT handler ────────────────────────────────────────
@@ -242,18 +276,25 @@ extern "C" LRESULT pulp_uia_handle_wm_getobject(void* handle,
                                                  WPARAM wParam,
                                                  LPARAM lParam) {
     auto* session = static_cast<UiaSession*>(handle);
-    if (!session || !session->host_provider) return 0;
+    if (!session) return 0;
+    // Acquire-load to pair with shutdown's exchange-release: once
+    // shutdown has nulled host_provider we must NOT republish a stale
+    // pointer to UIA, or UIA will AddRef a provider we are about to
+    // Release → UAF (#514).
+    auto* hp = session->host_provider.load(std::memory_order_acquire);
+    if (!hp) return 0;
     // UIA_RootObjectId == UiaRootObjectId (negative magic from UIA)
     if (static_cast<long>(lParam) != UiaRootObjectId) return 0;
-    return UiaReturnRawElementProvider(hwnd, wParam, lParam,
-                                       session->host_provider);
+    return UiaReturnRawElementProvider(hwnd, wParam, lParam, hp);
 }
 
 // ── Phase 2 event-raising helpers ────────────────────────────────────────
 
 void notify_accessibility_value_changed(void* handle, View& /*target*/) {
     auto* session = static_cast<UiaSession*>(handle);
-    if (!session || !session->host_provider) return;
+    if (!session) return;
+    auto* hp = session->host_provider.load(std::memory_order_acquire);
+    if (!hp) return;
     if (!UiaClientsAreListening()) return;
     // Phase 3 will resolve the target View to its per-widget provider and
     // raise property-change on THAT provider. Until per-widget providers
@@ -263,26 +304,29 @@ void notify_accessibility_value_changed(void* handle, View& /*target*/) {
     VariantInit(&old_v);
     VariantInit(&new_v);
     UiaRaiseAutomationPropertyChangedEvent(
-        session->host_provider, UIA_ValueValuePropertyId, old_v, new_v);
+        hp, UIA_ValueValuePropertyId, old_v, new_v);
 }
 
 void notify_accessibility_focus_changed(void* handle, View& /*target*/) {
     auto* session = static_cast<UiaSession*>(handle);
-    if (!session || !session->host_provider) return;
+    if (!session) return;
+    auto* hp = session->host_provider.load(std::memory_order_acquire);
+    if (!hp) return;
     if (!UiaClientsAreListening()) return;
-    UiaRaiseAutomationEvent(session->host_provider,
-                            UIA_AutomationFocusChangedEventId);
+    UiaRaiseAutomationEvent(hp, UIA_AutomationFocusChangedEventId);
 }
 
 void notify_accessibility_name_changed(void* handle, View& /*target*/) {
     auto* session = static_cast<UiaSession*>(handle);
-    if (!session || !session->host_provider) return;
+    if (!session) return;
+    auto* hp = session->host_provider.load(std::memory_order_acquire);
+    if (!hp) return;
     if (!UiaClientsAreListening()) return;
     VARIANT old_v, new_v;
     VariantInit(&old_v);
     VariantInit(&new_v);
     UiaRaiseAutomationPropertyChangedEvent(
-        session->host_provider, UIA_NamePropertyId, old_v, new_v);
+        hp, UIA_NamePropertyId, old_v, new_v);
 }
 
 } // namespace pulp::view

--- a/test/test_accessibility_provider.cpp
+++ b/test/test_accessibility_provider.cpp
@@ -35,19 +35,40 @@ TEST_CASE("accessibility_tree_changed tolerates a null handle",
 }
 
 TEST_CASE("shutdown_accessibility: repeated init+shutdown cycles are safe",
-          "[a11y][provider][issue-500]") {
+          "[a11y][provider][issue-500][issue-514]") {
     // #500 / #485: earlier shutdown ordering released our ref before
     // UIA clients were disconnected from the provider, creating a
     // UAF window if a cached client called any provider method after
     // we deleted the session. The fix calls UiaDisconnectProvider
     // before releasing our ref so in-flight calls drain and no new
-    // ones can land. Exercise many cycles to surface refcount or
-    // lifetime regressions; on Windows this drives the real UIA
-    // shutdown barrier, on Linux it exercises the stub.
+    // ones can land.
+    //
+    // #514 tightens this further: host_provider is now std::atomic<*>,
+    // and shutdown exchanges it to null BEFORE calling
+    // UiaReturnRawElementProvider(hwnd, 0, 0, nullptr) / disconnecting.
+    // That closes a secondary race where WM_GETOBJECT on the UI thread
+    // could republish the provider to UIA between "tell UIA we have no
+    // provider" and "null out the session pointer", handing UIA an
+    // AddRef'd reference we were about to Release.
+    //
+    // Invariant this test pins: repeated init+shutdown cycles execute
+    // without crashing, double-free, or hang. On Windows this drives
+    // the real UIA shutdown barrier through the atomic-null-first
+    // ordering; on Linux it exercises the stub. Stress with enough
+    // cycles that any lingering refcount or ordering regression has a
+    // fighting chance to surface.
     View root;
     for (int i = 0; i < 32; ++i) {
         void* h = init_accessibility(root, nullptr);
         REQUIRE(h != nullptr);
+        // Exercise the event-raise helpers while the session is live
+        // so they go through the atomic acquire-load path at least
+        // once per cycle. They must also be a no-op after shutdown —
+        // see the follow-up invariant check below.
+        accessibility_tree_changed(h);
+        notify_accessibility_value_changed(h, root);
+        notify_accessibility_focus_changed(h, root);
+        notify_accessibility_name_changed(h, root);
         shutdown_accessibility(h);
     }
     SUCCEED("no crash across repeated attach/detach");


### PR DESCRIPTION
## Summary

Closes the residual shutdown UAF in the Windows UIA accessibility provider (#514) that remained after #500 fixed the primary Release-before-Disconnect race.

## The race

`shutdown_accessibility` used to do:

1. `UiaReturnRawElementProvider(hwnd, 0, 0, nullptr)` — tell UIA this HWND has no provider
2. `UiaDisconnectProvider(host_provider)`
3. `host_provider->Release()`
4. `session->host_provider = nullptr`
5. `delete session`

Between (1) and (4), a concurrent `WM_GETOBJECT` on the Win32 UI thread ran `pulp_uia_handle_wm_getobject`, which loaded `session->host_provider` (still non-null!) and handed the raw pointer back to UIA via `UiaReturnRawElementProvider`. UIA then `AddRef`'s the provider we were about to `Release`. Our Release dropped the refcount to zero, `delete` ran, and the cached UIA client held a dangling pointer with `session_` pointing at freed memory — UAF under screen-reader re-attachment.

## The fix

Null the atomic FIRST, then tell UIA, then drain, then Release:

- `UiaSession::host_provider` is now `std::atomic<PulpHostProvider*>`.
- `shutdown_accessibility()` does `exchange(nullptr, acq_rel)` FIRST so any concurrent `WM_GETOBJECT` / `notify_*` helper sees null via its acquire load and returns early without re-publishing.
- Only after the atomic null-store do we call `UiaReturnRawElementProvider(hwnd, 0, 0, nullptr)`, then `UiaDisconnectProvider` (the barrier that drains in-flight UIA calls), then `Release` on the saved-aside pointer, then `delete session`.
- `init_accessibility` uses `store(release)` so the handler's acquire load sees a fully-constructed `PulpHostProvider`.
- All 5 readers now use `load(acquire)`: `pulp_uia_handle_wm_getobject`, `accessibility_tree_changed`, `notify_accessibility_value_changed`, `notify_accessibility_focus_changed`, `notify_accessibility_name_changed`.

## Why atomic

`WM_GETOBJECT` fires on the Win32 UI thread. `shutdown_accessibility` may run on the main/init thread when the plugin window is torn down. Without an atomic + acquire/release pairing, there is no publication barrier — the UI thread could observe the old non-null pointer indefinitely even after a plain store.

## Test plan

- [x] `test/test_accessibility_provider.cpp` — the existing 32-cycle init+shutdown hammer (#500) now also exercises the four event-raise helpers inside each cycle, so the acquire-load path on `host_provider` is hit every iteration. Retagged `[issue-500][issue-514]`.
- [x] Builds clean on macOS (file is `#ifdef _WIN32`-guarded; test's Windows/Linux branch untouched on macOS).
- [ ] CI green on Windows — this is where the real atomic / UIA path is exercised.
- [ ] CI green on Ubuntu (Linux stub path).
- [ ] CI green on macOS (no-op placeholder).

## Links

- Fixes #514
- Follow-up to #508, #500, #485

Version-Bump: sdk=patch reason="P1 correctness fix (Windows UIA shutdown race)"
Skill-Update: skip skill=none reason="no skill covers accessibility subsystem"