### PR TITLE
fix(cmake): install binary-data encoder alongside PulpUtils.cmake (Codex P1 on #905)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -789,6 +789,18 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Pulp
 )
 
+# pulp_add_binary_data resolves its Python encoder via
+# ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/scripts/encode_binary_data.py — i.e.
+# adjacent to whichever PulpUtils.cmake is sourced. That works in the
+# source tree (tools/cmake/PulpUtils.cmake → tools/cmake/scripts/…) and
+# must keep working in the installed tree (lib/cmake/Pulp/PulpUtils.cmake
+# → lib/cmake/Pulp/scripts/…). Install the encoder alongside PulpUtils.cmake
+# so find_package(Pulp) consumers can use the function (issue-905 follow-up).
+install(FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/scripts/encode_binary_data.py"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Pulp/scripts
+)
+
 # Templates for standalone project scaffolding
 install(DIRECTORY tools/templates/
     DESTINATION templates

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,20 @@ set_tests_properties(cmake-pulp-add-binary-data-encoder PROPERTIES
     LABELS "cmake;binary-data;issue-898"
     TIMEOUT 60)
 
+# Install-layout regression for issue-905 follow-up: when the SDK is
+# installed via `cmake --install`, the Python encoder MUST be bundled
+# alongside PulpUtils.cmake so find_package(Pulp) consumers can call
+# pulp_add_binary_data without seeing a missing-script error. Runs
+# `cmake --install` against this build into a temp prefix and asserts
+# both PulpUtils.cmake and scripts/encode_binary_data.py are present.
+add_test(NAME cmake-pulp-install-layout
+    COMMAND ${CMAKE_COMMAND}
+        -DPULP_BUILD_DIR=${CMAKE_BINARY_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_pulp_install_layout.cmake)
+set_tests_properties(cmake-pulp-install-layout PROPERTIES
+    LABELS "cmake;binary-data;issue-905"
+    TIMEOUT 120)
+
 # retry_git_clone unit test (setup.sh helper). Guards the #425 P1
 # Codex fix — a partial clone target is scrubbed between retries so
 # attempt 2+ can actually re-run the network fetch.

--- a/test/cmake/test_pulp_install_layout.cmake
+++ b/test/cmake/test_pulp_install_layout.cmake
@@ -1,0 +1,101 @@
+#[[
+Install-layout regression for issue-905 follow-up.
+
+`pulp_add_binary_data` resolves its Python encoder via
+${CMAKE_CURRENT_FUNCTION_LIST_DIR}/scripts/encode_binary_data.py — adjacent
+to whichever `PulpUtils.cmake` is sourced. That convention only works in
+the installed tree if the encoder is bundled alongside `PulpUtils.cmake`
+under `lib/cmake/Pulp/scripts/`. If the install rule omits the encoder,
+downstream `find_package(Pulp)` consumers see asset targets fail at
+build time with a missing-script error.
+
+This test runs `cmake --install` against a pre-configured Pulp build
+into a temporary prefix, then asserts the bundled SDK contains both
+`PulpUtils.cmake` and its sibling `scripts/encode_binary_data.py`.
+
+Inputs (passed via -D):
+  PULP_BUILD_DIR — path to a configured Pulp build directory.
+]]
+
+cmake_minimum_required(VERSION 3.20)
+
+if(NOT DEFINED PULP_BUILD_DIR)
+    message(FATAL_ERROR
+        "test_pulp_install_layout.cmake requires -DPULP_BUILD_DIR=<dir> "
+        "pointing at a configured Pulp build.")
+endif()
+get_filename_component(PULP_BUILD_DIR "${PULP_BUILD_DIR}" ABSOLUTE)
+if(NOT EXISTS "${PULP_BUILD_DIR}/CMakeCache.txt")
+    message(FATAL_ERROR
+        "PULP_BUILD_DIR=${PULP_BUILD_DIR} is not a configured CMake build "
+        "directory (no CMakeCache.txt).")
+endif()
+
+set(_prefix "${CMAKE_CURRENT_BINARY_DIR}/pulp-install-layout-test-prefix")
+file(REMOVE_RECURSE "${_prefix}")
+file(MAKE_DIRECTORY "${_prefix}")
+
+# `cmake --install` re-emits the install rules from the configured build.
+# It does not re-invoke the build — only published outputs that were
+# already produced by the previous `cmake --build` step are copied. The
+# CMake-package files (PulpConfig.cmake, PulpUtils.cmake, …) are
+# generated at configure time, so they are always present.
+execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+            --install "${PULP_BUILD_DIR}"
+            --prefix  "${_prefix}"
+    RESULT_VARIABLE _rc
+    OUTPUT_VARIABLE _stdout
+    ERROR_VARIABLE  _stderr)
+if(NOT _rc EQUAL 0)
+    message(FATAL_ERROR
+        "cmake --install failed (rc=${_rc}):\n"
+        "----- stdout -----\n${_stdout}\n"
+        "----- stderr -----\n${_stderr}\n----- end -----")
+endif()
+
+# Locate the installed PulpUtils.cmake — Pulp installs into
+# ${CMAKE_INSTALL_LIBDIR}/cmake/Pulp, which is libdir/cmake/Pulp on
+# every platform. libdir varies (lib vs lib64); glob both.
+file(GLOB _pulp_utils LIST_DIRECTORIES false
+    "${_prefix}/lib*/cmake/Pulp/PulpUtils.cmake")
+if(NOT _pulp_utils)
+    message(FATAL_ERROR
+        "Installed PulpUtils.cmake not found under ${_prefix}/lib*/cmake/Pulp/.")
+endif()
+list(GET _pulp_utils 0 _pulp_utils)
+get_filename_component(_pulp_cmake_dir "${_pulp_utils}" DIRECTORY)
+
+# The encoder MUST live next to PulpUtils.cmake — this is the path
+# pulp_add_binary_data computes via CMAKE_CURRENT_FUNCTION_LIST_DIR.
+set(_installed_encoder "${_pulp_cmake_dir}/scripts/encode_binary_data.py")
+if(NOT EXISTS "${_installed_encoder}")
+    message(FATAL_ERROR
+        "Encoder script not bundled with the installed Pulp SDK.\n"
+        "Expected: ${_installed_encoder}\n"
+        "find_package(Pulp) consumers calling pulp_add_binary_data would "
+        "fail at build time with a missing-script error. The install rule "
+        "in CMakeLists.txt must publish "
+        "tools/cmake/scripts/encode_binary_data.py under "
+        "lib/cmake/Pulp/scripts/ (issue-905 follow-up).")
+endif()
+
+# Sanity: the script we shipped must be the same one we built against.
+file(SIZE "${_installed_encoder}" _installed_size)
+get_filename_component(_repo_root "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+set(_source_encoder "${_repo_root}/tools/cmake/scripts/encode_binary_data.py")
+if(NOT EXISTS "${_source_encoder}")
+    message(FATAL_ERROR
+        "Source encoder ${_source_encoder} not found — repo layout broken?")
+endif()
+file(SIZE "${_source_encoder}" _source_size)
+if(NOT _installed_size EQUAL _source_size)
+    message(FATAL_ERROR
+        "Installed encoder size (${_installed_size}) differs from "
+        "source encoder size (${_source_size}) — install rule may be "
+        "publishing a stale or different file.")
+endif()
+
+message(STATUS
+    "Install layout: PulpUtils.cmake at ${_pulp_utils}, encoder at "
+    "${_installed_encoder} (${_installed_size} bytes). All present.")

--- a/tools/cmake/PulpUtils.cmake
+++ b/tools/cmake/PulpUtils.cmake
@@ -1076,6 +1076,15 @@ function(pulp_add_binary_data target)
 
     set(_pulp_encoder
         "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/scripts/encode_binary_data.py")
+    if(NOT EXISTS "${_pulp_encoder}")
+        message(FATAL_ERROR
+            "pulp_add_binary_data: encode_binary_data.py not found at "
+            "${_pulp_encoder}.\n"
+            "If you're consuming Pulp via find_package(Pulp), the SDK install "
+            "should have placed the encoder alongside PulpUtils.cmake under "
+            "lib/cmake/Pulp/scripts/. Re-install Pulp or report a packaging "
+            "regression (issue-905).")
+    endif()
 
     set(generated_hpp "${CMAKE_CURRENT_BINARY_DIR}/${target}_data.hpp")
 


### PR DESCRIPTION
## Summary

Codex post-merge P1 follow-up to #905. `pulp_add_binary_data` resolves its Python encoder via `${CMAKE_CURRENT_FUNCTION_LIST_DIR}/scripts/encode_binary_data.py` — adjacent to `PulpUtils.cmake`. That works in the source tree but the install rule for the SDK only published `PulpUtils.cmake`, not the new `tools/cmake/scripts/encode_binary_data.py`. `find_package(Pulp)` consumers calling `pulp_add_binary_data` would fail at build time with a missing-script error.

## Fix

- Install `tools/cmake/scripts/encode_binary_data.py` to `${CMAKE_INSTALL_LIBDIR}/cmake/Pulp/scripts/encode_binary_data.py`, sibling to the installed `PulpUtils.cmake`. Same `CMAKE_CURRENT_FUNCTION_LIST_DIR/scripts/...` lookup now resolves in both source and installed trees with no code changes to the function.
- Add a defensive existence check at the top of `pulp_add_binary_data` so any future packaging regression fails fast at configure time with a clear error pointing at `lib/cmake/Pulp/scripts/`, instead of silently passing through to a missing-script error during the build.

## Test plan

- [x] New `cmake-pulp-install-layout` ctest (`test/cmake/test_pulp_install_layout.cmake`, label `issue-905`): runs `cmake --install` against the configured build into a temp prefix, asserts both `PulpUtils.cmake` and its sibling `scripts/encode_binary_data.py` are present, with byte sizes matching the source tree.
- [x] Existing `cmake-pulp-add-binary-data-encoder` smoke still passes.
- [ ] Cross-platform validation via Namespace.

## Reference

- Codex review on #905: https://github.com/danielraffel/pulp/pull/905#discussion_r3150536975

## Notes

Local SSH `win` lane is currently unreachable; cross-platform Windows validation is via Namespace.