### PR TITLE
docs(ci-skill): note v0.24.0/v0.25.0 behavior changes at new pin

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -35,8 +35,8 @@ When the user says any of: **"push to main"**, **"ship this"**, **"ship it"**,
 **"we're done"**, **"merge this"**, **"push it"**, **"run CI"**, **"push a PR"** —
 run `shipyard pr` (not `gh pr create` + `shipyard ship` separately).
 
-`shipyard pr` is the single orchestrator (Shipyard v0.19.1+; pinned as v0.21.0
-in `tools/shipyard.toml`). It:
+`shipyard pr` is the single orchestrator (Shipyard v0.19.1+; pinned at
+v0.25.0 in `tools/shipyard.toml`). It:
 
 1. Calls `tools/scripts/skill_sync_check.py` (resolved via Shipyard's
    `[validation]` path-discovery, explicit in `.shipyard/config.toml`) and
@@ -61,6 +61,28 @@ valid, agents should prefer `shipyard pr` for directness.
 Backward compatibility: raw `shipyard ship` / `shipyard run` still work for
 diagnostics, experimental branches, or when `shipyard pr` itself is being
 debugged. Do not use them as the primary ship path.
+
+### Behaviour notes at the current pin (v0.25.0)
+
+- **Auto-PR titles and bodies use the feature commit** (Shipyard v0.24.0 /
+  Shipyard #151). The orchestrator walks past the mechanical
+  `chore: bump versions` commit when composing the title/body, and scrubs
+  the `Automated by shipyard pr.` tool-branding text. Pulp PR #624 was the
+  canonical repro before the fix. Previously the auto-PR pointed at the
+  bump commit — generic and uninformative. Shipped PRs now read as
+  first-party.
+- **`Version-Bump:` trailers are authoritative, not ceiling-raising**
+  (Shipyard v0.25.0 / Shipyard #152). An author-declared
+  `Version-Bump: <surface>=patch reason="..."` is no longer silently
+  raised to `minor` when the conventional-commit heuristic on other
+  subjects classifies the diff as `minor`. This matches the pulp-side
+  behaviour in `tools/scripts/version_bump_check.py` at this pin.
+- **`shipyard ship-state list` is served from the daemon via IPC** when
+  `shipyard daemon` is running (Shipyard v0.25.0 / Shipyard #154). The
+  PyInstaller cold-start (~5-6s) is bypassed. Callers that tight-loop
+  over ship-state — the macOS GUI polls every 7s; `pulp pr` preflight
+  calls it indirectly — see a meaningful CPU saving. Nothing to do at
+  the pulp side; it's transparent.
 
 ### SSH preflight (v0.20.0+ / Shipyard #106)
 

--- a/tools/scripts/version_bump_check.py
+++ b/tools/scripts/version_bump_check.py
@@ -15,11 +15,19 @@ Heuristics (per surface, deliberately conservative):
     - If only internal_only_paths changed       → patch-suggested
     - If any public_api_paths changed (non-comment/whitespace diff)
                                                 → minor-required
-    - If a Version-Bump: <surface>=<level>      → that level wins (after
-      path filtering — a plugin-only `BREAKING` does not bump the SDK)
+    - If a Version-Bump: <surface>=<level>      → that level is
+      authoritative (Shipyard v0.25.0 / PR #152): used as-is, not
+      just as a ceiling. Can lower a minor-heuristic to patch when the
+      author judges wide-surface-area diffs as still semver-patch.
+      The `reason="..."` string is the justification-of-record.
+      Still path-filtered — a plugin-only `Version-Bump: sdk=major`
+      is ignored when the SDK's trigger_paths weren't touched.
     - Conventional-commit subjects (`feat:`, `fix:`, `BREAKING:` or `!:`
       in subjects) may RAISE the heuristic verdict on a surface whose
-      trigger_paths were actually touched. Cannot lower it.
+      trigger_paths were actually touched. Cannot lower it. Skipped
+      entirely when an explicit `<surface>=<level>` trailer is present
+      (otherwise a `feat:` could silently revert an author-declared
+      `=patch` back to `=minor`, defeating the trailer).
     - Revert commits (subject starts with `Revert` or `Revert-Of:` trailer)
       suppress signals from the reverted work.
 
@@ -590,32 +598,43 @@ def assess_surfaces(
         override = surface_trailer_override(trailers, cfg.trailer_version_bump, s.name)
         final = heur
         skip_requested = (override == "skip")
+        explicit_level = override in LEVELS
 
         if skip_requested:
             final = "none"
-        elif override in LEVELS:
-            # Only raise, never lower. The override applies whenever the
-            # surface's trigger paths were touched at all — even if the
-            # diff-content heuristic fell through to "none" (comments only,
-            # whitespace only, etc.). This lets authors force a bump on a
-            # touched surface without the script second-guessing them.
-            # Untouched surfaces still ignore the override to avoid
-            # rubber-stamping unrelated bumps.
+        elif explicit_level:
+            # `Version-Bump: <surface>=<level> reason="..."` is authoritative
+            # (Shipyard v0.25.0 / PR #152): the author stated the level AND
+            # accepted accountability via the `reason` string. Use it exactly —
+            # this is *not* "can only raise". Patch can override a minor
+            # heuristic when the author judges that a wide-surface-area diff
+            # is still semver-patch (e.g. a bug fix that touches many files).
+            # The reason string is the justification-of-record; reviewers can
+            # still push back in PR review. Silently falling back to the
+            # heuristic when the author asked for a lower level defeats the
+            # entire point of the trailer. Untouched surfaces still ignore
+            # the override to avoid rubber-stamping unrelated bumps.
             if not trigger_touched:
                 final = "none"
-            elif heur == "none":
-                final = override
-            elif LEVELS.index(override) > LEVELS.index(heur):
+            elif heur != "none":
                 final = override
             else:
-                final = heur
+                # Surface has trigger-touched paths but the content
+                # heuristic saw nothing meaningful (comments only, etc.).
+                # Honor the override — the author knows the change is
+                # API-visible even if the byte-diff doesn't show it.
+                final = override
 
         # Promote via conventional-commit subjects on commits that touched
         # THIS surface — never from commits that only touched unrelated
         # paths. A plugin-only `feat:` cannot raise the SDK ceiling. An
         # explicit `Version-Bump: <surface>=skip` on the tip commit is
         # authoritative and is NOT raised back up by conv-commit subjects.
-        if heur != "none" and not skip_requested:
+        # Same reasoning for an explicit `<surface>=<level>` trailer:
+        # otherwise a `feat:` in a commit subject would silently raise an
+        # author-declared `=patch` back to `=minor`, defeating the
+        # trailer's purpose (Shipyard v0.25.0 / PR #152).
+        if heur != "none" and not skip_requested and not explicit_level:
             conv_ceiling = "none"
             for sha, subject, body in git_log_subjects_and_bodies(base, head):
                 if is_revert_commit(subject, {}):

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -84,6 +84,37 @@
 #             shipped via `shipyard pr` now read as first-party and
 #             reviewers see the commit's own rationale without
 #             clicking through to the diff.
+#   v0.23.0 — daemon wait primitive (Shipyard #150) so long-poll
+#             callers (like the macOS GUI) can block on ship-state
+#             changes instead of polling. Unused from pulp-side
+#             currently; it's the building block v0.25.0's daemon
+#             IPC shortcut relies on.
+#   v0.24.0 — `shipyard pr` walks past the mechanical "chore: bump
+#             versions" commit when composing the PR title and body
+#             (Shipyard #151). Previously the auto-PR text pointed
+#             at the bump commit (generic, uninformative) instead
+#             of the feature commit that actually explained the
+#             change. Pulp PR #624 was the canonical repro: title
+#             read "chore: bump versions" and the body was
+#             "Automated by `shipyard pr`." — the tool-branding
+#             text was also scrubbed. v0.24.0 resolves both.
+#   v0.25.0 — two semantic changes pulp benefits from directly:
+#               * `Version-Bump: <surface>=<level>` trailer is now
+#                 authoritative (Shipyard #152). Previously, if an
+#                 author wrote `=patch` but the heuristic classified
+#                 the diff as minor, the heuristic silently won.
+#                 v0.25.0 uses the trailer exactly as written (with
+#                 a `reason` string as the justification-of-record).
+#                 Pulp's `tools/scripts/version_bump_check.py` is
+#                 synced with this behaviour in the same PR that
+#                 bumps the pin.
+#               * `shipyard ship-state list` is served from the
+#                 running daemon via IPC when available, bypassing
+#                 the ~5-6s PyInstaller cold-start on every call
+#                 (Shipyard #154). The macOS GUI polls this every
+#                 7s, so the CPU-time saving compounds. Pulp's
+#                 `pulp pr` also hits this path during skill-sync
+#                 and version-bump preflight.
 #
 # Cumulative additions from earlier releases still in effect:
 #   v0.4–v0.8 — release-bot helpers, `shipyard doctor release-chain`,
@@ -98,7 +129,7 @@
 # in `tools/install-shipyard.sh` (v0.22.1+ `SHIPYARD_VERSION` support).
 # The older `~/.pulp/bin/shipyard` path is cleaned up on install to
 # prevent shadow-on-PATH bugs.
-version = "v0.22.9"
+version = "v0.25.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Skill-sync maps tools/shipyard.toml to the `ci` skill. The pin bump
in 3fb011ca surfaced three new behaviours agents need to know about:

1. Auto-PR title/body now walks past the bump commit (v0.24.0).
2. Version-Bump trailer is authoritative (v0.25.0).
3. ship-state list goes through the daemon over IPC (v0.25.0).

Updated the ci SKILL.md with a new "Behaviour notes at the current
pin" subsection, and corrected the stale `v0.21.0` pin reference.