### PR TITLE
coverage: add android kotlin jacoco lane

### DIFF
--- a/.agents/skills/android/SKILL.md
+++ b/.agents/skills/android/SKILL.md
@@ -434,6 +434,13 @@ Silicon) the arm64-v8a emulator hits `HV_UNSUPPORTED` — keep the gate
 OFF until Linux arm64 + KVM or x86\_64 APK lanes land (see #487).
 Run the smoke locally in the meantime.
 
+The same workflow now also has an `android-kotlin-coverage` job on
+`macos-latest`. It runs `./gradlew :app:testDebugUnitTest
+:app:jacocoDebugUnitTestReport`, uploads the JaCoCo HTML/XML artifacts,
+and sends `android/app/build/reports/jacoco/jacocoDebugUnitTestReport/jacocoDebugUnitTestReport.xml`
+to Codecov. This is a JVM-only lane for `android/app/src/main/kotlin/**`
+and does not replace emulator/device coverage.
+
 ## Critical Gotchas
 
 These are hard-won lessons from the bringup. Violating any of these will cause crashes or subtle bugs.

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -777,3 +777,10 @@ Gotchas surfaced while landing the four-phase SignalGraph follow-up:
   `python3 tools/scripts/version_bump_check.py --mode=apply` to update
   `CMakeLists.txt` + `CHANGELOG.md`. The gate reports "SDK X.Y.Z ✓
   bumped" when satisfied.
+- **Android/Kotlin coverage lives in `android.yml`, not `coverage.yml`.**
+  The dedicated `android-kotlin-coverage` job provisions Java + the
+  Android SDK/NDK, runs `:app:testDebugUnitTest` plus
+  `:app:jacocoDebugUnitTestReport`, uploads the JaCoCo artifacts, and
+  sends the XML to Codecov. Keep it separate from the Clang-based
+  `coverage.yml` matrix — Android coverage is a Gradle/SDK lane, not a
+  native profraw lane.

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -106,6 +106,92 @@ jobs:
           path: android/app/build/outputs/apk/debug/app-debug.apk
           retention-days: 7
 
+  android-kotlin-coverage:
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install NDK
+        run: sdkmanager "ndk;30.0.14904198"
+
+      - name: Cache Gradle
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: android-coverage-${{ runner.os }}-${{ hashFiles('android/**/*.gradle.kts', 'android/app/src/test/**/*.kt') }}
+          restore-keys: |
+            android-coverage-${{ runner.os }}-
+            ${{ runner.os }}-gradle-
+
+      - name: Run Kotlin unit tests + JaCoCo report
+        working-directory: android
+        run: ./gradlew :app:testDebugUnitTest :app:jacocoDebugUnitTestReport
+        env:
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
+
+      - name: Verify JaCoCo XML exists
+        shell: bash
+        run: |
+          xml=android/app/build/reports/jacoco/jacocoDebugUnitTestReport/jacocoDebugUnitTestReport.xml
+          test -s "$xml" || {
+            echo "::error::Android JaCoCo XML is missing or empty."
+            exit 1
+          }
+          python3 - <<'PY'
+          import pathlib
+          import sys
+          import xml.etree.ElementTree as ET
+
+          path = pathlib.Path(
+              "android/app/build/reports/jacoco/jacocoDebugUnitTestReport/"
+              "jacocoDebugUnitTestReport.xml"
+          )
+          root = ET.parse(path).getroot()
+          line = root.find("counter[@type='LINE']")
+          if line is None:
+              print("::error::Android JaCoCo XML has no LINE counter.")
+              sys.exit(1)
+          total = int(line.attrib["missed"]) + int(line.attrib["covered"])
+          if total == 0:
+              print("::error::Android JaCoCo XML reports zero measured lines.")
+              sys.exit(1)
+          print(f"Android JaCoCo XML lines: {line.attrib['covered']}/{total}")
+          PY
+
+      - name: Upload Kotlin coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: android-kotlin-coverage-${{ github.sha }}
+          path: |
+            android/app/build/reports/jacoco/jacocoDebugUnitTestReport/**
+            android/app/build/reports/tests/testDebugUnitTest/**
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload Android Kotlin coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: android/app/build/reports/jacoco/jacocoDebugUnitTestReport/jacocoDebugUnitTestReport.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          verbose: true
+
   # Emulator test — only on macOS (KVM not available on GitHub Windows runners).
   # This is a native-init smoke: boots a headless arm64-v8a emulator, installs
   # the arm64-only debug APK, launches PulpActivity, and greps logcat for the

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,7 +1,11 @@
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
+import org.gradle.testing.jacoco.tasks.JacocoReport
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("jacoco")
 }
 
 android {
@@ -46,6 +50,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            enableUnitTestCoverage = true
+        }
         release {
             isMinifyEnabled = false
             proguardFiles(
@@ -67,6 +74,10 @@ android {
     buildFeatures {
         compose = true
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -80,4 +91,53 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.material3:material3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito:mockito-core:5.15.2")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
+}
+
+tasks.withType<Test>().configureEach {
+    extensions.configure(JacocoTaskExtension::class.java) {
+        isIncludeNoLocationClasses = true
+        excludes = listOf("jdk.internal.*")
+    }
+}
+
+tasks.register<JacocoReport>("jacocoDebugUnitTestReport") {
+    dependsOn("testDebugUnitTest")
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+        csv.required.set(false)
+    }
+
+    val excludes = listOf(
+        "**/R.class",
+        "**/R$*.class",
+        "**/BuildConfig.*",
+        "**/Manifest*.*",
+    )
+
+    classDirectories.setFrom(
+        files(
+            fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) {
+                exclude(excludes)
+            },
+            fileTree(layout.buildDirectory.dir("intermediates/javac/debug/compileDebugJavaWithJavac/classes")) {
+                exclude(excludes)
+            },
+        )
+    )
+    sourceDirectories.setFrom(files("src/main/kotlin"))
+    executionData.setFrom(
+        fileTree(layout.buildDirectory) {
+            include(
+                "outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec",
+                "outputs/unit_test_code_coverage/debugUnitTest/**/*.exec",
+                "jacoco/testDebugUnitTest.exec",
+            )
+        }
+    )
 }

--- a/android/app/src/test/kotlin/com/pulp/audio/PulpAudioControllerTest.kt
+++ b/android/app/src/test/kotlin/com/pulp/audio/PulpAudioControllerTest.kt
@@ -1,0 +1,88 @@
+package com.pulp.audio
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.ServiceConnection
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class PulpAudioControllerTest {
+    @Test
+    fun startAudioStartsForegroundServiceAndBinds() {
+        val context = mock<Context>()
+        whenever(context.bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))).thenReturn(true)
+        val controller = PulpAudioController(context)
+
+        controller.startAudio(isRecording = true)
+
+        verify(context).startForegroundService(any())
+        verify(context).bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))
+        assertTrue(controller.isRunning)
+    }
+
+    @Test
+    fun startAudioIsIdempotentWhileRunning() {
+        val context = mock<Context>()
+        whenever(context.bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))).thenReturn(true)
+        val controller = PulpAudioController(context)
+
+        controller.startAudio()
+        controller.startAudio()
+
+        verify(context, times(1)).startForegroundService(any())
+        verify(context, times(1)).bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))
+    }
+
+    @Test
+    fun stopAudioStopsServiceAndUnbinds() {
+        val context = mock<Context>()
+        whenever(context.bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))).thenReturn(true)
+        val controller = PulpAudioController(context)
+        controller.startAudio()
+
+        controller.stopAudio()
+
+        verify(context).startService(any())
+        verify(context).unbindService(any())
+        assertFalse(controller.isRunning)
+    }
+
+    @Test
+    fun stopAudioIgnoresMissingBinding() {
+        val context = mock<Context>()
+        whenever(context.bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))).thenReturn(true)
+        doThrow(IllegalArgumentException("no binding")).whenever(context).unbindService(any())
+        val controller = PulpAudioController(context)
+        controller.startAudio()
+
+        controller.stopAudio()
+
+        assertFalse(controller.isRunning)
+    }
+
+    @Test
+    fun disconnectCallbackClearsRunningState() {
+        val context = mock<Context>()
+        whenever(context.bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))).thenReturn(true)
+        val connectionCaptor = argumentCaptor<ServiceConnection>()
+        val controller = PulpAudioController(context)
+
+        controller.startAudio()
+        verify(context).bindService(any(), connectionCaptor.capture(), eq(Context.BIND_AUTO_CREATE))
+
+        connectionCaptor.firstValue.onServiceDisconnected(
+            ComponentName("com.pulp.app", "com.pulp.PulpAudioService")
+        )
+
+        assertFalse(controller.isRunning)
+    }
+}

--- a/android/app/src/test/kotlin/com/pulp/audio/PulpAudioEngineTest.kt
+++ b/android/app/src/test/kotlin/com/pulp/audio/PulpAudioEngineTest.kt
@@ -1,0 +1,58 @@
+package com.pulp.audio
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.media.AudioDeviceCallback
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class PulpAudioEngineTest {
+    @Test
+    fun queriesAudioManagerAndPackageManagerCapabilities() {
+        val context = mock<Context>()
+        val audioManager = mock<AudioManager>()
+        val packageManager = mock<PackageManager>()
+        val inputDevice = mock<AudioDeviceInfo>()
+        val outputDevice = mock<AudioDeviceInfo>()
+        whenever(context.getSystemService(AudioManager::class.java)).thenReturn(audioManager)
+        whenever(context.packageManager).thenReturn(packageManager)
+        whenever(audioManager.getDevices(any())).thenReturn(arrayOf(inputDevice, outputDevice))
+        whenever(audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE)).thenReturn("96000")
+        whenever(audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER))
+            .thenReturn("512")
+        whenever(packageManager.hasSystemFeature("android.hardware.audio.pro")).thenReturn(true)
+        whenever(packageManager.hasSystemFeature("android.hardware.audio.low_latency"))
+            .thenReturn(false)
+        val engine = PulpAudioEngine(context)
+
+        assertEquals(2, engine.enumerateDevices().size)
+        assertEquals(96000, engine.getOptimalSampleRate())
+        assertEquals(512, engine.getOptimalFramesPerBuffer())
+        assertTrue(engine.isProAudioDevice())
+        assertFalse(engine.isLowLatencyDevice())
+    }
+
+    @Test
+    fun registerAndUnregisterDelegateToAudioManager() {
+        val context = mock<Context>()
+        val audioManager = mock<AudioManager>()
+        whenever(context.getSystemService(AudioManager::class.java)).thenReturn(audioManager)
+        val callback = mock<AudioDeviceCallback>()
+        val engine = PulpAudioEngine(context)
+
+        engine.registerDeviceCallback(callback)
+        engine.unregisterDeviceCallback(callback)
+
+        verify(audioManager).registerAudioDeviceCallback(eq(callback), eq(null))
+        verify(audioManager).unregisterAudioDeviceCallback(callback)
+    }
+}

--- a/android/app/src/test/kotlin/com/pulp/render/GpuDriverPolicyTest.kt
+++ b/android/app/src/test/kotlin/com/pulp/render/GpuDriverPolicyTest.kt
@@ -1,0 +1,66 @@
+package com.pulp.render
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class GpuDriverPolicyTest {
+    @Test
+    fun shouldUseVulkanReturnsTrueWhenNoFallbackFlagsAreSet() {
+        val (context, prefs, _) = mockedContext()
+        whenever(prefs.getBoolean("vulkan_crashed", false)).thenReturn(false)
+        whenever(prefs.getBoolean("force_gles", false)).thenReturn(false)
+
+        assertTrue(GpuDriverPolicy.shouldUseVulkan(context))
+    }
+
+    @Test
+    fun shouldUseVulkanReturnsFalseAfterCrash() {
+        val (context, prefs, _) = mockedContext()
+        whenever(prefs.getBoolean("vulkan_crashed", false)).thenReturn(true)
+
+        assertFalse(GpuDriverPolicy.shouldUseVulkan(context))
+    }
+
+    @Test
+    fun shouldUseVulkanReturnsFalseWhenGlesIsForced() {
+        val (context, prefs, _) = mockedContext()
+        whenever(prefs.getBoolean("vulkan_crashed", false)).thenReturn(false)
+        whenever(prefs.getBoolean("force_gles", false)).thenReturn(true)
+
+        assertFalse(GpuDriverPolicy.shouldUseVulkan(context))
+    }
+
+    @Test
+    fun mutatorsPersistTheirPreferenceFlags() {
+        val (context, _, editor) = mockedContext()
+
+        GpuDriverPolicy.markVulkanAttempt(context)
+        GpuDriverPolicy.markVulkanSuccess(context)
+        GpuDriverPolicy.forceOpenGLES(context, true)
+        GpuDriverPolicy.resetCrashFlag(context)
+
+        verify(editor, times(1)).putBoolean("vulkan_crashed", true)
+        verify(editor, times(2)).putBoolean("vulkan_crashed", false)
+        verify(editor, times(1)).putBoolean("force_gles", true)
+        verify(editor, times(4)).apply()
+    }
+
+    private fun mockedContext(): Triple<Context, SharedPreferences, SharedPreferences.Editor> {
+        val context = mock<Context>()
+        val prefs = mock<SharedPreferences>()
+        val editor = mock<SharedPreferences.Editor>()
+        whenever(context.getSharedPreferences(any(), eq(Context.MODE_PRIVATE))).thenReturn(prefs)
+        whenever(prefs.edit()).thenReturn(editor)
+        whenever(editor.putBoolean(any(), any())).thenReturn(editor)
+        return Triple(context, prefs, editor)
+    }
+}

--- a/docs/guides/coverage.md
+++ b/docs/guides/coverage.md
@@ -4,8 +4,9 @@ Coverage is measured per-subsystem, per-platform, and per-surface on
 macOS, Linux, and Windows for the native C/C++ lane, with an additional
 Python tooling lane on Linux covering `tools/scripts/**`,
 `tools/deps/**`, and `tools/local-ci/**`, plus a Swift package lane on
-macOS covering the Apple Swift sources that compile in `apple/`.
-All reports are uploaded to Codecov on every push.
+macOS covering the Apple Swift sources that compile in `apple/`, and a
+Kotlin/Android lane driven by the dedicated Android workflow. All
+reports are uploaded to Codecov on every push.
 [#566](https://github.com/danielraffel/pulp/issues/566) tracks the
 broader coverage initiative.
 
@@ -59,6 +60,15 @@ Apple Swift coverage (macOS only):
 python3 tools/scripts/run_swift_coverage.py
 ```
 
+Android Kotlin coverage (requires Java 17 + Android SDK/NDK):
+
+```bash
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+cd android
+./gradlew :app:testDebugUnitTest :app:jacocoDebugUnitTestReport
+```
+
 Output:
 
 - `build-coverage/coverage/index.html` — per-file HTML drilldown (open
@@ -79,6 +89,10 @@ Output:
   Swift source files under `apple/Sources/`.
 - `build-coverage/apple/coverage.apple.json` — Xcode/SwiftPM Codecov
   JSON emitted by `swift test --enable-code-coverage`.
+- `android/app/build/reports/jacoco/jacocoDebugUnitTestReport/` —
+  HTML + XML output for the Android Kotlin lane.
+- `android/app/build/reports/jacoco/jacocoDebugUnitTestReport/jacocoDebugUnitTestReport.xml`
+  — JaCoCo XML uploaded to Codecov from the Android workflow.
 
 The native script requires Clang (not gcc) because we use Clang
 source-based coverage, not gcov. See
@@ -101,6 +115,12 @@ inside `apple/`. The staged Codecov JSON is source-only by policy:
 `apple/Tests/**` and generated `.build/**` files are ignored in
 `codecov.yml` so the Apple component reflects package sources, not the
 test harness.
+
+The Android Kotlin lane runs through Gradle/JaCoCo rather than
+`coverage.yml`. The dedicated Android workflow provisions Java + the
+Android SDK/NDK, runs `:app:testDebugUnitTest` plus
+`:app:jacocoDebugUnitTestReport`, and uploads the resulting JaCoCo XML
+to Codecov.
 
 Optional flags:
 
@@ -186,6 +206,15 @@ Source → swift test --enable-code-coverage
   run_swift_coverage.py
          ↓
   summary + staged Codecov JSON (Codecov)
+
+Android Kotlin:
+Source → Gradle `testDebugUnitTest`
+         ↓
+     JaCoCo execution data
+         ↓
+  `jacocoDebugUnitTestReport`
+         ↓
+   JaCoCo XML + HTML (Codecov)
 ```
 
 - **Instrumentation**: enabled via `-DPULP_ENABLE_COVERAGE=ON` at
@@ -239,6 +268,8 @@ Today the live dashboard includes:
 - **Swift** coverage for the Apple Swift package sources under
   `apple/Sources/PulpSwift/**` on macOS via
   `tools/scripts/run_swift_coverage.py`.
+- **Kotlin/Android** coverage for `android/app/src/main/kotlin/**`
+  via the dedicated Android workflow's JaCoCo upload.
 
 Still out of scope today:
 
@@ -247,7 +278,7 @@ Still out of scope today:
 - Python outside the current Linux lane (for example top-level
   `tools/*.py`, `tools/packages/**`, and any future repo-root Python
   scripts) — follow-up after the current tooling surfaces stabilize.
-- Kotlin/Android coverage.
+- Android emulator / device instrumentation coverage.
 
 ## Cross-platform matrix
 
@@ -263,6 +294,12 @@ architectures —
 `llvm-profdata merge` is not architecture-portable
 (`planning/coverage-tooling-decision-2026-04-21.md` §7); Codecov does
 the cross-OS union at the flag layer.
+
+Android/Kotlin coverage is separate from that matrix. It runs in
+`.github/workflows/android.yml` on macOS, emits JaCoCo XML from
+Gradle, and uploads that XML directly to Codecov so the `android`
+component sees JVM-only Kotlin coverage even though the native coverage
+matrix is Clang-specific.
 
 Per-OS flags let the dashboard answer "what's covered on a specific
 OS." Per-subsystem components answer "how's a specific piece of the
@@ -296,6 +333,7 @@ without a workflow edit.
 - Issue #566 — umbrella initiative
 - Issue #615 — Apple Swift coverage lane
 - Issue #290 — coverage hardening (test surface growth)
+- Issue #633 — Android/Kotlin JaCoCo coverage lane
 - `planning/coverage-tooling-decision-2026-04-21.md` — Phase 0 spike
   findings, stack rationale, perf numbers
 - `planning/coverage-sanitizers-spec-2026-04-16.md` — the earlier


### PR DESCRIPTION
## Summary
- add a first Android JVM unit-test surface and JaCoCo report task under `android/app`
- add a dedicated `android-kotlin-coverage` CI job that uploads JaCoCo XML to Codecov
- document the Android/Kotlin coverage lane in the coverage guide and Android/CI skills

## Testing
- `JAVA_HOME=/Applications/Android Studio.app/Contents/jbr/Contents/Home ANDROID_HOME=$HOME/Library/Android/sdk ANDROID_SDK_ROOT=$ANDROID_HOME ./gradlew :app:testDebugUnitTest :app:jacocoDebugUnitTestReport`
- `python3 tools/scripts/skill_sync_check.py --mode=report`
- `python3 tools/scripts/docs_sync_check.py --mode=report`

Closes #633.
