### PR TITLE
test(midi): cover MIDI-CI edge paths

### DIFF
--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -1,7 +1,35 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/midi/midi_ci.hpp>
 
+#include <cstddef>
+
 using namespace pulp::midi;
+
+namespace {
+
+void append_muid(std::vector<uint8_t>& msg, MUID muid) {
+    msg.push_back(muid.value & 0x7F);
+    msg.push_back((muid.value >> 7) & 0x7F);
+    msg.push_back((muid.value >> 14) & 0x7F);
+    msg.push_back((muid.value >> 21) & 0x7F);
+}
+
+uint32_t read_muid_at(const std::vector<uint8_t>& msg, std::size_t offset) {
+    return static_cast<uint32_t>(msg[offset])
+        | (static_cast<uint32_t>(msg[offset + 1]) << 7)
+        | (static_cast<uint32_t>(msg[offset + 2]) << 14)
+        | (static_cast<uint32_t>(msg[offset + 3]) << 21);
+}
+
+std::vector<uint8_t> make_ci_header(CiMessageType type, MUID source, MUID destination) {
+    std::vector<uint8_t> msg{0xF0, 0x7E, 0x7F, 0x0D,
+                             static_cast<uint8_t>(type), 0x02};
+    append_muid(msg, source);
+    append_muid(msg, destination);
+    return msg;
+}
+
+} // namespace
 
 TEST_CASE("MUID generate is non-zero", "[midi][ci]") {
     auto muid = MUID::generate();
@@ -28,6 +56,21 @@ TEST_CASE("CiDiscovery creates valid inquiry", "[midi][ci]") {
     REQUIRE(msg[4] == 0x70);       // Discovery inquiry
 }
 
+TEST_CASE("CiDiscovery profile inquiry encodes destination",
+          "[midi][ci][issue-645]") {
+    CiDiscovery ci;
+    MUID destination{0x01234567};
+
+    auto msg = ci.create_profile_inquiry(destination);
+
+    REQUIRE(msg.size() == 15);
+    REQUIRE(msg.front() == 0xF0);
+    REQUIRE(msg.back() == 0xF7);
+    REQUIRE(msg[4] == static_cast<uint8_t>(CiMessageType::ProfileInquiry));
+    REQUIRE(read_muid_at(msg, 6) == ci.local_muid().value);
+    REQUIRE(read_muid_at(msg, 10) == destination.value);
+}
+
 TEST_CASE("CiDiscovery responds to inquiry", "[midi][ci]") {
     CiDiscovery responder;
     CiDiscovery inquirer;
@@ -38,6 +81,64 @@ TEST_CASE("CiDiscovery responds to inquiry", "[midi][ci]") {
     REQUIRE_FALSE(reply.empty());
     REQUIRE(reply.front() == 0xF0);
     REQUIRE(reply[4] == 0x71);  // Discovery reply
+}
+
+TEST_CASE("CiDiscovery ignores malformed and unhandled messages",
+          "[midi][ci][issue-645]") {
+    CiDiscovery ci;
+    std::vector<uint8_t> too_short{0xF0, 0x7E, 0x7F};
+    std::vector<uint8_t> wrong_start{0x00, 0x7E, 0x7F, 0x0D,
+                                     static_cast<uint8_t>(CiMessageType::DiscoveryInquiry),
+                                     0x02, 0, 0, 0, 0, 0, 0, 0, 0};
+    auto unknown = make_ci_header(static_cast<CiMessageType>(0x01),
+                                  MUID{0x01020304}, MUID::broadcast());
+    unknown.push_back(0xF7);
+
+    REQUIRE(ci.process_message(too_short.data(), too_short.size()).empty());
+    REQUIRE(ci.process_message(wrong_start.data(), wrong_start.size()).empty());
+    REQUIRE(ci.process_message(unknown.data(), unknown.size()).empty());
+}
+
+TEST_CASE("CiDiscovery ignores inquiries addressed to another MUID",
+          "[midi][ci][issue-645]") {
+    CiDiscovery responder;
+    CiDeviceInfo info = responder.device_info();
+    info.muid = MUID{0x00001234};
+    responder.set_device_info(info);
+
+    auto inquiry = make_ci_header(CiMessageType::DiscoveryInquiry,
+                                  MUID{0x00005678}, MUID{0x00009ABC});
+    inquiry.push_back(0xF7);
+
+    REQUIRE(responder.process_message(inquiry.data(), inquiry.size()).empty());
+}
+
+TEST_CASE("CiDiscovery stores discovery replies and fires callbacks",
+          "[midi][ci][issue-645]") {
+    CiDiscovery inquirer;
+    CiDiscovery responder;
+    CiDeviceInfo responder_info = responder.device_info();
+    responder_info.muid = MUID{0x00123456};
+    responder_info.ci_version = 3;
+    responder.set_device_info(responder_info);
+
+    std::vector<CiDeviceInfo> callbacks;
+    inquirer.on_device_discovered = [&](const CiDeviceInfo& info) {
+        callbacks.push_back(info);
+    };
+
+    auto inquiry = inquirer.create_discovery_inquiry();
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+    REQUIRE_FALSE(reply.empty());
+
+    auto response = inquirer.process_message(reply.data(), reply.size());
+
+    REQUIRE(response.empty());
+    REQUIRE(inquirer.discovered_devices().size() == 1);
+    REQUIRE(inquirer.discovered_devices()[0].muid.value == responder_info.muid.value);
+    REQUIRE(inquirer.discovered_devices()[0].ci_version == responder_info.ci_version);
+    REQUIRE(callbacks.size() == 1);
+    REQUIRE(callbacks[0].muid.value == responder_info.muid.value);
 }
 
 TEST_CASE("CiDiscovery profile management", "[midi][ci]") {
@@ -54,6 +155,22 @@ TEST_CASE("CiDiscovery profile management", "[midi][ci]") {
 
     ci.disable_profile(profile);
     REQUIRE_FALSE(ci.profiles()[0].enabled);
+}
+
+TEST_CASE("CiDiscovery profile management ignores unknown profiles",
+          "[midi][ci][issue-645]") {
+    CiDiscovery ci;
+    ProfileId known{0x01, 0x02, 0x03, 0x04, 0x00};
+    ProfileId unknown{0x10, 0x20, 0x30, 0x40, 0x00};
+    ci.add_profile({known, false, 0});
+
+    int callback_count = 0;
+    ci.on_profile_changed = [&](const ProfileId&, bool) { ++callback_count; };
+
+    REQUIRE_FALSE(ci.enable_profile(unknown));
+    REQUIRE_FALSE(ci.disable_profile(unknown));
+    REQUIRE_FALSE(ci.profiles()[0].enabled);
+    REQUIRE(callback_count == 0);
 }
 
 TEST_CASE("CiDiscovery profile callback", "[midi][ci]") {
@@ -101,26 +218,10 @@ TEST_CASE("CiDiscovery profile reply echoes inquirer MUID", "[midi][ci]") {
     ProfileId p{0x11, 0x01, 0x00, 0x00, 0x00};
     responder.add_profile({p, true, 0});
 
-    // Synthesize a profile inquiry from a distinct peer MUID.
     MUID peer_muid{0x01234567};
-    std::vector<uint8_t> inquiry;
-    inquiry.push_back(0xF0);
-    inquiry.push_back(0x7E);
-    inquiry.push_back(0x7F);
-    inquiry.push_back(0x0D);
-    inquiry.push_back(static_cast<uint8_t>(CiMessageType::ProfileInquiry));
-    inquiry.push_back(responder.device_info().ci_version);
-    // Source = peer
-    inquiry.push_back(peer_muid.value & 0x7F);
-    inquiry.push_back((peer_muid.value >> 7) & 0x7F);
-    inquiry.push_back((peer_muid.value >> 14) & 0x7F);
-    inquiry.push_back((peer_muid.value >> 21) & 0x7F);
-    // Destination = responder
     MUID resp_muid = responder.local_muid();
-    inquiry.push_back(resp_muid.value & 0x7F);
-    inquiry.push_back((resp_muid.value >> 7) & 0x7F);
-    inquiry.push_back((resp_muid.value >> 14) & 0x7F);
-    inquiry.push_back((resp_muid.value >> 21) & 0x7F);
+    auto inquiry = make_ci_header(CiMessageType::ProfileInquiry,
+                                  peer_muid, resp_muid);
     inquiry.push_back(0xF7);
 
     auto reply = responder.process_message(inquiry.data(), inquiry.size());
@@ -130,15 +231,41 @@ TEST_CASE("CiDiscovery profile reply echoes inquirer MUID", "[midi][ci]") {
     REQUIRE(reply[0] == 0xF0);
     REQUIRE(reply[4] == static_cast<uint8_t>(CiMessageType::ProfileReply));
     // Source MUID = responder (bytes 6..9)
-    uint32_t src =  (uint32_t)reply[6]
-                 | ((uint32_t)reply[7]  << 7)
-                 | ((uint32_t)reply[8]  << 14)
-                 | ((uint32_t)reply[9]  << 21);
-    REQUIRE(src == resp_muid.value);
+    REQUIRE(read_muid_at(reply, 6) == resp_muid.value);
     // Destination MUID = peer (bytes 10..13) — this is the regression assertion.
-    uint32_t dst =  (uint32_t)reply[10]
-                 | ((uint32_t)reply[11] << 7)
-                 | ((uint32_t)reply[12] << 14)
-                 | ((uint32_t)reply[13] << 21);
-    REQUIRE(dst == peer_muid.value);
+    REQUIRE(read_muid_at(reply, 10) == peer_muid.value);
+}
+
+TEST_CASE("CiDiscovery profile reply lists enabled and disabled profiles",
+          "[midi][ci][issue-645]") {
+    CiDiscovery responder;
+    ProfileId enabled{0x11, 0x22, 0x01, 0x02, 0x03};
+    ProfileId disabled{0x33, 0x44, 0x05, 0x06, 0x07};
+    responder.add_profile({enabled, true, 0});
+    responder.add_profile({disabled, false, 0});
+
+    MUID peer_muid{0x00013579};
+    auto inquiry = make_ci_header(CiMessageType::ProfileInquiry,
+                                  peer_muid, responder.local_muid());
+    inquiry.push_back(0xF7);
+
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+
+    REQUIRE(reply.size() == 29);
+    REQUIRE(reply[4] == static_cast<uint8_t>(CiMessageType::ProfileReply));
+    REQUIRE(reply[14] == 1);
+    REQUIRE(reply[15] == 0);
+    REQUIRE(reply[16] == enabled.bank);
+    REQUIRE(reply[17] == enabled.number);
+    REQUIRE(reply[18] == enabled.version);
+    REQUIRE(reply[19] == enabled.level);
+    REQUIRE(reply[20] == enabled.reserved);
+    REQUIRE(reply[21] == 1);
+    REQUIRE(reply[22] == 0);
+    REQUIRE(reply[23] == disabled.bank);
+    REQUIRE(reply[24] == disabled.number);
+    REQUIRE(reply[25] == disabled.version);
+    REQUIRE(reply[26] == disabled.level);
+    REQUIRE(reply[27] == disabled.reserved);
+    REQUIRE(reply[28] == 0xF7);
 }


### PR DESCRIPTION
## Summary
- add MIDI-CI coverage for profile inquiry destination encoding
- cover malformed/unhandled CI messages, discovery destination filtering, discovery-reply storage/callbacks, unknown profile no-ops, and enabled/disabled profile reply payloads
- refactor the existing MUID byte assertions through local test helpers

## Tracking
- Refs #645
- Refs #641
- Metadata: codecov

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF
- cmake --build build --target pulp-test-midi-ci -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-midi-ci "[issue-645]"
- ./build/test/pulp-test-midi-ci
- ctest --test-dir build -R "CiDiscovery.*(profile inquiry encodes|ignores malformed|ignores inquiries|stores discovery|unknown profiles|lists enabled)" --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD
