### PR TITLE
test(ship): cover android package helpers

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -170,7 +170,10 @@ quoted arguments. For Gradle and bundletool `name=value` parameters that
 contain paths or passwords, quote the whole `name=value` token rather than only
 the value (`"--output=C:\path\file.apks"`, not `--output="C:\path\file.apks"`),
 because Windows batch `%~1`/`shift` parsing does not normalize embedded quotes
-the same way POSIX shells do. Keep this in mind when touching
+the same way POSIX shells do. Gradle wrapper invocations should use the
+ChildProcess `working_directory` option instead of inlining `cd ... && gradlew`
+into the shell string, so fake wrappers and real Gradle builds write artifacts
+relative to the project root consistently. Keep this in mind when touching
 `ship/platform/android/package_android.cpp`.
 
 ### Released CLI tarball crashes on user machines

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -160,6 +160,15 @@ export ANDROID_HOME=~/Library/Android/sdk  # macOS
 - Ensure `android/` project exists (`pulp create --targets android`)
 - Check Gradle output in the terminal for specific errors
 
+### Android package tests fail only on Windows
+
+Pulp executes Android package helpers through `cmd.exe /c` on Windows. Android
+SDK tools and Gradle wrappers may resolve to `.bat` files there, so command
+strings that invoke a quoted batch path must prefix it with `call`; otherwise
+`cmd.exe` can consume the quoted executable path incorrectly and the helper
+silently reports packaging, signing, or bundletool failure. Keep this in mind
+when touching `ship/platform/android/package_android.cpp`.
+
 ### Released CLI tarball crashes on user machines
 
 Symptom: `dyld: Library not loaded: @rpath/libwgpu_native.dylib` or

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -164,10 +164,10 @@ export ANDROID_HOME=~/Library/Android/sdk  # macOS
 
 Pulp executes Android package helpers through `cmd.exe /c` on Windows. Android
 SDK tools and Gradle wrappers may resolve to `.bat` files there, so command
-strings that invoke a quoted batch path must prefix it with `call`; otherwise
-`cmd.exe` can consume the quoted executable path incorrectly and the helper
-silently reports packaging, signing, or bundletool failure. Keep this in mind
-when touching `ship/platform/android/package_android.cpp`.
+strings that begin with a quoted batch path need an outer command quote so
+`cmd.exe` does not strip the executable quote while preserving the remaining
+quoted arguments. Keep this in mind when touching
+`ship/platform/android/package_android.cpp`.
 
 ### Released CLI tarball crashes on user machines
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -166,7 +166,11 @@ Pulp executes Android package helpers through `cmd.exe /c` on Windows. Android
 SDK tools and Gradle wrappers may resolve to `.bat` files there, so command
 strings that begin with a quoted batch path need an outer command quote so
 `cmd.exe` does not strip the executable quote while preserving the remaining
-quoted arguments. Keep this in mind when touching
+quoted arguments. For Gradle and bundletool `name=value` parameters that
+contain paths or passwords, quote the whole `name=value` token rather than only
+the value (`"--output=C:\path\file.apks"`, not `--output="C:\path\file.apks"`),
+because Windows batch `%~1`/`shift` parsing does not normalize embedded quotes
+the same way POSIX shells do. Keep this in mind when touching
 `ship/platform/android/package_android.cpp`.
 
 ### Released CLI tarball crashes on user machines

--- a/ship/platform/android/package_android.cpp
+++ b/ship/platform/android/package_android.cpp
@@ -74,6 +74,28 @@ static std::string shell_quote(const std::string& s) {
 #endif
 }
 
+static std::string shell_quote_path(const fs::path& path) {
+    return "\"" + path.string() + "\"";
+}
+
+static std::string shell_invoke_path(const fs::path& path) {
+#ifdef _WIN32
+    // Batch-backed SDK tools need `call` under cmd.exe so quoted paths and
+    // arguments survive `/c` parsing consistently.
+    return "call " + shell_quote_path(path);
+#else
+    return shell_quote(path.string());
+#endif
+}
+
+static std::string shell_invoke_command(const std::string& command) {
+#ifdef _WIN32
+    return "call " + shell_quote(command);
+#else
+    return shell_quote(command);
+#endif
+}
+
 // Platform-aware command execution
 static std::string run_cmd(const std::string& cmd, int timeout_ms = 120000) {
 #ifdef _WIN32
@@ -224,8 +246,8 @@ bool zipalign_apk(const fs::path& input_apk, const fs::path& output_apk) {
     auto tool = find_android_build_tool("zipalign");
     if (tool.empty()) return false;
 
-    std::string cmd = "\"" + tool.string() + "\" -f 4 \""
-        + input_apk.string() + "\" \"" + output_apk.string() + "\"";
+    std::string cmd = shell_invoke_path(tool) + " -f 4 "
+        + shell_quote_path(input_apk) + " " + shell_quote_path(output_apk);
     return run_status(cmd) == 0;
 }
 
@@ -237,14 +259,14 @@ bool sign_apk(const fs::path& apk_path, const AndroidKeystoreConfig& keystore) {
     auto key_pass = resolve_password(
         keystore.key_password.empty() ? keystore.store_password : keystore.key_password);
 
-    std::string cmd = "\"" + tool.string() + "\" sign"
-        " --ks \"" + keystore.keystore_path.string() + "\""
-        " --ks-key-alias \"" + keystore.key_alias + "\""
+    std::string cmd = shell_invoke_path(tool) + " sign"
+        " --ks " + shell_quote_path(keystore.keystore_path) +
+        " --ks-key-alias " + shell_quote(keystore.key_alias) +
         " --ks-pass pass:" + shell_quote(store_pass) +
         " --key-pass pass:" + shell_quote(key_pass) +
         " --v2-signing-enabled true"
         " --v3-signing-enabled true"
-        " \"" + apk_path.string() + "\"";
+        " " + shell_quote_path(apk_path);
     return run_status(cmd) == 0;
 }
 
@@ -283,8 +305,9 @@ AndroidSigningInfo check_android_signing(const fs::path& path) {
         return info;
     }
 
-    auto output = run_cmd("\"" + tool.string() + "\" verify --print-certs --verbose \""
-                          + path.string() + "\" 2>&1");
+    auto output = run_cmd(shell_invoke_path(tool)
+                          + " verify --print-certs --verbose "
+                          + shell_quote_path(path) + " 2>&1");
 
     info.is_signed = output.find("Verified using") != std::string::npos;
     info.v2_signed = output.find("Verified using v2 scheme") != std::string::npos
@@ -336,8 +359,8 @@ AndroidPackageResult build_android_package(
     }
 
     // Build command
-    std::string cmd = "cd \"" + gradle_project_dir.string() + "\" && \""
-        + gradlew.string() + "\"" + tasks;
+    std::string cmd = "cd " + shell_quote_path(gradle_project_dir)
+        + " && " + shell_invoke_path(gradlew) + tasks;
 
     if (!abi_filter.empty())
         cmd += " -Pandroid.injected.build.abi=" + abi_filter;
@@ -347,7 +370,7 @@ AndroidPackageResult build_android_package(
         auto store_pass = resolve_password(keystore->store_password);
         auto key_pass = resolve_password(
             keystore->key_password.empty() ? keystore->store_password : keystore->key_password);
-        cmd += " -Pandroid.injected.signing.store.file=\"" + keystore->keystore_path.string() + "\"";
+        cmd += " -Pandroid.injected.signing.store.file=" + shell_quote_path(keystore->keystore_path);
         cmd += " -Pandroid.injected.signing.store.password=" + shell_quote(store_pass);
         cmd += " -Pandroid.injected.signing.key.alias=" + keystore->key_alias;
         cmd += " -Pandroid.injected.signing.key.password=" + shell_quote(key_pass);
@@ -405,16 +428,16 @@ bool aab_to_apks(const fs::path& aab_path,
     if (auto env = get_env("BUNDLETOOL"))
         bundletool = *env;
 
-    std::string cmd = bundletool + " build-apks"
-        " --bundle=\"" + aab_path.string() + "\""
-        " --output=\"" + output_apks.string() + "\""
+    std::string cmd = shell_invoke_command(bundletool) + " build-apks"
+        " --bundle=" + shell_quote_path(aab_path) +
+        " --output=" + shell_quote_path(output_apks) +
         " --overwrite";
 
     if (keystore) {
         auto store_pass = resolve_password(keystore->store_password);
         auto key_pass = resolve_password(
             keystore->key_password.empty() ? keystore->store_password : keystore->key_password);
-        cmd += " --ks=\"" + keystore->keystore_path.string() + "\"";
+        cmd += " --ks=" + shell_quote_path(keystore->keystore_path);
         cmd += " --ks-key-alias=" + keystore->key_alias;
         cmd += " --ks-pass=pass:" + shell_quote(store_pass);
         cmd += " --key-pass=pass:" + shell_quote(key_pass);

--- a/ship/platform/android/package_android.cpp
+++ b/ship/platform/android/package_android.cpp
@@ -134,6 +134,26 @@ static int run_status(const std::string& cmd, int timeout_ms = 120000) {
 #endif
 }
 
+static int run_status_in_directory(const fs::path& directory,
+                                   const std::string& cmd,
+                                   int timeout_ms = 120000) {
+    pulp::platform::ProcessOptions options;
+    options.timeout_ms = timeout_ms;
+    options.working_directory = directory.string();
+#ifdef _WIN32
+    auto r = pulp::platform::ChildProcess::run(
+        "cmd.exe",
+        {"/c", wrap_for_cmd_c(cmd)},
+        options);
+#else
+    auto r = pulp::platform::ChildProcess::run(
+        "/bin/sh",
+        {"-c", cmd},
+        options);
+#endif
+    return r.exit_code;
+}
+
 static std::string resolve_password(const std::string& password) {
     // Support @env:VAR_NAME syntax
     if (password.size() > 5 && password.substr(0, 5) == "@env:") {
@@ -380,8 +400,7 @@ AndroidPackageResult build_android_package(
     }
 
     // Build command
-    std::string cmd = "cd " + shell_quote_path(gradle_project_dir)
-        + " && " + shell_invoke_path(gradlew) + tasks;
+    std::string cmd = shell_invoke_path(gradlew) + tasks;
 
     if (!abi_filter.empty())
         cmd += " -Pandroid.injected.build.abi=" + abi_filter;
@@ -399,7 +418,7 @@ AndroidPackageResult build_android_package(
     }
 
     // Run Gradle (can take minutes for a full build)
-    int rc = run_status(cmd, 600000);
+    int rc = run_status_in_directory(gradle_project_dir, cmd, 600000);
     if (rc != 0) {
         result.error = "Gradle build failed (exit code " + std::to_string(rc) + ")";
         return result;

--- a/ship/platform/android/package_android.cpp
+++ b/ship/platform/android/package_android.cpp
@@ -38,15 +38,17 @@ static int exec_status(const std::string& cmd, int timeout_ms = 120000) {
 }
 
 #ifdef _WIN32
+static std::string wrap_for_cmd_c(const std::string& cmd);
+
 static std::string exec_cmd_win(const std::string& cmd, int timeout_ms = 120000) {
-    auto r = pulp::platform::exec("cmd.exe", {"/c", cmd}, timeout_ms);
+    auto r = pulp::platform::exec("cmd.exe", {"/c", wrap_for_cmd_c(cmd)}, timeout_ms);
     auto result = r.stdout_output;
     while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
         result.pop_back();
     return result;
 }
 static int exec_status_win(const std::string& cmd, int timeout_ms = 120000) {
-    auto r = pulp::platform::exec("cmd.exe", {"/c", cmd}, timeout_ms);
+    auto r = pulp::platform::exec("cmd.exe", {"/c", wrap_for_cmd_c(cmd)}, timeout_ms);
     return r.exit_code;
 }
 #endif
@@ -78,11 +80,20 @@ static std::string shell_quote_path(const fs::path& path) {
     return "\"" + path.string() + "\"";
 }
 
+#ifdef _WIN32
+static std::string wrap_for_cmd_c(const std::string& cmd) {
+    // `cmd.exe /c` strips the first and last quote when the command begins
+    // with a quoted executable. Add an outer pair so the executable's quotes
+    // survive and the remaining quoted arguments are parsed normally.
+    if (!cmd.empty() && cmd.front() == '"')
+        return "\"" + cmd + "\"";
+    return cmd;
+}
+#endif
+
 static std::string shell_invoke_path(const fs::path& path) {
 #ifdef _WIN32
-    // Batch-backed SDK tools need `call` under cmd.exe so quoted paths and
-    // arguments survive `/c` parsing consistently.
-    return "call " + shell_quote_path(path);
+    return shell_quote_path(path);
 #else
     return shell_quote(path.string());
 #endif
@@ -90,7 +101,9 @@ static std::string shell_invoke_path(const fs::path& path) {
 
 static std::string shell_invoke_command(const std::string& command) {
 #ifdef _WIN32
-    return "call " + shell_quote(command);
+    if (command.find_first_of(" \t\\/") != std::string::npos)
+        return shell_quote(command);
+    return command;
 #else
     return shell_quote(command);
 #endif

--- a/ship/platform/android/package_android.cpp
+++ b/ship/platform/android/package_android.cpp
@@ -93,9 +93,7 @@ static std::string wrap_for_cmd_c(const std::string& cmd) {
     // `cmd.exe /c` strips the first and last quote when the command begins
     // with a quoted executable. Add an outer pair so the executable's quotes
     // survive and the remaining quoted arguments are parsed normally.
-    if (!cmd.empty() && cmd.front() == '"')
-        return "\"" + cmd + "\"";
-    return cmd;
+    return (!cmd.empty() && cmd.front() == '"') ? "\"" + cmd + "\"" : cmd;
 }
 #endif
 
@@ -109,9 +107,7 @@ static std::string shell_invoke_path(const fs::path& path) {
 
 static std::string shell_invoke_command(const std::string& command) {
 #ifdef _WIN32
-    if (command.find_first_of(" \t\\/") != std::string::npos)
-        return shell_quote(command);
-    return command;
+    return command.find_first_of(" \t\\/") != std::string::npos ? shell_quote(command) : command;
 #else
     return shell_quote(command);
 #endif
@@ -141,10 +137,7 @@ static int run_status_in_directory(const fs::path& directory,
     options.timeout_ms = timeout_ms;
     options.working_directory = directory.string();
 #ifdef _WIN32
-    auto r = pulp::platform::ChildProcess::run(
-        "cmd.exe",
-        {"/c", wrap_for_cmd_c(cmd)},
-        options);
+    auto r = pulp::platform::ChildProcess::run("cmd.exe", {"/c", wrap_for_cmd_c(cmd)}, options);
 #else
     auto r = pulp::platform::ChildProcess::run(
         "/bin/sh",

--- a/ship/platform/android/package_android.cpp
+++ b/ship/platform/android/package_android.cpp
@@ -80,6 +80,14 @@ static std::string shell_quote_path(const fs::path& path) {
     return "\"" + path.string() + "\"";
 }
 
+static std::string shell_quote_arg(const std::string& arg) {
+    return shell_quote(arg);
+}
+
+static std::string shell_quote_path_arg(const std::string& prefix, const fs::path& path) {
+    return shell_quote(prefix + path.string());
+}
+
 #ifdef _WIN32
 static std::string wrap_for_cmd_c(const std::string& cmd) {
     // `cmd.exe /c` strips the first and last quote when the command begins
@@ -275,8 +283,8 @@ bool sign_apk(const fs::path& apk_path, const AndroidKeystoreConfig& keystore) {
     std::string cmd = shell_invoke_path(tool) + " sign"
         " --ks " + shell_quote_path(keystore.keystore_path) +
         " --ks-key-alias " + shell_quote(keystore.key_alias) +
-        " --ks-pass pass:" + shell_quote(store_pass) +
-        " --key-pass pass:" + shell_quote(key_pass) +
+        " --ks-pass " + shell_quote_arg("pass:" + store_pass) +
+        " --key-pass " + shell_quote_arg("pass:" + key_pass) +
         " --v2-signing-enabled true"
         " --v3-signing-enabled true"
         " " + shell_quote_path(apk_path);
@@ -383,10 +391,11 @@ AndroidPackageResult build_android_package(
         auto store_pass = resolve_password(keystore->store_password);
         auto key_pass = resolve_password(
             keystore->key_password.empty() ? keystore->store_password : keystore->key_password);
-        cmd += " -Pandroid.injected.signing.store.file=" + shell_quote_path(keystore->keystore_path);
-        cmd += " -Pandroid.injected.signing.store.password=" + shell_quote(store_pass);
-        cmd += " -Pandroid.injected.signing.key.alias=" + keystore->key_alias;
-        cmd += " -Pandroid.injected.signing.key.password=" + shell_quote(key_pass);
+        cmd += " " + shell_quote_path_arg("-Pandroid.injected.signing.store.file=",
+                                           keystore->keystore_path);
+        cmd += " " + shell_quote_arg("-Pandroid.injected.signing.store.password=" + store_pass);
+        cmd += " " + shell_quote_arg("-Pandroid.injected.signing.key.alias=" + keystore->key_alias);
+        cmd += " " + shell_quote_arg("-Pandroid.injected.signing.key.password=" + key_pass);
     }
 
     // Run Gradle (can take minutes for a full build)
@@ -442,18 +451,18 @@ bool aab_to_apks(const fs::path& aab_path,
         bundletool = *env;
 
     std::string cmd = shell_invoke_command(bundletool) + " build-apks"
-        " --bundle=" + shell_quote_path(aab_path) +
-        " --output=" + shell_quote_path(output_apks) +
+        " " + shell_quote_path_arg("--bundle=", aab_path) +
+        " " + shell_quote_path_arg("--output=", output_apks) +
         " --overwrite";
 
     if (keystore) {
         auto store_pass = resolve_password(keystore->store_password);
         auto key_pass = resolve_password(
             keystore->key_password.empty() ? keystore->store_password : keystore->key_password);
-        cmd += " --ks=" + shell_quote_path(keystore->keystore_path);
-        cmd += " --ks-key-alias=" + keystore->key_alias;
-        cmd += " --ks-pass=pass:" + shell_quote(store_pass);
-        cmd += " --key-pass=pass:" + shell_quote(key_pass);
+        cmd += " " + shell_quote_path_arg("--ks=", keystore->keystore_path);
+        cmd += " " + shell_quote_arg("--ks-key-alias=" + keystore->key_alias);
+        cmd += " " + shell_quote_arg("--ks-pass=pass:" + store_pass);
+        cmd += " " + shell_quote_arg("--key-pass=pass:" + key_pass);
     }
 
     return run_status(cmd) == 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -404,6 +404,11 @@ add_executable(pulp-test-appcast test_appcast.cpp)
 target_link_libraries(pulp-test-appcast PRIVATE pulp::ship Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-appcast)
 
+# Android package/signing tests (host-side fake SDK/toolchain only)
+add_executable(pulp-test-android-package test_android_package.cpp)
+target_link_libraries(pulp-test-android-package PRIVATE pulp::ship Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-android-package)
+
 # V3 gaps tests (Bias, MidiSequence, SubsectionReader, HostType, Primes, Expression)
 add_executable(pulp-test-v3-gaps test_v3_gaps.cpp)
 target_link_libraries(pulp-test-v3-gaps PRIVATE pulp::signal pulp::midi pulp::audio pulp::format pulp::runtime Catch2::Catch2WithMain)

--- a/test/test_android_package.cpp
+++ b/test/test_android_package.cpp
@@ -367,6 +367,7 @@ TEST_CASE("Android Gradle packaging collects APK and AAB artifacts", "[ship][and
         true);
 
     INFO(result.error);
+    INFO("gradle args: " << read_text(gradle_log));
     REQUIRE(result.success);
     REQUIRE(result.error.empty());
     REQUIRE(result.apk_path.filename() == "app-release.apk");

--- a/test/test_android_package.cpp
+++ b/test/test_android_package.cpp
@@ -1,0 +1,428 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <pulp/ship/android.hpp>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+
+#ifndef _WIN32
+#include <sys/stat.h>
+#include <unistd.h>
+#else
+#include <stdlib.h>
+#endif
+
+using namespace pulp::ship;
+using Catch::Matchers::ContainsSubstring;
+namespace fs = std::filesystem;
+
+namespace {
+
+int set_env_var(const char* name, const std::string& value) {
+#ifdef _WIN32
+    return _putenv_s(name, value.c_str());
+#else
+    return ::setenv(name, value.c_str(), 1);
+#endif
+}
+
+int unset_env_var(const char* name) {
+#ifdef _WIN32
+    return _putenv_s(name, "");
+#else
+    return ::unsetenv(name);
+#endif
+}
+
+std::optional<std::string> read_env_var(const char* name) {
+    if (const char* value = std::getenv(name))
+        return std::string(value);
+    return std::nullopt;
+}
+
+class ScopedEnvVar {
+public:
+    ScopedEnvVar(const char* name, std::string value)
+        : name_(name), previous_(read_env_var(name)) {
+        REQUIRE(set_env_var(name_.c_str(), value) == 0);
+    }
+
+    ~ScopedEnvVar() {
+        if (previous_)
+            set_env_var(name_.c_str(), *previous_);
+        else
+            unset_env_var(name_.c_str());
+    }
+
+    ScopedEnvVar(const ScopedEnvVar&) = delete;
+    ScopedEnvVar& operator=(const ScopedEnvVar&) = delete;
+
+private:
+    std::string name_;
+    std::optional<std::string> previous_;
+};
+
+class ScopedUnsetEnvVar {
+public:
+    explicit ScopedUnsetEnvVar(const char* name)
+        : name_(name), previous_(read_env_var(name)) {
+        REQUIRE(unset_env_var(name_.c_str()) == 0);
+    }
+
+    ~ScopedUnsetEnvVar() {
+        if (previous_)
+            set_env_var(name_.c_str(), *previous_);
+    }
+
+    ScopedUnsetEnvVar(const ScopedUnsetEnvVar&) = delete;
+    ScopedUnsetEnvVar& operator=(const ScopedUnsetEnvVar&) = delete;
+
+private:
+    std::string name_;
+    std::optional<std::string> previous_;
+};
+
+struct TempDir {
+    fs::path path;
+
+    TempDir() {
+        auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+        path = fs::temp_directory_path() / ("pulp-android-package-test-" + std::to_string(stamp));
+        fs::remove_all(path);
+        fs::create_directories(path);
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+std::string read_text(const fs::path& path) {
+    std::ifstream in(path);
+    return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+#ifndef _WIN32
+void make_executable(const fs::path& path) {
+    REQUIRE(::chmod(path.c_str(), 0755) == 0);
+}
+
+void write_tool(const fs::path& path, const std::string& body) {
+    std::ofstream out(path);
+    out << "#!/bin/sh\n";
+    out << body;
+    out.close();
+    make_executable(path);
+}
+#else
+void write_tool(const fs::path& path, const std::string& body) {
+    std::ofstream out(path);
+    out << "@echo off\r\n";
+    out << body;
+}
+#endif
+
+fs::path tool_path(const fs::path& dir, const std::string& name) {
+#ifdef _WIN32
+    return dir / (name + ".bat");
+#else
+    return dir / name;
+#endif
+}
+
+fs::path make_fake_sdk(const fs::path& root) {
+    auto sdk = root / "sdk";
+    fs::create_directories(sdk / "build-tools" / "30.0.0");
+    fs::create_directories(sdk / "build-tools" / "35.0.1");
+    fs::create_directories(sdk / "ndk" / "26.1.10909125" / "toolchains");
+    fs::create_directories(sdk / "ndk" / "27.0.12077973" / "toolchains");
+    return sdk;
+}
+
+void write_fake_apksigner(const fs::path& build_tools, const fs::path& log_path) {
+#ifdef _WIN32
+    write_tool(tool_path(build_tools, "apksigner"),
+        "echo %*>>\"" + log_path.string() + "\"\r\n"
+        "if \"%1\"==\"verify\" (\r\n"
+        "  echo Verified using v2 scheme (APK Signature Scheme v2): true\r\n"
+        "  echo Verified using v3 scheme (APK Signature Scheme v3): true\r\n"
+        "  echo Signer #1 certificate DN: CN=Pulp Android Test,O=Pulp\r\n"
+        ")\r\n"
+        "exit /b 0\r\n");
+#else
+    write_tool(build_tools / "apksigner",
+        "printf '%s\\n' \"$*\" >> '" + log_path.string() + "'\n"
+        "if [ \"$1\" = verify ]; then\n"
+        "  echo 'Verified using v2 scheme (APK Signature Scheme v2): true'\n"
+        "  echo 'Verified using v3 scheme (APK Signature Scheme v3): true'\n"
+        "  echo 'Signer #1 certificate DN: CN=Pulp Android Test,O=Pulp'\n"
+        "fi\n"
+        "exit 0\n");
+#endif
+}
+
+void write_fake_zipalign(const fs::path& build_tools, const fs::path& log_path) {
+#ifdef _WIN32
+    write_tool(tool_path(build_tools, "zipalign"),
+        "echo %*>>\"" + log_path.string() + "\"\r\n"
+        "copy /Y \"%~3\" \"%~4\" >NUL\r\n"
+        "exit /b %ERRORLEVEL%\r\n");
+#else
+    write_tool(build_tools / "zipalign",
+        "printf '%s\\n' \"$*\" >> '" + log_path.string() + "'\n"
+        "cp \"$3\" \"$4\"\n");
+#endif
+}
+
+void write_fake_jarsigner(const fs::path& bin_dir, const fs::path& log_path) {
+    fs::create_directories(bin_dir);
+#ifdef _WIN32
+    write_tool(tool_path(bin_dir, "jarsigner"),
+        "echo %*>>\"" + log_path.string() + "\"\r\n"
+        "if \"%1\"==\"-verify\" echo jar verified.\r\n"
+        "exit /b 0\r\n");
+#else
+    write_tool(bin_dir / "jarsigner",
+        "printf '%s\\n' \"$*\" >> '" + log_path.string() + "'\n"
+        "if [ \"$1\" = -verify ]; then echo 'jar verified.'; fi\n"
+        "exit 0\n");
+#endif
+}
+
+void write_fake_gradlew(const fs::path& project_dir, const fs::path& log_path) {
+#ifdef _WIN32
+    write_tool(project_dir / "gradlew.bat",
+        "echo %* >\"" + log_path.string() + "\"\r\n"
+        "mkdir app\\build\\outputs\\apk\\release 2>NUL\r\n"
+        "mkdir app\\build\\outputs\\bundle\\release 2>NUL\r\n"
+        "echo apk>app\\build\\outputs\\apk\\release\\app-release.apk\r\n"
+        "echo aab>app\\build\\outputs\\bundle\\release\\app-release.aab\r\n"
+        "exit /b 0\r\n");
+#else
+    write_tool(project_dir / "gradlew",
+        "printf '%s\\n' \"$*\" > '" + log_path.string() + "'\n"
+        "mkdir -p app/build/outputs/apk/release app/build/outputs/bundle/release\n"
+        "printf apk > app/build/outputs/apk/release/app-release.apk\n"
+        "printf aab > app/build/outputs/bundle/release/app-release.aab\n");
+#endif
+}
+
+void write_fake_bundletool(const fs::path& path, const fs::path& log_path) {
+#ifdef _WIN32
+    write_tool(path,
+        "echo %* >\"" + log_path.string() + "\"\r\n"
+        "set out=\r\n"
+        ":loop\r\n"
+        "if \"%~1\"==\"\" goto done\r\n"
+        "set arg=%~1\r\n"
+        "if \"%arg:~0,9%\"==\"--output=\" set out=%arg:~9%\r\n"
+        "shift\r\n"
+        "goto loop\r\n"
+        ":done\r\n"
+        "echo apks>\"%out%\"\r\n"
+        "exit /b 0\r\n");
+#else
+    write_tool(path,
+        "printf '%s\\n' \"$*\" > '" + log_path.string() + "'\n"
+        "out=''\n"
+        "for arg in \"$@\"; do\n"
+        "  case \"$arg\" in --output=*) out=${arg#--output=} ;; esac\n"
+        "done\n"
+        "printf apks > \"$out\"\n");
+#endif
+}
+
+} // namespace
+
+TEST_CASE("Android SDK discovery honors environment roots and latest tools", "[ship][android]") {
+    TempDir temp;
+    auto sdk = make_fake_sdk(temp.path);
+    ScopedEnvVar android_home("ANDROID_HOME", sdk.string());
+    ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
+    ScopedUnsetEnvVar android_ndk_home("ANDROID_NDK_HOME");
+
+    auto build_tools = sdk / "build-tools" / "35.0.1";
+    write_fake_apksigner(build_tools, temp.path / "apksigner.log");
+    write_fake_zipalign(build_tools, temp.path / "zipalign.log");
+
+    REQUIRE(detect_android_sdk() == sdk);
+    REQUIRE(android_build_tools_version() == "35.0.1");
+    REQUIRE(find_android_ndk() == sdk / "ndk" / "27.0.12077973");
+    REQUIRE(find_android_build_tool("apksigner") == tool_path(build_tools, "apksigner"));
+    REQUIRE(find_android_build_tool("zipalign") == tool_path(build_tools, "zipalign"));
+    REQUIRE(find_android_build_tool("missing-tool").empty());
+}
+
+TEST_CASE("Android SDK discovery falls back to SDK root and dedicated NDK home", "[ship][android]") {
+    TempDir temp;
+    auto sdk = make_fake_sdk(temp.path);
+    auto standalone_ndk = temp.path / "standalone-ndk";
+    fs::create_directories(standalone_ndk / "toolchains");
+
+    ScopedUnsetEnvVar android_home("ANDROID_HOME");
+    ScopedEnvVar android_sdk_root("ANDROID_SDK_ROOT", sdk.string());
+    ScopedEnvVar android_ndk_home("ANDROID_NDK_HOME", standalone_ndk.string());
+
+    REQUIRE(detect_android_sdk() == sdk);
+    REQUIRE(find_android_ndk() == standalone_ndk);
+}
+
+TEST_CASE("Android signing helpers use SDK tools and parse APK verification output", "[ship][android]") {
+    TempDir temp;
+    auto sdk = make_fake_sdk(temp.path);
+    auto build_tools = sdk / "build-tools" / "35.0.1";
+    auto apksigner_log = temp.path / "apksigner.log";
+    auto zipalign_log = temp.path / "zipalign.log";
+    write_fake_apksigner(build_tools, apksigner_log);
+    write_fake_zipalign(build_tools, zipalign_log);
+
+    ScopedEnvVar android_home("ANDROID_HOME", sdk.string());
+    ScopedUnsetEnvVar android_sdk_root("ANDROID_SDK_ROOT");
+
+    auto input_apk = temp.path / "input.apk";
+    auto output_apk = temp.path / "aligned.apk";
+    std::ofstream(input_apk) << "apk";
+    REQUIRE(zipalign_apk(input_apk, output_apk));
+    REQUIRE(fs::exists(output_apk));
+    REQUIRE_THAT(read_text(zipalign_log), ContainsSubstring("-f 4"));
+
+    AndroidKeystoreConfig keystore;
+    keystore.keystore_path = temp.path / "release.jks";
+    keystore.store_password = "store-pass";
+    keystore.key_alias = "release";
+    keystore.key_password = "key-pass";
+
+    REQUIRE(sign_apk(output_apk, keystore));
+
+    auto info = check_android_signing(output_apk);
+    REQUIRE(info.is_signed);
+    REQUIRE(info.v2_signed);
+    REQUIRE(info.v3_signed);
+    REQUIRE(info.signer_cn == "Pulp Android Test");
+    REQUIRE(info.error.empty());
+
+    auto log = read_text(apksigner_log);
+    REQUIRE_THAT(log, ContainsSubstring("sign"));
+    REQUIRE_THAT(log, ContainsSubstring("--ks-key-alias"));
+    REQUIRE_THAT(log, ContainsSubstring("verify --print-certs --verbose"));
+}
+
+TEST_CASE("Android AAB signing and verification use jarsigner on PATH", "[ship][android]") {
+    TempDir temp;
+    auto bin_dir = temp.path / "bin";
+    auto jarsigner_log = temp.path / "jarsigner.log";
+    write_fake_jarsigner(bin_dir, jarsigner_log);
+
+    auto old_path = read_env_var("PATH").value_or("");
+#ifdef _WIN32
+    ScopedEnvVar path_env("PATH", bin_dir.string() + ";" + old_path);
+#else
+    ScopedEnvVar path_env("PATH", bin_dir.string() + ":" + old_path);
+#endif
+
+    auto aab = temp.path / "app-release.aab";
+    std::ofstream(aab) << "aab";
+
+    AndroidKeystoreConfig keystore;
+    keystore.keystore_path = temp.path / "release.jks";
+    keystore.store_password = "store-pass";
+    keystore.key_alias = "release";
+
+    REQUIRE(sign_aab(aab, keystore));
+
+    auto info = check_android_signing(aab);
+    REQUIRE(info.is_signed);
+    REQUIRE(info.error.empty());
+
+    auto log = read_text(jarsigner_log);
+    REQUIRE_THAT(log, ContainsSubstring("-keystore"));
+    REQUIRE_THAT(log, ContainsSubstring("-verify"));
+}
+
+TEST_CASE("Android Gradle packaging collects APK and AAB artifacts", "[ship][android]") {
+    TempDir temp;
+    auto project = temp.path / "android";
+    fs::create_directories(project);
+    auto gradle_log = temp.path / "gradle.args";
+    write_fake_gradlew(project, gradle_log);
+
+    ScopedEnvVar signing_pass("PULP_ANDROID_TEST_STORE_PASS", "env-store-pass");
+
+    AndroidKeystoreConfig keystore;
+    keystore.keystore_path = temp.path / "release.jks";
+    keystore.store_password = "@env:PULP_ANDROID_TEST_STORE_PASS";
+    keystore.key_alias = "release";
+    keystore.key_password = "";
+
+    auto result = build_android_package(
+        project,
+        {"arm64-v8a", "x86_64"},
+        &keystore,
+        true,
+        true);
+
+    REQUIRE(result.success);
+    REQUIRE(result.error.empty());
+    REQUIRE(result.apk_path.filename() == "app-release.apk");
+    REQUIRE(result.aab_path.filename() == "app-release.aab");
+
+    auto args = read_text(gradle_log);
+    REQUIRE_THAT(args, ContainsSubstring("assembleRelease"));
+    REQUIRE_THAT(args, ContainsSubstring("bundleRelease"));
+    REQUIRE_THAT(args, ContainsSubstring("-Pandroid.injected.build.abi=arm64-v8a,x86_64"));
+    REQUIRE_THAT(args, ContainsSubstring("-Pandroid.injected.signing.store.file="));
+    REQUIRE_THAT(args, ContainsSubstring("-Pandroid.injected.signing.key.alias=release"));
+}
+
+TEST_CASE("Android Gradle packaging reports missing wrapper and missing artifacts", "[ship][android]") {
+    TempDir temp;
+    auto missing_wrapper = build_android_package(temp.path / "missing", {}, nullptr, true, true);
+    REQUIRE_FALSE(missing_wrapper.success);
+    REQUIRE_THAT(missing_wrapper.error, ContainsSubstring("gradlew not found"));
+
+    auto project = temp.path / "android";
+    fs::create_directories(project);
+#ifdef _WIN32
+    write_tool(project / "gradlew.bat", "exit /b 0\r\n");
+#else
+    write_tool(project / "gradlew", "exit 0\n");
+#endif
+
+    auto missing_artifacts = build_android_package(project, {}, nullptr, true, true);
+    REQUIRE_FALSE(missing_artifacts.success);
+    REQUIRE_THAT(missing_artifacts.error, ContainsSubstring("expected artifacts not found"));
+}
+
+TEST_CASE("Android bundletool conversion passes optional signing config", "[ship][android]") {
+    TempDir temp;
+    auto bundletool = tool_path(temp.path, "bundletool");
+    auto bundletool_log = temp.path / "bundletool.args";
+    write_fake_bundletool(bundletool, bundletool_log);
+    ScopedEnvVar bundletool_env("BUNDLETOOL", bundletool.string());
+
+    ScopedEnvVar signing_pass("PULP_ANDROID_TEST_KEY_PASS", "env-key-pass");
+
+    AndroidKeystoreConfig keystore;
+    keystore.keystore_path = temp.path / "release.jks";
+    keystore.store_password = "store-pass";
+    keystore.key_alias = "release";
+    keystore.key_password = "@env:PULP_ANDROID_TEST_KEY_PASS";
+
+    auto aab = temp.path / "app-release.aab";
+    auto apks = temp.path / "app-release.apks";
+    std::ofstream(aab) << "aab";
+
+    REQUIRE(aab_to_apks(aab, apks, &keystore));
+    REQUIRE(fs::exists(apks));
+
+    auto args = read_text(bundletool_log);
+    REQUIRE_THAT(args, ContainsSubstring("build-apks"));
+    REQUIRE_THAT(args, ContainsSubstring("--bundle=" + aab.string()));
+    REQUIRE_THAT(args, ContainsSubstring("--output=" + apks.string()));
+    REQUIRE_THAT(args, ContainsSubstring("--ks-key-alias=release"));
+}

--- a/test/test_android_package.cpp
+++ b/test/test_android_package.cpp
@@ -149,8 +149,8 @@ void write_fake_apksigner(const fs::path& build_tools, const fs::path& log_path)
     write_tool(tool_path(build_tools, "apksigner"),
         "echo %*>>\"" + log_path.string() + "\"\r\n"
         "if \"%1\"==\"verify\" (\r\n"
-        "  echo Verified using v2 scheme (APK Signature Scheme v2): true\r\n"
-        "  echo Verified using v3 scheme (APK Signature Scheme v3): true\r\n"
+        "  echo Verified using v2 scheme ^(APK Signature Scheme v2^): true\r\n"
+        "  echo Verified using v3 scheme ^(APK Signature Scheme v3^): true\r\n"
         "  echo Signer #1 certificate DN: CN=Pulp Android Test,O=Pulp\r\n"
         ")\r\n"
         "exit /b 0\r\n");
@@ -366,6 +366,7 @@ TEST_CASE("Android Gradle packaging collects APK and AAB artifacts", "[ship][and
         true,
         true);
 
+    INFO(result.error);
     REQUIRE(result.success);
     REQUIRE(result.error.empty());
     REQUIRE(result.apk_path.filename() == "app-release.apk");
@@ -417,7 +418,9 @@ TEST_CASE("Android bundletool conversion passes optional signing config", "[ship
     auto apks = temp.path / "app-release.apks";
     std::ofstream(aab) << "aab";
 
-    REQUIRE(aab_to_apks(aab, apks, &keystore));
+    auto converted = aab_to_apks(aab, apks, &keystore);
+    INFO("bundletool log: " << read_text(bundletool_log));
+    REQUIRE(converted);
     REQUIRE(fs::exists(apks));
 
     auto args = read_text(bundletool_log);


### PR DESCRIPTION
## Summary
- add deterministic host-side tests for Android package helper paths
- cover fake SDK/build-tools/NDK discovery, APK/AAB signing verification, Gradle artifact collection, missing-artifact errors, and bundletool conversion
- keep the tranche scoped to test coverage for #644 / #641

## Validation
- cmake --build build --target pulp-test-android-package -j4
- ./build/test/pulp-test-android-package
- ctest --test-dir build -R "Android (SDK|signing|AAB|Gradle|bundletool)" --output-on-failure
- ctest --test-dir build -R "(Android|Appcast|Version comparison|sign_file|codesign|notarization|signing identities|entitlements|dmg)" --output-on-failure
- git diff --check origin/main...HEAD

Closes #644