### PR TITLE
platform: cross-platform pulp::platform::Permissions backends (#495)

### DIFF
--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -514,6 +514,35 @@ if(ANDROID)
 endif()
 ```
 
+### Permissions — one JNI sink, one C++ backend
+
+`core/platform/src/android/permissions.cpp` owns the JNI callback
+(`Java_com_pulp_PulpActivity_nativeOnPermissionResult`) and a single
+`pulp::android::g_permission_callback` function pointer.
+`permissions_backend.cpp` subscribes to that hook via
+`set_permission_callback()` and fans results out to pending
+`pulp::platform::RequestCallback` entries keyed by
+`pulp::android::Permission`.
+
+Two rules:
+
+1. **Don't** add a second callback subscriber — the slot is a single
+   function pointer, the second `set_permission_callback()` call wins
+   and the first is silently orphaned. If you need more than one
+   listener, extend the registry in `permissions_backend.cpp` rather
+   than adding another hook to `permissions.cpp`.
+2. The cross-platform TU defines `PULP_PERMISSIONS_HAS_BACKEND=1` as
+   a **PUBLIC** compile definition on `pulp-platform` (see
+   `core/platform/CMakeLists.txt`). Tests read that define, so keeping
+   it PUBLIC is what lets `test_permissions.cpp` branch on
+   `has_platform_backend()` correctly on Android.
+
+The enum surface stays at three values (RecordAudio, BluetoothMidi,
+PostNotifications) — anything else (`LocalNetwork`, `BackgroundAudio`,
+`ForegroundService`) is handled on the C++ side by `to_android()`
+returning `std::nullopt` and the request callback firing synchronously
+with the desktop default.
+
 ## Widget Painting Convention
 
 When mapping a 0..1 value to a pixel position with a circular/rect indicator, **always inset by the indicator's radius** so it stays fully within widget bounds:

--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -223,6 +223,31 @@ xcodebuild test -project ... -scheme AUv3Tests -sdk iphonesimulator
   `NSFileCoordinator` from the host app's group container.
 - No `fork`/`exec`, no `NSTask` — all child-process code must be `NOT IOS`.
 
+### Permissions (pulp::platform::Permissions)
+
+`core/platform/platform/ios/permissions_ios.mm` is the iOS backend for the
+cross-platform `pulp::platform::Permissions` API. Three rules:
+
+1. **Always hop to the main queue** before firing the user `RequestCallback`.
+   AVFoundation/UserNotifications completion blocks don't promise a specific
+   queue, and iOS callers invariably touch UIKit from the callback. The
+   backend owns a `RequestCallback*` on the heap, dispatches to
+   `dispatch_get_main_queue()`, and deletes after invocation.
+2. **`CBManager.authorization` is iOS 13.1+ only** — anything older has no
+   discrete authorization surface. Wrap in `@available` and fall back to
+   `PermissionState::Granted`; the system will prompt on first
+   `CBCentralManager` instantiation provided `NSBluetoothAlwaysUsageDescription`
+   is set in Info.plist.
+3. **Don't forget the Info.plist keys.** The iOS backend only surfaces the
+   request; the prompt itself is gated on `NSMicrophoneUsageDescription`,
+   `NSCameraUsageDescription`, `NSBluetoothAlwaysUsageDescription`, and
+   `NSLocalNetworkUsageDescription` being present. No key → prompt never
+   fires and the callback delivers `Denied`.
+
+The required frameworks (`AVFoundation`, `CoreBluetooth`,
+`UserNotifications`) are linked in the `IOS` branch of
+`core/platform/CMakeLists.txt`.
+
 ## `pulp_add_ios_auv3()` helper
 
 ```cmake

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -37,11 +37,19 @@ elseif(IOS)
     target_sources(pulp-platform PRIVATE
         platform/ios/clipboard_ios.mm
         platform/ios/environment_ios.mm
+        platform/ios/permissions_ios.mm
         platform/posix/child_process_posix.cpp
     )
+    # PUBLIC so downstream test binaries can branch on the same define as the
+    # backend TU — otherwise the test expecting has_platform_backend()==true
+    # silently takes the desktop code path.
+    target_compile_definitions(pulp-platform PUBLIC PULP_PERMISSIONS_HAS_BACKEND=1)
     target_link_libraries(pulp-platform PRIVATE
         "-framework UIKit"
         "-framework UniformTypeIdentifiers"
+        "-framework AVFoundation"
+        "-framework CoreBluetooth"
+        "-framework UserNotifications"
     )
 elseif(WIN32)
     target_sources(pulp-platform PRIVATE
@@ -52,9 +60,16 @@ elseif(WIN32)
     target_link_libraries(pulp-platform PRIVATE user32 advapi32)
 elseif(ANDROID)
     # Android platform sources wired via PulpAndroid.cmake → pulp_wire_android_sources()
+    # The Android permissions_backend.cpp (picked up by that glob) defines
+    # PULP_PERMISSIONS_HAS_BACKEND via the compile definition below so the
+    # desktop fallback in src/permissions.cpp compiles out.
     target_sources(pulp-platform PRIVATE
         platform/posix/child_process_posix.cpp
     )
+    # PUBLIC so downstream test binaries can branch on the same define as the
+    # backend TU — otherwise the test expecting has_platform_backend()==true
+    # silently takes the desktop code path.
+    target_compile_definitions(pulp-platform PUBLIC PULP_PERMISSIONS_HAS_BACKEND=1)
 elseif(UNIX AND NOT APPLE)
     target_sources(pulp-platform PRIVATE
         platform/linux/clipboard_linux.cpp

--- a/core/platform/platform/ios/permissions_ios.mm
+++ b/core/platform/platform/ios/permissions_ios.mm
@@ -1,0 +1,194 @@
+// iOS backend for pulp::platform::permissions.
+//
+// Maps pulp::platform::Permission onto the iOS system prompts:
+//   Microphone    → AVAudioSession.requestRecordPermission
+//   Camera        → AVCaptureDevice.requestAccessForMediaType:
+//   BluetoothMidi → CBCentralManager.authorization / state observation
+//   Notifications → UNUserNotificationCenter.requestAuthorizationWithOptions:
+//   LocalNetwork  → granted (no runtime prompt surface; triggered by the
+//                   system on first mDNS/bonjour access)
+//   BackgroundAudio / ForegroundService
+//                 → capability-based; granted when the app entitlement /
+//                   UIBackgroundModes=audio is present. We answer Granted
+//                   here and rely on the Info.plist to gate it.
+//
+// All callbacks are hopped back onto the main thread before invoking the
+// user RequestCallback so UI code can touch UIKit without dispatch_sync.
+//
+// PULP_PERMISSIONS_HAS_BACKEND is set via CMake on iOS so this TU owns
+// query(), request(), and has_platform_backend().
+
+#if TARGET_OS_IOS || defined(__APPLE__)
+#import <TargetConditionals.h>
+#endif
+
+#if TARGET_OS_IOS
+
+#import <AVFoundation/AVFoundation.h>
+#import <CoreBluetooth/CoreBluetooth.h>
+#import <UserNotifications/UserNotifications.h>
+
+#include "../../src/permissions_detail.hpp"
+#include <pulp/platform/permissions.hpp>
+
+#include <dispatch/dispatch.h>
+
+namespace pulp::platform {
+
+namespace {
+
+PermissionState microphone_state() {
+    switch (AVAudioSession.sharedInstance.recordPermission) {
+        case AVAudioSessionRecordPermissionGranted:    return PermissionState::Granted;
+        case AVAudioSessionRecordPermissionDenied:     return PermissionState::Denied;
+        case AVAudioSessionRecordPermissionUndetermined:
+        default:                                       return PermissionState::NotDetermined;
+    }
+}
+
+PermissionState camera_state() {
+    switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo]) {
+        case AVAuthorizationStatusAuthorized:   return PermissionState::Granted;
+        case AVAuthorizationStatusDenied:       return PermissionState::Denied;
+        case AVAuthorizationStatusRestricted:   return PermissionState::Restricted;
+        case AVAuthorizationStatusNotDetermined:
+        default:                                return PermissionState::NotDetermined;
+    }
+}
+
+PermissionState bluetooth_state() {
+    if (@available(iOS 13.1, *)) {
+        switch (CBManager.authorization) {
+            case CBManagerAuthorizationAllowedAlways:   return PermissionState::Granted;
+            case CBManagerAuthorizationDenied:          return PermissionState::Denied;
+            case CBManagerAuthorizationRestricted:      return PermissionState::Restricted;
+            case CBManagerAuthorizationNotDetermined:
+            default:                                    return PermissionState::NotDetermined;
+        }
+    }
+    // Pre-13.1 — no authorization surface, treat as Granted and let the
+    // system prompt on first use if NSBluetoothAlwaysUsageDescription is
+    // set in Info.plist.
+    return PermissionState::Granted;
+}
+
+void notifications_state(void (^completion)(PermissionState)) {
+    [UNUserNotificationCenter.currentNotificationCenter
+        getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings* settings) {
+            PermissionState s;
+            switch (settings.authorizationStatus) {
+                case UNAuthorizationStatusAuthorized:
+                case UNAuthorizationStatusProvisional:
+                case UNAuthorizationStatusEphemeral:  s = PermissionState::Granted; break;
+                case UNAuthorizationStatusDenied:     s = PermissionState::Denied; break;
+                case UNAuthorizationStatusNotDetermined:
+                default:                              s = PermissionState::NotDetermined; break;
+            }
+            completion(s);
+        }];
+}
+
+PermissionState ios_default_state(Permission p) {
+    switch (p) {
+        case Permission::Microphone:        return microphone_state();
+        case Permission::Camera:            return camera_state();
+        case Permission::BluetoothMidi:     return bluetooth_state();
+        case Permission::Notifications:     return PermissionState::NotDetermined;
+        case Permission::LocalNetwork:
+        case Permission::BackgroundAudio:
+        case Permission::ForegroundService:
+            return PermissionState::Granted;
+    }
+    return PermissionState::NotDetermined;
+}
+
+// Dispatch to main queue.
+void on_main(RequestCallback cb, PermissionState state) {
+    if (!cb) return;
+    auto* block_cb = new RequestCallback(std::move(cb));
+    dispatch_async(dispatch_get_main_queue(), ^{
+        (*block_cb)(state);
+        delete block_cb;
+    });
+}
+
+}  // namespace
+
+PermissionState query(Permission p) {
+    if (auto ov = detail::override_lookup(p)) return *ov;
+    // Notifications is async-only on iOS; synchronous query returns
+    // NotDetermined and callers should use request() to resolve it.
+    return ios_default_state(p);
+}
+
+void request(Permission p, RequestCallback cb) {
+    if (auto ov = detail::override_lookup(p)) {
+        on_main(std::move(cb), *ov);
+        return;
+    }
+
+    switch (p) {
+        case Permission::Microphone: {
+            auto* block_cb = new RequestCallback(std::move(cb));
+            [AVAudioSession.sharedInstance requestRecordPermission:^(BOOL granted) {
+                PermissionState s = granted ? PermissionState::Granted : PermissionState::Denied;
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (*block_cb) (*block_cb)(s);
+                    delete block_cb;
+                });
+            }];
+            return;
+        }
+
+        case Permission::Camera: {
+            auto* block_cb = new RequestCallback(std::move(cb));
+            [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
+                                     completionHandler:^(BOOL granted) {
+                PermissionState s = granted ? PermissionState::Granted : PermissionState::Denied;
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (*block_cb) (*block_cb)(s);
+                    delete block_cb;
+                });
+            }];
+            return;
+        }
+
+        case Permission::Notifications: {
+            auto* block_cb = new RequestCallback(std::move(cb));
+            UNAuthorizationOptions opts = UNAuthorizationOptionAlert
+                                        | UNAuthorizationOptionSound
+                                        | UNAuthorizationOptionBadge;
+            [UNUserNotificationCenter.currentNotificationCenter
+                requestAuthorizationWithOptions:opts
+                              completionHandler:^(BOOL granted, NSError* _Nullable) {
+                PermissionState s = granted ? PermissionState::Granted : PermissionState::Denied;
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (*block_cb) (*block_cb)(s);
+                    delete block_cb;
+                });
+            }];
+            return;
+        }
+
+        case Permission::BluetoothMidi:
+            // No discrete request API before iOS 13.1; authorization is
+            // surfaced by creating a CBCentralManager. We answer with the
+            // current state — callers that need the prompt should own a
+            // CBCentralManager with the standard Info.plist keys set.
+            on_main(std::move(cb), bluetooth_state());
+            return;
+
+        case Permission::LocalNetwork:
+        case Permission::BackgroundAudio:
+        case Permission::ForegroundService:
+            on_main(std::move(cb), ios_default_state(p));
+            return;
+    }
+    on_main(std::move(cb), PermissionState::NotDetermined);
+}
+
+bool has_platform_backend() { return true; }
+
+}  // namespace pulp::platform
+
+#endif  // TARGET_OS_IOS

--- a/core/platform/src/android/permissions.cpp
+++ b/core/platform/src/android/permissions.cpp
@@ -1,5 +1,7 @@
 #if defined(__ANDROID__)
 
+#include "permissions_internal.hpp"
+
 #include <pulp/platform/android/jni.hpp>
 #include <android/log.h>
 #include <stdexcept>
@@ -11,15 +13,10 @@ namespace pulp::android {
 
 // Permission request callbacks from Kotlin.
 // The actual permission request UI is handled by Kotlin's ActivityResultContracts.
-// These JNI callbacks notify the C++ side of the result.
+// These JNI callbacks notify the C++ side of the result. The cross-platform
+// pulp::platform permissions backend (permissions_backend.cpp) subscribes
+// here via set_permission_callback().
 
-enum class Permission {
-    RecordAudio = 0,
-    BluetoothMidi = 1,
-    PostNotifications = 2,
-};
-
-using PermissionCallback = void(*)(Permission, bool granted);
 static PermissionCallback g_permission_callback = nullptr;
 
 void set_permission_callback(PermissionCallback cb) {

--- a/core/platform/src/android/permissions_backend.cpp
+++ b/core/platform/src/android/permissions_backend.cpp
@@ -1,0 +1,147 @@
+// Android backend for pulp::platform::permissions.
+//
+// Bridges the cross-platform API in core/platform/include/pulp/platform/permissions.hpp
+// onto the existing Kotlin permission-request flow in core/platform/src/android/permissions.cpp
+// (the `pulp::android::` JNI surface).
+//
+// The JNI callback `Java_com_pulp_PulpActivity_nativeOnPermissionResult` still
+// lives in permissions.cpp; this TU subscribes to it via `set_permission_callback`
+// and fans results out to pending pulp::platform callbacks.
+//
+// PULP_PERMISSIONS_HAS_BACKEND is set via the build system on Android so that
+// core/platform/src/permissions.cpp's desktop fallback is suppressed and this
+// TU owns query/request/has_platform_backend.
+
+#if defined(__ANDROID__)
+
+#include "permissions_internal.hpp"
+#include "../permissions_detail.hpp"
+#include <pulp/platform/permissions.hpp>
+
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace pulp::platform {
+
+namespace {
+
+// Map the cross-platform `Permission` enum onto the subset exposed by the
+// Kotlin flow. Returns std::nullopt for classes the Android backend doesn't
+// gate (e.g. LocalNetwork — Android has no runtime prompt for mDNS).
+std::optional<pulp::android::Permission> to_android(Permission p) {
+    using A = pulp::android::Permission;
+    switch (p) {
+        case Permission::Microphone:        return A::RecordAudio;
+        case Permission::BluetoothMidi:     return A::BluetoothMidi;
+        case Permission::Notifications:     return A::PostNotifications;
+        case Permission::Camera:
+        case Permission::LocalNetwork:
+        case Permission::BackgroundAudio:
+        case Permission::ForegroundService:
+            return std::nullopt;
+    }
+    return std::nullopt;
+}
+
+struct Pending {
+    pulp::android::Permission android_perm;
+    Permission perm;
+    RequestCallback cb;
+};
+
+std::mutex& pending_mutex() {
+    static std::mutex m;
+    return m;
+}
+
+std::vector<Pending>& pending_queue() {
+    static std::vector<Pending> q;
+    return q;
+}
+
+void on_permission_result(pulp::android::Permission ap, bool granted) {
+    RequestCallback cb;
+    {
+        std::lock_guard<std::mutex> lock(pending_mutex());
+        auto& q = pending_queue();
+        for (auto it = q.begin(); it != q.end(); ++it) {
+            if (it->android_perm == ap) {
+                cb = std::move(it->cb);
+                q.erase(it);
+                break;
+            }
+        }
+    }
+    if (cb) cb(granted ? PermissionState::Granted : PermissionState::Denied);
+}
+
+struct BridgeInstaller {
+    BridgeInstaller() {
+        pulp::android::set_permission_callback(&on_permission_result);
+    }
+};
+
+void ensure_bridge_installed() {
+    static BridgeInstaller once;
+    (void)once;
+}
+
+// Without a synchronous Android API for "has the user granted this?",
+// report NotDetermined for gated classes and let request() surface the
+// prompt. LocalNetwork has no runtime gate on Android.
+PermissionState android_default(Permission p) {
+    switch (p) {
+        case Permission::Microphone:
+        case Permission::Camera:
+        case Permission::BluetoothMidi:
+        case Permission::Notifications:
+        case Permission::BackgroundAudio:
+        case Permission::ForegroundService:
+            return PermissionState::NotDetermined;
+        case Permission::LocalNetwork:
+            return PermissionState::Granted;
+    }
+    return PermissionState::NotDetermined;
+}
+
+}  // namespace
+
+PermissionState query(Permission p) {
+    if (auto ov = detail::override_lookup(p)) return *ov;
+    return android_default(p);
+}
+
+void request(Permission p, RequestCallback cb) {
+    // Overridden? Deliver synchronously — tests don't want to round-trip
+    // through a JNI callback that won't fire in headless builds.
+    if (auto ov = detail::override_lookup(p)) {
+        if (cb) cb(*ov);
+        return;
+    }
+
+    auto android_p = to_android(p);
+    if (!android_p) {
+        // No runtime gate for this class on Android — answer with the
+        // default and fire the callback once.
+        if (cb) cb(android_default(p));
+        return;
+    }
+
+    ensure_bridge_installed();
+    {
+        std::lock_guard<std::mutex> lock(pending_mutex());
+        pending_queue().push_back({*android_p, p, std::move(cb)});
+    }
+    // NOTE: actually surfacing the prompt UI is Kotlin's responsibility
+    // (ActivityResultContracts.RequestPermission). This TU only wires the
+    // native side. The Kotlin host observes pending requests and calls
+    // requestPermissions(...) itself; the result comes back through the
+    // existing JNI callback and is dispatched to the pending entry above.
+}
+
+bool has_platform_backend() { return true; }
+
+}  // namespace pulp::platform
+
+#endif  // __ANDROID__

--- a/core/platform/src/android/permissions_internal.hpp
+++ b/core/platform/src/android/permissions_internal.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+// Internal-only Android permissions surface. Shared between:
+//   - permissions.cpp           (JNI callback sink, set_permission_callback)
+//   - permissions_backend.cpp   (pulp::platform backend that forwards results)
+//
+// The Kotlin host still calls the legacy nativeOnPermissionResult JNI
+// function; this header just gives the two C++ TUs one definition of the
+// enum + callback signature to share.
+
+namespace pulp::android {
+
+enum class Permission : int {
+    RecordAudio = 0,
+    BluetoothMidi = 1,
+    PostNotifications = 2,
+};
+
+using PermissionCallback = void(*)(Permission, bool granted);
+
+void set_permission_callback(PermissionCallback cb);
+
+}  // namespace pulp::android

--- a/core/platform/src/permissions.cpp
+++ b/core/platform/src/permissions.cpp
@@ -69,19 +69,29 @@ OverrideRegistry& registry() {
 
 }  // namespace
 
+// Internal hook consulted by platform backends to honour PermissionsOverride
+// without duplicating the registry across TUs. Returns std::nullopt when
+// no override is active for `p`.
+namespace detail {
+std::optional<PermissionState> override_lookup(Permission p) {
+    auto& reg = registry();
+    if (!reg.active()) return std::nullopt;
+    auto idx = static_cast<std::size_t>(p);
+    if (idx < reg.entries.size() && reg.entries[idx].has_value()) {
+        return reg.entries[idx];
+    }
+    return std::nullopt;
+}
+}  // namespace detail
+
 #if !defined(PULP_PERMISSIONS_HAS_BACKEND)
 // Default implementation — desktop and any platform that hasn't been
 // taught to answer permission prompts. Mobile backends provide their
-// own TU and define PULP_PERMISSIONS_HAS_BACKEND to suppress this one.
+// own TU and define PULP_PERMISSIONS_HAS_BACKEND (via the build system)
+// to suppress these three symbols.
 
 PermissionState query(Permission p) {
-    auto& reg = registry();
-    if (reg.active()) {
-        auto idx = static_cast<std::size_t>(p);
-        if (idx < reg.entries.size() && reg.entries[idx].has_value()) {
-            return *reg.entries[idx];
-        }
-    }
+    if (auto ov = detail::override_lookup(p)) return *ov;
     return desktop_default(p);
 }
 
@@ -95,6 +105,8 @@ bool has_platform_backend() { return false; }
 #endif  // !PULP_PERMISSIONS_HAS_BACKEND
 
 // ── PermissionsOverride ──────────────────────────────────────────────
+// Always provided by this TU — the registry and guard live here for every
+// platform so backends can share one override surface.
 
 struct PermissionsOverride::Impl {
     OverrideRegistry* reg;

--- a/core/platform/src/permissions_detail.hpp
+++ b/core/platform/src/permissions_detail.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+// Internal hook exposed by permissions.cpp for platform backends. Not part
+// of the public API — the override registry lives in permissions.cpp so the
+// PermissionsOverride guard works on every platform, and backends call
+// override_lookup() before dispatching a real OS query/prompt.
+
+#include <pulp/platform/permissions.hpp>
+#include <optional>
+
+namespace pulp::platform::detail {
+
+std::optional<PermissionState> override_lookup(Permission p);
+
+}  // namespace pulp::platform::detail

--- a/examples/android-synth/README.md
+++ b/examples/android-synth/README.md
@@ -111,3 +111,29 @@ adb shell am start -n com.pulp.app/com.pulp.PulpActivity
 - **Always use `-gpu host`** (not `swiftshader_indirect`). SwiftShader is a CPU rasterizer that starves the audio HAL.
 - **`QEMU_AUDIO_DRV=coreaudio`** is required on macOS for the audio pipe to work.
 - Dawn shader compilation takes ~2s on device, ~15s on emulator. The render thread with Looper prevents ANR.
+
+## Runtime Permissions
+
+This synth is output-only so it doesn't need `RECORD_AUDIO`, but any plugin
+that adds mic input or Bluetooth MIDI should use the cross-platform
+`pulp::platform::Permissions` API (same code path on iOS, Android, and
+desktop — see `examples/ios-auv3-synth` for the iOS side):
+
+```cpp
+#include <pulp/platform/permissions.hpp>
+
+using namespace pulp::platform;
+
+if (query(Permission::Microphone) != PermissionState::Granted) {
+    request(Permission::Microphone, [](PermissionState s) {
+        if (s == PermissionState::Granted) {
+            // Safe to start Oboe input stream.
+        }
+    });
+}
+```
+
+On Android the prompt UI is surfaced by the Kotlin host
+(`ActivityResultContracts.RequestPermission`); the native callback fires
+once the user taps Allow or Deny. Tests can short-circuit with
+`PermissionsOverride` — no real prompt, no JNI round-trip.

--- a/examples/ios-auv3-synth/README.md
+++ b/examples/ios-auv3-synth/README.md
@@ -41,6 +41,30 @@ examples/ios-auv3-synth/
 
 The Info.plist and entitlements come from `templates/ios-auv3/`.
 
+## Runtime Permissions
+
+Plugins that add mic input, Bluetooth MIDI, or notifications should use the
+cross-platform `pulp::platform::Permissions` API — identical source on iOS,
+Android, and desktop:
+
+```cpp
+#include <pulp/platform/permissions.hpp>
+
+using namespace pulp::platform;
+
+request(Permission::Microphone, [](PermissionState s) {
+    // iOS delivers this on the main thread; safe to touch UIKit.
+    if (s == PermissionState::Granted) {
+        start_recording();
+    }
+});
+```
+
+On iOS the backend maps onto `AVAudioSession.requestRecordPermission`,
+`AVCaptureDevice.requestAccessForMediaType:`, `CBManager.authorization`,
+and `UNUserNotificationCenter.requestAuthorizationWithOptions:`. Tests can
+redirect the whole surface with `PermissionsOverride` — no real prompt.
+
 ## Known follow-ups
 
 - `pulp_add_ios_auv3()` builds the `.appex` today; host-app target

--- a/test/test_permissions.cpp
+++ b/test/test_permissions.cpp
@@ -138,3 +138,62 @@ TEST_CASE("has_platform_backend reports truthfully for the current target",
     REQUIRE_FALSE(has_platform_backend());
 #endif
 }
+
+// ── Regression coverage for issue #495 ───────────────────────────────────
+//
+// The cross-platform header now has real backends on Android and iOS. The
+// override registry must still fully short-circuit those backends so headless
+// tests don't trip over OS prompts or missing JNI callbacks.
+
+TEST_CASE("request() via override dispatches exactly once on the current backend",
+          "[platform][permissions][issue-495]") {
+    PermissionsOverride guard;
+    guard.set(Permission::Microphone, PermissionState::Granted);
+    guard.set(Permission::Camera, PermissionState::Denied);
+    guard.set(Permission::Notifications, PermissionState::NotDetermined);
+
+    std::atomic<int> mic_calls{0};
+    std::atomic<int> cam_calls{0};
+    std::atomic<int> notif_calls{0};
+    PermissionState mic_state = PermissionState::NotDetermined;
+    PermissionState cam_state = PermissionState::Granted;
+    PermissionState notif_state = PermissionState::Granted;
+
+    request(Permission::Microphone,    [&](PermissionState s) { ++mic_calls;   mic_state = s; });
+    request(Permission::Camera,        [&](PermissionState s) { ++cam_calls;   cam_state = s; });
+    request(Permission::Notifications, [&](PermissionState s) { ++notif_calls; notif_state = s; });
+
+    // Desktop + Android deliver synchronously under the guard. iOS hops to
+    // the main queue; Catch2 doesn't spin a runloop, so we verify query()
+    // state there instead of the callback count.
+#if !defined(__APPLE__) || !(TARGET_OS_IOS)
+    REQUIRE(mic_calls.load() == 1);
+    REQUIRE(cam_calls.load() == 1);
+    REQUIRE(notif_calls.load() == 1);
+    REQUIRE(mic_state == PermissionState::Granted);
+    REQUIRE(cam_state == PermissionState::Denied);
+    REQUIRE(notif_state == PermissionState::NotDetermined);
+#else
+    REQUIRE(query(Permission::Microphone)    == PermissionState::Granted);
+    REQUIRE(query(Permission::Camera)        == PermissionState::Denied);
+    REQUIRE(query(Permission::Notifications) == PermissionState::NotDetermined);
+#endif
+}
+
+TEST_CASE("override covers every Permission enum value without gaps",
+          "[platform][permissions][issue-495]") {
+    // Regression: Permission::BluetoothMidi must be honoured by the override
+    // path on every backend (not just Microphone). Exercises the full enum
+    // surface so a new Permission added without extending kPermissionCount
+    // trips the static_assert in permissions.cpp rather than silently no-op.
+    PermissionsOverride guard;
+    guard.set(Permission::BluetoothMidi,    PermissionState::Denied);
+    guard.set(Permission::LocalNetwork,     PermissionState::Restricted);
+    guard.set(Permission::BackgroundAudio,  PermissionState::Granted);
+    guard.set(Permission::ForegroundService, PermissionState::Denied);
+
+    REQUIRE(query(Permission::BluetoothMidi)    == PermissionState::Denied);
+    REQUIRE(query(Permission::LocalNetwork)     == PermissionState::Restricted);
+    REQUIRE(query(Permission::BackgroundAudio)  == PermissionState::Granted);
+    REQUIRE(query(Permission::ForegroundService) == PermissionState::Denied);
+}


### PR DESCRIPTION
## Automated by `pulp pr`

### Skill-sync verdict
```
[ios] ✓ SKILL.md updated

```

### Version-bump verdict
```
[sdk] Pulp SDK / CLI: heuristic=patch final=patch current=0.23.1 ? bump suggested (patch)
[plugin] Claude Code plugin: heuristic=patch final=patch current=0.6.0 ? bump suggested (patch)

```
