### PR TITLE
ci(coverage): wire Codecov dashboard + 20-flag carve-up (#566 Phase 1 PR 2)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -108,5 +108,9 @@ jobs:
         with:
           files: build-coverage/coverage.cobertura.xml
           flags: audio,canvas,events,format,host,midi,osc,platform,render,runtime,signal,state,view,android,apple,linux,windows,cli,ship,tools
+          # Token makes upload more reliable (avoids tokenless rate limits);
+          # action silently falls back to tokenless if the secret is unset
+          # (e.g. in forked-PR context where secrets aren't exposed).
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,8 +81,8 @@ jobs:
           retention-days: 90
 
       - name: Upload Cobertura XML
-        # PR 1 lands the XML artifact; PR 2 wires it into Codecov and
-        # PR 3 wires it into diff-cover. Keep the retention short —
+        # PR 1 lands the XML artifact, PR 2 wires it into Codecov below,
+        # and PR 3 wires it into diff-cover. Keep the retention short —
         # once Codecov is live the XML lives there.
         if: always()
         uses: actions/upload-artifact@v6
@@ -91,3 +91,22 @@ jobs:
           path: build-coverage/coverage.cobertura.xml
           retention-days: 14
           if-no-files-found: warn
+
+      - name: Upload coverage to Codecov
+        # #566 Phase 1 PR 2: Codecov measurement baseline. The repo
+        # is public so tokenless upload is supported. 20 flags (13
+        # core subsystems + 4 platforms + 3 surfaces) per codecov.yml
+        # — Codecov splits coverage per flag using the `paths:`
+        # mappings in codecov.yml, so we list them all here to tell
+        # Codecov which flag buckets to populate for this upload.
+        #
+        # fail_ci_if_error: false — coverage is still advisory in
+        # Phase 1. Phase 3 adds a diff-cover gate for per-PR
+        # enforcement.
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: build-coverage/coverage.cobertura.xml
+          flags: audio,canvas,events,format,host,midi,osc,platform,render,runtime,signal,state,view,android,apple,linux,windows,cli,ship,tools
+          fail_ci_if_error: false
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,173 @@
+# codecov.yml — Codecov config for public/#566 Phase 1 (measurement baseline).
+#
+# Primary consumers (in order): Pulp developers, dispatched agents, CI
+# enforcement, contributors reading PR comments. Public dashboard is a
+# byproduct, not the design goal. See #566 for the framing and
+# planning/coverage-tooling-decision-2026-04-21.md for the full stack.
+#
+# Keep this file in sync with:
+#   - scripts/run_coverage.sh COVERAGE_IGNORE_REGEX (same exclude set)
+#   - .github/workflows/coverage.yml (upload step `flags:` list)
+#   - docs/guides/coverage.md (human-readable explanation)
+# Phase 2 adds ci/coverage-targets.yaml alongside this for the diff-cover
+# gate; Phase 4 introduces doc_path_map.json to prevent drift.
+
+coverage:
+  status:
+    # Project-wide status: "did we get worse?" Not a hard gate — we
+    # already have continue-on-error on the coverage job and Phase 3
+    # is where per-PR enforcement lands.
+    project:
+      default:
+        target: auto
+        threshold: 1%          # allow 1% drop without failing
+        informational: true    # Phase 1 is measurement; no blocking yet
+
+    # Patch status: "is new code covered?" Advisory in Phase 1; the
+    # authoritative patch gate comes from diff-cover in Phase 3.
+    patch:
+      default:
+        target: 75%
+        informational: true
+
+  # Exclude lists mirror scripts/run_coverage.sh COVERAGE_IGNORE_REGEX
+  # so Codecov and our local tooling count the same set of files.
+  # External FetchContent sources (Dawn, Skia, mbedTLS, QuickJS,
+  # Catch2, etc.) and our test trees are never counted as coverage-
+  # bearing. See planning/coverage-tooling-decision-2026-04-21.md §4.
+  ignore:
+    - "external/**"
+    - "_deps/**"
+    - "test/**"
+    - "examples/**"
+    - "build/**"
+    - "build-coverage/**"
+    - "**/Catch2/**"
+    - "**/catch2/**"
+
+# PR comment. Focused on reach + diff + flags + tree so contributors
+# see "how many lines of THIS PR are covered by THIS PR's tests"
+# front-and-centre. Tree view lets them jump to an uncovered file.
+comment:
+  layout: "reach, diff, flags, tree"
+  behavior: default
+  require_changes: true        # only post when coverage data is present
+
+# Flags carve up the codebase along the three axes we care about:
+# subsystem, platform, and surface. Defined per the canonical table
+# in issue #566. Cross-filter from the dashboard: e.g. `audio AND
+# linux` answers "what's audio coverage on Linux specifically?" —
+# useful when an ALSA-only regression would otherwise hide inside a
+# healthy multi-platform subsystem number.
+#
+# 13 core subsystems + 4 platforms + 3 surfaces = 20 flags (Phase 1
+# baseline). Adding a new subsystem adds a new flag + tier entry
+# here + a row in docs/reference/modules.md (Phase 4's doc-sync
+# gate will keep those three honest).
+flags:
+  # Core subsystems (13) — one flag per top-level core/** directory.
+  audio:
+    paths:
+      - core/audio/
+    carryforward: true
+  canvas:
+    paths:
+      - core/canvas/
+    carryforward: true
+  events:
+    paths:
+      - core/events/
+    carryforward: true
+  format:
+    paths:
+      - core/format/
+    carryforward: true
+  host:
+    paths:
+      - core/host/
+    carryforward: true
+  midi:
+    paths:
+      - core/midi/
+    carryforward: true
+  osc:
+    paths:
+      - core/osc/
+    carryforward: true
+  platform:
+    paths:
+      - core/platform/
+    carryforward: true
+  render:
+    paths:
+      - core/render/
+    carryforward: true
+  runtime:
+    paths:
+      - core/runtime/
+    carryforward: true
+  signal:
+    paths:
+      - core/signal/
+    carryforward: true
+  state:
+    paths:
+      - core/state/
+    carryforward: true
+  view:
+    paths:
+      - core/view/
+    carryforward: true
+
+  # Platform flags (4) — cross-cut the subsystem flags. "What's host
+  # coverage on Windows?" is answered by cross-filtering `host AND
+  # windows`. Paths cover all subsystems because any subsystem can
+  # have a Windows shim under its own `platform/windows/` tree.
+  android:
+    paths:
+      - core/platform/src/android/
+      - android/
+      - core/render/platform/android/
+      - core/**/android/
+    carryforward: true
+  apple:
+    paths:
+      - apple/
+      - core/**/macos/
+      - core/**/ios/
+      - core/**/mac/
+    carryforward: true
+  linux:
+    paths:
+      - core/**/linux/
+      - core/**/alsa/
+    carryforward: true
+  windows:
+    paths:
+      - core/**/windows/
+      - core/**/wasapi/
+    carryforward: true
+
+  # Surface flags (3) — non-core but first-party:
+  cli:
+    paths:
+      - tools/cli/
+    carryforward: true
+  ship:
+    paths:
+      - ship/
+    carryforward: true
+  tools:
+    # Everything under tools/ except the CLI (which already has its
+    # own flag above). Codecov's glob takes first-matching-flag per
+    # file, and more-specific `tools/cli/` wins over the broader
+    # `tools/` here.
+    paths:
+      - tools/
+    carryforward: true
+
+# carryforward: true on every flag — when a PR doesn't touch
+# a given subsystem, carry over the last known coverage for that
+# flag from main so the dashboard doesn't report a false 0%. Standard
+# Codecov practice for multi-job uploads (we have one job per OS
+# starting in Phase 1 PR 4).

--- a/docs/guides/coverage.md
+++ b/docs/guides/coverage.md
@@ -1,0 +1,177 @@
+# Coverage
+
+Pulp tracks test coverage per-subsystem, per-platform, and per-surface as
+a first-class metric alongside sanitizers and CI matrix results. The goal
+is to tell at any moment whether any subsystem's test surface is tracking
+its quality bar as the codebase grows — not to chase a vanity "100%"
+number.
+
+This guide covers the Phase 1 measurement baseline. Phase 2 adds per-tier
+targets, Phase 3 adds a per-PR diff-coverage gate, Phase 4 adds doc-sync
+enforcement. See issue #566 for the full initiative.
+
+## Where the numbers live
+
+All coverage is reported to [Codecov](https://app.codecov.io/gh/danielraffel/pulp).
+The repo is public, so the dashboard is public and tokenless. No login
+required. Three views worth knowing:
+
+- **Overall**: <https://app.codecov.io/gh/danielraffel/pulp>
+- **Per-flag breakdown**: <https://app.codecov.io/gh/danielraffel/pulp/flags>
+- **REST API for agents**:
+  `https://api.codecov.io/api/v2/github/danielraffel/repos/pulp/totals/`
+
+The dashboard also supports per-file drilldown (click any file in the
+tree view) and historical trend graphs.
+
+## The 20 flags
+
+Codecov splits coverage into 20 flags along three independent axes so you
+can cross-filter:
+
+| Axis | Flags | What it tells you |
+|------|-------|-------------------|
+| Core subsystem (13) | `audio`, `canvas`, `events`, `format`, `host`, `midi`, `osc`, `platform`, `render`, `runtime`, `signal`, `state`, `view` | Subsystem quality |
+| Platform (4)        | `android`, `apple`, `linux`, `windows` | Per-platform shim coverage |
+| Surface (3)         | `cli`, `ship`, `tools` | Non-core first-party code |
+
+Examples of useful cross-filters:
+
+- `audio AND linux` — "what's audio coverage on Linux?" Catches ALSA-only
+  regressions that a single aggregate `audio` number would hide.
+- `host AND windows` — "how well-tested is the Windows host layer?"
+- `format` alone — "is the VST3/AU/CLAP adapter layer covered uniformly?"
+
+The flag definitions are in `codecov.yml` at the repo root. Adding a new
+subsystem means adding a flag there, a row in
+`docs/reference/modules.md`, and (in Phase 2) a target row in
+`ci/coverage-targets.yaml`. The Phase 4 doc-sync gate will keep those in
+lockstep; until then treat it as checklist discipline.
+
+## How to run coverage locally
+
+```bash
+scripts/run_coverage.sh
+```
+
+Output:
+
+- `build-coverage/coverage/index.html` — per-file HTML drilldown (open in
+  a browser).
+- `build-coverage/coverage/summary.txt` — text summary matching the CI
+  artifact.
+- `build-coverage/coverage.cobertura.xml` — Cobertura XML (only if
+  `gcovr` is on PATH; `pip install gcovr` if not).
+
+The script requires Clang (not gcc) because we use Clang source-based
+coverage, not gcov. See `tools/cmake/PulpInstrumentation.cmake` for the
+flag configuration.
+
+Optional flags:
+
+```bash
+scripts/run_coverage.sh --jobs 16                 # parallelism
+scripts/run_coverage.sh --tests '^pulp-test-audio' # regex filter
+```
+
+### Troubleshooting
+
+If `scripts/run_coverage.sh` fails with
+`ERROR: PULP_ENABLE_COVERAGE=ON did not stick in the CMake cache`, the
+`build-coverage/` directory was previously configured without coverage.
+The fix is in the error message: `rm -rf build-coverage/` and re-run. This
+guard exists because the silent version of this failure produced empty
+profdata that looked like a test/instrumentation bug. Issue #570 has the
+details.
+
+If you see `_deps/catch2-build/src/src/catch2/...: No such file or
+directory` spam on stderr, you're on an older checkout — the canonical
+exclude regex in `scripts/run_coverage.sh` filters these. Update to the
+latest `main`. Issue #569 has the details.
+
+## How to interpret "my PR's coverage"
+
+Every PR gets a comment from Codecov once the Coverage workflow
+finishes. The comment layout is `reach, diff, flags, tree`:
+
+- **reach** — lines this PR's tests exercised.
+- **diff** — of the N lines this PR adds/modifies, K are covered by
+  tests. This is the number to focus on — adding untested code is the
+  most common way to regress a subsystem's coverage.
+- **flags** — per-flag coverage (both total and delta). If you touched
+  `core/audio/` and the `audio` flag shows −2%, something in your PR
+  dropped the subsystem's coverage; check the tree view to see which
+  file.
+- **tree** — per-file drilldown. Click through to see exactly which
+  lines are uncovered.
+
+In Phase 1 all of this is advisory — nothing fails a PR on coverage.
+Phase 3 adds a diff-cover gate at 75% for 2 weeks, flipping to
+tier-based thresholds after contributors have had time to adjust.
+
+## How the collection works
+
+```
+Source → Clang -fprofile-instr-generate -fcoverage-mapping
+         ↓ (at runtime, LLVM_PROFILE_FILE=...)
+       .profraw  × N test binaries
+         ↓ (llvm-profdata merge)
+       pulp.profdata
+         ↓                               ↓
+    llvm-cov report/show           gcovr --cobertura
+    (human-readable HTML          (Cobertura XML for
+     + text summary)                Codecov + diff-cover)
+```
+
+- **Instrumentation**: enabled via `-DPULP_ENABLE_COVERAGE=ON` at
+  configure time. See `tools/cmake/PulpInstrumentation.cmake`. Only
+  enabled when Clang is the compiler — gcov/gcc output shapes are
+  incompatible with our llvm-cov pipeline.
+- **Collection**: `scripts/run_coverage.sh` runs the test suite with
+  `LLVM_PROFILE_FILE` pointing at a per-test-binary template. Each test
+  writes its own profraw shard.
+- **Merge**: `llvm-profdata merge -sparse` unions them into a single
+  profdata.
+- **Report**: `llvm-cov show` produces the HTML locally; `gcovr` emits
+  Cobertura XML for Codecov + diff-cover.
+- **Exclusions**: a canonical regex in `scripts/run_coverage.sh`
+  excludes `_deps/`, `external/`, `test/`, `catch2/`, `build/`, and
+  `build-coverage/`. Codecov's `ignore` list in `codecov.yml` mirrors
+  this set.
+
+## Multi-OS coverage
+
+Phase 1 PR 4 extends the coverage workflow to run on
+`{ubuntu-latest, macos-latest, windows-latest}`. Each OS produces its
+own `coverage.cobertura.xml` and uploads to Codecov with an OS-tag
+flag (`os-linux`, `os-macos`, `os-windows`). Codecov unions same-file
+coverage across OSes using the flag mechanism — we do NOT try to merge
+profdata across architectures (llvm-profdata merge is not
+architecture-portable, see
+`planning/coverage-tooling-decision-2026-04-21.md` §7).
+
+## Phase roadmap (#566)
+
+- **Phase 0** — spike & stack decision (done, see planning doc above).
+- **Phase 1** (this phase) — measurement baseline
+  - PR 1: infra fixes (#569, #570 — landed)
+  - PR 2: Codecov integration (this change)
+  - PR 3: diff-cover advisory gate
+  - PR 4: cross-platform matrix
+- **Phase 2** — per-tier targets encoded in
+  `ci/coverage-targets.yaml`. Audio-critical subsystems (`audio`,
+  `format`, `host`, `midi`, `signal`, `platform`) ≥ 80% line / 70%
+  branch; user-facing (`view`, `render`, `cli`) ≥ 70% line;
+  infrastructure (`tools`, `ship`, `events`, `runtime`, `state`,
+  `canvas`, `osc`) ≥ 50% line.
+- **Phase 3** — diff-cover flipped from advisory to required.
+- **Phase 4** — docs cleanup + doc-sync enforcement (#567).
+
+## Related reading
+
+- Issue #566 — umbrella initiative
+- Issue #290 — coverage hardening (test surface growth)
+- `planning/coverage-tooling-decision-2026-04-21.md` — Phase 0 spike
+  findings, stack rationale, perf numbers.
+- `planning/coverage-sanitizers-spec-2026-04-16.md` — the earlier
+  spec that landed `PULP_ENABLE_COVERAGE`.

--- a/docs/status/docs-index.yaml
+++ b/docs/status/docs-index.yaml
@@ -244,6 +244,11 @@ docs:
     kind: guide
     summary: 10 practical recipes — form layout, modal, scroll list, tabs, meter, themes, hover, keys, drag, presets
 
+  - slug: coverage
+    path: guides/coverage.md
+    kind: guide
+    summary: Test coverage — Codecov dashboard, 20 flags, local runs, per-PR interpretation, phase roadmap
+
   - slug: design-tokens
     path: guides/design-tokens.md
     kind: guide


### PR DESCRIPTION
## Automated by `pulp pr`

### Skill-sync verdict
```
[ci] ✓ bypassed (Coverage lives in its own docs/guides/coverage.md as the single source of truth for dev+agent audiences. The ci SKILL.md documents the ship orchestrator path; coverage internals don't match that pattern.)
    .github/workflows/coverage.yml

```

### Version-bump verdict
```
[sdk] Pulp SDK / CLI: no bump needed
[plugin] Claude Code plugin: no bump needed

```
