### PR TITLE
skills: post-merge audit + CLAUDE.md table refresh + path-map fixes

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -125,6 +125,16 @@ With `AUMIDIEffectBase`, fall-through calls should go to `AUMIDIEffectBase::GetP
 
 The `std::mutex` guarding `pending_midi_` is contended only on the MIDI-delivery thread (where the host calls `HandleMIDIEvent`) and the audio thread (once per block, to drain). It is NOT the right primitive for per-event audio-thread publication. Do not extend this pattern to any new path that runs multiple times per block — switch to `choc::fifo::SingleReaderSingleWriterFIFO` if you need lock-free MIDI delivery inside a single block.
 
+### `AUSDK_RTSAFE` position with `override` — Xcode 16.4 incompat
+
+`AUSDK_RTSAFE` expands to `[[clang::nonblocking]]`. AudioUnitSDK's own base-class declarations use `... AUSDK_RTSAFE;` (no `override`), but placing the attribute between a function declarator and the `override` virt-specifier in a derived class compiles under older Xcode and fails on Xcode 16.4 / Clang 17+ with:
+
+```
+error: expected ';' at end of declaration list
+```
+
+The attribute is a static-analysis hint only — dropping it from derived-class `override` declarations has no runtime effect. `PulpAUInstrument::HandleNoteOn/Off` (the reference pattern for AU v2) doesn't carry `AUSDK_RTSAFE` either. When writing a new AU v2 override that matches an `AUSDK_RTSAFE` base declaration, omit the attribute. Caught on CI's Coverage-macOS leg in PR #638 after the AU v2 effect MIDI fix landed without it.
+
 ## Reference pointers
 
 - Adapter source: `core/format/src/au_v2_adapter.cpp`, `core/format/include/pulp/format/au_v2_adapter.hpp`

--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -195,6 +195,26 @@ extension's loaded `AUAudioUnit` once KVO fires on
 `NSExtensionMain`-style Info.plist — see `docs/guides/ios-auv3-guidance.md`
 and the `ios` skill for the extension target wiring.
 
+### Two CMake entry points: keep signatures in lockstep
+
+`pulp_add_plugin(...)` (the general entry) and `pulp_add_ios_auv3(...)`
+(the iOS-extension wrapper) both end up calling the internal
+`_pulp_add_auv3(target name bundle_id version manufacturer category
+plugin_code manufacturer_code accepts_midi)` helper with positional
+arguments. When you add or remove an arg on `_pulp_add_auv3`, you
+must update BOTH wrappers — a missed update on the iOS wrapper
+surfaces as:
+
+```
+CMake Error at tools/cmake/PulpUtils.cmake:<line> (_pulp_add_auv3):
+  _pulp_add_auv3 Function invoked with incorrect arguments
+```
+
+only on the iOS toolchain configure, because the other leg
+(`pulp_add_plugin`) never exercises the wrapper. Caught on CI's
+Coverage-macOS leg in PR #638 when `ACCEPTS_MIDI` was added to
+`_pulp_add_auv3` but not threaded through `pulp_add_ios_auv3`.
+
 ## Gotchas
 
 ### `AURenderEventMIDIEventList` = UMP — not short MIDI, not raw sysex

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -68,8 +68,12 @@ struct. It owns:
   so the host can record automation.
 - `mpe_tracker` + `mpe_buffer` + `mpe_enabled` — MPE sidecar populated
   only if `PluginDescriptor::supports_mpe` is true.
-- `ump_buffer` + `ump_enabled` — UMP sidecar synthesised from MIDI 1.0
-  events (CLAP has no `CLAP_EVENT_MIDI2` today; see Gotchas below).
+- `ump_buffer` + `ump_enabled` — UMP sidecar. Filled from the host's
+  native `CLAP_EVENT_MIDI2` packets when they arrive, otherwise
+  synthesised from the MIDI 1.0 stream via `midi1_to_ump`. A
+  `host_delivered_ump` flag tracks whether any native UMP was pushed
+  during the block — the synthesis path is skipped in that case to
+  avoid double-encoding. See Gotchas.
 - `ara_controller` — lazily created on the first host query for the
   ARA companion-factory extension.
 - `bridge` + `editor_host` + `editor_visible` — gated on
@@ -117,26 +121,47 @@ Processor API exposes a single sidechain slot. Secondary **output**
 buses are zero-filled so multi-out instruments don't surface
 uninitialised memory to hosts.
 
-### MIDI: short messages, sysex, MPE, UMP
+### MIDI: short messages, sysex, note-expression, UMP
 
-Note events are converted from CLAP's channel/key/velocity form into
-`midi::MidiEvent`:
+Inbound event decode in `clap_process()` (as of PR #627):
 
 ```
 CLAP_EVENT_NOTE_ON / _NOTE_OFF → MidiEvent::note_on / note_off
+CLAP_EVENT_MIDI                → MidiEvent::from_bytes(data[0..2])
+                                 — CC, pitch bend, channel AT,
+                                   poly AT, program change
 CLAP_EVENT_MIDI_SYSEX          → midi_in.add_sysex(bytes, time, 0.0)
+CLAP_EVENT_NOTE_EXPRESSION     → synthesised MIDI 1.0 (see table)
+CLAP_EVENT_NOTE_CHOKE          → note_off(channel, key, velocity=0)
+CLAP_EVENT_MIDI2               → self->ump_buffer.add(packet)
+                                 (guarded by CLAP_VERSION_GE(1,1,0) —
+                                  the event is an enumerator, NOT a
+                                  preprocessor macro; see Gotchas)
 ```
 
-CLAP's per-note events (`CLAP_EVENT_NOTE_EXPRESSION`) are **not**
-currently decoded by the adapter directly; MPE is delivered by
-running the inbound `midi_in` through `MpeVoiceTracker` and publishing
-the resulting `MpeBuffer` via `processor->set_mpe_input(&buf)`. See the
-`mpe` skill for per-note expression details.
+**Note-expression → MIDI 1.0 mapping.** `MpeVoiceTracker` only ingests
+MIDI 1.0, so per-note expressions are synthesised to channel-wide
+equivalents and narrowed back per-voice by the tracker:
 
-The UMP sidecar is synthesised from the MIDI 1.0 stream via
-`midi1_to_ump` because CLAP has not shipped `CLAP_EVENT_MIDI2` yet.
-When it does, flip the adapter to consume the native stream; the
-existing `UmpBuffer` shape is already the public contract.
+| CLAP expression id | Synthesised MIDI 1.0 |
+|---|---|
+| `PRESSURE` | channel aftertouch `0xDn` |
+| `TUNING` | 14-bit pitch bend (normalised to ±48st member range) |
+| `BRIGHTNESS` | CC 74 |
+| `VOLUME` | CC 7 (0..4 → 0..127 log-domain scale) |
+| `PAN` | CC 10 |
+| `VIBRATO`, `EXPRESSION` | dropped — no unambiguous MIDI 1.0 equivalent; UMP-aware plug-ins should consume via the `CLAP_EVENT_MIDI2` path |
+
+Non-MPE descriptors drop note-expression events with a one-time
+debug log. See the `mpe` skill for tracker details.
+
+**Outbound MIDI** (the processor's `midi_out` — previously dropped):
+short messages emit as `CLAP_EVENT_MIDI`, sysex entries as
+`CLAP_EVENT_MIDI_SYSEX`, both via `out_events->try_push`.
+`sample_offset` carries through to `header.time`. The sysex
+`clap_event_midi_sysex_t.buffer` field is non-owning — the backing
+vector is alive for the duration of `clap_process()`, which is all
+CLAP's push contract requires (the host copies before returning).
 
 ### State save / restore
 
@@ -234,14 +259,35 @@ controller at extension-query time triggers the
 `create_ara_document_controller()` virtual before the Processor is
 alive.
 
-### UMP sidecar is **synthesised**, not delivered by the host
+### UMP sidecar: native when available, synthesised otherwise
 
-`midi1_to_ump` conversion runs inside `clap_process()` every block
-that the Processor declares `supports_ump`. There is no
-`CLAP_EVENT_MIDI2` event type in CLAP 1.2. When CLAP adds native UMP
-delivery, flip the synth path off for hosts that advertise support —
-do not keep both running or you'll double-deliver per-note messages.
-See `#141` / `#139` for the UMP buffer shape.
+As of PR #627 the adapter handles both CLAP 1.1+ hosts that deliver
+native `CLAP_EVENT_MIDI2` packets and older / MIDI-1.0-only hosts:
+
+1. At the top of every `clap_process()` block, `ump_buffer.clear()`
+   runs when `ump_enabled`. This is load-bearing — if you refactor
+   the event loop, keep the clear up-front or the "skip synthesis
+   when host delivered native UMP" invariant breaks.
+2. During event decode, `CLAP_EVENT_MIDI2` packets are appended
+   directly to `self->ump_buffer` and set `host_delivered_ump = true`.
+3. After the decode loop, `midi1_to_ump(midi_in, self->ump_buffer)`
+   runs **only** when `!host_delivered_ump`. CLAP spec forbids a host
+   from encoding the same note as both `CLAP_EVENT_NOTE_*` and
+   `CLAP_EVENT_MIDI2`, so the two code paths never double-encode.
+
+See `#141` / `#139` for the UMP buffer shape, and PR #627 for the
+native-path wiring.
+
+### CLAP event types are enumerators, not preprocessor macros
+
+When gating on a new CLAP event type, **do not** write
+`#ifdef CLAP_EVENT_MIDI2` — `CLAP_EVENT_MIDI2` is a C enumerator value,
+and `#ifdef` on an enum always evaluates false. Use
+`#if defined(CLAP_VERSION_GE) && CLAP_VERSION_GE(1, 1, 0)` (or the
+release that introduced the event) instead. Same trap applies to any
+future `CLAP_EVENT_*` additions — the CLAP header does not define
+them as macros. See PR #627's `clap_adapter.cpp` for the canonical
+guard shape.
 
 ### GUI is gated on `PULP_CLAP_GUI`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -670,17 +670,37 @@ When updating existing skills, preserve backward compatibility — don't remove 
 
 ### Current Skills
 
-| Skill | Location | Purpose |
-|-------|----------|---------|
-| `android` | `.agents/skills/android/` | Android NDK build, deploy, debug, and platform gotchas |
-| `aax` | `.agents/skills/aax/` | Optional AAX setup, validation, and workflow |
-| `ci` | `.agents/skills/ci/` | PR creation, local/cloud CI, merge workflow |
-| `cmajor-external` | `.agents/skills/cmajor-external/` | Cmajor external toolchain codegen |
-| `engine` | `.agents/skills/engine/` | Query, recommend, switch JS engine backend |
-| `import-design` | `.agents/skills/import-design/` | Import from Figma/Stitch/v0/Pencil |
-| `jsfx` | `.agents/skills/jsfx/` | Bounded JSFX subset support |
-| `cli-maintenance` | `.agents/skills/cli-maintenance/` | CLI add/modify/remove checklist and sync |
-| `webview-ui` | `.agents/skills/webview-ui/` | Build WebView UIs with native bridge |
+Alphabetical. One line of purpose per skill. Each directory at `.agents/skills/<name>/SKILL.md` carries the authoritative, full description. `tools/scripts/skill_path_map.json` owns the source-path → skill mapping used by `skill_sync_check.py` to enforce SKILL.md updates on mapped edits.
+
+| Skill | Purpose |
+|-------|---------|
+| `aax` | Optional AAX format: developer-supplied Avid SDK, CMake enablement, DigiShell/AAX Validator workflows |
+| `android` | Android NDK builds, Oboe audio, Dawn/Skia GPU, JNI bridge, emulator smoke, platform gotchas |
+| `ara` | Optional ARA support: developer-supplied SDK, companion APIs, adapter wiring, validation |
+| `auv2` | AU v2 adapter: aufx/aumf/aumi/aumu component types, MIDI input wiring, DAW cache gotchas |
+| `auv3` | AU v3 adapter: AUAudioUnit render block, parameter tree, UMP / sysex, sidechain, iOS extension |
+| `ci` | Local + cloud CI: validate branches, `shipyard pr` ship flow, merge on green, PR triage |
+| `clap` | CLAP adapter: param / mod / sidechain routing, MIDI 1.0 + UMP + sysex + note-expression, ARA hook |
+| `cli-maintenance` | CLI command add/modify/remove checklist — keeps source, slash commands, docs, skills in sync |
+| `cmajor-external` | MIT-safe Cmajor lane: source-owned patches, external `cmaj` toolchain, generated-artifact flow |
+| `engine` | JS engine backend selection (QuickJS / JavaScriptCore / V8) with recommendations per workload |
+| `faust` | FAUST DSP plugins: offline codegen, pre-generated C++ headers, FaustProcessor wrapper |
+| `hosting` | Load + run + test VST3 / AU / CLAP / LV2 plugins from Pulp (scanner, plugin_slot, signal_graph) |
+| `import-design` | Import designs from Figma / Stitch / v0 / Pencil into Pulp web-compat JS with visual validation |
+| `ios` | iOS platform: AUv3 app extensions, Simulator builds, UIKit host, CoreAudio, touch + Pencil input |
+| `jsfx-subset` | Bounded JSFX subset — source-only examples, explicit exclusions (no `@gfx`), subset validation |
+| `mpe` | Build MPE-aware synths: descriptor opt-in, `MpeBuffer` consumption, `MpeVoiceAllocator` routing |
+| `packages` | Third-party audio package search, suggest, add, browse |
+| `sdf-text` | SDF / MSDF / PSDF glyph atlases: building, sampling via SkSL, shared text-layout helpers |
+| `ship` | Sign / notarize / package / distribute Pulp plugins and apps across macOS / Windows / Android |
+| `streams` | `pulp::runtime::AsyncStream` selection, async-callback wiring without deadlock, backpressure |
+| `threejs-bridge` | Native Dawn-backed Three.js: three.webgpu.js renderer, bridge tests, native demo capture |
+| `upgrade` | `pulp upgrade` guidance: release discovery, migration notes, breaking-change fixes |
+| `view-bridge` | Editor lifecycle and multi-view attach — `Processor::create_view()`, open/notify/resize/close protocol |
+| `vst3` | VST3 adapter: SingleComponentEffect, bus arrangement, param/MIDI routing, state, Steinberg SDK traps |
+| `webview-ui` | WebView UI: native bridge, embedded assets, directory-backed dev resources, WebView validation |
+
+24 skills as of 2026-04-22. When adding a new skill, append its row here and register the subsystem in `tools/scripts/skill_path_map.json`.
 
 ### Claude Code Plugin
 

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./skill_path_map.schema.json",
   "schema_version": 1,
-  "_comment": "Skill name -> glob patterns. When a diff touches any pattern, the corresponding SKILL.md must be updated in the same diff or a Skill-Update: skip trailer must appear on the tip commit. Paired with tools/scripts/versioning.json. Every subdir under .agents/skills/ MUST have an entry here; skill_sync_check.py fails if one is missing.",
+  "_comment": "Skill name -> glob patterns. When a diff touches any pattern, the corresponding SKILL.md must be updated in the same diff or a Skill-Update: skip trailer must appear on the tip commit. Paired with tools/scripts/versioning.json. Every subdir under .agents/skills/ MUST have an entry here; skill_sync_check.py fails if one is missing. Dual/triple ownership is permitted — and expected — for files that span multiple domains: e.g. core/format/src/au_adapter.mm is owned by both `auv3` (the adapter) and `view-bridge` (editor attach lifecycle), because a change to that file reasonably requires guidance updates on both sides. Dual ownership is not a mistake to collapse; use it when a single file legitimately teaches two skills.",
   "skills": {
     "aax": {
       "paths": [
@@ -47,6 +47,7 @@
         "core/format/src/au_v2_adapter.cpp",
         "core/format/src/au_v2_instrument.cpp",
         "core/format/src/au_v2_entry.*",
+        "core/format/src/au_v2_cocoa_view.mm",
         "core/format/include/pulp/format/au_v2_adapter.hpp",
         "core/format/include/pulp/format/au_v2_instrument.hpp",
         "core/format/include/pulp/format/au_v2_entry.hpp",
@@ -117,7 +118,6 @@
       "paths": [
         "core/view/platform/ios/**",
         "core/format/src/au_view_controller_ios.mm",
-        "core/format/src/au_v2_cocoa_view.mm",
         "tools/cmake/ios.toolchain.cmake",
         "templates/ios-auv3/**",
         "examples/ios-auv3-*/**"


### PR DESCRIPTION
Three follow-ups bundled into one PR after the three-PR CLAP + AU v2 +
skills-docs sequence landed:

1. `clap/SKILL.md` refreshed against shipped code (PR #627). The
   skills-docs PR (#650) was authored off `main @ 47e6aeb3`, BEFORE
   the CLAP MIDI handlers landed, so its description of MIDI flow was
   pre-fix. Updated:
   - Inbound decode table now covers CLAP_EVENT_MIDI,
     CLAP_EVENT_NOTE_EXPRESSION (with the MIDI 1.0 mapping table),
     CLAP_EVENT_NOTE_CHOKE, CLAP_EVENT_MIDI2.
   - Outbound midi_out → CLAP_EVENT_MIDI / _MIDI_SYSEX round-trip
     documented (previously described as "dropped").
   - UMP sidecar section rewritten: native CLAP_EVENT_MIDI2 path
     takes precedence; synthesis via midi1_to_ump is the fallback,
     gated by host_delivered_ump to prevent double-encoding.
   - New gotcha: "CLAP event types are enumerators, not preprocessor
     macros" — pins the `#ifdef CLAP_EVENT_MIDI2` trap caught in PR
     #627 and shows the correct CLAP_VERSION_GE(...) guard shape.

2. Two new gotchas added from PR #638's ship cycle:
   - `auv2/SKILL.md`: AUSDK_RTSAFE position + override on Xcode 16.4.
     Expands to [[clang::nonblocking]]; placing it between the
     declarator and override compiles under older Xcode but fails on
     Clang 17+ with "expected ';' at end of declaration list". The
     attribute is advisory only — drop it on derived-class overrides
     to stay portable. Matches PulpAUInstrument's pattern.
   - `auv3/SKILL.md`: two CMake entry points (pulp_add_plugin and
     pulp_add_ios_auv3) both call _pulp_add_auv3 positionally. When
     the internal helper's signature changes, BOTH wrappers must
     update in lockstep — otherwise the iOS toolchain surfaces as
     "Function invoked with incorrect arguments" at configure time
     (only, because the non-iOS leg never hits that wrapper).

3. `tools/scripts/skill_path_map.json`:
   - Moved `core/format/src/au_v2_cocoa_view.mm` from `ios` (wrong —
     "Cocoa" here means macOS NSView, not iOS) to `auv2`. It's still
     dual-owned with `view-bridge` since the cocoa view implements
     the AU v2 editor attach/detach lifecycle.
   - Added a paragraph to the file's top-level _comment explaining
     that dual/triple ownership is intentional for files that span
     multiple skill domains (e.g. au_adapter.mm teaches both `auv3`
     and `view-bridge`). The skill_sync gate already handles it; the
     doc-of-record just made it explicit.

4. `CLAUDE.md` "Current Skills" table rebuilt from scratch. The
   existing table listed 9 skills; the repo had 24. New table is
   alphabetical, one-line purpose per entry, and drops the
   `Location` column (every entry is at `.agents/skills/<name>/`, so
   the column was pure noise). Added a pointer to
   `skill_path_map.json` as the authoritative source-to-skill map.

No source code touched — docs + mapping only. Pre-commit skill-sync
runs clean against origin/main.