### PR TITLE
fix(view): drop explicit bridge close from AU editor dealloc paths

### DIFF
--- a/.agents/skills/auv2/SKILL.md
+++ b/.agents/skills/auv2/SKILL.md
@@ -146,6 +146,15 @@ error: expected ';' at end of declaration list
 
 The attribute is a static-analysis hint only — dropping it from derived-class `override` declarations has no runtime effect. `PulpAUInstrument::HandleNoteOn/Off` (the reference pattern for AU v2) doesn't carry `AUSDK_RTSAFE` either. When writing a new AU v2 override that matches an `AUSDK_RTSAFE` base declaration, omit the attribute. Caught on CI's Coverage-macOS leg in PR #638 after the AU v2 effect MIDI fix landed without it.
 
+### Editor `dealloc` ordering — never call `bridge->close()` explicitly
+
+`PulpAUEditorOwnership` (in `core/format/src/au_v2_cocoa_view.mm`) declares its members as `unique_ptr<ViewBridge> bridge` then `unique_ptr<PluginViewHost> host`. C++ destroys members in REVERSE declaration order, so when `delete _ownership` runs in `PulpAUEditorOwner::dealloc`:
+
+1. `~PluginViewHost` runs first. The host calls `root_.set_plugin_view_host(nullptr)` to clear the View → host back-pointer. The View it references is still alive (still owned by `bridge->view_`), so the call is safe.
+2. `~ViewBridge` runs second. Its destructor calls `close()` → `Processor::on_view_closed(*view_raw_)` fires → `view_.reset()` destroys the View. The back-pointer was already cleared in step 1, so the View's own teardown can't reach a dead host.
+
+Calling `_ownership->bridge->close()` HERE explicitly (BEFORE `delete _ownership`) reverses that order: the View dies first, then `~PluginViewHost` dereferences a dangling `root_` reference and crashes the AU v2 editor close path. Codex P1 review on PR #653 caught this — the fix is to remove the explicit close, NOT to add it. Same rule applies to any future Cocoa-View ownership wrapper that mixes a `ViewBridge` and a `PluginViewHost` in the same C++ scope.
+
 ## Reference pointers
 
 - Adapter source: `core/format/src/au_v2_adapter.cpp`, `core/format/include/pulp/format/au_v2_adapter.hpp`

--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -338,6 +338,29 @@ AUv3 iOS extensions use `NSExtensionPrincipalClass` =
 AUM), check the Info.plist before the Obj-C — a typo in the principal
 class name fails silently.
 
+### `PulpAUViewController::dealloc` — never call `_bridge->close()` explicitly
+
+The view controller declares its ivars `_bridge` (ViewBridge), then
+`_viewHost` (PluginViewHost), then `_fallbackView`. When `[super
+dealloc]` runs, the runtime destroys C++-typed ivars in REVERSE
+declaration order: `_fallbackView`, `_viewHost`, `_bridge`. That
+ordering is load-bearing:
+
+1. `~PluginViewHost` runs second. It calls
+   `root_.set_plugin_view_host(nullptr)` — the View `root_`
+   references is still alive (still owned by `_bridge->view_`), so
+   the call is safe and clears the back-pointer.
+2. `~ViewBridge` runs last. Its destructor calls `close()` →
+   `Processor::on_view_closed` → `view_.reset()` destroys the View.
+   The back-pointer was already cleared in step 1, so the View's
+   own teardown can't reach a dead host.
+
+Calling `_bridge->close()` HERE explicitly (before `[super dealloc]`)
+reverses that order: the View dies first, then `~PluginViewHost`
+dereferences a dangling `root_` reference and crashes AUv3 editor
+close. Codex P1 review on PR #653 caught this — the fix is to remove
+the explicit close, NOT to add it.
+
 ## Validation recipes
 
 Build and validate via the Pulp CLI:

--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -286,6 +286,12 @@ Builds the `.appex` only. The App Store container host-app target is authored se
 - Device-target code signing is documented but not scripted.
 - Visual regression for iOS UIs not wired up yet (see #330, #249).
 
+## Gotchas
+
+### `PulpAUViewController::dealloc` — never call `_bridge->close()` explicitly
+
+Touched here because `core/format/src/au_view_controller_ios.mm` is dual-owned by `ios` + `auv3` + `view-bridge`. The view controller's ivars `_bridge`, `_viewHost`, `_fallbackView` are destroyed in REVERSE declaration order by the runtime; the resulting sequence (host destroyed before bridge) is what makes the `root_.set_plugin_view_host(nullptr)` call in `~PluginViewHost` safe. Calling `_bridge->close()` explicitly in `dealloc` reverses that order, frees the View first, and the host's destructor then dereferences a dangling reference — crashes AUv3 editor close. Codex P1 review on PR #653. Full rationale lives in the `auv3` skill under "PulpAUViewController::dealloc — never call `_bridge->close()` explicitly".
+
 ## See Also
 
 - `android` skill — parallel structure for Android NDK.

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -180,6 +180,27 @@ its own view hierarchy informed by `view.metadata`. Canvas-command
 streaming is the next increment — see the "Not yet wired" section of
 the protocol doc.
 
+### AU editor `dealloc` ordering — never call `bridge->close()` explicitly
+
+When a `ViewBridge` and a `PluginViewHost` are owned by the same C++
+scope (a struct, an Obj-C class's ivars), C++ destroys members in
+REVERSE declaration order. AU's editor wrappers
+(`PulpAUEditorOwnership` for AU v2 Cocoa view, `PulpAUViewController`
+for AUv3 iOS) declare the bridge first and the host second so the
+host (which holds `View& root_`) is torn down BEFORE the bridge that
+owns the View. The host's destructor can then safely call
+`root_.set_plugin_view_host(nullptr)` to clear the back-pointer; then
+`~ViewBridge` fires `Processor::on_view_closed` and resets the View.
+
+Calling `bridge->close()` explicitly inside dealloc reverses that
+order — the View dies first, the host's `~PluginViewHost` then
+dereferences a dangling `root_` reference, and AU editor close
+crashes the host process. Codex P1 review on PR #653 caught the
+crash; the fix was to remove the explicit close (PR #667 / pulp
+`fix/au-editor-uaf-on-close`). Don't reintroduce it. The full
+rationale lives in the `auv2`, `auv3`, and `ios` skills since those
+files are dual-/triple-mapped.
+
 ## References
 
 - `core/format/include/pulp/format/view_bridge.hpp` — public API

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.37.0
+    VERSION 0.38.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/src/au_v2_cocoa_view.mm
+++ b/core/format/src/au_v2_cocoa_view.mm
@@ -48,7 +48,26 @@ struct PulpAUEditorOwnership {
 }
 - (void)dealloc {
     if (_ownership) {
-        if (_ownership->bridge) _ownership->bridge->close();
+        // Destruction-order contract (Codex P1 review on PR #653):
+        //
+        // PulpAUEditorOwnership declares `bridge` first, then `host`.
+        // C++ destroys members in REVERSE declaration order, so:
+        //   1. ~unique_ptr<PluginViewHost> runs first. Its destructor
+        //      calls `root_.set_plugin_view_host(nullptr)` — the View
+        //      that `root_` references is still alive at this point
+        //      (still owned by `bridge->view_`), so the call is safe
+        //      and clears the back-pointer.
+        //   2. ~unique_ptr<ViewBridge> runs second. Its destructor
+        //      calls `close()` which fires `Processor::on_view_closed`,
+        //      releases the scripted UI, and resets the View. The
+        //      back-pointer was already cleared in step 1, so the
+        //      View's own teardown can't reach a dead host.
+        //
+        // Calling `bridge->close()` HERE explicitly (before `delete`)
+        // reverses that ordering — the View dies BEFORE the host, and
+        // the host's destructor then dereferences a dangling `root_`
+        // reference, crashing AU v2 editor close. Don't reintroduce
+        // the explicit close in this dealloc path.
         delete _ownership;
     }
     [super dealloc];

--- a/core/format/src/au_view_controller_ios.mm
+++ b/core/format/src/au_view_controller_ios.mm
@@ -104,7 +104,33 @@
 }
 
 - (void)dealloc {
-    if (_bridge) _bridge->close();
+    // Destruction-order contract (Codex P1 review on PR #653):
+    //
+    // PulpAUViewController declares its ivars in order:
+    //     _bridge       (ViewBridge — owns the View tree)
+    //     _viewHost     (PluginViewHost — holds `View& root_`)
+    //     _fallbackView (only used when bridge fails)
+    //
+    // After [super dealloc] the runtime destroys C++-typed ivars in
+    // REVERSE declaration order: _fallbackView, then _viewHost, then
+    // _bridge. That ordering is load-bearing:
+    //   1. ~_fallbackView runs (no-op when bridge succeeded).
+    //   2. ~unique_ptr<PluginViewHost> runs. Its destructor calls
+    //      `root_.set_plugin_view_host(nullptr)` — the View that
+    //      `root_` references is still alive (still owned by
+    //      `_bridge->view_`), so the call is safe and clears the
+    //      back-pointer.
+    //   3. ~unique_ptr<ViewBridge> runs. Its destructor calls
+    //      `close()` which fires `Processor::on_view_closed`,
+    //      releases the scripted UI, and resets the View. The
+    //      back-pointer was already cleared in step 2, so the
+    //      View's own teardown can't reach a dead host.
+    //
+    // Calling `_bridge->close()` HERE explicitly (before [super
+    // dealloc]) reverses that order — the View dies first, then
+    // ~PluginViewHost dereferences a dangling `root_` reference and
+    // crashes AUv3 editor close. Don't reintroduce the explicit
+    // close in this dealloc path.
     [super dealloc];
 }
 


### PR DESCRIPTION
Codex P1 review on PR #653 caught a use-after-free in both AU editor
close paths:

  PulpAUEditorOwner::dealloc (au_v2_cocoa_view.mm)
    -> _ownership->bridge->close()  // ViewBridge::close() -> view_.reset()
    -> delete _ownership            // ~unique_ptr<host> runs next
       -> ~MacPluginViewHost
          -> root_.set_plugin_view_host(nullptr)  // root_ is now dangling

The iOS path (PulpAUViewController::dealloc) hit the same shape: the
explicit `_bridge->close()` freed the View tree that `_viewHost`'s
`root_` reference pointed at; when the runtime then destroyed the
ivars in reverse declaration order, `~PluginViewHost` dereferenced
that dead reference and any AUv3 editor close could crash the host.

The fix is the natural destruction order, NOT an additional clear:

  PulpAUEditorOwnership declares `bridge` then `host`. C++ destroys
  members in REVERSE order, so `~unique_ptr<host>` runs FIRST while
  `bridge->view_` is still alive. The host's destructor safely calls
  `root_.set_plugin_view_host(nullptr)`. Then `~unique_ptr<bridge>`
  runs `close()` -> `Processor::on_view_closed` -> `view_.reset()`,
  with the back-pointer already nulled so nothing dangles in either
  direction.

Same reasoning for the iOS view controller's three ivars (`_bridge`,
`_viewHost`, `_fallbackView`) — `[super dealloc]` destroys them in
reverse declaration order, and the only thing that broke that
sequence was the manual `_bridge->close()` we added on top.

Three SKILL.md updates pin the contract so the next refactor doesn't
reintroduce the explicit close:
- auv2: full rationale + reference to the UAF crash class.
- auv3: full rationale on the iOS view-controller ivar order.
- ios:  cross-reference, since `au_view_controller_ios.mm` is dual-
        owned (auv3 + ios + view-bridge per skill_path_map.json).

Other call sites of `bridge->close()` audited in the same pass and
left alone:
- clap_entry.hpp:298 — early-fail (host creation failed, nothing to
  dangle).
- clap_entry.hpp:308 (gui_destroy) — already correctly orders
  `editor_host.reset()` BEFORE `bridge->close()`.
- standalone.cpp:248 — early-fail (window/host not yet built).
- examples/view-bridge-demo/main.cpp:112 — test, no host.
- au_v2_cocoa_view.mm:115 — early-fail twin of the clap one.

Local: pulp-format builds clean. skill_sync_check clean against
origin/main.