### PR TITLE
test(events): cover async helper edge cases

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -864,6 +864,10 @@ add_executable(pulp-test-events test_events.cpp)
 target_link_libraries(pulp-test-events PRIVATE pulp::events Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-events)
 
+add_executable(pulp-test-events-async-helpers test_events_async_helpers.cpp)
+target_link_libraries(pulp-test-events-async-helpers PRIVATE pulp::events Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-events-async-helpers)
+
 # Audio file I/O tests
 add_executable(pulp-test-audio-file test_audio_file.cpp)
 target_link_libraries(pulp-test-audio-file PRIVATE pulp::audio Catch2::Catch2WithMain)

--- a/test/test_events_async_helpers.cpp
+++ b/test/test_events_async_helpers.cpp
@@ -1,0 +1,104 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/events/async_updater.hpp>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace pulp::events;
+
+namespace {
+
+class ReentrantUpdater : public AsyncUpdater {
+public:
+    void handle_async_update() override {
+        ++handles;
+        if (handles == 1) {
+            trigger_async_update();
+        }
+    }
+
+    int handles = 0;
+};
+
+class RecordingMultiTimer : public MultiTimer {
+public:
+    void timer_callback(int timer_id) override {
+        callbacks.push_back(timer_id);
+    }
+
+    std::vector<int> callbacks;
+};
+
+}  // namespace
+
+TEST_CASE("AsyncUpdater keeps a reentrant trigger pending",
+          "[events][async_updater][issue-642]") {
+    ReentrantUpdater updater;
+
+    updater.trigger_async_update();
+    REQUIRE(updater.is_update_pending());
+
+    updater.process_pending();
+    REQUIRE(updater.handles == 1);
+    REQUIRE(updater.is_update_pending());
+
+    updater.process_pending();
+    REQUIRE(updater.handles == 2);
+    REQUIRE_FALSE(updater.is_update_pending());
+}
+
+TEST_CASE("LambdaAsyncUpdater clears pending state without a callback",
+          "[events][async_updater][issue-642]") {
+    LambdaAsyncUpdater updater({});
+
+    updater.trigger_async_update();
+    REQUIRE(updater.is_update_pending());
+
+    updater.process_pending();
+    REQUIRE_FALSE(updater.is_update_pending());
+}
+
+TEST_CASE("ActionBroadcaster ignores missing listener removals",
+          "[events][async_updater][action_broadcaster][issue-642]") {
+    ActionBroadcaster broadcaster;
+    std::vector<std::string> seen;
+
+    const auto first = broadcaster.add_listener(
+        [&](std::string_view action) { seen.emplace_back(action); });
+    const auto second = broadcaster.add_listener(
+        [&](std::string_view action) { seen.emplace_back("second:" + std::string(action)); });
+
+    broadcaster.remove_listener(999);
+    broadcaster.send_action("refresh");
+    REQUIRE(seen == std::vector<std::string>{"refresh", "second:refresh"});
+
+    broadcaster.remove_listener(first);
+    broadcaster.remove_listener(first);
+    broadcaster.send_action("rebuild");
+    REQUIRE(seen == std::vector<std::string>{
+        "refresh", "second:refresh", "second:rebuild"});
+
+    broadcaster.remove_listener(second);
+    broadcaster.send_action("ignored");
+    REQUIRE(seen.size() == 3);
+}
+
+TEST_CASE("MultiTimer stop all permits selective restart",
+          "[events][async_updater][multi_timer][issue-642]") {
+    RecordingMultiTimer timers;
+
+    timers.start_timer(1, 20);
+    timers.start_timer(2, 10);
+    timers.stop_all_timers();
+    REQUIRE_FALSE(timers.is_timer_running(1));
+    REQUIRE_FALSE(timers.is_timer_running(2));
+
+    timers.start_timer(1, 5);
+    REQUIRE(timers.is_timer_running(1));
+    REQUIRE_FALSE(timers.is_timer_running(2));
+
+    timers.stop_timer(42);
+    REQUIRE(timers.is_timer_running(1));
+    REQUIRE_FALSE(timers.is_timer_running(2));
+}


### PR DESCRIPTION
## Summary
- add a focused events async-helper test target
- cover reentrant AsyncUpdater pending state
- cover LambdaAsyncUpdater empty-callback processing, ActionBroadcaster missing-removal behavior, and MultiTimer stop-all/restart behavior

Parent: #641
Tracker: #642

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build --target pulp-test-events-async-helpers -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-events-async-helpers passed 16 assertions / 4 cases
- ctest --test-dir build -R "AsyncUpdater|LambdaAsyncUpdater|ActionBroadcaster|MultiTimer" --output-on-failure passed 12/12
- git diff --check

Version-Bump: sdk=skip reason="test-only events async helper target"
