### PR TITLE
test(audio): cover OGG reader edges

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -864,6 +864,10 @@ add_executable(pulp-test-audio-file test_audio_file.cpp)
 target_link_libraries(pulp-test-audio-file PRIVATE pulp::audio Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-audio-file)
 
+add_executable(pulp-test-ogg-reader test_ogg_reader.cpp)
+target_link_libraries(pulp-test-ogg-reader PRIVATE pulp::audio Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-ogg-reader)
+
 # Audio tests
 add_executable(pulp-test-audio test_audio.cpp)
 target_link_libraries(pulp-test-audio PRIVATE pulp::audio Catch2::Catch2WithMain)

--- a/test/test_ogg_reader.cpp
+++ b/test/test_ogg_reader.cpp
@@ -1,0 +1,89 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/audio/format_registry.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace pulp::audio {
+std::unique_ptr<FormatReader> create_ogg_reader();
+}
+
+namespace {
+
+namespace fs = std::filesystem;
+
+uint64_t current_process_id() {
+#ifdef _WIN32
+    return static_cast<uint64_t>(_getpid());
+#else
+    return static_cast<uint64_t>(getpid());
+#endif
+}
+
+struct TempDir {
+    fs::path path;
+
+    TempDir() {
+        static std::atomic<uint64_t> next_id{0};
+        auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+        auto unique_id = next_id.fetch_add(1, std::memory_order_relaxed);
+        path = fs::temp_directory_path()
+             / ("pulp-ogg-reader-" + std::to_string(current_process_id()) + "-"
+                + std::to_string(stamp) + "-" + std::to_string(unique_id));
+        fs::create_directories(path);
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+void write_binary(const fs::path& path, std::string_view bytes) {
+    std::ofstream output(path, std::ios::binary);
+    REQUIRE(output.good());
+    output.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    REQUIRE(output.good());
+}
+
+} // namespace
+
+TEST_CASE("OggReader reports supported extensions and format name",
+          "[audio][ogg][issue-640]") {
+    auto reader = pulp::audio::create_ogg_reader();
+    REQUIRE(reader != nullptr);
+
+    REQUIRE(reader->format_name() == "OGG Vorbis");
+    REQUIRE(reader->supports_extension(".ogg"));
+    REQUIRE(reader->supports_extension(".oga"));
+    REQUIRE_FALSE(reader->supports_extension(".wav"));
+    REQUIRE_FALSE(reader->supports_extension(".OGG"));
+}
+
+TEST_CASE("OggReader rejects missing and malformed files",
+          "[audio][ogg][issue-640]") {
+    auto reader = pulp::audio::create_ogg_reader();
+    TempDir temp;
+
+    auto missing = (temp.path / "missing.ogg").string();
+    REQUIRE_FALSE(reader->read_info(missing).has_value());
+    REQUIRE_FALSE(reader->read(missing).has_value());
+
+    auto malformed = temp.path / "malformed.oga";
+    write_binary(malformed, "OggS_not_a_valid_vorbis_stream");
+
+    REQUIRE_FALSE(reader->read_info(malformed.string()).has_value());
+    REQUIRE_FALSE(reader->read(malformed.string()).has_value());
+}


### PR DESCRIPTION
## Summary
- Add a dedicated pulp-test-ogg-reader target for direct OGG reader factory coverage.
- Cover OGG/OGA extension support, format name, unsupported extension behavior, and missing/malformed input failure paths.
- Keep this separate from test_audio_file.cpp to avoid overlapping the open #822 audio-file helper tranche.

## Validation
- cmake -S . -B build-audio-ogg-lite -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-audio-ogg-lite --target pulp-test-ogg-reader -j4
- ./build-audio-ogg-lite/test/pulp-test-ogg-reader "[issue-640]"
- full pulp-test-ogg-reader
- ctest --test-dir build-audio-ogg-lite -R OggReader --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py
- python3 tools/scripts/version_bump_check.py --mode=report

Refs #640.
Refs #641.

Note: opened via GitHub directly while the Shipyard SSH Windows target remains the known preflight blocker; #774 tracks this fallback.