### PR TITLE
test(platform): cover environment edge helpers

### DIFF
--- a/test/test_environment.cpp
+++ b/test/test_environment.cpp
@@ -54,6 +54,39 @@ TEST_CASE("Environment: empty listener subscription is inert",
     REQUIRE(s.color_scheme == ColorScheme::dark);
 }
 
+TEST_CASE("EnvironmentChange: any reflects individual flags",
+          "[environment][issue-640]") {
+    EnvironmentChange change;
+    REQUIRE_FALSE(change.any());
+
+    change.display = true;
+    REQUIRE(change.any());
+
+    change = {};
+    change.safe_area = true;
+    REQUIRE(change.any());
+
+    change = {};
+    change.keyboard = true;
+    REQUIRE(change.any());
+
+    change = {};
+    change.orientation = true;
+    REQUIRE(change.any());
+
+    change = {};
+    change.color_scheme = true;
+    REQUIRE(change.any());
+
+    change = {};
+    change.lifecycle = true;
+    REQUIRE(change.any());
+
+    change = {};
+    change.memory_pressure = true;
+    REQUIRE(change.any());
+}
+
 TEST_CASE("Environment: subscribe receives publish + correct change mask",
           "[environment]") {
     Environment::reset_for_test();
@@ -97,6 +130,25 @@ TEST_CASE("Environment: token RAII unsubscribes", "[environment]") {
 
     Environment::inject_for_test(make_state(ColorScheme::light));
     REQUIRE(calls == 1);
+}
+
+TEST_CASE("Environment: reset clears listeners held by live tokens",
+          "[environment][issue-640]") {
+    Environment::reset_for_test();
+    int calls = 0;
+    auto token = Environment::instance().subscribe(
+        [&](const EnvironmentState&, EnvironmentChange) { ++calls; });
+    REQUIRE(token.valid());
+
+    Environment::reset_for_test();
+    Environment::inject_for_test(make_state(ColorScheme::dark));
+    REQUIRE(calls == 0);
+
+    token.reset();
+    REQUIRE_FALSE(token.valid());
+
+    Environment::inject_for_test(make_state(ColorScheme::light));
+    REQUIRE(calls == 0);
 }
 
 TEST_CASE("Environment: token move transfers ownership", "[environment]") {


### PR DESCRIPTION
## Summary
- cover EnvironmentChange::any individual flags
- cover Environment::reset_for_test clearing live-token listeners

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF with local Mbed TLS source override
- cmake --build build --target pulp-test-environment pulp-test-platform --parallel 4
- ctest --test-dir build -R "^(Platform detection|Apple-specific detection|Environment)" --output-on-failure
- git diff --check origin/main..HEAD

Refs #640
Refs #641
