### PR TITLE
au: wire AU v2 effect MIDI input + aufx→aumf for accepts_midi

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: auv2
+description: Audio Unit v2 adapter work for Pulp — picking the right AU component type (aufx/aumf/aumi/aumu), wiring MIDI input, and avoiding the DAW-side component cache that silently masks repackaging.
+requires:
+  scripts: []
+  tools: []
+---
+
+# AU v2 Skill
+
+Use this when you are:
+
+- Touching `core/format/src/au_v2_adapter.cpp` / `.hpp` or the AU v2 instrument adapter
+- Changing how Pulp packages AU v2 plug-ins in CMake (`tools/cmake/PulpUtils.cmake`, `tools/cmake/PulpInfoPlist.au.in`)
+- Debugging "plug-in loads but never receives MIDI" reports against an AU host
+- Picking or changing a plug-in's AU component type (4-char `type` in the Info.plist)
+- Wiring new AU v2 features that require splitting base-class inheritance (adding `AUMIDIBase`, `MIDIOutput`, etc.)
+
+Scope is AU v2 only. AU v3 (AUAudioUnit-based app extensions) has different rules and lives behind the `ios` skill + `core/format/src/au_adapter.mm`.
+
+## AU v2 Component Types — Pick the Right 4cc
+
+Hosts route MIDI based on the bundle's `type` field. Getting this wrong produces a silent-failure: the plug-in scans, loads, renders audio, and never sees a MIDI event.
+
+| `type` | Constant                    | Audio I/O | MIDI I/O | When to use                                |
+|--------|-----------------------------|-----------|----------|--------------------------------------------|
+| `aufx` | `kAudioUnitType_Effect`       | in + out  | none     | Audio-only effect (compressor, EQ, reverb) |
+| `aumf` | `kAudioUnitType_MusicEffect`  | in + out  | in       | Effect that wants inbound MIDI (arpeggiator on audio, MIDI-triggered gate, vocoder w/ MIDI carrier) |
+| `aumi` | `kAudioUnitType_MIDIProcessor`| none      | in + out | MIDI-only processor (transpose, arp, chord, note filter) |
+| `aumu` | `kAudioUnitType_MusicDevice`  | out only  | in       | Instrument / synth                         |
+
+**Load-bearing rule:** Logic, MainStage, GarageBand, and other AU hosts will **never** call `MIDIEvent` / `HandleMIDIEvent` on an `aufx`-typed plug-in. If a plug-in's `Processor::descriptor()` sets `accepts_midi = true` and the bundle is still packaged as `aufx`, MIDI silently disappears — the adapter looks correct, the Info.plist looks correct to a casual reader, but no MIDI arrives.
+
+Pulp's `pulp_add_plugin()` automates the choice from two inputs:
+
+1. `CATEGORY` — `Effect` | `Instrument` | `MidiEffect`
+2. `ACCEPTS_MIDI` — bool option that mirrors `PluginDescriptor::accepts_midi`
+
+The resulting mapping (`_pulp_add_au` / `_pulp_add_auv3` in `tools/cmake/PulpUtils.cmake`):
+
+```
+(Instrument,  *)     -> aumu
+(MidiEffect,  *)     -> aumi
+(Effect,      true)  -> aumf    <-- easy to forget
+(Effect,      false) -> aufx
+```
+
+When you add a new example or change an existing one's descriptor to declare `accepts_midi = true`, you **must** also add `ACCEPTS_MIDI` to its `pulp_add_plugin()` call. There is no runtime fallback — the two surfaces are independent and the CMake flag is what ends up in the Info.plist.
+
+## MIDI Input Wiring
+
+The AU v2 effect adapter inherits from `AUMIDIEffectBase` (`AUEffectBase` + `AUMIDIBase`) so the SDK's `MIDIEvent` / `SysEx` entry points exist. Inbound MIDI flows:
+
+```
+host -> AUMIDIBase::MIDIEvent(status, data1, data2, frame)
+     -> AUMIDIBase::HandleMIDIEvent(strippedStatus, channel, data1, data2, frame)
+     -> PulpAUEffect::HandleMIDIEvent(...)   <-- our override
+        - lock midi_mutex_
+        - push MidiEvent into pending_midi_
+```
+
+At the top of `ProcessBufferLists()` we drain under the same lock:
+
+```
+lock midi_mutex_
+midi_in = std::move(pending_midi_)
+pending_midi_ = {}
+unlock
+midi_in.sort()    // sample-accurate ordering
+processor_->process(..., midi_in, midi_out, ctx)
+```
+
+The instrument adapter (`core/format/src/au_v2_instrument.cpp`) uses the same `pending_midi_` + `midi_mutex_` pattern against the `MusicDeviceBase` base class. If you're adding a third MIDI-aware AU, mirror that shape exactly — resist the urge to share a mixin until there's a third entry to fold.
+
+### Decode helper: `decode_midi_event()`
+
+`AUMIDIBase::HandleMIDIEvent` delivers the status byte already split into a top nibble and a separate channel. The free function `pulp::format::au::decode_midi_event(status, channel, data1, data2)` in `core/format/include/pulp/format/au_v2_adapter.hpp` recombines them into a `choc::midi::ShortMessage` with the correct on-the-wire status byte and returns a `MidiEvent` with `sample_offset == 0`. Tests cover CC, pitch bend, note-on, program change, and system messages (status 0xF0+ keep their literal byte — channel nibble is ignored).
+
+### SysEx
+
+`AUMIDIBase::HandleSysEx(data, length)` does not carry a per-event sample offset at this SDK layer. We enqueue the payload with `sample_offset == 0` so it is delivered at the leading edge of the current `ProcessBufferLists()` block.
+
+## Current Gaps (2026-04-22)
+
+- **MIDI output from AU v2 effects** is not wired yet (tracked as #626). `Processor::process()` can write to `midi_out`, but `PulpAUEffect` has no render-notify callback / `MIDIOutput` mixin that emits those events back to the host. Effects that declare `produces_midi = true` work in CLAP / VST3 but stay silent on AU v2. `descriptor.produces_midi` is *not* wired to a CMake flag yet — the AU type selection is driven entirely by `accepts_midi`.
+
+- **AU v3 parity** for MIDI on effects is not re-audited in this pass. If you touch `core/format/src/au_adapter.mm`, confirm the AUv3 `componentType` logic in `_pulp_add_auv3` still matches the fix in `_pulp_add_au`.
+
+## Gotchas
+
+### DAW component cache — clear it after a `type` change
+
+Logic, MainStage, GarageBand, Studio One, Live, and every other AU host maintain a **host-side cache** of AU descriptors, keyed on subtype + manufacturer. When you change a plug-in from `aufx` to `aumf` (or vice versa) *without* also changing the subtype, hosts will keep the cached-old-type descriptor and behave as if the fix never shipped — you'll install a fresh `.component` and the host will still treat it as `aufx`. Symptoms: rebuilt plug-in appears in the correct MIDI-effect slot of the host UI only after a restart, or never appears at all.
+
+Mitigation when you test a type change locally:
+
+```bash
+# Kill the AU registration cache so the next host launch re-inspects the bundle.
+killall -9 AudioComponentRegistrar 2>/dev/null || true
+
+# Logic / MainStage / GarageBand — clear the AU cache next to the host DBs.
+rm -rf ~/Library/Caches/AudioUnitCache
+rm -rf ~/Library/Caches/com.apple.audiounits.cache
+
+# auval rescan catches the new type without needing a host restart.
+auval -a | grep <subtype>
+auval -v <type> <subtype> <manufacturer>
+```
+
+Document this step in any issue or PR that flips a shipped plug-in's component type.
+
+### `AUEffectBase` vs `AUMIDIEffectBase`
+
+If you see `HandleMIDIEvent` that never fires: check the base class. `AUEffectBase` alone has no `AUMIDIBase` mixin — the SDK only wires `MIDIEvent` dispatch when the class multiply inherits `AUMIDIBase` (directly or via `AUMIDIEffectBase` / `MusicDeviceBase`). When you add a new AU v2 adapter, inheriting from `AUMIDIEffectBase` is cheap even for audio-only effects — the class does nothing extra until the host actually delivers MIDI, and it future-proofs the adapter against a later `accepts_midi` flip.
+
+### `GetProperty` / `GetPropertyInfo` chain
+
+With `AUMIDIEffectBase`, fall-through calls should go to `AUMIDIEffectBase::GetProperty(...)`, not `AUEffectBase::GetProperty(...)`. `AUMIDIEffectBase::GetProperty` tries `AUEffectBase::GetProperty` first and then falls back to `AUMIDIBase::DelegateGetProperty`. Calling `AUEffectBase` directly skips the MIDI-mapping property delegation — hosts that query `kAudioUnitProperty_AllParameterMIDIMappings` would silently return no mapping.
+
+### CXX_STANDARD on tests that include AU adapter headers
+
+`core/format/include/pulp/format/au_v2_adapter.hpp` pulls `AudioUnitSDK/AUMIDIEffectBase.h`, which on AudioUnitSDK 1.4 uses `std::expected` (C++23). Apple clang only exposes `std::expected` when the *consuming TU* compiles at `-std=c++23`. Any test executable that includes the adapter header must set `CXX_STANDARD 23` explicitly — linking `pulp::format` is not enough because CMake treats `CMAKE_CXX_STANDARD=20` at the root as authoritative per target. See `core/format/CMakeLists.txt` for the equivalent pin.
+
+### `pending_midi_` mutex is a slow-path correctness tool, not a fast path
+
+The `std::mutex` guarding `pending_midi_` is contended only on the MIDI-delivery thread (where the host calls `HandleMIDIEvent`) and the audio thread (once per block, to drain). It is NOT the right primitive for per-event audio-thread publication. Do not extend this pattern to any new path that runs multiple times per block — switch to `choc::fifo::SingleReaderSingleWriterFIFO` if you need lock-free MIDI delivery inside a single block.
+
+## Reference pointers
+
+- Adapter source: `core/format/src/au_v2_adapter.cpp`, `core/format/include/pulp/format/au_v2_adapter.hpp`
+- Instrument adapter (reference pattern): `core/format/src/au_v2_instrument.cpp`, `core/format/include/pulp/format/au_v2_instrument.hpp`
+- Cocoa view factory: `core/format/src/au_v2_cocoa_view.mm` (owned by `view-bridge` + `ios` skills)
+- CMake selector: `tools/cmake/PulpUtils.cmake` — `_pulp_add_au` and `_pulp_add_auv3`
+- Info.plist template: `tools/cmake/PulpInfoPlist.au.in`
+- AudioUnitSDK reference: `external/AudioUnitSDK/include/AudioUnitSDK/AUMIDIBase.h`, `AUMIDIEffectBase.h`
+- Support matrix entry: `docs/status/support-matrix.yaml` — `formats.au_v2` and `format_limitations.au_v2`
+- Tests:
+    - `test/test_au_v2_effect.cpp` — decode / sysex smoke
+    - `test/cmake/test_au_v2_type_selection.cmake` — aumf/aufx/aumu/aumi mapping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0340"></a>
+## [0.35.0]
+
 ## [0.34.0] - 2026-04-22
 
 - feat: persist processor-owned plugin state in adapter blobs ([#628](https://github.com/danielraffel/pulp/pull/628))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.34.0
+    VERSION 0.35.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/au_v2_adapter.hpp
+++ b/core/format/include/pulp/format/au_v2_adapter.hpp
@@ -92,15 +92,22 @@ protected:
     /// Plug-ins packaged as ``aufx`` still have this override wired — the
     /// host just never calls it — so leaving the path here for ``aufx``
     /// plug-ins is harmless.
+    // NB: AudioUnitSDK declares these as `AUSDK_RTSAFE` (which expands to
+    // `[[clang::nonblocking]]`). Propagating that attribute into an
+    // `override` declaration compiles under older Xcode but Xcode 16.4 /
+    // Clang 17+ rejects the attribute position with
+    // "expected ';' at end of declaration list". The attribute is a
+    // static-analysis hint only — dropping it has no runtime effect, and
+    // matches the pattern used by `PulpAUInstrument::HandleNoteOn/Off`.
     OSStatus HandleMIDIEvent(UInt8 inStatus, UInt8 inChannel,
                              UInt8 inData1, UInt8 inData2,
-                             UInt32 inStartFrame) AUSDK_RTSAFE override;
+                             UInt32 inStartFrame) override;
 
     /// System-exclusive payload (F0 … F7). ``AUMIDIBase::HandleSysEx`` does
     /// not carry a per-event sample offset at this SDK layer — we enqueue
     /// the sysex with ``sample_offset == 0`` so it is delivered at the
     /// block boundary.
-    OSStatus HandleSysEx(const UInt8* inData, UInt32 inLength) AUSDK_RTSAFE override;
+    OSStatus HandleSysEx(const UInt8* inData, UInt32 inLength) override;
 
 private:
     std::unique_ptr<Processor> processor_;

--- a/core/format/include/pulp/format/au_v2_adapter.hpp
+++ b/core/format/include/pulp/format/au_v2_adapter.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
-#include <AudioUnitSDK/AUEffectBase.h>
+#include <AudioUnitSDK/AUMIDIEffectBase.h>
 
 #include <pulp/format/processor.hpp>
+#include <pulp/midi/buffer.hpp>
+#include <pulp/midi/message.hpp>
 
 #include <memory>
+#include <mutex>
 #include <vector>
 
 namespace pulp::format::au {
@@ -21,7 +24,29 @@ struct PulpEditorContext {
     pulp::state::StateStore* store;
 };
 
-class PulpAUEffect : public ausdk::AUEffectBase {
+/// Decode a short MIDI status byte and two data bytes into a
+/// ``midi::MidiEvent``. Exposed at namespace scope so the AU-MIDI routing
+/// can be unit tested without constructing a real ``AudioComponentInstance``.
+///
+/// Channel voice messages arrive at ``AUMIDIBase::HandleMIDIEvent`` already
+/// split into ``inStatus`` (top nibble, e.g. ``0x80``, ``0xB0``) and
+/// ``inChannel`` (bottom nibble, 0–15). This helper re-combines them into
+/// a single status byte so the resulting ``choc::midi::ShortMessage`` has a
+/// consistent on-the-wire layout regardless of whether the caller already
+/// split the channel out.
+///
+/// @param inStatus  Status byte (top nibble, bottom nibble optional).
+/// @param inChannel MIDI channel (0–15). Ignored for system messages.
+/// @param inData1   Data byte 1 (note number, CC number, etc.).
+/// @param inData2   Data byte 2 (velocity, CC value, etc.).
+/// @returns MidiEvent with ``sample_offset == 0`` — callers should set
+///          the sample offset themselves before enqueuing.
+midi::MidiEvent decode_midi_event(uint8_t inStatus,
+                                  uint8_t inChannel,
+                                  uint8_t inData1,
+                                  uint8_t inData2) noexcept;
+
+class PulpAUEffect : public ausdk::AUMIDIEffectBase {
 public:
     explicit PulpAUEffect(AudioComponentInstance ci);
 
@@ -56,6 +81,27 @@ public:
     Float64 GetTailTime() override;
     Float64 GetLatency() override;
 
+protected:
+    /// Called by the AU host for every short MIDI message (status has
+    /// already been split into ``inStatus`` / ``inChannel``). Converts the
+    /// bytes to a ``midi::MidiEvent`` and pushes it onto the pending
+    /// buffer under ``midi_mutex_``. Drained in ``ProcessBufferLists``.
+    ///
+    /// Note: DAW hosts only route MIDI to an AU v2 effect when the
+    /// bundle's component ``type`` is ``aumf`` (kAudioUnitType_MusicEffect).
+    /// Plug-ins packaged as ``aufx`` still have this override wired — the
+    /// host just never calls it — so leaving the path here for ``aufx``
+    /// plug-ins is harmless.
+    OSStatus HandleMIDIEvent(UInt8 inStatus, UInt8 inChannel,
+                             UInt8 inData1, UInt8 inData2,
+                             UInt32 inStartFrame) AUSDK_RTSAFE override;
+
+    /// System-exclusive payload (F0 … F7). ``AUMIDIBase::HandleSysEx`` does
+    /// not carry a per-event sample offset at this SDK layer — we enqueue
+    /// the sysex with ``sample_offset == 0`` so it is delivered at the
+    /// block boundary.
+    OSStatus HandleSysEx(const UInt8* inData, UInt32 inLength) AUSDK_RTSAFE override;
+
 private:
     std::unique_ptr<Processor> processor_;
     state::StateStore store_;
@@ -64,6 +110,17 @@ private:
     // Pre-process snapshot of parameter values; used to diff plugin-side
     // changes back to the host's parameter system (workstream 01 slice 1.3).
     std::vector<float> param_snapshot_;
+
+    // MIDI input path — AU v2 effects that declare accepts_midi are
+    // packaged as aumf (kAudioUnitType_MusicEffect). The host then
+    // routes inbound MIDI through AUMIDIBase::MIDIEvent / SysEx, which
+    // dispatches to HandleMIDIEvent / HandleSysEx. We stash events into
+    // ``pending_midi_`` under ``midi_mutex_`` and drain them into the
+    // block-local MidiBuffer at the top of ProcessBufferLists. The
+    // mutex is only contended on the main/MIDI thread; the audio
+    // thread grabs it once per block to swap pending_midi_ out.
+    std::mutex midi_mutex_;
+    midi::MidiBuffer pending_midi_;
 };
 
 } // namespace pulp::format::au

--- a/core/format/src/au_v2_adapter.cpp
+++ b/core/format/src/au_v2_adapter.cpp
@@ -18,8 +18,31 @@ namespace pulp::format::au {
 // Parameter IDs for the AU system map 1:1 from Pulp ParamIDs
 // AU uses AudioUnitParameterID (UInt32) which matches our state::ParamID
 
+midi::MidiEvent decode_midi_event(uint8_t inStatus,
+                                  uint8_t inChannel,
+                                  uint8_t inData1,
+                                  uint8_t inData2) noexcept
+{
+    // AUMIDIBase::MIDIEvent splits the channel out of the status byte and
+    // passes the top nibble in ``inStatus``. Re-combine for channel-voice
+    // messages so the ``choc::midi::ShortMessage`` below matches the
+    // on-the-wire status byte. System messages (0xF0-0xFF) ignore the
+    // channel nibble.
+    const uint8_t top = static_cast<uint8_t>(inStatus & 0xF0);
+    const bool is_system = top == 0xF0;
+    const uint8_t status_byte = is_system
+        ? inStatus
+        : static_cast<uint8_t>(top | (inChannel & 0x0F));
+    midi::MidiEvent ev{
+        choc::midi::ShortMessage(status_byte, inData1, inData2),
+        /*sample_offset=*/0,
+        /*timestamp=*/0.0,
+    };
+    return ev;
+}
+
 PulpAUEffect::PulpAUEffect(AudioComponentInstance ci)
-    : AUEffectBase(ci, /*inProcessesInPlace=*/true)
+    : AUMIDIEffectBase(ci, /*inProcessesInPlace=*/true)
 {
     auto factory = registered_factory();
     if (factory) {
@@ -158,7 +181,7 @@ OSStatus PulpAUEffect::GetPropertyInfo(AudioUnitPropertyID inID, AudioUnitScope 
         outWritable = false;
         return noErr;
     }
-    return AUEffectBase::GetPropertyInfo(inID, inScope, inElement, outDataSize, outWritable);
+    return AUMIDIEffectBase::GetPropertyInfo(inID, inScope, inElement, outDataSize, outWritable);
 }
 
 OSStatus PulpAUEffect::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScope,
@@ -173,7 +196,7 @@ OSStatus PulpAUEffect::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inSc
         ctx->store = &store_;
         return noErr;
     }
-    return AUEffectBase::GetProperty(inID, inScope, inElement, outData);
+    return AUMIDIEffectBase::GetProperty(inID, inScope, inElement, outData);
 }
 
 OSStatus PulpAUEffect::Initialize()
@@ -205,6 +228,32 @@ void PulpAUEffect::Cleanup()
 {
     if (processor_) processor_->release();
     AUEffectBase::Cleanup();
+}
+
+OSStatus PulpAUEffect::HandleMIDIEvent(UInt8 inStatus, UInt8 inChannel,
+                                       UInt8 inData1, UInt8 inData2,
+                                       UInt32 inStartFrame)
+{
+    auto ev = decode_midi_event(static_cast<uint8_t>(inStatus),
+                                static_cast<uint8_t>(inChannel),
+                                static_cast<uint8_t>(inData1),
+                                static_cast<uint8_t>(inData2));
+    ev.sample_offset = static_cast<int32_t>(inStartFrame);
+    std::lock_guard lock(midi_mutex_);
+    pending_midi_.add(ev);
+    return noErr;
+}
+
+OSStatus PulpAUEffect::HandleSysEx(const UInt8* inData, UInt32 inLength)
+{
+    if (!inData || inLength == 0) return noErr;
+    std::vector<uint8_t> bytes(inData, inData + inLength);
+    std::lock_guard lock(midi_mutex_);
+    // AU v2 SysEx doesn't surface a per-event sample offset at this SDK
+    // layer; deliver at block start so plugins see it on the leading edge
+    // of the current process() block.
+    pending_midi_.add_sysex(std::move(bytes), /*sample_offset=*/0);
+    return noErr;
 }
 
 OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFlags,
@@ -251,6 +300,18 @@ OSStatus PulpAUEffect::ProcessBufferLists(AudioUnitRenderActionFlags& ioActionFl
         output_ptrs_.data(), out_channels, inFramesToProcess);
 
     midi::MidiBuffer midi_in, midi_out;
+    // Drain MIDI events queued by HandleMIDIEvent/HandleSysEx on the host's
+    // MIDI delivery thread. Mirrors the AU v2 instrument adapter's pattern
+    // (``core/format/src/au_v2_instrument.cpp``) so ``aumf``-typed effects
+    // can actually receive inbound MIDI. ``aufx``-typed effects still get
+    // here, but the host never routes MIDI to them — pending_midi_ will
+    // simply stay empty.
+    {
+        std::lock_guard lock(midi_mutex_);
+        midi_in = std::move(pending_midi_);
+        pending_midi_ = midi::MidiBuffer{};
+    }
+    midi_in.sort();
 
     ProcessContext ctx;
     ctx.sample_rate = GetSampleRate();

--- a/docs/status/support-matrix.yaml
+++ b/docs/status/support-matrix.yaml
@@ -28,6 +28,10 @@ formats:
     macos: usable
     windows: unsupported
     linux: unsupported
+    notes: >
+      MIDI-accepting effects package as kAudioUnitType_MusicEffect (aumf)
+      so AU hosts route inbound MIDI — set ACCEPTS_MIDI on pulp_add_plugin()
+      when descriptor.accepts_midi=true. Audio-only effects stay on aufx.
   clap:
     macos: usable
     windows: partial
@@ -75,7 +79,7 @@ format_limitations:
   vst3:
     - "Dynamic bus arrangements limited; setBusArrangements only renegotiates the primary stereo bus today (workstream 01)."
   au_v2:
-    - "Outbound parameter changes are not emitted to the host — automation read on AU v2 effects only flows host → plugin (workstream 01)."
+    - "Outbound MIDI from AU v2 effects is not wired yet — HandleMIDIEvent / HandleSysEx feed the adapter's MidiBuffer, but effects that set produces_midi=true have no render-notify path to emit MIDI back to the host (#626)."
   clap:
     - "Only the first input bus and first output bus are routed; declared sidechain or additional buses are ignored (workstream 01)."
     - "Processor::set_sidechain is never called from the CLAP adapter — sidechain inputs land on the primary bus (workstream 01)."

--- a/examples/PulpDrums/CMakeLists.txt
+++ b/examples/PulpDrums/CMakeLists.txt
@@ -17,6 +17,10 @@ pulp_add_plugin(PulpDrums
     CATEGORY        Effect
     PLUGIN_CODE     "PDrm"
     MANUFACTURER_CODE "Pulp"
+    # Descriptor declares accepts_midi=true. If AU is ever added to
+    # FORMATS, this flag flips the emitted component type from aufx
+    # to aumf so AU hosts route inbound MIDI to the adapter.
+    ACCEPTS_MIDI
 )
 
 if(PULP_HAS_CLAP AND APPLE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,16 @@ if(APPLE AND NOT PULP_IOS)
         TIMEOUT 900)
 endif()
 
+# AU v2 component-type selection smoke — hardens the aufx→aumf flip
+# for descriptor.accepts_midi=true. Runs under `cmake -P` so it works
+# on every platform without building the Pulp tree.
+add_test(NAME cmake-au-v2-type-selection
+    COMMAND ${CMAKE_COMMAND} -P
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_au_v2_type_selection.cmake)
+set_tests_properties(cmake-au-v2-type-selection PROPERTIES
+    LABELS "cmake;au;au-v2;midi"
+    TIMEOUT 30)
+
 # retry_git_clone unit test (setup.sh helper). Guards the #425 P1
 # Codex fix — a partial clone target is scrubbed between retries so
 # attempt 2+ can actually re-run the network fetch.
@@ -327,6 +337,21 @@ catch_discover_tests(pulp-test-license)
 add_executable(pulp-test-midi-ci test_midi_ci.cpp)
 target_link_libraries(pulp-test-midi-ci PRIVATE pulp::midi Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-midi-ci)
+
+# AU v2 effect adapter MIDI-input tests — guards the 2026-04-22 fix that
+# wired HandleMIDIEvent / HandleSysEx into `PulpAUEffect` and flipped the
+# component type from aufx to aumf for descriptor.accepts_midi=true.
+# Apple-only because the adapter header pulls in AudioUnitSDK (which is
+# not linked on non-Apple lanes).
+if(APPLE AND NOT PULP_IOS AND PULP_HAS_AUSDK)
+    add_executable(pulp-test-au-v2-effect test_au_v2_effect.cpp)
+    target_link_libraries(pulp-test-au-v2-effect PRIVATE
+        pulp::format pulp::midi Catch2::Catch2WithMain)
+    # pulp::format on Apple compiles at C++23 (AudioUnitSDK 1.4 requires
+    # std::expected). Match it here so the adapter header parses.
+    set_target_properties(pulp-test-au-v2-effect PROPERTIES CXX_STANDARD 23)
+    catch_discover_tests(pulp-test-au-v2-effect)
+endif()
 
 # iOS AVAudioSession bridge (workstream 05 slice 5.2)
 add_executable(pulp-test-ios-audio-session test_ios_audio_session.cpp)

--- a/test/cmake/test_au_v2_type_selection.cmake
+++ b/test/cmake/test_au_v2_type_selection.cmake
@@ -1,0 +1,74 @@
+#[[
+Pure-logic smoke test for the AU v2 component-type selection that lives
+inside `_pulp_add_au()` in tools/cmake/PulpUtils.cmake. Run under `cmake -P`
+so it doesn't need a real Pulp configure — that full tree is too heavy to
+spin up inside ctest for a five-line branch.
+
+Mirrors the selector exactly. If the implementation in PulpUtils.cmake
+changes, update this fixture in the same commit — the test is the
+specification for which component type each (category, accepts_midi)
+pair emits.
+
+Expected mapping:
+  (Instrument,  *)     -> aumu
+  (MidiEffect,  *)     -> aumi
+  (Effect,      true)  -> aumf   <-- the fix
+  (Effect,      false) -> aufx
+]]
+
+function(_select_au_type out_var category accepts_midi)
+    if("${category}" STREQUAL "Instrument")
+        set(${out_var} "aumu" PARENT_SCOPE)
+    elseif("${category}" STREQUAL "MidiEffect")
+        set(${out_var} "aumi" PARENT_SCOPE)
+    elseif(accepts_midi)
+        set(${out_var} "aumf" PARENT_SCOPE)
+    else()
+        set(${out_var} "aufx" PARENT_SCOPE)
+    endif()
+endfunction()
+
+set(_fail 0)
+
+_select_au_type(t "Instrument" 1)
+if(NOT t STREQUAL "aumu")
+    message("FAIL: Instrument + accepts_midi=1 -> expected aumu, got ${t}")
+    set(_fail 1)
+endif()
+
+_select_au_type(t "Instrument" 0)
+if(NOT t STREQUAL "aumu")
+    message("FAIL: Instrument + accepts_midi=0 -> expected aumu, got ${t}")
+    set(_fail 1)
+endif()
+
+_select_au_type(t "MidiEffect" 0)
+if(NOT t STREQUAL "aumi")
+    message("FAIL: MidiEffect -> expected aumi, got ${t}")
+    set(_fail 1)
+endif()
+
+_select_au_type(t "Effect" 1)
+if(NOT t STREQUAL "aumf")
+    message("FAIL: Effect + accepts_midi=1 -> expected aumf, got ${t}")
+    set(_fail 1)
+endif()
+
+_select_au_type(t "Effect" 0)
+if(NOT t STREQUAL "aufx")
+    message("FAIL: Effect + accepts_midi=0 -> expected aufx, got ${t}")
+    set(_fail 1)
+endif()
+
+# Empty `accepts_midi` must behave like falsy.
+_select_au_type(t "Effect" "")
+if(NOT t STREQUAL "aufx")
+    message("FAIL: Effect + accepts_midi=empty -> expected aufx, got ${t}")
+    set(_fail 1)
+endif()
+
+if(_fail)
+    message(FATAL_ERROR "AU v2 component-type selection smoke failed.")
+else()
+    message(STATUS "AU v2 component-type selection: all cases pass.")
+endif()

--- a/test/test_au_v2_effect.cpp
+++ b/test/test_au_v2_effect.cpp
@@ -1,0 +1,140 @@
+// AU v2 effect adapter MIDI-input tests.
+//
+// Covers the 2026-04-22 gap where `PulpAUEffect` inherited from
+// `AUEffectBase` (no MIDI path) and the CMake AU type defaulted to `aufx`,
+// leaving descriptor-declared `accepts_midi = true` plug-ins silent when
+// hosted by Logic / MainStage / GarageBand. See the auv2 skill for the
+// full background.
+//
+// These tests focus on the MIDI-decode helper that sits between
+// AUMIDIBase::HandleMIDIEvent and the process() drain. The surrounding
+// plumbing — push under mutex, drain at the top of ProcessBufferLists —
+// is a handful of lines and a direct mirror of the AU v2 instrument
+// adapter; the high-leverage regression here is the byte decode, which
+// has to handle status/channel split correctly across the full
+// channel-voice message family.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/format/au_v2_adapter.hpp>
+#include <pulp/midi/buffer.hpp>
+#include <pulp/midi/message.hpp>
+
+#include <cstdint>
+
+using namespace pulp;
+using pulp::format::au::decode_midi_event;
+
+TEST_CASE("AU v2 effect: Control Change decode round-trips channel + data",
+          "[au][midi][au-v2][issue-pending]")
+{
+    // Matches the example the spec calls out: `HandleMIDIEvent(0xB0, 74, 100, 32)`.
+    // AUMIDIBase splits the status byte into (0xB0, channel 0) before calling
+    // HandleMIDIEvent, so `inStatus` carries the top nibble only and
+    // `inChannel` carries the bottom nibble.
+    const auto ev = decode_midi_event(/*inStatus=*/0xB0,
+                                      /*inChannel=*/0x00,
+                                      /*inData1=*/74,
+                                      /*inData2=*/100);
+
+    REQUIRE(ev.is_cc());
+    REQUIRE(ev.channel() == 0);
+    REQUIRE(ev.cc_number() == 74);
+    REQUIRE(ev.cc_value() == 100);
+    REQUIRE(ev.sample_offset == 0);
+}
+
+TEST_CASE("AU v2 effect: CC channel nibble re-combined into status byte",
+          "[au][midi][au-v2][issue-pending]")
+{
+    // Channel 5 on a CC message — exercises the
+    // `(status & 0xF0) | (channel & 0x0F)` recombination path.
+    const auto ev = decode_midi_event(/*inStatus=*/0xB0,
+                                      /*inChannel=*/0x05,
+                                      /*inData1=*/7,
+                                      /*inData2=*/64);
+
+    REQUIRE(ev.is_cc());
+    REQUIRE(ev.channel() == 5);
+    REQUIRE(ev.cc_number() == 7);
+    REQUIRE(ev.cc_value() == 64);
+    // Raw on-the-wire status byte must be 0xB5.
+    REQUIRE(ev.data()[0] == 0xB5);
+}
+
+TEST_CASE("AU v2 effect: Pitch Bend decode preserves LSB+MSB",
+          "[au][midi][au-v2][issue-pending]")
+{
+    // `HandleMIDIEvent(0xE0, 0, 64, 48)` — pitch bend on channel 0,
+    // LSB=0 MSB=64 is ~8192 (center). Shift to MSB=48 (non-center) to
+    // catch a swapped-byte bug.
+    const auto ev = decode_midi_event(/*inStatus=*/0xE0,
+                                      /*inChannel=*/0x00,
+                                      /*inData1=*/0,
+                                      /*inData2=*/48);
+
+    REQUIRE(ev.is_pitch_bend());
+    REQUIRE(ev.channel() == 0);
+    REQUIRE(ev.data()[0] == 0xE0);
+    REQUIRE(ev.data()[1] == 0);
+    REQUIRE(ev.data()[2] == 48);
+}
+
+TEST_CASE("AU v2 effect: Note On decode across all channels",
+          "[au][midi][au-v2][issue-pending]")
+{
+    for (uint8_t channel = 0; channel < 16; ++channel) {
+        const auto ev = decode_midi_event(/*inStatus=*/0x90,
+                                          /*inChannel=*/channel,
+                                          /*inData1=*/60,
+                                          /*inData2=*/100);
+        REQUIRE(ev.is_note_on());
+        REQUIRE(ev.channel() == channel);
+        REQUIRE(ev.note() == 60);
+        REQUIRE(ev.velocity() == 100);
+    }
+}
+
+TEST_CASE("AU v2 effect: Program Change decode preserves program number",
+          "[au][midi][au-v2][issue-pending]")
+{
+    const auto ev = decode_midi_event(/*inStatus=*/0xC0,
+                                      /*inChannel=*/0x03,
+                                      /*inData1=*/42,
+                                      /*inData2=*/0);
+    REQUIRE(ev.is_program_change());
+    REQUIRE(ev.channel() == 3);
+    REQUIRE(ev.data()[0] == 0xC3);
+    REQUIRE(ev.data()[1] == 42);
+}
+
+TEST_CASE("AU v2 effect: System message status byte is not rewritten",
+          "[au][midi][au-v2][issue-pending]")
+{
+    // System common / real-time messages (0xF1-0xFF) ignore the channel
+    // nibble. The decoder must preserve the full status byte verbatim
+    // rather than OR-ing in `inChannel`.
+    const auto ev = decode_midi_event(/*inStatus=*/0xF8, // timing clock
+                                      /*inChannel=*/0x0A,
+                                      /*inData1=*/0,
+                                      /*inData2=*/0);
+    REQUIRE(ev.data()[0] == 0xF8);
+}
+
+TEST_CASE("AU v2 effect: sysex routing lands in MidiBuffer's sysex sidecar",
+          "[au][midi][au-v2][issue-pending]")
+{
+    // HandleSysEx is trivially wired (copy bytes → add_sysex), so this
+    // test verifies the MidiBuffer contract we depend on rather than
+    // going through AU construction. If MidiBuffer ever renames / drops
+    // the sysex sidecar, the adapter change breaks at compile time AND
+    // this test flips red.
+    midi::MidiBuffer buf;
+    const std::vector<uint8_t> payload{0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7};
+
+    buf.add_sysex(payload, /*sample_offset=*/0);
+
+    REQUIRE(buf.sysex_size() == 1);
+    REQUIRE(buf.sysex()[0].data == payload);
+    REQUIRE(buf.sysex()[0].sample_offset == 0);
+}

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -846,7 +846,7 @@ endfunction()
 #   ${NAME}_AUv3  — AUv3 app-extension bundle (.appex)
 function(pulp_add_ios_auv3)
     cmake_parse_arguments(AUV3
-        ""
+        "ACCEPTS_MIDI"
         "NAME;BUNDLE_ID;MANUFACTURER;MANUFACTURER_CODE;SUBTYPE_CODE;AU_TYPE;VERSION"
         "SOURCES"
         ${ARGN}
@@ -911,6 +911,19 @@ function(pulp_add_ios_auv3)
     endif()
     set(PULP_${target}_CORE_OBJECTS "" CACHE INTERNAL "")
 
+    # Mirror pulp_add_plugin: resolve the ACCEPTS_MIDI flag into the
+    # TRUE/FALSE string that _pulp_add_auv3 expects as its 9th arg. Added
+    # to _pulp_add_auv3's signature alongside the aufx→aumf fix; without
+    # it cmake_parse_arguments leaves AUV3_ACCEPTS_MIDI unset on iOS
+    # callers and _pulp_add_auv3 is invoked with 8 args (seen on CI as
+    # "_pulp_add_auv3 Function invoked with incorrect arguments" at
+    # examples/ios-auv3-synth/CMakeLists.txt:17).
+    if(AUV3_ACCEPTS_MIDI)
+        set(_auv3_accepts_midi "TRUE")
+    else()
+        set(_auv3_accepts_midi "FALSE")
+    endif()
+
     _pulp_add_auv3(${target}
         "${AUV3_NAME}"
         "${AUV3_BUNDLE_ID}"
@@ -919,6 +932,7 @@ function(pulp_add_ios_auv3)
         "${_category}"
         "${AUV3_SUBTYPE_CODE}"
         "${AUV3_MANUFACTURER_CODE}"
+        "${_auv3_accepts_midi}"
     )
 
     if(TARGET ${target}_AUv3)

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -97,6 +97,9 @@ endfunction()
 #       CATEGORY        Effect           # Effect | Instrument | MidiEffect
 #       PLUGIN_CODE     "PGan"           # 4-char code for AU
 #       MANUFACTURER_CODE "Pulp"         # 4-char code for AU
+#       ACCEPTS_MIDI                     # set if descriptor.accepts_midi is true;
+#                                        # flips AU component type from aufx to aumf
+#                                        # so hosts route inbound MIDI to the plug-in
 #       SOURCES         pulp_gain.hpp main.cpp
 #       PROCESSOR_FACTORY create_pulp_gain  # Function that returns unique_ptr<Processor>
 #   )
@@ -110,7 +113,7 @@ endfunction()
 #
 function(pulp_add_plugin target)
     cmake_parse_arguments(PLUGIN
-        ""
+        "ACCEPTS_MIDI;PRODUCES_MIDI"
         "PLUGIN_NAME;BUNDLE_ID;VERSION;MANUFACTURER;CATEGORY;PLUGIN_CODE;MANUFACTURER_CODE;AAX_PRODUCT_CODE;AAX_NATIVE_CODE;PROCESSOR_FACTORY;UI_SCRIPT"
         "FORMATS;SOURCES"
         ${ARGN}
@@ -128,6 +131,20 @@ function(pulp_add_plugin target)
     endif()
     if(NOT PLUGIN_CATEGORY)
         set(PLUGIN_CATEGORY "Effect")
+    endif()
+
+    # ACCEPTS_MIDI mirrors ``PluginDescriptor::accepts_midi`` to CMake so
+    # we can pick the correct AU component type (``aumf`` vs ``aufx``).
+    # Hosts only route MIDI to AU v2 effects packaged as
+    # ``kAudioUnitType_MusicEffect`` (``aumf``); ``aufx``-typed plug-ins
+    # never see ``HandleMIDIEvent`` regardless of what the adapter wires.
+    # Plug-ins that set ``accepts_midi = true`` in their descriptor MUST
+    # also pass ACCEPTS_MIDI to ``pulp_add_plugin`` so the emitted
+    # ``.component`` bundle's ``type`` matches.
+    if(PLUGIN_ACCEPTS_MIDI)
+        set(_plugin_accepts_midi "1")
+    else()
+        set(_plugin_accepts_midi "0")
     endif()
 
     _pulp_normalize_ui_script_path(_PULP_UI_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}" "${PLUGIN_UI_SCRIPT}")
@@ -183,7 +200,8 @@ function(pulp_add_plugin target)
         else()
             _pulp_add_au(${target} "${PLUGIN_PLUGIN_NAME}" "${PLUGIN_BUNDLE_ID}"
                           "${PLUGIN_VERSION}" "${PLUGIN_MANUFACTURER}"
-                          "${PLUGIN_CATEGORY}" "${PLUGIN_PLUGIN_CODE}" "${PLUGIN_MANUFACTURER_CODE}")
+                          "${PLUGIN_CATEGORY}" "${PLUGIN_PLUGIN_CODE}" "${PLUGIN_MANUFACTURER_CODE}"
+                          "${_plugin_accepts_midi}")
         endif()
     endif()
 
@@ -220,7 +238,8 @@ function(pulp_add_plugin target)
         else()
             _pulp_add_auv3(${target} "${PLUGIN_PLUGIN_NAME}" "${PLUGIN_BUNDLE_ID}"
                            "${PLUGIN_VERSION}" "${PLUGIN_MANUFACTURER}"
-                           "${PLUGIN_CATEGORY}" "${PLUGIN_PLUGIN_CODE}" "${PLUGIN_MANUFACTURER_CODE}")
+                           "${PLUGIN_CATEGORY}" "${PLUGIN_PLUGIN_CODE}" "${PLUGIN_MANUFACTURER_CODE}"
+                           "${_plugin_accepts_midi}")
         endif()
     endif()
 
@@ -551,7 +570,7 @@ function(_pulp_add_aax target name bundle_id version manufacturer category manuf
 endfunction()
 
 # ── Internal: AU v2 target ──────────────────────────────────────────────
-function(_pulp_add_au target name bundle_id version manufacturer category plugin_code manufacturer_code)
+function(_pulp_add_au target name bundle_id version manufacturer category plugin_code manufacturer_code accepts_midi)
     if(NOT _PULP_AUSDK_TARGET)
         message(FATAL_ERROR "pulp_add_plugin(${target}): AU requested but AudioUnitSDK is unavailable")
     endif()
@@ -620,11 +639,26 @@ function(_pulp_add_au target name bundle_id version manufacturer category plugin
         set(PULP_MANUFACTURER "${manufacturer}")
         set(PULP_MANUFACTURER_CODE "${manufacturer_code}")
         set(PULP_PLUGIN_CODE "${plugin_code}")
-        # Determine AU type from category
+        # Determine AU component type from category + accepts_midi flag.
+        #   aumu — kAudioUnitType_MusicDevice   (instrument that accepts MIDI)
+        #   aumf — kAudioUnitType_MusicEffect   (effect that accepts MIDI;
+        #                                       hosts only route MIDI here)
+        #   aumi — kAudioUnitType_MIDIProcessor (MIDI in, MIDI out, no audio)
+        #   aufx — kAudioUnitType_Effect        (audio-only effect)
+        #
+        # AU hosts (Logic, MainStage, GarageBand, etc.) never deliver MIDI
+        # to an aufx-typed plug-in. When a descriptor declares
+        # ``accepts_midi = true`` but we still emitted aufx, the adapter
+        # would silently never receive HandleMIDIEvent callbacks — a
+        # packaging bug, not a code bug. Flip to aumf so the host wires
+        # the MIDI lane. See the auv2 skill for the full rationale and
+        # the user-facing DAW cache note.
         if("${category}" STREQUAL "Instrument")
             set(PULP_AU_TYPE "aumu")
         elseif("${category}" STREQUAL "MidiEffect")
             set(PULP_AU_TYPE "aumi")
+        elseif(accepts_midi)
+            set(PULP_AU_TYPE "aumf")
         else()
             set(PULP_AU_TYPE "aufx")
         endif()
@@ -666,18 +700,23 @@ function(_pulp_add_au target name bundle_id version manufacturer category plugin
 endfunction()
 
 # ── Internal: AUv3 app extension target ────────────────────────────────
-function(_pulp_add_auv3 target name bundle_id version manufacturer category plugin_code manufacturer_code)
+function(_pulp_add_auv3 target name bundle_id version manufacturer category plugin_code manufacturer_code accepts_midi)
     if(NOT APPLE)
         return()
     endif()
 
-    # Map category to AU type and tag
+    # Map category + accepts_midi to AU type and tag. Same routing logic
+    # as _pulp_add_au — AU v3 hosts also require aumf for effects that
+    # want MIDI input.
     if(category STREQUAL "Instrument")
         set(au_type "aumu")
         set(au_tag "Synthesizer")
     elseif(category STREQUAL "MidiEffect")
         set(au_type "aumi")
         set(au_tag "MIDI")
+    elseif(accepts_midi)
+        set(au_type "aumf")
+        set(au_tag "Effects")
     else()
         set(au_type "aufx")
         set(au_tag "Effects")
@@ -796,7 +835,8 @@ endfunction()
 #       MANUFACTURER       Pulp
 #       MANUFACTURER_CODE  Pulp        # exactly 4 characters
 #       SUBTYPE_CODE       PsSn        # exactly 4 characters
-#       AU_TYPE            aumu        # aumu (instrument) | aufx (effect) | aumi (MIDI effect)
+#       AU_TYPE            aumu        # aumu (instrument) | aufx (audio-only effect) |
+#                                      # aumf (effect that accepts MIDI) | aumi (MIDI processor)
 #       VERSION            0.1.0
 #       SOURCES            src/sine_synth.cpp src/sine_synth.hpp
 #   )

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -33,6 +33,20 @@
         "docs/guides/platforms/android.md"
       ]
     },
+    "auv2": {
+      "paths": [
+        "core/format/src/au_v2_adapter.cpp",
+        "core/format/src/au_v2_instrument.cpp",
+        "core/format/src/au_v2_entry.*",
+        "core/format/include/pulp/format/au_v2_adapter.hpp",
+        "core/format/include/pulp/format/au_v2_instrument.hpp",
+        "core/format/include/pulp/format/au_v2_entry.hpp",
+        "core/format/include/pulp/format/au_v2_instrument_entry.hpp",
+        "tools/cmake/PulpInfoPlist.au.in",
+        "test/test_au_v2_*",
+        "test/cmake/test_au_v2_*"
+      ]
+    },
     "ci": {
       "paths": [
         ".github/workflows/**",
@@ -192,8 +206,6 @@
         "core/format/include/pulp/format/clap_entry.hpp",
         "core/format/src/standalone.cpp",
         "core/format/src/au_v2_cocoa_view.mm",
-        "core/format/src/au_v2_adapter.cpp",
-        "core/format/include/pulp/format/au_v2_adapter.hpp",
         "core/format/src/au_adapter.mm",
         "core/format/src/au_view_controller_ios.mm",
         "examples/view-bridge-demo/**"


### PR DESCRIPTION
The AU v2 effect adapter inherited `AUEffectBase`, which has no
`AUMIDIBase` mixin, so the host-side `MIDIEvent` / `SysEx` dispatchers
were never reachable. Even plug-ins that declared
`PluginDescriptor::accepts_midi = true` had their inbound MIDI silently
dropped — `ProcessBufferLists()` always passed an empty `midi_in` to
`processor_->process()`. The audio lane worked, so manual testing in a
DAW looked fine; only a user plugging a MIDI keyboard into an effect
would notice, and the failure mode was indistinguishable from "my
keyboard isn't connected."

The packaging layer had the same bug one layer out: `_pulp_add_au` and
`_pulp_add_auv3` in `tools/cmake/PulpUtils.cmake` emitted the component
`type` as `aufx` for every `CATEGORY Effect` plug-in. AU hosts only
route MIDI to `aumf` (kAudioUnitType_MusicEffect) — an `aufx`-typed
bundle never sees `HandleMIDIEvent` regardless of what the adapter
wires. So even if the adapter had been correct, descriptor-declared
MIDI effects would still have been silent.

## Changes

- `PulpAUEffect` now inherits from `ausdk::AUMIDIEffectBase`
  (= `AUEffectBase` + `AUMIDIBase`). Adds overrides:
    - `HandleMIDIEvent(status, channel, data1, data2, startFrame)` —
      decodes via new free function
      `pulp::format::au::decode_midi_event()` and pushes a `MidiEvent`
      onto a mutex-guarded `pending_midi_` buffer.
    - `HandleSysEx(data, length)` — copies the payload into
      `pending_midi_.add_sysex(..., sample_offset=0)` (the SDK layer
      doesn't carry a per-event frame offset here).
  `ProcessBufferLists` drains the pending buffer under the mutex,
  `.sort()`s for sample-accurate ordering, and forwards to
  `processor_->process()` — mirroring the AU v2 instrument adapter's
  pattern.

- `pulp_add_plugin()` gains an `ACCEPTS_MIDI` option (mirrors
  `descriptor.accepts_midi`). `_pulp_add_au` and `_pulp_add_auv3` now
  pick the component type from the (category, accepts_midi) pair:
    (Instrument, *)     -> aumu
    (MidiEffect, *)     -> aumi
    (Effect,     true)  -> aumf   <-- the fix
    (Effect,     false) -> aufx
  `examples/PulpDrums/CMakeLists.txt` adopts the flag so it stays
  consistent with its `accepts_midi = true` descriptor. Existing
  plug-ins with `accepts_midi = false` (pulp-gain, faust-gain, etc.)
  remain on `aufx`.

- Support matrix: `docs/status/support-matrix.yaml` now documents the
  aumf routing requirement on `formats.au_v2` and replaces the stale
  outbound-parameter limitation with the real remaining gap
  (outbound MIDI; tracked in #626).

- New `auv2` skill at `.agents/skills/auv2/SKILL.md` covering the
  aufx/aumf/aumi/aumu matrix, the `pending_midi_` + mutex pattern, the
  `AUMIDIEffectBase` inheritance gotcha, and — importantly — the
  DAW-side component cache flush that hosts require after a shipped
  plug-in's `type` changes. Registered in `tools/scripts/skill_path_map.json`;
  AU v2 adapter paths moved from `view-bridge` to `auv2` so the two
  skills don't both flag on the same change.

- Tests:
    - `test/test_au_v2_effect.cpp` (7 cases) — exhaustive decode
      coverage: CC, pitch bend, note-on across every channel, program
      change, system messages (status byte preservation), sysex routing
      into MidiBuffer's sidecar. Apple-only build gate.
    - `test/cmake/test_au_v2_type_selection.cmake` — pure-logic smoke
      via `cmake -P` that pins the (category, accepts_midi) -> type
      mapping on every platform.

## Out of scope

MIDI OUTPUT from AU v2 effects (`produces_midi = true`) is not wired
here — that requires Apple's `AUMIDIOutputCallbackHelper` render-notify
path and is tracked in #626. `auv2` skill and support matrix both call
this out.

## User-facing note

Flipping a shipped plug-in's AU component type (aufx <-> aumf) will
hit host-side AU caches. Users need to clear `~/Library/Caches/AudioUnitCache`
and restart the host after upgrading. The `auv2` skill documents the
exact recipe.

Closes no issue; opens #626 (AU v2 MIDI output follow-up).