### PR TITLE
test(audio): cover frame-fill invalid dimensions

### DIFF
--- a/test/test_frame_fill.cpp
+++ b/test/test_frame_fill.cpp
@@ -82,9 +82,23 @@ TEST_CASE("zero_fill_short_read: zero channels is a no-op",
     for (float v : buf) REQUIRE(v == 0.5f);
 }
 
+TEST_CASE("zero_fill_short_read: negative channels is a no-op",
+          "[audio][frame-fill][issue-640]") {
+    auto buf = make_poisoned(4, 1);
+    zero_fill_short_read(buf.data(), 2, 4, /*ch=*/-1);
+    for (float v : buf) REQUIRE(v == 0.5f);
+}
+
 TEST_CASE("zero_fill_short_read: zero total_frames is a no-op",
           "[audio][frame-fill][issue-244]") {
     float buf[4] = {0.5f, 0.5f, 0.5f, 0.5f};
     zero_fill_short_read(buf, 0, /*total=*/0, 2);
+    for (float v : buf) REQUIRE(v == 0.5f);
+}
+
+TEST_CASE("zero_fill_short_read: negative total_frames is a no-op",
+          "[audio][frame-fill][issue-640]") {
+    float buf[4] = {0.5f, 0.5f, 0.5f, 0.5f};
+    zero_fill_short_read(buf, 0, /*total=*/-1, 2);
     for (float v : buf) REQUIRE(v == 0.5f);
 }


### PR DESCRIPTION
## Summary
- cover zero_fill_short_read negative-channel guard
- cover zero_fill_short_read negative-total-frame guard

Parent: #641
Tracker: #640

## Validation
- git diff --check
- cmake -S . -B build-audio-helper-lite -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF with local FETCHCONTENT_SOURCE_DIR_MBEDTLS override
- cmake --build build-audio-helper-lite --target pulp-test-frame-fill -j8
- ctest --test-dir build-audio-helper-lite -R zero_fill_short_read --output-on-failure passed 11/11
- ./build-audio-helper-lite/test/pulp-test-frame-fill passed 81 assertions / 11 cases
