### PR TITLE
feat(view): RN style-prop bridge primitives (pulp #1026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0670"></a>
+## [0.68.0]
+
 ## [0.67.0] - 2026-04-30
 
 - feat(cli): emit classnames.json from import-design --from claude (#1035) ([#1048](https://github.com/danielraffel/pulp/pull/1048))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.67.0
+    VERSION 0.68.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -218,6 +218,29 @@ public:
     bool hit_testable() const { return hit_testable_; }
     void set_hit_testable(bool h) { hit_testable_ = h; }
 
+    /// React Native pointerEvents (issue-1026). Four-valued enum that
+    /// mirrors RN's contract:
+    ///   auto      — default; this view AND children are interactive.
+    ///   none      — neither this view NOR descendants intercept events.
+    ///   box_only  — this view receives events; children do NOT.
+    ///   box_none  — this view does NOT receive events but children do.
+    /// hit_test() honors all four cases. set_hit_testable(false) is the
+    /// legacy two-valued knob and is preserved by also short-circuiting
+    /// hit_test() — set_pointer_events(PointerEvents::none) is the
+    /// idiomatic RN-shaped equivalent.
+    enum class PointerEvents { auto_, none, box_only, box_none };
+    void set_pointer_events(PointerEvents p) { pointer_events_ = p; }
+    PointerEvents pointer_events() const { return pointer_events_; }
+
+    /// React Native backfaceVisibility (issue-1026). Stored on the View
+    /// for plumbing parity with `@pulp/react`. The flag is consumed by
+    /// the paint path only when a 3D transform with negative Z is
+    /// active; pulp's transform model is currently 2D-affine, so this
+    /// is reserved for future 3D support and behaves as a no-op for
+    /// painting today.
+    bool backface_visible() const { return backface_visible_; }
+    void set_backface_visible(bool v) { backface_visible_ = v; }
+
     /// Mark layout as needing recalculation (auto-invalidation)
     void invalidate_layout() { layout_dirty_ = true; }
     bool layout_dirty() const { return layout_dirty_; }
@@ -286,17 +309,42 @@ public:
     float border_width() const { return border_width_; }
     float corner_radius() const { return corner_radius_; }
 
+    /// Standalone border setters (issue-1026, RN parity). Each setter
+    /// flips the has_border_ flag on so paint_all() actually emits the
+    /// stroke even when set_border() was never called.
+    void set_border_color(Color c) { border_color_ = c; has_border_ = true; }
+    void set_border_width(float w) { border_width_ = w; has_border_ = true; }
+    void set_border_radius(float r) { corner_radius_ = r; }
+
     /// Per-side borders (CSS border-top, border-right, etc.)
     void set_border_top(Color c, float w) { border_top_ = {c, w}; has_border_sides_ = true; }
     void set_border_right(Color c, float w) { border_right_ = {c, w}; has_border_sides_ = true; }
     void set_border_bottom(Color c, float w) { border_bottom_ = {c, w}; has_border_sides_ = true; }
     void set_border_left(Color c, float w) { border_left_ = {c, w}; has_border_sides_ = true; }
+    /// Per-side getters (issue-1026). The standalone setBorderTop/Right/...
+    /// {Color,Width} bridge calls need to preserve the unrelated attribute
+    /// when only one is being changed by a JSX prop diff.
+    Color border_top_color() const { return border_top_.color; }
+    float border_top_width() const { return border_top_.width; }
+    Color border_right_color() const { return border_right_.color; }
+    float border_right_width() const { return border_right_.width; }
+    Color border_bottom_color() const { return border_bottom_.color; }
+    float border_bottom_width() const { return border_bottom_.width; }
+    Color border_left_color() const { return border_left_.color; }
+    float border_left_width() const { return border_left_.width; }
+    bool has_border_sides() const { return has_border_sides_; }
 
     /// Per-corner border-radius (CSS border-top-left-radius, etc.)
     void set_corner_radius_tl(float r) { corner_radii_[0] = r; has_corner_radii_ = true; }
     void set_corner_radius_tr(float r) { corner_radii_[1] = r; has_corner_radii_ = true; }
     void set_corner_radius_bl(float r) { corner_radii_[2] = r; has_corner_radii_ = true; }
     void set_corner_radius_br(float r) { corner_radii_[3] = r; has_corner_radii_ = true; }
+    /// Per-corner radius accessors. corner_radii_[0..3] = TL, TR, BL, BR.
+    bool has_corner_radii() const { return has_corner_radii_; }
+    float corner_radius_tl() const { return corner_radii_[0]; }
+    float corner_radius_tr() const { return corner_radii_[1]; }
+    float corner_radius_bl() const { return corner_radii_[2]; }
+    float corner_radius_br() const { return corner_radii_[3]; }
 
     /// Box shadow (CSS-like: offset, blur, spread, color, inset).
     /// When `inset` is true, the shadow is drawn inside the box bounds (CSS
@@ -403,10 +451,17 @@ public:
 
     void set_skew(float x_deg, float y_deg) { skew_x_ = x_deg; skew_y_ = y_deg; }
 
-    /// Transform origin (0-1 normalized, default 0.5,0.5 = center)
-    void set_transform_origin(float x, float y) { origin_x_ = x; origin_y_ = y; }
+    /// Transform origin (0-1 normalized, default 0.5,0.5 = center).
+    /// pulp #1026 — also tracks an "explicitly set" flag so the affine
+    /// matrix path (issue-930 setTransform) only honors the origin when
+    /// the caller has actively chosen one. Without this, every existing
+    /// setTransform() call site would silently start anchoring at center.
+    void set_transform_origin(float x, float y) {
+        origin_x_ = x; origin_y_ = y; origin_explicit_ = true;
+    }
     float transform_origin_x() const { return origin_x_; }
     float transform_origin_y() const { return origin_y_; }
+    bool transform_origin_explicit() const { return origin_explicit_; }
 
     /// Full 2D affine transform matrix on the View (issue-930). Mirrors the
     /// CanvasRenderingContext2D.setTransform contract:
@@ -519,6 +574,8 @@ private:
     bool has_focus_ = false;
     bool hovered_ = false;
     bool hit_testable_ = true;
+    PointerEvents pointer_events_ = PointerEvents::auto_;
+    bool backface_visible_ = true;
     FrameClock* frame_clock_ = nullptr;
 
     // Visual properties
@@ -554,6 +611,7 @@ private:
     float rotation_deg_ = 0;
     float skew_x_ = 0, skew_y_ = 0;
     float origin_x_ = 0.5f, origin_y_ = 0.5f;  // transform-origin (normalized)
+    bool origin_explicit_ = false;  // pulp #1026 — has set_transform_origin been called?
     // Full 2D affine matrix (issue-930). Identity by default; only applied
     // when has_transform_matrix_ is true. Stored in CanvasRenderingContext2D
     // (a,b,c,d,e,f) order:  [a c e / b d f / 0 0 1].

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -7,6 +7,73 @@
 
 namespace pulp::view {
 
+namespace {
+
+// Build a per-corner rounded-rect path on the canvas (issue-1026). When any
+// of setBorderTopLeftRadius / TopRight / BottomLeft / BottomRight has been
+// called on the View, the four corners can have independent radii — which
+// the canvas's single-radius fill_rounded_rect / stroke_rounded_rect APIs
+// cannot express on their own. We approximate each corner with a single
+// cubic_to whose control magnitude is r * 0.55228 — the standard
+// "kappa" approximation of a quarter-circle by a Bezier. Subclasses of
+// Canvas that lack a real cubic_to fall back to line_to via the base class.
+//
+// Layout (TL, TR, BL, BR are clamped to half the box):
+//
+//      tl                 tr
+//        +---------------+
+//        |               |
+//      bl|               |br
+//        +---------------+
+void build_per_corner_rounded_rect_path(
+    pulp::canvas::Canvas& canvas,
+    float w, float h,
+    float tl, float tr, float bl, float br) {
+    const float half_w = w * 0.5f;
+    const float half_h = h * 0.5f;
+    auto clamp = [&](float r) {
+        const float lim = std::min(half_w, half_h);
+        return std::max(0.0f, std::min(r, lim));
+    };
+    tl = clamp(tl);
+    tr = clamp(tr);
+    bl = clamp(bl);
+    br = clamp(br);
+    // Cubic kappa for quarter-circle approximation.
+    constexpr float k = 0.5522847498f;
+
+    canvas.begin_path();
+    // Start at top edge after TL corner.
+    canvas.move_to(tl, 0.0f);
+    // Top edge → top-right corner.
+    canvas.line_to(w - tr, 0.0f);
+    if (tr > 0.0f)
+        canvas.cubic_to(w - tr + tr * k, 0.0f,
+                        w, tr - tr * k,
+                        w, tr);
+    // Right edge → bottom-right corner.
+    canvas.line_to(w, h - br);
+    if (br > 0.0f)
+        canvas.cubic_to(w, h - br + br * k,
+                        w - br + br * k, h,
+                        w - br, h);
+    // Bottom edge → bottom-left corner.
+    canvas.line_to(bl, h);
+    if (bl > 0.0f)
+        canvas.cubic_to(bl - bl * k, h,
+                        0.0f, h - bl + bl * k,
+                        0.0f, h - bl);
+    // Left edge → top-left corner.
+    canvas.line_to(0.0f, tl);
+    if (tl > 0.0f)
+        canvas.cubic_to(0.0f, tl - tl * k,
+                        tl - tl * k, 0.0f,
+                        tl, 0.0f);
+    canvas.close_path();
+}
+
+} // namespace
+
 void View::paint_all(canvas::Canvas& canvas) {
     if (!visible_) return;
 
@@ -47,10 +114,23 @@ void View::paint_all(canvas::Canvas& canvas) {
     // canvas matrix via concat_transform so parent transforms still apply
     // and children inherit. Used by setTransform(id,a,b,c,d,e,f) from JS,
     // primarily for translateX(-50%) centering and future animation.
+    //
+    // pulp #1026 — transform-origin now applies to the matrix path too,
+    // BUT only when the caller has explicitly called setTransformOrigin.
+    // Existing setTransform() call sites that never touched the origin
+    // continue to get a plain concat (backward-compat with #930). When
+    // an explicit origin is set, the canvas op equivalent of "transform
+    // around origin (ox, oy)" is
+    //   translate(ox, oy) ; concat(M) ; translate(-ox, -oy).
     if (has_transform_matrix_) {
+        const bool apply_origin = origin_explicit_;
+        const float ox = bounds_.width  * origin_x_;
+        const float oy = bounds_.height * origin_y_;
+        if (apply_origin) canvas.translate(ox, oy);
         canvas.concat_transform(transform_matrix_a_, transform_matrix_b_,
                                 transform_matrix_c_, transform_matrix_d_,
                                 transform_matrix_e_, transform_matrix_f_);
+        if (apply_origin) canvas.translate(-ox, -oy);
     }
 
     // CSS `backdrop-filter: blur(N)` (issue-926). A separate compositing layer
@@ -102,6 +182,14 @@ void View::paint_all(canvas::Canvas& canvas) {
     if (overflow_ == Overflow::hidden)
         canvas.clip_rect(0, 0, bounds_.width, bounds_.height);
 
+    // Per-corner border-radius (issue-1026): when any of the
+    // setBorderTopLeftRadius / TopRight / BottomLeft / BottomRight setters
+    // has been called we paint backgrounds and the border via a path
+    // approximating each corner independently. Otherwise we keep using the
+    // canvas's optimized fill_rounded_rect / stroke_rounded_rect with the
+    // uniform corner_radius_.
+    const bool use_per_corner = has_corner_radii_;
+
     // Paint background gradient if set (CSS background: linear-gradient)
     if (bg_gradient_type_ > 0 && !bg_gradient_colors_.empty()) {
         canvas.set_fill_gradient_linear(
@@ -109,30 +197,48 @@ void View::paint_all(canvas::Canvas& canvas) {
             bg_grad_x1_ * bounds_.width, bg_grad_y1_ * bounds_.height,
             bg_gradient_colors_.data(), bg_gradient_positions_.data(),
             static_cast<int>(bg_gradient_colors_.size()));
-        if (corner_radius_ > 0)
+        if (use_per_corner) {
+            build_per_corner_rounded_rect_path(canvas, bounds_.width, bounds_.height,
+                                               corner_radii_[0], corner_radii_[1],
+                                               corner_radii_[2], corner_radii_[3]);
+            canvas.fill_current_path();
+        } else if (corner_radius_ > 0) {
             canvas.fill_rounded_rect(0, 0, bounds_.width, bounds_.height, corner_radius_);
-        else
+        } else {
             canvas.fill_rect(0, 0, bounds_.width, bounds_.height);
+        }
         canvas.clear_fill_gradient();
     }
 
     // Paint background if set
     if (has_bg_ && bg_gradient_type_ == 0) {
         canvas.set_fill_color(bg_color_);
-        if (corner_radius_ > 0)
+        if (use_per_corner) {
+            build_per_corner_rounded_rect_path(canvas, bounds_.width, bounds_.height,
+                                               corner_radii_[0], corner_radii_[1],
+                                               corner_radii_[2], corner_radii_[3]);
+            canvas.fill_current_path();
+        } else if (corner_radius_ > 0) {
             canvas.fill_rounded_rect(0, 0, bounds_.width, bounds_.height, corner_radius_);
-        else
+        } else {
             canvas.fill_rect(0, 0, bounds_.width, bounds_.height);
+        }
     }
 
     // Paint border if set
     if (has_border_ && border_width_ > 0) {
         canvas.set_stroke_color(border_color_);
         canvas.set_line_width(border_width_);
-        if (corner_radius_ > 0)
+        if (use_per_corner) {
+            build_per_corner_rounded_rect_path(canvas, bounds_.width, bounds_.height,
+                                               corner_radii_[0], corner_radii_[1],
+                                               corner_radii_[2], corner_radii_[3]);
+            canvas.stroke_current_path();
+        } else if (corner_radius_ > 0) {
             canvas.stroke_rounded_rect(0, 0, bounds_.width, bounds_.height, corner_radius_);
-        else
+        } else {
             canvas.stroke_rect(0, 0, bounds_.width, bounds_.height);
+        }
     }
 
     // Widget-specific painting
@@ -324,36 +430,51 @@ std::vector<View*> View::sorted_children_by_z_index() const {
 View* View::hit_test(Point local_point) {
     if (!visible_ || !enabled_ || !hit_testable_) return nullptr;
 
+    // React Native pointerEvents (issue-1026):
+    //   none      — neither this view nor children intercept events.
+    //   box_none  — this view is invisible to hit-testing but children
+    //               can still receive events (descend, but never return self).
+    //   box_only  — this view receives events; children do NOT
+    //               (skip the descent below, then check own bounds).
+    //   auto_     — default behavior.
+    if (pointer_events_ == PointerEvents::none) return nullptr;
+
     // Check children topmost-first (pulp #972). With z-index honored,
     // "topmost" means highest z_index — and at equal z, latest insertion
     // — so iterate the z-sorted paint order in reverse. Without this,
     // a high-z popover could render on top yet have clicks fall through
     // to siblings beneath it.
-    auto paint_order = sorted_children_by_z_index();
-    for (auto it = paint_order.rbegin(); it != paint_order.rend(); ++it) {
-        View* child = *it;
-        if (!child->visible_) continue;
+    if (pointer_events_ != PointerEvents::box_only) {
+        auto paint_order = sorted_children_by_z_index();
+        for (auto it = paint_order.rbegin(); it != paint_order.rend(); ++it) {
+            View* child = *it;
+            if (!child->visible_) continue;
 
-        Point child_point = {local_point.x - child->bounds_.x,
-                            local_point.y - child->bounds_.y};
+            Point child_point = {local_point.x - child->bounds_.x,
+                                local_point.y - child->bounds_.y};
 
-        // For overflow:visible, expand the hit area to include content
-        // that extends beyond the child's bounds (e.g., dropdown menus)
-        bool in_bounds = child->local_bounds().contains(child_point);
-        if (!in_bounds && child->overflow() == Overflow::visible) {
-            // Allow hit testing up to 500px below the child (for dropdowns)
-            auto lb = child->local_bounds();
-            in_bounds = child_point.x >= lb.x && child_point.x <= lb.x + lb.width &&
-                       child_point.y >= lb.y && child_point.y <= lb.y + lb.height + 500;
-        }
+            // For overflow:visible, expand the hit area to include content
+            // that extends beyond the child's bounds (e.g., dropdown menus)
+            bool in_bounds = child->local_bounds().contains(child_point);
+            if (!in_bounds && child->overflow() == Overflow::visible) {
+                // Allow hit testing up to 500px below the child (for dropdowns)
+                auto lb = child->local_bounds();
+                in_bounds = child_point.x >= lb.x && child_point.x <= lb.x + lb.width &&
+                        child_point.y >= lb.y && child_point.y <= lb.y + lb.height + 500;
+            }
 
-        if (in_bounds) {
-            auto* hit = child->hit_test(child_point);
-            if (hit) return hit;
+            if (in_bounds) {
+                auto* hit = child->hit_test(child_point);
+                if (hit) return hit;
+            }
         }
     }
 
-    // No child was hit — return this view if the point is within bounds
+    // No child was hit — return this view if the point is within bounds.
+    // box_none suppresses self-targeting even when a child miss falls back
+    // here, matching RN's "container is just a layout pass-through" mode.
+    if (pointer_events_ == PointerEvents::box_none) return nullptr;
+
     if (local_bounds().contains(local_point))
         return this;
 

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1767,11 +1767,46 @@ void WidgetBridge::register_api() {
     });
 
     // setPointerEvents(id, "none"|"auto") — CSS pointer-events: skip in hit_test
+    // pulp #1026 — RN-shaped 4-valued pointerEvents:
+    //   "auto"     — default, this view + children intercept events.
+    //   "none"     — neither this view nor descendants intercept events.
+    //   "box-only" — this view intercepts; children do NOT.
+    //   "box-none" — this view does NOT intercept; children do.
+    // Pre-#1026 the bridge only honored auto / none and routed through
+    // set_hit_testable(); we keep that mapping for the binary cases for
+    // back-compat with existing scripts and additionally route the new
+    // four-valued enum via View::set_pointer_events().
     engine_.register_function("setPointerEvents", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto mode = args.get<std::string>(1, "auto");
         auto* v = id.empty() ? &root_ : widget(id);
-        if (v) v->set_hit_testable(mode != "none");
+        if (!v) return choc::value::Value();
+        if (mode == "none") {
+            v->set_hit_testable(false);
+            v->set_pointer_events(View::PointerEvents::none);
+        } else if (mode == "box-only" || mode == "box_only") {
+            v->set_hit_testable(true);
+            v->set_pointer_events(View::PointerEvents::box_only);
+        } else if (mode == "box-none" || mode == "box_none") {
+            v->set_hit_testable(true);
+            v->set_pointer_events(View::PointerEvents::box_none);
+        } else {
+            v->set_hit_testable(true);
+            v->set_pointer_events(View::PointerEvents::auto_);
+        }
+        return choc::value::Value();
+    });
+
+    // pulp #1026 — RN backfaceVisibility ("visible"|"hidden"). Stored on
+    // the View for plumbing parity with @pulp/react. The flag is consumed
+    // by the paint path only when a 3D transform with negative Z is
+    // active; pulp's transform model is currently 2D-affine, so this is
+    // a no-op for painting today and reserved for future 3D support.
+    engine_.register_function("setBackfaceVisibility", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto mode = args.get<std::string>(1, "visible");
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) v->set_backface_visible(mode != "hidden");
         return choc::value::Value();
     });
 
@@ -2417,6 +2452,190 @@ void WidgetBridge::register_api() {
             else if (corner == "BottomLeft") v->set_corner_radius_bl(r);
             else if (corner == "BottomRight") v->set_corner_radius_br(r);
         }
+        return choc::value::Value();
+    });
+
+    // pulp #1026 — Standalone border setters (RN parity). The shorthand
+    // setBorder(id, color, width, radius) is convenient for atomic style
+    // application but @pulp/react's prop-applier needs per-attribute
+    // setters so individual JSX style props (`borderColor`, `borderWidth`,
+    // `borderRadius`) can update without recomputing the others.
+    //
+    // setBorderColor(id, hex)
+    engine_.register_function("setBorderColor", [this, parseHexColor](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto hex = args.get<std::string>(1, "");
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v && !hex.empty()) v->set_border_color(parseHexColor(hex));
+        return choc::value::Value();
+    });
+
+    // setBorderWidth(id, width)
+    engine_.register_function("setBorderWidth", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto width = static_cast<float>(args.get<double>(1, 1.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) v->set_border_width(width);
+        return choc::value::Value();
+    });
+
+    // setBorderRadius(id, radius) — uniform corner radius. Per-corner
+    // setters (setBorderTopLeftRadius / TopRight / BottomLeft / BottomRight)
+    // override individual corners on top of the uniform value.
+    engine_.register_function("setBorderRadius", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto radius = static_cast<float>(args.get<double>(1, 0.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) v->set_border_radius(radius);
+        return choc::value::Value();
+    });
+
+    // pulp #1026 — Per-corner border-radius shorthands (RN parity).
+    // Equivalent to `setCornerRadius(id, "TopLeft", r)` but matches the
+    // RN style-prop name 1:1 so @pulp/react's prop-applier can bind them
+    // without a translation layer. Sets the `has_corner_radii_` flag on
+    // the View; paint_all() then routes background/border through the
+    // per-corner path builder rather than fill_rounded_rect.
+    engine_.register_function("setBorderTopLeftRadius", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto r = static_cast<float>(args.get<double>(1, 0.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) v->set_corner_radius_tl(r);
+        return choc::value::Value();
+    });
+    engine_.register_function("setBorderTopRightRadius", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto r = static_cast<float>(args.get<double>(1, 0.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) v->set_corner_radius_tr(r);
+        return choc::value::Value();
+    });
+    engine_.register_function("setBorderBottomLeftRadius", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto r = static_cast<float>(args.get<double>(1, 0.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) v->set_corner_radius_bl(r);
+        return choc::value::Value();
+    });
+    engine_.register_function("setBorderBottomRightRadius", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto r = static_cast<float>(args.get<double>(1, 0.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) v->set_corner_radius_br(r);
+        return choc::value::Value();
+    });
+
+    // pulp #1026 — Per-side border color/width shorthands (RN parity).
+    // RN exposes `borderTopColor`, `borderTopWidth`, etc. as separate
+    // style props; pulp's existing `setBorderSide(id, side, width, color)`
+    // sets both at once which is awkward for a prop-by-prop applier. The
+    // setBorderTop/Right/Bottom/Left{Color,Width} setters route through
+    // the per-side fields preserving whichever attribute the call doesn't
+    // specify.
+    auto applyBorderSide = [](View* v, const std::string& side,
+                              std::optional<canvas::Color> color,
+                              std::optional<float> width) {
+        if (!v) return;
+        // pulp #1026 — preserve the unrelated attribute when a per-side
+        // setter is called for only color OR only width, matching how
+        // RN's JSX prop-applier emits property updates one at a time.
+        canvas::Color cur_color{};
+        float cur_width = 0.0f;
+        if (side == "top")    { cur_color = v->border_top_color();    cur_width = v->border_top_width(); }
+        else if (side == "right") { cur_color = v->border_right_color();  cur_width = v->border_right_width(); }
+        else if (side == "bottom"){ cur_color = v->border_bottom_color(); cur_width = v->border_bottom_width(); }
+        else if (side == "left")  { cur_color = v->border_left_color();   cur_width = v->border_left_width(); }
+        canvas::Color c = color.value_or(cur_color);
+        float w = width.value_or(cur_width);
+        if (side == "top") v->set_border_top(c, w);
+        else if (side == "right") v->set_border_right(c, w);
+        else if (side == "bottom") v->set_border_bottom(c, w);
+        else if (side == "left") v->set_border_left(c, w);
+    };
+    engine_.register_function("setBorderTopColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto hex = args.get<std::string>(1, "");
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v && !hex.empty()) applyBorderSide(v, "top", parseHexColor(hex), std::nullopt);
+        return choc::value::Value();
+    });
+    engine_.register_function("setBorderRightColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto hex = args.get<std::string>(1, "");
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v && !hex.empty()) applyBorderSide(v, "right", parseHexColor(hex), std::nullopt);
+        return choc::value::Value();
+    });
+    engine_.register_function("setBorderBottomColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto hex = args.get<std::string>(1, "");
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v && !hex.empty()) applyBorderSide(v, "bottom", parseHexColor(hex), std::nullopt);
+        return choc::value::Value();
+    });
+    engine_.register_function("setBorderLeftColor", [this, parseHexColor, applyBorderSide](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto hex = args.get<std::string>(1, "");
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v && !hex.empty()) applyBorderSide(v, "left", parseHexColor(hex), std::nullopt);
+        return choc::value::Value();
+    });
+    engine_.register_function("setBorderTopWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto w = static_cast<float>(args.get<double>(1, 1.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) applyBorderSide(v, "top", std::nullopt, w);
+        return choc::value::Value();
+    });
+    engine_.register_function("setBorderRightWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto w = static_cast<float>(args.get<double>(1, 1.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) applyBorderSide(v, "right", std::nullopt, w);
+        return choc::value::Value();
+    });
+    engine_.register_function("setBorderBottomWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto w = static_cast<float>(args.get<double>(1, 1.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) applyBorderSide(v, "bottom", std::nullopt, w);
+        return choc::value::Value();
+    });
+    engine_.register_function("setBorderLeftWidth", [this, applyBorderSide](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto w = static_cast<float>(args.get<double>(1, 1.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (v) applyBorderSide(v, "left", std::nullopt, w);
+        return choc::value::Value();
+    });
+
+    // pulp #1026 — RN-shaped shadow primitive. RN's View style-prop names
+    // are { shadowColor, shadowOffset: {x,y}, shadowOpacity, shadowRadius }
+    // — none of which carries spread or inset. We lower these onto the
+    // existing pulp #925 box-shadow primitive (which carries spread+inset
+    // for CSS parity) by:
+    //   - hex carrying alpha 1.0 ('#RRGGBBff')
+    //   - composing shadowOpacity into the alpha channel (0..1)
+    //   - using shadowRadius as the blur, spread = 0, inset = false.
+    // The underlying setBoxShadow is left unchanged so CSS-style consumers
+    // keep working unaltered.
+    engine_.register_function("setShadow", [this, parseHexColor](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto hex = args.get<std::string>(1, "#000000ff");
+        auto ox = static_cast<float>(args.get<double>(2, 0.0));
+        auto oy = static_cast<float>(args.get<double>(3, 0.0));
+        auto opacity = static_cast<float>(args.get<double>(4, 1.0));
+        auto radius = static_cast<float>(args.get<double>(5, 0.0));
+        auto* v = id.empty() ? &root_ : widget(id);
+        if (!v) return choc::value::Value();
+        auto color = parseHexColor(hex);
+        opacity = std::clamp(opacity, 0.0f, 1.0f);
+        // RN composes opacity multiplicatively with whatever alpha came
+        // from shadowColor. Default shadowColor is opaque black, so
+        // opacity alone drives the final alpha for 99% of call sites.
+        color.a *= opacity;
+        v->set_box_shadow(ox, oy, /*blur=*/radius, /*spread=*/0.0f,
+                          color, /*inset=*/false);
         return choc::value::Value();
     });
 

--- a/docs/reference/style-props.md
+++ b/docs/reference/style-props.md
@@ -1,0 +1,183 @@
+# Style props reference
+
+All bridge functions exposed by `WidgetBridge` (`core/view/src/widget_bridge.cpp`)
+that map directly to React Native / CSS style props. Issue
+[#1026](https://github.com/danielraffel/pulp/issues/1026) adds RN-shaped
+counterparts to the existing CSS-shaped primitives so `@pulp/react`'s
+prop-applier can route JSX style props onto Pulp Views without an
+intermediate translation layer.
+
+**Status:** experimental.
+
+The two consumer-facing surfaces are:
+
+- **`@pulp/react`** — the React renderer. Its prop-applier translates JSX
+  `style={{ ... }}` props directly into the bridge calls listed below.
+- **`@pulp/css-adapt`** — the browser-CSS shim. It translates browser-style
+  selectors and longhand CSS into the same bridge calls.
+
+The native-side primitives (`View::set_*` methods) are documented in
+`core/view/include/pulp/view/view.hpp`. This page is the contract between
+JS callers and the bridge.
+
+## Layout
+
+| Prop | Bridge function | Notes |
+|---|---|---|
+| `flexDirection` | `setFlex(id, "direction", "row" \| "column" \| ...)` | |
+| `flexWrap` | `setFlex(id, "flex_wrap", true \| false)` | |
+| `flexGrow` | `setFlex(id, "flex_grow", n)` | |
+| `flexShrink` | `setFlex(id, "flex_shrink", n)` | |
+| `flexBasis` | `setFlex(id, "flex_basis", n)` | |
+| `order` | `setFlex(id, "order", n)` | |
+| `gap` | `setFlex(id, "gap", n)` | Also `row_gap` / `column_gap`. |
+| `padding` | `setFlex(id, "padding", n)` | Also `padding_{top,right,bottom,left}`. |
+| `margin` | `setFlex(id, "margin_{t,r,b,l}", n)` | Per-side only. |
+| `width` / `minWidth` / `maxWidth` | `setFlex(id, "width" \| "min_width" \| "max_width", n)` | |
+| `height` / `minHeight` / `maxHeight` | `setFlex(id, "height" \| "min_height" \| "max_height", n)` | |
+| `alignItems` | `setFlex(id, "align_items", "start" \| "center" \| "end" \| "stretch")` | |
+| `alignSelf` | `setFlex(id, "align_self", ...)` | |
+| `justifyContent` | `setFlex(id, "justify_content", "start" \| "center" \| "end" \| "space-between" \| "space-around" \| "space-evenly")` | |
+| `display: grid` | `setGrid(id, columns, rows, columnGap, rowGap)` | Container; children use `setGrid(id, ...)` for placement. |
+| `gridColumn` / `gridRow` | `setGrid(id, "column_start"/"column_end"/"row_start"/"row_end", n)` | |
+| `position` | `setPosition(id, "static" \| "relative" \| "absolute" \| "fixed" \| "sticky")` | |
+| `top` / `right` / `bottom` / `left` | `setTop(id, n)` / `setRight(id, n)` / `setBottom(id, n)` / `setLeft(id, n)` | |
+| `zIndex` | `setZIndex(id, n)` | |
+| `overflow` | `setOverflow(id, "visible" \| "hidden")` | |
+| `display` | `setVisible(id, true \| false)` and `setVisibility(id, "visible" \| "hidden")` | `setVisible` removes from layout (`display:none`); `setVisibility` only hides. |
+
+## Background
+
+| Prop | Bridge function | Notes |
+|---|---|---|
+| `backgroundColor` | `setBackground(id, color)` | Accepts hex, `rgb()`, `rgba()`, `hsl()`. |
+| `background: linear-gradient(...)` | `setBackgroundGradient(id, "linear-gradient(to right, red, blue)")` | CSS gradient string. |
+| `opacity` | `setOpacity(id, 0..1)` | Layer alpha. |
+
+## Border
+
+| Prop | Bridge function | Notes |
+|---|---|---|
+| `border` (shorthand) | `setBorder(id, color, width, radius)` | All four at once. |
+| `borderColor` | `setBorderColor(id, color)` | pulp #1026. Standalone setter; flips `has_border_` on. |
+| `borderWidth` | `setBorderWidth(id, width)` | pulp #1026. |
+| `borderRadius` | `setBorderRadius(id, radius)` | pulp #1026. Uniform corner radius. |
+| `borderTopLeftRadius` | `setBorderTopLeftRadius(id, n)` or `setCornerRadius(id, "TopLeft", n)` | pulp #1026. |
+| `borderTopRightRadius` | `setBorderTopRightRadius(id, n)` or `setCornerRadius(id, "TopRight", n)` | pulp #1026. |
+| `borderBottomLeftRadius` | `setBorderBottomLeftRadius(id, n)` or `setCornerRadius(id, "BottomLeft", n)` | pulp #1026. |
+| `borderBottomRightRadius` | `setBorderBottomRightRadius(id, n)` or `setCornerRadius(id, "BottomRight", n)` | pulp #1026. |
+| `borderTopColor` | `setBorderTopColor(id, color)` | pulp #1026. |
+| `borderRightColor` | `setBorderRightColor(id, color)` | pulp #1026. |
+| `borderBottomColor` | `setBorderBottomColor(id, color)` | pulp #1026. |
+| `borderLeftColor` | `setBorderLeftColor(id, color)` | pulp #1026. |
+| `borderTopWidth` | `setBorderTopWidth(id, n)` | pulp #1026. |
+| `borderRightWidth` | `setBorderRightWidth(id, n)` | pulp #1026. |
+| `borderBottomWidth` | `setBorderBottomWidth(id, n)` | pulp #1026. |
+| `borderLeftWidth` | `setBorderLeftWidth(id, n)` | pulp #1026. |
+| `border-{top,right,bottom,left}` (CSS shorthand) | `setBorderSide(id, "top" \| "right" \| "bottom" \| "left", width, color)` | Both at once. |
+
+## Shadow
+
+| Prop | Bridge function | Notes |
+|---|---|---|
+| `box-shadow` (CSS) | `setBoxShadow(id, offsetX, offsetY, blur, spread, color, inset?)` | Pulp's CSS-shaped primitive (#925). Carries spread + inset. |
+| RN `shadowColor` / `shadowOffset` / `shadowOpacity` / `shadowRadius` | `setShadow(id, color, offsetX, offsetY, opacity, radius)` | pulp #1026. RN-shaped; lowers onto `setBoxShadow` with spread=0, inset=false; opacity multiplies into color alpha. |
+| (clear shadow) | `clearBoxShadow(id)` | |
+
+## Transforms
+
+| Prop | Bridge function | Notes |
+|---|---|---|
+| `transform: translate(x, y)` | `setTranslate(id, x, y)` | |
+| `transform: scale(s)` | `setScale(id, s)` | |
+| `transform: rotate(deg)` | `setRotation(id, deg)` | |
+| `transform: matrix(a, b, c, d, e, f)` | `setTransform(id, a, b, c, d, e, f)` | Full 2D affine (#930). Composes onto parent transform. |
+| (clear matrix transform) | `clearTransform(id)` | Reverts to scalar transforms. |
+| `transformOrigin` | `setTransformOrigin(id, x, y)` | Normalized 0..1; `0.5,0.5` = center. Applies to BOTH the CSS-transform path AND the matrix path (#1026). |
+
+## Filters
+
+| Prop | Bridge function | Notes |
+|---|---|---|
+| `filter: blur(Npx)` | `setFilter(id, "blur(Npx)")` | Per-element blur via compositing layer. |
+| `backdrop-filter: blur(Npx)` | `setBackdropFilter(id, radius)` | Frosted-glass blur of content behind (#926). |
+
+## Pointer / interaction
+
+| Prop | Bridge function | Notes |
+|---|---|---|
+| RN `pointerEvents` | `setPointerEvents(id, "auto" \| "none" \| "box-only" \| "box-none")` | pulp #1026. 4-valued enum, matches RN contract. |
+| `cursor` | `setCursor(id, "default" \| "pointer" \| "crosshair" \| "text" \| "grab")` | |
+| RN `backfaceVisibility` | `setBackfaceVisibility(id, "visible" \| "hidden")` | pulp #1026. Plumbed; no-op for paint until 3D transforms land. |
+| (CSS-style hit toggling) | `setEnabled(id, bool)` | `:disabled` equivalent — blocks input, fades opacity. |
+
+## Text
+
+| Prop | Bridge function | Notes |
+|---|---|---|
+| `color` | `setTextColor(id, color)` | On `Label`: explicit color. On a container: cascade. |
+| `font-family` | `setFontFamily(id, name)` | |
+| `font-weight` | `setFontWeight(id, n)` | |
+| `font-style` | `setFontStyle(id, "normal" \| "italic")` | |
+| `font-size` | `setFontSize(id, n)` | |
+| `letter-spacing` | `setLetterSpacing(id, n)` | |
+| `line-height` | `setLineHeight(id, n)` | |
+| `text-align` | `setTextAlign(id, "left" \| "center" \| "right")` | |
+| `text-transform` | `setTextTransform(id, "uppercase" \| "lowercase" \| "capitalize" \| "none")` | |
+| `text-decoration` | `setTextDecoration(id, "none" \| "underline" \| "line-through")` | |
+| `text-overflow` | `setTextOverflow(id, "ellipsis" \| "clip")` | |
+| `white-space` | `setWhiteSpace(id, "normal" \| "nowrap" \| "pre" \| "pre-wrap")` | |
+| `user-select` | `setUserSelect(id, "none" \| "text" \| "all")` | Currently a no-op stub. |
+| `placeholder` (text input) | `setPlaceholder(id, text)` | |
+
+## Animation / transition
+
+| Prop | Bridge function | Notes |
+|---|---|---|
+| `transition-duration` | `setTransitionDuration(id, seconds)` | |
+| `@keyframes` | `defineKeyframes(name, [{offset, value}, ...])` | Stub today. |
+| `animation` | `setAnimation(id, prop, duration, iterations, direction, keyframes)` | Stub today. |
+
+## Theming hooks
+
+| Prop | Bridge function | Notes |
+|---|---|---|
+| Theme tokens (color) | `setColorToken(name, color)` | Sets a theme color token; resolved via `View::resolve_color`. |
+| Theme tokens (dimension) | `setDimensionToken(name, n)` | |
+| Apply panel theme | `setPanelStyle(id, bgToken, borderToken, radius, width)` | |
+| Theme JSON (whole) | `setTheme(id, json)`, `getThemeJson()`, `applyTokenDiff(id, diffJson)` | |
+| Design tokens import / export | `importDesignTokens(json)` / `exportDesignTokens()` | |
+| Per-state style | `setStateStyle(id, state, prop, value)` | `:hover`, `:active`, `:focus`. |
+| Per-widget style | `setWidgetStyle(id, json)` | |
+
+## Not yet implemented
+
+Style props that exist in the React Native or CSS surface area but do
+not yet have a bridge primitive in Pulp. These are the to-do list for
+future rounds. Cite issue [#1026](https://github.com/danielraffel/pulp/issues/1026)
+when filing follow-ups.
+
+| Prop | Notes |
+|---|---|
+| `aspectRatio` | RN style prop; pulp's `FlexStyle` does not yet model an aspect-ratio constraint. |
+| `direction: rtl` | Bidirectional layout. |
+| `tintColor` (RN Image) | Image tinting. |
+| `resizeMode` (RN Image) | Image fit mode. |
+| `transform: perspective(N)` and `rotateX/Y` | 3D transforms; `setBackfaceVisibility` is plumbed but inert until this lands. |
+| `elevation` (RN Android) | Material elevation; RN's lowering varies per platform. |
+| `boxSizing` | `border-box` vs `content-box`. |
+| `outline` / `outline-offset` | Outline ring distinct from `border`. |
+| `mask-image` / `clip-path` | Per-pixel masking. |
+| `mix-blend-mode` (View-level) | Canvas already supports per-draw blend modes via `canvasSetBlendMode`. |
+| `caret-color` | Text-input caret tint. |
+
+## See also
+
+- `@pulp/react` — JSX style-prop applier translates style props into the
+  bridge calls in this document.
+- `@pulp/css-adapt` — translates browser-CSS into the same bridge calls.
+- React Native's [View Style Props](https://reactnative.dev/docs/view-style-props)
+  and [Text Style Props](https://reactnative.dev/docs/text-style-props) for
+  the consumer-facing surface.
+- [JS Bridge API Reference](js-bridge.md) for the full bridge function
+  catalog, including non-style-prop primitives (createKnob, registerClick, etc.).

--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -1040,3 +1040,220 @@ TEST_CASE("Absolute child positioned outside parent's bounds still paints",
     REQUIRE(saw_magenta_fill);
     REQUIRE_FALSE(saw_parent_clip);
 }
+
+// ── pulp #1026: React Native pointerEvents 4-valued enum ────────────────────
+
+TEST_CASE("View::hit_test honors pointerEvents == auto (default)",
+          "[view][hit_test][issue-1026]") {
+    View root;
+    root.set_bounds({0, 0, 200, 200});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({50, 50, 100, 100});
+    auto* child_ptr = child.get();
+    root.add_child(std::move(child));
+
+    // Default (auto_): both root and child are interactive.
+    REQUIRE(root.pointer_events() == View::PointerEvents::auto_);
+    REQUIRE(root.hit_test({75, 75}) == child_ptr);
+    REQUIRE(root.hit_test({10, 10}) == &root);
+}
+
+TEST_CASE("View::hit_test honors pointerEvents == none",
+          "[view][hit_test][issue-1026]") {
+    View root;
+    root.set_bounds({0, 0, 200, 200});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({50, 50, 100, 100});
+    root.add_child(std::move(child));
+
+    // none: neither this view NOR descendants intercept events.
+    root.set_pointer_events(View::PointerEvents::none);
+    REQUIRE(root.hit_test({75, 75}) == nullptr);
+    REQUIRE(root.hit_test({10, 10}) == nullptr);
+}
+
+TEST_CASE("View::hit_test honors pointerEvents == box-only",
+          "[view][hit_test][issue-1026]") {
+    View root;
+    root.set_bounds({0, 0, 200, 200});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({50, 50, 100, 100});
+    root.add_child(std::move(child));
+
+    // box_only: this view receives events; children do NOT — even when
+    // the point lands directly on a child, hit_test returns the parent.
+    root.set_pointer_events(View::PointerEvents::box_only);
+    REQUIRE(root.hit_test({75, 75}) == &root);
+    REQUIRE(root.hit_test({10, 10}) == &root);
+}
+
+TEST_CASE("View::hit_test honors pointerEvents == box-none",
+          "[view][hit_test][issue-1026]") {
+    View root;
+    root.set_bounds({0, 0, 200, 200});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({50, 50, 100, 100});
+    auto* child_ptr = child.get();
+    root.add_child(std::move(child));
+
+    // box_none: this view does NOT receive events but children do —
+    // the point on the child still resolves to the child, but a point
+    // inside the parent's bounds (not on the child) returns nullptr.
+    root.set_pointer_events(View::PointerEvents::box_none);
+    REQUIRE(root.hit_test({75, 75}) == child_ptr);
+    REQUIRE(root.hit_test({10, 10}) == nullptr);
+}
+
+// ── pulp #1026: backfaceVisibility plumbing ────────────────────────────────
+
+TEST_CASE("View backface_visible defaults to true and round-trips",
+          "[view][issue-1026]") {
+    View v;
+    REQUIRE(v.backface_visible());
+    v.set_backface_visible(false);
+    REQUIRE_FALSE(v.backface_visible());
+    v.set_backface_visible(true);
+    REQUIRE(v.backface_visible());
+}
+
+// ── pulp #1026: transform-origin applies to matrix path ────────────────────
+
+TEST_CASE("View::paint_all applies transform-origin around concat_transform",
+          "[view][transform][issue-1026]") {
+    using namespace pulp::canvas;
+
+    // When the View has a transform-origin offset and a transform-matrix,
+    // paint_all should bracket the concat with translate(ox,oy) and
+    // translate(-ox,-oy) so rotation/scale anchor at the requested point
+    // — same behaviour as the CSS-transform path.
+    RecordingCanvas rc;
+    View v;
+    v.set_bounds({0, 0, 100, 50});
+    // Origin (0.25, 0.75): pivot at (25, 37.5).
+    v.set_transform_origin(0.25f, 0.75f);
+    v.set_transform_matrix(2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 0.0f);
+
+    v.paint_all(rc);
+
+    // Expected sequence around the concat:
+    //   translate(0,0)    — bounds_.x/y at (0,0)
+    //   translate(25, 37.5)
+    //   concat_transform(2,0,0,2,0,0)
+    //   translate(-25, -37.5)
+    bool saw_pre_origin = false, saw_concat = false, saw_post_origin = false;
+    int idx = 0;
+    int concat_at = -1;
+    for (auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::concat_transform) {
+            concat_at = idx;
+            saw_concat = true;
+        }
+        ++idx;
+    }
+    REQUIRE(saw_concat);
+    REQUIRE(concat_at > 0);
+
+    // Search the immediate neighbours.
+    auto& cmds = rc.commands();
+    REQUIRE(cmds[(size_t)(concat_at - 1)].type == DrawCommand::Type::translate);
+    REQUIRE_THAT(cmds[(size_t)(concat_at - 1)].f[0], WithinAbs(25.0f, 1e-4f));
+    REQUIRE_THAT(cmds[(size_t)(concat_at - 1)].f[1], WithinAbs(37.5f, 1e-4f));
+    saw_pre_origin = true;
+
+    REQUIRE((size_t)(concat_at + 1) < cmds.size());
+    REQUIRE(cmds[(size_t)(concat_at + 1)].type == DrawCommand::Type::translate);
+    REQUIRE_THAT(cmds[(size_t)(concat_at + 1)].f[0], WithinAbs(-25.0f, 1e-4f));
+    REQUIRE_THAT(cmds[(size_t)(concat_at + 1)].f[1], WithinAbs(-37.5f, 1e-4f));
+    saw_post_origin = true;
+
+    REQUIRE(saw_pre_origin);
+    REQUIRE(saw_post_origin);
+}
+
+TEST_CASE("View::paint_all does NOT bracket concat when origin is unset (back-compat)",
+          "[view][transform][issue-1026]") {
+    using namespace pulp::canvas;
+
+    // pulp #1026 — only an EXPLICIT setTransformOrigin call activates the
+    // pre/post-origin translate bracket on the matrix path. Existing
+    // setTransform() call sites (no origin) keep the pre-#1026 single
+    // concat, preserving back-compat with the issue-930 contract.
+    RecordingCanvas rc;
+    View v;
+    v.set_bounds({0, 0, 100, 50});
+    REQUIRE_FALSE(v.transform_origin_explicit());
+    v.set_transform_matrix(2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 0.0f);
+
+    v.paint_all(rc);
+
+    int translates = 0;
+    int concats = 0;
+    for (auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::translate) ++translates;
+        if (cmd.type == DrawCommand::Type::concat_transform) ++concats;
+    }
+    // Only the 1 bounds translate; no origin bracket.
+    REQUIRE(translates == 1);
+    REQUIRE(concats == 1);
+}
+
+// ── pulp #1026: per-corner border-radius ──────────────────────────────────
+
+TEST_CASE("View per-corner radii setters flip has_corner_radii",
+          "[view][border][issue-1026]") {
+    View v;
+    REQUIRE_FALSE(v.has_corner_radii());
+
+    v.set_corner_radius_tl(8.0f);
+    REQUIRE(v.has_corner_radii());
+    REQUIRE_THAT(v.corner_radius_tl(), WithinAbs(8.0f, 1e-5f));
+    REQUIRE_THAT(v.corner_radius_tr(), WithinAbs(0.0f, 1e-5f));
+
+    v.set_corner_radius_tr(12.0f);
+    v.set_corner_radius_bl(4.0f);
+    v.set_corner_radius_br(2.0f);
+    REQUIRE_THAT(v.corner_radius_tr(), WithinAbs(12.0f, 1e-5f));
+    REQUIRE_THAT(v.corner_radius_bl(), WithinAbs(4.0f,  1e-5f));
+    REQUIRE_THAT(v.corner_radius_br(), WithinAbs(2.0f,  1e-5f));
+}
+
+TEST_CASE("View::paint_all routes background through path API when per-corner radii set",
+          "[view][border][issue-1026]") {
+    using namespace pulp::canvas;
+
+    // With a uniform corner_radius the bg uses fill_rounded_rect; with
+    // any per-corner setter the path API takes over (begin_path /
+    // line_to / cubic_to / close_path / fill_current_path).
+    {
+        RecordingCanvas rc;
+        View v;
+        v.set_bounds({0, 0, 100, 50});
+        v.set_background_color(Color::rgba8(255, 0, 0));
+        v.set_border(Color::rgba8(0, 0, 0), 1.0f, /*radius=*/8.0f);
+        v.paint_all(rc);
+        REQUIRE(rc.count(DrawCommand::Type::fill_rounded_rect) >= 1);
+        REQUIRE(rc.count(DrawCommand::Type::stroke_rounded_rect) >= 1);
+    }
+    {
+        RecordingCanvas rc;
+        View v;
+        v.set_bounds({0, 0, 100, 50});
+        v.set_background_color(Color::rgba8(255, 0, 0));
+        v.set_border(Color::rgba8(0, 0, 0), 1.0f);
+        v.set_corner_radius_tl(8.0f);
+        v.set_corner_radius_tr(8.0f);
+        v.set_corner_radius_bl(0.0f);
+        v.set_corner_radius_br(0.0f);
+        v.paint_all(rc);
+        // Per-corner path: at least begin_path + close_path appear, and
+        // fill_rounded_rect / stroke_rounded_rect do NOT.
+        REQUIRE(rc.count(DrawCommand::Type::fill_rounded_rect) == 0);
+        REQUIRE(rc.count(DrawCommand::Type::stroke_rounded_rect) == 0);
+        REQUIRE(rc.count(DrawCommand::Type::begin_path) >= 1);
+        REQUIRE(rc.count(DrawCommand::Type::close_path) >= 1);
+    }
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -3027,3 +3027,206 @@ TEST_CASE("WidgetBridge canvasStrokeRect with no color uses active strokeStyle (
                            stroke_at_draw.b8() == 0 && stroke_at_draw.a8() == 255);
     REQUIRE(is_green);
 }
+
+// ── pulp #1026: React Native style-prop bridge primitives ──────────────────
+
+TEST_CASE("WidgetBridge setShadow lowers RN-shaped args onto setBoxShadow",
+          "[view][bridge][issue-1026]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('gain', 0, 0, 48, 48)");
+    // setShadow(id, color, offsetX, offsetY, opacity, radius). RN composes
+    // shadowOpacity into the alpha channel of shadowColor; with #000000ff
+    // and opacity 0.5 the resulting alpha is ~127/255.
+    bridge.load_script("setShadow('gain', '#000000ff', 4, 8, 0.5, 12)");
+
+    auto* w = bridge.widget("gain");
+    REQUIRE(w != nullptr);
+    REQUIRE(w->has_box_shadow());
+    const auto& s = w->box_shadow();
+    REQUIRE_THAT(s.offset_x, WithinAbs(4.0f, 1e-4f));
+    REQUIRE_THAT(s.offset_y, WithinAbs(8.0f, 1e-4f));
+    REQUIRE_THAT(s.blur, WithinAbs(12.0f, 1e-4f));
+    REQUIRE_THAT(s.spread, WithinAbs(0.0f, 1e-4f));
+    // alpha should be approximately 0.5 (1.0 * 0.5).
+    REQUIRE_THAT(s.color.a, WithinAbs(0.5f, 1e-3f));
+    REQUIRE(s.inset == false);
+}
+
+TEST_CASE("WidgetBridge setBackfaceVisibility plumbs the View flag",
+          "[view][bridge][issue-1026]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('k', 0, 0, 32, 32)");
+    auto* w = bridge.widget("k");
+    REQUIRE(w != nullptr);
+    REQUIRE(w->backface_visible());
+
+    bridge.load_script("setBackfaceVisibility('k', 'hidden')");
+    REQUIRE_FALSE(w->backface_visible());
+
+    bridge.load_script("setBackfaceVisibility('k', 'visible')");
+    REQUIRE(w->backface_visible());
+}
+
+TEST_CASE("WidgetBridge setPointerEvents routes 4-valued enum to View",
+          "[view][bridge][issue-1026]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('k', 0, 0, 32, 32)");
+    auto* w = bridge.widget("k");
+    REQUIRE(w != nullptr);
+    REQUIRE(w->pointer_events() == View::PointerEvents::auto_);
+
+    bridge.load_script("setPointerEvents('k', 'none')");
+    REQUIRE(w->pointer_events() == View::PointerEvents::none);
+    REQUIRE_FALSE(w->hit_testable());
+
+    bridge.load_script("setPointerEvents('k', 'box-only')");
+    REQUIRE(w->pointer_events() == View::PointerEvents::box_only);
+    REQUIRE(w->hit_testable());
+
+    bridge.load_script("setPointerEvents('k', 'box-none')");
+    REQUIRE(w->pointer_events() == View::PointerEvents::box_none);
+    REQUIRE(w->hit_testable());
+
+    bridge.load_script("setPointerEvents('k', 'auto')");
+    REQUIRE(w->pointer_events() == View::PointerEvents::auto_);
+    REQUIRE(w->hit_testable());
+}
+
+TEST_CASE("WidgetBridge setTransformOrigin sets normalized origin on View",
+          "[view][bridge][issue-1026]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('k', 0, 0, 32, 32)");
+    auto* w = bridge.widget("k");
+    REQUIRE(w != nullptr);
+    // Default is (0.5, 0.5).
+    REQUIRE_THAT(w->transform_origin_x(), WithinAbs(0.5f, 1e-5f));
+    REQUIRE_THAT(w->transform_origin_y(), WithinAbs(0.5f, 1e-5f));
+
+    bridge.load_script("setTransformOrigin('k', 0.0, 1.0)");
+    REQUIRE_THAT(w->transform_origin_x(), WithinAbs(0.0f, 1e-5f));
+    REQUIRE_THAT(w->transform_origin_y(), WithinAbs(1.0f, 1e-5f));
+}
+
+TEST_CASE("WidgetBridge setBorderColor / setBorderWidth / setBorderRadius granular setters",
+          "[view][bridge][issue-1026]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('k', 0, 0, 32, 32)");
+    auto* w = bridge.widget("k");
+    REQUIRE(w != nullptr);
+    REQUIRE_FALSE(w->has_border());
+
+    bridge.load_script("setBorderColor('k', '#ff8800')");
+    REQUIRE(w->has_border());
+    REQUIRE(w->border_color().r8() == 0xff);
+    REQUIRE(w->border_color().g8() == 0x88);
+    REQUIRE(w->border_color().b8() == 0x00);
+
+    bridge.load_script("setBorderWidth('k', 4.5)");
+    REQUIRE_THAT(w->border_width(), WithinAbs(4.5f, 1e-5f));
+
+    bridge.load_script("setBorderRadius('k', 9.0)");
+    REQUIRE_THAT(w->corner_radius(), WithinAbs(9.0f, 1e-5f));
+}
+
+TEST_CASE("WidgetBridge per-corner setBorder*Radius setters route to corner_radii",
+          "[view][bridge][issue-1026]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('k', 0, 0, 32, 32)");
+    auto* w = bridge.widget("k");
+    REQUIRE(w != nullptr);
+    REQUIRE_FALSE(w->has_corner_radii());
+
+    bridge.load_script("setBorderTopLeftRadius('k', 1.0)");
+    bridge.load_script("setBorderTopRightRadius('k', 2.0)");
+    bridge.load_script("setBorderBottomLeftRadius('k', 3.0)");
+    bridge.load_script("setBorderBottomRightRadius('k', 4.0)");
+
+    REQUIRE(w->has_corner_radii());
+    REQUIRE_THAT(w->corner_radius_tl(), WithinAbs(1.0f, 1e-5f));
+    REQUIRE_THAT(w->corner_radius_tr(), WithinAbs(2.0f, 1e-5f));
+    REQUIRE_THAT(w->corner_radius_bl(), WithinAbs(3.0f, 1e-5f));
+    REQUIRE_THAT(w->corner_radius_br(), WithinAbs(4.0f, 1e-5f));
+}
+
+TEST_CASE("WidgetBridge per-side setBorder*Color / Width route to BorderSide",
+          "[view][bridge][issue-1026]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('k', 0, 0, 32, 32)");
+    auto* w = bridge.widget("k");
+    REQUIRE(w != nullptr);
+
+    // Each setter sets its own per-side state without corrupting other
+    // sides. We assert each side's color and width round-trip.
+    bridge.load_script("setBorderTopColor('k', '#11ff00')");
+    bridge.load_script("setBorderTopWidth('k', 2.0)");
+    bridge.load_script("setBorderRightColor('k', '#0011ff')");
+    bridge.load_script("setBorderRightWidth('k', 3.0)");
+    bridge.load_script("setBorderBottomColor('k', '#ff0011')");
+    bridge.load_script("setBorderBottomWidth('k', 4.0)");
+    bridge.load_script("setBorderLeftColor('k', '#fefefe')");
+    bridge.load_script("setBorderLeftWidth('k', 5.0)");
+
+    REQUIRE(w->has_border_sides());
+    REQUIRE(w->border_top_color().r8() == 0x11);
+    REQUIRE(w->border_top_color().g8() == 0xff);
+    REQUIRE(w->border_top_color().b8() == 0x00);
+    REQUIRE_THAT(w->border_top_width(), WithinAbs(2.0f, 1e-5f));
+
+    REQUIRE(w->border_right_color().r8() == 0x00);
+    REQUIRE(w->border_right_color().g8() == 0x11);
+    REQUIRE(w->border_right_color().b8() == 0xff);
+    REQUIRE_THAT(w->border_right_width(), WithinAbs(3.0f, 1e-5f));
+
+    REQUIRE(w->border_bottom_color().r8() == 0xff);
+    REQUIRE(w->border_bottom_color().g8() == 0x00);
+    REQUIRE(w->border_bottom_color().b8() == 0x11);
+    REQUIRE_THAT(w->border_bottom_width(), WithinAbs(4.0f, 1e-5f));
+
+    REQUIRE(w->border_left_color().r8() == 0xfe);
+    REQUIRE_THAT(w->border_left_width(), WithinAbs(5.0f, 1e-5f));
+
+    // Now change ONLY the top color again — top width should be preserved.
+    bridge.load_script("setBorderTopColor('k', '#aabbcc')");
+    REQUIRE(w->border_top_color().r8() == 0xaa);
+    REQUIRE_THAT(w->border_top_width(), WithinAbs(2.0f, 1e-5f));
+
+    // And change ONLY the bottom width — bottom color should be preserved.
+    bridge.load_script("setBorderBottomWidth('k', 7.0)");
+    REQUIRE_THAT(w->border_bottom_width(), WithinAbs(7.0f, 1e-5f));
+    REQUIRE(w->border_bottom_color().r8() == 0xff);
+}


### PR DESCRIPTION
Frame the bridge layer that @pulp/react's prop-applier needs: standalone
border setters (color/width/radius and per-corner/per-side), an
RN-shaped setShadow that lowers onto setBoxShadow, a 4-valued
setPointerEvents enum, setBackfaceVisibility plumbing for future 3D
transform support, and consistent transform-origin handling between
the CSS-transform and matrix paths. Per-corner radii now route through
a path-builder approximation so border-top-left-radius et al actually
render.

Includes:

  * View::PointerEvents enum (auto, none, box_only, box_none) honored
    by hit_test() so @pulp/react can express RN's full pointerEvents
    contract; the legacy set_hit_testable() binary remains for
    back-compat.
  * View::set_backface_visible() — plumbed; the painter consumes it
    only when a 3D transform with negative Z is active. pulp's
    transform model is currently 2D-affine so this is no-op for paint
    today and reserved for future 3D support.
  * View::set_border_color/width/radius — standalone setters so JSX
    diff appliers can update one border attribute without touching the
    others. Per-corner setBorder*Radius and per-side setBorder*Color/
    Width primitives match RN style-prop names 1:1.
  * Per-corner radii painted via a kappa-cubic path approximation when
    any per-corner setter has been called; uniform corner_radius_
    keeps the optimized fill_rounded_rect / stroke_rounded_rect path.
  * setShadow(id, color, ox, oy, opacity, radius) — RN-shaped shadow.
    Lowers to set_box_shadow() with spread=0, inset=false, and
    composes opacity into the color alpha channel.
  * setTransformOrigin now flips an explicit-origin flag; the matrix
    path (issue-930) honors origin only when the caller has actively
    set it, preserving back-compat with existing setTransform() call
    sites that never touched the origin.

Tests in the same PR (Catch2 tag [issue-1026]):

  * test_view.cpp: 9 cases covering all 4 pointerEvents values via
    hit_test, backface flag round-trip, transform-origin bracket on
    matrix path (and back-compat when origin is unset), per-corner
    radii flag + paint-path routing.
  * test_widget_bridge.cpp: 7 cases covering setShadow opacity
    composition, setBackfaceVisibility plumbing, setPointerEvents
    4-value routing, setTransformOrigin, granular setBorderColor /
    Width / Radius, per-corner setBorder*Radius, per-side
    setBorder{Top,Right,Bottom,Left}{Color,Width} round-trip including
    the unrelated-attribute preservation contract.

docs/reference/style-props.md catalogs every prop-shaped bridge
function the framework currently exposes, plus a "Not yet implemented"
section for follow-up work (aspectRatio, 3D transforms, tintColor,
etc.).