### PR TITLE
ci(compat): seed compat-sync gate (#1029)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -745,16 +745,18 @@ the live ruleset in isolation — the next scheduled drift run will fail.
 
 ## Versioning & Skill-Sync gates (Layer 3)
 
-`pulp pr` orchestrates the full shipping flow. CI enforces two gates on every PR to `main`:
+`pulp pr` orchestrates the full shipping flow. CI enforces three gates on every PR to `main`:
 
-- `.github/workflows/version-skill-check.yml` — runs `tools/scripts/version_bump_check.py` and `tools/scripts/skill_sync_check.py` in `--mode=report`. Failure blocks merge. No bypass except the commit trailers documented in `docs/guides/versioning.md`.
+- `.github/workflows/version-skill-check.yml` — runs `tools/scripts/version_bump_check.py`, `tools/scripts/skill_sync_check.py`, and (since #1029) `tools/scripts/compat_sync_check.py` in `--mode=report`. Failure blocks merge. No bypass except the commit trailers documented in `docs/guides/versioning.md` and `docs/guides/compat-sync.md`.
 - `.shipyard/config.toml` → `[validation.gates]` pipeline — same scripts via `shipyard run --pipeline gates`. Runs with `PULP_ENFORCE_PREPUSH=1` so warnings become errors.
 
 Locally:
 
-- `.githooks/pre-push` (install via `tools/scripts/install-githooks.sh`) runs both scripts advisory-by-default. `PULP_ENFORCE_PREPUSH=1` upgrades to hard fail; `PULP_SKIP_PREPUSH=1` is the single-push emergency bypass.
+- `.githooks/pre-push` (install via `tools/scripts/install-githooks.sh`) runs all three scripts advisory-by-default. `PULP_ENFORCE_PREPUSH=1` upgrades to hard fail; `PULP_SKIP_PREPUSH=1` is the single-push emergency bypass.
 
 **Gotcha:** changing anything under `.github/workflows/**`, `tools/shipyard.toml`, `.shipyard/**`, `.githooks/**`, `tools/install-shipyard.sh`, or `tools/scripts/install-githooks.sh` triggers the skill-sync gate for the `ci` skill — keep this file in sync when those paths move. The map lives at `tools/scripts/skill_path_map.json`.
+
+**Compat-sync (#1029):** `tools/scripts/compat_sync_check.py` is the new third leg, mirroring the skill-sync / version-bump shape for the `compat.json` matrix at the repo root. The bypass trailer is `Compat-Update: skip prefix=<section|*> reason="..."` (multiple lines allowed). Path map: `tools/scripts/compat_path_map.json`. Until #1027 ships the populated matrix, empty `compat.json` sections are tolerated. See `docs/guides/compat-sync.md` for the full design.
 
 **Auto-release:** `.github/workflows/auto-release.yml` fires on push to `main`. It diffs the two version-bearing files (`CMakeLists.txt` project version, `.claude-plugin/plugin.json` version) against the previous push range and creates the corresponding `v<x.y.z>` or `plugin-v<x.y.z>` tag. The existing tag-triggered release workflows (`release-cli.yml`, `sign-and-release.yml`) then build and publish. `Release: skip reason="..."` on the merging commit suppresses the tag.
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -24,7 +24,9 @@ fi
 PYTHON="${PYTHON:-python3}"
 VBC="$ROOT/tools/scripts/version_bump_check.py"
 SSC="$ROOT/tools/scripts/skill_sync_check.py"
+CSC="$ROOT/tools/scripts/compat_sync_check.py"
 CFG="$ROOT/tools/scripts/versioning.json"
+COMPAT_MAP="$ROOT/tools/scripts/compat_path_map.json"
 
 if [ ! -f "$VBC" ] || [ ! -f "$SSC" ] || [ ! -f "$CFG" ]; then
     # Repo predates the gates; no-op so the hook doesn't block legitimate
@@ -50,6 +52,17 @@ case $? in
     1) fail=1 ;;
     *) echo "[pre-push] version_bump_check: internal error" >&2 ;;
 esac
+
+# Compat-sync (#1029). Advisory unless PULP_ENFORCE_PREPUSH=1 — the
+# script reads the env var directly, so just pass --mode=report.
+if [ -f "$CSC" ] && [ -f "$COMPAT_MAP" ]; then
+    "$PYTHON" "$CSC" --base "$BASE" --mode=report
+    case $? in
+        0) ;;
+        1) fail=1 ;;
+        *) echo "[pre-push] compat_sync_check: internal error" >&2 ;;
+    esac
+fi
 
 # Dependency attribution drift — fails if manifest entries are missing from
 # DEPENDENCIES.md, NOTICE.md, or docs/reference/licensing.md. Advisory by

--- a/.github/workflows/version-skill-check.yml
+++ b/.github/workflows/version-skill-check.yml
@@ -104,7 +104,19 @@ jobs:
               --mode=report \
               $extra
 
+      - name: Compat-sync check (issue #1029)
+        # Authoritative gate (Layer 3) for the compat-matrix sync
+        # pattern. Mirrors the skill-sync / docs-sync stages above.
+        # PULP_ENFORCE_PREPUSH=1 is set at the job level → drift is
+        # a hard fail with no bypass other than the
+        # `Compat-Update: skip prefix=<...> reason="..."` trailer.
+        run: |
+          python3 tools/scripts/compat_sync_check.py \
+              --base "${{ steps.base.outputs.ref }}" \
+              --mode=report --enforce
+
       - name: Gate-script fixture tests
         run: |
           python3 tools/scripts/test_gates.py
           python3 tools/scripts/test_docs_sync_check.py
+          python3 tools/scripts/test_compat_sync_check.py

--- a/compat.json
+++ b/compat.json
@@ -1,0 +1,11 @@
+{
+  "compat-schema-version": "0.1",
+  "_comment": "Generated compat matrix per #1027. Do not hand-edit prop entries; the source of truth is the bridge / shim / adapter source files. Run `pulp compat regenerate` (planned in #1027) to refresh. This is a stub committed in #1029 so the compat-sync infrastructure (tools/scripts/compat_sync_check.py and friends) has something to enforce against. Empty sections are tolerated — the gate treats them as 'no requirement yet' so #1029 can land before #1027 populates the matrix data.",
+  "css": {},
+  "rn": {},
+  "yoga": {},
+  "react": {},
+  "html": {},
+  "canvas2d": {},
+  "imports": {}
+}

--- a/docs/guides/compat-sync.md
+++ b/docs/guides/compat-sync.md
@@ -1,0 +1,150 @@
+# Compat-Sync Policy
+
+Pulp's `@pulp/react`, `@pulp/css-adapt`, and the native bridge layer
+underneath them ship a **compatibility matrix** at the repo root
+(`compat.json`) that tells users which React Native, CSS, Yoga, React,
+HTML, Canvas2D, and import-resolver props are supported on Pulp. The
+matrix is the contract — drifting it from the bridge code is the
+single most expensive mistake we can make for ecosystem trust.
+
+The compat-sync gate (issue #1029) generalizes the skill-sync /
+version-bump / docs-sync pattern to this domain: when a PR's diff
+touches a path mapped to a compat surface, the matching artifacts
+(compat.json prefix entry, doc page, test glob) must be updated in
+the same diff — or the PR must carry an explicit bypass trailer.
+
+> **Status (v0.59 era):** The infrastructure (script, hooks, CI gate,
+> bypass trailer, this doc) ships in #1029. The populated `compat.json`
+> matrix data ships in #1027. Until #1027 lands, empty sections in
+> `compat.json` are tolerated by the gate (treated as "no requirement
+> yet") so this scaffolding can land without blocking on the data.
+
+## Three-layer enforcement
+
+Same shape as [versioning.md § Three-layer gate](versioning.md#three-layer-gate):
+
+```
+Layer 1 (fast, per-edit, agent-specific)
+    hooks/scripts/cli-plugin-sync.sh, Claude Code PostToolUse hooks
+    → compat_sync_check.py --mode=hint, advisory
+
+Layer 2 (pre-push, agent-agnostic, advisory)
+    .githooks/pre-push
+    → compat_sync_check.py --mode=report
+    → PULP_ENFORCE_PREPUSH=1 upgrades to hard fail
+
+Layer 3 (PR gate, authoritative)
+    .github/workflows/version-skill-check.yml
+    → compat_sync_check.py --mode=report --enforce
+    → no bypass without commit trailer
+```
+
+All three layers call into the same script
+(`tools/scripts/compat_sync_check.py`); only the enforcement is
+different.
+
+## The path map
+
+`tools/scripts/compat_path_map.json` is the single source of truth for
+"this source file requires which compat artifacts." Each source-path
+entry is an array of `{kind, prefix|path|glob}` requirements:
+
+```json
+{
+  "core/view/js/web-compat-canvas.js": [
+    {"kind": "compat-json", "prefix": "canvas2d"},
+    {"kind": "doc", "path": "docs/reference/compat/canvas2d.md"},
+    {"kind": "test", "glob": "test/test_canvas_widget*.cpp"}
+  ]
+}
+```
+
+Three requirement kinds:
+
+| Kind          | Means                                                 |
+|---------------|-------------------------------------------------------|
+| `compat-json` | The named section in `compat.json` must exist (and, once #1027 lands, contain entries for the new prop). `prefix=*` means "any/all sections". |
+| `doc`         | The named doc page must be touched in the same diff. `{prefix}` in the path expands per-prefix when the source spans multiple compat sections. |
+| `test`        | At least one file matching the glob must be touched in the same diff. Tests are the bridge's correctness contract. |
+
+When a path-map entry has multiple requirements, they all share the
+"effective prefix" determined by the `compat-json` requirement (or
+the wildcard set if it's `*`). That means a single bypass trailer
+covers compat-json + doc + test for one source file.
+
+## Bypass trailer
+
+Tip-commit (or any commit in the diff range) trailer matching the
+existing `Version-Bump: skip` / `Skill-Update: skip` shape:
+
+```
+Compat-Update: skip prefix=<css|rn|yoga|react|html|canvas2d|imports|*> reason="..."
+```
+
+- Multiple `Compat-Update: skip` lines allowed, one per prefix.
+- `prefix=*` covers every section.
+- Bare `Compat-Update: skip` (no `prefix=`, no `reason=`) is rejected.
+- Empty reasons (`reason=""`) are rejected.
+
+The audit trail lives in git, not in the PR body. A bypass is a
+recorded admission that the author thought about the rule and decided
+it doesn't apply.
+
+## Modes
+
+| Mode     | Behavior |
+|----------|----------|
+| `hint`   | Always exit 0. Print advisory text. Used by agent PostToolUse hooks. |
+| `report` | Print drift. Exit 1 iff `--enforce` or `PULP_ENFORCE_PREPUSH=1`. CI sets both; pre-push hook sets the env var only when promoted. |
+| `apply`  | Like `report` but also writes stub `{}` sections into `compat.json` for any missing prefixes. Doc and test stubs are NOT auto-created — those need human-authored content. |
+
+## Adding a new mapped path
+
+1. Identify the prefix(es) the source spans:
+   - `core/view/src/widget_bridge.cpp` → `*` (every section).
+   - `core/view/js/web-compat-canvas.js` → `canvas2d` only.
+   - `core/view/js/web-compat-style-decl.js` → `css` only.
+
+2. Add the entry to `tools/scripts/compat_path_map.json`:
+
+   ```json
+   "core/view/js/web-compat-foo.js": [
+     {"kind": "compat-json", "prefix": "<prefix>"},
+     {"kind": "doc", "path": "docs/reference/compat/<prefix>.md"},
+     {"kind": "test", "glob": "test/test_widget_foo*.cpp"}
+   ]
+   ```
+
+3. Run the gate locally to verify your map entry is honored:
+
+   ```bash
+   python3 tools/scripts/compat_sync_check.py --mode=report
+   ```
+
+4. Update `tools/scripts/test_compat_sync_check.py` if the new path
+   class needs a regression test. (Adding entries that follow an
+   existing pattern usually doesn't.)
+
+## Adding a new compat section
+
+`compat.json` recognizes seven top-level sections by default:
+`css`, `rn`, `yoga`, `react`, `html`, `canvas2d`, `imports`. To add a
+new one:
+
+1. Add it to `KNOWN_PREFIXES` in `tools/scripts/compat_sync_check.py`.
+2. Add the empty section to `compat.json`.
+3. Update this doc, plus
+   `tools/scripts/test_compat_sync_check.py` if the new section
+   warrants a self-check coverage row.
+
+## See also
+
+- [docs/guides/versioning.md](versioning.md) — the parent three-layer
+  enforcement design (skill-sync + version-bump).
+- [tools/scripts/compat_sync_check.py](../../tools/scripts/compat_sync_check.py)
+  — the gate.
+- [tools/scripts/compat_path_map.json](../../tools/scripts/compat_path_map.json)
+  — the path map.
+- [compat.json](../../compat.json) — the matrix (stub until #1027).
+- Issue #1027 — the populated matrix.
+- Issue #1029 — this gate's design and rollout.

--- a/docs/guides/versioning.md
+++ b/docs/guides/versioning.md
@@ -231,9 +231,14 @@ All three bypass trailers live on the tip commit, never in the PR body. The audi
 |----------------|-----------------------------------------------------------|
 | Version bump   | `Version-Bump: <surface>=<patch|minor|major|skip> reason="..."` |
 | Skill update   | `Skill-Update: skip skill=<name> reason="..."`           |
+| Compat update  | `Compat-Update: skip prefix=<section\|*> reason="..."`    |
 | Auto-release   | `Release: skip reason="..."`                              |
 
 A bypass is a recorded admission that the author thought about the rule and decided it doesn't apply. Empty-reason bypasses are rejected.
+
+The compat-update gate uses the same three-layer pattern as the
+version-bump and skill-update gates; see [compat-sync.md](compat-sync.md)
+for the path map, requirement kinds, and rollout state (#1029 / #1027).
 
 ---
 

--- a/hooks/scripts/cli-plugin-sync.sh
+++ b/hooks/scripts/cli-plugin-sync.sh
@@ -54,10 +54,16 @@ done
 if [ -n "$REPO_ROOT" ]; then
     VBC="$REPO_ROOT/tools/scripts/version_bump_check.py"
     SSC="$REPO_ROOT/tools/scripts/skill_sync_check.py"
+    CSC="$REPO_ROOT/tools/scripts/compat_sync_check.py"
     if [ -x "$VBC" ]; then
         "$VBC" --base origin/main --config "$REPO_ROOT/tools/scripts/versioning.json" --mode=hint 2>/dev/null || true
     fi
     if [ -x "$SSC" ]; then
         "$SSC" --base origin/main --config "$REPO_ROOT/tools/scripts/versioning.json" --mode=hint 2>/dev/null || true
+    fi
+    # Compat-sync hint (#1029). Runs against tools/scripts/compat_path_map.json
+    # by default; advisory only — same shape as the version/skill hints.
+    if [ -x "$CSC" ]; then
+        "$CSC" --base origin/main --mode=hint 2>/dev/null || true
     fi
 fi

--- a/tools/scripts/compat_path_map.json
+++ b/tools/scripts/compat_path_map.json
@@ -1,0 +1,30 @@
+{
+  "compat-schema-version": "0.1",
+  "schema_version": 1,
+  "_comment": "Compat-sync map (#1029). Source path → required compat.json prefix(es) + doc(s) + test(s). When a diff touches any path matching a key, the corresponding requirement(s) must be satisfied in the same diff (compat.json prefix entry present + doc page touched + test glob matched), OR a `Compat-Update: skip prefix=<...> reason=\"...\"` trailer must appear on a commit in the range. Multiple skip lines allowed, one per prefix; bare `Compat-Update: skip` (no reason) is rejected.\n\nThe `*` prefix is a wildcard meaning the requirement applies regardless of which compat section the change touches — used when the source-path itself spans multiple sections (e.g. core/view/src/widget_bridge.cpp dispatches into css/, html/, canvas2d/ and rn/).\n\nNote: paired with tools/scripts/compat_sync_check.py and the (forthcoming, #1027) compat.json at the repo root. Until #1027 lands the populated compat.json, empty sections in the stub compat.json are tolerated — the gate treats `compat-json` requirements as satisfied when the named section exists but is empty so this infrastructure can land before the matrix data does.\n\nFuture extension: the `@pulp/react` and `@pulp/css-adapt` paths from the issue body live in separate npm packages NOT in this repo. Add entries here when those packages move into the monorepo.",
+  "paths": {
+    "core/view/src/widget_bridge.cpp": [
+      {"kind": "compat-json", "prefix": "*"},
+      {"kind": "doc", "path": "docs/reference/compat/{prefix}.md"},
+      {"kind": "test", "glob": "test/test_widget_bridge*.cpp"}
+    ],
+    "core/view/include/pulp/view/widget_bridge.hpp": [
+      {"kind": "compat-json", "prefix": "*"},
+      {"kind": "doc", "path": "docs/reference/compat/{prefix}.md"},
+      {"kind": "test", "glob": "test/test_widget_bridge*.cpp"}
+    ],
+    "core/view/js/web-compat-canvas.js": [
+      {"kind": "compat-json", "prefix": "canvas2d/"},
+      {"kind": "doc", "path": "docs/reference/compat/canvas2d.md"},
+      {"kind": "test", "glob": "test/test_canvas_widget*.cpp"}
+    ],
+    "core/view/js/web-compat-element.js": [
+      {"kind": "compat-json", "prefix": "html/"},
+      {"kind": "doc", "path": "docs/reference/compat/html.md"}
+    ],
+    "core/view/js/web-compat-style-decl.js": [
+      {"kind": "compat-json", "prefix": "css/"},
+      {"kind": "doc", "path": "docs/reference/compat/css.md"}
+    ]
+  }
+}

--- a/tools/scripts/compat_sync_check.py
+++ b/tools/scripts/compat_sync_check.py
@@ -1,0 +1,790 @@
+#!/usr/bin/env python3
+"""Compat-sync gate (#1029).
+
+Generalizes the skill-sync / docs-sync pattern to the compat-matrix
+domain. Given a diff range (base..head), assert that every
+compat-mapped source file that was touched also has its required
+artifacts updated:
+
+    1. an entry in the matching `compat.json` section/prefix,
+    2. the matching docs/reference/compat/<prefix>.md doc page, and
+    3. a test that matches the configured glob.
+
+If any of those is missing AND the tip commit (or any commit in the
+range) does NOT carry the matching bypass trailer, the gate fails.
+
+Bypass trailer (matches the existing `Version-Bump: skip` /
+`Skill-Update: skip` shape):
+
+    Compat-Update: skip prefix=<css|rn|yoga|react|html|canvas2d|imports|*> reason="..."
+
+Multiple skip lines allowed, one per prefix. Bare `Compat-Update: skip`
+(no reason) is rejected.
+
+Modes:
+    --mode=hint    advisory text only, exit 0
+    --mode=report  exit 1 on drift when --enforce or
+                   PULP_ENFORCE_PREPUSH=1 is set (advisory otherwise)
+    --mode=apply   like report, but ALSO writes stub keys into
+                   compat.json so the user only has to fill in details
+
+Partial-blocker tolerance (#1027): until the compat.json sections are
+populated, empty sections are NOT a self-check failure. A compat-json
+requirement counts as satisfied when:
+    - the requested prefix already has a non-empty entry in compat.json, OR
+    - the section is empty (no compat-matrix data has been generated
+      yet — accept "no requirement yet" so this infrastructure can
+      land before #1027), OR
+    - the same diff modified compat.json (someone added a new entry).
+
+When #1027 ships the populated matrix, flip COMPAT_TOLERATE_EMPTY in the
+config or just remove the empty-tolerance branch in
+``_compat_json_satisfied``.
+
+Uses JSON (not YAML) for zero-dependency execution on PEP-668 Python.
+Mirrors the shape of ``tools/scripts/skill_sync_check.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+# All compat sections recognized by the gate. Mirrors the top-level
+# keys in compat.json. The wildcard `*` is allowed in
+# compat_path_map.json to mean "any/all sections" — used when the
+# source file dispatches across multiple compat surfaces (e.g.
+# widget_bridge.cpp).
+KNOWN_PREFIXES = {"css", "rn", "yoga", "react", "html", "canvas2d", "imports"}
+
+
+# ── Types ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Requirement:
+    kind: str           # "compat-json" | "doc" | "test"
+    prefix: str | None  # for compat-json: section name like "css", or "*"
+    path: str | None    # for doc: literal path with optional {prefix} placeholder
+    glob: str | None    # for test: glob like "test/test_widget_bridge*.cpp"
+
+
+@dataclass
+class CompatMap:
+    paths: dict[str, list[Requirement]]
+
+
+@dataclass
+class Finding:
+    source_path: str
+    requirement: Requirement
+    resolved_prefix: str  # the actual prefix this finding pertains to
+    satisfied: bool
+    bypass_reason: str | None
+    detail: str           # human-readable "what's missing"
+
+
+# ── Git helpers ─────────────────────────────────────────────────────────
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True, capture_output=True, text=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def git_diff_names(base: str, head: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}..{head}"],
+        check=True, capture_output=True, text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def git_range_trailers(base: str, head: str) -> dict[str, list[str]]:
+    """Collect trailers from ALL commits in `base..head`, merged.
+
+    CI checks out a synthetic merge commit as HEAD, so a bypass trailer
+    on the branch's tip commit wouldn't be seen if we only looked at
+    HEAD. Walk the whole range instead — any commit in the range
+    carries the bypass. Mirrors the pattern in skill_sync_check.py.
+    """
+    try:
+        body = subprocess.run(
+            ["git", "log", "--format=%B%x00", f"{base}..{head}"],
+            check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return {}
+
+    result: dict[str, list[str]] = {}
+    for body_chunk in body.split("\x00"):
+        if not body_chunk.strip():
+            continue
+        trailers = subprocess.run(
+            ["git", "interpret-trailers", "--parse"],
+            input=body_chunk, capture_output=True, text=True,
+        )
+        for line in trailers.stdout.splitlines():
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            result.setdefault(key.strip().lower(), []).append(value.strip())
+    return result
+
+
+# ── Config loading ──────────────────────────────────────────────────────
+
+
+def _strip_comments(data: dict) -> dict:
+    if isinstance(data, dict):
+        return {
+            k: v for k, v in data.items()
+            if not k.startswith("_") and k != "$schema"
+        }
+    return data
+
+
+def load_compat_map(path: Path) -> CompatMap:
+    raw = _strip_comments(json.loads(path.read_text(encoding="utf-8")))
+    paths_raw = raw.get("paths", {}) or {}
+    paths: dict[str, list[Requirement]] = {}
+    for source, reqs in paths_raw.items():
+        out: list[Requirement] = []
+        for r in reqs:
+            kind = r.get("kind")
+            if kind == "compat-json":
+                out.append(Requirement(
+                    kind="compat-json",
+                    prefix=str(r.get("prefix") or "*").rstrip("/"),
+                    path=None,
+                    glob=None,
+                ))
+            elif kind == "doc":
+                out.append(Requirement(
+                    kind="doc",
+                    prefix=None,
+                    path=str(r.get("path", "")),
+                    glob=None,
+                ))
+            elif kind == "test":
+                out.append(Requirement(
+                    kind="test",
+                    prefix=None,
+                    path=None,
+                    glob=str(r.get("glob", "")),
+                ))
+            else:
+                # Unknown requirement kind — skip silently rather than
+                # crash. The self-check below catches obvious typos.
+                continue
+        paths[source] = out
+    return CompatMap(paths=paths)
+
+
+def load_compat_json(path: Path) -> dict:
+    """Load the repo-root compat.json. Tolerate missing/empty file —
+    #1027 may not have shipped yet."""
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except json.JSONDecodeError:
+        return {}
+
+
+# ── Glob matching (mirrors skill_sync_check) ───────────────────────────
+
+
+@lru_cache(maxsize=None)
+def _glob_to_regex(pattern: str) -> "re.Pattern[str]":
+    """Translate a gitignore-style glob into an anchored regex.
+
+    Mirrors ``skill_sync_check._glob_to_regex``. Kept here as a
+    deliberate copy so each gate stays a single-file script. Semantics:
+        - ``**`` matches zero or more path segments (including zero).
+        - ``*``  matches zero or more characters within a single segment.
+        - ``?``  matches exactly one character within a single segment.
+        - Patterns are anchored at both ends.
+    """
+    parts = pattern.split("/")
+    n = len(parts)
+
+    STARSTAR = object()
+    tokens: list = []
+    for part in parts:
+        if part == "**":
+            tokens.append(STARSTAR)
+            continue
+        seg = ""
+        for c in part:
+            if c == "*":
+                seg += "[^/]*"
+            elif c == "?":
+                seg += "[^/]"
+            else:
+                seg += re.escape(c)
+        tokens.append(seg)
+
+    out = ""
+    for i, tok in enumerate(tokens):
+        is_first = i == 0
+        is_last = i == n - 1
+        if tok is STARSTAR:
+            if is_first and is_last:
+                out += ".*"
+            elif is_first:
+                out += "(?:[^/]+/)*"
+            elif is_last:
+                if out.endswith("/"):
+                    out = out[:-1]
+                out += "(?:/.*)?"
+            else:
+                if not out.endswith("/"):
+                    out += "/"
+                out += "(?:[^/]+/)*"
+        else:
+            if not is_first:
+                if not out.endswith("/") and not out.endswith(")?") \
+                   and not out.endswith(")*"):
+                    out += "/"
+            out += tok
+
+    return re.compile("^" + out + "$")
+
+
+def _glob_match(path: str, pattern: str) -> bool:
+    return _glob_to_regex(pattern).match(path) is not None
+
+
+def _matches_any(path: str, patterns: Iterable[str]) -> bool:
+    p = path.replace(os.sep, "/")
+    for pat in patterns:
+        if _glob_match(p, pat):
+            return True
+    return False
+
+
+# ── Trailer parsing ─────────────────────────────────────────────────────
+
+
+def parse_compat_update_trailer(
+    trailers: dict[str, list[str]],
+) -> dict[str, str]:
+    """Parse `Compat-Update: skip prefix=<x> reason="..."` lines.
+
+    Returns {prefix: reason}. Multiple skip lines allowed, one per
+    prefix. Bare `skip` with no `prefix=` or no `reason=` is rejected
+    (returns nothing for that line).
+    """
+    bypasses: dict[str, str] = {}
+    for v in trailers.get("compat-update", []):
+        if not v.lower().startswith("skip"):
+            continue
+        m_prefix = re.search(r"prefix\s*=\s*([A-Za-z0-9_./*-]+)", v)
+        if not m_prefix:
+            # Bare "skip" — reject (no audit trail).
+            continue
+        prefix = m_prefix.group(1).rstrip("/")
+        reason_m = (
+            re.search(r'reason\s*=\s*"([^"]*)"', v)
+            or re.search(r"reason\s*=\s*(\S+)", v)
+        )
+        if not reason_m:
+            # Reason required.
+            continue
+        reason = reason_m.group(1).strip()
+        if not reason:
+            continue
+        bypasses[prefix] = reason
+    return bypasses
+
+
+# ── Resolution helpers ──────────────────────────────────────────────────
+
+
+def _resolve_prefixes_for_source(
+    requirement: Requirement,
+    source_path: str,
+    compat_data: dict,
+) -> list[str]:
+    """Determine which concrete prefixes a source-path requirement
+    expands into.
+
+    For most files the path-map declares the prefix directly
+    (e.g. canvas2d/). For widget_bridge-style files that span every
+    section, the path-map uses `*` and we expand to every KNOWN_PREFIX
+    that exists in compat.json (so reviewers see one bullet per
+    affected section).
+    """
+    if requirement.prefix and requirement.prefix != "*":
+        return [requirement.prefix]
+    # Wildcard: expand to all known sections that exist in compat.json.
+    # If compat.json itself is missing/empty, fall back to KNOWN_PREFIXES.
+    sections = [k for k in compat_data.keys() if k in KNOWN_PREFIXES]
+    if not sections:
+        sections = sorted(KNOWN_PREFIXES)
+    return sorted(sections)
+
+
+def _compat_json_satisfied(
+    prefix: str,
+    compat_data: dict,
+    changed: list[str],
+    compat_json_path: str,
+) -> tuple[bool, str]:
+    """Decide whether the compat-json requirement is satisfied.
+
+    Tolerance rules per #1029 partial-blocker:
+        1. compat.json modified in this diff → satisfied.
+        2. section is non-empty (#1027 has populated it) → satisfied.
+        3. section exists but is empty → tolerated (no requirement
+           yet) → satisfied.
+        4. section absent from compat.json → fail with guidance.
+    """
+    if compat_json_path in changed:
+        return True, "compat.json modified in diff"
+    if prefix not in compat_data:
+        return False, (
+            f"compat.json has no '{prefix}' section "
+            f"(expected `\"{prefix}\": {{}}` at minimum)"
+        )
+    section = compat_data[prefix]
+    if isinstance(section, dict) and len(section) == 0:
+        return True, "section empty — tolerated until #1027 populates"
+    return True, "section already populated"
+
+
+def _doc_path_for(prefix: str, template: str) -> str:
+    """Substitute {prefix} in a doc template path."""
+    return template.replace("{prefix}", prefix)
+
+
+# ── Core check ─────────────────────────────────────────────────────────
+
+
+def _effective_prefixes_for_source(
+    requirements: list[Requirement],
+    compat_data: dict,
+) -> list[str]:
+    """Collect the prefix(es) that apply to a given source-path entry.
+
+    A path-map entry usually declares a single concrete prefix on its
+    `compat-json` requirement (e.g. `canvas2d`). All sibling requirements
+    (doc, test) implicitly share that prefix — even if they themselves
+    are unprefixed — so a single bypass like `prefix=canvas2d` covers
+    every requirement for that source.
+
+    For wildcard (`*`) compat-json requirements, expand to every known
+    section present in compat.json (or `KNOWN_PREFIXES` if compat.json
+    is empty / absent).
+    """
+    compat_reqs = [r for r in requirements if r.kind == "compat-json"]
+    if not compat_reqs:
+        return ["*"]
+
+    prefixes: list[str] = []
+    for r in compat_reqs:
+        if r.prefix and r.prefix != "*":
+            prefixes.append(r.prefix)
+        else:
+            sections = [k for k in compat_data.keys() if k in KNOWN_PREFIXES]
+            if not sections:
+                sections = sorted(KNOWN_PREFIXES)
+            prefixes.extend(sorted(sections))
+    # De-dupe while preserving order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for p in prefixes:
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+def compute_findings(
+    changed: list[str],
+    compat_map: CompatMap,
+    compat_data: dict,
+    bypasses: dict[str, str],
+    compat_json_path: str = "compat.json",
+) -> list[Finding]:
+    """Walk every (source, requirement, prefix) triple and decide
+    whether it's satisfied / bypassed / failing.
+
+    The same `effective_prefixes` set applies to every requirement
+    under a source-path entry — that way a single bypass trailer like
+    `prefix=canvas2d` covers compat-json + doc + test in one go.
+    """
+    findings: list[Finding] = []
+
+    for source, requirements in compat_map.paths.items():
+        if source not in changed:
+            continue
+
+        effective_prefixes = _effective_prefixes_for_source(
+            requirements, compat_data,
+        )
+
+        for req in requirements:
+            for prefix in effective_prefixes:
+                # Bypass: explicit prefix or wildcard.
+                bypass = bypasses.get(prefix) or bypasses.get("*")
+
+                if req.kind == "compat-json":
+                    # Skip rows that don't match THIS requirement's
+                    # declared prefix — a non-wildcard compat-json
+                    # requirement only pertains to its own section.
+                    if req.prefix and req.prefix != "*" \
+                            and prefix != req.prefix:
+                        continue
+                    ok, detail = _compat_json_satisfied(
+                        prefix, compat_data, changed, compat_json_path,
+                    )
+                    findings.append(Finding(
+                        source_path=source,
+                        requirement=req,
+                        resolved_prefix=prefix,
+                        satisfied=ok,
+                        bypass_reason=bypass if not ok else None,
+                        detail=detail,
+                    ))
+                elif req.kind == "doc":
+                    if req.path and "{prefix}" in req.path:
+                        doc_path = _doc_path_for(prefix, req.path)
+                    else:
+                        # Non-templated doc path: only emit one row per
+                        # source (avoid one duplicate per prefix).
+                        if prefix != effective_prefixes[0]:
+                            continue
+                        doc_path = req.path or ""
+                    ok = doc_path in changed
+                    findings.append(Finding(
+                        source_path=source,
+                        requirement=req,
+                        resolved_prefix=prefix,
+                        satisfied=ok,
+                        bypass_reason=bypass if not ok else None,
+                        detail=(
+                            f"doc {doc_path} updated"
+                            if ok else f"doc {doc_path} NOT updated"
+                        ),
+                    ))
+                elif req.kind == "test":
+                    # Tests aren't prefix-specific — emit one row only.
+                    if prefix != effective_prefixes[0]:
+                        continue
+                    glob = req.glob or ""
+                    test_hits = [c for c in changed if _matches_any(c, [glob])]
+                    ok = bool(test_hits)
+                    findings.append(Finding(
+                        source_path=source,
+                        requirement=req,
+                        resolved_prefix=prefix,
+                        satisfied=ok,
+                        bypass_reason=bypass if not ok else None,
+                        detail=(
+                            f"matched {len(test_hits)} test file(s) for {glob}"
+                            if ok else f"no test file matching {glob}"
+                        ),
+                    ))
+    return findings
+
+
+# ── Self-check ─────────────────────────────────────────────────────────
+
+
+def self_check(compat_map: CompatMap, compat_data: dict) -> list[str]:
+    """Return list of problems with the configuration itself."""
+    errors: list[str] = []
+    for source, reqs in compat_map.paths.items():
+        for req in reqs:
+            if req.kind == "compat-json" and req.prefix:
+                if req.prefix != "*" and req.prefix not in KNOWN_PREFIXES:
+                    errors.append(
+                        f"self-check: compat_path_map.json[{source!r}] uses "
+                        f"unknown prefix '{req.prefix}' (known: "
+                        f"{', '.join(sorted(KNOWN_PREFIXES))} or '*')"
+                    )
+            if req.kind == "test" and not req.glob:
+                errors.append(
+                    f"self-check: compat_path_map.json[{source!r}] test "
+                    f"requirement has no glob"
+                )
+            if req.kind == "doc" and not req.path:
+                errors.append(
+                    f"self-check: compat_path_map.json[{source!r}] doc "
+                    f"requirement has no path"
+                )
+    # If compat.json is present, sanity-check its top-level keys against
+    # the known prefix set. Unknown keys are non-fatal but warn-worthy.
+    if compat_data:
+        unknown = [k for k in compat_data.keys()
+                   if not k.startswith("_")
+                   and not k.startswith("$")
+                   and k != "compat-schema-version"
+                   and k not in KNOWN_PREFIXES]
+        for k in unknown:
+            errors.append(
+                f"self-check: compat.json has unknown top-level key '{k}'"
+            )
+    return errors
+
+
+# ── Apply mode ─────────────────────────────────────────────────────────
+
+
+def apply_stubs(
+    findings: list[Finding],
+    compat_data: dict,
+    compat_json_path: Path,
+) -> list[str]:
+    """For each unsatisfied compat-json finding whose section is
+    missing, add an empty `{}` placeholder. Returns the list of
+    sections added so the caller can report what changed.
+
+    Doc and test stubs are NOT auto-created — those require
+    human-authored content per #1029's "user just has to fill in
+    details" directive (we add the JSON skeleton; the user authors
+    the prose and tests).
+    """
+    added: list[str] = []
+    if not compat_data:
+        compat_data = {
+            "compat-schema-version": "0.1",
+            "_comment": "Stub created by compat_sync_check.py --mode=apply",
+        }
+        for p in sorted(KNOWN_PREFIXES):
+            compat_data[p] = {}
+            added.append(p)
+    else:
+        for f in findings:
+            if f.requirement.kind != "compat-json":
+                continue
+            if f.satisfied:
+                continue
+            if f.resolved_prefix in KNOWN_PREFIXES \
+                    and f.resolved_prefix not in compat_data:
+                compat_data[f.resolved_prefix] = {}
+                added.append(f.resolved_prefix)
+
+    if added:
+        compat_json_path.write_text(
+            json.dumps(compat_data, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    return added
+
+
+# ── Reporting ──────────────────────────────────────────────────────────
+
+
+def render_report(
+    findings: list[Finding],
+    mode: str,
+    enforce: bool,
+) -> tuple[str, int]:
+    lines: list[str] = []
+    hard_failures: list[Finding] = []
+
+    # Group by (source, prefix) for compact output.
+    grouped: dict[tuple[str, str], list[Finding]] = {}
+    for f in findings:
+        grouped.setdefault((f.source_path, f.resolved_prefix), []).append(f)
+
+    for (source, prefix), group in sorted(grouped.items()):
+        lines.append(f"[{source}] (prefix={prefix})")
+        for f in group:
+            kind = f.requirement.kind
+            if f.satisfied:
+                lines.append(f"  ✓ {kind}: {f.detail}")
+            elif f.bypass_reason:
+                lines.append(
+                    f"  ✓ {kind}: bypassed ({f.bypass_reason}) — {f.detail}"
+                )
+            else:
+                lines.append(f"  ✗ {kind}: {f.detail}")
+                hard_failures.append(f)
+
+    if not findings:
+        lines.append("compat-sync: no mapped paths touched — nothing to verify.")
+
+    if hard_failures and mode in ("report", "apply"):
+        lines.append("")
+        lines.append("Compat-sync check FAILED.")
+        lines.append("For each row above marked ✗, do ONE of:")
+        lines.append("  1. Update compat.json (add prefix entry), the doc,")
+        lines.append("     or add a matching test in this branch, OR")
+        lines.append("  2. Add a commit trailer with the exact form:")
+        # Show one suggestion line per unique missing prefix.
+        seen: set[str] = set()
+        for f in hard_failures:
+            if f.resolved_prefix in seen:
+                continue
+            seen.add(f.resolved_prefix)
+            lines.append(
+                f'     Compat-Update: skip prefix={f.resolved_prefix} reason="..."'
+            )
+        if enforce:
+            return "\n".join(lines), 1
+        # Advisory: still print but exit 0.
+        lines.append("")
+        lines.append(
+            "(advisory — set PULP_ENFORCE_PREPUSH=1 or pass --enforce to block)"
+        )
+        return "\n".join(lines), 0
+
+    return "\n".join(lines), 0
+
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Compat-sync gate (#1029)")
+    parser.add_argument("--base", default="origin/main",
+                        help="Diff base (default: origin/main)")
+    parser.add_argument("--head", default="HEAD",
+                        help="Diff head (default: HEAD)")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help=(
+            "Path to compat_path_map.json "
+            "(default: tools/scripts/compat_path_map.json at repo root)"
+        ),
+    )
+    parser.add_argument(
+        "--compat-json",
+        default=None,
+        help="Path to compat.json (default: <repo>/compat.json)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("report", "hint", "apply"),
+        default="report",
+        help=(
+            "report: print drift, hard-fail iff --enforce or "
+            "PULP_ENFORCE_PREPUSH=1; "
+            "hint: advisory text only, exit 0; "
+            "apply: like report but auto-add stub compat.json sections"
+        ),
+    )
+    parser.add_argument(
+        "--enforce",
+        action="store_true",
+        help="Hard-fail on drift (CI sets this; pre-push hook sets via env).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Override repo root (default: git rev-parse --show-toplevel)",
+    )
+    args = parser.parse_args(argv)
+
+    enforce = args.enforce or os.environ.get("PULP_ENFORCE_PREPUSH") == "1"
+
+    try:
+        root = Path(args.repo_root) if args.repo_root else repo_root()
+    except subprocess.CalledProcessError:
+        sys.stderr.write(
+            "compat_sync_check: not in a git repo (or --repo-root invalid)\n"
+        )
+        return 2
+
+    cfg_path = (
+        Path(args.config) if args.config
+        else root / "tools" / "scripts" / "compat_path_map.json"
+    )
+    if not cfg_path.exists():
+        sys.stderr.write(
+            f"compat_sync_check: config not found: {cfg_path}\n"
+        )
+        return 2
+
+    compat_json_path = (
+        Path(args.compat_json) if args.compat_json
+        else root / "compat.json"
+    )
+
+    compat_map = load_compat_map(cfg_path)
+    compat_data = load_compat_json(compat_json_path)
+
+    self_errors = self_check(compat_map, compat_data)
+    if self_errors:
+        print("\n".join(self_errors), file=sys.stderr)
+        if args.mode == "report" and enforce:
+            return 1
+        if args.mode == "apply":
+            return 1
+
+    try:
+        changed = git_diff_names(args.base, args.head)
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            f"compat_sync_check: git diff against '{args.base}' failed: {exc}\n"
+            "  Fetch the base ref (e.g. `git fetch origin main`) and retry.\n"
+        )
+        return 2
+
+    trailers = git_range_trailers(args.base, args.head)
+    bypasses = parse_compat_update_trailer(trailers)
+
+    # Compute compat.json path RELATIVE to repo root for the changed-file
+    # comparison (`git diff --name-only` returns repo-relative paths).
+    try:
+        compat_json_rel = str(
+            compat_json_path.relative_to(root)
+        ).replace(os.sep, "/")
+    except ValueError:
+        compat_json_rel = "compat.json"
+
+    findings = compute_findings(
+        changed=changed,
+        compat_map=compat_map,
+        compat_data=compat_data,
+        bypasses=bypasses,
+        compat_json_path=compat_json_rel,
+    )
+
+    if args.mode == "apply":
+        added = apply_stubs(findings, compat_data, compat_json_path)
+        if added:
+            print(
+                f"compat-sync: added stub sections in {compat_json_path}: "
+                f"{', '.join(added)}"
+            )
+            # Re-evaluate now that stubs have been written.
+            compat_data = load_compat_json(compat_json_path)
+            findings = compute_findings(
+                changed=changed + [compat_json_rel],
+                compat_map=compat_map,
+                compat_data=compat_data,
+                bypasses=bypasses,
+                compat_json_path=compat_json_rel,
+            )
+
+    text, code = render_report(findings, args.mode, enforce)
+    if text:
+        print(text)
+
+    if args.mode == "hint":
+        return 0
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/scripts/test_compat_sync_check.py
+++ b/tools/scripts/test_compat_sync_check.py
@@ -288,9 +288,15 @@ def _git(cwd: Path, *args: str) -> None:
 
 
 def _run_script(cwd: Path, *args: str) -> tuple[int, str]:
+    # Drop PULP_ENFORCE_PREPUSH from the inherited env so advisory-mode
+    # tests (no --enforce flag) get a genuine advisory exit code.
+    # CI sets PULP_ENFORCE_PREPUSH=1 globally to harden the gate
+    # against drift; without scrubbing here, every advisory-mode test
+    # silently runs in enforce mode and false-fails on missing artifacts.
+    env = {k: v for k, v in os.environ.items() if k != "PULP_ENFORCE_PREPUSH"}
     result = subprocess.run(
         ["python3", str(SCRIPT), *args],
-        cwd=cwd, capture_output=True, text=True,
+        cwd=cwd, capture_output=True, text=True, env=env,
     )
     return result.returncode, result.stdout + result.stderr
 

--- a/tools/scripts/test_compat_sync_check.py
+++ b/tools/scripts/test_compat_sync_check.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Tests for compat_sync_check.py (#1029).
+
+Two layers:
+    1. Unit-style — pure-Python evaluation of compute_findings,
+       parse_compat_update_trailer, _compat_json_satisfied, etc.
+    2. Integration — throwaway git repo + real git commits + invoke
+       the script via subprocess. Mirrors test_gates.py's pattern.
+
+Run:
+    python3 tools/scripts/test_compat_sync_check.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "tools" / "scripts" / "compat_sync_check.py"
+
+# Make the script importable for unit-style tests.
+sys.path.insert(0, str(REPO_ROOT / "tools" / "scripts"))
+import compat_sync_check as csc  # noqa: E402
+
+
+# ── Unit tests (pure-Python) ───────────────────────────────────────────
+
+
+class TrailerParseTests(unittest.TestCase):
+
+    def test_parses_skip_with_reason(self) -> None:
+        trailers = {"compat-update": [
+            'skip prefix=css reason="docs-only PR"',
+        ]}
+        self.assertEqual(
+            csc.parse_compat_update_trailer(trailers),
+            {"css": "docs-only PR"},
+        )
+
+    def test_parses_multiple_prefixes(self) -> None:
+        trailers = {"compat-update": [
+            'skip prefix=css reason="a"',
+            'skip prefix=html reason="b"',
+        ]}
+        self.assertEqual(
+            csc.parse_compat_update_trailer(trailers),
+            {"css": "a", "html": "b"},
+        )
+
+    def test_wildcard_prefix(self) -> None:
+        trailers = {"compat-update": [
+            'skip prefix=* reason="multi-section change, no matrix entry yet"',
+        ]}
+        self.assertEqual(
+            csc.parse_compat_update_trailer(trailers),
+            {"*": "multi-section change, no matrix entry yet"},
+        )
+
+    def test_bare_skip_rejected(self) -> None:
+        trailers = {"compat-update": ["skip"]}
+        self.assertEqual(csc.parse_compat_update_trailer(trailers), {})
+
+    def test_skip_without_reason_rejected(self) -> None:
+        trailers = {"compat-update": ["skip prefix=css"]}
+        self.assertEqual(csc.parse_compat_update_trailer(trailers), {})
+
+    def test_skip_with_empty_reason_rejected(self) -> None:
+        trailers = {"compat-update": ['skip prefix=css reason=""']}
+        self.assertEqual(csc.parse_compat_update_trailer(trailers), {})
+
+
+class CompatJsonSatisfiedTests(unittest.TestCase):
+
+    def test_modified_in_diff_satisfies(self) -> None:
+        ok, _ = csc._compat_json_satisfied(
+            "css", {}, ["compat.json"], "compat.json",
+        )
+        self.assertTrue(ok)
+
+    def test_empty_section_tolerated(self) -> None:
+        ok, detail = csc._compat_json_satisfied(
+            "css", {"css": {}}, [], "compat.json",
+        )
+        self.assertTrue(ok)
+        self.assertIn("empty", detail.lower())
+
+    def test_populated_section_satisfies(self) -> None:
+        ok, _ = csc._compat_json_satisfied(
+            "css", {"css": {"color": "supported"}}, [], "compat.json",
+        )
+        self.assertTrue(ok)
+
+    def test_missing_section_fails(self) -> None:
+        ok, detail = csc._compat_json_satisfied(
+            "css", {}, [], "compat.json",
+        )
+        self.assertFalse(ok)
+        self.assertIn("css", detail)
+
+
+class ComputeFindingsTests(unittest.TestCase):
+
+    def _stub_compat_map(self) -> csc.CompatMap:
+        return csc.CompatMap(paths={
+            "core/view/js/web-compat-canvas.js": [
+                csc.Requirement(kind="compat-json", prefix="canvas2d",
+                                path=None, glob=None),
+                csc.Requirement(kind="doc", prefix=None,
+                                path="docs/reference/compat/canvas2d.md",
+                                glob=None),
+                csc.Requirement(kind="test", prefix=None, path=None,
+                                glob="test/test_canvas_widget*.cpp"),
+            ],
+        })
+
+    def test_unrelated_diff_no_findings(self) -> None:
+        findings = csc.compute_findings(
+            changed=["README.md"],
+            compat_map=self._stub_compat_map(),
+            compat_data={"canvas2d": {}},
+            bypasses={},
+        )
+        self.assertEqual(findings, [])
+
+    def test_touched_source_with_empty_section_satisfies_compat_json(self) -> None:
+        findings = csc.compute_findings(
+            changed=["core/view/js/web-compat-canvas.js"],
+            compat_map=self._stub_compat_map(),
+            compat_data={"canvas2d": {}},
+            bypasses={},
+        )
+        compat_findings = [f for f in findings
+                           if f.requirement.kind == "compat-json"]
+        self.assertEqual(len(compat_findings), 1)
+        self.assertTrue(compat_findings[0].satisfied)
+
+    def test_missing_doc_and_test_fails(self) -> None:
+        findings = csc.compute_findings(
+            changed=["core/view/js/web-compat-canvas.js"],
+            compat_map=self._stub_compat_map(),
+            compat_data={"canvas2d": {}},
+            bypasses={},
+        )
+        unsatisfied = [f for f in findings if not f.satisfied
+                       and f.bypass_reason is None]
+        kinds = {f.requirement.kind for f in unsatisfied}
+        self.assertEqual(kinds, {"doc", "test"})
+
+    def test_doc_and_test_present_satisfies(self) -> None:
+        findings = csc.compute_findings(
+            changed=[
+                "core/view/js/web-compat-canvas.js",
+                "docs/reference/compat/canvas2d.md",
+                "test/test_canvas_widget.cpp",
+            ],
+            compat_map=self._stub_compat_map(),
+            compat_data={"canvas2d": {}},
+            bypasses={},
+        )
+        self.assertTrue(all(f.satisfied for f in findings))
+
+    def test_bypass_trailer_marks_finding_bypassed(self) -> None:
+        findings = csc.compute_findings(
+            changed=["core/view/js/web-compat-canvas.js"],
+            compat_map=self._stub_compat_map(),
+            compat_data={"canvas2d": {}},
+            bypasses={"canvas2d": "test-only PR"},
+        )
+        unsatisfied_with_bypass = [
+            f for f in findings
+            if not f.satisfied and f.bypass_reason
+        ]
+        self.assertTrue(len(unsatisfied_with_bypass) >= 1)
+        for f in unsatisfied_with_bypass:
+            self.assertEqual(f.bypass_reason, "test-only PR")
+
+    def test_wildcard_bypass_covers_all_prefixes(self) -> None:
+        findings = csc.compute_findings(
+            changed=["core/view/src/widget_bridge.cpp"],
+            compat_map=csc.CompatMap(paths={
+                "core/view/src/widget_bridge.cpp": [
+                    csc.Requirement(kind="compat-json", prefix="*",
+                                    path=None, glob=None),
+                    csc.Requirement(
+                        kind="doc", prefix=None,
+                        path="docs/reference/compat/{prefix}.md",
+                        glob=None,
+                    ),
+                ],
+            }),
+            compat_data={
+                "css": {}, "html": {}, "canvas2d": {},
+            },
+            bypasses={"*": "infrastructure-only PR"},
+        )
+        # Every unsatisfied finding should be marked bypassed.
+        for f in findings:
+            if not f.satisfied:
+                self.assertEqual(f.bypass_reason, "infrastructure-only PR")
+
+    def test_doc_template_expansion_per_prefix(self) -> None:
+        compat_map = csc.CompatMap(paths={
+            "core/view/src/widget_bridge.cpp": [
+                csc.Requirement(kind="compat-json", prefix="*",
+                                path=None, glob=None),
+                csc.Requirement(
+                    kind="doc", prefix=None,
+                    path="docs/reference/compat/{prefix}.md",
+                    glob=None,
+                ),
+            ],
+        })
+        findings = csc.compute_findings(
+            changed=[
+                "core/view/src/widget_bridge.cpp",
+                "docs/reference/compat/css.md",
+            ],
+            compat_map=compat_map,
+            compat_data={"css": {}, "html": {}},
+            bypasses={},
+        )
+        # css doc must be satisfied; html doc must not be.
+        css_doc = [f for f in findings
+                   if f.requirement.kind == "doc"
+                   and f.resolved_prefix == "css"]
+        html_doc = [f for f in findings
+                    if f.requirement.kind == "doc"
+                    and f.resolved_prefix == "html"]
+        self.assertTrue(css_doc and css_doc[0].satisfied)
+        self.assertTrue(html_doc and not html_doc[0].satisfied)
+
+
+class SelfCheckTests(unittest.TestCase):
+
+    def test_unknown_prefix_flagged(self) -> None:
+        compat_map = csc.CompatMap(paths={
+            "core/view/src/x.cpp": [
+                csc.Requirement(kind="compat-json", prefix="bogus",
+                                path=None, glob=None),
+            ],
+        })
+        errors = csc.self_check(compat_map, {})
+        self.assertTrue(any("bogus" in e for e in errors), msg=errors)
+
+    def test_missing_doc_path_flagged(self) -> None:
+        compat_map = csc.CompatMap(paths={
+            "x": [csc.Requirement(kind="doc", prefix=None,
+                                  path="", glob=None)],
+        })
+        errors = csc.self_check(compat_map, {})
+        self.assertTrue(any("no path" in e for e in errors), msg=errors)
+
+    def test_missing_test_glob_flagged(self) -> None:
+        compat_map = csc.CompatMap(paths={
+            "x": [csc.Requirement(kind="test", prefix=None,
+                                  path=None, glob="")],
+        })
+        errors = csc.self_check(compat_map, {})
+        self.assertTrue(any("no glob" in e for e in errors), msg=errors)
+
+    def test_unknown_compat_json_section_flagged(self) -> None:
+        errors = csc.self_check(
+            csc.CompatMap(paths={}),
+            {"css": {}, "made-up": {}},
+        )
+        self.assertTrue(any("made-up" in e for e in errors), msg=errors)
+
+
+# ── Integration tests (real git repo) ──────────────────────────────────
+
+
+def _git(cwd: Path, *args: str) -> None:
+    env = os.environ.copy()
+    env["GIT_AUTHOR_NAME"] = env["GIT_COMMITTER_NAME"] = "Test"
+    env["GIT_AUTHOR_EMAIL"] = env["GIT_COMMITTER_EMAIL"] = "test@example.com"
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True, capture_output=True, env=env,
+    )
+
+
+def _run_script(cwd: Path, *args: str) -> tuple[int, str]:
+    result = subprocess.run(
+        ["python3", str(SCRIPT), *args],
+        cwd=cwd, capture_output=True, text=True,
+    )
+    return result.returncode, result.stdout + result.stderr
+
+
+class IntegrationFixture:
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def init(self) -> None:
+        r = self.root
+        _git(r, "init", "-q", "-b", "main")
+        _git(r, "config", "user.email", "test@example.com")
+        _git(r, "config", "user.name", "Test")
+        _git(r, "config", "commit.gpgsign", "false")
+
+        # Minimal layout the gate cares about.
+        (r / "tools" / "scripts").mkdir(parents=True)
+        (r / "core" / "view" / "src").mkdir(parents=True)
+        (r / "core" / "view" / "js").mkdir(parents=True)
+        (r / "test").mkdir()
+
+        # Stub bridge file so we can later modify it to trigger the gate.
+        (r / "core" / "view" / "src" / "widget_bridge.cpp").write_text(
+            "// stub\n"
+        )
+        (r / "core" / "view" / "js" / "web-compat-canvas.js").write_text(
+            "// stub\n"
+        )
+        (r / "core" / "view" / "js" / "web-compat-element.js").write_text(
+            "// stub\n"
+        )
+        (r / "core" / "view" / "js" / "web-compat-style-decl.js").write_text(
+            "// stub\n"
+        )
+        (r / "test" / "test_widget_bridge.cpp").write_text(
+            "int main() { return 0; }\n"
+        )
+        (r / "test" / "test_canvas_widget.cpp").write_text(
+            "int main() { return 0; }\n"
+        )
+
+        # compat_path_map.json — small but realistic.
+        (r / "tools" / "scripts" / "compat_path_map.json").write_text(
+            json.dumps({
+                "compat-schema-version": "0.1",
+                "schema_version": 1,
+                "paths": {
+                    "core/view/src/widget_bridge.cpp": [
+                        {"kind": "compat-json", "prefix": "*"},
+                        {"kind": "doc",
+                         "path": "docs/reference/compat/{prefix}.md"},
+                        {"kind": "test",
+                         "glob": "test/test_widget_bridge*.cpp"},
+                    ],
+                    "core/view/js/web-compat-canvas.js": [
+                        {"kind": "compat-json", "prefix": "canvas2d"},
+                        {"kind": "doc",
+                         "path": "docs/reference/compat/canvas2d.md"},
+                        {"kind": "test",
+                         "glob": "test/test_canvas_widget*.cpp"},
+                    ],
+                },
+            }, indent=2) + "\n"
+        )
+
+        # Stub compat.json with all known prefixes empty — the
+        # partial-blocker tolerance should cover the compat-json
+        # requirements.
+        (r / "compat.json").write_text(
+            json.dumps({
+                "compat-schema-version": "0.1",
+                "css": {}, "rn": {}, "yoga": {}, "react": {},
+                "html": {}, "canvas2d": {}, "imports": {},
+            }, indent=2) + "\n"
+        )
+
+        _git(r, "add", "-A")
+        _git(r, "commit", "-q", "-m", "initial")
+        _git(r, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+    def write(self, rel: str, content: str) -> None:
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+
+    def commit(self, message: str) -> None:
+        _git(self.root, "add", "-A")
+        _git(self.root, "commit", "-q", "-m", message)
+
+
+class IntegrationTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="pulp-compat-"))
+        self.f = IntegrationFixture(self.tmp)
+        self.f.init()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _common_args(self) -> list[str]:
+        return [
+            "--base", "origin/main",
+            "--config", str(self.tmp / "tools/scripts/compat_path_map.json"),
+            "--compat-json", str(self.tmp / "compat.json"),
+        ]
+
+    def test_no_drift_on_unrelated_diff(self) -> None:
+        self.f.write("README.md", "hello\n")
+        self.f.commit("docs: add readme")
+        code, out = _run_script(
+            self.tmp, "--mode=report", "--enforce", *self._common_args(),
+        )
+        self.assertEqual(code, 0, msg=out)
+        self.assertIn("nothing to verify", out)
+
+    def test_drift_when_canvas_touched_without_doc_or_test(self) -> None:
+        self.f.write("core/view/js/web-compat-canvas.js",
+                     "// new content\n")
+        self.f.commit("feat(view): tweak canvas shim")
+        code, out = _run_script(
+            self.tmp, "--mode=report", "--enforce", *self._common_args(),
+        )
+        self.assertEqual(code, 1, msg=out)
+        self.assertIn("canvas2d", out)
+        self.assertIn("FAILED", out)
+        # Empty compat.json section should be tolerated — the failing
+        # requirements are doc + test, NOT compat-json.
+        self.assertIn("doc", out)
+        self.assertIn("test", out)
+
+    def test_satisfied_when_doc_and_test_updated(self) -> None:
+        self.f.write("core/view/js/web-compat-canvas.js",
+                     "// new content\n")
+        self.f.write("docs/reference/compat/canvas2d.md",
+                     "# canvas2d compat\n")
+        self.f.write("test/test_canvas_widget.cpp",
+                     "int main() { return 1; }\n")
+        self.f.commit("feat(view): canvas shim + doc + test")
+        code, out = _run_script(
+            self.tmp, "--mode=report", "--enforce", *self._common_args(),
+        )
+        self.assertEqual(code, 0, msg=out)
+        self.assertIn("✓", out)
+
+    def test_bypass_trailer_passes(self) -> None:
+        self.f.write("core/view/js/web-compat-canvas.js",
+                     "// new content\n")
+        _git(self.tmp, "add", "-A")
+        _git(self.tmp, "commit", "-q", "-m",
+             'chore(view): mechanical canvas rename\n\n'
+             'Compat-Update: skip prefix=canvas2d reason="mechanical rename"')
+        code, out = _run_script(
+            self.tmp, "--mode=report", "--enforce", *self._common_args(),
+        )
+        self.assertEqual(code, 0, msg=out)
+        self.assertIn("bypassed", out)
+
+    def test_advisory_mode_does_not_block(self) -> None:
+        self.f.write("core/view/js/web-compat-canvas.js",
+                     "// new content\n")
+        self.f.commit("feat(view): canvas shim only")
+        # No --enforce, no PULP_ENFORCE_PREPUSH.
+        code, out = _run_script(
+            self.tmp, "--mode=report", *self._common_args(),
+        )
+        self.assertEqual(code, 0, msg=out)
+        self.assertIn("advisory", out)
+
+    def test_hint_mode_always_exit_zero(self) -> None:
+        self.f.write("core/view/js/web-compat-canvas.js",
+                     "// new content\n")
+        self.f.commit("feat(view): canvas shim only")
+        code, _ = _run_script(
+            self.tmp, "--mode=hint", "--enforce", *self._common_args(),
+        )
+        self.assertEqual(code, 0)
+
+    def test_empty_section_tolerance_smoke(self) -> None:
+        """Critical: an empty compat.json section must NOT false-
+        positive while #1027 is still open."""
+        # Touch widget_bridge.cpp (wildcard prefix → expands to all
+        # KNOWN_PREFIXES). The compat-json requirement should pass
+        # for every prefix because all sections are empty stubs. The
+        # only failures should be doc/test, not compat-json.
+        self.f.write("core/view/src/widget_bridge.cpp",
+                     "// new content\n")
+        self.f.commit("feat(view): bridge tweak")
+        code, out = _run_script(
+            self.tmp, "--mode=report", "--enforce", *self._common_args(),
+        )
+        # We expect drift (doc/test missing) — but the compat-json
+        # rows must each be ✓, not ✗.
+        for line in out.splitlines():
+            if "compat-json" in line:
+                self.assertIn("✓", line, msg=line)
+
+    def test_apply_mode_adds_missing_section(self) -> None:
+        # Bake the missing-canvas2d state into origin/main so the diff
+        # range we test against does NOT include the removal commit
+        # (otherwise compat.json being modified in the diff would
+        # auto-satisfy the compat-json requirement and there'd be
+        # nothing for apply to fix).
+        compat_path = self.tmp / "compat.json"
+        data = json.loads(compat_path.read_text())
+        del data["canvas2d"]
+        compat_path.write_text(json.dumps(data, indent=2) + "\n")
+        self.f.commit("chore: remove canvas2d section")
+        _git(self.tmp, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+        # Now touch the shim → compat-json requirement is unsatisfied.
+        self.f.write("core/view/js/web-compat-canvas.js",
+                     "// new content\n")
+        self.f.commit("feat(view): canvas shim")
+        code, out = _run_script(
+            self.tmp, "--mode=apply", *self._common_args(),
+        )
+        # apply mode should have re-added the section.
+        new_data = json.loads(compat_path.read_text())
+        self.assertIn("canvas2d", new_data, msg=out)
+        self.assertEqual(new_data["canvas2d"], {})
+        self.assertIn("added stub sections", out)
+
+    def test_self_check_unknown_prefix_in_map(self) -> None:
+        # Inject a bad entry into the path map.
+        cfg = self.tmp / "tools/scripts/compat_path_map.json"
+        data = json.loads(cfg.read_text())
+        data["paths"]["core/view/src/bogus.cpp"] = [
+            {"kind": "compat-json", "prefix": "not-real"},
+        ]
+        cfg.write_text(json.dumps(data, indent=2) + "\n")
+        self.f.commit("chore: add bogus map entry")
+        code, out = _run_script(
+            self.tmp, "--mode=report", "--enforce", *self._common_args(),
+        )
+        self.assertEqual(code, 1, msg=out)
+        self.assertIn("not-real", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Extend the three-layer enforcement pattern (skill-sync, version-bump)
to a new domain: compat-matrix sync. When a PR's diff touches a path
mapped to a compat section, the matching artifacts (compat.json prefix
entry, doc page, test glob) must be updated in the same diff — or the
PR must carry a 'Compat-Update: skip prefix=<name> reason="..."'
trailer.

Ships:

- tools/scripts/compat_sync_check.py — the gate (modes: hint/report/apply,
  --enforce + PULP_ENFORCE_PREPUSH=1 semantics, tip-or-range trailer
  detection, glob-to-regex matcher mirrored from skill_sync_check.py).
- tools/scripts/compat_path_map.json — the source-path → required-
  artifacts map (widget_bridge wildcard + canvas2d/html/css concrete
  prefixes initially).
- compat.json — minimal stub at repo root (#1027 will populate).
- tools/scripts/test_compat_sync_check.py — 30 tests (unit + integration).
- hooks/scripts/cli-plugin-sync.sh — Layer 1 hint mode.
- .githooks/pre-push — Layer 2 report mode (advisory by default).
- .github/workflows/version-skill-check.yml — Layer 3 enforce mode.
- docs/guides/compat-sync.md + versioning.md cross-link — design doc.
- .agents/skills/ci/SKILL.md — gotchas + gate listing updated.

Empty compat.json sections are tolerated as 'no requirement yet' so
this infrastructure can land before #1027's populated matrix data.
The moment #1027 ships, enforcement on populated sections goes live
without further integration.

Refs: #1029, #1027