### PR TITLE
test(signal): cover DSP helper edges

### DIFF
--- a/test/test_dsp_expansion.cpp
+++ b/test/test_dsp_expansion.cpp
@@ -7,6 +7,7 @@
 #include <pulp/signal/lookup_table.hpp>
 #include <pulp/signal/tpt_filter.hpp>
 #include <pulp/signal/gain.hpp>
+#include <pulp/signal/waveshaper.hpp>
 #include <cmath>
 #include <vector>
 
@@ -127,6 +128,27 @@ TEST_CASE("BallisticsFilter reset returns to zero", "[signal][ballistics]") {
     REQUIRE_THAT(env.current(), WithinAbs(0.0, 0.001));
 }
 
+TEST_CASE("BallisticsFilter clamps time constants and processes buffers",
+          "[signal][ballistics][issue-645]") {
+    BallisticsFilter env;
+    env.prepare(48000.0f);
+    env.set_attack_ms(-5.0f);
+    env.set_release_ms(0.0f);
+
+    REQUIRE_THAT(env.process(-0.5f), WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(env.process(0.0f), WithinAbs(0.0f, 1e-6f));
+
+    env.set_mode(BallisticsFilter::Mode::rms);
+    const float input[] = {-0.25f, 0.5f, -0.75f};
+    float output[] = {0.0f, 0.0f, 0.0f};
+    env.process(input, output, 3);
+
+    REQUIRE_THAT(output[0], WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(output[1], WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(output[2], WithinAbs(0.75f, 1e-6f));
+    REQUIRE_THAT(env.current(), WithinAbs(0.75f, 1e-6f));
+}
+
 // ── LogRampedValue ───────────────────────────────────────────────────────
 
 TEST_CASE("LogRampedValue reaches target", "[signal][log_ramp]") {
@@ -166,6 +188,62 @@ TEST_CASE("LogRampedValue skip advances correctly", "[signal][log_ramp]") {
     v.skip(4400);
     float remaining = v.next();
     REQUIRE(remaining > 900.0f);
+}
+
+TEST_CASE("LogRampedValue jumps for non-positive endpoints",
+          "[signal][log_ramp][issue-645]") {
+    LogRampedValue zero_start;
+    zero_start.set_ramp_time(1.0f, 48000.0f);
+    zero_start.skip(32);
+    zero_start.set_target(440.0f);
+    REQUIRE_FALSE(zero_start.is_smoothing());
+    REQUIRE_THAT(zero_start.current_value(), WithinAbs(440.0f, 1e-6f));
+    REQUIRE_THAT(zero_start.target_value(), WithinAbs(440.0f, 1e-6f));
+
+    LogRampedValue positive(220.0f);
+    positive.set_ramp_time(1.0f, 48000.0f);
+    positive.set_target(0.0f);
+    REQUIRE_FALSE(positive.is_smoothing());
+    REQUIRE_THAT(positive.next(), WithinAbs(0.0f, 1e-6f));
+}
+
+// ── WaveShaper ───────────────────────────────────────────────────────────
+
+TEST_CASE("WaveShaper covers all curve branches", "[signal][waveshaper][issue-645]") {
+    WaveShaper shaper;
+    shaper.set_drive(2.0f);
+
+    shaper.set_curve(WaveShaper::Curve::soft_clip);
+    REQUIRE_THAT(shaper.process(1.0f), WithinAbs(2.0f / 3.0f, 1e-6f));
+
+    shaper.set_curve(WaveShaper::Curve::hard_clip);
+    REQUIRE_THAT(shaper.process(0.75f), WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(shaper.process(-0.75f), WithinAbs(-1.0f, 1e-6f));
+
+    shaper.set_curve(WaveShaper::Curve::tanh_clip);
+    REQUIRE_THAT(shaper.process(-0.5f), WithinAbs(std::tanh(-1.0f), 1e-6f));
+
+    shaper.set_curve(WaveShaper::Curve::fold);
+    REQUIRE_THAT(shaper.process(0.75f), WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(shaper.process(-0.75f), WithinAbs(-0.5f, 1e-6f));
+
+    shaper.set_drive(1.0f);
+    shaper.set_curve(WaveShaper::Curve::sine_fold);
+    REQUIRE_THAT(shaper.process(1.0f), WithinAbs(1.0f, 1e-6f));
+}
+
+TEST_CASE("WaveShaper processes buffers in-place", "[signal][waveshaper][issue-645]") {
+    WaveShaper shaper;
+    shaper.set_curve(WaveShaper::Curve::hard_clip);
+    shaper.set_drive(3.0f);
+
+    float buffer[] = {-0.5f, 0.0f, 0.25f, 0.5f};
+    shaper.process(buffer, 4);
+
+    REQUIRE_THAT(buffer[0], WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(buffer[1], WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(buffer[2], WithinAbs(0.75f, 1e-6f));
+    REQUIRE_THAT(buffer[3], WithinAbs(1.0f, 1e-6f));
 }
 
 // ── ProcessorChain ───────────────────────────────────────────────────────

--- a/test/test_simd.cpp
+++ b/test/test_simd.cpp
@@ -199,6 +199,25 @@ TEST_CASE("AlignedBuffer move semantics", "[simd][aligned_buffer]") {
     REQUIRE(b[0] == 42.0f);
 }
 
+TEST_CASE("AlignedBuffer move assignment releases prior storage",
+          "[simd][aligned_buffer][issue-645]") {
+    AlignedBuffer source(3);
+    source[0] = 1.0f;
+    source[1] = 2.0f;
+    source[2] = 3.0f;
+
+    AlignedBuffer dest(2);
+    dest[0] = -1.0f;
+    dest = std::move(source);
+
+    REQUIRE(source.data() == nullptr);
+    REQUIRE(source.empty());
+    REQUIRE(dest.size() == 3);
+    REQUIRE_THAT(dest[0], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(dest[1], WithinAbs(2.0f, 1e-6f));
+    REQUIRE_THAT(dest[2], WithinAbs(3.0f, 1e-6f));
+}
+
 TEST_CASE("AlignedBuffer resize", "[simd][aligned_buffer]") {
     AlignedBuffer buf(50);
     buf[0] = 1.0f;
@@ -210,6 +229,21 @@ TEST_CASE("AlignedBuffer resize", "[simd][aligned_buffer]") {
     // Data not preserved after resize
     buf.resize(0);
     REQUIRE(buf.empty());
+}
+
+TEST_CASE("AlignedBuffer resize same size and empty clear are no-ops",
+          "[simd][aligned_buffer][issue-645]") {
+    AlignedBuffer empty;
+    empty.clear();
+    empty.resize(0);
+    REQUIRE(empty.empty());
+
+    AlignedBuffer buf(4);
+    auto* original = buf.data();
+    buf[0] = 9.0f;
+    buf.resize(4);
+    REQUIRE(buf.data() == original);
+    REQUIRE_THAT(buf[0], WithinAbs(9.0f, 1e-6f));
 }
 
 TEST_CASE("AlignedBuffer clear", "[simd][aligned_buffer]") {
@@ -230,6 +264,19 @@ TEST_CASE("AlignedBuffer copy_from", "[simd][aligned_buffer]") {
 
     for (size_t i = 0; i < 5; ++i)
         REQUIRE(buf[i] == src[i]);
+}
+
+TEST_CASE("AlignedBuffer copy_from truncates to destination size",
+          "[simd][aligned_buffer][issue-645]") {
+    const float src[] = {10.0f, 20.0f, 30.0f, 40.0f};
+    AlignedBuffer buf(2);
+    buf.copy_from(src, 4);
+
+    REQUIRE_THAT(buf[0], WithinAbs(10.0f, 1e-6f));
+    REQUIRE_THAT(buf[1], WithinAbs(20.0f, 1e-6f));
+
+    const AlignedBuffer& const_buf = buf;
+    REQUIRE(const_buf.begin() + 2 == const_buf.end());
 }
 
 TEST_CASE("AlignedBuffer works with simd operations", "[simd][aligned_buffer]") {


### PR DESCRIPTION
## Summary
- Add issue-645 coverage for AlignedBuffer move assignment, same-size resize, empty clear, and copy truncation paths.
- Add issue-645 coverage for BallisticsFilter time-constant clamps and buffer processing.
- Add issue-645 coverage for LogRampedValue non-positive endpoint jumps.
- Add issue-645 coverage for all WaveShaper curve branches and in-place buffer processing.

## Validation
- cmake -S . -B build-signal-dsp-helper-lite -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-signal-dsp-helper-lite --target pulp-test-simd pulp-test-dsp-expansion -j4
- ./build-signal-dsp-helper-lite/test/pulp-test-simd "[issue-645]"
- ./build-signal-dsp-helper-lite/test/pulp-test-dsp-expansion "[issue-645]"
- full pulp-test-simd
- full pulp-test-dsp-expansion
- ctest --test-dir build-signal-dsp-helper-lite -R focused signal DSP helper issue-645 selector --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py
- python3 tools/scripts/version_bump_check.py --mode=report

Refs #645.
Refs #641.

Note: opened via GitHub directly while the Shipyard SSH Windows target remains the known preflight blocker; #774 tracks this fallback.