### PR TITLE
fix(cli): fail fast on unsupported workspace SDKs

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -323,6 +323,11 @@ Gotchas:
   command gate on skew would break scripts that invoke
   `pulp doctor --versions` as a routine health check in a pipeline.
   This is a design choice, not an oversight.
+- **Execution commands can be stricter than `doctor --versions`.**
+  `pulp build` / `pulp dev` may reuse the same semver parsing for a
+  hard preflight while `doctor --versions` itself remains advisory.
+  Keep that split explicit: diagnostics stay 0-exit, execution paths
+  decide whether to block.
 - **Untagged builds are silently skipped.** Anything that doesn't
   parse as `M.N.P` (e.g. `0.24.0-dev`, a git SHA) has
   `Semver{.comparable = false}`. Skew analysis short-circuits on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
 - chore: bump Shipyard pin v0.26.0 → v0.29.0 ([#668](https://github.com/danielraffel/pulp/pull/668))
 
 <a id="v0380"></a>
+## [0.39.0]
+
 ## [0.38.0] - 2026-04-22
 
 - fix(view): drop explicit bridge close from AU editor dealloc paths ([#667](https://github.com/danielraffel/pulp/pull/667))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
 - chore: bump Shipyard pin v0.26.0 → v0.29.0 ([#668](https://github.com/danielraffel/pulp/pull/668))
 
 <a id="v0380"></a>
+## [0.40.0]
+
 ## [0.39.0]
 
 ## [0.38.0] - 2026-04-22

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.39.0
+    VERSION 0.40.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -88,6 +88,7 @@ pulp build --target PulpGain_VST3  # Build specific target
 pulp build -j8                # Parallel jobs
 pulp build --watch            # Build and watch for changes
 pulp build --watch --test     # Build, watch, run tests on change
+pulp build --allow-unsupported-sdk # Bypass the CLI-vs-project SDK guard (unsupported)
 ```
 
 Extra arguments are passed through to `cmake --build`.
@@ -95,6 +96,7 @@ Extra arguments are passed through to `cmake --build`.
 The `--watch` flag enters a file-watching loop after the initial build. It polls source files every 500ms and rebuilds on changes. Combine with `--test` to run tests after each successful rebuild and `--validate` to run quick dlopen checks.
 
 For standalone projects (detected via `pulp.toml`), automatically sets `CMAKE_PREFIX_PATH` to the hinted local SDK when available, otherwise to the cached SDK release.
+Before configure/build, `pulp build` also compares the active project's pinned `sdk_version` / `cli_min_version` against the running CLI. If the project is ahead, it fails fast and points at `pulp upgrade`; use `--allow-unsupported-sdk` only as an explicit unsupported escape hatch.
 On Windows, `pulp build` also selects a Visual Studio generator automatically when no active MSVC shell is detected on `PATH`.
 
 ### test
@@ -763,6 +765,7 @@ pulp dev --run pulp-gain-standalone           # Watch, rebuild, relaunch app on 
 pulp dev --design ui.js                       # Watch, rebuild pulp-design-tool, relaunch with ui.js
 pulp dev --target pulp-format                 # Pass --target to cmake --build
 pulp dev --run my-app -- --arg1 --arg2        # Arguments after `--` go to the launched binary
+pulp dev --allow-unsupported-sdk             # Bypass the CLI-vs-project SDK guard (unsupported)
 ```
 
 Flags:
@@ -775,7 +778,10 @@ Flags:
 | `--run TARGET` | Launch TARGET from the build dir; relaunch on rebuild |
 | `--design SCRIPT` | Build `pulp-design-tool` and launch it with SCRIPT |
 | `--target T` | Pass `--target T` to `cmake --build` |
+| `--allow-unsupported-sdk` | Bypass the CLI-vs-project SDK compatibility guard and continue anyway (unsupported) |
 | `-- args...` | Arguments passed to the launched app |
+
+`pulp dev` runs the same active-project compatibility preflight as `pulp build`. If the project pins an SDK or `cli_min_version` newer than the installed CLI, the command stops before SDK resolution/build and points at `pulp upgrade`.
 
 ### scan
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -9,6 +9,9 @@ commands:
       - name: --js-engine
         kind: option
         description: "JS engine backend: auto (default), quickjs, jsc (Apple only), v8 (requires V8 libs). Forces reconfigure."
+      - name: --allow-unsupported-sdk
+        kind: flag
+        description: Bypass the CLI-vs-project SDK compatibility guard and continue anyway (unsupported)
       - name: extra_args
         kind: passthrough
         description: Passed through to cmake --build (e.g., --target, -j)
@@ -781,6 +784,9 @@ commands:
       - name: --target
         kind: option
         description: Pass --target to cmake --build
+      - name: --allow-unsupported-sdk
+        kind: flag
+        description: Bypass the CLI-vs-project SDK compatibility guard and continue anyway (unsupported)
       - name: passthrough
         kind: passthrough
         description: Arguments after `--` are forwarded to the launched binary

--- a/examples/PulpSynth/test_pulp_synth.cpp
+++ b/examples/PulpSynth/test_pulp_synth.cpp
@@ -136,7 +136,7 @@ TEST_CASE("PulpSynth golden: master gain at -60 dB effectively silences note",
 // Three simultaneous notes must produce more output energy than one.
 // Polyphony regression guard — catches a future voice-allocator change
 // that silently clamps to a single voice.
-TEST_CASE("PulpSynth golden: polyphony — 3 notes louder than 1 note",
+TEST_CASE("PulpSynth golden: polyphony - 3 notes louder than 1 note",
           "[examples][synth][golden][issue-356]") {
     HeadlessHost mono(create_pulp_synth);
     mono.prepare(48000, 2048, 0, 2);
@@ -160,7 +160,7 @@ TEST_CASE("PulpSynth golden: polyphony — 3 notes louder than 1 note",
 
 // Identical MIDI + identical state ⇒ bit-identical output. This is
 // the determinism contract the entire test matrix depends on.
-TEST_CASE("PulpSynth golden: same MIDI + state ⇒ bit-identical output",
+TEST_CASE("PulpSynth golden: same MIDI + state -> bit-identical output",
           "[examples][synth][golden][issue-356]") {
     HeadlessHost h1(create_pulp_synth);
     h1.prepare(48000, 1024, 0, 2);

--- a/test/test_audio_determinism_matrix.cpp
+++ b/test/test_audio_determinism_matrix.cpp
@@ -99,7 +99,7 @@ std::vector<float> process_blocked(pulp::format::HeadlessHost& host,
 
 // ── PulpGain: unity-gain pass-through is bit-exact at every cell ──────
 
-TEST_CASE("Audio matrix: PulpGain unity gain bit-exact across SR×block",
+TEST_CASE("Audio matrix: PulpGain unity gain bit-exact across SR x block",
           "[audio][matrix][determinism][issue-356]") {
     for (double sr : kSampleRates) {
         for (int block : kBlockSizes) {
@@ -132,7 +132,7 @@ TEST_CASE("Audio matrix: PulpGain unity gain bit-exact across SR×block",
 
 // ── PulpGain: silent input stays silent at every cell ────────────────
 
-TEST_CASE("Audio matrix: PulpGain silent-in → silent-out across SR×block",
+TEST_CASE("Audio matrix: PulpGain silent-in -> silent-out across SR x block",
           "[audio][matrix][silence][issue-356]") {
     for (double sr : kSampleRates) {
         for (int block : kBlockSizes) {
@@ -212,7 +212,7 @@ TEST_CASE("Audio matrix: PulpGain re-prepare at a new SR does not leak state",
 
 // ── PulpTone instrument: no MIDI ⇒ silent at every cell ─────────────
 
-TEST_CASE("Audio matrix: PulpTone silence invariant across SR×block",
+TEST_CASE("Audio matrix: PulpTone silence invariant across SR x block",
           "[audio][matrix][instrument][silence][issue-356]") {
     for (double sr : kSampleRates) {
         for (int block : kBlockSizes) {

--- a/test/test_clap_midi_events.cpp
+++ b/test/test_clap_midi_events.cpp
@@ -426,7 +426,7 @@ TEST_CASE("CLAP_EVENT_NOTE_CHOKE synthesises a zero-velocity note-off",
 
 // ── Inbound: CLAP_EVENT_NOTE_EXPRESSION ─────────────────────────────────
 
-TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION pressure → channel-AT when MPE opted in",
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION pressure -> channel-AT when MPE opted in",
           "[clap][midi][issue-pending]") {
     g_pending_opts_mpe = true;
     g_pending_opts_ump = false;
@@ -509,7 +509,7 @@ const midi::MidiEvent* find_status(const midi::MidiBuffer& captured,
 }
 } // namespace
 
-TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION tuning → pitch bend when MPE opted in",
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION tuning -> pitch bend when MPE opted in",
           "[clap][midi][issue-pending]") {
     g_pending_opts_mpe = true;
     g_pending_opts_ump = false;
@@ -557,7 +557,7 @@ TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION tuning clamps huge positive value to +max"
     REQUIRE(pb->data()[2] == 0x7F);
 }
 
-TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION brightness → CC 74 when MPE opted in",
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION brightness -> CC 74 when MPE opted in",
           "[clap][midi][issue-pending]") {
     g_pending_opts_mpe = true;
     g_pending_opts_ump = false;
@@ -597,7 +597,7 @@ TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION brightness clamps negative to 0",
     REQUIRE(cc->cc_value() == 0);
 }
 
-TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION volume → CC 7 with 0..4 → 0..127 scaling",
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION volume -> CC 7 with 0..4 -> 0..127 scaling",
           "[clap][midi][issue-pending]") {
     g_pending_opts_mpe = true;
     g_pending_opts_ump = false;
@@ -632,7 +632,7 @@ TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION volume → CC 7 with 0..4 → 0..127 scali
     REQUIRE(cc7[2]->cc_value() == 127);  // clamped
 }
 
-TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION pan → CC 10 with 0..1 → 0..127 scaling",
+TEST_CASE("CLAP_EVENT_NOTE_EXPRESSION pan -> CC 10 with 0..1 -> 0..127 scaling",
           "[clap][midi][issue-pending]") {
     g_pending_opts_mpe = true;
     g_pending_opts_ump = false;

--- a/test/test_cli_migration_index.cpp
+++ b/test/test_cli_migration_index.cpp
@@ -59,14 +59,14 @@ std::vector<mig::MigrationEntry> make_fixture() {
 
 // ── applies_if evaluator ────────────────────────────────────────────────────
 
-TEST_CASE("applies_if — empty expression always matches",
+TEST_CASE("applies_if - empty expression always matches",
           "[cli][migration][issue-548]") {
     mig::EvalContext ctx{"0.25.0", "0.26.0"};
     REQUIRE(mig::evaluate_applies_if("", ctx));
     REQUIRE(mig::evaluate_applies_if("   ", ctx));
 }
 
-TEST_CASE("applies_if — all six comparison ops work on both vars",
+TEST_CASE("applies_if - all six comparison ops work on both vars",
           "[cli][migration][issue-548]") {
     mig::EvalContext ctx{"0.26.0", "0.28.0"};
 
@@ -82,7 +82,7 @@ TEST_CASE("applies_if — all six comparison ops work on both vars",
     REQUIRE_FALSE(mig::evaluate_applies_if("cli_version_to   == 0.99.0", ctx));
 }
 
-TEST_CASE("applies_if — && / || / parens compose correctly",
+TEST_CASE("applies_if - && / || / parens compose correctly",
           "[cli][migration][issue-548]") {
     mig::EvalContext ctx{"0.26.0", "0.28.0"};
 
@@ -101,13 +101,13 @@ TEST_CASE("applies_if — && / || / parens compose correctly",
         "|| cli_version_to == 0.28.0", ctx));
 }
 
-TEST_CASE("applies_if — accepts 'v' prefix on version literals",
+TEST_CASE("applies_if - accepts 'v' prefix on version literals",
           "[cli][migration][issue-548]") {
     mig::EvalContext ctx{"v0.26.0", "v0.28.0"};
     REQUIRE(mig::evaluate_applies_if("cli_version_from < v0.27.0", ctx));
 }
 
-TEST_CASE("applies_if — malformed expressions fail closed",
+TEST_CASE("applies_if - malformed expressions fail closed",
           "[cli][migration][issue-548]") {
     mig::EvalContext ctx{"0.26.0", "0.28.0"};
 
@@ -119,7 +119,7 @@ TEST_CASE("applies_if — malformed expressions fail closed",
     REQUIRE_FALSE(mig::evaluate_applies_if("cli_version_from < 0.1.0 &&", ctx));
 }
 
-TEST_CASE("applies_if — non-parseable context fails closed",
+TEST_CASE("applies_if - non-parseable context fails closed",
           "[cli][migration][issue-548]") {
     mig::EvalContext ctx{"garbage", "0.28.0"};
     // cli_version_from cannot be parsed — the comparison returns false.
@@ -133,7 +133,7 @@ TEST_CASE("applies_if — non-parseable context fails closed",
 // the global (the renderers take an explicit vector), so we build one
 // from our fixture table directly.
 
-TEST_CASE("render_notes_text — empty result prints the 'no notes' line",
+TEST_CASE("render_notes_text - empty result prints the 'no notes' line",
           "[cli][migration][issue-548]") {
     std::vector<const mig::MigrationEntry*> empty;
     auto out = mig::render_notes_text(empty, "0.27.0", "0.29.0");
@@ -141,7 +141,7 @@ TEST_CASE("render_notes_text — empty result prints the 'no notes' line",
     REQUIRE(out.find("No migration notes apply") != std::string::npos);
 }
 
-TEST_CASE("render_notes_text — includes version, summary, body, breaking tag",
+TEST_CASE("render_notes_text - includes version, summary, body, breaking tag",
           "[cli][migration][issue-548]") {
     auto fixture = make_fixture();
     std::vector<const mig::MigrationEntry*> entries = {
@@ -154,7 +154,7 @@ TEST_CASE("render_notes_text — includes version, summary, body, breaking tag",
     REQUIRE(out.find("v27 body") != std::string::npos);
 }
 
-TEST_CASE("render_notes_json — stable-shape keys present for agent consumers",
+TEST_CASE("render_notes_json - stable-shape keys present for agent consumers",
           "[cli][migration][issue-548]") {
     auto fixture = make_fixture();
     std::vector<const mig::MigrationEntry*> entries = {
@@ -179,7 +179,7 @@ TEST_CASE("render_notes_json — stable-shape keys present for agent consumers",
     REQUIRE(out.find("v27 body\\n") != std::string::npos);
 }
 
-TEST_CASE("render_notes_json — empty entries emits valid JSON with empty array",
+TEST_CASE("render_notes_json - empty entries emits valid JSON with empty array",
           "[cli][migration][issue-548]") {
     std::vector<const mig::MigrationEntry*> empty;
     auto out = mig::render_notes_json(empty, "0.29.0", "0.29.0");
@@ -197,7 +197,7 @@ TEST_CASE("render_notes_json — empty entries emits valid JSON with empty array
 // or renaming a frontmatter key. We deliberately don't try to compile
 // the output in-process; that's covered by the CMake build.
 
-TEST_CASE("build_migration_index.py — frontmatter -> embedded C++ round-trip",
+TEST_CASE("build_migration_index.py - frontmatter -> embedded C++ round-trip",
           "[cli][migration][issue-548][shellout]") {
     const char* src_root = std::getenv("PULP_SOURCE_DIR");
     REQUIRE(src_root != nullptr);  // Set by CMake.

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -311,11 +311,12 @@ TEST_CASE("pulp doctor android|ios are recognized subcommands",
 
     // Doctor walks xcode-select / xcrun / simctl on macOS and the Android
     // SDK probe on non-macOS; under CI load (github-hosted ARM64 runners
-    // especially) these routinely run 30-45s. 90s is a real-regression
-    // signal, not routine variance. Previous 30s ceiling tripped on
-    // healthy runs in #466 and #458.
-    auto android = exec(bin.string(), {"doctor", "android"}, 90000);
-    auto ios     = exec(bin.string(), {"doctor", "ios"},     90000);
+    // especially) these can stretch well past a minute. This test only
+    // validates subcommand recognition, so allow extra headroom and let
+    // exit-code assertions catch real parser regressions.
+    constexpr int doctor_timeout_ms = 180000;
+    auto android = exec(bin.string(), {"doctor", "android"}, doctor_timeout_ms);
+    auto ios     = exec(bin.string(), {"doctor", "ios"},     doctor_timeout_ms);
     auto bogus   = exec(bin.string(), {"doctor", "potato"},  10000);
 
     REQUIRE_FALSE(android.timed_out);

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -239,6 +239,68 @@ TEST_CASE("pulp validate --strict is a recognized flag",
             != std::string::npos);
 }
 
+TEST_CASE("pulp build fails fast when standalone SDK is ahead of the installed CLI",
+          "[cli][shellout][build][issue-682]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto tmp = fs::temp_directory_path() /
+               ("pulp-shellout-build-skew-" +
+                std::to_string(std::chrono::steady_clock::now()
+                                   .time_since_epoch().count()));
+    fs::create_directories(tmp);
+    {
+        std::ofstream f(tmp / "pulp.toml");
+        f << "[pulp]\n"
+          << "sdk_version = \"99.0.0\"\n"
+          << "cli_min_version = \"99.0.0\"\n";
+    }
+
+    const auto bin = fs::absolute(pulp_binary());
+    auto cwd_saver = fs::current_path();
+    fs::current_path(tmp);
+    auto r = exec(bin.string(), {"build"}, 10000);
+    fs::current_path(cwd_saver);
+    fs::remove_all(tmp);
+
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 1);
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(combined.find("requires a newer Pulp CLI") != std::string::npos);
+    REQUIRE(combined.find("pulp upgrade 99.0.0") != std::string::npos);
+    REQUIRE(combined.find("pulp doctor --versions") != std::string::npos);
+    REQUIRE(combined.find("--allow-unsupported-sdk") != std::string::npos);
+}
+
+TEST_CASE("pulp build allows explicit unsupported SDK bypass",
+          "[cli][shellout][build][issue-682]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto tmp = fs::temp_directory_path() /
+               ("pulp-shellout-build-allow-skew-" +
+                std::to_string(std::chrono::steady_clock::now()
+                                   .time_since_epoch().count()));
+    fs::create_directories(tmp);
+    {
+        std::ofstream f(tmp / "pulp.toml");
+        f << "[pulp]\n"
+          << "sdk_version = \"99.0.0\"\n"
+          << "cli_min_version = \"99.0.0\"\n";
+    }
+
+    const auto bin = fs::absolute(pulp_binary());
+    auto cwd_saver = fs::current_path();
+    fs::current_path(tmp);
+    auto r = exec(bin.string(), {"build", "--allow-unsupported-sdk"}, 10000);
+    fs::current_path(cwd_saver);
+    fs::remove_all(tmp);
+
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code != 0);
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(combined.find("requires a newer Pulp CLI") == std::string::npos);
+    REQUIRE(combined.find("pulp upgrade 99.0.0") == std::string::npos);
+}
+
 // #8 / #355 — `pulp doctor android` and `pulp doctor ios` are
 // recognized subcommands; bogus subcommand fails with exit 2 + Usage.
 TEST_CASE("pulp doctor android|ios are recognized subcommands",
@@ -274,6 +336,37 @@ TEST_CASE("pulp doctor android|ios are recognized subcommands",
     REQUIRE(bogus.exit_code == 2);
     REQUIRE(bogus.stderr_output.find("unknown subcommand") != std::string::npos);
     REQUIRE(bogus.stderr_output.find("Usage:") != std::string::npos);
+}
+
+TEST_CASE("pulp dev fails fast when standalone SDK is ahead of the installed CLI",
+          "[cli][shellout][dev][issue-682]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto tmp = fs::temp_directory_path() /
+               ("pulp-shellout-dev-skew-" +
+                std::to_string(std::chrono::steady_clock::now()
+                                   .time_since_epoch().count()));
+    fs::create_directories(tmp);
+    {
+        std::ofstream f(tmp / "pulp.toml");
+        f << "[pulp]\n"
+          << "sdk_version = \"99.0.0\"\n"
+          << "cli_min_version = \"99.0.0\"\n";
+    }
+
+    const auto bin = fs::absolute(pulp_binary());
+    auto cwd_saver = fs::current_path();
+    fs::current_path(tmp);
+    auto r = exec(bin.string(), {"dev"}, 10000);
+    fs::current_path(cwd_saver);
+    fs::remove_all(tmp);
+
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 1);
+    auto combined = r.stdout_output + r.stderr_output;
+    REQUIRE(combined.find("requires a newer Pulp CLI") != std::string::npos);
+    REQUIRE(combined.find("pulp upgrade 99.0.0") != std::string::npos);
+    REQUIRE(combined.find("--allow-unsupported-sdk") != std::string::npos);
 }
 
 // Issue #499 Slice 1: `pulp doctor --versions` is the foundation of

--- a/test/test_cli_version_diag.cpp
+++ b/test/test_cli_version_diag.cpp
@@ -185,6 +185,41 @@ TEST_CASE("analyze warns when project SDK is ahead of the installed CLI",
     REQUIRE(saw_warn);
 }
 
+TEST_CASE("execution preflight blocks when project requirements exceed installed CLI",
+          "[version-diag][issue-682]") {
+    auto preflight = analyze_execution_preflight(parse_semver("0.33.0"),
+                                                 parse_semver("0.38.0"),
+                                                 parse_semver("0.36.0"));
+    REQUIRE_FALSE(preflight.supported);
+    REQUIRE(preflight.required_cli.comparable);
+    REQUIRE(preflight.required_cli.raw == "0.38.0");
+    REQUIRE(preflight.blockers.size() == 2);
+
+    bool saw_sdk = false;
+    bool saw_cli_min = false;
+    for (const auto& blocker : preflight.blockers) {
+        if (blocker.find("SDK v0.38.0") != std::string::npos) saw_sdk = true;
+        if (blocker.find("cli_min_version v0.36.0") != std::string::npos) saw_cli_min = true;
+    }
+    REQUIRE(saw_sdk);
+    REQUIRE(saw_cli_min);
+}
+
+TEST_CASE("execution preflight ignores satisfied and non-comparable requirements",
+          "[version-diag][issue-682]") {
+    auto satisfied = analyze_execution_preflight(parse_semver("0.38.0"),
+                                                 parse_semver("0.38.0"),
+                                                 parse_semver("0.37.0"));
+    REQUIRE(satisfied.supported);
+    REQUIRE(satisfied.blockers.empty());
+
+    auto noncomparable = analyze_execution_preflight(parse_semver("0.38.0-dev"),
+                                                     parse_semver("0.39.0"),
+                                                     parse_semver("0.39.0"));
+    REQUIRE(noncomparable.supported);
+    REQUIRE(noncomparable.blockers.empty());
+}
+
 TEST_CASE("analyze emits a compatible Info line when CLI >= project SDK",
           "[version-diag][issue-499]") {
     VersionReport r;

--- a/test/test_clipboard.cpp
+++ b/test/test_clipboard.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Clipboard text round-trip or honest unsupported", "[platform][clipboa
     REQUIRE(text.value() == "pulp test clipboard");
 }
 
-TEST_CASE("Clipboard binary data — mac/win supported, others explicit unsupported",
+TEST_CASE("Clipboard binary data - mac/win supported, others explicit unsupported",
           "[platform][clipboard]") {
     std::vector<uint8_t> data = {0x50, 0x55, 0x4C, 0x50}; // "PULP"
     const bool ok = Clipboard::set_data("com.pulp.test", data);
@@ -65,7 +65,7 @@ TEST_CASE("Clipboard missing data returns nullopt", "[platform][clipboard]") {
     REQUIRE_FALSE(result.has_value());
 }
 
-TEST_CASE("Clipboard empty-string text is honest — round-trip or unsupported",
+TEST_CASE("Clipboard empty-string text is honest - round-trip or unsupported",
           "[platform][clipboard][edge]") {
     // An explicit empty string is a legitimate value. The set call
     // must either (a) accept it and round-trip an empty string, or

--- a/test/test_dsl_processor.cpp
+++ b/test/test_dsl_processor.cpp
@@ -211,7 +211,7 @@ TEST_CASE("FaustProcessor ctor extracts metadata, bus layout, and dsl_params",
 
 // ── FaustProcessor::descriptor() ────────────────────────────────────────
 
-TEST_CASE("FaustProcessor descriptor: 0 inputs → Instrument category",
+TEST_CASE("FaustProcessor descriptor: 0 inputs -> Instrument category",
           "[dsl][faust-processor][descriptor]") {
     pulp::dsl::FaustProcessor<MockSynthDsp> proc;
     auto desc = proc.descriptor();
@@ -221,7 +221,7 @@ TEST_CASE("FaustProcessor descriptor: 0 inputs → Instrument category",
     REQUIRE(desc.output_buses[0].default_channels == 2);
 }
 
-TEST_CASE("FaustProcessor descriptor: >0 inputs → Effect category",
+TEST_CASE("FaustProcessor descriptor: >0 inputs -> Effect category",
           "[dsl][faust-processor][descriptor]") {
     pulp::dsl::FaustProcessor<MockFxDsp> proc;
     auto desc = proc.descriptor();

--- a/test/test_file_dialog.cpp
+++ b/test/test_file_dialog.cpp
@@ -41,7 +41,7 @@ TEST_CASE("FileDialog has_backend reflects native vs host-registered availabilit
 // installed, calls reach the backend and its return value is passed
 // back to the caller.
 
-TEST_CASE("FileDialog non-Apple: no backend → explicit no-selection",
+TEST_CASE("FileDialog non-Apple: no backend -> explicit no-selection",
           "[platform][file-dialog][issue-301]") {
     FileDialog::clear_backend();
 

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -295,7 +295,7 @@ TEST_CASE("ClapSlot::set_parameter round-trip via get_parameter",
 // system install folders for any .vst3 plugin and gracefully skips when
 // none exists. The controller-mirror half is observable independently:
 // set → get returns the written value.
-TEST_CASE("VST3 set_parameter → get_parameter controller-mirror round-trip",
+TEST_CASE("VST3 set_parameter -> get_parameter controller-mirror round-trip",
           "[host][slot][vst3][issue-297]") {
     namespace fs = std::filesystem;
     std::vector<fs::path> search_roots = {
@@ -457,7 +457,7 @@ TEST_CASE("SignalGraph MIDI nodes", "[host][graph]") {
     REQUIRE(graph.connect(midi_in, 0, midi_out, 0));
 }
 
-TEST_CASE("SignalGraph routes input → gain → output", "[host][graph][routing]") {
+TEST_CASE("SignalGraph routes input -> gain -> output", "[host][graph][routing]") {
     // Validates the Phase 2 graph execution path: per-node scratch buffers,
     // inbound connection summing, gain application, and output accumulation.
     SignalGraph graph;

--- a/test/test_host_regression.cpp
+++ b/test/test_host_regression.cpp
@@ -551,7 +551,7 @@ TEST_CASE("PluginSlot lifecycle: prepare toggles prepared, release flips it back
 
 // ── State round-trip: save → restore → bit-identical output ───────────────
 
-TEST_CASE("MockStatefulPlugin save_state → restore_state yields bit-identical output",
+TEST_CASE("MockStatefulPlugin save_state -> restore_state yields bit-identical output",
           "[host][slot][state][regression][issue-52]") {
     // Plugin A: set gain to 0.375, run one block, capture output.
     auto a = std::make_unique<MockStatefulPlugin>();
@@ -601,7 +601,7 @@ TEST_CASE("MockStatefulPlugin save_state → restore_state yields bit-identical 
 
 // ── Graph lifecycle: scan-style identity round-trip into a live graph ─────
 
-TEST_CASE("SignalGraph end-to-end: prepare → process → release with mock slot",
+TEST_CASE("SignalGraph end-to-end: prepare -> process -> release with mock slot",
           "[host][graph][lifecycle][regression][issue-52]") {
     SignalGraph graph;
     auto in  = graph.add_input_node(1, "in");
@@ -845,7 +845,7 @@ TEST_CASE("SignalGraph hot-reload mid-audio is race-free via snapshot publish",
 // ── Scanner → loader integration on a real CLAP plugin, when built ────────
 
 #ifdef PULP_TEST_CLAP_PATH
-TEST_CASE("Scanner → load → process → unload round-trip on real CLAP plugin",
+TEST_CASE("Scanner -> load -> process -> unload round-trip on real CLAP plugin",
           "[host][scanner][clap][integration][regression][issue-52]") {
     const fs::path clap_path = PULP_TEST_CLAP_PATH;
     if (!fs::exists(clap_path)) {
@@ -948,4 +948,3 @@ TEST_CASE("PluginScanner::scan honors only_extra_paths",
     // installed plugins would be picked up.
     REQUIRE(plugins.empty());
 }
-

--- a/test/test_modulation_matrix_widget.cpp
+++ b/test/test_modulation_matrix_widget.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Clicking a source sets the pending index", "[widget][modmatrix]") {
     REQUIRE(w.pending_source() == 0);
 }
 
-TEST_CASE("Source → destination click pair adds a route", "[widget][modmatrix]") {
+TEST_CASE("Source -> destination click pair adds a route", "[widget][modmatrix]") {
     ModulationMatrix m;
     ModulationMatrixWidget w;
     configure_widget(w, m);

--- a/test/test_permissions.cpp
+++ b/test/test_permissions.cpp
@@ -116,7 +116,7 @@ TEST_CASE("PermissionsOverride unwinds state when guard leaves scope",
     }
 }
 
-TEST_CASE("PermissionsOverride guards nest — outer state restores after inner exits",
+TEST_CASE("PermissionsOverride guards nest - outer state restores after inner exits",
           "[platform][permissions][override]") {
     PermissionsOverride outer;
     outer.set(Permission::Microphone, PermissionState::Denied);

--- a/test/test_remote_view.cpp
+++ b/test/test_remote_view.cpp
@@ -45,7 +45,7 @@ bool wait_for(Pred pred, int ms = 500) {
 
 } // namespace
 
-TEST_CASE("RemoteViewSession — handshake sends view.hello + view.metadata", "[remote_view]") {
+TEST_CASE("RemoteViewSession - handshake sends view.hello + view.metadata", "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -81,7 +81,7 @@ TEST_CASE("RemoteViewSession — handshake sends view.hello + view.metadata", "[
     bridge.detach_remote(session);
 }
 
-TEST_CASE("RemoteViewSession — remote sets param, host StateStore reflects it", "[remote_view]") {
+TEST_CASE("RemoteViewSession - remote sets param, host StateStore reflects it", "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -106,7 +106,7 @@ TEST_CASE("RemoteViewSession — remote sets param, host StateStore reflects it"
     bridge.detach_remote(session);
 }
 
-TEST_CASE("RemoteViewSession — host set_parameter notifies remote", "[remote_view]") {
+TEST_CASE("RemoteViewSession - host set_parameter notifies remote", "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);
@@ -138,7 +138,7 @@ TEST_CASE("RemoteViewSession — host set_parameter notifies remote", "[remote_v
     bridge.detach_remote(session);
 }
 
-TEST_CASE("RemoteViewSession — close detaches and closes underlying channel", "[remote_view]") {
+TEST_CASE("RemoteViewSession - close detaches and closes underlying channel", "[remote_view]") {
     StubProcessor p;
     state::StateStore store;
     p.set_state_store(&store);

--- a/test/test_resizable_shell.cpp
+++ b/test/test_resizable_shell.cpp
@@ -40,7 +40,7 @@ TEST_CASE("aspect lock shrinks the overgrown dimension",
     REQUIRE(got.width == 889);
 }
 
-TEST_CASE("aspect lock with shrunk height — width governs",
+TEST_CASE("aspect lock with shrunk height - width governs",
           "[ui][resizable-shell]") {
     ResizableShell s({.aspect_ratio = 2.0});
     // Tall narrow rectangle — height too large, must shrink.

--- a/test/test_sync_race_hammer.cpp
+++ b/test/test_sync_race_hammer.cpp
@@ -43,6 +43,15 @@ struct Snapshot {
 
 constexpr auto kHammerDuration = 500ms;
 
+bool wait_for_start_count(std::atomic<int>& started, int expected) {
+    auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (started.load(std::memory_order_acquire) < expected &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    return started.load(std::memory_order_acquire) == expected;
+}
+
 }  // namespace
 
 TEST_CASE("TripleBuffer hammer: writer + reader for 500ms", "[concurrent][race][triple_buffer]") {
@@ -50,8 +59,10 @@ TEST_CASE("TripleBuffer hammer: writer + reader for 500ms", "[concurrent][race][
     std::atomic<bool> stop{false};
     std::atomic<int>  read_count{0};
     std::atomic<int>  write_count{0};
+    std::atomic<int>  started{0};
 
     std::thread writer([&] {
+        started.fetch_add(1, std::memory_order_release);
         int v = 0;
         while (!stop.load(std::memory_order_acquire)) {
             buf.write(++v);
@@ -60,12 +71,15 @@ TEST_CASE("TripleBuffer hammer: writer + reader for 500ms", "[concurrent][race][
     });
 
     std::thread reader([&] {
+        started.fetch_add(1, std::memory_order_release);
         while (!stop.load(std::memory_order_acquire)) {
             (void) buf.read();
             read_count.fetch_add(1, std::memory_order_relaxed);
         }
     });
 
+    INFO("started=" << started.load(std::memory_order_acquire));
+    REQUIRE(wait_for_start_count(started, 2));
     std::this_thread::sleep_for(kHammerDuration);
     stop.store(true, std::memory_order_release);
     writer.join();
@@ -81,8 +95,10 @@ TEST_CASE("SeqLock hammer: 1 writer + 2 readers for 500ms", "[concurrent][race][
     std::atomic<bool> stop{false};
     std::atomic<int>  read_count{0};
     std::atomic<int>  write_count{0};
+    std::atomic<int>  started{0};
 
     std::thread writer([&] {
+        started.fetch_add(1, std::memory_order_release);
         double tempo = 120.0;
         while (!stop.load(std::memory_order_acquire)) {
             lock.write(Snapshot{tempo, tempo * 0.125, 4});
@@ -99,6 +115,7 @@ TEST_CASE("SeqLock hammer: 1 writer + 2 readers for 500ms", "[concurrent][race][
     // `position == tempo * k` relation subject to rounding drift that
     // isn't a race but would flake the assertion.)
     auto read_worker = [&] {
+        started.fetch_add(1, std::memory_order_release);
         while (!stop.load(std::memory_order_acquire)) {
             Snapshot snap = lock.read();
             (void) snap;
@@ -109,6 +126,8 @@ TEST_CASE("SeqLock hammer: 1 writer + 2 readers for 500ms", "[concurrent][race][
     std::thread reader_a(read_worker);
     std::thread reader_b(read_worker);
 
+    INFO("started=" << started.load(std::memory_order_acquire));
+    REQUIRE(wait_for_start_count(started, 3));
     std::this_thread::sleep_for(kHammerDuration);
     stop.store(true, std::memory_order_release);
     writer.join();
@@ -125,8 +144,10 @@ TEST_CASE("SpscQueue hammer: producer + consumer for 500ms", "[concurrent][race]
     std::atomic<bool> stop{false};
     std::atomic<int>  produced{0};
     std::atomic<int>  consumed{0};
+    std::atomic<int>  started{0};
 
     std::thread producer([&] {
+        started.fetch_add(1, std::memory_order_release);
         int v = 0;
         while (!stop.load(std::memory_order_acquire)) {
             if (q.try_push(++v)) {
@@ -144,6 +165,7 @@ TEST_CASE("SpscQueue hammer: producer + consumer for 500ms", "[concurrent][race]
     std::atomic<bool> producer_done{false};
 
     std::thread consumer([&] {
+        started.fetch_add(1, std::memory_order_release);
         // Main hammer loop — drain concurrently while producer is pushing.
         while (!stop.load(std::memory_order_acquire)) {
             if (auto item = q.try_pop()) {
@@ -174,6 +196,8 @@ TEST_CASE("SpscQueue hammer: producer + consumer for 500ms", "[concurrent][race]
         }
     });
 
+    INFO("started=" << started.load(std::memory_order_acquire));
+    REQUIRE(wait_for_start_count(started, 2));
     std::this_thread::sleep_for(kHammerDuration);
     stop.store(true, std::memory_order_release);
     producer.join();

--- a/test/test_table_model.cpp
+++ b/test/test_table_model.cpp
@@ -55,7 +55,7 @@ TEST_CASE("sort_by uses numeric key when provided", "[ui][table-model]") {
     REQUIRE(m.cell(3, 2).text == "10");
 }
 
-TEST_CASE("toggle_sort cycles ascending → descending → none",
+TEST_CASE("toggle_sort cycles ascending -> descending -> none",
           "[ui][table-model]") {
     auto m = make_preset_table();
     m.toggle_sort(0);  REQUIRE(m.sort_order() == TableSortOrder::Ascending);

--- a/test/test_transport_hook.cpp
+++ b/test/test_transport_hook.cpp
@@ -95,7 +95,7 @@ TEST_CASE("on_host_transport_changed tolerates extreme and exotic positions",
     REQUIRE(p.calls == 3);
 }
 
-TEST_CASE("transport hook doesn't swallow play→stop→play transition",
+TEST_CASE("transport hook doesn't swallow play->stop->play transition",
           "[processor][transport][state]") {
     TransportAwareProcessor p;
     p.on_host_transport_changed(true, 0.0);

--- a/test/test_validation_harness.cpp
+++ b/test/test_validation_harness.cpp
@@ -378,7 +378,7 @@ TEST_CASE("ValidationHarness inspector passes with provider",
     REQUIRE_THAT(entry.payload_json, ContainsSubstring("\"children\""));
 }
 
-TEST_CASE("ValidationHarness compare_screenshots identical files → pass",
+TEST_CASE("ValidationHarness compare_screenshots identical files -> pass",
           "[harness][phase2][issue-298]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
@@ -395,7 +395,7 @@ TEST_CASE("ValidationHarness compare_screenshots identical files → pass",
     std::filesystem::remove(b);
 }
 
-TEST_CASE("ValidationHarness compare_screenshots differing files → fail",
+TEST_CASE("ValidationHarness compare_screenshots differing files -> fail",
           "[harness][phase2][issue-298]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});
@@ -416,7 +416,7 @@ TEST_CASE("ValidationHarness compare_screenshots differing files → fail",
 // when a caller passes a directory or other non-regular path. It must
 // return a ValidationStatus::error entry so the harness's report-
 // first behavior is preserved under bad input.
-TEST_CASE("ValidationHarness compare_screenshots directory input → error, not throw",
+TEST_CASE("ValidationHarness compare_screenshots directory input -> error, not throw",
           "[harness][phase2][issue-308]") {
     pulp::format::ValidationHarness harness(create_test_gain);
     harness.configure({});

--- a/test/test_view_host_bridge.cpp
+++ b/test/test_view_host_bridge.cpp
@@ -57,7 +57,7 @@ private:
 
 } // namespace
 
-TEST_CASE("Non-Apple screenshot: no provider → empty bytes + false file",
+TEST_CASE("Non-Apple screenshot: no provider -> empty bytes + false file",
           "[view][hosts][issue-299]") {
     clear_screenshot_provider();
     View root;
@@ -85,7 +85,7 @@ TEST_CASE("Non-Apple screenshot: provider routes through and carries data",
     REQUIRE(render_to_png(root, 10, 10).empty());
 }
 
-TEST_CASE("Non-Apple WindowHost::create: no factory → nullptr",
+TEST_CASE("Non-Apple WindowHost::create: no factory -> nullptr",
           "[view][hosts][issue-299]") {
     WindowHost::clear_factory();
     View root;
@@ -94,7 +94,7 @@ TEST_CASE("Non-Apple WindowHost::create: no factory → nullptr",
     REQUIRE(win == nullptr);
 }
 
-TEST_CASE("Non-Apple PluginViewHost::create: no factory → nullptr",
+TEST_CASE("Non-Apple PluginViewHost::create: no factory -> nullptr",
           "[view][hosts][issue-299]") {
     PluginViewHost::clear_factory();
     View root;

--- a/test/test_websocket_channel.cpp
+++ b/test/test_websocket_channel.cpp
@@ -53,7 +53,7 @@ bool wait_until(Pred pred, std::chrono::milliseconds budget = 3s) {
 
 }  // namespace
 
-TEST_CASE("WebSocket accept_key follows RFC 6455 §4.2.2", "[websocket]") {
+TEST_CASE("WebSocket accept_key follows RFC 6455 section 4.2.2", "[websocket]") {
     // Canonical example from the RFC:
     //   client key = "dGhlIHNhbXBsZSBub25jZQ=="
     //   accept     = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -694,7 +694,7 @@ TEST_CASE("WidgetBridge text editor escape dispatches JS handler", "[view][bridg
 
 // ── clear() lifecycle + snapshot/restore across hot reload ──────────────
 
-TEST_CASE("WidgetBridge::clear drops widgets — subsequent lookups return nullptr",
+TEST_CASE("WidgetBridge::clear drops widgets - subsequent lookups return nullptr",
           "[view][bridge][lifetime][clear]") {
     // clear() is the hot-reload entry point — it must actually purge
     // registered widgets so a fresh script build can start from an

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -2,6 +2,8 @@
 
 #include "cli_common.hpp"
 
+#include "version_diag.hpp"
+
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -773,6 +775,49 @@ fs::path read_sdk_path_hint(const fs::path& project_root) {
 fs::path read_sdk_checkout_hint(const fs::path& project_root) {
     auto value = read_pulp_toml_value(project_root, "sdk_checkout");
     return value.empty() ? fs::path{} : fs::path(value);
+}
+
+bool enforce_project_cli_compatibility(const fs::path& project_root,
+                                       const std::string& command_name,
+                                       bool allow_unsupported_sdk) {
+    if (allow_unsupported_sdk || project_root.empty()) return true;
+
+    namespace vd = pulp::cli::version_diag;
+    auto cli = vd::parse_semver(PULP_SDK_VERSION);
+    auto project_sdk = vd::parse_semver(read_sdk_version(project_root));
+    auto project_cli_min = vd::read_project_cli_min_version(project_root);
+    auto preflight = vd::analyze_execution_preflight(cli, project_sdk, project_cli_min);
+    if (preflight.supported) return true;
+
+    auto format_semver = [](const vd::Semver& value) {
+        return value.raw.empty() ? std::string("(unknown)")
+                                 : "v" + value.raw;
+    };
+
+    std::cerr << "Error: " << command_name
+              << " blocked: project requires a newer Pulp CLI.\n";
+    std::cerr << "  Installed CLI: " << format_semver(cli) << "\n";
+    if (!project_sdk.raw.empty()) {
+        std::cerr << "  Project SDK:   " << format_semver(project_sdk) << "\n";
+    }
+    if (project_cli_min.comparable) {
+        std::cerr << "  CLI minimum:   " << format_semver(project_cli_min) << "\n";
+    }
+    std::cerr << "  Project root:  " << project_root.string() << "\n";
+    for (const auto& blocker : preflight.blockers) {
+        std::cerr << "  - " << blocker << "\n";
+    }
+    std::cerr << "\n";
+    if (preflight.required_cli.comparable) {
+        std::cerr << "Run `pulp upgrade " << preflight.required_cli.raw
+                  << "` and retry.\n";
+    } else {
+        std::cerr << "Run `pulp upgrade` and retry.\n";
+    }
+    std::cerr << "Use `pulp doctor --versions` to inspect the mismatch.\n";
+    std::cerr << "If you need to bypass this guard, rerun with "
+              << "`--allow-unsupported-sdk` (unsupported).\n";
+    return false;
 }
 
 std::string read_user_config_value(const std::string& section, const std::string& key) {

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -117,6 +117,9 @@ std::string read_pulp_toml_value(const fs::path& project_root, const std::string
 std::string read_sdk_version(const fs::path& project_root);
 fs::path read_sdk_path_hint(const fs::path& project_root);
 fs::path read_sdk_checkout_hint(const fs::path& project_root);
+bool enforce_project_cli_compatibility(const fs::path& project_root,
+                                       const std::string& command_name,
+                                       bool allow_unsupported_sdk);
 std::string read_user_config_value(const std::string& section, const std::string& key);
 
 // Write/update `key = "value"` under `[section]` in ~/.pulp/config.toml.

--- a/tools/cli/cmd_build.cpp
+++ b/tools/cli/cmd_build.cpp
@@ -29,6 +29,7 @@ int cmd_build(const std::vector<std::string>& args) {
     bool watch_mode = false;
     bool watch_test = false;
     bool watch_validate = false;
+    bool allow_unsupported_sdk = false;
     std::string test_filter;
     std::vector<std::string> passthrough_args;
     for (auto& arg : args) {
@@ -49,6 +50,10 @@ int cmd_build(const std::vector<std::string>& args) {
             watch_test = true;
             continue;
         }
+        if (arg == "--allow-unsupported-sdk") {
+            allow_unsupported_sdk = true;
+            continue;
+        }
         if (arg.rfind("--js-engine=", 0) == 0) {
             js_engine = arg.substr(12);
             if (js_engine != "auto" && js_engine != "quickjs" && js_engine != "jsc" && js_engine != "v8") {
@@ -59,6 +64,12 @@ int cmd_build(const std::vector<std::string>& args) {
         } else {
             passthrough_args.push_back(arg);
         }
+    }
+
+    if (!enforce_project_cli_compatibility(project_root,
+                                           "pulp build",
+                                           allow_unsupported_sdk)) {
+        return 1;
     }
 
     if (needs_configure) {

--- a/tools/cli/cmd_dev.cpp
+++ b/tools/cli/cmd_dev.cpp
@@ -22,6 +22,7 @@ int cmd_dev(const std::vector<std::string>& args) {
     std::string launch_target;
     std::vector<std::string> launch_args;
     std::vector<std::string> build_args;
+    bool allow_unsupported_sdk = false;
     bool after_separator = false;
 
     for (size_t i = 0; i < args.size(); ++i) {
@@ -37,6 +38,7 @@ int cmd_dev(const std::vector<std::string>& args) {
             std::cout << "  --run TARGET           Launch TARGET from build dir, relaunch on rebuild\n";
             std::cout << "  --design SCRIPT        Launch design tool with SCRIPT, relaunch on rebuild\n";
             std::cout << "  --target T             Pass --target T to cmake --build\n";
+            std::cout << "  --allow-unsupported-sdk  Bypass the CLI-vs-project SDK guard (unsupported)\n";
             std::cout << "  -- args...             Arguments passed to the launched app\n\n";
             std::cout << "Examples:\n";
             std::cout << "  pulp dev                          # Watch and rebuild\n";
@@ -63,6 +65,8 @@ int cmd_dev(const std::vector<std::string>& args) {
         } else if (args[i].rfind("--test-filter=", 0) == 0) {
             test_filter = args[i].substr(14);
             run_tests = true;
+        } else if (args[i] == "--allow-unsupported-sdk") {
+            allow_unsupported_sdk = true;
         } else if (args[i] == "--validate") {
             run_validate = true;
         } else if (args[i] == "--run" && i + 1 < args.size()) {
@@ -94,10 +98,20 @@ int cmd_dev(const std::vector<std::string>& args) {
         }
     }
 
+    if (!enforce_project_cli_compatibility(project_root,
+                                           "pulp dev",
+                                           allow_unsupported_sdk)) {
+        return 1;
+    }
+
     // Ensure configured
     if (!fs::exists(build_dir / "CMakeCache.txt")) {
         std::cout << "Project not configured. Building first...\n";
-        int rc = cmd_build({});
+        std::vector<std::string> bootstrap_args;
+        if (allow_unsupported_sdk) {
+            bootstrap_args.push_back("--allow-unsupported-sdk");
+        }
+        int rc = cmd_build(bootstrap_args);
         if (rc != 0) return rc;
     }
 

--- a/tools/cli/version_diag.cpp
+++ b/tools/cli/version_diag.cpp
@@ -234,6 +234,40 @@ Semver read_project_cli_min_version(const fs::path& project_root) {
     return parse_semver(raw);
 }
 
+ExecutionPreflight analyze_execution_preflight(const Semver& cli,
+                                               const Semver& project_sdk,
+                                               const Semver& project_cli_min) {
+    ExecutionPreflight out;
+
+    auto note_required = [&](const Semver& required) {
+        if (!required.comparable) return;
+        if (!out.required_cli.comparable ||
+            compare_semver(required, out.required_cli) > 0) {
+            out.required_cli = required;
+        }
+    };
+
+    if (cli.comparable && project_cli_min.comparable &&
+        compare_semver(project_cli_min, cli) > 0) {
+        out.supported = false;
+        out.blockers.push_back(
+            "Project declares cli_min_version v" + project_cli_min.raw +
+            " but installed CLI is v" + cli.raw);
+        note_required(project_cli_min);
+    }
+
+    if (cli.comparable && project_sdk.comparable &&
+        compare_semver(project_sdk, cli) > 0) {
+        out.supported = false;
+        out.blockers.push_back(
+            "Project pins SDK v" + project_sdk.raw +
+            " but installed CLI is v" + cli.raw);
+        note_required(project_sdk);
+    }
+
+    return out;
+}
+
 std::vector<SkewFinding> VersionReport::analyze() const {
     std::vector<SkewFinding> findings;
 

--- a/tools/cli/version_diag.hpp
+++ b/tools/cli/version_diag.hpp
@@ -72,6 +72,20 @@ struct SkewFinding {
     std::string message;
 };
 
+// Build/dev execution preflight. Unlike `analyze()`, this is intended
+// for commands that must fail fast when a project's pinned SDK or
+// cli_min_version is ahead of the installed CLI. `doctor --versions`
+// stays advisory; execution commands can opt into this stricter lane.
+struct ExecutionPreflight {
+    bool supported = true;
+    Semver required_cli;               // highest comparable requirement
+    std::vector<std::string> blockers; // human-readable reasons
+};
+
+ExecutionPreflight analyze_execution_preflight(const Semver& cli,
+                                               const Semver& project_sdk,
+                                               const Semver& project_cli_min);
+
 // A single registered project's version snapshot, used for per-project
 // skew lines in `pulp doctor --versions`. Populated by cmd_doctor from
 // `~/.pulp/projects.json` (or the `--scan-parents` ancestor walk) and


### PR DESCRIPTION
Fixes #682

- keep `pulp doctor --versions` advisory
- make `pulp build` and `pulp dev` fail fast when the workspace SDK or `cli_min_version` exceeds the installed CLI
- surface the required CLI version, upgrade command, and `--allow-unsupported-sdk` escape hatch
- add focused shellout/version-diag coverage and sync the CLI docs/skill notes