### PR TITLE
test(format): cover host type policies

### DIFF
--- a/test/test_v3_gaps.cpp
+++ b/test/test_v3_gaps.cpp
@@ -277,8 +277,36 @@ TEST_CASE("HostType detect returns something", "[format][host]") {
 
 TEST_CASE("HostType names", "[format][host]") {
     REQUIRE(pulp::format::host_type_name(pulp::format::HostType::LogicPro) == "Logic Pro");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::GarageBand) == "GarageBand");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::AbletonLive) == "Ableton Live");
     REQUIRE(pulp::format::host_type_name(pulp::format::HostType::Reaper) == "REAPER");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::ProTools) == "Pro Tools");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::Cubase) == "Cubase");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::Nuendo) == "Nuendo");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::StudioOne) == "Studio One");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::FLStudio) == "FL Studio");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::Bitwig) == "Bitwig Studio");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::Maschine) == "Maschine");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::AudacityTenacity) == "Audacity/Tenacity");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::Ardour) == "Ardour");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::Standalone) == "Pulp Standalone");
+    REQUIRE(pulp::format::host_type_name(pulp::format::HostType::Other) == "Other");
     REQUIRE(pulp::format::host_type_name(pulp::format::HostType::Unknown) == "Unknown");
+    REQUIRE(pulp::format::host_type_name(static_cast<pulp::format::HostType>(999)) == "Unknown");
+}
+
+TEST_CASE("HostType capability policy exceptions", "[format][host]") {
+    using pulp::format::HostType;
+
+    REQUIRE_FALSE(pulp::format::host_supports_resize(HostType::GarageBand));
+    REQUIRE_FALSE(pulp::format::host_supports_resize(HostType::ProTools));
+    REQUIRE(pulp::format::host_supports_resize(HostType::LogicPro));
+    REQUIRE(pulp::format::host_supports_resize(HostType::Unknown));
+
+    REQUIRE_FALSE(pulp::format::host_supports_sidechain(HostType::GarageBand));
+    REQUIRE_FALSE(pulp::format::host_supports_sidechain(HostType::AudacityTenacity));
+    REQUIRE(pulp::format::host_supports_sidechain(HostType::ProTools));
+    REQUIRE(pulp::format::host_supports_sidechain(HostType::Unknown));
 }
 
 // ── Primes ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- cover all host_type_name enum mappings plus invalid enum fallback
- cover resize and sidechain policy exceptions for known host types

Refs #493
Refs #641

## Validation
- `cmake -S . -B build-next3-localdeps -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF ...`
- `cmake --build build-next3-localdeps --target pulp-test-v3-gaps -j$(sysctl -n hw.ncpu)`
- `./build-next3-localdeps/test/pulp-test-v3-gaps` (153 assertions, 28 test cases)
- `ctest --test-dir build-next3-localdeps -R "HostType" --output-on-failure` (3/3)
- `git diff --check HEAD^..HEAD`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
