### PR TITLE
test(canvas): cover rectangle list helper edges

### DIFF
--- a/test/test_rectangle_list.cpp
+++ b/test/test_rectangle_list.cpp
@@ -12,6 +12,17 @@ TEST_CASE("RectangleList add and size", "[canvas][rect]") {
     REQUIRE(rl.size() == 1);
 }
 
+TEST_CASE("RectangleList ignores empty rectangles", "[canvas][rect][issue-641]") {
+    RectangleList rl;
+    rl.add({0, 0, 0, 10});
+    rl.add({0, 0, 10, 0});
+    rl.add({0, 0, -1, 10});
+    REQUIRE(rl.empty());
+    REQUIRE(rl.size() == 0);
+    REQUIRE(rl.bounding_box().empty());
+    REQUIRE(rl.total_area() == Catch::Approx(0.0f));
+}
+
 TEST_CASE("RectangleList multiple rects", "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});
@@ -26,6 +37,17 @@ TEST_CASE("RectangleList contains point", "[canvas][rect]") {
     REQUIRE(rl.contains(5, 5));
     REQUIRE(rl.contains(25, 25));
     REQUIRE_FALSE(rl.contains(15, 15));  // gap between rects
+}
+
+TEST_CASE("RectangleList intersects uses rectangle area overlap", "[canvas][rect][issue-641]") {
+    RectangleList rl;
+    rl.add({0, 0, 10, 10});
+    rl.add({20, 20, 10, 10});
+
+    REQUIRE(rl.intersects({5, 5, 1, 1}));
+    REQUIRE(rl.intersects({25, 25, 2, 2}));
+    REQUIRE_FALSE(rl.intersects({10, 0, 5, 5})); // edge-touching only
+    REQUIRE_FALSE(rl.intersects({11, 11, 5, 5})); // gap between rects
 }
 
 TEST_CASE("RectangleList subtract", "[canvas][rect]") {
@@ -44,6 +66,40 @@ TEST_CASE("RectangleList clear", "[canvas][rect]") {
     REQUIRE_FALSE(rl.empty());
     rl.clear();
     REQUIRE(rl.empty());
+}
+
+TEST_CASE("RectangleList bounding box and area", "[canvas][rect][issue-641]") {
+    RectangleList rl;
+    rl.add({10, 20, 5, 6});
+    rl.add({-5, 25, 3, 4});
+    rl.add({20, -10, 10, 8});
+
+    auto bounds = rl.bounding_box();
+    REQUIRE(bounds.x == Catch::Approx(-5.0f));
+    REQUIRE(bounds.y == Catch::Approx(-10.0f));
+    REQUIRE(bounds.width == Catch::Approx(35.0f));
+    REQUIRE(bounds.height == Catch::Approx(39.0f));
+    REQUIRE(rl.total_area() == Catch::Approx(122.0f));
+}
+
+TEST_CASE("RectangleList clipped keeps only intersections", "[canvas][rect][issue-641]") {
+    RectangleList rl;
+    rl.add({0, 0, 10, 10});
+    rl.add({8, 8, 6, 6});
+    rl.add({30, 30, 5, 5});
+
+    auto clipped = rl.clipped({5, 5, 10, 10});
+    REQUIRE(clipped.size() == 2);
+
+    REQUIRE(clipped[0].x == Catch::Approx(5.0f));
+    REQUIRE(clipped[0].y == Catch::Approx(5.0f));
+    REQUIRE(clipped[0].width == Catch::Approx(5.0f));
+    REQUIRE(clipped[0].height == Catch::Approx(5.0f));
+
+    REQUIRE(clipped[1].x == Catch::Approx(8.0f));
+    REQUIRE(clipped[1].y == Catch::Approx(8.0f));
+    REQUIRE(clipped[1].width == Catch::Approx(6.0f));
+    REQUIRE(clipped[1].height == Catch::Approx(6.0f));
 }
 
 TEST_CASE("Rect intersection", "[canvas][rect]") {

--- a/test/test_rectangle_list.cpp
+++ b/test/test_rectangle_list.cpp
@@ -60,6 +60,19 @@ TEST_CASE("RectangleList subtract", "[canvas][rect]") {
     REQUIRE(rl.contains(2, 2));  // corner still exists
 }
 
+TEST_CASE("RectangleList subtract handles no-op and full-cover cases",
+          "[canvas][rect][issue-641]") {
+    RectangleList rl;
+    rl.add({0, 0, 10, 10});
+
+    rl.subtract({20, 20, 5, 5});
+    REQUIRE(rl.size() == 1);
+    REQUIRE(rl[0] == Rect{0, 0, 10, 10});
+
+    rl.subtract({-1, -1, 12, 12});
+    REQUIRE(rl.empty());
+}
+
 TEST_CASE("RectangleList clear", "[canvas][rect]") {
     RectangleList rl;
     rl.add({0, 0, 10, 10});


### PR DESCRIPTION
## Summary
- cover RectangleList empty-rectangle filtering and area-overlap intersection
- cover subtract no-op and full-cover cases
- cover bounding-box, total-area, and clipped-intersection helpers

Parent: #641
Tracker: #641

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF with local FETCHCONTENT_SOURCE_DIR_MBEDTLS override
- cmake --build build --target pulp-test-rectangle-list -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-rectangle-list "[issue-641]" passed 25 assertions / 5 cases
- ./build/test/pulp-test-rectangle-list passed 52 assertions / 14 cases
- ctest --test-dir build -R "RectangleList|Rect" --output-on-failure passed 14/14
- git diff --check
