### PR TITLE
test(render): cover dirty tracker and render loop edges

### DIFF
--- a/test/test_dirty_tracker.cpp
+++ b/test/test_dirty_tracker.cpp
@@ -87,10 +87,97 @@ TEST_CASE("DirtyTracker ignores zero-size rects", "[render][dirty]") {
     REQUIRE_FALSE(dt.is_dirty());
 }
 
+TEST_CASE("DirtyTracker ignores negative-size rects", "[render][dirty][issue-646]") {
+    DirtyTracker dt;
+    dt.clear();
+    dt.invalidate(10, 10, -5, 50);
+    dt.invalidate(10, 10, 50, -5);
+    REQUIRE_FALSE(dt.is_dirty());
+    REQUIRE(dt.dirty_rects().empty());
+}
+
+TEST_CASE("DirtyTracker empty bounds returns zero rect", "[render][dirty][issue-646]") {
+    DirtyTracker dt;
+    dt.clear();
+    auto b = dt.bounds();
+    REQUIRE(b.x == Catch::Approx(0.0f));
+    REQUIRE(b.y == Catch::Approx(0.0f));
+    REQUIRE(b.w == Catch::Approx(0.0f));
+    REQUIRE(b.h == Catch::Approx(0.0f));
+}
+
+TEST_CASE("DirtyTracker debug overlay flag toggles independently", "[render][dirty][issue-646]") {
+    DirtyTracker dt;
+    REQUIRE_FALSE(dt.debug_overlay());
+    dt.set_debug_overlay(true);
+    REQUIRE(dt.debug_overlay());
+    dt.clear();
+    REQUIRE(dt.debug_overlay());
+    dt.set_debug_overlay(false);
+    REQUIRE_FALSE(dt.debug_overlay());
+}
+
+TEST_CASE("DirtyTracker threshold sums partial dirty regions", "[render][dirty][issue-646]") {
+    DirtyTracker dt;
+    dt.set_viewport(100, 100, 0.1f);
+    dt.clear();
+
+    dt.invalidate(0, 0, 20, 20);
+    REQUIRE_FALSE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().size() == 1);
+
+    dt.invalidate(50, 50, 30, 30);
+    REQUIRE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().empty());
+}
+
+TEST_CASE("DirtyTracker does not promote to full repaint without viewport", "[render][dirty][issue-646]") {
+    DirtyTracker dt;
+    dt.clear();
+    dt.invalidate(0, 0, 1000, 1000);
+    REQUIRE(dt.is_dirty());
+    REQUIRE_FALSE(dt.needs_full_repaint());
+    REQUIRE(dt.dirty_rects().size() == 1);
+}
+
+TEST_CASE("DirtyTracker coalesces nearby non-overlapping rects", "[render][dirty][issue-646]") {
+    DirtyTracker dt;
+    dt.clear();
+
+    for (int i = 0; i < 20; ++i) {
+        dt.invalidate(static_cast<float>(i * 11), 0, 10, 10);
+    }
+
+    REQUIRE(dt.dirty_rects().size() < 20);
+    auto b = dt.bounds();
+    REQUIRE(b.x == Catch::Approx(0.0f));
+    REQUIRE(b.y == Catch::Approx(0.0f));
+    REQUIRE(b.w >= 219.0f);
+    REQUIRE(b.h == Catch::Approx(10.0f));
+}
+
 TEST_CASE("Rect intersection", "[render][dirty]") {
     DirtyTracker::Rect a{0, 0, 10, 10};
     DirtyTracker::Rect b{5, 5, 10, 10};
     DirtyTracker::Rect c{20, 20, 10, 10};
     REQUIRE(a.intersects(b));
     REQUIRE_FALSE(a.intersects(c));
+}
+
+TEST_CASE("Rect merge returns bounding box", "[render][dirty][issue-646]") {
+    DirtyTracker::Rect a{10, 20, 30, 40};
+    DirtyTracker::Rect b{-5, 10, 20, 15};
+    auto m = a.merged(b);
+    REQUIRE(m.x == Catch::Approx(-5.0f));
+    REQUIRE(m.y == Catch::Approx(10.0f));
+    REQUIRE(m.w == Catch::Approx(45.0f));
+    REQUIRE(m.h == Catch::Approx(50.0f));
+}
+
+TEST_CASE("Rect intersection excludes edge-touching rects", "[render][dirty][issue-646]") {
+    DirtyTracker::Rect a{0, 0, 10, 10};
+    DirtyTracker::Rect touches_right{10, 0, 10, 10};
+    DirtyTracker::Rect touches_bottom{0, 10, 10, 10};
+    REQUIRE_FALSE(a.intersects(touches_right));
+    REQUIRE_FALSE(a.intersects(touches_bottom));
 }

--- a/test/test_rendering_integration.cpp
+++ b/test/test_rendering_integration.cpp
@@ -330,6 +330,20 @@ TEST_CASE("KTX2 availability check", "[render][ktx2]") {
 // stop cycle. They exercise the factory + public lifecycle surface
 // without requiring a real GPU surface or window handle.
 
+#if !defined(__APPLE__)
+namespace {
+bool wait_for_frames(std::atomic<int>& frames, int target) {
+    for (int i = 0; i < 200; ++i) {
+        if (frames.load(std::memory_order_relaxed) >= target) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return frames.load(std::memory_order_relaxed) >= target;
+}
+} // namespace
+#endif
+
 TEST_CASE("RenderLoop factory returns a loop that starts and stops - issue-646",
           "[render][loop][issue-646]") {
     auto loop = render::RenderLoop::create();
@@ -392,3 +406,41 @@ TEST_CASE("RenderLoop request_frame before start is a safe no-op - issue-646",
     loop->request_frame();
     REQUIRE_FALSE(loop->is_running());
 }
+
+#if !defined(__APPLE__)
+TEST_CASE("RenderLoop timer backend invokes requested frames - issue-646",
+          "[render][loop][issue-646]") {
+    auto loop = render::RenderLoop::create();
+    REQUIRE(loop != nullptr);
+
+    std::atomic<int> frames{0};
+    loop->start([&]() { frames.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(loop->is_running());
+
+    REQUIRE(wait_for_frames(frames, 1));
+    const auto before_request = frames.load(std::memory_order_relaxed);
+    loop->request_frame();
+    REQUIRE(wait_for_frames(frames, before_request + 1));
+
+    loop->stop();
+    REQUIRE_FALSE(loop->is_running());
+}
+
+TEST_CASE("RenderLoop timer backend restarts after stop - issue-646",
+          "[render][loop][issue-646]") {
+    auto loop = render::RenderLoop::create();
+    REQUIRE(loop != nullptr);
+
+    std::atomic<int> frames{0};
+    loop->start([&]() { frames.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(wait_for_frames(frames, 1));
+    loop->stop();
+    REQUIRE_FALSE(loop->is_running());
+
+    loop->start([&]() { frames.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(loop->is_running());
+    REQUIRE(wait_for_frames(frames, 2));
+    loop->stop();
+    REQUIRE_FALSE(loop->is_running());
+}
+#endif


### PR DESCRIPTION
## Summary
- extend DirtyTracker coverage for negative/empty rects, debug overlay state, threshold accumulation, no-viewport behavior, nearby non-overlap coalescing, and Rect merge/touching edges
- add non-Apple TimerRenderLoop callback/restart coverage while preserving macOS CVDisplayLink lifecycle coverage

Parent: #641
Closes part of #646
Label: codecov

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
- cmake --build build --target pulp-test-dirty-tracker pulp-test-rendering-integration -j4
- ./build/test/pulp-test-dirty-tracker
- ./build/test/pulp-test-rendering-integration
- ctest --test-dir build -R "DirtyTracker|RenderLoop|dirty|render.*loop" --output-on-failure
- PULP_ENFORCE_PREPUSH=1 tools/scripts/skill_sync_check.py
- PULP_ENFORCE_PREPUSH=1 tools/scripts/version_bump_check.py
- git diff --check