### PR TITLE
ci: flip default runner provider to Namespace (for Linux + Windows + macOS)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -387,24 +387,47 @@ Then proceed with the `ship` workflow below.
 
 ## Runner Priority (hard rule)
 
-**Always use Namespace runners for Ubuntu and Windows CI. Never use GitHub-hosted runners as the primary path.**
+**Namespace is the default runner provider** for all three platform legs
+(Linux, Windows, macOS) as of 2026-04-24. Every PR-triggered or manually
+dispatched `build.yml` run routes to Namespace unless explicitly overridden.
+GitHub-hosted is the explicit opt-out for the rare case where a specific
+lane needs to be validated on GHA infrastructure.
+
+The default chain (`.github/workflows/build.yml` `resolve-provider` job):
+
+```yaml
+REQUESTED_PROVIDER:
+  ${{ inputs.runner_provider             # explicit workflow_dispatch input
+   || vars.PULP_DEFAULT_RUNNER_PROVIDER  # repo-level override
+   || 'namespace' }}                     # hardcoded fallback
+```
 
 Priority order:
-1. **Namespace** — dispatch with `gh workflow run build.yml --ref <branch> -f runner_provider=namespace`
-2. **Local VMs** — fallback if Namespace is unavailable (`ssh ubuntu`, `ssh win`)
-3. **GitHub-hosted** — last resort only if both Namespace and local VMs are down
+1. **Namespace (default)** — no action required; PR opens or pushes use it automatically.
+2. **Local SSH VMs** — used by `shipyard ship` directly (`ssh ubuntu`, `ssh-windows`). Useful for fast feedback when Namespace is slow or for reproducing bugs interactively.
+3. **GitHub-hosted** — last resort; explicitly request with `-f runner_provider=github-hosted` if you need to compare behaviour against GHA-specific environment quirks.
 
-macOS runs locally in parallel with Namespace Ubuntu/Windows.
+**No more cancel-and-redispatch ritual.** Before 2026-04-24 agents had to
+cancel the auto-triggered github-hosted run and re-dispatch with
+`-f runner_provider=namespace`. That muscle memory is now obsolete — the
+first PR-triggered run is already Namespace-backed.
 
-**Common mistake:** Pushing a branch and waiting for the auto-triggered GitHub Actions PR checks. Those use GitHub-hosted runners and are slow. Instead: cancel the auto-triggered run and dispatch on Namespace.
+**Historical override (removed on 2026-04-24)**: The `resolve-provider`
+job previously hardcoded Windows to `github-hosted` on `pull_request`
+events because Namespace Windows capacity was intermittently
+unavailable. That override is gone. If Namespace Windows capacity
+regresses and PRs start blocking, re-introduce the override via a
+short-lived PR rather than leaving it in-tree; revert once capacity is
+restored.
 
-```bash
-# Cancel auto-triggered GitHub-hosted run
-gh run cancel <run_id> --repo danielraffel/pulp
+### Overrides when you need them
 
-# Dispatch on Namespace
-gh workflow run build.yml --repo danielraffel/pulp --ref <branch> -f runner_provider=namespace
-```
+- **Dispatch a specific run on github-hosted** (comparing behaviour, reproducing a GHA-specific bug):
+  ```bash
+  gh workflow run build.yml --repo danielraffel/pulp --ref <branch> -f runner_provider=github-hosted
+  ```
+- **Pin to a specific Namespace runner selector** (larger instance, arm64, etc.): pass the per-OS `linux_runner_selector_json` / `windows_runner_selector_json` / `macos_runner_selector_json` workflow_dispatch inputs.
+- **Via `shipyard cloud run`**: same dispatch path. `shipyard cloud run build <branch>` picks up `[cloud] provider = namespace` from `.shipyard/config.toml` and fires the workflow with the matching provider input.
 
 ## Commands
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,11 @@ on:
       runner_provider:
         description: "Runner provider to use for Linux and Windows build legs"
         required: false
-        default: github-hosted
+        default: namespace
         type: choice
         options:
-          - github-hosted
           - namespace
+          - github-hosted
       linux_runner_selector_json:
         description: "Optional JSON string/array for Linux runs-on when routing through Namespace"
         required: false
@@ -52,7 +52,7 @@ jobs:
           lfs: false
       - id: resolve
         env:
-          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.PULP_DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
+          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.PULP_DEFAULT_RUNNER_PROVIDER || 'namespace' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
           EXPLICIT_MACOS_RUNNER_SELECTOR_JSON: ${{ inputs.macos_runner_selector_json || '' }}
@@ -98,22 +98,23 @@ jobs:
               "--namespace-env", "NAMESPACE_LINUX_RUNS_ON_JSON",
               "--namespace-setting-name", "PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON",
           ])
-          # Namespace Windows capacity has been intermittently unavailable.
-          # Keep PR validation on GitHub-hosted Windows so a queued Namespace
-          # lane does not block mergeability while the capacity issue is open.
-          if EVENT_NAME == "pull_request":
-              windows_runs_on = json.dumps("windows-latest")
-              windows_provider = "github-hosted"
-          else:
-              windows_runs_on = run([
-                  "--target-name", "Windows (x64)",
-                  "--mode", "provider",
-                  "--github-hosted-label", "windows-latest",
-                  "--explicit-env", "EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON",
-                  "--namespace-env", "NAMESPACE_WINDOWS_RUNS_ON_JSON",
-                  "--namespace-setting-name", "PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON",
-              ])
-              windows_provider = REQUESTED
+          # Windows routes through the same provider-resolver as Linux.
+          # Historical note: an earlier hardcoded override forced Windows to
+          # github-hosted on PR events because Namespace Windows capacity
+          # was intermittently unavailable. That override was removed on
+          # 2026-04-24 — Namespace is now the default for all three legs.
+          # If Namespace Windows capacity regresses and PRs start blocking,
+          # re-add the override here (track it via a temporary PR rather
+          # than leaving it in-tree) and revert once capacity is restored.
+          windows_runs_on = run([
+              "--target-name", "Windows (x64)",
+              "--mode", "provider",
+              "--github-hosted-label", "windows-latest",
+              "--explicit-env", "EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON",
+              "--namespace-env", "NAMESPACE_WINDOWS_RUNS_ON_JSON",
+              "--namespace-setting-name", "PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON",
+          ])
+          windows_provider = REQUESTED
           macos_runs_on = run([
               "--target-name", "macOS (ARM64)",
               "--mode", "optional-namespace",


### PR DESCRIPTION
Before today, every PR-triggered `build.yml` run used GitHub-hosted
runners by default — agents had to cancel + redispatch with
`runner_provider=namespace` to get Namespace-backed validation. Slow
ritual, easy to forget. Per-OS trade-offs:

- Linux  — already defaulted to Namespace via resolver config.
- macOS  — resolver stays Namespace-preferred with a github-hosted
  fallback; unchanged.
- Windows — hardcoded to github-hosted on `pull_request` events
  because Namespace Windows capacity was intermittently unavailable
  (see the comment removed in this commit). Removing the override as
  capacity has been stable; re-add via a short-lived PR if it
  regresses.

Changes:

- `.github/workflows/build.yml`
  - `workflow_dispatch.inputs.runner_provider.default`: github-hosted → namespace
  - `resolve-provider.REQUESTED_PROVIDER` final fallback: github-hosted → namespace
  - Remove the `if EVENT_NAME == "pull_request"` Windows-override block
    so Windows follows the same resolver path as Linux. Note left behind
    documenting why it was there and how to re-add if needed.

- `.agents/skills/ci/SKILL.md`
  - Rewrite "Runner Priority (hard rule)" section: Namespace is now the
    default, no cancel-and-redispatch ritual needed. Document the
    override paths for explicit github-hosted or runner-selector
    pinning.
  - Preserve the historical-override note so a future agent sees why
    the override block used to exist.

Impact: PR cycle time on Windows lane drops from ~20 min GHA cold-start
to Namespace's sub-5-min (per observed Linux [namespace] lane on PRs).

Version-Bump: sdk=skip reason="CI-only change, no SDK artifact delta"
Skill-Update: ci ← this commit updates .agents/skills/ci/SKILL.md