### PR TITLE
chore: bump versions to v0.66.0 (catches up after #1008)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.65.0
+    VERSION 0.66.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Why

#1008 (`fix(view): on(id,'click',fn) auto-wires View::on_click` — closes pulp#1006) merged on 2026-04-30 02:36Z **without a `chore: bump versions` co-commit**. Auto-release.yml correctly saw no version change and decided not to tag, so the fix is on `main` but unreleased — no tag, no SDK tarball.

Auto-release run: https://github.com/danielraffel/pulp/actions/runs/25144447906 (logs show `SDK_AFTER: 0.65.0`, `SDK_SHOULD_TAG: 0`)

## What this PR does

Bumps SDK 0.65.0 → 0.66.0 so auto-release fires and tags v0.66.0, which triggers release-cli.yml to publish pulp-sdk-darwin-arm64.tar.gz.

## Why this is needed

Spectr (consumer-zero for the React-bridge port) is blocked on validating clicks end-to-end because the SDK still publishes as v0.65.0. The click-dispatch fix is exactly what we need to flip dropdowns / SETTINGS / PRESETS from "render-correct, interaction-dead" to "fully interactive."

## Structural fix

Filed #1009 to harden the release pipeline so this never happens silently again — `version-skill-check.yml` should hard-fail user-facing PRs that lack a version bump, and branch protection should require it. This PR is the manual catch-up; #1009 closes the structural gap.

## Test plan

- Auto-release.yml fires on merge → tags v0.66.0
- release-cli.yml builds and publishes pulp-sdk-darwin-arm64.tar.gz
- Spectr bumps SDK pin to v0.66.0 and validates click dispatch end-to-end