### PR TITLE
test(audio): cover reader helper edges

### DIFF
--- a/test/test_buffering_reader.cpp
+++ b/test/test_buffering_reader.cpp
@@ -1,12 +1,35 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/audio/buffering_reader.hpp>
+#include <algorithm>
 #include <cmath>
 #include <thread>
 #include <chrono>
+#include <vector>
 
 using namespace pulp::audio;
 using Catch::Matchers::WithinAbs;
+
+namespace {
+
+bool wait_for_frames(BufferingReader& reader, int min_frames) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (reader.frames_available() < min_frames && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return reader.frames_available() >= min_frames;
+}
+
+bool wait_until_finished_with_frames(BufferingReader& reader, int min_frames) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while ((!reader.is_finished() || reader.frames_available() < min_frames) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return reader.is_finished() && reader.frames_available() >= min_frames;
+}
+
+} // namespace
 
 TEST_CASE("BufferingReader reads from callback", "[audio][buffering]") {
     BufferingReader reader;
@@ -35,6 +58,69 @@ TEST_CASE("BufferingReader reads from callback", "[audio][buffering]") {
 
     // First sample should be 0.0f (sequential counter)
     REQUIRE_THAT(buf[0], WithinAbs(0.0, 0.001));
+
+    reader.stop();
+}
+
+TEST_CASE("BufferingReader partial read zero-fills after source ends",
+          "[audio][buffering][issue-640]") {
+    BufferingReader reader;
+
+    int emitted = 0;
+    reader.set_read_callback([&](float* dest, int frames, int channels) {
+        int frames_to_emit = std::min(frames, 3 - emitted);
+        for (int frame = 0; frame < frames_to_emit; ++frame) {
+            for (int ch = 0; ch < channels; ++ch) {
+                dest[frame * channels + ch] = static_cast<float>(emitted + frame + 1);
+            }
+        }
+        emitted += frames_to_emit;
+        return frames_to_emit;
+    });
+
+    reader.start(1, 2048);
+    REQUIRE(wait_until_finished_with_frames(reader, 3));
+
+    float buf[5] = {-1.0f, -1.0f, -1.0f, -1.0f, -1.0f};
+    int got = reader.read(buf, 5, 1);
+    REQUIRE(got == 3);
+    REQUIRE(buf[0] == 1.0f);
+    REQUIRE(buf[1] == 2.0f);
+    REQUIRE(buf[2] == 3.0f);
+    REQUIRE(buf[3] == 0.0f);
+    REQUIRE(buf[4] == 0.0f);
+
+    reader.stop();
+}
+
+TEST_CASE("BufferingReader preserves sample order across ring wrap",
+          "[audio][buffering][issue-640]") {
+    BufferingReader reader;
+
+    int next_sample = 0;
+    reader.set_read_callback([&](float* dest, int frames, int channels) {
+        (void)channels;
+        for (int frame = 0; frame < frames; ++frame) {
+            dest[frame] = static_cast<float>(next_sample++);
+        }
+        return frames;
+    });
+
+    reader.start(1, 1100);
+    REQUIRE(wait_for_frames(reader, 1000));
+
+    std::vector<float> first(700, -1.0f);
+    REQUIRE(reader.read(first.data(), static_cast<int>(first.size()), 1) == 700);
+    REQUIRE(first.front() == 0.0f);
+    REQUIRE(first.back() == 699.0f);
+
+    REQUIRE(wait_for_frames(reader, 1000));
+
+    std::vector<float> second(800, -1.0f);
+    REQUIRE(reader.read(second.data(), static_cast<int>(second.size()), 1) == 800);
+    for (int i = 0; i < static_cast<int>(second.size()); ++i) {
+        REQUIRE(second[static_cast<size_t>(i)] == static_cast<float>(700 + i));
+    }
 
     reader.stop();
 }

--- a/test/test_v3_gaps.cpp
+++ b/test/test_v3_gaps.cpp
@@ -98,6 +98,71 @@ TEST_CASE("AudioSubsectionReader extract", "[audio][subsection]") {
     REQUIRE(extracted.channels[1][2] == 13.0f);
 }
 
+TEST_CASE("AudioSubsectionReader handles invalid and clamped reads",
+          "[audio][subsection][issue-640]") {
+    pulp::audio::AudioSubsectionReader invalid;
+    REQUIRE_FALSE(invalid.is_valid());
+    REQUIRE(invalid.num_frames() == 0);
+    REQUIRE(invalid.num_channels() == 0);
+    REQUIRE(invalid.sample_rate() == 0);
+    REQUIRE(invalid.sample(0, 0) == 0.0f);
+    REQUIRE(invalid.duration_seconds() == 0.0);
+
+    float untouched[2] = {42.0f, 43.0f};
+    invalid.read_frames(untouched, 0, 0, 2);
+    REQUIRE(untouched[0] == 42.0f);
+    REQUIRE(untouched[1] == 43.0f);
+    REQUIRE(invalid.extract().channels.empty());
+
+    pulp::audio::AudioFileData data;
+    data.sample_rate = 48000;
+    data.channels.resize(2);
+    data.channels[0] = {0, 1, 2, 3, 4, 5};
+    data.channels[1] = {10, 11, 12, 13, 14, 15};
+
+    pulp::audio::AudioSubsectionReader reader(data, 4, 99);
+    REQUIRE(reader.is_valid());
+    REQUIRE(reader.num_frames() == 2);
+    REQUIRE(reader.num_channels() == 2);
+    REQUIRE(reader.sample_rate() == 48000);
+    REQUIRE_THAT(reader.duration_seconds(), WithinAbs(2.0 / 48000.0, 1e-12));
+    REQUIRE(reader.sample(0, 0) == 4.0f);
+    REQUIRE(reader.sample(1, 1) == 15.0f);
+    REQUIRE(reader.sample(2, 0) == 0.0f);
+    REQUIRE(reader.sample(0, 2) == 0.0f);
+
+    float copied[4] = {-1.0f, -1.0f, -1.0f, -1.0f};
+    reader.read_frames(copied, 1, 1, 3);
+    REQUIRE(copied[0] == 15.0f);
+    REQUIRE(copied[1] == -1.0f);
+    REQUIRE(copied[2] == -1.0f);
+    REQUIRE(copied[3] == -1.0f);
+
+    reader.read_frames(copied, 9, 0, 2);
+    REQUIRE(copied[0] == 15.0f);
+    REQUIRE(copied[1] == -1.0f);
+}
+
+TEST_CASE("AudioSubsectionReader start past end is an empty source view",
+          "[audio][subsection][issue-640]") {
+    pulp::audio::AudioFileData data;
+    data.sample_rate = 44100;
+    data.channels.resize(1);
+    data.channels[0] = {1, 2, 3};
+
+    pulp::audio::AudioSubsectionReader reader(data, 99, 4);
+    REQUIRE_FALSE(reader.is_valid());
+    REQUIRE(reader.num_frames() == 0);
+    REQUIRE(reader.num_channels() == 1);
+    REQUIRE(reader.sample_rate() == 44100);
+    REQUIRE(reader.sample(0, 0) == 0.0f);
+
+    auto extracted = reader.extract();
+    REQUIRE(extracted.sample_rate == 44100);
+    REQUIRE(extracted.channels.size() == 1);
+    REQUIRE(extracted.channels[0].empty());
+}
+
 // ── PluginHostType ──────────────────────────────────────────────────────
 
 TEST_CASE("HostType detect returns something", "[format][host]") {


### PR DESCRIPTION
## Summary
- add BufferingReader coverage for source exhaustion zero-fill and ring wrap ordering
- add AudioSubsectionReader coverage for invalid, clamped, and empty subsection views

## Validation
- cmake -S . -B build-audio-reader-helpers-lite -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-audio-reader-helpers-lite --target pulp-test-buffering-reader pulp-test-v3-gaps -j4
- ./build-audio-reader-helpers-lite/test/pulp-test-buffering-reader "[audio][buffering][issue-640]"
- ./build-audio-reader-helpers-lite/test/pulp-test-buffering-reader
- ./build-audio-reader-helpers-lite/test/pulp-test-v3-gaps "[audio][subsection][issue-640]"
- ./build-audio-reader-helpers-lite/test/pulp-test-v3-gaps "[audio][subsection]"
- ./build-audio-reader-helpers-lite/test/pulp-test-v3-gaps
- ctest --test-dir build-audio-reader-helpers-lite -R "BufferingReader|AudioSubsectionReader" --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py
- python3 tools/scripts/version_bump_check.py --mode=report

Refs #640.
Refs #641.