### PR TITLE
test(view): cover code editor edge paths

### DIFF
--- a/test/test_code_editor.cpp
+++ b/test/test_code_editor.cpp
@@ -2,7 +2,70 @@
 #include <pulp/view/code_editor.hpp>
 #include <pulp/canvas/canvas.hpp>
 
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+
 using namespace pulp::view;
+
+namespace {
+
+bool has_text(const pulp::canvas::RecordingCanvas& canvas, const std::string& text) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const pulp::canvas::DrawCommand& cmd) {
+                           return cmd.type == pulp::canvas::DrawCommand::Type::fill_text &&
+                                  cmd.text == text;
+                       });
+}
+
+bool has_fill_rect(const pulp::canvas::RecordingCanvas& canvas,
+                   float x, float y, float w, float h) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const pulp::canvas::DrawCommand& cmd) {
+                           return cmd.type == pulp::canvas::DrawCommand::Type::fill_rect &&
+                                  cmd.f[0] == x && cmd.f[1] == y &&
+                                  cmd.f[2] == w && cmd.f[3] == h;
+                       });
+}
+
+pulp::canvas::Color color_used_for_text(const pulp::canvas::RecordingCanvas& canvas,
+                                        const std::string& text) {
+    pulp::canvas::Color current{};
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::set_fill_color) {
+            current = cmd.color;
+        } else if (cmd.type == pulp::canvas::DrawCommand::Type::fill_text &&
+                   cmd.text == text) {
+            return current;
+        }
+    }
+    return {};
+}
+
+struct TestDoc : FileBasedDocument {
+    bool load_result = true;
+    bool save_result = true;
+    int load_calls = 0;
+    int save_calls = 0;
+    std::string loaded_path;
+    std::string saved_path;
+
+    bool load_from_file(std::string_view path) override {
+        ++load_calls;
+        loaded_path = std::string(path);
+        return load_result;
+    }
+
+    bool save_to_file(std::string_view path) override {
+        ++save_calls;
+        saved_path = std::string(path);
+        return save_result;
+    }
+};
+
+} // namespace
 
 TEST_CASE("CodeEditor set and get text", "[gui][code-editor]") {
     CodeEditor editor;
@@ -48,17 +111,93 @@ TEST_CASE("CodeEditor paint renders without crash", "[gui][code-editor]") {
     REQUIRE(rc.command_count() > 0);
 }
 
-TEST_CASE("FileBasedDocument title from path", "[gui][code-editor]") {
-    // FileBasedDocument is abstract, test title() logic
-    struct TestDoc : FileBasedDocument {
-        bool load_from_file(std::string_view) override { return true; }
-        bool save_to_file(std::string_view) override { return true; }
-    };
+TEST_CASE("CodeEditor paint covers line numbers highlight clipping and token colors",
+          "[gui][code-editor][coverage]") {
+    CodeEditor editor;
+    CodeEditorConfig config;
+    config.theme = "vs-light";
+    config.line_numbers = false;
+    config.font_size = 10.0f;
+    editor.configure(config);
+    editor.set_text("# comment\n\"value\"\nplain");
+    editor.go_to_line(2);
+    editor.set_bounds({0, 0, 160, 31});
 
+    pulp::canvas::RecordingCanvas rc;
+    editor.paint(rc);
+
+    REQUIRE(has_text(rc, "# comment"));
+    REQUIRE(has_text(rc, "\"value\""));
+    REQUIRE_FALSE(has_text(rc, "plain"));
+    REQUIRE_FALSE(has_text(rc, "1"));
+
+    REQUIRE(has_fill_rect(rc, 0.0f, 20.0f, 160.0f, 15.0f));
+    REQUIRE(color_used_for_text(rc, "# comment") ==
+            pulp::canvas::Color::rgba(106, 153, 85));
+    REQUIRE(color_used_for_text(rc, "\"value\"") ==
+            pulp::canvas::Color::rgba(206, 145, 120));
+}
+
+TEST_CASE("CodeEditor paint emits gutter line numbers when enabled",
+          "[gui][code-editor][coverage]") {
+    CodeEditor editor;
+    CodeEditorConfig config;
+    config.line_numbers = true;
+    config.font_size = 12.0f;
+    editor.configure(config);
+    editor.set_text("alpha\nbeta");
+    editor.set_bounds({0, 0, 180, 80});
+
+    pulp::canvas::RecordingCanvas rc;
+    editor.paint(rc);
+
+    REQUIRE(has_fill_rect(rc, 0.0f, 0.0f, 50.0f, 80.0f));
+    REQUIRE(has_text(rc, "1"));
+    REQUIRE(has_text(rc, "2"));
+    REQUIRE(has_text(rc, "alpha"));
+    REQUIRE(has_text(rc, "beta"));
+}
+
+TEST_CASE("FileBasedDocument title from path", "[gui][code-editor]") {
     TestDoc doc;
     doc.load("/tmp/my_plugin.txt");
     REQUIRE(doc.title() == "my_plugin");
     REQUIRE(doc.file_path() == "/tmp/my_plugin.txt");
+}
+
+TEST_CASE("FileBasedDocument handles save and load edge paths",
+          "[gui][code-editor][coverage]") {
+    TestDoc doc;
+    int dirty_callback_count = 0;
+    bool last_dirty = true;
+    doc.on_dirty_changed = [&](bool dirty) {
+        ++dirty_callback_count;
+        last_dirty = dirty;
+    };
+
+    REQUIRE_FALSE(doc.save());
+    REQUIRE(doc.save_calls == 0);
+    REQUIRE(doc.title() == "Untitled");
+
+    doc.set_dirty(true);
+    doc.load_result = false;
+    REQUIRE_FALSE(doc.load("/tmp/missing.pulp"));
+    REQUIRE(doc.load_calls == 1);
+    REQUIRE(doc.loaded_path == "/tmp/missing.pulp");
+    REQUIRE(doc.file_path() == "/tmp/missing.pulp");
+    REQUIRE(doc.is_dirty());
+
+    doc.save_result = false;
+    REQUIRE_FALSE(doc.save_as("/tmp/output.pulp"));
+    REQUIRE(doc.save_calls == 1);
+    REQUIRE(doc.saved_path == "/tmp/output.pulp");
+    REQUIRE(doc.is_dirty());
+
+    doc.save_result = true;
+    REQUIRE(doc.save());
+    REQUIRE_FALSE(doc.is_dirty());
+    REQUIRE(dirty_callback_count == 1);
+    REQUIRE_FALSE(last_dirty);
 }
 
 TEST_CASE("RecentlyOpenedFilesList MRU behavior", "[gui][code-editor]") {
@@ -78,4 +217,45 @@ TEST_CASE("RecentlyOpenedFilesList MRU behavior", "[gui][code-editor]") {
     // Max entries
     mru.set_max_entries(2);
     REQUIRE(mru.files().size() == 2);
+}
+
+TEST_CASE("RecentlyOpenedFilesList persists trims and handles I/O misses",
+          "[gui][code-editor][coverage]") {
+    RecentlyOpenedFilesList mru;
+    mru.add("/keep/existing.txt");
+
+    const auto dir = std::filesystem::temp_directory_path() / "pulp-code-editor-mru-test";
+    std::filesystem::create_directories(dir);
+    const auto file = dir / "recent.txt";
+    const auto missing_dir_file = dir / "missing-dir" / "recent.txt";
+
+    REQUIRE_FALSE(mru.load(missing_dir_file.string()));
+    REQUIRE(mru.files().size() == 1);
+    REQUIRE_FALSE(mru.save(missing_dir_file.string()));
+
+    {
+        std::ofstream out(file);
+        out << "/one.txt\n\n/two.txt\n/three.txt\n";
+    }
+
+    mru.set_max_entries(2);
+    REQUIRE(mru.load(file.string()));
+    REQUIRE(mru.files().size() == 2);
+    REQUIRE(mru.files()[0] == "/one.txt");
+    REQUIRE(mru.files()[1] == "/two.txt");
+
+    mru.clear();
+    REQUIRE(mru.files().empty());
+
+    mru.add("/saved/a.txt");
+    mru.add("/saved/b.txt");
+    REQUIRE(mru.save(file.string()));
+
+    RecentlyOpenedFilesList reloaded;
+    REQUIRE(reloaded.load(file.string()));
+    REQUIRE(reloaded.files().size() == 2);
+    REQUIRE(reloaded.files()[0] == "/saved/b.txt");
+    REQUIRE(reloaded.files()[1] == "/saved/a.txt");
+
+    std::filesystem::remove_all(dir);
 }


### PR DESCRIPTION
Refs #493
Refs #641

Coverage tranche:
- Extends `pulp-test-code-editor`.
- Covers CodeEditor paint branches for line-number disabled/enabled modes, current-line highlight, height clipping, comment/string token colors, and gutter rendering.
- Covers FileBasedDocument missing-path save, failed load/save_as behavior, successful save dirty reset callback.
- Covers RecentlyOpenedFilesList load/save miss handling, empty-line filtering, max-entry trim, clear, save, and reload behavior.

Local validation:
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_HIGHWAY=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/highway-src -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/mbedtls-src -DFETCHCONTENT_SOURCE_DIR_THREEJS=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/threejs-src`
- `cmake --build build --target pulp-test-code-editor -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-code-editor`
- `ctest --test-dir build -R "CodeEditor|FileBasedDocument|RecentlyOpenedFilesList|code-editor" --output-on-failure`
- `git diff --check`
- `python3 tools/scripts/skill_sync_check.py`
- `python3 tools/scripts/version_bump_check.py --mode=report`
- `pulp_cli_version_check`

Namespace:
- `shipyard cloud run build feature/view-code-editor-coverage-493`
- Run: https://github.com/danielraffel/pulp/actions/runs/25160783641