### PR TITLE
test(render): cover render loop edge paths

### DIFF
--- a/core/render/src/render_loop.cpp
+++ b/core/render/src/render_loop.cpp
@@ -3,10 +3,11 @@
 
 #include <pulp/render/render_loop.hpp>
 #include <pulp/runtime/log.hpp>
+#include "render_loop_state.hpp"
 #include <thread>
 #include <chrono>
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(PULP_RENDER_LOOP_FORCE_TIMER)
 #include <TargetConditionals.h>
 #if TARGET_OS_OSX
 #include <CoreVideo/CVDisplayLink.h>
@@ -18,16 +19,17 @@ namespace pulp::render {
 
 // ── macOS: CVDisplayLink ────────────────────────────────────────────────
 
-#if defined(__APPLE__) && TARGET_OS_OSX
+#if defined(__APPLE__) && !defined(PULP_RENDER_LOOP_FORCE_TIMER) && TARGET_OS_OSX
 
 class MacRenderLoop : public RenderLoop {
 public:
     ~MacRenderLoop() override { stop(); }
 
     void start(FrameCallback on_frame) override {
+        if (!state_.start()) {
+            return;
+        }
         callback_ = std::move(on_frame);
-        running_ = true;
-        needs_frame_ = true;
 
         CVDisplayLinkCreateWithActiveCGDisplays(&display_link_);
         CVDisplayLinkSetOutputCallback(display_link_, &display_link_callback, this);
@@ -35,7 +37,7 @@ public:
     }
 
     void stop() override {
-        running_ = false;
+        state_.stop();
         if (display_link_) {
             CVDisplayLinkStop(display_link_);
             CVDisplayLinkRelease(display_link_);
@@ -44,23 +46,22 @@ public:
     }
 
     void request_frame() override {
-        needs_frame_.store(true, std::memory_order_relaxed);
+        state_.request_frame();
     }
 
-    bool is_running() const override { return running_.load(); }
+    bool is_running() const override { return state_.is_running(); }
 
 private:
     CVDisplayLinkRef display_link_ = nullptr;
     FrameCallback callback_;
-    std::atomic<bool> running_{false};
-    std::atomic<bool> needs_frame_{false};
+    RenderLoopState state_;
 
     static CVReturn display_link_callback(CVDisplayLinkRef, const CVTimeStamp*,
         const CVTimeStamp*, CVOptionFlags, CVOptionFlags*, void* ctx) {
         auto* self = static_cast<MacRenderLoop*>(ctx);
-        if (self->needs_frame_.exchange(false, std::memory_order_relaxed)) {
+        if (self->state_.consume_frame_request()) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                if (self->running_.load() && self->callback_) {
+                if (self->state_.is_running() && self->callback_) {
                     self->callback_();
                 }
             });
@@ -78,16 +79,17 @@ public:
     ~TimerRenderLoop() override { stop(); }
 
     void start(FrameCallback on_frame) override {
+        if (!state_.start()) {
+            return;
+        }
         callback_ = std::move(on_frame);
-        running_ = true;
-        needs_frame_ = true;
 
         thread_ = std::thread([this]() {
             using namespace std::chrono;
             auto frame_interval = microseconds(16667); // ~60Hz
-            while (running_.load()) {
+            while (state_.is_running()) {
                 auto start = steady_clock::now();
-                if (needs_frame_.exchange(false, std::memory_order_relaxed)) {
+                if (state_.consume_frame_request() && state_.is_running()) {
                     if (callback_) callback_();
                 }
                 auto elapsed = steady_clock::now() - start;
@@ -100,28 +102,27 @@ public:
     }
 
     void stop() override {
-        running_ = false;
+        state_.stop();
         if (thread_.joinable()) thread_.join();
     }
 
     void request_frame() override {
-        needs_frame_.store(true, std::memory_order_relaxed);
+        state_.request_frame();
     }
 
-    bool is_running() const override { return running_.load(); }
+    bool is_running() const override { return state_.is_running(); }
 
 private:
     std::thread thread_;
     FrameCallback callback_;
-    std::atomic<bool> running_{false};
-    std::atomic<bool> needs_frame_{false};
+    RenderLoopState state_;
 };
 
 // ── Factory ─────────────────────────────────────────────────────────────
 
 std::unique_ptr<RenderLoop> RenderLoop::create(void* native_handle) {
     (void)native_handle;
-#if defined(__APPLE__) && TARGET_OS_OSX
+#if defined(__APPLE__) && !defined(PULP_RENDER_LOOP_FORCE_TIMER) && TARGET_OS_OSX
     return std::make_unique<MacRenderLoop>();
 #else
     return std::make_unique<TimerRenderLoop>();

--- a/core/render/src/render_loop_state.hpp
+++ b/core/render/src/render_loop_state.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <atomic>
+
+namespace pulp::render {
+
+class RenderLoopState {
+public:
+    bool start() {
+        const bool was_running = running_.exchange(true, std::memory_order_acq_rel);
+        needs_frame_.store(true, std::memory_order_release);
+        return !was_running;
+    }
+
+    bool stop() {
+        const bool was_running = running_.exchange(false, std::memory_order_acq_rel);
+        needs_frame_.store(false, std::memory_order_release);
+        return was_running;
+    }
+
+    void request_frame() {
+        if (is_running()) {
+            needs_frame_.store(true, std::memory_order_release);
+        }
+    }
+
+    bool consume_frame_request() {
+        return is_running() && needs_frame_.exchange(false, std::memory_order_acq_rel);
+    }
+
+    bool is_running() const {
+        return running_.load(std::memory_order_acquire);
+    }
+
+private:
+    std::atomic<bool> running_{false};
+    std::atomic<bool> needs_frame_{false};
+};
+
+} // namespace pulp::render

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1351,7 +1351,9 @@ target_include_directories(pulp-test-render-loop PRIVATE
 target_link_libraries(pulp-test-render-loop PRIVATE
     pulp::runtime
     Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-render-loop)
+catch_discover_tests(pulp-test-render-loop
+    PROPERTIES
+        LABELS coverage)
 
 # GPU-stack tests — pulp::render only exists when PULP_ENABLE_GPU=ON.
 # The sanitizer matrix builds with GPU off; without the guard configure

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1318,8 +1318,8 @@ add_executable(pulp-test-view test_view.cpp)
 target_link_libraries(pulp-test-view PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-view)
 
-# DirtyTracker, GpuGraphRenderer, and DrawBatcher are header-only helpers; keep
-# their pure tests available in GPU-off sanitizer and local coverage builds.
+# DirtyTracker, GpuGraphRenderer, DrawBatcher, and RenderLoop timer-state tests
+# are pure helpers; keep them available in GPU-off sanitizer and coverage builds.
 add_executable(pulp-test-dirty-tracker test_dirty_tracker.cpp)
 target_include_directories(pulp-test-dirty-tracker PRIVATE
     ${CMAKE_SOURCE_DIR}/core/render/include)
@@ -1339,6 +1339,19 @@ target_link_libraries(pulp-test-draw-batcher PRIVATE
     pulp::canvas
     Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-draw-batcher)
+
+add_executable(pulp-test-render-loop
+    test_render_loop.cpp
+    ${CMAKE_SOURCE_DIR}/core/render/src/render_loop.cpp)
+target_compile_definitions(pulp-test-render-loop PRIVATE
+    PULP_RENDER_LOOP_FORCE_TIMER=1)
+target_include_directories(pulp-test-render-loop PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include
+    ${CMAKE_SOURCE_DIR}/core/render/src)
+target_link_libraries(pulp-test-render-loop PRIVATE
+    pulp::runtime
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-render-loop)
 
 # GPU-stack tests — pulp::render only exists when PULP_ENABLE_GPU=ON.
 # The sanitizer matrix builds with GPU off; without the guard configure

--- a/test/test_render_loop.cpp
+++ b/test/test_render_loop.cpp
@@ -1,0 +1,156 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/render/render_loop.hpp>
+
+#include "render_loop_state.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace pulp::render;
+
+namespace {
+
+bool wait_for_count(std::atomic<int>& count, int target) {
+    for (int i = 0; i < 200; ++i) {
+        if (count.load(std::memory_order_relaxed) >= target) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return count.load(std::memory_order_relaxed) >= target;
+}
+
+} // namespace
+
+TEST_CASE("RenderLoopState starts stopped and schedules the first frame",
+          "[render][loop][issue-646]") {
+    RenderLoopState state;
+
+    REQUIRE_FALSE(state.is_running());
+    REQUIRE_FALSE(state.consume_frame_request());
+
+    REQUIRE(state.start());
+    REQUIRE(state.is_running());
+    REQUIRE(state.consume_frame_request());
+    REQUIRE_FALSE(state.consume_frame_request());
+}
+
+TEST_CASE("RenderLoopState coalesces repeated frame requests",
+          "[render][loop][issue-646]") {
+    RenderLoopState state;
+    REQUIRE(state.start());
+    REQUIRE(state.consume_frame_request());
+
+    state.request_frame();
+    state.request_frame();
+
+    REQUIRE(state.consume_frame_request());
+    REQUIRE_FALSE(state.consume_frame_request());
+}
+
+TEST_CASE("RenderLoopState ignores requests while stopped",
+          "[render][loop][issue-646]") {
+    RenderLoopState state;
+
+    state.request_frame();
+    REQUIRE_FALSE(state.consume_frame_request());
+
+    REQUIRE(state.start());
+    REQUIRE(state.consume_frame_request());
+    REQUIRE(state.stop());
+
+    state.request_frame();
+    REQUIRE_FALSE(state.consume_frame_request());
+}
+
+TEST_CASE("RenderLoopState stop clears pending work and is idempotent",
+          "[render][loop][issue-646]") {
+    RenderLoopState state;
+    REQUIRE(state.start());
+
+    state.request_frame();
+    REQUIRE(state.stop());
+    REQUIRE_FALSE(state.is_running());
+    REQUIRE_FALSE(state.consume_frame_request());
+
+    REQUIRE_FALSE(state.stop());
+    REQUIRE_FALSE(state.is_running());
+}
+
+TEST_CASE("RenderLoopState repeated start only requests another frame",
+          "[render][loop][issue-646]") {
+    RenderLoopState state;
+    REQUIRE(state.start());
+    REQUIRE(state.consume_frame_request());
+
+    REQUIRE_FALSE(state.start());
+    REQUIRE(state.is_running());
+    REQUIRE(state.consume_frame_request());
+}
+
+TEST_CASE("RenderLoop timer backend tolerates stop before start",
+          "[render][loop][issue-646]") {
+    auto loop = RenderLoop::create();
+    REQUIRE(loop != nullptr);
+    REQUIRE_FALSE(loop->is_running());
+
+    loop->stop();
+    REQUIRE_FALSE(loop->is_running());
+}
+
+TEST_CASE("RenderLoop timer backend handles an empty callback",
+          "[render][loop][issue-646]") {
+    auto loop = RenderLoop::create();
+    REQUIRE(loop != nullptr);
+
+    loop->start(FrameCallback{});
+    REQUIRE(loop->is_running());
+    loop->request_frame();
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    loop->stop();
+
+    REQUIRE_FALSE(loop->is_running());
+}
+
+TEST_CASE("RenderLoop timer backend repeated start keeps the active callback",
+          "[render][loop][issue-646]") {
+    auto loop = RenderLoop::create();
+    REQUIRE(loop != nullptr);
+
+    std::atomic<int> first{0};
+    std::atomic<int> second{0};
+
+    loop->start([&]() { first.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(wait_for_count(first, 1));
+
+    loop->start([&]() { second.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(loop->is_running());
+    REQUIRE(wait_for_count(first, 2));
+
+    loop->stop();
+
+    REQUIRE_FALSE(loop->is_running());
+    REQUIRE(second.load(std::memory_order_relaxed) == 0);
+}
+
+TEST_CASE("RenderLoop timer backend can restart with a new callback",
+          "[render][loop][issue-646]") {
+    auto loop = RenderLoop::create();
+    REQUIRE(loop != nullptr);
+
+    std::atomic<int> first{0};
+    std::atomic<int> second{0};
+
+    loop->start([&]() { first.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(wait_for_count(first, 1));
+    loop->stop();
+
+    loop->start([&]() { second.fetch_add(1, std::memory_order_relaxed); });
+    REQUIRE(wait_for_count(second, 1));
+    loop->stop();
+
+    REQUIRE(first.load(std::memory_order_relaxed) == 1);
+    REQUIRE(second.load(std::memory_order_relaxed) == 1);
+}


### PR DESCRIPTION
Summary
- Added an internal RenderLoopState helper so render-loop running/pending-frame transitions are deterministic and repeat start requests are idempotent.
- Added a GPU-free pulp-test-render-loop target that compiles render_loop.cpp with the timer backend forced on every host.
- Covered start/stop/request coalescing, stopped requests, stop-before-start, empty callbacks, repeated start, and restart with a new callback.

Validation
- cmake -S . -B build-render-loop-coverage -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar
- cmake --build build-render-loop-coverage --target pulp-test-render-loop -j 8
- ./build-render-loop-coverage/test/pulp-test-render-loop "[render][loop]" (43 assertions in 9 test cases)
- ctest --test-dir build-render-loop-coverage -R "RenderLoop" --output-on-failure (9/9 passed)
- git diff --check origin/main..HEAD
- git diff --check
- PULP_ENFORCE_PREPUSH=1 python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report
- python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report
- source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh"; pulp_cli_version_check; shipyard pr --skip-target mac --skip-target ubuntu --skip-target windows (opened PR #1082, then exited with expected no-target filtering)

Refs #646
Refs #641