### PR TITLE
test(audio): cover hotplug callback edges

### DIFF
--- a/core/audio/include/pulp/audio/device.hpp
+++ b/core/audio/include/pulp/audio/device.hpp
@@ -5,7 +5,9 @@
 #include <vector>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <cstdint>
+#include <utility>
 
 namespace pulp::audio {
 
@@ -84,12 +86,19 @@ public:
     /// when a change is detected. Backends with richer semantics can still
     /// override this entirely.
     virtual void set_device_change_callback(DeviceChangeCallback cb) {
-        device_change_callback_ = std::move(cb);
+        std::lock_guard<std::mutex> lock(device_change_callback_mutex_);
+        if (cb) {
+            device_change_callback_ = std::make_shared<DeviceChangeCallback>(std::move(cb));
+        } else {
+            device_change_callback_.reset();
+        }
     }
 
     /// Dispatch a stored device-change callback. Safe to call from any
     /// thread; the callback itself is responsible for UI-thread
     /// marshalling.
+    /// The callback is retained before invocation so it may unregister or
+    /// replace itself during dispatch without invalidating the in-flight call.
     ///
     /// **Must be public, not protected.** Platform notifiers
     /// (WasapiNotificationClient, Win32 MIDI DeviceWatcher, ALSA
@@ -104,15 +113,22 @@ public:
     /// lenient; making this public matches the design intent the
     /// doc comment always described.
     void fire_device_change() {
-        if (device_change_callback_) device_change_callback_();
+        std::shared_ptr<DeviceChangeCallback> callback;
+        {
+            std::lock_guard<std::mutex> lock(device_change_callback_mutex_);
+            callback = device_change_callback_;
+        }
+        if (callback && *callback) (*callback)();
     }
     /// Observe whether a caller registered a callback.
     bool has_device_change_callback() const {
-        return static_cast<bool>(device_change_callback_);
+        std::lock_guard<std::mutex> lock(device_change_callback_mutex_);
+        return static_cast<bool>(device_change_callback_ && *device_change_callback_);
     }
 
 private:
-    DeviceChangeCallback device_change_callback_;
+    mutable std::mutex device_change_callback_mutex_;
+    std::shared_ptr<DeviceChangeCallback> device_change_callback_;
 };
 
 // Create the platform-appropriate audio system

--- a/test/test_audio_system_hotplug.cpp
+++ b/test/test_audio_system_hotplug.cpp
@@ -12,8 +12,8 @@ using namespace pulp::audio;
 
 namespace {
 
-// Minimal AudioSystem that exposes the protected fire_device_change()
-// for testing. Simulates a non-macOS backend using base-class storage.
+// Minimal AudioSystem that simulates a non-macOS backend using
+// AudioSystem's base-class callback storage.
 class StubSystem : public AudioSystem {
 public:
     std::vector<DeviceInfo> enumerate_devices() override { return {}; }
@@ -22,9 +22,6 @@ public:
     }
     DeviceInfo default_output_device() override { return {}; }
     DeviceInfo default_input_device() override { return {}; }
-    // expose protected helpers for the test
-    using AudioSystem::fire_device_change;
-    using AudioSystem::has_device_change_callback;
 };
 
 } // namespace
@@ -38,6 +35,35 @@ TEST_CASE("base class stores + fires the callback", "[audio][hotplug]") {
     sys.fire_device_change();
     sys.fire_device_change();
     REQUIRE(calls.load() == 2);
+}
+
+TEST_CASE("registering a new callback replaces the previous callback", "[audio][hotplug]") {
+    StubSystem sys;
+    int first_calls = 0;
+    int second_calls = 0;
+
+    sys.set_device_change_callback([&] { ++first_calls; });
+    sys.fire_device_change();
+    sys.set_device_change_callback([&] { ++second_calls; });
+
+    REQUIRE(sys.has_device_change_callback());
+    sys.fire_device_change();
+    REQUIRE(first_calls == 1);
+    REQUIRE(second_calls == 1);
+}
+
+TEST_CASE("callback state persists across fires", "[audio][hotplug]") {
+    StubSystem sys;
+    int observed_calls = 0;
+
+    sys.set_device_change_callback([calls = 0, &observed_calls]() mutable {
+        observed_calls = ++calls;
+    });
+
+    sys.fire_device_change();
+    REQUIRE(observed_calls == 1);
+    sys.fire_device_change();
+    REQUIRE(observed_calls == 2);
 }
 
 TEST_CASE("fire is a no-op with no callback", "[audio][hotplug]") {
@@ -55,4 +81,57 @@ TEST_CASE("nullptr unregisters the callback", "[audio][hotplug]") {
     REQUIRE_FALSE(sys.has_device_change_callback());
     sys.fire_device_change();
     REQUIRE(calls == 1);
+}
+
+TEST_CASE("repeated unregister remains a no-op", "[audio][hotplug]") {
+    StubSystem sys;
+    int calls = 0;
+
+    sys.set_device_change_callback(nullptr);
+    REQUIRE_FALSE(sys.has_device_change_callback());
+    sys.set_device_change_callback([&] { ++calls; });
+    REQUIRE(sys.has_device_change_callback());
+    sys.set_device_change_callback(nullptr);
+    sys.set_device_change_callback(nullptr);
+
+    REQUIRE_FALSE(sys.has_device_change_callback());
+    sys.fire_device_change();
+    REQUIRE(calls == 0);
+}
+
+TEST_CASE("callback may unregister itself during fire", "[audio][hotplug]") {
+    StubSystem sys;
+    int calls = 0;
+
+    sys.set_device_change_callback([&] {
+        ++calls;
+        sys.set_device_change_callback(nullptr);
+    });
+
+    sys.fire_device_change();
+    REQUIRE(calls == 1);
+    REQUIRE_FALSE(sys.has_device_change_callback());
+
+    sys.fire_device_change();
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("callback may replace itself during fire", "[audio][hotplug]") {
+    StubSystem sys;
+    int first_calls = 0;
+    int second_calls = 0;
+
+    sys.set_device_change_callback([&] {
+        ++first_calls;
+        sys.set_device_change_callback([&] { ++second_calls; });
+    });
+
+    sys.fire_device_change();
+    REQUIRE(first_calls == 1);
+    REQUIRE(second_calls == 0);
+    REQUIRE(sys.has_device_change_callback());
+
+    sys.fire_device_change();
+    REQUIRE(first_calls == 1);
+    REQUIRE(second_calls == 1);
 }

--- a/test/test_audio_system_hotplug.cpp
+++ b/test/test_audio_system_hotplug.cpp
@@ -7,6 +7,7 @@
 #include <pulp/audio/device.hpp>
 
 #include <atomic>
+#include <utility>
 
 using namespace pulp::audio;
 
@@ -24,17 +25,58 @@ public:
     DeviceInfo default_input_device() override { return {}; }
 };
 
+#if defined(_MSC_VER)
+#define PULP_TEST_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__) || defined(__clang__)
+#define PULP_TEST_NOINLINE __attribute__((noinline))
+#else
+#define PULP_TEST_NOINLINE
+#endif
+
+PULP_TEST_NOINLINE void set_callback_via_base(AudioSystem& sys, AudioSystem::DeviceChangeCallback cb) {
+    sys.set_device_change_callback(std::move(cb));
+}
+
+PULP_TEST_NOINLINE void fire_via_base(AudioSystem& sys) {
+    sys.fire_device_change();
+}
+
+PULP_TEST_NOINLINE bool has_callback_via_base(const AudioSystem& sys) {
+    return sys.has_device_change_callback();
+}
+
+#undef PULP_TEST_NOINLINE
+
 } // namespace
 
 TEST_CASE("base class stores + fires the callback", "[audio][hotplug]") {
     StubSystem sys;
     std::atomic<int> calls{0};
-    REQUIRE_FALSE(sys.has_device_change_callback());
-    sys.set_device_change_callback([&] { ++calls; });
-    REQUIRE(sys.has_device_change_callback());
-    sys.fire_device_change();
-    sys.fire_device_change();
+    REQUIRE_FALSE(has_callback_via_base(sys));
+    set_callback_via_base(sys, [&] { ++calls; });
+    REQUIRE(has_callback_via_base(sys));
+    fire_via_base(sys);
+    fire_via_base(sys);
     REQUIRE(calls.load() == 2);
+}
+
+TEST_CASE("base callback slot can be set cleared and observed through AudioSystem", "[audio][hotplug]") {
+    StubSystem sys;
+    AudioSystem& base = sys;
+    int calls = 0;
+
+    REQUIRE_FALSE(has_callback_via_base(base));
+    fire_via_base(base);
+
+    set_callback_via_base(base, [&] { ++calls; });
+    REQUIRE(has_callback_via_base(base));
+    fire_via_base(base);
+    REQUIRE(calls == 1);
+
+    set_callback_via_base(base, AudioSystem::DeviceChangeCallback{});
+    REQUIRE_FALSE(has_callback_via_base(base));
+    fire_via_base(base);
+    REQUIRE(calls == 1);
 }
 
 TEST_CASE("registering a new callback replaces the previous callback", "[audio][hotplug]") {


### PR DESCRIPTION
## Summary
- Harden `AudioSystem` base hotplug callback storage so callbacks can unregister or replace themselves during dispatch without invalidating the in-flight call.
- Extend `test_audio_system_hotplug.cpp` coverage for replacement, persistent callback state, repeated unregister, self-unregister, and self-replace paths.

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_TESTS=ON -DFETCHCONTENT_SOURCE_DIR_HIGHWAY=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/highway-src -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/mbedtls-src`
- `cmake --build build --target pulp-test-audio-system-hotplug -j 12`
- `./build/test/pulp-test-audio-system-hotplug`
- `ctest --test-dir build -R "callback|fire|unregister" --output-on-failure`
- `git diff --check origin/main..HEAD`
- `git diff --check`
- `python3 tools/scripts/skill_sync_check.py --mode=report`
- `python3 tools/scripts/version_bump_check.py --mode=report`
- `source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh" && pulp_cli_version_check && shipyard pr --skip-target mac --skip-target ubuntu --skip-target windows` created the PR, then exited with the expected `error: No targets remain after --skip-target filtering.`

Refs #640
Refs #641

Version-Bump: sdk=patch reason="AudioSystem callback storage hardening without API signature change"