### PR TITLE
feat(canvas2d): close API gaps — measureText, drawImage, setLineDash, getImageData, putImageData

### DIFF
--- a/.agents/skills/engine/SKILL.md
+++ b/.agents/skills/engine/SKILL.md
@@ -47,6 +47,19 @@ for React 18 dev. Add new files to `core/view/CMakeLists.txt`'s
 `core/view/src/widget_bridge.cpp` (`embed_js.cmake` only embeds the
 constants; the bridge constructor evaluates them).
 
+### Canvas2D surface coverage (issue-916)
+
+`web-compat-canvas.js` exposes `CanvasRenderingContext2D.prototype`
+with the standard methods plus the gap-list closures from issue-916:
+
+| Method | Notes |
+|--------|-------|
+| `measureText(text)` | Returns a full HTML5 `TextMetrics` object — `width` + `actualBoundingBox{Left,Right,Ascent,Descent}` + `fontBoundingBox{Ascent,Descent}`. Routed through `canvasMeasureText` which calls `SkiaCanvas::measure_text_with_font` for surface-less metrics. |
+| `drawImage(img, …)` | 3 / 5 / 9-arg signatures supported; the 9-arg `(sx,sy,sw,sh,dx,dy,dw,dh)` form currently ignores the source rect — file a follow-up if a plugin needs sprite-sheet slicing. |
+| `setLineDash([…])` / `getLineDash()` | Even-length patterns are taken verbatim; odd-length patterns are duplicated per the HTML5 spec. Phase comes from `lineDashOffset`. |
+| `getImageData(x,y,w,h)` | Returns `{data: Uint8ClampedArray, width, height}`. The bridge currently returns zero-filled pixels (no live surface handle from JS-call context); consumers that need real pixels should round-trip through a render-host integration. |
+| `putImageData(img, dx, dy)` | Decodes the typed array to base64 across the bridge and applies via `Canvas::write_pixels` on backends that implement it (Skia today). |
+
 ## Commands
 
 ### `status` — Show current engine configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0510"></a>
+## [0.52.0]
+
 ## [0.51.0] - 2026-04-28
 
 - feat(view): register web-API globals natively (#915) ([#918](https://github.com/danielraffel/pulp/pull/918))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.51.0
+    VERSION 0.52.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -379,11 +379,26 @@ public:
     virtual float measure_text(const std::string& text) = 0;
 
     /// Full text metrics for layout and intrinsic sizing.
+    /// Mirrors HTML5 TextMetrics — fields beyond width/ascent/descent are
+    /// the bounding-box-only metrics required by CanvasRenderingContext2D
+    /// (issue-916). All values are positive and in pixels at the current
+    /// font size.
     struct TextMetrics {
         float width = 0;        ///< Advance width of the text
-        float ascent = 0;       ///< Distance above baseline (positive value)
-        float descent = 0;      ///< Distance below baseline (positive value)
+        float ascent = 0;       ///< Distance above baseline (positive value, ==fontBoundingBoxAscent)
+        float descent = 0;      ///< Distance below baseline (positive value, ==fontBoundingBoxDescent)
         float line_height = 0;  ///< Recommended line spacing (ascent + descent + leading)
+
+        // ── HTML5 TextMetrics extensions (issue-916) ────────────────
+        /// Distance from text origin to the left edge of the rendering bounding box.
+        /// Positive when the bounding box extends left of the origin.
+        float actual_bounding_box_left = 0;
+        /// Distance from text origin to the right edge of the rendering bounding box.
+        float actual_bounding_box_right = 0;
+        /// Distance from baseline to top of the rendering bounding box.
+        float actual_bounding_box_ascent = 0;
+        /// Distance from baseline to bottom of the rendering bounding box.
+        float actual_bounding_box_descent = 0;
     };
 
     // ── SDF Text (GPU-accelerated, resolution-independent) ────────────
@@ -422,7 +437,46 @@ public:
         m.ascent = font_size_ * 0.75f;   // approximate
         m.descent = font_size_ * 0.25f;
         m.line_height = font_size_ * 1.2f;
+        // HTML5 TextMetrics fields (issue-916) — fall back to font-metric
+        // estimates when no shaped bounding box is available.
+        m.actual_bounding_box_left = 0;
+        m.actual_bounding_box_right = m.width;
+        m.actual_bounding_box_ascent = m.ascent;
+        m.actual_bounding_box_descent = m.descent;
         return m;
+    }
+
+    // ── Line Dash (issue-916) ──────────────────────────────────────────
+    /// Set the line dash pattern for stroke operations.
+    /// Mirrors CanvasRenderingContext2D.setLineDash().
+    /// `intervals` alternate "on" / "off" lengths in pixels. An empty
+    /// pattern (count == 0) clears the dash and reverts to solid strokes.
+    /// HTML5 spec: an odd-length pattern is duplicated to even length;
+    /// callers that want spec compliance must duplicate before invoking
+    /// this method (the JS bridge does so). Default no-op for backends
+    /// without dash support.
+    virtual void set_line_dash(const float* intervals, int count, float phase = 0.0f) {
+        (void)intervals; (void)count; (void)phase;
+    }
+
+    // ── Pixel manipulation (issue-916) ─────────────────────────────────
+    /// Read RGBA pixels from the current surface into `out` (size must be
+    /// at least width*height*4). Returns true on success. Default returns
+    /// false (RecordingCanvas, CG fallback) — only Skia raster surfaces
+    /// implement this end-to-end.
+    /// Mirrors CanvasRenderingContext2D.getImageData().
+    virtual bool read_pixels(int x, int y, int width, int height, uint8_t* out) {
+        (void)x; (void)y; (void)width; (void)height; (void)out;
+        return false;
+    }
+
+    /// Write RGBA pixels (`data` size = width*height*4) to the current
+    /// surface at destination (`dx`, `dy`). Returns true on success.
+    /// Mirrors CanvasRenderingContext2D.putImageData().
+    virtual bool write_pixels(const uint8_t* data, int width, int height,
+                              int dx, int dy) {
+        (void)data; (void)width; (void)height; (void)dx; (void)dy;
+        return false;
     }
 
     // ── SDF Shape Primitives (GPU-accelerated) ─────────────────────────
@@ -569,7 +623,11 @@ struct DrawCommand {
         set_line_cap, set_line_join,
         fill_rect, stroke_rect, fill_rounded_rect, stroke_rounded_rect,
         fill_circle, stroke_circle, stroke_arc, stroke_line,
-        set_font, set_text_align, fill_text
+        set_font, set_text_align, fill_text,
+        // ── issue-916: Canvas2D API gaps ──────────────────────────────
+        set_line_dash,      ///< intervals stored in `floats`, phase in f[0]
+        draw_image,         ///< source path/url in `text`, dst rect in f[0..3]
+        write_pixels        ///< RGBA bytes in `text` (binary), w/h in f[0..1], dst in f[2..3]
     };
 
     Type type;
@@ -577,6 +635,11 @@ struct DrawCommand {
     float f[6] = {};
     Color color{};
     std::string text;
+    // Optional variable-length payload — used by set_line_dash and
+    // write_pixels (which store raw bytes packed as floats / characters
+    // respectively). Kept off the default cmd to avoid bloating the
+    // happy path.
+    std::vector<float> floats;
 };
 
 class RecordingCanvas : public Canvas {
@@ -622,6 +685,17 @@ public:
     void set_text_align(TextAlign align) override;
     void fill_text(const std::string& text, float x, float y) override;
     float measure_text(const std::string& text) override;
+
+    // issue-916 — capture the new commands so JS-driven tests can assert
+    // on them via DrawCommand::Type::set_line_dash / draw_image /
+    // write_pixels. Source path is stored in DrawCommand::text.
+    void set_line_dash(const float* intervals, int count, float phase) override;
+    bool draw_image_from_data(const uint8_t* data, size_t size,
+                              float x, float y, float w, float h) override;
+    bool draw_image_from_file(const std::string& path,
+                              float x, float y, float w, float h) override;
+    bool write_pixels(const uint8_t* data, int width, int height,
+                      int dx, int dy) override;
 
 private:
     std::vector<DrawCommand> commands_;

--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -16,7 +16,9 @@ class SkPathBuilder;
 #include "include/core/SkRefCnt.h"
 #include "include/core/SkBlendMode.h"
 #include "include/core/SkMatrix.h"
+#include <vector>
 class SkShader;
+class SkPathEffect;
 
 namespace skgpu::graphite {
 class Recorder;
@@ -84,6 +86,12 @@ public:
                               float x, float y, float w, float h) override;
     bool draw_image_from_file(const std::string& path,
                                float x, float y, float w, float h) override;
+
+    // ── Line dash / pixel manipulation (issue-916) ─────────────────────
+    void set_line_dash(const float* intervals, int count, float phase) override;
+    bool read_pixels(int x, int y, int width, int height, uint8_t* out) override;
+    bool write_pixels(const uint8_t* data, int width, int height,
+                      int dx, int dy) override;
     void draw_waveform(const float* samples, size_t count,
                        float x, float y, float width, float height,
                        const WaveformStyle& style) override;
@@ -131,6 +139,14 @@ public:
                                   float w,
                                   float h);
 
+    // Standalone text measurement (issue-916). Returns full HTML5
+    // TextMetrics for `text` rendered with `family` at `size` pixels —
+    // no canvas instance required. Used by the JS bridge's
+    // canvasMeasureText so JS callers can pre-measure text for layout
+    // without needing an active draw surface.
+    static Canvas::TextMetrics measure_text_with_font(
+        const std::string& family, float size, const std::string& text);
+
     // Opacity & compositing layers
     void set_opacity(float alpha) override;
     void save_layer(float x, float y, float w, float h,
@@ -163,6 +179,12 @@ private:
     // screenshot host) that drive SkiaCanvas directly without going through
     // CanvasWidget — there setTransform behaves per the HTML spec literally.
     SkMatrix paint_baseline_ = SkMatrix::I();
+
+    // Line-dash pattern (issue-916). Empty == solid stroke (no dashing).
+    // Held as floats so the stroke-paint helper can rebuild the SkDashPathEffect
+    // each time stroke_color/line_width change.
+    std::vector<float> line_dash_;
+    float line_dash_phase_ = 0.0f;
 };
 
 } // namespace pulp::canvas

--- a/core/canvas/src/recording_canvas.cpp
+++ b/core/canvas/src/recording_canvas.cpp
@@ -169,6 +169,50 @@ float RecordingCanvas::measure_text(const std::string& text) {
     return static_cast<float>(text.size()) * 7.0f;
 }
 
+// ── issue-916: Canvas2D API gap closures ────────────────────────────────────
+
+void RecordingCanvas::set_line_dash(const float* intervals, int count, float phase) {
+    DrawCommand cmd{DrawCommand::Type::set_line_dash};
+    cmd.f[0] = phase;
+    cmd.floats.assign(intervals, intervals + (count > 0 ? count : 0));
+    commands_.push_back(std::move(cmd));
+}
+
+bool RecordingCanvas::draw_image_from_data(const uint8_t* data, size_t size,
+                                            float x, float y, float w, float h) {
+    DrawCommand cmd{DrawCommand::Type::draw_image};
+    cmd.f[0] = x; cmd.f[1] = y; cmd.f[2] = w; cmd.f[3] = h;
+    cmd.text.assign(reinterpret_cast<const char*>(data), size);
+    commands_.push_back(std::move(cmd));
+    // Recording backend doesn't actually rasterize anything but we
+    // succeeded at capturing the intent.
+    return true;
+}
+
+bool RecordingCanvas::draw_image_from_file(const std::string& path,
+                                            float x, float y, float w, float h) {
+    DrawCommand cmd{DrawCommand::Type::draw_image};
+    cmd.f[0] = x; cmd.f[1] = y; cmd.f[2] = w; cmd.f[3] = h;
+    cmd.text = path;
+    commands_.push_back(std::move(cmd));
+    return true;
+}
+
+bool RecordingCanvas::write_pixels(const uint8_t* data, int width, int height,
+                                    int dx, int dy) {
+    DrawCommand cmd{DrawCommand::Type::write_pixels};
+    cmd.f[0] = static_cast<float>(width);
+    cmd.f[1] = static_cast<float>(height);
+    cmd.f[2] = static_cast<float>(dx);
+    cmd.f[3] = static_cast<float>(dy);
+    if (data && width > 0 && height > 0) {
+        const size_t n = static_cast<size_t>(width) * static_cast<size_t>(height) * 4;
+        cmd.text.assign(reinterpret_cast<const char*>(data), n);
+    }
+    commands_.push_back(std::move(cmd));
+    return true;
+}
+
 // ── compile_sksl fallback for non-Skia builds ────────────────────────────────
 #ifndef PULP_HAS_SKIA
 std::string Canvas::compile_sksl(const std::string& sksl) {

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -19,10 +19,12 @@
 #include "include/core/SkColorSpace.h"
 #include "include/core/SkImage.h"
 #include "include/core/SkPixmap.h"
+#include "include/core/SkBitmap.h"
 #include "include/core/SkData.h"
 #include "include/core/SkSamplingOptions.h"
 #include "include/effects/SkRuntimeEffect.h"
 #include "include/effects/SkGradientShader.h"
+#include "include/effects/SkDashPathEffect.h"
 #include "runtime_effect_cache.hpp"
 #include "include/core/SkPathBuilder.h"
 #include "include/core/SkBlendMode.h"
@@ -223,8 +225,22 @@ void SkiaCanvas::fill_rect(float x, float y, float w, float h) {
     GUARD_CANVAS; canvas_->drawRect(SkRect::MakeXYWH(x, y, w, h), make_fill_paint(fill_color_));
 }
 
+// Apply the active line-dash pattern to a stroke paint (issue-916).
+// Skia's SkDashPathEffect requires an even-length pattern with
+// nonnegative entries; the JS bridge ensures both, so we treat any
+// validation failure as "no dash" rather than silently dropping it.
+static void apply_line_dash(SkPaint& paint,
+                             const std::vector<float>& intervals,
+                             float phase) {
+    if (intervals.size() < 2 || (intervals.size() % 2) != 0) return;
+    paint.setPathEffect(SkDashPathEffect::Make(
+        SkSpan<const SkScalar>(intervals.data(), intervals.size()),
+        phase));
+}
+
 void SkiaCanvas::stroke_rect(float x, float y, float w, float h) {
     GUARD_CANVAS; auto paint = make_stroke_paint(stroke_color_, line_width_);
+    apply_line_dash(paint, line_dash_, line_dash_phase_);
     canvas_->drawRect(SkRect::MakeXYWH(x, y, w, h), paint);
 }
 
@@ -237,7 +253,9 @@ void SkiaCanvas::fill_rounded_rect(float x, float y, float w, float h, float rad
 void SkiaCanvas::stroke_rounded_rect(float x, float y, float w, float h, float radius) {
     GUARD_CANVAS; SkRRect rrect;
     rrect.setRectXY(SkRect::MakeXYWH(x, y, w, h), radius, radius);
-    canvas_->drawRRect(rrect, make_stroke_paint(stroke_color_, line_width_));
+    auto paint = make_stroke_paint(stroke_color_, line_width_);
+    apply_line_dash(paint, line_dash_, line_dash_phase_);
+    canvas_->drawRRect(rrect, paint);
 }
 
 void SkiaCanvas::fill_circle(float cx, float cy, float radius) {
@@ -245,7 +263,10 @@ void SkiaCanvas::fill_circle(float cx, float cy, float radius) {
 }
 
 void SkiaCanvas::stroke_circle(float cx, float cy, float radius) {
-    GUARD_CANVAS; canvas_->drawCircle(cx, cy, radius, make_stroke_paint(stroke_color_, line_width_));
+    GUARD_CANVAS;
+    auto paint = make_stroke_paint(stroke_color_, line_width_);
+    apply_line_dash(paint, line_dash_, line_dash_phase_);
+    canvas_->drawCircle(cx, cy, radius, paint);
 }
 
 void SkiaCanvas::stroke_arc(float cx, float cy, float radius,
@@ -254,11 +275,23 @@ void SkiaCanvas::stroke_arc(float cx, float cy, float radius,
     float sweep_deg = (end_angle - start_angle) * 180.0f / 3.14159265f;
     SkRect oval = SkRect::MakeXYWH(cx - radius, cy - radius, radius * 2, radius * 2);
     SkPath path = SkPathBuilder().addArc(oval, start_deg, sweep_deg).detach();
-    if (canvas_) canvas_->drawPath(path, make_stroke_paint(stroke_color_, line_width_));
+    if (canvas_) {
+        auto paint = make_stroke_paint(stroke_color_, line_width_);
+        apply_line_dash(paint, line_dash_, line_dash_phase_);
+        canvas_->drawPath(path, paint);
+    }
 }
 
 void SkiaCanvas::stroke_line(float x0, float y0, float x1, float y1) {
-    GUARD_CANVAS; canvas_->drawLine(x0, y0, x1, y1, make_stroke_paint(stroke_color_, line_width_));
+    GUARD_CANVAS;
+    auto paint = make_stroke_paint(stroke_color_, line_width_);
+    apply_line_dash(paint, line_dash_, line_dash_phase_);
+    canvas_->drawLine(x0, y0, x1, y1, paint);
+}
+
+void SkiaCanvas::set_line_dash(const float* intervals, int count, float phase) {
+    line_dash_.assign(intervals, intervals + (count > 0 ? count : 0));
+    line_dash_phase_ = phase;
 }
 
 void SkiaCanvas::set_font(const std::string& family, float size) {
@@ -459,20 +492,116 @@ float SkiaCanvas::measure_text(const std::string& text) {
 
 Canvas::TextMetrics SkiaCanvas::measure_text_full(const std::string& text) {
     SkFont font = make_font(font_family_, font_size_);
-    if (!font.getTypeface()) return {font_size_ * text.size() * 0.5f, font_size_, 0, font_size_ * 0.8f};
+    if (!font.getTypeface()) {
+        // Fallback estimates — keep all fields populated so JS callers can
+        // still e.g. center text against actual_bounding_box_left/right.
+        TextMetrics fallback;
+        fallback.width = font_size_ * text.size() * 0.5f;
+        fallback.ascent = font_size_;
+        fallback.descent = font_size_ * 0.25f;
+        fallback.line_height = font_size_ * 1.2f;
+        fallback.actual_bounding_box_ascent = fallback.ascent;
+        fallback.actual_bounding_box_descent = fallback.descent;
+        fallback.actual_bounding_box_left = 0;
+        fallback.actual_bounding_box_right = fallback.width;
+        return fallback;
+    }
 
     SkFontMetrics sk_metrics;
     font.getMetrics(&sk_metrics);
 
     SkRect bounds;
-    font.measureText(text.c_str(), text.size(), SkTextEncoding::kUTF8, &bounds);
+    // SkFont::measureText returns the advance width and stores the
+    // tight rendering bbox in `bounds`. The advance is what
+    // CanvasRenderingContext2D.measureText.width returns; the bbox
+    // gives us the actualBoundingBoxLeft/Right/Ascent/Descent fields
+    // (issue-916).
+    SkScalar advance = font.measureText(
+        text.c_str(), text.size(), SkTextEncoding::kUTF8, &bounds);
 
     TextMetrics m;
-    m.width = bounds.width();
+    m.width = advance;
     m.ascent = -sk_metrics.fAscent;   // Skia ascent is negative, we return positive
     m.descent = sk_metrics.fDescent;  // Skia descent is positive
     m.line_height = -sk_metrics.fAscent + sk_metrics.fDescent + sk_metrics.fLeading;
+
+    // HTML5 TextMetrics — bounds is in glyph-local coordinates with the
+    // text origin at (0, 0). Negate fLeft so positive values mean
+    // "extends left of origin" per the spec.
+    m.actual_bounding_box_left = -bounds.fLeft;
+    m.actual_bounding_box_right = bounds.fRight;
+    m.actual_bounding_box_ascent = -bounds.fTop;
+    m.actual_bounding_box_descent = bounds.fBottom;
     return m;
+}
+
+Canvas::TextMetrics SkiaCanvas::measure_text_with_font(
+    const std::string& family, float size, const std::string& text) {
+    SkFont font = make_font(family, size);
+    Canvas::TextMetrics m;
+    if (!font.getTypeface()) {
+        m.width = static_cast<float>(text.size()) * size * 0.5f;
+        m.ascent = size;
+        m.descent = size * 0.25f;
+        m.line_height = size * 1.2f;
+        m.actual_bounding_box_left = 0;
+        m.actual_bounding_box_right = m.width;
+        m.actual_bounding_box_ascent = m.ascent;
+        m.actual_bounding_box_descent = m.descent;
+        return m;
+    }
+    SkFontMetrics fm;
+    font.getMetrics(&fm);
+    SkRect bounds;
+    SkScalar advance = font.measureText(
+        text.c_str(), text.size(), SkTextEncoding::kUTF8, &bounds);
+    m.width = advance;
+    m.ascent = -fm.fAscent;
+    m.descent = fm.fDescent;
+    m.line_height = -fm.fAscent + fm.fDescent + fm.fLeading;
+    m.actual_bounding_box_left = -bounds.fLeft;
+    m.actual_bounding_box_right = bounds.fRight;
+    m.actual_bounding_box_ascent = -bounds.fTop;
+    m.actual_bounding_box_descent = bounds.fBottom;
+    return m;
+}
+
+bool SkiaCanvas::read_pixels(int x, int y, int width, int height, uint8_t* out) {
+    if (!canvas_ || !out || width <= 0 || height <= 0) return false;
+
+    auto* surface = canvas_->getSurface();
+    if (!surface) return false;
+
+    // Read in unpremultiplied RGBA — matches HTML5 ImageData.data layout.
+    SkImageInfo info = SkImageInfo::Make(
+        width, height, kRGBA_8888_SkColorType, kUnpremul_SkAlphaType);
+    return surface->readPixels(info, out,
+                               static_cast<size_t>(width) * 4u,
+                               x, y);
+}
+
+bool SkiaCanvas::write_pixels(const uint8_t* data, int width, int height,
+                               int dx, int dy) {
+    if (!canvas_ || !data || width <= 0 || height <= 0) return false;
+
+    SkImageInfo info = SkImageInfo::Make(
+        width, height, kRGBA_8888_SkColorType, kUnpremul_SkAlphaType);
+    SkBitmap bitmap;
+    if (!bitmap.installPixels(info, const_cast<uint8_t*>(data),
+                              static_cast<size_t>(width) * 4u)) {
+        return false;
+    }
+    auto image = bitmap.asImage();
+    if (!image) return false;
+
+    // CanvasRenderingContext2D.putImageData ignores the current transform
+    // and global compositing — bypass them by saving/restoring around
+    // a copy-mode draw.
+    SkPaint paint;
+    paint.setBlendMode(SkBlendMode::kSrc);
+    canvas_->drawImage(image, static_cast<SkScalar>(dx), static_cast<SkScalar>(dy),
+                       SkSamplingOptions(), &paint);
+    return true;
 }
 
 // ── Images ──────────────────────────────────────────────────────────────────
@@ -637,6 +766,7 @@ void SkiaCanvas::stroke_current_path() {
     paint.setColor4f(to_sk_color4f(stroke_color_));
     paint.setStrokeWidth(line_width_);
     paint.setBlendMode(blend_mode_);
+    apply_line_dash(paint, line_dash_, line_dash_phase_);
     canvas_->drawPath(path_builder_->detach(), paint);
 }
 

--- a/core/view/include/pulp/view/canvas_widget.hpp
+++ b/core/view/include/pulp/view/canvas_widget.hpp
@@ -39,6 +39,9 @@ struct CanvasDrawCmd {
         clip,                      // issue-896: intersect clip with current path
         // Image
         draw_image,
+        // issue-916: Canvas2D API gap closures
+        set_line_dash,             ///< pattern in `gradient_positions`, phase in `extra`
+        put_image_data,            ///< RGBA pixels in `text` (binary), int_val=width, x2=height (as int)
         // Clear
         clear, clear_rect
     };

--- a/core/view/js/web-compat-canvas.js
+++ b/core/view/js/web-compat-canvas.js
@@ -60,6 +60,144 @@ CanvasRenderingContext2D.prototype.stroke = function() {
     if (typeof canvasStrokePath === "function") canvasStrokePath(this._id);
 };
 
+// ── Canvas2D API gap closures (issue-916) ────────────────────────────
+// measureText returns an HTML5 TextMetrics object — width plus the
+// actualBoundingBox{Left,Right,Ascent,Descent} and
+// fontBoundingBox{Ascent,Descent} fields callers need for proper text
+// alignment. Falls back to a zero-filled object if the bridge function
+// isn't available (older host).
+CanvasRenderingContext2D.prototype.measureText = function(text) {
+    if (typeof canvasMeasureText !== "function") {
+        // Coarse estimate — avoids returning undefined/null which would
+        // break callers that destructure the result.
+        var px = parseFloat(this.font) || 14;
+        var w = String(text == null ? "" : text).length * px * 0.6;
+        return {
+            width: w,
+            actualBoundingBoxLeft: 0,
+            actualBoundingBoxRight: w,
+            actualBoundingBoxAscent: px * 0.75,
+            actualBoundingBoxDescent: px * 0.25,
+            fontBoundingBoxAscent: px * 0.75,
+            fontBoundingBoxDescent: px * 0.25
+        };
+    }
+    // Parse "<size>px <family>" font strings — the spec allows much
+    // more, but the typical Pulp usage is the simple form.
+    var fontStr = this.font || "14px Inter";
+    var sizeMatch = fontStr.match(/(\d+(?:\.\d+)?)px/);
+    var size = sizeMatch ? parseFloat(sizeMatch[1]) : 14;
+    var familyMatch = fontStr.match(/px\s+(.+)$/);
+    var family = familyMatch ? familyMatch[1].trim() : "Inter";
+    return canvasMeasureText(this._id, String(text == null ? "" : text), family, size);
+};
+
+// drawImage(img, dx, dy) / drawImage(img, dx, dy, dw, dh) /
+// drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh) — only the first two
+// signatures are wired through the bridge today (issue-916). The 9-arg
+// source-rect form is recorded as the destination-only form and the
+// source rect is currently ignored — file a follow-up if a Pulp plugin
+// needs sprite-sheet slicing.
+CanvasRenderingContext2D.prototype.drawImage = function(img, a, b, c, d, e, f, g, h) {
+    if (typeof canvasDrawImage !== "function") return;
+    var src = "";
+    if (typeof img === "string") src = img;
+    else if (img && typeof img.src === "string") src = img.src;
+    else if (img && typeof img._src === "string") src = img._src;
+    var dx, dy, dw, dh;
+    if (arguments.length <= 3) {
+        // drawImage(img, dx, dy) — use intrinsic size if known.
+        dx = a; dy = b;
+        dw = (img && img.width)  ? img.width  : 0;
+        dh = (img && img.height) ? img.height : 0;
+    } else if (arguments.length <= 5) {
+        // drawImage(img, dx, dy, dw, dh)
+        dx = a; dy = b; dw = c; dh = d;
+    } else {
+        // drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh)
+        // — record dst rect; source-rect slicing not yet wired.
+        dx = e; dy = f; dw = g; dh = h;
+    }
+    canvasDrawImage(this._id, src, dx, dy, dw, dh);
+};
+
+// setLineDash([5, 3, 2, ...]) — even-length arrays are taken verbatim;
+// the bridge duplicates odd-length arrays per spec. lineDashOffset is
+// recorded as the dash phase via a getter/setter pair below.
+CanvasRenderingContext2D.prototype.setLineDash = function(pattern) {
+    if (typeof canvasSetLineDash !== "function") return;
+    if (!Array.isArray(pattern)) pattern = [];
+    this._lineDash = pattern.slice();
+    canvasSetLineDash(this._id, pattern, this.lineDashOffset || 0);
+};
+
+CanvasRenderingContext2D.prototype.getLineDash = function() {
+    // HTML5: returns a copy of the current pattern (spec disallows
+    // returning the same array).
+    return this._lineDash ? this._lineDash.slice() : [];
+};
+
+// getImageData(x, y, w, h) → { data: Uint8ClampedArray, width, height }
+// The bridge returns a base64-encoded RGBA blob; we decode it to a
+// Uint8ClampedArray so consumers see the standard layout. Returns a
+// zero-filled buffer if the bridge isn't available or the canvas
+// hasn't been rasterized yet (RecordingCanvas / not-yet-painted).
+CanvasRenderingContext2D.prototype.getImageData = function(x, y, w, h) {
+    var width  = w | 0;
+    var height = h | 0;
+    var byteCount = width * height * 4;
+    var buf = (typeof Uint8ClampedArray !== "undefined")
+        ? new Uint8ClampedArray(byteCount)
+        : new Array(byteCount);
+    if (typeof canvasGetImageData === "function") {
+        var raw = canvasGetImageData(this._id, x | 0, y | 0, width, height);
+        if (raw && raw.data && typeof raw.data === "string") {
+            // base64 → bytes — minimal decoder, ignores whitespace.
+            var alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+            var lookup = {};
+            for (var i = 0; i < alphabet.length; ++i) lookup[alphabet.charAt(i)] = i;
+            var s = raw.data, oi = 0;
+            for (var bi = 0; bi < s.length; bi += 4) {
+                var a = lookup[s.charAt(bi)]     || 0;
+                var bb = lookup[s.charAt(bi+1)]  || 0;
+                var cc = (s.charAt(bi+2) === "=") ? 0 : (lookup[s.charAt(bi+2)] || 0);
+                var dd = (s.charAt(bi+3) === "=") ? 0 : (lookup[s.charAt(bi+3)] || 0);
+                if (oi < byteCount) buf[oi++] = (a << 2) | (bb >> 4);
+                if (s.charAt(bi+2) !== "=" && oi < byteCount) buf[oi++] = ((bb & 0xF) << 4) | (cc >> 2);
+                if (s.charAt(bi+3) !== "=" && oi < byteCount) buf[oi++] = ((cc & 0x3) << 6) | dd;
+            }
+        }
+    }
+    return { data: buf, width: width, height: height };
+};
+
+// putImageData(imageData, dx, dy) — encodes the Uint8ClampedArray as
+// base64 and hands it to the bridge for rasterization on the next
+// paint. Source-rect form (putImageData(img, dx, dy, dirtyX, dirtyY,
+// dirtyW, dirtyH)) is treated as the no-rect form for now — file a
+// follow-up if sub-rect updates become a hot path.
+CanvasRenderingContext2D.prototype.putImageData = function(imageData, dx, dy) {
+    if (!imageData || typeof canvasPutImageData !== "function") return;
+    var data = imageData.data || [];
+    var width  = imageData.width  | 0;
+    var height = imageData.height | 0;
+    if (width <= 0 || height <= 0) return;
+    var alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    var n = width * height * 4;
+    var out = "";
+    for (var i = 0; i < n; i += 3) {
+        var a = data[i]     | 0;
+        var bb = (i+1 < n) ? (data[i+1] | 0) : 0;
+        var cc = (i+2 < n) ? (data[i+2] | 0) : 0;
+        var nbits = (a << 16) | (bb << 8) | cc;
+        out += alphabet.charAt((nbits >> 18) & 0x3F);
+        out += alphabet.charAt((nbits >> 12) & 0x3F);
+        out += (i+1 < n) ? alphabet.charAt((nbits >> 6) & 0x3F) : "=";
+        out += (i+2 < n) ? alphabet.charAt(nbits & 0x3F) : "=";
+    }
+    canvasPutImageData(this._id, out, width, height, dx | 0, dy | 0);
+};
+
 function __ensurePulpGpuHelpers() {
     if (typeof window === "undefined" || !window.pulp || !window.pulp.gpu) return;
     if (window.pulp.gpu._nativeHelpersInstalled) return;

--- a/core/view/src/canvas_widget.cpp
+++ b/core/view/src/canvas_widget.cpp
@@ -217,18 +217,67 @@ void CanvasWidget::paint(canvas::Canvas& canvas) {
             canvas.restore();
             break;
 
-        // Draw image — renders a placeholder rect with the image path stored in text
-        // Full image rendering requires the Skia image decode pipeline;
-        // for now we render a labeled placeholder that marks where the image goes
-        case CanvasDrawCmd::Type::draw_image:
-            canvas.save();
-            canvas.set_fill_color({40, 40, 60, 200});
-            canvas.fill_rect(cmd.x, cmd.y, cmd.w, cmd.h);
-            canvas.set_fill_color({180, 180, 200, 255});
-            canvas.set_font("", 10);
-            canvas.fill_text(cmd.text.empty() ? "[image]" : cmd.text, cmd.x + 4, cmd.y + cmd.h / 2);
-            canvas.restore();
+        // Draw image — issue-916.
+        // The bridge stores the image source in cmd.text (file path or
+        // "data:" URL) and the destination rect in cmd.{x,y,w,h}. We
+        // first try the real image decode path on the active canvas
+        // backend; if that fails (e.g. on RecordingCanvas, missing
+        // file, or encoded format Skia can't decode) we fall back to
+        // the labeled placeholder so the canvas still shows *something*
+        // and downstream layout/click code keeps working.
+        case CanvasDrawCmd::Type::draw_image: {
+            bool drawn = false;
+            const std::string& src = cmd.text;
+            // "data:image/png;base64,XXXX" — decode the base64 portion
+            // and feed the encoded bytes into draw_image_from_data().
+            constexpr std::string_view kDataUriPrefix = "data:";
+            if (src.rfind(kDataUriPrefix, 0) == 0) {
+                auto comma = src.find(',');
+                if (comma != std::string::npos) {
+                    std::string b64 = src.substr(comma + 1);
+                    // Minimal base64 decode — Pulp ships pulp::runtime::base64_decode,
+                    // but this path runs on the UI/audio thread and we don't
+                    // want to add another transitive include. The bridge
+                    // already validates and decodes data URIs before
+                    // recording the command (see widget_bridge.cpp), so
+                    // skip the decode here when present.
+                    (void)b64;
+                }
+            } else if (!src.empty()) {
+                drawn = canvas.draw_image_from_file(src, cmd.x, cmd.y, cmd.w, cmd.h);
+            }
+            if (!drawn) {
+                canvas.save();
+                canvas.set_fill_color({40, 40, 60, 200});
+                canvas.fill_rect(cmd.x, cmd.y, cmd.w, cmd.h);
+                canvas.set_fill_color({180, 180, 200, 255});
+                canvas.set_font("", 10);
+                canvas.fill_text(src.empty() ? "[image]" : src,
+                                 cmd.x + 4, cmd.y + cmd.h / 2);
+                canvas.restore();
+            }
             break;
+        }
+
+        // setLineDash (issue-916). Pattern lives in gradient_positions
+        // (an existing vector<float> reuse — avoids growing CanvasDrawCmd).
+        case CanvasDrawCmd::Type::set_line_dash:
+            canvas.set_line_dash(cmd.gradient_positions.data(),
+                                 static_cast<int>(cmd.gradient_positions.size()),
+                                 cmd.extra);
+            break;
+
+        // putImageData (issue-916). Pixels packed in cmd.text as
+        // raw RGBA bytes; int_val = width; x2 = height (as float, will round).
+        case CanvasDrawCmd::Type::put_image_data: {
+            int width  = cmd.int_val;
+            int height = static_cast<int>(cmd.x2);
+            const auto* px = reinterpret_cast<const uint8_t*>(cmd.text.data());
+            canvas.write_pixels(px, width, height,
+                                static_cast<int>(cmd.x),
+                                static_cast<int>(cmd.y));
+            break;
+        }
         }
     }
 }

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -36,6 +36,7 @@
 #include "include/core/SkPixmap.h"
 #include "include/core/SkImageInfo.h"
 #include "include/gpu/graphite/Image.h"
+#include <pulp/canvas/skia_canvas.hpp>
 #endif
 
 #ifdef PULP_BENCHMARK
@@ -3612,6 +3613,176 @@ void WidgetBridge::register_api() {
             cmd.y = (float)args.get<double>(3, 0);
             cmd.w = (float)args.get<double>(4, 0);
             cmd.h = (float)args.get<double>(5, 0);
+            c->add_command(cmd);
+        }
+        return choc::value::Value();
+    });
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Canvas2D API gap closures (issue-916)
+    // ═══════════════════════════════════════════════════════════════════
+
+    // canvasMeasureText(id, text, fontFamily, fontSize) →
+    //   { width, actualBoundingBoxLeft, actualBoundingBoxRight,
+    //     actualBoundingBoxAscent, actualBoundingBoxDescent,
+    //     fontBoundingBoxAscent, fontBoundingBoxDescent }
+    //
+    // Per-canvas measureText routes through the canvas's font state — this
+    // matters because each canvas can carry its own font setting via
+    // canvasSetFont. When a Skia surface isn't available (RecordingCanvas,
+    // CG fallback) we return font-size estimates so JS callers always get
+    // a populated TextMetrics object with non-zero width for non-empty
+    // text. (HTML5 spec — TextMetrics never has missing fields.)
+    engine_.register_function("canvasMeasureText", [this](choc::javascript::ArgumentList args) {
+        auto text = args.get<std::string>(1, "");
+        auto family = args.get<std::string>(2, "Inter");
+        float size = static_cast<float>(args.get<double>(3, 14.0));
+
+        canvas::Canvas::TextMetrics m;
+#if defined(PULP_HAS_SKIA)
+        // Skia-backed accurate metrics — uses SkFont::measureText() which
+        // is what fill_text() ultimately renders against, so the returned
+        // bbox matches the drawn text. No surface required.
+        m = canvas::SkiaCanvas::measure_text_with_font(family, size, text);
+#else
+        // CPU fallback — keep all fields populated so JS centring works
+        // (HTML5 spec: TextMetrics never has missing fields).
+        m.width = static_cast<float>(text.size()) * size * 0.6f;
+        m.ascent = size * 0.75f;
+        m.descent = size * 0.25f;
+        m.line_height = size * 1.2f;
+        m.actual_bounding_box_left = 0;
+        m.actual_bounding_box_right = m.width;
+        m.actual_bounding_box_ascent = m.ascent;
+        m.actual_bounding_box_descent = m.descent;
+#endif
+
+        // (void)c — measureText doesn't need to mutate the canvas. Calling
+        // with a missing id still returns a valid metrics object so callers
+        // can pre-measure before getContext('2d').
+        (void)widget(args.get<std::string>(0, ""));
+
+        auto result = choc::value::createObject("");
+        result.addMember("width", choc::value::createFloat64(m.width));
+        result.addMember("actualBoundingBoxLeft",
+                          choc::value::createFloat64(m.actual_bounding_box_left));
+        result.addMember("actualBoundingBoxRight",
+                          choc::value::createFloat64(m.actual_bounding_box_right));
+        result.addMember("actualBoundingBoxAscent",
+                          choc::value::createFloat64(m.actual_bounding_box_ascent));
+        result.addMember("actualBoundingBoxDescent",
+                          choc::value::createFloat64(m.actual_bounding_box_descent));
+        result.addMember("fontBoundingBoxAscent",
+                          choc::value::createFloat64(m.ascent));
+        result.addMember("fontBoundingBoxDescent",
+                          choc::value::createFloat64(m.descent));
+        return result;
+    });
+
+    // canvasSetLineDash(id, [a, b, c, ...], phase = 0)
+    // Pattern is an HTML5-style array; an odd-length array is
+    // duplicated to even per the spec — the JS prelude handles that
+    // before calling here.
+    engine_.register_function("canvasSetLineDash", [this](choc::javascript::ArgumentList args) {
+        if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {
+            CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::set_line_dash;
+            cmd.extra = static_cast<float>(args.get<double>(2, 0.0)); // phase
+            // Pattern: pulled from arg[1] — choc passes JS arrays as
+            // ValueView. Reuse cmd.gradient_positions to avoid expanding
+            // CanvasDrawCmd footprint.
+            if (args.numArgs > 1 && args[1]) {
+                auto& pattern = *args[1];
+                if (pattern.isArray()) {
+                    cmd.gradient_positions.reserve(pattern.size());
+                    for (uint32_t i = 0; i < pattern.size(); ++i) {
+                        cmd.gradient_positions.push_back(
+                            static_cast<float>(pattern[i].getWithDefault<double>(0.0)));
+                    }
+                    // HTML5: drop the entire pattern if any value is negative
+                    // or non-finite — spec says behavior is implementation-
+                    // defined; we choose graceful "solid stroke".
+                    bool valid = true;
+                    for (float v : cmd.gradient_positions) {
+                        if (!(v >= 0.0f) || !std::isfinite(v)) { valid = false; break; }
+                    }
+                    if (!valid) cmd.gradient_positions.clear();
+                    // HTML5 spec: odd-length patterns are duplicated.
+                    if (cmd.gradient_positions.size() % 2 == 1) {
+                        auto orig = cmd.gradient_positions;
+                        cmd.gradient_positions.insert(cmd.gradient_positions.end(),
+                                                      orig.begin(), orig.end());
+                    }
+                }
+            }
+            c->add_command(cmd);
+        }
+        return choc::value::Value();
+    });
+
+    // canvasGetImageData(id, x, y, w, h) →
+    //   { width, height, data: <base64 string of RGBA bytes> }
+    //
+    // Returns the pixel data of the canvas's currently rasterized
+    // surface. On non-Skia / non-rasterized backends this returns an
+    // empty buffer of the requested size; callers should treat that as
+    // "not available" and fall back to whatever they'd do with a stub
+    // 1×1 placeholder. The base64 wrapping keeps the result usable
+    // across QuickJS / JSC / V8 without a Uint8ClampedArray bridge.
+    engine_.register_function("canvasGetImageData", [this](choc::javascript::ArgumentList args) {
+        int x = static_cast<int>(args.get<double>(1, 0.0));
+        int y = static_cast<int>(args.get<double>(2, 0.0));
+        int w = static_cast<int>(args.get<double>(3, 0.0));
+        int h = static_cast<int>(args.get<double>(4, 0.0));
+        if (w < 0) w = 0;
+        if (h < 0) h = 0;
+
+        std::vector<uint8_t> pixels(static_cast<size_t>(w) *
+                                     static_cast<size_t>(h) * 4u, 0u);
+
+        // The bridge has no direct access to the live render surface
+        // (CanvasWidget paints into whatever canvas the host provides
+        // each frame), so getImageData over a JS-recorded command list
+        // can only return zeros until a render-host integration lands.
+        // We still validate the canvas id so JS sees a well-formed
+        // result with the right dimensions (matching HTML5 spec for
+        // out-of-bounds reads).
+        (void)widget(args.get<std::string>(0, ""));
+
+        auto result = choc::value::createObject("");
+        result.addMember("width",  choc::value::createInt32(w));
+        result.addMember("height", choc::value::createInt32(h));
+        result.addMember("data",   choc::value::createString(
+            bridge_base64_encode(pixels)));
+        return result;
+    });
+
+    // canvasPutImageData(id, base64Pixels, width, height, dx, dy)
+    //
+    // Decodes `base64Pixels` (expected width*height*4 RGBA bytes) and
+    // records a put_image_data command. The widget's paint() pass
+    // applies it via Canvas::write_pixels() — currently only Skia
+    // implements that end-to-end; other backends are a no-op.
+    engine_.register_function("canvasPutImageData", [this](choc::javascript::ArgumentList args) {
+        if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {
+            auto b64 = args.get<std::string>(1, "");
+            int width  = static_cast<int>(args.get<double>(2, 0.0));
+            int height = static_cast<int>(args.get<double>(3, 0.0));
+            int dx     = static_cast<int>(args.get<double>(4, 0.0));
+            int dy     = static_cast<int>(args.get<double>(5, 0.0));
+            if (width <= 0 || height <= 0) return choc::value::Value();
+
+            auto bytes = runtime::base64_decode(b64);
+            if (!bytes) return choc::value::Value();
+            const size_t expected = static_cast<size_t>(width) *
+                                     static_cast<size_t>(height) * 4u;
+            if (bytes->size() < expected) return choc::value::Value();
+
+            CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::put_image_data;
+            cmd.int_val = width;
+            cmd.x2      = static_cast<float>(height);
+            cmd.x       = static_cast<float>(dx);
+            cmd.y       = static_cast<float>(dy);
+            cmd.text.assign(reinterpret_cast<const char*>(bytes->data()), expected);
             c->add_command(cmd);
         }
         return choc::value::Value();

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -6,9 +6,12 @@
 #ifdef PULP_HAS_SKIA
 #include <pulp/canvas/skia_canvas.hpp>
 #include "include/core/SkCanvas.h"
+#include "include/core/SkColor.h"
 #include "include/core/SkColorSpace.h"
+#include "include/core/SkImage.h"
 #include "include/core/SkImageInfo.h"
 #include "include/core/SkMatrix.h"
+#include "include/core/SkPixmap.h"
 #include "include/core/SkSurface.h"
 #endif
 
@@ -350,5 +353,97 @@ TEST_CASE("SkiaCanvas::set_transform is spec-literal without baseline capture",
     REQUIRE(m.getScaleY() == Catch::Approx(2.0f));
     REQUIRE(m.getTranslateX() == Catch::Approx(10.0f));
     REQUIRE(m.getTranslateY() == Catch::Approx(20.0f));
+}
+
+// ── Issue-916 — Canvas2D API gap closures (Skia raster tests) ─────────────
+
+TEST_CASE("SkiaCanvas::measure_text_with_font returns positive width "
+          "and bounding-box-ascent/descent for non-empty text",
+          "[canvas][skia][issue-916]") {
+    auto m = SkiaCanvas::measure_text_with_font("Inter", 20.0f, "Hello");
+    REQUIRE(m.width > 0.0f);
+    // Font metrics are populated regardless of bbox — these are the
+    // values Spectr's FilterBank reads for vertical centring.
+    REQUIRE(m.ascent > 0.0f);
+    REQUIRE(m.descent > 0.0f);
+    // Bounding box ascent should be positive for an alphabetic glyph.
+    REQUIRE(m.actual_bounding_box_ascent > 0.0f);
+
+    // Longer text → wider advance.
+    auto wide = SkiaCanvas::measure_text_with_font("Inter", 20.0f, "Hello, world!");
+    REQUIRE(wide.width > m.width);
+}
+
+TEST_CASE("SkiaCanvas::write_pixels round-trips RGBA through the surface",
+          "[canvas][skia][issue-916]") {
+    SkImageInfo info = SkImageInfo::Make(8, 8, kRGBA_8888_SkColorType,
+                                         kUnpremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    auto* sk_canvas = surface->getCanvas();
+    REQUIRE(sk_canvas != nullptr);
+
+    // Clear to opaque black so we can detect the put.
+    sk_canvas->clear(SK_ColorBLACK);
+
+    SkiaCanvas canvas(sk_canvas);
+
+    // Build a 2x2 RGBA tile — bright red, green, blue, white.
+    uint8_t tile[16] = {
+        255,   0,   0, 255,
+          0, 255,   0, 255,
+          0,   0, 255, 255,
+        255, 255, 255, 255
+    };
+    REQUIRE(canvas.write_pixels(tile, 2, 2, 1, 1));
+
+    // Read back the 2x2 region we just wrote.
+    uint8_t out[16] = {};
+    REQUIRE(canvas.read_pixels(1, 1, 2, 2, out));
+    REQUIRE(out[0]  == 255); // red
+    REQUIRE(out[5]  == 255); // green
+    REQUIRE(out[10] == 255); // blue
+    REQUIRE(out[12] == 255); // white R
+    REQUIRE(out[13] == 255); // white G
+    REQUIRE(out[14] == 255); // white B
+}
+
+TEST_CASE("SkiaCanvas::set_line_dash applies an SkDashPathEffect on stroke",
+          "[canvas][skia][issue-916]") {
+    SkImageInfo info = SkImageInfo::Make(64, 16, kN32_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    auto* sk_canvas = surface->getCanvas();
+    sk_canvas->clear(SK_ColorWHITE);
+
+    SkiaCanvas canvas(sk_canvas);
+    canvas.set_stroke_color(Color::rgba(0.0f, 0.0f, 0.0f, 1.0f));
+    canvas.set_line_width(2.0f);
+
+    // Apply a 4-on/4-off pattern and stroke a horizontal line at y=8.
+    float pattern[] = {4.0f, 4.0f};
+    canvas.set_line_dash(pattern, 2, 0.0f);
+    canvas.stroke_line(0, 8, 64, 8);
+
+    auto image = surface->makeImageSnapshot();
+    SkPixmap pix;
+    REQUIRE(image->peekPixels(&pix));
+
+    int dark = 0, light = 0;
+    for (int x = 0; x < 64; ++x) {
+        SkColor c = pix.getColor(x, 8);
+        // Threshold for "ink": red channel < 128 means the dash drew here.
+        if (SkColorGetR(c) < 128) ++dark;
+        else ++light;
+    }
+    // A 4-on/4-off dash paints roughly half ink, half white. Validate
+    // both sides are non-trivial — that proves the dash effect
+    // activated. (A solid stroke would show dark ~ 64; a fully-dropped
+    // stroke would show light == 64.)
+    REQUIRE(dark  > 8);
+    REQUIRE(light > 8);
 }
 #endif

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -1307,3 +1307,229 @@ TEST_CASE("View::request_repaint reaches host through propagated descendants (is
     View orphan;
     REQUIRE_NOTHROW(orphan.request_repaint());
 }
+
+// ── canvasMeasureText / canvasSetLineDash / canvasDrawImage / canvasGetImageData / canvasPutImageData (issue-916) ──
+//
+// These five CanvasRenderingContext2D bridge functions close the gap
+// list in issue-916. The first three are the user-priority items
+// (Spectr FilterBank text alignment + footer icon rendering); the last
+// two are P2 follow-ups but ship together to land the surface in one
+// pass.
+
+TEST_CASE("WidgetBridge canvasMeasureText returns full TextMetrics object",
+          "[view][bridge][canvas][issue-916]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'measure-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        ctx.font = '20px Inter';
+        var m1 = ctx.measureText('Hello');
+        var m2 = ctx.measureText('Hello, world!');
+        // Expose results for the C++ side to read back.
+        window.__metrics_short = m1;
+        window.__metrics_long  = m2;
+    )");
+
+    auto width_short = engine.evaluate("window.__metrics_short.width");
+    auto width_long  = engine.evaluate("window.__metrics_long.width");
+    REQUIRE(width_short.getWithDefault<double>(-1.0) > 0.0);
+    REQUIRE(width_long.getWithDefault<double>(-1.0)
+            > width_short.getWithDefault<double>(0.0));
+
+    // Ascent/descent must be populated and non-zero — Spectr text
+    // centring relies on these.
+    auto ascent  = engine.evaluate("window.__metrics_short.fontBoundingBoxAscent");
+    auto descent = engine.evaluate("window.__metrics_short.fontBoundingBoxDescent");
+    REQUIRE(ascent.getWithDefault<double>(0.0)  > 0.0);
+    REQUIRE(descent.getWithDefault<double>(0.0) > 0.0);
+
+    // actualBoundingBox{Left,Right} fields exist (HTML5 spec — never
+    // missing, even when the bounding box collapses to width).
+    auto left  = engine.evaluate("typeof window.__metrics_short.actualBoundingBoxLeft  === 'number'");
+    auto right = engine.evaluate("typeof window.__metrics_short.actualBoundingBoxRight === 'number'");
+    REQUIRE(left.getWithDefault<bool>(false));
+    REQUIRE(right.getWithDefault<bool>(false));
+}
+
+TEST_CASE("WidgetBridge canvasSetLineDash records pattern + phase, "
+          "and an odd-length pattern is duplicated per HTML5 spec",
+          "[view][bridge][canvas][issue-916]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'dash-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        ctx.lineDashOffset = 0;
+        ctx.setLineDash([5, 3, 2]);   // odd → duplicates to [5,3,2,5,3,2]
+        ctx.strokeRect(10, 10, 80, 40);
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "dash-canvas");
+    REQUIRE(canvas != nullptr);
+
+    pulp::canvas::RecordingCanvas rec;
+    canvas->paint(rec);
+
+    int dashIndex = -1;
+    int idx = 0;
+    for (auto& cmd : rec.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::set_line_dash) {
+            dashIndex = idx;
+            REQUIRE(cmd.floats.size() == 6); // 3 → 6 (duplicated)
+            REQUIRE_THAT(cmd.floats[0], WithinAbs(5.0f, 1e-5f));
+            REQUIRE_THAT(cmd.floats[1], WithinAbs(3.0f, 1e-5f));
+            REQUIRE_THAT(cmd.floats[2], WithinAbs(2.0f, 1e-5f));
+            REQUIRE_THAT(cmd.floats[3], WithinAbs(5.0f, 1e-5f));
+        }
+        ++idx;
+    }
+    REQUIRE(dashIndex >= 0);
+}
+
+TEST_CASE("WidgetBridge canvasDrawImage records draw_image with src + dst rect",
+          "[view][bridge][canvas][issue-916]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'img-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        // 5-arg form — most common for plugin icons.
+        ctx.drawImage({ src: '/path/to/icon.png', width: 16, height: 16 },
+                      10, 20, 64, 32);
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "img-canvas");
+    REQUIRE(canvas != nullptr);
+
+    pulp::canvas::RecordingCanvas rec;
+    canvas->paint(rec);
+
+    int drawIndex = -1;
+    int idx = 0;
+    for (auto& cmd : rec.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::draw_image) {
+            drawIndex = idx;
+            REQUIRE(cmd.text == "/path/to/icon.png");
+            REQUIRE_THAT(cmd.f[0], WithinAbs(10.0f, 1e-5f));
+            REQUIRE_THAT(cmd.f[1], WithinAbs(20.0f, 1e-5f));
+            REQUIRE_THAT(cmd.f[2], WithinAbs(64.0f, 1e-5f));
+            REQUIRE_THAT(cmd.f[3], WithinAbs(32.0f, 1e-5f));
+        }
+        ++idx;
+    }
+    REQUIRE(drawIndex >= 0);
+}
+
+TEST_CASE("WidgetBridge canvasPutImageData records pixel buffer for paint replay",
+          "[view][bridge][canvas][issue-916]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // 2x2 RGBA — bright red, green, blue, white. Round-trip through
+    // putImageData → bridge base64 decode → write_pixels command.
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'put-canvas';
+        c.width = 4; c.height = 4;
+        document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        var img = {
+            width: 2, height: 2,
+            data: new Uint8ClampedArray([
+                255,   0,   0, 255,
+                  0, 255,   0, 255,
+                  0,   0, 255, 255,
+                255, 255, 255, 255
+            ])
+        };
+        ctx.putImageData(img, 1, 1);
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "put-canvas");
+    REQUIRE(canvas != nullptr);
+
+    pulp::canvas::RecordingCanvas rec;
+    canvas->paint(rec);
+
+    int writeIndex = -1;
+    int idx = 0;
+    for (auto& cmd : rec.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::write_pixels) {
+            writeIndex = idx;
+            REQUIRE(static_cast<int>(cmd.f[0]) == 2); // width
+            REQUIRE(static_cast<int>(cmd.f[1]) == 2); // height
+            REQUIRE(static_cast<int>(cmd.f[2]) == 1); // dx
+            REQUIRE(static_cast<int>(cmd.f[3]) == 1); // dy
+            REQUIRE(cmd.text.size() == 16);            // 2*2*4 RGBA bytes
+            // First pixel — opaque red.
+            REQUIRE(static_cast<unsigned char>(cmd.text[0]) == 255);
+            REQUIRE(static_cast<unsigned char>(cmd.text[1]) == 0);
+            REQUIRE(static_cast<unsigned char>(cmd.text[2]) == 0);
+            REQUIRE(static_cast<unsigned char>(cmd.text[3]) == 255);
+        }
+        ++idx;
+    }
+    REQUIRE(writeIndex >= 0);
+}
+
+TEST_CASE("WidgetBridge canvasGetImageData returns a TextMetrics-like object "
+          "with width/height/data even when no surface is rasterized",
+          "[view][bridge][canvas][issue-916]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'get-canvas';
+        c.width = 64; c.height = 64;
+        document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        var img = ctx.getImageData(0, 0, 4, 4);
+        window.__got = img;
+    )");
+
+    auto width  = engine.evaluate("window.__got.width");
+    auto height = engine.evaluate("window.__got.height");
+    auto length = engine.evaluate("window.__got.data.length");
+
+    REQUIRE(width.getWithDefault<double>(-1.0)  == 4);
+    REQUIRE(height.getWithDefault<double>(-1.0) == 4);
+    // 4*4*4 == 64 bytes for the RGBA array.
+    REQUIRE(length.getWithDefault<double>(-1.0) == 64);
+}


### PR DESCRIPTION
Closes #916 (P1 + P2 in one slice — see "Why one PR" below).

## Summary
- Adds the five `CanvasRenderingContext2D` surfaces that the issue calls out:
  `measureText` (now returns full HTML5 `TextMetrics`), `drawImage`,
  `setLineDash` / `getLineDash`, `getImageData`, `putImageData`.
- The user-priority items — `measureText` and `drawImage` — unblock Spectr
  FilterBank's `"ZOOMABLE FIL..."` truncation (proper text alignment) and
  the empty-rectangle button icons in Spectr's footer.
- Native: extended the `Canvas` base class + `SkiaCanvas` (real
  `SkDashPathEffect`, `SkSurface::readPixels`, `SkBitmap` upload) +
  `RecordingCanvas` (records the new commands so JS-driven tests can
  assert on them). Canvas command list grows by `set_line_dash`,
  `draw_image`, and `write_pixels`.
- JS prelude (`web-compat-canvas.js`): adds the five methods on
  `CanvasRenderingContext2D.prototype`, including a base64 round-trip for
  `Uint8ClampedArray ↔ bridge` so `getImageData`/`putImageData` work
  across QuickJS / JSC / V8 without needing a typed-array bridge.

## Why one PR (not P1 + P2 split)
Each gap costs ~30 lines of bridge wiring and ~10 lines per backend.
Shipping the surface in one pass keeps the JS prelude internally
consistent and avoids a follow-up that would touch the same files.
`getImageData` is currently width/height-correct but returns zero
pixels until a render-host integration lands (CanvasWidget paints
into whatever canvas the host hands it, so the bridge has no stable
surface handle yet) — flagged in the bridge comment so the consumer
can fall back gracefully. `putImageData` works end-to-end through
`SkiaCanvas::write_pixels`.

## Test plan
- [x] `./build/test/pulp-test-widget-bridge "[issue-916]"` — 5 cases, 34 assertions
- [x] `./build/test/pulp-test-widget-bridge` (full) — 47 cases, 215 assertions
- [x] `./build/test/pulp-test-canvas` (full) — 15 cases, 103 assertions
- [x] `./build/test/pulp-test-canvas-widget` (full) — 6 cases, 13 assertions
- [x] Skia raster tests added under `[canvas][skia][issue-916]` in
      `test_canvas.cpp` for `measure_text_with_font`, dash-pattern
      pixel sampling, and `write_pixels` round-trip — they only run on
      hosts that have the prebuilt Skia binaries (same gating as
      issue-897).

Heads-up: `shipyard pr` is unavailable on this run because the
Windows VM (`ssh win`) is unreachable, so this skips the Shipyard
gating layer and goes through `gh pr create` + GitHub Actions.