### PR TITLE
fix(coverage): include non-test binaries in local diff-cover object set (#943, #919)

### DIFF
--- a/tools/scripts/coverage_config.json
+++ b/tools/scripts/coverage_config.json
@@ -14,8 +14,7 @@
     "experimental/**"
   ],
   "diff_cover_excludes": [
-    "tools/cli/cmd_coverage.cpp",
     "tools/cli/cmd_loop.cpp"
   ],
-  "_comment": "Single source of truth consumed by .github/workflows/coverage.yml AND tools/scripts/local_diff_cover.sh. To change the threshold, surface set, or per-file exclusions, edit here once. `diff_cover_excludes` is the line-coverage-exclude list passed to `diff-cover --exclude=...` — use sparingly for thin dispatchers / generated code that is exercised end-to-end via shell-out tests but doesn't propagate llvm-cov instrumentation. cmd_loop.cpp's watch-loop entry path (lines ~280-306) cannot be exercised by a shellout test (the loop blocks until SIGINT), so the file is exercised end-to-end via the --no-watch shellout tests in test/test_cli_shellout.cpp instead."
+  "_comment": "Single source of truth consumed by .github/workflows/coverage.yml AND tools/scripts/local_diff_cover.sh. To change the threshold, surface set, or per-file exclusions, edit here once. `diff_cover_excludes` is the line-coverage-exclude list passed to `diff-cover --exclude=...` — use sparingly for thin dispatchers / generated code that is exercised end-to-end via shell-out tests but doesn't propagate llvm-cov instrumentation. cmd_loop.cpp's watch-loop entry path (lines ~280-306) cannot be exercised by a shellout test (the loop blocks until SIGINT), so the file is exercised end-to-end via the --no-watch shellout tests in test/test_cli_shellout.cpp instead. cmd_coverage.cpp was previously excluded for the same reason but is now properly counted: local_diff_cover.sh now mirrors run_coverage.sh's wider object-discovery pattern (build/tools, build/inspect, build/bindings) so CLI shell-out tests propagate llvm-cov instrumentation through pulp-cli / pulp-standalone / pulp-inspect (#919 follow-up)."
 }

--- a/tools/scripts/local_diff_cover.sh
+++ b/tools/scripts/local_diff_cover.sh
@@ -185,21 +185,50 @@ find "${PROFRAW_DIR}" -name '*.profraw' -print0 \
 
 # ── Gather binaries for llvm-cov -object ────────────────────────────────────
 # Mirror scripts/run_coverage.sh's binary discovery so we cover the same
-# surface CI does. Test binaries first, then libpulp-*.a archives, then
-# non-test executables.
+# surface CI does. Without the non-test executable / loadable-module
+# passes below, llvm-cov sees only test binaries — coverage data from
+# CLI shell-out tests (cmd_coverage.cpp, cmd_loop.cpp, etc.) never
+# propagates, and any first-party file exercised end-to-end through
+# pulp-cli / pulp-standalone / pulp-inspect is silently dropped from
+# the diff-cover gate. See issue #919 (Codex review on PR #919).
 BINARIES=()
+
+# 1. Test executables — primary coverage drivers.
 while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
     find "${BUILD_DIR}/test" -maxdepth 2 -type f -perm -u+x \
         ! -name '*.cmake' ! -name '*.txt' 2>/dev/null || true
 )
+
+# 2. First-party static archives — expose every instrumented TU even
+#    when no test transitively links it. `pulp-*.lib` covers Windows
+#    where clang-cl emits MSVC-style archives.
 while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
     find "${BUILD_DIR}" -type f \
         \( -name 'libpulp-*.a' -o -name 'pulp-*.lib' \) \
         2>/dev/null || true
 )
 
+# 3. First-party non-test executables — CLI, standalone host, inspector.
+#    These are the targets shell-out tests actually invoke; without them
+#    cmd_coverage.cpp et al. never accumulate coverage.
+while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
+    find "${BUILD_DIR}/tools" "${BUILD_DIR}/inspect" \
+        -maxdepth 3 -type f -perm -u+x \
+        ! -name '*.cmake' ! -name '*.txt' ! -name '*.o' \
+        2>/dev/null || true
+)
+
+# 4. Loadable first-party modules under bindings/ that execute
+#    instrumented code under test (Python smoke target etc.).
+while IFS= read -r f; do BINARIES+=("-object" "$f"); done < <(
+    find "${BUILD_DIR}/bindings" -type f \
+        \( -name 'pulp*.so' -o -name 'pulp*.pyd' -o -name 'pulp*.dylib' \) \
+        ! -path "${BUILD_DIR}/bindings/python/*" \
+        2>/dev/null || true
+)
+
 if [ "${#BINARIES[@]}" -eq 0 ]; then
-    echo "[local_diff_cover] no test binaries found under ${BUILD_DIR}/test" >&2
+    echo "[local_diff_cover] no binaries found under ${BUILD_DIR}" >&2
     exit 1
 fi
 

--- a/tools/scripts/test_local_diff_cover.py
+++ b/tools/scripts/test_local_diff_cover.py
@@ -30,6 +30,7 @@ import unittest
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 SCRIPT = REPO_ROOT / "tools" / "scripts" / "local_diff_cover.sh"
 CONFIG = REPO_ROOT / "tools" / "scripts" / "coverage_config.json"
+CI_SCRIPT = REPO_ROOT / "scripts" / "run_coverage.sh"
 
 
 class ConfigTests(unittest.TestCase):
@@ -131,6 +132,52 @@ class WorkflowSourceOfTruthTests(unittest.TestCase):
             f"workflow has hardcoded --fail-under literal(s): {literals}; "
             "remove and read from coverage_config.json instead",
         )
+
+
+class ObjectDiscoveryParityTests(unittest.TestCase):
+    """local_diff_cover.sh must mirror run_coverage.sh's object-set passes.
+
+    Anti-drift guard for #919: the local mirror previously only added
+    build/test/* binaries to llvm-cov, so coverage data from CLI
+    shell-out tests (cmd_coverage.cpp, cmd_loop.cpp, anything reached
+    via pulp-cli / pulp-standalone / pulp-inspect) never propagated.
+    The fix lifts run_coverage.sh's wider find passes; this test fails
+    if either side drops one.
+    """
+
+    REQUIRED_FIND_ROOTS = [
+        # (substring that must appear in the script, human description)
+        ('"${BUILD_DIR}/test"', "test executables"),
+        ("libpulp-*.a", "first-party static archives (Unix)"),
+        ("pulp-*.lib", "first-party static archives (Windows)"),
+        ('"${BUILD_DIR}/tools"', "non-test executables (CLI / standalone)"),
+        ('"${BUILD_DIR}/inspect"', "non-test executables (inspector)"),
+        ('"${BUILD_DIR}/bindings"', "loadable first-party modules"),
+    ]
+
+    def test_local_script_includes_all_object_roots(self) -> None:
+        text = SCRIPT.read_text()
+        for needle, desc in self.REQUIRED_FIND_ROOTS:
+            self.assertIn(
+                needle, text,
+                f"local_diff_cover.sh missing object-discovery for {desc} "
+                f"({needle!r}); without it llvm-cov drops coverage from "
+                f"that surface — see #919.",
+            )
+
+    def test_ci_script_still_includes_all_object_roots(self) -> None:
+        # If the CI script ever drops one of these, the local mirror is
+        # the wrong place to keep it — fix CI first, then update both.
+        if not CI_SCRIPT.exists():
+            self.skipTest(f"CI script not present: {CI_SCRIPT}")
+        text = CI_SCRIPT.read_text()
+        for needle, desc in self.REQUIRED_FIND_ROOTS:
+            self.assertIn(
+                needle, text,
+                f"scripts/run_coverage.sh missing object-discovery for "
+                f"{desc} ({needle!r}); local_diff_cover.sh mirrors this "
+                f"surface set, so dropping it here desyncs both lanes.",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `tools/scripts/local_diff_cover.sh` only added `build/test/*` binaries to the llvm-cov `-object` set. CLI shell-out tests (anything reaching code through `pulp-cli`, `pulp-standalone`, `pulp-inspect`) and loadable first-party modules under `bindings/` never propagated coverage data — same root cause that forced `tools/cli/cmd_coverage.cpp` into `diff_cover_excludes` rather than being properly counted.
- Lifted the wider object-discovery pattern from `scripts/run_coverage.sh` (the CI version): added explicit `find` passes for `build/tools`, `build/inspect`, and `build/bindings`, plus kept the `libpulp-*.a` / `pulp-*.lib` archive pass for full first-party TU expansion.
- Removed `tools/cli/cmd_coverage.cpp` from `diff_cover_excludes` in `tools/scripts/coverage_config.json` — it now accumulates coverage through the existing `cli-coverage-help` / `cli-coverage-bogus-subcommand` ctest shell-out cases. `cmd_loop.cpp` stays excluded because its watch-loop entry path blocks until SIGINT and can't be exercised by a shell-out test (existing `_comment` rationale).
- Added `ObjectDiscoveryParityTests` to `tools/scripts/test_local_diff_cover.py`: asserts the local script and `scripts/run_coverage.sh` agree on the surface set, so neither lane can silently drop a discovery pass again. Anti-drift guard.

## Refs

- Closes the #919 P1 entry from #943 (Codex post-merge sweep).
- Codex review comment: https://github.com/danielraffel/pulp/pull/919#discussion_r3151632818

## Test plan

- [x] `python3 tools/scripts/test_local_diff_cover.py` — 8/8 pass locally (includes the two new parity tests).
- [x] `bash -n tools/scripts/local_diff_cover.sh` clean.
- [x] `python3 -c 'import json; json.load(open("tools/scripts/coverage_config.json"))'` clean.
- [x] `python3 tools/scripts/skill_sync_check.py --mode=report` — no mapped paths touched.
- [x] `python3 tools/scripts/version_bump_check.py --mode=report` — no bump needed (script-only change).
- [ ] Cross-platform CI green via Shipyard (macOS / Ubuntu / Windows).
- [ ] Coverage workflow run on PR confirms `cmd_coverage.cpp` now appears in diff-cover with non-zero hits via the CLI shell-out tests.