### PR TITLE
test(view): cover accessibility tree edges

### DIFF
--- a/test/test_accessibility_tree.cpp
+++ b/test/test_accessibility_tree.cpp
@@ -56,6 +56,18 @@ TEST_CASE("snapshot captures role + label + value", "[a11y][harness]") {
     REQUIRE(nodes[1].depth == 0);
 }
 
+TEST_CASE("snapshot excludes root even when it is announceable",
+          "[a11y][harness]") {
+    Probe root;
+    root.set_access_role(View::AccessRole::group);
+    root.set_access_label("Root");
+
+    REQUIRE(snapshot_accessibility_tree(root).empty());
+    REQUIRE(count_announceable(root) == 0);
+    REQUIRE(find_by_role_and_label(root, View::AccessRole::group, "Root")
+            == nullptr);
+}
+
 TEST_CASE("count_announceable excludes AccessRole::none", "[a11y][harness]") {
     Probe root;
     // root has role::none by default
@@ -69,6 +81,31 @@ TEST_CASE("count_announceable excludes AccessRole::none", "[a11y][harness]") {
     c->set_access_role(View::AccessRole::meter);
     root.add_child(std::move(c));
     REQUIRE(count_announceable(root) == 2);
+}
+
+TEST_CASE("snapshot walks through non-announceable containers",
+          "[a11y][harness]") {
+    Probe root;
+
+    auto hidden_container = std::make_unique<Probe>();
+    hidden_container->set_access_label("Layout Only");
+
+    auto meter = std::make_unique<Probe>();
+    meter->set_access_role(View::AccessRole::meter);
+    meter->set_access_label("Output");
+    hidden_container->add_child(std::move(meter));
+
+    root.add_child(std::move(hidden_container));
+
+    auto nodes = snapshot_accessibility_tree(root);
+    REQUIRE(nodes.size() == 2);
+    REQUIRE(nodes[0].role == View::AccessRole::none);
+    REQUIRE(nodes[0].label == "Layout Only");
+    REQUIRE(nodes[0].depth == 0);
+    REQUIRE(nodes[1].role == View::AccessRole::meter);
+    REQUIRE(nodes[1].label == "Output");
+    REQUIRE(nodes[1].depth == 1);
+    REQUIRE(count_announceable(root) == 1);
 }
 
 TEST_CASE("find_by_role_and_label returns nullptr when absent",

--- a/test/test_tree_view.cpp
+++ b/test/test_tree_view.cpp
@@ -5,6 +5,25 @@
 using namespace pulp::view;
 using namespace pulp::canvas;
 
+namespace {
+
+MouseEvent mouse_down(float x, float y, int click_count = 1) {
+    MouseEvent e;
+    e.position = {x, y};
+    e.is_down = true;
+    e.click_count = click_count;
+    return e;
+}
+
+KeyEvent key_down(KeyCode key) {
+    KeyEvent e;
+    e.key = key;
+    e.is_down = true;
+    return e;
+}
+
+} // namespace
+
 TEST_CASE("TreeNode add children", "[view][tree]") {
     TreeNode root;
     auto& child1 = root.add_child("Synths");
@@ -50,13 +69,67 @@ TEST_CASE("TreeView on_select callback", "[view][tree]") {
 
     // Simulate click on the first visible item
     tree.set_bounds({0, 0, 300, 400});
-    MouseEvent e;
-    e.position = {50, 5}; // should hit "Synths"
-    e.is_down = true;
-    e.click_count = 1;
-    tree.on_mouse_event(e);
+    tree.on_mouse_event(mouse_down(50, 5)); // should hit "Synths"
 
     REQUIRE(selected_label == "Synths");
+}
+
+TEST_CASE("TreeView ignores mouse up and misses", "[view][tree]") {
+    TreeView tree;
+    tree.root().add_child("Synths");
+    tree.set_bounds({0, 0, 300, 400});
+
+    int selected_count = 0;
+    tree.on_select = [&](TreeNode&) { ++selected_count; };
+
+    auto up = mouse_down(50, 5);
+    up.is_down = false;
+    tree.on_mouse_event(up);
+    tree.on_mouse_event(mouse_down(50, 200));
+
+    REQUIRE(selected_count == 0);
+    REQUIRE(tree.selected_node() == nullptr);
+}
+
+TEST_CASE("TreeView triangle click toggles without selecting", "[view][tree]") {
+    TreeView tree;
+    auto& synths = tree.root().add_child("Synths");
+    synths.add_child("Bass");
+    tree.set_bounds({0, 0, 300, 400});
+
+    std::string toggled_label;
+    bool toggled_state = true;
+    int select_count = 0;
+    tree.on_toggle = [&](TreeNode& node, bool expanded) {
+        toggled_label = node.label;
+        toggled_state = expanded;
+    };
+    tree.on_select = [&](TreeNode&) { ++select_count; };
+
+    tree.on_mouse_event(mouse_down(4, 5));
+
+    REQUIRE(synths.expanded);
+    REQUIRE(toggled_label == "Synths");
+    REQUIRE(toggled_state);
+    REQUIRE(select_count == 0);
+    REQUIRE(tree.selected_node() == nullptr);
+}
+
+TEST_CASE("TreeView double click activates without selecting", "[view][tree]") {
+    TreeView tree;
+    tree.root().add_child("Synths");
+    tree.set_bounds({0, 0, 300, 400});
+
+    std::string activated_label;
+    int select_count = 0;
+    tree.on_activate = [&](TreeNode& node) { activated_label = node.label; };
+    tree.on_select = [&](TreeNode&) { ++select_count; };
+
+    tree.on_mouse_event(mouse_down(50, 5, 2));
+
+    REQUIRE(activated_label == "Synths");
+    REQUIRE(select_count == 0);
+    REQUIRE(tree.selected_node() == nullptr);
 }
 
 TEST_CASE("TreeView key right expands node", "[view][tree]") {
@@ -66,20 +139,62 @@ TEST_CASE("TreeView key right expands node", "[view][tree]") {
 
     // Select synths first
     tree.set_bounds({0, 0, 300, 400});
-    MouseEvent click;
-    click.position = {50, 5};
-    click.is_down = true;
-    click.click_count = 1;
-    tree.on_mouse_event(click);
+    tree.on_mouse_event(mouse_down(50, 5));
 
     REQUIRE(tree.selected_node() != nullptr);
     REQUIRE_FALSE(tree.selected_node()->expanded);
 
-    KeyEvent right;
-    right.key = KeyCode::right;
-    right.is_down = true;
-    REQUIRE(tree.on_key_event(right));
+    REQUIRE(tree.on_key_event(key_down(KeyCode::right)));
     REQUIRE(tree.selected_node()->expanded);
+}
+
+TEST_CASE("TreeView key left collapses expanded selection", "[view][tree]") {
+    TreeView tree;
+    auto& synths = tree.root().add_child("Synths");
+    synths.expanded = true;
+    synths.add_child("Bass");
+    tree.set_selected_node(&synths);
+
+    bool collapsed = false;
+    tree.on_toggle = [&](TreeNode& node, bool expanded) {
+        collapsed = node.label == "Synths" && !expanded;
+    };
+
+    REQUIRE(tree.on_key_event(key_down(KeyCode::left)));
+    REQUIRE_FALSE(synths.expanded);
+    REQUIRE(collapsed);
+}
+
+TEST_CASE("TreeView ignores unhandled key edges", "[view][tree]") {
+    TreeView tree;
+    auto& leaf = tree.root().add_child("Leaf");
+
+    REQUIRE_FALSE(tree.on_key_event(key_down(KeyCode::right)));
+
+    tree.set_selected_node(&leaf);
+    REQUIRE_FALSE(tree.on_key_event(key_down(KeyCode::right)));
+
+    auto left_up = key_down(KeyCode::left);
+    left_up.is_down = false;
+    REQUIRE_FALSE(tree.on_key_event(left_up));
+
+    REQUIRE_FALSE(tree.on_key_event(key_down(KeyCode::enter)));
+}
+
+TEST_CASE("TreeView user data lookup finds nested nodes only for non-null data",
+          "[view][tree]") {
+    TreeView tree;
+    int root_payload = 1;
+    int nested_payload = 2;
+
+    tree.root().user_data = &root_payload;
+    auto& group = tree.root().add_child("Group");
+    auto& nested = group.add_child("Nested");
+    nested.user_data = &nested_payload;
+
+    REQUIRE(tree.find_node_by_user_data(&nested_payload) == &nested);
+    REQUIRE(tree.find_node_by_user_data(nullptr) == nullptr);
+    REQUIRE(tree.find_node_by_user_data(&root_payload) == &tree.root());
 }
 
 TEST_CASE("TreeView paint produces draw commands", "[view][tree]") {


### PR DESCRIPTION
## Scope
- Adds focused unit coverage for `snapshot_accessibility_tree` root exclusion and traversal through non-announceable containers.
- Adds focused TreeView edge coverage for mouse-up/miss handling, disclosure toggles, double-click activation, key handling, and user-data lookup.
- Test-only change in `test/test_accessibility_tree.cpp` and `test/test_tree_view.cpp`; no production or CMake changes.

## Validation
- `cmake -S . -B build-coverage-view-a11y -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build-coverage-view-a11y --target pulp-test-accessibility-tree pulp-test-tree-view -j$(sysctl -n hw.ncpu)`
- `./build-coverage-view-a11y/test/pulp-test-accessibility-tree`
- `./build-coverage-view-a11y/test/pulp-test-tree-view`
- `ctest --test-dir build-coverage-view-a11y --output-on-failure -R "^(snapshot|count_announceable|find_by_role_and_label|TreeNode|TreeView)"`
- `git diff --check`
- `python3 tools/scripts/skill_sync_check.py`
- `python3 tools/scripts/version_bump_check.py --mode=report`
- `source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh" && pulp_cli_version_check`

## Namespace
- https://github.com/danielraffel/pulp/actions/runs/25160932302

Refs #493
Refs #641