### PR TITLE
test(midi): cover running status parser edges

### DIFF
--- a/test/test_running_status.cpp
+++ b/test/test_running_status.cpp
@@ -59,6 +59,46 @@ TEST_CASE("program change has a single data byte",
     REQUIRE(v[1].d1 == 0x07);
 }
 
+TEST_CASE("running status handles one and two byte channel messages",
+          "[midi][running-status][issue-645]") {
+    auto v = parse({
+        0xA2, 0x40, 0x20,  // poly pressure, two data bytes
+        0x41, 0x21,        // running poly pressure
+        0xD3, 0x7F,        // channel pressure, one data byte
+        0x70,              // running channel pressure
+    });
+
+    REQUIRE(v.size() == 4);
+    REQUIRE(v[0].status == 0xA2);
+    REQUIRE(v[0].d1 == 0x40);
+    REQUIRE(v[0].d2 == 0x20);
+    REQUIRE(v[1].status == 0xA2);
+    REQUIRE(v[1].d1 == 0x41);
+    REQUIRE(v[1].d2 == 0x21);
+    REQUIRE(v[2].status == 0xD3);
+    REQUIRE(v[2].d1 == 0x7F);
+    REQUIRE(v[3].status == 0xD3);
+    REQUIRE(v[3].d1 == 0x70);
+}
+
+TEST_CASE("system common messages use their status-specific data lengths",
+          "[midi][running-status][issue-645]") {
+    auto v = parse({
+        0xF1, 0x05,        // MTC quarter-frame
+        0xF2, 0x10, 0x20,  // song position pointer
+        0xF3, 0x07,        // song select
+    });
+
+    REQUIRE(v.size() == 3);
+    REQUIRE(v[0].status == 0xF1);
+    REQUIRE(v[0].d1 == 0x05);
+    REQUIRE(v[1].status == 0xF2);
+    REQUIRE(v[1].d1 == 0x10);
+    REQUIRE(v[1].d2 == 0x20);
+    REQUIRE(v[2].status == 0xF3);
+    REQUIRE(v[2].d1 == 0x07);
+}
+
 TEST_CASE("real-time clock interleaves without breaking running status",
           "[midi][running-status]") {
     // Note-on, clock, next note-on sharing running status.
@@ -92,6 +132,85 @@ TEST_CASE("sysex is delivered separately; cancels running status",
     REQUIRE(sx[0] == 0x7E);
     REQUIRE(shorts.size() == 1);   // only the first note-on
     REQUIRE(shorts[0] == 0x90);
+}
+
+TEST_CASE("real-time bytes inside sysex are emitted without ending sysex",
+          "[midi][running-status][issue-645]") {
+    RunningStatusParser p;
+    std::vector<uint8_t> sx;
+    std::vector<uint8_t> shorts;
+    p.on_sysex([&](const uint8_t* d, std::size_t s) {
+        sx.assign(d, d + s);
+    });
+    p.on_short_message([&](const MidiEvent& e) {
+        shorts.push_back(e.message.data()[0]);
+    });
+
+    std::vector<uint8_t> stream = {0xF0, 0x01, 0xF8, 0x02, 0xF7};
+    p.feed(stream.data(), stream.size());
+
+    REQUIRE(shorts == std::vector<uint8_t>{0xF8});
+    REQUIRE(sx == std::vector<uint8_t>{0x01, 0x02});
+}
+
+TEST_CASE("unexpected status inside sysex restarts short-message parsing",
+          "[midi][running-status][issue-645]") {
+    RunningStatusParser p;
+    std::vector<uint8_t> sx;
+    std::vector<Captured> shorts;
+    p.on_sysex([&](const uint8_t* d, std::size_t s) {
+        sx.assign(d, d + s);
+    });
+    p.on_short_message([&](const MidiEvent& e) {
+        const auto& m = e.message;
+        shorts.push_back({m.data()[0],
+                          m.length() > 1 ? m.data()[1] : uint8_t(0),
+                          m.length() > 2 ? m.data()[2] : uint8_t(0)});
+    });
+
+    std::vector<uint8_t> stream = {0xF0, 0x01, 0x90, 0x3C, 0x7F};
+    p.feed(stream.data(), stream.size());
+
+    REQUIRE(sx.empty());
+    REQUIRE(shorts.size() == 1);
+    REQUIRE(shorts[0].status == 0x90);
+    REQUIRE(shorts[0].d1 == 0x3C);
+    REQUIRE(shorts[0].d2 == 0x7F);
+}
+
+TEST_CASE("empty sysex and unknown statuses are ignored",
+          "[midi][running-status][issue-645]") {
+    RunningStatusParser p;
+    int sysex_count = 0;
+    std::vector<uint8_t> shorts;
+    p.on_sysex([&](const uint8_t*, std::size_t) {
+        ++sysex_count;
+    });
+    p.on_short_message([&](const MidiEvent& e) {
+        shorts.push_back(e.message.data()[0]);
+    });
+
+    std::vector<uint8_t> stream = {
+        0xF0, 0xF7,  // empty sysex should not call the sysex sink
+        0xF4, 0x01,  // undefined system-common status and stray data
+        0xF5, 0x02,  // another undefined status and stray data
+        0xF6,        // tune request still emits
+    };
+    p.feed(stream.data(), stream.size());
+
+    REQUIRE(sysex_count == 0);
+    REQUIRE(shorts == std::vector<uint8_t>{0xF6});
+}
+
+TEST_CASE("feed tolerates missing sinks and empty buffers",
+          "[midi][running-status][issue-645]") {
+    RunningStatusParser p;
+    p.feed(nullptr, 0);
+
+    std::vector<uint8_t> stream = {0xF6, 0x90, 0x3C, 0x7F, 0xF0, 0x01, 0xF7};
+    p.feed(stream.data(), stream.size());
+
+    SUCCEED("missing callbacks are ignored");
 }
 
 TEST_CASE("reset clears running status", "[midi][running-status]") {


### PR DESCRIPTION
## Summary
- Adds Phase 3 Codecov remediation coverage for MIDI running-status parser edge cases tracked by #645 under umbrella #641.
- Covers one-byte and two-byte channel messages, system-common lengths, real-time bytes inside sysex, status restart inside sysex, ignored empty/unknown messages, and null/empty feed inputs.
- Test-only change; no production behavior changes.

## Validation
- cmake -S . -B build-running-status-lite -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-running-status-lite --target pulp-test-running-status -j4
- ./build-running-status-lite/test/pulp-test-running-status '[midi][running-status][issue-645]'
- ./build-running-status-lite/test/pulp-test-running-status
- ctest --test-dir build-running-status-lite -R 'running status|RunningStatus|pulp-test-running-status' --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py --mode report
- python3 tools/scripts/version_bump_check.py --mode report

Refs #645
Refs #641