### PR TITLE
test(runtime): cover URL parser edge paths

### DIFF
--- a/core/runtime/src/http.cpp
+++ b/core/runtime/src/http.cpp
@@ -8,8 +8,9 @@
 
 #include <httplib.h>
 
-#include <regex>
+#include <charconv>
 #include <fstream>
+#include <regex>
 
 namespace pulp::runtime {
 
@@ -25,7 +26,18 @@ static bool parse_url(std::string_view url, std::string& scheme,
 
     scheme = match[1];
     host = match[2];
-    port = match[3].length() > 0 ? std::stoi(match[3]) : (scheme == "https" ? 443 : 80);
+    port = scheme == "https" ? 443 : 80;
+    if (match[3].length() > 0) {
+        const auto port_str = match[3].str();
+        int parsed_port = 0;
+        const auto* begin = port_str.data();
+        const auto* end = begin + port_str.size();
+        const auto result = std::from_chars(begin, end, parsed_port);
+        if (result.ec != std::errc{} || result.ptr != end || parsed_port < 1 || parsed_port > 65535)
+            return false;
+        port = parsed_port;
+    }
+
     path = match[4].length() > 0 ? match[4].str() : "/";
     return true;
 }

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -5,6 +5,7 @@
 #include <pulp/runtime/inter_process_lock.hpp>
 #include <pulp/runtime/child_process.hpp>
 #include <pulp/runtime/base64.hpp>
+#include <pulp/runtime/http.hpp>
 #include <pulp/runtime/range.hpp>
 #include <fstream>
 #include <filesystem>
@@ -209,6 +210,36 @@ TEST_CASE("base64 binary round-trip", "[runtime][base64]") {
     auto decoded = base64_decode(encoded);
     REQUIRE(decoded.has_value());
     REQUIRE(*decoded == data);
+}
+
+// ── HTTP URL parsing ───────────────────────────────────────────────────
+
+TEST_CASE("HTTP helpers reject malformed URLs without transport work",
+          "[runtime][http][url][issue-641]") {
+    const auto get_response = http_get("ftp://example.com/file", 1);
+    REQUIRE(get_response.status_code == 0);
+    REQUIRE(get_response.error == "Invalid URL");
+
+    const auto post_response = http_post("http:///missing-host", "{}", "application/json", 1);
+    REQUIRE(post_response.status_code == 0);
+    REQUIRE(post_response.error == "Invalid URL");
+
+    REQUIRE_FALSE(http_download("example.com/no-scheme", "/tmp/pulp-url-invalid-download", 1));
+}
+
+TEST_CASE("HTTP helpers reject invalid numeric URL ports",
+          "[runtime][http][url][issue-641]") {
+    const auto zero_port = http_get("http://example.com:0/path", 1);
+    REQUIRE(zero_port.status_code == 0);
+    REQUIRE(zero_port.error == "Invalid URL");
+
+    const auto overflow_port = http_get("http://example.com:999999999999999999999/path", 1);
+    REQUIRE(overflow_port.status_code == 0);
+    REQUIRE(overflow_port.error == "Invalid URL");
+
+    const auto too_large_port = http_post("http://example.com:65536/path", "body", "text/plain", 1);
+    REQUIRE(too_large_port.status_code == 0);
+    REQUIRE(too_large_port.error == "Invalid URL");
 }
 
 // ── Range ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Scope
- Adds focused runtime HTTP URL parser coverage for malformed schemes, missing hosts, invalid download URLs, and invalid numeric ports.
- Hardens the private URL parser to reject port `0`, ports above `65535`, and numeric overflow through the existing `Invalid URL` path.
- No CMake wiring changes; uses the existing `pulp-test-runtime-utils` target.

## Validation
- `cmake -S . -B build-runtime-url-coverage -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build-runtime-url-coverage --target pulp-test-runtime-utils -j$(sysctl -n hw.ncpu)`
- `./build-runtime-url-coverage/test/pulp-test-runtime-utils "*[runtime][http][url][issue-641]*"`
- `ctest --test-dir build-runtime-url-coverage -R "HTTP helpers reject.*URL|HTTP helpers reject invalid numeric URL ports|http.*url" --output-on-failure`
- `git diff --check`
- `python3 tools/scripts/skill_sync_check.py`
- `python3 tools/scripts/version_bump_check.py --mode=report`
- `source "$(git rev-parse --show-toplevel)/tools/scripts/cli_version_check.sh" && pulp_cli_version_check`
- `shipyard pr --skip-target mac --skip-target ubuntu --skip-target windows` created this PR, then exited with expected `No targets remain after --skip-target filtering.`

## Namespace
- https://github.com/danielraffel/pulp/actions/runs/25162384740

Refs #641
Refs #493

Version-Bump: skip reason="Internal runtime URL parser hardening and coverage; no public API or release surface change."