### PR TITLE
feat(view): RangeSlider widget for HTML <input type="range"> (#966)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0630"></a>
+## [0.64.0]
+
 ## [0.63.0] - 2026-04-29
 
 - feat(view): CSS-style typography inheritance for Label (pulp #969) ([#1002](https://github.com/danielraffel/pulp/pull/1002))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.63.0
+    VERSION 0.64.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -286,6 +286,102 @@ private:
     std::shared_ptr<SpriteStrip> sprite_strip_;
 };
 
+// ── RangeSlider ──────────────────────────────────────────────────────────────
+// Generic min/max/step slider mapped to HTML <input type="range">.
+//
+// Distinct from Knob (rotary, normalised 0..1) and Fader (DSP linear with
+// decorative track + large thumb). RangeSlider is the plain rectangular
+// track + circular handle the web uses for volume / morph / scrubber UIs.
+// Caller-supplied min/max/step are honoured natively — the bridge does
+// not preprocess them. Quantisation happens inside the widget so JS-side
+// callers see the same value the renderer paints.
+//
+// pulp issue-966.
+
+class RangeSlider : public View {
+public:
+    enum class Orientation { horizontal, vertical };
+
+    RangeSlider() {
+        set_access_role(AccessRole::slider);
+        set_focusable(true);
+    }
+
+    /// Inclusive lower bound (default 0).
+    void set_min(float v) { min_ = v; clamp_and_quantize_(); }
+    float min_value() const { return min_; }
+
+    /// Inclusive upper bound (default 1). If max < min, value falls
+    /// back to min — matches HTMLInputElement behaviour for invalid ranges.
+    void set_max(float v) { max_ = v; clamp_and_quantize_(); }
+    float max_value() const { return max_; }
+
+    /// Step size for quantisation. Zero or negative = no quantisation
+    /// (any value in [min,max] is allowed). HTML default is 1, but the
+    /// pulp default is 0 because most plugin UIs want continuous values
+    /// and explicitly opt in via `step` when they want stepping.
+    void set_step(float v) { step_ = v; clamp_and_quantize_(); }
+    float step() const { return step_; }
+
+    /// Set the current value. The value is clamped to [min,max] and
+    /// quantised to the nearest step if step > 0.
+    void set_value(float v) {
+        value_ = v;
+        clamp_and_quantize_();
+    }
+    float value() const { return value_; }
+
+    void set_orientation(Orientation o) { orientation_ = o; }
+    Orientation orientation() const { return orientation_; }
+
+    /// Override the accent color for the active fill and handle. Empty
+    /// (the default) means the widget pulls `control.fill` / `control.thumb`
+    /// from the active theme.
+    void set_accent_color(canvas::Color c) {
+        accent_color_ = c;
+        has_accent_color_ = true;
+    }
+    void clear_accent_color() { has_accent_color_ = false; }
+    bool has_accent_color() const { return has_accent_color_; }
+    canvas::Color accent_color() const { return accent_color_; }
+
+    /// Track thickness in pixels (default 4). Anything in 4–6 matches
+    /// the visual weight of common HTML range styling.
+    void set_track_thickness(float t) { track_thickness_ = std::max(1.0f, t); }
+    float track_thickness() const { return track_thickness_; }
+
+    /// Fired when the value changes — from drag, click, or set_value(). The
+    /// callback receives the post-quantisation value, exactly the same
+    /// number value() will return.
+    std::function<void(float)> on_change;
+
+    void paint(canvas::Canvas& canvas) override;
+    void on_mouse_event(const MouseEvent& event) override;
+    void on_mouse_drag(Point pos) override;
+
+private:
+    /// Convert a position along the track (0=start, 1=end) to a value
+    /// after applying clamp + step quantisation.
+    float position_to_value_(float t) const;
+
+    /// Clamp value_ to [min_,max_] and snap it to the nearest step, then
+    /// fire on_change if the post-quantisation value actually changed.
+    void clamp_and_quantize_();
+
+    /// Common drag/click handler — `pos` is in local coordinates.
+    void update_from_position_(Point pos);
+
+    float min_ = 0.0f;
+    float max_ = 1.0f;
+    float step_ = 0.0f;
+    float value_ = 0.0f;
+    Orientation orientation_ = Orientation::horizontal;
+    bool dragging_ = false;
+    float track_thickness_ = 4.0f;
+    canvas::Color accent_color_{};
+    bool has_accent_color_ = false;
+};
+
 // ── Toggle ───────────────────────────────────────────────────────────────────
 // Boolean on/off switch
 

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -760,6 +760,14 @@ void WidgetBridge::wire_callbacks(const std::string& id, View* w) {
         t->on_toggle = [alive, engine, id](bool v) {
             safe_dispatch_eval(alive, engine, "__dispatch__('" + id + "', 'toggle', " + std::string(v?"1":"0") + ")", "toggle");
         };
+    } else if (auto* r = dynamic_cast<RangeSlider*>(w)) {
+        // pulp issue-966 — HTML <input type="range"> change event. The
+        // payload is the post-quantisation value (not normalised) so JS
+        // callers see the same number they handed us via setValue/setMin
+        // /setMax/setStep.
+        r->on_change = [alive, engine, id](float v) {
+            safe_dispatch_eval(alive, engine, "__dispatch__('" + id + "', 'change', " + std::to_string(v) + ")", "range slider change");
+        };
     }
 }
 
@@ -779,6 +787,7 @@ void WidgetBridge::snapshot_values(std::unordered_map<std::string, float>& out) 
     for (auto& [id, view] : widgets_) {
         if (auto* k = dynamic_cast<Knob*>(view)) out[id] = k->value();
         else if (auto* f = dynamic_cast<Fader*>(view)) out[id] = f->value();
+        else if (auto* r = dynamic_cast<RangeSlider*>(view)) out[id] = r->value();
         else if (auto* t = dynamic_cast<Toggle*>(view)) out[id] = t->is_on() ? 1.0f : 0.0f;
         else if (auto* cb = dynamic_cast<Checkbox*>(view)) out[id] = cb->is_checked() ? 1.0f : 0.0f;
         else if (auto* tb = dynamic_cast<ToggleButton*>(view)) out[id] = tb->is_on() ? 1.0f : 0.0f;
@@ -791,6 +800,7 @@ void WidgetBridge::restore_values(const std::unordered_map<std::string, float>& 
         if (it == widgets_.end()) continue;
         if (auto* k = dynamic_cast<Knob*>(it->second)) k->set_value(val);
         else if (auto* f = dynamic_cast<Fader*>(it->second)) f->set_value(val);
+        else if (auto* r = dynamic_cast<RangeSlider*>(it->second)) r->set_value(val);
         else if (auto* t = dynamic_cast<Toggle*>(it->second)) t->set_on(val > 0.5f);
         else if (auto* cb = dynamic_cast<Checkbox*>(it->second)) cb->set_checked(val > 0.5f);
         else if (auto* tb = dynamic_cast<ToggleButton*>(it->second)) tb->set_on(val > 0.5f);
@@ -801,6 +811,7 @@ void WidgetBridge::snapshot_values(WidgetReloadSnapshot& out) const {
     for (auto& [id, view] : widgets_) {
         if (auto* k = dynamic_cast<Knob*>(view)) out.scalar_values[id] = k->value();
         else if (auto* f = dynamic_cast<Fader*>(view)) out.scalar_values[id] = f->value();
+        else if (auto* r = dynamic_cast<RangeSlider*>(view)) out.scalar_values[id] = r->value();
         else if (auto* t = dynamic_cast<Toggle*>(view)) out.scalar_values[id] = t->is_on() ? 1.0f : 0.0f;
         else if (auto* cb = dynamic_cast<Checkbox*>(view)) out.scalar_values[id] = cb->is_checked() ? 1.0f : 0.0f;
         else if (auto* tb = dynamic_cast<ToggleButton*>(view)) out.scalar_values[id] = tb->is_on() ? 1.0f : 0.0f;
@@ -814,6 +825,7 @@ void WidgetBridge::restore_values(const WidgetReloadSnapshot& snapshot) {
         if (it == widgets_.end()) continue;
         if (auto* k = dynamic_cast<Knob*>(it->second)) k->set_value(val);
         else if (auto* f = dynamic_cast<Fader*>(it->second)) f->set_value(val);
+        else if (auto* r = dynamic_cast<RangeSlider*>(it->second)) r->set_value(val);
         else if (auto* t = dynamic_cast<Toggle*>(it->second)) t->set_on(val > 0.5f);
         else if (auto* cb = dynamic_cast<Checkbox*>(it->second)) cb->set_checked(val > 0.5f);
         else if (auto* tb = dynamic_cast<ToggleButton*>(it->second)) tb->set_on(val > 0.5f);
@@ -948,6 +960,27 @@ void WidgetBridge::register_api() {
         return choc::value::createString(id);
     });
 
+    // createRangeSlider(id, parentId)
+    // ─────────────────────────────────────────────────────────────────────
+    // pulp issue-966 — generic HTML <input type="range"> mapping.
+    // Distinct from createKnob (rotary) and createFader (DSP linear with
+    // decorative chrome). Default visual is a 4px rounded track + circular
+    // handle with the active half filled in the theme accent. After
+    // creation, callers can drive setMin/setMax/setStep/setValue/
+    // setOrientation/setAccentColor; quantisation lives inside the widget
+    // so JS sees the same value the renderer paints.
+    engine_.register_function("createRangeSlider", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto pid = args.get<std::string>(1, "");
+        auto rs = std::make_unique<RangeSlider>();
+        rs->set_id(id);
+        auto* ptr = rs.get();
+        widgets_[id] = ptr;
+        wire_callbacks(id, ptr);
+        resolve_parent(pid)->add_child(std::move(rs));
+        return choc::value::createString(id);
+    });
+
     // createIcon(id, type, parentId) — type: "image_upload", "send", "search", "close"
     engine_.register_function("createIcon", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
@@ -1052,7 +1085,10 @@ void WidgetBridge::register_api() {
     // (Old createFader/Toggle/Label registrations removed — replaced with
     // dual-API versions above that detect parent ID vs absolute positioning)
 
-    // setValue(id, value) -> set widget normalized value
+    // setValue(id, value) -> set widget value
+    // For Knob / Fader / Toggle this is normalised 0..1.
+    // For RangeSlider (issue-966) it's the raw value in [min,max] — the
+    // widget clamps + quantises against its own configured range.
     engine_.register_function("setValue", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto value = args.get<double>(1, 0);
@@ -1064,6 +1100,8 @@ void WidgetBridge::register_api() {
             knob->set_value(static_cast<float>(value));
         else if (auto* fader = dynamic_cast<Fader*>(it->second))
             fader->set_value(static_cast<float>(value));
+        else if (auto* range = dynamic_cast<RangeSlider*>(it->second))
+            range->set_value(static_cast<float>(value));
         else if (auto* toggle = dynamic_cast<Toggle*>(it->second))
             toggle->set_on(value > 0.5);
         else if (auto* cb = dynamic_cast<Checkbox*>(it->second))
@@ -1074,7 +1112,8 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
-    // getValue(id) -> get widget normalized value
+    // getValue(id) -> get widget value (normalised for Knob/Fader/Toggle,
+    // raw for RangeSlider).
     engine_.register_function("getValue", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
 
@@ -1085,10 +1124,93 @@ void WidgetBridge::register_api() {
             return choc::value::createFloat64(knob->value());
         if (auto* fader = dynamic_cast<Fader*>(it->second))
             return choc::value::createFloat64(fader->value());
+        if (auto* range = dynamic_cast<RangeSlider*>(it->second))
+            return choc::value::createFloat64(range->value());
         if (auto* toggle = dynamic_cast<Toggle*>(it->second))
             return choc::value::createFloat64(toggle->is_on() ? 1.0 : 0.0);
 
         return choc::value::createFloat64(0);
+    });
+
+    // ── pulp issue-966 — RangeSlider configuration setters ────────────────
+    // setMin/setMax/setStep mirror the HTMLInputElement attributes
+    // `min`, `max`, `step`. Each one re-applies the widget's clamp +
+    // quantisation pipeline so out-of-range values stay consistent.
+    engine_.register_function("setMin", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto v = args.get<double>(1, 0);
+        if (auto* range = dynamic_cast<RangeSlider*>(widget(id)))
+            range->set_min(static_cast<float>(v));
+        return choc::value::Value();
+    });
+
+    engine_.register_function("setMax", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto v = args.get<double>(1, 1);
+        if (auto* range = dynamic_cast<RangeSlider*>(widget(id)))
+            range->set_max(static_cast<float>(v));
+        return choc::value::Value();
+    });
+
+    engine_.register_function("setStep", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto v = args.get<double>(1, 0);
+        if (auto* range = dynamic_cast<RangeSlider*>(widget(id)))
+            range->set_step(static_cast<float>(v));
+        return choc::value::Value();
+    });
+
+    // setOrientation(id, "horizontal" | "vertical")
+    // Currently only RangeSlider (issue-966); future widgets that need
+    // an orientation can extend this dynamic_cast chain.
+    engine_.register_function("setOrientation", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto orient = args.get<std::string>(1, "horizontal");
+        auto* w = widget(id);
+        if (auto* range = dynamic_cast<RangeSlider*>(w)) {
+            range->set_orientation(orient == "vertical"
+                ? RangeSlider::Orientation::vertical
+                : RangeSlider::Orientation::horizontal);
+        } else if (auto* fader = dynamic_cast<Fader*>(w)) {
+            fader->set_orientation(orient == "horizontal"
+                ? Fader::Orientation::horizontal
+                : Fader::Orientation::vertical);
+        }
+        return choc::value::Value();
+    });
+
+    // setAccentColor(id, "#hex" | "rgb(...)" | "")
+    // Empty string clears the override and returns to the active theme's
+    // `control.fill` / `control.thumb` tokens.
+    engine_.register_function("setAccentColor", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto hex = args.get<std::string>(1, "");
+        if (auto* range = dynamic_cast<RangeSlider*>(widget(id))) {
+            if (hex.empty()) {
+                range->clear_accent_color();
+            } else {
+                // parseColor is defined later in register_api; we rebuild
+                // the same parser inline so the order of registrations
+                // doesn't matter. Hex paths cover the spec's overwhelming
+                // majority of usage; rgb()/named fall back to white.
+                canvas::Color c = canvas::Color::rgba(1.0f, 1.0f, 1.0f, 1.0f);
+                if (!hex.empty() && hex[0] == '#') {
+                    if (hex.size() == 4) {
+                        c.r = static_cast<float>(std::stoul(std::string(2, hex[1]), nullptr, 16)) / 255.0f;
+                        c.g = static_cast<float>(std::stoul(std::string(2, hex[2]), nullptr, 16)) / 255.0f;
+                        c.b = static_cast<float>(std::stoul(std::string(2, hex[3]), nullptr, 16)) / 255.0f;
+                    } else if (hex.size() >= 7) {
+                        c.r = static_cast<float>(std::stoul(hex.substr(1,2), nullptr, 16)) / 255.0f;
+                        c.g = static_cast<float>(std::stoul(hex.substr(3,2), nullptr, 16)) / 255.0f;
+                        c.b = static_cast<float>(std::stoul(hex.substr(5,2), nullptr, 16)) / 255.0f;
+                        if (hex.size() >= 9)
+                            c.a = static_cast<float>(std::stoul(hex.substr(7,2), nullptr, 16)) / 255.0f;
+                    }
+                }
+                range->set_accent_color(c);
+            }
+        }
+        return choc::value::Value();
     });
 
     // getParam(name) -> get parameter value from store (normalized)

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -750,6 +750,145 @@ void Fader::paint(canvas::Canvas& canvas) {
     }
 }
 
+// ── RangeSlider ──────────────────────────────────────────────────────────────
+// HTML <input type="range"> equivalent. Track + handle, no decorative
+// fader chrome. Min/max/step quantisation lives here so the painted
+// position and the value seen by JS callers always agree.
+//
+// pulp issue-966.
+
+void RangeSlider::clamp_and_quantize_() {
+    // Defensive: if max < min, treat the range as collapsed at min.
+    float lo = min_;
+    float hi = std::max(min_, max_);
+
+    float v = std::clamp(value_, lo, hi);
+
+    // Snap to step relative to min_, but only when step is positive.
+    // Step <= 0 means "continuous" — matches HTML <input step="any">.
+    if (step_ > 0.0f) {
+        float steps = std::round((v - lo) / step_);
+        v = lo + steps * step_;
+        // Re-clamp because rounding can push us past hi (e.g. min=0 max=1
+        // step=0.3 — last reachable step is 0.9, not 1.2).
+        v = std::clamp(v, lo, hi);
+    }
+
+    if (v != value_) {
+        value_ = v;
+        if (on_change) on_change(value_);
+    }
+}
+
+float RangeSlider::position_to_value_(float t) const {
+    float lo = min_;
+    float hi = std::max(min_, max_);
+    float clamped_t = std::clamp(t, 0.0f, 1.0f);
+    float v = lo + clamped_t * (hi - lo);
+
+    if (step_ > 0.0f) {
+        float steps = std::round((v - lo) / step_);
+        v = lo + steps * step_;
+        v = std::clamp(v, lo, hi);
+    }
+    return v;
+}
+
+void RangeSlider::update_from_position_(Point pos) {
+    auto b = local_bounds();
+    float t;
+    if (orientation_ == Orientation::horizontal) {
+        t = b.width > 0 ? pos.x / b.width : 0;
+    } else {
+        // Vertical: y=0 at top → t=1 (max); y=height → t=0 (min).
+        t = b.height > 0 ? 1.0f - pos.y / b.height : 0;
+    }
+    float new_val = position_to_value_(t);
+    if (new_val != value_) {
+        value_ = new_val;
+        if (on_change) on_change(value_);
+    }
+}
+
+void RangeSlider::on_mouse_event(const MouseEvent& event) {
+    if (!event.is_down) {
+        dragging_ = false;
+        return;
+    }
+    dragging_ = true;
+    update_from_position_(event.position);
+}
+
+void RangeSlider::on_mouse_drag(Point pos) {
+    if (!dragging_) return;
+    update_from_position_(pos);
+}
+
+void RangeSlider::paint(canvas::Canvas& canvas) {
+    auto b = local_bounds();
+    bool horiz = orientation_ == Orientation::horizontal;
+
+    // Resolve theme colors. Caller-supplied accent overrides theme for
+    // both the active fill and the handle.
+    auto track_color = resolve_color("control.track", canvas::Color::rgba8(60, 60, 60));
+    auto theme_fill  = resolve_color("control.fill",  canvas::Color::rgba8(100, 150, 255));
+    auto theme_thumb = resolve_color("control.thumb", canvas::Color::rgba8(220, 220, 220));
+    auto fill_color  = has_accent_color_ ? accent_color_ : theme_fill;
+    auto thumb_color = has_accent_color_ ? accent_color_ : theme_thumb;
+
+    // Track thickness — typical HTML range visuals sit in 4..6px.
+    float track_thick = std::min(track_thickness_,
+                                 horiz ? std::max(b.height, 1.0f)
+                                       : std::max(b.width,  1.0f));
+
+    // Normalised position along the track, taking the (possibly-collapsed)
+    // [min,max] range into account.
+    float lo = min_;
+    float hi = std::max(min_, max_);
+    float span = hi - lo;
+    float t = span > 0 ? std::clamp((value_ - lo) / span, 0.0f, 1.0f) : 0.0f;
+
+    // Background track.
+    canvas.set_fill_color(track_color);
+    if (horiz) {
+        float ty = (b.height - track_thick) * 0.5f;
+        canvas.fill_rounded_rect(0, ty, b.width, track_thick, track_thick * 0.5f);
+    } else {
+        float tx = (b.width - track_thick) * 0.5f;
+        canvas.fill_rounded_rect(tx, 0, track_thick, b.height, track_thick * 0.5f);
+    }
+
+    // Active fill — only the portion between min and current value.
+    canvas.set_fill_color(fill_color);
+    if (horiz) {
+        float fill_w = t * b.width;
+        float ty = (b.height - track_thick) * 0.5f;
+        if (fill_w > 0)
+            canvas.fill_rounded_rect(0, ty, fill_w, track_thick, track_thick * 0.5f);
+    } else {
+        float fill_h = t * b.height;
+        float tx = (b.width - track_thick) * 0.5f;
+        // Vertical: fill the lower portion (closer to min at the bottom).
+        if (fill_h > 0)
+            canvas.fill_rounded_rect(tx, b.height - fill_h, track_thick, fill_h, track_thick * 0.5f);
+    }
+
+    // Handle. Inset by handle radius so it never overshoots the bounds.
+    canvas.set_fill_color(thumb_color);
+    float handle_radius = horiz ? std::min(b.height, 16.0f) * 0.5f
+                                : std::min(b.width,  16.0f) * 0.5f;
+    if (horiz) {
+        float usable = std::max(0.0f, b.width - 2.0f * handle_radius);
+        float hx = handle_radius + t * usable;
+        canvas.fill_circle(hx, b.height * 0.5f, handle_radius);
+    } else {
+        float usable = std::max(0.0f, b.height - 2.0f * handle_radius);
+        // Vertical: t=0 → bottom (handle near max-y), t=1 → top.
+        float hy = handle_radius + (1.0f - t) * usable;
+        canvas.fill_circle(b.width * 0.5f, hy, handle_radius);
+    }
+}
+
 // ── Toggle ───────────────────────────────────────────────────────────────────
 
 void Toggle::paint(canvas::Canvas& canvas) {

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -98,6 +98,127 @@ TEST_CASE("WidgetBridge creates toggle from JS", "[view][bridge]") {
     REQUIRE(dynamic_cast<Toggle*>(w) != nullptr);
 }
 
+TEST_CASE("WidgetBridge creates range slider from JS",
+          "[view][bridge][issue-966]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createRangeSlider('morph', '');
+        setMin('morph', 0);
+        setMax('morph', 1);
+        setStep('morph', 0.001);
+        setValue('morph', 0.4);
+    )");
+
+    auto* w = bridge.widget("morph");
+    REQUIRE(w != nullptr);
+    auto* range = dynamic_cast<RangeSlider*>(w);
+    REQUIRE(range != nullptr);
+    REQUIRE_THAT(range->min_value(), WithinAbs(0.0, 0.0001));
+    REQUIRE_THAT(range->max_value(), WithinAbs(1.0, 0.0001));
+    REQUIRE_THAT(range->step(), WithinAbs(0.001, 0.0001));
+    // Quantised to nearest 0.001 — 0.4 is already a clean step.
+    REQUIRE_THAT(range->value(), WithinAbs(0.4, 0.001));
+}
+
+TEST_CASE("WidgetBridge range slider setOrientation and setAccentColor",
+          "[view][bridge][issue-966]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createRangeSlider('volume', '');
+        setOrientation('volume', 'vertical');
+        setAccentColor('volume', '#ff8844');
+    )");
+
+    auto* range = dynamic_cast<RangeSlider*>(bridge.widget("volume"));
+    REQUIRE(range != nullptr);
+    REQUIRE(range->orientation() == RangeSlider::Orientation::vertical);
+    REQUIRE(range->has_accent_color());
+
+    auto c = range->accent_color();
+    // #ff8844 → r≈1.0, g≈0.533, b≈0.267
+    REQUIRE_THAT(c.r, WithinAbs(1.0, 0.01));
+    REQUIRE_THAT(c.g, WithinAbs(0.533, 0.02));
+    REQUIRE_THAT(c.b, WithinAbs(0.267, 0.02));
+
+    // Empty hex clears the override.
+    bridge.load_script("setAccentColor('volume', '')");
+    REQUIRE_FALSE(range->has_accent_color());
+}
+
+TEST_CASE("WidgetBridge range slider get/setValue round-trip",
+          "[view][bridge][issue-966]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createRangeSlider('scrub', '');
+        setMin('scrub', 0);
+        setMax('scrub', 100);
+        setStep('scrub', 5);
+        setValue('scrub', 47);
+    )");
+
+    auto* range = dynamic_cast<RangeSlider*>(bridge.widget("scrub"));
+    REQUIRE(range != nullptr);
+    // 47 quantised to step=5 → 45.
+    REQUIRE_THAT(range->value(), WithinAbs(45.0, 0.0001));
+
+    auto js_val = engine.evaluate("getValue('scrub')").getWithDefault<double>(-1);
+    REQUIRE_THAT(js_val, WithinAbs(45.0, 0.0001));
+}
+
+TEST_CASE("WidgetBridge range slider drag dispatches change event",
+          "[view][bridge][issue-966]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // The bridge dispatches via __dispatch__, which the script wires to
+    // a JS-side recorder. Confirms the dispatch path actually fires —
+    // matching the same pattern Knob/Fader callbacks use.
+    bridge.load_script(R"(
+        var changes = [];
+        __dispatch__ = function(id, type, value) {
+            changes.push({id: id, type: type, value: value});
+        };
+        createRangeSlider('scrub', '');
+        setMin('scrub', 0);
+        setMax('scrub', 1);
+    )");
+
+    auto* range = dynamic_cast<RangeSlider*>(bridge.widget("scrub"));
+    REQUIRE(range != nullptr);
+    range->set_bounds({0, 0, 200, 24});
+
+    // Simulate a click in the middle of the track.
+    MouseEvent ev;
+    ev.position = {100, 12};
+    ev.is_down = true;
+    range->on_mouse_event(ev);
+
+    auto count = engine.evaluate("changes.length").getWithDefault<double>(0);
+    REQUIRE(count >= 1);
+    auto type = engine.evaluate("changes[0].type").getWithDefault<std::string>("");
+    REQUIRE(type == "change");
+    auto val = engine.evaluate("changes[0].value").getWithDefault<double>(-1);
+    REQUIRE_THAT(val, WithinAbs(0.5, 0.05));
+}
+
 TEST_CASE("WidgetBridge creates modal overlay from JS", "[view][bridge]") {
     ScriptEngine engine;
     View root;

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -369,6 +369,195 @@ TEST_CASE("Fader horizontal orientation", "[view][widget]") {
     REQUIRE(canvas.count(DrawCommand::Type::fill_circle) == 1);
 }
 
+// ── RangeSlider (pulp issue-966) ────────────────────────────────────────────
+
+TEST_CASE("RangeSlider default state matches HTML <input type=\"range\">",
+          "[view][widget][issue-966]") {
+    RangeSlider rs;
+    REQUIRE_THAT(rs.min_value(), WithinAbs(0.0, 0.0001));
+    REQUIRE_THAT(rs.max_value(), WithinAbs(1.0, 0.0001));
+    // Default step is 0 (continuous) — HTML defaults to 1 but plugins
+    // overwhelmingly want continuous values. Callers opt into stepping.
+    REQUIRE_THAT(rs.step(), WithinAbs(0.0, 0.0001));
+    REQUIRE_THAT(rs.value(), WithinAbs(0.0, 0.0001));
+    REQUIRE(rs.orientation() == RangeSlider::Orientation::horizontal);
+    REQUIRE_FALSE(rs.has_accent_color());
+}
+
+TEST_CASE("RangeSlider clamps value to [min,max]", "[view][widget][issue-966]") {
+    RangeSlider rs;
+    rs.set_min(-1.0f);
+    rs.set_max(1.0f);
+
+    rs.set_value(2.0f);
+    REQUIRE_THAT(rs.value(), WithinAbs(1.0, 0.0001));
+
+    rs.set_value(-5.0f);
+    REQUIRE_THAT(rs.value(), WithinAbs(-1.0, 0.0001));
+
+    rs.set_value(0.5f);
+    REQUIRE_THAT(rs.value(), WithinAbs(0.5, 0.0001));
+}
+
+TEST_CASE("RangeSlider quantises to step", "[view][widget][issue-966]") {
+    RangeSlider rs;
+    rs.set_min(0.0f);
+    rs.set_max(1.0f);
+    rs.set_step(0.1f);
+
+    rs.set_value(0.34f);
+    REQUIRE_THAT(rs.value(), WithinAbs(0.3, 0.0001));
+
+    rs.set_value(0.36f);
+    REQUIRE_THAT(rs.value(), WithinAbs(0.4, 0.0001));
+
+    // Step that doesn't divide the range cleanly: max reachable step
+    // before exceeding hi must clamp back inside the range.
+    rs.set_step(0.3f);
+    rs.set_value(1.0f);
+    REQUIRE(rs.value() <= 1.0f + 1e-5f);
+    REQUIRE(rs.value() >= 0.0f);
+}
+
+TEST_CASE("RangeSlider step=0 means continuous", "[view][widget][issue-966]") {
+    RangeSlider rs;
+    rs.set_min(0.0f);
+    rs.set_max(100.0f);
+    rs.set_step(0.0f);
+    rs.set_value(33.7f);
+    REQUIRE_THAT(rs.value(), WithinAbs(33.7, 0.0001));
+}
+
+TEST_CASE("RangeSlider re-clamps when bounds change", "[view][widget][issue-966]") {
+    RangeSlider rs;
+    rs.set_min(0.0f);
+    rs.set_max(10.0f);
+    rs.set_value(7.0f);
+    REQUIRE_THAT(rs.value(), WithinAbs(7.0, 0.0001));
+
+    // Tighten the upper bound — the existing value falls outside and
+    // must snap back.
+    rs.set_max(5.0f);
+    REQUIRE_THAT(rs.value(), WithinAbs(5.0, 0.0001));
+
+    // Raise the lower bound past the value — same idea in the other
+    // direction.
+    rs.set_min(6.0f);
+    REQUIRE_THAT(rs.value(), WithinAbs(6.0, 0.0001));
+}
+
+TEST_CASE("RangeSlider invalid range collapses to min", "[view][widget][issue-966]") {
+    RangeSlider rs;
+    rs.set_min(10.0f);
+    rs.set_max(0.0f);  // invalid: max < min
+    rs.set_value(5.0f);
+    // Per HTMLInputElement: invalid range pins value to min.
+    REQUIRE_THAT(rs.value(), WithinAbs(10.0, 0.0001));
+}
+
+TEST_CASE("RangeSlider drag dispatches change with quantised value",
+          "[view][widget][issue-966]") {
+    RangeSlider rs;
+    rs.set_bounds({0, 0, 200, 24});
+    rs.set_min(0.0f);
+    rs.set_max(1.0f);
+    rs.set_step(0.25f);
+
+    std::vector<float> changes;
+    rs.on_change = [&](float v) { changes.push_back(v); };
+
+    // Mouse-down at x=100 (50% across) → expected snap to 0.5.
+    MouseEvent down;
+    down.position = {100, 12};
+    down.is_down = true;
+    rs.on_mouse_event(down);
+
+    REQUIRE(changes.size() == 1);
+    REQUIRE_THAT(changes.back(), WithinAbs(0.5, 0.0001));
+    REQUIRE_THAT(rs.value(), WithinAbs(0.5, 0.0001));
+
+    // Drag to x=180 (90%) → should snap to 1.0.
+    rs.on_mouse_drag({180, 12});
+    REQUIRE_THAT(rs.value(), WithinAbs(1.0, 0.0001));
+    REQUIRE(changes.size() >= 2);
+    REQUIRE_THAT(changes.back(), WithinAbs(1.0, 0.0001));
+
+    // Drag to x=10 (5%) → should snap to 0.
+    rs.on_mouse_drag({10, 12});
+    REQUIRE_THAT(rs.value(), WithinAbs(0.0, 0.0001));
+
+    // Mouse up → dragging stops; subsequent drags must not move value.
+    MouseEvent up = down; up.is_down = false;
+    rs.on_mouse_event(up);
+    rs.on_mouse_drag({180, 12});
+    REQUIRE_THAT(rs.value(), WithinAbs(0.0, 0.0001));
+}
+
+TEST_CASE("RangeSlider vertical orientation maps y correctly",
+          "[view][widget][issue-966]") {
+    RangeSlider rs;
+    rs.set_bounds({0, 0, 24, 200});
+    rs.set_orientation(RangeSlider::Orientation::vertical);
+    rs.set_min(0.0f);
+    rs.set_max(1.0f);
+
+    // y=0 is top → max value (1.0).
+    MouseEvent ev;
+    ev.position = {12, 0};
+    ev.is_down = true;
+    rs.on_mouse_event(ev);
+    REQUIRE_THAT(rs.value(), WithinAbs(1.0, 0.0001));
+
+    // y=200 is bottom → min value (0.0).
+    rs.on_mouse_drag({12, 200});
+    REQUIRE_THAT(rs.value(), WithinAbs(0.0, 0.0001));
+
+    // y=100 → halfway = 0.5.
+    rs.on_mouse_drag({12, 100});
+    REQUIRE_THAT(rs.value(), WithinAbs(0.5, 0.001));
+}
+
+TEST_CASE("RangeSlider renders track + fill + handle",
+          "[view][widget][issue-966]") {
+    RangeSlider rs;
+    rs.set_bounds({0, 0, 200, 24});
+    rs.set_value(0.5f);
+
+    RecordingCanvas canvas;
+    rs.paint(canvas);
+
+    // Track + active fill = 2 rounded rects, handle = 1 circle.
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) == 2);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_circle) == 1);
+}
+
+TEST_CASE("RangeSlider at minimum draws track but skips empty fill",
+          "[view][widget][issue-966]") {
+    RangeSlider rs;
+    rs.set_bounds({0, 0, 200, 24});
+    rs.set_value(0.0f);  // exactly at min — no active fill to draw
+
+    RecordingCanvas canvas;
+    rs.paint(canvas);
+
+    // Only the background track rounded rect — fill is zero-width and
+    // skipped. Handle still renders.
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_circle) == 1);
+}
+
+TEST_CASE("RangeSlider accent color overrides theme fill",
+          "[view][widget][issue-966]") {
+    RangeSlider rs;
+    rs.set_bounds({0, 0, 100, 20});
+    rs.set_value(0.6f);
+    rs.set_accent_color(Color::rgba8(255, 64, 32, 255));
+    REQUIRE(rs.has_accent_color());
+
+    rs.clear_accent_color();
+    REQUIRE_FALSE(rs.has_accent_color());
+}
+
 TEST_CASE("Toggle state", "[view][widget]") {
     Toggle toggle;
     REQUIRE_FALSE(toggle.is_on());


### PR DESCRIPTION
Adds a generic min/max/step slider that maps cleanly to HTML
`<input type="range">`. Distinct from Knob (rotary, normalised 0..1)
and Fader (DSP linear with decorative chrome) — RangeSlider is the
plain rectangular track + circular handle the web uses for volume,
morph sliders, and scrubbers. Spectr's MorphSlider previously fell
back to TextEditor in dom-adapter because no widget primitive
matched; this gives the dom-adapter a real target.

## Widget API (core/view/include/pulp/view/widgets.hpp)

  RangeSlider rs;
  rs.set_min(0); rs.set_max(1); rs.set_step(0.001);
  rs.set_value(0.42);
  rs.set_orientation(RangeSlider::Orientation::vertical);
  rs.set_accent_color(canvas::Color::rgba8(255, 64, 32));
  rs.on_change = [](float v) { /* post-quantisation value */ };

Quantisation lives inside the widget, not the bridge: clamp to
[min,max], snap to nearest step (skipped when step <= 0 to match
HTML <input step="any">), then re-clamp because rounding can push
past hi (min=0 max=1 step=0.3 → max reachable step is 0.9, not
1.2). Invalid range (max < min) collapses to min, matching
HTMLInputElement behaviour. Bound changes re-run the same
pipeline so existing values stay consistent.

paint() draws a 4px rounded track + active fill on the active half
+ circular handle (inset by handle radius so it stays in bounds).
Theme tokens are `control.track` / `control.fill` / `control.thumb`;
set_accent_color() overrides fill + thumb together. Vertical
orientation maps y=0 → max value, y=height → min value, matching
HTML range semantics.

## JS bridge (core/view/src/widget_bridge.cpp)

  createRangeSlider(id, parentId)
  setMin(id, n)
  setMax(id, n)
  setStep(id, n)
  setValue(id, n)             — extended existing setValue
  setOrientation(id, "horizontal" | "vertical")
  setAccentColor(id, "#hex" | "")

setValue / getValue gained a new dynamic_cast branch for
RangeSlider so existing callers keep working. setOrientation also
covers Fader (it already had orientation support but no JS hook).
Empty-string accent clears the override and returns to the active
theme. wire_callbacks dispatches the post-quantisation value via
__dispatch__('id', 'change', value), matching the Knob/Fader
contract. snapshot_values / restore_values were extended so UI
state survives script reloads.

## Tests

- test/test_widgets.cpp — 11 new cases / 35 assertions covering:
  default state, value clamping, step quantisation (including the
  "step doesn't divide range cleanly" edge case), step=0 means
  continuous, re-clamp on bound change, invalid range collapse,
  drag dispatch + drag-after-mouse-up, vertical orientation y-mapping,
  paint emit order, zero-width fill skip at minimum, accent color
  override + clear.
- test/test_widget_bridge.cpp — 4 new cases / 20 assertions covering:
  createRangeSlider + setters round-trip, orientation + accent
  color via JS (with #hex parsing), get/setValue with quantisation,
  drag dispatch via __dispatch__ JS callback.

All 60 widget tests pass (215 assertions). All 72 widget_bridge
tests pass (503 assertions). No new compiler warnings.

## Acceptance status (issue #966)

- [x] createRangeSlider(id, parentId) registered
- [x] setMin / setMax / setStep / setValue / setOrientation /
      setAccentColor setters
- [x] change event dispatches via __dispatch__ as a JS number
- [x] test/test_widgets.cpp + test/test_widget_bridge.cpp cover
      drag dispatch, set value sync, min/max/step quantisation
- [x] Quantisation enforced in the widget itself, not the bridge
- [x] Default visual: 4px rounded track, circular handle, accent
      fill on active half, theme-token defaults
      (control.track / control.fill / control.thumb)
- [x] Horizontal AND vertical orientations