### PR TITLE
test(runtime): cover stream edge paths

### DIFF
--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -200,6 +200,59 @@ TEST_CASE("AsyncStream cancel drains queue even before worker starts", "[async_s
     REQUIRE(stream.pending_write_bytes() == 0);
 }
 
+TEST_CASE("AsyncStream zero-byte write dispatches completion without worker", "[async_stream]") {
+    auto backing = std::make_unique<TestStream>();
+
+    std::mutex m;
+    std::vector<std::function<void()>> queued;
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    opts.executor = [&](std::function<void()> fn) {
+        std::lock_guard<std::mutex> lock(m);
+        queued.push_back(std::move(fn));
+    };
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<bool> done{false};
+    std::atomic<std::size_t> bytes{99};
+    std::atomic<StreamError> error{StreamError::Closed};
+    REQUIRE(stream.write_async(nullptr, 0, [&](std::size_t n, StreamError err) {
+        bytes.store(n);
+        error.store(err);
+        done.store(true);
+    }));
+    REQUIRE(stream.pending_write_bytes() == 0);
+    REQUIRE_FALSE(done.load());
+
+    std::vector<std::function<void()>> to_run;
+    {
+        std::lock_guard<std::mutex> lock(m);
+        REQUIRE(queued.size() == 1);
+        to_run.swap(queued);
+    }
+    to_run.front()();
+
+    REQUIRE(done.load());
+    REQUIRE(bytes.load() == 0);
+    REQUIRE(error.load() == StreamError::Ok);
+}
+
+TEST_CASE("CancellationToken sharing and idempotent cancel", "[async_stream]") {
+    CancellationToken token;
+    CancellationToken copy = token;
+    CancellationToken other;
+
+    REQUIRE(token.shares(copy));
+    REQUIRE_FALSE(token.shares(other));
+    REQUIRE_FALSE(copy.is_cancelled());
+
+    token.cancel();
+    token.cancel();
+    REQUIRE(token.is_cancelled());
+    REQUIRE(copy.is_cancelled());
+    REQUIRE_FALSE(other.is_cancelled());
+}
+
 TEST_CASE("AsyncStream executor routes callbacks off worker", "[async_stream]") {
     auto backing = std::make_unique<TestStream>();
     auto* raw = backing.get();

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -77,6 +77,44 @@ TEST_CASE("MemoryStream close rejects further I/O", "[stream]") {
     REQUIRE(w.closed());
 }
 
+TEST_CASE("MemoryStream zero-size, rewind, and clear edge paths", "[stream]") {
+    MemoryStream s(std::vector<std::uint8_t>{7, 8, 9});
+    std::uint8_t out[3]{};
+
+    auto zero_read = s.read(out, 0);
+    REQUIRE(zero_read.ok());
+    REQUIRE(zero_read.bytes == 0);
+    REQUIRE(s.read_position() == 0);
+
+    auto first = s.read(out, 2);
+    REQUIRE(first.ok());
+    REQUIRE(first.bytes == 2);
+    REQUIRE(s.read_position() == 2);
+
+    s.rewind();
+    REQUIRE(s.read_position() == 0);
+    auto replay = s.read(out, sizeof(out));
+    REQUIRE(replay.ok());
+    REQUIRE(replay.bytes == 3);
+    REQUIRE(out[0] == 7);
+    REQUIRE(out[1] == 8);
+    REQUIRE(out[2] == 9);
+
+    const std::uint8_t payload[] = {1, 2};
+    auto zero_write = s.write(payload, 0);
+    REQUIRE(zero_write.ok());
+    REQUIRE(zero_write.bytes == 0);
+    REQUIRE(s.size() == 3);
+
+    s.clear();
+    REQUIRE(s.is_open());
+    REQUIRE(s.size() == 0);
+    REQUIRE(s.read_position() == 0);
+    auto eof = s.read(out, sizeof(out));
+    REQUIRE_FALSE(eof.ok());
+    REQUIRE(eof.closed());
+}
+
 TEST_CASE("FileStream round-trip via filesystem", "[stream]") {
     auto path = make_temp_path("pulp_stream");
     const std::uint8_t payload[] = {'p', 'u', 'l', 'p', 0, 1, 2, 3};
@@ -104,6 +142,41 @@ TEST_CASE("FileStream round-trip via filesystem", "[stream]") {
         auto eof = r.read(tail, sizeof(tail));
         REQUIRE_FALSE(eof.ok());
         REQUIRE(eof.closed());
+    }
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("FileStream append and move keep handle ownership correct", "[stream]") {
+    auto path = make_temp_path("pulp_stream_append");
+    const std::uint8_t first[] = {'a', 'b'};
+    const std::uint8_t second[] = {'c', 'd', 'e'};
+
+    {
+        FileStream w(path.string(), FileStream::Mode::Write);
+        REQUIRE(w.write(first, sizeof(first)).bytes == sizeof(first));
+        REQUIRE(w.flush());
+    }
+
+    {
+        FileStream appender(path.string(), FileStream::Mode::Append);
+        REQUIRE(appender.is_open());
+        FileStream moved(std::move(appender));
+        REQUIRE_FALSE(appender.is_open());
+        REQUIRE(moved.is_open());
+        auto wrote = moved.write(second, sizeof(second));
+        REQUIRE(wrote.ok());
+        REQUIRE(wrote.bytes == sizeof(second));
+        REQUIRE(moved.flush());
+    }
+
+    {
+        FileStream r(path.string(), FileStream::Mode::Read);
+        std::uint8_t out[sizeof(first) + sizeof(second)]{};
+        auto got = r.read(out, sizeof(out));
+        REQUIRE(got.ok());
+        REQUIRE(got.bytes == sizeof(out));
+        REQUIRE(std::memcmp(out, "abcde", sizeof(out)) == 0);
     }
 
     std::filesystem::remove(path);


### PR DESCRIPTION
## Summary
- cover MemoryStream zero-size/rewind/clear edge paths
- cover FileStream append and move handle ownership
- cover AsyncStream zero-byte completion dispatch and CancellationToken sharing

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=OFF with local Mbed TLS source override
- cmake --build build --target pulp-test-stream pulp-test-async-stream --parallel 4
- ctest --test-dir build -R "MemoryStream|FileStream|Stream polymorphic|AsyncStream|CancellationToken" --output-on-failure
- git diff --check origin/main..HEAD

Refs #641
