### PR TITLE
test(render): cover draw batcher edge cases

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1157,8 +1157,8 @@ add_executable(pulp-test-view test_view.cpp)
 target_link_libraries(pulp-test-view PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-view)
 
-# DirtyTracker and GpuGraphRenderer are header-only helpers; keep their pure
-# tests available in GPU-off sanitizer and local coverage builds.
+# DirtyTracker, GpuGraphRenderer, and DrawBatcher are header-only helpers; keep
+# their pure tests available in GPU-off sanitizer and local coverage builds.
 add_executable(pulp-test-dirty-tracker test_dirty_tracker.cpp)
 target_include_directories(pulp-test-dirty-tracker PRIVATE
     ${CMAKE_SOURCE_DIR}/core/render/include)
@@ -1171,6 +1171,14 @@ target_include_directories(pulp-test-gpu-graph PRIVATE
 target_link_libraries(pulp-test-gpu-graph PRIVATE Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-gpu-graph)
 
+add_executable(pulp-test-draw-batcher test_draw_batcher.cpp)
+target_include_directories(pulp-test-draw-batcher PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include)
+target_link_libraries(pulp-test-draw-batcher PRIVATE
+    pulp::canvas
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-draw-batcher)
+
 # GPU-stack tests — pulp::render only exists when PULP_ENABLE_GPU=ON.
 # The sanitizer matrix builds with GPU off; without the guard configure
 # fails with "Target ... links to: pulp::render but the target was not
@@ -1181,11 +1189,6 @@ if(PULP_ENABLE_GPU)
     add_executable(pulp-test-rendering-integration test_rendering_integration.cpp)
     target_link_libraries(pulp-test-rendering-integration PRIVATE pulp::view pulp::render pulp::state Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-rendering-integration)
-
-    # Draw batcher tests
-    add_executable(pulp-test-draw-batcher test_draw_batcher.cpp)
-    target_link_libraries(pulp-test-draw-batcher PRIVATE pulp::render Catch2::Catch2WithMain)
-    catch_discover_tests(pulp-test-draw-batcher)
 
 endif()
 

--- a/test/test_draw_batcher.cpp
+++ b/test/test_draw_batcher.cpp
@@ -77,3 +77,66 @@ TEST_CASE("DrawBatcher not active before begin", "[render][batcher]") {
     REQUIRE_FALSE(b.is_active());
     REQUIRE(b.entries().size() == 1);
 }
+
+TEST_CASE("DrawBatcher merges chained same-key draws into one bounding box",
+          "[render][batcher][issue-646]") {
+    DrawBatcher b;
+
+    b.begin();
+    b.record({10, 5, 20, 10}, 7);
+    b.record({-5, 1, 3, 3}, 7);
+    b.record({40, 30, 5, 5}, 7);
+    const auto stats = b.end();
+
+    REQUIRE(stats.draws_before == 3);
+    REQUIRE(stats.draws_after == 1);
+    REQUIRE(stats.batches_merged == 2);
+
+    REQUIRE(b.entries().size() == 1);
+    const auto& bounds = b.entries().front().bounds;
+    REQUIRE(bounds.x == -5.0f);
+    REQUIRE(bounds.y == 1.0f);
+    REQUIRE(bounds.w == 50.0f);
+    REQUIRE(bounds.h == 34.0f);
+}
+
+TEST_CASE("DrawBatcher ignores records after end until the next begin",
+          "[render][batcher][issue-646]") {
+    DrawBatcher b;
+
+    b.begin();
+    b.record({0, 0, 10, 10}, 11);
+    REQUIRE(b.end().draws_after == 1);
+
+    b.record({20, 0, 10, 10}, 11);
+    REQUIRE(b.entries().size() == 1);
+
+    b.begin();
+    REQUIRE(b.entries().empty());
+    b.record({20, 0, 10, 10}, 11);
+    REQUIRE(b.end().draws_after == 1);
+    REQUIRE(b.entries().front().bounds.x == 20.0f);
+}
+
+TEST_CASE("DrawBatcher edge-touching blockers do not prevent same-key merge",
+          "[render][batcher][issue-646]") {
+    DrawBatcher b;
+
+    b.begin();
+    b.record({0, 0, 10, 10}, 3);
+    b.record({12, 10, 5, 5}, 99);
+    b.record({20, 0, 10, 10}, 3);
+    const auto stats = b.end();
+
+    REQUIRE(stats.draws_before == 3);
+    REQUIRE(stats.draws_after == 2);
+    REQUIRE(stats.batches_merged == 1);
+
+    REQUIRE(b.entries().size() == 2);
+    REQUIRE(b.entries()[0].state_key == 3);
+    REQUIRE(b.entries()[0].bounds.x == 0.0f);
+    REQUIRE(b.entries()[0].bounds.y == 0.0f);
+    REQUIRE(b.entries()[0].bounds.w == 30.0f);
+    REQUIRE(b.entries()[0].bounds.h == 10.0f);
+    REQUIRE(b.entries()[1].state_key == 99);
+}


### PR DESCRIPTION
## Summary
- add focused DrawBatcher edge-case coverage for chained same-key merges, post-end records, and edge-touching blockers
- move the DrawBatcher test target into the GPU-off-safe render helper lane so sanitizer and coverage builds can execute it

Refs #646
Refs #641

## Validation
- `cmake --build build-render-coverage-646-gpu-off --target pulp-test-draw-batcher -j$(sysctl -n hw.ncpu)`
- `ctest --test-dir build-render-coverage-646-gpu-off -R "DrawBatcher|draw-batcher" --output-on-failure` (10/10)
- `git diff --check HEAD^..HEAD`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
