### PR TITLE
harden(cli): curl timeouts + PULP_DEBUG phase markers (#682)

### DIFF
--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -636,3 +636,43 @@ TEST_CASE("pulp docs build-site resolves mkdocs.yml from project root",
     REQUIRE(combined.find("does not exist; use --config-file")
             == std::string::npos);
 }
+
+// #682 — PULP_DEBUG=1 must emit timestamped phase markers to stderr so
+// future "pulp hung at 0% CPU" reports pin themselves. Unset by default
+// it must stay silent so scripts that parse stderr aren't affected.
+TEST_CASE("PULP_DEBUG=1 surfaces phase markers to stderr (#682)",
+          "[cli][shellout][issue-682]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    // Disable the update-check network path so the test stays offline
+    // and deterministic — we're testing the instrumentation hook, not
+    // the network dependency.
+    pulp_setenv("PULP_UPDATE_CHECK_DISABLED", "1", 1);
+
+    SECTION("unset: stderr stays free of phase markers") {
+        pulp_unsetenv("PULP_DEBUG");
+        auto r = run_pulp({"version"});
+        REQUIRE(r.exit_code == 0);
+        REQUIRE(r.stderr_output.find("[pulp-debug") == std::string::npos);
+    }
+
+    SECTION("PULP_DEBUG=1: emits markers on stderr, not stdout") {
+        pulp_setenv("PULP_DEBUG", "1", 1);
+        auto r = run_pulp({"version"});
+        REQUIRE(r.exit_code == 0);
+        REQUIRE(r.stderr_output.find("[pulp-debug") != std::string::npos);
+        REQUIRE(r.stderr_output.find("update-banner") != std::string::npos);
+        REQUIRE(r.stdout_output.find("[pulp-debug") == std::string::npos);
+        pulp_unsetenv("PULP_DEBUG");
+    }
+
+    SECTION("PULP_DEBUG=0: treated as off, no markers") {
+        pulp_setenv("PULP_DEBUG", "0", 1);
+        auto r = run_pulp({"version"});
+        REQUIRE(r.exit_code == 0);
+        REQUIRE(r.stderr_output.find("[pulp-debug") == std::string::npos);
+        pulp_unsetenv("PULP_DEBUG");
+    }
+
+    pulp_unsetenv("PULP_UPDATE_CHECK_DISABLED");
+}

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -89,6 +89,25 @@ void print_warn(const std::string& msg) {
     std::cout << "  " << color::yellow() << "\xe2\x9a\xa0" << color::reset() << " " << msg << "\n";
 }
 
+// Timestamped phase marker for the `PULP_DEBUG=1` env. Silent by default.
+// Use at the top of any user-entrypoint phase that could plausibly hang,
+// so the next "`pulp` at 0% CPU with no output" report (#682) pins itself:
+// the user re-runs with PULP_DEBUG=1, and the last line printed before the
+// hang is the phase we blocked in.
+void pulp_debug(const char* phase) {
+    static const bool enabled = []() {
+        auto v = pulp::runtime::get_env("PULP_DEBUG");
+        return v && !v->empty() && *v != "0" && *v != "false";
+    }();
+    if (!enabled) return;
+    using clock = std::chrono::steady_clock;
+    static const auto start = clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        clock::now() - start).count();
+    std::cerr << "[pulp-debug " << std::setw(7) << ms << "ms] " << phase << "\n"
+              << std::flush;
+}
+
 // ── Shell Execution ───��─────────────────────────────────────────────────────
 
 int run(const std::string& cmd) {

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -38,6 +38,11 @@ void print_ok(const std::string& msg);
 void print_fail(const std::string& msg);
 void print_warn(const std::string& msg);
 
+// Phase-marker for `PULP_DEBUG=1` (stderr, timestamped). Silent otherwise.
+// Sprinkle at user-entrypoint phases that could plausibly hang so the next
+// hang report pins itself. See #682.
+void pulp_debug(const char* phase);
+
 // ── Shell Execution ─────────────────────────────────────────────────────────
 
 int run(const std::string& cmd);

--- a/tools/cli/cmd_build.cpp
+++ b/tools/cli/cmd_build.cpp
@@ -5,12 +5,14 @@
 #include <iostream>
 
 int cmd_build(const std::vector<std::string>& args) {
+    pulp_debug("cmd_build: enter");
     bool standalone_mode = false;
     auto project_root = resolve_active_project_root(&standalone_mode);
     if (project_root.empty()) {
         std::cerr << "Error: not in a Pulp project directory\n";
         return 1;
     }
+    pulp_debug("cmd_build: project root resolved");
 
     auto build_dir = project_root / "build";
     bool needs_configure = !fs::exists(build_dir / "CMakeCache.txt");
@@ -65,14 +67,17 @@ int cmd_build(const std::vector<std::string>& args) {
 
         // Standalone projects need CMAKE_PREFIX_PATH to find the SDK
         if (standalone_mode) {
+            pulp_debug("cmd_build: resolve SDK (standalone)");
             auto version = read_sdk_version(project_root);
             auto sdk_dir = read_sdk_path_hint(project_root);
             auto checkout_hint = read_sdk_checkout_hint(project_root);
             auto config = sdk_dir / "lib" / "cmake" / "Pulp" / "PulpConfig.cmake";
             if (sdk_dir.empty() || !fs::exists(config)) {
                 if (!checkout_hint.empty() && fs::exists(checkout_hint)) {
+                    pulp_debug("cmd_build: ensure_checkout_sdk");
                     sdk_dir = ensure_checkout_sdk(checkout_hint, version);
                 } else {
+                    pulp_debug("cmd_build: ensure_sdk (may download)");
                     sdk_dir = ensure_sdk(version);
                 }
             }
@@ -81,6 +86,7 @@ int cmd_build(const std::vector<std::string>& args) {
                 return 1;
             }
             configure_cmd += " -DCMAKE_PREFIX_PATH=" + sdk_dir.string();
+            pulp_debug("cmd_build: SDK resolved");
         }
 
         // JS engine selection
@@ -88,8 +94,10 @@ int cmd_build(const std::vector<std::string>& args) {
             configure_cmd += " -DPULP_JS_ENGINE=" + js_engine;
         }
 
+        pulp_debug("cmd_build: run configure (cmake)");
         int rc = run_with_spinner(configure_cmd, "Configuring");
         if (rc != 0) return rc;
+        pulp_debug("cmd_build: configure complete");
     }
 
     std::string build_cmd = "cmake --build " + build_dir.string();
@@ -99,6 +107,7 @@ int cmd_build(const std::vector<std::string>& args) {
         build_cmd += " " + arg;
     }
 
+    pulp_debug("cmd_build: run build (cmake --build)");
     int rc = run_with_spinner(build_cmd, "Building");
     if (rc != 0 || !watch_mode) return rc;
 

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -369,11 +369,13 @@ void maybe_complete_pending_upgrade() {
 // fail the real command.
 void maybe_emit_update_banner_and_refresh(const std::string& command) {
     try {
+        pulp_debug("update-banner: maybe_complete_pending_upgrade enter");
         // Pending-upgrade completion runs even for banner-blocked
         // commands so the user sees "upgrade complete" after the
         // swap — but only as a one-liner on stderr, which doesn't
         // corrupt machine-parseable stdout.
         maybe_complete_pending_upgrade();
+        pulp_debug("update-banner: maybe_complete_pending_upgrade exit");
 
         if (banner_blocked(command)) return;
 
@@ -382,12 +384,14 @@ void maybe_emit_update_banner_and_refresh(const std::string& command) {
         // Matches design Section G: "zero network calls".
         if (pulp::runtime::get_env("PULP_UPDATE_CHECK_DISABLED")) return;
 
+        pulp_debug("update-banner: read_update_mode");
         auto mode = read_update_mode();
         if (mode == um::Mode::Off) return;
 
         auto cache_path = banner_cache_path();
         if (cache_path.empty()) return;
 
+        pulp_debug("update-banner: read_cache_file");
         auto cache_opt = uc::read_cache_file(cache_path);
         uc::CacheEntry cache = cache_opt.value_or(uc::CacheEntry{});
 
@@ -460,8 +464,10 @@ void maybe_emit_update_banner_and_refresh(const std::string& command) {
 
         auto interval = read_check_interval_hours();
         if (uc::is_cache_stale(cache, now, interval)) {
+            pulp_debug("update-banner: kick_background_refresh (detached)");
             kick_background_refresh(cache_path);
         }
+        pulp_debug("update-banner: exit");
     } catch (...) {
         // Never let a banner bug break a user's actual command.
     }
@@ -491,7 +497,9 @@ int main(int argc, char* argv[]) {
         args.push_back(argv[i]);
     }
 
+    pulp_debug("main: update-banner enter");
     maybe_emit_update_banner_and_refresh(command);
+    pulp_debug("main: dispatch");
 
     // Lookup in command table
     for (int i = 0; i < command_count; ++i) {

--- a/tools/cli/update_check.cpp
+++ b/tools/cli/update_check.cpp
@@ -424,14 +424,21 @@ FetchResult GitHubReleasesFetcher::fetch_latest_release(const std::string& owner
     // stays constant across releases (helps their abuse-detection
     // heuristics treat us as one client, not N).
     std::string url = "https://api.github.com/repos/" + owner_repo + "/releases/latest";
+    // Timeouts matter: without them, a slow or black-holed network stalls
+    // the background refresh thread indefinitely. `cmd_upgrade` also calls
+    // this synchronously and would block the user's shell. 5s to connect +
+    // 15s wall ceiling is plenty for a single GitHub API GET and matches
+    // other CLI install scripts in the repo (#682).
 #ifdef _WIN32
     // PowerShell path — curl is present on Win10+, but Invoke-WebRequest
     // is the native fallback. Keep the stderr redirect so background
     // output stays quiet.
-    std::string cmd = "curl -fsSL -A \"pulp-cli\" -H \"Accept: application/vnd.github+json\" \"" +
+    std::string cmd = "curl -fsSL --connect-timeout 5 --max-time 15 "
+                      "-A \"pulp-cli\" -H \"Accept: application/vnd.github+json\" \"" +
                       url + "\" 2>NUL";
 #else
-    std::string cmd = "curl -fsSL -A 'pulp-cli' -H 'Accept: application/vnd.github+json' '" +
+    std::string cmd = "curl -fsSL --connect-timeout 5 --max-time 15 "
+                      "-A 'pulp-cli' -H 'Accept: application/vnd.github+json' '" +
                       url + "' 2>/dev/null";
 #endif
     auto body = run_capture(cmd);


### PR DESCRIPTION
Two small changes to make future "pulp hung at 0% CPU" reports
pin themselves, and to close one real latent hang path:

1. `update_check.cpp::fetch_latest_release` — add `--connect-timeout 5
   --max-time 15` to the curl invocation. Currently only called from a
   detached thread (so it didn't block main), but `cmd_upgrade` calls
   it synchronously and a slow/black-holed network would stall the
   user's shell indefinitely. 5s connect + 15s wall ceiling matches
   other CLI scripts in the repo.

2. `pulp_debug(const char* phase)` — timestamped phase marker helper
   in cli_common. Silent by default; `PULP_DEBUG=1` emits
   `[pulp-debug  <ms>ms] <phase>` to stderr. Sprinkled at
   user-entrypoints that could plausibly hang:
     - main: update-banner enter, dispatch
     - update-banner: maybe_complete_pending_upgrade enter/exit,
       read_update_mode, read_cache_file,
       kick_background_refresh, exit
     - cmd_build: enter, project root resolved, SDK resolve,
       configure (cmake), build (cmake --build)
   Next hang report sets PULP_DEBUG=1 and the last line emitted is
   the phase we're stuck in. Cheap to keep in, useful on demand.

Shellout test asserts PULP_DEBUG=1 emits markers on stderr (not
stdout), PULP_DEBUG=0 / unset stays silent, update-banner phase
markers are present in the stream. Catches regressions in both
the env gating and the instrumentation hook.

No root-cause fix for #682 yet — we can't reproduce the hang
without a live `sample <pid>`. These changes make the next
occurrence diagnosable in one run and remove one of the two
plausible blocking paths.

Skill-Update: skip skill=cli-maintenance reason="diagnostic/hardening addition: PULP_DEBUG env + curl timeouts; no new CLI command or surface"