### PR TITLE
test(bindings): cover embedded python state paths

### DIFF
--- a/test/test_python_bindings_embedded.cpp
+++ b/test/test_python_bindings_embedded.cpp
@@ -1,17 +1,117 @@
 #include <Python.h>
 
+#include <pybind11/pybind11.h>
+
+#include <pulp/format/headless.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <vector>
+
 extern "C" PyObject* PyInit_pulp();
+
+namespace {
+
+namespace py = pybind11;
+
+constexpr pulp::state::ParamID kHostParamId = 8101;
+constexpr pulp::state::ParamID kStoreGainParamId = 8201;
+constexpr pulp::state::ParamID kStoreMixParamId = 8202;
+
+class BindingsSmokeProcessor : public pulp::format::Processor {
+public:
+    pulp::format::PluginDescriptor descriptor() const override {
+        return {
+            .name = "BindingsSmoke",
+            .manufacturer = "PulpTest",
+            .bundle_id = "com.pulp.test.bindings-smoke",
+            .version = "1.2.3",
+            .category = pulp::format::PluginCategory::Effect,
+        };
+    }
+
+    void define_parameters(pulp::state::StateStore& store) override {
+        store.add_parameter({
+            .id = kHostParamId,
+            .name = "Host Gain",
+            .unit = "",
+            .range = {0.0f, 1.0f, 0.25f},
+        });
+    }
+
+    void prepare(const pulp::format::PrepareContext&) override {}
+
+    void process(
+        pulp::audio::BufferView<float>& output,
+        const pulp::audio::BufferView<const float>& input,
+        pulp::midi::MidiBuffer&,
+        pulp::midi::MidiBuffer&,
+        const pulp::format::ProcessContext&) override
+    {
+        const auto channels = std::min(output.num_channels(), input.num_channels());
+        const auto samples = std::min(output.num_samples(), input.num_samples());
+        for (std::size_t ch = 0; ch < channels; ++ch) {
+            auto out = output.channel(ch);
+            auto in = input.channel(ch);
+            std::copy_n(in.data(), samples, out.data());
+        }
+    }
+
+    std::vector<uint8_t> serialize_plugin_state() const override {
+        return {0x70, 0x79};
+    }
+};
+
+std::unique_ptr<pulp::format::Processor> create_bindings_smoke_processor() {
+    return std::make_unique<BindingsSmokeProcessor>();
+}
+
+void add_param(pulp::state::StateStore& store,
+               pulp::state::ParamID id,
+               const char* name,
+               pulp::state::ParamRange range)
+{
+    store.add_parameter({
+        .id = id,
+        .name = name,
+        .unit = "",
+        .range = range,
+    });
+}
+
+} // namespace
 
 int main() {
     if (PyImport_AppendInittab("pulp", &PyInit_pulp) == -1) {
         return 1;
     }
 
+    pulp::state::StateStore test_store;
+    add_param(test_store, kStoreGainParamId, "Python Gain", {-60.0f, 24.0f, 0.0f});
+    add_param(test_store, kStoreMixParamId, "Python Mix", {0.0f, 1.0f, 0.5f});
+
+    pulp::format::HeadlessHost test_host(create_bindings_smoke_processor);
+
     Py_Initialize();
+
+    try {
+        py::module_ pulp_module = py::module_::import("pulp");
+        pulp_module.attr("_test_state_store") =
+            py::cast(&test_store, py::return_value_policy::reference);
+        pulp_module.attr("_test_host") =
+            py::cast(&test_host, py::return_value_policy::reference);
+    } catch (const py::error_already_set&) {
+        PyErr_Print();
+        return 1;
+    }
 
     const char* script = R"PY(
 import math
 import pulp
+
+assert pulp.__doc__ == "Pulp audio plugin framework — Python bindings"
 
 param_range = pulp.ParamRange(0.0, 1.0, 0.5)
 assert math.isclose(param_range.normalize(0.5), 0.5)
@@ -39,6 +139,46 @@ assert midi.size() == 2
 assert not midi.empty()
 midi.clear()
 assert midi.empty()
+
+store = pulp._test_state_store
+assert store.param_count() == 2
+assert [param.name for param in store.all_params()] == ["Python Gain", "Python Mix"]
+assert store.info(8201).name == "Python Gain"
+assert store.info(999999) is None
+store.set_value(8201, -12.0)
+store.set_normalized(8202, 0.75)
+assert math.isclose(store.get_value(8201), -12.0)
+assert math.isclose(store.get_normalized(8202), 0.75)
+state_blob = bytes(store.serialize())
+store.set_value(8201, 999.0)
+store.reset_to_default(8202)
+assert math.isclose(store.get_value(8201), 24.0)
+assert math.isclose(store.get_value(8202), 0.5)
+assert store.deserialize(state_blob)
+assert math.isclose(store.get_value(8201), -12.0)
+assert math.isclose(store.get_normalized(8202), 0.75)
+assert not store.deserialize(b"bad")
+
+host = pulp._test_host
+host.prepare(48000.0, 16)
+descriptor = host.descriptor()
+assert descriptor.name == "BindingsSmoke"
+assert descriptor.manufacturer == "PulpTest"
+assert descriptor.bundle_id == "com.pulp.test.bindings-smoke"
+assert descriptor.version == "1.2.3"
+assert descriptor.is_instrument is False
+
+host_state = host.state()
+assert host_state.param_count() == 1
+assert math.isclose(host_state.get_default(8101), 0.25)
+host_state.set_normalized(8101, 1.0)
+saved = host.save_state()
+assert isinstance(saved, bytes)
+host_state.set_value(8101, 0.0)
+assert host.load_state(saved)
+assert math.isclose(host_state.get_value(8101), 1.0)
+assert not host.load_state(b"not a valid host state")
+host.release()
 )PY";
 
     const int rc = PyRun_SimpleString(script);


### PR DESCRIPTION
## Summary
- extend the embedded Python bindings smoke test with StateStore access, serialization, deserialization, and parameter info checks
- cover HeadlessHost descriptor/state/save/load paths from the Python module

Refs #641

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_BUILD_PYTHON=ON -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF ...`
- `cmake --build build --target pulp-test-python-bindings-embedded pulp_python -j$(sysctl -n hw.ncpu)`
- `ctest --test-dir build -R "python-bindings" --output-on-failure` (2/2)
- `git diff --check HEAD^..HEAD`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
