### PR TITLE
test(midi): cover MPE UMP and signal meter helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0430"></a>
+## [0.44.0]
+
 ## [0.43.0] - 2026-04-24
 
 - feat(view): web-compat shims for bundled-React imports (pulp #468 PR 1/2) ([#730](https://github.com/danielraffel/pulp/pull/730))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.43.0
+    VERSION 0.44.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/signal/include/pulp/signal/multi_channel_meter.hpp
+++ b/core/signal/include/pulp/signal/multi_channel_meter.hpp
@@ -127,6 +127,7 @@ public:
         for (int ch = 0; ch < kMaxMeterChannels; ++ch) {
             block_peak_[ch] = 0.0f;
             block_sum_sq_[ch] = 0.0f;
+            block_clipped_[ch] = false;
             lufs_sum_sq_[ch] = 0.0f;
         }
         block_samples_ = 0;

--- a/test/test_midi.cpp
+++ b/test/test_midi.cpp
@@ -1,7 +1,34 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <pulp/midi/midi.hpp>
+#include <pulp/midi/midi_file.hpp>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
 
 using namespace pulp::midi;
+using Catch::Approx;
+
+namespace {
+
+namespace fs = std::filesystem;
+
+struct TempDir {
+    fs::path path;
+
+    TempDir() {
+        const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+        path = fs::temp_directory_path() / ("pulp-midi-test-" + std::to_string(stamp));
+        fs::create_directories(path);
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+} // namespace
 
 TEST_CASE("MidiEvent factory methods", "[midi][message]") {
     SECTION("Note on") {
@@ -94,6 +121,60 @@ TEST_CASE("MidiBuffer operations", "[midi][buffer]") {
         buf.clear();
         REQUIRE(buf.empty());
     }
+}
+
+TEST_CASE("MidiFileData summarizes tracks", "[midi][file]") {
+    MidiFileData data;
+    MidiTrack first;
+    first.events.push_back({0.25, MidiEvent::note_on(0, 60, 100)});
+    first.events.push_back({1.50, MidiEvent::note_off(0, 60)});
+
+    MidiTrack second;
+    second.events.push_back({0.75, MidiEvent::cc(1, 74, 64)});
+
+    data.tracks.push_back(std::move(first));
+    data.tracks.push_back(std::move(second));
+
+    REQUIRE(data.total_events() == 3);
+    REQUIRE(data.duration_seconds() == Approx(1.50).margin(1e-6));
+}
+
+TEST_CASE("MidiFile read/write round-trips short messages", "[midi][file]") {
+    TempDir tmp;
+    const auto path = tmp.path / "roundtrip.mid";
+
+    MidiFileData data;
+    data.ticks_per_quarter = 960;
+
+    MidiTrack track;
+    track.events.push_back({0.00, MidiEvent::note_on(0, 60, 100)});
+    track.events.push_back({0.50, MidiEvent::cc(0, 74, 127)});
+    track.events.push_back({1.00, MidiEvent::note_off(0, 60)});
+    data.tracks.push_back(std::move(track));
+
+    REQUIRE(write_midi_file(path.string(), data));
+
+    auto read = read_midi_file(path.string());
+    REQUIRE(read.has_value());
+    REQUIRE(read->ticks_per_quarter == 960);
+    REQUIRE(read->total_events() == 3);
+    REQUIRE(read->duration_seconds() == Approx(1.0).margin(0.05));
+}
+
+TEST_CASE("MidiFile helpers report missing, corrupt, and unwritable files", "[midi][file]") {
+    TempDir tmp;
+
+    REQUIRE_FALSE(read_midi_file((tmp.path / "missing.mid").string()).has_value());
+
+    const auto corrupt = tmp.path / "corrupt.mid";
+    {
+        std::ofstream out(corrupt, std::ios::binary);
+        out << "not a midi file";
+    }
+    REQUIRE_FALSE(read_midi_file(corrupt.string()).has_value());
+
+    MidiFileData empty;
+    REQUIRE_FALSE(write_midi_file((tmp.path / "missing-parent" / "out.mid").string(), empty));
 }
 
 #if defined(__APPLE__) && !TARGET_OS_IPHONE

--- a/test/test_mpe_voice_tracker.cpp
+++ b/test/test_mpe_voice_tracker.cpp
@@ -176,3 +176,73 @@ TEST_CASE("MpeVoiceTracker reset clears per-channel expression caches", "[midi][
     REQUIRE(n->pressure == Approx(0.0f).margin(1e-6f));
     REQUIRE(n->timbre == Approx(0.0f).margin(1e-6f));
 }
+
+TEST_CASE("MpeVoiceTracker dispatches MIDI 1.0 UMP packets through MPE zones", "[midi][mpe][ump]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+
+    REQUIRE(tracker.process(UmpPacket::midi1_note_on(0, 1, 60, 100)));
+
+    const auto* n = tracker.find(1, 60);
+    REQUIRE(n != nullptr);
+    REQUIRE(n->velocity == 100);
+    REQUIRE(tracker.active_count() == 1);
+}
+
+TEST_CASE("MpeVoiceTracker applies MIDI 2.0 per-note expression to the matching note", "[midi][mpe][ump]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.set_member_bend_range(48.0f);
+
+    REQUIRE(tracker.process(UmpPacket::note_on_2(0, 1, 60, 0x8000)));
+    REQUIRE(tracker.process(UmpPacket::note_on_2(0, 2, 64, 0x8000)));
+
+    REQUIRE(tracker.process(UmpPacket::per_note_pitch_bend(0, 1, 60, 0xC0000000)));
+    REQUIRE(tracker.process(UmpPacket::registered_per_note_cc(0, 1, 60, 74, 0xFFFFFFFF)));
+
+    const auto* bent = tracker.find(1, 60);
+    const auto* untouched = tracker.find(2, 64);
+    REQUIRE(bent != nullptr);
+    REQUIRE(untouched != nullptr);
+    REQUIRE(bent->pitch_bend_semitones == Approx(24.0f).margin(0.01f));
+    REQUIRE(bent->timbre == Approx(1.0f).margin(1e-6f));
+    REQUIRE(untouched->pitch_bend_semitones == Approx(0.0f).margin(1e-6f));
+    REQUIRE(untouched->timbre == Approx(0.0f).margin(1e-6f));
+}
+
+TEST_CASE("MpeVoiceTracker handles MIDI 2.0 manager state and note release variants", "[midi][mpe][ump]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(15)};
+    tracker.set_manager_bend_range(2.0f);
+
+    REQUIRE(tracker.process(UmpPacket::pitch_bend_2(0, 0, 0x00000000)));
+    REQUIRE(tracker.lower_zone_state().pitch_bend_semitones == Approx(-2.0f).margin(0.01f));
+
+    REQUIRE(tracker.process(UmpPacket::cc_2(0, 0, 74, 0x80000000)));
+    REQUIRE(tracker.lower_zone_state().timbre == Approx(0.5f).margin(0.001f));
+
+    UmpPacket pressure;
+    pressure.word_count = 2;
+    pressure.words[0] = (0x4u << 28) | (uint32_t(0xD0) << 16);
+    pressure.words[1] = 0x80000000u;
+    REQUIRE(tracker.process(pressure));
+    REQUIRE(tracker.lower_zone_state().pressure == Approx(0.5f).margin(0.001f));
+
+    REQUIRE(tracker.process(UmpPacket::note_on_2(0, 3, 67, 0xFFFF)));
+    REQUIRE(tracker.active_count() == 1);
+    REQUIRE(tracker.process(UmpPacket::note_on_2(0, 3, 67, 0)));
+    REQUIRE(tracker.active_count() == 0);
+
+    REQUIRE(tracker.process(UmpPacket::note_on_2(0, 3, 67, 0xFFFF)));
+    REQUIRE(tracker.process(UmpPacket::note_off_2(0, 3, 67)));
+    REQUIRE(tracker.active_count() == 0);
+}
+
+TEST_CASE("MpeVoiceTracker ignores non-channel and out-of-zone UMP packets", "[midi][mpe][ump]") {
+    MpeVoiceTracker tracker{MpeConfig::standard_lower(4)};
+
+    UmpPacket utility;
+    utility.word_count = 1;
+    utility.words[0] = 0;
+
+    REQUIRE_FALSE(tracker.process(utility));
+    REQUIRE_FALSE(tracker.process(UmpPacket::note_on_2(0, 5, 60, 0xFFFF)));
+    REQUIRE(tracker.active_count() == 0);
+}

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/signal/signal.hpp>
+#include <array>
 #include <cmath>
 #include <vector>
 
@@ -269,6 +270,34 @@ TEST_CASE("Biquad reset clears state", "[signal][biquad]") {
     // After reset, should behave as if freshly initialized
     float out = filter.process(0.0f);
     REQUIRE_THAT(out, WithinAbs(0.0, 0.001));
+}
+
+TEST_CASE("Biquad coefficient variants process finite impulse buffers", "[signal][biquad]") {
+    struct Case {
+        Biquad::Type type;
+        float gain_db;
+    };
+
+    const std::array<Case, 6> cases{{
+        {Biquad::Type::bandpass, 0.0f},
+        {Biquad::Type::notch, 0.0f},
+        {Biquad::Type::allpass, 0.0f},
+        {Biquad::Type::peaking, 6.0f},
+        {Biquad::Type::low_shelf, 6.0f},
+        {Biquad::Type::high_shelf, -6.0f},
+    }};
+
+    for (const auto& c : cases) {
+        Biquad filter;
+        filter.set_coefficients(c.type, 1200.0f, 0.707f, 48000.0f, c.gain_db);
+
+        float impulse[] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+        filter.process(impulse, 8);
+
+        for (float sample : impulse) {
+            REQUIRE(std::isfinite(sample));
+        }
+    }
 }
 
 // ── Oscillator ───────────────────────────────────────────────────────────────
@@ -734,4 +763,97 @@ TEST_CASE("Convolver with simple delay IR", "[signal][convolver]") {
     }
     REQUIRE(peak > 0.9f); // Should find the delayed impulse
     REQUIRE(peak_pos >= 4); // At least 4 samples delayed
+}
+
+// ── MultiChannelMeter ────────────────────────────────────────────────────────
+
+TEST_CASE("MultiChannelMeter emits peak RMS clipping and stereo correlation", "[signal][meter]") {
+    MultiChannelMeter meter;
+    meter.prepare(44100.0f, 2);
+
+    std::vector<float> left(441, 0.5f);
+    std::vector<float> right(441, 0.5f);
+    left[10] = 1.2f;
+
+    const float* channels[] = {left.data(), right.data()};
+    meter.process(channels, 2, static_cast<int>(left.size()));
+
+    const auto& snap = meter.snapshot();
+    REQUIRE(snap.num_channels == 2);
+    REQUIRE_THAT(snap.channels[0].peak, WithinAbs(1.2f, 0.001f));
+    REQUIRE(snap.channels[0].clipped);
+    REQUIRE_THAT(snap.channels[1].peak, WithinAbs(0.5f, 0.001f));
+    REQUIRE_THAT(snap.channels[1].rms, WithinAbs(0.5f, 0.001f));
+    REQUIRE_THAT(snap.correlation, WithinAbs(1.0f, 0.005f));
+    REQUIRE(std::isfinite(snap.channels[0].lufs_momentary));
+}
+
+TEST_CASE("MultiChannelMeter tracks negative correlation and integrated loudness", "[signal][meter]") {
+    MultiChannelMeter meter;
+    meter.prepare(1000.0f, 2);
+
+    std::vector<float> left(10, 0.25f);
+    std::vector<float> right(10, -0.25f);
+    const float* channels[] = {left.data(), right.data()};
+
+    for (int i = 0; i < 40; ++i) {
+        meter.process(channels, 2, static_cast<int>(left.size()));
+    }
+
+    const auto& snap = meter.snapshot();
+    REQUIRE(snap.num_channels == 2);
+    REQUIRE_THAT(snap.correlation, WithinAbs(-1.0f, 0.001f));
+    REQUIRE(std::isfinite(snap.lufs_integrated));
+    REQUIRE_THAT(snap.lufs_integrated, WithinAbs(-12.73f, 0.1f));
+}
+
+TEST_CASE("MultiChannelMeter prepare clears stale clip flags", "[signal][meter]") {
+    MultiChannelMeter meter;
+    meter.prepare(1000.0f, 1);
+
+    std::vector<float> clipped(10, 1.2f);
+    const float* clipped_channels[] = {clipped.data()};
+    meter.process(clipped_channels, 1, static_cast<int>(clipped.size()));
+    REQUIRE(meter.snapshot().channels[0].clipped);
+
+    meter.prepare(1000.0f, 1);
+
+    std::vector<float> clean(10, 0.25f);
+    const float* clean_channels[] = {clean.data()};
+    meter.process(clean_channels, 1, static_cast<int>(clean.size()));
+    REQUIRE_FALSE(meter.snapshot().channels[0].clipped);
+}
+
+TEST_CASE("MultiChannelBallistics holds peaks and clip indicators", "[signal][meter]") {
+    MultiChannelBallistics ballistics;
+
+    MultiChannelMeterData data;
+    data.num_channels = 1;
+    data.channels[0].peak = 1.0f;
+    data.channels[0].rms = 0.5f;
+    data.channels[0].clipped = true;
+
+    ballistics.update(data, 0.016f);
+    REQUIRE(ballistics.num_channels == 1);
+    REQUIRE(ballistics.channels[0].display_peak > 0.9f);
+    REQUIRE(ballistics.channels[0].display_rms > 0.45f);
+    REQUIRE_THAT(ballistics.channels[0].held_peak, WithinAbs(1.0f, 0.001f));
+    REQUIRE(ballistics.channels[0].clip_indicator);
+
+    data.channels[0].peak = 0.0f;
+    data.channels[0].rms = 0.0f;
+    data.channels[0].clipped = false;
+
+    ballistics.update(data, 0.5f);
+    REQUIRE(ballistics.channels[0].clip_indicator);
+    REQUIRE_THAT(ballistics.channels[0].held_peak, WithinAbs(1.0f, 0.001f));
+
+    ballistics.update(data, 3.0f);
+    REQUIRE_FALSE(ballistics.channels[0].clip_indicator);
+
+    data.channels[0].clipped = true;
+    ballistics.update(data, 0.016f);
+    REQUIRE(ballistics.channels[0].clip_indicator);
+    ballistics.clear_clips();
+    REQUIRE_FALSE(ballistics.channels[0].clip_indicator);
 }


### PR DESCRIPTION
Parent: #645
Umbrella: #641

Refs: #645

Phase 2 midi/signal tranche covering hostable MPE UMP routing, MIDI file helpers, Biquad coefficient variants, and MultiChannelMeter snapshots/ballistics.

Local validation:
- `cmake --build build --target pulp-test-midi pulp-test-signal pulp-test-mpe-voice-tracker -j4`
- `./build/test/pulp-test-midi`
- `./build/test/pulp-test-signal`
- `./build/test/pulp-test-mpe-voice-tracker`
- `ctest --test-dir build -R "MidiFile|MpeVoiceTracker|Biquad|MultiChannel" --output-on-failure`

Shipyard note:
- `shipyard pr` was rerun with `--allow-unreachable-targets` because the SSH Windows target timed out during banner exchange before PR creation; GitHub Windows and coverage checks remain expected validation gates.