### PR TITLE
test(cli): cover JSFX subset validation errors

### DIFF
--- a/tools/scripts/test_jsfx_subset.py
+++ b/tools/scripts/test_jsfx_subset.py
@@ -90,6 +90,35 @@ class JsfxSubsetScriptTests(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("duplicate slider1", result.stderr)
 
+    def test_doctor_rejects_out_of_range_slider(self) -> None:
+        path = self.write_temp_jsfx(
+            """
+            desc:Out Of Range Slider Example
+            slider65:1<0,2,0.01>Gain
+            @sample
+              spl0 *= slider65;
+              spl1 *= slider65;
+            """
+        )
+        result = self.run_script("doctor", "--file", str(path))
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("slider index out of range", result.stderr)
+        self.assertIn("slider65", result.stderr)
+
+    def test_doctor_rejects_duplicate_section(self) -> None:
+        path = self.write_temp_jsfx(
+            """
+            desc:Duplicate Section Example
+            @sample
+              spl0 *= 0.5;
+            @sample
+              spl1 *= 0.5;
+            """
+        )
+        result = self.run_script("doctor", "--file", str(path))
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("duplicate @sample section", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add JSFX doctor coverage for out-of-range slider declarations
- cover duplicate `@sample` section rejection

Refs #643
Refs #641

## Validation
- `python3 -m unittest tools/scripts/test_jsfx_subset.py` (6 tests)
- `git diff --check HEAD^..HEAD`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --head HEAD --mode=report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --head HEAD --mode=report`
