### PR TITLE
chore: bump versions (catch-up after 9c780124) — closes #1124

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.68.0
+    VERSION 0.68.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Summary

PR #1032 (`fix(audio): make empty focus subscriptions inert`) merged to main at commit `9c780124` **without** an accompanying `chore: bump versions` commit. The auto-release watchdog fired [#1124](https://github.com/danielraffel/pulp/issues/1124) to flag this — without a bump, consumers can't reach the audio fix.

This PR resolves it: bumps `CMakeLists.txt VERSION 0.68.0 → 0.68.1` (patch bump, since #1032 is a `fix:` change with no plugin code touched).

After merge:
- `auto-release.yml` will tag `v0.68.1`
- Tag-triggered `release-cli.yml` will publish binaries
- The watchdog will auto-close #1124 once recovery is detected

## Test plan

- [x] `python3 tools/scripts/version_bump_check.py --mode=report` clean
- [x] Pre-push hook clean (gates: skill-sync, version-bump, compat-sync)
- [ ] CI green on macos / linux / windows required gates
- [ ] Auto-release tags `v0.68.1` post-merge
- [ ] `release-cli.yml` publishes binaries

Closes #1124.