### PR TITLE
feat(view): Label honors setFontFamily / setFontWeight / setLetterSpacing (#927)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0540"></a>
+## [0.55.0]
+
 ## [0.54.0] - 2026-04-28
 
 - feat(view): setTransform(id, a, b, c, d, e, f) on View — full 2D affine matrix (#930) ([#933](https://github.com/danielraffel/pulp/pull/933))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.54.0
+    VERSION 0.55.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -394,6 +394,20 @@ public:
     virtual void fill_text(const std::string& text, float x, float y) = 0;
     virtual float measure_text(const std::string& text) = 0;
 
+    /// Richer font setter that propagates CSS font-weight (100..900),
+    /// font-slant (0=upright, 1=italic), and letter-spacing (px between
+    /// glyphs) through to the backend. Default implementation forwards to
+    /// the legacy `set_font(family, size)` so non-Label callers keep
+    /// working unchanged. Backends that honor these properties (Skia,
+    /// CoreText, RecordingCanvas) override this to capture or apply them.
+    /// pulp #927 — Label widget honors setFontFamily / setFontWeight /
+    /// setLetterSpacing from JS.
+    virtual void set_font_full(const std::string& family, float size,
+                                int weight, int slant, float letter_spacing) {
+        (void)weight; (void)slant; (void)letter_spacing;
+        set_font(family, size);
+    }
+
     /// Full text metrics for layout and intrinsic sizing.
     /// Mirrors HTML5 TextMetrics — fields beyond width/ascent/descent are
     /// the bounding-box-only metrics required by CanvasRenderingContext2D
@@ -641,6 +655,11 @@ struct DrawCommand {
         fill_rect, stroke_rect, fill_rounded_rect, stroke_rounded_rect,
         fill_circle, stroke_circle, stroke_arc, stroke_line,
         set_font, set_text_align, fill_text,
+        // pulp #927 — full font setter: family in `text`, size/weight/slant/
+        // letter_spacing in f[0..3]. Emitted alongside (in addition to) the
+        // legacy set_font command so existing tests that count set_font
+        // continue to pass.
+        set_font_full,
         // ── issue-916: Canvas2D API gaps ──────────────────────────────
         set_line_dash,      ///< intervals stored in `floats`, phase in f[0]
         draw_image,         ///< source path/url in `text`, dst rect in f[0..3]
@@ -701,6 +720,8 @@ public:
                    float start_angle, float end_angle) override;
     void stroke_line(float x0, float y0, float x1, float y1) override;
     void set_font(const std::string& family, float size) override;
+    void set_font_full(const std::string& family, float size,
+                       int weight, int slant, float letter_spacing) override;
     void set_text_align(TextAlign align) override;
     void fill_text(const std::string& text, float x, float y) override;
     float measure_text(const std::string& text) override;

--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -76,6 +76,8 @@ public:
 
     // ── Text ─────────────────────────────────────────────────────────────
     void set_font(const std::string& family, float size) override;
+    void set_font_full(const std::string& family, float size,
+                       int weight, int slant, float letter_spacing) override;
     void set_text_align(TextAlign align) override;
     void fill_text(const std::string& text, float x, float y) override;
     void fill_text_sdf(const std::string& text, float x, float y,
@@ -163,6 +165,9 @@ private:
     LineCap line_cap_ = LineCap::butt;
     LineJoin line_join_ = LineJoin::miter;
     std::string font_family_ = "sans-serif";
+    int font_weight_ = 400;             ///< CSS weight 100..900 (pulp #927)
+    int font_slant_ = 0;                ///< 0=upright, 1=italic (pulp #927)
+    float letter_spacing_ = 0.0f;       ///< Extra advance per glyph in px (pulp #927)
     TextAlign text_align_ = TextAlign::left;
 
     // Gradient state

--- a/core/canvas/src/recording_canvas.cpp
+++ b/core/canvas/src/recording_canvas.cpp
@@ -159,6 +159,27 @@ void RecordingCanvas::set_font(const std::string& family, float size) {
     commands_.push_back(cmd);
 }
 
+void RecordingCanvas::set_font_full(const std::string& family, float size,
+                                    int weight, int slant, float letter_spacing) {
+    font_size_ = size;
+    // Record both the legacy set_font (for back-compat with existing tests
+    // that count fonts) and the rich set_font_full so callers can assert
+    // on the propagated weight / slant / letter_spacing. pulp #927.
+    {
+        DrawCommand cmd{DrawCommand::Type::set_font};
+        cmd.text = family;
+        cmd.f[0] = size;
+        commands_.push_back(cmd);
+    }
+    DrawCommand full{DrawCommand::Type::set_font_full};
+    full.text = family;
+    full.f[0] = size;
+    full.f[1] = static_cast<float>(weight);
+    full.f[2] = static_cast<float>(slant);
+    full.f[3] = letter_spacing;
+    commands_.push_back(full);
+}
+
 void RecordingCanvas::set_text_align(TextAlign align) {
     DrawCommand cmd{DrawCommand::Type::set_text_align};
     cmd.f[0] = static_cast<float>(align);

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -99,19 +99,46 @@ static SkPaint make_stroke_paint(Color c, float width) {
 }
 
 // Cached typeface loaded directly from a known path — bypasses family name
-// matching for deterministic metrics (Visage-style approach).
-static sk_sp<SkTypeface> get_cached_typeface(const std::string& family) {
-    static std::unordered_map<std::string, sk_sp<SkTypeface>> cache;
-    auto it = cache.find(family);
+// matching for deterministic metrics (Visage-style approach). Cache key
+// includes weight + slant so setFontWeight(700) actually returns a bold
+// typeface rather than the same Regular blob (pulp #927).
+static sk_sp<SkTypeface> get_cached_typeface(const std::string& family,
+                                             int weight, int slant) {
+    struct Key { std::string family; int weight; int slant; };
+    struct KeyHash {
+        size_t operator()(const Key& k) const noexcept {
+            return std::hash<std::string>{}(k.family)
+                ^ (static_cast<size_t>(k.weight) * 31u)
+                ^ (static_cast<size_t>(k.slant) * 1297u);
+        }
+    };
+    struct KeyEq {
+        bool operator()(const Key& a, const Key& b) const noexcept {
+            return a.weight == b.weight && a.slant == b.slant && a.family == b.family;
+        }
+    };
+    static std::unordered_map<Key, sk_sp<SkTypeface>, KeyHash, KeyEq> cache;
+
+    Key key{family, weight, slant};
+    auto it = cache.find(key);
     if (it != cache.end()) return it->second;
+
+    SkFontStyle sk_style{
+        weight,
+        SkFontStyle::kNormal_Width,
+        slant ? SkFontStyle::kItalic_Slant : SkFontStyle::kUpright_Slant
+    };
 
     sk_sp<SkTypeface> typeface;
 
 #if defined(__ANDROID__)
     // Load Roboto directly from filesystem for deterministic rendering.
     // This avoids the font manager's family matching which can return
-    // different fonts depending on the device/API level.
-    if (family == "sans-serif" || family == "Roboto" || family.empty()) {
+    // different fonts depending on the device/API level. Only the
+    // Regular/Upright path has a baked-in file; bold/italic still go
+    // through the family matcher below.
+    if (weight == 400 && slant == 0 &&
+        (family == "sans-serif" || family == "Roboto" || family.empty())) {
         auto mgr = get_font_manager();
         if (mgr) {
             typeface = mgr->makeFromFile("/system/fonts/Roboto-Regular.ttf");
@@ -123,17 +150,25 @@ static sk_sp<SkTypeface> get_cached_typeface(const std::string& family) {
     if (!typeface) {
         auto mgr = get_font_manager();
         if (mgr && mgr->countFamilies() > 0) {
-            typeface = mgr->matchFamilyStyle(family.c_str(), SkFontStyle::Normal());
+            typeface = mgr->matchFamilyStyle(family.c_str(), sk_style);
             if (!typeface)
-                typeface = mgr->matchFamilyStyle(nullptr, SkFontStyle::Normal());
+                typeface = mgr->matchFamilyStyle(nullptr, sk_style);
         }
     }
 
-    cache[family] = typeface;
+    cache[key] = typeface;
     return typeface;
 }
 
-static SkFont make_font(const std::string& family, float size) {
+// Legacy single-arg overload — preserves the old "Normal" behaviour for
+// callers that haven't migrated to the weight/slant-aware path.
+static sk_sp<SkTypeface> get_cached_typeface(const std::string& family) {
+    return get_cached_typeface(family, SkFontStyle::kNormal_Weight, 0);
+}
+
+static SkFont make_font(const std::string& family, float size,
+                        int weight = SkFontStyle::kNormal_Weight,
+                        int slant = 0) {
     SkFont font;
     font.setSize(size);
     font.setSubpixel(true);                               // Subpixel glyph positioning
@@ -141,7 +176,7 @@ static SkFont make_font(const std::string& family, float size) {
     font.setHinting(SkFontHinting::kSlight);               // Light hinting preserves glyph shapes
     font.setLinearMetrics(true);                           // Linear scaling for consistent metrics
 
-    auto typeface = get_cached_typeface(family);
+    auto typeface = get_cached_typeface(family, weight, slant);
     if (typeface) font.setTypeface(std::move(typeface));
 
     return font;
@@ -314,6 +349,20 @@ void SkiaCanvas::set_line_dash(const float* intervals, int count, float phase) {
 void SkiaCanvas::set_font(const std::string& family, float size) {
     font_family_ = family;
     font_size_ = size;
+    // Reset rich state so a legacy set_font() call doesn't carry a previous
+    // weight/slant/spacing forward unexpectedly.
+    font_weight_ = SkFontStyle::kNormal_Weight;
+    font_slant_ = 0;
+    letter_spacing_ = 0.0f;
+}
+
+void SkiaCanvas::set_font_full(const std::string& family, float size,
+                               int weight, int slant, float letter_spacing) {
+    font_family_ = family;
+    font_size_ = size;
+    font_weight_ = weight;
+    font_slant_ = slant;
+    letter_spacing_ = letter_spacing;
 }
 
 void SkiaCanvas::set_text_align(TextAlign align) {
@@ -324,7 +373,7 @@ void SkiaCanvas::fill_text(const std::string& text, float x, float y) {
     GUARD_CANVAS;
     if (text.empty()) return;
 
-    SkFont font = make_font(font_family_, font_size_);
+    SkFont font = make_font(font_family_, font_size_, font_weight_, font_slant_);
     if (!font.getTypeface()) return;
 
     auto paint = make_fill_paint(fill_color_);
@@ -339,29 +388,38 @@ void SkiaCanvas::fill_text(const std::string& text, float x, float y) {
     // positions are offset twice — once inside the blob and once by the
     // draw call — producing a ghost/double image that worsens with each
     // nesting level in the widget paint pipeline.
-    auto shaper = SkShaper::Make();
-    if (shaper) {
-        // Shape at origin {0,0}, then read the total shaped advance
-        // from endPoint() for accurate text alignment.
-        SkTextBlobBuilderRunHandler handler(text.c_str(), {0, 0});
-        shaper->shape(text.c_str(), text.size(), font,
-                      /*leftToRight=*/true, SK_ScalarInfinity, &handler);
-        float total_w = handler.endPoint().x();
+    //
+    // pulp #927: when letter_spacing_ != 0 we cannot use the shaped blob
+    // verbatim — the shaper packs glyph positions ignorant of CSS
+    // letter-spacing. Fall through to the per-glyph builder below so the
+    // extra advance lands on the rendered output.
+    if (letter_spacing_ == 0.0f) {
+        auto shaper = SkShaper::Make();
+        if (shaper) {
+            // Shape at origin {0,0}, then read the total shaped advance
+            // from endPoint() for accurate text alignment.
+            SkTextBlobBuilderRunHandler handler(text.c_str(), {0, 0});
+            shaper->shape(text.c_str(), text.size(), font,
+                          /*leftToRight=*/true, SK_ScalarInfinity, &handler);
+            float total_w = handler.endPoint().x();
 
-        float draw_x = x;
-        if (text_align_ == TextAlign::center) draw_x -= total_w * 0.5f;
-        else if (text_align_ == TextAlign::right) draw_x -= total_w;
+            float draw_x = x;
+            if (text_align_ == TextAlign::center) draw_x -= total_w * 0.5f;
+            else if (text_align_ == TextAlign::right) draw_x -= total_w;
 
-        auto blob = handler.makeBlob();
-        if (blob) {
-            canvas_->drawTextBlob(blob, draw_x, y, paint);
-            return;
+            auto blob = handler.makeBlob();
+            if (blob) {
+                canvas_->drawTextBlob(blob, draw_x, y, paint);
+                return;
+            }
         }
     }
 #endif
 
     // Fallback: per-glyph SkTextBlob without kerning/ligatures.
-    // Used when text shaping is disabled or SkShaper::Make() fails.
+    // Used when text shaping is disabled, SkShaper::Make() fails, or
+    // letter_spacing_ != 0 (pulp #927 — the shaped blob can't carry CSS
+    // letter-spacing so we lay glyphs out manually).
     int glyph_count = static_cast<int>(font.countText(text.c_str(), text.size(), SkTextEncoding::kUTF8));
     if (glyph_count <= 0) return;
 
@@ -375,6 +433,8 @@ void SkiaCanvas::fill_text(const std::string& text, float x, float y) {
 
     float total_w = 0;
     for (int i = 0; i < glyph_count; ++i) total_w += widths[i];
+    // CSS letter-spacing: extra advance between every pair of glyphs.
+    if (glyph_count > 1) total_w += letter_spacing_ * static_cast<float>(glyph_count - 1);
 
     float draw_x = x;
     if (text_align_ == TextAlign::center) draw_x -= total_w * 0.5f;
@@ -387,6 +447,7 @@ void SkiaCanvas::fill_text(const std::string& text, float x, float y) {
         run.glyphs[i] = glyphs[i];
         run.pos[i] = cursor;
         cursor += widths[i];
+        if (i + 1 < glyph_count) cursor += letter_spacing_;
     }
 
     canvas_->drawTextBlob(builder.make(), 0, 0, paint);
@@ -473,7 +534,7 @@ void SkiaCanvas::fill_text_sdf(const std::string& text, float x, float y,
 }
 
 float SkiaCanvas::measure_text(const std::string& text) {
-    SkFont font = make_font(font_family_, font_size_);
+    SkFont font = make_font(font_family_, font_size_, font_weight_, font_slant_);
     if (!font.getTypeface()) return font_size_ * text.size() * 0.5f;
 
 #ifdef PULP_HAS_TEXT_SHAPING
@@ -481,12 +542,18 @@ float SkiaCanvas::measure_text(const std::string& text) {
     // enabled — matches what fill_text() actually renders. Without
     // this, measure_text returns unshaped widths that mismatch drawn
     // text for kerning/ligature strings (e.g., "AV", "ffi").
-    auto shaper = SkShaper::Make();
-    if (shaper) {
-        SkTextBlobBuilderRunHandler handler(text.c_str(), {0, 0});
-        shaper->shape(text.c_str(), text.size(), font,
-                      /*leftToRight=*/true, SK_ScalarInfinity, &handler);
-        return handler.endPoint().x();
+    //
+    // pulp #927: if letter_spacing_ != 0 we bypass the shaper because
+    // fill_text() also bypasses it in that case — measuring via the
+    // shaper would diverge from what's actually drawn.
+    if (letter_spacing_ == 0.0f) {
+        auto shaper = SkShaper::Make();
+        if (shaper) {
+            SkTextBlobBuilderRunHandler handler(text.c_str(), {0, 0});
+            shaper->shape(text.c_str(), text.size(), font,
+                          /*leftToRight=*/true, SK_ScalarInfinity, &handler);
+            return handler.endPoint().x();
+        }
     }
 #endif
 
@@ -504,11 +571,15 @@ float SkiaCanvas::measure_text(const std::string& text) {
 
     float total = 0;
     for (int i = 0; i < glyph_count; ++i) total += widths[i];
+    // pulp #927: include CSS letter-spacing in measurement so layout code
+    // (e.g. ellipsis truncation in Label::paint) reasons over the same
+    // total advance the renderer will draw.
+    if (glyph_count > 1) total += letter_spacing_ * static_cast<float>(glyph_count - 1);
     return total;
 }
 
 Canvas::TextMetrics SkiaCanvas::measure_text_full(const std::string& text) {
-    SkFont font = make_font(font_family_, font_size_);
+    SkFont font = make_font(font_family_, font_size_, font_weight_, font_slant_);
     if (!font.getTypeface()) {
         // Fallback estimates — keep all fields populated so JS callers can
         // still e.g. center text against actual_bounding_box_left/right.

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -35,6 +35,11 @@ public:
     void set_font_size(float size) { font_size_ = size; }
     float font_size() const { return font_size_; }
 
+    /// CSS font-family string (e.g. "Inter", "JetBrains Mono"). Empty means
+    /// the widget falls back to the default theme family ("Inter").
+    void set_font_family(std::string family) { font_family_ = std::move(family); }
+    const std::string& font_family() const { return font_family_; }
+
     void set_font_weight(int weight) { font_weight_ = weight; }  // 100-900, 400=normal, 700=bold
     int font_weight() const { return font_weight_; }
 
@@ -72,6 +77,7 @@ public:
 
 private:
     std::string text_;
+    std::string font_family_;     ///< Empty == widget default ("Inter")
     float font_size_ = 14.0f;
     int font_weight_ = 400;       ///< 400=normal, 700=bold
     int font_style_ = 0;          ///< 0=normal, 1=italic

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1829,6 +1829,17 @@ void WidgetBridge::register_api() {
     });
 
     // Typography properties
+    // pulp #927 — `setFontFamily(id, family)` was called from web-compat JS
+    // but had no C++ binding, so the call became a silent no-op. Now wires
+    // through to Label::set_font_family() and Label::paint() honors it via
+    // canvas.set_font_full().
+    engine_.register_function("setFontFamily", [this](choc::javascript::ArgumentList args) {
+        auto* v = widget(args.get<std::string>(0, ""));
+        auto family = args.get<std::string>(1, "");
+        if (auto* l = dynamic_cast<Label*>(v)) l->set_font_family(std::move(family));
+        return choc::value::Value();
+    });
+
     engine_.register_function("setFontWeight", [this](choc::javascript::ArgumentList args) {
         auto* v = widget(args.get<std::string>(0, ""));
         int w = static_cast<int>(args.get<double>(1, 400));

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -245,7 +245,11 @@ void Label::paint(canvas::Canvas& canvas) {
 
     auto text_color = resolve_color("text.primary", canvas::Color::rgba8(200, 200, 200));
     canvas.set_fill_color({text_color.r, text_color.g, text_color.b, text_color.a});
-    canvas.set_font("Inter", font_size_);
+    // pulp #927 — propagate setFontFamily / setFontWeight / setLetterSpacing
+    // through to the canvas backend so JS calls actually change rasterised
+    // glyphs. Empty font_family_ falls back to the default theme face.
+    const std::string& family = font_family_.empty() ? std::string("Inter") : font_family_;
+    canvas.set_font_full(family, font_size_, font_weight_, font_style_, letter_spacing_);
 
     // Apply text-transform
     std::string display_text = text_;

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -387,3 +387,99 @@ TEST_CASE("View paint_all paints children", "[view][widget]") {
     REQUIRE(canvas.count(DrawCommand::Type::save) == 3);
     REQUIRE(canvas.count(DrawCommand::Type::restore) == 3);
 }
+
+// ── pulp #927 — Label honors setFontFamily / setFontWeight / setLetterSpacing ──
+//
+// Before #927, Label::paint() called canvas.set_font("Inter", size) with no
+// weight / family / spacing — so JS calls into setFontWeight, setFontFamily,
+// and setLetterSpacing landed on Label members but were dropped on the floor
+// at render time. These tests assert the propagation through the
+// RecordingCanvas, which captures the rich state via DrawCommand::set_font_full.
+
+TEST_CASE("Label propagates font_family to canvas", "[view][widget][issue-927]") {
+    Label label("Hello");
+    label.set_bounds({0, 0, 200, 24});
+    label.set_font_family("JetBrains Mono");
+
+    RecordingCanvas canvas;
+    label.paint(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::set_font_full) == 1);
+    // Locate the rich set_font_full command and assert family is forwarded.
+    bool found_family = false;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == DrawCommand::Type::set_font_full) {
+            REQUIRE(cmd.text == "JetBrains Mono");
+            found_family = true;
+        }
+    }
+    REQUIRE(found_family);
+}
+
+TEST_CASE("Label propagates font_weight to canvas", "[view][widget][issue-927]") {
+    Label label("BOLD");
+    label.set_bounds({0, 0, 200, 24});
+    label.set_font_weight(700);
+
+    RecordingCanvas canvas;
+    label.paint(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::set_font_full) == 1);
+    bool found_weight = false;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == DrawCommand::Type::set_font_full) {
+            // f[1] carries CSS font-weight (100..900).
+            REQUIRE(static_cast<int>(cmd.f[1]) == 700);
+            found_weight = true;
+        }
+    }
+    REQUIRE(found_weight);
+}
+
+TEST_CASE("Label propagates letter_spacing to canvas", "[view][widget][issue-927]") {
+    Label label("SPECTR");
+    label.set_bounds({0, 0, 200, 24});
+    label.set_letter_spacing(1.5f);
+
+    RecordingCanvas canvas;
+    label.paint(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::set_font_full) == 1);
+    bool found_spacing = false;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == DrawCommand::Type::set_font_full) {
+            // f[3] carries CSS letter-spacing in px.
+            REQUIRE_THAT(cmd.f[3], WithinAbs(1.5, 0.001));
+            found_spacing = true;
+        }
+    }
+    REQUIRE(found_spacing);
+}
+
+TEST_CASE("Label set_font_full carries default weight when no setter called",
+          "[view][widget][issue-927]") {
+    // Verifies that the rich command goes out even for the default
+    // (font_weight_=400, no family) path. Important: we do NOT want a
+    // regression where set_font_full only fires for "non-default" labels.
+    Label label("plain");
+    label.set_bounds({0, 0, 100, 20});
+
+    RecordingCanvas canvas;
+    label.paint(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::set_font_full) == 1);
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == DrawCommand::Type::set_font_full) {
+            REQUIRE(cmd.text == "Inter");          // default theme family
+            REQUIRE(static_cast<int>(cmd.f[1]) == 400);
+            REQUIRE_THAT(cmd.f[3], WithinAbs(0.0, 0.001));
+        }
+    }
+}
+
+TEST_CASE("Label getters round-trip font_family", "[view][widget][issue-927]") {
+    Label label("x");
+    REQUIRE(label.font_family().empty());          // default == theme fallback
+    label.set_font_family("Inter Display");
+    REQUIRE(label.font_family() == "Inter Display");
+}


### PR DESCRIPTION
Spectr's chrome calls setFontFamily (27x), setFontWeight (7x), and
setLetterSpacing (40x) on Labels. Today the JS bridge sets the values on
the Label widget but the canvas backend silently drops them — every
Label paints with a default-Inter / weight-400 / no-tracking SkFont
regardless of CSS intent.

This wires the property bag through to Skia:

- `Canvas::set_font_full(family, size, weight, slant, letter_spacing)`
  is a new virtual with a default impl that forwards to the legacy
  `set_font(family, size)`, so non-Label callers keep working unchanged.
- `SkiaCanvas` overrides `set_font_full`, stores weight + slant +
  letter_spacing as state, threads them through `make_font` (the
  typeface cache is now keyed on `(family, weight, slant)` so
  bold/italic actually pick a different blob), and applies CSS
  letter-spacing as extra per-glyph advance in both `fill_text` and
  `measure_text`. Bypasses the SkShaper fast path when letter_spacing
  is non-zero so what we measure matches what we draw.
- `RecordingCanvas` captures the rich state via a new
  `DrawCommand::set_font_full` (and still emits the legacy `set_font`
  command so existing tests that count fonts keep passing).
- `Label` gains `font_family_` (empty == default theme face), and
  `Label::paint()` calls `set_font_full(...)` instead of `set_font(...)`.
- `WidgetBridge` registers the previously-missing `setFontFamily(id,
  family)` JS function — web-compat-style-decl.js was already calling it
  via `typeof setFontFamily === "function"`, so today it's a silent
  no-op.

Tests: 5 new Catch2 cases in `test_widgets.cpp` under `[issue-927]` cover
the family / weight / letter_spacing forwarding, the default-state
round-trip, and the `font_family()` getter.

Refs #924 (native UI parity umbrella).