### PR TITLE
fix(audio): ignore invalid load-measurer timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
 <a id="v0680"></a>
+## [0.69.0]
+
 ## [0.68.0] - 2026-04-30
 
 - fix(view): bubble click up to ancestor on_click handler (#1067) ([#1073](https://github.com/danielraffel/pulp/pull/1073))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.68.0
+    VERSION 0.69.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/audio/include/pulp/audio/load_measurer.hpp
+++ b/core/audio/include/pulp/audio/load_measurer.hpp
@@ -28,6 +28,11 @@ public:
     /// @param sample_rate Current sample rate in Hz.
     void begin(int num_frames, float sample_rate) {
         start_time_ = clock::now();
+        if (num_frames <= 0 || !(sample_rate > 0.0f)) {
+            available_ns_ = 0;
+            return;
+        }
+
         available_ns_ = static_cast<int64_t>(
             static_cast<double>(num_frames) / static_cast<double>(sample_rate) * 1e9);
     }

--- a/test/test_load_measurer.cpp
+++ b/test/test_load_measurer.cpp
@@ -116,3 +116,47 @@ TEST_CASE("AudioProcessLoadMeasurer clamps smoothing and ignores zero available 
     REQUIRE(raw_load > 0.0f);
     REQUIRE_THAT(m.peak_load(), WithinAbs(raw_load, 0.001f));
 }
+
+TEST_CASE("AudioProcessLoadMeasurer zero smoothing still tracks peak",
+          "[audio][load][issue-640]") {
+    AudioProcessLoadMeasurer m;
+    m.set_smoothing(0.0f);
+
+    m.begin(512, 44100.0f);
+    busy_wait_for(std::chrono::microseconds(1200));
+    m.end();
+
+    REQUIRE_THAT(m.load(), WithinAbs(0.0f, 0.001f));
+    REQUIRE(m.peak_load() > 0.0f);
+}
+
+TEST_CASE("AudioProcessLoadMeasurer reset keeps smoothing configuration",
+          "[audio][load][issue-640]") {
+    AudioProcessLoadMeasurer m;
+    m.set_smoothing(0.0f);
+
+    m.reset();
+    m.begin(512, 44100.0f);
+    busy_wait_for(std::chrono::microseconds(1200));
+    m.end();
+
+    REQUIRE_THAT(m.load(), WithinAbs(0.0f, 0.001f));
+    REQUIRE(m.peak_load() > 0.0f);
+}
+
+TEST_CASE("AudioProcessLoadMeasurer zero sample rate leaves prior load unchanged",
+          "[audio][load][issue-640]") {
+    AudioProcessLoadMeasurer m;
+    m.set_smoothing(1.0f);
+
+    const float previous = measure_load(m, std::chrono::microseconds(1200));
+    REQUIRE(previous > 0.0f);
+    const float previous_peak = m.peak_load();
+
+    m.begin(512, 0.0f);
+    busy_wait_for(std::chrono::microseconds(1200));
+    m.end();
+
+    REQUIRE_THAT(m.load(), WithinAbs(previous, 0.001f));
+    REQUIRE_THAT(m.peak_load(), WithinAbs(previous_peak, 0.001f));
+}


### PR DESCRIPTION
## Summary
- Guards AudioProcessLoadMeasurer against invalid callback timing input so zero/invalid frame timing leaves the current load state unchanged.
- Adds focused coverage for zero smoothing peak tracking, reset retaining smoothing configuration, and zero sample-rate measurement safety.
- Scope is audio gap #640 / high-leverage tracker #493.

## Validation
- cmake -S . -B build-load -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar
- cmake --build build-load --target pulp-test-load-measurer -j$(sysctl -n hw.ncpu)
- ./build-load/test/pulp-test-load-measurer
- ctest --test-dir build-load -R "AudioProcessLoadMeasurer|load-measurer|load_measurer" --output-on-failure
- git diff --check
- pulp_cli_version_check
- python3 tools/scripts/skill_sync_check.py --mode=report
- python3 tools/scripts/version_bump_check.py --mode=report

Namespace: https://github.com/danielraffel/pulp/actions/runs/25168821687

Refs #640
Refs #493
Refs #641