### PR TITLE
fix(audio): make empty focus subscriptions inert

### DIFF
--- a/core/audio/src/audio_focus.cpp
+++ b/core/audio/src/audio_focus.cpp
@@ -19,6 +19,8 @@ AudioFocusRegistry& AudioFocusRegistry::instance() {
 }
 
 AudioFocusRegistry::Token AudioFocusRegistry::subscribe(Callback cb) {
+    if (!cb) return Token{};
+
     std::lock_guard<std::mutex> lock(mtx_);
     int id = next_id_++;
     cbs_.emplace_back(id, std::move(cb));
@@ -49,7 +51,7 @@ void AudioFocusRegistry::publish(AudioFocusState state) {
         snapshot = cbs_;
     }
     for (auto& [id, cb] : snapshot) {
-        cb(state);
+        if (cb) cb(state);
     }
 }
 

--- a/test/test_audio_focus.cpp
+++ b/test/test_audio_focus.cpp
@@ -113,6 +113,18 @@ TEST_CASE("AudioFocusRegistry: default token reset is a no-op",
     REQUIRE(token.id() == 0);
 }
 
+TEST_CASE("AudioFocusRegistry: empty subscription is inert",
+          "[audio][focus][issue-640]") {
+    AudioFocusRegistry::instance().reset_for_test();
+
+    auto token = AudioFocusRegistry::instance().subscribe({});
+
+    REQUIRE(token.id() == 0);
+    REQUIRE_NOTHROW(
+        AudioFocusRegistry::instance().publish(AudioFocusState::duck));
+    REQUIRE(AudioFocusRegistry::instance().current() == AudioFocusState::duck);
+}
+
 TEST_CASE("AudioFocusRegistry: callback that drops its own token does not deadlock",
           "[audio][focus][issue-334]") {
     AudioFocusRegistry::instance().reset_for_test();


### PR DESCRIPTION
## Summary
- Make empty `AudioFocusRegistry` subscriptions inert by returning a default token instead of registering an empty callback.
- Guard focus-state dispatch against empty callbacks.
- Add Phase 3 coverage for empty focus subscriptions under #640.

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar
- cmake --build build --target pulp-test-audio-focus -j$(sysctl -n hw.ncpu)
- ctest --test-dir build -R '^AudioFocusRegistry' --output-on-failure (14/14 passed)
- git diff --check
- python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main --head HEAD
- python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD

Refs #640
Refs #641