### PR TITLE
test(cli): cover inspect command edge paths

### DIFF
--- a/.claude/commands/inspect.md
+++ b/.claude/commands/inspect.md
@@ -1,18 +1,22 @@
 ---
 name: inspect
-description: Inspect the view hierarchy and widget state
+description: Connect to a running Pulp inspector server
 ---
 
-Launch the component inspector to debug the view tree, widget state, and layout.
+Connect to a running plugin's inspector server to query the view tree,
+widget state, layout, and runtime diagnostics.
 
 ```bash
-./build/tools/cli/pulp inspect [script.js]
+./build/tools/cli/pulp inspect
+./build/tools/cli/pulp inspect --port 49152
+./build/tools/cli/pulp inspect --command DOM.getDocument
+./build/tools/cli/pulp inspect --command Capture.screenshot --output shot.json
 ```
 
-The inspector shows:
+The inspector exposes:
 - View hierarchy with bounds, flex properties, and styles
 - Widget state (values, labels, visibility)
 - Theme tokens and computed colors
 - Layout debug information
 
-Use this when UI rendering doesn't match expectations or to understand the view tree structure.
+Use `--port` when auto-discovery cannot find a running inspector.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -830,13 +830,24 @@ Remaining limitation:
 
 **Status**: experimental
 
-Launch the built component inspector binary with its demo surface.
+Connect to a running Pulp inspector server. With no `--port`, the CLI
+auto-discovers the newest `pulp-inspector-*.port` file in the system temp
+directory.
 
 ```bash
 pulp inspect
+pulp inspect --port 49152
+pulp inspect --command DOM.getDocument
+pulp inspect --command Capture.screenshot --output shot.json
 ```
 
-This command delegates to `tools/screenshot/pulp-screenshot` in the active build tree. Build the repo first if the binary is missing.
+Options:
+
+- `--host HOST` - connect to a host other than `127.0.0.1`
+- `--port PORT` - connect to an explicit inspector port
+- `--command METHOD` - send one inspector command and print the response
+- `--params JSON` - JSON params for `--command`
+- `--output FILE` - write a one-shot command response to a file
 
 ### import-design
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -534,7 +534,28 @@ commands:
 
   - name: inspect
     status: experimental
-    summary: Launch the component inspector binary from the active build tree.
+    summary: Connect to a running plugin inspector server.
+    args:
+      - name: --host
+        kind: option
+        required: false
+        description: Inspector host, defaulting to 127.0.0.1
+      - name: --port
+        kind: option
+        required: false
+        description: Inspector port; defaults to auto-discovery from a temp-file hint
+      - name: --command
+        kind: option
+        required: false
+        description: Inspector method to send once before exiting
+      - name: --params
+        kind: option
+        required: false
+        description: JSON params for --command
+      - name: --output
+        kind: option
+        required: false
+        description: File path for the one-shot command response
     docs: reference/cli.md#inspect
 
   - name: import-design

--- a/test/test_cli_shellout.cpp
+++ b/test/test_cli_shellout.cpp
@@ -317,10 +317,120 @@ TEST_CASE("pulp help output lists the top-level subcommands",
     // from the dispatch table, this fails loudly.
     for (const char* cmd : {"build", "test", "run", "validate", "ship",
                             "version", "doctor", "create", "clean",
-                            "docs", "status"}) {
+                            "docs", "status", "inspect"}) {
         INFO("help output missing subcommand: " << cmd);
         REQUIRE(r.stdout_output.find(cmd) != std::string::npos);
     }
+}
+
+TEST_CASE("pulp inspect help and no-discovery paths are deterministic",
+          "[cli][shellout][inspect][issue-643][issue-641]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
+    update_disabled.set("1");
+
+    auto help = run_pulp({"inspect", "--help"}, 10000);
+    REQUIRE_FALSE(help.timed_out);
+    REQUIRE(help.exit_code == 0);
+    REQUIRE(help.stdout_output.find("Usage: pulp inspect [options]")
+            != std::string::npos);
+    REQUIRE(help.stdout_output.find("--port PORT") != std::string::npos);
+    REQUIRE(help.stdout_output.find("--output FILE") != std::string::npos);
+
+    auto base = unique_temp_dir("pulp-inspect-no-discovery");
+    fs::create_directories(base);
+#if defined(_WIN32)
+    ScopedEnvVar temp_dir("TEMP");
+#else
+    ScopedEnvVar temp_dir("TMPDIR");
+#endif
+    temp_dir.set(base.string());
+
+    auto missing = run_pulp({"inspect"}, 10000);
+    fs::remove_all(base);
+
+    REQUIRE_FALSE(missing.timed_out);
+    REQUIRE(missing.exit_code == 1);
+    REQUIRE(missing.stderr_output.find("no running Pulp inspector found")
+            != std::string::npos);
+    REQUIRE(missing.stderr_output.find("specify --port") != std::string::npos);
+    REQUIRE(missing.stdout_output.find("Connecting to") == std::string::npos);
+}
+
+TEST_CASE("pulp inspect explicit port failure does not require a server",
+          "[cli][shellout][inspect][issue-643][issue-641]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
+    update_disabled.set("1");
+
+    auto base = unique_temp_dir("pulp-inspect-explicit-port");
+    fs::create_directories(base);
+    auto output = base / "inspect-response.json";
+
+    auto r = run_pulp({"inspect",
+                       "--host", "127.0.0.1",
+                       "--port", "1",
+                       "--command", "DOM.getDocument",
+                       "--params", "{\"depth\":1}",
+                       "--output", output.string()},
+                      5000);
+    const bool wrote_output = fs::exists(output);
+    fs::remove_all(base);
+
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.exit_code == 1);
+    REQUIRE(r.stdout_output.find("Connecting to 127.0.0.1:1")
+            != std::string::npos);
+    REQUIRE(r.stderr_output.find("could not connect to 127.0.0.1:1")
+            != std::string::npos);
+    REQUIRE_FALSE(wrote_output);
+}
+
+TEST_CASE("pulp inspect rejects invalid arguments before networking",
+          "[cli][shellout][inspect][issue-643][issue-641]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    ScopedEnvVar update_disabled("PULP_UPDATE_CHECK_DISABLED");
+    update_disabled.set("1");
+
+    auto missing_port = run_pulp({"inspect", "--port"}, 10000);
+    REQUIRE_FALSE(missing_port.timed_out);
+    REQUIRE(missing_port.exit_code == 2);
+    REQUIRE(missing_port.stderr_output.find("--port requires a value")
+            != std::string::npos);
+    REQUIRE(missing_port.stdout_output.find("Connecting to") == std::string::npos);
+
+    auto invalid_port = run_pulp({"inspect", "--port", "not-a-port"}, 10000);
+    REQUIRE_FALSE(invalid_port.timed_out);
+    REQUIRE(invalid_port.exit_code == 2);
+    REQUIRE(invalid_port.stderr_output.find("invalid --port value: not-a-port")
+            != std::string::npos);
+    REQUIRE(invalid_port.stdout_output.find("Connecting to") == std::string::npos);
+
+    auto output_without_command = run_pulp({"inspect", "--output", "out.json"}, 10000);
+    REQUIRE_FALSE(output_without_command.timed_out);
+    REQUIRE(output_without_command.exit_code == 2);
+    REQUIRE(output_without_command.stderr_output.find("--output requires --command")
+            != std::string::npos);
+    REQUIRE(output_without_command.stdout_output.find("Connecting to")
+            == std::string::npos);
+
+    auto params_without_command = run_pulp({"inspect", "--params", "{}"}, 10000);
+    REQUIRE_FALSE(params_without_command.timed_out);
+    REQUIRE(params_without_command.exit_code == 2);
+    REQUIRE(params_without_command.stderr_output.find("--params requires --command")
+            != std::string::npos);
+    REQUIRE(params_without_command.stdout_output.find("Connecting to")
+            == std::string::npos);
+
+    auto unknown = run_pulp({"inspect", "--definitely-not-an-inspect-flag"}, 10000);
+    REQUIRE_FALSE(unknown.timed_out);
+    REQUIRE(unknown.exit_code == 2);
+    REQUIRE(unknown.stderr_output.find("unknown inspect argument")
+            != std::string::npos);
+    REQUIRE(unknown.stdout_output.find("Connecting to") == std::string::npos);
 }
 
 TEST_CASE("pulp create scaffolds a no-build app project with Android files",

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -267,6 +267,7 @@ int cmd_sdk(const std::vector<std::string>& args);
 int cmd_version(const std::vector<std::string>& args);
 int cmd_dev(const std::vector<std::string>& args);
 int cmd_loop(const std::vector<std::string>& args);
+int cmd_inspect(const std::vector<std::string>& args);
 int cmd_scan(const std::vector<std::string>& args);
 int cmd_host(const std::vector<std::string>& args);
 int cmd_pr(const std::vector<std::string>& args);

--- a/tools/cli/cmd_inspect.cpp
+++ b/tools/cli/cmd_inspect.cpp
@@ -10,6 +10,8 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <charconv>
+#include <system_error>
 #include <thread>
 #include <chrono>
 #include <atomic>
@@ -46,6 +48,37 @@ namespace {
 using namespace pulp::inspect;
 using namespace pulp::events;
 
+static bool parse_port_arg(const std::string& text, int& out) {
+    if (text.empty()) return false;
+
+    int value = 0;
+    const char* begin = text.data();
+    const char* end = begin + text.size();
+    auto [ptr, ec] = std::from_chars(begin, end, value);
+    if (ec != std::errc{} || ptr != end || value <= 0 || value > 65535) {
+        return false;
+    }
+
+    out = value;
+    return true;
+}
+
+static bool require_arg_value(const std::vector<std::string>& args,
+                              size_t& i,
+                              const char* flag,
+                              std::string& out) {
+    if (i + 1 >= args.size()) {
+        std::cerr << "Error: " << flag << " requires a value\n";
+        return false;
+    }
+    out = args[++i];
+    if (out.empty()) {
+        std::cerr << "Error: " << flag << " requires a non-empty value\n";
+        return false;
+    }
+    return true;
+}
+
 // Find the inspector port by reading discovery files
 static int discover_port() {
     std::string tmp_dir;
@@ -61,13 +94,23 @@ static int discover_port() {
     int found_port = 0;
     fs::file_time_type newest_time{};
 
-    for (auto& entry : fs::directory_iterator(tmp_dir)) {
+    std::error_code ec;
+    if (!fs::is_directory(tmp_dir, ec)) {
+        return 0;
+    }
+
+    fs::directory_iterator it(tmp_dir, ec);
+    fs::directory_iterator end;
+    for (; !ec && it != end; it.increment(ec)) {
+        const auto& entry = *it;
         auto name = entry.path().filename().string();
         if (name.find("pulp-inspector-") == 0 && name.find(".port") != std::string::npos) {
             std::ifstream f(entry.path());
             int port = 0;
             if (f >> port && port > 0) {
-                auto mtime = fs::last_write_time(entry.path());
+                std::error_code time_ec;
+                auto mtime = fs::last_write_time(entry.path(), time_ec);
+                if (time_ec) continue;
                 if (mtime > newest_time || found_port == 0) {
                     newest_time = mtime;
                     found_port = port;
@@ -104,6 +147,7 @@ int cmd_inspect(const std::vector<std::string>& args) {
     std::string one_shot_command;
     std::string one_shot_params = "{}";
     std::string output_file;
+    bool params_provided = false;
 
     for (size_t i = 0; i < args.size(); ++i) {
         if (args[i] == "--help" || args[i] == "-h") {
@@ -122,11 +166,36 @@ int cmd_inspect(const std::vector<std::string>& args) {
             std::cout << "  pulp inspect --host 192.168.1.42          # Remote debugging\n";
             return 0;
         }
-        if (args[i] == "--host" && i + 1 < args.size()) host = args[++i];
-        else if (args[i] == "--port" && i + 1 < args.size()) port = std::stoi(args[++i]);
-        else if (args[i] == "--command" && i + 1 < args.size()) one_shot_command = args[++i];
-        else if (args[i] == "--params" && i + 1 < args.size()) one_shot_params = args[++i];
-        else if (args[i] == "--output" && i + 1 < args.size()) output_file = args[++i];
+        if (args[i] == "--host") {
+            if (!require_arg_value(args, i, "--host", host)) return 2;
+        } else if (args[i] == "--port") {
+            std::string text;
+            if (!require_arg_value(args, i, "--port", text)) return 2;
+            if (!parse_port_arg(text, port)) {
+                std::cerr << "Error: invalid --port value: " << text << "\n";
+                return 2;
+            }
+        } else if (args[i] == "--command") {
+            if (!require_arg_value(args, i, "--command", one_shot_command)) return 2;
+        } else if (args[i] == "--params") {
+            if (!require_arg_value(args, i, "--params", one_shot_params)) return 2;
+            params_provided = true;
+        } else if (args[i] == "--output") {
+            if (!require_arg_value(args, i, "--output", output_file)) return 2;
+        } else {
+            std::cerr << "Error: unknown inspect argument: " << args[i] << "\n";
+            std::cerr << "Run `pulp inspect --help` for usage.\n";
+            return 2;
+        }
+    }
+
+    if (!output_file.empty() && one_shot_command.empty()) {
+        std::cerr << "Error: --output requires --command\n";
+        return 2;
+    }
+    if (params_provided && one_shot_command.empty()) {
+        std::cerr << "Error: --params requires --command\n";
+        return 2;
     }
 
     // Auto-discover port if not specified

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -47,6 +47,7 @@ static const Command commands[] = {
     {"version",  "Show, bump, or check version info",     cmd_version},
     {"dev",      "Unified dev loop: watch, build, test, run", cmd_dev},
     {"loop",     "Leveraged-prototype focus mode: single-platform watch + rebuild (#940)", cmd_loop},
+    {"inspect",  "Connect to a running plugin inspector", cmd_inspect},
     {"scan",     "Scan system paths for VST3 / AU / CLAP / LV2 plug-ins", cmd_scan},
     {"host",     "Load a plug-in and run a synthetic audio block through it", cmd_host},
     {"pr",       "One-shot push-a-PR: gates + bump + ship",   cmd_pr},
@@ -87,7 +88,6 @@ struct BinaryCommand {
 
 static const BinaryCommand binary_commands[] = {
     {"design-debug",  "tools/design/pulp-design-debug",            "Headless design debug runner", nullptr},
-    {"inspect",       "tools/screenshot/pulp-screenshot",          "Launch the component inspector", "--demo"},
     {"import-design", "tools/import-design/pulp-import-design",    "Import designs from Figma/Stitch/v0/Pencil", nullptr},
     {"export-tokens", "tools/import-design/pulp-import-design",    "Export theme as W3C Design Tokens", "--export-tokens"},
 };


### PR DESCRIPTION
## Summary
- Wire `pulp inspect` to the existing CLI inspect implementation instead of the screenshot demo delegate.
- Harden no-server paths and argument validation before networking: missing values, invalid ports, `--output`/`--params` without `--command`, and unknown flags.
- Add focused shellout coverage for help, no-discovery, explicit localhost connection failure, and invalid inspect arguments; sync CLI docs/status/slash help.

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar -DFETCHCONTENT_SOURCE_DIR_THREEJS=/tmp/pulp-empty-threejs`
- `cmake --build build --target pulp-cli pulp-test-cli-shellout -j4`
- `PULP_CLI_PATH=/Users/danielraffel/Code/pulp-cli-inspect-coverage-643/build/tools/cli/pulp ./build/test/pulp-test-cli-shellout "[cli][shellout][inspect]"` (3 test cases, 35 assertions)
- `PULP_CLI_PATH=/Users/danielraffel/Code/pulp-cli-inspect-coverage-643/build/tools/cli/pulp ctest --test-dir build -R "pulp inspect" --output-on-failure` (3/3 passed)
- `git diff --check`
- `python3 tools/scripts/skill_sync_check.py --mode=report`
- `python3 tools/scripts/version_bump_check.py --mode=report`
- `source tools/scripts/cli_version_check.sh && pulp_cli_version_check && shipyard pr --skip-target mac --skip-target ubuntu --skip-target windows` (created PR; exited with expected no-targets message)

## Caveats
- No inspector server is required or started; explicit-port coverage uses a fast localhost connection-refused path.
- Namespace/GitHub validation only, per Phase 3 Codecov tranche guidance.

Refs #643
Refs #641