### PR TITLE
fix(midi): reject malformed raw MIDI data bytes

### DIFF
--- a/core/midi/include/pulp/midi/raw_midi_parser.hpp
+++ b/core/midi/include/pulp/midi/raw_midi_parser.hpp
@@ -119,6 +119,16 @@ inline void parse_raw_midi_bytes(const uint8_t* buf,
         }
 
         if (i + msg_len <= n) {
+            bool has_valid_data = true;
+            for (std::size_t data_index = 1; data_index < msg_len; ++data_index) {
+                if ((buf[i + data_index] & 0x80) != 0) {
+                    has_valid_data = false;
+                    break;
+                }
+            }
+
+            if (!has_valid_data) continue;
+
             if (on_short) {
                 on_short(b,
                          msg_len > 1 ? buf[i + 1] : 0,

--- a/test/test_raw_midi_parser.cpp
+++ b/test/test_raw_midi_parser.cpp
@@ -59,6 +59,37 @@ TEST_CASE("raw_midi_parser emits short messages cleanly",
     REQUIRE(c.sysex.empty());
 }
 
+TEST_CASE("raw_midi_parser emits remaining short-message forms",
+          "[midi][raw_midi_parser][issue-645]") {
+    auto c = parse({0xD0, 0x45, // Channel Pressure
+                    0xF3, 0x09, // Song Select
+                    0xF6,       // Tune Request
+                    0xF7});      // Stray End-of-Exclusive
+
+    REQUIRE(c.shorts.size() == 4);
+    REQUIRE(c.shorts[0].status == 0xD0);
+    REQUIRE(c.shorts[0].d1 == 0x45);
+    REQUIRE(c.shorts[0].d2 == 0x00);
+    REQUIRE(c.shorts[1].status == 0xF3);
+    REQUIRE(c.shorts[1].d1 == 0x09);
+    REQUIRE(c.shorts[1].d2 == 0x00);
+    REQUIRE(c.shorts[2].status == 0xF6);
+    REQUIRE(c.shorts[2].d1 == 0x00);
+    REQUIRE(c.shorts[2].d2 == 0x00);
+    REQUIRE(c.shorts[3].status == 0xF7);
+    REQUIRE(c.sysex.empty());
+}
+
+TEST_CASE("raw_midi_parser drops stray data and incomplete short messages",
+          "[midi][raw_midi_parser][issue-645]") {
+    auto c = parse({0x00, 0x7F,       // stray data bytes
+                    0x90, 0x40,       // incomplete Note On
+                    0x80});           // incomplete Note Off
+
+    REQUIRE(c.shorts.empty());
+    REQUIRE(c.sysex.empty());
+}
+
 TEST_CASE("raw_midi_parser accumulates sysex across calls",
           "[midi][raw_midi_parser][issue-406]") {
     RawMidiParserState state;
@@ -92,6 +123,20 @@ TEST_CASE("raw_midi_parser emits realtime inside sysex without terminating",
     REQUIRE(c.sysex[0] == std::vector<uint8_t>{0xF0, 0x7E, 0x05, 0xF7});
     REQUIRE(c.shorts.size() == 1);
     REQUIRE(c.shorts[0].status == 0xF8); // MIDI Clock
+}
+
+TEST_CASE("raw_midi_parser tolerates omitted callbacks",
+          "[midi][raw_midi_parser][issue-645]") {
+    RawMidiParserState state;
+    uint8_t bytes[] = {0xF0, 0x7E, 0xF8, 0x01, 0xF7,
+                       0x90, 0x40, 0x7F};
+
+    parse_raw_midi_bytes(bytes, sizeof(bytes), state,
+                         RawMidiShortCallback{},
+                         RawMidiSysexCallback{});
+
+    REQUIRE_FALSE(state.sysex_in_progress);
+    REQUIRE(state.sysex_buffer.empty());
 }
 
 TEST_CASE("raw_midi_parser recovers from aborted sysex (#406 codex P2)",
@@ -149,4 +194,9 @@ TEST_CASE("raw_midi_parser caps runaway sysex at kRawMidiSysexLimit",
     REQUIRE(c.sysex.empty());
     REQUIRE_FALSE(state.sysex_in_progress);
     REQUIRE(state.sysex_buffer.empty());
+
+    uint8_t clean[] = {0xF0, 0x01, 0xF7};
+    parse_raw_midi_bytes(clean, sizeof(clean), state, on_short, on_sysex);
+    REQUIRE(c.sysex.size() == 1);
+    REQUIRE(c.sysex[0] == std::vector<uint8_t>{0xF0, 0x01, 0xF7});
 }


### PR DESCRIPTION
## Summary
- harden the raw MIDI byte-stream parser so status bytes are not emitted as short-message data bytes
- add coverage for remaining short-message forms, omitted callbacks, malformed/incomplete short messages, and recovery after runaway sysex cap reset

## Tracking
- Refs #645
- Refs #641
- Metadata: codecov

## Validation
- cmake --build build --target pulp-test-raw-midi-parser -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-raw-midi-parser "[issue-645]"
- ./build/test/pulp-test-raw-midi-parser
- ctest --test-dir build -R "raw_midi_parser.*(remaining short|drops stray|omitted callbacks|caps runaway)" --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD
