### PR TITLE
ci(android): re-gate emulator smoke — HVF unsupported on macos-latest

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -112,13 +112,28 @@ jobs:
   # JNI_OnLoad marker. Full GPU/rendering validation is out of scope here
   # (tracked under #77).
   #
-  # Re-enabled in #487 after identifying the real cause of earlier failures:
-  # the workflow was targeting an x86_64 system image while the APK only
-  # contains arm64-v8a (see android/app/build.gradle.kts), which produced
-  # INSTALL_FAILED_NO_MATCHING_ABIS and made every subsequent adb command
-  # appear to hang. The AVD arch and the `am start` intent below are the
-  # matched pair — touch both together if the applicationId ever changes.
+  # Re-gated 2026-04 after #530 (re-enable attempt) proved a third failure
+  # mode beyond the two originally documented in #487:
+  #
+  #   1. ABI mismatch (x86_64 emulator vs arm64-only APK) — fixed in workflow.
+  #   2. Wrong launch intent (com.pulp vs com.pulp.app) — fixed in workflow.
+  #   3. `macos-latest` is now Apple Silicon (ARM64). Booting an arm64-v8a
+  #      Android system image via QEMU + HVF hits `HV_UNSUPPORTED`, so
+  #      `qemu-system-aarch64-headless` exits with "failed to initialize HVF:
+  #      Invalid argument" immediately after startup. `adb wait-for-device`
+  #      then hangs, and the job burns its full `timeout-minutes: 20`.
+  #
+  # The AVD arch + `am start` intent below are still the matched pair for
+  # the APK (arm64-v8a / com.pulp.app/com.pulp.PulpActivity); do not change
+  # one without the other. What's missing is a runner that can actually
+  # accelerate arm64 Android guests — Linux arm64 + KVM, x86_64 APK + x86_64
+  # emulator, or a self-hosted ARM macOS with nested-HVF — see #487 for the
+  # path-forward discussion.
+  #
+  # `PULP_ANDROID_EMULATOR_ENABLED=true` in repo vars re-enables the job
+  # once a working runner configuration lands.
   android-emulator-test:
+    if: ${{ vars.PULP_ANDROID_EMULATOR_ENABLED == 'true' }}
     runs-on: macos-latest
     needs: android-build
     timeout-minutes: 20


### PR DESCRIPTION
## Summary

Follow-up to #530. The re-enable attempt in #530 surfaced a third failure mode that the original #487 triage didn't catch: `macos-latest` is Apple Silicon, and QEMU+HVF can't accelerate arm64 Android guests on ARM64 hosts.

Emulator log excerpt from #530's failing run (https://github.com/danielraffel/pulp/actions/runs/24655977992/job/72091082998):

```
HVF error: HV_UNSUPPORTED
WARNING      | QEMU main loop exits abnormally with code 1
qemu-system-aarch64-headless: failed to initialize HVF: Invalid argument
```

`qemu-system-aarch64-headless` exits immediately. `adb wait-for-device` hangs. The job burns its full `timeout-minutes: 20` on every Android PR. That's CI noise we don't want.

## What this PR does

- Re-adds the `if: ${{ vars.PULP_ANDROID_EMULATOR_ENABLED == 'true' }}` gate (same pattern used before #530). The AVD arch and launch intent fixes from #530 are **kept** — they're still correct prerequisites.
- Rewrites the comment block above the job to document all three failure modes (ABI mismatch, wrong intent, HVF-on-ARM64-macos), so the next person won't re-discover this.
- `PULP_ANDROID_EMULATOR_ENABLED=true` in repo vars re-enables the job once a working runner config lands.

## Path forward (tracked in #487)

One of:
1. Add x86_64 to debug `abiFilters` + produce x86_64 `libpulp.so` (Skia Android x86_64 prebuilt needed, or CMake gate disables Skia for x86_64 builds).
2. Run the emulator on a Linux arm64 runner via KVM (Namespace has `ubuntu-24.04-arm64`).
3. Self-hosted macOS with nested-HVF / real arm64 Android HAL.

## Test plan

- [x] yamllint + actionlint clean
- [x] skill_sync_check + version_bump_check pass in `--mode=report`
- [ ] Shipyard lanes (macos + linux + windows) pass
- [ ] `android-emulator-test` no longer appears as a failing check on Android PRs after merge

Closes loop on #530 (not a revert — keeps the useful AVD/intent fixes).