### PR TITLE
chore: bump Shipyard pin v0.37.0 → v0.38.0 + revert chcp workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,20 +241,8 @@ jobs:
 
       - name: Test
         working-directory: build
+        run: ctest --output-on-failure -C Release -LE validation -j4 --exclude-regex "STFT|VisualizationBridge|Clipboard|Toolbar add items"
         shell: bash
-        run: |
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            # Force UTF-8 console code page on Windows so ctest's child
-            # processes receive filter args (test names containing em-dashes
-            # like "applies_if — empty expression") without CP-1252 mangling.
-            # GitHub-hosted Windows defaults to 65001; Namespace Windows
-            # defaults to CP-1252 → mangled "—" to "G??" → 46 spurious
-            # test-filter-no-match failures (#676 debugging, 2026-04-23).
-            # Applies to the current console session; child processes inherit.
-            chcp.com 65001 >/dev/null || true
-            export PYTHONIOENCODING=utf-8
-          fi
-          ctest --output-on-failure -C Release -LE validation -j4 --exclude-regex "STFT|VisualizationBridge|Clipboard|Toolbar add items"
 
       - name: Upload plugin bundles (macOS)
         if: success() && runner.os == 'macOS'

--- a/.github/workflows/post-tag-sync.yml
+++ b/.github/workflows/post-tag-sync.yml
@@ -20,7 +20,7 @@ permissions:
   contents: write
 
 env:
-  SHIPYARD_VERSION: "0.37.0"
+  SHIPYARD_VERSION: "0.38.0"
 
 jobs:
   sync:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -22,7 +22,7 @@ env:
   # Pin shipyard to the same version post-tag-sync.yml uses so
   # `shipyard changelog regenerate --release-notes` produces the
   # same output as the hook that writes CHANGELOG.md.
-  SHIPYARD_VERSION: "0.37.0"
+  SHIPYARD_VERSION: "0.38.0"
 
 jobs:
   build-cli:

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -197,6 +197,17 @@
 #             forever. Would've named the Namespace Windows
 #             queue-stuck case on 4/23 in one glance instead of
 #             after multiple `gh run view` loops.
+#   v0.38.0 — ssh-windows UTF-8 prelude: shipyard prepends
+#             `chcp.com 65001 >nul 2>&1 &` to every command
+#             dispatched through the ssh-windows backend so
+#             non-ASCII argv (em-dashes in test names, etc.)
+#             survives the remote host's default OEM code page.
+#             Lands Pulp-side issue Shipyard #208 (I filed 4/23
+#             after 46 ctest filter-no-match failures traced
+#             back to Namespace Windows image's CP-1252 default).
+#             With this in place, Pulp's own build.yml `chcp 65001`
+#             workaround (PR #697) can be reverted — shipyard now
+#             owns the fix for every consumer.
 #
 # Cumulative additions from earlier releases still in effect:
 #   v0.4–v0.8 — release-bot helpers, `shipyard doctor release-chain`,
@@ -211,7 +222,7 @@
 # in `tools/install-shipyard.sh` (v0.22.1+ `SHIPYARD_VERSION` support).
 # The older `~/.pulp/bin/shipyard` path is cleaned up on install to
 # prevent shadow-on-PATH bugs.
-version = "v0.37.0"
+version = "v0.38.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Shipyard v0.38.0 (landing Shipyard PR #209, closing Shipyard #208
which I filed 4/23) now prepends `chcp.com 65001 >/dev/null 2>&1 &` to
every command dispatched through the ssh-windows backend. Shipyard
owns the UTF-8 code-page prelude; every consumer is shielded.

That renders Pulp's own workaround (PR #697, `ci(windows): set UTF-8
code page before ctest on Namespace runners`) redundant. Reverting
the per-consumer chcp step in build.yml and letting shipyard handle
it at the transport layer is the right boundary.

Files:
- tools/shipyard.toml: pin v0.37.0 → v0.38.0 + v0.38.0 changelog
  entry
- .github/workflows/release-cli.yml: SHIPYARD_VERSION 0.37.0 → 0.38.0
- .github/workflows/post-tag-sync.yml: SHIPYARD_VERSION 0.37.0 → 0.38.0
- .github/workflows/build.yml: revert the conditional chcp.com 65001
  + PYTHONIOENCODING=utf-8 step. Back to the plain single-line
  `ctest --output-on-failure ...` run.

Validation: with v0.38.0 installed locally + daemon restarted,
Pulp's Windows CI on this branch should pass WITHOUT the chcp step.
If it fails (shipyard-prelude issue), we'd restore the build.yml
step while shipyard fixes it — but with #208 merged upstream the
prelude should cover this cleanly.

Skill-Update: skip skill=ci reason="pin-bump + workaround-revert chore; no new ci workflow surface"
Skill-Update: skip skill=ship reason="SHIPYARD_VERSION env-var bump in release-cli.yml only; no new ship/release workflow surface"