### PR TITLE
ci(build): default to Namespace runners on every event (closes #714)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -387,24 +387,40 @@ Then proceed with the `ship` workflow below.
 
 ## Runner Priority (hard rule)
 
-**Always use Namespace runners for Ubuntu and Windows CI. Never use GitHub-hosted runners as the primary path.**
+**Always use Namespace runners for Ubuntu and Windows CI. Never use GitHub-hosted runners as the primary path. Never wait for local SSH validation when Namespace is available.**
+
+As of pulp #714 (PR #751), `.github/workflows/build.yml` defaults to Namespace on every event (push, pull_request, workflow_dispatch). The repo variable `PULP_DEFAULT_RUNNER_PROVIDER=namespace` is set. The pull_request → github-hosted Windows hardcode is removed. **You should rarely have to think about runner provider in 2026-04-24+ pulp PRs** — the auto-triggered workflow already picks Namespace.
 
 Priority order:
-1. **Namespace** — dispatch with `gh workflow run build.yml --ref <branch> -f runner_provider=namespace`
-2. **Local VMs** — fallback if Namespace is unavailable (`ssh ubuntu`, `ssh win`)
-3. **GitHub-hosted** — last resort only if both Namespace and local VMs are down
+1. **Namespace** (default) — dispatched automatically by build.yml on every event; can also be fired explicitly via `shipyard cloud run build <branch> --provider namespace --require-sha <sha>` for a fresh parallel cycle
+2. **Local VMs** — fallback only if Namespace is unavailable (`ssh ubuntu`, `ssh win`); rare since pulp #714
+3. **GitHub-hosted** — explicit opt-in only (e.g. cross-validating that a Namespace failure isn't a Namespace-specific bug)
 
-macOS runs locally in parallel with Namespace Ubuntu/Windows.
+macOS runs on Namespace too via `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` repo variable (`namespace-profile-generouscorp-macos`); falls back to GH-hosted `macos-15` only if the variable is unset.
 
-**Common mistake:** Pushing a branch and waiting for the auto-triggered GitHub Actions PR checks. Those use GitHub-hosted runners and are slow. Instead: cancel the auto-triggered run and dispatch on Namespace.
+### Operational rule for agents — fire Namespace immediately after every push
+
+The auto-triggered workflow takes a few seconds to register. To accelerate, **immediately after `git push` on a branch with an open or about-to-open PR, dispatch a parallel Namespace cycle**:
 
 ```bash
-# Cancel auto-triggered GitHub-hosted run
-gh run cancel <run_id> --repo danielraffel/pulp
-
-# Dispatch on Namespace
-gh workflow run build.yml --repo danielraffel/pulp --ref <branch> -f runner_provider=namespace
+FULL_SHA=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+shipyard cloud run build "$BRANCH" --provider namespace --require-sha "$FULL_SHA"
 ```
+
+The `--require-sha` guard (always pass the full 40-char SHA, not `HEAD` — `HEAD` resolves from the cwd which may differ from the branch) prevents stale dispatches. The dispatched run shows up on the PR's check rollup alongside the auto-triggered run; whichever lane reports first satisfies its check name.
+
+**Why even though build.yml defaults to namespace now**: the explicit dispatch is instant — no waiting for the auto-trigger to wake up. On a typical PR push that's 30-60 seconds saved per cycle, which compounds across rebases/force-pushes.
+
+### When a slow lane is blocking a merge
+
+If a GH-hosted lane is somehow still blocking (someone passed `runner_provider=github-hosted` explicitly, or a workflow other than build.yml hasn't been flipped), retarget mid-flight:
+
+```bash
+shipyard cloud retarget --pr <NNN> --target "Windows (x64) [github-hosted]" --provider namespace --apply
+```
+
+This requires `actions:write` on the gh token (granted to `pulp-release-bot` per pulp #713). If retarget reports a scope error, fall back to: `gh workflow run build.yml --ref <branch> -f runner_provider=namespace` for a fresh dispatch + let the slow lane finish in parallel.
 
 ## Commands
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,11 @@ on:
       runner_provider:
         description: "Runner provider to use for Linux and Windows build legs"
         required: false
-        default: github-hosted
+        default: namespace
         type: choice
         options:
-          - github-hosted
           - namespace
+          - github-hosted
       linux_runner_selector_json:
         description: "Optional JSON string/array for Linux runs-on when routing through Namespace"
         required: false
@@ -52,7 +52,7 @@ jobs:
           lfs: false
       - id: resolve
         env:
-          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.PULP_DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
+          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.PULP_DEFAULT_RUNNER_PROVIDER || 'namespace' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
           EXPLICIT_MACOS_RUNNER_SELECTOR_JSON: ${{ inputs.macos_runner_selector_json || '' }}
@@ -73,7 +73,7 @@ jobs:
           import sys
           from pathlib import Path
 
-          REQUESTED = (os.environ.get("REQUESTED_PROVIDER") or "github-hosted").strip()
+          REQUESTED = (os.environ.get("REQUESTED_PROVIDER") or "namespace").strip()
           EVENT_NAME = (os.environ.get("GITHUB_EVENT_NAME") or "").strip()
           RESOLVER = ["python3", "tools/scripts/resolve_runs_on.py"]
 
@@ -98,22 +98,25 @@ jobs:
               "--namespace-env", "NAMESPACE_LINUX_RUNS_ON_JSON",
               "--namespace-setting-name", "PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON",
           ])
-          # Namespace Windows capacity has been intermittently unavailable.
-          # Keep PR validation on GitHub-hosted Windows so a queued Namespace
-          # lane does not block mergeability while the capacity issue is open.
-          if EVENT_NAME == "pull_request":
-              windows_runs_on = json.dumps("windows-latest")
-              windows_provider = "github-hosted"
-          else:
-              windows_runs_on = run([
-                  "--target-name", "Windows (x64)",
-                  "--mode", "provider",
-                  "--github-hosted-label", "windows-latest",
-                  "--explicit-env", "EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON",
-                  "--namespace-env", "NAMESPACE_WINDOWS_RUNS_ON_JSON",
-                  "--namespace-setting-name", "PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON",
-              ])
-              windows_provider = REQUESTED
+          # Windows respects the REQUESTED provider on every event (pulp #714).
+          # Prior version hardcoded github-hosted on pull_request events
+          # because Namespace Windows capacity had been intermittently
+          # unavailable. Today's data (24+ Namespace Windows lanes across
+          # PRs #711, #719, #725, #730, #733 — all green within ~14 min vs
+          # 20-25 min for the GH-hosted twin) shows capacity is reliable.
+          # If a future capacity regression surfaces, restore the safety
+          # belt or use `shipyard cloud retarget --provider github-hosted`
+          # mid-flight (now possible since pulp-release-bot has actions:write
+          # — see pulp #713 for the scope-grant story).
+          windows_runs_on = run([
+              "--target-name", "Windows (x64)",
+              "--mode", "provider",
+              "--github-hosted-label", "windows-latest",
+              "--explicit-env", "EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON",
+              "--namespace-env", "NAMESPACE_WINDOWS_RUNS_ON_JSON",
+              "--namespace-setting-name", "PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON",
+          ])
+          windows_provider = REQUESTED
           macos_runs_on = run([
               "--target-name", "macOS (ARM64)",
               "--mode", "optional-namespace",

--- a/tools/scripts/test_release_workflow_test_step.py
+++ b/tools/scripts/test_release_workflow_test_step.py
@@ -232,5 +232,84 @@ class SignAndReleaseContentsWriteTest(unittest.TestCase):
         )
 
 
+class BuildYmlNamespaceDefaultTest(unittest.TestCase):
+    """#714: build.yml must default to Namespace runners on every event.
+
+    Three load-bearing flips, all in `.github/workflows/build.yml`:
+
+    1. The `runner_provider` workflow_dispatch input default → `namespace`
+       (not `github-hosted`). Manual workflow_dispatch picks up Namespace
+       without an explicit override.
+    2. The `REQUESTED_PROVIDER` env-var fallback → `'namespace'` (not
+       `'github-hosted'`). Defense-in-depth if the repo variable
+       `PULP_DEFAULT_RUNNER_PROVIDER` is unset.
+    3. NO `EVENT_NAME == "pull_request"` Windows hardcoded github-hosted
+       branch. The prior version pinned Windows to GitHub-hosted on PR
+       events because Namespace Windows capacity was intermittent;
+       today's data (24+ green Namespace Windows lanes across PRs
+       #711, #719, #725, #730, #733, #749) shows capacity is reliable.
+       Removing the safety belt unblocks the slowest lane on every PR.
+
+    These are the three changes pulp #714 ships. The regression test
+    exists so a future PR can't silently flip back to github-hosted.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        root = Path(__file__).resolve().parent.parent.parent
+        cls.workflow_path = root / ".github" / "workflows" / "build.yml"
+        cls.text = cls.workflow_path.read_text(encoding="utf-8")
+
+    def test_runner_provider_input_defaults_to_namespace(self) -> None:
+        """workflow_dispatch input `runner_provider` default == namespace."""
+        self.assertRegex(
+            self.text,
+            r"runner_provider:\s*\n[\s\S]{1,300}?default:\s*namespace",
+            "build.yml `runner_provider` workflow_dispatch input must "
+            "default to `namespace` (issue #714).",
+        )
+
+    def test_requested_provider_env_fallback_is_namespace(self) -> None:
+        """REQUESTED_PROVIDER env-var fallback string is 'namespace'."""
+        self.assertIn(
+            "PULP_DEFAULT_RUNNER_PROVIDER || 'namespace'",
+            self.text,
+            "build.yml REQUESTED_PROVIDER env fallback must be "
+            "'namespace' (issue #714) so the workflow defaults to "
+            "Namespace even if vars.PULP_DEFAULT_RUNNER_PROVIDER is unset.",
+        )
+        # Same for the inline Python REQUESTED string fallback.
+        self.assertIn(
+            'REQUESTED = (os.environ.get("REQUESTED_PROVIDER") or "namespace").strip()',
+            self.text,
+            "build.yml inline-Python REQUESTED fallback must be "
+            "\"namespace\" (issue #714).",
+        )
+
+    def test_no_pr_event_windows_safety_belt(self) -> None:
+        """The pull_request → github-hosted Windows hardcode must NOT exist.
+
+        Prior version pinned Windows to github-hosted on PR events for
+        capacity reasons. Removing the belt is the whole point of #714.
+        If a future regression in Namespace Windows surfaces, restore
+        the belt or use `shipyard cloud retarget --provider github-hosted`
+        mid-flight (pulp-release-bot has actions:write per #713).
+        """
+        # The exact load-bearing pattern the prior version had.
+        forbidden_patterns = [
+            r'EVENT_NAME\s*==\s*"pull_request"[\s\S]{1,200}?windows_provider\s*=\s*"github-hosted"',
+            r'windows_runs_on\s*=\s*json\.dumps\("windows-latest"\)',
+        ]
+        for pat in forbidden_patterns:
+            self.assertNotRegex(
+                self.text,
+                pat,
+                f"build.yml must not contain the Windows PR-event "
+                f"github-hosted safety belt (issue #714). Pattern "
+                f"`{pat}` matched. Restoring the belt regresses every "
+                f"PR's slowest lane back to ~25 min.",
+            )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Closes pulp #714. Flips Pulp's CI matrix to default to Namespace runners on every event — eliminates the GH-hosted Windows lane that was the slowest required check on every PR for months.

## Changes

Three workflow-file flips in `.github/workflows/build.yml`:

1. `runner_provider` workflow_dispatch input default: `github-hosted` → **`namespace`**
2. `REQUESTED_PROVIDER` env-var fallback (and inline-Python REQUESTED string fallback): `'github-hosted'` → **`'namespace'`**
3. **Removed** the `pull_request` → `github-hosted` Windows hardcode that was added when Namespace Windows capacity was intermittent

Plus two repo variables I set out-of-band (effective immediately, no PR):

- `PULP_DEFAULT_RUNNER_PROVIDER = "namespace"`
- `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON = "namespace-profile-generouscorp-macos"`

## Why now

Today's data: 24+ green Namespace Windows lanes across PRs #711, #719, #725, #730, #733, #749 — finishing in ~14 min vs ~20-25 min for the GH-hosted twin. Capacity is reliable. The safety belt was costing us the slowest required check on every PR.

If a future capacity regression surfaces:
- Revert this commit's resolver block to restore the belt, OR
- Use `shipyard cloud retarget --provider github-hosted` mid-flight (now possible since pulp-release-bot has actions:write per #713).

## Tests

`tools/scripts/test_release_workflow_test_step.py` gains `BuildYmlNamespaceDefaultTest` with three cases that lock the three flips in:

- `test_runner_provider_input_defaults_to_namespace`
- `test_requested_provider_env_fallback_is_namespace`
- `test_no_pr_event_windows_safety_belt`

Wired into `workflow-lint.yml` via the existing PR #721 hook so any future PR touching `.github/workflows/**` runs them. **8/8 pass** (5 prior + 3 new). Verified the new tests FAIL when the old build.yml is re-applied.

## Refs

- Closes #714
- Related: #713 (gh-token actions:write scope unblocking shipyard cloud retarget — the failback path if Namespace breaks)
- Related: #720, #721, #724, #725 (the release-pipeline reliability work that depended on this lane being fast)