### PR TITLE
test(host): cover scan worker CLI paths

### DIFF
--- a/tools/scan-worker/CMakeLists.txt
+++ b/tools/scan-worker/CMakeLists.txt
@@ -16,6 +16,17 @@ add_executable(pulp-scan-worker scan_worker_main.cpp)
 target_link_libraries(pulp-scan-worker PRIVATE pulp::host pulp::runtime)
 set_target_properties(pulp-scan-worker PROPERTIES OUTPUT_NAME "pulp-scan-worker")
 
+if(PULP_BUILD_TESTS)
+    add_executable(pulp-test-scan-worker test_scan_worker.cpp)
+    target_link_libraries(pulp-test-scan-worker PRIVATE
+        pulp::platform
+        Catch2::Catch2WithMain)
+    target_compile_definitions(pulp-test-scan-worker PRIVATE
+        PULP_SCAN_WORKER_PATH="$<TARGET_FILE:pulp-scan-worker>")
+    add_dependencies(pulp-test-scan-worker pulp-scan-worker)
+    catch_discover_tests(pulp-test-scan-worker)
+endif()
+
 install(TARGETS pulp-scan-worker
     RUNTIME DESTINATION bin
 )

--- a/tools/scan-worker/test_scan_worker.cpp
+++ b/tools/scan-worker/test_scan_worker.cpp
@@ -1,0 +1,86 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <pulp/platform/child_process.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#ifndef PULP_SCAN_WORKER_PATH
+#error "PULP_SCAN_WORKER_PATH must point at the built pulp-scan-worker binary"
+#endif
+
+namespace fs = std::filesystem;
+using Catch::Matchers::ContainsSubstring;
+
+namespace {
+
+struct ScratchDir {
+    fs::path path;
+
+    explicit ScratchDir(const char* stem) {
+        const auto counter =
+            std::chrono::steady_clock::now().time_since_epoch().count();
+        path = fs::temp_directory_path()
+             / (std::string("pulp-scan-worker-test-") + stem + "-"
+                + std::to_string(counter));
+        std::error_code ec;
+        fs::remove_all(path, ec);
+        fs::create_directories(path);
+    }
+
+    ~ScratchDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+
+    ScratchDir(const ScratchDir&) = delete;
+    ScratchDir& operator=(const ScratchDir&) = delete;
+};
+
+void write_file(const fs::path& path, const std::string& body) {
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    REQUIRE(out.good());
+    out << body;
+}
+
+pulp::platform::ProcessResult run_worker(const std::vector<std::string>& args) {
+    return pulp::platform::exec(PULP_SCAN_WORKER_PATH, args, 5000);
+}
+
+} // namespace
+
+TEST_CASE("pulp-scan-worker reports usage when bundle path is missing",
+          "[host][scan-worker][issue-493]") {
+    auto result = run_worker({});
+    REQUIRE(result.exit_code == 2);
+    REQUIRE_THAT(result.stderr_output, ContainsSubstring("usage: pulp-scan-worker"));
+}
+
+TEST_CASE("pulp-scan-worker rejects unsupported bundle extensions",
+          "[host][scan-worker][issue-493]") {
+    ScratchDir scratch("unsupported");
+    auto path = scratch.path / "not-a-plugin.txt";
+    write_file(path, "not a plugin");
+
+    auto result = run_worker({path.string()});
+    REQUIRE(result.exit_code == 3);
+    REQUIRE_THAT(result.stderr_output, ContainsSubstring("unsupported bundle extension"));
+}
+
+TEST_CASE("pulp-scan-worker emits JSON for a manifest-free VST3 bundle",
+          "[host][scan-worker][issue-493]") {
+    ScratchDir scratch("vst3");
+    auto bundle = scratch.path / "Probe.vst3";
+    fs::create_directories(bundle / "Contents" / "Resources");
+
+    auto result = run_worker({bundle.string()});
+    REQUIRE(result.exit_code == 0);
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"name\":\"Probe\""));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"unique_id\":\"Probe\""));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring("\"format\":\"vst3\""));
+    REQUIRE_THAT(result.stdout_output, ContainsSubstring(bundle.string()));
+}


### PR DESCRIPTION
## Parent
- #641

## Coverage tranche
- Part of #493 scan-worker/background-scanner gap closure.
- Adds an adjacent `pulp-test-scan-worker` target that shells out to the built `pulp-scan-worker` binary.
- Covers deterministic CLI paths:
  - missing bundle path usage error
  - unsupported bundle extension error
  - manifest-free fake VST3 bundle descriptor JSON emission

## Verification
- `cmake -S . -B build`
- `cmake --build build --target pulp-test-scan-worker -j4`
- `./build/tools/scan-worker/pulp-test-scan-worker`
- `ctest --test-dir build -R "scan-worker|pulp-scan-worker" --output-on-failure`
- `PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`

## CI routing
- Using GitHub Actions / Namespace for validation; not using Shipyard SSH for this tranche per coverage-session routing.
