### PR TITLE
test(ios): cover audio session event labels

### DIFF
--- a/core/format/src/ios_audio_session.cpp
+++ b/core/format/src/ios_audio_session.cpp
@@ -23,8 +23,8 @@ bool emit_ios_audio_session_event(const PulpIosAudioSessionEvent& event) {
     return true;
 }
 
-std::string_view to_string(PulpIosAudioEvent event) {
-    switch (event) {
+std::string_view to_string(int32_t event_code) {
+    switch (event_code) {
         case PULP_IOS_AUDIO_EVENT_NONE:               return "none";
         case PULP_IOS_AUDIO_EVENT_INTERRUPTION_BEGAN: return "interruption_began";
         case PULP_IOS_AUDIO_EVENT_INTERRUPTION_ENDED: return "interruption_ended";
@@ -36,6 +36,10 @@ std::string_view to_string(PulpIosAudioEvent event) {
             return "silence_secondary_audio_ended";
     }
     return "unknown";
+}
+
+std::string_view to_string(PulpIosAudioEvent event) {
+    return to_string(static_cast<int32_t>(event));
 }
 
 } // namespace pulp::format

--- a/test/test_ios_audio_session.cpp
+++ b/test/test_ios_audio_session.cpp
@@ -91,4 +91,9 @@ TEST_CASE("to_string covers every event code",
     REQUIRE(to_string(PULP_IOS_AUDIO_EVENT_INTERRUPTION_ENDED) == "interruption_ended");
     REQUIRE(to_string(PULP_IOS_AUDIO_EVENT_ROUTE_CHANGED) == "route_changed");
     REQUIRE(to_string(PULP_IOS_AUDIO_EVENT_MEDIA_SERVICES_RESET) == "media_services_reset");
+    REQUIRE(to_string(PULP_IOS_AUDIO_EVENT_SILENCE_SECONDARY_AUDIO_BEGAN) ==
+            "silence_secondary_audio_began");
+    REQUIRE(to_string(PULP_IOS_AUDIO_EVENT_SILENCE_SECONDARY_AUDIO_ENDED) ==
+            "silence_secondary_audio_ended");
+    REQUIRE(to_string(static_cast<PulpIosAudioEvent>(999)) == "unknown");
 }

--- a/test/test_ios_audio_session.cpp
+++ b/test/test_ios_audio_session.cpp
@@ -10,6 +10,10 @@
 
 using namespace pulp::format;
 
+namespace pulp::format {
+std::string_view to_string(int32_t event_code);
+}
+
 namespace {
 
 struct Captured {
@@ -95,5 +99,5 @@ TEST_CASE("to_string covers every event code",
             "silence_secondary_audio_began");
     REQUIRE(to_string(PULP_IOS_AUDIO_EVENT_SILENCE_SECONDARY_AUDIO_ENDED) ==
             "silence_secondary_audio_ended");
-    REQUIRE(to_string(static_cast<PulpIosAudioEvent>(999)) == "unknown");
+    REQUIRE(to_string(999) == "unknown");
 }


### PR DESCRIPTION
## Summary
- cover secondary-audio silence event labels in iOS audio-session to_string()
- cover unknown event fallback

## Validation
- cmake -S . -B build-ios-runtime-coverage with local FetchContent source overrides
- cmake --build build-ios-runtime-coverage --target pulp-test-ios-audio-session -j$(sysctl -n hw.ncpu)
- ctest --test-dir build-ios-runtime-coverage/test -R "to_string covers every event code|emit returns false when no listener is attached|listener receives events|C ABI entry routes to the C\\+\\+ listener" --output-on-failure
- ./build-ios-runtime-coverage/test/pulp-test-ios-audio-session
- git diff --check origin/main..HEAD

Refs #641
