### PR TITLE
ci(iwyu): advisory include-what-you-use gate (#594 Phase 2)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -566,6 +566,19 @@ Gotchas:
 - **The comment renderer is unit-tested.** When touching `tools/scripts/coverage_diff_comment.py`, run `python3 tools/scripts/test_coverage_diff_comment.py` locally — the workflow also runs it as a pre-flight fixture check so a regression fails fast.
 - **Adding a new core subsystem** means adding a flag in `codecov.yml`, listing it in the `flags:` csv in the `coverage` job's Codecov upload step, and documenting it in `docs/guides/coverage.md` — three-way change kept in sync manually until Phase 4's doc-sync gate lands.
 
+## IWYU advisory gate (`#594` Phase 2)
+
+`.github/workflows/iwyu.yml` runs include-what-you-use on the Linux Clang lane to catch transitive-include bugs before they reach the cross-platform matrix. Three incidents on 2026-04-21 (#540 `<memory>`, Slice 4 `<atomic>`, #593 `<algorithm>`) triggered this gate.
+
+- **Advisory until 2026-05-05** — `continue-on-error: true`. PR annotations appear inline on the diff; merges are not blocked.
+- **Linux Clang only** — macOS libc++ hides the bug class (false negatives); MSVC is not Clang. Don't attempt to extend it to those runners.
+- **Scope** — PR events analyze only files changed vs `origin/<base>`; push-to-main events run a full repo scan and upload the raw IWYU output as an artifact so we can track FP trends.
+- **The parser is unit-tested.** When touching `tools/scripts/iwyu_annotate.py`, run `python3 tools/scripts/test_iwyu_annotate.py` locally — the workflow runs it as a pre-flight fixture check so regressions fail fast without burning the build.
+- **Mappings** — `.iwyu-mappings.imp` at the repo root maps CHOC amalgamated headers and libstdc++ detail paths to the canonical public include. Prefer fixing the code (adding the missing include) over adding a new mapping.
+- **Flip to blocking** (Phase 3 of #594) requires FP rate < 5% across a one-week window. On the flip PR, edit `continue-on-error` to `false`, update `docs/guides/iwyu.md`'s "Advisory until" line, and reference the flip in the PR body. Do not close #594 until the blocking gate has held for a week.
+
+See [docs/guides/iwyu.md](../../../docs/guides/iwyu.md) for the full contributor-facing write-up.
+
 ## SignalGraph Phase 0 learnings (PR #153)
 
 Gotchas surfaced while landing the four-phase SignalGraph follow-up:

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -1,0 +1,234 @@
+name: IWYU advisory
+
+# include-what-you-use advisory gate for issue #594 Phase 2.
+#
+# Transitive-include bugs (code that uses std::X but only picks up
+# X's header transitively) keep reaching main because Apple Clang's
+# libc++ tolerates the miss while Linux Clang + MSVC reject. Three
+# incidents on 2026-04-21 (#540, Slice 4 <atomic>, #593) triggered
+# this gate. Phase 1 (#593) tightened the coverage-build gate so the
+# bugs can't hide silently. This workflow catches them earlier — at
+# IWYU-analysis time — before they reach the cross-platform matrix.
+#
+# Advisory until 2026-05-05: continue-on-error is true, PR diff
+# gets inline annotations, merge is not blocked. After the FP rate
+# settles (Phase 3 of #594), this flips to blocking.
+#
+# Scope:
+#   - PR events  → analyze only files changed vs origin/<base>
+#   - Push main → full repo scan, artifact uploaded for FP tracking
+#
+# Platform:
+#   - Linux Clang only. macOS libc++ hides the bug class (false
+#     negatives); MSVC is not Clang.
+#
+# Local equivalent (developers can validate before pushing):
+#   sudo apt-get install iwyu   # or build from source if stale
+#   cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+#   iwyu_tool.py -p build path/to/file.cpp \
+#       | python3 tools/scripts/iwyu_annotate.py
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'core/**'
+      - 'examples/**'
+      - 'tools/cli/**'
+      - 'test/**'
+      - 'CMakeLists.txt'
+      - 'tools/cmake/**'
+      - '.github/workflows/iwyu.yml'
+      - '.iwyu-mappings.imp'
+      - 'tools/scripts/iwyu_annotate.py'
+      - 'tools/scripts/test_iwyu_annotate.py'
+  push:
+    branches: [main]
+    paths:
+      - 'core/**'
+      - 'examples/**'
+      - 'tools/cli/**'
+      - 'test/**'
+      - 'CMakeLists.txt'
+      - 'tools/cmake/**'
+      - '.github/workflows/iwyu.yml'
+      - '.iwyu-mappings.imp'
+      - 'tools/scripts/iwyu_annotate.py'
+  workflow_dispatch:
+
+concurrency:
+  group: iwyu-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  iwyu:
+    name: IWYU (Linux, Clang) — advisory
+    runs-on: ubuntu-24.04
+    # Phase 2 advisory period — do NOT block PR merges.
+    # Flip to false on 2026-05-05 after FP rate < 5% per #594.
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Need base branch history to compute changed files on PR.
+          fetch-depth: 0
+          submodules: false
+          lfs: false
+
+      - name: Run iwyu_annotate.py fixture tests
+        # Same pattern as coverage.yml / docs-check: test the helper
+        # before we depend on it in a live step, so a regression fails
+        # fast without burning the build.
+        run: python3 tools/scripts/test_iwyu_annotate.py
+        shell: bash
+
+      - name: Install IWYU + Clang + Linux dev headers
+        # ubuntu-24.04 ships an `iwyu` apt package that links against
+        # system Clang. Package version tracks the distro Clang (18
+        # on 24.04), which is new enough for our C++20 use. If the
+        # distro version lags we can switch to building from source —
+        # flagged here for future maintainers.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            iwyu clang llvm lld \
+            libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev \
+            libgbm-dev libgl1-mesa-dev libx11-dev libxext-dev libxfixes-dev \
+            libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev \
+            libxrender-dev libxss-dev libxtst-dev libwayland-dev wayland-protocols
+          include-what-you-use --version || true
+          which iwyu_tool.py || which iwyu_tool || true
+
+      - name: Bootstrap dependencies
+        run: ./setup.sh --ci --deps-only
+        shell: bash
+
+      - name: Configure with compile_commands.json
+        # IWYU reads compile_commands.json to match a file's actual
+        # compiler flags. PULP_BUILD_TESTS/EXAMPLES OFF keeps the
+        # compile DB scoped to the core subsystems — IWYU on a
+        # 2,000-TU test tree blows past the job timeout.
+        run: |
+          cmake -S . -B build-iwyu \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DPULP_BUILD_TESTS=ON \
+            -DPULP_BUILD_EXAMPLES=OFF \
+            -DPULP_ENABLE_GPU=OFF
+          test -s build-iwyu/compile_commands.json
+
+      - name: Compute changed files (PR) or full scan (push)
+        id: files
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            base_ref="origin/${{ github.base_ref }}"
+            git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/${base_ref}" || true
+            # Changed files: C/C++ sources and headers only, skip deleted
+            # entries (no file to lint) and generated/external trees.
+            git diff --name-only --diff-filter=d "${base_ref}...HEAD" \
+              | grep -E '\.(cpp|cc|cxx|hpp|h|hh|hxx|mm|m)$' \
+              | grep -Ev '^(external/|build/|build-iwyu/|_deps/)' \
+              > changed-files.txt || true
+            echo "scope=pr" >> "$GITHUB_OUTPUT"
+            count=$(wc -l < changed-files.txt | tr -d ' ')
+            echo "changed_count=${count}" >> "$GITHUB_OUTPUT"
+            echo "Changed C/C++ files: ${count}"
+            cat changed-files.txt || true
+          else
+            # Full repo scan on push-to-main.
+            : > changed-files.txt
+            echo "scope=full" >> "$GITHUB_OUTPUT"
+            echo "changed_count=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run IWYU (advisory)
+        # iwyu_tool.py reads compile_commands.json and invokes IWYU
+        # per-TU. On PR events we pass only the changed paths; on
+        # push-to-main we let it scan the full compile DB. Any IWYU
+        # exit code is non-fatal here — the script below classifies
+        # the findings.
+        id: iwyu
+        shell: bash
+        run: |
+          set +e
+          # Locate the iwyu_tool wrapper (name varies across packagings).
+          iwyu_tool=""
+          for candidate in iwyu_tool.py iwyu_tool iwyu-tool; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+              iwyu_tool="$candidate"
+              break
+            fi
+          done
+          if [ -z "$iwyu_tool" ]; then
+            echo "::warning::iwyu_tool not found; skipping IWYU run."
+            : > iwyu-raw.txt
+            exit 0
+          fi
+          echo "Using ${iwyu_tool}"
+
+          iwyu_args=(
+            -p build-iwyu
+            --
+            -Xiwyu --mapping_file="$(pwd)/.iwyu-mappings.imp"
+            -Xiwyu --no_fwd_decls
+            -Xiwyu --quoted_includes_first
+          )
+
+          if [ "${{ steps.files.outputs.scope }}" = "pr" ] && [ -s changed-files.txt ]; then
+            xargs -a changed-files.txt "$iwyu_tool" "${iwyu_args[@]}" > iwyu-raw.txt 2>&1 || true
+          elif [ "${{ steps.files.outputs.scope }}" = "pr" ]; then
+            echo "No C/C++ files changed in PR; skipping IWYU scan."
+            : > iwyu-raw.txt
+          else
+            "$iwyu_tool" "${iwyu_args[@]}" > iwyu-raw.txt 2>&1 || true
+          fi
+          wc -l iwyu-raw.txt || true
+
+      - name: Emit GitHub annotations + summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.files.outputs.scope }}" = "pr" ]; then
+            python3 tools/scripts/iwyu_annotate.py \
+              --input iwyu-raw.txt \
+              --changed-files-from changed-files.txt \
+              --flip-date 2026-05-05 \
+              --advisory \
+              --summary-file "$GITHUB_STEP_SUMMARY"
+          else
+            python3 tools/scripts/iwyu_annotate.py \
+              --input iwyu-raw.txt \
+              --flip-date 2026-05-05 \
+              --advisory \
+              --summary-file "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload full IWYU report (push-to-main scan)
+        # On push-to-main we retain the full scan output so we can
+        # track the FP rate over the 2-week advisory window and
+        # decide when to flip to blocking (Phase 3 of #594).
+        if: always() && steps.files.outputs.scope == 'full'
+        uses: actions/upload-artifact@v6
+        with:
+          name: iwyu-full-scan-${{ github.sha }}
+          path: iwyu-raw.txt
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload changed-files report (PR scan)
+        if: always() && steps.files.outputs.scope == 'pr'
+        uses: actions/upload-artifact@v6
+        with:
+          name: iwyu-pr-report-${{ github.sha }}
+          path: |
+            iwyu-raw.txt
+            changed-files.txt
+          retention-days: 14
+          if-no-files-found: warn

--- a/.iwyu-mappings.imp
+++ b/.iwyu-mappings.imp
@@ -1,0 +1,47 @@
+// Pulp-specific IWYU mappings (issue #594 Phase 2).
+//
+// IWYU (include-what-you-use) runs as an advisory CI gate on the
+// Linux Clang lane to catch transitive-include bugs at compile time
+// instead of on a cross-platform CI run. Some of Pulp's vendored
+// single-header libraries and internal style conventions need
+// explicit mappings so IWYU doesn't suggest rewriting the world.
+//
+// Format:  { include: ["<private header>", <public-or-private>, "<public header>", <public-or-private>] }
+// Format:  { symbol:  ["<symbol>", <public-or-private>, "<public header>", <public-or-private>] }
+//
+// See https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUMappings.md
+//
+// Keep this list minimal and intentional — every mapping papers over
+// an IWYU analysis that would otherwise be correct. Prefer fixing the
+// code (adding the include) over adding a mapping.
+
+[
+    # ── CHOC single-header redirects ────────────────────────────────────
+    # CHOC ships as amalgamated headers; IWYU's "private/public" model
+    # only has one choice here — the canonical include IS the amalgam.
+    { include: ["<choc/audio/choc_AudioFileFormat_WAV.h>",   "private", "<choc/audio/choc_AudioFileFormat_WAV.h>",   "public"] },
+    { include: ["<choc/audio/choc_AudioFileFormat_FLAC.h>",  "private", "<choc/audio/choc_AudioFileFormat_FLAC.h>",  "public"] },
+    { include: ["<choc/audio/choc_AudioFileFormat_Ogg.h>",   "private", "<choc/audio/choc_AudioFileFormat_Ogg.h>",   "public"] },
+    { include: ["<choc/audio/choc_AudioFileFormat.h>",       "private", "<choc/audio/choc_AudioFileFormat.h>",       "public"] },
+    { include: ["<choc/audio/choc_SampleBuffers.h>",         "private", "<choc/audio/choc_SampleBuffers.h>",         "public"] },
+    { include: ["<choc/containers/choc_Value.h>",            "private", "<choc/containers/choc_Value.h>",            "public"] },
+    { include: ["<choc/containers/choc_SingleReaderSingleWriterFIFO.h>", "private", "<choc/containers/choc_SingleReaderSingleWriterFIFO.h>", "public"] },
+    { include: ["<choc/javascript/choc_javascript_QuickJS.h>", "private", "<choc/javascript/choc_javascript_QuickJS.h>", "public"] },
+    { include: ["<choc/text/choc_JSON.h>",                   "private", "<choc/text/choc_JSON.h>",                   "public"] },
+    { include: ["<choc/text/choc_StringUtilities.h>",        "private", "<choc/text/choc_StringUtilities.h>",        "public"] },
+
+    # ── libstdc++ internal → public ─────────────────────────────────────
+    # IWYU frequently suggests the libstdc++ detail headers; redirect
+    # to the canonical public header instead.
+    { include: ["<bits/std_abs.h>",                 "private", "<cstdlib>",  "public"] },
+    { include: ["<bits/std_function.h>",            "private", "<functional>", "public"] },
+    { include: ["<bits/chrono.h>",                  "private", "<chrono>",   "public"] },
+    { include: ["<bits/shared_ptr.h>",              "private", "<memory>",   "public"] },
+    { include: ["<bits/unique_ptr.h>",              "private", "<memory>",   "public"] },
+    { include: ["<bits/stl_algo.h>",                "private", "<algorithm>", "public"] },
+    { include: ["<bits/stl_algobase.h>",            "private", "<algorithm>", "public"] },
+    { include: ["<bits/atomic_base.h>",             "private", "<atomic>",   "public"] },
+
+    # ── Catch2 is test-only; never suggest trimming its includes ───────
+    { include: ["@<catch2/.*>",                     "private", "<catch2/catch_test_macros.hpp>", "public"] },
+]

--- a/docs/guides/iwyu.md
+++ b/docs/guides/iwyu.md
@@ -1,0 +1,125 @@
+# IWYU (include-what-you-use)
+
+Pulp runs IWYU as an **advisory** CI check on the Linux Clang lane to
+catch transitive-include bugs at analysis time instead of waiting for
+the cross-platform matrix to reject them.
+
+This guide covers the Phase 2 advisory gate. See
+[issue #594](https://github.com/danielraffel/pulp/issues/594) for the
+full 3-tier plan (Phase 1 tightened the coverage-build gate, Phase 2
+is this advisory IWYU check, Phase 3 will flip it to blocking once the
+false-positive rate settles).
+
+## What we're catching
+
+Apple Clang's libc++ tolerates a large number of transitive includes —
+if `<vector>` happens to pull in `<memory>`, code that uses `std::unique_ptr`
+without `#include <memory>` compiles fine on macOS. Linux Clang
+(libstdc++) and MSVC are stricter; the same code fails on those
+lanes.
+
+Three real incidents on 2026-04-21 alone:
+
+| Incident      | File                                      | Missing   |
+|---------------|-------------------------------------------|-----------|
+| [#540](https://github.com/danielraffel/pulp/issues/540)   | `core/signal/include/pulp/signal/fft.hpp` | `<memory>`    |
+| Slice 4 test  | `test/test_cli_version_diag.cpp`          | `<atomic>`    |
+| [#593](https://github.com/danielraffel/pulp/issues/593)   | `core/state/include/pulp/state/state_tree.hpp` | `<algorithm>` |
+
+Each bug was only detected by CI after landing on a feature branch.
+IWYU rejects them at analysis time.
+
+## How the gate runs
+
+- **Workflow**: `.github/workflows/iwyu.yml`
+- **Runner**: `ubuntu-24.04` (Linux Clang 18 via the distro `iwyu` apt package)
+- **Advisory until**: **2026-05-05** — `continue-on-error: true`. PRs get
+  inline annotations on the diff but merge is not blocked.
+- **Scope**: PR events analyze files changed vs `origin/<base>`;
+  push-to-main events run a full repo scan and upload the report as
+  an artifact so we can track FP trends.
+- **Not run on macOS** — libc++ hides the bug class; false negatives
+  would dilute the gate.
+- **Not run on Windows** — IWYU is Clang-only; MSVC already catches
+  transitive-include bugs at compile time in `build.yml`.
+
+## Output
+
+Findings surface two ways:
+
+1. **Inline PR annotations** — each missing-include suggestion appears
+   as a `warning` on line 1 of the offending file, visible on the PR
+   "Files changed" tab.
+2. **Job summary** — a markdown block listing every finding, rendered
+   at the bottom of the job log.
+
+Example annotation (from a local dry-run):
+
+```
+::warning file=core/signal/include/pulp/signal/fft.hpp,line=1,title=IWYU: missing include (advisory, issue #594)::add `<memory>` — for unique_ptr
+```
+
+## Local usage
+
+You can validate a branch before pushing:
+
+```bash
+# Install (one-time)
+sudo apt-get install iwyu         # Ubuntu/Debian
+brew install include-what-you-use  # macOS (advisory — may false-negative on libc++)
+
+# Configure + analyze
+cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+iwyu_tool.py -p build core/signal/src/fft.cpp \
+    -- -Xiwyu --mapping_file=.iwyu-mappings.imp \
+    | python3 tools/scripts/iwyu_annotate.py
+```
+
+On macOS you'll typically see fewer findings than the CI lane — that
+is the nature of libc++. Don't count on local IWYU to stand in for
+the Linux gate.
+
+## Mappings file
+
+`.iwyu-mappings.imp` at the repo root maps Pulp-specific includes to
+their canonical public header. The main use cases:
+
+- **CHOC amalgamated headers** — CHOC ships each utility as a single
+  header; IWYU's private/public model has nowhere else to redirect.
+- **libstdc++ detail headers** — IWYU sometimes suggests
+  `<bits/shared_ptr.h>` instead of `<memory>`. The mapping rewrites
+  those suggestions to the public header.
+
+Prefer fixing the code (adding the missing include) over adding a new
+mapping. Every mapping papers over an analysis that would otherwise be
+correct.
+
+## False-positive tracking
+
+During the advisory window (through 2026-05-05) we collect the
+push-to-main scan artifacts so we can see the repo-wide FP rate. Flip
+to blocking requires:
+
+- FP rate < 5% of total findings across a one-week window
+- No Pulp subsystem that cannot reasonably satisfy the gate
+
+Known FP sources so far (to extend as they come up):
+
+- **CHOC headers** — amalgamated; redirected in `.iwyu-mappings.imp`.
+- **libstdc++ detail paths** — redirected in `.iwyu-mappings.imp`.
+- **`<choc/text/choc_JSON.h>` / `choc_Value.h`** — choc JSON types
+  pull in iostream-like APIs that IWYU wants to rewrite; ignore.
+
+When flipping to blocking (Phase 3 of #594):
+
+1. Edit `.github/workflows/iwyu.yml`: set `continue-on-error: false`
+2. Update this guide's "Advisory until" line to "Blocking since &lt;date&gt;"
+3. Reference the flip in the PR description
+4. Close #594 only after the blocking gate has held for a week
+
+## Related
+
+- Issue #594 — the full 3-tier plan
+- Issue #593 — coverage-build gate hardening (Phase 1)
+- `docs/guides/coverage.md` — sibling CI gate (coverage diff advisory)
+- `docs/guides/local-ci.md` — end-to-end CI overview

--- a/tools/scripts/iwyu_annotate.py
+++ b/tools/scripts/iwyu_annotate.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Parse include-what-you-use output and emit GitHub annotations.
+
+IWYU prints per-file suggestions like:
+
+    core/signal/include/pulp/signal/fft.hpp should add these lines:
+    #include <memory>                      // for unique_ptr
+
+    core/signal/include/pulp/signal/fft.hpp should remove these lines:
+    - #include <vector>  // lines 3-3
+
+    The full include-list for core/signal/include/pulp/signal/fft.hpp:
+    ...
+    ---
+
+Issue #594 Phase 2 only cares about the "should add" section — that is
+the class of bug (transitive-include) that keeps reaching main. "Should
+remove" is the minimal-include class of suggestion IWYU is famous for,
+and #594 explicitly calls it a non-goal.
+
+This script:
+
+  1. Reads IWYU output from stdin (or --input <path>).
+  2. Walks the per-file blocks.
+  3. For every "should add" line, emits:
+
+        ::warning file=<path>,line=1,title=IWYU::<file> should add <header> <reason>
+
+  4. Optionally filters to a set of changed files passed via
+     --changed-files-from <path> (one path per line, typically the
+     output of `git diff --name-only origin/main...HEAD`).
+
+  5. Writes a short summary block to stdout (so the CI log is readable)
+     and optionally to $GITHUB_STEP_SUMMARY if --summary-file is given.
+
+The script never fails — it always exits 0. The gate decision is
+upstream (continue-on-error in the workflow). That keeps the script
+drop-in usable in either advisory or blocking mode: flip the workflow
+`continue-on-error: false` and the matching annotations will still fire.
+
+Run:
+    iwyu_tool.py -p build ... | python3 tools/scripts/iwyu_annotate.py \\
+        --changed-files-from changed.txt \\
+        --summary-file "$GITHUB_STEP_SUMMARY"
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from typing import Iterable, Iterator, List, Optional, Sequence, Tuple
+
+
+# ── IWYU block parser ──────────────────────────────────────────────────
+
+_HEADER_RE = re.compile(r"^(?P<path>\S[^\n]*?) should add these lines:\s*$")
+_ADD_LINE_RE = re.compile(
+    r"""^
+        \#include\s+
+        (?P<include>[<\"][^>\"]+[>\"])
+        (?:\s*//\s*(?P<reason>.+))?
+        \s*$
+    """,
+    re.VERBOSE,
+)
+_TERMINATOR_RE = re.compile(r"^\s*(?:---|The full include-list for )")
+
+
+def iter_add_findings(lines: Iterable[str]) -> Iterator[Tuple[str, str, str]]:
+    """Yield (file_path, include, reason) for every "should add" entry.
+
+    The IWYU output block structure is:
+
+        <path> should add these lines:
+        #include <X>     // for foo
+        #include "Y.h"
+        <blank line>
+        <path> should remove these lines:
+        ...
+
+    We walk until we hit an empty/non-matching line, then drop back into
+    scanning for the next header.
+    """
+
+    in_add_block = False
+    current_file: Optional[str] = None
+
+    for raw in lines:
+        line = raw.rstrip("\n")
+
+        if in_add_block:
+            if not line.strip():
+                in_add_block = False
+                current_file = None
+                continue
+            if _TERMINATOR_RE.match(line):
+                in_add_block = False
+                current_file = None
+                continue
+            m = _ADD_LINE_RE.match(line.strip())
+            if m and current_file is not None:
+                include = m.group("include")
+                reason = (m.group("reason") or "").strip()
+                yield current_file, include, reason
+            # else: IWYU sometimes annotates with namespace/ctor hints
+            # on subsequent lines — ignore them; the "for <symbol>" on
+            # the comment of the previous line is enough context.
+            continue
+
+        header = _HEADER_RE.match(line)
+        if header:
+            in_add_block = True
+            current_file = header.group("path").strip()
+
+
+# ── Changed-file filter ────────────────────────────────────────────────
+
+def load_changed_files(path: Optional[pathlib.Path]) -> Optional[set[str]]:
+    """Return the set of paths to filter annotations to, or None to skip."""
+    if path is None:
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return set()
+    changed: set[str] = set()
+    for row in text.splitlines():
+        stripped = row.strip()
+        if not stripped:
+            continue
+        # Normalize — IWYU prints repo-relative paths just like `git diff`.
+        changed.add(stripped)
+    return changed
+
+
+def is_relevant(path: str) -> bool:
+    """Filter out noisy paths that IWYU scans but we don't enforce."""
+    # Only C++ source / headers.
+    if not path.endswith((".cpp", ".cc", ".cxx", ".hpp", ".h", ".hh", ".hxx", ".mm", ".m")):
+        return False
+    # Skip generated / vendored trees.
+    skip_prefixes = (
+        "build/",
+        "build-coverage/",
+        "external/",
+        "_deps/",
+    )
+    norm = path.replace("\\", "/")
+    if any(norm.startswith(p) or f"/{p}" in norm for p in skip_prefixes):
+        return False
+    return True
+
+
+# ── Rendering ──────────────────────────────────────────────────────────
+
+def render_annotation(file_path: str, include: str, reason: str) -> str:
+    """Render a GitHub `::warning` annotation line.
+
+    GitHub's annotation parser strips newlines in the `title=` field, so
+    we keep it single-line. We anchor the annotation to line 1 of the
+    file rather than trying to guess the right line — IWYU doesn't emit
+    a target line for additions (they haven't happened yet).
+    """
+    title = "IWYU: missing include (advisory, issue #594)"
+    msg_parts = [f"add `{include}`"]
+    if reason:
+        msg_parts.append(reason)
+    message = " — ".join(msg_parts)
+    # Escape commas and colons in the message per GitHub workflow commands.
+    safe_message = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    return f"::warning file={file_path},line=1,title={title}::{safe_message}"
+
+
+def render_summary(findings: Sequence[Tuple[str, str, str]], *, advisory: bool, flip_date: str) -> str:
+    """Render the human-readable summary markdown."""
+    lines: List[str] = []
+    lines.append("## IWYU advisory report (issue #594 Phase 2)")
+    lines.append("")
+    if advisory:
+        lines.append(
+            f"This check is **advisory** until **{flip_date}**. "
+            "Findings annotate inline on the PR diff but do not block merge. "
+            "See [docs/guides/iwyu.md](../docs/guides/iwyu.md)."
+        )
+        lines.append("")
+    if not findings:
+        lines.append("No missing-include suggestions on the changed files.")
+        return "\n".join(lines) + "\n"
+
+    by_file: dict[str, list[tuple[str, str]]] = {}
+    for fp, inc, reason in findings:
+        by_file.setdefault(fp, []).append((inc, reason))
+
+    lines.append(f"Found **{len(findings)}** missing-include suggestion(s) across **{len(by_file)}** file(s).")
+    lines.append("")
+    for fp in sorted(by_file):
+        lines.append(f"- `{fp}`")
+        for inc, reason in by_file[fp]:
+            if reason:
+                lines.append(f"  - add `{inc}` — {reason}")
+            else:
+                lines.append(f"  - add `{inc}`")
+    lines.append("")
+    lines.append(
+        "Not every finding is real: IWYU has known false positives on "
+        "CHOC amalgamated headers and libc++/libstdc++ detail paths. "
+        "Document recurring FPs in `.iwyu-mappings.imp`."
+    )
+    return "\n".join(lines) + "\n"
+
+
+# ── Entry point ────────────────────────────────────────────────────────
+
+def run(
+    input_stream: Iterable[str],
+    *,
+    changed_files: Optional[set[str]],
+    advisory: bool,
+    flip_date: str,
+) -> Tuple[List[str], str]:
+    """Pure function: parse IWYU output, return (annotations, summary)."""
+    findings: List[Tuple[str, str, str]] = []
+    for file_path, include, reason in iter_add_findings(input_stream):
+        if not is_relevant(file_path):
+            continue
+        if changed_files is not None and file_path not in changed_files:
+            continue
+        findings.append((file_path, include, reason))
+
+    annotations = [render_annotation(fp, inc, reason) for fp, inc, reason in findings]
+    summary = render_summary(findings, advisory=advisory, flip_date=flip_date)
+    return annotations, summary
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=pathlib.Path, default=None,
+                        help="Read IWYU output from path (default: stdin)")
+    parser.add_argument("--changed-files-from", type=pathlib.Path, default=None,
+                        help="File with one path per line; filter annotations to these paths.")
+    parser.add_argument("--summary-file", type=pathlib.Path, default=None,
+                        help="Path to append the human-readable summary (e.g. $GITHUB_STEP_SUMMARY).")
+    parser.add_argument("--advisory", action="store_true", default=True,
+                        help="Label the summary as advisory (default).")
+    parser.add_argument("--blocking", dest="advisory", action="store_false",
+                        help="Label the summary as blocking instead of advisory.")
+    parser.add_argument("--flip-date", default="2026-05-05",
+                        help="Planned flip-to-blocking date, shown in summary.")
+    args = parser.parse_args(argv)
+
+    if args.input is not None:
+        input_text = args.input.read_text(encoding="utf-8")
+        input_iter: Iterable[str] = input_text.splitlines()
+    else:
+        input_iter = sys.stdin
+
+    changed_files = load_changed_files(args.changed_files_from)
+
+    annotations, summary = run(
+        input_iter,
+        changed_files=changed_files,
+        advisory=args.advisory,
+        flip_date=args.flip_date,
+    )
+
+    # Annotations go to stdout so the GitHub Actions log parser picks them up.
+    for line in annotations:
+        print(line)
+
+    # Summary goes to stderr (readable) + optional summary-file.
+    sys.stderr.write("\n")
+    sys.stderr.write(summary)
+    sys.stderr.write("\n")
+    if args.summary_file is not None:
+        try:
+            with args.summary_file.open("a", encoding="utf-8") as fh:
+                fh.write(summary)
+        except OSError as exc:
+            sys.stderr.write(f"warning: could not write summary: {exc}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/test_iwyu_annotate.py
+++ b/tools/scripts/test_iwyu_annotate.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Fixture tests for tools/scripts/iwyu_annotate.py.
+
+Guards the IWYU-output parser and GitHub-annotation renderer used by
+the issue #594 Phase 2 advisory gate. Pure-Python and fast — no IWYU
+binary, no compile_commands.json, no network.
+
+Run:
+    python3 tools/scripts/test_iwyu_annotate.py
+"""
+
+from __future__ import annotations
+
+import io
+import pathlib
+import sys
+import tempfile
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import iwyu_annotate as ia  # noqa: E402
+
+
+# ── Sample IWYU output snippets ────────────────────────────────────────
+
+SINGLE_FILE_ADD = """\
+core/signal/include/pulp/signal/fft.hpp should add these lines:
+#include <memory>     // for unique_ptr
+#include <vector>     // for vector
+
+core/signal/include/pulp/signal/fft.hpp should remove these lines:
+- #include <cstdint>  // lines 3-3
+
+The full include-list for core/signal/include/pulp/signal/fft.hpp:
+#include <algorithm>
+#include <memory>
+#include <vector>
+---
+"""
+
+MULTI_FILE = """\
+core/state/include/pulp/state/state_tree.hpp should add these lines:
+#include <algorithm>   // for sort
+
+core/state/include/pulp/state/state_tree.hpp should remove these lines:
+
+The full include-list for core/state/include/pulp/state/state_tree.hpp:
+#include <algorithm>
+---
+
+test/test_cli_version_diag.cpp should add these lines:
+#include <atomic>      // for atomic
+
+test/test_cli_version_diag.cpp should remove these lines:
+
+The full include-list for test/test_cli_version_diag.cpp:
+#include <atomic>
+---
+"""
+
+# IWYU emits this exact section when a file is already clean.
+NO_CHANGES = """\
+(core/view/src/button.cpp has correct #includes/fwd-decls)
+"""
+
+# Paths under build/, external/, or _deps/ must be ignored.
+NOISE_IN_DEPS = """\
+build-coverage/_deps/catch2-build/src/catch2/catch_test_macros.hpp should add these lines:
+#include <string>
+
+build-coverage/_deps/catch2-build/src/catch2/catch_test_macros.hpp should remove these lines:
+
+The full include-list for build-coverage/_deps/catch2-build/src/catch2/catch_test_macros.hpp:
+#include <string>
+---
+"""
+
+
+class ParserTests(unittest.TestCase):
+    def test_iter_add_findings_extracts_each_include(self) -> None:
+        findings = list(ia.iter_add_findings(SINGLE_FILE_ADD.splitlines()))
+        self.assertEqual(
+            findings,
+            [
+                ("core/signal/include/pulp/signal/fft.hpp", "<memory>", "for unique_ptr"),
+                ("core/signal/include/pulp/signal/fft.hpp", "<vector>", "for vector"),
+            ],
+        )
+
+    def test_iter_add_findings_walks_multiple_files(self) -> None:
+        findings = list(ia.iter_add_findings(MULTI_FILE.splitlines()))
+        self.assertEqual(len(findings), 2)
+        paths = {fp for fp, _, _ in findings}
+        self.assertEqual(
+            paths,
+            {
+                "core/state/include/pulp/state/state_tree.hpp",
+                "test/test_cli_version_diag.cpp",
+            },
+        )
+
+    def test_iter_add_findings_ignores_remove_section(self) -> None:
+        # Confirm we never emit a finding for "should remove these lines".
+        # This is the issue #594 non-goal: we aren't enforcing minimal
+        # includes, only missing ones.
+        findings = list(ia.iter_add_findings(SINGLE_FILE_ADD.splitlines()))
+        for _, include, _ in findings:
+            self.assertNotIn("cstdint", include)
+
+    def test_iter_add_findings_handles_no_findings(self) -> None:
+        findings = list(ia.iter_add_findings(NO_CHANGES.splitlines()))
+        self.assertEqual(findings, [])
+
+    def test_iter_add_findings_handles_missing_reason(self) -> None:
+        # Not every add line has "// for X" — IWYU sometimes omits it.
+        text = """\
+foo.hpp should add these lines:
+#include <memory>
+
+foo.hpp should remove these lines:
+"""
+        findings = list(ia.iter_add_findings(text.splitlines()))
+        self.assertEqual(findings, [("foo.hpp", "<memory>", "")])
+
+
+class FilterTests(unittest.TestCase):
+    def test_is_relevant_accepts_source_and_headers(self) -> None:
+        self.assertTrue(ia.is_relevant("core/signal/src/fft.cpp"))
+        self.assertTrue(ia.is_relevant("core/signal/include/pulp/signal/fft.hpp"))
+        self.assertTrue(ia.is_relevant("apple/src/foo.mm"))
+
+    def test_is_relevant_rejects_non_cpp(self) -> None:
+        self.assertFalse(ia.is_relevant("README.md"))
+        self.assertFalse(ia.is_relevant("CMakeLists.txt"))
+
+    def test_is_relevant_rejects_external_and_build_trees(self) -> None:
+        self.assertFalse(ia.is_relevant("external/choc/audio/foo.h"))
+        self.assertFalse(ia.is_relevant("build/CMakeFiles/foo.cpp"))
+        self.assertFalse(ia.is_relevant("build-coverage/_deps/catch2-src/x.hpp"))
+
+    def test_load_changed_files_missing_is_empty_set(self) -> None:
+        # Missing file (e.g. push to main with no diff) should return
+        # empty set, not None — None means "no filter at all".
+        path = pathlib.Path("/does-not-exist-12345.txt")
+        self.assertEqual(ia.load_changed_files(path), set())
+
+    def test_load_changed_files_strips_blank_lines(self) -> None:
+        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as fh:
+            fh.write("core/foo.cpp\n\n  core/bar.hpp  \n")
+            tmp = pathlib.Path(fh.name)
+        try:
+            self.assertEqual(
+                ia.load_changed_files(tmp),
+                {"core/foo.cpp", "core/bar.hpp"},
+            )
+        finally:
+            tmp.unlink()
+
+
+class RunTests(unittest.TestCase):
+    def test_run_filters_to_changed_files_on_pr(self) -> None:
+        # Only the state_tree.hpp change is in scope for this PR.
+        annotations, summary = ia.run(
+            MULTI_FILE.splitlines(),
+            changed_files={"core/state/include/pulp/state/state_tree.hpp"},
+            advisory=True,
+            flip_date="2026-05-05",
+        )
+        self.assertEqual(len(annotations), 1)
+        self.assertIn("state_tree.hpp", annotations[0])
+        self.assertIn("algorithm", annotations[0])
+        # The unrelated test file's finding must be suppressed.
+        self.assertNotIn("test_cli_version_diag", " ".join(annotations))
+        # Summary lists the single finding.
+        self.assertIn("Found **1**", summary)
+
+    def test_run_no_filter_reports_everything_relevant(self) -> None:
+        annotations, summary = ia.run(
+            MULTI_FILE.splitlines(),
+            changed_files=None,
+            advisory=True,
+            flip_date="2026-05-05",
+        )
+        self.assertEqual(len(annotations), 2)
+        self.assertIn("Found **2**", summary)
+
+    def test_run_drops_noisy_deps_paths(self) -> None:
+        annotations, summary = ia.run(
+            NOISE_IN_DEPS.splitlines(),
+            changed_files=None,
+            advisory=True,
+            flip_date="2026-05-05",
+        )
+        self.assertEqual(annotations, [])
+        self.assertIn("No missing-include", summary)
+
+    def test_run_empty_input_emits_clean_summary(self) -> None:
+        annotations, summary = ia.run(
+            iter([]),
+            changed_files=None,
+            advisory=True,
+            flip_date="2026-05-05",
+        )
+        self.assertEqual(annotations, [])
+        self.assertIn("No missing-include", summary)
+
+    def test_annotation_shape_matches_github_workflow_command(self) -> None:
+        # GitHub parses `::warning file=...,line=...,title=...::message`
+        # and strips the message at newlines. We escape CR/LF.
+        out = ia.render_annotation("foo.hpp", "<memory>", "for unique_ptr\nmultiline")
+        self.assertTrue(out.startswith("::warning "))
+        self.assertIn("file=foo.hpp", out)
+        self.assertIn("line=1", out)
+        self.assertIn("%0A", out)  # newline encoded per GH spec
+        # Message body is present.
+        self.assertIn("memory", out)
+
+    def test_summary_mentions_flip_date_and_issue(self) -> None:
+        _, summary = ia.run(
+            SINGLE_FILE_ADD.splitlines(),
+            changed_files=None,
+            advisory=True,
+            flip_date="2026-05-05",
+        )
+        self.assertIn("2026-05-05", summary)
+        self.assertIn("#594", summary)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds an advisory IWYU CI check on the Linux Clang lane to catch transitive-include bugs at analysis time instead of after they land on a feature branch and get rejected by the cross-platform matrix. Three incidents on 2026-04-21 drove the gate: #540 `<memory>`, Slice 4 `<atomic>`, #593 `<algorithm>`.

- **Advisory until 2026-05-05** (`continue-on-error: true`) — PR annotations appear inline on the diff, merges are not blocked.
- **Linux Clang only** — macOS libc++ hides the bug class (false negatives); MSVC is not Clang.
- **Scoped** — PR events analyze only files changed vs `origin/<base>`; push-to-main runs a full repo scan and uploads the raw IWYU output as an artifact so we can track FP rate before Phase 3 flips to blocking.

Closes **nothing** from #594 — Phase 3 (blocking flip) stays open.

## Files

| File | Purpose |
|------|---------|
| `.github/workflows/iwyu.yml` | Advisory CI job (Linux Clang, `ubuntu-24.04`, distro `iwyu` apt package) |
| `.iwyu-mappings.imp` | CHOC amalgamated-header + libstdc++ detail-path redirects |
| `tools/scripts/iwyu_annotate.py` | Parses IWYU "should add" blocks, filters to changed files, emits `::warning` annotations + job summary. Only cares about missing includes — "should remove" is a #594 non-goal. |
| `tools/scripts/test_iwyu_annotate.py` | 16 fixture tests (parser, filter, annotation format). Workflow runs it as a pre-flight check, same pattern as `test_coverage_diff_comment.py`. |
| `docs/guides/iwyu.md` | Contributor-facing guide: local usage, flip criteria, known FP sources |
| `.agents/skills/ci/SKILL.md` | CI skill gotcha note about the advisory gate |

## Sample annotation (local dry-run)

```
::warning file=core/signal/include/pulp/signal/fft.hpp,line=1,title=IWYU: missing include (advisory, issue #594)::add `<memory>` — for unique_ptr
```

## Flip-to-blocking date

**2026-05-05** (two weeks from 2026-04-21). Flip requires:

- FP rate < 5% across a one-week window of full-repo scan artifacts
- No subsystem that cannot reasonably satisfy the gate

Flip steps live in `docs/guides/iwyu.md` and the `ci` skill gotcha section.

## Test plan

- [ ] New `iwyu` workflow appears in the Actions tab and runs advisory (non-blocking) on this PR
- [ ] `tools/scripts/test_iwyu_annotate.py` runs as pre-flight step and passes
- [ ] If IWYU surfaces any finding on this PR's small changed-file set, it renders as a `::warning` on the "Files changed" tab
- [ ] Merge does NOT require the IWYU job (the PR should be mergeable even if IWYU finds issues)
- [ ] Standard cross-platform matrix (`build.yml` / sanitizers / coverage) stays green

## Non-goals (per #594)

- Not enforcing minimal includes — only catches **missing** includes
- Not running on macOS (libc++ hides the bug class)
- Not running on MSVC (IWYU is Clang-only; MSVC already rejects these at compile time)
- Not reformatting existing code to satisfy IWYU exhaustively — only the advisory signal

## Related

- #594 (parent issue, stays open through Phase 3)
- #540, Slice 4 test, #593 (the three 2026-04-21 incidents that triggered this)
- `docs/guides/iwyu.md` (full contributor guide, committed in this PR)