### PR TITLE
test(platform): cover child process edge paths

### DIFF
--- a/docs/guides/coverage.md
+++ b/docs/guides/coverage.md
@@ -220,6 +220,19 @@ at a **75%** floor. Sub-threshold diff coverage hard-fails this check
 and blocks the merge — adding untested code means either adding tests
 or splitting the untested portion into its own PR.
 
+### Phase 3 PR cadence
+
+Phase 3 is tranche work, not a queue stall. While a Codecov remediation
+PR is pending and blocked only on CI, keep moving with another small,
+focused coverage tranche. Check the open PR list and GitHub checks
+before starting each tranche, watch them again after pushing it, debug
+new failures as soon as they appear, and manually merge PRs once they
+are green.
+
+Use Namespace-backed GitHub checks and Codecov comments as the default
+evidence path. Local VMs are a fallback for reproducing or isolating
+failures, not the normal proof that a tranche is ready.
+
 ## How the collection works
 
 ```

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -238,6 +238,70 @@ TEST_CASE("stderr line callback fires independently",
     REQUIRE(trim_copy(stderr_lines[1]) == "err2");
 }
 
+TEST_CASE("line callback buffers partial stdout without trailing newline",
+          "[child_process][edge][issue-640]") {
+    std::vector<std::string> stdout_lines;
+    ProcessOptions opts;
+    opts.timeout_ms = 5000;
+    opts.on_stdout_line = [&](std::string_view line) {
+        stdout_lines.emplace_back(line);
+    };
+
+#ifdef _WIN32
+    auto r = ChildProcess::run("cmd", {"/c", "<nul set /p dummy=partial"}, opts);
+#else
+    auto r = ChildProcess::run("/bin/sh", {"-c", "printf partial"}, opts);
+#endif
+
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stdout_output == "partial");
+    REQUIRE(stdout_lines.empty());
+}
+
+TEST_CASE("wait is idempotent after process completion",
+          "[child_process][edge][issue-640]") {
+    ChildProcess cp;
+
+#ifdef _WIN32
+    REQUIRE(cp.start("cmd", {"/c", "<nul set /p dummy=once & exit /b 7"}));
+#else
+    REQUIRE(cp.start("/bin/sh", {"-c", "printf once; exit 7"}));
+#endif
+
+    auto first = cp.wait();
+    auto second = cp.wait();
+
+    REQUIRE(first.exit_code == 7);
+    REQUIRE(second.exit_code == first.exit_code);
+    REQUIRE(second.stdout_output == first.stdout_output);
+    REQUIRE(second.stderr_output == first.stderr_output);
+    REQUIRE(second.timed_out == first.timed_out);
+    REQUIRE(second.was_cancelled == first.was_cancelled);
+    REQUIRE(first.stdout_output.find("once") != std::string::npos);
+}
+
+TEST_CASE("timeout preserves output emitted before termination",
+          "[child_process][edge][issue-640]") {
+    ProcessOptions opts;
+    opts.timeout_ms = 500;
+
+#ifdef _WIN32
+    auto r = ChildProcess::run(
+        "cmd",
+        {"/c", "echo before-timeout& ping -n 10 127.0.0.1 >nul"},
+        opts);
+#else
+    auto r = ChildProcess::run(
+        "/bin/sh",
+        {"-c", "printf before-timeout; sleep 10"},
+        opts);
+#endif
+
+    REQUIRE(r.timed_out);
+    REQUIRE(r.exit_code == -1);
+    REQUIRE(r.stdout_output.find("before-timeout") != std::string::npos);
+}
+
 TEST_CASE("wait preserves output after is_running observes fast exit",
           "[child_process][edge][issue-640]") {
     ChildProcess cp;

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -248,7 +248,9 @@ TEST_CASE("line callback buffers partial stdout without trailing newline",
     };
 
 #ifdef _WIN32
-    auto r = ChildProcess::run("cmd", {"/c", "<nul set /p dummy=partial"}, opts);
+    auto r = ChildProcess::run("cmd",
+        {"/c", "<nul set /p dummy=partial & exit /b 0"},
+        opts);
 #else
     auto r = ChildProcess::run("/bin/sh", {"-c", "printf partial"}, opts);
 #endif

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -249,7 +249,7 @@ TEST_CASE("line callback buffers partial stdout without trailing newline",
 
 #ifdef _WIN32
     auto r = ChildProcess::run("cmd",
-        {"/c", "<nul set /p dummy=partial & exit /b 0"},
+        {"/c", "set /p dummy=partial<nul& exit /b 0"},
         opts);
 #else
     auto r = ChildProcess::run("/bin/sh", {"-c", "printf partial"}, opts);


### PR DESCRIPTION
Parent tracker: #640
Umbrella tracker: #641

## Scope
- Add child-process edge coverage for partial stdout without a trailing newline, repeated wait() after completion, and timeout output preservation.
- Codify the Phase 3 no-idle coverage cadence in docs/guides/coverage.md: monitor PRs, debug failures immediately, and keep advancing focused tranches while CI-only blockers run.

## Validation
- cmake --build build --target pulp-test-child-process -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-child-process
- ctest --test-dir build -R "child_process|ChildProcess|exec captures|timeout|wait|line callback|stderr|find_on_path|working directory|output capture" --output-on-failure
- git diff --check

## CI
- Opened with shipyard pr, deliberately skipping local VM targets so Namespace/GitHub checks are the evidence path.
- Codecov patch check expected on this PR.