### PR TITLE
fix(host): SignalGraph hot-reload race flake — second test copy (#669)

### DIFF
--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <string>
 #include <thread>
 #include <vector>
@@ -1075,7 +1076,7 @@ TEST_CASE("PluginSlot loads and processes a real CLAP plugin", "[host][clap][int
 // every sample in the audio thread's output buffer is either silence (post-
 // invalidate, pre-reprepare) or a valid sample in [-1, 1].
 
-TEST_CASE("SignalGraph snapshot publish is race-clean", "[host][graph][race]") {
+TEST_CASE("SignalGraph snapshot publish is race-clean", "[host][graph][race][issue-669]") {
     SignalGraph graph;
     auto in  = graph.add_input_node(1, "in");
     auto g   = graph.add_gain_node("g");
@@ -1092,6 +1093,20 @@ TEST_CASE("SignalGraph snapshot publish is race-clean", "[host][graph][race]") {
                                        // violations and assert on the main
                                        // thread after join.
 
+    // Deterministic handshake mirroring the regression-suite copy of this
+    // test (test_host_regression.cpp, the [issue-669] case): without an
+    // explicit "audio thread reached graph.process() at least once" promise,
+    // a slow shared-tenant Windows runner can complete all 200 mutation
+    // cycles + the 5ms tail sleep before the just-spawned audio thread is
+    // ever scheduled, leaving `blocks == 0` and tripping
+    // `REQUIRE(blocks.load() > 0)`. Captured in run #24910085528 (Windows
+    // github-hosted, 2026-04-24) — see issue #669. The two-promise barrier
+    // closes the window without any wall-clock sleep.
+    std::promise<void> audio_started;
+    auto started = audio_started.get_future();
+    std::promise<void> first_block_processed;
+    auto first_block = first_block_processed.get_future();
+
     std::thread audio([&] {
         std::vector<float> in_l(64, 0.25f);
         std::vector<float> out_l(64, 0.0f);
@@ -1099,6 +1114,8 @@ TEST_CASE("SignalGraph snapshot publish is race-clean", "[host][graph][race]") {
         float*       out_ptrs[1] = {out_l.data()};
         pulp::audio::BufferView<const float> iv(in_ptrs, 1, 64);
         pulp::audio::BufferView<float>       ov(out_ptrs, 1, 64);
+        audio_started.set_value();
+        bool first_block_signalled = false;
         while (!stop.load(std::memory_order_relaxed)) {
             graph.process(ov, iv, 64);
             for (int i = 0; i < 64; ++i) {
@@ -1110,8 +1127,19 @@ TEST_CASE("SignalGraph snapshot publish is race-clean", "[host][graph][race]") {
                 }
             }
             blocks.fetch_add(1, std::memory_order_relaxed);
+            if (!first_block_signalled) {
+                first_block_processed.set_value();
+                first_block_signalled = true;
+            }
         }
     });
+
+    // Wait for the audio thread to launch AND prove it has executed
+    // graph.process() at least once. Both barriers run before mutation so
+    // the test cannot pass or fail without exercising the snapshot-publish
+    // path under contention.
+    started.wait();
+    first_block.wait();
 
     // Hammer the graph with mutation cycles from the "UI" thread.
     const int cycles = 200;


### PR DESCRIPTION
## Summary

Issue #669's original fix (5a8a014b, "test(host): wait for first block in hot-reload regression") added a two-promise audio-thread handshake to the `[issue-669]` case in `test/test_host_regression.cpp`. A **second copy of the same race test** in `test/test_host.cpp:1078` (`SignalGraph snapshot publish is race-clean`, tag `[host][graph][race]`) was missed by that fix and continued to flake.

This PR applies the proven handshake pattern to the missed sibling.

## Evidence

Most recent captured failure on `origin/main` post the original #669 fix landing:

- **Run [#24910085528](https://github.com/danielraffel/pulp/actions/runs/24910085528)** — Windows (x64) [github-hosted], 2026-04-24 20:51 UTC, branch `feature/sandbox-e2e-harness-732`
  - `test_host_regression.cpp:780` `SignalGraph hot-reload mid-audio is race-free via snapshot publish` — **Passed 0.02s** (the original fix held)
  - `test_host.cpp(1130): FAILED: REQUIRE( blocks.load() > 0 )` — same assertion shape, missed sibling

Earlier flakes on the now-fixed regression copy (line 841 of pre-fix file) — same `REQUIRE(blocks.load() > 0)` shape:
- Run [#24871191244](https://github.com/danielraffel/pulp/actions/runs/24871191244) — Linux Namespace, 2026-04-24 04:07 UTC
- Run [#24872275599](https://github.com/danielraffel/pulp/actions/runs/24872275599) — Linux Namespace, 2026-04-24 04:48 UTC
- Run [#24867011159](https://github.com/danielraffel/pulp/actions/runs/24867011159) — Windows github-hosted, 2026-04-24 01:40 UTC

All four failures share the identical assertion: `REQUIRE(blocks.load() > 0)` triggered because the audio thread had not yet entered `graph.process()` when the main thread completed its mutation loop and signalled stop. None failed on `bad_samples == 0` — there is no evidence of an actual production race in the snapshot-publish path.

## Root cause (test-only sync bug)

Both tests spawn an audio thread and immediately begin mutating the graph. Without an explicit handshake, on a slow shared-tenant Windows runner the main thread can complete all mutation cycles + the 5ms tail sleep before the just-spawned audio thread is ever scheduled to enter the inner `graph.process()` loop, leaving `blocks == 0`.

Production code (`core/host/src/signal_graph.cpp` snapshot publish via `std::atomic_store_explicit(&live_, ..., release)` paired with `std::atomic_load_explicit(&live_, ..., acquire)` in `process()`) is correct as-is — `bad_samples` has never been the failing assertion in the captured flake history.

## Fix

Mirror the proven pattern from `test_host_regression.cpp:795-829`: two `std::promise<void>` barriers — `audio_started` (thread launched) and `first_block_processed` (process() executed at least once). Main blocks on both before mutating. Removes the timing dependency entirely; no wall-clock sleeps anywhere in the wait path. Re-tagged with `[issue-669]` so future failures link to this thread.

## Local stress (Apple Silicon, Debug build)

```
pre-fix:  100/100 quiet, 100/100 under 8x `yes >/dev/null` CPU saturation
post-fix: 100/100 quiet, 100/100 under 8x `yes >/dev/null` CPU saturation
```

Local repro doesn't discriminate (Apple Silicon is too fast/strong-memory) — same finding the original #669 investigator hit. The fix is justified by failure-shape analysis (the captured assertion is `blocks.load() > 0`, exactly what this barrier prevents) and by parity with the proven sibling fix.

## Test plan

- [x] `pulp-test-host` full-suite passes locally (1034 assertions, 27 cases)
- [x] `pulp-test-host-regression "[issue-669]"` still passes (regression-copy unaffected)
- [x] Post-fix stress 100/100 under CPU saturation
- [ ] CI on three platforms — Windows is the high-signal lane; macOS + Linux just need to stay green