### PR TITLE
cli: release-discovery Slice 3 migration-doc infrastructure (#548)

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -351,3 +351,76 @@ Gotchas:
 - **Commit trailer block must be contiguous.** Version-bump + skill
   trailers live on the tip commit. Do NOT split with blank lines —
   `git interpret-trailers --parse` treats them as non-trailers.
+
+## Migration notes + `pulp upgrade --notes` (#499 Slice 3 / #548)
+
+Slice 3 extends `cmd_upgrade` with an embedded, per-release migration
+index. The table is generated at CMake configure time from
+`docs/migrations/*.md` and compiled into the binary so upgrade notes
+are always in lock-step with the shipped version — no runtime
+download, no filesystem scan.
+
+Key layout:
+
+- **`docs/migrations/vX.Y.Z.md`** — one file per release with notes
+  worth surfacing. TOML frontmatter fields: `version` (required),
+  `breaking` (bool), `applies_if` (expression string), `summary`.
+  `docs/migrations/README.md` is the schema reference; the codegen
+  skips it. Only write a note when a reasonable pro developer needs
+  to change code / config / habits — not every PR.
+- **`tools/scripts/build_migration_index.py`** — standalone Python
+  codegen. Parses the TOML frontmatter, escapes the Markdown body for
+  a C++ string literal, sorts entries by parsed semver, and writes
+  `tools/cli/generated/migration_index.cpp`. Runs from
+  `tools/cli/CMakeLists.txt` via `add_custom_command`; also invokable
+  directly for iteration.
+- **`tools/cli/migration_index.hpp`** — schema (`MigrationEntry`),
+  `EvalContext`, `evaluate_applies_if`, `entries_for_hop`,
+  `applicable_entries`, `render_notes_text`, `render_notes_json`.
+  Link-free from `cli_common` (same pattern as `version_diag` /
+  `update_check`).
+- **`tools/cli/migration_runtime.cpp`** — evaluator + renderers. The
+  generated `migration_index.cpp` defines only the data table so
+  `migration_runtime.cpp` is the single TU unit tests build against
+  (the test provides its own stub `kMigrationIndex`).
+- **`pulp upgrade --notes [--json] [--from X --to Y]`** — new flag.
+  No network, no binary swap. `--json` is stable-shape for Slice 4
+  (`/upgrade` Claude skill); do NOT rename the keys (`from`, `to`,
+  `entries[].version|breaking|summary|applies_if|body`) without
+  bumping the skill.
+
+`applies_if` grammar:
+
+```
+expr    := or
+or      := and ("||" and)*
+and     := cmp ("&&" cmp)*
+cmp     := ident op version | "(" expr ")"
+ident   := "cli_version_from" | "cli_version_to"
+op      := "<" | "<=" | ">" | ">=" | "==" | "!="
+```
+
+Fail-closed semantics: unknown idents, malformed expressions, or
+unparseable context versions all evaluate to false (so a bad note
+doesn't noise the output). Empty expression matches every hop.
+
+Gotchas:
+
+- **Version literals in `applies_if` have optional `v` prefix, but
+  the lexer requires `v` to be followed by a digit.** `vnull` is
+  NOT a version; it's an identifier (and fails closed). If you need
+  a plain `v`-prefixed literal, make sure the next char is `0-9`.
+- **`from` is exclusive, `to` is inclusive.** `entries_for_hop(A, B)`
+  returns entries with version strictly `> A` and `<= B`. Stepping
+  `--from 0.27.0 --to 0.27.0` returns zero entries. This is
+  intentional — a no-op hop prints "No migration notes apply."
+- **`docs/migrations/README.md` is excluded from the index.** It's
+  the schema reference, not a migration note. Don't rename it without
+  updating `build_migration_index.py`.
+- **Generated `.cpp` lives under `${CMAKE_BINARY_DIR}/` — it is NOT
+  checked in.** The source of truth is `docs/migrations/*.md`.
+- **Duplicate `version = "X.Y.Z"` across two files is a hard error.**
+  The codegen exits 2 and CMake fails to configure. Rename one.
+- **MSVC transitive-include hygiene.** `migration_runtime.cpp`
+  explicitly `#include <cstddef>`, `<sstream>`, `<string>`, `<vector>`,
+  `<tuple>`. Don't rely on libc++ giving you those transitively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
 - fix: Codex post-merge sweep (2026-04-21 wave 2) ([#574](https://github.com/danielraffel/pulp/pull/574))
 
 <a id="v0290"></a>
+## [0.30.0]
+
 ## [0.29.0] - 2026-04-20
 
 - cli: ~/.pulp/projects.json registry + pulp projects commands (#552 Slice 1b) ([#563](https://github.com/danielraffel/pulp/pull/563))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.29.1
+    VERSION 0.30.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,104 @@
+# Migration Notes
+
+This directory holds per-release migration notes that ship embedded in
+the `pulp` CLI binary. `pulp upgrade --notes` filters this set against
+the hop the user is performing (from the installed version to the
+target) and prints only the entries that actually apply.
+
+## File layout
+
+One file per release that ships notes:
+
+```
+docs/migrations/
+├── README.md          (this file — never emitted into the binary)
+├── v0.24.0.md
+├── v0.25.0.md
+└── ...
+```
+
+Names are advisory — the tooling identifies each file by the `version`
+field in its TOML frontmatter, not by the filename. Keep them in sync
+anyway to make grep easy.
+
+## Frontmatter schema
+
+Every migration doc starts with a TOML frontmatter block:
+
+```markdown
+---
+version = "0.27.0"
+breaking = true
+applies_if = "cli_version_from < 0.27.0 && cli_version_to >= 0.27.0"
+summary = "CLI config file moved from ~/.pulp/config to ~/.pulp/config.toml"
+---
+
+## Breaking changes
+- ...
+
+## Migration steps
+- ...
+```
+
+| Field        | Type    | Required | Notes |
+|--------------|---------|----------|-------|
+| `version`    | string  | yes      | Semver `"M.N.P"`, no leading `v`. |
+| `breaking`   | bool    | no       | Defaults to `false`. Tags the note as a breaking change in CLI output and `--notes --json`. |
+| `applies_if` | string  | no       | Boolean expression over `cli_version_from` / `cli_version_to`. Empty / absent = always applies. |
+| `summary`    | string  | no       | One-line human-readable summary. |
+
+Arrays, inline tables, and multi-line strings are NOT supported. The
+parser is intentionally minimal (see
+`tools/scripts/build_migration_index.py`) so the schema stays easy to
+read and diff-review.
+
+## `applies_if` expression language
+
+A tiny Boolean mini-language for filtering. Grammar:
+
+```
+expr    := or
+or      := and ("||" and)*
+and     := cmp ("&&" cmp)*
+cmp     := ident op version | "(" expr ")"
+ident   := "cli_version_from" | "cli_version_to"
+op      := "<" | "<=" | ">" | ">=" | "==" | "!="
+version := M "." N "." P    (optionally prefixed with 'v')
+```
+
+Typical usage for a breaking change landed in 0.27.0:
+
+```toml
+applies_if = "cli_version_from < 0.27.0 && cli_version_to >= 0.27.0"
+```
+
+Unknown syntax fails closed (the entry is treated as non-applicable).
+Empty expression matches every hop — used for purely informational
+notes that a maintainer wants printed on every upgrade that crosses
+this version.
+
+## Authoring workflow
+
+1. On a release PR that adds a breaking change or user-visible
+   behaviour shift, add `docs/migrations/vX.Y.Z.md` for the version
+   the change lands in.
+2. Fill in `version`, `breaking`, `applies_if`, and `summary`. Write
+   a short Markdown body describing what changed and what to do
+   about it.
+3. Rebuild (`cmake --build build`). CMake re-runs
+   `tools/scripts/build_migration_index.py` at configure time, so
+   reconfigure (`cmake -S . -B build`) if the file list changes.
+4. Verify locally: `./build/tools/cli/pulp upgrade --notes
+   --from 0.26.0 --to 0.27.0`.
+5. Commit. The generated `tools/cli/migration_index.cpp` lives at
+   `${CMAKE_BINARY_DIR}/generated/migration_index.cpp` — it is NOT
+   checked in.
+
+## Non-goals
+
+- Not every PR deserves a migration note. Only write one when a
+  reasonable pro developer needs to change code, config, or habits.
+- Notes are advisory text only. The CLI never modifies user files
+  based on them. Code changes require explicit user action.
+
+Issue: #548 (parent #499).

--- a/docs/migrations/v0.24.0.md
+++ b/docs/migrations/v0.24.0.md
@@ -1,0 +1,23 @@
+---
+version = "0.24.0"
+breaking = false
+applies_if = "cli_version_from < 0.24.0 && cli_version_to >= 0.24.0"
+summary = "PluginManagerPanel widget; cross-platform pulp::platform::Permissions API; AU scanner split."
+---
+
+## What's new
+
+- **`view::PluginManagerPanel`** — a reusable widget sitting on top of
+  the plugin scanner backend (`#494` / #538). If you previously
+  embedded the scanner via custom glue, prefer the panel for
+  consistent UX.
+- **`pulp::platform::Permissions`** — cross-platform runtime permissions
+  (camera, microphone, network, accessibility) with Apple / Windows /
+  Android / Linux backends (`#495` / #539). Replaces hand-rolled
+  platform-specific permission checks.
+- **AU scanner split** — the AU / AUv3 scan paths live behind distinct
+  enums now; host code that branched on the old combined enum needs
+  to disambiguate.
+
+No code changes are required for existing projects; these are additive.
+Consider migrating to the new widgets / API for forward compatibility.

--- a/docs/migrations/v0.25.0.md
+++ b/docs/migrations/v0.25.0.md
@@ -1,0 +1,23 @@
+---
+version = "0.25.0"
+breaking = false
+applies_if = "cli_version_from < 0.25.0 && cli_version_to >= 0.25.0"
+summary = "core/view header split; Codex sweep fixes across sysex / scan / post-merge paths."
+---
+
+## What's new
+
+- **`core/view` header split** — the monolithic view umbrella header
+  was split into focused sub-headers. If you were including
+  `pulp/view/view.hpp` for a single widget, prefer the specific
+  sub-header for faster compiles. The umbrella header still exists
+  and re-exports the sub-headers.
+- **Sysex + scan AU / AUv3 fixes** — consolidated Codex-review sweep
+  landing across MIDI SysEx handling, the AU/AUv3 scanner paths, and
+  the post-merge commit-range limit (`#540`, `#500`, `#529`).
+- **Three.js headless rAF flush** — example projects using the
+  Three.js bridge now flush requestAnimationFrame in the headless
+  loader loop (fix `#542`).
+
+No user action required. Rebuild and run your tests — things should
+just work.

--- a/docs/migrations/v0.26.0.md
+++ b/docs/migrations/v0.26.0.md
@@ -1,0 +1,19 @@
+---
+version = "0.26.0"
+breaking = false
+applies_if = "cli_version_from < 0.26.0 && cli_version_to >= 0.26.0"
+summary = "Release-discovery Slice 1 foundation (pulp doctor --versions); SkSpan hygiene."
+---
+
+## What's new
+
+- **`pulp doctor --versions`** — first slice of the release-discovery
+  UX (`#499` Slice 1 / #546). Reports the installed CLI / SDK /
+  plugin versions plus per-project skew warnings. Run it to confirm
+  your toolchain is aligned before filing bug reports.
+- **Canvas SkSpan migration** — `sdf_atlas` now uses the SkSpan
+  `SkFont` overloads instead of the legacy pointer/length pair
+  (`#544`). No user-facing API change, but rebuilds against newer
+  Skia pre-builts are cleaner.
+
+No migration steps needed. `pulp doctor --versions` is additive.

--- a/docs/migrations/v0.27.0.md
+++ b/docs/migrations/v0.27.0.md
@@ -1,0 +1,19 @@
+---
+version = "0.27.0"
+breaking = false
+applies_if = "cli_version_from < 0.27.0 && cli_version_to >= 0.27.0"
+summary = "Codex post-merge sweep + version-bump / skill-sync fnmatch `**` glob fix."
+---
+
+## What's new
+
+- **Codex post-merge sweep (2026-04-21)** — consolidated fixes across
+  the post-merge review lane (`#560`). Nothing in your project changes.
+- **`pulp pr` glob fix** — `tools/scripts/version_bump_check.py` and
+  `tools/scripts/skill_sync_check.py` now correctly resolve `**`
+  globs when matching changed-file paths against the versioning map
+  (`#554`). If you had previously hit "no surface matched" warnings
+  from a CLI-only PR, they are fixed.
+- **CLI host error messages** — `cmd_host` now emits format-specific
+  errors (`#537` / #557). If your CI parsed the generic error string,
+  update it to the new prefix.

--- a/docs/migrations/v0.28.0.md
+++ b/docs/migrations/v0.28.0.md
@@ -1,0 +1,31 @@
+---
+version = "0.28.0"
+breaking = false
+applies_if = "cli_version_from < 0.28.0 && cli_version_to >= 0.28.0"
+summary = "Release-discovery Slice 2: update-check cache, pulp config, background GitHub polling."
+---
+
+## What's new
+
+- **`pulp config get|set|list`** — thin wrapper over `~/.pulp/config.toml`
+  with an allow-list of keys (`update.mode`,
+  `update.check_interval_hours`, `update.channel`). Use this to
+  configure the update-check lane:
+
+  ```bash
+  pulp config set update.mode prompt
+  pulp config set update.mode off        # air-gapped / CI
+  pulp config get update.mode
+  ```
+
+- **Update-check cache** — `pulp` now checks GitHub Releases every 24h
+  (anonymous API; no auth). On `prompt` mode a one-line banner appears
+  on stderr when a newer version is available. Set `update.mode = off`
+  to disable entirely.
+
+- **`pulp upgrade --check-only`** — reports what the banner would say
+  without downloading.
+
+No migration required. If your CI scripts assumed `pulp` never touched
+the network, set `PULP_UPDATE_CHECK_DISABLED=1` in the environment or
+`pulp config set update.mode off` before the first invocation.

--- a/docs/migrations/v0.29.0.md
+++ b/docs/migrations/v0.29.0.md
@@ -1,0 +1,34 @@
+---
+version = "0.29.0"
+breaking = false
+applies_if = "cli_version_from < 0.29.0 && cli_version_to >= 0.29.0"
+summary = "~/.pulp/projects.json project registry + pulp projects commands; deps attribution audit."
+---
+
+## What's new
+
+- **`pulp projects` — project registry** — `~/.pulp/projects.json` is
+  now a lightweight registry of every project created or `add`ed
+  locally. New commands:
+
+  ```bash
+  pulp projects list
+  pulp projects add ~/projects/my-plugin
+  pulp projects remove ~/projects/my-plugin
+  ```
+
+  `pulp create` auto-registers new projects. The registry powers
+  `pulp doctor --versions` multi-project skew reporting (Slice 1b of
+  `#499` / #552 / #563).
+
+- **`pulp doctor --versions --json`** — stable-shape JSON output for
+  tooling consumption (same Slice 1b PR).
+
+- **Attribution audit** — `DEPENDENCIES.md`, `NOTICE.md`,
+  `docs/policies/licensing.md`, and `tools/deps/manifest.json` were
+  reconciled so every vendored / fetched dependency is listed
+  consistently (#565). No code change; purely documentation.
+
+If you managed projects manually or from a script that pre-dates the
+registry, run `pulp projects add <path>` for each one to opt them into
+skew reporting.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -805,14 +805,19 @@ Install methods come from the registry — today `binary_download` (pinned relea
 Update the Pulp CLI binary to the latest (or a specific) version.
 
 ```bash
-pulp upgrade              # upgrade to latest release
-pulp upgrade 0.2.0        # install specific version
-pulp upgrade --check-only # report cached latest release; no download
+pulp upgrade                                      # upgrade to latest release
+pulp upgrade 0.2.0                                # install specific version
+pulp upgrade --check-only                         # report cached latest release; no download
+pulp upgrade --notes                              # print migration notes for installed -> cached latest
+pulp upgrade --notes --json                       # same, stable-shape JSON (agent-consumable)
+pulp upgrade --notes --from 0.25.0 --to 0.29.0    # explicit hop override
 ```
 
 Downloads the release from GitHub, replaces the current binary, and verifies. Requires `curl`.
 
 `--check-only` reads the on-disk cache written by the on-every-invocation background refresh (release-discovery #547 Slice 2) and prints installed/latest/notes. If the cache is empty (first run), it falls through to a single live GitHub query.
+
+`--notes` is the Slice 3 (#548) surface: it filters the embedded migration index (built from `docs/migrations/*.md` at compile time) through each entry's `applies_if` expression and prints only the notes relevant to the upgrade hop. No network, no binary swap. The JSON variant emits a stable-shape document (`from`, `to`, `entries[].{version, breaking, summary, applies_if, body}`) that Slice 4's `/upgrade` Claude Code skill consumes.
 
 ### config
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -258,7 +258,7 @@ commands:
 
   - name: upgrade
     status: usable
-    summary: Update the Pulp CLI binary to the latest or a specific version. `--check-only` reports the cached latest release without downloading.
+    summary: Update the Pulp CLI binary to the latest or a specific version. `--check-only` reports the cached latest release without downloading. `--notes` prints embedded migration notes for the upgrade hop.
     args:
       - name: version
         kind: positional
@@ -267,6 +267,18 @@ commands:
       - name: --check-only
         kind: flag
         description: Report cached latest release and exit; no download (#547 Slice 2).
+      - name: --notes
+        kind: flag
+        description: Print embedded migration notes for the upgrade hop; no binary swap (#548 Slice 3).
+      - name: --json
+        kind: flag
+        description: With `--notes`, emit stable-shape JSON for agent consumers (#548 Slice 3 → Slice 4).
+      - name: --from
+        kind: option
+        description: Override the `from` version for `--notes` (default is the installed CLI).
+      - name: --to
+        kind: option
+        description: Override the `to` version for `--notes` (default is the cached latest).
     docs: reference/cli.md#upgrade
 
   - name: config

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -120,6 +120,26 @@ target_link_libraries(pulp-test-cli-projects-registry PRIVATE
     Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-cli-projects-registry)
 
+# CLI migration index (#499 Slice 3 / #548): pure-logic tests for the
+# applies_if expression evaluator, hop filter, text/JSON renderers,
+# and the Python codegen round-trip. The generated translation unit
+# `migration_index.cpp` is deliberately NOT linked into this test —
+# the test provides its own empty index so the helpers stay link-safe,
+# and the real embedded index is exercised by the shell-out tests.
+add_executable(pulp-test-cli-migration-index
+    test_cli_migration_index.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/migration_runtime.cpp
+)
+target_include_directories(pulp-test-cli-migration-index PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/cli)
+target_link_libraries(pulp-test-cli-migration-index PRIVATE
+    Catch2::Catch2WithMain)
+target_compile_definitions(pulp-test-cli-migration-index PRIVATE
+    PULP_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+catch_discover_tests(pulp-test-cli-migration-index
+    PROPERTIES ENVIRONMENT "PULP_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
+
 # Child process tests
 add_executable(pulp-test-child-process test_child_process.cpp)
 target_link_libraries(pulp-test-child-process PRIVATE pulp::platform Catch2::Catch2WithMain)

--- a/test/test_cli_migration_index.cpp
+++ b/test/test_cli_migration_index.cpp
@@ -1,0 +1,259 @@
+// Release-discovery Slice 3 (#548, parent #499) — unit tests for the
+// migration-index runtime.
+//
+// Covers:
+//   - TOML frontmatter parse round-trip via the Python codegen (shell out)
+//   - applies_if evaluator: all six comparison operators, &&, ||, parens
+//   - applies_if fail-closed behaviour on malformed expressions
+//   - entries_for_hop: from-exclusive, to-inclusive bound
+//   - applicable_entries: applies_if filtering layered on top
+//   - render_notes_text: deterministic header + ordering
+//   - render_notes_json: stable-shape JSON with agent-consumable keys
+//   - Generated C++ round-trip: python script -> parseable stub ->
+//     in-process lookup (no build-system coupling required)
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "tools/cli/migration_index.hpp"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#  include <process.h>
+#  define pulp_test_getpid() _getpid()
+#else
+#  include <unistd.h>
+#  define pulp_test_getpid() ::getpid()
+#endif
+
+namespace mig = pulp::cli::migration;
+namespace fs = std::filesystem;
+
+namespace {
+
+// A hand-crafted fixture table used by everything except the codegen
+// round-trip test. Lives in a free function so each TEST_CASE gets a
+// fresh vector — string_view points into static storage so lifetime
+// is safe across the test run.
+std::vector<mig::MigrationEntry> make_fixture() {
+    return {
+        {/*version*/    "0.24.0",
+         /*breaking*/   false,
+         /*applies_if*/ "cli_version_from < 0.24.0 && cli_version_to >= 0.24.0",
+         /*summary*/    "Panel widget; permissions API.",
+         /*body*/       "v24 body\n"},
+        {"0.25.0", false, "", "No gating.", "v25 body\n"},
+        {"0.27.0", true,  "cli_version_from < 0.27.0 && cli_version_to >= 0.27.0",
+                   "Breaking change landed here.", "v27 body\n"},
+        {"0.29.0", false, "cli_version_to == 0.29.0",
+                   "Only when stepping exactly to 29.", "v29 body\n"},
+    };
+}
+
+}  // namespace
+
+// ── applies_if evaluator ────────────────────────────────────────────────────
+
+TEST_CASE("applies_if — empty expression always matches",
+          "[cli][migration][issue-548]") {
+    mig::EvalContext ctx{"0.25.0", "0.26.0"};
+    REQUIRE(mig::evaluate_applies_if("", ctx));
+    REQUIRE(mig::evaluate_applies_if("   ", ctx));
+}
+
+TEST_CASE("applies_if — all six comparison ops work on both vars",
+          "[cli][migration][issue-548]") {
+    mig::EvalContext ctx{"0.26.0", "0.28.0"};
+
+    REQUIRE(mig::evaluate_applies_if("cli_version_from <  0.27.0", ctx));
+    REQUIRE(mig::evaluate_applies_if("cli_version_from <= 0.26.0", ctx));
+    REQUIRE(mig::evaluate_applies_if("cli_version_to   >  0.27.0", ctx));
+    REQUIRE(mig::evaluate_applies_if("cli_version_to   >= 0.28.0", ctx));
+    REQUIRE(mig::evaluate_applies_if("cli_version_from == 0.26.0", ctx));
+    REQUIRE(mig::evaluate_applies_if("cli_version_to   != 0.26.0", ctx));
+
+    REQUIRE_FALSE(mig::evaluate_applies_if("cli_version_from >  0.27.0", ctx));
+    REQUIRE_FALSE(mig::evaluate_applies_if("cli_version_to   <  0.28.0", ctx));
+    REQUIRE_FALSE(mig::evaluate_applies_if("cli_version_to   == 0.99.0", ctx));
+}
+
+TEST_CASE("applies_if — && / || / parens compose correctly",
+          "[cli][migration][issue-548]") {
+    mig::EvalContext ctx{"0.26.0", "0.28.0"};
+
+    REQUIRE(mig::evaluate_applies_if(
+        "cli_version_from < 0.27.0 && cli_version_to >= 0.27.0", ctx));
+
+    REQUIRE(mig::evaluate_applies_if(
+        "cli_version_from > 0.99.0 || cli_version_to >= 0.28.0", ctx));
+
+    REQUIRE(mig::evaluate_applies_if(
+        "(cli_version_from < 0.27.0) && (cli_version_to > 0.27.0)", ctx));
+
+    // Mixed — precedence: && binds tighter than ||.
+    REQUIRE(mig::evaluate_applies_if(
+        "cli_version_from > 0.99.0 && cli_version_to < 0.01.0 "
+        "|| cli_version_to == 0.28.0", ctx));
+}
+
+TEST_CASE("applies_if — accepts 'v' prefix on version literals",
+          "[cli][migration][issue-548]") {
+    mig::EvalContext ctx{"v0.26.0", "v0.28.0"};
+    REQUIRE(mig::evaluate_applies_if("cli_version_from < v0.27.0", ctx));
+}
+
+TEST_CASE("applies_if — malformed expressions fail closed",
+          "[cli][migration][issue-548]") {
+    mig::EvalContext ctx{"0.26.0", "0.28.0"};
+
+    REQUIRE_FALSE(mig::evaluate_applies_if("cli_version_from", ctx));
+    REQUIRE_FALSE(mig::evaluate_applies_if("cli_version_from <", ctx));
+    REQUIRE_FALSE(mig::evaluate_applies_if("unknown_ident < 0.1.0", ctx));
+    REQUIRE_FALSE(mig::evaluate_applies_if("cli_version_from < garbage", ctx));
+    REQUIRE_FALSE(mig::evaluate_applies_if("&&", ctx));
+    REQUIRE_FALSE(mig::evaluate_applies_if("cli_version_from < 0.1.0 &&", ctx));
+}
+
+TEST_CASE("applies_if — non-parseable context fails closed",
+          "[cli][migration][issue-548]") {
+    mig::EvalContext ctx{"garbage", "0.28.0"};
+    // cli_version_from cannot be parsed — the comparison returns false.
+    REQUIRE_FALSE(mig::evaluate_applies_if("cli_version_from < 0.27.0", ctx));
+}
+
+// ── Hop filter + renderers exercised via a test-local lookup helper ────────
+//
+// The public `entries_for_hop` / `applicable_entries` helpers consult
+// the global `kMigrationIndex`. For the renderer tests we don't need
+// the global (the renderers take an explicit vector), so we build one
+// from our fixture table directly.
+
+TEST_CASE("render_notes_text — empty result prints the 'no notes' line",
+          "[cli][migration][issue-548]") {
+    std::vector<const mig::MigrationEntry*> empty;
+    auto out = mig::render_notes_text(empty, "0.27.0", "0.29.0");
+    REQUIRE(out.find("Pulp migration notes: 0.27.0 -> 0.29.0") != std::string::npos);
+    REQUIRE(out.find("No migration notes apply") != std::string::npos);
+}
+
+TEST_CASE("render_notes_text — includes version, summary, body, breaking tag",
+          "[cli][migration][issue-548]") {
+    auto fixture = make_fixture();
+    std::vector<const mig::MigrationEntry*> entries = {
+        &fixture[2],  // v0.27.0 breaking
+    };
+    auto out = mig::render_notes_text(entries, "0.26.0", "0.27.0");
+    REQUIRE(out.find("v0.27.0") != std::string::npos);
+    REQUIRE(out.find("[breaking]") != std::string::npos);
+    REQUIRE(out.find("Breaking change landed here.") != std::string::npos);
+    REQUIRE(out.find("v27 body") != std::string::npos);
+}
+
+TEST_CASE("render_notes_json — stable-shape keys present for agent consumers",
+          "[cli][migration][issue-548]") {
+    auto fixture = make_fixture();
+    std::vector<const mig::MigrationEntry*> entries = {
+        &fixture[0],
+        &fixture[2],
+    };
+    auto out = mig::render_notes_json(entries, "0.23.0", "0.29.0");
+    // Top-level keys
+    REQUIRE(out.find("\"from\": \"0.23.0\"") != std::string::npos);
+    REQUIRE(out.find("\"to\": \"0.29.0\"")   != std::string::npos);
+    REQUIRE(out.find("\"entries\":")          != std::string::npos);
+    // Per-entry keys — Slice 4 contract.
+    REQUIRE(out.find("\"version\":")    != std::string::npos);
+    REQUIRE(out.find("\"breaking\":")   != std::string::npos);
+    REQUIRE(out.find("\"summary\":")    != std::string::npos);
+    REQUIRE(out.find("\"applies_if\":") != std::string::npos);
+    REQUIRE(out.find("\"body\":")       != std::string::npos);
+    // Breaking flag serialized as a JSON literal, not a string.
+    REQUIRE(out.find("\"breaking\": true") != std::string::npos);
+    REQUIRE(out.find("\"breaking\": false") != std::string::npos);
+    // Newlines inside body are escaped.
+    REQUIRE(out.find("v27 body\\n") != std::string::npos);
+}
+
+TEST_CASE("render_notes_json — empty entries emits valid JSON with empty array",
+          "[cli][migration][issue-548]") {
+    std::vector<const mig::MigrationEntry*> empty;
+    auto out = mig::render_notes_json(empty, "0.29.0", "0.29.0");
+    REQUIRE(out.find("\"entries\": []") != std::string::npos);
+    REQUIRE(out.find("\"from\": \"0.29.0\"") != std::string::npos);
+    REQUIRE(out.find("\"to\": \"0.29.0\"")   != std::string::npos);
+}
+
+// ── Generated-code round-trip via the Python script ────────────────────────
+//
+// Shell out to the codegen script against a throwaway migrations dir,
+// read back the generated .cpp, and verify the field values are
+// present. This proves the TOML parse + C++ string-literal encode
+// pipeline — catching regressions like forgetting to escape backslashes
+// or renaming a frontmatter key. We deliberately don't try to compile
+// the output in-process; that's covered by the CMake build.
+
+TEST_CASE("build_migration_index.py — frontmatter -> embedded C++ round-trip",
+          "[cli][migration][issue-548][shellout]") {
+    const char* src_root = std::getenv("PULP_SOURCE_DIR");
+    REQUIRE(src_root != nullptr);  // Set by CMake.
+
+    auto tmp = fs::temp_directory_path() /
+               ("pulp-test-migration-index-" +
+                std::to_string(pulp_test_getpid()) + "-roundtrip");
+    fs::create_directories(tmp);
+    fs::create_directories(tmp / "docs");
+
+    // Write a minimal fixture doc.
+    {
+        std::ofstream f(tmp / "docs" / "v9.9.9.md");
+        f << "---\n";
+        f << "version = \"9.9.9\"\n";
+        f << "breaking = true\n";
+        f << "applies_if = \"cli_version_to >= 9.9.9\"\n";
+        f << "summary = \"synthetic fixture for round-trip test\"\n";
+        f << "---\n\n";
+        f << "Body text with \"quotes\" and a backslash \\ for escape coverage.\n";
+    }
+
+    auto out_cpp = tmp / "out.cpp";
+    std::string cmd = std::string("python3 ") +
+        std::string(src_root) + "/tools/scripts/build_migration_index.py" +
+        " --docs-dir " + (tmp / "docs").string() +
+        " --out "     + out_cpp.string();
+    int rc = std::system(cmd.c_str());
+    REQUIRE(rc == 0);
+
+    std::ifstream in(out_cpp);
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    std::string generated = ss.str();
+
+    REQUIRE(generated.find("\"9.9.9\"") != std::string::npos);
+    REQUIRE(generated.find("true") != std::string::npos);
+    REQUIRE(generated.find("cli_version_to >= 9.9.9") != std::string::npos);
+    REQUIRE(generated.find("synthetic fixture") != std::string::npos);
+    // Body text properly escaped.
+    REQUIRE(generated.find("\\\"quotes\\\"") != std::string::npos);
+    REQUIRE(generated.find("\\\\") != std::string::npos);
+    // Table structure sanity-check.
+    REQUIRE(generated.find("MigrationEntry kTable[]") != std::string::npos);
+    REQUIRE(generated.find("kMigrationIndexSize") != std::string::npos);
+
+    std::error_code ec;
+    fs::remove_all(tmp, ec);
+}
+
+// The unit-test binary doesn't link the generated index TU. To keep
+// `entries_for_hop` / `applicable_entries` linkable we provide a
+// weak-ish empty index here. The fixture-based tests above cover the
+// logic; the real embedded index is exercised by the CLI shell-out
+// tests in test_cli_shellout.cpp.
+namespace pulp::cli::migration {
+const MigrationEntry* const kMigrationIndex = nullptr;
+const std::size_t kMigrationIndexSize = 0;
+}  // namespace pulp::cli::migration

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -273,3 +273,54 @@ TEST_CASE("pulp doctor --versions prints diagnostics and exits 0",
     // We always print the CLI line, even when no project is active.
     REQUIRE(r.stdout_output.find("CLI:") != std::string::npos);
 }
+
+// Issue #548 Slice 3: `pulp upgrade --notes` prints migration notes
+// for the hop without downloading anything. `--from`/`--to` overrides
+// let us exercise the filter deterministically regardless of the
+// installed CLI version on the test host.
+TEST_CASE("pulp upgrade --notes --from A --to B prints migration header",
+          "[cli][shellout][upgrade][issue-548]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    // Use an env override to neutralise the network-facing update
+    // banner so its stderr noise doesn't interfere.
+    auto r = run_pulp({"upgrade", "--notes", "--from", "0.23.0", "--to", "0.29.0"}, 15000);
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stdout_output.find("Pulp migration notes: 0.23.0 -> 0.29.0")
+            != std::string::npos);
+    // At least one of the seeded migration docs must surface between
+    // 0.23.0 and 0.29.0 — otherwise the embedded index was not
+    // regenerated from docs/migrations/.
+    REQUIRE(r.stdout_output.find("v0.") != std::string::npos);
+}
+
+TEST_CASE("pulp upgrade --notes --json emits stable-shape JSON keys",
+          "[cli][shellout][upgrade][issue-548]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto r = run_pulp({"upgrade", "--notes", "--json",
+                       "--from", "0.23.0", "--to", "0.29.0"}, 15000);
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    // Slice 4 depends on these keys — they are a stable public surface.
+    REQUIRE(r.stdout_output.find("\"from\":")       != std::string::npos);
+    REQUIRE(r.stdout_output.find("\"to\":")         != std::string::npos);
+    REQUIRE(r.stdout_output.find("\"entries\":")    != std::string::npos);
+    REQUIRE(r.stdout_output.find("\"version\":")    != std::string::npos);
+    REQUIRE(r.stdout_output.find("\"breaking\":")   != std::string::npos);
+    REQUIRE(r.stdout_output.find("\"summary\":")    != std::string::npos);
+    REQUIRE(r.stdout_output.find("\"applies_if\":") != std::string::npos);
+    REQUIRE(r.stdout_output.find("\"body\":")       != std::string::npos);
+}
+
+TEST_CASE("pulp upgrade --notes with no hop prints the empty-notes line",
+          "[cli][shellout][upgrade][issue-548]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    // from == to → degenerate hop with zero applicable notes.
+    auto r = run_pulp({"upgrade", "--notes", "--from", "0.29.0", "--to", "0.29.0"}, 15000);
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stdout_output.find("No migration notes apply") != std::string::npos);
+}

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -7,6 +7,36 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/pulp_version_gen.h"
     @ONLY)
 
+# ── Migration index codegen (release-discovery Slice 3, #548) ───────────────
+#
+# Scan docs/migrations/*.md at configure time, parse the TOML
+# frontmatter, and emit a C++ source file holding the embedded
+# migration index. The generated TU is compiled into pulp-cli so
+# `pulp upgrade --notes` never needs a network or filesystem round-trip
+# to decide which release notes apply to the user's upgrade hop.
+#
+# The DEPENDS list ensures reconfigure / rebuild when either the
+# generator script changes or any migration doc is added/modified.
+
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+set(_pulp_migration_index_src "${CMAKE_CURRENT_BINARY_DIR}/generated/migration_index.cpp")
+file(GLOB _pulp_migration_docs
+     LIST_DIRECTORIES FALSE
+     CONFIGURE_DEPENDS
+     "${CMAKE_SOURCE_DIR}/docs/migrations/*.md")
+
+add_custom_command(
+    OUTPUT  "${_pulp_migration_index_src}"
+    COMMAND "${Python3_EXECUTABLE}"
+            "${CMAKE_SOURCE_DIR}/tools/scripts/build_migration_index.py"
+            --docs-dir "${CMAKE_SOURCE_DIR}/docs/migrations"
+            --out      "${_pulp_migration_index_src}"
+    DEPENDS "${CMAKE_SOURCE_DIR}/tools/scripts/build_migration_index.py"
+            ${_pulp_migration_docs}
+    COMMENT "Generating migration_index.cpp from docs/migrations/*.md"
+    VERBATIM)
+
 add_executable(pulp-cli
     pulp_cli.cpp
     cli_common.cpp
@@ -36,11 +66,15 @@ add_executable(pulp-cli
     version_diag.cpp
     projects_registry.cpp
     cmd_projects.cpp
-    update_check.cpp)
+    update_check.cpp
+    migration_runtime.cpp
+    "${_pulp_migration_index_src}")
 set_target_properties(pulp-cli PROPERTIES OUTPUT_NAME "pulp")
 target_compile_features(pulp-cli PRIVATE cxx_std_20)
 target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format pulp::inspect pulp::host)
-target_include_directories(pulp-cli PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(pulp-cli PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR})
 
 # RPATH so the installed binary can find shared libraries (e.g.,
 # libwgpu_native.dylib / libwgpu_native.so) inside its install prefix.

--- a/tools/cli/cmd_upgrade.cpp
+++ b/tools/cli/cmd_upgrade.cpp
@@ -16,6 +16,7 @@
 // "`pulp upgrade`" section and test_cli_upgrade_url.cpp.
 
 #include "cli_common.hpp"
+#include "migration_index.hpp"
 #include "update_check.hpp"
 #include "upgrade_url.hpp"
 
@@ -29,6 +30,7 @@
 #include <vector>
 
 namespace uc = pulp::cli::update_check;
+namespace mig = pulp::cli::migration;
 
 // ── Cache location helpers (shared with pulp_cli.cpp dispatch path) ─────────
 
@@ -40,22 +42,69 @@ fs::path update_cache_path() {
 
 int cmd_upgrade(const std::vector<std::string>& args) {
     bool check_only = false;
+    bool notes_only = false;
+    bool notes_json = false;
+    std::string from_override;
+    std::string to_override;
     std::string target_version;
     for (size_t i = 0; i < args.size(); ++i) {
         if (args[i] == "--help" || args[i] == "-h") {
             std::cout << "pulp upgrade — update the Pulp CLI to the latest version\n\n";
-            std::cout << "Usage: pulp upgrade [--check-only] [version]\n\n";
+            std::cout << "Usage: pulp upgrade [--check-only] [--notes [--json]] [--from X --to Y] [version]\n\n";
             std::cout << "Options:\n";
             std::cout << "  --check-only   Report the latest available version and exit.\n";
             std::cout << "                 Reads the update cache; does not download.\n";
             std::cout << "                 (Full enforcement lands in #499 Slice 5.)\n";
+            std::cout << "  --notes        Print migration notes for the upgrade hop and exit.\n";
+            std::cout << "                 No binary swap. Reads the embedded migration index.\n";
+            std::cout << "  --notes --json Same, but emit a stable-shape JSON document instead\n";
+            std::cout << "                 of human-readable text. Agent-consumable.\n";
+            std::cout << "  --from X       Override the `from` version (default: installed CLI).\n";
+            std::cout << "  --to   Y       Override the `to`   version (default: cached latest).\n";
             std::cout << "\n";
             std::cout << "If no version is specified, upgrades to the latest release.\n";
             std::cout << "Requires curl (macOS/Linux) or Invoke-WebRequest (Windows).\n";
             return 0;
         }
         if (args[i] == "--check-only") { check_only = true; continue; }
+        if (args[i] == "--notes")      { notes_only = true; continue; }
+        if (args[i] == "--json")       { notes_json = true; continue; }
+        if (args[i] == "--from" && i + 1 < args.size()) { from_override = args[++i]; continue; }
+        if (args[i] == "--to"   && i + 1 < args.size()) { to_override   = args[++i]; continue; }
         if (args[i][0] != '-') target_version = args[i];
+    }
+
+    // ── --notes path (Slice 3 surface) ──────────────────────────────────────
+    //
+    // Print migration notes that apply to the hop `from` → `to` and
+    // exit. No network, no binary swap. Defaults:
+    //   from = PULP_SDK_VERSION (the version of the running binary)
+    //   to   = cached latest_version (falls back to `from` if no cache)
+    //
+    // The JSON variant is stable-shape (see migration_index.hpp) — Slice 4
+    // depends on it. Printed to stdout so scripts can `pulp upgrade
+    // --notes --json | jq` without stripping a banner.
+    if (notes_only) {
+        std::string from = !from_override.empty() ? from_override : std::string(PULP_SDK_VERSION);
+        std::string to = to_override;
+        if (to.empty()) {
+            auto cache_path = update_cache_path();
+            if (!cache_path.empty()) {
+                if (auto cache = uc::read_cache_file(cache_path);
+                    cache && !cache->latest_version.empty()) {
+                    to = cache->latest_version;
+                }
+            }
+            if (to.empty()) to = from;  // no cache; degenerate hop = no notes
+        }
+
+        auto entries = mig::applicable_entries(from, to);
+        if (notes_json) {
+            std::cout << mig::render_notes_json(entries, from, to);
+        } else {
+            std::cout << mig::render_notes_text(entries, from, to);
+        }
+        return 0;
     }
 
     // ── --check-only path (Slice 2 surface) ─────────────────────────────────
@@ -205,6 +254,16 @@ int cmd_upgrade(const std::vector<std::string>& args) {
     run("rm -rf " + tmp_dir);
 
     std::cout << "\n  \xe2\x9c\x93 Pulp CLI upgraded to v" << version << "\n";
+
+    // Hint about the embedded migration notes — the `--notes` surface
+    // lives in this same binary so the just-installed CLI can replay
+    // the guidance for the hop the user just performed.
+    std::string installed = PULP_SDK_VERSION;
+    if (installed != version) {
+        std::cout << "    Run `pulp upgrade --notes --from " << installed
+                  << " --to " << version
+                  << "` to see what changed.\n";
+    }
 
     // Bump the banner-shown marker so we don't nag the user again
     // about the version they just installed.

--- a/tools/cli/migration_index.hpp
+++ b/tools/cli/migration_index.hpp
@@ -1,0 +1,118 @@
+// migration_index.hpp — Release-discovery Slice 3 (#548 / parent #499).
+//
+// Embedded catalogue of per-release migration notes. The generated
+// translation unit `migration_index.cpp` is produced at CMake configure
+// time by `tools/scripts/build_migration_index.py`, which scans
+// `docs/migrations/*.md`, parses TOML frontmatter, and emits a table
+// of `MigrationEntry` records plus a `kMigrationIndex` span.
+//
+// At runtime `cmd_upgrade --notes` (and `--notes --json`) filter the
+// table using the `applies_if` expression so users see only the notes
+// relevant to the specific upgrade hop they are performing.
+//
+// Deliberately decoupled from `cli_common.hpp` so the unit tests can
+// link this TU standalone — same pattern as `version_diag.hpp` and
+// `update_check.hpp` (see #499 Slice 1 and Slice 2).
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pulp::cli::migration {
+
+// ── Schema ──────────────────────────────────────────────────────────────────
+
+// One row per migration doc. Fields mirror the TOML frontmatter defined
+// at `docs/migrations/README.md` (or inline comment at the top of each
+// migration file). `body_markdown` is the post-frontmatter body with a
+// single leading newline trimmed — preserved so `--notes` can print it
+// verbatim without stripping formatting.
+struct MigrationEntry {
+    std::string_view version;        // "0.27.0"
+    bool breaking = false;           // `breaking = true` in frontmatter
+    std::string_view applies_if;     // expression string (may be empty)
+    std::string_view summary;        // one-line summary
+    std::string_view body_markdown;  // everything after the closing `---`
+};
+
+// The generated table. Defined in migration_index.cpp (autogen).
+// Ordered ascending by parsed semver so consumers can early-exit.
+extern const MigrationEntry* const kMigrationIndex;
+extern const std::size_t kMigrationIndexSize;
+
+// ── Expression Evaluator ────────────────────────────────────────────────────
+//
+// `applies_if` is a tiny Boolean expression language over the two
+// variables `cli_version_from` and `cli_version_to`, with the six
+// comparison operators `<`, `<=`, `>`, `>=`, `==`, `!=` against a
+// literal semver. Expressions may be combined with `&&` and `||`;
+// parentheses group. Unknown syntax fails closed (returns false).
+//
+// Grammar (informal):
+//
+//     expr    := or
+//     or      := and ("||" and)*
+//     and     := cmp ("&&" cmp)*
+//     cmp     := ident op version
+//              | "(" expr ")"
+//     ident   := "cli_version_from" | "cli_version_to"
+//     op      := "<" | "<=" | ">" | ">=" | "==" | "!="
+//     version := M "." N "." P   (with optional leading 'v')
+//
+// An empty expression matches every hop (used for non-breaking notes
+// that are informative but don't gate on versions).
+
+struct EvalContext {
+    std::string version_from;  // the "from" side of the hop (installed)
+    std::string version_to;    // the "to" side of the hop (target)
+};
+
+bool evaluate_applies_if(const std::string& expr, const EvalContext& ctx);
+
+// ── Public lookup helpers ───────────────────────────────────────────────────
+
+// Return the list of entries whose `version` is strictly newer than
+// `from` and <= `to`, in ascending order. This models "notes that
+// matter for the hop from X to Y" — the from-exclusive bound keeps
+// `pulp upgrade --notes --from 0.27.0 --to 0.28.0` from re-printing
+// 0.27.0 notes when stepping up from 0.27.0.
+std::vector<const MigrationEntry*> entries_for_hop(const std::string& from,
+                                                   const std::string& to);
+
+// Same as above, then filters each entry through its `applies_if`
+// expression. If an entry has an empty `applies_if`, it passes.
+std::vector<const MigrationEntry*> applicable_entries(const std::string& from,
+                                                      const std::string& to);
+
+// Render the matching entries as human-readable text. Deterministic
+// layout so shell-out tests can assert exact substrings.
+std::string render_notes_text(const std::vector<const MigrationEntry*>& entries,
+                              const std::string& from,
+                              const std::string& to);
+
+// Render as JSON. Stable-shape output for agent consumption — Slice 4's
+// `/upgrade` Claude Code skill depends on the keys listed here. Do NOT
+// rename them without bumping the skill.
+//
+//   {
+//     "from": "0.27.0",
+//     "to":   "0.29.0",
+//     "entries": [
+//       {
+//         "version":   "0.28.0",
+//         "breaking":  true,
+//         "summary":   "...",
+//         "applies_if":"...",
+//         "body":      "..."
+//       },
+//       ...
+//     ]
+//   }
+std::string render_notes_json(const std::vector<const MigrationEntry*>& entries,
+                              const std::string& from,
+                              const std::string& to);
+
+}  // namespace pulp::cli::migration

--- a/tools/cli/migration_runtime.cpp
+++ b/tools/cli/migration_runtime.cpp
@@ -1,0 +1,396 @@
+// migration_runtime.cpp — Expression evaluator, hop filter, text/JSON
+// renderers for the embedded migration index.
+//
+// The generated data table lives in `migration_index.cpp` (autogen).
+// This TU owns all runtime logic so it can be unit-tested without the
+// generated table — tests construct in-memory `MigrationEntry` vectors
+// and call the helpers directly.
+
+#include "migration_index.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+namespace pulp::cli::migration {
+
+namespace {
+
+// ── Semver helpers (local — intentionally not reusing version_diag's
+// parser to keep this TU link-free). ─────────────────────────────────────────
+
+struct Semver {
+    int major = 0;
+    int minor = 0;
+    int patch = 0;
+    bool ok = false;
+};
+
+Semver parse_semver(std::string_view s) {
+    // Accept optional leading 'v' / 'V'.
+    if (!s.empty() && (s.front() == 'v' || s.front() == 'V')) {
+        s.remove_prefix(1);
+    }
+    Semver out;
+    int parts[3] = {0, 0, 0};
+    std::size_t idx = 0;
+    std::size_t i = 0;
+    while (i < s.size() && idx < 3) {
+        if (!std::isdigit(static_cast<unsigned char>(s[i]))) return out;
+        int n = 0;
+        while (i < s.size() && std::isdigit(static_cast<unsigned char>(s[i]))) {
+            n = n * 10 + (s[i] - '0');
+            ++i;
+        }
+        parts[idx++] = n;
+        if (idx == 3) break;
+        if (i >= s.size() || s[i] != '.') return out;
+        ++i;  // consume '.'
+    }
+    // Trailing pre-release / build metadata tolerated but ignored.
+    if (idx < 3) return out;
+    out.major = parts[0];
+    out.minor = parts[1];
+    out.patch = parts[2];
+    out.ok = true;
+    return out;
+}
+
+int compare_semver(const Semver& a, const Semver& b) {
+    if (std::tie(a.major, a.minor, a.patch) <
+        std::tie(b.major, b.minor, b.patch)) return -1;
+    if (std::tie(a.major, a.minor, a.patch) >
+        std::tie(b.major, b.minor, b.patch)) return 1;
+    return 0;
+}
+
+// ── Tokeniser for the applies_if expression language. ───────────────────────
+
+enum class TokKind {
+    End,
+    Ident,      // "cli_version_from", "cli_version_to"
+    Version,    // "0.27.0" (optionally prefixed with 'v')
+    Op,         // <, <=, >, >=, ==, !=
+    And,        // &&
+    Or,         // ||
+    LParen,
+    RParen,
+    Invalid,
+};
+
+struct Token {
+    TokKind kind = TokKind::Invalid;
+    std::string text;  // for Ident / Version / Op
+};
+
+struct Lexer {
+    std::string src;
+    std::size_t pos = 0;
+
+    void skip_ws() {
+        while (pos < src.size() &&
+               std::isspace(static_cast<unsigned char>(src[pos]))) {
+            ++pos;
+        }
+    }
+
+    Token next() {
+        skip_ws();
+        Token t;
+        if (pos >= src.size()) { t.kind = TokKind::End; return t; }
+        char c = src[pos];
+
+        if (c == '(') { ++pos; t.kind = TokKind::LParen; return t; }
+        if (c == ')') { ++pos; t.kind = TokKind::RParen; return t; }
+
+        if (c == '&' && pos + 1 < src.size() && src[pos + 1] == '&') {
+            pos += 2; t.kind = TokKind::And; return t;
+        }
+        if (c == '|' && pos + 1 < src.size() && src[pos + 1] == '|') {
+            pos += 2; t.kind = TokKind::Or; return t;
+        }
+        if (c == '<' || c == '>' || c == '=' || c == '!') {
+            // Accept two-char ops (<=, >=, ==, !=) and one-char (<, >).
+            t.kind = TokKind::Op;
+            if (pos + 1 < src.size() && src[pos + 1] == '=') {
+                t.text = src.substr(pos, 2);
+                pos += 2;
+            } else if (c == '<' || c == '>') {
+                t.text = std::string(1, c);
+                ++pos;
+            } else {
+                t.kind = TokKind::Invalid;
+                ++pos;
+            }
+            return t;
+        }
+
+        // Version literal: optional 'v'/'V' followed by a digit, then M.N.P.
+        // Checked BEFORE identifier so `v0.27.0` parses as Version, not
+        // as an ident `v` trailed by a parse error on `0.27.0`.
+        if ((c == 'v' || c == 'V') && pos + 1 < src.size() &&
+            std::isdigit(static_cast<unsigned char>(src[pos + 1]))) {
+            auto start = pos;
+            ++pos;  // consume 'v'/'V'
+            while (pos < src.size() &&
+                   (std::isdigit(static_cast<unsigned char>(src[pos])) ||
+                    src[pos] == '.')) {
+                ++pos;
+            }
+            t.kind = TokKind::Version;
+            t.text = src.substr(start, pos - start);
+            return t;
+        }
+
+        if (std::isalpha(static_cast<unsigned char>(c)) || c == '_') {
+            auto start = pos;
+            while (pos < src.size() &&
+                   (std::isalnum(static_cast<unsigned char>(src[pos])) ||
+                    src[pos] == '_')) {
+                ++pos;
+            }
+            t.kind = TokKind::Ident;
+            t.text = src.substr(start, pos - start);
+            return t;
+        }
+
+        if (std::isdigit(static_cast<unsigned char>(c))) {
+            auto start = pos;
+            while (pos < src.size() &&
+                   (std::isdigit(static_cast<unsigned char>(src[pos])) ||
+                    src[pos] == '.')) {
+                ++pos;
+            }
+            t.kind = TokKind::Version;
+            t.text = src.substr(start, pos - start);
+            return t;
+        }
+
+        t.kind = TokKind::Invalid;
+        ++pos;
+        return t;
+    }
+};
+
+// ── Parser — recursive descent, fail-closed. ────────────────────────────────
+
+struct Parser {
+    Lexer& lx;
+    Token cur;
+    bool failed = false;
+    const EvalContext& ctx;
+
+    Parser(Lexer& l, const EvalContext& c) : lx(l), ctx(c) { cur = lx.next(); }
+
+    void advance() { cur = lx.next(); }
+
+    bool parse_expr(bool& out) {
+        if (!parse_or(out)) return false;
+        return cur.kind == TokKind::End;
+    }
+
+    bool parse_or(bool& out) {
+        bool lhs;
+        if (!parse_and(lhs)) return false;
+        while (cur.kind == TokKind::Or) {
+            advance();
+            bool rhs;
+            if (!parse_and(rhs)) return false;
+            lhs = lhs || rhs;
+        }
+        out = lhs;
+        return true;
+    }
+
+    bool parse_and(bool& out) {
+        bool lhs;
+        if (!parse_cmp(lhs)) return false;
+        while (cur.kind == TokKind::And) {
+            advance();
+            bool rhs;
+            if (!parse_cmp(rhs)) return false;
+            lhs = lhs && rhs;
+        }
+        out = lhs;
+        return true;
+    }
+
+    bool parse_cmp(bool& out) {
+        if (cur.kind == TokKind::LParen) {
+            advance();
+            if (!parse_or(out)) return false;
+            if (cur.kind != TokKind::RParen) return false;
+            advance();
+            return true;
+        }
+        if (cur.kind != TokKind::Ident) return false;
+        const std::string ident = cur.text;
+        advance();
+        if (cur.kind != TokKind::Op) return false;
+        const std::string op = cur.text;
+        advance();
+        if (cur.kind != TokKind::Version) return false;
+        Semver rhs = parse_semver(cur.text);
+        advance();
+        if (!rhs.ok) return false;
+
+        std::string lhs_str;
+        if (ident == "cli_version_from") lhs_str = ctx.version_from;
+        else if (ident == "cli_version_to") lhs_str = ctx.version_to;
+        else return false;
+
+        Semver lhs = parse_semver(lhs_str);
+        if (!lhs.ok) {
+            // Missing/unparseable context — fail closed.
+            out = false;
+            return true;
+        }
+
+        int c = compare_semver(lhs, rhs);
+        if (op == "<")  out = c <  0;
+        else if (op == "<=") out = c <= 0;
+        else if (op == ">")  out = c >  0;
+        else if (op == ">=") out = c >= 0;
+        else if (op == "==") out = c == 0;
+        else if (op == "!=") out = c != 0;
+        else return false;
+        return true;
+    }
+};
+
+std::string escape_json(std::string_view s) {
+    std::string out;
+    out.reserve(s.size() + 2);
+    for (char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x",
+                                  static_cast<unsigned>(
+                                      static_cast<unsigned char>(c)));
+                    out += buf;
+                } else {
+                    out += c;
+                }
+        }
+    }
+    return out;
+}
+
+}  // namespace
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+bool evaluate_applies_if(const std::string& expr, const EvalContext& ctx) {
+    // Empty expression: vacuously applicable.
+    bool only_ws = true;
+    for (char c : expr) {
+        if (!std::isspace(static_cast<unsigned char>(c))) { only_ws = false; break; }
+    }
+    if (only_ws) return true;
+
+    Lexer lx{expr, 0};
+    Parser p(lx, ctx);
+    bool out = false;
+    if (!p.parse_expr(out)) return false;  // fail closed
+    return out;
+}
+
+std::vector<const MigrationEntry*> entries_for_hop(const std::string& from,
+                                                   const std::string& to) {
+    std::vector<const MigrationEntry*> hits;
+    Semver sf = parse_semver(from);
+    Semver st = parse_semver(to);
+    if (!sf.ok || !st.ok) return hits;
+    if (compare_semver(sf, st) >= 0) return hits;  // from >= to → no hop
+
+    for (std::size_t i = 0; i < kMigrationIndexSize; ++i) {
+        const auto& e = kMigrationIndex[i];
+        Semver sv = parse_semver(e.version);
+        if (!sv.ok) continue;
+        if (compare_semver(sv, sf) <= 0) continue;  // strictly newer than from
+        if (compare_semver(sv, st) >  0) continue;  // <= to
+        hits.push_back(&e);
+    }
+    std::sort(hits.begin(), hits.end(),
+              [](const MigrationEntry* a, const MigrationEntry* b) {
+                  return compare_semver(parse_semver(a->version),
+                                        parse_semver(b->version)) < 0;
+              });
+    return hits;
+}
+
+std::vector<const MigrationEntry*> applicable_entries(const std::string& from,
+                                                      const std::string& to) {
+    auto hits = entries_for_hop(from, to);
+    std::vector<const MigrationEntry*> kept;
+    kept.reserve(hits.size());
+    EvalContext ctx{from, to};
+    for (const auto* e : hits) {
+        std::string expr(e->applies_if);
+        if (evaluate_applies_if(expr, ctx)) kept.push_back(e);
+    }
+    return kept;
+}
+
+std::string render_notes_text(const std::vector<const MigrationEntry*>& entries,
+                              const std::string& from,
+                              const std::string& to) {
+    std::ostringstream os;
+    os << "Pulp migration notes: " << from << " -> " << to << "\n";
+    if (entries.empty()) {
+        os << "\n  No migration notes apply to this upgrade.\n";
+        return os.str();
+    }
+    for (const auto* e : entries) {
+        os << "\n── v" << e->version;
+        if (e->breaking) os << "  [breaking]";
+        os << " ──\n";
+        if (!e->summary.empty()) os << e->summary << "\n";
+        if (!e->body_markdown.empty()) {
+            os << "\n" << e->body_markdown;
+            if (!e->body_markdown.empty() && e->body_markdown.back() != '\n')
+                os << "\n";
+        }
+    }
+    return os.str();
+}
+
+std::string render_notes_json(const std::vector<const MigrationEntry*>& entries,
+                              const std::string& from,
+                              const std::string& to) {
+    std::ostringstream os;
+    os << "{\n";
+    os << "  \"from\": \"" << escape_json(from) << "\",\n";
+    os << "  \"to\": \""   << escape_json(to)   << "\",\n";
+    os << "  \"entries\": [";
+    bool first = true;
+    for (const auto* e : entries) {
+        os << (first ? "\n" : ",\n");
+        first = false;
+        os << "    {\n";
+        os << "      \"version\": \""   << escape_json(e->version)     << "\",\n";
+        os << "      \"breaking\": "    << (e->breaking ? "true" : "false") << ",\n";
+        os << "      \"summary\": \""   << escape_json(e->summary)     << "\",\n";
+        os << "      \"applies_if\": \""<< escape_json(e->applies_if)  << "\",\n";
+        os << "      \"body\": \""      << escape_json(e->body_markdown)<< "\"\n";
+        os << "    }";
+    }
+    if (!first) os << "\n  ";
+    os << "]\n";
+    os << "}\n";
+    return os.str();
+}
+
+}  // namespace pulp::cli::migration

--- a/tools/scripts/build_migration_index.py
+++ b/tools/scripts/build_migration_index.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Generate `migration_index.cpp` from the `docs/migrations/*.md` tree.
+
+Release-discovery Slice 3 (#548, parent #499).
+
+Each migration doc is a Markdown file with a TOML frontmatter block:
+
+    ---
+    version = "0.27.0"
+    breaking = true
+    applies_if = "cli_version_from < 0.27.0 && cli_version_to >= 0.27.0"
+    summary = "CLI config file moved from ~/.pulp/config to ~/.pulp/config.toml"
+    ---
+
+    ## Breaking changes
+    - ...
+
+The script scans every ``docs/migrations/*.md`` except ``README.md``,
+parses the frontmatter, and emits a compile-time ``MigrationEntry`` table
+keyed off ``version``. The resulting ``tools/cli/migration_index.cpp`` is
+compiled into ``pulp-cli`` so upgrade notes never need a network fetch
+or a filesystem scan at runtime.
+
+Run by CMake at configure time (see ``tools/cli/CMakeLists.txt``). Also
+usable standalone for local iteration / tests:
+
+    python3 tools/scripts/build_migration_index.py \
+        --docs-dir docs/migrations \
+        --out tools/cli/migration_index.cpp
+
+The output is deterministic — entries are sorted by parsed semver so
+running the script twice with the same input always yields byte-identical
+output. This matters because CMake's ``configure_file`` downstream build
+caches are keyed off the file contents.
+
+The parser is deliberately minimal — only the fields we actually use
+are recognised. Anything else in the frontmatter is preserved verbatim
+in the generated file as a comment so reviewers can see what was
+dropped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from dataclasses import dataclass, field
+from typing import Iterable
+
+
+SUPPORTED_FIELDS = {"version", "breaking", "applies_if", "summary"}
+
+
+@dataclass
+class Entry:
+    version: str
+    breaking: bool
+    applies_if: str
+    summary: str
+    body: str
+    source_path: pathlib.Path
+    extra: dict = field(default_factory=dict)
+
+
+# ── Tiny TOML frontmatter parser ────────────────────────────────────────────
+#
+# Intentionally NOT a full TOML parser — we support the exact shapes the
+# schema doc advertises:
+#
+#     key = "string value"
+#     key = true | false
+#
+# Quotes are mandatory for strings. Bare-string values are rejected so
+# we never silently accept a typo like `version = 0.27.0` (which TOML
+# would treat as a float). Comments (`# ...`) and blank lines are
+# ignored. Arrays / inline tables / multi-line strings are not
+# supported; if one sneaks in, the script exits non-zero with a
+# pointer to the offending file.
+
+
+def _parse_toml_frontmatter(text: str, source: pathlib.Path) -> dict:
+    out: dict = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            _fatal(source, f"expected `key = value`, got: {raw_line!r}")
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+
+        # Strip trailing comment (but NOT `#` inside a quoted string).
+        if value.startswith('"'):
+            # Find closing quote respecting backslash escapes.
+            end = 1
+            while end < len(value):
+                if value[end] == "\\" and end + 1 < len(value):
+                    end += 2
+                    continue
+                if value[end] == '"':
+                    end += 1
+                    break
+                end += 1
+            else:
+                _fatal(source, f"unterminated string on line: {raw_line!r}")
+            # Anything after the closing quote (other than whitespace + comment) is an error.
+            trailing = value[end:].lstrip()
+            if trailing and not trailing.startswith("#"):
+                _fatal(source, f"trailing content after string: {raw_line!r}")
+            parsed = _unescape(value[1:end - 1])
+            out[key] = parsed
+            continue
+
+        # Non-quoted value: bool or error.
+        comment_idx = value.find("#")
+        if comment_idx >= 0:
+            value = value[:comment_idx].rstrip()
+        if value == "true":
+            out[key] = True
+        elif value == "false":
+            out[key] = False
+        else:
+            _fatal(source,
+                   f"unsupported value shape for key {key!r}: {raw_line!r}. "
+                   "Strings must be double-quoted; booleans are true|false.")
+    return out
+
+
+def _unescape(s: str) -> str:
+    out = []
+    i = 0
+    while i < len(s):
+        c = s[i]
+        if c == "\\" and i + 1 < len(s):
+            nxt = s[i + 1]
+            if nxt == "n":      out.append("\n")
+            elif nxt == "t":    out.append("\t")
+            elif nxt == "r":    out.append("\r")
+            elif nxt == "\\":   out.append("\\")
+            elif nxt == '"':    out.append('"')
+            else:
+                out.append(c)
+                out.append(nxt)
+            i += 2
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def _fatal(source: pathlib.Path, msg: str) -> None:
+    sys.stderr.write(f"build_migration_index: {source}: {msg}\n")
+    sys.exit(2)
+
+
+# ── Entry discovery ─────────────────────────────────────────────────────────
+
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", re.DOTALL)
+
+
+def load_entry(path: pathlib.Path) -> Entry:
+    raw = path.read_text(encoding="utf-8")
+    m = FRONTMATTER_RE.match(raw)
+    if not m:
+        _fatal(path, "missing or malformed TOML frontmatter block "
+                     "(expected `---\\n...\\n---`)")
+    frontmatter = _parse_toml_frontmatter(m.group(1), path)
+    body = m.group(2).lstrip("\n")
+
+    if "version" not in frontmatter:
+        _fatal(path, "frontmatter missing required `version` field")
+    version = frontmatter["version"]
+    if not isinstance(version, str):
+        _fatal(path, f"`version` must be a string, got {type(version).__name__}")
+
+    extra = {k: v for k, v in frontmatter.items() if k not in SUPPORTED_FIELDS}
+    if extra:
+        # Not fatal — just noted in the generated file header.
+        pass
+
+    return Entry(
+        version=version,
+        breaking=bool(frontmatter.get("breaking", False)),
+        applies_if=str(frontmatter.get("applies_if", "")),
+        summary=str(frontmatter.get("summary", "")),
+        body=body,
+        source_path=path,
+        extra=extra,
+    )
+
+
+SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[.\-+].*)?$")
+
+
+def semver_key(version: str) -> tuple[int, int, int]:
+    m = SEMVER_RE.match(version)
+    if not m:
+        return (0, 0, 0)
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+# ── C++ codegen ─────────────────────────────────────────────────────────────
+
+
+def _cpp_escape(s: str) -> str:
+    out = []
+    for c in s:
+        if c == "\\":
+            out.append("\\\\")
+        elif c == '"':
+            out.append('\\"')
+        elif c == "\n":
+            out.append("\\n")
+        elif c == "\r":
+            out.append("\\r")
+        elif c == "\t":
+            out.append("\\t")
+        elif ord(c) < 0x20:
+            out.append(f"\\x{ord(c):02x}")
+        else:
+            out.append(c)
+    return "".join(out)
+
+
+HEADER = """// migration_index.cpp — GENERATED at CMake configure time.
+//
+// Source: tools/scripts/build_migration_index.py
+// Inputs: docs/migrations/*.md
+//
+// DO NOT EDIT BY HAND. Re-run `cmake --build` to regenerate, or invoke
+// the Python script directly for iteration:
+//
+//     python3 tools/scripts/build_migration_index.py \\
+//         --docs-dir docs/migrations \\
+//         --out tools/cli/migration_index.cpp
+//
+// Schema / semantics: see tools/cli/migration_index.hpp and #548.
+
+#include "migration_index.hpp"
+
+namespace pulp::cli::migration {
+
+namespace {
+
+"""
+
+FOOTER = """}  // namespace
+
+const MigrationEntry* const kMigrationIndex = kTable;
+const std::size_t kMigrationIndexSize = sizeof(kTable) / sizeof(kTable[0]);
+
+}  // namespace pulp::cli::migration
+"""
+
+
+def emit_cpp(entries: list[Entry]) -> str:
+    buf: list[str] = [HEADER]
+    if not entries:
+        # An empty array is not valid C++; emit a 1-entry sentinel whose
+        # version sorts before every real release so lookups still work.
+        buf.append("// No migration docs found under docs/migrations/.\n")
+        buf.append("constexpr MigrationEntry kTable[] = {\n")
+        buf.append('    {"", false, "", "", ""},\n')
+        buf.append("};\n\n")
+        buf.append("}  // namespace\n\n")
+        buf.append(
+            "const MigrationEntry* const kMigrationIndex = nullptr;\n"
+            "const std::size_t kMigrationIndexSize = 0;\n\n"
+            "}  // namespace pulp::cli::migration\n"
+        )
+        return "".join(buf)
+
+    buf.append("constexpr MigrationEntry kTable[] = {\n")
+    for e in entries:
+        rel = e.source_path.as_posix()
+        buf.append(f'    // source: {rel}\n')
+        if e.extra:
+            buf.append(f'    // note: extra frontmatter keys ignored: {sorted(e.extra)}\n')
+        buf.append("    {\n")
+        buf.append(f'        "{_cpp_escape(e.version)}",\n')
+        buf.append(f'        {"true" if e.breaking else "false"},\n')
+        buf.append(f'        "{_cpp_escape(e.applies_if)}",\n')
+        buf.append(f'        "{_cpp_escape(e.summary)}",\n')
+        buf.append(f'        "{_cpp_escape(e.body)}",\n')
+        buf.append("    },\n")
+    buf.append("};\n\n")
+    buf.append(FOOTER)
+    return "".join(buf)
+
+
+# ── CLI driver ──────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--docs-dir", type=pathlib.Path, required=True,
+                    help="Directory containing vX.Y.Z.md migration files.")
+    ap.add_argument("--out", type=pathlib.Path, required=True,
+                    help="Path to write the generated migration_index.cpp.")
+    args = ap.parse_args(argv)
+
+    docs_dir: pathlib.Path = args.docs_dir
+    if not docs_dir.is_dir():
+        sys.stderr.write(f"build_migration_index: docs dir not found: {docs_dir}\n")
+        return 2
+
+    entries: list[Entry] = []
+    for md in sorted(docs_dir.glob("*.md")):
+        if md.name.lower() == "readme.md":
+            continue
+        entries.append(load_entry(md))
+
+    entries.sort(key=lambda e: semver_key(e.version))
+
+    # Detect duplicate versions — they would silently shadow each other.
+    seen: dict[str, pathlib.Path] = {}
+    for e in entries:
+        if e.version in seen:
+            _fatal(e.source_path,
+                   f"duplicate `version = {e.version!r}` already defined in "
+                   f"{seen[e.version]}")
+        seen[e.version] = e.source_path
+
+    generated = emit_cpp(entries)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    # Only rewrite when the content actually changes so CMake avoids
+    # spurious recompiles on no-op reconfigures.
+    old = args.out.read_text(encoding="utf-8") if args.out.exists() else ""
+    if old != generated:
+        args.out.write_text(generated, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Embeds per-release migration notes into pulp-cli at compile time so
`pulp upgrade --notes` can print guidance tailored to the specific
upgrade hop without a network call.

- **TOML-frontmatter schema** for `docs/migrations/vX.Y.Z.md`
  (`version`, `breaking`, `applies_if`, `summary`) plus
  `docs/migrations/README.md` as the schema reference.
- **`tools/scripts/build_migration_index.py`** — Python codegen
  invoked by `add_custom_command` at CMake configure time. Parses the
  frontmatter, sorts entries by semver, emits
  `migration_index.cpp` into `${CMAKE_BINARY_DIR}/generated/`.
- **`tools/cli/migration_index.hpp` + `migration_runtime.cpp`** —
  schema, `applies_if` boolean-expression evaluator (six comparison
  ops, `&&` / `||`, parens, fail-closed), hop filter (from-exclusive,
  to-inclusive), text + JSON renderers. The JSON keys are the stable
  contract Slice 4's `/upgrade` skill will consume.
- **`cmd_upgrade`** extended with `--notes`, `--notes --json`,
  `--from X --to Y`. No network, no binary swap.
- **`docs/migrations/v0.24.0..v0.29.0.md`** — seed entries so
  `pulp upgrade --notes` has content to show today.

## Embedding mechanism (open question from the design doc — resolved)

`add_custom_command` running a Python codegen that writes a
`.cpp` file compiled into `pulp-cli`. Chosen over `bin2c` / `xxd` /
`configure_file` because:

- It gives us real C++ data (an array of `MigrationEntry` structs),
  not an opaque blob that needs a runtime JSON parser.
- The generator is a plain script so authors can run it standalone for
  iteration; CMake only wraps it.
- Output is deterministic (entries sorted by semver, only rewritten
  when content actually changes) so incremental builds stay clean.

## Test plan

- [x] `pulp-test-cli-migration-index` (11 cases): empty expr, six
  comparison ops, `&&` / `||` / parens, `v`-prefix tolerance,
  fail-closed malformed input, non-parseable context, renderer text
  + JSON shape, Python codegen round-trip through a tmp fixture.
- [x] Shell-out tests: `pulp upgrade --notes --from A --to B` header,
  `--json` stable keys, empty-hop "No migration notes apply" path.
- [x] Full `pulp-test-cli-shellout` (13 cases) still green.

## Files touched

- Added: `docs/migrations/{README,v0.24.0..v0.29.0}.md`
- Added: `tools/scripts/build_migration_index.py`
- Added: `tools/cli/migration_index.hpp`, `migration_runtime.cpp`
- Added: `test/test_cli_migration_index.cpp`
- Modified: `tools/cli/{CMakeLists.txt, cmd_upgrade.cpp}`
- Modified: `test/{CMakeLists.txt, test_cli_shellout.cpp}`
- Modified: `.agents/skills/cli-maintenance/SKILL.md` (new "Migration
  notes" section)
- Modified: `docs/status/cli-commands.yaml`, `docs/reference/cli.md`
- Modified: `CMakeLists.txt` (SDK 0.29.0 → 0.30.0), `CHANGELOG.md`

Closes #548