### PR TITLE
test(host): cover LV2 discovery and entry paths

### DIFF
--- a/.agents/skills/hosting/SKILL.md
+++ b/.agents/skills/hosting/SKILL.md
@@ -140,6 +140,10 @@ on top of Phase 0 contracts:
   (lv2:ControlPort + name/default/min/max), per-port float scratch in
   `control_values_`, `connect_port` wired at process() block start,
   param_events apply last-write-wins.
+- LV2 bundle discovery has a private test seam in
+  `core/host/src/lv2_discovery.hpp`; keep TTL port/binary parsing tests in
+  `test/test_lv2_host_discovery.cpp` rather than reaching through real
+  plug-in binaries for deterministic coverage.
 
 Param domain: **plain values** at the PluginSlot boundary (not
 normalized). Loaders convert internally if they natively normalize

--- a/core/host/src/lv2_discovery.hpp
+++ b/core/host/src/lv2_discovery.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace pulp::host::detail {
+
+struct Lv2PortRole {
+    int index = -1;
+    bool is_audio = false;
+    bool is_control = false;
+    bool is_input = false;
+    std::string name;
+    float min_value = 0.0f;
+    float max_value = 1.0f;
+    float default_value = 0.0f;
+};
+
+std::vector<Lv2PortRole> discover_lv2_ports(const std::string& bundle_dir);
+std::string resolve_lv2_binary(const std::string& bundle_dir);
+
+} // namespace pulp::host::detail

--- a/core/host/src/plugin_slot_lv2.cpp
+++ b/core/host/src/plugin_slot_lv2.cpp
@@ -23,6 +23,7 @@
 #include <lv2/core/lv2.h>
 
 #include <pulp/host/dl_shim.hpp>
+#include "lv2_discovery.hpp"
 #include <algorithm>
 #include <atomic>
 #include <cstring>
@@ -34,21 +35,10 @@
 #include <vector>
 
 namespace pulp::host {
-namespace {
 
 namespace fs = std::filesystem;
 
-struct PortRole {
-    int index = -1;
-    bool is_audio = false;
-    bool is_control = false;
-    bool is_input = false;
-    // Control-port metadata (only meaningful when is_control == true).
-    std::string name;
-    float min_value = 0.0f;
-    float max_value = 1.0f;
-    float default_value = 0.0f;
-};
+namespace detail {
 
 // Scan every .ttl file in the bundle, concatenate content, and extract audio
 // port roles. We look for port stanzas containing:
@@ -57,8 +47,8 @@ struct PortRole {
 // This matches the conventional LV2 style. TTL blank-node syntax varies —
 // we only support the common "[ a lv2:…Port, lv2:…Port ; lv2:index N ; … ]"
 // pattern here.
-std::vector<PortRole> discover_audio_ports(const std::string& bundle_dir) {
-    std::vector<PortRole> out;
+std::vector<Lv2PortRole> discover_lv2_ports(const std::string& bundle_dir) {
+    std::vector<Lv2PortRole> out;
     std::string all;
     std::error_code ec;
     for (auto& entry : fs::directory_iterator(bundle_dir, ec)) {
@@ -90,7 +80,7 @@ std::vector<PortRole> discover_audio_ports(const std::string& bundle_dir) {
         if (!is_audio && !is_control) continue;
         std::smatch idx_m;
         if (!std::regex_search(body, idx_m, idx_re)) continue;
-        PortRole role;
+        Lv2PortRole role;
         role.index = std::stoi(idx_m[1]);
         role.is_audio   = is_audio;
         role.is_control = is_control;
@@ -118,10 +108,14 @@ std::string resolve_lv2_binary(const std::string& bundle_dir) {
     return {};
 }
 
+} // namespace detail
+
+namespace {
+
 class Lv2Slot final : public PluginSlot {
 public:
     Lv2Slot(PluginInfo info, void* handle, const LV2_Descriptor* desc,
-            std::vector<PortRole> port_roles)
+            std::vector<detail::Lv2PortRole> port_roles)
         : info_(std::move(info)),
           handle_(handle),
           desc_(desc),
@@ -298,7 +292,7 @@ private:
     void* handle_ = nullptr;
     const LV2_Descriptor* desc_ = nullptr;
     LV2_Handle instance_ = nullptr;
-    std::vector<PortRole> port_roles_;
+    std::vector<detail::Lv2PortRole> port_roles_;
     int num_audio_inputs_ = 0;
     int num_audio_outputs_ = 0;
     int max_block_size_ = 0;
@@ -321,7 +315,7 @@ std::unique_ptr<PluginSlot> load_lv2_plugin(const PluginInfo& info) {
         runtime::log_error("LV2 load: path is not a bundle directory: '{}'", info.path);
         return nullptr;
     }
-    std::string bin = resolve_lv2_binary(info.path);
+    std::string bin = detail::resolve_lv2_binary(info.path);
     if (bin.empty()) {
         runtime::log_error("LV2 load: no .so/.dylib found in bundle '{}'", info.path);
         return nullptr;
@@ -354,7 +348,7 @@ std::unique_ptr<PluginSlot> load_lv2_plugin(const PluginInfo& info) {
         return nullptr;
     }
 
-    auto roles = discover_audio_ports(info.path);
+    auto roles = detail::discover_lv2_ports(info.path);
     if (roles.empty()) {
         runtime::log_warn("LV2 load: no audio ports found in bundle TTLs for '{}'; "
                           "plugin will load but process() will be a pass-through", info.path);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -859,6 +859,15 @@ if(PULP_HAS_LV2)
     )
     target_link_libraries(pulp-test-lv2-adapter PRIVATE pulp::format lv2-headers Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-lv2-adapter)
+
+    add_executable(pulp-test-lv2-host-discovery test_lv2_host_discovery.cpp)
+    target_include_directories(pulp-test-lv2-host-discovery PRIVATE
+        ${CMAKE_SOURCE_DIR}/core/host/src)
+    target_link_libraries(pulp-test-lv2-host-discovery PRIVATE
+        pulp::host
+        lv2-headers
+        Catch2::Catch2WithMain)
+    catch_discover_tests(pulp-test-lv2-host-discovery)
 endif()
 
 # NSIS installer script generation tests (cross-platform — pure string output)

--- a/test/test_lv2_adapter.cpp
+++ b/test/test_lv2_adapter.cpp
@@ -9,6 +9,9 @@
 
 #include <array>
 #include <cstring>
+#include <memory>
+#include <tuple>
+#include <vector>
 
 using namespace pulp;
 using namespace pulp::format;
@@ -188,7 +191,251 @@ struct LV2SequenceBuffer {
         as_seq()->atom.type = 0;
     }
 };
+
+constexpr state::ParamID kLv2ProbeGainParam = 7;
+
+struct Lv2ProbeCapture {
+    int prepare_calls = 0;
+    int process_calls = 0;
+    int release_calls = 0;
+    int last_num_samples = 0;
+    double last_sample_rate = 0.0;
+    std::size_t last_midi_count = 0;
+    uint8_t first_status = 0;
+    uint8_t first_note = 0;
+
+    void reset() { *this = {}; }
+};
+
+Lv2ProbeCapture g_lv2_probe;
+
+class Lv2EntryProbeProcessor final : public Processor {
+public:
+    PluginDescriptor descriptor() const override {
+        PluginDescriptor desc;
+        desc.name = "Lv2EntryProbe";
+        desc.manufacturer = "PulpTest";
+        desc.bundle_id = "com.pulp.test.lv2-entry-probe";
+        desc.version = "1.0.0";
+        desc.category = PluginCategory::MidiEffect;
+        desc.input_buses = {{"Input", 1}};
+        desc.output_buses = {{"Output", 1}};
+        desc.accepts_midi = true;
+        desc.produces_midi = true;
+        return desc;
+    }
+
+    void define_parameters(state::StateStore& store) override {
+        store.add_parameter({
+            .id = kLv2ProbeGainParam,
+            .name = "Gain",
+            .unit = "",
+            .range = {0.0f, 2.0f, 1.0f},
+        });
+    }
+
+    void prepare(const PrepareContext& context) override {
+        ++g_lv2_probe.prepare_calls;
+        g_lv2_probe.last_sample_rate = context.sample_rate;
+    }
+
+    void release() override { ++g_lv2_probe.release_calls; }
+
+    void process(audio::BufferView<float>& audio_output,
+                 const audio::BufferView<const float>& audio_input,
+                 midi::MidiBuffer& midi_in,
+                 midi::MidiBuffer& midi_out,
+                 const ProcessContext& context) override {
+        ++g_lv2_probe.process_calls;
+        g_lv2_probe.last_num_samples = context.num_samples;
+        g_lv2_probe.last_sample_rate = context.sample_rate;
+        g_lv2_probe.last_midi_count = midi_in.size();
+        for (const auto& ev : midi_in) {
+            g_lv2_probe.first_status = ev.data()[0];
+            g_lv2_probe.first_note = ev.size() > 1 ? ev.data()[1] : 0;
+            break;
+        }
+
+        for (size_t c = 0; c < audio_output.num_channels(); ++c) {
+            auto* dst = audio_output.channel_ptr(c);
+            const auto* src = c < audio_input.num_channels()
+                ? audio_input.channel_ptr(c)
+                : nullptr;
+            for (int i = 0; i < context.num_samples; ++i) {
+                dst[i] = (src ? src[i] : 0.0f) * 2.0f;
+            }
+        }
+
+        auto out = midi::MidiEvent::note_on(0, 65, 110);
+        out.sample_offset = 7;
+        midi_out.add(out);
+    }
+};
+
+std::unique_ptr<Processor> make_lv2_entry_probe() {
+    return std::make_unique<Lv2EntryProbeProcessor>();
+}
+
+struct Lv2FactoryGuard {
+    ProcessorFactory previous_factory = lv2_generic::g_factory;
+    const char* previous_uri = lv2_generic::g_uri;
+    const char* previous_descriptor_uri = lv2_generic::g_lv2_descriptor.URI;
+
+    explicit Lv2FactoryGuard(ProcessorFactory factory) {
+        g_lv2_probe.reset();
+        lv2_generic::g_factory = factory;
+        lv2_generic::g_uri = "http://pulp.audio/test/lv2-entry-probe";
+        lv2_generic::g_lv2_descriptor.URI = lv2_generic::g_uri;
+    }
+
+    ~Lv2FactoryGuard() {
+        lv2_generic::g_factory = previous_factory;
+        lv2_generic::g_uri = previous_uri;
+        lv2_generic::g_lv2_descriptor.URI = previous_descriptor_uri;
+    }
+};
+
+struct Lv2HandleGuard {
+    LV2_Handle handle = nullptr;
+
+    ~Lv2HandleGuard() {
+        if (handle) lv2_generic::cleanup(handle);
+    }
+};
+
+struct Lv2FeatureBundle {
+    std::vector<std::string> table;
+    LV2_URID_Map map{&table, &fake_map};
+    LV2_Feature map_feature{LV2_URID__map, &map};
+    const LV2_Feature* features[2] = {&map_feature, nullptr};
+};
+
+uint32_t prepare_sequence(LV2SequenceBuffer& buf, LV2_URID atom_sequence_urid) {
+    buf.prepare_as_output_port();
+    auto* seq = buf.as_seq();
+    const uint32_t capacity = seq->atom.size;
+    seq->atom.type = atom_sequence_urid;
+    seq->body.unit = 0;
+    seq->body.pad = 0;
+    lv2_atom_sequence_clear(seq);
+    return capacity;
+}
+
+void append_midi_event(LV2_Atom_Sequence* seq,
+                       uint32_t capacity,
+                       LV2_URID midi_event_urid,
+                       int64_t frame,
+                       uint8_t status,
+                       uint8_t data1,
+                       uint8_t data2) {
+    struct alignas(8) {
+        LV2_Atom_Event hdr;
+        uint8_t payload[3];
+    } pkt{};
+    pkt.hdr.time.frames = frame;
+    pkt.hdr.body.type = midi_event_urid;
+    pkt.hdr.body.size = 3;
+    pkt.payload[0] = status;
+    pkt.payload[1] = data1;
+    pkt.payload[2] = data2;
+    REQUIRE(lv2_atom_sequence_append_event(seq, capacity, &pkt.hdr));
+}
 } // namespace
+
+TEST_CASE("LV2 generic entry refuses instantiation without URID map",
+          "[format][lv2][issue-493]") {
+    Lv2FactoryGuard factory(&make_lv2_entry_probe);
+    const LV2_Feature* empty_features[] = {nullptr};
+
+    REQUIRE(lv2_generic::instantiate(&lv2_generic::g_lv2_descriptor,
+                                     48000.0,
+                                     "",
+                                     nullptr) == nullptr);
+    REQUIRE(lv2_generic::instantiate(&lv2_generic::g_lv2_descriptor,
+                                     48000.0,
+                                     "",
+                                     empty_features) == nullptr);
+}
+
+TEST_CASE("LV2 generic entry wires ports, audio, control values, and MIDI",
+          "[format][lv2][issue-493]") {
+    Lv2FactoryGuard factory(&make_lv2_entry_probe);
+    Lv2FeatureBundle features;
+
+    Lv2HandleGuard handle{
+        lv2_generic::instantiate(&lv2_generic::g_lv2_descriptor,
+                                 44100.0,
+                                 "",
+                                 features.features)
+    };
+    REQUIRE(handle.handle != nullptr);
+
+    auto* inst = static_cast<PulpLv2Instance*>(handle.handle);
+    REQUIRE(inst->processor != nullptr);
+    REQUIRE(inst->sample_rate == 44100.0);
+    REQUIRE(inst->num_audio_inputs == 1);
+    REQUIRE(inst->num_audio_outputs == 1);
+    REQUIRE(inst->num_params == 1);
+    REQUIRE(inst->param_ids.size() == 1);
+    REQUIRE(inst->param_ids[0] == kLv2ProbeGainParam);
+    REQUIRE(inst->accepts_midi);
+    REQUIRE(inst->produces_midi);
+    REQUIRE(inst->urid_midi_event != 0);
+    REQUIRE(inst->urid_atom_sequence != 0);
+    REQUIRE(inst->urid_atom_chunk != 0);
+    REQUIRE(g_lv2_probe.prepare_calls == 1);
+
+    float input[4] = {0.25f, -0.5f, 1.0f, 0.0f};
+    float output[4] = {};
+    float gain = 0.5f;
+
+    LV2SequenceBuffer midi_in;
+    const uint32_t midi_in_capacity =
+        prepare_sequence(midi_in, inst->urid_atom_sequence);
+    append_midi_event(midi_in.as_seq(), midi_in_capacity,
+                      inst->urid_midi_event, 3, 0x90, 60, 100);
+
+    LV2SequenceBuffer midi_out;
+    midi_out.prepare_as_output_port();
+
+    lv2_generic::connect_port(handle.handle, 0, input);
+    lv2_generic::connect_port(handle.handle, 1, output);
+    lv2_generic::connect_port(handle.handle, 2, &gain);
+    lv2_generic::connect_port(handle.handle, 3, midi_in.as_seq());
+    lv2_generic::connect_port(handle.handle, 4, midi_out.as_seq());
+    lv2_generic::connect_port(handle.handle, 999, &gain);
+    lv2_generic::activate(handle.handle);
+
+    lv2_generic::run(handle.handle, 4);
+    lv2_generic::deactivate(handle.handle);
+
+    REQUIRE(inst->store.get_value(kLv2ProbeGainParam) == 0.5f);
+    REQUIRE(g_lv2_probe.process_calls == 1);
+    REQUIRE(g_lv2_probe.last_num_samples == 4);
+    REQUIRE(g_lv2_probe.last_sample_rate == 44100.0);
+    REQUIRE(g_lv2_probe.last_midi_count == 1);
+    REQUIRE(g_lv2_probe.first_status == 0x90);
+    REQUIRE(g_lv2_probe.first_note == 60);
+
+    REQUIRE(output[0] == 0.5f);
+    REQUIRE(output[1] == -1.0f);
+    REQUIRE(output[2] == 2.0f);
+    REQUIRE(output[3] == 0.0f);
+
+    std::vector<std::tuple<int64_t, LV2_URID, uint32_t, uint8_t, uint8_t, uint8_t>> seen;
+    LV2_ATOM_SEQUENCE_FOREACH(midi_out.as_seq(), ev) {
+        const auto* data = reinterpret_cast<const uint8_t*>(ev + 1);
+        seen.emplace_back(ev->time.frames, ev->body.type, ev->body.size,
+                          data[0], data[1], data[2]);
+    }
+    REQUIRE(seen.size() == 1);
+    REQUIRE(std::get<0>(seen[0]) == 7);
+    REQUIRE(std::get<1>(seen[0]) == inst->urid_midi_event);
+    REQUIRE(std::get<2>(seen[0]) == 3);
+    REQUIRE(std::get<3>(seen[0]) == 0x90);
+    REQUIRE(std::get<4>(seen[0]) == 65);
+    REQUIRE(std::get<5>(seen[0]) == 110);
+}
 
 TEST_CASE("write_midi_out_to_sequence emits MIDI events in order",
           "[format][lv2][issue-491]") {

--- a/test/test_lv2_host_discovery.cpp
+++ b/test/test_lv2_host_discovery.cpp
@@ -1,0 +1,154 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/host/plugin_slot.hpp>
+
+#include "lv2_discovery.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct ScratchDir {
+    fs::path path;
+
+    explicit ScratchDir(const char* stem) {
+        const auto counter =
+            std::chrono::steady_clock::now().time_since_epoch().count();
+        path = fs::temp_directory_path()
+             / (std::string("pulp-lv2-host-") + stem + "-"
+                + std::to_string(counter));
+        std::error_code ec;
+        fs::remove_all(path, ec);
+        fs::create_directories(path);
+    }
+
+    ~ScratchDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+
+    ScratchDir(const ScratchDir&) = delete;
+    ScratchDir& operator=(const ScratchDir&) = delete;
+};
+
+void write_file(const fs::path& path, const std::string& body) {
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    REQUIRE(out.good());
+    out << body;
+}
+
+} // namespace
+
+TEST_CASE("LV2 host discovery parses audio and control port roles",
+          "[host][lv2][issue-493]") {
+    ScratchDir scratch("ports");
+    const auto bundle = scratch.path / "Probe.lv2";
+    fs::create_directories(bundle);
+
+    write_file(bundle / "plugin.ttl", R"TTL(
+@prefix lv2: <http://lv2plug.in/ns/lv2core#> .
+
+<http://example.com/pulp/probe>
+    a lv2:Plugin ;
+    lv2:port
+    [
+        a lv2:InputPort , lv2:AudioPort ;
+        lv2:index 0 ;
+        lv2:name "Input L"
+    ] ,
+    [
+        a lv2:OutputPort , lv2:AudioPort ;
+        lv2:index 1 ;
+        lv2:name "Output L"
+    ] ,
+    [
+        a lv2:InputPort , lv2:ControlPort ;
+        lv2:index 2 ;
+        lv2:name "Gain" ;
+        lv2:default 0.75 ;
+        lv2:minimum -1.0 ;
+        lv2:maximum 2.0
+    ] ,
+    [
+        a lv2:OutputPort , lv2:ControlPort ;
+        lv2:index 3 ;
+        lv2:name "Meter" ;
+        lv2:default 0.0 ;
+        lv2:minimum 0.0 ;
+        lv2:maximum 1.0
+    ] .
+)TTL");
+
+    write_file(bundle / "ignored.txt",
+               "[ a lv2:InputPort , lv2:AudioPort ; lv2:index 99 ] .");
+    write_file(bundle / "malformed.ttl",
+               "[ a lv2:InputPort , lv2:AudioPort ; lv2:name \"No index\" ] .");
+
+    auto roles = pulp::host::detail::discover_lv2_ports(bundle.string());
+    REQUIRE(roles.size() == 4);
+
+    REQUIRE(roles[0].index == 0);
+    REQUIRE(roles[0].is_audio);
+    REQUIRE_FALSE(roles[0].is_control);
+    REQUIRE(roles[0].is_input);
+
+    REQUIRE(roles[1].index == 1);
+    REQUIRE(roles[1].is_audio);
+    REQUIRE_FALSE(roles[1].is_input);
+
+    REQUIRE(roles[2].index == 2);
+    REQUIRE(roles[2].is_control);
+    REQUIRE(roles[2].is_input);
+    REQUIRE(roles[2].name == "Gain");
+    REQUIRE(roles[2].default_value == 0.75f);
+    REQUIRE(roles[2].min_value == -1.0f);
+    REQUIRE(roles[2].max_value == 2.0f);
+
+    REQUIRE(roles[3].index == 3);
+    REQUIRE(roles[3].is_control);
+    REQUIRE_FALSE(roles[3].is_input);
+    REQUIRE(roles[3].name == "Meter");
+}
+
+TEST_CASE("LV2 host discovery resolves shared objects from bundle roots",
+          "[host][lv2][issue-493]") {
+    ScratchDir scratch("binary");
+    const auto bundle = scratch.path / "Binary.lv2";
+    fs::create_directories(bundle);
+    write_file(bundle / "README.txt", "not loadable");
+
+    REQUIRE(pulp::host::detail::resolve_lv2_binary(bundle.string()).empty());
+
+    const auto so = bundle / "pulp-probe.so";
+    write_file(so, "not a real shared library");
+    REQUIRE(pulp::host::detail::resolve_lv2_binary(bundle.string()) == so.string());
+}
+
+TEST_CASE("LV2 PluginSlot load fails cleanly for invalid bundles",
+          "[host][lv2][slot][issue-493]") {
+    using namespace pulp::host;
+
+    PluginInfo info;
+    info.format = PluginFormat::LV2;
+    info.name = "Missing";
+    info.path = "/path/that/does/not/exist.lv2";
+    REQUIRE(PluginSlot::load(info) == nullptr);
+
+    ScratchDir scratch("load-failures");
+    const auto bundle = scratch.path / "Invalid.lv2";
+    fs::create_directories(bundle);
+
+    info.name = "NoBinary";
+    info.path = bundle.string();
+    REQUIRE(PluginSlot::load(info) == nullptr);
+
+    write_file(bundle / "invalid.so", "not a real shared library");
+    info.name = "InvalidBinary";
+    REQUIRE(PluginSlot::load(info) == nullptr);
+}


### PR DESCRIPTION
## Parent
- #641

## Coverage tranche
- Part of #493 LV2 host/format gap closure.
- Exposes the existing LV2 TTL/binary discovery helpers through a private `core/host/src/lv2_discovery.hpp` seam so they can be tested without loading arbitrary plug-in binaries.
- Adds deterministic coverage for LV2 port parsing, binary resolution, invalid bundle load failures, and the generic LV2 entry instantiate/connect/run MIDI/control/audio path.
- Updates the hosting skill with the new LV2 discovery test seam for future handoff.

## Verification
- `cmake --build build --target pulp-test-lv2-adapter pulp-test-lv2-host-discovery -j4`
- `./build/test/pulp-test-lv2-adapter`
- `./build/test/pulp-test-lv2-host-discovery`
- `ctest --test-dir build -R "LV2|lv2" --output-on-failure`
- `PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`

## CI routing
- Using GitHub Actions / Namespace for validation; not using Shipyard SSH for this tranche per coverage-session routing.
