### PR TITLE
cli: ~/.pulp/projects.json registry + pulp projects commands (#552 Slice 1b)

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -43,7 +43,7 @@ requires:
 - It's a subcommand of something already covered
 
 **Commands that intentionally don't have slash commands:**
-audio, cache, clean, upgrade, config, export-tokens, ci-local, design-debug, help
+audio, cache, clean, upgrade, export-tokens, ci-local, design-debug, help, projects
 
 ### 4. Update docs
 - [ ] Add/update section in `docs/reference/cli.md`
@@ -212,6 +212,47 @@ a `ParameterEventQueue`. When adding new CLI hosting commands, include
 have no automation to deliver. See `docs/reference/host-thread-rules.md`
 for the full contract.
 
+## `pulp projects` + registry wiring (#499 / #552 Slice 1b)
+
+`pulp projects list/add/remove` live in `tools/cli/cmd_projects.cpp`.
+The JSON file at `~/.pulp/projects.json` (or `$PULP_HOME/projects.json`)
+is maintained by `tools/cli/projects_registry.{hpp,cpp}` and is
+populated automatically from `cmd_create.cpp` on successful scaffold
+via `pulp::cli::projects_registry::add_project(...)`.
+
+Design decision (2026-04-21, locked in): **registry is authoritative.**
+`pulp create` writes to it; `pulp projects add/remove` is the user
+surface; `pulp doctor --versions --scan-parents` walks CWD ancestors
+as an opt-in diagnostic but never mutates the registry. No silent
+disk scans.
+
+Gotchas:
+
+- **`projects_registry` is deliberately decoupled from `cli_common`.**
+  Same rule as `version_diag` — the unit test (`pulp-test-cli-
+  projects-registry`) links just `projects_registry.cpp` +
+  Catch2 so the test binary stays small. Don't reach into
+  `cli_common.hpp` from inside the registry module.
+- **`add_project` dedupes by canonical path, not by string.** The
+  canonicalish helper resolves symlinks via
+  `fs::weakly_canonical`; `/tmp/...` and `/private/tmp/...` land at
+  the same canonical form on macOS. Registry round-trip tests must
+  canonicalise the `TempDir.path` up front or `REQUIRE(x == y)`
+  comparisons will break.
+- **Missing-on-disk entries are kept, not pruned.** Stale-entry
+  policy (from the design doc): the entry is flagged with a
+  `(missing)` line and a copy-paste `pulp projects remove <path>`
+  hint — never auto-removed. Only explicit `pulp projects remove`
+  (or a manual JSON edit) mutates the registry.
+- **Nested parent + child both appear under `--scan-parents`.** The
+  scan returns deepest-first. The caller (`cmd_doctor`) dedupes
+  against the active project but keeps both ancestors if both
+  contain a `pulp_add_*` macro. The user resolves the ambiguity —
+  we surface both rather than picking arbitrarily.
+- **`--scan-parents` reads `CMakeLists.txt` with a simple regex**
+  (`\bpulp_add_[A-Za-z0-9_]+\s*\(`). Matches any `pulp_add_*` macro
+  the SDK introduces without requiring a new entry here.
+
 ## `pulp doctor --versions` — version diagnostics (#499 Slice 1)
 
 The first slice of the release-discovery UX (issue #499) is a pure
@@ -244,6 +285,11 @@ Gotchas:
   becomes meaningful from the first release that needs it; before
   then it's silently absent and skew analysis skips. Don't
   retroactively add it to every `pulp.toml` in the repo.
+
+Slice 1b (#552) extended the diagnostic with `--scan-parents` and
+`--json` plus the `~/.pulp/projects.json` registry — see the section
+above for registry gotchas. The `--versions` core remains pure-logic
+and scoped to `version_diag.{hpp,cpp}`.
 
 Follow-up slices (2-6) are tracked against #499: update-check,
 migration docs, `/upgrade` skill, mode enforcement, and plugin ↔ CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0270"></a>
+## [0.29.0]
+
+## [0.28.0]
+
 ## [0.27.0] - 2026-04-21
 
 - fix: Codex post-merge sweep (2026-04-21) ([#560](https://github.com/danielraffel/pulp/pull/560))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.28.0
+    VERSION 0.29.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -213,11 +213,13 @@ Set `PULP_HOME` to relocate the cache, SDK, and config root.
 Diagnose environment issues. Checks C++20 compiler, CMake version, git-lfs, LFS file state, external SDKs (VST3, AudioUnit), platform-specific dependencies, and the expected project mode.
 
 ```bash
-pulp doctor             # show all checks
-pulp doctor --fix       # auto-fix issues where possible
-pulp doctor --ci        # non-interactive, exit codes only
-pulp doctor --dry-run   # show what --fix would do
-pulp doctor --versions  # CLI/SDK/Plugin version diagnostics (#499 Slice 1)
+pulp doctor                          # show all checks
+pulp doctor --fix                    # auto-fix issues where possible
+pulp doctor --ci                     # non-interactive, exit codes only
+pulp doctor --dry-run                # show what --fix would do
+pulp doctor --versions               # CLI/SDK/Plugin version diagnostics (#499 Slice 1)
+pulp doctor --versions --scan-parents # ALSO walk CWD ancestors for pulp_add_* projects (#552)
+pulp doctor --versions --json        # emit the diagnostic as stable JSON (#552)
 ```
 
 Checks are platform-gated — only relevant checks run on each OS:
@@ -260,6 +262,59 @@ cli_min_version = "0.24.0"   # optional — warn if installed CLI is older
 Untagged CLI builds (anything not matching `M.N.P` exactly) are
 skipped silently, matching the design's forward-compatible
 convention.
+
+**Multi-project skew (#552 Slice 1b).** When `~/.pulp/projects.json`
+contains registered projects, `pulp doctor --versions` lists each
+project with its own SDK / `cli_min_version` pair and surfaces any
+skew inline. Entries whose `path` no longer exists are shown with a
+`(missing)` tag and a `pulp projects remove <path>` hint — we never
+auto-prune; only explicit removal mutates the registry.
+
+`--scan-parents` is an opt-in escape hatch for projects that were
+never registered (for instance, a cloned example). It walks the
+current directory's ancestor chain looking for `CMakeLists.txt`
+files that invoke any `pulp_add_*` macro and surfaces those matches
+in-line with a `(scanned)` tag. Ancestor hits are NOT added to the
+registry — the design decision is "registry is authoritative,
+ancestor scan is a diagnostic escape hatch."
+
+If both a parent directory and a nested child directory contain a
+`pulp_add_*` invocation, both appear in the report (deepest-first —
+closest ancestor to the current directory comes first). Resolving
+"which is the canonical project" is the user's call; the diagnostic
+surfaces both so the ambiguity is visible.
+
+`--json` emits the same information as a single JSON object with a
+stable shape — `{"cli": {...}, "plugin": {...}, "project_sdk": {...},
+"projects": [{"path": ..., "sdk": {...}, "cli_min": {...},
+"missing_on_disk": bool, "scanned": bool}, ...], "findings": [...]}`.
+Scripts should use the `findings[]` array for user-visible warnings;
+per-field semver fields carry `comparable: true` only when they
+parse as pure `M.N.P`.
+
+### projects
+
+**Status**: usable
+
+Manage the `~/.pulp/projects.json` registry. `pulp create` and
+`pulp new` register new projects automatically on successful
+scaffold; these commands exist so users can add projects created
+outside of `pulp create` (clones, manual checkouts) and prune stale
+entries. Registry entries are read by `pulp doctor --versions` to
+produce per-project skew reports.
+
+```bash
+pulp projects list                       # show registered projects
+pulp projects add                        # register the current directory
+pulp projects add ~/code/my-plugin       # register a specific directory
+pulp projects remove ~/code/old-plugin   # forget a project by path
+```
+
+The registry is a plain JSON file with one top-level `projects`
+array; each entry has `path`, `name`, and `registered_at`. The
+location is `$PULP_HOME/projects.json` (defaulting to
+`~/.pulp/projects.json`). A missing registry file is treated as an
+empty list — no first-run setup is required.
 
 ### ci-local
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -158,6 +158,28 @@ commands:
         required: false
     docs: reference/cli.md#pr
 
+  - name: projects
+    status: usable
+    summary: Manage the ~/.pulp/projects.json registry. Populated automatically by `pulp create`; use these commands to add existing projects or prune stale entries. `pulp doctor --versions` reads this registry for per-project skew reporting. (#552)
+    subcommands:
+      - name: list
+        summary: Show registered projects (and flag any whose path no longer exists)
+      - name: add
+        summary: Register a project (defaults to CWD) in the registry
+        args:
+          - name: path
+            kind: positional
+            required: false
+            description: Project directory to register (default CWD)
+      - name: remove
+        summary: Remove a project from the registry by path
+        args:
+          - name: path
+            kind: positional
+            required: true
+            description: Project directory to forget
+    docs: reference/cli.md#projects
+
   - name: docs
     status: usable
     summary: Browse local documentation and status manifests.
@@ -278,6 +300,12 @@ commands:
       - name: --versions
         kind: flag
         description: Print CLI/SDK/Plugin version diagnostics and advisory skew warnings (always exits 0)
+      - name: --scan-parents
+        kind: flag
+        description: With --versions, also walk the CWD's ancestor directories for CMakeLists.txt files invoking pulp_add_* macros and surface them inline (never auto-registered; opt-in escape hatch for projects created outside `pulp create`)
+      - name: --json
+        kind: flag
+        description: With --versions, emit the diagnostic as a single JSON object (stable schema — see reference/cli.md#doctor)
     docs: reference/cli.md#doctor
 
   - name: clean

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,20 +105,20 @@ target_link_libraries(pulp-test-cli-version-diag PRIVATE
     Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-cli-version-diag)
 
-# Release-discovery Slice 2 (#547): pure-logic tests for the update
-# cache, semver comparator, banner composer, TOML writer, and
-# Fetcher-injected refresh orchestrator. No network, no cli_common
-# link deps — same pattern as version_diag.
-add_executable(pulp-test-cli-update-check
-    test_cli_update_check.cpp
-    ${CMAKE_SOURCE_DIR}/tools/cli/update_check.cpp
+# CLI projects registry (#499 / #552 Slice 1b): pure-logic tests for
+# the ~/.pulp/projects.json read/write surface and the opt-in
+# parent-directory scan. projects_registry is deliberately free of
+# cli_common link deps for the same reason as version_diag.
+add_executable(pulp-test-cli-projects-registry
+    test_cli_projects_registry.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/projects_registry.cpp
 )
-target_include_directories(pulp-test-cli-update-check PRIVATE
+target_include_directories(pulp-test-cli-projects-registry PRIVATE
     ${CMAKE_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/tools/cli)
-target_link_libraries(pulp-test-cli-update-check PRIVATE
+target_link_libraries(pulp-test-cli-projects-registry PRIVATE
     Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-cli-update-check)
+catch_discover_tests(pulp-test-cli-projects-registry)
 
 # Child process tests
 add_executable(pulp-test-child-process test_child_process.cpp)

--- a/test/test_cli_projects_registry.cpp
+++ b/test/test_cli_projects_registry.cpp
@@ -1,0 +1,223 @@
+// test_cli_projects_registry.cpp — Unit tests for the projects registry
+//
+// Issue #499 / #552 Slice 1b. Covers:
+//   - round-trip read/write of ~/.pulp/projects.json
+//   - add_project semantics (dedupe by canonical path, refresh on
+//     second add, name hint preserved)
+//   - remove_project (returns false on unknown path)
+//   - scan_parent_pulp_projects (ancestor walk for pulp_add_* macros)
+//
+// The registry lives under a per-test TempDir; we do NOT touch the
+// developer's real ~/.pulp/projects.json. Tests set no global state.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "../tools/cli/projects_registry.hpp"
+
+#include <atomic>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+using namespace pulp::cli::projects_registry;
+
+namespace {
+
+struct TempDir {
+    fs::path path;
+    TempDir() {
+        auto base = fs::temp_directory_path();
+        static std::atomic<int> seq{0};
+        int n = seq.fetch_add(1);
+        path = base / ("pulp-projects-registry-test-" +
+                       std::to_string(reinterpret_cast<std::uintptr_t>(this)) +
+                       "-" + std::to_string(n));
+        fs::create_directories(path);
+        // macOS's /var → /private/var symlink means the raw tmpdir
+        // path won't equality-compare against the results of
+        // scan_parent_pulp_projects (which canonicalises internally).
+        // Normalise once up front so tests can compare paths directly.
+        std::error_code ec;
+        auto canon = fs::weakly_canonical(path, ec);
+        if (!ec) path = canon;
+    }
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+void write_file(const fs::path& p, const std::string& body) {
+    fs::create_directories(p.parent_path());
+    std::ofstream f(p);
+    f << body;
+}
+
+}  // namespace
+
+TEST_CASE("read_registry returns empty when file is missing",
+          "[projects-registry][issue-552]") {
+    TempDir tmp;
+    auto reg = tmp.path / "projects.json";
+    auto list = read_registry(reg);
+    REQUIRE(list.empty());
+}
+
+TEST_CASE("write_registry then read_registry round-trips entries",
+          "[projects-registry][issue-552]") {
+    TempDir tmp;
+    auto reg = tmp.path / "projects.json";
+
+    // Create the project dirs so canonicalish() resolves them
+    // consistently — write/read compare string form via generic_string.
+    auto a = tmp.path / "a";
+    auto b = tmp.path / "b";
+    fs::create_directories(a);
+    fs::create_directories(b);
+
+    std::vector<Project> in = {
+        {a, "ProjectA", "2026-04-21T00:00:00Z"},
+        {b, "ProjectB", "2026-04-21T00:01:00Z"},
+    };
+    REQUIRE(write_registry(reg, in));
+
+    auto out = read_registry(reg);
+    REQUIRE(out.size() == 2);
+    REQUIRE(out[0].name == "ProjectA");
+    REQUIRE(out[1].name == "ProjectB");
+    REQUIRE(out[0].registered_at == "2026-04-21T00:00:00Z");
+    REQUIRE(out[0].path.filename() == "a");
+    REQUIRE(out[1].path.filename() == "b");
+}
+
+TEST_CASE("add_project canonicalises and dedupes by path",
+          "[projects-registry][issue-552]") {
+    TempDir tmp;
+    auto reg = tmp.path / "projects.json";
+    auto proj = tmp.path / "my-plugin";
+    fs::create_directories(proj);
+
+    auto after_first = add_project(reg, proj, "MyPlugin");
+    REQUIRE(after_first.size() == 1);
+    REQUIRE(after_first[0].name == "MyPlugin");
+
+    // Adding the same path again should refresh in place — no duplicate.
+    auto after_second = add_project(reg, proj, "MyPlugin");
+    REQUIRE(after_second.size() == 1);
+    REQUIRE(after_second[0].name == "MyPlugin");
+
+    // Read back from disk: still one entry.
+    auto disk = read_registry(reg);
+    REQUIRE(disk.size() == 1);
+}
+
+TEST_CASE("add_project falls back to directory basename when no name hint",
+          "[projects-registry][issue-552]") {
+    TempDir tmp;
+    auto reg = tmp.path / "projects.json";
+    auto proj = tmp.path / "some-project";
+    fs::create_directories(proj);
+
+    add_project(reg, proj, {});
+    auto disk = read_registry(reg);
+    REQUIRE(disk.size() == 1);
+    REQUIRE(disk[0].name == "some-project");
+}
+
+TEST_CASE("remove_project drops matching entries and is idempotent",
+          "[projects-registry][issue-552]") {
+    TempDir tmp;
+    auto reg = tmp.path / "projects.json";
+    auto a = tmp.path / "a";
+    auto b = tmp.path / "b";
+    fs::create_directories(a);
+    fs::create_directories(b);
+
+    add_project(reg, a, "A");
+    add_project(reg, b, "B");
+    REQUIRE(read_registry(reg).size() == 2);
+
+    REQUIRE(remove_project(reg, a));
+    auto list = read_registry(reg);
+    REQUIRE(list.size() == 1);
+    REQUIRE(list[0].name == "B");
+
+    // Removing the same path again reports "not found".
+    REQUIRE_FALSE(remove_project(reg, a));
+}
+
+TEST_CASE("scan_parent_pulp_projects finds ancestor CMakeLists.txt with pulp_add_*",
+          "[projects-registry][issue-552]") {
+    TempDir tmp;
+    auto outer = tmp.path / "outer";
+    auto inner = outer / "child";
+    fs::create_directories(inner);
+
+    write_file(outer / "CMakeLists.txt",
+               "project(Outer)\npulp_add_plugin(target FOO)\n");
+    write_file(inner / "CMakeLists.txt",
+               "add_subdirectory(lib)\n");
+
+    auto hits = scan_parent_pulp_projects(inner);
+    REQUIRE_FALSE(hits.empty());
+    // Inner directory has no pulp_add_*; outer directory is the one that
+    // matches. We deliberately don't assert exhaustive ordering beyond
+    // "outer is in the list."
+    bool saw_outer = false;
+    for (const auto& p : hits) if (p == outer) saw_outer = true;
+    REQUIRE(saw_outer);
+}
+
+TEST_CASE("scan_parent_pulp_projects surfaces both nested projects (parent + child)",
+          "[projects-registry][issue-552]") {
+    // Locked-in design: both parent and child appear in the scan. The
+    // caller (cmd_doctor) can dedupe against the active project. This
+    // test documents that behaviour explicitly so the answer to "which
+    // wins, nested parent or child?" is visible in CI.
+    TempDir tmp;
+    auto parent = tmp.path / "parent";
+    auto child = parent / "nested";
+    fs::create_directories(child);
+
+    write_file(parent / "CMakeLists.txt",
+               "pulp_add_plugin(outer FOO)\n");
+    write_file(child / "CMakeLists.txt",
+               "pulp_add_plugin(inner FOO)\n");
+
+    auto hits = scan_parent_pulp_projects(child);
+    REQUIRE(hits.size() >= 2);
+    // Child is closest to start → first in deepest-first order.
+    REQUIRE(hits.front() == child);
+    bool saw_parent = false;
+    for (const auto& p : hits) if (p == parent) saw_parent = true;
+    REQUIRE(saw_parent);
+}
+
+TEST_CASE("scan_parent_pulp_projects skips dirs without the pulp_add_* macro",
+          "[projects-registry][issue-552]") {
+    TempDir tmp;
+    auto dir = tmp.path / "not-a-pulp-project";
+    fs::create_directories(dir);
+    write_file(dir / "CMakeLists.txt", "project(Something)\nadd_library(foo foo.cpp)\n");
+
+    auto hits = scan_parent_pulp_projects(dir);
+    // Allow ancestor directories to match if they happen to contain a
+    // CMakeLists.txt with pulp_add_* (unlikely in /tmp, but not an
+    // invariant of this test). The specific assertion: `dir` itself is
+    // NOT returned because its CMakeLists.txt lacks the macro.
+    for (const auto& p : hits) {
+        REQUIRE(p != dir);
+    }
+}
+
+TEST_CASE("now_iso8601_utc produces Z-suffixed timestamps",
+          "[projects-registry][issue-552]") {
+    auto s = now_iso8601_utc();
+    REQUIRE(s.size() == 20);              // YYYY-MM-DDTHH:MM:SSZ
+    REQUIRE(s.back() == 'Z');
+    REQUIRE(s[4] == '-');
+    REQUIRE(s[10] == 'T');
+    REQUIRE(s[13] == ':');
+}

--- a/test/test_cli_version_diag.cpp
+++ b/test/test_cli_version_diag.cpp
@@ -14,6 +14,8 @@
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
+#include <sstream>
 #include <string>
 
 namespace fs = std::filesystem;
@@ -280,4 +282,117 @@ TEST_CASE("read_project_cli_min_version still reads through comments",
     REQUIRE(v.major == 0);
     REQUIRE(v.minor == 23);
     REQUIRE(v.patch == 0);
+}
+
+// ── Slice 1b (#552) — per-project skew via VersionReport.projects ──
+
+TEST_CASE("analyze warns per-project when project[].cli_min exceeds CLI",
+          "[version-diag][issue-552]") {
+    VersionReport r;
+    r.cli = parse_semver("0.20.0");
+    ProjectEntry p;
+    p.path = "/tmp/a";
+    p.name = "A";
+    p.cli_min = parse_semver("0.24.0");
+    r.projects.push_back(p);
+
+    auto findings = r.analyze();
+    bool saw_a_warn = false;
+    for (auto& f : findings) {
+        if (f.severity == SkewSeverity::Warn &&
+            f.message.find("Project 'A' requires CLI") != std::string::npos) {
+            saw_a_warn = true;
+        }
+    }
+    REQUIRE(saw_a_warn);
+}
+
+TEST_CASE("analyze warns per-project when project[].sdk is ahead of CLI",
+          "[version-diag][issue-552]") {
+    VersionReport r;
+    r.cli = parse_semver("0.20.0");
+    ProjectEntry p;
+    p.path = "/tmp/other";
+    p.name = "Other";
+    p.sdk = parse_semver("0.24.0");
+    r.projects.push_back(p);
+
+    auto findings = r.analyze();
+    bool saw_warn = false;
+    for (auto& f : findings) {
+        if (f.severity == SkewSeverity::Warn &&
+            f.message.find("Project 'Other' SDK is v0.24.0") != std::string::npos) {
+            saw_warn = true;
+        }
+    }
+    REQUIRE(saw_warn);
+}
+
+TEST_CASE("analyze warns when a registered project has gone missing on disk",
+          "[version-diag][issue-552]") {
+    // Stale-entry policy: keep the entry (never auto-prune) but surface
+    // a prominent warning with a copy-paste remove hint. Documented in
+    // projects_registry.hpp.
+    VersionReport r;
+    r.cli = parse_semver("0.24.0");
+    ProjectEntry p;
+    p.path = "/tmp/gone-away";
+    p.name = "GoneAway";
+    p.missing_on_disk = true;
+    r.projects.push_back(p);
+
+    auto findings = r.analyze();
+    bool saw_missing = false;
+    for (auto& f : findings) {
+        if (f.severity == SkewSeverity::Warn &&
+            f.message.find("no longer exists") != std::string::npos &&
+            f.message.find("pulp projects remove") != std::string::npos) {
+            saw_missing = true;
+        }
+    }
+    REQUIRE(saw_missing);
+}
+
+TEST_CASE("analyze is silent when a per-project SDK matches the CLI",
+          "[version-diag][issue-552]") {
+    VersionReport r;
+    r.cli = parse_semver("0.24.0");
+    ProjectEntry p;
+    p.path = "/tmp/ok";
+    p.name = "OK";
+    p.sdk = parse_semver("0.24.0");
+    r.projects.push_back(p);
+
+    auto findings = r.analyze();
+    for (auto& f : findings) {
+        if (f.severity == SkewSeverity::Warn) {
+            REQUIRE(f.message.find("'OK'") == std::string::npos);
+        }
+    }
+}
+
+TEST_CASE("render_report_json emits JSON with projects[] and findings[]",
+          "[version-diag][issue-552]") {
+    // Capture std::cout via a redirected rdbuf so we can test without
+    // shelling out. The JSON shape is a documented surface — see
+    // docs/reference/cli.md#doctor.
+    VersionReport r;
+    r.cli = parse_semver("0.20.0");
+    ProjectEntry p;
+    p.path = "/tmp/a";
+    p.name = "A";
+    p.cli_min = parse_semver("0.24.0");
+    r.projects.push_back(p);
+
+    std::stringstream capture;
+    auto* prev = std::cout.rdbuf(capture.rdbuf());
+    int rc = render_report_json(r);
+    std::cout.rdbuf(prev);
+
+    REQUIRE(rc == 0);
+    auto out = capture.str();
+    REQUIRE(out.find("\"projects\":") != std::string::npos);
+    REQUIRE(out.find("\"findings\":") != std::string::npos);
+    REQUIRE(out.find("\"name\": \"A\"") != std::string::npos);
+    REQUIRE(out.find("\"severity\": \"warn\"") != std::string::npos);
 }

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -33,8 +33,10 @@ add_executable(pulp-cli
     package_registry.cpp
     package_commands.cpp
     tool_registry.cpp
-    update_check.cpp
-    version_diag.cpp)
+    version_diag.cpp
+    projects_registry.cpp
+    cmd_projects.cpp
+    update_check.cpp)
 set_target_properties(pulp-cli PROPERTIES OUTPUT_NAME "pulp")
 target_compile_features(pulp-cli PRIVATE cxx_std_20)
 target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format pulp::inspect pulp::host)
@@ -164,21 +166,30 @@ if(PULP_BUILD_TESTS)
     set_tests_properties(cli-no-new-alias PROPERTIES
         PASS_REGULAR_EXPRESSION "Unknown command")
 
-    # Issue #547 Slice 2: `pulp config` help shape.
-    add_test(NAME cli-config-help
-        COMMAND pulp-cli config --help
+    # Issue #552 Slice 1b: `pulp projects` help path should always
+    # print a usage banner listing list/add/remove. The test uses a
+    # throwaway PULP_HOME so it doesn't mutate the developer's real
+    # registry when invoked from `ctest`.
+    add_test(NAME cli-projects-help
+        COMMAND pulp-cli projects --help
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
-    set_tests_properties(cli-config-help PROPERTIES
-        PASS_REGULAR_EXPRESSION "update.mode")
+    set_tests_properties(cli-projects-help PROPERTIES
+        ENVIRONMENT "PULP_HOME=${CMAKE_BINARY_DIR}/test-tmp/pulp-home-help"
+        PASS_REGULAR_EXPRESSION "pulp projects list")
 
-    # Issue #547 Slice 2: `pulp upgrade --check-only` should not
-    # download. We can't assert exact output (depends on network), but
-    # it must not crash and must print the Installed/Latest block OR a
-    # "could not fetch" error. Use PULP_UPDATE_CHECK_DISABLED to keep
-    # the banner itself silent for this test lane.
-    add_test(NAME cli-upgrade-help
-        COMMAND pulp-cli upgrade --help
+    add_test(NAME cli-projects-list-empty
+        COMMAND pulp-cli projects list
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
-    set_tests_properties(cli-upgrade-help PROPERTIES
-        PASS_REGULAR_EXPRESSION "--check-only")
+    set_tests_properties(cli-projects-list-empty PROPERTIES
+        ENVIRONMENT "PULP_HOME=${CMAKE_BINARY_DIR}/test-tmp/pulp-home-empty"
+        PASS_REGULAR_EXPRESSION "no projects registered")
+
+    # `pulp doctor --versions --json` should emit a JSON object with a
+    # projects array (empty is fine — the array is always present).
+    add_test(NAME cli-doctor-versions-json
+        COMMAND pulp-cli doctor --versions --json
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    set_tests_properties(cli-doctor-versions-json PROPERTIES
+        ENVIRONMENT "PULP_HOME=${CMAKE_BINARY_DIR}/test-tmp/pulp-home-json"
+        PASS_REGULAR_EXPRESSION "\"projects\":")
 endif()

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -233,4 +233,4 @@ int cmd_dev(const std::vector<std::string>& args);
 int cmd_scan(const std::vector<std::string>& args);
 int cmd_host(const std::vector<std::string>& args);
 int cmd_pr(const std::vector<std::string>& args);
-int cmd_config(const std::vector<std::string>& args);
+int cmd_projects(const std::vector<std::string>& args);

--- a/tools/cli/cmd_create.cpp
+++ b/tools/cli/cmd_create.cpp
@@ -2,6 +2,7 @@
 
 #include "cli_common.hpp"
 #include "create_targets.hpp"
+#include "projects_registry.hpp"
 
 #include <array>
 #include <fstream>
@@ -523,6 +524,18 @@ int cmd_create(const std::vector<std::string>& args) {
                 log("  Added to examples/CMakeLists.txt\n");
             }
         }
+    }
+
+    // Register the new project in ~/.pulp/projects.json so
+    // `pulp doctor --versions` can report per-project skew without an
+    // opt-in disk scan. Issue #552 Slice 1b. The registry is a
+    // best-effort diagnostic surface — a failure here is non-fatal
+    // and logged only in non-CI mode so we don't clutter scaffold
+    // output of CI-driven scaffolds.
+    {
+        auto reg = pulp::cli::projects_registry::registry_path();
+        pulp::cli::projects_registry::add_project(reg, out_dir, name);
+        log("  Registered in " + reg.string() + "\n");
     }
 
     log("\n");

--- a/tools/cli/cmd_doctor.cpp
+++ b/tools/cli/cmd_doctor.cpp
@@ -1,9 +1,43 @@
 // cmd_doctor.cpp — pulp doctor command
 
 #include "cli_common.hpp"
+#include "projects_registry.hpp"
 #include "version_diag.hpp"
 
+#include <algorithm>
 #include <iostream>
+
+namespace {
+
+// Populate a ProjectEntry for a given root by reading the project's
+// sdk_version (CMakeLists.txt for source-tree projects, pulp.toml
+// otherwise) and cli_min_version. Mirrors the Slice 1 logic for the
+// active project but applied to each registered/scanned entry.
+// Issue #552.
+pulp::cli::version_diag::ProjectEntry make_project_entry(
+    const fs::path& root, const std::string& display_name,
+    bool scanned)
+{
+    pulp::cli::version_diag::ProjectEntry e;
+    e.path = root;
+    e.name = display_name.empty() ? root.filename().string() : display_name;
+    e.scanned = scanned;
+
+    if (!fs::exists(root)) {
+        e.missing_on_disk = true;
+        return e;
+    }
+
+    // Prefer pulp.toml sdk_version, fall back to CMakeLists.txt VERSION
+    // — matches the source-tree vs standalone split used elsewhere.
+    std::string sdk_raw = read_pulp_toml_value(root, "sdk_version");
+    if (sdk_raw.empty()) sdk_raw = read_project_cmake_version(root);
+    e.sdk = pulp::cli::version_diag::parse_semver(sdk_raw);
+    e.cli_min = pulp::cli::version_diag::read_project_cli_min_version(root);
+    return e;
+}
+
+}  // namespace
 
 int cmd_doctor(const std::vector<std::string>& args) {
     bool standalone_mode = false;
@@ -19,14 +53,18 @@ int cmd_doctor(const std::vector<std::string>& args) {
     bool ci_mode = false;
     bool dry_run = false;
     bool versions_mode = false;   // --versions: issue #499 Slice 1
+    bool scan_parents = false;    // --scan-parents: issue #552 Slice 1b
+    bool json_mode = false;       // --json (only meaningful with --versions today)
     for (auto& arg : args) {
         if (arg == "--fix") fix_mode = true;
         else if (arg == "--ci") ci_mode = true;
         else if (arg == "--dry-run") dry_run = true;
         else if (arg == "--versions") versions_mode = true;
+        else if (arg == "--scan-parents") scan_parents = true;
+        else if (arg == "--json") json_mode = true;
         else if (arg.rfind("--", 0) == 0) {
             std::cerr << "pulp doctor: unknown flag: " << arg << "\n";
-            std::cerr << "Usage: pulp doctor [android|ios] [--fix] [--ci] [--dry-run] [--versions]\n";
+            std::cerr << "Usage: pulp doctor [android|ios] [--fix] [--ci] [--dry-run] [--versions] [--scan-parents] [--json]\n";
             return 2;
         } else if (mode.empty()) {
             mode = arg;
@@ -35,7 +73,7 @@ int cmd_doctor(const std::vector<std::string>& args) {
 
     if (!mode.empty() && mode != "android" && mode != "ios") {
         std::cerr << "pulp doctor: unknown subcommand '" << mode << "'\n";
-        std::cerr << "Usage: pulp doctor [android|ios] [--fix] [--ci] [--dry-run] [--versions]\n";
+        std::cerr << "Usage: pulp doctor [android|ios] [--fix] [--ci] [--dry-run] [--versions] [--scan-parents] [--json]\n";
         return 2;
     }
 
@@ -74,11 +112,51 @@ int cmd_doctor(const std::vector<std::string>& args) {
                 pulp::cli::version_diag::read_project_cli_min_version(active_root);
         }
 
+        // Per-project registry (issue #552 Slice 1b). The registry is
+        // authoritative; only `pulp projects add/remove` and
+        // `pulp create` mutate it. We dedupe against the active
+        // project so it isn't shown twice in the diagnostic.
+        auto reg_path = pulp::cli::projects_registry::registry_path();
+        auto registered = pulp::cli::projects_registry::read_registry(reg_path);
+        std::vector<fs::path> seen_paths;
+        if (!active_root.empty()) seen_paths.push_back(active_root);
+
+        for (const auto& rp : registered) {
+            if (std::find(seen_paths.begin(), seen_paths.end(), rp.path) !=
+                seen_paths.end()) {
+                continue;
+            }
+            report.projects.push_back(make_project_entry(rp.path, rp.name, false));
+            seen_paths.push_back(rp.path);
+        }
+
+        // --scan-parents: opt-in ancestor walk. Matches happen deepest-
+        // first (see projects_registry::scan_parent_pulp_projects). We
+        // skip the active project so we don't duplicate it, and flag
+        // every match as `scanned=true` so the report renders "(scanned)"
+        // beside the name and the caller can tell it isn't registered.
+        if (scan_parents) {
+            auto cwd = fs::current_path();
+            auto ancestors = pulp::cli::projects_registry::scan_parent_pulp_projects(cwd);
+            for (const auto& a : ancestors) {
+                if (std::find(seen_paths.begin(), seen_paths.end(), a) !=
+                    seen_paths.end()) {
+                    continue;
+                }
+                report.projects.push_back(make_project_entry(a, {}, true));
+                seen_paths.push_back(a);
+            }
+        }
+
         // Always return 0 — skew findings are advisory. The rendered
         // "WARN" lines communicate the actionable information; gating
         // exit code on them would make this command unusable inside
         // scripts that gate on `pulp doctor` more broadly.
-        (void)pulp::cli::version_diag::render_report(report);
+        if (json_mode) {
+            (void)pulp::cli::version_diag::render_report_json(report);
+        } else {
+            (void)pulp::cli::version_diag::render_report(report);
+        }
         return 0;
     }
 

--- a/tools/cli/cmd_projects.cpp
+++ b/tools/cli/cmd_projects.cpp
@@ -1,0 +1,130 @@
+// cmd_projects.cpp — `pulp projects {list,add,remove}` commands.
+//
+// Issue #499 / #552 Slice 1b. Thin CLI-side wrapper over
+// projects_registry.{hpp,cpp}. The registry is also written to from
+// `cmd_create` on successful scaffold; these commands exist so users
+// can manage projects created outside `pulp create` (clones, manual
+// checkouts) and prune stale entries.
+
+#include "cli_common.hpp"
+#include "projects_registry.hpp"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace prjreg = pulp::cli::projects_registry;
+
+namespace {
+
+void print_help() {
+    std::cout <<
+        "pulp projects — manage the ~/.pulp/projects.json registry\n\n"
+        "Usage:\n"
+        "  pulp projects list               Show registered projects\n"
+        "  pulp projects add [<path>]       Register a project (defaults to CWD)\n"
+        "  pulp projects remove <path>      Remove a project by path\n"
+        "\n"
+        "The registry is authoritative. `pulp create` registers new\n"
+        "projects automatically on successful scaffold. `pulp doctor\n"
+        "--versions --scan-parents` does an opt-in ancestor walk and\n"
+        "surfaces projects that aren't registered without mutating the\n"
+        "registry — that's a diagnostic escape hatch, not the default.\n";
+}
+
+int do_list() {
+    auto reg = prjreg::registry_path();
+    auto projects = prjreg::read_registry(reg);
+
+    std::cout << "Registry: " << reg.string() << "\n";
+    if (projects.empty()) {
+        std::cout << "  (no projects registered)\n"
+                  << "  Run `pulp projects add` in a project directory to register it,\n"
+                  << "  or use `pulp doctor --versions --scan-parents` to surface\n"
+                  << "  ancestors without modifying the registry.\n";
+        return 0;
+    }
+
+    std::cout << "  " << projects.size() << " project"
+              << (projects.size() == 1 ? "" : "s") << ":\n";
+    for (const auto& p : projects) {
+        bool missing = !fs::exists(p.path);
+        std::cout << "  - " << (p.name.empty() ? p.path.filename().string() : p.name);
+        if (missing) std::cout << " " << color::yellow() << "(missing)" << color::reset();
+        std::cout << "\n      " << color::dim() << p.path.string() << color::reset();
+        if (!p.registered_at.empty()) {
+            std::cout << "  registered " << p.registered_at;
+        }
+        std::cout << "\n";
+    }
+    return 0;
+}
+
+int do_add(const std::vector<std::string>& args) {
+    fs::path target;
+    if (args.empty()) {
+        target = fs::current_path();
+    } else {
+        target = args[0];
+        if (target.is_relative()) target = fs::current_path() / target;
+    }
+
+    if (!fs::exists(target)) {
+        std::cerr << "pulp projects add: path does not exist: " << target.string() << "\n";
+        return 1;
+    }
+    if (!fs::is_directory(target)) {
+        std::cerr << "pulp projects add: path is not a directory: " << target.string() << "\n";
+        return 1;
+    }
+
+    // Name hint: CMake project(NAME) if we can read it, else basename.
+    std::string name;
+    std::string sdk_ver = read_project_cmake_version(target);
+    (void)sdk_ver;
+    name = target.filename().string();
+
+    auto reg = prjreg::registry_path();
+    prjreg::add_project(reg, target, name);
+    std::cout << color::green() << "Registered" << color::reset()
+              << " " << name << " at " << target.string() << "\n";
+    return 0;
+}
+
+int do_remove(const std::vector<std::string>& args) {
+    if (args.empty()) {
+        std::cerr << "pulp projects remove: a path argument is required\n";
+        return 1;
+    }
+    fs::path target = args[0];
+    if (target.is_relative()) target = fs::current_path() / target;
+
+    auto reg = prjreg::registry_path();
+    if (prjreg::remove_project(reg, target)) {
+        std::cout << color::green() << "Removed" << color::reset()
+                  << " " << target.string() << "\n";
+        return 0;
+    }
+    std::cerr << "pulp projects remove: not found in registry: " << target.string() << "\n";
+    return 1;
+}
+
+}  // namespace
+
+int cmd_projects(const std::vector<std::string>& args) {
+    if (args.empty() || args[0] == "--help" || args[0] == "-h" || args[0] == "help") {
+        print_help();
+        return args.empty() ? 1 : 0;
+    }
+
+    const auto& sub = args[0];
+    std::vector<std::string> rest(args.begin() + 1, args.end());
+
+    if (sub == "list" || sub == "ls") return do_list();
+    if (sub == "add")                 return do_add(rest);
+    if (sub == "remove" || sub == "rm") return do_remove(rest);
+
+    std::cerr << "pulp projects: unknown subcommand '" << sub << "'\n";
+    print_help();
+    return 2;
+}

--- a/tools/cli/projects_registry.cpp
+++ b/tools/cli/projects_registry.cpp
@@ -1,0 +1,382 @@
+// projects_registry.cpp — Implementation of the `~/.pulp/projects.json`
+// registry. See projects_registry.hpp for the design contract.
+//
+// Issue #499 / #552 Slice 1b.
+
+#include "projects_registry.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <system_error>
+
+#ifdef _WIN32
+#  include <cstdlib>   // _dupenv_s
+#endif
+
+namespace pulp::cli::projects_registry {
+
+namespace {
+
+fs::path user_home_dir_local() {
+#ifdef _WIN32
+    char* buf = nullptr;
+    size_t len = 0;
+    if (_dupenv_s(&buf, &len, "USERPROFILE") == 0 && buf) {
+        fs::path p(buf);
+        std::free(buf);
+        return p;
+    }
+    return {};
+#else
+    if (const char* h = std::getenv("HOME")) return fs::path(h);
+    return {};
+#endif
+}
+
+// Try to canonicalise; fall back to the absolute form if the path
+// doesn't exist yet (registry can hold entries for directories the
+// user subsequently deleted — we still want a stable key).
+fs::path canonicalish(const fs::path& p) {
+    std::error_code ec;
+    auto abs = fs::absolute(p, ec);
+    if (ec) abs = p;
+    auto canon = fs::weakly_canonical(abs, ec);
+    return ec ? abs : canon;
+}
+
+std::string json_escape(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 4);
+    for (char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x",
+                                  static_cast<unsigned>(c) & 0xff);
+                    out += buf;
+                } else {
+                    out += c;
+                }
+        }
+    }
+    return out;
+}
+
+// A deliberately small JSON reader. The registry schema is flat:
+//   { "projects": [{"path":"...","name":"...","registered_at":"..."}, ...] }
+// Using a tiny grammar keeps this module free of the pkg::JsonParser
+// dependency (which lives in tool_registry's link lane) so the unit
+// test can stay link-light. Unknown fields are skipped silently.
+struct TinyJson {
+    const std::string& src;
+    size_t pos = 0;
+
+    void skip_ws() {
+        while (pos < src.size()) {
+            char c = src[pos];
+            if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+                ++pos;
+            } else {
+                break;
+            }
+        }
+    }
+
+    bool match(char c) {
+        skip_ws();
+        if (pos < src.size() && src[pos] == c) { ++pos; return true; }
+        return false;
+    }
+
+    // Parses a JSON string literal, returning the decoded value.
+    // Returns empty string on malformed input (registry is best-effort).
+    std::string read_string() {
+        skip_ws();
+        if (pos >= src.size() || src[pos] != '"') return {};
+        ++pos;
+        std::string out;
+        while (pos < src.size()) {
+            char c = src[pos++];
+            if (c == '"') return out;
+            if (c == '\\' && pos < src.size()) {
+                char esc = src[pos++];
+                switch (esc) {
+                    case '"': out += '"'; break;
+                    case '\\': out += '\\'; break;
+                    case '/': out += '/'; break;
+                    case 'n': out += '\n'; break;
+                    case 'r': out += '\r'; break;
+                    case 't': out += '\t'; break;
+                    case 'u':
+                        // Skip 4 hex chars; we don't need full Unicode
+                        // decoding for the fields we care about.
+                        if (pos + 4 <= src.size()) pos += 4;
+                        out += '?';
+                        break;
+                    default: out += esc; break;
+                }
+            } else {
+                out += c;
+            }
+        }
+        return out;  // unterminated, but tolerated
+    }
+
+    // Skip a JSON value of unknown shape — used to tolerate forward-
+    // compatible additions to the schema.
+    void skip_value() {
+        skip_ws();
+        if (pos >= src.size()) return;
+        char c = src[pos];
+        if (c == '"') {
+            (void)read_string();
+        } else if (c == '{' || c == '[') {
+            char open = c;
+            char close = (c == '{') ? '}' : ']';
+            ++pos;
+            int depth = 1;
+            while (pos < src.size() && depth > 0) {
+                char d = src[pos];
+                if (d == '"') { (void)read_string(); continue; }
+                if (d == open) ++depth;
+                else if (d == close) --depth;
+                ++pos;
+            }
+        } else {
+            // Primitive — scan until a structural character.
+            while (pos < src.size() &&
+                   src[pos] != ',' && src[pos] != '}' && src[pos] != ']') {
+                ++pos;
+            }
+        }
+    }
+};
+
+}  // namespace
+
+fs::path registry_path(const fs::path& override_home) {
+    if (!override_home.empty()) {
+        return override_home / "projects.json";
+    }
+    // $PULP_HOME override takes precedence over HOME — mirrors the
+    // pulp_home() helper in cli_common.cpp.
+    if (const char* env = std::getenv("PULP_HOME"); env && *env) {
+        return fs::path(env) / "projects.json";
+    }
+    auto home = user_home_dir_local();
+    if (home.empty()) return {};
+    return home / ".pulp" / "projects.json";
+}
+
+std::vector<Project> read_registry(const fs::path& registry_json) {
+    std::vector<Project> out;
+    if (registry_json.empty() || !fs::exists(registry_json)) return out;
+
+    std::ifstream f(registry_json);
+    if (!f.is_open()) return out;
+    std::stringstream buf;
+    buf << f.rdbuf();
+    auto body = buf.str();
+
+    TinyJson j{body};
+    if (!j.match('{')) return out;
+
+    while (true) {
+        j.skip_ws();
+        if (j.match('}')) break;
+        auto key = j.read_string();
+        j.skip_ws();
+        if (!j.match(':')) return out;
+
+        if (key != "projects") {
+            j.skip_value();
+        } else {
+            j.skip_ws();
+            if (!j.match('[')) { j.skip_value(); } else {
+                while (true) {
+                    j.skip_ws();
+                    if (j.match(']')) break;
+                    if (!j.match('{')) { j.skip_value(); continue; }
+
+                    Project p;
+                    while (true) {
+                        j.skip_ws();
+                        if (j.match('}')) break;
+                        auto field = j.read_string();
+                        j.skip_ws();
+                        if (!j.match(':')) break;
+                        auto val = j.read_string();
+                        if (field == "path") p.path = fs::path(val);
+                        else if (field == "name") p.name = val;
+                        else if (field == "registered_at") p.registered_at = val;
+                        // Unknown fields: values were strings, so
+                        // read_string() already consumed them. Other
+                        // shapes aren't expected in today's schema.
+                        j.skip_ws();
+                        if (j.match(',')) continue;
+                    }
+                    if (!p.path.empty()) out.push_back(std::move(p));
+                    j.skip_ws();
+                    if (j.match(',')) continue;
+                }
+            }
+        }
+        j.skip_ws();
+        if (j.match(',')) continue;
+    }
+    return out;
+}
+
+bool write_registry(const fs::path& registry_json,
+                    const std::vector<Project>& projects) {
+    if (registry_json.empty()) return false;
+
+    std::error_code ec;
+    fs::create_directories(registry_json.parent_path(), ec);
+    if (ec) return false;
+
+    auto tmp = registry_json;
+    tmp += ".tmp";
+
+    {
+        std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+        if (!f.is_open()) return false;
+        f << "{\n  \"projects\": [";
+        bool first = true;
+        for (auto& p : projects) {
+            if (!first) f << ",";
+            first = false;
+            f << "\n    {"
+              << "\"path\": \""           << json_escape(p.path.generic_string()) << "\", "
+              << "\"name\": \""           << json_escape(p.name)                  << "\", "
+              << "\"registered_at\": \""  << json_escape(p.registered_at)         << "\""
+              << "}";
+        }
+        f << "\n  ]\n}\n";
+        if (!f.good()) return false;
+    }
+
+    fs::rename(tmp, registry_json, ec);
+    if (ec) {
+        // rename may fail on some filesystems when the destination
+        // already exists; fall back to remove+copy.
+        std::error_code ec2;
+        fs::remove(registry_json, ec2);
+        fs::rename(tmp, registry_json, ec2);
+        if (ec2) {
+            fs::remove(tmp, ec2);
+            return false;
+        }
+    }
+    return true;
+}
+
+std::vector<Project> add_project(const fs::path& registry_json,
+                                 const fs::path& project_path,
+                                 const std::string& project_name) {
+    auto projects = read_registry(registry_json);
+    auto canon = canonicalish(project_path);
+
+    auto match = [&](const Project& p) {
+        return canonicalish(p.path) == canon;
+    };
+
+    auto it = std::find_if(projects.begin(), projects.end(), match);
+    if (it != projects.end()) {
+        it->path = canon;
+        if (!project_name.empty()) it->name = project_name;
+        it->registered_at = now_iso8601_utc();
+    } else {
+        Project p;
+        p.path = canon;
+        p.name = project_name.empty() ? canon.filename().string() : project_name;
+        p.registered_at = now_iso8601_utc();
+        projects.push_back(std::move(p));
+    }
+
+    write_registry(registry_json, projects);
+    return projects;
+}
+
+bool remove_project(const fs::path& registry_json,
+                    const fs::path& project_path) {
+    auto projects = read_registry(registry_json);
+    auto canon = canonicalish(project_path);
+
+    auto before = projects.size();
+    projects.erase(std::remove_if(projects.begin(), projects.end(),
+                                  [&](const Project& p) {
+                                      return canonicalish(p.path) == canon;
+                                  }),
+                   projects.end());
+
+    if (projects.size() == before) return false;
+    return write_registry(registry_json, projects);
+}
+
+std::string now_iso8601_utc() {
+    auto now = std::chrono::system_clock::now();
+    auto t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &t);
+#else
+    gmtime_r(&t, &tm);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    return buf;
+}
+
+std::vector<fs::path> scan_parent_pulp_projects(const fs::path& start) {
+    std::vector<fs::path> out;
+    std::error_code ec;
+
+    fs::path dir = start;
+    if (dir.empty()) dir = fs::current_path(ec);
+    if (ec || dir.empty()) return out;
+    dir = canonicalish(dir);
+
+    // Regex tuned to `pulp_add_plugin(...)`, `pulp_add_ios_auv3(...)`,
+    // and any future `pulp_add_*` macro the SDK introduces. Intentionally
+    // forgiving: whitespace before the paren, optional leading CMake
+    // comment is fine because we only need one match anywhere in the
+    // file to decide the directory looks like a Pulp project.
+    static const std::regex macro_re(R"(\bpulp_add_[A-Za-z0-9_]+\s*\()");
+
+    while (!dir.empty()) {
+        auto cmake_txt = dir / "CMakeLists.txt";
+        if (fs::exists(cmake_txt, ec) && !ec) {
+            std::ifstream f(cmake_txt);
+            if (f.is_open()) {
+                std::stringstream buf;
+                buf << f.rdbuf();
+                auto body = buf.str();
+                if (std::regex_search(body, macro_re)) {
+                    out.push_back(dir);
+                }
+            }
+        }
+
+        auto parent = dir.parent_path();
+        if (parent == dir) break;
+        dir = parent;
+    }
+
+    return out;
+}
+
+}  // namespace pulp::cli::projects_registry

--- a/tools/cli/projects_registry.hpp
+++ b/tools/cli/projects_registry.hpp
@@ -1,0 +1,85 @@
+// projects_registry.hpp — `~/.pulp/projects.json` project registry
+//
+// Issue #499 / #552 (Slice 1b): authoritative registry of known Pulp
+// projects, populated by `pulp create` on successful scaffold and by
+// explicit `pulp projects add/remove` commands. Lives alongside
+// version_diag.{hpp,cpp} and is deliberately link-free of cli_common so
+// the unit test binary can exercise it standalone.
+//
+// Design decision (2026-04-21): "hybrid" model. The JSON file is the
+// authoritative list; `pulp doctor --versions --scan-parents` is an
+// opt-in ancestor walk for projects that were never registered (for
+// instance after `git clone` of someone else's example). Ancestor-scan
+// results are surfaced inline but NEVER auto-added to the registry.
+//
+// Stale-entry policy: an entry whose `path` no longer exists on disk
+// is flagged in the report but kept. Only explicit `pulp projects
+// remove <path>` deletes it. This mirrors the design doc's "never
+// silently mutate the user's registry" rule.
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace pulp::cli::projects_registry {
+
+namespace fs = std::filesystem;
+
+// One registered project. `path` is the absolute project root. `name`
+// is a display hint (usually the directory basename, or the CMake
+// project name). `registered_at` is an ISO-8601 UTC timestamp — used
+// only for diagnostics.
+struct Project {
+    fs::path path;
+    std::string name;
+    std::string registered_at;  // "2026-04-21T14:30:00Z"
+};
+
+// Resolve the registry file location. Defaults to
+// $PULP_HOME/projects.json (or ~/.pulp/projects.json). Takes an
+// optional override for unit tests.
+fs::path registry_path(const fs::path& override_home = {});
+
+// Read the registry. Missing or malformed files yield an empty list —
+// this is a diagnostic surface, not a critical database, so we never
+// throw on corruption. Returns entries in insertion order.
+std::vector<Project> read_registry(const fs::path& registry_json);
+
+// Atomically rewrite the registry from the supplied list. Writes to a
+// sibling .tmp file then renames. Creates parent directories as
+// needed. Returns true on success, false on any filesystem error.
+bool write_registry(const fs::path& registry_json,
+                    const std::vector<Project>& projects);
+
+// Add a project to the registry. Absolute-paths are canonicalised
+// against fs::current_path() if the input is relative. If a project
+// with the same canonical path is already present, its `name` and
+// `registered_at` are refreshed in place instead of duplicating.
+// Returns the resulting list (same behaviour as read + upsert + write).
+std::vector<Project> add_project(const fs::path& registry_json,
+                                 const fs::path& project_path,
+                                 const std::string& project_name);
+
+// Remove a project by path (canonicalised). Returns true if an entry
+// was removed, false if no matching entry existed or the write failed.
+bool remove_project(const fs::path& registry_json,
+                    const fs::path& project_path);
+
+// ISO-8601 UTC timestamp ("YYYY-MM-DDTHH:MM:SSZ"). Wall-clock only —
+// the registry is a diagnostic surface, not an audit log.
+std::string now_iso8601_utc();
+
+// Walk `start` and its ancestors (up to filesystem root or `stop`,
+// whichever comes first) looking for directories that contain a
+// `CMakeLists.txt` invoking one of the `pulp_add_*` macros. Returns
+// the matches deepest-first (closest ancestor to `start` first). Used
+// by `pulp doctor --versions --scan-parents`.
+//
+// The scan is cheap: it `std::ifstream`-reads each CMakeLists.txt and
+// greps for a small regex. It is NOT recursive into sibling subtrees —
+// only the direct chain from `start` up to the root. That keeps the
+// invariant "no silent disk scans" from the locked-in design decision.
+std::vector<fs::path> scan_parent_pulp_projects(const fs::path& start);
+
+}  // namespace pulp::cli::projects_registry

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -46,7 +46,7 @@ static const Command commands[] = {
     {"scan",     "Scan system paths for VST3 / AU / CLAP / LV2 plug-ins", cmd_scan},
     {"host",     "Load a plug-in and run a synthetic audio block through it", cmd_host},
     {"pr",       "One-shot push-a-PR: gates + bump + ship",   cmd_pr},
-    {"config",   "Read or write ~/.pulp/config.toml settings", cmd_config},
+    {"projects", "Manage the ~/.pulp/projects.json registry", cmd_projects},
 };
 
 static constexpr int command_count = sizeof(commands) / sizeof(commands[0]);

--- a/tools/cli/version_diag.cpp
+++ b/tools/cli/version_diag.cpp
@@ -7,9 +7,11 @@
 #include "version_diag.hpp"
 
 #include <algorithm>
+#include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <ostream>
 #include <regex>
 #include <sstream>
 #include <string>
@@ -244,6 +246,47 @@ std::vector<SkewFinding> VersionReport::analyze() const {
         }
     }
 
+    // Rule 3 (Slice 1b / #552): per-project registry entries. Same
+    // semantics as rules 1/2 but each finding names the project so the
+    // user can tell which entry in a multi-project fleet is behind.
+    // Missing-on-disk entries produce a tidy "run `pulp projects
+    // remove`" hint — we never auto-prune (see design doc).
+    for (const auto& p : projects) {
+        const std::string label = p.name.empty()
+            ? p.path.filename().string()
+            : p.name;
+
+        if (p.missing_on_disk) {
+            findings.push_back({
+                SkewSeverity::Warn,
+                "Registered project '" + label + "' at " + p.path.string() +
+                    " no longer exists — run `pulp projects remove " +
+                    p.path.string() + "` to forget it",
+            });
+            continue;
+        }
+
+        if (cli.comparable && p.cli_min.comparable &&
+            compare_semver(p.cli_min, cli) > 0) {
+            findings.push_back({
+                SkewSeverity::Warn,
+                "Project '" + label + "' requires CLI >= v" + p.cli_min.raw +
+                    " but installed CLI is v" + cli.raw +
+                    " — run `pulp upgrade`",
+            });
+        }
+
+        if (cli.comparable && p.sdk.comparable &&
+            compare_semver(p.sdk, cli) > 0) {
+            findings.push_back({
+                SkewSeverity::Warn,
+                "Project '" + label + "' SDK is v" + p.sdk.raw +
+                    " but installed CLI is v" + cli.raw +
+                    " — consider `pulp upgrade`",
+            });
+        }
+    }
+
     return findings;
 }
 
@@ -286,6 +329,33 @@ int render_report(const VersionReport& report) {
                             "   (from pulp.toml)");
     }
 
+    // Per-project lines (issue #552 Slice 1b). Sourced from the
+    // registry at ~/.pulp/projects.json plus any ancestor projects
+    // surfaced via --scan-parents. Displayed as a separate block so
+    // the "active project" line above keeps its primacy.
+    if (!report.projects.empty()) {
+        std::cout << "\n  Projects:\n";
+        for (const auto& p : report.projects) {
+            std::string label = p.name.empty()
+                ? p.path.filename().string()
+                : p.name;
+            std::string tag = p.scanned ? " (scanned)" : "";
+            if (p.missing_on_disk) tag = " (missing)";
+
+            std::string sdk_display = p.sdk.raw.empty()
+                ? std::string("(sdk ?)")
+                : std::string("sdk v") + p.sdk.raw;
+            std::string cli_min_display = p.cli_min.comparable
+                ? std::string(", cli_min v") + p.cli_min.raw
+                : std::string{};
+
+            std::cout << "    - " << label << tag
+                      << " [" << sdk_display << cli_min_display << "]\n"
+                      << "      " << ansi_dim() << p.path.string()
+                      << ansi_reset() << "\n";
+        }
+    }
+
     std::cout << "\n";
 
     auto findings = report.analyze();
@@ -319,6 +389,102 @@ int render_report(const VersionReport& report) {
                   << " — advisory only, commands continue to run.\n";
     }
     return warn_count > 0 ? 1 : 0;
+}
+
+namespace {
+
+// Local JSON string escaper. The render_report_json surface is small
+// enough that we deliberately don't pull in the pkg::JsonValue
+// machinery — keeping version_diag link-light for the unit test.
+std::string json_escape(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 4);
+    for (char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x",
+                                  static_cast<unsigned>(c) & 0xff);
+                    out += buf;
+                } else {
+                    out += c;
+                }
+        }
+    }
+    return out;
+}
+
+void write_semver_json(std::ostream& os, const Semver& v) {
+    os << "{\"raw\": \"" << json_escape(v.raw) << "\""
+       << ", \"comparable\": " << (v.comparable ? "true" : "false");
+    if (v.comparable) {
+        os << ", \"major\": " << v.major
+           << ", \"minor\": " << v.minor
+           << ", \"patch\": " << v.patch;
+    }
+    os << "}";
+}
+
+}  // namespace
+
+int render_report_json(const VersionReport& report) {
+    auto findings = report.analyze();
+
+    std::cout << "{\n";
+    std::cout << "  \"cli\": ";
+    write_semver_json(std::cout, report.cli);
+    std::cout << ",\n  \"plugin\": ";
+    write_semver_json(std::cout, report.plugin);
+    std::cout << ",\n  \"plugin_json_path\": \""
+              << json_escape(report.plugin_json_path.generic_string())
+              << "\"";
+    std::cout << ",\n  \"project_root\": \""
+              << json_escape(report.project_root.generic_string()) << "\"";
+    std::cout << ",\n  \"project_sdk\": ";
+    write_semver_json(std::cout, report.project_sdk);
+    std::cout << ",\n  \"project_cli_min\": ";
+    write_semver_json(std::cout, report.project_cli_min);
+
+    std::cout << ",\n  \"projects\": [";
+    for (size_t i = 0; i < report.projects.size(); ++i) {
+        const auto& p = report.projects[i];
+        std::cout << (i == 0 ? "\n    " : ",\n    ") << "{";
+        std::cout << "\"path\": \""           << json_escape(p.path.generic_string()) << "\", "
+                  << "\"name\": \""           << json_escape(p.name) << "\", "
+                  << "\"sdk\": ";
+        write_semver_json(std::cout, p.sdk);
+        std::cout << ", \"cli_min\": ";
+        write_semver_json(std::cout, p.cli_min);
+        std::cout << ", \"missing_on_disk\": "
+                  << (p.missing_on_disk ? "true" : "false");
+        std::cout << ", \"scanned\": "
+                  << (p.scanned ? "true" : "false");
+        std::cout << "}";
+    }
+    if (!report.projects.empty()) std::cout << "\n  ";
+    std::cout << "]";
+
+    std::cout << ",\n  \"findings\": [";
+    for (size_t i = 0; i < findings.size(); ++i) {
+        const auto& f = findings[i];
+        std::cout << (i == 0 ? "\n    " : ",\n    ") << "{"
+                  << "\"severity\": \""
+                  << (f.severity == SkewSeverity::Warn ? "warn" : "info")
+                  << "\", "
+                  << "\"message\": \"" << json_escape(f.message) << "\""
+                  << "}";
+    }
+    if (!findings.empty()) std::cout << "\n  ";
+    std::cout << "]\n";
+
+    std::cout << "}\n";
+    return 0;
 }
 
 }  // namespace pulp::cli::version_diag

--- a/tools/cli/version_diag.hpp
+++ b/tools/cli/version_diag.hpp
@@ -67,6 +67,20 @@ struct SkewFinding {
     std::string message;
 };
 
+// A single registered project's version snapshot, used for per-project
+// skew lines in `pulp doctor --versions`. Populated by cmd_doctor from
+// `~/.pulp/projects.json` (or the `--scan-parents` ancestor walk) and
+// fed into VersionReport::analyze() so each project contributes its
+// own skew findings. See issue #552 (Slice 1b).
+struct ProjectEntry {
+    fs::path path;               // canonical project root
+    std::string name;            // display name (directory basename or custom)
+    Semver sdk;                  // parsed from CMakeLists.txt / pulp.toml
+    Semver cli_min;              // parsed from pulp.toml cli_min_version
+    bool missing_on_disk = false;  // `path` doesn't exist — warn but keep
+    bool scanned = false;        // discovered via --scan-parents, not registered
+};
+
 // Inputs to the skew analyzer. All fields optional — the analyzer
 // skips checks silently when data is missing (forward-compatible
 // behaviour: never hard-fail on missing or untagged versions).
@@ -78,9 +92,15 @@ struct VersionReport {
     fs::path project_root;       // for report lines
     fs::path plugin_json_path;   // for report lines
 
-    // Analyse and return user-visible findings. Today's rules (Slice 1):
+    // Other registered projects (from ~/.pulp/projects.json) plus any
+    // ancestor projects surfaced by `--scan-parents`. See issue #552.
+    std::vector<ProjectEntry> projects;
+
+    // Analyse and return user-visible findings. Rules (Slice 1 + 1b):
     //   - project_cli_min set AND project_cli_min > cli  -> Warn "upgrade CLI"
     //   - project_sdk set AND project_sdk > cli          -> Warn "CLI behind project SDK"
+    //   - for each projects[] entry: same rules, message names the project
+    //   - missing-on-disk entries                        -> Warn "path missing"
     //   - otherwise                                      -> Info "compatible"
     std::vector<SkewFinding> analyze() const;
 };
@@ -89,5 +109,11 @@ struct VersionReport {
 // from the design doc). Returns 0 on no-warn, 1 if any Warn-level
 // finding is emitted — callers can use this for a non-zero exit code.
 int render_report(const VersionReport& report);
+
+// Render the same report as a single JSON object to stdout. The shape
+// is stable enough for scripts to parse (see docs/reference/cli.md).
+// Always returns 0 — the JSON lane is a pure data surface and mirrors
+// the human lane's advisory-only posture. Issue #552.
+int render_report_json(const VersionReport& report);
 
 }  // namespace pulp::cli::version_diag

--- a/tools/scripts/cli_sync_check.py
+++ b/tools/scripts/cli_sync_check.py
@@ -14,6 +14,11 @@ SKIP_SLASH_COMMANDS = {
     "inspect", "import-design", "install", "version",
     "sdk", "fetch", "list", "remove", "search", "suggest",
     "target", "update",
+    # `pulp projects` is a registry-management plumbing command; it's
+    # adequately documented via `--help` and the cli-maintenance
+    # skill. Adding a slash command for pure plumbing would clutter
+    # the slash-command surface for agents. #552
+    "projects",
 }
 
 


### PR DESCRIPTION
## Summary

Slice 1b of the release-discovery UX (parent: #499). Implements the
`~/.pulp/projects.json` project registry and extends
`pulp doctor --versions` (shipped in #546) with per-project skew
reporting, an opt-in `--scan-parents` ancestor walk, and a `--json`
emitter.

Design decision locked in 2026-04-21: **hybrid model** — the JSON
file is authoritative. `pulp create` writes to it; `pulp projects
add/remove` is the user surface; `--scan-parents` is an opt-in
diagnostic escape hatch that never mutates the registry.

## What lands

- `tools/cli/projects_registry.{hpp,cpp}` — registry module (read,
  write, add, remove, ancestor scan). Deliberately link-free of
  `cli_common` so the unit test binary stays light, matching the
  convention set by `version_diag`.
- `tools/cli/cmd_projects.cpp` + `pulp projects {list,add,remove}`
  wired into the main dispatcher.
- `cmd_create.cpp` registers new projects on successful scaffold
  via `add_project(...)`.
- `cmd_doctor.cpp --versions`:
  - reads the registry and populates `VersionReport.projects[]`.
  - `--scan-parents` flag → walks CWD ancestors for
    `CMakeLists.txt` files invoking any `pulp_add_*` macro and
    surfaces them inline with a `(scanned)` tag.
  - `--json` flag → stable JSON surface (`cli`, `plugin`,
    `project_sdk`/`_cli_min`, `projects[]`, `findings[]`).
- `version_diag::VersionReport::analyze()` extended with per-project
  skew rules (same semantics as the Slice 1 rules but each finding
  names the project).
- Stale-entry policy: missing-on-disk entries are kept and surfaced
  with a copy-paste `pulp projects remove <path>` hint — never
  auto-pruned.

## Tests

New Catch2 binary `pulp-test-cli-projects-registry`:
- round-trip `read_registry`/`write_registry`
- `add_project` dedupes by canonical path, refreshes in place
- `remove_project` idempotent on unknown paths
- `scan_parent_pulp_projects` ancestor walk — both parent and nested
  child surfaced when both contain `pulp_add_*` (deepest-first)
- `scan_parent_pulp_projects` skips CMakeLists without the macro
- `now_iso8601_utc` format

Extended `pulp-test-cli-version-diag`:
- per-project `cli_min` + `sdk` skew warnings
- missing-on-disk → named warn with remove hint
- `render_report_json` shape smoke test

New CTest lanes:
- `cli-projects-help`, `cli-projects-list-empty`,
  `cli-doctor-versions-json` (all under a `PULP_HOME=...` test tmpdir
  so they don't touch the developer's real registry).

## Docs + skill

- `docs/reference/cli.md#projects` and extended `#doctor`.
- `docs/status/cli-commands.yaml` — `projects` command + new
  `--scan-parents` / `--json` flags on `doctor`.
- `.agents/skills/cli-maintenance/SKILL.md` — new "projects +
  registry wiring" section plus Slice 1b note under the existing
  `pulp doctor --versions` gotchas.
- `tools/scripts/cli_sync_check.py` — `projects` added to
  `SKIP_SLASH_COMMANDS` (registry-management plumbing; `--help`
  documents the surface).

## Design Q&A

- **Nested parent + child both match under `--scan-parents`?** Both
  appear in the diagnostic (deepest-first); the user resolves
  ambiguity. Rationale: silent disambiguation would hide a real
  configuration question.
- **Stale registry entry (path deleted)?** Kept and flagged
  `(missing)` with a copy-paste remove hint. Explicit
  `pulp projects remove` is the only way to mutate the registry.

Closes #552

## Test plan

- [x] `pulp-test-cli-projects-registry` — all 9 cases pass
- [x] `pulp-test-cli-version-diag` — all 23 cases pass (extended)
- [x] `cli-doctor-versions`, `cli-projects-help`,
      `cli-projects-list-empty`, `cli-doctor-versions-json` — pass
- [x] Manual end-to-end: `projects add`/`list`/`remove`,
      `doctor --versions --scan-parents`, missing-on-disk warn
- [ ] CI green on macOS / Ubuntu / Windows via Shipyard