### PR TITLE
test(view): cover ui component edge paths

### DIFF
--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -423,9 +423,11 @@ void TabPanel::paint(canvas::Canvas& canvas) {
 
 void TabPanel::on_mouse_event(const MouseEvent& event) {
     if (!event.is_down) return;
+    if (tabs_.empty()) return;
     if (event.position.y > tab_height_) return; // click below tab bar
 
     float tab_w = tabs_.empty() ? 0 : local_bounds().width / static_cast<float>(tabs_.size());
+    if (tab_w <= 0.0f) return;
     int index = static_cast<int>(event.position.x / tab_w);
     set_active_tab(index);
 }

--- a/test/test_ui_components.cpp
+++ b/test/test_ui_components.cpp
@@ -183,6 +183,29 @@ TEST_CASE("ComboBox popup overlay paints separators hover and selection guards",
     ComboBox::close_active_popup();
 }
 
+TEST_CASE("ComboBox global click closes only outside active popup",
+          "[view][combo][issue-493]") {
+    ComboBox::close_active_popup();
+
+    ComboBox combo;
+    combo.set_items({"One", "Two"});
+
+    KeyEvent open;
+    open.key = KeyCode::space;
+    open.is_down = true;
+    REQUIRE(combo.on_key_event(open));
+    REQUIRE(combo.is_open());
+    REQUIRE(ComboBox::active_popup_ == &combo);
+
+    ComboBox::notify_global_click(&combo);
+    REQUIRE(combo.is_open());
+
+    View outside;
+    ComboBox::notify_global_click(&outside);
+    REQUIRE_FALSE(combo.is_open());
+    REQUIRE(ComboBox::active_popup_ == nullptr);
+}
+
 // ── Tooltip ──────────────────────────────────────────────────────────────
 
 TEST_CASE("Tooltip show and hide", "[view][tooltip]") {
@@ -232,6 +255,34 @@ TEST_CASE("ProgressBar paint with label", "[view][progress]") {
     REQUIRE(canvas.count(DrawCommand::Type::fill_text) == 1);
 }
 
+TEST_CASE("ProgressBar paint clamps high progress and skips indeterminate fill",
+          "[view][progress][issue-493]") {
+    ProgressBar high;
+    high.set_bounds({0, 0, 120, 12});
+    high.set_progress(2.0f);
+
+    RecordingCanvas high_canvas;
+    high.paint(high_canvas);
+
+    bool found_full_width_fill = false;
+    for (const auto& command : high_canvas.commands()) {
+        if (command.type != DrawCommand::Type::fill_rounded_rect) continue;
+        if (command.f[2] == 120.0f && command.f[3] == 12.0f) {
+            found_full_width_fill = true;
+        }
+    }
+    REQUIRE(found_full_width_fill);
+
+    ProgressBar indeterminate;
+    indeterminate.set_bounds({0, 0, 120, 12});
+    indeterminate.set_progress(-1.0f);
+
+    RecordingCanvas indeterminate_canvas;
+    indeterminate.paint(indeterminate_canvas);
+    REQUIRE(indeterminate_canvas.count(DrawCommand::Type::fill_rounded_rect) == 1);
+    REQUIRE(indeterminate_canvas.count(DrawCommand::Type::fill_text) == 0);
+}
+
 // ── CallOutBox ───────────────────────────────────────────────────────────
 
 TEST_CASE("CallOutBox confirm factory", "[view][callout]") {
@@ -262,6 +313,33 @@ TEST_CASE("CallOutBox notify factory sets auto-dismiss", "[view][callout]") {
     auto box = CallOutBox::notify("Saved!", 2.0f);
     REQUIRE(box->message() == "Saved!");
     REQUIRE(box->auto_dismiss_seconds == 2.0f);
+}
+
+TEST_CASE("CallOutBox ignores key-up and unrelated keys",
+          "[view][callout][issue-493]") {
+    bool confirmed = false;
+    bool cancelled = false;
+    auto box = CallOutBox::confirm("Apply?", [&] { confirmed = true; },
+                                   [&] { cancelled = true; });
+
+    KeyEvent enter_up;
+    enter_up.key = KeyCode::enter;
+    enter_up.is_down = false;
+    REQUIRE_FALSE(box->on_key_event(enter_up));
+
+    KeyEvent space;
+    space.key = KeyCode::space;
+    space.is_down = true;
+    REQUIRE_FALSE(box->on_key_event(space));
+
+    REQUIRE_FALSE(confirmed);
+    REQUIRE_FALSE(cancelled);
+
+    box->set_bounds({0, 0, 160, 40});
+    RecordingCanvas canvas;
+    box->paint(canvas);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_text) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_rounded_rect) == 1);
 }
 
 // ── TabPanel ─────────────────────────────────────────────────────────────
@@ -310,6 +388,39 @@ TEST_CASE("TabPanel out-of-range ignored", "[view][tabs]") {
 
     tabs.set_active_tab(-1);
     REQUIRE(tabs.active_tab() == 0);
+}
+
+TEST_CASE("TabPanel mouse selection paint and empty guard",
+          "[view][tabs][issue-493]") {
+    TabPanel empty;
+    empty.set_bounds({0, 0, 0, 60});
+    MouseEvent empty_click;
+    empty_click.position = {0.0f, 0.0f};
+    empty_click.is_down = true;
+    empty.on_mouse_event(empty_click);
+    REQUIRE(empty.active_tab() == 0);
+
+    TabPanel tabs;
+    tabs.set_bounds({0, 0, 200, 120});
+    tabs.add_tab("One", std::make_unique<View>());
+    tabs.add_tab("Two", std::make_unique<View>());
+
+    MouseEvent below_bar;
+    below_bar.position = {150.0f, 40.0f};
+    below_bar.is_down = true;
+    tabs.on_mouse_event(below_bar);
+    REQUIRE(tabs.active_tab() == 0);
+
+    MouseEvent second_tab;
+    second_tab.position = {150.0f, 12.0f};
+    second_tab.is_down = true;
+    tabs.on_mouse_event(second_tab);
+    REQUIRE(tabs.active_tab() == 1);
+
+    RecordingCanvas canvas;
+    tabs.paint(canvas);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_text) == 2);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) >= 3);
 }
 
 // ── ScrollView ───────────────────────────────────────────────────────────
@@ -406,6 +517,43 @@ TEST_CASE("ScrollView wheel respects horizontal direction and track clicks",
     down.button = MouseButton::left;
     track_click.on_mouse_event(down);
     REQUIRE(track_click.target_scroll_y() > 0.0f);
+}
+
+TEST_CASE("ScrollView vertical wheel leave and horizontal track click edges",
+          "[view][scroll][issue-493]") {
+    ScrollView vertical;
+    vertical.set_direction(ScrollView::Direction::vertical);
+    vertical.set_bounds({0, 0, 100, 100});
+    vertical.set_content_size({300, 500});
+
+    MouseEvent wheel;
+    wheel.is_wheel = true;
+    wheel.scroll_delta_x = 40.0f;
+    wheel.scroll_delta_y = 40.0f;
+    vertical.on_mouse_event(wheel);
+    vertical.advance_animations(1.0f);
+    REQUIRE(vertical.scroll_x() == 0.0f);
+    REQUIRE(vertical.scroll_y() > 0.0f);
+
+    vertical.on_mouse_enter();
+    vertical.advance_animations(1.0f);
+    REQUIRE(vertical.bar_width() == 8.0f);
+    vertical.on_mouse_leave();
+    vertical.advance_animations(1.0f);
+    REQUIRE(vertical.bar_width() == 4.0f);
+
+    ScrollView horizontal_track;
+    horizontal_track.set_direction(ScrollView::Direction::horizontal);
+    horizontal_track.set_bounds({0, 0, 100, 100});
+    horizontal_track.set_content_size({300, 100});
+
+    MouseEvent down;
+    down.position = {90.0f, 98.0f};
+    down.is_down = true;
+    down.button = MouseButton::left;
+    horizontal_track.on_mouse_event(down);
+    horizontal_track.advance_animations(1.0f);
+    REQUIRE(horizontal_track.scroll_x() > 0.0f);
 }
 
 // ── ListBox ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #493

Refs #641

## Summary
- guard empty/zero-width TabPanel mouse selection
- add focused ComboBox popup-close, ProgressBar clamp/indeterminate, CallOutBox ignored-key, TabPanel mouse/paint, and ScrollView direction/track regression coverage

## Validation
- cmake --build build --target pulp-test-ui-components -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-ui-components "[view]"
- ctest --test-dir build -R "ComboBox|ProgressBar|CallOutBox|TabPanel|ScrollView" --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py --mode=report
- python3 tools/scripts/version_bump_check.py --mode=report