### PR TITLE
test(cli): cover tool registry local paths

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -214,6 +214,22 @@ target_link_libraries(pulp-test-cli-package-registry PRIVATE
     Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-cli-package-registry)
 
+# CLI tool registry (#643): local-only coverage for registry parsing,
+# managed binary / Python wrapper discovery, deterministic install exits,
+# uninstall, and command dispatch branches. Avoids downloads, archive
+# extraction, Python package installs, and executing registry tools.
+add_executable(pulp-test-cli-tool-registry
+    test_cli_tool_registry.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/tool_registry.cpp
+)
+target_include_directories(pulp-test-cli-tool-registry PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/cli)
+target_link_libraries(pulp-test-cli-tool-registry PRIVATE
+    pulp::platform
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-cli-tool-registry)
+
 # CLI project bump (#499 Slice 7 / #564): pure-logic tests for the
 # CMakeLists pin parser, rewriter, refuse-dynamic-pin gate, semver /
 # downgrade guard, and the undo-batch JSON round-trip. project_bump.cpp

--- a/test/test_cli_tool_registry.cpp
+++ b/test/test_cli_tool_registry.cpp
@@ -1,0 +1,472 @@
+// test_cli_tool_registry.cpp - deterministic tests for
+// `tools/cli/tool_registry.cpp`.
+//
+// Coverage tranche for issue #643. These tests stay on local registry,
+// discovery, uninstall, and command dispatch paths. They intentionally avoid
+// network downloads, archive extraction, Python package installs, and running
+// external tools from the registry.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "../tools/cli/tool_registry.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace fs = std::filesystem;
+using namespace pulp::cli::tools;
+
+namespace {
+
+struct TempDir {
+    fs::path path;
+
+    TempDir() {
+        auto base = fs::temp_directory_path();
+        static std::atomic<int> seq{0};
+        const int n = seq.fetch_add(1);
+        path = base / ("pulp-cli-tool-registry-test-" +
+                       std::to_string(reinterpret_cast<std::uintptr_t>(this)) +
+                       "-" + std::to_string(n));
+        fs::create_directories(path);
+        std::error_code ec;
+        auto canon = fs::weakly_canonical(path, ec);
+        if (!ec) path = canon;
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+struct ScopedEnv {
+    std::string key;
+    bool had_value = false;
+    std::string old_value;
+
+    ScopedEnv(std::string k, const fs::path& value) : key(std::move(k)) {
+        if (const char* existing = std::getenv(key.c_str())) {
+            had_value = true;
+            old_value = existing;
+        }
+        set(value.string());
+    }
+
+    ~ScopedEnv() {
+#ifdef _WIN32
+        _putenv_s(key.c_str(), had_value ? old_value.c_str() : "");
+#else
+        if (had_value)
+            setenv(key.c_str(), old_value.c_str(), 1);
+        else
+            unsetenv(key.c_str());
+#endif
+    }
+
+    void set(const std::string& value) {
+#ifdef _WIN32
+        _putenv_s(key.c_str(), value.c_str());
+#else
+        setenv(key.c_str(), value.c_str(), 1);
+#endif
+    }
+};
+
+struct ScopedCurrentPath {
+    fs::path old_path = fs::current_path();
+
+    explicit ScopedCurrentPath(const fs::path& path) {
+        fs::current_path(path);
+    }
+
+    ~ScopedCurrentPath() {
+        std::error_code ec;
+        fs::current_path(old_path, ec);
+    }
+};
+
+struct ScopedOutput {
+    std::ostringstream out;
+    std::ostringstream err;
+    std::streambuf* old_out = std::cout.rdbuf(out.rdbuf());
+    std::streambuf* old_err = std::cerr.rdbuf(err.rdbuf());
+
+    ~ScopedOutput() {
+        std::cout.rdbuf(old_out);
+        std::cerr.rdbuf(old_err);
+    }
+};
+
+void write_file(const fs::path& path, const std::string& body) {
+    fs::create_directories(path.parent_path());
+    std::ofstream f(path);
+    f << body;
+}
+
+fs::path touch_file(const fs::path& path) {
+    write_file(path, "fixture\n");
+    return path;
+}
+
+std::string quote_json(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 2);
+    for (char c : s) {
+        if (c == '"' || c == '\\') out.push_back('\\');
+        out.push_back(c);
+    }
+    return out;
+}
+
+fs::path write_registry_fixture(const fs::path& root) {
+    const auto platform = current_platform_key();
+    auto path = root / "tool-registry.json";
+    write_file(path, std::string(R"({
+  "schema_version": 3,
+  "tools": {
+    "fixture-bin": {
+      "display_name": "Fixture Binary",
+      "category": "binary",
+      "description": "Local binary fixture",
+      "license": "MIT",
+      "install_method": "binary_download",
+      "pinned_version": "1.2.3",
+      "requires_tools": ["uv"],
+      "managed_by_pulp": false,
+      "bundleable": true,
+      "binary_sources": {
+        ")") + quote_json(platform) + R"(": {
+          "url_template": "https://example.invalid/fixture-${version}.tar.gz",
+          "archive_format": "tar.gz",
+          "binary_name": "fixture-bin"
+        }
+      }
+    },
+    "fixture-py": {
+      "display_name": "Fixture Python",
+      "category": "python_tool",
+      "description": "Local Python fixture",
+      "license": "Apache-2.0",
+      "install_method": "python_pip",
+      "pip_package": "fixture_tool",
+      "pinned_version": "4.5.6",
+      "requires_tools": ["uv"]
+    }
+  }
+}
+)");
+    return path;
+}
+
+ToolDescriptor binary_tool(std::string id, std::string binary_name = {}) {
+    ToolDescriptor tool;
+    tool.id = std::move(id);
+    tool.display_name = tool.id;
+    tool.install_method = "binary_download";
+    tool.pinned_version = "1.2.3";
+    if (binary_name.empty()) binary_name = tool.id;
+    tool.binary_sources[current_platform_key()] = {
+        "https://example.invalid/" + tool.id + "-${version}.tar.gz",
+        "tar.gz",
+        std::move(binary_name),
+    };
+    return tool;
+}
+
+fs::path managed_binary_path(const fs::path& home,
+                             const std::string& id,
+                             const std::string& version,
+                             const std::string& binary_name) {
+    return home / "tools" / id / version / binary_name;
+}
+
+}  // namespace
+
+TEST_CASE("tool registry parses descriptors and reports malformed roots",
+          "[cli][tool-registry][issue-643]") {
+    TempDir tmp;
+    auto registry_path = write_registry_fixture(tmp.path);
+
+    auto loaded = load_tool_registry(registry_path);
+    REQUIRE(loaded.error.empty());
+    REQUIRE(loaded.registry.schema_version == 3);
+    REQUIRE(loaded.registry.tools.size() == 2);
+
+    const auto& bin = loaded.registry.tools.at("fixture-bin");
+    REQUIRE(bin.id == "fixture-bin");
+    REQUIRE(bin.display_name == "Fixture Binary");
+    REQUIRE(bin.category == "binary");
+    REQUIRE(bin.description == "Local binary fixture");
+    REQUIRE(bin.license == "MIT");
+    REQUIRE(bin.install_method == "binary_download");
+    REQUIRE(bin.pinned_version == "1.2.3");
+    REQUIRE(bin.requires_tools == std::vector<std::string>{"uv"});
+    REQUIRE_FALSE(bin.managed_by_pulp);
+    REQUIRE(bin.bundleable);
+    REQUIRE(bin.binary_sources.at(current_platform_key()).archive_format == "tar.gz");
+    REQUIRE(bin.binary_sources.at(current_platform_key()).binary_name == "fixture-bin");
+
+    const auto& py = loaded.registry.tools.at("fixture-py");
+    REQUIRE(py.install_method == "python_pip");
+    REQUIRE(py.pip_package == "fixture_tool");
+    REQUIRE(py.requires_tools == std::vector<std::string>{"uv"});
+    REQUIRE(py.managed_by_pulp);
+    REQUIRE_FALSE(py.bundleable);
+
+    auto missing = load_tool_registry(tmp.path / "missing.json");
+    REQUIRE(missing.registry.tools.empty());
+    REQUIRE(missing.error.find("Cannot read tool registry") != std::string::npos);
+
+    write_file(tmp.path / "array.json", "[]");
+    auto malformed = load_tool_registry(tmp.path / "array.json");
+    REQUIRE(malformed.registry.tools.empty());
+    REQUIRE(malformed.error == "Tool registry is not a valid JSON object");
+}
+
+TEST_CASE("tool lookup prefers pulp-managed binaries and python wrappers",
+          "[cli][tool-registry][locate][issue-643]") {
+    TempDir tmp;
+    ScopedEnv home{"PULP_HOME", tmp.path / "home"};
+
+    auto managed = binary_tool("managed-fixture", "managed-bin");
+    auto managed_path = managed_binary_path(pulp_home(), managed.id, "1.2.3", "managed-bin");
+    touch_file(managed_path);
+
+    auto located = locate_tool(managed);
+    REQUIRE(located.found);
+    REQUIRE(located.source == "pulp-managed");
+    REQUIRE(located.path == managed_path);
+
+    auto default_name = binary_tool("default-name-fixture");
+    auto default_path = managed_binary_path(pulp_home(), default_name.id, "1.2.3", default_name.id);
+    touch_file(default_path);
+    auto located_default = locate_tool(default_name);
+    REQUIRE(located_default.found);
+    REQUIRE(located_default.path == default_path);
+
+    ToolDescriptor py;
+    py.id = "python-fixture";
+    py.install_method = "python_pip";
+#ifdef _WIN32
+    auto wrapper = pulp_home() / "tools" / "python-envs" / py.id / "run.bat";
+#else
+    auto wrapper = pulp_home() / "tools" / "python-envs" / py.id / "run.sh";
+#endif
+    touch_file(wrapper);
+
+    auto located_py = locate_tool(py);
+    REQUIRE(located_py.found);
+    REQUIRE(located_py.source == "pulp-managed");
+    REQUIRE(located_py.path == wrapper);
+
+    auto missing = binary_tool("pulp-tool-registry-missing-binary-xyz");
+    auto located_missing = locate_tool(missing);
+    REQUIRE_FALSE(located_missing.found);
+    REQUIRE(located_missing.source == "not-found");
+}
+
+TEST_CASE("tool install helpers have deterministic local exits",
+          "[cli][tool-registry][install][issue-643]") {
+    TempDir tmp;
+    ScopedEnv home{"PULP_HOME", tmp.path / "home"};
+
+    auto existing = binary_tool("cached-tool", "cached-bin");
+    auto cached_path = managed_binary_path(pulp_home(), existing.id, existing.pinned_version, "cached-bin");
+    touch_file(cached_path);
+    write_file(cached_path.parent_path() / "manifest.json",
+               "{\"version\":\"1.2.3\",\"tool_id\":\"cached-tool\"}\n");
+
+    auto cached = install_binary_tool(existing, /*force=*/false);
+    REQUIRE(cached.ok);
+    REQUIRE(cached.binary_path == cached_path);
+    REQUIRE(cached.installed_version == existing.pinned_version);
+
+    ToolDescriptor unavailable;
+    unavailable.id = "unavailable-tool";
+    unavailable.display_name = "Unavailable Tool";
+    unavailable.install_method = "binary_download";
+    unavailable.pinned_version = "9.9.9";
+    auto unavailable_result = install_binary_tool(unavailable, /*force=*/true);
+    REQUIRE_FALSE(unavailable_result.ok);
+    REQUIRE(unavailable_result.error.find(std::string("is not available for ") +
+                                          current_platform_key()) !=
+            std::string::npos);
+
+    ToolRegistry missing_uv;
+    ToolDescriptor py;
+    py.id = "py-tool";
+    py.display_name = "Python Tool";
+    py.install_method = "python_pip";
+    py.pip_package = "py_tool";
+    py.pinned_version = "1.0.0";
+    auto no_uv = install_python_tool(py, missing_uv, /*force=*/false);
+    REQUIRE_FALSE(no_uv.ok);
+    REQUIRE(no_uv.error == "UV not found in tool registry");
+
+    ToolRegistry with_uv;
+    auto uv = binary_tool("uv", "uv-bin");
+    with_uv.tools["uv"] = uv;
+    touch_file(managed_binary_path(pulp_home(), "uv", "1.2.3", "uv-bin"));
+
+    auto venv_dir = pulp_home() / "tools" / "python-envs" / py.id;
+    fs::create_directories(venv_dir / ".venv");
+#ifdef _WIN32
+    auto wrapper = venv_dir / "run.bat";
+#else
+    auto wrapper = venv_dir / "run.sh";
+#endif
+    touch_file(wrapper);
+
+    auto existing_py = install_python_tool(py, with_uv, /*force=*/false);
+    REQUIRE(existing_py.ok);
+    REQUIRE(existing_py.binary_path == wrapper);
+    REQUIRE(existing_py.installed_version == py.pinned_version);
+}
+
+TEST_CASE("tool uninstall removes managed binary and python tool roots",
+          "[cli][tool-registry][uninstall][issue-643]") {
+    TempDir tmp;
+    ScopedEnv home{"PULP_HOME", tmp.path / "home"};
+
+    auto binary_root = pulp_home() / "tools" / "binary-tool";
+    touch_file(binary_root / "1.0.0" / "binary-tool");
+    REQUIRE(uninstall_tool("binary-tool"));
+    REQUIRE_FALSE(fs::exists(binary_root));
+
+    auto py_root = pulp_home() / "tools" / "python-envs" / "py-tool";
+    touch_file(py_root / "run.sh");
+    REQUIRE(uninstall_tool("py-tool"));
+    REQUIRE_FALSE(fs::exists(py_root));
+
+    REQUIRE_FALSE(uninstall_tool("missing-tool"));
+}
+
+TEST_CASE("tool command handles local list path doctor and error branches",
+          "[cli][tool-registry][command][issue-643]") {
+    TempDir tmp;
+    ScopedEnv home{"PULP_HOME", tmp.path / "home"};
+    fs::create_directories(tmp.path / "repo" / "tools" / "packages");
+    ScopedCurrentPath cwd{tmp.path / "repo"};
+
+    const auto platform = current_platform_key();
+    write_file(tmp.path / "repo" / "tools" / "packages" / "tool-registry.json",
+               std::string(R"({
+  "schema_version": 1,
+  "tools": {
+    "managed-cmd": {
+      "display_name": "Managed Command",
+      "description": "Already installed fixture",
+      "install_method": "binary_download",
+      "pinned_version": "1.0.0",
+      "binary_sources": {
+        ")") + quote_json(platform) + R"(": {
+          "url_template": "https://example.invalid/managed-${version}.zip",
+          "archive_format": "zip",
+          "binary_name": "managed-cmd-bin"
+        }
+      }
+    },
+    "unavailable-cmd": {
+      "display_name": "Unavailable Command",
+      "description": "No source fixture",
+      "install_method": "binary_download",
+      "pinned_version": "1.0.0"
+    }
+  }
+}
+)");
+    auto managed_path = managed_binary_path(pulp_home(), "managed-cmd", "1.0.0",
+                                            "managed-cmd-bin");
+    touch_file(managed_path);
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({}) == 0);
+        REQUIRE(output.out.str().find("Usage: pulp tool") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"list"}) == 0);
+        REQUIRE(output.out.str().find("managed-cmd") != std::string::npos);
+        REQUIRE(output.out.str().find("unavailable-cmd") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"path", "managed-cmd"}) == 0);
+        REQUIRE(output.out.str().find(managed_path.string()) != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"path", "unavailable-cmd"}) == 1);
+        REQUIRE(output.err.str().find("unavailable-cmd not installed") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"doctor"}) == 1);
+        REQUIRE(output.out.str().find("Managed Command") != std::string::npos);
+        REQUIRE(output.out.str().find(std::string("not available for ") + platform) !=
+                std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"install"}) == 1);
+        REQUIRE(output.err.str().find("Usage: pulp tool install") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"install", "missing-cmd"}) == 1);
+        REQUIRE(output.err.str().find("Tool 'missing-cmd' not found") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"run"}) == 1);
+        REQUIRE(output.err.str().find("Usage: pulp tool run") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"run", "missing-cmd"}) == 1);
+        REQUIRE(output.err.str().find("Tool 'missing-cmd' not found") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"run", "unavailable-cmd"}) == 1);
+        REQUIRE(output.err.str().find("unavailable-cmd not installed") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"uninstall", "managed-cmd"}) == 0);
+        REQUIRE(output.out.str().find("Uninstalled managed-cmd") != std::string::npos);
+    }
+    REQUIRE_FALSE(fs::exists(pulp_home() / "tools" / "managed-cmd"));
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"uninstall", "managed-cmd"}) == 1);
+        REQUIRE(output.err.str().find("managed-cmd is not installed") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"unknown"}) == 1);
+        REQUIRE(output.err.str().find("Unknown tool subcommand: unknown") != std::string::npos);
+    }
+}


### PR DESCRIPTION
## Summary
- add deterministic `tool_registry.cpp` tests for registry parsing, managed binary lookup, Python wrapper lookup, uninstall, and local install early exits
- cover `pulp tool` list/path/doctor/uninstall/run/error dispatch branches against a staged local registry
- wire the new Catch2 target into `test/CMakeLists.txt`

Refs #643
Refs #641

## Validation
- cmake -S . -B build-cli-tool-registry-lite -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-cli-tool-registry-lite --target pulp-test-cli-tool-registry -j4
- ./build-cli-tool-registry-lite/test/pulp-test-cli-tool-registry (78 assertions / 5 test cases)
- ctest --test-dir build-cli-tool-registry-lite -R "tool (registry|lookup|install|uninstall|command)" --output-on-failure (5/5)
- git diff --check
- python3 tools/scripts/version_bump_check.py --mode=report

Note: opened via GitHub/Namespace path rather than `shipyard pr` because #794 exposed a local Shipyard mac configure stall in the default examples/Three.js path after GitHub/Namespace was clean.