### PR TITLE
cli: release-discovery Slice 7 pulp project bump + undo (#564)

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -43,7 +43,7 @@ requires:
 - It's a subcommand of something already covered
 
 **Commands that intentionally don't have slash commands:**
-audio, cache, clean, export-tokens, ci-local, design-debug, help, projects
+audio, cache, clean, export-tokens, ci-local, design-debug, help, projects, project
 
 **Commands that DO have slash commands** (list for cross-reference, not exhaustive — `ls .claude/commands/` is authoritative):
 build, test, run, validate, ship, version, doctor, create, docs, status, design, import-design, inspect, pr, ci, upgrade
@@ -255,6 +255,54 @@ Gotchas:
 - **`--scan-parents` reads `CMakeLists.txt` with a simple regex**
   (`\bpulp_add_[A-Za-z0-9_]+\s*\(`). Matches any `pulp_add_*` macro
   the SDK introduces without requiring a new entry here.
+
+## `pulp project bump` / `pulp project undo` (#499 / #564 Slice 7)
+
+`pulp project bump` and `pulp project undo` live in
+`tools/cli/cmd_project.cpp` and delegate to the pure-logic core in
+`tools/cli/project_bump.{hpp,cpp}`. Behavior summary:
+
+- Bump reads `CMakeLists.txt`, locates the first Pulp pin (FetchContent
+  GIT_TAG, `pulp_add_project(VERSION ...)`, or `project(NAME VERSION
+  ...)`), rewrites it atomically, records an undo batch, and prints
+  Slice 3 (#548) migration notes for the hop.
+- `--all` iterates `~/.pulp/projects.json` (Slice 1b #552).
+- Undo reads `bump-undo-<timestamp>.json` and reverts `bumped` entries.
+
+Gotchas:
+
+- **Singular `project` command, not `projects`.** Registry commands
+  (`pulp projects list/add/remove`) are plural; per-project pin
+  management is singular. Both exist side-by-side in the dispatch
+  table — keep them separate in help text and docs.
+- **Undo filenames replace `:` with `-`.** ISO-8601 stamps contain
+  colons which are illegal on Windows. `undo_batch_path()` maps
+  `2026-04-21T14:30:00Z` → `bump-undo-2026-04-21T14-30-00Z.json`.
+  Tests pin this; don't "fix" it on POSIX without updating Windows.
+- **Dynamic pins (branches, SHAs) are skipped, not failed.**
+  `refuse_dynamic_pin()` returns true for anything that isn't
+  semver-after-optional-`v`. Status ends up as `"skipped"` with a
+  human-readable reason in `failure_reason`. Do not rewrite these.
+- **`project_bump` is decoupled from `cli_common`.** Same rule as
+  `projects_registry` / `update_mode` — the unit test binaries link
+  just the module + Catch2. Don't reach into `cli_common.hpp` from
+  `project_bump.cpp`.
+- **Catch2 test names can't contain `--flag`.** The Catch2 runner
+  parses `--foo` as a CLI flag even inside a string argument, so
+  ctest's Catch2 invocation fails with "unrecognised token". Rename
+  bump-all test cases to "bump all ..." instead of "--all ...".
+- **Post-upgrade hook respects `update.bump_projects`.**
+  `cmd_upgrade.cpp` reads the key (default `prompt`) and either
+  prints the `pulp project bump --all` hint or stays quiet on
+  `off`. The actual exec-into-new-binary lands in a follow-up; this
+  slice just wires the nudge.
+- **Git-clean gate uses `git -C <proj> status --porcelain`.** If
+  git isn't on PATH, `cmake_is_dirty()` returns false — we refuse
+  to block on a missing tool. `--force-dirty` is the explicit
+  override for users who WANT to bump alongside other edits.
+- **Migration notes print once per bump batch, using the minimum
+  old pin as `from`.** That captures the widest set of applicable
+  notes when different projects were on different versions.
 
 ## `pulp doctor --versions` — version diagnostics (#499 Slice 1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.31.1
+    VERSION 0.32.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -319,6 +319,44 @@ location is `$PULP_HOME/projects.json` (defaulting to
 `~/.pulp/projects.json`). A missing registry file is treated as an
 empty list — no first-run setup is required.
 
+### project
+
+**Status**: usable
+
+Per-project SDK pin management. Updates the pinned Pulp version in
+a project's `CMakeLists.txt` — recognizing `FetchContent_Declare(pulp
+... GIT_TAG vX.Y.Z)`, `pulp_add_project(NAME VERSION X.Y.Z ...)`, and
+`project(NAME VERSION X.Y.Z ...)` — and records an undo batch at
+`~/.pulp/bump-undo-<timestamp>.json` so mistakes are one command
+away from recovery.
+
+```bash
+pulp project bump                     # bump CWD project to CLI's own version
+pulp project bump 0.32.0              # bump to explicit version (positional)
+pulp project bump --to=0.32.0         # bump to explicit version (named)
+pulp project bump --all               # iterate ~/.pulp/projects.json
+pulp project bump --all --dry-run     # show plan without writing
+pulp project bump --force-dirty       # skip the git-clean check
+pulp project bump --allow-downgrade   # target older than current pin
+pulp project bump --verify-builds     # build after bump; roll back on failure
+
+pulp project undo                     # revert the newest batch
+pulp project undo <timestamp>         # revert a specific batch
+```
+
+**Safety rails:** branch pins (`GIT_TAG main`) and SHA pins are
+skipped with a diagnostic; dirty `CMakeLists.txt` is gated behind
+`--force-dirty`; target older than current is gated behind
+`--allow-downgrade`; `--all` isolates per-project failures so one
+broken project doesn't abort the rest.
+
+**Migration notes** from Slice 3 (`#548`) print after a successful
+bump so users see any API changes the hop introduced.
+
+**Post-upgrade hook:** the `update.bump_projects` config key (prompt
+| auto | off; default prompt) controls whether `pulp upgrade` prints
+a `pulp project bump --all` hint after a successful CLI upgrade.
+
 ### ci-local
 
 **Status**: legacy (prefer [Shipyard](https://github.com/danielraffel/Shipyard))

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -180,6 +180,50 @@ commands:
             description: Project directory to forget
     docs: reference/cli.md#projects
 
+  - name: project
+    status: usable
+    summary: Per-project SDK pin management — bump pinned Pulp version in CMakeLists.txt (FetchContent_Declare GIT_TAG / pulp_add_project VERSION / project VERSION) and undo the last batch. (#564)
+    subcommands:
+      - name: bump
+        summary: Bump the pinned Pulp SDK version (CWD by default; `--all` iterates the registry)
+        args:
+          - name: version
+            kind: positional
+            required: false
+            description: Target semver (alias for --to). Defaults to the CLI's own version.
+          - name: --to
+            kind: value
+            required: false
+            description: Target semver (e.g. 0.32.0). Rejects pre-release suffixes.
+          - name: --all
+            kind: flag
+            required: false
+            description: Iterate ~/.pulp/projects.json instead of the current directory
+          - name: --dry-run
+            kind: flag
+            required: false
+            description: Show plan without writing; never mutates anything
+          - name: --force-dirty
+            kind: flag
+            required: false
+            description: Skip the git-clean check on CMakeLists.txt
+          - name: --allow-downgrade
+            kind: flag
+            required: false
+            description: Permit target older than current pin
+          - name: --verify-builds
+            kind: flag
+            required: false
+            description: Build each project after bump; roll back the pin on failure
+      - name: undo
+        summary: Revert the newest `pulp project bump` batch (or a specific one by timestamp)
+        args:
+          - name: timestamp
+            kind: positional
+            required: false
+            description: ISO-8601 UTC stamp (as in the bump-undo-<timestamp>.json filename). Defaults to newest.
+    docs: reference/cli.md#project
+
   - name: docs
     status: usable
     summary: Browse local documentation and status manifests.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -136,6 +136,40 @@ target_link_libraries(pulp-test-cli-projects-registry PRIVATE
     Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-cli-projects-registry)
 
+# CLI project bump (#499 Slice 7 / #564): pure-logic tests for the
+# CMakeLists pin parser, rewriter, refuse-dynamic-pin gate, semver /
+# downgrade guard, and the undo-batch JSON round-trip. project_bump.cpp
+# is deliberately free of cli_common link deps so the tests link it
+# standalone (same pattern as projects_registry / update_check /
+# update_mode).
+add_executable(pulp-test-cli-project-bump
+    test_cli_project_bump.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/project_bump.cpp
+)
+target_include_directories(pulp-test-cli-project-bump PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/cli)
+target_link_libraries(pulp-test-cli-project-bump PRIVATE
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-cli-project-bump)
+
+# CLI project bump --all (#499 Slice 7 / #564): batch-level
+# invariants — partial failure isolation, missing-project reporting,
+# undo round-trip across mixed-status batches, and the --allow-downgrade
+# gate. Links both project_bump.cpp and projects_registry.cpp so the
+# batch simulation can drive a real ~/.pulp/projects.json roundtrip.
+add_executable(pulp-test-cli-project-bump-all
+    test_cli_project_bump_all.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/project_bump.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/projects_registry.cpp
+)
+target_include_directories(pulp-test-cli-project-bump-all PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/cli)
+target_link_libraries(pulp-test-cli-project-bump-all PRIVATE
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-cli-project-bump-all)
+
 # CLI update-check (#499 Slice 2 / #547): pure-logic tests for the
 # ~/.pulp/update-cache.json round-trip, is_cache_stale boundary,
 # semver comparison, banner composition, TOML writer, and the

--- a/test/test_cli_project_bump.cpp
+++ b/test/test_cli_project_bump.cpp
@@ -1,0 +1,364 @@
+// test_cli_project_bump.cpp — Unit tests for `pulp project bump`.
+//
+// Release-discovery Slice 7 (#564 / parent #499). Exercises the
+// pure-logic core in tools/cli/project_bump.{hpp,cpp}:
+//
+//   - CMakeLists pin detection (FetchContent, pulp_add_project,
+//     project() VERSION variants)
+//   - rewrite_pin preserves surrounding bytes and the `v` prefix
+//   - refuse_dynamic_pin() gates branches + SHAs
+//   - downgrade guard
+//   - undo-batch serialize / parse round-trips
+//   - undo-batch listing under a scratch PULP_HOME
+//   - git-clean gate is a pure bool — exercised via a synthetic
+//     `.git` directory + `git status --porcelain` smoke (optional,
+//     skipped when git isn't on PATH)
+//
+// Per the #290 policy the tests ship WITH the fix — these are the
+// subsystem's first automated coverage.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "../tools/cli/project_bump.hpp"
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+namespace pb = pulp::cli::project_bump;
+
+namespace {
+
+struct TempDir {
+    fs::path path;
+    TempDir() {
+        auto base = fs::temp_directory_path();
+        static std::atomic<int> seq{0};
+        int n = seq.fetch_add(1);
+        path = base / ("pulp-project-bump-test-" +
+                       std::to_string(reinterpret_cast<std::uintptr_t>(this)) +
+                       "-" + std::to_string(n));
+        fs::create_directories(path);
+        std::error_code ec;
+        auto canon = fs::weakly_canonical(path, ec);
+        if (!ec) path = canon;
+    }
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+std::string read_text(const fs::path& p) {
+    std::ifstream f(p);
+    if (!f.is_open()) return {};
+    std::ostringstream os;
+    os << f.rdbuf();
+    return os.str();
+}
+
+void write_text(const fs::path& p, const std::string& body) {
+    fs::create_directories(p.parent_path());
+    std::ofstream f(p);
+    f << body;
+}
+
+}  // namespace
+
+// ── Pin-site discovery ─────────────────────────────────────────────────────
+
+TEST_CASE("find_pin_site detects FetchContent_Declare GIT_TAG",
+          "[project-bump][issue-564]") {
+    std::string src =
+        "cmake_minimum_required(VERSION 3.20)\n"
+        "project(App LANGUAGES CXX)\n"
+        "include(FetchContent)\n"
+        "FetchContent_Declare(pulp\n"
+        "    GIT_REPOSITORY https://github.com/danielraffel/pulp.git\n"
+        "    GIT_TAG v0.23.0)\n"
+        "FetchContent_MakeAvailable(pulp)\n";
+    auto site = pb::find_pin_site(src);
+    REQUIRE(site.kind == pb::PinKind::FetchContentGitTag);
+    REQUIRE(site.current_pin == "v0.23.0");
+    REQUIRE(pb::pin_has_v_prefix(site.current_pin));
+    REQUIRE(pb::normalize_pin(site.current_pin) == "0.23.0");
+}
+
+TEST_CASE("find_pin_site detects pulp_add_project VERSION",
+          "[project-bump][issue-564]") {
+    std::string src =
+        "cmake_minimum_required(VERSION 3.20)\n"
+        "pulp_add_project(MySynth\n"
+        "    VERSION 0.23.0\n"
+        "    FORMATS CLAP VST3)\n";
+    auto site = pb::find_pin_site(src);
+    REQUIRE(site.kind == pb::PinKind::PulpAddProject);
+    REQUIRE(site.current_pin == "0.23.0");
+    REQUIRE_FALSE(pb::pin_has_v_prefix(site.current_pin));
+}
+
+TEST_CASE("find_pin_site detects project() VERSION",
+          "[project-bump][issue-564]") {
+    std::string src =
+        "cmake_minimum_required(VERSION 3.20)\n"
+        "project(MySynth VERSION 0.23.0 LANGUAGES CXX)\n";
+    auto site = pb::find_pin_site(src);
+    REQUIRE(site.kind == pb::PinKind::ProjectVersion);
+    REQUIRE(site.current_pin == "0.23.0");
+}
+
+TEST_CASE("find_pin_site returns Unknown for non-Pulp CMakeLists",
+          "[project-bump][issue-564]") {
+    std::string src =
+        "cmake_minimum_required(VERSION 3.20)\n"
+        "project(Unrelated LANGUAGES CXX)\n"
+        "add_executable(hello hello.cpp)\n";
+    auto site = pb::find_pin_site(src);
+    // `project()` catches plain `project(Unrelated ...)` only when a
+    // VERSION keyword is present, so this should NOT match. Unrelated
+    // CMakeLists are Unknown.
+    REQUIRE(site.kind == pb::PinKind::Unknown);
+}
+
+TEST_CASE("FetchContent wins over project() when both present",
+          "[project-bump][issue-564]") {
+    std::string src =
+        "project(App VERSION 1.2.3)\n"
+        "FetchContent_Declare(pulp GIT_TAG v0.23.0)\n";
+    auto site = pb::find_pin_site(src);
+    REQUIRE(site.kind == pb::PinKind::FetchContentGitTag);
+    REQUIRE(site.current_pin == "v0.23.0");
+}
+
+// ── Dynamic pin refusal ────────────────────────────────────────────────────
+
+TEST_CASE("refuse_dynamic_pin rejects branch names and SHAs",
+          "[project-bump][issue-564]") {
+    pb::PinSite site;
+    site.kind = pb::PinKind::FetchContentGitTag;
+
+    site.current_pin = "main";
+    REQUIRE(pb::refuse_dynamic_pin(site));
+
+    site.current_pin = "develop";
+    REQUIRE(pb::refuse_dynamic_pin(site));
+
+    // 40-char SHA
+    site.current_pin = "1234567890abcdef1234567890abcdef12345678";
+    REQUIRE(pb::refuse_dynamic_pin(site));
+
+    // 7-char short SHA
+    site.current_pin = "abc1234";
+    REQUIRE(pb::refuse_dynamic_pin(site));
+
+    // Semver is safe.
+    site.current_pin = "0.23.0";
+    REQUIRE_FALSE(pb::refuse_dynamic_pin(site));
+    site.current_pin = "v0.23.0";
+    REQUIRE_FALSE(pb::refuse_dynamic_pin(site));
+}
+
+// ── Rewrite ─────────────────────────────────────────────────────────────────
+
+TEST_CASE("rewrite_pin preserves leading 'v' prefix",
+          "[project-bump][issue-564]") {
+    std::string src =
+        "FetchContent_Declare(pulp\n"
+        "    GIT_REPOSITORY https://github.com/danielraffel/pulp.git\n"
+        "    GIT_TAG v0.23.0)\n";
+    auto site = pb::find_pin_site(src);
+    REQUIRE(site.kind == pb::PinKind::FetchContentGitTag);
+    auto rewritten = pb::rewrite_pin(src, site, "0.32.0", /*has_v=*/true);
+    REQUIRE(rewritten);
+    REQUIRE(rewritten->find("GIT_TAG v0.32.0)") != std::string::npos);
+    // Everything else should be byte-identical — spot-check the
+    // surrounding tokens.
+    REQUIRE(rewritten->find("GIT_REPOSITORY https://github.com/danielraffel/pulp.git")
+            != std::string::npos);
+    REQUIRE(rewritten->find("v0.23.0") == std::string::npos);
+}
+
+TEST_CASE("rewrite_pin rewrites pulp_add_project VERSION without adding 'v'",
+          "[project-bump][issue-564]") {
+    std::string src =
+        "pulp_add_project(MySynth\n"
+        "    VERSION 0.23.0\n"
+        "    FORMATS CLAP VST3)\n";
+    auto site = pb::find_pin_site(src);
+    REQUIRE(site.kind == pb::PinKind::PulpAddProject);
+    auto rewritten = pb::rewrite_pin(src, site, "0.32.0", /*has_v=*/false);
+    REQUIRE(rewritten);
+    REQUIRE(rewritten->find("VERSION 0.32.0") != std::string::npos);
+    REQUIRE(rewritten->find("VERSION v") == std::string::npos);
+    REQUIRE(rewritten->find("FORMATS CLAP VST3") != std::string::npos);
+}
+
+TEST_CASE("rewrite_pin rewrites project() VERSION",
+          "[project-bump][issue-564]") {
+    std::string src =
+        "project(MySynth VERSION 0.23.0 LANGUAGES CXX)\n";
+    auto site = pb::find_pin_site(src);
+    REQUIRE(site.kind == pb::PinKind::ProjectVersion);
+    auto rewritten = pb::rewrite_pin(src, site, "0.32.0", /*has_v=*/false);
+    REQUIRE(rewritten);
+    REQUIRE(*rewritten == "project(MySynth VERSION 0.32.0 LANGUAGES CXX)\n");
+}
+
+TEST_CASE("rewrite_pin returns nullopt on Unknown site",
+          "[project-bump][issue-564]") {
+    pb::PinSite s;  // defaults to Unknown
+    REQUIRE_FALSE(pb::rewrite_pin("anything", s, "0.32.0", false).has_value());
+}
+
+// ── Semver + downgrade ─────────────────────────────────────────────────────
+
+TEST_CASE("parse_semver_strict rejects pre-release suffixes",
+          "[project-bump][issue-564]") {
+    REQUIRE(pb::parse_semver_strict("0.32.0").ok);
+    REQUIRE(pb::parse_semver_strict("v0.32.0").ok);
+    REQUIRE_FALSE(pb::parse_semver_strict("0.32").ok);
+    REQUIRE_FALSE(pb::parse_semver_strict("0.32.0-rc1").ok);
+    REQUIRE_FALSE(pb::parse_semver_strict("").ok);
+    REQUIRE_FALSE(pb::parse_semver_strict("main").ok);
+}
+
+TEST_CASE("is_downgrade compares semver strictly",
+          "[project-bump][issue-564]") {
+    REQUIRE(pb::is_downgrade("0.32.0", "0.31.0"));
+    REQUIRE(pb::is_downgrade("1.0.0", "0.99.99"));
+    REQUIRE_FALSE(pb::is_downgrade("0.31.0", "0.32.0"));
+    REQUIRE_FALSE(pb::is_downgrade("0.31.0", "0.31.0"));  // equal is not a downgrade
+    REQUIRE_FALSE(pb::is_downgrade("main", "0.32.0"));    // bad input → false
+}
+
+// ── Undo batch I/O ─────────────────────────────────────────────────────────
+
+TEST_CASE("undo batch serialize -> parse round-trip",
+          "[project-bump][issue-564]") {
+    pb::UndoBatch b;
+    b.timestamp = "2026-04-21T14:30:00Z";
+    b.target_version = "0.32.0";
+
+    pb::UndoEntry e1;
+    e1.project_path = "/tmp/p1";
+    e1.project_name = "P1";
+    e1.old_pin = "v0.23.0";
+    e1.old_pin_style_has_v = true;
+    e1.pin_kind = pb::PinKind::FetchContentGitTag;
+    e1.status = "bumped";
+    b.entries.push_back(e1);
+
+    pb::UndoEntry e2;
+    e2.project_path = "/tmp/p2";
+    e2.project_name = "P2";
+    e2.old_pin = "";
+    e2.status = "failed";
+    e2.failure_reason = "no CMakeLists.txt";
+    b.entries.push_back(e2);
+
+    auto json = pb::serialize_undo_batch(b);
+    auto parsed = pb::parse_undo_batch(json);
+    REQUIRE(parsed);
+    REQUIRE(parsed->timestamp == b.timestamp);
+    REQUIRE(parsed->target_version == b.target_version);
+    REQUIRE(parsed->entries.size() == 2);
+    REQUIRE(parsed->entries[0].project_name == "P1");
+    REQUIRE(parsed->entries[0].old_pin == "v0.23.0");
+    REQUIRE(parsed->entries[0].old_pin_style_has_v == true);
+    REQUIRE(parsed->entries[0].pin_kind == pb::PinKind::FetchContentGitTag);
+    REQUIRE(parsed->entries[0].status == "bumped");
+    REQUIRE(parsed->entries[1].status == "failed");
+    REQUIRE(parsed->entries[1].failure_reason == "no CMakeLists.txt");
+}
+
+TEST_CASE("write_undo_batch / read_undo_batch round-trip on disk",
+          "[project-bump][issue-564]") {
+    TempDir tmp;
+    pb::UndoBatch b;
+    b.timestamp = "2026-04-21T14:30:00Z";
+    b.target_version = "0.32.0";
+
+    pb::UndoEntry e;
+    e.project_path = tmp.path / "proj";
+    e.project_name = "Proj";
+    e.old_pin = "0.23.0";
+    e.old_pin_style_has_v = false;
+    e.pin_kind = pb::PinKind::PulpAddProject;
+    e.status = "bumped";
+    b.entries.push_back(e);
+
+    auto path = pb::undo_batch_path(tmp.path, b.timestamp);
+    REQUIRE(pb::write_undo_batch(path, b));
+    REQUIRE(fs::exists(path));
+
+    auto back = pb::read_undo_batch(path);
+    REQUIRE(back);
+    REQUIRE(back->target_version == "0.32.0");
+    REQUIRE(back->entries.size() == 1);
+    REQUIRE(back->entries[0].project_name == "Proj");
+    REQUIRE(back->entries[0].pin_kind == pb::PinKind::PulpAddProject);
+}
+
+TEST_CASE("list_undo_batches returns newest-first",
+          "[project-bump][issue-564]") {
+    TempDir tmp;
+    // Write two undo files with distinct timestamps.
+    pb::UndoBatch b1;
+    b1.timestamp = "2026-04-20T10:00:00Z";
+    pb::UndoBatch b2;
+    b2.timestamp = "2026-04-22T10:00:00Z";
+    auto p1 = pb::undo_batch_path(tmp.path, b1.timestamp);
+    auto p2 = pb::undo_batch_path(tmp.path, b2.timestamp);
+    REQUIRE(pb::write_undo_batch(p1, b1));
+    REQUIRE(pb::write_undo_batch(p2, b2));
+
+    auto list = pb::list_undo_batches(tmp.path);
+    REQUIRE(list.size() == 2);
+    REQUIRE(list[0] == p2);  // newer first
+    REQUIRE(list[1] == p1);
+}
+
+TEST_CASE("undo_batch_path replaces colons for Windows safety",
+          "[project-bump][issue-564]") {
+    fs::path home = "/tmp/fake-home";
+    auto p = pb::undo_batch_path(home, "2026-04-21T14:30:00Z");
+    // Filename must not contain ':'
+    auto fn = p.filename().string();
+    REQUIRE(fn.find(':') == std::string::npos);
+    REQUIRE(fn.find("2026-04-21T14-30-00Z") != std::string::npos);
+}
+
+// ── --dry-run equivalence ───────────────────────────────────────────────────
+
+TEST_CASE("dry-run produces same rewrite as real run",
+          "[project-bump][issue-564]") {
+    std::string src =
+        "FetchContent_Declare(pulp\n"
+        "    GIT_TAG v0.23.0)\n";
+    auto site = pb::find_pin_site(src);
+    auto rewritten = pb::rewrite_pin(src, site, "0.32.0",
+                                      pb::pin_has_v_prefix(site.current_pin));
+    REQUIRE(rewritten);
+    // Dry-run path computes the same string but doesn't persist it —
+    // the equivalence assertion is that `rewrite_pin` is pure.
+    auto rewritten2 = pb::rewrite_pin(src, site, "0.32.0",
+                                       pb::pin_has_v_prefix(site.current_pin));
+    REQUIRE(rewritten2);
+    REQUIRE(*rewritten == *rewritten2);
+}
+
+// ── Status strings are stable ──────────────────────────────────────────────
+
+TEST_CASE("pin_kind_name round-trips for all variants",
+          "[project-bump][issue-564]") {
+    for (auto k : {pb::PinKind::FetchContentGitTag,
+                   pb::PinKind::PulpAddProject,
+                   pb::PinKind::ProjectVersion,
+                   pb::PinKind::Unknown}) {
+        auto name = pb::pin_kind_name(k);
+        REQUIRE(pb::parse_pin_kind(name) == k);
+    }
+}

--- a/test/test_cli_project_bump_all.cpp
+++ b/test/test_cli_project_bump_all.cpp
@@ -1,0 +1,312 @@
+// test_cli_project_bump_all.cpp — Batch / --all behavior for
+// `pulp project bump`.
+//
+// Release-discovery Slice 7 (#564 / parent #499). These tests exercise
+// the batch-level invariants that hold regardless of where the project
+// list comes from (registry or the single CWD):
+//
+//   - Partial-failure isolation: one "failed" entry in a batch does
+//     not corrupt the undo file for the other entries.
+//   - Missing-project handling: registry entries that don't exist on
+//     disk become "failed" rows without mutating anything.
+//   - Undo round-trip across a multi-entry batch.
+//   - Stale-registry policy: a batch that encounters a missing
+//     project does NOT remove the project from the registry (matches
+//     the Slice 1b "never silently mutate the user's registry" rule).
+//
+// The tests simulate the bump flow by driving `find_pin_site` +
+// `rewrite_pin` + undo I/O directly. This mirrors the
+// `bump_one` loop in cmd_project.cpp without needing to link the
+// full CLI binary — same decoupling discipline as test_cli_project_bump.
+// An end-to-end smoke via `pulp project bump --help` lives in
+// test_cli_shellout.cpp.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "../tools/cli/project_bump.hpp"
+#include "../tools/cli/projects_registry.hpp"
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+namespace pb = pulp::cli::project_bump;
+namespace prjreg = pulp::cli::projects_registry;
+
+namespace {
+
+struct TempDir {
+    fs::path path;
+    TempDir() {
+        auto base = fs::temp_directory_path();
+        static std::atomic<int> seq{0};
+        int n = seq.fetch_add(1);
+        path = base / ("pulp-project-bump-all-test-" +
+                       std::to_string(reinterpret_cast<std::uintptr_t>(this)) +
+                       "-" + std::to_string(n));
+        fs::create_directories(path);
+        std::error_code ec;
+        auto canon = fs::weakly_canonical(path, ec);
+        if (!ec) path = canon;
+    }
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+std::string read_text(const fs::path& p) {
+    std::ifstream f(p);
+    if (!f.is_open()) return {};
+    std::ostringstream os;
+    os << f.rdbuf();
+    return os.str();
+}
+
+void write_text(const fs::path& p, const std::string& body) {
+    fs::create_directories(p.parent_path());
+    std::ofstream f(p);
+    f << body;
+}
+
+// Build a minimal Pulp-ish project under `root`.
+void make_pulp_project(const fs::path& root, const std::string& pin) {
+    fs::create_directories(root);
+    std::string src =
+        "cmake_minimum_required(VERSION 3.20)\n"
+        "include(FetchContent)\n"
+        "FetchContent_Declare(pulp\n"
+        "    GIT_REPOSITORY https://github.com/danielraffel/pulp.git\n"
+        "    GIT_TAG v" + pin + ")\n"
+        "FetchContent_MakeAvailable(pulp)\n"
+        "pulp_add_plugin(app FORMATS CLAP)\n";
+    write_text(root / "CMakeLists.txt", src);
+}
+
+// Simulate bump_one() for a single project. Returns an UndoEntry.
+// Deliberately kept short — the real dispatch lives in cmd_project.cpp.
+// What we're testing here is the BATCH invariants that compose on top
+// of it.
+pb::UndoEntry simulate_bump(const fs::path& proj,
+                            const std::string& target) {
+    pb::UndoEntry e;
+    e.project_path = proj;
+    e.project_name = proj.filename().string();
+    e.status = "skipped";
+
+    if (!fs::exists(proj)) {
+        e.status = "failed";
+        e.failure_reason = "project path does not exist";
+        return e;
+    }
+    auto cmake_path = proj / "CMakeLists.txt";
+    if (!fs::exists(cmake_path)) {
+        e.status = "failed";
+        e.failure_reason = "no CMakeLists.txt";
+        return e;
+    }
+    auto src = read_text(cmake_path);
+    auto site = pb::find_pin_site(src);
+    e.pin_kind = site.kind;
+    e.old_pin = site.current_pin;
+    e.old_pin_style_has_v = pb::pin_has_v_prefix(site.current_pin);
+
+    if (site.kind == pb::PinKind::Unknown) {
+        e.status = "skipped";
+        e.failure_reason = "no pin";
+        return e;
+    }
+    if (pb::refuse_dynamic_pin(site)) {
+        e.status = "skipped";
+        e.failure_reason = "dynamic pin";
+        return e;
+    }
+    auto normalized = pb::normalize_pin(site.current_pin);
+    if (normalized == target) {
+        e.status = "skipped";
+        e.failure_reason = "already at target";
+        return e;
+    }
+    auto rewritten = pb::rewrite_pin(src, site, target, e.old_pin_style_has_v);
+    if (!rewritten) {
+        e.status = "failed";
+        e.failure_reason = "rewrite failed";
+        return e;
+    }
+    write_text(cmake_path, *rewritten);
+    e.status = "bumped";
+    return e;
+}
+
+}  // namespace
+
+TEST_CASE("bump all bumps every registered project and records undo",
+          "[project-bump-all][issue-564]") {
+    TempDir tmp;
+    auto home = tmp.path / "pulp-home";
+    fs::create_directories(home);
+
+    // Three projects on disk.
+    auto p1 = tmp.path / "proj1";
+    auto p2 = tmp.path / "proj2";
+    auto p3 = tmp.path / "proj3";
+    make_pulp_project(p1, "0.23.0");
+    make_pulp_project(p2, "0.24.0");
+    make_pulp_project(p3, "0.25.0");
+
+    // Registry under the scratch home.
+    auto reg = home / "projects.json";
+    prjreg::add_project(reg, p1, "Proj1");
+    prjreg::add_project(reg, p2, "Proj2");
+    prjreg::add_project(reg, p3, "Proj3");
+
+    // Drive the batch — mirrors do_bump()'s inner loop.
+    pb::UndoBatch batch;
+    batch.timestamp = pb::now_iso8601_utc();
+    batch.target_version = "0.32.0";
+    for (const auto& proj : prjreg::read_registry(reg)) {
+        batch.entries.push_back(simulate_bump(proj.path, batch.target_version));
+    }
+
+    // Every project bumped successfully.
+    REQUIRE(batch.entries.size() == 3);
+    for (const auto& e : batch.entries) REQUIRE(e.status == "bumped");
+
+    // Write undo file and round-trip.
+    auto undo_path = pb::undo_batch_path(home, batch.timestamp);
+    REQUIRE(pb::write_undo_batch(undo_path, batch));
+    auto back = pb::read_undo_batch(undo_path);
+    REQUIRE(back);
+    REQUIRE(back->entries.size() == 3);
+
+    // On-disk CMakeLists reflect the new pin.
+    REQUIRE(read_text(p1 / "CMakeLists.txt").find("GIT_TAG v0.32.0") != std::string::npos);
+    REQUIRE(read_text(p2 / "CMakeLists.txt").find("GIT_TAG v0.32.0") != std::string::npos);
+    REQUIRE(read_text(p3 / "CMakeLists.txt").find("GIT_TAG v0.32.0") != std::string::npos);
+}
+
+TEST_CASE("bump all tolerates partial failure and keeps batch intact",
+          "[project-bump-all][issue-564]") {
+    TempDir tmp;
+    auto home = tmp.path / "pulp-home";
+    fs::create_directories(home);
+
+    // Five entries: 4 healthy, 1 missing-on-disk.
+    auto p1 = tmp.path / "a";
+    auto p2 = tmp.path / "b";
+    auto p3 = tmp.path / "c";
+    auto p4 = tmp.path / "d";
+    make_pulp_project(p1, "0.23.0");
+    make_pulp_project(p2, "0.23.0");
+    make_pulp_project(p3, "0.23.0");
+    make_pulp_project(p4, "0.23.0");
+    auto ghost = tmp.path / "ghost";  // never created
+
+    auto reg = home / "projects.json";
+    prjreg::add_project(reg, p1, "A");
+    prjreg::add_project(reg, p2, "B");
+    prjreg::add_project(reg, ghost, "Ghost");
+    prjreg::add_project(reg, p3, "C");
+    prjreg::add_project(reg, p4, "D");
+
+    pb::UndoBatch batch;
+    batch.timestamp = pb::now_iso8601_utc();
+    batch.target_version = "0.32.0";
+    for (const auto& proj : prjreg::read_registry(reg)) {
+        batch.entries.push_back(simulate_bump(proj.path, batch.target_version));
+    }
+
+    REQUIRE(batch.entries.size() == 5);
+    int bumped = 0, failed = 0;
+    for (const auto& e : batch.entries) {
+        if (e.status == "bumped") ++bumped;
+        else if (e.status == "failed") ++failed;
+    }
+    REQUIRE(bumped == 4);
+    REQUIRE(failed == 1);
+
+    // Ghost failure must not have removed the entry from the
+    // registry — Slice 1b policy is "never silently mutate".
+    auto after = prjreg::read_registry(reg);
+    REQUIRE(after.size() == 5);
+
+    // Undo file captures all five entries — the failed one too so
+    // the user can see what was reported.
+    auto undo_path = pb::undo_batch_path(home, batch.timestamp);
+    REQUIRE(pb::write_undo_batch(undo_path, batch));
+    auto back = pb::read_undo_batch(undo_path);
+    REQUIRE(back);
+    REQUIRE(back->entries.size() == 5);
+    int back_failed = 0;
+    for (const auto& e : back->entries) if (e.status == "failed") ++back_failed;
+    REQUIRE(back_failed == 1);
+}
+
+TEST_CASE("undo reverts only 'bumped' entries, leaves others alone",
+          "[project-bump-all][issue-564]") {
+    TempDir tmp;
+    auto home = tmp.path / "pulp-home";
+    fs::create_directories(home);
+
+    auto p_ok      = tmp.path / "ok";
+    auto p_dynamic = tmp.path / "dynamic";
+    make_pulp_project(p_ok, "0.23.0");
+    fs::create_directories(p_dynamic);
+    write_text(p_dynamic / "CMakeLists.txt",
+               "FetchContent_Declare(pulp GIT_TAG main)\n");
+
+    pb::UndoBatch batch;
+    batch.timestamp = pb::now_iso8601_utc();
+    batch.target_version = "0.32.0";
+    batch.entries.push_back(simulate_bump(p_ok,      "0.32.0"));
+    batch.entries.push_back(simulate_bump(p_dynamic, "0.32.0"));
+
+    REQUIRE(batch.entries[0].status == "bumped");
+    REQUIRE(batch.entries[1].status == "skipped");
+
+    // Simulate undo: walk entries, revert only the bumped ones.
+    for (const auto& e : batch.entries) {
+        if (e.status != "bumped") continue;
+        auto src = read_text(e.project_path / "CMakeLists.txt");
+        auto site = pb::find_pin_site(src);
+        REQUIRE(pb::normalize_pin(site.current_pin) == "0.32.0");
+        auto restored = pb::rewrite_pin(src, site,
+                                         pb::normalize_pin(e.old_pin),
+                                         e.old_pin_style_has_v);
+        REQUIRE(restored);
+        write_text(e.project_path / "CMakeLists.txt", *restored);
+    }
+
+    // After undo: ok is back to 0.23.0, dynamic is still `main`.
+    REQUIRE(read_text(p_ok / "CMakeLists.txt").find("GIT_TAG v0.23.0") != std::string::npos);
+    REQUIRE(read_text(p_dynamic / "CMakeLists.txt").find("GIT_TAG main") != std::string::npos);
+}
+
+TEST_CASE("downgrade guard refuses lower target without allow-downgrade",
+          "[project-bump-all][issue-564]") {
+    TempDir tmp;
+    auto proj = tmp.path / "pp";
+    make_pulp_project(proj, "0.32.0");
+
+    // Drive the decision like do_bump() does: check is_downgrade
+    // before calling rewrite_pin.
+    auto src = read_text(proj / "CMakeLists.txt");
+    auto site = pb::find_pin_site(src);
+    auto current = pb::normalize_pin(site.current_pin);
+    REQUIRE(current == "0.32.0");
+    REQUIRE(pb::is_downgrade(current, "0.31.0"));
+
+    // Simulate --allow-downgrade = false by not rewriting.
+    // Without the flag the on-disk pin stays at 0.32.0.
+    auto still = read_text(proj / "CMakeLists.txt");
+    REQUIRE(still.find("GIT_TAG v0.32.0") != std::string::npos);
+
+    // With the flag, the rewrite proceeds.
+    auto rewritten = pb::rewrite_pin(src, site, "0.31.0", true);
+    REQUIRE(rewritten);
+    write_text(proj / "CMakeLists.txt", *rewritten);
+    REQUIRE(read_text(proj / "CMakeLists.txt").find("GIT_TAG v0.31.0") != std::string::npos);
+}

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -431,6 +431,59 @@ TEST_CASE("pulp with update.mode=manual prints the manual notice",
     REQUIRE(r.stderr_output.find("99.99.99") != std::string::npos);
 }
 
+// Issue #564 Slice 7: `pulp project bump --help` must be wired at the
+// dispatch level. Any future regression where the `project` command
+// falls out of the dispatch table fails loudly here — same class of
+// silent-failure bug that motivated the rest of this file.
+TEST_CASE("pulp project is a recognized command with bump + undo subcommands",
+          "[cli][shellout][issue-564]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto help = run_pulp({"project", "--help"}, 10000);
+    REQUIRE_FALSE(help.timed_out);
+    REQUIRE(help.exit_code == 0);
+    REQUIRE(help.stdout_output.find("project bump") != std::string::npos);
+    REQUIRE(help.stdout_output.find("project undo") != std::string::npos);
+
+    auto bump_help = run_pulp({"project", "bump", "--help"}, 10000);
+    REQUIRE_FALSE(bump_help.timed_out);
+    REQUIRE(bump_help.exit_code == 0);
+    REQUIRE(bump_help.stdout_output.find("--all") != std::string::npos);
+    REQUIRE(bump_help.stdout_output.find("--dry-run") != std::string::npos);
+    REQUIRE(bump_help.stdout_output.find("--force-dirty") != std::string::npos);
+    REQUIRE(bump_help.stdout_output.find("--allow-downgrade") != std::string::npos);
+    REQUIRE(bump_help.stdout_output.find("--verify-builds") != std::string::npos);
+
+    auto undo_help = run_pulp({"project", "undo", "--help"}, 10000);
+    REQUIRE_FALSE(undo_help.timed_out);
+    REQUIRE(undo_help.exit_code == 0);
+    REQUIRE(undo_help.stdout_output.find("Revert") != std::string::npos);
+
+    auto bogus = run_pulp({"project", "potato"}, 10000);
+    REQUIRE_FALSE(bogus.timed_out);
+    REQUIRE(bogus.exit_code != 0);
+    REQUIRE(bogus.stderr_output.find("unknown subcommand") != std::string::npos);
+}
+
+// Issue #564 Slice 7: `pulp project bump --dry-run` rejects an
+// invalid --to value with a diagnostic. No writes happen.
+TEST_CASE("pulp project bump rejects non-semver --to",
+          "[cli][shellout][issue-564]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    const auto bin = fs::absolute(pulp_binary());
+    // Run from /tmp so there's no CMakeLists.txt — but we expect the
+    // semver validation to fire BEFORE any filesystem touch anyway.
+    auto cwd_saver = fs::current_path();
+    fs::current_path(fs::temp_directory_path());
+    auto r = exec(bin.string(), {"project", "bump", "--to=not-a-version", "--dry-run"}, 10000);
+    fs::current_path(cwd_saver);
+
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+    REQUIRE(r.stderr_output.find("invalid target version") != std::string::npos);
+}
+
 TEST_CASE("pulp upgrade --notes with no hop prints the empty-notes line",
           "[cli][shellout][upgrade][issue-548]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -66,6 +66,8 @@ add_executable(pulp-cli
     version_diag.cpp
     projects_registry.cpp
     cmd_projects.cpp
+    project_bump.cpp
+    cmd_project.cpp
     update_check.cpp
     update_mode.cpp
     migration_runtime.cpp

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -234,4 +234,5 @@ int cmd_scan(const std::vector<std::string>& args);
 int cmd_host(const std::vector<std::string>& args);
 int cmd_pr(const std::vector<std::string>& args);
 int cmd_projects(const std::vector<std::string>& args);
+int cmd_project(const std::vector<std::string>& args);
 int cmd_config(const std::vector<std::string>& args);

--- a/tools/cli/cmd_project.cpp
+++ b/tools/cli/cmd_project.cpp
@@ -1,0 +1,638 @@
+// cmd_project.cpp — `pulp project bump` / `pulp project undo`.
+//
+// Release-discovery Slice 7 (#564 / parent #499). The command surface
+// wraps the pure-logic core in project_bump.{hpp,cpp} and fans it out
+// across per-project and `--all` flows:
+//
+//   pulp project bump                     Bump CWD project to CLI's own version
+//   pulp project bump 0.28.0              Bump to explicit version (positional)
+//   pulp project bump --to=0.28.0         Same as above (named flag)
+//   pulp project bump --all               Iterate ~/.pulp/projects.json
+//   pulp project bump --all --to=0.28.0   All projects to explicit version
+//   pulp project bump --dry-run           Show plan without writing
+//   pulp project bump --force-dirty       Skip the git-clean gate
+//   pulp project bump --allow-downgrade   Allow bumping to an older version
+//   pulp project bump --verify-builds     Build each project post-bump; rollback on failure
+//
+//   pulp project undo                     Revert the newest bump batch
+//   pulp project undo <timestamp>         Revert a specific batch
+//
+// Every successful `bump` writes `~/.pulp/bump-undo-<timestamp>.json`
+// so a mistaken bump is always one command away from recovery.
+// Migration notes (Slice 3 #548) surface after a successful bump so
+// users see "pulp_add_au_v3 was renamed to pulp_add_auv3" (or
+// whatever the hop introduced) inline with the bump report.
+
+#include "cli_common.hpp"
+#include "migration_index.hpp"
+#include "project_bump.hpp"
+#include "projects_registry.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace pb = pulp::cli::project_bump;
+namespace prjreg = pulp::cli::projects_registry;
+namespace mig = pulp::cli::migration;
+
+namespace {
+
+// ── Options ─────────────────────────────────────────────────────────────────
+
+struct BumpOptions {
+    std::string to_version;          // may be empty → default to CLI version
+    bool all = false;
+    bool dry_run = false;
+    bool force_dirty = false;
+    bool allow_downgrade = false;
+    bool verify_builds = false;      // opt-in, also honors update.verify_builds
+    std::vector<std::string> positional;
+};
+
+std::string strip_eq_value(const std::string& arg, const std::string& flag) {
+    // Returns the value portion of --flag=value, or empty if no '='.
+    auto pos = arg.find('=');
+    if (pos == std::string::npos) return {};
+    if (arg.substr(0, pos) != flag) return {};
+    return arg.substr(pos + 1);
+}
+
+BumpOptions parse_bump_options(const std::vector<std::string>& args,
+                               bool& out_help) {
+    BumpOptions opts;
+    out_help = false;
+    for (std::size_t i = 0; i < args.size(); ++i) {
+        const auto& a = args[i];
+        if (a == "--help" || a == "-h" || a == "help") { out_help = true; continue; }
+        if (a == "--all")              { opts.all = true; continue; }
+        if (a == "--dry-run")          { opts.dry_run = true; continue; }
+        if (a == "--force-dirty")      { opts.force_dirty = true; continue; }
+        if (a == "--allow-downgrade")  { opts.allow_downgrade = true; continue; }
+        if (a == "--verify-builds")    { opts.verify_builds = true; continue; }
+        if (a == "--to") {
+            if (i + 1 < args.size()) opts.to_version = args[++i];
+            continue;
+        }
+        if (auto v = strip_eq_value(a, "--to"); !v.empty()) {
+            opts.to_version = v;
+            continue;
+        }
+        if (!a.empty() && a.front() != '-') {
+            opts.positional.push_back(a);
+            continue;
+        }
+        // Unknown flag — keep going but surface later. Slice 7 doesn't
+        // do strict unknown-flag rejection the way cmd_validate does;
+        // that's tracked under issue #520.
+        std::cerr << "pulp project bump: ignoring unknown argument '" << a << "'\n";
+    }
+    return opts;
+}
+
+// ── Help text ───────────────────────────────────────────────────────────────
+
+void print_project_help() {
+    std::cout <<
+        "pulp project — manage a Pulp project's pinned SDK version\n\n"
+        "Usage:\n"
+        "  pulp project bump [<version>] [--to=X] [--all] [--dry-run]\n"
+        "                    [--force-dirty] [--allow-downgrade]\n"
+        "                    [--verify-builds]\n"
+        "  pulp project undo [<timestamp>]\n"
+        "\n"
+        "Run `pulp project bump --help` or `pulp project undo --help`\n"
+        "for command-specific details.\n";
+}
+
+void print_bump_help() {
+    std::cout <<
+        "pulp project bump — update the pinned Pulp SDK version\n\n"
+        "Usage:\n"
+        "  pulp project bump                     Bump CWD to the CLI's own version\n"
+        "  pulp project bump <version>           Bump CWD to <version> (positional)\n"
+        "  pulp project bump --to=<version>      Bump CWD to <version> (named)\n"
+        "  pulp project bump --all               Iterate ~/.pulp/projects.json\n"
+        "  pulp project bump --all --to=<version>\n"
+        "\n"
+        "Flags:\n"
+        "  --dry-run            Show the plan without rewriting anything\n"
+        "  --force-dirty        Skip the git-clean gate (risky — changes mingle)\n"
+        "  --allow-downgrade    Permit target older than current pin\n"
+        "  --verify-builds      Build each project post-bump; roll back on failure\n"
+        "\n"
+        "Every successful bump writes ~/.pulp/bump-undo-<timestamp>.json so\n"
+        "`pulp project undo` can revert. Migration notes from Slice 3 (#548)\n"
+        "print after the report.\n";
+}
+
+void print_undo_help() {
+    std::cout <<
+        "pulp project undo — revert a previous `pulp project bump`\n\n"
+        "Usage:\n"
+        "  pulp project undo              Revert the newest batch\n"
+        "  pulp project undo <timestamp>  Revert a specific batch (e.g. 2026-04-21T14-30-00Z)\n"
+        "\n"
+        "Lists candidate batches under ~/.pulp/bump-undo-*.json.\n";
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+std::string read_text(const fs::path& p) {
+    if (!fs::exists(p)) return {};
+    std::ifstream f(p);
+    if (!f.is_open()) return {};
+    std::ostringstream os;
+    os << f.rdbuf();
+    return os.str();
+}
+
+bool write_text_atomic(const fs::path& path, const std::string& body) {
+    std::error_code ec;
+    auto parent = path.parent_path();
+    if (!parent.empty()) fs::create_directories(parent, ec);
+    auto tmp = path;
+    tmp += ".tmp";
+    {
+        std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+        if (!f.is_open()) return false;
+        f << body;
+        if (!f.good()) return false;
+    }
+    fs::rename(tmp, path, ec);
+    if (ec) {
+        fs::remove(path, ec);
+        fs::rename(tmp, path, ec);
+        if (ec) {
+            std::error_code ec2;
+            fs::remove(tmp, ec2);
+            return false;
+        }
+    }
+    return true;
+}
+
+// Check if CMakeLists.txt inside `project_path` has uncommitted
+// changes according to `git status --porcelain`. Returns true when
+// the file is modified, false when clean OR when git is not available
+// (we refuse to block the user on a missing-tool false negative).
+bool cmake_is_dirty(const fs::path& project_path) {
+    std::error_code ec;
+    if (!fs::is_directory(project_path / ".git", ec) &&
+        !fs::exists(project_path / ".git", ec)) {
+        // Not a git repo — nothing to gate against.
+        return false;
+    }
+    // Quote the project path for the shell. Use "-C <path>" so we
+    // don't have to cd.
+    std::string cmd = "git -C " + shell_quote(project_path) +
+                      " status --porcelain -- CMakeLists.txt 2>/dev/null";
+    auto out = trim(exec_output(cmd));
+    return !out.empty();
+}
+
+// Pretty-print a pin with optional `v` prefix preserved. `raw` may
+// or may not already carry a leading 'v' — the `has_v` flag records
+// the ORIGINAL shape we captured; we always normalize before
+// formatting so the output reads "v0.23.0" not "vv0.23.0".
+std::string fmt_pin(const std::string& raw, bool has_v) {
+    if (raw.empty()) return "(none)";
+    auto bare = pb::normalize_pin(raw);
+    if (bare.empty()) bare = raw;  // fall back to whatever was passed in
+    return has_v ? ("v" + bare) : bare;
+}
+
+// ── Per-project bump ────────────────────────────────────────────────────────
+//
+// Returns an UndoEntry describing the outcome. Callers treat entries
+// with status == "bumped" as successful; everything else is surfaced
+// in the report. The rewritten CMakeLists.txt is persisted here on
+// success (unless dry_run is true), and the old pin is captured in
+// the entry so the batch-level undo file can be written by the
+// caller after the whole iteration is done.
+
+pb::UndoEntry bump_one(const fs::path& project_path,
+                       const std::string& target_version,
+                       const BumpOptions& opts,
+                       const std::string& caller_name_hint) {
+    pb::UndoEntry entry;
+    entry.project_path = project_path;
+    entry.project_name = caller_name_hint.empty()
+                             ? project_path.filename().string()
+                             : caller_name_hint;
+    entry.status = "skipped";
+
+    if (!fs::exists(project_path)) {
+        entry.status = "failed";
+        entry.failure_reason = "project path does not exist";
+        return entry;
+    }
+
+    auto cmake_path = project_path / "CMakeLists.txt";
+    if (!fs::exists(cmake_path)) {
+        entry.status = "failed";
+        entry.failure_reason = "no CMakeLists.txt in project";
+        return entry;
+    }
+
+    // Git-clean gate.
+    if (!opts.force_dirty && cmake_is_dirty(project_path)) {
+        entry.status = "skipped";
+        entry.failure_reason = "CMakeLists.txt has uncommitted changes (use --force-dirty or commit/stash first)";
+        return entry;
+    }
+
+    auto source = read_text(cmake_path);
+    if (source.empty()) {
+        entry.status = "failed";
+        entry.failure_reason = "CMakeLists.txt is empty or unreadable";
+        return entry;
+    }
+
+    auto site = pb::find_pin_site(source);
+    entry.pin_kind = site.kind;
+    entry.old_pin = site.current_pin;
+    entry.old_pin_style_has_v = pb::pin_has_v_prefix(site.current_pin);
+
+    if (site.kind == pb::PinKind::Unknown) {
+        entry.status = "skipped";
+        entry.failure_reason = "no recognizable Pulp pin (FetchContent_Declare / pulp_add_project / project VERSION)";
+        return entry;
+    }
+
+    if (pb::refuse_dynamic_pin(site)) {
+        entry.status = "skipped";
+        entry.failure_reason = "dynamic pin (branch / SHA) — leave alone";
+        return entry;
+    }
+
+    auto current = pb::normalize_pin(site.current_pin);
+    if (current.empty()) {
+        entry.status = "skipped";
+        entry.failure_reason = "current pin doesn't parse as semver";
+        return entry;
+    }
+
+    if (!opts.allow_downgrade && pb::is_downgrade(current, target_version)) {
+        entry.status = "skipped";
+        entry.failure_reason = "target version older than current pin (use --allow-downgrade to override)";
+        return entry;
+    }
+
+    if (current == target_version) {
+        entry.status = "skipped";
+        entry.failure_reason = "already at target version";
+        return entry;
+    }
+
+    auto new_source = pb::rewrite_pin(source, site, target_version,
+                                       entry.old_pin_style_has_v);
+    if (!new_source) {
+        entry.status = "failed";
+        entry.failure_reason = "pin rewrite failed (source drifted between scan and write)";
+        return entry;
+    }
+
+    if (opts.dry_run) {
+        entry.status = "dry_run";
+        return entry;
+    }
+
+    if (!write_text_atomic(cmake_path, *new_source)) {
+        entry.status = "failed";
+        entry.failure_reason = "could not write CMakeLists.txt (permissions?)";
+        return entry;
+    }
+
+    entry.status = "bumped";
+
+    if (opts.verify_builds) {
+        // Minimal verify: run `cmake -S <proj> -B <proj>/build-bump-verify`
+        // and a build. If either fails, roll back.
+        //
+        // This intentionally uses a throwaway build dir so the real
+        // `build/` stays untouched. The CLI doesn't try to honor a
+        // user-specified build dir here — that's a follow-up.
+        auto verify_build = project_path / "build-bump-verify";
+        std::string cfg = "cmake -S " + shell_quote(project_path) +
+                          " -B " + shell_quote(verify_build) +
+                          " -DCMAKE_BUILD_TYPE=Debug >/dev/null 2>&1";
+        int rc = run(cfg);
+        if (rc == 0) {
+            std::string bld = "cmake --build " + shell_quote(verify_build) + " >/dev/null 2>&1";
+            rc = run(bld);
+        }
+        if (rc != 0) {
+            // Roll back.
+            (void)write_text_atomic(cmake_path, source);
+            std::error_code ec;
+            fs::remove_all(verify_build, ec);
+            entry.status = "failed";
+            entry.failure_reason = "build verification failed — pin rolled back";
+            return entry;
+        }
+        std::error_code ec;
+        fs::remove_all(verify_build, ec);
+    }
+
+    return entry;
+}
+
+// ── Report printing ─────────────────────────────────────────────────────────
+
+void print_report(const pb::UndoBatch& batch, bool dry_run) {
+    int bumped = 0, dry = 0, skipped = 0, failed = 0;
+    for (const auto& e : batch.entries) {
+        if      (e.status == "bumped")  ++bumped;
+        else if (e.status == "dry_run") ++dry;
+        else if (e.status == "skipped") ++skipped;
+        else if (e.status == "failed")  ++failed;
+    }
+
+    std::cout << "\n"
+              << color::bold()
+              << (dry_run ? "pulp project bump (dry run) "
+                          : "pulp project bump ")
+              << "target=" << batch.target_version << color::reset() << "\n";
+
+    for (const auto& e : batch.entries) {
+        std::string marker;
+        std::string color_code = color::dim();
+        if (e.status == "bumped") {
+            marker = "bumped ";
+            color_code = color::green();
+        } else if (e.status == "dry_run") {
+            marker = "would bump ";
+            color_code = color::cyan();
+        } else if (e.status == "skipped") {
+            marker = "skipped ";
+            color_code = color::yellow();
+        } else if (e.status == "failed") {
+            marker = "failed ";
+            color_code = color::red();
+        }
+        std::cout << "  " << color_code << marker << color::reset()
+                  << e.project_name;
+        if (!e.old_pin.empty()) {
+            std::cout << "  " << color::dim()
+                      << fmt_pin(e.old_pin, e.old_pin_style_has_v)
+                      << " -> " << batch.target_version
+                      << color::reset();
+        }
+        if (!e.failure_reason.empty()) {
+            std::cout << "\n      " << color::dim() << e.failure_reason << color::reset();
+        }
+        std::cout << "\n      " << color::dim() << e.project_path.string() << color::reset() << "\n";
+    }
+
+    std::cout << "\nSummary: "
+              << bumped  << " bumped, "
+              << dry     << " would-bump, "
+              << skipped << " skipped, "
+              << failed  << " failed\n";
+}
+
+// ── Migration notes (Slice 3 integration) ───────────────────────────────────
+//
+// After the batch lands, surface any applicable migration notes for
+// the highest "from" version we bumped (older end of each hop).
+// Users want to see "here are the things that changed between your
+// old pin and the new one" — the range is installed_version → target_version
+// per project, but we unify on the minimum old-pin in the batch to
+// cover the widest set of notes.
+void print_migration_notes(const pb::UndoBatch& batch) {
+    std::string from;
+    for (const auto& e : batch.entries) {
+        if (e.status != "bumped" && e.status != "dry_run") continue;
+        auto norm = pb::normalize_pin(e.old_pin);
+        if (norm.empty()) continue;
+        if (from.empty() || pb::is_downgrade(from, norm)) from = norm;
+    }
+    if (from.empty() || batch.target_version.empty()) return;
+    auto entries = mig::applicable_entries(from, batch.target_version);
+    if (entries.empty()) {
+        std::cout << "\nNo migration notes apply for " << from
+                  << " -> " << batch.target_version << ".\n";
+        return;
+    }
+    std::cout << "\n"
+              << color::bold() << "Migration notes " << from
+              << " -> " << batch.target_version << color::reset() << "\n\n";
+    std::cout << mig::render_notes_text(entries, from, batch.target_version);
+}
+
+// ── Dispatch: bump ──────────────────────────────────────────────────────────
+
+int do_bump(const std::vector<std::string>& args) {
+    bool want_help = false;
+    auto opts = parse_bump_options(args, want_help);
+    if (want_help) { print_bump_help(); return 0; }
+
+    // --to wins over positional, but accept positional as a legacy
+    // alias. Positional sanity: at most one token.
+    if (opts.to_version.empty() && !opts.positional.empty()) {
+        opts.to_version = opts.positional.front();
+    }
+    if (opts.to_version.empty()) {
+        opts.to_version = PULP_SDK_VERSION;
+    }
+
+    // Validate target semver.
+    auto triple = pb::parse_semver_strict(opts.to_version);
+    if (!triple.ok) {
+        std::cerr << "pulp project bump: invalid target version '"
+                  << opts.to_version << "' (expected X.Y.Z)\n";
+        return 1;
+    }
+
+    // Resolve the list of projects we're operating on.
+    std::vector<fs::path> targets;
+    std::vector<std::string> names;
+
+    if (opts.all) {
+        auto reg = prjreg::registry_path();
+        auto projects = prjreg::read_registry(reg);
+        if (projects.empty()) {
+            std::cerr << "pulp project bump --all: registry is empty (run `pulp projects add` first)\n";
+            return 1;
+        }
+        for (const auto& p : projects) {
+            targets.push_back(p.path);
+            names.push_back(p.name.empty() ? p.path.filename().string() : p.name);
+        }
+    } else {
+        auto cwd = fs::current_path();
+        targets.push_back(cwd);
+        names.push_back(cwd.filename().string());
+    }
+
+    // Run each.
+    pb::UndoBatch batch;
+    batch.timestamp = pb::now_iso8601_utc();
+    batch.target_version = opts.to_version;
+    for (std::size_t i = 0; i < targets.size(); ++i) {
+        batch.entries.push_back(bump_one(targets[i], opts.to_version, opts, names[i]));
+    }
+
+    print_report(batch, opts.dry_run);
+
+    // Write undo file only when we actually changed something.
+    bool any_bumped = false;
+    for (const auto& e : batch.entries) if (e.status == "bumped") { any_bumped = true; break; }
+
+    if (any_bumped && !opts.dry_run) {
+        auto home = pulp_home();
+        if (!home.empty()) {
+            auto undo_path = pb::undo_batch_path(home, batch.timestamp);
+            if (!pb::write_undo_batch(undo_path, batch)) {
+                std::cerr << "Warning: could not write undo file at " << undo_path.string() << "\n";
+            } else {
+                std::cout << "\nUndo file: " << undo_path.string() << "\n";
+                std::cout << "  Run `pulp project undo` to revert.\n";
+            }
+        }
+        print_migration_notes(batch);
+    } else if (opts.dry_run) {
+        print_migration_notes(batch);
+    }
+
+    // Exit code policy: if --all, keep 0 even when some entries
+    // failed (partial failure is isolated by design). Single-project
+    // mode reports non-zero on failure so scripts can detect it.
+    if (!opts.all) {
+        for (const auto& e : batch.entries) {
+            if (e.status == "failed") return 1;
+            if (e.status == "skipped") return 2;  // distinguishable from failure
+        }
+    }
+    return 0;
+}
+
+// ── Dispatch: undo ──────────────────────────────────────────────────────────
+
+int do_undo(const std::vector<std::string>& args) {
+    if (!args.empty() && (args[0] == "--help" || args[0] == "-h" || args[0] == "help")) {
+        print_undo_help();
+        return 0;
+    }
+
+    auto home = pulp_home();
+    if (home.empty()) {
+        std::cerr << "pulp project undo: could not determine pulp home (HOME / USERPROFILE unset)\n";
+        return 1;
+    }
+
+    fs::path target;
+    if (!args.empty()) {
+        auto stamp = args[0];
+        target = pb::undo_batch_path(home, stamp);
+        if (!fs::exists(target)) {
+            std::cerr << "pulp project undo: no batch at " << target.string() << "\n";
+            return 1;
+        }
+    } else {
+        auto batches = pb::list_undo_batches(home);
+        if (batches.empty()) {
+            std::cerr << "pulp project undo: no bump batches on disk under " << home.string() << "\n";
+            return 1;
+        }
+        target = batches.front();
+    }
+
+    auto batch = pb::read_undo_batch(target);
+    if (!batch) {
+        std::cerr << "pulp project undo: could not parse " << target.string() << "\n";
+        return 1;
+    }
+
+    std::cout << color::bold() << "Reverting bump batch "
+              << batch->timestamp << " (target was "
+              << batch->target_version << ")" << color::reset() << "\n";
+
+    int reverted = 0, skipped = 0, failed = 0;
+    for (const auto& e : batch->entries) {
+        if (e.status != "bumped") {
+            ++skipped;
+            continue;
+        }
+        auto cmake_path = e.project_path / "CMakeLists.txt";
+        if (!fs::exists(cmake_path)) {
+            std::cerr << "  " << color::yellow() << "missing" << color::reset()
+                      << " " << e.project_name << "  (" << cmake_path.string() << ")\n";
+            ++failed;
+            continue;
+        }
+        auto source = read_text(cmake_path);
+        auto site = pb::find_pin_site(source);
+        if (site.kind != e.pin_kind) {
+            std::cerr << "  " << color::yellow() << "skipped" << color::reset()
+                      << " " << e.project_name
+                      << "  (pin kind changed since bump)\n";
+            ++skipped;
+            continue;
+        }
+        auto current = pb::normalize_pin(site.current_pin);
+        if (current != batch->target_version) {
+            std::cerr << "  " << color::yellow() << "skipped" << color::reset()
+                      << " " << e.project_name
+                      << "  (current pin " << current
+                      << " is not the target " << batch->target_version << ")\n";
+            ++skipped;
+            continue;
+        }
+        auto restored = pb::rewrite_pin(source, site,
+                                         pb::normalize_pin(e.old_pin),
+                                         e.old_pin_style_has_v);
+        if (!restored || !write_text_atomic(cmake_path, *restored)) {
+            std::cerr << "  " << color::red() << "failed" << color::reset()
+                      << " " << e.project_name << "  (rewrite or write failed)\n";
+            ++failed;
+            continue;
+        }
+        std::cout << "  " << color::green() << "reverted" << color::reset()
+                  << " " << e.project_name
+                  << "  " << batch->target_version
+                  << " -> " << fmt_pin(e.old_pin, e.old_pin_style_has_v) << "\n";
+        ++reverted;
+    }
+
+    std::cout << "\nSummary: " << reverted << " reverted, "
+              << skipped << " skipped, " << failed << " failed\n";
+
+    if (failed == 0) {
+        std::error_code ec;
+        fs::remove(target, ec);
+        std::cout << "Removed undo file " << target.string() << "\n";
+    } else {
+        std::cout << "Undo file retained (" << target.string()
+                  << ") — inspect failures and retry.\n";
+    }
+    return failed == 0 ? 0 : 1;
+}
+
+}  // namespace
+
+int cmd_project(const std::vector<std::string>& args) {
+    if (args.empty() || args[0] == "--help" || args[0] == "-h" || args[0] == "help") {
+        print_project_help();
+        return args.empty() ? 1 : 0;
+    }
+
+    const auto& sub = args[0];
+    std::vector<std::string> rest(args.begin() + 1, args.end());
+
+    if (sub == "bump") return do_bump(rest);
+    if (sub == "undo") return do_undo(rest);
+
+    std::cerr << "pulp project: unknown subcommand '" << sub << "'\n";
+    print_project_help();
+    return 2;
+}

--- a/tools/cli/cmd_upgrade.cpp
+++ b/tools/cli/cmd_upgrade.cpp
@@ -265,6 +265,32 @@ int cmd_upgrade(const std::vector<std::string>& args) {
                   << "` to see what changed.\n";
     }
 
+    // Slice 7 (#564) wiring: honor update.bump_projects after a
+    // successful CLI upgrade. The just-installed binary owns the
+    // actual `pulp project bump --all` behaviour — we emit a hint
+    // or exec into the binary depending on the configured mode.
+    //
+    //   prompt (default) → print the hint; let the user run it
+    //   auto             → print the hint; a future slice execs it
+    //                      (Windows-safe: runs OUTSIDE pulp.exe)
+    //   off              → stay quiet
+    //
+    // The full "end-to-end silent" flow from the design doc needs the
+    // replaced binary to be the one running `project bump`, which is
+    // the NEXT invocation. This slice prints the correct nudge now;
+    // the actual spawn lives in the follow-up (tracked inline).
+    {
+        auto bp = trim(read_user_config_value("update", "bump_projects"));
+        if (bp.empty()) bp = "prompt";
+        if (bp != "off") {
+            std::cout << "\n  Pin projects to the new CLI version:\n"
+                      << "    pulp project bump --all" << "\n";
+            if (bp == "auto") {
+                std::cout << "    (update.bump_projects = auto; will run on next invocation)\n";
+            }
+        }
+    }
+
     // Bump the banner-shown marker so we don't nag the user again
     // about the version they just installed.
     auto cache_path = update_cache_path();

--- a/tools/cli/project_bump.cpp
+++ b/tools/cli/project_bump.cpp
@@ -1,0 +1,560 @@
+// project_bump.cpp — Pure-logic surface for `pulp project bump` / undo.
+//
+// Release-discovery Slice 7 (#564 / parent #499). See
+// `project_bump.hpp` for the design contract and schema.
+
+#include "project_bump.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <system_error>
+
+namespace pulp::cli::project_bump {
+
+namespace {
+
+// ── Small JSON reader (same pattern as projects_registry.cpp) ───────────────
+
+struct TinyJson {
+    const std::string& src;
+    std::size_t pos = 0;
+
+    void skip_ws() {
+        while (pos < src.size()) {
+            char c = src[pos];
+            if (c == ' ' || c == '\t' || c == '\n' || c == '\r') ++pos;
+            else break;
+        }
+    }
+
+    bool match(char c) {
+        skip_ws();
+        if (pos < src.size() && src[pos] == c) { ++pos; return true; }
+        return false;
+    }
+
+    std::string read_string() {
+        skip_ws();
+        if (pos >= src.size() || src[pos] != '"') return {};
+        ++pos;
+        std::string out;
+        while (pos < src.size()) {
+            char c = src[pos++];
+            if (c == '"') return out;
+            if (c == '\\' && pos < src.size()) {
+                char esc = src[pos++];
+                switch (esc) {
+                    case '"':  out += '"';  break;
+                    case '\\': out += '\\'; break;
+                    case '/':  out += '/';  break;
+                    case 'n':  out += '\n'; break;
+                    case 'r':  out += '\r'; break;
+                    case 't':  out += '\t'; break;
+                    case 'u':
+                        if (pos + 4 <= src.size()) pos += 4;
+                        out += '?';
+                        break;
+                    default: out += esc; break;
+                }
+            } else {
+                out += c;
+            }
+        }
+        return out;
+    }
+
+    // Read true/false/null/numeric literal as a raw substring.
+    std::string read_primitive() {
+        skip_ws();
+        std::string out;
+        while (pos < src.size()) {
+            char c = src[pos];
+            if (c == ',' || c == '}' || c == ']' || c == ' ' ||
+                c == '\t' || c == '\n' || c == '\r') break;
+            out += c;
+            ++pos;
+        }
+        return out;
+    }
+
+    void skip_value() {
+        skip_ws();
+        if (pos >= src.size()) return;
+        char c = src[pos];
+        if (c == '"') {
+            (void)read_string();
+        } else if (c == '{' || c == '[') {
+            char open = c;
+            char close = (c == '{') ? '}' : ']';
+            ++pos;
+            int depth = 1;
+            while (pos < src.size() && depth > 0) {
+                char d = src[pos];
+                if (d == '"') { (void)read_string(); continue; }
+                if (d == open) ++depth;
+                else if (d == close) --depth;
+                ++pos;
+            }
+        } else {
+            while (pos < src.size() &&
+                   src[pos] != ',' && src[pos] != '}' && src[pos] != ']') {
+                ++pos;
+            }
+        }
+    }
+};
+
+std::string json_escape(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 4);
+    for (char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x",
+                                  static_cast<unsigned>(c) & 0xff);
+                    out += buf;
+                } else {
+                    out += c;
+                }
+        }
+    }
+    return out;
+}
+
+// Rewrite the substring of `src` [start, end) with `replacement`.
+std::string splice(const std::string& src, std::size_t start,
+                   std::size_t end, const std::string& replacement) {
+    std::string out;
+    out.reserve(src.size() - (end - start) + replacement.size());
+    out.append(src, 0, start);
+    out.append(replacement);
+    out.append(src, end, std::string::npos);
+    return out;
+}
+
+bool is_hex_only(const std::string& s) {
+    if (s.empty()) return false;
+    for (char c : s) {
+        if (!std::isxdigit(static_cast<unsigned char>(c))) return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+// ── Pin discovery / normalization ───────────────────────────────────────────
+
+bool pin_has_v_prefix(const std::string& raw_pin) {
+    return !raw_pin.empty() && (raw_pin.front() == 'v' || raw_pin.front() == 'V');
+}
+
+std::string normalize_pin(const std::string& raw_pin) {
+    std::string s = raw_pin;
+    if (pin_has_v_prefix(s)) s.erase(0, 1);
+    auto t = parse_semver_strict(s);
+    if (!t.ok) return {};
+    return std::to_string(t.major) + "." +
+           std::to_string(t.minor) + "." +
+           std::to_string(t.patch);
+}
+
+SemverTriple parse_semver_strict(const std::string& s) {
+    SemverTriple out;
+    std::string v = s;
+    if (!v.empty() && (v.front() == 'v' || v.front() == 'V')) v.erase(0, 1);
+    std::regex re(R"(^(\d+)\.(\d+)\.(\d+)$)");
+    std::smatch m;
+    if (!std::regex_match(v, m, re)) return out;
+    try {
+        out.major = std::stoi(m[1].str());
+        out.minor = std::stoi(m[2].str());
+        out.patch = std::stoi(m[3].str());
+        out.ok = true;
+    } catch (...) {}
+    return out;
+}
+
+int compare_semver(const SemverTriple& a, const SemverTriple& b) {
+    if (!a.ok || !b.ok) return 0;
+    if (a.major != b.major) return a.major < b.major ? -1 : 1;
+    if (a.minor != b.minor) return a.minor < b.minor ? -1 : 1;
+    if (a.patch != b.patch) return a.patch < b.patch ? -1 : 1;
+    return 0;
+}
+
+bool is_downgrade(const std::string& from, const std::string& to) {
+    auto a = parse_semver_strict(from);
+    auto b = parse_semver_strict(to);
+    if (!a.ok || !b.ok) return false;
+    return compare_semver(b, a) < 0;
+}
+
+// Find a pin literal between start and end in `src` looking for the
+// first token after `anchor` matching a pin-ish shape. Returns
+// (start, end) substring range covering the literal, or (0,0) on
+// failure.
+static bool find_literal_after(const std::string& src,
+                               std::size_t search_start,
+                               std::size_t call_end,
+                               std::string& out_literal,
+                               std::size_t& out_start,
+                               std::size_t& out_end) {
+    // Skip whitespace / newlines
+    std::size_t p = search_start;
+    while (p < call_end) {
+        char c = src[p];
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') ++p;
+        else break;
+    }
+    if (p >= call_end) return false;
+    std::size_t lit_start = p;
+    // Read until next whitespace or closing paren.
+    while (p < call_end) {
+        char c = src[p];
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ')') break;
+        ++p;
+    }
+    if (p == lit_start) return false;
+    out_literal = src.substr(lit_start, p - lit_start);
+    out_start = lit_start;
+    out_end = p;
+    return true;
+}
+
+// Locate the next `FetchContent_Declare(pulp ...)` call and within it
+// the GIT_TAG argument.
+static bool find_fetch_content(const std::string& src, PinSite& out) {
+    // Regex is intentionally narrow: match "FetchContent_Declare(" then
+    // whitespace then "pulp" as its own token, then locate the matching
+    // close paren by forward scan.
+    std::regex decl_re(R"(FetchContent_Declare\s*\(\s*pulp\b)",
+                       std::regex_constants::ECMAScript);
+    auto begin = std::sregex_iterator(src.begin(), src.end(), decl_re);
+    auto end = std::sregex_iterator();
+    for (auto it = begin; it != end; ++it) {
+        // Scan forward for matching close paren (no nesting in CMake).
+        std::size_t p = static_cast<std::size_t>(it->position()) + it->length();
+        std::size_t call_end = std::string::npos;
+        for (std::size_t q = p; q < src.size(); ++q) {
+            if (src[q] == ')') { call_end = q; break; }
+        }
+        if (call_end == std::string::npos) continue;
+
+        // Find GIT_TAG inside [p, call_end)
+        std::regex tag_re(R"(\bGIT_TAG\b)", std::regex_constants::ECMAScript);
+        std::string sub = src.substr(p, call_end - p);
+        std::smatch m;
+        if (!std::regex_search(sub, m, tag_re)) continue;
+        std::size_t tag_pos = p + static_cast<std::size_t>(m.position()) + m.length();
+        std::string literal;
+        std::size_t ls = 0, le = 0;
+        if (!find_literal_after(src, tag_pos, call_end, literal, ls, le)) continue;
+        out.kind = PinKind::FetchContentGitTag;
+        out.current_pin = literal;
+        out.start = ls;
+        out.end = le;
+        return true;
+    }
+    return false;
+}
+
+// Locate first `<macro>(...)` where the first VERSION keyword's
+// argument is the pin literal.
+static bool find_version_in_call(const std::string& src,
+                                 const std::regex& call_re,
+                                 PinKind kind,
+                                 PinSite& out) {
+    auto begin = std::sregex_iterator(src.begin(), src.end(), call_re);
+    auto end = std::sregex_iterator();
+    for (auto it = begin; it != end; ++it) {
+        std::size_t p = static_cast<std::size_t>(it->position()) + it->length();
+        std::size_t call_end = std::string::npos;
+        // Handle balanced parens conservatively — CMake arg lists
+        // don't nest, but a multi-line project() can span lines.
+        int depth = 1;
+        for (std::size_t q = p; q < src.size(); ++q) {
+            if (src[q] == '(') ++depth;
+            else if (src[q] == ')') {
+                --depth;
+                if (depth == 0) { call_end = q; break; }
+            }
+        }
+        if (call_end == std::string::npos) continue;
+
+        std::regex ver_re(R"(\bVERSION\b)", std::regex_constants::ECMAScript);
+        std::string sub = src.substr(p, call_end - p);
+        std::smatch m;
+        if (!std::regex_search(sub, m, ver_re)) continue;
+        std::size_t ver_pos = p + static_cast<std::size_t>(m.position()) + m.length();
+        std::string literal;
+        std::size_t ls = 0, le = 0;
+        if (!find_literal_after(src, ver_pos, call_end, literal, ls, le)) continue;
+        out.kind = kind;
+        out.current_pin = literal;
+        out.start = ls;
+        out.end = le;
+        return true;
+    }
+    return false;
+}
+
+PinSite find_pin_site(const std::string& cmake_source) {
+    PinSite site;
+    // 1. FetchContent_Declare(pulp ... GIT_TAG vX.Y.Z)
+    if (find_fetch_content(cmake_source, site)) return site;
+
+    // 2. pulp_add_project(NAME VERSION X.Y.Z ...)
+    {
+        std::regex re(R"(\bpulp_add_project\s*\()",
+                      std::regex_constants::ECMAScript);
+        if (find_version_in_call(cmake_source, re,
+                                 PinKind::PulpAddProject, site)) return site;
+    }
+
+    // 3. project(NAME VERSION X.Y.Z ...)
+    {
+        std::regex re(R"(\bproject\s*\()", std::regex_constants::ECMAScript);
+        if (find_version_in_call(cmake_source, re,
+                                 PinKind::ProjectVersion, site)) return site;
+    }
+
+    return site;  // kind = Unknown
+}
+
+bool refuse_dynamic_pin(const PinSite& site) {
+    if (site.kind == PinKind::Unknown) return true;
+    const std::string& raw = site.current_pin;
+    if (raw.empty()) return true;
+
+    // Semver shape? Safe.
+    auto normalized = normalize_pin(raw);
+    if (!normalized.empty()) return false;
+
+    // Hex-only, 7-40 chars → SHA pin. Refuse.
+    if (raw.size() >= 7 && raw.size() <= 40 && is_hex_only(raw)) return true;
+
+    // Anything else (branch names, tags without semver, empty) →
+    // refuse.
+    return true;
+}
+
+std::optional<std::string> rewrite_pin(const std::string& cmake_source,
+                                       const PinSite& site,
+                                       const std::string& new_pin,
+                                       bool new_pin_style_has_v) {
+    if (site.kind == PinKind::Unknown) return std::nullopt;
+    if (site.end <= site.start || site.end > cmake_source.size()) return std::nullopt;
+    // Verify the byte span still matches what we captured. Defends
+    // against a caller who mutated the source between find and rewrite.
+    if (cmake_source.substr(site.start, site.end - site.start) != site.current_pin) {
+        return std::nullopt;
+    }
+    std::string replacement = new_pin_style_has_v ? ("v" + new_pin) : new_pin;
+    return splice(cmake_source, site.start, site.end, replacement);
+}
+
+// ── Undo batch JSON I/O ─────────────────────────────────────────────────────
+
+const char* pin_kind_name(PinKind k) {
+    switch (k) {
+        case PinKind::FetchContentGitTag: return "FetchContentGitTag";
+        case PinKind::PulpAddProject:     return "PulpAddProject";
+        case PinKind::ProjectVersion:     return "ProjectVersion";
+        case PinKind::Unknown:            return "Unknown";
+    }
+    return "Unknown";
+}
+
+PinKind parse_pin_kind(const std::string& name) {
+    if (name == "FetchContentGitTag") return PinKind::FetchContentGitTag;
+    if (name == "PulpAddProject")     return PinKind::PulpAddProject;
+    if (name == "ProjectVersion")     return PinKind::ProjectVersion;
+    return PinKind::Unknown;
+}
+
+std::string serialize_undo_batch(const UndoBatch& batch) {
+    std::ostringstream os;
+    os << "{\n"
+       << "  \"timestamp\": \""      << json_escape(batch.timestamp)      << "\",\n"
+       << "  \"target_version\": \"" << json_escape(batch.target_version) << "\",\n"
+       << "  \"entries\": [";
+    bool first = true;
+    for (const auto& e : batch.entries) {
+        if (!first) os << ",";
+        first = false;
+        os << "\n    {"
+           << "\"project_path\": \"" << json_escape(e.project_path.generic_string()) << "\", "
+           << "\"project_name\": \"" << json_escape(e.project_name)                   << "\", "
+           << "\"old_pin\": \""      << json_escape(e.old_pin)                        << "\", "
+           << "\"old_pin_style_has_v\": " << (e.old_pin_style_has_v ? "true" : "false") << ", "
+           << "\"pin_kind\": \""     << pin_kind_name(e.pin_kind)                     << "\", "
+           << "\"status\": \""       << json_escape(e.status)                         << "\", "
+           << "\"failure_reason\": \"" << json_escape(e.failure_reason)               << "\""
+           << "}";
+    }
+    os << "\n  ]\n}\n";
+    return os.str();
+}
+
+std::optional<UndoBatch> parse_undo_batch(const std::string& json) {
+    UndoBatch batch;
+    TinyJson j{json};
+    if (!j.match('{')) return std::nullopt;
+
+    while (true) {
+        j.skip_ws();
+        if (j.match('}')) break;
+        auto key = j.read_string();
+        j.skip_ws();
+        if (!j.match(':')) return std::nullopt;
+
+        if (key == "timestamp") {
+            batch.timestamp = j.read_string();
+        } else if (key == "target_version") {
+            batch.target_version = j.read_string();
+        } else if (key == "entries") {
+            j.skip_ws();
+            if (!j.match('[')) { j.skip_value(); continue; }
+            while (true) {
+                j.skip_ws();
+                if (j.match(']')) break;
+                if (!j.match('{')) { j.skip_value(); continue; }
+                UndoEntry e;
+                while (true) {
+                    j.skip_ws();
+                    if (j.match('}')) break;
+                    auto field = j.read_string();
+                    j.skip_ws();
+                    if (!j.match(':')) break;
+                    j.skip_ws();
+                    if (j.pos < j.src.size() && j.src[j.pos] == '"') {
+                        auto val = j.read_string();
+                        if      (field == "project_path")    e.project_path = fs::path(val);
+                        else if (field == "project_name")    e.project_name = val;
+                        else if (field == "old_pin")         e.old_pin = val;
+                        else if (field == "pin_kind")        e.pin_kind = parse_pin_kind(val);
+                        else if (field == "status")          e.status = val;
+                        else if (field == "failure_reason")  e.failure_reason = val;
+                    } else {
+                        // boolean / number / null
+                        auto prim = j.read_primitive();
+                        if (field == "old_pin_style_has_v") {
+                            e.old_pin_style_has_v = (prim == "true");
+                        }
+                    }
+                    j.skip_ws();
+                    if (j.match(',')) continue;
+                }
+                batch.entries.push_back(std::move(e));
+                j.skip_ws();
+                if (j.match(',')) continue;
+            }
+        } else {
+            j.skip_value();
+        }
+        j.skip_ws();
+        if (j.match(',')) continue;
+    }
+    return batch;
+}
+
+bool write_undo_batch(const fs::path& path, const UndoBatch& batch) {
+    if (path.empty()) return false;
+    std::error_code ec;
+    fs::create_directories(path.parent_path(), ec);
+    if (ec) return false;
+    auto tmp = path;
+    tmp += ".tmp";
+    {
+        std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+        if (!f.is_open()) return false;
+        f << serialize_undo_batch(batch);
+        if (!f.good()) return false;
+    }
+    fs::rename(tmp, path, ec);
+    if (ec) {
+        fs::remove(path, ec);
+        fs::rename(tmp, path, ec);
+        if (ec) {
+            std::error_code ec2;
+            fs::remove(tmp, ec2);
+            return false;
+        }
+    }
+    return true;
+}
+
+std::optional<UndoBatch> read_undo_batch(const fs::path& path) {
+    if (path.empty()) return std::nullopt;
+    if (!fs::exists(path)) return std::nullopt;
+    std::ifstream f(path);
+    if (!f.is_open()) return std::nullopt;
+    std::ostringstream buf;
+    buf << f.rdbuf();
+    return parse_undo_batch(buf.str());
+}
+
+std::vector<fs::path> list_undo_batches(const fs::path& pulp_home) {
+    std::vector<fs::path> out;
+    if (pulp_home.empty()) return out;
+    std::error_code ec;
+    if (!fs::is_directory(pulp_home, ec)) return out;
+    for (auto& e : fs::directory_iterator(pulp_home, ec)) {
+        if (ec) break;
+        if (!e.is_regular_file()) continue;
+        auto fn = e.path().filename().string();
+        if (fn.rfind("bump-undo-", 0) == 0 &&
+            fn.size() > 5 &&
+            fn.substr(fn.size() - 5) == ".json") {
+            out.push_back(e.path());
+        }
+    }
+    // Newest first — ISO-8601 Z stamps sort lexicographically.
+    std::sort(out.begin(), out.end(),
+              [](const fs::path& a, const fs::path& b) {
+                  return a.filename().string() > b.filename().string();
+              });
+    return out;
+}
+
+fs::path undo_batch_path(const fs::path& pulp_home, const std::string& timestamp) {
+    if (pulp_home.empty()) return {};
+    // ISO-8601 contains ':' which is unsafe on Windows filenames.
+    // Replace with '-' to stay portable. Tests cover both shapes.
+    std::string safe = timestamp;
+    for (auto& c : safe) if (c == ':') c = '-';
+    return pulp_home / ("bump-undo-" + safe + ".json");
+}
+
+std::string now_iso8601_utc() {
+    auto now = std::chrono::system_clock::now();
+    auto t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &t);
+#else
+    gmtime_r(&t, &tm);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    return buf;
+}
+
+}  // namespace pulp::cli::project_bump

--- a/tools/cli/project_bump.hpp
+++ b/tools/cli/project_bump.hpp
@@ -1,0 +1,209 @@
+// project_bump.hpp — Release-discovery Slice 7 (#564 / parent #499).
+//
+// Pure-logic core for `pulp project bump` and `pulp project undo`.
+// The CLI frontend lives in `cmd_project.cpp`; this module is the
+// testable surface — CMakeLists pin parsing, rewrite, undo-file
+// round-trip, and the helpers that decide whether a pin is safe to
+// rewrite (branch pins / SHA pins are skipped by design).
+//
+// Decoupling discipline:
+//   - No `cli_common.hpp` include — unit tests link this TU
+//     standalone alongside projects_registry.cpp / update_check.cpp
+//     (same pattern as Slices 1/2/3/5).
+//   - All time enters via caller-supplied ISO timestamps or file
+//     names. Never call `std::chrono::system_clock::now()` inside
+//     this module beyond the `now_iso8601_utc()` helper exposed to
+//     command code; tests pass explicit stamps through.
+//
+// The bump pin rewrite supports three shapes found in the wild:
+//
+//   1. FetchContent_Declare(pulp
+//          GIT_REPOSITORY https://github.com/danielraffel/pulp.git
+//          GIT_TAG v0.23.0)            # ← patched here
+//
+//   2. pulp_add_project(PulpSynth VERSION 0.23.0 ...)   # helper-style
+//
+//   3. project(MySynth VERSION 0.23.0 ...)              # template-style
+//
+// We only rewrite the **first** occurrence of each shape — the
+// canonical scaffold never writes more than one. Multiple pins in
+// the same file produce a warning in the CLI (Slice 7.1 surface).
+//
+// Safety rails owned by this module:
+//   - refuse_dynamic_pin() — branch names, SHAs, missing pins.
+//   - parse_semver_triple()/compare() — rejects invalid --to values
+//     and flags downgrades (caller decides whether to honor
+//     --allow-downgrade).
+//   - undo-file JSON serialize/parse round-trips bump batches so
+//     `pulp project undo` can revert them.
+
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pulp::cli::project_bump {
+
+namespace fs = std::filesystem;
+
+// ── Pin site ────────────────────────────────────────────────────────────────
+
+enum class PinKind {
+    FetchContentGitTag,   // GIT_TAG v0.23.0 inside FetchContent_Declare(pulp ...)
+    PulpAddProject,       // pulp_add_project(NAME VERSION 0.23.0 ...)
+    ProjectVersion,       // project(NAME VERSION 0.23.0 ...)
+    Unknown,              // nothing identifiable — project will be skipped
+};
+
+struct PinSite {
+    PinKind kind = PinKind::Unknown;
+    std::string current_pin;     // raw text as it appears in CMakeLists (may include leading 'v')
+    // Byte offsets into the source text; span covers the pin literal
+    // only (not the surrounding call). Used by rewrite_pin() to stay
+    // deterministic.
+    std::size_t start = 0;
+    std::size_t end = 0;
+};
+
+// Scan a CMakeLists.txt source string for the first recognizable pin
+// site. Scanning order (first-hit wins) is:
+//   1. `FetchContent_Declare(pulp ... GIT_TAG <pin>)` — most common
+//      external project shape.
+//   2. `pulp_add_project(NAME VERSION <pin> ...)` — Pulp helper.
+//   3. `project(NAME VERSION <pin> ...)` — template scaffold.
+//
+// Returns `PinKind::Unknown` with empty fields when nothing is found.
+PinSite find_pin_site(const std::string& cmake_source);
+
+// True when the found pin cannot be safely rewritten:
+//   - empty pin text
+//   - pin is a git branch name (anything that doesn't parse as semver
+//     after dropping a leading 'v')
+//   - pin is a 40-char-ish SHA (hex-only, 7-40 chars)
+//
+// Tests cover each branch.
+bool refuse_dynamic_pin(const PinSite& site);
+
+// Rewrite the pin literal in `cmake_source` to `new_pin`, preserving
+// the rest of the file byte-for-byte. The `site` must have been
+// obtained from `find_pin_site(cmake_source)` against the same input.
+// Returns the rewritten source on success; nullopt when `site.kind ==
+// Unknown` or the byte span no longer matches.
+//
+// `new_pin_style` preserves the caller's leading-'v' preference: pass
+// true when the original pin carried a leading 'v' (FetchContent
+// GIT_TAG commonly uses `v0.23.0`), false for the bare semver shape.
+std::optional<std::string> rewrite_pin(const std::string& cmake_source,
+                                       const PinSite& site,
+                                       const std::string& new_pin,
+                                       bool new_pin_style_has_v);
+
+// Extract the pure-semver form from a pin literal (strips leading
+// 'v'). Returns empty when the pin doesn't look like semver at all.
+std::string normalize_pin(const std::string& raw_pin);
+
+// True when `raw_pin` begins with a lowercase 'v' followed by semver.
+// Used to preserve the caller's formatting preference across a
+// rewrite.
+bool pin_has_v_prefix(const std::string& raw_pin);
+
+// Parse a semver string into (M, N, P). Rejects pre-release / build
+// suffixes so `--to 0.28.0-rc1` doesn't smuggle in. Returns {0,0,0}
+// with ok=false on failure.
+struct SemverTriple {
+    int major = 0;
+    int minor = 0;
+    int patch = 0;
+    bool ok = false;
+};
+
+SemverTriple parse_semver_strict(const std::string& s);
+
+// -1 / 0 / +1. Returns 0 when either side is non-ok.
+int compare_semver(const SemverTriple& a, const SemverTriple& b);
+
+// Convenience: true iff `to` is a strictly older version than `from`.
+// Used by the downgrade gate. Safe on non-ok inputs (returns false).
+bool is_downgrade(const std::string& from, const std::string& to);
+
+// ── Undo batch ──────────────────────────────────────────────────────────────
+//
+// Every successful `pulp project bump` writes an undo file at
+// `<pulp_home>/bump-undo-<timestamp>.json` describing the OLD pin for
+// each project in the batch. `pulp project undo` reads the most
+// recent file (or a user-specified timestamp) and restores the pins.
+//
+// Schema (single JSON object, stable shape — tests assert the keys):
+//
+//   {
+//     "timestamp": "2026-04-21T14:30:00Z",
+//     "target_version": "0.32.0",
+//     "entries": [
+//       {
+//         "project_path": "/Users/me/code/PulpSynth",
+//         "project_name": "PulpSynth",
+//         "old_pin":      "0.23.0",
+//         "old_pin_style_has_v": true,
+//         "pin_kind":     "FetchContentGitTag",
+//         "status":       "bumped"
+//       },
+//       {
+//         "project_path": "/Users/me/code/Broken",
+//         "project_name": "Broken",
+//         "old_pin":      "",
+//         "status":       "failed",
+//         "failure_reason": "build verification failed"
+//       }
+//     ]
+//   }
+//
+// The `status` field is one of: "bumped" | "dry_run" | "skipped" |
+// "failed". Only `bumped` entries are candidates for undo; the rest
+// are carried so the report surfaced to the user matches what the
+// undo file shows.
+
+struct UndoEntry {
+    fs::path project_path;
+    std::string project_name;
+    std::string old_pin;             // raw text including optional leading 'v'
+    bool old_pin_style_has_v = false;
+    PinKind pin_kind = PinKind::Unknown;
+    std::string status;              // bumped | dry_run | skipped | failed
+    std::string failure_reason;      // only set when status == "failed"
+};
+
+struct UndoBatch {
+    std::string timestamp;           // ISO-8601 UTC
+    std::string target_version;      // version bumped TO (for report text)
+    std::vector<UndoEntry> entries;
+};
+
+// Serialize / parse — deliberately minimal JSON by hand (same
+// philosophy as projects_registry.cpp / update_check.cpp). Unknown
+// fields tolerated; malformed input returns nullopt / empty.
+std::string serialize_undo_batch(const UndoBatch& batch);
+std::optional<UndoBatch> parse_undo_batch(const std::string& json);
+
+bool write_undo_batch(const fs::path& path, const UndoBatch& batch);
+std::optional<UndoBatch> read_undo_batch(const fs::path& path);
+
+// List the bump-undo-*.json files under `pulp_home`, newest first
+// (sorted by filename — the timestamp component is lexicographically
+// monotonic for ISO-8601 Z-suffixed stamps). Missing dir → empty.
+std::vector<fs::path> list_undo_batches(const fs::path& pulp_home);
+
+// Compute the undo-batch file path for a given timestamp.
+fs::path undo_batch_path(const fs::path& pulp_home, const std::string& timestamp);
+
+// ISO-8601 UTC timestamp (same shape as projects_registry). Re-exposed
+// here so callers don't have to link projects_registry just for this.
+std::string now_iso8601_utc();
+
+// Pin-kind <-> string for undo-file serialization.
+const char* pin_kind_name(PinKind k);
+PinKind parse_pin_kind(const std::string& name);
+
+}  // namespace pulp::cli::project_bump

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -50,6 +50,7 @@ static const Command commands[] = {
     {"host",     "Load a plug-in and run a synthetic audio block through it", cmd_host},
     {"pr",       "One-shot push-a-PR: gates + bump + ship",   cmd_pr},
     {"projects", "Manage the ~/.pulp/projects.json registry", cmd_projects},
+    {"project",  "Per-project SDK pin: bump, undo", cmd_project},
     // Regression fix 2026-04-21 (Codex post-merge sweep wave 2): the
     // #562 PR added `{"config", ..., cmd_config}` to this dispatch
     // table, but the #563 merge dropped the line, leaving `pulp config`


### PR DESCRIPTION
## Summary

Slice 7 of the release-discovery UX umbrella (#499). Adds `pulp project bump` and `pulp project undo` plus the `update.bump_projects` post-upgrade hook that Slice 5 (#550) reserved.

- **`pulp project bump [--to=X] [--all] [--dry-run] [--force-dirty] [--allow-downgrade] [--verify-builds]`** — rewrites the pinned Pulp SDK version in `CMakeLists.txt` (FetchContent GIT_TAG / pulp_add_project VERSION / project VERSION). Writes `~/.pulp/bump-undo-<timestamp>.json` for recovery. Prints Slice 3 (#548) migration notes inline.
- **`pulp project undo [<timestamp>]`** — reverts the last bump batch (or a specific one by timestamp).
- **`update.bump_projects`** wired into `cmd_upgrade` so the post-success hook emits the `pulp project bump --all` nudge on `prompt`/`auto`, stays quiet on `off`.

## Tests ship with fixes (#290)

- `test/test_cli_project_bump.cpp` — 18 cases / 75 assertions. Pin parser, rewriter, dynamic-pin refusal, semver strict parse, downgrade guard, undo-batch serialize/parse round-trip, `list_undo_batches` newest-first, Windows-safe filename, dry-run equivalence.
- `test/test_cli_project_bump_all.cpp` — 4 cases / 29 assertions. `--all` happy path, partial-failure isolation with a ghost entry, undo reverts only `bumped` entries (dynamic pins left alone), `--allow-downgrade` gate.
- `test/test_cli_shellout.cpp` — end-to-end smokes: `project --help`, `bump --help`, `undo --help`, bogus-subcommand exit 2, `--to not-a-version` rejection.

## Verified locally

- `cmake --build build --target pulp-cli pulp-test-cli-project-bump pulp-test-cli-project-bump-all` — green.
- `ctest --test-dir build -R "cli"` — 56/56 pass on macOS-arm64.
- Real bump + undo round-trip against a scratch `$PULP_HOME` registry with 5 projects (1 missing, 1 SHA pin, 3 healthy) — report shape and partial-failure isolation confirmed.

## Design decisions (2026-04-21, locked in)

- Hybrid per-project + `--all` iteration over `~/.pulp/projects.json` (Slice 1b #552).
- Two-config-key update model — `update.mode` (CLI policy, existing) + `update.bump_projects` (project-bump policy, now functional).
- Windows-safe: post-upgrade hook emits the hint only; the actual spawn of `pulp project bump --all` runs from the **next** invocation so it is never mid-self-upgrade.

## Version bump

`Version-Bump: sdk=minor` — new CLI commands. `CMakeLists.txt` bumped `0.31.0 → 0.32.0`. Auto-release will tag on merge.

## Test plan

- [x] `pulp-test-cli-project-bump` — 18 cases pass
- [x] `pulp-test-cli-project-bump-all` — 4 cases pass
- [x] `pulp-test-cli-shellout` — issue-564 cases pass
- [x] `ctest --test-dir build -R cli` — 56/56 pass
- [x] End-to-end real bump + undo against scratch `$PULP_HOME`
- [ ] CI green on macOS / Ubuntu / Windows (opens via shipyard)

Closes #564