### PR TITLE
test(cli): cover update check parser edges

### DIFF
--- a/test/test_cli_update_check.cpp
+++ b/test/test_cli_update_check.cpp
@@ -176,6 +176,30 @@ TEST_CASE("parse_semver handles common shapes", "[cli][update-check][issue-547]"
     REQUIRE_FALSE(d.ok);
 }
 
+TEST_CASE("parse_semver tolerates release tag boundaries",
+          "[cli][update-check][issue-547][issue-643]") {
+    auto upper = uc::parse_semver("V2.4.6");
+    REQUIRE(upper.ok);
+    REQUIRE(upper.major == 2);
+    REQUIRE(upper.minor == 4);
+    REQUIRE(upper.patch == 6);
+
+    auto build = uc::parse_semver("1.2.3+build.7");
+    REQUIRE(build.ok);
+    REQUIRE(build.major == 1);
+    REQUIRE(build.minor == 2);
+    REQUIRE(build.patch == 3);
+
+    auto extra = uc::parse_semver("3.4.5.6");
+    REQUIRE(extra.ok);
+    REQUIRE(extra.major == 3);
+    REQUIRE(extra.minor == 4);
+    REQUIRE(extra.patch == 5);
+
+    REQUIRE_FALSE(uc::parse_semver("1.two.3").ok);
+    REQUIRE_FALSE(uc::parse_semver("1..3").ok);
+}
+
 TEST_CASE("is_newer compares correctly", "[cli][update-check][issue-547]") {
     REQUIRE(uc::is_newer("0.27.0", "0.28.0"));
     REQUIRE(uc::is_newer("0.27.0", "1.0.0"));
@@ -237,6 +261,32 @@ TEST_CASE("write_toml_key_in_section appends key to existing section",
     REQUIRE(uc::read_toml_key_in_section(out, "update", "check_interval_hours") == "12");
     REQUIRE(uc::read_toml_key_in_section(out, "update", "mode") == "prompt");
     REQUIRE(uc::read_toml_key_in_section(out, "create", "projects_dir") == "~/dev");
+}
+
+TEST_CASE("write_toml_key_in_section respects adjacent sections and inline section comments",
+          "[cli][update-check][issue-547][issue-643]") {
+    std::string src =
+        "[update] # user preferences\n"
+        "\n"
+        "[create]\n"
+        "projects_dir = \"~/dev\"\n";
+
+    auto out = uc::write_toml_key_in_section(src, "update", "mode", "manual");
+    REQUIRE(uc::read_toml_key_in_section(out, "update", "mode") == "manual");
+    REQUIRE(uc::read_toml_key_in_section(out, "create", "projects_dir") == "~/dev");
+
+    auto update_pos = out.find("[update]");
+    auto mode_pos = out.find("mode = \"manual\"");
+    auto create_pos = out.find("[create]");
+    REQUIRE(update_pos != std::string::npos);
+    REQUIRE(mode_pos != std::string::npos);
+    REQUIRE(create_pos != std::string::npos);
+    REQUIRE(update_pos < mode_pos);
+    REQUIRE(mode_pos < create_pos);
+
+    auto replaced = uc::write_toml_key_in_section(out, "update", "mode", "off");
+    REQUIRE(uc::read_toml_key_in_section(replaced, "update", "mode") == "off");
+    REQUIRE(replaced.find("mode = \"manual\"") == std::string::npos);
 }
 
 TEST_CASE("read_toml_key_in_section ignores commented examples",

--- a/tools/cli/update_check.cpp
+++ b/tools/cli/update_check.cpp
@@ -301,7 +301,9 @@ std::vector<std::string> split_lines(const std::string& s) {
 }
 
 bool line_is_section_header(const std::string& line, std::string* section_out) {
-    auto t = trim(line);
+    auto hash = line.find('#');
+    auto effective = (hash == std::string::npos) ? line : line.substr(0, hash);
+    auto t = trim(effective);
     if (t.size() < 2 || t.front() != '[' || t.back() != ']') return false;
     auto name = trim(t.substr(1, t.size() - 2));
     if (section_out) *section_out = name;


### PR DESCRIPTION
Parent: #643
Umbrella: #641

## Scope
- Covers tolerant update-check release tag parsing boundaries: uppercase `V`, build metadata, extra dotted components, and invalid dotted forms.
- Makes TOML section-header detection tolerate inline comments, matching existing key-line comment tolerance.
- Adds coverage for adjacent-section writes so `[update]` edits do not bleed into `[create]`.
- Updates only `tools/cli/update_check.cpp` and `test/test_cli_update_check.cpp`.

## Validation
- `cmake --build build --target pulp-test-cli-update-check -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-cli-update-check` (83 assertions / 17 cases)
- `./build/test/pulp-test-cli-update-check "[issue-643]"` (23 assertions / 2 cases)
- `ctest --test-dir build -R "update-cache|parse_cache_json|write_cache_file|read_cache_file|is_cache_stale|parse_semver|compose_banner|write_toml_key|read_toml_key|refresh_cache|banner_shown" --output-on-failure` (16/16 passed)
- `git diff --check`
- `PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`

## CI
Opened through `shipyard pr` with local mac/ubuntu/windows targets deliberately skipped per the Namespace-first workflow; PR-triggered Namespace/GitHub checks are the merge evidence.