### PR TITLE
docs(skills): Claude bundled-React export shapes + shipyard quiescent-tree

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -157,6 +157,52 @@ Flags:
 Automation (crons, agents) should branch on exit code 3 specifically rather
 than parsing error strings.
 
+### Quiescent working tree required — no edits during a shipyard run
+
+`shipyard run` and `shipyard ship` read the live working tree throughout
+the configure / build / test stages — there is no sandbox, snapshot, or
+content-hash guard at the shipyard pin as of v0.46.0. Any file write
+between `shipyard run` starting and a stage reading the tree corrupts
+the run non-deterministically. This matters because:
+
+- The build is ~30 minutes of SSH/local work; you lose the whole cycle,
+  not a checkpoint.
+- The failure surfaces as a misleading compile error deep in the log
+  (e.g. `error: no member named 'X' in 'Y'` when a .cpp file referenced
+  in CMakeLists.txt was deleted on a parallel branch mid-configure).
+  Nothing in the error points at the root cause.
+- Switching branches in the same worktree also counts as an edit — git
+  changes the files on disk.
+
+**Discipline (agent-applicable)**:
+
+- Before starting any edit in the repo, check whether a `shipyard run`
+  or `shipyard ship` is in flight locally or queued. Shipyard prints a
+  dim one-liner at run start warning about this (Shipyard #238 fix);
+  agents running it via `run_in_background` must still self-enforce
+  since the banner scrolls past.
+- For genuine parallel work on two branches, use separate git worktrees
+  (`git worktree add ../pulp-other-feature other-branch`) — each
+  worktree has its own file tree, so edits don't cross-contaminate.
+- If you must interleave, queue the shipyard ship **after** all edits
+  are committed and the branch is static.
+
+**Recovery when this bites**:
+
+- `shipyard ship` exits non-zero with a real failure log; the PR is not
+  merged. Revert to a clean tree state on the target branch
+  (`git checkout <branch>` + `git status` shows no diff), then re-run
+  `shipyard ship`. It should pass the second time.
+- Don't diagnose the original compile error — it's a race symptom, not
+  a real bug in your PR.
+
+**Longer-term fix tracked**: Shipyard #249 proposes tree-hash drift
+detection (fail-fast at each stage boundary instead of silent 30-minute
+builds). Until that ships, the discipline above is load-bearing.
+
+Related: Shipyard #238 (doc-only fix, landed 2026-04-24), #249 (P2
+follow-up with tree-hash proposal).
+
 ## Tool selection: Shipyard (primary)
 
 **Shipyard is Pulp's primary CI tool.** All merges, validations, and

--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -50,6 +50,17 @@ Ask the user or detect from context:
 - Run `pulp import-design --from claude --file <path>` — the parser delegates to the Stitch HTML pipeline and tags the IR as Claude.
 - The CLI also writes a `bridge_handlers.cpp` scaffold next to the generated JS (override path with `--bridge-output`, skip with `--no-bridge-scaffold`). The scaffold demonstrates registering `pulp::view::EditorBridge` handlers and attaching to a `WebViewPanel` (or future `JsRuntime`).
 
+**Claude Design export file shapes (2026-04-24)**:
+Claude's "standalone HTML" export comes in two shapes — know which one you have before you spend time on the output:
+
+1. **Static HTML** — plain DOM markup (or Claude artifacts that render without a build step). Parses cleanly through the current static walker; produces real `pulp::view` output plus the bridge scaffold.
+
+2. **Bundled-React envelope** — the inline `<script>` is NOT raw JS. It's a JSON envelope mapping UUID → `{mime, compressed, data}`, where `data` is **base64-encoded gzip-compressed** asset payloads (JS bundles + woff2 fonts). A single export observed in the wild was 1.86 MB on disk / 4.3 MB of JS inflated across 3 assets + 13 woff2 fonts. The JS half is typically `react.development.js` + the app code.
+
+**The static walker handles case 1 today.** For case 2 it captures ~9 elements of shell (loader div, `#__bundler_loading` / `#__bundler_thumbnail`, `<style>` and `<script>` bodies as labels) — NOT the actual editor UI, because the UI only materializes after React executes the bundled JS. Consumer-side diagnostic: if `--from claude` output reports `"9 elements: 1 containers, 0 widgets, 8 labels"` and the input file is >500 KB, it's almost certainly a bundled-React export hitting case 2.
+
+Case 2 requires the **native-runtime import path** (`--execute-bundle`, tracked in pulp #468 + #731): unpack the envelope → run the JS in Pulp's JS engine against the `web-compat-*` polyfill layer → walk the materialized DOM → lower to `pulp::view` calls. Until that lane ships, case-2 inputs should either be re-exported as static HTML or deferred. The web-compat shims landed in pulp #730 (nodeType/nodeName on Element, MessageChannel/queueMicrotask polyfills, observer stubs) — that's the prerequisite; the harness itself lands in #731.
+
 **File-based fallback**:
 - Read the file and parse based on --from source type
 


### PR DESCRIPTION
**import-design**: extend the existing Claude Design section with the
two-shape classification observed in the wild on 2026-04-24:
1. Static HTML → parses cleanly today.
2. Bundled-React envelope (JSON map of UUID → gzip+base64 assets)
   which only materializes the real UI after JS execution; static
   walker captures ~9 shell elements ("9 elements: 1 containers,
   0 widgets, 8 labels") instead of the editor.

Consumer diagnostic: >500 KB input + 9-element output almost always
means case 2. Case 2 needs the native-runtime harness tracked in
pulp #468 / #731 (web-compat shims in #730, harness in #731).

**ci**: new "Quiescent working tree required" section. shipyard run
and shipyard ship read the live working tree throughout all stages;
edits mid-run (including branch switches) corrupt the build with
misleading compile errors. Document the discipline (separate worktrees
for parallel work) and the recovery path (revert + re-ship). Cross-ref
Shipyard #238 (doc-only fix landed today) and #249 (P2 tree-hash
drift-detection follow-up).

Skill-Update: skip skill=clap reason="docs-only SKILL additions; not touching core/format/clap_*"
Skill-Update: skip skill=hosting reason="docs-only SKILL additions; not touching core/host/plugin_slot_clap*"