### PR TITLE
chore(shipyard): bump mac target timeout to 3600s

### DIFF
--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -117,6 +117,14 @@ build     = "cmake --build build --config Release --parallel; if ($LASTEXITCODE 
 [targets.mac]
 backend  = "local"
 platform = "macos-arm64"
+# Phase 8 brings the Rust CLI crate into the build graph (Dawn,
+# Skia, mbedtls, plus a fresh `cargo build` of pulp-rs). On a cold
+# FetchContent cache the configure+build runs ~35–45 min on this
+# host, well past Shipyard's default 30 min budget. Two parallel
+# ships (#790, #791) both timed out at 30:02 / 30:10 in the same
+# CMake configure stage on the Phase 8 prep branch; bump matches
+# the windows lane that already exempts itself for the same reason.
+timeout_secs = 3600
 
 [targets.ubuntu]
 backend  = "ssh"


### PR DESCRIPTION
The Phase 8 prep work (PRs #778, #790, #791) brings the Rust CLI
crate into the CMake build graph alongside the existing Dawn /
Skia / mbedtls / SDL3 FetchContent dependencies. On a cold cache
the mac configure+build runs roughly 35–45 minutes on this host,
which is well past Shipyard's default 30 min target budget.

Two consecutive ships against `feature/phase8-cmake-bridge`
(sy-20260425-b73bb9 for PR #790 and sy-20260425-38f19e for PR
#791) both timed out at 30:02 / 30:10 inside the CMake configure
stage. Ubuntu and (when reachable) Windows pass quickly because
they reuse warm SSH-host caches; mac runs locally and pays the
full FetchContent cost on a fresh worktree.

Mirror the windows lane's existing `timeout_secs = 3600` and
explain the why so future readers don't trim it back.