### PR TITLE
fix(state/ci): state_tree.hpp missing <algorithm> + coverage silent-failure gate

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,6 +80,21 @@ jobs:
           path: build-coverage/coverage/summary.txt
           retention-days: 90
 
+      - name: Verify Cobertura XML exists
+        # Fail loudly if the coverage build didn't produce a cobertura file.
+        # Without this check, a silent build failure (e.g. a missing transitive
+        # include that breaks under Clang strict mode) produces zero profraw
+        # → no cobertura → Codecov upload "succeeds" with no files → dashboard
+        # stays empty. We had exactly this class of silent failure until
+        # state_tree.hpp missing <algorithm> was caught on 2026-04-21.
+        run: |
+          test -s build-coverage/coverage.cobertura.xml || {
+            echo "::error::coverage.cobertura.xml is missing or empty."
+            echo "::error::Coverage build likely failed — check the 'Run coverage suite' step above."
+            exit 1
+          }
+          echo "coverage.cobertura.xml size: $(wc -c < build-coverage/coverage.cobertura.xml) bytes"
+
       - name: Upload Cobertura XML
         # PR 1 lands the XML artifact, PR 2 wires it into Codecov below,
         # and PR 3 wires it into diff-cover. Keep the retention short —
@@ -90,7 +105,7 @@ jobs:
           name: coverage-cobertura-${{ github.sha }}
           path: build-coverage/coverage.cobertura.xml
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Upload coverage to Codecov
         # #566 Phase 1 PR 2: Codecov measurement baseline. The repo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pulp
 
+[![Coverage](https://codecov.io/gh/danielraffel/pulp/branch/main/graph/badge.svg)](https://app.codecov.io/gh/danielraffel/pulp)
+
 A cross-platform audio plugin and application framework. MIT licensed, C++20 core, Swift on Apple, JS-scripted GPU UIs.
 
 > **What version is Pulp?** The SDK / CLI version is the `project(Pulp VERSION …)` number in `CMakeLists.txt`. The Claude Code plugin has its own version (`.claude-plugin/plugin.json`). Full explanation: [docs/reference/versioning.md](docs/reference/versioning.md).

--- a/core/state/include/pulp/state/state_tree.hpp
+++ b/core/state/include/pulp/state/state_tree.hpp
@@ -4,16 +4,17 @@
 // A tree of named properties with typed access, change listeners, and undo integration.
 // Alternative to flat StateStore for complex nested state (presets, UI layout, etc.)
 
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
-#include <vector>
-#include <map>
 #include <variant>
-#include <functional>
-#include <memory>
-#include <optional>
-#include <mutex>
-#include <cstdint>
+#include <vector>
 
 namespace pulp::state {
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,6 +153,7 @@ nav:
   - Guides:
       - Web Plugins: guides/web-plugins.md
       - GPU Validation: guides/gpu-validation-checklist.md
+      - Test Coverage: guides/coverage.md
   - Policies:
       - Code Style: policies/code-style.md
       - Agent Rules: policies/agent-contribution-rules.md


### PR DESCRIPTION
## Root cause of empty Codecov dashboard

`scripts/run_coverage.sh` has been silently failing on every coverage workflow run for hours. The error (caught in latest run):

```
core/state/include/pulp/state/state_tree.hpp:180:18:
error: no member named 'remove_if' in namespace 'std'
```

Classic missing `#include <algorithm>`. **macOS libc++ allows it transitively; Linux Clang 18 (coverage runner) rejects.** With the build failing, no `.profraw` emitted → no `coverage.cobertura.xml` → Codecov's upload step reported success with zero files → dashboard stays empty despite green CI.

## Fixes

**Correctness:**
- `core/state/include/pulp/state/state_tree.hpp`: add `#include <algorithm>` (alphabetized the include block while touching it)

**Codify the silent-failure class:**
- New "Verify Cobertura XML exists" step in `.github/workflows/coverage.yml` — fails loudly with `::error::` if `build-coverage/coverage.cobertura.xml` is missing or empty
- Changed `if-no-files-found: warn` → `error` on the cobertura artifact upload — silent drops no longer possible

**Docs visibility (answers your "update the docs site with the coverage link" ask):**
- `README.md`: Codecov badge added at top
- `mkdocs.yml`: "Test Coverage" added to Guides nav so `docs/guides/coverage.md` (orphaned since #578) is reachable from the live MkDocs site

## Expected effect after merge

1. Coverage workflow runs green on main
2. `build-coverage/coverage.cobertura.xml` produced (non-zero bytes)
3. Codecov upload succeeds with real data
4. `https://app.codecov.io/gh/danielraffel/pulp` transforms from setup wizard to live dashboard
5. README badge renders the live coverage %
6. MkDocs site shows "Test Coverage" in the Guides nav

## Related

- #566 coverage initiative (Phase 1 PRs 1-3 merged, PR 4 in flight)
- #578 original Codecov wiring PR (introduced the silent-failure surface)

## Follow-up consideration

Transitive-include bugs keep surfacing (earlier today: #540 `<memory>`, Slice 4 `<atomic>`, now this). Worth a dedicated initiative to enforce "include what you use" via a lint or IWYU gate? Filing as a separate issue now.