### PR TITLE
ci(android): re-enable emulator smoke test with correct ABI + intent

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -106,15 +106,19 @@ jobs:
           path: android/app/build/outputs/apk/debug/app-debug.apk
           retention-days: 7
 
-  # Emulator test — only on macOS (KVM not available on GitHub Windows runners)
-  # Disabled until emulator CI infrastructure is set up (see #77).
-  # The emulator test requires GPU support (Dawn/Vulkan) which CI runners
-  # don't have, causing a guaranteed 20-minute timeout on every PR.
-  # actionlint flags `if: false` as a constant expression; we gate on an
-  # unsettable GitHub expression instead so the job is skipped at plan
-  # time without triggering the [if-cond] lint.
+  # Emulator test — only on macOS (KVM not available on GitHub Windows runners).
+  # This is a native-init smoke: boots a headless arm64-v8a emulator, installs
+  # the arm64-only debug APK, launches PulpActivity, and greps logcat for the
+  # JNI_OnLoad marker. Full GPU/rendering validation is out of scope here
+  # (tracked under #77).
+  #
+  # Re-enabled in #487 after identifying the real cause of earlier failures:
+  # the workflow was targeting an x86_64 system image while the APK only
+  # contains arm64-v8a (see android/app/build.gradle.kts), which produced
+  # INSTALL_FAILED_NO_MATCHING_ABIS and made every subsequent adb command
+  # appear to hang. The AVD arch and the `am start` intent below are the
+  # matched pair — touch both together if the applicationId ever changes.
   android-emulator-test:
-    if: ${{ vars.PULP_ANDROID_EMULATOR_ENABLED == 'true' }}
     runs-on: macos-latest
     needs: android-build
     timeout-minutes: 20


### PR DESCRIPTION
## Summary

Re-enables the `android-emulator-test` CI job in `.github/workflows/android.yml`. The job was gated on an unsettable repo variable (`PULP_ANDROID_EMULATOR_ENABLED`) after PR #486 hit what looked like an emulator boot failure three times. Post-merge Codex review on #487 found the real cause wasn't the emulator at all — the smoke script itself was broken.

## Root cause (from #487)

1. **ABI mismatch.** `android/app/build.gradle.kts` pins `abiFilters = listOf("arm64-v8a")` only (GPU/Skia pre-built for arm64). Earlier iterations of the workflow targeted an `x86_64` system image, so `adb install` returned `INSTALL_FAILED_NO_MATCHING_ABIS` and every subsequent adb command looked like it hung.
2. **Wrong activity intent.** The APK's `applicationId` is `com.pulp.app`; an earlier `am start -n com.pulp/com.pulp.PulpActivity` invocation would not resolve.

Both the AVD arch (`system-images;android-34;google_apis;arm64-v8a`) and the launch intent (`com.pulp.app/com.pulp.PulpActivity`) are already correct in the current workflow — the only remaining blocker was the gate. This PR removes it and adds a comment block above the job explaining why AVD arch + launch intent must stay matched to `build.gradle.kts`.

## Why this is safe to re-enable unconditionally

- The job only runs when `android/**`, `core/**`, `tools/cmake/PulpAndroid.cmake`, or this workflow changes (path filters at the top of the file).
- `timeout-minutes: 20` caps the runtime, so a still-broken run burns 20 min of budget, not the whole CI lane.
- It `needs: android-build`, so it cannot start until the APK + `libpulp.so` verification has passed on macOS.

## Test plan

- [x] yamllint + actionlint clean
- [x] Structural YAML parse round-trips
- [x] skill_sync_check.py + version_bump_check.py pass in --mode=report
- [ ] Android Build job (macOS + Windows) stays green
- [ ] `android-emulator-test` actually boots the arm64-v8a emulator on `macos-latest`, installs the APK, launches `PulpActivity`, and greps `JNI_OnLoad: Pulp native bridge initialized` out of logcat

Closes #487.