### PR TITLE
test(runtime): cover range edge paths

### DIFF
--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -260,6 +260,35 @@ TEST_CASE("Range from_start_length", "[runtime][range]") {
     REQUIRE(r.length() == 10);
 }
 
+TEST_CASE("Range covers containment and equality edge paths",
+          "[runtime][range][coverage][issue-641]") {
+    IntRange outer(0, 10);
+
+    REQUIRE(outer.contains(IntRange(0, 10)));
+    REQUIRE(outer.contains(IntRange(2, 8)));
+    REQUIRE(outer.contains(IntRange(5, 5)));
+    REQUIRE_FALSE(outer.contains(IntRange(-1, 5)));
+    REQUIRE_FALSE(outer.contains(IntRange(5, 11)));
+
+    REQUIRE(outer == IntRange(0, 10));
+    REQUIRE(outer != IntRange(0, 9));
+}
+
+TEST_CASE("Range expands empty and non-empty intervals",
+          "[runtime][range][coverage][issue-641]") {
+    REQUIRE(IntRange(5, 5).expanded(8) == IntRange(8, 9));
+    REQUIRE(IntRange(3, 7).expanded(10) == IntRange(3, 11));
+    REQUIRE(IntRange(3, 7).expanded(-2) == IntRange(-2, 7));
+    REQUIRE(IntRange(3, 7).expanded(5) == IntRange(3, 7));
+}
+
+TEST_CASE("Range union handles empty operands",
+          "[runtime][range][coverage][issue-641]") {
+    REQUIRE(IntRange().enclosing_union(IntRange(4, 9)) == IntRange(4, 9));
+    REQUIRE(IntRange(4, 9).enclosing_union(IntRange()) == IntRange(4, 9));
+    REQUIRE(IntRange().enclosing_union(IntRange()) == IntRange());
+}
+
 TEST_CASE("FloatRange", "[runtime][range]") {
     FloatRange r(0.0f, 1.0f);
     REQUIRE(r.contains(0.5f));


### PR DESCRIPTION
## Summary
- Add Phase 3 coverage for `Range<T>` containment, equality, expansion, and empty-union edge paths.
- Keep the slice test-only and limited to `pulp-test-runtime-utils`.

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar
- cmake --build build --target pulp-test-runtime-utils -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-runtime-utils "[runtime][range]" (34 assertions, 10 test cases)
- ctest --test-dir build -R "Range covers|Range expands|Range union" --output-on-failure (4/4 passed)
- git diff --check
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report

Refs #641