### PR TITLE
fix(view): canvas widget transparent by default + real clearRect (#929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0530"></a>
+## [0.55.0]
+
 ## [0.54.0]
 
 ## [0.53.0] - 2026-04-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0560"></a>
+## [0.57.0]
+
 ## [0.56.0] - 2026-04-28
 
 - feat(view): setBoxShadow JS bridge + draw_box_shadow Canvas primitive (#925) ([#936](https://github.com/danielraffel/pulp/pull/936))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0530"></a>
+## [0.54.0]
+
 ## [0.53.0] - 2026-04-28
 
 - feat(coverage): local diff-coverage check mirroring CI's gate ([#919](https://github.com/danielraffel/pulp/pull/919))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0530"></a>
+## [0.56.0]
+
 ## [0.55.0]
 
 ## [0.54.0]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.54.0
+    VERSION 0.55.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.56.0
+    VERSION 0.57.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.53.0
+    VERSION 0.54.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.55.0
+    VERSION 0.56.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -710,6 +710,8 @@ struct DrawCommand {
         set_line_dash,      ///< intervals stored in `floats`, phase in f[0]
         draw_image,         ///< source path/url in `text`, dst rect in f[0..3]
         write_pixels,       ///< RGBA bytes in `text` (binary), w/h in f[0..1], dst in f[2..3]
+        // ── issue-925: setBoxShadow / draw_box_shadow ─────────────────
+        draw_box_shadow,    ///< x/y/w/h in f[0..3], blur in f[4], spread/offsets via floats payload
         // ── issue-926: save_backdrop_filter for frosted-glass overlays ─
         save_backdrop_filter, ///< x/y/w/h in f[0..3], blur_radius in f[4]
         // ── issue-929: real clearRect that replaces pixels ────────────

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -317,6 +317,22 @@ public:
     virtual void fill_circle(float cx, float cy, float radius) = 0;
     virtual void stroke_circle(float cx, float cy, float radius) = 0;
 
+    /// Clear a rectangular region to transparent black (rgba 0,0,0,0).
+    /// Equivalent to CanvasRenderingContext2D.clearRect — replaces existing
+    /// pixels rather than compositing over them. Pixel backends (SkiaCanvas)
+    /// override with a kSrc/kClear paint so the underlying texels actually
+    /// become transparent; the default falls back to a SrcOver fill with a
+    /// transparent color (a no-op on most surfaces, but keeps recording /
+    /// introspection backends inert). See pulp issue #929 — without this,
+    /// ctx.clearRect() on the canvas widget would not clear residual or
+    /// parent-painted pixels.
+    virtual void clear_rect(float x, float y, float w, float h) {
+        // Default: best-effort SrcOver fill with transparent color. Pixel
+        // backends should override to use kSrc / kClear blend.
+        set_fill_color(Color::rgba(0.0f, 0.0f, 0.0f, 0.0f));
+        fill_rect(x, y, w, h);
+    }
+
     // ── Arcs ─────────────────────────────────────────────────────────────
     virtual void stroke_arc(float cx, float cy, float radius,
                            float start_angle, float end_angle) = 0;
@@ -627,7 +643,9 @@ struct DrawCommand {
         // ── issue-916: Canvas2D API gaps ──────────────────────────────
         set_line_dash,      ///< intervals stored in `floats`, phase in f[0]
         draw_image,         ///< source path/url in `text`, dst rect in f[0..3]
-        write_pixels        ///< RGBA bytes in `text` (binary), w/h in f[0..1], dst in f[2..3]
+        write_pixels,       ///< RGBA bytes in `text` (binary), w/h in f[0..1], dst in f[2..3]
+        // ── issue-929: real clearRect that replaces pixels ────────────
+        clear_rect          ///< clear rect, x/y/w/h in f[0..3]
     };
 
     Type type;
@@ -673,6 +691,7 @@ public:
     void set_line_cap(LineCap cap) override;
     void set_line_join(LineJoin join) override;
     void fill_rect(float x, float y, float w, float h) override;
+    void clear_rect(float x, float y, float w, float h) override;
     void stroke_rect(float x, float y, float w, float h) override;
     void fill_rounded_rect(float x, float y, float w, float h, float radius) override;
     void stroke_rounded_rect(float x, float y, float w, float h, float radius) override;

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -694,6 +694,8 @@ struct DrawCommand {
         set_line_dash,      ///< intervals stored in `floats`, phase in f[0]
         draw_image,         ///< source path/url in `text`, dst rect in f[0..3]
         write_pixels,       ///< RGBA bytes in `text` (binary), w/h in f[0..1], dst in f[2..3]
+        // ── issue-926: save_backdrop_filter for frosted-glass overlays ─
+        save_backdrop_filter, ///< x/y/w/h in f[0..3], blur_radius in f[4]
         // ── issue-929: real clearRect that replaces pixels ────────────
         clear_rect          ///< clear rect, x/y/w/h in f[0..3]
     };

--- a/core/canvas/include/pulp/canvas/cg_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/cg_canvas.hpp
@@ -30,6 +30,7 @@ public:
     void set_line_join(LineJoin join) override;
 
     void fill_rect(float x, float y, float w, float h) override;
+    void clear_rect(float x, float y, float w, float h) override;
     void stroke_rect(float x, float y, float w, float h) override;
     void fill_rounded_rect(float x, float y, float w, float h, float radius) override;
     void stroke_rounded_rect(float x, float y, float w, float h, float radius) override;

--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -59,6 +59,7 @@ public:
 
     // ── Shapes ───────────────────────────────────────────────────────────
     void fill_rect(float x, float y, float w, float h) override;
+    void clear_rect(float x, float y, float w, float h) override;
     void stroke_rect(float x, float y, float w, float h) override;
     void fill_rounded_rect(float x, float y, float w, float h, float radius) override;
     void stroke_rounded_rect(float x, float y, float w, float h, float radius) override;

--- a/core/canvas/platform/mac/cg_canvas.mm
+++ b/core/canvas/platform/mac/cg_canvas.mm
@@ -86,6 +86,16 @@ void CoreGraphicsCanvas::fill_rect(float x, float y, float w, float h) {
     CGContextFillRect(ctx_, CGRectMake(x, y, w, h));
 }
 
+// pulp #929 — clearRect must replace destination pixels with transparent
+// black, not SrcOver-blend a transparent fill (which CoreGraphics would
+// treat as a no-op the same way Skia does). CGContextClearRect zeroes
+// the alpha channel of the destination region directly, mirroring the
+// CanvasRenderingContext2D.clearRect spec for the CoreGraphics-backed
+// macOS / iOS render paths.
+void CoreGraphicsCanvas::clear_rect(float x, float y, float w, float h) {
+    CGContextClearRect(ctx_, CGRectMake(x, y, w, h));
+}
+
 void CoreGraphicsCanvas::stroke_rect(float x, float y, float w, float h) {
     apply_stroke_color();
     CGContextStrokeRect(ctx_, CGRectMake(x, y, w, h));

--- a/core/canvas/src/recording_canvas.cpp
+++ b/core/canvas/src/recording_canvas.cpp
@@ -99,6 +99,14 @@ void RecordingCanvas::fill_rect(float x, float y, float w, float h) {
     commands_.push_back(cmd);
 }
 
+// pulp #929 — record clearRect distinctly from fill_rect so tests can assert
+// CanvasWidget::paint() does not pre-fill its bounds with a solid background.
+void RecordingCanvas::clear_rect(float x, float y, float w, float h) {
+    DrawCommand cmd{DrawCommand::Type::clear_rect};
+    cmd.f[0] = x; cmd.f[1] = y; cmd.f[2] = w; cmd.f[3] = h;
+    commands_.push_back(cmd);
+}
+
 void RecordingCanvas::stroke_rect(float x, float y, float w, float h) {
     DrawCommand cmd{DrawCommand::Type::stroke_rect};
     cmd.f[0] = x; cmd.f[1] = y; cmd.f[2] = w; cmd.f[3] = h;

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -225,6 +225,21 @@ void SkiaCanvas::fill_rect(float x, float y, float w, float h) {
     GUARD_CANVAS; canvas_->drawRect(SkRect::MakeXYWH(x, y, w, h), make_fill_paint(fill_color_));
 }
 
+// pulp #929 — clearRect must actually clear pixels rather than compose a
+// transparent SrcOver fill (which is a visual no-op). Use SkBlendMode::kClear
+// so the destination texels become transparent black, mirroring the HTML
+// CanvasRenderingContext2D.clearRect semantics. Without this, the canvas
+// widget sat over whatever the parent had previously painted (or the
+// undefined swapchain-texture pixels), which on FilterBank looked like a
+// stuck white inner area.
+void SkiaCanvas::clear_rect(float x, float y, float w, float h) {
+    GUARD_CANVAS;
+    SkPaint paint;
+    paint.setBlendMode(SkBlendMode::kClear);
+    paint.setAntiAlias(false);
+    canvas_->drawRect(SkRect::MakeXYWH(x, y, w, h), paint);
+}
+
 // Apply the active line-dash pattern to a stroke paint (issue-916).
 // Skia's SkDashPathEffect requires an even-length pattern with
 // nonnegative entries; the JS bridge ensures both, so we treat any

--- a/core/view/src/canvas_widget.cpp
+++ b/core/view/src/canvas_widget.cpp
@@ -12,6 +12,19 @@ void CanvasWidget::paint(canvas::Canvas& canvas) {
     // P1 follow-up to issue-896).
     canvas.capture_paint_baseline_transform();
     last_native_gpu_texture_draw_succeeded_ = false;
+
+    // pulp #929 — Canvas widget paint contract:
+    //   * The widget MUST NOT pre-fill its bounds with an opaque background
+    //     before processing JS draw commands. The default state is fully
+    //     transparent so the parent's paint surface (View::paint_self_and_children
+    //     paints background + border before invoking this paint()) shows
+    //     through wherever the JS code does not explicitly draw.
+    //   * If the JS code wants an opaque background it must issue an explicit
+    //     fill_rect / clear command.
+    //   * If the host caller wants a regression check, the test below records
+    //     against a RecordingCanvas and asserts no full-bounds fill_rect was
+    //     emitted (test_canvas_widget.cpp [issue-929]).
+    // Do NOT add any unconditional fill / clear here.
 #ifdef PULP_HAS_SKIA
     if (native_gpu_texture_provider_) {
         auto frame = native_gpu_texture_provider_();
@@ -208,13 +221,13 @@ void CanvasWidget::paint(canvas::Canvas& canvas) {
             canvas.clear_fill_gradient();
             break;
 
-        // Clear rect
+        // Clear rect (pulp #929) — replace pixels with transparent black, do
+        // not SrcOver-blend a transparent fill (which is a no-op). The
+        // canvas::Canvas API exposes clear_rect with a kClear-equivalent
+        // implementation per backend; this is what CanvasRenderingContext2D
+        // .clearRect must do per the HTML spec.
         case CanvasDrawCmd::Type::clear_rect:
-            canvas.save();
-            canvas.clip_rect(cmd.x, cmd.y, cmd.w, cmd.h);
-            canvas.set_fill_color({0, 0, 0, 0});
-            canvas.fill_rect(cmd.x, cmd.y, cmd.w, cmd.h);
-            canvas.restore();
+            canvas.clear_rect(cmd.x, cmd.y, cmd.w, cmd.h);
             break;
 
         // Draw image — issue-916.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1188,6 +1188,11 @@ endif()
 # Canvas tests
 add_executable(pulp-test-canvas test_canvas.cpp)
 target_link_libraries(pulp-test-canvas PRIVATE pulp::canvas Catch2::Catch2WithMain)
+if(APPLE)
+    # CoreGraphicsCanvas tests (#929) build a CGBitmapContext directly to
+    # verify CGContextClearRect actually clears destination pixels.
+    target_link_libraries(pulp-test-canvas PRIVATE "-framework CoreGraphics")
+endif()
 catch_discover_tests(pulp-test-canvas)
 
 # SDF glyph atlas exploration (#76)

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -15,6 +15,11 @@
 #include "include/core/SkSurface.h"
 #endif
 
+#ifdef __APPLE__
+#include <pulp/canvas/cg_canvas.hpp>
+#include <CoreGraphics/CoreGraphics.h>
+#endif
+
 using namespace pulp::canvas;
 
 TEST_CASE("RecordingCanvas captures commands", "[canvas]") {
@@ -447,3 +452,116 @@ TEST_CASE("SkiaCanvas::set_line_dash applies an SkDashPathEffect on stroke",
     REQUIRE(light > 8);
 }
 #endif
+
+// ── pulp #929 — Canvas::clear_rect default + CoreGraphics override ──────────
+
+namespace {
+
+// Minimal Canvas subclass that records every fill_rect / set_fill_color call
+// so we can assert the documented Canvas::clear_rect default behaviour
+// (delegates to set_fill_color(transparent) + fill_rect) without coupling to
+// any real GPU/CPU backend.
+class StubCanvas : public Canvas {
+public:
+    struct FillRectCall { float x, y, w, h; Color color; };
+    std::vector<FillRectCall> fills;
+    Color current_color = Color::rgba(1.0f, 1.0f, 1.0f, 1.0f);
+
+    void save() override {}
+    void restore() override {}
+    void translate(float, float) override {}
+    void scale(float, float) override {}
+    void rotate(float) override {}
+    void clip_rect(float, float, float, float) override {}
+    void set_fill_color(Color c) override { current_color = c; }
+    void set_stroke_color(Color) override {}
+    void set_line_width(float) override {}
+    void set_line_cap(LineCap) override {}
+    void set_line_join(LineJoin) override {}
+    void fill_rect(float x, float y, float w, float h) override {
+        fills.push_back({x, y, w, h, current_color});
+    }
+    void stroke_rect(float, float, float, float) override {}
+    void fill_rounded_rect(float, float, float, float, float) override {}
+    void stroke_rounded_rect(float, float, float, float, float) override {}
+    void fill_circle(float, float, float) override {}
+    void stroke_circle(float, float, float) override {}
+    void stroke_arc(float, float, float, float, float) override {}
+    void stroke_line(float, float, float, float) override {}
+    void set_font(const std::string&, float) override {}
+    void set_text_align(TextAlign) override {}
+    void fill_text(const std::string&, float, float) override {}
+    float measure_text(const std::string&) override { return 0.0f; }
+};
+
+}  // namespace
+
+TEST_CASE("Canvas::clear_rect default falls back to transparent fill_rect",
+          "[canvas][issue-929]") {
+    StubCanvas canvas;
+    canvas.set_fill_color(Color::rgba(1.0f, 0.0f, 0.0f, 1.0f));
+    canvas.clear_rect(5, 6, 7, 8);
+
+    REQUIRE(canvas.fills.size() == 1);
+    REQUIRE(canvas.fills[0].x == 5.0f);
+    REQUIRE(canvas.fills[0].y == 6.0f);
+    REQUIRE(canvas.fills[0].w == 7.0f);
+    REQUIRE(canvas.fills[0].h == 8.0f);
+    // Default fallback set the fill color to transparent before drawing.
+    REQUIRE(canvas.fills[0].color.a == 0.0f);
+    REQUIRE(canvas.current_color.a == 0.0f);
+}
+
+TEST_CASE("RecordingCanvas::clear_rect emits a dedicated clear_rect command",
+          "[canvas][issue-929]") {
+    RecordingCanvas rc;
+    rc.clear_rect(1, 2, 3, 4);
+
+    REQUIRE(rc.commands().size() == 1);
+    REQUIRE(rc.commands()[0].type == DrawCommand::Type::clear_rect);
+    REQUIRE(rc.commands()[0].f[0] == 1.0f);
+    REQUIRE(rc.commands()[0].f[1] == 2.0f);
+    REQUIRE(rc.commands()[0].f[2] == 3.0f);
+    REQUIRE(rc.commands()[0].f[3] == 4.0f);
+}
+
+#ifdef __APPLE__
+TEST_CASE("CoreGraphicsCanvas::clear_rect zeroes destination pixels",
+          "[canvas][cg][issue-929]") {
+    // Build a 16x16 RGBA8 CGBitmapContext, fill it with opaque red, then
+    // ask CoreGraphicsCanvas::clear_rect to clear the entire region. Read
+    // back the pixels — every byte should be zero (transparent black),
+    // proving CGContextClearRect actually replaces destination texels
+    // rather than SrcOver-ing a transparent fill.
+    constexpr int W = 16;
+    constexpr int H = 16;
+    std::vector<uint8_t> pixels(static_cast<size_t>(W) * H * 4u, 0u);
+    auto cs = CGColorSpaceCreateDeviceRGB();
+    REQUIRE(cs != nullptr);
+    const uint32_t bitmap_info =
+        static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) |
+        static_cast<uint32_t>(kCGBitmapByteOrder32Big);
+    CGContextRef ctx = CGBitmapContextCreate(
+        pixels.data(), W, H, 8, W * 4u, cs, bitmap_info);
+    CGColorSpaceRelease(cs);
+    REQUIRE(ctx != nullptr);
+
+    // Pre-fill with opaque red via CG directly so the test doesn't rely on
+    // any CoreGraphicsCanvas method other than clear_rect.
+    CGContextSetRGBFillColor(ctx, 1.0f, 0.0f, 0.0f, 1.0f);
+    CGContextFillRect(ctx, CGRectMake(0, 0, W, H));
+
+    {
+        CoreGraphicsCanvas canvas(ctx, static_cast<float>(W),
+                                  static_cast<float>(H));
+        canvas.clear_rect(0, 0, W, H);
+    }
+    CGContextRelease(ctx);
+
+    // Every pixel byte must be zero after CGContextClearRect.
+    for (size_t i = 0; i < pixels.size(); ++i) {
+        INFO("Pixel byte " << i << " value=" << int(pixels[i]));
+        REQUIRE(pixels[i] == 0);
+    }
+}
+#endif  // __APPLE__

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -4,7 +4,18 @@
 #include <pulp/view/theme.hpp>
 #include <pulp/canvas/canvas.hpp>
 
+#ifdef PULP_HAS_SKIA
+#include <pulp/canvas/skia_canvas.hpp>
+#include "include/core/SkCanvas.h"
+#include "include/core/SkColor.h"
+#include "include/core/SkColorSpace.h"
+#include "include/core/SkImageInfo.h"
+#include "include/core/SkPixmap.h"
+#include "include/core/SkSurface.h"
+#endif
+
 using namespace pulp::view;
+using pulp::canvas::DrawCommand;
 using pulp::canvas::RecordingCanvas;
 
 TEST_CASE("CanvasWidget: add and clear commands", "[canvas_widget]") {
@@ -124,3 +135,187 @@ TEST_CASE("CanvasWidget::paint baseline capture is idempotent and ordered",
     REQUIRE(rc.baseline_capture_count() == 1);
     REQUIRE_FALSE(rc.commands().empty());
 }
+
+// ── pulp #929 — Canvas widget transparent default + clearRect semantics ──
+
+// Empty-command paint must not introduce a full-bounds fill that would
+// hide the parent's painted surface. Asserting against RecordingCanvas
+// gives us a backend-independent regression guard, even on platforms
+// where Skia raster isn't available in the test build.
+TEST_CASE("CanvasWidget::paint with no JS draw commands does not pre-fill bounds",
+          "[canvas_widget][issue-929]") {
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 200, 100});
+
+    cw.paint(rc);
+
+    // Allowed bookkeeping commands: capture_paint_baseline_transform()
+    // does not add to commands_, so the recorded list should stay empty.
+    // What MUST NOT happen: a fill_rect covering the widget bounds. We
+    // walk the full command list to be defensive against future state-
+    // tracking commands sneaking in (set_blend_mode, save, etc.).
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::fill_rect) {
+            const bool covers_bounds = cmd.f[0] <= 0.0f && cmd.f[1] <= 0.0f &&
+                                       cmd.f[2] >= 200.0f && cmd.f[3] >= 100.0f;
+            INFO("CanvasWidget::paint emitted a fill_rect that covers the full "
+                 "widget bounds — this would mask the parent's paint surface "
+                 "(pulp #929).");
+            REQUIRE_FALSE(covers_bounds);
+        }
+    }
+}
+
+// JS-issued clearRect should produce a single clear_rect command, not a
+// SrcOver fill that is a no-op. RecordingCanvas captures the dedicated
+// DrawCommand::Type::clear_rect introduced in pulp #929 so this is a
+// straightforward identity assertion.
+TEST_CASE("CanvasWidget::paint translates clearRect into a real clear_rect command",
+          "[canvas_widget][issue-929]") {
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 200, 100});
+
+    CanvasDrawCmd c;
+    c.type = CanvasDrawCmd::Type::clear_rect;
+    c.x = 10; c.y = 20; c.w = 80; c.h = 40;
+    cw.add_command(c);
+
+    cw.paint(rc);
+
+    // Exactly one clear_rect command, matching the JS-issued bounds.
+    size_t clear_count = 0;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::clear_rect) {
+            ++clear_count;
+            REQUIRE(cmd.f[0] == 10.0f);
+            REQUIRE(cmd.f[1] == 20.0f);
+            REQUIRE(cmd.f[2] == 80.0f);
+            REQUIRE(cmd.f[3] == 40.0f);
+        }
+    }
+    REQUIRE(clear_count == 1);
+
+    // And no SrcOver fill_rect snuck in — the previous implementation was
+    // save / clip / setFillColor(0,0,0,0) / fill_rect, which is a visual
+    // no-op (#929 root cause).
+    for (const auto& cmd : rc.commands()) {
+        REQUIRE(cmd.type != DrawCommand::Type::fill_rect);
+    }
+}
+
+#ifdef PULP_HAS_SKIA
+
+namespace {
+struct Pixel {
+    uint8_t r, g, b, a;
+};
+
+// Sample a single RGBA8 pixel (premul) from a Skia raster surface so
+// tests can assert on the actual texels CanvasWidget produced.
+Pixel sample_pixel(SkSurface* surface, int x, int y) {
+    SkPixmap pix;
+    REQUIRE(surface->peekPixels(&pix));
+    auto* row = static_cast<const uint8_t*>(pix.addr(0, y));
+    return {row[4 * x + 0], row[4 * x + 1], row[4 * x + 2], row[4 * x + 3]};
+}
+}  // namespace
+
+TEST_CASE("CanvasWidget paints transparent by default on a Skia raster surface",
+          "[canvas_widget][skia][issue-929]") {
+    // Premultiplied RGBA8 raster surface — Skia initializes the backing
+    // store to all-zero (fully transparent) on first access. If the
+    // CanvasWidget were pre-filling its bounds with white, every sampled
+    // pixel would become (255, 255, 255, 255).
+    SkImageInfo info = SkImageInfo::Make(64, 64, kRGBA_8888_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    auto* sk_canvas = surface->getCanvas();
+    REQUIRE(sk_canvas != nullptr);
+
+    pulp::canvas::SkiaCanvas canvas(sk_canvas);
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 64, 64});
+    cw.paint(canvas);
+
+    // Spot-check four corners + center — all pixels stay fully transparent.
+    for (auto [x, y] : std::initializer_list<std::pair<int, int>>{
+             {0, 0}, {63, 0}, {0, 63}, {63, 63}, {32, 32}}) {
+        auto px = sample_pixel(surface.get(), x, y);
+        INFO("Pixel (" << x << "," << y << ") rgba=("
+             << int(px.r) << "," << int(px.g) << ","
+             << int(px.b) << "," << int(px.a) << ")");
+        REQUIRE(px.a == 0);
+        REQUIRE(px.r == 0);
+        REQUIRE(px.g == 0);
+        REQUIRE(px.b == 0);
+    }
+}
+
+TEST_CASE("CanvasWidget partial fillRect leaves untouched pixels transparent",
+          "[canvas_widget][skia][issue-929]") {
+    // 64x64 surface; widget fills a 32x64 left half with opaque red. The
+    // right half must stay at the surface's initial transparent black.
+    SkImageInfo info = SkImageInfo::Make(64, 64, kRGBA_8888_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    pulp::canvas::SkiaCanvas canvas(surface->getCanvas());
+
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 64, 64});
+    CanvasDrawCmd r;
+    r.type = CanvasDrawCmd::Type::fill_rect;
+    r.x = 0; r.y = 0; r.w = 32; r.h = 64;
+    r.color = {255, 0, 0, 255};
+    cw.add_command(r);
+    cw.paint(canvas);
+
+    // Inside the fill: opaque red.
+    auto inside = sample_pixel(surface.get(), 16, 32);
+    REQUIRE(inside.a == 255);
+    REQUIRE(inside.r == 255);
+    // Outside the fill: still transparent.
+    auto outside = sample_pixel(surface.get(), 48, 32);
+    REQUIRE(outside.a == 0);
+    REQUIRE(outside.r == 0);
+}
+
+TEST_CASE("CanvasWidget clearRect actually clears Skia pixels",
+          "[canvas_widget][skia][issue-929]") {
+    // Pre-fill the surface with opaque white (simulates a parent's paint
+    // pass having already drawn the underlying area). A subsequent
+    // clearRect issued through CanvasWidget must replace those pixels
+    // with transparent black, not SrcOver-blend a transparent fill.
+    SkImageInfo info = SkImageInfo::Make(32, 32, kRGBA_8888_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    auto* sk_canvas = surface->getCanvas();
+    sk_canvas->clear(SkColorSetARGB(255, 255, 255, 255));
+
+    pulp::canvas::SkiaCanvas canvas(sk_canvas);
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 32, 32});
+    CanvasDrawCmd c;
+    c.type = CanvasDrawCmd::Type::clear_rect;
+    c.x = 0; c.y = 0; c.w = 32; c.h = 32;
+    cw.add_command(c);
+    cw.paint(canvas);
+
+    auto px = sample_pixel(surface.get(), 16, 16);
+    INFO("Cleared pixel rgba=("
+         << int(px.r) << "," << int(px.g) << ","
+         << int(px.b) << "," << int(px.a) << ")");
+    REQUIRE(px.a == 0);
+    REQUIRE(px.r == 0);
+    REQUIRE(px.g == 0);
+    REQUIRE(px.b == 0);
+}
+
+#endif  // PULP_HAS_SKIA


### PR DESCRIPTION
CanvasWidget::paint() must not pre-fill its bounds with an opaque
background — the default state is fully transparent so the parent
View's painted surface shows through wherever JS hasn't drawn. The
previous clear_rect handler did `set_fill_color({0,0,0,0})` +
`fill_rect`, which under SkBlendMode::kSrcOver is a visual no-op and
left whatever pixels happened to be underneath untouched (frame-stale
or undefined swapchain texels). FilterBank's `ctx.clearRect()` therefore
never cleared anything, leaving the canvas surface looking white in
Spectr#28's reproducer.

Changes:
- canvas::Canvas: add `clear_rect(x,y,w,h)` virtual with a documented
  SrcOver fallback default. Pixel backends override.
- SkiaCanvas: override clear_rect with SkBlendMode::kClear paint so the
  underlying texels actually become transparent, mirroring the
  CanvasRenderingContext2D.clearRect spec.
- RecordingCanvas: record a dedicated DrawCommand::Type::clear_rect so
  tests can assert CanvasWidget never emits a full-bounds fill_rect as
  the first command.
- CanvasWidget::paint: explicit no-pre-fill comment + use the new
  Canvas::clear_rect API for the JS clearRect bridge.
- Tests (test_canvas_widget.cpp):
  * RecordingCanvas: paint with no JS commands → no full-bounds
    fill_rect recorded.
  * RecordingCanvas: clearRect produces a single clear_rect command
    with the expected bounds and no SrcOver fill_rect.
  * Skia raster (PULP_HAS_SKIA): empty paint leaves all pixels at
    transparent black.
  * Skia raster: partial fillRect leaves uncovered pixels transparent.
  * Skia raster: clearRect over a pre-filled white surface produces
    transparent pixels (the regression guard for the previous bug).

Issue: #929
Tracked-under: #924