### PR TITLE
test(cli): cover cached cli common helper paths

### DIFF
--- a/test/test_cli_project_command.cpp
+++ b/test/test_cli_project_command.cpp
@@ -668,6 +668,32 @@ TEST_CASE("cli common standalone SDK resolution reports missing hints without ma
     REQUIRE(checkout_only.resolved_sdk_dir.empty());
 }
 
+TEST_CASE("cli common cached SDK and build helpers return without shelling out",
+          "[cli][common][issue-643]") {
+    TempDir tmp;
+    ScopedEnv pulp_home("PULP_HOME", (tmp.path / "home").string());
+
+    make_fake_sdk(sdk_cache_path("0.8.0"), "0.8.0");
+    REQUIRE(ensure_sdk("0.8.0") == sdk_cache_path("0.8.0"));
+
+    auto repo = tmp.path / "repo";
+    fs::create_directories(repo / "core");
+    write_file(repo / "CMakeLists.txt",
+               "cmake_minimum_required(VERSION 3.24)\n"
+               "project(PulpFixture VERSION 0.8.0 LANGUAGES CXX)\n");
+
+    make_fake_sdk(local_sdk_cache_path("0.9.0"), "0.9.0");
+    REQUIRE(ensure_checkout_sdk(repo, "0.9.0") == local_sdk_cache_path("0.9.0"));
+
+    auto build = tmp.path / "build";
+    fs::create_directories(build);
+    write_file(build / "CMakeCache.txt",
+               "CMAKE_HOME_DIRECTORY:INTERNAL=" + repo.string() + "\n");
+
+    REQUIRE(cmake_home_directory(build) == repo);
+    REQUIRE(ensure_repo_build_configured(repo, build) == 0);
+}
+
 TEST_CASE("cli common AAX helpers classify SDKs, bundles, and validator output",
           "[cli][common][issue-643]") {
     TempDir tmp;


### PR DESCRIPTION
## Summary
- cover cached `ensure_sdk` and `ensure_checkout_sdk` fast paths without invoking downloads, setup, or CMake
- cover `cmake_home_directory` parsing and the already-configured `ensure_repo_build_configured` no-op branch

## Validation
- cmake --build build --target pulp-test-cli-project-command -j4
- ./build/test/pulp-test-cli-project-command "cli common cached SDK and build helpers return without shelling out"
- ./build/test/pulp-test-cli-project-command
- ctest --test-dir build -R "cli common cached SDK|cli-project-command" --output-on-failure
- git diff --check
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report

Refs #643
Refs #641