### PR TITLE
test(ship): cover NSIS uninstall metadata

### DIFF
--- a/test/test_nsis_installer.cpp
+++ b/test/test_nsis_installer.cpp
@@ -66,6 +66,21 @@ TEST_CASE("NSIS script includes uninstaller", "[ship][installer]") {
     REQUIRE_THAT(script, ContainsSubstring("UninstallString"));
 }
 
+TEST_CASE("NSIS script registers uninstall metadata", "[ship][installer]") {
+    auto config = make_test_config();
+    auto script = generate_nsis_script(config);
+
+    const auto uninstall_key =
+        "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\TestPlugin";
+
+    REQUIRE_THAT(script, ContainsSubstring(
+        std::string("WriteRegStr HKLM \"") + uninstall_key + "\" \"DisplayName\" \"TestPlugin\""));
+    REQUIRE_THAT(script, ContainsSubstring(
+        std::string("WriteRegStr HKLM \"") + uninstall_key + "\" \"DisplayVersion\" \"1.2.3\""));
+    REQUIRE_THAT(script, ContainsSubstring(
+        std::string("WriteRegStr HKLM \"") + uninstall_key + "\" \"Publisher\" \"TestCorp\""));
+}
+
 TEST_CASE("NSIS script per-user install uses LOCALAPPDATA", "[ship][installer]") {
     auto config = make_test_config();
     config.per_user_install = true;
@@ -93,6 +108,27 @@ TEST_CASE("NSIS script per-user install uses HKCU registry", "[ship][installer]"
 
     REQUIRE_THAT(script, ContainsSubstring("InstallDirRegKey HKCU"));
     REQUIRE_THAT(script, ContainsSubstring("WriteRegStr HKCU"));
+}
+
+TEST_CASE("NSIS script deletes uninstall registry keys from selected hive", "[ship][installer]") {
+    const auto uninstall_key =
+        "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\TestPlugin";
+
+    auto admin = make_test_config();
+    admin.per_user_install = false;
+    auto admin_script = generate_nsis_script(admin);
+
+    REQUIRE_THAT(admin_script, ContainsSubstring("DeleteRegKey HKLM \"Software\\TestCorp\\TestPlugin\""));
+    REQUIRE_THAT(admin_script, ContainsSubstring(
+        std::string("DeleteRegKey HKLM \"") + uninstall_key + "\""));
+
+    auto user = make_test_config();
+    user.per_user_install = true;
+    auto user_script = generate_nsis_script(user);
+
+    REQUIRE_THAT(user_script, ContainsSubstring("DeleteRegKey HKCU \"Software\\TestCorp\\TestPlugin\""));
+    REQUIRE_THAT(user_script, ContainsSubstring(
+        std::string("DeleteRegKey HKCU \"") + uninstall_key + "\""));
 }
 
 TEST_CASE("NSIS script includes directory selection page", "[ship][installer]") {


### PR DESCRIPTION
## Summary
- add NSIS installer coverage for Add/Remove Programs registry metadata
- cover HKLM/HKCU uninstall key deletion paths for admin and per-user installs

Refs #641

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_HIGHWAY=... -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=...`
- `cmake --build build --target pulp-test-nsis-installer -j$(sysctl -n hw.ncpu)`
- `ctest --test-dir build -R "NSIS script" --output-on-failure` (14/14)
- `git diff --check HEAD^..HEAD`
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report`
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
