### PR TITLE
test(tools): cover runner resolver edge paths

### DIFF
--- a/tools/scripts/test_resolve_runs_on.py
+++ b/tools/scripts/test_resolve_runs_on.py
@@ -151,6 +151,22 @@ def test_optional_namespace_with_explicit_routes_to_namespace() -> None:
             f"unexpected macOS namespace selector: {out!r}")
 
 
+def test_optional_namespace_falls_back_to_namespace_env() -> None:
+    _, out, _ = _run([
+        "--target-name", "macOS (ARM64)",
+        "--mode", "optional-namespace",
+        "--explicit-env", "EXPLICIT_MACOS_RUNNER_SELECTOR_JSON",
+        "--namespace-env", "NAMESPACE_MACOS_RUNS_ON_JSON",
+    ], env_extra={
+        "REQUESTED_PROVIDER": "namespace",
+        "EXPLICIT_MACOS_RUNNER_SELECTOR_JSON": "   ",
+        "NAMESPACE_MACOS_RUNS_ON_JSON":
+            '"namespace-profile-generouscorp-macos"',
+    })
+    _assert(json.loads(out) == "namespace-profile-generouscorp-macos",
+            f"namespace fallback selector ignored: {out!r}")
+
+
 # ── new: local provider ─────────────────────────────────────────────────
 
 
@@ -246,6 +262,40 @@ def test_default_mode_ubuntu_default() -> None:
     ])
     _assert(json.loads(out) == "ubuntu-24.04",
             f"expected default 'ubuntu-24.04', got {out!r}")
+
+
+# ── argument validation ───────────────────────────────────────────────────
+
+
+def test_provider_mode_requires_github_hosted_label() -> None:
+    code, _, err = _run([
+        "--target-name", "Linux (x64)",
+        "--mode", "provider",
+    ], expect_error=True)
+    _assert(code == 1, "expected error exit")
+    _assert("--github-hosted-label is required" in err,
+            f"stderr missing required-label error: {err!r}")
+
+
+def test_default_mode_requires_default_label() -> None:
+    code, _, err = _run([
+        "--target-name", "TSan (macOS ARM64)",
+        "--mode", "default",
+    ], expect_error=True)
+    _assert(code == 1, "expected error exit")
+    _assert("--default-label is required" in err,
+            f"stderr missing required-default error: {err!r}")
+
+
+def test_provider_mode_rejects_unsupported_provider() -> None:
+    code, _, err = _run([
+        "--target-name", "Linux (x64)",
+        "--mode", "provider",
+        "--github-hosted-label", "ubuntu-latest",
+    ], env_extra={"REQUESTED_PROVIDER": "bogus"}, expect_error=True)
+    _assert(code == 1, "expected error exit")
+    _assert("Unsupported runner_provider" in err,
+            f"stderr missing unsupported-provider error: {err!r}")
 
 
 # ── JSON validation ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- cover optional Namespace runner fallback from environment selectors
- cover missing provider/default label argument validation
- cover unsupported runner provider diagnostics

Parent: #641
Tracker: #643

## Validation
- python3 tools/scripts/test_resolve_runs_on.py passed 18 tests
- python3 -m compileall -q tools/scripts/resolve_runs_on.py tools/scripts/test_resolve_runs_on.py
- git diff --check

Note: local Python coverage was not run because coverage.py is not installed in this interpreter.
