### PR TITLE
fix: Codex sweep rollup - sysex, view header, scan AU/AUv3, post-merge limit (#500 #529)

### DIFF
--- a/.github/workflows/post-merge-review-sweep.yml
+++ b/.github/workflows/post-merge-review-sweep.yml
@@ -78,17 +78,25 @@ jobs:
           echo "Repo:     $repo"
           echo "Lookback: ${lookback}h (cutoff ${cutoff})"
 
-          # List PRs merged since cutoff. Codex post-merge review:
+          # List PRs merged since cutoff. Codex post-merge review
+          # history on this file:
           # - `--base main` filter: without it, merges into feature/develop
           #   branches are ingested too, polluting the tracker.
           # - `--search` with `is:merged merged:>DATE` lets the GitHub
           #   search backend do the time filter server-side, eliminating
           #   the `--limit 100` hard cap that was a silent data-loss
           #   risk in a busy 48h window.
+          # - Explicit `--limit 500` (Codex P2 on PR #515 / #500):
+          #   `gh pr list`'s default is 30 items even when `--search` is
+          #   used. Without an explicit high limit, the sweep silently
+          #   inspected at most 30 PRs in a busy window and delayed bot
+          #   findings on older PRs were never ingested. 500 covers any
+          #   realistic 48h window without paginating.
           mapfile -t prs < <(
               gh pr list --repo "$repo" \
                   --base main \
                   --search "is:merged merged:>${cutoff}" \
+                  --limit 500 \
                   --json number,title,mergedAt \
                   --jq ".[] | .number"
           )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0240"></a>
+## [0.25.0]
+
 ## [0.24.0] - 2026-04-20
 
 - view: PluginManagerPanel widget over scanner backend (#494) ([#538](https://github.com/danielraffel/pulp/pull/538))
@@ -32,6 +34,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
 - lv2: serialize midi_out back to atom output port (#491) ([#511](https://github.com/danielraffel/pulp/pull/511))
 
 <a id="v0231"></a>
+## [0.24.0]
+
 ## [0.23.1] - 2026-04-20
 
 - chore: bump SDK to v0.23.1 ([#509](https://github.com/danielraffel/pulp/pull/509))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.24.0
+    VERSION 0.25.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/midi/include/pulp/midi/sysex_accumulator.hpp
+++ b/core/midi/include/pulp/midi/sysex_accumulator.hpp
@@ -134,11 +134,20 @@ public:
 private:
     static bool is_status(std::uint8_t b) noexcept { return (b & 0x80) != 0; }
     static bool is_realtime(std::uint8_t b) noexcept {
-        // MIDI 1.0 System Realtime Messages: 0xF8 (Timing Clock),
-        // 0xFA-0xFC (Start/Continue/Stop), 0xFE (Active Sensing),
-        // 0xFF (System Reset). 0xF9 and 0xFD are undefined. 0xF7 is
-        // EOX and intentionally excluded (handled by feed() explicitly).
-        return b >= 0xF8 && b <= 0xFF && b != 0xF9 && b != 0xFD;
+        // MIDI 1.0 System Realtime Messages occupy 0xF8-0xFF, minus
+        // 0xF7 (EOX, handled explicitly in feed()). 0xF9 and 0xFD are
+        // officially undefined/reserved by MIDI 1.0, but the contract
+        // documented at the top of this file — and the behavior
+        // required by transports that emit them — is that everything
+        // in 0xF8-0xFF *except F7* passes through without disturbing
+        // the SysEx state machine. Treating 0xF9/0xFD as generic
+        // status bytes aborted otherwise-valid SysEx on devices that
+        // forwarded the reserved codes (Codex P2 on PR #484 / #500).
+        //
+        // Pass-through is safe because the accumulator only classifies
+        // the byte — the caller's normal short-message path decides
+        // whether to ignore, log, or forward the reserved code.
+        return b >= 0xF8 && b <= 0xFF;
     }
 
     bool in_sysex_ = false;

--- a/core/signal/include/pulp/signal/fft.hpp
+++ b/core/signal/include/pulp/signal/fft.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <vector>
-#include <complex>
-#include <cmath>
 #include <algorithm>
+#include <cmath>
+#include <complex>
 #include <cstdint>
+#include <memory>
+#include <vector>
 
 #if defined(__APPLE__)
 #include <Accelerate/Accelerate.h>

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -157,6 +157,7 @@ target_sources(pulp-view PRIVATE
     src/screenshot_compare.cpp
     src/app_framework.cpp
     src/canvas_widget.cpp
+    src/visualization_bridge.cpp
     src/frame_clock.cpp
     src/window_manager.cpp
     src/eq_curve_view.cpp
@@ -364,14 +365,14 @@ elseif(UNIX)
 endif()
 
 # Link against render for native GPU bridge (Three.js, WebGPU canvas).
-# When PULP_BENCHMARK is on, visualization_bridge.hpp pulls a public
-# header from pulp::render (perf_counters.hpp) — downstream consumers
-# must be able to resolve the include path, so the link goes PUBLIC in
-# that case. Off-by-default production builds keep the PRIVATE link.
+# Codex P1 on PR #526 / #500: previously visualization_bridge.hpp
+# directly included pulp/render/bench/perf_counters.hpp under
+# PULP_BENCHMARK, which forced this link to go PUBLIC and leaked the
+# render include tree through every view consumer. The header now
+# forward-declares PerfCounters and the dereferencing code lives in
+# visualization_bridge.cpp — so the link stays PRIVATE regardless of
+# PULP_BENCHMARK, and downstream targets that only use view APIs do
+# NOT need to link pulp::render when PULP_BENCHMARK is enabled.
 if(TARGET pulp-render)
-    if(PULP_BENCHMARK)
-        target_link_libraries(pulp-view PUBLIC pulp::render)
-    else()
-        target_link_libraries(pulp-view PRIVATE pulp::render)
-    endif()
+    target_link_libraries(pulp-view PRIVATE pulp::render)
 endif()

--- a/core/view/include/pulp/view/visualization_bridge.hpp
+++ b/core/view/include/pulp/view/visualization_bridge.hpp
@@ -20,8 +20,16 @@
 #include <algorithm>
 #include <vector>
 
+// Codex P1 on PR #526 / #500: the public view header must NOT include
+// pulp/render/bench/perf_counters.hpp — it leaks render include paths
+// through every view consumer under PULP_BENCHMARK, even those that
+// don't link pulp::render. Forward-declare instead; the non-trivial
+// process() body that actually dereferences PerfCounters lives in
+// visualization_bridge.cpp, which DOES include the render header.
 #ifdef PULP_BENCHMARK
-#include <pulp/render/bench/perf_counters.hpp>
+namespace pulp::render::bench {
+struct PerfCounters;
+}
 #endif
 
 namespace pulp::view {
@@ -101,99 +109,12 @@ public:
     /// @param channels  Array of channel buffer pointers.
     /// @param num_channels  Number of channels.
     /// @param num_samples  Samples per channel in this block.
-    void process(const float* const* channels, int num_channels, int num_samples) {
-        // Multi-channel metering
-        meter_.process(channels, num_channels, num_samples);
-#ifdef PULP_BENCHMARK
-        {
-            const double t0 = render::bench::now_us();
-            meter_buf_.write(meter_.snapshot());
-            if (bench_counters_) {
-                bench_counters_->triplebuffer_publish_total_us.fetch_add(
-                    render::bench::now_us() - t0, std::memory_order_relaxed);
-            }
-        }
-#else
-        meter_buf_.write(meter_.snapshot());
-#endif
-
-        // STFT on first channel (or mono mix for multi-channel)
-        if (num_channels > 0 && num_samples > 0) {
-            bool new_frame = stft_.push_samples(channels[0], num_samples);
-
-            if (new_frame) {
-                // Publish spectrum
-                SpectrumData spec;
-                auto db = stft_.latest_magnitude_db(-120.0f);
-                spec.num_bins = std::min(static_cast<int>(db.size()),
-                                         static_cast<int>(SpectrumData::kMaxBins));
-#ifdef PULP_BENCHMARK
-                {
-                    const double t_copy = render::bench::now_us();
-                    std::copy_n(db.data(), spec.num_bins, spec.magnitude_db.data());
-                    if (bench_counters_) {
-                        bench_counters_->audio_copy_total_us.fetch_add(
-                            render::bench::now_us() - t_copy,
-                            std::memory_order_relaxed);
-                    }
-                }
-                {
-                    const double t_pub = render::bench::now_us();
-                    spectrum_buf_.write(spec);
-                    if (bench_counters_) {
-                        bench_counters_->triplebuffer_publish_total_us.fetch_add(
-                            render::bench::now_us() - t_pub,
-                            std::memory_order_relaxed);
-                    }
-                }
-#else
-                std::copy_n(db.data(), spec.num_bins, spec.magnitude_db.data());
-                spectrum_buf_.write(spec);
-#endif
-            }
-        }
-
-        // Waveform capture (ring buffer of latest samples from channel 0)
-        if (config_.capture_waveform && num_channels > 0) {
-            for (int i = 0; i < num_samples; ++i) {
-                waveform_ring_[waveform_pos_] = channels[0][i];
-                waveform_pos_ = (waveform_pos_ + 1) % waveform_length_;
-            }
-
-            WaveformData wd;
-            wd.num_samples = waveform_length_;
-            wd.num_channels = num_channels;
-#ifdef PULP_BENCHMARK
-            {
-                const double t_copy = render::bench::now_us();
-                // Copy in order from oldest to newest
-                for (int i = 0; i < waveform_length_; ++i) {
-                    wd.samples[i] = waveform_ring_[(waveform_pos_ + i) % waveform_length_];
-                }
-                if (bench_counters_) {
-                    bench_counters_->audio_copy_total_us.fetch_add(
-                        render::bench::now_us() - t_copy,
-                        std::memory_order_relaxed);
-                }
-            }
-            {
-                const double t_pub = render::bench::now_us();
-                waveform_buf_.write(wd);
-                if (bench_counters_) {
-                    bench_counters_->triplebuffer_publish_total_us.fetch_add(
-                        render::bench::now_us() - t_pub,
-                        std::memory_order_relaxed);
-                }
-            }
-#else
-            // Copy in order from oldest to newest
-            for (int i = 0; i < waveform_length_; ++i) {
-                wd.samples[i] = waveform_ring_[(waveform_pos_ + i) % waveform_length_];
-            }
-            waveform_buf_.write(wd);
-#endif
-        }
-    }
+    ///
+    /// Defined out-of-line in visualization_bridge.cpp so the benchmark
+    /// counter paths can dereference `render::bench::PerfCounters`
+    /// fields without leaking the render include path through this
+    /// public header (Codex P1 on PR #526 / #500).
+    void process(const float* const* channels, int num_channels, int num_samples);
 
 #ifdef PULP_BENCHMARK
     /// Install (or clear) the benchmark perf-counter sink. Call from the

--- a/core/view/src/visualization_bridge.cpp
+++ b/core/view/src/visualization_bridge.cpp
@@ -1,0 +1,118 @@
+// visualization_bridge.cpp — out-of-line VisualizationBridge::process().
+//
+// The public header (pulp/view/visualization_bridge.hpp) forward-declares
+// pulp::render::bench::PerfCounters so view consumers don't pull the
+// render include tree when PULP_BENCHMARK is on (Codex P1 on PR #526 /
+// #500). The PerfCounters FIELDS (atomic<double>::fetch_add) still need
+// the full type, so the process() body lives here and only pulp-view's
+// translation unit sees the render header — consumers of
+// pulp::view::VisualizationBridge still don't need to link pulp::render.
+
+#include <pulp/view/visualization_bridge.hpp>
+
+#ifdef PULP_BENCHMARK
+#include <pulp/render/bench/perf_counters.hpp>
+#endif
+
+#include <algorithm>
+#include <cmath>
+
+namespace pulp::view {
+
+void VisualizationBridge::process(const float* const* channels,
+                                  int num_channels,
+                                  int num_samples) {
+    // Multi-channel metering
+    meter_.process(channels, num_channels, num_samples);
+#ifdef PULP_BENCHMARK
+    {
+        const double t0 = render::bench::now_us();
+        meter_buf_.write(meter_.snapshot());
+        if (bench_counters_) {
+            bench_counters_->triplebuffer_publish_total_us.fetch_add(
+                render::bench::now_us() - t0, std::memory_order_relaxed);
+        }
+    }
+#else
+    meter_buf_.write(meter_.snapshot());
+#endif
+
+    // STFT on first channel (or mono mix for multi-channel)
+    if (num_channels > 0 && num_samples > 0) {
+        bool new_frame = stft_.push_samples(channels[0], num_samples);
+
+        if (new_frame) {
+            // Publish spectrum
+            SpectrumData spec;
+            auto db = stft_.latest_magnitude_db(-120.0f);
+            spec.num_bins = std::min(static_cast<int>(db.size()),
+                                     static_cast<int>(SpectrumData::kMaxBins));
+#ifdef PULP_BENCHMARK
+            {
+                const double t_copy = render::bench::now_us();
+                std::copy_n(db.data(), spec.num_bins, spec.magnitude_db.data());
+                if (bench_counters_) {
+                    bench_counters_->audio_copy_total_us.fetch_add(
+                        render::bench::now_us() - t_copy,
+                        std::memory_order_relaxed);
+                }
+            }
+            {
+                const double t_pub = render::bench::now_us();
+                spectrum_buf_.write(spec);
+                if (bench_counters_) {
+                    bench_counters_->triplebuffer_publish_total_us.fetch_add(
+                        render::bench::now_us() - t_pub,
+                        std::memory_order_relaxed);
+                }
+            }
+#else
+            std::copy_n(db.data(), spec.num_bins, spec.magnitude_db.data());
+            spectrum_buf_.write(spec);
+#endif
+        }
+    }
+
+    // Waveform capture (ring buffer of latest samples from channel 0)
+    if (config_.capture_waveform && num_channels > 0) {
+        for (int i = 0; i < num_samples; ++i) {
+            waveform_ring_[waveform_pos_] = channels[0][i];
+            waveform_pos_ = (waveform_pos_ + 1) % waveform_length_;
+        }
+
+        WaveformData wd;
+        wd.num_samples = waveform_length_;
+        wd.num_channels = num_channels;
+#ifdef PULP_BENCHMARK
+        {
+            const double t_copy = render::bench::now_us();
+            // Copy in order from oldest to newest
+            for (int i = 0; i < waveform_length_; ++i) {
+                wd.samples[i] = waveform_ring_[(waveform_pos_ + i) % waveform_length_];
+            }
+            if (bench_counters_) {
+                bench_counters_->audio_copy_total_us.fetch_add(
+                    render::bench::now_us() - t_copy,
+                    std::memory_order_relaxed);
+            }
+        }
+        {
+            const double t_pub = render::bench::now_us();
+            waveform_buf_.write(wd);
+            if (bench_counters_) {
+                bench_counters_->triplebuffer_publish_total_us.fetch_add(
+                    render::bench::now_us() - t_pub,
+                    std::memory_order_relaxed);
+            }
+        }
+#else
+        // Copy in order from oldest to newest
+        for (int i = 0; i < waveform_length_; ++i) {
+            wd.samples[i] = waveform_ring_[(waveform_pos_ + i) % waveform_length_];
+        }
+        waveform_buf_.write(wd);
+#endif
+    }
+}
+
+} // namespace pulp::view

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -383,9 +383,9 @@ By default it delegates to `shipyard pr` (single source of truth for ship
 orchestration). Use `--native` only for diagnostics when debugging the
 CLI-side fallback path. Natural-language triggers in agent conversations
 ("push to main", "ship this", "ship it", "we're done", "merge this",
-"push it", "run CI", "push a PR") all route here — see
-[`.agents/skills/ci/SKILL.md`](../../.agents/skills/ci/SKILL.md) for the
-authoritative trigger list.
+"push it", "run CI", "push a PR") all route here — see the
+[CI skill](../../.agents/skills/ci/SKILL.md) (`.agents/skills/ci/SKILL.md`)
+for the authoritative trigger list.
 
 ```bash
 pulp pr
@@ -420,7 +420,8 @@ Notes:
 - `--native` runs an in-CLI fallback that performs the same gates + PR flow
   without delegating to Shipyard. Diagnostic use only.
 - For the canonical list of natural-language ship triggers and the full
-  policy, see [`.agents/skills/ci/SKILL.md`](../../.agents/skills/ci/SKILL.md).
+  policy, see the [CI skill](../../.agents/skills/ci/SKILL.md)
+  (`.agents/skills/ci/SKILL.md`).
 
 ### docs
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1221,9 +1221,13 @@ add_subdirectory(web-compat)
 # ── Zero-copy benchmark (Slice 0 of #516) ──────────────────────────────────
 #
 # Tooling-only tests, gated on PULP_BENCHMARK. The perf-counter unit
-# test is portable; the integration test shell-outs to pulp-ui-preview
-# which is currently Apple-desktop-only (same guard as the target).
-if(PULP_BENCHMARK)
+# test links pulp::render, which is only added to the build when
+# PULP_ENABLE_GPU=ON (see root CMakeLists.txt). Gating the test on the
+# render target's presence lets -DPULP_BENCHMARK=ON -DPULP_ENABLE_GPU=OFF
+# configure cleanly without a missing-target error (Codex P2 on PR #526
+# / #500). The integration test shell-outs to pulp-ui-preview which is
+# currently Apple-desktop-only (same guard as the target).
+if(PULP_BENCHMARK AND TARGET pulp-render)
     add_executable(pulp-test-bench-perf-counters test_bench_perf_counters.cpp)
     target_link_libraries(pulp-test-bench-perf-counters PRIVATE
         pulp::render Catch2::Catch2WithMain)

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -3,6 +3,7 @@
 #include <pulp/host/scanner.hpp>
 #include <pulp/host/plugin_slot.hpp>
 #include <pulp/host/signal_graph.hpp>
+#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <cstdlib>
@@ -41,6 +42,45 @@ TEST_CASE("PluginScanner bundle detection", "[host][scanner]") {
     REQUIRE(PluginScanner::is_plugin_bundle("MyPlugin.component", PluginFormat::AudioUnit));
     REQUIRE(PluginScanner::is_plugin_bundle("MyPlugin.lv2", PluginFormat::LV2));
     REQUIRE_FALSE(PluginScanner::is_plugin_bundle("MyPlugin.dll", PluginFormat::VST3));
+}
+
+TEST_CASE("AU / AUv3 post-scan narrowing keeps exact flavour",
+          "[host][scanner][issue-500]") {
+    // Regression for the Codex P2 finding on PR #531 / #500: `pulp scan`
+    // advertised `--format au` and `--format auv3` as mutually-exclusive
+    // filters, but both values set the same ScanOptions::scan_au flag,
+    // and PluginScanner::scan_audio_units() returns mixed AU + AUv3
+    // entries. The CLI now runs a post-scan narrowing step — this test
+    // models that step on a synthetic mixed slice so the narrowing
+    // logic is covered independently of any installed AudioComponents.
+    std::vector<PluginInfo> mixed;
+    PluginInfo v2;  v2.format = PluginFormat::AudioUnit;    v2.name = "EffectV2";
+    PluginInfo v3;  v3.format = PluginFormat::AudioUnitV3;  v3.name = "EffectV3";
+    PluginInfo v2b; v2b.format = PluginFormat::AudioUnit;   v2b.name = "SynthV2";
+    mixed = {v2, v3, v2b};
+
+    auto narrow = [&](PluginFormat wanted) {
+        auto out = mixed;
+        out.erase(std::remove_if(out.begin(), out.end(),
+            [&](const PluginInfo& info) { return info.format != wanted; }),
+            out.end());
+        return out;
+    };
+
+    SECTION("asking for AU v2 drops AUv3 entries") {
+        auto v2_only = narrow(PluginFormat::AudioUnit);
+        REQUIRE(v2_only.size() == 2);
+        for (const auto& info : v2_only) {
+            REQUIRE(info.format == PluginFormat::AudioUnit);
+        }
+    }
+
+    SECTION("asking for AUv3 drops AU v2 entries") {
+        auto v3_only = narrow(PluginFormat::AudioUnitV3);
+        REQUIRE(v3_only.size() == 1);
+        REQUIRE(v3_only[0].format == PluginFormat::AudioUnitV3);
+        REQUIRE(v3_only[0].name == "EffectV3");
+    }
 }
 
 TEST_CASE("PluginScanner scan runs without crash", "[host][scanner]") {

--- a/test/test_sysex_accumulator.cpp
+++ b/test/test_sysex_accumulator.cpp
@@ -193,6 +193,39 @@ TEST_CASE("SysexAccumulator: large sysex (>1KB) accumulates correctly",
     REQUIRE(e.complete[0].back() == 0xF7);
 }
 
+TEST_CASE("SysexAccumulator: reserved 0xF9/0xFD pass through mid-sysex",
+          "[midi][sysex][issue-500]") {
+    // Regression for the Codex P2 finding on #484 / #500: 0xF9 and 0xFD
+    // are MIDI-1.0-undefined codes in the System Realtime range. The
+    // accumulator's pass-through contract covers all of F8-FF except F7,
+    // but an earlier is_realtime() carved out 0xF9 and 0xFD, which sent
+    // them down the aborted-status path and truncated otherwise-valid
+    // SysEx streams on transports that emitted the reserved codes.
+    SysexAccumulator acc;
+    Emit e;
+    auto cb = make_callback(e);
+
+    REQUIRE(acc.feed(0xF0, cb) == Classification::in_sysex);
+    REQUIRE(acc.feed(0x41, cb) == Classification::in_sysex);
+    // Reserved realtime 0xF9 — treat as pass-through, NOT an abort.
+    REQUIRE(acc.feed(0xF9, cb) == Classification::passthrough);
+    REQUIRE(acc.in_progress());
+    REQUIRE(acc.feed(0x10, cb) == Classification::in_sysex);
+    // Reserved realtime 0xFD — same story.
+    REQUIRE(acc.feed(0xFD, cb) == Classification::passthrough);
+    REQUIRE(acc.in_progress());
+    REQUIRE(acc.feed(0xF7, cb) == Classification::completed);
+
+    REQUIRE(e.aborted.empty());
+    REQUIRE(e.complete.size() == 1);
+    // Reserved bytes are NOT buffered into the payload — only F0 41 10 F7.
+    REQUIRE(e.complete[0].size() == 4);
+    REQUIRE(e.complete[0][0] == 0xF0);
+    REQUIRE(e.complete[0][1] == 0x41);
+    REQUIRE(e.complete[0][2] == 0x10);
+    REQUIRE(e.complete[0][3] == 0xF7);
+}
+
 TEST_CASE("SysexAccumulator: aborted then recovered sysex",
           "[midi][sysex][issue-86]") {
     SysexAccumulator acc;

--- a/tools/cli/cmd_host.cpp
+++ b/tools/cli/cmd_host.cpp
@@ -70,10 +70,30 @@ int cmd_scan(const std::vector<std::string>& args) {
         if (!all_formats && f != requested) continue;
         ScanOptions opts;
         opts.scan_vst3 = (f == PluginFormat::VST3);
+        // AU and AUv3 share the single AudioComponent discovery path
+        // (scanner_au.mm), so scan_au covers both. The actual
+        // PluginInfo.format is already tagged per-entry by
+        // scanner_au.mm's infer_format(), which lets us narrow the
+        // results to exactly AU v2 or exactly AUv3 below. Codex P2 on
+        // PR #531 / #500: without that post-scan filter, a user who
+        // asked for `--format au` still got mixed AU/AUv3 results,
+        // contradicting the docs and making plugin selection
+        // unreliable.
         opts.scan_au   = (f == PluginFormat::AudioUnit || f == PluginFormat::AudioUnitV3);
         opts.scan_clap = (f == PluginFormat::CLAP);
         opts.scan_lv2  = (f == PluginFormat::LV2);
         auto results = scanner.scan(opts);
+        // Narrow AU / AUv3 results to the exact requested flavour. When
+        // `all_formats` is in play each iteration's `f` is authoritative
+        // for the bucket, so we still trim mixed entries out of the
+        // wrong bucket and print each plugin in its own [au]/[auv3]
+        // section.
+        if (f == PluginFormat::AudioUnit || f == PluginFormat::AudioUnitV3) {
+            results.erase(
+                std::remove_if(results.begin(), results.end(),
+                    [&](const PluginInfo& info) { return info.format != f; }),
+                results.end());
+        }
         if (results.empty()) continue;
         std::printf("[%s] %zu plugin(s)\n", format_name(f), results.size());
         for (auto& info : results) {


### PR DESCRIPTION
## Automated by `pulp pr`

### Skill-sync verdict
```
[ci] ✓ bypassed (post-merge-review-sweep.yml --limit tweak is an infra parameter, not a workflow-shape change)
    .github/workflows/post-merge-review-sweep.yml
[cli-maintenance] ✓ bypassed (cmd_host.cpp scan filter is a behavioral fix for existing flags, no CLI surface or pattern change)
    tools/cli/cmd_host.cpp

```

### Version-bump verdict
```
[sdk] Pulp SDK / CLI: heuristic=minor final=minor current=0.23.1 ✗ bump required
[plugin] Claude Code plugin: no bump needed

Version-bump check FAILED.
Apply the required bump with:
  python3 tools/scripts/version_bump_check.py --mode=apply
Or record an explicit override on the tip commit:
  Version-Bump: <surface>=<patch|minor|major|skip> reason="..."

```
