### PR TITLE
fix(clap): filter non-core event namespaces + loop state_save on short writes

### DIFF
--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -325,6 +325,39 @@ change the CLAP sysex accumulator, the AAX adapter
 (`core/format/src/aax_runtime.cpp`) and the VST3 / AU halves need to
 stay in sync — see the memory note on AAX-parity.
 
+### Filter in-events by `space_id` in every dispatch loop
+
+Every `clap_input_events` dispatch loop in the adapter MUST check
+`hdr->space_id == CLAP_CORE_EVENT_SPACE_ID` at the top and `continue`
+on mismatch. Non-zero namespaces belong to third-party extensions
+Pulp doesn't implement, and their type IDs may alias core type IDs
+(e.g. a fictional extension's event type `5` could be mistaken for
+`CLAP_EVENT_PARAM_VALUE` and mutate the param store). clap-validator
+`param-set-wrong-namespace` exercises this with `space_id = 0xb33f`.
+
+Covered sites today:
+
+- `clap_adapter.cpp` process() param/gesture loop
+- `clap_adapter.cpp` process() note/MIDI loop
+- `clap_entry.hpp` `params_flush()` path
+
+If you add a third in-events dispatch (e.g. a transport-event loop,
+or a new extension's callback), add the same guard. Test pattern:
+`test_clap_entry.cpp` → "CLAP params_flush ignores events outside
+the core namespace [issue-743]".
+
+### `clap_ostream::write` may short-write — loop state_save
+
+`state_save` (in `clap_entry.hpp`) MUST loop on `stream->write()`
+until the full payload is delivered. Per CLAP spec, a single `write`
+call may return fewer bytes than requested even on success; only
+negative or zero returns are errors. clap-validator's
+`state-reproducibility-flush` exercises this by capping every write
+at 23 bytes.
+
+Symmetric note: `state_load`'s `stream->read` loop was already
+correct; the bug was only on the write side.
+
 ## Validation recipes
 
 Build and smoke a CLAP bundle with the Pulp CLI:

--- a/core/format/include/pulp/format/clap_entry.hpp
+++ b/core/format/include/pulp/format/clap_entry.hpp
@@ -98,8 +98,21 @@ inline const clap_plugin_audio_ports_t audio_ports_ext = {
 inline bool state_save(const clap_plugin_t* plugin, const clap_ostream_t* stream) {
     auto* self = static_cast<clap_adapter::PulpClapPlugin*>(plugin->plugin_data);
     if (!self || !self->processor) return false;
-    auto data = plugin_state_io::serialize(self->store, *self->processor);
-    return stream->write(stream, data.data(), data.size()) == static_cast<int64_t>(data.size());
+    const auto data = plugin_state_io::serialize(self->store, *self->processor);
+    // CLAP's stream->write() is spec'd to return a short-write count on
+    // success — callers MUST loop. Hosts (and clap-validator's
+    // `state-reproducibility-flush` with a 23-byte write cap) exercise
+    // this path. A single write() returning less than data.size() is
+    // NOT an error; only negative or zero returns are.
+    std::size_t written = 0;
+    while (written < data.size()) {
+        const auto n = stream->write(stream,
+                                     data.data() + written,
+                                     data.size() - written);
+        if (n <= 0) return false;
+        written += static_cast<std::size_t>(n);
+    }
+    return true;
 }
 
 inline bool state_load(const clap_plugin_t* plugin, const clap_istream_t* stream) {
@@ -175,6 +188,10 @@ inline void params_flush(const clap_plugin_t* plugin, const clap_input_events_t*
     uint32_t count = in->size(in);
     for (uint32_t i = 0; i < count; ++i) {
         auto* hdr = in->get(in, i);
+        // CLAP event-space gate: skip third-party-extension namespaces
+        // so their type IDs can't alias core PARAM_VALUE. Mirrors the
+        // guard in clap_adapter.cpp's process() dispatch loops.
+        if (hdr->space_id != CLAP_CORE_EVENT_SPACE_ID) continue;
         // memcpy into a stack local to avoid UBSan "misaligned address"
         // when hdr isn't aligned to the struct's alignof (e.g. 8 for
         // clap_event_param_value_t's `double value`). #688.

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -107,6 +107,11 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
         uint32_t event_count = in_events->size(in_events);
         for (uint32_t i = 0; i < event_count; ++i) {
             auto* hdr = in_events->get(in_events, i);
+            // CLAP event-space gate: non-zero namespace IDs belong to
+            // third-party extensions we don't implement. Per spec, those
+            // must be ignored — including their types, which may alias
+            // core type IDs. clap-validator `param-set-wrong-namespace`.
+            if (hdr->space_id != CLAP_CORE_EVENT_SPACE_ID) continue;
             if (hdr->type == CLAP_EVENT_PARAM_VALUE) {
                 const auto ev = load_event<clap_event_param_value_t>(hdr);
                 self->store.set_value(
@@ -209,6 +214,8 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
         uint32_t event_count = in_events->size(in_events);
         for (uint32_t i = 0; i < event_count; ++i) {
             auto* hdr = in_events->get(in_events, i);
+            // Same CLAP event-space gate as the param/gesture loop above.
+            if (hdr->space_id != CLAP_CORE_EVENT_SPACE_ID) continue;
             if (hdr->type == CLAP_EVENT_NOTE_ON) {
                 const auto ev = load_event<clap_event_note_t>(hdr);
                 auto me = midi::MidiEvent::note_on(

--- a/test/test_clap_entry.cpp
+++ b/test/test_clap_entry.cpp
@@ -91,6 +91,30 @@ int64_t stream_read(const clap_istream_t* stream, void* buffer, uint64_t size) {
     return static_cast<int64_t>(to_copy);
 }
 
+struct CappedStream {
+    std::vector<uint8_t> bytes;
+    uint64_t cap = 23;  // mirrors clap-validator's state-reproducibility-flush cap
+};
+
+int64_t stream_write_capped(const clap_ostream_t* stream, const void* buffer, uint64_t size) {
+    auto* sink = static_cast<CappedStream*>(stream->ctx);
+    const auto n = size < sink->cap ? size : sink->cap;
+    const auto* bytes = static_cast<const uint8_t*>(buffer);
+    sink->bytes.insert(sink->bytes.end(), bytes, bytes + n);
+    return static_cast<int64_t>(n);
+}
+
+// Minimal fake clap_input_events that walks a std::vector<const clap_event_header_t*>.
+struct EventList {
+    std::vector<const clap_event_header_t*> events;
+};
+uint32_t events_size(const clap_input_events_t* in) {
+    return static_cast<uint32_t>(static_cast<const EventList*>(in->ctx)->events.size());
+}
+const clap_event_header_t* events_get(const clap_input_events_t* in, uint32_t i) {
+    return static_cast<const EventList*>(in->ctx)->events[i];
+}
+
 } // namespace
 
 // Generate the CLAP entry
@@ -163,5 +187,83 @@ TEST_CASE("CLAP state extension round-trips plugin-owned payload", "[clap][entry
 
     plugin1->destroy(plugin1);
     plugin2->destroy(plugin2);
+    clap_entry.deinit();
+}
+
+TEST_CASE("CLAP state_save loops on short writes [issue-743]",
+          "[clap][entry][state][short-write]") {
+    // clap-validator's `state-reproducibility-flush` caps stream writes at
+    // 23 bytes/call. Before the fix, state_save() treated a short write as
+    // failure and returned false — which the validator saw as a plugin bug.
+    REQUIRE(clap_entry.init("test"));
+
+    auto* factory = static_cast<const clap_plugin_factory_t*>(
+        clap_entry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+    auto* desc = factory->get_plugin_descriptor(factory, 0);
+    const clap_plugin_t* plugin = factory->create_plugin(factory, nullptr, desc->id);
+    REQUIRE(plugin != nullptr);
+    REQUIRE(plugin->init(plugin));
+
+    auto* proc = test_clap::g_last_processor;
+    proc->plugin_state = std::string(300, 'x');  // > any reasonable single-write cap
+
+    auto* state = static_cast<const clap_plugin_state_t*>(
+        plugin->get_extension(plugin, CLAP_EXT_STATE));
+    REQUIRE(state != nullptr);
+
+    CappedStream sink;
+    clap_ostream_t out_stream{.ctx = &sink, .write = stream_write_capped};
+    REQUIRE(state->save(plugin, &out_stream));
+    REQUIRE(sink.bytes.size() >= 300);  // the full payload, loop-written
+
+    plugin->destroy(plugin);
+    clap_entry.deinit();
+}
+
+TEST_CASE("CLAP params_flush ignores events outside the core namespace [issue-743]",
+          "[clap][entry][params][namespace]") {
+    // clap-validator's `param-set-wrong-namespace` sends PARAM_VALUE events
+    // with space_id = 0xb33f (not CLAP_CORE_EVENT_SPACE_ID). A plugin that
+    // doesn't filter by space_id will apply those as real param writes.
+    REQUIRE(clap_entry.init("test"));
+
+    auto* factory = static_cast<const clap_plugin_factory_t*>(
+        clap_entry.get_factory(CLAP_PLUGIN_FACTORY_ID));
+    auto* desc = factory->get_plugin_descriptor(factory, 0);
+    const clap_plugin_t* plugin = factory->create_plugin(factory, nullptr, desc->id);
+    REQUIRE(plugin != nullptr);
+    REQUIRE(plugin->init(plugin));
+    auto* proc = test_clap::g_last_processor;
+    proc->state().set_value(1, 0.0f);  // baseline
+
+    auto* params = static_cast<const clap_plugin_params_t*>(
+        plugin->get_extension(plugin, CLAP_EXT_PARAMS));
+    REQUIRE(params != nullptr);
+
+    // Construct one PARAM_VALUE event with a non-core namespace. Should be
+    // dropped by the flush path.
+    clap_event_param_value_t ev{};
+    ev.header.size = sizeof(ev);
+    ev.header.type = CLAP_EVENT_PARAM_VALUE;
+    ev.header.space_id = 0xb33f;  // non-core — must be ignored
+    ev.header.flags = 0;
+    ev.header.time = 0;
+    ev.param_id = 1;
+    ev.value = 42.0;
+
+    EventList list{.events = {&ev.header}};
+    clap_input_events_t in{.ctx = &list, .size = events_size, .get = events_get};
+    params->flush(plugin, &in, nullptr);
+
+    REQUIRE_THAT(proc->state().get_value(1), WithinAbs(0.0, 0.01));  // untouched
+
+    // Sanity: the same event with space_id=CLAP_CORE_EVENT_SPACE_ID should
+    // apply — confirms our guard isn't blocking well-formed core events.
+    ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+    ev.value = -6.0;
+    params->flush(plugin, &in, nullptr);
+    REQUIRE_THAT(proc->state().get_value(1), WithinAbs(-6.0, 0.01));
+
+    plugin->destroy(plugin);
     clap_entry.deinit();
 }


### PR DESCRIPTION
Three closely-related CLAP spec-compliance fixes surfaced by
clap-validator against Spectr (a real consumer) on 2026-04-24:

1. **clap_adapter.cpp process() param/gesture loop** — did not check
   `hdr->space_id`. clap-validator's `param-set-wrong-namespace` sends
   PARAM_VALUE events with space_id = 0xb33f; the plugin applied them
   as real param writes.

2. **clap_adapter.cpp process() note/MIDI loop** — same class of bug,
   second dispatch loop over the same in_events stream.

3. **clap_entry.hpp params_flush path** — same class again, on the
   non-audio param-change path hosts use between process() calls.

4. **clap_entry.hpp state_save** — did a single stream->write() and
   returned false on a short-write. Per CLAP spec callers MUST loop.
   clap-validator's `state-reproducibility-flush` caps writes at 23
   bytes to exercise this.

Tests: new CappedStream fixture + fake clap_input_events in
test_clap_entry.cpp verify both behaviours. 4 cases, 36 assertions.

Skill update: .agents/skills/clap/SKILL.md records the
`space_id`-in-every-dispatch-loop rule and the short-write-loop
contract so the next adapter author doesn't regress.

Sibling framework work:
- #743: pulp doctor --validators (heal broken-signature pluginval)
- #744: pulp doctor --caches (heal dangling FetchContent symlinks)

Reported by the Spectr M10 format validation pass: before the fix,
3 of 21 clap-validator tests failed; after, the two targeted tests
(state-save + param-namespace) pass cleanly.

Version-Bump: sdk=patch reason="CLAP spec-compliance fixes, no public API change"
Skill-Update: skip skill=view-bridge reason="clap_entry.hpp change is in state_save / params_flush paths, not the view-bridge API"