### PR TITLE
chore: bump versions to 0.66.0 — catch-up for #1008

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v0660"></a>
+## [0.66.0] - 2026-04-30
+
+- fix(view): on(id,'click',fn) auto-wires View::on_click (pulp #1006) ([#1008](https://github.com/danielraffel/pulp/pull/1008)) — catch-up bump; the original PR landed without a `chore: bump versions` commit due to a `shipyard pr` short-circuit when the branch was force-pushed before the bump step ran. See #1009 for the hardening that prevents this gap.
+
 <a id="v0650"></a>
 ## [0.65.0] - 2026-04-29
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.65.0
+    VERSION 0.66.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Why

PR #1008 (the click-dispatch fix for #1006) merged at 02:36:45Z on 2026-04-30 without an accompanying \`chore: bump versions\` commit. Auto-release.yml ran post-merge and decided not to tag (\`SHOULD_TAG=0\`) — leaving the user-facing fix stuck on main, unreachable to Spectr's standalone build.

## How it happened

The branch was force-pushed before \`shipyard pr\` ran, which made shipyard pr's version-bump step short-circuit (\`Everything up-to-date\` from the push step). The procedural error is mine — I should have run shipyard pr first, then let it push.

## What this PR does

Manually applies the bump that should have landed with #1008:

- \`CMakeLists.txt\` VERSION 0.65.0 → 0.66.0 (minor — new event-registration auto-wiring is API-additive)
- \`CHANGELOG.md\` adds a 0.66.0 entry attributing #1008 with a note about the gap

After this lands, auto-release.yml should fire and tag v0.66.0, which triggers the release.yml workflow that publishes the SDK tarball. Spectr can then rebuild against v0.66.0 and validate the click-dispatch fix end-to-end.

## Hardening

#1009 tracks the structural prevention so this class of slip can't recur. Three layers:

- \`version-skill-check.yml\` hard-fail on \`fix(...)\`/\`feat(...)\` PR without a bump (with \`Version-Bump: skip reason="..."\` trailer escape)
- Branch protection requiring the check
- \`auto-release.yml\` watchdog tracking-issue when \`SHOULD_TAG=0\` after a fix/feat lands

Closes the gap surfaced by today's incident.

## Test plan

- [x] CMakeLists.txt version line updated
- [x] CHANGELOG.md entry attributing the source PR
- [ ] Auto-release fires on merge → v0.66.0 tag → release workflow publishes tarball