### PR TITLE
test(inspect): cover inspector window and domain edges

### DIFF
--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -1,8 +1,47 @@
 #include <catch2/catch_test_macros.hpp>
+#include <pulp/inspect/inspector_window.hpp>
 #include <pulp/view/inspector.hpp>
 #include <pulp/view/widgets.hpp>
 
+#include <string_view>
+#include <vector>
+
 using namespace pulp::view;
+using namespace pulp::inspect;
+
+namespace {
+
+template <typename T>
+void collect_views_of_type(View& root, std::vector<T*>& out) {
+    if (auto* match = dynamic_cast<T*>(&root))
+        out.push_back(match);
+    for (size_t i = 0; i < root.child_count(); ++i)
+        collect_views_of_type(*root.child_at(i), out);
+}
+
+template <typename T>
+std::vector<T*> collect_views_of_type(View& root) {
+    std::vector<T*> out;
+    collect_views_of_type(root, out);
+    return out;
+}
+
+template <typename T>
+T* first_view_of_type(View& root) {
+    auto matches = collect_views_of_type<T>(root);
+    return matches.empty() ? nullptr : matches.front();
+}
+
+bool has_label_containing(View& root, std::string_view text) {
+    auto labels = collect_views_of_type<Label>(root);
+    for (auto* label : labels) {
+        if (label->text().find(text) != std::string::npos)
+            return true;
+    }
+    return false;
+}
+
+} // namespace
 
 TEST_CASE("ViewInspector type_name", "[view][inspector]") {
     View v;
@@ -105,8 +144,6 @@ TEST_CASE("ViewInspector JSON includes widget values", "[view][inspector]") {
 
 #include <pulp/inspect/protocol.hpp>
 
-using namespace pulp::inspect;
-
 TEST_CASE("Protocol: encode request") {
     auto msg = make_request(1, "DOM.getDocument", R"({"depth":1})");
     auto json = encode_message(msg);
@@ -202,6 +239,267 @@ TEST_CASE("InspectorOverlay: inactive ignores events") {
     me.position = {10, 10};
     me.is_down = true;
     REQUIRE_FALSE(overlay.handle_mouse_event(me));
+}
+
+TEST_CASE("InspectorOverlay: mouse selection and panel tree interactions", "[inspect][overlay][issue-641]") {
+    View root;
+    root.set_id("root");
+    root.set_bounds({0, 0, 500, 300});
+
+    auto first = std::make_unique<View>();
+    first->set_id("first");
+    first->set_bounds({10, 10, 80, 40});
+    first->flex().padding = 3;
+    first->flex().margin = 4;
+    auto* first_ptr = first.get();
+    root.add_child(std::move(first));
+
+    auto second = std::make_unique<View>();
+    second->set_id("second");
+    second->set_bounds({120, 10, 80, 40});
+    auto* second_ptr = second.get();
+    root.add_child(std::move(second));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+    REQUIRE(canvas.command_count() > 0);
+
+    MouseEvent hover;
+    hover.position = {20, 20};
+    hover.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(hover));
+    REQUIRE(overlay.hovered_view() == first_ptr);
+
+    MouseEvent click;
+    click.position = {20, 20};
+    click.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(click));
+    REQUIRE(overlay.selected_view() == first_ptr);
+
+    canvas.clear();
+    overlay.paint(canvas);
+    REQUIRE(canvas.command_count() > 0);
+
+    MouseEvent panel_select;
+    panel_select.position = {250, 25};
+    panel_select.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(panel_select));
+    REQUIRE(overlay.selected_view() == first_ptr);
+
+    MouseEvent panel_collapse;
+    panel_collapse.position = {205, 5};
+    panel_collapse.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(panel_collapse));
+
+    canvas.clear();
+    overlay.paint(canvas);
+    REQUIRE(canvas.command_count() > 0);
+
+    overlay.set_active(false);
+    REQUIRE(overlay.selected_view() == nullptr);
+    REQUIRE(overlay.hovered_view() == nullptr);
+
+    overlay.set_active(true);
+    MouseEvent alt_first;
+    alt_first.position = {20, 20};
+    alt_first.modifiers = kModAlt;
+    alt_first.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(alt_first));
+
+    MouseEvent alt_second;
+    alt_second.position = {130, 20};
+    alt_second.modifiers = kModAlt;
+    alt_second.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(alt_second));
+    REQUIRE(overlay.selected_view() == second_ptr);
+}
+
+// ── InspectorWindow ────────────────────────────────────────────────────────
+
+TEST_CASE("CollapsableSection toggles content from header clicks", "[inspect][window][issue-641]") {
+    CollapsableSection section("Layout");
+    REQUIRE(section.is_expanded());
+    REQUIRE(section.content() != nullptr);
+    REQUIRE(section.content()->visible());
+
+    MouseEvent up;
+    up.position = {4, 4};
+    up.is_down = false;
+    section.on_mouse_event(up);
+    REQUIRE(section.is_expanded());
+
+    MouseEvent body_click;
+    body_click.position = {4, 30};
+    body_click.is_down = true;
+    section.on_mouse_event(body_click);
+    REQUIRE(section.is_expanded());
+
+    MouseEvent header_click;
+    header_click.position = {4, 6};
+    header_click.is_down = true;
+    section.on_mouse_event(header_click);
+    REQUIRE_FALSE(section.is_expanded());
+    REQUIRE_FALSE(section.content()->visible());
+
+    section.set_expanded(true);
+    REQUIRE(section.is_expanded());
+    REQUIRE(section.content()->visible());
+}
+
+TEST_CASE("InspectorWindow builds tabs and updates element properties", "[inspect][window][issue-641]") {
+    View inspected_root;
+    inspected_root.set_id("root");
+    inspected_root.set_bounds({0, 0, 480, 320});
+
+    Theme theme;
+    theme.colors["accent.primary"] = Color::rgba8(10, 20, 30);
+    theme.colors["bg.surface"] = Color::rgba8(40, 50, 60);
+    inspected_root.set_theme(theme);
+
+    auto knob = std::make_unique<Knob>();
+    knob->set_id("gain");
+    knob->set_bounds({12, 18, 48, 48});
+    knob->flex().direction = FlexDirection::row;
+    knob->flex().gap = 3;
+    knob->flex().padding = 4;
+    knob->flex().margin = 2;
+    knob->flex().flex_grow = 1.0f;
+    knob->flex().flex_shrink = 0.5f;
+    knob->set_background_color(Color::rgba8(30, 40, 50, 200));
+    knob->set_border(Color::rgba8(80, 90, 100), 2, 5);
+    knob->set_opacity(0.75f);
+    knob->set_value(0.625f);
+    knob->set_label("Gain");
+    auto* knob_ptr = knob.get();
+    inspected_root.add_child(std::move(knob));
+
+    InspectorWindow window(inspected_root);
+    REQUIRE(window.child_count() == 1);
+
+    auto* tabs = dynamic_cast<TabPanel*>(window.child_at(0));
+    REQUIRE(tabs != nullptr);
+    REQUIRE(tabs->tab_count() == 4);
+    REQUIRE(tabs->active_tab() == 0);
+    REQUIRE(tabs->child_at(0)->visible());
+    REQUIRE_FALSE(tabs->child_at(1)->visible());
+
+    auto* tree = first_view_of_type<TreeView>(*tabs->child_at(0));
+    REQUIRE(tree != nullptr);
+    auto* knob_node = tree->find_node_by_user_data(knob_ptr);
+    REQUIRE(knob_node != nullptr);
+    REQUIRE(knob_node->label.find("Knob #gain") != std::string::npos);
+
+    bool callback_seen = false;
+    window.on_view_selected = [&](View* view) {
+        callback_seen = (view == knob_ptr);
+    };
+    window.select_view(knob_ptr);
+    REQUIRE(callback_seen);
+    REQUIRE(has_label_containing(window, "Type: Knob"));
+    REQUIRE(has_label_containing(window, "ID: gain"));
+    REQUIRE(has_label_containing(window, "Bounds: 12, 18  48 x 48"));
+    REQUIRE(has_label_containing(window, "Direction: row"));
+    REQUIRE(has_label_containing(window, "Gap: 3.0"));
+    REQUIRE(has_label_containing(window, "Padding: 4.0"));
+    REQUIRE(has_label_containing(window, "Margin: 2.0"));
+    REQUIRE(has_label_containing(window, "Grow: 1.0 / Shrink: 0.5"));
+    REQUIRE(has_label_containing(window, "Opacity: 0.75"));
+    REQUIRE(has_label_containing(window, "Border: 2.0px"));
+    REQUIRE(has_label_containing(window, "Corner radius: 5.0"));
+    REQUIRE(has_label_containing(window, "Value: 0.625  Label: Gain"));
+
+    Fader fader;
+    fader.set_value(0.2f);
+    fader.set_label("Mix");
+    window.select_view(&fader);
+    REQUIRE(has_label_containing(window, "Value: 0.200  Label: Mix"));
+
+    Toggle toggle;
+    toggle.set_on(true);
+    toggle.set_label("Bypass");
+    window.select_view(&toggle);
+    REQUIRE(has_label_containing(window, "On: true  Label: Bypass"));
+
+    Label label("Ready");
+    window.select_view(&label);
+    REQUIRE(has_label_containing(window, "Text: Ready"));
+
+    Meter meter;
+    meter.set_level(0.125f, 0.5f);
+    window.select_view(&meter);
+    REQUIRE(has_label_containing(window, "RMS: 0.125  Peak: 0.500"));
+
+    window.refresh();
+    REQUIRE(tree->find_node_by_user_data(knob_ptr) != nullptr);
+}
+
+TEST_CASE("InspectorWindow refreshes console performance and state tabs", "[inspect][window][issue-641]") {
+    View inspected_root;
+    inspected_root.set_id("root");
+    inspected_root.add_child(std::make_unique<Label>("child"));
+
+    InspectorWindow window(inspected_root);
+    auto* tabs = dynamic_cast<TabPanel*>(window.child_at(0));
+    REQUIRE(tabs != nullptr);
+
+    ConsoleCapture capture;
+    auto console = capture.callback();
+    console("warn", "careful");
+    console("debug", "trace");
+    window.set_console_capture(&capture);
+    tabs->set_active_tab(1);
+    window.refresh();
+    REQUIRE(tabs->active_tab() == 1);
+    REQUIRE(tabs->child_at(1)->visible());
+    REQUIRE(collect_views_of_type<ConsoleEntryView>(*tabs->child_at(1)).size() == 2);
+
+    pulp::render::RenderPassManager rpm;
+    rpm.set_budget(1.0f);
+    rpm.begin_frame();
+    rpm.begin_pass(pulp::render::RenderPassType::background);
+    rpm.end_pass(0.75f, 3);
+    rpm.begin_pass(pulp::render::RenderPassType::overlay);
+    rpm.end_pass(1.75f, 7);
+    rpm.end_frame();
+
+    window.set_render_pass_manager(&rpm);
+    tabs->set_active_tab(2);
+    window.refresh();
+    REQUIRE(has_label_containing(*tabs->child_at(2), "FPS: 400.0"));
+    REQUIRE(has_label_containing(*tabs->child_at(2), "Frame time: 2.50 ms"));
+    REQUIRE(has_label_containing(*tabs->child_at(2), "Budget: 1.0 ms  [OVER BUDGET]"));
+    REQUIRE(has_label_containing(*tabs->child_at(2), "View count: 2"));
+    REQUIRE(has_label_containing(*tabs->child_at(2), "background: 0.75 ms, 3 draws"));
+    REQUIRE(has_label_containing(*tabs->child_at(2), "overlay: 1.75 ms, 7 draws"));
+
+    InspectorWindow missing_perf_window(inspected_root);
+    auto* missing_perf_tabs = dynamic_cast<TabPanel*>(missing_perf_window.child_at(0));
+    REQUIRE(missing_perf_tabs != nullptr);
+    missing_perf_tabs->set_active_tab(2);
+    missing_perf_window.refresh();
+    REQUIRE(has_label_containing(*missing_perf_tabs->child_at(2), "FPS: (no data)"));
+
+    StateStore store;
+    ParamInfo gain;
+    gain.id = 7;
+    gain.name = "Gain";
+    gain.unit = "dB";
+    gain.range = {-60.0f, 12.0f, -12.0f, 0.5f};
+    gain.to_string = [](float value) {
+        return std::to_string(static_cast<int>(value)) + " dB";
+    };
+    store.add_parameter(gain);
+    store.set_value(7, -6.0f);
+
+    StateInspector state_inspector(store);
+    window.set_state_inspector(&state_inspector);
+    tabs->set_active_tab(3);
+    window.refresh();
+    REQUIRE(has_label_containing(*tabs->child_at(3), "Gain: -6.000 (-6 dB)"));
+    REQUIRE(has_label_containing(*tabs->child_at(3), "Range: [-60.00, 12.00] step=0.500  Unit: dB"));
 }
 
 // ── ConsoleCapture ──────────────────────────────────────────────────────────
@@ -372,4 +670,182 @@ TEST_CASE("DomainHandler: Audio domain exposes config and MIDI log") {
     DomainHandler missing_audio;
     auto missing = missing_audio.handle(make_request(5, methods::kAudioGetConfig));
     REQUIRE(missing.is_error);
+}
+
+TEST_CASE("DomainHandler: dispatches inspector domain edge paths", "[inspect][domain][issue-641]") {
+    View root;
+    root.set_id("root");
+    root.set_bounds({0, 0, 320, 200});
+    Theme theme;
+    theme.colors["accent.primary"] = Color::rgba8(12, 34, 56);
+    root.set_theme(theme);
+
+    auto child = std::make_unique<Label>("Child");
+    child->set_id("child");
+    child->set_bounds({5, 6, 70, 20});
+    child->set_opacity(0.5f);
+    child->set_visible(false);
+    child->flex().direction = FlexDirection::row;
+    child->flex().gap = 8;
+    child->flex().padding = 3;
+    child->flex().margin = 2;
+    root.add_child(std::move(child));
+
+    InspectorOverlay overlay(root);
+    ConsoleCapture capture;
+    auto console = capture.callback();
+    console("info", "hello");
+
+    StateStore store;
+    ParamInfo gain;
+    gain.id = 9;
+    gain.name = "Gain";
+    gain.unit = "dB";
+    gain.range = {-60.0f, 12.0f, 0.0f, 0.5f};
+    store.add_parameter(gain);
+    StateInspector state(store);
+
+    AudioInspector audio;
+    AudioConfig cfg;
+    cfg.sample_rate = 44100;
+    cfg.buffer_size = 256;
+    audio.set_config(cfg);
+
+    pulp::render::RenderPassManager rpm;
+    rpm.begin_frame();
+    rpm.begin_pass(pulp::render::RenderPassType::content);
+    rpm.end_pass(4.0f, 11);
+    rpm.end_frame();
+
+    DomainHandler handler;
+    handler.set_root_view(&root);
+    handler.set_overlay(&overlay);
+    handler.set_console_capture(&capture);
+    handler.set_state_inspector(&state);
+    handler.set_audio_inspector(&audio);
+    handler.set_render_pass_manager(&rpm);
+
+    auto invalid = handler.handle(make_request(1, "InvalidMethod"));
+    REQUIRE(invalid.is_error);
+    REQUIRE(invalid.params_json.find("Invalid method") != std::string::npos);
+
+    auto enabled = handler.handle(make_request(2, methods::kInspectorEnable));
+    REQUIRE_FALSE(enabled.is_error);
+    REQUIRE(overlay.is_active());
+
+    auto disabled = handler.handle(make_request(3, methods::kInspectorDisable));
+    REQUIRE_FALSE(disabled.is_error);
+    REQUIRE_FALSE(overlay.is_active());
+
+    auto unknown_inspector = handler.handle(make_request(4, "Inspector.nope"));
+    REQUIRE(unknown_inspector.is_error);
+
+    auto node = handler.handle(make_request(5, methods::kDOMGetNodeById, R"({"id":"child"})"));
+    REQUIRE_FALSE(node.is_error);
+    REQUIRE(node.params_json.find("\"id\"") != std::string::npos);
+    REQUIRE(node.params_json.find("child") != std::string::npos);
+    REQUIRE(node.params_json.find("child_count") != std::string::npos);
+
+    auto missing_node = handler.handle(make_request(6, methods::kDOMGetNodeById, R"({"id":"missing"})"));
+    REQUIRE(missing_node.is_error);
+
+    auto bad_node_params = handler.handle(make_request(7, methods::kDOMGetNodeById, "not json"));
+    REQUIRE(bad_node_params.is_error);
+
+    auto highlight = handler.handle(make_request(8, methods::kDOMHighlightNode));
+    REQUIRE_FALSE(highlight.is_error);
+    auto clear = handler.handle(make_request(9, methods::kDOMClearHighlight));
+    REQUIRE_FALSE(clear.is_error);
+
+    auto search = handler.handle(make_request(10, methods::kDOMSearch, R"({"query":"child"})"));
+    REQUIRE_FALSE(search.is_error);
+    REQUIRE(search.params_json.find("child") != std::string::npos);
+
+    auto bad_search = handler.handle(make_request(11, methods::kDOMSearch, "not json"));
+    REQUIRE(bad_search.is_error);
+
+    auto unknown_dom = handler.handle(make_request(12, "DOM.nope"));
+    REQUIRE(unknown_dom.is_error);
+
+    auto style = handler.handle(make_request(13, methods::kCSSGetComputedStyle, R"({"id":"child"})"));
+    REQUIRE_FALSE(style.is_error);
+    REQUIRE(style.params_json.find("direction") != std::string::npos);
+    REQUIRE(style.params_json.find("row") != std::string::npos);
+    REQUIRE(style.params_json.find("visible") != std::string::npos);
+    REQUIRE(style.params_json.find("false") != std::string::npos);
+
+    auto missing_style = handler.handle(make_request(14, methods::kCSSGetComputedStyle, R"({"id":"missing"})"));
+    REQUIRE(missing_style.is_error);
+
+    auto bad_style = handler.handle(make_request(15, methods::kCSSGetComputedStyle, "not json"));
+    REQUIRE(bad_style.is_error);
+
+    auto theme_resp = handler.handle(make_request(16, methods::kCSSGetTheme));
+    REQUIRE_FALSE(theme_resp.is_error);
+    REQUIRE(theme_resp.params_json.find("accent.primary") != std::string::npos);
+
+    auto unknown_css = handler.handle(make_request(17, "CSS.nope"));
+    REQUIRE(unknown_css.is_error);
+
+    auto perf = handler.handle(make_request(18, methods::kPerfGetMetrics));
+    REQUIRE_FALSE(perf.is_error);
+    REQUIRE(perf.params_json.find("total_time_ms") != std::string::npos);
+    REQUIRE(perf.params_json.find("draw_calls") != std::string::npos);
+    REQUIRE(perf.params_json.find("11") != std::string::npos);
+
+    auto tracking = handler.handle(make_request(19, methods::kPerfEnableTracking));
+    REQUIRE_FALSE(tracking.is_error);
+
+    auto unknown_perf = handler.handle(make_request(20, "Performance.nope"));
+    REQUIRE(unknown_perf.is_error);
+
+    auto set_param = handler.handle(make_request(21, methods::kStateSetParameter, R"({"id":9,"value":-12.5})"));
+    REQUIRE_FALSE(set_param.is_error);
+    REQUIRE(store.get_value(9) == -12.5f);
+
+    auto bad_set_param = handler.handle(make_request(22, methods::kStateSetParameter, "not json"));
+    REQUIRE(bad_set_param.is_error);
+
+    auto unknown_state = handler.handle(make_request(23, "State.nope"));
+    REQUIRE(unknown_state.is_error);
+
+    auto console_entries = handler.handle(make_request(24, methods::kConsoleEnable));
+    REQUIRE_FALSE(console_entries.is_error);
+    REQUIRE(console_entries.params_json.find("hello") != std::string::npos);
+
+    auto unknown_console = handler.handle(make_request(25, "Console.nope"));
+    REQUIRE(unknown_console.is_error);
+
+    auto runtime_eval = handler.handle(make_request(26, methods::kRuntimeEvaluate));
+    REQUIRE(runtime_eval.is_error);
+
+    auto hot_reload = handler.handle(make_request(27, methods::kRuntimeGetHotReloadStatus));
+    REQUIRE_FALSE(hot_reload.is_error);
+    REQUIRE(hot_reload.params_json.find("available") != std::string::npos);
+    REQUIRE(hot_reload.params_json.find("false") != std::string::npos);
+
+    auto unknown_runtime = handler.handle(make_request(28, "Runtime.nope"));
+    REQUIRE(unknown_runtime.is_error);
+
+    auto screenshot = handler.handle(make_request(29, methods::kCaptureScreenshot));
+    REQUIRE(screenshot.is_error);
+    auto screenshot_node = handler.handle(make_request(30, methods::kCaptureScreenshotNode));
+    REQUIRE(screenshot_node.is_error);
+    auto unknown_capture = handler.handle(make_request(31, "Capture.nope"));
+    REQUIRE(unknown_capture.is_error);
+
+    DomainHandler missing_sources;
+    REQUIRE(missing_sources.handle(make_request(32, methods::kDOMGetDocument)).is_error);
+    REQUIRE(missing_sources.handle(make_request(33, methods::kCSSGetTheme)).is_error);
+    REQUIRE(missing_sources.handle(make_request(34, methods::kStateGetParameters)).is_error);
+    REQUIRE(missing_sources.handle(make_request(35, methods::kAudioGetConfig)).is_error);
+
+    auto no_console = missing_sources.handle(make_request(36, methods::kConsoleEnable));
+    REQUIRE_FALSE(no_console.is_error);
+    REQUIRE(no_console.params_json == "[]");
+
+    auto no_perf = missing_sources.handle(make_request(37, methods::kPerfGetMetrics));
+    REQUIRE_FALSE(no_perf.is_error);
+    REQUIRE(no_perf.params_json.find("available") != std::string::npos);
+    REQUIRE(no_perf.params_json.find("false") != std::string::npos);
 }


### PR DESCRIPTION
## Summary
- Add deterministic inspector-window coverage for tab construction, element-property refresh, console/performance/state refresh paths, and collapsable sections.
- Add InspectorOverlay mouse-selection, panel tree, collapse-toggle, and distance-click coverage using RecordingCanvas.
- Add DomainHandler edge coverage across Inspector, DOM, CSS, Performance, State, Console, Runtime, Audio, and Capture dispatch paths.

Parent: #641

## Validation
- cmake -S . -B build-inspect-coverage -DPULP_BUILD_EXAMPLES=OFF -DPULP_ENABLE_GPU=ON -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-inspect-coverage --target pulp-test-inspector -j4
- ./build-inspect-coverage/test/pulp-test-inspector (211 assertions / 31 cases)
- ctest --test-dir build-inspect-coverage -R "Collapsable|Inspector|inspector|DomainHandler" --output-on-failure (22/22)
- git diff --check
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- pre-push hook gates clean