### PR TITLE
ci: migrate Namespace caches to nscloud + cap artifact retention (#683 slice 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,13 +191,34 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install ccache --no-progress -y
 
-      # ── Caches (#420) ──────────────────────────────────────────────────
+      # ── Caches (#420, #683) ───────────────────────────────────────────
       # FetchContent source cache: Skia / Dawn / Yoga / SDL3 / Catch2 /
       # mbedtls / CHOC / CLAP / LV2 / VST3 SDK, keyed on setup.sh's
       # content (which pins every ref). Hit → setup.sh finds everything
       # already unpacked and returns in seconds. Cold → ~3-5 min
       # downloading + unpacking.
-      - name: Cache FetchContent sources
+      #
+      # #683: each cache step is split into two lanes so the Namespace
+      # Linux/macOS matrix entries use Namespace-hosted cache storage
+      # (keeps GH Actions cache quota bounded) while Windows + any
+      # GitHub-hosted fallback keeps the stock actions/cache.
+      # Namespace Windows instances don't support caching (per Namespace,
+      # 2026-04-23), so the Windows leg always takes the actions/cache
+      # path.
+      - name: Cache FetchContent sources (Namespace)
+        if: matrix.provider == 'namespace' && runner.os != 'Windows'
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: |
+            ~/Library/Caches/Pulp/fetchcontent-src
+            ~/.cache/Pulp/fetchcontent-src
+            ~/AppData/Local/Pulp/Cache/fetchcontent-src
+          key: ${{ runner.os }}-${{ matrix.key || 'build' }}-fetchcontent-${{ hashFiles('setup.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.key || 'build' }}-fetchcontent-
+
+      - name: Cache FetchContent sources (GitHub-hosted + Windows)
+        if: matrix.provider != 'namespace' || runner.os == 'Windows'
         uses: actions/cache@v4
         with:
           path: |
@@ -212,7 +233,21 @@ jobs:
       # on CMakeLists + PR ref so each PR has its own warm cache. The
       # restore-key fallback shares warm cache across PRs on the same
       # base branch, so first-run-per-PR starts near-warm.
-      - name: Cache ccache
+      - name: Cache ccache (Namespace)
+        if: matrix.provider == 'namespace' && runner.os != 'Windows'
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: |
+            ~/Library/Caches/ccache
+            ~/.cache/ccache
+            ~/AppData/Local/ccache
+          key: ${{ runner.os }}-${{ matrix.key || 'build' }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'tools/cmake/*.cmake') }}-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.key || 'build' }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'tools/cmake/*.cmake') }}-
+            ${{ runner.os }}-${{ matrix.key || 'build' }}-ccache-
+
+      - name: Cache ccache (GitHub-hosted + Windows)
+        if: matrix.provider != 'namespace' || runner.os == 'Windows'
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -282,7 +282,7 @@ jobs:
         with:
           name: coverage-report-${{ matrix.os }}-${{ github.sha }}
           path: build-coverage/coverage/
-          retention-days: 30
+          retention-days: 7
 
       - name: Upload summary
         if: always()
@@ -290,7 +290,7 @@ jobs:
         with:
           name: coverage-summary-${{ matrix.os }}-${{ github.sha }}
           path: build-coverage/coverage/summary.txt
-          retention-days: 90
+          retention-days: 7
 
       - name: Upload Python HTML report
         if: always() && matrix.os == 'linux'
@@ -298,7 +298,7 @@ jobs:
         with:
           name: coverage-python-report-${{ github.sha }}
           path: build-coverage/python/html/
-          retention-days: 30
+          retention-days: 7
           if-no-files-found: error
 
       - name: Upload Python summary
@@ -307,7 +307,7 @@ jobs:
         with:
           name: coverage-python-summary-${{ github.sha }}
           path: build-coverage/python/summary.txt
-          retention-days: 90
+          retention-days: 7
           if-no-files-found: error
 
       - name: Upload Apple summary
@@ -316,7 +316,7 @@ jobs:
         with:
           name: coverage-apple-summary-${{ github.sha }}
           path: build-coverage/apple/summary.txt
-          retention-days: 90
+          retention-days: 7
           if-no-files-found: error
 
       - name: Verify Cobertura XML exists
@@ -556,7 +556,7 @@ jobs:
           path: |
             android/app/build/reports/jacoco/jacocoDebugUnitTestReport/**
             android/app/build/reports/tests/testDebugUnitTest/**
-          retention-days: 14
+          retention-days: 7
           if-no-files-found: error
 
       - name: Upload Android Kotlin coverage to Codecov
@@ -821,7 +821,7 @@ jobs:
             coverage-diff.md
             coverage-diff-comment.md
             coverage-tier.md
-          retention-days: 14
+          retention-days: 7
           if-no-files-found: warn
 
       - name: Upsert PR comment with diff-coverage summary

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           name: dependency-audit
           path: dependency-audit.md
+          retention-days: 7

--- a/.github/workflows/docs-material.yml
+++ b/.github/workflows/docs-material.yml
@@ -92,5 +92,5 @@ jobs:
         with:
           name: docs-material-preview
           path: build/site-material
-          retention-days: 14
+          retention-days: 7
           if-no-files-found: error

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -230,5 +230,5 @@ jobs:
           path: |
             iwyu-raw.txt
             changed-files.txt
-          retention-days: 14
+          retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -149,12 +149,14 @@ jobs:
         with:
           name: pulp-${{ matrix.platform }}
           path: pulp-${{ matrix.platform }}.*
+          retention-days: 7
 
       - name: Upload SDK artifact
         uses: actions/upload-artifact@v6
         with:
           name: pulp-sdk-${{ matrix.platform }}
           path: pulp-sdk-${{ matrix.platform }}.*
+          retention-days: 7
 
   # ── Portable-binary smoke gate (#391) ─────────────────────────────
   #


### PR DESCRIPTION
## Summary

Slice 1 of #683 — shifts cache + artifact storage off GitHub's bucket for lanes that already run on Namespace compute. See [#683](https://github.com/danielraffel/pulp/issues/683) for full context (112 GB artifacts + 10.6 GB caches consumed the $15 overage on 2026-04-23).

## Layers

### Cache migration (`actions/cache` → `nscloud-cache-action`)
- `build.yml` — 2 cache steps split into Namespace + GH-hosted twins. Namespace lane (Linux/macOS) uses `namespacelabs/nscloud-cache-action@v1`; Windows + GH-hosted twin keeps `actions/cache@v4` (Namespace Windows doesn't support caching per Namespace support).
- `coverage.yml` / `android.yml` — cache steps are on GitHub-hosted macos-latest / windows-latest; left on `actions/cache`.

### Artifact retention caps (7 days for CI-internal)
- 10 `upload-artifact` calls capped from 14/30/90 → 7 days across coverage / dependency-audit / docs-material / iwyu / release-cli workflows.
- Left intentionally >7: coverage Cobertura XMLs (14d, long-running PRs), IWYU push-to-main full report (30d, #594), weekly-cadence reports (30d), signed release plugin (30d).

## Reversibility

**Trivially easy to switch back.** Every migrated cache step kept its `actions/cache@v4` twin on the non-Namespace side. If `nscloud-cache-action` misbehaves on any lane:
- Quick revert: flip the `if:` on the Namespace twin to `false`, both lanes fall back to `actions/cache`.
- Full revert: `git revert <this-merge-commit>`.
- Cache keys are identical between the two actions, so worst case on rollback is one cold-start run.

## Out of scope (future slices)

- Monthly `actions-storage-audit.yml` workflow (tier-3 governance).
- Repo-level retention setting (requires UI change).
- Artifact migration to Namespace scratch volumes (tier-1 job-to-job handoffs; cache migration alone is likely enough).

## Validation

- `yamllint` + `actionlint` clean on all 6 touched files (pre-existing shellcheck infos in release-cli.yml lines 330/352 are outside this diff).
- Expected storage impact once merged: cache bucket drops ~8-10 GB of the 10.6 GB footprint; artifact bucket drops 60-80% of 112 GB within 7 days as old artifacts time out.