### PR TITLE
fix(view): wire platform font manager into TextShaper to fix Label width collapse (#945)

### DIFF
--- a/core/canvas/src/text_shaper.cpp
+++ b/core/canvas/src/text_shaper.cpp
@@ -19,6 +19,24 @@
 #include "modules/skparagraph/include/FontCollection.h"
 #include "modules/skshaper/include/SkShaper.h"
 #include "include/core/SkFontMgr.h"
+
+// Platform font managers — must mirror what SkiaCanvas uses, otherwise
+// `mgr->matchFamilyStyle("Inter", ...)` returns null and SkFont falls
+// back to a typeface-less default whose `measureText()` advance is
+// effectively zero. That collapses Label::intrinsic_width() and Yoga
+// reserves no horizontal space for the label, which paints into the
+// (now-tiny) box and clips. See pulp #945 (regression of #935 / #928).
+#if defined(__APPLE__)
+#include "include/ports/SkFontMgr_mac_ct.h"
+#elif defined(_WIN32)
+#include "include/ports/SkTypeface_win.h"
+#elif defined(__ANDROID__)
+#include "include/ports/SkFontMgr_android.h"
+#include "include/ports/SkFontScanner_FreeType.h"
+#elif defined(__linux__)
+#include "include/ports/SkFontMgr_fontconfig.h"
+#include "include/ports/SkFontScanner_FreeType.h"
+#endif
 #endif
 
 namespace pulp::canvas {
@@ -136,12 +154,35 @@ struct TextShaper::Impl {
     bool has_real_shaping = false;
 
 #ifdef PULP_HAS_TEXT_SHAPING
+    sk_sp<SkFontMgr> font_mgr;
     sk_sp<skia::textlayout::FontCollection> font_collection;
 
+    // Lazily create a platform-appropriate font manager — mirrors the
+    // helper in skia_canvas.cpp. Without this, SkFontMgr::RefEmpty()
+    // returns no typefaces and `font.measureText()` reports near-zero
+    // advance, collapsing Label::intrinsic_width() (pulp #945).
+    static sk_sp<SkFontMgr> make_platform_font_mgr() {
+#if defined(__APPLE__)
+        return SkFontMgr_New_CoreText(nullptr);
+#elif defined(_WIN32)
+        return SkFontMgr_New_DirectWrite();
+#elif defined(__ANDROID__)
+        return SkFontMgr_New_Android(nullptr, SkFontScanner_Make_FreeType());
+#elif defined(__linux__)
+        return SkFontMgr_New_FontConfig(nullptr, SkFontScanner_Make_FreeType());
+#else
+        return nullptr;
+#endif
+    }
+
     Impl() {
+        font_mgr = make_platform_font_mgr();
+        if (!font_mgr) {
+            font_mgr = SkFontMgr::RefEmpty();
+        }
         font_collection = sk_sp<skia::textlayout::FontCollection>(
             new skia::textlayout::FontCollection());
-        font_collection->setDefaultFontManager(SkFontMgr::RefEmpty());
+        font_collection->setDefaultFontManager(font_mgr);
         has_real_shaping = true;
     }
 #else
@@ -181,20 +222,40 @@ struct TextShaper::Impl {
         float width = 0;
 
 #ifdef PULP_HAS_TEXT_SHAPING
-        // Real measurement via SkFont
+        // Real measurement via SkFont. Use the platform font manager
+        // (CoreText/DirectWrite/fontconfig/Android) — RefEmpty() returns
+        // no typefaces and silently produces ~0 advance widths, which
+        // is what regressed Label measurement in pulp #945.
         SkFont font;
-        auto mgr = SkFontMgr::RefEmpty();
-        if (mgr) {
-            auto typeface = mgr->matchFamilyStyle(font_family.c_str(), SkFontStyle::Normal());
-            if (typeface) font.setTypeface(std::move(typeface));
+        sk_sp<SkTypeface> typeface;
+        if (font_mgr && font_mgr->countFamilies() > 0) {
+            typeface = font_mgr->matchFamilyStyle(font_family.c_str(),
+                                                  SkFontStyle::Normal());
+            if (!typeface) {
+                // Family wasn't found (e.g. "Inter" not installed) —
+                // fall back to the platform default face so we still
+                // get a real measurement instead of a phantom typeface.
+                typeface = font_mgr->matchFamilyStyle(nullptr,
+                                                      SkFontStyle::Normal());
+            }
         }
+        if (typeface) font.setTypeface(std::move(typeface));
         font.setSize(font_size);
         font.setEdging(SkFont::Edging::kSubpixelAntiAlias);
 
-        // Use the advance width (return value), not bounds.width().
-        // Advance includes whitespace and proper glyph spacing;
-        // bounds.width() can exclude trailing spaces and differ for overhangs.
-        width = font.measureText(text.c_str(), text.size(), SkTextEncoding::kUTF8, nullptr);
+        if (font.getTypeface()) {
+            // Use the advance width (return value), not bounds.width().
+            // Advance includes whitespace and proper glyph spacing;
+            // bounds.width() can exclude trailing spaces and differ for
+            // overhangs.
+            width = font.measureText(text.c_str(), text.size(),
+                                     SkTextEncoding::kUTF8, nullptr);
+        } else {
+            // No platform font manager (or all matchers failed) — fall
+            // back to the same character-width estimator the non-Skia
+            // build uses, so callers still get a sane positive width.
+            width = static_cast<float>(text.size()) * font_size * 0.6f;
+        }
 #else
         // Fallback: character-width estimation
         width = static_cast<float>(text.size()) * font_size * 0.6f;

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -253,6 +253,16 @@ float Label::intrinsic_width() const {
     // single-line text width.
     if (text_.empty() || multi_line_) return 0;
 
+    // pulp #943 P2 / #945: when paint() rotates the text 90° the
+    // horizontal footprint is just the line height, not the shaped
+    // string advance. Reporting the advance here makes Yoga reserve
+    // far too much width for vertical labels and starves siblings.
+    bool vertical = (text_direction_ == canvas::TextDirection::top_to_bottom ||
+                     text_direction_ == canvas::TextDirection::bottom_to_top);
+    if (vertical) {
+        return std::ceil(line_height_ > 0 ? line_height_ : font_size_ * 1.4f);
+    }
+
     // Mirror paint()'s text-transform — measurement must match what's
     // drawn or a row of uppercase chars will wrap unexpectedly.
     std::string display_text = text_;
@@ -282,9 +292,20 @@ float Label::intrinsic_width() const {
     float width = prepared.total_width();
 
     // Letter-spacing adds extra advance per glyph break that isn't
-    // captured by HarfBuzz shaping.
-    if (letter_spacing_ != 0 && display_text.size() > 1) {
-        width += letter_spacing_ * static_cast<float>(display_text.size() - 1);
+    // captured by HarfBuzz shaping. Count UTF-8 *code points*, not
+    // bytes — using `size()` over-applies spacing on multibyte input
+    // (CJK, accented Latin, emoji) and inflates intrinsic width
+    // (pulp #943 P2 #935 finding 2).
+    if (letter_spacing_ != 0 && !display_text.empty()) {
+        std::size_t glyph_count = 0;
+        for (unsigned char c : display_text) {
+            // Count any byte that is not a UTF-8 continuation byte
+            // (0b10xxxxxx) — that's one glyph per code point.
+            if ((c & 0xC0) != 0x80) ++glyph_count;
+        }
+        if (glyph_count > 1) {
+            width += letter_spacing_ * static_cast<float>(glyph_count - 1);
+        }
     }
 
     // Sub-pixel-safe ceil so layout never clips on rounding.

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -101,6 +101,125 @@ TEST_CASE("Label intrinsic_width yields zero for multi-line", "[view][widget][is
     REQUIRE(ml.intrinsic_width() == 0);
 }
 
+TEST_CASE("Label intrinsic_width is sane for typical chrome strings",
+          "[view][widget][issue-945]") {
+    // pulp #945 regression: after PR #935 enabled Label auto-grow,
+    // certain fresh-build states reported tiny intrinsic widths
+    // (e.g. 5–20 px for a 20-character string) because the global
+    // TextShaper used SkFontMgr::RefEmpty() and silently produced
+    // ~0 advance widths. Yoga then collapsed the Label and the
+    // painter truncated the chrome ("SF · ZOOMA · LIVE · IIR · F").
+    //
+    // Lower-bound the reported width against a conservative
+    // estimate (40% of font_size per character) — well below any
+    // real shaped/estimated width, but well above the broken
+    // ~zero-advance regression. If this test ever drops below the
+    // bound, the platform font manager has stopped resolving
+    // typefaces in the shaper path.
+    Label chrome("SPECTR ZOOMABLE FILTER BANK");
+    chrome.set_font_size(14.0f);
+
+    float w = chrome.intrinsic_width();
+    float min_expected = chrome.text().size() * 14.0f * 0.40f;
+    REQUIRE(w > min_expected);
+}
+
+TEST_CASE("Label intrinsic_width matches text after rebuild / re-measure",
+          "[view][widget][issue-945]") {
+    // pulp #945: A label whose text is changed after construction must
+    // re-measure cleanly. The first capture in the field showed correct
+    // labels; subsequent rebuilds collapsed widths because the shaper
+    // cached zero-advance segments under (font, size). With the
+    // platform font manager wired up, repeated prepare() calls always
+    // return positive width and the cached entries are sane.
+    Label l("SF");
+    l.set_font_size(14.0f);
+    float short_w = l.intrinsic_width();
+
+    l.set_text("SPECTR ZOOMABLE FILTER BANK");
+    float long_w = l.intrinsic_width();
+
+    REQUIRE(short_w > 0);
+    REQUIRE(long_w > 0);
+    // The longer string must report a substantially wider footprint.
+    // Field-observed regression collapsed long_w to ~short_w.
+    REQUIRE(long_w > short_w * 5.0f);
+
+    // Reverting back to the short text must give back the short width
+    // (within a small rounding margin) — proves measurement is a pure
+    // function of the current text, not stuck on a stale value.
+    l.set_text("SF");
+    float short_again = l.intrinsic_width();
+    REQUIRE(short_again > 0);
+    REQUIRE(short_again < long_w * 0.5f);
+}
+
+TEST_CASE("Label intrinsic_width handles vertical text direction",
+          "[view][widget][issue-945][issue-943]") {
+    // pulp #943 P2 (#935 finding 1): when text_direction_ is vertical,
+    // paint() rotates the canvas 90° so the horizontal footprint is the
+    // line height, not the shaped string advance. Reporting the advance
+    // here would make Yoga reserve enormous width for a vertical label
+    // and starve sibling columns.
+    Label vertical("VERTICAL LABEL TEXT");
+    vertical.set_font_size(14.0f);
+    vertical.set_text_direction(TextDirection::top_to_bottom);
+
+    Label horizontal("VERTICAL LABEL TEXT");
+    horizontal.set_font_size(14.0f);
+
+    float v = vertical.intrinsic_width();
+    float h = horizontal.intrinsic_width();
+
+    REQUIRE(v > 0);
+    REQUIRE(h > 0);
+    // Vertical width is one line tall — must be much smaller than the
+    // full horizontal advance of the same string.
+    REQUIRE(v < h * 0.25f);
+
+    // Bottom-to-top gets the same treatment.
+    Label vertical2("VERTICAL LABEL TEXT");
+    vertical2.set_font_size(14.0f);
+    vertical2.set_text_direction(TextDirection::bottom_to_top);
+    REQUIRE(vertical2.intrinsic_width() == v);
+}
+
+TEST_CASE("Label letter_spacing counts glyphs not UTF-8 bytes",
+          "[view][widget][issue-945][issue-943]") {
+    // pulp #943 P2 (#935 finding 2): letter_spacing was multiplied by
+    // (display_text.size() - 1), counting raw UTF-8 bytes instead of
+    // code points. A 4-character CJK string takes 12 bytes in UTF-8,
+    // so spacing was over-applied 3x and the label inflated.
+    //
+    // ASCII baseline — both strings are 4 ASCII chars, so byte count
+    // and glyph count match. This anchors the comparison.
+    Label ascii_no_spacing("ABCD");
+    ascii_no_spacing.set_font_size(14.0f);
+    Label ascii_with_spacing("ABCD");
+    ascii_with_spacing.set_font_size(14.0f);
+    ascii_with_spacing.set_letter_spacing(2.0f);
+
+    float ascii_delta = ascii_with_spacing.intrinsic_width()
+                      - ascii_no_spacing.intrinsic_width();
+    // 4 glyphs → 3 gaps → 6.0 px extra (subject to ceil rounding).
+    REQUIRE(ascii_delta >= 5.0f);
+    REQUIRE(ascii_delta <= 7.0f);
+
+    // Multibyte path: 4 CJK characters in UTF-8 are 12 bytes. With the
+    // old byte-count math the spacing delta would be ~22 px (11 gaps);
+    // with the glyph-count math it's the same ~6 px as the ASCII case.
+    Label cjk_no_spacing("\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E\xE6\x96\x87"); // 日本語文
+    cjk_no_spacing.set_font_size(14.0f);
+    Label cjk_with_spacing("\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E\xE6\x96\x87");
+    cjk_with_spacing.set_font_size(14.0f);
+    cjk_with_spacing.set_letter_spacing(2.0f);
+
+    float cjk_delta = cjk_with_spacing.intrinsic_width()
+                    - cjk_no_spacing.intrinsic_width();
+    REQUIRE(cjk_delta >= 5.0f);
+    REQUIRE(cjk_delta <= 7.0f);
+}
+
 TEST_CASE("Knob value clamping", "[view][widget]") {
     Knob knob;
     knob.set_value(0.5f);


### PR DESCRIPTION
## Summary

Fixes the **Label rendering truncation regression on rebuild** described in #945. Field-observed symptom: chrome strings collapse to a few characters ("SF · ZOOMA · LIVE · IIR · F") after rebuilding, even when the source commit and SDK version are unchanged. Reproducible across many cold builds; first capture in #945's referenced screenshot was the lucky outlier.

## Root cause

`Label::intrinsic_width()` (added in #935) routes through `pulp::canvas::global_text_shaper()`. The shaper's `SkFont`-based measurement path was constructing a font with `SkFontMgr::RefEmpty()` — an empty font manager that returns **no typefaces for any family**. With no resolved typeface, `SkFont::measureText()` returned ~0 advance for every string. Yoga then reserved no horizontal space for the Label, and `paint()` truncated the string to fit the collapsed box.

`SkiaCanvas` itself paints correctly because it uses the platform font manager (`SkFontMgr_New_CoreText` / `SkFontMgr_New_DirectWrite` / `SkFontMgr_New_FontConfig` / `SkFontMgr_New_Android`). Only the **measure** side was broken — which matches the field observation that some captures rendered correctly (Skia paint OK) and the same source produced different layouts on different builds (depending on whether the auto-grow path was even hit before the shaper cache populated zero-width entries).

## Fix

Mirror the platform-font-manager pattern from `skia_canvas.cpp` inside `TextShaper::Impl`:

* Lazily create a `CoreText` / `DirectWrite` / `fontconfig` / `Android` font manager (`SkFontMgr::RefEmpty()` only as a final fallback).
* Use it both for `setDefaultFontManager()` on the SkParagraph `FontCollection` and for the per-segment `SkFont` measurement path.
* Fall back to the platform default face (`matchFamilyStyle(nullptr, ...)`) when "Inter" or any other requested family isn't installed.
* Fall back to the same character-width estimator the non-Skia build uses if no font manager is available.

## Bonus (pulp #943 P2 findings 1 and 2 from PR #935)

While in `Label::intrinsic_width()`, also closed two related Codex findings:

1. **Vertical text** (`top_to_bottom` / `bottom_to_top`) now reports a one-line-tall horizontal footprint — `paint()` rotates 90° so the on-screen width is line height, not the shaped string advance.
2. **`letter_spacing`** multiplier now counts UTF-8 code points instead of raw bytes — multibyte input (CJK, accented Latin, emoji) no longer over-applies spacing.

## Tests

New cases in `test/test_widgets.cpp` tagged `[issue-945]` (and `[issue-943]` where applicable):

* `Label intrinsic_width is sane for typical chrome strings` — lower-bound that catches the zero-advance regression directly.
* `Label intrinsic_width matches text after rebuild / re-measure` — proves measurement is a pure function of current text, not a stuck cached value.
* `Label intrinsic_width handles vertical text direction` — vertical width < 25% of horizontal width.
* `Label letter_spacing counts glyphs not UTF-8 bytes` — same delta for 4-ASCII and 4-CJK strings.

All 39 widget test cases (107 assertions) pass locally on macOS arm64. All 16 text-shaper test cases also still pass.

## Cross-links

- Closes #945
- Addresses #943 P2 findings 1 and 2 (#935)
- Builds on #935 (Label auto-grow via `intrinsic_width()`)

## Test plan

- [x] `pulp-test-widgets` — 39 cases / 107 assertions pass on macOS arm64
- [x] `pulp-test-widgets [issue-945]` — 4 new cases / 14 assertions pass
- [x] `pulp-test-widgets [issue-928]` and `[issue-927]` — adjacent Label tests still pass
- [x] `pulp-test-text-shaper` — 16 cases / 28 assertions still pass
- [ ] CI macOS / Ubuntu / Windows green