### PR TITLE
chore: bump Shipyard pin v0.26.0 → v0.29.0

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -36,7 +36,7 @@ When the user says any of: **"push to main"**, **"ship this"**, **"ship it"**,
 run `shipyard pr` (not `gh pr create` + `shipyard ship` separately).
 
 `shipyard pr` is the single orchestrator (Shipyard v0.19.1+; pinned at
-v0.26.0 in `tools/shipyard.toml`). It:
+v0.29.0 in `tools/shipyard.toml`). It:
 
 1. Calls `tools/scripts/skill_sync_check.py` (resolved via Shipyard's
    `[validation]` path-discovery, explicit in `.shipyard/config.toml`) and
@@ -62,8 +62,36 @@ Backward compatibility: raw `shipyard ship` / `shipyard run` still work for
 diagnostics, experimental branches, or when `shipyard pr` itself is being
 debugged. Do not use them as the primary ship path.
 
-### Behaviour notes at the current pin (v0.26.0)
+### Behaviour notes at the current pin (v0.29.0)
 
+- **macOS binary is signed + notarized** (Shipyard v0.29.0). On
+  macOS 26.3+ XProtect skips the deep scan for notarized binaries,
+  cutting `shipyard pr` cold-start ~4-5x (from ~5-6s to ~1-1.5s).
+  No pulp-side action; transparent.
+- **Heartbeat line during long validation** (Shipyard v0.29.0). A
+  20-minute lane now prints periodic progress instead of leaving a
+  silent terminal. Helpful when watching `shipyard ship` interactively.
+- **Backend errors are surfaced under the summary table** (Shipyard
+  v0.28.0). A bare `ubuntu     error     ssh    12s` row used to
+  give zero diagnostic signal — the captured stderr tail (bundle
+  upload failure, remote `cmake` apply failure, SSH transport
+  error, etc.) now prints below the table. Closes pulp #665's
+  diagnosis-blind-spot complaint.
+- **Worktree-local `.shipyard.local/` falls back to the primary
+  checkout** (Shipyard v0.27.2). Pulp uses worktrees heavily for
+  parallel agent work; without this every new worktree had to
+  manually `cp .shipyard.local/config.toml` from the primary repo
+  before `shipyard pr` could see the SSH host config. Now it
+  inherits automatically.
+- **Ship preflight runs BEFORE `gh pr create`** (Shipyard v0.27.1).
+  Earlier the PR was opened first and ship aborted on unreachable
+  SSH backend, leaving stranded PRs with no validation (the
+  Apr 22 pattern that left several pulp PRs mid-flight). Now an
+  unreachable target fails fast and the PR is never opened.
+- **Daemon tunnel supervisor** (Shipyard v0.27.0). Tailscale Funnel
+  transients no longer kill the daemon — the supervisor restarts
+  the funnel on backoff. Periodic reconcile loop runs independently
+  of per-PR polls. Both apply to the macOS GUI's webhook delivery.
 - **Long-running daemons keep accepting fresh subscribers** (Shipyard
   v0.26.0). The subscribe-replay path now uses blocking `put()`
   instead of `put_nowait()`, so once the replay ring grows past 64

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -197,9 +197,11 @@ Pulp's release automation depends on the pinned Shipyard CLI in two places:
   carry a `SHIPYARD_VERSION` env used by the release-side workflows.
 
 If you bump the Shipyard pin, update both workflows in the same PR and keep the
-existing string format in each file (`v0.26.0` vs `0.26.0`). Otherwise local
-shipping and tag-time release jobs quietly diverge onto different Shipyard
-versions, which is how release-only behavior changes get missed.
+existing string format in each file (`v0.29.0` in `tools/shipyard.toml`,
+`0.29.0` in the workflow envs — the `v` prefix is intentional only on the
+toml). Otherwise local shipping and tag-time release jobs quietly diverge
+onto different Shipyard versions, which is how release-only behavior
+changes get missed.
 
 ## Doctor Checks
 

--- a/.github/workflows/post-tag-sync.yml
+++ b/.github/workflows/post-tag-sync.yml
@@ -20,7 +20,7 @@ permissions:
   contents: write
 
 env:
-  SHIPYARD_VERSION: "0.26.0"
+  SHIPYARD_VERSION: "0.29.0"
 
 jobs:
   sync:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -22,7 +22,7 @@ env:
   # Pin shipyard to the same version post-tag-sync.yml uses so
   # `shipyard changelog regenerate --release-notes` produces the
   # same output as the hook that writes CHANGELOG.md.
-  SHIPYARD_VERSION: "0.26.0"
+  SHIPYARD_VERSION: "0.29.0"
 
 jobs:
   build-cli:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,7 +492,7 @@ Pulp versions three surfaces independently: SDK/CLI (`CMakeLists.txt`), Claude p
 3. `git commit` + `gh pr create` + `shipyard ship` — one command, merges on green.
 4. `.github/workflows/auto-release.yml` — on merge to main, tags the new version(s) and the existing tag-triggered release workflows build + publish binaries.
 
-Shipyard v0.19.1+ (pinned as v0.26.0 in `tools/shipyard.toml`) auto-discovers Pulp's `tools/scripts/` layout; `.shipyard/config.toml [validation]` additionally pins the paths explicitly for reproducibility.
+Shipyard v0.19.1+ (pinned as v0.29.0 in `tools/shipyard.toml`) auto-discovers Pulp's `tools/scripts/` layout; `.shipyard/config.toml [validation]` additionally pins the paths explicitly for reproducibility.
 
 **Bypass trailers** (tip commit, never PR body — audit trail lives in git):
 

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -125,6 +125,45 @@
 #             advertises the daemon's own `shipyard_version` in
 #             hello/status frames, and teaches `shipyard doctor`
 #             to flag daemon-vs-CLI version drift.
+#   v0.27.0 — daemon tunnel supervisor: a Tailscale Funnel transient
+#             (the funnel process drops momentarily, common on
+#             flaky networks) no longer kills the daemon. The
+#             supervisor restarts the funnel on backoff and keeps
+#             webhook delivery alive. Also adds a periodic
+#             reconcile loop that closes the daemon-vs-GitHub
+#             state-drift gap independently of the per-PR poll.
+#   v0.27.1 — `shipyard ship` preflights the SSH targets BEFORE
+#             `gh pr create` runs. Earlier the PR was opened first
+#             and ship aborted on unreachable SSH backend, leaving
+#             stranded PRs with no validation. Now an unreachable
+#             target fails fast and the PR is never opened.
+#             Directly addresses the pulp-side "PR opened but ship
+#             never finished" pattern that left #627 / #629 / #638
+#             stuck mid-flight on Apr 22.
+#   v0.27.2 — worktree-local `.shipyard.local/` falls back to the
+#             primary checkout's `.shipyard.local/` when the
+#             worktree's copy is missing. Pulp uses worktrees
+#             heavily for parallel agent work; without this every
+#             new worktree had to manually `cp ../primary/.shipyard.local/config.toml`
+#             before `shipyard pr` could see the SSH host config.
+#             v0.27.2 inherits it automatically.
+#   v0.28.0 — `shipyard run` / `shipyard pr` now print the
+#             underlying backend error (bundle upload failure,
+#             remote `cmake` apply failure, SSH transport error,
+#             ssh-keygen mismatch, etc.) below the summary table
+#             instead of the bare `ubuntu     error     ssh    12s`
+#             row. Lands the diagnosis blind spot called out by
+#             pulp #665 (no signal from a 17-second SSH error).
+#             Symbol-level fix: error rows now carry the captured
+#             stderr tail in the rendered output.
+#   v0.29.0 — macOS binary is Developer-ID-signed and Apple-
+#             notarized. macOS 26.3+ XProtect skips deep scan for
+#             notarized binaries — cold-start on `shipyard pr`
+#             drops ~4-5x (from ~5-6s to ~1-1.5s). Also adds a
+#             heartbeat status line during long validation phases
+#             so a 20-minute lane shows progress instead of a dead
+#             terminal, and the bundled Python is bumped to 3.13
+#             with lazy-imported rich for further startup wins.
 #
 # Cumulative additions from earlier releases still in effect:
 #   v0.4–v0.8 — release-bot helpers, `shipyard doctor release-chain`,
@@ -139,7 +178,7 @@
 # in `tools/install-shipyard.sh` (v0.22.1+ `SHIPYARD_VERSION` support).
 # The older `~/.pulp/bin/shipyard` path is cleaned up on install to
 # prevent shadow-on-PATH bugs.
-version = "v0.26.0"
+version = "v0.29.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Pulls in four releases that materially affect pulp's ship + diagnose
loops:

* v0.27.0 — daemon tunnel supervisor. Tailscale Funnel transients no
  longer kill the daemon; the supervisor restarts the funnel on
  backoff and keeps webhook delivery alive. Periodic reconcile loop
  closes a state-drift gap independently of the per-PR poll. Both
  apply transparently to the macOS GUI's webhook delivery and the
  long-running daemon Pulp's CI flow depends on.

* v0.27.1 — `shipyard ship` SSH preflight runs BEFORE `gh pr create`.
  Earlier the PR was opened first and ship aborted on unreachable
  SSH backend, leaving stranded PRs with no validation. Pulp PRs
  #627 / #629 / #638 / #654 / #660 / #667 all hit this on Apr 22 —
  the PR existed, GH Actions ran independently, but `shipyard ship`
  never recorded any local target evidence so auto-merge couldn't
  fire. v0.27.1 fails fast: an unreachable target rejects the run
  and no PR is opened.

* v0.27.2 — worktree-local `.shipyard.local/` falls back to the
  primary checkout's copy. Pulp uses worktrees heavily for parallel
  agent work; before this every new worktree had to manually copy
  the SSH host config from the primary repo before `shipyard pr`
  could see it. Now inherited automatically.

* v0.28.0 — backend errors print under the summary table instead of
  the bare `ubuntu     error     ssh    12s` row. Lands the
  diagnostic blind spot called out by pulp #665 — bundle upload
  failure, remote `cmake` apply failure, SSH transport error all
  surface their captured stderr tail in the rendered output.

* v0.29.0 — macOS binary is Developer-ID-signed and Apple-notarized.
  macOS 26.3+ XProtect skips the deep scan for notarized binaries;
  cold-start on `shipyard pr` drops ~4-5x (5-6s → 1-1.5s). Also
  adds a heartbeat status line during long validation phases so a
  20-min lane shows progress instead of a dead terminal, and the
  bundled Python jumps to 3.13 with lazy-imported rich for further
  startup wins.

Files updated:
- tools/shipyard.toml: pin → v0.29.0; changelog comments for v0.27.0
  through v0.29.0 appended.
- .github/workflows/release-cli.yml + post-tag-sync.yml:
  SHIPYARD_VERSION env "0.26.0" → "0.29.0".
- CLAUDE.md: pin reference updated.
- .agents/skills/ci/SKILL.md: pin reference updated, behaviour notes
  rewritten for v0.29.0 (with v0.26.0 notes retained for history).
- .agents/skills/ship/SKILL.md: pin format note updated.

Verified locally: ./tools/install-shipyard.sh installs the new
binary, `shipyard --version` reports 0.29.0. skill_sync_check
clean against origin/main.