### PR TITLE
test(signal): cover multi-channel meter edges

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -783,6 +783,11 @@ add_executable(pulp-test-signal test_signal.cpp)
 target_link_libraries(pulp-test-signal PRIVATE pulp::signal Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-signal)
 
+# Multi-channel meter edge tests (#645)
+add_executable(pulp-test-multi-channel-meter test_multi_channel_meter.cpp)
+target_link_libraries(pulp-test-multi-channel-meter PRIVATE pulp::signal Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-multi-channel-meter)
+
 # DSL processor contract tests (FaustProcessor + PulpFaustUI + PulpFaustMeta)
 add_executable(pulp-test-dsl-processor test_dsl_processor.cpp)
 target_link_libraries(pulp-test-dsl-processor PRIVATE

--- a/test/test_multi_channel_meter.cpp
+++ b/test/test_multi_channel_meter.cpp
@@ -1,0 +1,120 @@
+#include <pulp/signal/multi_channel_meter.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <limits>
+
+using Catch::Matchers::WithinAbs;
+using namespace pulp::signal;
+
+TEST_CASE("MultiChannelMeter process clamps to prepared channel count", "[signal][meter][issue-645]") {
+    MultiChannelMeter meter;
+    meter.prepare(100.0f, 1);
+
+    float first[] = {0.25f};
+    float ignored[] = {1.0f};
+    const float* channels[] = {first, ignored};
+    meter.process(channels, 2, 1);
+
+    const auto& snap = meter.snapshot();
+    REQUIRE(snap.num_channels == 1);
+    REQUIRE_THAT(snap.channels[0].peak, WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(snap.channels[1].peak, WithinAbs(0.0f, 1e-6f));
+}
+
+TEST_CASE("MultiChannelMeter empty process leaves current snapshot untouched", "[signal][meter][issue-645]") {
+    MultiChannelMeter meter;
+    meter.prepare(100.0f, 1);
+
+    float sample[] = {0.5f};
+    const float* channels[] = {sample};
+    meter.process(channels, 1, 0);
+
+    const auto& snap = meter.snapshot();
+    REQUIRE(snap.num_channels == 1);
+    REQUIRE_THAT(snap.channels[0].peak, WithinAbs(0.0f, 1e-6f));
+    REQUIRE(std::isinf(snap.channels[0].lufs_momentary));
+}
+
+TEST_CASE("MultiChannelMeter correlation window can replace previous sign", "[signal][meter][issue-645]") {
+    MultiChannelMeter meter;
+    meter.prepare(10.0f, 2);
+
+    float left[] = {0.5f};
+    float right[] = {0.5f};
+    const float* channels[] = {left, right};
+    meter.process(channels, 2, 1);
+    REQUIRE_THAT(meter.snapshot().correlation, WithinAbs(1.0f, 1e-6f));
+
+    right[0] = -0.5f;
+    meter.process(channels, 2, 1);
+    REQUIRE_THAT(meter.snapshot().correlation, WithinAbs(-1.0f, 1e-6f));
+}
+
+TEST_CASE("MultiChannelMeter integrated LUFS averages multiple windows", "[signal][meter][issue-645]") {
+    MultiChannelMeter meter;
+    meter.prepare(10.0f, 1);
+
+    float half[] = {0.5f};
+    const float* half_channels[] = {half};
+    for (int i = 0; i < 4; ++i)
+        meter.process(half_channels, 1, 1);
+
+    REQUIRE(std::isfinite(meter.snapshot().lufs_integrated));
+
+    float quarter[] = {0.25f};
+    const float* quarter_channels[] = {quarter};
+    for (int i = 0; i < 4; ++i)
+        meter.process(quarter_channels, 1, 1);
+
+    constexpr double first_mean_sq = 0.25;
+    constexpr double second_mean_sq = 0.0625;
+    auto expected = -0.691f + 10.0f * static_cast<float>(
+        std::log10((first_mean_sq + second_mean_sq) / 2.0));
+    REQUIRE_THAT(meter.snapshot().lufs_integrated, WithinAbs(expected, 1e-4f));
+}
+
+TEST_CASE("MultiChannelBallistics releases held values and clamps display floor", "[signal][meter][issue-645]") {
+    MultiChannelBallistics ballistics;
+    ballistics.peak_hold_time = 0.05f;
+    ballistics.release_time = 0.01f;
+
+    MultiChannelMeterData data;
+    data.num_channels = 1;
+    data.channels[0].peak = 0.75f;
+    data.channels[0].rms = 0.5f;
+    ballistics.update(data, 0.01f);
+
+    REQUIRE(ballistics.channels[0].display_peak > 0.0f);
+    REQUIRE(ballistics.channels[0].display_rms > 0.0f);
+    REQUIRE_THAT(ballistics.channels[0].held_peak, WithinAbs(0.75f, 1e-6f));
+
+    data.channels[0].peak = 0.0f;
+    data.channels[0].rms = 0.0f;
+    ballistics.update(data, 1.0f);
+
+    REQUIRE_THAT(ballistics.channels[0].display_peak, WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(ballistics.channels[0].display_rms, WithinAbs(0.0f, 1e-6f));
+    REQUIRE(ballistics.channels[0].held_peak < 1e-3f);
+}
+
+TEST_CASE("MultiChannelBallistics higher peak refreshes held peak", "[signal][meter][issue-645]") {
+    MultiChannelBallistics ballistics;
+
+    MultiChannelMeterData data;
+    data.num_channels = 1;
+    data.channels[0].peak = 0.5f;
+    ballistics.update(data, 0.01f);
+    REQUIRE_THAT(ballistics.channels[0].held_peak, WithinAbs(0.5f, 1e-6f));
+
+    data.channels[0].peak = 0.25f;
+    ballistics.update(data, 0.01f);
+    REQUIRE_THAT(ballistics.channels[0].held_peak, WithinAbs(0.5f, 1e-6f));
+
+    data.channels[0].peak = 0.8f;
+    ballistics.update(data, 0.01f);
+    REQUIRE_THAT(ballistics.channels[0].held_peak, WithinAbs(0.8f, 1e-6f));
+    REQUIRE_THAT(ballistics.channels[0].hold_counter, WithinAbs(ballistics.peak_hold_time, 1e-6f));
+}


### PR DESCRIPTION
## Summary
- add a dedicated multi-channel meter edge-path test target
- cover prepared-channel clamping, empty process blocks, correlation window replacement, integrated LUFS running averages, ballistics release/noise-floor clamping, and held-peak refresh
- keep this separate from test_signal.cpp to avoid overlap with the open signal math/DSP coverage PRs

Refs #645
Refs #641

## Local validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF
- cmake --build build --target pulp-test-multi-channel-meter -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-multi-channel-meter [issue-645]
- ./build/test/pulp-test-multi-channel-meter
- ctest --test-dir build -R MultiChannel... --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD