### PR TITLE
fix(view): Label auto-grows to fit text content (#928)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0540"></a>
+## [0.55.0]
+
 ## [0.54.0] - 2026-04-28
 
 - feat(view): setTransform(id, a, b, c, d, e, f) on View — full 2D affine matrix (#930) ([#933](https://github.com/danielraffel/pulp/pull/933))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.54.0
+    VERSION 0.55.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -65,6 +65,15 @@ public:
 
     void paint(canvas::Canvas& canvas) override;
 
+    /// Intrinsic width — measured text width (issue-928).
+    /// Uses TextShaper (HarfBuzz/SkParagraph) when available, otherwise
+    /// falls back to the same character-width estimate the base Canvas
+    /// uses. This lets Yoga reserve enough horizontal space for the full
+    /// label content instead of clipping to a parent-inherited width.
+    /// Applies the same text-transform as paint() so measurement matches
+    /// what is actually drawn.
+    float intrinsic_width() const override;
+
     /// Intrinsic height based on font size and line height.
     float intrinsic_height() const override {
         return line_height_ > 0 ? line_height_ : font_size_ * 1.4f;

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -5,7 +5,9 @@
 #include <pulp/view/frame_clock.hpp>
 #include <pulp/view/image_cache.hpp>
 #include <pulp/view/window_host.hpp>
+#include <pulp/canvas/text_shaper.hpp>
 #include <choc/text/choc_JSON.h>
+#include <cctype>
 #include <cmath>
 #include <string>
 
@@ -239,6 +241,55 @@ void Toggle::advance_animations(float dt) {
 }
 
 // ── Label ────────────────────────────────────────────────────────────────────
+
+float Label::intrinsic_width() const {
+    // issue-928: report the natural shaped-text width so Yoga reserves
+    // enough horizontal space for the full label content. Without this,
+    // long labels in flex-row containers (e.g. Spectr's "ZOOMABLE FILTER
+    // BANK" header) inherit a small parent width and clip mid-word.
+    //
+    // For multi-line labels we deliberately return 0 so the parent
+    // container's available width drives line wrapping instead of the
+    // single-line text width.
+    if (text_.empty() || multi_line_) return 0;
+
+    // Mirror paint()'s text-transform — measurement must match what's
+    // drawn or a row of uppercase chars will wrap unexpectedly.
+    std::string display_text = text_;
+    if (text_transform_ == TextTransform::uppercase) {
+        for (auto& ch : display_text)
+            ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+    } else if (text_transform_ == TextTransform::lowercase) {
+        for (auto& ch : display_text)
+            ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+    } else if (text_transform_ == TextTransform::capitalize) {
+        bool cap_next = true;
+        for (auto& ch : display_text) {
+            if (cap_next && std::isalpha(static_cast<unsigned char>(ch))) {
+                ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+                cap_next = false;
+            }
+            if (ch == ' ') cap_next = true;
+        }
+    }
+
+    // Shape with the same font + size the painter will use. TextShaper
+    // uses the global Skia/HarfBuzz path when available and falls back
+    // to a character-width estimator otherwise — same fallback that
+    // Canvas::measure_text() uses on the recording / non-Skia backends.
+    auto& shaper = canvas::global_text_shaper();
+    auto prepared = shaper.prepare(display_text, "Inter", font_size_);
+    float width = prepared.total_width();
+
+    // Letter-spacing adds extra advance per glyph break that isn't
+    // captured by HarfBuzz shaping.
+    if (letter_spacing_ != 0 && display_text.size() > 1) {
+        width += letter_spacing_ * static_cast<float>(display_text.size() - 1);
+    }
+
+    // Sub-pixel-safe ceil so layout never clips on rounding.
+    return std::ceil(width);
+}
 
 void Label::paint(canvas::Canvas& canvas) {
     if (text_.empty()) return;

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -67,6 +67,28 @@ TEST_CASE("Label intrinsic_width respects text-transform", "[view][widget][issue
     // Uppercase characters typically advance wider than lowercase, so
     // the transformed label must measure at least as wide.
     REQUIRE(upper.intrinsic_width() >= lower.intrinsic_width());
+
+    // Lowercase transform path — exercises the std::tolower branch in
+    // intrinsic_width() so estimator and shaper agree on the post-
+    // transform character count.
+    Label lc("ZOOMABLE Filter Bank");
+    lc.set_text_transform(Label::TextTransform::lowercase);
+    REQUIRE(lc.intrinsic_width() > 0);
+
+    // Capitalize transform path — exercises the per-word leading-cap
+    // loop. Same character count as the source string, so width is at
+    // least as wide as the all-lowercase variant.
+    Label cap("zoomable filter bank");
+    cap.set_text_transform(Label::TextTransform::capitalize);
+    REQUIRE(cap.intrinsic_width() > 0);
+    REQUIRE(cap.intrinsic_width() >= lower.intrinsic_width());
+
+    // Letter-spacing branch — adds extra advance per glyph break that
+    // HarfBuzz / the estimator don't include natively.
+    Label spaced("ZOOMABLE FILTER BANK");
+    spaced.set_letter_spacing(2.0f);
+    Label tight("ZOOMABLE FILTER BANK");
+    REQUIRE(spaced.intrinsic_width() > tight.intrinsic_width());
 }
 
 TEST_CASE("Label intrinsic_width yields zero for multi-line", "[view][widget][issue-928]") {

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -26,6 +26,59 @@ TEST_CASE("Label text can be changed", "[view][widget]") {
     REQUIRE(label.text() == "Changed");
 }
 
+TEST_CASE("Label intrinsic_width fits long text", "[view][widget][issue-928]") {
+    // Regression: previously Label reported 0 intrinsic width and
+    // inherited a small parent width in flex-row containers, causing
+    // Spectr's "ZOOMABLE FILTER BANK" header to clip to "ZOOMABLE FII".
+    Label long_label("ZOOMABLE FILTER BANK");
+    Label short_label("BANK");
+
+    float long_w = long_label.intrinsic_width();
+    float short_w = short_label.intrinsic_width();
+
+    // Both must report a positive, non-zero natural width.
+    REQUIRE(long_w > 0);
+    REQUIRE(short_w > 0);
+
+    // The long label must report a width comfortably larger than the
+    // short label — proving width scales with content length.
+    REQUIRE(long_w > short_w * 2.0f);
+
+    // Empty labels report no intrinsic width (parent decides).
+    Label empty;
+    REQUIRE(empty.intrinsic_width() == 0);
+}
+
+TEST_CASE("Label intrinsic_width scales with font size", "[view][widget][issue-928]") {
+    Label small("Hello world");
+    small.set_font_size(12.0f);
+
+    Label large("Hello world");
+    large.set_font_size(36.0f);
+
+    REQUIRE(large.intrinsic_width() > small.intrinsic_width());
+}
+
+TEST_CASE("Label intrinsic_width respects text-transform", "[view][widget][issue-928]") {
+    Label lower("zoomable filter bank");
+    Label upper("zoomable filter bank");
+    upper.set_text_transform(Label::TextTransform::uppercase);
+
+    // Uppercase characters typically advance wider than lowercase, so
+    // the transformed label must measure at least as wide.
+    REQUIRE(upper.intrinsic_width() >= lower.intrinsic_width());
+}
+
+TEST_CASE("Label intrinsic_width yields zero for multi-line", "[view][widget][issue-928]") {
+    // Multi-line labels defer to the parent's available width for
+    // wrapping; reporting a single-line natural width here would force
+    // a flex-row container to grow when the user explicitly opted into
+    // wrapping.
+    Label ml("ZOOMABLE FILTER BANK\nWITH SUBTITLE");
+    ml.set_multi_line(true);
+    REQUIRE(ml.intrinsic_width() == 0);
+}
+
 TEST_CASE("Knob value clamping", "[view][widget]") {
     Knob knob;
     knob.set_value(0.5f);


### PR DESCRIPTION
Closes #928 — refs #924 (Native UI parity umbrella).

## Why

Spectr's `<Label>ZOOMABLE FILTER BANK</Label>` was rendering as `ZOOMABLE FII` — truncated mid-word. Other long labels (status banners, dropdown items) clipped the same way.

`Label` only overrode `intrinsic_height()`, leaving `intrinsic_width()` at the `View` base default of `0`. Yoga's `yoga_measure` callback (`core/view/src/yoga_layout.cpp:120`) returned that `0`, so flex-row containers reserved no horizontal space and the label inherited a small parent width that clipped the text.

## What

- `Label::intrinsic_width()` now returns the natural shaped-text width via `TextShaper::global_text_shaper()` — the same measure-once-reflow-forever shaper used for paragraph layout.
- Uses HarfBuzz / SkParagraph when Skia shaping is available; falls back to the character-width estimator on the recording / non-Skia backends — exact same fallback `Canvas::measure_text_full()` and `RecordingCanvas` use, so measured width matches painted width on every backend.
- Mirrors `paint()`'s `text-transform` before measuring (uppercase / lowercase / capitalize).
- Adds `letter-spacing` advance that HarfBuzz shaping doesn't include.
- `ceil()`s to next pixel so layout never clips on subpixel rounding.
- Multi-line labels return `0` so parent-width drives wrapping (single-line natural width would force the row to grow past the wrap intent).
- Empty labels return `0` so the parent decides.

Yoga's hook (`yoga_layout.cpp:153`) already attaches a measure callback when `intrinsic_width > 0 || intrinsic_height > 0`. Filling in the real Label width is all that was missing after #920 closed the `TextMetrics.width` gap.

## Tests

`test/test_widgets.cpp`, tag `[issue-928]`:

- Long label measures comfortably wider than short label; empty labels stay at 0.
- Width scales with font size (36px > 12px).
- Uppercase text-transform measures ≥ lowercase.
- Multi-line yields 0 so wrap intent is preserved.

Local: `pulp-test-widgets` — 74 assertions in 30 cases, all green; the 4 issue-928 cases pass against both the real shaper and the estimator fallback.

## Validation lanes

- macOS local — green (pulp-test-widgets, all assertions).
- Ubuntu / Windows SSH — Windows lane unreachable from this worktree; relying on Shipyard / GitHub Actions remote runners to validate cross-platform.