### PR TITLE
test: split state and ship hardening from #647

### DIFF
--- a/test/test_appcast.cpp
+++ b/test/test_appcast.cpp
@@ -57,6 +57,86 @@ TEST_CASE("Appcast XML round-trip", "[ship][appcast]") {
     REQUIRE(parsed->items[0].file_size == 9999);
 }
 
+TEST_CASE("Appcast XML escapes metadata and omits empty optional item fields", "[ship][appcast]") {
+    Appcast feed;
+    feed.title = R"(Pulp & "Friends" <Beta>)";
+    feed.link = R"(https://example.com/appcast.xml?channel="stable"&x=1)";
+    feed.description = R"(Ships <fast> & "safe")";
+
+    AppcastItem item;
+    item.version = "3.4.5";
+    item.title = R"(Release & "Notes" <Here>)";
+    item.pub_date = "Wed, 02 Apr 2026 12:00:00 +0000";
+    item.download_url = R"(https://example.com/PulpGain.pkg?sig="abc"&v=1)";
+    feed.items.push_back(item);
+
+    auto xml = feed.to_xml();
+
+    REQUIRE(xml.find("<title>Pulp &amp; &quot;Friends&quot; &lt;Beta&gt;</title>") != std::string::npos);
+    REQUIRE(xml.find("<link>https://example.com/appcast.xml?channel=&quot;stable&quot;&amp;x=1</link>") != std::string::npos);
+    REQUIRE(xml.find("<description>Ships &lt;fast&gt; &amp; &quot;safe&quot;</description>") != std::string::npos);
+    REQUIRE(xml.find("<title>Release &amp; &quot;Notes&quot; &lt;Here&gt;</title>") != std::string::npos);
+    REQUIRE(xml.find("<sparkle:version>3.4.5</sparkle:version>") != std::string::npos);
+    REQUIRE(xml.find("url=\"https://example.com/PulpGain.pkg?sig=&quot;abc&quot;&amp;v=1\"") != std::string::npos);
+    REQUIRE(xml.find("<![CDATA[") == std::string::npos);
+    REQUIRE(xml.find("sparkle:minimumSystemVersion") == std::string::npos);
+    REQUIRE(xml.find("sparkle:edSignature=") == std::string::npos);
+}
+
+TEST_CASE("Appcast from_xml parses optional fields across multiple items", "[ship][appcast]") {
+    auto parsed = Appcast::from_xml(R"(<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Ship Feed</title>
+    <link>https://example.com/feed.xml</link>
+    <description>Stable releases</description>
+    <item>
+      <title>Version 3.1.0</title>
+      <description><![CDATA[<p>Signed update</p>]]></description>
+      <pubDate>Thu, 03 Apr 2026 12:00:00 +0000</pubDate>
+      <sparkle:version>3100</sparkle:version>
+      <sparkle:shortVersionString>3.1.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://example.com/Pulp-3.1.0.pkg"
+                 length="321"
+                 type="application/octet-stream"
+                 sparkle:edSignature="abc123" />
+    </item>
+    <item>
+      <title>Version 3.0.9</title>
+      <pubDate>Wed, 02 Apr 2026 12:00:00 +0000</pubDate>
+      <sparkle:shortVersionString>3.0.9</sparkle:shortVersionString>
+      <enclosure url="https://example.com/Pulp-3.0.9.pkg"
+                 type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>)");
+
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->title == "Ship Feed");
+    REQUIRE(parsed->link == "https://example.com/feed.xml");
+    REQUIRE(parsed->description == "Stable releases");
+    REQUIRE(parsed->items.size() == 2);
+
+    REQUIRE(parsed->items[0].title == "Version 3.1.0");
+    REQUIRE(parsed->items[0].description == "<p>Signed update</p>");
+    REQUIRE(parsed->items[0].build_number == "3100");
+    REQUIRE(parsed->items[0].version == "3.1.0");
+    REQUIRE(parsed->items[0].minimum_os == "13.0");
+    REQUIRE(parsed->items[0].download_url == "https://example.com/Pulp-3.1.0.pkg");
+    REQUIRE(parsed->items[0].ed_signature == "abc123");
+    REQUIRE(parsed->items[0].file_size == 321);
+
+    REQUIRE(parsed->items[1].title == "Version 3.0.9");
+    REQUIRE(parsed->items[1].description.empty());
+    REQUIRE(parsed->items[1].build_number.empty());
+    REQUIRE(parsed->items[1].version == "3.0.9");
+    REQUIRE(parsed->items[1].minimum_os.empty());
+    REQUIRE(parsed->items[1].download_url == "https://example.com/Pulp-3.0.9.pkg");
+    REQUIRE(parsed->items[1].ed_signature.empty());
+    REQUIRE(parsed->items[1].file_size == 0);
+}
+
 TEST_CASE("Appcast from_xml invalid", "[ship][appcast]") {
     auto result = Appcast::from_xml("not xml");
     REQUIRE_FALSE(result.has_value());
@@ -69,6 +149,12 @@ TEST_CASE("Version comparison", "[ship][version]") {
     REQUIRE(compare_versions("2.0.0", "1.9.9") == 1);
     REQUIRE(compare_versions("1.0", "1.0.0") == 0);
     REQUIRE(compare_versions("1.0.0.1", "1.0.0") == 1);
+}
+
+TEST_CASE("Version comparison tolerates non-numeric segments", "[ship][version]") {
+    REQUIRE(compare_versions("01.002.0003", "1.2.3") == 0);
+    REQUIRE(compare_versions("1.beta.5", "1.0.7") == -1);
+    REQUIRE(compare_versions("1..5", "1.0.4") == 1);
 }
 
 // #295 P0 regression: sign_file_ed25519 MUST NOT silently return an

--- a/test/test_codesign.cpp
+++ b/test/test_codesign.cpp
@@ -29,6 +29,10 @@ TEST_CASE("check_codesign on nonexistent path", "[ship][codesign]") {
     REQUIRE_FALSE(info.is_valid);
 }
 
+TEST_CASE("check_notarization on nonexistent path is false", "[ship][codesign]") {
+    REQUIRE_FALSE(check_notarization("/nonexistent/binary"));
+}
+
 TEST_CASE("list_signing_identities does not crash", "[ship][codesign]") {
     auto ids = list_signing_identities();
     // May be empty on CI, but should not crash

--- a/test/test_nsis_installer.cpp
+++ b/test/test_nsis_installer.cpp
@@ -2,8 +2,13 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <pulp/ship/installer.hpp>
 
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+
 using namespace pulp::ship;
 using Catch::Matchers::ContainsSubstring;
+namespace fs = std::filesystem;
 
 static InstallerConfig make_test_config() {
     InstallerConfig config;
@@ -17,6 +22,21 @@ static InstallerConfig make_test_config() {
     };
     return config;
 }
+
+struct ScopedTempDir {
+    fs::path path;
+
+    ScopedTempDir() {
+        path = fs::temp_directory_path() / ("pulp-nsis-test-"
+            + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+        fs::create_directories(path);
+    }
+
+    ~ScopedTempDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
 
 TEST_CASE("NSIS script contains product metadata", "[ship][installer]") {
     auto config = make_test_config();
@@ -107,4 +127,33 @@ TEST_CASE("NSIS script includes publisher URL when set", "[ship][installer]") {
 
     REQUIRE_THAT(script, ContainsSubstring("PRODUCT_WEB_SITE"));
     REQUIRE_THAT(script, ContainsSubstring("https://testcorp.com"));
+}
+
+TEST_CASE("NSIS script recurses into directory bundles", "[ship][installer]") {
+    ScopedTempDir temp;
+    auto bundle = temp.path / "TestPlugin.vst3";
+    fs::create_directories(bundle);
+    std::ofstream(bundle / "Contents.txt") << "bundle";
+
+    auto config = make_test_config();
+    config.plugins = {{bundle.string(), "", "vst3"}};
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("File /r \"" + bundle.string() + "\""));
+    REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$COMMONFILES\\VST3\\TestPlugin.vst3\""));
+}
+
+TEST_CASE("NSIS script maps standalone and unknown formats to INSTDIR", "[ship][installer]") {
+    auto config = make_test_config();
+    config.plugins = {
+        {"C:/build/TestPlugin.exe", "", "standalone"},
+        {"C:/build/TestPlugin.lv2", "", "lv2"},
+    };
+    auto script = generate_nsis_script(config);
+
+    REQUIRE_THAT(script, ContainsSubstring("Section \"TestPlugin (Standalone)\""));
+    REQUIRE_THAT(script, ContainsSubstring("Section \"TestPlugin (lv2)\""));
+    REQUIRE_THAT(script, ContainsSubstring("SetOutPath \"$INSTDIR\""));
+    REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$INSTDIR\\TestPlugin.exe\""));
+    REQUIRE_THAT(script, ContainsSubstring("RMDir /r \"$INSTDIR\\TestPlugin.lv2\""));
 }

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/state/cached_property.hpp>
 #include <pulp/state/state_tree.hpp>
+#include <pulp/state/state_tree_sync.hpp>
 
 using namespace pulp::state;
 using Catch::Matchers::WithinAbs;
@@ -294,4 +296,160 @@ TEST_CASE("ObservableValue remove listener", "[state][observable]") {
     val.remove_listener(id);
     val.set(2);
     REQUIRE(count == 1);  // Listener removed
+}
+
+// ── CachedProperty ──────────────────────────────────────────────────────
+
+TEST_CASE("CachedProperty binds default and follows tree updates", "[state][cached]") {
+    auto tree = StateTree::create("params");
+    CachedProperty<std::string> name(tree, "name", "default");
+
+    REQUIRE(name.is_bound());
+    REQUIRE(name.get() == "default");
+
+    tree->set("name", std::string("Gain"));
+    REQUIRE(name.get() == "Gain");
+
+    name.set("Drive");
+    REQUIRE(tree->get_string("name") == "Drive");
+    REQUIRE(name.get() == "Drive");
+}
+
+TEST_CASE("CachedProperty refresh and numeric coercion", "[state][cached]") {
+    auto tree = StateTree::create("params");
+    tree->set("mix", int64_t(7));
+
+    CachedProperty<double> mix(tree, "mix", 0.5);
+    REQUIRE_THAT(mix.get(), WithinAbs(7.0, 1e-5));
+
+    tree->set("mix", 2.5);
+    REQUIRE_THAT(mix.get(), WithinAbs(2.5, 1e-5));
+
+    tree->remove("mix");
+    mix.refresh();
+    REQUIRE_THAT(mix.get(), WithinAbs(2.5, 1e-5));
+}
+
+TEST_CASE("CachedProperty move transfers listener ownership", "[state][cached]") {
+    auto tree = StateTree::create("params");
+    tree->set("enabled", true);
+
+    CachedProperty<bool> enabled(tree, "enabled", false);
+    CachedProperty<bool> moved(std::move(enabled));
+
+    REQUIRE(moved.is_bound());
+    REQUIRE(moved.get());
+
+    tree->set("enabled", false);
+    REQUIRE_FALSE(moved.get());
+}
+
+// ── StateTreeSynchroniser ───────────────────────────────────────────────
+
+TEST_CASE("StateTreeSynchroniser records property and child deltas", "[state][sync]") {
+    auto tree = StateTree::create("root");
+    StateTreeSynchroniser sync;
+    sync.attach(tree);
+
+    tree->set("name", std::string("Lead"));
+    tree->add_child(StateTree::create("osc"));
+    tree->remove_child(0);
+
+    auto deltas = sync.take_deltas();
+    REQUIRE(deltas.size() == 3);
+
+    REQUIRE(deltas[0].type == SyncDeltaType::PropertySet);
+    REQUIRE(deltas[0].path == "root");
+    REQUIRE(deltas[0].key == "name");
+    REQUIRE(std::get<std::string>(deltas[0].value) == "Lead");
+
+    REQUIRE(deltas[1].type == SyncDeltaType::ChildAdd);
+    REQUIRE(deltas[1].path == "root");
+    REQUIRE(deltas[1].key == "osc");
+    REQUIRE(deltas[1].child_index == 0);
+
+    REQUIRE(deltas[2].type == SyncDeltaType::ChildRemove);
+    REQUIRE(deltas[2].path == "root");
+    REQUIRE(deltas[2].child_index == 0);
+
+    REQUIRE(sync.take_deltas().empty());
+}
+
+TEST_CASE("StateTreeSynchroniser detach clears pending and stops recording", "[state][sync]") {
+    auto tree = StateTree::create("root");
+    StateTreeSynchroniser sync;
+    sync.attach(tree);
+
+    tree->set("name", std::string("before"));
+    sync.detach();
+    REQUIRE(sync.take_deltas().empty());
+
+    tree->set("name", std::string("after"));
+    REQUIRE(sync.take_deltas().empty());
+}
+
+TEST_CASE("StateTreeSynchroniser encode and decode round-trip", "[state][sync]") {
+    std::vector<SyncDelta> deltas = {
+        {SyncDeltaType::PropertySet, "root", "name", std::string("Lead"), 3},
+        {SyncDeltaType::PropertySet, "root", "count", int64_t(42), 7},
+        {SyncDeltaType::PropertySet, "root", "mix", 0.25, 1},
+        {SyncDeltaType::PropertySet, "root", "enabled", true, 2},
+        {SyncDeltaType::PropertyRemove, "root", "unused", {}, -1},
+        {SyncDeltaType::ChildAdd, "root", "osc", {}, 1},
+        {SyncDeltaType::ChildRemove, "root", "", {}, 0},
+    };
+
+    auto encoded = StateTreeSynchroniser::encode(deltas);
+    auto decoded = StateTreeSynchroniser::decode(encoded.data(), encoded.size());
+
+    REQUIRE(decoded.size() == deltas.size());
+    REQUIRE(decoded[0].type == SyncDeltaType::PropertySet);
+    REQUIRE(decoded[0].path == "root");
+    REQUIRE(decoded[0].key == "name");
+    REQUIRE(std::get<std::string>(decoded[0].value) == "Lead");
+
+    REQUIRE(std::get<int64_t>(decoded[1].value) == 42);
+    REQUIRE_THAT(std::get<double>(decoded[2].value), WithinAbs(0.25, 1e-8));
+    REQUIRE(std::get<bool>(decoded[3].value));
+    REQUIRE(decoded[4].type == SyncDeltaType::PropertyRemove);
+    REQUIRE(decoded[4].value.index() == 0);
+    REQUIRE(decoded[5].type == SyncDeltaType::ChildAdd);
+    REQUIRE(decoded[5].child_index == 1);
+    REQUIRE(decoded[6].type == SyncDeltaType::ChildRemove);
+    REQUIRE(decoded[6].child_index == 0);
+}
+
+TEST_CASE("StateTreeSynchroniser decode rejects undersized buffers", "[state][sync]") {
+    std::vector<uint8_t> encoded = {1, 0, static_cast<uint8_t>(SyncDeltaType::PropertySet)};
+    auto decoded = StateTreeSynchroniser::decode(encoded.data(), encoded.size());
+    REQUIRE(decoded.empty());
+
+    decoded = StateTreeSynchroniser::decode(nullptr, 0);
+    REQUIRE(decoded.empty());
+}
+
+TEST_CASE("StateTreeSynchroniser apply mutates properties and children", "[state][sync]") {
+    auto tree = StateTree::create("root");
+    tree->set("remove_me", std::string("bye"));
+    tree->add_child(StateTree::create("existing"));
+
+    std::vector<SyncDelta> deltas = {
+        {SyncDeltaType::PropertySet, "root", "name", std::string("Lead"), -1},
+        {SyncDeltaType::PropertySet, "root", "count", int64_t(5), -1},
+        {SyncDeltaType::PropertyRemove, "root", "remove_me", {}, -1},
+        {SyncDeltaType::ChildAdd, "root", "inserted", {}, 0},
+        {SyncDeltaType::ChildAdd, "root", "appended", {}, 99},
+        {SyncDeltaType::ChildRemove, "root", "", {}, 1},
+        {SyncDeltaType::ChildRemove, "root", "", {}, 99},
+    };
+
+    StateTreeSynchroniser::apply(*tree, deltas);
+
+    REQUIRE(tree->get_string("name") == "Lead");
+    REQUIRE(tree->get_int("count") == 5);
+    REQUIRE_FALSE(tree->has("remove_me"));
+
+    REQUIRE(tree->child_count() == 2);
+    REQUIRE(tree->child(0)->type_name() == "inserted");
+    REQUIRE(tree->child(1)->type_name() == "appended");
 }


### PR DESCRIPTION
## Summary

Preserves the older bundled `state` and `ship` test-lift work that was removed from `#647` so the Codecov-fidelity branch could stay focused.

Included here:

- `test/test_state_tree.cpp` hardening for `CachedProperty` and `StateTreeSynchroniser`
- `test/test_appcast.cpp`
- `test/test_nsis_installer.cpp`
- `test/test_codesign.cpp`

## Why this is separate

`#647` stayed narrowed to Codecov truth and workflow fidelity only. These tests are useful deterministic coverage work, but they belong in a separate tranche so coverage truth work is not coupled to unrelated test expansion.

## Local validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target pulp-test-appcast pulp-test-codesign pulp-test-nsis-installer pulp-test-state-tree -j4`
- `./build/test/pulp-test-appcast`
- `./build/test/pulp-test-codesign`
- `./build/test/pulp-test-nsis-installer`
- `./build/test/pulp-test-state-tree`
- `ctest --test-dir build -R "appcast|codesign|nsis|state-tree|CachedProperty|StateTreeSynchroniser" --output-on-failure`
- `ctest --test-dir build -R "Appcast|NSIS" --output-on-failure`

## Tracking

- umbrella: #641
- ship overlap: #644
- split from: #647
