### PR TITLE
fix(view): validate _dragTarget against live tree before deref (#992)

### DIFF
--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -282,6 +282,23 @@ static pulp::view::Point toLocal(pulp::view::Point pos, pulp::view::View* target
     return local;
 }
 
+// pulp #992 — confirm a cached View* is still attached to the live tree
+// before any dereference. Walks `root` and compares pointers only, so it's
+// safe to call with `needle` pointing into freed memory. Returns false if
+// `needle` was unparented or destroyed between the cached capture (e.g. at
+// mouseDown) and the next event (e.g. mouseUp). Does NOT detect the ABA
+// case where memory was freed and reused at the same address — see #992
+// follow-up issue if profiling shows that's hit; for now a tree walk
+// catches the React-unmount-during-click pattern that actually crashes.
+static bool view_is_in_tree(pulp::view::View* needle, pulp::view::View* root) {
+    if (!needle || !root) return false;
+    if (needle == root) return true;
+    for (size_t i = 0; i < root->child_count(); ++i) {
+        if (view_is_in_tree(needle, root->child_at(i))) return true;
+    }
+    return false;
+}
+
 static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
     using KC = pulp::view::KeyCode;
     switch (code) {
@@ -398,7 +415,16 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
 - (void)mouseDragged:(NSEvent*)event {
     @try {
         try {
+            // pulp #992 — _dragTarget is captured in mouseDown but the View
+            // it points to may be unmounted (and freed) before the next
+            // drag event arrives, e.g. when a click triggers a React state
+            // change that destroys the widget. Re-validate against the
+            // live tree before any deref.
             if (!_dragTarget || !self.rootView) return;
+            if (!view_is_in_tree(_dragTarget, self.rootView)) {
+                _dragTarget = nullptr;
+                return;
+            }
             auto pt = [self localPoint:event];
             auto local = toLocal(pt, _dragTarget, self.rootView);
             _dragTarget->on_mouse_drag(local);
@@ -420,6 +446,19 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
     @try {
         try {
             if (_dragTarget) {
+                // pulp #992 — _dragTarget may point at a freed View if
+                // the mouseDown handler triggered a React unmount of the
+                // clicked widget (every dropdown selection in Spectr does
+                // this — clicking a band-count item flushes the React
+                // tree and the popover Views are dropped before mouseUp
+                // ever arrives). Drop the up event silently if the
+                // captured pointer is no longer in the live tree, rather
+                // than dereference garbage memory and SIGSEGV.
+                if (!view_is_in_tree(_dragTarget, self.rootView)) {
+                    _dragTarget = nullptr;
+                    [self setNeedsDisplay:YES];
+                    return;
+                }
                 auto pt = [self localPoint:event];
                 auto local = toLocal(pt, _dragTarget, self.rootView);
                 auto released_target = self.rootView ? self.rootView->hit_test(pt) : nullptr;

--- a/test/test_view_host_bridge_mac.mm
+++ b/test/test_view_host_bridge_mac.mm
@@ -65,4 +65,93 @@ TEST_CASE("macOS WindowHost reports content size and fires resize callbacks",
     }
 }
 
+// pulp #992 — `-[PulpView mouseUp:]` SIGSEGV regression test.
+//
+// Repro: a click on a child View triggers a state change (in real apps,
+// React unmounts the clicked widget on its own click handler), so by the
+// time `mouseUp` fires the captured `_dragTarget` is a freed pointer.
+// Without the fix in `view_is_in_tree`, the next deref crashes the app.
+//
+// We stage this directly on the macOS host: post a real `NSLeftMouseDown`
+// to the PulpView's window, remove the child during the down handler,
+// then post `NSLeftMouseUp` and verify the up event drops cleanly with
+// no exception. The `view_is_in_tree` check must catch the unmount
+// before any field of `_dragTarget` is touched.
+TEST_CASE("PulpView mouseUp survives mouseDown handler that unmounts the target",
+          "[view][hosts][issue-992]") {
+    @autoreleasepool {
+        [NSApplication sharedApplication];
+
+        View root;
+        WindowOptions opts;
+        opts.title = "PulpView issue-992";
+        opts.width = 200.0f;
+        opts.height = 100.0f;
+        opts.resizable = false;
+        opts.use_gpu = false;
+
+        auto host = WindowHost::create(root, opts);
+        REQUIRE(host != nullptr);
+
+        auto child = std::make_unique<View>();
+        child->set_bounds({0, 0, 200, 100});
+        auto* child_ptr = child.get();
+        root.add_child(std::move(child));
+
+        host->show();
+        auto* nswindow = (__bridge NSWindow*)host->native_window_handle();
+        REQUIRE(nswindow != nil);
+        auto* contentView = nswindow.contentView;
+        REQUIRE(contentView != nil);
+
+        // Pump the run loop so the window finishes coming up.
+        for (int i = 0; i < 20; ++i) {
+            [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.005]];
+        }
+
+        const NSPoint local = NSMakePoint(40.0, 50.0);   // arbitrary, inside child
+        const NSPoint window_pt = [contentView convertPoint:local toView:nil];
+
+        NSEvent* down = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                                           location:window_pt
+                                      modifierFlags:0
+                                          timestamp:0
+                                       windowNumber:nswindow.windowNumber
+                                            context:nil
+                                        eventNumber:0
+                                         clickCount:1
+                                           pressure:1.0];
+        NSEvent* up = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp
+                                         location:window_pt
+                                    modifierFlags:0
+                                        timestamp:0
+                                     windowNumber:nswindow.windowNumber
+                                          context:nil
+                                      eventNumber:0
+                                       clickCount:1
+                                         pressure:0.0];
+
+        // Dispatch directly to the view — bypasses the AppKit responder
+        // chain so the test stays deterministic on a headless CI runner.
+        REQUIRE_NOTHROW([contentView mouseDown:down]);
+
+        // Mirror the real-world race: between mouseDown and mouseUp, the
+        // app's React-style state machine unmounts and frees the clicked
+        // child. After this, PulpView's private `_dragTarget` ivar points
+        // at freed memory.
+        auto removed = root.remove_child(child_ptr);
+        REQUIRE(removed != nullptr);
+        removed.reset();   // free the heap object so any later deref by
+                           // PulpView is a true use-after-free.
+
+        // Without the fix this call SIGSEGVs deterministically (loads
+        // `_dragTarget->on_click` from freed memory). With the fix the
+        // `view_is_in_tree` check rejects the dangling pointer and the
+        // up event drops cleanly.
+        REQUIRE_NOTHROW([contentView mouseUp:up]);
+
+        host->hide();
+    }
+}
+
 #endif


### PR DESCRIPTION
Every click on Spectr's editor surface SIGSEGV'd at
`-[PulpView mouseUp:] + 428`. The captured `_dragTarget` set at
mouseDown time is a raw `pulp::view::View*` — if anything between
mouseDown and mouseUp removes the View from the tree (React state
change unmounting the clicked widget; popover that closes itself on
selection; modal that flushes its tree on Cancel), `_dragTarget` is
left pointing at freed memory and mouseUp's `_dragTarget->on_click`
deref crashes.

This is reproducible by every real CGEvent. It was masked until now
because earlier validation runs used `osascript "tell process X to
click"` — those go through Accessibility, and Dawn-backed surfaces
have no AX peer, so the events were silently dropped before reaching
PulpView. Switching to `cliclick` (HID-layer CGEvent) made every
click crash deterministically — same path real users trigger.

## Fix

New `view_is_in_tree(needle, root)` helper walks the live tree and
compares pointers only, never dereferencing `needle`. mouseUp and
mouseDragged each call it before any field access on `_dragTarget`;
if the captured pointer is no longer in the live tree, the event is
dropped silently and `_dragTarget` is reset.

This catches the React-unmount-during-click pattern that actually
crashes. It does NOT detect ABA — pointer freed and reused at the
same address. ABA needs a generation counter or a host-level
`std::set<View*>` of live views; that's a follow-up if profiling
shows it. The pointer-only walk is safe to call with `needle`
already pointing into freed memory because we only dereference
`root` (the live root view) and its child pointers.

## Test (test/test_view_host_bridge_mac.mm, [issue-992])

Spawns a real macOS WindowHost, dispatches a real `NSLeftMouseDown`
to the PulpView, then removes-and-frees the clicked child in
between, then dispatches `NSLeftMouseUp`. Without the fix this
crashes the test process; with the fix the up event drops cleanly.
The same harness shape can later assert mouseDragged behaviour.

Full pulp-test-view-host-bridge suite green (3 cases / 21
assertions).