### PR TITLE
fix(view): on(id,'click',fn) auto-wires View::on_click (pulp #1006)

### DIFF
--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -460,16 +460,60 @@ struct WidgetBridge::NativeGpuBridgeState {
     uint64_t next_texture_id = 1;
 };
 
+// pulp #1006 — `on(id, eventName, fn)` is the JS-side hook that callers
+// (notably @pulp/react's prop-applier turning JSX `onClick={fn}` into a
+// bridge subscription) use to register event callbacks. Storing the fn
+// in __callbacks__ is necessary but not sufficient: events that the
+// native side fires through View::on_click / on_hover_enter /
+// on_pointer_event require an explicit `registerClick(id)` /
+// `registerHover(id)` / `registerPointer(id)` to wire the View
+// callback. Without that wiring real NSEvent / Win32 / X11 clicks
+// reach View::on_mouse_down/up but never trigger __dispatch__('click'),
+// so the JS handler never runs.
+//
+// The fix: when JS subscribes to a known event name, transparently
+// invoke the matching native registrar (idempotent per (id, group)
+// via __nativeRegistered__). This mirrors what
+// Element.prototype._registerNativeEvent does for addEventListener
+// callers, but on the lower-level `on()` channel that @pulp/react and
+// other native bridges use directly.
 static const char* kJSPreamble = R"(
 var __callbacks__ = {};
+var __nativeRegistered__ = {};
 function __dispatch__(id, eventName) {
     var key = id + ':' + eventName;
     if (__callbacks__[key]) {
         __callbacks__[key].apply(null, Array.prototype.slice.call(arguments, 2));
     }
 }
+function __ensureNativeRegistered__(id, group) {
+    var key = id + ':' + group;
+    if (__nativeRegistered__[key]) return;
+    __nativeRegistered__[key] = true;
+    if (group === 'click' && typeof registerClick === 'function') {
+        registerClick(id);
+    } else if (group === 'hover' && typeof registerHover === 'function') {
+        registerHover(id);
+    } else if (group === 'pointer' && typeof registerPointer === 'function') {
+        registerPointer(id);
+    } else if (group === 'gesture' && typeof registerGesture === 'function') {
+        registerGesture(id);
+    }
+}
 function on(id, eventName, fn) {
     __callbacks__[id + ':' + eventName] = fn;
+    if (eventName === 'click' || eventName === 'mousedown' || eventName === 'mouseup') {
+        __ensureNativeRegistered__(id, 'click');
+    } else if (eventName === 'mouseenter' || eventName === 'mouseleave' ||
+               eventName === 'pointerenter' || eventName === 'pointerleave') {
+        __ensureNativeRegistered__(id, 'hover');
+    } else if (eventName === 'pointerdown' || eventName === 'pointermove' ||
+               eventName === 'pointerup' || eventName === 'pointercancel') {
+        __ensureNativeRegistered__(id, 'pointer');
+    } else if (eventName === 'gesturestart' || eventName === 'gesturechange' ||
+               eventName === 'gestureend') {
+        __ensureNativeRegistered__(id, 'gesture');
+    }
 }
 )";
 

--- a/test/test_view_host_bridge_mac.mm
+++ b/test/test_view_host_bridge_mac.mm
@@ -5,7 +5,10 @@
 #import <Cocoa/Cocoa.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <pulp/state/store.hpp>
+#include <pulp/view/script_engine.hpp>
 #include <pulp/view/view.hpp>
+#include <pulp/view/widget_bridge.hpp>
 #include <pulp/view/window_host.hpp>
 
 #include <chrono>
@@ -149,6 +152,114 @@ TEST_CASE("PulpView mouseUp survives mouseDown handler that unmounts the target"
         // `view_is_in_tree` check rejects the dangling pointer and the
         // up event drops cleanly.
         REQUIRE_NOTHROW([contentView mouseUp:up]);
+
+        host->hide();
+    }
+}
+
+// pulp #1006 — full integration: a JSX `onClick={fn}` flows through
+// @pulp/react's prop-applier into a bare `on(id, 'click', fn)` bridge
+// call (no addEventListener, no explicit registerClick). A real
+// NSLeftMouseDown + NSLeftMouseUp pair on the contentView must reach
+// the JS handler. Pre-#1006 the bridge stored the callback in
+// __callbacks__ but never wired View::on_click, so post-#992 mouseUp
+// found `_dragTarget->on_click == nullptr` and silently dropped the
+// click — the user-facing symptom that every <RailBtn onClick=...>
+// stayed dead in Spectr.
+TEST_CASE("PulpView NSEvent click dispatches JS on(id,'click') subscriber",
+          "[view][hosts][bridge][issue-1006]") {
+    @autoreleasepool {
+        [NSApplication sharedApplication];
+
+        View root;
+        WindowOptions opts;
+        opts.title = "PulpView issue-1006";
+        opts.width = 200.0f;
+        opts.height = 100.0f;
+        opts.resizable = false;
+        opts.use_gpu = false;
+
+        auto host = WindowHost::create(root, opts);
+        REQUIRE(host != nullptr);
+        // hit_test walks the live bounds; the host only resizes the
+        // root during paint, so set bounds up front so the synthetic
+        // event lands on the child without depending on a paint cycle.
+        root.set_bounds({0, 0, 200, 100});
+
+        pulp::state::StateStore store;
+        pulp::view::ScriptEngine engine;
+        pulp::view::WidgetBridge bridge(engine, root, store);
+
+        // createCol → child View added to root with the given id; the
+        // subsequent `on('clear', 'click', fn)` is exactly the call the
+        // @pulp/react prop-applier emits for `<RailBtn onClick={fn}>`.
+        // Pin a preferred size so Yoga doesn't shrink the child to 0
+        // during paint-driven layout (test stays deterministic).
+        bridge.load_script(R"(
+            var clicks = 0;
+            createCol('clear', '');
+            setFlex('clear', 'width', 200);
+            setFlex('clear', 'height', 100);
+            on('clear', 'click', function() { clicks += 1; });
+        )");
+
+        auto* child_ptr = bridge.widget("clear");
+        REQUIRE(child_ptr != nullptr);
+
+        host->show();
+        auto* nswindow = (__bridge NSWindow*)host->native_window_handle();
+        REQUIRE(nswindow != nil);
+        auto* contentView = nswindow.contentView;
+        REQUIRE(contentView != nil);
+
+        for (int i = 0; i < 20; ++i) {
+            [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.005]];
+        }
+
+        const NSPoint local = NSMakePoint(40.0, 50.0);
+        const NSPoint window_pt = [contentView convertPoint:local toView:nil];
+
+        NSEvent* down = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                                           location:window_pt
+                                      modifierFlags:0
+                                          timestamp:0
+                                       windowNumber:nswindow.windowNumber
+                                            context:nil
+                                        eventNumber:0
+                                         clickCount:1
+                                           pressure:1.0];
+        NSEvent* up = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp
+                                         location:window_pt
+                                    modifierFlags:0
+                                        timestamp:0
+                                     windowNumber:nswindow.windowNumber
+                                          context:nil
+                                      eventNumber:0
+                                       clickCount:1
+                                         pressure:0.0];
+
+        // Sanity: hit_test must find the child under the click point;
+        // otherwise mouseDown sets _dragTarget=nullptr and mouseUp has
+        // no view to dispatch the click to.
+        {
+            auto* target = root.hit_test({static_cast<float>(local.x),
+                                          static_cast<float>(local.y)});
+            REQUIRE(target == child_ptr);
+        }
+
+        [contentView mouseDown:down];
+        [contentView mouseUp:up];
+
+        // mouseUp queues the click handler via dispatch_async on the
+        // main queue (post-#992). Drain the run loop until it fires.
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+        int clicks = 0;
+        while (clicks == 0 && std::chrono::steady_clock::now() < deadline) {
+            [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+            clicks = engine.evaluate("clicks").getWithDefault<int>(0);
+        }
+
+        REQUIRE(clicks == 1);
 
         host->hide();
     }

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -288,6 +288,88 @@ TEST_CASE("WidgetBridge stale click callbacks are inert after bridge destruction
     REQUIRE_NOTHROW(global_click_handler("button", 0x10));
 }
 
+// pulp #1006 — JSX `onClick={fn}` flows through @pulp/react's prop-applier
+// into a bare `on(id, 'click', fn)` bridge call (no addEventListener,
+// no registerClick). Before the fix, this stored the JS callback in
+// __callbacks__ but never wired View::on_click on the native side, so
+// real NSEvent / Win32 mouse events fired View::on_mouse_down/up but
+// never dispatched 'click' through the bridge — the React handler
+// silently dropped on the floor.
+TEST_CASE("WidgetBridge on(id,'click',fn) auto-wires View::on_click", "[view][bridge][issue-1006]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var clicks = 0;
+        createToggleButton('clear', '');
+        on('clear', 'click', function() { clicks += 1; });
+    )");
+
+    auto* button = bridge.widget("clear");
+    REQUIRE(button != nullptr);
+
+    // The smoking gun: without the fix, `View::on_click` is empty and
+    // the deferred mac-host dispatch (which reads exactly this field
+    // post-#992) has nothing to call. With the fix, `on()` delegates
+    // to registerClick(id), which installs the native callback that
+    // emits __dispatch__('clear', 'click', 0).
+    REQUIRE(static_cast<bool>(button->on_click));
+
+    // Drive the native callback directly to verify it routes through
+    // __dispatch__ to the JS subscriber registered above.
+    button->on_click();
+    REQUIRE(engine.evaluate("clicks").getWithDefault<int>(-1) == 1);
+
+    // The full mouse-down/up path through the View should also fire
+    // the JS handler exactly once (matches mac-host mouseUp path that
+    // calls `click_handler()` after view_is_in_tree validation).
+    button->on_mouse_down({4, 4});
+    button->on_mouse_up({4, 4});
+    button->on_click();
+    REQUIRE(engine.evaluate("clicks").getWithDefault<int>(-1) == 2);
+}
+
+// pulp #1006 — repeated `on(id, 'click', fn)` calls (which @pulp/react
+// performs on every commitUpdate) must remain idempotent on the native
+// side. registerClick is overwriting-by-design (it stores its lambda
+// on view->on_click), but registerPointer chains (each call wraps the
+// previous handler). The auto-wire in `on()` guards re-registration
+// via __nativeRegistered__ so pointer events don't grow an O(N) chain.
+TEST_CASE("WidgetBridge on() native registration is idempotent", "[view][bridge][issue-1006]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var pointer_events = 0;
+        createCol('panel', '');
+        on('panel', 'pointerdown', function() { pointer_events += 1; });
+        on('panel', 'pointerdown', function() { pointer_events += 1; });
+        on('panel', 'pointerdown', function() { pointer_events += 1; });
+    )");
+
+    auto* panel = bridge.widget("panel");
+    REQUIRE(panel != nullptr);
+    REQUIRE(static_cast<bool>(panel->on_pointer_event));
+
+    MouseEvent down;
+    down.position = {10, 10};
+    down.is_down = true;
+    panel->on_pointer_event(down);
+
+    // Three subscriptions but each call to on() overwrites the
+    // __callbacks__ slot, so a single dispatch fires once. If the
+    // pointer chain wasn't guarded, this would grow with each
+    // re-registration into a multi-fire chain.
+    auto count = engine.evaluate("pointer_events").getWithDefault<int>(-1);
+    REQUIRE(count == 1);
+}
+
 TEST_CASE("WidgetBridge getLayoutRect accounts for scroll offsets", "[view][bridge][layout]") {
     ScriptEngine engine;
     View root;


### PR DESCRIPTION
Real NSEvent / Win32 / X11 clicks survived the post-#992 mouseUp guard
but their JSX onClick handlers never fired. The bridge's `on()`
preamble stored the JS callback in __callbacks__ but never invoked
the matching native registrar (registerClick / registerHover /
registerPointer / registerGesture), so View::on_click stayed
nullptr and the macOS mouseUp deferred-dispatch had nothing to
call. addEventListener callers got the right wiring through
Element.prototype._registerNativeEvent, but @pulp/react's
prop-applier (the JSX onClick={fn} → bridge call site) goes
through the lower-level on() channel directly and bypassed it.

Auto-register the native side from on() for the four event groups
that need it, gated by __nativeRegistered__ to keep registerPointer
(which chains on_pointer_event) idempotent across the per-commit
re-subscriptions @pulp/react performs.

Tests:
- WidgetBridge on(id,'click',fn) auto-wires View::on_click
- WidgetBridge on() native registration is idempotent
- PulpView NSEvent click dispatches JS on(id,'click') subscriber
  (full integration: NSLeftMouseDown + NSLeftMouseUp on a real
  PulpView contentView fires the JS handler exactly once)