### PR TITLE
test(runtime): cover base64 decode edge paths

### DIFF
--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -193,14 +193,40 @@ TEST_CASE("base64 decode invalid", "[runtime][base64]") {
 TEST_CASE("base64 decode rejects malformed padding", "[runtime][base64][issue-641]") {
     REQUIRE_FALSE(base64_decode("A").has_value());
     REQUIRE_FALSE(base64_decode("YQ=").has_value());
+    REQUIRE_FALSE(base64_decode("Y=Q=").has_value());
     REQUIRE_FALSE(base64_decode("YQ==Z").has_value());
     REQUIRE_FALSE(base64_decode("YQ===").has_value());
+    REQUIRE_FALSE(base64_decode("====").has_value());
 }
 
 TEST_CASE("base64 decode permits whitespace around terminal padding", "[runtime][base64][issue-641]") {
     auto decoded = base64_decode(" YQ = = \n");
     REQUIRE(decoded.has_value());
     REQUIRE(std::string(decoded->begin(), decoded->end()) == "a");
+}
+
+TEST_CASE("base64 decode handles whitespace and unpadded tail groups", "[runtime][base64][issue-641]") {
+    auto empty = base64_decode(" \n\r\t");
+    REQUIRE(empty.has_value());
+    REQUIRE(empty->empty());
+
+    auto one_byte = base64_decode("YQ");
+    REQUIRE(one_byte.has_value());
+    REQUIRE(std::string(one_byte->begin(), one_byte->end()) == "a");
+
+    auto two_bytes = base64_decode("YWI");
+    REQUIRE(two_bytes.has_value());
+    REQUIRE(std::string(two_bytes->begin(), two_bytes->end()) == "ab");
+
+    auto with_whitespace = base64_decode(" SGV sbG8=\n");
+    REQUIRE(with_whitespace.has_value());
+    REQUIRE(std::string(with_whitespace->begin(), with_whitespace->end()) == "Hello");
+}
+
+TEST_CASE("base64 decode rejects non-ascii bytes", "[runtime][base64][issue-641]") {
+    std::string encoded = "YQ";
+    encoded.push_back(static_cast<char>(0x80));
+    REQUIRE_FALSE(base64_decode(encoded).has_value());
 }
 
 TEST_CASE("base64 binary round-trip", "[runtime][base64]") {


### PR DESCRIPTION
## Summary
- cover base64 decoder malformed padding cases that previously exited through untested guards
- cover whitespace-only input, unpadded 2/3-character tails, embedded whitespace, and non-ASCII rejection

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_HIGHWAY=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/highway-src -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/mbedtls-src -DFETCHCONTENT_SOURCE_DIR_THREEJS=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/threejs-src
- cmake --build build --target pulp-test-runtime-utils -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-runtime-utils "*[runtime][base64]*"
- ctest --test-dir build -R "base64|runtime-utils" --output-on-failure
- git diff --check origin/main..HEAD && git diff --check
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report

Refs #641