### PR TITLE
docs(ci): route shipyard pin bumps through shipyard pin bump

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -333,7 +333,9 @@ export PATH="$HOME/.pulp/bin:$PATH"   # add ~/.pulp/bin to PATH (one-time)
 After install, every Pulp checkout that has `~/.pulp/bin` on PATH gets
 the same pinned Shipyard version automatically. The pin lives in
 `tools/shipyard.toml` and is bumped via PR after each Shipyard release
-that passes Pulp's CI matrix.
+that passes Pulp's CI matrix. Use `shipyard pin bump --to vX.Y.Z`
+instead of hand-editing `tools/shipyard.toml`; the helper owns the pin
+edit and worktree-safety checks.
 
 The two tools cover the same target matrix (mac local + Linux SSH +
 Windows SSH + Namespace cloud) and accept the same `--base` flag for

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -11,11 +11,11 @@
 #   ./tools/install-shipyard.sh --status
 #
 # To bump the pin (after verifying a new Shipyard release works on
-# Pulp's CI matrix):
-#   1. Edit `version` below.
-#   2. Run `./tools/install-shipyard.sh` to download the new binary.
-#   3. Run `shipyard run` on a feature branch to verify.
-#   4. Open a PR with this file change and your verification notes.
+# Pulp's CI matrix), use:
+#   shipyard pin bump --to vX.Y.Z
+#
+# That flow owns the pin edit and worktree-safety checks; keep the
+# lockstep doc skim below as part of the bump PR.
 #
 # Lockstep docs:
 # When bumping the pin, also re-check that the following docs still


### PR DESCRIPTION
Closes danielraffel/Shipyard#244

## Summary
- replace the stale manual 4-step shipyard pin-bump recipe in `tools/shipyard.toml`
- point maintainers at `shipyard pin bump --to vX.Y.Z` instead
- sync the CI skill note so the skill-sync gate reflects the same workflow

## Test plan
- `python3 tools/scripts/skill_sync_check.py --base origin/main`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `git diff --check`
