### PR TITLE
chore(shipyard): bump pin v0.20.0 → v0.21.0

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -18,7 +18,7 @@ When the user says any of: **"push to main"**, **"ship this"**, **"ship it"**,
 **"we're done"**, **"merge this"**, **"push it"**, **"run CI"**, **"push a PR"** —
 run `shipyard pr` (not `gh pr create` + `shipyard ship` separately).
 
-`shipyard pr` is the single orchestrator (Shipyard v0.19.1+; pinned as v0.20.0
+`shipyard pr` is the single orchestrator (Shipyard v0.19.1+; pinned as v0.21.0
 in `tools/shipyard.toml`). It:
 
 1. Calls `tools/scripts/skill_sync_check.py` (resolved via Shipyard's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,7 +492,7 @@ Pulp versions three surfaces independently: SDK/CLI (`CMakeLists.txt`), Claude p
 3. `git commit` + `gh pr create` + `shipyard ship` — one command, merges on green.
 4. `.github/workflows/auto-release.yml` — on merge to main, tags the new version(s) and the existing tag-triggered release workflows build + publish binaries.
 
-Shipyard v0.19.1+ (pinned as v0.20.0 in `tools/shipyard.toml`) auto-discovers Pulp's `tools/scripts/` layout; `.shipyard/config.toml [validation]` additionally pins the paths explicitly for reproducibility.
+Shipyard v0.19.1+ (pinned as v0.21.0 in `tools/shipyard.toml`) auto-discovers Pulp's `tools/scripts/` layout; `.shipyard/config.toml [validation]` additionally pins the paths explicitly for reproducibility.
 
 **Bypass trailers** (tip commit, never PR body — audit trail lives in git):
 

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -48,7 +48,7 @@
 # v0.2.0 surface still present in v0.8.0:
 #   - Incremental bundles, `--resume-from` SSH, targets/config, cloud
 #     polling timeout, ssh upload, stale queue recovery.
-version = "v0.20.0"
+version = "v0.21.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
## Summary

Shipyard v0.21.0 is released. Bumping the pin brings:

- **Four internal ship-state bug fixes** from the #101 audit (no CLI contract changes)
  - Correct `shipyard auto-merge` verdicts (no longer fires on partial evidence coverage)
  - `shipyard ship --no-resume` attempt counter is monotonic (no longer resets to 1 on force-restart)
  - `shipyard cloud retarget --apply` updates ShipState so `watch` / `auto-merge` reflect the new provider/run_id
  - `_cloud_runs_by_platform` now scopes to SHA (can't mis-attribute run_ids across PRs on busy machines)
- **Atomic queue-file writes (Shipyard #105)** — root cause for pulp#528's queue-truncation symptom is fixed upstream. Removal of our `tools/install-shipyard.sh` defensive reinit block is tracked in #586 and will follow in ~1 release cycle.

## Changes

- `tools/shipyard.toml`: `v0.20.0` → `v0.21.0`
- `.agents/skills/ci/SKILL.md`: updated pinned-version reference
- `CLAUDE.md`: updated pinned-version reference

## Verification

Local install verified: `shipyard --version` → `shipyard, version 0.21.0`.

## Not in this PR

- Removal of `tools/install-shipyard.sh` queue-reinit block (tracked by #586, deferred until Shipyard v0.21.0 has soaked for ~1 release cycle).

## Related

- #586 — follow-up tracker for queue-reinit block removal
- pulp#585 — earlier bump from v0.8.0 → v0.20.0 with `--native` workaround retirement