### PR TITLE
test(state): cover undo history edge cases

### DIFF
--- a/core/state/include/pulp/state/edit_history.hpp
+++ b/core/state/include/pulp/state/edit_history.hpp
@@ -44,6 +44,9 @@ public:
     /// replaces it (merging rapid small changes into one undo step).
     void perform(std::unique_ptr<EditAction> action) {
         action->redo();
+        // A new edit invalidates redo history even when it coalesces into
+        // the current undo step.
+        redo_stack_.clear();
         // Coalesce: if same description as last action, replace it
         if (coalesce_ && !undo_stack_.empty() &&
             !action->description().empty() &&
@@ -51,8 +54,6 @@ public:
             undo_stack_.back() = std::move(action);
             return;
         }
-        // Clear any redo actions
-        redo_stack_.clear();
         undo_stack_.push_back(std::move(action));
         // Enforce depth limit
         while (undo_stack_.size() > max_depth_)

--- a/test/test_edit_history.cpp
+++ b/test/test_edit_history.cpp
@@ -114,12 +114,14 @@ TEST_CASE("EditHistory coalesced new action clears redo stack", "[state][undo]")
     REQUIRE(history.undo());
     REQUIRE(v == 1);
     REQUIRE(history.can_redo());
+    REQUIRE(history.redo_count() == 1);
 
     history.perform([&]() { v = 2; }, [&]() { v = 1; }, "Drag");
 
     REQUIRE(v == 2);
     REQUIRE(history.undo_count() == 1);
     REQUIRE_FALSE(history.can_redo());
+    REQUIRE(history.redo_count() == 0);
 }
 
 TEST_CASE("EditHistory empty undo/redo returns false", "[state][undo]") {

--- a/test/test_edit_history.cpp
+++ b/test/test_edit_history.cpp
@@ -61,6 +61,67 @@ TEST_CASE("EditHistory redo cleared on new action", "[state][undo]") {
     REQUIRE_FALSE(history.can_redo());
 }
 
+TEST_CASE("EditHistory coalesces matching non-empty descriptions", "[state][undo]") {
+    EditHistory history;
+    int v = 0;
+
+    history.perform([&]() { v = 1; }, [&]() { v = 0; }, "Drag");
+    history.perform([&]() { v = 2; }, [&]() { v = 1; }, "Drag");
+
+    REQUIRE(v == 2);
+    REQUIRE(history.undo_count() == 1);
+    REQUIRE(history.undo_description() == "Drag");
+
+    REQUIRE(history.undo());
+    REQUIRE(v == 1);
+    REQUIRE_FALSE(history.can_undo());
+}
+
+TEST_CASE("EditHistory does not coalesce empty descriptions", "[state][undo]") {
+    EditHistory history;
+    int v = 0;
+
+    history.perform([&]() { v = 1; }, [&]() { v = 0; });
+    history.perform([&]() { v = 2; }, [&]() { v = 1; });
+
+    REQUIRE(v == 2);
+    REQUIRE(history.undo_count() == 2);
+    REQUIRE(history.undo_description().empty());
+}
+
+TEST_CASE("EditHistory coalescing can be disabled", "[state][undo]") {
+    EditHistory history;
+    int v = 0;
+    history.set_coalesce(false);
+
+    history.perform([&]() { v = 1; }, [&]() { v = 0; }, "Drag");
+    history.perform([&]() { v = 2; }, [&]() { v = 1; }, "Drag");
+
+    REQUIRE(v == 2);
+    REQUIRE(history.undo_count() == 2);
+
+    REQUIRE(history.undo());
+    REQUIRE(v == 1);
+    REQUIRE(history.can_undo());
+}
+
+TEST_CASE("EditHistory coalesced new action clears redo stack", "[state][undo]") {
+    EditHistory history;
+    int v = 0;
+
+    history.perform([&]() { v = 1; }, [&]() { v = 0; }, "Drag");
+    history.perform([&]() { v = 10; }, [&]() { v = 1; }, "Commit");
+    REQUIRE(history.undo());
+    REQUIRE(v == 1);
+    REQUIRE(history.can_redo());
+
+    history.perform([&]() { v = 2; }, [&]() { v = 1; }, "Drag");
+
+    REQUIRE(v == 2);
+    REQUIRE(history.undo_count() == 1);
+    REQUIRE_FALSE(history.can_redo());
+}
+
 TEST_CASE("EditHistory empty undo/redo returns false", "[state][undo]") {
     EditHistory history;
     REQUIRE_FALSE(history.undo());

--- a/test/test_undo_manager.cpp
+++ b/test/test_undo_manager.cpp
@@ -66,6 +66,24 @@ TEST_CASE("UndoManager transaction groups actions", "[state][undo]") {
     REQUIRE(y == 0);
 }
 
+TEST_CASE("UndoManager empty transaction end and cancel are no-ops", "[state][undo]") {
+    UndoManager um;
+    int change_count = 0;
+    um.on_state_changed = [&] { ++change_count; };
+
+    um.begin_transaction("Empty end");
+    um.end_transaction();
+    REQUIRE_FALSE(um.can_undo());
+    REQUIRE(um.undo_count() == 0);
+    REQUIRE(change_count == 0);
+
+    um.begin_transaction("Empty cancel");
+    um.cancel_transaction();
+    REQUIRE_FALSE(um.can_undo());
+    REQUIRE(um.undo_count() == 0);
+    REQUIRE(change_count == 0);
+}
+
 TEST_CASE("UndoManager cancel_transaction reverts", "[state][undo]") {
     UndoManager um;
     int value = 0;
@@ -137,6 +155,49 @@ TEST_CASE("UndoManager on_state_changed callback", "[state][undo]") {
 
     um.redo();
     REQUIRE(change_count == 3);
+}
+
+TEST_CASE("UndoManager actions with missing callbacks are no-ops", "[state][undo]") {
+    UndoManager um;
+    int redo_count = 0;
+
+    um.perform(UndoAction::create("Redo only",
+        {},
+        [&] { ++redo_count; }));
+
+    REQUIRE(redo_count == 1);
+    REQUIRE(um.can_undo());
+    REQUIRE(um.undo());
+    REQUIRE(redo_count == 1);
+    REQUIRE(um.can_redo());
+    REQUIRE(um.redo());
+    REQUIRE(redo_count == 2);
+
+    um.perform(UndoAction::create("Undo only",
+        [&] { --redo_count; },
+        {}));
+
+    REQUIRE(redo_count == 2);
+    REQUIRE(um.undo());
+    REQUIRE(redo_count == 1);
+}
+
+TEST_CASE("UndoManager missing callbacks inside cancel_transaction are no-ops", "[state][undo]") {
+    UndoManager um;
+    int value = 0;
+
+    um.begin_transaction("Partial callbacks");
+    um.perform(UndoAction::create("Redo only",
+        {},
+        [&] { value = 7; }));
+    um.perform(UndoAction::create("Undo only",
+        [&] { value = 3; },
+        {}));
+
+    REQUIRE(value == 7);
+    um.cancel_transaction();
+    REQUIRE(value == 3);
+    REQUIRE_FALSE(um.can_undo());
 }
 
 TEST_CASE("UndoManager add_without_executing", "[state][undo]") {


### PR DESCRIPTION
Version-Bump: sdk=patch reason="EditHistory redo invalidation fix is behavioral, not API expansion."

Namespace: https://github.com/danielraffel/pulp/actions/runs/25165878118