### PR TITLE
fix(view): __requestFrame__ calls request_repaint() to drive paints (#921)

### DIFF
--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -3173,7 +3173,14 @@ void WidgetBridge::register_api() {
 
     engine_.register_function("__requestFrame__", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<int>(0, 0);
-        if (id > 0) pending_frame_ids_.push_back(id);
+        if (id > 0) {
+            pending_frame_ids_.push_back(id);
+            // pulp #921 — signal the host so the next paint runs and
+            // service_frame_callbacks() drains the queue. Without this,
+            // requestAnimationFrame queues a callback but never asks the
+            // host for a frame, so the canvas never repaints.
+            request_repaint();
+        }
         return choc::value::createInt32(id);
     });
 

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -1308,6 +1308,90 @@ TEST_CASE("View::request_repaint reaches host through propagated descendants (is
     REQUIRE_NOTHROW(orphan.request_repaint());
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// pulp #921 — __requestFrame__ must call request_repaint() so that
+// requestAnimationFrame() actually drives the host paint loop. Without
+// this wiring, JS-side rAF callbacks accumulate in pending_frame_ids_
+// but the host never schedules the paint that drains them — Spectr's
+// FilterBank canvas stays blank.
+// ───────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("WidgetBridge requestAnimationFrame triggers a host repaint (issue 921)",
+          "[view][bridge][issue-921]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+
+    CountingWindowHost host;
+    root.set_window_host(&host);
+
+    WidgetBridge bridge(engine, root, store);
+
+    // Snapshot — bridge construction may itself touch the host (it does
+    // not today, but pin behaviour to a delta around the rAF call).
+    int repaint_baseline = host.repaint_calls;
+
+    bridge.load_script("var __raf_id = window.requestAnimationFrame(function () {});");
+
+    // The fix wires __requestFrame__ → request_repaint() → repaint_callback_
+    // → root.request_repaint() → host.repaint(). Without it, repaint_calls
+    // would not advance until something else (mouse, resize, layout) ran.
+    REQUIRE(host.repaint_calls > repaint_baseline);
+
+    // The id round-trip from JS proves the queue path itself still works
+    // — the fix only adds the repaint signal, it must not break the queue.
+    auto id_value = engine.evaluate("__raf_id");
+    REQUIRE(id_value.getWithDefault<int>(-1) >= 1);
+}
+
+TEST_CASE("WidgetBridge requestAnimationFrame chain keeps requesting paints (issue 921)",
+          "[view][bridge][issue-921]") {
+    // The Spectr FilterBank pattern: a draw() callback re-arms itself via
+    // requestAnimationFrame. Each rAF must request a paint so the host
+    // actually services the next frame. Three queued rAFs across a poll
+    // cycle therefore produce at least three host repaint signals.
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+
+    CountingWindowHost host;
+    root.set_window_host(&host);
+
+    WidgetBridge bridge(engine, root, store);
+
+    int repaint_baseline = host.repaint_calls;
+
+    bridge.load_script(R"(
+        var rafs_requested = 0;
+        function tick() {
+            rafs_requested++;
+            if (rafs_requested < 3) window.requestAnimationFrame(tick);
+        }
+        window.requestAnimationFrame(tick);
+    )");
+
+    // First rAF was synchronous in the script and must already have hit
+    // the host once.
+    REQUIRE(host.repaint_calls > repaint_baseline);
+
+    // Drain queued rAFs so each tick re-arms and lands another rAF /
+    // host repaint. Bound the loop — production hosts coalesce, but the
+    // test only needs to see the rAF→repaint signal continuing.
+    for (int i = 0; i < 10; ++i) {
+        bridge.poll_async_results();
+        if (engine.evaluate("rafs_requested").getWithDefault<int>(-1) >= 3)
+            break;
+    }
+
+    REQUIRE(engine.evaluate("rafs_requested").getWithDefault<int>(-1) == 3);
+    // Each of the three rAFs requested a repaint (one synchronous + two
+    // re-armed inside tick()). The host counter is monotonic; we want
+    // strictly more than the first-rAF post-condition above.
+    REQUIRE(host.repaint_calls >= repaint_baseline + 3);
+}
+
 // ── canvasMeasureText / canvasSetLineDash / canvasDrawImage / canvasGetImageData / canvasPutImageData (issue-916) ──
 //
 // These five CanvasRenderingContext2D bridge functions close the gap


### PR DESCRIPTION
## Summary

Closes the loop between native \`requestAnimationFrame\` (PR #918) and the auto-wired paint pump (PR #913). Before this PR, \`requestAnimationFrame(draw)\` queued a callback in \`pending_frame_ids_\` but never asked the host for a frame, so the queue stayed full and FilterBank's draw loop never ran (paint count = 1, canvas blank).

## Fix

One line in \`WidgetBridge::register_api()\`'s \`__requestFrame__\` registration: call \`request_repaint()\` after the queue push.

\`\`\`cpp
engine_.register_function(\"__requestFrame__\", [this](choc::javascript::ArgumentList args) {
    auto id = args.get<int>(0, 0);
    if (id > 0) {
        pending_frame_ids_.push_back(id);
        request_repaint();  // <-- new
    }
    return choc::value::createInt32(id);
});
\`\`\`

\`request_repaint()\` fires \`repaint_callback_\` (auto-wired to \`root.request_repaint()\` per #913), the host coalesces, the next paint runs, \`service_frame_callbacks()\` drains the snapshot. No recursion, bounded by frame rate.

## Test plan

- [x] New \`[issue-921]\` Catch2 cases in \`test_widget_bridge.cpp\` asserting that calling \`requestAnimationFrame(fn)\` from JS increments the host's repaint count.
- [ ] Cross-platform validation via Namespace.

Closes #921. Refs pulp #913 (paint pump auto-wire), #918 (native rAF), spectr#28.

## Notes

Local SSH \`win\` lane is currently unreachable; cross-platform Windows validation runs via Namespace.