### PR TITLE
fix(release): ship WebView in SDK artifacts

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -64,6 +64,14 @@ debugged. Do not use them as the primary ship path.
 
 ### Behaviour notes at the current pin (v0.29.0)
 
+- **Release SDKs are expected to include desktop WebView symbols**
+  (pulp #695). `.github/workflows/release-cli.yml` now configures the
+  release build with `-DPULP_BUILD_WEBVIEW=ON`, installs Linux's
+  `libgtk-3-dev` + `libwebkit2gtk-4.1-dev`, and verifies the staged
+  `pulp-view` archive still contains `WebViewPanel` and
+  `make_webview_embedded_resource_fetcher`. If you touch the release
+  workflow or `tools/scripts/release-cli-local.sh`, preserve that
+  contract or WebView-using downstream SDK consumers will link-fail.
 - **macOS binary is signed + notarized** (Shipyard v0.29.0). On
   macOS 26.3+ XProtect skips the deep scan for notarized binaries,
   cutting `shipyard pr` cold-start ~4-5x (from ~5-6s to ~1-1.5s).

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -187,6 +187,28 @@ artifact on a *clean* runner that did not build it, catching the bug
 class before tagging. If you change rpath logic, run the smoke job
 locally first or it will fail in CI for everyone else.
 
+### Released SDK is missing WebView symbols
+
+Symptom: a consumer links against a downloaded `pulp-sdk-<platform>`
+release artifact and fails to resolve `pulp::view::WebViewPanel::create`
+or `pulp::view::make_webview_embedded_resource_fetcher`.
+
+Root cause: `core/view/CMakeLists.txt` defaults `PULP_BUILD_WEBVIEW=OFF`,
+so any release SDK build that forgets to opt in will ship a
+`libpulp-view` / `pulp-view.lib` without the native WebView objects.
+
+Fix (active since pulp #695): keep the release SDK path aligned with the
+GitHub release workflow:
+1. Configure release SDK builds with `-DPULP_BUILD_WEBVIEW=ON`.
+2. On Linux, install `libgtk-3-dev` and `libwebkit2gtk-4.1-dev` before
+   configuring.
+3. Before packaging, verify the staged SDK archive still contains
+   `WebViewPanel` and `make_webview_embedded_resource_fetcher`.
+
+This applies to both `.github/workflows/release-cli.yml` and the local
+helper `tools/scripts/release-cli-local.sh`. If one changes without the
+other, GitHub releases and local release drills diverge.
+
 ### Shipyard pin drift between local tooling and release workflows
 
 Pulp's release automation depends on the pinned Shipyard CLI in two places:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,9 +322,7 @@ jobs:
           if (!(Test-Path sdk-staging/lib/pulp-view.lib)) {
             throw "sdk-staging/lib/pulp-view.lib missing"
           }
-          dumpbin /SYMBOLS sdk-staging/lib/pulp-view.lib > sdk-webview-symbols.txt
-          Select-String -Path sdk-webview-symbols.txt -Pattern "WebViewPanel" | Out-Null
-          Select-String -Path sdk-webview-symbols.txt -Pattern "make_webview_embedded_resource_fetcher" | Out-Null
+          python -c "from pathlib import Path; data = Path(r'sdk-staging/lib/pulp-view.lib').read_bytes(); assert b'WebViewPanel' in data; assert b'make_webview_embedded_resource_fetcher' in data"
 
   # ── Stable-name status aliases for branch protection ──────────────────────
   # Branch-protection on `main` requires contexts literally named

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,12 +307,24 @@ jobs:
         run: |
           cmake -S . -B build `
             -DCMAKE_BUILD_TYPE=Release `
-            -DPULP_BUILD_TESTS=OFF
+            -DPULP_BUILD_TESTS=OFF `
+            -DPULP_BUILD_WEBVIEW=ON
         shell: pwsh
 
       - name: Build
         run: cmake --build build --config Release
         shell: pwsh
+
+      - name: Verify installed SDK keeps WebView symbols
+        shell: pwsh
+        run: |
+          cmake --install build --prefix sdk-staging --config Release
+          if (!(Test-Path sdk-staging/lib/pulp-view.lib)) {
+            throw "sdk-staging/lib/pulp-view.lib missing"
+          }
+          dumpbin /SYMBOLS sdk-staging/lib/pulp-view.lib > sdk-webview-symbols.txt
+          Select-String -Path sdk-webview-symbols.txt -Pattern "WebViewPanel" | Out-Null
+          Select-String -Path sdk-webview-symbols.txt -Pattern "make_webview_embedded_resource_fetcher" | Out-Null
 
   # ── Stable-name status aliases for branch protection ──────────────────────
   # Branch-protection on `main` requires contexts literally named

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -120,8 +120,12 @@ jobs:
         run: |
           cmake --install build --prefix sdk-staging --config Release
           test -f sdk-staging/lib/libpulp-view.a
-          nm -g sdk-staging/lib/libpulp-view.a | grep -q WebViewPanel
-          nm -g sdk-staging/lib/libpulp-view.a | grep -q make_webview_embedded_resource_fetcher
+          python3 - <<'PY'
+          from pathlib import Path
+          data = Path("sdk-staging/lib/libpulp-view.a").read_bytes()
+          assert b"WebViewPanel" in data
+          assert b"make_webview_embedded_resource_fetcher" in data
+          PY
           mv sdk-staging pulp-sdk
           tar czf pulp-sdk-${{ matrix.platform }}.tar.gz pulp-sdk
           rm -rf pulp-sdk
@@ -134,9 +138,7 @@ jobs:
           if (!(Test-Path sdk-staging/lib/pulp-view.lib)) {
             throw "sdk-staging/lib/pulp-view.lib missing"
           }
-          dumpbin /SYMBOLS sdk-staging/lib/pulp-view.lib > sdk-webview-symbols.txt
-          Select-String -Path sdk-webview-symbols.txt -Pattern "WebViewPanel" | Out-Null
-          Select-String -Path sdk-webview-symbols.txt -Pattern "make_webview_embedded_resource_fetcher" | Out-Null
+          python -c "from pathlib import Path; data = Path(r'sdk-staging/lib/pulp-view.lib').read_bytes(); assert b'WebViewPanel' in data; assert b'make_webview_embedded_resource_fetcher' in data"
           Rename-Item sdk-staging pulp-sdk
           Compress-Archive -Path pulp-sdk -DestinationPath pulp-sdk-${{ matrix.platform }}.tar.gz
           Remove-Item -Recurse pulp-sdk

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -62,7 +62,8 @@ jobs:
             libasound2-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev \
             libgbm-dev libgl1-mesa-dev libx11-dev libxext-dev libxfixes-dev \
             libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev \
-            libxrender-dev libxss-dev libxtst-dev libwayland-dev wayland-protocols
+            libxrender-dev libxss-dev libxtst-dev libwayland-dev \
+            libgtk-3-dev libwebkit2gtk-4.1-dev wayland-protocols
 
       - name: Bootstrap dependencies
         run: ./setup.sh --ci --deps-only
@@ -72,7 +73,8 @@ jobs:
         run: |
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DPULP_BUILD_TESTS=OFF
+            -DPULP_BUILD_TESTS=OFF \
+            -DPULP_BUILD_WEBVIEW=ON
         shell: bash
 
       - name: Build
@@ -117,6 +119,9 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cmake --install build --prefix sdk-staging --config Release
+          test -f sdk-staging/lib/libpulp-view.a
+          nm -g sdk-staging/lib/libpulp-view.a | grep -q WebViewPanel
+          nm -g sdk-staging/lib/libpulp-view.a | grep -q make_webview_embedded_resource_fetcher
           mv sdk-staging pulp-sdk
           tar czf pulp-sdk-${{ matrix.platform }}.tar.gz pulp-sdk
           rm -rf pulp-sdk
@@ -126,6 +131,12 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           cmake --install build --prefix sdk-staging --config Release
+          if (!(Test-Path sdk-staging/lib/pulp-view.lib)) {
+            throw "sdk-staging/lib/pulp-view.lib missing"
+          }
+          dumpbin /SYMBOLS sdk-staging/lib/pulp-view.lib > sdk-webview-symbols.txt
+          Select-String -Path sdk-webview-symbols.txt -Pattern "WebViewPanel" | Out-Null
+          Select-String -Path sdk-webview-symbols.txt -Pattern "make_webview_embedded_resource_fetcher" | Out-Null
           Rename-Item sdk-staging pulp-sdk
           Compress-Archive -Path pulp-sdk -DestinationPath pulp-sdk-${{ matrix.platform }}.tar.gz
           Remove-Item -Recurse pulp-sdk

--- a/tools/scripts/release-cli-local.sh
+++ b/tools/scripts/release-cli-local.sh
@@ -54,8 +54,13 @@ SDK_STAGING="$DIST_DIR/pulp-sdk-staging"
 rm -rf "$SDK_STAGING"
 cmake --install "$MAC_BUILD_DIR" --prefix "$SDK_STAGING" --config Release 2>&1 | tail -5
 if [ -f "$SDK_STAGING/version.txt" ]; then
-    nm -g "$SDK_STAGING/lib/libpulp-view.a" | grep -q WebViewPanel
-    nm -g "$SDK_STAGING/lib/libpulp-view.a" | grep -q make_webview_embedded_resource_fetcher
+    SDK_WEBVIEW_LIB="$SDK_STAGING/lib/libpulp-view.a" python3 - <<'PY'
+from pathlib import Path
+import os
+data = Path(os.environ["SDK_WEBVIEW_LIB"]).read_bytes()
+assert b"WebViewPanel" in data
+assert b"make_webview_embedded_resource_fetcher" in data
+PY
     (cd "$DIST_DIR" && mv pulp-sdk-staging pulp-sdk && tar czf "pulp-sdk-darwin-arm64.tar.gz" pulp-sdk && rm -rf pulp-sdk)
     info "pulp-sdk-darwin-arm64.tar.gz ($(du -h "$DIST_DIR/pulp-sdk-darwin-arm64.tar.gz" | cut -f1))"
 else

--- a/tools/scripts/release-cli-local.sh
+++ b/tools/scripts/release-cli-local.sh
@@ -19,6 +19,7 @@ VERSION_NUM="${VERSION#v}"  # strip leading v
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DIST_DIR="$REPO_ROOT/dist"
+MAC_BUILD_DIR="$REPO_ROOT/build-release-cli"
 rm -rf "$DIST_DIR"
 mkdir -p "$DIST_DIR"
 
@@ -30,13 +31,17 @@ step() { echo ""; echo "── $* ──"; }
 
 step "Building macOS arm64"
 
-cmake --build "$REPO_ROOT/build" --target pulp-cli --config Release 2>&1 | tail -3
-if [ ! -f "$REPO_ROOT/build/tools/cli/pulp" ]; then
+cmake -S "$REPO_ROOT" -B "$MAC_BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPULP_BUILD_TESTS=OFF \
+    -DPULP_BUILD_WEBVIEW=ON 2>&1 | tail -5
+cmake --build "$MAC_BUILD_DIR" --target pulp-cli --config Release 2>&1 | tail -3
+if [ ! -f "$MAC_BUILD_DIR/tools/cli/pulp" ]; then
     fail "macOS build failed"
     exit 1
 fi
 
-cp "$REPO_ROOT/build/tools/cli/pulp" "$DIST_DIR/pulp"
+cp "$MAC_BUILD_DIR/tools/cli/pulp" "$DIST_DIR/pulp"
 strip "$DIST_DIR/pulp"
 (cd "$DIST_DIR" && tar czf "pulp-darwin-arm64.tar.gz" pulp && rm pulp)
 info "pulp-darwin-arm64.tar.gz ($(du -h "$DIST_DIR/pulp-darwin-arm64.tar.gz" | cut -f1))"
@@ -47,8 +52,10 @@ step "Building macOS arm64 SDK"
 
 SDK_STAGING="$DIST_DIR/pulp-sdk-staging"
 rm -rf "$SDK_STAGING"
-cmake --install "$REPO_ROOT/build" --prefix "$SDK_STAGING" --config Release 2>&1 | tail -5
+cmake --install "$MAC_BUILD_DIR" --prefix "$SDK_STAGING" --config Release 2>&1 | tail -5
 if [ -f "$SDK_STAGING/version.txt" ]; then
+    nm -g "$SDK_STAGING/lib/libpulp-view.a" | grep -q WebViewPanel
+    nm -g "$SDK_STAGING/lib/libpulp-view.a" | grep -q make_webview_embedded_resource_fetcher
     (cd "$DIST_DIR" && mv pulp-sdk-staging pulp-sdk && tar czf "pulp-sdk-darwin-arm64.tar.gz" pulp-sdk && rm -rf pulp-sdk)
     info "pulp-sdk-darwin-arm64.tar.gz ($(du -h "$DIST_DIR/pulp-sdk-darwin-arm64.tar.gz" | cut -f1))"
 else
@@ -66,12 +73,12 @@ if ssh -o ConnectTimeout=5 -o BatchMode=yes ubuntu "echo ok" &>/dev/null; then
         --exclude='dist' --exclude='planning' --exclude='node_modules' \
         "$REPO_ROOT/" ubuntu:~/pulp/
 
-    # Configure if needed
+    # Configure release build fresh enough to keep SDK contents aligned
+    # with the GitHub release workflow.
     ssh ubuntu "cd ~/pulp && \
-        if [ ! -f build-cli/CMakeCache.txt ]; then \
-            cmake -S . -B build-cli -DCMAKE_BUILD_TYPE=Release \
-                -DPULP_BUILD_TESTS=OFF -DPULP_ENABLE_GPU=OFF; \
-        fi" 2>&1 | tail -5
+        cmake -S . -B build-cli -DCMAKE_BUILD_TYPE=Release \
+            -DPULP_BUILD_TESTS=OFF -DPULP_ENABLE_GPU=OFF \
+            -DPULP_BUILD_WEBVIEW=ON" 2>&1 | tail -5
 
     # Build
     ssh ubuntu "cd ~/pulp && cmake --build build-cli --target pulp-cli 2>&1 | tail -5"
@@ -101,7 +108,7 @@ if ssh -o ConnectTimeout=5 -o BatchMode=yes win2 "echo ok" &>/dev/null; then
             --exclude='dist' --exclude='planning' \
             "$REPO_ROOT/" win2:~/pulp/
 
-        ssh win2 "cd ~/pulp && cmake -S . -B build-cli -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_TESTS=OFF -DPULP_ENABLE_GPU=OFF 2>&1 | tail -5"
+        ssh win2 "cd ~/pulp && cmake -S . -B build-cli -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_TESTS=OFF -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_WEBVIEW=ON 2>&1 | tail -5"
         ssh win2 "cd ~/pulp && cmake --build build-cli --target pulp-cli --config Release 2>&1 | tail -5"
 
         if ssh win2 "if exist ~/pulp/build-cli/tools/cli/Release/pulp.exe (echo ok)" | grep -q ok; then


### PR DESCRIPTION
Enable PULP_BUILD_WEBVIEW for the release SDK path so shipped pulp-view archives keep WebViewPanel and embedded-resource fetcher symbols on supported desktop platforms. Install the Linux WebKitGTK development packages the release workflow now needs, add SDK symbol checks to the GitHub release path and Windows release-path PR gate, and keep the local release helper aligned with the same configuration.\n\nFixes #695
