### PR TITLE
test(runtime): cover base64 padding validation

### DIFF
--- a/core/runtime/src/base64.cpp
+++ b/core/runtime/src/base64.cpp
@@ -55,15 +55,35 @@ std::string base64_encode(std::string_view input) {
 }
 
 std::optional<std::vector<uint8_t>> base64_decode(std::string_view input) {
-    // Strip whitespace and padding
+    // Strip whitespace while validating that padding, if present, is terminal.
     std::string clean;
     clean.reserve(input.size());
+    bool saw_padding = false;
+    size_t padding_count = 0;
     for (char c : input) {
-        if (c == '=') break;
-        if (c == ' ' || c == '\n' || c == '\r' || c == '\t') continue;
+        if (c == ' ' || c == '\n' || c == '\r' || c == '\t')
+            continue;
+        if (c == '=') {
+            saw_padding = true;
+            ++padding_count;
+            if (padding_count > 2)
+                return std::nullopt;
+            clean += c;
+            continue;
+        }
+        if (saw_padding)
+            return std::nullopt;
         if (static_cast<unsigned char>(c) >= 128 || kDecodeTable[static_cast<unsigned char>(c)] == 255)
             return std::nullopt;
         clean += c;
+    }
+
+    if (clean.size() % 4 == 1)
+        return std::nullopt;
+    if (padding_count > 0) {
+        if (clean.size() % 4 != 0 || padding_count > clean.size())
+            return std::nullopt;
+        clean.resize(clean.size() - padding_count);
     }
 
     std::vector<uint8_t> result;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -190,6 +190,19 @@ TEST_CASE("base64 decode invalid", "[runtime][base64]") {
     REQUIRE_FALSE(result.has_value());
 }
 
+TEST_CASE("base64 decode rejects malformed padding", "[runtime][base64][issue-641]") {
+    REQUIRE_FALSE(base64_decode("A").has_value());
+    REQUIRE_FALSE(base64_decode("YQ=").has_value());
+    REQUIRE_FALSE(base64_decode("YQ==Z").has_value());
+    REQUIRE_FALSE(base64_decode("YQ===").has_value());
+}
+
+TEST_CASE("base64 decode permits whitespace around terminal padding", "[runtime][base64][issue-641]") {
+    auto decoded = base64_decode(" YQ = = \n");
+    REQUIRE(decoded.has_value());
+    REQUIRE(std::string(decoded->begin(), decoded->end()) == "a");
+}
+
 TEST_CASE("base64 binary round-trip", "[runtime][base64]") {
     std::vector<uint8_t> data = {0x00, 0xFF, 0x80, 0x7F, 0x01, 0xFE};
     auto encoded = base64_encode(data.data(), data.size());


### PR DESCRIPTION
## Summary
- validate terminal Base64 padding while preserving whitespace tolerance
- reject malformed padded input instead of truncating at the first padding byte
- add focused runtime coverage for malformed and whitespace-padded Base64 inputs

Parent: #641
Tracker: #641

## Validation
- cmake -S . -B build-runtime-coverage-641-next -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF with local FETCHCONTENT_SOURCE_DIR_MBEDTLS override
- cmake --build build-runtime-coverage-641-next --target pulp-test-runtime-utils -j$(sysctl -n hw.ncpu)
- ./build-runtime-coverage-641-next/test/pulp-test-runtime-utils "[issue-641]"
- ./build-runtime-coverage-641-next/test/pulp-test-runtime-utils
- focused CTest for Base64 padding tests
- git diff --check
- python3 tools/scripts/skill_sync_check.py --mode=report
- python3 tools/scripts/version_bump_check.py --mode=report

Version-Bump: sdk=patch reason="base64 decoder padding validation"
