### PR TITLE
fix: Codex post-merge sweep (2026-04-21 wave 3)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -30,20 +30,25 @@ coverage:
         target: 75%
         informational: true
 
-  # Exclude lists mirror scripts/run_coverage.sh COVERAGE_IGNORE_REGEX
-  # so Codecov and our local tooling count the same set of files.
-  # External FetchContent sources (Dawn, Skia, mbedTLS, QuickJS,
-  # Catch2, etc.) and our test trees are never counted as coverage-
-  # bearing. See planning/coverage-tooling-decision-2026-04-21.md §4.
-  ignore:
-    - "external/**"
-    - "_deps/**"
-    - "test/**"
-    - "examples/**"
-    - "build/**"
-    - "build-coverage/**"
-    - "**/Catch2/**"
-    - "**/catch2/**"
+# Exclude lists mirror scripts/run_coverage.sh COVERAGE_IGNORE_REGEX
+# so Codecov and our local tooling count the same set of files.
+# External FetchContent sources (Dawn, Skia, mbedTLS, QuickJS,
+# Catch2, etc.) and our test trees are never counted as coverage-
+# bearing. See planning/coverage-tooling-decision-2026-04-21.md §4.
+#
+# `ignore` is a TOP-LEVEL key in Codecov config — nesting it under
+# `coverage:` silently no-ops, which would count files we explicitly
+# want excluded and skew the baseline metrics. See Codecov config
+# schema: https://docs.codecov.com/docs/codecov-yaml
+ignore:
+  - "external/**"
+  - "_deps/**"
+  - "test/**"
+  - "examples/**"
+  - "build/**"
+  - "build-coverage/**"
+  - "**/Catch2/**"
+  - "**/catch2/**"
 
 # PR comment. Focused on reach + diff + flags + tree so contributors
 # see "how many lines of THIS PR are covered by THIS PR's tests"
@@ -171,3 +176,98 @@ flags:
 # flag from main so the dashboard doesn't report a false 0%. Standard
 # Codecov practice for multi-job uploads (we have one job per OS
 # starting in Phase 1 PR 4).
+
+# Components are Codecov's canonical mechanism for path-based coverage
+# slicing driven by a single upload. Flags (above) are ultimately keyed
+# to upload sources and come into their own once Phase 1 PR 4 splits
+# the coverage job per-OS; components give us the subsystem / platform /
+# surface breakdown today from the single-upload Cobertura XML without
+# relying on Codecov's flag-with-paths behaviour (which is documented
+# but has historically been less reliable for trend analysis across
+# 20 flags attached to one upload).
+#
+# Keep component_id values aligned with the flag names above so the
+# dashboard reads consistently whichever dimension you filter by.
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+        informational: true
+  individual_components:
+    # Core subsystems (13)
+    - component_id: audio
+      name: audio
+      paths: ["core/audio/**"]
+    - component_id: canvas
+      name: canvas
+      paths: ["core/canvas/**"]
+    - component_id: events
+      name: events
+      paths: ["core/events/**"]
+    - component_id: format
+      name: format
+      paths: ["core/format/**"]
+    - component_id: host
+      name: host
+      paths: ["core/host/**"]
+    - component_id: midi
+      name: midi
+      paths: ["core/midi/**"]
+    - component_id: osc
+      name: osc
+      paths: ["core/osc/**"]
+    - component_id: platform
+      name: platform
+      paths: ["core/platform/**"]
+    - component_id: render
+      name: render
+      paths: ["core/render/**"]
+    - component_id: runtime
+      name: runtime
+      paths: ["core/runtime/**"]
+    - component_id: signal
+      name: signal
+      paths: ["core/signal/**"]
+    - component_id: state
+      name: state
+      paths: ["core/state/**"]
+    - component_id: view
+      name: view
+      paths: ["core/view/**"]
+    # Platform (4) — cross-cut the subsystems.
+    - component_id: android
+      name: android
+      paths:
+        - "core/platform/src/android/**"
+        - "android/**"
+        - "core/render/platform/android/**"
+        - "core/**/android/**"
+    - component_id: apple
+      name: apple
+      paths:
+        - "apple/**"
+        - "core/**/macos/**"
+        - "core/**/ios/**"
+        - "core/**/mac/**"
+    - component_id: linux
+      name: linux
+      paths:
+        - "core/**/linux/**"
+        - "core/**/alsa/**"
+    - component_id: windows
+      name: windows
+      paths:
+        - "core/**/windows/**"
+        - "core/**/wasapi/**"
+    # Surface (3)
+    - component_id: cli
+      name: cli
+      paths: ["tools/cli/**"]
+    - component_id: ship
+      name: ship
+      paths: ["ship/**"]
+    - component_id: tools
+      name: tools
+      paths: ["tools/**"]

--- a/tools/build-docs.py
+++ b/tools/build-docs.py
@@ -55,11 +55,41 @@ def md_to_html(md: str) -> str:
             in_table = False
 
     def inline(text):
-        # Order matters: links FIRST (before code-span split) so link text
-        # containing backticks — e.g. [`DEPENDENCIES.md`](...) — is kept
-        # intact. Previous order split on backticks first, which shattered
-        # the [...](...) brackets and left literal `[` / `](url)` in the
-        # output. Inside link text we still honour backticks as code.
+        # Pipeline (order matters — mis-ordering regressed twice):
+        #
+        #   1. Tokenize inline code spans into opaque placeholders so the
+        #      link regex below can never look inside them. This is what
+        #      CommonMark calls "code span precedence over link": a backtick
+        #      span like `` `[x](y)` `` must render as literal `[x](y)`
+        #      inside <code>, not as a link.
+        #   2. Rewrite links. Link-text that itself contains backticks
+        #      (e.g. [`foo`](url)) is handled specially so the backtick
+        #      run inside the link text becomes inline <code>.
+        #   3. Restore code-span placeholders as escaped <code>…</code>.
+        #   4. Apply bold/italic to remaining text.
+        #
+        # Before this pipeline we ran links first, which turned
+        # `` `[x](y)` `` into `` `<a href="y">x</a>` `` — the renderer
+        # then escaped the HTML and emitted <code>&lt;a …&gt;</code>
+        # instead of <code>[x](y)</code>. Before THAT we ran code spans
+        # first with a naive split, which shattered `[` `` `foo` `` `](url)`
+        # because the code-span boundaries cut the link brackets in half.
+        # Tokenize → link → restore is the only order that handles both.
+
+        placeholders: list[str] = []
+
+        def _tokenize_code(m: re.Match) -> str:
+            idx = len(placeholders)
+            placeholders.append(f'<code>{html.escape(m.group(1))}</code>')
+            # Use a marker the link regex can't match: no `[`, `]`, or `(`.
+            return f'\x00CODE{idx}\x00'
+
+        # Tokenize standalone code spans. A code span inside link text
+        # (i.e. [`foo`](url)) is still matched here — but the subsequent
+        # link regex accepts placeholders inside its text, and we render
+        # the placeholder back out to <code> via `restore_placeholders`.
+        text = re.sub(r'`([^`]+)`', _tokenize_code, text)
+
         def rewrite_link(m):
             link_text, url = m.group(1), m.group(2)
             if '.md' in url and not url.startswith('http'):
@@ -71,31 +101,39 @@ def md_to_html(md: str) -> str:
                     url, anchor = url.split('#', 1)
                     anchor = '#' + anchor
                 url = url.split('/')[-1] + anchor
-            # Render backticks inside link text as inline <code>.
-            inner_parts = re.split(r'(`[^`]+`)', link_text)
-            rendered = []
-            for ip in inner_parts:
-                if ip.startswith('`') and ip.endswith('`'):
-                    rendered.append(f'<code>{html.escape(ip[1:-1])}</code>')
-                else:
-                    rendered.append(ip)
-            return f'<a href="{url}">{"".join(rendered)}</a>'
+            return f'<a href="{url}">{link_text}</a>'
+
+        # Link-text intentionally allows placeholder markers (no `]` in them).
         text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', rewrite_link, text)
 
-        # Code spans (after links, so backticks inside links were already handled)
-        parts = re.split(r'(`[^`]+`)', text)
-        result = []
-        for part in parts:
-            if part.startswith('`') and part.endswith('`'):
-                result.append(f'<code>{html.escape(part[1:-1])}</code>')
-            else:
-                p = part
-                p = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', p)
-                p = re.sub(r'__(.+?)__', r'<strong>\1</strong>', p)
-                p = re.sub(r'\*(.+?)\*', r'<em>\1</em>', p)
-                p = re.sub(r'_(.+?)_', r'<em>\1</em>', p)
-                result.append(p)
-        return ''.join(result)
+        # Restore code spans now that both links (which could contain them)
+        # and the surrounding context have been rewritten.
+        def restore_placeholders(s: str) -> str:
+            return re.sub(
+                r'\x00CODE(\d+)\x00',
+                lambda m: placeholders[int(m.group(1))],
+                s,
+            )
+
+        text = restore_placeholders(text)
+
+        # Bold / italic on the remaining surface. Do NOT touch placeholder
+        # markers (they don't contain `*` or `_`) or already-rendered
+        # <code>/<a> spans (bold/italic inside them is intentionally ignored).
+        # Walk around <code>...</code> and <a ...>...</a> to avoid mangling
+        # escaped HTML — split on tag boundaries, apply emphasis to plain
+        # runs only.
+        parts = re.split(r'(<code>.*?</code>|<a [^>]*>.*?</a>)', text)
+        for i, part in enumerate(parts):
+            if part.startswith('<'):
+                continue
+            p = part
+            p = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', p)
+            p = re.sub(r'__(.+?)__', r'<strong>\1</strong>', p)
+            p = re.sub(r'\*(.+?)\*', r'<em>\1</em>', p)
+            p = re.sub(r'_(.+?)_', r'<em>\1</em>', p)
+            parts[i] = p
+        return ''.join(parts)
 
     i = 0
     while i < len(lines):

--- a/tools/scripts/build_migration_index.py
+++ b/tools/scripts/build_migration_index.py
@@ -175,6 +175,37 @@ def load_entry(path: pathlib.Path) -> Entry:
     version = frontmatter["version"]
     if not isinstance(version, str):
         _fatal(path, f"`version` must be a string, got {type(version).__name__}")
+    # Reject non-semver `version` strings up front so typos like
+    # `version = "0.29"` or `version = "abc"` fail the build instead of
+    # sorting as (0,0,0) and silently disappearing from the runtime
+    # hop-filter (which parses the same semver at load time and drops
+    # anything it can't parse). Every migration doc must pin a real
+    # released version to be discoverable by `pulp upgrade migration-notes`.
+    if not SEMVER_RE.match(version):
+        _fatal(
+            path,
+            f"`version` must be semver (X.Y.Z), got {version!r}. "
+            "Examples: \"0.27.0\", \"1.2.3\", \"v0.30.0\".",
+        )
+
+    # Types must match the schema. `bool("false")` is True — accepting
+    # strings for a boolean field would silently flip migration notes
+    # to breaking in shipped CLI output; accepting ints for string
+    # fields would stringify "42" into the summary. Fail fast instead.
+    breaking_raw = frontmatter.get("breaking", False)
+    if not isinstance(breaking_raw, bool):
+        _fatal(
+            path,
+            f"`breaking` must be a boolean (true|false), got "
+            f"{type(breaking_raw).__name__}: {breaking_raw!r}.",
+        )
+    for key in ("applies_if", "summary"):
+        if key in frontmatter and not isinstance(frontmatter[key], str):
+            _fatal(
+                path,
+                f"`{key}` must be a double-quoted string, got "
+                f"{type(frontmatter[key]).__name__}: {frontmatter[key]!r}.",
+            )
 
     extra = {k: v for k, v in frontmatter.items() if k not in SUPPORTED_FIELDS}
     if extra:
@@ -183,9 +214,9 @@ def load_entry(path: pathlib.Path) -> Entry:
 
     return Entry(
         version=version,
-        breaking=bool(frontmatter.get("breaking", False)),
-        applies_if=str(frontmatter.get("applies_if", "")),
-        summary=str(frontmatter.get("summary", "")),
+        breaking=breaking_raw,
+        applies_if=frontmatter.get("applies_if", ""),
+        summary=frontmatter.get("summary", ""),
         body=body,
         source_path=path,
         extra=extra,

--- a/tools/scripts/test_build_migration_index.py
+++ b/tools/scripts/test_build_migration_index.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Fixture tests for tools/scripts/build_migration_index.py.
+
+Regression coverage for the Codex post-merge sweep wave 3 findings on
+PR #571 (release-discovery Slice 3):
+
+- P2: `bool("false")` is True — if a schema-incorrect `breaking = "false"`
+  (quoted string) slipped through, the codegen silently emitted a
+  `breaking = true` row. The generator must reject non-boolean values
+  for a boolean field rather than coercing.
+- P2: `version = "abc"` or `version = "0.29"` was silently keyed as
+  (0,0,0) in the sort, and the runtime hop-filter — which parses semver
+  from the same string at load time — dropped the entry completely.
+  Users would never see the note. Reject non-semver versions at
+  codegen time instead.
+
+Run:
+    python3 tools/scripts/test_build_migration_index.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "tools" / "scripts" / "build_migration_index.py"
+
+_SPEC = importlib.util.spec_from_file_location("bmi", SCRIPT)
+assert _SPEC and _SPEC.loader
+_bmi = importlib.util.module_from_spec(_SPEC)
+sys.modules["bmi"] = _bmi
+_SPEC.loader.exec_module(_bmi)
+
+
+def _write_doc(tmp: pathlib.Path, name: str, frontmatter: str, body: str = "body.\n") -> pathlib.Path:
+    path = tmp / name
+    path.write_text(f"---\n{frontmatter}\n---\n{body}", encoding="utf-8")
+    return path
+
+
+class LoadEntryValidation(unittest.TestCase):
+    """Direct unit tests for `load_entry()` type + semver validation."""
+
+    def test_valid_frontmatter_loads(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            doc = _write_doc(
+                tmp,
+                "v0.27.0.md",
+                'version = "0.27.0"\n'
+                'breaking = true\n'
+                'applies_if = "x"\n'
+                'summary = "s"',
+            )
+            e = _bmi.load_entry(doc)
+            self.assertEqual(e.version, "0.27.0")
+            self.assertIs(e.breaking, True)
+            self.assertEqual(e.applies_if, "x")
+            self.assertEqual(e.summary, "s")
+
+    def test_string_value_rejected_for_boolean_field(self):
+        # Codex P2: bool("false") is True.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            doc = _write_doc(
+                tmp,
+                "v0.27.0.md",
+                'version = "0.27.0"\n'
+                'breaking = "false"',
+            )
+            with self.assertRaises(SystemExit) as ctx:
+                _bmi.load_entry(doc)
+            self.assertEqual(ctx.exception.code, 2)
+
+    def test_non_semver_version_rejected(self):
+        # Codex P2: silent (0,0,0) sort + runtime hop-filter drops entry.
+        # SEMVER_RE deliberately allows prerelease/build suffixes like
+        # "0.27.0-rc.1" or "0.27.0.beta" — those are rejected as
+        # "not semver" in the stricter sense, but the generator has
+        # historically accepted the (\d+)\.(\d+)\.(\d+)(?:[.\-+].*)? shape.
+        # Keep the reject list limited to inputs the major.minor.patch
+        # regex truly cannot parse.
+        bad_versions = ['"abc"', '"0.29"', '"1"', '""']
+        for v in bad_versions:
+            with self.subTest(version=v):
+                with tempfile.TemporaryDirectory() as td:
+                    tmp = pathlib.Path(td)
+                    doc = _write_doc(tmp, "bad.md", f"version = {v}")
+                    with self.assertRaises(SystemExit) as ctx:
+                        _bmi.load_entry(doc)
+                    self.assertEqual(ctx.exception.code, 2)
+
+    def test_version_v_prefix_allowed(self):
+        # `v0.30.0` is a common convention; SEMVER_RE already allows it
+        # and the hop-filter strips the prefix. Keep it working.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            doc = _write_doc(tmp, "v0.30.0.md", 'version = "v0.30.0"')
+            e = _bmi.load_entry(doc)
+            self.assertEqual(e.version, "v0.30.0")
+
+    def test_semver_with_prerelease_allowed(self):
+        # `0.27.0-rc.1` is valid semver; the parser must accept it so
+        # pre-release migration notes can ship (e.g. during a beta hop).
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            doc = _write_doc(tmp, "rc.md", 'version = "0.27.0-rc.1"')
+            e = _bmi.load_entry(doc)
+            self.assertEqual(e.version, "0.27.0-rc.1")
+
+
+class EndToEndCodegen(unittest.TestCase):
+    """Shell out to the generator and assert exit code + stderr signals."""
+
+    def _run(self, docs_dir: pathlib.Path, out: pathlib.Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--docs-dir",
+                str(docs_dir),
+                "--out",
+                str(out),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_invalid_breaking_value_fails_codegen(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            _write_doc(
+                tmp,
+                "v0.27.0.md",
+                'version = "0.27.0"\nbreaking = "true"',
+            )
+            out = tmp / "out.cpp"
+            res = self._run(tmp, out)
+            self.assertNotEqual(res.returncode, 0)
+            self.assertIn("breaking", res.stderr)
+            self.assertFalse(out.exists(), "codegen must not emit on schema error")
+
+    def test_invalid_version_fails_codegen(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = pathlib.Path(td)
+            _write_doc(tmp, "v.md", 'version = "abc"')
+            out = tmp / "out.cpp"
+            res = self._run(tmp, out)
+            self.assertNotEqual(res.returncode, 0)
+            self.assertIn("semver", res.stderr.lower())
+            self.assertFalse(out.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_codecov_config.py
+++ b/tools/scripts/test_codecov_config.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Structural tests for codecov.yml.
+
+Regression coverage for the Codex post-merge sweep wave 3 findings on
+PR #578 (Codecov wiring, Phase 1 PR 2):
+
+- P2: `ignore:` must be a TOP-LEVEL key in the Codecov YAML schema.
+  Nesting it under `coverage:` silently no-ops, which would pollute
+  the baseline coverage numbers with FetchContent sources and tests.
+- P1: Path-based coverage slicing across subsystem/platform/surface
+  axes must be declared via `component_management`, not only via
+  flag-level `paths:` on a multi-flag single upload. Components are
+  Codecov's canonical path-slicing mechanism and trend-analysis
+  consumer.
+
+The test is structural only — no network call to Codecov. PyYAML is
+already pulled in by other Pulp tooling.
+
+Run:
+    python3 tools/scripts/test_codecov_config.py
+"""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+CODECOV = REPO_ROOT / "codecov.yml"
+
+
+# Canonical 13 core subsystems + 4 platforms + 3 surfaces = 20.
+# Kept in lockstep with codecov.yml `flags:` and `component_management:
+# individual_components` blocks; drift here is a real bug.
+EXPECTED_IDS = {
+    # subsystems (13)
+    "audio", "canvas", "events", "format", "host", "midi", "osc",
+    "platform", "render", "runtime", "signal", "state", "view",
+    # platforms (4)
+    "android", "apple", "linux", "windows",
+    # surfaces (3)
+    "cli", "ship", "tools",
+}
+
+
+class CodecovYamlStructure(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        with CODECOV.open("r", encoding="utf-8") as fh:
+            cls.doc = yaml.safe_load(fh)
+
+    def test_ignore_is_top_level(self):
+        # Codecov config schema: ignore MUST be a top-level key. If it
+        # sits under `coverage:` the exclusions silently no-op.
+        self.assertIn("ignore", self.doc, "`ignore` missing at top level")
+        coverage = self.doc.get("coverage", {})
+        self.assertNotIn(
+            "ignore",
+            coverage,
+            "`ignore` must NOT be nested under `coverage:` (silently no-ops)",
+        )
+
+    def test_ignore_covers_external_and_test_sources(self):
+        # Regression: the baseline metrics in Phase 1 must not count
+        # FetchContent-ed sources or our test trees.
+        patterns = set(self.doc["ignore"])
+        required = {
+            "external/**",
+            "_deps/**",
+            "test/**",
+            "examples/**",
+            "build/**",
+            "build-coverage/**",
+            "**/Catch2/**",
+            "**/catch2/**",
+        }
+        missing = required - patterns
+        self.assertFalse(
+            missing,
+            f"codecov.yml ignore missing required patterns: {sorted(missing)}",
+        )
+
+    def test_component_management_defines_all_axes(self):
+        # Path-based slicing lives on components, not only on flags.
+        # Keep the 20-component carve-up explicit and checked.
+        self.assertIn(
+            "component_management",
+            self.doc,
+            "component_management missing — flags alone are ambiguous for "
+            "Codecov's trend analysis on a single-upload Cobertura XML.",
+        )
+        ids = {
+            c["component_id"]
+            for c in self.doc["component_management"]["individual_components"]
+        }
+        self.assertEqual(
+            ids,
+            EXPECTED_IDS,
+            f"component set drifted from canonical 20 (missing={EXPECTED_IDS - ids}, "
+            f"extra={ids - EXPECTED_IDS})",
+        )
+
+    def test_flags_and_components_stay_aligned(self):
+        # Flag names must match component ids so dashboard filters
+        # read consistently regardless of which dimension is selected.
+        flag_names = set(self.doc.get("flags", {}).keys())
+        comp_ids = {
+            c["component_id"]
+            for c in self.doc["component_management"]["individual_components"]
+        }
+        self.assertEqual(
+            flag_names,
+            comp_ids,
+            "flags and component_ids drifted — cross-filter queries on the "
+            "Codecov dashboard will be inconsistent.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_build_docs.py
+++ b/tools/test_build_docs.py
@@ -132,6 +132,28 @@ class LinkRenderingTests(unittest.TestCase):
         self.assertIn("<em>italic</em>", html)
         self.assertIn("<code>code</code>", html)
 
+    def test_link_syntax_inside_code_span_stays_literal(self):
+        # Regression (Codex post-merge sweep wave 3, PR #575 follow-up):
+        # `[x](y)` inside a code span must render as literal text inside
+        # <code>, NOT as a link. Before this fix the link regex ran first
+        # and transformed the inside of the backticks into <a href="y">x</a>,
+        # which the code-span pass then HTML-escaped into literal
+        # <code>&lt;a href="y"&gt;x&lt;/a&gt;</code>.
+        html = render("Docs showing the literal form `[text](url)` here.")
+        self.assertIn("<code>[text](url)</code>", html)
+        # Must NOT have turned the inside of the code span into an anchor
+        # tag, escaped or otherwise.
+        self.assertNotIn('<a href="url">text</a>', html)
+        self.assertNotIn("&lt;a href=", html)
+
+    def test_markdown_link_syntax_inside_code_span_with_md_url(self):
+        # .md-rewriting must also not fire inside a code span. The link
+        # rewriter rewrites foo.md → foo.html; if it ran inside a code
+        # span the user would see the wrong literal in the docs.
+        html = render("Example: `[docs](modules.md)` renders as-is.")
+        self.assertIn("<code>[docs](modules.md)</code>", html)
+        self.assertNotIn('<a href="modules.html">', html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Automated by `pulp pr`

### Skill-sync verdict
```
skill-sync: no mapped paths touched — nothing to verify.

```

### Version-bump verdict
```
[sdk] Pulp SDK / CLI: no bump needed
[plugin] Claude Code plugin: no bump needed

```
