### PR TITLE
bench: treat missing memory_bandwidth_fraction as unknown, not zero (Codex P1 on #518)

### DIFF
--- a/tools/scripts/bench_diff.py
+++ b/tools/scripts/bench_diff.py
@@ -172,18 +172,30 @@ def main() -> int:
         )
     )
 
-    base_mb = baseline.get("memory_bandwidth_fraction", 0.0)
-    curr_mb = current.get("memory_bandwidth_fraction", 0.0)
+    # Codex P1 on #518: missing `memory_bandwidth_fraction` is UNKNOWN,
+    # not zero. Defaulting to 0.0 would silently emit "below threshold —
+    # ROI may be limited" for snapshots where the field was never
+    # captured (schema drift, partial profiling runs, etc.) and mask a
+    # real missing-data problem. Distinguish "absent" from "0%".
+    base_mb = baseline.get("memory_bandwidth_fraction")
+    curr_mb = current.get("memory_bandwidth_fraction")
     out.append("## Memory-bandwidth fraction")
     out.append("")
-    out.append(f"- Baseline: {fmt_pct(base_mb)}")
-    out.append(f"- Current:  {fmt_pct(curr_mb)}")
-    out.append(f"- Δ:        {fmt_delta(base_mb, curr_mb)}")
+    out.append(f"- Baseline: {fmt_pct(base_mb) if base_mb is not None else '(not reported)'}")
+    out.append(f"- Current:  {fmt_pct(curr_mb) if curr_mb is not None else '(not reported)'}")
+    if base_mb is not None and curr_mb is not None:
+        out.append(f"- Δ:        {fmt_delta(base_mb, curr_mb)}")
     out.append(f"- Threshold: {fmt_pct(args.threshold)} of frame budget")
     out.append("")
 
     verdict = []
-    if base_mb >= args.threshold:
+    if base_mb is None:
+        verdict.append(
+            "**Baseline** did not report `memory_bandwidth_fraction` — "
+            "threshold evaluation skipped. This field is required for the "
+            "zero-copy go/no-go decision; check the capture harness."
+        )
+    elif base_mb >= args.threshold:
         verdict.append(
             f"**Baseline** exceeds {fmt_pct(args.threshold)} threshold — "
             "zero-copy has leverage here."
@@ -193,8 +205,19 @@ def main() -> int:
             f"**Baseline** below {fmt_pct(args.threshold)} threshold — "
             "zero-copy ROI may be limited on this widget."
         )
-    if curr_mb < base_mb:
-        saved = (base_mb - curr_mb) / base_mb
+
+    if curr_mb is None:
+        verdict.append(
+            "**Current** did not report `memory_bandwidth_fraction` — "
+            "no before/after comparison possible on this metric."
+        )
+    elif base_mb is None:
+        verdict.append(
+            "Current reported the fraction but baseline didn't — record "
+            "a fresh baseline before drawing conclusions."
+        )
+    elif curr_mb < base_mb:
+        saved = (base_mb - curr_mb) / base_mb if base_mb > 0 else 0.0
         verdict.append(
             f"**Current** reduced memory-bandwidth fraction by {fmt_pct(saved)} "
             "relative to baseline."


### PR DESCRIPTION
## Summary

Codex P1 on merged #518 ([comment link](https://github.com/danielraffel/pulp/pull/518#discussion_r3108033943)) — defaulting \`memory_bandwidth_fraction\` to \`0.0\` when a snapshot omits the field produced false "below threshold — ROI limited" verdicts. The verdict text looked authoritative but was based on no data at all, which would bury a real missing-data bug under the zero-copy go/no-go decision.

## Fix

Distinguish "field absent" from "field == 0%" in both display and verdict logic:

- Baseline / Current lines print \`(not reported)\` when absent, not \`0.00%\`
- Δ line suppressed if either side is missing
- Verdict says explicitly "threshold evaluation skipped — check capture harness" when baseline lacks the field
- Directional verdict only emitted when both sides present
- Divide-by-zero guarded even when both sides report 0.0

## Verified

Synthetic baseline-has-field + current-lacks-field snapshot → output correctly reports "(not reported)" + "no before/after comparison possible" instead of claiming zero change.

## Refs

- Fixes Codex P1 on #518
- Related: #516 (parent audit), #517 (benchmark sub-task)