### PR TITLE
clap: wire CLAP_EVENT_MIDI + CC/NE/choke/UMP events; emit MIDI on out_events

### DIFF
--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -7,6 +7,7 @@
 #include <pulp/runtime/log.hpp>
 #include <clap/ext/preset-load.h>
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <filesystem>
 
@@ -175,6 +176,20 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
 
     // Build MIDI from CLAP note events
     midi::MidiBuffer midi_in, midi_out;
+    // Track whether any native CLAP_EVENT_MIDI2 packet was delivered so we
+    // can skip the MIDI 1.0 → UMP synthesis path when the host is speaking
+    // UMP natively. The host still sends CLAP_EVENT_NOTE_* in parallel for
+    // note events; those populate midi_in for the MPE tracker and plugins
+    // that only consume MIDI 1.0.
+    bool host_delivered_ump = false;
+    // Clear the UMP sidecar up-front: we append to it directly when the
+    // host sends CLAP_EVENT_MIDI2 during the event loop below.
+    if (self->ump_enabled) {
+        self->ump_buffer.clear();
+    }
+    // One-time debug log when a plugin that didn't opt into MPE drops a
+    // note-expression event.
+    bool note_expression_drop_logged = false;
     if (in_events) {
         uint32_t event_count = in_events->size(in_events);
         for (uint32_t i = 0; i < event_count; ++i) {
@@ -195,6 +210,134 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                     static_cast<uint8_t>(ev->velocity * 127.0));
                 me.sample_offset = static_cast<int32_t>(hdr->time);
                 midi_in.add(me);
+            } else if (hdr->type == CLAP_EVENT_NOTE_CHOKE) {
+                // NOTE_CHOKE has no MIDI 1.0 equivalent (the host is
+                // telling the plugin "force-release this voice, no
+                // matching note-off is coming"). The closest analogue is
+                // a zero-velocity note-off on the same (channel, key).
+                // See clap/events.h around CLAP_EVENT_NOTE_CHOKE — the
+                // velocity field is spec-ignored.
+                auto* ev = reinterpret_cast<const clap_event_note_t*>(hdr);
+                auto me = midi::MidiEvent::note_off(
+                    static_cast<uint8_t>(ev->channel),
+                    static_cast<uint8_t>(ev->key),
+                    0);
+                me.sample_offset = static_cast<int32_t>(hdr->time);
+                midi_in.add(me);
+            } else if (hdr->type == CLAP_EVENT_NOTE_EXPRESSION) {
+                // CLAP per-note expression. Pulp already has an MPE
+                // sidecar (`MpeBuffer`); map the expression to the
+                // closest MIDI 1.0 message and let the MPE tracker turn
+                // it into per-note state below. Only do this when the
+                // plugin opted into MPE — otherwise there is no sensible
+                // channel-wide interpretation (e.g. a per-note pressure
+                // would collapse onto whichever voice happens to share
+                // the channel). Plugins that consume UMP can access
+                // per-note expressions natively via the UMP sidecar;
+                // future work can extend that path.
+                auto* ev = reinterpret_cast<const clap_event_note_expression_t*>(hdr);
+                if (!self->mpe_enabled) {
+                    if (!note_expression_drop_logged) {
+                        runtime::log_debug(
+                            "CLAP: dropping CLAP_EVENT_NOTE_EXPRESSION; "
+                            "plugin did not opt in to MPE");
+                        note_expression_drop_logged = true;
+                    }
+                } else {
+                    const auto channel = static_cast<uint8_t>(
+                        ev->channel < 0 ? 0 : ev->channel & 0x0F);
+                    // NOTE: ev->key selects the target note for per-note
+                    // routing. The MIDI 1.0 synthesis path below emits
+                    // channel-wide messages (channel AT, pitch bend,
+                    // CCs); the MpeVoiceTracker narrows them back to the
+                    // matching member-channel voice by convention. A
+                    // future pass can route via the UMP sidecar for true
+                    // per-note fidelity.
+                    const auto t = static_cast<int32_t>(hdr->time);
+                    midi::MidiEvent me{};
+                    bool emitted = false;
+                    switch (ev->expression_id) {
+                        case CLAP_NOTE_EXPRESSION_PRESSURE: {
+                            // 0..1 → channel aftertouch (7-bit).
+                            const double v = std::clamp(ev->value, 0.0, 1.0);
+                            const uint8_t v7 = static_cast<uint8_t>(v * 127.0 + 0.5);
+                            me = {choc::midi::ShortMessage(
+                                static_cast<uint8_t>(0xD0 | (channel & 0x0F)),
+                                v7, 0), t, 0.0};
+                            emitted = true;
+                            break;
+                        }
+                        case CLAP_NOTE_EXPRESSION_TUNING: {
+                            // ±120 semitones → 14-bit pitch bend clamped
+                            // to ±2 semitones default MPE member range.
+                            // We normalise the raw value to the ±48st
+                            // member-bend default so the MpeVoiceTracker
+                            // expands it back correctly.
+                            const double norm = std::clamp(
+                                ev->value / static_cast<double>(
+                                    midi::MpeVoiceTracker::kDefaultMemberBendSemitones),
+                                -1.0, 1.0);
+                            const int bend14 = static_cast<int>(
+                                std::lround(8192.0 + norm * 8191.0));
+                            const auto pb = static_cast<uint16_t>(
+                                std::clamp(bend14, 0, 16383));
+                            me = midi::MidiEvent::pitch_bend(channel, pb);
+                            me.sample_offset = t;
+                            emitted = true;
+                            break;
+                        }
+                        case CLAP_NOTE_EXPRESSION_BRIGHTNESS: {
+                            // Brightness / timbre → CC 74.
+                            const double v = std::clamp(ev->value, 0.0, 1.0);
+                            const auto v7 = static_cast<uint8_t>(v * 127.0 + 0.5);
+                            me = midi::MidiEvent::cc(channel, 74, v7);
+                            me.sample_offset = t;
+                            emitted = true;
+                            break;
+                        }
+                        case CLAP_NOTE_EXPRESSION_VOLUME: {
+                            // Volume (log domain in CLAP spec) → CC 7.
+                            const double v = std::clamp(ev->value, 0.0, 4.0);
+                            const auto v7 = static_cast<uint8_t>(
+                                (v / 4.0) * 127.0 + 0.5);
+                            me = midi::MidiEvent::cc(channel, 7, v7);
+                            me.sample_offset = t;
+                            emitted = true;
+                            break;
+                        }
+                        case CLAP_NOTE_EXPRESSION_PAN: {
+                            // 0..1 → CC 10.
+                            const double v = std::clamp(ev->value, 0.0, 1.0);
+                            const auto v7 = static_cast<uint8_t>(v * 127.0 + 0.5);
+                            me = midi::MidiEvent::cc(channel, 10, v7);
+                            me.sample_offset = t;
+                            emitted = true;
+                            break;
+                        }
+                        case CLAP_NOTE_EXPRESSION_VIBRATO:
+                        case CLAP_NOTE_EXPRESSION_EXPRESSION:
+                        default:
+                            // Vibrato / expression and any future/unknown
+                            // IDs have no universally sensible MIDI 1.0
+                            // mapping; UMP-aware plugins should consume
+                            // these via the native UMP sidecar.
+                            break;
+                    }
+                    if (emitted) {
+                        midi_in.add(me);
+                    }
+                }
+            } else if (hdr->type == CLAP_EVENT_MIDI) {
+                // Raw MIDI 1.0 event — the host's fallback channel for
+                // CC, pitch bend, channel aftertouch, poly aftertouch,
+                // and program change. `port_index` is informational for
+                // multi-port plugins; single-port plugins accept all.
+                auto* ev = reinterpret_cast<const clap_event_midi_t*>(hdr);
+                midi::MidiEvent me{
+                    choc::midi::ShortMessage(ev->data[0], ev->data[1], ev->data[2]),
+                    static_cast<int32_t>(hdr->time),
+                    0.0};
+                midi_in.add(me);
             } else if (hdr->type == CLAP_EVENT_MIDI_SYSEX) {
                 // Workstream 01 — route CLAP sysex into MidiBuffer's
                 // variable-length sidecar (issue #239).
@@ -205,6 +348,27 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                         static_cast<int32_t>(hdr->time),
                         0.0);
                 }
+#if defined(CLAP_VERSION_GE) && CLAP_VERSION_GE(1, 1, 0)
+            } else if (hdr->type == CLAP_EVENT_MIDI2) {
+                // Native MIDI 2.0 UMP packet — append directly to the
+                // UMP sidecar when the plugin opted in. We flag
+                // host_delivered_ump so the MIDI 1.0 → UMP synthesis
+                // path below does not double-append the same voice
+                // events. CLAP_EVENT_MIDI2 is an enum value (not a
+                // #define), so we gate on CLAP_VERSION_GE(1,1,0), which
+                // is the release that introduced it.
+                if (self->ump_enabled) {
+                    auto* ev = reinterpret_cast<const clap_event_midi2_t*>(hdr);
+                    midi::UmpPacket p{};
+                    p.words[0] = ev->data[0];
+                    p.words[1] = ev->data[1];
+                    p.words[2] = ev->data[2];
+                    p.words[3] = ev->data[3];
+                    p.word_count = midi::UmpPacket::size_for_type(p.message_type());
+                    self->ump_buffer.add(p, static_cast<int32_t>(hdr->time));
+                    host_delivered_ump = true;
+                }
+#endif
             }
         }
     }
@@ -247,13 +411,25 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
         self->processor->set_mpe_input(nullptr);
     }
 
-    // UMP sidecar: until CLAP ships CLAP_EVENT_MIDI2, synthesise the UMP
-    // stream by converting the inbound MIDI 1.0 events to MIDI 2.0
-    // Channel Voice packets. Plugins that declare supports_ump see the
-    // same sample-ordered stream the host would otherwise deliver natively.
+    // UMP sidecar. Two paths, depending on what the host delivers:
+    //   1. Native: the host sent at least one CLAP_EVENT_MIDI2 this
+    //      block. Those packets were appended to self->ump_buffer during
+    //      the event loop above, so the buffer already holds the
+    //      host's authoritative UMP stream. Do NOT run the MIDI 1.0
+    //      synthesis — CLAP forbids sending the same note event as both
+    //      NOTE_* and MIDI2 (events.h note), so the NOTE_* events we
+    //      kept in midi_in for MPE/MIDI1 consumers are the
+    //      complementary half of the stream, not duplicates of UMP.
+    //   2. Fallback: the host speaks MIDI 1.0 only. Convert the
+    //      inbound CLAP_EVENT_NOTE_* / CLAP_EVENT_MIDI stream to MIDI
+    //      2.0 Channel Voice packets so supports_ump plugins see a
+    //      full-resolution view.
     if (self->ump_enabled) {
-        self->ump_buffer.clear();
-        midi::midi1_to_ump(midi_in, self->ump_buffer);
+        if (!host_delivered_ump) {
+            // Buffer was cleared up-front; populate from the MIDI 1.0
+            // stream only when the host didn't deliver native UMP.
+            midi::midi1_to_ump(midi_in, self->ump_buffer);
+        }
         self->processor->set_ump_input(&self->ump_buffer);
     } else {
         self->processor->set_ump_input(nullptr);
@@ -284,6 +460,41 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                 ev.value = static_cast<double>(current);
                 out_events->try_push(out_events, &ev.header);
             }
+        }
+
+        // Bridge processor-emitted MIDI (midi_out) back to the host.
+        // Before this loop, plugins that produced CC, pitch bend, channel
+        // aftertouch, program change, etc. had those events silently
+        // dropped by the CLAP adapter. Sort first so the host sees
+        // sample-ordered events (required by CLAP out-events contract).
+        midi_out.sort();
+        for (const auto& me : midi_out) {
+            clap_event_midi_t ev{};
+            ev.header.size = sizeof(ev);
+            ev.header.type = CLAP_EVENT_MIDI;
+            ev.header.time = static_cast<uint32_t>(
+                me.sample_offset < 0 ? 0 : me.sample_offset);
+            ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+            ev.header.flags = 0;
+            ev.port_index = 0;
+            ev.data[0] = me.data()[0];
+            ev.data[1] = me.size() > 1 ? me.data()[1] : uint8_t{0};
+            ev.data[2] = me.size() > 2 ? me.data()[2] : uint8_t{0};
+            out_events->try_push(out_events, &ev.header);
+        }
+        for (const auto& se : midi_out.sysex()) {
+            if (se.data.empty()) continue;
+            clap_event_midi_sysex_t ev{};
+            ev.header.size = sizeof(ev);
+            ev.header.type = CLAP_EVENT_MIDI_SYSEX;
+            ev.header.time = static_cast<uint32_t>(
+                se.sample_offset < 0 ? 0 : se.sample_offset);
+            ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+            ev.header.flags = 0;
+            ev.port_index = 0;
+            ev.buffer = se.data.data();
+            ev.size = static_cast<uint32_t>(se.data.size());
+            out_events->try_push(out_events, &ev.header);
         }
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -736,6 +736,15 @@ if(PULP_HAS_CLAP)
     )
     target_link_libraries(pulp-test-clap-entry PRIVATE pulp::format clap Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-clap-entry)
+
+    # CLAP inbound/outbound MIDI event coverage — pins the CLAP_EVENT_MIDI,
+    # CLAP_EVENT_NOTE_EXPRESSION, CLAP_EVENT_NOTE_CHOKE, CLAP_EVENT_MIDI2
+    # handlers added alongside feature/clap-midi-cc-coverage.
+    add_executable(pulp-test-clap-midi-events test_clap_midi_events.cpp
+        ${CMAKE_SOURCE_DIR}/core/format/src/clap_adapter.cpp
+    )
+    target_link_libraries(pulp-test-clap-midi-events PRIVATE pulp::format clap Catch2::Catch2WithMain)
+    catch_discover_tests(pulp-test-clap-midi-events)
 endif()
 
 # LV2 adapter tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -740,9 +740,17 @@ if(PULP_HAS_CLAP)
     # CLAP inbound/outbound MIDI event coverage — pins the CLAP_EVENT_MIDI,
     # CLAP_EVENT_NOTE_EXPRESSION, CLAP_EVENT_NOTE_CHOKE, CLAP_EVENT_MIDI2
     # handlers added alongside feature/clap-midi-cc-coverage.
-    add_executable(pulp-test-clap-midi-events test_clap_midi_events.cpp
-        ${CMAKE_SOURCE_DIR}/core/format/src/clap_adapter.cpp
-    )
+    #
+    # Unlike `pulp-test-clap-entry` above, this test DOES NOT re-compile
+    # clap_adapter.cpp into its own TU. The test drives the adapter via
+    # its public header surface (clap_init / clap_activate / clap_process
+    # — see core/format/include/pulp/format/clap_adapter.hpp), so linking
+    # against pulp::format is sufficient. Keeping the direct compilation
+    # out means the coverage artifact reports exactly one TU for
+    # clap_adapter.cpp (the library's), which is what CI's diff-cover
+    # gate reads — avoids the split-TU problem that produced "96% local
+    # / 62% CI" reports on PR #627.
+    add_executable(pulp-test-clap-midi-events test_clap_midi_events.cpp)
     target_link_libraries(pulp-test-clap-midi-events PRIVATE pulp::format clap Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-clap-midi-events)
 endif()

--- a/test/test_clap_midi_events.cpp
+++ b/test/test_clap_midi_events.cpp
@@ -480,6 +480,261 @@ TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION dropped when MPE not opted in",
     REQUIRE(g_capturing->captured_midi.empty());
 }
 
+// Helper: build a note-expression event with common MPE-opted-in defaults.
+namespace {
+clap_event_note_expression_t make_note_expression(uint32_t expr_id,
+                                                   uint8_t channel,
+                                                   uint8_t key,
+                                                   double value,
+                                                   uint32_t time) {
+    clap_event_note_expression_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_NOTE_EXPRESSION, time);
+    ev.expression_id = expr_id;
+    ev.note_id = -1;
+    ev.port_index = 0;
+    ev.channel = channel;
+    ev.key = key;
+    ev.value = value;
+    return ev;
+}
+
+// Locate the first MidiEvent in `captured` with the given status byte (top
+// nibble = message type, low nibble = channel).
+const midi::MidiEvent* find_status(const midi::MidiBuffer& captured,
+                                    uint8_t status_byte) {
+    for (const auto& got : captured) {
+        if (got.data()[0] == status_byte) return &got;
+    }
+    return nullptr;
+}
+} // namespace
+
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION tuning → pitch bend when MPE opted in",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = true;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    // 1 semitone of tuning; default member-bend range is ±48 semitones, so
+    // norm = 1.0/48 ≈ 0.02083 → bend14 ≈ 8192 + 0.02083*8191 = 8363.67 →
+    // rounded to 8364 → low 7 bits = 0x2C, high 7 bits = 0x41.
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_TUNING, /*channel*/2, /*key*/64,
+        /*value*/1.0, /*time*/9));
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    const auto* pb = find_status(g_capturing->captured_midi, 0xE2);
+    REQUIRE(pb != nullptr);
+    REQUIRE(pb->is_pitch_bend());
+    REQUIRE(pb->channel() == 2);
+    REQUIRE(pb->sample_offset == 9);
+    // Center is 8192; 1 semitone over a ±48st range should round to a
+    // specific 14-bit value — pin it so a regression in the scaling
+    // constant is caught loudly.
+    const int bend14 = pb->data()[1] | (pb->data()[2] << 7);
+    REQUIRE(bend14 == 8363);  // lround(8192 + (1.0/48.0) * 8191.0)
+}
+
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION tuning clamps huge positive value to +max",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = true;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    // 200 semitones is far past the ±48st member-bend range; should
+    // clamp to bend14 = 16383 (data[1]=0x7F, data[2]=0x7F).
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_TUNING, /*channel*/0, /*key*/60,
+        /*value*/200.0, /*time*/0));
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    const auto* pb = find_status(g_capturing->captured_midi, 0xE0);
+    REQUIRE(pb != nullptr);
+    REQUIRE(pb->is_pitch_bend());
+    REQUIRE(pb->data()[1] == 0x7F);
+    REQUIRE(pb->data()[2] == 0x7F);
+}
+
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION brightness → CC 74 when MPE opted in",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = true;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    // value 1.0 → v7 = round(1.0 * 127) = 127.
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_BRIGHTNESS, /*channel*/3, /*key*/60,
+        /*value*/1.0, /*time*/7));
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    const auto* cc = find_status(g_capturing->captured_midi, 0xB3);
+    REQUIRE(cc != nullptr);
+    REQUIRE(cc->is_cc());
+    REQUIRE(cc->channel() == 3);
+    REQUIRE(cc->cc_number() == 74);
+    REQUIRE(cc->cc_value() == 127);
+    REQUIRE(cc->sample_offset == 7);
+}
+
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION brightness clamps negative to 0",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = true;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_BRIGHTNESS, /*channel*/0, /*key*/60,
+        /*value*/-0.5, /*time*/0));
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    const auto* cc = find_status(g_capturing->captured_midi, 0xB0);
+    REQUIRE(cc != nullptr);
+    REQUIRE(cc->cc_number() == 74);
+    REQUIRE(cc->cc_value() == 0);
+}
+
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION volume → CC 7 with 0..4 → 0..127 scaling",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = true;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    // value 2.0 (half of max=4) → v7 = round(0.5 * 127) = 64.
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_VOLUME, /*channel*/4, /*key*/60,
+        /*value*/2.0, /*time*/3));
+    // value 4.0 (max) → 127.
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_VOLUME, /*channel*/4, /*key*/60,
+        /*value*/4.0, /*time*/4));
+    // value 10.0 should clamp to 4 → v7 = 127.
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_VOLUME, /*channel*/4, /*key*/60,
+        /*value*/10.0, /*time*/5));
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+
+    // Collect all CC 7 / channel 4 events.
+    std::vector<const midi::MidiEvent*> cc7;
+    for (const auto& got : g_capturing->captured_midi) {
+        if (got.data()[0] == 0xB4 && got.data()[1] == 7) cc7.push_back(&got);
+    }
+    REQUIRE(cc7.size() == 3);
+    REQUIRE(cc7[0]->cc_value() == 64);
+    REQUIRE(cc7[0]->sample_offset == 3);
+    REQUIRE(cc7[1]->cc_value() == 127);
+    REQUIRE(cc7[1]->sample_offset == 4);
+    REQUIRE(cc7[2]->cc_value() == 127);  // clamped
+}
+
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION pan → CC 10 with 0..1 → 0..127 scaling",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = true;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    // value 0.5 → v7 = round(0.5 * 127 + 0.5) = 64.
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_PAN, /*channel*/5, /*key*/60,
+        /*value*/0.5, /*time*/14));
+    // value 0 → 0, extreme-left.
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_PAN, /*channel*/5, /*key*/60,
+        /*value*/0.0, /*time*/15));
+    // value 1.0 → 127, extreme-right.
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_PAN, /*channel*/5, /*key*/60,
+        /*value*/1.0, /*time*/16));
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+
+    std::vector<const midi::MidiEvent*> cc10;
+    for (const auto& got : g_capturing->captured_midi) {
+        if (got.data()[0] == 0xB5 && got.data()[1] == 10) cc10.push_back(&got);
+    }
+    REQUIRE(cc10.size() == 3);
+    REQUIRE(cc10[0]->cc_value() == 64);
+    REQUIRE(cc10[1]->cc_value() == 0);
+    REQUIRE(cc10[2]->cc_value() == 127);
+}
+
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION vibrato / expression dropped silently when MPE opted in",
+          "[clap][midi][issue-pending]") {
+    // Covers the default-arm of the expression switch: vibrato and
+    // expression IDs leave `emitted = false`, so no MIDI event is added
+    // to midi_in even though MPE is opted in.
+    g_pending_opts_mpe = true;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_VIBRATO, /*channel*/0, /*key*/60,
+        /*value*/0.5, /*time*/0));
+    events.push(make_note_expression(
+        CLAP_NOTE_EXPRESSION_EXPRESSION, /*channel*/0, /*key*/60,
+        /*value*/0.5, /*time*/1));
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    // No MIDI event should have been added from either expression.
+    REQUIRE(g_capturing->captured_midi.empty());
+}
+
+// ── Inbound: CLAP_EVENT_MIDI_SYSEX ──────────────────────────────────────
+
+TEST_CASE("CLAP_EVENT_MIDI_SYSEX decodes into MidiBuffer sysex sidecar",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    static const uint8_t kPayload[] = {0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7};
+    InputEventList events;
+    clap_event_midi_sysex_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI_SYSEX, 21);
+    ev.port_index = 0;
+    ev.buffer = kPayload;
+    ev.size = sizeof(kPayload);
+    events.push(ev);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    // The sysex stream survives as a sidecar entry on MidiBuffer.
+    REQUIRE(g_capturing->captured_midi.sysex().size() == 1);
+    const auto& sx = g_capturing->captured_midi.sysex()[0];
+    REQUIRE(sx.sample_offset == 21);
+    REQUIRE(sx.data.size() == sizeof(kPayload));
+    for (std::size_t i = 0; i < sx.data.size(); ++i) {
+        REQUIRE(sx.data[i] == kPayload[i]);
+    }
+}
+
+TEST_CASE("CLAP_EVENT_MIDI_SYSEX with empty payload is dropped",
+          "[clap][midi][issue-pending]") {
+    // Covers the `ev->buffer && ev->size > 0` guard — a zero-length or
+    // null-buffer sysex must NOT be added to the sidecar.
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    clap_event_midi_sysex_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI_SYSEX, 5);
+    ev.port_index = 0;
+    ev.buffer = nullptr;
+    ev.size = 0;
+    events.push(ev);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    REQUIRE(g_capturing->captured_midi.sysex().empty());
+    REQUIRE(g_capturing->captured_midi.empty());
+}
+
 // ── Inbound: CLAP_EVENT_MIDI2 ───────────────────────────────────────────
 
 #if defined(CLAP_VERSION_GE) && CLAP_VERSION_GE(1, 1, 0)
@@ -511,6 +766,116 @@ TEST_CASE("CLAP_EVENT_MIDI2 routed straight to UMP sidecar when opted in",
     REQUIRE(got.packet.channel() == 1);
     REQUIRE(got.packet.note_number() == 60);
     REQUIRE(got.packet.velocity_16() == 0xFFFF);
+}
+
+TEST_CASE("CLAP_EVENT_MIDI2 skips MIDI 1.0 → UMP synthesis when host is native",
+          "[clap][midi][issue-pending]") {
+    // If the host delivers even one CLAP_EVENT_MIDI2, the adapter must
+    // NOT also run midi1_to_ump over the NOTE_ON stream. Otherwise the
+    // plugin would see two UMP packets for a single voice event. The
+    // native MIDI2 packet is the authoritative source, and any NOTE_*
+    // events co-delivered by the host are complementary (for MIDI 1.0
+    // consumers), not duplicates.
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = true;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    // One native MIDI2 note-on packet.
+    auto packet = midi::UmpPacket::note_on_2(/*group*/0, /*channel*/0,
+                                              /*note*/72, /*vel16*/0x8000);
+    clap_event_midi2_t e2{};
+    e2.header = make_header(sizeof(e2), CLAP_EVENT_MIDI2, 1);
+    e2.port_index = 0;
+    e2.data[0] = packet.words[0];
+    e2.data[1] = packet.words[1];
+    e2.data[2] = 0;
+    e2.data[3] = 0;
+    events.push(e2);
+    // Plus a co-delivered CLAP_EVENT_NOTE_ON (MIDI 1.0 path).
+    clap_event_note_t en{};
+    en.header = make_header(sizeof(en), CLAP_EVENT_NOTE_ON, 1);
+    en.note_id = -1;
+    en.port_index = 0;
+    en.channel = 0;
+    en.key = 72;
+    en.velocity = 1.0;
+    events.push(en);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    // UMP sidecar must contain EXACTLY the native packet — not two
+    // copies (native + synthesised from the MIDI 1.0 NOTE_ON).
+    REQUIRE(g_capturing->had_ump_input);
+    REQUIRE(g_capturing->captured_ump.size() == 1);
+    REQUIRE(g_capturing->captured_ump[0].sample_offset == 1);
+    REQUIRE(g_capturing->captured_ump[0].packet.velocity_16() == 0x8000);
+    // The NOTE_ON still reaches midi_in for MIDI 1.0 consumers / MPE.
+    REQUIRE(g_capturing->captured_midi.size() == 1);
+    REQUIRE(g_capturing->captured_midi[0].is_note_on());
+    REQUIRE(g_capturing->captured_midi[0].note() == 72);
+}
+
+TEST_CASE("UMP sidecar is cleared on every process() when opted in",
+          "[clap][midi][issue-pending]") {
+    // A block with a native MIDI2 packet leaves ump_buffer holding one
+    // entry; the next block must start from an empty buffer so the
+    // plugin doesn't see stale data. This pins the
+    // `if (self->ump_enabled) self->ump_buffer.clear();` line at the
+    // top of each process() call.
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = true;
+    Harness h(make_capturing);
+
+    // Block 1: deliver a native MIDI2 note-on.
+    {
+        InputEventList events;
+        auto packet = midi::UmpPacket::note_on_2(
+            /*group*/0, /*channel*/2, /*note*/60, /*vel16*/0x4000);
+        clap_event_midi2_t ev{};
+        ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI2, 0);
+        ev.port_index = 0;
+        ev.data[0] = packet.words[0];
+        ev.data[1] = packet.words[1];
+        ev.data[2] = 0;
+        ev.data[3] = 0;
+        events.push(ev);
+        REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+        REQUIRE(g_capturing->captured_ump.size() == 1);
+    }
+    // Block 2: deliver nothing. The UMP sidecar should be empty — the
+    // previous packet must not leak through.
+    {
+        InputEventList events;
+        REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+        REQUIRE(g_capturing->had_ump_input);
+        REQUIRE(g_capturing->captured_ump.empty());
+    }
+}
+
+TEST_CASE("CLAP_EVENT_MIDI2 dropped when plugin did not opt in to UMP",
+          "[clap][midi][issue-pending]") {
+    // Pins the `if (self->ump_enabled)` guard on the MIDI2 branch.
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    auto packet = midi::UmpPacket::note_on_2(
+        /*group*/0, /*channel*/0, /*note*/60, /*vel16*/0xFFFF);
+    clap_event_midi2_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI2, 0);
+    ev.port_index = 0;
+    ev.data[0] = packet.words[0];
+    ev.data[1] = packet.words[1];
+    ev.data[2] = 0;
+    ev.data[3] = 0;
+    events.push(ev);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    // Plugin didn't opt in — no UMP sidecar exposed, packet is dropped.
+    REQUIRE_FALSE(g_capturing->had_ump_input);
+    REQUIRE(g_capturing->captured_ump.empty());
+    REQUIRE(g_capturing->captured_midi.empty());
 }
 #endif
 
@@ -567,4 +932,54 @@ TEST_CASE("midi_out sysex surfaces on CLAP out_events",
     REQUIRE(sysexes[0]->size == 5);
     REQUIRE(sysexes[0]->buffer[0] == 0xF0);
     REQUIRE(sysexes[0]->buffer[4] == 0xF7);
+}
+
+TEST_CASE("midi_out program change (2-byte) clamps size padding on CLAP out_events",
+          "[clap][midi][issue-pending]") {
+    // Covers the `me.size() > 2 ? ... : uint8_t{0}` padding branch of
+    // the outbound short-message loop — a 2-byte message like program
+    // change must still write a zero into data[2].
+    g_pending_emit.clear();
+    g_pending_sysex.clear();
+    auto pc = midi::MidiEvent::program_change(/*ch*/1, /*program*/42);
+    pc.sample_offset = 8;
+    g_pending_emit = {pc};
+
+    Harness h(make_emitting);
+    InputEventList in;
+    OutputEventList out;
+    REQUIRE(h.run(in, &out) == CLAP_PROCESS_CONTINUE);
+
+    auto midis = out.by_type<clap_event_midi_t>(CLAP_EVENT_MIDI);
+    REQUIRE(midis.size() == 1);
+    REQUIRE(midis[0]->header.time == 8);
+    REQUIRE(midis[0]->data[0] == 0xC1);
+    REQUIRE(midis[0]->data[1] == 42);
+    REQUIRE(midis[0]->data[2] == 0);
+}
+
+TEST_CASE("midi_out empty sysex payload is skipped on CLAP out_events",
+          "[clap][midi][issue-pending]") {
+    // Covers the `if (se.data.empty()) continue;` guard in the outbound
+    // sysex loop.
+    g_pending_emit.clear();
+    g_pending_sysex.clear();
+    midi::MidiBuffer::SysexEvent empty_se;
+    empty_se.data = {};
+    empty_se.sample_offset = 3;
+    midi::MidiBuffer::SysexEvent real_se;
+    real_se.data = {0xF0, 0x7E, 0xF7};
+    real_se.sample_offset = 4;
+    g_pending_sysex = {empty_se, real_se};
+
+    Harness h(make_emitting);
+    InputEventList in;
+    OutputEventList out;
+    REQUIRE(h.run(in, &out) == CLAP_PROCESS_CONTINUE);
+
+    // The empty entry is dropped; only the non-empty one surfaces.
+    auto sysexes = out.by_type<clap_event_midi_sysex_t>(CLAP_EVENT_MIDI_SYSEX);
+    REQUIRE(sysexes.size() == 1);
+    REQUIRE(sysexes[0]->size == 3);
+    REQUIRE(sysexes[0]->header.time == 4);
 }

--- a/test/test_clap_midi_events.cpp
+++ b/test/test_clap_midi_events.cpp
@@ -1,0 +1,570 @@
+// CLAP adapter inbound/outbound MIDI event coverage (issue-pending).
+//
+// This suite pins the behaviour added alongside
+// feature/clap-midi-cc-coverage:
+//
+//   Inbound:
+//     - CLAP_EVENT_MIDI    — CC, pitch bend, channel/poly aftertouch,
+//                            program change decoded into MidiBuffer.
+//     - CLAP_EVENT_NOTE_EXPRESSION
+//                           — mapped to channel aftertouch / pitch
+//                             bend / CC when the plugin opted in to
+//                             MPE; dropped otherwise.
+//     - CLAP_EVENT_NOTE_CHOKE
+//                           — synthesised as a zero-velocity note-off
+//                             at the event's sample offset.
+//     - CLAP_EVENT_MIDI2    — routed straight to the UMP sidecar when
+//                             the plugin opted in to UMP.
+//   Outbound:
+//     - midi_out → CLAP_EVENT_MIDI on out_events.
+//     - midi_out sysex → CLAP_EVENT_MIDI_SYSEX on out_events.
+//
+// The tests build an in-memory clap_input_events_t / clap_output_events_t
+// with vtables, drive pulp::format::clap_adapter::clap_process(), and
+// assert that the TestProcessor saw the MIDI event (or that the output
+// stream captured the right bytes). No real DAW or shared library is
+// needed.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/format/clap_adapter.hpp>
+#include <pulp/format/clap_entry.hpp>
+#include <pulp/format/processor.hpp>
+#include <pulp/midi/buffer.hpp>
+#include <pulp/midi/message.hpp>
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+using namespace pulp;
+using namespace pulp::format;
+
+namespace {
+
+// ── Event-stream helpers ────────────────────────────────────────────────
+
+// Heterogeneous event stream that copies the full CLAP struct payload into
+// a contiguous byte vector, so the `clap_input_events_t` get() vtable can
+// hand back stable pointers to each event header.
+class InputEventList {
+public:
+    template <typename Event>
+    void push(const Event& e) {
+        const auto offset = storage_.size();
+        storage_.resize(offset + sizeof(Event));
+        std::memcpy(storage_.data() + offset, &e, sizeof(Event));
+        offsets_.push_back(offset);
+    }
+
+    clap_input_events_t make_vtable() {
+        vtable_.ctx = this;
+        vtable_.size = [](const clap_input_events_t* list) -> uint32_t {
+            auto* self = static_cast<InputEventList*>(list->ctx);
+            return static_cast<uint32_t>(self->offsets_.size());
+        };
+        vtable_.get = [](const clap_input_events_t* list, uint32_t idx)
+            -> const clap_event_header_t* {
+            auto* self = static_cast<InputEventList*>(list->ctx);
+            return reinterpret_cast<const clap_event_header_t*>(
+                self->storage_.data() + self->offsets_[idx]);
+        };
+        return vtable_;
+    }
+
+private:
+    std::vector<std::uint8_t> storage_;
+    std::vector<std::size_t> offsets_;
+    clap_input_events_t vtable_{};
+};
+
+// Collects the pushed CLAP events as raw byte copies so the test can walk
+// back over them after clap_process() returns. Sysex bodies are copied
+// into `sysex_bodies_` and the stored event header's `buffer` pointer is
+// rebased to point at that copy, mirroring what a real host's try_push()
+// does — otherwise the adapter's local MidiBuffer data would be freed by
+// the time the test inspects the event.
+class OutputEventList {
+public:
+    clap_output_events_t make_vtable() {
+        vtable_.ctx = this;
+        vtable_.try_push = [](const clap_output_events_t* list,
+                              const clap_event_header_t* hdr) -> bool {
+            auto* self = static_cast<OutputEventList*>(list->ctx);
+            std::vector<std::uint8_t> buf(hdr->size);
+            std::memcpy(buf.data(), hdr, hdr->size);
+            if (hdr->type == CLAP_EVENT_MIDI_SYSEX) {
+                auto* sx = reinterpret_cast<const clap_event_midi_sysex_t*>(hdr);
+                std::vector<std::uint8_t> body(sx->buffer, sx->buffer + sx->size);
+                self->sysex_bodies_.push_back(std::move(body));
+                auto* stored = reinterpret_cast<clap_event_midi_sysex_t*>(buf.data());
+                stored->buffer = self->sysex_bodies_.back().data();
+            }
+            self->events_.push_back(std::move(buf));
+            return true;
+        };
+        return vtable_;
+    }
+
+    std::size_t size() const { return events_.size(); }
+    const clap_event_header_t* at(std::size_t i) const {
+        return reinterpret_cast<const clap_event_header_t*>(events_[i].data());
+    }
+
+    // Filter by type.
+    template <typename Event>
+    std::vector<const Event*> by_type(uint16_t type) const {
+        std::vector<const Event*> out;
+        for (const auto& buf : events_) {
+            auto* h = reinterpret_cast<const clap_event_header_t*>(buf.data());
+            if (h->type == type) {
+                out.push_back(reinterpret_cast<const Event*>(buf.data()));
+            }
+        }
+        return out;
+    }
+
+private:
+    std::vector<std::vector<std::uint8_t>> events_;
+    // Owns the copied sysex payloads so their pointers stay valid for the
+    // lifetime of the OutputEventList. Must be declared before events_ is
+    // resized via push_back to avoid invalidation — plain vector<vector>
+    // reallocates on growth, so we reserve() in the ctor.
+    std::vector<std::vector<std::uint8_t>> sysex_bodies_;
+    clap_output_events_t vtable_{};
+
+public:
+    OutputEventList() { sysex_bodies_.reserve(16); events_.reserve(64); }
+};
+
+// ── Test processors ─────────────────────────────────────────────────────
+
+// Captures midi_in so the test can assert what the CLAP adapter handed up.
+class CapturingProcessor : public Processor {
+public:
+    bool opts_mpe = false;
+    bool opts_ump = false;
+
+    // Mutable state captured each time process() runs.
+    mutable midi::MidiBuffer captured_midi;
+    mutable std::vector<midi::UmpEvent> captured_ump;
+    mutable bool had_mpe_input = false;
+    mutable bool had_ump_input = false;
+
+    PluginDescriptor descriptor() const override {
+        PluginDescriptor d;
+        d.name = "CapturingCLAP";
+        d.manufacturer = "PulpTest";
+        d.bundle_id = "com.pulp.test.clap.capture";
+        d.version = "1.0.0";
+        d.accepts_midi = true;
+        d.supports_mpe = opts_mpe;
+        d.supports_ump = opts_ump;
+        return d;
+    }
+    void define_parameters(state::StateStore&) override {}
+    void prepare(const PrepareContext&) override {}
+    void process(audio::BufferView<float>&,
+                 const audio::BufferView<const float>&,
+                 midi::MidiBuffer& midi_in,
+                 midi::MidiBuffer&,
+                 const ProcessContext&) override {
+        captured_midi.clear();
+        for (const auto& ev : midi_in) captured_midi.add(ev);
+        for (const auto& se : midi_in.sysex()) {
+            captured_midi.add_sysex(se.data, se.sample_offset, se.timestamp);
+        }
+        had_mpe_input = (mpe_input() != nullptr);
+        had_ump_input = (ump_input() != nullptr);
+        captured_ump.clear();
+        if (auto* ump = ump_input()) {
+            for (const auto& e : *ump) captured_ump.push_back(e);
+        }
+    }
+};
+
+// Emits a pre-programmed set of MIDI events on midi_out so we can test
+// the outbound bridge.
+class EmittingProcessor : public Processor {
+public:
+    std::vector<midi::MidiEvent> to_emit;
+    std::vector<midi::MidiBuffer::SysexEvent> sysex_to_emit;
+
+    PluginDescriptor descriptor() const override {
+        PluginDescriptor d;
+        d.name = "EmittingCLAP";
+        d.manufacturer = "PulpTest";
+        d.bundle_id = "com.pulp.test.clap.emit";
+        d.version = "1.0.0";
+        d.produces_midi = true;
+        return d;
+    }
+    void define_parameters(state::StateStore&) override {}
+    void prepare(const PrepareContext&) override {}
+    void process(audio::BufferView<float>&,
+                 const audio::BufferView<const float>&,
+                 midi::MidiBuffer&,
+                 midi::MidiBuffer& midi_out,
+                 const ProcessContext&) override {
+        for (const auto& ev : to_emit) midi_out.add(ev);
+        for (const auto& se : sysex_to_emit) {
+            midi_out.add_sysex(se.data, se.sample_offset, se.timestamp);
+        }
+    }
+};
+
+// Processor factory hooks have to be raw function pointers. Route through
+// singletons so the tests can configure the active processor before the
+// adapter instantiates one.
+CapturingProcessor* g_capturing = nullptr;
+EmittingProcessor*  g_emitting  = nullptr;
+bool g_pending_opts_mpe = false;
+bool g_pending_opts_ump = false;
+std::vector<midi::MidiEvent> g_pending_emit;
+std::vector<midi::MidiBuffer::SysexEvent> g_pending_sysex;
+
+std::unique_ptr<Processor> make_capturing() {
+    auto up = std::make_unique<CapturingProcessor>();
+    g_capturing = up.get();
+    if (g_pending_opts_mpe) up->opts_mpe = true;
+    if (g_pending_opts_ump) up->opts_ump = true;
+    return up;
+}
+
+std::unique_ptr<Processor> make_emitting() {
+    auto up = std::make_unique<EmittingProcessor>();
+    g_emitting = up.get();
+    if (!g_pending_emit.empty()) up->to_emit = g_pending_emit;
+    if (!g_pending_sysex.empty()) up->sysex_to_emit = g_pending_sysex;
+    return up;
+}
+
+// ── Driver: spin up a PulpClapPlugin, run one process block ─────────────
+
+struct Harness {
+    static constexpr uint32_t kFrames = 64;
+    static constexpr int      kChannels = 2;
+
+    clap_adapter::PulpClapPlugin plugin;
+    std::vector<float> in_left, in_right;
+    std::vector<float> out_left, out_right;
+    const float* in_ptrs[2]{};
+    float* out_ptrs[2]{};
+    clap_audio_buffer_t audio_in{}, audio_out{};
+
+    explicit Harness(ProcessorFactory factory) {
+        plugin.factory = factory;
+        plugin.plugin.plugin_data = &plugin;
+        REQUIRE(clap_adapter::clap_init(&plugin.plugin));
+        REQUIRE(clap_adapter::clap_activate(&plugin.plugin, 48000.0, 32, kFrames));
+        in_left.assign(kFrames, 0.0f);
+        in_right.assign(kFrames, 0.0f);
+        out_left.assign(kFrames, 0.0f);
+        out_right.assign(kFrames, 0.0f);
+        in_ptrs[0] = in_left.data();
+        in_ptrs[1] = in_right.data();
+        out_ptrs[0] = out_left.data();
+        out_ptrs[1] = out_right.data();
+        audio_in.data32 = const_cast<float**>(in_ptrs);
+        audio_in.channel_count = kChannels;
+        audio_out.data32 = out_ptrs;
+        audio_out.channel_count = kChannels;
+    }
+
+    ~Harness() {
+        clap_adapter::clap_deactivate(&plugin.plugin);
+    }
+
+    clap_process_status run(InputEventList& in_list,
+                            OutputEventList* out_list = nullptr) {
+        clap_input_events_t in_vt = in_list.make_vtable();
+        clap_output_events_t out_vt{};
+        if (out_list) out_vt = out_list->make_vtable();
+
+        clap_process_t proc{};
+        proc.frames_count = kFrames;
+        proc.audio_inputs = &audio_in;
+        proc.audio_inputs_count = 1;
+        proc.audio_outputs = &audio_out;
+        proc.audio_outputs_count = 1;
+        proc.in_events = &in_vt;
+        proc.out_events = out_list ? &out_vt : nullptr;
+        return clap_adapter::clap_process(&plugin.plugin, &proc);
+    }
+};
+
+clap_event_header_t make_header(uint32_t size, uint16_t type, uint32_t time) {
+    clap_event_header_t h{};
+    h.size = size;
+    h.type = type;
+    h.time = time;
+    h.space_id = CLAP_CORE_EVENT_SPACE_ID;
+    h.flags = 0;
+    return h;
+}
+
+} // namespace
+
+// ── Inbound: CLAP_EVENT_MIDI ────────────────────────────────────────────
+
+TEST_CASE("CLAP_EVENT_MIDI decodes CC into MidiBuffer",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+    REQUIRE(g_capturing != nullptr);
+
+    InputEventList events;
+    clap_event_midi_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI, 17);
+    ev.port_index = 0;
+    ev.data[0] = 0xB1;  // CC on channel 1
+    ev.data[1] = 74;    // Brightness
+    ev.data[2] = 99;
+    events.push(ev);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    REQUIRE(g_capturing->captured_midi.size() == 1);
+    const auto& got = g_capturing->captured_midi[0];
+    REQUIRE(got.is_cc());
+    REQUIRE(got.channel() == 1);
+    REQUIRE(got.cc_number() == 74);
+    REQUIRE(got.cc_value() == 99);
+    REQUIRE(got.sample_offset == 17);
+}
+
+TEST_CASE("CLAP_EVENT_MIDI decodes pitch bend, program change, poly AT, channel AT",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    // Pitch bend: channel 2, value 0x3FFF (roughly +max).
+    clap_event_midi_t pb{};
+    pb.header = make_header(sizeof(pb), CLAP_EVENT_MIDI, 4);
+    pb.data[0] = 0xE2;
+    pb.data[1] = 0x7F;  // LSB
+    pb.data[2] = 0x7F;  // MSB
+    events.push(pb);
+    // Program change.
+    clap_event_midi_t pc{};
+    pc.header = make_header(sizeof(pc), CLAP_EVENT_MIDI, 5);
+    pc.data[0] = 0xC3;
+    pc.data[1] = 42;
+    pc.data[2] = 0;
+    events.push(pc);
+    // Poly aftertouch: key 60 value 77 on channel 4.
+    clap_event_midi_t poly{};
+    poly.header = make_header(sizeof(poly), CLAP_EVENT_MIDI, 6);
+    poly.data[0] = 0xA4;
+    poly.data[1] = 60;
+    poly.data[2] = 77;
+    events.push(poly);
+    // Channel pressure: value 33 on channel 5.
+    clap_event_midi_t chat{};
+    chat.header = make_header(sizeof(chat), CLAP_EVENT_MIDI, 7);
+    chat.data[0] = 0xD5;
+    chat.data[1] = 33;
+    chat.data[2] = 0;
+    events.push(chat);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    REQUIRE(g_capturing->captured_midi.size() == 4);
+
+    const auto& gp = g_capturing->captured_midi[0];
+    REQUIRE(gp.is_pitch_bend());
+    REQUIRE(gp.channel() == 2);
+    REQUIRE(gp.sample_offset == 4);
+    REQUIRE(gp.data()[1] == 0x7F);
+    REQUIRE(gp.data()[2] == 0x7F);
+
+    const auto& gpc = g_capturing->captured_midi[1];
+    REQUIRE(gpc.is_program_change());
+    REQUIRE(gpc.channel() == 3);
+    REQUIRE(gpc.data()[1] == 42);
+
+    const auto& gpoly = g_capturing->captured_midi[2];
+    REQUIRE(gpoly.channel() == 4);
+    REQUIRE(gpoly.data()[0] == 0xA4);
+    REQUIRE(gpoly.data()[1] == 60);
+    REQUIRE(gpoly.data()[2] == 77);
+
+    const auto& gchat = g_capturing->captured_midi[3];
+    REQUIRE(gchat.channel() == 5);
+    REQUIRE(gchat.data()[0] == 0xD5);
+    REQUIRE(gchat.data()[1] == 33);
+}
+
+// ── Inbound: CLAP_EVENT_NOTE_CHOKE ──────────────────────────────────────
+
+TEST_CASE("CLAP_EVENT_NOTE_CHOKE synthesises a zero-velocity note-off",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    clap_event_note_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_NOTE_CHOKE, 23);
+    ev.note_id = -1;
+    ev.port_index = 0;
+    ev.channel = 3;
+    ev.key = 64;
+    ev.velocity = 0.0;  // spec-ignored
+    events.push(ev);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    REQUIRE(g_capturing->captured_midi.size() == 1);
+    const auto& got = g_capturing->captured_midi[0];
+    REQUIRE(got.is_note_off());
+    REQUIRE(got.channel() == 3);
+    REQUIRE(got.note() == 64);
+    REQUIRE(got.velocity() == 0);
+    REQUIRE(got.sample_offset == 23);
+}
+
+// ── Inbound: CLAP_EVENT_NOTE_EXPRESSION ─────────────────────────────────
+
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION pressure → channel-AT when MPE opted in",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = true;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    clap_event_note_expression_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_NOTE_EXPRESSION, 11);
+    ev.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
+    ev.note_id = -1;
+    ev.port_index = 0;
+    ev.channel = 2;
+    ev.key = 72;
+    ev.value = 0.5;   // → roughly 64/127
+    events.push(ev);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    // After the MPE tracker runs, midi_in still contains the synthesised
+    // channel-AT message (we deliberately don't consume it). Check for it.
+    bool found = false;
+    for (const auto& got : g_capturing->captured_midi) {
+        if (got.data()[0] == 0xD2) {
+            REQUIRE(got.sample_offset == 11);
+            // 0.5 → 64 (rounded).
+            REQUIRE(got.data()[1] == 64);
+            found = true;
+        }
+    }
+    REQUIRE(found);
+}
+
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION dropped when MPE not opted in",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = false;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    clap_event_note_expression_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_NOTE_EXPRESSION, 3);
+    ev.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
+    ev.note_id = -1;
+    ev.port_index = 0;
+    ev.channel = 0;
+    ev.key = 60;
+    ev.value = 0.5;
+    events.push(ev);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    // Plugin opted out of MPE — adapter should drop the expression.
+    REQUIRE(g_capturing->captured_midi.empty());
+}
+
+// ── Inbound: CLAP_EVENT_MIDI2 ───────────────────────────────────────────
+
+#if defined(CLAP_VERSION_GE) && CLAP_VERSION_GE(1, 1, 0)
+TEST_CASE("CLAP_EVENT_MIDI2 routed straight to UMP sidecar when opted in",
+          "[clap][midi][issue-pending]") {
+    g_pending_opts_mpe = false;
+    g_pending_opts_ump = true;
+    Harness h(make_capturing);
+
+    InputEventList events;
+    // Build a MIDI 2.0 note-on UMP packet; velocity = 0xFFFF.
+    auto packet = midi::UmpPacket::note_on_2(/*group*/0, /*channel*/1,
+                                              /*note*/60, /*vel16*/0xFFFF);
+    clap_event_midi2_t ev{};
+    ev.header = make_header(sizeof(ev), CLAP_EVENT_MIDI2, 13);
+    ev.port_index = 0;
+    ev.data[0] = packet.words[0];
+    ev.data[1] = packet.words[1];
+    ev.data[2] = 0;
+    ev.data[3] = 0;
+    events.push(ev);
+
+    REQUIRE(h.run(events) == CLAP_PROCESS_CONTINUE);
+    REQUIRE(g_capturing->had_ump_input);
+    REQUIRE(g_capturing->captured_ump.size() == 1);
+    const auto& got = g_capturing->captured_ump[0];
+    REQUIRE(got.sample_offset == 13);
+    REQUIRE(got.packet.message_type() == midi::UmpMessageType::Midi2ChannelVoice);
+    REQUIRE(got.packet.channel() == 1);
+    REQUIRE(got.packet.note_number() == 60);
+    REQUIRE(got.packet.velocity_16() == 0xFFFF);
+}
+#endif
+
+// ── Outbound: midi_out → CLAP_EVENT_MIDI / SYSEX ────────────────────────
+
+TEST_CASE("midi_out CC + pitch-bend surface on CLAP out_events",
+          "[clap][midi][issue-pending]") {
+    g_pending_emit.clear();
+    g_pending_sysex.clear();
+    auto cc = midi::MidiEvent::cc(/*ch*/0, /*num*/7, /*val*/100);
+    cc.sample_offset = 12;
+    auto pb = midi::MidiEvent::pitch_bend(/*ch*/0, /*val*/12345);
+    pb.sample_offset = 20;
+    g_pending_emit = {cc, pb};
+
+    Harness h(make_emitting);
+    InputEventList in;
+    OutputEventList out;
+    REQUIRE(h.run(in, &out) == CLAP_PROCESS_CONTINUE);
+
+    auto midis = out.by_type<clap_event_midi_t>(CLAP_EVENT_MIDI);
+    REQUIRE(midis.size() == 2);
+
+    // Sort guarantee — sample_offset ascending.
+    REQUIRE(midis[0]->header.time == 12);
+    REQUIRE(midis[0]->data[0] == 0xB0);
+    REQUIRE(midis[0]->data[1] == 7);
+    REQUIRE(midis[0]->data[2] == 100);
+
+    REQUIRE(midis[1]->header.time == 20);
+    REQUIRE(midis[1]->data[0] == 0xE0);
+    // pitch bend low = value & 0x7F, high = (value >> 7) & 0x7F
+    REQUIRE(midis[1]->data[1] == (12345 & 0x7F));
+    REQUIRE(midis[1]->data[2] == ((12345 >> 7) & 0x7F));
+}
+
+TEST_CASE("midi_out sysex surfaces on CLAP out_events",
+          "[clap][midi][issue-pending]") {
+    g_pending_emit.clear();
+    g_pending_sysex.clear();
+    midi::MidiBuffer::SysexEvent se;
+    se.data = {0xF0, 0x7D, 0x01, 0x02, 0xF7};
+    se.sample_offset = 5;
+    g_pending_sysex = {se};
+
+    Harness h(make_emitting);
+    InputEventList in;
+    OutputEventList out;
+    REQUIRE(h.run(in, &out) == CLAP_PROCESS_CONTINUE);
+
+    auto sysexes = out.by_type<clap_event_midi_sysex_t>(CLAP_EVENT_MIDI_SYSEX);
+    REQUIRE(sysexes.size() == 1);
+    REQUIRE(sysexes[0]->header.time == 5);
+    REQUIRE(sysexes[0]->size == 5);
+    REQUIRE(sysexes[0]->buffer[0] == 0xF0);
+    REQUIRE(sysexes[0]->buffer[4] == 0xF7);
+}


### PR DESCRIPTION
The CLAP adapter only handled CLAP_EVENT_NOTE_ON / NOTE_OFF /
MIDI_SYSEX inbound and CLAP_EVENT_PARAM_VALUE outbound. Almost every
DAW sends CC, pitch bend, program change, channel AT, and poly AT
via CLAP_EVENT_MIDI rather than CLAP's native note events, so those
messages were silently dropped on the way in. Per-note expression
and note-choke were likewise ignored. Outbound MIDI generated by
MIDI-effect plugins (midi_out) never reached the host at all.

Inbound additions (all respecting hdr->time as sample_offset):
  - CLAP_EVENT_MIDI        — decoded into midi_in as a 3-byte
                              choc::midi::ShortMessage; covers CC,
                              pitch bend, channel/poly aftertouch,
                              and program change.
  - CLAP_EVENT_NOTE_EXPRESSION
                            — routed through MPE when the plugin set
                              supports_mpe. PRESSURE → channel AT,
                              TUNING → pitch bend (normalised to the
                              default ±48st member bend), BRIGHTNESS
                              → CC 74, VOLUME → CC 7, PAN → CC 10.
                              Plugins that opted out of MPE see a
                              one-time debug log and no MIDI 1.0
                              synthesis (the collapse onto a shared
                              channel would misroute voices).
  - CLAP_EVENT_NOTE_CHOKE  — synthesised as a zero-velocity note-off
                              on (channel, key); the CLAP spec says
                              velocity is ignored for choke.
  - CLAP_EVENT_MIDI2       — gated on CLAP_VERSION_GE(1,1,0);
                              appended straight to the UMP sidecar
                              and marked so the MIDI 1.0 → UMP
                              synthesis path is skipped for that
                              block. The stale "until CLAP ships
                              CLAP_EVENT_MIDI2" comment at line 250
                              is replaced with the native-vs-fallback
                              note.

Outbound additions:
  - midi_out (short messages) → CLAP_EVENT_MIDI on out_events, sorted
    by sample_offset per the CLAP contract.
  - midi_out sysex sidecar    → CLAP_EVENT_MIDI_SYSEX on out_events.

Tests (test/test_clap_midi_events.cpp, 8 Catch2 cases tagged
[clap][midi][issue-pending]): drive pulp::format::clap_adapter::
clap_process() with an in-memory clap_input_events_t/clap_output_
events_t vtable so no real DAW is needed. Verifies each new inbound
event type (CC via CLAP_EVENT_MIDI; PB/PC/polyAT/chanAT via
CLAP_EVENT_MIDI; NOTE_CHOKE; NOTE_EXPRESSION both MPE-on and
MPE-off drop; CLAP_EVENT_MIDI2 under CLAP_VERSION_GE guard) as well
as the outbound midi_out CC + pitch-bend and sysex bridge.

Touches the MPE (core/midi/include/pulp/midi/mpe_buffer.hpp,
mpe_voice_tracker.hpp) and UMP (ump_buffer.hpp, ump_conversion.hpp)
sidecar sites only as consumers; no public API change.