### PR TITLE
test(platform): cover progress parser edge cases

### DIFF
--- a/test/test_progress_parser.cpp
+++ b/test/test_progress_parser.cpp
@@ -38,6 +38,30 @@ TEST_CASE("ProgressParser handles type-only (no payload)", "[progress_parser]") 
     REQUIRE(events[0].payload.empty());
 }
 
+TEST_CASE("ProgressParser handles empty callbacks for matching lines",
+          "[progress_parser][edge][issue-640]") {
+    ProgressParser parser(nullptr);
+
+    REQUIRE_NOTHROW(parser.feed_line("PROGRESS:START:payload"));
+    REQUIRE_NOTHROW(parser.feed_line("PROGRESS:DONE"));
+    REQUIRE_NOTHROW(parser.feed_line("regular output"));
+}
+
+TEST_CASE("ProgressParser preserves empty type and payload boundaries",
+          "[progress_parser][edge][issue-640]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });
+
+    parser.feed_line("PROGRESS::payload");
+    parser.feed_line("PROGRESS:EMPTY_PAYLOAD:");
+
+    REQUIRE(events.size() == 2);
+    REQUIRE(events[0].type.empty());
+    REQUIRE(events[0].payload == "payload");
+    REQUIRE(events[1].type == "EMPTY_PAYLOAD");
+    REQUIRE(events[1].payload.empty());
+}
+
 TEST_CASE("ProgressParser handles multiple events", "[progress_parser]") {
     std::vector<ProgressEvent> events;
     ProgressParser parser([&](const ProgressEvent& e) { events.push_back(e); });


### PR DESCRIPTION
## Summary
- add ProgressParser coverage for null callbacks on matching progress lines
- cover empty event-type and empty-payload boundary parsing

Refs #640
Refs #641

## Validation
- `cmake -S . -B build-progress -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Code/pulp/build/_deps/mbedtls-src`
- `cmake --build build-progress --target pulp-test-progress-parser -j$(sysctl -n hw.ncpu)`
- `./build-progress/test/pulp-test-progress-parser` (32 assertions, 10 test cases)
- `ctest --test-dir build-progress -R ProgressParser --output-on-failure` (10/10)
- `git diff --check HEAD^..HEAD`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
