### PR TITLE
fix(import-design): use runtime gzip_decompress for bundle assets — unblocks ReactDOM + Babel-standalone

### DIFF
--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -300,7 +300,24 @@ std::optional<ClaudeBundle> parse_claude_bundle(const std::string& html) {
             if (cval.isBool()) compressed = cval.getBool();
         }
         if (compressed) {
-            auto inflated = claude_bundle_inflate(decoded->data(), decoded->size());
+            // Prefer the runtime gzip_decompress entry point — it handles
+            // real RFC 1952 streams of any size. The inline
+            // `claude_bundle_inflate` shim's `deflate_decompress`-via-
+            // `inflate_raw` path was silently failing on assets > ~900 KB
+            // inflated (the heuristic initial buffer is `compressed_size *
+            // 4` and the buffer-doubling retry loop on MZ_BUF_ERROR doesn't
+            // recover for some inputs miniz produces partial output for).
+            // On canonical Spectr Claude exports that meant ReactDOM
+            // (1.08 MB) and Babel-standalone (3.14 MB) were silently
+            // dropped during parsing, leaving only the React payload —
+            // and inline `text/babel` scripts (the actual app code) had
+            // no Babel.transform to compile against. Fall back to the
+            // inline shim if the runtime path returns nullopt — preserves
+            // back-compat for any exotic stream shape we haven't seen yet.
+            auto inflated = pulp::runtime::gzip_decompress(decoded->data(), decoded->size());
+            if (!inflated) {
+                inflated = claude_bundle_inflate(decoded->data(), decoded->size());
+            }
             if (!inflated) continue;
             asset.data = std::move(*inflated);
         } else {


### PR DESCRIPTION
`claude_bundle_inflate` (the inline RFC 1952 header stripper that ships
with `parse_claude_bundle`) silently fails on bundle assets larger than
~900 KB inflated. The shim parses the gzip header correctly but
delegates the deflate body to `pulp::runtime::deflate_decompress` →
`inflate_raw`, whose buffer-doubling retry loop on MZ_BUF_ERROR doesn't
always recover for inputs miniz produces partial output for. The bigger
the payload, the more likely the failure.

On canonical Spectr Claude exports (`/Users/danielraffel/Code/spectr/
resources/editor.html`, 1.86 MB on disk):

  Before:
    asset[0] React        110 KB inflated  ✓ kept
    asset[1] ReactDOM    1.08 MB inflated  ✗ DROPPED (inflate_failed)
    asset[2] Babel       3.14 MB inflated  ✗ DROPPED (inflate_failed)
    → only React loaded into the engine; no globalThis.ReactDOM or
      globalThis.Babel; inline `text/babel` scripts skipped because
      `babel-standalone not loaded`; React mount call never runs;
      walker captures empty `<div id="root">` skeleton (11 elements).

  After:
    All three JS payloads decompress and evaluate. Globals after eval:
    {hasReact:"object", hasReactDOM:"object", hasBabel:"object",
     babelTransform:"function"}.

#747 introduced `pulp::runtime::gzip_decompress` as a real RFC 1952
decoder and called out in the commit message that "the bundle parser's
inline RFC 1952 header stripper can land a deletion patch on top of
this." This is that follow-up: switch the primary decode path to the
runtime entry point, leave the inline shim as a fallback for any
exotic stream we haven't encountered.

`claude_bundle_inflate` is left in the file (rather than fully
deleted) so any caller that picks it up via the existing internal
namespace contract — and any unit test that builds custom bundles
via the inline format — still has a working code path. We can
delete it in a follow-up once we're confident the runtime entry
point covers every shape.

Reproduction (validated locally on 2026-04-25):

  /tmp/pulp-main-628/build/tools/import-design/pulp-import-design \
      --from claude \
      --file /Users/danielraffel/Code/spectr/resources/editor.html \
      --execute-bundle

  Without this patch: globals.hasBabel = "undefined", text/babel
  inline scripts skipped, walker emits 11 elements (loader skeleton).

  With this patch: globals.hasBabel = "object", babelTransform =
  "function", inline text/babel scripts compile via Babel.transform.
  React + ReactDOM + Babel + the inline `text/javascript` block
  (Pattern data) all load; only one inline `text/babel` script
  (`Main app entry`) currently still fails at the eval phase — that's
  a separate follow-up issue in the React mount path, not the
  decompression issue this PR fixes.

Refs: #468, #747, #758. Follow-up #759 proposed exercising large
fixtures behind `PULP_CLAUDE_BUNDLE_FIXTURE` for the optional fixture
test; this fix makes that fixture path work for any payload the gzip
decoder can handle.

Version-Bump: sdk=patch reason="bug fix in --execute-bundle decompression path"