### PR TITLE
fix(cli): MSVCRT-correct shell_quote for Windows backslash paths (#776)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,30 @@ if(TARGET pulp-cli)
 endif()
 catch_discover_tests(pulp-test-cli-shellout)
 
+# pulp #776 — pin shell_quote's per-platform contract so it can't
+# silently regress to the pre-fix shape that broke `git fetch origin`
+# on Windows by writing doubled backslashes into clone URLs.
+add_executable(pulp-test-cli-shell-quote
+    test_cli_shell_quote.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/cli_common.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/update_check.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/version_diag.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/package_registry.cpp
+)
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/tools/cli")
+configure_file(
+    "${CMAKE_SOURCE_DIR}/tools/cli/pulp_version_gen.h.in"
+    "${CMAKE_BINARY_DIR}/tools/cli/pulp_version_gen.h"
+    @ONLY)
+target_include_directories(pulp-test-cli-shell-quote PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/cli
+    ${CMAKE_BINARY_DIR}/tools/cli)
+target_link_libraries(pulp-test-cli-shell-quote PRIVATE
+    pulp::runtime
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-cli-shell-quote)
+
 # Plugin ↔ CLI skew banner helper (#551 Slice 6): shells out to bash
 # with a staged `pulp` shim and asserts the banner copy + once-per-
 # session semantics of `.agents/skills/_common/cli_version_check.sh`.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,6 +89,8 @@ catch_discover_tests(pulp-test-cli-shellout)
 add_executable(pulp-test-cli-shell-quote
     test_cli_shell_quote.cpp
     ${CMAKE_SOURCE_DIR}/tools/cli/cli_common.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/fetchcontent_cache.cpp
+    ${CMAKE_SOURCE_DIR}/tools/cli/projects_registry.cpp
     ${CMAKE_SOURCE_DIR}/tools/cli/update_check.cpp
     ${CMAKE_SOURCE_DIR}/tools/cli/version_diag.cpp
     ${CMAKE_SOURCE_DIR}/tools/cli/package_registry.cpp

--- a/test/test_cli_project_command.cpp
+++ b/test/test_cli_project_command.cpp
@@ -501,7 +501,16 @@ TEST_CASE("cli common config helpers honor PULP_HOME and project-dir overrides",
 
 TEST_CASE("cli common format, AAX, quoting, and fuzzy helpers stay deterministic",
           "[cli][common][issue-643]") {
+    // shell_quote is platform-divergent (#776): POSIX escapes both `\`
+    // and `"`; Windows uses MSVCRT-correct escaping (backslashes are
+    // literal unless they precede `"`). Input chars: `a b"c\d`.
+#ifdef _WIN32
+    // Windows: `\` is literal, only `"` is escaped (with one preceding `\`).
+    REQUIRE(shell_quote(std::string("a b\"c\\d")) == "\"a b\\\"c\\d\"");
+#else
+    // POSIX: both `\` and `"` are backslash-escaped.
     REQUIRE(shell_quote(std::string("a b\"c\\d")) == "\"a b\\\"c\\\\d\"");
+#endif
     REQUIRE(platform_executable("tool").filename().string().find("tool") == 0);
 
     REQUIRE(default_create_formats({}, "app") == "Standalone");

--- a/test/test_cli_shell_quote.cpp
+++ b/test/test_cli_shell_quote.cpp
@@ -1,0 +1,71 @@
+// pulp #776 — pin the shell_quote contract.
+//
+// Until 2026-04-26, `shell_quote` Unix-style escaped backslashes
+// unconditionally. On Windows that broke `git clone "C:\path"
+// dest`: the URL written into `dest/.git/config` had doubled
+// backslashes, so the next `git fetch origin` couldn't resolve the
+// remote and `bump_one`'s origin/main redundancy gate silently
+// fell through, returning "bumped" where the test expected "skipped".
+//
+// These tests assert the platform-correct shapes so the algorithm
+// can't silently regress to the broken pre-#776 form. POSIX side
+// keeps the original escape-`\`-and-`"` contract; Windows side
+// follows the canonical MSVCRT argv-parsing rules from Microsoft's
+// docs.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "../tools/cli/cli_common.hpp"
+
+using pulp::cli::shell_quote;
+
+#ifdef _WIN32
+
+TEST_CASE("shell_quote leaves Windows path backslashes literal", "[cli][shell-quote][issue-776]") {
+    REQUIRE(shell_quote(std::string{"C:\\Users\\foo"}) == "\"C:\\Users\\foo\"");
+}
+
+TEST_CASE("shell_quote handles Windows paths with spaces", "[cli][shell-quote][issue-776]") {
+    REQUIRE(shell_quote(std::string{"C:\\Program Files\\git\\cmd"}) ==
+            "\"C:\\Program Files\\git\\cmd\"");
+}
+
+TEST_CASE("shell_quote escapes embedded quote per MSVCRT rules", "[cli][shell-quote][issue-776]") {
+    // A literal " inside the argument needs one extra backslash so the
+    // parser doesn't end the quoted region. Existing backslashes in the
+    // run before the " are NOT doubled when there are none.
+    REQUIRE(shell_quote(std::string{R"(say "hi")"}) == R"("say \"hi\"")");
+}
+
+TEST_CASE("shell_quote doubles backslashes that immediately precede an embedded quote",
+          "[cli][shell-quote][issue-776]") {
+    // For a run of N backslashes followed by ", the algorithm emits
+    // (2N + 1) backslashes then the quote. Two `\` + `"` -> `\\\\\"`.
+    REQUIRE(shell_quote(std::string{"foo\\\\\"bar"}) == "\"foo\\\\\\\\\\\"bar\"");
+}
+
+TEST_CASE("shell_quote doubles trailing backslashes so they don't escape the closing quote",
+          "[cli][shell-quote][issue-776]") {
+    // `C:\foo\` -> `"C:\foo\\"` so that the closing `"` is genuinely
+    // the close, not an escape produced by the trailing `\`.
+    REQUIRE(shell_quote(std::string{"C:\\foo\\"}) == "\"C:\\foo\\\\\"");
+}
+
+TEST_CASE("shell_quote leaves cmd.exe metacharacters inert inside quotes",
+          "[cli][shell-quote][issue-776]") {
+    // `&`, `|`, `<`, `>`, `%`, `!`, `^` are inert inside `"..."` to
+    // cmd.exe — wrapping is enough; we don't need to ^-escape them.
+    REQUIRE(shell_quote(std::string{"a&b|c<d>e"}) == "\"a&b|c<d>e\"");
+}
+
+#else  // POSIX
+
+TEST_CASE("shell_quote escapes backslash and quote on POSIX", "[cli][shell-quote][issue-776]") {
+    REQUIRE(shell_quote(std::string{"/usr/bin/git"}) == "\"/usr/bin/git\"");
+    REQUIRE(shell_quote(std::string{"/path with spaces/git"}) ==
+            "\"/path with spaces/git\"");
+    REQUIRE(shell_quote(std::string{"a\\b"}) == "\"a\\\\b\"");
+    REQUIRE(shell_quote(std::string{R"(say "hi")"}) == R"("say \"hi\"")");
+}
+
+#endif

--- a/test/test_cli_shell_quote.cpp
+++ b/test/test_cli_shell_quote.cpp
@@ -17,16 +17,14 @@
 
 #include "../tools/cli/cli_common.hpp"
 
-using pulp::cli::shell_quote;
-
 #ifdef _WIN32
 
 TEST_CASE("shell_quote leaves Windows path backslashes literal", "[cli][shell-quote][issue-776]") {
-    REQUIRE(shell_quote(std::string{"C:\\Users\\foo"}) == "\"C:\\Users\\foo\"");
+    REQUIRE(shell_quote(std::string("C:\\Users\\foo")) == "\"C:\\Users\\foo\"");
 }
 
 TEST_CASE("shell_quote handles Windows paths with spaces", "[cli][shell-quote][issue-776]") {
-    REQUIRE(shell_quote(std::string{"C:\\Program Files\\git\\cmd"}) ==
+    REQUIRE(shell_quote(std::string("C:\\Program Files\\git\\cmd")) ==
             "\"C:\\Program Files\\git\\cmd\"");
 }
 
@@ -34,38 +32,47 @@ TEST_CASE("shell_quote escapes embedded quote per MSVCRT rules", "[cli][shell-qu
     // A literal " inside the argument needs one extra backslash so the
     // parser doesn't end the quoted region. Existing backslashes in the
     // run before the " are NOT doubled when there are none.
-    REQUIRE(shell_quote(std::string{R"(say "hi")"}) == R"("say \"hi\"")");
+    //
+    // Input:  say "hi"
+    // Output: "say \"hi\""
+    REQUIRE(shell_quote(std::string("say \"hi\"")) == "\"say \\\"hi\\\"\"");
 }
 
 TEST_CASE("shell_quote doubles backslashes that immediately precede an embedded quote",
           "[cli][shell-quote][issue-776]") {
     // For a run of N backslashes followed by ", the algorithm emits
-    // (2N + 1) backslashes then the quote. Two `\` + `"` -> `\\\\\"`.
-    REQUIRE(shell_quote(std::string{"foo\\\\\"bar"}) == "\"foo\\\\\\\\\\\"bar\"");
+    // (2N + 1) backslashes then the quote.
+    //
+    // Input:  foo\\"bar     (chars: f o o \ \ " b a r)
+    // Output: "foo\\\\\\"bar"   (chars: " f o o \ \ \ \ \ " b a r ")
+    REQUIRE(shell_quote(std::string("foo\\\\\"bar")) == "\"foo\\\\\\\\\\\"bar\"");
 }
 
 TEST_CASE("shell_quote doubles trailing backslashes so they don't escape the closing quote",
           "[cli][shell-quote][issue-776]") {
-    // `C:\foo\` -> `"C:\foo\\"` so that the closing `"` is genuinely
-    // the close, not an escape produced by the trailing `\`.
-    REQUIRE(shell_quote(std::string{"C:\\foo\\"}) == "\"C:\\foo\\\\\"");
+    // Input:  C:\foo\        (chars: C : \ f o o \)
+    // Output: "C:\foo\\"     (the trailing run is doubled to 2 backslashes
+    //                        before the closing ")
+    REQUIRE(shell_quote(std::string("C:\\foo\\")) == "\"C:\\foo\\\\\"");
 }
 
 TEST_CASE("shell_quote leaves cmd.exe metacharacters inert inside quotes",
           "[cli][shell-quote][issue-776]") {
     // `&`, `|`, `<`, `>`, `%`, `!`, `^` are inert inside `"..."` to
     // cmd.exe — wrapping is enough; we don't need to ^-escape them.
-    REQUIRE(shell_quote(std::string{"a&b|c<d>e"}) == "\"a&b|c<d>e\"");
+    REQUIRE(shell_quote(std::string("a&b|c<d>e")) == "\"a&b|c<d>e\"");
 }
 
 #else  // POSIX
 
 TEST_CASE("shell_quote escapes backslash and quote on POSIX", "[cli][shell-quote][issue-776]") {
-    REQUIRE(shell_quote(std::string{"/usr/bin/git"}) == "\"/usr/bin/git\"");
-    REQUIRE(shell_quote(std::string{"/path with spaces/git"}) ==
+    REQUIRE(shell_quote(std::string("/usr/bin/git")) == "\"/usr/bin/git\"");
+    REQUIRE(shell_quote(std::string("/path with spaces/git")) ==
             "\"/path with spaces/git\"");
-    REQUIRE(shell_quote(std::string{"a\\b"}) == "\"a\\\\b\"");
-    REQUIRE(shell_quote(std::string{R"(say "hi")"}) == R"("say \"hi\"")");
+    REQUIRE(shell_quote(std::string("a\\b")) == "\"a\\\\b\"");
+    // Input:  say "hi"
+    // Output: "say \"hi\""
+    REQUIRE(shell_quote(std::string("say \"hi\"")) == "\"say \\\"hi\\\"\"");
 }
 
 #endif

--- a/tools/cli/cli_common.cpp
+++ b/tools/cli/cli_common.cpp
@@ -118,6 +118,46 @@ int run(const std::string& cmd) {
 }
 
 std::string shell_quote(const std::string& s) {
+#ifdef _WIN32
+    // pulp #776: on Windows, MSVCRT argv parsing treats backslashes
+    // literally unless they immediately precede a double quote. Unix-
+    // style escaping (`\` -> `\\`) breaks file paths: `git clone
+    // "C:\\Users\\foo\\origin.git" feature` writes the doubled-backslash
+    // URL into feature/.git/config; the next `git fetch origin main`
+    // looks up a path that doesn't exist, fails, and `bump_one` skips
+    // the origin/main redundancy gate it relied on for `"skipped"`.
+    //
+    // Implementation follows the canonical MSVCRT-correct algorithm
+    // (Microsoft docs, Daniel Colascione's "Everyone quotes command
+    // line arguments the wrong way"):
+    //
+    //   - Backslashes NOT followed by `"` are literal.
+    //   - To embed a literal `"`, prefix with one extra backslash and
+    //     double every backslash already in the run before it.
+    //   - Trailing backslashes before the closing `"` must be doubled
+    //     so they don't escape it.
+    //
+    // cmd.exe's own metacharacters (`&`, `|`, `<`, `>`, `%`, `!`, `^`)
+    // are inert inside `"..."`, so wrapping is enough to neutralize them.
+    std::string out = "\"";
+    int backslashes = 0;
+    for (char c : s) {
+        if (c == '\\') {
+            backslashes++;
+        } else if (c == '"') {
+            out.append(static_cast<std::size_t>(backslashes) * 2 + 1, '\\');
+            out += '"';
+            backslashes = 0;
+        } else {
+            out.append(static_cast<std::size_t>(backslashes), '\\');
+            out += c;
+            backslashes = 0;
+        }
+    }
+    out.append(static_cast<std::size_t>(backslashes) * 2, '\\');
+    out += "\"";
+    return out;
+#else
     std::string out = "\"";
     for (char c : s) {
         if (c == '\\' || c == '"') out += '\\';
@@ -125,6 +165,7 @@ std::string shell_quote(const std::string& s) {
     }
     out += "\"";
     return out;
+#endif
 }
 
 std::string shell_quote(const fs::path& p) {


### PR DESCRIPTION
Closes #776.

## Problem

`shell_quote` (`tools/cli/cli_common.cpp`) Unix-style escaped backslashes unconditionally (`\` → `\\`). On Windows that's wrong — MSVCRT argv parsing treats backslashes as literal unless they immediately precede a `"`. The doubled form was passed verbatim to git on the bare-repo + clone path inside `test_cli_project_command.cpp`'s setup — `git clone "C:\\Users\\...\\Temp\\...\\origin.git" feature` wrote the doubled-backslash URL into `feature/.git/config` as the `origin` remote URL.

Subsequent `git fetch origin main` from `main_pinned_version_at_origin` (`tools/cli/cmd_project.cpp:309`) failed to resolve the malformed URL, returned non-zero, and `bump_one` skipped the origin/main redundancy gate the test relied on for `"skipped"` — so the result came back `"bumped"`.

The failure manifested deterministically on the Windows namespace lane every time the matrix touched `tools/cli/`, blocking PRs #769 and #773 today and showing up on most main runs since PR #735 added the test.

## Fix

`shell_quote` now branches on `_WIN32` and uses the canonical MSVCRT-correct algorithm:

- Backslashes NOT followed by `"` are literal.
- To embed `"`, emit `(2N+1)\` where N is the run of backslashes immediately before the `"`.
- Trailing backslashes before the closing `"` are doubled so they don't escape it.

cmd.exe metacharacters (`&|<>%!^`) are inert inside `"..."`, so wrapping is enough — no `^`-escaping needed. POSIX path is unchanged.

Reference: Microsoft docs on argv parsing + Daniel Colascione's "Everyone quotes command line arguments the wrong way".

## Tests

New `test/test_cli_shell_quote.cpp` pins both platform shapes:

- **Windows**: backslash-literal path (`"C:\\Users\\foo"`), embedded-quote escape (`(2N+1)\`), trailing-backslash doubling, cmd.exe metacharacters inert.
- **POSIX**: existing `\` + `"` escape contract preserved (with explicit assertions so a future Windows-only edit can't silently flip POSIX too).

The test target compiles `cli_common.cpp` standalone — small, fast, and the Windows assertions only build on Windows.

## Note on local verification

I could not run the macOS test locally before pushing — the worktree's `cmake configure` was racing other concurrent worktrees over the threejs git clone (FetchContent is not deduped via the shared cache for threejs) and the deps fetch couldn't complete reliably. CI on macOS will be the first run of these assertions; if anything's wrong with the new test file syntax, I'll fix in a follow-up commit. The Windows lane is the actual target for this fix.

## Refs

- Issue: #776
- Investigation: PRs #769 and #773 hit this flake during their CI cycles (visible in their Windows namespace job logs).
- Pre-existing on main since PR #735 (`feat: harden project SDK bump flow`) — has been failing most main Windows runs since.