### PR TITLE
chore: bump Shipyard pin v0.40.0 → v0.46.0

### DIFF
--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -242,7 +242,7 @@
 # in `tools/install-shipyard.sh` (v0.22.1+ `SHIPYARD_VERSION` support).
 # The older `~/.pulp/bin/shipyard` path is cleaned up on install to
 # prevent shadow-on-PATH bugs.
-version = "v0.40.0"
+version = "v0.46.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Bumps the pinned Shipyard version from v0.40.0 to **v0.46.0**.

Verified locally:
- [x] `./tools/install-shipyard.sh` succeeded
- [x] `shipyard --version` matches target

Release notes: https://github.com/danielraffel/Shipyard/releases/tag/v0.46.0