### PR TITLE
fix(cli): use platform-aware redirects in project bump (#780)

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -396,6 +396,17 @@ Gotchas:
   git isn't on PATH, `cmake_is_dirty()` returns false — we refuse
   to block on a missing tool. `--force-dirty` is the explicit
   override for users who WANT to bump alongside other edits.
+- **Use `silence_stderr()` / `silence_all()` on shelled-out
+  redirects, never literal `2>/dev/null`.** cmd.exe treats
+  `/dev/null` as a relative file path (it tries `dev\null` under
+  the cwd) and the redirection failure can abort the whole
+  pipeline. The two `pin_files_are_dirty` and
+  `main_pinned_version_at_origin` paths fell over this way on
+  the Windows lane (#780): `git status` and `git fetch origin
+  main` never ran, the dirty/redundant gates returned false, and
+  the bump_one tests asserting `"skipped"` failed. The helpers
+  live in `cli_common.{hpp,cpp}` and resolve to `2>NUL`/`>NUL
+  2>&1` on Windows, `2>/dev/null`/`>/dev/null 2>&1` elsewhere.
 - **Migration notes print once per bump batch, using the minimum
   old pin as `from`.** That captures the widest set of applicable
   notes when different projects were on different versions.

--- a/test/test_cli_project_command.cpp
+++ b/test/test_cli_project_command.cpp
@@ -377,3 +377,62 @@ TEST_CASE("resolve_standalone_sdk handles custom sdk_path and checkout local cac
     REQUIRE(installed_checkout->passed);
     REQUIRE(installed_checkout->detail.find("(local cache)") != std::string::npos);
 }
+
+// Cover the platform-conditional silence helpers introduced for #780.
+// Both branches exist at compile time, so the assertion shape is the
+// same on every OS — only the *value* varies. The "leading space, then
+// 2> / >, then NUL on Windows or /dev/null elsewhere" contract is what
+// callers (cmd_project and any future shellouts) depend on.
+TEST_CASE("silence_stderr / silence_all return platform-correct redirects",
+          "[project-command][issue-780]") {
+    std::string stderr_redir = silence_stderr();
+    std::string all_redir    = silence_all();
+
+    REQUIRE_FALSE(stderr_redir.empty());
+    REQUIRE_FALSE(all_redir.empty());
+    REQUIRE(stderr_redir.front() == ' ');
+    REQUIRE(all_redir.front() == ' ');
+    REQUIRE(stderr_redir.find("2>") != std::string::npos);
+    REQUIRE(all_redir.find(">") != std::string::npos);
+    REQUIRE(all_redir.find("2>&1") != std::string::npos);
+
+#if defined(_WIN32)
+    REQUIRE(stderr_redir == " 2>NUL");
+    REQUIRE(all_redir == " >NUL 2>&1");
+#else
+    REQUIRE(stderr_redir == " 2>/dev/null");
+    REQUIRE(all_redir == " >/dev/null 2>&1");
+#endif
+}
+
+// Cover the source-tree fallback in main_pinned_version_at_origin.
+// The standalone path (test #138 above) exercises the toml-first
+// branch; this case has no pulp.toml on origin/main, so the function
+// must fall back to scanning CMakeLists.txt for a pulp pin and
+// returning it.
+TEST_CASE("main_pinned_version_at_origin reads source-tree CMakeLists when pulp.toml absent",
+          "[project-command][issue-780]") {
+    TempDir tmp;
+    auto origin = tmp.path / "origin.git";
+    auto seed = tmp.path / "seed";
+    auto feature = tmp.path / "feature";
+
+    require_run_ok("git init --bare -q " + quote(origin));
+
+    fs::create_directories(seed);
+    require_run_ok("git init -q " + quote(seed));
+    configure_git_identity(seed);
+    require_run_ok("git -C " + quote(seed) + " checkout -q -b main");
+    make_fetchcontent_project(seed, "0.5.0");
+    require_run_ok("git -C " + quote(seed) + " add CMakeLists.txt");
+    require_run_ok("git -C " + quote(seed) + " commit -q -m \"main pin\"");
+    require_run_ok("git -C " + quote(seed) + " remote add origin " + quote(origin));
+    require_run_ok("git -C " + quote(seed) + " push -q -u origin main");
+
+    require_run_ok("git clone -q " + quote(origin) + " " + quote(feature));
+    configure_git_identity(feature);
+
+    auto pinned = main_pinned_version_at_origin(feature, /*standalone=*/false);
+    REQUIRE(pinned.has_value());
+    REQUIRE(*pinned == "0.5.0");
+}

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -138,6 +138,29 @@ fs::path platform_executable(fs::path p) {
     return p;
 }
 
+// cmd.exe interprets `/dev/null` as a relative file path and refuses
+// to open it; on some configurations the whole pipeline aborts when
+// the redirection target can't be opened, which is how #780 fell
+// over (`git status` never ran inside the dirty gate, the gate
+// silently returned clean, and the test that asserted "skipped"
+// failed). The leading space lets these helpers be appended directly
+// to a command string.
+const char* silence_stderr() {
+#ifdef _WIN32
+    return " 2>NUL";
+#else
+    return " 2>/dev/null";
+#endif
+}
+
+const char* silence_all() {
+#ifdef _WIN32
+    return " >NUL 2>&1";
+#else
+    return " >/dev/null 2>&1";
+#endif
+}
+
 static bool parse_uint64_arg(const std::string& text, const char* flag, uint64_t& out) {
     if (text.empty()) {
         std::cerr << "Error: invalid value for " << flag << ": " << text << "\n";

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -52,6 +52,15 @@ std::string shell_quote(const std::string& s);
 std::string shell_quote(const fs::path& p);
 fs::path platform_executable(fs::path p);
 
+// Platform-aware shell-redirection fragments for muting subprocess
+// chatter inside command strings passed to run/exec_output. cmd.exe
+// rejects `/dev/null` outright (treats it as a literal path that
+// can't be opened, and on some configs that aborts the whole
+// command — see #780). Use `silence_stderr()` for `2>NUL`/`2>/dev/null`
+// and `silence_all()` for `>NUL 2>&1`/`>/dev/null 2>&1`.
+const char* silence_stderr();
+const char* silence_all();
+
 // ── String Utilities ────────────────────────────────────────────────────────
 
 std::string trim(const std::string& s);

--- a/tools/cli/cmd_project.cpp
+++ b/tools/cli/cmd_project.cpp
@@ -228,7 +228,7 @@ bool pin_files_are_dirty(const fs::path& project_path, bool standalone) {
     std::string cmd = "git -C " + shell_quote(project_path) +
                       " status --porcelain -- CMakeLists.txt";
     if (standalone) cmd += " pulp.toml";
-    cmd += " 2>/dev/null";
+    cmd += silence_stderr();
     auto out = trim(exec_output(cmd));
     return !out.empty();
 }
@@ -293,12 +293,14 @@ std::optional<std::string> managed_sdk_path_replacement(const fs::path& raw_path
 std::optional<std::string> main_pinned_version_at_origin(const fs::path& project_path,
                                                          bool standalone) {
     std::string fetch = "git -C " + shell_quote(project_path) +
-                        " fetch --quiet origin main >/dev/null 2>&1";
+                        " fetch --quiet origin main";
+    fetch += silence_all();
     if (run(fetch) != 0) return std::nullopt;
 
     if (standalone) {
         std::string toml_cmd = "git -C " + shell_quote(project_path) +
-                               " show origin/main:pulp.toml 2>/dev/null";
+                               " show origin/main:pulp.toml";
+        toml_cmd += silence_stderr();
         auto toml = exec_output(toml_cmd);
         if (!toml.empty()) {
             auto site = pb::find_toml_string_value(toml, "sdk_version",
@@ -309,7 +311,8 @@ std::optional<std::string> main_pinned_version_at_origin(const fs::path& project
     }
 
     std::string cmake_cmd = "git -C " + shell_quote(project_path) +
-                            " show origin/main:CMakeLists.txt 2>/dev/null";
+                            " show origin/main:CMakeLists.txt";
+    cmake_cmd += silence_stderr();
     auto cmake = exec_output(cmake_cmd);
     if (cmake.empty()) return std::nullopt;
     auto site = standalone ? pb::find_find_package_pulp_version(cmake)
@@ -605,16 +608,7 @@ pb::UndoEntry bump_one(const fs::path& project_path,
         // `build/` stays untouched. The CLI doesn't try to honor a
         // user-specified build dir here — that's a follow-up.
         auto verify_build = project_path / "build-bump-verify";
-        // Silence redirection — POSIX uses `/dev/null`, Windows cmd.exe
-        // uses `NUL`. Without branching on the host, a bare `>/dev/null`
-        // makes cmd.exe create a literal file named `dev\null` (or fail
-        // to parse) and the advertised `--verify-builds` flag rolls the
-        // pin back even on healthy projects. See codex-sweep(#599).
-#if defined(_WIN32)
-        const char* silence = " >NUL 2>&1";
-#else
-        const char* silence = " >/dev/null 2>&1";
-#endif
+        const char* silence = silence_all();
         std::string cfg = "cmake -S " + shell_quote(project_path) +
                           " -B " + shell_quote(verify_build) +
                           " -DCMAKE_BUILD_TYPE=Debug";


### PR DESCRIPTION
cmd.exe interprets `2>/dev/null` as a redirect to a literal file
named `dev/null` under the current working directory; the
redirection failure can abort the whole pipeline. Two paths in
`cmd_project.cpp` shelled out with that bare POSIX form and
silently no-op'd on Windows:

- `pin_files_are_dirty()` — `git status --porcelain` never ran,
  so the dirty gate returned false and `bump_one` proceeded
  through dirty trees.
- `main_pinned_version_at_origin()` — `git fetch origin main`
  and `git show origin/main:{pulp.toml,CMakeLists.txt}` never
  ran, so the redundant-bump gate never fired.

This surfaced as test #136 (`bump_one enforces the dirty gate
and rewrites managed standalone sdk_path`) and #138 (`bump_one
refuses redundant standalone bumps when origin main already
pins the target`) failing on the Windows (x64) namespace lane
since #735 landed.

Add `silence_stderr()` / `silence_all()` helpers in
`cli_common.{hpp,cpp}` that resolve to `2>NUL` / `>/dev/null 2>&1`
on Windows and `2>/dev/null` / `>/dev/null 2>&1` elsewhere.
Use them at the four broken sites in `cmd_project.cpp` and
collapse the existing inline `#if defined(_WIN32)` block in the
`--verify-builds` path onto the same helper.

The existing macOS/Linux Catch2 tests at
`test/test_cli_project_command.cpp:225,271` already exercise
both code paths end-to-end (clean repo + dirty marker for the
gate; bare-origin clone with a feature branch for the redundant
guard). They pass on macOS before and after the fix; the hard
verification for the fix itself is the Windows lane on this
PR's CI run.

Skill update: noted the gotcha in `.agents/skills/cli-maintenance/SKILL.md`
under the project-bump section so the next agent shelling out
to git from C++ doesn't repeat the mistake.

Closes #780.

Refs #735 (introduced) and #778 (Phase 8 PR #1, was waiting on
this fix to clear the Windows lane cleanly).