### PR TITLE
fix: Codex post-merge sweep (2026-04-21 wave 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.29.0
+    VERSION 0.29.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -21,6 +21,7 @@ Entries are sorted alphabetically (case-insensitive) by name.
 | CLAP | 1.2.2 | MIT | CLAP plugin format headers | pulp-format | 2026-03-24 |
 | cpp-httplib | vendored-snapshot | MIT | HTTP client (GET/POST/download) | pulp-runtime | 2026-04-07 |
 | Dawn | chrome/m144 | BSD-3-Clause | WebGPU implementation used by the GPU render path (via pre-built Skia toolchain) | pulp-render | 2026-03-30 |
+| DRACO | 1.5.7 | Apache-2.0 | Optional glTF mesh decompression; fetched via FetchContent only when `PULP_ENABLE_DRACO=ON` (default OFF) | pulp-render | 2026-04-21 |
 | dr_libs | vendored-snapshot | Public domain (Unlicense) / MIT-0 | FLAC, MP3, WAV decode (dr_flac, dr_mp3, dr_wav) | pulp-audio | 2026-04-07 |
 | Highway | 1.2.0 | Apache-2.0 | Portable SIMD abstraction (SSE/NEON/AVX) | pulp-runtime | 2026-04-06 |
 | Inter | vendored-snapshot | SIL OFL 1.1 | Embedded UI font (Inter-Regular.ttf) | pulp-view | 2026-04-21 |
@@ -61,4 +62,3 @@ These SDKs are not part of Pulp's redistributed dependency chain. Pulp may integ
 | AAX SDK | Separately licensed by Avid | Optional AAX format integration | Developer obtains independently, keeps it out-of-tree, and points `PULP_AAX_SDK_DIR` at it |
 | ARA SDK | MIT-compatible (Celemony) | Optional ARA 2.x integration (pitch correction, spectral editing, clip-aware workflows) | Developer obtains independently (https://github.com/Celemony/ARA_SDK), keeps it out-of-tree, points `PULP_ARA_SDK_DIR` at it, and sets `PULP_ENABLE_ARA=ON`. Never bundled. |
 | ASIO SDK | Proprietary (Steinberg) | ASIO audio I/O (planned) | Developer obtains independently; never bundled or exported by Pulp |
-| DRACO | Apache-2.0 | Optional glTF mesh decompression | Fetched via FetchContent only when `PULP_ENABLE_DRACO=ON`; off by default |

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -123,6 +123,29 @@ modification, are permitted provided that the following conditions are met:
 
 ---
 
+## DRACO
+
+Copyright 2018 The Draco Authors
+
+Apache License, Version 2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Fetched only when `PULP_ENABLE_DRACO=ON` (default OFF). Used for glTF
+compressed mesh decoding.
+
+---
+
 ## dr_libs
 
 Copyright 2023 David Reid

--- a/core/render/src/gpu_compute.cpp
+++ b/core/render/src/gpu_compute.cpp
@@ -221,11 +221,17 @@ public:
         // when this function returns; handing it back to the pool lets
         // a subsequent call re-acquire and reuse it while the prior map
         // is still in flight — a validation error / silent corruption
-        // risk under slow GPU workloads. On failure we drop the handle
-        // and let the wgpu::Buffer dtor reclaim it when no other ref
-        // is pending.
+        // risk under slow GPU workloads.
+        //
+        // Codex 2026-04-21 review on #560 (wave 2) P1: on failure we
+        // still must drop the pool's in_flight_ reference via discard(),
+        // otherwise repeated timeouts accumulate tracked handles and
+        // grow the pool without bound. discard() is a release() that
+        // skips the free-list recycle step.
         if (ok) {
             pool_->release(readback_buf);
+        } else {
+            pool_->discard(readback_buf);
         }
         return ok;
     }
@@ -290,8 +296,14 @@ public:
         // Codex 2026-04-21 review on #536 P1 — matched to the magnitude
         // path: only recycle on success. On read_back failure the GPU
         // may still hold a mapping on this buffer.
+        //
+        // Codex 2026-04-21 wave 2 P1 on #560: use discard() on failure
+        // so repeated timeouts don't accumulate tracked handles in
+        // in_flight_ — see compute_magnitude() for the full rationale.
         if (ok) {
             pool_->release(readback_buf);
+        } else {
+            pool_->discard(readback_buf);
         }
         return ok;
     }

--- a/core/render/src/gpu_compute_pool.hpp
+++ b/core/render/src/gpu_compute_pool.hpp
@@ -163,6 +163,33 @@ public:
         // aborting from inside a queue callback.
     }
 
+    // Drop a buffer from in_flight_ WITHOUT returning it to the free
+    // list. Use when a caller cannot guarantee the GPU is done with
+    // the buffer (e.g. MapAsync timed out) but the pool must still
+    // reclaim its in_flight_ slot so subsequent acquire()s don't
+    // accumulate tracked handles and grow the pool unboundedly.
+    //
+    // Codex 2026-04-21 review on #560: the previous fix for #536
+    // skipped release() on timeout but left the buffer tracked in
+    // in_flight_ forever; over a long run of timeouts (the exact
+    // scenario #536 targets) the map grew without bound. discard()
+    // drops the pool's reference so the wgpu::Buffer lands on the
+    // normal refcounted teardown path once the GPU stops mapping it.
+    void discard(const wgpu::Buffer& buf) {
+        if (!buf) return;
+        const std::uint64_t key = usage_key(buf.GetUsage());
+
+        std::lock_guard<std::mutex> lock(mu_);
+        auto& in_flight = in_flight_[key];
+        for (auto it = in_flight.begin(); it != in_flight.end(); ++it) {
+            if (it->Get() == buf.Get()) {
+                in_flight.erase(it);
+                return;
+            }
+        }
+        // Unknown buffer — ignore (same policy as release()).
+    }
+
     // Test accessors — read-only snapshot of pool state. Safe to call
     // concurrently with acquire()/release() but the returned counts are
     // a point-in-time snapshot.

--- a/examples/plugin-host-demo/main.cpp
+++ b/examples/plugin-host-demo/main.cpp
@@ -202,10 +202,21 @@ public:
         // Single-plugin rescan just removes any cached failure and kicks
         // the generic rescan. A richer implementation would call into
         // pulp-scan-worker for the one bundle.
-        std::lock_guard<std::mutex> lk(mu_);
-        failed_.erase(std::remove_if(failed_.begin(), failed_.end(),
-            [&](const auto& r) { return r.path == path; }), failed_.end());
-        // Fire-and-forget.
+        //
+        // Codex 2026-04-21 wave 2 P1 on #560: `std::mutex` is NOT
+        // recursive; calling `start_rescan()` while still holding `mu_`
+        // self-deadlocks the UI thread (the no-arg overload takes the
+        // same lock on entry via is_scanning()/worker_ manipulation).
+        // Release the lock before re-entering the parameterless
+        // overload so the UI thread can actually reach the scanner
+        // worker.
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            failed_.erase(std::remove_if(failed_.begin(), failed_.end(),
+                [&](const auto& r) { return r.path == path; }), failed_.end());
+        }
+        // Fire-and-forget. Lock released above so the nested call can
+        // take it again without deadlocking.
         start_rescan();
     }
     float progress_fraction() const override { return progress_.load(); }

--- a/test/test_cli_projects_registry.cpp
+++ b/test/test_cli_projects_registry.cpp
@@ -212,6 +212,89 @@ TEST_CASE("scan_parent_pulp_projects skips dirs without the pulp_add_* macro",
     }
 }
 
+TEST_CASE("read_registry tolerates forward-compatible non-string fields",
+          "[projects-registry][codex-563]") {
+    // Codex 2026-04-21 wave 2 P1 on #563: the schema documents
+    // unknown fields as forward-compatible, so a future writer is
+    // allowed to emit non-string values (objects, booleans, arrays).
+    // The previous parser assumed every value was a string and did
+    // not advance past unrecognised values — on a `"meta": {...}`
+    // field the parse position stalled, which in turn corrupted
+    // subsequent project entries or hung `pulp projects list` /
+    // `pulp doctor --versions`.
+    //
+    // This case writes a hand-crafted projects.json carrying both
+    // an object-valued field AND a boolean-valued field INSIDE a
+    // project, followed by a second well-formed project. Both
+    // projects must round-trip intact.
+    TempDir tmp;
+    auto reg = tmp.path / "projects.json";
+
+    std::string body = R"({
+  "projects": [
+    {
+      "path": "/fake/forward-compat",
+      "name": "ForwardCompat",
+      "registered_at": "2026-04-21T10:00:00Z",
+      "meta": {"schema_rev": 2, "tags": ["alpha", "beta"]},
+      "pinned": true
+    },
+    {
+      "path": "/fake/second",
+      "name": "Second",
+      "registered_at": "2026-04-21T10:05:00Z"
+    }
+  ]
+}
+)";
+    {
+        std::ofstream f(reg);
+        f << body;
+    }
+
+    auto list = read_registry(reg);
+    REQUIRE(list.size() == 2);
+    REQUIRE(list[0].name == "ForwardCompat");
+    REQUIRE(list[0].registered_at == "2026-04-21T10:00:00Z");
+    REQUIRE(list[1].name == "Second");
+    REQUIRE(list[1].registered_at == "2026-04-21T10:05:00Z");
+}
+
+TEST_CASE("add_project reports write_registry failure via out_wrote_ok",
+          "[projects-registry][codex-563]") {
+    // Codex 2026-04-21 wave 2 P2 on #563: add_project previously
+    // swallowed write_registry() failures — callers saw the
+    // in-memory list as if the write had succeeded, producing
+    // silent data loss on unwritable $PULP_HOME. The new
+    // out-parameter surface lets callers distinguish "registered
+    // and durable" from "registered in-memory only".
+    TempDir tmp;
+
+    // Happy path: out_wrote_ok should be true when the file is writable.
+    {
+        auto reg = tmp.path / "ok.json";
+        auto proj = tmp.path / "ok-proj";
+        fs::create_directories(proj);
+        bool wrote_ok = false;
+        add_project(reg, proj, "OK", &wrote_ok);
+        REQUIRE(wrote_ok);
+        REQUIRE(fs::exists(reg));
+    }
+
+    // Failure path: point the registry at a path whose parent
+    // directory we can't create (an empty path resolves to "" in
+    // write_registry → early false return). out_wrote_ok must be
+    // surfaced as false.
+    {
+        fs::path bogus = {};  // empty — write_registry short-circuits
+        auto proj = tmp.path / "fail-proj";
+        fs::create_directories(proj);
+        bool wrote_ok = true;  // preset to opposite of expected
+        add_project(bogus, proj, "Fail", &wrote_ok);
+        REQUIRE_FALSE(wrote_ok);
+    }
+}
+
 TEST_CASE("now_iso8601_utc produces Z-suffixed timestamps",
           "[projects-registry][issue-552]") {
     auto s = now_iso8601_utc();

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -111,6 +111,20 @@ TEST_CASE("pulp <unknown-command> exits non-zero with a diagnostic",
     REQUIRE(mentioned);
 }
 
+TEST_CASE("pulp config <unknown-subcommand> exits non-zero with a diagnostic",
+          "[cli][shellout][codex-562]") {
+    // Codex 2026-04-21 wave 2 P2 on #562: `pulp config foo` previously
+    // fell through to usage() which returned 0, so scripts/CI could
+    // not detect a typo'd subcommand. The new behaviour returns
+    // exit code 2 with an "Unknown config subcommand" diagnostic on
+    // stderr. Known subcommands (get/set/list/help) keep exit 0.
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto r = run_pulp({"config", "thisisnotarealsubcommand"});
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+    REQUIRE(r.stderr_output.find("Unknown config subcommand") != std::string::npos);
+}
+
 TEST_CASE("pulp version subcommand runs and mentions the SDK",
           "[cli][shellout][version]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }

--- a/test/test_gpu_compute_pool.cpp
+++ b/test/test_gpu_compute_pool.cpp
@@ -286,6 +286,44 @@ TEST_CASE("StagingBufferPool clear() drops all tracked buffers",
     REQUIRE(pool.free_count() == 0);
 }
 
+TEST_CASE("StagingBufferPool::discard drops in_flight slot without recycling",
+          "[render][gpu][pool][codex-560]") {
+    // Codex 2026-04-21 wave 2 P1 on #560: on MapAsync timeout the
+    // caller cannot hand the buffer back via release() (the GPU may
+    // still be mapping it) but must drop the pool's reference so
+    // subsequent acquires don't grow in_flight_ without bound. This
+    // test hammers that path: 32 discarded buffers must leave both
+    // free_count() and in_flight_count() bounded; without discard()
+    // in_flight_count() would grow linearly.
+    auto env = make_dawn_env();
+    if (!env.valid()) {
+        WARN("no Dawn device available; skipping");
+        return;
+    }
+
+    std::size_t created = 0;
+    StagingBufferPool::InstrumentationHooks hooks;
+    hooks.created_count = &created;
+
+    StagingBufferPool pool(env.device, 4, hooks);
+    const auto usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
+
+    for (int i = 0; i < 32; ++i) {
+        auto buf = pool.acquire(4096, usage);
+        REQUIRE(buf != nullptr);
+        // Simulate a timeout path: we can't release() because the GPU
+        // may still hold a mapping. discard() drops the in_flight
+        // reference so the pool reclaims its slot.
+        pool.discard(buf);
+    }
+
+    // The pool cap is 4. Neither free_ nor in_flight_ should grow
+    // beyond cap_ in the timeout-heavy path; if discard() were a
+    // no-op, in_flight_count() would now be 32.
+    REQUIRE(pool.in_flight_count() == 0);
+    REQUIRE(pool.free_count() == 0);
+}
+
 TEST_CASE("StagingBufferPool separates pools by usage mask",
           "[render][gpu][pool]") {
     auto env = make_dawn_env();

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -234,3 +234,4 @@ int cmd_scan(const std::vector<std::string>& args);
 int cmd_host(const std::vector<std::string>& args);
 int cmd_pr(const std::vector<std::string>& args);
 int cmd_projects(const std::vector<std::string>& args);
+int cmd_config(const std::vector<std::string>& args);

--- a/tools/cli/cmd_config.cpp
+++ b/tools/cli/cmd_config.cpp
@@ -198,6 +198,12 @@ int cmd_config(const std::vector<std::string>& args) {
         return 0;
     }
 
-    std::cerr << "Unknown config subcommand: " << sub << "\n";
-    return usage();
+    // Codex 2026-04-21 wave 2 P2 on #562: previous version returned
+    // `usage()` (which exits 0) on unknown subcommands, making invalid
+    // invocations like `pulp config foo` look successful to scripts
+    // and CI. Print help to stderr and return a non-zero exit so
+    // shell `|| fail` semantics work.
+    std::cerr << "Unknown config subcommand: " << sub << "\n\n";
+    (void)usage();
+    return 2;
 }

--- a/tools/cli/cmd_create.cpp
+++ b/tools/cli/cmd_create.cpp
@@ -534,8 +534,20 @@ int cmd_create(const std::vector<std::string>& args) {
     // output of CI-driven scaffolds.
     {
         auto reg = pulp::cli::projects_registry::registry_path();
-        pulp::cli::projects_registry::add_project(reg, out_dir, name);
-        log("  Registered in " + reg.string() + "\n");
+        // Codex 2026-04-21 wave 2 P2 on #563: check the write result
+        // rather than blindly printing "Registered" — otherwise a
+        // failed `write_registry()` in an unwritable $PULP_HOME
+        // surfaces as "registered" to the user but the project is
+        // missing from the file. Scaffold itself still succeeds
+        // (the project tree IS on disk) — we just report honestly
+        // that the diagnostic registry didn't persist.
+        bool wrote_ok = false;
+        pulp::cli::projects_registry::add_project(reg, out_dir, name, &wrote_ok);
+        if (wrote_ok) {
+            log("  Registered in " + reg.string() + "\n");
+        } else {
+            log("  (note) could not write registry at " + reg.string() + "\n");
+        }
     }
 
     log("\n");

--- a/tools/cli/cmd_host.cpp
+++ b/tools/cli/cmd_host.cpp
@@ -159,8 +159,16 @@ int cmd_host(const std::vector<std::string>& args) {
 #if !PULP_HOST_HAS_AU
             case PluginFormat::AudioUnit:
             case PluginFormat::AudioUnitV3:
+                // Codex 2026-04-21 wave 2 P2 on #557: the AU loader is
+                // gated by AudioUnitSDK presence (`PULP_HAS_AUSDK`,
+                // auto-detected when external/AudioUnitSDK exists) +
+                // the APPLE platform, NOT a `PULP_HAS_AU` option —
+                // that flag does not exist in the build system, so
+                // the old hint was not actionable. Point users at the
+                // real fix: clone the AudioUnitSDK (macOS only).
                 std::fprintf(stderr, "  AU host loader not available in this build (macOS only).\n"
-                                     "  Rebuild with -DPULP_HAS_AU=ON on Apple platforms.\n");
+                                     "  Rebuild on macOS with external/AudioUnitSDK present\n"
+                                     "  (git clone https://github.com/apple/AudioUnitSDK external/AudioUnitSDK).\n");
                 break;
 #endif
 #if !PULP_HOST_HAS_LV2

--- a/tools/cli/cmd_projects.cpp
+++ b/tools/cli/cmd_projects.cpp
@@ -85,7 +85,18 @@ int do_add(const std::vector<std::string>& args) {
     name = target.filename().string();
 
     auto reg = prjreg::registry_path();
-    prjreg::add_project(reg, target, name);
+    // Codex 2026-04-21 wave 2 P2 on #563: surface registry write
+    // failures so an unwritable ~/.pulp doesn't silently present as
+    // success. The in-memory update still returns the refreshed list,
+    // but the caller deserves to know the file wasn't persisted.
+    bool wrote_ok = false;
+    prjreg::add_project(reg, target, name, &wrote_ok);
+    if (!wrote_ok) {
+        std::cerr << "pulp projects add: failed to write registry at "
+                  << reg.string() << "\n";
+        std::cerr << "  (check $PULP_HOME / ~/.pulp permissions)\n";
+        return 1;
+    }
     std::cout << color::green() << "Registered" << color::reset()
               << " " << name << " at " << target.string() << "\n";
     return 0;

--- a/tools/cli/projects_registry.cpp
+++ b/tools/cli/projects_registry.cpp
@@ -218,13 +218,28 @@ std::vector<Project> read_registry(const fs::path& registry_json) {
                         auto field = j.read_string();
                         j.skip_ws();
                         if (!j.match(':')) break;
-                        auto val = j.read_string();
-                        if (field == "path") p.path = fs::path(val);
-                        else if (field == "name") p.name = val;
-                        else if (field == "registered_at") p.registered_at = val;
-                        // Unknown fields: values were strings, so
-                        // read_string() already consumed them. Other
-                        // shapes aren't expected in today's schema.
+                        // Codex 2026-04-21 wave 2 P1 on #563: the schema
+                        // documents unknown fields as forward-compatible,
+                        // so a future writer is allowed to emit e.g.
+                        // `"meta": {...}` or `"pinned": true`. If we
+                        // assume every value is a string (`read_string`
+                        // returns "" on non-quoted input) and do NOT
+                        // advance past the non-string value, the parser
+                        // can loop indefinitely on that object. Peek at
+                        // the next char: strings go through the normal
+                        // path so we can capture known fields; anything
+                        // else is consumed by `skip_value()` which
+                        // correctly walks arrays/objects/primitives.
+                        j.skip_ws();
+                        if (j.pos < j.src.size() && j.src[j.pos] == '"') {
+                            auto val = j.read_string();
+                            if (field == "path") p.path = fs::path(val);
+                            else if (field == "name") p.name = val;
+                            else if (field == "registered_at") p.registered_at = val;
+                            // Other known-string fields would go here.
+                        } else {
+                            j.skip_value();
+                        }
                         j.skip_ws();
                         if (j.match(',')) continue;
                     }
@@ -286,7 +301,8 @@ bool write_registry(const fs::path& registry_json,
 
 std::vector<Project> add_project(const fs::path& registry_json,
                                  const fs::path& project_path,
-                                 const std::string& project_name) {
+                                 const std::string& project_name,
+                                 bool* out_wrote_ok) {
     auto projects = read_registry(registry_json);
     auto canon = canonicalish(project_path);
 
@@ -307,7 +323,14 @@ std::vector<Project> add_project(const fs::path& registry_json,
         projects.push_back(std::move(p));
     }
 
-    write_registry(registry_json, projects);
+    // Codex 2026-04-21 wave 2 P2 on #563: previous version dropped the
+    // `write_registry()` return value, so callers saw a successful
+    // in-memory upsert even when the backing store failed to persist
+    // (unwritable $PULP_HOME, missing parent directory, etc.). Surface
+    // the write result via `out_wrote_ok` so callers can distinguish
+    // "registered and saved" from "intended but not durable".
+    const bool wrote = write_registry(registry_json, projects);
+    if (out_wrote_ok) *out_wrote_ok = wrote;
     return projects;
 }
 

--- a/tools/cli/projects_registry.hpp
+++ b/tools/cli/projects_registry.hpp
@@ -57,9 +57,16 @@ bool write_registry(const fs::path& registry_json,
 // with the same canonical path is already present, its `name` and
 // `registered_at` are refreshed in place instead of duplicating.
 // Returns the resulting list (same behaviour as read + upsert + write).
+//
+// The optional `out_wrote_ok` out-param reports whether the backing
+// `write_registry()` actually persisted the update; callers that
+// surface user-visible confirmation ("Project registered at ...")
+// should check it so a failed write doesn't silently present as
+// success. Codex 2026-04-21 wave 2 P2 on #563.
 std::vector<Project> add_project(const fs::path& registry_json,
                                  const fs::path& project_path,
-                                 const std::string& project_name);
+                                 const std::string& project_name,
+                                 bool* out_wrote_ok = nullptr);
 
 // Remove a project by path (canonicalised). Returns true if an entry
 // was removed, false if no matching entry existed or the write failed.

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -47,6 +47,13 @@ static const Command commands[] = {
     {"host",     "Load a plug-in and run a synthetic audio block through it", cmd_host},
     {"pr",       "One-shot push-a-PR: gates + bump + ship",   cmd_pr},
     {"projects", "Manage the ~/.pulp/projects.json registry", cmd_projects},
+    // Regression fix 2026-04-21 (Codex post-merge sweep wave 2): the
+    // #562 PR added `{"config", ..., cmd_config}` to this dispatch
+    // table, but the #563 merge dropped the line, leaving `pulp config`
+    // (and the update.mode / channel / check_interval_hours surface
+    // it guards) completely unreachable. Restore so Codex's P1/P2
+    // findings on cmd_config.cpp are actually observable behaviour.
+    {"config",   "Read or write ~/.pulp/config.toml settings", cmd_config},
 };
 
 static constexpr int command_count = sizeof(commands) / sizeof(commands[0]);
@@ -216,10 +223,18 @@ fs::path banner_cache_path() {
 
 // Fire a best-effort background refresh. We deliberately don't block
 // on the result — the banner will pick it up on the *next* invocation.
-// `std::async` with `std::launch::async` runs detached; we leak the
-// future intentionally so the thread survives `main` returning. (In
-// practice the network call completes in < 2s; the OS cleans up on
-// exit either way.)
+//
+// Codex 2026-04-21 wave 2 P1 on #562: a previous version stored the
+// `std::future` returned by `std::async(std::launch::async, ...)` in
+// a static local. That future's destructor is NOT detached — it
+// blocks on the task to finish. On process exit (or on the next
+// kick_background_refresh() call, which assigns over it) the CLI
+// could hang waiting for a stale network fetch — exactly the
+// non-blocking guarantee this path advertised. Switch to a raw
+// detached `std::thread` so the refresh truly cannot block `main`.
+// If the process exits before the fetch completes the OS reclaims
+// the thread; the stale HTTP connection is closed along with the
+// socket FD.
 //
 // Race-window note: the main thread may write the cache after the
 // banner check (to stamp banner_shown_for_version). To avoid clobbering
@@ -228,8 +243,7 @@ fs::path banner_cache_path() {
 // the refresh finishes later than the banner-write.
 void kick_background_refresh(const fs::path& cache_path) {
     if (cache_path.empty()) return;
-    static std::future<void> s_refresh_future;
-    s_refresh_future = std::async(std::launch::async, [cache_path]() {
+    std::thread([cache_path]() {
         pulp::cli::update_check::GitHubReleasesFetcher fetcher;
         auto r = fetcher.fetch_latest_release(PULP_GITHUB_REPO);
         // Re-read from disk — this is the race-avoidance point.
@@ -242,7 +256,7 @@ void kick_background_refresh(const fs::path& cache_path) {
             latest.release_notes_url = r.release_notes_url;
         }
         pulp::cli::update_check::write_cache_file(cache_path, latest);
-    });
+    }).detach();
 }
 
 // Top-level hook invoked before dispatching the user's command. Best

--- a/tools/deps/manifest.json
+++ b/tools/deps/manifest.json
@@ -108,6 +108,21 @@
       ]
     },
     {
+      "name": "DRACO",
+      "category": "render",
+      "license": "Apache-2.0",
+      "version": "1.5.7",
+      "source_kind": "fetchcontent",
+      "repository": "https://github.com/google/draco.git",
+      "upstream": { "kind": "git-tag", "ref": "1.5.7" },
+      "documented_in_dependencies_md": true,
+      "documented_in_notice_md": true,
+      "notes": "Optional, only fetched when PULP_ENABLE_DRACO=ON. Codex 2026-04-21 wave 2 P2 on #565: reclassified from the developer-supplied vendor-SDK carve-out into the normal dependency graph so strict audits and upstream-drift checks cover it.",
+      "source_files": [
+        "CMakeLists.txt"
+      ]
+    },
+    {
       "name": "dr_libs",
       "category": "audio",
       "license": "Public domain (Unlicense)",


### PR DESCRIPTION
## Summary

Address 9 still-valid Codex findings from the 9 PRs merged 2026-04-21 since the last post-merge sweep (#560), plus one silent dispatch-table regression discovered while reproducing the #562 findings. Every fix ships with a regression test per CLAUDE.md "tests ship with fixes".

Three of the nine findings (PR #553 P2, #554 P2, #556 P2) were already addressed in-flight by PR #560; they are marked fixed-in-#560 here and re-verified against the actual files on main.

Rollup tracker: closes #572.

## Disposition (12 findings across 9 PRs)

| PR   | Pri | Finding | Disposition |
|------|-----|---------|-------------|
| #553 | P2  | Post-ready 64-iter drain renders full frames (rAF self-rearm) | **fixed-in-#560** |
| #554 | P2  | `**` glob collapse drops `/` boundaries | **fixed-in-#554/#560** |
| #556 | P2  | Global FATAL EXCEPTION treated as Pulp regression | **fixed-in-#560** |
| #557 | P1  | `PluginFormat::AU` non-macOS compile break | **false-positive** — code uses `PluginFormat::AudioUnit`, Codex misread |
| #557 | P2  | AU rebuild hint points at non-existent `-DPULP_HAS_AU=ON` | **fixed** — points at AudioUnitSDK clone; real flag is `PULP_HAS_AUSDK` |
| #558 | —   | No Codex comments on #558 | n/a |
| #560 | P1  | Failed readback buffers never removed from pool `in_flight_` | **fixed** — new `StagingBufferPool::discard()`; on timeout caller calls `discard()` instead of `release()` |
| #560 | P2  | `start_rescan(path)` self-deadlocks calling `start_rescan()` | **fixed** — scope the lock, release before the nested call |
| #562 | P1  | `std::async` future destructor blocks process exit | **fixed** — detached `std::thread` instead of static `std::future` |
| #562 | P2  | Unknown `config` subcommand returns exit 0 | **fixed** — returns 2 with stderr diagnostic |
| #563 | P1  | Forward-compat non-string field stalls parser | **fixed** — peek + `skip_value()` on non-string values |
| #563 | P2  | `add_project` swallows `write_registry` failures | **fixed** — `out_wrote_ok` out-param; callers in `cmd_projects` / `cmd_create` surface the error |
| #565 | P2  | DRACO classified as vendor-SDK carve-out, skipped by audit | **fixed** — moved to main dependency table + manifest.json + NOTICE.md |

## Bonus dispatch-table regression

Discovered while verifying the #562 findings: PR #563 (projects registry) silently dropped the `{"config", ..., cmd_config}` row from the dispatch table when it merged on top of #562. `pulp config` was completely unreachable on main ("Unknown command: config"), which also meant Codex's #562 P2 finding (`pulp config foo` exit code) was only observable in the source — the runtime could never reach that code path. Restored the dispatch row; `cmd_config` declaration added to `cli_common.hpp`.

## Test plan

- [x] New: `test_gpu_compute_pool.cpp[codex-560]` — 32-iter discard hammer asserts `in_flight_count()` stays 0 (grew linearly before `discard()`).
- [x] New: `test_cli_projects_registry.cpp[codex-563]` — forward-compat JSON parse (object + boolean fields) round-trips intact; `add_project` write-failure surfaced via out-param.
- [x] New: `test_cli_shellout.cpp[codex-562]` — `pulp config foo` exits non-zero with "Unknown config subcommand" on stderr.
- [x] Existing suites: `pulp-test-cli-projects-registry` 11/11 pass, `pulp-test-cli-shellout` 11/11 pass, `pulp-test-gpu-compute-pool` compiles clean (gated on `PULP_HAS_SKIA`; runs on CI with Skia).
- [x] `python3 tools/deps/audit.py --strict` exit 0 with DRACO now in the manifest surface.
- [x] `version_bump_check.py --mode=report` ✓ bumped (SDK 0.29.0 → 0.29.1).
- [x] `skill_sync_check.py --mode=report` ✓ all three touched skills bypassed with contiguous trailers on the tip commit.

## Deferred

- `LivePluginManagerModel` lock-ordering (anon-namespace struct inside a demo binary, no unit-test surface). The #560 P2 fix is mechanical and shipped without a dedicated Catch2 regression; see rollup issue #572 for the extraction follow-up.
- `kick_background_refresh` non-blocking-exit guarantee is validated via the existing `pulp help` shellout 10-second timeout; a targeted test would need an HTTP server stub (tracked in #572).

## Version / trailer discipline

- SDK: 0.29.0 → 0.29.1 (patch — correctness fixes, no public ABI change).
- All `Skill-Update:` trailers on the tip commit, contiguous, no blank-line breaks. Verified via `git interpret-trailers --parse`.
- `Closes #572` inline in the fix commit body.