### PR TITLE
fix(view): bubble click up to ancestor on_click handler (#1067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v0680"></a>
+## [0.68.0] - 2026-04-30
+
+- fix(view): bubble click up to ancestor on_click handler (pulp #1067) — the actual close on the React onClick chain. #1006/#1008's auto-wire put the handler on the right widget; this fix bubbles the click target up the parent chain so clicks on a Label child of a `<button>` find the parent's handler. Resolves the post-v0.66.0 symptom where clicks survived but never fired the React handler.
+
 <a id="v0670"></a>
 ## [0.67.0] - 2026-04-30
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.67.0
+    VERSION 0.68.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -462,8 +462,30 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                 auto pt = [self localPoint:event];
                 auto local = toLocal(pt, _dragTarget, self.rootView);
                 auto released_target = self.rootView ? self.rootView->hit_test(pt) : nullptr;
-                auto click_handler = _dragTarget->on_click;
+                // pulp #1067 — DOM-style click bubbling. `hit_test` returns
+                // the deepest hit-testable view under the cursor, but the
+                // `onClick` handler (registered via `registerClick(id)`) may
+                // live on an ancestor. The classic reproducer: @pulp/react
+                // turns `<button onClick=...>Clear</button>` into a
+                // `<View onClick=...>` parent with a `<Label>Clear</Label>`
+                // child (Spectr's dom-adapter wraps string children in
+                // synthetic Labels). Clicking the visible "Clear" text
+                // hits the Label, which has no `on_click`, so #1006/#1008's
+                // capture-by-_dragTarget path silently dropped the click.
+                // Walk up the parent chain to find the nearest ancestor
+                // (including `_dragTarget` itself) with a registered
+                // handler — mirrors the browser behaviour @pulp/react users
+                // expect.
+                pulp::view::View* click_target = _dragTarget;
+                while (click_target && !click_target->on_click) {
+                    click_target = click_target->parent();
+                }
+                auto click_handler = click_target ? click_target->on_click : std::function<void()>{};
                 auto global_click = self.rootView ? self.rootView->on_global_click : std::function<void(const std::string&, uint16_t)>{};
+                // global_click reports the immediate hit (matches existing
+                // inspect-click behaviour: Cmd-click on a text label tells
+                // the inspector exactly which view was hit, not the
+                // bubbled-to ancestor).
                 auto clicked_id = _dragTarget->id();
                 auto modifiers = modifiersFromNSFlags(event.modifierFlags);
                 _dragTarget->on_mouse_up(local);

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -199,7 +199,16 @@ void View::simulate_click(Point root_pos) {
 
     target->on_mouse_down(local);
     target->on_mouse_up(local);
-    if (target->on_click) target->on_click();
+    // pulp #1067 — DOM-style click bubbling. `hit_test` returns the deepest
+    // hit-testable view, which for `<button onClick=...>Label</button>` is
+    // the inner Label child. Walk up the parent chain to find the nearest
+    // ancestor with a registered handler. Mirrors the same bubble pass the
+    // mac mouseUp path performs (see core/view/platform/mac/window_host_mac.mm).
+    View* click_target = target;
+    while (click_target && !click_target->on_click) {
+        click_target = click_target->parent();
+    }
+    if (click_target && click_target->on_click) click_target->on_click();
 }
 
 void View::simulate_drag(Point start, Point end, int steps) {

--- a/test/test_view_host_bridge_mac.mm
+++ b/test/test_view_host_bridge_mac.mm
@@ -265,4 +265,123 @@ TEST_CASE("PulpView NSEvent click dispatches JS on(id,'click') subscriber",
     }
 }
 
+// pulp #1067 — #1006/#1008 wired `on(id, 'click', fn)` to the native
+// `View::on_click`, but the click still doesn't fire when the visible
+// hit target is a child of the registered widget. The classic shape:
+// `<button onClick=...>Clear</button>` lowers (via Spectr's dom-adapter
+// + @pulp/react host config) into a `<View onClick=...>` with a child
+// `<Label>Clear</Label>`. `hit_test` walks topmost-child-first and
+// returns the Label (the visible text covers the parent's bounds), but
+// `on_click` is registered on the parent View. Pre-#1067 the mac
+// mouseUp path captured `_dragTarget = label`, found `on_click ==
+// nullptr`, and silently dropped the click. Fix: walk up the parent
+// chain to find the nearest ancestor with a registered handler — DOM
+// click bubbling.
+TEST_CASE("PulpView NSEvent click bubbles up to ancestor on_click handler",
+          "[view][hosts][bridge][issue-1067]") {
+    @autoreleasepool {
+        [NSApplication sharedApplication];
+
+        View root;
+        WindowOptions opts;
+        opts.title = "PulpView issue-1067";
+        opts.width = 200.0f;
+        opts.height = 100.0f;
+        opts.resizable = false;
+        opts.use_gpu = false;
+
+        auto host = WindowHost::create(root, opts);
+        REQUIRE(host != nullptr);
+        root.set_bounds({0, 0, 200, 100});
+
+        pulp::state::StateStore store;
+        pulp::view::ScriptEngine engine;
+        pulp::view::WidgetBridge bridge(engine, root, store);
+
+        // Mirrors what @pulp/react + Spectr's dom-adapter emit for
+        // `<button onClick={fn}>Clear</button>`:
+        //   * a Panel (Button) with the click handler attached
+        //   * a Label child whose bounds cover the visible button area
+        // Pin the parent's bounds so hit_test lands on the Label child
+        // deterministically without depending on a paint pass.
+        bridge.load_script(R"(
+            var clicks = 0;
+            createPanel('btn', '');
+            setFlex('btn', 'width', 200);
+            setFlex('btn', 'height', 100);
+            createLabel('btn_l', 'Clear', 'btn');
+            setFlex('btn_l', 'width', 200);
+            setFlex('btn_l', 'height', 100);
+            on('btn', 'click', function() { clicks += 1; });
+        )");
+
+        auto* button = bridge.widget("btn");
+        auto* label  = bridge.widget("btn_l");
+        REQUIRE(button != nullptr);
+        REQUIRE(label  != nullptr);
+        REQUIRE(label->parent() == button);
+        // The handler is on the parent button.
+        REQUIRE(static_cast<bool>(button->on_click));
+        // The label has no handler of its own — that's the point.
+        REQUIRE_FALSE(static_cast<bool>(label->on_click));
+
+        host->show();
+        auto* nswindow = (__bridge NSWindow*)host->native_window_handle();
+        REQUIRE(nswindow != nil);
+        auto* contentView = nswindow.contentView;
+        REQUIRE(contentView != nil);
+
+        for (int i = 0; i < 20; ++i) {
+            [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.005]];
+        }
+
+        // Sanity: hit_test must find the Label child, not the Button
+        // parent (otherwise the test wouldn't be exercising the bubble
+        // path — it would be the trivial #1006 case).
+        {
+            auto* target = root.hit_test({40.0f, 50.0f});
+            REQUIRE(target == label);
+        }
+
+        const NSPoint local = NSMakePoint(40.0, 50.0);
+        const NSPoint window_pt = [contentView convertPoint:local toView:nil];
+
+        NSEvent* down = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                                           location:window_pt
+                                      modifierFlags:0
+                                          timestamp:0
+                                       windowNumber:nswindow.windowNumber
+                                            context:nil
+                                        eventNumber:0
+                                         clickCount:1
+                                           pressure:1.0];
+        NSEvent* up = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp
+                                         location:window_pt
+                                    modifierFlags:0
+                                        timestamp:0
+                                     windowNumber:nswindow.windowNumber
+                                          context:nil
+                                      eventNumber:0
+                                       clickCount:1
+                                         pressure:0.0];
+
+        [contentView mouseDown:down];
+        [contentView mouseUp:up];
+
+        // mouseUp queues the click handler via dispatch_async on the
+        // main queue; drain the run loop until it fires (or we hit a
+        // generous timeout, in which case the bubble path is broken).
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+        int clicks = 0;
+        while (clicks == 0 && std::chrono::steady_clock::now() < deadline) {
+            [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+            clicks = engine.evaluate("clicks").getWithDefault<int>(0);
+        }
+
+        REQUIRE(clicks == 1);
+
+        host->hide();
+    }
+}
+
 #endif


### PR DESCRIPTION
#1006/#1008 wired `on(id, 'click', fn)` from @pulp/react's prop-applier
to the native `View::on_click`, but in v0.66.0 React `onClick` handlers
still didn't fire. Diagnosis: `<button onClick=...>Clear</button>`
lowers (via @pulp/react's host-config + Spectr's dom-adapter) into a
parent View carrying the handler with a `<Label>Clear</Label>` child
covering the visible text. `hit_test` walks topmost-child-first and
returns the Label, which has no `on_click`, so the post-#992 mac
mouseUp path captured `_dragTarget = label`, found `on_click ==
nullptr`, and silently dropped the click — exactly the symptom users
reported on the Spectr "CLEAR" button.

Walk up `_dragTarget`'s parent chain in mouseUp (and `simulate_click`)
to find the nearest ancestor with a registered handler, mirroring DOM
click bubbling. global_click still reports the immediate hit (preserves
inspect-click semantics).

The existing #1006 test passed because it used `createCol('clear', '')`
with no children, sidestepping the hit_test child-first path. The new
#1067 test reproduces the real shape: Panel parent + Label child, click
lands on Label, asserts the parent handler fires.