### PR TITLE
ci(windows): set UTF-8 code page before ctest on Namespace runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,8 +241,20 @@ jobs:
 
       - name: Test
         working-directory: build
-        run: ctest --output-on-failure -C Release -LE validation -j4 --exclude-regex "STFT|VisualizationBridge|Clipboard|Toolbar add items"
         shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            # Force UTF-8 console code page on Windows so ctest's child
+            # processes receive filter args (test names containing em-dashes
+            # like "applies_if — empty expression") without CP-1252 mangling.
+            # GitHub-hosted Windows defaults to 65001; Namespace Windows
+            # defaults to CP-1252 → mangled "—" to "G??" → 46 spurious
+            # test-filter-no-match failures (#676 debugging, 2026-04-23).
+            # Applies to the current console session; child processes inherit.
+            chcp.com 65001 >/dev/null || true
+            export PYTHONIOENCODING=utf-8
+          fi
+          ctest --output-on-failure -C Release -LE validation -j4 --exclude-regex "STFT|VisualizationBridge|Clipboard|Toolbar add items"
 
       - name: Upload plugin bundles (macOS)
         if: success() && runner.os == 'macOS'


### PR DESCRIPTION
Pulp test names contain em-dashes (e.g. "applies_if — empty expression
always matches"). On GitHub-hosted Windows the console defaults to
code page 65001 (UTF-8), so ctest passes the em-dash through to the
test binary's Catch2 filter unchanged and the match succeeds. On
Namespace's Windows image the default is CP-1252, which mangles the
UTF-8 bytes 0xE2 0x80 0x94 into "G??" when ctest re-encodes the
filter string for CreateProcess argv — Catch2 then doesn't find any
matching test and ctest reports 46 spurious "Failed 0.01s" tests
(observed on #676 PR validation, 2026-04-23).

Fix: run `chcp.com 65001` in the Test step when RUNNER_OS=Windows,
which sets the code page for the current console session. ctest's
child processes inherit it. Also export PYTHONIOENCODING=utf-8 for
any Python helpers along the path. Lightweight — does nothing on
mac/linux.

Shipyard #197 (filed earlier today) asks Namespace to align their
default image with GitHub-hosted (chcp 65001). Until that lands,
this workflow-side workaround keeps our Windows lane green on both
runner types.

Skill-Update: skip skill=ci reason="CI workflow-only fix; Windows-specific console-codepage workaround documented in the step comment, no new CI surface to document in the ci skill"