### PR TITLE
fix(signal): zero-initialize Mat3 multiplication

### DIFF
--- a/core/signal/include/pulp/signal/poly_math.hpp
+++ b/core/signal/include/pulp/signal/poly_math.hpp
@@ -137,7 +137,7 @@ struct Mat3 {
     static Mat3 identity() { return {{{1,0,0}, {0,1,0}, {0,0,1}}}; }
 
     Mat3 operator*(const Mat3& b) const {
-        Mat3 r{};
+        Mat3 r{{{0,0,0}, {0,0,0}, {0,0,0}}};
         for (int i = 0; i < 3; ++i)
             for (int j = 0; j < 3; ++j)
                 for (int k = 0; k < 3; ++k)

--- a/test/test_dsp_enhancements.cpp
+++ b/test/test_dsp_enhancements.cpp
@@ -279,6 +279,21 @@ TEST_CASE("MIDI/frequency conversions", "[dsp][special]") {
     REQUIRE_THAT(midi_to_freq(60.0f), WithinAbs(261.63f, 0.1f));
 }
 
+TEST_CASE("Special functions cover kernels and statistical wrappers",
+          "[dsp][special][issue-645]") {
+    REQUIRE_THAT(gamma_fn(5.0f), WithinAbs(24.0f, 0.001f));
+    REQUIRE_THAT(erf_fn(0.0f), WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(erfc_fn(0.0f), WithinAbs(1.0f, 0.001f));
+    REQUIRE_THAT(erf_fn(1.0f) + erfc_fn(1.0f), WithinAbs(1.0f, 0.001f));
+
+    REQUIRE_THAT(lanczos(0.0f, 3), WithinAbs(1.0f, 0.001f));
+    REQUIRE_THAT(lanczos(3.0f, 3), WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(lanczos(-3.0f, 3), WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(lanczos(0.5f, 3), WithinAbs(0.6079f, 0.001f));
+
+    REQUIRE_THAT(linear_to_db(0.0f), WithinAbs(-200.0f, 0.001f));
+}
+
 // ── Limiter (already exists in compressor.hpp) ──────────────────────────
 
 TEST_CASE("Limiter clamps signal", "[dsp][limiter]") {

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -23,6 +23,16 @@ TEST_CASE("FastMath sin approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::sin(-1.5707963f), WithinAbs(-1.0, 0.01));
 }
 
+TEST_CASE("FastMath trigonometry wraps large phases",
+          "[signal][fast_math][issue-645]") {
+    constexpr float pi = 3.14159265f;
+    constexpr float two_pi = 6.28318530f;
+
+    REQUIRE_THAT(FastMath::sin(two_pi + pi * 0.5f), WithinAbs(1.0f, 0.01f));
+    REQUIRE_THAT(FastMath::sin(-two_pi - pi * 0.5f), WithinAbs(-1.0f, 0.01f));
+    REQUIRE_THAT(FastMath::cos(-two_pi), WithinAbs(1.0f, 0.01f));
+}
+
 TEST_CASE("FastMath cos approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::cos(0.0f), WithinAbs(1.0, 0.01));
     REQUIRE_THAT(FastMath::cos(1.5707963f), WithinAbs(0.0, 0.02)); // pi/2
@@ -50,6 +60,16 @@ TEST_CASE("FastMath pow approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::pow(0.5f, 2.0f), WithinAbs(0.25, 0.01));
 }
 
+TEST_CASE("FastMath pow and reciprocal guard edge inputs",
+          "[signal][fast_math][issue-645]") {
+    REQUIRE_THAT(FastMath::pow(0.0f, 2.0f), WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(FastMath::pow(-2.0f, 3.0f), WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(FastMath::pow(4.0f, 0.5f), WithinAbs(2.0f, 0.05f));
+
+    REQUIRE_THAT(FastMath::rcp(4.0f), WithinAbs(0.25f, 0.001f));
+    REQUIRE_THAT(FastMath::rcp(-2.0f), WithinAbs(-0.5f, 0.001f));
+}
+
 TEST_CASE("FastMath db_to_gain", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::db_to_gain(0.0f), WithinAbs(1.0, 0.01));
     REQUIRE_THAT(FastMath::db_to_gain(6.0f), WithinAbs(std::pow(10.0f, 6.0f / 20.0f), 0.05));
@@ -62,6 +82,13 @@ TEST_CASE("FastMath gain_to_db", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::gain_to_db(2.0f), WithinAbs(6.02, 0.1));
     REQUIRE_THAT(FastMath::gain_to_db(0.5f), WithinAbs(-6.02, 0.1));
     REQUIRE(FastMath::gain_to_db(0.0f) < -100.0f);
+}
+
+TEST_CASE("FastMath gain conversion handles negative silence floor",
+          "[signal][fast_math][issue-645]") {
+    REQUIRE_THAT(FastMath::gain_to_db(-1.0f), WithinAbs(-200.0f, 0.001f));
+    REQUIRE(FastMath::db_to_gain(-120.0f) > 0.0f);
+    REQUIRE(FastMath::db_to_gain(-120.0f) < 0.00001f);
 }
 
 TEST_CASE("FastMath rsqrt approximation", "[signal][fast_math]") {

--- a/test/test_poly_math.cpp
+++ b/test/test_poly_math.cpp
@@ -69,6 +69,39 @@ TEST_CASE("Polynomial scale", "[signal][poly]") {
     REQUIRE_THAT(s[2], WithinAbs(6.0, 0.001));
 }
 
+TEST_CASE("Polynomial helpers handle empty and constant inputs",
+          "[signal][poly][issue-645]") {
+    REQUIRE_THAT(Polynomial::eval({}, 3.0f), WithinAbs(0.0f, 0.001f));
+
+    auto complex_zero = Polynomial::eval_complex({}, {1.0f, 2.0f});
+    REQUIRE_THAT(complex_zero.real(), WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(complex_zero.imag(), WithinAbs(0.0f, 0.001f));
+
+    REQUIRE(Polynomial::multiply({}, {1.0f, 2.0f}).empty());
+    REQUIRE(Polynomial::multiply({1.0f}, {}).empty());
+    REQUIRE(Polynomial::scale({}, 2.0f).empty());
+
+    auto constant_derivative = Polynomial::derivative({7.0f});
+    REQUIRE(constant_derivative.size() == 1);
+    REQUIRE_THAT(constant_derivative[0], WithinAbs(0.0f, 0.001f));
+
+    auto empty_derivative = Polynomial::derivative({});
+    REQUIRE(empty_derivative.size() == 1);
+    REQUIRE_THAT(empty_derivative[0], WithinAbs(0.0f, 0.001f));
+}
+
+TEST_CASE("Polynomial add handles empty operands", "[signal][poly][issue-645]") {
+    auto left_empty = Polynomial::add({}, {3.0f, -2.0f});
+    REQUIRE(left_empty.size() == 2);
+    REQUIRE_THAT(left_empty[0], WithinAbs(3.0f, 0.001f));
+    REQUIRE_THAT(left_empty[1], WithinAbs(-2.0f, 0.001f));
+
+    auto right_empty = Polynomial::add({1.0f, 2.0f}, {});
+    REQUIRE(right_empty.size() == 2);
+    REQUIRE_THAT(right_empty[0], WithinAbs(1.0f, 0.001f));
+    REQUIRE_THAT(right_empty[1], WithinAbs(2.0f, 0.001f));
+}
+
 TEST_CASE("Mat2 identity and multiply", "[signal][matrix]") {
     auto id = Mat2::identity();
     Mat2 a{{{2, 3}, {1, 4}}};
@@ -92,9 +125,38 @@ TEST_CASE("Mat2 inverse", "[signal][matrix]") {
     REQUIRE_THAT(product.m[1][1], WithinAbs(1.0, 0.001));
 }
 
+TEST_CASE("Mat2 inverse returns identity for singular matrices",
+          "[signal][matrix][issue-645]") {
+    Mat2 singular{{{1.0f, 2.0f}, {2.0f, 4.0f}}};
+    REQUIRE_THAT(singular.determinant(), WithinAbs(0.0f, 0.001f));
+
+    auto inv = singular.inverse();
+    REQUIRE_THAT(inv.m[0][0], WithinAbs(1.0f, 0.001f));
+    REQUIRE_THAT(inv.m[0][1], WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(inv.m[1][0], WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(inv.m[1][1], WithinAbs(1.0f, 0.001f));
+}
+
 TEST_CASE("Mat3 determinant", "[signal][matrix]") {
     auto id = Mat3::identity();
     REQUIRE_THAT(id.determinant(), WithinAbs(1.0, 0.001));
+}
+
+TEST_CASE("Mat3 multiply composes non-identity matrices",
+          "[signal][matrix][issue-645]") {
+    Mat3 a{{{1.0f, 2.0f, 3.0f}, {0.0f, 1.0f, 4.0f}, {5.0f, 6.0f, 0.0f}}};
+    Mat3 b{{{-2.0f, 1.0f, 0.0f}, {3.0f, 0.0f, 1.0f}, {4.0f, -1.0f, 2.0f}}};
+
+    auto r = a * b;
+    REQUIRE_THAT(r.m[0][0], WithinAbs(16.0f, 0.001f));
+    REQUIRE_THAT(r.m[0][1], WithinAbs(-2.0f, 0.001f));
+    REQUIRE_THAT(r.m[0][2], WithinAbs(8.0f, 0.001f));
+    REQUIRE_THAT(r.m[1][0], WithinAbs(19.0f, 0.001f));
+    REQUIRE_THAT(r.m[1][1], WithinAbs(-4.0f, 0.001f));
+    REQUIRE_THAT(r.m[1][2], WithinAbs(9.0f, 0.001f));
+    REQUIRE_THAT(r.m[2][0], WithinAbs(8.0f, 0.001f));
+    REQUIRE_THAT(r.m[2][1], WithinAbs(5.0f, 0.001f));
+    REQUIRE_THAT(r.m[2][2], WithinAbs(6.0f, 0.001f));
 }
 
 TEST_CASE("Polynomial eval_complex", "[signal][poly]") {

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -73,6 +73,19 @@ TEST_CASE("Gain processor", "[signal][gain]") {
     REQUIRE(out < 0.51f);
 }
 
+TEST_CASE("Gain linear setter and buffer processing", "[signal][gain][issue-645]") {
+    Gain g;
+    g.set_gain_linear(0.25f);
+    REQUIRE_THAT(g.gain_linear(), WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(g.gain_db(), WithinAbs(-12.0412f, 0.01f));
+
+    float buffer[] = {1.0f, -2.0f, 0.5f};
+    g.process(buffer, 3);
+    REQUIRE_THAT(buffer[0], WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(buffer[1], WithinAbs(-0.5f, 1e-6f));
+    REQUIRE_THAT(buffer[2], WithinAbs(0.125f, 1e-6f));
+}
+
 TEST_CASE("SimpleMixer", "[signal][mix]") {
     SimpleMixer mixer;
 
@@ -84,6 +97,25 @@ TEST_CASE("SimpleMixer", "[signal][mix]") {
 
     mixer.set_mix(0.5f); // 50/50
     REQUIRE_THAT(mixer.process(1.0f, 0.0f), WithinAbs(0.5, 0.001));
+}
+
+TEST_CASE("SimpleMixer clamps mix and processes buffers",
+          "[signal][mix][issue-645]") {
+    SimpleMixer mixer;
+    mixer.set_mix(-1.0f);
+    REQUIRE_THAT(mixer.mix(), WithinAbs(0.0f, 1e-6f));
+    mixer.set_mix(2.0f);
+    REQUIRE_THAT(mixer.mix(), WithinAbs(1.0f, 1e-6f));
+
+    mixer.set_mix(0.25f);
+    const float dry[] = {1.0f, 0.0f, -1.0f};
+    const float wet[] = {0.0f, 1.0f, 1.0f};
+    float output[] = {9.0f, 9.0f, 9.0f};
+
+    mixer.process(dry, wet, output, 3);
+    REQUIRE_THAT(output[0], WithinAbs(0.75f, 1e-6f));
+    REQUIRE_THAT(output[1], WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(output[2], WithinAbs(-0.5f, 1e-6f));
 }
 
 // ── Compressor ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix Mat3 multiplication so products accumulate from zero instead of the identity default.
- Add issue-645 coverage for polynomial edge cases, matrix helpers, FastMath guards, gain/mix buffer processing, and special-function wrappers.

## Validation
- cmake -S . -B build-signal-math-lite -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-signal-math-lite --target pulp-test-poly-math pulp-test-fast-math pulp-test-signal pulp-test-dsp-enhancements -j4
- ./build-signal-math-lite/test/pulp-test-poly-math "[issue-645]"
- ./build-signal-math-lite/test/pulp-test-fast-math "[issue-645]"
- ./build-signal-math-lite/test/pulp-test-signal "[issue-645]"
- ./build-signal-math-lite/test/pulp-test-dsp-enhancements "[issue-645]"
- full pulp-test-poly-math, pulp-test-fast-math, pulp-test-signal, pulp-test-dsp-enhancements
- ctest --test-dir build-signal-math-lite -R focused signal/math issue-645 selector --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py
- python3 tools/scripts/version_bump_check.py --mode=report

Refs #645.
Refs #641.

Note: opened via GitHub directly while the Shipyard SSH Windows target remains the known preflight blocker; #774 tracks this fallback.