### PR TITLE
fix(render): harden GPU graph data setters

### DIFF
--- a/core/render/include/pulp/render/gpu_graph.hpp
+++ b/core/render/include/pulp/render/gpu_graph.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <vector>
 #include <cstddef>
+#include <limits>
+#include <vector>
 
 namespace pulp::render {
 
@@ -12,6 +13,10 @@ class GpuGraphRenderer {
 public:
     /// Update the data buffer. Thread-safe when used with TripleBuffer.
     void set_data(const float* data, size_t count) {
+        if (data == nullptr || count == 0) {
+            data_.clear();
+            return;
+        }
         data_.assign(data, data + count);
     }
 
@@ -48,6 +53,13 @@ class GpuHeatMapRenderer {
 public:
     /// Set the data grid (row-major, width x height).
     void set_data(const float* data, size_t width, size_t height) {
+        if (data == nullptr || width == 0 || height == 0 ||
+            height > std::numeric_limits<size_t>::max() / width) {
+            width_ = 0;
+            height_ = 0;
+            data_.clear();
+            return;
+        }
         width_ = width;
         height_ = height;
         data_.assign(data, data + width * height);
@@ -78,6 +90,10 @@ private:
 class GpuBarRenderer {
 public:
     void set_data(const float* data, size_t count) {
+        if (data == nullptr || count == 0) {
+            data_.clear();
+            return;
+        }
         data_.assign(data, data + count);
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1157,17 +1157,26 @@ add_executable(pulp-test-view test_view.cpp)
 target_link_libraries(pulp-test-view PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-view)
 
+# DirtyTracker and GpuGraphRenderer are header-only helpers; keep their pure
+# tests available in GPU-off sanitizer and local coverage builds.
+add_executable(pulp-test-dirty-tracker test_dirty_tracker.cpp)
+target_include_directories(pulp-test-dirty-tracker PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include)
+target_link_libraries(pulp-test-dirty-tracker PRIVATE Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-dirty-tracker)
+
+add_executable(pulp-test-gpu-graph test_gpu_graph.cpp)
+target_include_directories(pulp-test-gpu-graph PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include)
+target_link_libraries(pulp-test-gpu-graph PRIVATE Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-gpu-graph)
+
 # GPU-stack tests — pulp::render only exists when PULP_ENABLE_GPU=ON.
 # The sanitizer matrix builds with GPU off; without the guard configure
 # fails with "Target ... links to: pulp::render but the target was not
 # found". The earlier GPU-test block (test_gpu_surface, test_skia_surface,
 # test_gpu_compute) already gates on the same condition.
 if(PULP_ENABLE_GPU)
-    # Dirty region tracker tests
-    add_executable(pulp-test-dirty-tracker test_dirty_tracker.cpp)
-    target_link_libraries(pulp-test-dirty-tracker PRIVATE pulp::render Catch2::Catch2WithMain)
-    catch_discover_tests(pulp-test-dirty-tracker)
-
     # Rendering integration tests (effects, dimensions, text direction, render passes)
     add_executable(pulp-test-rendering-integration test_rendering_integration.cpp)
     target_link_libraries(pulp-test-rendering-integration PRIVATE pulp::view pulp::render pulp::state Catch2::Catch2WithMain)
@@ -1177,11 +1186,6 @@ if(PULP_ENABLE_GPU)
     add_executable(pulp-test-draw-batcher test_draw_batcher.cpp)
     target_link_libraries(pulp-test-draw-batcher PRIVATE pulp::render Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-draw-batcher)
-
-    # GPU graph renderer tests
-    add_executable(pulp-test-gpu-graph test_gpu_graph.cpp)
-    target_link_libraries(pulp-test-gpu-graph PRIVATE pulp::render Catch2::Catch2WithMain)
-    catch_discover_tests(pulp-test-gpu-graph)
 
 endif()
 

--- a/test/test_gpu_graph.cpp
+++ b/test/test_gpu_graph.cpp
@@ -2,6 +2,8 @@
 #include <catch2/catch_approx.hpp>
 #include <pulp/render/gpu_graph.hpp>
 
+#include <limits>
+
 using namespace pulp::render;
 
 TEST_CASE("GpuGraphRenderer basic usage", "[render][gpu-graph]") {
@@ -65,6 +67,18 @@ TEST_CASE("GpuGraphRenderer raw-pointer set_data overload - issue-646",
     REQUIRE(g.count() == 0);
 }
 
+TEST_CASE("GpuGraphRenderer null data clears without pointer arithmetic - issue-646",
+          "[render][gpu-graph][issue-646]") {
+    GpuGraphRenderer g;
+    float data[] = {0.25f, 0.5f};
+    g.set_data(data, 2);
+    REQUIRE_FALSE(g.empty());
+
+    g.set_data(nullptr, 8);
+    REQUIRE(g.empty());
+    REQUIRE(g.count() == 0);
+}
+
 TEST_CASE("GpuGraphRenderer defaults match documented values - issue-646",
           "[render][gpu-graph][issue-646]") {
     GpuGraphRenderer g;
@@ -92,6 +106,26 @@ TEST_CASE("GpuHeatMapRenderer range set/get - issue-646",
     REQUIRE(h.height() == 0);
 }
 
+TEST_CASE("GpuHeatMapRenderer rejects null and overflowing grids - issue-646",
+          "[render][gpu-graph][issue-646]") {
+    GpuHeatMapRenderer h;
+    float data[] = {0.1f, 0.2f, 0.3f, 0.4f};
+    h.set_data(data, 2, 2);
+    REQUIRE_FALSE(h.empty());
+    REQUIRE(h.width() == 2);
+    REQUIRE(h.height() == 2);
+
+    h.set_data(nullptr, 2, 2);
+    REQUIRE(h.empty());
+    REQUIRE(h.width() == 0);
+    REQUIRE(h.height() == 0);
+
+    h.set_data(data, std::numeric_limits<size_t>::max(), 2);
+    REQUIRE(h.empty());
+    REQUIRE(h.width() == 0);
+    REQUIRE(h.height() == 0);
+}
+
 TEST_CASE("GpuBarRenderer gap + data accessors - issue-646",
           "[render][gpu-graph][issue-646]") {
     GpuBarRenderer b;
@@ -106,4 +140,22 @@ TEST_CASE("GpuBarRenderer gap + data accessors - issue-646",
     b.set_data(data, 2);
     REQUIRE(b.data().size() == 2);
     REQUIRE(b.data()[1] == Catch::Approx(0.9f));
+}
+
+TEST_CASE("GpuBarRenderer null and zero data clear existing bars - issue-646",
+          "[render][gpu-graph][issue-646]") {
+    GpuBarRenderer b;
+    float data[] = {0.2f, 0.4f, 0.8f};
+    b.set_data(data, 3);
+    REQUIRE(b.count() == 3);
+
+    b.set_data(nullptr, 3);
+    REQUIRE(b.count() == 0);
+    REQUIRE(b.data().empty());
+
+    b.set_data(data, 3);
+    REQUIRE(b.count() == 3);
+    b.set_data(data, 0);
+    REQUIRE(b.count() == 0);
+    REQUIRE(b.data().empty());
 }


### PR DESCRIPTION
## Summary

Phase 3 render tranche for #646 / #641.

- Harden `GpuGraphRenderer`, `GpuHeatMapRenderer`, and `GpuBarRenderer` raw-pointer `set_data()` paths for null, zero-sized, and overflowing inputs.
- Add focused `test_gpu_graph.cpp` coverage for those edge paths.
- Move the header-only dirty-tracker and GPU-graph tests out of the GPU-only CMake block so GPU-off sanitizer/local coverage builds still exercise them without linking `pulp::render`.

## Local validation

- `cmake -S . -B build -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target pulp-test-gpu-graph pulp-test-dirty-tracker -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-gpu-graph "[issue-646]"` (39 assertions / 7 cases)
- `./build/test/pulp-test-gpu-graph` (52 assertions / 11 cases)
- `./build/test/pulp-test-dirty-tracker` (52 assertions / 18 cases)
- `ctest --test-dir build -R "Gpu(Graph|HeatMap|Bar)|DirtyTracker|Rect" --output-on-failure` (29/29)
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main` (SDK patch suggested/documented by trailer)
- pre-push gates clean

Uses the GitHub/Namespace path for the Codecov queue.

Closes no issue; rolls up to #646 and #641.