### PR TITLE
chore: bump Shipyard pin v0.22.8 → v0.22.9 (auto-PR title+body quality)

### DIFF
--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -30,7 +30,7 @@
 # bumps this pin.
 
 [shipyard]
-# v0.22.8 — eight patch releases on the v0.22.x line:
+# v0.22.9 — nine patch releases on the v0.22.x line:
 #
 #   v0.22.1 — `install.sh` grew `SHIPYARD_VERSION` and
 #             `SHIPYARD_INSTALL_DIR` env-var support so downstreams
@@ -78,6 +78,12 @@
 #             drift from GitHub-side re-runs self-heals within 30s.
 #             Cost: ~120 REST calls/hr per active PR — marginal vs
 #             the 5000/hr budget even at 10+ tracked PRs.
+#   v0.22.9 — auto-opened PR titles + bodies use the HEAD commit's
+#             subject and body instead of "Ship <branch>" + empty.
+#             Previous versions produced unhelpful boilerplate; PRs
+#             shipped via `shipyard pr` now read as first-party and
+#             reviewers see the commit's own rationale without
+#             clicking through to the diff.
 #
 # Cumulative additions from earlier releases still in effect:
 #   v0.4–v0.8 — release-bot helpers, `shipyard doctor release-chain`,
@@ -92,7 +98,7 @@
 # in `tools/install-shipyard.sh` (v0.22.1+ `SHIPYARD_VERSION` support).
 # The older `~/.pulp/bin/shipyard` path is cleaned up on install to
 # prevent shadow-on-PATH bugs.
-version = "v0.22.8"
+version = "v0.22.9"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Previous versions produced `Ship <branch>` titles with either empty
bodies or "Automated by Shipyard." trailers — unhelpful to reviewers
and easy to mistake for throwaway automation output. 0.22.9 uses the
HEAD commit's subject as the PR title and the commit body as the PR
body, so PRs opened via `shipyard pr` are indistinguishable from
human-written ones. Downstream effect: the *next* Pulp PR opened
with this pin will carry the real commit message instead of a
generic "Ship chore/..." line.

Verified locally once the v0.22.9 binary publishes (installer
delegates upstream).

Version-Bump: sdk=patch reason="shipyard pin bump for PR title/body quality"
Skill-Update: skip skill=ci reason="pin-only change"