### PR TITLE
feat(view): SvgPathWidget for inline SVG <path> icons (#965)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0600"></a>
+## [0.61.0]
+
 ## [0.60.0] - 2026-04-28
 
 - fix(canvas): CoreGraphicsCanvas::concat_transform composes onto CTM (Codex P1 on #933) ([#961](https://github.com/danielraffel/pulp/pull/961))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.60.0
+    VERSION 0.61.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -715,7 +715,19 @@ struct DrawCommand {
         // ── issue-926: save_backdrop_filter for frosted-glass overlays ─
         save_backdrop_filter, ///< x/y/w/h in f[0..3], blur_radius in f[4]
         // ── issue-929: real clearRect that replaces pixels ────────────
-        clear_rect          ///< clear rect, x/y/w/h in f[0..3]
+        clear_rect,          ///< clear rect, x/y/w/h in f[0..3]
+        // ── issue-965: Canvas2D path API recording ────────────────────
+        // Captured so widgets that emit path commands (SvgPathWidget,
+        // CanvasWidget JS path-replays) can be asserted at the
+        // command-stream level without a Skia raster surface.
+        begin_path,           ///< no payload
+        move_to,              ///< (x, y) in f[0..1]
+        line_to,              ///< (x, y) in f[0..1]
+        quad_to,              ///< (cpx, cpy, x, y) in f[0..3]
+        cubic_to,             ///< (cp1x, cp1y, cp2x, cp2y, x, y) in f[0..5]
+        close_path,           ///< no payload
+        fill_current_path,    ///< no payload — uses last set_fill_color
+        stroke_current_path   ///< no payload — uses last set_stroke_color + set_line_width
     };
 
     Type type;
@@ -798,6 +810,20 @@ public:
     void draw_box_shadow(float x, float y, float w, float h,
                          float dx, float dy, float blur, float spread,
                          Color color, bool inset, float corner_radius) override;
+
+    // issue-965 — Canvas2D path API recording. Each call appends one
+    // DrawCommand so widget tests can assert on emit order and shape
+    // without needing a real raster surface. Pure capture; no geometry
+    // is computed.
+    void begin_path() override;
+    void move_to(float x, float y) override;
+    void line_to(float x, float y) override;
+    void quad_to(float cpx, float cpy, float x, float y) override;
+    void cubic_to(float cp1x, float cp1y, float cp2x, float cp2y,
+                  float x, float y) override;
+    void close_path() override;
+    void fill_current_path() override;
+    void stroke_current_path() override;
 
 private:
     std::vector<DrawCommand> commands_;

--- a/core/canvas/src/recording_canvas.cpp
+++ b/core/canvas/src/recording_canvas.cpp
@@ -318,6 +318,51 @@ void RecordingCanvas::draw_box_shadow(float x, float y, float w, float h,
     commands_.push_back(std::move(cmd));
 }
 
+// ── issue-965: Canvas2D path API recording ──────────────────────────────────
+void RecordingCanvas::begin_path() {
+    commands_.push_back({DrawCommand::Type::begin_path});
+}
+
+void RecordingCanvas::move_to(float x, float y) {
+    DrawCommand cmd{DrawCommand::Type::move_to};
+    cmd.f[0] = x; cmd.f[1] = y;
+    commands_.push_back(cmd);
+}
+
+void RecordingCanvas::line_to(float x, float y) {
+    DrawCommand cmd{DrawCommand::Type::line_to};
+    cmd.f[0] = x; cmd.f[1] = y;
+    commands_.push_back(cmd);
+}
+
+void RecordingCanvas::quad_to(float cpx, float cpy, float x, float y) {
+    DrawCommand cmd{DrawCommand::Type::quad_to};
+    cmd.f[0] = cpx; cmd.f[1] = cpy;
+    cmd.f[2] = x;   cmd.f[3] = y;
+    commands_.push_back(cmd);
+}
+
+void RecordingCanvas::cubic_to(float cp1x, float cp1y, float cp2x, float cp2y,
+                               float x, float y) {
+    DrawCommand cmd{DrawCommand::Type::cubic_to};
+    cmd.f[0] = cp1x; cmd.f[1] = cp1y;
+    cmd.f[2] = cp2x; cmd.f[3] = cp2y;
+    cmd.f[4] = x;    cmd.f[5] = y;
+    commands_.push_back(cmd);
+}
+
+void RecordingCanvas::close_path() {
+    commands_.push_back({DrawCommand::Type::close_path});
+}
+
+void RecordingCanvas::fill_current_path() {
+    commands_.push_back({DrawCommand::Type::fill_current_path});
+}
+
+void RecordingCanvas::stroke_current_path() {
+    commands_.push_back({DrawCommand::Type::stroke_current_path});
+}
+
 // ── compile_sksl fallback for non-Skia builds ────────────────────────────────
 #ifndef PULP_HAS_SKIA
 std::string Canvas::compile_sksl(const std::string& sksl) {

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -164,6 +164,7 @@ target_sources(pulp-view PRIVATE
     src/screenshot_compare.cpp
     src/app_framework.cpp
     src/canvas_widget.cpp
+    src/svg_path_widget.cpp
     src/visualization_bridge.cpp
     src/frame_clock.cpp
     src/window_manager.cpp

--- a/core/view/include/pulp/view/svg_path_widget.hpp
+++ b/core/view/include/pulp/view/svg_path_widget.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+/// @file svg_path_widget.hpp
+/// A View that renders an inline SVG path-data string. Targets HTML
+/// patterns of the form `<svg viewBox="0 0 24 24"><path d="M..."/></svg>`
+/// — common for icon glyphs in React/HTML bundles. The widget parses
+/// the path data once on set_path() into a flat list of Canvas2D path
+/// segments, then replays them in paint() at the widget's bounds, scaled
+/// from the source viewBox.
+
+#include <pulp/view/view.hpp>
+#include <pulp/canvas/canvas.hpp>
+#include <string>
+#include <vector>
+
+namespace pulp::view {
+
+/// Parsed path segment — flat, allocation-light, ready to replay onto
+/// a Canvas in a single pass during paint().
+struct SvgPathSegment {
+    enum class Op {
+        move_to,    ///< (x, y)
+        line_to,    ///< (x, y)
+        quad_to,    ///< (cpx, cpy, x, y)
+        cubic_to,   ///< (cp1x, cp1y, cp2x, cp2y, x, y)
+        close_path
+    };
+    Op op = Op::move_to;
+    float p[6] = {};
+};
+
+/// Renders an inline SVG `<path d="...">` icon. Supports the path-data
+/// commands that occur in icon glyphs: M/m, L/l, H/h, V/v, C/c, S/s,
+/// Q/q, T/t, Z/z. Elliptical arcs (A/a) are converted to a chain of
+/// cubic-bezier approximations. Default fill is black, no stroke.
+class SvgPathWidget : public View {
+public:
+    SvgPathWidget() = default;
+
+    /// Set the path-data string. Re-parses immediately. Empty string
+    /// clears the widget.
+    void set_path(std::string data);
+
+    /// Set the source coordinate space the path was authored in. The
+    /// widget scales path coords from this box to its own bounds with
+    /// preserved aspect ratio (xMidYMid meet — the SVG default). When
+    /// width or height is <= 0, the widget falls back to its bounds
+    /// 1:1, which matches HTML default for path data with no viewBox.
+    void set_viewbox(float width, float height);
+
+    /// Solid-fill paint. Pass an alpha-zero color or call clear_fill()
+    /// to disable filling. Default: opaque black, fill enabled.
+    void set_fill_color(canvas::Color c);
+    void clear_fill();
+
+    /// Solid-stroke paint. Pass an alpha-zero color or call
+    /// clear_stroke() to disable stroking. Default: no stroke.
+    void set_stroke_color(canvas::Color c);
+    void clear_stroke();
+
+    /// Stroke width in SVG path-coords (i.e. viewBox space). Default 1.
+    void set_stroke_width(float w);
+
+    // Accessors used by tests.
+    const std::string& path_data() const { return path_data_; }
+    const std::vector<SvgPathSegment>& segments() const { return segments_; }
+    bool has_fill() const { return has_fill_; }
+    bool has_stroke() const { return has_stroke_; }
+    canvas::Color fill_color() const { return fill_color_; }
+    canvas::Color stroke_color() const { return stroke_color_; }
+    float stroke_width() const { return stroke_width_; }
+    float viewbox_width() const { return viewbox_w_; }
+    float viewbox_height() const { return viewbox_h_; }
+
+    void paint(canvas::Canvas& canvas) override;
+
+private:
+    void reparse();
+
+    std::string path_data_;
+    std::vector<SvgPathSegment> segments_;
+    canvas::Color fill_color_{0.0f, 0.0f, 0.0f, 1.0f};
+    canvas::Color stroke_color_{0.0f, 0.0f, 0.0f, 1.0f};
+    float stroke_width_ = 1.0f;
+    float viewbox_w_ = 0.0f;   // 0 means "use widget bounds 1:1"
+    float viewbox_h_ = 0.0f;
+    bool has_fill_ = true;
+    bool has_stroke_ = false;
+};
+
+} // namespace pulp::view

--- a/core/view/src/svg_path_widget.cpp
+++ b/core/view/src/svg_path_widget.cpp
@@ -1,0 +1,492 @@
+#include <pulp/view/svg_path_widget.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+
+namespace pulp::view {
+
+namespace {
+
+// SVG path-data tokenizer. Walks the input string, returning the next
+// command letter or float in turn. Whitespace and commas are separators
+// per the SVG 1.1 spec. Negative numbers don't need a separator from
+// the previous token (e.g. "M0 0L1-1" is valid).
+class PathScanner {
+public:
+    explicit PathScanner(const std::string& s) : s_(s), i_(0) {}
+
+    bool at_end() const { return i_ >= s_.size(); }
+
+    void skip_separators() {
+        while (i_ < s_.size()) {
+            char c = s_[i_];
+            if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',') {
+                ++i_;
+            } else {
+                break;
+            }
+        }
+    }
+
+    // Returns 0 (no command) when the next non-separator char is a
+    // digit / sign / dot — meaning the caller should re-use the
+    // previous command (SVG path implicit-command rule).
+    char next_command() {
+        skip_separators();
+        if (i_ >= s_.size()) return 0;
+        char c = s_[i_];
+        if (std::isalpha(static_cast<unsigned char>(c))) {
+            ++i_;
+            return c;
+        }
+        return 0;
+    }
+
+    bool next_float(float& out) {
+        skip_separators();
+        if (i_ >= s_.size()) return false;
+        const char* start = s_.data() + i_;
+        char* end = nullptr;
+        out = std::strtof(start, &end);
+        if (end == start) return false;
+        i_ += static_cast<size_t>(end - start);
+        return true;
+    }
+
+    // SVG arcs encode the large-arc and sweep flags as a single '0' or
+    // '1' digit, optionally without a separator from the next number.
+    // Strtof would happily read '01' as 1.0 and consume both digits, so
+    // arcs need a dedicated single-flag scan.
+    bool next_flag(int& out) {
+        skip_separators();
+        if (i_ >= s_.size()) return false;
+        char c = s_[i_];
+        if (c == '0') { out = 0; ++i_; return true; }
+        if (c == '1') { out = 1; ++i_; return true; }
+        return false;
+    }
+
+private:
+    const std::string& s_;
+    size_t i_;
+};
+
+struct ParserState {
+    float cx = 0, cy = 0;        // current point
+    float sx = 0, sy = 0;        // last move-to (for Z)
+    float prev_cubic_cpx = 0;    // last cubic control-point-2 (for S/s reflect)
+    float prev_cubic_cpy = 0;
+    float prev_quad_cpx = 0;     // last quadratic control point (for T/t reflect)
+    float prev_quad_cpy = 0;
+    bool has_prev_cubic = false;
+    bool has_prev_quad = false;
+};
+
+// Approximate an SVG elliptical arc with a chain of cubic-bezier
+// segments, following the W3C SVG implementation note:
+// https://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes
+// One bezier per <= pi/2 sweep angle. Returns the new current point.
+void emit_arc_as_cubics(std::vector<SvgPathSegment>& out,
+                        float x1, float y1,
+                        float rx, float ry,
+                        float phi_deg,
+                        int large_arc, int sweep,
+                        float x2, float y2) {
+    if (x1 == x2 && y1 == y2) return;
+    if (rx == 0 || ry == 0) {
+        SvgPathSegment seg;
+        seg.op = SvgPathSegment::Op::line_to;
+        seg.p[0] = x2; seg.p[1] = y2;
+        out.push_back(seg);
+        return;
+    }
+    rx = std::abs(rx);
+    ry = std::abs(ry);
+    const float phi = phi_deg * 3.14159265358979323846f / 180.0f;
+    const float cos_phi = std::cos(phi);
+    const float sin_phi = std::sin(phi);
+
+    // Step 1: transform to centred parametrisation (W3C eq. F.6.5.1).
+    const float dx = (x1 - x2) * 0.5f;
+    const float dy = (y1 - y2) * 0.5f;
+    const float x1p =  cos_phi * dx + sin_phi * dy;
+    const float y1p = -sin_phi * dx + cos_phi * dy;
+
+    // Correct out-of-range radii (W3C eq. F.6.6.2).
+    float lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry);
+    if (lambda > 1.0f) {
+        const float s = std::sqrt(lambda);
+        rx *= s;
+        ry *= s;
+    }
+
+    const float rx2 = rx * rx;
+    const float ry2 = ry * ry;
+    const float x1p2 = x1p * x1p;
+    const float y1p2 = y1p * y1p;
+    float radicand = rx2 * ry2 - rx2 * y1p2 - ry2 * x1p2;
+    radicand /= (rx2 * y1p2 + ry2 * x1p2);
+    if (radicand < 0) radicand = 0;
+    float coef = std::sqrt(radicand);
+    if (large_arc == sweep) coef = -coef;
+    const float cxp =  coef * (rx * y1p) / ry;
+    const float cyp = -coef * (ry * x1p) / rx;
+
+    // Centre in original coords.
+    const float cx = cos_phi * cxp - sin_phi * cyp + (x1 + x2) * 0.5f;
+    const float cy = sin_phi * cxp + cos_phi * cyp + (y1 + y2) * 0.5f;
+
+    // Start and sweep angles.
+    auto angle_between = [](float ux, float uy, float vx, float vy) {
+        const float dot = ux * vx + uy * vy;
+        const float len = std::sqrt((ux*ux + uy*uy) * (vx*vx + vy*vy));
+        float c = len > 0 ? dot / len : 1.0f;
+        c = std::clamp(c, -1.0f, 1.0f);
+        float ang = std::acos(c);
+        if (ux * vy - uy * vx < 0) ang = -ang;
+        return ang;
+    };
+    const float theta1 = angle_between(1, 0, (x1p - cxp) / rx, (y1p - cyp) / ry);
+    float dtheta = angle_between((x1p - cxp) / rx, (y1p - cyp) / ry,
+                                  (-x1p - cxp) / rx, (-y1p - cyp) / ry);
+    constexpr float kTwoPi = 2.0f * 3.14159265358979323846f;
+    if (!sweep && dtheta > 0) dtheta -= kTwoPi;
+    else if (sweep && dtheta < 0) dtheta += kTwoPi;
+
+    // Number of cubic segments — one per <= pi/2 sweep.
+    const int n_segs = std::max(1, static_cast<int>(std::ceil(std::abs(dtheta) / (3.14159265f * 0.5f))));
+    const float seg_angle = dtheta / static_cast<float>(n_segs);
+    // Bezier control-handle length factor for an arc of seg_angle radians.
+    const float t = (4.0f / 3.0f) * std::tan(seg_angle * 0.25f);
+
+    float prev_x = x1, prev_y = y1;
+    for (int i = 1; i <= n_segs; ++i) {
+        const float a0 = theta1 + seg_angle * static_cast<float>(i - 1);
+        const float a1 = theta1 + seg_angle * static_cast<float>(i);
+        const float cos_a0 = std::cos(a0), sin_a0 = std::sin(a0);
+        const float cos_a1 = std::cos(a1), sin_a1 = std::sin(a1);
+
+        const float ex = cos_phi * rx * cos_a1 - sin_phi * ry * sin_a1 + cx;
+        const float ey = sin_phi * rx * cos_a1 + cos_phi * ry * sin_a1 + cy;
+
+        const float c1x = prev_x + (-cos_phi * rx * sin_a0 - sin_phi * ry * cos_a0) * t;
+        const float c1y = prev_y + (-sin_phi * rx * sin_a0 + cos_phi * ry * cos_a0) * t;
+        const float c2x = ex + (cos_phi * rx * sin_a1 + sin_phi * ry * cos_a1) * t;
+        const float c2y = ey + (sin_phi * rx * sin_a1 - cos_phi * ry * cos_a1) * t;
+
+        SvgPathSegment seg;
+        seg.op = SvgPathSegment::Op::cubic_to;
+        seg.p[0] = c1x; seg.p[1] = c1y;
+        seg.p[2] = c2x; seg.p[3] = c2y;
+        seg.p[4] = ex;  seg.p[5] = ey;
+        out.push_back(seg);
+        prev_x = ex; prev_y = ey;
+    }
+}
+
+void parse_path(const std::string& data, std::vector<SvgPathSegment>& out) {
+    out.clear();
+    PathScanner sc(data);
+    ParserState st;
+    char prev = 0;
+
+    auto rel = [](char c) { return std::islower(static_cast<unsigned char>(c)) != 0; };
+
+    while (!sc.at_end()) {
+        char cmd = sc.next_command();
+        if (cmd == 0) {
+            // Implicit command — re-use the previous one. M repeats as L,
+            // m repeats as l (W3C path-data grammar). All others repeat as
+            // themselves.
+            if (prev == 'M') cmd = 'L';
+            else if (prev == 'm') cmd = 'l';
+            else cmd = prev;
+            if (cmd == 0) break;  // garbage at start
+        }
+
+        const bool relative = rel(cmd);
+        const char up = static_cast<char>(std::toupper(static_cast<unsigned char>(cmd)));
+
+        switch (up) {
+        case 'M': {
+            float x, y;
+            if (!sc.next_float(x) || !sc.next_float(y)) return;
+            if (relative) { x += st.cx; y += st.cy; }
+            SvgPathSegment seg;
+            seg.op = SvgPathSegment::Op::move_to;
+            seg.p[0] = x; seg.p[1] = y;
+            out.push_back(seg);
+            st.cx = x; st.cy = y;
+            st.sx = x; st.sy = y;
+            st.has_prev_cubic = false;
+            st.has_prev_quad = false;
+            break;
+        }
+        case 'L': {
+            float x, y;
+            if (!sc.next_float(x) || !sc.next_float(y)) return;
+            if (relative) { x += st.cx; y += st.cy; }
+            SvgPathSegment seg;
+            seg.op = SvgPathSegment::Op::line_to;
+            seg.p[0] = x; seg.p[1] = y;
+            out.push_back(seg);
+            st.cx = x; st.cy = y;
+            st.has_prev_cubic = false;
+            st.has_prev_quad = false;
+            break;
+        }
+        case 'H': {
+            float x;
+            if (!sc.next_float(x)) return;
+            if (relative) x += st.cx;
+            SvgPathSegment seg;
+            seg.op = SvgPathSegment::Op::line_to;
+            seg.p[0] = x; seg.p[1] = st.cy;
+            out.push_back(seg);
+            st.cx = x;
+            st.has_prev_cubic = false;
+            st.has_prev_quad = false;
+            break;
+        }
+        case 'V': {
+            float y;
+            if (!sc.next_float(y)) return;
+            if (relative) y += st.cy;
+            SvgPathSegment seg;
+            seg.op = SvgPathSegment::Op::line_to;
+            seg.p[0] = st.cx; seg.p[1] = y;
+            out.push_back(seg);
+            st.cy = y;
+            st.has_prev_cubic = false;
+            st.has_prev_quad = false;
+            break;
+        }
+        case 'C': {
+            float x1, y1, x2, y2, x, y;
+            if (!sc.next_float(x1) || !sc.next_float(y1) ||
+                !sc.next_float(x2) || !sc.next_float(y2) ||
+                !sc.next_float(x)  || !sc.next_float(y)) return;
+            if (relative) {
+                x1 += st.cx; y1 += st.cy;
+                x2 += st.cx; y2 += st.cy;
+                x  += st.cx; y  += st.cy;
+            }
+            SvgPathSegment seg;
+            seg.op = SvgPathSegment::Op::cubic_to;
+            seg.p[0] = x1; seg.p[1] = y1;
+            seg.p[2] = x2; seg.p[3] = y2;
+            seg.p[4] = x;  seg.p[5] = y;
+            out.push_back(seg);
+            st.cx = x; st.cy = y;
+            st.prev_cubic_cpx = x2;
+            st.prev_cubic_cpy = y2;
+            st.has_prev_cubic = true;
+            st.has_prev_quad = false;
+            break;
+        }
+        case 'S': {
+            float x2, y2, x, y;
+            if (!sc.next_float(x2) || !sc.next_float(y2) ||
+                !sc.next_float(x)  || !sc.next_float(y)) return;
+            if (relative) {
+                x2 += st.cx; y2 += st.cy;
+                x  += st.cx; y  += st.cy;
+            }
+            // First control point is the reflection of the previous
+            // cubic's second control point through the current point.
+            // If the previous segment wasn't a cubic, use the current
+            // point itself (W3C spec).
+            float x1, y1;
+            if (st.has_prev_cubic) {
+                x1 = 2.0f * st.cx - st.prev_cubic_cpx;
+                y1 = 2.0f * st.cy - st.prev_cubic_cpy;
+            } else {
+                x1 = st.cx; y1 = st.cy;
+            }
+            SvgPathSegment seg;
+            seg.op = SvgPathSegment::Op::cubic_to;
+            seg.p[0] = x1; seg.p[1] = y1;
+            seg.p[2] = x2; seg.p[3] = y2;
+            seg.p[4] = x;  seg.p[5] = y;
+            out.push_back(seg);
+            st.cx = x; st.cy = y;
+            st.prev_cubic_cpx = x2;
+            st.prev_cubic_cpy = y2;
+            st.has_prev_cubic = true;
+            st.has_prev_quad = false;
+            break;
+        }
+        case 'Q': {
+            float x1, y1, x, y;
+            if (!sc.next_float(x1) || !sc.next_float(y1) ||
+                !sc.next_float(x)  || !sc.next_float(y)) return;
+            if (relative) {
+                x1 += st.cx; y1 += st.cy;
+                x  += st.cx; y  += st.cy;
+            }
+            SvgPathSegment seg;
+            seg.op = SvgPathSegment::Op::quad_to;
+            seg.p[0] = x1; seg.p[1] = y1;
+            seg.p[2] = x;  seg.p[3] = y;
+            out.push_back(seg);
+            st.cx = x; st.cy = y;
+            st.prev_quad_cpx = x1;
+            st.prev_quad_cpy = y1;
+            st.has_prev_quad = true;
+            st.has_prev_cubic = false;
+            break;
+        }
+        case 'T': {
+            float x, y;
+            if (!sc.next_float(x) || !sc.next_float(y)) return;
+            if (relative) { x += st.cx; y += st.cy; }
+            float x1, y1;
+            if (st.has_prev_quad) {
+                x1 = 2.0f * st.cx - st.prev_quad_cpx;
+                y1 = 2.0f * st.cy - st.prev_quad_cpy;
+            } else {
+                x1 = st.cx; y1 = st.cy;
+            }
+            SvgPathSegment seg;
+            seg.op = SvgPathSegment::Op::quad_to;
+            seg.p[0] = x1; seg.p[1] = y1;
+            seg.p[2] = x;  seg.p[3] = y;
+            out.push_back(seg);
+            st.cx = x; st.cy = y;
+            st.prev_quad_cpx = x1;
+            st.prev_quad_cpy = y1;
+            st.has_prev_quad = true;
+            st.has_prev_cubic = false;
+            break;
+        }
+        case 'A': {
+            float rx, ry, phi, x, y;
+            int large, sweep;
+            if (!sc.next_float(rx) || !sc.next_float(ry) ||
+                !sc.next_float(phi) ||
+                !sc.next_flag(large) || !sc.next_flag(sweep) ||
+                !sc.next_float(x)   || !sc.next_float(y)) return;
+            if (relative) { x += st.cx; y += st.cy; }
+            emit_arc_as_cubics(out, st.cx, st.cy, rx, ry, phi,
+                               large, sweep, x, y);
+            st.cx = x; st.cy = y;
+            st.has_prev_cubic = false;
+            st.has_prev_quad = false;
+            break;
+        }
+        case 'Z': {
+            SvgPathSegment seg;
+            seg.op = SvgPathSegment::Op::close_path;
+            out.push_back(seg);
+            st.cx = st.sx; st.cy = st.sy;
+            st.has_prev_cubic = false;
+            st.has_prev_quad = false;
+            break;
+        }
+        default:
+            // Unknown command — skip a token to make progress and avoid
+            // infinite loops on malformed input.
+            float dummy;
+            if (!sc.next_float(dummy)) return;
+            break;
+        }
+        prev = cmd;
+    }
+}
+
+}  // namespace
+
+void SvgPathWidget::set_path(std::string data) {
+    path_data_ = std::move(data);
+    reparse();
+}
+
+void SvgPathWidget::set_viewbox(float w, float h) {
+    viewbox_w_ = w;
+    viewbox_h_ = h;
+}
+
+void SvgPathWidget::set_fill_color(canvas::Color c) {
+    fill_color_ = c;
+    has_fill_ = true;
+}
+
+void SvgPathWidget::clear_fill() {
+    has_fill_ = false;
+}
+
+void SvgPathWidget::set_stroke_color(canvas::Color c) {
+    stroke_color_ = c;
+    has_stroke_ = true;
+}
+
+void SvgPathWidget::clear_stroke() {
+    has_stroke_ = false;
+}
+
+void SvgPathWidget::set_stroke_width(float w) {
+    stroke_width_ = std::max(0.0f, w);
+}
+
+void SvgPathWidget::reparse() {
+    parse_path(path_data_, segments_);
+}
+
+void SvgPathWidget::paint(canvas::Canvas& canvas) {
+    if (segments_.empty()) return;
+    if (!has_fill_ && !has_stroke_) return;
+
+    const auto b = local_bounds();
+    if (b.width <= 0 || b.height <= 0) return;
+
+    const float vw = viewbox_w_ > 0 ? viewbox_w_ : b.width;
+    const float vh = viewbox_h_ > 0 ? viewbox_h_ : b.height;
+
+    canvas.save();
+    // xMidYMid meet — preserve aspect, centre, scale to fit.
+    const float sx = b.width / vw;
+    const float sy = b.height / vh;
+    const float scale = std::min(sx, sy);
+    const float ox = (b.width  - vw * scale) * 0.5f;
+    const float oy = (b.height - vh * scale) * 0.5f;
+    canvas.translate(ox, oy);
+    canvas.scale(scale, scale);
+
+    canvas.begin_path();
+    for (const auto& seg : segments_) {
+        switch (seg.op) {
+        case SvgPathSegment::Op::move_to:
+            canvas.move_to(seg.p[0], seg.p[1]);
+            break;
+        case SvgPathSegment::Op::line_to:
+            canvas.line_to(seg.p[0], seg.p[1]);
+            break;
+        case SvgPathSegment::Op::quad_to:
+            canvas.quad_to(seg.p[0], seg.p[1], seg.p[2], seg.p[3]);
+            break;
+        case SvgPathSegment::Op::cubic_to:
+            canvas.cubic_to(seg.p[0], seg.p[1], seg.p[2], seg.p[3],
+                            seg.p[4], seg.p[5]);
+            break;
+        case SvgPathSegment::Op::close_path:
+            canvas.close_path();
+            break;
+        }
+    }
+
+    if (has_fill_) {
+        canvas.set_fill_color(fill_color_);
+        canvas.fill_current_path();
+    }
+    if (has_stroke_ && stroke_width_ > 0) {
+        canvas.set_stroke_color(stroke_color_);
+        canvas.set_line_width(stroke_width_);
+        canvas.stroke_current_path();
+    }
+
+    canvas.restore();
+}
+
+}  // namespace pulp::view

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -4,6 +4,7 @@
 #include <pulp/view/ui_components.hpp>
 #include <pulp/view/text_editor.hpp>
 #include <pulp/view/canvas_widget.hpp>
+#include <pulp/view/svg_path_widget.hpp>
 #include <pulp/view/modal.hpp>
 #include <pulp/view/asset_manager.hpp>
 #include <pulp/view/design_import.hpp>
@@ -2114,6 +2115,75 @@ void WidgetBridge::register_api() {
         auto hex = args.get<std::string>(1, "");
         auto* v = id.empty() ? &root_ : widget(id);
         if (v && !hex.empty()) v->set_background_color(parseHexColor(hex));
+        return choc::value::Value();
+    });
+
+    // ── pulp #965 — SvgPathWidget bridge ─────────────────────────────────────
+    // Mirrors the API surface of CanvasWidget but for inline <svg><path>
+    // icons. JS registers the widget and pushes its path-data + paint
+    // attributes; the native widget parses path-data once on set_path()
+    // and replays as Canvas2D path commands inside paint().
+    engine_.register_function("createSvgPath", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto pid = args.get<std::string>(1, "");
+        auto w = std::make_unique<SvgPathWidget>();
+        w->set_id(id);
+        widgets_[id] = w.get();
+        resolve_parent(pid)->add_child(std::move(w));
+        return choc::value::createString(id);
+    });
+
+    engine_.register_function("setSvgPath", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto data = args.get<std::string>(1, "");
+        if (auto* w = dynamic_cast<SvgPathWidget*>(widget(id))) {
+            w->set_path(data);
+        }
+        return choc::value::Value();
+    });
+
+    engine_.register_function("setSvgViewBox", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto vw = args.get<double>(1, 0.0);
+        auto vh = args.get<double>(2, 0.0);
+        if (auto* w = dynamic_cast<SvgPathWidget*>(widget(id))) {
+            w->set_viewbox(static_cast<float>(vw), static_cast<float>(vh));
+        }
+        return choc::value::Value();
+    });
+
+    engine_.register_function("setSvgFill", [this, parseHexColor](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto hex = args.get<std::string>(1, "");
+        if (auto* w = dynamic_cast<SvgPathWidget*>(widget(id))) {
+            if (hex.empty() || hex == "none") {
+                w->clear_fill();
+            } else {
+                w->set_fill_color(parseHexColor(hex));
+            }
+        }
+        return choc::value::Value();
+    });
+
+    engine_.register_function("setSvgStroke", [this, parseHexColor](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto hex = args.get<std::string>(1, "");
+        if (auto* w = dynamic_cast<SvgPathWidget*>(widget(id))) {
+            if (hex.empty() || hex == "none") {
+                w->clear_stroke();
+            } else {
+                w->set_stroke_color(parseHexColor(hex));
+            }
+        }
+        return choc::value::Value();
+    });
+
+    engine_.register_function("setSvgStrokeWidth", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto width = args.get<double>(1, 1.0);
+        if (auto* w = dynamic_cast<SvgPathWidget*>(widget(id))) {
+            w->set_stroke_width(static_cast<float>(width));
+        }
         return choc::value::Value();
     });
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1359,6 +1359,11 @@ add_executable(pulp-test-canvas-widget test_canvas_widget.cpp)
 target_link_libraries(pulp-test-canvas-widget PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-canvas-widget)
 
+# SvgPathWidget tests (issue-965)
+add_executable(pulp-test-svg-path-widget test_svg_path_widget.cpp)
+target_link_libraries(pulp-test-svg-path-widget PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-svg-path-widget)
+
 # ScrollView tests
 add_executable(pulp-test-scroll-view test_scroll_view.cpp)
 target_link_libraries(pulp-test-scroll-view PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_svg_path_widget.cpp
+++ b/test/test_svg_path_widget.cpp
@@ -1,0 +1,291 @@
+// SvgPathWidget tests — pulp #965.
+//
+// Coverage targets:
+//   * Path-data parser handles M/m, L/l, H/h, V/v, C/c, S/s, Q/q, T/t,
+//     A/a, Z/z including the implicit-command repeat rule and the
+//     "no separator before negative number" lexing case.
+//   * Defaults (fill enabled black, no stroke) and the
+//     set/clear_fill / set/clear_stroke API.
+//   * paint() emits begin_path → path commands → fill / stroke in the
+//     correct order, gated on has_fill_ / has_stroke_.
+//   * viewBox-to-bounds scale: a unit-square path inside a 10x10
+//     viewBox lands at the centre of a 20x20 widget when set_viewbox
+//     and set_bounds disagree (xMidYMid meet).
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/svg_path_widget.hpp>
+#include <pulp/canvas/canvas.hpp>
+
+using pulp::view::SvgPathWidget;
+using pulp::view::SvgPathSegment;
+using pulp::canvas::DrawCommand;
+using pulp::canvas::RecordingCanvas;
+
+TEST_CASE("SvgPathWidget defaults match HTML <path> semantics", "[svg_path][issue-965]") {
+    SvgPathWidget w;
+    REQUIRE(w.has_fill());
+    REQUIRE_FALSE(w.has_stroke());
+    REQUIRE(w.stroke_width() == 1.0f);
+    REQUIRE(w.path_data().empty());
+    REQUIRE(w.segments().empty());
+}
+
+TEST_CASE("SvgPathWidget parses absolute M/L/Z", "[svg_path][issue-965]") {
+    SvgPathWidget w;
+    w.set_path("M 1 2 L 3 4 Z");
+    const auto& s = w.segments();
+    REQUIRE(s.size() == 3);
+    REQUIRE(s[0].op == SvgPathSegment::Op::move_to);
+    REQUIRE(s[0].p[0] == 1.0f);
+    REQUIRE(s[0].p[1] == 2.0f);
+    REQUIRE(s[1].op == SvgPathSegment::Op::line_to);
+    REQUIRE(s[1].p[0] == 3.0f);
+    REQUIRE(s[1].p[1] == 4.0f);
+    REQUIRE(s[2].op == SvgPathSegment::Op::close_path);
+}
+
+TEST_CASE("SvgPathWidget parses relative m/l with current-point offset",
+          "[svg_path][issue-965]") {
+    SvgPathWidget w;
+    w.set_path("m 10 10 l 5 0 l 0 5");
+    const auto& s = w.segments();
+    REQUIRE(s.size() == 3);
+    REQUIRE(s[0].op == SvgPathSegment::Op::move_to);
+    REQUIRE(s[0].p[0] == 10.0f);
+    REQUIRE(s[0].p[1] == 10.0f);
+    REQUIRE(s[1].op == SvgPathSegment::Op::line_to);
+    REQUIRE(s[1].p[0] == 15.0f);
+    REQUIRE(s[1].p[1] == 10.0f);
+    REQUIRE(s[2].op == SvgPathSegment::Op::line_to);
+    REQUIRE(s[2].p[0] == 15.0f);
+    REQUIRE(s[2].p[1] == 15.0f);
+}
+
+TEST_CASE("SvgPathWidget implicit-command repeat: M then implicit L",
+          "[svg_path][issue-965]") {
+    // "M 1 1 2 2 3 3" — after the move-to, the next coord pairs are
+    // implicit line-to per the SVG path-data grammar.
+    SvgPathWidget w;
+    w.set_path("M 1 1 2 2 3 3");
+    const auto& s = w.segments();
+    REQUIRE(s.size() == 3);
+    REQUIRE(s[0].op == SvgPathSegment::Op::move_to);
+    REQUIRE(s[1].op == SvgPathSegment::Op::line_to);
+    REQUIRE(s[1].p[0] == 2.0f);
+    REQUIRE(s[1].p[1] == 2.0f);
+    REQUIRE(s[2].op == SvgPathSegment::Op::line_to);
+    REQUIRE(s[2].p[0] == 3.0f);
+    REQUIRE(s[2].p[1] == 3.0f);
+}
+
+TEST_CASE("SvgPathWidget parses H/V into line_to, absolute and relative",
+          "[svg_path][issue-965]") {
+    SvgPathWidget w;
+    w.set_path("M 0 0 H 10 v 5 h -3");
+    const auto& s = w.segments();
+    REQUIRE(s.size() == 4);
+    // H 10 — horizontal line to absolute x=10
+    REQUIRE(s[1].op == SvgPathSegment::Op::line_to);
+    REQUIRE(s[1].p[0] == 10.0f);
+    REQUIRE(s[1].p[1] == 0.0f);
+    // v 5 — relative vertical, current y was 0, becomes 5
+    REQUIRE(s[2].op == SvgPathSegment::Op::line_to);
+    REQUIRE(s[2].p[0] == 10.0f);
+    REQUIRE(s[2].p[1] == 5.0f);
+    // h -3 — relative horizontal, current x was 10, becomes 7
+    REQUIRE(s[3].op == SvgPathSegment::Op::line_to);
+    REQUIRE(s[3].p[0] == 7.0f);
+    REQUIRE(s[3].p[1] == 5.0f);
+}
+
+TEST_CASE("SvgPathWidget cubic C and smooth-cubic S reflection",
+          "[svg_path][issue-965]") {
+    // After a cubic ending at (10,0) with cp2=(8,2), an S 12 4 16 0
+    // implies cp1 = reflection of (8,2) through (10,0) = (12,-2).
+    SvgPathWidget w;
+    w.set_path("M 0 0 C 2 -2 8 2 10 0 S 12 4 16 0");
+    const auto& s = w.segments();
+    REQUIRE(s.size() == 3);
+    REQUIRE(s[1].op == SvgPathSegment::Op::cubic_to);
+    REQUIRE(s[2].op == SvgPathSegment::Op::cubic_to);
+    REQUIRE(s[2].p[0] == 12.0f);
+    REQUIRE(s[2].p[1] == -2.0f);
+    REQUIRE(s[2].p[2] == 12.0f);
+    REQUIRE(s[2].p[3] == 4.0f);
+    REQUIRE(s[2].p[4] == 16.0f);
+    REQUIRE(s[2].p[5] == 0.0f);
+}
+
+TEST_CASE("SvgPathWidget quadratic Q and smooth-quadratic T reflection",
+          "[svg_path][issue-965]") {
+    SvgPathWidget w;
+    w.set_path("M 0 0 Q 5 5 10 0 T 20 0");
+    const auto& s = w.segments();
+    REQUIRE(s.size() == 3);
+    REQUIRE(s[1].op == SvgPathSegment::Op::quad_to);
+    REQUIRE(s[1].p[0] == 5.0f);
+    REQUIRE(s[1].p[1] == 5.0f);
+    REQUIRE(s[2].op == SvgPathSegment::Op::quad_to);
+    // Reflection of (5,5) through (10,0) = (15,-5).
+    REQUIRE(s[2].p[0] == 15.0f);
+    REQUIRE(s[2].p[1] == -5.0f);
+    REQUIRE(s[2].p[2] == 20.0f);
+    REQUIRE(s[2].p[3] == 0.0f);
+}
+
+TEST_CASE("SvgPathWidget Z returns current point to last move-to",
+          "[svg_path][issue-965]") {
+    // Two subpaths separated by Z. The second M starts a fresh subpath,
+    // and a relative l after the second M offsets from (5,5), not (0,0).
+    SvgPathWidget w;
+    w.set_path("M 0 0 L 1 1 Z M 5 5 l 1 0");
+    const auto& s = w.segments();
+    REQUIRE(s.size() == 5);
+    REQUIRE(s[2].op == SvgPathSegment::Op::close_path);
+    REQUIRE(s[3].op == SvgPathSegment::Op::move_to);
+    REQUIRE(s[3].p[0] == 5.0f);
+    REQUIRE(s[4].op == SvgPathSegment::Op::line_to);
+    REQUIRE(s[4].p[0] == 6.0f);
+    REQUIRE(s[4].p[1] == 5.0f);
+}
+
+TEST_CASE("SvgPathWidget tokenizer accepts negative number without separator",
+          "[svg_path][issue-965]") {
+    // Real-world icon path data omits separators before negative numbers
+    // ("M0 0L1-1L-2 0"). The strtof-based scanner must accept this.
+    SvgPathWidget w;
+    w.set_path("M0 0L1-1L-2 0");
+    const auto& s = w.segments();
+    REQUIRE(s.size() == 3);
+    REQUIRE(s[0].p[0] == 0.0f);
+    REQUIRE(s[1].p[0] == 1.0f);
+    REQUIRE(s[1].p[1] == -1.0f);
+    REQUIRE(s[2].p[0] == -2.0f);
+    REQUIRE(s[2].p[1] == 0.0f);
+}
+
+TEST_CASE("SvgPathWidget arc A is converted to cubic-bezier segments",
+          "[svg_path][issue-965]") {
+    // A semicircle from (0,0) to (10,0) with rx=ry=5, sweep=1, large=0
+    // approximates as a chain of cubics — exact count depends on the
+    // ceil(|dtheta| / (pi/2)) split. For a half-turn that's 2 cubics.
+    SvgPathWidget w;
+    w.set_path("M 0 0 A 5 5 0 0 1 10 0");
+    const auto& s = w.segments();
+    REQUIRE(s.size() >= 2);
+    REQUIRE(s[0].op == SvgPathSegment::Op::move_to);
+    for (size_t i = 1; i < s.size(); ++i) {
+        REQUIRE(s[i].op == SvgPathSegment::Op::cubic_to);
+    }
+    // Last cubic's endpoint must land on the arc's stated end.
+    const auto& last = s.back();
+    REQUIRE(std::abs(last.p[4] - 10.0f) < 1e-3f);
+    REQUIRE(std::abs(last.p[5] -  0.0f) < 1e-3f);
+}
+
+TEST_CASE("SvgPathWidget paint emits begin_path → path → fill in order",
+          "[svg_path][issue-965]") {
+    SvgPathWidget w;
+    w.set_bounds({0, 0, 10, 10});
+    w.set_path("M 0 0 L 10 0 L 10 10 Z");
+    w.set_fill_color(pulp::canvas::Color::rgba8(255, 0, 0, 255));
+
+    RecordingCanvas rc;
+    w.paint(rc);
+
+    int begin_idx = -1, fill_idx = -1, stroke_idx = -1;
+    for (size_t i = 0; i < rc.commands().size(); ++i) {
+        const auto& cmd = rc.commands()[i];
+        if (cmd.type == DrawCommand::Type::begin_path && begin_idx < 0) {
+            begin_idx = static_cast<int>(i);
+        } else if (cmd.type == DrawCommand::Type::fill_current_path && fill_idx < 0) {
+            fill_idx = static_cast<int>(i);
+        } else if (cmd.type == DrawCommand::Type::stroke_current_path && stroke_idx < 0) {
+            stroke_idx = static_cast<int>(i);
+        }
+    }
+    REQUIRE(begin_idx >= 0);
+    REQUIRE(fill_idx > begin_idx);
+    REQUIRE(stroke_idx == -1);  // default is no stroke
+}
+
+TEST_CASE("SvgPathWidget paint emits stroke_path when stroke is set",
+          "[svg_path][issue-965]") {
+    SvgPathWidget w;
+    w.set_bounds({0, 0, 10, 10});
+    w.set_path("M 0 0 L 10 10");
+    w.clear_fill();
+    w.set_stroke_color(pulp::canvas::Color::rgba8(0, 0, 0, 255));
+    w.set_stroke_width(2.0f);
+
+    RecordingCanvas rc;
+    w.paint(rc);
+
+    int fill_idx = -1, stroke_idx = -1;
+    for (size_t i = 0; i < rc.commands().size(); ++i) {
+        const auto& cmd = rc.commands()[i];
+        if (cmd.type == DrawCommand::Type::fill_current_path) fill_idx = static_cast<int>(i);
+        if (cmd.type == DrawCommand::Type::stroke_current_path) stroke_idx = static_cast<int>(i);
+    }
+    REQUIRE(fill_idx == -1);
+    REQUIRE(stroke_idx >= 0);
+}
+
+TEST_CASE("SvgPathWidget paint with no path data emits nothing",
+          "[svg_path][issue-965]") {
+    SvgPathWidget w;
+    w.set_bounds({0, 0, 10, 10});
+
+    RecordingCanvas rc;
+    w.paint(rc);
+
+    REQUIRE(rc.commands().empty());
+}
+
+TEST_CASE("SvgPathWidget viewBox is mapped onto widget bounds with xMidYMid meet",
+          "[svg_path][issue-965]") {
+    // Widget bounds 20x20, viewBox 10x10. Scale factor = 2. With a unit
+    // square path at (0,0)-(1,1) in viewBox space, the scaled translate
+    // brings it into the widget. Aspect-preserved, centred.
+    SvgPathWidget w;
+    w.set_bounds({0, 0, 20, 20});
+    w.set_viewbox(10, 10);
+    w.set_path("M 0 0 L 1 0");
+    w.set_fill_color(pulp::canvas::Color::rgba8(255, 255, 255));
+
+    RecordingCanvas rc;
+    w.paint(rc);
+
+    bool saw_scale = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::scale) {
+            REQUIRE(cmd.f[0] == 2.0f);
+            REQUIRE(cmd.f[1] == 2.0f);
+            saw_scale = true;
+        }
+    }
+    REQUIRE(saw_scale);
+}
+
+TEST_CASE("SvgPathWidget setFill / clearFill toggles emission",
+          "[svg_path][issue-965]") {
+    SvgPathWidget w;
+    w.set_bounds({0, 0, 8, 8});
+    w.set_path("M 0 0 L 8 8");
+    w.clear_fill();
+    w.clear_stroke();
+
+    RecordingCanvas rc1;
+    w.paint(rc1);
+    REQUIRE(rc1.commands().empty());
+
+    w.set_fill_color(pulp::canvas::Color::rgba8(10, 20, 30));
+    RecordingCanvas rc2;
+    w.paint(rc2);
+    REQUIRE_FALSE(rc2.commands().empty());
+
+    w.clear_fill();
+    RecordingCanvas rc3;
+    w.paint(rc3);
+    REQUIRE(rc3.commands().empty());
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -2589,3 +2589,55 @@ TEST_CASE("Canvas::draw_box_shadow CPU fallback approximates shadow as "
     // (steps = ceil(blur/2) + 1 = 21 for blur=40).
     REQUIRE(backing.count(DrawCommand::Type::fill_rounded_rect) >= 5);
 }
+
+// ── pulp #965 — SvgPathWidget JS bridge integration ──────────────────────────
+
+#include <pulp/view/svg_path_widget.hpp>
+
+TEST_CASE("WidgetBridge createSvgPath produces an SvgPathWidget the bridge can address",
+          "[view][bridge][issue-965]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createSvgPath('icon', '')");
+    bridge.load_script("setSvgPath('icon', 'M 0 0 L 10 0 L 10 10 Z')");
+    bridge.load_script("setSvgViewBox('icon', 10, 10)");
+    bridge.load_script("setSvgFill('icon', '#ff0000')");
+    bridge.load_script("setSvgStroke('icon', '#000000')");
+    bridge.load_script("setSvgStrokeWidth('icon', 2.0)");
+
+    auto* w = dynamic_cast<SvgPathWidget*>(bridge.widget("icon"));
+    REQUIRE(w != nullptr);
+    REQUIRE(w->path_data() == "M 0 0 L 10 0 L 10 10 Z");
+    REQUIRE(w->segments().size() == 4);
+    REQUIRE(w->viewbox_width() == 10.0f);
+    REQUIRE(w->viewbox_height() == 10.0f);
+    REQUIRE(w->has_fill());
+    REQUIRE(w->has_stroke());
+    REQUIRE(w->stroke_width() == 2.0f);
+    REQUIRE(w->fill_color().r8() == 255);
+    REQUIRE(w->fill_color().g8() == 0);
+    REQUIRE(w->fill_color().b8() == 0);
+}
+
+TEST_CASE("WidgetBridge setSvgFill 'none' disables fill",
+          "[view][bridge][issue-965]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createSvgPath('a', '')");
+    bridge.load_script("setSvgPath('a', 'M0 0L1 1')");
+    bridge.load_script("setSvgFill('a', 'none')");
+    bridge.load_script("setSvgStroke('a', '#222222')");
+    bridge.load_script("setSvgStrokeWidth('a', 1.5)");
+
+    auto* w = dynamic_cast<SvgPathWidget*>(bridge.widget("a"));
+    REQUIRE(w != nullptr);
+    REQUIRE_FALSE(w->has_fill());
+    REQUIRE(w->has_stroke());
+}


### PR DESCRIPTION
Adds a standalone widget that renders inline `<svg><path>` icon glyphs
common in HTML/React bundles (gear, dropdown carets, status indicators,
etc.). Spectr's editor.js had ~8+ such usages painting as text-only
because the bridge had no path-data primitive.

## Widget API (core/view/include/pulp/view/svg_path_widget.hpp)

  SvgPathWidget w;
  w.set_path("M 12 2 L 22 22 Z");
  w.set_viewbox(24, 24);            // optional
  w.set_fill_color(canvas::Color::rgba8(255, 0, 0));
  w.set_stroke_color(canvas::Color::rgba8(0, 0, 0));
  w.set_stroke_width(1.5f);

Path-data parser supports the SVG 1.1 commands real-world icons use:
M/m, L/l, H/h, V/v, C/c, S/s, Q/q, T/t, A/a, Z/z. Smooth-cubic / smooth-
quadratic reflection follows the spec. Elliptical arcs (A/a) are
converted to a chain of cubic-bezier approximations via the W3C
implnote algorithm — one bezier per <= pi/2 sweep.

paint() emits begin_path → path commands → fill_current_path /
stroke_current_path against any Canvas backend. Default render is
xMidYMid meet (preserve aspect, centre, scale to fit) when a viewBox
is set; otherwise the widget bounds are used 1:1.

## JS bridge (core/view/src/widget_bridge.cpp)

  createSvgPath(id, parentId)
  setSvgPath(id, "M ...")
  setSvgViewBox(id, w, h)
  setSvgFill(id, "#hex" | "none")
  setSvgStroke(id, "#hex" | "none")
  setSvgStrokeWidth(id, n)

Matches the issue's acceptance API. "none" disables fill/stroke;
default fill is opaque black, stroke is off.

## RecordingCanvas path-command capture

Extended canvas::DrawCommand::Type with begin_path / move_to / line_to /
quad_to / cubic_to / close_path / fill_current_path / stroke_current_path
and the matching RecordingCanvas overrides. The Canvas base already
exposed those methods as no-op virtuals, so widgets that emit path
commands had no way to be tested at the command-stream level — this
closes that gap. CanvasWidget JS path-replays already use the same
methods and now record cleanly too.

## Tests

- test/test_svg_path_widget.cpp — 15 cases / 90 assertions covering
  parser correctness (every command, implicit-repeat rule, no-separator
  negative numbers, smooth reflection, arc chaining), default state,
  paint emit order, viewBox scaling, and the fill/stroke toggle path.
- test/test_widget_bridge.cpp — 2 cases / 14 assertions covering the
  full JS bridge surface: createSvgPath, setSvgPath, setSvgViewBox,
  setSvgFill (#hex + 'none'), setSvgStroke, setSvgStrokeWidth.

All 62 widget_bridge tests still pass (292 assertions). All 9
canvas_widget tests still pass after the RecordingCanvas additions.

## Acceptance status (issue #965)

- [x] createSvgPath(id, parentId) registered in widget_bridge.cpp
- [x] setSvgPath / setSvgFill / setSvgStroke / setSvgStrokeWidth /
      setSvgViewBox setters
- [x] Tests cover render of icon path, stroke+fill, color changes
- [ ] Spectr editor.js renders SCULPT glyph + gear icon natively —
      requires Spectr-side web-compat layer to map <svg><path> →
      createSvgPath. Tracked separately on Spectr; framework primitive
      lands here.