### PR TITLE
docs: refresh coverage compliance handoff

### DIFF
--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -67,35 +67,32 @@ Finish line:
 
 Latest complete Codecov `main` report observed while updating this doc:
 
-- commit: `a80929c42ff61b88cd366383baad2ee817558b57`
-- workflow: Coverage run `24926536334`, completed successfully
-- note: this is the latest complete `main` Codecov report observed before
-  the `#771`, `#777`, `#782`, and `#786` merges; refresh after the next
-  complete `main` coverage run reaches a terminal state.
-- overall tracked coverage: `43.27%` over `70,197` lines in `556` files
-- covered lines: `30,376`
+- commit: `26dd396da53e5ceab340eac5681f1b10d75ed56b`
+- workflow: Coverage run `24930675870`, completed successfully
+- overall tracked coverage: `44.35%` over `70,205` lines in `556` files
+- covered lines: `31,140`
 - current component coverage from the Codecov API:
-  - `audio`: `25.57%`
-  - `canvas`: `66.77%`
-  - `dsl`: `63.38%`
-  - `events`: `30.24%`
-  - `format`: `47.92%`
-  - `host`: `37.43%`
-  - `midi`: `50.14%`
-  - `osc`: `62.22%`
-  - `platform`: `52.06%`
-  - `render`: `56.68%`
-  - `runtime`: `51.69%`
-  - `signal`: `66.03%`
-  - `state`: `65.70%`
-  - `view`: `43.71%`
+  - `audio`: `24.8%`
+  - `canvas`: `67.83%`
+  - `dsl`: `77.04%`
+  - `events`: `29.47%`
+  - `format`: `52.61%`
+  - `host`: `43.23%`
+  - `midi`: `50.96%`
+  - `osc`: `72.52%`
+  - `platform`: `46.92%`
+  - `render`: `61.35%`
+  - `runtime`: `48.56%`
+  - `signal`: `67.25%`
+  - `state`: `67.26%`
+  - `view`: `45.04%`
   - `android`: `13.83%`
-  - `apple`: `25.36%`
-  - `linux`: `7.07%`
-  - `windows`: `10.67%`
-  - `cli`: `32.10%`
-  - `ship`: `34.44%`
-  - `tools`: `39.46%`
+  - `apple`: `25.72%`
+  - `linux`: `0.0%`
+  - `windows`: `16.83%`
+  - `cli`: `32.96%`
+  - `ship`: `36.48%`
+  - `tools`: `39.89%`
 
 Merged after the Phase 1 closeout / `#723` baseline:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 14:29 EDT
+Last reviewed: 2026-04-26 14:32 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -67,34 +67,34 @@ Finish line:
 
 Latest complete Codecov `main` report observed while updating this doc:
 
-- commit: `c4e6ad0930a7871046225b84fcfb130263ff98aa`
-- workflow: Coverage run `24946798292`, completed successfully
-- overall tracked coverage: `44.77%` over `70,284` lines in `556` files
-- covered lines: `31,470`
-- missed lines: `37,442`
-- partial lines: `1,372`
+- commit: `f712702afff325b35785eb56b88f1b85df0226a8`
+- workflow: Coverage run `24963571323`, completed successfully
+- overall tracked coverage: `45.58%` over `70,381` lines in `556` files
+- covered lines: `32,086`
+- missed lines: `37,163`
+- partial lines: `1,132`
 - current component coverage from the Codecov API:
-  - `audio`: `26.86%`
-  - `canvas`: `65.12%`
-  - `dsl`: `78.68%`
-  - `events`: `50.64%`
-  - `format`: `51.64%`
-  - `host`: `46.6%`
-  - `midi`: `49.12%`
-  - `osc`: `68.88%`
-  - `platform`: `39.25%`
-  - `render`: `61.03%`
-  - `runtime`: `52.21%`
-  - `signal`: `66.89%`
-  - `state`: `65.21%`
-  - `view`: `44.38%`
+  - `audio`: `35.3%`
+  - `canvas`: `64.59%`
+  - `dsl`: `63.38%`
+  - `events`: `49.49%`
+  - `format`: `51.43%`
+  - `host`: `43.48%`
+  - `midi`: `47.81%`
+  - `osc`: `61.61%`
+  - `platform`: `39.05%`
+  - `render`: `57.66%`
+  - `runtime`: `49.7%`
+  - `signal`: `65.95%`
+  - `state`: `61.26%`
+  - `view`: `43.12%`
   - `android`: `13.83%`
   - `apple`: `25.36%`
-  - `linux`: `7.96%`
-  - `windows`: `0.63%`
-  - `cli`: `33.15%`
-  - `ship`: `53.77%`
-  - `tools`: `39.98%`
+  - `linux`: `3.31%`
+  - `windows`: `0.0%`
+  - `cli`: `38.28%`
+  - `ship`: `53.66%`
+  - `tools`: `43.99%`
 
 Post-`#794` file-level proof point: `core/audio/src/aiff_reader.cpp`
 is now `72.01%` covered with `61` misses, up from `64.22%` with `78`

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 16:39 EDT
+Last reviewed: 2026-04-26 16:52 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -166,6 +166,11 @@ Open Phase 3 PRs:
   unreachable.
 - `#820` signal spectrogram edge coverage for `#645`, branch
   `feature/signal-spectrogram-coverage-645`, head `0fd8aa5a`; opened
+  from `main` at `c9620a65`. This tranche also uses the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
+- `#821` audio reader helper edge coverage for `#640`, branch
+  `feature/audio-reader-helpers-coverage-640`, head `be7d604f`; opened
   from `main` at `c9620a65`. This tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
@@ -386,6 +391,21 @@ Local Phase 3 draft worktrees:
   cases, full binary passed `390` assertions in `30` cases, focused
   CTest selection passed `12/12`, `git diff --check`, skill-sync
   report, and version-bump report.
+- `#640` audio reader helper worktree
+  `/Users/danielraffel/Code/pulp-audio-reader-helpers-coverage-640`,
+  branch `feature/audio-reader-helpers-coverage-640`, commit
+  `be7d604f`; open as PR `#821`.
+  Scope: test-only coverage for `BufferingReader` source-exhaustion
+  zero-fill and ring-wrap ordering, plus `AudioSubsectionReader` invalid
+  reader, clamped-read, and start-past-end empty-view paths. Local
+  validation: no-GPU/no-examples configure, `pulp-test-buffering-reader`
+  and `pulp-test-v3-gaps` build, direct
+  `[audio][buffering][issue-640]` passed `813` assertions in `2` cases,
+  direct `[audio][subsection][issue-640]` passed `32` assertions in `2`
+  cases, full buffering-reader binary passed `823` assertions in `8`
+  cases, full v3-gaps binary passed `87` assertions in `23` cases,
+  focused CTest passed `12/12`, `git diff --check`, skill-sync report,
+  and version-bump report.
 
 Open supporting PR:
 
@@ -393,8 +413,8 @@ Open supporting PR:
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#813` merged,
-  updated after `#816` merged, `#817` was repaired, and `#820` opened,
-  and remains docs-only.
+  updated after `#816` merged, `#817` was repaired, `#820` opened, and
+  `#821` opened, and remains docs-only.
 
 Local environment note:
 
@@ -425,10 +445,13 @@ Next recovery actions:
 5. Monitor `#820` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-spectrogram-coverage-645`,
    patch, validate locally, and push with lease.
-6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. Monitor `#821` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-audio-reader-helpers-coverage-640`,
+   patch, validate locally, and push with lease.
+7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-7. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 23:37 EDT
+Last reviewed: 2026-04-25 23:51 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -120,6 +120,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#788` events socket-IPC coverage -> `23d3ed1d`
 - `#793` package-registry CLI/tools coverage -> `e2af9c4d`
 - `#794` AIFF reader edge-path coverage -> `c4e6ad09`
+- `#796` tool-registry CLI/tools coverage -> `11c10a7e`
 
 Open Phase 3 PRs:
 
@@ -144,18 +145,6 @@ Open Phase 3 PRs:
   `codecov` and is using the direct GitHub/Namespace path instead of
   `shipyard pr` because `#794` exposed a local Shipyard mac configure
   stall after GitHub/Namespace was already clean.
-- `#796` `test(cli): cover tool registry local paths`, branch
-  `feature/cli-tool-registry-coverage-643`, commit `cdfbbcec`,
-  worktree `/Users/danielraffel/Code/pulp-cli-tool-registry-coverage-643`.
-  Scope: deterministic `tools/cli/tool_registry.cpp` coverage for
-  registry parsing, managed binary lookup, Python wrapper lookup,
-  uninstall, local install early exits, and `pulp tool`
-  list/path/doctor/uninstall/run/error dispatch branches against a
-  staged local registry. Local validation: lightweight configure
-  completed; `pulp-test-cli-tool-registry` built and passed with `78`
-  assertions in `5` test cases; focused CTest passed `5/5`;
-  `git diff --check` clean; version bump report says no bump needed.
-  The PR is using the same direct GitHub/Namespace path as `#795`.
 - `#797` `test(audio): cover streaming WAV writer edges`, branch
   `feature/audio-streaming-writer-coverage-640`, commit `29a3f26d`,
   worktree
@@ -171,6 +160,22 @@ Open Phase 3 PRs:
   `StreamingWriter|audio.*file|FormatRegistry` passed `6/6`;
   `git diff --check` clean; version bump report says no bump needed.
   The PR is labeled `codecov` and is using the same direct
+  GitHub/Namespace path as `#795`. Codecov's complete commit report shows
+  `core/audio/src/streaming_writer.cpp` represented at `60.67%` coverage;
+  the early Codecov PR comment reporting `0%` patch coverage appears stale
+  relative to the green `codecov/patch` check and line-level API data.
+- `#798` `test(audio): cover format registry dispatch paths`, branch
+  `feature/audio-format-registry-coverage-640`, commit `43739ac1`,
+  worktree
+  `/Users/danielraffel/Code/pulp-audio-system-volume-coverage-640`.
+  Scope: deterministic `FormatRegistry` unsupported read/read_info
+  dispatch, custom reader/writer registration, normalized extension lookup,
+  read_info/read/write dispatch through registered handlers, and supported
+  extension collection for `.aifc`. Local validation:
+  `pulp-test-audio-file` passed with `258` assertions in `16` test cases;
+  focused CTest `FormatRegistry|audio.*file` passed `3/3`;
+  `git diff --check` clean; version bump report says no bump needed.
+  The PR is labeled `codecov` and is using the same direct
   GitHub/Namespace path as `#795`.
 
 Local Phase 3 draft worktrees:
@@ -181,7 +186,7 @@ Local Phase 3 draft worktrees:
   `c4e6ad09`. The remote branch was deleted after merge.
 - `#642` events volume/service-discovery worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`, branch
-  `feature/events-volume-coverage-642`, commit `a193f617`; open as PR
+  `feature/events-volume-coverage-642`, commit `c33133e9`; open as PR
   `#795`.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
@@ -189,19 +194,23 @@ Local Phase 3 draft worktrees:
   PR `#793`.
 - `#643` tool-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-cli-tool-registry-coverage-643`, branch
-  `feature/cli-tool-registry-coverage-643`, commit `cdfbbcec`; open as
-  PR `#796`.
+  `feature/cli-tool-registry-coverage-643`, commit `cdfbbcec`; merged via
+  PR `#796` as `11c10a7e`. The remote branch was deleted after merge.
 - `#640` streaming-writer audio/platform worktree
   `/Users/danielraffel/Code/pulp-audio-streaming-writer-coverage-640`,
   branch `feature/audio-streaming-writer-coverage-640`, commit
   `29a3f26d`; open as PR `#797`.
+- `#640` format-registry audio/platform worktree
+  `/Users/danielraffel/Code/pulp-audio-system-volume-coverage-640`,
+  branch `feature/audio-format-registry-coverage-640`, commit
+  `43739ac1`; open as PR `#798`.
 
 Open supporting PR:
 
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#793` merged and
+  The branch has been rebased onto `origin/main` after `#796` merged and
   remains docs-only.
 
 Local environment note:
@@ -215,9 +224,9 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795`, `#796`, and `#797` and address any Codecov, build,
+2. Monitor `#795`, `#797`, and `#798` and address any Codecov, build,
    sanitizer, or Namespace feedback.
-3. If `#795`, `#796`, or `#797` is green but GitHub reports it behind `main`,
+3. If `#795`, `#797`, or `#798` is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 14:32 EDT
+Last reviewed: 2026-04-26 14:42 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -136,12 +136,13 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#808` MIDI file edge round-trip coverage -> `aae5d5d0`
 - `#809` signal FFT/convolver helper coverage -> `453bcec8`
 - `#810` platform Environment diff-edge coverage -> `f712702a`
+- `#811` CLI project-command dispatch coverage -> `810743d4`
 
 Open Phase 3 PRs:
 
-- `#811` CLI project-command dispatch coverage for `#643`, branch
-  `feature/cli-project-coverage-643`, head `46dca652`; opened after
-  rebasing onto `main` at `f712702a`. Cloud checks are the active gate.
+- None currently open after `#811` merged. The next ready Phase 3
+  candidate is the local-only `#645` signal dynamics helper draft at
+  `a43a305b`, recorded below.
 
 Local Phase 3 draft worktrees:
 
@@ -225,8 +226,8 @@ Local Phase 3 draft worktrees:
   `#809` as `453bcec8`. The remote branch was deleted after merge.
 - `#643` CLI project-command dispatch worktree
   `/Users/danielraffel/Code/pulp-cli-project-coverage-643`, branch
-  `feature/cli-project-coverage-643`, commit `46dca652`; open as PR
-  `#811`. Scope:
+  `feature/cli-project-coverage-643`, commit `46dca652`; merged via PR
+  `#811` as `810743d4`. The remote branch was deleted after merge. Scope:
   direct `cmd_project.cpp` coverage for top-level help/no-arg/unknown
   dispatch, bump option parsing, `--all` empty-registry handling,
   registry-backed `--all --dry-run` reporting without undo files, a
@@ -240,8 +241,8 @@ Local Phase 3 draft worktrees:
 - `#645` signal dynamics helper worktree
   `/Users/danielraffel/Code/pulp-signal-dynamics-coverage-645`, branch
   `feature/signal-dynamics-coverage-645`, commit `a43a305b`;
-  local-only draft, not opened as a PR yet while `#811` and `#774`
-  drain. Scope: test-only coverage for `DryWetMixer` mix
+  local-only draft, not opened as a PR yet while `#774` drains. Scope:
+  test-only coverage for `DryWetMixer` mix
   clamping/equal-power/latency/reset paths, `Compressor`
   hard-knee/soft-knee/buffer/reset paths, `Limiter` buffer/reset paths,
   `WindowFunction` hamming/flat-top/kaiser branches, and
@@ -259,9 +260,9 @@ Open supporting PR:
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#810` merged,
-  updated after `#811` opened and after the local `#645` signal dynamics
-  draft was prepared, and remains docs-only.
+  The branch has been rebased onto `origin/main` after `#811` merged,
+  updated after the local `#645` signal dynamics draft was prepared, and
+  remains docs-only.
 
 Local environment note:
 
@@ -274,11 +275,9 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#811` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-cli-project-coverage-643`, patch,
-   validate locally, and push with lease.
-3. After `#811` is merged or otherwise no longer blocking the active
-   implementation slot, rebase/push/open the local `#645`
+2. Let the `main` Coverage run for `810743d4` complete, then refresh the
+   Codecov baseline if it changes the execution order materially.
+3. Rebase/push/open the local `#645`
    `feature/signal-dynamics-coverage-645` draft from
    `/Users/danielraffel/Code/pulp-signal-dynamics-coverage-645`.
 4. If any open Phase 3 PR is green but GitHub reports it behind `main`,

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:16 EDT
+Last reviewed: 2026-04-26 19:25 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -152,6 +152,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#823` platform helper edge coverage -> `f69338eb`
 - `#824` signal math helper coverage and Mat3 fix -> `94e3ef2a`
 - `#825` signal DSP helper edge coverage -> `d0262a1b`
+- `#827` signal multi-channel meter edge coverage -> `d5efea57`
 
 Open Phase 3 PRs:
 
@@ -166,10 +167,6 @@ Open Phase 3 PRs:
   `windows` target remains unreachable.
 - `#826` OGG reader edge coverage for `#640`, branch
   `feature/audio-ogg-reader-coverage-640`, head `6b721c22`; opened from
-  `main` at `1a1b7f07`. This tranche also uses the GitHub/Namespace path
-  while the SSH `windows` target remains unreachable.
-- `#827` signal multi-channel meter edge coverage for `#645`, branch
-  `feature/signal-meter-coverage-645`, head `ed51248f`; opened from
   `main` at `1a1b7f07`. This tranche also uses the GitHub/Namespace path
   while the SSH `windows` target remains unreachable.
 - `#828` raw MIDI parser edge coverage and malformed-data hardening for
@@ -522,8 +519,8 @@ Local Phase 3 draft worktrees:
   `2/2`, `git diff --check`, skill-sync report, and version-bump report.
 - `#645` signal multi-channel meter worktree
   `/Users/danielraffel/Code/pulp-signal-meter-coverage-645`, branch
-  `feature/signal-meter-coverage-645`, commit `ed51248f`; open as PR
-  `#827`.
+  `feature/signal-meter-coverage-645`, commit `ed51248f`; merged via PR
+  `#827` as `d5efea57`. The remote branch was deleted after merge.
   Scope: dedicated `pulp-test-multi-channel-meter` target covering
   prepared-channel clamping, empty process blocks, correlation window
   replacement after reset, integrated LUFS running-average behavior,
@@ -601,7 +598,8 @@ Open supporting PR:
   merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
   repaired again for Android SDK discovery, `#827` opened, `#823`
   merged, `#824` merged, `#828` opened, `#829` opened, `#825` merged,
-  `#830` opened, and `#831` opened, and remains docs-only.
+  `#830` opened, `#831` opened, and `#827` merged, and remains
+  docs-only.
 
 Local environment note:
 
@@ -626,25 +624,22 @@ Next recovery actions:
 3. Monitor `#826` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-ogg-reader-coverage-640`,
    patch, validate locally, and push with lease.
-4. Monitor `#827` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-signal-meter-coverage-645`, patch,
-   validate locally, and push with lease.
-5. Monitor `#828` cloud checks; if a required lane fails, debug in
+4. Monitor `#828` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-raw-parser-coverage-645`, patch,
    validate locally, and push with lease.
-6. Monitor `#829` cloud checks; if a required lane fails, debug in
+5. Monitor `#829` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, patch,
    validate locally, and push with lease.
-7. Monitor `#830` cloud checks; if a required lane fails, debug in
+6. Monitor `#830` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, patch,
    validate locally, and push with lease.
-8. Monitor `#831` cloud checks; if a required lane fails, debug in
+7. Monitor `#831` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, patch,
    validate locally, and push with lease.
-9. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-10. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 01:53 EDT
+Last reviewed: 2026-04-26 02:02 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -187,6 +187,21 @@ Open Phase 3 PRs:
   because the GPU-off configure intentionally does not build `pulp-cli`;
   CI builds the normal CLI path. The PR is labeled `codecov` and is
   using the direct GitHub/Namespace path.
+- `#803` `test(signal): cover matrix helper edges`, branch
+  `feature/signal-matrix-coverage-645`, commit `e18f5f27`, worktree
+  `/Users/danielraffel/Code/pulp-signal-matrix-coverage-645`.
+  Scope: test-only signal matrix helper coverage for element-wise
+  arithmetic, non-triangular `Matrix3` determinant, `Matrix4` scale
+  transforms, and X/Y/Z axis rotations. Local validation: GPU-off
+  configure with `PULP_BUILD_EXAMPLES=OFF` and `PULP_ENABLE_GPU=OFF`,
+  `pulp-test-dsp-enhancements` target build, direct Catch2 tag
+  `[dsp][matrix]` passed with `31` assertions in `8` test cases,
+  focused CTest for the three new cases passed `3/3`, `git diff --check`
+  clean, skill sync clean, and version bump report says no bump needed.
+  The broad `ctest -R "Matrix|matrix"` regex intentionally was not used
+  as final evidence because it overmatches unrelated `*_NOT_BUILT`
+  placeholder tests in the focused no-GPU build. The PR is labeled
+  `codecov` and is using the direct GitHub/Namespace path.
 
 Local Phase 3 draft worktrees:
 
@@ -232,6 +247,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-cli-create-coverage-643`, branch
   `feature/cli-create-coverage-643`, commit `f5e4a05f`; open as PR
   `#802`.
+- `#645` signal matrix helper worktree
+  `/Users/danielraffel/Code/pulp-signal-matrix-coverage-645`, branch
+  `feature/signal-matrix-coverage-645`, commit `e18f5f27`; open as PR
+  `#803`.
 
 Open supporting PR:
 
@@ -252,11 +271,11 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795`, `#801`, and `#802` and address any Codecov, build,
-   sanitizer, or Namespace feedback.
-3. If `#795`, `#801`, or `#802` is green but GitHub reports it behind
-   `main`, rebase that branch onto `origin/main`, push with lease, and
-   let checks rerun.
+2. Monitor `#795`, `#801`, `#802`, and `#803` and address any Codecov,
+   build, sanitizer, or Namespace feedback.
+3. If `#795`, `#801`, `#802`, or `#803` is green but GitHub reports it
+   behind `main`, rebase that branch onto `origin/main`, push with lease,
+   and let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -196,6 +196,22 @@ Local Phase 3 draft not yet opened as a PR:
   whitespace. A direct multi-filter Catch2 invocation was intentionally not
   used as validation because Catch2 treats multiple quoted filters as an AND
   expression; CTest was used for the focused multi-test slice.
+- `#644` Android ship/package helper tranche, worktree
+  `/Users/danielraffel/Code/pulp-android-package-coverage-644`, branch
+  `feature/android-package-coverage-644`, local commit `3fe64e02`. This
+  draft adds a deterministic host-side fake Android SDK/toolchain harness for
+  `ship/platform/android/package_android.cpp` without requiring a real SDK,
+  device, keystore, Gradle install, bundletool, or network access. Scope:
+  SDK/build-tools/NDK discovery, fake `zipalign`, fake `apksigner` signing and
+  APK verification parsing, fake `jarsigner` AAB signing/verification, fake
+  Gradle APK/AAB artifact collection, missing-wrapper/missing-artifact errors,
+  and fake bundletool conversion with optional signing config. Local validation
+  is green: configure in the fresh worktree, `cmake --build build --target
+  pulp-test-android-package -j4`, direct `pulp-test-android-package` (`64`
+  assertions / `7` test cases), focused Android package CTest (`7/7`), adjacent
+  ship CTest slice for Android/appcast/codesign/NSIS (`21/21`), and whitespace.
+  Keep this local until the shared Windows-safe project-bump fix lands on
+  `main`, or explicitly carry the same shared support commits before opening.
 
 Open supporting PR:
 
@@ -224,17 +240,20 @@ Next recovery actions:
    CI-unblocker commits are on `main`; then rebase it, open a PR, and
    link it from `#642`. If opening before then, keep the local shared commits
    in place.
-5. If any Windows Namespace lane fails again, pull the fresh completed-run
+5. Keep the local `#644` Android package draft paused for the same reason;
+   after the shared Windows-safe project-bump fix lands, rebase the draft,
+   open a PR, and link it from `#644`.
+6. If any Windows Namespace lane fails again, pull the fresh completed-run
    log first and search for `pulp-test-cli-project-command`; the known
    failing tests were the dirty-gate and redundant-origin project-bump cases.
-6. If sandbox-e2e fails again, pull the fresh log first; the expected
+7. If sandbox-e2e fails again, pull the fresh log first; the expected
    failure fixed here was `pulp upgrade --check-only` ignoring
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
-7. If a PR is green but GitHub reports it behind `main`, rebase that
+8. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-8. After active PRs merge, refresh this section with the next complete
+9. After active PRs merge, refresh this section with the next complete
    Codecov `main` report.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+10. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 23:29 EDT
+Last reviewed: 2026-04-26 23:34 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -303,6 +303,11 @@ Open Phase 3 PRs:
   `feature/host-format-view-coverage-493-next3`, head `c42e0603`;
   covers `host_type_name()` enum mappings, invalid enum fallback, and
   resize/sidechain policy exceptions.
+- `#871` JSFX subset validation coverage for `#643`, branch
+  `feature/cli-tools-coverage-643-next5`, head `ad536fb5`; covers JSFX
+  doctor rejection for out-of-range sliders and duplicate sections. The
+  commit carries `Skill-Update: skip` because this is test-only coverage
+  for a skill-mapped path.
 
 Local-only queued work:
 
@@ -1080,7 +1085,8 @@ Open supporting PR:
   and `#857` opened from the latest worker batch, and `#832` merged as
   `3f92f066`, and `#842` merged as `51be8860`, and `#858` through
   `#864` opened from the parallel worker queue, and `#865` through
-  `#870` opened from the next completed local worker queue,
+  `#870` opened from the next completed local worker queue, and `#871`
+  opened for JSFX subset validation coverage,
   and remains docs-only.
 
 Local environment note:
@@ -1111,7 +1117,7 @@ Next recovery actions:
    fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
    patch, validate locally, and push with lease.
-5. Monitor `#845` through `#870`; if a required lane fails, debug in
+5. Monitor `#845` through `#871`; if a required lane fails, debug in
    the worktree named in the open-PR list above, patch, validate
    locally, and push with lease. Pay particular attention to `#848` and
    `#851` because they include patch-level production hardening.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 02:10 EDT
+Last reviewed: 2026-04-26 02:13 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -182,6 +182,19 @@ Open Phase 3 PRs:
   onto `origin/main` after `#795` merged, pushed with lease as
   `b1f5a125`, and the focused local validation above passed again. The PR
   is labeled `codecov` and is using the direct GitHub/Namespace path.
+- `#804` `test(signal): cover oversampling helper edges`, branch
+  `feature/signal-oversampling-coverage-645`, commit `bccaec0f`,
+  worktree `/Users/danielraffel/Code/pulp-signal-oversampling-coverage-645`.
+  Scope: test-only signal `Oversampler` coverage for x2/x4 callback
+  dispatch, configured anti-alias filter paths, and reset determinism.
+  Local validation: no-GPU configure,
+  `pulp-test-signal` target build, direct Catch2 tag
+  `[signal][oversampling]` passed with `16` assertions in `2` test cases,
+  focused CTest `Oversampler` passed `2/2`, `git diff --check` clean,
+  skill sync clean, and version bump report says no bump needed. The
+  local build still reports an existing unused-variable warning elsewhere
+  in `test/test_signal.cpp`; it is not introduced by this tranche. The PR
+  is labeled `codecov` and is using the direct GitHub/Namespace path.
 
 Local Phase 3 draft worktrees:
 
@@ -234,15 +247,7 @@ Local Phase 3 draft worktrees:
 - `#645` signal oversampling helper worktree
   `/Users/danielraffel/Code/pulp-signal-oversampling-coverage-645`,
   branch `feature/signal-oversampling-coverage-645`, commit `bccaec0f`;
-  local draft, not pushed/opened yet. Scope: test-only oversampling
-  coverage for x2/x4 callback dispatch, configured anti-alias filter
-  paths, and reset determinism. Local validation: no-GPU configure,
-  `pulp-test-signal` target build, direct Catch2 tag
-  `[signal][oversampling]` passed with `16` assertions in `2` test cases,
-  focused CTest `Oversampler` passed `2/2`, `git diff --check` clean,
-  skill sync clean, and version bump report says no bump needed. The
-  local build still reports an existing unused-variable warning elsewhere
-  in `test/test_signal.cpp`; it is not introduced by this tranche.
+  open as PR `#804`.
 
 Open supporting PR:
 
@@ -263,14 +268,13 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#801`, `#802`, and `#803` and address any Codecov, build,
-   sanitizer, or Namespace feedback.
-3. If `#801`, `#802`, or `#803` is green but GitHub reports it behind
-   `main`, rebase that branch onto `origin/main`, push with lease, and
-   let checks rerun.
-4. Open the local `#645` oversampling draft as the next small signal
-   tranche once the active PR queue has capacity, or keep it local if the
-   queue is still saturated.
+2. Monitor `#801`, `#802`, `#803`, and `#804` and address any Codecov,
+   build, sanitizer, or Namespace feedback.
+3. If `#801`, `#802`, `#803`, or `#804` is green but GitHub reports it
+   behind `main`, rebase that branch onto `origin/main`, push with lease,
+   and let checks rerun.
+4. Continue Phase 3 from the tranche issues below, prioritizing
+   represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:33 EDT
+Last reviewed: 2026-04-26 19:34 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -180,9 +180,11 @@ Open Phase 3 PRs:
   at `d0262a1b`. This tranche also uses the GitHub/Namespace path while
   the SSH `windows` target remains unreachable.
 - `#831` signal utility helper edge coverage for `#645`, branch
-  `feature/signal-utility-coverage-645`, head `d021a35c`; opened from
-  `main` at `d0262a1b`. This tranche also uses the GitHub/Namespace path
-  while the SSH `windows` target remains unreachable.
+  `feature/signal-utility-coverage-645`, head `1b8169aa`; opened from
+  `main` at `d0262a1b` and updated after the first Windows Namespace run
+  exposed an exact float-array equality assertion in the Phaser reset
+  test. This tranche also uses the GitHub/Namespace path while the SSH
+  `windows` target remains unreachable.
 - `#832` platform child-process edge coverage for `#640`, branch
   `feature/platform-child-process-coverage-640`, head `a361c8b9`;
   opened from `main` at `d5efea57` and updated after the first Windows
@@ -575,20 +577,22 @@ Local Phase 3 draft worktrees:
   report.
 - `#645` signal utility helper worktree
   `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, branch
-  `feature/signal-utility-coverage-645`, commit `d021a35c`; open as PR
-  `#831`.
+  `feature/signal-utility-coverage-645`, commits `d021a35c` and
+  `1b8169aa`; open as PR `#831`.
   Scope: test-only coverage for `DelayLine` empty/wraparound/reset
   paths, `SmoothedValue` one-sample clamp and partial skip paths, `Svf`
   bandpass/notch/buffer/reset paths, `Panner` clamp plus in-place stereo
   processing, `Phaser` stage/feedback clamp safety plus buffer/reset/dry
-  paths, and `Bias` getter plus separate input/output buffer paths. Local
+  paths, and `Bias` getter plus separate input/output buffer paths. The
+  follow-up commit compares Phaser reset output with tolerance instead
+  of exact float-array equality for MSVC/math-library variance. Local
   validation: no-GPU/no-examples configure, `pulp-test-signal` and
   `pulp-test-v3-gaps` builds, direct signal `[issue-645]` run passed
-  `163` assertions in `21` cases, direct bias issue run passed `5`
-  assertions in `1` case, full signal binary passed `930` assertions in
-  `74` cases, full v3 gaps binary passed `131` assertions in `27` cases,
-  focused CTest passed `6/6`, `git diff --check`, skill-sync report, and
-  version-bump report.
+  `167` assertions in `21` cases, direct v3-gaps `[issue-645]` run
+  passed `44` assertions in `4` cases, full signal binary passed `934`
+  assertions in `74` cases, full v3 gaps binary passed `131` assertions
+  in `27` cases, focused CTest passed `6/6`, `git diff --check`, skill-sync
+  report, and version-bump report.
 - `#640` platform child-process worktree
   `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
   branch `feature/platform-child-process-coverage-640`, commits
@@ -619,7 +623,8 @@ Open supporting PR:
   merged, `#824` merged, `#828` opened, `#829` opened, `#825` merged,
   `#830` opened, `#831` opened, `#827` merged, `#832` opened, `#826`
   merged, and `#832` was repaired for Windows cmd portability, and
-  remains docs-only.
+  `#831` was repaired for Windows float tolerance, and remains
+  docs-only.
 
 Local environment note:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 22:50 EDT
+Last reviewed: 2026-04-25 23:05 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -94,6 +94,11 @@ Latest complete Codecov `main` report observed while updating this doc:
   - `ship`: `54.34%`
   - `tools`: `40.22%`
 
+`#794` has merged after this baseline. The post-merge `main` Coverage
+workflow for `c4e6ad0930a7871046225b84fcfb130263ff98aa` is queued as
+run `24946798292`; do not treat the `c4e6ad09` totals as rebaselined
+until that run completes and Codecov reflects the new uploads.
+
 Merged after the Phase 1 closeout / `#723` baseline:
 
 - `#649` CLI/tools tranche 1 -> `8449b6e8`
@@ -113,36 +118,38 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#789` Android ship/package helper coverage -> `e61dce8d`
 - `#788` events socket-IPC coverage -> `23d3ed1d`
 - `#793` package-registry CLI/tools coverage -> `e2af9c4d`
+- `#794` AIFF reader edge-path coverage -> `c4e6ad09`
 
 Open Phase 3 PRs:
 
-- `#794` `test(audio): cover AIFF reader edge paths`, branch
-  `feature/audio-aiff-coverage-640`, commit `f3414ae9`, worktree
-  `/Users/danielraffel/Code/pulp-audio-aiff-coverage-640`.
-  Scope: deterministic `test/test_audio_file.cpp` coverage for AIFC
-  metadata, odd unknown-chunk padding, 8/24/32-bit AIFF PCM decode,
-  malformed SSND skip, and truncated payload rejection. Local validation:
-  `pulp-test-audio-file` passed with `231` assertions in `15` test cases;
-  focused CTest `AIFF|audio.*file|FormatRegistry` passed `8/8`;
-  `git diff --check` clean; version bump report says no bump needed.
-  `shipyard pr` opened the PR and validation is in progress.
+- `#795` `test(events): cover volume detector lifecycle edges`, branch
+  `feature/events-volume-coverage-642`, commit `a193f617`, worktree
+  `/Users/danielraffel/Code/pulp-events-volume-coverage-642`.
+  Scope: deterministic `test/test_network_service_discovery.cpp`
+  coverage for `NetworkServiceDiscovery` backend removal, cached-service
+  eviction, no-backend registration behavior,
+  `MountedVolumeListChangeDetector` mounted-volume snapshot plus
+  start/restart/stop lifecycle paths, and
+  `LockingAsyncUpdater::trigger_and_wait()`. Local validation:
+  `pulp-test-network-service-discovery` passed with `43` assertions in
+  `10` test cases; focused CTest
+  `NSD|MountedVolume|LockingAsyncUpdater|service-discovery|volume`
+  passed `10/10`; `git diff --check` clean; version bump report says no
+  bump needed. The PR is labeled `codecov` and is using the direct
+  GitHub/Namespace path instead of `shipyard pr` because `#794` exposed a
+  local Shipyard mac configure stall after GitHub/Namespace was already
+  clean.
 
 Local Phase 3 draft worktrees:
 
 - `#640` AIFF reader edge-path worktree
   `/Users/danielraffel/Code/pulp-audio-aiff-coverage-640`, branch
-  `feature/audio-aiff-coverage-640`, commit `f3414ae9`; open as PR `#794`.
+  `feature/audio-aiff-coverage-640`; merged via PR `#794` as
+  `c4e6ad09`. The remote branch was deleted after merge.
 - `#642` events volume/service-discovery worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`, branch
-  `feature/events-volume-coverage-642`, commit `6e56d62b`; local draft is
-  ready but not opened yet to avoid overlapping local Shipyard runs while
-  `#794` is still validating. Scope: deterministic
-  `test/test_network_service_discovery.cpp` coverage for
-  `NetworkServiceDiscovery` backend removal, mounted-volume snapshot and
-  start/stop lifecycle, and `LockingAsyncUpdater::trigger_and_wait()`.
-  Validation: `pulp-test-network-service-discovery` passed with `43`
-  assertions in `10` test cases; focused CTest passed `10/10`;
-  `git diff --check` clean; version bump report says no bump needed.
+  `feature/events-volume-coverage-642`, commit `a193f617`; open as PR
+  `#795`.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
   `feature/package-registry-coverage-643`, commit `75a529ef`; merged via
@@ -167,10 +174,10 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#794` and address any Codecov, build, or Shipyard feedback.
-3. Once `#794` is resolved or no longer consuming the local Shipyard mac
-   lane, open the ready `#642` draft from
-   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`.
+2. Monitor `#795` and address any Codecov, build, sanitizer, or
+   Namespace feedback.
+3. When the `c4e6ad09` `main` Coverage run `24946798292` completes,
+   refresh the current live Codecov baseline from the API.
 4. If a new PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
 5. Continue Phase 3 from the tranche issues below, prioritizing

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 03:13 EDT
+Last reviewed: 2026-04-26 03:15 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -127,6 +127,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#800` Python gate-helper tooling coverage -> `55b6dfab`
 - `#795` events volume/service-discovery coverage -> `f1a5aa84`
 - `#802` CLI-create shellout coverage -> `2de79ff3`
+- `#803` signal matrix helper coverage -> `57285797`
 
 Open Phase 3 PRs:
 
@@ -157,23 +158,6 @@ Open Phase 3 PRs:
   the changed atlas lines covered, `git diff --check` clean, skill sync
   clean, and version report still clean. The PR is labeled `codecov` and
   is using the direct GitHub/Namespace path.
-- `#803` `test(signal): cover matrix helper edges`, branch
-  `feature/signal-matrix-coverage-645`, commit `b1f5a125`, worktree
-  `/Users/danielraffel/Code/pulp-signal-matrix-coverage-645`.
-  Scope: test-only signal matrix helper coverage for element-wise
-  arithmetic, non-triangular `Matrix3` determinant, `Matrix4` scale
-  transforms, and X/Y/Z axis rotations. Local validation: GPU-off
-  configure with `PULP_BUILD_EXAMPLES=OFF` and `PULP_ENABLE_GPU=OFF`,
-  `pulp-test-dsp-enhancements` target build, direct Catch2 tag
-  `[dsp][matrix]` passed with `31` assertions in `8` test cases,
-  focused CTest for the three new cases passed `3/3`, `git diff --check`
-  clean, skill sync clean, and version bump report says no bump needed.
-  The broad `ctest -R "Matrix|matrix"` regex intentionally was not used
-  as final evidence because it overmatches unrelated `*_NOT_BUILT`
-  placeholder tests in the focused no-GPU build. The branch was rebased
-  onto `origin/main` after `#795` merged, pushed with lease as
-  `b1f5a125`, and the focused local validation above passed again. The PR
-  is labeled `codecov` and is using the direct GitHub/Namespace path.
 - `#804` `test(signal): cover oversampling helper edges`, branch
   `feature/signal-oversampling-coverage-645`, commit `bccaec0f`,
   worktree `/Users/danielraffel/Code/pulp-signal-oversampling-coverage-645`.
@@ -302,8 +286,8 @@ Local Phase 3 draft worktrees:
   `325485bc`; open as PR `#801`.
 - `#645` signal matrix helper worktree
   `/Users/danielraffel/Code/pulp-signal-matrix-coverage-645`, branch
-  `feature/signal-matrix-coverage-645`, commit `b1f5a125`; open as PR
-  `#803`.
+  `feature/signal-matrix-coverage-645`, commit `b1f5a125`; merged via PR
+  `#803` as `57285797`. The remote branch was deleted after merge.
 - `#645` signal oversampling helper worktree
   `/Users/danielraffel/Code/pulp-signal-oversampling-coverage-645`,
   branch `feature/signal-oversampling-coverage-645`, commit `bccaec0f`;
@@ -347,7 +331,7 @@ Open supporting PR:
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#802` merged and
+  The branch has been rebased onto `origin/main` after `#803` merged and
   remains docs-only.
 
 Local environment note:
@@ -361,7 +345,7 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#801`, `#803`, `#804`, `#805`, `#806`, `#807`, `#808`, and `#809`
+2. Monitor `#801`, `#804`, `#805`, `#806`, `#807`, `#808`, and `#809`
    and address any Codecov, build, sanitizer, or Namespace feedback.
 3. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:06 EDT
+Last reviewed: 2026-04-26 19:16 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -185,6 +185,10 @@ Open Phase 3 PRs:
   `feature/midi-rpn-coverage-645`, head `d1edf1e1`; opened from `main`
   at `d0262a1b`. This tranche also uses the GitHub/Namespace path while
   the SSH `windows` target remains unreachable.
+- `#831` signal utility helper edge coverage for `#645`, branch
+  `feature/signal-utility-coverage-645`, head `d021a35c`; opened from
+  `main` at `d0262a1b`. This tranche also uses the GitHub/Namespace path
+  while the SSH `windows` target remains unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -568,6 +572,22 @@ Local Phase 3 draft worktrees:
   binary passed `57` assertions in `23` cases, focused CTest passed
   `3/3`, `git diff --check`, skill-sync report, and version-bump
   report.
+- `#645` signal utility helper worktree
+  `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, branch
+  `feature/signal-utility-coverage-645`, commit `d021a35c`; open as PR
+  `#831`.
+  Scope: test-only coverage for `DelayLine` empty/wraparound/reset
+  paths, `SmoothedValue` one-sample clamp and partial skip paths, `Svf`
+  bandpass/notch/buffer/reset paths, `Panner` clamp plus in-place stereo
+  processing, `Phaser` stage/feedback clamp safety plus buffer/reset/dry
+  paths, and `Bias` getter plus separate input/output buffer paths. Local
+  validation: no-GPU/no-examples configure, `pulp-test-signal` and
+  `pulp-test-v3-gaps` builds, direct signal `[issue-645]` run passed
+  `163` assertions in `21` cases, direct bias issue run passed `5`
+  assertions in `1` case, full signal binary passed `930` assertions in
+  `74` cases, full v3 gaps binary passed `131` assertions in `27` cases,
+  focused CTest passed `6/6`, `git diff --check`, skill-sync report, and
+  version-bump report.
 
 Open supporting PR:
 
@@ -581,7 +601,7 @@ Open supporting PR:
   merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
   repaired again for Android SDK discovery, `#827` opened, `#823`
   merged, `#824` merged, `#828` opened, `#829` opened, `#825` merged,
-  and `#830` opened, and remains docs-only.
+  `#830` opened, and `#831` opened, and remains docs-only.
 
 Local environment note:
 
@@ -618,10 +638,13 @@ Next recovery actions:
 7. Monitor `#830` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, patch,
    validate locally, and push with lease.
-8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+8. Monitor `#831` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, patch,
+   validate locally, and push with lease.
+9. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+10. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 17:08 EDT
+Last reviewed: 2026-04-26 17:28 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -145,16 +145,10 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#815` MPE tracker edge-path coverage -> `019130bd`
 - `#816` MIDI running-status parser edge coverage -> `c9620a65`
 - `#818` MPE synth voice / allocator coverage -> `3d4560d1`
+- `#817` UMP conversion edge coverage -> `a38216fd`
 
 Open Phase 3 PRs:
 
-- `#817` UMP conversion edge coverage for `#645`, branch
-  `feature/midi-ump-conversion-coverage-645`, head `31a53432`; opened
-  from `main` at `957a0735`, then updated with scan-cache temp-file
-  isolation after macOS ASan exposed a parallel CTest collision. `shipyard
-  pr` was attempted first but stopped before PR creation because the SSH
-  `windows` backend timed out, so this tranche is using the
-  GitHub/Namespace path instead of skipping that lane.
 - `#819` MIDI keyboard/sequence edge coverage for `#645`, branch
   `feature/midi-keyboard-sequence-coverage-645`, head `60676709`;
   opened from `main` at `019130bd`. This tranche also uses the
@@ -171,10 +165,16 @@ Open Phase 3 PRs:
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
 - `#822` audio file helper edge coverage for `#640`, branch
-  `feature/audio-file-helper-coverage-640`, head `f4e59d2b`; opened
-  from `main` at `c9620a65`. This tranche also uses the
+  `feature/audio-file-helper-coverage-640`, head `8aa7a78d`; opened
+  from `main` at `c9620a65` and updated after the first macOS UBSan run
+  exposed a real `float_to_int32` endpoint conversion overflow. This
+  tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
+- `#823` platform helper edge coverage for `#640`, branch
+  `feature/platform-helper-coverage-640`, head `6ec4ff2e`; opened from
+  `main` at `3d4560d1`. This tranche also uses the GitHub/Namespace path
+  while the SSH `windows` target remains unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -329,7 +329,8 @@ Local Phase 3 draft worktrees:
 - `#645` MIDI UMP conversion worktree
   `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
   branch `feature/midi-ump-conversion-coverage-645`, commit `31a53432`;
-  open as PR `#817`.
+  merged via PR `#817` as `a38216fd`. The remote branch was deleted
+  after merge.
   Scope: test-only coverage for velocity-zero note-on aliasing,
   program-change fallback packets, group masking, sample-offset
   preservation, MIDI 2 edge-value down-conversion, skipped packets
@@ -410,21 +411,42 @@ Local Phase 3 draft worktrees:
   and version-bump report.
 - `#640` audio file helper worktree
   `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
-  branch `feature/audio-file-helper-coverage-640`, commit `f4e59d2b`;
+  branch `feature/audio-file-helper-coverage-640`, commit `8aa7a78d`;
   open as PR `#822`.
-  Scope: test-only coverage for packed int24 conversion, int32 full-scale
+  Scope: coverage for packed int24 conversion, int32 full-scale
   conversion, float-to-int32 clamping, zero-count conversion no-ops, CHOC
   WAV helper output via RIFF chunk parsing, malformed WAV rejection,
   invalid OGG registry dispatch, `Buffer` resize/view ownership, and
-  `AudioProcessLoadMeasurer` smoothing/zero-available-time guards. Local
-  validation: no-GPU/no-examples configure, `pulp-test-audio-file`,
-  `pulp-test-audio`, and `pulp-test-load-measurer` build, direct
-  `[issue-640]` audio-file run passed `217` assertions in `11` cases,
-  full audio-file binary passed `450` assertions in `26` cases, full
-  audio binary passed `586` assertions in `8` cases, full load-measurer
-  binary passed `20` assertions in `6` cases, focused CTest passed
-  `11/11`, `git diff --check`, skill-sync report, and version-bump
+  `AudioProcessLoadMeasurer` smoothing/zero-available-time guards.
+  Follow-up `8aa7a78d` fixes a production `float_to_int32` UBSan issue
+  by handling `+/-1` endpoints explicitly and using double precision for
+  the midrange cast. Local validation: no-GPU/no-examples configure,
+  `pulp-test-audio-file`, `pulp-test-audio`, and
+  `pulp-test-load-measurer` build, direct `[issue-640]` audio-file run
+  passed `217` assertions in `11` cases, full audio-file binary passed
+  `450` assertions in `26` cases, full audio binary passed `586`
+  assertions in `8` cases, full load-measurer binary passed `20`
+  assertions in `6` cases, focused CTest passed `11/11`, local UBSan
+  focused CTest for `sample conversion handles packed 24-bit and 32-bit
+  edges` passed, `git diff --check`, skill-sync report, and version-bump
   report.
+- `#640` platform helper worktree
+  `/Users/danielraffel/Code/pulp-platform-helper-coverage-640`, branch
+  `feature/platform-helper-coverage-640`, commit `6ec4ff2e`; open as PR
+  `#823`.
+  Scope: test-only coverage for file-dialog no-handler backend failure
+  paths, popup-menu item metadata and non-Apple stub behavior, audio
+  excerpt value/default helpers, and non-Apple `AudioWorkgroup` fallback
+  idempotency. Local validation: no-GPU/no-examples configure,
+  `pulp-test-file-dialog`, `pulp-test-audio-excerpt`, and
+  `pulp-test-workgroup` build, direct `[issue-640]` file-dialog run
+  passed `13` assertions in `1` case, direct
+  `[audio][excerpt][issue-640]` audio-excerpt run passed `14`
+  assertions in `1` case, full workgroup binary passed `4` assertions in
+  `5` cases, full file-dialog binary passed `15` assertions in `3`
+  cases, full audio-excerpt binary passed `33` assertions in `5` cases,
+  focused CTest passed `9/9`, `git diff --check`, skill-sync report, and
+  version-bump report.
 
 Open supporting PR:
 
@@ -433,7 +455,8 @@ Open supporting PR:
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#813` merged,
   updated after `#816` merged, `#817` was repaired, `#820` opened,
-  `#821` opened, `#822` opened, and `#818` merged, and remains docs-only.
+  `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
+  merged, and `#822` was repaired, and remains docs-only.
 
 Local environment note:
 
@@ -452,21 +475,21 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#817` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
-   patch, validate locally, and push with lease.
-3. Monitor `#819` cloud checks; if a required lane fails, debug in
+2. Monitor `#819` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-keyboard-sequence-coverage-645`,
    patch, validate locally, and push with lease.
-4. Monitor `#820` cloud checks; if a required lane fails, debug in
+3. Monitor `#820` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-spectrogram-coverage-645`,
    patch, validate locally, and push with lease.
-5. Monitor `#821` cloud checks; if a required lane fails, debug in
+4. Monitor `#821` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-reader-helpers-coverage-640`,
    patch, validate locally, and push with lease.
-6. Monitor `#822` cloud checks; if a required lane fails, debug in
+5. Monitor `#822` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
    patch, validate locally, and push with lease.
+6. Monitor `#823` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-platform-helper-coverage-640`, patch,
+   validate locally, and push with lease.
 7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 16:23 EDT
+Last reviewed: 2026-04-26 16:39 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -148,11 +148,12 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#817` UMP conversion edge coverage for `#645`, branch
-  `feature/midi-ump-conversion-coverage-645`, head `c4420370`; opened
-  from `main` at `957a0735`. `shipyard pr` was attempted first but
-  stopped before PR creation because the SSH `windows` backend timed
-  out, so this tranche is using the GitHub/Namespace path instead of
-  skipping that lane.
+  `feature/midi-ump-conversion-coverage-645`, head `31a53432`; opened
+  from `main` at `957a0735`, then updated with scan-cache temp-file
+  isolation after macOS ASan exposed a parallel CTest collision. `shipyard
+  pr` was attempted first but stopped before PR creation because the SSH
+  `windows` backend timed out, so this tranche is using the
+  GitHub/Namespace path instead of skipping that lane.
 - `#818` MPE synth voice / allocator edge coverage for `#645`, branch
   `feature/midi-mpe-synth-voice-coverage-645`, head `21eb74e1`; opened
   from `main` at `957a0735`. This tranche is also using the
@@ -161,6 +162,11 @@ Open Phase 3 PRs:
 - `#819` MIDI keyboard/sequence edge coverage for `#645`, branch
   `feature/midi-keyboard-sequence-coverage-645`, head `60676709`;
   opened from `main` at `019130bd`. This tranche also uses the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
+- `#820` signal spectrogram edge coverage for `#645`, branch
+  `feature/signal-spectrogram-coverage-645`, head `0fd8aa5a`; opened
+  from `main` at `c9620a65`. This tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
 
@@ -316,20 +322,26 @@ Local Phase 3 draft worktrees:
   version-bump report.
 - `#645` MIDI UMP conversion worktree
   `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
-  branch `feature/midi-ump-conversion-coverage-645`, commit `c4420370`;
+  branch `feature/midi-ump-conversion-coverage-645`, commit `31a53432`;
   open as PR `#817`.
   Scope: test-only coverage for velocity-zero note-on aliasing,
   program-change fallback packets, group masking, sample-offset
   preservation, MIDI 2 edge-value down-conversion, skipped packets
-  without MIDI 1 equivalents, and scale endpoint preservation. Local
+  without MIDI 1 equivalents, and scale endpoint preservation. Follow-up
+  `31a53432` isolates scan-cache test temp files with process id plus a
+  per-process counter after macOS ASan showed the previous
+  steady-clock-only stem could collide under parallel CTest. Local
   validation: no-GPU/no-examples configure, `pulp-test-ump-buffer-
   conversion` build, direct `[midi][ump][issue-645]` passed `46`
   assertions in `4` cases, full binary passed `97` assertions in `15`
-  cases, focused CTest conversion selection passed `6/6`,
-  `git diff --check`, skill-sync report, and version-bump report. A
-  broader CTest regex was intentionally not used for the final summary
-  because the lite build exposes `*_NOT_BUILT_*` placeholder tests that
-  match generic `ump` patterns.
+  cases, focused CTest conversion selection passed `6/6`, normal
+  `pulp-test-scan-cache` `[scan_cache]` passed, normal and ASan CTest
+  repeats for `put + get round-trip on an existing file` and `get
+  invalidates when file changes` passed `10/10`, `git diff --check`,
+  skill-sync report, and version-bump report. A broader CTest regex was
+  intentionally not used for the final summary because the lite build
+  exposes `*_NOT_BUILT_*` placeholder tests that match generic `ump`
+  patterns.
 - `#645` MPE synth voice worktree
   `/Users/danielraffel/Code/pulp-midi-mpe-synth-voice-coverage-645`,
   branch `feature/midi-mpe-synth-voice-coverage-645`, commit
@@ -360,6 +372,20 @@ Local Phase 3 draft worktrees:
   full binaries passed `51` assertions in `20` cases and `94`
   assertions in `24` cases, focused CTest passed `20/20`,
   `git diff --check`, skill-sync report, and version-bump report.
+- `#645` signal spectrogram worktree
+  `/Users/danielraffel/Code/pulp-signal-spectrogram-coverage-645`,
+  branch `feature/signal-spectrogram-coverage-645`, commit `0fd8aa5a`;
+  open as PR `#820`.
+  Scope: test-only coverage for `ColorMapper` ramp switching/control
+  points, `FrequencyAxis` clamping and bin/display conversions,
+  `SpectrogramBuffer` column wraparound, row-to-bin mapping,
+  degenerate dB ranges, and empty-row buffers. Local validation:
+  no-GPU/no-examples configure, `pulp-test-stft` build, direct
+  `[signal][spectrogram][issue-645]` passed `49` assertions in `4`
+  cases, direct `[signal][spectrogram]` passed `79` assertions in `12`
+  cases, full binary passed `390` assertions in `30` cases, focused
+  CTest selection passed `12/12`, `git diff --check`, skill-sync
+  report, and version-bump report.
 
 Open supporting PR:
 
@@ -367,7 +393,8 @@ Open supporting PR:
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#813` merged,
-  updated after `#816` merged and `#819` opened, and remains docs-only.
+  updated after `#816` merged, `#817` was repaired, and `#820` opened,
+  and remains docs-only.
 
 Local environment note:
 
@@ -395,10 +422,13 @@ Next recovery actions:
 4. Monitor `#819` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-keyboard-sequence-coverage-645`,
    patch, validate locally, and push with lease.
-5. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+5. Monitor `#820` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-signal-spectrogram-coverage-645`,
+   patch, validate locally, and push with lease.
+6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-6. Continue Phase 3 from the tranche issues below, prioritizing
+7. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 22:02 EDT
+Last reviewed: 2026-04-25 22:14 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -67,39 +67,32 @@ Finish line:
 
 Latest complete Codecov `main` report observed while updating this doc:
 
-- commit: `23d3ed1d9dca9b39e3e7f3a851698eb93c717ae6`
-- workflow: Coverage run `24944888062`, completed successfully
-- overall tracked coverage: `44.73%` over `70,325` lines in `556` files
-- covered lines: `31,458`
+- commit: `e2af9c4db73c6b404553eb41cbd8dd3fc5a3b4db`
+- workflow: Coverage run `24945821780`, completed successfully
+- overall tracked coverage: `44.84%` over `70,312` lines in `556` files
+- covered lines: `31,532`
 - current component coverage from the Codecov API:
-  - `audio`: `25.53%`
-  - `canvas`: `65.87%`
-  - `dsl`: `68.85%`
-  - `events`: `49.64%`
-  - `format`: `52.64%`
-  - `host`: `44.32%`
+  - `audio`: `25.69%`
+  - `canvas`: `68.09%`
+  - `dsl`: `72.13%`
+  - `events`: `47.76%`
+  - `format`: `52.55%`
+  - `host`: `43.48%`
   - `midi`: `49.95%`
-  - `osc`: `67.47%`
-  - `platform`: `48.83%`
-  - `render`: `62.31%`
-  - `runtime`: `53.89%`
-  - `signal`: `63.96%`
-  - `state`: `66.69%`
-  - `view`: `44.6%`
+  - `osc`: `70.9%`
+  - `platform`: `37.53%`
+  - `render`: `61.51%`
+  - `runtime`: `52.48%`
+  - `signal`: `66.16%`
+  - `state`: `65.13%`
+  - `view`: `44.63%`
   - `android`: `13.83%`
-  - `apple`: `25.72%`
-  - `linux`: `0.0%`
-  - `windows`: `10.13%`
-  - `cli`: `32.21%`
-  - `ship`: `59.15%`
-  - `tools`: `39.5%`
-
-Newer `main` state:
-
-- `#793` merged after the latest complete Codecov report above. The new
-  `main` head is `e2af9c4db73c6b404553eb41cbd8dd3fc5a3b4db`.
-- Main Coverage run `24945821780` is in progress for `e2af9c4d`; refresh
-  this baseline from Codecov after it completes.
+  - `apple`: `25.36%`
+  - `linux`: `0.44%`
+  - `windows`: `1.62%`
+  - `cli`: `33.43%`
+  - `ship`: `54.34%`
+  - `tools`: `40.22%`
 
 Merged after the Phase 1 closeout / `#723` baseline:
 
@@ -156,11 +149,9 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its post-`#793` status-update checks drain.
-2. Let main Coverage run `24945821780` for `e2af9c4d` drain, then refresh
-   this section with the next complete Codecov `main` report.
-3. If a new PR is green but GitHub reports it behind `main`, rebase that
+2. If a new PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-4. Continue Phase 3 from the tranche issues below, prioritizing
+3. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 15:28 EDT
+Last reviewed: 2026-04-26 15:39 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -145,11 +145,18 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#814` CLI `pulp pr` shellout coverage for `#643`, branch
-  `feature/cli-pr-coverage-643`, head `22ba6162`; opened after rebasing
-  onto `main` at `957a0735`. Cloud checks are the active gate.
+  `feature/cli-pr-coverage-643`, head `615bd756`; opened after rebasing
+  onto `main` at `957a0735`. The Linux Namespace cwd-sensitive shellout
+  failure was patched by resolving the CLI binary before the test changes
+  cwd; cloud checks are rerunning from the new head.
 - `#815` MPE tracker edge-path coverage for `#645`, branch
   `feature/mpe-tracker-coverage-645`, head `b7c72711`; opened from
-  `main` at `957a0735`. Cloud checks are the active gate.
+  `main` at `957a0735`. Windows coverage failed during dependency
+  bootstrap on a `wgpu-native` 502; rerun the failed coverage job after
+  the still-queued macOS coverage job lets the workflow finish.
+- `#816` MIDI running-status parser edge coverage for `#645`, branch
+  `feature/midi-running-status-coverage-645`, head `94b93a6e`; opened
+  from `main` at `957a0735`. Cloud checks are the active gate.
 
 Local Phase 3 draft worktrees:
 
@@ -263,14 +270,17 @@ Local Phase 3 draft worktrees:
   skill-sync report, and version-bump report.
 - `#643` CLI `pulp pr` shellout worktree
   `/Users/danielraffel/Code/pulp-cli-pr-coverage-643`, branch
-  `feature/cli-pr-coverage-643`, commit `22ba6162`; open as PR `#814`.
+  `feature/cli-pr-coverage-643`, commit `615bd756`; open as PR `#814`.
   Scope: shellout coverage for missing-Shipyard install guidance,
   native fallback help, outside-project refusal, and POSIX delegation to
-  a fake `shipyard pr` executable without invoking real Shipyard. Local
-  validation: no-GPU/no-examples configure, `pulp-test-cli-shellout`
-  build, direct `[cli][shellout][pr][issue-643]` passed `18` assertions
-  in `4` cases, focused CTest `pulp pr` passed `7/7`,
-  `git diff --check`, skill-sync report, and version-bump report.
+  a fake `shipyard pr` executable without invoking real Shipyard. Follow-
+  up `615bd756` fixed Linux Namespace by resolving the CLI binary before
+  changing cwd in the native outside-project test. Local validation:
+  no-GPU/no-examples configure, `pulp-test-cli-shellout` build, direct
+  `[cli][shellout][pr][issue-643]` passed `18` assertions in `4` cases,
+  single failed cloud case passed `3` assertions in `1` case after the
+  fix, focused CTest `pulp pr` passed `7/7`, `git diff --check`,
+  skill-sync report, and version-bump report.
 - `#645` MPE tracker worktree
   `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, branch
   `feature/mpe-tracker-coverage-645`, commit `b7c72711`; open as PR
@@ -283,6 +293,19 @@ Local Phase 3 draft worktrees:
   full binary passed `239` assertions in `23` cases, and focused CTest
   `MpeVoiceTracker` passed `23/23`, `git diff --check`, skill-sync
   report, and version-bump report.
+- `#645` MIDI running-status parser worktree
+  `/Users/danielraffel/Code/pulp-midi-running-status-coverage-645`,
+  branch `feature/midi-running-status-coverage-645`, commit `94b93a6e`;
+  open as PR `#816`.
+  Scope: test-only coverage for one-byte and two-byte channel running
+  status, system-common data lengths, real-time bytes inside sysex,
+  status restart inside sysex, empty sysex / unknown status ignore
+  behavior, and null sink / empty feed inputs. Local validation:
+  no-GPU/no-examples configure, `pulp-test-running-status` build, direct
+  `[midi][running-status][issue-645]` passed `29` assertions in `6`
+  cases, full binary passed `56` assertions in `14` cases, focused CTest
+  selection passed `5/5`, `git diff --check`, skill-sync report, and
+  version-bump report.
 
 Open supporting PR:
 
@@ -303,16 +326,21 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#814` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-cli-pr-coverage-643`, patch,
-   validate locally, and push with lease.
+2. Monitor `#814` cloud checks from head `615bd756`; if a required lane
+   fails, debug in `/Users/danielraffel/Code/pulp-cli-pr-coverage-643`,
+   patch, validate locally, and push with lease.
 3. Monitor `#815` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, patch,
-   validate locally, and push with lease.
-4. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+   validate locally, and push with lease. For the current Windows
+   coverage 502 failure, prefer rerunning failed jobs after run
+   `24965100026` completes before changing code.
+4. Monitor `#816` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-midi-running-status-coverage-645`,
+   patch, validate locally, and push with lease.
+5. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-5. Continue Phase 3 from the tranche issues below, prioritizing
+6. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 23:17 EDT
+Last reviewed: 2026-04-25 23:37 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -124,7 +124,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#795` `test(events): cover volume detector lifecycle edges`, branch
-  `feature/events-volume-coverage-642`, commit `a193f617`, worktree
+  `feature/events-volume-coverage-642`, commit `c33133e9`, worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`.
   Scope: deterministic `test/test_network_service_discovery.cpp`
   coverage for `NetworkServiceDiscovery` backend removal, cached-service
@@ -135,11 +135,15 @@ Open Phase 3 PRs:
   `pulp-test-network-service-discovery` passed with `43` assertions in
   `10` test cases; focused CTest
   `NSD|MountedVolume|LockingAsyncUpdater|service-discovery|volume`
-  passed `10/10`; `git diff --check` clean; version bump report says no
-  bump needed. The PR is labeled `codecov` and is using the direct
-  GitHub/Namespace path instead of `shipyard pr` because `#794` exposed a
-  local Shipyard mac configure stall after GitHub/Namespace was already
-  clean.
+  passed `10/10`; `git diff --check` clean. After the first CI pass, the
+  Windows Namespace lane exposed an unavailable-drive exception from
+  `std::filesystem::exists("E:\\")`; commit `c33133e9` fixes
+  `MountedVolumeListChangeDetector::get_mounted_volumes()` to use
+  non-throwing filesystem overloads for platform volume enumeration.
+  GitHub Versioning & Skill-Sync passed on `c33133e9`. The PR is labeled
+  `codecov` and is using the direct GitHub/Namespace path instead of
+  `shipyard pr` because `#794` exposed a local Shipyard mac configure
+  stall after GitHub/Namespace was already clean.
 - `#796` `test(cli): cover tool registry local paths`, branch
   `feature/cli-tool-registry-coverage-643`, commit `cdfbbcec`,
   worktree `/Users/danielraffel/Code/pulp-cli-tool-registry-coverage-643`.
@@ -152,6 +156,22 @@ Open Phase 3 PRs:
   assertions in `5` test cases; focused CTest passed `5/5`;
   `git diff --check` clean; version bump report says no bump needed.
   The PR is using the same direct GitHub/Namespace path as `#795`.
+- `#797` `test(audio): cover streaming WAV writer edges`, branch
+  `feature/audio-streaming-writer-coverage-640`, commit `29a3f26d`,
+  worktree
+  `/Users/danielraffel/Code/pulp-audio-streaming-writer-coverage-640`.
+  Scope: `StreamingWriter` invalid opens, closed writes, null/zero/negative
+  write arguments, finalized WAV headers, 16-bit interleaved PCM clamping,
+  24-bit deinterleaved channel interleaving, and 32-bit PCM destructor
+  finalization. The tranche also fixes the production edge where unopened
+  writes could advance `frames_written_`, and where negative deinterleaved
+  frame counts could underflow or allocate an invalid buffer. Local
+  validation: `pulp-test-audio-file` passed with `312` assertions in `19`
+  test cases; focused CTest
+  `StreamingWriter|audio.*file|FormatRegistry` passed `6/6`;
+  `git diff --check` clean; version bump report says no bump needed.
+  The PR is labeled `codecov` and is using the same direct
+  GitHub/Namespace path as `#795`.
 
 Local Phase 3 draft worktrees:
 
@@ -171,6 +191,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-cli-tool-registry-coverage-643`, branch
   `feature/cli-tool-registry-coverage-643`, commit `cdfbbcec`; open as
   PR `#796`.
+- `#640` streaming-writer audio/platform worktree
+  `/Users/danielraffel/Code/pulp-audio-streaming-writer-coverage-640`,
+  branch `feature/audio-streaming-writer-coverage-640`, commit
+  `29a3f26d`; open as PR `#797`.
 
 Open supporting PR:
 
@@ -191,9 +215,9 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795` and `#796` and address any Codecov, build,
+2. Monitor `#795`, `#796`, and `#797` and address any Codecov, build,
    sanitizer, or Namespace feedback.
-3. If `#795` or `#796` is green but GitHub reports it behind `main`,
+3. If `#795`, `#796`, or `#797` is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 18:28 EDT
+Last reviewed: 2026-04-25 18:43 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -134,7 +134,7 @@ Open Phase 3 PRs:
   workflows, not only the Linux jobs; the current polling window shows no
   failures while those fresh checks drain.
 - `#789` Android ship/package helper coverage, branch
-  `feature/android-package-coverage-644`, head `a3f124a1`. This tranche
+  `feature/android-package-coverage-644`, head `23ea43e2`. This tranche
   adds a deterministic host-side fake Android SDK/toolchain harness for
   `ship/platform/android/package_android.cpp` without requiring a real SDK,
   device, keystore, Gradle install, bundletool, or network access. Scope:
@@ -159,9 +159,13 @@ Open Phase 3 PRs:
   `cmake --build build --target pulp-test-android-package -j4`, direct
   `pulp-test-android-package` (`64` assertions / `7` test cases), focused
   Android package CTest (`7/7`), adjacent ship CTest slice for
-  Android/appcast/codesign/notarization/DMG (`20/20`), and whitespace. The
+  Android/appcast/codesign/notarization/DMG (`20/20`), and whitespace.
+  `a3f124a1` cleared the platform/test lanes but failed required diff
+  coverage at `74.6%` because Windows-only helper branch lines were not marked
+  hit in the merged coverage artifact. The current head simplifies those
+  helpers without behavior changes to reduce the uncovered diff surface; the
   current polling window shows no failures while fresh checks run on
-  `a3f124a1`.
+  `23ea43e2`.
 
 Local Phase 3 draft not yet opened as a PR:
 - `#643` package-registry CLI/tools draft, worktree

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 20:43 EDT
+Last reviewed: 2026-04-25 21:08 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -94,6 +94,13 @@ Latest complete Codecov `main` report observed while updating this doc:
   - `ship`: `57.66%`
   - `tools`: `40.17%`
 
+Newer `main` state:
+
+- `#788` merged after the latest complete Codecov report above. The new
+  `main` head is `23d3ed1d9dca9b39e3e7f3a851698eb93c717ae6`.
+- Main Coverage run `24944888062` is in progress for `23d3ed1d`; refresh
+  this baseline from Codecov after it completes.
+
 Merged after the Phase 1 closeout / `#723` baseline:
 
 - `#649` CLI/tools tranche 1 -> `8449b6e8`
@@ -111,76 +118,38 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#782` VST3 adapter process-path coverage -> `648c2d27`
 - `#786` render DirtyTracker / RenderLoop edge coverage -> `26dd396d`
 - `#789` Android ship/package helper coverage -> `e61dce8d`
+- `#788` events socket-IPC coverage -> `23d3ed1d`
 
 Open Phase 3 PRs:
 
-- `#788` events socket-IPC coverage, branch
-  `feature/events-ipc-coverage-642`, head `931627b0`. This tranche
-  extends `test/test_ipc.cpp` with malformed socket endpoint rejection,
-  non-throwing socket endpoint parsing in
-  `core/events/src/interprocess_connection.cpp`, and a deterministic
-  localhost client/server framed-message exchange. It also hardens
-  `pulp::runtime::Socket::close()` to call TCP `shutdown()` before closing,
-  so Linux threads blocked in `accept()` / `recv()` wake during cleanup.
-  After `9e73a084`, Linux coverage remained in `Run coverage suite` for
-  roughly an hour while every other required lane was green. The current
-  `931627b0` head adds a more direct server cleanup fix:
-  `InterprocessConnectionServer::stop()` self-connects to the listening
-  socket before closing it, so a thread blocked in `accept()` wakes without
-  relying on cross-thread `close()` / `shutdown()` behavior. The new
-  regression test covers stopping a socket server while no client is
-  connected.
-  After `#771` merged, this
-  branch was rebased onto `origin/main` and duplicate shared CLI support
-  commits were skipped, leaving only the events tranche. After `#789` merged,
-  the branch was rebased again onto `origin/main` at
-  `e61dce8d907c29888fd7dd97ae7f49e3bc219662`. Local validation is
-  green: `pulp-test-ipc` (`34` assertions / `9` test
-  cases), focused CTest `IPC` (`9/9`), and
-  whitespace. A direct multi-filter Catch2 invocation was intentionally not
-  used as validation because Catch2 treats multiple quoted filters as an AND
-  expression; CTest was used for the focused multi-test slice. PR is labeled
-  `codecov`. The earlier Linux Namespace and Linux coverage failures did not
-  expose usable logs through `gh`. A rerun of Build/Test `24929736674` and
-  Coverage `24929736678` then sat in progress for roughly 90 minutes with no
-  logs and no timestamp movement, so both stuck runs were canceled. The branch
-  was then rebased after `#789`. The `2ac5b09e` run got through all other
-  required lanes but Linux Build/Test and Linux Coverage remained in their
-  long test/coverage steps, matching a likely blocking-`accept()` cleanup hang.
-  The targeted `9e73a084` fix was pushed after local IPC validation stayed
-  green. That head got Build/Test green on Linux, macOS, and Windows;
-  sanitizer lanes green or skipped as expected; Android build, IWYU,
-  macOS coverage, and Windows coverage green; but Linux coverage stayed
-  in `Run coverage suite` with no logs. The current `931627b0` head has
-  local IPC validation green: `pulp-test-ipc` (`37` assertions / `10`
-  test cases), focused CTest `IPC` (`10/10`), `git diff --check`, and
-  `version_bump_check.py --mode=report` (patch suggestion only). Fresh
-  GitHub checks are now running on that head.
+- None at this checkpoint. The next planned Phase 3 PR is the local
+  `#643` package-registry CLI/tools draft below.
 
 Local Phase 3 draft not yet opened as a PR:
 - `#643` package-registry CLI/tools draft, worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
-  `feature/package-registry-coverage-643`, local commit `16bbe5bb`. This draft is local-only and
-  should not be opened until `#788` resolves. Current scope adds
+  `feature/package-registry-coverage-643`, local commit `75a529ef`.
+  This draft was rebased onto `origin/main` at
+  `23d3ed1d9dca9b39e3e7f3a851698eb93c717ae6` after `#788` merged.
+  Current scope adds
   `pulp-test-cli-package-registry` for pure local registry parsing,
   lock-file round trips, target TOML parsing/writing, semver, quality
   scoring, unsupported-target detection, and search ranking. Local validation
-  is green after rebasing onto `origin/main` at
-  `e61dce8d907c29888fd7dd97ae7f49e3bc219662`, in a no-GPU/no-examples build
-  directory using the completed local `mbedtls` source tree: configure
+  is green after the latest rebase: configure
   `cmake -S . -B build-package-registry-localdeps -DCMAKE_BUILD_TYPE=Debug
   -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF
   -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=$PWD/build/_deps/mbedtls-src`, build
   `cmake --build build-package-registry-localdeps --target
   pulp-test-cli-package-registry -j4`, direct binary (`88` assertions / `5`
-  test cases), focused CTest (`5/5`), and whitespace.
+  test cases), focused CTest (`5/5`), whitespace, and
+  `version_bump_check.py --mode=report`.
 
 Open supporting PR:
 
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#789` merged and
+  The branch has been rebased onto `origin/main` after `#788` merged and
   remains docs-only.
 
 Local environment note:
@@ -193,18 +162,14 @@ Local environment note:
 
 Next recovery actions:
 
-1. Poll `#788`; merge manually when green because auto-merge is disabled.
-2. Let `#788`'s fresh checks on `931627b0` drain.
-3. Keep `#774` docs-only and let its post-`#789` rebase checks drain.
-4. After `#788` merges, refresh this section with the next
-   complete Codecov `main` report.
-5. If `#788` Linux Namespace or Linux coverage fails again, pull the fresh log
-   first; the current branch already has local IPC validation green.
-6. If a PR is green but GitHub reports it behind `main`, rebase that
+1. Let main Coverage run `24944888062` for `23d3ed1d` drain, then refresh
+   this section with the next complete Codecov `main` report.
+2. Keep `#774` docs-only and let its post-`#788` rebase checks drain.
+3. Push/open the rebased and locally validated `#643` draft (`75a529ef`)
+   as the next CLI/tools tranche PR.
+4. If a new PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-7. After `#788` resolves, push/open the local `#643` draft
-   (`16bbe5bb`) as the next CLI/tools tranche PR.
-8. Continue Phase 3 from the tranche issues below, prioritizing
+5. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 19:16 EDT
+Last reviewed: 2026-04-25 19:44 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -115,11 +115,14 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#788` events socket-IPC coverage, branch
-  `feature/events-ipc-coverage-642`, head `2ac5b09e`. This tranche
+  `feature/events-ipc-coverage-642`, head `9e73a084`. This tranche
   extends `test/test_ipc.cpp` with malformed socket endpoint rejection,
   non-throwing socket endpoint parsing in
   `core/events/src/interprocess_connection.cpp`, and a deterministic
-  localhost client/server framed-message exchange. After `#771` merged, this
+  localhost client/server framed-message exchange. It also hardens
+  `pulp::runtime::Socket::close()` to call TCP `shutdown()` before closing,
+  so Linux threads blocked in `accept()` / `recv()` wake during cleanup.
+  After `#771` merged, this
   branch was rebased onto `origin/main` and duplicate shared CLI support
   commits were skipped, leaving only the events tranche. After `#789` merged,
   the branch was rebased again onto `origin/main` at
@@ -133,8 +136,11 @@ Open Phase 3 PRs:
   expose usable logs through `gh`. A rerun of Build/Test `24929736674` and
   Coverage `24929736678` then sat in progress for roughly 90 minutes with no
   logs and no timestamp movement, so both stuck runs were canceled. The branch
-  was then rebased after `#789`; the current polling window shows no failures
-  while the fresh `2ac5b09e` checks drain.
+  was then rebased after `#789`. The `2ac5b09e` run got through all other
+  required lanes but Linux Build/Test and Linux Coverage remained in their
+  long test/coverage steps, matching a likely blocking-`accept()` cleanup hang.
+  The targeted `9e73a084` fix was pushed after local IPC validation stayed
+  green, and fresh checks are now running on that head.
 
 Local Phase 3 draft not yet opened as a PR:
 - `#643` package-registry CLI/tools draft, worktree
@@ -165,7 +171,7 @@ Open supporting PR:
 Next recovery actions:
 
 1. Poll `#788`; merge manually when green because auto-merge is disabled.
-2. Let `#788`'s fresh full Build/Test and Coverage workflows on `2ac5b09e`
+2. Let `#788`'s fresh full Build/Test and Coverage workflows on `9e73a084`
    drain.
 3. Keep `#774` docs-only and let its post-`#789` rebase checks drain.
 4. After `#788` merges, refresh this section with the next
@@ -175,7 +181,7 @@ Next recovery actions:
 6. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
 7. After `#788` resolves, push/open the local `#643` draft
-   (`b1443bb9`) as the next CLI/tools tranche PR.
+   (`16bbe5bb`) as the next CLI/tools tranche PR.
 8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 22:49 EDT
+Last reviewed: 2026-04-26 23:14 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -66,7 +66,7 @@ Finish line:
 ## Current live state
 
 Latest complete Codecov `main` report observed while updating this doc
-(`main` head `62ad9870` has a newer Coverage run queued):
+(`main` head `51be8860` has a newer Coverage run queued):
 
 - commit: `5b8e4529cfc553fd98b65f265ed1e9c0487b3d66`
 - workflow: Coverage run `24970413173`, completed successfully
@@ -166,19 +166,11 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#833` signal filter-design edge coverage -> `8fc5dd2d`
 - `#838` CLI release packager coverage -> `3d47dbd2`
 - `#839` GPU graph render helper hardening/coverage -> `62ad9870`
+- `#832` platform child-process edge coverage -> `3f92f066`
+- `#842` inspect Codecov classification -> `51be8860`
 
 Open Phase 3 PRs:
 
-- `#832` platform child-process edge coverage for `#640`, branch
-  `feature/platform-child-process-coverage-640`, head `7496ba0a`;
-  opened from `main` at `d5efea57`, updated after the first Windows
-  Namespace run exposed a cmd/PowerShell portability issue in the test
-  commands, then rebased onto `87ef6d90` and updated after Windows
-  exposed the fast-exit no-newline `cmd` probe returning nonzero, then
-  rebased onto `b5e7a463` and updated after review flagged a fixed
-  100ms fast-exit deadline. This tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
 - `#835` CLI ship command validation coverage for `#643`, branch
   `feature/cli-ship-coverage-643`, head `b8f22af9`; opened from
   `main` at `5b8e4529`, then rebased onto `b5e7a463` and updated after
@@ -199,13 +191,6 @@ Open Phase 3 PRs:
   and removes unrelated POSIX `waitpid` hardening from this tranche.
   This tranche also uses the GitHub/Namespace path while the SSH
   `windows` target remains unreachable.
-- `#842` inspect Codecov classification for `#841` / parent `#641`,
-  branch `feature/inspect-codecov-component-841`, head `0541fd69`;
-  promotes `inspect/**` to a first-class Codecov flag/component and
-  classifies it in the existing user-facing coverage tier. Local
-  validation passed the Codecov config test, coverage-tier check,
-  docs-sync report, diff check, skill-sync report, and version-bump
-  report.
 - `#843` MPE tracker UMP edge-path coverage for `#645`, branch
   `feature/midi-mpe-tracker-extra-coverage-645-next`, head `fcdbd278`;
   opened from `main` at `eaf991b0`. This test-only tranche covers
@@ -265,6 +250,34 @@ Open Phase 3 PRs:
   focused async-helper target covering reentrant `AsyncUpdater`,
   `LambdaAsyncUpdater` empty-callback handling, `ActionBroadcaster`
   missing-removal behavior, and `MultiTimer` stop-all/restart behavior.
+- `#858` render DrawBatcher edge coverage for `#646`, branch
+  `feature/render-only-coverage-646-next2`, head `d055cc7d`; covers
+  chained same-key merges, post-end records, and edge-touching blockers,
+  and moves the DrawBatcher test target into the GPU-off-safe lane.
+- `#859` platform ProgressParser edge coverage for `#640`, branch
+  `feature/audio-helper-coverage-640-next3`, head `176f1b12`; covers
+  null callbacks on matching progress lines plus empty event-type and
+  empty-payload parsing boundaries.
+- `#860` MIDI SysEx accumulator coverage for `#645`, branch
+  `feature/midi-signal-coverage-645-next3`, head `0ede5297`; covers
+  fresh `F0` abort/restart behavior, single-byte abort ownership, and
+  idle `F7` passthrough.
+- `#861` descriptor-validation edge coverage for `#493`, branch
+  `feature/format-view-coverage-493-next3`, head `75acf512`; covers
+  warning-only malformed reverse-DNS bundle IDs, instrument input-bus
+  exceptions, and UMP/MIDI sidecar warning behavior.
+- `#862` LCOV-to-Cobertura utility coverage for `#643`, branch
+  `feature/cli-tools-coverage-643-next4`, head `191785c6`; covers
+  relpath fallback, package exclusion summary recalculation, and CLI XML
+  output for the vendored converter.
+- `#863` StateStore helper coverage for parent `#641`, branch
+  `feature/runtime-state-coverage-641-next3`, head `c9b98058`; covers
+  modulation offsets, unknown parameter getters, default resets,
+  registration spans, and gesture callback dispatch.
+- `#864` Apple Swift bridge-parameter coverage for parent `#641`,
+  branch `feature/apple-swift-coverage-641-next`, head `3ff82a4e`;
+  covers parameter reload replacement after backend changes, invalid
+  `pulp_param_info` requests, and C string field population.
 
 Local Phase 3 draft worktrees:
 
@@ -1029,7 +1042,9 @@ Open supporting PR:
   was repaired for diff coverage with `410a0371`, and `#852`, `#853`,
   `#854`, and `#855` opened from the next worker batch, and `#838`
   merged as `3d47dbd2`, and `#839` merged as `62ad9870`, and `#856`
-  and `#857` opened from the latest worker batch,
+  and `#857` opened from the latest worker batch, and `#832` merged as
+  `3f92f066`, and `#842` merged as `51be8860`, and `#858` through
+  `#864` opened from the parallel worker queue,
   and remains docs-only.
 
 Local environment note:
@@ -1049,32 +1064,25 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#832` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
-   patch, validate locally, and push with lease.
-3. Monitor `#835` cloud checks; if a required lane fails, debug in
+2. Monitor `#835` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
    validate locally, and push with lease.
-4. Monitor `#840` cloud checks on head `410a0371`; if a required lane
+3. Monitor `#840` cloud checks on head `410a0371`; if a required lane
    fails after dependency bootstrap succeeds, debug in
    `/Users/danielraffel/Code/pulp-events-child-process-coverage-642`,
    patch, validate locally, and push with lease.
-5. Monitor `#842` cloud checks on head `0541fd69`; if a required lane
-   fails, debug in
-   `/Users/danielraffel/Code/pulp-inspect-codecov-component-841`,
-   patch, validate locally, and push with lease.
-6. Monitor `#843` cloud checks on head `fcdbd278`; if a required lane
+4. Monitor `#843` cloud checks on head `fcdbd278`; if a required lane
    fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
    patch, validate locally, and push with lease.
-7. Monitor `#845` through `#857`; if a required lane fails, debug in
+5. Monitor `#845` through `#864`; if a required lane fails, debug in
    the worktree named in the open-PR list above, patch, validate
    locally, and push with lease. Pay particular attention to `#848` and
    `#851` because they include patch-level production hardening.
-8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+7. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline
@@ -1164,7 +1172,7 @@ represented surface.
 
 - `inspect/` is represented on the Codecov website as a first-party
   top-level bucket (`1,505` lines, `10.10%` in the user-observed
-  snapshot). It is tracked by `#841`, and PR `#842` promotes
+  snapshot). It was tracked by `#841`, and merged PR `#842` promotes
   `inspect/**` to a first-class Codecov flag/component and assigns it to
   the existing user-facing coverage tier in `ci/coverage-targets.yaml`.
 
@@ -1198,7 +1206,7 @@ represented surface.
 - `#77` decide and, if in scope, add mobile runtime coverage from
   Android instrumentation and iOS simulator / runtime app paths
 - `#841` classify represented `inspect/**` as a first-class Codecov
-  component/tier; implemented by open PR `#842`
+  component/tier; implemented by merged PR `#842`
 
 ### Supporting infrastructure
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 18:31 EDT
+Last reviewed: 2026-04-26 18:42 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -176,6 +176,11 @@ Open Phase 3 PRs:
   `feature/signal-meter-coverage-645`, head `ed51248f`; opened from
   `main` at `1a1b7f07`. This tranche also uses the GitHub/Namespace path
   while the SSH `windows` target remains unreachable.
+- `#828` raw MIDI parser edge coverage and malformed-data hardening for
+  `#645`, branch `feature/midi-raw-parser-coverage-645`, head
+  `4e2e6092`; opened from `main` at `94e3ef2a`. This tranche also uses
+  the GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -520,6 +525,21 @@ Local Phase 3 draft worktrees:
   passed `20` assertions in `6` cases, full binary passed `20`
   assertions in `6` cases, focused CTest passed `6/6`,
   `git diff --check`, skill-sync report, and version-bump report.
+- `#645` raw MIDI parser worktree
+  `/Users/danielraffel/Code/pulp-midi-raw-parser-coverage-645`, branch
+  `feature/midi-raw-parser-coverage-645`, commit `4e2e6092`; open as PR
+  `#828`.
+  Scope: fixes `parse_raw_midi_bytes` so malformed short messages do not
+  emit status bytes as data, then adds coverage for remaining
+  short-message forms, stray data plus incomplete short messages,
+  omitted callbacks, and recovery after the runaway sysex cap resets the
+  accumulator. Local validation: no-GPU/no-examples configure,
+  `pulp-test-raw-midi-parser` build, direct `[issue-645]` run passed
+  `16` assertions in `3` cases, full binary passed `53` assertions in
+  `9` cases, focused CTest passed `4/4`, `git diff --check`,
+  skill-sync report, and version-bump report with
+  `Version-Bump: sdk=patch` because the inline header is an internal
+  transport helper despite living under `include`.
 
 Open supporting PR:
 
@@ -532,7 +552,7 @@ Open supporting PR:
   merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
   merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
   repaired again for Android SDK discovery, `#827` opened, `#823`
-  merged, and `#824` merged, and remains docs-only.
+  merged, `#824` merged, and `#828` opened, and remains docs-only.
 
 Local environment note:
 
@@ -563,10 +583,13 @@ Next recovery actions:
 5. Monitor `#827` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-meter-coverage-645`, patch,
    validate locally, and push with lease.
-6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. Monitor `#828` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-midi-raw-parser-coverage-645`, patch,
+   validate locally, and push with lease.
+7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-7. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 17:55 EDT
+Last reviewed: 2026-04-25 18:11 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -159,15 +159,19 @@ Open Phase 3 PRs:
 Local Phase 3 draft not yet opened as a PR:
 - `#643` package-registry CLI/tools draft, worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
-  `feature/package-registry-coverage-643`. This draft is local-only and
+  `feature/package-registry-coverage-643`, local commit `b1443bb9`. This draft is local-only and
   should not be opened until `#788` / `#789` resolve. Current scope adds
   `pulp-test-cli-package-registry` for pure local registry parsing,
   lock-file round trips, target TOML parsing/writing, semver, quality
-  scoring, unsupported-target detection, and search ranking. Local configure
-  has been resumed and is currently working through mandatory `mbedtls`
-  FetchContent population; once it completes, build
-  `pulp-test-cli-package-registry` and fix any compile/test issues before
-  opening a PR.
+  scoring, unsupported-target detection, and search ranking. Local validation
+  is green in a no-GPU/no-examples build directory using the completed local
+  `mbedtls` source tree: configure
+  `cmake -S . -B build-package-registry-localdeps -DCMAKE_BUILD_TYPE=Debug
+  -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF
+  -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=$PWD/build/_deps/mbedtls-src`, build
+  `cmake --build build-package-registry-localdeps --target
+  pulp-test-cli-package-registry -j4`, direct binary (`88` assertions / `5`
+  test cases), focused CTest (`5/5`), and whitespace.
 
 Open supporting PR:
 
@@ -195,7 +199,9 @@ Next recovery actions:
    first; the current branch already has local IPC validation green.
 8. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+9. After `#788` and `#789` resolve, push/open the local `#643` draft
+   (`b1443bb9`) as the next CLI/tools tranche PR.
+10. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 01:13 EDT
+Last reviewed: 2026-04-26 01:19 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -123,11 +123,12 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#796` tool-registry CLI/tools coverage -> `11c10a7e`
 - `#797` StreamingWriter audio edge coverage -> `64ba65e3`
 - `#798` FormatRegistry audio dispatch coverage -> `443ca260`
+- `#799` docs-reader CLI shellout coverage -> `22438468`
 
 Open Phase 3 PRs:
 
 - `#795` `test(events): cover volume detector lifecycle edges`, branch
-  `feature/events-volume-coverage-642`, commit `2d684f4b`, worktree
+  `feature/events-volume-coverage-642`, commit `2f109744`, worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`.
   Scope: deterministic `test/test_network_service_discovery.cpp`
   coverage for `NetworkServiceDiscovery` backend removal, cached-service
@@ -144,24 +145,15 @@ Open Phase 3 PRs:
   final PR diff because the Windows coverage XML reports that translation
   unit at `0%` even though the CTest cases run and pass there. The final
   PR diff is test-only, and the mounted-volume enumeration tests skip on
-  Windows while retaining POSIX coverage. GitHub checks were rerunning on
-  `2d684f4b` with no failures at the last poll. The PR is labeled
+  Windows while retaining POSIX coverage. The prior Linux coverage failure
+  on `2d684f4b` was not from the events tests; the failed job showed the
+  #795 events tests passed and unrelated CLI/Python coverage tests failed
+  on the stale base. The branch was rebased onto `origin/main` after
+  `#798` and `#799` merged, local validation passed again, and fresh CI is
+  running on `2f109744`. The PR is labeled
   `codecov` and is using the direct GitHub/Namespace path instead of
   `shipyard pr` because `#794` exposed a local Shipyard mac configure
   stall after GitHub/Namespace was already clean.
-- `#799` `test(cli): cover docs shellout reader paths`, branch
-  `feature/cli-docs-coverage-643`, commit `4877cb1b`, worktree
-  `/Users/danielraffel/Code/pulp-cli-docs-coverage-643`.
-  Scope: deterministic `test/test_cli_shellout.cpp` coverage for
-  `pulp docs` local reader usage, index, open, search, support/command/
-  CMake/style `show` paths, and error diagnostics. Local validation:
-  `pulp-cli` and `pulp-test-cli-shellout` built successfully; direct
-  Catch2 tag run `[cli][shellout][docs][issue-643]` passed with `38`
-  assertions in `1` test case; focused CTest
-  `pulp docs covers local reader` passed `1/1`; `git diff --check`
-  clean; skill sync found no mapped paths; version bump report says no
-  bump needed. The PR is labeled `codecov` and is using the direct
-  GitHub/Namespace path.
 - `#800` `test(tools): cover version and skill gate helpers`, branch
   `feature/python-tooling-coverage-643`, commit `acadc5af`, worktree
   `/Users/danielraffel/Code/pulp-python-tooling-coverage-643`.
@@ -204,7 +196,7 @@ Local Phase 3 draft worktrees:
   `c4e6ad09`. The remote branch was deleted after merge.
 - `#642` events volume/service-discovery worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`, branch
-  `feature/events-volume-coverage-642`, commit `2d684f4b`; open as PR
+  `feature/events-volume-coverage-642`, commit `2f109744`; open as PR
   `#795`.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
@@ -226,8 +218,8 @@ Local Phase 3 draft worktrees:
   deleted after merge.
 - `#643` docs-reader CLI/tools worktree
   `/Users/danielraffel/Code/pulp-cli-docs-coverage-643`, branch
-  `feature/cli-docs-coverage-643`, commit `4877cb1b`; open as PR
-  `#799`.
+  `feature/cli-docs-coverage-643`, commit `4877cb1b`; merged via PR
+  `#799` as `22438468`. The remote branch was deleted after merge.
 - `#643` Python gate-helper tooling worktree
   `/Users/danielraffel/Code/pulp-python-tooling-coverage-643`, branch
   `feature/python-tooling-coverage-643`, commit `acadc5af`; open as PR
@@ -242,7 +234,7 @@ Open supporting PR:
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#798` merged and
+  The branch has been rebased onto `origin/main` after `#799` merged and
   remains docs-only.
 
 Local environment note:
@@ -256,11 +248,11 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795`, `#799`, `#800`, and `#801` and address any Codecov,
-   build, sanitizer, or Namespace feedback.
-3. If `#795`, `#799`, `#800`, or `#801` is green but GitHub reports it
-   behind `main`, rebase that branch onto `origin/main`, push with lease,
-   and let checks rerun.
+2. Monitor `#795`, `#800`, and `#801` and address any Codecov, build,
+   sanitizer, or Namespace feedback.
+3. If `#795`, `#800`, or `#801` is green but GitHub reports it behind
+   `main`, rebase that branch onto `origin/main`, push with lease, and
+   let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 20:22 EDT
+Last reviewed: 2026-04-26 20:30 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -65,36 +65,37 @@ Finish line:
 
 ## Current live state
 
-Latest complete Codecov `main` report observed while updating this doc:
+Latest complete Codecov `main` report observed while updating this doc
+(`main` head `5b8e4529` has a newer Coverage run in progress):
 
-- commit: `957a073523e3aabcd7b11972acaf98065909bf67`
-- workflow: Coverage run `24964746369`, completed successfully
-- overall tracked coverage: `45.96%` over `70,376` lines in `556` files
-- covered lines: `32,349`
-- missed lines: `36,895`
-- partial lines: `1,132`
+- commit: `87ef6d90e54a1aa940278aab15b6e444d5c1c30d`
+- workflow: Coverage run `24969958550`, completed successfully
+- overall tracked coverage: `46.83%` over `70,453` lines in `556` files
+- covered lines: `32,994`
+- missed lines: `36,163`
+- partial lines: `1,296`
 - current component coverage from the Codecov API:
-  - `audio`: `34.45%`
-  - `canvas`: `63.96%`
-  - `dsl`: `63.38%`
-  - `events`: `49.49%`
-  - `format`: `51.03%`
-  - `host`: `43.61%`
-  - `midi`: `47.77%`
-  - `osc`: `62.22%`
-  - `platform`: `43.18%`
-  - `render`: `59.74%`
-  - `runtime`: `50.48%`
-  - `signal`: `69.4%`
-  - `state`: `62.99%`
-  - `view`: `43.72%`
+  - `audio`: `37.36%`
+  - `canvas`: `64.74%`
+  - `dsl`: `68.3%`
+  - `events`: `50.5%`
+  - `format`: `51.72%`
+  - `host`: `43.07%`
+  - `midi`: `54.18%`
+  - `osc`: `66.26%`
+  - `platform`: `40.16%`
+  - `render`: `62.77%`
+  - `runtime`: `49.14%`
+  - `signal`: `73.87%`
+  - `state`: `63.56%`
+  - `view`: `44.0%`
   - `android`: `13.83%`
   - `apple`: `25.36%`
-  - `linux`: `0.22%`
-  - `windows`: `6.42%`
-  - `cli`: `38.92%`
-  - `ship`: `53.77%`
-  - `tools`: `44.36%`
+  - `linux`: `3.31%`
+  - `windows`: `0.0%`
+  - `cli`: `40.86%`
+  - `ship`: `53.99%`
+  - `tools`: `45.32%`
 
 Post-`#794` file-level proof point: `core/audio/src/aiff_reader.cpp`
 is now `72.01%` covered with `61` misses, up from `64.22%` with `78`
@@ -193,6 +194,10 @@ Open Phase 3 PRs:
   path while the SSH `windows` target remains unreachable.
 - `#835` CLI ship command validation coverage for `#643`, branch
   `feature/cli-ship-coverage-643`, head `6c1e5a4b`; opened from
+  `main` at `5b8e4529`. This tranche also uses the GitHub/Namespace
+  path while the SSH `windows` target remains unreachable.
+- `#836` CLI sync checker coverage for `#643`, branch
+  `feature/cli-sync-coverage-643`, head `86048a3f`; opened from
   `main` at `5b8e4529`. This tranche also uses the GitHub/Namespace
   path while the SSH `windows` target remains unreachable.
 
@@ -347,6 +352,19 @@ Local Phase 3 draft worktrees:
   `git diff --check HEAD~1..HEAD`, `git diff --check`, skill-sync
   report, and version-bump report with `Version-Bump: sdk=skip` for
   the test-only coverage tranche.
+- `#643` CLI sync checker worktree
+  `/Users/danielraffel/Code/pulp-cli-sync-coverage-643`, branch
+  `feature/cli-sync-coverage-643`, commit `86048a3f`; open as PR
+  `#836`.
+  Scope: test-only Python coverage for `tools/scripts/cli_sync_check.py`
+  repo-root discovery, command-table/YAML/slash-command/skill-reference
+  extraction, strict JSON mismatch exits, warning-only success behavior,
+  and non-repo diagnostics. Local validation: direct
+  `python3 tools/scripts/test_cli_sync_check.py` passed `7` cases,
+  `git diff --check`, skill-sync report, and version-bump report. The
+  local Python coverage runner could not run because this interpreter
+  lacks `coverage.py >= 7.10`; hosted CI remains the coverage proof for
+  this tranche.
 - `#645` MPE tracker worktree
   `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, branch
   `feature/mpe-tracker-coverage-645`, commit `b7c72711`; merged via PR
@@ -679,7 +697,7 @@ Open supporting PR:
   and `#833` opened, and `#829` was rebased onto `87ef6d90` to pick up
   the merged Android SDK discovery fix, and `#832` was rebased/repaired
   for the Windows fast-exit command, and `#834` opened, and `#828`
-  merged, and `#835` opened, and remains docs-only.
+  merged, and `#835` opened, and `#836` opened, and remains docs-only.
 
 Local environment note:
 
@@ -719,10 +737,13 @@ Next recovery actions:
 8. Monitor `#835` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
    validate locally, and push with lease.
-9. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+9. Monitor `#836` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-cli-sync-coverage-643`, patch,
+   validate locally, and push with lease.
+10. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-10. Continue Phase 3 from the tranche issues below, prioritizing
+11. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 02:50 EDT
+Last reviewed: 2026-04-26 03:01 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -126,6 +126,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#799` docs-reader CLI shellout coverage -> `22438468`
 - `#800` Python gate-helper tooling coverage -> `55b6dfab`
 - `#795` events volume/service-discovery coverage -> `f1a5aa84`
+- `#802` CLI-create shellout coverage -> `2de79ff3`
 
 Open Phase 3 PRs:
 
@@ -156,23 +157,6 @@ Open Phase 3 PRs:
   the changed atlas lines covered, `git diff --check` clean, skill sync
   clean, and version report still clean. The PR is labeled `codecov` and
   is using the direct GitHub/Namespace path.
-- `#802` `test(cli): cover create shellout scaffolding`, branch
-  `feature/cli-create-coverage-643`, commit `222d0f88`, worktree
-  `/Users/danielraffel/Code/pulp-cli-create-coverage-643`.
-  Scope: deterministic `pulp create` shellout coverage for no-build app
-  scaffolding with Android target output, generated header/main/CMake/
-  `pulp.toml`/projects registry substitutions, and invalid `--type`
-  rejection before scaffolding. Local validation: no-GPU/no-examples
-  configure, `pulp-test-cli-shellout` target build, focused Catch2 tag
-  run passed with `21` assertions in `2` test cases, focused CTest
-  `pulp create` passed `2/2`, `git diff --check` clean, skill sync
-  clean, and version bump report says no bump needed. Local shellout
-  validation used `PULP_CLI_PATH=/Users/danielraffel/Code/pulp/build/tools/cli/pulp`
-  because the GPU-off configure intentionally does not build `pulp-cli`;
-  CI builds the normal CLI path. The branch was rebased onto
-  `origin/main` after `#795` merged, pushed with lease as `222d0f88`, and
-  the focused local validation above passed again. The PR is labeled
-  `codecov` and is using the direct GitHub/Namespace path.
 - `#803` `test(signal): cover matrix helper edges`, branch
   `feature/signal-matrix-coverage-645`, commit `b1f5a125`, worktree
   `/Users/danielraffel/Code/pulp-signal-matrix-coverage-645`.
@@ -293,14 +277,14 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-python-tooling-coverage-643`, branch
   `feature/python-tooling-coverage-643`, commit `acadc5af`; merged via PR
   `#800` as `55b6dfab`. The remote branch was deleted after merge.
+- `#643` CLI-create shellout worktree
+  `/Users/danielraffel/Code/pulp-cli-create-coverage-643`, branch
+  `feature/cli-create-coverage-643`, commit `222d0f88`; merged via PR
+  `#802` as `2de79ff3`. The remote branch was deleted after merge.
 - `#646` texture-atlas render worktree
   `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`,
   branch `feature/render-texture-atlas-coverage-646`, commit
   `325485bc`; open as PR `#801`.
-- `#643` CLI-create shellout worktree
-  `/Users/danielraffel/Code/pulp-cli-create-coverage-643`, branch
-  `feature/cli-create-coverage-643`, commit `222d0f88`; open as PR
-  `#802`.
 - `#645` signal matrix helper worktree
   `/Users/danielraffel/Code/pulp-signal-matrix-coverage-645`, branch
   `feature/signal-matrix-coverage-645`, commit `b1f5a125`; open as PR
@@ -331,7 +315,7 @@ Open supporting PR:
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#795` merged and
+  The branch has been rebased onto `origin/main` after `#802` merged and
   remains docs-only.
 
 Local environment note:
@@ -345,7 +329,7 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#801`, `#802`, `#803`, `#804`, `#805`, `#806`, `#807`, and `#808`
+2. Monitor `#801`, `#803`, `#804`, `#805`, `#806`, `#807`, and `#808`
    and address any Codecov, build, sanitizer, or Namespace feedback.
 3. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 17:41 EDT
+Last reviewed: 2026-04-26 17:43 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -146,21 +146,13 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#816` MIDI running-status parser edge coverage -> `c9620a65`
 - `#818` MPE synth voice / allocator coverage -> `3d4560d1`
 - `#817` UMP conversion edge coverage -> `a38216fd`
+- `#821` audio reader helper edge coverage -> `7aff17f9`
+- `#819` MIDI keyboard/sequence edge coverage -> `7a646f33`
 
 Open Phase 3 PRs:
 
-- `#819` MIDI keyboard/sequence edge coverage for `#645`, branch
-  `feature/midi-keyboard-sequence-coverage-645`, head `60676709`;
-  opened from `main` at `019130bd`. This tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
 - `#820` signal spectrogram edge coverage for `#645`, branch
   `feature/signal-spectrogram-coverage-645`, head `0fd8aa5a`; opened
-  from `main` at `c9620a65`. This tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
-- `#821` audio reader helper edge coverage for `#640`, branch
-  `feature/audio-reader-helpers-coverage-640`, head `be7d604f`; opened
   from `main` at `c9620a65`. This tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
@@ -371,7 +363,8 @@ Local Phase 3 draft worktrees:
 - `#645` MIDI keyboard/sequence worktree
   `/Users/danielraffel/Code/pulp-midi-keyboard-sequence-coverage-645`,
   branch `feature/midi-keyboard-sequence-coverage-645`, commit
-  `60676709`; open as PR `#819`.
+  `60676709`; merged via PR `#819` as `7a646f33`. The remote branch was
+  deleted after merge.
   Scope: test-only coverage for `MidiKeyboardState` invalid queries,
   ignored non-note events, release callbacks, and retrigger velocity
   updates; plus `MidiMessageSequence` helper field masking,
@@ -402,7 +395,8 @@ Local Phase 3 draft worktrees:
 - `#640` audio reader helper worktree
   `/Users/danielraffel/Code/pulp-audio-reader-helpers-coverage-640`,
   branch `feature/audio-reader-helpers-coverage-640`, commit
-  `be7d604f`; open as PR `#821`.
+  `be7d604f`; merged via PR `#821` as `7aff17f9`. The remote branch was
+  deleted after merge.
   Scope: test-only coverage for `BufferingReader` source-exhaustion
   zero-fill and ring-wrap ordering, plus `AudioSubsectionReader` invalid
   reader, clamped-read, and start-past-end empty-view paths. Local
@@ -481,8 +475,8 @@ Open supporting PR:
   The branch has been rebased onto `origin/main` after `#813` merged,
   updated after `#816` merged, `#817` was repaired, `#820` opened,
   `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
-  merged, `#822` was repaired, and `#824` opened, and remains
-  docs-only.
+  merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
+  merged, and remains docs-only.
 
 Local environment note:
 
@@ -501,28 +495,22 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#819` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-midi-keyboard-sequence-coverage-645`,
-   patch, validate locally, and push with lease.
-3. Monitor `#820` cloud checks; if a required lane fails, debug in
+2. Monitor `#820` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-spectrogram-coverage-645`,
    patch, validate locally, and push with lease.
-4. Monitor `#821` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-audio-reader-helpers-coverage-640`,
-   patch, validate locally, and push with lease.
-5. Monitor `#822` cloud checks; if a required lane fails, debug in
+3. Monitor `#822` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
    patch, validate locally, and push with lease.
-6. Monitor `#823` cloud checks; if a required lane fails, debug in
+4. Monitor `#823` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-helper-coverage-640`, patch,
    validate locally, and push with lease.
-7. Monitor `#824` cloud checks; if a required lane fails, debug in
+5. Monitor `#824` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-math-helper-coverage-645`,
    patch, validate locally, and push with lease.
-8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+7. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 17:27 EDT
+Last reviewed: 2026-04-25 17:55 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -131,7 +131,7 @@ Open Phase 3 PRs:
   the current polling window shows no failures while Linux Namespace plus
   Linux coverage drain.
 - `#789` Android ship/package helper coverage, branch
-  `feature/android-package-coverage-644`, head `3c1a49c0`. This tranche
+  `feature/android-package-coverage-644`, head `3c3a1ea4`. This tranche
   adds a deterministic host-side fake Android SDK/toolchain harness for
   `ship/platform/android/package_android.cpp` without requiring a real SDK,
   device, keystore, Gradle install, bundletool, or network access. Scope:
@@ -143,15 +143,18 @@ Open Phase 3 PRs:
   and labeled `codecov`. The first GitHub Actions pass exposed a Windows
   Namespace-only failure in batch-backed Android tool invocation. The first
   follow-up fixed the skill-sync gap but still failed the same three Windows
-  Android tests. The branch now preserves quoted batch executable paths for
-  `cmd.exe /c` by wrapping commands that begin with a quoted tool path, and
-  documents that gotcha in the `ship` skill. Local validation is green:
+  Android tests. The second follow-up preserved quoted batch executable paths
+  for `cmd.exe /c` but still failed the same Windows tests. The current head
+  additionally fixes the fake Windows `apksigner.bat` fixture's unescaped
+  parenthesized echo text and quotes whole Gradle / bundletool `name=value`
+  arguments instead of only quoted values; the `ship` skill documents both
+  Windows batch gotchas. Local validation is green:
   `cmake --build build --target pulp-test-android-package -j4`, direct
   `pulp-test-android-package` (`64` assertions / `7` test cases), focused
   Android package CTest (`7/7`), adjacent ship CTest slice for
   Android/appcast/codesign/notarization/DMG (`20/20`), and whitespace. The
   current polling window shows no failures while fresh checks run on
-  `3c1a49c0`.
+  `3c3a1ea4`.
 
 Local Phase 3 draft not yet opened as a PR:
 - `#643` package-registry CLI/tools draft, worktree
@@ -161,8 +164,10 @@ Local Phase 3 draft not yet opened as a PR:
   `pulp-test-cli-package-registry` for pure local registry parsing,
   lock-file round trips, target TOML parsing/writing, semver, quality
   scoring, unsupported-target detection, and search ranking. Local configure
-  was interrupted while fetching `mbedtls` because `#789` required immediate
-  Windows triage; resume with a clean configure/build in that worktree.
+  has been resumed and is currently working through mandatory `mbedtls`
+  FetchContent population; once it completes, build
+  `pulp-test-cli-package-registry` and fix any compile/test issues before
+  opening a PR.
 
 Open supporting PR:
 
@@ -177,17 +182,17 @@ Next recovery actions:
 1. Poll `#788` and `#789`; merge manually when green because auto-merge is
    disabled.
 2. Let `#788`'s rerun Linux Namespace and Linux coverage checks drain.
-3. Let `#789`'s post-Windows-fix GitHub Actions checks drain; pull the
+3. Let `#789`'s post-Windows-batch-fix GitHub Actions checks drain; pull the
    exact failing job log first if anything turns red.
 4. Keep `#774` docs-only and let its post-`#786` rebase checks drain.
 5. After the active code PRs merge, refresh this section with the next
    complete Codecov `main` report.
-6. If any Windows Namespace lane fails again, pull the fresh completed-run
-   log first and search for `pulp-test-cli-project-command`; the known
-   failing tests were the dirty-gate and redundant-origin project-bump cases.
-7. If sandbox-e2e fails again, pull the fresh log first; the expected
-   failure fixed here was `pulp upgrade --check-only` ignoring
-   `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
+6. If `#789` Windows Namespace fails again, pull the fresh completed-run log
+   first and search for `test_android_package.cpp`, `Android signing helpers`,
+   `Android Gradle packaging`, and `Android bundletool`; do not patch further
+   without the new log.
+7. If `#788` Linux Namespace or Linux coverage fails again, pull the fresh log
+   first; the current branch already has local IPC validation green.
 8. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
 9. Continue Phase 3 from the tranche issues below, prioritizing

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 21:50 EDT
+Last reviewed: 2026-04-26 22:21 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -211,6 +211,45 @@ Open Phase 3 PRs:
   FetchContent cache hit a GitHub 403 cloning `Tracktion/choc.git`. This
   tranche also uses the GitHub/Namespace path while the SSH `windows`
   target remains unreachable.
+- `#842` inspect Codecov classification for `#841` / parent `#641`,
+  branch `feature/inspect-codecov-component-841`, head `0541fd69`;
+  promotes `inspect/**` to a first-class Codecov flag/component and
+  classifies it in the existing user-facing coverage tier. Local
+  validation passed the Codecov config test, coverage-tier check,
+  docs-sync report, diff check, skill-sync report, and version-bump
+  report.
+- `#843` MPE tracker UMP edge-path coverage for `#645`, branch
+  `feature/midi-mpe-tracker-extra-coverage-645-next`, head `fcdbd278`;
+  opened from `main` at `eaf991b0`. This test-only tranche covers
+  unmatched MIDI 2.0 per-note expression packets, MIDI 2.0 member
+  expression fan-out across active channel notes, and supported-zone UMP
+  packets that should be consumed without mapped side effects.
+- `#845` host automation queue coverage for `#493`, branch
+  `feature/format-host-coverage-493-next`, head `c3c5cfce`; covers
+  `ParameterEventQueue` sample-offset sorting and clear/reuse lifecycle.
+- `#846` audio focus coverage for `#640`, branch
+  `feature/audio-platform-coverage-640-next`, head `97568e27`; covers
+  `AudioFocusRegistry` token move-assignment, default-token reset, and
+  publish-without-subscribers state behavior.
+- `#847` events NSD / async helper coverage for `#642`, branch
+  `feature/events-volume-coverage-642-next`, head `8365c969`; covers
+  `LambdaAsyncUpdater` empty-callback processing plus
+  `NetworkServiceDiscovery` dispatcher and service-keying behavior.
+- `#848` runtime Base64 padding validation for parent `#641`, branch
+  `feature/runtime-coverage-641-next`, head `36aa5c71`; hardens
+  `base64_decode` terminal-padding validation and carries a patch-level
+  SDK metadata trailer.
+- `#849` view label paint coverage for `#493`, branch
+  `feature/view-widget-coverage-493-next`, head `7f6deaf6`; covers
+  label text transforms, multiline/decorations, and vertical text
+  direction transform wrapping.
+- `#850` CLI/tools runner resolver coverage for `#643`, branch
+  `feature/cli-tools-coverage-643-next2`, head `b8e7b22a`; covers
+  optional Namespace fallback plus provider/default argument validation.
+- `#851` signal meter channel-count guards for `#645`, branch
+  `feature/signal-meter-coverage-645-next`, head `ad9c3d81`; hardens
+  negative/invalid `MultiChannelMeter` and `MultiChannelBallistics`
+  channel counts and carries a patch-level SDK metadata trailer.
 
 Local Phase 3 draft worktrees:
 
@@ -716,6 +755,19 @@ Local Phase 3 draft worktrees:
   binary runs, diff whitespace checks, skill-sync report, and
   version-bump report; the focused CTest pattern found no local tests in
   that incremental build but exited cleanly.
+- `#645` MPE tracker UMP edge-path worktree
+  `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
+  branch `feature/midi-mpe-tracker-extra-coverage-645-next`, commit
+  `fcdbd278`; open as PR `#843`.
+  Scope: test-only coverage for unmatched MIDI 2.0 per-note expression
+  handling without seeding channel state, MIDI 2.0 member expression
+  fan-out across active channel notes, and supported-zone UMP packets
+  that are consumed without mapped side effects. Local validation:
+  no-GPU/no-examples configure, `pulp-test-mpe-voice-tracker` build,
+  direct `[issue-645]` run passed `195` assertions in `9` cases, full
+  binary passed `268` assertions in `26` cases, focused CTest
+  `MpeVoiceTracker` passed `26/26`, `git diff --check`, skill-sync
+  report, and version-bump report.
 - `#645` RPN parser worktree
   `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, branch
   `feature/midi-rpn-coverage-645`, commit `d1edf1e1`; merged via PR
@@ -794,6 +846,70 @@ Local Phase 3 draft worktrees:
   compares tool revisions numerically` selector with `5` assertions in
   `1` case, passed the matching CTest selector, passed
   `git diff --check origin/main...HEAD`, and cleared pre-push gates.
+- `#493` host automation queue worktree
+  `/Users/danielraffel/Code/pulp-format-host-coverage-493-next`,
+  branch `feature/format-host-coverage-493-next`, commit `c3c5cfce`;
+  open as PR `#845`. Scope: test-only coverage for
+  `ParameterEventQueue` sample-offset sorting and clear/reuse lifecycle.
+  Local validation passed the no-GPU/no-examples configure, affected
+  target build, direct `[issue-493]` run, full host-regression binary,
+  focused CTest selector, diff check, skill-sync report, and
+  version-bump report.
+- `#640` audio focus worktree
+  `/Users/danielraffel/Code/pulp-audio-platform-coverage-640-next`,
+  branch `feature/audio-platform-coverage-640-next`, commit
+  `97568e27`; open as PR `#846`. Scope: test-only coverage for
+  `AudioFocusRegistry` token move-assignment replacement, default token
+  reset no-op behavior, and publish-without-subscribers state updates.
+  Local validation passed the no-GPU/no-examples configure, affected
+  target build, direct `[issue-640]` run, full binary, focused CTest,
+  diff checks, skill-sync report, and version-bump report.
+- `#642` events NSD / async helper worktree
+  `/Users/danielraffel/Code/pulp-events-volume-coverage-642-next`,
+  branch `feature/events-volume-coverage-642-next`, commit `8365c969`;
+  open as PR `#847`. Scope: test-only coverage for
+  `LambdaAsyncUpdater` empty-callback processing and
+  `NetworkServiceDiscovery` backend dispatcher / service-name-plus-type
+  keying behavior. Local validation passed the no-GPU/no-examples
+  configure, affected target builds, direct `[issue-642]` runs for
+  events and NSD, full binaries, focused CTest, diff check, skill-sync
+  report, and version-bump report.
+- `#641` runtime Base64 validation worktree
+  `/Users/danielraffel/Code/pulp-runtime-coverage-641-next`, branch
+  `feature/runtime-coverage-641-next`, commits `20626508` and metadata
+  tip `36aa5c71`; open as PR `#848`. Scope: hardens
+  `base64_decode` to reject malformed terminal padding and adds focused
+  runtime coverage for malformed / whitespace-padded input. Local
+  validation passed the no-GPU/no-examples configure, affected target
+  build, direct `[issue-641]` run, full runtime-utils binary, focused
+  CTest, diff check, skill-sync report, and version-bump report with an
+  SDK patch trailer.
+- `#493` view label worktree
+  `/Users/danielraffel/Code/pulp-view-widget-coverage-493-next`, branch
+  `feature/view-widget-coverage-493-next`, commit `7f6deaf6`; open as
+  PR `#849`. Scope: test-only coverage for label text transforms,
+  multiline/decorations, and vertical text-direction transform wrapping.
+  Local validation passed the no-GPU/no-examples configure, widgets
+  target build, full widgets binary, focused selectors, diff check,
+  skill-sync report, and version-bump report.
+- `#643` runner resolver worktree
+  `/Users/danielraffel/Code/pulp-cli-tools-coverage-643-next2`, branch
+  `feature/cli-tools-coverage-643-next2`, commit `b8e7b22a`; open as
+  PR `#850`. Scope: test-only Python coverage for
+  `resolve_runs_on.py` optional Namespace fallback and
+  argument/provider validation branches. Local validation passed the
+  direct Python test suite, compileall, and diff check; local
+  `coverage.py` is not installed in this interpreter.
+- `#645` signal meter guard worktree
+  `/Users/danielraffel/Code/pulp-signal-meter-coverage-645-next`,
+  branch `feature/signal-meter-coverage-645-next`, commits `e53b5152`
+  and metadata tip `ad9c3d81`; open as PR `#851`. Scope: hardens
+  negative/invalid channel-count handling in `MultiChannelMeter` and
+  `MultiChannelBallistics` and adds focused signal meter coverage.
+  Local validation passed the no-GPU/no-examples configure, affected
+  target build, direct `[signal][meter][issue-645]` run, full signal
+  binary, focused CTest, diff check, skill-sync report, and
+  version-bump report with an SDK patch trailer.
 
 Open supporting PR:
 
@@ -823,7 +939,11 @@ Open supporting PR:
   for the Android package parallel temp-dir collision, and `#834` merged,
   and `#840` opened, and `#841` was opened to classify the represented
   but currently uncomponentized `inspect/` Codecov bucket, and `#829`
-  merged, and `#840` was rebased onto `eaf991b0`,
+  merged, and `#840` was rebased onto `eaf991b0`, and `#842` opened to
+  promote `inspect/**` to a first-class Codecov component/tier, and
+  `#843` opened for MPE tracker UMP edge-path coverage, and `#845`,
+  `#846`, `#847`, `#848`, `#849`, `#850`, and `#851` opened from the
+  parallel worker batch,
   and remains docs-only.
 
 Local environment note:
@@ -862,10 +982,22 @@ Next recovery actions:
    fails after dependency bootstrap succeeds, debug in
    `/Users/danielraffel/Code/pulp-events-child-process-coverage-642`,
    patch, validate locally, and push with lease.
-8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+8. Monitor `#842` cloud checks on head `0541fd69`; if a required lane
+   fails, debug in
+   `/Users/danielraffel/Code/pulp-inspect-codecov-component-841`,
+   patch, validate locally, and push with lease.
+9. Monitor `#843` cloud checks on head `fcdbd278`; if a required lane
+   fails, debug in
+   `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
+   patch, validate locally, and push with lease.
+10. Monitor `#845` through `#851`; if a required lane fails, debug in
+   the worktree named in the open-PR list above, patch, validate
+   locally, and push with lease. Pay particular attention to `#848` and
+   `#851` because they include patch-level production hardening.
+11. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+12. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline
@@ -951,14 +1083,13 @@ represented surface.
   shims, and Web/WASM-specific sources, remain outside the measured
   graph unless Phase 2 decides to add focused follow-up issues.
 
-## Represented but not yet componentized
+## Represented inspect surface
 
 - `inspect/` is represented on the Codecov website as a first-party
   top-level bucket (`1,505` lines, `10.10%` in the user-observed
-  snapshot), but it is not currently a named component in `codecov.yml`
-  or a target tier in `ci/coverage-targets.yaml`. This is now tracked by
-  `#841`: either promote `inspect/**` to a first-class component/tier or
-  document it explicitly as represented-but-uncategorized for now.
+  snapshot). It is tracked by `#841`, and PR `#842` promotes
+  `inspect/**` to a first-class Codecov flag/component and assigns it to
+  the existing user-facing coverage tier in `ci/coverage-targets.yaml`.
 
 ## Phase 1 issue map
 
@@ -989,8 +1120,8 @@ represented surface.
   dedicated future lanes
 - `#77` decide and, if in scope, add mobile runtime coverage from
   Android instrumentation and iOS simulator / runtime app paths
-- `#841` classify represented `inspect/**` as either a first-class
-  Codecov component/tier or explicitly represented-but-uncategorized
+- `#841` classify represented `inspect/**` as a first-class Codecov
+  component/tier; implemented by open PR `#842`
 
 ### Supporting infrastructure
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 00:50 EDT
+Last reviewed: 2026-04-26 00:57 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -176,6 +176,22 @@ Open Phase 3 PRs:
   clean; skill sync found no mapped paths; version bump report says no
   bump needed. The PR is labeled `codecov` and is using the direct
   GitHub/Namespace path.
+- `#800` `test(tools): cover version and skill gate helpers`, branch
+  `feature/python-tooling-coverage-643`, commit `acadc5af`, worktree
+  `/Users/danielraffel/Code/pulp-python-tooling-coverage-643`.
+  Scope: deterministic `tools/scripts/test_gates.py` coverage for
+  `version_bump_check.py` version-file readers/writers, semver
+  arithmetic, conventional-commit classification, and `Version-Bump`
+  trailer parsing; plus `skill_sync_check.py` trailer parsing,
+  generated-file filtering, path-map self-check failures, nested
+  `SKILL.md` recognition, and bypass propagation. Local validation:
+  `python3 tools/scripts/test_gates.py` passed with `22` tests;
+  `git diff --check` clean; skill sync found no mapped paths; version
+  bump report says no bump needed. Local `run_python_coverage.py` was not
+  run because this local Python lacks `coverage.py`; the CI coverage
+  workflow installs `coverage>=7.10` before running the Python tooling
+  coverage lane. The PR is labeled `codecov` and is using the direct
+  GitHub/Namespace path.
 
 Local Phase 3 draft worktrees:
 
@@ -208,6 +224,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-cli-docs-coverage-643`, branch
   `feature/cli-docs-coverage-643`, commit `4877cb1b`; open as PR
   `#799`.
+- `#643` Python gate-helper tooling worktree
+  `/Users/danielraffel/Code/pulp-python-tooling-coverage-643`, branch
+  `feature/python-tooling-coverage-643`, commit `acadc5af`; open as PR
+  `#800`.
 
 Open supporting PR:
 
@@ -228,11 +248,11 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795`, `#798`, and `#799` and address any Codecov, build,
-   sanitizer, or Namespace feedback.
-3. If `#795`, `#798`, or `#799` is green but GitHub reports it behind `main`,
-   rebase that branch onto `origin/main`, push with lease, and let
-   checks rerun.
+2. Monitor `#795`, `#798`, `#799`, and `#800` and address any Codecov,
+   build, sanitizer, or Namespace feedback.
+3. If `#795`, `#798`, `#799`, or `#800` is green but GitHub reports it
+   behind `main`, rebase that branch onto `origin/main`, push with lease,
+   and let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -107,62 +107,11 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#765` TextEditor multiline navigation coverage -> `7257a154`
 - `#766` OSC UDP sender/receiver edge coverage -> `31aa80e1`
 - `#771` WidgetBridge extended-controls coverage -> `3d03c0fe`
+- `#777` real CLAP `PluginSlot` coverage -> `478f489c`
+- `#782` VST3 adapter process-path coverage -> `648c2d27`
 
 Open Phase 3 PRs:
 
-- `#777` real CLAP `PluginSlot` coverage, branch
-  `feature/clap-slot-coverage-493`, head `f5f6f47a`. This tranche wires
-  the built PulpGain CLAP bundle into host tests after examples are
-  registered, adds metadata/defaults, bypass/release, and restore-state
-  coverage, and fixes CLAP state restore so restored plugin state
-  supersedes stale cached host edits. After `#771` merged, this branch was
-  rebased onto `origin/main` and duplicate shared support commits were
-  skipped. Local configure/build,
-  `pulp-test-host "[host][slot][clap]"` (`139` assertions / `4` test
-  cases), generated `ClapSlot` CTest entries, whitespace, CI-configured
-  skill-sync, direct disabled-upgrade smoke, focused CLI shellout coverage
-  for `PULP_UPDATE_CHECK_DISABLED`, focused project-bump probe tests
-  (`pulp-test-cli-project-command` now `150` assertions / `10` cases), and
-  version checks are green. The previous Windows Namespace failure was traced
-  to POSIX `/dev/null` redirection inside `pulp project bump` git probes on
-  Windows; the branch now uses Windows-safe `NUL` redirection for those probes
-  and adds tests for the affected paths. The previous diff-coverage failure
-  at `753bcccf` (`63%`) was the shared disabled-update branch in
-  `cmd_upgrade.cpp`; that is covered by the shellout test now present on all
-  active coverage branches. GitHub Actions is rerunning at `f5f6f47a`; no
-  completed failures were visible at the last poll.
-- `#782` VST3 adapter process-path coverage, branch
-  `feature/vst3-adapter-coverage-493`, head `c182ee21`. This tranche adds
-  focused VST3 adapter coverage for parameter metadata, setup/release lifecycle,
-  bus/event/process routing, sidechain visibility, secondary output zeroing,
-  host input automation, plugin-to-host output automation, MIDI output, and
-  transport context mapping. Local `pulp-test-vst3-plugin-state` passed
-  `118` assertions / `5` test cases, and the focused CTest subset passed
-  `5/5`. A broad local `ctest -R "VST3|vst3"` also ran, but it includes
-  `pluginval-*` bundle validation tests and those failed locally because
-  pluginval found zero plugin types in the built VST3 bundles; that is being
-  treated separately from the unit coverage tranche unless it reproduces in
-  CI. The PR is labeled `codecov`. Shipyard local/SSH validation at
-  `bc23956d` passed mac and ubuntu, then hit a Windows SSH bundle-upload
-  timeout during banner exchange. After `#771` merged, this branch was rebased
-  onto `origin/main` and duplicate shared support commits were skipped. Local
-  GPU-off configure/build of
-  `pulp-test-cli-project-command`, focused `pulp-test-vst3-plugin-state`
-  (`118` assertions / `5` test cases), direct disabled-upgrade smoke,
-  focused CLI shellout coverage for `PULP_UPDATE_CHECK_DISABLED`,
-  focused project-bump probe tests (`pulp-test-cli-project-command` now `150`
-  assertions / `10` cases), whitespace, skill-sync, and version checks are
-  green. The `f09adb04` rerun failed the required diff-coverage gate because
-  the shared `cmd_project.cpp` support commit left Windows helper returns,
-  non-standalone `origin/main` fallback, and `--verify-builds` lines uncovered;
-  that shared coverage is now on `main` via `#771`. A later automated review
-  correctly noted that the process-context test set a tempo value without
-  setting VST3's `kTempoValid` bit; `c182ee21` includes that test validity
-  flag, with local `pulp-test-vst3-plugin-state` still green (`118`
-  assertions / `5` test cases). GitHub Actions is rerunning at `c182ee21`.
-  The TSan job failed before tests due a Git checkout partial-pack/RPC
-  disconnect (`curl 18` / bad pack header); rerun failed sanitizer jobs once
-  the sanitizer workflow reaches a terminal state.
 - `#786` render DirtyTracker / RenderLoop edge coverage, branch
   `feature/render-coverage-646-next`, head `49983137`. This tranche extends
   the still-open `#646` render component follow-up after the earlier merged
@@ -230,29 +179,26 @@ Open supporting PR:
 
 Next recovery actions:
 
-1. Poll `#777`, `#782`, and `#786`; merge green PRs manually
+1. Poll `#786` and `#788`; merge green PRs manually
    because auto-merge is disabled.
-2. Let the rebased `#777`, `#782`, and `#786` checks drain at their new heads.
+2. Let `#786`'s macOS Namespace rerun and `#788`'s initial checks drain.
 3. Keep `#644` as the next rebased local draft; open it after the current
    active PR queue has room or if `ship` becomes the next priority.
 4. Keep `#774` docs-only and let its post-`#771` rebase checks drain.
-5. After `#777`, `#782`, and `#786` merge, refresh this section with the next
+5. After `#786` and `#788` merge, refresh this section with the next
    complete Codecov `main` report.
 6. If any Windows Namespace lane fails again, pull the fresh completed-run
    log first and search for `pulp-test-cli-project-command`; the known
    failing tests were the dirty-gate and redundant-origin project-bump cases.
-7. If `#782` still shows TSan failed after the sanitizer workflow completes,
-   rerun failed jobs for run `24929565716`; the observed failure was checkout
-   infrastructure before tests, not a sanitizer report.
-8. If `#786` still shows macOS Namespace failed after the Build and Test
+7. If `#786` still shows macOS Namespace failed after the Build and Test
    workflow completes, rerun failed jobs for run `24929553366`; the observed
    failure was a transient `wgpu-native` download HTTP 502 before tests.
-9. If sandbox-e2e fails again, pull the fresh log first; the expected
+8. If sandbox-e2e fails again, pull the fresh log first; the expected
    failure fixed here was `pulp upgrade --check-only` ignoring
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
-10. If a PR is green but GitHub reports it behind `main`, rebase that
+9. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-11. Continue Phase 3 from the tranche issues below, prioritizing
+10. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -131,24 +131,24 @@ Open Phase 3 PRs:
   expression; CTest was used for the focused multi-test slice. PR is labeled
   `codecov`; GitHub Actions has no failures observed in the current polling
   window and is waiting on Linux Namespace plus Linux coverage to finish.
-
-Local Phase 3 draft not yet opened as a PR:
-- `#644` Android ship/package helper tranche, worktree
-  `/Users/danielraffel/Code/pulp-android-package-coverage-644`, branch
-  `feature/android-package-coverage-644`, local commit `1de9b8e6`. This
-  draft adds a deterministic host-side fake Android SDK/toolchain harness for
+- `#789` Android ship/package helper coverage, branch
+  `feature/android-package-coverage-644`, head `9f14204e`. This tranche
+  adds a deterministic host-side fake Android SDK/toolchain harness for
   `ship/platform/android/package_android.cpp` without requiring a real SDK,
   device, keystore, Gradle install, bundletool, or network access. Scope:
   SDK/build-tools/NDK discovery, fake `zipalign`, fake `apksigner` signing and
   APK verification parsing, fake `jarsigner` AAB signing/verification, fake
   Gradle APK/AAB artifact collection, missing-wrapper/missing-artifact errors,
-  and fake bundletool conversion with optional signing config. Local validation
-  is green: configure in the fresh worktree, `cmake --build build --target
-  pulp-test-android-package -j4`, direct `pulp-test-android-package` (`64`
-  assertions / `7` test cases), focused Android package CTest (`7/7`), adjacent
-  ship CTest slice for Android/appcast/codesign/NSIS (`21/21`), and whitespace.
-  After `#771` merged, this branch was rebased onto `origin/main`; direct
-  `pulp-test-android-package` still passes (`64` assertions / `7` test cases).
+  and fake bundletool conversion with optional signing config. After `#786`
+  merged, this branch was rebased onto `origin/main`, pushed, opened as a PR,
+  and labeled `codecov`. Local validation is green:
+  `cmake --build build --target pulp-test-android-package -j4`, direct
+  `pulp-test-android-package` (`64` assertions / `7` test cases), focused
+  Android package CTest (`7/7`), adjacent ship CTest slice for
+  Android/appcast/codesign/notarization/DMG (`20/20`), and whitespace.
+
+Local Phase 3 draft not yet opened as a PR:
+- none at this update. The former `#644` draft is now open as `#789`.
 
 Open supporting PR:
 
@@ -160,12 +160,13 @@ Open supporting PR:
 
 Next recovery actions:
 
-1. Poll `#788`; merge manually when green because auto-merge is disabled.
+1. Poll `#788` and `#789`; merge manually when green because auto-merge is
+   disabled.
 2. Let `#788`'s Linux Namespace and Linux coverage checks drain.
-3. Keep `#644` as the next rebased local draft; open it after the current
-   active PR queue has room or if `ship` becomes the next priority.
+3. Let `#789`'s initial GitHub Actions checks drain; pull the exact failing
+   job log first if anything turns red.
 4. Keep `#774` docs-only and let its post-`#786` rebase checks drain.
-5. After `#788` merges, refresh this section with the next
+5. After the active code PRs merge, refresh this section with the next
    complete Codecov `main` report.
 6. If any Windows Namespace lane fails again, pull the fresh completed-run
    log first and search for `pulp-test-cli-project-command`; the known

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 21:15 EDT
+Last reviewed: 2026-04-26 21:17 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -66,7 +66,7 @@ Finish line:
 ## Current live state
 
 Latest complete Codecov `main` report observed while updating this doc
-(`main` head `bdc406cc` has a newer Coverage run queued):
+(`main` head `d02c9ec9` has a newer Coverage run queued):
 
 - commit: `5b8e4529cfc553fd98b65f265ed1e9c0487b3d66`
 - workflow: Coverage run `24970413173`, completed successfully
@@ -160,6 +160,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#831` signal utility helper edge coverage -> `b5e7a463`
 - `#836` CLI sync checker Python tooling coverage -> `6ef8ca8b`
 - `#837` package registry validation tools coverage -> `bdc406cc`
+- `#830` RPN parser edge coverage -> `d02c9ec9`
 
 Open Phase 3 PRs:
 
@@ -169,10 +170,6 @@ Open Phase 3 PRs:
   exposed the already-fixed Android SDK discovery regression from the
   stale base. This tranche also uses the GitHub/Namespace path while the
   SSH `windows` target remains unreachable.
-- `#830` RPN parser edge coverage for `#645`, branch
-  `feature/midi-rpn-coverage-645`, head `d1edf1e1`; opened from `main`
-  at `d0262a1b`. This tranche also uses the GitHub/Namespace path while
-  the SSH `windows` target remains unreachable.
 - `#832` platform child-process edge coverage for `#640`, branch
   `feature/platform-child-process-coverage-640`, head `7496ba0a`;
   opened from `main` at `d5efea57`, updated after the first Windows
@@ -691,7 +688,8 @@ Local Phase 3 draft worktrees:
   that incremental build but exited cleanly.
 - `#645` RPN parser worktree
   `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, branch
-  `feature/midi-rpn-coverage-645`, commit `d1edf1e1`; open as PR `#830`.
+  `feature/midi-rpn-coverage-645`, commit `d1edf1e1`; merged via PR
+  `#830` as `d02c9ec9`. The remote branch was deleted after merge.
   Scope: test-only coverage for incomplete selections, unrelated CCs,
   omitted callbacks on otherwise complete RPN/NRPN sequences, and NRPN
   increment/decrement metadata. Local validation: no-GPU/no-examples
@@ -791,6 +789,7 @@ Open supporting PR:
   repaired for the fast-exit deadline review, and `#833` was rebased
   onto `b5e7a463` to clear the stale Android SDK discovery ASan failure,
   and `#836` merged, and `#837` merged, and `#839` opened,
+  and `#830` merged,
   and remains docs-only.
 
 Local environment note:
@@ -813,31 +812,28 @@ Next recovery actions:
 2. Monitor `#829` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, patch,
    validate locally, and push with lease.
-3. Monitor `#830` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, patch,
-   validate locally, and push with lease.
-4. Monitor `#832` cloud checks; if a required lane fails, debug in
+3. Monitor `#832` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
    patch, validate locally, and push with lease.
-5. Monitor `#833` cloud checks; if a required lane fails, debug in
+4. Monitor `#833` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, patch,
    validate locally, and push with lease.
-6. Monitor `#834` cloud checks; if a required lane fails, debug in
+5. Monitor `#834` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-events-loop-coverage-642`, patch,
    validate locally, and push with lease.
-7. Monitor `#835` cloud checks; if a required lane fails, debug in
+6. Monitor `#835` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
    validate locally, and push with lease.
-8. Monitor `#838` cloud checks; if a required lane fails, debug in
+7. Monitor `#838` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, patch,
    validate locally, and push with lease.
-9. Monitor `#839` cloud checks; if a required lane fails, debug in
+8. Monitor `#839` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-render-gpu-graph-coverage-646`,
    patch, validate locally, and push with lease.
-10. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+9. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-11. Continue Phase 3 from the tranche issues below, prioritizing
+10. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 00:19 EDT
+Last reviewed: 2026-04-26 00:50 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -126,7 +126,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#795` `test(events): cover volume detector lifecycle edges`, branch
-  `feature/events-volume-coverage-642`, commit `ab941cd9`, worktree
+  `feature/events-volume-coverage-642`, commit `2d684f4b`, worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`.
   Scope: deterministic `test/test_network_service_discovery.cpp`
   coverage for `NetworkServiceDiscovery` backend removal, cached-service
@@ -134,20 +134,20 @@ Open Phase 3 PRs:
   `MountedVolumeListChangeDetector` mounted-volume snapshot plus
   start/restart/stop lifecycle paths, and
   `LockingAsyncUpdater::trigger_and_wait()`. Local validation:
+  after rebasing onto current `origin/main`,
   `pulp-test-network-service-discovery` passed with `43` assertions in
-  `10` test cases; focused CTest
-  `NSD|MountedVolume|LockingAsyncUpdater|service-discovery|volume`
-  passed `10/10`; `git diff --check` clean. After the first CI pass, the
-  Windows Namespace lane exposed an unavailable-drive exception from
-  `std::filesystem::exists("E:\\")`; the latest fix keeps the guard on a
-  coverage-visible source line via `PULP_VOLUME_EXISTS(drive)`. A local
-  replay of the failed CI merged Cobertura artifact now reports `85.7%`
-  diff coverage for `core/events/src/volume_detector.cpp`, above the
-  required `75%` gate. GitHub checks were rerunning on `ab941cd9` with no
-  failures at the last poll. The PR is labeled `codecov` and is using the
-  direct GitHub/Namespace path instead of `shipyard pr` because `#794`
-  exposed a local Shipyard mac configure stall after GitHub/Namespace was
-  already clean.
+  `10` test cases; focused CTest `NSD|MountedVolume|LockingAsyncUpdater`
+  passed `10/10`; `git diff --check` clean; skill sync found no mapped
+  paths; version bump report says no bump needed. The earlier
+  `core/events/src/volume_detector.cpp` Windows guard was removed from the
+  final PR diff because the Windows coverage XML reports that translation
+  unit at `0%` even though the CTest cases run and pass there. The final
+  PR diff is test-only, and the mounted-volume enumeration tests skip on
+  Windows while retaining POSIX coverage. GitHub checks were rerunning on
+  `2d684f4b` with no failures at the last poll. The PR is labeled
+  `codecov` and is using the direct GitHub/Namespace path instead of
+  `shipyard pr` because `#794` exposed a local Shipyard mac configure
+  stall after GitHub/Namespace was already clean.
 - `#798` `test(audio): cover format registry dispatch paths`, branch
   `feature/audio-format-registry-coverage-640`, commit `0b35bb83`,
   worktree
@@ -163,6 +163,19 @@ Open Phase 3 PRs:
   report says no bump needed.
   The PR is labeled `codecov` and is using the same direct
   GitHub/Namespace path as `#795`.
+- `#799` `test(cli): cover docs shellout reader paths`, branch
+  `feature/cli-docs-coverage-643`, commit `4877cb1b`, worktree
+  `/Users/danielraffel/Code/pulp-cli-docs-coverage-643`.
+  Scope: deterministic `test/test_cli_shellout.cpp` coverage for
+  `pulp docs` local reader usage, index, open, search, support/command/
+  CMake/style `show` paths, and error diagnostics. Local validation:
+  `pulp-cli` and `pulp-test-cli-shellout` built successfully; direct
+  Catch2 tag run `[cli][shellout][docs][issue-643]` passed with `38`
+  assertions in `1` test case; focused CTest
+  `pulp docs covers local reader` passed `1/1`; `git diff --check`
+  clean; skill sync found no mapped paths; version bump report says no
+  bump needed. The PR is labeled `codecov` and is using the direct
+  GitHub/Namespace path.
 
 Local Phase 3 draft worktrees:
 
@@ -191,6 +204,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-audio-system-volume-coverage-640`,
   branch `feature/audio-format-registry-coverage-640`, commit
   `0b35bb83`; open as PR `#798`.
+- `#643` docs-reader CLI/tools worktree
+  `/Users/danielraffel/Code/pulp-cli-docs-coverage-643`, branch
+  `feature/cli-docs-coverage-643`, commit `4877cb1b`; open as PR
+  `#799`.
 
 Open supporting PR:
 
@@ -211,9 +228,9 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795` and `#798` and address any Codecov, build,
+2. Monitor `#795`, `#798`, and `#799` and address any Codecov, build,
    sanitizer, or Namespace feedback.
-3. If `#795` or `#798` is green but GitHub reports it behind `main`,
+3. If `#795`, `#798`, or `#799` is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 20:53 EDT
+Last reviewed: 2026-04-26 21:01 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -182,9 +182,11 @@ Open Phase 3 PRs:
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
 - `#833` signal filter-design edge coverage for `#645`, branch
-  `feature/signal-biquad-coverage-645`, head `740bdc9c`; opened from
-  `main` at `87ef6d90`. This tranche also uses the GitHub/Namespace
-  path while the SSH `windows` target remains unreachable.
+  `feature/signal-biquad-coverage-645`, head `e3795fca`; opened from
+  `main` at `87ef6d90`, then rebased onto `b5e7a463` after the ASan
+  lane failed in the already-fixed Android SDK discovery regression
+  from the stale base. This tranche also uses the GitHub/Namespace path
+  while the SSH `windows` target remains unreachable.
 - `#834` events event-loop lifecycle edge coverage for `#642`, branch
   `feature/events-loop-coverage-642`, head `ee3894cb`; opened from
   `main` at `87ef6d90`. This tranche also uses the GitHub/Namespace
@@ -731,7 +733,7 @@ Local Phase 3 draft worktrees:
   deadline was resolved.
 - `#645` signal filter-design worktree
   `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, branch
-  `feature/signal-biquad-coverage-645`, commit `740bdc9c`; open as PR
+  `feature/signal-biquad-coverage-645`, commit `e3795fca`; open as PR
   `#833`.
   Scope: test-only coverage for peaking boost/cut coefficients, low/high
   shelf cut paths, shelf slope variants, and Butterworth empty/high-order
@@ -742,6 +744,12 @@ Local Phase 3 draft worktrees:
   assertions in `3` cases, full binary passed `116` assertions in `14`
   cases, focused CTest passed `14/14`, `git diff --check HEAD~1..HEAD`,
   `git diff --check`, skill-sync report, and version-bump report.
+  Follow-up validation after rebasing onto `b5e7a463` passed the same
+  focused filter-design build/direct/CTest checks, built
+  `pulp-test-android-package`, passed the direct `Android SDK discovery
+  compares tool revisions numerically` selector with `5` assertions in
+  `1` case, passed the matching CTest selector, passed
+  `git diff --check origin/main...HEAD`, and cleared pre-push gates.
 
 Open supporting PR:
 
@@ -764,7 +772,9 @@ Open supporting PR:
   merged, and `#835` opened, and `#836` opened, and `#837` opened, and
   `#831` merged, and `#838` opened, and `#835` was repaired for Linux
   Android-validation ordering plus config isolation, and `#832` was
-  repaired for the fast-exit deadline review, and remains docs-only.
+  repaired for the fast-exit deadline review, and `#833` was rebased
+  onto `b5e7a463` to clear the stale Android SDK discovery ASan failure,
+  and remains docs-only.
 
 Local environment note:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 23:51 EDT
+Last reviewed: 2026-04-26 00:10 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -125,7 +125,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#795` `test(events): cover volume detector lifecycle edges`, branch
-  `feature/events-volume-coverage-642`, commit `c33133e9`, worktree
+  `feature/events-volume-coverage-642`, commit `ab941cd9`, worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`.
   Scope: deterministic `test/test_network_service_discovery.cpp`
   coverage for `NetworkServiceDiscovery` backend removal, cached-service
@@ -138,13 +138,15 @@ Open Phase 3 PRs:
   `NSD|MountedVolume|LockingAsyncUpdater|service-discovery|volume`
   passed `10/10`; `git diff --check` clean. After the first CI pass, the
   Windows Namespace lane exposed an unavailable-drive exception from
-  `std::filesystem::exists("E:\\")`; commit `c33133e9` fixes
-  `MountedVolumeListChangeDetector::get_mounted_volumes()` to use
-  non-throwing filesystem overloads for platform volume enumeration.
-  GitHub Versioning & Skill-Sync passed on `c33133e9`. The PR is labeled
-  `codecov` and is using the direct GitHub/Namespace path instead of
-  `shipyard pr` because `#794` exposed a local Shipyard mac configure
-  stall after GitHub/Namespace was already clean.
+  `std::filesystem::exists("E:\\")`; the latest fix keeps the guard on a
+  coverage-visible source line via `PULP_VOLUME_EXISTS(drive)`. A local
+  replay of the failed CI merged Cobertura artifact now reports `85.7%`
+  diff coverage for `core/events/src/volume_detector.cpp`, above the
+  required `75%` gate. GitHub checks were rerunning on `ab941cd9` with no
+  failures at the last poll. The PR is labeled `codecov` and is using the
+  direct GitHub/Namespace path instead of `shipyard pr` because `#794`
+  exposed a local Shipyard mac configure stall after GitHub/Namespace was
+  already clean.
 - `#797` `test(audio): cover streaming WAV writer edges`, branch
   `feature/audio-streaming-writer-coverage-640`, commit `29a3f26d`,
   worktree
@@ -186,7 +188,7 @@ Local Phase 3 draft worktrees:
   `c4e6ad09`. The remote branch was deleted after merge.
 - `#642` events volume/service-discovery worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`, branch
-  `feature/events-volume-coverage-642`, commit `c33133e9`; open as PR
+  `feature/events-volume-coverage-642`, commit `ab941cd9`; open as PR
   `#795`.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:42 EDT
+Last reviewed: 2026-04-26 19:49 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -164,9 +164,11 @@ Open Phase 3 PRs:
   the GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
 - `#829` MIDI-CI edge coverage for `#645`, branch
-  `feature/midi-ci-coverage-645`, head `f0ef6b0f`; opened from `main`
-  at `94e3ef2a`. This tranche also uses the GitHub/Namespace path while
-  the SSH `windows` target remains unreachable.
+  `feature/midi-ci-coverage-645`, head `1d3cd1ce`; opened from `main`
+  at `94e3ef2a` and rebased onto `87ef6d90` after the first ASan run
+  exposed the already-fixed Android SDK discovery regression from the
+  stale base. This tranche also uses the GitHub/Namespace path while the
+  SSH `windows` target remains unreachable.
 - `#830` RPN parser edge coverage for `#645`, branch
   `feature/midi-rpn-coverage-645`, head `d1edf1e1`; opened from `main`
   at `d0262a1b`. This tranche also uses the GitHub/Namespace path while
@@ -551,7 +553,7 @@ Local Phase 3 draft worktrees:
   transport helper despite living under `include`.
 - `#645` MIDI-CI worktree
   `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, branch
-  `feature/midi-ci-coverage-645`, commit `f0ef6b0f`; open as PR `#829`.
+  `feature/midi-ci-coverage-645`, commit `1d3cd1ce`; open as PR `#829`.
   Scope: test-only coverage for profile inquiry destination encoding,
   malformed and unhandled CI messages, discovery inquiry destination
   filtering, discovery reply storage plus callback dispatch, unknown
@@ -560,7 +562,11 @@ Local Phase 3 draft worktrees:
   `pulp-test-midi-ci` build, direct `[issue-645]` run passed `38`
   assertions in `6` cases, full binary passed `65` assertions in `15`
   cases, focused CTest passed `6/6`, `git diff --check`, skill-sync
-  report, and version-bump report.
+  report, and version-bump report. Rebase recovery validation on
+  2026-04-26 after `#822` merged also passed the build, direct/full
+  binary runs, diff whitespace checks, skill-sync report, and
+  version-bump report; the focused CTest pattern found no local tests in
+  that incremental build but exited cleanly.
 - `#645` RPN parser worktree
   `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, branch
   `feature/midi-rpn-coverage-645`, commit `d1edf1e1`; open as PR `#830`.
@@ -634,7 +640,8 @@ Open supporting PR:
   `#830` opened, `#831` opened, `#827` merged, `#832` opened, `#826`
   merged, and `#832` was repaired for Windows cmd portability, and
   `#831` was repaired for Windows float tolerance, and `#822` merged,
-  and `#833` opened, and remains docs-only.
+  and `#833` opened, and `#829` was rebased onto `87ef6d90` to pick up
+  the merged Android SDK discovery fix, and remains docs-only.
 
 Local environment note:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:28 EDT
+Last reviewed: 2026-04-26 19:30 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -152,6 +152,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#823` platform helper edge coverage -> `f69338eb`
 - `#824` signal math helper coverage and Mat3 fix -> `94e3ef2a`
 - `#825` signal DSP helper edge coverage -> `d0262a1b`
+- `#826` OGG reader edge coverage -> `6ae4d487`
 - `#827` signal multi-channel meter edge coverage -> `d5efea57`
 
 Open Phase 3 PRs:
@@ -165,10 +166,6 @@ Open Phase 3 PRs:
   branch now compares Android build-tools and NDK revisions numerically.
   This tranche also uses the GitHub/Namespace path while the SSH
   `windows` target remains unreachable.
-- `#826` OGG reader edge coverage for `#640`, branch
-  `feature/audio-ogg-reader-coverage-640`, head `6b721c22`; opened from
-  `main` at `1a1b7f07`. This tranche also uses the GitHub/Namespace path
-  while the SSH `windows` target remains unreachable.
 - `#828` raw MIDI parser edge coverage and malformed-data hardening for
   `#645`, branch `feature/midi-raw-parser-coverage-645`, head
   `4e2e6092`; opened from `main` at `94e3ef2a`. This tranche also uses
@@ -512,7 +509,8 @@ Local Phase 3 draft worktrees:
 - `#640` OGG reader worktree
   `/Users/danielraffel/Code/pulp-audio-ogg-reader-coverage-640`,
   branch `feature/audio-ogg-reader-coverage-640`, commit `6b721c22`;
-  open as PR `#826`.
+  merged via PR `#826` as `6ae4d487`. The remote branch was deleted
+  after merge.
   Scope: dedicated `pulp-test-ogg-reader` target covering direct OGG
   reader factory construction, `.ogg` / `.oga` extension support,
   unsupported extension behavior, format-name reporting, and
@@ -616,8 +614,8 @@ Open supporting PR:
   merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
   repaired again for Android SDK discovery, `#827` opened, `#823`
   merged, `#824` merged, `#828` opened, `#829` opened, `#825` merged,
-  `#830` opened, `#831` opened, `#827` merged, and `#832` opened, and
-  remains docs-only.
+  `#830` opened, `#831` opened, `#827` merged, `#832` opened, and
+  `#826` merged, and remains docs-only.
 
 Local environment note:
 
@@ -639,28 +637,25 @@ Next recovery actions:
 2. Monitor `#822` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
    patch, validate locally, and push with lease.
-3. Monitor `#826` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-audio-ogg-reader-coverage-640`,
-   patch, validate locally, and push with lease.
-4. Monitor `#828` cloud checks; if a required lane fails, debug in
+3. Monitor `#828` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-raw-parser-coverage-645`, patch,
    validate locally, and push with lease.
-5. Monitor `#829` cloud checks; if a required lane fails, debug in
+4. Monitor `#829` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, patch,
    validate locally, and push with lease.
-6. Monitor `#830` cloud checks; if a required lane fails, debug in
+5. Monitor `#830` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, patch,
    validate locally, and push with lease.
-7. Monitor `#831` cloud checks; if a required lane fails, debug in
+6. Monitor `#831` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, patch,
    validate locally, and push with lease.
-8. Monitor `#832` cloud checks; if a required lane fails, debug in
+7. Monitor `#832` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
    patch, validate locally, and push with lease.
-9. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-10. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 15:39 EDT
+Last reviewed: 2026-04-26 15:53 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -152,11 +152,18 @@ Open Phase 3 PRs:
 - `#815` MPE tracker edge-path coverage for `#645`, branch
   `feature/mpe-tracker-coverage-645`, head `b7c72711`; opened from
   `main` at `957a0735`. Windows coverage failed during dependency
-  bootstrap on a `wgpu-native` 502; rerun the failed coverage job after
-  the still-queued macOS coverage job lets the workflow finish.
+  bootstrap on a `wgpu-native` 502; the failed coverage jobs were rerun,
+  and the rerun passed dependency bootstrap and is now in the Windows
+  coverage suite.
 - `#816` MIDI running-status parser edge coverage for `#645`, branch
   `feature/midi-running-status-coverage-645`, head `94b93a6e`; opened
   from `main` at `957a0735`. Cloud checks are the active gate.
+- `#817` UMP conversion edge coverage for `#645`, branch
+  `feature/midi-ump-conversion-coverage-645`, head `c4420370`; opened
+  from `main` at `957a0735`. `shipyard pr` was attempted first but
+  stopped before PR creation because the SSH `windows` backend timed
+  out, so this tranche is using the GitHub/Namespace path instead of
+  skipping that lane.
 
 Local Phase 3 draft worktrees:
 
@@ -306,6 +313,22 @@ Local Phase 3 draft worktrees:
   cases, full binary passed `56` assertions in `14` cases, focused CTest
   selection passed `5/5`, `git diff --check`, skill-sync report, and
   version-bump report.
+- `#645` MIDI UMP conversion worktree
+  `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
+  branch `feature/midi-ump-conversion-coverage-645`, commit `c4420370`;
+  open as PR `#817`.
+  Scope: test-only coverage for velocity-zero note-on aliasing,
+  program-change fallback packets, group masking, sample-offset
+  preservation, MIDI 2 edge-value down-conversion, skipped packets
+  without MIDI 1 equivalents, and scale endpoint preservation. Local
+  validation: no-GPU/no-examples configure, `pulp-test-ump-buffer-
+  conversion` build, direct `[midi][ump][issue-645]` passed `46`
+  assertions in `4` cases, full binary passed `97` assertions in `15`
+  cases, focused CTest conversion selection passed `6/6`,
+  `git diff --check`, skill-sync report, and version-bump report. A
+  broader CTest regex was intentionally not used for the final summary
+  because the lite build exposes `*_NOT_BUILT_*` placeholder tests that
+  match generic `ump` patterns.
 
 Open supporting PR:
 
@@ -322,6 +345,12 @@ Local environment note:
   `shipyard, version 0.50.0`; rerunning `./tools/install-shipyard.sh`
   restored the pinned binary, and `shipyard --version` prints
   `shipyard, version 0.46.0`.
+- On 2026-04-26, `shipyard pr` for the UMP conversion tranche failed
+  pre-PR with exit code `3` because the SSH `windows` target timed out
+  (`100.92.174.43:22`). For this Codecov batch, continue using the
+  GitHub Actions / Namespace checks rather than spending time on the
+  unreachable SSH backend, unless the user explicitly asks to repair the
+  SSH target.
 
 Next recovery actions:
 
@@ -331,16 +360,19 @@ Next recovery actions:
    patch, validate locally, and push with lease.
 3. Monitor `#815` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, patch,
-   validate locally, and push with lease. For the current Windows
-   coverage 502 failure, prefer rerunning failed jobs after run
-   `24965100026` completes before changing code.
+   validate locally, and push with lease. The current Windows coverage
+   failure was rerun in run `24965100026`; wait for that rerun result
+   before changing code.
 4. Monitor `#816` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-running-status-coverage-645`,
    patch, validate locally, and push with lease.
-5. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+5. Monitor `#817` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
+   patch, validate locally, and push with lease.
+6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-6. Continue Phase 3 from the tranche issues below, prioritizing
+7. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:25 EDT
+Last reviewed: 2026-04-26 19:28 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -186,6 +186,11 @@ Open Phase 3 PRs:
   `feature/signal-utility-coverage-645`, head `d021a35c`; opened from
   `main` at `d0262a1b`. This tranche also uses the GitHub/Namespace path
   while the SSH `windows` target remains unreachable.
+- `#832` platform child-process edge coverage for `#640`, branch
+  `feature/platform-child-process-coverage-640`, head `3018c8d5`;
+  opened from `main` at `d5efea57`. This tranche also uses the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -585,6 +590,19 @@ Local Phase 3 draft worktrees:
   `74` cases, full v3 gaps binary passed `131` assertions in `27` cases,
   focused CTest passed `6/6`, `git diff --check`, skill-sync report, and
   version-bump report.
+- `#640` platform child-process worktree
+  `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
+  branch `feature/platform-child-process-coverage-640`, commit
+  `3018c8d5`; open as PR `#832`.
+  Scope: test-only coverage for pre-start wait/read defaults,
+  working-directory launch, stdout/stderr max-output byte caps,
+  stderr-line callbacks, and fast-exit output preservation after
+  `is_running()` observes process completion. Local validation:
+  no-GPU/no-examples configure, `pulp-test-child-process` build, direct
+  `[issue-640]` run passed `25` assertions in `5` cases, full binary
+  passed `46` assertions in `17` cases, focused CTest passed `5/5`,
+  `git diff --check HEAD~1..HEAD`, `git diff --check`, skill-sync
+  report, and version-bump report.
 
 Open supporting PR:
 
@@ -598,8 +616,8 @@ Open supporting PR:
   merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
   repaired again for Android SDK discovery, `#827` opened, `#823`
   merged, `#824` merged, `#828` opened, `#829` opened, `#825` merged,
-  `#830` opened, `#831` opened, and `#827` merged, and remains
-  docs-only.
+  `#830` opened, `#831` opened, `#827` merged, and `#832` opened, and
+  remains docs-only.
 
 Local environment note:
 
@@ -636,10 +654,13 @@ Next recovery actions:
 7. Monitor `#831` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, patch,
    validate locally, and push with lease.
-8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+8. Monitor `#832` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
+   patch, validate locally, and push with lease.
+9. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+10. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 22:14 EDT
+Last reviewed: 2026-04-25 22:36 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -116,15 +116,22 @@ Merged after the Phase 1 closeout / `#723` baseline:
 
 Open Phase 3 PRs:
 
-- None at this checkpoint. `#793` was merged manually after GitHub
-  required checks were clean. Shipyard validation did not merge it because
-  mac passed, ubuntu failed in a full examples-enabled build when linker
-  processes were killed near the end of the build, and windows failed before
-  validation with a bundle-apply infra error
-  (`could not open C:/Users/danielraffel/shipyard.bundle`).
+- `#794` `test(audio): cover AIFF reader edge paths`, branch
+  `feature/audio-aiff-coverage-640`, commit `f3414ae9`, worktree
+  `/Users/danielraffel/Code/pulp-audio-aiff-coverage-640`.
+  Scope: deterministic `test/test_audio_file.cpp` coverage for AIFC
+  metadata, odd unknown-chunk padding, 8/24/32-bit AIFF PCM decode,
+  malformed SSND skip, and truncated payload rejection. Local validation:
+  `pulp-test-audio-file` passed with `231` assertions in `15` test cases;
+  focused CTest `AIFF|audio.*file|FormatRegistry` passed `8/8`;
+  `git diff --check` clean; version bump report says no bump needed.
+  `shipyard pr` opened the PR and validation is in progress.
 
 Local Phase 3 draft worktrees:
 
+- `#640` AIFF reader edge-path worktree
+  `/Users/danielraffel/Code/pulp-audio-aiff-coverage-640`, branch
+  `feature/audio-aiff-coverage-640`, commit `f3414ae9`; open as PR `#794`.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
   `feature/package-registry-coverage-643`, commit `75a529ef`; merged via
@@ -148,10 +155,11 @@ Local environment note:
 
 Next recovery actions:
 
-1. Keep `#774` docs-only and let its post-`#793` status-update checks drain.
-2. If a new PR is green but GitHub reports it behind `main`, rebase that
+1. Keep `#774` docs-only and let its latest status-update checks drain.
+2. Monitor `#794` and address any Codecov, build, or Shipyard feedback.
+3. If a new PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-3. Continue Phase 3 from the tranche issues below, prioritizing
+4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 17:28 EDT
+Last reviewed: 2026-04-26 17:41 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -175,6 +175,11 @@ Open Phase 3 PRs:
   `feature/platform-helper-coverage-640`, head `6ec4ff2e`; opened from
   `main` at `3d4560d1`. This tranche also uses the GitHub/Namespace path
   while the SSH `windows` target remains unreachable.
+- `#824` signal math helper coverage and Mat3 multiplication fix for
+  `#645`, branch `feature/signal-math-helper-coverage-645`, head
+  `1b7f1cfd`; opened from `main` at `a38216fd`. This tranche also uses
+  the GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -447,6 +452,26 @@ Local Phase 3 draft worktrees:
   cases, full audio-excerpt binary passed `33` assertions in `5` cases,
   focused CTest passed `9/9`, `git diff --check`, skill-sync report, and
   version-bump report.
+- `#645` signal math helper worktree
+  `/Users/danielraffel/Code/pulp-signal-math-helper-coverage-645`,
+  branch `feature/signal-math-helper-coverage-645`, commits `b304e0f4`
+  and metadata tip `1b7f1cfd`; open as PR `#824`.
+  Scope: fixes `Mat3::operator*` so multiplication accumulates into a
+  zero matrix instead of adding the product onto the identity default,
+  and adds coverage for polynomial empty/constant helpers, empty
+  polynomial add, singular `Mat2` inverse, non-identity `Mat3`
+  multiplication, FastMath large-phase wrapping and guard inputs,
+  Gain linear buffer processing, SimpleMixer clamp/buffer paths, and
+  special-function wrappers. The metadata tip records
+  `Version-Bump: sdk=patch` because this is an inline public-header bug
+  fix without an SDK API signature change. Local validation:
+  no-GPU/no-examples configure, `pulp-test-poly-math`,
+  `pulp-test-fast-math`, `pulp-test-signal`, and
+  `pulp-test-dsp-enhancements` builds, direct issue-645 slices passed
+  `30`, `11`, `128`, and `39` assertions respectively, full binaries
+  passed `62`, `55`, `895`, and `71` assertions respectively, focused
+  CTest passed `11/11`, `git diff --check`, skill-sync report, and
+  version-bump report.
 
 Open supporting PR:
 
@@ -456,7 +481,8 @@ Open supporting PR:
   The branch has been rebased onto `origin/main` after `#813` merged,
   updated after `#816` merged, `#817` was repaired, `#820` opened,
   `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
-  merged, and `#822` was repaired, and remains docs-only.
+  merged, `#822` was repaired, and `#824` opened, and remains
+  docs-only.
 
 Local environment note:
 
@@ -490,10 +516,13 @@ Next recovery actions:
 6. Monitor `#823` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-helper-coverage-640`, patch,
    validate locally, and push with lease.
-7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+7. Monitor `#824` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-signal-math-helper-coverage-645`,
+   patch, validate locally, and push with lease.
+8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-8. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 20:50 EDT
+Last reviewed: 2026-04-26 20:53 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -172,13 +172,15 @@ Open Phase 3 PRs:
   at `d0262a1b`. This tranche also uses the GitHub/Namespace path while
   the SSH `windows` target remains unreachable.
 - `#832` platform child-process edge coverage for `#640`, branch
-  `feature/platform-child-process-coverage-640`, head `c07dd268`;
+  `feature/platform-child-process-coverage-640`, head `7496ba0a`;
   opened from `main` at `d5efea57`, updated after the first Windows
   Namespace run exposed a cmd/PowerShell portability issue in the test
   commands, then rebased onto `87ef6d90` and updated after Windows
-  exposed the fast-exit no-newline `cmd` probe returning nonzero. This
-  tranche also uses the GitHub/Namespace path while the SSH `windows`
-  target remains unreachable.
+  exposed the fast-exit no-newline `cmd` probe returning nonzero, then
+  rebased onto `b5e7a463` and updated after review flagged a fixed
+  100ms fast-exit deadline. This tranche also uses the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
 - `#833` signal filter-design edge coverage for `#645`, branch
   `feature/signal-biquad-coverage-645`, head `740bdc9c`; opened from
   `main` at `87ef6d90`. This tranche also uses the GitHub/Namespace
@@ -702,7 +704,8 @@ Local Phase 3 draft worktrees:
 - `#640` platform child-process worktree
   `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
   branch `feature/platform-child-process-coverage-640`, commits
-  `3018c8d5`, `a361c8b9`, and `c07dd268`; open as PR `#832`.
+  `3018c8d5`, `a361c8b9`, `c07dd268`, and `7496ba0a`; open as PR
+  `#832`.
   Scope: test-only coverage for pre-start wait/read defaults,
   working-directory launch, stdout/stderr max-output byte caps,
   stderr-line callbacks, and fast-exit output preservation after
@@ -710,13 +713,22 @@ Local Phase 3 draft worktrees:
   removed a PowerShell dependency and trims stderr callback comparisons
   so the test is resilient to `cmd` redirection spacing on Windows; the
   second follow-up forces the fast-exit Windows `cmd` probe to exit zero
-  while still proving no-newline cached output is preserved.
+  while still proving no-newline cached output is preserved. The third
+  follow-up replaces the fixed 100ms fast-exit polling loop with a 5s
+  deadline so loaded/virtualized runners do not fail before normal
+  process launch/teardown completes.
   Local validation: no-GPU/no-examples configure,
   `pulp-test-child-process` build, direct `[issue-640]` run passed `25`
   assertions in `5` cases, full binary passed `46` assertions in `17`
   cases, focused CTest passed for the fast-exit case,
   `git diff --check HEAD~1..HEAD`, `git diff --check`, skill-sync
   report, and version-bump report after rebasing onto `87ef6d90`.
+  Follow-up validation after rebasing onto `b5e7a463` passed the focused
+  fast-exit test with `4` assertions, the `[issue-640]` slice with `25`
+  assertions in `5` cases, the full child-process binary with `46`
+  assertions in `17` cases, diff check, skill-sync report, version-bump
+  report, and pre-push gates. The Codex review thread on the fast-exit
+  deadline was resolved.
 - `#645` signal filter-design worktree
   `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, branch
   `feature/signal-biquad-coverage-645`, commit `740bdc9c`; open as PR
@@ -751,8 +763,8 @@ Open supporting PR:
   for the Windows fast-exit command, and `#834` opened, and `#828`
   merged, and `#835` opened, and `#836` opened, and `#837` opened, and
   `#831` merged, and `#838` opened, and `#835` was repaired for Linux
-  Android-validation ordering plus config isolation, and remains
-  docs-only.
+  Android-validation ordering plus config isolation, and `#832` was
+  repaired for the fast-exit deadline review, and remains docs-only.
 
 Local environment note:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 19:52 EDT
+Last reviewed: 2026-04-25 20:16 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -140,7 +140,11 @@ Open Phase 3 PRs:
   required lanes but Linux Build/Test and Linux Coverage remained in their
   long test/coverage steps, matching a likely blocking-`accept()` cleanup hang.
   The targeted `9e73a084` fix was pushed after local IPC validation stayed
-  green, and fresh checks are now running on that head.
+  green. As of 2026-04-25 20:16 EDT, Build/Test is green on Linux,
+  macOS, and Windows; sanitizer lanes are green or skipped as expected;
+  Android build, IWYU, macOS coverage, and Windows coverage are green.
+  The only remaining required check is Linux coverage, still in the
+  `Run coverage suite` step after roughly 31 minutes.
 
 Local Phase 3 draft not yet opened as a PR:
 - `#643` package-registry CLI/tools draft, worktree
@@ -179,8 +183,7 @@ Local environment note:
 Next recovery actions:
 
 1. Poll `#788`; merge manually when green because auto-merge is disabled.
-2. Let `#788`'s fresh full Build/Test and Coverage workflows on `9e73a084`
-   drain.
+2. Let `#788`'s final Linux coverage job on `9e73a084` drain.
 3. Keep `#774` docs-only and let its post-`#789` rebase checks drain.
 4. After `#788` merges, refresh this section with the next
    complete Codecov `main` report.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-27 00:04 EDT
+Last reviewed: 2026-04-27 00:16 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -360,6 +360,40 @@ jobs rather than code failures.
   `feature/web-compat-coverage-641-next`, head `393e841f`; covers
   compound selector matching, child vs descendant combinators, and nested
   `querySelector` / `querySelectorAll` traversal.
+- `#885` state `PropertiesFile` helper coverage for parent `#641`,
+  branch `feature/state-properties-coverage-641-next`, head `dcf00b53`;
+  covers invalid numeric conversion, loading an empty file over stale
+  values, and save-without-path failure.
+- `#886` iOS audio-session label coverage for parent `#641`, branch
+  `feature/ios-runtime-coverage-641-next`, head `5f266fd5`; covers
+  secondary-audio silence event labels and unknown event fallback in
+  `to_string()`.
+- `#887` ship appcast helper coverage for parent `#641`, branch
+  `feature/ship-helper-coverage-641-next2`, head `fb9cee78`; covers
+  Sparkle signature XML emission and malformed-item parse behavior.
+- `#888` tools skill-sync helper coverage for `#643`, branch
+  `feature/tools-helper-coverage-643-next7`, head `e13c227b`; covers
+  `skill_sync_check.py` config loading, skill-map parsing, SKILL.md
+  enforcement, and report / hint rendering modes.
+- `#889` MIDI UMP packet helper coverage for parent `#641`, branch
+  `feature/midi-osc-helper-coverage-641-next`, head `d29cc79b`; covers
+  UMP packet factory masking for groups, channels, notes, and data
+  fields.
+- `#890` view accessibility-tree range coverage for `#493`, branch
+  `feature/view-accessibility-coverage-493-next4`, head `b2dc5c38`;
+  covers nested accessibility snapshot traversal plus
+  `AccessibilityValueInterface` range metadata and value-string capture.
+- `#891` Android accessibility delegate coverage for parent `#641`,
+  branch `feature/android-helper-coverage-641-next2`, head `2312fdfd`;
+  covers accessibility event class-name initialization and action
+  fallback when the native bridge is unavailable. Local Gradle execution
+  was blocked by a missing Java runtime, so hosted Android JVM CI is the
+  first executable validation for this tranche; pre-push gates are clean
+  and the branch carries `Skill-Update: skip skill=android`.
+- `#892` image-cache failure-edge coverage for `#646` / parent `#641`,
+  branch `feature/render-image-coverage-646-next4`, head `248f6cfc`;
+  covers decode failures not being cached and oversized decoded entries
+  being released / discarded when over the byte budget.
 
 Local-only queued work:
 
@@ -376,26 +410,21 @@ Local-only queued work:
   test-only target `pulp-test-ipc-endpoints` for deterministic IPC
   socket endpoint parse failures. Review CMake overlap with open `#857`
   before opening a PR.
-- Active worker: state/properties helper coverage worktree
-  `/Users/danielraffel/Code/pulp-state-properties-coverage-641-next`,
-  branch `feature/state-properties-coverage-641-next`; no commit reported
+- Active worker: audio edge/helper coverage worktree
+  `/Users/danielraffel/Code/pulp-audio-edge-coverage-640-next6`, branch
+  `feature/audio-edge-coverage-640-next6`; no commit reported yet.
+- Active worker: runtime crypto / i18n helper coverage worktree
+  `/Users/danielraffel/Code/pulp-runtime-helper-coverage-641-next5`,
+  branch `feature/runtime-helper-coverage-641-next5`; no commit reported
   yet.
-- Active worker: iOS/mobile runtime helper coverage worktree
-  `/Users/danielraffel/Code/pulp-ios-runtime-coverage-641-next`, branch
-  `feature/ios-runtime-coverage-641-next`; no commit reported yet.
-- Active worker: ship helper coverage worktree
-  `/Users/danielraffel/Code/pulp-ship-helper-coverage-641-next2`, branch
-  `feature/ship-helper-coverage-641-next2`; no commit reported yet.
-- Active worker: MIDI / OSC helper coverage worktree
-  `/Users/danielraffel/Code/pulp-midi-osc-helper-coverage-641-next`,
-  branch `feature/midi-osc-helper-coverage-641-next`; no commit reported
+- Active worker: host / format helper coverage worktree
+  `/Users/danielraffel/Code/pulp-host-format-helper-coverage-493-next4`,
+  branch `feature/host-format-helper-coverage-493-next4`; no commit
+  reported yet.
+- Active worker: canvas helper coverage worktree
+  `/Users/danielraffel/Code/pulp-canvas-helper-coverage-641-next2`,
+  branch `feature/canvas-helper-coverage-641-next2`; no commit reported
   yet.
-- Active worker: render image-helper coverage worktree, branch
-  `feature/render-image-coverage-646-next4`; spawned after this review,
-  no commit reported yet.
-- Active worker: view/accessibility helper coverage worktree, branch
-  `feature/view-accessibility-coverage-493-next4`; spawned after this
-  review, no commit reported yet.
 
 Local Phase 3 draft worktrees:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -93,12 +93,27 @@ Open Phase 3 PRs:
   `feature/osc-udp-coverage-493`, head `0cecfa51`. The macOS UBSan
   abort was reproduced locally and fixed by replacing the legacy
   `gethostbyname`/`hostent` hostname fallback with `getaddrinfo`.
-  Local normal and UBSan OSC tests are green; GitHub Actions is still
-  draining required lanes.
+  Local normal and UBSan OSC tests are green; GitHub Actions has passed
+  Linux/Windows/macOS Namespace, Linux/Windows coverage, Codecov patch,
+  IWYU, docs, Android, version, and audit lanes. It is still draining
+  macOS coverage and macOS sanitizer lanes.
 - `#771` WidgetBridge extended-controls coverage, branch
-  `feature/widget-bridge-coverage-493`, head `172bfb71`. Local
+  `feature/widget-bridge-coverage-493`, head `429b8941`. Local
   `pulp-test-widget-bridge`, focused CTest, skill sync, version report,
-  and whitespace checks are green; GitHub Actions has started.
+  and whitespace checks are green. The follow-up CMake fix removes the
+  GPU-only `pulp::inspect` link from `pulp-test-cli-project-command` and
+  generates the CLI version header when `tools/cli` is skipped in
+  `PULP_ENABLE_GPU=OFF` sanitizer/IWYU configurations. Local GPU-off
+  configure/build plus `pulp-test-cli-project-command` are green; GitHub
+  Actions reran at `429b8941` and is draining.
+
+Open supporting PR:
+
+- `#774` refreshes this durable handoff/status document, branch
+  `docs/coverage-status-2026-04-25`, head `7f9ae827`. Docs preview,
+  docs consistency, audit, version, Android coverage, Linux coverage,
+  and Codecov patch are green; Namespace/remaining coverage lanes are
+  still draining.
 
 Next recovery actions:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -92,39 +92,34 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#771` WidgetBridge extended-controls coverage, branch
-  `feature/widget-bridge-coverage-493`, head `429b8941`. Local
-  `pulp-test-widget-bridge`, focused CTest, skill sync, version report,
-  and whitespace checks are green. The follow-up CMake fix removes the
-  GPU-only `pulp::inspect` link from `pulp-test-cli-project-command` and
-  generates the CLI version header when `tools/cli` is skipped in
-  `PULP_ENABLE_GPU=OFF` sanitizer/IWYU configurations. Local GPU-off
-  configure/build plus `pulp-test-cli-project-command` are green. GitHub
-  Actions at `429b8941` has passed Codecov patch, IWYU, Linux/macOS/Windows
-  coverage, Linux Namespace, Windows MSVC, docs, audit, Android, and version
-  checks, but Windows Namespace failed while the overall run was still in
-  progress and logs were not yet available through `gh run view`. The next
-  action is to pull that failed job log when the run completes, then either
-  rerun if it is an infra flake or patch the branch if it is reproducible.
+  `feature/widget-bridge-coverage-493`, head `c7e5de1d`. Local
+  `pulp-test-widget-bridge`, focused CTest, GPU-off configure/build of
+  `pulp-test-cli-project-command`, skill sync, version report, and
+  whitespace checks are green. The branch now carries three shared CI
+  unblockers discovered while validating this tranche: the GPU-off
+  `pulp-test-cli-project-command` CMake fix, Windows-safe CLI redirection
+  for `pulp project bump` probes, and a GPU/`pulp::inspect` guard around
+  `examples/ui-preview`. GitHub Actions at `c7e5de1d` has passed Codecov
+  patch, Android coverage, docs, audit, version/skill sync, and provider
+  resolution; IWYU, sandbox-e2e, Namespace, coverage, Windows MSVC, and
+  sanitizer lanes are still draining.
 - `#777` real CLAP `PluginSlot` coverage, branch
-  `feature/clap-slot-coverage-493`, head `5363bbe0`. This tranche wires
+  `feature/clap-slot-coverage-493`, head `ceb8c5db`. This tranche wires
   the built PulpGain CLAP bundle into host tests after examples are
   registered, adds metadata/defaults, bypass/release, and restore-state
   coverage, and fixes CLAP state restore so restored plugin state
-  supersedes stale cached host edits. Local configure, build,
-  `pulp-test-host`, generated `ClapSlot` CTest entries, whitespace,
-  CI-configured skill-sync, and version checks are green. GitHub Actions
-  has passed Codecov patch, Linux coverage, Android, docs, audit, version,
-  and Windows MSVC checks, but IWYU failed for the same GPU-off
-  `pulp-test-cli-project-command` / `pulp::inspect` CMake issue that `#771`
-  fixes. The preferred path is to merge or repair `#771`, then rebase `#777`
-  and rerun; if `#771` stays blocked, carrying the minimal CMake fix in
-  `#777` is the fallback.
-
-Active local Phase 3 branch not yet in PR:
-
-- `feature/vst3-adapter-coverage-493`, worktree
-  `/Users/danielraffel/Code/pulp-vst3-adapter-coverage-493`, adds focused
-  VST3 adapter coverage for parameter metadata, setup/release lifecycle,
+  supersedes stale cached host edits. The branch has been rebased onto
+  `origin/main` and now carries the same GPU-off CMake and `ui-preview`
+  guard fixes needed before `#771` lands. Local configure/build,
+  `pulp-test-host "[host][slot][clap]"` (`139` assertions / `4` test
+  cases), generated `ClapSlot` CTest entries, whitespace, CI-configured
+  skill-sync, and version checks are green. GitHub Actions is rerunning at
+  `ceb8c5db`; early docs, audit, version/skill sync, and provider checks
+  are green while IWYU, Namespace, coverage, Windows MSVC, Android, and
+  sanitizer lanes drain.
+- `#782` VST3 adapter process-path coverage, branch
+  `feature/vst3-adapter-coverage-493`, head `f2947827`. This tranche adds
+  focused VST3 adapter coverage for parameter metadata, setup/release lifecycle,
   bus/event/process routing, sidechain visibility, secondary output zeroing,
   host input automation, plugin-to-host output automation, MIDI output, and
   transport context mapping. Local `pulp-test-vst3-plugin-state` passed
@@ -133,7 +128,14 @@ Active local Phase 3 branch not yet in PR:
   `pluginval-*` bundle validation tests and those failed locally because
   pluginval found zero plugin types in the built VST3 bundles; that is being
   treated separately from the unit coverage tranche unless it reproduces in
-  CI.
+  CI. The PR is labeled `codecov`. Shipyard local/SSH validation at
+  `bc23956d` passed mac and ubuntu, then hit a Windows SSH bundle-upload
+  timeout during banner exchange. The branch now carries the same shared
+  GPU-off CMake, Windows-safe redirection, skill-doc, and `ui-preview`
+  guard fixes as `#771`; local GPU-off configure/build of
+  `pulp-test-cli-project-command`, focused `pulp-test-vst3-plugin-state`
+  (`118` assertions / `5` test cases), whitespace, skill-sync, and version
+  checks are green. GitHub Actions is rerunning at `f2947827`.
 
 Open supporting PR:
 
@@ -146,18 +148,17 @@ Open supporting PR:
 
 Next recovery actions:
 
-1. Poll `#771`, `#774`, and `#777`; merge green PRs manually because
+1. Poll `#771`, `#774`, `#777`, and `#782`; merge green PRs manually because
    auto-merge is disabled.
-2. Diagnose `#771`'s Windows Namespace failure once logs are available.
-3. Rebase or patch `#777` after the `#771` CMake fix lands, because its
-   current IWYU failure is the same GPU-off CMake issue.
-4. Finish local validation for `feature/vst3-adapter-coverage-493`, open a
-   PR, and keep it separate from the CLAP/WidgetBridge branches.
-5. If a PR is green but GitHub reports it behind `main`, rebase that
+2. Let the current `#771` and `#777` reruns drain after the shared CI
+   unblockers were pushed.
+3. Let the current `#782` rerun drain after the shared CI unblockers were
+   pushed at `f2947827`.
+4. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-6. After active PRs merge, refresh this section with the next complete
+5. After active PRs merge, refresh this section with the next complete
    Codecov `main` report.
-7. Continue Phase 3 from the tranche issues below, prioritizing
+6. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:34 EDT
+Last reviewed: 2026-04-26 19:39 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -147,6 +147,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#818` MPE synth voice / allocator coverage -> `3d4560d1`
 - `#817` UMP conversion edge coverage -> `a38216fd`
 - `#821` audio reader helper edge coverage -> `7aff17f9`
+- `#822` audio file helper edge coverage -> `87ef6d90`
 - `#819` MIDI keyboard/sequence edge coverage -> `7a646f33`
 - `#820` signal spectrogram edge coverage -> `1a1b7f07`
 - `#823` platform helper edge coverage -> `f69338eb`
@@ -157,15 +158,6 @@ Merged after the Phase 1 closeout / `#723` baseline:
 
 Open Phase 3 PRs:
 
-- `#822` audio file helper edge coverage for `#640`, branch
-  `feature/audio-file-helper-coverage-640`, head `2db6be4a`; opened
-  from `main` at `c9620a65` and updated after the first macOS UBSan run
-  exposed a real `float_to_int32` endpoint conversion overflow. This
-  branch was updated again after macOS Namespace full-suite test `392`
-  exposed Android SDK discovery choosing an older fake NDK revision; the
-  branch now compares Android build-tools and NDK revisions numerically.
-  This tranche also uses the GitHub/Namespace path while the SSH
-  `windows` target remains unreachable.
 - `#828` raw MIDI parser edge coverage and malformed-data hardening for
   `#645`, branch `feature/midi-raw-parser-coverage-645`, head
   `4e2e6092`; opened from `main` at `94e3ef2a`. This tranche also uses
@@ -431,7 +423,8 @@ Local Phase 3 draft worktrees:
 - `#640` audio file helper worktree
   `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
   branch `feature/audio-file-helper-coverage-640`, head `2db6be4a`;
-  open as PR `#822`.
+  merged via PR `#822` as `87ef6d90`. The remote branch was deleted
+  after merge.
   Scope: coverage for packed int24 conversion, int32 full-scale
   conversion, float-to-int32 clamping, zero-count conversion no-ops, CHOC
   WAV helper output via RIFF chunk parsing, malformed WAV rejection,
@@ -623,8 +616,8 @@ Open supporting PR:
   merged, `#824` merged, `#828` opened, `#829` opened, `#825` merged,
   `#830` opened, `#831` opened, `#827` merged, `#832` opened, `#826`
   merged, and `#832` was repaired for Windows cmd portability, and
-  `#831` was repaired for Windows float tolerance, and remains
-  docs-only.
+  `#831` was repaired for Windows float tolerance, and `#822` merged,
+  and remains docs-only.
 
 Local environment note:
 
@@ -643,28 +636,25 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#822` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
-   patch, validate locally, and push with lease.
-3. Monitor `#828` cloud checks; if a required lane fails, debug in
+2. Monitor `#828` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-raw-parser-coverage-645`, patch,
    validate locally, and push with lease.
-4. Monitor `#829` cloud checks; if a required lane fails, debug in
+3. Monitor `#829` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, patch,
    validate locally, and push with lease.
-5. Monitor `#830` cloud checks; if a required lane fails, debug in
+4. Monitor `#830` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, patch,
    validate locally, and push with lease.
-6. Monitor `#831` cloud checks; if a required lane fails, debug in
+5. Monitor `#831` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, patch,
    validate locally, and push with lease.
-7. Monitor `#832` cloud checks; if a required lane fails, debug in
+6. Monitor `#832` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
    patch, validate locally, and push with lease.
-8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -92,7 +92,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#771` WidgetBridge extended-controls coverage, branch
-  `feature/widget-bridge-coverage-493`, head `13f1be94`. Local
+  `feature/widget-bridge-coverage-493`, head `45a146d5`. Local
   `pulp-test-widget-bridge`, focused CTest, GPU-off configure/build of
   `pulp-test-cli-project-command`, skill sync, version report, and
   whitespace checks are green. The branch now carries three shared CI
@@ -103,10 +103,13 @@ Open Phase 3 PRs:
   unblocker that makes `pulp upgrade --check-only` honor
   `PULP_UPDATE_CHECK_DISABLED=1` without hitting GitHub Releases when the
   update cache is empty, plus the shellout test covering that path so the
-  diff-coverage gate sees those lines. GitHub Actions is rerunning at
-  `13f1be94`.
+  diff-coverage gate sees those lines. After `#782`/`#786` exposed shared
+  `cmd_project.cpp` diff-coverage misses, the branch also carries focused
+  project-bump probe tests for platform null redirection, non-standalone
+  `origin/main` fallback, and `--verify-builds`. GitHub Actions is rerunning
+  at `45a146d5`; no completed failures were visible at the last poll.
 - `#777` real CLAP `PluginSlot` coverage, branch
-  `feature/clap-slot-coverage-493`, head `83e9f9be`. This tranche wires
+  `feature/clap-slot-coverage-493`, head `f9be330c`. This tranche wires
   the built PulpGain CLAP bundle into host tests after examples are
   registered, adds metadata/defaults, bypass/release, and restore-state
   coverage, and fixes CLAP state restore so restored plugin state
@@ -117,15 +120,18 @@ Open Phase 3 PRs:
   `pulp-test-host "[host][slot][clap]"` (`139` assertions / `4` test
   cases), generated `ClapSlot` CTest entries, whitespace, CI-configured
   skill-sync, direct disabled-upgrade smoke, focused CLI shellout coverage
-  for `PULP_UPDATE_CHECK_DISABLED`, and version checks are green. The
-  previous `753bcccf` rerun exposed two blockers: Windows Namespace failed
-  but logs were still unavailable while the run continued, and the required
-  diff-coverage gate reported `63%` because the shared
-  `cmd_upgrade.cpp` disabled-update branch was uncovered. The new head
-  adds the shellout coverage test for that path and is rerunning at
-  `83e9f9be`.
+  for `PULP_UPDATE_CHECK_DISABLED`, focused project-bump probe tests
+  (`pulp-test-cli-project-command` now `150` assertions / `10` cases), and
+  version checks are green. The previous Windows Namespace failure was traced
+  to POSIX `/dev/null` redirection inside `pulp project bump` git probes on
+  Windows; the branch now uses Windows-safe `NUL` redirection for those probes
+  and adds tests for the affected paths. The previous diff-coverage failure
+  at `753bcccf` (`63%`) was the shared disabled-update branch in
+  `cmd_upgrade.cpp`; that is covered by the shellout test now present on all
+  active coverage branches. GitHub Actions is rerunning at `f9be330c`; no
+  completed failures were visible at the last poll.
 - `#782` VST3 adapter process-path coverage, branch
-  `feature/vst3-adapter-coverage-493`, head `f09adb04`. This tranche adds
+  `feature/vst3-adapter-coverage-493`, head `dcad28de`. This tranche adds
   focused VST3 adapter coverage for parameter metadata, setup/release lifecycle,
   bus/event/process routing, sidechain visibility, secondary output zeroing,
   host input automation, plugin-to-host output automation, MIDI output, and
@@ -144,10 +150,15 @@ Open Phase 3 PRs:
   `pulp-test-cli-project-command`, focused `pulp-test-vst3-plugin-state`
   (`118` assertions / `5` test cases), direct disabled-upgrade smoke,
   focused CLI shellout coverage for `PULP_UPDATE_CHECK_DISABLED`,
-  whitespace, skill-sync, and version checks are green. GitHub Actions is
-  rerunning at `f09adb04`.
+  focused project-bump probe tests (`pulp-test-cli-project-command` now `150`
+  assertions / `10` cases), whitespace, skill-sync, and version checks are
+  green. The `f09adb04` rerun failed the required diff-coverage gate because
+  the shared `cmd_project.cpp` support commit left Windows helper returns,
+  non-standalone `origin/main` fallback, and `--verify-builds` lines uncovered;
+  `dcad28de` adds direct coverage for those lines. GitHub Actions is rerunning
+  at `dcad28de`; no completed failures were visible at the last poll.
 - `#786` render DirtyTracker / RenderLoop edge coverage, branch
-  `feature/render-coverage-646-next`, head `f7da209d`. This tranche extends
+  `feature/render-coverage-646-next`, head `54d209d5`. This tranche extends
   the still-open `#646` render component follow-up after the earlier merged
   `#700` slice. Scope is intentionally pure and hostable: DirtyTracker
   negative/empty rects, debug overlay state, threshold accumulation,
@@ -164,51 +175,66 @@ Open Phase 3 PRs:
   redirection, `ui-preview` guard, disabled-update-check fix, and CLI
   coverage test as the other active Phase 3 tranches because IWYU exposed
   the GPU-off target-link failure before any of those shared fixes had
-  merged. GitHub Actions is rerunning at `f7da209d`.
+  merged. The `f7da209d` rerun failed the required diff-coverage gate on the
+  same shared `cmd_project.cpp` probe edges as `#782`; `54d209d5` carries the
+  same focused CLI project-command coverage fix. GitHub Actions is rerunning
+  at `54d209d5`; no completed failures were visible at the last poll.
 
 Local Phase 3 draft not yet opened as a PR:
 
 - `#642` events socket-IPC tranche, worktree
   `/Users/danielraffel/Code/pulp-events-ipc-coverage-642`, branch
-  `feature/events-ipc-coverage-642`, local commit `aea1dfa7`. This draft
-  extends `test/test_ipc.cpp` with socket endpoint rejection coverage and
-  a deterministic localhost client/server framed-message exchange. Local
-  validation is green: configure, `cmake --build build --target
-  pulp-test-ipc -j4`, direct `pulp-test-ipc` (`23` assertions / `8` test
-  cases), focused CTest `IPC` (`8/8`), and whitespace. Keep this local
-  until one of the shared CI-unblocker PRs merges, or cherry-pick the same
-  shared GPU-off/sandbox/diff-coverage unblockers before opening it.
+  `feature/events-ipc-coverage-642`, local commit `f3b9807c`. This draft
+  extends `test/test_ipc.cpp` with malformed socket endpoint rejection,
+  non-throwing socket endpoint parsing in
+  `core/events/src/interprocess_connection.cpp`, and a deterministic
+  localhost client/server framed-message exchange. It also carries the same
+  shared CLI support commits as the open coverage PRs so it can be opened
+  safely if the session is interrupted before those fixes reach `main`.
+  Local validation is green: `pulp-test-ipc` (`34` assertions / `9` test
+  cases), focused CTest `IPC` plus project-bump probe edges (`12/12`), and
+  whitespace. A direct multi-filter Catch2 invocation was intentionally not
+  used as validation because Catch2 treats multiple quoted filters as an AND
+  expression; CTest was used for the focused multi-test slice.
 
 Open supporting PR:
 
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  Docs preview, docs consistency, audit, version, Android coverage,
-  Linux coverage, and Codecov patch were green on the previous run;
-  Namespace/remaining coverage lanes are draining on each refresh.
+  The previous head `3f1df148` failed Windows Namespace for the same
+  `pulp project bump` Windows redirection bug now fixed on the active code
+  PRs. Keep this PR docs-only; once one code PR carrying the shared
+  Windows-safe probe fix merges, rebase `#774` onto `origin/main` and the
+  inherited Windows failure should clear. Docs preview, docs consistency,
+  audit, version, Android coverage, Linux coverage, Windows coverage, and
+  Codecov patch were green on that previous run.
 
 Next recovery actions:
 
-1. Poll `#771`, `#774`, `#777`, `#782`, and `#786`; merge green PRs manually
+1. Poll `#771`, `#777`, `#782`, and `#786`; merge green PRs manually
    because auto-merge is disabled.
 2. Let the current `#771`, `#777`, `#782`, and `#786` reruns drain after
-   the shared CI, sandbox-e2e, and CLI diff-coverage unblockers were
-   pushed.
-3. If `#777` Windows Namespace fails again, pull the fresh completed-run
-   log first; the previous failed job's log was unavailable while the
-   overall run was still in progress.
+   the shared CI, sandbox-e2e, Windows-safe project-bump, and CLI
+   diff-coverage unblockers were pushed.
+3. After the first code PR carrying the shared Windows-safe
+   `cmd_project.cpp` probe fix merges, rebase `#774` onto `origin/main` and
+   push a doc refresh so its inherited Windows Namespace failure clears.
 4. Keep the local `#642` events IPC draft paused until the shared
    CI-unblocker commits are on `main`; then rebase it, open a PR, and
-   link it from `#642`.
-5. If sandbox-e2e fails again, pull the fresh log first; the expected
+   link it from `#642`. If opening before then, keep the local shared commits
+   in place.
+5. If any Windows Namespace lane fails again, pull the fresh completed-run
+   log first and search for `pulp-test-cli-project-command`; the known
+   failing tests were the dirty-gate and redundant-origin project-bump cases.
+6. If sandbox-e2e fails again, pull the fresh log first; the expected
    failure fixed here was `pulp upgrade --check-only` ignoring
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
-6. If a PR is green but GitHub reports it behind `main`, rebase that
+7. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-7. After active PRs merge, refresh this section with the next complete
+8. After active PRs merge, refresh this section with the next complete
    Codecov `main` report.
-8. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 20:42 EDT
+Last reviewed: 2026-04-26 20:47 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -188,9 +188,12 @@ Open Phase 3 PRs:
   `main` at `87ef6d90`. This tranche also uses the GitHub/Namespace
   path while the SSH `windows` target remains unreachable.
 - `#835` CLI ship command validation coverage for `#643`, branch
-  `feature/cli-ship-coverage-643`, head `6c1e5a4b`; opened from
-  `main` at `5b8e4529`. This tranche also uses the GitHub/Namespace
-  path while the SSH `windows` target remains unreachable.
+  `feature/cli-ship-coverage-643`, head `5ef39944`; opened from
+  `main` at `5b8e4529`, then rebased onto `b5e7a463` and updated after
+  Linux Namespace exposed that the Android validation test created
+  `artifacts/` before asserting the missing-artifacts check path. This
+  tranche also uses the GitHub/Namespace path while the SSH `windows`
+  target remains unreachable.
 - `#836` CLI sync checker coverage for `#643`, branch
   `feature/cli-sync-coverage-643`, head `86048a3f`; opened from
   `main` at `5b8e4529`. This tranche also uses the GitHub/Namespace
@@ -343,19 +346,26 @@ Local Phase 3 draft worktrees:
   skill-sync report, and version-bump report.
 - `#643` CLI ship command validation worktree
   `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, branch
-  `feature/cli-ship-coverage-643`, commit `6c1e5a4b`; open as PR
+  `feature/cli-ship-coverage-643`, commit `5ef39944`; open as PR
   `#835`.
   Scope: test-only `pulp ship` shellout coverage for fake project roots
   with missing build-cache guidance, Android signing/package/check
   validation before external tools run, appcast feed generation, and
-  remote `--sign-key` rejection without real signing material. Local
-  validation after rebasing onto `5b8e4529`: no-GPU/no-examples
+  remote `--sign-key` rejection without real signing material. The
+  follow-up commit moves the Android `ship check --target android`
+  missing-artifacts assertion before package probes create `artifacts/`
+  as part of their validation path. Local validation after rebasing onto
+  `5b8e4529`: no-GPU/no-examples
   configure, `pulp-test-cli-ship-shellout` build, direct `[issue-643]`
   run passed `3` assertions in `3` cases, full binary passed `10`
   assertions in `10` cases, focused CTest `pulp ship` passed `10/10`,
   `git diff --check HEAD~1..HEAD`, `git diff --check`, skill-sync
   report, and version-bump report with `Version-Bump: sdk=skip` for
-  the test-only coverage tranche.
+  the test-only coverage tranche. Follow-up validation after rebasing
+  onto `b5e7a463` used a real built CLI path and passed the focused
+  Android validation test with `12` assertions, the `[issue-643]` slice
+  with `25` assertions in `3` cases, the full binary with `45`
+  assertions in `10` cases, diff check, and pre-push gates.
 - `#643` CLI sync checker worktree
   `/Users/danielraffel/Code/pulp-cli-sync-coverage-643`, branch
   `feature/cli-sync-coverage-643`, commit `86048a3f`; open as PR
@@ -733,7 +743,8 @@ Open supporting PR:
   the merged Android SDK discovery fix, and `#832` was rebased/repaired
   for the Windows fast-exit command, and `#834` opened, and `#828`
   merged, and `#835` opened, and `#836` opened, and `#837` opened, and
-  `#831` merged, and `#838` opened, and remains docs-only.
+  `#831` merged, and `#838` opened, and `#835` was repaired for Linux
+  Android-validation ordering, and remains docs-only.
 
 Local environment note:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,11 +1,11 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-24
+Last reviewed: 2026-04-25
 
 This is the durable tracker for the repo-wide coverage compliance
-program under `#641`. The Phase 1 representation stack has now landed
-on `main`; this document records the corrected Codecov baseline that
-Phase 2 planning should use.
+program under `#641`. Phase 1 representation is complete, Phase 2 gap
+planning has been seeded from the corrected Codecov baseline, and Phase
+3 gap closure is active through small, reviewable PR tranches.
 
 ## Goal
 
@@ -23,8 +23,7 @@ Target tiers remain unchanged in `ci/coverage-targets.yaml`:
 
 ### Phase 1 - Representation / Codecov truth
 
-Status: code and workflow slices are merged; this rebaseline is the
-closeout artifact.
+Status: complete.
 
 Finish line state:
 
@@ -40,7 +39,8 @@ Finish line state:
 
 ### Phase 2 - Gap planning
 
-Status: next.
+Status: complete enough to execute, with the roadmap tracked in `#641`
+and the tranche issues listed below.
 
 Finish line:
 
@@ -53,7 +53,7 @@ Finish line:
 
 ### Phase 3 - Gap closure
 
-Status: parked until Phase 2 produces the tranche plan.
+Status: active.
 
 Finish line:
 
@@ -63,7 +63,55 @@ Finish line:
 - deferred or exceptional surfaces stay documented explicitly instead of
   silently omitted
 
-## Corrected main baseline
+## Current live state
+
+Latest complete Codecov `main` report observed while updating this doc:
+
+- commit: `b4edebe046fdf2886891016fff4158a195ee7fbd`
+- workflow: Coverage run `24925413069`, completed successfully
+- overall tracked coverage: `43.28%` over `70,175` lines in `556` files
+- covered lines: `30,372`
+- note: `origin/main` is currently `95e917cf40026e29035f05c9eca1307ba68fa177`;
+  that commit is a changelog-only `[skip ci]` commit, so Codecov's latest
+  complete coverage report is from the previous executable-code commit.
+
+Merged after the Phase 1 closeout / `#723` baseline:
+
+- `#649` CLI/tools tranche 1 -> `8449b6e8`
+- `#648` events tranche 1 -> `357eded1`
+- `#666` ship/state deterministic hardening -> `75439c89`
+- `#734` audio/platform tranche 1 -> `2224d11d`
+- `#741` midi/signal tranche 1 -> `63fd5ad5`
+- `#757` scan-worker CLI coverage -> `9053e0b`
+- `#755` LV2 host/entry coverage -> `aed8acb`
+- `#756` validation harness edge coverage -> `22d1e69`
+- `#765` TextEditor multiline navigation coverage -> `7257a154`
+
+Open Phase 3 PRs:
+
+- `#766` OSC UDP sender/receiver edge coverage, branch
+  `feature/osc-udp-coverage-493`, head `0cecfa51`. The macOS UBSan
+  abort was reproduced locally and fixed by replacing the legacy
+  `gethostbyname`/`hostent` hostname fallback with `getaddrinfo`.
+  Local normal and UBSan OSC tests are green; GitHub Actions is still
+  draining required lanes.
+- `#771` WidgetBridge extended-controls coverage, branch
+  `feature/widget-bridge-coverage-493`, head `172bfb71`. Local
+  `pulp-test-widget-bridge`, focused CTest, skill sync, version report,
+  and whitespace checks are green; GitHub Actions has started.
+
+Next recovery actions:
+
+1. Poll `#766` and `#771`; merge green PRs manually because auto-merge
+   is disabled.
+2. If a PR is green but GitHub reports it behind `main`, rebase that
+   branch onto `origin/main`, push with lease, and let checks rerun.
+3. After active PRs merge, refresh this section with the next complete
+   Codecov `main` report.
+4. Continue Phase 3 from the tranche issues below, prioritizing
+   represented high-miss files over adding new perimeter lanes.
+
+## Phase 1 corrected baseline
 
 Source:
 
@@ -72,7 +120,8 @@ Source:
 - GitHub Actions Coverage run `24886403280`, completed successfully
   across Android/Kotlin, Linux/Clang, Windows/Clang, and macOS/Clang
 
-Current observed `main` snapshot:
+This snapshot is the corrected Phase 1 component baseline used to seed
+Phase 2 planning:
 
 - overall tracked coverage: `39.28%` over `68,001` lines in `551` files
 - `audio`: `20.95%`
@@ -185,19 +234,20 @@ represented surface.
 - `#568` historical multi-language expansion umbrella. Active execution
   now rolls up through `#641`.
 
-## Phase 2 starting point
+## Phase 2 / Phase 3 working queue
 
-Phase 2 should start from the component snapshot above, not from older
-pre-`#715` numbers. The first planning pass should:
+Phase 2 started from the component snapshot above, not from older
+pre-`#715` numbers. The current execution rule is:
 
 1. Rank below-target counted components against `ci/coverage-targets.yaml`.
-2. Separate "represented but zero/low coverage" files from intentionally
+2. Separate represented but zero/low coverage files from intentionally
    unrepresented surfaces.
-3. Refresh or close the parked tranche issues based on the corrected
-   numbers.
-4. Post the final Phase 1 closeout and Phase 2 entry note on `#641`.
+3. Land small, focused PRs that improve represented files and keep diff
+   coverage above the required 75% floor.
+4. Refresh this doc and `#641` after each batch of merges or after a
+   meaningful Codecov `main` rebaseline.
 
-### Phase 2 / Phase 3 issues to re-evaluate
+### Phase 2 / Phase 3 tranche issues
 
 - `#640` audio / platform tranche
 - `#642` events tranche
@@ -206,12 +256,15 @@ pre-`#715` numbers. The first planning pass should:
 - `#645` midi / signal tranche
 - `#646` render tranche
 - `#493` host / format / view and related hardening gaps
+- `#737` optional native surfaces not compiled by the default coverage
+  configuration
 
-### Parked draft PRs to re-evaluate
+### Deferred perimeter follow-ups
 
-- `#648` draft events tranche
-- `#649` draft CLI / tools tranche
-- `#666` draft state / ship hardening split from `#647`
+- `#659` authored JavaScript source lane
+- `#657` Node bindings plus shell / PowerShell classification, closed as
+  explicitly out of scope for now
+- `#77` mobile runtime / iOS simulator coverage
 
 ## Control-plane invariants
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -107,13 +107,14 @@ Open Phase 3 PRs:
   configure/build plus `pulp-test-cli-project-command` are green; GitHub
   Actions reran at `429b8941` and is draining.
 - `#777` real CLAP `PluginSlot` coverage, branch
-  `feature/clap-slot-coverage-493`, head `9a2a1d90`. This tranche wires
+  `feature/clap-slot-coverage-493`, head `5363bbe0`. This tranche wires
   the built PulpGain CLAP bundle into host tests after examples are
   registered, adds metadata/defaults, bypass/release, and restore-state
   coverage, and fixes CLAP state restore so restored plugin state
   supersedes stale cached host edits. Local configure, build,
   `pulp-test-host`, generated `ClapSlot` CTest entries, whitespace,
-  skill-sync, and version checks are green; GitHub Actions is draining.
+  CI-configured skill-sync, and version checks are green; GitHub Actions
+  is draining.
 
 Open supporting PR:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 18:17 EDT
+Last reviewed: 2026-04-26 18:26 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -177,6 +177,10 @@ Open Phase 3 PRs:
   unreachable.
 - `#826` OGG reader edge coverage for `#640`, branch
   `feature/audio-ogg-reader-coverage-640`, head `6b721c22`; opened from
+  `main` at `1a1b7f07`. This tranche also uses the GitHub/Namespace path
+  while the SSH `windows` target remains unreachable.
+- `#827` signal multi-channel meter edge coverage for `#645`, branch
+  `feature/signal-meter-coverage-645`, head `ed51248f`; opened from
   `main` at `1a1b7f07`. This tranche also uses the GitHub/Namespace path
   while the SSH `windows` target remains unreachable.
 
@@ -508,6 +512,20 @@ Local Phase 3 draft worktrees:
   `[audio][ogg][issue-640]` run passed `12` assertions in `2` cases,
   full binary passed `12` assertions in `2` cases, focused CTest passed
   `2/2`, `git diff --check`, skill-sync report, and version-bump report.
+- `#645` signal multi-channel meter worktree
+  `/Users/danielraffel/Code/pulp-signal-meter-coverage-645`, branch
+  `feature/signal-meter-coverage-645`, commit `ed51248f`; open as PR
+  `#827`.
+  Scope: dedicated `pulp-test-multi-channel-meter` target covering
+  prepared-channel clamping, empty process blocks, correlation window
+  replacement after reset, integrated LUFS running-average behavior,
+  ballistics release/noise-floor clamping, and held-peak refresh paths.
+  This intentionally avoids `test_signal.cpp` while `#824` is open.
+  Local validation: no-GPU/no-examples configure,
+  `pulp-test-multi-channel-meter` build, direct `[issue-645]` run
+  passed `20` assertions in `6` cases, full binary passed `20`
+  assertions in `6` cases, focused CTest passed `6/6`,
+  `git diff --check`, skill-sync report, and version-bump report.
 
 Open supporting PR:
 
@@ -518,8 +536,9 @@ Open supporting PR:
   updated after `#816` merged, `#817` was repaired, `#820` opened,
   `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
   merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
-  merged, `#825` opened, `#820` merged, `#826` opened, and `#822` was
-  repaired again for Android SDK discovery, and remains docs-only.
+  merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
+  repaired again for Android SDK discovery, and `#827` opened, and
+  remains docs-only.
 
 Local environment note:
 
@@ -553,10 +572,13 @@ Next recovery actions:
 6. Monitor `#826` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-ogg-reader-coverage-640`,
    patch, validate locally, and push with lease.
-7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+7. Monitor `#827` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-signal-meter-coverage-645`, patch,
+   validate locally, and push with lease.
+8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-8. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 00:15 EDT
+Last reviewed: 2026-04-26 00:19 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -149,16 +149,18 @@ Open Phase 3 PRs:
   exposed a local Shipyard mac configure stall after GitHub/Namespace was
   already clean.
 - `#798` `test(audio): cover format registry dispatch paths`, branch
-  `feature/audio-format-registry-coverage-640`, commit `43739ac1`,
+  `feature/audio-format-registry-coverage-640`, commit `0b35bb83`,
   worktree
   `/Users/danielraffel/Code/pulp-audio-system-volume-coverage-640`.
   Scope: deterministic `FormatRegistry` unsupported read/read_info
   dispatch, custom reader/writer registration, normalized extension lookup,
   read_info/read/write dispatch through registered handlers, and supported
   extension collection for `.aifc`. Local validation:
-  `pulp-test-audio-file` passed with `258` assertions in `16` test cases;
-  focused CTest `FormatRegistry|audio.*file` passed `3/3`;
-  `git diff --check` clean; version bump report says no bump needed.
+  after rebasing across `#797`, `pulp-test-audio-file` passed with `339`
+  assertions in `20` test cases; focused CTest
+  `FormatRegistry|audio.*file|StreamingWriter` passed `7/7`;
+  `git diff --check` clean; skill sync found no mapped paths; version bump
+  report says no bump needed.
   The PR is labeled `codecov` and is using the same direct
   GitHub/Namespace path as `#795`.
 
@@ -188,7 +190,7 @@ Local Phase 3 draft worktrees:
 - `#640` format-registry audio/platform worktree
   `/Users/danielraffel/Code/pulp-audio-system-volume-coverage-640`,
   branch `feature/audio-format-registry-coverage-640`, commit
-  `43739ac1`; open as PR `#798`.
+  `0b35bb83`; open as PR `#798`.
 
 Open supporting PR:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 21:14 EDT
+Last reviewed: 2026-04-25 21:23 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -67,39 +67,32 @@ Finish line:
 
 Latest complete Codecov `main` report observed while updating this doc:
 
-- commit: `e61dce8d907c29888fd7dd97ae7f49e3bc219662`
-- workflow: Coverage run `24942795469`, completed successfully
-- overall tracked coverage: `44.85%` over `70,229` lines in `556` files
-- covered lines: `31,498`
+- commit: `23d3ed1d9dca9b39e3e7f3a851698eb93c717ae6`
+- workflow: Coverage run `24944888062`, completed successfully
+- overall tracked coverage: `44.73%` over `70,325` lines in `556` files
+- covered lines: `31,458`
 - current component coverage from the Codecov API:
-  - `audio`: `25.45%`
-  - `canvas`: `67.14%`
-  - `dsl`: `68.3%`
-  - `events`: `33.48%`
-  - `format`: `52.89%`
-  - `host`: `45.92%`
-  - `midi`: `48.44%`
-  - `osc`: `66.26%`
-  - `platform`: `50.65%`
+  - `audio`: `25.53%`
+  - `canvas`: `65.87%`
+  - `dsl`: `68.85%`
+  - `events`: `49.64%`
+  - `format`: `52.64%`
+  - `host`: `44.32%`
+  - `midi`: `49.95%`
+  - `osc`: `67.47%`
+  - `platform`: `48.83%`
   - `render`: `62.31%`
-  - `runtime`: `50.2%`
-  - `signal`: `66.89%`
-  - `state`: `63.32%`
-  - `view`: `44.81%`
+  - `runtime`: `53.89%`
+  - `signal`: `63.96%`
+  - `state`: `66.69%`
+  - `view`: `44.6%`
   - `android`: `13.83%`
-  - `apple`: `25.36%`
-  - `linux`: `3.98%`
-  - `windows`: `15.02%`
-  - `cli`: `33.15%`
-  - `ship`: `57.66%`
-  - `tools`: `40.17%`
-
-Newer `main` state:
-
-- `#788` merged after the latest complete Codecov report above. The new
-  `main` head is `23d3ed1d9dca9b39e3e7f3a851698eb93c717ae6`.
-- Main Coverage run `24944888062` is in progress for `23d3ed1d`; refresh
-  this baseline from Codecov after it completes.
+  - `apple`: `25.72%`
+  - `linux`: `0.0%`
+  - `windows`: `10.13%`
+  - `cli`: `32.21%`
+  - `ship`: `59.15%`
+  - `tools`: `39.5%`
 
 Merged after the Phase 1 closeout / `#723` baseline:
 
@@ -160,14 +153,12 @@ Local environment note:
 
 Next recovery actions:
 
-1. Let main Coverage run `24944888062` for `23d3ed1d` drain, then refresh
-   this section with the next complete Codecov `main` report.
-2. Keep `#774` docs-only and let its post-`#788` rebase checks drain.
-3. Monitor `#793`; Shipyard is validating the PR and GitHub workflows are
+1. Keep `#774` docs-only and let its post-`#793` status-update checks drain.
+2. Monitor `#793`; Shipyard is validating the PR and GitHub workflows are
    running.
-4. If a new PR is green but GitHub reports it behind `main`, rebase that
+3. If a new PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-5. Continue Phase 3 from the tranche issues below, prioritizing
+4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 23:42 EDT
+Last reviewed: 2026-04-27 00:04 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -171,6 +171,10 @@ Merged after the Phase 1 closeout / `#723` baseline:
 
 Open Phase 3 PRs:
 
+As of this review, the open `codecov` PR queue has no failing checks.
+The oldest PRs are blocked by still-queued macOS / sanitizer / Namespace
+jobs rather than code failures.
+
 - `#835` CLI ship command validation coverage for `#643`, branch
   `feature/cli-ship-coverage-643`, head `b8f22af9`; opened from
   `main` at `5b8e4529`, then rebased onto `b5e7a463` and updated after
@@ -220,9 +224,13 @@ Open Phase 3 PRs:
   `feature/cli-tools-coverage-643-next2`, head `b8e7b22a`; covers
   optional Namespace fallback plus provider/default argument validation.
 - `#851` signal meter channel-count guards for `#645`, branch
-  `feature/signal-meter-coverage-645-next`, head `ad9c3d81`; hardens
+  `feature/signal-meter-coverage-645-next`, head `a3aec442`; hardens
   negative/invalid `MultiChannelMeter` and `MultiChannelBallistics`
-  channel counts and carries a patch-level SDK metadata trailer.
+  channel counts and carries a patch-level SDK metadata trailer. After
+  the first coverage run reported diff coverage `66%` because
+  `multi_channel_meter.hpp:151` was uncovered, follow-up `118dbce4`
+  added process-channel clamp coverage and `a3aec442` refreshed the
+  tip-level version / skill metadata.
 - `#852` canvas rectangle-list helper coverage for parent `#641`,
   branch `feature/runtime-helper-coverage-641-next2`, head `05c85d55`;
   consolidates overlapping rectangle-list worker output into one
@@ -316,6 +324,42 @@ Open Phase 3 PRs:
   `feature/ship-coverage-641-next`, head `752ae0bb`; covers
   Add/Remove Programs registry metadata and HKLM/HKCU uninstall key
   deletion paths.
+- `#876` OSC malformed codec guard coverage for parent `#641`, branch
+  `feature/osc-coverage-641-next`, head `8a3b0135`; covers truncated
+  float payload fallback and negative blob-size fallback.
+- `#877` runtime scope/string helper coverage for parent `#641`, branch
+  `feature/runtime-coverage-641-next4`, head `5f61635d`; covers
+  `ScopeGuard` move ownership and `copy_c_string` degenerate buffer
+  paths.
+- `#878` inspect Audio domain coverage for `#841` / parent `#641`,
+  branch `feature/inspect-coverage-641-next`, head `821244bc`; covers
+  `AudioInspector` metering gates and `DomainHandler` Audio config,
+  metering, MIDI log, unknown-method, and missing-inspector paths.
+- `#879` tools limitations helper coverage for `#643`, branch
+  `feature/tools-helper-coverage-643-next6`, head `c56acc8a`; covers
+  `tools/list_limitations.py` extraction, capability-path validation,
+  markdown rendering, and unresolved-path diagnostics.
+- `#880` audio model missing-checkpoint coverage for `#640`, branch
+  `feature/audio-tools-coverage-640-next5`, head `bfe7d578`; covers
+  installed audio-model metadata with a missing resolved checkpoint and
+  activation rejection for that state.
+- `#881` runtime XML/gzip helper coverage for parent `#641`, branch
+  `feature/runtime-xmlzip-coverage-641-next`, head `597b0a3a`; covers
+  XML XPath attribute / invalid-expression paths, XML text escaping, and
+  gzip optional-header / reserved-flag decode edges.
+- `#882` platform Environment helper coverage for `#640`, branch
+  `feature/platform-env-coverage-640-next`, head `63aa707a`; covers
+  `EnvironmentChange::any()` flag reporting and `Environment::reset_for_test()`
+  listener clearing while tokens are still live.
+- `#883` runtime Stream / AsyncStream helper coverage for parent `#641`,
+  branch `feature/runtime-stream-coverage-641-next`, head `a74e0bf4`;
+  covers `MemoryStream` zero-size / rewind / clear paths, `FileStream`
+  append and move ownership, `AsyncStream` zero-byte completion dispatch,
+  and `CancellationToken` sharing / idempotent cancel behavior.
+- `#884` web-compat selector helper coverage for parent `#641`, branch
+  `feature/web-compat-coverage-641-next`, head `393e841f`; covers
+  compound selector matching, child vs descendant combinators, and nested
+  `querySelector` / `querySelectorAll` traversal.
 
 Local-only queued work:
 
@@ -332,6 +376,26 @@ Local-only queued work:
   test-only target `pulp-test-ipc-endpoints` for deterministic IPC
   socket endpoint parse failures. Review CMake overlap with open `#857`
   before opening a PR.
+- Active worker: state/properties helper coverage worktree
+  `/Users/danielraffel/Code/pulp-state-properties-coverage-641-next`,
+  branch `feature/state-properties-coverage-641-next`; no commit reported
+  yet.
+- Active worker: iOS/mobile runtime helper coverage worktree
+  `/Users/danielraffel/Code/pulp-ios-runtime-coverage-641-next`, branch
+  `feature/ios-runtime-coverage-641-next`; no commit reported yet.
+- Active worker: ship helper coverage worktree
+  `/Users/danielraffel/Code/pulp-ship-helper-coverage-641-next2`, branch
+  `feature/ship-helper-coverage-641-next2`; no commit reported yet.
+- Active worker: MIDI / OSC helper coverage worktree
+  `/Users/danielraffel/Code/pulp-midi-osc-helper-coverage-641-next`,
+  branch `feature/midi-osc-helper-coverage-641-next`; no commit reported
+  yet.
+- Active worker: render image-helper coverage worktree, branch
+  `feature/render-image-coverage-646-next4`; spawned after this review,
+  no commit reported yet.
+- Active worker: view/accessibility helper coverage worktree, branch
+  `feature/view-accessibility-coverage-493-next4`; spawned after this
+  review, no commit reported yet.
 
 Local Phase 3 draft worktrees:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 13:37 EDT
+Last reviewed: 2026-04-26 13:54 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -232,6 +232,20 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-signal-fft-coverage-645`, branch
   `feature/signal-fft-coverage-645`, commit `11c83082`; merged via PR
   `#809` as `453bcec8`. The remote branch was deleted after merge.
+- `#643` CLI project-command dispatch worktree
+  `/Users/danielraffel/Code/pulp-cli-project-coverage-643`, branch
+  `feature/cli-project-coverage-643`, commit `3a2820bb`; local-only
+  draft, not opened as a PR yet while `#810` and `#774` drain. Scope:
+  direct `cmd_project.cpp` coverage for top-level help/no-arg/unknown
+  dispatch, bump option parsing, `--all` empty-registry handling,
+  registry-backed `--all --dry-run` reporting without undo files, a
+  single-project bump plus newest-batch undo round-trip, and undo
+  no-batch/missing-batch/malformed-batch diagnostics. Local validation:
+  no-GPU/no-examples configure, `pulp-test-cli-project-command` build,
+  `[cli][project-command][issue-643]` passed `75` assertions in `6`
+  cases, full binary passed `318` assertions in `22` cases, focused
+  CTest `cmd_project` passed `8/8`, `git diff --check`, skill-sync
+  report, and version-bump report.
 
 Open supporting PR:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 17:43 EDT
+Last reviewed: 2026-04-26 17:53 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -171,6 +171,11 @@ Open Phase 3 PRs:
   `#645`, branch `feature/signal-math-helper-coverage-645`, head
   `1b7f1cfd`; opened from `main` at `a38216fd`. This tranche also uses
   the GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
+- `#825` signal DSP helper edge coverage for `#645`, branch
+  `feature/signal-dsp-helper-coverage-645`, head `da05acaf`; opened
+  from `main` at `7a646f33`. This tranche also uses the
+  GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
 
 Local Phase 3 draft worktrees:
@@ -466,6 +471,21 @@ Local Phase 3 draft worktrees:
   passed `62`, `55`, `895`, and `71` assertions respectively, focused
   CTest passed `11/11`, `git diff --check`, skill-sync report, and
   version-bump report.
+- `#645` signal DSP helper worktree
+  `/Users/danielraffel/Code/pulp-signal-dsp-helper-coverage-645`,
+  branch `feature/signal-dsp-helper-coverage-645`, commit `da05acaf`;
+  open as PR `#825`.
+  Scope: test-only coverage for `AlignedBuffer` move assignment,
+  same-size resize, empty clear, and copy truncation paths;
+  `BallisticsFilter` time-constant clamp and buffer processing paths;
+  `LogRampedValue` non-positive endpoint jump paths; and all
+  `WaveShaper` curve branches plus in-place buffer processing. Local
+  validation: no-GPU/no-examples configure, `pulp-test-simd` and
+  `pulp-test-dsp-expansion` builds, direct issue-645 slices passed `12`
+  assertions in `3` SIMD cases and `22` assertions in `4` DSP cases,
+  full binaries passed `2927` assertions in `23` cases and `75`
+  assertions in `34` cases, focused CTest passed `7/7`,
+  `git diff --check`, skill-sync report, and version-bump report.
 
 Open supporting PR:
 
@@ -476,7 +496,7 @@ Open supporting PR:
   updated after `#816` merged, `#817` was repaired, `#820` opened,
   `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
   merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
-  merged, and remains docs-only.
+  merged, and `#825` opened, and remains docs-only.
 
 Local environment note:
 
@@ -507,10 +527,13 @@ Next recovery actions:
 5. Monitor `#824` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-math-helper-coverage-645`,
    patch, validate locally, and push with lease.
-6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. Monitor `#825` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-signal-dsp-helper-coverage-645`,
+   patch, validate locally, and push with lease.
+7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-7. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 03:15 EDT
+Last reviewed: 2026-04-26 13:37 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -128,117 +128,30 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#795` events volume/service-discovery coverage -> `f1a5aa84`
 - `#802` CLI-create shellout coverage -> `2de79ff3`
 - `#803` signal matrix helper coverage -> `57285797`
+- `#801` render texture-atlas coverage and LCOV converter fix -> `ae4fdab8`
+- `#804` signal Oversampler helper coverage -> `c6600f9`
+- `#805` CLI common helper coverage -> `5844c6ac`
+- `#806` audio mapped-reader/offline processing coverage -> `1bcb23e3`
+- `#807` audio ChannelSet helper coverage -> `46e0fdeb`
+- `#808` MIDI file edge round-trip coverage -> `aae5d5d0`
+- `#809` signal FFT/convolver helper coverage -> `453bcec8`
 
 Open Phase 3 PRs:
 
-- `#801` `fix(render): harden texture atlas edge cases`, branch
-  `feature/render-texture-atlas-coverage-646`, commit `325485bc`,
-  worktree `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`.
-  Scope: reject non-positive `AtlasPacker` allocation dimensions, clamp
-  repeated `ImageAtlas::release()` calls so refcounts cannot underflow,
-  avoid unsigned frame-age underflow for Image/Gradient/Glyph/Path atlas
-  eviction when `last_used` is ahead of `current_frame`, cover
-  full-atlas allocation failure and `GradientAtlas` capacity exhaustion,
-  and move `pulp-test-texture-atlas` out of the GPU-only CMake block
-  because the helpers are header-only. Local validation: GPU-off
-  configure with `PULP_BUILD_EXAMPLES=OFF` and `PULP_ENABLE_GPU=OFF`,
-  `pulp-test-texture-atlas` target build, direct binary passed with
-  `1139` assertions in `22` test cases, focused texture/atlas CTest
-  passed `20/20`, `git diff --check` clean, skill sync clean, and version
-  report clean with explicit `Version-Bump: sdk=patch` for the
-  header-only behavior fix. The branch was rebased onto `origin/main`
-  after `#795` merged, then updated as `325485bc` after Codecov reported
-  a false diff-coverage miss for covered `texture_atlas.hpp` lines. The
-  follow-up fixes `tools/scripts/lcov_cobertura.py` so duplicate LCOV
-  source-file records merge instead of overwriting covered header hits,
-  and adds a regression test in `tools/scripts/test_run_coverage.py`.
-  Local validation for the follow-up: `test_run_coverage.py` passed,
-  direct `pulp-test-texture-atlas` passed, focused texture/atlas CTest
-  passed `20/20`, a local LLVM coverage-to-Cobertura reproduction showed
-  the changed atlas lines covered, `git diff --check` clean, skill sync
-  clean, and version report still clean. The PR is labeled `codecov` and
-  is using the direct GitHub/Namespace path.
-- `#804` `test(signal): cover oversampling helper edges`, branch
-  `feature/signal-oversampling-coverage-645`, commit `bccaec0f`,
-  worktree `/Users/danielraffel/Code/pulp-signal-oversampling-coverage-645`.
-  Scope: test-only signal `Oversampler` coverage for x2/x4 callback
-  dispatch, configured anti-alias filter paths, and reset determinism.
-  Local validation: no-GPU configure,
-  `pulp-test-signal` target build, direct Catch2 tag
-  `[signal][oversampling]` passed with `16` assertions in `2` test cases,
-  focused CTest `Oversampler` passed `2/2`, `git diff --check` clean,
-  skill sync clean, and version bump report says no bump needed. The
-  local build still reports an existing unused-variable warning elsewhere
-  in `test/test_signal.cpp`; it is not introduced by this tranche. The PR
-  is labeled `codecov` and is using the direct GitHub/Namespace path.
-- `#805` `test(cli): cover common helper edges`, branch
-  `feature/cli-common-coverage-643`, commit `17b42f0f`, worktree
-  `/Users/danielraffel/Code/pulp-cli-common-coverage-643`.
-  Scope: test-only CLI common helper coverage for numeric parsing,
-  string normalization, root/path containment helpers, `PULP_HOME` and
-  config overrides, create-format defaults, AAX helper labels, shell
-  quoting, and fuzzy scoring. Local validation: no-GPU configure,
-  `pulp-test-cli-project-command` target build, direct Catch2 tag
-  `[cli][common][issue-643]` passed with `54` assertions in `4` test
-  cases, focused CTest `cli common` passed `4/4`, `git diff --check`
+- `#810` `test(platform): cover environment diff edges`, branch
+  `feature/platform-environment-coverage-640`, commit `bc1e96af`,
+  worktree `/Users/danielraffel/Code/pulp-platform-environment-coverage-640`.
+  Scope: test-only platform `Environment` coverage for inert empty
+  listener subscriptions, token move-assignment replacement, keyboard
+  animation-duration diffs, left/right safe-area diffs, display
+  physical/name/refresh metadata diffs, and isolated orientation/lifecycle
+  changes. Local validation after rebasing onto `main` at `453bcec8`:
+  `pulp-test-environment` target build, direct Catch2 selector
+  `[environment][issue-640]` passed with `32` assertions in `5` test
+  cases, focused CTest `Environment` passed `16/16`, `git diff --check`
   clean, skill sync clean, and version bump report says no bump needed.
   The PR is labeled `codecov` and is using the direct GitHub/Namespace
   path.
-- `#806` `test(audio): cover mapped reader and offline processing`,
-  branch `feature/audio-reader-coverage-640`, commit `c1d61e3a`,
-  worktree `/Users/danielraffel/Code/pulp-audio-reader-coverage-640`.
-  Scope: deterministic `MemoryMappedAudioReader` coverage for
-  open/read-range/read-all/close/missing-file paths, offline processing
-  coverage for guard paths, non-divisible block tails, `apply_gain`, and
-  `offline_process_file` registry dispatch, plus a defensive production
-  guard so `block_size <= 0` returns `nullopt` instead of hanging. Local
-  validation: no-GPU configure, `pulp-test-audio-file` target build,
-  direct Catch2 tag `[issue-640]` passed with `159` assertions in `7`
-  test cases, full `pulp-test-audio-file` passed with `392` assertions in
-  `22` test cases, focused CTest passed `15/15`, `git diff --check`
-  clean, skill sync clean, and version bump report exits clean while
-  noting the SDK patch suggestion from the defensive production guard.
-  The PR is labeled `codecov` and is using the direct GitHub/Namespace
-  path.
-- `#807` `test(audio): cover channel set helpers`, branch
-  `feature/audio-channel-set-coverage-640`, commit `89b969c9`,
-  worktree `/Users/danielraffel/Code/pulp-audio-channel-set-coverage-640`.
-  Scope: test-only `ChannelSet` coverage for standard layouts by count
-  and name, discrete fallbacks, speaker-name mappings including the
-  unknown-enum fallback, and equality semantics. Local validation:
-  no-GPU configure, `pulp-test-audio` target build, direct Catch2 tag
-  `[audio][channel-set][issue-640]` passed with `38` assertions in `2`
-  test cases, focused CTest `ChannelSet` passed `2/2`, diff check
-  clean, skill sync clean, and version bump report says no bump
-  needed. The PR is labeled `codecov` and is using the direct
-  GitHub/Namespace path.
-- `#808` `test(midi): cover file edge round trips`, branch
-  `feature/midi-file-coverage-645`, commit `d02e853e`, worktree
-  `/Users/danielraffel/Code/pulp-midi-file-coverage-645`.
-  Scope: test-only MIDI file coverage for empty-track and zero-event
-  round-trips, plus multi-track program-change, pitch-bend, and note-on
-  readback. Local validation: no-GPU configure,
-  `pulp-test-midi` target build, direct Catch2 tag
-  `[midi][file][issue-645]` passed with `19` assertions in `2` test
-  cases, focused CTest `MidiFile` passed `5/5`, `git diff --check`
-  clean, skill sync clean, and version bump report says no bump needed.
-  The PR is labeled `codecov` and is using the direct GitHub/Namespace
-  path.
-- `#809` `test(signal): cover fft helper edges`, branch
-  `feature/signal-fft-coverage-645`, commit `11c83082`, worktree
-  `/Users/danielraffel/Code/pulp-signal-fft-coverage-645`.
-  Scope: test-only FFT helper coverage for move construction and move
-  assignment, linear and dB magnitude edge cases including silence
-  clamping, exact-bin real FFT conjugate symmetry, and `Convolver::reset`
-  clearing buffered overlap. Local validation: no-GPU configure,
-  `pulp-test-signal` target build, direct Catch2 selector
-  `[signal][fft],[signal][convolver][issue-645]` passed with `582`
-  assertions in `8` test cases, focused CTest `FFT|Convolver` passed
-  `10/10`, `git diff --check` clean, skill sync clean, and version bump
-  report says no bump needed. The local build still reports the existing
-  unused-variable warning elsewhere in `test/test_signal.cpp`; this
-  tranche does not introduce it. The PR is labeled `codecov` and is using
-  the direct GitHub/Namespace path.
 
 Local Phase 3 draft worktrees:
 
@@ -283,7 +196,8 @@ Local Phase 3 draft worktrees:
 - `#646` texture-atlas render worktree
   `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`,
   branch `feature/render-texture-atlas-coverage-646`, commit
-  `325485bc`; open as PR `#801`.
+  `325485bc`; merged via PR `#801` as `ae4fdab8`. The remote branch was
+  deleted after merge.
 - `#645` signal matrix helper worktree
   `/Users/danielraffel/Code/pulp-signal-matrix-coverage-645`, branch
   `feature/signal-matrix-coverage-645`, commit `b1f5a125`; merged via PR
@@ -291,47 +205,40 @@ Local Phase 3 draft worktrees:
 - `#645` signal oversampling helper worktree
   `/Users/danielraffel/Code/pulp-signal-oversampling-coverage-645`,
   branch `feature/signal-oversampling-coverage-645`, commit `bccaec0f`;
-  open as PR `#804`.
+  merged via PR `#804` as `c6600f9`. The remote branch was deleted after
+  merge.
 - `#643` CLI common helper worktree
   `/Users/danielraffel/Code/pulp-cli-common-coverage-643`, branch
-  `feature/cli-common-coverage-643`, commit `17b42f0f`; open as PR
-  `#805`.
+  `feature/cli-common-coverage-643`, commit `17b42f0f`; merged via PR
+  `#805` as `5844c6ac`. The remote branch was deleted after merge.
 - `#640` mapped-reader/offline audio worktree
   `/Users/danielraffel/Code/pulp-audio-reader-coverage-640`, branch
-  `feature/audio-reader-coverage-640`, commit `c1d61e3a`; open as PR
-  `#806`.
+  `feature/audio-reader-coverage-640`, commit `c1d61e3a`; merged via PR
+  `#806` as `1bcb23e3`. The remote branch was deleted after merge.
 - `#640` ChannelSet audio worktree
   `/Users/danielraffel/Code/pulp-audio-channel-set-coverage-640`,
   branch `feature/audio-channel-set-coverage-640`, commit `89b969c9`;
-  open as PR `#807`.
+  merged via PR `#807` as `46e0fdeb`. The remote branch was deleted after
+  merge.
 - `#640` platform Environment diff-edge worktree
   `/Users/danielraffel/Code/pulp-platform-environment-coverage-640`,
   branch `feature/platform-environment-coverage-640`, commit
-  `b298c7a2`; local-only draft, not opened as a PR yet. Scope: empty
-  listener subscription, token move-assignment replacement, keyboard
-  animation-duration diffs, left/right safe-area diffs, display
-  physical/name/refresh metadata diffs, and isolated orientation/
-  lifecycle changes. Local validation: no-GPU configure,
-  `pulp-test-environment` target build, direct Catch2 selector
-  `[environment][issue-640]` passed with `32` assertions in `5` test
-  cases, focused CTest `Environment` passed `16/16`, `git diff --check`
-  clean, skill sync clean, and version bump report says no bump needed.
-  Hold local until the active CI queue has a merge slot.
+  `bc1e96af`; open as PR `#810`.
 - `#645` MIDI file edge round-trip worktree
   `/Users/danielraffel/Code/pulp-midi-file-coverage-645`, branch
-  `feature/midi-file-coverage-645`, commit `d02e853e`; open as PR
-  `#808`.
+  `feature/midi-file-coverage-645`, commit `d02e853e`; merged via PR
+  `#808` as `aae5d5d0`. The remote branch was deleted after merge.
 - `#645` signal FFT/convolver helper worktree
   `/Users/danielraffel/Code/pulp-signal-fft-coverage-645`, branch
-  `feature/signal-fft-coverage-645`, commit `11c83082`; open as PR
-  `#809`.
+  `feature/signal-fft-coverage-645`, commit `11c83082`; merged via PR
+  `#809` as `453bcec8`. The remote branch was deleted after merge.
 
 Open supporting PR:
 
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#803` merged and
+  The branch has been rebased onto `origin/main` after `#809` merged and
   remains docs-only.
 
 Local environment note:
@@ -345,15 +252,12 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#801`, `#804`, `#805`, `#806`, `#807`, `#808`, and `#809`
+2. Monitor `#810`
    and address any Codecov, build, sanitizer, or Namespace feedback.
 3. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-4. When the queue has a merge slot, push/open the local #640 platform
-   Environment draft from
-   `/Users/danielraffel/Code/pulp-platform-environment-coverage-640`.
-5. Continue Phase 3 from the tranche issues below, prioritizing
+4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 18:42 EDT
+Last reviewed: 2026-04-26 18:53 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -151,6 +151,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#820` signal spectrogram edge coverage -> `1a1b7f07`
 - `#823` platform helper edge coverage -> `f69338eb`
 - `#824` signal math helper coverage and Mat3 fix -> `94e3ef2a`
+- `#825` signal DSP helper edge coverage -> `d0262a1b`
 
 Open Phase 3 PRs:
 
@@ -163,11 +164,6 @@ Open Phase 3 PRs:
   branch now compares Android build-tools and NDK revisions numerically.
   This tranche also uses the GitHub/Namespace path while the SSH
   `windows` target remains unreachable.
-- `#825` signal DSP helper edge coverage for `#645`, branch
-  `feature/signal-dsp-helper-coverage-645`, head `da05acaf`; opened
-  from `main` at `7a646f33`. This tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
 - `#826` OGG reader edge coverage for `#640`, branch
   `feature/audio-ogg-reader-coverage-640`, head `6b721c22`; opened from
   `main` at `1a1b7f07`. This tranche also uses the GitHub/Namespace path
@@ -181,6 +177,10 @@ Open Phase 3 PRs:
   `4e2e6092`; opened from `main` at `94e3ef2a`. This tranche also uses
   the GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
+- `#829` MIDI-CI edge coverage for `#645`, branch
+  `feature/midi-ci-coverage-645`, head `f0ef6b0f`; opened from `main`
+  at `94e3ef2a`. This tranche also uses the GitHub/Namespace path while
+  the SSH `windows` target remains unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -486,7 +486,8 @@ Local Phase 3 draft worktrees:
 - `#645` signal DSP helper worktree
   `/Users/danielraffel/Code/pulp-signal-dsp-helper-coverage-645`,
   branch `feature/signal-dsp-helper-coverage-645`, commit `da05acaf`;
-  open as PR `#825`.
+  merged via PR `#825` as `d0262a1b`. The remote branch was deleted
+  after merge.
   Scope: test-only coverage for `AlignedBuffer` move assignment,
   same-size resize, empty clear, and copy truncation paths;
   `BallisticsFilter` time-constant clamp and buffer processing paths;
@@ -540,6 +541,18 @@ Local Phase 3 draft worktrees:
   skill-sync report, and version-bump report with
   `Version-Bump: sdk=patch` because the inline header is an internal
   transport helper despite living under `include`.
+- `#645` MIDI-CI worktree
+  `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, branch
+  `feature/midi-ci-coverage-645`, commit `f0ef6b0f`; open as PR `#829`.
+  Scope: test-only coverage for profile inquiry destination encoding,
+  malformed and unhandled CI messages, discovery inquiry destination
+  filtering, discovery reply storage plus callback dispatch, unknown
+  profile enable/disable no-op paths, and enabled/disabled profile reply
+  payload layout. Local validation: no-GPU/no-examples configure,
+  `pulp-test-midi-ci` build, direct `[issue-645]` run passed `38`
+  assertions in `6` cases, full binary passed `65` assertions in `15`
+  cases, focused CTest passed `6/6`, `git diff --check`, skill-sync
+  report, and version-bump report.
 
 Open supporting PR:
 
@@ -552,7 +565,8 @@ Open supporting PR:
   merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
   merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
   repaired again for Android SDK discovery, `#827` opened, `#823`
-  merged, `#824` merged, and `#828` opened, and remains docs-only.
+  merged, `#824` merged, `#828` opened, `#829` opened, and `#825`
+  merged, and remains docs-only.
 
 Local environment note:
 
@@ -574,17 +588,17 @@ Next recovery actions:
 2. Monitor `#822` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
    patch, validate locally, and push with lease.
-3. Monitor `#825` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-signal-dsp-helper-coverage-645`,
-   patch, validate locally, and push with lease.
-4. Monitor `#826` cloud checks; if a required lane fails, debug in
+3. Monitor `#826` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-ogg-reader-coverage-640`,
    patch, validate locally, and push with lease.
-5. Monitor `#827` cloud checks; if a required lane fails, debug in
+4. Monitor `#827` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-meter-coverage-645`, patch,
    validate locally, and push with lease.
-6. Monitor `#828` cloud checks; if a required lane fails, debug in
+5. Monitor `#828` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-raw-parser-coverage-645`, patch,
+   validate locally, and push with lease.
+6. Monitor `#829` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, patch,
    validate locally, and push with lease.
 7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 03:01 EDT
+Last reviewed: 2026-04-26 03:04 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -240,6 +240,21 @@ Open Phase 3 PRs:
   clean, skill sync clean, and version bump report says no bump needed.
   The PR is labeled `codecov` and is using the direct GitHub/Namespace
   path.
+- `#809` `test(signal): cover fft helper edges`, branch
+  `feature/signal-fft-coverage-645`, commit `11c83082`, worktree
+  `/Users/danielraffel/Code/pulp-signal-fft-coverage-645`.
+  Scope: test-only FFT helper coverage for move construction and move
+  assignment, linear and dB magnitude edge cases including silence
+  clamping, exact-bin real FFT conjugate symmetry, and `Convolver::reset`
+  clearing buffered overlap. Local validation: no-GPU configure,
+  `pulp-test-signal` target build, direct Catch2 selector
+  `[signal][fft],[signal][convolver][issue-645]` passed with `582`
+  assertions in `8` test cases, focused CTest `FFT|Convolver` passed
+  `10/10`, `git diff --check` clean, skill sync clean, and version bump
+  report says no bump needed. The local build still reports the existing
+  unused-variable warning elsewhere in `test/test_signal.cpp`; this
+  tranche does not introduce it. The PR is labeled `codecov` and is using
+  the direct GitHub/Namespace path.
 
 Local Phase 3 draft worktrees:
 
@@ -309,6 +324,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-midi-file-coverage-645`, branch
   `feature/midi-file-coverage-645`, commit `d02e853e`; open as PR
   `#808`.
+- `#645` signal FFT/convolver helper worktree
+  `/Users/danielraffel/Code/pulp-signal-fft-coverage-645`, branch
+  `feature/signal-fft-coverage-645`, commit `11c83082`; open as PR
+  `#809`.
 
 Open supporting PR:
 
@@ -329,7 +348,7 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#801`, `#803`, `#804`, `#805`, `#806`, `#807`, and `#808`
+2. Monitor `#801`, `#803`, `#804`, `#805`, `#806`, `#807`, `#808`, and `#809`
    and address any Codecov, build, sanitizer, or Namespace feedback.
 3. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -71,9 +71,10 @@ Latest complete Codecov `main` report observed while updating this doc:
 - workflow: Coverage run `24925413069`, completed successfully
 - overall tracked coverage: `43.28%` over `70,175` lines in `556` files
 - covered lines: `30,372`
-- note: `origin/main` is currently `95e917cf40026e29035f05c9eca1307ba68fa177`;
-  that commit is a changelog-only `[skip ci]` commit, so Codecov's latest
-  complete coverage report is from the previous executable-code commit.
+- note: `origin/main` is currently `a80929c42ff61b88cd366383baad2ee817558b57`.
+  Coverage and sanitizer workflows for that head are still in progress, so
+  Codecov's latest complete `main` report is still the older executable-code
+  baseline above until the new `main` Coverage run completes.
 
 Merged after the Phase 1 closeout / `#723` baseline:
 
@@ -86,17 +87,10 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#755` LV2 host/entry coverage -> `aed8acb`
 - `#756` validation harness edge coverage -> `22d1e69`
 - `#765` TextEditor multiline navigation coverage -> `7257a154`
+- `#766` OSC UDP sender/receiver edge coverage -> `31aa80e1`
 
 Open Phase 3 PRs:
 
-- `#766` OSC UDP sender/receiver edge coverage, branch
-  `feature/osc-udp-coverage-493`, head `0cecfa51`. The macOS UBSan
-  abort was reproduced locally and fixed by replacing the legacy
-  `gethostbyname`/`hostent` hostname fallback with `getaddrinfo`.
-  Local normal and UBSan OSC tests are green; GitHub Actions has passed
-  Linux/Windows/macOS Namespace, Linux/Windows coverage, Codecov patch,
-  IWYU, docs, Android, version, and audit lanes. It is still draining
-  macOS coverage and macOS sanitizer lanes.
 - `#771` WidgetBridge extended-controls coverage, branch
   `feature/widget-bridge-coverage-493`, head `429b8941`. Local
   `pulp-test-widget-bridge`, focused CTest, skill sync, version report,
@@ -104,8 +98,13 @@ Open Phase 3 PRs:
   GPU-only `pulp::inspect` link from `pulp-test-cli-project-command` and
   generates the CLI version header when `tools/cli` is skipped in
   `PULP_ENABLE_GPU=OFF` sanitizer/IWYU configurations. Local GPU-off
-  configure/build plus `pulp-test-cli-project-command` are green; GitHub
-  Actions reran at `429b8941` and is draining.
+  configure/build plus `pulp-test-cli-project-command` are green. GitHub
+  Actions at `429b8941` has passed Codecov patch, IWYU, Linux/macOS/Windows
+  coverage, Linux Namespace, Windows MSVC, docs, audit, Android, and version
+  checks, but Windows Namespace failed while the overall run was still in
+  progress and logs were not yet available through `gh run view`. The next
+  action is to pull that failed job log when the run completes, then either
+  rerun if it is an infra flake or patch the branch if it is reproducible.
 - `#777` real CLAP `PluginSlot` coverage, branch
   `feature/clap-slot-coverage-493`, head `5363bbe0`. This tranche wires
   the built PulpGain CLAP bundle into host tests after examples are
@@ -113,8 +112,28 @@ Open Phase 3 PRs:
   coverage, and fixes CLAP state restore so restored plugin state
   supersedes stale cached host edits. Local configure, build,
   `pulp-test-host`, generated `ClapSlot` CTest entries, whitespace,
-  CI-configured skill-sync, and version checks are green; GitHub Actions
-  is draining.
+  CI-configured skill-sync, and version checks are green. GitHub Actions
+  has passed Codecov patch, Linux coverage, Android, docs, audit, version,
+  and Windows MSVC checks, but IWYU failed for the same GPU-off
+  `pulp-test-cli-project-command` / `pulp::inspect` CMake issue that `#771`
+  fixes. The preferred path is to merge or repair `#771`, then rebase `#777`
+  and rerun; if `#771` stays blocked, carrying the minimal CMake fix in
+  `#777` is the fallback.
+
+Active local Phase 3 branch not yet in PR:
+
+- `feature/vst3-adapter-coverage-493`, worktree
+  `/Users/danielraffel/Code/pulp-vst3-adapter-coverage-493`, adds focused
+  VST3 adapter coverage for parameter metadata, setup/release lifecycle,
+  bus/event/process routing, sidechain visibility, secondary output zeroing,
+  host input automation, plugin-to-host output automation, MIDI output, and
+  transport context mapping. Local `pulp-test-vst3-plugin-state` passed
+  `118` assertions / `5` test cases, and the focused CTest subset passed
+  `5/5`. A broad local `ctest -R "VST3|vst3"` also ran, but it includes
+  `pluginval-*` bundle validation tests and those failed locally because
+  pluginval found zero plugin types in the built VST3 bundles; that is being
+  treated separately from the unit coverage tranche unless it reproduces in
+  CI.
 
 Open supporting PR:
 
@@ -127,13 +146,18 @@ Open supporting PR:
 
 Next recovery actions:
 
-1. Poll `#766`, `#771`, `#774`, and `#777`; merge green PRs manually
-   because auto-merge is disabled.
-2. If a PR is green but GitHub reports it behind `main`, rebase that
+1. Poll `#771`, `#774`, and `#777`; merge green PRs manually because
+   auto-merge is disabled.
+2. Diagnose `#771`'s Windows Namespace failure once logs are available.
+3. Rebase or patch `#777` after the `#771` CMake fix lands, because its
+   current IWYU failure is the same GPU-off CMake issue.
+4. Finish local validation for `feature/vst3-adapter-coverage-493`, open a
+   PR, and keep it separate from the CLAP/WidgetBridge branches.
+5. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-3. After active PRs merge, refresh this section with the next complete
+6. After active PRs merge, refresh this section with the next complete
    Codecov `main` report.
-4. Continue Phase 3 from the tranche issues below, prioritizing
+7. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 22:36 EDT
+Last reviewed: 2026-04-25 22:50 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -132,6 +132,17 @@ Local Phase 3 draft worktrees:
 - `#640` AIFF reader edge-path worktree
   `/Users/danielraffel/Code/pulp-audio-aiff-coverage-640`, branch
   `feature/audio-aiff-coverage-640`, commit `f3414ae9`; open as PR `#794`.
+- `#642` events volume/service-discovery worktree
+  `/Users/danielraffel/Code/pulp-events-volume-coverage-642`, branch
+  `feature/events-volume-coverage-642`, commit `6e56d62b`; local draft is
+  ready but not opened yet to avoid overlapping local Shipyard runs while
+  `#794` is still validating. Scope: deterministic
+  `test/test_network_service_discovery.cpp` coverage for
+  `NetworkServiceDiscovery` backend removal, mounted-volume snapshot and
+  start/stop lifecycle, and `LockingAsyncUpdater::trigger_and_wait()`.
+  Validation: `pulp-test-network-service-discovery` passed with `43`
+  assertions in `10` test cases; focused CTest passed `10/10`;
+  `git diff --check` clean; version bump report says no bump needed.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
   `feature/package-registry-coverage-643`, commit `75a529ef`; merged via
@@ -157,9 +168,12 @@ Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
 2. Monitor `#794` and address any Codecov, build, or Shipyard feedback.
-3. If a new PR is green but GitHub reports it behind `main`, rebase that
+3. Once `#794` is resolved or no longer consuming the local Shipyard mac
+   lane, open the ready `#642` draft from
+   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`.
+4. If a new PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-4. Continue Phase 3 from the tranche issues below, prioritizing
+5. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 02:13 EDT
+Last reviewed: 2026-04-26 02:22 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -195,6 +195,19 @@ Open Phase 3 PRs:
   local build still reports an existing unused-variable warning elsewhere
   in `test/test_signal.cpp`; it is not introduced by this tranche. The PR
   is labeled `codecov` and is using the direct GitHub/Namespace path.
+- `#805` `test(cli): cover common helper edges`, branch
+  `feature/cli-common-coverage-643`, commit `17b42f0f`, worktree
+  `/Users/danielraffel/Code/pulp-cli-common-coverage-643`.
+  Scope: test-only CLI common helper coverage for numeric parsing,
+  string normalization, root/path containment helpers, `PULP_HOME` and
+  config overrides, create-format defaults, AAX helper labels, shell
+  quoting, and fuzzy scoring. Local validation: no-GPU configure,
+  `pulp-test-cli-project-command` target build, direct Catch2 tag
+  `[cli][common][issue-643]` passed with `54` assertions in `4` test
+  cases, focused CTest `cli common` passed `4/4`, `git diff --check`
+  clean, skill sync clean, and version bump report says no bump needed.
+  The PR is labeled `codecov` and is using the direct GitHub/Namespace
+  path.
 
 Local Phase 3 draft worktrees:
 
@@ -248,6 +261,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-signal-oversampling-coverage-645`,
   branch `feature/signal-oversampling-coverage-645`, commit `bccaec0f`;
   open as PR `#804`.
+- `#643` CLI common helper worktree
+  `/Users/danielraffel/Code/pulp-cli-common-coverage-643`, branch
+  `feature/cli-common-coverage-643`, commit `17b42f0f`; open as PR
+  `#805`.
 
 Open supporting PR:
 
@@ -268,11 +285,11 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#801`, `#802`, `#803`, and `#804` and address any Codecov,
-   build, sanitizer, or Namespace feedback.
-3. If `#801`, `#802`, `#803`, or `#804` is green but GitHub reports it
-   behind `main`, rebase that branch onto `origin/main`, push with lease,
-   and let checks rerun.
+2. Monitor `#801`, `#802`, `#803`, `#804`, and `#805` and address any
+   Codecov, build, sanitizer, or Namespace feedback.
+3. If `#801`, `#802`, `#803`, `#804`, or `#805` is green but GitHub
+   reports it behind `main`, rebase that branch onto `origin/main`, push
+   with lease, and let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 16:20 EDT
+Last reviewed: 2026-04-26 16:23 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -143,12 +143,10 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#813` signal dynamics helper coverage -> `957a0735`
 - `#814` CLI `pulp pr` shellout coverage -> `8bd4a3e9`
 - `#815` MPE tracker edge-path coverage -> `019130bd`
+- `#816` MIDI running-status parser edge coverage -> `c9620a65`
 
 Open Phase 3 PRs:
 
-- `#816` MIDI running-status parser edge coverage for `#645`, branch
-  `feature/midi-running-status-coverage-645`, head `94b93a6e`; opened
-  from `main` at `957a0735`. Cloud checks are the active gate.
 - `#817` UMP conversion edge coverage for `#645`, branch
   `feature/midi-ump-conversion-coverage-645`, head `c4420370`; opened
   from `main` at `957a0735`. `shipyard pr` was attempted first but
@@ -305,7 +303,8 @@ Local Phase 3 draft worktrees:
 - `#645` MIDI running-status parser worktree
   `/Users/danielraffel/Code/pulp-midi-running-status-coverage-645`,
   branch `feature/midi-running-status-coverage-645`, commit `94b93a6e`;
-  open as PR `#816`.
+  merged via PR `#816` as `c9620a65`. The remote branch was deleted
+  after merge.
   Scope: test-only coverage for one-byte and two-byte channel running
   status, system-common data lengths, real-time bytes inside sysex,
   status restart inside sysex, empty sysex / unknown status ignore
@@ -368,7 +367,7 @@ Open supporting PR:
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#813` merged,
-  updated after `#815` merged and `#819` opened, and remains docs-only.
+  updated after `#816` merged and `#819` opened, and remains docs-only.
 
 Local environment note:
 
@@ -387,22 +386,19 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#816` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-midi-running-status-coverage-645`,
-   patch, validate locally, and push with lease.
-3. Monitor `#817` cloud checks; if a required lane fails, debug in
+2. Monitor `#817` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
    patch, validate locally, and push with lease.
-4. Monitor `#818` cloud checks; if a required lane fails, debug in
+3. Monitor `#818` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-synth-voice-coverage-645`,
    patch, validate locally, and push with lease.
-5. Monitor `#819` cloud checks; if a required lane fails, debug in
+4. Monitor `#819` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-keyboard-sequence-coverage-645`,
    patch, validate locally, and push with lease.
-6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+5. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-7. Continue Phase 3 from the tranche issues below, prioritizing
+6. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 22:43 EDT
+Last reviewed: 2026-04-26 22:49 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -66,7 +66,7 @@ Finish line:
 ## Current live state
 
 Latest complete Codecov `main` report observed while updating this doc
-(`main` head `8fc5dd2d` has a newer Coverage run queued):
+(`main` head `62ad9870` has a newer Coverage run queued):
 
 - commit: `5b8e4529cfc553fd98b65f265ed1e9c0487b3d66`
 - workflow: Coverage run `24970413173`, completed successfully
@@ -164,6 +164,8 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#834` events event-loop lifecycle edge coverage -> `455c0a9d`
 - `#829` MIDI-CI edge coverage -> `eaf991b0`
 - `#833` signal filter-design edge coverage -> `8fc5dd2d`
+- `#838` CLI release packager coverage -> `3d47dbd2`
+- `#839` GPU graph render helper hardening/coverage -> `62ad9870`
 
 Open Phase 3 PRs:
 
@@ -186,18 +188,6 @@ Open Phase 3 PRs:
   `PULP_HOME` and cleared password env vars. This tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
-- `#838` CLI release packager coverage for `#643`, branch
-  `feature/package-cli-coverage-643`, head `09666f46`; opened from
-  `main` at `b5e7a463`, then rebased onto `d02c9ec9` and repaired after
-  macOS Namespace exposed a parallel CTest temp-dir collision in
-  `test/test_android_package.cpp`. This tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
-- `#839` GPU graph render helper hardening/coverage for `#646`, branch
-  `feature/render-gpu-graph-coverage-646`, head `fa3deb3b`; opened
-  from `main` at `bdc406cc`, then rebased onto `d02c9ec9` after `#830`
-  merged. This tranche also uses the GitHub/Namespace path while the
-  SSH `windows` target remains unreachable.
 - `#840` events child-process manager coverage for `#642`, branch
   `feature/events-child-process-coverage-642`, head `410a0371`; opened
   from `main` at `455c0a9d`, then rebased onto `eaf991b0` after `#829`
@@ -266,6 +256,15 @@ Open Phase 3 PRs:
   `feature/midi-signal-helper-coverage-645-next2`, head `2d8b0bc3`;
   covers rounded/zero block-size setup, empty IR pass-through, and
   wrong-block-size pass-through behavior.
+- `#856` CLI/tools LCOV/Cobertura helper coverage for `#643`, branch
+  `feature/cli-tools-coverage-643-next3`, head `96d20a3a`; covers
+  package exclusions before summary-rate calculation, duplicate
+  source-record function-hit merging, and relpath fallback paths.
+- `#857` events async-helper coverage for `#642`, branch
+  `feature/events-helper-coverage-642-next2`, head `4cbfd67c`; adds a
+  focused async-helper target covering reentrant `AsyncUpdater`,
+  `LambdaAsyncUpdater` empty-callback handling, `ActionBroadcaster`
+  missing-removal behavior, and `MultiTimer` stop-all/restart behavior.
 
 Local Phase 3 draft worktrees:
 
@@ -481,7 +480,8 @@ Local Phase 3 draft worktrees:
 - `#646` GPU graph render helper worktree
   `/Users/danielraffel/Code/pulp-render-gpu-graph-coverage-646`,
   branch `feature/render-gpu-graph-coverage-646`, commit `fa3deb3b`;
-  open as PR `#839`.
+  merged via PR `#839` as `62ad9870`. The remote branch was deleted
+  after merge.
   Scope: hardens `GpuGraphRenderer`, `GpuHeatMapRenderer`, and
   `GpuBarRenderer` raw-pointer `set_data()` paths for null, zero-sized,
   and overflowing inputs; adds focused `test_gpu_graph.cpp` edge
@@ -497,8 +497,8 @@ Local Phase 3 draft worktrees:
   report with an SDK patch trailer, and pre-push gates.
 - `#643` CLI release packager worktree
   `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, branch
-  `feature/package-cli-coverage-643`, commit `09666f46`; open as PR
-  `#838`.
+  `feature/package-cli-coverage-643`, commit `09666f46`; merged via PR
+  `#838` as `3d47dbd2`. The remote branch was deleted after merge.
   Scope: test-only Python coverage for `tools/scripts/package_cli.py`
   wgpu library discovery, macOS/Linux rpath command selection,
   tar/zip archive writer layout, missing-binary and missing-library
@@ -968,6 +968,30 @@ Local Phase 3 draft worktrees:
   convolver binary with `91` assertions in `6` cases, direct
   `[issue-645]` run with `19` assertions in `2` cases, and focused CTest
   `6/6`.
+- `#643` LCOV/Cobertura helper worktree
+  `/Users/danielraffel/Code/pulp-cli-tools-coverage-643-next3`,
+  branch `feature/cli-tools-coverage-643-next3`, commit `96d20a3a`;
+  open as PR `#856`. Scope: test-only coverage for
+  `tools/scripts/test_run_coverage.py` package exclusions before
+  summary-rate calculation, duplicate source-record function-hit
+  merging, and relpath `ValueError` fallback paths. Local validation
+  passed `python3 tools/scripts/test_run_coverage.py`,
+  `python3 tools/scripts/test_merge_cobertura.py`,
+  `python3 tools/scripts/test_run_python_coverage.py`, and diff check;
+  local `coverage.py >= 7.10` is not installed, so hosted CI remains the
+  coverage proof.
+- `#642` events async-helper worktree
+  `/Users/danielraffel/Code/pulp-events-helper-coverage-642-next2`,
+  branch `feature/events-helper-coverage-642-next2`, commits `7b6f653e`
+  and metadata tip `4cbfd67c`; open as PR `#857`. Scope: new focused
+  test-only target for reentrant `AsyncUpdater`, `LambdaAsyncUpdater`
+  empty-callback handling, `ActionBroadcaster` missing-removal behavior,
+  and `MultiTimer` stop-all/restart behavior. Local validation after
+  rebasing onto `origin/main` passed the no-GPU/no-examples configure,
+  affected target build, direct `pulp-test-events-async-helpers` run
+  with `16` assertions in `4` cases, focused CTest `12/12`, diff check,
+  and pre-push gates with a `Version-Bump: sdk=skip` trailer for the
+  test-only target registration.
 
 Open supporting PR:
 
@@ -1003,7 +1027,9 @@ Open supporting PR:
   `#846`, `#847`, `#848`, `#849`, `#850`, and `#851` opened from the
   parallel worker batch, and `#833` merged as `8fc5dd2d`, and `#840`
   was repaired for diff coverage with `410a0371`, and `#852`, `#853`,
-  `#854`, and `#855` opened from the next worker batch,
+  `#854`, and `#855` opened from the next worker batch, and `#838`
+  merged as `3d47dbd2`, and `#839` merged as `62ad9870`, and `#856`
+  and `#857` opened from the latest worker batch,
   and remains docs-only.
 
 Local environment note:
@@ -1029,32 +1055,26 @@ Next recovery actions:
 3. Monitor `#835` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
    validate locally, and push with lease.
-4. Monitor `#838` cloud checks on head `09666f46`; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, patch,
-   validate locally, and push with lease.
-5. Monitor `#839` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-render-gpu-graph-coverage-646`,
-   patch, validate locally, and push with lease.
-6. Monitor `#840` cloud checks on head `410a0371`; if a required lane
+4. Monitor `#840` cloud checks on head `410a0371`; if a required lane
    fails after dependency bootstrap succeeds, debug in
    `/Users/danielraffel/Code/pulp-events-child-process-coverage-642`,
    patch, validate locally, and push with lease.
-7. Monitor `#842` cloud checks on head `0541fd69`; if a required lane
+5. Monitor `#842` cloud checks on head `0541fd69`; if a required lane
    fails, debug in
    `/Users/danielraffel/Code/pulp-inspect-codecov-component-841`,
    patch, validate locally, and push with lease.
-8. Monitor `#843` cloud checks on head `fcdbd278`; if a required lane
+6. Monitor `#843` cloud checks on head `fcdbd278`; if a required lane
    fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
    patch, validate locally, and push with lease.
-9. Monitor `#845` through `#855`; if a required lane fails, debug in
+7. Monitor `#845` through `#857`; if a required lane fails, debug in
    the worktree named in the open-PR list above, patch, validate
    locally, and push with lease. Pay particular attention to `#848` and
    `#851` because they include patch-level production hardening.
-10. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-11. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -166,6 +166,19 @@ Open Phase 3 PRs:
   the GPU-off target-link failure before any of those shared fixes had
   merged. GitHub Actions is rerunning at `f7da209d`.
 
+Local Phase 3 draft not yet opened as a PR:
+
+- `#642` events socket-IPC tranche, worktree
+  `/Users/danielraffel/Code/pulp-events-ipc-coverage-642`, branch
+  `feature/events-ipc-coverage-642`, local commit `aea1dfa7`. This draft
+  extends `test/test_ipc.cpp` with socket endpoint rejection coverage and
+  a deterministic localhost client/server framed-message exchange. Local
+  validation is green: configure, `cmake --build build --target
+  pulp-test-ipc -j4`, direct `pulp-test-ipc` (`23` assertions / `8` test
+  cases), focused CTest `IPC` (`8/8`), and whitespace. Keep this local
+  until one of the shared CI-unblocker PRs merges, or cherry-pick the same
+  shared GPU-off/sandbox/diff-coverage unblockers before opening it.
+
 Open supporting PR:
 
 - `#774` refreshes this durable handoff/status document, branch
@@ -185,14 +198,17 @@ Next recovery actions:
 3. If `#777` Windows Namespace fails again, pull the fresh completed-run
    log first; the previous failed job's log was unavailable while the
    overall run was still in progress.
-4. If sandbox-e2e fails again, pull the fresh log first; the expected
+4. Keep the local `#642` events IPC draft paused until the shared
+   CI-unblocker commits are on `main`; then rebase it, open a PR, and
+   link it from `#642`.
+5. If sandbox-e2e fails again, pull the fresh log first; the expected
    failure fixed here was `pulp upgrade --check-only` ignoring
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
-5. If a PR is green but GitHub reports it behind `main`, rebase that
+6. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-6. After active PRs merge, refresh this section with the next complete
+7. After active PRs merge, refresh this section with the next complete
    Codecov `main` report.
-7. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 18:28 EDT
+Last reviewed: 2026-04-26 18:31 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -150,6 +150,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#819` MIDI keyboard/sequence edge coverage -> `7a646f33`
 - `#820` signal spectrogram edge coverage -> `1a1b7f07`
 - `#823` platform helper edge coverage -> `f69338eb`
+- `#824` signal math helper coverage and Mat3 fix -> `94e3ef2a`
 
 Open Phase 3 PRs:
 
@@ -162,11 +163,6 @@ Open Phase 3 PRs:
   branch now compares Android build-tools and NDK revisions numerically.
   This tranche also uses the GitHub/Namespace path while the SSH
   `windows` target remains unreachable.
-- `#824` signal math helper coverage and Mat3 multiplication fix for
-  `#645`, branch `feature/signal-math-helper-coverage-645`, head
-  `1b7f1cfd`; opened from `main` at `a38216fd`. This tranche also uses
-  the GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
 - `#825` signal DSP helper edge coverage for `#645`, branch
   `feature/signal-dsp-helper-coverage-645`, head `da05acaf`; opened
   from `main` at `7a646f33`. This tranche also uses the
@@ -464,7 +460,8 @@ Local Phase 3 draft worktrees:
 - `#645` signal math helper worktree
   `/Users/danielraffel/Code/pulp-signal-math-helper-coverage-645`,
   branch `feature/signal-math-helper-coverage-645`, commits `b304e0f4`
-  and metadata tip `1b7f1cfd`; open as PR `#824`.
+  and metadata tip `1b7f1cfd`; merged via PR `#824` as `94e3ef2a`. The
+  remote branch was deleted after merge.
   Scope: fixes `Mat3::operator*` so multiplication accumulates into a
   zero matrix instead of adding the product onto the identity default,
   and adds coverage for polynomial empty/constant helpers, empty
@@ -517,7 +514,7 @@ Local Phase 3 draft worktrees:
   prepared-channel clamping, empty process blocks, correlation window
   replacement after reset, integrated LUFS running-average behavior,
   ballistics release/noise-floor clamping, and held-peak refresh paths.
-  This intentionally avoids `test_signal.cpp` while `#824` is open.
+  This intentionally avoided `test_signal.cpp` while `#824` was open.
   Local validation: no-GPU/no-examples configure,
   `pulp-test-multi-channel-meter` build, direct `[issue-645]` run
   passed `20` assertions in `6` cases, full binary passed `20`
@@ -534,8 +531,8 @@ Open supporting PR:
   `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
   merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
   merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
-  repaired again for Android SDK discovery, `#827` opened, and `#823`
-  merged, and remains docs-only.
+  repaired again for Android SDK discovery, `#827` opened, `#823`
+  merged, and `#824` merged, and remains docs-only.
 
 Local environment note:
 
@@ -557,22 +554,19 @@ Next recovery actions:
 2. Monitor `#822` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
    patch, validate locally, and push with lease.
-3. Monitor `#824` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-signal-math-helper-coverage-645`,
-   patch, validate locally, and push with lease.
-4. Monitor `#825` cloud checks; if a required lane fails, debug in
+3. Monitor `#825` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-dsp-helper-coverage-645`,
    patch, validate locally, and push with lease.
-5. Monitor `#826` cloud checks; if a required lane fails, debug in
+4. Monitor `#826` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-ogg-reader-coverage-640`,
    patch, validate locally, and push with lease.
-6. Monitor `#827` cloud checks; if a required lane fails, debug in
+5. Monitor `#827` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-meter-coverage-645`, patch,
    validate locally, and push with lease.
-7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-8. Continue Phase 3 from the tranche issues below, prioritizing
+7. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -92,33 +92,39 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#771` WidgetBridge extended-controls coverage, branch
-  `feature/widget-bridge-coverage-493`, head `c7e5de1d`. Local
+  `feature/widget-bridge-coverage-493`, head `b51a48b5`. Local
   `pulp-test-widget-bridge`, focused CTest, GPU-off configure/build of
   `pulp-test-cli-project-command`, skill sync, version report, and
   whitespace checks are green. The branch now carries three shared CI
   unblockers discovered while validating this tranche: the GPU-off
   `pulp-test-cli-project-command` CMake fix, Windows-safe CLI redirection
   for `pulp project bump` probes, and a GPU/`pulp::inspect` guard around
-  `examples/ui-preview`. GitHub Actions at `c7e5de1d` has passed Codecov
-  patch, Android coverage, docs, audit, version/skill sync, and provider
-  resolution; IWYU, sandbox-e2e, Namespace, coverage, Windows MSVC, and
-  sanitizer lanes are still draining.
+  `examples/ui-preview`. The branch also carries the sandbox-e2e
+  unblocker that makes `pulp upgrade --check-only` honor
+  `PULP_UPDATE_CHECK_DISABLED=1` without hitting GitHub Releases when the
+  update cache is empty. GitHub Actions at `b51a48b5` is draining; early
+  docs, audit, version/skill sync, provider resolution, Android coverage,
+  Linux Namespace, and Codecov patch checks are green, while sandbox-e2e,
+  remaining Namespace/coverage, Windows MSVC, IWYU, and sanitizer lanes
+  continue.
 - `#777` real CLAP `PluginSlot` coverage, branch
-  `feature/clap-slot-coverage-493`, head `ceb8c5db`. This tranche wires
+  `feature/clap-slot-coverage-493`, head `753bcccf`. This tranche wires
   the built PulpGain CLAP bundle into host tests after examples are
   registered, adds metadata/defaults, bypass/release, and restore-state
   coverage, and fixes CLAP state restore so restored plugin state
   supersedes stale cached host edits. The branch has been rebased onto
-  `origin/main` and now carries the same GPU-off CMake and `ui-preview`
-  guard fixes needed before `#771` lands. Local configure/build,
+  `origin/main` and now carries the same GPU-off CMake, Windows-safe CLI
+  redirection, `ui-preview` guard, and disabled-update-check fixes needed
+  before `#771` lands. Local configure/build,
   `pulp-test-host "[host][slot][clap]"` (`139` assertions / `4` test
   cases), generated `ClapSlot` CTest entries, whitespace, CI-configured
-  skill-sync, and version checks are green. GitHub Actions is rerunning at
-  `ceb8c5db`; early docs, audit, version/skill sync, and provider checks
-  are green while IWYU, Namespace, coverage, Windows MSVC, Android, and
-  sanitizer lanes drain.
+  skill-sync, direct disabled-upgrade smoke, and version checks are green.
+  GitHub Actions is rerunning at `753bcccf`; early docs, audit,
+  version/skill sync, provider checks, Android coverage, and docs preview
+  are green while sandbox-e2e, IWYU, Namespace, coverage, Windows MSVC,
+  Android build, and sanitizer lanes drain.
 - `#782` VST3 adapter process-path coverage, branch
-  `feature/vst3-adapter-coverage-493`, head `f2947827`. This tranche adds
+  `feature/vst3-adapter-coverage-493`, head `8e9caaa7`. This tranche adds
   focused VST3 adapter coverage for parameter metadata, setup/release lifecycle,
   bus/event/process routing, sidechain visibility, secondary output zeroing,
   host input automation, plugin-to-host output automation, MIDI output, and
@@ -132,10 +138,12 @@ Open Phase 3 PRs:
   `bc23956d` passed mac and ubuntu, then hit a Windows SSH bundle-upload
   timeout during banner exchange. The branch now carries the same shared
   GPU-off CMake, Windows-safe redirection, skill-doc, and `ui-preview`
-  guard fixes as `#771`; local GPU-off configure/build of
+  guard fixes as `#771`, plus the disabled-update-check sandbox-e2e
+  unblocker. Local GPU-off configure/build of
   `pulp-test-cli-project-command`, focused `pulp-test-vst3-plugin-state`
-  (`118` assertions / `5` test cases), whitespace, skill-sync, and version
-  checks are green. GitHub Actions is rerunning at `f2947827`.
+  (`118` assertions / `5` test cases), direct disabled-upgrade smoke,
+  whitespace, skill-sync, and version checks are green. GitHub Actions is
+  rerunning at `8e9caaa7`.
 
 Open supporting PR:
 
@@ -150,10 +158,11 @@ Next recovery actions:
 
 1. Poll `#771`, `#774`, `#777`, and `#782`; merge green PRs manually because
    auto-merge is disabled.
-2. Let the current `#771` and `#777` reruns drain after the shared CI
-   unblockers were pushed.
-3. Let the current `#782` rerun drain after the shared CI unblockers were
-   pushed at `f2947827`.
+2. Let the current `#771`, `#777`, and `#782` reruns drain after the
+   shared CI and sandbox-e2e unblockers were pushed.
+3. If sandbox-e2e fails again, pull the fresh log first; the expected
+   failure fixed here was `pulp upgrade --check-only` ignoring
+   `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
 4. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
 5. After active PRs merge, refresh this section with the next complete

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 21:01 EDT
+Last reviewed: 2026-04-26 21:15 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -66,7 +66,7 @@ Finish line:
 ## Current live state
 
 Latest complete Codecov `main` report observed while updating this doc
-(`main` head `b5e7a463` has a newer Coverage run queued):
+(`main` head `bdc406cc` has a newer Coverage run queued):
 
 - commit: `5b8e4529cfc553fd98b65f265ed1e9c0487b3d66`
 - workflow: Coverage run `24970413173`, completed successfully
@@ -158,6 +158,8 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#827` signal multi-channel meter edge coverage -> `d5efea57`
 - `#828` raw MIDI parser edge coverage and malformed-data hardening -> `5b8e4529`
 - `#831` signal utility helper edge coverage -> `b5e7a463`
+- `#836` CLI sync checker Python tooling coverage -> `6ef8ca8b`
+- `#837` package registry validation tools coverage -> `bdc406cc`
 
 Open Phase 3 PRs:
 
@@ -200,19 +202,15 @@ Open Phase 3 PRs:
   `PULP_HOME` and cleared password env vars. This tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
-- `#836` CLI sync checker coverage for `#643`, branch
-  `feature/cli-sync-coverage-643`, head `86048a3f`; opened from
-  `main` at `5b8e4529`. This tranche also uses the GitHub/Namespace
-  path while the SSH `windows` target remains unreachable.
-- `#837` package registry validation tools coverage for `#643`, branch
-  `feature/package-validator-coverage-643`, head `8a2edbe9`; opened
-  from `main` at `5b8e4529`. This tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
 - `#838` CLI release packager coverage for `#643`, branch
   `feature/package-cli-coverage-643`, head `7e76a1b7`; opened from
   `main` at `b5e7a463`. This tranche also uses the GitHub/Namespace
   path while the SSH `windows` target remains unreachable.
+- `#839` GPU graph render helper hardening/coverage for `#646`, branch
+  `feature/render-gpu-graph-coverage-646`, head `c4261740`; opened
+  from `main` at `bdc406cc`. This tranche also uses the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -379,8 +377,8 @@ Local Phase 3 draft worktrees:
   issues were resolved.
 - `#643` CLI sync checker worktree
   `/Users/danielraffel/Code/pulp-cli-sync-coverage-643`, branch
-  `feature/cli-sync-coverage-643`, commit `86048a3f`; open as PR
-  `#836`.
+  `feature/cli-sync-coverage-643`, commit `86048a3f`; merged via PR
+  `#836` as `6ef8ca8b`. The remote branch was deleted after merge.
   Scope: test-only Python coverage for `tools/scripts/cli_sync_check.py`
   repo-root discovery, command-table/YAML/slash-command/skill-reference
   extraction, strict JSON mismatch exits, warning-only success behavior,
@@ -393,7 +391,8 @@ Local Phase 3 draft worktrees:
 - `#643` package registry validation tools worktree
   `/Users/danielraffel/Code/pulp-package-validator-coverage-643`,
   branch `feature/package-validator-coverage-643`, commit `8a2edbe9`;
-  open as PR `#837`.
+  merged via PR `#837` as `bdc406cc`. The remote branch was deleted
+  after merge.
   Scope: test-only Python coverage for
   `tools/packages/validate_registry.py` JSON load/error paths,
   structural and license classification, and CLI success output, plus
@@ -406,6 +405,23 @@ Local Phase 3 draft worktrees:
   local Python coverage runner could not run because this interpreter
   lacks `coverage.py >= 7.10`; hosted CI remains the coverage proof for
   this tranche.
+- `#646` GPU graph render helper worktree
+  `/Users/danielraffel/Code/pulp-render-gpu-graph-coverage-646`,
+  branch `feature/render-gpu-graph-coverage-646`, commit `c4261740`;
+  open as PR `#839`.
+  Scope: hardens `GpuGraphRenderer`, `GpuHeatMapRenderer`, and
+  `GpuBarRenderer` raw-pointer `set_data()` paths for null, zero-sized,
+  and overflowing inputs; adds focused `test_gpu_graph.cpp` edge
+  coverage; and moves the header-only dirty-tracker and GPU-graph tests
+  out of the GPU-only CMake block so GPU-off sanitizer/local coverage
+  builds can exercise them without linking `pulp::render`. Local
+  validation after rebasing onto `bdc406cc`: GPU-off configure,
+  `pulp-test-gpu-graph` and `pulp-test-dirty-tracker` builds, direct
+  `[issue-646]` run passed `39` assertions in `7` cases, full
+  gpu-graph binary passed `52` assertions in `11` cases, full
+  dirty-tracker binary passed `52` assertions in `18` cases, focused
+  CTest passed `29/29`, diff check, skill-sync report, version-bump
+  report with an SDK patch trailer, and pre-push gates.
 - `#643` CLI release packager worktree
   `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, branch
   `feature/package-cli-coverage-643`, commit `7e76a1b7`; open as PR
@@ -774,6 +790,7 @@ Open supporting PR:
   Android-validation ordering plus config isolation, and `#832` was
   repaired for the fast-exit deadline review, and `#833` was rebased
   onto `b5e7a463` to clear the stale Android SDK discovery ASan failure,
+  and `#836` merged, and `#837` merged, and `#839` opened,
   and remains docs-only.
 
 Local environment note:
@@ -811,19 +828,16 @@ Next recovery actions:
 7. Monitor `#835` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
    validate locally, and push with lease.
-8. Monitor `#836` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-cli-sync-coverage-643`, patch,
-   validate locally, and push with lease.
-9. Monitor `#837` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-package-validator-coverage-643`,
-   patch, validate locally, and push with lease.
-10. Monitor `#838` cloud checks; if a required lane fails, debug in
+8. Monitor `#838` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, patch,
    validate locally, and push with lease.
-11. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+9. Monitor `#839` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-render-gpu-graph-coverage-646`,
+   patch, validate locally, and push with lease.
+10. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-12. Continue Phase 3 from the tranche issues below, prioritizing
+11. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 02:22 EDT
+Last reviewed: 2026-04-26 02:29 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -208,6 +208,22 @@ Open Phase 3 PRs:
   clean, skill sync clean, and version bump report says no bump needed.
   The PR is labeled `codecov` and is using the direct GitHub/Namespace
   path.
+- `#806` `test(audio): cover mapped reader and offline processing`,
+  branch `feature/audio-reader-coverage-640`, commit `c1d61e3a`,
+  worktree `/Users/danielraffel/Code/pulp-audio-reader-coverage-640`.
+  Scope: deterministic `MemoryMappedAudioReader` coverage for
+  open/read-range/read-all/close/missing-file paths, offline processing
+  coverage for guard paths, non-divisible block tails, `apply_gain`, and
+  `offline_process_file` registry dispatch, plus a defensive production
+  guard so `block_size <= 0` returns `nullopt` instead of hanging. Local
+  validation: no-GPU configure, `pulp-test-audio-file` target build,
+  direct Catch2 tag `[issue-640]` passed with `159` assertions in `7`
+  test cases, full `pulp-test-audio-file` passed with `392` assertions in
+  `22` test cases, focused CTest passed `15/15`, `git diff --check`
+  clean, skill sync clean, and version bump report exits clean while
+  noting the SDK patch suggestion from the defensive production guard.
+  The PR is labeled `codecov` and is using the direct GitHub/Namespace
+  path.
 
 Local Phase 3 draft worktrees:
 
@@ -265,6 +281,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-cli-common-coverage-643`, branch
   `feature/cli-common-coverage-643`, commit `17b42f0f`; open as PR
   `#805`.
+- `#640` mapped-reader/offline audio worktree
+  `/Users/danielraffel/Code/pulp-audio-reader-coverage-640`, branch
+  `feature/audio-reader-coverage-640`, commit `c1d61e3a`; open as PR
+  `#806`.
 
 Open supporting PR:
 
@@ -285,11 +305,11 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#801`, `#802`, `#803`, `#804`, and `#805` and address any
-   Codecov, build, sanitizer, or Namespace feedback.
-3. If `#801`, `#802`, `#803`, `#804`, or `#805` is green but GitHub
-   reports it behind `main`, rebase that branch onto `origin/main`, push
-   with lease, and let checks rerun.
+2. Monitor `#801`, `#802`, `#803`, `#804`, `#805`, and `#806` and
+   address any Codecov, build, sanitizer, or Namespace feedback.
+3. If `#801`, `#802`, `#803`, `#804`, `#805`, or `#806` is green but
+   GitHub reports it behind `main`, rebase that branch onto
+   `origin/main`, push with lease, and let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -145,7 +145,7 @@ Open Phase 3 PRs:
   whitespace, skill-sync, and version checks are green. GitHub Actions is
   rerunning at `8e9caaa7`.
 - `#786` render DirtyTracker / RenderLoop edge coverage, branch
-  `feature/render-coverage-646-next`, head `330e373d`. This tranche extends
+  `feature/render-coverage-646-next`, head `a9f4526a`. This tranche extends
   the still-open `#646` render component follow-up after the earlier merged
   `#700` slice. Scope is intentionally pure and hostable: DirtyTracker
   negative/empty rects, debug overlay state, threshold accumulation,
@@ -154,8 +154,14 @@ Open Phase 3 PRs:
   validation is green: configure, focused target build,
   `pulp-test-dirty-tracker` (`52` assertions / `18` cases),
   `pulp-test-rendering-integration` (`71` assertions / `40` cases),
-  focused CTest (`19/19`), skill/version checks, and whitespace. GitHub
-  Actions is draining at `330e373d` with no completed failures observed.
+  focused CTest (`19/19`), GPU-off configure/build of
+  `pulp-test-cli-project-command`, `pulp-cli` build, direct
+  disabled-upgrade smoke, skill/version checks, and whitespace. The branch
+  now carries the same shared GPU-off CMake, Windows-safe redirection,
+  `ui-preview` guard, and disabled-update-check fixes as the other active
+  Phase 3 tranches because IWYU exposed the GPU-off target-link failure
+  before any of those shared fixes had merged. GitHub Actions is draining
+  at `a9f4526a`.
 
 Open supporting PR:
 
@@ -172,7 +178,7 @@ Next recovery actions:
    because auto-merge is disabled.
 2. Let the current `#771`, `#777`, and `#782` reruns drain after the
    shared CI and sandbox-e2e unblockers were pushed.
-3. Let the new `#786` render coverage tranche drain at `330e373d`.
+3. Let the new `#786` render coverage tranche drain at `a9f4526a`.
 4. If sandbox-e2e fails again, pull the fresh log first; the expected
    failure fixed here was `pulp upgrade --check-only` ignoring
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 18:11 EDT
+Last reviewed: 2026-04-25 18:17 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -131,7 +131,7 @@ Open Phase 3 PRs:
   the current polling window shows no failures while Linux Namespace plus
   Linux coverage drain.
 - `#789` Android ship/package helper coverage, branch
-  `feature/android-package-coverage-644`, head `3c3a1ea4`. This tranche
+  `feature/android-package-coverage-644`, head `a3f124a1`. This tranche
   adds a deterministic host-side fake Android SDK/toolchain harness for
   `ship/platform/android/package_android.cpp` without requiring a real SDK,
   device, keystore, Gradle install, bundletool, or network access. Scope:
@@ -145,16 +145,20 @@ Open Phase 3 PRs:
   follow-up fixed the skill-sync gap but still failed the same three Windows
   Android tests. The second follow-up preserved quoted batch executable paths
   for `cmd.exe /c` but still failed the same Windows tests. The current head
-  additionally fixes the fake Windows `apksigner.bat` fixture's unescaped
+  additionally fixed the fake Windows `apksigner.bat` fixture's unescaped
   parenthesized echo text and quotes whole Gradle / bundletool `name=value`
-  arguments instead of only quoted values; the `ship` skill documents both
-  Windows batch gotchas. Local validation is green:
+  arguments instead of only quoted values; that narrowed the Windows Namespace
+  failure to only the fake Gradle artifact-collection case. The current head
+  runs Gradle through `ChildProcess::run` with `ProcessOptions::working_directory`
+  set to the Gradle project directory instead of relying on inline
+  `cd ... && gradlew` shell parsing; the `ship` skill documents these Windows
+  batch gotchas. Local validation is green:
   `cmake --build build --target pulp-test-android-package -j4`, direct
   `pulp-test-android-package` (`64` assertions / `7` test cases), focused
   Android package CTest (`7/7`), adjacent ship CTest slice for
   Android/appcast/codesign/notarization/DMG (`20/20`), and whitespace. The
   current polling window shows no failures while fresh checks run on
-  `3c3a1ea4`.
+  `a3f124a1`.
 
 Local Phase 3 draft not yet opened as a PR:
 - `#643` package-registry CLI/tools draft, worktree

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 18:03 EDT
+Last reviewed: 2026-04-26 18:17 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -153,12 +153,14 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#822` audio file helper edge coverage for `#640`, branch
-  `feature/audio-file-helper-coverage-640`, head `8aa7a78d`; opened
+  `feature/audio-file-helper-coverage-640`, head `2db6be4a`; opened
   from `main` at `c9620a65` and updated after the first macOS UBSan run
   exposed a real `float_to_int32` endpoint conversion overflow. This
-  tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
+  branch was updated again after macOS Namespace full-suite test `392`
+  exposed Android SDK discovery choosing an older fake NDK revision; the
+  branch now compares Android build-tools and NDK revisions numerically.
+  This tranche also uses the GitHub/Namespace path while the SSH
+  `windows` target remains unreachable.
 - `#823` platform helper edge coverage for `#640`, branch
   `feature/platform-helper-coverage-640`, head `6ec4ff2e`; opened from
   `main` at `3d4560d1`. This tranche also uses the GitHub/Namespace path
@@ -416,7 +418,7 @@ Local Phase 3 draft worktrees:
   and version-bump report.
 - `#640` audio file helper worktree
   `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
-  branch `feature/audio-file-helper-coverage-640`, commit `8aa7a78d`;
+  branch `feature/audio-file-helper-coverage-640`, head `2db6be4a`;
   open as PR `#822`.
   Scope: coverage for packed int24 conversion, int32 full-scale
   conversion, float-to-int32 clamping, zero-count conversion no-ops, CHOC
@@ -425,16 +427,22 @@ Local Phase 3 draft worktrees:
   `AudioProcessLoadMeasurer` smoothing/zero-available-time guards.
   Follow-up `8aa7a78d` fixes a production `float_to_int32` UBSan issue
   by handling `+/-1` endpoints explicitly and using double precision for
-  the midrange cast. Local validation: no-GPU/no-examples configure,
+  the midrange cast. Follow-up `fc7a1364` fixes a macOS Namespace
+  full-suite blocker by comparing Android build-tools and NDK revisions
+  numerically, with `2db6be4a` carrying the required skill/version
+  metadata trailers. Local validation: no-GPU/no-examples configure,
   `pulp-test-audio-file`, `pulp-test-audio`, and
-  `pulp-test-load-measurer` build, direct `[issue-640]` audio-file run
-  passed `217` assertions in `11` cases, full audio-file binary passed
-  `450` assertions in `26` cases, full audio binary passed `586`
-  assertions in `8` cases, full load-measurer binary passed `20`
-  assertions in `6` cases, focused CTest passed `11/11`, local UBSan
-  focused CTest for `sample conversion handles packed 24-bit and 32-bit
-  edges` passed, `git diff --check`, skill-sync report, and version-bump
-  report.
+  `pulp-test-load-measurer` build, later `pulp-test-android-package`
+  build, direct `[issue-640]` audio-file run passed `217` assertions in
+  `11` cases, full audio-file binary passed `450` assertions in `26`
+  cases, full audio binary passed `586` assertions in `8` cases, full
+  load-measurer binary passed `20` assertions in `6` cases, full Android
+  package binary passed `69` assertions in `8` cases, focused CTest
+  passed `11/11` before the Android fix and `9/9` for the Android/load
+  measurer rerun after the fix, local UBSan focused CTest for `sample
+  conversion handles packed 24-bit and 32-bit edges` passed,
+  skill-sync report passed with the `ship` bypass trailer, and
+  version-bump report classified the SDK change as `patch`.
 - `#640` platform helper worktree
   `/Users/danielraffel/Code/pulp-platform-helper-coverage-640`, branch
   `feature/platform-helper-coverage-640`, commit `6ec4ff2e`; open as PR
@@ -510,8 +518,8 @@ Open supporting PR:
   updated after `#816` merged, `#817` was repaired, `#820` opened,
   `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
   merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
-  merged, `#825` opened, `#820` merged, and `#826` opened, and remains
-  docs-only.
+  merged, `#825` opened, `#820` merged, `#826` opened, and `#822` was
+  repaired again for Android SDK discovery, and remains docs-only.
 
 Local environment note:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:39 EDT
+Last reviewed: 2026-04-26 19:42 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -183,6 +183,10 @@ Open Phase 3 PRs:
   Namespace run exposed a cmd/PowerShell portability issue in the test
   commands. This tranche also uses the GitHub/Namespace path while the
   SSH `windows` target remains unreachable.
+- `#833` signal filter-design edge coverage for `#645`, branch
+  `feature/signal-biquad-coverage-645`, head `740bdc9c`; opened from
+  `main` at `87ef6d90`. This tranche also uses the GitHub/Namespace
+  path while the SSH `windows` target remains unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -601,6 +605,19 @@ Local Phase 3 draft worktrees:
   assertions in `5` cases, full binary passed `46` assertions in `17`
   cases, focused CTest passed `5/5`, `git diff --check HEAD~1..HEAD`,
   `git diff --check`, skill-sync report, and version-bump report.
+- `#645` signal filter-design worktree
+  `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, branch
+  `feature/signal-biquad-coverage-645`, commit `740bdc9c`; open as PR
+  `#833`.
+  Scope: test-only coverage for peaking boost/cut coefficients, low/high
+  shelf cut paths, shelf slope variants, and Butterworth empty/high-order
+  section behavior. This intentionally touches only
+  `test_filter_design.cpp` to avoid overlap with open `test_signal.cpp`
+  tranches. Local validation: no-GPU/no-examples configure,
+  `pulp-test-filter-design` build, direct `[issue-645]` run passed `100`
+  assertions in `3` cases, full binary passed `116` assertions in `14`
+  cases, focused CTest passed `14/14`, `git diff --check HEAD~1..HEAD`,
+  `git diff --check`, skill-sync report, and version-bump report.
 
 Open supporting PR:
 
@@ -617,7 +634,7 @@ Open supporting PR:
   `#830` opened, `#831` opened, `#827` merged, `#832` opened, `#826`
   merged, and `#832` was repaired for Windows cmd portability, and
   `#831` was repaired for Windows float tolerance, and `#822` merged,
-  and remains docs-only.
+  and `#833` opened, and remains docs-only.
 
 Local environment note:
 
@@ -651,10 +668,13 @@ Next recovery actions:
 6. Monitor `#832` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
    patch, validate locally, and push with lease.
-7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+7. Monitor `#833` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, patch,
+   validate locally, and push with lease.
+8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-8. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 21:23 EDT
+Last reviewed: 2026-04-25 22:02 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -94,6 +94,13 @@ Latest complete Codecov `main` report observed while updating this doc:
   - `ship`: `59.15%`
   - `tools`: `39.5%`
 
+Newer `main` state:
+
+- `#793` merged after the latest complete Codecov report above. The new
+  `main` head is `e2af9c4db73c6b404553eb41cbd8dd3fc5a3b4db`.
+- Main Coverage run `24945821780` is in progress for `e2af9c4d`; refresh
+  this baseline from Codecov after it completes.
+
 Merged after the Phase 1 closeout / `#723` baseline:
 
 - `#649` CLI/tools tranche 1 -> `8449b6e8`
@@ -112,35 +119,30 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#786` render DirtyTracker / RenderLoop edge coverage -> `26dd396d`
 - `#789` Android ship/package helper coverage -> `e61dce8d`
 - `#788` events socket-IPC coverage -> `23d3ed1d`
+- `#793` package-registry CLI/tools coverage -> `e2af9c4d`
 
 Open Phase 3 PRs:
 
-- `#793` package-registry CLI/tools coverage, branch
-  `feature/package-registry-coverage-643`, head `75a529ef`. This is the
-  `#643` tranche opened by `shipyard pr` after `#788` merged. Scope:
-  `pulp-test-cli-package-registry` for pure local registry parsing,
-  lock-file round trips, target TOML parsing/writing, semver, quality
-  scoring, unsupported-target detection, and search ranking. Local
-  validation after rebasing onto `origin/main` at `23d3ed1d` is green:
-  build `pulp-test-cli-package-registry`, direct binary (`88`
-  assertions / `5` test cases), focused CTest (`5/5`), whitespace, and
-  `version_bump_check.py --mode=report`. Shipyard validation and GitHub
-  checks are running.
+- None at this checkpoint. `#793` was merged manually after GitHub
+  required checks were clean. Shipyard validation did not merge it because
+  mac passed, ubuntu failed in a full examples-enabled build when linker
+  processes were killed near the end of the build, and windows failed before
+  validation with a bundle-apply infra error
+  (`could not open C:/Users/danielraffel/shipyard.bundle`).
 
 Local Phase 3 draft worktrees:
 
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
-  `feature/package-registry-coverage-643`, commit `75a529ef`; now backs
-  open PR `#793`. Do not edit this worktree while `shipyard pr` is still
-  validating it.
+  `feature/package-registry-coverage-643`, commit `75a529ef`; merged via
+  PR `#793`.
 
 Open supporting PR:
 
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#788` merged and
+  The branch has been rebased onto `origin/main` after `#793` merged and
   remains docs-only.
 
 Local environment note:
@@ -154,8 +156,8 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its post-`#793` status-update checks drain.
-2. Monitor `#793`; Shipyard is validating the PR and GitHub workflows are
-   running.
+2. Let main Coverage run `24945821780` for `e2af9c4d` drain, then refresh
+   this section with the next complete Codecov `main` report.
 3. If a new PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:49 EDT
+Last reviewed: 2026-04-26 19:58 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -180,13 +180,19 @@ Open Phase 3 PRs:
   test. This tranche also uses the GitHub/Namespace path while the SSH
   `windows` target remains unreachable.
 - `#832` platform child-process edge coverage for `#640`, branch
-  `feature/platform-child-process-coverage-640`, head `a361c8b9`;
-  opened from `main` at `d5efea57` and updated after the first Windows
+  `feature/platform-child-process-coverage-640`, head `c07dd268`;
+  opened from `main` at `d5efea57`, updated after the first Windows
   Namespace run exposed a cmd/PowerShell portability issue in the test
-  commands. This tranche also uses the GitHub/Namespace path while the
-  SSH `windows` target remains unreachable.
+  commands, then rebased onto `87ef6d90` and updated after Windows
+  exposed the fast-exit no-newline `cmd` probe returning nonzero. This
+  tranche also uses the GitHub/Namespace path while the SSH `windows`
+  target remains unreachable.
 - `#833` signal filter-design edge coverage for `#645`, branch
   `feature/signal-biquad-coverage-645`, head `740bdc9c`; opened from
+  `main` at `87ef6d90`. This tranche also uses the GitHub/Namespace
+  path while the SSH `windows` target remains unreachable.
+- `#834` events event-loop lifecycle edge coverage for `#642`, branch
+  `feature/events-loop-coverage-642`, head `ee3894cb`; opened from
   `main` at `87ef6d90`. This tranche also uses the GitHub/Namespace
   path while the SSH `windows` target remains unreachable.
 
@@ -200,6 +206,18 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`, branch
   `feature/events-volume-coverage-642`, commit `357fc429`; merged via PR
   `#795` as `f1a5aa84`. The remote branch was deleted after merge.
+- `#642` events event-loop lifecycle worktree
+  `/Users/danielraffel/Code/pulp-events-loop-coverage-642`, branch
+  `feature/events-loop-coverage-642`, commit `ee3894cb`; open as PR
+  `#834`.
+  Scope: test-only coverage for `EventLoop` thread identity, explicit
+  stop and idempotent stop state, delayed work dropped after stop,
+  multiple delayed tasks, plus `Timer` interval getter/setter and
+  idempotent stop-state behavior. Local validation: no-GPU/no-examples
+  configure, `pulp-test-events` build, direct `[issue-642]` run passed
+  `14` assertions in `4` cases, full binary passed `74` assertions in
+  `20` cases, precise CTest selector passed `18/18`, `git diff --check`,
+  skill-sync report, and version-bump report.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
   `feature/package-registry-coverage-643`, commit `75a529ef`; merged via
@@ -599,18 +617,21 @@ Local Phase 3 draft worktrees:
 - `#640` platform child-process worktree
   `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
   branch `feature/platform-child-process-coverage-640`, commits
-  `3018c8d5` and `a361c8b9`; open as PR `#832`.
+  `3018c8d5`, `a361c8b9`, and `c07dd268`; open as PR `#832`.
   Scope: test-only coverage for pre-start wait/read defaults,
   working-directory launch, stdout/stderr max-output byte caps,
   stderr-line callbacks, and fast-exit output preservation after
   `is_running()` observes process completion. The follow-up commit
   removed a PowerShell dependency and trims stderr callback comparisons
-  so the test is resilient to `cmd` redirection spacing on Windows.
+  so the test is resilient to `cmd` redirection spacing on Windows; the
+  second follow-up forces the fast-exit Windows `cmd` probe to exit zero
+  while still proving no-newline cached output is preserved.
   Local validation: no-GPU/no-examples configure,
   `pulp-test-child-process` build, direct `[issue-640]` run passed `25`
   assertions in `5` cases, full binary passed `46` assertions in `17`
-  cases, focused CTest passed `5/5`, `git diff --check HEAD~1..HEAD`,
-  `git diff --check`, skill-sync report, and version-bump report.
+  cases, focused CTest passed for the fast-exit case,
+  `git diff --check HEAD~1..HEAD`, `git diff --check`, skill-sync
+  report, and version-bump report after rebasing onto `87ef6d90`.
 - `#645` signal filter-design worktree
   `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, branch
   `feature/signal-biquad-coverage-645`, commit `740bdc9c`; open as PR
@@ -641,7 +662,9 @@ Open supporting PR:
   merged, and `#832` was repaired for Windows cmd portability, and
   `#831` was repaired for Windows float tolerance, and `#822` merged,
   and `#833` opened, and `#829` was rebased onto `87ef6d90` to pick up
-  the merged Android SDK discovery fix, and remains docs-only.
+  the merged Android SDK discovery fix, and `#832` was rebased/repaired
+  for the Windows fast-exit command, and `#834` opened, and remains
+  docs-only.
 
 Local environment note:
 
@@ -678,10 +701,13 @@ Next recovery actions:
 7. Monitor `#833` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, patch,
    validate locally, and push with lease.
-8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+8. Monitor `#834` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-events-loop-coverage-642`, patch,
+   validate locally, and push with lease.
+9. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+10. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -181,8 +181,10 @@ Open Phase 3 PRs:
   shared support commits were skipped. The `f7da209d` rerun failed the
   required diff-coverage gate on the same shared `cmd_project.cpp` probe edges
   as `#782`; that shared coverage is now on `main` via `#771`. GitHub Actions
-  is rerunning at `49983137`; no completed failures were visible at the last
-  poll.
+  is rerunning at `49983137`. The macOS Namespace job failed during setup on a
+  transient `curl` HTTP 502 while downloading the shared `wgpu-native` runtime,
+  before configure/tests; rerun failed jobs once the Build and Test workflow
+  reaches a terminal state.
 - `#788` events socket-IPC coverage, branch
   `feature/events-ipc-coverage-642`, head `4cb33f4e`. This tranche
   extends `test/test_ipc.cpp` with malformed socket endpoint rejection,
@@ -242,12 +244,15 @@ Next recovery actions:
 7. If `#782` still shows TSan failed after the sanitizer workflow completes,
    rerun failed jobs for run `24929565716`; the observed failure was checkout
    infrastructure before tests, not a sanitizer report.
-8. If sandbox-e2e fails again, pull the fresh log first; the expected
+8. If `#786` still shows macOS Namespace failed after the Build and Test
+   workflow completes, rerun failed jobs for run `24929553366`; the observed
+   failure was a transient `wgpu-native` download HTTP 502 before tests.
+9. If sandbox-e2e fails again, pull the fresh log first; the expected
    failure fixed here was `pulp upgrade --check-only` ignoring
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
-9. If a PR is green but GitHub reports it behind `main`, rebase that
+10. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-10. Continue Phase 3 from the tranche issues below, prioritizing
+11. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 03:04 EDT
+Last reviewed: 2026-04-26 03:13 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -320,6 +320,19 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-audio-channel-set-coverage-640`,
   branch `feature/audio-channel-set-coverage-640`, commit `89b969c9`;
   open as PR `#807`.
+- `#640` platform Environment diff-edge worktree
+  `/Users/danielraffel/Code/pulp-platform-environment-coverage-640`,
+  branch `feature/platform-environment-coverage-640`, commit
+  `b298c7a2`; local-only draft, not opened as a PR yet. Scope: empty
+  listener subscription, token move-assignment replacement, keyboard
+  animation-duration diffs, left/right safe-area diffs, display
+  physical/name/refresh metadata diffs, and isolated orientation/
+  lifecycle changes. Local validation: no-GPU configure,
+  `pulp-test-environment` target build, direct Catch2 selector
+  `[environment][issue-640]` passed with `32` assertions in `5` test
+  cases, focused CTest `Environment` passed `16/16`, `git diff --check`
+  clean, skill sync clean, and version bump report says no bump needed.
+  Hold local until the active CI queue has a merge slot.
 - `#645` MIDI file edge round-trip worktree
   `/Users/danielraffel/Code/pulp-midi-file-coverage-645`, branch
   `feature/midi-file-coverage-645`, commit `d02e853e`; open as PR
@@ -353,7 +366,10 @@ Next recovery actions:
 3. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-4. Continue Phase 3 from the tranche issues below, prioritizing
+4. When the queue has a merge slot, push/open the local #640 platform
+   Environment draft from
+   `/Users/danielraffel/Code/pulp-platform-environment-coverage-640`.
+5. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 18:17 EDT
+Last reviewed: 2026-04-25 18:28 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -127,9 +127,12 @@ Open Phase 3 PRs:
   used as validation because Catch2 treats multiple quoted filters as an AND
   expression; CTest was used for the focused multi-test slice. PR is labeled
   `codecov`. The earlier Linux Namespace and Linux coverage failures did not
-  expose usable logs through `gh`; both failed workflows have been rerun and
-  the current polling window shows no failures while Linux Namespace plus
-  Linux coverage drain.
+  expose usable logs through `gh`. A rerun of Build/Test `24929736674` and
+  Coverage `24929736678` then sat in progress for roughly 90 minutes with no
+  logs and no timestamp movement, so both runs were canceled and rerun from
+  the same head `4cb33f4e`. GitHub reran the full Build/Test and Coverage
+  workflows, not only the Linux jobs; the current polling window shows no
+  failures while those fresh checks drain.
 - `#789` Android ship/package helper coverage, branch
   `feature/android-package-coverage-644`, head `a3f124a1`. This tranche
   adds a deterministic host-side fake Android SDK/toolchain harness for
@@ -189,7 +192,7 @@ Next recovery actions:
 
 1. Poll `#788` and `#789`; merge manually when green because auto-merge is
    disabled.
-2. Let `#788`'s rerun Linux Namespace and Linux coverage checks drain.
+2. Let `#788`'s fresh full Build/Test and Coverage workflow reruns drain.
 3. Let `#789`'s post-Windows-batch-fix GitHub Actions checks drain; pull the
    exact failing job log first if anything turns red.
 4. Keep `#774` docs-only and let its post-`#786` rebase checks drain.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 14:13 EDT
+Last reviewed: 2026-04-26 14:17 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -139,9 +139,9 @@ Merged after the Phase 1 closeout / `#723` baseline:
 
 Open Phase 3 PRs:
 
-- None currently open after `#810` merged. The next ready Phase 3
-  candidate is the local-only `#643` CLI project-command draft at
-  `3a2820bb`, recorded below.
+- `#811` CLI project-command dispatch coverage for `#643`, branch
+  `feature/cli-project-coverage-643`, head `46dca652`; opened after
+  rebasing onto `main` at `f712702a`. Cloud checks are the active gate.
 
 Local Phase 3 draft worktrees:
 
@@ -225,8 +225,8 @@ Local Phase 3 draft worktrees:
   `#809` as `453bcec8`. The remote branch was deleted after merge.
 - `#643` CLI project-command dispatch worktree
   `/Users/danielraffel/Code/pulp-cli-project-coverage-643`, branch
-  `feature/cli-project-coverage-643`, commit `3a2820bb`; local-only
-  draft, not opened as a PR yet while `#774` drains. Scope:
+  `feature/cli-project-coverage-643`, commit `46dca652`; open as PR
+  `#811`. Scope:
   direct `cmd_project.cpp` coverage for top-level help/no-arg/unknown
   dispatch, bump option parsing, `--all` empty-registry handling,
   registry-backed `--all --dry-run` reporting without undo files, a
@@ -243,8 +243,8 @@ Open supporting PR:
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#810` merged and
-  remains docs-only.
+  The branch has been rebased onto `origin/main` after `#810` merged,
+  updated after `#811` opened, and remains docs-only.
 
 Local environment note:
 
@@ -257,9 +257,9 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. When ready to add the next active code tranche, push/open local
-   `#643` branch `feature/cli-project-coverage-643` from
-   `/Users/danielraffel/Code/pulp-cli-project-coverage-643`.
+2. Monitor `#811` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-cli-project-coverage-643`, patch,
+   validate locally, and push with lease.
 3. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -144,6 +144,18 @@ Open Phase 3 PRs:
   (`118` assertions / `5` test cases), direct disabled-upgrade smoke,
   whitespace, skill-sync, and version checks are green. GitHub Actions is
   rerunning at `8e9caaa7`.
+- `#786` render DirtyTracker / RenderLoop edge coverage, branch
+  `feature/render-coverage-646-next`, head `330e373d`. This tranche extends
+  the still-open `#646` render component follow-up after the earlier merged
+  `#700` slice. Scope is intentionally pure and hostable: DirtyTracker
+  negative/empty rects, debug overlay state, threshold accumulation,
+  no-viewport behavior, nearby non-overlap coalescing, Rect merge/touching
+  edges, and non-Apple TimerRenderLoop callback/restart behavior. Local
+  validation is green: configure, focused target build,
+  `pulp-test-dirty-tracker` (`52` assertions / `18` cases),
+  `pulp-test-rendering-integration` (`71` assertions / `40` cases),
+  focused CTest (`19/19`), skill/version checks, and whitespace. GitHub
+  Actions is draining at `330e373d` with no completed failures observed.
 
 Open supporting PR:
 
@@ -156,18 +168,19 @@ Open supporting PR:
 
 Next recovery actions:
 
-1. Poll `#771`, `#774`, `#777`, and `#782`; merge green PRs manually because
-   auto-merge is disabled.
+1. Poll `#771`, `#774`, `#777`, `#782`, and `#786`; merge green PRs manually
+   because auto-merge is disabled.
 2. Let the current `#771`, `#777`, and `#782` reruns drain after the
    shared CI and sandbox-e2e unblockers were pushed.
-3. If sandbox-e2e fails again, pull the fresh log first; the expected
+3. Let the new `#786` render coverage tranche drain at `330e373d`.
+4. If sandbox-e2e fails again, pull the fresh log first; the expected
    failure fixed here was `pulp upgrade --check-only` ignoring
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
-4. If a PR is green but GitHub reports it behind `main`, rebase that
+5. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-5. After active PRs merge, refresh this section with the next complete
+6. After active PRs merge, refresh this section with the next complete
    Codecov `main` report.
-6. Continue Phase 3 from the tranche issues below, prioritizing
+7. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 17:53 EDT
+Last reviewed: 2026-04-26 17:54 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -148,14 +148,10 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#817` UMP conversion edge coverage -> `a38216fd`
 - `#821` audio reader helper edge coverage -> `7aff17f9`
 - `#819` MIDI keyboard/sequence edge coverage -> `7a646f33`
+- `#820` signal spectrogram edge coverage -> `1a1b7f07`
 
 Open Phase 3 PRs:
 
-- `#820` signal spectrogram edge coverage for `#645`, branch
-  `feature/signal-spectrogram-coverage-645`, head `0fd8aa5a`; opened
-  from `main` at `c9620a65`. This tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
 - `#822` audio file helper edge coverage for `#640`, branch
   `feature/audio-file-helper-coverage-640`, head `8aa7a78d`; opened
   from `main` at `c9620a65` and updated after the first macOS UBSan run
@@ -386,7 +382,8 @@ Local Phase 3 draft worktrees:
 - `#645` signal spectrogram worktree
   `/Users/danielraffel/Code/pulp-signal-spectrogram-coverage-645`,
   branch `feature/signal-spectrogram-coverage-645`, commit `0fd8aa5a`;
-  open as PR `#820`.
+  merged via PR `#820` as `1a1b7f07`. The remote branch was deleted
+  after merge.
   Scope: test-only coverage for `ColorMapper` ramp switching/control
   points, `FrequencyAxis` clamping and bin/display conversions,
   `SpectrogramBuffer` column wraparound, row-to-bin mapping,
@@ -496,7 +493,7 @@ Open supporting PR:
   updated after `#816` merged, `#817` was repaired, `#820` opened,
   `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
   merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
-  merged, and `#825` opened, and remains docs-only.
+  merged, `#825` opened, and `#820` merged, and remains docs-only.
 
 Local environment note:
 
@@ -515,25 +512,22 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#820` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-signal-spectrogram-coverage-645`,
-   patch, validate locally, and push with lease.
-3. Monitor `#822` cloud checks; if a required lane fails, debug in
+2. Monitor `#822` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
    patch, validate locally, and push with lease.
-4. Monitor `#823` cloud checks; if a required lane fails, debug in
+3. Monitor `#823` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-helper-coverage-640`, patch,
    validate locally, and push with lease.
-5. Monitor `#824` cloud checks; if a required lane fails, debug in
+4. Monitor `#824` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-math-helper-coverage-645`,
    patch, validate locally, and push with lease.
-6. Monitor `#825` cloud checks; if a required lane fails, debug in
+5. Monitor `#825` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-dsp-helper-coverage-645`,
    patch, validate locally, and push with lease.
-7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-8. Continue Phase 3 from the tranche issues below, prioritizing
+7. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 15:13 EDT
+Last reviewed: 2026-04-26 15:28 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -67,43 +67,41 @@ Finish line:
 
 Latest complete Codecov `main` report observed while updating this doc:
 
-- commit: `810743d49f588385aab50ced672344e098710403`
-- workflow: Coverage run `24964141128`, completed successfully
-- overall tracked coverage: `45.43%` over `70,380` lines in `556` files
-- covered lines: `31,974`
-- missed lines: `37,398`
-- partial lines: `1,008`
+- commit: `957a073523e3aabcd7b11972acaf98065909bf67`
+- workflow: Coverage run `24964746369`, completed successfully
+- overall tracked coverage: `45.96%` over `70,376` lines in `556` files
+- covered lines: `32,349`
+- missed lines: `36,895`
+- partial lines: `1,132`
 - current component coverage from the Codecov API:
-  - `audio`: `34.78%`
-  - `canvas`: `64.22%`
-  - `dsl`: `68.3%`
-  - `events`: `50.5%`
-  - `format`: `51.04%`
-  - `host`: `43.39%`
-  - `midi`: `47.62%`
-  - `osc`: `65.65%`
-  - `platform`: `36.93%`
-  - `render`: `60.38%`
-  - `runtime`: `47.51%`
-  - `signal`: `66.13%`
-  - `state`: `60.77%`
-  - `view`: `42.93%`
+  - `audio`: `34.45%`
+  - `canvas`: `63.96%`
+  - `dsl`: `63.38%`
+  - `events`: `49.49%`
+  - `format`: `51.03%`
+  - `host`: `43.61%`
+  - `midi`: `47.77%`
+  - `osc`: `62.22%`
+  - `platform`: `43.18%`
+  - `render`: `59.74%`
+  - `runtime`: `50.48%`
+  - `signal`: `69.4%`
+  - `state`: `62.99%`
+  - `view`: `43.72%`
   - `android`: `13.83%`
   - `apple`: `25.36%`
-  - `linux`: `0.0%`
-  - `windows`: `0.0%`
-  - `cli`: `38.94%`
-  - `ship`: `54.46%`
-  - `tools`: `44.33%`
-
-Newer `main` coverage is running for `#813`'s merge commit
-`957a073523e3aabcd7b11972acaf98065909bf67` as Coverage run
-`24964746369`; keep the `810743d4` numbers above as the latest complete
-baseline until that run finishes.
+  - `linux`: `0.22%`
+  - `windows`: `6.42%`
+  - `cli`: `38.92%`
+  - `ship`: `53.77%`
+  - `tools`: `44.36%`
 
 Post-`#794` file-level proof point: `core/audio/src/aiff_reader.cpp`
 is now `72.01%` covered with `61` misses, up from `64.22%` with `78`
 misses at the prior `e2af9c4d` baseline.
+
+Post-`#813` proof point: the `signal` component is now `69.4%` covered,
+up from `66.13%` at the prior `810743d4` baseline.
 
 Merged after the Phase 1 closeout / `#723` baseline:
 
@@ -149,6 +147,9 @@ Open Phase 3 PRs:
 - `#814` CLI `pulp pr` shellout coverage for `#643`, branch
   `feature/cli-pr-coverage-643`, head `22ba6162`; opened after rebasing
   onto `main` at `957a0735`. Cloud checks are the active gate.
+- `#815` MPE tracker edge-path coverage for `#645`, branch
+  `feature/mpe-tracker-coverage-645`, head `b7c72711`; opened from
+  `main` at `957a0735`. Cloud checks are the active gate.
 
 Local Phase 3 draft worktrees:
 
@@ -270,6 +271,18 @@ Local Phase 3 draft worktrees:
   build, direct `[cli][shellout][pr][issue-643]` passed `18` assertions
   in `4` cases, focused CTest `pulp pr` passed `7/7`,
   `git diff --check`, skill-sync report, and version-bump report.
+- `#645` MPE tracker worktree
+  `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, branch
+  `feature/mpe-tracker-coverage-645`, commit `b7c72711`; open as PR
+  `#815`.
+  Scope: test-only coverage for `MpeVoiceTracker` bend-range rejection,
+  config reset, manager pressure/timbre state, cached member expression,
+  bounded snapshots, and full-table overflow behavior. Local validation:
+  no-GPU/no-examples configure, `pulp-test-mpe-voice-tracker` build,
+  direct `[midi][mpe][issue-645]` passed `166` assertions in `6` cases,
+  full binary passed `239` assertions in `23` cases, and focused CTest
+  `MpeVoiceTracker` passed `23/23`, `git diff --check`, skill-sync
+  report, and version-bump report.
 
 Open supporting PR:
 
@@ -290,10 +303,11 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Let the `main` Coverage run for `957a0735` complete, then refresh the
-   Codecov baseline if it changes the execution order materially.
-3. Monitor `#814` cloud checks; if a required lane fails, debug in
+2. Monitor `#814` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-pr-coverage-643`, patch,
+   validate locally, and push with lease.
+3. Monitor `#815` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, patch,
    validate locally, and push with lease.
 4. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 23:34 EDT
+Last reviewed: 2026-04-26 23:42 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -308,6 +308,14 @@ Open Phase 3 PRs:
   doctor rejection for out-of-range sliders and duplicate sections. The
   commit carries `Skill-Update: skip` because this is test-only coverage
   for a skill-mapped path.
+- `#873` canvas text-layout cursor coverage for parent `#641`, branch
+  `feature/canvas-coverage-641-next`, head `6adc7a4b`; covers wrapped
+  `GlyphArrangement` hit testing, cursor positions, and clear-state
+  behavior.
+- `#875` ship NSIS uninstall metadata coverage for parent `#641`, branch
+  `feature/ship-coverage-641-next`, head `752ae0bb`; covers
+  Add/Remove Programs registry metadata and HKLM/HKCU uninstall key
+  deletion paths.
 
 Local-only queued work:
 
@@ -318,6 +326,12 @@ Local-only queued work:
   after firing and adds a restart regression. Because this is a
   production behavior fix, review it before opening a PR and add the
   appropriate SDK patch metadata trailer.
+- `#642` events IPC endpoint parse worktree
+  `/Users/danielraffel/Code/pulp-events-coverage-642-next4`, branch
+  `feature/events-coverage-642-next4`, commit `3701a940`; adds new
+  test-only target `pulp-test-ipc-endpoints` for deterministic IPC
+  socket endpoint parse failures. Review CMake overlap with open `#857`
+  before opening a PR.
 
 Local Phase 3 draft worktrees:
 
@@ -1086,7 +1100,8 @@ Open supporting PR:
   `3f92f066`, and `#842` merged as `51be8860`, and `#858` through
   `#864` opened from the parallel worker queue, and `#865` through
   `#870` opened from the next completed local worker queue, and `#871`
-  opened for JSFX subset validation coverage,
+  opened for JSFX subset validation coverage, and `#873` and `#875`
+  opened for canvas and ship coverage,
   and remains docs-only.
 
 Local environment note:
@@ -1117,7 +1132,7 @@ Next recovery actions:
    fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
    patch, validate locally, and push with lease.
-5. Monitor `#845` through `#871`; if a required lane fails, debug in
+5. Monitor `#845` through `#875`; if a required lane fails, debug in
    the worktree named in the open-PR list above, patch, validate
    locally, and push with lease. Pay particular attention to `#848` and
    `#851` because they include patch-level production hardening.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 18:53 EDT
+Last reviewed: 2026-04-26 19:06 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -180,6 +180,10 @@ Open Phase 3 PRs:
 - `#829` MIDI-CI edge coverage for `#645`, branch
   `feature/midi-ci-coverage-645`, head `f0ef6b0f`; opened from `main`
   at `94e3ef2a`. This tranche also uses the GitHub/Namespace path while
+  the SSH `windows` target remains unreachable.
+- `#830` RPN parser edge coverage for `#645`, branch
+  `feature/midi-rpn-coverage-645`, head `d1edf1e1`; opened from `main`
+  at `d0262a1b`. This tranche also uses the GitHub/Namespace path while
   the SSH `windows` target remains unreachable.
 
 Local Phase 3 draft worktrees:
@@ -553,6 +557,17 @@ Local Phase 3 draft worktrees:
   assertions in `6` cases, full binary passed `65` assertions in `15`
   cases, focused CTest passed `6/6`, `git diff --check`, skill-sync
   report, and version-bump report.
+- `#645` RPN parser worktree
+  `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, branch
+  `feature/midi-rpn-coverage-645`, commit `d1edf1e1`; open as PR `#830`.
+  Scope: test-only coverage for incomplete selections, unrelated CCs,
+  omitted callbacks on otherwise complete RPN/NRPN sequences, and NRPN
+  increment/decrement metadata. Local validation: no-GPU/no-examples
+  configure, `pulp-test-midi-expansion` build, direct
+  `[midi][rpn][issue-645]` run passed `6` assertions in `3` cases, full
+  binary passed `57` assertions in `23` cases, focused CTest passed
+  `3/3`, `git diff --check`, skill-sync report, and version-bump
+  report.
 
 Open supporting PR:
 
@@ -565,8 +580,8 @@ Open supporting PR:
   merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
   merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
   repaired again for Android SDK discovery, `#827` opened, `#823`
-  merged, `#824` merged, `#828` opened, `#829` opened, and `#825`
-  merged, and remains docs-only.
+  merged, `#824` merged, `#828` opened, `#829` opened, `#825` merged,
+  and `#830` opened, and remains docs-only.
 
 Local environment note:
 
@@ -600,10 +615,13 @@ Next recovery actions:
 6. Monitor `#829` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, patch,
    validate locally, and push with lease.
-7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+7. Monitor `#830` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, patch,
+   validate locally, and push with lease.
+8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-8. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 15:53 EDT
+Last reviewed: 2026-04-26 16:04 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -164,6 +164,11 @@ Open Phase 3 PRs:
   stopped before PR creation because the SSH `windows` backend timed
   out, so this tranche is using the GitHub/Namespace path instead of
   skipping that lane.
+- `#818` MPE synth voice / allocator edge coverage for `#645`, branch
+  `feature/midi-mpe-synth-voice-coverage-645`, head `21eb74e1`; opened
+  from `main` at `957a0735`. This tranche is also using the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -329,6 +334,19 @@ Local Phase 3 draft worktrees:
   broader CTest regex was intentionally not used for the final summary
   because the lite build exposes `*_NOT_BUILT_*` placeholder tests that
   match generic `ump` patterns.
+- `#645` MPE synth voice worktree
+  `/Users/danielraffel/Code/pulp-midi-mpe-synth-voice-coverage-645`,
+  branch `feature/midi-mpe-synth-voice-coverage-645`, commit
+  `21eb74e1`; open as PR `#818`.
+  Scope: test-only coverage for `MpeSynthVoice` smoothing clamp,
+  reset/release state, timbre routing, all non-oldest `MpeVoiceAllocator`
+  steal policies, unknown expression events, `reset_all`, and
+  zero-polyphony dispatch tolerance. Local validation: no-GPU/no-examples
+  configure, `pulp-test-mpe-synth-voice` build, direct
+  `[midi][mpe][issue-645]` passed `51` assertions in `4` cases, full
+  binary passed `75` assertions in `12` cases, focused CTest passed
+  `12/12`, `git diff --check`, skill-sync report, and version-bump
+  report.
 
 Open supporting PR:
 
@@ -369,10 +387,13 @@ Next recovery actions:
 5. Monitor `#817` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
    patch, validate locally, and push with lease.
-6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. Monitor `#818` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-midi-mpe-synth-voice-coverage-645`,
+   patch, validate locally, and push with lease.
+7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-7. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 00:57 EDT
+Last reviewed: 2026-04-26 00:59 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -122,6 +122,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#794` AIFF reader edge-path coverage -> `c4e6ad09`
 - `#796` tool-registry CLI/tools coverage -> `11c10a7e`
 - `#797` StreamingWriter audio edge coverage -> `64ba65e3`
+- `#798` FormatRegistry audio dispatch coverage -> `443ca260`
 
 Open Phase 3 PRs:
 
@@ -148,21 +149,6 @@ Open Phase 3 PRs:
   `codecov` and is using the direct GitHub/Namespace path instead of
   `shipyard pr` because `#794` exposed a local Shipyard mac configure
   stall after GitHub/Namespace was already clean.
-- `#798` `test(audio): cover format registry dispatch paths`, branch
-  `feature/audio-format-registry-coverage-640`, commit `0b35bb83`,
-  worktree
-  `/Users/danielraffel/Code/pulp-audio-system-volume-coverage-640`.
-  Scope: deterministic `FormatRegistry` unsupported read/read_info
-  dispatch, custom reader/writer registration, normalized extension lookup,
-  read_info/read/write dispatch through registered handlers, and supported
-  extension collection for `.aifc`. Local validation:
-  after rebasing across `#797`, `pulp-test-audio-file` passed with `339`
-  assertions in `20` test cases; focused CTest
-  `FormatRegistry|audio.*file|StreamingWriter` passed `7/7`;
-  `git diff --check` clean; skill sync found no mapped paths; version bump
-  report says no bump needed.
-  The PR is labeled `codecov` and is using the same direct
-  GitHub/Namespace path as `#795`.
 - `#799` `test(cli): cover docs shellout reader paths`, branch
   `feature/cli-docs-coverage-643`, commit `4877cb1b`, worktree
   `/Users/danielraffel/Code/pulp-cli-docs-coverage-643`.
@@ -201,7 +187,7 @@ Local Phase 3 draft worktrees:
   `c4e6ad09`. The remote branch was deleted after merge.
 - `#642` events volume/service-discovery worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`, branch
-  `feature/events-volume-coverage-642`, commit `ab941cd9`; open as PR
+  `feature/events-volume-coverage-642`, commit `2d684f4b`; open as PR
   `#795`.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
@@ -219,7 +205,8 @@ Local Phase 3 draft worktrees:
 - `#640` format-registry audio/platform worktree
   `/Users/danielraffel/Code/pulp-audio-system-volume-coverage-640`,
   branch `feature/audio-format-registry-coverage-640`, commit
-  `0b35bb83`; open as PR `#798`.
+  `0b35bb83`; merged via PR `#798` as `443ca260`. The remote branch was
+  deleted after merge.
 - `#643` docs-reader CLI/tools worktree
   `/Users/danielraffel/Code/pulp-cli-docs-coverage-643`, branch
   `feature/cli-docs-coverage-643`, commit `4877cb1b`; open as PR
@@ -234,7 +221,7 @@ Open supporting PR:
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#796` merged and
+  The branch has been rebased onto `origin/main` after `#798` merged and
   remains docs-only.
 
 Local environment note:
@@ -248,11 +235,11 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795`, `#798`, `#799`, and `#800` and address any Codecov,
-   build, sanitizer, or Namespace feedback.
-3. If `#795`, `#798`, `#799`, or `#800` is green but GitHub reports it
-   behind `main`, rebase that branch onto `origin/main`, push with lease,
-   and let checks rerun.
+2. Monitor `#795`, `#799`, and `#800` and address any Codecov, build,
+   sanitizer, or Namespace feedback.
+3. If `#795`, `#799`, or `#800` is green but GitHub reports it behind
+   `main`, rebase that branch onto `origin/main`, push with lease, and
+   let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 01:19 EDT
+Last reviewed: 2026-04-26 01:40 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -124,6 +124,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#797` StreamingWriter audio edge coverage -> `64ba65e3`
 - `#798` FormatRegistry audio dispatch coverage -> `443ca260`
 - `#799` docs-reader CLI shellout coverage -> `22438468`
+- `#800` Python gate-helper tooling coverage -> `55b6dfab`
 
 Open Phase 3 PRs:
 
@@ -154,22 +155,6 @@ Open Phase 3 PRs:
   `codecov` and is using the direct GitHub/Namespace path instead of
   `shipyard pr` because `#794` exposed a local Shipyard mac configure
   stall after GitHub/Namespace was already clean.
-- `#800` `test(tools): cover version and skill gate helpers`, branch
-  `feature/python-tooling-coverage-643`, commit `acadc5af`, worktree
-  `/Users/danielraffel/Code/pulp-python-tooling-coverage-643`.
-  Scope: deterministic `tools/scripts/test_gates.py` coverage for
-  `version_bump_check.py` version-file readers/writers, semver
-  arithmetic, conventional-commit classification, and `Version-Bump`
-  trailer parsing; plus `skill_sync_check.py` trailer parsing,
-  generated-file filtering, path-map self-check failures, nested
-  `SKILL.md` recognition, and bypass propagation. Local validation:
-  `python3 tools/scripts/test_gates.py` passed with `22` tests;
-  `git diff --check` clean; skill sync found no mapped paths; version
-  bump report says no bump needed. Local `run_python_coverage.py` was not
-  run because this local Python lacks `coverage.py`; the CI coverage
-  workflow installs `coverage>=7.10` before running the Python tooling
-  coverage lane. The PR is labeled `codecov` and is using the direct
-  GitHub/Namespace path.
 - `#801` `fix(render): harden texture atlas edge cases`, branch
   `feature/render-texture-atlas-coverage-646`, commit `332c1a95`,
   worktree `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`.
@@ -222,8 +207,8 @@ Local Phase 3 draft worktrees:
   `#799` as `22438468`. The remote branch was deleted after merge.
 - `#643` Python gate-helper tooling worktree
   `/Users/danielraffel/Code/pulp-python-tooling-coverage-643`, branch
-  `feature/python-tooling-coverage-643`, commit `acadc5af`; open as PR
-  `#800`.
+  `feature/python-tooling-coverage-643`, commit `acadc5af`; merged via PR
+  `#800` as `55b6dfab`. The remote branch was deleted after merge.
 - `#646` texture-atlas render worktree
   `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`,
   branch `feature/render-texture-atlas-coverage-646`, commit
@@ -248,9 +233,9 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795`, `#800`, and `#801` and address any Codecov, build,
+2. Monitor `#795` and `#801` and address any Codecov, build,
    sanitizer, or Namespace feedback.
-3. If `#795`, `#800`, or `#801` is green but GitHub reports it behind
+3. If `#795` or `#801` is green but GitHub reports it behind
    `main`, rebase that branch onto `origin/main`, push with lease, and
    let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 00:59 EDT
+Last reviewed: 2026-04-26 01:13 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -178,6 +178,23 @@ Open Phase 3 PRs:
   workflow installs `coverage>=7.10` before running the Python tooling
   coverage lane. The PR is labeled `codecov` and is using the direct
   GitHub/Namespace path.
+- `#801` `fix(render): harden texture atlas edge cases`, branch
+  `feature/render-texture-atlas-coverage-646`, commit `332c1a95`,
+  worktree `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`.
+  Scope: reject non-positive `AtlasPacker` allocation dimensions, clamp
+  repeated `ImageAtlas::release()` calls so refcounts cannot underflow,
+  avoid unsigned frame-age underflow for Image/Gradient/Glyph/Path atlas
+  eviction when `last_used` is ahead of `current_frame`, cover
+  full-atlas allocation failure and `GradientAtlas` capacity exhaustion,
+  and move `pulp-test-texture-atlas` out of the GPU-only CMake block
+  because the helpers are header-only. Local validation: GPU-off
+  configure with `PULP_BUILD_EXAMPLES=OFF` and `PULP_ENABLE_GPU=OFF`,
+  `pulp-test-texture-atlas` target build, direct binary passed with
+  `1139` assertions in `22` test cases, focused texture/atlas CTest
+  passed `20/20`, `git diff --check` clean, skill sync clean, and version
+  report clean with explicit `Version-Bump: sdk=patch` for the
+  header-only behavior fix. The PR is labeled `codecov` and is using the
+  direct GitHub/Namespace path.
 
 Local Phase 3 draft worktrees:
 
@@ -215,6 +232,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-python-tooling-coverage-643`, branch
   `feature/python-tooling-coverage-643`, commit `acadc5af`; open as PR
   `#800`.
+- `#646` texture-atlas render worktree
+  `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`,
+  branch `feature/render-texture-atlas-coverage-646`, commit
+  `332c1a95`; open as PR `#801`.
 
 Open supporting PR:
 
@@ -235,11 +256,11 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795`, `#799`, and `#800` and address any Codecov, build,
-   sanitizer, or Namespace feedback.
-3. If `#795`, `#799`, or `#800` is green but GitHub reports it behind
-   `main`, rebase that branch onto `origin/main`, push with lease, and
-   let checks rerun.
+2. Monitor `#795`, `#799`, `#800`, and `#801` and address any Codecov,
+   build, sanitizer, or Namespace feedback.
+3. If `#795`, `#799`, `#800`, or `#801` is green but GitHub reports it
+   behind `main`, rebase that branch onto `origin/main`, push with lease,
+   and let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -149,7 +149,7 @@ Open Phase 3 PRs:
   active coverage branches. GitHub Actions is rerunning at `f9be330c`; no
   completed failures were visible at the last poll.
 - `#782` VST3 adapter process-path coverage, branch
-  `feature/vst3-adapter-coverage-493`, head `dcad28de`. This tranche adds
+  `feature/vst3-adapter-coverage-493`, head `0fd5f83c`. This tranche adds
   focused VST3 adapter coverage for parameter metadata, setup/release lifecycle,
   bus/event/process routing, sidechain visibility, secondary output zeroing,
   host input automation, plugin-to-host output automation, MIDI output, and
@@ -173,8 +173,12 @@ Open Phase 3 PRs:
   green. The `f09adb04` rerun failed the required diff-coverage gate because
   the shared `cmd_project.cpp` support commit left Windows helper returns,
   non-standalone `origin/main` fallback, and `--verify-builds` lines uncovered;
-  `dcad28de` adds direct coverage for those lines. GitHub Actions is rerunning
-  at `dcad28de`; no completed failures were visible at the last poll.
+  `dcad28de` adds direct coverage for those lines. A later automated review
+  correctly noted that the process-context test set a tempo value without
+  setting VST3's `kTempoValid` bit; `0fd5f83c` fixes that test validity flag,
+  with local `pulp-test-vst3-plugin-state` still green (`118` assertions / `5`
+  test cases). GitHub Actions is rerunning at `0fd5f83c`; no completed failures
+  were visible at the last poll.
 - `#786` render DirtyTracker / RenderLoop edge coverage, branch
   `feature/render-coverage-646-next`, head `54d209d5`. This tranche extends
   the still-open `#646` render component follow-up after the earlier merged

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 01:40 EDT
+Last reviewed: 2026-04-26 01:42 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -129,7 +129,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#795` `test(events): cover volume detector lifecycle edges`, branch
-  `feature/events-volume-coverage-642`, commit `2f109744`, worktree
+  `feature/events-volume-coverage-642`, commit `357fc429`, worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`.
   Scope: deterministic `test/test_network_service_discovery.cpp`
   coverage for `NetworkServiceDiscovery` backend removal, cached-service
@@ -150,13 +150,13 @@ Open Phase 3 PRs:
   on `2d684f4b` was not from the events tests; the failed job showed the
   #795 events tests passed and unrelated CLI/Python coverage tests failed
   on the stale base. The branch was rebased onto `origin/main` after
-  `#798` and `#799` merged, local validation passed again, and fresh CI is
-  running on `2f109744`. The PR is labeled
+  `#800` merged, local validation passed again, and fresh CI is running
+  on `357fc429`. The PR is labeled
   `codecov` and is using the direct GitHub/Namespace path instead of
   `shipyard pr` because `#794` exposed a local Shipyard mac configure
   stall after GitHub/Namespace was already clean.
 - `#801` `fix(render): harden texture atlas edge cases`, branch
-  `feature/render-texture-atlas-coverage-646`, commit `332c1a95`,
+  `feature/render-texture-atlas-coverage-646`, commit `a2201dbb`,
   worktree `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`.
   Scope: reject non-positive `AtlasPacker` allocation dimensions, clamp
   repeated `ImageAtlas::release()` calls so refcounts cannot underflow,
@@ -181,7 +181,7 @@ Local Phase 3 draft worktrees:
   `c4e6ad09`. The remote branch was deleted after merge.
 - `#642` events volume/service-discovery worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`, branch
-  `feature/events-volume-coverage-642`, commit `2f109744`; open as PR
+  `feature/events-volume-coverage-642`, commit `357fc429`; open as PR
   `#795`.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
@@ -212,7 +212,7 @@ Local Phase 3 draft worktrees:
 - `#646` texture-atlas render worktree
   `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`,
   branch `feature/render-texture-atlas-coverage-646`, commit
-  `332c1a95`; open as PR `#801`.
+  `a2201dbb`; open as PR `#801`.
 
 Open supporting PR:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -159,8 +159,10 @@ Open Phase 3 PRs:
   correctly noted that the process-context test set a tempo value without
   setting VST3's `kTempoValid` bit; `c182ee21` includes that test validity
   flag, with local `pulp-test-vst3-plugin-state` still green (`118`
-  assertions / `5` test cases). GitHub Actions is rerunning at `c182ee21`; no
-  completed failures were visible at the last poll.
+  assertions / `5` test cases). GitHub Actions is rerunning at `c182ee21`.
+  The TSan job failed before tests due a Git checkout partial-pack/RPC
+  disconnect (`curl 18` / bad pack header); rerun failed sanitizer jobs once
+  the sanitizer workflow reaches a terminal state.
 - `#786` render DirtyTracker / RenderLoop edge coverage, branch
   `feature/render-coverage-646-next`, head `49983137`. This tranche extends
   the still-open `#646` render component follow-up after the earlier merged
@@ -181,23 +183,22 @@ Open Phase 3 PRs:
   as `#782`; that shared coverage is now on `main` via `#771`. GitHub Actions
   is rerunning at `49983137`; no completed failures were visible at the last
   poll.
-
-Local Phase 3 draft not yet opened as a PR:
-
-- `#642` events socket-IPC tranche, worktree
-  `/Users/danielraffel/Code/pulp-events-ipc-coverage-642`, branch
-  `feature/events-ipc-coverage-642`, local commit `4cb33f4e`. This draft
+- `#788` events socket-IPC coverage, branch
+  `feature/events-ipc-coverage-642`, head `4cb33f4e`. This tranche
   extends `test/test_ipc.cpp` with malformed socket endpoint rejection,
   non-throwing socket endpoint parsing in
   `core/events/src/interprocess_connection.cpp`, and a deterministic
   localhost client/server framed-message exchange. After `#771` merged, this
   branch was rebased onto `origin/main` and duplicate shared CLI support
-  commits were skipped, leaving only the events tranche.
-  Local validation is green: `pulp-test-ipc` (`34` assertions / `9` test
-  cases), focused CTest `IPC` plus project-bump probe edges (`12/12`), and
+  commits were skipped, leaving only the events tranche. Local validation is
+  green: `pulp-test-ipc` (`34` assertions / `9` test
+  cases), focused CTest `IPC` (`9/9`), and
   whitespace. A direct multi-filter Catch2 invocation was intentionally not
   used as validation because Catch2 treats multiple quoted filters as an AND
-  expression; CTest was used for the focused multi-test slice.
+  expression; CTest was used for the focused multi-test slice. PR is labeled
+  `codecov` and GitHub Actions is starting.
+
+Local Phase 3 draft not yet opened as a PR:
 - `#644` Android ship/package helper tranche, worktree
   `/Users/danielraffel/Code/pulp-android-package-coverage-644`, branch
   `feature/android-package-coverage-644`, local commit `1de9b8e6`. This
@@ -230,20 +231,23 @@ Next recovery actions:
 1. Poll `#777`, `#782`, and `#786`; merge green PRs manually
    because auto-merge is disabled.
 2. Let the rebased `#777`, `#782`, and `#786` checks drain at their new heads.
-3. Open either rebased local draft `#642` or `#644` as the next Phase 3 PR
-   and link it from its issue.
+3. Keep `#644` as the next rebased local draft; open it after the current
+   active PR queue has room or if `ship` becomes the next priority.
 4. Keep `#774` docs-only and let its post-`#771` rebase checks drain.
 5. After `#777`, `#782`, and `#786` merge, refresh this section with the next
    complete Codecov `main` report.
 6. If any Windows Namespace lane fails again, pull the fresh completed-run
    log first and search for `pulp-test-cli-project-command`; the known
    failing tests were the dirty-gate and redundant-origin project-bump cases.
-7. If sandbox-e2e fails again, pull the fresh log first; the expected
+7. If `#782` still shows TSan failed after the sanitizer workflow completes,
+   rerun failed jobs for run `24929565716`; the observed failure was checkout
+   infrastructure before tests, not a sanitizer report.
+8. If sandbox-e2e fails again, pull the fresh log first; the expected
    failure fixed here was `pulp upgrade --check-only` ignoring
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
-8. If a PR is green but GitHub reports it behind `main`, rebase that
+9. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+10. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 20:30 EDT
+Last reviewed: 2026-04-26 20:36 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -200,6 +200,11 @@ Open Phase 3 PRs:
   `feature/cli-sync-coverage-643`, head `86048a3f`; opened from
   `main` at `5b8e4529`. This tranche also uses the GitHub/Namespace
   path while the SSH `windows` target remains unreachable.
+- `#837` package registry validation tools coverage for `#643`, branch
+  `feature/package-validator-coverage-643`, head `8a2edbe9`; opened
+  from `main` at `5b8e4529`. This tranche also uses the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -362,6 +367,22 @@ Local Phase 3 draft worktrees:
   and non-repo diagnostics. Local validation: direct
   `python3 tools/scripts/test_cli_sync_check.py` passed `7` cases,
   `git diff --check`, skill-sync report, and version-bump report. The
+  local Python coverage runner could not run because this interpreter
+  lacks `coverage.py >= 7.10`; hosted CI remains the coverage proof for
+  this tranche.
+- `#643` package registry validation tools worktree
+  `/Users/danielraffel/Code/pulp-package-validator-coverage-643`,
+  branch `feature/package-validator-coverage-643`, commit `8a2edbe9`;
+  open as PR `#837`.
+  Scope: test-only Python coverage for
+  `tools/packages/validate_registry.py` JSON load/error paths,
+  structural and license classification, and CLI success output, plus
+  `tools/packages/freshness_check.py` GitHub URL parsing, `gh api`
+  failure handling, issue aggregation, and package-filtered JSON output.
+  Local validation: direct
+  `python3 tools/packages/test_package_validation_tools.py` passed `9`
+  cases, `git diff --check HEAD~1..HEAD`, skill-sync report with
+  `Skill-Update: skip skill=packages`, and version-bump report. The
   local Python coverage runner could not run because this interpreter
   lacks `coverage.py >= 7.10`; hosted CI remains the coverage proof for
   this tranche.
@@ -697,7 +718,8 @@ Open supporting PR:
   and `#833` opened, and `#829` was rebased onto `87ef6d90` to pick up
   the merged Android SDK discovery fix, and `#832` was rebased/repaired
   for the Windows fast-exit command, and `#834` opened, and `#828`
-  merged, and `#835` opened, and `#836` opened, and remains docs-only.
+  merged, and `#835` opened, and `#836` opened, and `#837` opened, and
+  remains docs-only.
 
 Local environment note:
 
@@ -740,10 +762,13 @@ Next recovery actions:
 9. Monitor `#836` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-sync-coverage-643`, patch,
    validate locally, and push with lease.
-10. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+10. Monitor `#837` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-package-validator-coverage-643`,
+   patch, validate locally, and push with lease.
+11. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-11. Continue Phase 3 from the tranche issues below, prioritizing
+12. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:30 EDT
+Last reviewed: 2026-04-26 19:33 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -184,10 +184,11 @@ Open Phase 3 PRs:
   `main` at `d0262a1b`. This tranche also uses the GitHub/Namespace path
   while the SSH `windows` target remains unreachable.
 - `#832` platform child-process edge coverage for `#640`, branch
-  `feature/platform-child-process-coverage-640`, head `3018c8d5`;
-  opened from `main` at `d5efea57`. This tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
+  `feature/platform-child-process-coverage-640`, head `a361c8b9`;
+  opened from `main` at `d5efea57` and updated after the first Windows
+  Namespace run exposed a cmd/PowerShell portability issue in the test
+  commands. This tranche also uses the GitHub/Namespace path while the
+  SSH `windows` target remains unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -590,17 +591,19 @@ Local Phase 3 draft worktrees:
   version-bump report.
 - `#640` platform child-process worktree
   `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
-  branch `feature/platform-child-process-coverage-640`, commit
-  `3018c8d5`; open as PR `#832`.
+  branch `feature/platform-child-process-coverage-640`, commits
+  `3018c8d5` and `a361c8b9`; open as PR `#832`.
   Scope: test-only coverage for pre-start wait/read defaults,
   working-directory launch, stdout/stderr max-output byte caps,
   stderr-line callbacks, and fast-exit output preservation after
-  `is_running()` observes process completion. Local validation:
-  no-GPU/no-examples configure, `pulp-test-child-process` build, direct
-  `[issue-640]` run passed `25` assertions in `5` cases, full binary
-  passed `46` assertions in `17` cases, focused CTest passed `5/5`,
-  `git diff --check HEAD~1..HEAD`, `git diff --check`, skill-sync
-  report, and version-bump report.
+  `is_running()` observes process completion. The follow-up commit
+  removed a PowerShell dependency and trims stderr callback comparisons
+  so the test is resilient to `cmd` redirection spacing on Windows.
+  Local validation: no-GPU/no-examples configure,
+  `pulp-test-child-process` build, direct `[issue-640]` run passed `25`
+  assertions in `5` cases, full binary passed `46` assertions in `17`
+  cases, focused CTest passed `5/5`, `git diff --check HEAD~1..HEAD`,
+  `git diff --check`, skill-sync report, and version-bump report.
 
 Open supporting PR:
 
@@ -614,8 +617,9 @@ Open supporting PR:
   merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
   repaired again for Android SDK discovery, `#827` opened, `#823`
   merged, `#824` merged, `#828` opened, `#829` opened, `#825` merged,
-  `#830` opened, `#831` opened, `#827` merged, `#832` opened, and
-  `#826` merged, and remains docs-only.
+  `#830` opened, `#831` opened, `#827` merged, `#832` opened, `#826`
+  merged, and `#832` was repaired for Windows cmd portability, and
+  remains docs-only.
 
 Local environment note:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 02:02 EDT
+Last reviewed: 2026-04-26 02:10 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -125,38 +125,12 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#798` FormatRegistry audio dispatch coverage -> `443ca260`
 - `#799` docs-reader CLI shellout coverage -> `22438468`
 - `#800` Python gate-helper tooling coverage -> `55b6dfab`
+- `#795` events volume/service-discovery coverage -> `f1a5aa84`
 
 Open Phase 3 PRs:
 
-- `#795` `test(events): cover volume detector lifecycle edges`, branch
-  `feature/events-volume-coverage-642`, commit `357fc429`, worktree
-  `/Users/danielraffel/Code/pulp-events-volume-coverage-642`.
-  Scope: deterministic `test/test_network_service_discovery.cpp`
-  coverage for `NetworkServiceDiscovery` backend removal, cached-service
-  eviction, no-backend registration behavior,
-  `MountedVolumeListChangeDetector` mounted-volume snapshot plus
-  start/restart/stop lifecycle paths, and
-  `LockingAsyncUpdater::trigger_and_wait()`. Local validation:
-  after rebasing onto current `origin/main`,
-  `pulp-test-network-service-discovery` passed with `43` assertions in
-  `10` test cases; focused CTest `NSD|MountedVolume|LockingAsyncUpdater`
-  passed `10/10`; `git diff --check` clean; skill sync found no mapped
-  paths; version bump report says no bump needed. The earlier
-  `core/events/src/volume_detector.cpp` Windows guard was removed from the
-  final PR diff because the Windows coverage XML reports that translation
-  unit at `0%` even though the CTest cases run and pass there. The final
-  PR diff is test-only, and the mounted-volume enumeration tests skip on
-  Windows while retaining POSIX coverage. The prior Linux coverage failure
-  on `2d684f4b` was not from the events tests; the failed job showed the
-  #795 events tests passed and unrelated CLI/Python coverage tests failed
-  on the stale base. The branch was rebased onto `origin/main` after
-  `#800` merged, local validation passed again, and fresh CI is running
-  on `357fc429`. The PR is labeled
-  `codecov` and is using the direct GitHub/Namespace path instead of
-  `shipyard pr` because `#794` exposed a local Shipyard mac configure
-  stall after GitHub/Namespace was already clean.
 - `#801` `fix(render): harden texture atlas edge cases`, branch
-  `feature/render-texture-atlas-coverage-646`, commit `a2201dbb`,
+  `feature/render-texture-atlas-coverage-646`, commit `50012c04`,
   worktree `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`.
   Scope: reject non-positive `AtlasPacker` allocation dimensions, clamp
   repeated `ImageAtlas::release()` calls so refcounts cannot underflow,
@@ -170,10 +144,12 @@ Open Phase 3 PRs:
   `1139` assertions in `22` test cases, focused texture/atlas CTest
   passed `20/20`, `git diff --check` clean, skill sync clean, and version
   report clean with explicit `Version-Bump: sdk=patch` for the
-  header-only behavior fix. The PR is labeled `codecov` and is using the
-  direct GitHub/Namespace path.
+  header-only behavior fix. The branch was rebased onto `origin/main`
+  after `#795` merged, pushed with lease as `50012c04`, and the focused
+  local validation above passed again. The PR is labeled `codecov` and is
+  using the direct GitHub/Namespace path.
 - `#802` `test(cli): cover create shellout scaffolding`, branch
-  `feature/cli-create-coverage-643`, commit `f5e4a05f`, worktree
+  `feature/cli-create-coverage-643`, commit `222d0f88`, worktree
   `/Users/danielraffel/Code/pulp-cli-create-coverage-643`.
   Scope: deterministic `pulp create` shellout coverage for no-build app
   scaffolding with Android target output, generated header/main/CMake/
@@ -185,10 +161,12 @@ Open Phase 3 PRs:
   clean, and version bump report says no bump needed. Local shellout
   validation used `PULP_CLI_PATH=/Users/danielraffel/Code/pulp/build/tools/cli/pulp`
   because the GPU-off configure intentionally does not build `pulp-cli`;
-  CI builds the normal CLI path. The PR is labeled `codecov` and is
-  using the direct GitHub/Namespace path.
+  CI builds the normal CLI path. The branch was rebased onto
+  `origin/main` after `#795` merged, pushed with lease as `222d0f88`, and
+  the focused local validation above passed again. The PR is labeled
+  `codecov` and is using the direct GitHub/Namespace path.
 - `#803` `test(signal): cover matrix helper edges`, branch
-  `feature/signal-matrix-coverage-645`, commit `e18f5f27`, worktree
+  `feature/signal-matrix-coverage-645`, commit `b1f5a125`, worktree
   `/Users/danielraffel/Code/pulp-signal-matrix-coverage-645`.
   Scope: test-only signal matrix helper coverage for element-wise
   arithmetic, non-triangular `Matrix3` determinant, `Matrix4` scale
@@ -200,8 +178,10 @@ Open Phase 3 PRs:
   clean, skill sync clean, and version bump report says no bump needed.
   The broad `ctest -R "Matrix|matrix"` regex intentionally was not used
   as final evidence because it overmatches unrelated `*_NOT_BUILT`
-  placeholder tests in the focused no-GPU build. The PR is labeled
-  `codecov` and is using the direct GitHub/Namespace path.
+  placeholder tests in the focused no-GPU build. The branch was rebased
+  onto `origin/main` after `#795` merged, pushed with lease as
+  `b1f5a125`, and the focused local validation above passed again. The PR
+  is labeled `codecov` and is using the direct GitHub/Namespace path.
 
 Local Phase 3 draft worktrees:
 
@@ -211,8 +191,8 @@ Local Phase 3 draft worktrees:
   `c4e6ad09`. The remote branch was deleted after merge.
 - `#642` events volume/service-discovery worktree
   `/Users/danielraffel/Code/pulp-events-volume-coverage-642`, branch
-  `feature/events-volume-coverage-642`, commit `357fc429`; open as PR
-  `#795`.
+  `feature/events-volume-coverage-642`, commit `357fc429`; merged via PR
+  `#795` as `f1a5aa84`. The remote branch was deleted after merge.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
   `feature/package-registry-coverage-643`, commit `75a529ef`; merged via
@@ -242,22 +222,34 @@ Local Phase 3 draft worktrees:
 - `#646` texture-atlas render worktree
   `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`,
   branch `feature/render-texture-atlas-coverage-646`, commit
-  `a2201dbb`; open as PR `#801`.
+  `50012c04`; open as PR `#801`.
 - `#643` CLI-create shellout worktree
   `/Users/danielraffel/Code/pulp-cli-create-coverage-643`, branch
-  `feature/cli-create-coverage-643`, commit `f5e4a05f`; open as PR
+  `feature/cli-create-coverage-643`, commit `222d0f88`; open as PR
   `#802`.
 - `#645` signal matrix helper worktree
   `/Users/danielraffel/Code/pulp-signal-matrix-coverage-645`, branch
-  `feature/signal-matrix-coverage-645`, commit `e18f5f27`; open as PR
+  `feature/signal-matrix-coverage-645`, commit `b1f5a125`; open as PR
   `#803`.
+- `#645` signal oversampling helper worktree
+  `/Users/danielraffel/Code/pulp-signal-oversampling-coverage-645`,
+  branch `feature/signal-oversampling-coverage-645`, commit `bccaec0f`;
+  local draft, not pushed/opened yet. Scope: test-only oversampling
+  coverage for x2/x4 callback dispatch, configured anti-alias filter
+  paths, and reset determinism. Local validation: no-GPU configure,
+  `pulp-test-signal` target build, direct Catch2 tag
+  `[signal][oversampling]` passed with `16` assertions in `2` test cases,
+  focused CTest `Oversampler` passed `2/2`, `git diff --check` clean,
+  skill sync clean, and version bump report says no bump needed. The
+  local build still reports an existing unused-variable warning elsewhere
+  in `test/test_signal.cpp`; it is not introduced by this tranche.
 
 Open supporting PR:
 
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#800` merged and
+  The branch has been rebased onto `origin/main` after `#795` merged and
   remains docs-only.
 
 Local environment note:
@@ -271,13 +263,14 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795`, `#801`, `#802`, and `#803` and address any Codecov,
-   build, sanitizer, or Namespace feedback.
-3. If `#795`, `#801`, `#802`, or `#803` is green but GitHub reports it
-   behind `main`, rebase that branch onto `origin/main`, push with lease,
-   and let checks rerun.
-4. Continue Phase 3 from the tranche issues below, prioritizing
-   represented high-miss files over adding new perimeter lanes.
+2. Monitor `#801`, `#802`, and `#803` and address any Codecov, build,
+   sanitizer, or Namespace feedback.
+3. If `#801`, `#802`, or `#803` is green but GitHub reports it behind
+   `main`, rebase that branch onto `origin/main`, push with lease, and
+   let checks rerun.
+4. Open the local `#645` oversampling draft as the next small signal
+   tranche once the active PR queue has capacity, or keep it local if the
+   queue is still saturated.
 
 ## Phase 1 corrected baseline
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -69,6 +69,9 @@ Latest complete Codecov `main` report observed while updating this doc:
 
 - commit: `a80929c42ff61b88cd366383baad2ee817558b57`
 - workflow: Coverage run `24926536334`, completed successfully
+- note: this is the latest complete `main` Codecov report observed before
+  the `#771`, `#777`, `#782`, and `#786` merges; refresh after the next
+  complete `main` coverage run reaches a terminal state.
 - overall tracked coverage: `43.27%` over `70,197` lines in `556` files
 - covered lines: `30,376`
 - current component coverage from the Codecov API:
@@ -109,31 +112,10 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#771` WidgetBridge extended-controls coverage -> `3d03c0fe`
 - `#777` real CLAP `PluginSlot` coverage -> `478f489c`
 - `#782` VST3 adapter process-path coverage -> `648c2d27`
+- `#786` render DirtyTracker / RenderLoop edge coverage -> `26dd396d`
 
 Open Phase 3 PRs:
 
-- `#786` render DirtyTracker / RenderLoop edge coverage, branch
-  `feature/render-coverage-646-next`, head `49983137`. This tranche extends
-  the still-open `#646` render component follow-up after the earlier merged
-  `#700` slice. Scope is intentionally pure and hostable: DirtyTracker
-  negative/empty rects, debug overlay state, threshold accumulation,
-  no-viewport behavior, nearby non-overlap coalescing, Rect merge/touching
-  edges, and non-Apple TimerRenderLoop callback/restart behavior. Local
-  validation is green: configure, focused target build,
-  `pulp-test-dirty-tracker` (`52` assertions / `18` cases),
-  `pulp-test-rendering-integration` (`71` assertions / `40` cases),
-  focused CTest (`19/19`), GPU-off configure/build of
-  `pulp-test-cli-project-command`, `pulp-cli` build, direct
-  disabled-upgrade smoke, focused CLI shellout coverage for
-  `PULP_UPDATE_CHECK_DISABLED`, skill/version checks, and whitespace. After
-  `#771` merged, this branch was rebased onto `origin/main` and duplicate
-  shared support commits were skipped. The `f7da209d` rerun failed the
-  required diff-coverage gate on the same shared `cmd_project.cpp` probe edges
-  as `#782`; that shared coverage is now on `main` via `#771`. GitHub Actions
-  is rerunning at `49983137`. The macOS Namespace job failed during setup on a
-  transient `curl` HTTP 502 while downloading the shared `wgpu-native` runtime,
-  before configure/tests; rerun failed jobs once the Build and Test workflow
-  reaches a terminal state.
 - `#788` events socket-IPC coverage, branch
   `feature/events-ipc-coverage-642`, head `4cb33f4e`. This tranche
   extends `test/test_ipc.cpp` with malformed socket endpoint rejection,
@@ -147,7 +129,8 @@ Open Phase 3 PRs:
   whitespace. A direct multi-filter Catch2 invocation was intentionally not
   used as validation because Catch2 treats multiple quoted filters as an AND
   expression; CTest was used for the focused multi-test slice. PR is labeled
-  `codecov` and GitHub Actions is starting.
+  `codecov`; GitHub Actions has no failures observed in the current polling
+  window and is waiting on Linux Namespace plus Linux coverage to finish.
 
 Local Phase 3 draft not yet opened as a PR:
 - `#644` Android ship/package helper tranche, worktree
@@ -172,33 +155,27 @@ Open supporting PR:
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The previous head `3f1df148` failed Windows Namespace for the same
-  `pulp project bump` Windows redirection bug now fixed on `main` via `#771`.
-  This branch has been rebased onto `origin/main` after that merge and should
-  rerun without carrying code changes.
+  The branch has been rebased onto `origin/main` after `#786` merged and
+  remains docs-only.
 
 Next recovery actions:
 
-1. Poll `#786` and `#788`; merge green PRs manually
-   because auto-merge is disabled.
-2. Let `#786`'s macOS Namespace rerun and `#788`'s initial checks drain.
+1. Poll `#788`; merge manually when green because auto-merge is disabled.
+2. Let `#788`'s Linux Namespace and Linux coverage checks drain.
 3. Keep `#644` as the next rebased local draft; open it after the current
    active PR queue has room or if `ship` becomes the next priority.
-4. Keep `#774` docs-only and let its post-`#771` rebase checks drain.
-5. After `#786` and `#788` merge, refresh this section with the next
+4. Keep `#774` docs-only and let its post-`#786` rebase checks drain.
+5. After `#788` merges, refresh this section with the next
    complete Codecov `main` report.
 6. If any Windows Namespace lane fails again, pull the fresh completed-run
    log first and search for `pulp-test-cli-project-command`; the known
    failing tests were the dirty-gate and redundant-origin project-bump cases.
-7. If `#786` still shows macOS Namespace failed after the Build and Test
-   workflow completes, rerun failed jobs for run `24929553366`; the observed
-   failure was a transient `wgpu-native` download HTTP 502 before tests.
-8. If sandbox-e2e fails again, pull the fresh log first; the expected
+7. If sandbox-e2e fails again, pull the fresh log first; the expected
    failure fixed here was `pulp upgrade --check-only` ignoring
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
-9. If a PR is green but GitHub reports it behind `main`, rebase that
+8. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-10. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 16:52 EDT
+Last reviewed: 2026-04-26 17:05 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -171,6 +171,11 @@ Open Phase 3 PRs:
   unreachable.
 - `#821` audio reader helper edge coverage for `#640`, branch
   `feature/audio-reader-helpers-coverage-640`, head `be7d604f`; opened
+  from `main` at `c9620a65`. This tranche also uses the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
+- `#822` audio file helper edge coverage for `#640`, branch
+  `feature/audio-file-helper-coverage-640`, head `f4e59d2b`; opened
   from `main` at `c9620a65`. This tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
@@ -406,6 +411,23 @@ Local Phase 3 draft worktrees:
   cases, full v3-gaps binary passed `87` assertions in `23` cases,
   focused CTest passed `12/12`, `git diff --check`, skill-sync report,
   and version-bump report.
+- `#640` audio file helper worktree
+  `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
+  branch `feature/audio-file-helper-coverage-640`, commit `f4e59d2b`;
+  open as PR `#822`.
+  Scope: test-only coverage for packed int24 conversion, int32 full-scale
+  conversion, float-to-int32 clamping, zero-count conversion no-ops, CHOC
+  WAV helper output via RIFF chunk parsing, malformed WAV rejection,
+  invalid OGG registry dispatch, `Buffer` resize/view ownership, and
+  `AudioProcessLoadMeasurer` smoothing/zero-available-time guards. Local
+  validation: no-GPU/no-examples configure, `pulp-test-audio-file`,
+  `pulp-test-audio`, and `pulp-test-load-measurer` build, direct
+  `[issue-640]` audio-file run passed `217` assertions in `11` cases,
+  full audio-file binary passed `450` assertions in `26` cases, full
+  audio binary passed `586` assertions in `8` cases, full load-measurer
+  binary passed `20` assertions in `6` cases, focused CTest passed
+  `11/11`, `git diff --check`, skill-sync report, and version-bump
+  report.
 
 Open supporting PR:
 
@@ -413,8 +435,8 @@ Open supporting PR:
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#813` merged,
-  updated after `#816` merged, `#817` was repaired, `#820` opened, and
-  `#821` opened, and remains docs-only.
+  updated after `#816` merged, `#817` was repaired, `#820` opened,
+  `#821` opened, and `#822` opened, and remains docs-only.
 
 Local environment note:
 
@@ -448,10 +470,13 @@ Next recovery actions:
 6. Monitor `#821` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-reader-helpers-coverage-640`,
    patch, validate locally, and push with lease.
-7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+7. Monitor `#822` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
+   patch, validate locally, and push with lease.
+8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-8. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 17:05 EDT
+Last reviewed: 2026-04-26 17:08 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -144,6 +144,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#814` CLI `pulp pr` shellout coverage -> `8bd4a3e9`
 - `#815` MPE tracker edge-path coverage -> `019130bd`
 - `#816` MIDI running-status parser edge coverage -> `c9620a65`
+- `#818` MPE synth voice / allocator coverage -> `3d4560d1`
 
 Open Phase 3 PRs:
 
@@ -154,11 +155,6 @@ Open Phase 3 PRs:
   pr` was attempted first but stopped before PR creation because the SSH
   `windows` backend timed out, so this tranche is using the
   GitHub/Namespace path instead of skipping that lane.
-- `#818` MPE synth voice / allocator edge coverage for `#645`, branch
-  `feature/midi-mpe-synth-voice-coverage-645`, head `21eb74e1`; opened
-  from `main` at `957a0735`. This tranche is also using the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
 - `#819` MIDI keyboard/sequence edge coverage for `#645`, branch
   `feature/midi-keyboard-sequence-coverage-645`, head `60676709`;
   opened from `main` at `019130bd`. This tranche also uses the
@@ -355,7 +351,8 @@ Local Phase 3 draft worktrees:
 - `#645` MPE synth voice worktree
   `/Users/danielraffel/Code/pulp-midi-mpe-synth-voice-coverage-645`,
   branch `feature/midi-mpe-synth-voice-coverage-645`, commit
-  `21eb74e1`; open as PR `#818`.
+  `21eb74e1`; merged via PR `#818` as `3d4560d1`. The remote branch was
+  deleted after merge.
   Scope: test-only coverage for `MpeSynthVoice` smoothing clamp,
   reset/release state, timbre routing, all non-oldest `MpeVoiceAllocator`
   steal policies, unknown expression events, `reset_all`, and
@@ -436,7 +433,7 @@ Open supporting PR:
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#813` merged,
   updated after `#816` merged, `#817` was repaired, `#820` opened,
-  `#821` opened, and `#822` opened, and remains docs-only.
+  `#821` opened, `#822` opened, and `#818` merged, and remains docs-only.
 
 Local environment note:
 
@@ -458,25 +455,22 @@ Next recovery actions:
 2. Monitor `#817` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
    patch, validate locally, and push with lease.
-3. Monitor `#818` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-midi-mpe-synth-voice-coverage-645`,
-   patch, validate locally, and push with lease.
-4. Monitor `#819` cloud checks; if a required lane fails, debug in
+3. Monitor `#819` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-keyboard-sequence-coverage-645`,
    patch, validate locally, and push with lease.
-5. Monitor `#820` cloud checks; if a required lane fails, debug in
+4. Monitor `#820` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-spectrogram-coverage-645`,
    patch, validate locally, and push with lease.
-6. Monitor `#821` cloud checks; if a required lane fails, debug in
+5. Monitor `#821` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-reader-helpers-coverage-640`,
    patch, validate locally, and push with lease.
-7. Monitor `#822` cloud checks; if a required lane fails, debug in
+6. Monitor `#822` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
    patch, validate locally, and push with lease.
-8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 18:43 EDT
+Last reviewed: 2026-04-25 19:08 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -94,6 +94,10 @@ Latest complete Codecov `main` report observed while updating this doc:
   - `ship`: `36.48%`
   - `tools`: `39.89%`
 
+`main` has since advanced to `e61dce8d907c29888fd7dd97ae7f49e3bc219662`
+after `#789` merged. The next complete Codecov `main` report for that
+commit had not landed at the time of this update.
+
 Merged after the Phase 1 closeout / `#723` baseline:
 
 - `#649` CLI/tools tranche 1 -> `8449b6e8`
@@ -110,17 +114,20 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#777` real CLAP `PluginSlot` coverage -> `478f489c`
 - `#782` VST3 adapter process-path coverage -> `648c2d27`
 - `#786` render DirtyTracker / RenderLoop edge coverage -> `26dd396d`
+- `#789` Android ship/package helper coverage -> `e61dce8d`
 
 Open Phase 3 PRs:
 
 - `#788` events socket-IPC coverage, branch
-  `feature/events-ipc-coverage-642`, head `4cb33f4e`. This tranche
+  `feature/events-ipc-coverage-642`, head `2ac5b09e`. This tranche
   extends `test/test_ipc.cpp` with malformed socket endpoint rejection,
   non-throwing socket endpoint parsing in
   `core/events/src/interprocess_connection.cpp`, and a deterministic
   localhost client/server framed-message exchange. After `#771` merged, this
   branch was rebased onto `origin/main` and duplicate shared CLI support
-  commits were skipped, leaving only the events tranche. Local validation is
+  commits were skipped, leaving only the events tranche. After `#789` merged,
+  the branch was rebased again onto `origin/main` at
+  `e61dce8d907c29888fd7dd97ae7f49e3bc219662`. Local validation is
   green: `pulp-test-ipc` (`34` assertions / `9` test
   cases), focused CTest `IPC` (`9/9`), and
   whitespace. A direct multi-filter Catch2 invocation was intentionally not
@@ -129,49 +136,15 @@ Open Phase 3 PRs:
   `codecov`. The earlier Linux Namespace and Linux coverage failures did not
   expose usable logs through `gh`. A rerun of Build/Test `24929736674` and
   Coverage `24929736678` then sat in progress for roughly 90 minutes with no
-  logs and no timestamp movement, so both runs were canceled and rerun from
-  the same head `4cb33f4e`. GitHub reran the full Build/Test and Coverage
-  workflows, not only the Linux jobs; the current polling window shows no
-  failures while those fresh checks drain.
-- `#789` Android ship/package helper coverage, branch
-  `feature/android-package-coverage-644`, head `23ea43e2`. This tranche
-  adds a deterministic host-side fake Android SDK/toolchain harness for
-  `ship/platform/android/package_android.cpp` without requiring a real SDK,
-  device, keystore, Gradle install, bundletool, or network access. Scope:
-  SDK/build-tools/NDK discovery, fake `zipalign`, fake `apksigner` signing and
-  APK verification parsing, fake `jarsigner` AAB signing/verification, fake
-  Gradle APK/AAB artifact collection, missing-wrapper/missing-artifact errors,
-  and fake bundletool conversion with optional signing config. After `#786`
-  merged, this branch was rebased onto `origin/main`, pushed, opened as a PR,
-  and labeled `codecov`. The first GitHub Actions pass exposed a Windows
-  Namespace-only failure in batch-backed Android tool invocation. The first
-  follow-up fixed the skill-sync gap but still failed the same three Windows
-  Android tests. The second follow-up preserved quoted batch executable paths
-  for `cmd.exe /c` but still failed the same Windows tests. The current head
-  additionally fixed the fake Windows `apksigner.bat` fixture's unescaped
-  parenthesized echo text and quotes whole Gradle / bundletool `name=value`
-  arguments instead of only quoted values; that narrowed the Windows Namespace
-  failure to only the fake Gradle artifact-collection case. The current head
-  runs Gradle through `ChildProcess::run` with `ProcessOptions::working_directory`
-  set to the Gradle project directory instead of relying on inline
-  `cd ... && gradlew` shell parsing; the `ship` skill documents these Windows
-  batch gotchas. Local validation is green:
-  `cmake --build build --target pulp-test-android-package -j4`, direct
-  `pulp-test-android-package` (`64` assertions / `7` test cases), focused
-  Android package CTest (`7/7`), adjacent ship CTest slice for
-  Android/appcast/codesign/notarization/DMG (`20/20`), and whitespace.
-  `a3f124a1` cleared the platform/test lanes but failed required diff
-  coverage at `74.6%` because Windows-only helper branch lines were not marked
-  hit in the merged coverage artifact. The current head simplifies those
-  helpers without behavior changes to reduce the uncovered diff surface; the
-  current polling window shows no failures while fresh checks run on
-  `23ea43e2`.
+  logs and no timestamp movement, so both stuck runs were canceled. The branch
+  was then rebased after `#789`; the current polling window shows no failures
+  while the fresh `2ac5b09e` checks drain.
 
 Local Phase 3 draft not yet opened as a PR:
 - `#643` package-registry CLI/tools draft, worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
   `feature/package-registry-coverage-643`, local commit `b1443bb9`. This draft is local-only and
-  should not be opened until `#788` / `#789` resolve. Current scope adds
+  should not be opened until `#788` resolves. Current scope adds
   `pulp-test-cli-package-registry` for pure local registry parsing,
   lock-file round trips, target TOML parsing/writing, semver, quality
   scoring, unsupported-target detection, and search ranking. Local validation
@@ -189,30 +162,24 @@ Open supporting PR:
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#786` merged and
+  The branch has been rebased onto `origin/main` after `#789` merged and
   remains docs-only.
 
 Next recovery actions:
 
-1. Poll `#788` and `#789`; merge manually when green because auto-merge is
-   disabled.
-2. Let `#788`'s fresh full Build/Test and Coverage workflow reruns drain.
-3. Let `#789`'s post-Windows-batch-fix GitHub Actions checks drain; pull the
-   exact failing job log first if anything turns red.
-4. Keep `#774` docs-only and let its post-`#786` rebase checks drain.
-5. After the active code PRs merge, refresh this section with the next
+1. Poll `#788`; merge manually when green because auto-merge is disabled.
+2. Let `#788`'s fresh full Build/Test and Coverage workflows on `2ac5b09e`
+   drain.
+3. Keep `#774` docs-only and let its post-`#789` rebase checks drain.
+4. After `#788` merges, refresh this section with the next
    complete Codecov `main` report.
-6. If `#789` Windows Namespace fails again, pull the fresh completed-run log
-   first and search for `test_android_package.cpp`, `Android signing helpers`,
-   `Android Gradle packaging`, and `Android bundletool`; do not patch further
-   without the new log.
-7. If `#788` Linux Namespace or Linux coverage fails again, pull the fresh log
+5. If `#788` Linux Namespace or Linux coverage fails again, pull the fresh log
    first; the current branch already has local IPC validation green.
-8. If a PR is green but GitHub reports it behind `main`, rebase that
+6. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-9. After `#788` and `#789` resolve, push/open the local `#643` draft
+7. After `#788` resolves, push/open the local `#643` draft
    (`b1443bb9`) as the next CLI/tools tranche PR.
-10. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 16:08 EDT
+Last reviewed: 2026-04-26 16:15 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -142,15 +142,10 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#811` CLI project-command dispatch coverage -> `810743d4`
 - `#813` signal dynamics helper coverage -> `957a0735`
 - `#814` CLI `pulp pr` shellout coverage -> `8bd4a3e9`
+- `#815` MPE tracker edge-path coverage -> `019130bd`
 
 Open Phase 3 PRs:
 
-- `#815` MPE tracker edge-path coverage for `#645`, branch
-  `feature/mpe-tracker-coverage-645`, head `b7c72711`; opened from
-  `main` at `957a0735`. Windows coverage failed during dependency
-  bootstrap on a `wgpu-native` 502; the failed coverage jobs were rerun,
-  and the rerun passed dependency bootstrap and is now in the Windows
-  coverage suite.
 - `#816` MIDI running-status parser edge coverage for `#645`, branch
   `feature/midi-running-status-coverage-645`, head `94b93a6e`; opened
   from `main` at `957a0735`. Cloud checks are the active gate.
@@ -292,8 +287,8 @@ Local Phase 3 draft worktrees:
   skill-sync report, and version-bump report.
 - `#645` MPE tracker worktree
   `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, branch
-  `feature/mpe-tracker-coverage-645`, commit `b7c72711`; open as PR
-  `#815`.
+  `feature/mpe-tracker-coverage-645`, commit `b7c72711`; merged via PR
+  `#815` as `019130bd`. The remote branch was deleted after merge.
   Scope: test-only coverage for `MpeVoiceTracker` bend-range rejection,
   config reset, manager pressure/timbre state, cached member expression,
   bounded snapshots, and full-table overflow behavior. Local validation:
@@ -370,24 +365,19 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#815` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, patch,
-   validate locally, and push with lease. The current Windows coverage
-   failure was rerun in run `24965100026`; wait for that rerun result
-   before changing code.
-3. Monitor `#816` cloud checks; if a required lane fails, debug in
+2. Monitor `#816` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-running-status-coverage-645`,
    patch, validate locally, and push with lease.
-4. Monitor `#817` cloud checks; if a required lane fails, debug in
+3. Monitor `#817` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
    patch, validate locally, and push with lease.
-5. Monitor `#818` cloud checks; if a required lane fails, debug in
+4. Monitor `#818` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-synth-voice-coverage-645`,
    patch, validate locally, and push with lease.
-6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+5. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-7. Continue Phase 3 from the tranche issues below, prioritizing
+6. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 02:29 EDT
+Last reviewed: 2026-04-26 02:34 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -224,6 +224,18 @@ Open Phase 3 PRs:
   noting the SDK patch suggestion from the defensive production guard.
   The PR is labeled `codecov` and is using the direct GitHub/Namespace
   path.
+- `#807` `test(audio): cover channel set helpers`, branch
+  `feature/audio-channel-set-coverage-640`, commit `89b969c9`,
+  worktree `/Users/danielraffel/Code/pulp-audio-channel-set-coverage-640`.
+  Scope: test-only `ChannelSet` coverage for standard layouts by count
+  and name, discrete fallbacks, speaker-name mappings including the
+  unknown-enum fallback, and equality semantics. Local validation:
+  no-GPU configure, `pulp-test-audio` target build, direct Catch2 tag
+  `[audio][channel-set][issue-640]` passed with `38` assertions in `2`
+  test cases, focused CTest `ChannelSet` passed `2/2`, diff check
+  clean, skill sync clean, and version bump report says no bump
+  needed. The PR is labeled `codecov` and is using the direct
+  GitHub/Namespace path.
 
 Local Phase 3 draft worktrees:
 
@@ -285,6 +297,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-audio-reader-coverage-640`, branch
   `feature/audio-reader-coverage-640`, commit `c1d61e3a`; open as PR
   `#806`.
+- `#640` ChannelSet audio worktree
+  `/Users/danielraffel/Code/pulp-audio-channel-set-coverage-640`,
+  branch `feature/audio-channel-set-coverage-640`, commit `89b969c9`;
+  open as PR `#807`.
 
 Open supporting PR:
 
@@ -305,10 +321,10 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#801`, `#802`, `#803`, `#804`, `#805`, and `#806` and
-   address any Codecov, build, sanitizer, or Namespace feedback.
-3. If `#801`, `#802`, `#803`, `#804`, `#805`, or `#806` is green but
-   GitHub reports it behind `main`, rebase that branch onto
+2. Monitor `#801`, `#802`, `#803`, `#804`, `#805`, `#806`, and `#807`
+   and address any Codecov, build, sanitizer, or Namespace feedback.
+3. If `#801`, `#802`, `#803`, `#804`, `#805`, `#806`, or `#807` is green
+   but GitHub reports it behind `main`, rebase that branch onto
    `origin/main`, push with lease, and let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 21:20 EDT
+Last reviewed: 2026-04-26 21:29 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -200,9 +200,12 @@ Open Phase 3 PRs:
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
 - `#838` CLI release packager coverage for `#643`, branch
-  `feature/package-cli-coverage-643`, head `7e76a1b7`; opened from
-  `main` at `b5e7a463`. This tranche also uses the GitHub/Namespace
-  path while the SSH `windows` target remains unreachable.
+  `feature/package-cli-coverage-643`, head `09666f46`; opened from
+  `main` at `b5e7a463`, then rebased onto `d02c9ec9` and repaired after
+  macOS Namespace exposed a parallel CTest temp-dir collision in
+  `test/test_android_package.cpp`. This tranche also uses the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
 - `#839` GPU graph render helper hardening/coverage for `#646`, branch
   `feature/render-gpu-graph-coverage-646`, head `fa3deb3b`; opened
   from `main` at `bdc406cc`, then rebased onto `d02c9ec9` after `#830`
@@ -412,7 +415,7 @@ Local Phase 3 draft worktrees:
   coverage; and moves the header-only dirty-tracker and GPU-graph tests
   out of the GPU-only CMake block so GPU-off sanitizer/local coverage
   builds can exercise them without linking `pulp::render`. Local
-  validation after rebasing onto `bdc406cc`: GPU-off configure,
+  validation after rebasing onto `d02c9ec9`: GPU-off configure,
   `pulp-test-gpu-graph` and `pulp-test-dirty-tracker` builds, direct
   `[issue-646]` run passed `39` assertions in `7` cases, full
   gpu-graph binary passed `52` assertions in `11` cases, full
@@ -421,18 +424,26 @@ Local Phase 3 draft worktrees:
   report with an SDK patch trailer, and pre-push gates.
 - `#643` CLI release packager worktree
   `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, branch
-  `feature/package-cli-coverage-643`, commit `7e76a1b7`; open as PR
+  `feature/package-cli-coverage-643`, commit `09666f46`; open as PR
   `#838`.
   Scope: test-only Python coverage for `tools/scripts/package_cli.py`
   wgpu library discovery, macOS/Linux rpath command selection,
   tar/zip archive writer layout, missing-binary and missing-library
   exits, and successful Linux/Windows package staging with external
-  tools mocked. Local validation after rebasing onto `origin/main` with
-  `#831` merged: direct `python3 tools/scripts/test_package_cli.py`
-  passed `10` cases, `git diff --check HEAD~1..HEAD`, skill-sync
-  report, and version-bump report. The local Python coverage runner
-  could not run because this interpreter lacks `coverage.py >= 7.10`;
-  hosted CI remains the coverage proof for this tranche.
+  tools mocked. Follow-up repair after rebasing onto `d02c9ec9` isolates
+  Android package test temp dirs with process id plus an atomic
+  per-process counter, fixing the macOS Namespace failure where
+  concurrently discovered Catch2 test processes could read a neighboring
+  fake SDK and report `35.0.1` instead of `10.0.0`. Local validation:
+  direct `python3 tools/scripts/test_package_cli.py` passed `10` cases,
+  no-GPU/no-examples configure, `pulp-test-android-package` build, direct
+  `Android SDK discovery compares tool revisions numerically` run passed
+  `5` assertions in `1` case, matching CTest passed, parallel CTest
+  `Android SDK discovery` passed `3/3`, broader parallel CTest `Android`
+  passed `8/8`, `git diff --check origin/main...HEAD`, skill-sync report,
+  and version-bump report. The local Python coverage runner could not
+  run because this interpreter lacks `coverage.py >= 7.10`; hosted CI
+  remains the coverage proof for this tranche.
 - `#645` MPE tracker worktree
   `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, branch
   `feature/mpe-tracker-coverage-645`, commit `b7c72711`; merged via PR
@@ -789,7 +800,8 @@ Open supporting PR:
   repaired for the fast-exit deadline review, and `#833` was rebased
   onto `b5e7a463` to clear the stale Android SDK discovery ASan failure,
   and `#836` merged, and `#837` merged, and `#839` opened,
-  and `#830` merged,
+  and `#830` merged, and `#838` was rebased onto `d02c9ec9` and repaired
+  for the Android package parallel temp-dir collision,
   and remains docs-only.
 
 Local environment note:
@@ -824,7 +836,7 @@ Next recovery actions:
 6. Monitor `#835` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
    validate locally, and push with lease.
-7. Monitor `#838` cloud checks; if a required lane fails, debug in
+7. Monitor `#838` cloud checks on head `09666f46`; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, patch,
    validate locally, and push with lease.
 8. Monitor `#839` cloud checks; if a required lane fails, debug in

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,11 +1,29 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-27 00:20 EDT
+Last reviewed: 2026-04-29 02:10 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
-program under `#641`. Phase 1 representation is complete, Phase 2 gap
-planning has been seeded from the corrected Codecov baseline, and Phase
-3 gap closure is active through small, reviewable PR tranches.
+program under `#641`.
+
+## Current Phase
+
+- Phase 1 - Representation / Codecov truth: complete.
+- Phase 2 - Gap planning: complete enough to execute from the tracker
+  map and tranche issues.
+- Phase 3 - Gap closure: active. The work is now small, focused
+  coverage PRs that move represented components toward their tier
+  targets.
+
+The authoritative live tracker remains `#641`. The high-leverage
+host/format/view tracker remains `#493`. Component tranche trackers are:
+
+- `#640` audio / platform
+- `#642` events
+- `#643` CLI / tools
+- `#644` ship
+- `#645` MIDI / signal
+- `#646` render
+- `#493` host / format / view
 
 ## Goal
 
@@ -19,1390 +37,119 @@ Target tiers remain unchanged in `ci/coverage-targets.yaml`:
 - `70%`: `render`, `view`, `cli`
 - `50%`: `events`, `runtime`, `state`, `canvas`, `osc`, `ship`, `tools`
 
-## Three-phase program
+## Latest Complete Codecov Snapshot
 
-### Phase 1 - Representation / Codecov truth
+Latest complete Codecov `main` report observed while updating this doc:
 
-Status: complete.
+- commit: `e9c994d1bb2c42f1a50e4775a5886b6348808fb0`
+- PR: `#851` - `test(signal): cover meter channel-count guards`
+- state: complete
+- overall tracked coverage: `48.40%`
+- covered lines: `34,608 / 71,492`
+- missed lines: `35,511`
+- partial lines: `1,373`
+- files: `560`
+- sessions: `4`
 
-Finish line state:
+Current component coverage from the same Codecov API snapshot:
 
-- `windows` is non-null on `main` (`0.0%` at the current baseline).
-- `dsl` is a real component on `main` (`68.3%`).
-- `apple/Sources/**` materializes on Codecov for the macOS Swift package
-  lane and the native `PulpBridge.cpp` lane.
-- `android/app/src/main/kotlin/**` materializes on Codecov.
-- `bindings/python/bindings.cpp` materializes on Codecov.
-- the clearly known remaining "still not on Codecov" buckets are listed
-  below as explicit follow-up or out-of-scope surfaces.
-- this status document is rebaselined from the corrected `main` surface.
+| Component | Coverage | Target | Gap |
+| --- | ---: | ---: | ---: |
+| `audio` | `37.20%` | `80%` | `42.80` |
+| `platform` | `38.95%` | `80%` | `41.05` |
+| `host` | `44.16%` | `80%` | `35.84` |
+| `cli` | `40.84%` | `70%` | `29.16` |
+| `format` | `51.92%` | `80%` | `28.08` |
+| `view` | `45.17%` | `70%` | `24.83` |
+| `midi` | `55.72%` | `80%` | `24.28` |
+| `render` | `64.43%` | `70%` | `5.57` |
+| `signal` | `75.40%` | `80%` | `4.60` |
+| `tools` | `46.93%` | `50%` | `3.07` |
 
-### Phase 2 - Gap planning
+Components currently above their configured Phase 3 tier floor in this
+snapshot include `canvas`, `events`, `runtime`, `state`, `osc`, and
+`ship`. Non-tier reporting components include `android`, `apple`,
+`linux`, `windows`, `dsl`, and `inspect`.
 
-Status: complete enough to execute, with the roadmap tracked in `#641`
-and the tranche issues listed below.
+## Queue State
 
-Finish line:
+The active codecov code-PR queue has been drained. The only open PR with
+the `codecov` label at this review is this doc refresh:
 
-- counted components are ranked from the corrected `main` baseline
-- major low-coverage files and components are grouped into tranche issues
-- remaining out-of-scope surfaces are either accepted for now or have
-  explicit expansion issues
-- the repo has an actionable issue / PR roadmap for closing measured
-  gaps
+- `#774` - `docs: refresh coverage compliance handoff`
 
-### Phase 3 - Gap closure
+Final code PRs merged during the 2026-04-29 drain:
 
-Status: active.
+- `#849` view label paint coverage -
+  `4148c6723f3951c6861e13cdbd502b90111f8f5f`
+- `#867` embedded Python bindings state coverage -
+  `bd13a2add545b9cfa4db530c9f66171dfb8fb69e`
+- `#850` runner resolver coverage -
+  `55857f15361e591972eef58f955427745cec0198`
+- `#971` version bump helper coverage -
+  `dc4bc66e55f0d9f85fbc2c4f8d0910ca7224e032`
+- `#886` iOS audio-session event label coverage -
+  `0f260b812ed9d4a8b6bb76293d02f768fac046b7`
+- `#853` audio frame-fill invalid-dimension coverage -
+  `c05384aaef731ccee481c7f47e6089ba8ef42afe`
+- `#851` signal meter channel-count guard coverage -
+  `e9c994d1bb2c42f1a50e4775a5886b6348808fb0`
 
-Finish line:
+The previously listed stale open PR queue from `#840` through `#895`
+has been resolved; those code coverage tranches are no longer active
+open work.
 
-- planned coverage tranches are implemented and merged
-- target components move materially toward or to their configured
-  thresholds
-- deferred or exceptional surfaces stay documented explicitly instead of
-  silently omitted
+## Phase 3 Finish Line
 
-## Current live state
+Phase 3 is done when the planned represented-surface tranches have been
+implemented or explicitly deferred, and the remaining gaps are
+documented rather than silently ignored.
 
-Latest complete Codecov `main` report observed while updating this doc
-(`main` head `51be8860` has a newer Coverage run queued):
+Practical finish criteria for the current plan:
 
-- commit: `5b8e4529cfc553fd98b65f265ed1e9c0487b3d66`
-- workflow: Coverage run `24970413173`, completed successfully
-- overall tracked coverage: `46.83%` over `70,453` lines in `556` files
-- covered lines: `32,996`
-- missed lines: `36,165`
-- partial lines: `1,292`
-- current component coverage from the Codecov API:
-  - `audio`: `37.36%`
-  - `canvas`: `64.74%`
-  - `dsl`: `68.3%`
-  - `events`: `49.78%`
-  - `format`: `51.72%`
-  - `host`: `43.07%`
-  - `midi`: `54.56%`
-  - `osc`: `66.26%`
-  - `platform`: `40.16%`
-  - `render`: `62.77%`
-  - `runtime`: `49.11%`
-  - `signal`: `73.87%`
-  - `state`: `63.56%`
-  - `view`: `44.0%`
-  - `android`: `13.83%`
-  - `apple`: `25.36%`
-  - `linux`: `3.31%`
-  - `windows`: `0.0%`
-  - `cli`: `40.86%`
-  - `ship`: `53.99%`
-  - `tools`: `45.32%`
+- `audio`, `platform`, `host`, `format`, `midi`, and `signal` move
+  materially toward the `80%` tier, with any hardware-bound platform
+  shims either covered through deterministic seams or documented as
+  deferred.
+- `view`, `render`, and `cli` move toward the `70%` tier, prioritizing
+  large represented files before small tail cleanup.
+- `tools` crosses the `50%` infrastructure floor, then further tooling
+  slices are handled only when they are high leverage or support the
+  coverage system itself.
+- `canvas`, `events`, `runtime`, `state`, `osc`, and `ship` stay above
+  their `50%` infrastructure floor while ordinary feature work continues
+  to satisfy the required diff-coverage gate.
+- Deferred surfaces remain explicit in the tracker set: authored
+  JavaScript (`#659`), Node bindings plus shell/PowerShell
+  classification (`#657`), optional native surfaces (`#737`), and
+  mobile runtime / simulator coverage (`#77`).
 
-Post-`#794` file-level proof point: `core/audio/src/aiff_reader.cpp`
-is now `72.01%` covered with `61` misses, up from `64.22%` with `78`
-misses at the prior `e2af9c4d` baseline.
+## Next Tranche Order
 
-Post-`#813` proof point: the `signal` component is now `69.4%` covered,
-up from `66.13%` at the prior `810743d4` baseline.
+Use the latest complete Codecov file ranking and the tracker issues to
+choose the next small PR. As of the `c05384aa` snapshot, the highest
+remaining misses are concentrated in:
 
-Merged after the Phase 1 closeout / `#723` baseline:
+- `#640`: `audio` / `platform`, especially platform device shims and
+  deterministic platform helpers.
+- `#493`: `host` / `format` / `view`, especially real slot adapters,
+  `widget_bridge.cpp`, and macOS view-host surfaces.
+- `#643`: `cli` / `tools`, especially large command modules and
+  low-coverage Python helpers.
+- `#645`: `midi` / `signal`, with `signal` close to the 80% tier and
+  `midi` still led by platform MIDI shims and MPE tracker paths.
+- `#646`: `render`, now close to the 70% tier and best handled through
+  GPU-off-safe helper targets when possible.
 
-- `#649` CLI/tools tranche 1 -> `8449b6e8`
-- `#648` events tranche 1 -> `357eded1`
-- `#666` ship/state deterministic hardening -> `75439c89`
-- `#734` audio/platform tranche 1 -> `2224d11d`
-- `#741` midi/signal tranche 1 -> `63fd5ad5`
-- `#757` scan-worker CLI coverage -> `9053e0b`
-- `#755` LV2 host/entry coverage -> `aed8acb`
-- `#756` validation harness edge coverage -> `22d1e69`
-- `#765` TextEditor multiline navigation coverage -> `7257a154`
-- `#766` OSC UDP sender/receiver edge coverage -> `31aa80e1`
-- `#771` WidgetBridge extended-controls coverage -> `3d03c0fe`
-- `#777` real CLAP `PluginSlot` coverage -> `478f489c`
-- `#782` VST3 adapter process-path coverage -> `648c2d27`
-- `#786` render DirtyTracker / RenderLoop edge coverage -> `26dd396d`
-- `#789` Android ship/package helper coverage -> `e61dce8d`
-- `#788` events socket-IPC coverage -> `23d3ed1d`
-- `#793` package-registry CLI/tools coverage -> `e2af9c4d`
-- `#794` AIFF reader edge-path coverage -> `c4e6ad09`
-- `#796` tool-registry CLI/tools coverage -> `11c10a7e`
-- `#797` StreamingWriter audio edge coverage -> `64ba65e3`
-- `#798` FormatRegistry audio dispatch coverage -> `443ca260`
-- `#799` docs-reader CLI shellout coverage -> `22438468`
-- `#800` Python gate-helper tooling coverage -> `55b6dfab`
-- `#795` events volume/service-discovery coverage -> `f1a5aa84`
-- `#802` CLI-create shellout coverage -> `2de79ff3`
-- `#803` signal matrix helper coverage -> `57285797`
-- `#801` render texture-atlas coverage and LCOV converter fix -> `ae4fdab8`
-- `#804` signal Oversampler helper coverage -> `c6600f9`
-- `#805` CLI common helper coverage -> `5844c6ac`
-- `#806` audio mapped-reader/offline processing coverage -> `1bcb23e3`
-- `#807` audio ChannelSet helper coverage -> `46e0fdeb`
-- `#808` MIDI file edge round-trip coverage -> `aae5d5d0`
-- `#809` signal FFT/convolver helper coverage -> `453bcec8`
-- `#810` platform Environment diff-edge coverage -> `f712702a`
-- `#811` CLI project-command dispatch coverage -> `810743d4`
-- `#813` signal dynamics helper coverage -> `957a0735`
-- `#814` CLI `pulp pr` shellout coverage -> `8bd4a3e9`
-- `#815` MPE tracker edge-path coverage -> `019130bd`
-- `#816` MIDI running-status parser edge coverage -> `c9620a65`
-- `#818` MPE synth voice / allocator coverage -> `3d4560d1`
-- `#817` UMP conversion edge coverage -> `a38216fd`
-- `#821` audio reader helper edge coverage -> `7aff17f9`
-- `#822` audio file helper edge coverage -> `87ef6d90`
-- `#819` MIDI keyboard/sequence edge coverage -> `7a646f33`
-- `#820` signal spectrogram edge coverage -> `1a1b7f07`
-- `#823` platform helper edge coverage -> `f69338eb`
-- `#824` signal math helper coverage and Mat3 fix -> `94e3ef2a`
-- `#825` signal DSP helper edge coverage -> `d0262a1b`
-- `#826` OGG reader edge coverage -> `6ae4d487`
-- `#827` signal multi-channel meter edge coverage -> `d5efea57`
-- `#828` raw MIDI parser edge coverage and malformed-data hardening -> `5b8e4529`
-- `#831` signal utility helper edge coverage -> `b5e7a463`
-- `#836` CLI sync checker Python tooling coverage -> `6ef8ca8b`
-- `#837` package registry validation tools coverage -> `bdc406cc`
-- `#830` RPN parser edge coverage -> `d02c9ec9`
-- `#834` events event-loop lifecycle edge coverage -> `455c0a9d`
-- `#829` MIDI-CI edge coverage -> `eaf991b0`
-- `#833` signal filter-design edge coverage -> `8fc5dd2d`
-- `#838` CLI release packager coverage -> `3d47dbd2`
-- `#839` GPU graph render helper hardening/coverage -> `62ad9870`
-- `#832` platform child-process edge coverage -> `3f92f066`
-- `#842` inspect Codecov classification -> `51be8860`
-- `#835` CLI ship command validation coverage -> `93d3656e`
+Keep the tranche size small: one subsystem slice, local focused
+validation, Codecov patch/diff proof, tracker update, then merge when
+GitHub branch protection is green and `mergeStateStatus` is `CLEAN`.
 
-Open Phase 3 PRs:
-
-As of this review, the open `codecov` PR queue has no failing checks.
-The oldest PRs are blocked by still-queued macOS / sanitizer / Namespace
-jobs rather than code failures.
-
-- `#840` events child-process manager coverage for `#642`, branch
-  `feature/events-child-process-coverage-642`, head `410a0371`; opened
-  from `main` at `455c0a9d`, then rebased onto `eaf991b0` after `#829`
-  merged. The first Linux Namespace and Linux coverage failures were
-  dependency-bootstrap failures before configure/tests because a cold
-  FetchContent cache hit a GitHub 403 cloning `Tracktion/choc.git`. The
-  first diff-coverage failure was fixed by pushing `410a0371`, which
-  keeps the production change focused on the covered invalid-PID guard
-  and removes unrelated POSIX `waitpid` hardening from this tranche.
-  This tranche also uses the GitHub/Namespace path while the SSH
-  `windows` target remains unreachable.
-- `#843` MPE tracker UMP edge-path coverage for `#645`, branch
-  `feature/midi-mpe-tracker-extra-coverage-645-next`, head `fcdbd278`;
-  opened from `main` at `eaf991b0`. This test-only tranche covers
-  unmatched MIDI 2.0 per-note expression packets, MIDI 2.0 member
-  expression fan-out across active channel notes, and supported-zone UMP
-  packets that should be consumed without mapped side effects.
-- `#845` host automation queue coverage for `#493`, branch
-  `feature/format-host-coverage-493-next`, head `c3c5cfce`; covers
-  `ParameterEventQueue` sample-offset sorting and clear/reuse lifecycle.
-- `#846` audio focus coverage for `#640`, branch
-  `feature/audio-platform-coverage-640-next`, head `97568e27`; covers
-  `AudioFocusRegistry` token move-assignment, default-token reset, and
-  publish-without-subscribers state behavior.
-- `#847` events NSD / async helper coverage for `#642`, branch
-  `feature/events-volume-coverage-642-next`, head `8365c969`; covers
-  `LambdaAsyncUpdater` empty-callback processing plus
-  `NetworkServiceDiscovery` dispatcher and service-keying behavior.
-- `#848` runtime Base64 padding validation for parent `#641`, branch
-  `feature/runtime-coverage-641-next`, head `36aa5c71`; hardens
-  `base64_decode` terminal-padding validation and carries a patch-level
-  SDK metadata trailer.
-- `#849` view label paint coverage for `#493`, branch
-  `feature/view-widget-coverage-493-next`, head `7f6deaf6`; covers
-  label text transforms, multiline/decorations, and vertical text
-  direction transform wrapping.
-- `#850` CLI/tools runner resolver coverage for `#643`, branch
-  `feature/cli-tools-coverage-643-next2`, head `b8e7b22a`; covers
-  optional Namespace fallback plus provider/default argument validation.
-- `#851` signal meter channel-count guards for `#645`, branch
-  `feature/signal-meter-coverage-645-next`, head `a3aec442`; hardens
-  negative/invalid `MultiChannelMeter` and `MultiChannelBallistics`
-  channel counts and carries a patch-level SDK metadata trailer. After
-  the first coverage run reported diff coverage `66%` because
-  `multi_channel_meter.hpp:151` was uncovered, follow-up `118dbce4`
-  added process-channel clamp coverage and `a3aec442` refreshed the
-  tip-level version / skill metadata.
-- `#852` canvas rectangle-list helper coverage for parent `#641`,
-  branch `feature/runtime-helper-coverage-641-next2`, head `05c85d55`;
-  consolidates overlapping rectangle-list worker output into one
-  test-only PR covering empty-rectangle filtering, intersection
-  semantics, subtract no-op/full-cover, bounding-box/area, and clipped
-  intersections.
-- `#853` audio frame-fill invalid-dimension coverage for `#640`,
-  branch `feature/audio-helper-coverage-640-next2`, head `53bc6020`;
-  covers `zero_fill_short_read` negative channel-count and negative
-  total-frame no-op guards.
-- `#854` ViewBridge helper coverage for `#493`, branch
-  `feature/host-view-helper-coverage-493-next2`, head `5c9eeeba`;
-  covers idempotent open/release behavior, secondary-view null/bounds
-  cleanup, and null remote-channel diagnostics.
-- `#855` signal convolver edge coverage for `#645`, branch
-  `feature/midi-signal-helper-coverage-645-next2`, head `2d8b0bc3`;
-  covers rounded/zero block-size setup, empty IR pass-through, and
-  wrong-block-size pass-through behavior.
-- `#856` CLI/tools LCOV/Cobertura helper coverage for `#643`, branch
-  `feature/cli-tools-coverage-643-next3`, head `96d20a3a`; covers
-  package exclusions before summary-rate calculation, duplicate
-  source-record function-hit merging, and relpath fallback paths.
-- `#857` events async-helper coverage for `#642`, branch
-  `feature/events-helper-coverage-642-next2`, head `4cbfd67c`; adds a
-  focused async-helper target covering reentrant `AsyncUpdater`,
-  `LambdaAsyncUpdater` empty-callback handling, `ActionBroadcaster`
-  missing-removal behavior, and `MultiTimer` stop-all/restart behavior.
-- `#858` render DrawBatcher edge coverage for `#646`, branch
-  `feature/render-only-coverage-646-next2`, head `d055cc7d`; covers
-  chained same-key merges, post-end records, and edge-touching blockers,
-  and moves the DrawBatcher test target into the GPU-off-safe lane.
-- `#859` platform ProgressParser edge coverage for `#640`, branch
-  `feature/audio-helper-coverage-640-next3`, head `176f1b12`; covers
-  null callbacks on matching progress lines plus empty event-type and
-  empty-payload parsing boundaries.
-- `#860` MIDI SysEx accumulator coverage for `#645`, branch
-  `feature/midi-signal-coverage-645-next3`, head `0ede5297`; covers
-  fresh `F0` abort/restart behavior, single-byte abort ownership, and
-  idle `F7` passthrough.
-- `#861` descriptor-validation edge coverage for `#493`, branch
-  `feature/format-view-coverage-493-next3`, head `75acf512`; covers
-  warning-only malformed reverse-DNS bundle IDs, instrument input-bus
-  exceptions, and UMP/MIDI sidecar warning behavior.
-- `#862` LCOV-to-Cobertura utility coverage for `#643`, branch
-  `feature/cli-tools-coverage-643-next4`, head `191785c6`; covers
-  relpath fallback, package exclusion summary recalculation, and CLI XML
-  output for the vendored converter.
-- `#863` StateStore helper coverage for parent `#641`, branch
-  `feature/runtime-state-coverage-641-next3`, head `c9b98058`; covers
-  modulation offsets, unknown parameter getters, default resets,
-  registration spans, and gesture callback dispatch.
-- `#864` Apple Swift bridge-parameter coverage for parent `#641`,
-  branch `feature/apple-swift-coverage-641-next`, head `3ff82a4e`;
-  covers parameter reload replacement after backend changes, invalid
-  `pulp_param_info` requests, and C string field population.
-- `#865` Android/Kotlin audio-engine fallback coverage for parent
-  `#641`, branch `feature/android-kotlin-coverage-641-next`, head
-  `08368a1e`; covers default audio config fallbacks when Android audio
-  properties are malformed or unavailable.
-- `#866` audio excerpt-window exact-tail coverage for `#640`, branch
-  `feature/platform-audio-coverage-640-next4`, head `bf10fa20`; covers
-  exact final-window coverage without duplicate tails and single-window
-  full-file metadata preservation.
-- `#867` Python bindings embedded-state coverage for parent `#641`,
-  branch `feature/python-bindings-coverage-641-next`, head `d572fb04`;
-  covers Python-facing `StateStore` access, serialization,
-  deserialization, parameter info, and `HeadlessHost` descriptor/state
-  save/load paths.
-- `#868` signal `ProcessorDuplicator` edge coverage for `#645`, branch
-  `feature/midi-signal-coverage-645-next4`, head `6fe50d38`; covers
-  bounded channel processing, invalid `process_channel` indices, const
-  channel access, and reset forwarding.
-- `#869` render KTX2 decoder header-edge coverage for `#646`, branch
-  `feature/render-coverage-646-next3`, head `f48a931b`; covers
-  null/short/incomplete headers plus minimal valid header parsing and
-  level-count normalization.
-- `#870` host-type policy coverage for `#493`, branch
-  `feature/host-format-view-coverage-493-next3`, head `c42e0603`;
-  covers `host_type_name()` enum mappings, invalid enum fallback, and
-  resize/sidechain policy exceptions.
-- `#871` JSFX subset validation coverage for `#643`, branch
-  `feature/cli-tools-coverage-643-next5`, head `ad536fb5`; covers JSFX
-  doctor rejection for out-of-range sliders and duplicate sections. The
-  commit carries `Skill-Update: skip` because this is test-only coverage
-  for a skill-mapped path.
-- `#873` canvas text-layout cursor coverage for parent `#641`, branch
-  `feature/canvas-coverage-641-next`, head `6adc7a4b`; covers wrapped
-  `GlyphArrangement` hit testing, cursor positions, and clear-state
-  behavior.
-- `#875` ship NSIS uninstall metadata coverage for parent `#641`, branch
-  `feature/ship-coverage-641-next`, head `752ae0bb`; covers
-  Add/Remove Programs registry metadata and HKLM/HKCU uninstall key
-  deletion paths.
-- `#876` OSC malformed codec guard coverage for parent `#641`, branch
-  `feature/osc-coverage-641-next`, head `8a3b0135`; covers truncated
-  float payload fallback and negative blob-size fallback.
-- `#877` runtime scope/string helper coverage for parent `#641`, branch
-  `feature/runtime-coverage-641-next4`, head `5f61635d`; covers
-  `ScopeGuard` move ownership and `copy_c_string` degenerate buffer
-  paths.
-- `#878` inspect Audio domain coverage for `#841` / parent `#641`,
-  branch `feature/inspect-coverage-641-next`, head `821244bc`; covers
-  `AudioInspector` metering gates and `DomainHandler` Audio config,
-  metering, MIDI log, unknown-method, and missing-inspector paths.
-- `#879` tools limitations helper coverage for `#643`, branch
-  `feature/tools-helper-coverage-643-next6`, head `c56acc8a`; covers
-  `tools/list_limitations.py` extraction, capability-path validation,
-  markdown rendering, and unresolved-path diagnostics.
-- `#880` audio model missing-checkpoint coverage for `#640`, branch
-  `feature/audio-tools-coverage-640-next5`, head `bfe7d578`; covers
-  installed audio-model metadata with a missing resolved checkpoint and
-  activation rejection for that state.
-- `#881` runtime XML/gzip helper coverage for parent `#641`, branch
-  `feature/runtime-xmlzip-coverage-641-next`, head `597b0a3a`; covers
-  XML XPath attribute / invalid-expression paths, XML text escaping, and
-  gzip optional-header / reserved-flag decode edges.
-- `#882` platform Environment helper coverage for `#640`, branch
-  `feature/platform-env-coverage-640-next`, head `63aa707a`; covers
-  `EnvironmentChange::any()` flag reporting and `Environment::reset_for_test()`
-  listener clearing while tokens are still live.
-- `#883` runtime Stream / AsyncStream helper coverage for parent `#641`,
-  branch `feature/runtime-stream-coverage-641-next`, head `a74e0bf4`;
-  covers `MemoryStream` zero-size / rewind / clear paths, `FileStream`
-  append and move ownership, `AsyncStream` zero-byte completion dispatch,
-  and `CancellationToken` sharing / idempotent cancel behavior.
-- `#884` web-compat selector helper coverage for parent `#641`, branch
-  `feature/web-compat-coverage-641-next`, head `393e841f`; covers
-  compound selector matching, child vs descendant combinators, and nested
-  `querySelector` / `querySelectorAll` traversal.
-- `#885` state `PropertiesFile` helper coverage for parent `#641`,
-  branch `feature/state-properties-coverage-641-next`, head `dcf00b53`;
-  covers invalid numeric conversion, loading an empty file over stale
-  values, and save-without-path failure.
-- `#886` iOS audio-session label coverage for parent `#641`, branch
-  `feature/ios-runtime-coverage-641-next`, head `5f266fd5`; covers
-  secondary-audio silence event labels and unknown event fallback in
-  `to_string()`.
-- `#887` ship appcast helper coverage for parent `#641`, branch
-  `feature/ship-helper-coverage-641-next2`, head `fb9cee78`; covers
-  Sparkle signature XML emission and malformed-item parse behavior.
-- `#888` tools skill-sync helper coverage for `#643`, branch
-  `feature/tools-helper-coverage-643-next7`, head `e13c227b`; covers
-  `skill_sync_check.py` config loading, skill-map parsing, SKILL.md
-  enforcement, and report / hint rendering modes.
-- `#889` MIDI UMP packet helper coverage for parent `#641`, branch
-  `feature/midi-osc-helper-coverage-641-next`, head `d29cc79b`; covers
-  UMP packet factory masking for groups, channels, notes, and data
-  fields.
-- `#890` view accessibility-tree range coverage for `#493`, branch
-  `feature/view-accessibility-coverage-493-next4`, head `b2dc5c38`;
-  covers nested accessibility snapshot traversal plus
-  `AccessibilityValueInterface` range metadata and value-string capture.
-- `#891` Android accessibility delegate coverage for parent `#641`,
-  branch `feature/android-helper-coverage-641-next2`, head `2312fdfd`;
-  covers accessibility event class-name initialization and action
-  fallback when the native bridge is unavailable. Local Gradle execution
-  was blocked by a missing Java runtime, so hosted Android JVM CI is the
-  first executable validation for this tranche; pre-push gates are clean
-  and the branch carries `Skill-Update: skip skill=android`.
-- `#892` image-cache failure-edge coverage for `#646` / parent `#641`,
-  branch `feature/render-image-coverage-646-next4`, head `248f6cfc`;
-  covers decode failures not being cached and oversized decoded entries
-  being released / discarded when over the byte budget.
-
-Local-only queued work:
-
-- `#642` events timer one-shot behavior worktree
-  `/Users/danielraffel/Code/pulp-events-helper-coverage-642-next3`,
-  branch `feature/events-helper-coverage-642-next3`, commit
-  `51f9aeda`; fixes one-shot timers so `is_active()` becomes false
-  after firing and adds a restart regression. Because this is a
-  production behavior fix, review it before opening a PR and add the
-  appropriate SDK patch metadata trailer.
-- `#642` events IPC endpoint parse worktree
-  `/Users/danielraffel/Code/pulp-events-coverage-642-next4`, branch
-  `feature/events-coverage-642-next4`, commit `3701a940`; adds new
-  test-only target `pulp-test-ipc-endpoints` for deterministic IPC
-  socket endpoint parse failures. Review CMake overlap with open `#857`
-  before opening a PR.
-- Active worker: audio edge/helper coverage worktree
-  `/Users/danielraffel/Code/pulp-audio-edge-coverage-640-next6`, branch
-  `feature/audio-edge-coverage-640-next6`; no commit reported yet.
-- Active worker: runtime crypto / i18n helper coverage worktree
-  `/Users/danielraffel/Code/pulp-runtime-helper-coverage-641-next5`,
-  branch `feature/runtime-helper-coverage-641-next5`; no commit reported
-  yet.
-- Active worker: host / format helper coverage worktree
-  `/Users/danielraffel/Code/pulp-host-format-helper-coverage-493-next4`,
-  branch `feature/host-format-helper-coverage-493-next4`; no commit
-  reported yet.
-- Active worker: canvas helper coverage worktree
-  `/Users/danielraffel/Code/pulp-canvas-helper-coverage-641-next2`,
-  branch `feature/canvas-helper-coverage-641-next2`; no commit reported
-  yet.
-
-Local Phase 3 draft worktrees:
-
-- `#640` AIFF reader edge-path worktree
-  `/Users/danielraffel/Code/pulp-audio-aiff-coverage-640`, branch
-  `feature/audio-aiff-coverage-640`; merged via PR `#794` as
-  `c4e6ad09`. The remote branch was deleted after merge.
-- `#642` events volume/service-discovery worktree
-  `/Users/danielraffel/Code/pulp-events-volume-coverage-642`, branch
-  `feature/events-volume-coverage-642`, commit `357fc429`; merged via PR
-  `#795` as `f1a5aa84`. The remote branch was deleted after merge.
-- `#642` events event-loop lifecycle worktree
-  `/Users/danielraffel/Code/pulp-events-loop-coverage-642`, branch
-  `feature/events-loop-coverage-642`, commit `ee3894cb`; merged via PR
-  `#834` as `455c0a9d`. The remote branch was deleted after merge.
-  Scope: test-only coverage for `EventLoop` thread identity, explicit
-  stop and idempotent stop state, delayed work dropped after stop,
-  multiple delayed tasks, plus `Timer` interval getter/setter and
-  idempotent stop-state behavior. Local validation: no-GPU/no-examples
-  configure, `pulp-test-events` build, direct `[issue-642]` run passed
-  `14` assertions in `4` cases, full binary passed `74` assertions in
-  `20` cases, precise CTest selector passed `18/18`, `git diff --check`,
-  skill-sync report, and version-bump report.
-- `#642` events child-process manager worktree
-  `/Users/danielraffel/Code/pulp-events-child-process-coverage-642`,
-  branch `feature/events-child-process-coverage-642`, commit
-  `47e38795`; open as PR `#840`.
-  Scope: covers unlaunched `ConnectedChildProcess` default state,
-  disconnected send, idempotent kill, and `wait_for_exit()` return
-  behavior; covers empty `ChildProcessManager` active-count, wait, kill,
-  and cleanup no-op lifecycle; and hardens
-  `ConnectedChildProcess::wait_for_exit()` so unlaunched/invalid PID
-  state returns `-1` instead of probing an invalid process id. Local
-  validation before opening: no-GPU/no-examples configure,
-  `pulp-test-ipc` build, direct `[issue-642]` run passed `7`
-  assertions in `2` cases, full IPC binary passed `44` assertions in
-  `12` cases, focused CTest `ConnectedChildProcess|ChildProcessManager|IPC`
-  passed `12/12`, diff check, skill-sync report, and version-bump
-  report. Follow-up validation after rebasing onto `eaf991b0` passed the
-  direct issue selector, focused CTest, diff check, skill-sync report,
-  version-bump report, and pre-push gates.
-- `#643` package-registry CLI/tools worktree
-  `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
-  `feature/package-registry-coverage-643`, commit `75a529ef`; merged via
-  PR `#793`.
-- `#643` tool-registry CLI/tools worktree
-  `/Users/danielraffel/Code/pulp-cli-tool-registry-coverage-643`, branch
-  `feature/cli-tool-registry-coverage-643`, commit `cdfbbcec`; merged via
-  PR `#796` as `11c10a7e`. The remote branch was deleted after merge.
-- `#640` streaming-writer audio/platform worktree
-  `/Users/danielraffel/Code/pulp-audio-streaming-writer-coverage-640`,
-  branch `feature/audio-streaming-writer-coverage-640`, commit
-  `29a3f26d`; merged via PR `#797` as `64ba65e3`. The remote branch was
-  deleted after merge.
-- `#640` format-registry audio/platform worktree
-  `/Users/danielraffel/Code/pulp-audio-system-volume-coverage-640`,
-  branch `feature/audio-format-registry-coverage-640`, commit
-  `0b35bb83`; merged via PR `#798` as `443ca260`. The remote branch was
-  deleted after merge.
-- `#643` docs-reader CLI/tools worktree
-  `/Users/danielraffel/Code/pulp-cli-docs-coverage-643`, branch
-  `feature/cli-docs-coverage-643`, commit `4877cb1b`; merged via PR
-  `#799` as `22438468`. The remote branch was deleted after merge.
-- `#643` Python gate-helper tooling worktree
-  `/Users/danielraffel/Code/pulp-python-tooling-coverage-643`, branch
-  `feature/python-tooling-coverage-643`, commit `acadc5af`; merged via PR
-  `#800` as `55b6dfab`. The remote branch was deleted after merge.
-- `#643` CLI-create shellout worktree
-  `/Users/danielraffel/Code/pulp-cli-create-coverage-643`, branch
-  `feature/cli-create-coverage-643`, commit `222d0f88`; merged via PR
-  `#802` as `2de79ff3`. The remote branch was deleted after merge.
-- `#646` texture-atlas render worktree
-  `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`,
-  branch `feature/render-texture-atlas-coverage-646`, commit
-  `325485bc`; merged via PR `#801` as `ae4fdab8`. The remote branch was
-  deleted after merge.
-- `#645` signal matrix helper worktree
-  `/Users/danielraffel/Code/pulp-signal-matrix-coverage-645`, branch
-  `feature/signal-matrix-coverage-645`, commit `b1f5a125`; merged via PR
-  `#803` as `57285797`. The remote branch was deleted after merge.
-- `#645` signal oversampling helper worktree
-  `/Users/danielraffel/Code/pulp-signal-oversampling-coverage-645`,
-  branch `feature/signal-oversampling-coverage-645`, commit `bccaec0f`;
-  merged via PR `#804` as `c6600f9`. The remote branch was deleted after
-  merge.
-- `#643` CLI common helper worktree
-  `/Users/danielraffel/Code/pulp-cli-common-coverage-643`, branch
-  `feature/cli-common-coverage-643`, commit `17b42f0f`; merged via PR
-  `#805` as `5844c6ac`. The remote branch was deleted after merge.
-- `#640` mapped-reader/offline audio worktree
-  `/Users/danielraffel/Code/pulp-audio-reader-coverage-640`, branch
-  `feature/audio-reader-coverage-640`, commit `c1d61e3a`; merged via PR
-  `#806` as `1bcb23e3`. The remote branch was deleted after merge.
-- `#640` ChannelSet audio worktree
-  `/Users/danielraffel/Code/pulp-audio-channel-set-coverage-640`,
-  branch `feature/audio-channel-set-coverage-640`, commit `89b969c9`;
-  merged via PR `#807` as `46e0fdeb`. The remote branch was deleted after
-  merge.
-- `#640` platform Environment diff-edge worktree
-  `/Users/danielraffel/Code/pulp-platform-environment-coverage-640`,
-  branch `feature/platform-environment-coverage-640`, commit
-  `bc1e96af`; merged via PR `#810` as `f712702a`. The remote branch was
-  deleted after merge.
-- `#645` MIDI file edge round-trip worktree
-  `/Users/danielraffel/Code/pulp-midi-file-coverage-645`, branch
-  `feature/midi-file-coverage-645`, commit `d02e853e`; merged via PR
-  `#808` as `aae5d5d0`. The remote branch was deleted after merge.
-- `#645` signal FFT/convolver helper worktree
-  `/Users/danielraffel/Code/pulp-signal-fft-coverage-645`, branch
-  `feature/signal-fft-coverage-645`, commit `11c83082`; merged via PR
-  `#809` as `453bcec8`. The remote branch was deleted after merge.
-- `#643` CLI project-command dispatch worktree
-  `/Users/danielraffel/Code/pulp-cli-project-coverage-643`, branch
-  `feature/cli-project-coverage-643`, commit `46dca652`; merged via PR
-  `#811` as `810743d4`. The remote branch was deleted after merge. Scope:
-  direct `cmd_project.cpp` coverage for top-level help/no-arg/unknown
-  dispatch, bump option parsing, `--all` empty-registry handling,
-  registry-backed `--all --dry-run` reporting without undo files, a
-  single-project bump plus newest-batch undo round-trip, and undo
-  no-batch/missing-batch/malformed-batch diagnostics. Local validation:
-  no-GPU/no-examples configure, `pulp-test-cli-project-command` build,
-  `[cli][project-command][issue-643]` passed `75` assertions in `6`
-  cases, full binary passed `318` assertions in `22` cases, focused
-  CTest `cmd_project` passed `8/8`, `git diff --check`, skill-sync
-  report, and version-bump report.
-- `#645` signal dynamics helper worktree
-  `/Users/danielraffel/Code/pulp-signal-dynamics-coverage-645`, branch
-  `feature/signal-dynamics-coverage-645`, commit `fb0505f7`; merged via
-  PR `#813` as `957a0735`. The remote branch was deleted after merge.
-  Scope: test-only coverage for `DryWetMixer` mix
-  clamping/equal-power/latency/reset paths, `Compressor`
-  hard-knee/soft-knee/buffer/reset paths, `Limiter` buffer/reset paths,
-  `WindowFunction` hamming/flat-top/kaiser branches, and
-  `MultiChannelMeter` channel clamping/reset/silent-correlation/block
-  threshold edges. Local validation: no-GPU/no-examples configure,
-  `pulp-test-dsp-enhancements` and `pulp-test-signal` builds, targeted
-  issue tags passed `9` assertions in `2` DSP cases and `35`
-  assertions in `8` signal cases, full DSP binary passed `62`
-  assertions in `20` cases, full signal binary passed `885` assertions
-  in `67` cases, focused CTest passed `23/23`, `git diff --check`,
-  skill-sync report, and version-bump report.
-- `#643` CLI `pulp pr` shellout worktree
-  `/Users/danielraffel/Code/pulp-cli-pr-coverage-643`, branch
-  `feature/cli-pr-coverage-643`, commit `615bd756`; merged via PR
-  `#814` as `8bd4a3e9`. The remote branch was deleted after merge.
-  Scope: shellout coverage for missing-Shipyard install guidance,
-  native fallback help, outside-project refusal, and POSIX delegation to
-  a fake `shipyard pr` executable without invoking real Shipyard. Follow-
-  up `615bd756` fixed Linux Namespace by resolving the CLI binary before
-  changing cwd in the native outside-project test. Local validation:
-  no-GPU/no-examples configure, `pulp-test-cli-shellout` build, direct
-  `[cli][shellout][pr][issue-643]` passed `18` assertions in `4` cases,
-  single failed cloud case passed `3` assertions in `1` case after the
-  fix, focused CTest `pulp pr` passed `7/7`, `git diff --check`,
-  skill-sync report, and version-bump report.
-- `#643` CLI ship command validation worktree
-  `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, branch
-  `feature/cli-ship-coverage-643`, commit `b8f22af9`; open as PR
-  `#835`.
-  Scope: test-only `pulp ship` shellout coverage for fake project roots
-  with missing build-cache guidance, Android signing/package/check
-  validation before external tools run, appcast feed generation, and
-  remote `--sign-key` rejection without real signing material. The
-  follow-up commit moves the Android `ship check --target android`
-  missing-artifacts assertion before package probes create `artifacts/`
-  as part of their validation path. The second follow-up sets `PULP_HOME`
-  to a scratch directory and clears Android password env vars before
-  asserting the missing-keystore branch, so the test is not affected by a
-  developer or runner config file. Local validation after rebasing onto
-  `5b8e4529`: no-GPU/no-examples
-  configure, `pulp-test-cli-ship-shellout` build, direct `[issue-643]`
-  run passed `3` assertions in `3` cases, full binary passed `10`
-  assertions in `10` cases, focused CTest `pulp ship` passed `10/10`,
-  `git diff --check HEAD~1..HEAD`, `git diff --check`, skill-sync
-  report, and version-bump report with `Version-Bump: sdk=skip` for
-  the test-only coverage tranche. Follow-up validation after rebasing
-  onto `b5e7a463` and applying both follow-ups used a real built CLI path
-  and passed the focused Android validation test with `12` assertions,
-  the `[issue-643]` slice with `25` assertions in `3` cases, the full
-  binary with `45` assertions in `10` cases, diff check, and pre-push
-  gates. The two Codex review threads on the ordering/config isolation
-  issues were resolved.
-- `#643` CLI sync checker worktree
-  `/Users/danielraffel/Code/pulp-cli-sync-coverage-643`, branch
-  `feature/cli-sync-coverage-643`, commit `86048a3f`; merged via PR
-  `#836` as `6ef8ca8b`. The remote branch was deleted after merge.
-  Scope: test-only Python coverage for `tools/scripts/cli_sync_check.py`
-  repo-root discovery, command-table/YAML/slash-command/skill-reference
-  extraction, strict JSON mismatch exits, warning-only success behavior,
-  and non-repo diagnostics. Local validation: direct
-  `python3 tools/scripts/test_cli_sync_check.py` passed `7` cases,
-  `git diff --check`, skill-sync report, and version-bump report. The
-  local Python coverage runner could not run because this interpreter
-  lacks `coverage.py >= 7.10`; hosted CI remains the coverage proof for
-  this tranche.
-- `#643` package registry validation tools worktree
-  `/Users/danielraffel/Code/pulp-package-validator-coverage-643`,
-  branch `feature/package-validator-coverage-643`, commit `8a2edbe9`;
-  merged via PR `#837` as `bdc406cc`. The remote branch was deleted
-  after merge.
-  Scope: test-only Python coverage for
-  `tools/packages/validate_registry.py` JSON load/error paths,
-  structural and license classification, and CLI success output, plus
-  `tools/packages/freshness_check.py` GitHub URL parsing, `gh api`
-  failure handling, issue aggregation, and package-filtered JSON output.
-  Local validation: direct
-  `python3 tools/packages/test_package_validation_tools.py` passed `9`
-  cases, `git diff --check HEAD~1..HEAD`, skill-sync report with
-  `Skill-Update: skip skill=packages`, and version-bump report. The
-  local Python coverage runner could not run because this interpreter
-  lacks `coverage.py >= 7.10`; hosted CI remains the coverage proof for
-  this tranche.
-- `#646` GPU graph render helper worktree
-  `/Users/danielraffel/Code/pulp-render-gpu-graph-coverage-646`,
-  branch `feature/render-gpu-graph-coverage-646`, commit `fa3deb3b`;
-  merged via PR `#839` as `62ad9870`. The remote branch was deleted
-  after merge.
-  Scope: hardens `GpuGraphRenderer`, `GpuHeatMapRenderer`, and
-  `GpuBarRenderer` raw-pointer `set_data()` paths for null, zero-sized,
-  and overflowing inputs; adds focused `test_gpu_graph.cpp` edge
-  coverage; and moves the header-only dirty-tracker and GPU-graph tests
-  out of the GPU-only CMake block so GPU-off sanitizer/local coverage
-  builds can exercise them without linking `pulp::render`. Local
-  validation after rebasing onto `d02c9ec9`: GPU-off configure,
-  `pulp-test-gpu-graph` and `pulp-test-dirty-tracker` builds, direct
-  `[issue-646]` run passed `39` assertions in `7` cases, full
-  gpu-graph binary passed `52` assertions in `11` cases, full
-  dirty-tracker binary passed `52` assertions in `18` cases, focused
-  CTest passed `29/29`, diff check, skill-sync report, version-bump
-  report with an SDK patch trailer, and pre-push gates.
-- `#643` CLI release packager worktree
-  `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, branch
-  `feature/package-cli-coverage-643`, commit `09666f46`; merged via PR
-  `#838` as `3d47dbd2`. The remote branch was deleted after merge.
-  Scope: test-only Python coverage for `tools/scripts/package_cli.py`
-  wgpu library discovery, macOS/Linux rpath command selection,
-  tar/zip archive writer layout, missing-binary and missing-library
-  exits, and successful Linux/Windows package staging with external
-  tools mocked. Follow-up repair after rebasing onto `d02c9ec9` isolates
-  Android package test temp dirs with process id plus an atomic
-  per-process counter, fixing the macOS Namespace failure where
-  concurrently discovered Catch2 test processes could read a neighboring
-  fake SDK and report `35.0.1` instead of `10.0.0`. Local validation:
-  direct `python3 tools/scripts/test_package_cli.py` passed `10` cases,
-  no-GPU/no-examples configure, `pulp-test-android-package` build, direct
-  `Android SDK discovery compares tool revisions numerically` run passed
-  `5` assertions in `1` case, matching CTest passed, parallel CTest
-  `Android SDK discovery` passed `3/3`, broader parallel CTest `Android`
-  passed `8/8`, `git diff --check origin/main...HEAD`, skill-sync report,
-  and version-bump report. The local Python coverage runner could not
-  run because this interpreter lacks `coverage.py >= 7.10`; hosted CI
-  remains the coverage proof for this tranche.
-- `#645` MPE tracker worktree
-  `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, branch
-  `feature/mpe-tracker-coverage-645`, commit `b7c72711`; merged via PR
-  `#815` as `019130bd`. The remote branch was deleted after merge.
-  Scope: test-only coverage for `MpeVoiceTracker` bend-range rejection,
-  config reset, manager pressure/timbre state, cached member expression,
-  bounded snapshots, and full-table overflow behavior. Local validation:
-  no-GPU/no-examples configure, `pulp-test-mpe-voice-tracker` build,
-  direct `[midi][mpe][issue-645]` passed `166` assertions in `6` cases,
-  full binary passed `239` assertions in `23` cases, and focused CTest
-  `MpeVoiceTracker` passed `23/23`, `git diff --check`, skill-sync
-  report, and version-bump report.
-- `#645` MIDI running-status parser worktree
-  `/Users/danielraffel/Code/pulp-midi-running-status-coverage-645`,
-  branch `feature/midi-running-status-coverage-645`, commit `94b93a6e`;
-  merged via PR `#816` as `c9620a65`. The remote branch was deleted
-  after merge.
-  Scope: test-only coverage for one-byte and two-byte channel running
-  status, system-common data lengths, real-time bytes inside sysex,
-  status restart inside sysex, empty sysex / unknown status ignore
-  behavior, and null sink / empty feed inputs. Local validation:
-  no-GPU/no-examples configure, `pulp-test-running-status` build, direct
-  `[midi][running-status][issue-645]` passed `29` assertions in `6`
-  cases, full binary passed `56` assertions in `14` cases, focused CTest
-  selection passed `5/5`, `git diff --check`, skill-sync report, and
-  version-bump report.
-- `#645` MIDI UMP conversion worktree
-  `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
-  branch `feature/midi-ump-conversion-coverage-645`, commit `31a53432`;
-  merged via PR `#817` as `a38216fd`. The remote branch was deleted
-  after merge.
-  Scope: test-only coverage for velocity-zero note-on aliasing,
-  program-change fallback packets, group masking, sample-offset
-  preservation, MIDI 2 edge-value down-conversion, skipped packets
-  without MIDI 1 equivalents, and scale endpoint preservation. Follow-up
-  `31a53432` isolates scan-cache test temp files with process id plus a
-  per-process counter after macOS ASan showed the previous
-  steady-clock-only stem could collide under parallel CTest. Local
-  validation: no-GPU/no-examples configure, `pulp-test-ump-buffer-
-  conversion` build, direct `[midi][ump][issue-645]` passed `46`
-  assertions in `4` cases, full binary passed `97` assertions in `15`
-  cases, focused CTest conversion selection passed `6/6`, normal
-  `pulp-test-scan-cache` `[scan_cache]` passed, normal and ASan CTest
-  repeats for `put + get round-trip on an existing file` and `get
-  invalidates when file changes` passed `10/10`, `git diff --check`,
-  skill-sync report, and version-bump report. A broader CTest regex was
-  intentionally not used for the final summary because the lite build
-  exposes `*_NOT_BUILT_*` placeholder tests that match generic `ump`
-  patterns.
-- `#645` MPE synth voice worktree
-  `/Users/danielraffel/Code/pulp-midi-mpe-synth-voice-coverage-645`,
-  branch `feature/midi-mpe-synth-voice-coverage-645`, commit
-  `21eb74e1`; merged via PR `#818` as `3d4560d1`. The remote branch was
-  deleted after merge.
-  Scope: test-only coverage for `MpeSynthVoice` smoothing clamp,
-  reset/release state, timbre routing, all non-oldest `MpeVoiceAllocator`
-  steal policies, unknown expression events, `reset_all`, and
-  zero-polyphony dispatch tolerance. Local validation: no-GPU/no-examples
-  configure, `pulp-test-mpe-synth-voice` build, direct
-  `[midi][mpe][issue-645]` passed `51` assertions in `4` cases, full
-  binary passed `75` assertions in `12` cases, focused CTest passed
-  `12/12`, `git diff --check`, skill-sync report, and version-bump
-  report.
-- `#645` MIDI keyboard/sequence worktree
-  `/Users/danielraffel/Code/pulp-midi-keyboard-sequence-coverage-645`,
-  branch `feature/midi-keyboard-sequence-coverage-645`, commit
-  `60676709`; merged via PR `#819` as `7a646f33`. The remote branch was
-  deleted after merge.
-  Scope: test-only coverage for `MidiKeyboardState` invalid queries,
-  ignored non-note events, release callbacks, and retrigger velocity
-  updates; plus `MidiMessageSequence` helper field masking,
-  classifier aliases, zero-velocity note-on note-off behavior,
-  channel-specific note-off lookup, range boundaries, timestamp offsets,
-  iteration, duration, and clear behavior. Local validation:
-  no-GPU/no-examples configure, `pulp-test-midi-expansion` and
-  `pulp-test-v3-gaps` build, direct `[midi][keyboard][issue-645]`
-  passed `19` assertions in `3` cases, direct
-  `[midi][sequence][issue-645]` passed `39` assertions in `3` cases,
-  full binaries passed `51` assertions in `20` cases and `94`
-  assertions in `24` cases, focused CTest passed `20/20`,
-  `git diff --check`, skill-sync report, and version-bump report.
-- `#645` signal spectrogram worktree
-  `/Users/danielraffel/Code/pulp-signal-spectrogram-coverage-645`,
-  branch `feature/signal-spectrogram-coverage-645`, commit `0fd8aa5a`;
-  merged via PR `#820` as `1a1b7f07`. The remote branch was deleted
-  after merge.
-  Scope: test-only coverage for `ColorMapper` ramp switching/control
-  points, `FrequencyAxis` clamping and bin/display conversions,
-  `SpectrogramBuffer` column wraparound, row-to-bin mapping,
-  degenerate dB ranges, and empty-row buffers. Local validation:
-  no-GPU/no-examples configure, `pulp-test-stft` build, direct
-  `[signal][spectrogram][issue-645]` passed `49` assertions in `4`
-  cases, direct `[signal][spectrogram]` passed `79` assertions in `12`
-  cases, full binary passed `390` assertions in `30` cases, focused
-  CTest selection passed `12/12`, `git diff --check`, skill-sync
-  report, and version-bump report.
-- `#640` audio reader helper worktree
-  `/Users/danielraffel/Code/pulp-audio-reader-helpers-coverage-640`,
-  branch `feature/audio-reader-helpers-coverage-640`, commit
-  `be7d604f`; merged via PR `#821` as `7aff17f9`. The remote branch was
-  deleted after merge.
-  Scope: test-only coverage for `BufferingReader` source-exhaustion
-  zero-fill and ring-wrap ordering, plus `AudioSubsectionReader` invalid
-  reader, clamped-read, and start-past-end empty-view paths. Local
-  validation: no-GPU/no-examples configure, `pulp-test-buffering-reader`
-  and `pulp-test-v3-gaps` build, direct
-  `[audio][buffering][issue-640]` passed `813` assertions in `2` cases,
-  direct `[audio][subsection][issue-640]` passed `32` assertions in `2`
-  cases, full buffering-reader binary passed `823` assertions in `8`
-  cases, full v3-gaps binary passed `87` assertions in `23` cases,
-  focused CTest passed `12/12`, `git diff --check`, skill-sync report,
-  and version-bump report.
-- `#640` audio file helper worktree
-  `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
-  branch `feature/audio-file-helper-coverage-640`, head `2db6be4a`;
-  merged via PR `#822` as `87ef6d90`. The remote branch was deleted
-  after merge.
-  Scope: coverage for packed int24 conversion, int32 full-scale
-  conversion, float-to-int32 clamping, zero-count conversion no-ops, CHOC
-  WAV helper output via RIFF chunk parsing, malformed WAV rejection,
-  invalid OGG registry dispatch, `Buffer` resize/view ownership, and
-  `AudioProcessLoadMeasurer` smoothing/zero-available-time guards.
-  Follow-up `8aa7a78d` fixes a production `float_to_int32` UBSan issue
-  by handling `+/-1` endpoints explicitly and using double precision for
-  the midrange cast. Follow-up `fc7a1364` fixes a macOS Namespace
-  full-suite blocker by comparing Android build-tools and NDK revisions
-  numerically, with `2db6be4a` carrying the required skill/version
-  metadata trailers. Local validation: no-GPU/no-examples configure,
-  `pulp-test-audio-file`, `pulp-test-audio`, and
-  `pulp-test-load-measurer` build, later `pulp-test-android-package`
-  build, direct `[issue-640]` audio-file run passed `217` assertions in
-  `11` cases, full audio-file binary passed `450` assertions in `26`
-  cases, full audio binary passed `586` assertions in `8` cases, full
-  load-measurer binary passed `20` assertions in `6` cases, full Android
-  package binary passed `69` assertions in `8` cases, focused CTest
-  passed `11/11` before the Android fix and `9/9` for the Android/load
-  measurer rerun after the fix, local UBSan focused CTest for `sample
-  conversion handles packed 24-bit and 32-bit edges` passed,
-  skill-sync report passed with the `ship` bypass trailer, and
-  version-bump report classified the SDK change as `patch`.
-- `#640` platform helper worktree
-  `/Users/danielraffel/Code/pulp-platform-helper-coverage-640`, branch
-  `feature/platform-helper-coverage-640`, commit `6ec4ff2e`; merged via
-  PR `#823` as `f69338eb`. The remote branch was deleted after merge.
-  Scope: test-only coverage for file-dialog no-handler backend failure
-  paths, popup-menu item metadata and non-Apple stub behavior, audio
-  excerpt value/default helpers, and non-Apple `AudioWorkgroup` fallback
-  idempotency. Local validation: no-GPU/no-examples configure,
-  `pulp-test-file-dialog`, `pulp-test-audio-excerpt`, and
-  `pulp-test-workgroup` build, direct `[issue-640]` file-dialog run
-  passed `13` assertions in `1` case, direct
-  `[audio][excerpt][issue-640]` audio-excerpt run passed `14`
-  assertions in `1` case, full workgroup binary passed `4` assertions in
-  `5` cases, full file-dialog binary passed `15` assertions in `3`
-  cases, full audio-excerpt binary passed `33` assertions in `5` cases,
-  focused CTest passed `9/9`, `git diff --check`, skill-sync report, and
-  version-bump report.
-- `#645` signal math helper worktree
-  `/Users/danielraffel/Code/pulp-signal-math-helper-coverage-645`,
-  branch `feature/signal-math-helper-coverage-645`, commits `b304e0f4`
-  and metadata tip `1b7f1cfd`; merged via PR `#824` as `94e3ef2a`. The
-  remote branch was deleted after merge.
-  Scope: fixes `Mat3::operator*` so multiplication accumulates into a
-  zero matrix instead of adding the product onto the identity default,
-  and adds coverage for polynomial empty/constant helpers, empty
-  polynomial add, singular `Mat2` inverse, non-identity `Mat3`
-  multiplication, FastMath large-phase wrapping and guard inputs,
-  Gain linear buffer processing, SimpleMixer clamp/buffer paths, and
-  special-function wrappers. The metadata tip records
-  `Version-Bump: sdk=patch` because this is an inline public-header bug
-  fix without an SDK API signature change. Local validation:
-  no-GPU/no-examples configure, `pulp-test-poly-math`,
-  `pulp-test-fast-math`, `pulp-test-signal`, and
-  `pulp-test-dsp-enhancements` builds, direct issue-645 slices passed
-  `30`, `11`, `128`, and `39` assertions respectively, full binaries
-  passed `62`, `55`, `895`, and `71` assertions respectively, focused
-  CTest passed `11/11`, `git diff --check`, skill-sync report, and
-  version-bump report.
-- `#645` signal DSP helper worktree
-  `/Users/danielraffel/Code/pulp-signal-dsp-helper-coverage-645`,
-  branch `feature/signal-dsp-helper-coverage-645`, commit `da05acaf`;
-  merged via PR `#825` as `d0262a1b`. The remote branch was deleted
-  after merge.
-  Scope: test-only coverage for `AlignedBuffer` move assignment,
-  same-size resize, empty clear, and copy truncation paths;
-  `BallisticsFilter` time-constant clamp and buffer processing paths;
-  `LogRampedValue` non-positive endpoint jump paths; and all
-  `WaveShaper` curve branches plus in-place buffer processing. Local
-  validation: no-GPU/no-examples configure, `pulp-test-simd` and
-  `pulp-test-dsp-expansion` builds, direct issue-645 slices passed `12`
-  assertions in `3` SIMD cases and `22` assertions in `4` DSP cases,
-  full binaries passed `2927` assertions in `23` cases and `75`
-  assertions in `34` cases, focused CTest passed `7/7`,
-  `git diff --check`, skill-sync report, and version-bump report.
-- `#640` OGG reader worktree
-  `/Users/danielraffel/Code/pulp-audio-ogg-reader-coverage-640`,
-  branch `feature/audio-ogg-reader-coverage-640`, commit `6b721c22`;
-  merged via PR `#826` as `6ae4d487`. The remote branch was deleted
-  after merge.
-  Scope: dedicated `pulp-test-ogg-reader` target covering direct OGG
-  reader factory construction, `.ogg` / `.oga` extension support,
-  unsupported extension behavior, format-name reporting, and
-  missing/malformed input failure paths. This intentionally avoids
-  `test_audio_file.cpp` while `#822` is open. Local validation:
-  no-GPU/no-examples configure, `pulp-test-ogg-reader` build, direct
-  `[audio][ogg][issue-640]` run passed `12` assertions in `2` cases,
-  full binary passed `12` assertions in `2` cases, focused CTest passed
-  `2/2`, `git diff --check`, skill-sync report, and version-bump report.
-- `#645` signal multi-channel meter worktree
-  `/Users/danielraffel/Code/pulp-signal-meter-coverage-645`, branch
-  `feature/signal-meter-coverage-645`, commit `ed51248f`; merged via PR
-  `#827` as `d5efea57`. The remote branch was deleted after merge.
-  Scope: dedicated `pulp-test-multi-channel-meter` target covering
-  prepared-channel clamping, empty process blocks, correlation window
-  replacement after reset, integrated LUFS running-average behavior,
-  ballistics release/noise-floor clamping, and held-peak refresh paths.
-  This intentionally avoided `test_signal.cpp` while `#824` was open.
-  Local validation: no-GPU/no-examples configure,
-  `pulp-test-multi-channel-meter` build, direct `[issue-645]` run
-  passed `20` assertions in `6` cases, full binary passed `20`
-  assertions in `6` cases, focused CTest passed `6/6`,
-  `git diff --check`, skill-sync report, and version-bump report.
-- `#645` raw MIDI parser worktree
-  `/Users/danielraffel/Code/pulp-midi-raw-parser-coverage-645`, branch
-  `feature/midi-raw-parser-coverage-645`, commit `4e2e6092`; merged via
-  PR `#828` as `5b8e4529`. The remote branch was deleted after merge.
-  Scope: fixes `parse_raw_midi_bytes` so malformed short messages do not
-  emit status bytes as data, then adds coverage for remaining
-  short-message forms, stray data plus incomplete short messages,
-  omitted callbacks, and recovery after the runaway sysex cap resets the
-  accumulator. Local validation: no-GPU/no-examples configure,
-  `pulp-test-raw-midi-parser` build, direct `[issue-645]` run passed
-  `16` assertions in `3` cases, full binary passed `53` assertions in
-  `9` cases, focused CTest passed `4/4`, `git diff --check`,
-  skill-sync report, and version-bump report with
-  `Version-Bump: sdk=patch` because the inline header is an internal
-  transport helper despite living under `include`.
-- `#645` MIDI-CI worktree
-  `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, branch
-  `feature/midi-ci-coverage-645`, commit `1d3cd1ce`; merged via PR
-  `#829` as `eaf991b0`. The remote branch was deleted after merge.
-  Scope: test-only coverage for profile inquiry destination encoding,
-  malformed and unhandled CI messages, discovery inquiry destination
-  filtering, discovery reply storage plus callback dispatch, unknown
-  profile enable/disable no-op paths, and enabled/disabled profile reply
-  payload layout. Local validation: no-GPU/no-examples configure,
-  `pulp-test-midi-ci` build, direct `[issue-645]` run passed `38`
-  assertions in `6` cases, full binary passed `65` assertions in `15`
-  cases, focused CTest passed `6/6`, `git diff --check`, skill-sync
-  report, and version-bump report. Rebase recovery validation on
-  2026-04-26 after `#822` merged also passed the build, direct/full
-  binary runs, diff whitespace checks, skill-sync report, and
-  version-bump report; the focused CTest pattern found no local tests in
-  that incremental build but exited cleanly.
-- `#645` MPE tracker UMP edge-path worktree
-  `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
-  branch `feature/midi-mpe-tracker-extra-coverage-645-next`, commit
-  `fcdbd278`; open as PR `#843`.
-  Scope: test-only coverage for unmatched MIDI 2.0 per-note expression
-  handling without seeding channel state, MIDI 2.0 member expression
-  fan-out across active channel notes, and supported-zone UMP packets
-  that are consumed without mapped side effects. Local validation:
-  no-GPU/no-examples configure, `pulp-test-mpe-voice-tracker` build,
-  direct `[issue-645]` run passed `195` assertions in `9` cases, full
-  binary passed `268` assertions in `26` cases, focused CTest
-  `MpeVoiceTracker` passed `26/26`, `git diff --check`, skill-sync
-  report, and version-bump report.
-- `#645` RPN parser worktree
-  `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, branch
-  `feature/midi-rpn-coverage-645`, commit `d1edf1e1`; merged via PR
-  `#830` as `d02c9ec9`. The remote branch was deleted after merge.
-  Scope: test-only coverage for incomplete selections, unrelated CCs,
-  omitted callbacks on otherwise complete RPN/NRPN sequences, and NRPN
-  increment/decrement metadata. Local validation: no-GPU/no-examples
-  configure, `pulp-test-midi-expansion` build, direct
-  `[midi][rpn][issue-645]` run passed `6` assertions in `3` cases, full
-  binary passed `57` assertions in `23` cases, focused CTest passed
-  `3/3`, `git diff --check`, skill-sync report, and version-bump
-  report.
-- `#645` signal utility helper worktree
-  `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, branch
-  `feature/signal-utility-coverage-645`, commits `d021a35c` and
-  `1b8169aa`; merged via PR `#831` as `b5e7a463`. The remote branch was
-  deleted after merge.
-  Scope: test-only coverage for `DelayLine` empty/wraparound/reset
-  paths, `SmoothedValue` one-sample clamp and partial skip paths, `Svf`
-  bandpass/notch/buffer/reset paths, `Panner` clamp plus in-place stereo
-  processing, `Phaser` stage/feedback clamp safety plus buffer/reset/dry
-  paths, and `Bias` getter plus separate input/output buffer paths. The
-  follow-up commit compares Phaser reset output with tolerance instead
-  of exact float-array equality for MSVC/math-library variance. Local
-  validation: no-GPU/no-examples configure, `pulp-test-signal` and
-  `pulp-test-v3-gaps` builds, direct signal `[issue-645]` run passed
-  `167` assertions in `21` cases, direct v3-gaps `[issue-645]` run
-  passed `44` assertions in `4` cases, full signal binary passed `934`
-  assertions in `74` cases, full v3 gaps binary passed `131` assertions
-  in `27` cases, focused CTest passed `6/6`, `git diff --check`, skill-sync
-  report, and version-bump report. Cloud checks were clean before merge.
-- `#640` platform child-process worktree
-  `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
-  branch `feature/platform-child-process-coverage-640`, commits
-  `3018c8d5`, `a361c8b9`, `c07dd268`, and `7496ba0a`; open as PR
-  `#832`.
-  Scope: test-only coverage for pre-start wait/read defaults,
-  working-directory launch, stdout/stderr max-output byte caps,
-  stderr-line callbacks, and fast-exit output preservation after
-  `is_running()` observes process completion. The follow-up commit
-  removed a PowerShell dependency and trims stderr callback comparisons
-  so the test is resilient to `cmd` redirection spacing on Windows; the
-  second follow-up forces the fast-exit Windows `cmd` probe to exit zero
-  while still proving no-newline cached output is preserved. The third
-  follow-up replaces the fixed 100ms fast-exit polling loop with a 5s
-  deadline so loaded/virtualized runners do not fail before normal
-  process launch/teardown completes.
-  Local validation: no-GPU/no-examples configure,
-  `pulp-test-child-process` build, direct `[issue-640]` run passed `25`
-  assertions in `5` cases, full binary passed `46` assertions in `17`
-  cases, focused CTest passed for the fast-exit case,
-  `git diff --check HEAD~1..HEAD`, `git diff --check`, skill-sync
-  report, and version-bump report after rebasing onto `87ef6d90`.
-  Follow-up validation after rebasing onto `b5e7a463` passed the focused
-  fast-exit test with `4` assertions, the `[issue-640]` slice with `25`
-  assertions in `5` cases, the full child-process binary with `46`
-  assertions in `17` cases, diff check, skill-sync report, version-bump
-  report, and pre-push gates. The Codex review thread on the fast-exit
-  deadline was resolved.
-- `#645` signal filter-design worktree
-  `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, branch
-  `feature/signal-biquad-coverage-645`, commit `e3795fca`; merged via
-  PR `#833` as `8fc5dd2d`. The remote branch was deleted after merge.
-  Scope: test-only coverage for peaking boost/cut coefficients, low/high
-  shelf cut paths, shelf slope variants, and Butterworth empty/high-order
-  section behavior. This intentionally touches only
-  `test_filter_design.cpp` to avoid overlap with open `test_signal.cpp`
-  tranches. Local validation: no-GPU/no-examples configure,
-  `pulp-test-filter-design` build, direct `[issue-645]` run passed `100`
-  assertions in `3` cases, full binary passed `116` assertions in `14`
-  cases, focused CTest passed `14/14`, `git diff --check HEAD~1..HEAD`,
-  `git diff --check`, skill-sync report, and version-bump report.
-  Follow-up validation after rebasing onto `b5e7a463` passed the same
-  focused filter-design build/direct/CTest checks, built
-  `pulp-test-android-package`, passed the direct `Android SDK discovery
-  compares tool revisions numerically` selector with `5` assertions in
-  `1` case, passed the matching CTest selector, passed
-  `git diff --check origin/main...HEAD`, and cleared pre-push gates.
-- `#493` host automation queue worktree
-  `/Users/danielraffel/Code/pulp-format-host-coverage-493-next`,
-  branch `feature/format-host-coverage-493-next`, commit `c3c5cfce`;
-  open as PR `#845`. Scope: test-only coverage for
-  `ParameterEventQueue` sample-offset sorting and clear/reuse lifecycle.
-  Local validation passed the no-GPU/no-examples configure, affected
-  target build, direct `[issue-493]` run, full host-regression binary,
-  focused CTest selector, diff check, skill-sync report, and
-  version-bump report.
-- `#640` audio focus worktree
-  `/Users/danielraffel/Code/pulp-audio-platform-coverage-640-next`,
-  branch `feature/audio-platform-coverage-640-next`, commit
-  `97568e27`; open as PR `#846`. Scope: test-only coverage for
-  `AudioFocusRegistry` token move-assignment replacement, default token
-  reset no-op behavior, and publish-without-subscribers state updates.
-  Local validation passed the no-GPU/no-examples configure, affected
-  target build, direct `[issue-640]` run, full binary, focused CTest,
-  diff checks, skill-sync report, and version-bump report.
-- `#642` events NSD / async helper worktree
-  `/Users/danielraffel/Code/pulp-events-volume-coverage-642-next`,
-  branch `feature/events-volume-coverage-642-next`, commit `8365c969`;
-  open as PR `#847`. Scope: test-only coverage for
-  `LambdaAsyncUpdater` empty-callback processing and
-  `NetworkServiceDiscovery` backend dispatcher / service-name-plus-type
-  keying behavior. Local validation passed the no-GPU/no-examples
-  configure, affected target builds, direct `[issue-642]` runs for
-  events and NSD, full binaries, focused CTest, diff check, skill-sync
-  report, and version-bump report.
-- `#641` runtime Base64 validation worktree
-  `/Users/danielraffel/Code/pulp-runtime-coverage-641-next`, branch
-  `feature/runtime-coverage-641-next`, commits `20626508` and metadata
-  tip `36aa5c71`; open as PR `#848`. Scope: hardens
-  `base64_decode` to reject malformed terminal padding and adds focused
-  runtime coverage for malformed / whitespace-padded input. Local
-  validation passed the no-GPU/no-examples configure, affected target
-  build, direct `[issue-641]` run, full runtime-utils binary, focused
-  CTest, diff check, skill-sync report, and version-bump report with an
-  SDK patch trailer.
-- `#493` view label worktree
-  `/Users/danielraffel/Code/pulp-view-widget-coverage-493-next`, branch
-  `feature/view-widget-coverage-493-next`, commit `7f6deaf6`; open as
-  PR `#849`. Scope: test-only coverage for label text transforms,
-  multiline/decorations, and vertical text-direction transform wrapping.
-  Local validation passed the no-GPU/no-examples configure, widgets
-  target build, full widgets binary, focused selectors, diff check,
-  skill-sync report, and version-bump report.
-- `#643` runner resolver worktree
-  `/Users/danielraffel/Code/pulp-cli-tools-coverage-643-next2`, branch
-  `feature/cli-tools-coverage-643-next2`, commit `b8e7b22a`; open as
-  PR `#850`. Scope: test-only Python coverage for
-  `resolve_runs_on.py` optional Namespace fallback and
-  argument/provider validation branches. Local validation passed the
-  direct Python test suite, compileall, and diff check; local
-  `coverage.py` is not installed in this interpreter.
-- `#645` signal meter guard worktree
-  `/Users/danielraffel/Code/pulp-signal-meter-coverage-645-next`,
-  branch `feature/signal-meter-coverage-645-next`, commits `e53b5152`
-  and metadata tip `ad9c3d81`; open as PR `#851`. Scope: hardens
-  negative/invalid channel-count handling in `MultiChannelMeter` and
-  `MultiChannelBallistics` and adds focused signal meter coverage.
-  Local validation passed the no-GPU/no-examples configure, affected
-  target build, direct `[signal][meter][issue-645]` run, full signal
-  binary, focused CTest, diff check, skill-sync report, and
-  version-bump report with an SDK patch trailer.
-- `#641` canvas rectangle-list helper worktree
-  `/Users/danielraffel/Code/pulp-runtime-helper-coverage-641-next2`,
-  branch `feature/runtime-helper-coverage-641-next2`, commits
-  `3e1cfd51` and `05c85d55`; open as PR `#852`. Scope: test-only
-  coverage for `RectangleList` empty-rectangle filtering, area-overlap
-  intersection semantics, subtract no-op/full-cover behavior,
-  bounding-box/area helpers, and clipped intersections. Local validation
-  passed the no-GPU/no-text-shaping configure, affected target build,
-  direct `[issue-641]` run with `25` assertions in `5` cases, full
-  binary with `52` assertions in `14` cases, focused CTest `14/14`, and
-  diff check. The overlapping `/Users/danielraffel/Code/pulp-render-helper-coverage-646-next`
-  branch also touched `test/test_rectangle_list.cpp`; its unique
-  subtract case was folded into `#852` and that duplicate branch should
-  not be opened as-is.
-- `#640` audio frame-fill helper worktree
-  `/Users/danielraffel/Code/pulp-audio-helper-coverage-640-next2`,
-  branch `feature/audio-helper-coverage-640-next2`, commit `53bc6020`;
-  open as PR `#853`. Scope: test-only coverage for
-  `zero_fill_short_read` negative channel-count and negative total-frame
-  guards. Local validation passed diff check, no-GPU/no-examples
-  configure, affected target build, focused CTest `11/11`, and full
-  frame-fill binary with `81` assertions in `11` cases.
-- `#493` ViewBridge helper worktree
-  `/Users/danielraffel/Code/pulp-host-view-helper-coverage-493-next2`,
-  branch `feature/host-view-helper-coverage-493-next2`, commit
-  `5c9eeeba`; open as PR `#854`. Scope: test-only coverage for
-  idempotent `open()`, primary role helpers, repeated `release_view()`,
-  secondary view null/bounds cleanup, and null remote-channel diagnostics
-  followed by successful open. Local validation passed diff check,
-  no-GPU configure, affected target build, and focused ViewBridge CTest
-  `10/10`.
-- `#645` signal convolver worktree
-  `/Users/danielraffel/Code/pulp-midi-signal-helper-coverage-645-next2`,
-  branch `feature/midi-signal-helper-coverage-645-next2`, commit
-  `2d8b0bc3`; open as PR `#855`. Scope: test-only coverage for
-  `PartitionedConvolver` rounded/zero block-size setup, empty IR
-  pass-through, and wrong-block-size process pass-through behavior.
-  Local validation passed diff check, skill-sync report, version-bump
-  report, no-GPU/no-examples configure, affected target build, full
-  convolver binary with `91` assertions in `6` cases, direct
-  `[issue-645]` run with `19` assertions in `2` cases, and focused CTest
-  `6/6`.
-- `#643` LCOV/Cobertura helper worktree
-  `/Users/danielraffel/Code/pulp-cli-tools-coverage-643-next3`,
-  branch `feature/cli-tools-coverage-643-next3`, commit `96d20a3a`;
-  open as PR `#856`. Scope: test-only coverage for
-  `tools/scripts/test_run_coverage.py` package exclusions before
-  summary-rate calculation, duplicate source-record function-hit
-  merging, and relpath `ValueError` fallback paths. Local validation
-  passed `python3 tools/scripts/test_run_coverage.py`,
-  `python3 tools/scripts/test_merge_cobertura.py`,
-  `python3 tools/scripts/test_run_python_coverage.py`, and diff check;
-  local `coverage.py >= 7.10` is not installed, so hosted CI remains the
-  coverage proof.
-- `#642` events async-helper worktree
-  `/Users/danielraffel/Code/pulp-events-helper-coverage-642-next2`,
-  branch `feature/events-helper-coverage-642-next2`, commits `7b6f653e`
-  and metadata tip `4cbfd67c`; open as PR `#857`. Scope: new focused
-  test-only target for reentrant `AsyncUpdater`, `LambdaAsyncUpdater`
-  empty-callback handling, `ActionBroadcaster` missing-removal behavior,
-  and `MultiTimer` stop-all/restart behavior. Local validation after
-  rebasing onto `origin/main` passed the no-GPU/no-examples configure,
-  affected target build, direct `pulp-test-events-async-helpers` run
-  with `16` assertions in `4` cases, focused CTest `12/12`, diff check,
-  and pre-push gates with a `Version-Bump: sdk=skip` trailer for the
-  test-only target registration.
-
-Open supporting PR:
-
-- `#774` refreshes this durable handoff/status document, branch
-  `docs/coverage-status-2026-04-25`. The branch is updated as this
-  tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#813` merged,
-  updated after `#816` merged, `#817` was repaired, `#820` opened,
-  `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
-  merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
-  merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
-  repaired again for Android SDK discovery, `#827` opened, `#823`
-  merged, `#824` merged, `#828` opened, `#829` opened, `#825` merged,
-  `#830` opened, `#831` opened, `#827` merged, `#832` opened, `#826`
-  merged, and `#832` was repaired for Windows cmd portability, and
-  `#831` was repaired for Windows float tolerance, and `#822` merged,
-  and `#833` opened, and `#829` was rebased onto `87ef6d90` to pick up
-  the merged Android SDK discovery fix, and `#832` was rebased/repaired
-  for the Windows fast-exit command, and `#834` opened, and `#828`
-  merged, and `#835` opened, and `#836` opened, and `#837` opened, and
-  `#831` merged, and `#838` opened, and `#835` was repaired for Linux
-  Android-validation ordering plus config isolation, and `#832` was
-  repaired for the fast-exit deadline review, and `#833` was rebased
-  onto `b5e7a463` to clear the stale Android SDK discovery ASan failure,
-  and `#836` merged, and `#837` merged, and `#839` opened,
-  and `#830` merged, and `#838` was rebased onto `d02c9ec9` and repaired
-  for the Android package parallel temp-dir collision, and `#834` merged,
-  and `#840` opened, and `#841` was opened to classify the represented
-  but currently uncomponentized `inspect/` Codecov bucket, and `#829`
-  merged, and `#840` was rebased onto `eaf991b0`, and `#842` opened to
-  promote `inspect/**` to a first-class Codecov component/tier, and
-  `#843` opened for MPE tracker UMP edge-path coverage, and `#845`,
-  `#846`, `#847`, `#848`, `#849`, `#850`, and `#851` opened from the
-  parallel worker batch, and `#833` merged as `8fc5dd2d`, and `#840`
-  was repaired for diff coverage with `410a0371`, and `#852`, `#853`,
-  `#854`, and `#855` opened from the next worker batch, and `#838`
-  merged as `3d47dbd2`, and `#839` merged as `62ad9870`, and `#856`
-  and `#857` opened from the latest worker batch, and `#832` merged as
-  `3f92f066`, and `#842` merged as `51be8860`, and `#858` through
-  `#864` opened from the parallel worker queue, and `#865` through
-  `#870` opened from the next completed local worker queue, and `#871`
-  opened for JSFX subset validation coverage, and `#873` and `#875`
-  opened for canvas and ship coverage,
-  and remains docs-only.
-
-Local environment note:
-
-- Pulp's Shipyard source pin is `v0.46.0` in `tools/shipyard.toml`
-  and the release workflows. On 2026-04-25, PATH had drifted to
-  `shipyard, version 0.50.0`; rerunning `./tools/install-shipyard.sh`
-  restored the pinned binary, and `shipyard --version` prints
-  `shipyard, version 0.46.0`.
-- On 2026-04-26, `shipyard pr` for the UMP conversion tranche failed
-  pre-PR with exit code `3` because the SSH `windows` target timed out
-  (`100.92.174.43:22`). For this Codecov batch, continue using the
-  GitHub Actions / Namespace checks rather than spending time on the
-  unreachable SSH backend, unless the user explicitly asks to repair the
-  SSH target.
-
-Next recovery actions:
-
-1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#835` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
-   validate locally, and push with lease.
-3. Monitor `#840` cloud checks on head `410a0371`; if a required lane
-   fails after dependency bootstrap succeeds, debug in
-   `/Users/danielraffel/Code/pulp-events-child-process-coverage-642`,
-   patch, validate locally, and push with lease.
-4. Monitor `#843` cloud checks on head `fcdbd278`; if a required lane
-   fails, debug in
-   `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
-   patch, validate locally, and push with lease.
-5. Monitor `#845` through `#875`; if a required lane fails, debug in
-   the worktree named in the open-PR list above, patch, validate
-   locally, and push with lease. Pay particular attention to `#848` and
-   `#851` because they include patch-level production hardening.
-6. Review the local-only timer one-shot worktree listed above. If the
-   production behavior change is accepted, add SDK patch metadata,
-   rerun focused events validation, open a `codecov` PR, and update this
-   doc plus `#642` / `#641`.
-7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
-   rebase that branch onto `origin/main`, push with lease, and let
-   checks rerun.
-8. Continue Phase 3 from the tranche issues below, prioritizing
-   represented high-miss files over adding new perimeter lanes.
-
-## Phase 1 corrected baseline
-
-Source:
-
-- Codecov public totals and components API for `main` commit
-  `abe2b07a820d9e705864a3ecd3f0350772f694d1`
-- GitHub Actions Coverage run `24886403280`, completed successfully
-  across Android/Kotlin, Linux/Clang, Windows/Clang, and macOS/Clang
-
-This snapshot is the corrected Phase 1 component baseline used to seed
-Phase 2 planning:
-
-- overall tracked coverage: `39.28%` over `68,001` lines in `551` files
-- `audio`: `20.95%`
-- `canvas`: `64.06%`
-- `dsl`: `63.38%`
-- `events`: `24.14%`
-- `format`: `43.86%`
-- `host`: `33.38%`
-- `midi`: `45.2%`
-- `osc`: `60.25%`
-- `platform`: `35.41%`
-- `render`: `55.87%`
-- `runtime`: `46.89%`
-- `signal`: `61.85%`
-- `state`: `50.94%`
-- `view`: `42.41%`
-- `android`: `13.83%`
-- `apple`: `29.93%`
-- `linux`: `0.0%`
-- `windows`: `0.0%`
-- `cli`: `21.38%`
-- `ship`: `31.45%`
-- `tools`: `34.07%`
-
-Representation proof points from the same Codecov snapshot:
-
-- Apple files now visible:
-  - `apple/Sources/PulpSwift/PulpBridge.cpp`: `70.78%`
-  - `apple/Sources/PulpSwift/PulpBridge.swift`: `98.7%`
-  - `apple/Sources/PulpSwift/PulpParameter.swift`: `100.0%`
-  - `apple/Sources/PulpSwift/PulpViews.swift`: `79.79%`
-- Python perimeter files now visible, including top-level `tools/*.py`,
-  `tools/packages/**`, `tools/deps/**`, `tools/local-ci/**`,
-  `tools/scripts/**`, and `core/view/js/embed_js.py`.
-- `bindings/python/bindings.cpp` is visible as a counted file
-  (`0.0%`, `0/121` lines). It is represented but still a test gap.
-- `tools/packages/freshness_check.py` and
-  `tools/packages/validate_registry.py` are visible as counted files.
-- Python test modules remain intentionally omitted from the reported
-  source set.
-
-## Clearly known still not on Codecov
-
-These are explicit perimeter decisions after the corrected baseline.
-They should not be treated as silent omissions while Phase 2 ranks the
-represented surface.
-
-- Authored JavaScript source roots remain out of the represented surface
-  until a dedicated JS lane is added - tracked by `#659`.
-- `bindings/nodejs/bindings.cpp` remains explicitly out of scope for now
-  because the repo does not have a supported Node binding CI/test lane -
-  tracked by `#657`.
-- Shell and PowerShell scripts remain explicitly out of scope for now.
-  They are tested indirectly where practical, but do not surface as
-  first-class Codecov lines - tracked by `#657`.
-- iOS-only Swift and standalone Swift outside the macOS SwiftPM lane stay
-  outside the represented surface unless a later simulator/runtime lane
-  pulls them in. Known examples:
-  - `apple/Sources/PulpSwift/PulpAudioSession.swift`
-  - `templates/ios-auv3/HostApp/ContentView.swift`
-  - `templates/ios-auv3/HostApp/PulpHostApp.swift`
-  - `tools/local-ci/macos_window_probe.swift`
-  tracked by `#77`; the Apple perimeter classification work in `#656`
-  is closed.
-- `apple/Sources/PulpSwift/PulpBridge.h` is a declaration-only C header
-  and is not materialized as an executable-line Codecov row. The
-  implementation in `PulpBridge.cpp` is now represented and tested.
-- Optional native surfaces that are not compiled by the current coverage
-  configure, such as AAX/ARA runtime sources, Android native device
-  shims, and Web/WASM-specific sources, remain outside the measured
-  graph unless Phase 2 decides to add focused follow-up issues.
-
-## Represented inspect surface
-
-- `inspect/` is represented on the Codecov website as a first-party
-  top-level bucket (`1,505` lines, `10.10%` in the user-observed
-  snapshot). It was tracked by `#841`, and merged PR `#842` promotes
-  `inspect/**` to a first-class Codecov flag/component and assigns it to
-  the existing user-facing coverage tier in `ci/coverage-targets.yaml`.
-
-## Phase 1 issue map
-
-### Control plane and verification
-
-- `#641` authoritative umbrella and phase tracker
-- `#639` Codecov control plane and dashboard truth follow-up
-- `#647` merged representation tranche for `dsl`, `windows`, and the
-  durable status report
-- `#715` merged Python coverage normalization / zero-file visibility fix
-
-### Completed perimeter-expansion work
-
-- `#656` Swift / Apple perimeter classification, with
-  `PulpBridge.cpp` represented through `#678`
-- `#658` Python perimeter expansion, implemented through `#677` and
-  normalized by `#715`
-- `#679` / `#680` `bindings/python/bindings.cpp` representation
-- `#633` Android/Kotlin JaCoCo lane
-- `#615` Apple Swift package lane
-
-### Remaining explicit perimeter follow-ups
-
-- `#659` add a JavaScript source lane for authored repo assets
-- `#657` classify optional bindings and shell / PowerShell surfaces in
-  docs; after this rebaseline lands, the remaining implementation
-  decision is whether to keep Node and scripts out of scope or file
-  dedicated future lanes
-- `#77` decide and, if in scope, add mobile runtime coverage from
-  Android instrumentation and iOS simulator / runtime app paths
-- `#841` classify represented `inspect/**` as a first-class Codecov
-  component/tier; implemented by merged PR `#842`
-
-### Supporting infrastructure
-
-- `#671` Windows Shipyard bundle-lock infra failure: closed
-- `#692` Windows Namespace capacity fallback for PR lanes: closed
-- `#655` Android SDK / NDK provisioning on SSH validation hosts remains
-  useful supporting infra but is not a blocker for hosted Codecov truth
-  on `main`
-- `#568` historical multi-language expansion umbrella. Active execution
-  now rolls up through `#641`.
-
-## Phase 2 / Phase 3 working queue
-
-Phase 2 started from the component snapshot above, not from older
-pre-`#715` numbers. The current execution rule is:
-
-1. Rank below-target counted components against `ci/coverage-targets.yaml`.
-2. Separate represented but zero/low coverage files from intentionally
-   unrepresented surfaces.
-3. Land small, focused PRs that improve represented files and keep diff
-   coverage above the required 75% floor.
-4. Refresh this doc and `#641` after each batch of merges or after a
-   meaningful Codecov `main` rebaseline.
-
-### Phase 2 / Phase 3 tranche issues
-
-- `#640` audio / platform tranche
-- `#642` events tranche
-- `#643` CLI / tools tranche
-- `#644` ship tranche
-- `#645` midi / signal tranche
-- `#646` render tranche
-- `#493` host / format / view and related hardening gaps
-- `#737` optional native surfaces not compiled by the default coverage
-  configuration
-- `#841` inspect component / tier classification
-
-### Deferred perimeter follow-ups
-
-- `#659` authored JavaScript source lane
-- `#657` Node bindings plus shell / PowerShell classification, closed as
-  explicitly out of scope for now
-- `#77` mobile runtime / iOS simulator coverage
-- `#841` represented `inspect/**` classification
-
-## Control-plane invariants
+## Control-Plane Invariants
 
 - Every top-level `core/*` directory must have matching subsystem
   entries in `codecov.yml` `flags:` and `component_management:`.
-- Platform axes must match the live repo path conventions, including
+- Platform axes must match live repo path conventions, including
   `core/**/win/**` for Windows.
 - Swift upload artifacts must be repo-relative LCOV with `SF:` paths
   rooted under `apple/Sources/**`.
@@ -1414,18 +161,13 @@ pre-`#715` numbers. The current execution rule is:
 - The authoritative program tracker is `#641`, not the older language
   umbrella `#568`.
 
-## Validation commands for this slice
+## Validation Commands
 
-- `python3 tools/scripts/test_codecov_config.py`
-- `python3 tools/scripts/test_run_swift_coverage.py`
-- `python3 tools/scripts/test_coverage_diff_comment.py`
-- `tools/check-docs.sh`
+For doc-only refreshes:
 
-## Follow-ups not solved by this doc
-
-- If another top-level `core/*` subsystem is added, update `codecov.yml`
-  in the same change; the structural test should fail immediately if the
-  mapping is missed.
-- `docs/reference/modules.md` still lacks a `#dsl` section even though
-  `docs/status/modules.yaml` points at one. That is real docs drift, but
-  it is outside this coverage-compliance slice.
+```bash
+tools/check-docs.sh
+PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
+python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
+git diff --check
+```

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 20:40 EDT
+Last reviewed: 2026-04-26 20:42 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -200,6 +200,10 @@ Open Phase 3 PRs:
   from `main` at `5b8e4529`. This tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
+- `#838` CLI release packager coverage for `#643`, branch
+  `feature/package-cli-coverage-643`, head `7e76a1b7`; opened from
+  `main` at `b5e7a463`. This tranche also uses the GitHub/Namespace
+  path while the SSH `windows` target remains unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -381,6 +385,20 @@ Local Phase 3 draft worktrees:
   local Python coverage runner could not run because this interpreter
   lacks `coverage.py >= 7.10`; hosted CI remains the coverage proof for
   this tranche.
+- `#643` CLI release packager worktree
+  `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, branch
+  `feature/package-cli-coverage-643`, commit `7e76a1b7`; open as PR
+  `#838`.
+  Scope: test-only Python coverage for `tools/scripts/package_cli.py`
+  wgpu library discovery, macOS/Linux rpath command selection,
+  tar/zip archive writer layout, missing-binary and missing-library
+  exits, and successful Linux/Windows package staging with external
+  tools mocked. Local validation after rebasing onto `origin/main` with
+  `#831` merged: direct `python3 tools/scripts/test_package_cli.py`
+  passed `10` cases, `git diff --check HEAD~1..HEAD`, skill-sync
+  report, and version-bump report. The local Python coverage runner
+  could not run because this interpreter lacks `coverage.py >= 7.10`;
+  hosted CI remains the coverage proof for this tranche.
 - `#645` MPE tracker worktree
   `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, branch
   `feature/mpe-tracker-coverage-645`, commit `b7c72711`; merged via PR
@@ -715,7 +733,7 @@ Open supporting PR:
   the merged Android SDK discovery fix, and `#832` was rebased/repaired
   for the Windows fast-exit command, and `#834` opened, and `#828`
   merged, and `#835` opened, and `#836` opened, and `#837` opened, and
-  `#831` merged, and remains docs-only.
+  `#831` merged, and `#838` opened, and remains docs-only.
 
 Local environment note:
 
@@ -758,10 +776,13 @@ Next recovery actions:
 9. Monitor `#837` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-package-validator-coverage-643`,
    patch, validate locally, and push with lease.
-10. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+10. Monitor `#838` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, patch,
+   validate locally, and push with lease.
+11. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-11. Continue Phase 3 from the tranche issues below, prioritizing
+12. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 22:21 EDT
+Last reviewed: 2026-04-26 22:32 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -66,7 +66,7 @@ Finish line:
 ## Current live state
 
 Latest complete Codecov `main` report observed while updating this doc
-(`main` head `eaf991b0` has a newer Coverage run queued):
+(`main` head `8fc5dd2d` has a newer Coverage run queued):
 
 - commit: `5b8e4529cfc553fd98b65f265ed1e9c0487b3d66`
 - workflow: Coverage run `24970413173`, completed successfully
@@ -163,6 +163,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#830` RPN parser edge coverage -> `d02c9ec9`
 - `#834` events event-loop lifecycle edge coverage -> `455c0a9d`
 - `#829` MIDI-CI edge coverage -> `eaf991b0`
+- `#833` signal filter-design edge coverage -> `8fc5dd2d`
 
 Open Phase 3 PRs:
 
@@ -176,12 +177,6 @@ Open Phase 3 PRs:
   100ms fast-exit deadline. This tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
-- `#833` signal filter-design edge coverage for `#645`, branch
-  `feature/signal-biquad-coverage-645`, head `e3795fca`; opened from
-  `main` at `87ef6d90`, then rebased onto `b5e7a463` after the ASan
-  lane failed in the already-fixed Android SDK discovery regression
-  from the stale base. This tranche also uses the GitHub/Namespace path
-  while the SSH `windows` target remains unreachable.
 - `#835` CLI ship command validation coverage for `#643`, branch
   `feature/cli-ship-coverage-643`, head `b8f22af9`; opened from
   `main` at `5b8e4529`, then rebased onto `b5e7a463` and updated after
@@ -204,13 +199,16 @@ Open Phase 3 PRs:
   merged. This tranche also uses the GitHub/Namespace path while the
   SSH `windows` target remains unreachable.
 - `#840` events child-process manager coverage for `#642`, branch
-  `feature/events-child-process-coverage-642`, head `47e38795`; opened
+  `feature/events-child-process-coverage-642`, head `410a0371`; opened
   from `main` at `455c0a9d`, then rebased onto `eaf991b0` after `#829`
   merged. The first Linux Namespace and Linux coverage failures were
   dependency-bootstrap failures before configure/tests because a cold
-  FetchContent cache hit a GitHub 403 cloning `Tracktion/choc.git`. This
-  tranche also uses the GitHub/Namespace path while the SSH `windows`
-  target remains unreachable.
+  FetchContent cache hit a GitHub 403 cloning `Tracktion/choc.git`. The
+  first diff-coverage failure was fixed by pushing `410a0371`, which
+  keeps the production change focused on the covered invalid-PID guard
+  and removes unrelated POSIX `waitpid` hardening from this tranche.
+  This tranche also uses the GitHub/Namespace path while the SSH
+  `windows` target remains unreachable.
 - `#842` inspect Codecov classification for `#841` / parent `#641`,
   branch `feature/inspect-codecov-component-841`, head `0541fd69`;
   promotes `inspect/**` to a first-class Codecov flag/component and
@@ -829,8 +827,8 @@ Local Phase 3 draft worktrees:
   deadline was resolved.
 - `#645` signal filter-design worktree
   `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, branch
-  `feature/signal-biquad-coverage-645`, commit `e3795fca`; open as PR
-  `#833`.
+  `feature/signal-biquad-coverage-645`, commit `e3795fca`; merged via
+  PR `#833` as `8fc5dd2d`. The remote branch was deleted after merge.
   Scope: test-only coverage for peaking boost/cut coefficients, low/high
   shelf cut paths, shelf slope variants, and Butterworth empty/high-order
   section behavior. This intentionally touches only
@@ -943,7 +941,8 @@ Open supporting PR:
   promote `inspect/**` to a first-class Codecov component/tier, and
   `#843` opened for MPE tracker UMP edge-path coverage, and `#845`,
   `#846`, `#847`, `#848`, `#849`, `#850`, and `#851` opened from the
-  parallel worker batch,
+  parallel worker batch, and `#833` merged as `8fc5dd2d`, and `#840`
+  was repaired for diff coverage with `410a0371`,
   and remains docs-only.
 
 Local environment note:
@@ -966,38 +965,35 @@ Next recovery actions:
 2. Monitor `#832` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
    patch, validate locally, and push with lease.
-3. Monitor `#833` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, patch,
-   validate locally, and push with lease.
-4. Monitor `#835` cloud checks; if a required lane fails, debug in
+3. Monitor `#835` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
    validate locally, and push with lease.
-5. Monitor `#838` cloud checks on head `09666f46`; if a required lane fails, debug in
+4. Monitor `#838` cloud checks on head `09666f46`; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, patch,
    validate locally, and push with lease.
-6. Monitor `#839` cloud checks; if a required lane fails, debug in
+5. Monitor `#839` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-render-gpu-graph-coverage-646`,
    patch, validate locally, and push with lease.
-7. Monitor `#840` cloud checks on head `47e38795`; if a required lane
+6. Monitor `#840` cloud checks on head `410a0371`; if a required lane
    fails after dependency bootstrap succeeds, debug in
    `/Users/danielraffel/Code/pulp-events-child-process-coverage-642`,
    patch, validate locally, and push with lease.
-8. Monitor `#842` cloud checks on head `0541fd69`; if a required lane
+7. Monitor `#842` cloud checks on head `0541fd69`; if a required lane
    fails, debug in
    `/Users/danielraffel/Code/pulp-inspect-codecov-component-841`,
    patch, validate locally, and push with lease.
-9. Monitor `#843` cloud checks on head `fcdbd278`; if a required lane
+8. Monitor `#843` cloud checks on head `fcdbd278`; if a required lane
    fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
    patch, validate locally, and push with lease.
-10. Monitor `#845` through `#851`; if a required lane fails, debug in
+9. Monitor `#845` through `#851`; if a required lane fails, debug in
    the worktree named in the open-PR list above, patch, validate
    locally, and push with lease. Pay particular attention to `#848` and
    `#851` because they include patch-level production hardening.
-11. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+10. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-12. Continue Phase 3 from the tranche issues below, prioritizing
+11. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 20:16 EDT
+Last reviewed: 2026-04-25 20:43 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -115,13 +115,21 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#788` events socket-IPC coverage, branch
-  `feature/events-ipc-coverage-642`, head `9e73a084`. This tranche
+  `feature/events-ipc-coverage-642`, head `931627b0`. This tranche
   extends `test/test_ipc.cpp` with malformed socket endpoint rejection,
   non-throwing socket endpoint parsing in
   `core/events/src/interprocess_connection.cpp`, and a deterministic
   localhost client/server framed-message exchange. It also hardens
   `pulp::runtime::Socket::close()` to call TCP `shutdown()` before closing,
   so Linux threads blocked in `accept()` / `recv()` wake during cleanup.
+  After `9e73a084`, Linux coverage remained in `Run coverage suite` for
+  roughly an hour while every other required lane was green. The current
+  `931627b0` head adds a more direct server cleanup fix:
+  `InterprocessConnectionServer::stop()` self-connects to the listening
+  socket before closing it, so a thread blocked in `accept()` wakes without
+  relying on cross-thread `close()` / `shutdown()` behavior. The new
+  regression test covers stopping a socket server while no client is
+  connected.
   After `#771` merged, this
   branch was rebased onto `origin/main` and duplicate shared CLI support
   commits were skipped, leaving only the events tranche. After `#789` merged,
@@ -140,11 +148,14 @@ Open Phase 3 PRs:
   required lanes but Linux Build/Test and Linux Coverage remained in their
   long test/coverage steps, matching a likely blocking-`accept()` cleanup hang.
   The targeted `9e73a084` fix was pushed after local IPC validation stayed
-  green. As of 2026-04-25 20:16 EDT, Build/Test is green on Linux,
-  macOS, and Windows; sanitizer lanes are green or skipped as expected;
-  Android build, IWYU, macOS coverage, and Windows coverage are green.
-  The only remaining required check is Linux coverage, still in the
-  `Run coverage suite` step after roughly 31 minutes.
+  green. That head got Build/Test green on Linux, macOS, and Windows;
+  sanitizer lanes green or skipped as expected; Android build, IWYU,
+  macOS coverage, and Windows coverage green; but Linux coverage stayed
+  in `Run coverage suite` with no logs. The current `931627b0` head has
+  local IPC validation green: `pulp-test-ipc` (`37` assertions / `10`
+  test cases), focused CTest `IPC` (`10/10`), `git diff --check`, and
+  `version_bump_check.py --mode=report` (patch suggestion only). Fresh
+  GitHub checks are now running on that head.
 
 Local Phase 3 draft not yet opened as a PR:
 - `#643` package-registry CLI/tools draft, worktree
@@ -183,7 +194,7 @@ Local environment note:
 Next recovery actions:
 
 1. Poll `#788`; merge manually when green because auto-merge is disabled.
-2. Let `#788`'s final Linux coverage job on `9e73a084` drain.
+2. Let `#788`'s fresh checks on `931627b0` drain.
 3. Keep `#774` docs-only and let its post-`#789` rebase checks drain.
 4. After `#788` merges, refresh this section with the next
    complete Codecov `main` report.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 19:58 EDT
+Last reviewed: 2026-04-26 20:04 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -155,14 +155,10 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#825` signal DSP helper edge coverage -> `d0262a1b`
 - `#826` OGG reader edge coverage -> `6ae4d487`
 - `#827` signal multi-channel meter edge coverage -> `d5efea57`
+- `#828` raw MIDI parser edge coverage and malformed-data hardening -> `5b8e4529`
 
 Open Phase 3 PRs:
 
-- `#828` raw MIDI parser edge coverage and malformed-data hardening for
-  `#645`, branch `feature/midi-raw-parser-coverage-645`, head
-  `4e2e6092`; opened from `main` at `94e3ef2a`. This tranche also uses
-  the GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
 - `#829` MIDI-CI edge coverage for `#645`, branch
   `feature/midi-ci-coverage-645`, head `1d3cd1ce`; opened from `main`
   at `94e3ef2a` and rebased onto `87ef6d90` after the first ASan run
@@ -556,8 +552,8 @@ Local Phase 3 draft worktrees:
   `git diff --check`, skill-sync report, and version-bump report.
 - `#645` raw MIDI parser worktree
   `/Users/danielraffel/Code/pulp-midi-raw-parser-coverage-645`, branch
-  `feature/midi-raw-parser-coverage-645`, commit `4e2e6092`; open as PR
-  `#828`.
+  `feature/midi-raw-parser-coverage-645`, commit `4e2e6092`; merged via
+  PR `#828` as `5b8e4529`. The remote branch was deleted after merge.
   Scope: fixes `parse_raw_midi_bytes` so malformed short messages do not
   emit status bytes as data, then adds coverage for remaining
   short-message forms, stray data plus incomplete short messages,
@@ -663,8 +659,8 @@ Open supporting PR:
   `#831` was repaired for Windows float tolerance, and `#822` merged,
   and `#833` opened, and `#829` was rebased onto `87ef6d90` to pick up
   the merged Android SDK discovery fix, and `#832` was rebased/repaired
-  for the Windows fast-exit command, and `#834` opened, and remains
-  docs-only.
+  for the Windows fast-exit command, and `#834` opened, and `#828`
+  merged, and remains docs-only.
 
 Local environment note:
 
@@ -683,31 +679,28 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#828` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-midi-raw-parser-coverage-645`, patch,
-   validate locally, and push with lease.
-3. Monitor `#829` cloud checks; if a required lane fails, debug in
+2. Monitor `#829` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, patch,
    validate locally, and push with lease.
-4. Monitor `#830` cloud checks; if a required lane fails, debug in
+3. Monitor `#830` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, patch,
    validate locally, and push with lease.
-5. Monitor `#831` cloud checks; if a required lane fails, debug in
+4. Monitor `#831` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, patch,
    validate locally, and push with lease.
-6. Monitor `#832` cloud checks; if a required lane fails, debug in
+5. Monitor `#832` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
    patch, validate locally, and push with lease.
-7. Monitor `#833` cloud checks; if a required lane fails, debug in
+6. Monitor `#833` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, patch,
    validate locally, and push with lease.
-8. Monitor `#834` cloud checks; if a required lane fails, debug in
+7. Monitor `#834` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-events-loop-coverage-642`, patch,
    validate locally, and push with lease.
-9. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-10. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 19:11 EDT
+Last reviewed: 2026-04-25 19:16 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -67,36 +67,32 @@ Finish line:
 
 Latest complete Codecov `main` report observed while updating this doc:
 
-- commit: `26dd396da53e5ceab340eac5681f1b10d75ed56b`
-- workflow: Coverage run `24930675870`, completed successfully
-- overall tracked coverage: `44.35%` over `70,205` lines in `556` files
-- covered lines: `31,140`
+- commit: `e61dce8d907c29888fd7dd97ae7f49e3bc219662`
+- workflow: Coverage run `24942795469`, completed successfully
+- overall tracked coverage: `44.85%` over `70,229` lines in `556` files
+- covered lines: `31,498`
 - current component coverage from the Codecov API:
-  - `audio`: `24.8%`
-  - `canvas`: `67.83%`
-  - `dsl`: `77.04%`
-  - `events`: `29.47%`
-  - `format`: `52.61%`
-  - `host`: `43.23%`
-  - `midi`: `50.96%`
-  - `osc`: `72.52%`
-  - `platform`: `46.92%`
-  - `render`: `61.35%`
-  - `runtime`: `48.56%`
-  - `signal`: `67.25%`
-  - `state`: `67.26%`
-  - `view`: `45.04%`
+  - `audio`: `25.45%`
+  - `canvas`: `67.14%`
+  - `dsl`: `68.3%`
+  - `events`: `33.48%`
+  - `format`: `52.89%`
+  - `host`: `45.92%`
+  - `midi`: `48.44%`
+  - `osc`: `66.26%`
+  - `platform`: `50.65%`
+  - `render`: `62.31%`
+  - `runtime`: `50.2%`
+  - `signal`: `66.89%`
+  - `state`: `63.32%`
+  - `view`: `44.81%`
   - `android`: `13.83%`
-  - `apple`: `25.72%`
-  - `linux`: `0.0%`
-  - `windows`: `16.83%`
-  - `cli`: `32.96%`
-  - `ship`: `36.48%`
-  - `tools`: `39.89%`
-
-`main` has since advanced to `e61dce8d907c29888fd7dd97ae7f49e3bc219662`
-after `#789` merged. The next complete Codecov `main` report for that
-commit had not landed at the time of this update.
+  - `apple`: `25.36%`
+  - `linux`: `3.98%`
+  - `windows`: `15.02%`
+  - `cli`: `33.15%`
+  - `ship`: `57.66%`
+  - `tools`: `40.17%`
 
 Merged after the Phase 1 closeout / `#723` baseline:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 01:42 EDT
+Last reviewed: 2026-04-26 01:53 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -172,6 +172,21 @@ Open Phase 3 PRs:
   report clean with explicit `Version-Bump: sdk=patch` for the
   header-only behavior fix. The PR is labeled `codecov` and is using the
   direct GitHub/Namespace path.
+- `#802` `test(cli): cover create shellout scaffolding`, branch
+  `feature/cli-create-coverage-643`, commit `f5e4a05f`, worktree
+  `/Users/danielraffel/Code/pulp-cli-create-coverage-643`.
+  Scope: deterministic `pulp create` shellout coverage for no-build app
+  scaffolding with Android target output, generated header/main/CMake/
+  `pulp.toml`/projects registry substitutions, and invalid `--type`
+  rejection before scaffolding. Local validation: no-GPU/no-examples
+  configure, `pulp-test-cli-shellout` target build, focused Catch2 tag
+  run passed with `21` assertions in `2` test cases, focused CTest
+  `pulp create` passed `2/2`, `git diff --check` clean, skill sync
+  clean, and version bump report says no bump needed. Local shellout
+  validation used `PULP_CLI_PATH=/Users/danielraffel/Code/pulp/build/tools/cli/pulp`
+  because the GPU-off configure intentionally does not build `pulp-cli`;
+  CI builds the normal CLI path. The PR is labeled `codecov` and is
+  using the direct GitHub/Namespace path.
 
 Local Phase 3 draft worktrees:
 
@@ -213,13 +228,17 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`,
   branch `feature/render-texture-atlas-coverage-646`, commit
   `a2201dbb`; open as PR `#801`.
+- `#643` CLI-create shellout worktree
+  `/Users/danielraffel/Code/pulp-cli-create-coverage-643`, branch
+  `feature/cli-create-coverage-643`, commit `f5e4a05f`; open as PR
+  `#802`.
 
 Open supporting PR:
 
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#799` merged and
+  The branch has been rebased onto `origin/main` after `#800` merged and
   remains docs-only.
 
 Local environment note:
@@ -233,9 +252,9 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795` and `#801` and address any Codecov, build,
+2. Monitor `#795`, `#801`, and `#802` and address any Codecov, build,
    sanitizer, or Namespace feedback.
-3. If `#795` or `#801` is green but GitHub reports it behind
+3. If `#795`, `#801`, or `#802` is green but GitHub reports it behind
    `main`, rebase that branch onto `origin/main`, push with lease, and
    let checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 00:10 EDT
+Last reviewed: 2026-04-26 00:15 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -121,6 +121,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#793` package-registry CLI/tools coverage -> `e2af9c4d`
 - `#794` AIFF reader edge-path coverage -> `c4e6ad09`
 - `#796` tool-registry CLI/tools coverage -> `11c10a7e`
+- `#797` StreamingWriter audio edge coverage -> `64ba65e3`
 
 Open Phase 3 PRs:
 
@@ -147,25 +148,6 @@ Open Phase 3 PRs:
   direct GitHub/Namespace path instead of `shipyard pr` because `#794`
   exposed a local Shipyard mac configure stall after GitHub/Namespace was
   already clean.
-- `#797` `test(audio): cover streaming WAV writer edges`, branch
-  `feature/audio-streaming-writer-coverage-640`, commit `29a3f26d`,
-  worktree
-  `/Users/danielraffel/Code/pulp-audio-streaming-writer-coverage-640`.
-  Scope: `StreamingWriter` invalid opens, closed writes, null/zero/negative
-  write arguments, finalized WAV headers, 16-bit interleaved PCM clamping,
-  24-bit deinterleaved channel interleaving, and 32-bit PCM destructor
-  finalization. The tranche also fixes the production edge where unopened
-  writes could advance `frames_written_`, and where negative deinterleaved
-  frame counts could underflow or allocate an invalid buffer. Local
-  validation: `pulp-test-audio-file` passed with `312` assertions in `19`
-  test cases; focused CTest
-  `StreamingWriter|audio.*file|FormatRegistry` passed `6/6`;
-  `git diff --check` clean; version bump report says no bump needed.
-  The PR is labeled `codecov` and is using the same direct
-  GitHub/Namespace path as `#795`. Codecov's complete commit report shows
-  `core/audio/src/streaming_writer.cpp` represented at `60.67%` coverage;
-  the early Codecov PR comment reporting `0%` patch coverage appears stale
-  relative to the green `codecov/patch` check and line-level API data.
 - `#798` `test(audio): cover format registry dispatch paths`, branch
   `feature/audio-format-registry-coverage-640`, commit `43739ac1`,
   worktree
@@ -201,7 +183,8 @@ Local Phase 3 draft worktrees:
 - `#640` streaming-writer audio/platform worktree
   `/Users/danielraffel/Code/pulp-audio-streaming-writer-coverage-640`,
   branch `feature/audio-streaming-writer-coverage-640`, commit
-  `29a3f26d`; open as PR `#797`.
+  `29a3f26d`; merged via PR `#797` as `64ba65e3`. The remote branch was
+  deleted after merge.
 - `#640` format-registry audio/platform worktree
   `/Users/danielraffel/Code/pulp-audio-system-volume-coverage-640`,
   branch `feature/audio-format-registry-coverage-640`, commit
@@ -226,9 +209,9 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795`, `#797`, and `#798` and address any Codecov, build,
+2. Monitor `#795` and `#798` and address any Codecov, build,
    sanitizer, or Namespace feedback.
-3. If `#795`, `#797`, or `#798` is green but GitHub reports it behind `main`,
+3. If `#795` or `#798` is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -106,19 +106,28 @@ Open Phase 3 PRs:
   `PULP_ENABLE_GPU=OFF` sanitizer/IWYU configurations. Local GPU-off
   configure/build plus `pulp-test-cli-project-command` are green; GitHub
   Actions reran at `429b8941` and is draining.
+- `#777` real CLAP `PluginSlot` coverage, branch
+  `feature/clap-slot-coverage-493`, head `9a2a1d90`. This tranche wires
+  the built PulpGain CLAP bundle into host tests after examples are
+  registered, adds metadata/defaults, bypass/release, and restore-state
+  coverage, and fixes CLAP state restore so restored plugin state
+  supersedes stale cached host edits. Local configure, build,
+  `pulp-test-host`, generated `ClapSlot` CTest entries, whitespace,
+  skill-sync, and version checks are green; GitHub Actions is draining.
 
 Open supporting PR:
 
 - `#774` refreshes this durable handoff/status document, branch
-  `docs/coverage-status-2026-04-25`, head `7f9ae827`. Docs preview,
-  docs consistency, audit, version, Android coverage, Linux coverage,
-  and Codecov patch are green; Namespace/remaining coverage lanes are
-  still draining.
+  `docs/coverage-status-2026-04-25`. The branch is updated as this
+  tracker changes; use the PR head SHA in GitHub as the live value.
+  Docs preview, docs consistency, audit, version, Android coverage,
+  Linux coverage, and Codecov patch were green on the previous run;
+  Namespace/remaining coverage lanes are draining on each refresh.
 
 Next recovery actions:
 
-1. Poll `#766` and `#771`; merge green PRs manually because auto-merge
-   is disabled.
+1. Poll `#766`, `#771`, `#774`, and `#777`; merge green PRs manually
+   because auto-merge is disabled.
 2. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
 3. After active PRs merge, refresh this section with the next complete

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 20:36 EDT
+Last reviewed: 2026-04-26 20:40 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -66,26 +66,26 @@ Finish line:
 ## Current live state
 
 Latest complete Codecov `main` report observed while updating this doc
-(`main` head `5b8e4529` has a newer Coverage run in progress):
+(`main` head `b5e7a463` has a newer Coverage run queued):
 
-- commit: `87ef6d90e54a1aa940278aab15b6e444d5c1c30d`
-- workflow: Coverage run `24969958550`, completed successfully
+- commit: `5b8e4529cfc553fd98b65f265ed1e9c0487b3d66`
+- workflow: Coverage run `24970413173`, completed successfully
 - overall tracked coverage: `46.83%` over `70,453` lines in `556` files
-- covered lines: `32,994`
-- missed lines: `36,163`
-- partial lines: `1,296`
+- covered lines: `32,996`
+- missed lines: `36,165`
+- partial lines: `1,292`
 - current component coverage from the Codecov API:
   - `audio`: `37.36%`
   - `canvas`: `64.74%`
   - `dsl`: `68.3%`
-  - `events`: `50.5%`
+  - `events`: `49.78%`
   - `format`: `51.72%`
   - `host`: `43.07%`
-  - `midi`: `54.18%`
+  - `midi`: `54.56%`
   - `osc`: `66.26%`
   - `platform`: `40.16%`
   - `render`: `62.77%`
-  - `runtime`: `49.14%`
+  - `runtime`: `49.11%`
   - `signal`: `73.87%`
   - `state`: `63.56%`
   - `view`: `44.0%`
@@ -157,6 +157,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#826` OGG reader edge coverage -> `6ae4d487`
 - `#827` signal multi-channel meter edge coverage -> `d5efea57`
 - `#828` raw MIDI parser edge coverage and malformed-data hardening -> `5b8e4529`
+- `#831` signal utility helper edge coverage -> `b5e7a463`
 
 Open Phase 3 PRs:
 
@@ -170,12 +171,6 @@ Open Phase 3 PRs:
   `feature/midi-rpn-coverage-645`, head `d1edf1e1`; opened from `main`
   at `d0262a1b`. This tranche also uses the GitHub/Namespace path while
   the SSH `windows` target remains unreachable.
-- `#831` signal utility helper edge coverage for `#645`, branch
-  `feature/signal-utility-coverage-645`, head `1b8169aa`; opened from
-  `main` at `d0262a1b` and updated after the first Windows Namespace run
-  exposed an exact float-array equality assertion in the Phaser reset
-  test. This tranche also uses the GitHub/Namespace path while the SSH
-  `windows` target remains unreachable.
 - `#832` platform child-process edge coverage for `#640`, branch
   `feature/platform-child-process-coverage-640`, head `c07dd268`;
   opened from `main` at `d5efea57`, updated after the first Windows
@@ -653,7 +648,8 @@ Local Phase 3 draft worktrees:
 - `#645` signal utility helper worktree
   `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, branch
   `feature/signal-utility-coverage-645`, commits `d021a35c` and
-  `1b8169aa`; open as PR `#831`.
+  `1b8169aa`; merged via PR `#831` as `b5e7a463`. The remote branch was
+  deleted after merge.
   Scope: test-only coverage for `DelayLine` empty/wraparound/reset
   paths, `SmoothedValue` one-sample clamp and partial skip paths, `Svf`
   bandpass/notch/buffer/reset paths, `Panner` clamp plus in-place stereo
@@ -667,7 +663,7 @@ Local Phase 3 draft worktrees:
   passed `44` assertions in `4` cases, full signal binary passed `934`
   assertions in `74` cases, full v3 gaps binary passed `131` assertions
   in `27` cases, focused CTest passed `6/6`, `git diff --check`, skill-sync
-  report, and version-bump report.
+  report, and version-bump report. Cloud checks were clean before merge.
 - `#640` platform child-process worktree
   `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
   branch `feature/platform-child-process-coverage-640`, commits
@@ -719,7 +715,7 @@ Open supporting PR:
   the merged Android SDK discovery fix, and `#832` was rebased/repaired
   for the Windows fast-exit command, and `#834` opened, and `#828`
   merged, and `#835` opened, and `#836` opened, and `#837` opened, and
-  remains docs-only.
+  `#831` merged, and remains docs-only.
 
 Local environment note:
 
@@ -744,31 +740,28 @@ Next recovery actions:
 3. Monitor `#830` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-rpn-coverage-645`, patch,
    validate locally, and push with lease.
-4. Monitor `#831` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-signal-utility-coverage-645`, patch,
-   validate locally, and push with lease.
-5. Monitor `#832` cloud checks; if a required lane fails, debug in
+4. Monitor `#832` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
    patch, validate locally, and push with lease.
-6. Monitor `#833` cloud checks; if a required lane fails, debug in
+5. Monitor `#833` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, patch,
    validate locally, and push with lease.
-7. Monitor `#834` cloud checks; if a required lane fails, debug in
+6. Monitor `#834` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-events-loop-coverage-642`, patch,
    validate locally, and push with lease.
-8. Monitor `#835` cloud checks; if a required lane fails, debug in
+7. Monitor `#835` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
    validate locally, and push with lease.
-9. Monitor `#836` cloud checks; if a required lane fails, debug in
+8. Monitor `#836` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-sync-coverage-643`, patch,
    validate locally, and push with lease.
-10. Monitor `#837` cloud checks; if a required lane fails, debug in
+9. Monitor `#837` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-package-validator-coverage-643`,
    patch, validate locally, and push with lease.
-11. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+10. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-12. Continue Phase 3 from the tranche issues below, prioritizing
+11. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 18:26 EDT
+Last reviewed: 2026-04-26 18:28 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -149,6 +149,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#821` audio reader helper edge coverage -> `7aff17f9`
 - `#819` MIDI keyboard/sequence edge coverage -> `7a646f33`
 - `#820` signal spectrogram edge coverage -> `1a1b7f07`
+- `#823` platform helper edge coverage -> `f69338eb`
 
 Open Phase 3 PRs:
 
@@ -161,10 +162,6 @@ Open Phase 3 PRs:
   branch now compares Android build-tools and NDK revisions numerically.
   This tranche also uses the GitHub/Namespace path while the SSH
   `windows` target remains unreachable.
-- `#823` platform helper edge coverage for `#640`, branch
-  `feature/platform-helper-coverage-640`, head `6ec4ff2e`; opened from
-  `main` at `3d4560d1`. This tranche also uses the GitHub/Namespace path
-  while the SSH `windows` target remains unreachable.
 - `#824` signal math helper coverage and Mat3 multiplication fix for
   `#645`, branch `feature/signal-math-helper-coverage-645`, head
   `1b7f1cfd`; opened from `main` at `a38216fd`. This tranche also uses
@@ -449,8 +446,8 @@ Local Phase 3 draft worktrees:
   version-bump report classified the SDK change as `patch`.
 - `#640` platform helper worktree
   `/Users/danielraffel/Code/pulp-platform-helper-coverage-640`, branch
-  `feature/platform-helper-coverage-640`, commit `6ec4ff2e`; open as PR
-  `#823`.
+  `feature/platform-helper-coverage-640`, commit `6ec4ff2e`; merged via
+  PR `#823` as `f69338eb`. The remote branch was deleted after merge.
   Scope: test-only coverage for file-dialog no-handler backend failure
   paths, popup-menu item metadata and non-Apple stub behavior, audio
   excerpt value/default helpers, and non-Apple `AudioWorkgroup` fallback
@@ -537,8 +534,8 @@ Open supporting PR:
   `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
   merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
   merged, `#825` opened, `#820` merged, `#826` opened, `#822` was
-  repaired again for Android SDK discovery, and `#827` opened, and
-  remains docs-only.
+  repaired again for Android SDK discovery, `#827` opened, and `#823`
+  merged, and remains docs-only.
 
 Local environment note:
 
@@ -560,25 +557,22 @@ Next recovery actions:
 2. Monitor `#822` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-file-helper-coverage-640`,
    patch, validate locally, and push with lease.
-3. Monitor `#823` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-platform-helper-coverage-640`, patch,
-   validate locally, and push with lease.
-4. Monitor `#824` cloud checks; if a required lane fails, debug in
+3. Monitor `#824` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-math-helper-coverage-645`,
    patch, validate locally, and push with lease.
-5. Monitor `#825` cloud checks; if a required lane fails, debug in
+4. Monitor `#825` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-dsp-helper-coverage-645`,
    patch, validate locally, and push with lease.
-6. Monitor `#826` cloud checks; if a required lane fails, debug in
+5. Monitor `#826` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-audio-ogg-reader-coverage-640`,
    patch, validate locally, and push with lease.
-7. Monitor `#827` cloud checks; if a required lane fails, debug in
+6. Monitor `#827` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-meter-coverage-645`, patch,
    validate locally, and push with lease.
-8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 23:14 EDT
+Last reviewed: 2026-04-26 23:29 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -278,6 +278,41 @@ Open Phase 3 PRs:
   branch `feature/apple-swift-coverage-641-next`, head `3ff82a4e`;
   covers parameter reload replacement after backend changes, invalid
   `pulp_param_info` requests, and C string field population.
+- `#865` Android/Kotlin audio-engine fallback coverage for parent
+  `#641`, branch `feature/android-kotlin-coverage-641-next`, head
+  `08368a1e`; covers default audio config fallbacks when Android audio
+  properties are malformed or unavailable.
+- `#866` audio excerpt-window exact-tail coverage for `#640`, branch
+  `feature/platform-audio-coverage-640-next4`, head `bf10fa20`; covers
+  exact final-window coverage without duplicate tails and single-window
+  full-file metadata preservation.
+- `#867` Python bindings embedded-state coverage for parent `#641`,
+  branch `feature/python-bindings-coverage-641-next`, head `d572fb04`;
+  covers Python-facing `StateStore` access, serialization,
+  deserialization, parameter info, and `HeadlessHost` descriptor/state
+  save/load paths.
+- `#868` signal `ProcessorDuplicator` edge coverage for `#645`, branch
+  `feature/midi-signal-coverage-645-next4`, head `6fe50d38`; covers
+  bounded channel processing, invalid `process_channel` indices, const
+  channel access, and reset forwarding.
+- `#869` render KTX2 decoder header-edge coverage for `#646`, branch
+  `feature/render-coverage-646-next3`, head `f48a931b`; covers
+  null/short/incomplete headers plus minimal valid header parsing and
+  level-count normalization.
+- `#870` host-type policy coverage for `#493`, branch
+  `feature/host-format-view-coverage-493-next3`, head `c42e0603`;
+  covers `host_type_name()` enum mappings, invalid enum fallback, and
+  resize/sidechain policy exceptions.
+
+Local-only queued work:
+
+- `#642` events timer one-shot behavior worktree
+  `/Users/danielraffel/Code/pulp-events-helper-coverage-642-next3`,
+  branch `feature/events-helper-coverage-642-next3`, commit
+  `51f9aeda`; fixes one-shot timers so `is_active()` becomes false
+  after firing and adds a restart regression. Because this is a
+  production behavior fix, review it before opening a PR and add the
+  appropriate SDK patch metadata trailer.
 
 Local Phase 3 draft worktrees:
 
@@ -1044,7 +1079,8 @@ Open supporting PR:
   merged as `3d47dbd2`, and `#839` merged as `62ad9870`, and `#856`
   and `#857` opened from the latest worker batch, and `#832` merged as
   `3f92f066`, and `#842` merged as `51be8860`, and `#858` through
-  `#864` opened from the parallel worker queue,
+  `#864` opened from the parallel worker queue, and `#865` through
+  `#870` opened from the next completed local worker queue,
   and remains docs-only.
 
 Local environment note:
@@ -1075,14 +1111,18 @@ Next recovery actions:
    fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
    patch, validate locally, and push with lease.
-5. Monitor `#845` through `#864`; if a required lane fails, debug in
+5. Monitor `#845` through `#870`; if a required lane fails, debug in
    the worktree named in the open-PR list above, patch, validate
    locally, and push with lease. Pay particular attention to `#848` and
    `#851` because they include patch-level production hardening.
-6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. Review the local-only timer one-shot worktree listed above. If the
+   production behavior change is accepted, add SDK patch metadata,
+   rerun focused events validation, open a `codecov` PR, and update this
+   doc plus `#642` / `#641`.
+7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-7. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 14:17 EDT
+Last reviewed: 2026-04-26 14:29 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -237,6 +237,22 @@ Local Phase 3 draft worktrees:
   cases, full binary passed `318` assertions in `22` cases, focused
   CTest `cmd_project` passed `8/8`, `git diff --check`, skill-sync
   report, and version-bump report.
+- `#645` signal dynamics helper worktree
+  `/Users/danielraffel/Code/pulp-signal-dynamics-coverage-645`, branch
+  `feature/signal-dynamics-coverage-645`, commit `a43a305b`;
+  local-only draft, not opened as a PR yet while `#811` and `#774`
+  drain. Scope: test-only coverage for `DryWetMixer` mix
+  clamping/equal-power/latency/reset paths, `Compressor`
+  hard-knee/soft-knee/buffer/reset paths, `Limiter` buffer/reset paths,
+  `WindowFunction` hamming/flat-top/kaiser branches, and
+  `MultiChannelMeter` channel clamping/reset/silent-correlation/block
+  threshold edges. Local validation: no-GPU/no-examples configure,
+  `pulp-test-dsp-enhancements` and `pulp-test-signal` builds, targeted
+  issue tags passed `9` assertions in `2` DSP cases and `35`
+  assertions in `8` signal cases, full DSP binary passed `62`
+  assertions in `20` cases, full signal binary passed `885` assertions
+  in `67` cases, focused CTest passed `23/23`, `git diff --check`,
+  skill-sync report, and version-bump report.
 
 Open supporting PR:
 
@@ -244,7 +260,8 @@ Open supporting PR:
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#810` merged,
-  updated after `#811` opened, and remains docs-only.
+  updated after `#811` opened and after the local `#645` signal dynamics
+  draft was prepared, and remains docs-only.
 
 Local environment note:
 
@@ -260,10 +277,14 @@ Next recovery actions:
 2. Monitor `#811` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-project-coverage-643`, patch,
    validate locally, and push with lease.
-3. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+3. After `#811` is merged or otherwise no longer blocking the active
+   implementation slot, rebase/push/open the local `#645`
+   `feature/signal-dynamics-coverage-645` draft from
+   `/Users/danielraffel/Code/pulp-signal-dynamics-coverage-645`.
+4. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-4. Continue Phase 3 from the tranche issues below, prioritizing
+5. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 14:51 EDT
+Last reviewed: 2026-04-26 15:13 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -96,6 +96,11 @@ Latest complete Codecov `main` report observed while updating this doc:
   - `ship`: `54.46%`
   - `tools`: `44.33%`
 
+Newer `main` coverage is running for `#813`'s merge commit
+`957a073523e3aabcd7b11972acaf98065909bf67` as Coverage run
+`24964746369`; keep the `810743d4` numbers above as the latest complete
+baseline until that run finishes.
+
 Post-`#794` file-level proof point: `core/audio/src/aiff_reader.cpp`
 is now `72.01%` covered with `61` misses, up from `64.22%` with `78`
 misses at the prior `e2af9c4d` baseline.
@@ -137,12 +142,13 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#809` signal FFT/convolver helper coverage -> `453bcec8`
 - `#810` platform Environment diff-edge coverage -> `f712702a`
 - `#811` CLI project-command dispatch coverage -> `810743d4`
+- `#813` signal dynamics helper coverage -> `957a0735`
 
 Open Phase 3 PRs:
 
-- `#813` signal dynamics helper coverage for `#645`, branch
-  `feature/signal-dynamics-coverage-645`, head `fb0505f7`; opened after
-  rebasing onto `main` at `810743d4`. Cloud checks are the active gate.
+- `#814` CLI `pulp pr` shellout coverage for `#643`, branch
+  `feature/cli-pr-coverage-643`, head `22ba6162`; opened after rebasing
+  onto `main` at `957a0735`. Cloud checks are the active gate.
 
 Local Phase 3 draft worktrees:
 
@@ -240,8 +246,9 @@ Local Phase 3 draft worktrees:
   report, and version-bump report.
 - `#645` signal dynamics helper worktree
   `/Users/danielraffel/Code/pulp-signal-dynamics-coverage-645`, branch
-  `feature/signal-dynamics-coverage-645`, commit `fb0505f7`; open as PR
-  `#813`. Scope: test-only coverage for `DryWetMixer` mix
+  `feature/signal-dynamics-coverage-645`, commit `fb0505f7`; merged via
+  PR `#813` as `957a0735`. The remote branch was deleted after merge.
+  Scope: test-only coverage for `DryWetMixer` mix
   clamping/equal-power/latency/reset paths, `Compressor`
   hard-knee/soft-knee/buffer/reset paths, `Limiter` buffer/reset paths,
   `WindowFunction` hamming/flat-top/kaiser branches, and
@@ -253,14 +260,24 @@ Local Phase 3 draft worktrees:
   assertions in `20` cases, full signal binary passed `885` assertions
   in `67` cases, focused CTest passed `23/23`, `git diff --check`,
   skill-sync report, and version-bump report.
+- `#643` CLI `pulp pr` shellout worktree
+  `/Users/danielraffel/Code/pulp-cli-pr-coverage-643`, branch
+  `feature/cli-pr-coverage-643`, commit `22ba6162`; open as PR `#814`.
+  Scope: shellout coverage for missing-Shipyard install guidance,
+  native fallback help, outside-project refusal, and POSIX delegation to
+  a fake `shipyard pr` executable without invoking real Shipyard. Local
+  validation: no-GPU/no-examples configure, `pulp-test-cli-shellout`
+  build, direct `[cli][shellout][pr][issue-643]` passed `18` assertions
+  in `4` cases, focused CTest `pulp pr` passed `7/7`,
+  `git diff --check`, skill-sync report, and version-bump report.
 
 Open supporting PR:
 
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#811` merged,
-  updated after `#813` opened, and remains docs-only.
+  The branch has been rebased onto `origin/main` after `#813` merged,
+  updated after `#814` opened, and remains docs-only.
 
 Local environment note:
 
@@ -273,10 +290,10 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Let the `main` Coverage run for `810743d4` complete, then refresh the
+2. Let the `main` Coverage run for `957a0735` complete, then refresh the
    Codecov baseline if it changes the execution order materially.
-3. Monitor `#813` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-signal-dynamics-coverage-645`, patch,
+3. Monitor `#814` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-cli-pr-coverage-643`, patch,
    validate locally, and push with lease.
 4. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 20:04 EDT
+Last reviewed: 2026-04-26 20:22 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -191,6 +191,10 @@ Open Phase 3 PRs:
   `feature/events-loop-coverage-642`, head `ee3894cb`; opened from
   `main` at `87ef6d90`. This tranche also uses the GitHub/Namespace
   path while the SSH `windows` target remains unreachable.
+- `#835` CLI ship command validation coverage for `#643`, branch
+  `feature/cli-ship-coverage-643`, head `6c1e5a4b`; opened from
+  `main` at `5b8e4529`. This tranche also uses the GitHub/Namespace
+  path while the SSH `windows` target remains unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -328,6 +332,21 @@ Local Phase 3 draft worktrees:
   single failed cloud case passed `3` assertions in `1` case after the
   fix, focused CTest `pulp pr` passed `7/7`, `git diff --check`,
   skill-sync report, and version-bump report.
+- `#643` CLI ship command validation worktree
+  `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, branch
+  `feature/cli-ship-coverage-643`, commit `6c1e5a4b`; open as PR
+  `#835`.
+  Scope: test-only `pulp ship` shellout coverage for fake project roots
+  with missing build-cache guidance, Android signing/package/check
+  validation before external tools run, appcast feed generation, and
+  remote `--sign-key` rejection without real signing material. Local
+  validation after rebasing onto `5b8e4529`: no-GPU/no-examples
+  configure, `pulp-test-cli-ship-shellout` build, direct `[issue-643]`
+  run passed `3` assertions in `3` cases, full binary passed `10`
+  assertions in `10` cases, focused CTest `pulp ship` passed `10/10`,
+  `git diff --check HEAD~1..HEAD`, `git diff --check`, skill-sync
+  report, and version-bump report with `Version-Bump: sdk=skip` for
+  the test-only coverage tranche.
 - `#645` MPE tracker worktree
   `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, branch
   `feature/mpe-tracker-coverage-645`, commit `b7c72711`; merged via PR
@@ -660,7 +679,7 @@ Open supporting PR:
   and `#833` opened, and `#829` was rebased onto `87ef6d90` to pick up
   the merged Android SDK discovery fix, and `#832` was rebased/repaired
   for the Windows fast-exit command, and `#834` opened, and `#828`
-  merged, and remains docs-only.
+  merged, and `#835` opened, and remains docs-only.
 
 Local environment note:
 
@@ -697,10 +716,13 @@ Next recovery actions:
 7. Monitor `#834` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-events-loop-coverage-642`, patch,
    validate locally, and push with lease.
-8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+8. Monitor `#835` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
+   validate locally, and push with lease.
+9. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-9. Continue Phase 3 from the tranche issues below, prioritizing
+10. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 16:04 EDT
+Last reviewed: 2026-04-26 16:08 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -141,14 +141,10 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#810` platform Environment diff-edge coverage -> `f712702a`
 - `#811` CLI project-command dispatch coverage -> `810743d4`
 - `#813` signal dynamics helper coverage -> `957a0735`
+- `#814` CLI `pulp pr` shellout coverage -> `8bd4a3e9`
 
 Open Phase 3 PRs:
 
-- `#814` CLI `pulp pr` shellout coverage for `#643`, branch
-  `feature/cli-pr-coverage-643`, head `615bd756`; opened after rebasing
-  onto `main` at `957a0735`. The Linux Namespace cwd-sensitive shellout
-  failure was patched by resolving the CLI binary before the test changes
-  cwd; cloud checks are rerunning from the new head.
 - `#815` MPE tracker edge-path coverage for `#645`, branch
   `feature/mpe-tracker-coverage-645`, head `b7c72711`; opened from
   `main` at `957a0735`. Windows coverage failed during dependency
@@ -282,7 +278,8 @@ Local Phase 3 draft worktrees:
   skill-sync report, and version-bump report.
 - `#643` CLI `pulp pr` shellout worktree
   `/Users/danielraffel/Code/pulp-cli-pr-coverage-643`, branch
-  `feature/cli-pr-coverage-643`, commit `615bd756`; open as PR `#814`.
+  `feature/cli-pr-coverage-643`, commit `615bd756`; merged via PR
+  `#814` as `8bd4a3e9`. The remote branch was deleted after merge.
   Scope: shellout coverage for missing-Shipyard install guidance,
   native fallback help, outside-project refusal, and POSIX delegation to
   a fake `shipyard pr` executable without invoking real Shipyard. Follow-
@@ -354,7 +351,7 @@ Open supporting PR:
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#813` merged,
-  updated after `#814` opened, and remains docs-only.
+  updated after `#814` merged, and remains docs-only.
 
 Local environment note:
 
@@ -373,27 +370,24 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#814` cloud checks from head `615bd756`; if a required lane
-   fails, debug in `/Users/danielraffel/Code/pulp-cli-pr-coverage-643`,
-   patch, validate locally, and push with lease.
-3. Monitor `#815` cloud checks; if a required lane fails, debug in
+2. Monitor `#815` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-mpe-tracker-coverage-645`, patch,
    validate locally, and push with lease. The current Windows coverage
    failure was rerun in run `24965100026`; wait for that rerun result
    before changing code.
-4. Monitor `#816` cloud checks; if a required lane fails, debug in
+3. Monitor `#816` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-running-status-coverage-645`,
    patch, validate locally, and push with lease.
-5. Monitor `#817` cloud checks; if a required lane fails, debug in
+4. Monitor `#817` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-ump-conversion-coverage-645`,
    patch, validate locally, and push with lease.
-6. Monitor `#818` cloud checks; if a required lane fails, debug in
+5. Monitor `#818` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-synth-voice-coverage-645`,
    patch, validate locally, and push with lease.
-7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-8. Continue Phase 3 from the tranche issues below, prioritizing
+7. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 20:47 EDT
+Last reviewed: 2026-04-26 20:50 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -188,12 +188,14 @@ Open Phase 3 PRs:
   `main` at `87ef6d90`. This tranche also uses the GitHub/Namespace
   path while the SSH `windows` target remains unreachable.
 - `#835` CLI ship command validation coverage for `#643`, branch
-  `feature/cli-ship-coverage-643`, head `5ef39944`; opened from
+  `feature/cli-ship-coverage-643`, head `b8f22af9`; opened from
   `main` at `5b8e4529`, then rebased onto `b5e7a463` and updated after
   Linux Namespace exposed that the Android validation test created
-  `artifacts/` before asserting the missing-artifacts check path. This
-  tranche also uses the GitHub/Namespace path while the SSH `windows`
-  target remains unreachable.
+  `artifacts/` before asserting the missing-artifacts check path. It was
+  updated again to isolate Android signing config via a scratch
+  `PULP_HOME` and cleared password env vars. This tranche also uses the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
 - `#836` CLI sync checker coverage for `#643`, branch
   `feature/cli-sync-coverage-643`, head `86048a3f`; opened from
   `main` at `5b8e4529`. This tranche also uses the GitHub/Namespace
@@ -346,7 +348,7 @@ Local Phase 3 draft worktrees:
   skill-sync report, and version-bump report.
 - `#643` CLI ship command validation worktree
   `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, branch
-  `feature/cli-ship-coverage-643`, commit `5ef39944`; open as PR
+  `feature/cli-ship-coverage-643`, commit `b8f22af9`; open as PR
   `#835`.
   Scope: test-only `pulp ship` shellout coverage for fake project roots
   with missing build-cache guidance, Android signing/package/check
@@ -354,7 +356,10 @@ Local Phase 3 draft worktrees:
   remote `--sign-key` rejection without real signing material. The
   follow-up commit moves the Android `ship check --target android`
   missing-artifacts assertion before package probes create `artifacts/`
-  as part of their validation path. Local validation after rebasing onto
+  as part of their validation path. The second follow-up sets `PULP_HOME`
+  to a scratch directory and clears Android password env vars before
+  asserting the missing-keystore branch, so the test is not affected by a
+  developer or runner config file. Local validation after rebasing onto
   `5b8e4529`: no-GPU/no-examples
   configure, `pulp-test-cli-ship-shellout` build, direct `[issue-643]`
   run passed `3` assertions in `3` cases, full binary passed `10`
@@ -362,10 +367,12 @@ Local Phase 3 draft worktrees:
   `git diff --check HEAD~1..HEAD`, `git diff --check`, skill-sync
   report, and version-bump report with `Version-Bump: sdk=skip` for
   the test-only coverage tranche. Follow-up validation after rebasing
-  onto `b5e7a463` used a real built CLI path and passed the focused
-  Android validation test with `12` assertions, the `[issue-643]` slice
-  with `25` assertions in `3` cases, the full binary with `45`
-  assertions in `10` cases, diff check, and pre-push gates.
+  onto `b5e7a463` and applying both follow-ups used a real built CLI path
+  and passed the focused Android validation test with `12` assertions,
+  the `[issue-643]` slice with `25` assertions in `3` cases, the full
+  binary with `45` assertions in `10` cases, diff check, and pre-push
+  gates. The two Codex review threads on the ordering/config isolation
+  issues were resolved.
 - `#643` CLI sync checker worktree
   `/Users/danielraffel/Code/pulp-cli-sync-coverage-643`, branch
   `feature/cli-sync-coverage-643`, commit `86048a3f`; open as PR
@@ -744,7 +751,8 @@ Open supporting PR:
   for the Windows fast-exit command, and `#834` opened, and `#828`
   merged, and `#835` opened, and `#836` opened, and `#837` opened, and
   `#831` merged, and `#838` opened, and `#835` was repaired for Linux
-  Android-validation ordering, and remains docs-only.
+  Android-validation ordering plus config isolation, and remains
+  docs-only.
 
 Local environment note:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -67,14 +67,32 @@ Finish line:
 
 Latest complete Codecov `main` report observed while updating this doc:
 
-- commit: `b4edebe046fdf2886891016fff4158a195ee7fbd`
-- workflow: Coverage run `24925413069`, completed successfully
-- overall tracked coverage: `43.28%` over `70,175` lines in `556` files
-- covered lines: `30,372`
-- note: `origin/main` is currently `a80929c42ff61b88cd366383baad2ee817558b57`.
-  Coverage and sanitizer workflows for that head are still in progress, so
-  Codecov's latest complete `main` report is still the older executable-code
-  baseline above until the new `main` Coverage run completes.
+- commit: `a80929c42ff61b88cd366383baad2ee817558b57`
+- workflow: Coverage run `24926536334`, completed successfully
+- overall tracked coverage: `43.27%` over `70,197` lines in `556` files
+- covered lines: `30,376`
+- current component coverage from the Codecov API:
+  - `audio`: `25.57%`
+  - `canvas`: `66.77%`
+  - `dsl`: `63.38%`
+  - `events`: `30.24%`
+  - `format`: `47.92%`
+  - `host`: `37.43%`
+  - `midi`: `50.14%`
+  - `osc`: `62.22%`
+  - `platform`: `52.06%`
+  - `render`: `56.68%`
+  - `runtime`: `51.69%`
+  - `signal`: `66.03%`
+  - `state`: `65.70%`
+  - `view`: `43.71%`
+  - `android`: `13.83%`
+  - `apple`: `25.36%`
+  - `linux`: `7.07%`
+  - `windows`: `10.67%`
+  - `cli`: `32.10%`
+  - `ship`: `34.44%`
+  - `tools`: `39.46%`
 
 Merged after the Phase 1 closeout / `#723` baseline:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 13:54 EDT
+Last reviewed: 2026-04-26 14:13 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -135,23 +135,13 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#807` audio ChannelSet helper coverage -> `46e0fdeb`
 - `#808` MIDI file edge round-trip coverage -> `aae5d5d0`
 - `#809` signal FFT/convolver helper coverage -> `453bcec8`
+- `#810` platform Environment diff-edge coverage -> `f712702a`
 
 Open Phase 3 PRs:
 
-- `#810` `test(platform): cover environment diff edges`, branch
-  `feature/platform-environment-coverage-640`, commit `bc1e96af`,
-  worktree `/Users/danielraffel/Code/pulp-platform-environment-coverage-640`.
-  Scope: test-only platform `Environment` coverage for inert empty
-  listener subscriptions, token move-assignment replacement, keyboard
-  animation-duration diffs, left/right safe-area diffs, display
-  physical/name/refresh metadata diffs, and isolated orientation/lifecycle
-  changes. Local validation after rebasing onto `main` at `453bcec8`:
-  `pulp-test-environment` target build, direct Catch2 selector
-  `[environment][issue-640]` passed with `32` assertions in `5` test
-  cases, focused CTest `Environment` passed `16/16`, `git diff --check`
-  clean, skill sync clean, and version bump report says no bump needed.
-  The PR is labeled `codecov` and is using the direct GitHub/Namespace
-  path.
+- None currently open after `#810` merged. The next ready Phase 3
+  candidate is the local-only `#643` CLI project-command draft at
+  `3a2820bb`, recorded below.
 
 Local Phase 3 draft worktrees:
 
@@ -223,7 +213,8 @@ Local Phase 3 draft worktrees:
 - `#640` platform Environment diff-edge worktree
   `/Users/danielraffel/Code/pulp-platform-environment-coverage-640`,
   branch `feature/platform-environment-coverage-640`, commit
-  `bc1e96af`; open as PR `#810`.
+  `bc1e96af`; merged via PR `#810` as `f712702a`. The remote branch was
+  deleted after merge.
 - `#645` MIDI file edge round-trip worktree
   `/Users/danielraffel/Code/pulp-midi-file-coverage-645`, branch
   `feature/midi-file-coverage-645`, commit `d02e853e`; merged via PR
@@ -235,7 +226,7 @@ Local Phase 3 draft worktrees:
 - `#643` CLI project-command dispatch worktree
   `/Users/danielraffel/Code/pulp-cli-project-coverage-643`, branch
   `feature/cli-project-coverage-643`, commit `3a2820bb`; local-only
-  draft, not opened as a PR yet while `#810` and `#774` drain. Scope:
+  draft, not opened as a PR yet while `#774` drains. Scope:
   direct `cmd_project.cpp` coverage for top-level help/no-arg/unknown
   dispatch, bump option parsing, `--all` empty-registry handling,
   registry-backed `--all --dry-run` reporting without undo files, a
@@ -252,7 +243,7 @@ Open supporting PR:
 - `#774` refreshes this durable handoff/status document, branch
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
-  The branch has been rebased onto `origin/main` after `#809` merged and
+  The branch has been rebased onto `origin/main` after `#810` merged and
   remains docs-only.
 
 Local environment note:
@@ -266,8 +257,9 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#810`
-   and address any Codecov, build, sanitizer, or Namespace feedback.
+2. When ready to add the next active code tranche, push/open local
+   `#643` branch `feature/cli-project-coverage-643` from
+   `/Users/danielraffel/Code/pulp-cli-project-coverage-643`.
 3. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 16:15 EDT
+Last reviewed: 2026-04-26 16:20 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -158,6 +158,11 @@ Open Phase 3 PRs:
 - `#818` MPE synth voice / allocator edge coverage for `#645`, branch
   `feature/midi-mpe-synth-voice-coverage-645`, head `21eb74e1`; opened
   from `main` at `957a0735`. This tranche is also using the
+  GitHub/Namespace path while the SSH `windows` target remains
+  unreachable.
+- `#819` MIDI keyboard/sequence edge coverage for `#645`, branch
+  `feature/midi-keyboard-sequence-coverage-645`, head `60676709`;
+  opened from `main` at `019130bd`. This tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
 
@@ -339,6 +344,23 @@ Local Phase 3 draft worktrees:
   binary passed `75` assertions in `12` cases, focused CTest passed
   `12/12`, `git diff --check`, skill-sync report, and version-bump
   report.
+- `#645` MIDI keyboard/sequence worktree
+  `/Users/danielraffel/Code/pulp-midi-keyboard-sequence-coverage-645`,
+  branch `feature/midi-keyboard-sequence-coverage-645`, commit
+  `60676709`; open as PR `#819`.
+  Scope: test-only coverage for `MidiKeyboardState` invalid queries,
+  ignored non-note events, release callbacks, and retrigger velocity
+  updates; plus `MidiMessageSequence` helper field masking,
+  classifier aliases, zero-velocity note-on note-off behavior,
+  channel-specific note-off lookup, range boundaries, timestamp offsets,
+  iteration, duration, and clear behavior. Local validation:
+  no-GPU/no-examples configure, `pulp-test-midi-expansion` and
+  `pulp-test-v3-gaps` build, direct `[midi][keyboard][issue-645]`
+  passed `19` assertions in `3` cases, direct
+  `[midi][sequence][issue-645]` passed `39` assertions in `3` cases,
+  full binaries passed `51` assertions in `20` cases and `94`
+  assertions in `24` cases, focused CTest passed `20/20`,
+  `git diff --check`, skill-sync report, and version-bump report.
 
 Open supporting PR:
 
@@ -346,7 +368,7 @@ Open supporting PR:
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#813` merged,
-  updated after `#814` merged, and remains docs-only.
+  updated after `#815` merged and `#819` opened, and remains docs-only.
 
 Local environment note:
 
@@ -374,10 +396,13 @@ Next recovery actions:
 4. Monitor `#818` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-synth-voice-coverage-645`,
    patch, validate locally, and push with lease.
-5. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+5. Monitor `#819` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-midi-keyboard-sequence-coverage-645`,
+   patch, validate locally, and push with lease.
+6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-6. Continue Phase 3 from the tranche issues below, prioritizing
+7. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 21:29 EDT
+Last reviewed: 2026-04-26 21:31 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -66,7 +66,7 @@ Finish line:
 ## Current live state
 
 Latest complete Codecov `main` report observed while updating this doc
-(`main` head `d02c9ec9` has a newer Coverage run queued):
+(`main` head `455c0a9d` has a newer Coverage run queued):
 
 - commit: `5b8e4529cfc553fd98b65f265ed1e9c0487b3d66`
 - workflow: Coverage run `24970413173`, completed successfully
@@ -161,6 +161,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#836` CLI sync checker Python tooling coverage -> `6ef8ca8b`
 - `#837` package registry validation tools coverage -> `bdc406cc`
 - `#830` RPN parser edge coverage -> `d02c9ec9`
+- `#834` events event-loop lifecycle edge coverage -> `455c0a9d`
 
 Open Phase 3 PRs:
 
@@ -186,10 +187,6 @@ Open Phase 3 PRs:
   lane failed in the already-fixed Android SDK discovery regression
   from the stale base. This tranche also uses the GitHub/Namespace path
   while the SSH `windows` target remains unreachable.
-- `#834` events event-loop lifecycle edge coverage for `#642`, branch
-  `feature/events-loop-coverage-642`, head `ee3894cb`; opened from
-  `main` at `87ef6d90`. This tranche also uses the GitHub/Namespace
-  path while the SSH `windows` target remains unreachable.
 - `#835` CLI ship command validation coverage for `#643`, branch
   `feature/cli-ship-coverage-643`, head `b8f22af9`; opened from
   `main` at `5b8e4529`, then rebased onto `b5e7a463` and updated after
@@ -224,8 +221,8 @@ Local Phase 3 draft worktrees:
   `#795` as `f1a5aa84`. The remote branch was deleted after merge.
 - `#642` events event-loop lifecycle worktree
   `/Users/danielraffel/Code/pulp-events-loop-coverage-642`, branch
-  `feature/events-loop-coverage-642`, commit `ee3894cb`; open as PR
-  `#834`.
+  `feature/events-loop-coverage-642`, commit `ee3894cb`; merged via PR
+  `#834` as `455c0a9d`. The remote branch was deleted after merge.
   Scope: test-only coverage for `EventLoop` thread identity, explicit
   stop and idempotent stop state, delayed work dropped after stop,
   multiple delayed tasks, plus `Timer` interval getter/setter and
@@ -801,7 +798,7 @@ Open supporting PR:
   onto `b5e7a463` to clear the stale Android SDK discovery ASan failure,
   and `#836` merged, and `#837` merged, and `#839` opened,
   and `#830` merged, and `#838` was rebased onto `d02c9ec9` and repaired
-  for the Android package parallel temp-dir collision,
+  for the Android package parallel temp-dir collision, and `#834` merged,
   and remains docs-only.
 
 Local environment note:
@@ -830,22 +827,19 @@ Next recovery actions:
 4. Monitor `#833` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, patch,
    validate locally, and push with lease.
-5. Monitor `#834` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-events-loop-coverage-642`, patch,
-   validate locally, and push with lease.
-6. Monitor `#835` cloud checks; if a required lane fails, debug in
+5. Monitor `#835` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
    validate locally, and push with lease.
-7. Monitor `#838` cloud checks on head `09666f46`; if a required lane fails, debug in
+6. Monitor `#838` cloud checks on head `09666f46`; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, patch,
    validate locally, and push with lease.
-8. Monitor `#839` cloud checks; if a required lane fails, debug in
+7. Monitor `#839` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-render-gpu-graph-coverage-646`,
    patch, validate locally, and push with lease.
-9. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-10. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 19:44 EDT
+Last reviewed: 2026-04-25 19:52 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -167,6 +167,14 @@ Open supporting PR:
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#789` merged and
   remains docs-only.
+
+Local environment note:
+
+- Pulp's Shipyard source pin is `v0.46.0` in `tools/shipyard.toml`
+  and the release workflows. On 2026-04-25, PATH had drifted to
+  `shipyard, version 0.50.0`; rerunning `./tools/install-shipyard.sh`
+  restored the pinned binary, and `shipyard --version` prints
+  `shipyard, version 0.46.0`.
 
 Next recovery actions:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 17:54 EDT
+Last reviewed: 2026-04-26 18:03 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -173,6 +173,10 @@ Open Phase 3 PRs:
   from `main` at `7a646f33`. This tranche also uses the
   GitHub/Namespace path while the SSH `windows` target remains
   unreachable.
+- `#826` OGG reader edge coverage for `#640`, branch
+  `feature/audio-ogg-reader-coverage-640`, head `6b721c22`; opened from
+  `main` at `1a1b7f07`. This tranche also uses the GitHub/Namespace path
+  while the SSH `windows` target remains unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -483,6 +487,19 @@ Local Phase 3 draft worktrees:
   full binaries passed `2927` assertions in `23` cases and `75`
   assertions in `34` cases, focused CTest passed `7/7`,
   `git diff --check`, skill-sync report, and version-bump report.
+- `#640` OGG reader worktree
+  `/Users/danielraffel/Code/pulp-audio-ogg-reader-coverage-640`,
+  branch `feature/audio-ogg-reader-coverage-640`, commit `6b721c22`;
+  open as PR `#826`.
+  Scope: dedicated `pulp-test-ogg-reader` target covering direct OGG
+  reader factory construction, `.ogg` / `.oga` extension support,
+  unsupported extension behavior, format-name reporting, and
+  missing/malformed input failure paths. This intentionally avoids
+  `test_audio_file.cpp` while `#822` is open. Local validation:
+  no-GPU/no-examples configure, `pulp-test-ogg-reader` build, direct
+  `[audio][ogg][issue-640]` run passed `12` assertions in `2` cases,
+  full binary passed `12` assertions in `2` cases, focused CTest passed
+  `2/2`, `git diff --check`, skill-sync report, and version-bump report.
 
 Open supporting PR:
 
@@ -493,7 +510,8 @@ Open supporting PR:
   updated after `#816` merged, `#817` was repaired, `#820` opened,
   `#821` opened, `#822` opened, `#818` merged, `#823` opened, `#817`
   merged, `#822` was repaired, `#824` opened, `#821` merged, and `#819`
-  merged, `#825` opened, and `#820` merged, and remains docs-only.
+  merged, `#825` opened, `#820` merged, and `#826` opened, and remains
+  docs-only.
 
 Local environment note:
 
@@ -524,10 +542,13 @@ Next recovery actions:
 5. Monitor `#825` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-dsp-helper-coverage-645`,
    patch, validate locally, and push with lease.
-6. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+6. Monitor `#826` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-audio-ogg-reader-coverage-640`,
+   patch, validate locally, and push with lease.
+7. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.
-7. Continue Phase 3 from the tranche issues below, prioritizing
+8. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 21:08 EDT
+Last reviewed: 2026-04-25 21:14 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -122,27 +122,25 @@ Merged after the Phase 1 closeout / `#723` baseline:
 
 Open Phase 3 PRs:
 
-- None at this checkpoint. The next planned Phase 3 PR is the local
-  `#643` package-registry CLI/tools draft below.
-
-Local Phase 3 draft not yet opened as a PR:
-- `#643` package-registry CLI/tools draft, worktree
-  `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
-  `feature/package-registry-coverage-643`, local commit `75a529ef`.
-  This draft was rebased onto `origin/main` at
-  `23d3ed1d9dca9b39e3e7f3a851698eb93c717ae6` after `#788` merged.
-  Current scope adds
+- `#793` package-registry CLI/tools coverage, branch
+  `feature/package-registry-coverage-643`, head `75a529ef`. This is the
+  `#643` tranche opened by `shipyard pr` after `#788` merged. Scope:
   `pulp-test-cli-package-registry` for pure local registry parsing,
   lock-file round trips, target TOML parsing/writing, semver, quality
-  scoring, unsupported-target detection, and search ranking. Local validation
-  is green after the latest rebase: configure
-  `cmake -S . -B build-package-registry-localdeps -DCMAKE_BUILD_TYPE=Debug
-  -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF
-  -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=$PWD/build/_deps/mbedtls-src`, build
-  `cmake --build build-package-registry-localdeps --target
-  pulp-test-cli-package-registry -j4`, direct binary (`88` assertions / `5`
-  test cases), focused CTest (`5/5`), whitespace, and
-  `version_bump_check.py --mode=report`.
+  scoring, unsupported-target detection, and search ranking. Local
+  validation after rebasing onto `origin/main` at `23d3ed1d` is green:
+  build `pulp-test-cli-package-registry`, direct binary (`88`
+  assertions / `5` test cases), focused CTest (`5/5`), whitespace, and
+  `version_bump_check.py --mode=report`. Shipyard validation and GitHub
+  checks are running.
+
+Local Phase 3 draft worktrees:
+
+- `#643` package-registry CLI/tools worktree
+  `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
+  `feature/package-registry-coverage-643`, commit `75a529ef`; now backs
+  open PR `#793`. Do not edit this worktree while `shipyard pr` is still
+  validating it.
 
 Open supporting PR:
 
@@ -165,8 +163,8 @@ Next recovery actions:
 1. Let main Coverage run `24944888062` for `23d3ed1d` drain, then refresh
    this section with the next complete Codecov `main` report.
 2. Keep `#774` docs-only and let its post-`#788` rebase checks drain.
-3. Push/open the rebased and locally validated `#643` draft (`75a529ef`)
-   as the next CLI/tools tranche PR.
+3. Monitor `#793`; Shipyard is validating the PR and GitHub workflows are
+   running.
 4. If a new PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
 5. Continue Phase 3 from the tranche issues below, prioritizing

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -92,7 +92,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#771` WidgetBridge extended-controls coverage, branch
-  `feature/widget-bridge-coverage-493`, head `b51a48b5`. Local
+  `feature/widget-bridge-coverage-493`, head `13f1be94`. Local
   `pulp-test-widget-bridge`, focused CTest, GPU-off configure/build of
   `pulp-test-cli-project-command`, skill sync, version report, and
   whitespace checks are green. The branch now carries three shared CI
@@ -102,13 +102,11 @@ Open Phase 3 PRs:
   `examples/ui-preview`. The branch also carries the sandbox-e2e
   unblocker that makes `pulp upgrade --check-only` honor
   `PULP_UPDATE_CHECK_DISABLED=1` without hitting GitHub Releases when the
-  update cache is empty. GitHub Actions at `b51a48b5` is draining; early
-  docs, audit, version/skill sync, provider resolution, Android coverage,
-  Linux Namespace, and Codecov patch checks are green, while sandbox-e2e,
-  remaining Namespace/coverage, Windows MSVC, IWYU, and sanitizer lanes
-  continue.
+  update cache is empty, plus the shellout test covering that path so the
+  diff-coverage gate sees those lines. GitHub Actions is rerunning at
+  `13f1be94`.
 - `#777` real CLAP `PluginSlot` coverage, branch
-  `feature/clap-slot-coverage-493`, head `753bcccf`. This tranche wires
+  `feature/clap-slot-coverage-493`, head `83e9f9be`. This tranche wires
   the built PulpGain CLAP bundle into host tests after examples are
   registered, adds metadata/defaults, bypass/release, and restore-state
   coverage, and fixes CLAP state restore so restored plugin state
@@ -118,13 +116,16 @@ Open Phase 3 PRs:
   before `#771` lands. Local configure/build,
   `pulp-test-host "[host][slot][clap]"` (`139` assertions / `4` test
   cases), generated `ClapSlot` CTest entries, whitespace, CI-configured
-  skill-sync, direct disabled-upgrade smoke, and version checks are green.
-  GitHub Actions is rerunning at `753bcccf`; early docs, audit,
-  version/skill sync, provider checks, Android coverage, and docs preview
-  are green while sandbox-e2e, IWYU, Namespace, coverage, Windows MSVC,
-  Android build, and sanitizer lanes drain.
+  skill-sync, direct disabled-upgrade smoke, focused CLI shellout coverage
+  for `PULP_UPDATE_CHECK_DISABLED`, and version checks are green. The
+  previous `753bcccf` rerun exposed two blockers: Windows Namespace failed
+  but logs were still unavailable while the run continued, and the required
+  diff-coverage gate reported `63%` because the shared
+  `cmd_upgrade.cpp` disabled-update branch was uncovered. The new head
+  adds the shellout coverage test for that path and is rerunning at
+  `83e9f9be`.
 - `#782` VST3 adapter process-path coverage, branch
-  `feature/vst3-adapter-coverage-493`, head `8e9caaa7`. This tranche adds
+  `feature/vst3-adapter-coverage-493`, head `f09adb04`. This tranche adds
   focused VST3 adapter coverage for parameter metadata, setup/release lifecycle,
   bus/event/process routing, sidechain visibility, secondary output zeroing,
   host input automation, plugin-to-host output automation, MIDI output, and
@@ -142,10 +143,11 @@ Open Phase 3 PRs:
   unblocker. Local GPU-off configure/build of
   `pulp-test-cli-project-command`, focused `pulp-test-vst3-plugin-state`
   (`118` assertions / `5` test cases), direct disabled-upgrade smoke,
+  focused CLI shellout coverage for `PULP_UPDATE_CHECK_DISABLED`,
   whitespace, skill-sync, and version checks are green. GitHub Actions is
-  rerunning at `8e9caaa7`.
+  rerunning at `f09adb04`.
 - `#786` render DirtyTracker / RenderLoop edge coverage, branch
-  `feature/render-coverage-646-next`, head `a9f4526a`. This tranche extends
+  `feature/render-coverage-646-next`, head `f7da209d`. This tranche extends
   the still-open `#646` render component follow-up after the earlier merged
   `#700` slice. Scope is intentionally pure and hostable: DirtyTracker
   negative/empty rects, debug overlay state, threshold accumulation,
@@ -156,12 +158,13 @@ Open Phase 3 PRs:
   `pulp-test-rendering-integration` (`71` assertions / `40` cases),
   focused CTest (`19/19`), GPU-off configure/build of
   `pulp-test-cli-project-command`, `pulp-cli` build, direct
-  disabled-upgrade smoke, skill/version checks, and whitespace. The branch
-  now carries the same shared GPU-off CMake, Windows-safe redirection,
-  `ui-preview` guard, and disabled-update-check fixes as the other active
-  Phase 3 tranches because IWYU exposed the GPU-off target-link failure
-  before any of those shared fixes had merged. GitHub Actions is draining
-  at `a9f4526a`.
+  disabled-upgrade smoke, focused CLI shellout coverage for
+  `PULP_UPDATE_CHECK_DISABLED`, skill/version checks, and whitespace. The
+  branch now carries the same shared GPU-off CMake, Windows-safe
+  redirection, `ui-preview` guard, disabled-update-check fix, and CLI
+  coverage test as the other active Phase 3 tranches because IWYU exposed
+  the GPU-off target-link failure before any of those shared fixes had
+  merged. GitHub Actions is rerunning at `f7da209d`.
 
 Open supporting PR:
 
@@ -176,9 +179,12 @@ Next recovery actions:
 
 1. Poll `#771`, `#774`, `#777`, `#782`, and `#786`; merge green PRs manually
    because auto-merge is disabled.
-2. Let the current `#771`, `#777`, and `#782` reruns drain after the
-   shared CI and sandbox-e2e unblockers were pushed.
-3. Let the new `#786` render coverage tranche drain at `a9f4526a`.
+2. Let the current `#771`, `#777`, `#782`, and `#786` reruns drain after
+   the shared CI, sandbox-e2e, and CLI diff-coverage unblockers were
+   pushed.
+3. If `#777` Windows Namespace fails again, pull the fresh completed-run
+   log first; the previous failed job's log was unavailable while the
+   overall run was still in progress.
 4. If sandbox-e2e fails again, pull the fresh log first; the expected
    failure fixed here was `pulp upgrade --check-only` ignoring
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 21:17 EDT
+Last reviewed: 2026-04-26 21:20 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -204,10 +204,10 @@ Open Phase 3 PRs:
   `main` at `b5e7a463`. This tranche also uses the GitHub/Namespace
   path while the SSH `windows` target remains unreachable.
 - `#839` GPU graph render helper hardening/coverage for `#646`, branch
-  `feature/render-gpu-graph-coverage-646`, head `c4261740`; opened
-  from `main` at `bdc406cc`. This tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
+  `feature/render-gpu-graph-coverage-646`, head `fa3deb3b`; opened
+  from `main` at `bdc406cc`, then rebased onto `d02c9ec9` after `#830`
+  merged. This tranche also uses the GitHub/Namespace path while the
+  SSH `windows` target remains unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -404,7 +404,7 @@ Local Phase 3 draft worktrees:
   this tranche.
 - `#646` GPU graph render helper worktree
   `/Users/danielraffel/Code/pulp-render-gpu-graph-coverage-646`,
-  branch `feature/render-gpu-graph-coverage-646`, commit `c4261740`;
+  branch `feature/render-gpu-graph-coverage-646`, commit `fa3deb3b`;
   open as PR `#839`.
   Scope: hardens `GpuGraphRenderer`, `GpuHeatMapRenderer`, and
   `GpuBarRenderer` raw-pointer `set_data()` paths for null, zero-sized,

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 14:42 EDT
+Last reviewed: 2026-04-26 14:44 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -140,9 +140,9 @@ Merged after the Phase 1 closeout / `#723` baseline:
 
 Open Phase 3 PRs:
 
-- None currently open after `#811` merged. The next ready Phase 3
-  candidate is the local-only `#645` signal dynamics helper draft at
-  `a43a305b`, recorded below.
+- `#813` signal dynamics helper coverage for `#645`, branch
+  `feature/signal-dynamics-coverage-645`, head `fb0505f7`; opened after
+  rebasing onto `main` at `810743d4`. Cloud checks are the active gate.
 
 Local Phase 3 draft worktrees:
 
@@ -240,9 +240,8 @@ Local Phase 3 draft worktrees:
   report, and version-bump report.
 - `#645` signal dynamics helper worktree
   `/Users/danielraffel/Code/pulp-signal-dynamics-coverage-645`, branch
-  `feature/signal-dynamics-coverage-645`, commit `a43a305b`;
-  local-only draft, not opened as a PR yet while `#774` drains. Scope:
-  test-only coverage for `DryWetMixer` mix
+  `feature/signal-dynamics-coverage-645`, commit `fb0505f7`; open as PR
+  `#813`. Scope: test-only coverage for `DryWetMixer` mix
   clamping/equal-power/latency/reset paths, `Compressor`
   hard-knee/soft-knee/buffer/reset paths, `Limiter` buffer/reset paths,
   `WindowFunction` hamming/flat-top/kaiser branches, and
@@ -261,8 +260,7 @@ Open supporting PR:
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
   The branch has been rebased onto `origin/main` after `#811` merged,
-  updated after the local `#645` signal dynamics draft was prepared, and
-  remains docs-only.
+  updated after `#813` opened, and remains docs-only.
 
 Local environment note:
 
@@ -277,9 +275,9 @@ Next recovery actions:
 1. Keep `#774` docs-only and let its latest status-update checks drain.
 2. Let the `main` Coverage run for `810743d4` complete, then refresh the
    Codecov baseline if it changes the execution order materially.
-3. Rebase/push/open the local `#645`
-   `feature/signal-dynamics-coverage-645` draft from
-   `/Users/danielraffel/Code/pulp-signal-dynamics-coverage-645`.
+3. Monitor `#813` cloud checks; if a required lane fails, debug in
+   `/Users/danielraffel/Code/pulp-signal-dynamics-coverage-645`, patch,
+   validate locally, and push with lease.
 4. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
    checks rerun.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -106,35 +106,18 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#756` validation harness edge coverage -> `22d1e69`
 - `#765` TextEditor multiline navigation coverage -> `7257a154`
 - `#766` OSC UDP sender/receiver edge coverage -> `31aa80e1`
+- `#771` WidgetBridge extended-controls coverage -> `3d03c0fe`
 
 Open Phase 3 PRs:
 
-- `#771` WidgetBridge extended-controls coverage, branch
-  `feature/widget-bridge-coverage-493`, head `45a146d5`. Local
-  `pulp-test-widget-bridge`, focused CTest, GPU-off configure/build of
-  `pulp-test-cli-project-command`, skill sync, version report, and
-  whitespace checks are green. The branch now carries three shared CI
-  unblockers discovered while validating this tranche: the GPU-off
-  `pulp-test-cli-project-command` CMake fix, Windows-safe CLI redirection
-  for `pulp project bump` probes, and a GPU/`pulp::inspect` guard around
-  `examples/ui-preview`. The branch also carries the sandbox-e2e
-  unblocker that makes `pulp upgrade --check-only` honor
-  `PULP_UPDATE_CHECK_DISABLED=1` without hitting GitHub Releases when the
-  update cache is empty, plus the shellout test covering that path so the
-  diff-coverage gate sees those lines. After `#782`/`#786` exposed shared
-  `cmd_project.cpp` diff-coverage misses, the branch also carries focused
-  project-bump probe tests for platform null redirection, non-standalone
-  `origin/main` fallback, and `--verify-builds`. GitHub Actions is rerunning
-  at `45a146d5`; no completed failures were visible at the last poll.
 - `#777` real CLAP `PluginSlot` coverage, branch
-  `feature/clap-slot-coverage-493`, head `f9be330c`. This tranche wires
+  `feature/clap-slot-coverage-493`, head `f5f6f47a`. This tranche wires
   the built PulpGain CLAP bundle into host tests after examples are
   registered, adds metadata/defaults, bypass/release, and restore-state
   coverage, and fixes CLAP state restore so restored plugin state
-  supersedes stale cached host edits. The branch has been rebased onto
-  `origin/main` and now carries the same GPU-off CMake, Windows-safe CLI
-  redirection, `ui-preview` guard, and disabled-update-check fixes needed
-  before `#771` lands. Local configure/build,
+  supersedes stale cached host edits. After `#771` merged, this branch was
+  rebased onto `origin/main` and duplicate shared support commits were
+  skipped. Local configure/build,
   `pulp-test-host "[host][slot][clap]"` (`139` assertions / `4` test
   cases), generated `ClapSlot` CTest entries, whitespace, CI-configured
   skill-sync, direct disabled-upgrade smoke, focused CLI shellout coverage
@@ -146,10 +129,10 @@ Open Phase 3 PRs:
   and adds tests for the affected paths. The previous diff-coverage failure
   at `753bcccf` (`63%`) was the shared disabled-update branch in
   `cmd_upgrade.cpp`; that is covered by the shellout test now present on all
-  active coverage branches. GitHub Actions is rerunning at `f9be330c`; no
+  active coverage branches. GitHub Actions is rerunning at `f5f6f47a`; no
   completed failures were visible at the last poll.
 - `#782` VST3 adapter process-path coverage, branch
-  `feature/vst3-adapter-coverage-493`, head `0fd5f83c`. This tranche adds
+  `feature/vst3-adapter-coverage-493`, head `c182ee21`. This tranche adds
   focused VST3 adapter coverage for parameter metadata, setup/release lifecycle,
   bus/event/process routing, sidechain visibility, secondary output zeroing,
   host input automation, plugin-to-host output automation, MIDI output, and
@@ -161,10 +144,9 @@ Open Phase 3 PRs:
   treated separately from the unit coverage tranche unless it reproduces in
   CI. The PR is labeled `codecov`. Shipyard local/SSH validation at
   `bc23956d` passed mac and ubuntu, then hit a Windows SSH bundle-upload
-  timeout during banner exchange. The branch now carries the same shared
-  GPU-off CMake, Windows-safe redirection, skill-doc, and `ui-preview`
-  guard fixes as `#771`, plus the disabled-update-check sandbox-e2e
-  unblocker. Local GPU-off configure/build of
+  timeout during banner exchange. After `#771` merged, this branch was rebased
+  onto `origin/main` and duplicate shared support commits were skipped. Local
+  GPU-off configure/build of
   `pulp-test-cli-project-command`, focused `pulp-test-vst3-plugin-state`
   (`118` assertions / `5` test cases), direct disabled-upgrade smoke,
   focused CLI shellout coverage for `PULP_UPDATE_CHECK_DISABLED`,
@@ -173,14 +155,14 @@ Open Phase 3 PRs:
   green. The `f09adb04` rerun failed the required diff-coverage gate because
   the shared `cmd_project.cpp` support commit left Windows helper returns,
   non-standalone `origin/main` fallback, and `--verify-builds` lines uncovered;
-  `dcad28de` adds direct coverage for those lines. A later automated review
+  that shared coverage is now on `main` via `#771`. A later automated review
   correctly noted that the process-context test set a tempo value without
-  setting VST3's `kTempoValid` bit; `0fd5f83c` fixes that test validity flag,
-  with local `pulp-test-vst3-plugin-state` still green (`118` assertions / `5`
-  test cases). GitHub Actions is rerunning at `0fd5f83c`; no completed failures
-  were visible at the last poll.
+  setting VST3's `kTempoValid` bit; `c182ee21` includes that test validity
+  flag, with local `pulp-test-vst3-plugin-state` still green (`118`
+  assertions / `5` test cases). GitHub Actions is rerunning at `c182ee21`; no
+  completed failures were visible at the last poll.
 - `#786` render DirtyTracker / RenderLoop edge coverage, branch
-  `feature/render-coverage-646-next`, head `54d209d5`. This tranche extends
+  `feature/render-coverage-646-next`, head `49983137`. This tranche extends
   the still-open `#646` render component follow-up after the earlier merged
   `#700` slice. Scope is intentionally pure and hostable: DirtyTracker
   negative/empty rects, debug overlay state, threshold accumulation,
@@ -192,27 +174,25 @@ Open Phase 3 PRs:
   focused CTest (`19/19`), GPU-off configure/build of
   `pulp-test-cli-project-command`, `pulp-cli` build, direct
   disabled-upgrade smoke, focused CLI shellout coverage for
-  `PULP_UPDATE_CHECK_DISABLED`, skill/version checks, and whitespace. The
-  branch now carries the same shared GPU-off CMake, Windows-safe
-  redirection, `ui-preview` guard, disabled-update-check fix, and CLI
-  coverage test as the other active Phase 3 tranches because IWYU exposed
-  the GPU-off target-link failure before any of those shared fixes had
-  merged. The `f7da209d` rerun failed the required diff-coverage gate on the
-  same shared `cmd_project.cpp` probe edges as `#782`; `54d209d5` carries the
-  same focused CLI project-command coverage fix. GitHub Actions is rerunning
-  at `54d209d5`; no completed failures were visible at the last poll.
+  `PULP_UPDATE_CHECK_DISABLED`, skill/version checks, and whitespace. After
+  `#771` merged, this branch was rebased onto `origin/main` and duplicate
+  shared support commits were skipped. The `f7da209d` rerun failed the
+  required diff-coverage gate on the same shared `cmd_project.cpp` probe edges
+  as `#782`; that shared coverage is now on `main` via `#771`. GitHub Actions
+  is rerunning at `49983137`; no completed failures were visible at the last
+  poll.
 
 Local Phase 3 draft not yet opened as a PR:
 
 - `#642` events socket-IPC tranche, worktree
   `/Users/danielraffel/Code/pulp-events-ipc-coverage-642`, branch
-  `feature/events-ipc-coverage-642`, local commit `f3b9807c`. This draft
+  `feature/events-ipc-coverage-642`, local commit `4cb33f4e`. This draft
   extends `test/test_ipc.cpp` with malformed socket endpoint rejection,
   non-throwing socket endpoint parsing in
   `core/events/src/interprocess_connection.cpp`, and a deterministic
-  localhost client/server framed-message exchange. It also carries the same
-  shared CLI support commits as the open coverage PRs so it can be opened
-  safely if the session is interrupted before those fixes reach `main`.
+  localhost client/server framed-message exchange. After `#771` merged, this
+  branch was rebased onto `origin/main` and duplicate shared CLI support
+  commits were skipped, leaving only the events tranche.
   Local validation is green: `pulp-test-ipc` (`34` assertions / `9` test
   cases), focused CTest `IPC` plus project-bump probe edges (`12/12`), and
   whitespace. A direct multi-filter Catch2 invocation was intentionally not
@@ -220,7 +200,7 @@ Local Phase 3 draft not yet opened as a PR:
   expression; CTest was used for the focused multi-test slice.
 - `#644` Android ship/package helper tranche, worktree
   `/Users/danielraffel/Code/pulp-android-package-coverage-644`, branch
-  `feature/android-package-coverage-644`, local commit `3fe64e02`. This
+  `feature/android-package-coverage-644`, local commit `1de9b8e6`. This
   draft adds a deterministic host-side fake Android SDK/toolchain harness for
   `ship/platform/android/package_android.cpp` without requiring a real SDK,
   device, keystore, Gradle install, bundletool, or network access. Scope:
@@ -232,8 +212,8 @@ Local Phase 3 draft not yet opened as a PR:
   pulp-test-android-package -j4`, direct `pulp-test-android-package` (`64`
   assertions / `7` test cases), focused Android package CTest (`7/7`), adjacent
   ship CTest slice for Android/appcast/codesign/NSIS (`21/21`), and whitespace.
-  Keep this local until the shared Windows-safe project-bump fix lands on
-  `main`, or explicitly carry the same shared support commits before opening.
+  After `#771` merged, this branch was rebased onto `origin/main`; direct
+  `pulp-test-android-package` still passes (`64` assertions / `7` test cases).
 
 Open supporting PR:
 
@@ -241,30 +221,20 @@ Open supporting PR:
   `docs/coverage-status-2026-04-25`. The branch is updated as this
   tracker changes; use the PR head SHA in GitHub as the live value.
   The previous head `3f1df148` failed Windows Namespace for the same
-  `pulp project bump` Windows redirection bug now fixed on the active code
-  PRs. Keep this PR docs-only; once one code PR carrying the shared
-  Windows-safe probe fix merges, rebase `#774` onto `origin/main` and the
-  inherited Windows failure should clear. Docs preview, docs consistency,
-  audit, version, Android coverage, Linux coverage, Windows coverage, and
-  Codecov patch were green on that previous run.
+  `pulp project bump` Windows redirection bug now fixed on `main` via `#771`.
+  This branch has been rebased onto `origin/main` after that merge and should
+  rerun without carrying code changes.
 
 Next recovery actions:
 
-1. Poll `#771`, `#777`, `#782`, and `#786`; merge green PRs manually
+1. Poll `#777`, `#782`, and `#786`; merge green PRs manually
    because auto-merge is disabled.
-2. Let the current `#771`, `#777`, `#782`, and `#786` reruns drain after
-   the shared CI, sandbox-e2e, Windows-safe project-bump, and CLI
-   diff-coverage unblockers were pushed.
-3. After the first code PR carrying the shared Windows-safe
-   `cmd_project.cpp` probe fix merges, rebase `#774` onto `origin/main` and
-   push a doc refresh so its inherited Windows Namespace failure clears.
-4. Keep the local `#642` events IPC draft paused until the shared
-   CI-unblocker commits are on `main`; then rebase it, open a PR, and
-   link it from `#642`. If opening before then, keep the local shared commits
-   in place.
-5. Keep the local `#644` Android package draft paused for the same reason;
-   after the shared Windows-safe project-bump fix lands, rebase the draft,
-   open a PR, and link it from `#644`.
+2. Let the rebased `#777`, `#782`, and `#786` checks drain at their new heads.
+3. Open either rebased local draft `#642` or `#644` as the next Phase 3 PR
+   and link it from its issue.
+4. Keep `#774` docs-only and let its post-`#771` rebase checks drain.
+5. After `#777`, `#782`, and `#786` merge, refresh this section with the next
+   complete Codecov `main` report.
 6. If any Windows Namespace lane fails again, pull the fresh completed-run
    log first and search for `pulp-test-cli-project-command`; the known
    failing tests were the dirty-gate and redundant-origin project-bump cases.
@@ -273,9 +243,7 @@ Next recovery actions:
    `PULP_UPDATE_CHECK_DISABLED=1` on an empty cache.
 8. If a PR is green but GitHub reports it behind `main`, rebase that
    branch onto `origin/main`, push with lease, and let checks rerun.
-9. After active PRs merge, refresh this section with the next complete
-   Codecov `main` report.
-10. Continue Phase 3 from the tranche issues below, prioritizing
+9. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 23:05 EDT
+Last reviewed: 2026-04-25 23:17 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -67,37 +67,38 @@ Finish line:
 
 Latest complete Codecov `main` report observed while updating this doc:
 
-- commit: `e2af9c4db73c6b404553eb41cbd8dd3fc5a3b4db`
-- workflow: Coverage run `24945821780`, completed successfully
-- overall tracked coverage: `44.84%` over `70,312` lines in `556` files
-- covered lines: `31,532`
+- commit: `c4e6ad0930a7871046225b84fcfb130263ff98aa`
+- workflow: Coverage run `24946798292`, completed successfully
+- overall tracked coverage: `44.77%` over `70,284` lines in `556` files
+- covered lines: `31,470`
+- missed lines: `37,442`
+- partial lines: `1,372`
 - current component coverage from the Codecov API:
-  - `audio`: `25.69%`
-  - `canvas`: `68.09%`
-  - `dsl`: `72.13%`
-  - `events`: `47.76%`
-  - `format`: `52.55%`
-  - `host`: `43.48%`
-  - `midi`: `49.95%`
-  - `osc`: `70.9%`
-  - `platform`: `37.53%`
-  - `render`: `61.51%`
-  - `runtime`: `52.48%`
-  - `signal`: `66.16%`
-  - `state`: `65.13%`
-  - `view`: `44.63%`
+  - `audio`: `26.86%`
+  - `canvas`: `65.12%`
+  - `dsl`: `78.68%`
+  - `events`: `50.64%`
+  - `format`: `51.64%`
+  - `host`: `46.6%`
+  - `midi`: `49.12%`
+  - `osc`: `68.88%`
+  - `platform`: `39.25%`
+  - `render`: `61.03%`
+  - `runtime`: `52.21%`
+  - `signal`: `66.89%`
+  - `state`: `65.21%`
+  - `view`: `44.38%`
   - `android`: `13.83%`
   - `apple`: `25.36%`
-  - `linux`: `0.44%`
-  - `windows`: `1.62%`
-  - `cli`: `33.43%`
-  - `ship`: `54.34%`
-  - `tools`: `40.22%`
+  - `linux`: `7.96%`
+  - `windows`: `0.63%`
+  - `cli`: `33.15%`
+  - `ship`: `53.77%`
+  - `tools`: `39.98%`
 
-`#794` has merged after this baseline. The post-merge `main` Coverage
-workflow for `c4e6ad0930a7871046225b84fcfb130263ff98aa` is queued as
-run `24946798292`; do not treat the `c4e6ad09` totals as rebaselined
-until that run completes and Codecov reflects the new uploads.
+Post-`#794` file-level proof point: `core/audio/src/aiff_reader.cpp`
+is now `72.01%` covered with `61` misses, up from `64.22%` with `78`
+misses at the prior `e2af9c4d` baseline.
 
 Merged after the Phase 1 closeout / `#723` baseline:
 
@@ -139,6 +140,18 @@ Open Phase 3 PRs:
   GitHub/Namespace path instead of `shipyard pr` because `#794` exposed a
   local Shipyard mac configure stall after GitHub/Namespace was already
   clean.
+- `#796` `test(cli): cover tool registry local paths`, branch
+  `feature/cli-tool-registry-coverage-643`, commit `cdfbbcec`,
+  worktree `/Users/danielraffel/Code/pulp-cli-tool-registry-coverage-643`.
+  Scope: deterministic `tools/cli/tool_registry.cpp` coverage for
+  registry parsing, managed binary lookup, Python wrapper lookup,
+  uninstall, local install early exits, and `pulp tool`
+  list/path/doctor/uninstall/run/error dispatch branches against a
+  staged local registry. Local validation: lightweight configure
+  completed; `pulp-test-cli-tool-registry` built and passed with `78`
+  assertions in `5` test cases; focused CTest passed `5/5`;
+  `git diff --check` clean; version bump report says no bump needed.
+  The PR is using the same direct GitHub/Namespace path as `#795`.
 
 Local Phase 3 draft worktrees:
 
@@ -154,6 +167,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
   `feature/package-registry-coverage-643`, commit `75a529ef`; merged via
   PR `#793`.
+- `#643` tool-registry CLI/tools worktree
+  `/Users/danielraffel/Code/pulp-cli-tool-registry-coverage-643`, branch
+  `feature/cli-tool-registry-coverage-643`, commit `cdfbbcec`; open as
+  PR `#796`.
 
 Open supporting PR:
 
@@ -174,13 +191,12 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#795` and address any Codecov, build, sanitizer, or
-   Namespace feedback.
-3. When the `c4e6ad09` `main` Coverage run `24946798292` completes,
-   refresh the current live Codecov baseline from the API.
-4. If a new PR is green but GitHub reports it behind `main`, rebase that
-   branch onto `origin/main`, push with lease, and let checks rerun.
-5. Continue Phase 3 from the tranche issues below, prioritizing
+2. Monitor `#795` and `#796` and address any Codecov, build,
+   sanitizer, or Namespace feedback.
+3. If `#795` or `#796` is green but GitHub reports it behind `main`,
+   rebase that branch onto `origin/main`, push with lease, and let
+   checks rerun.
+4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 
 ## Phase 1 corrected baseline

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-27 00:16 EDT
+Last reviewed: 2026-04-27 00:20 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -168,6 +168,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#839` GPU graph render helper hardening/coverage -> `62ad9870`
 - `#832` platform child-process edge coverage -> `3f92f066`
 - `#842` inspect Codecov classification -> `51be8860`
+- `#835` CLI ship command validation coverage -> `93d3656e`
 
 Open Phase 3 PRs:
 
@@ -175,15 +176,6 @@ As of this review, the open `codecov` PR queue has no failing checks.
 The oldest PRs are blocked by still-queued macOS / sanitizer / Namespace
 jobs rather than code failures.
 
-- `#835` CLI ship command validation coverage for `#643`, branch
-  `feature/cli-ship-coverage-643`, head `b8f22af9`; opened from
-  `main` at `5b8e4529`, then rebased onto `b5e7a463` and updated after
-  Linux Namespace exposed that the Android validation test created
-  `artifacts/` before asserting the missing-artifacts check path. It was
-  updated again to isolate Android signing config via a scratch
-  `PULP_HOME` and cleared password env vars. This tranche also uses the
-  GitHub/Namespace path while the SSH `windows` target remains
-  unreachable.
 - `#840` events child-process manager coverage for `#642`, branch
   `feature/events-child-process-coverage-642`, head `410a0371`; opened
   from `main` at `455c0a9d`, then rebased onto `eaf991b0` after `#829`

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 02:34 EDT
+Last reviewed: 2026-04-26 02:50 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -130,7 +130,7 @@ Merged after the Phase 1 closeout / `#723` baseline:
 Open Phase 3 PRs:
 
 - `#801` `fix(render): harden texture atlas edge cases`, branch
-  `feature/render-texture-atlas-coverage-646`, commit `50012c04`,
+  `feature/render-texture-atlas-coverage-646`, commit `325485bc`,
   worktree `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`.
   Scope: reject non-positive `AtlasPacker` allocation dimensions, clamp
   repeated `ImageAtlas::release()` calls so refcounts cannot underflow,
@@ -145,9 +145,17 @@ Open Phase 3 PRs:
   passed `20/20`, `git diff --check` clean, skill sync clean, and version
   report clean with explicit `Version-Bump: sdk=patch` for the
   header-only behavior fix. The branch was rebased onto `origin/main`
-  after `#795` merged, pushed with lease as `50012c04`, and the focused
-  local validation above passed again. The PR is labeled `codecov` and is
-  using the direct GitHub/Namespace path.
+  after `#795` merged, then updated as `325485bc` after Codecov reported
+  a false diff-coverage miss for covered `texture_atlas.hpp` lines. The
+  follow-up fixes `tools/scripts/lcov_cobertura.py` so duplicate LCOV
+  source-file records merge instead of overwriting covered header hits,
+  and adds a regression test in `tools/scripts/test_run_coverage.py`.
+  Local validation for the follow-up: `test_run_coverage.py` passed,
+  direct `pulp-test-texture-atlas` passed, focused texture/atlas CTest
+  passed `20/20`, a local LLVM coverage-to-Cobertura reproduction showed
+  the changed atlas lines covered, `git diff --check` clean, skill sync
+  clean, and version report still clean. The PR is labeled `codecov` and
+  is using the direct GitHub/Namespace path.
 - `#802` `test(cli): cover create shellout scaffolding`, branch
   `feature/cli-create-coverage-643`, commit `222d0f88`, worktree
   `/Users/danielraffel/Code/pulp-cli-create-coverage-643`.
@@ -236,6 +244,18 @@ Open Phase 3 PRs:
   clean, skill sync clean, and version bump report says no bump
   needed. The PR is labeled `codecov` and is using the direct
   GitHub/Namespace path.
+- `#808` `test(midi): cover file edge round trips`, branch
+  `feature/midi-file-coverage-645`, commit `d02e853e`, worktree
+  `/Users/danielraffel/Code/pulp-midi-file-coverage-645`.
+  Scope: test-only MIDI file coverage for empty-track and zero-event
+  round-trips, plus multi-track program-change, pitch-bend, and note-on
+  readback. Local validation: no-GPU configure,
+  `pulp-test-midi` target build, direct Catch2 tag
+  `[midi][file][issue-645]` passed with `19` assertions in `2` test
+  cases, focused CTest `MidiFile` passed `5/5`, `git diff --check`
+  clean, skill sync clean, and version bump report says no bump needed.
+  The PR is labeled `codecov` and is using the direct GitHub/Namespace
+  path.
 
 Local Phase 3 draft worktrees:
 
@@ -276,7 +296,7 @@ Local Phase 3 draft worktrees:
 - `#646` texture-atlas render worktree
   `/Users/danielraffel/Code/pulp-render-texture-atlas-coverage-646`,
   branch `feature/render-texture-atlas-coverage-646`, commit
-  `50012c04`; open as PR `#801`.
+  `325485bc`; open as PR `#801`.
 - `#643` CLI-create shellout worktree
   `/Users/danielraffel/Code/pulp-cli-create-coverage-643`, branch
   `feature/cli-create-coverage-643`, commit `222d0f88`; open as PR
@@ -301,6 +321,10 @@ Local Phase 3 draft worktrees:
   `/Users/danielraffel/Code/pulp-audio-channel-set-coverage-640`,
   branch `feature/audio-channel-set-coverage-640`, commit `89b969c9`;
   open as PR `#807`.
+- `#645` MIDI file edge round-trip worktree
+  `/Users/danielraffel/Code/pulp-midi-file-coverage-645`, branch
+  `feature/midi-file-coverage-645`, commit `d02e853e`; open as PR
+  `#808`.
 
 Open supporting PR:
 
@@ -321,11 +345,11 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#801`, `#802`, `#803`, `#804`, `#805`, `#806`, and `#807`
+2. Monitor `#801`, `#802`, `#803`, `#804`, `#805`, `#806`, `#807`, and `#808`
    and address any Codecov, build, sanitizer, or Namespace feedback.
-3. If `#801`, `#802`, `#803`, `#804`, `#805`, `#806`, or `#807` is green
-   but GitHub reports it behind `main`, rebase that branch onto
-   `origin/main`, push with lease, and let checks rerun.
+3. If any open Phase 3 PR is green but GitHub reports it behind `main`,
+   rebase that branch onto `origin/main`, push with lease, and let
+   checks rerun.
 4. Continue Phase 3 from the tranche issues below, prioritizing
    represented high-miss files over adding new perimeter lanes.
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 21:31 EDT
+Last reviewed: 2026-04-26 21:50 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -66,7 +66,7 @@ Finish line:
 ## Current live state
 
 Latest complete Codecov `main` report observed while updating this doc
-(`main` head `455c0a9d` has a newer Coverage run queued):
+(`main` head `eaf991b0` has a newer Coverage run queued):
 
 - commit: `5b8e4529cfc553fd98b65f265ed1e9c0487b3d66`
 - workflow: Coverage run `24970413173`, completed successfully
@@ -162,15 +162,10 @@ Merged after the Phase 1 closeout / `#723` baseline:
 - `#837` package registry validation tools coverage -> `bdc406cc`
 - `#830` RPN parser edge coverage -> `d02c9ec9`
 - `#834` events event-loop lifecycle edge coverage -> `455c0a9d`
+- `#829` MIDI-CI edge coverage -> `eaf991b0`
 
 Open Phase 3 PRs:
 
-- `#829` MIDI-CI edge coverage for `#645`, branch
-  `feature/midi-ci-coverage-645`, head `1d3cd1ce`; opened from `main`
-  at `94e3ef2a` and rebased onto `87ef6d90` after the first ASan run
-  exposed the already-fixed Android SDK discovery regression from the
-  stale base. This tranche also uses the GitHub/Namespace path while the
-  SSH `windows` target remains unreachable.
 - `#832` platform child-process edge coverage for `#640`, branch
   `feature/platform-child-process-coverage-640`, head `7496ba0a`;
   opened from `main` at `d5efea57`, updated after the first Windows
@@ -208,6 +203,14 @@ Open Phase 3 PRs:
   from `main` at `bdc406cc`, then rebased onto `d02c9ec9` after `#830`
   merged. This tranche also uses the GitHub/Namespace path while the
   SSH `windows` target remains unreachable.
+- `#840` events child-process manager coverage for `#642`, branch
+  `feature/events-child-process-coverage-642`, head `47e38795`; opened
+  from `main` at `455c0a9d`, then rebased onto `eaf991b0` after `#829`
+  merged. The first Linux Namespace and Linux coverage failures were
+  dependency-bootstrap failures before configure/tests because a cold
+  FetchContent cache hit a GitHub 403 cloning `Tracktion/choc.git`. This
+  tranche also uses the GitHub/Namespace path while the SSH `windows`
+  target remains unreachable.
 
 Local Phase 3 draft worktrees:
 
@@ -231,6 +234,24 @@ Local Phase 3 draft worktrees:
   `14` assertions in `4` cases, full binary passed `74` assertions in
   `20` cases, precise CTest selector passed `18/18`, `git diff --check`,
   skill-sync report, and version-bump report.
+- `#642` events child-process manager worktree
+  `/Users/danielraffel/Code/pulp-events-child-process-coverage-642`,
+  branch `feature/events-child-process-coverage-642`, commit
+  `47e38795`; open as PR `#840`.
+  Scope: covers unlaunched `ConnectedChildProcess` default state,
+  disconnected send, idempotent kill, and `wait_for_exit()` return
+  behavior; covers empty `ChildProcessManager` active-count, wait, kill,
+  and cleanup no-op lifecycle; and hardens
+  `ConnectedChildProcess::wait_for_exit()` so unlaunched/invalid PID
+  state returns `-1` instead of probing an invalid process id. Local
+  validation before opening: no-GPU/no-examples configure,
+  `pulp-test-ipc` build, direct `[issue-642]` run passed `7`
+  assertions in `2` cases, full IPC binary passed `44` assertions in
+  `12` cases, focused CTest `ConnectedChildProcess|ChildProcessManager|IPC`
+  passed `12/12`, diff check, skill-sync report, and version-bump
+  report. Follow-up validation after rebasing onto `eaf991b0` passed the
+  direct issue selector, focused CTest, diff check, skill-sync report,
+  version-bump report, and pre-push gates.
 - `#643` package-registry CLI/tools worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
   `feature/package-registry-coverage-643`, commit `75a529ef`; merged via
@@ -680,7 +701,8 @@ Local Phase 3 draft worktrees:
   transport helper despite living under `include`.
 - `#645` MIDI-CI worktree
   `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, branch
-  `feature/midi-ci-coverage-645`, commit `1d3cd1ce`; open as PR `#829`.
+  `feature/midi-ci-coverage-645`, commit `1d3cd1ce`; merged via PR
+  `#829` as `eaf991b0`. The remote branch was deleted after merge.
   Scope: test-only coverage for profile inquiry destination encoding,
   malformed and unhandled CI messages, discovery inquiry destination
   filtering, discovery reply storage plus callback dispatch, unknown
@@ -799,6 +821,9 @@ Open supporting PR:
   and `#836` merged, and `#837` merged, and `#839` opened,
   and `#830` merged, and `#838` was rebased onto `d02c9ec9` and repaired
   for the Android package parallel temp-dir collision, and `#834` merged,
+  and `#840` opened, and `#841` was opened to classify the represented
+  but currently uncomponentized `inspect/` Codecov bucket, and `#829`
+  merged, and `#840` was rebased onto `eaf991b0`,
   and remains docs-only.
 
 Local environment note:
@@ -818,23 +843,24 @@ Local environment note:
 Next recovery actions:
 
 1. Keep `#774` docs-only and let its latest status-update checks drain.
-2. Monitor `#829` cloud checks; if a required lane fails, debug in
-   `/Users/danielraffel/Code/pulp-midi-ci-coverage-645`, patch,
-   validate locally, and push with lease.
-3. Monitor `#832` cloud checks; if a required lane fails, debug in
+2. Monitor `#832` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-platform-child-process-coverage-640`,
    patch, validate locally, and push with lease.
-4. Monitor `#833` cloud checks; if a required lane fails, debug in
+3. Monitor `#833` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-signal-biquad-coverage-645`, patch,
    validate locally, and push with lease.
-5. Monitor `#835` cloud checks; if a required lane fails, debug in
+4. Monitor `#835` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-cli-ship-coverage-643`, patch,
    validate locally, and push with lease.
-6. Monitor `#838` cloud checks on head `09666f46`; if a required lane fails, debug in
+5. Monitor `#838` cloud checks on head `09666f46`; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-package-cli-coverage-643`, patch,
    validate locally, and push with lease.
-7. Monitor `#839` cloud checks; if a required lane fails, debug in
+6. Monitor `#839` cloud checks; if a required lane fails, debug in
    `/Users/danielraffel/Code/pulp-render-gpu-graph-coverage-646`,
+   patch, validate locally, and push with lease.
+7. Monitor `#840` cloud checks on head `47e38795`; if a required lane
+   fails after dependency bootstrap succeeds, debug in
+   `/Users/danielraffel/Code/pulp-events-child-process-coverage-642`,
    patch, validate locally, and push with lease.
 8. If any open Phase 3 PR is green but GitHub reports it behind `main`,
    rebase that branch onto `origin/main`, push with lease, and let
@@ -925,6 +951,15 @@ represented surface.
   shims, and Web/WASM-specific sources, remain outside the measured
   graph unless Phase 2 decides to add focused follow-up issues.
 
+## Represented but not yet componentized
+
+- `inspect/` is represented on the Codecov website as a first-party
+  top-level bucket (`1,505` lines, `10.10%` in the user-observed
+  snapshot), but it is not currently a named component in `codecov.yml`
+  or a target tier in `ci/coverage-targets.yaml`. This is now tracked by
+  `#841`: either promote `inspect/**` to a first-class component/tier or
+  document it explicitly as represented-but-uncategorized for now.
+
 ## Phase 1 issue map
 
 ### Control plane and verification
@@ -954,6 +989,8 @@ represented surface.
   dedicated future lanes
 - `#77` decide and, if in scope, add mobile runtime coverage from
   Android instrumentation and iOS simulator / runtime app paths
+- `#841` classify represented `inspect/**` as either a first-class
+  Codecov component/tier or explicitly represented-but-uncategorized
 
 ### Supporting infrastructure
 
@@ -989,6 +1026,7 @@ pre-`#715` numbers. The current execution rule is:
 - `#493` host / format / view and related hardening gaps
 - `#737` optional native surfaces not compiled by the default coverage
   configuration
+- `#841` inspect component / tier classification
 
 ### Deferred perimeter follow-ups
 
@@ -996,6 +1034,7 @@ pre-`#715` numbers. The current execution rule is:
 - `#657` Node bindings plus shell / PowerShell classification, closed as
   explicitly out of scope for now
 - `#77` mobile runtime / iOS simulator coverage
+- `#841` represented `inspect/**` classification
 
 ## Control-plane invariants
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 14:44 EDT
+Last reviewed: 2026-04-26 14:51 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -28,7 +28,7 @@ Status: complete.
 Finish line state:
 
 - `windows` is non-null on `main` (`0.0%` at the current baseline).
-- `dsl` is a real component on `main` (`63.38%`).
+- `dsl` is a real component on `main` (`68.3%`).
 - `apple/Sources/**` materializes on Codecov for the macOS Swift package
   lane and the native `PulpBridge.cpp` lane.
 - `android/app/src/main/kotlin/**` materializes on Codecov.
@@ -67,34 +67,34 @@ Finish line:
 
 Latest complete Codecov `main` report observed while updating this doc:
 
-- commit: `f712702afff325b35785eb56b88f1b85df0226a8`
-- workflow: Coverage run `24963571323`, completed successfully
-- overall tracked coverage: `45.58%` over `70,381` lines in `556` files
-- covered lines: `32,086`
-- missed lines: `37,163`
-- partial lines: `1,132`
+- commit: `810743d49f588385aab50ced672344e098710403`
+- workflow: Coverage run `24964141128`, completed successfully
+- overall tracked coverage: `45.43%` over `70,380` lines in `556` files
+- covered lines: `31,974`
+- missed lines: `37,398`
+- partial lines: `1,008`
 - current component coverage from the Codecov API:
-  - `audio`: `35.3%`
-  - `canvas`: `64.59%`
-  - `dsl`: `63.38%`
-  - `events`: `49.49%`
-  - `format`: `51.43%`
-  - `host`: `43.48%`
-  - `midi`: `47.81%`
-  - `osc`: `61.61%`
-  - `platform`: `39.05%`
-  - `render`: `57.66%`
-  - `runtime`: `49.7%`
-  - `signal`: `65.95%`
-  - `state`: `61.26%`
-  - `view`: `43.12%`
+  - `audio`: `34.78%`
+  - `canvas`: `64.22%`
+  - `dsl`: `68.3%`
+  - `events`: `50.5%`
+  - `format`: `51.04%`
+  - `host`: `43.39%`
+  - `midi`: `47.62%`
+  - `osc`: `65.65%`
+  - `platform`: `36.93%`
+  - `render`: `60.38%`
+  - `runtime`: `47.51%`
+  - `signal`: `66.13%`
+  - `state`: `60.77%`
+  - `view`: `42.93%`
   - `android`: `13.83%`
   - `apple`: `25.36%`
-  - `linux`: `3.31%`
+  - `linux`: `0.0%`
   - `windows`: `0.0%`
-  - `cli`: `38.28%`
-  - `ship`: `53.66%`
-  - `tools`: `43.99%`
+  - `cli`: `38.94%`
+  - `ship`: `54.46%`
+  - `tools`: `44.33%`
 
 Post-`#794` file-level proof point: `core/audio/src/aiff_reader.cpp`
 is now `72.01%` covered with `61` misses, up from `64.22%` with `78`

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 17:00 EDT
+Last reviewed: 2026-04-25 17:27 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -131,7 +131,7 @@ Open Phase 3 PRs:
   the current polling window shows no failures while Linux Namespace plus
   Linux coverage drain.
 - `#789` Android ship/package helper coverage, branch
-  `feature/android-package-coverage-644`, head `5070182c`. This tranche
+  `feature/android-package-coverage-644`, head `3c1a49c0`. This tranche
   adds a deterministic host-side fake Android SDK/toolchain harness for
   `ship/platform/android/package_android.cpp` without requiring a real SDK,
   device, keystore, Gradle install, bundletool, or network access. Scope:
@@ -141,18 +141,28 @@ Open Phase 3 PRs:
   and fake bundletool conversion with optional signing config. After `#786`
   merged, this branch was rebased onto `origin/main`, pushed, opened as a PR,
   and labeled `codecov`. The first GitHub Actions pass exposed a Windows
-  Namespace-only failure in batch-backed Android tool invocation; the branch
-  now invokes quoted `.bat` SDK/Gradle/bundletool commands through `call` and
+  Namespace-only failure in batch-backed Android tool invocation. The first
+  follow-up fixed the skill-sync gap but still failed the same three Windows
+  Android tests. The branch now preserves quoted batch executable paths for
+  `cmd.exe /c` by wrapping commands that begin with a quoted tool path, and
   documents that gotcha in the `ship` skill. Local validation is green:
   `cmake --build build --target pulp-test-android-package -j4`, direct
   `pulp-test-android-package` (`64` assertions / `7` test cases), focused
   Android package CTest (`7/7`), adjacent ship CTest slice for
   Android/appcast/codesign/notarization/DMG (`20/20`), and whitespace. The
   current polling window shows no failures while fresh checks run on
-  `5070182c`.
+  `3c1a49c0`.
 
 Local Phase 3 draft not yet opened as a PR:
-- none at this update. The former `#644` draft is now open as `#789`.
+- `#643` package-registry CLI/tools draft, worktree
+  `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
+  `feature/package-registry-coverage-643`. This draft is local-only and
+  should not be opened until `#788` / `#789` resolve. Current scope adds
+  `pulp-test-cli-package-registry` for pure local registry parsing,
+  lock-file round trips, target TOML parsing/writing, semver, quality
+  scoring, unsupported-target detection, and search ranking. Local configure
+  was interrupted while fetching `mbedtls` because `#789` required immediate
+  Windows triage; resume with a clean configure/build in that worktree.
 
 Open supporting PR:
 

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25 19:08 EDT
+Last reviewed: 2026-04-25 19:11 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -143,13 +143,14 @@ Open Phase 3 PRs:
 Local Phase 3 draft not yet opened as a PR:
 - `#643` package-registry CLI/tools draft, worktree
   `/Users/danielraffel/Code/pulp-package-registry-coverage-643`, branch
-  `feature/package-registry-coverage-643`, local commit `b1443bb9`. This draft is local-only and
+  `feature/package-registry-coverage-643`, local commit `16bbe5bb`. This draft is local-only and
   should not be opened until `#788` resolves. Current scope adds
   `pulp-test-cli-package-registry` for pure local registry parsing,
   lock-file round trips, target TOML parsing/writing, semver, quality
   scoring, unsupported-target detection, and search ranking. Local validation
-  is green in a no-GPU/no-examples build directory using the completed local
-  `mbedtls` source tree: configure
+  is green after rebasing onto `origin/main` at
+  `e61dce8d907c29888fd7dd97ae7f49e3bc219662`, in a no-GPU/no-examples build
+  directory using the completed local `mbedtls` source tree: configure
   `cmake -S . -B build-package-registry-localdeps -DCMAKE_BUILD_TYPE=Debug
   -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF
   -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=$PWD/build/_deps/mbedtls-src`, build

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-26 22:32 EDT
+Last reviewed: 2026-04-26 22:43 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -248,6 +248,24 @@ Open Phase 3 PRs:
   `feature/signal-meter-coverage-645-next`, head `ad9c3d81`; hardens
   negative/invalid `MultiChannelMeter` and `MultiChannelBallistics`
   channel counts and carries a patch-level SDK metadata trailer.
+- `#852` canvas rectangle-list helper coverage for parent `#641`,
+  branch `feature/runtime-helper-coverage-641-next2`, head `05c85d55`;
+  consolidates overlapping rectangle-list worker output into one
+  test-only PR covering empty-rectangle filtering, intersection
+  semantics, subtract no-op/full-cover, bounding-box/area, and clipped
+  intersections.
+- `#853` audio frame-fill invalid-dimension coverage for `#640`,
+  branch `feature/audio-helper-coverage-640-next2`, head `53bc6020`;
+  covers `zero_fill_short_read` negative channel-count and negative
+  total-frame no-op guards.
+- `#854` ViewBridge helper coverage for `#493`, branch
+  `feature/host-view-helper-coverage-493-next2`, head `5c9eeeba`;
+  covers idempotent open/release behavior, secondary-view null/bounds
+  cleanup, and null remote-channel diagnostics.
+- `#855` signal convolver edge coverage for `#645`, branch
+  `feature/midi-signal-helper-coverage-645-next2`, head `2d8b0bc3`;
+  covers rounded/zero block-size setup, empty IR pass-through, and
+  wrong-block-size pass-through behavior.
 
 Local Phase 3 draft worktrees:
 
@@ -908,6 +926,48 @@ Local Phase 3 draft worktrees:
   target build, direct `[signal][meter][issue-645]` run, full signal
   binary, focused CTest, diff check, skill-sync report, and
   version-bump report with an SDK patch trailer.
+- `#641` canvas rectangle-list helper worktree
+  `/Users/danielraffel/Code/pulp-runtime-helper-coverage-641-next2`,
+  branch `feature/runtime-helper-coverage-641-next2`, commits
+  `3e1cfd51` and `05c85d55`; open as PR `#852`. Scope: test-only
+  coverage for `RectangleList` empty-rectangle filtering, area-overlap
+  intersection semantics, subtract no-op/full-cover behavior,
+  bounding-box/area helpers, and clipped intersections. Local validation
+  passed the no-GPU/no-text-shaping configure, affected target build,
+  direct `[issue-641]` run with `25` assertions in `5` cases, full
+  binary with `52` assertions in `14` cases, focused CTest `14/14`, and
+  diff check. The overlapping `/Users/danielraffel/Code/pulp-render-helper-coverage-646-next`
+  branch also touched `test/test_rectangle_list.cpp`; its unique
+  subtract case was folded into `#852` and that duplicate branch should
+  not be opened as-is.
+- `#640` audio frame-fill helper worktree
+  `/Users/danielraffel/Code/pulp-audio-helper-coverage-640-next2`,
+  branch `feature/audio-helper-coverage-640-next2`, commit `53bc6020`;
+  open as PR `#853`. Scope: test-only coverage for
+  `zero_fill_short_read` negative channel-count and negative total-frame
+  guards. Local validation passed diff check, no-GPU/no-examples
+  configure, affected target build, focused CTest `11/11`, and full
+  frame-fill binary with `81` assertions in `11` cases.
+- `#493` ViewBridge helper worktree
+  `/Users/danielraffel/Code/pulp-host-view-helper-coverage-493-next2`,
+  branch `feature/host-view-helper-coverage-493-next2`, commit
+  `5c9eeeba`; open as PR `#854`. Scope: test-only coverage for
+  idempotent `open()`, primary role helpers, repeated `release_view()`,
+  secondary view null/bounds cleanup, and null remote-channel diagnostics
+  followed by successful open. Local validation passed diff check,
+  no-GPU configure, affected target build, and focused ViewBridge CTest
+  `10/10`.
+- `#645` signal convolver worktree
+  `/Users/danielraffel/Code/pulp-midi-signal-helper-coverage-645-next2`,
+  branch `feature/midi-signal-helper-coverage-645-next2`, commit
+  `2d8b0bc3`; open as PR `#855`. Scope: test-only coverage for
+  `PartitionedConvolver` rounded/zero block-size setup, empty IR
+  pass-through, and wrong-block-size process pass-through behavior.
+  Local validation passed diff check, skill-sync report, version-bump
+  report, no-GPU/no-examples configure, affected target build, full
+  convolver binary with `91` assertions in `6` cases, direct
+  `[issue-645]` run with `19` assertions in `2` cases, and focused CTest
+  `6/6`.
 
 Open supporting PR:
 
@@ -942,7 +1002,8 @@ Open supporting PR:
   `#843` opened for MPE tracker UMP edge-path coverage, and `#845`,
   `#846`, `#847`, `#848`, `#849`, `#850`, and `#851` opened from the
   parallel worker batch, and `#833` merged as `8fc5dd2d`, and `#840`
-  was repaired for diff coverage with `410a0371`,
+  was repaired for diff coverage with `410a0371`, and `#852`, `#853`,
+  `#854`, and `#855` opened from the next worker batch,
   and remains docs-only.
 
 Local environment note:
@@ -986,7 +1047,7 @@ Next recovery actions:
    fails, debug in
    `/Users/danielraffel/Code/pulp-midi-mpe-tracker-extra-coverage-645-next`,
    patch, validate locally, and push with lease.
-9. Monitor `#845` through `#851`; if a required lane fails, debug in
+9. Monitor `#845` through `#855`; if a required lane fails, debug in
    the worktree named in the open-PR list above, patch, validate
    locally, and push with lease. Pay particular attention to `#848` and
    `#851` because they include patch-level production hardening.

--- a/docs/reports/coverage-compliance-status.md
+++ b/docs/reports/coverage-compliance-status.md
@@ -1,6 +1,6 @@
 # Coverage Compliance Status
 
-Last reviewed: 2026-04-25
+Last reviewed: 2026-04-25 17:00 EDT
 
 This is the durable tracker for the repo-wide coverage compliance
 program under `#641`. Phase 1 representation is complete, Phase 2 gap
@@ -126,10 +126,12 @@ Open Phase 3 PRs:
   whitespace. A direct multi-filter Catch2 invocation was intentionally not
   used as validation because Catch2 treats multiple quoted filters as an AND
   expression; CTest was used for the focused multi-test slice. PR is labeled
-  `codecov`; GitHub Actions has no failures observed in the current polling
-  window and is waiting on Linux Namespace plus Linux coverage to finish.
+  `codecov`. The earlier Linux Namespace and Linux coverage failures did not
+  expose usable logs through `gh`; both failed workflows have been rerun and
+  the current polling window shows no failures while Linux Namespace plus
+  Linux coverage drain.
 - `#789` Android ship/package helper coverage, branch
-  `feature/android-package-coverage-644`, head `9f14204e`. This tranche
+  `feature/android-package-coverage-644`, head `5070182c`. This tranche
   adds a deterministic host-side fake Android SDK/toolchain harness for
   `ship/platform/android/package_android.cpp` without requiring a real SDK,
   device, keystore, Gradle install, bundletool, or network access. Scope:
@@ -138,11 +140,16 @@ Open Phase 3 PRs:
   Gradle APK/AAB artifact collection, missing-wrapper/missing-artifact errors,
   and fake bundletool conversion with optional signing config. After `#786`
   merged, this branch was rebased onto `origin/main`, pushed, opened as a PR,
-  and labeled `codecov`. Local validation is green:
+  and labeled `codecov`. The first GitHub Actions pass exposed a Windows
+  Namespace-only failure in batch-backed Android tool invocation; the branch
+  now invokes quoted `.bat` SDK/Gradle/bundletool commands through `call` and
+  documents that gotcha in the `ship` skill. Local validation is green:
   `cmake --build build --target pulp-test-android-package -j4`, direct
   `pulp-test-android-package` (`64` assertions / `7` test cases), focused
   Android package CTest (`7/7`), adjacent ship CTest slice for
-  Android/appcast/codesign/notarization/DMG (`20/20`), and whitespace.
+  Android/appcast/codesign/notarization/DMG (`20/20`), and whitespace. The
+  current polling window shows no failures while fresh checks run on
+  `5070182c`.
 
 Local Phase 3 draft not yet opened as a PR:
 - none at this update. The former `#644` draft is now open as `#789`.
@@ -159,9 +166,9 @@ Next recovery actions:
 
 1. Poll `#788` and `#789`; merge manually when green because auto-merge is
    disabled.
-2. Let `#788`'s Linux Namespace and Linux coverage checks drain.
-3. Let `#789`'s initial GitHub Actions checks drain; pull the exact failing
-   job log first if anything turns red.
+2. Let `#788`'s rerun Linux Namespace and Linux coverage checks drain.
+3. Let `#789`'s post-Windows-fix GitHub Actions checks drain; pull the
+   exact failing job log first if anything turns red.
 4. Keep `#774` docs-only and let its post-`#786` rebase checks drain.
 5. After the active code PRs merge, refresh this section with the next
    complete Codecov `main` report.


### PR DESCRIPTION
## Summary
- Refreshes the coverage compliance status doc for the current Phase 3 state after the active codecov queue drained.
- Records the latest complete Codecov `main` report observed at `e9c994d1` from #851, now complete at 48.40%.
- Replaces the stale open-PR handoff with the current queue state, final-batch merges, remaining component gaps, and next tranche order.

Refs #641.
Refs #493.

## Validation
- tools/check-docs.sh (passed with existing warnings)
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- git diff --check origin/main...HEAD
- git diff --check