### PR TITLE
install-shipyard: defensively reinitialize truncated queue.json (#528)

### DIFF
--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -1379,3 +1379,17 @@ You don't need the same VM setup as the original developer. Options:
 - **Physical machines**: A spare Linux box or Windows machine on your network works fine.
 
 Local CI config is intentionally gitignored. Keep your host topology local, and prefer the machine-global config path so every worktree uses the same host map by default.
+
+## Troubleshooting
+
+### `JSONDecodeError` on Shipyard queue file
+
+Shipyard's local job queue lives at `~/Library/Application Support/shipyard/queue/queue.json` on macOS (`~/AppData/Local/shipyard/queue/queue.json` on Windows, `${XDG_STATE_HOME:-~/.local/state}/shipyard/queue/queue.json` on Linux). On rare crashes Shipyard can truncate this file to zero bytes, which then breaks every subsequent invocation with a `JSONDecodeError`.
+
+Recovery (run once):
+
+```bash
+echo '{"jobs": []}' > ~/Library/Application\ Support/shipyard/queue/queue.json
+```
+
+Re-running `tools/install-shipyard.sh` also performs this reset automatically. Tracked as #528.

--- a/tools/install-shipyard.sh
+++ b/tools/install-shipyard.sh
@@ -192,6 +192,32 @@ chmod +x "$INSTALLED"
 ln -sf "$INSTALLED" "$SYMLINK"
 echo "→ Symlinked $SYMLINK → $INSTALLED"
 
+# ── Queue-file truncation recovery (#528) ───────────────────────────────────
+# A crash between open(O_TRUNC) and the subsequent write() in Shipyard can
+# leave the machine-global job queue at zero bytes. Any subsequent Shipyard
+# invocation then dies with JSONDecodeError, which blocks autonomous
+# ship cycles. Defensively re-initialize the file when we see it truncated.
+#
+# Platform layout matches shipyard.core.config._default_state_dir():
+#   macOS   → ~/Library/Application Support/shipyard/queue/queue.json
+#   Windows → ~/AppData/Local/shipyard/queue/queue.json
+#   Linux   → ~/.local/state/shipyard/queue/queue.json
+
+case "$PLATFORM" in
+    darwin-*)  SHIPYARD_STATE_DIR="$HOME/Library/Application Support/shipyard" ;;
+    windows-*) SHIPYARD_STATE_DIR="$HOME/AppData/Local/shipyard" ;;
+    linux-*)   SHIPYARD_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/shipyard" ;;
+    *)         SHIPYARD_STATE_DIR="" ;;
+esac
+
+if [ -n "$SHIPYARD_STATE_DIR" ]; then
+    SHIPYARD_QUEUE_FILE="$SHIPYARD_STATE_DIR/queue/queue.json"
+    if [ -f "$SHIPYARD_QUEUE_FILE" ] && [ ! -s "$SHIPYARD_QUEUE_FILE" ]; then
+        echo "→ Shipyard queue file is empty — reinitializing (#528)"
+        echo '{"jobs": []}' > "$SHIPYARD_QUEUE_FILE"
+    fi
+fi
+
 # ── Final report ────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Automated by `pulp pr`

### Skill-sync verdict
```
[ci] ✓ bypassed (local-ci.md update mirrors existing troubleshooting pattern)
    tools/install-shipyard.sh

```

### Version-bump verdict
```
[sdk] Pulp SDK / CLI: no bump needed
[plugin] Claude Code plugin: no bump needed

```
