### PR TITLE
feat(view): add canvasSetTransform / canvasClip / canvasGlobalCompositeOperation (#896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0471"></a>
+## [0.48.0]
+
 ## [0.47.1] - 2026-04-25
 
 - fix(project): close standalone bump edge cases ([#770](https://github.com/danielraffel/pulp/pull/770))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.47.1
+    VERSION 0.48.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -191,8 +191,25 @@ public:
     virtual void scale(float sx, float sy) = 0;
     virtual void rotate(float radians) = 0;
 
+    /// Replace the current transform with the affine matrix
+    /// [ a c e ]
+    /// [ b d f ]
+    /// [ 0 0 1 ]
+    /// Mirrors CanvasRenderingContext2D.setTransform(a, b, c, d, e, f).
+    /// Default implementation is a no-op so non-GPU backends still compile;
+    /// SkiaCanvas overrides with a full SkMatrix replace.
+    virtual void set_transform(float a, float b, float c,
+                               float d, float e, float f) {
+        (void)a; (void)b; (void)c; (void)d; (void)e; (void)f;
+    }
+
     // ── Clipping ─────────────────────────────────────────────────────────
     virtual void clip_rect(float x, float y, float w, float h) = 0;
+
+    /// Intersect the current clip region with the current path.
+    /// Mirrors CanvasRenderingContext2D.clip(). Default no-op so
+    /// backends without a path builder remain unaffected.
+    virtual void clip() {}
 
     // ── Fill and stroke style ────────────────────────────────────────────
     virtual void set_fill_color(Color c) = 0;
@@ -227,10 +244,29 @@ public:
     virtual void clear_fill_gradient() {}
 
     // ── Blend modes ─────────────────────────────────────────────────────
+    /// Indices 0..15 match the existing W3C "advanced" composite ops and
+    /// must stay stable — set_blend_mode in the JS bridge currently
+    /// passes int_val 1/2/3 = multiply/screen/overlay. Indices 16+ are
+    /// Porter-Duff and "extra" CSS composite ops added so the JS bridge
+    /// can support the full CanvasRenderingContext2D.globalCompositeOperation
+    /// surface (issue-896).
     enum class BlendMode {
-        normal, multiply, screen, overlay, darken, lighten,
+        // Advanced (separable & non-separable W3C blend modes)
+        normal = 0, multiply, screen, overlay, darken, lighten,
         color_dodge, color_burn, hard_light, soft_light,
-        difference, exclusion, hue, saturation, color, luminosity
+        difference, exclusion, hue, saturation, color, luminosity,
+        // Porter-Duff compositing modes (issue-896)
+        source_over,        // 16 — alias for normal/source-over (CSS default)
+        destination_over,   // 17
+        source_in,          // 18
+        destination_in,     // 19
+        source_out,         // 20
+        destination_out,    // 21
+        source_atop,        // 22
+        destination_atop,   // 23
+        xor_mode,           // 24 — "xor" CSS string
+        copy,               // 25
+        lighter             // 26 — additive ("plus" / SVG kPlus)
     };
 
     /// Set the compositing blend mode for subsequent draw operations.
@@ -521,6 +557,7 @@ struct DrawCommand {
     enum class Type {
         save, restore,
         translate, scale, rotate, clip_rect,
+        set_transform, clip, set_blend_mode,    // issue-896
         set_fill_color, set_stroke_color, set_line_width,
         set_line_cap, set_line_join,
         fill_rect, stroke_rect, fill_rounded_rect, stroke_rounded_rect,
@@ -549,7 +586,11 @@ public:
     void translate(float x, float y) override;
     void scale(float sx, float sy) override;
     void rotate(float radians) override;
+    void set_transform(float a, float b, float c,
+                       float d, float e, float f) override;
     void clip_rect(float x, float y, float w, float h) override;
+    void clip() override;
+    void set_blend_mode(BlendMode mode) override;
     void set_fill_color(Color c) override;
     void set_stroke_color(Color c) override;
     void set_line_width(float w) override;

--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -39,9 +39,12 @@ public:
     void translate(float x, float y) override;
     void scale(float sx, float sy) override;
     void rotate(float radians) override;
+    void set_transform(float a, float b, float c,
+                       float d, float e, float f) override;
 
     // ── Clipping ─────────────────────────────────────────────────────────
     void clip_rect(float x, float y, float w, float h) override;
+    void clip() override;
 
     // ── Fill and stroke ──────────────────────────────────────────────────
     void set_fill_color(Color c) override;

--- a/core/canvas/src/recording_canvas.cpp
+++ b/core/canvas/src/recording_canvas.cpp
@@ -35,9 +35,27 @@ void RecordingCanvas::rotate(float radians) {
     commands_.push_back(cmd);
 }
 
+void RecordingCanvas::set_transform(float a, float b, float c,
+                                    float d, float e, float f) {
+    DrawCommand cmd{DrawCommand::Type::set_transform};
+    cmd.f[0] = a; cmd.f[1] = b; cmd.f[2] = c;
+    cmd.f[3] = d; cmd.f[4] = e; cmd.f[5] = f;
+    commands_.push_back(cmd);
+}
+
 void RecordingCanvas::clip_rect(float x, float y, float w, float h) {
     DrawCommand cmd{DrawCommand::Type::clip_rect};
     cmd.f[0] = x; cmd.f[1] = y; cmd.f[2] = w; cmd.f[3] = h;
+    commands_.push_back(cmd);
+}
+
+void RecordingCanvas::clip() {
+    commands_.push_back({DrawCommand::Type::clip});
+}
+
+void RecordingCanvas::set_blend_mode(BlendMode mode) {
+    DrawCommand cmd{DrawCommand::Type::set_blend_mode};
+    cmd.f[0] = static_cast<float>(static_cast<int>(mode));
     commands_.push_back(cmd);
 }
 

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -173,9 +173,30 @@ void SkiaCanvas::rotate(float radians) {
     canvas_->rotate(radians * 180.0f / 3.14159265f);
 }
 
+void SkiaCanvas::set_transform(float a, float b, float c,
+                               float d, float e, float f) {
+    GUARD_CANVAS;
+    // CanvasRenderingContext2D.setTransform uses the column-major form
+    //   [a c e]   [scaleX skewY translateX]
+    //   [b d f] = [skewX  scaleY translateY]
+    //   [0 0 1]
+    // SkMatrix::MakeAll takes row-major (sx, kx, tx, ky, sy, ty, p0, p1, p2).
+    canvas_->setMatrix(SkMatrix::MakeAll(a, c, e,
+                                          b, d, f,
+                                          0.0f, 0.0f, 1.0f));
+}
+
 void SkiaCanvas::clip_rect(float x, float y, float w, float h) {
     GUARD_CANVAS;
     canvas_->clipRect(SkRect::MakeXYWH(x, y, w, h));
+}
+
+void SkiaCanvas::clip() {
+    GUARD_CANVAS;
+    if (!path_builder_) return;
+    // Snapshot the path (don't detach — Canvas2D allows continued use of
+    // the same path after clip()) and intersect with the current clip.
+    canvas_->clipPath(path_builder_->snapshot(), /*doAntiAlias=*/true);
 }
 
 void SkiaCanvas::set_fill_color(Color c) { fill_color_ = c; }
@@ -529,15 +550,36 @@ void SkiaCanvas::clear_fill_gradient() {
 // ── Blend modes ─────────────────────────────────────────────────────────────
 
 void SkiaCanvas::set_blend_mode(BlendMode mode) {
+    // Indices 0..15 — advanced/W3C blend modes (must stay in sync with
+    // canvas.hpp BlendMode enum).
+    // Indices 16..26 — Porter-Duff compositing modes (issue-896).
     static const SkBlendMode map[] = {
         SkBlendMode::kSrcOver, SkBlendMode::kMultiply, SkBlendMode::kScreen,
         SkBlendMode::kOverlay, SkBlendMode::kDarken, SkBlendMode::kLighten,
         SkBlendMode::kColorDodge, SkBlendMode::kColorBurn, SkBlendMode::kHardLight,
         SkBlendMode::kSoftLight, SkBlendMode::kDifference, SkBlendMode::kExclusion,
         SkBlendMode::kHue, SkBlendMode::kSaturation, SkBlendMode::kColor,
-        SkBlendMode::kLuminosity
+        SkBlendMode::kLuminosity,
+        // Porter-Duff
+        SkBlendMode::kSrcOver,    // 16 source_over (CSS default alias)
+        SkBlendMode::kDstOver,    // 17 destination_over
+        SkBlendMode::kSrcIn,      // 18 source_in
+        SkBlendMode::kDstIn,      // 19 destination_in
+        SkBlendMode::kSrcOut,     // 20 source_out
+        SkBlendMode::kDstOut,     // 21 destination_out
+        SkBlendMode::kSrcATop,    // 22 source_atop
+        SkBlendMode::kDstATop,    // 23 destination_atop
+        SkBlendMode::kXor,        // 24 xor
+        SkBlendMode::kSrc,        // 25 copy
+        SkBlendMode::kPlus        // 26 lighter
     };
-    blend_mode_ = map[static_cast<int>(mode)];
+    int idx = static_cast<int>(mode);
+    constexpr int count = static_cast<int>(sizeof(map) / sizeof(map[0]));
+    if (idx < 0 || idx >= count) {
+        blend_mode_ = SkBlendMode::kSrcOver;
+        return;
+    }
+    blend_mode_ = map[idx];
 }
 
 // ── Path building ───────────────────────────────────────────────────────────

--- a/core/view/include/pulp/view/canvas_widget.hpp
+++ b/core/view/include/pulp/view/canvas_widget.hpp
@@ -35,6 +35,8 @@ struct CanvasDrawCmd {
         save, restore,
         // Transform
         translate, scale, rotate, clip_rect,
+        set_transform,             // issue-896: replace transform with affine matrix
+        clip,                      // issue-896: intersect clip with current path
         // Image
         draw_image,
         // Clear

--- a/core/view/src/canvas_widget.cpp
+++ b/core/view/src/canvas_widget.cpp
@@ -140,6 +140,15 @@ void CanvasWidget::paint(canvas::Canvas& canvas) {
             // Clip to current path (fill_current_path sets the clip)
             canvas.clip_rect(cmd.x, cmd.y, cmd.w, cmd.h); // fallback
             break;
+        case CanvasDrawCmd::Type::set_transform:
+            // Affine matrix laid out as cmd.x = a, cmd.y = b, cmd.w = c,
+            // cmd.h = d, cmd.x2 = e, cmd.y2 = f (issue-896).
+            canvas.set_transform(cmd.x, cmd.y, cmd.w, cmd.h, cmd.x2, cmd.y2);
+            break;
+        case CanvasDrawCmd::Type::clip:
+            // Intersect clip with current path (issue-896).
+            canvas.clip();
+            break;
 
         // Arc
         case CanvasDrawCmd::Type::stroke_arc:

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -3354,16 +3354,89 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
-    // P3: Canvas globalCompositeOperation (blend mode)
-    engine_.register_function("canvasSetBlendMode", [this](choc::javascript::ArgumentList args) {
+    // CSS globalCompositeOperation → Canvas::BlendMode index. Returns -1
+    // for unknown strings so callers can no-op gracefully (issue-896).
+    auto cssCompositeOpToBlendModeIndex = [](const std::string& mode) -> int {
+        // Indices below MUST match Canvas::BlendMode in core/canvas/include/pulp/canvas/canvas.hpp.
+        if (mode == "source-over")      return 16; // also accepted at index 0 (normal)
+        if (mode == "destination-over") return 17;
+        if (mode == "source-in")        return 18;
+        if (mode == "destination-in")   return 19;
+        if (mode == "source-out")       return 20;
+        if (mode == "destination-out")  return 21;
+        if (mode == "source-atop")      return 22;
+        if (mode == "destination-atop") return 23;
+        if (mode == "xor")              return 24;
+        if (mode == "copy")             return 25;
+        if (mode == "lighter")          return 26;
+        // W3C advanced blend modes (indices match enum order)
+        if (mode == "multiply")     return 1;
+        if (mode == "screen")       return 2;
+        if (mode == "overlay")      return 3;
+        if (mode == "darken")       return 4;
+        if (mode == "lighten")      return 5;
+        if (mode == "color-dodge")  return 6;
+        if (mode == "color-burn")   return 7;
+        if (mode == "hard-light")   return 8;
+        if (mode == "soft-light")   return 9;
+        if (mode == "difference")   return 10;
+        if (mode == "exclusion")    return 11;
+        if (mode == "hue")          return 12;
+        if (mode == "saturation")   return 13;
+        if (mode == "color")        return 14;
+        if (mode == "luminosity")   return 15;
+        return -1; // unknown — caller treats as no-op
+    };
+
+    // P3: Canvas globalCompositeOperation (blend mode) — back-compat alias
+    engine_.register_function("canvasSetBlendMode", [this, cssCompositeOpToBlendModeIndex](choc::javascript::ArgumentList args) {
         if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {
-            CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::set_blend_mode;
             auto mode = args.get<std::string>(1, "source-over");
-            // Map CSS composite operation names to Canvas::BlendMode enum
-            if (mode == "multiply") cmd.int_val = 1;
-            else if (mode == "screen") cmd.int_val = 2;
-            else if (mode == "overlay") cmd.int_val = 3;
-            else cmd.int_val = 0; // source_over
+            int idx = cssCompositeOpToBlendModeIndex(mode);
+            if (idx < 0) return choc::value::Value(); // unknown string → no-op
+            CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::set_blend_mode;
+            cmd.int_val = idx;
+            c->add_command(cmd);
+        }
+        return choc::value::Value();
+    });
+
+    // canvasGlobalCompositeOperation — full CanvasRenderingContext2D
+    // globalCompositeOperation surface (issue-896). Accepts every standard
+    // CSS string and falls back to no-op on unknown values.
+    engine_.register_function("canvasGlobalCompositeOperation", [this, cssCompositeOpToBlendModeIndex](choc::javascript::ArgumentList args) {
+        if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {
+            auto mode = args.get<std::string>(1, "source-over");
+            int idx = cssCompositeOpToBlendModeIndex(mode);
+            if (idx < 0) return choc::value::Value(); // unknown — graceful no-op
+            CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::set_blend_mode;
+            cmd.int_val = idx;
+            c->add_command(cmd);
+        }
+        return choc::value::Value();
+    });
+
+    // canvasSetTransform(id, a, b, c, d, e, f) — replace current transform
+    // with the affine matrix (issue-896). Used for devicePixelRatio scaling
+    // (ctx.setTransform(scale, 0, 0, scale, 0, 0)) and Spectr FilterBank.
+    engine_.register_function("canvasSetTransform", [this](choc::javascript::ArgumentList args) {
+        if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {
+            CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::set_transform;
+            cmd.x  = (float)args.get<double>(1, 1.0); // a (scaleX)
+            cmd.y  = (float)args.get<double>(2, 0.0); // b (skewY)
+            cmd.w  = (float)args.get<double>(3, 0.0); // c (skewX)
+            cmd.h  = (float)args.get<double>(4, 1.0); // d (scaleY)
+            cmd.x2 = (float)args.get<double>(5, 0.0); // e (translateX)
+            cmd.y2 = (float)args.get<double>(6, 0.0); // f (translateY)
+            c->add_command(cmd);
+        }
+        return choc::value::Value();
+    });
+
+    // canvasClip(id) — intersect clip region with current path (issue-896).
+    engine_.register_function("canvasClip", [this](choc::javascript::ArgumentList args) {
+        if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {
+            CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::clip;
             c->add_command(cmd);
         }
         return choc::value::Value();

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/canvas/canvas.hpp>
 #include <pulp/view/canvas_widget.hpp>
 #include <pulp/view/modal.hpp>
 #include <pulp/view/text_editor.hpp>
@@ -982,4 +983,154 @@ TEST_CASE("WidgetBridge __gpuComputeDispatchImpl tolerates malformed bufferDataB
             }
         }));
     )"));
+}
+
+// ── canvasSetTransform / canvasClip / canvasGlobalCompositeOperation (issue-896) ──
+//
+// These three CanvasRenderingContext2D bridge functions are exercised end-to-end:
+// the JS bridge records a CanvasDrawCmd, and CanvasWidget::paint() replays each
+// command on a pulp::canvas::RecordingCanvas, which lets us assert on the
+// resulting Canvas-API call sequence.
+namespace {
+static pulp::view::CanvasWidget* canvasFromBridge(pulp::view::WidgetBridge& bridge,
+                                                  pulp::view::ScriptEngine& engine,
+                                                  const std::string& id) {
+    auto value = engine.evaluate("document.getElementById('" + id + "')._id");
+    auto nativeId = std::string(value.getWithDefault<std::string_view>(""));
+    return dynamic_cast<pulp::view::CanvasWidget*>(bridge.widget(nativeId));
+}
+} // namespace
+
+TEST_CASE("WidgetBridge canvasSetTransform records affine matrix and replays via setMatrix",
+          "[view][bridge][canvas][issue-896]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'xform-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        // Bypass the prelude — the bridge function is the unit under test.
+        canvasSetTransform(c._id, 2.0, 0.0, 0.0, 3.0, 17.0, 23.0);
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "xform-canvas");
+    REQUIRE(canvas != nullptr);
+    REQUIRE(canvas->command_count() >= 1);
+
+    pulp::canvas::RecordingCanvas rec;
+    canvas->paint(rec);
+
+    bool sawSetTransform = false;
+    for (auto& cmd : rec.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::set_transform) {
+            REQUIRE_THAT(cmd.f[0], WithinAbs(2.0f, 1e-5f));
+            REQUIRE_THAT(cmd.f[1], WithinAbs(0.0f, 1e-5f));
+            REQUIRE_THAT(cmd.f[2], WithinAbs(0.0f, 1e-5f));
+            REQUIRE_THAT(cmd.f[3], WithinAbs(3.0f, 1e-5f));
+            REQUIRE_THAT(cmd.f[4], WithinAbs(17.0f, 1e-5f));
+            REQUIRE_THAT(cmd.f[5], WithinAbs(23.0f, 1e-5f));
+            sawSetTransform = true;
+        }
+    }
+    REQUIRE(sawSetTransform);
+}
+
+TEST_CASE("WidgetBridge canvasClip records clip command and replays Canvas::clip()",
+          "[view][bridge][canvas][issue-896]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'clip-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+        canvasBeginPath(c._id);
+        canvasMoveTo(c._id, 10, 10);
+        canvasLineTo(c._id, 80, 10);
+        canvasLineTo(c._id, 80, 60);
+        canvasLineTo(c._id, 10, 60);
+        canvasClosePath(c._id);
+        canvasClip(c._id);
+        canvasRect(c._id, 0, 0, 200, 100, '#ff0000');
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "clip-canvas");
+    REQUIRE(canvas != nullptr);
+
+    pulp::canvas::RecordingCanvas rec;
+    canvas->paint(rec);
+
+    int clipIndex = -1;
+    int fillRectAfterClip = -1;
+    int idx = 0;
+    for (auto& cmd : rec.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::clip) clipIndex = idx;
+        if (cmd.type == pulp::canvas::DrawCommand::Type::fill_rect && clipIndex >= 0
+            && fillRectAfterClip < 0) {
+            fillRectAfterClip = idx;
+        }
+        ++idx;
+    }
+    REQUIRE(clipIndex >= 0);                  // canvasClip dispatched Canvas::clip()
+    REQUIRE(fillRectAfterClip > clipIndex);   // subsequent draws are still issued (clip applies, doesn't drop)
+}
+
+TEST_CASE("WidgetBridge canvasGlobalCompositeOperation maps CSS strings to BlendMode",
+          "[view][bridge][canvas][issue-896]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'comp-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+        canvasGlobalCompositeOperation(c._id, 'destination-out');
+        canvasGlobalCompositeOperation(c._id, 'multiply');
+        canvasGlobalCompositeOperation(c._id, 'lighter');
+        // Invalid string — must be a graceful no-op (no command emitted).
+        canvasGlobalCompositeOperation(c._id, 'not-a-real-blend-mode');
+        canvasGlobalCompositeOperation(c._id, 'source-over');
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "comp-canvas");
+    REQUIRE(canvas != nullptr);
+
+    pulp::canvas::RecordingCanvas rec;
+    canvas->paint(rec);
+
+    std::vector<int> blendIndices;
+    for (auto& cmd : rec.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::set_blend_mode) {
+            blendIndices.push_back(static_cast<int>(cmd.f[0]));
+        }
+    }
+
+    // 4 valid strings → 4 set_blend_mode commands; the bogus mode string
+    // emits nothing.
+    REQUIRE(blendIndices.size() == 4);
+    using BM = pulp::canvas::Canvas::BlendMode;
+    REQUIRE(blendIndices[0] == static_cast<int>(BM::destination_out));
+    REQUIRE(blendIndices[1] == static_cast<int>(BM::multiply));
+    REQUIRE(blendIndices[2] == static_cast<int>(BM::lighter));
+    REQUIRE(blendIndices[3] == static_cast<int>(BM::source_over));
 }


### PR DESCRIPTION
## Summary

Three Canvas2D APIs were missing from `widget_bridge.cpp`'s JS surface, breaking Spectr's FilterBank port through `@pulp/react` (#779):

- **`canvasSetTransform(id, a, b, c, d, e, f)`** — replaces the current transform matrix; powers devicePixelRatio scaling (`ctx.setTransform(scale, 0, 0, scale, 0, 0)` on every resize)
- **`canvasClip(id)`** — intersects the clip region with the current path
- **`canvasGlobalCompositeOperation(id, op)`** — sets the blend mode from a CSS string

The three ops were threaded through the full stack since the underlying primitives weren't exposed at the canvas layer yet:
`Canvas` / `SkiaCanvas` / `RecordingCanvas` → `CanvasWidget` → `WidgetBridge`.

The CSS-string → `SkBlendMode` mapping covers all 26 standard composite operations (`source-over`, `destination-out`, `multiply`, `screen`, `xor`, `lighter`, the source/destination-in/out/atop/over family, plus the separable + non-separable PorterDuff blends). Unknown strings are a graceful no-op.

Spec source: [Mystral Native's `Canvas2DContext`](https://github.com/danielraffel/mystralnative/blob/main/include/mystral/canvas/canvas2d.h#L52-L140) per the issue.

Closes #896. Refs: pulp #779, spectr #28.

## Test plan

`test/test_widget_bridge.cpp`, all green locally:

- [x] `WidgetBridge canvasSetTransform records affine matrix and replays via setMatrix` — 9 assertions
- [x] `WidgetBridge canvasClip records clip command and replays Canvas::clip()` — 3 assertions
- [x] `WidgetBridge canvasGlobalCompositeOperation maps CSS strings to BlendMode` — 6 assertions, including invalid-string no-op
- [x] No regressions in `pulp-test-canvas`, `pulp-test-canvas-widget`, `pulp-test-editor-bridge`, `pulp-test-widgets`
- [ ] Cross-platform validation via Namespace (Ubuntu / Windows lanes)

## Notes

- Local SSH `win` lane is currently unreachable; this PR's Windows validation is being routed through Namespace cloud runners instead. Mac validated locally.