### PR TITLE
test: ASCII hyphens in TEST_CASE names (supersedes #708, closes #707)

### DIFF
--- a/test/test_gpu_graph.cpp
+++ b/test/test_gpu_graph.cpp
@@ -49,7 +49,7 @@ TEST_CASE("GpuBarRenderer stores bar data", "[render][gpu-graph]") {
 
 // ── Additional coverage — issue-646 ─────────────────────────────────────
 
-TEST_CASE("GpuGraphRenderer raw-pointer set_data overload — issue-646",
+TEST_CASE("GpuGraphRenderer raw-pointer set_data overload - issue-646",
           "[render][gpu-graph][issue-646]") {
     GpuGraphRenderer g;
     float data[] = {-1.0f, -0.25f, 0.25f, 1.0f};
@@ -65,7 +65,7 @@ TEST_CASE("GpuGraphRenderer raw-pointer set_data overload — issue-646",
     REQUIRE(g.count() == 0);
 }
 
-TEST_CASE("GpuGraphRenderer defaults match documented values — issue-646",
+TEST_CASE("GpuGraphRenderer defaults match documented values - issue-646",
           "[render][gpu-graph][issue-646]") {
     GpuGraphRenderer g;
     REQUIRE(g.line_thickness() == Catch::Approx(1.5f));
@@ -73,7 +73,7 @@ TEST_CASE("GpuGraphRenderer defaults match documented values — issue-646",
     REQUIRE(g.fill_center() == Catch::Approx(0.5f));
 }
 
-TEST_CASE("GpuHeatMapRenderer range set/get — issue-646",
+TEST_CASE("GpuHeatMapRenderer range set/get - issue-646",
           "[render][gpu-graph][issue-646]") {
     GpuHeatMapRenderer h;
     // Defaults.
@@ -92,7 +92,7 @@ TEST_CASE("GpuHeatMapRenderer range set/get — issue-646",
     REQUIRE(h.height() == 0);
 }
 
-TEST_CASE("GpuBarRenderer gap + data accessors — issue-646",
+TEST_CASE("GpuBarRenderer gap + data accessors - issue-646",
           "[render][gpu-graph][issue-646]") {
     GpuBarRenderer b;
     // Defaults.

--- a/test/test_rendering_integration.cpp
+++ b/test/test_rendering_integration.cpp
@@ -330,7 +330,7 @@ TEST_CASE("KTX2 availability check", "[render][ktx2]") {
 // stop cycle. They exercise the factory + public lifecycle surface
 // without requiring a real GPU surface or window handle.
 
-TEST_CASE("RenderLoop factory returns a loop that starts and stops — issue-646",
+TEST_CASE("RenderLoop factory returns a loop that starts and stops - issue-646",
           "[render][loop][issue-646]") {
     auto loop = render::RenderLoop::create();
     REQUIRE(loop != nullptr);
@@ -352,7 +352,7 @@ TEST_CASE("RenderLoop factory returns a loop that starts and stops — issue-646
     REQUIRE_FALSE(loop->is_running());
 }
 
-TEST_CASE("RenderLoop stop is idempotent — issue-646",
+TEST_CASE("RenderLoop stop is idempotent - issue-646",
           "[render][loop][issue-646]") {
     auto loop = render::RenderLoop::create();
     REQUIRE(loop != nullptr);
@@ -366,7 +366,7 @@ TEST_CASE("RenderLoop stop is idempotent — issue-646",
     REQUIRE_FALSE(loop->is_running());
 }
 
-TEST_CASE("RenderLoop destructor stops a running loop — issue-646",
+TEST_CASE("RenderLoop destructor stops a running loop - issue-646",
           "[render][loop][issue-646]") {
     std::atomic<int> frames{0};
     {
@@ -384,7 +384,7 @@ TEST_CASE("RenderLoop destructor stops a running loop — issue-646",
     SUCCEED("RenderLoop destructor joined cleanly");
 }
 
-TEST_CASE("RenderLoop request_frame before start is a safe no-op — issue-646",
+TEST_CASE("RenderLoop request_frame before start is a safe no-op - issue-646",
           "[render][loop][issue-646]") {
     auto loop = render::RenderLoop::create();
     REQUIRE(loop != nullptr);

--- a/test/test_texture_atlas.cpp
+++ b/test/test_texture_atlas.cpp
@@ -86,7 +86,7 @@ TEST_CASE("BufferPool acquire and release", "[render][atlas]") {
 
 // ── Additional coverage — issue-646 ─────────────────────────────────────
 
-TEST_CASE("AtlasPacker starts new shelf when current is full — issue-646",
+TEST_CASE("AtlasPacker starts new shelf when current is full - issue-646",
           "[render][atlas][issue-646]") {
     // 100-wide packer: first 60 fit on shelf 0, second 60 won't fit next to them,
     // so the allocator rolls to a new shelf and returns x=0 at y=shelf_h.
@@ -105,7 +105,7 @@ TEST_CASE("AtlasPacker starts new shelf when current is full — issue-646",
     REQUIRE(p.height() == 200);
 }
 
-TEST_CASE("AtlasPacker returns false when atlas is full — issue-646",
+TEST_CASE("AtlasPacker returns false when atlas is full - issue-646",
           "[render][atlas][issue-646]") {
     AtlasPacker p(64, 64);
     AtlasPacker::Region r{};
@@ -115,7 +115,7 @@ TEST_CASE("AtlasPacker returns false when atlas is full — issue-646",
     REQUIRE_FALSE(p.allocate(64, 20, r));
 }
 
-TEST_CASE("AtlasPacker reset lets us pack again from origin — issue-646",
+TEST_CASE("AtlasPacker reset lets us pack again from origin - issue-646",
           "[render][atlas][issue-646]") {
     AtlasPacker p(64, 64);
     AtlasPacker::Region r{};
@@ -128,7 +128,7 @@ TEST_CASE("AtlasPacker reset lets us pack again from origin — issue-646",
     REQUIRE(r.y == 0);
 }
 
-TEST_CASE("ImageAtlas mark_used keeps live entry from eviction — issue-646",
+TEST_CASE("ImageAtlas mark_used keeps live entry from eviction - issue-646",
           "[render][atlas][issue-646]") {
     ImageAtlas atlas(256);
     AtlasPacker::Region r{};
@@ -145,7 +145,7 @@ TEST_CASE("ImageAtlas mark_used keeps live entry from eviction — issue-646",
     REQUIRE(atlas.entry_count() == 0);
 }
 
-TEST_CASE("ImageAtlas release of unknown key is a no-op — issue-646",
+TEST_CASE("ImageAtlas release of unknown key is a no-op - issue-646",
           "[render][atlas][issue-646]") {
     ImageAtlas atlas(128);
     atlas.release(999);                 // no entry, must not crash or mutate
@@ -154,7 +154,7 @@ TEST_CASE("ImageAtlas release of unknown key is a no-op — issue-646",
     REQUIRE(atlas.entry_count() == 0);
 }
 
-TEST_CASE("ImageAtlas skips eviction while ref_count is non-zero — issue-646",
+TEST_CASE("ImageAtlas skips eviction while ref_count is non-zero - issue-646",
           "[render][atlas][issue-646]") {
     ImageAtlas atlas(128);
     AtlasPacker::Region r{};
@@ -164,7 +164,7 @@ TEST_CASE("ImageAtlas skips eviction while ref_count is non-zero — issue-646",
     REQUIRE(atlas.entry_count() == 1);
 }
 
-TEST_CASE("GradientAtlas has() reflects allocation and mark_used no-ops — issue-646",
+TEST_CASE("GradientAtlas has() reflects allocation and mark_used no-ops - issue-646",
           "[render][atlas][issue-646]") {
     GradientAtlas ga;
     REQUIRE_FALSE(ga.has(42));
@@ -178,7 +178,7 @@ TEST_CASE("GradientAtlas has() reflects allocation and mark_used no-ops — issu
     REQUIRE(ga.entry_count() == 1);
 }
 
-TEST_CASE("GlyphAtlas allocate reuses same key, evicts by age — issue-646",
+TEST_CASE("GlyphAtlas allocate reuses same key, evicts by age - issue-646",
           "[render][atlas][issue-646]") {
     GlyphAtlas atlas(256);
     AtlasPacker::Region r1{};
@@ -205,7 +205,7 @@ TEST_CASE("GlyphAtlas allocate reuses same key, evicts by age — issue-646",
     REQUIRE(atlas.entry_count() == 0);
 }
 
-TEST_CASE("GlyphAtlas rejects oversized glyph — issue-646",
+TEST_CASE("GlyphAtlas rejects oversized glyph - issue-646",
           "[render][atlas][issue-646]") {
     GlyphAtlas atlas(32);
     AtlasPacker::Region r{};
@@ -213,7 +213,7 @@ TEST_CASE("GlyphAtlas rejects oversized glyph — issue-646",
     REQUIRE(atlas.entry_count() == 0);
 }
 
-TEST_CASE("PathAtlas allocate, cache hit, and eviction — issue-646",
+TEST_CASE("PathAtlas allocate, cache hit, and eviction - issue-646",
           "[render][atlas][issue-646]") {
     PathAtlas atlas(256);
     AtlasPacker::Region r1{};
@@ -234,7 +234,7 @@ TEST_CASE("PathAtlas allocate, cache hit, and eviction — issue-646",
     REQUIRE(atlas.entry_count() == 0);
 }
 
-TEST_CASE("PathAtlas rejects oversized path bitmap — issue-646",
+TEST_CASE("PathAtlas rejects oversized path bitmap - issue-646",
           "[render][atlas][issue-646]") {
     PathAtlas atlas(64);
     AtlasPacker::Region r{};
@@ -242,7 +242,7 @@ TEST_CASE("PathAtlas rejects oversized path bitmap — issue-646",
     REQUIRE(atlas.entry_count() == 0);
 }
 
-TEST_CASE("BufferPool caps retained buffers at max_pool_size — issue-646",
+TEST_CASE("BufferPool caps retained buffers at max_pool_size - issue-646",
           "[render][atlas][issue-646]") {
     BufferPool<int> pool;
     // max_pool_size_ defaults to 32 (see texture_atlas.hpp); release many more


### PR DESCRIPTION
## Summary

Closes [#707](https://github.com/danielraffel/pulp/issues/707), supersedes [#708](https://github.com/danielraffel/pulp/pull/708).

Replaces em-dashes (\`—\`) with ASCII hyphens (\`-\`) in the 20 TEST_CASE name strings added in #700 (render coverage tranche 1). Codifies the rule in the commit message so future contributors don't reintroduce them.

## Why this over the #708 approach

Spent today chasing MSVC CP_ACP argv decoding, \`chcp\` workflow wrappers, \`/utf-8\` compile flag, cmd-shell ctest wrapping — all plausible fixes, all mixed results on Namespace Windows. **The simplest load-bearing fix is to not use em-dashes in TEST_CASE names.** Text substitution is guaranteed to work, requires zero infrastructure changes, survives any Windows encoding config.

## Scope

- 3 files, 20 string replacements inside `TEST_CASE("...")` first-arg strings only. Comments + non-test em-dashes untouched.
- No CMakeLists change, no workflow change, no compile flag change.

## Rule going forward

ASCII hyphens in TEST_CASE names. Em-dashes fine in comments, docs, anywhere else. Commit message is the rationale; `git log -p test/` surfaces it on search.

## Unblocks

Every subsequent PR's Windows (x64) [namespace] lane. No more admin-merge for em-dash encoding failures.