### PR TITLE
feat: persist processor-owned plugin state in adapter blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0330"></a>
+## [0.34.0]
+
 ## [0.11.0]
 
 ## [0.10.0]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.33.0
+    VERSION 0.34.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/CMakeLists.txt
+++ b/core/format/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(pulp-format PRIVATE
     src/format.cpp
     src/registry.cpp
     src/headless.cpp
+    src/plugin_state_io.cpp
     src/validation_harness.cpp
     src/aax_model.cpp
     src/host_type.cpp

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -10,6 +10,7 @@
 //   PULP_CLAP_PLUGIN(my_namespace::create_my_processor)
 
 #include <pulp/format/processor.hpp>
+#include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/format/clap_adapter.hpp>
 #ifdef PULP_CLAP_GUI
@@ -96,12 +97,14 @@ inline const clap_plugin_audio_ports_t audio_ports_ext = {
 // ── State extension ────────────────────────────────────────────────────
 inline bool state_save(const clap_plugin_t* plugin, const clap_ostream_t* stream) {
     auto* self = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
-    auto data = self->store.serialize();
+    if (!self || !self->processor) return false;
+    auto data = plugin_state_io::serialize(self->store, *self->processor);
     return stream->write(stream, data.data(), data.size()) == static_cast<int64_t>(data.size());
 }
 
 inline bool state_load(const clap_plugin_t* plugin, const clap_istream_t* stream) {
     auto* self = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
+    if (!self || !self->processor) return false;
     std::vector<uint8_t> data;
     uint8_t buf[4096];
     while (true) {
@@ -109,7 +112,7 @@ inline bool state_load(const clap_plugin_t* plugin, const clap_istream_t* stream
         if (read <= 0) break;
         data.insert(data.end(), buf, buf + read);
     }
-    return self->store.deserialize(data);
+    return plugin_state_io::deserialize(data, self->store, *self->processor);
 }
 
 inline const clap_plugin_state_t state_ext = { .save = state_save, .load = state_load };

--- a/core/format/include/pulp/format/headless.hpp
+++ b/core/format/include/pulp/format/headless.hpp
@@ -74,12 +74,15 @@ public:
     /// The plugin's static descriptor (name, vendor, bus layout, etc.).
     const PluginDescriptor& descriptor() const { return descriptor_; }
 
-    /// Serialize the current parameter state to a binary blob.
-    std::vector<uint8_t> save_state() const { return store_.serialize(); }
+    /// Serialize the current plugin state to a binary blob.
+    ///
+    /// Includes StateStore plus any processor-owned plugin state exposed via
+    /// Processor::serialize_plugin_state().
+    std::vector<uint8_t> save_state() const;
 
-    /// Restore parameter state from a binary blob.
+    /// Restore plugin state from a binary blob.
     /// @return True on success.
-    bool load_state(std::span<const uint8_t> data) { return store_.deserialize(data); }
+    bool load_state(std::span<const uint8_t> data);
 
 private:
     std::unique_ptr<Processor> processor_;

--- a/core/format/include/pulp/format/plugin_state_io.hpp
+++ b/core/format/include/pulp/format/plugin_state_io.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace pulp::state {
+class StateStore;
+}
+
+namespace pulp::format {
+class Processor;
+
+namespace plugin_state_io {
+
+/// Serialize the host-facing plugin state blob for a Processor.
+///
+/// StateStore remains the parameter-only inner payload. When the processor
+/// exposes a non-empty plugin-owned blob, this helper wraps both payloads in
+/// a versioned outer envelope. When the plugin-owned blob is empty, the
+/// legacy raw StateStore blob is returned unchanged.
+std::vector<uint8_t> serialize(const state::StateStore& store,
+                               const Processor& processor);
+
+/// Restore a host-facing plugin state blob.
+///
+/// Accepts both legacy raw StateStore blobs and the combined envelope emitted
+/// by serialize(). On failure, the live StateStore is rolled back to its
+/// previous state before returning false.
+bool deserialize(std::span<const uint8_t> bytes,
+                 state::StateStore& store,
+                 Processor& processor);
+
+} // namespace plugin_state_io
+} // namespace pulp::format

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -6,8 +6,9 @@
 #include <pulp/midi/ump_buffer.hpp>
 #include <pulp/state/store.hpp>
 #include <pulp/view/view.hpp>
-#include <string>
 #include <memory>
+#include <span>
+#include <string>
 #include <vector>
 
 namespace pulp::format {
@@ -206,6 +207,28 @@ public:
 
     /// Release resources. Called on the host thread with audio stopped.
     virtual void release() {}
+
+    /// Serialize plugin-owned state that is not part of StateStore.
+    ///
+    /// Use this for opaque state that must survive host/session recall but
+    /// should not be exposed as flat automatable parameters. The returned
+    /// bytes travel alongside StateStore through the format adapters'
+    /// save/load paths.
+    ///
+    /// Called on a host/main thread, never from process().
+    virtual std::vector<uint8_t> serialize_plugin_state() const { return {}; }
+
+    /// Restore plugin-owned state previously returned by
+    /// serialize_plugin_state().
+    ///
+    /// An empty span means the host blob carried no plugin-owned payload
+    /// (legacy state or a processor that saved only StateStore data). Plugins
+    /// that override this hook should treat empty input as "reset persisted
+    /// plugin-owned state to defaults". Return false to reject malformed or
+    /// incompatible payloads.
+    ///
+    /// Called on a host/main thread with the audio thread stopped.
+    virtual bool deserialize_plugin_state(std::span<const uint8_t>) { return true; }
 
     /// Memory-pressure levels a host can surface to a plugin. Mirrors the
     /// broad shape of iOS didReceiveMemoryWarning + Windows low-memory

--- a/core/format/include/pulp/format/validation_harness.hpp
+++ b/core/format/include/pulp/format/validation_harness.hpp
@@ -114,10 +114,10 @@ public:
     std::vector<float> process_buffer(const std::vector<float>& interleaved_input,
                                        int num_channels, int num_samples);
 
-    /// Save current state to binary blob.
+    /// Save current plugin state to a binary blob.
     std::vector<uint8_t> save_state() const;
 
-    /// Load state from binary blob.
+    /// Load plugin state from a binary blob.
     bool load_state(std::span<const uint8_t> data);
 
     // ── Capture ─────────────────────────────────────────────────────────

--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -5,6 +5,7 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import <AVFoundation/AVFoundation.h>
 #include <pulp/format/processor.hpp>
+#include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/format/ara.hpp>
 #include <pulp/runtime/log.hpp>
@@ -222,16 +223,16 @@ struct AUBridge {
     AUParameterTree *tree = [AUParameterTree createTreeWithChildren:auParams];
 
     // Wire parameter changes from host to StateStore
-    __weak typeof(self) weakSelf = self;
+    __unsafe_unretained PulpAudioUnit* weakSelf = self;
     tree.implementorValueObserver = ^(AUParameter *param, AUValue value) {
-        __strong typeof(weakSelf) strongSelf = weakSelf;
+        PulpAudioUnit* strongSelf = weakSelf;
         if (!strongSelf) return;
         strongSelf->_bridge.store.set_value(
             static_cast<pulp::state::ParamID>(param.address), value);
     };
 
     tree.implementorValueProvider = ^AUValue(AUParameter *param) {
-        __strong typeof(weakSelf) strongSelf = weakSelf;
+        PulpAudioUnit* strongSelf = weakSelf;
         if (!strongSelf) return 0.0f;
         return strongSelf->_bridge.store.get_value(
             static_cast<pulp::state::ParamID>(param.address));
@@ -239,7 +240,7 @@ struct AUBridge {
 
     tree.implementorStringFromValueCallback = ^NSString *(AUParameter *param, const AUValue *value) {
         AUValue v = value ? *value : param.value;
-        __strong typeof(weakSelf) strongSelf = weakSelf;
+        PulpAudioUnit* strongSelf = weakSelf;
         if (strongSelf) {
             auto* info = strongSelf->_bridge.store.info(
                 static_cast<pulp::state::ParamID>(param.address));
@@ -342,7 +343,7 @@ struct AUBridge {
         int scChans = bridge->sidechain_channels;
         if (pullInputBlock && scChans > 0) {
             UInt32 scBufs = std::min(static_cast<UInt32>(scChans),
-                                     static_cast<UInt32>(kMaxChannels));
+                                     static_cast<UInt32>(pulp::format::au::kMaxChannels));
             // Size sidechain_storage for this block if needed (rare —
             // max_frames should cover; guard anyway).
             std::size_t needed = static_cast<std::size_t>(scBufs) * frameCount;
@@ -556,7 +557,8 @@ struct AUBridge {
 // ── State persistence ──────────────────────────────────────────────────────
 
 - (NSDictionary<NSString *, id> *)fullState {
-    auto data = _bridge.store.serialize();
+    if (!_bridge.processor) return [super fullState];
+    auto data = pulp::format::plugin_state_io::serialize(_bridge.store, *_bridge.processor);
     NSData *nsData = [NSData dataWithBytes:data.data() length:data.size()];
     NSMutableDictionary *state = [[super fullState] mutableCopy] ?: [NSMutableDictionary new];
     state[@"pulpState"] = nsData;
@@ -566,9 +568,13 @@ struct AUBridge {
 - (void)setFullState:(NSDictionary<NSString *, id> *)fullState {
     [super setFullState:fullState];
     NSData *nsData = fullState[@"pulpState"];
-    if (nsData) {
+    if (nsData && _bridge.processor) {
         auto* bytes = static_cast<const uint8_t*>(nsData.bytes);
-        _bridge.store.deserialize({bytes, nsData.length});
+        if (!pulp::format::plugin_state_io::deserialize({bytes, nsData.length},
+                                                        _bridge.store,
+                                                        *_bridge.processor)) {
+            pulp::runtime::log_warn("AU: failed to restore plugin state");
+        }
     }
 }
 

--- a/core/format/src/au_v2_adapter.cpp
+++ b/core/format/src/au_v2_adapter.cpp
@@ -6,6 +6,7 @@
 #include <AudioToolbox/AudioUnitUtilities.h>
 
 #include <pulp/format/au_v2_adapter.hpp>
+#include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/runtime/log.hpp>
 
@@ -287,16 +288,29 @@ OSStatus PulpAUEffect::SaveState(CFPropertyListRef* outData)
     auto result = AUEffectBase::SaveState(outData);
     if (result != noErr) return result;
 
-    auto data = store_.serialize();
+    if (!processor_) return kAudioUnitErr_Uninitialized;
+    auto data = plugin_state_io::serialize(store_, *processor_);
     CFDataRef cfData = CFDataCreate(kCFAllocatorDefault,
                                     data.data(),
                                     static_cast<CFIndex>(data.size()));
-    if (cfData && *outData) {
-        CFMutableDictionaryRef dict = CFDictionaryCreateMutableCopy(
-            kCFAllocatorDefault, 0,
-            static_cast<CFDictionaryRef>(*outData));
+    if (cfData) {
+        CFMutableDictionaryRef dict = nullptr;
+        if (*outData && CFGetTypeID(*outData) == CFDictionaryGetTypeID()) {
+            dict = CFDictionaryCreateMutableCopy(
+                kCFAllocatorDefault, 0,
+                static_cast<CFDictionaryRef>(*outData));
+        } else {
+            dict = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                             0,
+                                             &kCFTypeDictionaryKeyCallBacks,
+                                             &kCFTypeDictionaryValueCallBacks);
+        }
+
+        if (*outData) {
+            CFRelease(*outData);
+        }
+
         CFDictionarySetValue(dict, CFSTR("pulp-state"), cfData);
-        CFRelease(*outData);
         *outData = dict;
         CFRelease(cfData);
     }
@@ -315,7 +329,11 @@ OSStatus PulpAUEffect::RestoreState(CFPropertyListRef plist)
         if (cfData && CFGetTypeID(cfData) == CFDataGetTypeID()) {
             auto* bytes = CFDataGetBytePtr(cfData);
             auto length = CFDataGetLength(cfData);
-            store_.deserialize({bytes, static_cast<size_t>(length)});
+            if (!processor_) return kAudioUnitErr_Uninitialized;
+            if (!plugin_state_io::deserialize({bytes, static_cast<size_t>(length)},
+                                              store_, *processor_)) {
+                return kAudioUnitErr_InvalidPropertyValue;
+            }
 
             for (const auto& param : store_.all_params()) {
                 Globals()->SetParameter(

--- a/core/format/src/au_v2_instrument.cpp
+++ b/core/format/src/au_v2_instrument.cpp
@@ -6,6 +6,7 @@
 #include <AudioUnitSDK/AUOutputElement.h>
 
 #include <pulp/format/au_v2_instrument.hpp>
+#include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/registry.hpp>
 #include <pulp/runtime/log.hpp>
 
@@ -201,16 +202,29 @@ OSStatus PulpAUInstrument::SaveState(CFPropertyListRef* outData)
     auto result = MusicDeviceBase::SaveState(outData);
     if (result != noErr) return result;
 
-    auto data = store_.serialize();
+    if (!processor_) return kAudioUnitErr_Uninitialized;
+    auto data = plugin_state_io::serialize(store_, *processor_);
     CFDataRef cfData = CFDataCreate(kCFAllocatorDefault,
                                     data.data(),
                                     static_cast<CFIndex>(data.size()));
-    if (cfData && *outData) {
-        CFMutableDictionaryRef dict = CFDictionaryCreateMutableCopy(
-            kCFAllocatorDefault, 0,
-            static_cast<CFDictionaryRef>(*outData));
+    if (cfData) {
+        CFMutableDictionaryRef dict = nullptr;
+        if (*outData && CFGetTypeID(*outData) == CFDictionaryGetTypeID()) {
+            dict = CFDictionaryCreateMutableCopy(
+                kCFAllocatorDefault, 0,
+                static_cast<CFDictionaryRef>(*outData));
+        } else {
+            dict = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                             0,
+                                             &kCFTypeDictionaryKeyCallBacks,
+                                             &kCFTypeDictionaryValueCallBacks);
+        }
+
+        if (*outData) {
+            CFRelease(*outData);
+        }
+
         CFDictionarySetValue(dict, CFSTR("pulp-state"), cfData);
-        CFRelease(*outData);
         *outData = dict;
         CFRelease(cfData);
     }
@@ -229,7 +243,11 @@ OSStatus PulpAUInstrument::RestoreState(CFPropertyListRef plist)
         if (cfData && CFGetTypeID(cfData) == CFDataGetTypeID()) {
             auto* bytes = CFDataGetBytePtr(cfData);
             auto length = CFDataGetLength(cfData);
-            store_.deserialize({bytes, static_cast<size_t>(length)});
+            if (!processor_) return kAudioUnitErr_Uninitialized;
+            if (!plugin_state_io::deserialize({bytes, static_cast<size_t>(length)},
+                                              store_, *processor_)) {
+                return kAudioUnitErr_InvalidPropertyValue;
+            }
 
             for (const auto& param : store_.all_params()) {
                 Globals()->SetParameter(

--- a/core/format/src/headless.cpp
+++ b/core/format/src/headless.cpp
@@ -2,6 +2,7 @@
 // Simplest possible host — no threading, no UI, no device I/O
 
 #include <pulp/format/headless.hpp>
+#include <pulp/format/plugin_state_io.hpp>
 
 namespace pulp::format {
 
@@ -64,6 +65,16 @@ void HeadlessHost::process(audio::BufferView<float>& output,
 
 void HeadlessHost::release() {
     if (processor_) processor_->release();
+}
+
+std::vector<uint8_t> HeadlessHost::save_state() const {
+    if (!processor_) return {};
+    return plugin_state_io::serialize(store_, *processor_);
+}
+
+bool HeadlessHost::load_state(std::span<const uint8_t> data) {
+    if (!processor_) return false;
+    return plugin_state_io::deserialize(data, store_, *processor_);
 }
 
 } // namespace pulp::format

--- a/core/format/src/plugin_state_io.cpp
+++ b/core/format/src/plugin_state_io.cpp
@@ -1,0 +1,185 @@
+#include <pulp/format/plugin_state_io.hpp>
+
+#include <pulp/format/processor.hpp>
+#include <pulp/runtime/assert.hpp>
+#include <pulp/state/store.hpp>
+#include <choc/memory/choc_Endianness.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace pulp::format::plugin_state_io {
+namespace {
+
+constexpr uint8_t kStateStoreMagic[4] = {'P', 'U', 'L', 'P'};
+constexpr uint8_t kEnvelopeMagic[4] = {'P', 'L', 'S', 'T'};
+constexpr uint32_t kEnvelopeVersion = 1;
+constexpr std::size_t kEnvelopeHeaderSize = 16;
+constexpr std::size_t kEnvelopeFooterSize = 4;
+
+uint32_t crc32_simple(const uint8_t* data, std::size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (std::size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; ++j) {
+            const uint32_t mask = (crc & 1u) ? 0xFFFFFFFFu : 0u;
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
+}
+
+void append_u32(std::vector<uint8_t>& out, uint32_t value) {
+    uint8_t bytes[4];
+    choc::memory::writeLittleEndian(bytes, value);
+    out.insert(out.end(), bytes, bytes + sizeof(bytes));
+}
+
+bool has_magic(std::span<const uint8_t> data, const uint8_t (&magic)[4]) {
+    return data.size() >= 4
+        && data[0] == magic[0]
+        && data[1] == magic[1]
+        && data[2] == magic[2]
+        && data[3] == magic[3];
+}
+
+void clone_schema(const state::StateStore& source, state::StateStore& dest) {
+    dest.set_state_version(source.state_version());
+    for (const auto& group : source.all_groups()) {
+        dest.add_group(group);
+    }
+    for (const auto& param : source.all_params()) {
+        dest.add_parameter(param);
+    }
+}
+
+struct ParsedBlob {
+    std::span<const uint8_t> store_blob;
+    std::span<const uint8_t> plugin_blob;
+};
+
+bool parse_blob(std::span<const uint8_t> bytes, ParsedBlob& parsed) {
+    if (has_magic(bytes, kStateStoreMagic)) {
+        parsed.store_blob = bytes;
+        parsed.plugin_blob = {};
+        return true;
+    }
+
+    if (!has_magic(bytes, kEnvelopeMagic)) {
+        return false;
+    }
+
+    if (bytes.size() < (kEnvelopeHeaderSize + kEnvelopeFooterSize)) {
+        return false;
+    }
+
+    const uint32_t version =
+        choc::memory::readLittleEndian<uint32_t>(bytes.data() + 4);
+    if (version != kEnvelopeVersion) {
+        return false;
+    }
+
+    const uint32_t store_size =
+        choc::memory::readLittleEndian<uint32_t>(bytes.data() + 8);
+    const uint32_t plugin_size =
+        choc::memory::readLittleEndian<uint32_t>(bytes.data() + 12);
+    const std::size_t payload_size =
+        static_cast<std::size_t>(store_size) + static_cast<std::size_t>(plugin_size);
+
+    if (payload_size > (bytes.size() - kEnvelopeHeaderSize - kEnvelopeFooterSize)) {
+        return false;
+    }
+
+    const std::size_t expected_size =
+        kEnvelopeHeaderSize + payload_size + kEnvelopeFooterSize;
+    if (bytes.size() != expected_size) {
+        return false;
+    }
+
+    const std::size_t crc_offset = kEnvelopeHeaderSize + payload_size;
+    const uint32_t stored_crc =
+        choc::memory::readLittleEndian<uint32_t>(bytes.data() + crc_offset);
+    const uint32_t computed_crc = crc32_simple(bytes.data(), crc_offset);
+    if (stored_crc != computed_crc) {
+        return false;
+    }
+
+    parsed.store_blob = bytes.subspan(kEnvelopeHeaderSize, store_size);
+    parsed.plugin_blob = bytes.subspan(kEnvelopeHeaderSize + store_size, plugin_size);
+    return true;
+}
+
+bool restore_previous_state(const std::vector<uint8_t>& store_blob,
+                            const std::vector<uint8_t>& plugin_blob,
+                            state::StateStore& store,
+                            Processor& processor) {
+    const bool store_restored = store.deserialize(store_blob);
+    PULP_ASSERT(store_restored, "StateStore rollback must succeed");
+    if (!store_restored) {
+        return false;
+    }
+
+    const bool plugin_restored = processor.deserialize_plugin_state(plugin_blob);
+    PULP_ASSERT(plugin_restored, "Processor plugin-state rollback must succeed");
+    return plugin_restored;
+}
+
+} // namespace
+
+std::vector<uint8_t> serialize(const state::StateStore& store,
+                               const Processor& processor) {
+    auto store_blob = store.serialize();
+    auto plugin_blob = processor.serialize_plugin_state();
+    if (plugin_blob.empty()) {
+        return store_blob;
+    }
+
+    std::vector<uint8_t> out;
+    out.reserve(kEnvelopeHeaderSize + store_blob.size()
+                + plugin_blob.size() + kEnvelopeFooterSize);
+
+    out.insert(out.end(), kEnvelopeMagic, kEnvelopeMagic + 4);
+    append_u32(out, kEnvelopeVersion);
+    append_u32(out, static_cast<uint32_t>(store_blob.size()));
+    append_u32(out, static_cast<uint32_t>(plugin_blob.size()));
+    out.insert(out.end(), store_blob.begin(), store_blob.end());
+    out.insert(out.end(), plugin_blob.begin(), plugin_blob.end());
+    append_u32(out, crc32_simple(out.data(), out.size()));
+    return out;
+}
+
+bool deserialize(std::span<const uint8_t> bytes,
+                 state::StateStore& store,
+                 Processor& processor) {
+    ParsedBlob parsed{};
+    if (!parse_blob(bytes, parsed)) {
+        return false;
+    }
+
+    state::StateStore probe;
+    clone_schema(store, probe);
+    if (!probe.deserialize(parsed.store_blob)) {
+        return false;
+    }
+
+    const auto previous_store_blob = store.serialize();
+    const auto previous_plugin_blob = processor.serialize_plugin_state();
+
+    if (!store.deserialize(parsed.store_blob)) {
+        restore_previous_state(previous_store_blob, previous_plugin_blob,
+                               store, processor);
+        return false;
+    }
+
+    if (processor.deserialize_plugin_state(parsed.plugin_blob)) {
+        return true;
+    }
+
+    restore_previous_state(previous_store_blob, previous_plugin_blob,
+                           store, processor);
+    return false;
+}
+
+} // namespace pulp::format::plugin_state_io

--- a/core/format/src/vst3_adapter.cpp
+++ b/core/format/src/vst3_adapter.cpp
@@ -4,6 +4,7 @@
 // with the Pulp StateStore during processing
 
 #include <pulp/format/vst3_adapter.hpp>
+#include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/vst3_plug_view.hpp>
 #include <pulp/format/ara.hpp>
 #include <pulp/runtime/log.hpp>
@@ -442,7 +443,8 @@ tresult PLUGIN_API PulpVst3Processor::process(ProcessData& data) {
 }
 
 tresult PLUGIN_API PulpVst3Processor::getState(IBStream* stream) {
-    auto data = store_.serialize();
+    if (!processor_) return kResultFalse;
+    auto data = plugin_state_io::serialize(store_, *processor_);
     int32 written;
     return stream->write(data.data(), static_cast<int32>(data.size()), &written);
 }
@@ -455,7 +457,8 @@ tresult PLUGIN_API PulpVst3Processor::setState(IBStream* stream) {
     while (stream->read(buf, sizeof(buf), &read_count) == kResultOk && read_count > 0) {
         data.insert(data.end(), buf, buf + read_count);
     }
-    if (!store_.deserialize(data)) return kResultFalse;
+    if (!processor_) return kResultFalse;
+    if (!plugin_state_io::deserialize(data, store_, *processor_)) return kResultFalse;
 
     // Sync restored values back to VST3 parameter system
     for (const auto& param : store_.all_params()) {

--- a/core/state/include/pulp/state/store.hpp
+++ b/core/state/include/pulp/state/store.hpp
@@ -108,10 +108,16 @@ public:
     void add_listener(ParamChangeCallback callback);
 
     /// Serialize all parameter values to a binary blob for preset/state save.
+    ///
+    /// This is the parameter-only payload. Format adapters may wrap it in a
+    /// higher-level host blob alongside Processor::serialize_plugin_state().
     /// @return Byte vector suitable for storage or transmission.
     std::vector<uint8_t> serialize() const;
 
-    /// Restore parameter values from a binary blob.
+    /// Restore parameter values from a parameter-only binary blob.
+    ///
+    /// Format adapters may decode a higher-level host blob first, then pass
+    /// only the embedded StateStore payload here.
     /// @return True if deserialization succeeded.
     bool deserialize(std::span<const uint8_t> data);
 

--- a/docs/guides/formats.md
+++ b/docs/guides/formats.md
@@ -60,8 +60,14 @@ Note port declaration is driven by `descriptor().accepts_midi` and `descriptor()
 
 ### State Save/Load
 
-- **Save:** `store.serialize()` returns a `std::vector<uint8_t>`. The adapter writes it to the CLAP `clap_ostream_t`.
-- **Load:** The adapter reads all bytes from `clap_istream_t` into a buffer (4 KB chunks), then calls `store.deserialize()`.
+- **Save:** The adapter writes a host-facing blob containing `StateStore` plus
+  any non-empty `Processor::serialize_plugin_state()` payload. When the
+  processor-owned payload is empty, the adapter preserves the legacy raw
+  `StateStore` blob for backward compatibility.
+- **Load:** The adapter reads all bytes from `clap_istream_t` into a buffer
+  (4 KB chunks), restores `StateStore`, then calls
+  `deserialize_plugin_state()`. Older blobs without a processor-owned payload
+  call `deserialize_plugin_state()` with empty bytes.
 
 ### Multi-Bus / Sidechain
 
@@ -139,8 +145,13 @@ VST3 note events (`Event::kNoteOnEvent`, `Event::kNoteOffEvent`) are converted t
 
 ### State Save/Load
 
-- **Save (`getState`):** `store_.serialize()` writes the binary blob to `IBStream`.
-- **Load (`setState`):** Reads the stream in 4 KB chunks, calls `store_.deserialize()`, then syncs all restored values back to the VST3 parameter system via `setParamNormalized()`.
+- **Save (`getState`):** Writes a combined host-facing blob containing the
+  `StateStore` payload plus any non-empty
+  `Processor::serialize_plugin_state()` bytes.
+- **Load (`setState`):** Reads the stream in 4 KB chunks, restores both layers,
+  then syncs restored parameter values back to the VST3 parameter system via
+  `setParamNormalized()`. Older blobs without a processor-owned payload still
+  load and call `deserialize_plugin_state()` with empty bytes.
 
 ### Multi-Bus / Sidechain
 
@@ -239,8 +250,15 @@ Stepped parameters with a `to_string` function get value string arrays via `GetP
 
 The AU adapter stores Pulp state alongside the standard AU state dictionary:
 
-- **Save:** Calls `AUEffectBase::SaveState()` (or `MusicDeviceBase::SaveState()`), then appends a `CFData` blob under the key `"pulp-state"` containing `store_.serialize()`.
-- **Load:** Calls the base `RestoreState()`, then looks for the `"pulp-state"` key. If found, calls `store_.deserialize()` and syncs all values back to the AU parameter system via `Globals()->SetParameter()`.
+- **Save:** Calls `AUEffectBase::SaveState()` (or `MusicDeviceBase::SaveState()`),
+  then appends a `CFData` blob under the key `"pulp-state"`. That blob contains
+  the parameter-only `StateStore` payload plus any non-empty
+  `Processor::serialize_plugin_state()` bytes.
+- **Load:** Calls the base `RestoreState()`, then looks for the `"pulp-state"`
+  key. If found, restores both layers and syncs all parameter values back to
+  the AU parameter system via `Globals()->SetParameter()`. Older blobs with only
+  raw `StateStore` data still load and call `deserialize_plugin_state()` with
+  empty bytes.
 
 ### Tail and Latency
 
@@ -286,6 +304,17 @@ Status: `experimental` on macOS and iOS per
 today but hasn't yet passed the host-compatibility bar (auval v2 validation,
 Logic Pro + GarageBand + AUM cross-check) that would justify promotion to
 `usable`; see the status manifest for the current promotion criteria.
+
+### State Save/Load
+
+AU v3 mirrors the AU v2 state contract through `AUAudioUnit.fullState`:
+
+- **Save:** `fullState` writes a `NSData` payload under the key `"pulpState"`.
+  That payload contains the parameter-only `StateStore` bytes plus any
+  non-empty `Processor::serialize_plugin_state()` blob.
+- **Load:** `setFullState:` reads `"pulpState"` and restores both layers.
+  Older blobs that contain only raw `StateStore` data still load and call
+  `deserialize_plugin_state()` with empty bytes.
 
 ---
 
@@ -521,8 +550,8 @@ Key methods:
 | `process(output, input, midi_in, midi_out)` | Process audio with MIDI |
 | `release()` | Release processing resources |
 | `state()` | Access the `StateStore` for parameter reads/writes |
-| `save_state()` | Serialize current parameter state to bytes |
-| `load_state(data)` | Restore parameter state from bytes |
+| `save_state()` | Serialize current plugin state to bytes |
+| `load_state(data)` | Restore parameter and plugin-owned state from bytes |
 | `descriptor()` | Read the plugin's `PluginDescriptor` |
 
 Input and output views may alias for in-place processing.

--- a/docs/guides/parameters.md
+++ b/docs/guides/parameters.md
@@ -205,6 +205,32 @@ The format includes a version number and CRC32 checksum:
 
 Use `set_state_version()` for forward compatibility when adding parameters in new plugin versions.
 
+## Processor-Owned Plugin State
+
+`StateStore` is intentionally limited to flat, automatable parameters. Anything
+that should survive host/session recall but should not appear in the host's
+automation lane belongs in `Processor`'s plugin-owned state hooks instead:
+
+```cpp
+std::vector<uint8_t> serialize_plugin_state() const override;
+bool deserialize_plugin_state(std::span<const uint8_t> data) override;
+```
+
+Typical examples:
+
+- snapshot banks or scene slots
+- variable layouts that change what the parameters mean
+- editor/model state stored as `StateTree` JSON or a custom binary payload
+
+Format adapters, `HeadlessHost`, and `ValidationHarness` save an outer
+host-facing blob. The inner `StateStore` payload remains the same parameter-only
+binary format shown above. If `serialize_plugin_state()` returns an empty blob,
+Pulp preserves the legacy raw `StateStore` format for backward compatibility.
+
+`deserialize_plugin_state()` receives an empty span when loading an older blob
+that contains only `StateStore` data. Override implementations should treat
+empty input as "reset persisted plugin-owned state to defaults".
+
 ## Thread Model
 
 | Thread | Can Read | Can Write | Mechanism |
@@ -223,3 +249,8 @@ Format adapters sync parameters bidirectionally:
 - **Plugin → Host**: adapters snapshot values before `process()`, then emit output events for any changes after
 - **UI → Host**: `Binding::begin_gesture()` / `end_gesture()` forward to host undo system
 - **CLAP modulation**: adapter handles `CLAP_EVENT_PARAM_MOD` and calls `set_mod_offset()` / `add_mod_offset()`
+
+Host/project save-load uses both layers:
+
+- **Automatable state**: `StateStore::serialize()` / `deserialize()`
+- **Opaque plugin-owned state**: `Processor::serialize_plugin_state()` / `deserialize_plugin_state()`

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -289,6 +289,10 @@ add_executable(pulp-test-validation-harness test_validation_harness.cpp)
 target_link_libraries(pulp-test-validation-harness PRIVATE pulp::format Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-validation-harness)
 
+add_executable(pulp-test-plugin-state-io test_plugin_state_io.cpp)
+target_link_libraries(pulp-test-plugin-state-io PRIVATE pulp::format Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-plugin-state-io)
+
 # AAX metadata/model tests
 add_executable(pulp-test-aax-model test_aax_model.cpp)
 target_link_libraries(pulp-test-aax-model PRIVATE pulp::format Catch2::Catch2WithMain)
@@ -736,6 +740,38 @@ if(PULP_HAS_CLAP)
     )
     target_link_libraries(pulp-test-clap-entry PRIVATE pulp::format clap Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-clap-entry)
+endif()
+
+if(PULP_HAS_VST3)
+    add_executable(pulp-test-vst3-plugin-state
+        test_vst3_plugin_state.cpp
+        ${CMAKE_SOURCE_DIR}/core/format/src/vst3_plug_view.cpp
+    )
+    target_link_libraries(pulp-test-vst3-plugin-state PRIVATE pulp::format Catch2::Catch2WithMain)
+    target_compile_definitions(pulp-test-vst3-plugin-state PRIVATE
+        PULP_VST3=1
+        PULP_VST3_GUI=1
+    )
+    catch_discover_tests(pulp-test-vst3-plugin-state)
+endif()
+
+if(APPLE AND PULP_HAS_AUSDK)
+    add_executable(pulp-test-au-plugin-state
+        test_au_plugin_state.mm
+        ${CMAKE_SOURCE_DIR}/core/format/src/au_adapter.mm
+    )
+    target_link_libraries(pulp-test-au-plugin-state PRIVATE
+        pulp::format
+        Catch2::Catch2WithMain
+        "-framework AudioToolbox"
+        "-framework AVFoundation"
+        "-framework Foundation"
+    )
+    set_target_properties(pulp-test-au-plugin-state PROPERTIES
+        CXX_STANDARD 23
+        OBJCXX_STANDARD 23
+    )
+    catch_discover_tests(pulp-test-au-plugin-state)
 endif()
 
 # LV2 adapter tests

--- a/test/test_au_plugin_state.mm
+++ b/test/test_au_plugin_state.mm
@@ -1,0 +1,254 @@
+#import <AudioToolbox/AudioToolbox.h>
+#import <Foundation/Foundation.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/format/au_v2_adapter.hpp>
+#include <pulp/format/au_v2_instrument.hpp>
+#include <pulp/format/processor.hpp>
+#include <pulp/format/registry.hpp>
+
+#import "../core/format/src/au_audio_unit.h"
+
+#include <string>
+#include <vector>
+
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+class TestAUEffectProcessor;
+class TestAUInstrumentProcessor;
+
+TestAUEffectProcessor* g_last_effect_processor = nullptr;
+TestAUInstrumentProcessor* g_last_instrument_processor = nullptr;
+
+class TestAUEffectProcessor : public pulp::format::Processor {
+public:
+    TestAUEffectProcessor() { g_last_effect_processor = this; }
+
+    pulp::format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "AUEffectPluginStateTest",
+            .manufacturer = "PulpTest",
+            .bundle_id = "com.pulp.test.au-effect-plugin-state",
+            .version = "1.0.0",
+            .category = pulp::format::PluginCategory::Effect,
+            .input_buses = {{"Audio In", 2}},
+            .output_buses = {{"Audio Out", 2}},
+        };
+    }
+
+    void define_parameters(pulp::state::StateStore& store) override {
+        store.add_parameter({
+            .id = 1,
+            .name = "Gain",
+            .unit = "dB",
+            .range = {-60.0f, 24.0f, 0.0f, 0.1f},
+        });
+    }
+
+    void prepare(const pulp::format::PrepareContext&) override {}
+
+    void process(pulp::audio::BufferView<float>&,
+                 const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const pulp::format::ProcessContext&) override {}
+
+    std::vector<uint8_t> serialize_plugin_state() const override {
+        return std::vector<uint8_t>(plugin_state.begin(), plugin_state.end());
+    }
+
+    bool deserialize_plugin_state(std::span<const uint8_t> data) override {
+        plugin_state.assign(data.begin(), data.end());
+        return true;
+    }
+
+    std::string plugin_state;
+};
+
+class TestAUInstrumentProcessor : public pulp::format::Processor {
+public:
+    TestAUInstrumentProcessor() { g_last_instrument_processor = this; }
+
+    pulp::format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "AUInstrumentPluginStateTest",
+            .manufacturer = "PulpTest",
+            .bundle_id = "com.pulp.test.au-instrument-plugin-state",
+            .version = "1.0.0",
+            .category = pulp::format::PluginCategory::Instrument,
+            .input_buses = {},
+            .output_buses = {{"Audio Out", 2}},
+            .accepts_midi = true,
+        };
+    }
+
+    void define_parameters(pulp::state::StateStore& store) override {
+        store.add_parameter({
+            .id = 1,
+            .name = "Cutoff",
+            .unit = "Hz",
+            .range = {20.0f, 20000.0f, 440.0f, 1.0f},
+        });
+    }
+
+    void prepare(const pulp::format::PrepareContext&) override {}
+
+    void process(pulp::audio::BufferView<float>&,
+                 const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const pulp::format::ProcessContext&) override {}
+
+    std::vector<uint8_t> serialize_plugin_state() const override {
+        return std::vector<uint8_t>(plugin_state.begin(), plugin_state.end());
+    }
+
+    bool deserialize_plugin_state(std::span<const uint8_t> data) override {
+        plugin_state.assign(data.begin(), data.end());
+        return true;
+    }
+
+    std::string plugin_state;
+};
+
+std::unique_ptr<pulp::format::Processor> create_effect_processor() {
+    return std::make_unique<TestAUEffectProcessor>();
+}
+
+std::unique_ptr<pulp::format::Processor> create_instrument_processor() {
+    return std::make_unique<TestAUInstrumentProcessor>();
+}
+
+void require_plst_blob(const uint8_t* bytes, std::size_t size) {
+    REQUIRE(size >= 4);
+    REQUIRE(bytes[0] == 'P');
+    REQUIRE(bytes[1] == 'L');
+    REQUIRE(bytes[2] == 'S');
+    REQUIRE(bytes[3] == 'T');
+}
+
+} // namespace
+
+TEST_CASE("AU v2 effect SaveState/RestoreState round-trips plugin-owned payload",
+          "[au][auv2][state]") {
+    pulp::format::register_plugin(create_effect_processor);
+
+    pulp::format::au::PulpAUEffect saver(nullptr);
+    auto* saver_processor = g_last_effect_processor;
+    REQUIRE(saver_processor != nullptr);
+    saver_processor->state().set_value(1, -10.5f);
+    saver_processor->plugin_state = "layout=48";
+
+    CFPropertyListRef saved = nullptr;
+    REQUIRE(saver.SaveState(&saved) == noErr);
+    REQUIRE(saved != nullptr);
+    REQUIRE(CFGetTypeID(saved) == CFDictionaryGetTypeID());
+    auto saved_dict = static_cast<CFDictionaryRef>(saved);
+    auto payload = static_cast<CFDataRef>(
+        CFDictionaryGetValue(saved_dict, CFSTR("pulp-state")));
+    REQUIRE(payload != nullptr);
+    require_plst_blob(CFDataGetBytePtr(payload),
+                      static_cast<std::size_t>(CFDataGetLength(payload)));
+
+    pulp::format::register_plugin(create_effect_processor);
+    pulp::format::au::PulpAUEffect loader(nullptr);
+    auto* loader_processor = g_last_effect_processor;
+    REQUIRE(loader_processor != nullptr);
+    loader_processor->state().set_value(1, 6.0f);
+    loader_processor->plugin_state = "stale";
+
+    REQUIRE(loader.RestoreState(saved) == noErr);
+    REQUIRE_THAT(loader_processor->state().get_value(1), WithinAbs(-10.5, 0.01));
+    REQUIRE(loader_processor->plugin_state == "layout=48");
+
+    CFRelease(saved);
+}
+
+TEST_CASE("AU v2 instrument SaveState/RestoreState round-trips plugin-owned payload",
+          "[au][auv2][instrument][state]") {
+    pulp::format::register_plugin(create_instrument_processor);
+
+    pulp::format::au::PulpAUInstrument saver(nullptr);
+    auto* saver_processor = g_last_instrument_processor;
+    REQUIRE(saver_processor != nullptr);
+    saver_processor->state().set_value(1, 880.0f);
+    saver_processor->plugin_state = "snapshot=B";
+
+    CFPropertyListRef saved = nullptr;
+    REQUIRE(saver.SaveState(&saved) == noErr);
+    REQUIRE(saved != nullptr);
+    REQUIRE(CFGetTypeID(saved) == CFDictionaryGetTypeID());
+    auto saved_dict = static_cast<CFDictionaryRef>(saved);
+    auto payload = static_cast<CFDataRef>(
+        CFDictionaryGetValue(saved_dict, CFSTR("pulp-state")));
+    REQUIRE(payload != nullptr);
+    require_plst_blob(CFDataGetBytePtr(payload),
+                      static_cast<std::size_t>(CFDataGetLength(payload)));
+
+    pulp::format::register_plugin(create_instrument_processor);
+    pulp::format::au::PulpAUInstrument loader(nullptr);
+    auto* loader_processor = g_last_instrument_processor;
+    REQUIRE(loader_processor != nullptr);
+    loader_processor->state().set_value(1, 220.0f);
+    loader_processor->plugin_state = "stale";
+
+    REQUIRE(loader.RestoreState(saved) == noErr);
+    REQUIRE_THAT(loader_processor->state().get_value(1), WithinAbs(880.0, 0.01));
+    REQUIRE(loader_processor->plugin_state == "snapshot=B");
+
+    CFRelease(saved);
+}
+
+TEST_CASE("AU v3 fullState round-trips plugin-owned payload",
+          "[au][auv3][state]") {
+    @autoreleasepool {
+        AudioComponentDescription desc{};
+        desc.componentType = kAudioUnitType_Effect;
+        desc.componentSubType = 'TstE';
+        desc.componentManufacturer = 'Plup';
+
+        pulp::format::register_plugin(create_effect_processor);
+
+        NSError* saver_error = nil;
+        PulpAudioUnit* saver =
+            [[PulpAudioUnit alloc] initWithComponentDescription:desc
+                                                       options:0
+                                                         error:&saver_error];
+        REQUIRE(saver != nil);
+        REQUIRE(saver_error == nil);
+        auto* saver_processor = g_last_effect_processor;
+        REQUIRE(saver_processor != nullptr);
+        saver_processor->state().set_value(1, -14.0f);
+        saver_processor->plugin_state = "view=60-12000";
+
+        NSDictionary<NSString*, id>* saved = [saver fullState];
+        REQUIRE(saved != nil);
+        NSData* payload = saved[@"pulpState"];
+        REQUIRE(payload != nil);
+        require_plst_blob(static_cast<const uint8_t*>(payload.bytes), payload.length);
+
+        pulp::format::register_plugin(create_effect_processor);
+
+        NSError* loader_error = nil;
+        PulpAudioUnit* loader =
+            [[PulpAudioUnit alloc] initWithComponentDescription:desc
+                                                       options:0
+                                                         error:&loader_error];
+        REQUIRE(loader != nil);
+        REQUIRE(loader_error == nil);
+        auto* loader_processor = g_last_effect_processor;
+        REQUIRE(loader_processor != nullptr);
+        loader_processor->state().set_value(1, 3.0f);
+        loader_processor->plugin_state = "stale";
+
+        [loader setFullState:saved];
+        REQUIRE_THAT(loader_processor->state().get_value(1), WithinAbs(-14.0, 0.01));
+        REQUIRE(loader_processor->plugin_state == "view=60-12000");
+
+        [loader release];
+        [saver release];
+    }
+}

--- a/test/test_au_plugin_state.mm
+++ b/test/test_au_plugin_state.mm
@@ -130,11 +130,24 @@ void require_plst_blob(const uint8_t* bytes, std::size_t size) {
     REQUIRE(bytes[3] == 'T');
 }
 
+struct ScopedFactoryRegistration {
+    explicit ScopedFactoryRegistration(pulp::format::ProcessorFactory factory)
+        : previous(pulp::format::registered_factory()) {
+        pulp::format::register_plugin(factory);
+    }
+
+    ~ScopedFactoryRegistration() {
+        pulp::format::register_plugin(previous);
+    }
+
+    pulp::format::ProcessorFactory previous;
+};
+
 } // namespace
 
 TEST_CASE("AU v2 effect SaveState/RestoreState round-trips plugin-owned payload",
           "[au][auv2][state]") {
-    pulp::format::register_plugin(create_effect_processor);
+    ScopedFactoryRegistration registration(create_effect_processor);
 
     pulp::format::au::PulpAUEffect saver(nullptr);
     auto* saver_processor = g_last_effect_processor;
@@ -153,7 +166,6 @@ TEST_CASE("AU v2 effect SaveState/RestoreState round-trips plugin-owned payload"
     require_plst_blob(CFDataGetBytePtr(payload),
                       static_cast<std::size_t>(CFDataGetLength(payload)));
 
-    pulp::format::register_plugin(create_effect_processor);
     pulp::format::au::PulpAUEffect loader(nullptr);
     auto* loader_processor = g_last_effect_processor;
     REQUIRE(loader_processor != nullptr);
@@ -169,7 +181,7 @@ TEST_CASE("AU v2 effect SaveState/RestoreState round-trips plugin-owned payload"
 
 TEST_CASE("AU v2 instrument SaveState/RestoreState round-trips plugin-owned payload",
           "[au][auv2][instrument][state]") {
-    pulp::format::register_plugin(create_instrument_processor);
+    ScopedFactoryRegistration registration(create_instrument_processor);
 
     pulp::format::au::PulpAUInstrument saver(nullptr);
     auto* saver_processor = g_last_instrument_processor;
@@ -188,7 +200,6 @@ TEST_CASE("AU v2 instrument SaveState/RestoreState round-trips plugin-owned payl
     require_plst_blob(CFDataGetBytePtr(payload),
                       static_cast<std::size_t>(CFDataGetLength(payload)));
 
-    pulp::format::register_plugin(create_instrument_processor);
     pulp::format::au::PulpAUInstrument loader(nullptr);
     auto* loader_processor = g_last_instrument_processor;
     REQUIRE(loader_processor != nullptr);
@@ -210,7 +221,7 @@ TEST_CASE("AU v3 fullState round-trips plugin-owned payload",
         desc.componentSubType = 'TstE';
         desc.componentManufacturer = 'Plup';
 
-        pulp::format::register_plugin(create_effect_processor);
+        ScopedFactoryRegistration registration(create_effect_processor);
 
         NSError* saver_error = nil;
         PulpAudioUnit* saver =
@@ -230,8 +241,6 @@ TEST_CASE("AU v3 fullState round-trips plugin-owned payload",
         REQUIRE(payload != nil);
         require_plst_blob(static_cast<const uint8_t*>(payload.bytes), payload.length);
 
-        pulp::format::register_plugin(create_effect_processor);
-
         NSError* loader_error = nil;
         PulpAudioUnit* loader =
             [[PulpAudioUnit alloc] initWithComponentDescription:desc
@@ -250,5 +259,173 @@ TEST_CASE("AU v3 fullState round-trips plugin-owned payload",
 
         [loader release];
         [saver release];
+    }
+}
+
+TEST_CASE("AU v2 SaveState accepts pre-existing property lists",
+          "[au][auv2][state]") {
+    SECTION("effect") {
+        ScopedFactoryRegistration registration(create_effect_processor);
+        pulp::format::au::PulpAUEffect saver(nullptr);
+        auto* processor = g_last_effect_processor;
+        REQUIRE(processor != nullptr);
+        processor->plugin_state = "layout=48";
+
+        CFPropertyListRef saved = CFRetain(CFSTR("stale"));
+
+        REQUIRE(saver.SaveState(&saved) == noErr);
+        REQUIRE(saved != nullptr);
+        auto saved_dict = static_cast<CFDictionaryRef>(saved);
+        auto payload = static_cast<CFDataRef>(
+            CFDictionaryGetValue(saved_dict, CFSTR("pulp-state")));
+        REQUIRE(payload != nullptr);
+        require_plst_blob(CFDataGetBytePtr(payload),
+                          static_cast<std::size_t>(CFDataGetLength(payload)));
+        CFRelease(saved);
+    }
+
+    SECTION("instrument") {
+        ScopedFactoryRegistration registration(create_instrument_processor);
+        pulp::format::au::PulpAUInstrument saver(nullptr);
+        auto* processor = g_last_instrument_processor;
+        REQUIRE(processor != nullptr);
+        processor->plugin_state = "snapshot=B";
+
+        CFPropertyListRef saved = CFRetain(CFSTR("stale"));
+
+        REQUIRE(saver.SaveState(&saved) == noErr);
+        REQUIRE(saved != nullptr);
+        auto saved_dict = static_cast<CFDictionaryRef>(saved);
+        auto payload = static_cast<CFDataRef>(
+            CFDictionaryGetValue(saved_dict, CFSTR("pulp-state")));
+        REQUIRE(payload != nullptr);
+        require_plst_blob(CFDataGetBytePtr(payload),
+                          static_cast<std::size_t>(CFDataGetLength(payload)));
+        CFRelease(saved);
+    }
+}
+
+TEST_CASE("AU v2 state persistence rejects invalid payloads and uninitialized processors",
+          "[au][auv2][state]") {
+    SECTION("effect rejects invalid payload") {
+        ScopedFactoryRegistration registration(create_effect_processor);
+        pulp::format::au::PulpAUEffect effect(nullptr);
+        auto* processor = g_last_effect_processor;
+        REQUIRE(processor != nullptr);
+        processor->state().set_value(1, 2.0f);
+        processor->plugin_state = "keep";
+
+        const uint8_t bad_bytes[] = {'N', 'O', 'P', 'E'};
+        CFDataRef payload = CFDataCreate(kCFAllocatorDefault, bad_bytes, 4);
+        CFMutableDictionaryRef state = CFDictionaryCreateMutable(
+            kCFAllocatorDefault, 0,
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+        CFDictionarySetValue(state, CFSTR("pulp-state"), payload);
+
+        REQUIRE(effect.RestoreState(state) == kAudioUnitErr_InvalidPropertyValue);
+        REQUIRE_THAT(processor->state().get_value(1), WithinAbs(2.0, 0.01));
+        REQUIRE(processor->plugin_state == "keep");
+
+        CFRelease(state);
+        CFRelease(payload);
+    }
+
+    SECTION("instrument rejects invalid payload") {
+        ScopedFactoryRegistration registration(create_instrument_processor);
+        pulp::format::au::PulpAUInstrument instrument(nullptr);
+        auto* processor = g_last_instrument_processor;
+        REQUIRE(processor != nullptr);
+        processor->state().set_value(1, 330.0f);
+        processor->plugin_state = "keep";
+
+        const uint8_t bad_bytes[] = {'N', 'O', 'P', 'E'};
+        CFDataRef payload = CFDataCreate(kCFAllocatorDefault, bad_bytes, 4);
+        CFMutableDictionaryRef state = CFDictionaryCreateMutable(
+            kCFAllocatorDefault, 0,
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+        CFDictionarySetValue(state, CFSTR("pulp-state"), payload);
+
+        REQUIRE(instrument.RestoreState(state) == kAudioUnitErr_InvalidPropertyValue);
+        REQUIRE_THAT(processor->state().get_value(1), WithinAbs(330.0, 0.01));
+        REQUIRE(processor->plugin_state == "keep");
+
+        CFRelease(state);
+        CFRelease(payload);
+    }
+
+    SECTION("effect reports uninitialized when no factory is registered") {
+        CFPropertyListRef saved = nullptr;
+        {
+            ScopedFactoryRegistration registration(create_effect_processor);
+            pulp::format::au::PulpAUEffect saver(nullptr);
+            REQUIRE(saver.SaveState(&saved) == noErr);
+            REQUIRE(saved != nullptr);
+        }
+
+        ScopedFactoryRegistration registration(nullptr);
+        pulp::format::au::PulpAUEffect effect(nullptr);
+
+        CFPropertyListRef empty = nullptr;
+        REQUIRE(effect.SaveState(&empty) == kAudioUnitErr_Uninitialized);
+        if (empty) CFRelease(empty);
+
+        REQUIRE(effect.RestoreState(saved) == kAudioUnitErr_Uninitialized);
+        CFRelease(saved);
+    }
+
+    SECTION("instrument reports uninitialized when no factory is registered") {
+        CFPropertyListRef saved = nullptr;
+        {
+            ScopedFactoryRegistration registration(create_instrument_processor);
+            pulp::format::au::PulpAUInstrument saver(nullptr);
+            REQUIRE(saver.SaveState(&saved) == noErr);
+            REQUIRE(saved != nullptr);
+        }
+
+        ScopedFactoryRegistration registration(nullptr);
+        pulp::format::au::PulpAUInstrument instrument(nullptr);
+
+        CFPropertyListRef empty = nullptr;
+        REQUIRE(instrument.SaveState(&empty) == kAudioUnitErr_Uninitialized);
+        if (empty) CFRelease(empty);
+
+        REQUIRE(instrument.RestoreState(saved) == kAudioUnitErr_Uninitialized);
+        CFRelease(saved);
+    }
+}
+
+TEST_CASE("AU v3 setFullState ignores invalid plugin payload",
+          "[au][auv3][state]") {
+    @autoreleasepool {
+        AudioComponentDescription desc{};
+        desc.componentType = kAudioUnitType_Effect;
+        desc.componentSubType = 'TstE';
+        desc.componentManufacturer = 'Plup';
+
+        ScopedFactoryRegistration registration(create_effect_processor);
+
+        NSError* error = nil;
+        PulpAudioUnit* unit =
+            [[PulpAudioUnit alloc] initWithComponentDescription:desc
+                                                       options:0
+                                                         error:&error];
+        REQUIRE(unit != nil);
+        REQUIRE(error == nil);
+
+        auto* processor = g_last_effect_processor;
+        REQUIRE(processor != nullptr);
+        processor->state().set_value(1, 5.0f);
+        processor->plugin_state = "keep";
+
+        NSData* payload = [NSData dataWithBytes:"NOPE" length:4];
+        NSDictionary<NSString*, id>* saved = @{@"pulpState": payload};
+        [unit setFullState:saved];
+
+        REQUIRE_THAT(processor->state().get_value(1), WithinAbs(5.0, 0.01));
+        REQUIRE(processor->plugin_state == "keep");
+
+        [unit release];
     }
 }

--- a/test/test_clap_entry.cpp
+++ b/test/test_clap_entry.cpp
@@ -3,15 +3,23 @@
 // symbols and factory can be called programmatically.
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/format/processor.hpp>
 #include <pulp/format/clap_entry.hpp>
 #include <cmath>
+#include <cstring>
+#include <vector>
 
 // Minimal test processor
 namespace test_clap {
 
+class TestProcessor;
+inline TestProcessor* g_last_processor = nullptr;
+
 class TestProcessor : public pulp::format::Processor {
 public:
+    TestProcessor() { g_last_processor = this; }
+
     pulp::format::PluginDescriptor descriptor() const override {
         return {
             .name = "TestClap",
@@ -38,6 +46,17 @@ public:
             for (std::size_t i = 0; i < out.num_samples(); ++i) oc[i] = ic[i];
         }
     }
+
+    std::vector<uint8_t> serialize_plugin_state() const override {
+        return std::vector<uint8_t>(plugin_state.begin(), plugin_state.end());
+    }
+
+    bool deserialize_plugin_state(std::span<const uint8_t> data) override {
+        plugin_state.assign(data.begin(), data.end());
+        return true;
+    }
+
+    std::string plugin_state;
 };
 
 inline std::unique_ptr<pulp::format::Processor> create_test() {
@@ -45,6 +64,34 @@ inline std::unique_ptr<pulp::format::Processor> create_test() {
 }
 
 } // namespace test_clap
+
+namespace {
+
+using Catch::Matchers::WithinAbs;
+
+struct MemoryStream {
+    std::vector<uint8_t> bytes;
+    std::size_t read_offset = 0;
+};
+
+int64_t stream_write(const clap_ostream_t* stream, const void* buffer, uint64_t size) {
+    auto* sink = static_cast<MemoryStream*>(stream->ctx);
+    const auto* bytes = static_cast<const uint8_t*>(buffer);
+    sink->bytes.insert(sink->bytes.end(), bytes, bytes + size);
+    return static_cast<int64_t>(size);
+}
+
+int64_t stream_read(const clap_istream_t* stream, void* buffer, uint64_t size) {
+    auto* source = static_cast<MemoryStream*>(stream->ctx);
+    const auto remaining = source->bytes.size() - source->read_offset;
+    const auto to_copy = remaining < size ? remaining : static_cast<std::size_t>(size);
+    if (to_copy == 0) return 0;
+    std::memcpy(buffer, source->bytes.data() + source->read_offset, to_copy);
+    source->read_offset += to_copy;
+    return static_cast<int64_t>(to_copy);
+}
+
+} // namespace
 
 // Generate the CLAP entry
 PULP_CLAP_PLUGIN(test_clap::create_test)
@@ -68,5 +115,53 @@ TEST_CASE("PULP_CLAP_PLUGIN generates valid entry", "[clap][entry]") {
     REQUIRE(std::string(desc->id) == "com.pulp.test.clap");
     REQUIRE(std::string(desc->vendor) == "PulpTest");
 
+    clap_entry.deinit();
+}
+
+TEST_CASE("CLAP state extension round-trips plugin-owned payload", "[clap][entry][state]") {
+    REQUIRE(clap_entry.init("test"));
+
+    auto* factory = static_cast<const clap_plugin_factory_t*>(
+        clap_entry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+    REQUIRE(factory != nullptr);
+    auto* desc = factory->get_plugin_descriptor(factory, 0);
+    REQUIRE(desc != nullptr);
+
+    const clap_plugin_t* plugin1 = factory->create_plugin(factory, nullptr, desc->id);
+    REQUIRE(plugin1 != nullptr);
+    REQUIRE(plugin1->init(plugin1));
+    auto* proc1 = test_clap::g_last_processor;
+    REQUIRE(proc1 != nullptr);
+    proc1->state().set_value(1, -12.5f);
+    proc1->plugin_state = "snapshots=A|B";
+
+    auto* state1 = static_cast<const clap_plugin_state_t*>(
+        plugin1->get_extension(plugin1, CLAP_EXT_STATE));
+    REQUIRE(state1 != nullptr);
+
+    MemoryStream sink;
+    clap_ostream_t out_stream{.ctx = &sink, .write = stream_write};
+    REQUIRE(state1->save(plugin1, &out_stream));
+
+    const clap_plugin_t* plugin2 = factory->create_plugin(factory, nullptr, desc->id);
+    REQUIRE(plugin2 != nullptr);
+    REQUIRE(plugin2->init(plugin2));
+    auto* proc2 = test_clap::g_last_processor;
+    REQUIRE(proc2 != nullptr);
+    proc2->state().set_value(1, 6.0f);
+    proc2->plugin_state = "stale";
+
+    auto* state2 = static_cast<const clap_plugin_state_t*>(
+        plugin2->get_extension(plugin2, CLAP_EXT_STATE));
+    REQUIRE(state2 != nullptr);
+
+    MemoryStream source{.bytes = sink.bytes};
+    clap_istream_t in_stream{.ctx = &source, .read = stream_read};
+    REQUIRE(state2->load(plugin2, &in_stream));
+    REQUIRE_THAT(proc2->state().get_value(1), WithinAbs(-12.5, 0.01));
+    REQUIRE(proc2->plugin_state == "snapshots=A|B");
+
+    plugin1->destroy(plugin1);
+    plugin2->destroy(plugin2);
     clap_entry.deinit();
 }

--- a/test/test_headless.cpp
+++ b/test/test_headless.cpp
@@ -7,9 +7,12 @@
 namespace {
 
 static pulp::format::ProcessContext last_context{};
+static class TestGainProcessor* last_processor = nullptr;
 
 class TestGainProcessor : public pulp::format::Processor {
 public:
+    TestGainProcessor() { last_processor = this; }
+
     pulp::format::PluginDescriptor descriptor() const override {
         return {
             .name = "TestGain",
@@ -49,6 +52,17 @@ public:
                 out[i] = in[i] * gain;
         }
     }
+
+    std::vector<uint8_t> serialize_plugin_state() const override {
+        return std::vector<uint8_t>(plugin_state.begin(), plugin_state.end());
+    }
+
+    bool deserialize_plugin_state(std::span<const uint8_t> data) override {
+        plugin_state.assign(data.begin(), data.end());
+        return true;
+    }
+
+    std::string plugin_state;
 };
 
 std::unique_ptr<pulp::format::Processor> create_test_gain() {
@@ -145,4 +159,22 @@ TEST_CASE("HeadlessHost state round-trip", "[headless]") {
     pulp::format::HeadlessHost host2(create_test_gain);
     REQUIRE(host2.load_state(saved));
     REQUIRE_THAT(host2.state().get_value(1), WithinAbs(-12.5, 0.01));
+}
+
+TEST_CASE("HeadlessHost state round-trip includes plugin-owned payload", "[headless]") {
+    pulp::format::HeadlessHost host1(create_test_gain);
+    REQUIRE(last_processor != nullptr);
+    last_processor->plugin_state = "bands=56;view=40-18000";
+    host1.state().set_value(1, -18.0f);
+
+    auto saved = host1.save_state();
+
+    pulp::format::HeadlessHost host2(create_test_gain);
+    auto* restored_processor = last_processor;
+    REQUIRE(restored_processor != nullptr);
+    restored_processor->plugin_state = "stale";
+
+    REQUIRE(host2.load_state(saved));
+    REQUIRE_THAT(host2.state().get_value(1), WithinAbs(-18.0, 0.01));
+    REQUIRE(restored_processor->plugin_state == "bands=56;view=40-18000");
 }

--- a/test/test_headless.cpp
+++ b/test/test_headless.cpp
@@ -69,6 +69,10 @@ std::unique_ptr<pulp::format::Processor> create_test_gain() {
     return std::make_unique<TestGainProcessor>();
 }
 
+std::unique_ptr<pulp::format::Processor> create_null_processor() {
+    return {};
+}
+
 } // anonymous namespace
 
 using Catch::Matchers::WithinAbs;
@@ -177,4 +181,12 @@ TEST_CASE("HeadlessHost state round-trip includes plugin-owned payload", "[headl
     REQUIRE(host2.load_state(saved));
     REQUIRE_THAT(host2.state().get_value(1), WithinAbs(-18.0, 0.01));
     REQUIRE(restored_processor->plugin_state == "bands=56;view=40-18000");
+}
+
+TEST_CASE("HeadlessHost save/load fail cleanly without a processor", "[headless]") {
+    pulp::format::HeadlessHost host(create_null_processor);
+    REQUIRE(host.save_state().empty());
+
+    const std::vector<uint8_t> bad_state = {'N', 'O', 'P', 'E'};
+    REQUIRE_FALSE(host.load_state(bad_state));
 }

--- a/test/test_plugin_state_io.cpp
+++ b/test/test_plugin_state_io.cpp
@@ -1,8 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <choc/memory/choc_Endianness.h>
 #include <pulp/format/plugin_state_io.hpp>
 #include <pulp/format/processor.hpp>
 
+#include <array>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -25,17 +28,23 @@ public:
     }
 
     void define_parameters(pulp::state::StateStore& store) override {
+        store.add_group({
+            .id = 1,
+            .name = "Main",
+        });
         store.add_parameter({
             .id = 1,
             .name = "Gain",
             .unit = "dB",
             .range = {-60.0f, 24.0f, 0.0f, 0.1f},
+            .group_id = 1,
         });
         store.add_parameter({
             .id = 2,
             .name = "Mix",
             .unit = "%",
             .range = {0.0f, 100.0f, 100.0f, 0.1f},
+            .group_id = 1,
         });
     }
 
@@ -69,6 +78,31 @@ public:
     std::vector<uint8_t> last_payload;
 };
 
+class DefaultPluginStateProcessor : public pulp::format::Processor {
+public:
+    pulp::format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "DefaultPluginStateProcessor",
+            .manufacturer = "PulpTest",
+            .bundle_id = "com.pulp.test.default-plugin-state-io",
+            .version = "1.0.0",
+            .category = pulp::format::PluginCategory::Effect,
+            .input_buses = {{"Audio In", 2}},
+            .output_buses = {{"Audio Out", 2}},
+        };
+    }
+
+    void define_parameters(pulp::state::StateStore&) override {}
+
+    void prepare(const pulp::format::PrepareContext&) override {}
+
+    void process(pulp::audio::BufferView<float>&,
+                 const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const pulp::format::ProcessContext&) override {}
+};
+
 struct TestRig {
     pulp::state::StateStore store;
     TestPluginStateProcessor processor;
@@ -79,7 +113,56 @@ struct TestRig {
     }
 };
 
+constexpr uint8_t kEnvelopeMagic[4] = {'P', 'L', 'S', 'T'};
+
+uint32_t crc32_simple(const uint8_t* data, std::size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (std::size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; ++j) {
+            const uint32_t mask = (crc & 1u) ? 0xFFFFFFFFu : 0u;
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
+}
+
+void append_u32(std::vector<uint8_t>& bytes, uint32_t value) {
+    uint8_t out[4];
+    choc::memory::writeLittleEndian(out, value);
+    bytes.insert(bytes.end(), out, out + sizeof(out));
+}
+
+void write_u32(std::vector<uint8_t>& bytes, std::size_t offset, uint32_t value) {
+    REQUIRE(offset + 4 <= bytes.size());
+    choc::memory::writeLittleEndian(bytes.data() + offset, value);
+}
+
+std::vector<uint8_t> make_envelope(std::span<const uint8_t> store_blob,
+                                   std::span<const uint8_t> plugin_blob = {},
+                                   uint32_t version = 1) {
+    std::vector<uint8_t> bytes;
+    bytes.insert(bytes.end(), kEnvelopeMagic, kEnvelopeMagic + 4);
+    append_u32(bytes, version);
+    append_u32(bytes, static_cast<uint32_t>(store_blob.size()));
+    append_u32(bytes, static_cast<uint32_t>(plugin_blob.size()));
+    bytes.insert(bytes.end(), store_blob.begin(), store_blob.end());
+    bytes.insert(bytes.end(), plugin_blob.begin(), plugin_blob.end());
+    append_u32(bytes, crc32_simple(bytes.data(), bytes.size()));
+    return bytes;
+}
+
 } // namespace
+
+TEST_CASE("Processor default plugin-state hooks are no-ops", "[format][plugin-state]") {
+    DefaultPluginStateProcessor processor;
+    REQUIRE(processor.serialize_plugin_state().empty());
+
+    REQUIRE(processor.deserialize_plugin_state({}));
+
+    const std::array<uint8_t, 4> payload = {'N', 'O', 'P', 'E'};
+    REQUIRE(processor.deserialize_plugin_state(payload));
+}
 
 TEST_CASE("plugin_state_io round-trips parameter and plugin-owned state",
           "[format][plugin-state]") {
@@ -130,6 +213,20 @@ TEST_CASE("plugin_state_io preserves legacy raw StateStore blobs and resets plug
     REQUIRE(restored.processor.last_payload.empty());
 }
 
+TEST_CASE("plugin_state_io serialize falls back to raw StateStore blobs when plugin payload is empty",
+          "[format][plugin-state]") {
+    TestRig source;
+    source.store.set_value(1, -7.5f);
+    source.processor.plugin_state.clear();
+
+    auto blob = pulp::format::plugin_state_io::serialize(source.store, source.processor);
+    REQUIRE(blob.size() >= 4);
+    REQUIRE(blob[0] == 'P');
+    REQUIRE(blob[1] == 'U');
+    REQUIRE(blob[2] == 'L');
+    REQUIRE(blob[3] == 'P');
+}
+
 TEST_CASE("plugin_state_io rejects corrupt envelopes without touching live state",
           "[format][plugin-state]") {
     TestRig source;
@@ -150,6 +247,104 @@ TEST_CASE("plugin_state_io rejects corrupt envelopes without touching live state
     REQUIRE_THAT(restored.store.get_value(2), WithinAbs(77.0, 0.01));
     REQUIRE(restored.processor.plugin_state == "keep");
     REQUIRE(restored.processor.deserialize_calls == 0);
+}
+
+TEST_CASE("plugin_state_io rejects malformed blobs without touching live state",
+          "[format][plugin-state]") {
+    TestRig reference;
+    reference.store.set_value(1, -18.0f);
+    reference.processor.plugin_state = "snapshot-a";
+    auto legacy_blob = reference.store.serialize();
+
+    std::vector<uint8_t> bad_store = {'N', 'O', 'P', 'E'};
+
+    SECTION("non-envelope garbage") {
+        std::vector<uint8_t> blob = {'N', 'O', 'P', 'E'};
+
+        TestRig restored;
+        restored.store.set_value(1, 3.0f);
+        restored.processor.plugin_state = "keep";
+
+        REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                                 restored.store,
+                                                                 restored.processor));
+        REQUIRE_THAT(restored.store.get_value(1), WithinAbs(3.0, 0.01));
+        REQUIRE(restored.processor.plugin_state == "keep");
+    }
+
+    SECTION("truncated envelope") {
+        std::vector<uint8_t> blob = {'P', 'L', 'S', 'T'};
+
+        TestRig restored;
+        restored.store.set_value(1, 3.0f);
+        restored.processor.plugin_state = "keep";
+
+        REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                                 restored.store,
+                                                                 restored.processor));
+        REQUIRE_THAT(restored.store.get_value(1), WithinAbs(3.0, 0.01));
+        REQUIRE(restored.processor.plugin_state == "keep");
+    }
+
+    SECTION("unsupported version") {
+        auto blob = make_envelope(legacy_blob);
+        write_u32(blob, 4, 2);
+
+        TestRig restored;
+        restored.store.set_value(1, 3.0f);
+        restored.processor.plugin_state = "keep";
+
+        REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                                 restored.store,
+                                                                 restored.processor));
+        REQUIRE_THAT(restored.store.get_value(1), WithinAbs(3.0, 0.01));
+        REQUIRE(restored.processor.plugin_state == "keep");
+    }
+
+    SECTION("payload size exceeds bytes available") {
+        auto blob = make_envelope(legacy_blob);
+        write_u32(blob, 8, static_cast<uint32_t>(legacy_blob.size() + 1));
+
+        TestRig restored;
+        restored.store.set_value(1, 3.0f);
+        restored.processor.plugin_state = "keep";
+
+        REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                                 restored.store,
+                                                                 restored.processor));
+        REQUIRE_THAT(restored.store.get_value(1), WithinAbs(3.0, 0.01));
+        REQUIRE(restored.processor.plugin_state == "keep");
+    }
+
+    SECTION("size mismatch with trailing bytes") {
+        auto blob = make_envelope(legacy_blob);
+        blob.push_back(0x7F);
+
+        TestRig restored;
+        restored.store.set_value(1, 3.0f);
+        restored.processor.plugin_state = "keep";
+
+        REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                                 restored.store,
+                                                                 restored.processor));
+        REQUIRE_THAT(restored.store.get_value(1), WithinAbs(3.0, 0.01));
+        REQUIRE(restored.processor.plugin_state == "keep");
+    }
+
+    SECTION("invalid inner StateStore payload") {
+        auto blob = make_envelope(bad_store);
+
+        TestRig restored;
+        restored.store.set_value(1, 3.0f);
+        restored.processor.plugin_state = "keep";
+
+        REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                                 restored.store,
+                                                                 restored.processor));
+        REQUIRE_THAT(restored.store.get_value(1), WithinAbs(3.0, 0.01));
+        REQUIRE(restored.processor.plugin_state == "keep");
+        REQUIRE(restored.processor.deserialize_calls == 0);
+    }
 }
 
 TEST_CASE("plugin_state_io rolls back StateStore when plugin payload restore fails",

--- a/test/test_plugin_state_io.cpp
+++ b/test/test_plugin_state_io.cpp
@@ -1,0 +1,175 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/format/plugin_state_io.hpp>
+#include <pulp/format/processor.hpp>
+
+#include <string>
+#include <vector>
+
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+class TestPluginStateProcessor : public pulp::format::Processor {
+public:
+    pulp::format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "PluginStateIOTest",
+            .manufacturer = "PulpTest",
+            .bundle_id = "com.pulp.test.plugin-state-io",
+            .version = "1.0.0",
+            .category = pulp::format::PluginCategory::Effect,
+            .input_buses = {{"Audio In", 2}},
+            .output_buses = {{"Audio Out", 2}},
+        };
+    }
+
+    void define_parameters(pulp::state::StateStore& store) override {
+        store.add_parameter({
+            .id = 1,
+            .name = "Gain",
+            .unit = "dB",
+            .range = {-60.0f, 24.0f, 0.0f, 0.1f},
+        });
+        store.add_parameter({
+            .id = 2,
+            .name = "Mix",
+            .unit = "%",
+            .range = {0.0f, 100.0f, 100.0f, 0.1f},
+        });
+    }
+
+    void prepare(const pulp::format::PrepareContext&) override {}
+
+    void process(pulp::audio::BufferView<float>&,
+                 const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const pulp::format::ProcessContext&) override {}
+
+    std::vector<uint8_t> serialize_plugin_state() const override {
+        return std::vector<uint8_t>(plugin_state.begin(), plugin_state.end());
+    }
+
+    bool deserialize_plugin_state(std::span<const uint8_t> data) override {
+        ++deserialize_calls;
+        last_payload.assign(data.begin(), data.end());
+        const std::string payload(data.begin(), data.end());
+        if (!rejected_payload.empty() && payload == rejected_payload) {
+            return false;
+        }
+
+        plugin_state = payload;
+        return true;
+    }
+
+    std::string plugin_state;
+    std::string rejected_payload;
+    int deserialize_calls = 0;
+    std::vector<uint8_t> last_payload;
+};
+
+struct TestRig {
+    pulp::state::StateStore store;
+    TestPluginStateProcessor processor;
+
+    TestRig() {
+        processor.set_state_store(&store);
+        processor.define_parameters(store);
+    }
+};
+
+} // namespace
+
+TEST_CASE("plugin_state_io round-trips parameter and plugin-owned state",
+          "[format][plugin-state]") {
+    TestRig source;
+    source.store.set_value(1, -12.5f);
+    source.store.set_value(2, 42.0f);
+    source.processor.plugin_state = "bands=48;view=60-12000";
+
+    auto blob = pulp::format::plugin_state_io::serialize(source.store, source.processor);
+    REQUIRE(blob.size() >= 4);
+    REQUIRE(blob[0] == 'P');
+    REQUIRE(blob[1] == 'L');
+    REQUIRE(blob[2] == 'S');
+    REQUIRE(blob[3] == 'T');
+
+    TestRig restored;
+    restored.store.set_value(1, 6.0f);
+    restored.processor.plugin_state = "stale";
+
+    REQUIRE(pulp::format::plugin_state_io::deserialize(blob,
+                                                       restored.store,
+                                                       restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(-12.5, 0.01));
+    REQUIRE_THAT(restored.store.get_value(2), WithinAbs(42.0, 0.01));
+    REQUIRE(restored.processor.plugin_state == "bands=48;view=60-12000");
+}
+
+TEST_CASE("plugin_state_io preserves legacy raw StateStore blobs and resets plugin payload",
+          "[format][plugin-state]") {
+    TestRig source;
+    source.store.set_value(1, -9.0f);
+    auto legacy_blob = source.store.serialize();
+    REQUIRE(legacy_blob.size() >= 4);
+    REQUIRE(legacy_blob[0] == 'P');
+    REQUIRE(legacy_blob[1] == 'U');
+    REQUIRE(legacy_blob[2] == 'L');
+    REQUIRE(legacy_blob[3] == 'P');
+
+    TestRig restored;
+    restored.processor.plugin_state = "stale";
+
+    REQUIRE(pulp::format::plugin_state_io::deserialize(legacy_blob,
+                                                       restored.store,
+                                                       restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(-9.0, 0.01));
+    REQUIRE(restored.processor.plugin_state.empty());
+    REQUIRE(restored.processor.deserialize_calls == 1);
+    REQUIRE(restored.processor.last_payload.empty());
+}
+
+TEST_CASE("plugin_state_io rejects corrupt envelopes without touching live state",
+          "[format][plugin-state]") {
+    TestRig source;
+    source.store.set_value(1, -18.0f);
+    source.processor.plugin_state = "snapshot-a";
+    auto blob = pulp::format::plugin_state_io::serialize(source.store, source.processor);
+    blob.back() ^= 0xFF;
+
+    TestRig restored;
+    restored.store.set_value(1, 3.0f);
+    restored.store.set_value(2, 77.0f);
+    restored.processor.plugin_state = "keep";
+
+    REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                             restored.store,
+                                                             restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(3.0, 0.01));
+    REQUIRE_THAT(restored.store.get_value(2), WithinAbs(77.0, 0.01));
+    REQUIRE(restored.processor.plugin_state == "keep");
+    REQUIRE(restored.processor.deserialize_calls == 0);
+}
+
+TEST_CASE("plugin_state_io rolls back StateStore when plugin payload restore fails",
+          "[format][plugin-state]") {
+    TestRig source;
+    source.store.set_value(1, -24.0f);
+    source.processor.plugin_state = "snapshot-b";
+    auto blob = pulp::format::plugin_state_io::serialize(source.store, source.processor);
+
+    TestRig restored;
+    restored.store.set_value(1, 5.0f);
+    restored.store.set_value(2, 12.0f);
+    restored.processor.plugin_state = "keep";
+    restored.processor.rejected_payload = "snapshot-b";
+
+    REQUIRE_FALSE(pulp::format::plugin_state_io::deserialize(blob,
+                                                             restored.store,
+                                                             restored.processor));
+    REQUIRE_THAT(restored.store.get_value(1), WithinAbs(5.0, 0.01));
+    REQUIRE_THAT(restored.store.get_value(2), WithinAbs(12.0, 0.01));
+    REQUIRE(restored.processor.plugin_state == "keep");
+    REQUIRE(restored.processor.deserialize_calls == 2);
+}

--- a/test/test_validation_harness.cpp
+++ b/test/test_validation_harness.cpp
@@ -15,8 +15,12 @@
 
 namespace {
 
+static class TestGainProcessor* last_processor = nullptr;
+
 class TestGainProcessor : public pulp::format::Processor {
 public:
+    TestGainProcessor() { last_processor = this; }
+
     pulp::format::PluginDescriptor descriptor() const override {
         return {
             .name = "HarnessTestGain",
@@ -68,7 +72,17 @@ public:
         }
     }
 
+    std::vector<uint8_t> serialize_plugin_state() const override {
+        return std::vector<uint8_t>(plugin_state.begin(), plugin_state.end());
+    }
+
+    bool deserialize_plugin_state(std::span<const uint8_t> data) override {
+        plugin_state.assign(data.begin(), data.end());
+        return true;
+    }
+
     int note_on_count_ = 0;
+    std::string plugin_state;
 };
 
 std::unique_ptr<pulp::format::Processor> create_test_gain() {
@@ -166,6 +180,26 @@ TEST_CASE("ValidationHarness state round-trip", "[harness][phase2]") {
     REQUIRE(h2.load_state(saved));
     REQUIRE_THAT(h2.get_param(1), WithinAbs(-12.5, 0.01));
     REQUIRE_THAT(h2.get_param(2), WithinAbs(0.75, 0.01));
+}
+
+TEST_CASE("ValidationHarness state round-trip includes plugin-owned payload", "[harness][phase2]") {
+    pulp::format::ValidationHarness h1(create_test_gain);
+    h1.configure({});
+    REQUIRE(last_processor != nullptr);
+    last_processor->plugin_state = "snapshots=A|B";
+    h1.set_param(1, -9.0f);
+
+    auto saved = h1.save_state();
+
+    pulp::format::ValidationHarness h2(create_test_gain);
+    h2.configure({});
+    auto* restored_processor = last_processor;
+    REQUIRE(restored_processor != nullptr);
+    restored_processor->plugin_state = "stale";
+
+    REQUIRE(h2.load_state(saved));
+    REQUIRE_THAT(h2.get_param(1), WithinAbs(-9.0, 0.01));
+    REQUIRE(restored_processor->plugin_state == "snapshots=A|B");
 }
 
 // ── Report generation ───────────────────────────────────────────────────────

--- a/test/test_vst3_plugin_state.cpp
+++ b/test/test_vst3_plugin_state.cpp
@@ -62,6 +62,10 @@ std::unique_ptr<pulp::format::Processor> create_test_processor() {
     return std::make_unique<TestVst3Processor>();
 }
 
+std::unique_ptr<pulp::format::Processor> create_null_processor() {
+    return {};
+}
+
 class HostApp final : public Steinberg::Vst::IHostApplication {
 public:
     Steinberg::tresult PLUGIN_API getName(Steinberg::Vst::String128 name) override {
@@ -211,4 +215,51 @@ TEST_CASE("VST3 getState/setState round-trip includes plugin-owned payload",
 
     REQUIRE(loader.terminate() == Steinberg::kResultOk);
     REQUIRE(saver.terminate() == Steinberg::kResultOk);
+}
+
+TEST_CASE("VST3 setState rejects invalid plugin payload",
+          "[vst3][state]") {
+    HostApp host_app;
+
+    pulp::format::vst3::PulpVst3Processor loader(create_test_processor);
+    REQUIRE(loader.initialize(&host_app) == Steinberg::kResultOk);
+    auto* processor = TestVst3Processor::g_last_processor;
+    REQUIRE(processor != nullptr);
+    processor->state().set_value(1, 7.0f);
+    processor->plugin_state = "keep";
+
+    VectorStream bad_stream(std::vector<uint8_t>{'N', 'O', 'P', 'E'});
+    REQUIRE(loader.setState(&bad_stream) == Steinberg::kResultFalse);
+    REQUIRE_THAT(processor->state().get_value(1), WithinAbs(7.0, 0.01));
+    REQUIRE(processor->plugin_state == "keep");
+
+    REQUIRE(loader.terminate() == Steinberg::kResultOk);
+}
+
+TEST_CASE("VST3 getState/setState fail cleanly without a live processor",
+          "[vst3][state]") {
+    HostApp host_app;
+
+    SECTION("after terminate") {
+        pulp::format::vst3::PulpVst3Processor processor(create_test_processor);
+        REQUIRE(processor.initialize(&host_app) == Steinberg::kResultOk);
+        REQUIRE(processor.terminate() == Steinberg::kResultOk);
+
+        VectorStream out_stream;
+        REQUIRE(processor.getState(&out_stream) == Steinberg::kResultFalse);
+
+        VectorStream in_stream(std::vector<uint8_t>{'N', 'O', 'P', 'E'});
+        REQUIRE(processor.setState(&in_stream) == Steinberg::kResultFalse);
+    }
+
+    SECTION("null factory") {
+        pulp::format::vst3::PulpVst3Processor processor(create_null_processor);
+        REQUIRE(processor.initialize(&host_app) == Steinberg::kInternalError);
+
+        VectorStream out_stream;
+        REQUIRE(processor.getState(&out_stream) == Steinberg::kResultFalse);
+
+        VectorStream in_stream(std::vector<uint8_t>{'N', 'O', 'P', 'E'});
+        REQUIRE(processor.setState(&in_stream) == Steinberg::kResultFalse);
+    }
 }

--- a/test/test_vst3_plugin_state.cpp
+++ b/test/test_vst3_plugin_state.cpp
@@ -1,0 +1,214 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/format/vst3_adapter.hpp>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+class TestVst3Processor : public pulp::format::Processor {
+public:
+    TestVst3Processor() { g_last_processor = this; }
+
+    pulp::format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "Vst3PluginStateTest",
+            .manufacturer = "PulpTest",
+            .bundle_id = "com.pulp.test.vst3-plugin-state",
+            .version = "1.0.0",
+            .category = pulp::format::PluginCategory::Effect,
+            .input_buses = {{"Audio In", 2}},
+            .output_buses = {{"Audio Out", 2}},
+        };
+    }
+
+    void define_parameters(pulp::state::StateStore& store) override {
+        store.add_parameter({
+            .id = 1,
+            .name = "Gain",
+            .unit = "dB",
+            .range = {-60.0f, 24.0f, 0.0f, 0.1f},
+        });
+    }
+
+    void prepare(const pulp::format::PrepareContext&) override {}
+
+    void process(pulp::audio::BufferView<float>&,
+                 const pulp::audio::BufferView<const float>&,
+                 pulp::midi::MidiBuffer&,
+                 pulp::midi::MidiBuffer&,
+                 const pulp::format::ProcessContext&) override {}
+
+    std::vector<uint8_t> serialize_plugin_state() const override {
+        return std::vector<uint8_t>(plugin_state.begin(), plugin_state.end());
+    }
+
+    bool deserialize_plugin_state(std::span<const uint8_t> data) override {
+        plugin_state.assign(data.begin(), data.end());
+        return true;
+    }
+
+    std::string plugin_state;
+    static TestVst3Processor* g_last_processor;
+};
+
+TestVst3Processor* TestVst3Processor::g_last_processor = nullptr;
+
+std::unique_ptr<pulp::format::Processor> create_test_processor() {
+    return std::make_unique<TestVst3Processor>();
+}
+
+class HostApp final : public Steinberg::Vst::IHostApplication {
+public:
+    Steinberg::tresult PLUGIN_API getName(Steinberg::Vst::String128 name) override {
+        const char* kName = "PulpTest";
+        for (int i = 0; i < 127 && kName[i]; ++i) {
+            name[i] = static_cast<Steinberg::Vst::TChar>(kName[i]);
+        }
+        name[8] = 0;
+        return Steinberg::kResultTrue;
+    }
+
+    Steinberg::tresult PLUGIN_API createInstance(Steinberg::TUID,
+                                                 Steinberg::TUID,
+                                                 void** obj) override {
+        if (obj) *obj = nullptr;
+        return Steinberg::kNotImplemented;
+    }
+
+    Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid,
+                                                 void** obj) override {
+        if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IHostApplication::iid) ||
+            Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid)) {
+            *obj = static_cast<Steinberg::Vst::IHostApplication*>(this);
+            return Steinberg::kResultTrue;
+        }
+        *obj = nullptr;
+        return Steinberg::kNoInterface;
+    }
+
+    Steinberg::uint32 PLUGIN_API addRef() override { return 1; }
+    Steinberg::uint32 PLUGIN_API release() override { return 1; }
+};
+
+class VectorStream final : public Steinberg::IBStream {
+public:
+    VectorStream() = default;
+    explicit VectorStream(const std::vector<uint8_t>& src) : buf_(src) {}
+
+    std::vector<uint8_t> take() { return std::move(buf_); }
+
+    Steinberg::tresult PLUGIN_API read(void* buffer, Steinberg::int32 num_bytes,
+                                       Steinberg::int32* num_bytes_read) override {
+        if (num_bytes < 0) return Steinberg::kInvalidArgument;
+        const Steinberg::int64 remaining =
+            static_cast<Steinberg::int64>(buf_.size()) - pos_;
+        const Steinberg::int64 count = num_bytes < remaining ? num_bytes : remaining;
+        if (count > 0) {
+            std::memcpy(buffer, buf_.data() + pos_, static_cast<std::size_t>(count));
+        }
+        pos_ += count;
+        if (num_bytes_read) *num_bytes_read = static_cast<Steinberg::int32>(count);
+        return Steinberg::kResultOk;
+    }
+
+    Steinberg::tresult PLUGIN_API write(void* buffer, Steinberg::int32 num_bytes,
+                                        Steinberg::int32* num_bytes_written) override {
+        if (num_bytes < 0) return Steinberg::kInvalidArgument;
+        const auto* bytes = static_cast<const uint8_t*>(buffer);
+        buf_.insert(buf_.end(), bytes, bytes + num_bytes);
+        pos_ = static_cast<Steinberg::int64>(buf_.size());
+        if (num_bytes_written) *num_bytes_written = num_bytes;
+        return Steinberg::kResultOk;
+    }
+
+    Steinberg::tresult PLUGIN_API seek(Steinberg::int64 pos, Steinberg::int32 mode,
+                                       Steinberg::int64* result) override {
+        Steinberg::int64 new_pos = pos_;
+        switch (mode) {
+            case kIBSeekSet:
+                new_pos = pos;
+                break;
+            case kIBSeekCur:
+                new_pos = pos_ + pos;
+                break;
+            case kIBSeekEnd:
+                new_pos = static_cast<Steinberg::int64>(buf_.size()) + pos;
+                break;
+            default:
+                return Steinberg::kInvalidArgument;
+        }
+        if (new_pos < 0 || new_pos > static_cast<Steinberg::int64>(buf_.size())) {
+            return Steinberg::kInvalidArgument;
+        }
+        pos_ = new_pos;
+        if (result) *result = pos_;
+        return Steinberg::kResultOk;
+    }
+
+    Steinberg::tresult PLUGIN_API tell(Steinberg::int64* pos) override {
+        if (!pos) return Steinberg::kInvalidArgument;
+        *pos = pos_;
+        return Steinberg::kResultOk;
+    }
+
+    Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid,
+                                                 void** obj) override {
+        if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::IBStream::iid) ||
+            Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid)) {
+            *obj = static_cast<Steinberg::IBStream*>(this);
+            return Steinberg::kResultTrue;
+        }
+        *obj = nullptr;
+        return Steinberg::kNoInterface;
+    }
+
+    Steinberg::uint32 PLUGIN_API addRef() override { return 1; }
+    Steinberg::uint32 PLUGIN_API release() override { return 1; }
+
+private:
+    std::vector<uint8_t> buf_;
+    Steinberg::int64 pos_ = 0;
+};
+
+} // namespace
+
+TEST_CASE("VST3 getState/setState round-trip includes plugin-owned payload",
+          "[vst3][state]") {
+    HostApp host_app;
+
+    pulp::format::vst3::PulpVst3Processor saver(create_test_processor);
+    REQUIRE(saver.initialize(&host_app) == Steinberg::kResultOk);
+    auto* saver_processor = TestVst3Processor::g_last_processor;
+    REQUIRE(saver_processor != nullptr);
+    saver_processor->state().set_value(1, -15.0f);
+    saver_processor->plugin_state = "layout=64";
+
+    VectorStream out_stream;
+    REQUIRE(saver.getState(&out_stream) == Steinberg::kResultOk);
+    auto saved = out_stream.take();
+    REQUIRE(saved.size() >= 4);
+    REQUIRE(saved[0] == 'P');
+    REQUIRE(saved[1] == 'L');
+    REQUIRE(saved[2] == 'S');
+    REQUIRE(saved[3] == 'T');
+
+    pulp::format::vst3::PulpVst3Processor loader(create_test_processor);
+    REQUIRE(loader.initialize(&host_app) == Steinberg::kResultOk);
+    auto* loader_processor = TestVst3Processor::g_last_processor;
+    REQUIRE(loader_processor != nullptr);
+    loader_processor->state().set_value(1, 9.0f);
+    loader_processor->plugin_state = "stale";
+
+    VectorStream in_stream(saved);
+    REQUIRE(loader.setState(&in_stream) == Steinberg::kResultOk);
+    REQUIRE_THAT(loader_processor->state().get_value(1), WithinAbs(-15.0, 0.01));
+    REQUIRE(loader_processor->plugin_state == "layout=64");
+
+    REQUIRE(loader.terminate() == Steinberg::kResultOk);
+    REQUIRE(saver.terminate() == Steinberg::kResultOk);
+}


### PR DESCRIPTION
## Summary
- add `Processor::serialize_plugin_state()` / `deserialize_plugin_state()` and a shared `plugin_state_io` envelope that preserves legacy raw `StateStore` blobs when no processor-owned payload is present
- route the combined state blob through CLAP, VST3, AU v2, AU v3, `HeadlessHost`, and `ValidationHarness`, with rollback when processor-owned restore fails
- add round-trip coverage for the helper plus CLAP, VST3, AU v2 effect/instrument, AU v3, headless, and validation harness
- document the distinction between flat automatable `StateStore` data and opaque plugin-owned state

## Verification
- `./build/test/pulp-test-plugin-state-io`
- `./build/test/pulp-test-headless`
- `./build/test/pulp-test-validation-harness`
- `./build/test/pulp-test-clap-entry`
- `./build/test/pulp-test-vst3-plugin-state`
- `./build/test/pulp-test-au-plugin-state`

Closes #625