### PR TITLE
test(view): cover multiline text editor navigation

### DIFF
--- a/core/view/src/text_editor.cpp
+++ b/core/view/src/text_editor.cpp
@@ -222,8 +222,17 @@ void TextEditor::move_to_line_end(bool extend) {
     else selection_start_ = selection_end_ = caret_position_;
 }
 
-void TextEditor::move_to_start(bool extend) { move_to_line_start(extend); }
-void TextEditor::move_to_end(bool extend) { move_to_line_end(extend); }
+void TextEditor::move_to_start(bool extend) {
+    caret_position_ = 0;
+    if (extend) selection_end_ = caret_position_;
+    else selection_start_ = selection_end_ = caret_position_;
+}
+
+void TextEditor::move_to_end(bool extend) {
+    caret_position_ = static_cast<int>(text_.size());
+    if (extend) selection_end_ = caret_position_;
+    else selection_start_ = selection_end_ = caret_position_;
+}
 
 bool TextEditor::is_word_char(char c) const {
     return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
@@ -298,11 +307,13 @@ bool TextEditor::on_key_event(const KeyEvent& event) {
             return true;
 
         case KeyCode::home:
-            move_to_start(shift);
+            if (multi_line) move_to_line_start(shift);
+            else move_to_start(shift);
             return true;
 
         case KeyCode::end_:
-            move_to_end(shift);
+            if (multi_line) move_to_line_end(shift);
+            else move_to_end(shift);
             return true;
 
         case KeyCode::backspace:

--- a/core/view/src/text_editor.cpp
+++ b/core/view/src/text_editor.cpp
@@ -5,6 +5,50 @@
 
 namespace pulp::view {
 
+namespace {
+
+int clamp_position(const std::string& text, int position) {
+    return std::clamp(position, 0, static_cast<int>(text.size()));
+}
+
+int line_start_for_position(const std::string& text, int position) {
+    position = clamp_position(text, position);
+    while (position > 0 && text[static_cast<size_t>(position - 1)] != '\n') {
+        --position;
+    }
+    return position;
+}
+
+int line_end_for_position(const std::string& text, int position) {
+    position = clamp_position(text, position);
+    const int len = static_cast<int>(text.size());
+    while (position < len && text[static_cast<size_t>(position)] != '\n') {
+        ++position;
+    }
+    return position;
+}
+
+int vertical_line_position(const std::string& text, int caret, int direction) {
+    caret = clamp_position(text, caret);
+    const int current_start = line_start_for_position(text, caret);
+    const int current_end = line_end_for_position(text, caret);
+    const int column = caret - current_start;
+
+    if (direction < 0) {
+        if (current_start == 0) return caret;
+        const int previous_end = current_start - 1;
+        const int previous_start = line_start_for_position(text, previous_end);
+        return previous_start + std::min(column, previous_end - previous_start);
+    }
+
+    if (current_end >= static_cast<int>(text.size())) return caret;
+    const int next_start = current_end + 1;
+    const int next_end = line_end_for_position(text, next_start);
+    return next_start + std::min(column, next_end - next_start);
+}
+
+} // namespace
+
 void TextEditor::set_text(const std::string& t) {
     push_undo();
     text_ = t;
@@ -167,14 +211,13 @@ void TextEditor::move_word(int direction, bool extend) {
 }
 
 void TextEditor::move_to_line_start(bool extend) {
-    // For single-line, start = 0
-    caret_position_ = 0;
-    if (extend) selection_end_ = 0;
-    else selection_start_ = selection_end_ = 0;
+    caret_position_ = line_start_for_position(text_, caret_position_);
+    if (extend) selection_end_ = caret_position_;
+    else selection_start_ = selection_end_ = caret_position_;
 }
 
 void TextEditor::move_to_line_end(bool extend) {
-    caret_position_ = static_cast<int>(text_.size());
+    caret_position_ = line_end_for_position(text_, caret_position_);
     if (extend) selection_end_ = caret_position_;
     else selection_start_ = selection_end_ = caret_position_;
 }
@@ -242,12 +285,16 @@ bool TextEditor::on_key_event(const KeyEvent& event) {
 
         case KeyCode::up:
             if (!multi_line) { move_to_start(shift); return true; }
-            // TODO: multi-line up movement
+            caret_position_ = vertical_line_position(text_, caret_position_, -1);
+            if (shift) selection_end_ = caret_position_;
+            else selection_start_ = selection_end_ = caret_position_;
             return true;
 
         case KeyCode::down:
             if (!multi_line) { move_to_end(shift); return true; }
-            // TODO: multi-line down movement
+            caret_position_ = vertical_line_position(text_, caret_position_, 1);
+            if (shift) selection_end_ = caret_position_;
+            else selection_start_ = selection_end_ = caret_position_;
             return true;
 
         case KeyCode::home:

--- a/test/test_text_editor.cpp
+++ b/test/test_text_editor.cpp
@@ -5,6 +5,18 @@
 using namespace pulp::view;
 using namespace pulp::canvas;
 
+namespace {
+
+KeyEvent key_event(KeyCode key, uint16_t modifiers = 0) {
+    KeyEvent event;
+    event.key = key;
+    event.modifiers = modifiers;
+    event.is_down = true;
+    return event;
+}
+
+} // namespace
+
 TEST_CASE("TextEditor set and get text", "[view][text_editor]") {
     TextEditor editor;
     REQUIRE(editor.is_empty());
@@ -156,6 +168,73 @@ TEST_CASE("TextEditor key event: Up goes to start in single-line", "[view][text_
     e.is_down = true;
     REQUIRE(editor.on_key_event(e));
     // Up in single-line moves to start — verify by typing
+}
+
+TEST_CASE("TextEditor multi-line up and down preserve the visual column", "[view][text_editor]") {
+    TextEditor editor;
+    editor.multi_line = true;
+    editor.on_focus_changed(true);
+    editor.set_text("abc\nde\nfghi");
+
+    REQUIRE(editor.caret_pos() == 11);
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::up)));
+    REQUIRE(editor.caret_pos() == 6);
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::up)));
+    REQUIRE(editor.caret_pos() == 2);
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::down)));
+    REQUIRE(editor.caret_pos() == 6);
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::down)));
+    REQUIRE(editor.caret_pos() == 9);
+}
+
+TEST_CASE("TextEditor multi-line home and end move within the current line", "[view][text_editor]") {
+    TextEditor editor;
+    editor.multi_line = true;
+    editor.on_focus_changed(true);
+    editor.set_text("abc\ndefg\nhi");
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::up)));
+    REQUIRE(editor.caret_pos() == 6);
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::home)));
+    REQUIRE(editor.caret_pos() == 4);
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::end_)));
+    REQUIRE(editor.caret_pos() == 8);
+}
+
+TEST_CASE("TextEditor shift-up extends multi-line selection", "[view][text_editor]") {
+    TextEditor editor;
+    editor.multi_line = true;
+    editor.on_focus_changed(true);
+    editor.set_text("abcd\nef\nghij");
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::up, kModShift)));
+    REQUIRE(editor.caret_pos() == 7);
+    REQUIRE(editor.has_selection());
+    REQUIRE(editor.selected_text() == "\nghij");
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::up, kModShift)));
+    REQUIRE(editor.caret_pos() == 2);
+    REQUIRE(editor.selected_text() == "cd\nef\nghij");
+}
+
+TEST_CASE("TextEditor multi-line Enter inserts a newline instead of returning", "[view][text_editor]") {
+    TextEditor editor;
+    editor.multi_line = true;
+    editor.on_focus_changed(true);
+    editor.set_text("alpha");
+
+    bool returned = false;
+    editor.on_return = [&](const std::string&) { returned = true; };
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::enter)));
+    REQUIRE(editor.text() == "alpha\n");
+    REQUIRE_FALSE(returned);
 }
 
 TEST_CASE("TextEditor paint produces draw commands", "[view][text_editor]") {

--- a/test/test_text_editor.cpp
+++ b/test/test_text_editor.cpp
@@ -170,6 +170,26 @@ TEST_CASE("TextEditor key event: Up goes to start in single-line", "[view][text_
     // Up in single-line moves to start — verify by typing
 }
 
+TEST_CASE("TextEditor single-line navigation treats embedded newlines as plain text", "[view][text_editor]") {
+    TextEditor editor;
+    editor.on_focus_changed(true);
+    editor.set_text("aa\nbb\ncc");
+
+    REQUIRE(editor.caret_pos() == 8);
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::up)));
+    REQUIRE(editor.caret_pos() == 0);
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::down)));
+    REQUIRE(editor.caret_pos() == 8);
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::home)));
+    REQUIRE(editor.caret_pos() == 0);
+
+    REQUIRE(editor.on_key_event(key_event(KeyCode::end_)));
+    REQUIRE(editor.caret_pos() == 8);
+}
+
 TEST_CASE("TextEditor multi-line up and down preserve the visual column", "[view][text_editor]") {
     TextEditor editor;
     editor.multi_line = true;


### PR DESCRIPTION
## Summary
- implement newline-aware multi-line TextEditor Up/Down and line Home/End navigation
- add focused tests for multi-line vertical movement, shift-selection, line Home/End, and Enter insertion

## Validation
- cmake --build build --target pulp-test-text-editor -j4
- ./build/test/pulp-test-text-editor
- ctest --test-dir build -R "TextEditor|text-editor|text_editor" --output-on-failure
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- git diff --check

Part of #493 / #641 coverage hardening.