### PR TITLE
fix(test): avoid gpu-only inspect link in cli project command target

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -397,7 +397,16 @@ Gotchas:
 - **`--allow-redundant` bypasses the origin/main guard.** `pulp project
   bump` fetches `origin main` best-effort and refuses by default when
   main already pins the target-or-newer SDK. Fetch failures fail open
-  so offline users aren't blocked by stale refs.
+  so offline users aren't blocked by stale refs. In standalone
+  projects, still compare local `pulp.toml` / `find_package(Pulp ...)`
+  lockstep before firing the guard: if `sdk_version` already matches
+  the target but `find_package` is stale, the command should repair the
+  local drift instead of forcing `--allow-redundant`.
+- **Managed `sdk_path` rewrites are only real edits when the path
+  changes.** If a standalone project already targets the requested SDK
+  and `sdk_path` already points at that managed cache, the command must
+  return "already at target version" rather than staging a no-op
+  rewrite just because the path is managed.
 - **`project_bump` is decoupled from `cli_common`.** Same rule as
   `projects_registry` / `update_mode` — the unit test binaries link
   just the module + Catch2. Don't reach into `cli_common.hpp` from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v0471"></a>
+## [0.47.1] - 2026-04-25
+
+- fix(project): close standalone project bump edge cases ([#770](https://github.com/danielraffel/pulp/pull/770))
+
 <a id="v0470"></a>
 ## [0.47.0] - 2026-04-25
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.47.0
+    VERSION 0.47.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -238,7 +238,8 @@ catch_discover_tests(pulp-test-cli-project-bump-all)
 # cli_common.cpp. The test includes cmd_project.cpp directly so the
 # anonymous-namespace helpers can be exercised without shelling out.
 # The desktop CLI subdirectory is skipped for PULP_ENABLE_GPU=OFF, but
-# this test still compiles cli_common.cpp in sanitizer/IWYU configurations.
+# this test still compiles cli_common.cpp in sanitizer/IWYU configurations,
+# so generate the shared version header here too.
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/tools/cli")
 configure_file(
     "${CMAKE_SOURCE_DIR}/tools/cli/pulp_version_gen.h.in"

--- a/test/test_cli_project_command.cpp
+++ b/test/test_cli_project_command.cpp
@@ -368,6 +368,67 @@ TEST_CASE("bump_one verify-builds succeeds with a cached standalone SDK",
             != std::string::npos);
 }
 
+TEST_CASE("bump_one skips standalone no-op managed sdk_path rewrites at target",
+          "[project-command][issue-244]") {
+    TempDir tmp;
+    auto home = tmp.path / "home";
+    auto project = tmp.path / "Clock";
+    ScopedEnv pulp_home("PULP_HOME", home.string());
+
+    auto current_sdk = local_sdk_cache_path("0.2.0");
+    make_standalone_project(project, "0.2.0", current_sdk.generic_string());
+
+    BumpOptions opts;
+    auto skipped = bump_one(project, "0.2.0", opts, "Clock");
+    REQUIRE(skipped.status == "skipped");
+    REQUIRE(skipped.failure_reason == "already at target version");
+    REQUIRE(skipped.edits.empty());
+
+    auto toml = read_file_text(project / "pulp.toml");
+    REQUIRE(toml.find("sdk_path = \"" + current_sdk.generic_string() + "\"")
+            != std::string::npos);
+}
+
+TEST_CASE("bump_one repairs standalone lockstep drift even when origin main already pins target",
+          "[project-command][issue-244]") {
+    TempDir tmp;
+    auto origin = tmp.path / "origin.git";
+    auto seed = tmp.path / "seed";
+    auto feature = tmp.path / "feature";
+
+    require_run_ok("git init --bare -q " + quote(origin));
+
+    fs::create_directories(seed);
+    require_run_ok("git init -q " + quote(seed));
+    configure_git_identity(seed);
+    require_run_ok("git -C " + quote(seed) + " checkout -q -b main");
+    make_standalone_project(seed, "0.2.0");
+    require_run_ok("git -C " + quote(seed) + " add CMakeLists.txt pulp.toml");
+    require_run_ok("git -C " + quote(seed) + " commit -q -m \"main pin\"");
+    require_run_ok("git -C " + quote(seed) + " remote add origin " + quote(origin));
+    require_run_ok("git -C " + quote(seed) + " push -q -u origin main");
+
+    require_run_ok("git clone -q " + quote(origin) + " " + quote(feature));
+    configure_git_identity(feature);
+    require_run_ok("git -C " + quote(feature) + " checkout -q -b feature");
+    make_standalone_project(feature, "0.2.0");
+    write_file(feature / "CMakeLists.txt",
+               "cmake_minimum_required(VERSION 3.20)\n"
+               "project(Clock VERSION 1.0.0 LANGUAGES CXX)\n"
+               "find_package(Pulp 0.1.0 REQUIRED)\n");
+    require_run_ok("git -C " + quote(feature) + " add CMakeLists.txt pulp.toml");
+    require_run_ok("git -C " + quote(feature) + " commit -q -m \"stale cmake pin\"");
+
+    BumpOptions opts;
+    auto bumped = bump_one(feature, "0.2.0", opts, "Clock");
+    REQUIRE(bumped.status == "bumped");
+    REQUIRE(bumped.edits.size() == 1);
+    REQUIRE(bumped.edits.front().kind == pb::PinKind::CMakeFindPackagePulpVersion);
+    REQUIRE(read_file_text(feature / "CMakeLists.txt")
+                .find("find_package(Pulp 0.2.0 REQUIRED)")
+            != std::string::npos);
+}
+
 TEST_CASE("resolve_standalone_sdk falls back from mismatched sdk_path to caches",
           "[project-command][issue-244]") {
     TempDir tmp;

--- a/tools/cli/cmd_project.cpp
+++ b/tools/cli/cmd_project.cpp
@@ -470,7 +470,7 @@ pb::UndoEntry bump_one(const fs::path& project_path,
             return entry;
         }
 
-        if (!opts.allow_redundant) {
+        if (current != target_version && !opts.allow_redundant) {
             if (auto main_pin = main_pinned_version_at_origin(project_path, true);
                 main_pin && !pb::is_downgrade(*main_pin, target_version)) {
                 entry.status = "skipped";
@@ -513,7 +513,7 @@ pb::UndoEntry bump_one(const fs::path& project_path,
             auto replacement = managed_sdk_path_replacement(fs::path(path_site.current_pin),
                                                             current,
                                                             target_version);
-            if (replacement) {
+            if (replacement && *replacement != path_site.current_pin) {
                 if (!add_edit(toml_path, pb::PinKind::PulpTomlSdkPath,
                               path_site.current_pin, false, *replacement)) {
                     entry.status = "failed";


### PR DESCRIPTION
Follow-up to #735.

`pulp-test-cli-project-command` does not need `pulp::inspect`, and linking it breaks sanitizer configures that run with `-DPULP_ENABLE_GPU=OFF` before any build/test work happens. This drops that unnecessary dependency so the sanitizer matrix can configure the tree portably.

Test Plan:
- cmake -S . -B build-asan-check -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer" -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" -DPULP_BUILD_TESTS=ON -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF
- python3 tools/scripts/version_bump_check.py --base origin/main --mode=report
- git diff --check