### PR TITLE
fix(coverage): honor LCOV_EXCL markers via lcov_strip_excl.py (#1058)

### DIFF
--- a/docs/guides/coverage.md
+++ b/docs/guides/coverage.md
@@ -292,6 +292,17 @@ Source → Gradle `testDebugUnitTest`
   `llvm-cov export --format=lcov` plus the vendored
   `tools/scripts/lcov_cobertura.py` converter emit Cobertura XML for
   Codecov + diff-cover.
+- **`LCOV_EXCL` markers**: `tools/scripts/lcov_strip_excl.py` runs
+  between `llvm-cov export` and `lcov_cobertura.py` (wired into both
+  `tools/scripts/local_diff_cover.sh` and `scripts/run_coverage.sh`).
+  llvm-cov itself does NOT honor `LCOV_EXCL_LINE` /
+  `LCOV_EXCL_START..STOP` (those are a gcov/lcov convention, not LLVM),
+  so without this strip pass the markers are documentation-only —
+  excluded code still appears in diff-cover's "missing lines" report
+  and in the Cobertura XML uploaded to Codecov. The Python helper
+  walks each `SF:<path>` record, drops `DA`/`BRDA`/`FN[A]`/`FNDA` rows
+  on excluded lines, and recomputes the `LF`/`LH`/`BRF`/`BRH`/`FNF`/`FNH`
+  counters so the output is internally consistent. See `#1058`.
 - **`-object` list**: llvm-cov only reports translation units linked
   into the binaries given via `-object`. The script passes every test
   executable **plus** every first-party static archive (`libpulp-*.a`)

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -318,21 +318,36 @@ llvm-cov show \
 # a vendored copy of https://github.com/eriwen/lcov-to-cobertura-xml
 # (Apache 2.0, MIT-compatible).
 COBERTURA_XML="${BUILD_DIR}/coverage.cobertura.xml"
+LCOV_RAW="${REPORT_DIR}/coverage.raw.lcov"
 LCOV_FILE="${REPORT_DIR}/coverage.lcov"
 LCOV_COBERTURA="${REPO_ROOT}/tools/scripts/lcov_cobertura.py"
+LCOV_STRIP_EXCL="${REPO_ROOT}/tools/scripts/lcov_strip_excl.py"
 
 if [[ ! -f "${LCOV_COBERTURA}" ]]; then
     echo "run_coverage.sh: missing ${LCOV_COBERTURA}" >&2
     echo "    (expected the vendored lcov→cobertura converter)" >&2
     exit 1
 fi
+if [[ ! -f "${LCOV_STRIP_EXCL}" ]]; then
+    echo "run_coverage.sh: missing ${LCOV_STRIP_EXCL}" >&2
+    echo "    (expected the LCOV_EXCL stripper — pulp #1058)" >&2
+    exit 1
+fi
 
-echo "=== llvm-cov export → LCOV ==="
+echo "=== llvm-cov export → LCOV (raw) ==="
 llvm-cov export --format=lcov \
     "${BINARIES[@]}" \
     -instr-profile="${PROFDATA}" \
     -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
-    > "${LCOV_FILE}"
+    > "${LCOV_RAW}"
+
+# llvm-cov-export does NOT honor LCOV_EXCL_LINE / LCOV_EXCL_START..STOP
+# markers — those are a gcov/lcov convention. Without this strip step,
+# code wrapped in LCOV_EXCL still appears in the diff-cover "missing
+# lines" report and in the Cobertura XML uploaded to Codecov
+# (pulp #1058).
+echo "=== Strip LCOV_EXCL ranges → LCOV (filtered) ==="
+python3 "${LCOV_STRIP_EXCL}" "${LCOV_RAW}" "${LCOV_FILE}"
 
 echo "=== LCOV → Cobertura XML ==="
 python3 "${LCOV_COBERTURA}" "${LCOV_FILE}" \

--- a/tools/scripts/lcov_strip_excl.py
+++ b/tools/scripts/lcov_strip_excl.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+# tools/scripts/lcov_strip_excl.py
+#
+# Strip lines wrapped in `LCOV_EXCL_*` markers from an .lcov file before
+# it reaches the Cobertura converter.
+#
+# Why this script exists
+# ----------------------
+# `llvm-cov export --format=lcov` does NOT honor `LCOV_EXCL_LINE` /
+# `LCOV_EXCL_START` / `LCOV_EXCL_STOP` markers. Those markers are a
+# `gcov` / `lcov` convention; LLVM's exporter just emits the raw line
+# data and the markers are silently ignored. Result: any code wrapped in
+# `LCOV_EXCL_START..STOP` STILL appears in `diff-cover`'s "missing
+# lines" report — making the markers documentation-only.
+#
+# This helper closes that gap. It walks each `SF:<path>` record in the
+# input .lcov, opens the source file, scans for the LCOV_EXCL markers,
+# and drops every `DA:<line>,...`, `BRDA:<line>,...`, and `FN[A]:<line>,...`
+# record whose line falls inside an excluded range. The line/branch/fn
+# totals (`LF`, `LH`, `BRF`, `BRH`, `FNF`, `FNH`) are recomputed so the
+# resulting file is internally consistent.
+#
+# Markers honored
+# ---------------
+#   LCOV_EXCL_LINE             — exclude that one line (the marker line itself)
+#   LCOV_EXCL_START..STOP      — exclude every line in the (inclusive) range
+#   LCOV_EXCL_BR_LINE          — exclude branch records on that line only
+#   LCOV_EXCL_BR_START..STOP   — exclude branch records in the range
+#
+# Mismatched markers (an unmatched START or STOP) print a warning to
+# stderr and are treated leniently (orphan STOP is ignored; orphan START
+# excludes everything to EOF — same as lcov(1)).
+#
+# Usage
+# -----
+#   python3 tools/scripts/lcov_strip_excl.py INPUT.lcov OUTPUT.lcov
+#   python3 tools/scripts/lcov_strip_excl.py --in-place INPUT.lcov
+#   cat foo.lcov | python3 tools/scripts/lcov_strip_excl.py - -   # stdin/stdout
+#
+# Exit codes
+# ----------
+#   0 — success (or no markers found; input copied through unchanged)
+#   1 — I/O error or malformed input
+#   2 — argument error
+#
+# Refs: pulp #1058, parent #1049
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from typing import Dict, List, Optional, Set, TextIO, Tuple
+
+
+# Regex catches the marker token even when it's inside a `//` or `/* */`
+# comment, with optional leading whitespace and trailing junk. The
+# trailing `\b` boundary keeps us from matching `LCOV_EXCL_LINE_FOO` as
+# a `LCOV_EXCL_LINE`.
+_MARKER_RE = re.compile(
+    r"\bLCOV_EXCL_("
+    r"LINE|START|STOP|BR_LINE|BR_START|BR_STOP"
+    r")\b"
+)
+
+
+class _ExcludeMap:
+    """Per-source-file map of which lines are excluded.
+
+    Keys are 1-based line numbers (matching the .lcov line-number
+    convention). `branch_lines` is a SUPERSET of `lines` because
+    excluding a regular line also excludes branches on it. Hand-rolled
+    instead of @dataclass to avoid a Python-3.14 quirk where
+    `importlib.util.spec_from_file_location`-loaded modules trip a
+    dataclass introspection edge case (`AttributeError: 'NoneType'`).
+    """
+
+    __slots__ = ("lines", "branch_lines")
+
+    def __init__(self) -> None:
+        self.lines: Set[int] = set()
+        self.branch_lines: Set[int] = set()
+
+    def is_line_excluded(self, n: int) -> bool:
+        return n in self.lines
+
+    def is_branch_excluded(self, n: int) -> bool:
+        # Excluding a line via LCOV_EXCL_LINE/START..STOP also excludes
+        # any branch records on that line. lcov(1) behavior.
+        return n in self.lines or n in self.branch_lines
+
+
+def compute_exclusions(source_text: str) -> _ExcludeMap:
+    """Scan source text for LCOV_EXCL markers and build an exclude map.
+
+    A standalone helper so tests can exercise the marker grammar
+    directly without spinning up a full .lcov fixture.
+    """
+    em = _ExcludeMap()
+    in_block = False
+    block_start: Optional[int] = None
+    in_br_block = False
+    br_block_start: Optional[int] = None
+
+    for idx, line in enumerate(source_text.splitlines(), start=1):
+        m = _MARKER_RE.search(line)
+        if not m:
+            if in_block:
+                em.lines.add(idx)
+            if in_br_block:
+                em.branch_lines.add(idx)
+            continue
+
+        kind = m.group(1)
+
+        if kind == "LINE":
+            em.lines.add(idx)
+            # Continue tracking enclosing blocks, but the marker line
+            # itself is always excluded.
+            if in_block:
+                em.lines.add(idx)
+            if in_br_block:
+                em.branch_lines.add(idx)
+        elif kind == "BR_LINE":
+            em.branch_lines.add(idx)
+            if in_block:
+                em.lines.add(idx)
+            if in_br_block:
+                em.branch_lines.add(idx)
+        elif kind == "START":
+            # Marker line itself is excluded (lcov behavior).
+            in_block = True
+            block_start = idx
+            em.lines.add(idx)
+        elif kind == "STOP":
+            if not in_block:
+                # Orphan STOP — warn and ignore.
+                print(
+                    f"[lcov_strip_excl] warning: orphan LCOV_EXCL_STOP at "
+                    f"line {idx} (no matching START)",
+                    file=sys.stderr,
+                )
+            else:
+                em.lines.add(idx)
+                in_block = False
+                block_start = None
+        elif kind == "BR_START":
+            in_br_block = True
+            br_block_start = idx
+            em.branch_lines.add(idx)
+        elif kind == "BR_STOP":
+            if not in_br_block:
+                print(
+                    f"[lcov_strip_excl] warning: orphan LCOV_EXCL_BR_STOP at "
+                    f"line {idx} (no matching BR_START)",
+                    file=sys.stderr,
+                )
+            else:
+                em.branch_lines.add(idx)
+                in_br_block = False
+                br_block_start = None
+
+    if in_block:
+        # Orphan START: lcov(1) excludes everything to EOF.
+        print(
+            f"[lcov_strip_excl] warning: unterminated LCOV_EXCL_START at "
+            f"line {block_start}; excluding through EOF",
+            file=sys.stderr,
+        )
+    if in_br_block:
+        print(
+            f"[lcov_strip_excl] warning: unterminated LCOV_EXCL_BR_START at "
+            f"line {br_block_start}; excluding through EOF",
+            file=sys.stderr,
+        )
+
+    return em
+
+
+def _read_source(path: str) -> Optional[str]:
+    """Best-effort source read. Returns None if the file is unreadable.
+
+    .lcov SF: paths can point at vendored / generated files we can't
+    open (especially after `-ignore-filename-regex` filtering on llvm-cov
+    side). Returning None means "no markers" — equivalent to passing
+    the records through.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def _split_da(record: str) -> Tuple[Optional[int], str]:
+    """Parse `DA:<line>,<hits>[,<checksum>]` and return (line, rest).
+
+    rest is the unmodified original record so we can pass through
+    untouched if the line is kept.
+    """
+    # `DA:NN,HH` — split off the prefix.
+    if not record.startswith("DA:"):
+        return None, record
+    payload = record[3:]
+    comma = payload.find(",")
+    if comma < 0:
+        return None, record
+    try:
+        return int(payload[:comma]), record
+    except ValueError:
+        return None, record
+
+
+def _split_brda(record: str) -> Optional[int]:
+    """Parse `BRDA:<line>,<block>,<branch>,<taken>` → line number."""
+    if not record.startswith("BRDA:"):
+        return None
+    payload = record[5:]
+    comma = payload.find(",")
+    if comma < 0:
+        return None
+    try:
+        return int(payload[:comma])
+    except ValueError:
+        return None
+
+
+def _split_fn(record: str) -> Optional[int]:
+    """Parse `FN:<line>,<name>` or `FNA:<line>,<hits>,<name>` → line."""
+    if record.startswith("FN:"):
+        payload = record[3:]
+    elif record.startswith("FNA:"):
+        payload = record[4:]
+    else:
+        return None
+    comma = payload.find(",")
+    if comma < 0:
+        return None
+    try:
+        return int(payload[:comma])
+    except ValueError:
+        return None
+
+
+def _split_fnda(record: str) -> Optional[Tuple[int, str]]:
+    """Parse `FNDA:<hits>,<name>` — but FNDA carries no line number,
+    so we have to look up the function's line via the FN/FNA records
+    we've already seen. Returns (hits, name) or None if malformed.
+    """
+    if not record.startswith("FNDA:"):
+        return None
+    payload = record[5:]
+    comma = payload.find(",")
+    if comma < 0:
+        return None
+    try:
+        return int(payload[:comma]), payload[comma + 1 :]
+    except ValueError:
+        return None
+
+
+def filter_lcov(input_text: str, source_lookup=None) -> str:
+    """Filter an .lcov stream, dropping records on LCOV_EXCL'd lines.
+
+    Args:
+        input_text: full contents of the .lcov file.
+        source_lookup: callable taking a path string, returning source
+            text or None. Defaults to reading from the filesystem; the
+            indirection lets tests inject in-memory fixtures without
+            writing temp files.
+
+    Returns:
+        The filtered .lcov text, with LF/LH/BRF/BRH/FNF/FNH counters
+        recomputed per record block.
+    """
+    if source_lookup is None:
+        source_lookup = _read_source
+
+    out: List[str] = []
+    cache: Dict[str, _ExcludeMap] = {}
+
+    # State that resets at each `SF:` record:
+    current_excl: Optional[_ExcludeMap] = None
+    block_lines: List[str] = []
+    # Function name → line, so we can apply LCOV_EXCL to FNDA via the
+    # earlier FN/FNA record on the same line.
+    fn_line_by_name: Dict[str, int] = {}
+
+    def flush_block() -> None:
+        """Flush `block_lines` to `out`, recomputing summary counters.
+
+        Counters in lcov format:
+          LF / LH = line-found / line-hit
+          BRF / BRH = branch-found / branch-hit
+          FNF / FNH = function-found / function-hit
+        """
+        if not block_lines:
+            return
+
+        # First pass: count after filtering (DA/BRDA/FN[A]/FNDA already
+        # filtered upstream in this function — block_lines only holds
+        # records we plan to keep).
+        lf = lh = brf = brh = fnf = fnh = 0
+        for rec in block_lines:
+            if rec.startswith("DA:"):
+                lf += 1
+                # DA:<line>,<hits>...
+                _, rest = _split_da(rec)
+                # Re-parse the hits column.
+                payload = rec[3:]
+                first_c = payload.find(",")
+                second_c = payload.find(",", first_c + 1)
+                hits_str = (
+                    payload[first_c + 1 : second_c]
+                    if second_c >= 0
+                    else payload[first_c + 1 :]
+                )
+                try:
+                    if int(hits_str) > 0:
+                        lh += 1
+                except ValueError:
+                    pass
+            elif rec.startswith("BRDA:"):
+                brf += 1
+                # BRDA:<line>,<block>,<branch>,<taken>
+                payload = rec[5:]
+                last_c = payload.rfind(",")
+                taken = payload[last_c + 1 :] if last_c >= 0 else ""
+                # `taken` is "-" when never executed, else an integer.
+                if taken not in ("-", "", "0"):
+                    try:
+                        if int(taken) > 0:
+                            brh += 1
+                    except ValueError:
+                        pass
+            elif rec.startswith("FN:") or rec.startswith("FNA:"):
+                fnf += 1
+            elif rec.startswith("FNDA:"):
+                parsed = _split_fnda(rec)
+                if parsed is not None and parsed[0] > 0:
+                    fnh += 1
+
+        # Strip out the original LF/LH/BRF/BRH/FNF/FNH lines (we
+        # recompute them) and emit the rest, then append fresh totals.
+        skip_prefixes = ("LF:", "LH:", "BRF:", "BRH:", "FNF:", "FNH:")
+        for rec in block_lines:
+            if rec.startswith(skip_prefixes):
+                continue
+            if rec == "end_of_record":
+                continue
+            out.append(rec)
+
+        # Counter ordering matches lcov's own `geninfo` output so
+        # downstream tools that pattern-match are unsurprised.
+        if any(r.startswith(("FN:", "FNA:", "FNDA:")) for r in block_lines):
+            out.append(f"FNF:{fnf}")
+            out.append(f"FNH:{fnh}")
+        if any(r.startswith("BRDA:") for r in block_lines):
+            out.append(f"BRF:{brf}")
+            out.append(f"BRH:{brh}")
+        if any(r.startswith("DA:") for r in block_lines):
+            out.append(f"LF:{lf}")
+            out.append(f"LH:{lh}")
+        out.append("end_of_record")
+
+        block_lines.clear()
+        fn_line_by_name.clear()
+
+    for raw in input_text.split("\n"):
+        rec = raw.rstrip("\r")
+        if not rec:
+            # Preserve blank lines outside any record.
+            if current_excl is None:
+                out.append("")
+            continue
+
+        if rec.startswith("SF:"):
+            # Start of a new file record. Flush whatever we had and
+            # set up exclusions for this file.
+            flush_block()
+            path = rec[3:].strip()
+            if path not in cache:
+                src = source_lookup(path)
+                cache[path] = (
+                    compute_exclusions(src) if src is not None else _ExcludeMap()
+                )
+            current_excl = cache[path]
+            block_lines.append(rec)
+            continue
+
+        if rec == "end_of_record":
+            flush_block()
+            current_excl = None
+            continue
+
+        if current_excl is None:
+            # Pre-amble or post-amble outside any SF block — preserve.
+            out.append(rec)
+            continue
+
+        # Inside an SF..end_of_record block: filter excluded records.
+        line_no, _ = _split_da(rec)
+        if line_no is not None:
+            if current_excl.is_line_excluded(line_no):
+                continue
+            block_lines.append(rec)
+            continue
+
+        line_no = _split_brda(rec)
+        if line_no is not None:
+            if current_excl.is_branch_excluded(line_no):
+                continue
+            block_lines.append(rec)
+            continue
+
+        line_no = _split_fn(rec)
+        if line_no is not None:
+            # Track function name → line so we can filter FNDA below.
+            payload = rec[3:] if rec.startswith("FN:") else rec[4:]
+            comma = payload.find(",")
+            if comma >= 0:
+                name = payload[comma + 1 :]
+                fn_line_by_name[name] = line_no
+            if current_excl.is_line_excluded(line_no):
+                continue
+            block_lines.append(rec)
+            continue
+
+        parsed_fnda = _split_fnda(rec)
+        if parsed_fnda is not None:
+            _, name = parsed_fnda
+            fline = fn_line_by_name.get(name)
+            if fline is not None and current_excl.is_line_excluded(fline):
+                continue
+            block_lines.append(rec)
+            continue
+
+        # Unknown record kind (TN, KF, VER, etc.) — pass through.
+        block_lines.append(rec)
+
+    # If the input ended without a closing end_of_record (rare/malformed
+    # but defensive), flush the last block.
+    flush_block()
+
+    return "\n".join(out)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Strip LCOV_EXCL'd source lines from an .lcov file before "
+            "the Cobertura converter sees them. Closes the gap that "
+            "llvm-cov-export ignores LCOV_EXCL markers."
+        ),
+    )
+    parser.add_argument(
+        "input",
+        help="Input .lcov path, or '-' for stdin",
+    )
+    parser.add_argument(
+        "output",
+        nargs="?",
+        help="Output .lcov path, or '-' for stdout. Required unless --in-place.",
+    )
+    parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Overwrite the input file in place (mutually exclusive with output).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.in_place and args.output:
+        parser.error("--in-place is mutually exclusive with a positional output path")
+    if not args.in_place and args.output is None:
+        parser.error("output path is required (or pass --in-place)")
+
+    # Read input.
+    if args.input == "-":
+        text = sys.stdin.read()
+    else:
+        try:
+            with open(args.input, "r", encoding="utf-8", errors="replace") as f:
+                text = f.read()
+        except OSError as e:
+            print(f"[lcov_strip_excl] error reading {args.input}: {e}", file=sys.stderr)
+            return 1
+
+    filtered = filter_lcov(text)
+
+    # Write output.
+    out_path = args.input if args.in_place else args.output
+    if out_path == "-":
+        sys.stdout.write(filtered)
+        return 0
+    try:
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(filtered)
+    except OSError as e:
+        print(f"[lcov_strip_excl] error writing {out_path}: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scripts/local_diff_cover.sh
+++ b/tools/scripts/local_diff_cover.sh
@@ -254,21 +254,34 @@ fi
 # Same pipeline scripts/run_coverage.sh uses — `llvm-cov export --format=lcov`
 # then the vendored lcov_cobertura.py converter.
 COVERAGE_IGNORE_REGEX='(^|/)(_deps|external|test|[Cc]atch2|build|build-cov|build-coverage|examples|fetchcontent-src|sandbox-e2e)/'
+LCOV_RAW="${BUILD_DIR}/coverage/coverage.raw.lcov"
 LCOV_FILE="${BUILD_DIR}/coverage/coverage.lcov"
 COBERTURA_XML="${BUILD_DIR}/coverage.cobertura.xml"
 LCOV_COBERTURA="${REPO_ROOT}/tools/scripts/lcov_cobertura.py"
+LCOV_STRIP_EXCL="${REPO_ROOT}/tools/scripts/lcov_strip_excl.py"
 
 if [ ! -f "${LCOV_COBERTURA}" ]; then
     echo "[local_diff_cover] missing converter: ${LCOV_COBERTURA}" >&2
     exit 1
 fi
+if [ ! -f "${LCOV_STRIP_EXCL}" ]; then
+    echo "[local_diff_cover] missing LCOV_EXCL stripper: ${LCOV_STRIP_EXCL}" >&2
+    exit 1
+fi
 
-echo "=== llvm-cov export → LCOV ==="
+echo "=== llvm-cov export → LCOV (raw) ==="
 llvm-cov export --format=lcov \
     "${BINARIES[@]}" \
     -instr-profile="${PROFDATA}" \
     -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
-    > "${LCOV_FILE}"
+    > "${LCOV_RAW}"
+
+# llvm-cov-export does NOT honor LCOV_EXCL_LINE / LCOV_EXCL_START..STOP
+# markers — those are a gcov/lcov convention. Without this strip step,
+# code wrapped in LCOV_EXCL still appears in the diff-cover "missing
+# lines" report (pulp #1058).
+echo "=== Strip LCOV_EXCL ranges → LCOV (filtered) ==="
+python3 "${LCOV_STRIP_EXCL}" "${LCOV_RAW}" "${LCOV_FILE}"
 
 echo "=== LCOV → Cobertura XML ==="
 python3 "${LCOV_COBERTURA}" "${LCOV_FILE}" \

--- a/tools/scripts/test_lcov_strip_excl.py
+++ b/tools/scripts/test_lcov_strip_excl.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Fixture tests for tools/scripts/lcov_strip_excl.py.
+
+Locks in the LCOV_EXCL propagation contract that closes pulp #1058.
+
+`llvm-cov export --format=lcov` does NOT honor `LCOV_EXCL_LINE` or
+`LCOV_EXCL_START..STOP` markers. Without `lcov_strip_excl.py`, lines
+inside an LCOV_EXCL block leak through into the Cobertura XML and the
+diff-cover "missing lines" report — turning the markers into
+documentation-only with no runtime effect.
+
+These tests fail loudly the moment that propagation step is removed
+from either `tools/scripts/local_diff_cover.sh` or
+`scripts/run_coverage.sh`, or if the strip helper itself stops
+honoring a marker.
+
+Run:
+    python3 tools/scripts/test_lcov_strip_excl.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from xml.etree import ElementTree as ET
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+STRIP_SCRIPT = REPO_ROOT / "tools" / "scripts" / "lcov_strip_excl.py"
+LOCAL_SCRIPT = REPO_ROOT / "tools" / "scripts" / "local_diff_cover.sh"
+CI_SCRIPT = REPO_ROOT / "scripts" / "run_coverage.sh"
+CONVERTER = REPO_ROOT / "tools" / "scripts" / "lcov_cobertura.py"
+
+
+def _import_strip_module():
+    """Import lcov_strip_excl as a module so we can call filter_lcov() in-process.
+
+    The script doubles as a CLI; importing lets the unit tests skip
+    subprocess overhead for the inner-loop assertions.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "lcov_strip_excl", str(STRIP_SCRIPT)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+lcov_strip_excl = _import_strip_module()
+
+
+# ---------------------------------------------------------------------------
+# Marker-grammar tests — feed source text directly to compute_exclusions
+# ---------------------------------------------------------------------------
+
+class ComputeExclusionsTests(unittest.TestCase):
+    """compute_exclusions() honors every LCOV_EXCL marker variant."""
+
+    def test_lcov_excl_line_marks_only_that_line(self) -> None:
+        src = "\n".join([
+            "int a;",            # 1
+            "int b; // LCOV_EXCL_LINE",  # 2
+            "int c;",            # 3
+        ])
+        em = lcov_strip_excl.compute_exclusions(src)
+        self.assertEqual(em.lines, {2})
+
+    def test_lcov_excl_start_stop_block_inclusive(self) -> None:
+        src = "\n".join([
+            "int a;",                       # 1
+            "// LCOV_EXCL_START",           # 2  (excluded — marker line)
+            "int b;",                       # 3  (excluded)
+            "int c;",                       # 4  (excluded)
+            "// LCOV_EXCL_STOP",            # 5  (excluded — marker line)
+            "int d;",                       # 6
+        ])
+        em = lcov_strip_excl.compute_exclusions(src)
+        self.assertEqual(em.lines, {2, 3, 4, 5})
+
+    def test_lcov_excl_br_line_branch_only(self) -> None:
+        src = "\n".join([
+            "int a;",                          # 1
+            "if (x) { y(); } // LCOV_EXCL_BR_LINE",  # 2
+            "int c;",                          # 3
+        ])
+        em = lcov_strip_excl.compute_exclusions(src)
+        self.assertEqual(em.lines, set(),
+                         "BR_LINE excludes branches only, not lines")
+        self.assertEqual(em.branch_lines, {2})
+
+    def test_orphan_stop_warns_and_no_exclusion(self) -> None:
+        src = "// LCOV_EXCL_STOP\nint a;\n"
+        em = lcov_strip_excl.compute_exclusions(src)
+        self.assertEqual(em.lines, set())
+
+    def test_unterminated_start_excludes_to_eof(self) -> None:
+        # lcov(1) behavior: orphan START excludes everything to EOF.
+        src = "int a;\n// LCOV_EXCL_START\nint b;\nint c;\n"
+        em = lcov_strip_excl.compute_exclusions(src)
+        # Lines 2, 3, 4 should be excluded.
+        self.assertIn(2, em.lines)
+        self.assertIn(3, em.lines)
+        self.assertIn(4, em.lines)
+
+    def test_word_boundary_does_not_match_substring(self) -> None:
+        # `LCOV_EXCL_LINE_FOO` is NOT a real marker; must not trigger.
+        src = "int a; // LCOV_EXCL_LINE_FOO\n"
+        em = lcov_strip_excl.compute_exclusions(src)
+        self.assertEqual(em.lines, set())
+
+
+# ---------------------------------------------------------------------------
+# End-to-end .lcov filter tests — fixtures + filter_lcov()
+# ---------------------------------------------------------------------------
+
+def _make_lcov_for(src_path: str, lines: list) -> str:
+    """Build a minimal .lcov record covering `lines` of file `src_path`.
+
+    `lines` is a list of (line_number, hits) pairs.
+    """
+    da = "\n".join(f"DA:{n},{hits}" for n, hits in lines)
+    lf = len(lines)
+    lh = sum(1 for _, h in lines if h > 0)
+    return f"TN:\nSF:{src_path}\n{da}\nLF:{lf}\nLH:{lh}\nend_of_record\n"
+
+
+class FilterLcovTests(unittest.TestCase):
+    """filter_lcov() drops DA records on LCOV_EXCL'd lines.
+
+    This is THE anti-drift test for #1058 — if the propagation step
+    ever stops working, this fails loudly with an actionable message.
+    """
+
+    def test_lines_inside_lcov_excl_block_do_not_appear_in_filtered_output(self) -> None:
+        # Source: 6 lines, lines 3-5 wrapped in LCOV_EXCL_START..STOP.
+        src = "\n".join([
+            "int a;",              # 1
+            "int b;",              # 2
+            "// LCOV_EXCL_START",  # 3
+            "int c;",              # 4
+            "// LCOV_EXCL_STOP",   # 5
+            "int d;",              # 6
+        ])
+        # Pretend llvm-cov-export emitted DA records for every line —
+        # this is the shape that exposes the bug: lines 3-5 are
+        # PRESENT in the .lcov even though they're LCOV_EXCL'd in src.
+        lcov_in = _make_lcov_for("/fake/foo.cpp", [
+            (1, 1), (2, 1), (3, 0), (4, 0), (5, 0), (6, 1),
+        ])
+        filtered = lcov_strip_excl.filter_lcov(
+            lcov_in,
+            source_lookup=lambda p: src if p == "/fake/foo.cpp" else None,
+        )
+        # Lines 3, 4, 5 must be gone.
+        for excluded in (3, 4, 5):
+            self.assertNotIn(
+                f"DA:{excluded},", filtered,
+                f"line {excluded} is inside LCOV_EXCL_START..STOP but "
+                f"still appears in filtered .lcov — propagation broken; "
+                f"see pulp #1058",
+            )
+        # Lines 1, 2, 6 must remain.
+        for kept in (1, 2, 6):
+            self.assertIn(f"DA:{kept},", filtered)
+
+    def test_lf_and_lh_recomputed_after_strip(self) -> None:
+        src = "// LCOV_EXCL_START\nint a;\n// LCOV_EXCL_STOP\nint b;\n"
+        lcov_in = _make_lcov_for("/fake/bar.cpp", [
+            (1, 0), (2, 0), (3, 0), (4, 1),
+        ])
+        # All 4 lines counted in the input.
+        self.assertIn("LF:4", lcov_in)
+        self.assertIn("LH:1", lcov_in)
+        filtered = lcov_strip_excl.filter_lcov(
+            lcov_in,
+            source_lookup=lambda p: src if p == "/fake/bar.cpp" else None,
+        )
+        # After filtering, only line 4 remains. LF must be 1, LH must be 1.
+        self.assertIn("LF:1", filtered)
+        self.assertIn("LH:1", filtered)
+        # And the stale totals must NOT be present.
+        self.assertNotIn("LF:4", filtered)
+
+    def test_brda_records_filtered_on_excluded_line(self) -> None:
+        src = "int a;\n// LCOV_EXCL_LINE\nint c;\n"
+        # Line 2 has a branch record we need to drop.
+        lcov_in = (
+            "TN:\n"
+            "SF:/fake/branchy.cpp\n"
+            "DA:1,1\n"
+            "DA:2,0\n"
+            "DA:3,1\n"
+            "BRDA:2,0,0,1\n"
+            "BRDA:2,0,1,0\n"
+            "BRDA:3,0,0,1\n"
+            "LF:3\nLH:2\n"
+            "BRF:3\nBRH:2\n"
+            "end_of_record\n"
+        )
+        filtered = lcov_strip_excl.filter_lcov(
+            lcov_in,
+            source_lookup=lambda p: src if p == "/fake/branchy.cpp" else None,
+        )
+        # Line-2 DA gone, line-2 BRDA gone, line-3 BRDA kept.
+        self.assertNotIn("DA:2,", filtered)
+        self.assertNotIn("BRDA:2,", filtered)
+        self.assertIn("BRDA:3,", filtered)
+
+    def test_no_markers_passes_through_unchanged(self) -> None:
+        # When the source has no LCOV_EXCL markers, nothing must change.
+        src = "int a;\nint b;\nint c;\n"
+        lcov_in = _make_lcov_for("/fake/clean.cpp", [(1, 1), (2, 1), (3, 1)])
+        filtered = lcov_strip_excl.filter_lcov(
+            lcov_in,
+            source_lookup=lambda p: src if p == "/fake/clean.cpp" else None,
+        )
+        for n in (1, 2, 3):
+            self.assertIn(f"DA:{n},1", filtered)
+        self.assertIn("LF:3", filtered)
+        self.assertIn("LH:3", filtered)
+
+    def test_unreadable_source_passes_records_through(self) -> None:
+        # If we can't open the source file (vendored / generated /
+        # outside-tree), records pass through — the strip helper must
+        # NOT drop coverage just because it failed to read the source.
+        lcov_in = _make_lcov_for("/no/such/file.cpp", [(1, 1), (2, 1)])
+        filtered = lcov_strip_excl.filter_lcov(
+            lcov_in,
+            source_lookup=lambda p: None,
+        )
+        self.assertIn("DA:1,1", filtered)
+        self.assertIn("DA:2,1", filtered)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end pipeline test — strip → cobertura. This is THE acceptance
+# criterion in pulp #1058: lines inside LCOV_EXCL must not appear in
+# the resulting Cobertura XML.
+# ---------------------------------------------------------------------------
+
+class CoberturaPropagationTests(unittest.TestCase):
+    """Verify LCOV_EXCL'd lines are stripped before reaching cobertura XML.
+
+    Invokes the strip helper as a subprocess (matching the way
+    local_diff_cover.sh / run_coverage.sh use it), then runs the
+    same lcov_cobertura.py converter, then asserts the excluded
+    line numbers are absent from the resulting <line number="..."/>
+    elements.
+    """
+
+    def test_lines_inside_lcov_excl_block_do_not_appear_in_cobertura(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = pathlib.Path(tmpdir)
+
+            # 1. Create a source file with an LCOV_EXCL'd block.
+            src_path = tmp / "subject.cpp"
+            src_path.write_text(
+                "int a = 1;\n"             # 1  kept
+                "int b = 2;\n"             # 2  kept
+                "// LCOV_EXCL_START\n"     # 3  excluded
+                "int c = 3;\n"             # 4  excluded
+                "int d = 4;\n"             # 5  excluded
+                "// LCOV_EXCL_STOP\n"      # 6  excluded
+                "int e = 5;\n"             # 7  kept
+            )
+
+            # 2. Synthesize the .lcov shape llvm-cov-export would emit
+            #    — note that lines 3-6 are PRESENT, exposing the bug.
+            raw_lcov = tmp / "raw.lcov"
+            raw_lcov.write_text(
+                f"TN:\n"
+                f"SF:{src_path}\n"
+                "DA:1,1\nDA:2,1\nDA:3,0\nDA:4,0\nDA:5,0\nDA:6,0\nDA:7,1\n"
+                "LF:7\nLH:3\n"
+                "end_of_record\n"
+            )
+
+            # 3. Run the strip helper as a subprocess (mirrors how the
+            #    real pipeline uses it).
+            filt_lcov = tmp / "filtered.lcov"
+            result = subprocess.run(
+                [sys.executable, str(STRIP_SCRIPT),
+                 str(raw_lcov), str(filt_lcov)],
+                capture_output=True, text=True, timeout=30,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(filt_lcov.exists())
+
+            # 4. Convert filtered .lcov → Cobertura XML.
+            xml_out = tmp / "cobertura.xml"
+            result = subprocess.run(
+                [sys.executable, str(CONVERTER), str(filt_lcov),
+                 "--output", str(xml_out),
+                 "--base-dir", tmpdir],
+                capture_output=True, text=True, timeout=30,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(xml_out.exists())
+
+            # 5. Parse the XML and collect every <line number="..."/>.
+            tree = ET.parse(xml_out)
+            line_numbers = {
+                int(el.get("number"))
+                for el in tree.iter("line")
+                if el.get("number") is not None
+            }
+
+            # Excluded lines must NOT be present. This is the
+            # acceptance criterion from pulp #1058.
+            for excluded in (3, 4, 5, 6):
+                self.assertNotIn(
+                    excluded, line_numbers,
+                    f"line {excluded} is inside LCOV_EXCL_START..STOP but "
+                    f"still appears in cobertura XML — propagation broken; "
+                    f"see pulp #1058. If you reverted the strip step in "
+                    f"local_diff_cover.sh / run_coverage.sh, restore it.",
+                )
+
+            # Sanity: lines we KEPT must be present.
+            for kept in (1, 2, 7):
+                self.assertIn(
+                    kept, line_numbers,
+                    f"line {kept} should remain in cobertura XML but is missing",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Wiring tests — both pipeline scripts must invoke the strip helper.
+# Anti-drift guard: if a future edit drops the strip step from one of
+# the scripts, the propagation gap reopens silently. These tests fail
+# the moment that wire is cut.
+# ---------------------------------------------------------------------------
+
+class PipelineWiringTests(unittest.TestCase):
+    """tools/scripts/local_diff_cover.sh and scripts/run_coverage.sh
+    must both run the LCOV_EXCL strip step BEFORE invoking the
+    Cobertura converter (pulp #1058).
+    """
+
+    def test_local_script_invokes_strip_helper(self) -> None:
+        text = LOCAL_SCRIPT.read_text()
+        self.assertIn(
+            "lcov_strip_excl.py", text,
+            "tools/scripts/local_diff_cover.sh must invoke "
+            "lcov_strip_excl.py between `llvm-cov export` and the "
+            "Cobertura converter — without it, LCOV_EXCL_START..STOP "
+            "markers leak into the diff-cover report (pulp #1058).",
+        )
+
+    def test_ci_script_invokes_strip_helper(self) -> None:
+        text = CI_SCRIPT.read_text()
+        self.assertIn(
+            "lcov_strip_excl.py", text,
+            "scripts/run_coverage.sh must invoke lcov_strip_excl.py "
+            "between `llvm-cov export` and the Cobertura converter — "
+            "without it, LCOV_EXCL_START..STOP markers leak into the "
+            "Cobertura XML uploaded to Codecov (pulp #1058).",
+        )
+
+    @staticmethod
+    def _exec_pos(text: str, var_name: str, needle: str) -> int:
+        """Return the offset of the FIRST `python3 "${VAR}"` invocation.
+
+        Variable assignments like `LCOV_COBERTURA="${REPO_ROOT}/.../lcov_cobertura.py"`
+        appear textually before the actual subprocess call. We want to
+        compare the order of EXECUTION — so we look for either:
+          1. `python3 "${LCOV_FOO}" ...`  (variable form, what we use), OR
+          2. `python3 [path/to/]<needle>` (literal form, future-proof).
+        """
+        # Variable form: python3 "${LCOV_STRIP_EXCL}"
+        var_form = re.compile(
+            r"python3\s+\"\$\{" + re.escape(var_name) + r"\}\"",
+        )
+        # Literal form: python3 path/to/lcov_strip_excl.py
+        lit_form = re.compile(
+            r"python3\s+(?:\")?(?:[^\s\"]*?/)?" + re.escape(needle),
+        )
+        positions = []
+        m = var_form.search(text)
+        if m:
+            positions.append(m.start())
+        m = lit_form.search(text)
+        if m:
+            positions.append(m.start())
+        return min(positions) if positions else -1
+
+    def test_strip_runs_before_cobertura_in_local_script(self) -> None:
+        # Order matters: strip must happen BEFORE the converter sees
+        # the file, otherwise the excluded lines are already in the
+        # XML by the time we'd strip.
+        text = LOCAL_SCRIPT.read_text()
+        strip_idx = self._exec_pos(text, "LCOV_STRIP_EXCL", "lcov_strip_excl.py")
+        cobertura_idx = self._exec_pos(text, "LCOV_COBERTURA", "lcov_cobertura.py")
+        self.assertGreater(strip_idx, 0,
+                           "no `python3 ... lcov_strip_excl.py` invocation")
+        self.assertGreater(cobertura_idx, 0,
+                           "no `python3 ... lcov_cobertura.py` invocation")
+        self.assertLess(
+            strip_idx, cobertura_idx,
+            "lcov_strip_excl.py must run BEFORE lcov_cobertura.py in "
+            "tools/scripts/local_diff_cover.sh — otherwise excluded "
+            "lines reach the Cobertura XML (pulp #1058).",
+        )
+
+    def test_strip_runs_before_cobertura_in_ci_script(self) -> None:
+        text = CI_SCRIPT.read_text()
+        strip_idx = self._exec_pos(text, "LCOV_STRIP_EXCL", "lcov_strip_excl.py")
+        cobertura_idx = self._exec_pos(text, "LCOV_COBERTURA", "lcov_cobertura.py")
+        self.assertGreater(strip_idx, 0,
+                           "no `python3 ... lcov_strip_excl.py` invocation")
+        self.assertGreater(cobertura_idx, 0,
+                           "no `python3 ... lcov_cobertura.py` invocation")
+        self.assertLess(
+            strip_idx, cobertura_idx,
+            "lcov_strip_excl.py must run BEFORE lcov_cobertura.py in "
+            "scripts/run_coverage.sh — otherwise excluded lines reach "
+            "the Cobertura XML uploaded to Codecov (pulp #1058).",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

`llvm-cov export --format=lcov` does NOT honor `LCOV_EXCL_LINE` / `LCOV_EXCL_START..STOP` markers — those are a `gcov`/`lcov` convention, not an LLVM one. Without a strip pass between `llvm-cov export` and the Cobertura converter, code wrapped in `LCOV_EXCL` still appears in diff-cover's missing-lines report and in the Cobertura XML uploaded to Codecov, making the markers documentation-only.

This was the gap that forced PR #1005's `**/scanner_clap.cpp` file-level workaround in `diff_cover_excludes` (since reverted on main), and it's the toolchain bug tracked in #1058.

## Audit confirmation

- `grep LCOV_EXCL core/host/src/scanner_clap.cpp` on `origin/main` → 0 hits (the LCOV_EXCL bracketing from PR #1005 was rolled back when the file-level exclude was rolled back). The bug itself is structural: `llvm-cov-export` ignores LCOV markers regardless of where they live, so any future LCOV_EXCL anywhere in the tree would silently fail to propagate.
- `**/scanner_clap.cpp` is **not** currently in `tools/scripts/coverage_config.json`'s `diff_cover_excludes` on `origin/main`, so there is nothing to remove in this PR (per the issue's "DO NOT drop" boundary, which is already satisfied).
- Verified by reverting the strip wire in `local_diff_cover.sh` and running the new wiring test: `AssertionError: -1 not greater than 0 : no `python3 ... lcov_strip_excl.py` invocation`. Restoring the wire makes the test pass.

## Path chosen — Path B (Python helper)

Picked over Path A (insert `lcov --remove`) because:

- The issue's **Boundaries** explicitly call out: "DO NOT add lcov as a hard dep on developer machines without the lazy-prompt pattern." Path B avoids the dep entirely.
- Cross-platform: `lcov` is non-trivial on Windows, easy on macOS via Homebrew, easy on Linux via apt — Python is already on every developer machine and every Pulp CI lane.
- Pulp already vendors `tools/scripts/lcov_cobertura.py` (a Python script), so this fits the existing pattern.
- Pure-Python is faster to test (we ship 16 fixture tests that run in ~0.1s each).

The cost is ~330 lines of Python to maintain. Acceptable given the alternative is a multi-platform dep-preflight + brew/apt install paths in three scripts.

## Changes

- **`tools/scripts/lcov_strip_excl.py`** (new) — pure-Python helper. Walks each `SF:<path>` record, opens the source, scans for `LCOV_EXCL_*` markers, and drops `DA:` / `BRDA:` / `FN[A]:` / `FNDA:` records on excluded lines. Recomputes `LF` / `LH` / `BRF` / `BRH` / `FNF` / `FNH` counters. Honors `LINE`, `START`, `STOP`, `BR_LINE`, `BR_START`, `BR_STOP`. Orphan markers warn but degrade safely (lcov(1)-compatible behavior).
- **`tools/scripts/local_diff_cover.sh`** — wires the strip step between `llvm-cov export` and the Cobertura converter. Adds an existence preflight on `lcov_strip_excl.py`.
- **`scripts/run_coverage.sh`** — same wiring on the CI lane.
- **`tools/scripts/test_lcov_strip_excl.py`** (new) — 16 fixture tests:
  - Marker-grammar tests (`compute_exclusions` over each marker variant + edge cases).
  - `.lcov` filter tests (DA/BRDA drops, LF/LH recompute, no-marker passthrough, unreadable-source passthrough).
  - **End-to-end test** (the headline acceptance criterion from #1058): synthesize a source with `LCOV_EXCL_START..STOP`, synthesize the matching `.lcov`, run the strip script as a subprocess, run the Cobertura converter, parse the XML, assert excluded line numbers do NOT appear as `<line number="..."/>` elements.
  - Pipeline-wiring tests: both shell scripts must invoke the strip helper, and the strip step must run BEFORE the Cobertura converter.

## Acceptance (from #1058)

- [x] Audit recipe run; bug confirmed (structural — LCOV_EXCL markers don't propagate through `llvm-cov export`).
- [x] PR landing the chosen fix path + structural test.
- [x] Test verified to fail when the propagation step is removed (reverted strip wire → wiring test fails with actionable message).
- [ ] **Follow-up after merge**: the `**/scanner_clap.cpp` entry can be removed from `coverage_config.json`'s `diff_cover_excludes` once it's needed again. It's NOT in the excludes list on `origin/main` today, so there's nothing to remove in this PR. Mention in the changelog when the strip path is verified working in CI.

## Boundaries respected

- Did NOT drop anything from `coverage_config.json`'s `diff_cover_excludes` (the boundary).
- Did NOT change the diff-cover threshold.
- Did NOT add `lcov` as a hard dep — Path B uses pure Python.
- Tests ship with the fix in this PR, per CLAUDE.md "Tests ship with fixes".

## Test plan

- [x] `python3 tools/scripts/test_lcov_strip_excl.py` — 16/16 pass locally.
- [x] `python3 tools/scripts/test_local_diff_cover.py` — 8/8 still pass (no regression).
- [x] `python3 tools/scripts/test_lcov_cobertura.py` — 3/3 still pass.
- [x] `python3 tools/scripts/test_run_coverage.py` — 13/13 still pass.
- [x] CLI sanity check: synthesized .lcov with LCOV_EXCL'd lines → strip script removes them and recomputes LF/LH correctly.
- [ ] CI's coverage workflow (`.github/workflows/coverage.yml`) still produces a non-empty Cobertura XML on the macOS / Linux / Windows lanes.

Closes #1058
Refs #1049