### PR TITLE
test(tools): cover CLI release packager

### DIFF
--- a/test/test_android_package.cpp
+++ b/test/test_android_package.cpp
@@ -2,7 +2,9 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <pulp/ship/android.hpp>
 
+#include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -13,6 +15,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #else
+#include <process.h>
 #include <stdlib.h>
 #endif
 
@@ -21,6 +24,16 @@ using Catch::Matchers::ContainsSubstring;
 namespace fs = std::filesystem;
 
 namespace {
+
+std::uint64_t process_id() {
+#ifdef _WIN32
+    return static_cast<std::uint64_t>(_getpid());
+#else
+    return static_cast<std::uint64_t>(::getpid());
+#endif
+}
+
+std::atomic_uint64_t temp_dir_counter{0};
 
 int set_env_var(const char* name, const std::string& value) {
 #ifdef _WIN32
@@ -91,7 +104,10 @@ struct TempDir {
 
     TempDir() {
         auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
-        path = fs::temp_directory_path() / ("pulp-android-package-test-" + std::to_string(stamp));
+        auto counter = temp_dir_counter.fetch_add(1, std::memory_order_relaxed);
+        path = fs::temp_directory_path() / (
+            "pulp-android-package-test-" + std::to_string(process_id()) +
+            "-" + std::to_string(stamp) + "-" + std::to_string(counter));
         fs::remove_all(path);
         fs::create_directories(path);
     }

--- a/tools/scripts/test_package_cli.py
+++ b/tools/scripts/test_package_cli.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/scripts/package_cli.py."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).parent / "package_cli.py"
+spec = importlib.util.spec_from_file_location("package_cli", SCRIPT)
+assert spec and spec.loader
+pc = importlib.util.module_from_spec(spec)
+sys.modules["package_cli"] = pc
+spec.loader.exec_module(pc)
+
+
+@contextlib.contextmanager
+def argv(args: list[str]):
+    old = sys.argv[:]
+    sys.argv = args[:]
+    try:
+        yield
+    finally:
+        sys.argv = old
+
+
+class FindWgpuLibTests(unittest.TestCase):
+    def test_find_wgpu_lib_selects_platform_suffix_from_build_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            build = pathlib.Path(td) / "build"
+            nested = build / "_deps" / "wgpu"
+            nested.mkdir(parents=True)
+            lib = nested / "libwgpu_native.so"
+            lib.write_text("so", encoding="utf-8")
+            (nested / "libwgpu_native.dylib").write_text("dylib", encoding="utf-8")
+
+            self.assertEqual(pc.find_wgpu_lib(build, "linux-x64"), lib)
+
+    def test_find_wgpu_lib_finds_windows_dll_name(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            build = pathlib.Path(td) / "build"
+            nested = build / "bin"
+            nested.mkdir(parents=True)
+            dll = nested / "wgpu_native.dll"
+            dll.write_text("dll", encoding="utf-8")
+
+            self.assertEqual(pc.find_wgpu_lib(build, "windows-x64"), dll)
+
+
+class RpathTests(unittest.TestCase):
+    def test_fix_rpath_macos_deletes_absolute_rpaths_and_adds_loader_path(self) -> None:
+        otool_output = """
+Load command 1
+          cmd LC_RPATH
+      cmdsize 48
+         path /Users/runner/Library/Caches/Pulp/wgpu (offset 12)
+Load command 2
+          cmd LC_RPATH
+      cmdsize 32
+         path @loader_path (offset 12)
+        """
+        binary = pathlib.Path("/tmp/pulp")
+
+        with mock.patch.object(pc.subprocess, "check_output", return_value=otool_output):
+            with mock.patch.object(pc.subprocess, "check_call") as check_call:
+                with mock.patch.object(pc.subprocess, "run") as run:
+                    pc.fix_rpath_macos(binary)
+
+        check_call.assert_called_once_with(
+            [
+                "install_name_tool",
+                "-delete_rpath",
+                "/Users/runner/Library/Caches/Pulp/wgpu",
+                str(binary),
+            ]
+        )
+        run.assert_called_once_with(
+            ["install_name_tool", "-add_rpath", "@loader_path", str(binary)],
+            check=False,
+        )
+
+    def test_fix_rpath_linux_skips_when_patchelf_is_missing(self) -> None:
+        out = io.StringIO()
+        with mock.patch.object(pc.shutil, "which", return_value=None):
+            with mock.patch.object(pc.subprocess, "check_call") as check_call:
+                with contextlib.redirect_stdout(out):
+                    pc.fix_rpath_linux(pathlib.Path("/tmp/pulp"))
+
+        check_call.assert_not_called()
+        self.assertIn("patchelf not on PATH", out.getvalue())
+
+    def test_fix_rpath_linux_sets_origin_when_patchelf_exists(self) -> None:
+        binary = pathlib.Path("/tmp/pulp")
+        with mock.patch.object(pc.shutil, "which", return_value="/usr/bin/patchelf"):
+            with mock.patch.object(pc.subprocess, "check_call") as check_call:
+                pc.fix_rpath_linux(binary)
+
+        check_call.assert_called_once_with(["patchelf", "--set-rpath", "$ORIGIN", str(binary)])
+
+
+class ArchiveTests(unittest.TestCase):
+    def test_write_tarball_and_zip_preserve_inner_names(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            a = root / "a.bin"
+            b = root / "b.bin"
+            a.write_text("a", encoding="utf-8")
+            b.write_text("b", encoding="utf-8")
+
+            tar_path = root / "out" / "pulp.tar.gz"
+            pc.write_tarball(tar_path, [a, b], ["pulp", "libwgpu_native.so"])
+            with tarfile.open(tar_path, "r:gz") as tar:
+                self.assertEqual(sorted(tar.getnames()), ["libwgpu_native.so", "pulp"])
+
+            zip_path = root / "out" / "pulp.zip"
+            pc.write_zip(zip_path, [a, b], ["pulp.exe", "wgpu_native.dll"])
+            with zipfile.ZipFile(zip_path) as z:
+                self.assertEqual(sorted(z.namelist()), ["pulp.exe", "wgpu_native.dll"])
+
+
+class MainTests(unittest.TestCase):
+    def test_main_returns_missing_binary_error(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            err = io.StringIO()
+            with argv(
+                [
+                    "package_cli.py",
+                    "--binary",
+                    str(root / "missing-pulp"),
+                    "--build-dir",
+                    str(root / "build"),
+                    "--platform",
+                    "linux-x64",
+                    "--out",
+                    str(root / "pulp.tar.gz"),
+                ]
+            ):
+                with contextlib.redirect_stderr(err):
+                    rc = pc.main()
+
+        self.assertEqual(rc, 2)
+        self.assertIn("FAIL: binary not at", err.getvalue())
+
+    def test_main_refuses_to_package_without_wgpu_library(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp"
+            binary.write_text("binary", encoding="utf-8")
+            err = io.StringIO()
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=None):
+                with argv(
+                    [
+                        "package_cli.py",
+                        "--binary",
+                        str(binary),
+                        "--build-dir",
+                        str(root / "build"),
+                        "--platform",
+                        "linux-x64",
+                        "--out",
+                        str(root / "pulp.tar.gz"),
+                    ]
+                ):
+                    with contextlib.redirect_stderr(err):
+                        rc = pc.main()
+
+        self.assertEqual(rc, 1)
+        self.assertIn("wgpu native library not found", err.getvalue())
+
+    def test_main_packages_linux_tarball_with_bundled_wgpu(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp-built"
+            binary.write_text("binary", encoding="utf-8")
+            wgpu = root / "libwgpu_native.so"
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-linux-x64.tar.gz"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_linux") as fix_rpath:
+                    with argv(
+                        [
+                            "package_cli.py",
+                            "--binary",
+                            str(binary),
+                            "--build-dir",
+                            str(root / "build"),
+                            "--platform",
+                            "linux-x64",
+                            "--out",
+                            str(out),
+                        ]
+                    ):
+                        rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            fix_rpath.assert_called_once()
+            with tarfile.open(out, "r:gz") as tar:
+                self.assertEqual(sorted(tar.getnames()), ["libwgpu_native.so", "pulp"])
+
+    def test_main_packages_windows_zip_without_rpath_rewrite(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            binary = root / "pulp.exe-built"
+            binary.write_text("binary", encoding="utf-8")
+            wgpu = root / "wgpu_native.dll"
+            wgpu.write_text("wgpu", encoding="utf-8")
+            out = root / "pulp-windows-x64.zip"
+
+            with mock.patch.object(pc, "find_wgpu_lib", return_value=wgpu):
+                with mock.patch.object(pc, "fix_rpath_linux") as linux_rpath:
+                    with mock.patch.object(pc, "fix_rpath_macos") as mac_rpath:
+                        with argv(
+                            [
+                                "package_cli.py",
+                                "--binary",
+                                str(binary),
+                                "--build-dir",
+                                str(root / "build"),
+                                "--platform",
+                                "windows-x64",
+                                "--out",
+                                str(out),
+                            ]
+                        ):
+                            rc = pc.main()
+
+            self.assertEqual(rc, 0)
+            linux_rpath.assert_not_called()
+            mac_rpath.assert_not_called()
+            with zipfile.ZipFile(out) as z:
+                self.assertEqual(sorted(z.namelist()), ["pulp.exe", "wgpu_native.dll"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- adds pure-Python unit coverage for `tools/scripts/package_cli.py` wgpu library discovery, macOS/Linux rpath command selection, archive writers, and main error paths
- covers successful Linux tarball and Windows zip staging without invoking real `otool`, `install_name_tool`, `patchelf`, or signing tools
- keeps the tranche test-only and scoped to #643 / #641

## Validation
- `python3 tools/scripts/test_package_cli.py`
- `git diff --check HEAD~1..HEAD`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD`

Note: the local Python coverage runner remains unavailable in this interpreter because `coverage.py >= 7.10` is not installed; hosted CI provides the Python coverage proof.

Refs #643
Refs #641