### PR TITLE
test(render): cover gpu surface state edges

### DIFF
--- a/test/test_gpu_surface.cpp
+++ b/test/test_gpu_surface.cpp
@@ -70,6 +70,21 @@ TEST_CASE("GpuSurface resize updates dimensions", "[render][gpu]") {
     REQUIRE(surface->height() == 768);
 }
 
+TEST_CASE("GpuSurface resize before initialize records pending dimensions", "[render][gpu][issue-646]") {
+    auto surface = GpuSurface::create_dawn();
+    if (!surface) return;
+
+    REQUIRE_FALSE(surface->is_initialized());
+
+    surface->resize(321, 123);
+
+    REQUIRE(surface->width() == 321);
+    REQUIRE(surface->height() == 123);
+    REQUIRE_FALSE(surface->is_initialized());
+    REQUIRE_FALSE(surface->has_surface());
+    REQUIRE_FALSE(surface->begin_frame());
+}
+
 TEST_CASE("GpuSurface exposes Dawn handles when initialized", "[render][gpu]") {
     auto surface = GpuSurface::create_dawn();
     if (!surface) return;
@@ -95,6 +110,46 @@ TEST_CASE("GpuSurface exposes Dawn handles when initialized", "[render][gpu]") {
     REQUIRE(surface->dawn_queue_handle() == nullptr);
     REQUIRE(surface->current_texture_handle() == nullptr);
 #endif
+}
+
+TEST_CASE("GpuSurface adapter_info reflects initialization state", "[render][gpu][issue-646]") {
+    auto surface = GpuSurface::create_dawn();
+    if (!surface) return;
+
+    auto before = surface->adapter_info();
+    REQUIRE_FALSE(before.available);
+    REQUIRE_FALSE(before.native_bridge);
+    REQUIRE_FALSE(before.backend.empty());
+    REQUIRE_FALSE(before.backend_type.empty());
+    REQUIRE_FALSE(before.name.empty());
+    REQUIRE_FALSE(before.vendor.empty());
+    REQUIRE_FALSE(before.architecture.empty());
+    REQUIRE_FALSE(before.description.empty());
+    REQUIRE_FALSE(before.preferred_canvas_format.empty());
+
+    GpuSurface::Config config{};
+    config.width = 64;
+    config.height = 32;
+    config.native_surface_handle = nullptr;
+
+    if (!surface->initialize(config)) {
+        auto failed = surface->adapter_info();
+        REQUIRE_FALSE(failed.available);
+        REQUIRE_FALSE(failed.native_bridge);
+        REQUIRE_FALSE(failed.preferred_canvas_format.empty());
+        return;
+    }
+
+    auto after = surface->adapter_info();
+    REQUIRE(after.available);
+    REQUIRE(after.native_bridge);
+    REQUIRE_FALSE(after.backend.empty());
+    REQUIRE_FALSE(after.backend_type.empty());
+    REQUIRE_FALSE(after.name.empty());
+    REQUIRE_FALSE(after.vendor.empty());
+    REQUIRE_FALSE(after.architecture.empty());
+    REQUIRE_FALSE(after.description.empty());
+    REQUIRE_FALSE(after.preferred_canvas_format.empty());
 }
 
 TEST_CASE("GpuSurface begin_frame before initialize returns false", "[render][gpu]") {


### PR DESCRIPTION
## Summary
- cover GpuSurface resize-before-initialize state
- cover adapter_info before initialization and after failed initialization
- cover adapter_info fields after successful offscreen initialization when a GPU adapter is available

## Validation
- `cmake -S . -B build ...`
- `cmake --build build --target pulp-test-gpu-surface -j$(sysctl -n hw.ncpu)`
- `ctest --test-dir build -R '^GpuSurface' --output-on-failure` (9/9 passed)
- `git diff --check`
- `python3 tools/scripts/version_bump_check.py --mode=report`
- `python3 tools/scripts/skill_sync_check.py --mode=report`

Refs #646
Refs #641