### PR TITLE
fix(view): canvasRect/canvasStrokeRect honour active fillStyle when no color arg (pulp #968)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0640"></a>
+## [0.65.0]
+
 ## [0.64.0] - 2026-04-29
 
 - feat(view): RangeSlider widget for HTML <input type="range"> (#966) ([#1004](https://github.com/danielraffel/pulp/pull/1004))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.64.0
+    VERSION 0.65.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/canvas_widget.hpp
+++ b/core/view/include/pulp/view/canvas_widget.hpp
@@ -55,6 +55,15 @@ struct CanvasDrawCmd {
     int int_val = 0;            // for enum values (text align, baseline, blend mode, cap, join)
     std::vector<canvas::Color> gradient_colors;    // for gradient stops
     std::vector<float> gradient_positions;          // gradient stop positions
+    /// pulp #968 — when true on a fill_rect / stroke_rect cmd, the paint
+    /// loop must NOT call set_fill_color / set_stroke_color from `color`
+    /// before drawing. The most recent set_fill_color, set_stroke_color,
+    /// or set_fill_gradient_* on the underlying canvas stays active.
+    /// Bridge sets this when the JS caller omitted the color arg
+    /// (e.g. `canvasRect(id, x, y, w, h)` — Canvas2D `ctx.fillRect()`
+    /// shim that relies on a previously-set `ctx.fillStyle`, including
+    /// gradients).
+    bool use_active_style = false;
 };
 
 /// A View whose paint() replays a list of recorded draw commands.

--- a/core/view/src/canvas_widget.cpp
+++ b/core/view/src/canvas_widget.cpp
@@ -52,11 +52,20 @@ void CanvasWidget::paint(canvas::Canvas& canvas) {
             canvas.fill_rect(0, 0, bounds().width, bounds().height);
             break;
         case CanvasDrawCmd::Type::fill_rect:
-            canvas.set_fill_color(cmd.color);
+            // pulp #968 — when use_active_style is set the bridge's caller
+            // omitted the color arg (Canvas2D `ctx.fillRect(x,y,w,h)` shim),
+            // so honour the active fillStyle (color OR gradient set most
+            // recently on the canvas) instead of overwriting with cmd.color.
+            if (!cmd.use_active_style) {
+                canvas.set_fill_color(cmd.color);
+            }
             canvas.fill_rect(cmd.x, cmd.y, cmd.w, cmd.h);
             break;
         case CanvasDrawCmd::Type::stroke_rect:
-            canvas.set_stroke_color(cmd.color);
+            // pulp #968 — same fallback as fill_rect, applied to strokeStyle.
+            if (!cmd.use_active_style) {
+                canvas.set_stroke_color(cmd.color);
+            }
             canvas.set_line_width(cmd.extra);
             canvas.stroke_rect(cmd.x, cmd.y, cmd.w, cmd.h);
             break;

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2461,7 +2461,19 @@ void WidgetBridge::register_api() {
             CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::fill_rect;
             cmd.x=(float)args.get<double>(1,0); cmd.y=(float)args.get<double>(2,0);
             cmd.w=(float)args.get<double>(3,0); cmd.h=(float)args.get<double>(4,0);
-            cmd.color = parseColor(args.get<std::string>(5, "#fff"));
+            // pulp #968 — when no color arg was passed (or it was the empty
+            // string), honour the active fillStyle (color OR gradient) on
+            // the canvas widget. This makes a JS shim like
+            //   fillRect(x,y,w,h) { call('canvasRect', id, x,y,w,h); }
+            // behave like the Canvas2D spec — `ctx.fillRect` paints with
+            // whatever `ctx.fillStyle` was last set to, including a
+            // CanvasGradient. With 6+ args the explicit color wins.
+            const std::string color_str = args.get<std::string>(5, "");
+            if (args.size() < 6 || color_str.empty()) {
+                cmd.use_active_style = true;
+            } else {
+                cmd.color = parseColor(color_str);
+            }
             c->add_command(cmd);
         }
         return choc::value::Value();
@@ -2472,7 +2484,14 @@ void WidgetBridge::register_api() {
             CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::stroke_rect;
             cmd.x=(float)args.get<double>(1,0); cmd.y=(float)args.get<double>(2,0);
             cmd.w=(float)args.get<double>(3,0); cmd.h=(float)args.get<double>(4,0);
-            cmd.color = parseColor(args.get<std::string>(5, "#fff"));
+            // pulp #968 — same active-style fallback as canvasRect, applied
+            // to strokeStyle. Width arg (index 6) is unaffected.
+            const std::string color_str = args.get<std::string>(5, "");
+            if (args.size() < 6 || color_str.empty()) {
+                cmd.use_active_style = true;
+            } else {
+                cmd.color = parseColor(color_str);
+            }
             cmd.extra = (float)args.get<double>(6, 1);
             c->add_command(cmd);
         }

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -593,3 +593,218 @@ TEST_CASE("Bare View with no setBackground emits no background fill",
     }
     REQUIRE(fill_rect_count == 0);
 }
+
+// ── pulp #968 — canvasRect must honour active fillStyle when no color arg ──
+//
+// The Canvas2D `ctx.fillRect(x,y,w,h)` API has no color argument — it paints
+// with whatever `ctx.fillStyle` (a CSS color OR a CanvasGradient) was set
+// most recently. The bridge's `canvasRect(id, x, y, w, h, color="#fff")`
+// previously baked in literal white when the caller omitted the color, which
+// makes a JS fillRect shim unable to honour the active fillStyle and breaks
+// gradient fills entirely (gradient is not a string color so the shim has
+// nothing to pass).
+//
+// Contract: when CanvasDrawCmd.use_active_style is true, the paint loop
+// must NOT call set_fill_color / set_stroke_color on the underlying canvas
+// before drawing — the previously-set fill/stroke state stays active.
+
+// Case 1 — fill_rect with use_active_style honours the active fill colour.
+TEST_CASE("CanvasWidget fill_rect with use_active_style preserves prior set_fill_color",
+          "[canvas_widget][issue-968]") {
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 100, 100});
+
+    // Active fill = magenta.
+    CanvasDrawCmd set_color;
+    set_color.type = CanvasDrawCmd::Type::set_fill_color;
+    set_color.color = pulp::canvas::Color::rgba8(255, 0, 255, 255);
+    cw.add_command(set_color);
+
+    // fillRect with no explicit colour (use_active_style = true). The
+    // baked-in cmd.color stays at its default of opaque white — the test
+    // asserts that white is NOT what the underlying canvas actually paints
+    // with.
+    CanvasDrawCmd r;
+    r.type = CanvasDrawCmd::Type::fill_rect;
+    r.x = 10; r.y = 10; r.w = 50; r.h = 50;
+    r.use_active_style = true;
+    cw.add_command(r);
+
+    cw.paint(rc);
+
+    // Walk the recorded stream tracking the most recent set_fill_color.
+    // For each fill_rect, the active fill at draw time is what the rect
+    // is painted with. We expect the magenta to still be active when the
+    // fill_rect is emitted — i.e. no intervening set_fill_color(white).
+    pulp::canvas::Color active_fill{};
+    bool saw_fill_rect = false;
+    pulp::canvas::Color fill_at_draw{};
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::set_fill_color) {
+            active_fill = cmd.color;
+            continue;
+        }
+        if (cmd.type == DrawCommand::Type::fill_rect) {
+            // Match the rect we recorded (skip any incidental fills).
+            const bool matches = (cmd.f[0] == 10.0f && cmd.f[1] == 10.0f &&
+                                  cmd.f[2] == 50.0f && cmd.f[3] == 50.0f);
+            if (matches) {
+                saw_fill_rect = true;
+                fill_at_draw = active_fill;
+            }
+        }
+    }
+    REQUIRE(saw_fill_rect);
+    const bool is_magenta = (fill_at_draw.r8() == 255 && fill_at_draw.g8() == 0
+                          && fill_at_draw.b8() == 255 && fill_at_draw.a8() == 255);
+    REQUIRE(is_magenta);
+}
+
+// Case 2 — fill_rect with explicit colour (use_active_style = false) keeps
+// the legacy behaviour: cmd.color overrides whatever was set before.
+TEST_CASE("CanvasWidget fill_rect with explicit color overrides active fill",
+          "[canvas_widget][issue-968]") {
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 100, 100});
+
+    // Active fill = magenta.
+    CanvasDrawCmd set_color;
+    set_color.type = CanvasDrawCmd::Type::set_fill_color;
+    set_color.color = pulp::canvas::Color::rgba8(255, 0, 255, 255);
+    cw.add_command(set_color);
+
+    // fillRect with explicit cyan colour, use_active_style = false.
+    CanvasDrawCmd r;
+    r.type = CanvasDrawCmd::Type::fill_rect;
+    r.x = 10; r.y = 10; r.w = 50; r.h = 50;
+    r.color = pulp::canvas::Color::rgba8(0, 255, 255, 255);
+    r.use_active_style = false;
+    cw.add_command(r);
+
+    cw.paint(rc);
+
+    pulp::canvas::Color active_fill{};
+    bool saw_fill_rect = false;
+    pulp::canvas::Color fill_at_draw{};
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::set_fill_color) {
+            active_fill = cmd.color;
+            continue;
+        }
+        if (cmd.type == DrawCommand::Type::fill_rect) {
+            const bool matches = (cmd.f[0] == 10.0f && cmd.f[1] == 10.0f &&
+                                  cmd.f[2] == 50.0f && cmd.f[3] == 50.0f);
+            if (matches) {
+                saw_fill_rect = true;
+                fill_at_draw = active_fill;
+            }
+        }
+    }
+    REQUIRE(saw_fill_rect);
+    const bool is_cyan = (fill_at_draw.r8() == 0 && fill_at_draw.g8() == 255
+                       && fill_at_draw.b8() == 255 && fill_at_draw.a8() == 255);
+    REQUIRE(is_cyan);
+}
+
+// Case 3 — fill_rect with use_active_style after a gradient set keeps the
+// gradient active. RecordingCanvas's default set_fill_gradient_linear falls
+// back to set_fill_color(colors[0]); we use that to verify no white-on-top
+// set_fill_color overwrites the gradient's first stop before the draw.
+TEST_CASE("CanvasWidget fill_rect with use_active_style preserves active gradient",
+          "[canvas_widget][issue-968]") {
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 100, 100});
+
+    // Active fill = linear gradient red→blue. RecordingCanvas's default
+    // overload of set_fill_gradient_linear records a set_fill_color of the
+    // first stop (red).
+    CanvasDrawCmd grad;
+    grad.type = CanvasDrawCmd::Type::set_fill_gradient_linear;
+    grad.x = 0; grad.y = 0; grad.x2 = 100; grad.y2 = 0;
+    grad.gradient_colors = {pulp::canvas::Color::rgba8(255, 0, 0, 255),
+                            pulp::canvas::Color::rgba8(0, 0, 255, 255)};
+    grad.gradient_positions = {0.0f, 1.0f};
+    cw.add_command(grad);
+
+    // fillRect with no explicit colour — use_active_style = true.
+    CanvasDrawCmd r;
+    r.type = CanvasDrawCmd::Type::fill_rect;
+    r.x = 10; r.y = 10; r.w = 50; r.h = 50;
+    r.use_active_style = true;
+    cw.add_command(r);
+
+    cw.paint(rc);
+
+    // The active fill at draw time must still be the gradient's first stop
+    // (red) — NOT white, which is what would have been overwritten if the
+    // paint loop had called set_fill_color(cmd.color) before fill_rect.
+    pulp::canvas::Color active_fill{};
+    bool saw_fill_rect = false;
+    pulp::canvas::Color fill_at_draw{};
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::set_fill_color) {
+            active_fill = cmd.color;
+            continue;
+        }
+        if (cmd.type == DrawCommand::Type::fill_rect) {
+            const bool matches = (cmd.f[0] == 10.0f && cmd.f[1] == 10.0f &&
+                                  cmd.f[2] == 50.0f && cmd.f[3] == 50.0f);
+            if (matches) {
+                saw_fill_rect = true;
+                fill_at_draw = active_fill;
+            }
+        }
+    }
+    REQUIRE(saw_fill_rect);
+    const bool is_red = (fill_at_draw.r8() == 255 && fill_at_draw.g8() == 0
+                      && fill_at_draw.b8() == 0 && fill_at_draw.a8() == 255);
+    REQUIRE(is_red);
+}
+
+// Case 4 — stroke_rect mirrors fill_rect: with use_active_style the prior
+// strokeStyle stays active.
+TEST_CASE("CanvasWidget stroke_rect with use_active_style preserves prior set_stroke_color",
+          "[canvas_widget][issue-968]") {
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 100, 100});
+
+    CanvasDrawCmd set_color;
+    set_color.type = CanvasDrawCmd::Type::set_stroke_color;
+    set_color.color = pulp::canvas::Color::rgba8(0, 255, 0, 255); // green
+    cw.add_command(set_color);
+
+    CanvasDrawCmd r;
+    r.type = CanvasDrawCmd::Type::stroke_rect;
+    r.x = 5; r.y = 5; r.w = 40; r.h = 40;
+    r.extra = 2.0f;
+    r.use_active_style = true;
+    cw.add_command(r);
+
+    cw.paint(rc);
+
+    pulp::canvas::Color active_stroke{};
+    bool saw_stroke_rect = false;
+    pulp::canvas::Color stroke_at_draw{};
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::set_stroke_color) {
+            active_stroke = cmd.color;
+            continue;
+        }
+        if (cmd.type == DrawCommand::Type::stroke_rect) {
+            const bool matches = (cmd.f[0] == 5.0f && cmd.f[1] == 5.0f &&
+                                  cmd.f[2] == 40.0f && cmd.f[3] == 40.0f);
+            if (matches) {
+                saw_stroke_rect = true;
+                stroke_at_draw = active_stroke;
+            }
+        }
+    }
+    REQUIRE(saw_stroke_rect);
+    const bool is_green = (stroke_at_draw.r8() == 0 && stroke_at_draw.g8() == 255
+                        && stroke_at_draw.b8() == 0 && stroke_at_draw.a8() == 255);
+    REQUIRE(is_green);
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -2767,3 +2767,181 @@ TEST_CASE("WidgetBridge setSvgFill 'none' disables fill",
     REQUIRE_FALSE(w->has_fill());
     REQUIRE(w->has_stroke());
 }
+
+// pulp #968 — canvasRect / canvasStrokeRect must honour the active fill /
+// stroke style when no color arg is passed. Validates the JS bridge path:
+//   1. five-arg canvasRect → fillStyle (color or gradient) wins
+//   2. six-arg canvasRect with explicit color → explicit color wins
+//   3. linear gradient set, then five-arg canvasRect → gradient wins
+//   4. five-arg canvasStrokeRect → strokeStyle wins
+TEST_CASE("WidgetBridge canvasRect with no color uses active fillStyle (issue-968)",
+          "[view][bridge][canvas][issue-968]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'fill-style-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+
+        // Active fill = magenta. Then a five-arg canvasRect (no color).
+        canvasSetFillColor(c._id, '#ff00ff');
+        canvasRect(c._id, 10, 10, 50, 50);
+
+        // Explicit color (six-arg) — overrides active fill.
+        canvasSetFillColor(c._id, '#ff00ff');
+        canvasRect(c._id, 70, 10, 50, 50, '#00ffff');
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "fill-style-canvas");
+    REQUIRE(canvas != nullptr);
+
+    pulp::canvas::RecordingCanvas rec;
+    canvas->paint(rec);
+
+    using DrawType = pulp::canvas::DrawCommand::Type;
+    pulp::canvas::Color active_fill{};
+    pulp::canvas::Color first_rect_fill{};
+    pulp::canvas::Color second_rect_fill{};
+    bool saw_first = false, saw_second = false;
+    for (const auto& cmd : rec.commands()) {
+        if (cmd.type == DrawType::set_fill_color) {
+            active_fill = cmd.color;
+            continue;
+        }
+        if (cmd.type == DrawType::fill_rect) {
+            const bool is_first  = (cmd.f[0] == 10.0f && cmd.f[1] == 10.0f &&
+                                    cmd.f[2] == 50.0f && cmd.f[3] == 50.0f);
+            const bool is_second = (cmd.f[0] == 70.0f && cmd.f[1] == 10.0f &&
+                                    cmd.f[2] == 50.0f && cmd.f[3] == 50.0f);
+            if (is_first  && !saw_first)  { saw_first  = true; first_rect_fill  = active_fill; }
+            if (is_second && !saw_second) { saw_second = true; second_rect_fill = active_fill; }
+        }
+    }
+    REQUIRE(saw_first);
+    REQUIRE(saw_second);
+    // First rect (no color arg) → magenta (the active fill at the time).
+    const bool first_is_magenta = (first_rect_fill.r8() == 255 &&
+                                   first_rect_fill.g8() == 0 &&
+                                   first_rect_fill.b8() == 255 &&
+                                   first_rect_fill.a8() == 255);
+    REQUIRE(first_is_magenta);
+    // Second rect (explicit color arg) → cyan, overriding the active fill.
+    const bool second_is_cyan = (second_rect_fill.r8() == 0 &&
+                                 second_rect_fill.g8() == 255 &&
+                                 second_rect_fill.b8() == 255 &&
+                                 second_rect_fill.a8() == 255);
+    REQUIRE(second_is_cyan);
+}
+
+TEST_CASE("WidgetBridge canvasRect with no color preserves active linear gradient (issue-968)",
+          "[view][bridge][canvas][issue-968]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Linear gradient red→blue along x. RecordingCanvas's default
+    // set_fill_gradient_linear records a set_fill_color of the first
+    // stop (red) — we use that as the proxy for "gradient is active".
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'grad-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+
+        canvasSetLinearGradient(c._id, 0, 0, 100, 0, '#ff0000', 0, '#0000ff', 1);
+        canvasRect(c._id, 10, 10, 50, 50);
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "grad-canvas");
+    REQUIRE(canvas != nullptr);
+
+    pulp::canvas::RecordingCanvas rec;
+    canvas->paint(rec);
+
+    using DrawType = pulp::canvas::DrawCommand::Type;
+    pulp::canvas::Color active_fill{};
+    bool saw_rect = false;
+    pulp::canvas::Color rect_fill{};
+    for (const auto& cmd : rec.commands()) {
+        if (cmd.type == DrawType::set_fill_color) {
+            active_fill = cmd.color;
+            continue;
+        }
+        if (cmd.type == DrawType::fill_rect) {
+            const bool matches = (cmd.f[0] == 10.0f && cmd.f[1] == 10.0f &&
+                                  cmd.f[2] == 50.0f && cmd.f[3] == 50.0f);
+            if (matches) {
+                saw_rect = true;
+                rect_fill = active_fill;
+            }
+        }
+    }
+    REQUIRE(saw_rect);
+    // The gradient's first stop (red) must still be the active fill —
+    // i.e. no white set_fill_color from a baked-in cmd.color was emitted
+    // between the gradient set and the fill_rect.
+    const bool is_red = (rect_fill.r8() == 255 && rect_fill.g8() == 0 &&
+                         rect_fill.b8() == 0 && rect_fill.a8() == 255);
+    REQUIRE(is_red);
+}
+
+TEST_CASE("WidgetBridge canvasStrokeRect with no color uses active strokeStyle (issue-968)",
+          "[view][bridge][canvas][issue-968]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'stroke-style-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+
+        canvasSetStrokeColor(c._id, '#00ff00');
+        canvasStrokeRect(c._id, 5, 5, 40, 40);
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "stroke-style-canvas");
+    REQUIRE(canvas != nullptr);
+
+    pulp::canvas::RecordingCanvas rec;
+    canvas->paint(rec);
+
+    using DrawType = pulp::canvas::DrawCommand::Type;
+    pulp::canvas::Color active_stroke{};
+    bool saw_rect = false;
+    pulp::canvas::Color stroke_at_draw{};
+    for (const auto& cmd : rec.commands()) {
+        if (cmd.type == DrawType::set_stroke_color) {
+            active_stroke = cmd.color;
+            continue;
+        }
+        if (cmd.type == DrawType::stroke_rect) {
+            const bool matches = (cmd.f[0] == 5.0f && cmd.f[1] == 5.0f &&
+                                  cmd.f[2] == 40.0f && cmd.f[3] == 40.0f);
+            if (matches) {
+                saw_rect = true;
+                stroke_at_draw = active_stroke;
+            }
+        }
+    }
+    REQUIRE(saw_rect);
+    const bool is_green = (stroke_at_draw.r8() == 0 && stroke_at_draw.g8() == 255 &&
+                           stroke_at_draw.b8() == 0 && stroke_at_draw.a8() == 255);
+    REQUIRE(is_green);
+}


### PR DESCRIPTION
The bridge's canvasRect(id, x, y, w, h, color="#fff") defaulted the color
arg to literal white when omitted, so a Canvas2D shim like
  fillRect(x, y, w, h) { call('canvasRect', this.canvasId, x, y, w, h); }
painted white over everything regardless of the active fillStyle. The same
went for canvasStrokeRect. Worse, when fillStyle was a CanvasGradient the
shim had nothing to pass — gradients aren't strings — so Spectr's port had
to emit beginPath + lineTo*4 + closePath + fillPath (7 calls) for every
rectangle.

Add a use_active_style flag to CanvasDrawCmd. The bridge sets it when no
color arg (or empty-string color) was passed; the paint loop skips the
set_fill_color / set_stroke_color call so the previously-set fill or
stroke (color OR gradient) on the underlying canvas stays active. Six-arg
calls keep the explicit color override.

Tests in test/test_canvas_widget.cpp cover the unit-level paint contract
for all three cases (fill colour fallback, explicit colour wins, gradient
fallback) plus stroke parity. Tests in test/test_widget_bridge.cpp drive
the same scenarios through the JS bridge end-to-end via canvasSetFillColor
/ canvasSetLinearGradient / canvasSetStrokeColor + canvasRect /
canvasStrokeRect, asserting against RecordingCanvas's command stream.