### PR TITLE
fix(coverage): classify inspect Codecov surface

### DIFF
--- a/ci/coverage-targets.yaml
+++ b/ci/coverage-targets.yaml
@@ -41,6 +41,7 @@ tiers:
     paths:
       - core/view/**
       - core/render/**
+      - inspect/**
       - tools/cli/**
 
   - name: infrastructure

--- a/codecov.yml
+++ b/codecov.yml
@@ -170,10 +170,14 @@ flags:
       - core/**/wasapi/
     carryforward: true
 
-  # Surface flags (3) — non-core but first-party:
+  # Surface flags (4) — non-core but first-party:
   cli:
     paths:
       - tools/cli/
+    carryforward: true
+  inspect:
+    paths:
+      - inspect/
     carryforward: true
   ship:
     paths:
@@ -300,10 +304,13 @@ component_management:
         - "core/**/win/**"
         - "core/**/windows/**"
         - "core/**/wasapi/**"
-    # Surface (3)
+    # Surface (4)
     - component_id: cli
       name: cli
       paths: ["tools/cli/**"]
+    - component_id: inspect
+      name: inspect
+      paths: ["inspect/**"]
     - component_id: ship
       name: ship
       paths: ["ship/**"]

--- a/docs/guides/coverage.md
+++ b/docs/guides/coverage.md
@@ -64,7 +64,9 @@ at the repo root; the dashboard is the source of truth for the current
 set of names. Subsystem / platform / surface slicing happens via the
 `component_management` block (path-globbed from a single upload).
 Per-OS slicing happens via upload flags — one upload per operating
-system in the matrix.
+system in the matrix. First-party non-core surfaces are represented as
+their own components too; for example, `inspect/**` appears under the
+`inspect` surface rather than falling through as uncategorized code.
 
 ## How to run coverage locally
 

--- a/tools/scripts/test_codecov_config.py
+++ b/tools/scripts/test_codecov_config.py
@@ -37,7 +37,7 @@ EXPECTED_NON_CORE_COMPONENT_IDS = {
     # platforms
     "android", "apple", "linux", "windows",
     # surfaces
-    "cli", "ship", "tools",
+    "cli", "inspect", "ship", "tools",
 }
 
 # Upload-axis flags are intentionally not components: they describe
@@ -178,6 +178,19 @@ class CodecovYamlStructure(unittest.TestCase):
             any("/android/" in path for path in android_paths),
             "android platform axis must cover Android source paths",
         )
+
+    def test_inspect_surface_is_first_class(self):
+        # inspect/ is a first-party C++ surface and is included in the
+        # native coverage object list, so it must not fall through as an
+        # uncategorized Codecov path.
+        flags = self.doc["flags"]
+        components = {
+            entry["component_id"]: set(entry.get("paths", []))
+            for entry in self.doc["component_management"]["individual_components"]
+        }
+
+        self.assertEqual(set(flags["inspect"]["paths"]), {"inspect/"})
+        self.assertEqual(components["inspect"], {"inspect/**"})
 
 
 if __name__ == "__main__":

--- a/tools/scripts/test_coverage_tier_check.py
+++ b/tools/scripts/test_coverage_tier_check.py
@@ -7,9 +7,13 @@ of classify_file / aggregate / render so a regression fails fast.
 
 from __future__ import annotations
 
+import pathlib
 import unittest
 
 import coverage_tier_check as ctc
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+TARGETS = REPO_ROOT / "ci" / "coverage-targets.yaml"
 
 
 TIERS = [
@@ -48,6 +52,12 @@ class ClassifyTests(unittest.TestCase):
         # the global 75% gate applies instead of a per-tier rule.
         self.assertIsNone(ctc.classify_file("docs/guides/coverage.md", TIERS))
         self.assertIsNone(ctc.classify_file("README.md", TIERS))
+
+    def test_live_targets_classify_inspect_as_user_facing(self) -> None:
+        tiers = ctc.load_targets(TARGETS)
+        tier = ctc.classify_file("inspect/src/inspector_server.cpp", tiers)
+        self.assertIsNotNone(tier)
+        self.assertEqual(tier.name, "user-facing")
 
 
 class AggregateTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- promote inspect/** to a first-class Codecov flag/component
- classify inspect/** in the existing user-facing coverage tier
- add structural tests and coverage docs so the represented surface is no longer ambiguous

Parent: #641
Closes: #841

## Validation
- python3 tools/scripts/test_codecov_config.py
- python3 tools/scripts/test_coverage_tier_check.py
- python3 tools/scripts/docs_sync_check.py --base origin/main --config tools/scripts/docs_sync_map.json --mode=report
- git diff --check origin/main...HEAD
- python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --mode=report