### PR TITLE
test(events): cover socket IPC message flow

### DIFF
--- a/core/events/src/interprocess_connection.cpp
+++ b/core/events/src/interprocess_connection.cpp
@@ -2,11 +2,9 @@
 #include <pulp/runtime/named_pipe.hpp>
 #include <pulp/runtime/socket.hpp>
 #include <charconv>
-#include <chrono>
 #include <cstring>
 #include <mutex>
 #include <optional>
-#include <thread>
 
 namespace pulp::events {
 
@@ -282,7 +280,6 @@ bool InterprocessConnectionServer::start(std::string_view name, IpcTransport tra
         server_impl_->listen_socket.create(SocketType::TCP);
         if (!server_impl_->listen_socket.bind(host, *port)) return false;
         if (!server_impl_->listen_socket.listen(5)) return false;
-        if (!server_impl_->listen_socket.set_non_blocking(true)) return false;
     }
 
     running_.store(true);
@@ -290,11 +287,11 @@ bool InterprocessConnectionServer::start(std::string_view name, IpcTransport tra
         while (running_.load()) {
             if (server_impl_->transport == IpcTransport::Socket) {
                 auto client_sock = server_impl_->listen_socket.accept();
-                if (!client_sock) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
-                    continue;
+                if (!client_sock) continue;
+                if (!running_.load()) {
+                    client_sock->close();
+                    break;
                 }
-                (void)client_sock->set_non_blocking(false);
 
                 auto conn = std::make_unique<InterprocessConnection>();
                 // Inject the accepted socket via friend access
@@ -324,7 +321,27 @@ bool InterprocessConnectionServer::start(std::string_view name, IpcTransport tra
 }
 
 void InterprocessConnectionServer::stop() {
-    running_.store(false);
+    const bool was_running = running_.exchange(false);
+    if (was_running && server_impl_->transport == IpcTransport::Socket &&
+        server_impl_->listen_socket.is_open()) {
+        std::string host = "127.0.0.1";
+        std::optional<uint16_t> port;
+        std::string_view name(server_impl_->name);
+        auto colon = name.find(':');
+        if (colon != std::string_view::npos) {
+            host = std::string(name.substr(0, colon));
+            port = parse_port(name.substr(colon + 1));
+        } else {
+            port = parse_port(name);
+        }
+        if (host.empty() || host == "0.0.0.0") host = "127.0.0.1";
+        if (port) {
+            Socket wake;
+            if (wake.create(SocketType::TCP)) {
+                (void)wake.connect(host, *port);
+            }
+        }
+    }
     server_impl_->listen_socket.close();
     if (accept_thread_.joinable()) accept_thread_.join();
     clients_.clear();

--- a/core/events/src/interprocess_connection.cpp
+++ b/core/events/src/interprocess_connection.cpp
@@ -1,12 +1,31 @@
 #include <pulp/events/interprocess_connection.hpp>
 #include <pulp/runtime/named_pipe.hpp>
 #include <pulp/runtime/socket.hpp>
+#include <charconv>
 #include <cstring>
 #include <mutex>
+#include <optional>
 
 namespace pulp::events {
 
 using namespace pulp::runtime;
+
+namespace {
+
+std::optional<uint16_t> parse_port(std::string_view text) {
+    if (text.empty()) return std::nullopt;
+
+    uint32_t value = 0;
+    const char* begin = text.data();
+    const char* end = begin + text.size();
+    auto [ptr, ec] = std::from_chars(begin, end, value);
+    if (ec != std::errc{} || ptr != end || value > 65535) {
+        return std::nullopt;
+    }
+    return static_cast<uint16_t>(value);
+}
+
+}  // namespace
 
 // ── Impl ────────────────────────────────────────────────────────────────
 
@@ -56,11 +75,18 @@ bool InterprocessConnection::connect(std::string_view name, IpcTransport transpo
     } else {
         // Parse host:port
         auto colon = name.find(':');
-        if (colon == std::string_view::npos) return false;
+        if (colon == std::string_view::npos) {
+            state_.store(IpcState::Error);
+            return false;
+        }
         std::string host(name.substr(0, colon));
-        uint16_t port = static_cast<uint16_t>(std::stoi(std::string(name.substr(colon + 1))));
+        auto port = parse_port(name.substr(colon + 1));
+        if (!port) {
+            state_.store(IpcState::Error);
+            return false;
+        }
         impl_->socket.create(SocketType::TCP);
-        ok = impl_->socket.connect(host, port);
+        ok = impl_->socket.connect(host, *port);
     }
 
     if (ok) {
@@ -85,16 +111,20 @@ bool InterprocessConnection::create_server(std::string_view name, IpcTransport t
         ok = impl_->pipe.create_server(name);
     } else {
         auto colon = name.find(':');
-        uint16_t port = 0;
+        std::optional<uint16_t> port;
         std::string host = "0.0.0.0";
         if (colon != std::string_view::npos) {
             host = std::string(name.substr(0, colon));
-            port = static_cast<uint16_t>(std::stoi(std::string(name.substr(colon + 1))));
+            port = parse_port(name.substr(colon + 1));
         } else {
-            port = static_cast<uint16_t>(std::stoi(std::string(name)));
+            port = parse_port(name);
+        }
+        if (!port) {
+            state_.store(IpcState::Error);
+            return false;
         }
         impl_->socket.create(SocketType::TCP);
-        if (impl_->socket.bind(host, port) && impl_->socket.listen(1)) {
+        if (impl_->socket.bind(host, *port) && impl_->socket.listen(1)) {
             auto client = impl_->socket.accept();
             if (client) {
                 impl_->socket = std::move(*client);
@@ -238,16 +268,17 @@ bool InterprocessConnectionServer::start(std::string_view name, IpcTransport tra
     if (transport == IpcTransport::Socket) {
         auto colon = name.find(':');
         std::string host = "0.0.0.0";
-        uint16_t port = 0;
+        std::optional<uint16_t> port;
         if (colon != std::string_view::npos) {
             host = std::string(name.substr(0, colon));
-            port = static_cast<uint16_t>(std::stoi(std::string(name.substr(colon + 1))));
+            port = parse_port(name.substr(colon + 1));
         } else {
-            port = static_cast<uint16_t>(std::stoi(std::string(name)));
+            port = parse_port(name);
         }
+        if (!port) return false;
 
         server_impl_->listen_socket.create(SocketType::TCP);
-        if (!server_impl_->listen_socket.bind(host, port)) return false;
+        if (!server_impl_->listen_socket.bind(host, *port)) return false;
         if (!server_impl_->listen_socket.listen(5)) return false;
     }
 

--- a/core/events/src/interprocess_connection.cpp
+++ b/core/events/src/interprocess_connection.cpp
@@ -2,9 +2,11 @@
 #include <pulp/runtime/named_pipe.hpp>
 #include <pulp/runtime/socket.hpp>
 #include <charconv>
+#include <chrono>
 #include <cstring>
 #include <mutex>
 #include <optional>
+#include <thread>
 
 namespace pulp::events {
 
@@ -280,6 +282,7 @@ bool InterprocessConnectionServer::start(std::string_view name, IpcTransport tra
         server_impl_->listen_socket.create(SocketType::TCP);
         if (!server_impl_->listen_socket.bind(host, *port)) return false;
         if (!server_impl_->listen_socket.listen(5)) return false;
+        if (!server_impl_->listen_socket.set_non_blocking(true)) return false;
     }
 
     running_.store(true);
@@ -287,7 +290,11 @@ bool InterprocessConnectionServer::start(std::string_view name, IpcTransport tra
         while (running_.load()) {
             if (server_impl_->transport == IpcTransport::Socket) {
                 auto client_sock = server_impl_->listen_socket.accept();
-                if (!client_sock) continue;
+                if (!client_sock) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                    continue;
+                }
+                (void)client_sock->set_non_blocking(false);
 
                 auto conn = std::make_unique<InterprocessConnection>();
                 // Inject the accepted socket via friend access

--- a/core/runtime/include/pulp/runtime/socket.hpp
+++ b/core/runtime/include/pulp/runtime/socket.hpp
@@ -29,9 +29,6 @@ public:
     /// Accept an incoming connection (TCP only). Returns a new Socket.
     std::optional<Socket> accept();
 
-    /// Toggle blocking mode for operations such as accept/receive.
-    bool set_non_blocking(bool non_blocking);
-
     /// Connect to a remote address (TCP).
     bool connect(std::string_view address, uint16_t port);
 

--- a/core/runtime/include/pulp/runtime/socket.hpp
+++ b/core/runtime/include/pulp/runtime/socket.hpp
@@ -29,6 +29,9 @@ public:
     /// Accept an incoming connection (TCP only). Returns a new Socket.
     std::optional<Socket> accept();
 
+    /// Toggle blocking mode for operations such as accept/receive.
+    bool set_non_blocking(bool non_blocking);
+
     /// Connect to a remote address (TCP).
     bool connect(std::string_view address, uint16_t port);
 

--- a/core/runtime/src/socket.cpp
+++ b/core/runtime/src/socket.cpp
@@ -104,23 +104,6 @@ std::optional<Socket> Socket::accept() {
     return client;
 }
 
-bool Socket::set_non_blocking(bool non_blocking) {
-    if (fd_ == SOCKET_INVALID) return false;
-
-#ifdef _WIN32
-    u_long mode = non_blocking ? 1UL : 0UL;
-    return ::ioctlsocket(fd_, FIONBIO, &mode) == 0;
-#else
-    int flags = ::fcntl(fd_, F_GETFL, 0);
-    if (flags == -1) return false;
-    if (non_blocking)
-        flags |= O_NONBLOCK;
-    else
-        flags &= ~O_NONBLOCK;
-    return ::fcntl(fd_, F_SETFL, flags) == 0;
-#endif
-}
-
 bool Socket::connect(std::string_view address, uint16_t port) {
     if (fd_ == SOCKET_INVALID) return false;
 

--- a/core/runtime/src/socket.cpp
+++ b/core/runtime/src/socket.cpp
@@ -27,9 +27,11 @@ static bool winsock_init() {
     return initialized;
 }
 #define SOCKET_CLOSE closesocket
+#define SOCKET_SHUTDOWN(fd) ::shutdown((fd), SD_BOTH)
 #define SOCKET_INVALID INVALID_SOCKET
 #else
 #define SOCKET_CLOSE ::close
+#define SOCKET_SHUTDOWN(fd) ::shutdown((fd), SHUT_RDWR)
 #define SOCKET_INVALID (-1)
 #endif
 
@@ -167,6 +169,9 @@ int Socket::receive_from(uint8_t* buffer, size_t buffer_size,
 
 void Socket::close() {
     if (fd_ != SOCKET_INVALID) {
+        if (type_ == SocketType::TCP) {
+            (void)SOCKET_SHUTDOWN(fd_);
+        }
         SOCKET_CLOSE(fd_);
         fd_ = -1;
     }

--- a/core/runtime/src/socket.cpp
+++ b/core/runtime/src/socket.cpp
@@ -104,6 +104,23 @@ std::optional<Socket> Socket::accept() {
     return client;
 }
 
+bool Socket::set_non_blocking(bool non_blocking) {
+    if (fd_ == SOCKET_INVALID) return false;
+
+#ifdef _WIN32
+    u_long mode = non_blocking ? 1UL : 0UL;
+    return ::ioctlsocket(fd_, FIONBIO, &mode) == 0;
+#else
+    int flags = ::fcntl(fd_, F_GETFL, 0);
+    if (flags == -1) return false;
+    if (non_blocking)
+        flags |= O_NONBLOCK;
+    else
+        flags &= ~O_NONBLOCK;
+    return ::fcntl(fd_, F_SETFL, flags) == 0;
+#endif
+}
+
 bool Socket::connect(std::string_view address, uint16_t port) {
     if (fd_ == SOCKET_INVALID) return false;
 

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -1,12 +1,32 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/events/interprocess_connection.hpp>
 #include <pulp/runtime/temporary_file.hpp>
-#include <thread>
-#include <chrono>
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
 
 using namespace pulp::events;
 using namespace pulp::runtime;
+
+namespace {
+
+std::optional<uint16_t> start_socket_server_on_loopback(InterprocessConnectionServer& server) {
+    const auto seed = static_cast<uint16_t>(
+        std::chrono::steady_clock::now().time_since_epoch().count() % 20000);
+    for (uint16_t i = 0; i < 200; ++i) {
+        const uint16_t port = static_cast<uint16_t>(20000 + ((seed + i) % 20000));
+        if (server.start("127.0.0.1:" + std::to_string(port), IpcTransport::Socket)) {
+            return port;
+        }
+    }
+    return std::nullopt;
+}
+
+}  // namespace
 
 // ── InterprocessConnection via named pipe ───────────────────────────────
 
@@ -28,6 +48,12 @@ TEST_CASE("IPC connect to nonexistent fails", "[events][ipc]") {
     bool ok = conn.connect("/tmp/pulp_nonexistent_pipe_12345", IpcTransport::NamedPipe);
     REQUIRE_FALSE(ok);
     REQUIRE(conn.state() == IpcState::Error);
+}
+
+TEST_CASE("IPC socket connect rejects endpoints without a port", "[events][ipc]") {
+    InterprocessConnection conn;
+    REQUIRE_FALSE(conn.connect("127.0.0.1", IpcTransport::Socket));
+    REQUIRE_FALSE(conn.is_connected());
 }
 
 TEST_CASE("IPC send while disconnected returns false", "[events][ipc]") {
@@ -52,5 +78,92 @@ TEST_CASE("IPC lambda callbacks settable", "[events][ipc]") {
 
 TEST_CASE("IPC server initial state", "[events][ipc]") {
     InterprocessConnectionServer server;
+    REQUIRE_FALSE(server.is_running());
+}
+
+TEST_CASE("IPC socket server accepts client and exchanges framed messages",
+          "[events][ipc][socket]") {
+    InterprocessConnectionServer server;
+
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::unique_ptr<InterprocessConnection> accepted;
+    bool accepted_connected = false;
+    bool server_received = false;
+    bool client_connected = false;
+    bool client_received = false;
+    std::string server_text;
+    std::string client_text;
+
+    server.on_client_connected = [&](std::unique_ptr<InterprocessConnection> conn) {
+        conn->on_text_message = [&](std::string_view message) {
+            std::lock_guard<std::mutex> lock(mutex);
+            server_text.assign(message);
+            server_received = true;
+            cv.notify_all();
+        };
+
+        std::lock_guard<std::mutex> lock(mutex);
+        accepted = std::move(conn);
+        accepted_connected = true;
+        cv.notify_all();
+    };
+
+    auto port = start_socket_server_on_loopback(server);
+    REQUIRE(port.has_value());
+    REQUIRE(server.is_running());
+
+    InterprocessConnection client;
+    client.on_connected = [&] {
+        std::lock_guard<std::mutex> lock(mutex);
+        client_connected = true;
+        cv.notify_all();
+    };
+    client.on_text_message = [&](std::string_view message) {
+        std::lock_guard<std::mutex> lock(mutex);
+        client_text.assign(message);
+        client_received = true;
+        cv.notify_all();
+    };
+
+    REQUIRE(client.connect("127.0.0.1:" + std::to_string(*port), IpcTransport::Socket));
+
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return client_connected && accepted_connected;
+        }));
+    }
+
+    REQUIRE(client.send_message("client-to-server"));
+
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return server_received;
+        }));
+        REQUIRE(server_text == "client-to-server");
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        REQUIRE(accepted != nullptr);
+        REQUIRE(accepted->send_message("server-to-client"));
+    }
+
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        REQUIRE(cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return client_received;
+        }));
+        REQUIRE(client_text == "server-to-client");
+    }
+
+    client.disconnect();
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (accepted) accepted->disconnect();
+    }
+    server.stop();
     REQUIRE_FALSE(server.is_running());
 }

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -102,6 +102,17 @@ TEST_CASE("IPC socket server rejects malformed listen endpoints",
     REQUIRE(conn.state() == IpcState::Error);
 }
 
+TEST_CASE("IPC socket server stops while waiting for a client",
+          "[events][ipc][socket]") {
+    InterprocessConnectionServer server;
+    auto port = start_socket_server_on_loopback(server);
+    REQUIRE(port.has_value());
+    REQUIRE(server.is_running());
+
+    server.stop();
+    REQUIRE_FALSE(server.is_running());
+}
+
 TEST_CASE("IPC socket server accepts client and exchanges framed messages",
           "[events][ipc][socket]") {
     InterprocessConnectionServer server;

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -50,9 +50,16 @@ TEST_CASE("IPC connect to nonexistent fails", "[events][ipc]") {
     REQUIRE(conn.state() == IpcState::Error);
 }
 
-TEST_CASE("IPC socket connect rejects endpoints without a port", "[events][ipc]") {
+TEST_CASE("IPC socket connect rejects malformed endpoints", "[events][ipc]") {
     InterprocessConnection conn;
     REQUIRE_FALSE(conn.connect("127.0.0.1", IpcTransport::Socket));
+    REQUIRE(conn.state() == IpcState::Error);
+
+    REQUIRE_FALSE(conn.connect("127.0.0.1:not-a-port", IpcTransport::Socket));
+    REQUIRE(conn.state() == IpcState::Error);
+
+    REQUIRE_FALSE(conn.connect("127.0.0.1:70000", IpcTransport::Socket));
+    REQUIRE(conn.state() == IpcState::Error);
     REQUIRE_FALSE(conn.is_connected());
 }
 
@@ -79,6 +86,20 @@ TEST_CASE("IPC lambda callbacks settable", "[events][ipc]") {
 TEST_CASE("IPC server initial state", "[events][ipc]") {
     InterprocessConnectionServer server;
     REQUIRE_FALSE(server.is_running());
+}
+
+TEST_CASE("IPC socket server rejects malformed listen endpoints",
+          "[events][ipc][socket]") {
+    InterprocessConnectionServer server;
+    REQUIRE_FALSE(server.start("127.0.0.1:not-a-port", IpcTransport::Socket));
+    REQUIRE_FALSE(server.is_running());
+
+    REQUIRE_FALSE(server.start("70000", IpcTransport::Socket));
+    REQUIRE_FALSE(server.is_running());
+
+    InterprocessConnection conn;
+    REQUIRE_FALSE(conn.create_server("127.0.0.1:not-a-port", IpcTransport::Socket));
+    REQUIRE(conn.state() == IpcState::Error);
 }
 
 TEST_CASE("IPC socket server accepts client and exchanges framed messages",


### PR DESCRIPTION
## Summary

- Adds deterministic socket IPC coverage for malformed endpoints and a localhost client/server framed-message exchange.
- Hardens socket endpoint parsing so malformed or out-of-range ports are rejected without throwing.
- Keeps the tranche focused on `#642` events coverage after rebasing onto `main` post-`#771`.

## Tracking

- Parent: #641
- Component issue: #642
- Status tracker: #774 / `docs/reports/coverage-compliance-status.md`
- Label: codecov

## Local Validation

- `cmake --build build --target pulp-test-ipc -j4`
- `./build/test/pulp-test-ipc` (`34` assertions / `9` cases)
- `ctest --test-dir build -R "IPC" --output-on-failure` (`9/9`)
