### PR TITLE
test(android): cover accessibility delegate fallback

### DIFF
--- a/android/app/src/test/kotlin/com/pulp/accessibility/PulpAccessibilityDelegateTest.kt
+++ b/android/app/src/test/kotlin/com/pulp/accessibility/PulpAccessibilityDelegateTest.kt
@@ -1,0 +1,36 @@
+package com.pulp.accessibility
+
+import android.view.View
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import com.pulp.PulpApplication
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class PulpAccessibilityDelegateTest {
+    @Test
+    fun initializesAccessibilityEventWithSurfaceViewClassName() {
+        val delegate = PulpAccessibilityDelegate()
+        val host = mock<View>()
+        val event = mock<AccessibilityEvent>()
+
+        delegate.onInitializeAccessibilityEvent(host, event)
+
+        verify(event).className = "com.pulp.render.PulpSurfaceView"
+    }
+
+    @Test
+    fun performAccessibilityActionFallsBackWhenNativeBridgeIsUnavailable() {
+        assertFalse(PulpApplication.nativeLoaded)
+
+        val handled = PulpAccessibilityDelegate().performAccessibilityAction(
+            mock(),
+            AccessibilityNodeInfo.ACTION_CLICK,
+            null
+        )
+
+        assertFalse(handled)
+    }
+}


### PR DESCRIPTION
## Summary
- add Android JVM coverage for accessibility event class-name initialization
- cover accessibility action fallback when the native bridge is unavailable

## Validation
- git diff --check origin/main..HEAD
- pre-push version and skill gates passed after adding the test-only Android skill skip metadata

Local Gradle note: `./gradlew :app:testDebugUnitTest --tests 'com.pulp.accessibility.PulpAccessibilityDelegateTest'` could not start in this environment because no Java Runtime is installed (`Unable to locate a Java Runtime`). Hosted Android JVM CI is the first executable validation for this tranche.

Refs #641
