### PR TITLE
fix(release): use pinned VST3 SDK tag

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -733,6 +733,8 @@ Locally:
 
 **Auto-release:** `.github/workflows/auto-release.yml` fires on push to `main`. It diffs the two version-bearing files (`CMakeLists.txt` project version, `.claude-plugin/plugin.json` version) against the previous push range and creates the corresponding `v<x.y.z>` or `plugin-v<x.y.z>` tag. The existing tag-triggered release workflows (`release-cli.yml`, `sign-and-release.yml`) then build and publish. `Release: skip reason="..."` on the merging commit suppresses the tag.
 
+**Release-workflow VST3 pin:** `sign-and-release.yml` must clone the same Steinberg tag pinned everywhere else in the repo: `v3.7.12_build_20`. The shorthand `v3.7.12` does not exist upstream and will make tag-time macOS release jobs fail before configure/build even start.
+
 **Tag safety:** the auto-release workflow is idempotent-strict — if a tag already exists pointing at a different SHA, it fails loudly rather than overwriting. See `docs/guides/versioning.md` for the manual recovery recipe.
 
 **`RELEASE_BOT_TOKEN` is required for the auto-release chain to fire.** Without it, auto-release silently degrades — tags get created via `GITHUB_TOKEN` but GitHub doesn't trigger workflows on `GITHUB_TOKEN`-pushed tags, so `release-cli.yml` and `sign-and-release.yml` never run and no GitHub Release appears. Run `pulp doctor` to check; if missing, follow the "One-time setup" section in `docs/guides/versioning.md`. `pulp pr` will also print a heads-up before pushing the PR if the secret isn't present.

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -225,6 +225,15 @@ toml). Otherwise local shipping and tag-time release jobs quietly diverge
 onto different Shipyard versions, which is how release-only behavior
 changes get missed.
 
+### VST3 SDK tag drift in `sign-and-release.yml`
+
+Pulp's notarized macOS release workflow clones the Steinberg VST3 SDK directly
+inside `.github/workflows/sign-and-release.yml`. Keep that workflow pinned to
+the same upstream tag used everywhere else in the repo: `v3.7.12_build_20`.
+The shortened `v3.7.12` ref does not exist on Steinberg's repo and causes the
+tag-triggered macOS release job to fail immediately at `Clone VST3 SDK`, before
+configure, build, or signing begin.
+
 ## Doctor Checks
 
 `pulp doctor` validates Android toolchain:

--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Clone VST3 SDK
         run: |
-          git clone --depth 1 --branch v3.7.12 \
+          git clone --depth 1 --branch v3.7.12_build_20 \
             https://github.com/steinbergmedia/vst3sdk.git \
             external/vst3sdk
           cd external/vst3sdk && git submodule update --init --recursive --depth 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ cmake -S . -B build -DPULP_SANITIZER=address
 ```
 
 **External SDKs** (not committed, cloned at configure time or manually):
-- VST3 SDK → `external/vst3sdk` (MIT, `git clone --depth 1 --branch v3.7.12`)
+- VST3 SDK → `external/vst3sdk` (MIT, `git clone --depth 1 --branch v3.7.12_build_20`)
 - AudioUnitSDK → `external/AudioUnitSDK` (Apache 2.0, `git clone --depth 1`)
 - CLAP → fetched automatically via CMake FetchContent
 - Skia → pre-built binaries in `external/skia-build/`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.40.1
+    VERSION 0.40.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
The sign-and-release workflow drifted to Steinberg ref v3.7.12, which does not exist upstream. Align the release clone step and CLAUDE.md with the repo's pinned v3.7.12_build_20 VST3 SDK ref so tagged release builds can fetch the SDK again.

Bump the SDK version to 0.40.2 so merging this change produces a fresh release with the corrected workflow after the broken v0.40.1 publish attempt.

Sync the ci and ship skills with the VST3 release-pin gotcha so Shipyard's skill gate documents the same failure mode the workflow now avoids.