### PR TITLE
coverage: expand Python tooling lane beyond tools/scripts

### DIFF
--- a/docs/guides/coverage.md
+++ b/docs/guides/coverage.md
@@ -2,8 +2,9 @@
 
 Coverage is measured per-subsystem, per-platform, and per-surface on
 macOS, Linux, and Windows for the native C/C++ lane, with an additional
-Python tooling lane for `tools/scripts/**` on Linux. All reports are
-uploaded to Codecov on every push.
+Python tooling lane on Linux covering `tools/scripts/**`,
+`tools/deps/**`, and `tools/local-ci/**`. All reports are uploaded to
+Codecov on every push.
 [#566](https://github.com/danielraffel/pulp/issues/566) tracks the
 broader coverage initiative.
 
@@ -43,7 +44,8 @@ Native C/C++ coverage:
 scripts/run_coverage.sh
 ```
 
-Python tooling coverage (`tools/scripts/**`):
+Python tooling coverage
+(`tools/scripts/**`, `tools/deps/**`, `tools/local-ci/**`):
 
 ```bash
 python3 -m pip install 'coverage>=7.10' PyYAML
@@ -61,7 +63,7 @@ Output:
 - `build-coverage/coverage.cobertura.xml` — Cobertura XML converted
   from the LCOV via the vendored `tools/scripts/lcov_cobertura.py`.
 - `build-coverage/python/html/index.html` — HTML drilldown for
-  `tools/scripts/**`.
+  the Python tooling lane.
 - `build-coverage/python/summary.txt` — text summary for the Python
   tooling lane.
 - `build-coverage/python/coverage.python.xml` — Cobertura XML emitted
@@ -76,10 +78,11 @@ Xcode toolchain:
 
 The Python tooling lane requires `coverage.py >= 7.10` because
 subprocess coverage support (`[run] patch = subprocess`) is what lets
-tests like `test_resolve_runs_on.py` and `test_gates.py` measure the
-actual script they spawn, not just the test harness. `PyYAML` is also
-required because `tools/scripts/test_codecov_config.py` parses
-`codecov.yml` as part of the lane.
+tests like `test_resolve_runs_on.py`, `test_audit.py`, and
+`test_local_ci.py` measure the actual script they spawn or import, not
+just the test harness. `PyYAML` is also required because
+`tools/scripts/test_codecov_config.py` parses `codecov.yml` as part of
+the lane.
 
 Optional flags:
 
@@ -87,6 +90,9 @@ Optional flags:
 scripts/run_coverage.sh --jobs 16                 # parallelism
 scripts/run_coverage.sh --tests '^pulp-test-audio' # regex filter
 python3 tools/scripts/run_python_coverage.py --pattern 'tools/scripts/test_resolve_runs_on.py'
+python3 tools/scripts/run_python_coverage.py \
+  --pattern 'tools/scripts/test_resolve_runs_on.py' \
+  --pattern 'tools/deps/test_audit.py'
 ```
 
 ### Troubleshooting
@@ -199,16 +205,17 @@ Today the live dashboard includes:
 
 - **Clang C/C++** coverage from the native build graph on macOS, Linux,
   and Windows.
-- **Python** coverage for `tools/scripts/**` on Linux via
+- **Python** coverage for `tools/scripts/**`, `tools/deps/**`, and
+  `tools/local-ci/**` on Linux via
   `tools/scripts/run_python_coverage.py`.
 
 Still out of scope today:
 
 - Swift code under `apple/` — separate SPM/Xcode lane, tracked in
   issue #615.
-- Python outside `tools/scripts/**` (`tools/deps/**`,
-  `tools/local-ci/**`, repo-root `scripts/**`) — follow-up after the
-  `tools/scripts` lane stabilizes.
+- Python outside the current Linux lane (for example top-level
+  `tools/*.py`, `tools/packages/**`, and any future repo-root Python
+  scripts) — follow-up after the current tooling surfaces stabilize.
 - Kotlin/Android coverage.
 
 ## Cross-platform matrix
@@ -217,7 +224,8 @@ The coverage workflow runs on
 `{ubuntu-latest, macos-latest, windows-latest}` for the native lane.
 Each OS produces its own `coverage.cobertura.xml` and uploads to
 Codecov with an OS-tag flag. The Linux leg also uploads the Python
-tools XML for `tools/scripts/**`. We do NOT merge profdata across
+tools XML for `tools/scripts/**`, `tools/deps/**`, and
+`tools/local-ci/**`. We do NOT merge profdata across
 architectures —
 `llvm-profdata merge` is not architecture-portable
 (`planning/coverage-tooling-decision-2026-04-21.md` §7); Codecov does

--- a/tools/scripts/run_python_coverage.py
+++ b/tools/scripts/run_python_coverage.py
@@ -21,6 +21,7 @@ import re
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 try:
@@ -36,7 +37,20 @@ SUMMARY_FILE = OUTPUT_DIR / "summary.txt"
 XML_FILE = OUTPUT_DIR / "coverage.python.xml"
 DATA_FILE = OUTPUT_DIR / ".coverage"
 RCFILE = OUTPUT_DIR / ".coveragerc"
-TEST_GLOB = "tools/scripts/test_*.py"
+
+
+@dataclass(frozen=True)
+class CoverageSurface:
+    source_root: str
+    test_glob: str
+
+
+COVERAGE_SURFACES = (
+    CoverageSurface("tools/scripts", "tools/scripts/test_*.py"),
+    CoverageSurface("tools/deps", "tools/deps/test_*.py"),
+    CoverageSurface("tools/local-ci", "tools/local-ci/test_*.py"),
+)
+DEFAULT_TEST_GLOBS = [surface.test_glob for surface in COVERAGE_SURFACES]
 
 
 def _require_supported_coverage() -> None:
@@ -57,40 +71,75 @@ def _require_supported_coverage() -> None:
         )
 
 
-def _discover_tests(pattern: str) -> list[Path]:
-    tests = sorted(REPO_ROOT.glob(pattern))
-    return [p for p in tests if p.is_file()]
+def _discover_tests(patterns: list[str]) -> list[Path]:
+    seen: set[Path] = set()
+    tests: list[Path] = []
+    for pattern in patterns:
+        for path in sorted(REPO_ROOT.glob(pattern)):
+            if not path.is_file() or path in seen:
+                continue
+            seen.add(path)
+            tests.append(path)
+    return tests
 
 
-def _write_coveragerc() -> None:
+def _selected_surfaces(tests: list[Path]) -> list[CoverageSurface]:
+    selected: list[CoverageSurface] = []
+    for surface in COVERAGE_SURFACES:
+        prefix = f"{surface.source_root}/"
+        if any(test.relative_to(REPO_ROOT).as_posix().startswith(prefix) for test in tests):
+            selected.append(surface)
+    return selected
+
+
+def _write_coveragerc(surfaces: list[CoverageSurface]) -> None:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    source_roots = [surface.source_root for surface in surfaces]
+    omit_globs: list[str] = []
+    for surface in surfaces:
+        omit_globs.append(surface.test_glob)
+        omit_globs.append(f"{surface.source_root}/_*.py")
+    if not source_roots:
+        raise ValueError("run_python_coverage.py: no coverage surfaces selected")
+
+    lines = [
+        "[run]",
+        "branch = True",
+        "parallel = True",
+        "relative_files = True",
+        "source =",
+    ]
+    lines.extend(f"    {source_root}" for source_root in source_roots)
+    lines.extend(
+        [
+            "omit =",
+        ]
+    )
+    lines.extend(f"    {omit_glob}" for omit_glob in omit_globs)
+    lines.extend(
+        [
+            "patch =",
+            "    subprocess",
+            "",
+            "[report]",
+            "show_missing = True",
+            "omit =",
+        ]
+    )
+    lines.extend(f"    {omit_glob}" for omit_glob in omit_globs)
+    lines.extend(
+        [
+            "",
+            "[html]",
+            f"directory = {HTML_DIR.as_posix()}",
+            "",
+            "[xml]",
+            f"output = {XML_FILE.as_posix()}",
+            "",
+        ]
+    )
     RCFILE.write_text(
-        "\n".join(
-            [
-                "[run]",
-                "branch = True",
-                "parallel = True",
-                "relative_files = True",
-                "source =",
-                "    tools/scripts",
-                "omit =",
-                "    tools/scripts/test_*.py",
-                "patch =",
-                "    subprocess",
-                "",
-                "[report]",
-                "show_missing = True",
-                "omit =",
-                "    tools/scripts/test_*.py",
-                "",
-                f"[html]",
-                f"directory = {HTML_DIR.as_posix()}",
-                "",
-                "[xml]",
-                f"output = {XML_FILE.as_posix()}",
-                "",
-            ]
-        )
+        "\n".join(lines)
         + "\n",
         encoding="utf-8",
     )
@@ -132,20 +181,34 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--pattern",
-        default=TEST_GLOB,
-        help=f"Glob for test discovery (default: {TEST_GLOB})",
+        action="append",
+        default=None,
+        help=(
+            "Repeatable glob for test discovery. Defaults to the configured "
+            "Python coverage surfaces."
+        ),
     )
     args = parser.parse_args(argv)
 
     _require_supported_coverage()
 
-    tests = _discover_tests(args.pattern)
+    patterns = args.pattern or DEFAULT_TEST_GLOBS
+    tests = _discover_tests(patterns)
     if not tests:
-        print(f"run_python_coverage.py: no tests matched {args.pattern!r}", file=sys.stderr)
+        print(f"run_python_coverage.py: no tests matched {patterns!r}", file=sys.stderr)
+        return 1
+
+    surfaces = _selected_surfaces(tests)
+    if not surfaces:
+        print(
+            "run_python_coverage.py: matched tests are outside the configured "
+            "Python coverage surfaces",
+            file=sys.stderr,
+        )
         return 1
 
     shutil.rmtree(OUTPUT_DIR, ignore_errors=True)
-    _write_coveragerc()
+    _write_coveragerc(surfaces)
 
     env = os.environ.copy()
     env["COVERAGE_PROCESS_START"] = str(RCFILE)

--- a/tools/scripts/test_run_python_coverage.py
+++ b/tools/scripts/test_run_python_coverage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
+import sys
 import tempfile
 import unittest
 from unittest import mock
@@ -15,6 +16,7 @@ SCRIPT = pathlib.Path(__file__).parent / "run_python_coverage.py"
 spec = importlib.util.spec_from_file_location("run_python_coverage", SCRIPT)
 assert spec and spec.loader
 rpc = importlib.util.module_from_spec(spec)
+sys.modules["run_python_coverage"] = rpc
 spec.loader.exec_module(rpc)
 
 
@@ -35,30 +37,52 @@ class VersionGuardTests(unittest.TestCase):
 
 
 class CoveragercTests(unittest.TestCase):
-    def test_write_coveragerc_enables_subprocess_patch(self) -> None:
+    def test_write_coveragerc_tracks_selected_surfaces(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)
             output = root / "out"
             html = output / "html"
             xml = output / "coverage.python.xml"
             rcfile = output / ".coveragerc"
+            surfaces = [
+                rpc.CoverageSurface("tools/scripts", "tools/scripts/test_*.py"),
+                rpc.CoverageSurface("tools/deps", "tools/deps/test_*.py"),
+                rpc.CoverageSurface("tools/local-ci", "tools/local-ci/test_*.py"),
+            ]
             with mock.patch.object(rpc, "OUTPUT_DIR", output), \
                  mock.patch.object(rpc, "HTML_DIR", html), \
                  mock.patch.object(rpc, "XML_FILE", xml), \
                  mock.patch.object(rpc, "RCFILE", rcfile):
-                rpc._write_coveragerc()
+                rpc._write_coveragerc(surfaces)
             text = rcfile.read_text(encoding="utf-8")
             self.assertIn("patch =", text)
             self.assertIn("subprocess", text)
             self.assertIn(html.as_posix(), text)
             self.assertIn(xml.as_posix(), text)
+            self.assertIn("tools/scripts", text)
+            self.assertIn("tools/deps", text)
+            self.assertIn("tools/local-ci", text)
+            self.assertIn("tools/local-ci/test_*.py", text)
+            self.assertIn("tools/deps/_*.py", text)
+
+    def test_selected_surfaces_follow_discovered_tests(self) -> None:
+        tests = [
+            rpc.REPO_ROOT / "tools/scripts/test_alpha.py",
+            rpc.REPO_ROOT / "tools/local-ci/test_local_ci.py",
+        ]
+        surfaces = rpc._selected_surfaces(tests)
+        self.assertEqual(
+            [surface.source_root for surface in surfaces],
+            ["tools/scripts", "tools/local-ci"],
+        )
 
 
 class MainFlowTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tests = [
             rpc.REPO_ROOT / "tools/scripts/test_alpha.py",
-            rpc.REPO_ROOT / "tools/scripts/test_beta.py",
+            rpc.REPO_ROOT / "tools/deps/test_audit.py",
+            rpc.REPO_ROOT / "tools/local-ci/test_local_ci.py",
         ]
 
     def test_returns_one_when_no_tests_match(self) -> None:
@@ -69,7 +93,7 @@ class MainFlowTests(unittest.TestCase):
 
     def test_sets_coverage_env_and_surfaces_failures(self) -> None:
         envs: list[dict[str, str]] = []
-        returns = iter([0, 3])
+        returns = iter([0, 0, 3])
 
         def fake_run(test_path: pathlib.Path, env: dict[str, str]) -> int:
             envs.append(env.copy())
@@ -78,17 +102,22 @@ class MainFlowTests(unittest.TestCase):
 
         with mock.patch.object(rpc, "_require_supported_coverage"), \
              mock.patch.object(rpc, "_discover_tests", return_value=self.tests), \
-             mock.patch.object(rpc, "_write_coveragerc"), \
+             mock.patch.object(rpc, "_write_coveragerc") as write_coveragerc, \
              mock.patch.object(rpc.shutil, "rmtree"), \
              mock.patch.object(rpc, "_run_test", side_effect=fake_run), \
              mock.patch.object(rpc, "_build_reports"):
             rc = rpc.main([])
 
         self.assertEqual(rc, 1)
-        self.assertEqual(len(envs), 2)
+        self.assertEqual(len(envs), 3)
         for env in envs:
             self.assertEqual(env["COVERAGE_PROCESS_START"], str(rpc.RCFILE))
             self.assertEqual(env["COVERAGE_FILE"], str(rpc.DATA_FILE))
+        surfaces = write_coveragerc.call_args.args[0]
+        self.assertEqual(
+            [surface.source_root for surface in surfaces],
+            ["tools/scripts", "tools/deps", "tools/local-ci"],
+        )
 
     def test_returns_one_when_report_builder_has_no_data(self) -> None:
         fake_coverage = mock.Mock()
@@ -108,15 +137,29 @@ class MainFlowTests(unittest.TestCase):
             rc = rpc.main([])
         self.assertEqual(rc, 1)
 
+    def test_returns_one_when_tests_are_outside_configured_surfaces(self) -> None:
+        with mock.patch.object(rpc, "_require_supported_coverage"), \
+             mock.patch.object(
+                 rpc,
+                 "_discover_tests",
+                 return_value=[rpc.REPO_ROOT / "tools/test_check_docs_consistency.py"],
+             ), \
+             mock.patch.object(rpc.shutil, "rmtree"), \
+             mock.patch.object(rpc, "_build_reports"):
+            rc = rpc.main([])
+        self.assertEqual(rc, 1)
+
     def test_returns_zero_on_success(self) -> None:
         with mock.patch.object(rpc, "_require_supported_coverage"), \
              mock.patch.object(rpc, "_discover_tests", return_value=[self.tests[0]]), \
-             mock.patch.object(rpc, "_write_coveragerc"), \
+             mock.patch.object(rpc, "_write_coveragerc") as write_coveragerc, \
              mock.patch.object(rpc.shutil, "rmtree"), \
              mock.patch.object(rpc, "_run_test", return_value=0), \
              mock.patch.object(rpc, "_build_reports"):
             rc = rpc.main([])
         self.assertEqual(rc, 0)
+        surfaces = write_coveragerc.call_args.args[0]
+        self.assertEqual([surface.source_root for surface in surfaces], ["tools/scripts"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand the Python coverage runner from `tools/scripts/**` to also cover `tools/deps/**` and `tools/local-ci/**`
- make surface selection dynamic so targeted `--pattern` runs only report the matching roots
- omit scratch `_*.py` helpers from selected roots so synthetic tests don't break report generation
- update coverage docs for the widened Python lane

## Why
`#631` intentionally landed the smallest possible Python Codecov lane for `tools/scripts/**`.

That still left real first-party Python coverage invisible for:
- `tools/deps/audit.py`
- `tools/deps/validate_hosts.py`
- `tools/local-ci/local_ci.py`
- `tools/local-ci/android_target.py`

This PR widens the same Linux `coverage.py` lane instead of inventing a second Python workflow.

## Verification
- `python3 tools/scripts/test_run_python_coverage.py`
- `python3 tools/deps/test_audit.py`
- `python3 tools/local-ci/test_local_ci.py`
- end-to-end `python3 tools/scripts/run_python_coverage.py` in a clean venv with `coverage>=7.10` and `PyYAML`

Refs #632
