### PR TITLE
fix(view): harden color picker edge paths

### DIFF
--- a/core/view/src/color_picker.cpp
+++ b/core/view/src/color_picker.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <pulp/view/color_picker.hpp>
 #include <algorithm>
 #include <cstdio>
@@ -21,8 +20,17 @@ void ColorPicker::set_hsl(HSL hsl) {
 }
 
 void ColorPicker::set_hex(const std::string& hex) {
-    if (hex.size() < 7 || hex[0] != '#') return;
-    auto val = std::stoul(hex.substr(1), nullptr, 16);
+    if ((hex.size() != 7 && hex.size() != 9) || hex[0] != '#') return;
+
+    std::size_t parsed = 0;
+    uint32_t val = 0;
+    try {
+        val = static_cast<uint32_t>(std::stoul(hex.substr(1), &parsed, 16));
+    } catch (...) {
+        return;
+    }
+    if (parsed != hex.size() - 1) return;
+
     if (hex.size() == 7)
         color_ = color_from_hex(static_cast<uint32_t>(val));
     else if (hex.size() == 9)
@@ -135,7 +143,7 @@ void ColorPicker::paint(canvas::Canvas& canvas) {
         }
         // Alpha cursor — inset by half cursor width to prevent edge clipping
         float alpha_cursor_w = 4.0f;
-        float alpha_x = ab.x + alpha_cursor_w * 0.5f + (static_cast<float>(color_.a) / 255.0f) * (ab.width - alpha_cursor_w);
+        float alpha_x = ab.x + alpha_cursor_w * 0.5f + color_.a * (ab.width - alpha_cursor_w);
         canvas.set_fill_color(Color::rgba8(255, 255, 255));
         canvas.fill_rect(alpha_x - 2, ab.y - 2, alpha_cursor_w, ab.height + 4);
     }

--- a/test/test_phase9_widgets.cpp
+++ b/test/test_phase9_widgets.cpp
@@ -132,6 +132,25 @@ TEST_CASE("ColorPicker hex round-trip", "[view][color_picker]") {
     REQUIRE(picker.color().b8() == 0x00);
 }
 
+TEST_CASE("ColorPicker hex alpha and malformed input are stable",
+          "[view][color_picker][issue-493]") {
+    ColorPicker picker;
+    picker.set_hex("#33669980");
+    REQUIRE(picker.hex() == "#33669980");
+    REQUIRE(picker.color().r8() == 0x33);
+    REQUIRE(picker.color().g8() == 0x66);
+    REQUIRE(picker.color().b8() == 0x99);
+    REQUIRE(picker.color().a8() == 0x80);
+
+    const auto before = picker.hex();
+    picker.set_hex("336699");
+    REQUIRE(picker.hex() == before);
+    picker.set_hex("#3366991234");
+    REQUIRE(picker.hex() == before);
+    REQUIRE_NOTHROW(picker.set_hex("#zzzzzz"));
+    REQUIRE(picker.hex() == before);
+}
+
 TEST_CASE("ColorPicker HSL round-trip", "[view][color_picker]") {
     ColorPicker picker;
     HSL hsl{120.0f, 1.0f, 0.5f};
@@ -148,6 +167,69 @@ TEST_CASE("ColorPicker swatches", "[view][color_picker]") {
         Color::rgba8(0, 0, 255)
     });
     REQUIRE(picker.swatches().size() == 3);
+}
+
+TEST_CASE("ColorPicker mouse editing updates SL hue alpha and swatches",
+          "[view][color_picker][issue-493]") {
+    ColorPicker picker;
+    picker.set_bounds({0, 0, 200, 280});
+    picker.set_hex("#000000ff");
+
+    int changes = 0;
+    picker.on_change = [&](Color) { ++changes; };
+
+    picker.on_mouse_down({90, 90});
+    REQUIRE(changes == 1);
+    REQUIRE(picker.color().r8() > 0);
+
+    picker.on_mouse_down({176, 184});
+    REQUIRE(changes == 2);
+    REQUIRE_THAT(picker.hsl().h, WithinAbs(360.0, 0.1));
+
+    picker.set_show_alpha(true);
+    picker.on_mouse_down({4, 212});
+    REQUIRE(changes == 3);
+    REQUIRE(picker.color().a8() == 0);
+    picker.on_mouse_drag({176, 212});
+    REQUIRE(changes == 4);
+    REQUIRE(picker.color().a8() == 255);
+    picker.on_mouse_up({176, 212});
+    picker.on_mouse_drag({4, 212});
+    REQUIRE(changes == 4);
+
+    picker.set_show_alpha(false);
+    picker.set_swatches({
+        Color::rgba8(255, 0, 0),
+        Color::rgba8(0, 255, 0),
+    });
+
+    picker.on_mouse_down({32, 216});
+    REQUIRE(changes == 5);
+    REQUIRE(picker.color().g8() == 255);
+    REQUIRE(picker.color().r8() == 0);
+}
+
+TEST_CASE("ColorPicker paint positions alpha cursor from normalized alpha",
+          "[view][color_picker][issue-493]") {
+    ColorPicker picker;
+    picker.set_bounds({0, 0, 200, 280});
+    picker.set_show_alpha(true);
+    picker.set_hex("#33669980");
+
+    pulp::canvas::RecordingCanvas canvas;
+    picker.paint(canvas);
+
+    bool found_alpha_cursor = false;
+    for (const auto& command : canvas.commands()) {
+        if (command.type != pulp::canvas::DrawCommand::Type::fill_rect) continue;
+        if (command.f[1] < 209.0f || command.f[1] > 211.0f) continue;
+        if (command.f[2] != 4.0f || command.f[3] != 24.0f) continue;
+
+        found_alpha_cursor = true;
+        REQUIRE(command.f[0] > 86.0f);
+        REQUIRE(command.f[0] < 91.0f);
+    }
+    REQUIRE(found_alpha_cursor);
 }
 
 // ── FileDropZone ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #493

Refs #641

## Summary
- harden ColorPicker hex parsing for malformed and overlong input
- preserve alpha hex round-trips and fix alpha cursor paint positioning from normalized alpha
- add focused ColorPicker mouse/edit/paint regression coverage

## Validation
- cmake --build build --target pulp-test-phase9-widgets -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-phase9-widgets "*[view][color_picker]*"
- ctest --test-dir build -R "ColorPicker" --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py --mode=report
- python3 tools/scripts/version_bump_check.py --mode=report