### PR TITLE
test(view): cover widget bridge extended controls

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -110,6 +110,16 @@ pulp #709 / `--from claude` is the worked example.
 - [ ] Search CLAUDE.md
 - [ ] Run sync check
 
+## `pulp project bump` shell helpers
+
+`tools/cli/cmd_project.cpp` shells out to `git` / `cmake` from unit-tested
+helper paths, including Windows CI. Keep output redirection platform-aware:
+POSIX uses `/dev/null`, but Windows `cmd.exe` needs `NUL`. Do not add raw
+`2>/dev/null` or `>/dev/null 2>&1` in this file; route new call sites through
+the local null-redirection helpers instead. Otherwise Windows Namespace can
+misreport clean/dirty git state or fail origin-main probes even though the
+same tests pass on macOS/Linux.
+
 ## `pulp pr` — shim over `shipyard pr`
 
 By default `pulp pr` now delegates to `shipyard pr` (on PATH), forwarding

--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -161,6 +161,15 @@ Gotchas:
   run *before* `pulp pr` if you want to see what the gate will say. Same
   script, `--mode=report`.
 
+## `pulp upgrade --check-only`
+
+The sandbox E2E harness runs this command with
+`PULP_UPDATE_CHECK_DISABLED=1` and expects a non-silent, network-free result.
+If the update cache is empty in that mode, print the installed CLI version
+and an explicit disabled/not-queried latest-version line instead of probing
+GitHub Releases. Otherwise PR sandbox lanes can fail spuriously when GitHub
+release fetches are blocked or rate-limited.
+
 ## `pulp validate` — plugin-format validators
 
 Runs `clap-validator` / `pluginval` / `auval` / optional AAX validator

--- a/.agents/skills/upgrade/SKILL.md
+++ b/.agents/skills/upgrade/SKILL.md
@@ -117,6 +117,11 @@ source of truth.
    slash command must capture the `Latest:` value from `--check-only`
    and forward it as `--to "$LATEST"` (#583 Codex P1 / wave-4 sweep).
 
+   In CI / sandbox lanes, `PULP_UPDATE_CHECK_DISABLED=1` makes
+   `--check-only` network-free. If the cache is empty in that mode, the
+   command reports the installed CLI version plus an explicit
+   disabled/not-queried latest line instead of querying GitHub Releases.
+
    ```bash
    pulp upgrade --notes --json                  # defaults: from = installed CLI, to = cached latest
    pulp upgrade --notes --json --to "$LATEST"   # recommended — use value captured from --check-only

--- a/examples/ui-preview/CMakeLists.txt
+++ b/examples/ui-preview/CMakeLists.txt
@@ -1,6 +1,6 @@
 # UI Preview — standalone app for validating the rendering pipeline.
-# Desktop-only: depends on pulp::inspect which needs Dawn/Skia GPU.
-if(APPLE AND NOT PULP_IOS)
+# Desktop-only: depends on pulp::inspect which needs the GPU stack.
+if(APPLE AND NOT PULP_IOS AND PULP_ENABLE_GPU AND TARGET pulp::inspect)
     add_executable(pulp-ui-preview main.cpp)
     target_link_libraries(pulp-ui-preview PRIVATE
         pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -237,6 +237,13 @@ catch_discover_tests(pulp-test-cli-project-bump-all)
 # plus the shared standalone SDK resolution/doctor helpers in
 # cli_common.cpp. The test includes cmd_project.cpp directly so the
 # anonymous-namespace helpers can be exercised without shelling out.
+# The desktop CLI subdirectory is skipped for PULP_ENABLE_GPU=OFF, but
+# this test still compiles cli_common.cpp in sanitizer/IWYU configurations.
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/tools/cli")
+configure_file(
+    "${CMAKE_SOURCE_DIR}/tools/cli/pulp_version_gen.h.in"
+    "${CMAKE_BINARY_DIR}/tools/cli/pulp_version_gen.h"
+    @ONLY)
 add_executable(pulp-test-cli-project-command
     test_cli_project_command.cpp
     ${CMAKE_SOURCE_DIR}/tools/cli/cli_common.cpp
@@ -260,7 +267,6 @@ target_link_libraries(pulp-test-cli-project-command PRIVATE
     pulp::ship
     pulp::view
     pulp::format
-    pulp::inspect
     pulp::host
     Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-cli-project-command)

--- a/test/test_cli_project_command.cpp
+++ b/test/test_cli_project_command.cpp
@@ -222,6 +222,17 @@ TEST_CASE("cmd_project bump rejects targets newer than the installed CLI",
     REQUIRE(capture.err.str().find("pulp upgrade 99.0.0") != std::string::npos);
 }
 
+TEST_CASE("project command shell redirection helpers use platform null devices",
+          "[project-command][issue-244]") {
+#if defined(_WIN32)
+    REQUIRE(std::string(stderr_to_null()) == " 2>NUL");
+    REQUIRE(std::string(output_to_null()) == " >NUL 2>&1");
+#else
+    REQUIRE(std::string(stderr_to_null()) == " 2>/dev/null");
+    REQUIRE(std::string(output_to_null()) == " >/dev/null 2>&1");
+#endif
+}
+
 TEST_CASE("bump_one enforces the dirty gate and rewrites managed standalone sdk_path",
           "[project-command][issue-244]") {
     TempDir tmp;
@@ -268,6 +279,39 @@ TEST_CASE("bump_one rewrites non-standalone FetchContent pins",
             != std::string::npos);
 }
 
+TEST_CASE("bump_one refuses redundant FetchContent bumps when origin main already pins the target",
+          "[project-command][issue-244]") {
+    TempDir tmp;
+    auto origin = tmp.path / "origin.git";
+    auto seed = tmp.path / "seed";
+    auto feature = tmp.path / "feature";
+
+    require_run_ok("git init --bare -q " + quote(origin));
+
+    fs::create_directories(seed);
+    require_run_ok("git init -q " + quote(seed));
+    configure_git_identity(seed);
+    require_run_ok("git -C " + quote(seed) + " checkout -q -b main");
+    make_fetchcontent_project(seed, "0.2.0");
+    require_run_ok("git -C " + quote(seed) + " add CMakeLists.txt");
+    require_run_ok("git -C " + quote(seed) + " commit -q -m \"main pin\"");
+    require_run_ok("git -C " + quote(seed) + " remote add origin " + quote(origin));
+    require_run_ok("git -C " + quote(seed) + " push -q -u origin main");
+
+    require_run_ok("git clone -q " + quote(origin) + " " + quote(feature));
+    configure_git_identity(feature);
+    require_run_ok("git -C " + quote(feature) + " checkout -q -b feature");
+    make_fetchcontent_project(feature, "0.1.0");
+    require_run_ok("git -C " + quote(feature) + " add CMakeLists.txt");
+    require_run_ok("git -C " + quote(feature) + " commit -q -m \"older local pin\"");
+
+    BumpOptions opts;
+    auto skipped = bump_one(feature, "0.2.0", opts, "FetchClock");
+    REQUIRE(skipped.status == "skipped");
+    REQUIRE(skipped.failure_reason.find("origin/main already pins SDK 0.2.0 >= target 0.2.0")
+            != std::string::npos);
+}
+
 TEST_CASE("bump_one refuses redundant standalone bumps when origin main already pins the target",
           "[project-command][issue-244]") {
     TempDir tmp;
@@ -298,6 +342,29 @@ TEST_CASE("bump_one refuses redundant standalone bumps when origin main already 
     auto skipped = bump_one(feature, "0.2.0", opts, "Clock");
     REQUIRE(skipped.status == "skipped");
     REQUIRE(skipped.failure_reason.find("origin/main already pins SDK 0.2.0 >= target 0.2.0")
+            != std::string::npos);
+}
+
+TEST_CASE("bump_one verify-builds succeeds with a cached standalone SDK",
+          "[project-command][issue-244]") {
+    TempDir tmp;
+    auto home = tmp.path / "home";
+    auto project = tmp.path / "Clock";
+    ScopedEnv pulp_home("PULP_HOME", home.string());
+
+    make_standalone_project(project, "0.1.0");
+    make_fake_sdk(sdk_cache_path("0.2.0"), "0.2.0");
+
+    BumpOptions opts;
+    opts.verify_builds = true;
+    auto bumped = bump_one(project, "0.2.0", opts, "Clock");
+
+    REQUIRE(bumped.status == "bumped");
+    REQUIRE(bumped.edits.size() == 2);
+    REQUIRE_FALSE(fs::exists(project / "build-bump-verify"));
+    REQUIRE(read_file_text(project / "CMakeLists.txt").find("find_package(Pulp 0.2.0 REQUIRED)")
+            != std::string::npos);
+    REQUIRE(read_file_text(project / "pulp.toml").find("sdk_version = \"0.2.0\"")
             != std::string::npos);
 }
 

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -548,6 +548,32 @@ TEST_CASE("pulp upgrade --notes --json emits stable-shape JSON keys",
     REQUIRE(r.stdout_output.find("\"body\":")       != std::string::npos);
 }
 
+TEST_CASE("pulp upgrade --check-only honors disabled update checks with an empty cache",
+          "[cli][shellout][upgrade][codecov]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto tmp = fs::temp_directory_path() /
+               ("pulp-shellout-upgrade-disabled-" +
+                std::to_string(std::chrono::steady_clock::now()
+                                   .time_since_epoch().count()));
+    fs::create_directories(tmp);
+
+    pulp_setenv("PULP_HOME", tmp.string().c_str(), 1);
+    pulp_setenv("PULP_UPDATE_CHECK_DISABLED", "1", 1);
+    auto r = run_pulp({"upgrade", "--check-only"}, 10000);
+    pulp_unsetenv("PULP_UPDATE_CHECK_DISABLED");
+    pulp_unsetenv("PULP_HOME");
+    fs::remove_all(tmp);
+
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stdout_output.find("Installed:  v") != std::string::npos);
+    REQUIRE(r.stdout_output.find("Latest:     update check disabled; not queried")
+            != std::string::npos);
+    REQUIRE(r.stdout_output.find("Cache empty; querying GitHub Releases")
+            == std::string::npos);
+}
+
 // Issue #550 Slice 5: `update.mode = off` must produce zero network
 // traffic and zero banner output. We can't directly observe the
 // network inside ctest, but we CAN verify that (a) the command

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -4,6 +4,7 @@
 #include <pulp/view/modal.hpp>
 #include <pulp/view/text_editor.hpp>
 #include <pulp/view/widget_bridge.hpp>
+#include <pulp/view/widgets.hpp>
 #include <pulp/view/theme.hpp>
 #include <pulp/view/ui_components.hpp>
 #include <chrono>
@@ -292,6 +293,118 @@ TEST_CASE("WidgetBridge complete UI script", "[view][bridge]") {
     auto* gain_knob = dynamic_cast<Knob*>(bridge.widget("Gain"));
     REQUIRE(gain_knob != nullptr);
     REQUIRE_THAT(gain_knob->value(), WithinAbs(0.5, 0.01));
+}
+
+TEST_CASE("WidgetBridge extended controls and visualization APIs round-trip JS to native state",
+          "[view][bridge][controls]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var checkbox_change = -1;
+        var toggle_change = -1;
+        var list_select = -1;
+        var list_activate = -1;
+
+        createIcon('send-icon', 'send', '');
+        createImage('preview', '');
+        setImageSource('preview', '/tmp/pulp-preview.png');
+
+        createCheckbox('armed', '');
+        on('armed', 'change', function(value) { checkbox_change = value; });
+        setValue('armed', 1);
+
+        createToggleButton('latched', '');
+        on('latched', 'toggle', function(value) { toggle_change = value; });
+        setLabel('latched', 'Latch');
+        setValue('latched', 1);
+
+        createMeter('meter', 'horizontal', '');
+        setMeterLevel('meter', 0.25, 0.75);
+        setWidgetStyle('meter', 'minimal');
+
+        createXYPad('xy', '');
+        setXY('xy', 1.2, -0.2);
+
+        createWaveform('wave', '');
+        setWaveformData('wave', [-1, 0, 1]);
+
+        createSpectrum('spectrum', '');
+        setSpectrumData('spectrum', [-60, -12, 0, -6]);
+
+        createProgress('progress', '');
+        setProgress('progress', 0.66);
+
+        createListBox('list', '');
+        on('list', 'select', function(index) { list_select = index; });
+        on('list', 'activate', function(index) { list_activate = index; });
+        setListItems('list', ['A', 'B', 'C']);
+        setListRowHeight('list', 31);
+        setListSelected('list', 2);
+    )");
+
+    auto* icon = dynamic_cast<Icon*>(bridge.widget("send-icon"));
+    REQUIRE(icon != nullptr);
+    REQUIRE(icon->type() == Icon::Type::send);
+
+    auto* image = dynamic_cast<ImageView*>(bridge.widget("preview"));
+    REQUIRE(image != nullptr);
+    REQUIRE(image->image_path() == "file:///tmp/pulp-preview.png");
+
+    auto* checkbox = dynamic_cast<Checkbox*>(bridge.widget("armed"));
+    REQUIRE(checkbox != nullptr);
+    REQUIRE(checkbox->is_checked());
+    checkbox->on_mouse_down({});
+    REQUIRE_FALSE(checkbox->is_checked());
+    REQUIRE(engine.evaluate("checkbox_change").getWithDefault<int>(-1) == 0);
+
+    auto* toggle = dynamic_cast<ToggleButton*>(bridge.widget("latched"));
+    REQUIRE(toggle != nullptr);
+    REQUIRE(toggle->is_on());
+    REQUIRE(toggle->label() == "Latch");
+    toggle->on_mouse_down({});
+    REQUIRE_FALSE(toggle->is_on());
+    REQUIRE(engine.evaluate("toggle_change").getWithDefault<int>(-1) == 0);
+
+    auto* meter = dynamic_cast<Meter*>(bridge.widget("meter"));
+    REQUIRE(meter != nullptr);
+    REQUIRE(meter->orientation() == Meter::Orientation::horizontal);
+    REQUIRE(meter->render_style() == WidgetRenderStyle::minimal);
+    REQUIRE_THAT(meter->display_rms(), WithinAbs(0.25f, 0.001f));
+    REQUIRE_THAT(meter->display_peak(), WithinAbs(0.75f, 0.001f));
+
+    auto* xy = dynamic_cast<XYPad*>(bridge.widget("xy"));
+    REQUIRE(xy != nullptr);
+    REQUIRE_THAT(xy->x_value(), WithinAbs(1.0f, 0.001f));
+    REQUIRE_THAT(xy->y_value(), WithinAbs(0.0f, 0.001f));
+
+    auto* wave = dynamic_cast<WaveformView*>(bridge.widget("wave"));
+    REQUIRE(wave != nullptr);
+    REQUIRE(wave->sample_count() == 3);
+
+    auto* spectrum = dynamic_cast<SpectrumView*>(bridge.widget("spectrum"));
+    REQUIRE(spectrum != nullptr);
+    REQUIRE(spectrum->bin_count() == 4);
+
+    auto* progress = dynamic_cast<ProgressBar*>(bridge.widget("progress"));
+    REQUIRE(progress != nullptr);
+    REQUIRE_THAT(progress->progress(), WithinAbs(0.66f, 0.001f));
+
+    auto* list = dynamic_cast<ListBox*>(bridge.widget("list"));
+    REQUIRE(list != nullptr);
+    REQUIRE(list->items().size() == 3);
+    REQUIRE(list->selected() == 2);
+    REQUIRE_THAT(list->row_height(), WithinAbs(31.0f, 0.001f));
+    REQUIRE(engine.evaluate("list_select").getWithDefault<int>(-1) == 2);
+
+    KeyEvent enter{};
+    enter.is_down = true;
+    enter.key = KeyCode::enter;
+    REQUIRE(list->on_key_event(enter));
+    REQUIRE(engine.evaluate("list_activate").getWithDefault<int>(-1) == 2);
 }
 
 // ── Bridge animation API tests ──────────────────────────────────────────────

--- a/tools/cli/cmd_project.cpp
+++ b/tools/cli/cmd_project.cpp
@@ -112,6 +112,22 @@ BumpOptions parse_bump_options(const std::vector<std::string>& args,
     return opts;
 }
 
+const char* stderr_to_null() {
+#if defined(_WIN32)
+    return " 2>NUL";
+#else
+    return " 2>/dev/null";
+#endif
+}
+
+const char* output_to_null() {
+#if defined(_WIN32)
+    return " >NUL 2>&1";
+#else
+    return " >/dev/null 2>&1";
+#endif
+}
+
 // ── Help text ───────────────────────────────────────────────────────────────
 
 void print_project_help() {
@@ -228,7 +244,7 @@ bool pin_files_are_dirty(const fs::path& project_path, bool standalone) {
     std::string cmd = "git -C " + shell_quote(project_path) +
                       " status --porcelain -- CMakeLists.txt";
     if (standalone) cmd += " pulp.toml";
-    cmd += " 2>/dev/null";
+    cmd += stderr_to_null();
     auto out = trim(exec_output(cmd));
     return !out.empty();
 }
@@ -293,12 +309,12 @@ std::optional<std::string> managed_sdk_path_replacement(const fs::path& raw_path
 std::optional<std::string> main_pinned_version_at_origin(const fs::path& project_path,
                                                          bool standalone) {
     std::string fetch = "git -C " + shell_quote(project_path) +
-                        " fetch --quiet origin main >/dev/null 2>&1";
+                        " fetch --quiet origin main" + output_to_null();
     if (run(fetch) != 0) return std::nullopt;
 
     if (standalone) {
         std::string toml_cmd = "git -C " + shell_quote(project_path) +
-                               " show origin/main:pulp.toml 2>/dev/null";
+                               " show origin/main:pulp.toml" + stderr_to_null();
         auto toml = exec_output(toml_cmd);
         if (!toml.empty()) {
             auto site = pb::find_toml_string_value(toml, "sdk_version",
@@ -309,7 +325,7 @@ std::optional<std::string> main_pinned_version_at_origin(const fs::path& project
     }
 
     std::string cmake_cmd = "git -C " + shell_quote(project_path) +
-                            " show origin/main:CMakeLists.txt 2>/dev/null";
+                            " show origin/main:CMakeLists.txt" + stderr_to_null();
     auto cmake = exec_output(cmake_cmd);
     if (cmake.empty()) return std::nullopt;
     auto site = standalone ? pb::find_find_package_pulp_version(cmake)
@@ -605,16 +621,6 @@ pb::UndoEntry bump_one(const fs::path& project_path,
         // `build/` stays untouched. The CLI doesn't try to honor a
         // user-specified build dir here — that's a follow-up.
         auto verify_build = project_path / "build-bump-verify";
-        // Silence redirection — POSIX uses `/dev/null`, Windows cmd.exe
-        // uses `NUL`. Without branching on the host, a bare `>/dev/null`
-        // makes cmd.exe create a literal file named `dev\null` (or fail
-        // to parse) and the advertised `--verify-builds` flag rolls the
-        // pin back even on healthy projects. See codex-sweep(#599).
-#if defined(_WIN32)
-        const char* silence = " >NUL 2>&1";
-#else
-        const char* silence = " >/dev/null 2>&1";
-#endif
         std::string cfg = "cmake -S " + shell_quote(project_path) +
                           " -B " + shell_quote(verify_build) +
                           " -DCMAKE_BUILD_TYPE=Debug";
@@ -630,10 +636,10 @@ pb::UndoEntry bump_one(const fs::path& project_path,
             }
             cfg += " -DCMAKE_PREFIX_PATH=" + shell_quote(sdk.resolved_sdk_dir);
         }
-        cfg += silence;
+        cfg += output_to_null();
         int rc = run(cfg);
         if (rc == 0) {
-            std::string bld = "cmake --build " + shell_quote(verify_build) + silence;
+            std::string bld = "cmake --build " + shell_quote(verify_build) + output_to_null();
             rc = run(bld);
         }
         if (rc != 0) {

--- a/tools/cli/cmd_upgrade.cpp
+++ b/tools/cli/cmd_upgrade.cpp
@@ -124,6 +124,10 @@ int cmd_upgrade(const std::vector<std::string>& args) {
         if (cache && !cache->latest_version.empty()) {
             latest = cache->latest_version;
             url = cache->release_notes_url;
+        } else if (pulp::runtime::get_env("PULP_UPDATE_CHECK_DISABLED")) {
+            std::cout << "Installed:  v" << installed << "\n";
+            std::cout << "Latest:     update check disabled; not queried\n";
+            return 0;
         } else {
             std::cout << "Cache empty; querying GitHub Releases...\n";
             uc::GitHubReleasesFetcher fetcher;


### PR DESCRIPTION
## Summary
- Adds WidgetBridge coverage for extended JS-created controls and visualization widgets.
- Exercises icon/image setup, checkbox/toggle callbacks, meter styling, XY clamping, waveform/spectrum/progress state, and listbox selection/activation.

Refs #493.
Refs #641.

## Validation
- cmake --build build --target pulp-test-widget-bridge -j4
- ./build/test/pulp-test-widget-bridge
- ctest --test-dir build -R "WidgetBridge|widget-bridge|widget_bridge" --output-on-failure
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- git diff --check