### PR TITLE
chore: bump Shipyard pin v0.40.0 to v0.46.0

### DIFF
--- a/.github/workflows/post-tag-sync.yml
+++ b/.github/workflows/post-tag-sync.yml
@@ -20,7 +20,7 @@ permissions:
   contents: write
 
 env:
-  SHIPYARD_VERSION: "0.40.0"
+  SHIPYARD_VERSION: "0.46.0"
 
 jobs:
   sync:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -21,8 +21,10 @@ concurrency:
 env:
   # Pin shipyard to the same version post-tag-sync.yml uses so
   # `shipyard changelog regenerate --release-notes` produces the
-  # same output as the hook that writes CHANGELOG.md.
-  SHIPYARD_VERSION: "0.40.0"
+  # same output as the hook that writes CHANGELOG.md. Must track
+  # tools/shipyard.toml to avoid split behavior between local flows
+  # and release-time jobs (Codex P1 on PR #719).
+  SHIPYARD_VERSION: "0.46.0"
 
 jobs:
   build-cli:


### PR DESCRIPTION
Updates Pulp's checked-in Shipyard pin to v0.46.0.

Verification:
- `shipyard pin bump --to v0.46.0 --no-pr`
- `shipyard --version` -> `shipyard, version 0.46.0`