### PR TITLE
fix(view): drain QuickJS jobs to empty (Codex P2 follow-up to #769)

### DIFF
--- a/core/view/src/js_quickjs_engine.cpp
+++ b/core/view/src/js_quickjs_engine.cpp
@@ -39,9 +39,16 @@ static void set_quickjs_stack_size(choc::javascript::Context& ctx, size_t size) 
 // JSContext*, and call JS_ExecutePendingJob until the queue is empty.
 // JS_ExecutePendingJob returns 1 when it ran a job, 0 when the queue is
 // empty, and a negative value on a JS exception inside the job — we
-// stop on either terminal state. A safety cap prevents a microtask that
-// re-schedules itself indefinitely from looping forever; 4096 matches
-// the order of magnitude React's scheduler uses for its own bail-out.
+// stop on either terminal state.
+//
+// Per Codex P2 on PR #769: the previous implementation capped at 4096
+// jobs and returned silently, which meant a Promise/microtask chain
+// larger than the cap (rare but possible with bundled frameworks)
+// would be silently half-drained. Browsers and Node don't cap; the JS
+// spec says microtasks drain to completion before returning to the
+// macrotask loop. A genuine runaway microtask self-loop is a JS bug
+// the test will surface as a timeout, which is correct. Drain to empty
+// and trust callers to fix any test that legitimately can't terminate.
 static void pump_quickjs_jobs(choc::javascript::Context& ctx) {
     struct ContextLayout {
         std::unique_ptr<choc::javascript::Context::Pimpl> pimpl;
@@ -49,9 +56,8 @@ static void pump_quickjs_jobs(choc::javascript::Context& ctx) {
     auto& layout = reinterpret_cast<ContextLayout&>(ctx);
     auto* qjctx = static_cast<choc::javascript::quickjs::QuickJSContext*>(layout.pimpl.get());
     if (!qjctx || !qjctx->runtime) return;
-    constexpr int kMaxJobsPerPump = 4096;
     choc::javascript::quickjs::JSContext* pctx = nullptr;
-    for (int i = 0; i < kMaxJobsPerPump; ++i) {
+    for (;;) {
         int rc = JS_ExecutePendingJob(qjctx->runtime, &pctx);
         if (rc <= 0) return;  // 0 = empty queue, <0 = JS exception inside job
     }

--- a/test/test_web_compat_react_shims.cpp
+++ b/test/test_web_compat_react_shims.cpp
@@ -465,6 +465,33 @@ TEST_CASE("pump_message_loop transitively drains microtasks scheduled from micro
     REQUIRE(std::string(v.getString()) == "5");
 }
 
+// Codex P2 on PR #769: an earlier 4096-job hard cap silently returned
+// after 4096 iterations, leaving a larger Promise/microtask chain
+// half-drained. The cap is gone — pump now drains to empty (rc == 0).
+// Verify by scheduling 5000 microtasks (≥ the old cap) in one chain
+// and asserting every one of them executed before the pump returns.
+TEST_CASE("pump_message_loop drains a long chain past the old 4096-job cutoff",
+          "[view][web-compat][issue-746][issue-769]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.load_script(R"(
+        globalThis.__count__ = 0;
+        var TARGET = 5000;
+        function step () {
+            globalThis.__count__++;
+            if (globalThis.__count__ < TARGET) queueMicrotask(step);
+        }
+        queueMicrotask(step);
+    )");
+    engine.pump_message_loop();
+    auto v = engine.evaluate("String(globalThis.__count__)");
+    REQUIRE(v.isString());
+    REQUIRE(std::string(v.getString()) == "5000");
+}
+
 // ── MessageChannel + MessagePort + postMessage ─────────────────────────
 
 TEST_CASE("MessageChannel constructs, exposes port1/port2, and postMessage doesn't throw",


### PR DESCRIPTION
Follow-up to merged PR #769. Addresses Codex P2 review on `core/view/src/js_quickjs_engine.cpp:56`.

## Codex's concern

> `pump_message_loop()` is documented and tested as a full microtask drain, but the hard `kMaxJobsPerPump = 4096` cutoff returns early without signaling partial completion. Any finite queue larger than 4096 jobs (for example, large Promise/microtask chains emitted by bundled frameworks) will be left half-drained after a single call, so callers that pump once and then read state can observe incomplete initialization or stale values.

Reasonable. The cap was a defensive measure I added without strong justification; browsers and Node don't cap; the JS spec says microtasks drain to completion before returning to the macrotask loop.

## Fix

Remove the 4096-iteration cap. The loop now exits on `JS_ExecutePendingJob` returning ≤ 0 (0 = empty queue, < 0 = JS exception inside job) — both real terminal states. A genuine runaway microtask self-loop is a JS bug that the test will surface as a timeout, which is the correct signal.

The diff is ~3 lines of behavior change plus an updated rationale comment that documents WHY there's no cap.

## Test

`pump_message_loop drains a long chain past the old 4096-job cutoff` (tagged `[issue-746][issue-769]`) — schedules a self-chaining 5000-microtask sequence (≥ the old cap) and asserts every one runs before pump returns. Pre-fix, this would have read `4096`; post-fix, it reads `5000`.

## Note on local verification

I could not run the macOS test locally before pushing — the worktree's `cmake configure` was racing concurrent worktrees over the threejs git clone (FetchContent isn't deduped via the shared cache for threejs) and the deps fetch couldn't complete reliably. CI on macOS is the first run; if anything's wrong with the new test, I'll fix in a follow-up commit.

## Refs

- Codex review: https://github.com/danielraffel/pulp/pull/769#discussion_r... (P2 comment ID 3141639964)
- Original fix: PR #769 (closed #746)
- Umbrella: #768 (closed)