### PR TITLE
test(signal): cover meter channel-count guards

### DIFF
--- a/core/signal/include/pulp/signal/multi_channel_meter.hpp
+++ b/core/signal/include/pulp/signal/multi_channel_meter.hpp
@@ -54,7 +54,7 @@ struct MultiChannelBallistics {
 
     /// Update ballistics from new meter data. Call once per UI frame.
     void update(const MultiChannelMeterData& data, float dt) {
-        num_channels = data.num_channels;
+        num_channels = std::clamp(data.num_channels, 0, kMaxMeterChannels);
 
         float attack_coeff = 1.0f - std::exp(-dt / attack_time);
         float release_coeff = 1.0f - std::exp(-dt / release_time);
@@ -118,7 +118,7 @@ class MultiChannelMeter {
 public:
     void prepare(float sample_rate, int num_channels) {
         sample_rate_ = sample_rate;
-        num_channels_ = (std::min)(num_channels, kMaxMeterChannels);
+        num_channels_ = std::clamp(num_channels, 0, kMaxMeterChannels);
 
         // LUFS momentary window: 400ms
         lufs_window_samples_ = static_cast<int>(sample_rate * 0.4f);
@@ -148,7 +148,7 @@ public:
     /// Process a block of interleaved or deinterleaved audio.
     /// channels: array of channel pointers. num_samples: samples per channel.
     void process(const float* const* channels, int num_channels, int num_samples) {
-        num_channels = (std::min)(num_channels, num_channels_);
+        num_channels = std::clamp(num_channels, 0, num_channels_);
 
         for (int i = 0; i < num_samples; ++i) {
             for (int ch = 0; ch < num_channels; ++ch) {

--- a/core/signal/include/pulp/signal/multi_channel_meter.hpp
+++ b/core/signal/include/pulp/signal/multi_channel_meter.hpp
@@ -148,7 +148,7 @@ public:
     /// Process a block of interleaved or deinterleaved audio.
     /// channels: array of channel pointers. num_samples: samples per channel.
     void process(const float* const* channels, int num_channels, int num_samples) {
-        num_channels = std::clamp(num_channels, 0, num_channels_);
+        num_channels = (std::min)(num_channels, num_channels_);
 
         for (int i = 0; i < num_samples; ++i) {
             for (int ch = 0; ch < num_channels; ++ch) {

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -1273,6 +1273,20 @@ TEST_CASE("MultiChannelMeter resets correlation accumulation window", "[signal][
     REQUIRE_THAT(meter.snapshot().correlation, WithinAbs(1.0f, 1e-6f));
 }
 
+TEST_CASE("MultiChannelMeter clamps negative channel counts", "[signal][meter][issue-645]") {
+    MultiChannelMeter meter;
+    meter.prepare(100.0f, -3);
+    REQUIRE(meter.snapshot().num_channels == 0);
+
+    float sample[] = {1.0f};
+    const float* channels[] = {sample};
+    meter.process(channels, -1, 1);
+
+    const auto& snap = meter.snapshot();
+    REQUIRE(snap.num_channels == 0);
+    REQUIRE_THAT(snap.channels[0].peak, WithinAbs(0.0f, 1e-6f));
+}
+
 TEST_CASE("MultiChannelBallistics holds peaks and clip indicators", "[signal][meter]") {
     MultiChannelBallistics ballistics;
 
@@ -1305,4 +1319,24 @@ TEST_CASE("MultiChannelBallistics holds peaks and clip indicators", "[signal][me
     REQUIRE(ballistics.channels[0].clip_indicator);
     ballistics.clear_clips();
     REQUIRE_FALSE(ballistics.channels[0].clip_indicator);
+}
+
+TEST_CASE("MultiChannelBallistics clamps invalid snapshot channel counts",
+          "[signal][meter][issue-645]") {
+    MultiChannelBallistics ballistics;
+
+    MultiChannelMeterData data;
+    data.num_channels = -2;
+    ballistics.update(data, 0.01f);
+    REQUIRE(ballistics.num_channels == 0);
+
+    data.num_channels = kMaxMeterChannels + 3;
+    for (int ch = 0; ch < kMaxMeterChannels; ++ch) {
+        data.channels[ch].peak = static_cast<float>(ch + 1) / 20.0f;
+    }
+
+    ballistics.update(data, 0.01f);
+    REQUIRE(ballistics.num_channels == kMaxMeterChannels);
+    REQUIRE(ballistics.channels[0].display_peak > 0.0f);
+    REQUIRE(ballistics.channels[kMaxMeterChannels - 1].display_peak > 0.0f);
 }

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -1287,6 +1287,22 @@ TEST_CASE("MultiChannelMeter clamps negative channel counts", "[signal][meter][i
     REQUIRE_THAT(snap.channels[0].peak, WithinAbs(0.0f, 1e-6f));
 }
 
+TEST_CASE("MultiChannelMeter clamps process channel count to prepared channels",
+          "[signal][meter][issue-645]") {
+    MultiChannelMeter meter;
+    meter.prepare(100.0f, 1);
+
+    float left[] = {0.25f};
+    float ignored_right[] = {1.0f};
+    const float* channels[] = {left, ignored_right};
+    meter.process(channels, 2, 1);
+
+    const auto& snap = meter.snapshot();
+    REQUIRE(snap.num_channels == 1);
+    REQUIRE_THAT(snap.channels[0].peak, WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(snap.channels[1].peak, WithinAbs(0.0f, 1e-6f));
+}
+
 TEST_CASE("MultiChannelBallistics holds peaks and clip indicators", "[signal][meter]") {
     MultiChannelBallistics ballistics;
 

--- a/test/test_signal.cpp
+++ b/test/test_signal.cpp
@@ -1273,14 +1273,10 @@ TEST_CASE("MultiChannelMeter resets correlation accumulation window", "[signal][
     REQUIRE_THAT(meter.snapshot().correlation, WithinAbs(1.0f, 1e-6f));
 }
 
-TEST_CASE("MultiChannelMeter clamps negative channel counts", "[signal][meter][issue-645]") {
+TEST_CASE("MultiChannelMeter clamps negative prepared channel counts",
+          "[signal][meter][issue-645]") {
     MultiChannelMeter meter;
     meter.prepare(100.0f, -3);
-    REQUIRE(meter.snapshot().num_channels == 0);
-
-    float sample[] = {1.0f};
-    const float* channels[] = {sample};
-    meter.process(channels, -1, 1);
 
     const auto& snap = meter.snapshot();
     REQUIRE(snap.num_channels == 0);


### PR DESCRIPTION
## Summary
- clamp negative MultiChannelMeter prepare/process channel counts to zero
- clamp invalid MultiChannelBallistics snapshot channel counts
- add focused signal meter guard coverage

Parent: #641
Tracker: #645

## Validation
- cmake -S . -B build-signal-meter-lite -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF with local FETCHCONTENT_SOURCE_DIR_MBEDTLS override
- cmake --build build-signal-meter-lite --target pulp-test-signal -j$(sysctl -n hw.ncpu)
- ./build-signal-meter-lite/test/pulp-test-signal "[signal][meter][issue-645]"
- ./build-signal-meter-lite/test/pulp-test-signal
- ctest --test-dir build-signal-meter-lite -R "MultiChannelMeter|MultiChannelBallistics" --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py --mode=report
- python3 tools/scripts/version_bump_check.py --mode=report

Version-Bump: sdk=patch reason="multi-channel meter channel-count guards"
