### PR TITLE
test(host): cover LV2 plugin slot happy path

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1068,6 +1068,70 @@ if(PULP_HAS_LV2)
         pulp::host
         lv2-headers
         Catch2::Catch2WithMain)
+
+    if(UNIX)
+        set(_pulp_lv2_slot_probe_bundle
+            "${CMAKE_CURRENT_BINARY_DIR}/Lv2SlotProbe.lv2")
+        set(_pulp_lv2_slot_probe_binary
+            "${_pulp_lv2_slot_probe_bundle}/lv2-slot-probe${CMAKE_SHARED_MODULE_SUFFIX}")
+
+        add_library(pulp-test-lv2-slot-probe MODULE
+            fixtures/lv2_slot_probe.cpp)
+        target_link_libraries(pulp-test-lv2-slot-probe PRIVATE lv2-headers)
+        set_target_properties(pulp-test-lv2-slot-probe PROPERTIES
+            PREFIX ""
+            OUTPUT_NAME "lv2-slot-probe"
+            LIBRARY_OUTPUT_DIRECTORY "${_pulp_lv2_slot_probe_bundle}")
+
+        file(MAKE_DIRECTORY "${_pulp_lv2_slot_probe_bundle}")
+        string(CONCAT _pulp_lv2_slot_probe_ttl [=[
+@prefix lv2: <http://lv2plug.in/ns/lv2core#> .
+
+<http://example.com/pulp/lv2-slot-probe>
+    a lv2:Plugin ;
+    lv2:binary <lv2-slot-probe]=]
+    "${CMAKE_SHARED_MODULE_SUFFIX}"
+    [=[> ;
+    lv2:port
+    [
+        a lv2:InputPort , lv2:AudioPort ;
+        lv2:index 0 ;
+        lv2:name "Input L"
+    ] ,
+    [
+        a lv2:InputPort , lv2:AudioPort ;
+        lv2:index 1 ;
+        lv2:name "Input R"
+    ] ,
+    [
+        a lv2:OutputPort , lv2:AudioPort ;
+        lv2:index 2 ;
+        lv2:name "Output L"
+    ] ,
+    [
+        a lv2:OutputPort , lv2:AudioPort ;
+        lv2:index 3 ;
+        lv2:name "Output R"
+    ] ,
+    [
+        a lv2:InputPort , lv2:ControlPort ;
+        lv2:index 4 ;
+        lv2:name "Probe Gain" ;
+        lv2:default 0.5 ;
+        lv2:minimum -2.0 ;
+        lv2:maximum 4.0
+    ] .
+]=])
+        file(WRITE "${_pulp_lv2_slot_probe_bundle}/plugin.ttl"
+            "${_pulp_lv2_slot_probe_ttl}")
+
+        add_dependencies(pulp-test-lv2-host-discovery
+            pulp-test-lv2-slot-probe)
+        target_compile_definitions(pulp-test-lv2-host-discovery PRIVATE
+            PULP_TEST_LV2_SLOT_PROBE_BUNDLE="${_pulp_lv2_slot_probe_bundle}"
+            PULP_TEST_LV2_SLOT_PROBE_BINARY="${_pulp_lv2_slot_probe_binary}")
+    endif()
+
     catch_discover_tests(pulp-test-lv2-host-discovery)
 endif()
 

--- a/test/fixtures/lv2_slot_probe.cpp
+++ b/test/fixtures/lv2_slot_probe.cpp
@@ -1,0 +1,176 @@
+#include <lv2/core/lv2.h>
+
+#include <cstdint>
+
+#if defined(_WIN32)
+#define PULP_LV2_SLOT_PROBE_EXPORT __declspec(dllexport)
+#else
+#define PULP_LV2_SLOT_PROBE_EXPORT __attribute__((visibility("default")))
+#endif
+
+namespace {
+
+constexpr const char* kDecoyUri = "http://example.com/pulp/lv2-slot-decoy";
+constexpr const char* kProbeUri = "http://example.com/pulp/lv2-slot-probe";
+
+enum PortIndex : uint32_t {
+    kAudioInL = 0,
+    kAudioInR = 1,
+    kAudioOutL = 2,
+    kAudioOutR = 3,
+    kGain = 4,
+};
+
+struct ProbeState {
+    uint32_t instantiate_count = 0;
+    uint32_t activate_count = 0;
+    uint32_t run_count = 0;
+    uint32_t deactivate_count = 0;
+    uint32_t cleanup_count = 0;
+    uint32_t decoy_instantiate_count = 0;
+    uint32_t last_sample_count = 0;
+    float last_gain = 0.0f;
+};
+
+struct ProbeInstance {
+    const float* in_l = nullptr;
+    const float* in_r = nullptr;
+    float* out_l = nullptr;
+    float* out_r = nullptr;
+    const float* gain = nullptr;
+};
+
+ProbeState g_state;
+
+LV2_Handle instantiate_decoy(const LV2_Descriptor*,
+                             double,
+                             const char*,
+                             const LV2_Feature* const*) {
+    ++g_state.decoy_instantiate_count;
+    return nullptr;
+}
+
+LV2_Handle instantiate_probe(const LV2_Descriptor*,
+                             double,
+                             const char*,
+                             const LV2_Feature* const*) {
+    ++g_state.instantiate_count;
+    return new ProbeInstance();
+}
+
+void connect_probe_port(LV2_Handle handle, uint32_t port, void* data) {
+    auto* probe = static_cast<ProbeInstance*>(handle);
+    if (!probe) return;
+
+    switch (port) {
+        case kAudioInL:  probe->in_l = static_cast<const float*>(data); break;
+        case kAudioInR:  probe->in_r = static_cast<const float*>(data); break;
+        case kAudioOutL: probe->out_l = static_cast<float*>(data); break;
+        case kAudioOutR: probe->out_r = static_cast<float*>(data); break;
+        case kGain:      probe->gain = static_cast<const float*>(data); break;
+        default: break;
+    }
+}
+
+void activate_probe(LV2_Handle) {
+    ++g_state.activate_count;
+}
+
+void run_probe(LV2_Handle handle, uint32_t sample_count) {
+    auto* probe = static_cast<ProbeInstance*>(handle);
+    if (!probe) return;
+
+    ++g_state.run_count;
+    g_state.last_sample_count = sample_count;
+
+    const float gain = probe->gain ? *probe->gain : 0.0f;
+    g_state.last_gain = gain;
+
+    for (uint32_t i = 0; i < sample_count; ++i) {
+        const float left = probe->in_l ? probe->in_l[i] : 0.0f;
+        const float right = probe->in_r ? probe->in_r[i] : 0.0f;
+        if (probe->out_l) probe->out_l[i] = left * gain;
+        if (probe->out_r) probe->out_r[i] = right * gain;
+    }
+}
+
+void deactivate_probe(LV2_Handle) {
+    ++g_state.deactivate_count;
+}
+
+void cleanup_probe(LV2_Handle handle) {
+    ++g_state.cleanup_count;
+    delete static_cast<ProbeInstance*>(handle);
+}
+
+const LV2_Descriptor kDescriptors[] = {
+    {kDecoyUri,
+     instantiate_decoy,
+     nullptr,
+     nullptr,
+     nullptr,
+     nullptr,
+     nullptr,
+     nullptr},
+    {kProbeUri,
+     instantiate_probe,
+     connect_probe_port,
+     activate_probe,
+     run_probe,
+     deactivate_probe,
+     cleanup_probe,
+     nullptr},
+};
+
+} // namespace
+
+extern "C" PULP_LV2_SLOT_PROBE_EXPORT
+const LV2_Descriptor* lv2_descriptor(uint32_t index) {
+    if (index >= 2) return nullptr;
+    return &kDescriptors[index];
+}
+
+extern "C" PULP_LV2_SLOT_PROBE_EXPORT
+void pulp_lv2_slot_probe_reset() {
+    g_state = {};
+}
+
+extern "C" PULP_LV2_SLOT_PROBE_EXPORT
+uint32_t pulp_lv2_slot_probe_instantiate_count() {
+    return g_state.instantiate_count;
+}
+
+extern "C" PULP_LV2_SLOT_PROBE_EXPORT
+uint32_t pulp_lv2_slot_probe_decoy_instantiate_count() {
+    return g_state.decoy_instantiate_count;
+}
+
+extern "C" PULP_LV2_SLOT_PROBE_EXPORT
+uint32_t pulp_lv2_slot_probe_activate_count() {
+    return g_state.activate_count;
+}
+
+extern "C" PULP_LV2_SLOT_PROBE_EXPORT
+uint32_t pulp_lv2_slot_probe_run_count() {
+    return g_state.run_count;
+}
+
+extern "C" PULP_LV2_SLOT_PROBE_EXPORT
+uint32_t pulp_lv2_slot_probe_deactivate_count() {
+    return g_state.deactivate_count;
+}
+
+extern "C" PULP_LV2_SLOT_PROBE_EXPORT
+uint32_t pulp_lv2_slot_probe_cleanup_count() {
+    return g_state.cleanup_count;
+}
+
+extern "C" PULP_LV2_SLOT_PROBE_EXPORT
+uint32_t pulp_lv2_slot_probe_last_sample_count() {
+    return g_state.last_sample_count;
+}
+
+extern "C" PULP_LV2_SLOT_PROBE_EXPORT
+float pulp_lv2_slot_probe_last_gain() {
+    return g_state.last_gain;
+}

--- a/test/test_lv2_host_discovery.cpp
+++ b/test/test_lv2_host_discovery.cpp
@@ -1,17 +1,30 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <pulp/host/dl_shim.hpp>
 #include <pulp/host/plugin_slot.hpp>
 
 #include "lv2_discovery.hpp"
 
+#include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <vector>
 
 namespace fs = std::filesystem;
+using Catch::Matchers::WithinAbs;
 
 namespace {
+
+#if defined(PULP_TEST_LV2_SLOT_PROBE_BUNDLE) && defined(PULP_TEST_LV2_SLOT_PROBE_BINARY)
+
+constexpr const char* kLv2SlotProbeUri = "http://example.com/pulp/lv2-slot-probe";
+constexpr uint32_t kLv2SlotProbeGain = 4;
+
+#endif
 
 struct ScratchDir {
     fs::path path;
@@ -42,6 +55,106 @@ void write_file(const fs::path& path, const std::string& body) {
     REQUIRE(out.good());
     out << body;
 }
+
+#if defined(PULP_TEST_LV2_SLOT_PROBE_BUNDLE) && defined(PULP_TEST_LV2_SLOT_PROBE_BINARY)
+
+const pulp::host::HostParamInfo* find_param(
+    const std::vector<pulp::host::HostParamInfo>& params,
+    uint32_t id) {
+    auto it = std::find_if(params.begin(), params.end(),
+                           [id](const auto& p) { return p.id == id; });
+    return it == params.end() ? nullptr : &*it;
+}
+
+class Lv2ProbeLibrary {
+public:
+    using VoidFn = void (*)();
+    using U32Fn = uint32_t (*)();
+    using FloatFn = float (*)();
+
+    explicit Lv2ProbeLibrary(const std::string& binary_path) {
+        handle_ = dlopen(binary_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+        REQUIRE(handle_ != nullptr);
+        reset = symbol<VoidFn>("pulp_lv2_slot_probe_reset");
+        instantiate_count =
+            symbol<U32Fn>("pulp_lv2_slot_probe_instantiate_count");
+        decoy_instantiate_count =
+            symbol<U32Fn>("pulp_lv2_slot_probe_decoy_instantiate_count");
+        activate_count =
+            symbol<U32Fn>("pulp_lv2_slot_probe_activate_count");
+        run_count = symbol<U32Fn>("pulp_lv2_slot_probe_run_count");
+        deactivate_count =
+            symbol<U32Fn>("pulp_lv2_slot_probe_deactivate_count");
+        cleanup_count =
+            symbol<U32Fn>("pulp_lv2_slot_probe_cleanup_count");
+        last_sample_count =
+            symbol<U32Fn>("pulp_lv2_slot_probe_last_sample_count");
+        last_gain = symbol<FloatFn>("pulp_lv2_slot_probe_last_gain");
+        reset();
+    }
+
+    ~Lv2ProbeLibrary() {
+        if (handle_) dlclose(handle_);
+    }
+
+    Lv2ProbeLibrary(const Lv2ProbeLibrary&) = delete;
+    Lv2ProbeLibrary& operator=(const Lv2ProbeLibrary&) = delete;
+
+    VoidFn reset = nullptr;
+    U32Fn instantiate_count = nullptr;
+    U32Fn decoy_instantiate_count = nullptr;
+    U32Fn activate_count = nullptr;
+    U32Fn run_count = nullptr;
+    U32Fn deactivate_count = nullptr;
+    U32Fn cleanup_count = nullptr;
+    U32Fn last_sample_count = nullptr;
+    FloatFn last_gain = nullptr;
+
+private:
+    template <typename Fn>
+    Fn symbol(const char* name) const {
+        auto* ptr = dlsym(handle_, name);
+        REQUIRE(ptr != nullptr);
+        return reinterpret_cast<Fn>(ptr);
+    }
+
+    void* handle_ = nullptr;
+};
+
+std::unique_ptr<pulp::host::PluginSlot> load_lv2_slot_probe(
+    Lv2ProbeLibrary& probe) {
+    const std::string bundle = PULP_TEST_LV2_SLOT_PROBE_BUNDLE;
+    if (!fs::exists(bundle)) {
+        WARN("LV2 slot probe bundle not built at " << bundle << " - skipping");
+        return nullptr;
+    }
+
+    probe.reset();
+
+    pulp::host::PluginInfo info;
+    info.name = "LV2 Slot Probe";
+    info.path = bundle;
+    info.format = pulp::host::PluginFormat::LV2;
+    info.unique_id = kLv2SlotProbeUri;
+
+    auto slot = pulp::host::PluginSlot::load(info);
+    REQUIRE(slot != nullptr);
+    REQUIRE(slot->is_loaded());
+    REQUIRE(slot->info().unique_id == kLv2SlotProbeUri);
+    return slot;
+}
+
+std::unique_ptr<pulp::host::PluginSlot> try_load_lv2_slot_probe(
+    Lv2ProbeLibrary& probe) {
+    const std::string binary = PULP_TEST_LV2_SLOT_PROBE_BINARY;
+    if (!fs::exists(binary)) {
+        WARN("LV2 slot probe module not built at " << binary << " - skipping");
+        return nullptr;
+    }
+    return load_lv2_slot_probe(probe);
+}
+
+#endif
 
 } // namespace
 
@@ -152,3 +265,158 @@ TEST_CASE("LV2 PluginSlot load fails cleanly for invalid bundles",
     info.name = "InvalidBinary";
     REQUIRE(PluginSlot::load(info) == nullptr);
 }
+
+#if defined(PULP_TEST_LV2_SLOT_PROBE_BUNDLE) && defined(PULP_TEST_LV2_SLOT_PROBE_BINARY)
+
+TEST_CASE("LV2 PluginSlot loads probe descriptor by URI and exposes TTL params",
+          "[host][lv2][slot][coverage][issue-493]") {
+    Lv2ProbeLibrary probe(PULP_TEST_LV2_SLOT_PROBE_BINARY);
+    auto slot = try_load_lv2_slot_probe(probe);
+    if (!slot) return;
+
+    REQUIRE(probe.decoy_instantiate_count() == 0);
+    REQUIRE(probe.instantiate_count() == 0);
+    REQUIRE(slot->prepare(48000.0, 64));
+    REQUIRE(probe.decoy_instantiate_count() == 0);
+    REQUIRE(probe.instantiate_count() == 1);
+    REQUIRE(probe.activate_count() == 1);
+
+    const auto params = slot->parameters();
+    REQUIRE(params.size() == 1);
+
+    const auto* gain = find_param(params, kLv2SlotProbeGain);
+    REQUIRE(gain != nullptr);
+    REQUIRE(gain->name == "Probe Gain");
+    REQUIRE_THAT(gain->default_value, WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(gain->min_value, WithinAbs(-2.0f, 1e-6f));
+    REQUIRE_THAT(gain->max_value, WithinAbs(4.0f, 1e-6f));
+    REQUIRE(gain->flags.automatable);
+    REQUIRE_FALSE(gain->flags.read_only);
+
+    REQUIRE_THAT(slot->get_parameter(kLv2SlotProbeGain),
+                 WithinAbs(0.5f, 1e-6f));
+
+    slot->release();
+    REQUIRE(probe.deactivate_count() == 1);
+}
+
+TEST_CASE("LV2 PluginSlot processes audio and applies control-port events",
+          "[host][lv2][slot][coverage][issue-493]") {
+    Lv2ProbeLibrary probe(PULP_TEST_LV2_SLOT_PROBE_BINARY);
+    auto slot = try_load_lv2_slot_probe(probe);
+    if (!slot) return;
+
+    constexpr int kFrames = 16;
+    REQUIRE(slot->prepare(48000.0, kFrames));
+
+    std::vector<float> in_l(kFrames);
+    std::vector<float> in_r(kFrames);
+    std::vector<float> out_l(kFrames, 0.0f);
+    std::vector<float> out_r(kFrames, 0.0f);
+    for (int i = 0; i < kFrames; ++i) {
+        in_l[static_cast<size_t>(i)] = 0.25f + 0.01f * static_cast<float>(i);
+        in_r[static_cast<size_t>(i)] = -0.50f + 0.02f * static_cast<float>(i);
+    }
+
+    const float* in_ptrs[2] = {in_l.data(), in_r.data()};
+    float* out_ptrs[2] = {out_l.data(), out_r.data()};
+    pulp::audio::BufferView<const float> input(in_ptrs, 2, kFrames);
+    pulp::audio::BufferView<float> output(out_ptrs, 2, kFrames);
+    pulp::midi::MidiBuffer midi_in;
+    pulp::midi::MidiBuffer midi_out;
+
+    slot->set_parameter(kLv2SlotProbeGain, 1.25f);
+    pulp::host::ParameterEventQueue empty_events;
+    slot->process(output, input, midi_in, midi_out, empty_events, kFrames);
+
+    REQUIRE(probe.run_count() == 1);
+    REQUIRE(probe.last_sample_count() == kFrames);
+    REQUIRE_THAT(probe.last_gain(), WithinAbs(1.25f, 1e-6f));
+    REQUIRE_THAT(out_l[3], WithinAbs(in_l[3] * 1.25f, 1e-6f));
+    REQUIRE_THAT(out_r[7], WithinAbs(in_r[7] * 1.25f, 1e-6f));
+    REQUIRE_THAT(slot->get_parameter(kLv2SlotProbeGain),
+                 WithinAbs(1.25f, 1e-6f));
+
+    std::fill(out_l.begin(), out_l.end(), 0.0f);
+    std::fill(out_r.begin(), out_r.end(), 0.0f);
+    slot->set_parameter(kLv2SlotProbeGain, 0.75f);
+
+    pulp::host::ParameterEventQueue param_events;
+    param_events.push({kLv2SlotProbeGain, 0, 1.5f});
+    param_events.push({kLv2SlotProbeGain, kFrames - 1, 2.0f});
+    param_events.sort();
+    slot->process(output, input, midi_in, midi_out, param_events, kFrames);
+
+    REQUIRE(probe.run_count() == 2);
+    REQUIRE_THAT(probe.last_gain(), WithinAbs(2.0f, 1e-6f));
+    REQUIRE_THAT(out_l[3], WithinAbs(in_l[3] * 2.0f, 1e-6f));
+    REQUIRE_THAT(out_r[7], WithinAbs(in_r[7] * 2.0f, 1e-6f));
+    REQUIRE_THAT(slot->get_parameter(kLv2SlotProbeGain),
+                 WithinAbs(2.0f, 1e-6f));
+
+    slot->release();
+}
+
+TEST_CASE("LV2 PluginSlot bypass and released processing avoid LV2 run",
+          "[host][lv2][slot][coverage][issue-493]") {
+    Lv2ProbeLibrary probe(PULP_TEST_LV2_SLOT_PROBE_BINARY);
+    auto slot = try_load_lv2_slot_probe(probe);
+    if (!slot) return;
+
+    constexpr int kFrames = 8;
+    REQUIRE(slot->prepare(44100.0, kFrames));
+
+    std::vector<float> in_l(kFrames);
+    std::vector<float> in_r(kFrames);
+    std::vector<float> out_l(kFrames, 9.0f);
+    std::vector<float> out_r(kFrames, 9.0f);
+    std::vector<float> out_extra(kFrames, 9.0f);
+    for (int i = 0; i < kFrames; ++i) {
+        in_l[static_cast<size_t>(i)] = 0.1f * static_cast<float>(i + 1);
+        in_r[static_cast<size_t>(i)] = -0.2f * static_cast<float>(i + 1);
+    }
+
+    const float* in_ptrs[2] = {in_l.data(), in_r.data()};
+    float* out_ptrs[3] = {out_l.data(), out_r.data(), out_extra.data()};
+    pulp::audio::BufferView<const float> input(in_ptrs, 2, kFrames);
+    pulp::audio::BufferView<float> output(out_ptrs, 3, kFrames);
+    pulp::midi::MidiBuffer midi_in;
+    pulp::midi::MidiBuffer midi_out;
+    pulp::host::ParameterEventQueue events;
+
+    slot->set_bypass(true);
+    REQUIRE(slot->is_bypassed());
+    const auto before_bypass = probe.run_count();
+    slot->process(output, input, midi_in, midi_out, events, kFrames);
+    REQUIRE(probe.run_count() == before_bypass);
+
+    for (int i = 0; i < kFrames; ++i) {
+        REQUIRE_THAT(out_l[static_cast<size_t>(i)],
+                     WithinAbs(in_l[static_cast<size_t>(i)], 1e-6f));
+        REQUIRE_THAT(out_r[static_cast<size_t>(i)],
+                     WithinAbs(in_r[static_cast<size_t>(i)], 1e-6f));
+        REQUIRE_THAT(out_extra[static_cast<size_t>(i)],
+                     WithinAbs(0.0f, 1e-6f));
+    }
+
+    std::fill(out_l.begin(), out_l.end(), 8.0f);
+    std::fill(out_r.begin(), out_r.end(), 8.0f);
+    std::fill(out_extra.begin(), out_extra.end(), 8.0f);
+
+    slot->set_bypass(false);
+    slot->release();
+    const auto before_released = probe.run_count();
+    slot->process(output, input, midi_in, midi_out, events, kFrames);
+    REQUIRE(probe.run_count() == before_released);
+
+    for (int i = 0; i < kFrames; ++i) {
+        REQUIRE_THAT(out_l[static_cast<size_t>(i)],
+                     WithinAbs(in_l[static_cast<size_t>(i)], 1e-6f));
+        REQUIRE_THAT(out_r[static_cast<size_t>(i)],
+                     WithinAbs(in_r[static_cast<size_t>(i)], 1e-6f));
+        REQUIRE_THAT(out_extra[static_cast<size_t>(i)],
+                     WithinAbs(0.0f, 1e-6f));
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary
- Add a generated LV2 probe bundle fixture for host-side PluginSlot coverage.
- Cover LV2 PluginSlot descriptor selection by URI, TTL control metadata exposure, prepare/release lifecycle, set_parameter/process, queued parameter events, bypass pass-through, and released-state pass-through.
- Link Phase 3 coverage work for #493 and #641.

## Validation
- cmake --build build --target pulp-test-lv2-host-discovery -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-lv2-host-discovery
- cmake --build build --target pulp-test-lv2-adapter -j$(sysctl -n hw.ncpu) && ctest --test-dir build -R 'lv2|LV2|pulp-test-lv2-host-discovery' --output-on-failure
- git diff --check
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report

Refs #493
Refs #641