### PR TITLE
test(host): cover plugin bundle suffix helper

### DIFF
--- a/test/test_plugin_info_metadata.cpp
+++ b/test/test_plugin_info_metadata.cpp
@@ -145,3 +145,24 @@ TEST_CASE("PluginFormat enum covers the 5 shipping formats",
         REQUIRE(p.format == f);
     }
 }
+
+TEST_CASE("PluginScanner identifies bundle suffixes for each host format",
+          "[host][plugin-info][format]") {
+    REQUIRE(PluginScanner::is_plugin_bundle("/Library/Audio/Plug-Ins/VST3/Test.vst3",
+                                            PluginFormat::VST3));
+    REQUIRE(PluginScanner::is_plugin_bundle("/Library/Audio/Plug-Ins/Components/Test.component",
+                                            PluginFormat::AudioUnit));
+    REQUIRE(PluginScanner::is_plugin_bundle("/Applications/Synth.app/PlugIns/Test.component",
+                                            PluginFormat::AudioUnitV3));
+    REQUIRE(PluginScanner::is_plugin_bundle("/Library/Audio/Plug-Ins/CLAP/Test.clap",
+                                            PluginFormat::CLAP));
+    REQUIRE(PluginScanner::is_plugin_bundle("/usr/lib/lv2/Test.lv2",
+                                            PluginFormat::LV2));
+
+    REQUIRE_FALSE(PluginScanner::is_plugin_bundle("/tmp/Test.vst3.backup",
+                                                  PluginFormat::VST3));
+    REQUIRE_FALSE(PluginScanner::is_plugin_bundle("/tmp/Test.component",
+                                                  PluginFormat::CLAP));
+    REQUIRE_FALSE(PluginScanner::is_plugin_bundle("/tmp/Test.clap",
+                                                  PluginFormat::LV2));
+}


### PR DESCRIPTION
## Summary
- cover PluginScanner::is_plugin_bundle suffix matching for VST3, AUv2, AUv3, CLAP, and LV2
- cover negative suffix and format-mismatch cases

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF with local FetchContent source overrides
- cmake --build build --target pulp-test-plugin-info-metadata -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-plugin-info-metadata
- ctest --test-dir build -R "PluginInfo|PluginFormat|PluginScanner" --output-on-failure
- git diff --check origin/main..HEAD

Refs #493
Refs #641
