### PR TITLE
test(midi): cover keyboard and sequence edges

### DIFF
--- a/test/test_midi_expansion.cpp
+++ b/test/test_midi_expansion.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/midi/rpn_parser.hpp>
 #include <pulp/midi/keyboard_state.hpp>
+#include <vector>
 
 using namespace pulp::midi;
 
@@ -217,4 +218,64 @@ TEST_CASE("MidiKeyboardState reset without callbacks", "[midi][keyboard]") {
     keys.reset(); // should NOT fire callbacks
     REQUIRE(off_count == 0);
     REQUIRE_FALSE(keys.any_notes_held());
+}
+
+TEST_CASE("MidiKeyboardState ignores non-note events and invalid queries", "[midi][keyboard][issue-645]") {
+    MidiKeyboardState keys;
+    int on_count = 0;
+    int off_count = 0;
+    keys.on_note_on = [&](uint8_t, uint8_t, uint8_t) { ++on_count; };
+    keys.on_note_off = [&](uint8_t, uint8_t) { ++off_count; };
+
+    keys.process(MidiEvent::cc(0, 64, 127));
+    keys.process(MidiEvent::pitch_bend(1, 8192));
+    keys.process(MidiEvent::program_change(2, 10));
+
+    REQUIRE_FALSE(keys.any_notes_held());
+    REQUIRE(on_count == 0);
+    REQUIRE(off_count == 0);
+    REQUIRE_FALSE(keys.is_note_on(16, 60));
+    REQUIRE(keys.velocity(16, 60) == 0);
+    REQUIRE(keys.velocity(0, 128) == 0);
+    REQUIRE(keys.notes_held(16) == 0);
+    REQUIRE(keys.lowest_note(16) == -1);
+    REQUIRE(keys.highest_note(16) == -1);
+
+    keys.all_notes_off(16);
+    REQUIRE(off_count == 0);
+}
+
+TEST_CASE("MidiKeyboardState reports released keys when clearing", "[midi][keyboard][issue-645]") {
+    MidiKeyboardState keys;
+    std::vector<int> released;
+    keys.on_note_off = [&](uint8_t channel, uint8_t note) {
+        released.push_back(static_cast<int>(channel) * 128 + static_cast<int>(note));
+    };
+
+    keys.process(MidiEvent::note_on(1, 60, 100));
+    keys.process(MidiEvent::note_on(1, 62, 90));
+    keys.process(MidiEvent::note_on(2, 65, 80));
+
+    keys.all_notes_off(1);
+    REQUIRE(keys.notes_held(1) == 0);
+    REQUIRE(keys.notes_held(2) == 1);
+    REQUIRE(released == std::vector<int>{188, 190});
+
+    keys.all_notes_off();
+    REQUIRE_FALSE(keys.any_notes_held());
+    REQUIRE(released == std::vector<int>{188, 190, 321});
+}
+
+TEST_CASE("MidiKeyboardState retrigger updates velocity without duplicating held count", "[midi][keyboard][issue-645]") {
+    MidiKeyboardState keys;
+    int on_count = 0;
+    keys.on_note_on = [&](uint8_t, uint8_t, uint8_t) { ++on_count; };
+
+    keys.process(MidiEvent::note_on(0, 60, 40));
+    keys.process(MidiEvent::note_on(0, 60, 120));
+
+    REQUIRE(keys.notes_held(0) == 1);
+    REQUIRE(keys.total_notes_held() == 1);
+    REQUIRE(keys.velocity(0, 60) == 120);
+    REQUIRE(on_count == 2);
 }

--- a/test/test_v3_gaps.cpp
+++ b/test/test_v3_gaps.cpp
@@ -70,6 +70,89 @@ TEST_CASE("MidiMessageSequence CC events", "[midi][sequence]") {
     REQUIRE(seq[0].data2 == 64);
 }
 
+TEST_CASE("MidiMessageSequence classifies aliases and masks helper fields", "[midi][sequence][issue-645]") {
+    pulp::midi::MidiMessageSequence seq;
+    seq.add_note_on(1.0, 31, 130, 255);
+    seq.add_note_off(2.0, 17, 130);
+    seq.add_cc(0.5, 31, 200, 255);
+
+    REQUIRE(seq.size() == 3);
+    REQUIRE(seq[0].is_cc());
+    REQUIRE(seq[0].status == 0xBF);
+    REQUIRE(seq[0].data1 == 72);
+    REQUIRE(seq[0].data2 == 127);
+
+    REQUIRE(seq[1].is_note_on());
+    REQUIRE(seq[1].channel() == 15);
+    REQUIRE(seq[1].note() == 2);
+    REQUIRE(seq[1].velocity() == 127);
+
+    REQUIRE(seq[2].is_note_off());
+    REQUIRE(seq[2].channel() == 1);
+    REQUIRE(seq[2].note() == 2);
+
+    pulp::midi::TimestampedMidiEvent zero_velocity_note_on{0.0, 0x92, 60, 0, {}};
+    REQUIRE_FALSE(zero_velocity_note_on.is_note_on());
+    REQUIRE(zero_velocity_note_on.is_note_off());
+    REQUIRE(zero_velocity_note_on.channel() == 2);
+
+    pulp::midi::TimestampedMidiEvent sysex;
+    sysex.status = 0xF0;
+    sysex.sysex = {0xF0, 0x7D, 0x01, 0xF7};
+    REQUIRE(sysex.is_sysex());
+}
+
+TEST_CASE("MidiMessageSequence note-off lookup handles invalid and channel-specific cases", "[midi][sequence][issue-645]") {
+    pulp::midi::MidiMessageSequence seq;
+    REQUIRE_FALSE(seq.find_note_off(-1).has_value());
+    REQUIRE_FALSE(seq.find_note_off(0).has_value());
+
+    seq.add_note_on(0.0, 0, 60, 100);
+    seq.add_note_off(0.25, 1, 60);
+    seq.add_note_on(0.5, 0, 64, 0);
+    seq.add_note_off(1.0, 0, 60);
+    seq.add_note_on(2.0, 0, 70, 100);
+
+    auto off = seq.find_note_off(0);
+    REQUIRE(off.has_value());
+    REQUIRE(*off == 3);
+    REQUIRE_FALSE(seq.find_note_off(1).has_value());
+    REQUIRE_FALSE(seq.find_note_off(2).has_value());
+    REQUIRE_FALSE(seq.find_note_off(4).has_value());
+    REQUIRE_FALSE(seq.find_note_off(99).has_value());
+}
+
+TEST_CASE("MidiMessageSequence ranges offsets duration and clear", "[midi][sequence][issue-645]") {
+    pulp::midi::MidiMessageSequence seq;
+    REQUIRE(seq.duration() == 0.0);
+    REQUIRE(seq.events().empty());
+    REQUIRE(seq.begin() == seq.end());
+
+    seq.add_note_on(0.25, 0, 60, 100);
+    seq.add_note_on(0.75, 0, 64, 100);
+    seq.add_note_off(1.25, 0, 60);
+    seq.offset_timestamps(-0.25);
+
+    REQUIRE(seq.duration() == 1.0);
+    auto events = seq.events_in_range(0.0, 0.5);
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0]->note() == 60);
+    REQUIRE(seq.events_in_range(0.5, 1.0).size() == 1);
+    REQUIRE(seq.events_in_range(1.0, 2.0).size() == 1);
+
+    int iterated = 0;
+    for (const auto& event : seq) {
+        REQUIRE(event.timestamp >= 0.0);
+        ++iterated;
+    }
+    REQUIRE(iterated == seq.size());
+
+    seq.clear();
+    REQUIRE(seq.size() == 0);
+    REQUIRE(seq.duration() == 0.0);
+    REQUIRE(seq.events().empty());
+}
+
 // ── AudioSubsectionReader ───────────────────────────────────────────────
 
 TEST_CASE("AudioSubsectionReader basic", "[audio][subsection]") {


### PR DESCRIPTION
## Summary
- add #645 edge coverage for MidiKeyboardState invalid queries, ignored non-note events, release callbacks, and retrigger velocity updates
- add #645 edge coverage for MidiMessageSequence masking/classification, zero-velocity note-on aliases, channel-specific note-off lookup, range boundaries, timestamp offsets, duration, iteration, and clear

## Validation
- cmake -S . -B build-midi-keyboard-sequence-lite -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-midi-keyboard-sequence-lite --target pulp-test-midi-expansion pulp-test-v3-gaps -j4
- ./build-midi-keyboard-sequence-lite/test/pulp-test-midi-expansion "[midi][keyboard][issue-645]"
- ./build-midi-keyboard-sequence-lite/test/pulp-test-v3-gaps "[midi][sequence][issue-645]"
- ./build-midi-keyboard-sequence-lite/test/pulp-test-midi-expansion
- ./build-midi-keyboard-sequence-lite/test/pulp-test-v3-gaps
- ctest --test-dir build-midi-keyboard-sequence-lite -R "MidiKeyboardState|MidiMessageSequence" --output-on-failure
- git diff --check HEAD~1..HEAD
- python3 tools/scripts/skill_sync_check.py --mode report
- python3 tools/scripts/version_bump_check.py --mode report

## Notes
- Codecov Phase 3 tranche for #645 under umbrella #641.
- Opened through GitHub/Namespace path because the normal shipyard pr path is currently blocked by the SSH windows target timeout documented in #774.