### PR TITLE
test(cli): cover tooling edge paths

### DIFF
--- a/test/test_cli_fetchcontent_cache.cpp
+++ b/test/test_cli_fetchcontent_cache.cpp
@@ -14,6 +14,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <map>
@@ -55,6 +56,34 @@ fcc::DiscoveryEnv make_mock_env(const fs::path& root,
         return state.children;
     };
     return env;
+}
+
+std::string json_escape_for_test(const std::string& in) {
+    std::string out;
+    for (unsigned char c : in) {
+        switch (c) {
+            case '"': out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x",
+                                  static_cast<unsigned int>(c));
+                    out += buf;
+                } else {
+                    out += static_cast<char>(c);
+                }
+        }
+    }
+    return out;
+}
+
+std::string json_field_fragment(const std::string& key,
+                                const std::string& value) {
+    return "\"" + key + "\": \"" + json_escape_for_test(value) + "\"";
 }
 
 }  // namespace
@@ -613,13 +642,15 @@ TEST_CASE("render_report_json: escapes control characters in entry fields",
     CHECK(fcc::render_report_json({e}, fs::path("/fake/cache") / weird, out) == 0);
     auto s = out.str();
 
-    CHECK(s.find("\"cache_root\": \"/fake/cache/dep\\n\\t\\u0001\\\"\\\\suffix\"")
+    CHECK(s.find(json_field_fragment("cache_root",
+                                     (fs::path("/fake/cache") / weird).string()))
           != std::string::npos);
     CHECK(s.find("\"name\": \"dep\\n\\t\\u0001\\\"\\\\suffix\"")
           != std::string::npos);
-    CHECK(s.find("\"path\": \"/fake/cache/dep\\n\\t\\u0001\\\"\\\\suffix\"")
+    CHECK(s.find(json_field_fragment("path", e.path.string()))
           != std::string::npos);
-    CHECK(s.find("\"resolved_target\": \"/tmp/dep\\n\\t\\u0001\\\"\\\\suffix\"")
+    CHECK(s.find(json_field_fragment("resolved_target",
+                                     e.resolved_target.string()))
           != std::string::npos);
     CHECK(s.find("\"declared_ref\": \"dep\\n\\t\\u0001\\\"\\\\suffix\"")
           != std::string::npos);

--- a/test/test_cli_fetchcontent_cache.cpp
+++ b/test/test_cli_fetchcontent_cache.cpp
@@ -239,6 +239,33 @@ TEST_CASE("discover: missing cache root returns empty and renders OK",
     CHECK(out.str().find("no entries") != std::string::npos);
 }
 
+TEST_CASE("discover: lstat miss reports Unknown and blocks preflight",
+          "[fetchcontent_cache][issue-643]") {
+    fs::path root = "/fake/cache";
+    fs::path entry = root / "choc-f0f5cdf5a938b8b779fea6c083571cce5ccab925";
+    MockState state;
+    state.children = {entry};
+
+    fcc::DeclaredRefs refs{
+        {"choc", "f0f5cdf5a938b8b779fea6c083571cce5ccab925"}};
+    auto env = make_mock_env(root, refs, state);
+
+    auto entries = fcc::discover_fetchcontent_cache(env);
+    REQUIRE(entries.size() == 1);
+    CHECK(entries[0].status == fcc::CacheStatus::Unknown);
+    CHECK_FALSE(entries[0].fixable);
+    CHECK(entries[0].reason == "lstat failed");
+    CHECK(entries[0].remediation.find("ls -la") != std::string::npos);
+    CHECK(fcc::any_unhealthy(entries));
+    CHECK(fcc::blocks_preflight(entries));
+
+    std::stringstream out;
+    int rc = fcc::render_preflight(entries, root, out);
+    CHECK(rc == 1);
+    CHECK(out.str().find("unknown") != std::string::npos);
+    CHECK(out.str().find("lstat failed") != std::string::npos);
+}
+
 // ── apply_fixes: dry-run skips real I/O ─────────────────────────────────────
 
 TEST_CASE("apply_fixes: dry-run reports DryRun for fixable entries",
@@ -563,6 +590,47 @@ TEST_CASE("render_report_json: healthy fixture reports healthy=true",
     CHECK(fcc::render_report_json(entries, root, out) == 0);
     CHECK_FALSE(fcc::any_unhealthy(entries));
     CHECK(out.str().find("\"healthy\": true") != std::string::npos);
+}
+
+TEST_CASE("render_report_json: escapes control characters in entry fields",
+          "[fetchcontent_cache][issue-643]") {
+    std::string weird = std::string("dep\n\t") + char(0x01) + "\"\\suffix";
+
+    fcc::CacheEntry e;
+    e.name = weird;
+    e.path = fs::path("/fake/cache") / weird;
+    e.status = fcc::CacheStatus::Dangling;
+    e.is_symlink = true;
+    e.resolved_target = fs::path("/tmp") / weird;
+    e.declared_ref = weird;
+    e.cached_ref = weird;
+    e.dep_name = weird;
+    e.reason = weird;
+    e.remediation = weird;
+    e.fixable = true;
+
+    std::stringstream out;
+    CHECK(fcc::render_report_json({e}, fs::path("/fake/cache") / weird, out) == 0);
+    auto s = out.str();
+
+    CHECK(s.find("\"cache_root\": \"/fake/cache/dep\\n\\t\\u0001\\\"\\\\suffix\"")
+          != std::string::npos);
+    CHECK(s.find("\"name\": \"dep\\n\\t\\u0001\\\"\\\\suffix\"")
+          != std::string::npos);
+    CHECK(s.find("\"path\": \"/fake/cache/dep\\n\\t\\u0001\\\"\\\\suffix\"")
+          != std::string::npos);
+    CHECK(s.find("\"resolved_target\": \"/tmp/dep\\n\\t\\u0001\\\"\\\\suffix\"")
+          != std::string::npos);
+    CHECK(s.find("\"declared_ref\": \"dep\\n\\t\\u0001\\\"\\\\suffix\"")
+          != std::string::npos);
+    CHECK(s.find("\"cached_ref\": \"dep\\n\\t\\u0001\\\"\\\\suffix\"")
+          != std::string::npos);
+    CHECK(s.find("\"dep_name\": \"dep\\n\\t\\u0001\\\"\\\\suffix\"")
+          != std::string::npos);
+    CHECK(s.find("\"reason\": \"dep\\n\\t\\u0001\\\"\\\\suffix\"")
+          != std::string::npos);
+    CHECK(s.find("\"remediation\": \"dep\\n\\t\\u0001\\\"\\\\suffix\"")
+          != std::string::npos);
 }
 
 // ── default_cache_root respects PULP_SHARED_FETCHCONTENT_SOURCE_DIR ────────

--- a/test/test_cli_tool_registry.cpp
+++ b/test/test_cli_tool_registry.cpp
@@ -117,6 +117,14 @@ fs::path touch_file(const fs::path& path) {
     return path;
 }
 
+std::string system_shell_tool_id() {
+#ifdef _WIN32
+    return "cmd.exe";
+#else
+    return "sh";
+#endif
+}
+
 std::string quote_json(const std::string& s) {
     std::string out;
     out.reserve(s.size() + 2);
@@ -317,6 +325,13 @@ TEST_CASE("tool lookup prefers pulp-managed binaries and python wrappers",
     auto located_missing = locate_tool(missing);
     REQUIRE_FALSE(located_missing.found);
     REQUIRE(located_missing.source == "not-found");
+
+    ToolDescriptor system_shell;
+    system_shell.id = system_shell_tool_id();
+    auto located_system = locate_tool(system_shell);
+    REQUIRE(located_system.found);
+    REQUIRE(located_system.source == "system-path");
+    REQUIRE_FALSE(located_system.path.empty());
 }
 
 TEST_CASE("tool install helpers have deterministic local exits",
@@ -401,6 +416,29 @@ TEST_CASE("tool install helpers have deterministic local exits",
     REQUIRE(existing_py.ok);
     REQUIRE(existing_py.binary_path == wrapper);
     REQUIRE(existing_py.installed_version == py.pinned_version);
+
+    ToolRegistry uv_unavailable;
+    ToolDescriptor uv_without_source;
+    uv_without_source.id = "uv";
+    uv_without_source.display_name = "UV";
+    uv_without_source.install_method = "binary_download";
+    uv_without_source.pinned_version = "9.9.9";
+    uv_unavailable.tools["uv"] = uv_without_source;
+    {
+        ScopedEnv path{"PATH", tmp.path / "empty-path"};
+        ScopedOutput output;
+        auto uv_bootstrap_failed = install_python_tool(py, uv_unavailable, /*force=*/false);
+        REQUIRE_FALSE(uv_bootstrap_failed.ok);
+        REQUIRE(output.out.str().find("Installing UV") != std::string::npos);
+        REQUIRE(uv_bootstrap_failed.error.find("Failed to install UV: UV is not available for ") ==
+                0);
+    }
+
+    fs::remove(wrapper);
+    auto missing_wrapper = install_python_tool(py, with_uv, /*force=*/false);
+    REQUIRE_FALSE(missing_wrapper.ok);
+    REQUIRE(missing_wrapper.binary_path == wrapper);
+    REQUIRE(missing_wrapper.installed_version == py.pinned_version);
 }
 
 TEST_CASE("tool uninstall removes managed binary and python tool roots",
@@ -486,6 +524,12 @@ TEST_CASE("tool command handles local list path doctor and error branches",
 
     {
         ScopedOutput output;
+        REQUIRE(cmd_tool({"path", "missing-cmd"}) == 1);
+        REQUIRE(output.err.str().find("Tool 'missing-cmd' not found") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
         REQUIRE(cmd_tool({"doctor"}) == 1);
         REQUIRE(output.out.str().find("Managed Command") != std::string::npos);
         REQUIRE(output.out.str().find(std::string("not available for ") + platform) !=
@@ -542,6 +586,62 @@ TEST_CASE("tool command handles local list path doctor and error branches",
     }
 }
 
+TEST_CASE("tool command reports and runs system path tools",
+          "[cli][tool-registry][command][issue-643]") {
+    TempDir tmp;
+    ScopedEnv home{"PULP_HOME", tmp.path / "home"};
+    fs::create_directories(tmp.path / "repo" / "tools" / "packages");
+    ScopedCurrentPath cwd{tmp.path / "repo"};
+
+    const auto shell_id = system_shell_tool_id();
+    write_file(tmp.path / "repo" / "tools" / "packages" / "tool-registry.json",
+               std::string(R"({
+  "schema_version": 1,
+  "tools": {
+    ")") + quote_json(shell_id) + R"(": {
+      "display_name": "System Shell",
+      "description": "Known shell on PATH",
+      "install_method": "binary_download",
+      "pinned_version": "1.0.0"
+    }
+  }
+}
+)");
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"list"}) == 0);
+        REQUIRE(output.out.str().find("system (") != std::string::npos);
+        REQUIRE(output.out.str().find(shell_id) != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"path", shell_id}) == 0);
+        REQUIRE(output.out.str().find(shell_id) != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"doctor"}) == 0);
+        REQUIRE(output.out.str().find("System Shell") != std::string::npos);
+        REQUIRE(output.out.str().find("system-path") != std::string::npos);
+    }
+
+    {
+        ScopedOutput output;
+#ifdef _WIN32
+        REQUIRE(cmd_tool({"run", shell_id, "/c",
+                          "echo tool-system-out&& echo tool-system-err 1>&2&& exit /b 7"}) == 7);
+#else
+        REQUIRE(cmd_tool({"run", shell_id, "-c",
+                          "printf tool-system-out; printf tool-system-err >&2; exit 7"}) == 7);
+#endif
+        REQUIRE(output.out.str().find("tool-system-out") != std::string::npos);
+        REQUIRE(output.err.str().find("tool-system-err") != std::string::npos);
+    }
+}
+
 TEST_CASE("tool command reports registry and argument failures deterministically",
           "[cli][tool-registry][command][issue-643]") {
     TempDir tmp;
@@ -565,17 +665,32 @@ TEST_CASE("tool command reports registry and argument failures deterministically
                 std::string::npos);
     }
 
+    const auto platform = quote_json(current_platform_key());
     write_file(repo / "tools" / "packages" / "tool-registry.json",
                std::string(R"({
   "schema_version": 1,
   "tools": {
+    "needs-unavailable-dep": {
+      "display_name": "Needs Unavailable Dependency",
+      "description": "Dependency failure fixture",
+      "install_method": "binary_download",
+      "pinned_version": "1.0.0",
+      "requires_tools": ["unavailable-tool"],
+      "binary_sources": {
+        ")" + platform + R"(": {
+          "url_template": "https://example.invalid/needs-dep-${version}.tar.gz",
+          "archive_format": "tar.gz",
+          "binary_name": "needs-unavailable-dep"
+        }
+      }
+    },
     "available-tool-fixture": {
       "display_name": "Available Tool",
       "description": "Available but not installed",
       "install_method": "binary_download",
       "pinned_version": "1.0.0",
       "binary_sources": {
-        ")") + quote_json(current_platform_key()) + R"(": {
+        ")") + platform + R"(": {
           "url_template": "https://example.invalid/available-${version}.tar.gz",
           "archive_format": "tar.gz",
           "binary_name": "available-tool-fixture"
@@ -628,6 +743,17 @@ TEST_CASE("tool command reports registry and argument failures deterministically
         REQUIRE(output.err.str().find(std::string("is not available for ") +
                                       current_platform_key()) != std::string::npos);
     }
+    {
+        ScopedOutput output;
+        REQUIRE(cmd_tool({"install", "needs-unavailable-dep"}) == 1);
+        REQUIRE(output.err.str().find("Failed to install dependency unavailable-tool") !=
+                std::string::npos);
+    }
+    auto available_path = managed_binary_path(pulp_home(), "available-tool-fixture", "1.0.0",
+                                              "available-tool-fixture");
+    touch_file(available_path);
+    write_file(available_path.parent_path() / "manifest.json",
+               "{\"version\":\"1.0.0\",\"tool_id\":\"available-tool-fixture\"}\n");
     {
         ScopedOutput output;
         REQUIRE(cmd_tool({"install", "--all"}) == 1);

--- a/test/test_cli_version_diag.cpp
+++ b/test/test_cli_version_diag.cpp
@@ -514,6 +514,53 @@ TEST_CASE("render_report_json exposes plugin_min_cli as a top-level field",
     REQUIRE(out.find("Claude plugin requires") != std::string::npos);
 }
 
+TEST_CASE("render_report returns non-zero and prints plugin/project warnings",
+          "[version-diag][issue-643]") {
+    VersionReport r;
+    r.cli = parse_semver("0.20.0");
+    r.plugin = parse_semver("0.8.0");
+    r.plugin_min_cli = parse_semver("0.31.0");
+    r.project_sdk = parse_semver("0.24.0");
+    r.project_cli_min = parse_semver("0.25.0");
+    r.project_root = "/tmp/pulp-render-warn";
+    r.plugin_json_path = "/tmp/pulp-render-warn/plugin.json";
+
+    std::stringstream capture;
+    auto* prev = std::cout.rdbuf(capture.rdbuf());
+    int rc = render_report(r);
+    std::cout.rdbuf(prev);
+
+    REQUIRE(rc == 1);
+    auto out = capture.str();
+    REQUIRE(out.find("Pulp Version Diagnostics") != std::string::npos);
+    REQUIRE(out.find("Plugin:") != std::string::npos);
+    REQUIRE(out.find("needs CLI >= v0.31.0") != std::string::npos);
+    REQUIRE(out.find("WARN") != std::string::npos);
+    REQUIRE(out.find("Claude plugin requires CLI >= v0.31.0") != std::string::npos);
+    REQUIRE(out.find("Project requires CLI >= v0.25.0") != std::string::npos);
+    REQUIRE(out.find("Project SDK is v0.24.0") != std::string::npos);
+    REQUIRE(out.find("3 warnings") != std::string::npos);
+}
+
+TEST_CASE("render_report returns zero for an empty comparable report",
+          "[version-diag][issue-643]") {
+    VersionReport r;
+    r.cli = parse_semver("0.31.0");
+
+    std::stringstream capture;
+    auto* prev = std::cout.rdbuf(capture.rdbuf());
+    int rc = render_report(r);
+    std::cout.rdbuf(prev);
+
+    REQUIRE(rc == 0);
+    auto out = capture.str();
+    REQUIRE(out.find("CLI:") != std::string::npos);
+    REQUIRE(out.find("v0.31.0") != std::string::npos);
+    REQUIRE(out.find("No version information to compare.") != std::string::npos);
+    REQUIRE(out.find("All checks passed.") != std::string::npos);
+    REQUIRE(out.find("WARN") == std::string::npos);
+}
+
 TEST_CASE("render_report_json emits JSON with projects[] and findings[]",
           "[version-diag][issue-552]") {
     // Capture std::cout via a redirected rdbuf so we can test without


### PR DESCRIPTION
Parent: #643
Umbrella: #641

## Scope
- Covers `pulp tool` registry/path/run/install edge branches, including system PATH fallback, missing path lookup, Python UV bootstrap failure, missing wrapper cache state, and dependency install failure.
- Covers FetchContent cache lstat-miss preflight blocking plus JSON escaping for control characters.
- Covers version diagnostics human renderer warning and no-comparable-info paths.

## Validation
- `cmake --build build --target pulp-test-cli-tool-registry pulp-test-cli-fetchcontent-cache pulp-test-cli-version-diag -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-cli-tool-registry`
- `./build/test/pulp-test-cli-fetchcontent-cache`
- `./build/test/pulp-test-cli-version-diag`
- `ctest --test-dir build -R "tool registry|tool lookup|tool install|tool uninstall|tool command|lstat miss|escapes control|render_report returns" --output-on-failure`
- `git diff --check`

## CI
Queued for the repository GitHub/Namespace checks. Local VM shipyard targets were deliberately skipped for this Codecov tranche.