### PR TITLE
test(android): cover audio engine default config

### DIFF
--- a/android/app/src/test/kotlin/com/pulp/audio/PulpAudioEngineTest.kt
+++ b/android/app/src/test/kotlin/com/pulp/audio/PulpAudioEngineTest.kt
@@ -42,6 +42,21 @@ class PulpAudioEngineTest {
     }
 
     @Test
+    fun usesDefaultAudioConfigWhenPropertiesAreUnavailableOrMalformed() {
+        val context = mock<Context>()
+        val audioManager = mock<AudioManager>()
+        whenever(context.getSystemService(AudioManager::class.java)).thenReturn(audioManager)
+        whenever(audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE))
+            .thenReturn("not-a-number")
+        whenever(audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER))
+            .thenReturn(null)
+        val engine = PulpAudioEngine(context)
+
+        assertEquals(48000, engine.getOptimalSampleRate())
+        assertEquals(256, engine.getOptimalFramesPerBuffer())
+    }
+
+    @Test
     fun registerAndUnregisterDelegateToAudioManager() {
         val context = mock<Context>()
         val audioManager = mock<AudioManager>()


### PR DESCRIPTION
## Summary
- add Android JVM coverage for default audio config fallbacks when AudioManager properties are malformed or unavailable

Refs #641

## Validation
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/danielraffel/Library/Android/sdk" ./gradlew :app:testDebugUnitTest`
- `git diff --check HEAD^..HEAD`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
