### PR TITLE
test(render): cover atlas cache edge paths

### DIFF
--- a/test/test_texture_atlas.cpp
+++ b/test/test_texture_atlas.cpp
@@ -128,6 +128,23 @@ TEST_CASE("AtlasPacker reset lets us pack again from origin - issue-646",
     REQUIRE(r.y == 0);
 }
 
+TEST_CASE("AtlasPacker shelf height tracks the tallest item - issue-646",
+          "[render][atlas][issue-646]") {
+    AtlasPacker p(80, 80);
+    AtlasPacker::Region r{};
+
+    REQUIRE(p.allocate(20, 10, r));
+    REQUIRE(r.y == 0);
+
+    REQUIRE(p.allocate(20, 30, r));
+    REQUIRE(r.x == 20);
+    REQUIRE(r.y == 0);
+
+    REQUIRE(p.allocate(60, 10, r));
+    REQUIRE(r.x == 0);
+    REQUIRE(r.y == 30);
+}
+
 TEST_CASE("AtlasPacker rejects non-positive dimensions - issue-646",
           "[render][atlas][issue-646]") {
     AtlasPacker p(64, 64);
@@ -141,6 +158,29 @@ TEST_CASE("AtlasPacker rejects non-positive dimensions - issue-646",
     REQUIRE(p.allocate(8, 8, r));
     REQUIRE(r.x == 0);
     REQUIRE(r.y == 0);
+}
+
+TEST_CASE("ImageAtlas cache hit keeps original region and refcount - issue-646",
+          "[render][atlas][issue-646]") {
+    ImageAtlas atlas(64);
+    AtlasPacker::Region first{};
+    AtlasPacker::Region second{};
+
+    REQUIRE(atlas.allocate(9, 16, 12, first));
+    REQUIRE(atlas.allocate(9, 48, 48, second));
+    REQUIRE(second.x == first.x);
+    REQUIRE(second.y == first.y);
+    REQUIRE(second.w == first.w);
+    REQUIRE(second.h == first.h);
+    REQUIRE(atlas.entry_count() == 1);
+
+    atlas.release(9);
+    REQUIRE(atlas.evict_stale(1000, /*max_age=*/1) == 0);
+    REQUIRE(atlas.entry_count() == 1);
+
+    atlas.release(9);
+    REQUIRE(atlas.evict_stale(1000, /*max_age=*/1) == 1);
+    REQUIRE(atlas.entry_count() == 0);
 }
 
 TEST_CASE("ImageAtlas mark_used keeps live entry from eviction - issue-646",
@@ -218,6 +258,20 @@ TEST_CASE("GradientAtlas reports capacity exhaustion - issue-646",
 
     REQUIRE_FALSE(ga.allocate(9999, row));
     REQUIRE(ga.entry_count() == 512);
+}
+
+TEST_CASE("GradientAtlas allocates monotonically after eviction - issue-646",
+          "[render][atlas][issue-646]") {
+    GradientAtlas ga;
+    int row = -1;
+    REQUIRE(ga.allocate(1, row));
+    REQUIRE(row == 0);
+    REQUIRE(ga.evict_stale(10, /*max_age=*/1) == 1);
+    REQUIRE(ga.entry_count() == 0);
+
+    REQUIRE(ga.allocate(2, row));
+    REQUIRE(row == 1);
+    REQUIRE(ga.entry_count() == 1);
 }
 
 TEST_CASE("GlyphAtlas allocate reuses same key, evicts by age - issue-646",


### PR DESCRIPTION
## Summary
- Add texture-atlas coverage for shelf-height rollover and cache-hit region reuse.
- Cover ImageAtlas duplicate-key refcount eviction behavior and GradientAtlas monotonic row allocation after eviction.
- Link Phase 3 render coverage work for #646 and #641.

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar
- cmake --build build --target pulp-test-texture-atlas -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-texture-atlas
- ctest --test-dir build -R "^(AtlasPacker|ImageAtlas|GradientAtlas|GlyphAtlas|PathAtlas|BufferPool)" --output-on-failure
- git diff --check
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report

Refs #646
Refs #641