### PR TITLE
docs: document pulp pr + reconcile CLAUDE.md ship guidance (#523 P0 Gap 2+3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -669,17 +669,33 @@ Pulp ships as a Claude Code plugin with slash commands (`/build`, `/test`, `/cre
 #### The `ship` workflow (primary path for all agents)
 
 ```bash
-# Shipyard is the primary CI tool. Say "ship this" or use directly:
+# Primary path for "ship this" / "push a PR" / any natural-language ship trigger:
+pulp pr
+
+# Useful options:
+pulp pr --base origin/main
+pulp pr --title "<title>"
+pulp pr --no-ship
+pulp pr --no-push
+pulp pr --dry-run
+
+# Fallback ONLY when the local `pulp` binary is broken (e.g. wgpu dylib load failure):
+shipyard pr
+
+# Lower-level Shipyard commands — use only for diagnostics or recovery, NOT as the
+# default ship path:
 shipyard run                              # validate current branch
 shipyard ship                             # PR + validate + merge on green
 shipyard cloud run build <branch>         # dispatch to Namespace
 ```
 
-The CI skill (`.agents/skills/ci/SKILL.md`) is the single process for landing code. It:
-1. Creates a PR to main
-2. Runs `shipyard ship` which validates on macOS (locally), Ubuntu (SSH), and Windows (SSH)
-3. Merges only when ALL targets pass
-4. Posts a closeout comment
+The CI skill (`.agents/skills/ci/SKILL.md`) is the single source of truth for landing code. Normal ship cycle:
+
+1. Run `pulp pr` — never `gh pr create` + `shipyard ship` separately (that bypasses the skill-sync and version-bump gates)
+2. The orchestrator runs skill-sync + version-bump gates, commits any bumps, pushes, opens a PR, and invokes `shipyard ship`
+3. `shipyard ship` validates on macOS (locally), Ubuntu (SSH), and Windows (SSH)
+4. Merges only when ALL targets pass
+5. Posts a closeout comment
 
 `local_ci.py` remains in the repo as a legacy fallback but is scheduled for removal (see issue #120).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -372,6 +372,56 @@ pulp ship check
 
 `package` creates per-format `.pkg` files using `pkgbuild`. macOS only.
 
+### pr
+
+**Status**: usable
+
+Create, validate, and merge a PR through the canonical ship flow.
+
+`pulp pr` is the primary "ship this" orchestrator referenced by the CI skill.
+By default it delegates to `shipyard pr` (single source of truth for ship
+orchestration). Use `--native` only for diagnostics when debugging the
+CLI-side fallback path. Natural-language triggers in agent conversations
+("push to main", "ship this", "ship it", "we're done", "merge this",
+"push it", "run CI", "push a PR") all route here — see
+[`.agents/skills/ci/SKILL.md`](../../.agents/skills/ci/SKILL.md) for the
+authoritative trigger list.
+
+```bash
+pulp pr
+pulp pr --base origin/main
+pulp pr --title "feat(cli): document pulp pr and sync CI policy"
+pulp pr --no-ship
+pulp pr --no-push
+pulp pr --dry-run
+
+# Fallback when the local `pulp` binary is broken (for example wgpu
+# dylib load failure). Equivalent for the default ship cycle:
+shipyard pr
+```
+
+Flags:
+
+| Flag | Description |
+|------|-------------|
+| `--base <ref>` | Diff base (default: `origin/main`) |
+| `--title <s>` | PR title (default: tip commit subject) |
+| `--no-ship` | Create PR but skip `shipyard ship` |
+| `--no-push` | Stop after bump commit; do not push or create PR |
+| `--dry-run` | Print the plan without executing steps |
+| `-h`, `--help` | Show help |
+
+Notes:
+
+- Default behavior is shim delegation to `shipyard pr` — the single source
+  of truth for ship orchestration. Do not treat `gh pr create` + `shipyard ship`
+  as a substitute; that sequence bypasses the skill-sync and version-bump
+  gates `pulp pr` runs first.
+- `--native` runs an in-CLI fallback that performs the same gates + PR flow
+  without delegating to Shipyard. Diagnostic use only.
+- For the canonical list of natural-language ship triggers and the full
+  policy, see [`.agents/skills/ci/SKILL.md`](../../.agents/skills/ci/SKILL.md).
+
 ### docs
 
 **Status**: usable

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -124,6 +124,40 @@ commands:
             required: false
     docs: reference/cli.md#ship
 
+  - name: pr
+    status: usable
+    summary: One-shot push-a-PR orchestrator. Primary path for shipping; delegates to shipyard pr by default and keeps native orchestration for diagnostics.
+    args:
+      - name: --base
+        kind: option
+        description: Diff base (default origin/main)
+        required: false
+      - name: --title
+        kind: option
+        description: PR title override (default tip commit subject)
+        required: false
+      - name: --no-ship
+        kind: flag
+        description: Create PR but skip shipyard ship
+        required: false
+      - name: --no-push
+        kind: flag
+        description: Stop after bump commit; do not push or create PR
+        required: false
+      - name: --dry-run
+        kind: flag
+        description: Print the plan without executing steps
+        required: false
+      - name: --help
+        kind: flag
+        description: Show help for the command
+        required: false
+      - name: --native
+        kind: flag
+        description: Run in-CLI fallback orchestrator instead of delegating to shipyard pr (diagnostics only)
+        required: false
+    docs: reference/cli.md#pr
+
   - name: docs
     status: usable
     summary: Browse local documentation and status manifests.


### PR DESCRIPTION
## Summary

Closes two P0 items from #523 (docs accuracy audit). RepoPrompt-driven plan (\`document-pulp-pr-ED452C\` chat), direct execution here.

## What was wrong

**Gap 2** — \`pulp pr\` is implemented in \`tools/cli/cmd_pr.cpp\` and surfaced by \`pulp help\`, but \`docs/reference/cli.md\` and \`docs/status/cli-commands.yaml\` never listed it. External contributors couldn't find the canonical PR workflow via published docs; agents trained on the docs invented \`gh pr create\` + \`shipyard ship\` sequences that bypass the skill-sync + version-bump gates.

**Gap 3** — \`CLAUDE.md\`'s ship-workflow subsection said *"Say 'ship this' or use directly: shipyard run / shipyard ship"*, directly contradicting \`.agents/skills/ci/SKILL.md\`'s rule that natural-language ship triggers route through \`pulp pr\`. Agents reading CLAUDE.md would silently bypass the gates.

## What changed

| File | Change |
|---|---|
| \`docs/reference/cli.md\` | New \`### pr\` section (flags table + examples + shim vs native notes + cross-link to ci skill) |
| \`docs/status/cli-commands.yaml\` | New \`- name: pr\` entry with full args list including the diagnostic-only \`--native\` flag |
| \`CLAUDE.md\` | Ship-workflow subsection rewritten: \`pulp pr\` primary, \`shipyard pr\` dylib-bug fallback, \`shipyard run/ship/cloud run\` demoted to diagnostics |

## Remaining from #523

P0 Gap 1 (\`pulp_add_ios_auv3\` export vs example rewrite) + P1/P2 items (LV2 URID stale claim, host-loader stubbed claim, 6 other undocumented CLI commands, local-ci.md Shipyard v0.3.0 surface, duplicate ci-local sections) remain in #523 for future PRs.

## Test plan

- [x] YAML parses (\`python3 -c "import yaml; yaml.safe_load(open(...))"\`)
- [x] Slug \`#pr\` is unique in \`docs/reference/cli.md\`
- [ ] CI green on all platforms (docs-only change)
- [ ] \`tools/check-docs.sh\` / \`pulp docs check\` passes if run