### PR TITLE
fix(cli): reject partial run frame counts

### DIFF
--- a/test/test_cli_run_options.cpp
+++ b/test/test_cli_run_options.cpp
@@ -100,12 +100,19 @@ TEST_CASE("pulp run --frames sets the frame count and forwards it",
 }
 
 TEST_CASE("pulp run --frames rejects non-positive and non-integer values",
-          "[cli][run][issue-914]") {
+          "[cli][run][issue-914][issue-643]") {
     REQUIRE_FALSE(parse_run_options({"--frames", "0"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames", "-2"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames", "abc"}).error.empty());
+    REQUIRE_FALSE(parse_run_options({"--frames", "12x"}).error.empty());
+    REQUIRE_FALSE(parse_run_options({"--frames", "12.5"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames=zero"}).error.empty());
+    REQUIRE_FALSE(parse_run_options({"--frames=12x"}).error.empty());
+    REQUIRE_FALSE(parse_run_options({"--frames=12.5"}).error.empty());
+
+    auto partial = parse_run_options({"--frames=12x"});
+    REQUIRE(partial.frames == 1);
 }
 
 TEST_CASE("pulp run --watch is recorded and composes with --headless",

--- a/tools/cli/cmd_run_parse.cpp
+++ b/tools/cli/cmd_run_parse.cpp
@@ -6,10 +6,26 @@
 
 #include "cmd_run.hpp"
 
-#include <stdexcept>
+#include <charconv>
 #include <string>
+#include <system_error>
 
 namespace pulp_cli {
+
+namespace {
+
+bool parse_frame_count(const std::string& value, int& frames) {
+    if (value.empty()) return false;
+    int parsed = 0;
+    const char* first = value.data();
+    const char* last = first + value.size();
+    auto result = std::from_chars(first, last, parsed);
+    if (result.ec != std::errc{} || result.ptr != last) return false;
+    frames = parsed;
+    return true;
+}
+
+}  // namespace
 
 ParseRunResult parse_run_options(const std::vector<std::string>& args) {
     ParseRunResult r;
@@ -58,30 +74,28 @@ ParseRunResult parse_run_options(const std::vector<std::string>& args) {
         }
         if (a == "--frames") {
             if (i + 1 < args.size()) {
-                try {
-                    int n = std::stoi(args[i + 1]);
-                    if (n <= 0) { r.error = "--frames must be > 0"; return r; }
-                    r.frames = n;
-                    ++i;
-                    continue;
-                } catch (...) {
+                int n = 0;
+                if (!parse_frame_count(args[i + 1], n)) {
                     r.error = "--frames requires an integer argument";
                     return r;
                 }
+                if (n <= 0) { r.error = "--frames must be > 0"; return r; }
+                r.frames = n;
+                ++i;
+                continue;
             }
             r.error = "--frames requires an integer argument";
             return r;
         }
         if (a.rfind("--frames=", 0) == 0) {
-            try {
-                int n = std::stoi(a.substr(std::string("--frames=").size()));
-                if (n <= 0) { r.error = "--frames must be > 0"; return r; }
-                r.frames = n;
-                continue;
-            } catch (...) {
+            int n = 0;
+            if (!parse_frame_count(a.substr(std::string("--frames=").size()), n)) {
                 r.error = "--frames= requires an integer";
                 return r;
             }
+            if (n <= 0) { r.error = "--frames must be > 0"; return r; }
+            r.frames = n;
+            continue;
         }
         if (a == "--watch") {
             r.watch = true;


### PR DESCRIPTION
Parent: #643
Umbrella: #641

## Scope
- Fixes `pulp run --frames` parsing so partial numeric tokens such as `12x` or `12.5` are rejected instead of accepting the numeric prefix from `std::stoi`.
- Adds focused parser coverage for both `--frames 12x` and `--frames=12x` forms.
- Updates only `tools/cli/cmd_run_parse.cpp` and `test/test_cli_run_options.cpp`.

## Validation
- `cmake --build build --target pulp-test-cli-run-options -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-cli-run-options` (74 assertions / 13 cases)
- `ctest --test-dir build -R "pulp run" --output-on-failure` (16/16 passed)
- `./build/test/pulp-test-cli-run-options "[cli][run][issue-643]"` (10 assertions / 1 case)
- `git diff --check`
- `PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`

## CI
Opened through `shipyard pr` with local mac/ubuntu/windows targets deliberately skipped per the Namespace-first workflow; PR-triggered Namespace/GitHub checks are the merge evidence.