### PR TITLE
test(events): cover child process manager edges

### DIFF
--- a/core/events/src/child_process_manager.cpp
+++ b/core/events/src/child_process_manager.cpp
@@ -115,9 +115,9 @@ int ConnectedChildProcess::wait_for_exit(int timeout_ms) {
     }
 
 #ifndef _WIN32
-    int status = 0;
-    auto waited = waitpid(static_cast<pid_t>(pid_), &status, WNOHANG);
-    return waited == static_cast<pid_t>(pid_) && WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    int status;
+    waitpid(static_cast<pid_t>(pid_), &status, WNOHANG);
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
 #else
     return 0;
 #endif

--- a/core/events/src/child_process_manager.cpp
+++ b/core/events/src/child_process_manager.cpp
@@ -1,4 +1,5 @@
 #include <pulp/events/child_process_manager.hpp>
+#include <algorithm>
 #include <random>
 #include <sstream>
 #include <chrono>
@@ -101,6 +102,8 @@ void ConnectedChildProcess::kill() {
 }
 
 int ConnectedChildProcess::wait_for_exit(int timeout_ms) {
+    if (pid_ < 0) return -1;
+
     auto start = std::chrono::steady_clock::now();
     while (running_.load()) {
         if (timeout_ms > 0) {
@@ -112,9 +115,9 @@ int ConnectedChildProcess::wait_for_exit(int timeout_ms) {
     }
 
 #ifndef _WIN32
-    int status;
-    waitpid(static_cast<pid_t>(pid_), &status, WNOHANG);
-    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    int status = 0;
+    auto waited = waitpid(static_cast<pid_t>(pid_), &status, WNOHANG);
+    return waited == static_cast<pid_t>(pid_) && WIFEXITED(status) ? WEXITSTATUS(status) : -1;
 #else
     return 0;
 #endif

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <pulp/events/child_process_manager.hpp>
 #include <pulp/events/interprocess_connection.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <atomic>
@@ -86,6 +87,35 @@ TEST_CASE("IPC lambda callbacks settable", "[events][ipc]") {
 TEST_CASE("IPC server initial state", "[events][ipc]") {
     InterprocessConnectionServer server;
     REQUIRE_FALSE(server.is_running());
+}
+
+// ── Child process manager ───────────────────────────────────────────────
+
+TEST_CASE("ConnectedChildProcess default state is safe to tear down",
+          "[events][child-process][issue-642]") {
+    ConnectedChildProcess child;
+
+    REQUIRE_FALSE(child.is_running());
+    REQUIRE(child.pid() == -1);
+    REQUIRE_FALSE(child.send_message("not launched"));
+
+    child.kill();
+    REQUIRE(child.wait_for_exit(1) == -1);
+}
+
+TEST_CASE("ChildProcessManager empty lifecycle operations are no-ops",
+          "[events][child-process][issue-642]") {
+    ChildProcessManager manager;
+    int exit_callbacks = 0;
+    manager.on_child_exit = [&](ConnectedChildProcess*, int) { ++exit_callbacks; };
+
+    REQUIRE(manager.active_count() == 0);
+    manager.wait_all(1);
+    manager.kill_all();
+    manager.cleanup();
+
+    REQUIRE(manager.active_count() == 0);
+    REQUIRE(exit_callbacks == 0);
 }
 
 TEST_CASE("IPC socket server rejects malformed listen endpoints",


### PR DESCRIPTION
## Summary
- add deterministic child-process manager edge coverage under #642
- cover unlaunched ConnectedChildProcess default behavior and empty ChildProcessManager lifecycle no-ops
- harden ConnectedChildProcess::wait_for_exit() so unlaunched/invalid PID state returns -1 instead of probing an invalid process id

Parent: #641
Tracker: #642

## Validation
- `cmake -S . -B build -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target pulp-test-ipc -j10`
- `./build/test/pulp-test-ipc "[issue-642]"` passed 7 assertions / 2 cases
- `./build/test/pulp-test-ipc` passed 44 assertions / 12 cases
- `ctest --test-dir build -R "ConnectedChildProcess|ChildProcessManager|IPC" --output-on-failure` passed 12/12
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main`