### PR TITLE
cli: release-discovery Slice 6 plugin ↔ CLI skew detection (#551)

### DIFF
--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -14,6 +14,21 @@ requires:
 
 Build, deploy, and debug Pulp on Android. This skill captures the architecture decisions and hard-won gotchas from the Android platform bringup.
 
+## Pre-flight: plugin ↔ CLI skew check
+
+Before running `pulp doctor android` / `pulp build` / `pulp ship` for
+Android work, source the shared skew-check helper so a user on an
+outdated CLI sees a one-line hint (stderr, once per session) before
+wrestling with a confusing flag-missing error:
+
+```bash
+source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh"
+pulp_cli_version_check
+```
+
+Advisory only. Full contract in the `upgrade` skill. Release-discovery
+Slice 6 (#551).
+
 ## Architecture Overview
 
 ```

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -12,6 +12,23 @@ requires:
 
 Validate branches and ship code safely. This skill handles all CI workflows for Pulp across local machines and VMs.
 
+## Pre-flight: plugin ↔ CLI skew check
+
+Before shelling out to `pulp` (or `shipyard pr`, which ultimately
+invokes `pulp`), source the shared skew-check helper so a user on an
+outdated CLI sees a one-line hint rather than running into obscure
+flag-missing errors mid-ship:
+
+```bash
+source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh"
+pulp_cli_version_check
+```
+
+This is advisory only — the helper never blocks. See the `upgrade`
+skill for the full banner contract and override knobs
+(`PULP_SKEW_CHECK_DISABLE`, `PULP_SKEW_CHECK_CACHE`). Release-discovery
+Slice 6 (#551).
+
 ## Shipping a PR: route through `shipyard pr`
 
 When the user says any of: **"push to main"**, **"ship this"**, **"ship it"**,

--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -288,16 +288,25 @@ Gotchas:
   becomes meaningful from the first release that needs it; before
   then it's silently absent and skew analysis skips. Don't
   retroactively add it to every `pulp.toml` in the repo.
+- **Plugin `min_cli_version` mirrors the same semantics (Slice 6,
+  #551).** A plugin `plugin.json` with no `min_cli_version` skips the
+  check silently; a newer `min_cli_version` emits the same advisory
+  WARN finding in `analyze()` and an inline "needs CLI: >= vX.Y.Z"
+  line under the Plugin entry in the human report. The JSON surface
+  adds a `plugin_min_cli` top-level field alongside `cli` and
+  `plugin` — do not rename it; `tools/scripts/cli_version_check.sh`
+  and the `upgrade` skill parse it by key.
 
 Slice 1b (#552) extended the diagnostic with `--scan-parents` and
 `--json` plus the `~/.pulp/projects.json` registry — see the section
 above for registry gotchas. The `--versions` core remains pure-logic
 and scoped to `version_diag.{hpp,cpp}`.
 
-Follow-up slices (2-6) are tracked against #499: update-check,
-migration docs, `/upgrade` skill, mode enforcement, and plugin ↔ CLI
-skew detection. Do not land them piecemeal under Slice 1's PR; file
-new issues and PRs.
+Follow-up slices tracked against #499: Slice 2 (update-check), Slice 3
+(migration docs), Slice 4 (`/upgrade` skill), Slice 5 (mode
+enforcement), Slice 6 (plugin ↔ CLI skew — `min_cli_version` +
+`plugin_min_cli` JSON + `tools/scripts/cli_version_check.sh`). Do not
+land them piecemeal under Slice 1's PR; file new issues and PRs.
 
 ## `pulp config` + update-check (#499 Slice 2 / #547)
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -21,6 +21,21 @@ triggers:
 
 The `pulp ship` command handles the full distribution pipeline: code signing, Apple notarization, platform-specific packaging, update feed generation, and Android APK/AAB builds.
 
+## Pre-flight: plugin ↔ CLI skew check
+
+Before running `pulp ship ...`, source the shared skew-check helper so
+a user on an outdated CLI sees a one-line hint (stderr, once per
+session) when the installed CLI is older than the plugin's declared
+`min_cli_version`:
+
+```bash
+source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh"
+pulp_cli_version_check
+```
+
+Advisory only — never blocks. Full contract + override knobs in the
+`upgrade` skill. Release-discovery Slice 6 (#551).
+
 ## Subcommands
 
 | Command | Platform | What It Does |

--- a/.agents/skills/upgrade/SKILL.md
+++ b/.agents/skills/upgrade/SKILL.md
@@ -55,6 +55,32 @@ requirement. If `pulp` is not on PATH, tell the user to install first
 (`curl -fsSL https://raw.githubusercontent.com/danielraffel/pulp/main/install.sh | sh`)
 and stop.
 
+### Plugin ↔ CLI skew banner (Slice 6, #551)
+
+Before running any `pulp` command, source the shared skew-check helper
+so the user sees a single-line hint when the installed CLI is older
+than the plugin's declared `min_cli_version`:
+
+```bash
+source "$(git rev-parse --show-toplevel 2>/dev/null || echo .)/tools/scripts/cli_version_check.sh"
+pulp_cli_version_check   # no-ops silently if already checked this session
+```
+
+Behaviour:
+
+- Banner (stderr, at most once per session):
+  `[pulp] Claude plugin requires CLI >= v<MIN> but installed CLI is v<HAVE>. Run \`pulp upgrade\` or \`/upgrade\` in Claude Code.`
+- Silent when CLI ≥ min, when the plugin manifest omits
+  `min_cli_version` (older plugin builds), or when either version is
+  non-numeric (dev builds).
+- Overrides: `PULP_SKEW_CHECK_DISABLE=1` turns it off;
+  `PULP_SKEW_CHECK_CACHE` overrides the session-marker directory.
+
+The same skew logic is surfaced by `pulp doctor --versions` inline, so
+users who prefer running the diagnostic directly see the finding there
+too — the helper is a convenience for skill authors, not a second
+source of truth.
+
 1. **Identify the active plugin directory** (so the skill can resolve
    `docs/migrations/` for full-body lookups):
 
@@ -248,4 +274,6 @@ skill AND the slash command AND the test in the same PR.
 - Slice 1 (diagnostics): #546 (`pulp doctor --versions`)
 - Slice 2 (update check): #562 (`pulp upgrade --check-only`)
 - Slice 3 (migration index): #571 (`pulp upgrade --notes --json`)
-- This slice: #549
+- Slice 4 (this skill): #549
+- Slice 6 (plugin ↔ CLI skew): #551 (`min_cli_version` +
+  `tools/scripts/cli_version_check.sh` + `plugin_min_cli` JSON field)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,8 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.5.0",
+      "version": "0.8.0",
+      "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
       },
@@ -34,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.7.1"
+  "version": "0.8.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "pulp",
-  "version": "0.7.1",
+  "version": "0.8.0",
+  "min_cli_version": "0.31.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.31.0
+    VERSION 0.31.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -285,12 +285,15 @@ closest ancestor to the current directory comes first). Resolving
 surfaces both so the ambiguity is visible.
 
 `--json` emits the same information as a single JSON object with a
-stable shape — `{"cli": {...}, "plugin": {...}, "project_sdk": {...},
-"projects": [{"path": ..., "sdk": {...}, "cli_min": {...},
-"missing_on_disk": bool, "scanned": bool}, ...], "findings": [...]}`.
-Scripts should use the `findings[]` array for user-visible warnings;
-per-field semver fields carry `comparable: true` only when they
-parse as pure `M.N.P`.
+stable shape — `{"cli": {...}, "plugin": {...}, "plugin_min_cli":
+{...}, "project_sdk": {...}, "projects": [{"path": ..., "sdk": {...},
+"cli_min": {...}, "missing_on_disk": bool, "scanned": bool}, ...],
+"findings": [...]}`. Scripts should use the `findings[]` array for
+user-visible warnings; per-field semver fields carry
+`comparable: true` only when they parse as pure `M.N.P`.
+`plugin_min_cli` is populated from the plugin's `plugin.json`
+`min_cli_version` field (release-discovery Slice 6, #551); absent in
+older plugin builds.
 
 ### projects
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,22 @@ if(TARGET pulp-cli)
 endif()
 catch_discover_tests(pulp-test-cli-shellout)
 
+# Plugin ↔ CLI skew banner helper (#551 Slice 6): shells out to bash
+# with a staged `pulp` shim and asserts the banner copy + once-per-
+# session semantics of `.agents/skills/_common/cli_version_check.sh`.
+# The test file is POSIX-only (invokes /bin/bash) — on Windows we skip
+# to avoid forcing a bash-for-Windows dependency into CI. The helper
+# itself is plain POSIX shell, so wgpu/macOS don't factor in.
+if(NOT WIN32)
+    add_executable(pulp-test-cli-skew-banner test_cli_skew_banner.cpp)
+    target_link_libraries(pulp-test-cli-skew-banner PRIVATE
+        pulp::platform Catch2::Catch2WithMain)
+    target_compile_definitions(pulp-test-cli-skew-banner PRIVATE
+        PULP_REPO_ROOT="${CMAKE_SOURCE_DIR}")
+    catch_discover_tests(pulp-test-cli-skew-banner
+        PROPERTIES ENVIRONMENT "PULP_REPO_ROOT=${CMAKE_SOURCE_DIR}")
+endif()
+
 # CLI ship shell-out behaviour tests — launches the built `pulp` binary
 # for the non-destructive ship subcommand branches.
 add_executable(pulp-test-cli-ship-shellout test_cli_ship_shellout.cpp)

--- a/test/test_cli_skew_banner.cpp
+++ b/test/test_cli_skew_banner.cpp
@@ -1,0 +1,257 @@
+// test_cli_skew_banner.cpp — Plugin ↔ CLI skew banner smoke tests.
+//
+// Release-discovery Slice 6 (#551). The helper at
+// `tools/scripts/cli_version_check.sh` reads
+// `pulp doctor --versions --json`'s `plugin_min_cli` field and prints a
+// one-line banner on stderr when the installed CLI is older than that
+// minimum. These tests shell out to `bash` with a staged `pulp` shim
+// on PATH, mirroring the real execution environment skills run in.
+//
+// Per CLAUDE.md "Tests ship with fixes — NON-NEGOTIABLE": the helper
+// has a stable banner surface and once-per-session semantics; its test
+// lives here, not in a follow-up coverage PR.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/platform/child_process.hpp>
+
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+using namespace pulp::platform;
+
+namespace {
+
+// Walk up from the test binary's CWD to find the repo root (marker:
+// `.claude-plugin/plugin.json`). CTest runs tests from <build>/test,
+// so the ancestor walk tolerates arbitrary nesting depth.
+fs::path find_repo_root() {
+    if (const char* env = std::getenv("PULP_REPO_ROOT"); env && *env) {
+        return fs::path(env);
+    }
+    auto cwd = fs::current_path();
+    for (int i = 0; i < 8; ++i) {
+        auto marker = cwd / ".claude-plugin" / "plugin.json";
+        if (fs::exists(marker)) return cwd;
+        if (!cwd.has_parent_path() || cwd == cwd.parent_path()) break;
+        cwd = cwd.parent_path();
+    }
+    return {};
+}
+
+struct TempDir {
+    fs::path path;
+    TempDir() {
+        auto base = fs::temp_directory_path();
+        static std::atomic<int> seq{0};
+        int n = seq.fetch_add(1);
+        path = base / ("pulp-skew-banner-" +
+                       std::to_string(
+                           reinterpret_cast<std::uintptr_t>(this)) +
+                       "-" + std::to_string(n));
+        fs::create_directories(path);
+    }
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+// Write a synthetic `pulp` shim that returns a canned
+// `doctor --versions --json` payload.
+void write_pulp_shim(const fs::path& bin_dir,
+                     const std::string& cli_raw,
+                     const std::string& plugin_min_raw) {
+    fs::create_directories(bin_dir);
+    auto shim = bin_dir / "pulp";
+    std::ofstream f(shim);
+    f << "#!/bin/sh\n";
+    f << "if [ \"$1\" = \"doctor\" ] && [ \"$2\" = \"--versions\" ] "
+         "&& [ \"$3\" = \"--json\" ]; then\n";
+    f << "  cat <<'JSON'\n";
+    f << "{\n";
+    f << "  \"cli\": {\"raw\": \"" << cli_raw
+      << "\", \"comparable\": true},\n";
+    f << "  \"plugin\": {\"raw\": \"0.8.0\", \"comparable\": true},\n";
+    f << "  \"plugin_min_cli\": {\"raw\": \"" << plugin_min_raw
+      << "\", \"comparable\": true},\n";
+    f << "  \"findings\": []\n";
+    f << "}\n";
+    f << "JSON\n";
+    f << "  exit 0\n";
+    f << "fi\n";
+    f << "echo \"unexpected shim invocation: $*\" >&2\n";
+    f << "exit 99\n";
+    f.close();
+    fs::permissions(shim,
+                    fs::perms::owner_all | fs::perms::group_read |
+                    fs::perms::group_exec | fs::perms::others_read |
+                    fs::perms::others_exec,
+                    fs::perm_options::replace);
+}
+
+// Write a bash driver script that sets env, then sources the helper
+// and invokes the function. We do this because platform::exec doesn't
+// accept an env block — the driver script owns the env state instead.
+//
+// `extra_before` lets a test pre-seed side state (e.g. session marker)
+// before the helper runs.
+fs::path write_driver(const fs::path& sandbox,
+                      const fs::path& bin_dir,
+                      const fs::path& cache_dir,
+                      const fs::path& helper,
+                      bool disable,
+                      const std::string& extra_before = {}) {
+    static std::atomic<int> counter{0};
+    auto p = sandbox /
+             ("driver-" + std::to_string(counter.fetch_add(1)) + ".sh");
+    std::ofstream f(p);
+    f << "#!/bin/bash\n";
+    f << "set -u\n";
+    f << "export PATH=\"" << bin_dir.string() << ":$PATH\"\n";
+    f << "export PULP_SKEW_CHECK_CACHE=\"" << cache_dir.string() << "\"\n";
+    if (disable) {
+        f << "export PULP_SKEW_CHECK_DISABLE=1\n";
+    } else {
+        f << "export PULP_SKEW_CHECK_DISABLE=0\n";
+    }
+    if (!extra_before.empty()) {
+        f << extra_before << "\n";
+    }
+    f << "source \"" << helper.string() << "\"\n";
+    f << "pulp_cli_version_check\n";
+    f.close();
+    fs::permissions(p,
+                    fs::perms::owner_all |
+                    fs::perms::group_read | fs::perms::group_exec |
+                    fs::perms::others_read | fs::perms::others_exec,
+                    fs::perm_options::replace);
+    return p;
+}
+
+struct HelperCtx {
+    TempDir sandbox;
+    fs::path helper;
+    fs::path bin_dir;
+    fs::path cache_dir;
+    bool enabled;
+
+    HelperCtx() : helper{}, bin_dir{}, cache_dir{}, enabled(false) {
+        auto root = find_repo_root();
+        if (root.empty()) return;
+        helper = root / "tools" / "scripts" / "cli_version_check.sh";
+        if (!fs::exists(helper)) return;
+        bin_dir = sandbox.path / "bin";
+        cache_dir = sandbox.path / "cache";
+        fs::create_directories(cache_dir);
+        enabled = true;
+    }
+};
+
+}  // namespace
+
+TEST_CASE("cli_version_check helper prints banner when CLI is behind plugin min",
+          "[cli][shellout][skill][issue-551]") {
+    HelperCtx ctx;
+    if (!ctx.enabled) {
+        SUCCEED("skipped: repo root or helper not available in this run");
+        return;
+    }
+    write_pulp_shim(ctx.bin_dir, "0.20.0", "0.31.0");
+    auto driver = write_driver(ctx.sandbox.path, ctx.bin_dir, ctx.cache_dir,
+                               ctx.helper, /*disable=*/false);
+
+    auto r = exec("/bin/bash", {driver.string()}, 10000);
+    REQUIRE(r.exit_code == 0);
+    REQUIRE_FALSE(r.timed_out);
+    // Stable banner copy — mirrored in the helper's comments, the
+    // _common/README.md, and the upgrade skill's references.
+    REQUIRE(r.stderr_output.find(
+                "[pulp] Claude plugin requires CLI >= v0.31.0") !=
+            std::string::npos);
+    REQUIRE(r.stderr_output.find("installed CLI is v0.20.0") !=
+            std::string::npos);
+    REQUIRE(r.stderr_output.find("`pulp upgrade`") != std::string::npos);
+}
+
+TEST_CASE("cli_version_check helper is silent when CLI is ahead",
+          "[cli][shellout][skill][issue-551]") {
+    HelperCtx ctx;
+    if (!ctx.enabled) { SUCCEED("skipped"); return; }
+    write_pulp_shim(ctx.bin_dir, "0.31.0", "0.20.0");
+    auto driver = write_driver(ctx.sandbox.path, ctx.bin_dir, ctx.cache_dir,
+                               ctx.helper, /*disable=*/false);
+    auto r = exec("/bin/bash", {driver.string()}, 10000);
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stderr_output.find("Claude plugin requires CLI") ==
+            std::string::npos);
+}
+
+TEST_CASE("cli_version_check helper banners at most once per session",
+          "[cli][shellout][skill][issue-551]") {
+    // Same-session semantics: the helper keys its "already checked"
+    // marker on $PPID. Within a single bash driver script, $PPID is
+    // stable across multiple `pulp_cli_version_check` calls — so a
+    // second call in the same driver should NOT re-emit the banner
+    // even though the skew condition still holds.
+    HelperCtx ctx;
+    if (!ctx.enabled) { SUCCEED("skipped"); return; }
+    write_pulp_shim(ctx.bin_dir, "0.20.0", "0.31.0");
+
+    // Driver that invokes the check twice and records each run's stderr
+    // separately so the test can count banner occurrences precisely.
+    static std::atomic<int> counter{0};
+    auto driver = ctx.sandbox.path /
+                  ("rerun-" + std::to_string(counter.fetch_add(1)) + ".sh");
+    std::ofstream f(driver);
+    f << "#!/bin/bash\n";
+    f << "set -u\n";
+    f << "export PATH=\"" << ctx.bin_dir.string() << ":$PATH\"\n";
+    f << "export PULP_SKEW_CHECK_CACHE=\"" << ctx.cache_dir.string()
+      << "\"\n";
+    f << "export PULP_SKEW_CHECK_DISABLE=0\n";
+    f << "source \"" << ctx.helper.string() << "\"\n";
+    f << "echo '=== RUN 1 ===' >&2\n";
+    f << "pulp_cli_version_check\n";
+    f << "echo '=== RUN 2 ===' >&2\n";
+    f << "pulp_cli_version_check\n";
+    f.close();
+    fs::permissions(driver,
+                    fs::perms::owner_all |
+                    fs::perms::group_read | fs::perms::group_exec |
+                    fs::perms::others_read | fs::perms::others_exec,
+                    fs::perm_options::replace);
+
+    auto r = exec("/bin/bash", {driver.string()}, 10000);
+    REQUIRE(r.exit_code == 0);
+
+    // Split the captured stderr at the two RUN markers and count
+    // banner occurrences in each half — must be exactly one, in the
+    // first run only.
+    auto& err = r.stderr_output;
+    auto m1 = err.find("=== RUN 1 ===");
+    auto m2 = err.find("=== RUN 2 ===");
+    REQUIRE(m1 != std::string::npos);
+    REQUIRE(m2 != std::string::npos);
+    auto run1 = err.substr(m1, m2 - m1);
+    auto run2 = err.substr(m2);
+    REQUIRE(run1.find("Claude plugin requires") != std::string::npos);
+    REQUIRE(run2.find("Claude plugin requires") == std::string::npos);
+}
+
+TEST_CASE("cli_version_check helper honours PULP_SKEW_CHECK_DISABLE",
+          "[cli][shellout][skill][issue-551]") {
+    HelperCtx ctx;
+    if (!ctx.enabled) { SUCCEED("skipped"); return; }
+    write_pulp_shim(ctx.bin_dir, "0.20.0", "0.31.0");
+    auto driver = write_driver(ctx.sandbox.path, ctx.bin_dir, ctx.cache_dir,
+                               ctx.helper, /*disable=*/true);
+    auto r = exec("/bin/bash", {driver.string()}, 10000);
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stderr_output.find("Claude plugin requires") ==
+            std::string::npos);
+}

--- a/test/test_cli_version_diag.cpp
+++ b/test/test_cli_version_diag.cpp
@@ -371,6 +371,114 @@ TEST_CASE("analyze is silent when a per-project SDK matches the CLI",
     }
 }
 
+// ── Slice 6 (#551) — plugin ↔ CLI skew detection ─────────────────────
+
+TEST_CASE("read_plugin_min_cli_version scrapes min_cli_version field",
+          "[version-diag][issue-551]") {
+    TempDir tmp;
+    auto plugin_json = tmp.path / ".claude-plugin" / "plugin.json";
+    write_file(plugin_json, R"({
+        "name": "pulp",
+        "version": "0.8.0",
+        "min_cli_version": "0.31.0",
+        "description": "test"
+    })");
+
+    auto v = read_plugin_min_cli_version(plugin_json);
+    REQUIRE(v.comparable);
+    REQUIRE(v.major == 0);
+    REQUIRE(v.minor == 31);
+    REQUIRE(v.patch == 0);
+}
+
+TEST_CASE("read_plugin_min_cli_version is empty when the field is absent",
+          "[version-diag][issue-551]") {
+    // Forward-compatible: older plugin builds (pre-Slice 6) shipped no
+    // min_cli_version field. The helper must return empty, not choke,
+    // so the skew analyzer silently skips the check.
+    TempDir tmp;
+    auto plugin_json = tmp.path / ".claude-plugin" / "plugin.json";
+    write_file(plugin_json, R"({
+        "name": "pulp",
+        "version": "0.7.0"
+    })");
+    auto v = read_plugin_min_cli_version(plugin_json);
+    REQUIRE_FALSE(v.comparable);
+    REQUIRE(v.raw.empty());
+}
+
+TEST_CASE("analyze warns when plugin_min_cli exceeds installed CLI",
+          "[version-diag][issue-551]") {
+    VersionReport r;
+    r.cli = parse_semver("0.20.0");
+    r.plugin = parse_semver("0.8.0");
+    r.plugin_min_cli = parse_semver("0.31.0");
+
+    auto findings = r.analyze();
+    bool saw_warn = false;
+    for (auto& f : findings) {
+        if (f.severity == SkewSeverity::Warn &&
+            f.message.find("Claude plugin requires CLI") != std::string::npos &&
+            f.message.find("pulp upgrade") != std::string::npos) {
+            saw_warn = true;
+        }
+    }
+    REQUIRE(saw_warn);
+}
+
+TEST_CASE("analyze is silent when plugin_min_cli is satisfied by CLI",
+          "[version-diag][issue-551]") {
+    VersionReport r;
+    r.cli = parse_semver("0.31.0");
+    r.plugin = parse_semver("0.8.0");
+    r.plugin_min_cli = parse_semver("0.31.0");  // equal — satisfied
+
+    auto findings = r.analyze();
+    for (auto& f : findings) {
+        if (f.severity == SkewSeverity::Warn) {
+            REQUIRE(f.message.find("Claude plugin requires") == std::string::npos);
+        }
+    }
+}
+
+TEST_CASE("analyze skips plugin_min_cli check when the field is absent",
+          "[version-diag][issue-551]") {
+    // Backward-compat: a plugin manifest without min_cli_version must
+    // never surface a skew warning. This is the "older plugin build"
+    // path the design doc calls out explicitly.
+    VersionReport r;
+    r.cli = parse_semver("0.20.0");
+    r.plugin = parse_semver("0.7.0");
+    // plugin_min_cli deliberately empty.
+    auto findings = r.analyze();
+    for (auto& f : findings) {
+        REQUIRE(f.message.find("Claude plugin requires") == std::string::npos);
+    }
+}
+
+TEST_CASE("render_report_json exposes plugin_min_cli as a top-level field",
+          "[version-diag][issue-551]") {
+    // The /upgrade slash command + plugin skills rely on this key to
+    // make a skew decision. Renaming or dropping it breaks the helper
+    // at `.agents/skills/_common/cli_version_check.sh`.
+    VersionReport r;
+    r.cli = parse_semver("0.20.0");
+    r.plugin = parse_semver("0.8.0");
+    r.plugin_min_cli = parse_semver("0.31.0");
+
+    std::stringstream capture;
+    auto* prev = std::cout.rdbuf(capture.rdbuf());
+    int rc = render_report_json(r);
+    std::cout.rdbuf(prev);
+
+    REQUIRE(rc == 0);
+    auto out = capture.str();
+    REQUIRE(out.find("\"plugin_min_cli\":") != std::string::npos);
+    // Skew finding should also land in findings[] so JSON consumers
+    // don't need to re-run the comparison themselves.
+    REQUIRE(out.find("Claude plugin requires") != std::string::npos);
+}
+
 TEST_CASE("render_report_json emits JSON with projects[] and findings[]",
           "[version-diag][issue-552]") {
     // Capture std::cout via a redirected rdbuf so we can test without

--- a/tools/cli/cmd_doctor.cpp
+++ b/tools/cli/cmd_doctor.cpp
@@ -93,6 +93,11 @@ int cmd_doctor(const std::vector<std::string>& args) {
             standalone_mode ? fs::path{} : active_root);
         report.plugin_json_path = plugin_json;
         report.plugin = pulp::cli::version_diag::read_plugin_version(plugin_json);
+        // Slice 6 (#551): pick up the plugin's declared `min_cli_version`
+        // so the diagnostic surfaces plugin ↔ CLI skew alongside the
+        // existing project ↔ CLI checks.
+        report.plugin_min_cli =
+            pulp::cli::version_diag::read_plugin_min_cli_version(plugin_json);
 
         // Project SDK version. For standalone projects it lives in
         // `pulp.toml`; for source-tree use it lives in CMakeLists.txt.

--- a/tools/cli/version_diag.cpp
+++ b/tools/cli/version_diag.cpp
@@ -182,6 +182,30 @@ Semver read_plugin_version(const fs::path& plugin_json_path) {
     return out;
 }
 
+Semver read_plugin_min_cli_version(const fs::path& plugin_json_path) {
+    Semver out;
+    if (plugin_json_path.empty() || !fs::exists(plugin_json_path)) return out;
+
+    std::ifstream f(plugin_json_path);
+    if (!f.is_open()) return out;
+
+    std::stringstream buf;
+    buf << f.rdbuf();
+    auto body = buf.str();
+
+    // Same cheap scan as read_plugin_version — the key is a stable
+    // top-level JSON string. Absent field → empty Semver (no skew
+    // check). Added in Slice 6 (#551); older plugin manifests won't
+    // have this field and must silently no-op.
+    static const std::regex mcv_re(
+        R"RE("min_cli_version"\s*:\s*"([^"]+)")RE");
+    std::smatch m;
+    if (std::regex_search(body, m, mcv_re)) {
+        return parse_semver(m[1].str());
+    }
+    return out;
+}
+
 fs::path locate_plugin_json(const fs::path& active_repo_root,
                             const fs::path& override_path) {
     if (!override_path.empty() && fs::exists(override_path)) {
@@ -220,6 +244,22 @@ std::vector<SkewFinding> VersionReport::analyze() const {
             findings.push_back({
                 SkewSeverity::Warn,
                 "Project requires CLI >= v" + project_cli_min.raw +
+                    " but installed CLI is v" + cli.raw +
+                    " — run `pulp upgrade`",
+            });
+        }
+    }
+
+    // Rule 1b (Slice 6 / #551): Claude plugin's `min_cli_version` is
+    // ahead of the installed CLI. This is the exact mirror of the
+    // project-side cli_min_version rule, but from the plugin's
+    // perspective — the same skew banner the plugin-side skill prints
+    // on first invocation, surfaced via `pulp doctor --versions` too.
+    if (cli.comparable && plugin_min_cli.comparable) {
+        if (compare_semver(plugin_min_cli, cli) > 0) {
+            findings.push_back({
+                SkewSeverity::Warn,
+                "Claude plugin requires CLI >= v" + plugin_min_cli.raw +
                     " but installed CLI is v" + cli.raw +
                     " — run `pulp upgrade`",
             });
@@ -311,6 +351,15 @@ int render_report(const VersionReport& report) {
                            (report.plugin_json_path.empty()
                                 ? std::string{}
                                 : "   (" + report.plugin_json_path.string() + ")"));
+        if (report.plugin_min_cli.comparable) {
+            // Plugin min_cli_version is a Slice 6 (#551) field. Render
+            // it right under the Plugin line so the requirement sits
+            // next to the plugin version it's attached to. Four extra
+            // spaces of indent (instead of the usual two) visually
+            // subordinate it to the Plugin line above.
+            std::cout << "    needs CLI >= v"
+                      << report.plugin_min_cli.raw << "\n";
+        }
     } else {
         line("Plugin:", "(not found — install the Claude Code plugin to enable checks)");
     }
@@ -441,6 +490,8 @@ int render_report_json(const VersionReport& report) {
     write_semver_json(std::cout, report.cli);
     std::cout << ",\n  \"plugin\": ";
     write_semver_json(std::cout, report.plugin);
+    std::cout << ",\n  \"plugin_min_cli\": ";
+    write_semver_json(std::cout, report.plugin_min_cli);
     std::cout << ",\n  \"plugin_json_path\": \""
               << json_escape(report.plugin_json_path.generic_string())
               << "\"";

--- a/tools/cli/version_diag.hpp
+++ b/tools/cli/version_diag.hpp
@@ -44,6 +44,11 @@ int compare_semver(const Semver& a, const Semver& b);
 // diagnostic. The plugin manifest is a stable, well-known shape.
 Semver read_plugin_version(const fs::path& plugin_json_path);
 
+// Parse ".claude-plugin/plugin.json" -> min_cli_version field. Returns
+// empty Semver if the field is absent — older plugin builds shipped
+// without it, so this is forward-compatible by design (Slice 6, #551).
+Semver read_plugin_min_cli_version(const fs::path& plugin_json_path);
+
 // Locate the plugin.json the diagnostic should report on, in order:
 //   1. explicit override path (if non-empty and exists)
 //   2. inside the current repo checkout: <repo>/.claude-plugin/plugin.json
@@ -87,6 +92,7 @@ struct ProjectEntry {
 struct VersionReport {
     Semver cli;                  // PULP_SDK_VERSION of the running binary
     Semver plugin;               // .claude-plugin/plugin.json "version"
+    Semver plugin_min_cli;       // .claude-plugin/plugin.json "min_cli_version" (Slice 6, #551)
     Semver project_sdk;          // project's own CMake/pulp.toml sdk_version
     Semver project_cli_min;      // project's pulp.toml cli_min_version
     fs::path project_root;       // for report lines
@@ -96,9 +102,10 @@ struct VersionReport {
     // ancestor projects surfaced by `--scan-parents`. See issue #552.
     std::vector<ProjectEntry> projects;
 
-    // Analyse and return user-visible findings. Rules (Slice 1 + 1b):
+    // Analyse and return user-visible findings. Rules (Slice 1 + 1b + 6):
     //   - project_cli_min set AND project_cli_min > cli  -> Warn "upgrade CLI"
     //   - project_sdk set AND project_sdk > cli          -> Warn "CLI behind project SDK"
+    //   - plugin_min_cli set AND plugin_min_cli > cli    -> Warn "upgrade CLI for plugin"
     //   - for each projects[] entry: same rules, message names the project
     //   - missing-on-disk entries                        -> Warn "path missing"
     //   - otherwise                                      -> Info "compatible"

--- a/tools/scripts/cli_version_check.sh
+++ b/tools/scripts/cli_version_check.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# cli_version_check.sh — plugin ↔ CLI skew detection helper.
+#
+# Release-discovery Slice 6 (#551). Sourced by Pulp Claude-Code plugin
+# skills that shell out to `pulp`. On the first invocation in a session,
+# compares the installed CLI's version against the plugin's declared
+# `min_cli_version` (from `plugin.json`, via `pulp doctor --versions --json`)
+# and prints a one-line upgrade hint on skew.
+#
+# Design locked 2026-04-21: plugin location comes from
+# `pulp doctor --versions --json` (Slice 1 surface, #546) — never from
+# an env var, a Claude-Code-specific lookup, or a self-locating trick.
+# That keeps the helper portable to any shell context and avoids
+# coupling Pulp skills to Claude-Code internals.
+#
+# The helper lives in `tools/scripts/` because it's a shared shell
+# utility, not a skill of its own — putting it under `.agents/skills/`
+# would require a stub SKILL.md and a skill_path_map entry. Keeping it
+# here also mirrors `install.sh`, `cli_sync_check.py`, and the other
+# cross-cutting shell helpers.
+#
+# Usage (sourced):
+#   source "$PULP_REPO_ROOT/tools/scripts/cli_version_check.sh"
+#   pulp_cli_version_check   # no-ops silently if already checked this session
+#
+# Usage (direct probe):
+#   bash tools/scripts/cli_version_check.sh
+#
+# Behaviour contract (stable — test/test_cli_skew_banner.cpp depends on it):
+#   - Exits 0 always (advisory only — never block a skill).
+#   - Writes the banner to stderr (stdout is reserved for data).
+#   - Honours $PULP_SKEW_CHECK_CACHE to override the session marker dir
+#     (test harness uses this to simulate fresh sessions).
+#   - Honours $PULP_SKEW_CHECK_DISABLE=1 to turn the check off entirely
+#     (users who want silence without an `update.mode = off` round-trip).
+#   - Emits the banner at most once per session (keyed by PPID).
+
+set -u
+
+pulp_cli_version_check() {
+    # Explicit opt-out.
+    if [ "${PULP_SKEW_CHECK_DISABLE:-0}" = "1" ]; then
+        return 0
+    fi
+
+    # `pulp` must be on PATH. If it isn't, that's a separate problem
+    # (the skill will surface its own "pulp not found" message) and
+    # not our concern here. We stay silent — a missing CLI is a user
+    # state, not a skew.
+    if ! command -v pulp >/dev/null 2>&1; then
+        return 0
+    fi
+
+    # Session marker. PPID is the parent shell — stable within a single
+    # bash driver script across multiple calls. Test harnesses override
+    # the cache dir so a fresh session can be simulated.
+    local cache_dir="${PULP_SKEW_CHECK_CACHE:-${TMPDIR:-/tmp}}"
+    mkdir -p "$cache_dir" 2>/dev/null || return 0
+    local marker="$cache_dir/pulp-skew-check-${PPID:-0}"
+    if [ -f "$marker" ]; then
+        return 0
+    fi
+
+    # Grab the diagnostic once. --json is the stable-shape surface
+    # (Slice 1 / #546) — do NOT parse human output. If the CLI is so
+    # old it lacks --json or --versions, the invocation fails and we
+    # silently stop (older users will upgrade for other reasons).
+    local json
+    json="$(pulp doctor --versions --json 2>/dev/null)" || {
+        : >"$marker" 2>/dev/null || true
+        return 0
+    }
+    if [ -z "$json" ]; then
+        : >"$marker" 2>/dev/null || true
+        return 0
+    fi
+
+    # Extract fields with POSIX awk. We deliberately avoid jq — this
+    # helper must work on every machine a user might run Claude Code
+    # on, including slim Git-Bash shells on Windows and ops containers
+    # without jq pre-installed.
+    local cli_raw plugin_min_raw
+    cli_raw="$(printf '%s' "$json" | \
+        awk 'BEGIN{RS="\"cli\"[ \t]*:"}NR==2{print}' | \
+        awk 'BEGIN{RS="\"raw\"[ \t]*:[ \t]*\""}NR==2{print}' | \
+        awk -F'"' 'NR==1{print $1}')"
+    plugin_min_raw="$(printf '%s' "$json" | \
+        awk 'BEGIN{RS="\"plugin_min_cli\"[ \t]*:"}NR==2{print}' | \
+        awk 'BEGIN{RS="\"raw\"[ \t]*:[ \t]*\""}NR==2{print}' | \
+        awk -F'"' 'NR==1{print $1}')"
+
+    # Missing plugin_min_cli (older plugin builds pre-Slice 6) —
+    # silently skip the check but still mark the session so we don't
+    # re-probe on every skill load in that session.
+    if [ -z "$plugin_min_raw" ] || [ -z "$cli_raw" ]; then
+        : >"$marker" 2>/dev/null || true
+        return 0
+    fi
+
+    # Compare semvers. Anything non-numeric (dev builds, tags) → skip.
+    _pulp_skew_parse() {
+        # $1 = raw string; prints "MAJ MIN PAT" on stdout, exit 1 if
+        # the string isn't a clean numeric triple.
+        local v="${1#v}"
+        v="${v#V}"
+        case "$v" in
+            *[!0-9.]*) return 1 ;;
+            *.*.*)     ;;
+            *)         return 1 ;;
+        esac
+        local maj="${v%%.*}"
+        local rest="${v#*.}"
+        local min="${rest%%.*}"
+        local pat="${rest#*.}"
+        case "$maj$min$pat" in
+            *[!0-9]*) return 1 ;;
+        esac
+        printf '%s %s %s\n' "$maj" "$min" "$pat"
+    }
+
+    local cli_parts min_parts
+    cli_parts="$(_pulp_skew_parse "$cli_raw")" || {
+        : >"$marker" 2>/dev/null || true
+        return 0
+    }
+    min_parts="$(_pulp_skew_parse "$plugin_min_raw")" || {
+        : >"$marker" 2>/dev/null || true
+        return 0
+    }
+
+    # shellcheck disable=SC2086
+    set -- $cli_parts; local cli_maj=$1 cli_min=$2 cli_pat=$3
+    # shellcheck disable=SC2086
+    set -- $min_parts; local m_maj=$1 m_min=$2 m_pat=$3
+
+    local skew=0
+    if [ "$m_maj" -gt "$cli_maj" ]; then
+        skew=1
+    elif [ "$m_maj" -eq "$cli_maj" ] && [ "$m_min" -gt "$cli_min" ]; then
+        skew=1
+    elif [ "$m_maj" -eq "$cli_maj" ] && [ "$m_min" -eq "$cli_min" ] && \
+         [ "$m_pat" -gt "$cli_pat" ]; then
+        skew=1
+    fi
+
+    if [ "$skew" = "1" ]; then
+        # Stable banner copy — mirrored in:
+        #   - .agents/skills/upgrade/SKILL.md (references this helper)
+        #   - .agents/skills/cli-maintenance/SKILL.md
+        #   - docs/guides/versioning.md (future Slice 6 addendum)
+        # If you change this text, update test/test_cli_skew_banner.cpp
+        # ("Stable banner copy") in the same PR.
+        printf '[pulp] Claude plugin requires CLI >= v%s but installed CLI is v%s. Run `pulp upgrade` or `/upgrade` in Claude Code.\n' \
+            "$plugin_min_raw" "$cli_raw" >&2
+    fi
+
+    : >"$marker" 2>/dev/null || true
+    return 0
+}
+
+# Direct invocation (e.g. `bash cli_version_check.sh`) runs the check.
+# When sourced, callers invoke `pulp_cli_version_check` explicitly so
+# the trigger point is visible at every call site.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    pulp_cli_version_check
+fi

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -176,6 +176,7 @@
         "tools/cli/migration_index.hpp",
         "tools/cli/migration_runtime.cpp",
         "tools/scripts/build_migration_index.py",
+        "tools/scripts/cli_version_check.sh",
         "docs/migrations/**",
         ".claude/commands/upgrade.md"
       ]


### PR DESCRIPTION
## Summary

Release-discovery Slice 6 — plugin ↔ CLI skew detection. Adds `min_cli_version` to `.claude-plugin/plugin.json` + `marketplace.json`, surfaces plugin ↔ CLI skew in `pulp doctor --versions` (both human and JSON), and ships a reusable shell helper that skills source before shelling out to `pulp`.

Design reference: `planning/release-discovery-ux-design-2026-04-20.md` Section E + F Slice 6.

- `.claude-plugin/plugin.json` / `marketplace.json`: new top-level `min_cli_version` field (0.31.0); plugin bump 0.7.1 → 0.8.0.
- `tools/cli/version_diag.{hpp,cpp}` + `cmd_doctor.cpp`: new `read_plugin_min_cli_version`, new `VersionReport.plugin_min_cli`, new skew rule, new `"plugin_min_cli"` JSON key, and an indented `needs CLI >= vX.Y.Z` line under the Plugin entry in human output.
- `tools/scripts/cli_version_check.sh`: new shared helper. Parses `pulp doctor --versions --json` with POSIX awk (no jq dependency), compares semvers, prints a one-line banner on stderr at most once per session. Honors `PULP_SKEW_CHECK_DISABLE` and `PULP_SKEW_CHECK_CACHE`.
- `.agents/skills/{upgrade,cli-maintenance,ci,ship,android}/SKILL.md`: document the helper + reference it from the shell-out skills.
- `docs/reference/cli.md`: document the new `plugin_min_cli` JSON key.

## Banner copy (stable, tested verbatim)

```
[pulp] Claude plugin requires CLI >= v<MIN> but installed CLI is v<HAVE>. Run `pulp upgrade` or `/upgrade` in Claude Code.
```

## Versioning

- SDK: `0.31.0 → 0.31.1` (patch — meaningful `cmd_doctor` + `version_diag` extension).
- Plugin: `0.7.1 → 0.8.0` (minor — new `min_cli_version` field + helper).

## Test plan

- [x] `pulp-test-cli-version-diag` — 6 new `[issue-551]` cases (new helpers + skew rule + JSON surface), all 29 existing cases still green.
- [x] `pulp-test-cli-skew-banner` — new shell-out test with a staged `pulp` shim: banner fires on skew, silent when CLI ahead, at most once per session, honors `PULP_SKEW_CHECK_DISABLE`.
- [x] `ctest -R "cli-"` — all 52 existing CLI ctest cases still green.
- [x] Full build green on macOS arm64.
- [x] `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode=report` clean.
- [x] `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --mode=report` clean.

Closes #551