### PR TITLE
chore(shipyard): bump v0.8.0→v0.20.0 + drop pulp pr --native workaround

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -12,18 +12,21 @@ requires:
 
 Validate branches and ship code safely. This skill handles all CI workflows for Pulp across local machines and VMs.
 
-## Shipping a PR: route through `pulp pr`
+## Shipping a PR: route through `shipyard pr`
 
 When the user says any of: **"push to main"**, **"ship this"**, **"ship it"**,
 **"we're done"**, **"merge this"**, **"push it"**, **"run CI"**, **"push a PR"** —
-run `pulp pr` (not `gh pr create` + `shipyard ship` separately).
+run `shipyard pr` (not `gh pr create` + `shipyard ship` separately).
 
-`pulp pr` is the single orchestrator. It:
+`shipyard pr` is the single orchestrator (Shipyard v0.19.1+; pinned as v0.20.0
+in `tools/shipyard.toml`). It:
 
-1. Calls `tools/scripts/skill_sync_check.py` and hard-fails if a mapped skill
-   path was touched without a `SKILL.md` update or a `Skill-Update:` trailer.
-2. Calls `tools/scripts/version_bump_check.py --mode=apply` to bump SDK, Claude
-   plugin, and marketplace versions consistently, honoring any
+1. Calls `tools/scripts/skill_sync_check.py` (resolved via Shipyard's
+   `[validation]` path-discovery, explicit in `.shipyard/config.toml`) and
+   hard-fails if a mapped skill path was touched without a `SKILL.md` update
+   or a `Skill-Update:` trailer.
+2. Calls `tools/scripts/version_bump_check.py --mode=apply` to bump SDK,
+   Claude plugin, and marketplace versions consistently, honoring any
    `Version-Bump:` trailers.
 3. Commits the bump (if any) as `chore: bump <surfaces>`.
 4. `gh pr create` with a generated body.
@@ -32,12 +35,40 @@ run `pulp pr` (not `gh pr create` + `shipyard ship` separately).
    publishes binaries on merge.
 
 Never run `gh pr create` + `shipyard ship` separately for a normal ship
-cycle. Never invoke the two version/skill scripts by hand — `pulp pr`
+cycle. Never invoke the two version/skill scripts by hand — `shipyard pr`
 wires them together with the right flags.
 
+`pulp pr` is a Pulp-side wrapper that delegates to `shipyard pr`; both are
+valid, agents should prefer `shipyard pr` for directness.
+
 Backward compatibility: raw `shipyard ship` / `shipyard run` still work for
-diagnostics, experimental branches, or when `pulp pr` itself is being
+diagnostics, experimental branches, or when `shipyard pr` itself is being
 debugged. Do not use them as the primary ship path.
+
+### SSH preflight (v0.20.0+ / Shipyard #106)
+
+Exit codes are distinct:
+
+| Exit | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Validation failed |
+| 2 | Configuration error |
+| 3 | Backend unreachable (new; surfaces within 10s with classified reason) |
+
+The unreachable-backend error names the failure class (auth / host_key /
+network / timeout / configuration / unknown) and prints the last ssh stderr.
+
+Flags:
+
+- `--skip-target NAME` — **DELIBERATE** lane skip (no probe runs). Use when
+  you know a target is irrelevant for this PR.
+- `--allow-unreachable-targets` — proceed despite an unreachable backend.
+  Prints a loud `⚠︎ VALIDATION GAP: <target> skipped` banner. Use only when
+  you genuinely cannot reach a backend and accept the validation gap.
+
+Automation (crons, agents) should branch on exit code 3 specifically rather
+than parsing error strings.
 
 ## Tool selection: Shipyard (primary)
 

--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -17,6 +17,17 @@ name      = "pulp"
 type      = "cmake"
 platforms = ["macos", "linux", "windows"]
 
+# ── Gate script paths (Shipyard v0.19.1+ path discovery) ───────────────────
+# Pulp keeps the skill-sync, version-bump, and versioning-config files
+# under tools/scripts/. Shipyard v0.19.1+ auto-discovers this layout, but
+# we pin the paths explicitly here so any future Shipyard bump can't
+# accidentally drop the discovery order and silently fall back to
+# scripts/ (which Pulp doesn't use).
+[validation]
+skill_sync_script   = "tools/scripts/skill_sync_check.py"
+version_bump_script = "tools/scripts/version_bump_check.py"
+versioning_config   = "tools/scripts/versioning.json"
+
 # ── Validation pipeline ────────────────────────────────────────────────────
 # Each stage maps to a step in tools/validate-build.sh. Shipyard runs
 # them in order; stage failure short-circuits the pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,12 +485,14 @@ Pulp versions three surfaces independently: SDK/CLI (`CMakeLists.txt`), Claude p
 2. **Pre-push hook (Layer 2)** — `.githooks/pre-push` runs both scripts in `--mode=report`. Advisory by default; `PULP_ENFORCE_PREPUSH=1` upgrades to hard failure.
 3. **CI + Shipyard (Layer 3, authoritative)** — `.github/workflows/version-skill-check.yml` and the `validation.gates` stage in `.shipyard/config.toml` both invoke the same scripts in `--mode=report` with `PULP_ENFORCE_PREPUSH=1`. No bypass other than the commit trailers below.
 
-**Shipping a PR** — when the user says any of "push a PR", "ship this", "ship it", "we're done", "merge this", or "push it", invoke `pulp pr` (the existing `ci` skill routes through this). Never run `gh pr create` + `shipyard ship` separately; never run the version-bump or skill-sync scripts by hand. `pulp pr` orchestrates:
+**Shipping a PR** — when the user says any of "push a PR", "ship this", "ship it", "we're done", "merge this", or "push it", invoke `shipyard pr` (the existing `ci` skill routes through this). Never run `gh pr create` + `shipyard ship` separately; never run the version-bump or skill-sync scripts by hand. `shipyard pr` orchestrates:
 
 1. `skill_sync_check.py --mode=report` — hard-fails on missing SKILL.md updates.
 2. `version_bump_check.py --mode=apply` — rewrites version files and CHANGELOG stub.
 3. `git commit` + `gh pr create` + `shipyard ship` — one command, merges on green.
 4. `.github/workflows/auto-release.yml` — on merge to main, tags the new version(s) and the existing tag-triggered release workflows build + publish binaries.
+
+Shipyard v0.19.1+ (pinned as v0.20.0 in `tools/shipyard.toml`) auto-discovers Pulp's `tools/scripts/` layout; `.shipyard/config.toml [validation]` additionally pins the paths explicitly for reproducibility.
 
 **Bypass trailers** (tip commit, never PR body — audit trail lives in git):
 
@@ -692,28 +694,39 @@ Pulp ships as a Claude Code plugin with slash commands (`/build`, `/test`, `/cre
 
 ```bash
 # Primary path for "ship this" / "push a PR" / any natural-language ship trigger:
-pulp pr
-
-# Useful options:
-pulp pr --base origin/main
-pulp pr --title "<title>"
-pulp pr --no-ship
-pulp pr --no-push
-pulp pr --dry-run
-
-# Fallback ONLY when the local `pulp` binary is broken (e.g. wgpu dylib load failure):
 shipyard pr
+
+# Useful options (v0.20.0):
+shipyard pr --base origin/main
+shipyard pr --no-apply-bumps                    # hard-fail on missing version bumps
+shipyard pr --skip-bump plugin --bump-reason="test-only change"
+shipyard pr --skip-skill-update ci --skill-reason="docs-only"
+shipyard pr --skip-target ubuntu                # deliberate lane skip
+
+# `pulp pr` is a Pulp-side wrapper; it still works and delegates to shipyard pr.
+# Use either — agents should prefer `shipyard pr` for directness.
+pulp pr
 
 # Lower-level Shipyard commands — use only for diagnostics or recovery, NOT as the
 # default ship path:
 shipyard run                              # validate current branch
 shipyard ship                             # PR + validate + merge on green
 shipyard cloud run build <branch>         # dispatch to Namespace
+
+# SSH preflight (v0.20.0+ / Shipyard #106): exit codes are distinct.
+#   0 — success
+#   1 — validation failed
+#   2 — configuration error
+#   3 — backend unreachable (new; surfaces within 10s with classified reason)
+# Use --skip-target NAME for DELIBERATE lane skips (no probe).
+# Use --allow-unreachable-targets only when you genuinely want to proceed despite
+# an unreachable backend — it now prints a loud "⚠︎ VALIDATION GAP" banner naming
+# the skipped lane.
 ```
 
 The CI skill (`.agents/skills/ci/SKILL.md`) is the single source of truth for landing code. Normal ship cycle:
 
-1. Run `pulp pr` — never `gh pr create` + `shipyard ship` separately (that bypasses the skill-sync and version-bump gates)
+1. Run `shipyard pr` — never `gh pr create` + `shipyard ship` separately (that bypasses the skill-sync and version-bump gates)
 2. The orchestrator runs skill-sync + version-bump gates, commits any bumps, pushes, opens a PR, and invokes `shipyard ship`
 3. `shipyard ship` validates on macOS (locally), Ubuntu (SSH), and Windows (SSH)
 4. Merges only when ALL targets pass

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -48,7 +48,7 @@
 # v0.2.0 surface still present in v0.8.0:
 #   - Incremental bundles, `--resume-from` SSH, targets/config, cloud
 #     polling timeout, ssh upload, stale queue recovery.
-version = "v0.8.0"
+version = "v0.20.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
## Summary

Shipyard upstream landed three fixes affecting Pulp. This PR adopts two of them and defers the third (queue atomic writes are only in v0.21.0+ which isn't released yet).

## Changes

- **`tools/shipyard.toml`**: bump pin `v0.8.0` → `v0.20.0`
  - Brings Shipyard #104 (path discovery: now finds `tools/scripts/skill_sync_check.py` etc. natively, no hardcoded `scripts/` assumption)
  - Brings Shipyard #106 (SSH preflight fail-fast: exit code 3 for unreachable, 10s detection, classified error reasons, `--skip-target NAME` for deliberate lane skips)
- **`.shipyard/config.toml`**: new `[validation]` section pins the script paths explicitly (belt-and-suspenders over v0.19.1+'s auto-discovery — protects against any future Shipyard bump accidentally dropping the discovery order)
- **`CLAUDE.md`**: "Shipping a PR" section now directs agents to `shipyard pr` directly. Ship workflow references updated. Exit-code table added for SSH preflight semantics. Actual v0.20.0 flags documented (replaced hallucinated `--title`/`--no-ship`/`--dry-run` with real `--apply-bumps`/`--skip-bump`/`--skip-skill-update`).
- **`.agents/skills/ci/SKILL.md`**: mirrors CLAUDE.md. New "SSH preflight" subsection documents exit codes + `--skip-target` vs `--allow-unreachable-targets` semantics. Automation consumers should branch on exit 3 specifically.

## Memory cleanup (separate from this PR)

- Removed `feedback_shipyard_pr_primary.md` from auto-memory (the workaround it documented is now unnecessary)
- Updated `MEMORY.md` index to drop the retired entry

## Not in this PR (deferred)

- `tools/install-shipyard.sh` queue-file reinit block stays in place. Shipyard #105 (atomic queue writes) is merged to main but not yet released (Shipyard v0.21.0+). Will remove the block in a follow-up PR after we pin to v0.21.0 and it soaks for one release cycle.

## Verification

- `./tools/install-shipyard.sh` installs v0.20.0 cleanly ✓
- `shipyard --version` → `shipyard, version 0.20.0` ✓
- `shipyard pr --help` lists `--skip-target`, `--allow-unreachable-targets`, etc. ✓
- `shipyard pr --dry-run` flag doesn't exist; removed from CLAUDE.md's aspirational surface ✓
- Trailer block contiguous: `Version-Bump: sdk=skip` + `Skill-Update: ci` parse cleanly ✓

## Test plan

- [ ] CI matrix (macOS / Linux / Windows)
- [ ] `shipyard pr` on this branch to confirm it finds `tools/scripts/skill_sync_check.py` without the `--native` fallback

Closes: the Shipyard #104 + #106 retrofit ask from the 2026-04-21 handoff.