### PR TITLE
tools/scripts: fix fnmatch `**` glob bug in version + skill gates

### DIFF
--- a/tools/scripts/skill_sync_check.py
+++ b/tools/scripts/skill_sync_check.py
@@ -15,13 +15,13 @@ Uses JSON (not YAML) for zero-dependency execution on PEP-668 Python.
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import json
 import os
 import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Iterable
 
@@ -168,19 +168,69 @@ def load_skill_map(path: Path) -> SkillMap:
 # ── Matching ────────────────────────────────────────────────────────────
 
 
-def _glob_match(path: str, pattern: str) -> bool:
-    """fnmatch-with-`**` support.
+@lru_cache(maxsize=None)
+def _glob_to_regex(pattern: str) -> "re.Pattern[str]":
+    """Translate a gitignore-style glob into an anchored regex.
 
-    fnmatch treats `*` as matching `/`, which is already what we want for
-    `**` semantics — but we also need `**/X` to match `X` at the repo root.
-    Normalize the pattern so that `**` expands to allow any segment count,
-    including zero.
+    Mirrors ``tools/scripts/version_bump_check._glob_to_regex``. Kept here
+    as a deliberate copy so each gate stays a single-file script (agent
+    hooks and CI both invoke them directly). If this diverges from the
+    version-bump copy, the regression tests in test_gates.py will catch
+    it.
+
+    Semantics:
+        - ``**`` matches zero or more path segments (including zero).
+        - ``*``  matches zero or more characters within a single segment.
+        - ``?``  matches exactly one character within a single segment.
+        - Patterns are anchored at both ends.
     """
-    # Normalize `**/` at the start to match both `foo/X` and `X`.
-    if pattern.startswith("**/"):
-        tail = pattern[3:]
-        return fnmatch.fnmatchcase(path, tail) or fnmatch.fnmatchcase(path, pattern)
-    return fnmatch.fnmatchcase(path, pattern)
+    parts = pattern.split("/")
+    n = len(parts)
+
+    STARSTAR = object()
+    tokens: list = []
+    for part in parts:
+        if part == "**":
+            tokens.append(STARSTAR)
+            continue
+        seg = ""
+        for c in part:
+            if c == "*":
+                seg += "[^/]*"
+            elif c == "?":
+                seg += "[^/]"
+            else:
+                seg += re.escape(c)
+        tokens.append(seg)
+
+    out = ""
+    for i, tok in enumerate(tokens):
+        is_first = i == 0
+        is_last = i == n - 1
+        if tok is STARSTAR:
+            if is_first and is_last:
+                out += ".*"
+            elif is_first:
+                out += "(?:.*/)?"
+            elif is_last:
+                if out.endswith("/"):
+                    out = out[:-1]
+                out += "(?:/.*)?"
+            else:
+                if out.endswith("/"):
+                    out = out[:-1]
+                out += "(?:.*/)?"
+        else:
+            if not is_first:
+                if not (out.endswith("/") or out.endswith(")?")):
+                    out += "/"
+            out += tok
+
+    return re.compile("^" + out + "$")
+
+
+def _glob_match(path: str, pattern: str) -> bool:
+    return _glob_to_regex(pattern).match(path) is not None
 
 
 def _matches_any(path: str, patterns: Iterable[str]) -> bool:

--- a/tools/scripts/test_gates.py
+++ b/tools/scripts/test_gates.py
@@ -122,9 +122,14 @@ class Fixture:
                     "trigger_paths": [
                         "core/**/include/**/*.hpp",
                         "core/**/src/**/*.cpp",
+                        "tools/cli/**/*.cpp",
+                        "tools/cli/**/*.hpp",
                     ],
                     "public_api_paths": ["core/**/include/**/*.hpp"],
-                    "internal_only_paths": ["core/**/src/**"],
+                    "internal_only_paths": [
+                        "core/**/src/**",
+                        "tools/cli/**",
+                    ],
                 },
                 "plugin": {
                     "label": "Plugin",
@@ -367,6 +372,149 @@ class GateFixtureTests(unittest.TestCase):
         # Net diff from origin/main to HEAD is empty on this surface; the
         # gate should not demand a bump.
         self.assertEqual(code, 0, msg=out)
+        self.assertIn("no bump needed", out)
+
+    # ── Regression: 2026-04-20 fnmatch `**` glob bug (#538/#540/#541/#546) ─
+
+    def test_tools_cli_top_level_file_is_detected(self) -> None:
+        """Editing tools/cli/cmd_foo.cpp must match the sdk trigger pattern
+        tools/cli/**/*.cpp. The stdlib fnmatch-based matcher previously
+        failed here because it didn't treat `**` as zero-or-more segments,
+        so a `feat:` on a top-level CLI file silently produced "no bump
+        needed". See today's incidents on PRs #538/#540/#541/#546."""
+        self.f.write(
+            "tools/cli/cmd_foo.cpp",
+            "int cmd_foo_run() { return 0; }\n",
+        )
+        self.f.commit("feat: cli add cmd_foo")
+        code, out = self.f.run_vbc()
+        self.assertEqual(code, 1, msg=out)
+        self.assertIn("[sdk]", out)
+        self.assertIn("bump required", out)
+        self.assertIn("minor", out)
+
+    def test_apply_writes_version_for_tools_cli_top_level_file(self) -> None:
+        """`--mode=apply` must actually rewrite CMakeLists.txt for a
+        top-level tools/cli/*.cpp edit. The silent-skip was the symptom
+        reported by four agents today."""
+        self.f.write(
+            "tools/cli/cmd_foo.cpp",
+            "int cmd_foo_run() { return 0; }\n",
+        )
+        self.f.commit("feat: cli add cmd_foo")
+        code, out = self.f.run_vbc(["--mode=apply"])
+        self.assertEqual(code, 0, msg=out)
+        self.assertIn("bumped", out)
+        new_cmake = (self.tmp / "CMakeLists.txt").read_text()
+        # 0.1.0 → minor bump → 0.2.0.
+        self.assertIn("VERSION 0.2.0", new_cmake, msg=new_cmake)
+
+    def test_glob_matching_unit_cases(self) -> None:
+        """Direct unit coverage for the glob-to-regex helper. These are the
+        cases the incident playbook explicitly calls out — keep them
+        exhaustive so a future refactor can't silently regress."""
+        # Import here so the rest of the file keeps working even without
+        # the fix rolled out.
+        sys.path.insert(0, str(REPO_ROOT / "tools" / "scripts"))
+        from version_bump_check import _glob_match
+
+        positives = [
+            ("tools/cli/cmd_doctor.cpp", "tools/cli/**/*.cpp"),
+            ("tools/cli/cmd_doctor.cpp", "tools/cli/*.cpp"),
+            ("tools/cli/sub/cmd_x.cpp",  "tools/cli/**/*.cpp"),
+            ("core/view/src/widget_bridge.cpp", "core/**"),
+            ("core/view/src/widget.cpp", "core/**/src/**/*.cpp"),
+            ("core/view/include/pulp/view.hpp", "core/**/include/**/*.hpp"),
+            ("CMakeLists.txt", "CMakeLists.txt"),
+            ("docs/reference/cli.md", "docs/**/*.md"),
+            ("docs/cli.md", "docs/**/*.md"),
+            (".claude-plugin/plugin.json", ".claude-plugin/**"),
+            (".claude-plugin/sub/foo.json", ".claude-plugin/**"),
+            ("build/foo/bar.cpp", "build/**"),
+            ("build/bar.cpp", "build/**"),
+            ("foo.generated.cpp", "**/*.generated.*"),
+            ("sub/foo.generated.cpp", "**/*.generated.*"),
+            ("pulp.lock", "*.lock"),
+            ("foo/bar/baz.hpp", "**/bar/*.hpp"),
+            ("bar/baz.hpp", "**/bar/*.hpp"),
+        ]
+        negatives = [
+            # Non-sibling directory — core/** must not match external/**.
+            ("external/choc/json.hpp", "core/**"),
+            # Wrong extension.
+            ("tools/cli/foo.js", "tools/cli/**/*.cpp"),
+            # Pattern has no leading `**/` so root-level file must not match.
+            ("sub/pulp.lock", "*.lock"),
+            # `**/bar/*.hpp` requires a `bar` segment.
+            ("baz.hpp", "**/bar/*.hpp"),
+            # Completely unrelated top-level file.
+            ("CMakeLists.txt", "core/**"),
+            # Prefix that looks like a subdir but isn't.
+            ("coretools/foo.cpp", "core/**"),
+        ]
+        for path, pattern in positives:
+            self.assertTrue(
+                _glob_match(path, pattern),
+                msg=f"expected {path!r} to match {pattern!r}",
+            )
+        for path, pattern in negatives:
+            self.assertFalse(
+                _glob_match(path, pattern),
+                msg=f"expected {path!r} to NOT match {pattern!r}",
+            )
+
+    def test_skill_sync_matches_top_level_cli_file(self) -> None:
+        """Skill-sync carried the same glob bug — its `tools/cli/**` map
+        entry must match `tools/cli/cmd_foo.cpp` directly."""
+        self.f.write(
+            "tools/cli/cmd_foo.cpp",
+            "int cmd_foo_run() { return 0; }\n",
+        )
+        self.f.commit("chore: cli tweak")
+        code, out = self.f.run_ssc()
+        # cli-maintenance skill is mapped to tools/cli/** and its SKILL.md
+        # was NOT updated → expect the gate to hard-fail.
+        self.assertEqual(code, 1, msg=out)
+        self.assertIn("cli-maintenance", out)
+        self.assertIn("SKILL.md NOT updated", out)
+
+    def test_override_applies_when_heuristic_is_comment_only(self) -> None:
+        """An explicit Version-Bump trailer should apply when the surface's
+        trigger paths were touched, even if the diff is entirely comments
+        and the heuristic would otherwise fall through to "none"."""
+        # Comment-only edit to a touched trigger path → heuristic none.
+        path = self.tmp / "core/runtime/include/pulp/runtime/foo.hpp"
+        path.write_text(
+            "#pragma once\n"
+            "// Explanatory header comment added by a docs-only PR.\n"
+            "int foo();\n"
+        )
+        _git(self.tmp, "add", "-A")
+        _git(self.tmp, "commit", "-q", "-m",
+             'docs: flesh out foo() header comment\n\n'
+             'Version-Bump: sdk=patch reason="doc-only header tweak, explicit patch"')
+        code, out = self.f.run_vbc()
+        # Patch is advisory in report mode; what we verify here is that
+        # the trailer was honored, not ignored — the verdict line should
+        # show `override=patch` alongside `final=patch`.
+        self.assertIn("override=patch", out, msg=out)
+        self.assertIn("final=patch", out, msg=out)
+
+    def test_override_for_untouched_surface_is_ignored(self) -> None:
+        """Anti-rubberstamp: a Version-Bump trailer referencing a surface
+        whose trigger paths weren't touched must NOT force a bump."""
+        # Touch only the plugin manifest; SDK trigger paths are untouched.
+        (self.tmp / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "test", "version": "0.2.0"}, indent=2) + "\n"
+        )
+        _git(self.tmp, "add", "-A")
+        _git(self.tmp, "commit", "-q", "-m",
+             'chore(plugin): bump\n\n'
+             'Version-Bump: sdk=major reason="should be ignored, sdk untouched"')
+        code, out = self.f.run_vbc()
+        # Plugin surface is properly bumped, SDK is untouched and the stray
+        # override must not conjure a bump for it.
+        self.assertIn("[sdk]", out)
         self.assertIn("no bump needed", out)
 
 

--- a/tools/scripts/version_bump_check.py
+++ b/tools/scripts/version_bump_check.py
@@ -29,13 +29,13 @@ Uses JSON configs (zero-dep).
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import json
 import os
 import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Iterable
 
@@ -316,11 +316,78 @@ def write_version(repo: Path, vf: VersionFile, new: str) -> bool:
 # ── Matching / heuristics ───────────────────────────────────────────────
 
 
+@lru_cache(maxsize=None)
+def _glob_to_regex(pattern: str) -> "re.Pattern[str]":
+    """Translate a gitignore-style glob into an anchored regex.
+
+    Semantics (needed because Python's stdlib ``fnmatch`` and
+    ``pathlib.PurePath.match`` both fail to treat ``**`` as "zero or more
+    path segments" — they require at least one intermediate segment, so
+    ``tools/cli/**/*.cpp`` does NOT match ``tools/cli/cmd_doctor.cpp``):
+
+        - ``**`` matches zero or more path segments (including zero).
+        - ``*``  matches zero or more characters within a single segment.
+        - ``?``  matches exactly one character within a single segment.
+        - Patterns are anchored at both ends.
+
+    This is the single source of truth for matching changed-file paths
+    against ``versioning.json``'s trigger_paths / public_api_paths /
+    internal_only_paths / generated_globs. See 2026-04-20 incident
+    (#538/#540/#541/#546) where the previous ``fnmatch``-based matcher
+    silently failed to flag SDK changes touching ``tools/cli/*.cpp``.
+    """
+    parts = pattern.split("/")
+    n = len(parts)
+
+    STARSTAR = object()
+    tokens: list = []
+    for part in parts:
+        if part == "**":
+            tokens.append(STARSTAR)
+            continue
+        seg = ""
+        for c in part:
+            if c == "*":
+                seg += "[^/]*"
+            elif c == "?":
+                seg += "[^/]"
+            else:
+                seg += re.escape(c)
+        tokens.append(seg)
+
+    out = ""
+    for i, tok in enumerate(tokens):
+        is_first = i == 0
+        is_last = i == n - 1
+        if tok is STARSTAR:
+            if is_first and is_last:
+                out += ".*"
+            elif is_first:
+                # leading '**/' — zero or more segments followed by '/'.
+                out += "(?:.*/)?"
+            elif is_last:
+                # trailing '/**' — match either '' or '/<rest>'.
+                if out.endswith("/"):
+                    out = out[:-1]
+                out += "(?:/.*)?"
+            else:
+                # middle '/**/' — zero or more segments between two slashes.
+                if out.endswith("/"):
+                    out = out[:-1]
+                out += "(?:.*/)?"
+        else:
+            if not is_first:
+                # Only add a separator if the preceding emission hasn't
+                # already supplied one (leading/middle ** tokens end in '/').
+                if not (out.endswith("/") or out.endswith(")?")):
+                    out += "/"
+            out += tok
+
+    return re.compile("^" + out + "$")
+
+
 def _glob_match(path: str, pattern: str) -> bool:
-    if pattern.startswith("**/"):
-        tail = pattern[3:]
-        return fnmatch.fnmatchcase(path, tail) or fnmatch.fnmatchcase(path, pattern)
-    return fnmatch.fnmatchcase(path, pattern)
+    return _glob_to_regex(pattern).match(path) is not None
 
 
 def _matches_any(path: str, patterns: Iterable[str]) -> bool:
@@ -492,6 +559,13 @@ def assess_surfaces(
     verdicts: list[Verdict] = []
     for s in cfg.surfaces:
         heur = heuristic_for_surface(s, changed, base, head)
+        # "Did the diff touch ANY of this surface's trigger paths?" is a
+        # weaker condition than the heuristic (which also requires a
+        # meaningful, non-comment diff). We use it to decide whether an
+        # explicit trailer override is allowed to take effect even when the
+        # heuristic is "none" (e.g. the author knows a comment-only change
+        # is still API-visible via the docstring).
+        trigger_touched = any(_matches_any(p, s.trigger_paths) for p in changed)
 
         override = surface_trailer_override(trailers, cfg.trailer_version_bump, s.name)
         final = heur
@@ -500,15 +574,21 @@ def assess_surfaces(
         if skip_requested:
             final = "none"
         elif override in LEVELS:
-            # Only raise, never lower. And only if the surface was actually touched.
-            if heur != "none" and LEVELS.index(override) > LEVELS.index(heur):
-                final = override
-            elif heur != "none":
-                final = heur
-            else:
-                # Surface not touched; ignore the override to avoid
-                # rubber-stamping unrelated bumps.
+            # Only raise, never lower. The override applies whenever the
+            # surface's trigger paths were touched at all — even if the
+            # diff-content heuristic fell through to "none" (comments only,
+            # whitespace only, etc.). This lets authors force a bump on a
+            # touched surface without the script second-guessing them.
+            # Untouched surfaces still ignore the override to avoid
+            # rubber-stamping unrelated bumps.
+            if not trigger_touched:
                 final = "none"
+            elif heur == "none":
+                final = override
+            elif LEVELS.index(override) > LEVELS.index(heur):
+                final = override
+            else:
+                final = heur
 
         # Promote via conventional-commit subjects on commits that touched
         # THIS surface — never from commits that only touched unrelated


### PR DESCRIPTION
## Summary

Root-cause fix for a `fnmatch`-based glob bug that caused four PRs today
(#538, #540, #541, #546) to land their version bumps manually or via amend.

Python's stdlib `fnmatch` (and `pathlib.PurePath.match`) do NOT implement
the gitignore-style "`**` matches zero or more path segments" semantics
that `versioning.json` assumes. `tools/cli/**/*.cpp` therefore silently
failed to match top-level `tools/cli/cmd_doctor.cpp`, so `pulp pr` kept
reporting "no bump needed" for CLI-only changes across all three
enforcement layers (agent hook, pre-push, CI).

### Changes

- `tools/scripts/version_bump_check.py`: replace `fnmatch.fnmatchcase`
  with a hand-rolled `_glob_to_regex` that explicitly models `**` as
  "zero or more segments, including zero". LRU-cached.
- `tools/scripts/skill_sync_check.py`: same fix — it carried the same
  bug via the same `_glob_match` helper, so skill-sync on top-level
  CLI files was also silently skipping.
- `tools/scripts/version_bump_check.py` (second, smaller fix): an
  explicit `Version-Bump: <surface>=<level>` trailer now applies
  whenever the surface's trigger paths were touched, not only when
  the content heuristic already returned non-"none". This lets
  authors force a bump on a comment-only diff that's still
  API-visible. The anti-rubberstamp rule for totally untouched
  surfaces is preserved.
- `tools/scripts/test_gates.py`: six new regression cases (top-level
  CLI file detection, `--mode=apply` actually rewrites
  `CMakeLists.txt`, direct unit cases for the glob helper including
  negatives, skill-sync parity, comment-only override application,
  untouched-surface override anti-rubberstamp).

### Self-verification

The fix itself lives in `tools/scripts/*.py`, which isn't in any
surface's `trigger_paths`, so no version bump is expected for this
change — and both gates confirm that. The existing pre-push hook ran
both scripts clean on this branch: `[pre-push] gates clean.`

## Test plan

- [x] `python3 tools/scripts/test_gates.py` — 19/19 pass locally
- [x] Deterministic reproducer on a throwaway repo: editing
      `tools/cli/cmd_doctor.cpp` with a `feat:` commit now correctly
      reports `bump required minor` where the pre-fix script returned
      `no bump needed`.
- [x] `--mode=apply` now rewrites `CMakeLists.txt` for the same
      scenario (verified via the new
      `test_apply_writes_version_for_tools_cli_top_level_file` case).
- [x] `python3 tools/scripts/version_bump_check.py --mode=report` and
      `python3 tools/scripts/skill_sync_check.py --mode=report` both
      pass cleanly on this branch.
- [ ] Shipyard ship lane validates on macOS + Ubuntu + Windows.