### PR TITLE
chore(release): bump SDK 0.42.0 → 0.42.1 to verify #724 fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.42.0
+    VERSION 0.42.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Summary

One-line SDK bump to trigger a fresh release pipeline that exercises PR #725's sign-and-release fix end-to-end.

PR #725 (squash `f5ede1ca`) merged earlier — added `permissions: contents: write` to `sign-and-release.yml`'s macOS job, the structural fix for the long-running silent failure pattern in #724. But PR #725 only bumped the plugin (0.15.0 → 0.15.1), so `auto-release.yml` cut a `plugin-v0.15.1` tag, and the SDK release workflows (`release-cli.yml` + `sign-and-release.yml`) only fire on `v*` SDK tags. The fix never actually ran.

This bump cuts `v0.42.1`, which:
1. Triggers `release-cli.yml` (should publish CLI + SDK binaries for all 5 platforms — same path as v0.42.0)
2. Triggers `sign-and-release.yml` (should now go GREEN end-to-end with the contents:write fix from #725)
3. macOS artifacts get codesigned + notarized for the first time in 30+ release cycles

If both go green and the v0.42.1 GitHub Release exists with macOS notarization metadata, #724 closes with verified evidence and the followup is a sweep of the older releases (v0.40.x, v0.41.x, v0.42.0) that shipped without sign-and-release ever succeeding.

## Test plan

- [ ] CI green on this PR
- [ ] Merge → `auto-release.yml` cuts `v0.42.1` tag
- [ ] `release-cli.yml` succeeds on `v0.42.1` (binaries published)
- [ ] `sign-and-release.yml` succeeds on `v0.42.1` (macOS notarized)
- [ ] GH Release `v0.42.1` exists with all expected assets

## Trailers

`Version-Bump: sdk=patch` — explicit; the bump itself IS the change, version_bump_check.py wouldn't infer it from heuristics.

`Skill-Update: skip skill=ci` — no skill content change; PR #725 already documented the gotcha in `ci` and `ship` SKILL.md.