### PR TITLE
fix(sanitizer): eliminate Timer TSan race + CLAP UBSan misalign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0380"></a>
+## [0.39.0]
+
 ## [0.38.0] - 2026-04-22
 
 - fix(view): drop explicit bridge close from AU editor dealloc paths ([#667](https://github.com/danielraffel/pulp/pull/667))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.38.0
+    VERSION 0.39.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/events/include/pulp/events/timer.hpp
+++ b/core/events/include/pulp/events/timer.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <pulp/events/event_loop.hpp>
-#include <functional>
 #include <atomic>
-#include <memory>
+#include <cstdint>
+#include <functional>
 
 namespace pulp::events {
 
@@ -26,14 +26,19 @@ public:
     Duration interval() const { return interval_; }
 
 private:
-    void schedule_next();
+    void schedule_next(std::uint64_t gen);
 
     EventLoop& loop_;
     Duration interval_;
     Callback callback_;
     bool repeating_;
     std::atomic<bool> active_{false};
-    std::shared_ptr<std::atomic<bool>> alive_; // prevent use-after-free on stop
+    // Cycle generation — incremented by stop() so that stale dispatch
+    // lambdas scheduled before stop() return early when they fire. Cheap
+    // replacement for the previous shared_ptr<atomic<bool>> sentinel,
+    // which raced on the shared_ptr slot between start() (main thread)
+    // and schedule_next() (event-loop thread). See #687 / #414.
+    std::atomic<std::uint64_t> generation_{0};
 };
 
 } // namespace pulp::events

--- a/core/events/src/timer.cpp
+++ b/core/events/src/timer.cpp
@@ -7,7 +7,6 @@ Timer::Timer(EventLoop& loop, Duration interval, Callback callback, bool repeati
     , interval_(interval)
     , callback_(std::move(callback))
     , repeating_(repeating)
-    , alive_(std::make_shared<std::atomic<bool>>(true))
 {
 }
 
@@ -16,59 +15,42 @@ Timer::~Timer() {
 }
 
 void Timer::start() {
-    // Idempotent against concurrent schedule_next() lambdas copying
-    // alive_. If start() is called while the timer is already active,
-    // skipping the reassignment avoids an unsynchronized write to the
-    // shared_ptr that an in-flight event-loop copy is reading — the
-    // original #414 race pattern. See #438 P1 Codex review on #428.
+    // Idempotent when already running. See #438 P1 Codex review on #428.
     if (active_.load(std::memory_order_acquire)) {
         return;
     }
-
-    // Fresh sentinel for this lifecycle. Safe to reassign alive_ here
-    // because start() runs on the owner thread — no in-flight dispatch
-    // lambda can be copying alive_ concurrently at this point (active_
-    // is false, schedule_next() gated on it), and any prior-cycle
-    // lambdas hold their own shared_ptr copies captured before stop()
-    // flipped them to false.
-    //
-    // Previously this reassignment lived in stop(), racing with
-    // schedule_next()'s `auto alive = alive_;` copy on the event-loop
-    // thread — std::shared_ptr is NOT thread-safe for concurrent
-    // read/write of the same instance. TSan caught it as a
-    // std::swap-of-atomic<bool>* race in test_events.cpp "Timer basic
-    // operation". Issue #414.
-    alive_ = std::make_shared<std::atomic<bool>>(true);
     active_.store(true, std::memory_order_release);
-    schedule_next();
+    schedule_next(generation_.load(std::memory_order_acquire));
 }
 
 void Timer::stop() {
     active_.store(false, std::memory_order_release);
-    alive_->store(false, std::memory_order_release);
-    // Don't replace alive_ here. In-flight dispatch lambdas still
-    // hold a shared_ptr copy to this sentinel and correctly see the
-    // false value set above; the old sentinel is reclaimed when the
-    // last in-flight lambda drops its ref. start() allocates a fresh
-    // sentinel for the next lifecycle.
+    // Bump the generation so any in-flight dispatch lambda whose captured
+    // generation no longer matches returns early before calling the
+    // callback or rescheduling. Atomic RMW — safe to race with start()
+    // and schedule_next().
+    generation_.fetch_add(1, std::memory_order_acq_rel);
 }
 
 void Timer::set_interval(Duration interval) {
     interval_ = interval;
 }
 
-void Timer::schedule_next() {
-    auto alive = alive_;
+void Timer::schedule_next(std::uint64_t gen) {
     auto* self = this;
-    loop_.dispatch_after(interval_, [self, alive]() {
-        if (!alive->load(std::memory_order_acquire))
+    loop_.dispatch_after(interval_, [self, gen]() {
+        if (!self->active_.load(std::memory_order_acquire))
+            return;
+        if (self->generation_.load(std::memory_order_acquire) != gen)
+            return;
+        self->callback_();
+        if (!self->repeating_)
             return;
         if (!self->active_.load(std::memory_order_acquire))
             return;
-        self->callback_();
-        if (self->repeating_ && self->active_.load(std::memory_order_acquire)) {
-            self->schedule_next();
-        }
+        if (self->generation_.load(std::memory_order_acquire) != gen)
+            return;
+        self->schedule_next(gen);
     });
 }
 

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -175,16 +175,22 @@ inline void params_flush(const clap_plugin_t* plugin, const clap_input_events_t*
     uint32_t count = in->size(in);
     for (uint32_t i = 0; i < count; ++i) {
         auto* hdr = in->get(in, i);
+        // memcpy into a stack local to avoid UBSan "misaligned address"
+        // when hdr isn't aligned to the struct's alignof (e.g. 8 for
+        // clap_event_param_value_t's `double value`). #688.
         if (hdr->type == CLAP_EVENT_PARAM_VALUE) {
-            auto* ev = reinterpret_cast<const clap_event_param_value_t*>(hdr);
-            self->store.set_value(static_cast<state::ParamID>(ev->param_id),
-                                  static_cast<float>(ev->value));
+            clap_event_param_value_t ev;
+            std::memcpy(&ev, hdr, sizeof(ev));
+            self->store.set_value(static_cast<state::ParamID>(ev.param_id),
+                                  static_cast<float>(ev.value));
         } else if (hdr->type == CLAP_EVENT_PARAM_GESTURE_BEGIN) {
-            auto* ev = reinterpret_cast<const clap_event_param_gesture_t*>(hdr);
-            self->store.begin_gesture(static_cast<state::ParamID>(ev->param_id));
+            clap_event_param_gesture_t ev;
+            std::memcpy(&ev, hdr, sizeof(ev));
+            self->store.begin_gesture(static_cast<state::ParamID>(ev.param_id));
         } else if (hdr->type == CLAP_EVENT_PARAM_GESTURE_END) {
-            auto* ev = reinterpret_cast<const clap_event_param_gesture_t*>(hdr);
-            self->store.end_gesture(static_cast<state::ParamID>(ev->param_id));
+            clap_event_param_gesture_t ev;
+            std::memcpy(&ev, hdr, sizeof(ev));
+            self->store.end_gesture(static_cast<state::ParamID>(ev.param_id));
         }
     }
 }

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -17,6 +17,21 @@ static PulpClapPlugin* get_self(const clap_plugin_t* plugin) {
     return static_cast<PulpClapPlugin*>(plugin->plugin_data);
 }
 
+// Read a CLAP event by value from the (possibly-misaligned) header
+// pointer handed out by `clap_input_events.get()`. Hosts may pack
+// variable-size events back-to-back without padding to the strictest
+// member alignment, so `reinterpret_cast<const Foo*>(hdr)` can yield a
+// pointer that violates alignof(Foo) — access to any 8-byte member
+// (e.g. `double velocity` in `clap_event_note_t`) is then UB. UBSan
+// caught this at clap_adapter.cpp:200 via test_clap_midi_events.cpp:772.
+// See #688. memcpy into a stack local guarantees proper alignment.
+template <typename T>
+static T load_event(const clap_event_header_t* hdr) {
+    T out;
+    std::memcpy(&out, hdr, sizeof(T));
+    return out;
+}
+
 bool clap_init(const clap_plugin_t* plugin) {
     auto* self = get_self(plugin);
     self->processor = self->factory();
@@ -93,21 +108,21 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
         for (uint32_t i = 0; i < event_count; ++i) {
             auto* hdr = in_events->get(in_events, i);
             if (hdr->type == CLAP_EVENT_PARAM_VALUE) {
-                auto* ev = reinterpret_cast<const clap_event_param_value_t*>(hdr);
+                const auto ev = load_event<clap_event_param_value_t>(hdr);
                 self->store.set_value(
-                    static_cast<state::ParamID>(ev->param_id),
-                    static_cast<float>(ev->value));
+                    static_cast<state::ParamID>(ev.param_id),
+                    static_cast<float>(ev.value));
             } else if (hdr->type == CLAP_EVENT_PARAM_MOD) {
-                auto* ev = reinterpret_cast<const clap_event_param_mod_t*>(hdr);
+                const auto ev = load_event<clap_event_param_mod_t>(hdr);
                 self->store.set_mod_offset(
-                    static_cast<state::ParamID>(ev->param_id),
-                    static_cast<float>(ev->amount));
+                    static_cast<state::ParamID>(ev.param_id),
+                    static_cast<float>(ev.amount));
             } else if (hdr->type == CLAP_EVENT_PARAM_GESTURE_BEGIN) {
-                auto* ev = reinterpret_cast<const clap_event_param_gesture_t*>(hdr);
-                self->store.begin_gesture(static_cast<state::ParamID>(ev->param_id));
+                const auto ev = load_event<clap_event_param_gesture_t>(hdr);
+                self->store.begin_gesture(static_cast<state::ParamID>(ev.param_id));
             } else if (hdr->type == CLAP_EVENT_PARAM_GESTURE_END) {
-                auto* ev = reinterpret_cast<const clap_event_param_gesture_t*>(hdr);
-                self->store.end_gesture(static_cast<state::ParamID>(ev->param_id));
+                const auto ev = load_event<clap_event_param_gesture_t>(hdr);
+                self->store.end_gesture(static_cast<state::ParamID>(ev.param_id));
             }
         }
     }
@@ -195,19 +210,19 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
         for (uint32_t i = 0; i < event_count; ++i) {
             auto* hdr = in_events->get(in_events, i);
             if (hdr->type == CLAP_EVENT_NOTE_ON) {
-                auto* ev = reinterpret_cast<const clap_event_note_t*>(hdr);
+                const auto ev = load_event<clap_event_note_t>(hdr);
                 auto me = midi::MidiEvent::note_on(
-                    static_cast<uint8_t>(ev->channel),
-                    static_cast<uint8_t>(ev->key),
-                    static_cast<uint8_t>(ev->velocity * 127.0));
+                    static_cast<uint8_t>(ev.channel),
+                    static_cast<uint8_t>(ev.key),
+                    static_cast<uint8_t>(ev.velocity * 127.0));
                 me.sample_offset = static_cast<int32_t>(hdr->time);
                 midi_in.add(me);
             } else if (hdr->type == CLAP_EVENT_NOTE_OFF) {
-                auto* ev = reinterpret_cast<const clap_event_note_t*>(hdr);
+                const auto ev = load_event<clap_event_note_t>(hdr);
                 auto me = midi::MidiEvent::note_off(
-                    static_cast<uint8_t>(ev->channel),
-                    static_cast<uint8_t>(ev->key),
-                    static_cast<uint8_t>(ev->velocity * 127.0));
+                    static_cast<uint8_t>(ev.channel),
+                    static_cast<uint8_t>(ev.key),
+                    static_cast<uint8_t>(ev.velocity * 127.0));
                 me.sample_offset = static_cast<int32_t>(hdr->time);
                 midi_in.add(me);
             } else if (hdr->type == CLAP_EVENT_NOTE_CHOKE) {
@@ -217,10 +232,10 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                 // a zero-velocity note-off on the same (channel, key).
                 // See clap/events.h around CLAP_EVENT_NOTE_CHOKE — the
                 // velocity field is spec-ignored.
-                auto* ev = reinterpret_cast<const clap_event_note_t*>(hdr);
+                const auto ev = load_event<clap_event_note_t>(hdr);
                 auto me = midi::MidiEvent::note_off(
-                    static_cast<uint8_t>(ev->channel),
-                    static_cast<uint8_t>(ev->key),
+                    static_cast<uint8_t>(ev.channel),
+                    static_cast<uint8_t>(ev.key),
                     0);
                 me.sample_offset = static_cast<int32_t>(hdr->time);
                 midi_in.add(me);
@@ -235,7 +250,7 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                 // the channel). Plugins that consume UMP can access
                 // per-note expressions natively via the UMP sidecar;
                 // future work can extend that path.
-                auto* ev = reinterpret_cast<const clap_event_note_expression_t*>(hdr);
+                const auto ev = load_event<clap_event_note_expression_t>(hdr);
                 if (!self->mpe_enabled) {
                     if (!note_expression_drop_logged) {
                         runtime::log_debug(
@@ -245,8 +260,8 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                     }
                 } else {
                     const auto channel = static_cast<uint8_t>(
-                        ev->channel < 0 ? 0 : ev->channel & 0x0F);
-                    // NOTE: ev->key selects the target note for per-note
+                        ev.channel < 0 ? 0 : ev.channel & 0x0F);
+                    // NOTE: ev.key selects the target note for per-note
                     // routing. The MIDI 1.0 synthesis path below emits
                     // channel-wide messages (channel AT, pitch bend,
                     // CCs); the MpeVoiceTracker narrows them back to the
@@ -256,10 +271,10 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                     const auto t = static_cast<int32_t>(hdr->time);
                     midi::MidiEvent me{};
                     bool emitted = false;
-                    switch (ev->expression_id) {
+                    switch (ev.expression_id) {
                         case CLAP_NOTE_EXPRESSION_PRESSURE: {
                             // 0..1 → channel aftertouch (7-bit).
-                            const double v = std::clamp(ev->value, 0.0, 1.0);
+                            const double v = std::clamp(ev.value, 0.0, 1.0);
                             const uint8_t v7 = static_cast<uint8_t>(v * 127.0 + 0.5);
                             me = {choc::midi::ShortMessage(
                                 static_cast<uint8_t>(0xD0 | (channel & 0x0F)),
@@ -274,7 +289,7 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                             // member-bend default so the MpeVoiceTracker
                             // expands it back correctly.
                             const double norm = std::clamp(
-                                ev->value / static_cast<double>(
+                                ev.value / static_cast<double>(
                                     midi::MpeVoiceTracker::kDefaultMemberBendSemitones),
                                 -1.0, 1.0);
                             const int bend14 = static_cast<int>(
@@ -288,7 +303,7 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                         }
                         case CLAP_NOTE_EXPRESSION_BRIGHTNESS: {
                             // Brightness / timbre → CC 74.
-                            const double v = std::clamp(ev->value, 0.0, 1.0);
+                            const double v = std::clamp(ev.value, 0.0, 1.0);
                             const auto v7 = static_cast<uint8_t>(v * 127.0 + 0.5);
                             me = midi::MidiEvent::cc(channel, 74, v7);
                             me.sample_offset = t;
@@ -297,7 +312,7 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                         }
                         case CLAP_NOTE_EXPRESSION_VOLUME: {
                             // Volume (log domain in CLAP spec) → CC 7.
-                            const double v = std::clamp(ev->value, 0.0, 4.0);
+                            const double v = std::clamp(ev.value, 0.0, 4.0);
                             const auto v7 = static_cast<uint8_t>(
                                 (v / 4.0) * 127.0 + 0.5);
                             me = midi::MidiEvent::cc(channel, 7, v7);
@@ -307,7 +322,7 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                         }
                         case CLAP_NOTE_EXPRESSION_PAN: {
                             // 0..1 → CC 10.
-                            const double v = std::clamp(ev->value, 0.0, 1.0);
+                            const double v = std::clamp(ev.value, 0.0, 1.0);
                             const auto v7 = static_cast<uint8_t>(v * 127.0 + 0.5);
                             me = midi::MidiEvent::cc(channel, 10, v7);
                             me.sample_offset = t;
@@ -332,19 +347,19 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                 // CC, pitch bend, channel aftertouch, poly aftertouch,
                 // and program change. `port_index` is informational for
                 // multi-port plugins; single-port plugins accept all.
-                auto* ev = reinterpret_cast<const clap_event_midi_t*>(hdr);
+                const auto ev = load_event<clap_event_midi_t>(hdr);
                 midi::MidiEvent me{
-                    choc::midi::ShortMessage(ev->data[0], ev->data[1], ev->data[2]),
+                    choc::midi::ShortMessage(ev.data[0], ev.data[1], ev.data[2]),
                     static_cast<int32_t>(hdr->time),
                     0.0};
                 midi_in.add(me);
             } else if (hdr->type == CLAP_EVENT_MIDI_SYSEX) {
                 // Workstream 01 — route CLAP sysex into MidiBuffer's
                 // variable-length sidecar (issue #239).
-                auto* ev = reinterpret_cast<const clap_event_midi_sysex_t*>(hdr);
-                if (ev->buffer && ev->size > 0) {
+                const auto ev = load_event<clap_event_midi_sysex_t>(hdr);
+                if (ev.buffer && ev.size > 0) {
                     midi_in.add_sysex(
-                        std::vector<uint8_t>(ev->buffer, ev->buffer + ev->size),
+                        std::vector<uint8_t>(ev.buffer, ev.buffer + ev.size),
                         static_cast<int32_t>(hdr->time),
                         0.0);
                 }
@@ -358,12 +373,12 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
                 // #define), so we gate on CLAP_VERSION_GE(1,1,0), which
                 // is the release that introduced it.
                 if (self->ump_enabled) {
-                    auto* ev = reinterpret_cast<const clap_event_midi2_t*>(hdr);
+                    const auto ev = load_event<clap_event_midi2_t>(hdr);
                     midi::UmpPacket p{};
-                    p.words[0] = ev->data[0];
-                    p.words[1] = ev->data[1];
-                    p.words[2] = ev->data[2];
-                    p.words[3] = ev->data[3];
+                    p.words[0] = ev.data[0];
+                    p.words[1] = ev.data[1];
+                    p.words[2] = ev.data[2];
+                    p.words[3] = ev.data[3];
                     p.word_count = midi::UmpPacket::size_for_type(p.message_type());
                     self->ump_buffer.add(p, static_cast<int32_t>(hdr->time));
                     host_delivered_ump = true;

--- a/core/host/src/plugin_slot_clap.cpp
+++ b/core/host/src/plugin_slot_clap.cpp
@@ -234,10 +234,14 @@ public:
             // host UI; we drop them for now.
             if (ev->space_id == CLAP_CORE_EVENT_SPACE_ID
                 && ev->type == CLAP_EVENT_MIDI && self->out_midi_sink_) {
-                auto* m = reinterpret_cast<const clap_event_midi_t*>(ev);
+                // memcpy into a stack local to avoid UBSan "misaligned
+                // address" when ev isn't aligned to alignof(clap_event_midi_t).
+                // #688.
+                clap_event_midi_t m;
+                std::memcpy(&m, ev, sizeof(m));
                 pulp::midi::MidiEvent e;
                 e.sample_offset = (int32_t)ev->time;
-                e.message = choc::midi::ShortMessage(m->data[0], m->data[1], m->data[2]);
+                e.message = choc::midi::ShortMessage(m.data[0], m.data[1], m.data[2]);
                 self->out_midi_sink_->add(e);
             }
             return true;

--- a/test/test_events.cpp
+++ b/test/test_events.cpp
@@ -169,6 +169,32 @@ TEST_CASE("Timer basic operation", "[events][timer]") {
     }
 }
 
+// #687 — stop()/start() pairs repeatedly on the owner thread while the
+// event-loop thread is running timer dispatches. Pre-fix, start()'s
+// `alive_ = make_shared<>(...)` raced with schedule_next()'s
+// `auto alive = alive_;` read on the loop thread. Post-fix, alive_ is
+// gone — stop() bumps generation_ (atomic) so stale dispatches early
+// return. Under TSan this loop reliably surfaced the old race within
+// a couple of iterations; 50 iterations is a comfortable margin.
+TEST_CASE("Timer stop+start hammer (TSan-clean, #687)",
+          "[events][timer][tsan][issue-687]") {
+    EventLoop loop;
+    std::atomic<int> count{0};
+    Timer timer(loop, 1ms, [&] { count.fetch_add(1); }, true);
+    for (int i = 0; i < 50; ++i) {
+        timer.start();
+        // Let the loop run at least one dispatch before stopping.
+        std::this_thread::sleep_for(3ms);
+        timer.stop();
+        // Sleep long enough that any in-flight dispatch from this
+        // cycle fires (and hits the generation/active checks) before
+        // we hand start() a fresh cycle.
+        std::this_thread::sleep_for(2ms);
+    }
+    // No functional claim about count — this test exists for TSan.
+    SUCCEED("stop+start hammer completed without races");
+}
+
 // ── EventLoop lifecycle edges ───────────────────────────────────────────
 
 TEST_CASE("EventLoop destructor tolerates pending dispatches",


### PR DESCRIPTION
#687 — Timer::start() reassigning alive_ (shared_ptr<atomic<bool>>)
raced against schedule_next()'s read on the event-loop thread.
std::shared_ptr isn't thread-safe for concurrent read/write of the
same instance; the #414 fix (move reassignment into start()) was
incomplete because a prior-cycle dispatch lambda that passed its
active_ check just before stop(), then saw active_=true again after
start(), would call schedule_next() and read alive_ on the loop
thread while start() was writing it on main.

Replace the shared_ptr sentinel with an atomic<uint64_t> generation
counter. stop() bumps generation_; each dispatch lambda captures its
creation generation by value and returns early when the counter has
moved on. All cross-thread state is now atomic — no shared_ptr
accesses left to race on.

Add a TSan stop+start hammer test (test_events.cpp, tag [issue-687])
that iterates 50 cycles to keep TSan catching regressions.

#688 — reinterpret_cast<const clap_event_FOO_t*>(hdr) is UB when
hdr doesn't meet alignof(FOO). CLAP events are packed back-to-back
in host-supplied buffers, so e.g. a clap_event_note_t (alignof=8
due to `double velocity`) can land on a 4-byte boundary. UBSan
caught it at clap_adapter.cpp:200 via the existing "Mixed
CLAP_EVENT_MIDI2 + NOTE_ON" test.

Add a load_event<T>(hdr) helper in clap_adapter.cpp that memcpys
the event payload into a stack local (properly aligned), and
replace all 11 cast sites. Inline the same pattern at the 3 sites
in clap_entry.hpp's params_flush and the 1 site in
plugin_slot_clap.cpp's try_push callback. The existing test that
trips it is the regression guard — no new fixture needed.

Skill-Update: skip skill=clap reason="internal sanitizer-hygiene fix, no new consumer-facing gotcha"
Skill-Update: skip skill=hosting reason="internal sanitizer-hygiene fix, no new consumer-facing gotcha"
Skill-Update: skip skill=view-bridge reason="clap_entry.hpp maps to view-bridge but change is sanitizer-hygiene only, no view-bridge semantics affected"