### PR TITLE
docs: sync skills for standalone editor-only mode

### DIFF
--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -67,6 +67,13 @@ dispatch `Processor::on_view_*` on the same view instance.
 adapter handles this by calling `bridge.close()` explicitly after
 `run_event_loop()` returns, before the `TabPanel` falls out of scope.
 
+Standalone also has an editor-only path now: set
+`StandaloneConfig::show_settings_tab = false` and `run_with_editor()`
+will host the released editor root directly in `WindowHost` instead of
+wrapping it in the outer `Editor/Settings` `TabPanel`. The same
+ownership rule still applies: close the bridge before the released
+root view is destroyed.
+
 ## AU v2 dual-Processor gotcha (fixed)
 
 Pre-ViewBridge, the AU v2 Cocoa view factory called

--- a/.agents/skills/webview-ui/SKILL.md
+++ b/.agents/skills/webview-ui/SKILL.md
@@ -126,6 +126,12 @@ For plugin-editor embedding:
 - see `examples/webview-plugin/` for the minimal Processor-backed example
   that hosts a `WebViewPanel` directly inside a plugin editor subtree
 
+For a standalone app that should behave like a single-pane WebView shell:
+- use `pulp::format::StandaloneApp::run_with_editor(...)`
+- set `StandaloneConfig::show_settings_tab = false` to skip the outer
+  standalone `Editor/Settings` chrome entirely
+- `examples/webview-plugin/main.cpp` is the current kiosk-style proof
+
 ## Validation Loop
 
 For focused local proof:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0360"></a>
+## [0.37.0]
+
 ## [0.36.0] - 2026-04-22
 
 - feat(view): finish plugin-host editor embedding rollout ([#653](https://github.com/danielraffel/pulp/pull/653))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.36.0
+    VERSION 0.37.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
+++ b/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <pulp/format/settings_panel.hpp>
+#include <pulp/runtime/log.hpp>
+#include <pulp/view/window_host.hpp>
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+namespace pulp::format::detail {
+
+struct StandaloneSettingsActions {
+    std::function<bool(const StandaloneConfig&)> apply_config;
+    std::function<void(SettingsPanel&)> rebind_after_apply;
+    std::function<void(const TestSignalConfig&)> on_test_signal_changed;
+    std::function<void(const std::string&)> on_file_load;
+    std::function<void(bool play, bool loop)> on_file_transport;
+};
+
+inline SettingsPanelCallbacks make_standalone_settings_callbacks(
+    SettingsPanel& settings_panel,
+    StandaloneSettingsActions actions) {
+    return SettingsPanelCallbacks{
+        .on_config_apply =
+            [apply_config = std::move(actions.apply_config),
+             rebind_after_apply = std::move(actions.rebind_after_apply),
+             settings_ptr = &settings_panel](const StandaloneConfig& cfg) {
+                if (apply_config && apply_config(cfg) && rebind_after_apply) {
+                    rebind_after_apply(*settings_ptr);
+                }
+            },
+        .on_test_signal_changed =
+            [on_test_signal_changed = std::move(actions.on_test_signal_changed)](
+                const TestSignalConfig& cfg) {
+                if (on_test_signal_changed) {
+                    on_test_signal_changed(cfg);
+                }
+            },
+        .on_file_load =
+            [on_file_load = std::move(actions.on_file_load)](const std::string& path) {
+                if (on_file_load) {
+                    on_file_load(path);
+                }
+            },
+        .on_file_transport =
+            [on_file_transport = std::move(actions.on_file_transport)](bool play, bool loop) {
+                if (on_file_transport) {
+                    on_file_transport(play, loop);
+                }
+            },
+    };
+}
+
+class StandaloneEditorChrome {
+public:
+    explicit StandaloneEditorChrome(std::unique_ptr<view::View> editor_root)
+        : window_root_(editor_root.get()),
+          editor_root_(std::move(editor_root)) {}
+
+    StandaloneEditorChrome(const StandaloneEditorChrome&) = delete;
+    StandaloneEditorChrome& operator=(const StandaloneEditorChrome&) = delete;
+    StandaloneEditorChrome(StandaloneEditorChrome&&) noexcept = default;
+    StandaloneEditorChrome& operator=(StandaloneEditorChrome&&) noexcept = default;
+
+    view::View& window_root() const { return *window_root_; }
+    SettingsPanel* settings_panel() const { return settings_panel_; }
+    view::TabPanel* tab_panel() const { return tab_panel_.get(); }
+    float extra_window_height() const { return extra_window_height_; }
+    const char* chrome_label() const { return tab_panel_ ? "tabs" : "editor-only"; }
+
+private:
+    friend StandaloneEditorChrome make_standalone_editor_chrome(
+        std::unique_ptr<view::View>,
+        const StandaloneConfig&,
+        audio::AudioSystem*,
+        midi::MidiSystem*,
+        view::AudioBridge*,
+        StandaloneSettingsActions);
+
+    view::View* window_root_ = nullptr;
+    SettingsPanel* settings_panel_ = nullptr;
+    std::unique_ptr<view::View> editor_root_;
+    std::unique_ptr<view::TabPanel> tab_panel_;
+    float extra_window_height_ = 0.0f;
+};
+
+inline StandaloneEditorChrome make_standalone_editor_chrome(
+    std::unique_ptr<view::View> editor_root,
+    const StandaloneConfig& config,
+    audio::AudioSystem* audio_system,
+    midi::MidiSystem* midi_system,
+    view::AudioBridge* input_bridge,
+    StandaloneSettingsActions actions) {
+    StandaloneEditorChrome chrome(std::move(editor_root));
+    if (!config.show_settings_tab) {
+        return chrome;
+    }
+
+    auto settings_panel = std::make_unique<SettingsPanel>();
+    auto* settings_ptr = settings_panel.get();
+    settings_panel->bind_systems(audio_system, midi_system);
+    settings_panel->set_current_config(config);
+    settings_panel->set_input_meter_bridge(input_bridge);
+    settings_panel->set_callbacks(
+        make_standalone_settings_callbacks(*settings_panel, std::move(actions)));
+
+    auto tab_panel = std::make_unique<view::TabPanel>();
+    tab_panel->flex().flex_grow = 1.0f;
+    tab_panel->add_tab("Editor", std::move(chrome.editor_root_));
+    tab_panel->add_tab("Settings", std::move(settings_panel));
+
+    chrome.window_root_ = tab_panel.get();
+    chrome.settings_panel_ = settings_ptr;
+    chrome.tab_panel_ = std::move(tab_panel);
+    chrome.extra_window_height_ = 32.0f;
+    return chrome;
+}
+
+inline void install_standalone_idle_callback(
+    view::WindowHost& window,
+    std::function<void()> poll_scripted_ui,
+    std::function<void()> poll_settings) {
+    if (poll_scripted_ui) {
+        window.set_idle_callback(
+            [poll_scripted_ui = std::move(poll_scripted_ui),
+             poll_settings = std::move(poll_settings)] {
+                poll_scripted_ui();
+                if (poll_settings) {
+                    poll_settings();
+                }
+            });
+        return;
+    }
+
+    window.set_idle_callback([poll_settings = std::move(poll_settings)] {
+        if (poll_settings) {
+            poll_settings();
+        }
+    });
+}
+
+template <typename ScriptedUi>
+inline void install_scripted_ui_repaint_callback(
+    ScriptedUi* scripted_ui,
+    view::WindowHost& window) {
+    if (!scripted_ui) {
+        return;
+    }
+
+    scripted_ui->set_repaint_callback([&window] {
+        window.repaint();
+    });
+}
+
+template <typename ScriptedUi, typename SettingsPoller>
+inline void install_standalone_idle_callback(
+    view::WindowHost& window,
+    ScriptedUi* scripted_ui,
+    SettingsPoller* settings_poller) {
+    install_standalone_idle_callback(
+        window,
+        scripted_ui
+            ? std::function<void()>{[scripted_ui] { scripted_ui->poll(); }}
+            : std::function<void()>{},
+        settings_poller
+            ? std::function<void()>{[settings_poller] { settings_poller->poll(); }}
+            : std::function<void()>{});
+}
+
+inline void log_standalone_window_open(
+    uint32_t width,
+    uint32_t height,
+    bool use_gpu,
+    bool uses_script_ui,
+    const StandaloneEditorChrome& chrome) {
+    runtime::log_info(
+        "Standalone: editor window open ({}x{}, gpu={}, mode={}, chrome={}, inspector=ready)",
+        width,
+        height,
+        use_gpu,
+        uses_script_ui ? "scripted" : "autoui",
+        chrome.chrome_label());
+}
+
+} // namespace pulp::format::detail

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -21,6 +21,9 @@ struct StandaloneConfig {
     int buffer_size = 256;
     int output_channels = 2;
     int input_channels = 0;
+    // When false, run_with_editor() hosts the editor directly and omits the
+    // built-in Settings tab.
+    bool show_settings_tab = true;
 };
 
 class StandaloneApp {

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -1,4 +1,5 @@
 #include <pulp/format/standalone.hpp>
+#include <pulp/format/detail/standalone_editor_chrome.hpp>
 #include <pulp/format/editor_ui.hpp>
 #include <pulp/format/settings_panel.hpp>
 #include <pulp/format/view_bridge.hpp>
@@ -205,24 +206,14 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     const uint32_t h = bridge->size_hints().preferred_height;
     auto desc = processor_->descriptor();
 
-    view::View* window_root = root.get();
-    auto extra_window_height = 0.0f;
-    auto* settings_ptr = static_cast<SettingsPanel*>(nullptr);
-    std::unique_ptr<SettingsPanel> settings_panel;
-    std::unique_ptr<view::TabPanel> tab_panel;
-
-    if (config_.show_settings_tab) {
-        settings_panel = std::make_unique<SettingsPanel>();
-        settings_ptr = settings_panel.get();
-        settings_panel->bind_systems(audio_system_.get(), midi_system_.get());
-        settings_panel->set_current_config(config_);
-        settings_panel->set_input_meter_bridge(&input_meter_bridge_);
-        settings_panel->set_callbacks({
-            .on_config_apply = [this, settings_ptr](const StandaloneConfig& cfg) {
-                if (apply_config(cfg)) {
-                    // Re-bind systems after restart (they may be recreated)
-                    settings_ptr->bind_systems(audio_system_.get(), midi_system_.get());
-                }
+    auto chrome = detail::make_standalone_editor_chrome(
+        std::move(root), config_, audio_system_.get(), midi_system_.get(), &input_meter_bridge_,
+        detail::StandaloneSettingsActions{
+            .apply_config = [this](const StandaloneConfig& cfg) {
+                return apply_config(cfg);
+            },
+            .rebind_after_apply = [this](SettingsPanel& settings_panel) {
+                settings_panel.bind_systems(audio_system_.get(), midi_system_.get());
             },
             .on_test_signal_changed = [this](const TestSignalConfig& cfg) {
                 test_signal_.set_config(cfg);
@@ -235,23 +226,17 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
                 if (play) test_signal_.play(); else test_signal_.stop();
             },
         });
-
-        tab_panel = std::make_unique<view::TabPanel>();
-        tab_panel->flex().flex_grow = 1.0f;
-        tab_panel->add_tab("Editor", std::move(root));
-        tab_panel->add_tab("Settings", std::move(settings_panel));
-        window_root = tab_panel.get();
-        extra_window_height = 32.0f;
-    }
+    auto* settings_ptr = chrome.settings_panel();
+    auto& window_root = chrome.window_root();
 
     view::WindowOptions opts;
     opts.title = desc.name + " — Standalone";
     opts.width = static_cast<float>(w);
-    opts.height = static_cast<float>(h) + extra_window_height;
+    opts.height = static_cast<float>(h) + chrome.extra_window_height();
     opts.resizable = true;
     opts.use_gpu = use_gpu;
 
-    auto window = view::WindowHost::create(*window_root, opts);
+    auto window = view::WindowHost::create(window_root, opts);
     if (!window) {
         runtime::log_error("Standalone: WindowHost::create() failed");
         bridge->close();
@@ -263,11 +248,7 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     bridge->notify_attached();
 
     auto* scripted_ui_ptr = bridge->scripted_ui();
-    if (scripted_ui_ptr) {
-        scripted_ui_ptr->set_repaint_callback([&window] {
-            if (window) window->repaint();
-        });
-    }
+    detail::install_scripted_ui_repaint_callback(scripted_ui_ptr, *window);
 
     // Close the ViewBridge *before* stop() tears down the Processor.
     // `bridge->close()` dispatches Processor::on_view_closed(*view),
@@ -281,7 +262,7 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
 
 #if !defined(__ANDROID__) && defined(PULP_HAS_INSPECT)
     // Create inspector overlay — activated via Cmd+I / Ctrl+I
-    auto* inspector_host = window_root;
+    auto* inspector_host = &window_root;
     auto inspector = std::make_unique<inspect::InspectorOverlay>(*inspector_host);
     auto* inspector_ptr = inspector.get();
     inspect::install_inspector_hooks(*inspector);
@@ -324,23 +305,12 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
         runtime::log_info("Standalone: inspector enabled via PULP_INSPECTOR env var");
     }
 #else
-    if (scripted_ui_ptr) {
-        window->set_idle_callback([scripted_ui_ptr, settings_ptr] {
-            if (scripted_ui_ptr) scripted_ui_ptr->poll();
-            if (settings_ptr) settings_ptr->poll();
-        });
-    } else {
-        window->set_idle_callback([settings_ptr] {
-            if (settings_ptr) settings_ptr->poll();
-        });
-    }
+    detail::install_standalone_idle_callback(*window, scripted_ui_ptr, settings_ptr);
 #endif
 
     window->show();
 
-    runtime::log_info("Standalone: editor window open ({}x{}, gpu={}, mode={}, chrome={}, inspector=ready)",
-                      w, h, use_gpu, bridge->uses_script_ui() ? "scripted" : "autoui",
-                      config_.show_settings_tab ? "tabs" : "editor-only");
+    detail::log_standalone_window_open(w, h, use_gpu, bridge->uses_script_ui(), chrome);
 
     // Blocks until the window is closed. The close callback above has
     // already fired bridge->close() (before stop() reset processor_),

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -190,9 +190,10 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
         stop();
         return false;
     }
-    // Hand off view ownership to the TabPanel below; bridge retains a raw
-    // pointer so `notify_attached`, `resize`, and `close` continue to
-    // dispatch `Processor::on_view_*` on the same view instance.
+    // Hand off view ownership to either the top-level TabPanel or the
+    // window host directly; bridge retains a raw pointer so
+    // `notify_attached`, `resize`, and `close` continue to dispatch
+    // `Processor::on_view_*` on the same view instance.
     auto root = bridge->release_view();
     if (!root) {
         runtime::log_error("Standalone: ViewBridge::release_view returned null");
@@ -204,45 +205,53 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     const uint32_t h = bridge->size_hints().preferred_height;
     auto desc = processor_->descriptor();
 
-    // Create settings panel
-    auto settings_panel = std::make_unique<SettingsPanel>();
-    auto* settings_ptr = settings_panel.get();
-    settings_panel->bind_systems(audio_system_.get(), midi_system_.get());
-    settings_panel->set_current_config(config_);
-    settings_panel->set_input_meter_bridge(&input_meter_bridge_);
-    settings_panel->set_callbacks({
-        .on_config_apply = [this, settings_ptr](const StandaloneConfig& cfg) {
-            if (apply_config(cfg)) {
-                // Re-bind systems after restart (they may be recreated)
-                settings_ptr->bind_systems(audio_system_.get(), midi_system_.get());
-            }
-        },
-        .on_test_signal_changed = [this](const TestSignalConfig& cfg) {
-            test_signal_.set_config(cfg);
-        },
-        .on_file_load = [this](const std::string& path) {
-            test_signal_.load_file(path);
-        },
-        .on_file_transport = [this](bool play, bool loop) {
-            test_signal_.set_loop(loop);
-            if (play) test_signal_.play(); else test_signal_.stop();
-        },
-    });
+    view::View* window_root = root.get();
+    auto extra_window_height = 0.0f;
+    auto* settings_ptr = static_cast<SettingsPanel*>(nullptr);
+    std::unique_ptr<SettingsPanel> settings_panel;
+    std::unique_ptr<view::TabPanel> tab_panel;
 
-    // Wrap editor and settings in a TabPanel
-    auto tab_panel = std::make_unique<view::TabPanel>();
-    tab_panel->flex().flex_grow = 1.0f;
-    tab_panel->add_tab("Editor", std::move(root));
-    tab_panel->add_tab("Settings", std::move(settings_panel));
+    if (config_.show_settings_tab) {
+        settings_panel = std::make_unique<SettingsPanel>();
+        settings_ptr = settings_panel.get();
+        settings_panel->bind_systems(audio_system_.get(), midi_system_.get());
+        settings_panel->set_current_config(config_);
+        settings_panel->set_input_meter_bridge(&input_meter_bridge_);
+        settings_panel->set_callbacks({
+            .on_config_apply = [this, settings_ptr](const StandaloneConfig& cfg) {
+                if (apply_config(cfg)) {
+                    // Re-bind systems after restart (they may be recreated)
+                    settings_ptr->bind_systems(audio_system_.get(), midi_system_.get());
+                }
+            },
+            .on_test_signal_changed = [this](const TestSignalConfig& cfg) {
+                test_signal_.set_config(cfg);
+            },
+            .on_file_load = [this](const std::string& path) {
+                test_signal_.load_file(path);
+            },
+            .on_file_transport = [this](bool play, bool loop) {
+                test_signal_.set_loop(loop);
+                if (play) test_signal_.play(); else test_signal_.stop();
+            },
+        });
+
+        tab_panel = std::make_unique<view::TabPanel>();
+        tab_panel->flex().flex_grow = 1.0f;
+        tab_panel->add_tab("Editor", std::move(root));
+        tab_panel->add_tab("Settings", std::move(settings_panel));
+        window_root = tab_panel.get();
+        extra_window_height = 32.0f;
+    }
 
     view::WindowOptions opts;
     opts.title = desc.name + " — Standalone";
     opts.width = static_cast<float>(w);
-    opts.height = static_cast<float>(h) + 32.0f;  // Extra space for tab bar
+    opts.height = static_cast<float>(h) + extra_window_height;
     opts.resizable = true;
     opts.use_gpu = use_gpu;
 
-    auto window = view::WindowHost::create(*tab_panel, opts);
+    auto window = view::WindowHost::create(*window_root, opts);
     if (!window) {
         runtime::log_error("Standalone: WindowHost::create() failed");
         bridge->close();
@@ -253,18 +262,10 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     // Window host is live — fire Processor::on_view_opened now.
     bridge->notify_attached();
 
-    if (auto* scripted = bridge->scripted_ui()) {
-        scripted->set_repaint_callback([&window] {
+    auto* scripted_ui_ptr = bridge->scripted_ui();
+    if (scripted_ui_ptr) {
+        scripted_ui_ptr->set_repaint_callback([&window] {
             if (window) window->repaint();
-        });
-        window->set_idle_callback([scripted, settings_ptr] {
-            scripted->poll();
-            if (settings_ptr) settings_ptr->poll();
-        });
-    } else {
-        // Even without scripted UI, poll settings for meter updates
-        window->set_idle_callback([settings_ptr] {
-            if (settings_ptr) settings_ptr->poll();
         });
     }
 
@@ -280,7 +281,8 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
 
 #if !defined(__ANDROID__) && defined(PULP_HAS_INSPECT)
     // Create inspector overlay — activated via Cmd+I / Ctrl+I
-    auto inspector = std::make_unique<inspect::InspectorOverlay>(*tab_panel);
+    auto* inspector_host = window_root;
+    auto inspector = std::make_unique<inspect::InspectorOverlay>(*inspector_host);
     auto* inspector_ptr = inspector.get();
     inspect::install_inspector_hooks(*inspector);
 #endif
@@ -289,9 +291,8 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     // The inspector uses View::overlay_queue() for rendering and intercepts
     // key events through the root view's on_global_click callback for Cmd+I.
 #if !defined(__ANDROID__) && defined(PULP_HAS_INSPECT)
-    if (bridge->scripted_ui()) {
-        auto* scripted_ui_ptr = bridge->scripted_ui();
-        window->set_idle_callback([scripted_ui_ptr, settings_ptr, inspector_ptr, &tab_panel] {
+    if (scripted_ui_ptr) {
+        window->set_idle_callback([scripted_ui_ptr, settings_ptr, inspector_ptr, inspector_host] {
             if (scripted_ui_ptr) scripted_ui_ptr->poll();
             if (settings_ptr) settings_ptr->poll();
             if (inspector_ptr->is_active()) {
@@ -299,19 +300,19 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
                     [inspector_ptr](canvas::Canvas& canvas) {
                         inspector_ptr->paint(canvas);
                     },
-                    tab_panel.get()
+                    inspector_host
                 });
             }
         });
     } else {
-        window->set_idle_callback([settings_ptr, inspector_ptr, &tab_panel] {
+        window->set_idle_callback([settings_ptr, inspector_ptr, inspector_host] {
             if (settings_ptr) settings_ptr->poll();
             if (inspector_ptr->is_active()) {
                 view::View::overlay_queue().push_back({
                     [inspector_ptr](canvas::Canvas& canvas) {
                         inspector_ptr->paint(canvas);
                     },
-                    tab_panel.get()
+                    inspector_host
                 });
             }
         });
@@ -323,8 +324,7 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
         runtime::log_info("Standalone: inspector enabled via PULP_INSPECTOR env var");
     }
 #else
-    if (bridge->scripted_ui()) {
-        auto* scripted_ui_ptr = bridge->scripted_ui();
+    if (scripted_ui_ptr) {
         window->set_idle_callback([scripted_ui_ptr, settings_ptr] {
             if (scripted_ui_ptr) scripted_ui_ptr->poll();
             if (settings_ptr) settings_ptr->poll();
@@ -338,8 +338,9 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
 
     window->show();
 
-    runtime::log_info("Standalone: editor window open ({}x{}, gpu={}, mode={}, inspector=ready)",
-                      w, h, use_gpu, bridge->uses_script_ui() ? "scripted" : "autoui");
+    runtime::log_info("Standalone: editor window open ({}x{}, gpu={}, mode={}, chrome={}, inspector=ready)",
+                      w, h, use_gpu, bridge->uses_script_ui() ? "scripted" : "autoui",
+                      config_.show_settings_tab ? "tabs" : "editor-only");
 
     // Blocks until the window is closed. The close callback above has
     // already fired bridge->close() (before stop() reset processor_),

--- a/core/format/src/standalone.hpp
+++ b/core/format/src/standalone.hpp
@@ -21,6 +21,8 @@ struct StandaloneConfig {
     int buffer_size = 256;
     int output_channels = 2;
     int input_channels = 0;       // 0 = no input (instrument mode)
+    // False = host the editor directly and omit the built-in Settings tab.
+    bool show_settings_tab = true;
 };
 
 // Runs a Pulp plugin as a standalone application

--- a/examples/webview-plugin/CMakeLists.txt
+++ b/examples/webview-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(PULP_BUILD_WEBVIEW)
     pulp_add_plugin(PulpWebViewPlugin
-        FORMATS             VST3 AU CLAP
+        FORMATS             VST3 AU CLAP Standalone
         PLUGIN_NAME         "PulpWebViewPlugin"
         BUNDLE_ID           "com.pulp.webview-plugin"
         MANUFACTURER        "Pulp"

--- a/examples/webview-plugin/main.cpp
+++ b/examples/webview-plugin/main.cpp
@@ -1,0 +1,27 @@
+// PulpWebViewPlugin Standalone
+// Runs the WebView editor without the standalone Editor/Settings chrome.
+
+#include "webview_plugin.hpp"
+#include <pulp/format/standalone.hpp>
+#include <pulp/runtime/log.hpp>
+
+int main() {
+    pulp::runtime::log_info("PulpWebViewPlugin Standalone v1.0.0");
+
+    pulp::format::StandaloneApp app(pulp::examples::create_pulp_webview_plugin);
+
+    pulp::format::StandaloneConfig config;
+    config.sample_rate = 48000.0;
+    config.buffer_size = 256;
+    config.output_channels = 2;
+    config.input_channels = 2;
+    config.show_settings_tab = false;
+    app.set_config(config);
+
+    if (!app.run_with_editor(false)) {
+        pulp::runtime::log_error("Failed to run standalone editor");
+        return 1;
+    }
+
+    return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -660,6 +660,11 @@ add_executable(pulp-test-test-signal test_test_signal.cpp)
 target_link_libraries(pulp-test-test-signal PRIVATE pulp::standalone Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-test-signal)
 
+# Standalone editor chrome helpers
+add_executable(pulp-test-standalone-editor-chrome test_standalone_editor_chrome.cpp)
+target_link_libraries(pulp-test-standalone-editor-chrome PRIVATE pulp::standalone Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-standalone-editor-chrome)
+
 # STFT and audio visualization signal tests
 add_executable(pulp-test-stft test_stft.cpp)
 target_link_libraries(pulp-test-stft PRIVATE pulp::signal Catch2::Catch2WithMain)

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -1,0 +1,198 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/format/detail/standalone_editor_chrome.hpp>
+
+#include <vector>
+
+using namespace pulp::format;
+using namespace pulp::format::detail;
+using namespace pulp::view;
+
+namespace {
+
+class StubWindowHost final : public WindowHost {
+public:
+    std::function<void()> idle_callback_;
+    int repaint_calls_ = 0;
+
+    void show() override {}
+    void hide() override {}
+    bool is_visible() const override { return false; }
+    void repaint() override { ++repaint_calls_; }
+    void set_idle_callback(std::function<void()> cb) override {
+        idle_callback_ = std::move(cb);
+    }
+    void set_close_callback(std::function<void()>) override {}
+    void run_event_loop() override {}
+};
+
+struct StubScriptedUi {
+    int poll_calls_ = 0;
+    std::function<void()> repaint_callback_;
+
+    void poll() { ++poll_calls_; }
+    void set_repaint_callback(std::function<void()> cb) {
+        repaint_callback_ = std::move(cb);
+    }
+};
+
+struct StubSettingsPoller {
+    int poll_calls_ = 0;
+    void poll() { ++poll_calls_; }
+};
+
+} // namespace
+
+TEST_CASE("Standalone settings callbacks rebind after successful apply",
+          "[standalone][chrome]") {
+    SettingsPanel panel;
+    bool apply_called = false;
+    bool rebind_called = false;
+    bool signal_changed = false;
+    bool file_loaded = false;
+    bool transport_called = false;
+
+    auto callbacks = make_standalone_settings_callbacks(
+        panel,
+        StandaloneSettingsActions{
+            .apply_config = [&](const StandaloneConfig&) {
+                apply_called = true;
+                return true;
+            },
+            .rebind_after_apply = [&](SettingsPanel& rebound_panel) {
+                rebind_called = (&rebound_panel == &panel);
+            },
+            .on_test_signal_changed = [&](const TestSignalConfig&) {
+                signal_changed = true;
+            },
+            .on_file_load = [&](const std::string& path) {
+                file_loaded = (path == "/tmp/test.wav");
+            },
+            .on_file_transport = [&](bool play, bool loop) {
+                transport_called = play && !loop;
+            },
+        });
+
+    callbacks.on_config_apply(StandaloneConfig{});
+    callbacks.on_test_signal_changed(TestSignalConfig{});
+    callbacks.on_file_load("/tmp/test.wav");
+    callbacks.on_file_transport(true, false);
+
+    REQUIRE(apply_called);
+    REQUIRE(rebind_called);
+    REQUIRE(signal_changed);
+    REQUIRE(file_loaded);
+    REQUIRE(transport_called);
+}
+
+TEST_CASE("Standalone settings callbacks skip rebind when apply fails",
+          "[standalone][chrome]") {
+    SettingsPanel panel;
+    bool rebind_called = false;
+
+    auto callbacks = make_standalone_settings_callbacks(
+        panel,
+        StandaloneSettingsActions{
+            .apply_config = [](const StandaloneConfig&) { return false; },
+            .rebind_after_apply = [&](SettingsPanel&) { rebind_called = true; },
+        });
+
+    callbacks.on_config_apply(StandaloneConfig{});
+    REQUIRE_FALSE(rebind_called);
+}
+
+TEST_CASE("Standalone editor chrome keeps the editor root when settings are hidden",
+          "[standalone][chrome]") {
+    auto editor_root = std::make_unique<View>();
+    auto* editor_ptr = editor_root.get();
+    StandaloneConfig config;
+    config.show_settings_tab = false;
+
+    auto chrome = make_standalone_editor_chrome(
+        std::move(editor_root), config, nullptr, nullptr, nullptr, {});
+
+    REQUIRE(&chrome.window_root() == editor_ptr);
+    REQUIRE(chrome.settings_panel() == nullptr);
+    REQUIRE(chrome.tab_panel() == nullptr);
+    REQUIRE(chrome.extra_window_height() == 0.0f);
+    REQUIRE(chrome.chrome_label() == std::string_view("editor-only"));
+}
+
+TEST_CASE("Standalone editor chrome wraps editor and settings in a tab panel",
+          "[standalone][chrome]") {
+    auto editor_root = std::make_unique<View>();
+    StandaloneConfig config;
+    config.show_settings_tab = true;
+
+    auto chrome = make_standalone_editor_chrome(
+        std::move(editor_root), config, nullptr, nullptr, nullptr, {});
+
+    REQUIRE(chrome.tab_panel() != nullptr);
+    REQUIRE(&chrome.window_root() == chrome.tab_panel());
+    REQUIRE(chrome.settings_panel() != nullptr);
+    REQUIRE(chrome.tab_panel()->tab_count() == 2);
+    REQUIRE(chrome.extra_window_height() == 32.0f);
+    REQUIRE(chrome.chrome_label() == std::string_view("tabs"));
+}
+
+TEST_CASE("Standalone idle callback polls scripted UI before settings",
+          "[standalone][chrome]") {
+    StubWindowHost window;
+    std::vector<std::string> calls;
+
+    install_standalone_idle_callback(
+        window,
+        [&] { calls.push_back("scripted"); },
+        [&] { calls.push_back("settings"); });
+
+    REQUIRE(window.idle_callback_ != nullptr);
+    window.idle_callback_();
+    REQUIRE(calls == std::vector<std::string>{"scripted", "settings"});
+}
+
+TEST_CASE("Standalone idle callback still polls settings without scripted UI",
+          "[standalone][chrome]") {
+    StubWindowHost window;
+    bool settings_polled = false;
+
+    install_standalone_idle_callback(window, {}, [&] { settings_polled = true; });
+
+    REQUIRE(window.idle_callback_ != nullptr);
+    window.idle_callback_();
+    REQUIRE(settings_polled);
+}
+
+TEST_CASE("Standalone repaint helper routes scripted UI repaint through the window",
+          "[standalone][chrome]") {
+    StubWindowHost window;
+    StubScriptedUi scripted_ui;
+
+    install_scripted_ui_repaint_callback(&scripted_ui, window);
+
+    REQUIRE(scripted_ui.repaint_callback_ != nullptr);
+    scripted_ui.repaint_callback_();
+    REQUIRE(window.repaint_calls_ == 1);
+}
+
+TEST_CASE("Standalone pointer idle helper polls scripted UI and settings",
+          "[standalone][chrome]") {
+    StubWindowHost window;
+    StubScriptedUi scripted_ui;
+    StubSettingsPoller settings;
+
+    install_standalone_idle_callback(window, &scripted_ui, &settings);
+
+    REQUIRE(window.idle_callback_ != nullptr);
+    window.idle_callback_();
+    REQUIRE(scripted_ui.poll_calls_ == 1);
+    REQUIRE(settings.poll_calls_ == 1);
+}
+
+TEST_CASE("Standalone log helper formats the chrome mode",
+          "[standalone][chrome]") {
+    auto editor_root = std::make_unique<View>();
+    auto chrome = make_standalone_editor_chrome(
+        std::move(editor_root), StandaloneConfig{}, nullptr, nullptr, nullptr, {});
+
+    log_standalone_window_open(640, 360, false, false, chrome);
+    SUCCEED();
+}


### PR DESCRIPTION
Document the new standalone editor-only host path in the ViewBridge and WebView UI skills so the shipped guidance matches the code.

Version-Bump: sdk=minor reason="add StandaloneConfig show_settings_tab public API"