### PR TITLE
fix(audio): guard load measurer invalid timing inputs

### DIFF
--- a/core/audio/include/pulp/audio/load_measurer.hpp
+++ b/core/audio/include/pulp/audio/load_measurer.hpp
@@ -5,6 +5,9 @@
 
 #include <chrono>
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
 
 namespace pulp::audio {
 
@@ -28,8 +31,22 @@ public:
     /// @param sample_rate Current sample rate in Hz.
     void begin(int num_frames, float sample_rate) {
         start_time_ = clock::now();
-        available_ns_ = static_cast<int64_t>(
-            static_cast<double>(num_frames) / static_cast<double>(sample_rate) * 1e9);
+
+        if (num_frames <= 0 || !(sample_rate > 0.0f)) {
+            available_ns_ = 0;
+            return;
+        }
+
+        const double available_ns =
+            static_cast<double>(num_frames) / static_cast<double>(sample_rate) * 1e9;
+
+        if (!std::isfinite(available_ns) || available_ns <= 0.0 ||
+            available_ns > static_cast<double>(std::numeric_limits<int64_t>::max())) {
+            available_ns_ = 0;
+            return;
+        }
+
+        available_ns_ = static_cast<int64_t>(available_ns);
     }
 
     /// Call at the end of the audio callback.
@@ -58,6 +75,8 @@ public:
     void reset() {
         load_ = 0.0f;
         peak_load_ = 0.0f;
+        available_ns_ = 0;
+        start_time_ = {};
     }
 
     /// Set smoothing factor (0 = no smoothing, 1 = no averaging).

--- a/test/test_load_measurer.cpp
+++ b/test/test_load_measurer.cpp
@@ -178,7 +178,6 @@ TEST_CASE("AudioProcessLoadMeasurer ignores invalid begin timing inputs", "[audi
         {512, -44100.0f},
         {512, std::numeric_limits<float>::quiet_NaN()},
         {512, std::numeric_limits<float>::infinity()},
-        {std::numeric_limits<int>::max(), std::numeric_limits<float>::min()},
     };
 
     for (const auto& input : inputs) {
@@ -191,7 +190,31 @@ TEST_CASE("AudioProcessLoadMeasurer ignores invalid begin timing inputs", "[audi
     }
 }
 
-TEST_CASE("AudioProcessLoadMeasurer reset clears pending timing state", "[audio][load][issue-641]") {
+TEST_CASE("AudioProcessLoadMeasurer rejects overflow-sized available time", "[audio][load][issue-640]") {
+    AudioProcessLoadMeasurer m;
+    m.set_smoothing(1.0f);
+
+    m.begin(std::numeric_limits<int>::max(), std::numeric_limits<float>::min());
+    m.end();
+
+    REQUIRE_THAT(m.load(), WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(m.peak_load(), WithinAbs(0.0f, 0.001f));
+}
+
+TEST_CASE("AudioProcessLoadMeasurer accepts valid available time", "[audio][load][issue-640]") {
+    AudioProcessLoadMeasurer m;
+    m.set_smoothing(1.0f);
+
+    m.begin(480, 48000.0f);
+    busy_wait_for(std::chrono::microseconds(1200));
+    m.end();
+
+    REQUIRE(m.load() > 0.0f);
+    REQUIRE(std::isfinite(m.load()));
+    REQUIRE_THAT(m.peak_load(), WithinAbs(m.load(), 0.001f));
+}
+
+TEST_CASE("AudioProcessLoadMeasurer reset clears pending timing state", "[audio][load][issue-640]") {
     AudioProcessLoadMeasurer m;
     m.set_smoothing(1.0f);
 

--- a/test/test_load_measurer.cpp
+++ b/test/test_load_measurer.cpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <chrono>
 #include <cmath>
+#include <limits>
 
 using namespace pulp::audio;
 using Catch::Matchers::WithinAbs;
@@ -115,4 +116,91 @@ TEST_CASE("AudioProcessLoadMeasurer clamps smoothing and ignores zero available 
     auto raw_load = measure_load(m, std::chrono::microseconds(1200));
     REQUIRE(raw_load > 0.0f);
     REQUIRE_THAT(m.peak_load(), WithinAbs(raw_load, 0.001f));
+}
+
+TEST_CASE("AudioProcessLoadMeasurer zero smoothing still tracks peak",
+          "[audio][load][issue-640]") {
+    AudioProcessLoadMeasurer m;
+    m.set_smoothing(0.0f);
+
+    m.begin(512, 44100.0f);
+    busy_wait_for(std::chrono::microseconds(1200));
+    m.end();
+
+    REQUIRE_THAT(m.load(), WithinAbs(0.0f, 0.001f));
+    REQUIRE(m.peak_load() > 0.0f);
+}
+
+TEST_CASE("AudioProcessLoadMeasurer reset keeps smoothing configuration",
+          "[audio][load][issue-640]") {
+    AudioProcessLoadMeasurer m;
+    m.set_smoothing(0.0f);
+
+    m.reset();
+    m.begin(512, 44100.0f);
+    busy_wait_for(std::chrono::microseconds(1200));
+    m.end();
+
+    REQUIRE_THAT(m.load(), WithinAbs(0.0f, 0.001f));
+    REQUIRE(m.peak_load() > 0.0f);
+}
+
+TEST_CASE("AudioProcessLoadMeasurer invalid timing leaves prior load unchanged",
+          "[audio][load][issue-640]") {
+    AudioProcessLoadMeasurer m;
+    m.set_smoothing(1.0f);
+
+    const float previous = measure_load(m, std::chrono::microseconds(1200));
+    REQUIRE(previous > 0.0f);
+    const float previous_peak = m.peak_load();
+
+    m.begin(512, 0.0f);
+    busy_wait_for(std::chrono::microseconds(1200));
+    m.end();
+
+    REQUIRE_THAT(m.load(), WithinAbs(previous, 0.001f));
+    REQUIRE_THAT(m.peak_load(), WithinAbs(previous_peak, 0.001f));
+}
+
+TEST_CASE("AudioProcessLoadMeasurer ignores invalid begin timing inputs", "[audio][load][issue-640]") {
+    AudioProcessLoadMeasurer m;
+    m.set_smoothing(1.0f);
+
+    struct InvalidTimingInput {
+        int num_frames;
+        float sample_rate;
+    };
+
+    const InvalidTimingInput inputs[] = {
+        {0, 44100.0f},
+        {-128, 44100.0f},
+        {512, 0.0f},
+        {512, -44100.0f},
+        {512, std::numeric_limits<float>::quiet_NaN()},
+        {512, std::numeric_limits<float>::infinity()},
+        {std::numeric_limits<int>::max(), std::numeric_limits<float>::min()},
+    };
+
+    for (const auto& input : inputs) {
+        INFO("num_frames=" << input.num_frames << " sample_rate=" << input.sample_rate);
+        m.begin(input.num_frames, input.sample_rate);
+        m.end();
+
+        REQUIRE_THAT(m.load(), WithinAbs(0.0f, 0.001f));
+        REQUIRE_THAT(m.peak_load(), WithinAbs(0.0f, 0.001f));
+    }
+}
+
+TEST_CASE("AudioProcessLoadMeasurer reset clears pending timing state", "[audio][load][issue-641]") {
+    AudioProcessLoadMeasurer m;
+    m.set_smoothing(1.0f);
+
+    m.begin(512, 44100.0f);
+    busy_wait_for(std::chrono::microseconds(1200));
+
+    m.reset();
+    m.end();
+
+    REQUIRE_THAT(m.load(), WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(m.peak_load(), WithinAbs(0.0f, 0.001f));
 }


### PR DESCRIPTION
## Summary
- Guard `AudioProcessLoadMeasurer::begin()` against zero, negative, non-finite, and out-of-range timing inputs before converting to nanoseconds.
- Clear pending timing state in `reset()` so a stray `end()` cannot repopulate load or peak after reset.
- Add focused `[audio][load]` coverage for invalid begin inputs, reset/pending-end semantics, zero smoothing peak tracking, reset preserving smoothing, and invalid timing preserving prior load.

## Validation
- `cmake --build build --target pulp-test-load-measurer -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-load-measurer "[audio][load]"` — 43 assertions, 11 test cases passed
- `ctest --test-dir build -R "LoadMeasurer|load-measurer|load_measurer|AudioProcessLoadMeasurer" --output-on-failure` — 11/11 passed
- `git diff --check`
- `python3 tools/scripts/skill_sync_check.py --mode=report`
- `python3 tools/scripts/version_bump_check.py --mode=report --require-bump-for-fix-feat --pr-title "fix(audio): guard load measurer invalid timing inputs"`
- `shipyard pr --skip-target mac --skip-target ubuntu --skip-target windows` — existing PR path reached expected no-local-targets exit after preflight; refreshed branch was pushed and Namespace was dispatched

Namespace: https://github.com/danielraffel/pulp/actions/runs/25170103165

Refs #640
Refs #493
Refs #641