### PR TITLE
test(view): cover widget bridge raf cancellation

### DIFF
--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -2186,6 +2186,42 @@ TEST_CASE("WidgetBridge requestAnimationFrame triggers a host repaint (issue 921
     REQUIRE(id_value.getWithDefault<int>(-1) >= 1);
 }
 
+TEST_CASE("WidgetBridge cancelAnimationFrame removes the pending native frame",
+          "[view][bridge][async][issue-493]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+
+    CountingWindowHost host;
+    root.set_window_host(&host);
+
+    WidgetBridge bridge(engine, root, store);
+
+    const int baseline_repaints = host.repaint_calls;
+    bridge.load_script("var invalid_raf_id = window.requestAnimationFrame('not a callback');");
+    REQUIRE(engine.evaluate("invalid_raf_id").getWithDefault<int>(-1) == 0);
+    REQUIRE(host.repaint_calls == baseline_repaints);
+
+    bridge.load_script(R"(
+        var raf_hits = 0;
+        var canceled_raf_id = window.requestAnimationFrame(function () {
+            raf_hits += 1;
+        });
+        window.cancelAnimationFrame(canceled_raf_id);
+    )");
+
+    REQUIRE(engine.evaluate("canceled_raf_id").getWithDefault<int>(-1) >= 1);
+    REQUIRE(host.repaint_calls > baseline_repaints);
+
+    const int repaints_after_cancel = host.repaint_calls;
+    bridge.poll_async_results();
+    bridge.service_frame_callbacks();
+
+    REQUIRE(engine.evaluate("raf_hits").getWithDefault<int>(-1) == 0);
+    REQUIRE(host.repaint_calls == repaints_after_cancel);
+}
+
 TEST_CASE("WidgetBridge requestAnimationFrame chain keeps requesting paints (issue 921)",
           "[view][bridge][issue-921]") {
     // The Spectr FilterBank pattern: a draw() callback re-arms itself via


### PR DESCRIPTION
## Summary
- Add WidgetBridge coverage for non-callable `requestAnimationFrame` handling.
- Cover `cancelAnimationFrame` removing the pending native frame before service callbacks run.
- Link Phase 3 host/view coverage work for #493 and #641.

## Validation
- cmake --build build --target pulp-test-widget-bridge -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-widget-bridge "WidgetBridge cancelAnimationFrame removes the pending native frame"
- ctest --test-dir build -R "cancelAnimationFrame" --output-on-failure
- git diff --check origin/main..HEAD
- git diff --check
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report

Refs #493
Refs #641