### PR TITLE
fix(canvas): normalize wrapped color hues

### DIFF
--- a/core/canvas/src/color.cpp
+++ b/core/canvas/src/color.cpp
@@ -6,6 +6,18 @@
 
 namespace pulp::canvas {
 
+namespace {
+
+float normalize_hue_degrees(float h) {
+    h = std::fmod(h, 360.0f);
+    if (h < 0.0f) {
+        h += 360.0f;
+    }
+    return h;
+}
+
+}  // namespace
+
 // ── HSV Conversion ──────────────────────────────────────────────────────────
 
 Color::HSV Color::to_hsv() const {
@@ -35,7 +47,7 @@ Color::HSV Color::to_hsv() const {
 }
 
 Color Color::from_hsv(HSV hsv, float alpha) {
-    float h = std::fmod(hsv.h, 360.0f) / 60.0f;
+    float h = normalize_hue_degrees(hsv.h) / 60.0f;
     float s = std::clamp(hsv.s, 0.0f, 1.0f);
     float v = std::clamp(hsv.v, 0.0f, 1.0f);
 
@@ -105,7 +117,7 @@ Color Color::from_hsl(HSL hsl, float alpha) {
 
     float q = (l < 0.5f) ? l * (1.0f + s) : l + s - l * s;
     float p = 2.0f * l - q;
-    float h = std::fmod(hsl.h, 360.0f) / 360.0f;
+    float h = normalize_hue_degrees(hsl.h) / 360.0f;
 
     return rgba(
         std::clamp(hue2rgb(p, q, h + 1.0f / 3.0f), 0.0f, 1.0f),

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -260,6 +260,25 @@ TEST_CASE("Color HSV round-trip", "[canvas][color]") {
     REQUIRE(ghsv.v == Catch::Approx(0.5f).margin(0.01f));
 }
 
+TEST_CASE("Color HSV clamps channels and normalizes wrapped hues",
+          "[canvas][color][issue-641]") {
+    auto clamped = Color::rgba(1.5f, -0.25f, 0.5f).to_hsv();
+    REQUIRE(clamped.h == Catch::Approx(330.0f).margin(1.0f));
+    REQUIRE(clamped.s == Catch::Approx(1.0f).margin(0.01f));
+    REQUIRE(clamped.v == Catch::Approx(1.0f).margin(0.01f));
+
+    auto negative = Color::from_hsv({-60.0f, 1.0f, 1.0f}, 0.25f);
+    REQUIRE(negative.r == Catch::Approx(1.0f).margin(0.01f));
+    REQUIRE(negative.g == Catch::Approx(0.0f).margin(0.01f));
+    REQUIRE(negative.b == Catch::Approx(1.0f).margin(0.01f));
+    REQUIRE(negative.a == Catch::Approx(0.25f));
+
+    auto overflow = Color::from_hsv({420.0f, 2.0f, 2.0f});
+    REQUIRE(overflow.r == Catch::Approx(1.0f).margin(0.01f));
+    REQUIRE(overflow.g == Catch::Approx(1.0f).margin(0.01f));
+    REQUIRE(overflow.b == Catch::Approx(0.0f).margin(0.01f));
+}
+
 TEST_CASE("Color HSL round-trip", "[canvas][color]") {
     auto blue = Color::rgba(0.0f, 0.0f, 1.0f);
     auto hsl = blue.to_hsl();
@@ -269,6 +288,25 @@ TEST_CASE("Color HSL round-trip", "[canvas][color]") {
     auto back = Color::from_hsl(hsl);
     REQUIRE(back.b == Catch::Approx(1.0f).margin(0.01f));
     REQUIRE(back.r == Catch::Approx(0.0f).margin(0.01f));
+}
+
+TEST_CASE("Color HSL clamps channels and normalizes wrapped hues",
+          "[canvas][color][issue-641]") {
+    auto clamped = Color::rgba(-1.0f, 0.25f, 2.0f).to_hsl();
+    REQUIRE(clamped.h == Catch::Approx(225.0f).margin(1.0f));
+    REQUIRE(clamped.s == Catch::Approx(1.0f).margin(0.01f));
+    REQUIRE(clamped.l == Catch::Approx(0.5f).margin(0.01f));
+
+    auto negative = Color::from_hsl({-120.0f, 1.0f, 0.5f}, 0.4f);
+    REQUIRE(negative.r == Catch::Approx(0.0f).margin(0.01f));
+    REQUIRE(negative.g == Catch::Approx(0.0f).margin(0.01f));
+    REQUIRE(negative.b == Catch::Approx(1.0f).margin(0.01f));
+    REQUIRE(negative.a == Catch::Approx(0.4f));
+
+    auto gray = Color::from_hsl({45.0f, -1.0f, 2.0f});
+    REQUIRE(gray.r == Catch::Approx(1.0f));
+    REQUIRE(gray.g == Catch::Approx(1.0f));
+    REQUIRE(gray.b == Catch::Approx(1.0f));
 }
 
 TEST_CASE("Color OKLCH round-trip", "[canvas][color]") {
@@ -293,6 +331,20 @@ TEST_CASE("Color OKLCH round-trip", "[canvas][color]") {
     auto black = Color::rgba(0.0f, 0.0f, 0.0f);
     auto blch = black.to_oklch();
     REQUIRE(blch.L == Catch::Approx(0.0f).margin(0.01f));
+}
+
+TEST_CASE("Color OKLCH clamps out-of-gamut conversion inputs",
+          "[canvas][color][issue-641]") {
+    auto dark = Color::from_oklch({-0.5f, -0.25f, 90.0f}, 0.3f);
+    REQUIRE(dark.r8() == 0);
+    REQUIRE(dark.g8() == 0);
+    REQUIRE(dark.b8() == 0);
+    REQUIRE(dark.a == Catch::Approx(0.3f));
+
+    auto bright = Color::from_oklch({1.5f, 0.0f, 720.0f});
+    REQUIRE(bright.r8() == 255);
+    REQUIRE(bright.g8() == 255);
+    REQUIRE(bright.b8() == 255);
 }
 
 TEST_CASE("Color encode/decode round-trip", "[canvas][color]") {


### PR DESCRIPTION
## Summary
- Normalize negative and overflow hue values before HSV/HSL sector math.
- Add focused coverage for HSV/HSL clamping and hue wrapping plus OKLCH out-of-gamut clamps.

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_HIGHWAY=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/highway-src -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/mbedtls-src -DFETCHCONTENT_SOURCE_DIR_THREEJS=/Users/danielraffel/Code/pulp-coverage-audio-platform/build/_deps/threejs-src
- cmake --build build --target pulp-test-canvas -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-canvas "[canvas][color]"
- ctest --test-dir build -R "Color HSV|Color HSL|Color OKLCH|Color encode" --output-on-failure
- git diff --check
- python3 tools/scripts/skill_sync_check.py
- python3 tools/scripts/version_bump_check.py --mode=report
- GITHUB_PR_TITLE="fix(canvas): normalize wrapped color hues" python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report --require-bump-for-fix-feat
- source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh" && pulp_cli_version_check

## Namespace
- https://github.com/danielraffel/pulp/actions/runs/25162335404

Refs #641

Version-Bump: skip reason="Coverage tranche hardening for canvas color conversion edge behavior; no public API or release surface change."