### PR TITLE
ci(coverage): add --break-system-packages for Namespace pip install

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -764,6 +764,22 @@ Gotchas:
 
 See [docs/guides/iwyu.md](../../../docs/guides/iwyu.md) for the full contributor-facing write-up.
 
+## PEP 668 + Namespace runners
+
+Namespace's runner image is PEP-668-strict: `pip install --user <pkg>` fails with `error: externally-managed-environment` unless you also pass `--break-system-packages`. The github-hosted ubuntu-latest image tolerates `--user` without the flag, so this regression only surfaces after a workflow's matrix routes its Linux leg through Namespace via a `PULP_*_RUNS_ON_JSON` repo variable.
+
+When you add a new `pip install --user` step to a workflow that may run on Namespace, ALWAYS include `--break-system-packages`. Same applies to any virtualenv-less Python helper installed inline at workflow time. If the workflow uses a hard-coded `runs-on: ubuntu-24.04` (e.g. `coverage-diff-gate`), the flag isn't required because GH-hosted runners aren't PEP-668-strict — but adding the flag is harmless and future-proofs against a later Namespace migration.
+
+Symptom (on Namespace) when you forget:
+
+```
+error: externally-managed-environment
+× This environment is externally managed
+╰─> To install Python packages system-wide, try apt install python3-xyz, ...
+```
+
+Followed by cascade-skipped downstream steps (default `if: success()`) and a "coverage.python.xml is missing" hard-fail in the validation step. Coverage Linux ran into this when it migrated to Namespace via `PULP_COVERAGE_LINUX_RUNS_ON_JSON` (PR #676 → #677).
+
 ## SignalGraph Phase 0 learnings (PR #153)
 
 Gotchas surfaced while landing the four-phase SignalGraph follow-up:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -246,7 +246,16 @@ jobs:
         # Linux-only, tools/scripts-only, same workflow.
         if: matrix.os == 'linux'
         shell: bash
-        run: python3 -m pip install --user 'coverage>=7.10' PyYAML
+        # `--break-system-packages` is the PEP 668 "yes I know what
+        # I'm doing" escape. The github-hosted ubuntu-latest image
+        # tolerates `--user` without it; Namespace's runner image
+        # is PEP-668-strict and rejects this with
+        # `error: externally-managed-environment`. Pulp routes
+        # Coverage Linux through Namespace via
+        # `PULP_COVERAGE_LINUX_RUNS_ON_JSON`, so the flag is
+        # required to keep this step (and the cascade-skipped
+        # downstream Python coverage steps) green.
+        run: python3 -m pip install --user --break-system-packages 'coverage>=7.10' PyYAML
 
       - name: Run Python tools coverage
         # Mirror scripts/run_coverage.sh semantics: keep going even if a


### PR DESCRIPTION
The "Install Python coverage tooling" step in coverage.yml's matrix
job uses `pip install --user 'coverage>=7.10' PyYAML`. The
github-hosted ubuntu-latest image tolerates this; Namespace's runner
image is PEP-668-strict and rejects the install with:

    error: externally-managed-environment
    × This environment is externally managed
    ╰─> To install Python packages system-wide, try apt install ...

Cascade effect (verified on PR #676 / run #24819128162):
- Install Python coverage tooling: failure (PEP 668)
- Run Python tools coverage: skipped (default `if: success()`)
- Run Swift apple coverage: skipped
- Upload Python HTML report: failure (no input)
- Upload Python summary: failure (no input)
- Verify Python Cobertura XML exists: failure (file missing)
- Coverage report (Linux, Clang) job: failure

C++ coverage (the `Run coverage suite` step) finished successfully
and uploaded a valid Cobertura XML — only the Python lane was lost.

Pulp routed Coverage Linux to Namespace via `PULP_COVERAGE_LINUX_RUNS_ON_JSON`
yesterday; this is the first PR run after that change. Adding
`--break-system-packages` is the PEP 668 escape hatch that says "yes,
install system-wide, I know what I'm doing" — appropriate for a
fresh CI runner with no other Python state to clobber.

Updated `.agents/skills/ci/SKILL.md` with a "PEP 668 + Namespace
runners" section so future workflow edits remember to include the
flag. The other two pip-install sites in coverage.yml
(coverage-diff-gate at lines 562, 669) currently run on hard-coded
`ubuntu-24.04` (GH-hosted) and don't strictly need the flag, but the
skill note flags them for proactive update if those jobs ever
migrate.