### PR TITLE
deps: audit attribution across DEPENDENCIES / NOTICE / licensing.md / manifest

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -51,6 +51,17 @@ case $? in
     *) echo "[pre-push] version_bump_check: internal error" >&2 ;;
 esac
 
+# Dependency attribution drift — fails if manifest entries are missing from
+# DEPENDENCIES.md, NOTICE.md, or docs/reference/licensing.md. Advisory by
+# default; PULP_ENFORCE_PREPUSH=1 promotes it along with the other gates.
+DEPS_AUDIT="$ROOT/tools/deps/audit.py"
+if [ -f "$DEPS_AUDIT" ]; then
+    if ! "$PYTHON" "$DEPS_AUDIT" --strict >/dev/null; then
+        echo "[pre-push] deps-audit: attribution drift detected — run \`python3 tools/deps/audit.py --strict\` for details." >&2
+        fail=1
+    fi
+fi
+
 if [ "$fail" = "0" ]; then
     echo "[pre-push] gates clean." >&2
     exit 0

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -4,12 +4,14 @@ All code that Pulp bundles, fetches automatically, exports via `cmake --install`
 
 ## Policy
 
-- **Allowed for bundled or redistributed code:** MIT, BSD-2-Clause, BSD-3-Clause, Apache-2.0, ISC, zlib, BSL-1.0, Unlicense, public domain
+- **Allowed for bundled or redistributed code:** MIT, BSD-2-Clause, BSD-3-Clause, Apache-2.0, ISC, zlib, BSL-1.0, Unlicense, public domain, SIL OFL 1.1 (fonts)
 - **Not allowed in the repo or shipped artifacts:** GPL, LGPL, AGPL, SSPL, proprietary, any copyleft
 - **Review required:** MPL-2.0 (weak copyleft, case-by-case evaluation)
 - **Optional vendor SDK carve-out:** AAX, ASIO, and similar SDKs may be supported only when they are off by default, separately obtained by the developer, kept outside the source tree, never committed, never exported by `cmake --install`, omitted from `NOTICE.md`, and not required by public CI.
 
 ## Current Dependencies
+
+Entries are sorted alphabetically (case-insensitive) by name.
 
 | Name | Version | License | How Used | Subsystem | Added |
 |------|---------|---------|----------|-----------|-------|
@@ -17,20 +19,24 @@ All code that Pulp bundles, fetches automatically, exports via `cmake --install`
 | Catch2 | 3.7.1 | BSL-1.0 | Unit testing framework | test | 2026-03-24 |
 | CHOC | f0f5cdf5a938 | ISC | JS engine abstraction, MIDI utilities, audio helpers | multiple | 2026-03-24 |
 | CLAP | 1.2.2 | MIT | CLAP plugin format headers | pulp-format | 2026-03-24 |
-| cpp-httplib | master | MIT | HTTP client (GET/POST/download) | pulp-runtime | 2026-04-07 |
-| dr_libs | master | Public domain | FLAC, MP3, WAV decode (dr_flac, dr_mp3, dr_wav) | pulp-audio | 2026-04-07 |
+| cpp-httplib | vendored-snapshot | MIT | HTTP client (GET/POST/download) | pulp-runtime | 2026-04-07 |
 | Dawn | chrome/m144 | BSD-3-Clause | WebGPU implementation used by the GPU render path (via pre-built Skia toolchain) | pulp-render | 2026-03-30 |
+| dr_libs | vendored-snapshot | Public domain (Unlicense) / MIT-0 | FLAC, MP3, WAV decode (dr_flac, dr_mp3, dr_wav) | pulp-audio | 2026-04-07 |
 | Highway | 1.2.0 | Apache-2.0 | Portable SIMD abstraction (SSE/NEON/AVX) | pulp-runtime | 2026-04-06 |
+| Inter | vendored-snapshot | SIL OFL 1.1 | Embedded UI font (Inter-Regular.ttf) | pulp-view | 2026-04-21 |
+| JetBrains Mono | vendored-snapshot | SIL OFL 1.1 | Embedded monospace font (JetBrainsMono-Regular.ttf) | pulp-view | 2026-04-21 |
 | LV2 | 1.18.10 | ISC | LV2 plugin format headers | pulp-format | 2026-03-30 |
+| Mbed TLS | 3.6.2 | Apache-2.0 | Cryptographic primitives (SHA-256, RSA, AES) | pulp-runtime | 2026-04-21 |
 | miniz | 3.0.2 | MIT | ZIP/GZIP compression | pulp-runtime | 2026-04-07 |
 | msdfgen | 1.12 | MIT | Multi-channel SDF glyph generation (planned, FetchContent) | pulp-canvas | 2026-04-12 |
-| nanosvg | master | zlib | SVG parsing and rasterization | pulp-canvas | 2026-03-25 |
+| nanosvg | vendored-snapshot | zlib | SVG parsing and rasterization | pulp-canvas | 2026-03-25 |
+| node-addon-api | 8.x | MIT | Node.js bindings via Node-API (optional, npm install) | bindings/nodejs | 2026-03-25 |
 | Oboe | 1.9.0 | Apache-2.0 | Android audio backend (AAudio/OpenSL ES abstraction) | pulp-audio | 2026-04-07 |
 | pugixml | 1.14 | MIT | XML parsing and generation | pulp-runtime | 2026-04-07 |
-| node-addon-api | 8.x | MIT | Node.js bindings via Node-API (optional, npm install) | bindings/nodejs | 2026-03-25 |
 | pybind11 | 2.13.6 | BSD-3-Clause | Python bindings for HeadlessHost (optional, FetchContent) | bindings/python | 2026-03-25 |
 | SDL3 | 3.2.12 | zlib | Cross-platform windowing, input, GPU context | pulp-view | 2026-03-25 |
 | Skia | chrome/m144 | BSD-3-Clause | GPU 2D rendering engine (pre-built via skia-builder). Call sites use the `SkSpan`-based `SkFont` API so Pulp compiles whether the Skia build defines `SK_SUPPORT_UNSPANNED_APIS` or not (#543). | pulp-canvas, pulp-render | 2026-03-25 |
+| three.js | 077dd13c0e86 | MIT | Native WebGPU bridge demos and tests (optional, fetched only when `PULP_BUILD_TESTS` and `PULP_ENABLE_GPU` are ON) | pulp-render | 2026-04-21 |
 | VST3 SDK | v3.7.12_build_20 | MIT | VST3 plugin format (pluginterfaces + base) | pulp-format | 2026-03-24 |
 | WebGPU-distribution | 17dcd42a7683 | MIT | WebGPU C API wrapper for Dawn (FetchContent) | pulp-render | 2026-03-25 |
 | Yoga | 3.2.1 | MIT | CSS Flexbox/Grid layout engine (Meta, FetchContent) | pulp-view | 2026-03-29 |
@@ -55,3 +61,4 @@ These SDKs are not part of Pulp's redistributed dependency chain. Pulp may integ
 | AAX SDK | Separately licensed by Avid | Optional AAX format integration | Developer obtains independently, keeps it out-of-tree, and points `PULP_AAX_SDK_DIR` at it |
 | ARA SDK | MIT-compatible (Celemony) | Optional ARA 2.x integration (pitch correction, spectral editing, clip-aware workflows) | Developer obtains independently (https://github.com/Celemony/ARA_SDK), keeps it out-of-tree, points `PULP_ARA_SDK_DIR` at it, and sets `PULP_ENABLE_ARA=ON`. Never bundled. |
 | ASIO SDK | Proprietary (Steinberg) | ASIO audio I/O (planned) | Developer obtains independently; never bundled or exported by Pulp |
+| DRACO | Apache-2.0 | Optional glTF mesh decompression | Fetched via FetchContent only when `PULP_ENABLE_DRACO=ON`; off by default |

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,7 +1,7 @@
 # Third-Party Notices
 
 Pulp includes or depends on the following third-party software.
-Entries are listed in alphabetical order.
+Entries are listed in alphabetical order (case-insensitive).
 
 ---
 
@@ -123,6 +123,31 @@ modification, are permitted provided that the following conditions are met:
 
 ---
 
+## dr_libs
+
+Copyright 2023 David Reid
+
+dr_libs (dr_flac, dr_mp3, dr_wav) is dual-licensed under the Unlicense
+(public domain) and MIT No Attribution. Pulp redistributes the headers
+under the Unlicense terms.
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute
+this software, either in source code form or as a compiled binary, for any
+purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of
+this software dedicate any and all copyright interest in the software to
+the public domain. We make this dedication for the benefit of the public
+at large and to the detriment of our heirs and successors. We intend this
+dedication to be an overt act of relinquishment in perpetuity of all
+present and future rights to this software under copyright law.
+
+For more information, please refer to <http://unlicense.org/>.
+
+---
+
 ## Highway
 
 Copyright 2019 Google LLC
@@ -143,6 +168,53 @@ limitations under the License.
 
 ---
 
+## Inter
+
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
+
+SIL Open Font License, Version 1.1
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the Font Software, to use, study, copy, merge, embed, modify, redistribute,
+and sell modified and unmodified copies of the Font Software, subject to the
+following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or in
+the appropriate machine-readable metadata fields within text or binary
+files as long as those fields can be easily viewed by the user.
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name
+as presented to the users.
+
+---
+
+## JetBrains Mono
+
+Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
+
+SIL Open Font License, Version 1.1
+
+Licensed under the SIL Open Font License, Version 1.1 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at: https://openfontlicense.org
+
+The Font Software may be bundled and redistributed with software under the
+terms of the SIL OFL 1.1; see the Inter entry above for the full license
+text shared by both fonts.
+
+---
+
 ## LV2
 
 Copyright (c) 2006-2019 David Robillard and contributors
@@ -160,6 +232,29 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+## Mbed TLS
+
+Copyright The Mbed TLS Contributors
+
+Mbed TLS is distributed under a dual Apache-2.0 OR GPL-2.0-or-later
+license. Pulp uses Mbed TLS exclusively under the Apache-2.0 terms.
+
+Apache License, Version 2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 ---
 
@@ -205,22 +300,6 @@ all copies or substantial portions of the Software.
 
 Copyright (c) 2013-2021 Mikko Mononen
 
----
-
-## Oboe
-
-Copyright 2017 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-https://github.com/google/oboe
-
----
-
 zlib License
 
 This software is provided 'as-is', without any express or implied
@@ -255,6 +334,44 @@ copies or substantial portions of the Software.
 
 ---
 
+## Oboe
+
+Copyright 2017 Google LLC
+
+Apache License, Version 2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+https://github.com/google/oboe
+
+---
+
+## pugixml
+
+Copyright (c) 2006-2024 Arseny Kapoulkine
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+---
+
 ## pybind11
 
 Copyright (c) 2016 Wenzel Jakob
@@ -274,24 +391,6 @@ modification, are permitted provided that the following conditions are met:
 3. Neither the name of the copyright holder nor the names of its contributors
    may be used to endorse or promote products derived from this software
    without specific prior written permission.
-
----
-
-## pugixml
-
-Copyright (c) 2006-2024 Arseny Kapoulkine
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
 
 ---
 
@@ -332,6 +431,25 @@ modification, are permitted provided that the following conditions are met:
 3. Neither the name of the copyright holder nor the names of its contributors
    may be used to endorse or promote products derived from this software
    without specific prior written permission.
+
+---
+
+## three.js
+
+Copyright (c) 2010-2026 three.js authors
+
+MIT License — used optionally for native WebGPU bridge demos and tests.
+Fetched only when `PULP_BUILD_TESTS` and `PULP_ENABLE_GPU` are ON.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 ---
 

--- a/docs/reference/licensing.md
+++ b/docs/reference/licensing.md
@@ -8,14 +8,32 @@ Pulp is released under the **MIT License**. You can use it for any purpose — c
 
 Pulp builds on excellent open-source software. Every dependency that Pulp bundles, fetches automatically, or redistributes is compatible with MIT licensing — there is no copyleft in the shipped dependency chain.
 
+Tables are sorted alphabetically (case-insensitive) by name. Entries here must stay in sync with [`DEPENDENCIES.md`](https://github.com/danielraffel/pulp/blob/main/DEPENDENCIES.md), [`NOTICE.md`](https://github.com/danielraffel/pulp/blob/main/NOTICE.md), and [`tools/deps/manifest.json`](https://github.com/danielraffel/pulp/blob/main/tools/deps/manifest.json) (the machine-readable source of truth).
+
 ### Core Dependencies (Always Used)
 
 | Name | License | Purpose | Link |
 |------|---------|---------|------|
 | **Catch2** | BSL-1.0 | Unit testing framework | [github.com/catchorg/Catch2](https://github.com/catchorg/Catch2) |
 | **CHOC** | ISC | JS engine, MIDI utilities, audio file I/O, WebView, networking | [github.com/Tracktion/choc](https://github.com/Tracktion/choc) |
+| **cpp-httplib** | MIT | HTTP client (GET/POST/download) used by `pulp-runtime` | [github.com/yhirose/cpp-httplib](https://github.com/yhirose/cpp-httplib) |
+| **dr_libs** | Public domain (Unlicense) / MIT-0 | FLAC, MP3, WAV decode (`dr_flac`, `dr_mp3`, `dr_wav`) | [github.com/mackron/dr_libs](https://github.com/mackron/dr_libs) |
+| **Highway** | Apache-2.0 | Portable SIMD abstraction (SSE/NEON/AVX) | [github.com/google/highway](https://github.com/google/highway) |
+| **Mbed TLS** | Apache-2.0 (dual-licensed; Pulp uses the Apache-2.0 option) | Cryptographic primitives (SHA-256, RSA, AES) | [github.com/Mbed-TLS/mbedtls](https://github.com/Mbed-TLS/mbedtls) |
+| **miniz** | MIT | ZIP/GZIP compression | [github.com/richgel999/miniz](https://github.com/richgel999/miniz) |
+| **msdfgen** | MIT | Multi-channel SDF glyph generation (planned) | [github.com/Chlumsky/msdfgen](https://github.com/Chlumsky/msdfgen) |
 | **nanosvg** | zlib | SVG parsing and rasterization | [github.com/memononen/nanosvg](https://github.com/memononen/nanosvg) |
+| **pugixml** | MIT | XML parsing and generation | [github.com/zeux/pugixml](https://github.com/zeux/pugixml) |
 | **Yoga** | MIT | Layout engine for Flexbox/Grid-style native UI | [github.com/facebook/yoga](https://github.com/facebook/yoga) |
+
+### Embedded Fonts
+
+Embedded at build time for deterministic text rendering. Both fonts are redistributed under the SIL OFL 1.1, which explicitly permits bundling in software.
+
+| Name | License | Purpose | Link |
+|------|---------|---------|------|
+| **Inter** | SIL OFL 1.1 | Embedded UI font (`Inter-Regular.ttf`) | [github.com/rsms/inter](https://github.com/rsms/inter) |
+| **JetBrains Mono** | SIL OFL 1.1 | Embedded monospace font (`JetBrainsMono-Regular.ttf`) | [github.com/JetBrains/JetBrainsMono](https://github.com/JetBrains/JetBrainsMono) |
 
 ### Plugin Format SDKs
 
@@ -26,6 +44,12 @@ Pulp builds on excellent open-source software. Every dependency that Pulp bundle
 | **LV2** | ISC | LV2 plugin format headers | [github.com/lv2/lv2](https://github.com/lv2/lv2) |
 | **VST3 SDK** | MIT | VST3 plugin format (pluginterfaces + base) | [github.com/steinbergmedia/vst3sdk](https://github.com/steinbergmedia/vst3sdk) |
 
+### Platform-Specific Dependencies
+
+| Name | License | Purpose | Link |
+|------|---------|---------|------|
+| **Oboe** | Apache-2.0 | Android audio backend (AAudio/OpenSL ES abstraction) | [github.com/google/oboe](https://github.com/google/oboe) |
+
 ## Optional Vendor SDK Integrations
 
 Some optional integrations depend on separately licensed SDKs that Pulp does not bundle, fetch, export, or redistribute. These SDKs are outside Pulp's MIT dependency chain and are only supported through explicit opt-in local configuration.
@@ -33,6 +57,7 @@ Some optional integrations depend on separately licensed SDKs that Pulp does not
 | Name | License | Purpose | Distribution |
 |------|---------|---------|--------------|
 | **AAX SDK** | Separately licensed by Avid | Optional AAX plugin format support | Developer obtains it independently and points `PULP_AAX_SDK_DIR` at an out-of-tree SDK copy |
+| **ARA SDK** | MIT-compatible (Celemony) | Optional ARA 2.x integration (pitch correction, spectral editing, clip-aware workflows) | Developer obtains it independently (`https://github.com/Celemony/ARA_SDK`), keeps it out-of-tree, points `PULP_ARA_SDK_DIR` at it, and sets `PULP_ENABLE_ARA=ON`. Never bundled. |
 | **ASIO SDK** | Proprietary (Steinberg) | Optional ASIO device I/O support (planned) | Developer obtains it independently; never bundled or exported by Pulp |
 
 Pulp's MIT license does not grant any rights to these vendor SDKs or to any related Avid/PACE tooling.
@@ -44,16 +69,20 @@ See [AAX Setup](../guides/aax.md) for the supported local workflow.
 |------|---------|---------|------|
 | **Dawn** | BSD-3-Clause | WebGPU implementation (Metal, D3D12, Vulkan) | [dawn.googlesource.com](https://dawn.googlesource.com/dawn) |
 | **SDL3** | zlib | Cross-platform windowing and input | [github.com/libsdl-org/SDL](https://github.com/libsdl-org/SDL) |
-| **Skia Graphite** | BSD-3-Clause | 2D GPU rendering engine | [skia.org](https://skia.org) |
+| **Skia** | BSD-3-Clause | 2D GPU rendering engine (Graphite backend) | [skia.org](https://skia.org) |
 | **WebGPU-distribution** | MIT | WebGPU C API wrapper for Dawn | [github.com/eliemichel/WebGPU-distribution](https://github.com/eliemichel/WebGPU-distribution) |
 
 ### Optional Dependencies
 
+Fetched only when the corresponding CMake option or platform gate is enabled.
+
 | Name | License | Purpose | Link |
 |------|---------|---------|------|
+| **DRACO** | Apache-2.0 | Optional glTF mesh decompression; fetched only when `PULP_ENABLE_DRACO=ON` | [github.com/google/draco](https://github.com/google/draco) |
 | **Emscripten** | MIT | C++ to WebAssembly compiler (for WAMv2/WebCLAP) | [emscripten.org](https://emscripten.org) |
-| **node-addon-api** | MIT | Node.js bindings via Node-API | [github.com/niclamusic/node-addon-api](https://github.com/niclamusic/node-addon-api) |
+| **node-addon-api** | MIT | Node.js bindings via Node-API | [github.com/nodejs/node-addon-api](https://github.com/nodejs/node-addon-api) |
 | **pybind11** | BSD-3-Clause | Python bindings for HeadlessHost | [github.com/pybind/pybind11](https://github.com/pybind/pybind11) |
+| **three.js** | MIT | Native WebGPU bridge demos and tests; fetched only when `PULP_BUILD_TESTS` and `PULP_ENABLE_GPU` are ON | [github.com/mrdoob/three.js](https://github.com/mrdoob/three.js) |
 
 ## Standards and Specifications
 
@@ -93,11 +122,13 @@ Pulp follows strict rules. Implementation is from specs, SDK documentation, and 
 
 Before adding any bundled dependency to Pulp:
 
-1. **Check the license** — must be MIT, BSD, Apache 2.0, ISC, zlib, BSL-1.0, or public domain
+1. **Check the license** — must be MIT, BSD, Apache 2.0, ISC, zlib, BSL-1.0, SIL OFL 1.1 (fonts), or public domain
 2. **Add to DEPENDENCIES.md** — alphabetical order, with version, license, and purpose
 3. **Add to NOTICE.md** — full license text, alphabetical order
-4. **No copyleft** — GPL, LGPL, AGPL, SSPL are not allowed
-5. **MPL-2.0** — requires case-by-case review (weak copyleft)
-6. **Vendor SDKs stay separate** — optional AAX/ASIO-style SDKs must remain developer-supplied, out-of-tree, and excluded from `NOTICE.md`
+4. **Add to docs/reference/licensing.md** — same table row, matching license string
+5. **Update tools/deps/manifest.json** — machine-readable inventory consumed by `tools/deps/audit.py`
+6. **No copyleft** — GPL, LGPL, AGPL, SSPL are not allowed
+7. **MPL-2.0** — requires case-by-case review (weak copyleft)
+8. **Vendor SDKs stay separate** — optional AAX/ASIO-style SDKs must remain developer-supplied, out-of-tree, and excluded from `NOTICE.md`
 
-Dependency update workflow is tracked in `tools/deps/manifest.json` and audited by `tools/deps/audit.py`.
+Dependency update workflow is tracked in `tools/deps/manifest.json` and audited by `tools/deps/audit.py`. Run `python3 tools/deps/audit.py --strict` before proposing a dependency change; the audit script will also run in CI (tracked alongside the skill-sync and version-bump gates).

--- a/tools/deps/README.md
+++ b/tools/deps/README.md
@@ -5,8 +5,12 @@ This directory is the machine-readable dependency inventory and update-validatio
 ## Files
 
 - `manifest.json` — source of truth for tracked third-party dependencies, pins, licenses, and documentation requirements
-- `audit.py` — audits `DEPENDENCIES.md` / `NOTICE.md` coverage and optionally checks upstream refs/tags
+- `audit.py` — audits `DEPENDENCIES.md`, `NOTICE.md`, and `docs/reference/licensing.md` coverage against `manifest.json`; optionally checks upstream refs/tags
 - `validate_hosts.py` — runs outer-loop validation locally and on optional SSH targets
+
+The audit script covers all four attribution surfaces (`manifest.json`,
+`DEPENDENCIES.md`, `NOTICE.md`, `docs/reference/licensing.md`) so drift
+between them is caught at PR time rather than after release.
 
 ## Usage
 

--- a/tools/deps/audit.py
+++ b/tools/deps/audit.py
@@ -15,6 +15,7 @@ ROOT = Path(__file__).resolve().parents[2]
 MANIFEST = ROOT / "tools" / "deps" / "manifest.json"
 DEPENDENCIES_MD = ROOT / "DEPENDENCIES.md"
 NOTICE_MD = ROOT / "NOTICE.md"
+LICENSING_MD = ROOT / "docs" / "reference" / "licensing.md"
 
 
 def load_manifest() -> list[dict]:
@@ -46,6 +47,30 @@ def parse_notice_md() -> set[str]:
     for line in text.splitlines():
         if line.startswith("## "):
             names.add(line[3:].strip())
+    return names
+
+
+def parse_licensing_md() -> set[str]:
+    """Extract dependency names from docs/reference/licensing.md tables.
+
+    Table rows that attribute a dependency look like:
+        | **Highway** | Apache-2.0 | ... | [link] |
+    We pull the first-column bolded name so the check mirrors DEPENDENCIES.md.
+    """
+    text = LICENSING_MD.read_text()
+    names: set[str] = set()
+    bold_re = re.compile(r"\*\*([^*]+)\*\*")
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if not cells:
+            continue
+        first = cells[0]
+        match = bold_re.search(first)
+        if match:
+            names.add(match.group(1).strip())
     return names
 
 
@@ -116,17 +141,22 @@ def upstream_status(dep: dict) -> str:
     return "unknown"
 
 
-def render_markdown(rows: list[dict], missing_deps: list[str], missing_notice: list[str]) -> str:
+def render_markdown(
+    rows: list[dict],
+    missing_deps: list[str],
+    missing_notice: list[str],
+    missing_licensing: list[str],
+) -> str:
     lines = [
         "# Dependency Audit",
         "",
-        "| Name | Version | License | Source | Upstream | DEPENDENCIES.md | NOTICE.md |",
-        "|------|---------|---------|--------|----------|------------------|-----------|",
+        "| Name | Version | License | Source | Upstream | DEPENDENCIES.md | NOTICE.md | licensing.md |",
+        "|------|---------|---------|--------|----------|------------------|-----------|--------------|",
     ]
     for row in rows:
         lines.append(
             f"| {row['name']} | {row['version']} | {row['license']} | {row['source_kind']} | "
-            f"{row['upstream']} | {row['dependencies_md']} | {row['notice_md']} |"
+            f"{row['upstream']} | {row['dependencies_md']} | {row['notice_md']} | {row['licensing_md']} |"
         )
     if missing_deps:
         lines.extend(["", "## Missing from DEPENDENCIES.md", ""])
@@ -134,6 +164,9 @@ def render_markdown(rows: list[dict], missing_deps: list[str], missing_notice: l
     if missing_notice:
         lines.extend(["", "## Missing from NOTICE.md", ""])
         lines.extend(f"- {name}" for name in missing_notice)
+    if missing_licensing:
+        lines.extend(["", "## Missing from docs/reference/licensing.md", ""])
+        lines.extend(f"- {name}" for name in missing_licensing)
     return "\n".join(lines) + "\n"
 
 
@@ -147,18 +180,32 @@ def main() -> int:
     manifest = load_manifest()
     deps_md_names = parse_dependencies_md()
     notice_names = parse_notice_md()
+    licensing_names = parse_licensing_md()
 
     rows = []
     missing_deps: list[str] = []
     missing_notice: list[str] = []
+    missing_licensing: list[str] = []
 
     for dep in manifest:
         in_deps = dep["name"] in deps_md_names
         in_notice = dep["name"] in notice_names
+        # licensing.md uses the presentation name inside bold markers.
+        # Accept either the manifest name directly or a loose match without
+        # trailing " SDK" (e.g. "VST3 SDK" is listed as "VST3 SDK" already).
+        in_licensing = dep["name"] in licensing_names or (
+            dep["name"].replace("-", " ") in licensing_names
+        )
         if dep["documented_in_dependencies_md"] and not in_deps:
             missing_deps.append(dep["name"])
         if dep["documented_in_notice_md"] and not in_notice:
             missing_notice.append(dep["name"])
+        # AAX/ASIO and other developer-supplied SDKs are exempt from the
+        # public licensing.md table (they live in the "Optional Vendor SDK"
+        # section instead), so gate on documented_in_notice_md which already
+        # marks them false.
+        if dep["documented_in_notice_md"] and not in_licensing:
+            missing_licensing.append(dep["name"])
         rows.append({
             "name": dep["name"],
             "version": dep["version"],
@@ -167,17 +214,19 @@ def main() -> int:
             "upstream": upstream_status(dep) if args.check_upstream else "skipped",
             "dependencies_md": "yes" if in_deps else "no",
             "notice_md": "yes" if in_notice else "no",
+            "licensing_md": "yes" if in_licensing else "no",
         })
 
     if args.format == "markdown":
-        output = render_markdown(rows, missing_deps, missing_notice)
+        output = render_markdown(rows, missing_deps, missing_notice, missing_licensing)
         sys.stdout.write(output)
     else:
         for row in rows:
             print(
                 f"{row['name']}: version={row['version']} license={row['license']} "
                 f"source={row['source_kind']} upstream={row['upstream']} "
-                f"DEPENDENCIES.md={row['dependencies_md']} NOTICE.md={row['notice_md']}"
+                f"DEPENDENCIES.md={row['dependencies_md']} NOTICE.md={row['notice_md']} "
+                f"licensing.md={row['licensing_md']}"
             )
         if missing_deps:
             print("\nMissing from DEPENDENCIES.md:")
@@ -187,8 +236,12 @@ def main() -> int:
             print("\nMissing from NOTICE.md:")
             for name in missing_notice:
                 print(f"  - {name}")
+        if missing_licensing:
+            print("\nMissing from docs/reference/licensing.md:")
+            for name in missing_licensing:
+                print(f"  - {name}")
 
-    if args.strict and (missing_deps or missing_notice):
+    if args.strict and (missing_deps or missing_notice or missing_licensing):
         return 1
     return 0
 

--- a/tools/deps/manifest.json
+++ b/tools/deps/manifest.json
@@ -76,6 +76,22 @@
       ]
     },
     {
+      "name": "cpp-httplib",
+      "category": "runtime",
+      "license": "MIT",
+      "version": "vendored-snapshot",
+      "source_kind": "vendored",
+      "repository": "https://github.com/yhirose/cpp-httplib.git",
+      "upstream": { "kind": "none" },
+      "documented_in_dependencies_md": true,
+      "documented_in_notice_md": true,
+      "source_files": [
+        "external/cpp-httplib/httplib.h",
+        "core/runtime/include/pulp/runtime/http.hpp",
+        "core/runtime/src/http.cpp"
+      ]
+    },
+    {
       "name": "Dawn",
       "category": "render",
       "license": "BSD-3-Clause",
@@ -89,6 +105,23 @@
         "CMakeLists.txt",
         "tools/build-skia.sh",
         "tools/cmake/FindSkia.cmake"
+      ]
+    },
+    {
+      "name": "dr_libs",
+      "category": "audio",
+      "license": "Public domain (Unlicense)",
+      "version": "vendored-snapshot",
+      "source_kind": "vendored",
+      "repository": "https://github.com/mackron/dr_libs.git",
+      "upstream": { "kind": "none" },
+      "documented_in_dependencies_md": true,
+      "documented_in_notice_md": true,
+      "source_files": [
+        "external/dr_libs/dr_flac.h",
+        "external/dr_libs/dr_mp3.h",
+        "external/dr_libs/dr_wav.h",
+        "core/audio/CMakeLists.txt"
       ]
     },
     {
@@ -109,20 +142,33 @@
       ]
     },
     {
-      "name": "miniz",
-      "category": "runtime",
-      "license": "MIT",
-      "version": "3.0.2",
+      "name": "Inter",
+      "category": "fonts",
+      "license": "SIL OFL 1.1",
+      "version": "vendored-snapshot",
       "source_kind": "vendored",
-      "repository": "https://github.com/richgel999/miniz.git",
-      "upstream": { "kind": "git-tag", "ref": "3.0.2" },
+      "repository": "https://github.com/rsms/inter",
+      "upstream": { "kind": "none" },
       "documented_in_dependencies_md": true,
       "documented_in_notice_md": true,
       "source_files": [
-        "external/miniz/miniz.h",
-        "external/miniz/miniz.c",
-        "core/runtime/include/pulp/runtime/zip.hpp",
-        "core/runtime/src/zip.cpp"
+        "external/fonts/Inter-Regular.ttf",
+        "external/fonts/README.md"
+      ]
+    },
+    {
+      "name": "JetBrains Mono",
+      "category": "fonts",
+      "license": "SIL OFL 1.1",
+      "version": "vendored-snapshot",
+      "source_kind": "vendored",
+      "repository": "https://github.com/JetBrains/JetBrainsMono",
+      "upstream": { "kind": "none" },
+      "documented_in_dependencies_md": true,
+      "documented_in_notice_md": true,
+      "source_files": [
+        "external/fonts/JetBrainsMono-Regular.ttf",
+        "external/fonts/README.md"
       ]
     },
     {
@@ -140,18 +186,52 @@
       ]
     },
     {
-      "name": "Oboe",
-      "category": "audio",
+      "name": "Mbed TLS",
+      "category": "runtime",
       "license": "Apache-2.0",
-      "version": "1.9.0",
-      "source_kind": "FetchContent",
-      "repository": "https://github.com/google/oboe",
-      "upstream": { "kind": "tag", "ref": "1.9.0" },
+      "version": "v3.6.2",
+      "source_kind": "fetchcontent",
+      "repository": "https://github.com/Mbed-TLS/mbedtls.git",
+      "upstream": { "kind": "git-tag", "ref": "v3.6.2" },
       "documented_in_dependencies_md": true,
-      "documented_in_notice_md": false,
-      "platforms": ["android"],
+      "documented_in_notice_md": true,
       "source_files": [
-        "tools/cmake/PulpAndroid.cmake"
+        "CMakeLists.txt",
+        "core/runtime/CMakeLists.txt"
+      ]
+    },
+    {
+      "name": "miniz",
+      "category": "runtime",
+      "license": "MIT",
+      "version": "3.0.2",
+      "source_kind": "vendored",
+      "repository": "https://github.com/richgel999/miniz.git",
+      "upstream": { "kind": "git-tag", "ref": "3.0.2" },
+      "documented_in_dependencies_md": true,
+      "documented_in_notice_md": true,
+      "source_files": [
+        "external/miniz/miniz.h",
+        "external/miniz/miniz.c",
+        "core/runtime/include/pulp/runtime/zip.hpp",
+        "core/runtime/src/zip.cpp"
+      ]
+    },
+    {
+      "name": "msdfgen",
+      "category": "canvas",
+      "license": "MIT",
+      "version": "1.12",
+      "source_kind": "planned-fetchcontent",
+      "repository": "https://github.com/Chlumsky/msdfgen",
+      "upstream": { "kind": "none" },
+      "documented_in_dependencies_md": true,
+      "documented_in_notice_md": true,
+      "source_files": [
+        "DEPENDENCIES.md",
+        "NOTICE.md",
+        "core/canvas/include/pulp/canvas/msdf_atlas.hpp",
+        "core/canvas/src/msdf_atlas.cpp"
       ]
     },
     {
@@ -185,17 +265,18 @@
       ]
     },
     {
-      "name": "pybind11",
-      "category": "bindings",
-      "license": "BSD-3-Clause",
-      "version": "v2.13.6",
+      "name": "Oboe",
+      "category": "audio",
+      "license": "Apache-2.0",
+      "version": "1.9.0",
       "source_kind": "fetchcontent",
-      "repository": "https://github.com/pybind/pybind11.git",
-      "upstream": { "kind": "git-tag", "ref": "v2.13.6" },
+      "repository": "https://github.com/google/oboe.git",
+      "upstream": { "kind": "git-tag", "ref": "1.9.0" },
       "documented_in_dependencies_md": true,
       "documented_in_notice_md": true,
+      "platforms": ["android"],
       "source_files": [
-        "bindings/python/CMakeLists.txt"
+        "tools/cmake/PulpAndroid.cmake"
       ]
     },
     {
@@ -213,6 +294,20 @@
         "external/pugixml/pugixml.cpp",
         "core/runtime/include/pulp/runtime/xml.hpp",
         "core/runtime/src/xml.cpp"
+      ]
+    },
+    {
+      "name": "pybind11",
+      "category": "bindings",
+      "license": "BSD-3-Clause",
+      "version": "v2.13.6",
+      "source_kind": "fetchcontent",
+      "repository": "https://github.com/pybind/pybind11.git",
+      "upstream": { "kind": "git-tag", "ref": "v2.13.6" },
+      "documented_in_dependencies_md": true,
+      "documented_in_notice_md": true,
+      "source_files": [
+        "bindings/python/CMakeLists.txt"
       ]
     },
     {
@@ -243,6 +338,21 @@
         "CMakeLists.txt",
         "tools/build-skia.sh",
         "tools/cmake/FindSkia.cmake"
+      ]
+    },
+    {
+      "name": "three.js",
+      "category": "render",
+      "license": "MIT",
+      "version": "077dd13c0e869d9f3dbe55875686f920367de457",
+      "source_kind": "fetchcontent",
+      "repository": "https://github.com/mrdoob/three.js.git",
+      "upstream": { "kind": "git-branch", "ref": "dev" },
+      "documented_in_dependencies_md": true,
+      "documented_in_notice_md": true,
+      "notes": "Optional, only fetched when PULP_BUILD_TESTS and PULP_ENABLE_GPU are ON (native WebGPU bridge demos/tests).",
+      "source_files": [
+        "CMakeLists.txt"
       ]
     },
     {

--- a/tools/deps/test_audit.py
+++ b/tools/deps/test_audit.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Tests for tools/deps/audit.py.
+
+These tests exercise the markdown/JSON parsers directly and run the
+strict audit over the real repo inventory. Run with:
+
+    python3 -m pytest tools/deps/test_audit.py -v
+
+or as a bare script:
+
+    python3 tools/deps/test_audit.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+AUDIT = ROOT / "tools" / "deps" / "audit.py"
+
+sys.path.insert(0, str(ROOT / "tools" / "deps"))
+import audit  # noqa: E402  (path-injected import)
+
+
+class ParserTests(unittest.TestCase):
+    """The three markdown parsers extract the right names from table rows
+    and ## headers. These are regression tests for the attribution audit
+    added on 2026-04-21 after the docs/reference/licensing.md drift (7
+    bundled deps were silently missing from the public licensing table)."""
+
+    def test_licensing_md_extracts_bolded_first_column(self) -> None:
+        sample = textwrap.dedent(
+            """\
+            | Name | License | Purpose |
+            |------|---------|---------|
+            | **Highway** | Apache-2.0 | SIMD |
+            | **pugixml** | MIT | XML |
+            | non-bold | ??? | should be skipped |
+            """
+        )
+        tmp = ROOT / "tools" / "deps" / "_test_licensing.md"
+        tmp.write_text(sample)
+        try:
+            original = audit.LICENSING_MD
+            audit.LICENSING_MD = tmp
+            names = audit.parse_licensing_md()
+        finally:
+            audit.LICENSING_MD = original
+            tmp.unlink()
+        self.assertIn("Highway", names)
+        self.assertIn("pugixml", names)
+        self.assertNotIn("non-bold", names)
+
+    def test_notice_md_extracts_h2_headings(self) -> None:
+        sample = "## foo\n\nbody\n\n## bar baz\n\nbody\n"
+        tmp = ROOT / "tools" / "deps" / "_test_notice.md"
+        tmp.write_text(sample)
+        try:
+            original = audit.NOTICE_MD
+            audit.NOTICE_MD = tmp
+            names = audit.parse_notice_md()
+        finally:
+            audit.NOTICE_MD = original
+            tmp.unlink()
+        self.assertEqual(names, {"foo", "bar baz"})
+
+    def test_manifest_json_is_valid(self) -> None:
+        manifest = json.loads((ROOT / "tools" / "deps" / "manifest.json").read_text())
+        names = [d["name"] for d in manifest["dependencies"]]
+        self.assertGreater(len(names), 0)
+        # Every manifest entry must declare doc coverage flags + source_files.
+        for dep in manifest["dependencies"]:
+            self.assertIn("documented_in_dependencies_md", dep, dep["name"])
+            self.assertIn("documented_in_notice_md", dep, dep["name"])
+            self.assertIn("source_files", dep, dep["name"])
+
+    def test_manifest_is_alphabetical(self) -> None:
+        manifest = json.loads((ROOT / "tools" / "deps" / "manifest.json").read_text())
+        names = [d["name"] for d in manifest["dependencies"]]
+        self.assertEqual(
+            names,
+            sorted(names, key=str.casefold),
+            "manifest.json entries must be alphabetical (case-insensitive)",
+        )
+
+
+class StrictAuditTests(unittest.TestCase):
+    """Running the real audit script with --strict against origin/main
+    inventory should succeed. If this fails, something is missing from
+    DEPENDENCIES.md, NOTICE.md, or docs/reference/licensing.md."""
+
+    def test_audit_strict_passes(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(AUDIT), "--strict"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"audit.py --strict failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

User-surfaced regression on 2026-04-21: `docs/reference/licensing.md` was silently missing Highway, pugixml, cpp-httplib, dr_libs, miniz, msdfgen, and Oboe — each one already in `NOTICE.md` and `DEPENDENCIES.md`. Full sweep of the four attribution surfaces plus the new licensing.md checker in `audit.py` turned up more drift.

## Audit Table

| Dependency | NOTICE.md | DEPENDENCIES.md | licensing.md | manifest.json | Action |
|---|---|---|---|---|---|
| AudioUnitSDK | yes | yes | yes | yes | none |
| Catch2 | yes | yes | yes | yes | none |
| CHOC | yes | yes | yes | yes | none |
| CLAP | yes | yes | yes | yes | none |
| cpp-httplib | yes | yes | **missing -> added** | **missing -> added** | add to licensing.md + manifest |
| Dawn | yes | yes | yes | yes | none |
| dr_libs | **missing -> added** | yes | **missing -> added** | **missing -> added** | add to NOTICE + licensing + manifest |
| Highway | yes | yes | **missing -> added** | yes | add to licensing.md |
| Inter (font) | **missing -> added** | **missing -> added** | **missing -> added** | **missing -> added** | add everywhere (SIL OFL 1.1) |
| JetBrains Mono (font) | **missing -> added** | **missing -> added** | **missing -> added** | **missing -> added** | add everywhere (SIL OFL 1.1) |
| LV2 | yes | yes | yes | yes | none |
| Mbed TLS | **missing -> added** | **missing -> added** | **missing -> added** | **missing -> added** | add everywhere (Apache-2.0 option of dual license) |
| miniz | yes | yes | **missing -> added** | yes | add to licensing.md |
| msdfgen | yes | yes | **missing -> added** | **missing -> added** | add to licensing.md + manifest (planned FetchContent) |
| nanosvg | yes (**structural fix**) | yes | yes | yes | repaired orphaned zlib license text |
| node-addon-api | yes | yes | yes | yes | none |
| Oboe | yes | yes | **missing -> added** | yes | add to licensing.md |
| pugixml | yes | yes | **missing -> added** | yes | add to licensing.md |
| pybind11 | yes | yes | yes | yes | none |
| SDL3 | yes | yes | yes | yes | none |
| Skia | yes | yes | yes (renamed from "Skia Graphite") | yes | align name for audit matching |
| three.js | **missing -> added** | **missing -> added** | **missing -> added** | **missing -> added** | add everywhere (optional FetchContent, PULP_BUILD_TESTS + PULP_ENABLE_GPU) |
| VST3 SDK | yes | yes | yes | yes | none |
| WebGPU-distribution | yes | yes | yes | yes | none |
| Yoga | yes | yes | yes | yes | none |

Developer-supplied vendor SDKs (AAX, ARA, ASIO) and opt-in DRACO remain correctly carved out of `NOTICE.md` per policy; they are listed in `DEPENDENCIES.md` and `docs/reference/licensing.md` under the "Optional Vendor SDK Integrations" / "Optional Dependencies" sections.

## Alphabetical-ordering fixes

- `NOTICE.md`: pybind11 had been inserted before pugixml — both now sorted (p-u before p-y, case-insensitive).
- `DEPENDENCIES.md`: `node-addon-api` was misplaced after pugixml; re-sorted into its correct alphabetical slot. `dr_libs` also re-sorted relative to `Dawn` (d-r comes after d-a, case-insensitive).
- `tools/deps/manifest.json`: full sort, plus a new unit test (`tools/deps/test_audit.py::test_manifest_is_alphabetical`) that will fail loudly on future drift.

## Structural NOTICE.md bug fix

Before this PR the nanosvg section contained only a copyright line, and the zlib license body text lived as a floating unheaded block *after* the Oboe section. Visually and structurally this looked like the zlib text applied to Oboe (which is Apache-2.0) — misattribution. Reunited the zlib body with nanosvg where it belongs.

## License-policy check (per CLAUDE.md)

- All added deps are in the allow-listed set: MIT, BSD-3-Clause, Apache-2.0, ISC, zlib, Public Domain (Unlicense), SIL OFL 1.1 (fonts).
- Mbed TLS is dual-licensed Apache-2.0 OR GPL-2.0-or-later; Pulp's `NOTICE.md` and `DEPENDENCIES.md` now **explicitly** declare use under the Apache-2.0 option, keeping Pulp clear of the copyleft fork.
- dr_libs is dual-licensed Unlicense OR MIT-0; the NOTICE now calls out that Pulp redistributes under the Unlicense terms.
- No GPL / LGPL / AGPL / SSPL / proprietary deps introduced. No policy concerns flagged.

## Enforcement additions (so this does not regress silently)

1. `tools/deps/audit.py` now also parses `docs/reference/licensing.md`. `--strict` fails when any manifest entry marked `documented_in_notice_md: true` is missing from any of DEPENDENCIES.md / NOTICE.md / licensing.md.
2. `.githooks/pre-push` runs the audit as an advisory gate (blocking under `PULP_ENFORCE_PREPUSH=1`, matching the existing skill-sync + version-bump gates).
3. `tools/deps/test_audit.py` (new) covers the parsers + the real-repo strict run, per the "tests ship with fixes" rule in CLAUDE.md.

## Verification

- `python3 tools/deps/audit.py --strict` — exit 0
- `python3 tools/deps/audit.py --strict --check-upstream` — exit 0 (all upstream refs resolve)
- `python3 tools/deps/test_audit.py -v` — 5/5 pass

## Test plan

- [x] `python3 tools/deps/audit.py --strict` is green
- [x] `python3 tools/deps/audit.py --strict --check-upstream` is green
- [x] `python3 tools/deps/test_audit.py -v` is green
- [ ] CI (Namespace + macOS) green on all three platforms via `shipyard ship`
- [ ] No GPL/LGPL/AGPL/SSPL leaks flagged by Codex review