### PR TITLE
test(state): cover state tree listener detach edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0680"></a>
+## [0.69.0]
+
 ## [0.68.0] - 2026-04-30
 
 - fix(view): bubble click up to ancestor on_click handler (#1067) ([#1073](https://github.com/danielraffel/pulp/pull/1073))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.68.0
+    VERSION 0.69.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/state/include/pulp/state/state_tree.hpp
+++ b/core/state/include/pulp/state/state_tree.hpp
@@ -109,6 +109,8 @@ public:
     /// Listen for child added/removed
     int add_child_added_listener(ChildListener listener);
     int add_child_removed_listener(ChildListener listener);
+    void remove_child_added_listener(int id);
+    void remove_child_removed_listener(int id);
 
     // ── Serialization ───────────────────────────────────────────────────
 

--- a/core/state/src/state_tree.cpp
+++ b/core/state/src/state_tree.cpp
@@ -132,6 +132,20 @@ int StateTree::add_child_removed_listener(ChildListener listener) {
     return id;
 }
 
+void StateTree::remove_child_added_listener(int id) {
+    child_added_listeners_.erase(
+        std::remove_if(child_added_listeners_.begin(), child_added_listeners_.end(),
+                      [id](auto& e) { return e.first == id; }),
+        child_added_listeners_.end());
+}
+
+void StateTree::remove_child_removed_listener(int id) {
+    child_removed_listeners_.erase(
+        std::remove_if(child_removed_listeners_.begin(), child_removed_listeners_.end(),
+                      [id](auto& e) { return e.first == id; }),
+        child_removed_listeners_.end());
+}
+
 void StateTree::notify_property_changed(std::string_view name,
                                         const PropertyValue& old_val,
                                         const PropertyValue& new_val) {

--- a/core/state/src/state_tree_sync.cpp
+++ b/core/state/src/state_tree_sync.cpp
@@ -43,6 +43,10 @@ void StateTreeSynchroniser::attach(StateTree::Ptr tree) {
 void StateTreeSynchroniser::detach() {
     if (tree_ && listener_id_ >= 0)
         tree_->remove_listener(listener_id_);
+    if (tree_ && child_listener_ids_.size() >= 2) {
+        tree_->remove_child_added_listener(child_listener_ids_[0]);
+        tree_->remove_child_removed_listener(child_listener_ids_[1]);
+    }
     listener_id_ = -1;
     child_listener_ids_.clear();
     tree_ = nullptr;

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -141,6 +141,32 @@ TEST_CASE("StateTree child added listener", "[state][tree]") {
     REQUIRE(added_count == 2);
 }
 
+TEST_CASE("StateTree child listener removal stops callbacks", "[state][tree]") {
+    auto root = StateTree::create("root");
+    auto first = StateTree::create("first");
+    root->add_child(first);
+
+    int added_count = 0;
+    int removed_count = 0;
+    int added_id = root->add_child_added_listener(
+        [&](StateTree&, StateTree&, int) { added_count++; });
+    int removed_id = root->add_child_removed_listener(
+        [&](StateTree&, StateTree&, int) { removed_count++; });
+
+    root->add_child(StateTree::create("second"));
+    root->remove_child(first.get());
+    REQUIRE(added_count == 1);
+    REQUIRE(removed_count == 1);
+
+    root->remove_child_added_listener(added_id);
+    root->remove_child_removed_listener(removed_id);
+    root->add_child(StateTree::create("third"));
+    root->remove_child(0);
+
+    REQUIRE(added_count == 1);
+    REQUIRE(removed_count == 1);
+}
+
 TEST_CASE("StateTree remove listener", "[state][tree]") {
     auto tree = StateTree::create("test");
 
@@ -344,6 +370,16 @@ TEST_CASE("CachedProperty move transfers listener ownership", "[state][cached]")
     REQUIRE_FALSE(moved.get());
 }
 
+TEST_CASE("CachedProperty unbound set only updates local cache", "[state][cached]") {
+    CachedProperty<int64_t> size;
+
+    REQUIRE_FALSE(size.is_bound());
+    REQUIRE(size.get() == 0);
+
+    size.set(512);
+    REQUIRE(size.get() == 512);
+}
+
 // ── StateTreeSynchroniser ───────────────────────────────────────────────
 
 TEST_CASE("StateTreeSynchroniser records property and child deltas", "[state][sync]") {
@@ -381,10 +417,13 @@ TEST_CASE("StateTreeSynchroniser detach clears pending and stops recording", "[s
     sync.attach(tree);
 
     tree->set("name", std::string("before"));
+    tree->add_child(StateTree::create("before_child"));
     sync.detach();
     REQUIRE(sync.take_deltas().empty());
 
     tree->set("name", std::string("after"));
+    tree->add_child(StateTree::create("after_child"));
+    tree->remove_child(0);
     REQUIRE(sync.take_deltas().empty());
 }
 


### PR DESCRIPTION
## Summary
- Add focused Phase 3 state-tree coverage for child listener removal and synchroniser detach child-mutation edges.
- Fix StateTreeSynchroniser::detach() so child add/remove listeners are unregistered along with property listeners.
- Cover unbound CachedProperty local-cache behavior.

Refs #641.
Refs #493.

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF
- cmake --build build --target pulp-test-state-tree -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-state-tree
- ctest --test-dir build -R "StateTree|CachedProperty|StateTreeSynchroniser|ObservableValue" --output-on-failure
- git diff --check

## Notes
- Worktree: /Users/danielraffel/Code/pulp-state-properties-coverage-641-next2
- Avoids preset-manager files owned by the main tranche.