### PR TITLE
ci(coverage): fix cache-value silent failure + filter Catch2 spam + add cobertura output (#569 #570)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,8 @@ name: Coverage
 
 # Non-blocking coverage artifact. Informational only; no merge gate.
 # Local equivalent: scripts/run_coverage.sh.
-# Full design: planning/coverage-sanitizers-spec-2026-04-16.md.
+# Full design: planning/coverage-sanitizers-spec-2026-04-16.md
+#              planning/coverage-tooling-decision-2026-04-21.md (Phase 0 spike)
 
 on:
   pull_request:
@@ -35,6 +36,23 @@ jobs:
             libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev \
             libxrender-dev libxss-dev libxtst-dev libwayland-dev wayland-protocols
 
+      - name: Install coverage reporting tools (gcovr)
+        # gcovr bridges Clang source-based coverage → Cobertura XML,
+        # which Codecov (PR 2) and diff-cover (PR 3) consume.
+        # Pin >=8.2 for the --llvm-profdata-executable path used by
+        # scripts/run_coverage.sh.
+        run: python3 -m pip install --user 'gcovr>=8.2'
+        shell: bash
+
+      - name: run_coverage.sh fixture tests (#569 / #570)
+        # Assert the canonical ignore-regex excludes _deps/catch2-build
+        # spam (#569) AND that the stale-cache guard trips loudly
+        # instead of silently producing empty profdata (#570). Runs
+        # before the heavy build so a regex/guard regression fails
+        # fast without burning the full coverage build.
+        run: python3 tools/scripts/test_run_coverage.py
+        shell: bash
+
       - name: Bootstrap dependencies
         run: ./setup.sh --ci --deps-only
         shell: bash
@@ -61,3 +79,15 @@ jobs:
           name: coverage-summary-${{ github.sha }}
           path: build-coverage/coverage/summary.txt
           retention-days: 90
+
+      - name: Upload Cobertura XML
+        # PR 1 lands the XML artifact; PR 2 wires it into Codecov and
+        # PR 3 wires it into diff-cover. Keep the retention short —
+        # once Codecov is live the XML lives there.
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-cobertura-${{ github.sha }}
+          path: build-coverage/coverage.cobertura.xml
+          retention-days: 14
+          if-no-files-found: warn

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -5,12 +5,16 @@
 #   scripts/run_coverage.sh [--jobs N] [--tests REGEX]
 #
 # Produces:
-#   build-coverage/coverage/index.html         — per-file drilldown
-#   build-coverage/coverage/summary.txt        — top-level table
+#   build-coverage/coverage/index.html          — per-file drilldown
+#   build-coverage/coverage/summary.txt         — top-level table
+#   build-coverage/coverage.cobertura.xml       — Cobertura XML (for
+#                                                 Codecov + diff-cover);
+#                                                 skipped if gcovr not on
+#                                                 PATH (local-only).
 #
 # Coverage is informational only. This script never fails on a
-# coverage threshold; thresholds would be noise without a baseline
-# and the #290 hardening initiative.
+# coverage threshold; thresholds come via the Phase 2/3 diff-cover
+# gate (see planning/coverage-tooling-decision-2026-04-21.md).
 
 set -euo pipefail
 
@@ -21,6 +25,23 @@ PROFRAW_DIR="${BUILD_DIR}/profraw"
 REPORT_DIR="${BUILD_DIR}/coverage"
 JOBS=$(command -v nproc >/dev/null 2>&1 && nproc || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 TESTS_REGEX=""
+
+# Canonical source-filter regex used by both llvm-cov and gcovr.
+# Matches paths we explicitly DO NOT want in the coverage report:
+#   _deps/          — FetchContent build trees (incl. Catch2)
+#   external/       — vendored dependencies
+#   test/           — test code itself (we measure coverage OF code under test)
+#   catch2/Catch2/  — Catch2 headers/src anywhere; papers over the
+#                     `build-coverage/_deps/catch2-build/src/src/` mapping
+#                     that produces "No such file or directory" stderr spam
+#                     on every llvm-cov show invocation (issue #569).
+#   build-coverage/ — this build tree itself.
+#   build/          — any other build tree.
+#
+# Each alternative uses `(^|/)` as the leading anchor so relative and
+# absolute paths are both matched. Keep in sync with `gcovr --exclude`
+# flags below and with planning/coverage-tooling-decision-2026-04-21.md §4.
+COVERAGE_IGNORE_REGEX='(^|/)(_deps|external|test|[Cc]atch2|build|build-coverage)/'
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -50,6 +71,31 @@ cmake -S "${REPO_ROOT}" -B "${BUILD_DIR}" \
     -DPULP_ENABLE_COVERAGE=ON \
     -DCMAKE_C_COMPILER=clang \
     -DCMAKE_CXX_COMPILER=clang++
+
+# Issue #570: if build-coverage/CMakeCache.txt was previously populated
+# with PULP_ENABLE_COVERAGE:BOOL=OFF (e.g. from a non-coverage run
+# that reused the same directory), the cached value wins on
+# reconfigure even though we pass -DPULP_ENABLE_COVERAGE=ON. The
+# instrumentation flags never reach flags.make, no profraw files are
+# emitted, and llvm-profdata merge later dies with "could not read
+# profile data!" — a symptom that looks like a test/instrumentation
+# bug, not a stale-cache bug. Assert the expected value stuck and
+# error loudly with the fix if not.
+CACHE_FILE="${BUILD_DIR}/CMakeCache.txt"
+if ! grep -q '^PULP_ENABLE_COVERAGE:BOOL=ON$' "${CACHE_FILE}" 2>/dev/null; then
+    echo "" >&2
+    echo "ERROR: PULP_ENABLE_COVERAGE=ON did not stick in the CMake cache." >&2
+    echo "  ${CACHE_FILE}" >&2
+    echo "  still holds the previous (non-coverage) value, so no" >&2
+    echo "  instrumentation flags will reach the compiler and no" >&2
+    echo "  profraw files will be emitted. This is issue #570." >&2
+    echo "" >&2
+    echo "  Fix: remove the stale cache and re-run this script:" >&2
+    echo "      rm -rf ${BUILD_DIR}" >&2
+    echo "      ${BASH_SOURCE[0]}" >&2
+    echo "" >&2
+    exit 3
+fi
 
 echo "=== Building ==="
 cmake --build "${BUILD_DIR}" -j"${JOBS}"
@@ -98,16 +144,55 @@ echo "=== llvm-cov report (top-level summary) ==="
 llvm-cov report \
     "${BINARIES[@]}" \
     -instr-profile="${PROFDATA}" \
-    -ignore-filename-regex='_deps/|/external/|/test/' \
+    -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
     | tee "${REPORT_DIR}/summary.txt"
 
 echo "=== llvm-cov show (HTML drilldown) ==="
 llvm-cov show \
     "${BINARIES[@]}" \
     -instr-profile="${PROFDATA}" \
-    -ignore-filename-regex='_deps/|/external/|/test/' \
+    -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
     -format=html \
     -output-dir="${REPORT_DIR}"
+
+# Issue #569 Phase 1 PR 1: also emit Cobertura XML alongside the HTML
+# report. Codecov + diff-cover both consume Cobertura; llvm-cov does
+# NOT produce Cobertura natively, so gcovr bridges llvm-cov JSON →
+# Cobertura XML. If gcovr isn't installed (local developer machine
+# without the optional dep), skip with a hint rather than fail — the
+# CI workflow explicitly installs gcovr, so CI coverage always has XML.
+COBERTURA_XML="${BUILD_DIR}/coverage.cobertura.xml"
+if command -v gcovr >/dev/null 2>&1; then
+    echo "=== gcovr (Cobertura XML for Codecov + diff-cover) ==="
+    # gcovr consumes the raw profdata + instrumented binaries and
+    # produces Cobertura XML. Pass the same filter set as llvm-cov
+    # (filters are anchored at repo root; excludes are regexes).
+    GCOVR_LLVM_BINS=()
+    for obj in "${BINARIES[@]}"; do
+        if [[ "${obj}" != "-object" ]]; then
+            GCOVR_LLVM_BINS+=("--llvm-cov-binary" "${obj}")
+        fi
+    done
+    gcovr \
+        --root "${REPO_ROOT}" \
+        --llvm-profdata-executable llvm-profdata \
+        "${GCOVR_LLVM_BINS[@]}" \
+        --filter 'core/' \
+        --filter 'tools/cli/' \
+        --exclude '.*/external/' \
+        --exclude '.*/test/' \
+        --exclude '.*/_deps/' \
+        --exclude '.*/[Cc]atch2/' \
+        --exclude '.*/build-coverage/' \
+        --exclude '.*/build/' \
+        --cobertura "${COBERTURA_XML}" \
+        "${PROFRAW_DIR}" \
+        || echo "gcovr exited non-zero — Cobertura XML may be partial (non-fatal)."
+    echo "Cobertura:  ${COBERTURA_XML}"
+else
+    echo "=== gcovr not found on PATH — skipping Cobertura XML ==="
+    echo "    (Codecov + diff-cover need this in CI; install: pip install gcovr)"
+fi
 
 echo ""
 echo "HTML report: ${REPORT_DIR}/index.html"

--- a/tools/scripts/test_run_coverage.py
+++ b/tools/scripts/test_run_coverage.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Fixture tests for scripts/run_coverage.sh.
+
+Covers the two bugs fixed in issue #566 Phase 1 PR 1:
+
+- #570: silent failure when CMakeCache.txt was previously configured
+  with PULP_ENABLE_COVERAGE:BOOL=OFF. The script must error loudly
+  (exit 3) with a helpful remediation message instead of silently
+  producing empty profdata.
+- #569: Catch2-path / _deps/ / build-coverage/ spam from llvm-cov
+  show and gcovr. The canonical `COVERAGE_IGNORE_REGEX` in the
+  script must match the noisy paths and NOT match the paths we
+  actually want to report on.
+
+We intentionally test the script without running a full build —
+that's minutes of CI time and the real dependency (Clang toolchain)
+already runs in `.github/workflows/coverage.yml`. Instead we exercise:
+
+  1. The post-configure cache assert by simulating a stale cache via
+     a stub `cmake` binary on PATH that leaves a bad cache in place.
+  2. The ignore-regex by grepping the canonical constant from the
+     script and running it against representative path fixtures.
+
+Run:
+    python3 tools/scripts/test_run_coverage.py
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "run_coverage.sh"
+
+
+def _read_ignore_regex() -> str:
+    """Extract COVERAGE_IGNORE_REGEX value from the script.
+
+    The script is the single source of truth; parse it directly so
+    this test can't drift from the shell variable definition.
+    """
+    text = SCRIPT.read_text()
+    match = re.search(
+        r"^COVERAGE_IGNORE_REGEX=(['\"])(?P<pattern>[^'\"]+)\1",
+        text,
+        flags=re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(
+            "Could not find COVERAGE_IGNORE_REGEX in scripts/run_coverage.sh"
+        )
+    return match.group("pattern")
+
+
+class IgnoreRegexTests(unittest.TestCase):
+    """The regex excludes noisy paths and keeps our real source tree."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.pattern = _read_ignore_regex()
+        cls.regex = re.compile(cls.pattern)
+
+    def assert_ignored(self, path: str) -> None:
+        self.assertTrue(
+            self.regex.search(path),
+            f"expected COVERAGE_IGNORE_REGEX to match noisy path: {path!r}",
+        )
+
+    def assert_kept(self, path: str) -> None:
+        self.assertFalse(
+            self.regex.search(path),
+            f"expected COVERAGE_IGNORE_REGEX to NOT match production path: {path!r}",
+        )
+
+    def test_ignores_catch2_build_mapping(self) -> None:
+        # The exact noisy paths from issue #569.
+        self.assert_ignored(
+            "build-coverage/_deps/catch2-build/src/src/catch2/catch_test_registry.cpp"
+        )
+        self.assert_ignored(
+            "build-coverage/_deps/catch2-build/src/src/catch2/internal/catch_debug_console.cpp"
+        )
+        self.assert_ignored(
+            "/abs/build-coverage/_deps/catch2-src/src/catch2/catch_all.hpp"
+        )
+
+    def test_ignores_fetchcontent_deps(self) -> None:
+        self.assert_ignored("build/_deps/dawn-src/src/dawn/native/device.cpp")
+        self.assert_ignored("build-coverage/_deps/skia-src/include/core/SkCanvas.h")
+
+    def test_ignores_external_dir(self) -> None:
+        self.assert_ignored("/repo/external/choc/choc_midi.h")
+        self.assert_ignored("external/vst3sdk/base/source/fbuffer.cpp")
+
+    def test_ignores_test_dir(self) -> None:
+        self.assert_ignored("test/test_audio.cpp")
+        self.assert_ignored("/abs/repo/test/helpers/test_helpers.hpp")
+
+    def test_ignores_build_dirs(self) -> None:
+        self.assert_ignored("/repo/build-coverage/CMakeFiles/Foo.cpp")
+        self.assert_ignored("/repo/build/CMakeFiles/bar.cpp")
+
+    def test_keeps_core_source(self) -> None:
+        # The stuff we ACTUALLY want coverage on.
+        self.assert_kept("core/audio/src/buffer_view.cpp")
+        self.assert_kept("core/host/src/host.cpp")
+        self.assert_kept("core/midi/include/pulp/midi/sysex_accumulator.hpp")
+        self.assert_kept("core/format/src/vst3_adapter.cpp")
+        self.assert_kept("tools/cli/src/cmd_build.cpp")
+
+    def test_keeps_paths_that_merely_contain_test_substring(self) -> None:
+        # Regression guard: a file called `attested.cpp` or a path like
+        # `core/contest/` should not be accidentally excluded by a naive
+        # 'test' substring match. We require the '/test/' component.
+        self.assert_kept("core/runtime/src/attested_payload.cpp")
+        self.assert_kept("core/protest/src/demo.cpp")
+
+
+class StaleCacheTests(unittest.TestCase):
+    """#570: the post-configure assert errors when the cache is stale.
+
+    Rather than running a real cmake configure (slow, toolchain-dependent),
+    we stub `cmake` with a shell script that writes a BAD CMakeCache.txt
+    (PULP_ENABLE_COVERAGE:BOOL=OFF) into the specified build directory,
+    then assert run_coverage.sh detects the mismatch and exits with the
+    expected error message + exit code.
+    """
+
+    def test_stale_cache_off_triggers_helpful_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            self._run_with_stub(tmp_path, cached_value="OFF")
+
+    def test_missing_cache_triggers_helpful_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            # Write nothing; the script should still bail with the same
+            # error (missing file == stale-or-bogus cache).
+            self._run_with_stub(tmp_path, cached_value=None)
+
+    def _run_with_stub(self, tmp: Path, cached_value: str | None) -> None:
+        # Stub cmake binary: writes a deliberately-wrong cache to the
+        # build dir so our post-configure assert trips.
+        stub_bin = tmp / "bin"
+        stub_bin.mkdir()
+        stub_cmake = stub_bin / "cmake"
+        cache_line = (
+            f"PULP_ENABLE_COVERAGE:BOOL={cached_value}\n"
+            if cached_value is not None
+            else ""
+        )
+        stub_cmake.write_text(
+            textwrap.dedent(
+                f"""
+                #!/usr/bin/env bash
+                set -e
+                # Parse -B to find the build dir.
+                BUILD=""
+                while [[ $# -gt 0 ]]; do
+                    case "$1" in
+                        -B) BUILD="$2"; shift 2 ;;
+                        *) shift ;;
+                    esac
+                done
+                if [[ -n "$BUILD" ]]; then
+                    mkdir -p "$BUILD"
+                    printf '{cache_line}' > "$BUILD/CMakeCache.txt"
+                fi
+                exit 0
+                """
+            ).lstrip()
+        )
+        stub_cmake.chmod(stub_cmake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+        # Fake build dir inside the stubbed repo root so the script's
+        # REPO_ROOT logic still works. We point REPO_ROOT at a tmp tree
+        # that has scripts/run_coverage.sh as a symlink to the real one.
+        repo = tmp / "repo"
+        repo.mkdir()
+        (repo / "scripts").mkdir()
+        (repo / "scripts" / "run_coverage.sh").symlink_to(SCRIPT)
+
+        # Provide stub clang/llvm-profdata/llvm-cov so the preflight
+        # checks pass even on hosts without a real toolchain.
+        for tool in ("clang", "llvm-profdata", "llvm-cov"):
+            stub = stub_bin / tool
+            stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+            stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+        env = os.environ.copy()
+        env["PATH"] = f"{stub_bin}:{env['PATH']}"
+
+        result = subprocess.run(
+            ["bash", str(repo / "scripts" / "run_coverage.sh")],
+            cwd=repo,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        # The script must exit 3 (our sentinel code) with a helpful
+        # message referencing the fix and the build dir.
+        self.assertEqual(
+            result.returncode,
+            3,
+            f"expected exit 3 for stale-cache guard, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        combined = result.stdout + result.stderr
+        self.assertIn("PULP_ENABLE_COVERAGE", combined)
+        self.assertIn("rm -rf", combined)
+        self.assertIn("#570", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Automated by `pulp pr`

### Skill-sync verdict
```
[ci] ✓ bypassed (Coverage workflow changes are documented alongside the pipeline itself and in the upcoming docs/guides/coverage.md (PR 2). The ci skill already documents the ship path; coverage internals don't match the 'gotcha' skill pattern.)
    .github/workflows/coverage.yml

```

### Version-bump verdict
```
[sdk] Pulp SDK / CLI: no bump needed
[plugin] Claude Code plugin: no bump needed

```
