### PR TITLE
feat(view): CSS-style typography inheritance for Label (pulp #969)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0620"></a>
+## [0.63.0]
+
 ## [0.62.0] - 2026-04-29
 
 - fix(view): honor z_index() and default overflow to visible (#972) ([#996](https://github.com/danielraffel/pulp/pull/996))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.62.0
+    VERSION 0.63.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -6,6 +6,7 @@
 #include <pulp/view/theme.hpp>
 #include <pulp/canvas/canvas.hpp>
 #include <pulp/canvas/view_effect.hpp>
+#include <optional>
 #include <vector>
 #include <memory>
 #include <string>
@@ -67,6 +68,46 @@ public:
 
     // Resolve a color: check own theme first, then walk up to parent
     Color resolve_color(const std::string& name, Color fallback = {}) const;
+
+    // ── CSS-style typography inheritance (issue-969) ─────────────────────
+    //
+    // Mirrors CSS: setting `color: white` on a parent View cascades down
+    // to every text descendant unless overridden. These fields are stored
+    // on the View but DO NOT affect the View's own paint — they're picked
+    // up by Label::paint() (and other text widgets) when the widget has
+    // no explicit value of its own.
+    //
+    // The cascade order at paint time is:
+    //   1. Widget's own explicit value (e.g. Label::set_font_size on this Label)
+    //   2. inheritable_*() — walks up the parent chain returning the first
+    //      ancestor that set the matching field
+    //   3. Theme token / widget default fallback (existing behavior)
+    //
+    // text_align uses int rather than LabelAlign to keep View free of a
+    // back-include of widgets.hpp; the int matches LabelAlign's enum
+    // order: 0 = left, 1 = center, 2 = right.
+
+    void set_inheritable_text_color(Color c) { inh_text_color_ = c; }
+    void clear_inheritable_text_color() { inh_text_color_.reset(); }
+    /// Walks own value, then parent chain. nullopt if no ancestor set it.
+    std::optional<Color> inheritable_text_color() const;
+
+    void set_inheritable_font_size(float size) { inh_font_size_ = size; }
+    void clear_inheritable_font_size() { inh_font_size_.reset(); }
+    std::optional<float> inheritable_font_size() const;
+
+    void set_inheritable_letter_spacing(float sp) { inh_letter_spacing_ = sp; }
+    void clear_inheritable_letter_spacing() { inh_letter_spacing_.reset(); }
+    std::optional<float> inheritable_letter_spacing() const;
+
+    void set_inheritable_font_weight(int w) { inh_font_weight_ = w; }
+    void clear_inheritable_font_weight() { inh_font_weight_.reset(); }
+    std::optional<int> inheritable_font_weight() const;
+
+    /// 0 = left, 1 = center, 2 = right (matches LabelAlign).
+    void set_inheritable_text_align(int a) { inh_text_align_ = a; }
+    void clear_inheritable_text_align() { inh_text_align_.reset(); }
+    std::optional<int> inheritable_text_align() const;
 
     // ── Visibility ───────────────────────────────────────────────────────
 
@@ -535,6 +576,16 @@ private:
 
     // Pointer capture: pointer_id → this view receives all events for that pointer
     std::vector<int> captured_pointers_;
+
+    // CSS-style typography inheritance (issue-969). Unset by default; only
+    // populated when the bridge / app calls a set_inheritable_* setter.
+    // These do not affect the View's own paint — only descendant Labels
+    // (and other text widgets) consult them.
+    std::optional<Color> inh_text_color_;
+    std::optional<float> inh_font_size_;
+    std::optional<float> inh_letter_spacing_;
+    std::optional<int>   inh_font_weight_;
+    std::optional<int>   inh_text_align_;
 };
 
 } // namespace pulp::view

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -32,28 +32,41 @@ public:
     void set_text(std::string text) { text_ = std::move(text); }
     const std::string& text() const { return text_; }
 
-    void set_font_size(float size) { font_size_ = size; }
+    // issue-969: each setter marks the corresponding has_own_* flag so
+    // paint() can distinguish "default value" from "explicitly set" and
+    // fall through to inheritable_*() for unset properties.
+    void set_font_size(float size) { font_size_ = size; has_own_font_size_ = true; }
     float font_size() const { return font_size_; }
+    bool has_own_font_size() const { return has_own_font_size_; }
 
     /// CSS font-family string (e.g. "Inter", "JetBrains Mono"). Empty means
     /// the widget falls back to the default theme family ("Inter").
     void set_font_family(std::string family) { font_family_ = std::move(family); }
     const std::string& font_family() const { return font_family_; }
 
-    void set_font_weight(int weight) { font_weight_ = weight; }  // 100-900, 400=normal, 700=bold
+    void set_font_weight(int weight) { font_weight_ = weight; has_own_font_weight_ = true; }  // 100-900, 400=normal, 700=bold
     int font_weight() const { return font_weight_; }
+    bool has_own_font_weight() const { return has_own_font_weight_; }
 
     void set_font_style(int style) { font_style_ = style; }  // 0=normal, 1=italic
     int font_style() const { return font_style_; }
 
-    void set_letter_spacing(float sp) { letter_spacing_ = sp; }
+    void set_letter_spacing(float sp) { letter_spacing_ = sp; has_own_letter_spacing_ = true; }
     float letter_spacing() const { return letter_spacing_; }
+    bool has_own_letter_spacing() const { return has_own_letter_spacing_; }
 
     void set_line_height(float lh) { line_height_ = lh; }
     float line_height() const { return line_height_; }
 
-    void set_text_align(LabelAlign align) { text_align_ = align; }
+    void set_text_align(LabelAlign align) { text_align_ = align; has_own_text_align_ = true; }
     LabelAlign text_align() const { return text_align_; }
+    bool has_own_text_align() const { return has_own_text_align_; }
+
+    // issue-969: explicit text color override on the Label itself. When
+    // set, overrides any inherited typography color and the theme token.
+    void set_text_color(canvas::Color c) { text_color_ = c; has_own_text_color_ = true; }
+    bool has_own_text_color() const { return has_own_text_color_; }
+    canvas::Color text_color() const { return text_color_; }
 
     void set_multi_line(bool ml) { multi_line_ = ml; }
     bool multi_line() const { return multi_line_; }
@@ -80,9 +93,9 @@ public:
     float intrinsic_width() const override;
 
     /// Intrinsic height based on font size and line height.
-    float intrinsic_height() const override {
-        return line_height_ > 0 ? line_height_ : font_size_ * 1.4f;
-    }
+    /// issue-969: walks the inheritance cascade so an unset font_size
+    /// picks up an ancestor View's setInheritableFontSize value.
+    float intrinsic_height() const override;
 
 private:
     std::string text_;
@@ -100,6 +113,15 @@ private:
     bool has_decoration_color_ = false;
     canvas::TextDirection text_direction_ = canvas::TextDirection::left_to_right;
     canvas::TextVerticalAlign vertical_align_ = canvas::TextVerticalAlign::top;
+    // issue-969: explicit-vs-inherited tracking. Fields keep their default
+    // values until a setter is called; the has_own_* flag tells paint()
+    // whether to honor the field or fall through to View::inheritable_*().
+    canvas::Color text_color_{};
+    bool has_own_text_color_ = false;
+    bool has_own_font_size_ = false;
+    bool has_own_font_weight_ = false;
+    bool has_own_letter_spacing_ = false;
+    bool has_own_text_align_ = false;
 
 public:
     /// Set text direction (LTR, RTL, vertical top-to-bottom, vertical bottom-to-top).

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -416,6 +416,42 @@ float View::resolve_dimension(const std::string& name, float fallback) const {
     return fallback;
 }
 
+// ── CSS-style typography inheritance (issue-969) ────────────────────────
+//
+// Each inheritable_*() walks the chain own → parent → … → root, returning
+// the first ancestor that has a value. nullopt means no one in the chain
+// set the field, so the caller falls back to the theme/widget default.
+
+std::optional<Color> View::inheritable_text_color() const {
+    if (inh_text_color_.has_value()) return inh_text_color_;
+    if (parent_) return parent_->inheritable_text_color();
+    return std::nullopt;
+}
+
+std::optional<float> View::inheritable_font_size() const {
+    if (inh_font_size_.has_value()) return inh_font_size_;
+    if (parent_) return parent_->inheritable_font_size();
+    return std::nullopt;
+}
+
+std::optional<float> View::inheritable_letter_spacing() const {
+    if (inh_letter_spacing_.has_value()) return inh_letter_spacing_;
+    if (parent_) return parent_->inheritable_letter_spacing();
+    return std::nullopt;
+}
+
+std::optional<int> View::inheritable_font_weight() const {
+    if (inh_font_weight_.has_value()) return inh_font_weight_;
+    if (parent_) return parent_->inheritable_font_weight();
+    return std::nullopt;
+}
+
+std::optional<int> View::inheritable_text_align() const {
+    if (inh_text_align_.has_value()) return inh_text_align_;
+    if (parent_) return parent_->inheritable_text_align();
+    return std::nullopt;
+}
+
 // ── Pointer capture ─────────────────────────────────────────────────────
 
 void View::set_pointer_capture(int pointer_id) {

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1841,10 +1841,17 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
+    // issue-969: typography setters cascade. Label gets its own value;
+    // any other View (Panel, Box, container) stores the value on the
+    // View's inheritable_* slot so descendant Labels pick it up. Don't
+    // silently no-op on container Views — that was the dom-adapter
+    // workaround we're replacing.
     engine_.register_function("setFontWeight", [this](choc::javascript::ArgumentList args) {
         auto* v = widget(args.get<std::string>(0, ""));
         int w = static_cast<int>(args.get<double>(1, 400));
+        if (!v) return choc::value::Value();
         if (auto* l = dynamic_cast<Label*>(v)) l->set_font_weight(w);
+        else v->set_inheritable_font_weight(w);
         return choc::value::Value();
     });
 
@@ -1858,7 +1865,9 @@ void WidgetBridge::register_api() {
     engine_.register_function("setLetterSpacing", [this](choc::javascript::ArgumentList args) {
         auto* v = widget(args.get<std::string>(0, ""));
         auto sp = static_cast<float>(args.get<double>(1, 0));
+        if (!v) return choc::value::Value();
         if (auto* l = dynamic_cast<Label*>(v)) l->set_letter_spacing(sp);
+        else v->set_inheritable_letter_spacing(sp);
         return choc::value::Value();
     });
 
@@ -1872,10 +1881,17 @@ void WidgetBridge::register_api() {
     engine_.register_function("setTextAlign", [this](choc::javascript::ArgumentList args) {
         auto* v = widget(args.get<std::string>(0, ""));
         auto a = args.get<std::string>(1, "left");
+        if (!v) return choc::value::Value();
+        // Map "left"/"center"/"right" → 0/1/2 (matches LabelAlign enum order).
+        int aligned = (a == "center") ? 1 : (a == "right") ? 2 : 0;
         if (auto* l = dynamic_cast<Label*>(v)) {
-            if (a == "center") l->set_text_align(LabelAlign::center);
-            else if (a == "right") l->set_text_align(LabelAlign::right);
+            if (aligned == 1) l->set_text_align(LabelAlign::center);
+            else if (aligned == 2) l->set_text_align(LabelAlign::right);
             else l->set_text_align(LabelAlign::left);
+        } else {
+            // issue-969: container Views store the alignment in the
+            // inheritable slot for descendant Labels.
+            v->set_inheritable_text_align(aligned);
         }
         return choc::value::Value();
     });
@@ -1889,10 +1905,19 @@ void WidgetBridge::register_api() {
     });
 
     engine_.register_function("setFontSize", [this](choc::javascript::ArgumentList args) {
-        if (auto* l = dynamic_cast<Label*>(widget(args.get<std::string>(0, ""))))
-            l->set_font_size(static_cast<float>(args.get<double>(1, 14)));
-        else if (auto* e = dynamic_cast<TextEditor*>(widget(args.get<std::string>(0, ""))))
-            e->set_font_size(static_cast<float>(args.get<double>(1, 14)));
+        auto id = args.get<std::string>(0, "");
+        auto size = static_cast<float>(args.get<double>(1, 14));
+        auto* v = widget(id);
+        if (!v) return choc::value::Value();
+        if (auto* l = dynamic_cast<Label*>(v)) {
+            l->set_font_size(size);
+        } else if (auto* e = dynamic_cast<TextEditor*>(v)) {
+            e->set_font_size(size);
+        } else {
+            // issue-969: container Views store the size for descendant
+            // Labels via the inheritable slot.
+            v->set_inheritable_font_size(size);
+        }
         return choc::value::Value();
     });
 
@@ -2265,9 +2290,24 @@ void WidgetBridge::register_api() {
         auto hex = args.get<std::string>(1, "");
         auto* v = widget(id);
         if (!v || hex.empty()) return choc::value::Value();
-        // Set a custom text color token override on the view's theme
+        auto color = parseHexColor(hex);
+        // issue-969: CSS-style cascade.
+        //   - On a Label: set the Label's own explicit text_color, which
+        //     wins over inheritance and theme tokens.
+        //   - On a container View: store the color on the inheritable
+        //     slot so descendant Labels pick it up. This replaces the
+        //     dom-adapter's manual "walk children and pushdown" hack.
+        if (auto* l = dynamic_cast<Label*>(v)) {
+            l->set_text_color(color);
+        } else {
+            v->set_inheritable_text_color(color);
+        }
+        // Keep the theme-token fallback in sync so widgets that resolve
+        // through `resolve_color("text.primary")` (e.g. Knob/ToggleButton)
+        // also pick up the override on their own subtree — preserves the
+        // pre-#969 behavior for those widgets.
         auto theme = v->theme();
-        theme.colors["text.primary"] = parseHexColor(hex);
+        theme.colors["text.primary"] = color;
         v->set_theme(theme);
         return choc::value::Value();
     });

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -242,6 +242,18 @@ void Toggle::advance_animations(float dt) {
 
 // ── Label ────────────────────────────────────────────────────────────────────
 
+float Label::intrinsic_height() const {
+    // issue-969: cascade font_size before computing height so descendants
+    // of a parent that called setInheritableFontSize report a height that
+    // actually matches what paint() will draw.
+    float effective_font_size = font_size_;
+    if (!has_own_font_size_) {
+        if (auto inh = inheritable_font_size(); inh.has_value())
+            effective_font_size = inh.value();
+    }
+    return line_height_ > 0 ? line_height_ : effective_font_size * 1.4f;
+}
+
 float Label::intrinsic_width() const {
     // issue-928: report the natural shaped-text width so Yoga reserves
     // enough horizontal space for the full label content. Without this,
@@ -253,6 +265,20 @@ float Label::intrinsic_width() const {
     // single-line text width.
     if (text_.empty() || multi_line_) return 0;
 
+    // issue-969: intrinsic measurement must match what paint() will
+    // actually draw, so honor the same own→inherited cascade for
+    // font_size and letter_spacing.
+    float effective_font_size = font_size_;
+    if (!has_own_font_size_) {
+        if (auto inh = inheritable_font_size(); inh.has_value())
+            effective_font_size = inh.value();
+    }
+    float effective_letter_spacing = letter_spacing_;
+    if (!has_own_letter_spacing_) {
+        if (auto inh = inheritable_letter_spacing(); inh.has_value())
+            effective_letter_spacing = inh.value();
+    }
+
     // pulp #943 P2 / #945: when paint() rotates the text 90° the
     // horizontal footprint is just the line height, not the shaped
     // string advance. Reporting the advance here makes Yoga reserve
@@ -260,7 +286,7 @@ float Label::intrinsic_width() const {
     bool vertical = (text_direction_ == canvas::TextDirection::top_to_bottom ||
                      text_direction_ == canvas::TextDirection::bottom_to_top);
     if (vertical) {
-        return std::ceil(line_height_ > 0 ? line_height_ : font_size_ * 1.4f);
+        return std::ceil(line_height_ > 0 ? line_height_ : effective_font_size * 1.4f);
     }
 
     // Mirror paint()'s text-transform — measurement must match what's
@@ -288,7 +314,7 @@ float Label::intrinsic_width() const {
     // to a character-width estimator otherwise — same fallback that
     // Canvas::measure_text() uses on the recording / non-Skia backends.
     auto& shaper = canvas::global_text_shaper();
-    auto prepared = shaper.prepare(display_text, "Inter", font_size_);
+    auto prepared = shaper.prepare(display_text, "Inter", effective_font_size);
     float width = prepared.total_width();
 
     // Letter-spacing adds extra advance per glyph break that isn't
@@ -296,7 +322,7 @@ float Label::intrinsic_width() const {
     // bytes — using `size()` over-applies spacing on multibyte input
     // (CJK, accented Latin, emoji) and inflates intrinsic width
     // (pulp #943 P2 #935 finding 2).
-    if (letter_spacing_ != 0 && !display_text.empty()) {
+    if (effective_letter_spacing != 0 && !display_text.empty()) {
         std::size_t glyph_count = 0;
         for (unsigned char c : display_text) {
             // Count any byte that is not a UTF-8 continuation byte
@@ -304,7 +330,7 @@ float Label::intrinsic_width() const {
             if ((c & 0xC0) != 0x80) ++glyph_count;
         }
         if (glyph_count > 1) {
-            width += letter_spacing_ * static_cast<float>(glyph_count - 1);
+            width += effective_letter_spacing * static_cast<float>(glyph_count - 1);
         }
     }
 
@@ -315,13 +341,42 @@ float Label::intrinsic_width() const {
 void Label::paint(canvas::Canvas& canvas) {
     if (text_.empty()) return;
 
-    auto text_color = resolve_color("text.primary", canvas::Color::rgba8(200, 200, 200));
+    // issue-969: CSS-style typography cascade. For each property:
+    //   1. Use the Label's own value if explicitly set.
+    //   2. Otherwise walk up the parent chain via View::inheritable_*().
+    //   3. Otherwise fall back to the existing theme/default behavior.
+    canvas::Color text_color;
+    if (has_own_text_color_) {
+        text_color = text_color_;
+    } else if (auto inherited = inheritable_text_color(); inherited.has_value()) {
+        text_color = inherited.value();
+    } else {
+        text_color = resolve_color("text.primary", canvas::Color::rgba8(200, 200, 200));
+    }
     canvas.set_fill_color({text_color.r, text_color.g, text_color.b, text_color.a});
+
+    float effective_font_size = font_size_;
+    if (!has_own_font_size_) {
+        if (auto inh = inheritable_font_size(); inh.has_value())
+            effective_font_size = inh.value();
+    }
+    int effective_font_weight = font_weight_;
+    if (!has_own_font_weight_) {
+        if (auto inh = inheritable_font_weight(); inh.has_value())
+            effective_font_weight = inh.value();
+    }
+    float effective_letter_spacing = letter_spacing_;
+    if (!has_own_letter_spacing_) {
+        if (auto inh = inheritable_letter_spacing(); inh.has_value())
+            effective_letter_spacing = inh.value();
+    }
+
     // pulp #927 — propagate setFontFamily / setFontWeight / setLetterSpacing
     // through to the canvas backend so JS calls actually change rasterised
     // glyphs. Empty font_family_ falls back to the default theme face.
     const std::string& family = font_family_.empty() ? std::string("Inter") : font_family_;
-    canvas.set_font_full(family, font_size_, font_weight_, font_style_, letter_spacing_);
+    canvas.set_font_full(family, effective_font_size, effective_font_weight,
+                          font_style_, effective_letter_spacing);
 
     // Apply text-transform
     std::string display_text = text_;
@@ -346,36 +401,47 @@ void Label::paint(canvas::Canvas& canvas) {
     if (vertical) {
         canvas.save();
         if (text_direction_ == canvas::TextDirection::top_to_bottom) {
-            canvas.translate(bounds().width * 0.5f + font_size_ * 0.35f, 0);
+            canvas.translate(bounds().width * 0.5f + effective_font_size * 0.35f, 0);
             canvas.rotate(3.14159265f / 2.0f);
         } else {
-            canvas.translate(bounds().width * 0.5f - font_size_ * 0.35f, bounds().height);
+            canvas.translate(bounds().width * 0.5f - effective_font_size * 0.35f, bounds().height);
             canvas.rotate(-3.14159265f / 2.0f);
         }
     }
 
     // Vertical alignment
-    float lh = line_height_ > 0 ? line_height_ : font_size_ * 1.4f;
-    float text_h = multi_line_ ? lh * static_cast<float>(std::count(display_text.begin(), display_text.end(), '\n') + 1) : font_size_;
+    float lh = line_height_ > 0 ? line_height_ : effective_font_size * 1.4f;
+    float text_h = multi_line_ ? lh * static_cast<float>(std::count(display_text.begin(), display_text.end(), '\n') + 1) : effective_font_size;
     float baseline_y;
     switch (vertical_align_) {
         case canvas::TextVerticalAlign::top:
-            baseline_y = font_size_ * 0.85f;
+            baseline_y = effective_font_size * 0.85f;
             break;
         case canvas::TextVerticalAlign::bottom:
-            baseline_y = bounds().height - text_h + font_size_ * 0.85f;
+            baseline_y = bounds().height - text_h + effective_font_size * 0.85f;
             break;
         case canvas::TextVerticalAlign::baseline:
             baseline_y = bounds().height * 0.75f;
             break;
         case canvas::TextVerticalAlign::center:
         default:
-            baseline_y = bounds().height * 0.5f + font_size_ * 0.35f;
+            baseline_y = bounds().height * 0.5f + effective_font_size * 0.35f;
             break;
     }
 
+    // issue-969: text-align cascade. Own value wins, otherwise inherited.
+    LabelAlign effective_text_align = text_align_;
+    if (!has_own_text_align_) {
+        if (auto inh = inheritable_text_align(); inh.has_value()) {
+            int v = inh.value();
+            if (v == 1) effective_text_align = LabelAlign::center;
+            else if (v == 2) effective_text_align = LabelAlign::right;
+            else effective_text_align = LabelAlign::left;
+        }
+    }
+
     float x = 0;
-    switch (text_align_) {
+    switch (effective_text_align) {
         case LabelAlign::left:
             canvas.set_text_align(canvas::TextAlign::left);
             break;
@@ -391,7 +457,7 @@ void Label::paint(canvas::Canvas& canvas) {
 
     if (!multi_line_) {
         // Text overflow ellipsis
-        if (text_overflow_ellipsis() && text_align_ == LabelAlign::left) {
+        if (text_overflow_ellipsis() && effective_text_align == LabelAlign::left) {
             float avail = bounds().width;
             float text_w = canvas.measure_text(display_text);
             if (text_w > avail && display_text.size() > 3) {
@@ -408,7 +474,7 @@ void Label::paint(canvas::Canvas& canvas) {
         }
         canvas.fill_text(display_text, x, baseline_y);
     } else {
-        float y = font_size_ * 0.85f;
+        float y = effective_font_size * 0.85f;
         size_t pos = 0;
         while (pos < display_text.size()) {
             size_t nl = display_text.find('\n', pos);
@@ -427,15 +493,15 @@ void Label::paint(canvas::Canvas& canvas) {
         canvas.set_line_width(1.0f);
         float text_w = canvas.measure_text(display_text);
         float draw_x = x;
-        if (text_align_ == LabelAlign::center) draw_x = x - text_w * 0.5f;
-        else if (text_align_ == LabelAlign::right) draw_x = x - text_w;
+        if (effective_text_align == LabelAlign::center) draw_x = x - text_w * 0.5f;
+        else if (effective_text_align == LabelAlign::right) draw_x = x - text_w;
 
         if (text_decoration_ == TextDecoration::underline)
             canvas.stroke_line(draw_x, baseline_y + 2, draw_x + text_w, baseline_y + 2);
         else if (text_decoration_ == TextDecoration::line_through)
-            canvas.stroke_line(draw_x, baseline_y - font_size_ * 0.2f, draw_x + text_w, baseline_y - font_size_ * 0.2f);
+            canvas.stroke_line(draw_x, baseline_y - effective_font_size * 0.2f, draw_x + text_w, baseline_y - effective_font_size * 0.2f);
         else if (text_decoration_ == TextDecoration::overline)
-            canvas.stroke_line(draw_x, baseline_y - font_size_ * 0.7f, draw_x + text_w, baseline_y - font_size_ * 0.7f);
+            canvas.stroke_line(draw_x, baseline_y - effective_font_size * 0.7f, draw_x + text_w, baseline_y - effective_font_size * 0.7f);
     }
 
     if (vertical) canvas.restore();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1329,6 +1329,11 @@ add_executable(pulp-test-widget-bridge test_widget_bridge.cpp)
 target_link_libraries(pulp-test-widget-bridge PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-widget-bridge)
 
+# Typography inheritance — pulp #969 (CSS-style cascade)
+add_executable(pulp-test-typography-inheritance test_typography_inheritance.cpp)
+target_link_libraries(pulp-test-typography-inheritance PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-typography-inheritance)
+
 # Editor bridge tests (pulp #709 — renderer-agnostic envelope/dispatcher)
 add_executable(pulp-test-editor-bridge test_editor_bridge.cpp)
 target_link_libraries(pulp-test-editor-bridge PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_typography_inheritance.cpp
+++ b/test/test_typography_inheritance.cpp
@@ -1,0 +1,458 @@
+// CSS-style typography inheritance — pulp #969.
+//
+// A parent View's setInheritable* setters (driven by setTextColor /
+// setFontSize / setLetterSpacing / setFontWeight / setTextAlign on the
+// JS bridge when the target is a non-Label View) must cascade to
+// descendant Labels unless the Label sets its own value.
+//
+// Acceptance criteria mirrored from issue body:
+//  1. <View><Label/></View> with setTextColor on the View renders
+//     the Label in that color without an explicit Label-level setter.
+//  2. Same for fontSize, letterSpacing, fontWeight, textAlign.
+//  3. Explicit Label-level value wins over the inherited cascade.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/view/script_engine.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/widget_bridge.hpp>
+#include <pulp/view/widgets.hpp>
+
+#include <memory>
+#include <optional>
+
+using namespace pulp::view;
+using namespace pulp::canvas;
+
+namespace {
+
+// Pull the most recent set_fill_color color out of a recording canvas.
+// The Label paints set_fill_color BEFORE fill_text, so this is the color
+// the text was actually drawn in.
+std::optional<Color> last_fill_color_before_text(const RecordingCanvas& canvas) {
+    std::optional<Color> last_fill;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == DrawCommand::Type::set_fill_color) {
+            last_fill = cmd.color;
+        } else if (cmd.type == DrawCommand::Type::fill_text) {
+            return last_fill;
+        }
+    }
+    return std::nullopt;
+}
+
+// Pull the (size, weight, letter_spacing) triple out of the most recent
+// set_font_full command before the first fill_text.
+struct FontSnapshot {
+    float size = 0;
+    int weight = 0;
+    float letter_spacing = 0;
+    bool found = false;
+};
+
+FontSnapshot last_font_full_before_text(const RecordingCanvas& canvas) {
+    FontSnapshot snap{};
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == DrawCommand::Type::set_font_full) {
+            snap.size = cmd.f[0];
+            snap.weight = static_cast<int>(cmd.f[1]);
+            snap.letter_spacing = cmd.f[3];
+            snap.found = true;
+        } else if (cmd.type == DrawCommand::Type::fill_text) {
+            return snap;
+        }
+    }
+    return snap;
+}
+
+// Build a parent → child: Label tree and paint just the label.
+// Returns the Label* for further inspection; lifetime owned by parent.
+Label* build_parent_label(View& parent, std::string text = "x") {
+    auto child = std::make_unique<Label>(std::move(text));
+    child->set_bounds({0, 0, 100, 20});
+    auto* raw = child.get();
+    parent.add_child(std::move(child));
+    return raw;
+}
+
+}  // namespace
+
+// ── 1. Bare View → Label inheritance ──────────────────────────────────
+
+TEST_CASE("View::set_inheritable_text_color cascades to child Label",
+          "[view][typography][issue-969]") {
+    View parent;
+    parent.set_bounds({0, 0, 200, 100});
+    auto* label = build_parent_label(parent);
+
+    // No theme override — pure inheritance path.
+    Color white = Color::rgba8(255, 255, 255);
+    parent.set_inheritable_text_color(white);
+
+    RecordingCanvas canvas;
+    label->paint(canvas);
+
+    auto fill = last_fill_color_before_text(canvas);
+    REQUIRE(fill.has_value());
+    REQUIRE(fill.value() == white);
+}
+
+TEST_CASE("Inheritable font_size flows to descendant Label",
+          "[view][typography][issue-969]") {
+    View parent;
+    parent.set_bounds({0, 0, 200, 100});
+    auto* label = build_parent_label(parent);
+    REQUIRE_FALSE(label->has_own_font_size());
+
+    parent.set_inheritable_font_size(24.0f);
+
+    RecordingCanvas canvas;
+    label->paint(canvas);
+
+    auto snap = last_font_full_before_text(canvas);
+    REQUIRE(snap.found);
+    REQUIRE(snap.size == 24.0f);
+}
+
+TEST_CASE("Inheritable letter_spacing flows to descendant Label",
+          "[view][typography][issue-969]") {
+    View parent;
+    parent.set_bounds({0, 0, 200, 100});
+    auto* label = build_parent_label(parent);
+
+    parent.set_inheritable_letter_spacing(2.5f);
+
+    RecordingCanvas canvas;
+    label->paint(canvas);
+
+    auto snap = last_font_full_before_text(canvas);
+    REQUIRE(snap.found);
+    REQUIRE(snap.letter_spacing == 2.5f);
+}
+
+TEST_CASE("Inheritable font_weight flows to descendant Label",
+          "[view][typography][issue-969]") {
+    View parent;
+    parent.set_bounds({0, 0, 200, 100});
+    auto* label = build_parent_label(parent);
+
+    parent.set_inheritable_font_weight(700);
+
+    RecordingCanvas canvas;
+    label->paint(canvas);
+
+    auto snap = last_font_full_before_text(canvas);
+    REQUIRE(snap.found);
+    REQUIRE(snap.weight == 700);
+}
+
+TEST_CASE("Inheritable text_align flows to descendant Label",
+          "[view][typography][issue-969]") {
+    View parent;
+    parent.set_bounds({0, 0, 200, 100});
+    auto* label = build_parent_label(parent);
+    REQUIRE_FALSE(label->has_own_text_align());
+
+    // 1 == center per the bridge mapping (left=0, center=1, right=2).
+    parent.set_inheritable_text_align(1);
+
+    // The cascade is applied inside Label::paint via the inheritable
+    // getter; verify the public getter returns the inherited value.
+    auto inh = label->inheritable_text_align();
+    REQUIRE(inh.has_value());
+    REQUIRE(inh.value() == 1);
+}
+
+// ── 2. Override semantics ────────────────────────────────────────────
+
+TEST_CASE("Explicit Label setters win over inherited cascade",
+          "[view][typography][issue-969]") {
+    View parent;
+    parent.set_bounds({0, 0, 200, 100});
+    auto* label = build_parent_label(parent);
+
+    Color parent_white = Color::rgba8(255, 255, 255);
+    Color label_red = Color::rgba8(255, 0, 0);
+
+    parent.set_inheritable_text_color(parent_white);
+    parent.set_inheritable_font_size(40.0f);
+    parent.set_inheritable_font_weight(900);
+
+    label->set_text_color(label_red);
+    label->set_font_size(12.0f);
+    label->set_font_weight(400);
+
+    RecordingCanvas canvas;
+    label->paint(canvas);
+
+    auto fill = last_fill_color_before_text(canvas);
+    REQUIRE(fill.has_value());
+    REQUIRE(fill.value() == label_red);
+
+    auto snap = last_font_full_before_text(canvas);
+    REQUIRE(snap.found);
+    REQUIRE(snap.size == 12.0f);
+    REQUIRE(snap.weight == 400);
+}
+
+// ── 3. Multi-level cascade ───────────────────────────────────────────
+
+TEST_CASE("Inheritance walks the full ancestor chain",
+          "[view][typography][issue-969]") {
+    // grandparent → parent → label. Setting the value on grandparent
+    // must reach the label even though parent has nothing set.
+    View grandparent;
+    grandparent.set_bounds({0, 0, 200, 200});
+
+    auto parent_holder = std::make_unique<View>();
+    parent_holder->set_bounds({0, 0, 200, 100});
+    auto* parent = parent_holder.get();
+    grandparent.add_child(std::move(parent_holder));
+
+    auto* label = build_parent_label(*parent);
+
+    Color blue = Color::rgba8(0, 0, 255);
+    grandparent.set_inheritable_text_color(blue);
+
+    RecordingCanvas canvas;
+    label->paint(canvas);
+
+    auto fill = last_fill_color_before_text(canvas);
+    REQUIRE(fill.has_value());
+    REQUIRE(fill.value() == blue);
+}
+
+TEST_CASE("Closer ancestor overrides farther ancestor",
+          "[view][typography][issue-969]") {
+    View grandparent;
+    grandparent.set_bounds({0, 0, 200, 200});
+
+    auto parent_holder = std::make_unique<View>();
+    parent_holder->set_bounds({0, 0, 200, 100});
+    auto* parent = parent_holder.get();
+    grandparent.add_child(std::move(parent_holder));
+
+    auto* label = build_parent_label(*parent);
+
+    grandparent.set_inheritable_text_color(Color::rgba8(255, 255, 255));
+    Color green = Color::rgba8(0, 255, 0);
+    parent->set_inheritable_text_color(green);
+
+    RecordingCanvas canvas;
+    label->paint(canvas);
+
+    auto fill = last_fill_color_before_text(canvas);
+    REQUIRE(fill.has_value());
+    REQUIRE(fill.value() == green);
+}
+
+// ── 4. WidgetBridge integration ──────────────────────────────────────
+//
+// The bridge dispatches setTextColor / setFontSize / etc. to either the
+// Label-level setter (when the target is a Label) or the inheritable
+// slot (when the target is a non-Label container). Verify both code
+// paths against an actual ScriptEngine + WidgetBridge.
+
+TEST_CASE("WidgetBridge setTextColor on a Panel cascades to child Label",
+          "[view][typography][issue-969][bridge]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    pulp::state::StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('panel', '');
+        createLabel('text', 'hello', 'panel');
+        setTextColor('panel', '#ffffff');
+    )");
+
+    auto* label = dynamic_cast<Label*>(bridge.widget("text"));
+    REQUIRE(label != nullptr);
+    REQUIRE_FALSE(label->has_own_text_color());
+
+    auto* panel = bridge.widget("panel");
+    REQUIRE(panel != nullptr);
+    auto inh = panel->inheritable_text_color();
+    REQUIRE(inh.has_value());
+    REQUIRE(inh.value() == Color::rgba8(255, 255, 255));
+
+    label->set_bounds({0, 0, 100, 20});
+    RecordingCanvas canvas;
+    label->paint(canvas);
+    auto fill = last_fill_color_before_text(canvas);
+    REQUIRE(fill.has_value());
+    REQUIRE(fill.value() == Color::rgba8(255, 255, 255));
+}
+
+TEST_CASE("WidgetBridge setTextColor on a Label sets its own color",
+          "[view][typography][issue-969][bridge]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    pulp::state::StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createLabel('text', 'hello', '');
+        setTextColor('text', '#ff0000');
+    )");
+
+    auto* label = dynamic_cast<Label*>(bridge.widget("text"));
+    REQUIRE(label != nullptr);
+    REQUIRE(label->has_own_text_color());
+    REQUIRE(label->text_color() == Color::rgba8(255, 0, 0));
+}
+
+TEST_CASE("WidgetBridge setFontSize on a Panel cascades to child Label",
+          "[view][typography][issue-969][bridge]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    pulp::state::StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('panel', '');
+        createLabel('text', 'hello', 'panel');
+        setFontSize('panel', 32);
+    )");
+
+    auto* panel = bridge.widget("panel");
+    REQUIRE(panel != nullptr);
+    auto inh_size = panel->inheritable_font_size();
+    REQUIRE(inh_size.has_value());
+    REQUIRE(inh_size.value() == 32.0f);
+
+    auto* label = dynamic_cast<Label*>(bridge.widget("text"));
+    REQUIRE(label != nullptr);
+    REQUIRE_FALSE(label->has_own_font_size());
+
+    label->set_bounds({0, 0, 100, 60});
+    RecordingCanvas canvas;
+    label->paint(canvas);
+    auto snap = last_font_full_before_text(canvas);
+    REQUIRE(snap.found);
+    REQUIRE(snap.size == 32.0f);
+}
+
+TEST_CASE("WidgetBridge setLetterSpacing on a Panel cascades to child Label",
+          "[view][typography][issue-969][bridge]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    pulp::state::StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('panel', '');
+        createLabel('text', 'hello', 'panel');
+        setLetterSpacing('panel', 3);
+    )");
+
+    auto* panel = bridge.widget("panel");
+    auto inh = panel->inheritable_letter_spacing();
+    REQUIRE(inh.has_value());
+    REQUIRE(inh.value() == 3.0f);
+
+    auto* label = dynamic_cast<Label*>(bridge.widget("text"));
+    REQUIRE_FALSE(label->has_own_letter_spacing());
+
+    label->set_bounds({0, 0, 100, 20});
+    RecordingCanvas canvas;
+    label->paint(canvas);
+    auto snap = last_font_full_before_text(canvas);
+    REQUIRE(snap.found);
+    REQUIRE(snap.letter_spacing == 3.0f);
+}
+
+TEST_CASE("WidgetBridge setFontWeight on a Panel cascades to child Label",
+          "[view][typography][issue-969][bridge]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    pulp::state::StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('panel', '');
+        createLabel('text', 'hello', 'panel');
+        setFontWeight('panel', 700);
+    )");
+
+    auto* panel = bridge.widget("panel");
+    auto inh = panel->inheritable_font_weight();
+    REQUIRE(inh.has_value());
+    REQUIRE(inh.value() == 700);
+
+    auto* label = dynamic_cast<Label*>(bridge.widget("text"));
+    REQUIRE_FALSE(label->has_own_font_weight());
+
+    label->set_bounds({0, 0, 100, 20});
+    RecordingCanvas canvas;
+    label->paint(canvas);
+    auto snap = last_font_full_before_text(canvas);
+    REQUIRE(snap.found);
+    REQUIRE(snap.weight == 700);
+}
+
+TEST_CASE("WidgetBridge setTextAlign on a Panel cascades to child Label",
+          "[view][typography][issue-969][bridge]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    pulp::state::StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('panel', '');
+        createLabel('text', 'hello', 'panel');
+        setTextAlign('panel', 'center');
+    )");
+
+    auto* panel = bridge.widget("panel");
+    auto inh = panel->inheritable_text_align();
+    REQUIRE(inh.has_value());
+    REQUIRE(inh.value() == 1);  // center
+
+    auto* label = dynamic_cast<Label*>(bridge.widget("text"));
+    REQUIRE_FALSE(label->has_own_text_align());
+    auto reach = label->inheritable_text_align();
+    REQUIRE(reach.has_value());
+    REQUIRE(reach.value() == 1);
+}
+
+// Spectr's dom-adapter previously walked the React tree to push
+// inherited typography down to the leaf Labels. With the framework
+// cascade in place the dom-adapter doesn't need to set the value on
+// the Label at all — verify that explicit Label setters still win when
+// they ARE present (to avoid regressing the manual-pushdown case until
+// Spectr deletes its workaround).
+TEST_CASE("WidgetBridge: explicit Label setter wins over panel-level cascade",
+          "[view][typography][issue-969][bridge]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    pulp::state::StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('panel', '');
+        createLabel('text', 'hello', 'panel');
+        setTextColor('panel', '#ffffff');
+        setTextColor('text', '#ff0000');
+    )");
+
+    auto* label = dynamic_cast<Label*>(bridge.widget("text"));
+    REQUIRE(label != nullptr);
+    REQUIRE(label->has_own_text_color());
+
+    label->set_bounds({0, 0, 100, 20});
+    RecordingCanvas canvas;
+    label->paint(canvas);
+    auto fill = last_fill_color_before_text(canvas);
+    REQUIRE(fill.has_value());
+    REQUIRE(fill.value() == Color::rgba8(255, 0, 0));
+}


### PR DESCRIPTION
Pulp's Label widget honored its own setTextColor/setFontSize/etc. but
didn't inherit them from a parent View. CSS does: setting `color: white`
on a `<div>` cascades to every text descendant unless overridden.
Spectr's dom-adapter currently walks the React tree and pushes parent
typography down to leaf Labels — a workaround that should live in the
framework.

Changes:

- View gains `inheritable_text_color`, `inheritable_font_size`,
  `inheritable_letter_spacing`, `inheritable_font_weight`, and
  `inheritable_text_align` slots (`std::optional<...>`). Each
  `inheritable_*()` accessor walks own → parent → root, returning the
  first ancestor that set the value. These slots do NOT affect the
  View's own paint — only descendant Labels consult them.

- Label tracks `has_own_*` flags per inheritable property so paint()
  can distinguish "default value" from "explicitly set." paint() and
  intrinsic_width()/intrinsic_height() resolve the cascade as
  own → inheritable → existing theme/widget default.

- Label gains an explicit `set_text_color` setter (separate from the
  `text.primary` theme token override path). When the bridge targets a
  Label, it sets this; when it targets a non-Label View, it stores the
  color in the View's inheritable slot.

- WidgetBridge setTextColor / setFontSize / setLetterSpacing /
  setFontWeight / setTextAlign now dynamic_cast to Label first (existing
  behavior preserved) and fall back to setting the inheritable slot on
  any other View (Panel, container) — so calls on container Views no
  longer silently no-op.

- setTextColor on a container View also keeps the legacy theme-token
  override (`text.primary`) in sync so widgets that resolve their text
  color through the theme path (Knob, ToggleButton, etc.) still see the
  override on their own subtree. This avoids regressing pre-#969
  callers that relied on theme cascade.

Tests: new `test/test_typography_inheritance.cpp` (15 cases /
57 assertions) covers the bare cascade, multi-level ancestor walk,
override semantics, and the WidgetBridge entry points for each of the
five inheritable properties. Existing pulp-test-widgets,
pulp-test-widget-bridge, pulp-test-view, pulp-test-layout-w3c,
pulp-test-canvas, pulp-test-scripted-ui, pulp-test-inspector,
pulp-test-scroll-view, pulp-test-text-editor, pulp-test-design-import,
and pulp-test-design-tool-layout all stay green.

Refs: #969