### PR TITLE
skills: add clap, vst3, auv3 format skills + skill_path_map entries

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: auv3
+description: Audio Unit v3 (AUAudioUnit) format adapter for Pulp — render-block wiring, parameter tree bridging, MIDI / sysex via AURenderEvent, sidechain pulls, state persistence, iOS extension surface, and the pitfalls discovered while wiring the adapter.
+---
+
+# AU v3 Skill
+
+Use this skill when touching Pulp's Audio Unit v3 adapter, when
+answering questions about how a Pulp plugin behaves inside Logic Pro,
+GarageBand, MainStage, AUM, Cubasis, or any AUv3-aware iOS host, or
+when an `auval` run fails. AU v3 is one of Pulp's three first-class
+first-party formats; unlike AU v2 (which is owned by the `view-bridge`
+skill via `au_v2_adapter.cpp`), AU v3 is the modern `AUAudioUnit`
+subclass surface.
+
+## When to use
+
+- Editing `core/format/src/au_adapter.mm` — the `PulpAudioUnit`
+  `AUAudioUnit` subclass.
+- Editing `core/format/src/au_entry.mm` — the
+  `AUAudioUnitFactory`-conforming entry object (`PulpAUFactoryObj`)
+  and the `PulpAUFactory` component entry symbol.
+- Touching `core/format/src/au_audio_unit.h` — the Obj-C forward
+  declaration used by `au_entry.mm` and the iOS view controller.
+- Editing the iOS extension view controller
+  (`core/format/src/au_view_controller_ios.mm`) — but first read the
+  `ios` and `view-bridge` skills; that file is **also** mapped to
+  them.
+- An AUv3 host reports a behaviour issue — sidechain pull missing,
+  sysex dropped, parameter tree blank, preset recall fails, MIDI-out
+  not delivered.
+- An `auval` pass regresses.
+- Working on ARA-aware AU — but start with the `ara` skill; the AU
+  story there is the `audioUnitARAFactory` KVO property.
+
+AU v2 (`core/format/src/au_v2_adapter.cpp`) is a **separate** adapter
+covered by its own `auv2` skill. AU v2 is `AUEffectBase`-based and
+used where hosts require the classic v2 Component Manager API. **Do
+not edit `au_v2_adapter.cpp` as part of AU v3 work.**
+
+## Files and entry points
+
+| Role | Path |
+|---|---|
+| Core adapter (Obj-C++) | `core/format/src/au_adapter.mm` |
+| Forward declaration used by entry / view | `core/format/src/au_audio_unit.h` |
+| Component entry factory | `core/format/src/au_entry.mm` |
+| iOS AUv3 extension view controller | `core/format/src/au_view_controller_ios.mm` (also mapped to `ios` + `view-bridge` skills) |
+| iOS AU audio session helper | `core/format/src/ios_audio_session.cpp`, `core/format/include/pulp/format/ios_audio_session.{h,hpp}` |
+| Info.plist template (AU component bundle) | `tools/cmake/PulpInfoPlist.au.in` |
+| AudioUnitSDK fetch (used primarily by AU v2 but shared utilities reach AU v3) | `external/AudioUnitSDK` (Apache 2.0) |
+| Tests | `test/test_ios_audio_session.cpp`, `test/test_ios_background_audio_flag.cpp` (iOS-specific); AU v3 shares state / processor tests with CLAP / VST3 |
+| CLI validator invocation | `tools/cli/cmd_validate.cpp` — runs `auval` via the `auval-<name>` CTest target |
+
+There is no `PulpAU3.cmake`; AU v3 targets are wired directly in the
+top-level CMake plugin helpers alongside AU v2 and the iOS extension
+target.
+
+## Core conventions
+
+### `AUAudioUnit`, not `AUEffectBase`
+
+AU v3 uses `AUAudioUnit` as the plugin base class — Apple's modern,
+block-based render API. AU v2 (`AUEffectBase`) and AU v3
+(`AUAudioUnit`) are **two different C++ classes and two separate
+`.component` bundles**. Pulp ships both where applicable; the
+v3 subclass is `PulpAudioUnit` in `au_adapter.mm`.
+
+The bridge struct `pulp::format::au::AUBridge` owns:
+
+- `std::unique_ptr<Processor> processor` + `state::StateStore store`
+  — the same Pulp DSP + state objects used by the CLAP/VST3 adapters.
+- Pre-allocated `output_ptrs`, `input_ptrs`, `sidechain_ptrs` (sized
+  to `kMaxChannels = 8`) so the render block never allocates.
+- `InputBufferStorage input_abl` and `SidechainBufferStorage
+  sidechain_abl` — pre-sized `AudioBufferList` structs for the
+  `AURenderPullInputBlock` pulls. The sidechain has its **own** ABL
+  so it doesn't alias the main input pull.
+- `sidechain_storage` — a `std::vector<float>` backing buffer for the
+  sidechain pull so the adapter can stay allocation-free on the audio
+  thread after `allocateRenderResources`.
+
+### Entry point: `PulpAUFactory` + `AUAudioUnitFactory`
+
+`au_entry.mm` defines two symbols a host uses:
+
+1. `PulpAUFactoryObj` — a tiny Obj-C class conforming to
+   `<AUAudioUnitFactory>`. Its `createAudioUnitWithComponentDescription:error:`
+   allocs a `PulpAudioUnit`.
+2. `extern "C" void* PulpAUFactory(const AudioComponentDescription*)` —
+   the C component-registration symbol the Info.plist points at. It
+   calls `pulp_gain_force_link()` to force the static
+   `register_plugin` initialisers to link (prevents the linker from
+   stripping `au_register.cpp`), then returns a `__bridge_retained`
+   pointer to a freshly-allocated `PulpAUFactoryObj`.
+
+If the registered factory is null at entry time, the function returns
+`NULL` and a DAW sees "no factory" rather than a crash. The
+`force_link` shim is what makes a static-library-only build actually
+ship the factory symbol.
+
+### Bus construction
+
+Inside `initWithComponentDescription:…`:
+
+- Output bus: one `AUAudioUnitBus` at 48 kHz default with
+  `desc.default_output_channels()` channels.
+- Main input bus: when `desc.default_input_channels() > 0`, one
+  `AUAudioUnitBus` with that channel count.
+- Sidechain bus: when `desc.input_buses.size() > 1` and
+  `desc.input_buses[1].default_channels > 0`, a **second** input
+  `AUAudioUnitBus` — bus index 1. Hosts connect their sidechain source
+  to bus index 1 and the render block pulls it from that index.
+
+This mirrors the CLAP / VST3 "bus 0 = main, bus 1 = sidechain" rule;
+see commit `8a960d51 auv3: sidechain input bus + render-block routing
+(workstream 01 slice 1.4b)`.
+
+### Parameters: `AUParameterTree`
+
+`- (AUParameterTree *)parameterTree` builds one `AUParameter` per
+`StateStore` param:
+
+- `AUParameterAddress` is the Pulp `ParamID` cast to `uint64_t`.
+- `unit` is mapped from Pulp's unit string
+  (`dB` → `kAudioUnitParameterUnit_Decibels`, `Hz` → `_Hertz`, `%` →
+  `_Percent`, boolean-shaped ranges → `_Boolean`, everything else →
+  `_Generic`).
+- `implementorValueObserver` writes host param changes into
+  `store.set_value(id, value)`.
+- `implementorValueProvider` reads current values back from the store.
+- `implementorStringFromValueCallback` delegates to
+  `ParamInfo::to_string` when provided, otherwise a `%.2f` fallback.
+
+`__weak` capture + `strongSelf` null-check pattern is deliberate —
+Obj-C blocks on `AUParameterTree` must not retain the audio unit.
+
+### Render block
+
+`- (AUInternalRenderBlock)internalRenderBlock` returns a block that
+captures a raw `&_bridge` pointer (Obj-C `__block` / ARC semantics do
+not apply — `_bridge` is a C++ struct). The block:
+
+1. Zeroes outputs and returns `noErr` if the Processor is null (host
+   calling render before `allocateRenderResources` succeeded).
+2. Points `output_ptrs[i]` at `outputData->mBuffers[i].mData`.
+3. Pulls the main input via `pullInputBlock(…, 0, &input_abl)`. This
+   reuses the **output** buffers as the input destination — in-place
+   processing is allowed (`canProcessInPlace` returns `YES`).
+4. Pulls the sidechain (if enabled) via
+   `pullInputBlock(…, 1, &sidechain_abl)` into the separate backing
+   storage; publishes to `processor->set_sidechain(&view)` only on
+   success, nulls out the slot on failure.
+5. Walks the realtime event list — short MIDI via `AURenderEventMIDI`,
+   long / sysex via `AURenderEventMIDIEventList`. See gotchas below.
+6. Calls `processor->process(output_view, input_view, midi_in,
+   midi_out, ctx)`.
+7. Forwards any `midi_out` events back to the host via
+   `self.MIDIOutputEventBlock` (AU v3.1+). Each event's
+   `sample_offset` is added to `timestamp->mSampleTime`.
+
+### State: `fullState` dictionary
+
+`fullState` wraps `store_.serialize()` bytes inside an `NSData` keyed
+`@"pulpState"` within the dictionary returned by `super.fullState`.
+`setFullState:` reads `@"pulpState"` back, calls
+`store_.deserialize`. The super call is intentional — AUAudioUnit
+merges its own internal state (e.g. maximum frames to render) into the
+dictionary, and the round-trip must preserve it.
+
+`supportsUserPresets` currently returns `NO`. `currentPreset` is not
+overridden — use `fullState` for persistence, not
+`AUAudioUnitPreset`. Wiring user presets requires implementing
+`userPresets`, `supportsUserPresets`, `saveUserPreset:error:`,
+`deleteUserPreset:error:`, `presetStateFor:error:`, and
+`currentPreset` as a matched pair.
+
+### ARA companion factory
+
+`audioUnitARAFactory` is a `@property (readonly, nullable) void *` —
+the AU-host-observed KVO property that ARA-aware hosts (Logic Pro 11+)
+read during scan. It returns
+`pulp::format::ara_companion_factory_for(nullptr)`, which is non-null
+in `PULP_HAS_ARA` builds where a Processor overrode
+`create_ara_document_controller()`. See commit `cb5812c1 ara(au):
+audioUnitARAFactory KVO property on PulpAudioUnit (#252)`.
+
+### iOS AUv3 extension
+
+AUv3 on iOS is a UIKit **app extension**. The view controller
+(`PulpAUViewController` in `au_view_controller_ios.mm`) is
+`AUViewController`-derived and builds a `ViewBridge` against the
+extension's loaded `AUAudioUnit` once KVO fires on
+`self.audioUnit`. Extension principal class registration is via
+`NSExtensionMain`-style Info.plist — see `docs/guides/ios-auv3-guidance.md`
+and the `ios` skill for the extension target wiring.
+
+## Gotchas
+
+### `AURenderEventMIDIEventList` = UMP — not short MIDI, not raw sysex
+
+AU v3.1+ delivers long MIDI and MIDI 2.0 messages through
+`AURenderEventMIDIEventList`, which carries a `MIDIEventList` of
+`MIDIEventPacket` structs — **UMP-encoded** 32-bit words. Sysex7
+arrives as type-3 UMP messages spread across 2-word packets with a
+4-bit status field in bits 20–23 of word 0:
+
+```
+status == 0x0  → complete single-packet sysex
+status == 0x1  → start (reset accumulator)
+status == 0x2  → continue
+status == 0x3  → end
+```
+
+`au_adapter.mm` accumulates start → continue → end spans into one
+`add_sysex` call (`#292` / `#288`). Two hard-learned P1 lessons:
+
+1. **Advance the word cursor by `ump_words`, not by 1.** A type-3
+   message is 2 UMP words long; advancing by 1 makes the second
+   word's header nibble look like a new message header (P1).
+2. **Sysex7 size is 0..6 bytes per 2-word packet.** Extract bytes
+   from word0 bits 15..0 + word1 bits 31..0, clamped to `size` and to
+   6 (#292 P2 — preserve message boundaries).
+
+Both are tested by `test/test_ump_*.cpp`. Touch the accumulator → add
+a test that exercises the boundary.
+
+### Short-MIDI length must be validated
+
+`AURenderEventMIDI.length` is the length in bytes. Short messages are
+1..3 bytes and `data[0]`'s MSB must be set (status byte). The adapter
+explicitly rejects `length == 0`, `length > 3`, and messages with
+`(data[0] & 0x80) == 0`. Do not relax that gate — corrupt short
+messages past the gate feed `choc::midi::ShortMessage` garbage.
+
+### `_bridge` captured as raw pointer in the render block
+
+The render block captures `&_bridge` (a C++ struct inside the Obj-C
+class) as a raw pointer. ARC does not retain `_bridge`. Keeping the
+audio unit alive is the host's job; the block lives for the audio
+unit's lifetime. **Do not** capture `self` into the render block —
+that creates a retain cycle that only breaks when the host drops the
+unit, and Logic will reproduce-steps that via preset hot-swap.
+
+The MIDI-out fan-out in the same block does capture `self.MIDIOutputEventBlock`
+via ARC (`__block id` style through the implicit-self path). That one
+is intentional — the block the host installs is ARC-retained on the
+audio unit and does not form a cycle.
+
+### `allocateRenderResourcesAndReturnError` is where `prepare()` lives
+
+Not in `initWithComponentDescription:`. The host may instantiate the
+audio unit to enumerate parameters / buses without ever rendering;
+calling `Processor::prepare()` before the host has a sample rate +
+max frames in hand wastes work and can mis-size buffers. Mirror:
+`deallocateRenderResources` calls `processor->release()`.
+
+### `tailTime` is in **seconds**, not samples
+
+Pulp's `descriptor().tail_samples` is an integer sample count;
+`tailTime` returns seconds. `< 0` means infinite and returns
+`std::numeric_limits<double>::infinity()` (AU's sentinel). Do not
+return `0` — a `0` tail tells the host "this plugin emits nothing
+after input stops" and delay/reverb tails get chopped.
+
+### Sidechain pull uses its **own** `AudioBufferList`
+
+Aliasing the main `input_abl` into the sidechain pull corrupts the
+main input (the pull overwrites it). `sidechain_abl` +
+`sidechain_storage` are separate by design — the storage is sized for
+`kMaxChannels * max_frames` at `allocate`, with a defensive re-size
+inside the render block for the rare case where a host asks for more
+frames than `maximumFramesToRender` claimed.
+
+### Factory entry point needs `force_link` to keep registration alive
+
+`pulp_gain_force_link()` is an empty function whose only purpose is to
+keep the linker from stripping `au_register.cpp`. The static
+initialisers in that TU are what populate the Pulp plugin registry
+before `PulpAUFactory` runs. If you add a new auto-registering TU,
+either reference it from `force_link` or the linker will drop it in
+release builds — and `registered_factory()` returns null at AU
+instantiation time.
+
+### Channel count hard limit of 8
+
+`kMaxChannels = 8`. Bumping that requires re-sizing every
+pre-allocated buffer array and validating hosts don't ask for more
+channels than the descriptor declares. Not a surround-readiness flag
+yet.
+
+### No `kAudioUnitProperty_CocoaUI` v3-native view plumbing today
+
+AU v3 uses `requestViewControllerWithCompletionHandler:` to fetch an
+`AUViewController`. macOS bundles that ship a desktop editor for an AU
+v3 `.component` rely on the AU v2 Cocoa view path
+(`au_v2_cocoa_view.mm`) for the editor. iOS bundles use the
+`AUViewController` subclass directly. Cross-platform editor work lives
+in the `view-bridge` skill.
+
+### `auval` is the AU gate
+
+`auval` ships with macOS; `pulp validate` wraps the CTest target
+`auval-<name>` rather than running `auval` directly. On a raw
+development machine, run manually via e.g.
+`auval -v aufx MyPl Plup`. A freshly built `.component` that was just
+copied into `~/Library/Audio/Plug-Ins/Components/` requires a cached-
+plist rebuild — delete
+`~/Library/Caches/AudioUnitCache/` and `~/Library/Caches/com.apple.audiounits.cache`
+(or call `killall -9 AudioComponentRegistrar`) before validating a new
+bundle.
+
+### iOS extension principal class is declared in Info.plist
+
+AUv3 iOS extensions use `NSExtensionPrincipalClass` =
+`PulpAUViewController` in the extension target's Info.plist, not
+`NSExtensionMain`. If the extension fails to load in a host (Cubasis /
+AUM), check the Info.plist before the Obj-C — a typo in the principal
+class name fails silently.
+
+## Validation recipes
+
+Build and validate via the Pulp CLI:
+
+```bash
+./build/tools/cli/pulp build
+./build/tools/cli/pulp validate         # runs auval via the auval-<name> CTest target
+```
+
+Manual `auval` (macOS only — `auval` is an Apple tool):
+
+```bash
+# List all registered AUs; find yours in the list
+auval -a
+
+# Validate an effect (type/subtype/manufacturer are 4-char codes)
+auval -v aufx MyPl Plup
+
+# Validate an instrument
+auval -v aumu MySy Plup
+```
+
+If `auval -a` doesn't list the plugin, the AU cache is stale. Reset
+it:
+
+```bash
+killall -9 AudioComponentRegistrar
+rm -rf ~/Library/Caches/AudioUnitCache/ \
+       ~/Library/Caches/com.apple.audiounits.cache
+```
+
+`auval -r` runs the longer reinit-stress pass; use it before shipping
+a release but not on every iteration — it takes minutes.
+
+iOS: no standalone `auval`-equivalent. Run the AUv3 extension in the
+AUHost sample app (available from Apple's developer portal) or inside
+AUM / Cubasis to smoke-test instantiation + render. See the `ios`
+skill for device deploy.
+
+## Cross-references
+
+- `.agents/skills/ios/SKILL.md` — iOS extension wiring, simulator
+  deploy, audio session handling.
+- `.agents/skills/view-bridge/SKILL.md` — editor contract. On iOS,
+  `au_view_controller_ios.mm` is the canonical AUv3 example of the
+  protocol.
+- `.agents/skills/auv2/SKILL.md` — the AU v2 adapter, separate bundle.
+- `.agents/skills/ara/SKILL.md` — `audioUnitARAFactory` KVO property.
+- `.agents/skills/mpe/SKILL.md` — MPE sidecar contract (AU v3 delivers
+  MPE as short MIDI via `AURenderEventMIDI`; the Pulp path is the same
+  `MpeVoiceTracker` as CLAP / VST3).
+- `.agents/skills/clap/SKILL.md` and `.agents/skills/vst3/SKILL.md` —
+  cross-format parity sanity-check for host-specific regressions.
+- `docs/guides/ios-auv3-guidance.md` — the human-facing iOS AUv3 guide.
+- `docs/guides/formats.md` — user-facing format overview + auval
+  recipes.
+- Memory note: AAX-parity sweep — AU sysex (#288), VST3 sysex (#274),
+  CLAP sysex (#269) and AAX sysex (#239) all share the same
+  sidecar. Fixing one means checking the other three.

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: clap
+description: CLAP format adapter for Pulp — how Processor bridges to clap_plugin_t, how parameters / modulation / sidechain / MPE / UMP / sysex flow, and the pitfalls discovered while wiring the adapter.
+---
+
+# CLAP Skill
+
+Use this skill when touching Pulp's CLAP adapter, when answering
+questions about how a Pulp plugin appears to a CLAP host, or when a
+CLAP validator run surfaces something odd. CLAP is Pulp's first-class,
+MIT-safe plugin format — every plugin built with Pulp ships a CLAP
+binary and CLAP is the fastest iteration lane because the
+`clap-validator` runs without a DAW.
+
+## When to use
+
+- Editing `core/format/src/clap_adapter.cpp` or the generated entry header
+  `core/format/include/pulp/format/clap_entry.hpp` (the boilerplate-
+  generator macro `PULP_CLAP_PLUGIN(…)`).
+- Adding or changing a CLAP extension (`audio-ports`, `note-ports`,
+  `params`, `state`, `gui`, `preset-load`, ARA companion factory, …).
+- A CLAP host reports a behaviour issue — sidechain missing, MIDI
+  events dropped, presets not loading, GUI refusing to attach.
+- A `clap-validator` pass regresses.
+- Working on the MPE or UMP sidecar as it flows through the CLAP path
+  — the CLAP adapter is currently the canonical consumer of
+  `set_mpe_input` / `set_ump_input`.
+- Cross-referencing CLAP behaviour against VST3 / AU when debugging
+  host-specific regressions — use the three adapters as each other's
+  "oracle" during parity fixes.
+
+## Files and entry points
+
+| Role | Path |
+|---|---|
+| Core adapter (C++) | `core/format/src/clap_adapter.cpp` |
+| Adapter header / `PulpClapPlugin` | `core/format/include/pulp/format/clap_adapter.hpp` |
+| Entry-point generator macro | `core/format/include/pulp/format/clap_entry.hpp` |
+| CLAP module (FetchContent) | declared in `CMakeLists.txt`; CLAP headers are MIT and fetched at configure time — there is no hand-written `PulpClap.cmake` |
+| WebAssembly compact variant (wclap) | `tools/cmake/PulpWclap.cmake`, `core/format/src/wasm/` |
+| CLAP+ARA surface | `core/format/src/ara*`, see the `ara` skill |
+| Tests | `test/test_clap_entry.cpp` (dlopen + descriptor), `test/test_clap_ara_extension.cpp` (ARA companion factory), `test/test_clap_webview.cpp` (WebView bridge) |
+| CLI validator invocation | `tools/cli/cmd_validate.cpp` (`clap-validator validate …` with dlopen-only fallback) |
+
+The `PULP_CLAP_PLUGIN(factory_fn)` macro (bottom of `clap_entry.hpp`)
+is the sole developer-facing surface. It expands to the static
+`g_factory` initialisation, calls `register_plugin(factory_fn)`, fills
+in `g_clap_desc` from the `PluginDescriptor`, and defines the
+`clap_entry` exported symbol. There is no separate "factory" TU — the
+macro is the factory.
+
+## Core conventions
+
+### The shape of a CLAP instance
+
+`PulpClapPlugin` (in `clap_adapter.hpp`) is the shared per-instance
+struct. It owns:
+
+- `std::unique_ptr<Processor> processor` — the user's DSP.
+- `state::StateStore store` — parameter state, wired to the processor
+  via `set_state_store(&store)` during `clap_init`.
+- Pre-allocated `input_ptrs` / `output_ptrs` / `sidechain_ptrs` arrays
+  sized to `kMaxChannels = 8`. **Process must not allocate** — these
+  pointer fan-outs are static across calls.
+- `param_snapshot` for detecting plugin-side parameter edits during
+  `process()`. After `processor->process()`, the adapter compares each
+  param to its snapshot and emits `CLAP_EVENT_PARAM_VALUE` out-events
+  so the host can record automation.
+- `mpe_tracker` + `mpe_buffer` + `mpe_enabled` — MPE sidecar populated
+  only if `PluginDescriptor::supports_mpe` is true.
+- `ump_buffer` + `ump_enabled` — UMP sidecar synthesised from MIDI 1.0
+  events (CLAP has no `CLAP_EVENT_MIDI2` today; see Gotchas below).
+- `ara_controller` — lazily created on the first host query for the
+  ARA companion-factory extension.
+- `bridge` + `editor_host` + `editor_visible` — gated on
+  `PULP_CLAP_GUI`. Editor lifecycle flows through `ViewBridge`; see the
+  `view-bridge` skill for the open/attach/close protocol.
+
+### Parameters
+
+Parameters are defined by the Processor during `define_parameters(store)`
+and enumerated to the host by the `params` extension in
+`clap_entry.hpp`:
+
+- `params_count` → `store.param_count()`.
+- `params_get_info` → builds a `clap_param_info_t` from the stored
+  `ParamInfo`. `CLAP_PARAM_IS_AUTOMATABLE` is always set.
+  `CLAP_PARAM_IS_STEPPED` is set when `range.step >= 1` and the range
+  is narrow (`< 10`).
+- `params_get_value` returns the current **base** value (without
+  modulation).
+- `params_value_to_text` uses `ParamInfo::to_string` when provided,
+  otherwise falls back to `"%.2f %s"` with the unit.
+
+During `clap_process`, the adapter routes host events into the store:
+
+```
+CLAP_EVENT_PARAM_VALUE   → store.set_value(id, value)
+CLAP_EVENT_PARAM_MOD     → store.set_mod_offset(id, amount)
+CLAP_EVENT_PARAM_GESTURE_BEGIN / _END → store.begin_gesture / end_gesture
+```
+
+The **modulation offset is per-buffer**: `store.reset_all_mod()` runs
+at the top of every `process()` before applying new `PARAM_MOD` events.
+DSP reads modulated values via `store.get_modulated(id)` = base +
+current mod offset. Plugins that only read `store.get_value(id)` do
+**not** see host modulation.
+
+### Audio buses (incl. sidechain)
+
+`audio_ports` enumeration in `clap_entry.hpp` is descriptor-driven:
+`desc.input_buses` / `desc.output_buses`. **Bus 0 is always the main
+bus** (flag `CLAP_AUDIO_PORT_IS_MAIN`); **bus 1 (when present) is the
+sidechain** and is routed via `Processor::set_sidechain(&view)` before
+`process()`. Additional input buses beyond index 1 are ignored — the
+Processor API exposes a single sidechain slot. Secondary **output**
+buses are zero-filled so multi-out instruments don't surface
+uninitialised memory to hosts.
+
+### MIDI: short messages, sysex, MPE, UMP
+
+Note events are converted from CLAP's channel/key/velocity form into
+`midi::MidiEvent`:
+
+```
+CLAP_EVENT_NOTE_ON / _NOTE_OFF → MidiEvent::note_on / note_off
+CLAP_EVENT_MIDI_SYSEX          → midi_in.add_sysex(bytes, time, 0.0)
+```
+
+CLAP's per-note events (`CLAP_EVENT_NOTE_EXPRESSION`) are **not**
+currently decoded by the adapter directly; MPE is delivered by
+running the inbound `midi_in` through `MpeVoiceTracker` and publishing
+the resulting `MpeBuffer` via `processor->set_mpe_input(&buf)`. See the
+`mpe` skill for per-note expression details.
+
+The UMP sidecar is synthesised from the MIDI 1.0 stream via
+`midi1_to_ump` because CLAP has not shipped `CLAP_EVENT_MIDI2` yet.
+When it does, flip the adapter to consume the native stream; the
+existing `UmpBuffer` shape is already the public contract.
+
+### State save / restore
+
+Serialisation goes through the single `StateStore::serialize()` /
+`deserialize(bytes)` path (in `clap_entry.hpp` `state_ext`). Format is
+the Pulp binary blob — identical bytes across CLAP / VST3 / AU, so
+round-trip parity is trivial to test.
+
+### Editor
+
+Gated on `PULP_CLAP_GUI` (set for plugin targets, off for the shared
+format lib to keep the core thin). Lifecycle flows through
+`pulp::format::ViewBridge`: `gui_create` → `bridge->open()`, the host
+then calls `gui_set_parent(window)` → `editor_host->attach_to_parent` +
+`bridge->notify_attached()`, `gui_destroy` → `bridge->close()`. See the
+`view-bridge` skill for the full contract — the CLAP adapter is the
+reference implementation for the "open, then notify_attached after
+host has attached" protocol.
+
+Window API negotiation is compile-time platform-switched to Cocoa /
+Win32 / X11. `gui_can_resize` returns false today — resize negotiation
+has not been wired.
+
+### ARA companion factory
+
+`clap_get_extension(kClapAraFactoryExtension)` lazily creates the
+plugin's `AraDocumentController` on first query, then returns the
+companion factory pointer. Only instantiates when the Processor
+overrode `create_ara_document_controller()` — plugins that don't
+participate in ARA return `nullptr` naturally. See the `ara` skill.
+
+### Preset loading
+
+`clap_plugin_preset_load` is exposed only when the Processor builds a
+`PresetManager` during `clap_init` (driven by
+`desc.manufacturer`/`desc.name`). Today only
+`CLAP_PRESET_DISCOVERY_LOCATION_FILE` is honoured; bundle- and plugin-
+internal preset sources are ignored and return false.
+
+## Gotchas
+
+### Sidechain `data32` can be null — guard before routing (#277)
+
+A host may report `audio_inputs_count > 1` but hand the adapter a null
+`data32` pointer (bus deactivated). A loose translation of "bus exists
+→ publish sidechain" hands the Processor a `BufferView` over garbage.
+The guard in `clap_process` demotes the whole sidechain bus to "not
+supplied" if any per-channel pointer is null — do not remove it.
+
+```cpp
+if (sc_bus.data32) {
+    sc_channels = std::min(static_cast<int>(sc_bus.channel_count), kMaxChannels);
+    for (int ch = 0; ch < sc_channels; ++ch) {
+        self->sidechain_ptrs[ch] = sc_bus.data32[ch];
+        if (!self->sidechain_ptrs[ch]) { sc_channels = 0; break; }
+    }
+}
+```
+
+The VST3 adapter carries the same guard (`#178` review). Mirror both
+whenever reshaping the sidechain path.
+
+### Reset modulation offsets **every** buffer
+
+`store.reset_all_mod()` is the first line of `clap_process()`. If you
+refactor the process prologue, keep it first — otherwise stale
+`PARAM_MOD` offsets from a previous block leak into the next one and
+the plugin's DSP drifts away from the host's expected modulated value.
+Found during CLAP modulation bring-up.
+
+### `param_snapshot` is **per-buffer**, not cached
+
+The snapshot is taken after host events are applied but before
+`processor->process()`. The diff compared against current values at
+the end is what the adapter emits as `PARAM_VALUE` out-events. If you
+optimise this into a persisted snapshot you will drop plugin-side
+param edits that happen at block boundaries.
+
+### Secondary output buses must be zero-filled
+
+Multi-out instruments that don't route to bus ≥ 1 leave those output
+buffers whatever the host's last tenant wrote. The adapter now zeroes
+every secondary output channel every block — do not skip this even for
+"only bus 0 used" plugins; some hosts reuse memory across plugin
+slots.
+
+### ARA companion factory is returned **only after Processor exists**
+
+`clap_get_extension` may be called before `clap_init` populates
+`self->processor`. The current impl returns the static companion
+factory pointer early; it only lazily instantiates the
+`AraDocumentController` once `self->processor != nullptr`. If you
+refactor this path, preserve that ordering — eagerly constructing the
+controller at extension-query time triggers the
+`create_ara_document_controller()` virtual before the Processor is
+alive.
+
+### UMP sidecar is **synthesised**, not delivered by the host
+
+`midi1_to_ump` conversion runs inside `clap_process()` every block
+that the Processor declares `supports_ump`. There is no
+`CLAP_EVENT_MIDI2` event type in CLAP 1.2. When CLAP adds native UMP
+delivery, flip the synth path off for hosts that advertise support —
+do not keep both running or you'll double-deliver per-note messages.
+See `#141` / `#139` for the UMP buffer shape.
+
+### GUI is gated on `PULP_CLAP_GUI`
+
+The shared `pulp_format` library is built without `PULP_CLAP_GUI` so
+the adapter stays thin. Only the per-plugin CLAP target turns it on.
+If you add a new GUI-dependent member to `PulpClapPlugin`, wrap it in
+`#ifdef PULP_CLAP_GUI` or the non-GUI builds break.
+
+### ARA CLAP lives outside `CLAP_EXT_*`
+
+The ARA companion factory is keyed on
+`kClapAraFactoryExtension` (Pulp-private identifier), not one of CLAP's
+reserved `CLAP_EXT_*` strings. Don't rename it; other Pulp + ARA hosts
+already search for that exact key. Defined in `pulp/format/ara.hpp`.
+
+### `clap-validator` is optional — fallback is dlopen
+
+`pulp validate` (`tools/cli/cmd_validate.cpp`) runs
+`clap-validator validate …` when installed, otherwise falls back to a
+plain `dlopen` check. CI lanes without `clap-validator` still exercise
+the "plugin loads" path; full spec conformance requires the validator
+binary.
+
+### AAX-parity sweep
+
+AAX and CLAP share CLAP's sysex-sidecar pattern (#239). When you
+change the CLAP sysex accumulator, the AAX adapter
+(`core/format/src/aax_runtime.cpp`) and the VST3 / AU halves need to
+stay in sync — see the memory note on AAX-parity.
+
+## Validation recipes
+
+Build and smoke a CLAP bundle with the Pulp CLI:
+
+```bash
+# Build everything, then validate
+./build/tools/cli/pulp build
+./build/tools/cli/pulp validate          # runs clap-validator if installed
+```
+
+Direct `clap-validator` usage (matches what `cmd_validate.cpp` invokes):
+
+```bash
+# macOS / Linux
+clap-validator validate "$(pwd)/build/path/to/MyPlugin.clap"
+
+# Install if missing
+cargo install clap-validator
+```
+
+CI's fallback when `clap-validator` is not on the path is a dlopen
+check — load the bundle's entry symbol (`clap_entry`) and verify the
+factory hands back a valid descriptor. See
+`test/test_clap_entry.cpp` for the in-repo equivalent.
+
+`pulp build --test` runs validation before allowing
+`pulp build --install` to write into
+`~/Library/Audio/Plug-Ins/CLAP/`. Do not `--skip-validation` a CLAP
+build before a DAW scan — a crashing entry point takes the DAW down
+with it.
+
+## Cross-references
+
+- `.agents/skills/view-bridge/SKILL.md` — editor open / attach /
+  close protocol; CLAP was the reference wiring in PR #140.
+- `.agents/skills/mpe/SKILL.md` — MPE sidecar contract. CLAP is the
+  canonical consumer.
+- `.agents/skills/ara/SKILL.md` — ARA SDK setup and companion-factory
+  lifecycle.
+- `.agents/skills/vst3/SKILL.md` and `.agents/skills/auv3/SKILL.md` —
+  cross-format parity table when triaging host-specific bugs.
+- `docs/guides/formats.md` — user-facing format overview.
+- `docs/guides/host-matrix.md` — per-host ARA / CLAP compatibility
+  notes.
+- Memory note: CHOC-first policy — prefer `choc::midi` helpers over
+  hand-rolled MIDI decode when touching the adapter.

--- a/.agents/skills/vst3/SKILL.md
+++ b/.agents/skills/vst3/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: vst3
+description: VST3 format adapter for Pulp — SingleComponentEffect wiring, bus arrangement negotiation, parameter / MIDI event routing, state round-trip, and the pitfalls discovered while wiring the adapter against Steinberg's SDK.
+---
+
+# VST3 Skill
+
+Use this skill when touching Pulp's VST3 adapter, when answering
+questions about how a Pulp plugin behaves inside Cubase / Nuendo /
+Studio One / Reaper (VST3 lane) / FL Studio / Ableton Live (VST3
+lane), or when a `pluginval` run surfaces something odd. VST3 is one
+of Pulp's three first-class plugin formats alongside CLAP and AU v3.
+
+## When to use
+
+- Editing `core/format/src/vst3_adapter.cpp` or its header.
+- Changing the generator macro `PULP_VST3_PLUGIN(…)` in
+  `core/format/include/pulp/format/vst3_entry.hpp`.
+- Changing bus-arrangement negotiation, parameter registration, MIDI
+  event routing, state save/restore, or editor lifecycle.
+- A VST3 host reports a behaviour issue — sidechain not exposed,
+  mono↔stereo swap crashes the track, automation not recorded,
+  tempo-sync glitches, preset load misbehaves.
+- A `pluginval --strictness-level 5` run regresses.
+- Working on the ARA VST3 surface — but first read the `ara` skill.
+
+## Files and entry points
+
+| Role | Path |
+|---|---|
+| Core adapter (C++) | `core/format/src/vst3_adapter.cpp` |
+| Adapter header / `PulpVst3Processor` | `core/format/include/pulp/format/vst3_adapter.hpp` |
+| Entry-point generator macro | `core/format/include/pulp/format/vst3_entry.hpp` |
+| Editor `IPlugView` implementation | `core/format/src/vst3_plug_view.cpp`, `core/format/include/pulp/format/vst3_plug_view.hpp` |
+| Info.plist template (macOS bundle) | `tools/cmake/PulpInfoPlist.vst3.in` |
+| VST3 SDK fetch | `external/vst3sdk` — `git clone --depth 1 --branch v3.7.12 https://github.com/steinbergmedia/vst3sdk.git` (MIT) |
+| CLI validator invocation | `tools/cli/cmd_validate.cpp` (`pluginval --strictness-level 5 --timeout-ms 30000 --validate …`) |
+
+There is no hand-written `PulpVst3.cmake` helper — the VST3 target is
+wired directly in the top-level `CMakeLists.txt` / `PulpPlugin` CMake
+surface.
+
+The VST3 editor lives in a sibling file (`vst3_plug_view.cpp`) that is
+**owned by the `view-bridge` skill** per `skill_path_map.json`. Edits
+to the editor surface trigger the `view-bridge` skill rather than
+this one.
+
+## Core conventions
+
+### SingleComponentEffect pattern
+
+`PulpVst3Processor` extends
+`Steinberg::Vst::SingleComponentEffect` — Steinberg's combined
+processor-plus-controller class. That means **no separate
+`IEditController`** instance: the same C++ object both processes audio
+and advertises parameters. This is deliberate; it simplifies
+bidirectional parameter sync and matches how CLAP/AU handle the two
+roles in one object.
+
+The `PULP_VST3_PLUGIN(uid, name, category, vendor, version, url,
+factory_fn)` macro (in `vst3_entry.hpp`) expands to a single
+`BEGIN_FACTORY_DEF / DEF_CLASS2 / END_FACTORY` block that registers
+the class under `kVstAudioEffectClass`. One factory per TU — do not
+macro-expand it twice in the same plugin.
+
+### `initialize` — the setup path
+
+```cpp
+SingleComponentEffect::initialize(context)       // Steinberg base
+processor_ = factory_()                          // Pulp Processor
+processor_->set_state_store(&store_)
+processor_->define_parameters(store_)
+store_.set_gesture_callbacks(beginEdit, endEdit) // host-recorded gestures
+addAudioInput / addAudioOutput                   // from desc.{input,output}_buses
+addEventInput / addEventOutput                   // gated on desc.{accepts,produces}_midi
+parameters.addParameter(…)                       // one per StateStore param
+```
+
+The `unitId` field on each VST3 `ParameterInfo` is populated from
+Pulp's `ParamInfo::group_id` — that's how VST3 hosts render a
+parameter tree / folder structure.
+
+Context-aware behaviour: if `context` resolves to an
+`IHostApplication`, the adapter logs `kVst3AraFactoryContextKey` for
+ARA-aware VST3 hosts (Cubase, Studio One). Surfaces Pulp's ARA factory
+through the companion-factory negotiation. See the `ara` skill for
+the full story.
+
+### Bus arrangement negotiation
+
+`setBusArrangements(inputs, numIns, outputs, numOuts)` is **not** a
+pass-through to the base class. Pulp's implementation:
+
+1. Rejects with `kResultFalse` if `numIns`/`numOuts` don't match the
+   descriptor's declared bus counts.
+2. Rejects if any requested speaker arrangement is neither `kMono` nor
+   `kStereo` — negotiation is currently limited to those two.
+3. Otherwise updates each `AudioBus` via
+   `bus->setArrangement(arrangement)` in place, then re-propagates to
+   `SingleComponentEffect::setBusArrangements`.
+
+Why: hosts swap project channel layouts (load a stereo session over a
+mono plugin slot) and expect the plugin's `descriptor()` view to
+follow. Without the in-place update, the Pulp Processor's channel
+counts diverge from the VST3 bus state. See commit
+`b9cda370 vst3: dynamic bus arrangements — honor setBusArrangements
+(#240)`.
+
+### `setupProcessing` / `setActive` sequence
+
+The Steinberg lifecycle is:
+
+```
+initialize → setBusArrangements → setupProcessing → setActive(true)
+    → process loop → setActive(false) → terminate
+```
+
+`setupProcessing` calls `processor_->prepare(ctx)` with the host's
+sample rate, max buffer size, and the descriptor's default channel
+counts. `setActive(false)` calls `processor_->release()` so the
+Processor can free prepare-time resources. Never move `prepare()` out
+of `setupProcessing` — Steinberg guarantees `process()` is only called
+after a successful `setupProcessing` + `setActive(true)` sequence.
+
+### Parameters
+
+Parameters flow both ways:
+
+- **Host → plugin**: every block, `process()` walks
+  `data.inputParameterChanges`, takes the **last** point from each
+  `IParamValueQueue`, and calls `store_.set_normalized(id, value)`. VST3
+  values are always normalised 0..1 — `set_normalized` converts to the
+  ParamInfo's real range.
+- **Plugin → host**: `param_snapshot_` is taken before `process()`;
+  after, any changed param emits a point via
+  `data.outputParameterChanges->addParameterData(id).addPoint(0, norm)`
+  **and** `setParamNormalized(id, norm)` keeps the SDK-side parameter
+  cache in sync. Without both, automation-recording hosts miss the
+  edit.
+- **Gesture grouping**: `store_.set_gesture_callbacks(beginEdit,
+  endEdit)` forwards Pulp gesture begin/end to Steinberg's undo-group
+  primitives. UI code that edits params via `Binding` automatically
+  gets gestures.
+
+`kIsBypass` is auto-set on any parameter named `"Bypass"` whose range
+is `[0,1]` with `step >= 1` — Steinberg requires exactly one bypass
+parameter per plugin for the host bypass control to work.
+
+### MIDI events
+
+VST3 delivers note-on / note-off through `IEventList`:
+
+```
+Event::kNoteOnEvent  → MidiEvent::note_on
+Event::kNoteOffEvent → MidiEvent::note_off
+Event::kDataEvent (type=kMidiSysEx) → midi_in.add_sysex(bytes, sampleOffset, 0.0)
+```
+
+Non-note short MIDI (CC, pitch bend, aftertouch) is **not** delivered
+by Steinberg's event list — VST3 hosts translate those into parameter
+automation using `kIsMidiCC`-tagged parameters. If you need them, model
+them as Pulp parameters, not MIDI. See `docs/guides/formats.md`.
+
+MIDI output mirrors the inverse: note_on / note_off in
+`midi_out` are written back into `data.outputEvents`.
+
+### Audio buses (incl. sidechain)
+
+Same "bus 0 = main, bus 1 = sidechain" rule as CLAP/AU. The adapter
+defensively guards against inactive sidechain buses:
+
+```cpp
+if (data.numInputs > 1 &&
+    data.inputs[1].numChannels > 0 &&
+    data.inputs[1].channelBuffers32 &&
+    data.inputs[1].channelBuffers32[0]) {
+    // publish sidechain
+}
+```
+
+(See commit `c0f49a63 Workstream 01 slice 1.2: VST3 multi-bus +
+sidechain routing` and the `#178` review.) Secondary **output** buses
+are zero-filled every block — identical rationale to CLAP.
+
+### Transport context
+
+`ProcessContext` is populated from `data.processContext`:
+
+- `is_playing` from `state & kPlaying`.
+- `tempo_bpm` always read.
+- `position_samples` always read.
+- `time_sig_numerator/denominator` only when
+  `state & kTimeSigValid`.
+
+No `processContextRequirements` flag is currently requested — if a
+host needs opt-in declaration of which fields Pulp reads, we will add
+`IProcessContextRequirements`. Today every supported host delivers all
+required fields by default.
+
+### State save / restore
+
+`getState(stream)` serialises `store_.serialize()` bytes directly.
+`setState(stream)` chunks up the stream via a 4 KiB buffer, feeds
+`store_.deserialize`, and then `setParamNormalized`s every restored
+param back through the Steinberg parameter cache so the host UI
+re-reads the correct values. Format is identical to CLAP/AU — test
+with a round-trip across all three adapters for parity regressions.
+
+### Editor
+
+`createView("editor")` returns a `PulpPlugView` (in
+`vst3_plug_view.cpp`) when the build defines `PULP_VST3_GUI` and the
+Processor `has_editor()`. The editor flows through
+`pulp::format::ViewBridge` — see the `view-bridge` skill for the
+lifecycle protocol. Editing `vst3_plug_view.cpp` triggers `view-bridge`,
+not this skill.
+
+## Gotchas
+
+### `DEVELOPMENT` / `RELEASE` macro must precede the SDK include
+
+VST3 SDK fails to compile unless **exactly one** of `DEVELOPMENT` or
+`RELEASE` is defined. `vst3_adapter.hpp` defines them from `NDEBUG` at
+the top of the file. If you rearrange includes and pull an SDK header
+in before that block, you get a confusing sea of SDK complaints. Keep
+the define block first.
+
+### `#include <public.sdk/source/vst/vstsinglecomponenteffect.h>` first
+
+The VST3 SDK demands this header be the first SDK include — ordering
+requirements bleed through its internal `#pragma` state. Honour that
+even when IDE auto-formatting wants to reorder.
+
+### Host reports `numChannels > 0` but buffer is null
+
+A VST3 bus can be active per its channel count but have
+`channelBuffers32 == nullptr` or `channelBuffers32[0] == nullptr` when
+the host hasn't actually activated the bus. The main-input branch
+doesn't guard against this today — only the sidechain branch does
+(per #178 review). If you ever hit a null-deref on bus 0, the same
+guard needs to apply there. See CLAP's #277 for the parallel fix.
+
+### `setupProcessing` reuses the same `ProcessSetup` across re-activation
+
+Steinberg's SDK does not guarantee a fresh `ProcessSetup` on each
+`setActive(true)` — hosts commonly reuse the same setup. Don't rely on
+`setupProcessing` being called again just because the host toggled
+active — if you need to recompute anything per-activation, hook it
+into `setActive` instead.
+
+### `param_snapshot_` is **post-input-events, pre-process**
+
+Same contract as CLAP — host events are applied first, then snapshot,
+then process. If the adapter needs additional logic (e.g.
+gesture-coalesced output events), insert it after `process()` and
+before the snapshot diff, not before `set_normalized`.
+
+### `getTailSamples` returns `kInfiniteTail` for `tail_samples < 0`
+
+Pulp uses `tail_samples = -1` to mean "infinite" (reverb, delay with
+feedback). The adapter converts that to Steinberg's
+`Steinberg::Vst::kInfiniteTail` constant. Hosts interpret the literal
+`0xFFFFFFFF` value — do not clamp the tail to any other uint32.
+
+### `addParameter` must match the later `setParamNormalized` ID
+
+Parameters are indexed by the `ParamID` cast from Pulp's
+`ParamInfo::id`. If a plugin re-orders its parameter registration
+between versions, stored automation data breaks. Do not reorder —
+append only, and never reuse a retired ParamID. This is a VST3-wide
+backward-compat requirement, not a Pulp quirk.
+
+### Only mono + stereo are negotiable today
+
+`setBusArrangements` rejects anything other than
+`SpeakerArr::kMono` or `kStereo`. Surround / immersive layouts
+require expanding the `supported` lambda — do not add surround without
+verifying the descriptor, DSP, and `kSpeakerArr` constants align.
+
+### VST3 SDK is MIT, fetched via `git clone` in setup.sh
+
+`external/vst3sdk` is not checked in. `setup.sh` clones v3.7.12 by
+default. If you bump the SDK version, also update the note in
+`docs/guides/formats.md` and verify `public.sdk/source/...` ABI didn't
+shift.
+
+## Validation recipes
+
+Build and validate a VST3 bundle:
+
+```bash
+./build/tools/cli/pulp build
+./build/tools/cli/pulp validate         # runs pluginval --strictness-level 5
+```
+
+Direct `pluginval` invocation (matches what `cmd_validate.cpp` uses):
+
+```bash
+pluginval --strictness-level 5 --timeout-ms 30000 \
+  --validate "$(pwd)/build/path/to/MyPlugin.vst3"
+```
+
+`pluginval` install paths:
+
+```bash
+brew install pluginval               # macOS (Homebrew tap)
+# Linux / Windows: download a release binary from
+# https://github.com/Tracktion/pluginval/releases
+```
+
+`pluginval` returns a non-zero exit code on any strictness-5 failure.
+Treat it as gating — VST3 bundles failing strict pluginval must not
+ship. `pulp build --install` refuses to copy a failing VST3 into
+`~/Library/Audio/Plug-Ins/VST3/`.
+
+## Cross-references
+
+- `.agents/skills/view-bridge/SKILL.md` — the editor contract;
+  `vst3_plug_view.cpp` edits route through that skill.
+- `.agents/skills/ara/SKILL.md` — IHostApplication-based factory
+  negotiation (`kVst3AraFactoryContextKey`).
+- `.agents/skills/mpe/SKILL.md` — MPE sidecar (VST3 hosts deliver MPE
+  as channel-per-note short MIDI; the adapter routes it through the
+  same `MpeVoiceTracker` path CLAP uses).
+- `.agents/skills/clap/SKILL.md` and `.agents/skills/auv3/SKILL.md` —
+  cross-format parity for host-specific regressions.
+- `docs/guides/formats.md` — user-facing format overview.
+- `docs/guides/host-matrix.md` — per-host VST3 + ARA compatibility.
+- Memory note: "Tests ship with fixes" — every VST3 process-path
+  behaviour change needs a Catch2 fixture (the #290 coverage lane
+  explicitly names `format` as under active hardening).

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -20,6 +20,15 @@
         "external/ara-sdk/**"
       ]
     },
+    "auv3": {
+      "paths": [
+        "core/format/src/au_adapter.mm",
+        "core/format/src/au_entry.mm",
+        "core/format/src/au_audio_unit.h",
+        "core/format/src/au_view_controller_ios.mm",
+        "tools/cmake/PulpInfoPlist.au.in"
+      ]
+    },
     "android": {
       "paths": [
         "core/render/platform/android/**",
@@ -56,6 +65,11 @@
         "tools/install-shipyard.sh",
         "tools/scripts/install-githooks.sh",
         ".githooks/**"
+      ]
+    },
+    "clap": {
+      "paths": [
+        "core/format/src/clap_adapter.cpp"
       ]
     },
     "cli-maintenance": {
@@ -209,6 +223,14 @@
         "core/format/src/au_adapter.mm",
         "core/format/src/au_view_controller_ios.mm",
         "examples/view-bridge-demo/**"
+      ]
+    },
+    "vst3": {
+      "paths": [
+        "core/format/src/vst3_adapter.cpp",
+        "core/format/include/pulp/format/vst3_adapter.hpp",
+        "core/format/include/pulp/format/vst3_entry.hpp",
+        "tools/cmake/PulpInfoPlist.vst3.in"
       ]
     },
     "webview-ui": {


### PR DESCRIPTION
Pulp's .agents/skills/ previously had format-specific skills only for the
optional-SDK formats (aax, ara) and none for the three first-party format
adapters (CLAP, VST3, AU v3). This closes that asymmetry so every format
Pulp ships has a dedicated automation surface.

Each SKILL.md covers:
- When to reach for it (source paths, host-behaviour triggers, validator
  failures).
- The adapter's entry points, bridge struct, and parameter / MIDI / state
  / editor wiring — grounded in the actual code at this commit.
- Gotchas surfaced from real recent commits (CLAP sidechain null-guard
  #277, VST3 dynamic bus arrangements #240, AU v3 UMP sysex cursor-advance
  #292) and from review comments that shipped with those PRs.
- Validation recipes (clap-validator, pluginval, auval) matching what
  tools/cli/cmd_validate.cpp actually invokes.
- Cross-references into view-bridge, ara, mpe, ios, and the other format
  skills for parity sweeps.

skill_path_map.json gains three entries:
- auv3  → core/format/src/au_adapter.mm, au_entry.mm, au_audio_unit.h,
          au_view_controller_ios.mm, PulpInfoPlist.au.in
- clap  → core/format/src/clap_adapter.cpp
- vst3  → core/format/src/vst3_adapter.cpp + vst3 headers +
          PulpInfoPlist.vst3.in

Where a path is already mapped (view-bridge owns the adapter headers
and the AU/VST3 plug-view .cpp/.hpp; ios owns au_view_controller_ios.mm)
the new mapping is intentionally additive so future CLAP/VST3/AU v3
adapter edits trigger the per-format SKILL.md in addition to the
cross-cutting skill. The skill-sync CI gate allows this dual ownership.

Note: an auv2 skill is landing on a parallel branch; this change does
not touch auv2 or its paths. Merge conflicts in skill_path_map.json at
land-time are expected and will be rebase-resolved.

Docs-only — no adapter source changes. After this lands, future edits
to the listed adapter paths require matching SKILL.md updates via the
skill-sync gate (tools/scripts/skill_sync_check.py).