### PR TITLE
fix(view): register canvasFillRect bridge name (pulp #964)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v0660"></a>
+## [0.66.0] - 2026-04-30
+
+- fix(view): on(id,'click',fn) auto-wires View::on_click (pulp #1006) ([#1008](https://github.com/danielraffel/pulp/pull/1008)) — landed without a bump commit due to a `shipyard pr` short-circuit; this bump rolls it into the same release as #964
+- fix(view): register canvasFillRect bridge name so HTML5 ctx.fillRect() reaches the bridge (pulp #964) — JS-side bridge name mismatch; the web-compat shim called `canvasFillRect` but the bridge only registered `canvasRect`, so every `ctx.fillRect()` silently no-op'd. Both names now register the same handler.
+
 <a id="v0650"></a>
 ## [0.65.0] - 2026-04-29
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.65.0
+    VERSION 0.66.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2500,7 +2500,21 @@ void WidgetBridge::register_api() {
         return c;
     };
 
-    engine_.register_function("canvasRect", [this, parseColor](choc::javascript::ArgumentList args) {
+    // pulp #964 — Two registered names for the same handler:
+    //   * `canvasRect`     — legacy direct-bridge name used by hand-written
+    //                        examples (`canvasRect(id, x, y, w, h, "#fff")`).
+    //   * `canvasFillRect` — the name the HTML5 Canvas2D shim emits for
+    //                        `ctx.fillRect()` (see core/view/js/web-compat-canvas.js).
+    // Pre-#964 only `canvasRect` was registered, so every `ctx.fillRect()`
+    // from the web-compat shim silently no-op'd at the typeof guard
+    // (`if (typeof canvasFillRect === "function")`). That dropped every
+    // full-bounds opaque fillRect — e.g. the Spectr FilterBank's clear-to-
+    // background fill — without surfacing any error. Path-based draws
+    // (`canvasFillPath`, `canvasStrokePath`) and `canvasStrokeRect` happened
+    // to be wired correctly so they kept working, which is why the bug
+    // looked like "compositing eats the canvas surface" instead of
+    // "fillRect is silently dropped".
+    auto canvasRectHandler = [this, parseColor](choc::javascript::ArgumentList args) {
         if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {
             CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::fill_rect;
             cmd.x=(float)args.get<double>(1,0); cmd.y=(float)args.get<double>(2,0);
@@ -2508,7 +2522,7 @@ void WidgetBridge::register_api() {
             // pulp #968 — when no color arg was passed (or it was the empty
             // string), honour the active fillStyle (color OR gradient) on
             // the canvas widget. This makes a JS shim like
-            //   fillRect(x,y,w,h) { call('canvasRect', id, x,y,w,h); }
+            //   fillRect(x,y,w,h) { call('canvasFillRect', id, x,y,w,h); }
             // behave like the Canvas2D spec — `ctx.fillRect` paints with
             // whatever `ctx.fillStyle` was last set to, including a
             // CanvasGradient. With 6+ args the explicit color wins.
@@ -2521,7 +2535,9 @@ void WidgetBridge::register_api() {
             c->add_command(cmd);
         }
         return choc::value::Value();
-    });
+    };
+    engine_.register_function("canvasRect", canvasRectHandler);
+    engine_.register_function("canvasFillRect", canvasRectHandler);
 
     engine_.register_function("canvasStrokeRect", [this, parseColor](choc::javascript::ArgumentList args) {
         if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -808,3 +808,128 @@ TEST_CASE("CanvasWidget stroke_rect with use_active_style preserves prior set_st
                         && stroke_at_draw.b8() == 0 && stroke_at_draw.a8() == 255);
     REQUIRE(is_green);
 }
+
+// ── pulp #964 — `ctx.fillRect()` from web-compat-canvas.js must reach the bridge ──
+//
+// Pre-#964, `core/view/js/web-compat-canvas.js` defined
+//   CanvasRenderingContext2D.prototype.fillRect = function(x, y, w, h) {
+//       this._applyFillStyle();
+//       if (typeof canvasFillRect === "function") canvasFillRect(this._id, x, y, w, h);
+//   };
+// but the WidgetBridge only registered `canvasRect`, not `canvasFillRect`.
+// The `typeof` guard then short-circuited every fillRect invocation — silently.
+// `canvasStrokeRect`, `canvasFillPath`, and `canvasStrokePath` were registered
+// under their natural names so they kept working, which is what made the bug
+// look like a Skia compositing failure: a Canvas2D scene that mixed paths
+// (visible) and fillRects (invisible) produced partial output.
+//
+// Contract: the bridge must register both `canvasFillRect` (the web-compat
+// shim's name) and `canvasRect` (the legacy direct-bridge name used by
+// hand-written examples) so neither path silently drops fills.
+
+#include <pulp/view/script_engine.hpp>
+#include <pulp/view/widget_bridge.hpp>
+
+TEST_CASE("WidgetBridge: canvasFillRect bridges ctx.fillRect to a fill_rect command",
+          "[canvas_widget][bridge][issue-964]") {
+    pulp::view::ScriptEngine engine;
+    pulp::view::View root;
+    root.set_bounds({0, 0, 200, 100});
+    pulp::state::StateStore store;
+    pulp::view::WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createCanvas('cv', '');
+        canvasFillRect('cv', 5, 7, 40, 30, '#ff0000');
+    )");
+
+    auto* cw = dynamic_cast<CanvasWidget*>(bridge.widget("cv"));
+    REQUIRE(cw != nullptr);
+    REQUIRE(cw->command_count() == 1);
+
+    // Replay onto a RecordingCanvas and verify a single fill_rect with the
+    // correct geometry and colour landed.
+    RecordingCanvas rc;
+    cw->paint(rc);
+
+    int fill_rect_count = 0;
+    pulp::canvas::Color last_fill{};
+    bool saw_correct_geom = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::set_fill_color) {
+            last_fill = cmd.color;
+            continue;
+        }
+        if (cmd.type == DrawCommand::Type::fill_rect) {
+            ++fill_rect_count;
+            const bool matches = (cmd.f[0] == 5.0f && cmd.f[1] == 7.0f &&
+                                  cmd.f[2] == 40.0f && cmd.f[3] == 30.0f);
+            if (matches) saw_correct_geom = true;
+        }
+    }
+    REQUIRE(fill_rect_count == 1);
+    REQUIRE(saw_correct_geom);
+    REQUIRE(last_fill.r8() == 255);
+    REQUIRE(last_fill.g8() == 0);
+    REQUIRE(last_fill.b8() == 0);
+    REQUIRE(last_fill.a8() == 255);
+}
+
+TEST_CASE("WidgetBridge: HTML5 ctx.fillRect via web-compat shim reaches the bridge",
+          "[canvas_widget][bridge][issue-964]") {
+    // The user-facing path: a JS author writes `ctx.fillRect(...)`. The
+    // web-compat-canvas.js prelude installs CanvasRenderingContext2D, the
+    // shim's fillRect calls canvasFillRect, the bridge dispatches to a
+    // CanvasDrawCmd::fill_rect on the widget. Pre-#964 this whole chain
+    // silently produced zero commands.
+    pulp::view::ScriptEngine engine;
+    pulp::view::View root;
+    root.set_bounds({0, 0, 200, 100});
+    pulp::state::StateStore store;
+    pulp::view::WidgetBridge bridge(engine, root, store);
+
+    // Build a minimal Canvas element via the DOM-ish bridge surface, then
+    // exercise the actual `ctx.fillRect()` path the FilterBank scenario
+    // hits in production.
+    bridge.load_script(R"JS(
+        // Manually create a CanvasWidget bridged element. createCanvas binds
+        // the C++ widget; the web-compat shim wraps it in a JS Element-like
+        // object so getContext('2d') returns a real CanvasRenderingContext2D.
+        createCanvas('cv', '');
+        // The web-compat layer expects an Element with _id; fabricate the
+        // smallest viable one so getContext('2d') and the prototype chain
+        // see the canvas widget.
+        var el = { _id: 'cv', tagName: 'CANVAS' };
+        // The Canvas2D shim references Element.prototype.getContext, so
+        // borrow the prototype method directly.
+        var ctx = Element.prototype.getContext.call(el, '2d');
+        ctx.fillStyle = '#00ff00';
+        ctx.fillRect(10, 10, 80, 40);
+    )JS");
+
+    auto* cw = dynamic_cast<CanvasWidget*>(bridge.widget("cv"));
+    REQUIRE(cw != nullptr);
+    // Pre-fix the shim's fillRect produces zero commands. The fix wires
+    // canvasFillRect at the bridge so the call is actually recorded.
+    REQUIRE(cw->command_count() >= 1);
+
+    RecordingCanvas rc;
+    cw->paint(rc);
+
+    bool saw_green_full_fill = false;
+    pulp::canvas::Color active_fill{};
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::set_fill_color) {
+            active_fill = cmd.color;
+            continue;
+        }
+        if (cmd.type != DrawCommand::Type::fill_rect) continue;
+        const bool matches = (cmd.f[0] == 10.0f && cmd.f[1] == 10.0f &&
+                              cmd.f[2] == 80.0f && cmd.f[3] == 40.0f);
+        if (!matches) continue;
+        const bool is_green = (active_fill.r8() == 0 && active_fill.g8() == 255 &&
+                               active_fill.b8() == 0 && active_fill.a8() == 255);
+        if (is_green) saw_green_full_fill = true;
+    }
+    REQUIRE(saw_green_full_fill);
+}


### PR DESCRIPTION
The web-compat Canvas2D shim in core/view/js/web-compat-canvas.js
calls `canvasFillRect(id, x, y, w, h)` for `ctx.fillRect()`, but the
WidgetBridge only registered `canvasRect`. The shim's `typeof` guard
silently short-circuited every fillRect invocation — no error, no
log, no command queued.

Path-based draws (`canvasFillPath`/`canvasStrokePath`) and
`canvasStrokeRect` were registered under their natural names, so
they kept working. A Canvas2D scene that mixed paths and fillRects
produced partial output, which is what made the bug look like a
Skia compositing failure (paths visible, rects invisible) instead
of a silent JS-bridge name mismatch.

Repro: Spectr's FilterBank used `ctx.fillRect()` to clear and to
stamp the diagnostic background. The path-based curve fills landed
correctly, but every fillRect was dropped. The user's three-way
bisect probe — an opaque red full-bounds `ctx.fillRect()` injected
at the top of the canvas2D render fn — was invisible, which
isolated the bug to the bridge layer downstream of JS.

Fix: register the same handler under both `canvasRect` (legacy
direct-bridge name used by examples/) and `canvasFillRect` (the
shim's name). Tests in test_canvas_widget.cpp [issue-964]:

  1. Direct call: `canvasFillRect('cv', x, y, w, h, '#ff0000')`
     reaches the widget as a fill_rect command with the right
     geometry and colour.
  2. End-to-end: `Element.prototype.getContext.call(el, '2d')`
     followed by `ctx.fillStyle = '#00ff00'; ctx.fillRect(...)`
     produces a green full-bounds fill_rect — the actual user
     path through the web-compat shim.

Both tests fail without the fix (test 1 throws on the unknown JS
function; test 2 records zero commands), pass with it. All 17 cases
in pulp-test-canvas-widget pass; pulp-test-view, pulp-test-widget-
bridge, pulp-test-widgets, pulp-test-typography-inheritance, pulp-
test-svg-path-widget, pulp-test-view-bridge, and pulp-test-view-
host-bridge all green.