### PR TITLE
ci(coverage): normalize Python coverage surface

### DIFF
--- a/docs/guides/coverage.md
+++ b/docs/guides/coverage.md
@@ -112,7 +112,7 @@ Output:
 - `build-coverage/python/summary.txt` — text summary for the Python
   tooling lane.
 - `build-coverage/python/coverage.python.xml` — Cobertura XML emitted
-  by coverage.py for the Python tooling lane.
+  by coverage.py and normalized by the Python tooling lane.
 - `build-coverage/apple/summary.txt` — text summary for the Apple
   Swift source files under `apple/Sources/`.
 - `build-coverage/apple/coverage.apple.json` — SwiftPM LLVM coverage
@@ -140,6 +140,16 @@ just the test harness. `PyYAML` is also required because
 the lane. The generated coverage config also omits Python test modules
 from the reported source set so the lane reflects first-party tooling
 code rather than the test harness.
+
+After `coverage combine`, `tools/scripts/run_python_coverage.py`
+explicitly inventories the configured non-test `.py` source roots and
+marks unexecuted files as measured before report generation. This keeps
+zero-hit files visible as 0% rows instead of letting coverage.py's
+package discovery hide non-package helper directories such as
+`tools/packages/`. The generated Cobertura XML is also normalized to
+repo-relative filenames with `<source>.</source>` so Codecov attributes
+entries like `tools/audit.py`, `tools/deps/audit.py`, and
+`core/view/js/embed_js.py` unambiguously.
 
 The Apple Swift lane currently runs on macOS only because it uses
 SwiftPM's native coverage support (`swift test --enable-code-coverage`)

--- a/tools/scripts/run_python_coverage.py
+++ b/tools/scripts/run_python_coverage.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -173,6 +174,87 @@ def _resolved_omit_globs(surfaces: list[CoverageSurface]) -> list[str]:
     )
 
 
+def _matches_any_glob(rel_path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(rel_path, pattern) for pattern in patterns)
+
+
+def _report_source_files(source_roots: list[str], omit_globs: list[str]) -> list[Path]:
+    files: list[Path] = []
+    seen: set[Path] = set()
+    for source_root in source_roots:
+        root = REPO_ROOT / source_root
+        candidates = [root] if root.is_file() else sorted(root.rglob("*.py"))
+        for path in candidates:
+            if not path.is_file() or path.suffix != ".py":
+                continue
+            rel_path = path.relative_to(REPO_ROOT).as_posix()
+            if _matches_any_glob(rel_path, omit_globs):
+                continue
+            if path in seen:
+                continue
+            seen.add(path)
+            files.append(path)
+    return files
+
+
+def _touch_report_source_files(
+    cov: coverage.Coverage,
+    source_roots: list[str],
+    omit_globs: list[str],
+) -> None:
+    data = cov.get_data()
+    for path in _report_source_files(source_roots, omit_globs):
+        data.touch_file(path.relative_to(REPO_ROOT).as_posix())
+
+
+def _repo_relative_xml_filename(filename: str, sources: list[str]) -> str:
+    normalized = filename.replace("\\", "/")
+    candidate = Path(normalized)
+    if candidate.is_absolute():
+        try:
+            return candidate.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+        except ValueError:
+            return normalized
+
+    if (REPO_ROOT / normalized).exists():
+        return normalized
+
+    for source in sources:
+        source_path = Path(source or ".")
+        if source_path.is_absolute():
+            full_path = source_path / normalized
+            try:
+                return full_path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+            except ValueError:
+                continue
+        rel_path = (source_path / normalized).as_posix()
+        if (REPO_ROOT / rel_path).exists():
+            return rel_path
+
+    return normalized
+
+
+def _rewrite_cobertura_filenames(xml_file: Path) -> None:
+    tree = ET.parse(xml_file)
+    root = tree.getroot()
+    sources_element = root.find("sources")
+    sources = [
+        source.text or "."
+        for source in root.findall("./sources/source")
+    ]
+    for class_element in root.findall(".//class"):
+        filename = class_element.get("filename")
+        if not filename:
+            continue
+        class_element.set("filename", _repo_relative_xml_filename(filename, sources))
+
+    if sources_element is not None:
+        sources_element.clear()
+        ET.SubElement(sources_element, "source").text = "."
+
+    tree.write(xml_file, encoding="utf-8", xml_declaration=True)
+
+
 def _write_coveragerc(surfaces: list[CoverageSurface]) -> None:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     source_roots = _normalized_source_roots(surfaces)
@@ -243,9 +325,12 @@ def _run_test(test_path: Path, env: dict[str, str]) -> int:
     return proc.returncode
 
 
-def _build_reports() -> None:
+def _build_reports(surfaces: list[CoverageSurface]) -> None:
+    source_roots = _normalized_source_roots(surfaces)
+    omit_globs = _resolved_omit_globs(surfaces)
     cov = coverage.Coverage(config_file=str(RCFILE), data_file=str(DATA_FILE))
     cov.combine(data_paths=[str(OUTPUT_DIR)], strict=True)
+    _touch_report_source_files(cov, source_roots, omit_globs)
     cov.save()
 
     with SUMMARY_FILE.open("w", encoding="utf-8") as fh:
@@ -253,6 +338,7 @@ def _build_reports() -> None:
     print(SUMMARY_FILE.read_text(encoding="utf-8"), end="")
     cov.html_report(directory=str(HTML_DIR))
     cov.xml_report(outfile=str(XML_FILE))
+    _rewrite_cobertura_filenames(XML_FILE)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -299,7 +385,7 @@ def main(argv: list[str] | None = None) -> int:
             failures.append(f"{test_path.relative_to(REPO_ROOT)} (exit {rc})")
 
     try:
-        _build_reports()
+        _build_reports(surfaces)
     except coverage.exceptions.NoDataError:
         print("run_python_coverage.py: coverage.py produced no data", file=sys.stderr)
         return 1

--- a/tools/scripts/test_run_python_coverage.py
+++ b/tools/scripts/test_run_python_coverage.py
@@ -8,6 +8,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
+import xml.etree.ElementTree as ET
 from unittest import mock
 
 
@@ -103,6 +104,116 @@ class CoveragercTests(unittest.TestCase):
             ]
         )
         self.assertEqual(rpc._normalized_source_roots(surfaces), ["tools", "core/view/js"])
+
+    def test_report_source_files_recurses_into_non_package_tooling_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            for rel_path in (
+                "tools/audit.py",
+                "tools/test_audit.py",
+                "tools/packages/freshness_check.py",
+                "tools/packages/validate_registry.py",
+                "tools/packages/_private.py",
+                "core/view/js/embed_js.py",
+            ):
+                path = root / rel_path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("print('covered by inventory')\n", encoding="utf-8")
+
+            with mock.patch.object(rpc, "REPO_ROOT", root):
+                files = rpc._report_source_files(
+                    ["tools", "core/view/js"],
+                    [
+                        "tools/test_*.py",
+                        "tools/packages/_*.py",
+                        "core/view/js/_*.py",
+                    ],
+                )
+
+            self.assertEqual(
+                [path.relative_to(root).as_posix() for path in files],
+                [
+                    "tools/audit.py",
+                    "tools/packages/freshness_check.py",
+                    "tools/packages/validate_registry.py",
+                    "core/view/js/embed_js.py",
+                ],
+            )
+
+    def test_touch_report_source_files_marks_unexecuted_sources_measured(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            source = root / "tools/packages/freshness_check.py"
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_text("print('zero hit source')\n", encoding="utf-8")
+            omitted = root / "tools/packages/_private.py"
+            omitted.write_text("print('not reportable')\n", encoding="utf-8")
+
+            touched: list[str] = []
+            fake_data = mock.Mock()
+            fake_data.touch_file.side_effect = touched.append
+            fake_cov = mock.Mock()
+            fake_cov.get_data.return_value = fake_data
+
+            with mock.patch.object(rpc, "REPO_ROOT", root):
+                rpc._touch_report_source_files(
+                    fake_cov,
+                    ["tools"],
+                    ["tools/packages/_*.py"],
+                )
+
+            self.assertEqual(touched, ["tools/packages/freshness_check.py"])
+
+    def test_rewrite_cobertura_filenames_uses_repo_relative_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            for rel_path in (
+                "tools/audit.py",
+                "tools/deps/audit.py",
+                "core/view/js/embed_js.py",
+            ):
+                path = root / rel_path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("print('source')\n", encoding="utf-8")
+
+            xml = root / "coverage.xml"
+            xml.write_text(
+                """<?xml version="1.0" ?>
+<coverage>
+  <sources>
+    <source>core/view/js</source>
+    <source>tools</source>
+  </sources>
+  <packages>
+    <package name="">
+      <classes>
+        <class name="audit.py" filename="audit.py" />
+        <class name="deps/audit.py" filename="deps/audit.py" />
+        <class name="embed_js.py" filename="embed_js.py" />
+      </classes>
+    </package>
+  </packages>
+</coverage>
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(rpc, "REPO_ROOT", root):
+                rpc._rewrite_cobertura_filenames(xml)
+
+            tree = ET.parse(xml)
+            self.assertEqual(
+                [source.text for source in tree.findall("./sources/source")],
+                ["."],
+            )
+            self.assertEqual(
+                [node.get("filename") for node in tree.findall(".//class")],
+                [
+                    "tools/audit.py",
+                    "tools/deps/audit.py",
+                    "core/view/js/embed_js.py",
+                ],
+            )
 
 
 class MainFlowTests(unittest.TestCase):

--- a/tools/scripts/test_run_python_coverage.py
+++ b/tools/scripts/test_run_python_coverage.py
@@ -140,6 +140,26 @@ class CoveragercTests(unittest.TestCase):
                 ],
             )
 
+    def test_report_source_files_accepts_file_roots_and_dedupes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            source = root / "tools/audit.py"
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_text("print('source')\n", encoding="utf-8")
+            not_python = root / "tools/README.txt"
+            not_python.write_text("not python\n", encoding="utf-8")
+
+            with mock.patch.object(rpc, "REPO_ROOT", root):
+                files = rpc._report_source_files(
+                    ["tools/audit.py", "tools", "tools/README.txt"],
+                    [],
+                )
+
+            self.assertEqual(
+                [path.relative_to(root).as_posix() for path in files],
+                ["tools/audit.py"],
+            )
+
     def test_touch_report_source_files_marks_unexecuted_sources_measured(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = pathlib.Path(td)
@@ -163,6 +183,39 @@ class CoveragercTests(unittest.TestCase):
                 )
 
             self.assertEqual(touched, ["tools/packages/freshness_check.py"])
+
+    def test_repo_relative_xml_filename_handles_all_resolution_modes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            source = root / "tools/audit.py"
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_text("print('source')\n", encoding="utf-8")
+
+            outside = pathlib.Path(td).parent / "outside_coverage_source.py"
+            outside.write_text("print('outside')\n", encoding="utf-8")
+            self.addCleanup(lambda: outside.unlink(missing_ok=True))
+
+            with mock.patch.object(rpc, "REPO_ROOT", root):
+                self.assertEqual(
+                    rpc._repo_relative_xml_filename(str(source), []),
+                    "tools/audit.py",
+                )
+                self.assertEqual(
+                    rpc._repo_relative_xml_filename(str(outside), []),
+                    str(outside),
+                )
+                self.assertEqual(
+                    rpc._repo_relative_xml_filename("tools/audit.py", []),
+                    "tools/audit.py",
+                )
+                self.assertEqual(
+                    rpc._repo_relative_xml_filename("audit.py", [str(root / "tools")]),
+                    "tools/audit.py",
+                )
+                self.assertEqual(
+                    rpc._repo_relative_xml_filename("missing.py", [str(outside.parent)]),
+                    "missing.py",
+                )
 
     def test_rewrite_cobertura_filenames_uses_repo_relative_paths(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -214,6 +267,38 @@ class CoveragercTests(unittest.TestCase):
                     "core/view/js/embed_js.py",
                 ],
             )
+
+    def test_rewrite_cobertura_filenames_handles_missing_sources_and_filenames(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            xml = root / "coverage.xml"
+            xml.write_text(
+                """<?xml version="1.0" ?>
+<coverage>
+  <packages>
+    <package name="">
+      <classes>
+        <class name="without-filename" />
+        <class name="unknown.py" filename="unknown.py" />
+      </classes>
+    </package>
+  </packages>
+</coverage>
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(rpc, "REPO_ROOT", root):
+                rpc._rewrite_cobertura_filenames(xml)
+
+            tree = ET.parse(xml)
+            classes = tree.findall(".//class")
+            self.assertIsNone(classes[0].get("filename"))
+            self.assertEqual(classes[1].get("filename"), "unknown.py")
+
+    def test_write_coveragerc_rejects_empty_surface_selection(self) -> None:
+        with self.assertRaisesRegex(ValueError, "no coverage surfaces selected"):
+            rpc._write_coveragerc([])
 
 
 class MainFlowTests(unittest.TestCase):
@@ -310,6 +395,69 @@ class MainFlowTests(unittest.TestCase):
             [surface.source_roots for surface in surfaces],
             [("tools/scripts",), ("tools", "core/view/js")],
         )
+
+    def test_run_test_invokes_coverage_cli(self) -> None:
+        fake_proc = mock.Mock(returncode=7)
+        with mock.patch.object(rpc.subprocess, "run", return_value=fake_proc) as run:
+            rc = rpc._run_test(
+                rpc.REPO_ROOT / "tools/scripts/test_alpha.py",
+                {"COVERAGE_FILE": "data"},
+            )
+
+        self.assertEqual(rc, 7)
+        self.assertEqual(run.call_args.kwargs["cwd"], rpc.REPO_ROOT)
+        self.assertEqual(run.call_args.kwargs["env"], {"COVERAGE_FILE": "data"})
+        self.assertEqual(
+            run.call_args.args[0],
+            [
+                sys.executable,
+                "-m",
+                "coverage",
+                "run",
+                "--rcfile",
+                str(rpc.RCFILE),
+                "--parallel-mode",
+                "tools/scripts/test_alpha.py",
+            ],
+        )
+
+    def test_build_reports_combines_touches_and_rewrites_outputs(self) -> None:
+        fake_cov = mock.Mock()
+        fake_coverage = mock.Mock()
+        fake_coverage.Coverage.return_value = fake_cov
+
+        def fake_report(file, show_missing: bool) -> None:
+            self.assertTrue(show_missing)
+            file.write("summary\n")
+
+        fake_cov.report.side_effect = fake_report
+        surfaces = [rpc.CoverageSurface(("tools",), ("tools/test_*.py",))]
+
+        with tempfile.TemporaryDirectory() as td:
+            output = pathlib.Path(td)
+            summary = output / "summary.txt"
+            xml = output / "coverage.xml"
+            html = output / "html"
+
+            with mock.patch.object(rpc, "OUTPUT_DIR", output), \
+                 mock.patch.object(rpc, "SUMMARY_FILE", summary), \
+                 mock.patch.object(rpc, "XML_FILE", xml), \
+                 mock.patch.object(rpc, "HTML_DIR", html), \
+                 mock.patch.object(rpc, "coverage", fake_coverage), \
+                 mock.patch.object(rpc, "_touch_report_source_files") as touch, \
+                 mock.patch.object(rpc, "_rewrite_cobertura_filenames") as rewrite:
+                rpc._build_reports(surfaces)
+
+        fake_coverage.Coverage.assert_called_once_with(
+            config_file=str(rpc.RCFILE),
+            data_file=str(rpc.DATA_FILE),
+        )
+        fake_cov.combine.assert_called_once_with(data_paths=[str(output)], strict=True)
+        fake_cov.save.assert_called_once_with()
+        fake_cov.html_report.assert_called_once_with(directory=str(html))
+        fake_cov.xml_report.assert_called_once_with(outfile=str(xml))
+        touch.assert_called_once_with(fake_cov, ["tools"], ["tools/test_*.py", "tools/_*.py"])
+        rewrite.assert_called_once_with(xml)
 
     def test_main_includes_broader_slice_for_default_tooling_tests(self) -> None:
         tests = [rpc.REPO_ROOT / "tools/scripts/test_alpha.py"]


### PR DESCRIPTION
## Summary
- enumerate configured non-test Python source files before report generation so zero-hit helpers remain visible in the Python coverage lane
- normalize Python Cobertura XML filenames to repo-relative paths with a single source root for Codecov attribution
- document the Python lane inventory/normalization behavior

Refs #641.

## Validation
- python3 tools/scripts/test_run_python_coverage.py
- python3 tools/scripts/test_codecov_config.py
- python3 tools/scripts/test_docs_sync_check.py
- python3 tools/scripts/docs_sync_check.py --base origin/main --mode report
- /tmp/pulp-phase1-cov-venv/bin/python tools/scripts/run_python_coverage.py