### PR TITLE
test(signal): cover convolver edge paths

### DIFF
--- a/test/test_convolver.cpp
+++ b/test/test_convolver.cpp
@@ -80,3 +80,56 @@ TEST_CASE("Convolver: multi-partition IR", "[signal][convolver]") {
     REQUIRE(conv.num_partitions() == 3);
     REQUIRE(conv.latency() == 0);
 }
+
+TEST_CASE("Convolver: block size is rounded to a processable power of two",
+          "[signal][convolver][issue-645]") {
+    const std::vector<float> ir = {1.0f};
+
+    PartitionedConvolver rounded;
+    rounded.load_ir(ir.data(), ir.size(), 3);
+    REQUIRE(rounded.is_loaded());
+    REQUIRE(rounded.num_partitions() == 1);
+
+    const float input[] = {1.0f, -0.5f, 0.25f, 0.75f};
+    float output[] = {0.0f, 0.0f, 0.0f, 0.0f};
+    rounded.process(input, output, 4);
+
+    for (size_t i = 0; i < 4; ++i)
+        REQUIRE_THAT(output[i], WithinAbs(input[i], 1e-5f));
+
+    PartitionedConvolver zero_block;
+    zero_block.load_ir(ir.data(), ir.size(), 0);
+    REQUIRE(zero_block.is_loaded());
+
+    const float single_input[] = {0.625f};
+    float single_output[] = {0.0f};
+    zero_block.process(single_input, single_output, 1);
+    REQUIRE_THAT(single_output[0], WithinAbs(single_input[0], 1e-5f));
+}
+
+TEST_CASE("Convolver: empty IR and wrong block size pass input through",
+          "[signal][convolver][issue-645]") {
+    float dummy_ir = 0.0f;
+    PartitionedConvolver empty_ir;
+    empty_ir.load_ir(&dummy_ir, 0, 8);
+    REQUIRE_FALSE(empty_ir.is_loaded());
+    REQUIRE(empty_ir.num_partitions() == 0);
+
+    const float input[] = {0.0f, 1.0f, 2.0f, 3.0f};
+    float output[] = {-1.0f, -1.0f, -1.0f, -1.0f};
+    empty_ir.process(input, output, 4);
+
+    for (size_t i = 0; i < 4; ++i)
+        REQUIRE_THAT(output[i], WithinAbs(input[i], 1e-6f));
+
+    const std::vector<float> identity_ir = {1.0f};
+    PartitionedConvolver loaded;
+    loaded.load_ir(identity_ir.data(), identity_ir.size(), 8);
+    REQUIRE(loaded.is_loaded());
+
+    std::fill(std::begin(output), std::end(output), -1.0f);
+    loaded.process(input, output, 4);
+
+    for (size_t i = 0; i < 4; ++i)
+        REQUIRE_THAT(output[i], WithinAbs(input[i], 1e-6f));
+}


### PR DESCRIPTION
## Summary
- cover rounded and zero block-size convolver setup
- cover empty-IR pass-through behavior
- cover wrong-block-size process pass-through behavior

Parent: #641
Tracker: #645

## Validation
- git diff --check
- python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --mode=report
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF with local FETCHCONTENT_SOURCE_DIR_MBEDTLS override
- cmake --build build --target pulp-test-convolver -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-convolver passed 91 assertions / 6 cases
- ./build/test/pulp-test-convolver "[issue-645]" passed 19 assertions / 2 cases
- ctest --test-dir build -R "Convolver" --output-on-failure passed 6/6
