### PR TITLE
test(view): cover table list edge paths

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -781,6 +781,10 @@ add_executable(pulp-test-gui-components test_gui_components.cpp)
 target_link_libraries(pulp-test-gui-components PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-gui-components)
 
+add_executable(pulp-test-table-list-box test_table_list_box.cpp)
+target_link_libraries(pulp-test-table-list-box PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-table-list-box)
+
 # CodeEditor / FileBasedDocument / RecentlyOpenedFilesList tests
 add_executable(pulp-test-code-editor test_code_editor.cpp)
 target_link_libraries(pulp-test-code-editor PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_table_list_box.cpp
+++ b/test/test_table_list_box.cpp
@@ -1,0 +1,175 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/view/table.hpp>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+using namespace pulp::view;
+using namespace pulp::canvas;
+
+namespace {
+
+class RecordingTableModel : public TableModel {
+public:
+    explicit RecordingTableModel(std::vector<std::vector<std::string>> rows)
+        : rows_(std::move(rows)) {}
+
+    int row_count() const override { return static_cast<int>(rows_.size()); }
+
+    std::string cell_text(int row, int column) const override {
+        if (row < 0 || row >= row_count()) return {};
+        const auto& r = rows_[static_cast<size_t>(row)];
+        if (column < 0 || column >= static_cast<int>(r.size())) return {};
+        return r[static_cast<size_t>(column)];
+    }
+
+    bool sort(int column, bool ascending) override {
+        sort_calls.push_back({column, ascending});
+        return true;
+    }
+
+    void row_selected(int row) override {
+        selected_rows.push_back(row);
+    }
+
+    std::vector<std::pair<int, bool>> sort_calls;
+    std::vector<int> selected_rows;
+
+private:
+    std::vector<std::vector<std::string>> rows_;
+};
+
+bool has_text(const RecordingCanvas& canvas, const std::string& text) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const DrawCommand& cmd) {
+                           return cmd.type == DrawCommand::Type::fill_text &&
+                                  cmd.text == text;
+                       });
+}
+
+const DrawCommand* find_text(const RecordingCanvas& canvas, const std::string& text) {
+    auto it = std::find_if(canvas.commands().begin(),
+                           canvas.commands().end(),
+                           [&](const DrawCommand& cmd) {
+                               return cmd.type == DrawCommand::Type::fill_text &&
+                                      cmd.text == text;
+                           });
+    return it == canvas.commands().end() ? nullptr : &*it;
+}
+
+} // namespace
+
+TEST_CASE("TableListBox paint returns early without model or columns", "[gui][table][coverage]") {
+    TableListBox table;
+    table.set_bounds({0, 0, 200, 100});
+
+    RecordingCanvas canvas;
+    table.paint(canvas);
+    REQUIRE(canvas.command_count() == 0);
+
+    RecordingTableModel model({{"A"}});
+    table.set_model(&model);
+    table.paint(canvas);
+    REQUIRE(canvas.command_count() == 0);
+}
+
+TEST_CASE("TableListBox paints scaled aligned headers rows and sort indicator",
+          "[gui][table][coverage]") {
+    RecordingTableModel model({
+        {"Alpha", "Synth", "10"},
+        {"Beta", "Effect", "2"},
+    });
+
+    TableListBox table;
+    table.set_bounds({0, 0, 120, 90});
+    table.set_header_height(20.0f);
+    table.set_row_height(18.0f);
+    table.set_model(&model);
+    table.add_column({"Name", 100.0f, true, true, TableColumn::Align::left});
+    table.add_column({"Type", 100.0f, true, true, TableColumn::Align::center});
+    table.add_column({"Value", 100.0f, true, true, TableColumn::Align::right});
+
+    table.on_mouse_down({45.0f, 5.0f});
+    REQUIRE(model.sort_calls == std::vector<std::pair<int, bool>>{{1, true}});
+
+    RecordingCanvas canvas;
+    table.paint(canvas);
+
+    REQUIRE(has_text(canvas, "Name"));
+    REQUIRE(has_text(canvas, "Type"));
+    REQUIRE(has_text(canvas, "Value"));
+    REQUIRE(has_text(canvas, "Alpha"));
+    REQUIRE(has_text(canvas, "Effect"));
+    REQUIRE(has_text(canvas, "10"));
+    REQUIRE(has_text(canvas, "\xe2\x96\xb2"));
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_line) >= 4);
+
+    auto* left = find_text(canvas, "Name");
+    auto* center = find_text(canvas, "Type");
+    auto* right = find_text(canvas, "Value");
+    REQUIRE(left != nullptr);
+    REQUIRE(center != nullptr);
+    REQUIRE(right != nullptr);
+    REQUIRE(left->f[0] == 6.0f);
+    REQUIRE(center->f[0] == 46.0f);
+    REQUIRE(right->f[0] == 79.0f);
+
+    table.on_mouse_down({45.0f, 5.0f});
+    REQUIRE(model.sort_calls == std::vector<std::pair<int, bool>>{{1, true}, {1, false}});
+
+    RecordingCanvas descending_canvas;
+    table.paint(descending_canvas);
+    REQUIRE(has_text(descending_canvas, "\xe2\x96\xbc"));
+}
+
+TEST_CASE("TableListBox ignores unsortable header clicks and selects visible rows",
+          "[gui][table][coverage]") {
+    RecordingTableModel model({
+        {"Row 0", "A"},
+        {"Row 1", "B"},
+        {"Row 2", "C"},
+    });
+
+    TableListBox table;
+    table.set_bounds({0, 0, 180, 100});
+    table.set_header_height(20.0f);
+    table.set_row_height(10.0f);
+    table.set_model(&model);
+    table.add_column({"Name", 90.0f, false});
+    table.add_column({"Value", 90.0f, true});
+
+    table.on_mouse_down({30.0f, 5.0f});
+    REQUIRE(model.sort_calls.empty());
+    REQUIRE(table.selected_row() == -1);
+
+    std::vector<int> changed_rows;
+    table.on_selection_changed = [&](int row) { changed_rows.push_back(row); };
+
+    table.on_mouse_down({10.0f, 35.0f});
+    REQUIRE(table.selected_row() == 1);
+    REQUIRE(changed_rows == std::vector<int>{1});
+    REQUIRE(model.selected_rows == std::vector<int>{1});
+
+    table.on_mouse_down({10.0f, 500.0f});
+    REQUIRE(table.selected_row() == 1);
+    REQUIRE(changed_rows == std::vector<int>{1});
+    REQUIRE(model.selected_rows == std::vector<int>{1});
+}
+
+TEST_CASE("SimpleTableModel handles negative sort columns and sparse rows",
+          "[gui][table][coverage]") {
+    SimpleTableModel model;
+    model.add_row({"B"});
+    model.add_row({"A", "two"});
+
+    REQUIRE_FALSE(model.sort(-1, true));
+    REQUIRE(model.cell_text(0, 0) == "B");
+
+    REQUIRE(model.sort(1, true));
+    REQUIRE(model.cell_text(0, 0) == "B");
+    REQUIRE(model.cell_text(0, 1).empty());
+    REQUIRE(model.cell_text(1, 1) == "two");
+}


### PR DESCRIPTION
Refs #493
Refs #641

Coverage tranche:
- Adds `pulp-test-table-list-box`.
- Covers early paint returns, scaled aligned headers and rows, sort indicators, unsortable header clicks, row selection and miss handling, and `SimpleTableModel` sparse/negative-sort behavior.

Local validation:
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_HIGHWAY=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/highway-src -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/mbedtls-src -DFETCHCONTENT_SOURCE_DIR_THREEJS=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/threejs-src`
- `cmake --build build --target pulp-test-table-list-box -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-table-list-box`
- `ctest --test-dir build -R "TableListBox|SimpleTableModel|table-list|table_list" --output-on-failure`
- `git diff --check`
- `python3 tools/scripts/skill_sync_check.py`
- `python3 tools/scripts/version_bump_check.py --mode=report`
- `pulp_cli_version_check`

Namespace:
- `shipyard cloud run build feature/view-table-coverage-493`
- Run: https://github.com/danielraffel/pulp/actions/runs/25160445050