### PR TITLE
fix(midi): clear stale running status on undefined system bytes

### DIFF
--- a/core/midi/src/running_status.cpp
+++ b/core/midi/src/running_status.cpp
@@ -85,7 +85,16 @@ void RunningStatusParser::feed(const uint8_t* data, std::size_t size) {
             }
             // Channel voice status or system common
             int expected = expected_data_bytes(b);
-            if (expected < 0) continue;  // unknown — drop
+            if (expected < 0) {
+                // Unknown non-realtime statuses are still status bytes.
+                // Drop them, but cancel any in-flight/running message so
+                // later stray data cannot complete under stale state.
+                running_status_ = 0;
+                current_system_common_ = 0;
+                data_expected_ = 0;
+                data_count_ = 0;
+                continue;
+            }
             if ((b & 0xF0) >= 0x80 && (b & 0xF0) <= 0xE0) {
                 // Channel voice — becomes running status
                 running_status_ = b;

--- a/test/test_running_status.cpp
+++ b/test/test_running_status.cpp
@@ -202,6 +202,48 @@ TEST_CASE("empty sysex and unknown statuses are ignored",
     REQUIRE(shorts == std::vector<uint8_t>{0xF6});
 }
 
+TEST_CASE("undefined system statuses clear stale running state",
+          "[midi][running-status][issue-645]") {
+    auto v = parse({
+        0x90, 0x3C, 0x7F,  // establish note-on running status
+        0xF4,              // undefined system-common status cancels it
+        0x3D, 0x7F,        // would emit a stale note if not cleared
+        0x90, 0x40,        // partial note-on data
+        0xF5,              // undefined status also clears partial data
+        0x41,              // must not complete the interrupted note
+    });
+
+    REQUIRE(v.size() == 1);
+    REQUIRE(v[0].status == 0x90);
+    REQUIRE(v[0].d1 == 0x3C);
+    REQUIRE(v[0].d2 == 0x7F);
+}
+
+TEST_CASE("system common interruption inside sysex is reprocessed",
+          "[midi][running-status][issue-645]") {
+    RunningStatusParser p;
+    std::vector<uint8_t> sx;
+    std::vector<Captured> shorts;
+    p.on_sysex([&](const uint8_t* d, std::size_t s) {
+        sx.assign(d, d + s);
+    });
+    p.on_short_message([&](const MidiEvent& e) {
+        const auto& m = e.message;
+        shorts.push_back({m.data()[0],
+                          m.length() > 1 ? m.data()[1] : uint8_t(0),
+                          m.length() > 2 ? m.data()[2] : uint8_t(0)});
+    });
+
+    std::vector<uint8_t> stream = {0xF0, 0x01, 0xF2, 0x10, 0x20};
+    p.feed(stream.data(), stream.size());
+
+    REQUIRE(sx.empty());
+    REQUIRE(shorts.size() == 1);
+    REQUIRE(shorts[0].status == 0xF2);
+    REQUIRE(shorts[0].d1 == 0x10);
+    REQUIRE(shorts[0].d2 == 0x20);
+}
+
 TEST_CASE("feed tolerates missing sinks and empty buffers",
           "[midi][running-status][issue-645]") {
     RunningStatusParser p;

--- a/test/test_running_status.cpp
+++ b/test/test_running_status.cpp
@@ -219,6 +219,26 @@ TEST_CASE("undefined system statuses clear stale running state",
     REQUIRE(v[0].d2 == 0x7F);
 }
 
+TEST_CASE("undefined system statuses cancel pending system common data",
+          "[midi][running-status][issue-645]") {
+    auto v = parse({
+        0xF2, 0x10,  // pending song-position pointer with one missing byte
+        0xF4,        // undefined system-common status cancels the pending F2
+        0x20,        // must not complete the interrupted F2
+        0xF1,        // pending MTC quarter-frame
+        0xF5,        // undefined system-common status cancels the pending F1
+        0x05,        // must not complete the interrupted F1
+        0x90, 0x3C, 0x7F,
+        0xF4,        // also cancels established channel running status
+        0x3D, 0x7F,
+    });
+
+    REQUIRE(v.size() == 1);
+    REQUIRE(v[0].status == 0x90);
+    REQUIRE(v[0].d1 == 0x3C);
+    REQUIRE(v[0].d2 == 0x7F);
+}
+
 TEST_CASE("system common interruption inside sysex is reprocessed",
           "[midi][running-status][issue-645]") {
     RunningStatusParser p;


### PR DESCRIPTION
## Summary
- Clear stale running status and partial message state when undefined non-realtime system status bytes are dropped.
- Add regressions for undefined system statuses after running status, partial channel-message interruption, and system-common reprocessing from inside sysex.

## Validation
- cmake --build build --target pulp-test-running-status -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-running-status
- ctest --test-dir build -R "undefined system statuses|system common interruption|running status" --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py
- python3 tools/scripts/version_bump_check.py --mode=report
- GITHUB_PR_TITLE="fix(midi): clear stale running status on undefined system bytes" python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh" && pulp_cli_version_check

## Namespace
- https://github.com/danielraffel/pulp/actions/runs/25161407405

Refs #645
Refs #641

Version-Bump: skip reason="Coverage tranche hardening for internal MIDI parser edge behavior; no public API or release surface change."