### PR TITLE
fix(skills): drop empty-match patterns from skill_path_map.json

### DIFF
--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -1,24 +1,31 @@
 {
   "$schema": "./skill_path_map.schema.json",
   "schema_version": 1,
-  "_comment": "Skill name -> glob patterns. When a diff touches any pattern, the corresponding SKILL.md must be updated in the same diff or a Skill-Update: skip trailer must appear on the tip commit. Paired with tools/scripts/versioning.json. Every subdir under .agents/skills/ MUST have an entry here; skill_sync_check.py fails if one is missing. Dual/triple ownership is permitted — and expected — for files that span multiple domains: e.g. core/format/src/au_adapter.mm is owned by both `auv3` (the adapter) and `view-bridge` (editor attach lifecycle), because a change to that file reasonably requires guidance updates on both sides. Dual ownership is not a mistake to collapse; use it when a single file legitimately teaches two skills.",
+  "_comment": "Skill name -> glob patterns. When a diff touches any pattern, the corresponding SKILL.md must be updated in the same diff or a Skill-Update: skip trailer must appear on the tip commit. Paired with tools/scripts/versioning.json. Every subdir under .agents/skills/ MUST have an entry here; skill_sync_check.py fails if one is missing. Dual/triple ownership is permitted — and expected — for files that span multiple domains: e.g. core/format/src/au_adapter.mm is owned by both `auv3` (the adapter) and `view-bridge` (editor attach lifecycle), because a change to that file reasonably requires guidance updates on both sides. Dual ownership is not a mistake to collapse; use it when a single file legitimately teaches two skills. Empty-match contract: every glob in `paths` MUST match at least one tracked file (enforced by SkillPathMapTests in tools/scripts/test_skill_sync_check.py — mirrors PR #1005's coverage-exclude fix (efefe144 + b258730c)). Patterns that are intentionally future-facing (e.g. developer-supplied SDKs that ship outside the source tree) MUST be declared in `_doc.expected_empty` with a one-line reason, NOT under `paths`, so they don't hide silent typos in real path entries.",
   "skills": {
     "aax": {
       "paths": [
         "core/format/src/aax*",
         "core/format/include/pulp/format/aax*",
-        "external/AAX-SDK/**",
         "tools/cmake/PulpAAX.cmake"
-      ]
+      ],
+      "_doc": {
+        "expected_empty": {
+          "external/AAX-SDK/**": "Avid AAX SDK is developer-supplied per the vendor-SDK carve-out in CLAUDE.md; never committed to the source tree."
+        }
+      }
     },
     "ara": {
       "paths": [
         "core/format/src/ara*",
-        "core/format/src/ara/**",
         "core/format/include/pulp/format/ara*",
-        "core/format/include/pulp/format/ara/**",
-        "external/ara-sdk/**"
-      ]
+        "core/format/include/pulp/format/ara/**"
+      ],
+      "_doc": {
+        "expected_empty": {
+          "external/ara-sdk/**": "ARA SDK is developer-supplied per the vendor-SDK carve-out in CLAUDE.md; never committed to the source tree."
+        }
+      }
     },
     "auv3": {
       "paths": [
@@ -49,7 +56,6 @@
       "paths": [
         "core/format/src/au_v2_adapter.cpp",
         "core/format/src/au_v2_instrument.cpp",
-        "core/format/src/au_v2_entry.*",
         "core/format/src/au_v2_cocoa_view.mm",
         "core/format/include/pulp/format/au_v2_adapter.hpp",
         "core/format/include/pulp/format/au_v2_instrument.hpp",
@@ -91,33 +97,24 @@
       "paths": [
         "tools/scripts/cmajor_external.py",
         "tools/scripts/test_cmajor_external.py",
-        "examples/cmajor-*/**",
-        "core/**/*cmajor*"
+        "examples/cmajor-*/**"
       ]
     },
     "engine": {
       "paths": [
-        "core/view/src/js_bridge*",
-        "core/view/include/**/js_bridge*",
-        "core/view/src/engine*",
-        "core/view/js/web-compat-*.js",
-        "external/quickjs*/**",
-        "tools/cmake/PulpJsEngine.cmake"
+        "core/view/js/web-compat-*.js"
       ]
     },
     "faust": {
       "paths": [
-        "examples/faust-*/**",
-        "tools/scripts/faust*",
-        "core/signal/**/*faust*"
+        "examples/faust-*/**"
       ]
     },
     "hosting": {
       "paths": [
         "core/host/**",
         "examples/plugin-host-demo/**",
-        "tools/cli/commands/host.cpp",
-        "tools/cli/commands/scan.cpp"
+        "tools/cli/cmd_host.cpp"
       ]
     },
     "ios": {
@@ -142,15 +139,12 @@
       "paths": [
         "tools/scripts/jsfx_subset.py",
         "tools/scripts/test_jsfx_subset.py",
-        "examples/jsfx-*/**",
-        "core/signal/**/*jsfx*"
+        "examples/jsfx-*/**"
       ]
     },
     "mpe": {
       "paths": [
-        "core/midi/src/*mpe*",
         "core/midi/include/**/*mpe*",
-        "core/midi/src/*ump*",
         "core/midi/include/**/*ump*",
         "examples/mpe-*/**"
       ]
@@ -158,12 +152,6 @@
     "packages": {
       "paths": [
         "tools/packages/**",
-        "tools/cli/cmd_add.cpp",
-        "tools/cli/cmd_audit.cpp",
-        "tools/cli/cmd_fetch.cpp",
-        "tools/cli/cmd_install.cpp",
-        "tools/cli/cmd_remove.cpp",
-        "tools/cli/cmd_search.cpp",
         "DEPENDENCIES.md",
         "NOTICE.md",
         "tools/deps/manifest.json"
@@ -180,7 +168,6 @@
       "paths": [
         "core/canvas/src/*sdf*",
         "core/canvas/src/*msdf*",
-        "core/canvas/src/*psdf*",
         "core/canvas/include/**/*sdf*",
         "core/canvas/include/**/*msdf*",
         "core/canvas/include/**/*psdf*",
@@ -200,17 +187,12 @@
       "paths": [
         "core/runtime/src/*stream*",
         "core/runtime/include/**/*stream*",
-        "core/events/src/*stream*",
-        "core/events/include/**/*stream*",
-        "examples/streams-*/**"
+        "examples/stream-*/**"
       ]
     },
     "threejs-bridge": {
       "paths": [
-        "core/view/src/threejs*",
-        "core/view/include/**/threejs*",
-        "examples/threejs-*/**",
-        "tools/scripts/threejs*"
+        "examples/threejs-*/**"
       ]
     },
     "upgrade": {
@@ -252,9 +234,6 @@
     },
     "webview-ui": {
       "paths": [
-        "core/view/src/webview*",
-        "core/view/include/**/webview*",
-        "core/view/platform/**/webview*",
         "examples/webview-*/**"
       ]
     }

--- a/tools/scripts/test_skill_sync_check.py
+++ b/tools/scripts/test_skill_sync_check.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -12,6 +13,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import skill_sync_check as ssc
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH_MAP = REPO_ROOT / "tools" / "scripts" / "skill_path_map.json"
 
 
 class SkillSyncCheckTests(unittest.TestCase):
@@ -103,6 +108,93 @@ class SkillSyncCheckTests(unittest.TestCase):
         self.assertIn('Skill-Update: skip skill=ci reason="..."', report_text)
         self.assertEqual(hint_code, 0)
         self.assertIn("SKILL.md NOT updated", hint_text)
+
+
+class SkillPathMapTests(unittest.TestCase):
+    """Anti-drift contract for tools/scripts/skill_path_map.json.
+
+    Mirrors the audit recipe in issue #1053. Same shape family as the
+    diff-cover empty-match bug fixed in efefe144 + b258730c (#1005):
+    a path pattern that matches NOTHING is a silent no-op — the skill
+    never gets a sync-check trigger, and a typo or rename can quietly
+    disable enforcement until a contributor stumbles on it.
+
+    Every glob in `paths` MUST match at least one tracked file. Patterns
+    that are intentionally future-facing (e.g. developer-supplied SDKs
+    that ship outside the source tree) MUST be declared under
+    `_doc.expected_empty` instead, with a one-line reason.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.skill_map_raw = json.loads(SKILL_PATH_MAP.read_text())
+        cls.tracked_files = subprocess.check_output(
+            ["git", "ls-files"],
+            cwd=REPO_ROOT,
+            text=True,
+        ).splitlines()
+
+    def _matches(self, pattern: str) -> list[str]:
+        return [f for f in self.tracked_files if ssc._glob_match(f, pattern)]
+
+    def test_every_paths_pattern_matches_at_least_one_tracked_file(self) -> None:
+        # The core anti-drift contract — added back any empty-match
+        # pattern (typo, renamed file, never-existed path) and this
+        # test fails loudly with the offending skill+pattern.
+        empty: list[tuple[str, str]] = []
+        for skill, entry in self.skill_map_raw.get("skills", {}).items():
+            for pat in entry.get("paths", []):
+                if not self._matches(pat):
+                    empty.append((skill, pat))
+        self.assertFalse(
+            empty,
+            "skill_path_map.json contains paths patterns that match zero "
+            "tracked files (silent no-ops). Either fix the pattern, "
+            "delete it, or move it to the entry's `_doc.expected_empty` "
+            "with a reason if it's intentionally future-facing:\n  "
+            + "\n  ".join(f"{skill}: {pat!r}" for skill, pat in empty),
+        )
+
+    def test_expected_empty_patterns_actually_match_nothing(self) -> None:
+        # Guard rail on the `_doc.expected_empty` escape hatch: anything
+        # listed there must currently match zero tracked files. If a
+        # listed path *does* exist in the tree, the entry should be
+        # promoted into `paths` instead — keeping `_doc.expected_empty`
+        # narrowly scoped to genuinely external/future-facing surfaces.
+        wrong: list[tuple[str, str]] = []
+        for skill, entry in self.skill_map_raw.get("skills", {}).items():
+            doc = entry.get("_doc") or {}
+            expected_empty = doc.get("expected_empty") or {}
+            for pat in expected_empty:
+                if self._matches(pat):
+                    wrong.append((skill, pat))
+        self.assertFalse(
+            wrong,
+            "skill_path_map.json `_doc.expected_empty` entries must "
+            "currently match zero tracked files. Move these into "
+            "`paths` instead so they actually gate the skill:\n  "
+            + "\n  ".join(f"{skill}: {pat!r}" for skill, pat in wrong),
+        )
+
+    def test_expected_empty_entries_have_reason_strings(self) -> None:
+        # `_doc.expected_empty` is a dict of pattern -> reason. Empty or
+        # missing reason strings defeat the purpose of the annotation.
+        bad: list[tuple[str, str]] = []
+        for skill, entry in self.skill_map_raw.get("skills", {}).items():
+            doc = entry.get("_doc") or {}
+            expected_empty = doc.get("expected_empty") or {}
+            if not isinstance(expected_empty, dict):
+                bad.append((skill, "_doc.expected_empty must be a dict of pattern->reason"))
+                continue
+            for pat, reason in expected_empty.items():
+                if not isinstance(reason, str) or not reason.strip():
+                    bad.append((skill, f"missing reason for {pat!r}"))
+        self.assertFalse(
+            bad,
+            "skill_path_map.json `_doc.expected_empty` entries must each "
+            "carry a non-empty reason string:\n  "
+            + "\n  ".join(f"{skill}: {msg}" for skill, msg in bad),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

33 patterns in `tools/scripts/skill_path_map.json` were silently matching zero tracked files, so any change under those paths slipped past the skill-sync gate undetected. Same shape family as #1005's `diff_cover_excludes` silent-no-op (commits `efefe144` + `b258730c`).

Audited every pattern against `git ls-files` using the same glob matcher `skill_sync_check.py` uses (`_glob_match`). Empty hits fell into three buckets:

1. **Typos / wrong subdir** — fixed in place where the intended file was obvious (e.g. `tools/cli/commands/host.cpp` -> `tools/cli/cmd_host.cpp`), otherwise dropped.
2. **Never-existed or removed surfaces** — deleted (e.g. `core/**/*cmajor*`, `core/view/{src,include}/webview*`, `external/quickjs*/**`, six obsolete `tools/cli/cmd_*.cpp` package entries that consolidated into `package_commands.cpp`).
3. **Intentionally future-facing developer-supplied SDKs** — moved to a new `_doc.expected_empty` companion key with a one-line reason. Currently: `external/AAX-SDK/**` and `external/ara-sdk/**`, both dev-supplied per the vendor-SDK carve-out in CLAUDE.md.

Total `paths` patterns: **151 -> 120, all matching**.

## Anti-drift contract

`SkillPathMapTests` in `tools/scripts/test_skill_sync_check.py` asserts three invariants on the real path map:

- every glob in `paths` matches at least one tracked file (the core bug class)
- every glob in `_doc.expected_empty` currently matches **zero** tracked files (so the escape hatch can't be used to silently shadow live typos)
- every `_doc.expected_empty` entry carries a non-empty reason string

Verified by reverting each fix in turn: re-introducing an empty pattern fails `test_every_paths_pattern_matches_at_least_one_tracked_file` loudly with the offending skill+pattern; pointing `_doc.expected_empty` at a real path fails `test_expected_empty_patterns_actually_match_nothing`.

## Boundaries respected

- No SKILL.md files touched (no skills were removed).
- No new skill mappings added — only typo fixes and dead-pattern deletes.
- No surfaces outside `tools/scripts/skill_path_map.json` + `tools/scripts/test_skill_sync_check.py` touched.

## Test plan

- [x] `python3 tools/scripts/test_skill_sync_check.py` — 7 tests, all pass
- [x] `python3 tools/scripts/test_gates.py` — 39 tests, all pass
- [x] Audit recipe re-run: 0 empty matches across 120 patterns
- [x] Anti-drift test verified to fail when an empty-match pattern is added back
- [x] Anti-drift test verified to fail when `_doc.expected_empty` is pointed at a real file

Closes #1053
Refs #1049, #1005