### PR TITLE
fix(examples/threejs): flush rAF in headless loader loop (#542)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.25.0
+    VERSION 0.25.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/examples/threejs-native-demo/CMakeLists.txt
+++ b/examples/threejs-native-demo/CMakeLists.txt
@@ -16,4 +16,26 @@ if(PULP_ENABLE_GPU AND PULP_HAS_THREEJS)
     elseif(UNIX)
         target_link_options(pulp-threejs-native-demo PRIVATE -Wl,-z,stacksize=16777216)
     endif()
+
+    # #542: Headless `--capture` must not hang at `status: 'starting'`. This
+    # test runs the cube demo with --capture and asserts the binary exits
+    # within a bounded time (i.e. does NOT hang). When V8 is actually linked
+    # and a native Dawn adapter is available, the test additionally asserts
+    # that a non-empty PNG was written. On builds without V8 (or without a
+    # Dawn adapter), the binary prints an explanatory banner and exits 1 —
+    # the test script tolerates that case explicitly so every CI node still
+    # exercises the no-hang path that regressed in #542.
+    if(PULP_BUILD_TESTS)
+        add_test(
+            NAME threejs_native_demo_capture_no_hang
+            COMMAND ${CMAKE_COMMAND}
+                -DDEMO_BIN=$<TARGET_FILE:pulp-threejs-native-demo>
+                -DCAPTURE_PATH=${CMAKE_CURRENT_BINARY_DIR}/pulp-threejs-demo-capture-test.png
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/capture_test.cmake
+        )
+        set_tests_properties(threejs_native_demo_capture_no_hang PROPERTIES
+            TIMEOUT 30
+            LABELS "threejs;gpu;headless"
+        )
+    endif()
 endif()

--- a/examples/threejs-native-demo/capture_test.cmake
+++ b/examples/threejs-native-demo/capture_test.cmake
@@ -1,0 +1,78 @@
+# CTest helper for #542: run pulp-threejs-native-demo --demo cube --capture
+# and verify the process exits bounded (not hanging at status: 'starting').
+#
+# Inputs (set via -D):
+#   DEMO_BIN      : path to the built pulp-threejs-native-demo binary
+#   CAPTURE_PATH  : path where the demo should write the PNG
+#
+# Pass criteria:
+#   - Binary exits within the test TIMEOUT (CTest enforces 30s externally).
+#   - If the build has V8 linked AND a native Dawn adapter is available,
+#     the PNG file must exist and be non-empty.
+#   - If V8 is unavailable or the Dawn adapter is unavailable, the binary
+#     prints an explanatory message on stderr and exits 1 without hanging;
+#     that is still a pass for this test (the hang is the #542 regression
+#     we guard against).
+
+if(NOT DEFINED DEMO_BIN)
+    message(FATAL_ERROR "capture_test.cmake: DEMO_BIN not set")
+endif()
+if(NOT DEFINED CAPTURE_PATH)
+    message(FATAL_ERROR "capture_test.cmake: CAPTURE_PATH not set")
+endif()
+
+# Clean stale capture from previous runs so a success/failure signal is real.
+if(EXISTS "${CAPTURE_PATH}")
+    file(REMOVE "${CAPTURE_PATH}")
+endif()
+
+# Run the demo. TIMEOUT here is a belt-and-braces guard; the outer
+# set_tests_properties TIMEOUT is the authoritative hang detector.
+execute_process(
+    COMMAND "${DEMO_BIN}" --demo cube --capture "${CAPTURE_PATH}"
+    TIMEOUT 20
+    RESULT_VARIABLE demo_result
+    OUTPUT_VARIABLE demo_stdout
+    ERROR_VARIABLE demo_stderr
+)
+
+message(STATUS "threejs-native-demo stdout:\n${demo_stdout}")
+if(demo_stderr)
+    message(STATUS "threejs-native-demo stderr:\n${demo_stderr}")
+endif()
+
+# A string/integer RESULT_VARIABLE means timeout or signal — that IS the hang.
+if(NOT demo_result MATCHES "^-?[0-9]+$")
+    message(FATAL_ERROR
+        "#542 regression: pulp-threejs-native-demo --demo cube --capture "
+        "did not exit within the bounded timeout (result='${demo_result}').")
+endif()
+
+# Environment-skip cases are not regressions — guard only against hangs.
+if(demo_stderr MATCHES "V8 is required")
+    message(STATUS "Skipping PNG assertion: build lacks V8 (no #542 regression).")
+    return()
+endif()
+if(demo_stderr MATCHES "Native Dawn adapter unavailable")
+    message(STATUS "Skipping PNG assertion: no native Dawn adapter on this host.")
+    return()
+endif()
+
+# With V8 + Dawn present, exit non-zero or empty PNG = real failure.
+if(NOT demo_result EQUAL 0)
+    message(FATAL_ERROR
+        "pulp-threejs-native-demo exited ${demo_result} "
+        "(stderr: ${demo_stderr})")
+endif()
+
+if(NOT EXISTS "${CAPTURE_PATH}")
+    message(FATAL_ERROR "Capture PNG not written: ${CAPTURE_PATH}")
+endif()
+
+file(SIZE "${CAPTURE_PATH}" capture_size)
+if(capture_size LESS 64)
+    message(FATAL_ERROR
+        "Capture PNG is suspiciously small (${capture_size} bytes): ${CAPTURE_PATH}")
+endif()
+
+message(STATUS "threejs_native_demo_capture_no_hang: OK (${capture_size} bytes)")

--- a/examples/threejs-native-demo/main.cpp
+++ b/examples/threejs-native-demo/main.cpp
@@ -1318,15 +1318,27 @@ bool load_demo(DemoEnvironment& env, int width, int height, DemoMode mode, std::
             module_error = error;
         });
 
+    // Drain microtasks AND pump requestAnimationFrame callbacks while waiting for
+    // the module's top-level promise to settle. Without servicing frame callbacks
+    // here, a headless `--capture` run hangs at `status: 'starting'` because the
+    // frame clock (normally driven by the windowed NSTimer/run_event_loop) never
+    // ticks, so any rAF registered by three.webgpu.js / OrbitControls during the
+    // `await renderer.init()` chain never fires and the module promise stays
+    // pending. Fixes #542.
     for (int i = 0; i < 1024; ++i) {
+        env.advance_sources(1.0f / 60.0f);
+        if (env.bridge) env.bridge->service_frame_callbacks();
         env.engine.pump_message_loop();
-        const auto status = eval_string(env.engine, "globalThis.__pulpThreeDemoState && globalThis.__pulpThreeDemoState.status || ''");
+        const auto status = eval_string(
+            env.engine,
+            "globalThis.__pulpThreeDemoState && globalThis.__pulpThreeDemoState.status || ''");
         if (status == "ready" || status == "error") {
             break;
         }
     }
 
     for (int i = 0; i < 64; ++i) {
+        if (env.bridge) env.bridge->service_frame_callbacks();
         env.engine.pump_message_loop();
     }
 

--- a/test/web-compat/CMakeLists.txt
+++ b/test/web-compat/CMakeLists.txt
@@ -103,3 +103,16 @@ elseif(UNIX)
     target_link_options(pulp-test-minimal-append PRIVATE -Wl,-z,stacksize=16777216)
 endif()
 catch_discover_tests(pulp-test-minimal-append)
+
+# #542 regression: headless loader loops must flush requestAnimationFrame
+# callbacks, not just microtasks, or three.webgpu.js-style demos hang at
+# status: 'starting' on the --capture path.
+add_executable(pulp-test-headless-frame-pump test_headless_frame_pump.cpp)
+target_link_libraries(pulp-test-headless-frame-pump PRIVATE pulp::view Catch2::Catch2WithMain)
+target_include_directories(pulp-test-headless-frame-pump PRIVATE ${WEBCOMPAT_INCLUDE_DIR})
+if(APPLE)
+    target_link_options(pulp-test-headless-frame-pump PRIVATE -Wl,-stack_size,0x2000000)
+elseif(UNIX)
+    target_link_options(pulp-test-headless-frame-pump PRIVATE -Wl,-z,stacksize=16777216)
+endif()
+catch_discover_tests(pulp-test-headless-frame-pump)

--- a/test/web-compat/test_headless_frame_pump.cpp
+++ b/test/web-compat/test_headless_frame_pump.cpp
@@ -1,0 +1,140 @@
+// Regression test for #542 — the native Three.js demo (and anything else
+// that follows the same pattern) hung in headless `--capture` mode because
+// the load loop only pumped JS microtasks via `pump_message_loop()` and
+// never flushed pending `requestAnimationFrame` callbacks. In windowed
+// mode the NSTimer-driven frame clock calls
+// WidgetBridge::service_frame_callbacks which both pumps microtasks AND
+// invokes __flushFrames__, so the hang was invisible there.
+//
+// This test reproduces the core invariant in a backend-agnostic way
+// (QuickJS is always available) so every CI lane catches future
+// regressions even when V8 isn't linked in.
+//
+// The test is deliberately independent of three.webgpu.js: we just need a
+// JS fragment that reaches "ready" only once a requestAnimationFrame
+// callback has run, which is the exact shape of the demo's module
+// bootstrap.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/state/store.hpp>
+#include <pulp/view/script_engine.hpp>
+#include <pulp/view/theme.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/widget_bridge.hpp>
+
+#include <memory>
+#include <string>
+
+using namespace pulp::view;
+using namespace pulp;
+
+namespace {
+
+struct Env {
+    View root;
+    state::StateStore store;
+    ScriptEngine engine;
+    std::unique_ptr<WidgetBridge> bridge;
+    Env() {
+        root.set_bounds({0, 0, 256, 256});
+        root.set_theme(Theme::dark());
+        bridge = std::make_unique<WidgetBridge>(engine, root, store);
+        // Prime the web-compat preamble (installs requestAnimationFrame /
+        // __requestFrame__ / __flushFrames__).
+        bridge->load_script("");
+    }
+};
+
+std::string eval_string(ScriptEngine& engine, const std::string& code) {
+    return std::string(engine.evaluate(code).getWithDefault<std::string_view>(""));
+}
+
+} // namespace
+
+// Issue-NNN tag style keeps us compatible with Catch2's reserved-character
+// rules (see CLAUDE.md — "Catch2 tag names cannot contain #").
+TEST_CASE("headless load loop flushes requestAnimationFrame callbacks",
+          "[view][widget-bridge][issue-542]") {
+    Env env;
+
+    // The JS under test mirrors the exact pattern that hung in #542:
+    //   1. Set status = 'starting' synchronously.
+    //   2. Register a requestAnimationFrame callback that flips the status
+    //      to 'ready'. In the real demo this corresponds to the post-init
+    //      frame that three.webgpu.js schedules during
+    //      `await renderer.init()`.
+    // Use engine.evaluate() directly (not load_script) because load_script
+    // itself calls __flushFrames__ as part of its contract, which would
+    // mask the bug we are reproducing. The pre-fix `load_demo` loop only
+    // invoked pump_message_loop() after the initial load_script, and that
+    // is what this test exercises.
+    env.engine.evaluate(
+        "globalThis.__issue542State = 'starting';"
+        "window.requestAnimationFrame(function () {"
+        "    globalThis.__issue542State = 'ready';"
+        "});"
+        "void 0"
+    );
+
+    REQUIRE(eval_string(env.engine,
+                        "String(globalThis.__issue542State)") == "starting");
+
+    // Microtask pumps alone must NOT advance the state — this is what the
+    // pre-fix headless loop did, and is the exact bug we are guarding.
+    for (int i = 0; i < 16; ++i) {
+        env.engine.pump_message_loop();
+    }
+    REQUIRE(eval_string(env.engine,
+                        "String(globalThis.__issue542State)") == "starting");
+
+    // Servicing frame callbacks drains the pending rAF queue, which is the
+    // behaviour load_demo() in examples/threejs-native-demo/main.cpp now
+    // invokes inside its bounded pump loop.
+    bool advanced = false;
+    for (int i = 0; i < 16 && !advanced; ++i) {
+        env.bridge->service_frame_callbacks();
+        if (eval_string(env.engine,
+                        "String(globalThis.__issue542State)") == "ready") {
+            advanced = true;
+        }
+    }
+
+    REQUIRE(advanced);
+    REQUIRE(eval_string(env.engine,
+                        "String(globalThis.__issue542State)") == "ready");
+}
+
+TEST_CASE("headless load loop repeatedly services chained rAF callbacks",
+          "[view][widget-bridge][issue-542]") {
+    // The demo's tick() function re-arms itself via requestAnimationFrame at
+    // the end of each frame. Ensuring service_frame_callbacks() can drive a
+    // chained animation loop for multiple frames protects against a fix
+    // that only works for the very first rAF tick.
+    Env env;
+
+    env.engine.evaluate(
+        "globalThis.__issue542Frames = 0;"
+        "function __issue542Tick() {"
+        "    globalThis.__issue542Frames += 1;"
+        "    if (globalThis.__issue542Frames < 4) {"
+        "        window.requestAnimationFrame(__issue542Tick);"
+        "    }"
+        "}"
+        "window.requestAnimationFrame(__issue542Tick);"
+        "void 0"
+    );
+
+    // Each service_frame_callbacks() call invokes one batch of pending
+    // frames; the callback may re-arm the next frame via rAF.
+    for (int i = 0; i < 16; ++i) {
+        env.bridge->service_frame_callbacks();
+        if (env.engine.evaluate("globalThis.__issue542Frames")
+                .getWithDefault<int32_t>(0) >= 4) {
+            break;
+        }
+    }
+
+    REQUIRE(env.engine.evaluate("globalThis.__issue542Frames")
+                .getWithDefault<int32_t>(0) == 4);
+}


### PR DESCRIPTION
## Summary

Fixes #542 — the native Three.js demo's headless `--capture` path hung at `status: 'starting'` because the bounded pump loop in `load_demo()` only drained JS microtasks via `pump_message_loop()` and never flushed pending `requestAnimationFrame` callbacks.

In windowed mode the NSTimer-driven frame clock calls `WidgetBridge::service_frame_callbacks()` which both pumps microtasks AND invokes `__flushFrames__`, masking the bug. `--capture` skipped `window->run_event_loop()` so the frame clock never ticked, and any rAF-chained init work (three.webgpu.js / OrbitControls) never completed.

- Drop two calls to `bridge->service_frame_callbacks()` (plus an `advance_sources()` tick) into the `load_demo()` pump loop, matching the `prime_demo_frames()` post-load pattern. No behaviour change in windowed mode.
- Ship two tests with the fix (per CLAUDE.md "tests ship with fixes"):
  - `test/web-compat/test_headless_frame_pump.cpp` — backend-agnostic Catch2 coverage on QuickJS that proves microtask-only pumps fail to advance an rAF-gated status while `service_frame_callbacks()` succeeds, and that chained rAF ticks run across multiple frames. Runs on every CI lane.
  - `examples/threejs-native-demo/capture_test.cmake` + ctest target `threejs_native_demo_capture_no_hang` — end-to-end `--demo cube --capture` with a 30s TIMEOUT. Guards against the hang directly; asserts a non-empty PNG when V8 + Dawn are linked, tolerates the "V8 required" / "Dawn unavailable" env-skip exits otherwise.

## Test plan

- [x] `ctest --test-dir build --exclude-regex "AudioWorkgroup|NOT_BUILT"` — 2597/2597 pass locally on macOS arm64
- [x] `ctest -R "headless load|threejs_native_demo_capture|chained rAF"` — 3/3 pass
- [x] `git diff origin/main CMakeLists.txt` confirms SDK bump 0.25.0 → 0.25.1
- [x] `git interpret-trailers --parse` confirms contiguous `Closes #542` / `Version-Bump:` / `Skill-Update:` trailer block

Closes #542