### PR TITLE
test(platform): cover helper edge paths

### DIFF
--- a/test/test_audio_excerpt.cpp
+++ b/test/test_audio_excerpt.cpp
@@ -71,3 +71,36 @@ TEST_CASE("excerpt windows report seconds from sample rate", "[audio][excerpt]")
     REQUIRE_THAT(result.windows[1].start_seconds(), WithinAbs(0.5, 0.0001));
     REQUIRE_THAT(result.windows[1].duration_seconds(), WithinAbs(0.5, 0.0001));
 }
+
+TEST_CASE("excerpt value types expose zero-rate and summary defaults",
+          "[audio][excerpt][issue-640]") {
+    ExcerptWindow window;
+    window.source_path = "loop.wav";
+    window.start_frame = 480;
+    window.frame_count = 120;
+
+    REQUIRE(window.end_frame() == 600);
+    REQUIRE_THAT(window.start_seconds(), WithinAbs(0.0, 0.0001));
+    REQUIRE_THAT(window.duration_seconds(), WithinAbs(0.0, 0.0001));
+
+    window.sample_rate = 24000;
+    REQUIRE_THAT(window.start_seconds(), WithinAbs(0.02, 0.0001));
+    REQUIRE_THAT(window.duration_seconds(), WithinAbs(0.005, 0.0001));
+
+    ExcerptCandidate candidate;
+    candidate.window = window;
+    candidate.score = 0.75;
+    candidate.backend = "deterministic";
+    candidate.model_id = "hash-v1";
+    REQUIRE(candidate.window.source_path == "loop.wav");
+    REQUIRE(candidate.score == 0.75);
+    REQUIRE(candidate.backend == "deterministic");
+    REQUIRE(candidate.model_id == "hash-v1");
+
+    ExcerptSearchSummary summary;
+    REQUIRE(summary.query_text.empty());
+    REQUIRE(summary.input_file_count == 0);
+    REQUIRE(summary.total_frames_scanned == 0);
+    REQUIRE(summary.enumerated_window_count == 0);
+    REQUIRE(summary.ranked_candidate_count == 0);
+}

--- a/test/test_file_dialog.cpp
+++ b/test/test_file_dialog.cpp
@@ -9,6 +9,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/platform/file_dialog.hpp>
+#include <pulp/platform/popup_menu.hpp>
 
 #include <string>
 #include <vector>
@@ -19,6 +20,7 @@
 
 using pulp::platform::FileDialog;
 using pulp::platform::FileFilter;
+using pulp::platform::PopupMenu;
 
 TEST_CASE("FileDialog has_backend reflects native vs host-registered availability",
           "[platform][file-dialog][issue-301][issue-312][issue-316]") {
@@ -56,6 +58,21 @@ TEST_CASE("FileDialog non-Apple: no backend -> explicit no-selection",
 
     auto folder = FileDialog::choose_folder("t", "");
     REQUIRE_FALSE(folder.has_value());
+}
+
+TEST_CASE("FileDialog non-Apple: installed backend without handlers fails closed",
+          "[platform][file-dialog][issue-640]") {
+    FileDialog::Backend b;
+    FileDialog::set_backend(b);
+    REQUIRE(FileDialog::has_backend());
+
+    REQUIRE_FALSE(FileDialog::open_file("open", {}, "").has_value());
+    REQUIRE(FileDialog::open_files("open-many", {}, "").empty());
+    REQUIRE_FALSE(FileDialog::save_file("save", {}, "", "preset.pulp").has_value());
+    REQUIRE_FALSE(FileDialog::choose_folder("folder", "").has_value());
+
+    FileDialog::clear_backend();
+    REQUIRE_FALSE(FileDialog::has_backend());
 }
 
 TEST_CASE("FileDialog non-Apple: backend routes through",
@@ -113,6 +130,41 @@ TEST_CASE("FileDialog non-Apple: backend routes through",
     REQUIRE(open_calls == 1); // not called again
 }
 #endif // !defined(__APPLE__)
+
+TEST_CASE("PopupMenu stores item metadata without showing native UI",
+          "[platform][popup-menu][issue-640]") {
+    PopupMenu menu;
+    menu.add_item(7, "Enabled");
+    menu.add_item(8, "Checked disabled", false, true);
+    menu.add_separator();
+
+    REQUIRE(menu.items().size() == 3);
+    REQUIRE(menu.items()[0].id == 7);
+    REQUIRE(menu.items()[0].label == "Enabled");
+    REQUIRE(menu.items()[0].enabled);
+    REQUIRE_FALSE(menu.items()[0].checked);
+    REQUIRE_FALSE(menu.items()[0].is_separator);
+
+    REQUIRE(menu.items()[1].id == 8);
+    REQUIRE_FALSE(menu.items()[1].enabled);
+    REQUIRE(menu.items()[1].checked);
+    REQUIRE_FALSE(menu.items()[1].is_separator);
+
+    REQUIRE(menu.items()[2].id == 0);
+    REQUIRE(menu.items()[2].label.empty());
+    REQUIRE(menu.items()[2].is_separator);
+}
+
+#if !defined(__APPLE__)
+TEST_CASE("PopupMenu non-Apple stub returns no selection",
+          "[platform][popup-menu][issue-640]") {
+    PopupMenu menu;
+    menu.add_item(1, "One");
+
+    REQUIRE_FALSE(menu.show(10.0f, 20.0f).has_value());
+    REQUIRE_FALSE(menu.show_at_view(nullptr).has_value());
+}
+#endif
 
 TEST_CASE("FileDialog backend registration is safe to call on any platform",
           "[platform][file-dialog][issue-301][issue-312]") {

--- a/test/test_workgroup.cpp
+++ b/test/test_workgroup.cpp
@@ -37,3 +37,19 @@ TEST_CASE("AudioWorkgroup join without workgroup uses fallback", "[audio][workgr
         REQUIRE_FALSE(wg.is_joined());
     }
 }
+
+#if !defined(__APPLE__)
+TEST_CASE("AudioWorkgroup non-Apple fallback join is idempotent",
+          "[audio][workgroup][issue-640]") {
+    AudioWorkgroup wg;
+    REQUIRE(wg.join_from_audio_thread());
+    REQUIRE(wg.is_joined());
+    REQUIRE(wg.join_from_audio_thread());
+    REQUIRE(wg.is_joined());
+
+    wg.leave();
+    REQUIRE_FALSE(wg.is_joined());
+    wg.leave();
+    REQUIRE_FALSE(wg.is_joined());
+}
+#endif


### PR DESCRIPTION
## Summary
- Cover file-dialog no-handler backend failure paths and popup-menu item/stub behavior.
- Cover audio excerpt value/default helpers.
- Cover non-Apple AudioWorkgroup fallback idempotency on Linux/Windows CI.

## Validation
- cmake -S . -B build-platform-helper-lite -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-platform-helper-lite --target pulp-test-file-dialog pulp-test-audio-excerpt pulp-test-workgroup -j4
- ./build-platform-helper-lite/test/pulp-test-file-dialog "[issue-640]"
- ./build-platform-helper-lite/test/pulp-test-file-dialog
- ./build-platform-helper-lite/test/pulp-test-audio-excerpt "[audio][excerpt][issue-640]"
- ./build-platform-helper-lite/test/pulp-test-audio-excerpt
- ./build-platform-helper-lite/test/pulp-test-workgroup
- ctest --test-dir build-platform-helper-lite -R "FileDialog|PopupMenu|excerpt value|AudioWorkgroup" --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py
- python3 tools/scripts/version_bump_check.py --mode=report

Refs #640.
Refs #641.