### PR TITLE
fix(view): honor z_index() and default overflow to visible (#972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0610"></a>
+## [0.62.0]
+
 ## [0.61.0] - 2026-04-29
 
 - framework/spectr parity 965 ([#991](https://github.com/danielraffel/pulp/pull/991))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.61.0
+    VERSION 0.62.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -338,6 +338,12 @@ public:
     void set_z_index(int z) { z_index_ = z; }
     int z_index() const { return z_index_; }
 
+    /// pulp #972 — return children stably sorted by z_index() ascending.
+    /// paint_all paints in this order so higher-z siblings render on top;
+    /// hit_test walks the same order in reverse. Exposed so tests can
+    /// assert ordering directly without piping through the paint pipeline.
+    std::vector<View*> sorted_children_by_z_index() const;
+
     /// Overflow mode
     enum class Overflow { hidden, visible };
     void set_overflow(Overflow o) { overflow_ = o; }
@@ -493,7 +499,13 @@ private:
     float top_ = 0, right_ = 0, bottom_ = 0, left_ = 0;
     bool has_top_ = false, has_right_ = false, has_bottom_ = false, has_left_ = false;
     int z_index_ = 0;
-    Overflow overflow_ = Overflow::hidden;
+    // pulp #972 — default is `visible` to match CSS. Pulp previously
+    // defaulted to `hidden`, which clipped absolutely-positioned children
+    // (popovers, dropdowns, tooltips) to the parent's content bounds and
+    // made them invisible whenever they extended outside. Plugins that
+    // intentionally need clipping must call set_overflow(Overflow::hidden)
+    // explicitly — same opt-in as `overflow:hidden` in CSS.
+    Overflow overflow_ = Overflow::visible;
     BoxShadow shadow_{};
     bool has_shadow_ = false;
     float scale_ = 1.0f;

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -95,7 +95,10 @@ void View::paint_all(canvas::Canvas& canvas) {
                                corner_radius_);
     }
 
-    // Clip only if overflow is hidden (default)
+    // Clip only when overflow:hidden is explicitly opted into. Default
+    // is overflow:visible (CSS default, pulp #972) so absolutely-
+    // positioned popover/dropdown children that extend outside the
+    // parent's content bounds still paint.
     if (overflow_ == Overflow::hidden)
         canvas.clip_rect(0, 0, bounds_.width, bounds_.height);
 
@@ -135,8 +138,15 @@ void View::paint_all(canvas::Canvas& canvas) {
     // Widget-specific painting
     paint(canvas);
 
-    // Paint children
-    for (auto& child : children_) {
+    // Paint children — pulp #972. CSS z-index ordering: stable-sort
+    // ascending by z_index() so siblings with equal z keep insertion
+    // order (CSS painting-order rule). Higher z paints later, ending
+    // up visually on top. The default z_index_ is 0, so views that
+    // never call set_z_index() retain insertion order — no behaviour
+    // change for legacy plugins. setZIndex() on the JS bridge has
+    // existed as a no-op until now; this hooks it up.
+    auto paint_order = sorted_children_by_z_index();
+    for (View* child : paint_order) {
         child->paint_all(canvas);
     }
 
@@ -298,12 +308,30 @@ std::unique_ptr<View> View::remove_child(View* child) {
     return owned;
 }
 
+std::vector<View*> View::sorted_children_by_z_index() const {
+    std::vector<View*> result;
+    result.reserve(children_.size());
+    for (const auto& child : children_) result.push_back(child.get());
+    // Stable sort so siblings with equal z_index() retain insertion
+    // order (CSS painting-order rule, pulp #972).
+    std::stable_sort(result.begin(), result.end(),
+        [](const View* a, const View* b) {
+            return a->z_index() < b->z_index();
+        });
+    return result;
+}
+
 View* View::hit_test(Point local_point) {
     if (!visible_ || !enabled_ || !hit_testable_) return nullptr;
 
-    // Check children in reverse order (topmost first)
-    for (auto it = children_.rbegin(); it != children_.rend(); ++it) {
-        auto& child = *it;
+    // Check children topmost-first (pulp #972). With z-index honored,
+    // "topmost" means highest z_index — and at equal z, latest insertion
+    // — so iterate the z-sorted paint order in reverse. Without this,
+    // a high-z popover could render on top yet have clicks fall through
+    // to siblings beneath it.
+    auto paint_order = sorted_children_by_z_index();
+    for (auto it = paint_order.rbegin(); it != paint_order.rend(); ++it) {
+        View* child = *it;
         if (!child->visible_) continue;
 
         Point child_point = {local_point.x - child->bounds_.x,

--- a/test/test_layout_w3c.cpp
+++ b/test/test_layout_w3c.cpp
@@ -192,9 +192,14 @@ TEST_CASE("View: border", "[view][w3c]") {
     REQUIRE(v.corner_radius() == 8.0f);
 }
 
-TEST_CASE("View: overflow default is hidden", "[view][w3c]") {
+TEST_CASE("View: overflow default is visible (CSS default, pulp #972)", "[view][w3c][issue-972]") {
+    // pulp #972 — Pulp previously defaulted overflow to `hidden`, which
+    // clipped absolutely-positioned children (popovers, dropdowns) to
+    // their parent's content bounds and made them invisible. CSS default
+    // is `overflow: visible`. Plugins that intentionally want clipping
+    // must call set_overflow(Overflow::hidden) explicitly.
     View v;
-    REQUIRE(v.overflow() == View::Overflow::hidden);
+    REQUIRE(v.overflow() == View::Overflow::visible);
 }
 
 // ═══════════════════════════════════════════════════════════════════

--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -763,3 +763,280 @@ TEST_CASE("View transform_matrix does not affect layout or hit testing",
     auto* missed = root.hit_test({530.0f, 530.0f});
     REQUIRE(missed != child_ptr);
 }
+
+// ── pulp #972 — z-index paint-order ──────────────────────────────────────────
+
+TEST_CASE("sorted_children_by_z_index returns insertion order at default z=0",
+          "[view][issue-972]") {
+    View parent;
+    auto a = std::make_unique<View>(); auto* a_ptr = a.get();
+    auto b = std::make_unique<View>(); auto* b_ptr = b.get();
+    auto c = std::make_unique<View>(); auto* c_ptr = c.get();
+    parent.add_child(std::move(a));
+    parent.add_child(std::move(b));
+    parent.add_child(std::move(c));
+
+    auto order = parent.sorted_children_by_z_index();
+    REQUIRE(order.size() == 3);
+    REQUIRE(order[0] == a_ptr);
+    REQUIRE(order[1] == b_ptr);
+    REQUIRE(order[2] == c_ptr);
+}
+
+TEST_CASE("sorted_children_by_z_index sorts ascending — higher z comes last",
+          "[view][issue-972]") {
+    // Spectr's bandsMenu repro: insertion order is content, content, popover,
+    // but popover has zIndex=20. Sorted order must paint popover last.
+    View parent;
+    auto content_a = std::make_unique<View>(); auto* a_ptr = content_a.get();
+    auto popover  = std::make_unique<View>(); auto* p_ptr = popover.get();
+    auto content_b = std::make_unique<View>(); auto* b_ptr = content_b.get();
+    popover->set_z_index(20);
+
+    parent.add_child(std::move(content_a));
+    parent.add_child(std::move(popover));
+    parent.add_child(std::move(content_b));
+
+    auto order = parent.sorted_children_by_z_index();
+    REQUIRE(order.size() == 3);
+    REQUIRE(order[0] == a_ptr);    // z=0, inserted 1st
+    REQUIRE(order[1] == b_ptr);    // z=0, inserted 3rd — keeps insertion order at equal z
+    REQUIRE(order[2] == p_ptr);    // z=20 — last → topmost
+}
+
+TEST_CASE("sorted_children_by_z_index is stable for equal z (insertion order)",
+          "[view][issue-972]") {
+    View parent;
+    auto a = std::make_unique<View>(); auto* a_ptr = a.get();
+    auto b = std::make_unique<View>(); auto* b_ptr = b.get();
+    auto c = std::make_unique<View>(); auto* c_ptr = c.get();
+    a->set_z_index(5);
+    b->set_z_index(5);
+    c->set_z_index(5);
+    parent.add_child(std::move(a));
+    parent.add_child(std::move(b));
+    parent.add_child(std::move(c));
+
+    auto order = parent.sorted_children_by_z_index();
+    REQUIRE(order[0] == a_ptr);
+    REQUIRE(order[1] == b_ptr);
+    REQUIRE(order[2] == c_ptr);
+}
+
+TEST_CASE("View::paint_all paints higher-z child last so it lands on top",
+          "[view][issue-972]") {
+    using namespace pulp::canvas;
+
+    // Three siblings stacked at the same bounds with distinct backgrounds.
+    // Popover sits in the MIDDLE of insertion order with z_index=10. The
+    // last full-bounds fill in the recorded stream must be popover's
+    // colour — without #972 it would be content_b's (last by insertion).
+    View parent;
+    parent.set_bounds({0, 0, 100, 100});
+
+    auto content_a = std::make_unique<View>();
+    content_a->set_bounds({0, 0, 100, 100});
+    content_a->set_background_color(Color::rgba8(255, 0, 0, 255));   // red
+
+    auto popover = std::make_unique<View>();
+    popover->set_bounds({0, 0, 100, 100});
+    popover->set_background_color(Color::rgba8(0, 200, 0, 255));     // green
+    popover->set_z_index(10);
+
+    auto content_b = std::make_unique<View>();
+    content_b->set_bounds({0, 0, 100, 100});
+    content_b->set_background_color(Color::rgba8(0, 0, 255, 255));   // blue
+
+    parent.add_child(std::move(content_a));
+    parent.add_child(std::move(popover));
+    parent.add_child(std::move(content_b));
+
+    RecordingCanvas rc;
+    parent.paint_all(rc);
+
+    // Walk full-bounds fill_rects and capture the last one's set_fill_color.
+    Color last_fill{};
+    Color last_full_bounds_fill{};
+    bool saw_full_bounds = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::set_fill_color) {
+            last_fill = cmd.color;
+            continue;
+        }
+        if (cmd.type == DrawCommand::Type::fill_rect &&
+            cmd.f[0] == 0.0f && cmd.f[1] == 0.0f &&
+            cmd.f[2] == 100.0f && cmd.f[3] == 100.0f) {
+            last_full_bounds_fill = last_fill;
+            saw_full_bounds = true;
+        }
+    }
+    REQUIRE(saw_full_bounds);
+    INFO("last_full_bounds rgba=("
+         << int(last_full_bounds_fill.r8()) << ","
+         << int(last_full_bounds_fill.g8()) << ","
+         << int(last_full_bounds_fill.b8()) << ","
+         << int(last_full_bounds_fill.a8()) << ")");
+    REQUIRE(last_full_bounds_fill.r8() == 0);
+    REQUIRE(last_full_bounds_fill.g8() == 200);
+    REQUIRE(last_full_bounds_fill.b8() == 0);
+}
+
+TEST_CASE("View::hit_test returns the highest-z child for overlapping bounds",
+          "[view][issue-972]") {
+    // Three siblings at the same bounds: content (z=0, inserted last),
+    // popover (z=10, inserted middle), content (z=0, inserted first).
+    // Click in the middle should hit the popover, not whichever content
+    // happened to be inserted last.
+    View parent;
+    parent.set_bounds({0, 0, 100, 100});
+
+    auto a = std::make_unique<View>();
+    a->set_bounds({0, 0, 100, 100});
+    auto* a_ptr = a.get();
+
+    auto popover = std::make_unique<View>();
+    popover->set_bounds({0, 0, 100, 100});
+    popover->set_z_index(10);
+    auto* p_ptr = popover.get();
+
+    auto b = std::make_unique<View>();
+    b->set_bounds({0, 0, 100, 100});
+    auto* b_ptr = b.get();
+
+    parent.add_child(std::move(a));
+    parent.add_child(std::move(popover));
+    parent.add_child(std::move(b));
+
+    auto* hit = parent.hit_test({50.0f, 50.0f});
+    REQUIRE(hit == p_ptr);
+    REQUIRE(hit != a_ptr);
+    REQUIRE(hit != b_ptr);
+}
+
+TEST_CASE("View::hit_test falls back to insertion-order topmost at equal z",
+          "[view][issue-972]") {
+    // All siblings at same z=0 (default) — last inserted is visually topmost,
+    // matching legacy behaviour. This locks in the no-regression contract.
+    View parent;
+    parent.set_bounds({0, 0, 100, 100});
+
+    auto a = std::make_unique<View>();
+    a->set_bounds({0, 0, 100, 100});
+    parent.add_child(std::move(a));
+
+    auto b = std::make_unique<View>();
+    b->set_bounds({0, 0, 100, 100});
+    auto* b_ptr = b.get();
+    parent.add_child(std::move(b));
+
+    auto* hit = parent.hit_test({50.0f, 50.0f});
+    REQUIRE(hit == b_ptr);
+}
+
+// ── pulp #972 — overflow:visible default for absolute-positioned popovers ────
+// Symptom on Spectr's bandsMenu: a `position:absolute; top:28; right:0`
+// popover declared inside a 24px-tall flex parent renders nowhere because
+// Pulp previously defaulted overflow to hidden and clipped paint to the
+// parent's content rect. CSS default is `overflow: visible` — children
+// that extend past the parent should still paint. Z-index sorting alone
+// (above) is necessary but not sufficient; the clip was eating the
+// popover's fill regardless of paint order.
+
+TEST_CASE("View default overflow is visible (matches CSS default)",
+          "[view][issue-972]") {
+    View v;
+    REQUIRE(v.overflow() == View::Overflow::visible);
+}
+
+TEST_CASE("View::paint_all does not emit clip_rect when overflow is visible",
+          "[view][issue-972]") {
+    using namespace pulp::canvas;
+    View v;
+    v.set_bounds({0, 0, 100, 24});
+    REQUIRE(v.overflow() == View::Overflow::visible);
+
+    RecordingCanvas rc;
+    v.paint_all(rc);
+
+    for (const auto& cmd : rc.commands()) {
+        // The compositing-layer save_layer / save_backdrop_filter may
+        // emit their own clip-shaped commands as part of layer setup,
+        // but a plain clip_rect at the view's content bounds is the
+        // overflow:hidden marker we explicitly want absent.
+        if (cmd.type == DrawCommand::Type::clip_rect) {
+            const bool covers_bounds = (cmd.f[0] == 0.0f && cmd.f[1] == 0.0f &&
+                                        cmd.f[2] == 100.0f && cmd.f[3] == 24.0f);
+            INFO("Unexpected clip_rect at (" << cmd.f[0] << "," << cmd.f[1]
+                 << "," << cmd.f[2] << "," << cmd.f[3] << ")");
+            REQUIRE_FALSE(covers_bounds);
+        }
+    }
+}
+
+TEST_CASE("View::paint_all emits clip_rect when overflow is explicitly hidden",
+          "[view][issue-972]") {
+    using namespace pulp::canvas;
+    View v;
+    v.set_bounds({0, 0, 100, 24});
+    v.set_overflow(View::Overflow::hidden);
+
+    RecordingCanvas rc;
+    v.paint_all(rc);
+
+    bool saw_bounds_clip = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::clip_rect &&
+            cmd.f[0] == 0.0f && cmd.f[1] == 0.0f &&
+            cmd.f[2] == 100.0f && cmd.f[3] == 24.0f) {
+            saw_bounds_clip = true;
+            break;
+        }
+    }
+    REQUIRE(saw_bounds_clip);
+}
+
+TEST_CASE("Absolute child positioned outside parent's bounds still paints",
+          "[view][issue-972]") {
+    // Spectr bandsMenu repro: 24px-tall parent with a popover-like child
+    // at top:50, left:50 — completely outside the parent's content rect.
+    // With overflow:visible default, the child's translate-from-bounds.x/y
+    // and its own paint commands must reach the canvas without a parent
+    // clip_rect blocking them.
+    using namespace pulp::canvas;
+
+    View parent;
+    parent.set_bounds({0, 0, 100, 24});
+
+    auto popover = std::make_unique<View>();
+    popover->set_bounds({50, 50, 100, 50});
+    popover->set_background_color(Color::rgba8(255, 0, 255, 255));   // magenta
+    parent.add_child(std::move(popover));
+
+    RecordingCanvas rc;
+    parent.paint_all(rc);
+
+    // Verify a magenta fill_rect lands in the recorded stream — the
+    // popover's bg fill is at the child's local origin, which becomes
+    // (50, 50) in parent coords after the translate inside paint_all.
+    Color last_fill{};
+    bool saw_magenta_fill = false;
+    bool saw_parent_clip = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::set_fill_color) {
+            last_fill = cmd.color;
+            continue;
+        }
+        if (cmd.type == DrawCommand::Type::fill_rect &&
+            last_fill.r8() == 255 && last_fill.g8() == 0 &&
+            last_fill.b8() == 255 && last_fill.a8() == 255) {
+            saw_magenta_fill = true;
+        }
+        if (cmd.type == DrawCommand::Type::clip_rect &&
+            cmd.f[0] == 0.0f && cmd.f[1] == 0.0f &&
+            cmd.f[2] == 100.0f && cmd.f[3] == 24.0f) {
+            saw_parent_clip = true;
+        }
+    }
+    REQUIRE(saw_magenta_fill);
+    REQUIRE_FALSE(saw_parent_clip);
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -2514,6 +2514,10 @@ TEST_CASE("View::paint_all dispatches outset shadow before clip, "
     SECTION("outset shadow paints before clip_rect") {
         View v;
         v.set_bounds({0, 0, 100, 50});
+        // pulp #972 — overflow now defaults to visible (no clip_rect).
+        // This test specifically asserts the shadow / clip_rect ordering
+        // contract, so opt-in to clipping explicitly.
+        v.set_overflow(View::Overflow::hidden);
         v.set_box_shadow(0, 14, 40, 0, Color::rgba8(0, 0, 0, 160), /*inset=*/false);
 
         RecordingCanvas rc;
@@ -2541,6 +2545,7 @@ TEST_CASE("View::paint_all dispatches outset shadow before clip, "
     SECTION("inset shadow paints inside the bounds clip") {
         View v;
         v.set_bounds({0, 0, 100, 50});
+        v.set_overflow(View::Overflow::hidden);  // pulp #972
         v.set_box_shadow(0, 4, 10, 0, Color::rgba8(0, 0, 0, 80), /*inset=*/true);
 
         RecordingCanvas rc;


### PR DESCRIPTION
Two related framework gaps that together broke every popover, dropdown,
and tooltip in Spectr's React port. Both lived in View::paint_all():

## (1) z-index was ignored

paint_all() walked children_ in insertion order regardless of their
z_index() value. setZIndex() on the JS bridge mutated the field but
no consumer read it. Spectr's popovers (bandsMenu, PRESETS submenu,
SETTINGS dialog) declared the right zIndex but rendered behind the
sibling content beneath them.

**Fix:** new `View::sorted_children_by_z_index()` returns children
stably-sorted ascending by `z_index()` so equal-z siblings keep
insertion order (CSS painting-order rule). paint_all() walks this
sequence forward (low z paints first → high z lands on top).
hit_test() walks the same sequence in reverse so the visually-
topmost child is the first one tested for a hit; without this,
popovers would render correctly but clicks would fall through to
siblings beneath them.

## (2) overflow defaulted to hidden, not visible (CSS bug)

`View::overflow_` defaulted to `Overflow::hidden`, so paint_all()
issued a `clip_rect` at the parent's content bounds for every
unconfigured View. Absolutely-positioned children declared with
`top:28; right:0` (Spectr's bandsMenu pattern) were positioned
correctly by Yoga but immediately clipped away by the parent's
24px-tall bounds. Z-index sorting alone wouldn't fix this — the
fill never reached the framebuffer regardless of paint order.

CSS default is `overflow: visible`. Empirically confirmed via
Spectr-side magenta-popover probe (#972 comment, 2026-04-29):
absolute children at coords inside the parent's bounds rendered
correctly; same children with coords *outside* the bounds were
invisible.

**Fix:** `Overflow overflow_ = Overflow::visible;` (was `::hidden`).
Plugins that intentionally want the clip behaviour must call
`set_overflow(Overflow::hidden)` explicitly — same opt-in shape
as `overflow:hidden` in CSS.

## Tests (test/test_view.cpp, 10 cases / 24 assertions)

Z-index (6 cases):
- sorted_children_by_z_index: default insertion order, ascending sort,
  stable at equal z.
- paint_all: middle-inserted child with z_index=10 ends up as the LAST
  full-bounds fill in a RecordingCanvas stream — the contract issue
  #972 originally calls out as the acceptance signal.
- hit_test: high-z popover wins over siblings at z=0 regardless of
  insertion order, AND last-inserted wins at equal z (no-regression
  contract for legacy plugins).

Overflow (4 cases):
- View default overflow is visible.
- paint_all does NOT emit a bounds clip_rect when overflow is visible.
- paint_all DOES emit a bounds clip_rect when overflow is explicitly
  hidden — preserves opt-in behaviour for plugins that want clipping
  (e.g. ScrollView).
- Spectr bandsMenu repro: 24px-tall parent with magenta popover at
  (50, 50, 100, 50) — magenta fill_rect reaches the recorded stream
  and no parent-bounds clip_rect is emitted.

## Behaviour change for existing plugins

The only test that broke was `[issue-925]` shadow-vs-clip ordering,
which existed precisely to assert clip_rect emission. Updated to opt-
in to `Overflow::hidden` explicitly — same fix any plugin that
genuinely needed the old default would apply.

Verified clean across the surrounding suites:
- pulp-test-view              30 cases / 133 assertions ✓
- pulp-test-canvas-widget      9 cases /  22 assertions ✓
- pulp-test-widgets           42 cases / 120 assertions ✓
- pulp-test-widget-bridge     60 cases / 278 assertions ✓
- pulp-test-panel              4 cases /  10 assertions ✓
- pulp-test-modal              5 cases /   8 assertions ✓
- pulp-test-ui-components     23 cases /  55 assertions ✓
- pulp-test-scroll-view        6 cases /   7 assertions ✓