### PR TITLE
fix(view): wire CanvasRenderingContext2D shim to record save/transform/gradient/path commands (pulp #964)

### DIFF
--- a/.agents/skills/engine/SKILL.md
+++ b/.agents/skills/engine/SKILL.md
@@ -47,10 +47,11 @@ for React 18 dev. Add new files to `core/view/CMakeLists.txt`'s
 `core/view/src/widget_bridge.cpp` (`embed_js.cmake` only embeds the
 constants; the bridge constructor evaluates them).
 
-### Canvas2D surface coverage (issue-916)
+### Canvas2D surface coverage (issue-916, issue-964)
 
 `web-compat-canvas.js` exposes `CanvasRenderingContext2D.prototype`
-with the standard methods plus the gap-list closures from issue-916:
+with the standard methods plus the gap-list closures from issue-916
+and the FilterBank-parity additions from issue-964:
 
 | Method | Notes |
 |--------|-------|
@@ -59,6 +60,45 @@ with the standard methods plus the gap-list closures from issue-916:
 | `setLineDash([…])` / `getLineDash()` | Even-length patterns are taken verbatim; odd-length patterns are duplicated per the HTML5 spec. Phase comes from `lineDashOffset`. |
 | `getImageData(x,y,w,h)` | Returns `{data: Uint8ClampedArray, width, height}`. The bridge currently returns zero-filled pixels (no live surface handle from JS-call context); consumers that need real pixels should round-trip through a render-host integration. |
 | `putImageData(img, dx, dy)` | Decodes the typed array to base64 across the bridge and applies via `Canvas::write_pixels` on backends that implement it (Skia today). |
+| `save()` / `restore()` (#964) | Forward to `canvasSave` / `canvasRestore`. JS-side caches of last-pushed text/line/global state are invalidated on save so the next draw re-pushes — the bridge captures the matching state on the C++ side via SkCanvas::save. |
+| `translate` / `scale` / `rotate` / `setTransform` / `resetTransform` / `transform` (#964) | Forward to `canvasTranslate` / `canvasScale` / `canvasRotate` / `canvasSetTransform`. `transform` is best-effort: pure translation forwards to `canvasTranslate`; other matrices are silently dropped (the bridge has no concat primitive). `setTransform` accepts the (a,b,c,d,e,f) form and the single-DOMMatrix form. |
+| `arc(cx,cy,r,a0,a1,ccw)` / `ellipse` (#964) | Approximated as cubic-Bezier segments (4-segment unit-circle scaling) so the path participates in `fill()` / `stroke()` / `clip()`. `arcTo` is a conservative two-segment lineTo approximation — sufficient for rounded marquee corners, not fidelity-critical. |
+| `bezierCurveTo` / `quadraticCurveTo` / `rect` / `roundRect` (#964) | Forward to `canvasCubicTo` / `canvasQuadTo` / repeated `canvasLineTo`. `rect` emits an explicit closing lineTo back to the start so the resulting subpath is closed. `roundRect` honours the uniform-radius case; non-uniform `radii[]` falls back to `radii[0]`. |
+| `clip(fillRule)` (#964) | Calls `canvasClip` (issue-896 path-based clip). The fill rule is dropped — Pulp's bridge currently ignores even-odd vs nonzero, matching SkCanvas defaults. |
+| `fillText(text,x,y)` / `strokeText` (#964) | `fillText` syncs global / text state and forwards to `canvasFillText` with the active fillStyle's colour (or first gradient stop). `strokeText` falls back to `fillText` with the strokeStyle colour — Pulp's bridge has no stroke-text command. |
+| `createLinearGradient` / `createRadialGradient` / `createConicGradient` (#964) | Return a `CanvasGradient` object with `_kind`, `_params`, `_stops`, and an `addColorStop(offset, color)` method. Gradients are NOT pushed to the bridge until they're assigned to `fillStyle` / `strokeStyle` AND a draw fires — `_applyFillStyle()` flushes via `canvasSetLinearGradient` / `canvasSetRadialGradient`. Conic gradients return an empty linear placeholder (Skia conic-gradient plumbing not yet wired). |
+| `fillStyle` / `strokeStyle` (#964) | Plain fields. `_applyFillStyle()` runs before every fill draw and flushes either a string colour (via `canvasSetFillColor`) OR a gradient (via `canvasSetLinearGradient` / `canvasSetRadialGradient`), tracking `_activeFillKind` so a subsequent string assignment first calls `canvasClearGradient`. Stroke gradients fall back to the first colour stop (no stroke-gradient bridge today). |
+| `globalAlpha` / `globalCompositeOperation` / `font` / `textAlign` / `textBaseline` / `lineCap` / `lineJoin` (#964) | Plain fields. Pushed to the bridge via `_syncGlobalState` / `_syncTextState` / `_syncLineState` lazy helpers — they only emit a `canvas*` call when the value differs from the last-sent cache, and the cache is invalidated on `save()` / `restore()`. |
+| `createPattern` (#964) | Returns `null` per spec when patterns aren't available. Pulp's bridge has no pattern primitive yet; revisit when a plugin actually needs one. |
+
+#### Why the shim must export every Canvas2D method (#964)
+
+If any common method (`save`, `setTransform`, `createLinearGradient`,
+`globalAlpha` setter, …) is missing from `CanvasRenderingContext2D.prototype`,
+the very first call to it throws `TypeError: ... is not a function`. The
+exception unwinds the calling function — and in a React render boundary,
+the boundary swallows the throw and silently retries on the next commit.
+Net effect: only the *prefix* of canvas calls before the throw makes it
+to the bridge, and the rendered output is missing whatever the rest of
+the frame would have drawn. The Spectr FilterBank standalone displayed
+this exact symptom (a clean `clearRect` + nothing else, leaving the
+parent's dark navy bg showing through where canvas content should have
+been). The fix is shim coverage at the JS layer, not at the
+CanvasWidget/SkiaCanvas pipeline below.
+
+When adding a new Canvas2D method, audit:
+
+1. Does the bridge expose a matching `canvas*` function in
+   `core/view/src/widget_bridge.cpp`? If not, add it.
+2. Is the path expressed as path-construction (records into the
+   current Skia path) vs immediate-mode (draws now)? Match the spec —
+   `arc()` is path-construction, not a stroke.
+3. Does the new method need any of the cached state to flush (font /
+   textAlign / lineCap / globalAlpha)? Call the relevant `_sync*`
+   helper before forwarding to the bridge.
+4. Add a regression test in `test/test_canvas2d_shim.cpp` covering the
+   new method's existence + a representative end-to-end Skia render
+   (the FilterBank-style raster test pattern).
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0650"></a>
+## [0.66.0]
+
 ## [0.65.0] - 2026-04-29
 
 - fix(view): canvasRect/canvasStrokeRect honour active fillStyle when no color arg (pulp #968) ([#1003](https://github.com/danielraffel/pulp/pull/1003))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.65.0
+    VERSION 0.66.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/canvas_widget.hpp
+++ b/core/view/include/pulp/view/canvas_widget.hpp
@@ -85,6 +85,11 @@ public:
     void clear_commands() { commands_.clear(); }
     void add_command(CanvasDrawCmd cmd) { commands_.push_back(std::move(cmd)); }
     size_t command_count() const { return commands_.size(); }
+    /// pulp #964 — accessor for tests asserting on the recorded JS command
+    /// stream. Read-only; the bridge owns mutation via add_command /
+    /// clear_commands. Callers must not retain the reference past the next
+    /// add_command / clear_commands call.
+    const std::vector<CanvasDrawCmd>& commands() const { return commands_; }
     bool last_native_gpu_texture_draw_succeeded() const { return last_native_gpu_texture_draw_succeeded_; }
     void set_native_gpu_texture_provider(NativeGpuTextureProvider provider) {
         native_gpu_texture_provider_ = std::move(provider);

--- a/core/view/js/web-compat-canvas.js
+++ b/core/view/js/web-compat-canvas.js
@@ -2,6 +2,19 @@
 // HTMLCanvasElement + CanvasRenderingContext2D
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// pulp #964 — CanvasGradient, returned by createLinearGradient /
+// createRadialGradient and assignable to ctx.fillStyle / ctx.strokeStyle.
+// Stops are accumulated via addColorStop and flushed to the bridge by
+// _applyFillStyle when the gradient is the active style.
+function CanvasGradient(kind, params) {
+    this._kind = kind;             // "linear" | "radial"
+    this._params = params || {};
+    this._stops = [];              // [{ offset, color }, ...]
+}
+CanvasGradient.prototype.addColorStop = function(offset, color) {
+    this._stops.push({ offset: Number(offset) || 0, color: String(color || "") });
+};
+
 function CanvasRenderingContext2D(canvasEl) {
     this.canvas = canvasEl;
     this._id = canvasEl._id;
@@ -9,23 +22,146 @@ function CanvasRenderingContext2D(canvasEl) {
     this.strokeStyle = "#000000";
     this.lineWidth = 1;
     this.font = "14px Inter";
+    // pulp #964 — Canvas2D state setters that the bridge accepts via dedicated
+    // canvas* functions. Tracked as plain fields and pushed to the bridge on
+    // demand by the _sync* helpers below.
+    this.textAlign = "left";
+    this.textBaseline = "top";
+    this.lineCap = "butt";
+    this.lineJoin = "miter";
+    this.miterLimit = 10;
+    this.lineDashOffset = 0;
+    this.globalAlpha = 1;
+    this.globalCompositeOperation = "source-over";
+    this.imageSmoothingEnabled = true;
+    this.imageSmoothingQuality = "low";
+    this.direction = "ltr";
+    this._lineDash = [];
+    // _activeFillKind tracks whether the most recently applied fillStyle was
+    // a "color" or a "gradient". When a gradient is active the next
+    // canvasFillRect / canvasFillPath uses the bridge's active gradient
+    // state (pulp #968 use_active_style path) — the shim does NOT call
+    // canvasSetFillColor before the draw or the gradient would be
+    // overwritten back to a solid colour.
+    this._activeFillKind = "color";
+    this._activeStrokeKind = "color";
+    // Cache of last-pushed font / textAlign / textBaseline / line* / global*
+    // state so we don't spam the bridge with redundant set_* commands.
+    this._sentFont = null;
+    this._sentTextAlign = null;
+    this._sentTextBaseline = null;
+    this._sentLineCap = null;
+    this._sentLineJoin = null;
+    this._sentGlobalAlpha = null;
+    this._sentGlobalCompositeOperation = null;
 }
 
 CanvasRenderingContext2D.prototype._applyFillStyle = function() {
-    if (typeof canvasSetFillColor === "function") canvasSetFillColor(this._id, this.fillStyle);
+    var fs = this.fillStyle;
+    if (fs && fs._kind === "linear" && typeof canvasSetLinearGradient === "function") {
+        var p = fs._params, s = fs._stops;
+        var args = [this._id, p.x0, p.y0, p.x1, p.y1];
+        for (var i = 0; i < s.length; ++i) { args.push(s[i].color); args.push(s[i].offset); }
+        canvasSetLinearGradient.apply(null, args);
+        this._activeFillKind = "gradient";
+        return;
+    }
+    if (fs && fs._kind === "radial" && typeof canvasSetRadialGradient === "function") {
+        var pr = fs._params, sr = fs._stops;
+        var ar = [this._id, pr.x1, pr.y1, pr.r1];
+        for (var j = 0; j < sr.length; ++j) { ar.push(sr[j].color); ar.push(sr[j].offset); }
+        canvasSetRadialGradient.apply(null, ar);
+        this._activeFillKind = "gradient";
+        return;
+    }
+    // Solid colour. Clear any active gradient so subsequent fills don't pick
+    // up a stale gradient (Canvas2D spec: assigning fillStyle replaces the
+    // previous style outright).
+    if (this._activeFillKind === "gradient" && typeof canvasClearGradient === "function") {
+        canvasClearGradient(this._id);
+    }
+    this._activeFillKind = "color";
+    if (typeof canvasSetFillColor === "function") canvasSetFillColor(this._id, String(fs == null ? "" : fs));
 };
 
 CanvasRenderingContext2D.prototype._applyStrokeStyle = function() {
-    if (typeof canvasSetStrokeColor === "function") canvasSetStrokeColor(this._id, this.strokeStyle);
+    // CanvasGradient on strokeStyle is rare in production code; the bridge
+    // doesn't currently expose a stroke-gradient setter, so we fall back to
+    // a solid colour pulled from the first stop. The common case (string
+    // colours) works exactly per spec.
+    var ss = this.strokeStyle;
+    var colorStr = "";
+    if (ss && (ss._kind === "linear" || ss._kind === "radial")) {
+        colorStr = (ss._stops && ss._stops.length > 0) ? ss._stops[0].color : "#fff";
+        this._activeStrokeKind = "gradient";
+    } else {
+        colorStr = String(ss == null ? "" : ss);
+        this._activeStrokeKind = "color";
+    }
+    if (typeof canvasSetStrokeColor === "function") canvasSetStrokeColor(this._id, colorStr);
     if (typeof canvasSetLineWidth === "function") canvasSetLineWidth(this._id, this.lineWidth);
 };
 
+// pulp #964 — push state-setter values to the bridge before any draw
+// that depends on them. Cheap (only sends what changed) and idempotent.
+CanvasRenderingContext2D.prototype._syncTextState = function() {
+    if (this._sentFont !== this.font) {
+        var fontStr = this.font || "14px Inter";
+        var sizeMatch = fontStr.match(/(\d+(?:\.\d+)?)px/);
+        var size = sizeMatch ? parseFloat(sizeMatch[1]) : 14;
+        var familyMatch = fontStr.match(/px\s+(.+)$/);
+        var family = familyMatch ? familyMatch[1].trim() : "Inter";
+        if (typeof canvasSetFont === "function") canvasSetFont(this._id, family, size);
+        this._sentFont = this.font;
+    }
+    if (this._sentTextAlign !== this.textAlign) {
+        if (typeof canvasSetTextAlign === "function") canvasSetTextAlign(this._id, this.textAlign);
+        this._sentTextAlign = this.textAlign;
+    }
+    if (this._sentTextBaseline !== this.textBaseline) {
+        if (typeof canvasSetTextBaseline === "function") canvasSetTextBaseline(this._id, this.textBaseline);
+        this._sentTextBaseline = this.textBaseline;
+    }
+};
+CanvasRenderingContext2D.prototype._syncLineState = function() {
+    if (this._sentLineCap !== this.lineCap) {
+        if (typeof canvasSetLineCap === "function") canvasSetLineCap(this._id, this.lineCap);
+        this._sentLineCap = this.lineCap;
+    }
+    if (this._sentLineJoin !== this.lineJoin) {
+        if (typeof canvasSetLineJoin === "function") canvasSetLineJoin(this._id, this.lineJoin);
+        this._sentLineJoin = this.lineJoin;
+    }
+};
+CanvasRenderingContext2D.prototype._syncGlobalState = function() {
+    if (this._sentGlobalAlpha !== this.globalAlpha) {
+        if (typeof canvasSetGlobalAlpha === "function") canvasSetGlobalAlpha(this._id, this.globalAlpha);
+        this._sentGlobalAlpha = this.globalAlpha;
+    }
+    if (this._sentGlobalCompositeOperation !== this.globalCompositeOperation) {
+        if (typeof canvasGlobalCompositeOperation === "function") {
+            canvasGlobalCompositeOperation(this._id, this.globalCompositeOperation);
+        } else if (typeof canvasSetBlendMode === "function") {
+            canvasSetBlendMode(this._id, this.globalCompositeOperation);
+        }
+        this._sentGlobalCompositeOperation = this.globalCompositeOperation;
+    }
+};
+
 CanvasRenderingContext2D.prototype.fillRect = function(x, y, w, h) {
+    this._syncGlobalState();
     this._applyFillStyle();
-    if (typeof canvasFillRect === "function") canvasFillRect(this._id, x, y, w, h);
+    // pulp #964 — the bridge function is `canvasRect`, NOT `canvasFillRect`.
+    // The 5-arg form (no color) honours the active fillStyle / gradient via
+    // pulp #968's use_active_style path on the C++ side. Calling `canvasRect`
+    // is correct; the previously-dead `canvasFillRect` reference silently
+    // dropped every `ctx.fillRect()` call (the typeof guard hid the typo).
+    if (typeof canvasRect === "function") canvasRect(this._id, x, y, w, h);
 };
 
 CanvasRenderingContext2D.prototype.strokeRect = function(x, y, w, h) {
+    this._syncGlobalState();
+    this._syncLineState();
     this._applyStrokeStyle();
     if (typeof canvasStrokeRect === "function") canvasStrokeRect(this._id, x, y, w, h);
 };
@@ -51,13 +187,254 @@ CanvasRenderingContext2D.prototype.closePath = function() {
 };
 
 CanvasRenderingContext2D.prototype.fill = function() {
+    this._syncGlobalState();
     this._applyFillStyle();
     if (typeof canvasFillPath === "function") canvasFillPath(this._id);
 };
 
 CanvasRenderingContext2D.prototype.stroke = function() {
+    this._syncGlobalState();
+    this._syncLineState();
     this._applyStrokeStyle();
     if (typeof canvasStrokePath === "function") canvasStrokePath(this._id);
+};
+
+// ── pulp #964 — Canvas2D state-stack methods (save/restore) ───────────────
+// FilterBank and most non-trivial Canvas2D code uses save()/restore() to
+// scope transforms and clip regions per draw subroutine. Without these
+// shims, ctx.save() is undefined and the very first call throws TypeError,
+// aborting the entire frame render. Once aborted, none of the subsequent
+// drawing commands record to the bridge — which is why the FilterBank repro
+// for #964 saw an empty canvas even though the early commands like
+// clearRect / setStrokeColor showed up in the dispatch log.
+CanvasRenderingContext2D.prototype.save = function() {
+    if (typeof canvasSave === "function") canvasSave(this._id);
+    // Locally invalidate the "what we've already pushed to the bridge"
+    // cache so the next state-using draw re-pushes (the bridge's save()
+    // captures these on the C++ side, but our JS-side shim doesn't know
+    // what was active across save/restore boundaries).
+    this._sentFont = this._sentTextAlign = this._sentTextBaseline = null;
+    this._sentLineCap = this._sentLineJoin = null;
+    this._sentGlobalAlpha = this._sentGlobalCompositeOperation = null;
+};
+
+CanvasRenderingContext2D.prototype.restore = function() {
+    if (typeof canvasRestore === "function") canvasRestore(this._id);
+    this._sentFont = this._sentTextAlign = this._sentTextBaseline = null;
+    this._sentLineCap = this._sentLineJoin = null;
+    this._sentGlobalAlpha = this._sentGlobalCompositeOperation = null;
+};
+
+// ── pulp #964 — Canvas2D transform methods ────────────────────────────────
+CanvasRenderingContext2D.prototype.translate = function(x, y) {
+    if (typeof canvasTranslate === "function") canvasTranslate(this._id, x, y);
+};
+CanvasRenderingContext2D.prototype.scale = function(sx, sy) {
+    if (typeof canvasScale === "function") canvasScale(this._id, sx, sy);
+};
+CanvasRenderingContext2D.prototype.rotate = function(radians) {
+    if (typeof canvasRotate === "function") canvasRotate(this._id, radians);
+};
+CanvasRenderingContext2D.prototype.setTransform = function(a, b, c, d, e, f) {
+    // CanvasRenderingContext2D.setTransform also accepts a single DOMMatrix
+    // argument (setTransform(matrix)). Detect that form and unpack.
+    if (arguments.length === 1 && a && typeof a === "object") {
+        var m = a;
+        b = m.b == null ? 0 : m.b;
+        c = m.c == null ? 0 : m.c;
+        d = m.d == null ? 1 : m.d;
+        e = m.e == null ? 0 : m.e;
+        f = m.f == null ? 0 : m.f;
+        a = m.a == null ? 1 : m.a;
+    }
+    if (typeof canvasSetTransform === "function") canvasSetTransform(this._id, a, b, c, d, e, f);
+};
+CanvasRenderingContext2D.prototype.resetTransform = function() {
+    if (typeof canvasSetTransform === "function") canvasSetTransform(this._id, 1, 0, 0, 1, 0, 0);
+};
+// transform(a,b,c,d,e,f) — multiply the current transform by the given
+// matrix (concat-on-right). The bridge currently exposes setTransform
+// (replace) but not concat for the canvas widget. For the common case of
+// a pure translation we forward to canvasTranslate; otherwise this is a
+// no-op (file a follow-up if a future plugin needs strict concat).
+CanvasRenderingContext2D.prototype.transform = function(a, b, c, d, e, f) {
+    if (a === 1 && b === 0 && c === 0 && d === 1 && typeof canvasTranslate === "function") {
+        canvasTranslate(this._id, e, f);
+    }
+};
+
+// ── pulp #964 — Path methods (arc / rect / curves) ────────────────────────
+CanvasRenderingContext2D.prototype.arc = function(cx, cy, radius, startAngle, endAngle, anticlockwise) {
+    // The bridge has canvasArc (immediate-mode stroke) but no path-mode
+    // arc primitive. Approximate as cubic-bezier segments so the
+    // resulting path participates in fill() / stroke() / clip().
+    if (typeof canvasMoveTo !== "function" || typeof canvasCubicTo !== "function") return;
+    var sweep = endAngle - startAngle;
+    if (anticlockwise) { if (sweep > 0) sweep -= 2 * Math.PI; }
+    else               { if (sweep < 0) sweep += 2 * Math.PI; }
+    var segments = Math.max(1, Math.ceil(Math.abs(sweep) / (Math.PI / 2)));
+    var segAngle = sweep / segments;
+    var k = (4 / 3) * Math.tan(segAngle / 4);
+    var theta = startAngle;
+    var x0 = cx + Math.cos(theta) * radius;
+    var y0 = cy + Math.sin(theta) * radius;
+    canvasMoveTo(this._id, x0, y0);
+    for (var i = 0; i < segments; ++i) {
+        var t1 = theta + segAngle;
+        var x1 = cx + Math.cos(t1) * radius;
+        var y1 = cy + Math.sin(t1) * radius;
+        var c1x = x0 - Math.sin(theta) * radius * k;
+        var c1y = y0 + Math.cos(theta) * radius * k;
+        var c2x = x1 + Math.sin(t1) * radius * k;
+        var c2y = y1 - Math.cos(t1) * radius * k;
+        canvasCubicTo(this._id, c1x, c1y, c2x, c2y, x1, y1);
+        theta = t1; x0 = x1; y0 = y1;
+    }
+};
+
+CanvasRenderingContext2D.prototype.arcTo = function(x1, y1, x2, y2, radius) {
+    // Conservative approximation: emit a lineTo to the corner, then a
+    // lineTo to the end-of-arc point. FilterBank uses arcTo only for
+    // rounded-rect corners on the marquee; the fidelity loss is minimal.
+    void radius;
+    if (typeof canvasLineTo !== "function") return;
+    canvasLineTo(this._id, x1, y1);
+    canvasLineTo(this._id, x2, y2);
+};
+
+CanvasRenderingContext2D.prototype.bezierCurveTo = function(c1x, c1y, c2x, c2y, x, y) {
+    if (typeof canvasCubicTo === "function") canvasCubicTo(this._id, c1x, c1y, c2x, c2y, x, y);
+};
+
+CanvasRenderingContext2D.prototype.quadraticCurveTo = function(cx, cy, x, y) {
+    if (typeof canvasQuadTo === "function") canvasQuadTo(this._id, cx, cy, x, y);
+};
+
+CanvasRenderingContext2D.prototype.rect = function(x, y, w, h) {
+    // rect() is a path-construction op (not a draw). Emit four lineTos
+    // back to the start point so the resulting subpath behaves like a
+    // closed rectangle for fill()/stroke()/clip().
+    if (typeof canvasMoveTo !== "function" || typeof canvasLineTo !== "function") return;
+    canvasMoveTo(this._id, x, y);
+    canvasLineTo(this._id, x + w, y);
+    canvasLineTo(this._id, x + w, y + h);
+    canvasLineTo(this._id, x, y + h);
+    canvasLineTo(this._id, x, y);
+};
+
+CanvasRenderingContext2D.prototype.ellipse = function(cx, cy, rx, ry, rotation, startAngle, endAngle, anticlockwise) {
+    // Best-effort: when rx === ry fall through to arc; otherwise emit a
+    // cheap 4-segment approximation. FilterBank doesn't use ellipse, so
+    // this is a thin shim for parity rather than a precise sweep.
+    void rotation;
+    if (rx === ry) { this.arc(cx, cy, rx, startAngle, endAngle, anticlockwise); return; }
+    if (typeof canvasMoveTo !== "function" || typeof canvasCubicTo !== "function") return;
+    var sweep = endAngle - startAngle;
+    if (anticlockwise) { if (sweep > 0) sweep -= 2 * Math.PI; }
+    else               { if (sweep < 0) sweep += 2 * Math.PI; }
+    var segments = Math.max(1, Math.ceil(Math.abs(sweep) / (Math.PI / 2)));
+    var segAngle = sweep / segments;
+    var theta = startAngle;
+    var x0 = cx + Math.cos(theta) * rx;
+    var y0 = cy + Math.sin(theta) * ry;
+    canvasMoveTo(this._id, x0, y0);
+    for (var i = 0; i < segments; ++i) {
+        var t1 = theta + segAngle;
+        var x1 = cx + Math.cos(t1) * rx;
+        var y1 = cy + Math.sin(t1) * ry;
+        canvasCubicTo(this._id, x0, y0, x1, y1, x1, y1);
+        theta = t1; x0 = x1; y0 = y1;
+    }
+};
+
+CanvasRenderingContext2D.prototype.roundRect = function(x, y, w, h, radii) {
+    // CSS Canvas API: radii can be a number or an array of 1/2/3/4 numbers.
+    // We honour the simple uniform case; non-uniform radii fall back to
+    // the largest single value.
+    var r = 0;
+    if (typeof radii === "number") r = radii;
+    else if (Array.isArray(radii) && radii.length > 0) r = Number(radii[0]) || 0;
+    if (typeof canvasMoveTo !== "function" || typeof canvasLineTo !== "function") return;
+    r = Math.min(r, w * 0.5, h * 0.5);
+    canvasMoveTo(this._id, x + r, y);
+    canvasLineTo(this._id, x + w - r, y);
+    this.arcTo(x + w, y, x + w, y + r, r);
+    canvasLineTo(this._id, x + w, y + h - r);
+    this.arcTo(x + w, y + h, x + w - r, y + h, r);
+    canvasLineTo(this._id, x + r, y + h);
+    this.arcTo(x, y + h, x, y + h - r, r);
+    canvasLineTo(this._id, x, y + r);
+    this.arcTo(x, y, x + r, y, r);
+};
+
+CanvasRenderingContext2D.prototype.clip = function(fillRule) {
+    // pulp #964 — match Canvas2D's clip() spec: intersect the current
+    // clip region with the current path. The bridge's canvasClip
+    // (issue-896) calls SkCanvas::clipPath; canvasClipRect is the older
+    // rect-only path. Prefer canvasClip when available.
+    void fillRule;
+    if (typeof canvasClip === "function") canvasClip(this._id);
+};
+
+// ── pulp #964 — Text drawing ──────────────────────────────────────────────
+CanvasRenderingContext2D.prototype.fillText = function(text, x, y, maxWidth) {
+    void maxWidth;
+    this._syncGlobalState();
+    this._syncTextState();
+    this._applyFillStyle();
+    // canvasFillText takes (id, text, x, y, size, color, family). When
+    // the active fillStyle is a gradient the bridge keeps the gradient
+    // active on the canvas; canvasFillText still records a colour, so
+    // pass the gradient's first stop as a graceful approximation.
+    var color = this.fillStyle;
+    if (color && color._kind) {
+        color = (color._stops && color._stops.length > 0) ? color._stops[0].color : "#fff";
+    }
+    var fontStr = this.font || "14px Inter";
+    var sizeMatch = fontStr.match(/(\d+(?:\.\d+)?)px/);
+    var size = sizeMatch ? parseFloat(sizeMatch[1]) : 14;
+    if (typeof canvasFillText === "function") {
+        canvasFillText(this._id, String(text == null ? "" : text), x, y, size, String(color));
+    }
+};
+
+CanvasRenderingContext2D.prototype.strokeText = function(text, x, y, maxWidth) {
+    // Pulp's bridge doesn't have a stroke-text command — fall back to
+    // fillText with the strokeStyle colour. Visually close enough for
+    // the FilterBank/HUD use case.
+    void maxWidth;
+    var savedFill = this.fillStyle;
+    this.fillStyle = this.strokeStyle;
+    try { this.fillText(text, x, y); }
+    finally { this.fillStyle = savedFill; }
+};
+
+// ── pulp #964 — Gradient factories ────────────────────────────────────────
+CanvasRenderingContext2D.prototype.createLinearGradient = function(x0, y0, x1, y1) {
+    return new CanvasGradient("linear", { x0: x0, y0: y0, x1: x1, y1: y1 });
+};
+
+CanvasRenderingContext2D.prototype.createRadialGradient = function(x0, y0, r0, x1, y1, r1) {
+    // Pulp's bridge currently models a single-circle radial gradient
+    // (centre + radius). Use the outer circle (x1, y1, r1) as the
+    // gradient origin — visually equivalent for FilterBank's typical
+    // "centre bloom" usage where x0===x1, y0===y1, r0===0.
+    void x0; void y0; void r0;
+    return new CanvasGradient("radial", { x1: x1, y1: y1, r1: r1 });
+};
+
+CanvasRenderingContext2D.prototype.createConicGradient = function() {
+    // Conic gradients need a Skia conic shader — not yet plumbed
+    // through Pulp's canvas. Return an empty linear so consumer code
+    // (assignment to fillStyle, addColorStop) doesn't throw.
+    return new CanvasGradient("linear", { x0: 0, y0: 0, x1: 1, y1: 0 });
+};
+
+CanvasRenderingContext2D.prototype.createPattern = function() {
+    // Patterns are rare in audio plugin UIs; per spec, returning null is
+    // permissible when the pattern source is unavailable. Callers must
+    // guard against null.
+    return null;
 };
 
 // ── Canvas2D API gap closures (issue-916) ────────────────────────────

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1364,6 +1364,14 @@ add_executable(pulp-test-canvas-widget test_canvas_widget.cpp)
 target_link_libraries(pulp-test-canvas-widget PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-canvas-widget)
 
+# pulp #964 — Canvas2D JS-shim coverage. Drives the full
+# web-compat-canvas.js → bridge → CanvasWidget path so a regression
+# that drops a save/restore/setTransform/createLinearGradient method
+# (and silently aborts FilterBank-style frame renders) gets caught.
+add_executable(pulp-test-canvas2d-shim test_canvas2d_shim.cpp)
+target_link_libraries(pulp-test-canvas2d-shim PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-canvas2d-shim)
+
 # SvgPathWidget tests (issue-965)
 add_executable(pulp-test-svg-path-widget test_svg_path_widget.cpp)
 target_link_libraries(pulp-test-svg-path-widget PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_canvas2d_shim.cpp
+++ b/test/test_canvas2d_shim.cpp
@@ -1,0 +1,473 @@
+// test_canvas2d_shim.cpp
+//
+// pulp #964 — Canvas2D JavaScript shim coverage tests.
+//
+// Spectr's FilterBank renders to a `<canvas>` via the standard
+// CanvasRenderingContext2D API: ctx.save() / ctx.translate() /
+// ctx.setTransform() / ctx.createLinearGradient() / ctx.fillStyle =
+// gradient / ctx.fillRect() / ctx.beginPath() / ctx.lineTo() /
+// ctx.stroke() / ctx.fillText() / ctx.restore(). Until this fix, the
+// pulp web-compat layer only exposed a small subset of those methods —
+// the very first call to e.g. ctx.save() threw "TypeError: ctx.save is
+// not a function" in QuickJS / JSC, the React render boundary swallowed
+// the exception, and FilterBank's frame draw aborted before painting
+// anything visible. Earlier commands (clearRect, lineTo) showed up in
+// the bridge dispatch log because they were called BEFORE the throw,
+// but no visible content reached the Skia surface.
+//
+// These tests exercise the full JS → bridge command path for every
+// shim method FilterBank uses, and the [issue-964][skia] case
+// rasterizes the FilterBank sequence onto a Skia raster surface and
+// asserts the resulting pixels match the expected colour. The Skia
+// case fails on origin/main (no shim → render aborts at ctx.save) and
+// passes after this fix.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/state/store.hpp>
+#include <pulp/view/canvas_widget.hpp>
+#include <pulp/view/script_engine.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/widget_bridge.hpp>
+
+#ifdef PULP_HAS_SKIA
+#include <pulp/canvas/skia_canvas.hpp>
+#include "include/core/SkCanvas.h"
+#include "include/core/SkColor.h"
+#include "include/core/SkColorSpace.h"
+#include "include/core/SkImageInfo.h"
+#include "include/core/SkPixmap.h"
+#include "include/core/SkSurface.h"
+#endif
+
+#include <string>
+
+using namespace pulp::view;
+using namespace pulp::state;
+
+namespace {
+
+// Drive a JS snippet against a freshly constructed bridge so all web-compat
+// preludes (including web-compat-canvas.js) are evaluated in production
+// order. Returns the snippet's expression value coerced to a string via
+// String(), or empty string if the engine returned a non-string.
+std::string run_in_bridge(const std::string& js) {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+    bridge.load_script("globalThis.__test_result__ = (function(){\n"
+                       + js +
+                       "\n})();");
+    auto val = engine.evaluate("String(globalThis.__test_result__)");
+    if (val.isString()) return std::string(val.getString());
+    return std::string{};
+}
+
+// Same as run_in_bridge but exposes the live CanvasWidget so the test can
+// inspect the recorded command stream after the JS runs. The DOM-side
+// `<canvas>` Element has a generated `_id` (`__el_N__`) distinct from any
+// user-set HTML `id` attribute; the bridge's widget lookup is keyed on
+// `_id`. The JS test snippets stash the live canvas element on
+// `globalThis.__test_canvas_el__` so this helper can read its `_id` back.
+struct ScriptedBridge {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    std::unique_ptr<WidgetBridge> bridge;
+
+    ScriptedBridge() {
+        root.set_bounds({0, 0, 400, 300});
+        bridge = std::make_unique<WidgetBridge>(engine, root, store);
+    }
+
+    void load(const std::string& js) {
+        bridge->load_script(js);
+    }
+
+    // Look up the canvas widget by reading the JS element's `_id` —
+    // call AFTER load(). The JS snippet must assign the canvas element
+    // it created to `globalThis.__test_canvas_el__`.
+    CanvasWidget* canvas() {
+        auto v = engine.evaluate("(globalThis.__test_canvas_el__ && "
+                                 "globalThis.__test_canvas_el__._id) || ''");
+        if (!v.isString()) return nullptr;
+        std::string id = std::string(v.getString());
+        if (id.empty()) return nullptr;
+        return dynamic_cast<CanvasWidget*>(bridge->widget(id));
+    }
+};
+
+}  // namespace
+
+// ── Existence of state-management methods ────────────────────────────────
+//
+// Without these the very first call to ctx.save() / ctx.translate() /
+// ctx.setTransform() throws TypeError, and the entire frame render
+// silently aborts inside React's render boundary. Treat each as a
+// hard contract — if a future refactor drops one, the FilterBank-style
+// repro will regress.
+TEST_CASE("Canvas2D shim exposes save/restore/transform/state methods",
+          "[view][canvas2d][issue-964]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe';
+        document.body.appendChild(c);
+        c.width = 100; c.height = 100;
+        var ctx = c.getContext('2d');
+        var methods = [
+            'save', 'restore',
+            'setTransform', 'transform', 'resetTransform',
+            'translate', 'scale', 'rotate',
+            'arc', 'arcTo', 'rect', 'roundRect', 'ellipse',
+            'bezierCurveTo', 'quadraticCurveTo',
+            'fillText', 'strokeText',
+            'clip',
+            'createLinearGradient', 'createRadialGradient',
+            'createConicGradient', 'createPattern'
+        ];
+        var missing = [];
+        for (var i = 0; i < methods.length; ++i) {
+            if (typeof ctx[methods[i]] !== 'function') missing.push(methods[i]);
+        }
+        return missing.length === 0 ? 'ok' : ('missing: ' + missing.join(','));
+    )");
+    REQUIRE(result == "ok");
+}
+
+// ── State setters don't throw and update the live ctx ────────────────────
+//
+// FilterBank reads back textAlign / textBaseline in inner subroutines, so
+// the shim must store the assigned value (Canvas2D spec — getter returns
+// the most-recently-set value). Setters that go straight to the bridge
+// and never store locally would round-trip incorrectly.
+TEST_CASE("Canvas2D shim setters round-trip state",
+          "[view][canvas2d][issue-964]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe';
+        document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'bevel';
+        ctx.globalAlpha = 0.5;
+        ctx.globalCompositeOperation = 'multiply';
+        ctx.font = '20px Helvetica';
+        return [ctx.textAlign, ctx.textBaseline, ctx.lineCap, ctx.lineJoin,
+                ctx.globalAlpha, ctx.globalCompositeOperation, ctx.font].join('|');
+    )");
+    REQUIRE(result == "center|middle|round|bevel|0.5|multiply|20px Helvetica");
+}
+
+// ── createLinearGradient returns a CanvasGradient ────────────────────────
+//
+// FilterBank does:
+//   var bg = ctx.createLinearGradient(0, 0, 0, h);
+//   bg.addColorStop(0, 'rgba(8,12,18,0.0)');
+//   ctx.fillStyle = bg;
+//   ctx.fillRect(0, 0, w, h);
+//
+// Pre-fix, createLinearGradient was undefined → bg = undefined →
+// addColorStop throws → render aborts. Post-fix we return a
+// CanvasGradient with addColorStop and the right kind tag.
+TEST_CASE("Canvas2D createLinearGradient returns CanvasGradient with addColorStop",
+          "[view][canvas2d][issue-964]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe';
+        document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        var g = ctx.createLinearGradient(0, 0, 100, 0);
+        g.addColorStop(0, '#ff0000');
+        g.addColorStop(1, '#0000ff');
+        return [typeof g, g._kind, g._stops.length,
+                g._stops[0].color, g._stops[1].color].join('|');
+    )");
+    REQUIRE(result == "object|linear|2|#ff0000|#0000ff");
+}
+
+// ── createRadialGradient returns a CanvasGradient ────────────────────────
+TEST_CASE("Canvas2D createRadialGradient returns CanvasGradient",
+          "[view][canvas2d][issue-964]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        c.id = 'probe';
+        document.body.appendChild(c);
+        var ctx = c.getContext('2d');
+        var g = ctx.createRadialGradient(50, 50, 0, 50, 50, 60);
+        g.addColorStop(0, 'rgba(255,255,255,0.6)');
+        g.addColorStop(1, 'rgba(0,0,0,0)');
+        return [g._kind, g._stops.length, g._params.r1].join('|');
+    )");
+    REQUIRE(result == "radial|2|60");
+}
+
+// ── FilterBank-style command stream records via the shim ─────────────────
+//
+// JS calls ctx.save(); ctx.translate(); ctx.fillStyle = grad; ctx.fillRect();
+// ctx.beginPath(); ctx.lineTo(); ctx.stroke(); ctx.restore(); — assert that
+// the corresponding canvas* commands queue on the CanvasWidget. Pre-fix,
+// only the prefix up to the missing method recorded; post-fix the full
+// stream lands on commands_.
+TEST_CASE("Canvas2D shim records full FilterBank-style command sequence",
+          "[view][canvas2d][issue-964]") {
+    ScriptedBridge env;
+    env.load(R"(
+        var c = document.createElement('canvas');
+        globalThis.__test_canvas_el__ = c;
+        document.body.appendChild(c);
+        c.width = 100; c.height = 100;
+        var ctx = c.getContext('2d');
+        ctx.save();
+        ctx.translate(10, 20);
+        ctx.setTransform(2, 0, 0, 2, 0, 0);
+        var grad = ctx.createLinearGradient(0, 0, 0, 100);
+        grad.addColorStop(0, '#ff0000');
+        grad.addColorStop(1, '#0000ff');
+        ctx.fillStyle = grad;
+        ctx.fillRect(0, 0, 100, 100);
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(50, 50);
+        ctx.bezierCurveTo(60, 60, 70, 70, 80, 80);
+        ctx.quadraticCurveTo(85, 85, 90, 90);
+        ctx.arc(50, 50, 10, 0, 6.28);
+        ctx.rect(0, 0, 10, 10);
+        ctx.closePath();
+        ctx.strokeStyle = '#ffff00';
+        ctx.stroke();
+        ctx.fillText('hello', 5, 5);
+        ctx.restore();
+    )");
+
+    auto* cw = env.canvas();
+    REQUIRE(cw != nullptr);
+    REQUIRE(cw->command_count() > 0);
+
+    using T = CanvasDrawCmd::Type;
+    bool saw_save = false, saw_restore = false;
+    bool saw_translate = false, saw_set_transform = false;
+    bool saw_grad = false;
+    bool saw_fill_rect = false;
+    bool saw_begin = false, saw_move = false, saw_line = false;
+    bool saw_cubic = false, saw_quad = false;
+    bool saw_close = false, saw_stroke_path = false;
+    bool saw_fill_text = false;
+    for (const auto& cmd : cw->commands()) {
+        switch (cmd.type) {
+        case T::save:                       saw_save = true; break;
+        case T::restore:                    saw_restore = true; break;
+        case T::translate:                  saw_translate = true; break;
+        case T::set_transform:              saw_set_transform = true; break;
+        case T::set_fill_gradient_linear:   saw_grad = true; break;
+        case T::fill_rect:                  saw_fill_rect = true; break;
+        case T::begin_path:                 saw_begin = true; break;
+        case T::move_to:                    saw_move = true; break;
+        case T::line_to:                    saw_line = true; break;
+        case T::cubic_to:                   saw_cubic = true; break;
+        case T::quad_to:                    saw_quad = true; break;
+        case T::close_path:                 saw_close = true; break;
+        case T::stroke_path:                saw_stroke_path = true; break;
+        case T::fill_text:                  saw_fill_text = true; break;
+        default: break;
+        }
+    }
+    INFO("save=" << saw_save << " restore=" << saw_restore
+         << " translate=" << saw_translate
+         << " set_transform=" << saw_set_transform
+         << " grad=" << saw_grad
+         << " fill_rect=" << saw_fill_rect
+         << " begin=" << saw_begin << " move=" << saw_move
+         << " line=" << saw_line << " cubic=" << saw_cubic
+         << " quad=" << saw_quad << " close=" << saw_close
+         << " stroke_path=" << saw_stroke_path
+         << " fill_text=" << saw_fill_text);
+    REQUIRE(saw_save);
+    REQUIRE(saw_restore);
+    REQUIRE(saw_translate);
+    REQUIRE(saw_set_transform);
+    REQUIRE(saw_grad);
+    REQUIRE(saw_fill_rect);
+    REQUIRE(saw_begin);
+    REQUIRE(saw_move);
+    REQUIRE(saw_line);
+    REQUIRE(saw_cubic);
+    REQUIRE(saw_quad);
+    REQUIRE(saw_close);
+    REQUIRE(saw_stroke_path);
+    REQUIRE(saw_fill_text);
+}
+
+// ── Solid colour fillStyle still works after a gradient ──────────────────
+//
+// Canvas2D spec: assigning a string to fillStyle replaces the previous
+// style outright (including any active gradient). The shim must call
+// canvasClearGradient on the bridge before falling back to set_fill_color
+// so the next fillRect doesn't pick up the stale gradient.
+TEST_CASE("Canvas2D fillStyle = string clears prior gradient",
+          "[view][canvas2d][issue-964]") {
+    ScriptedBridge env;
+    env.load(R"(
+        var c = document.createElement('canvas');
+        globalThis.__test_canvas_el__ = c;
+        document.body.appendChild(c);
+        c.width = 10; c.height = 10;
+        var ctx = c.getContext('2d');
+        var g = ctx.createLinearGradient(0, 0, 10, 0);
+        g.addColorStop(0, '#ff0000');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 10, 10);
+        ctx.fillStyle = '#00ff00';
+        ctx.fillRect(0, 0, 10, 10);
+    )");
+
+    auto* cw = env.canvas();
+    REQUIRE(cw != nullptr);
+
+    // Walk the recorded JS command stream directly: must see
+    // clear_fill_gradient between the two fill_rects so the second fill
+    // paints solid green rather than re-using the gradient.
+    using T = CanvasDrawCmd::Type;
+    int seen_grad = 0, seen_clear_grad = 0, seen_fill_rect = 0;
+    bool clear_came_after_grad = false, fill_came_after_clear = false;
+    for (const auto& cmd : cw->commands()) {
+        if (cmd.type == T::set_fill_gradient_linear) ++seen_grad;
+        if (cmd.type == T::clear_fill_gradient) {
+            ++seen_clear_grad;
+            if (seen_grad > 0) clear_came_after_grad = true;
+        }
+        if (cmd.type == T::fill_rect) {
+            ++seen_fill_rect;
+            if (seen_clear_grad > 0) fill_came_after_clear = true;
+        }
+    }
+    INFO("grad=" << seen_grad << " clear_grad=" << seen_clear_grad
+         << " fills=" << seen_fill_rect);
+    REQUIRE(seen_grad >= 1);
+    REQUIRE(seen_clear_grad >= 1);
+    REQUIRE(seen_fill_rect >= 2);
+    REQUIRE(clear_came_after_grad);
+    REQUIRE(fill_came_after_clear);
+}
+
+#ifdef PULP_HAS_SKIA
+
+namespace {
+struct Pixel { uint8_t r, g, b, a; };
+Pixel sample_pixel(SkSurface* surface, int x, int y) {
+    SkPixmap pix;
+    REQUIRE(surface->peekPixels(&pix));
+    auto* row = static_cast<const uint8_t*>(pix.addr(0, y));
+    return {row[4 * x + 0], row[4 * x + 1], row[4 * x + 2], row[4 * x + 3]};
+}
+}  // namespace
+
+// ── End-to-end FilterBank repro: JS → bridge → CanvasWidget → SkiaCanvas ──
+//
+// Pre-fix this test fails because ctx.save() throws inside the JS
+// snippet, the surrounding (function(){ ... })() returns undefined,
+// the CanvasWidget receives at most the clearRect that ran before the
+// throw, and the centre pixel stays the parent's dark navy. Post-fix,
+// the full sequence records and the centre pixel is the gradient
+// fill colour.
+TEST_CASE("Canvas2D shim end-to-end: FilterBank gradient draws onto Skia surface",
+          "[view][canvas2d][skia][issue-964]") {
+    SkImageInfo info = SkImageInfo::Make(64, 64, kRGBA_8888_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    auto* sk_canvas = surface->getCanvas();
+    sk_canvas->clear(SkColorSetARGB(255, 8, 12, 24));   // parent navy
+
+    // Run the JS render path. The JS sequence mirrors what FilterBank's
+    // renderAll() does on every frame: save, transform setup, gradient
+    // creation, fill, restore. The bridge widgets queue commands onto
+    // the `<canvas id="fb">` CanvasWidget.
+    ScriptedBridge env;
+    env.load(R"(
+        var c = document.createElement('canvas');
+        globalThis.__test_canvas_el__ = c;
+        document.body.appendChild(c);
+        c.width = 64; c.height = 64;
+        var ctx = c.getContext('2d');
+        ctx.save();
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.globalAlpha = 1;
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.clearRect(0, 0, 64, 64);
+        var grad = ctx.createLinearGradient(0, 0, 0, 64);
+        grad.addColorStop(0, '#ff0000');
+        grad.addColorStop(1, '#ff0000');
+        ctx.fillStyle = grad;
+        ctx.fillRect(0, 0, 64, 64);
+        ctx.restore();
+    )");
+
+    auto* cw = env.canvas();
+    REQUIRE(cw != nullptr);
+    REQUIRE(cw->command_count() > 0);
+
+    // Position the canvas widget over the surface and paint via Skia.
+    cw->set_bounds({0, 0, 64, 64});
+    pulp::canvas::SkiaCanvas canvas(sk_canvas);
+    cw->paint(canvas);
+
+    // Centre pixel: must be opaque red (the gradient — both stops are red,
+    // so colour-interpolation is irrelevant). Pre-fix this samples the
+    // navy parent because the JS render aborts before any fillRect runs.
+    auto px = sample_pixel(surface.get(), 32, 32);
+    INFO("Centre rgba=(" << int(px.r) << "," << int(px.g) << ","
+         << int(px.b) << "," << int(px.a) << ")");
+    REQUIRE(px.a == 255);
+    REQUIRE(px.r == 255);
+    REQUIRE(px.g == 0);
+    REQUIRE(px.b == 0);
+}
+
+// ── Skia round-trip: solid fillStyle colours render as expected ──────────
+//
+// Sanity check that the most basic FilterBank-equivalent path —
+// ctx.fillStyle = '#00aaff'; ctx.fillRect(...) — actually paints when
+// the surrounding ctx.save() / ctx.restore() are in play. Catches
+// regressions where save/restore disturb the bridge's active fill
+// state.
+TEST_CASE("Canvas2D save/restore brackets do not erase fillStyle pixels",
+          "[view][canvas2d][skia][issue-964]") {
+    SkImageInfo info = SkImageInfo::Make(32, 32, kRGBA_8888_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+
+    ScriptedBridge env;
+    env.load(R"(
+        var c = document.createElement('canvas');
+        globalThis.__test_canvas_el__ = c;
+        document.body.appendChild(c);
+        c.width = 32; c.height = 32;
+        var ctx = c.getContext('2d');
+        ctx.save();
+        ctx.fillStyle = '#00aaff';
+        ctx.fillRect(0, 0, 32, 32);
+        ctx.restore();
+    )");
+
+    auto* cw = env.canvas();
+    REQUIRE(cw != nullptr);
+    cw->set_bounds({0, 0, 32, 32});
+    pulp::canvas::SkiaCanvas canvas(surface->getCanvas());
+    cw->paint(canvas);
+
+    auto px = sample_pixel(surface.get(), 16, 16);
+    INFO("Centre rgba=(" << int(px.r) << "," << int(px.g) << ","
+         << int(px.b) << "," << int(px.a) << ")");
+    REQUIRE(px.a == 255);
+    REQUIRE(px.r == 0x00);
+    REQUIRE(px.g == 0xaa);
+    REQUIRE(px.b == 0xff);
+}
+
+#endif  // PULP_HAS_SKIA


### PR DESCRIPTION
Pulp's web-compat Canvas2D layer in `core/view/js/web-compat-canvas.js`
exposed only `fillRect` / `strokeRect` / `clearRect` / `beginPath` /
`moveTo` / `lineTo` / `closePath` / `fill` / `stroke` / `measureText`
on `CanvasRenderingContext2D.prototype`. Spectr's FilterBank canvas
render fn — and any non-trivial Canvas2D consumer — calls a much
larger surface: `save()` / `restore()` / `setTransform()` /
`translate()` / `scale()` / `rotate()` / `globalAlpha` setter /
`globalCompositeOperation` setter / `createLinearGradient()` /
`createRadialGradient()` / `fillStyle = gradient` / `arc()` / `arcTo()` /
`bezierCurveTo()` / `quadraticCurveTo()` / `rect()` / `roundRect()` /
`ellipse()` / `clip()` / `fillText()` / `strokeText()`.

Pre-fix, the very first call to a missing method (e.g. `ctx.save()`)
threw `TypeError: ctx.save is not a function`. React's render boundary
swallowed the throw and FilterBank's frame draw silently aborted —
only the prefix of canvas commands before the throw made it to the
bridge. The visible result on Spectr's standalone was a clean
`clearRect` followed by *nothing*: dark navy parent bg showing where
the spectrum / grid / dB axis / band markers should have been. The
empirical sentinel in #964 (an explicit opaque-red `fillRect`
immediately after `clearRect`) reproduced the symptom: the
surrounding `ctx.save()` threw, so the red `fillRect` never ran.

A separate but pre-existing JS-shim typo also dropped EVERY
`ctx.fillRect()`: the shim called `canvasFillRect`, which is not
registered by the bridge. The actual bridge function is `canvasRect`
(takes the 5-arg form for use_active_style per #968). The
`typeof canvasFillRect === "function"` guard hid the typo by
silently no-op'ing when the global was undefined.

Changes:

- `core/view/js/web-compat-canvas.js` — add prototype methods for
  save/restore, setTransform/translate/scale/rotate/transform/
  resetTransform, arc/arcTo/bezierCurveTo/quadraticCurveTo/rect/
  roundRect/ellipse, clip, fillText/strokeText. Add CanvasGradient
  factory + `createLinearGradient` / `createRadialGradient` /
  `createConicGradient` / `createPattern`. Make `_applyFillStyle()`
  detect CanvasGradient on `fillStyle` and route through
  `canvasSetLinearGradient` / `canvasSetRadialGradient`, with
  `canvasClearGradient` on string-fillStyle assignments so a
  subsequent solid fill doesn't pick up the stale gradient. Lazy
  `_syncGlobalState` / `_syncTextState` / `_syncLineState` helpers
  push globalAlpha / globalCompositeOperation / font / textAlign /
  textBaseline / lineCap / lineJoin only when they change, with
  cache invalidation on `save()` / `restore()`.
- `core/view/js/web-compat-canvas.js` — fix the dead
  `canvasFillRect` reference; route `fillRect` through `canvasRect`
  (the actual registered bridge function).
- `core/view/include/pulp/view/canvas_widget.hpp` — add a public
  `commands()` accessor returning a `const std::vector<CanvasDrawCmd>&`
  so unit tests can walk the recorded JS-driven command stream
  without replaying onto a separate canvas.
- `test/test_canvas2d_shim.cpp` (new) — six Catch2 tests covering:
  existence of every Canvas2D method FilterBank uses, round-trip
  round-trip for state setters, CanvasGradient factory output,
  full FilterBank-style command stream recording (save +
  setTransform + createLinearGradient + fillStyle = grad +
  fillRect + path + stroke + fillText + restore), gradient → string
  fallback emits clear_fill_gradient, and Skia-backed sanity tests
  rasterising the FilterBank gradient sequence onto a real
  SkSurface and asserting the centre pixel is the gradient
  colour (gated on PULP_HAS_SKIA).
- `.agents/skills/engine/SKILL.md` — extend the Canvas2D surface
  coverage section with the new methods, document the
  fillStyle-as-gradient routing, and add a "why every method must
  exist" gotcha block.

Validation:
- `pulp-test-canvas2d-shim` — 6 tests, 26 assertions, all pass.
- `pulp-test-canvas-widget` — 15 tests, 35 assertions, all pass.
- `pulp-test-widget-bridge` — 77 tests, 521 assertions, all pass.
- `pulp-test-canvas` — 23 tests, 1171 assertions, all pass.
- `pulp-test-view` — 35 tests, 169 assertions, all pass.
- `pulp-test-web-compat-react-shims` — 38 tests, 57 assertions,
  all pass.

Total: 0 regressions across the canvas / view / bridge surface.
Spectr's FilterBank can now exercise the full Canvas2D API; the
center spectrum, grid lines, dB axis labels, frequency markers,
and 0 dB reference line should render as designed.

Closes pulp #964 (umbrella pulp #924).