### PR TITLE
fix(version-bump): reject malformed bypass trailers and emit diagnostics

### DIFF
--- a/docs/guides/versioning.md
+++ b/docs/guides/versioning.md
@@ -236,6 +236,31 @@ All three bypass trailers live on the tip commit, never in the PR body. The audi
 
 A bypass is a recorded admission that the author thought about the rule and decided it doesn't apply. Empty-reason bypasses are rejected.
 
+### `Version-Bump:` trailer parsing rules (#1054)
+
+`tools/scripts/version_bump_check.py` rejects malformed bypass
+trailers loudly instead of silently accepting them:
+
+- **Surface name is anchored.** The `<surface>` token must be a
+  recognized surface (currently `sdk`, `plugin`) on a word boundary —
+  `Version-Bump: mysdk=skip reason="x"` no longer parses as `sdk=skip`.
+- **`reason="..."` is required and must be non-empty.** Trailers with
+  no `reason=`, `reason=""`, or whitespace-only `reason="   "` fall
+  through and the gate stays active. The reason string is the
+  audit-trail-of-record per CLAUDE.md; an empty justification defeats
+  the trailer's purpose.
+- **Unknown-surface typos surface a `[trailer-warning]`.** A trailer
+  like `Version-Bump: cli=skip reason="x"` (no `cli` surface exists)
+  used to silently parse as absent, leaving the author guessing why
+  the gate still failed. The diagnostic now prints the offending
+  trailer alongside a `Did you mean?` Levenshtein suggestion (distance
+  ≤ max(2, len/3)) before the per-surface verdicts. Bogus levels and
+  the legacy `none` sentinel are reported with the same shape.
+
+The contract is locked in by `test_version_bump_check.py`'s
+`SurfaceTrailerOverrideHardening`, `CollectTrailerDiagnosticsHardening`,
+and `TrailerParsingEdgeCases` test classes.
+
 The compat-update gate uses the same three-layer pattern as the
 version-bump and skill-update gates; see [compat-sync.md](compat-sync.md)
 for the path map, requirement kinds, and rollout state (#1029 / #1027).

--- a/tools/scripts/test_version_bump_check.py
+++ b/tools/scripts/test_version_bump_check.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Anti-drift tests for ``version_bump_check.py`` trailer parsing.
+
+Locks in the contract for the bypass-trailer parser hardening landed
+for issue #1054. The audit found three silent-acceptance bugs and one
+silent-no-op bug in the pre-#1054 parser:
+
+1. ``mysdk=skip`` parsed as ``sdk=skip`` — substring left-attached typo
+   silently bypassed the gate. (silent acceptance)
+2. ``Version-Bump: sdk=skip`` (no ``reason=``) was honored. (silent
+   acceptance — no audit-trail string)
+3. ``Version-Bump: sdk=skip reason=""`` (empty reason) was honored.
+   (silent acceptance — empty audit-trail string)
+4. ``Version-Bump: cli=skip reason="x"`` (typo'd surface) parsed as
+   absent with no diagnostic, leaving the author with a confusing
+   "missing version bump" error and no way to know their bypass was
+   rejected. (silent no-op)
+
+Each test below deliberately fails if the hardening in
+``surface_trailer_override`` / ``collect_trailer_diagnostics`` is
+reverted, mirroring the pattern in ``test_local_diff_cover.py`` (see
+commits ``efefe144`` + ``b258730c`` for the precedent).
+
+Refs: #1054, #1049, #290 ("tests ship with fixes").
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+# Import the parser surface under test. Imported by name to keep the
+# anti-drift tests pinned to the exact public API the script exposes.
+import version_bump_check as vbc  # noqa: E402
+
+
+KNOWN_SURFACES = ["sdk", "plugin"]
+
+
+def _trailers_from_body(body: str) -> dict[str, list[str]]:
+    """Parse a synthetic commit body the same way ``git_range_trailers``
+    does — feed it through ``git interpret-trailers --parse`` and group
+    the resulting key/value pairs by lowercased trailer key.
+
+    A multi-line body (subject + blank + body) is required; ``git
+    interpret-trailers`` returns nothing for a single-line input.
+    """
+    out = subprocess.run(
+        ["git", "interpret-trailers", "--parse"],
+        input=body, capture_output=True, text=True, check=True,
+    )
+    result: dict[str, list[str]] = {}
+    for line in out.stdout.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        result.setdefault(key.strip().lower(), []).append(value.strip())
+    return result
+
+
+class SurfaceTrailerOverrideHardening(unittest.TestCase):
+    """Behavior contracts for ``surface_trailer_override``.
+
+    Every test pairs the structurally-malformed input that USED to
+    silently bypass the gate (pre-#1054) with the strict-rejection
+    behavior the audit installed.
+    """
+
+    # ── Substring left-attached typo (silent acceptance bug) ─────────
+
+    def test_mysdk_skip_does_not_match_sdk_surface(self):
+        """``mysdk=skip`` must not be honored as a bypass for ``sdk``.
+
+        Pre-#1054 the regex was ``rf"{surface}\\s*=\\s*..."`` — unanchored
+        on the left, so ``mysdk=skip`` substring-matched ``sdk=skip``
+        and silently bypassed the gate. If this test fails, the regex
+        in ``_surface_name_regex`` has lost its left-side word boundary
+        (``(?:^|[\\s,;])`` prefix).
+        """
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: mysdk=skip reason="x"'
+        )
+        self.assertIsNone(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "sdk"),
+            "mysdk=skip silently parsed as sdk=skip — substring bug "
+            "regressed (#1054). The surface match must be anchored on a "
+            "word boundary.",
+        )
+
+    def test_sdkx_skip_does_not_match_sdk_surface(self):
+        """Right-side substring is also rejected.
+
+        The pre-#1054 regex happened to fail on right-attached typos
+        like ``sdkx`` because ``([A-Za-z]+)`` was greedy and consumed
+        ``x`` into the level group. The hardening adds a trailing
+        ``\\b`` anchor to make this rejection explicit instead of
+        accidental.
+        """
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: sdkx=skip reason="x"'
+        )
+        self.assertIsNone(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "sdk"),
+            "sdkx=skip silently parsed as sdk=<level> — right-boundary "
+            "anchor regressed (#1054).",
+        )
+
+    # ── Missing reason (silent acceptance bug) ───────────────────────
+
+    def test_skip_without_reason_is_rejected(self):
+        """``Version-Bump: sdk=skip`` with no ``reason="..."`` falls
+        through. Pre-#1054 the gate accepted it silently, defeating the
+        audit-trail-of-record contract.
+        """
+        trailers = _trailers_from_body(
+            "subj\n\nVersion-Bump: sdk=skip"
+        )
+        self.assertIsNone(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "sdk"),
+            "Bypass without reason=\"...\" silently honored — "
+            "audit-trail contract regressed (#1054).",
+        )
+
+    def test_skip_with_empty_reason_is_rejected(self):
+        """``reason=""`` (empty quotes) is rejected — empty string is
+        not a justification.
+        """
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: sdk=skip reason=""'
+        )
+        self.assertIsNone(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "sdk"),
+            'reason="" silently honored — empty-justification check '
+            "regressed (#1054).",
+        )
+
+    def test_skip_with_whitespace_only_reason_is_rejected(self):
+        """``reason="   "`` (whitespace-only) is rejected — must contain
+        a non-whitespace character.
+        """
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: sdk=skip reason="   "'
+        )
+        self.assertIsNone(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "sdk"),
+            'whitespace-only reason silently honored — '
+            "_has_nonempty_reason regressed (#1054).",
+        )
+
+    # ── Canonical positive cases (must remain green) ─────────────────
+
+    def test_canonical_skip_with_reason_is_honored(self):
+        """``sdk=skip reason="..."`` continues to work — the
+        anti-drift hardening must not break the documented grammar.
+        """
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: sdk=skip reason="legitimate"'
+        )
+        self.assertEqual(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "sdk"),
+            "skip",
+        )
+
+    def test_canonical_patch_with_reason_is_honored(self):
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: plugin=patch reason="docs-only"'
+        )
+        self.assertEqual(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "plugin"),
+            "patch",
+        )
+
+    def test_canonical_levels_all_accepted(self):
+        """All four documented levels are accepted (when paired with a
+        non-empty reason)."""
+        for level in ("patch", "minor", "major", "skip"):
+            with self.subTest(level=level):
+                trailers = _trailers_from_body(
+                    f'subj\n\nVersion-Bump: sdk={level} reason="ok"'
+                )
+                self.assertEqual(
+                    vbc.surface_trailer_override(
+                        trailers, "Version-Bump", "sdk"
+                    ),
+                    level,
+                )
+
+    def test_none_sentinel_is_rejected(self):
+        """``Version-Bump: sdk=none`` must be rejected even with a
+        valid reason — the ``none`` sentinel is a heuristic-pipeline
+        internal value, not a trailer level. Pre-existing behavior
+        from #629; locked in here so it can't drift.
+        """
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: sdk=none reason="bypass"'
+        )
+        self.assertIsNone(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "sdk"),
+        )
+
+    def test_bogus_level_is_rejected(self):
+        """Any level outside the known set falls through."""
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: sdk=foobar reason="x"'
+        )
+        self.assertIsNone(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "sdk"),
+        )
+
+    def test_multiple_trailers_each_resolve_correctly(self):
+        """When two valid trailers appear (no blank line between them),
+        each surface picks up its own level."""
+        trailers = _trailers_from_body(
+            'subj\n\n'
+            'Version-Bump: sdk=skip reason="a"\n'
+            'Version-Bump: plugin=patch reason="b"'
+        )
+        self.assertEqual(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "sdk"),
+            "skip",
+        )
+        self.assertEqual(
+            vbc.surface_trailer_override(trailers, "Version-Bump", "plugin"),
+            "patch",
+        )
+
+
+class CollectTrailerDiagnosticsHardening(unittest.TestCase):
+    """Behavior contracts for ``collect_trailer_diagnostics``.
+
+    The diagnostic surface is the user-visible half of the #1054 fix:
+    when a malformed trailer is rejected by ``surface_trailer_override``,
+    the author needs a clear "did you mean?" or "add a reason" message
+    instead of the generic "missing version bump" failure.
+    """
+
+    def test_unknown_surface_emits_did_you_mean_hint(self):
+        """``Version-Bump: cli=skip reason="x"`` (typo of ``sdk``) must
+        emit a diagnostic naming the closest known surface.
+
+        Pre-#1054 this case parsed as absent with no warning — the
+        author saw "missing version bump" and had to guess why. If
+        this test fails, ``collect_trailer_diagnostics`` has lost its
+        unknown-surface branch.
+        """
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: cli=skip reason="x"'
+        )
+        diag = vbc.collect_trailer_diagnostics(
+            trailers, "Version-Bump", KNOWN_SURFACES,
+        )
+        self.assertEqual(len(diag), 1, f"expected 1 diagnostic, got {diag!r}")
+        self.assertIn("unknown surface", diag[0])
+        self.assertIn("`cli`", diag[0])
+        self.assertIn("Known surfaces", diag[0])
+
+    def test_close_typo_suggests_correction(self):
+        """A small-edit-distance typo emits a ``Did you mean?`` hint."""
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: pluggin=skip reason="x"'
+        )
+        diag = vbc.collect_trailer_diagnostics(
+            trailers, "Version-Bump", KNOWN_SURFACES,
+        )
+        self.assertTrue(
+            any("Did you mean `plugin`" in d for d in diag),
+            f"close-typo hint missing — diagnostics: {diag!r}",
+        )
+
+    def test_substring_typo_emits_diagnostic(self):
+        """``mysdk=skip`` is rejected by the parser AND surfaces a
+        diagnostic — the user sees the bypass was rejected.
+        """
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: mysdk=skip reason="x"'
+        )
+        diag = vbc.collect_trailer_diagnostics(
+            trailers, "Version-Bump", KNOWN_SURFACES,
+        )
+        self.assertTrue(
+            any("`mysdk`" in d for d in diag),
+            f"mysdk diagnostic missing — diagnostics: {diag!r}",
+        )
+
+    def test_missing_reason_emits_diagnostic(self):
+        """A bypass without ``reason="..."`` produces a diagnostic
+        explaining the audit-trail-of-record contract.
+        """
+        trailers = _trailers_from_body(
+            "subj\n\nVersion-Bump: sdk=skip"
+        )
+        diag = vbc.collect_trailer_diagnostics(
+            trailers, "Version-Bump", KNOWN_SURFACES,
+        )
+        self.assertTrue(
+            any("missing a non-empty `reason" in d for d in diag),
+            f"missing-reason diagnostic missing — diagnostics: {diag!r}",
+        )
+
+    def test_empty_reason_emits_diagnostic(self):
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: sdk=skip reason=""'
+        )
+        diag = vbc.collect_trailer_diagnostics(
+            trailers, "Version-Bump", KNOWN_SURFACES,
+        )
+        self.assertTrue(
+            any("missing a non-empty `reason" in d for d in diag),
+            f"empty-reason diagnostic missing — diagnostics: {diag!r}",
+        )
+
+    def test_none_sentinel_emits_diagnostic(self):
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: sdk=none reason="x"'
+        )
+        diag = vbc.collect_trailer_diagnostics(
+            trailers, "Version-Bump", KNOWN_SURFACES,
+        )
+        self.assertTrue(
+            any("not a valid bypass level" in d for d in diag),
+            f"none-sentinel diagnostic missing — diagnostics: {diag!r}",
+        )
+
+    def test_bogus_level_emits_diagnostic(self):
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: sdk=foobar reason="x"'
+        )
+        diag = vbc.collect_trailer_diagnostics(
+            trailers, "Version-Bump", KNOWN_SURFACES,
+        )
+        self.assertTrue(
+            any("unrecognised level" in d for d in diag),
+            f"bogus-level diagnostic missing — diagnostics: {diag!r}",
+        )
+
+    def test_canonical_trailer_emits_no_diagnostic(self):
+        """Well-formed trailers must NOT produce diagnostics — the
+        warning surface is reserved for actual bugs.
+        """
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: sdk=skip reason="legit"'
+        )
+        diag = vbc.collect_trailer_diagnostics(
+            trailers, "Version-Bump", KNOWN_SURFACES,
+        )
+        self.assertEqual(
+            diag, [],
+            f"canonical trailer falsely flagged: {diag!r}",
+        )
+
+    def test_canonical_patch_emits_no_diagnostic(self):
+        trailers = _trailers_from_body(
+            'subj\n\nVersion-Bump: plugin=patch reason="x"'
+        )
+        diag = vbc.collect_trailer_diagnostics(
+            trailers, "Version-Bump", KNOWN_SURFACES,
+        )
+        self.assertEqual(diag, [])
+
+    def test_no_trailer_emits_no_diagnostic(self):
+        """A commit with no Version-Bump trailer at all produces no
+        diagnostics (it's the absent-trailer case the per-surface
+        verdict pipeline handles)."""
+        trailers = _trailers_from_body(
+            "subj\n\nJust a normal commit body."
+        )
+        diag = vbc.collect_trailer_diagnostics(
+            trailers, "Version-Bump", KNOWN_SURFACES,
+        )
+        self.assertEqual(diag, [])
+
+
+class TrailerParsingEdgeCases(unittest.TestCase):
+    """End-to-end pipeline contract — locks the audit recipe from
+    issue #1054 directly into the test suite.
+
+    Each entry is one of the cases the audit recipe enumerates,
+    paired with the post-#1054 expected behavior. If this test fails,
+    the parser has drifted away from the contract recorded in #1054.
+    """
+
+    # (label, commit body, expected per-surface verdicts, must produce >=1 diagnostic)
+    CASES: list[tuple[str, str, dict[str, str | None], bool]] = [
+        (
+            "canonical sdk=skip",
+            'subj\n\nVersion-Bump: sdk=skip reason="x"',
+            {"sdk": "skip", "plugin": None},
+            False,
+        ),
+        (
+            "no space after colon",
+            'subj\n\nVersion-Bump:sdk=skip reason="x"',
+            # `git interpret-trailers --parse` accepts `Trailer:value`
+            # without the canonical space — exercise the documented
+            # forgiving behavior.
+            {"sdk": "skip", "plugin": None},
+            False,
+        ),
+        (
+            "missing reason",
+            "subj\n\nVersion-Bump: sdk=skip",
+            {"sdk": None, "plugin": None},
+            True,
+        ),
+        (
+            "bad surface (cli)",
+            'subj\n\nVersion-Bump: cli=skip reason="x"',
+            {"sdk": None, "plugin": None},
+            True,
+        ),
+        (
+            "absent",
+            "subj\n\nNothing to see here.",
+            {"sdk": None, "plugin": None},
+            False,
+        ),
+    ]
+
+    def test_audit_recipe_cases_match_contract(self):
+        for label, body, expected, expect_diag in self.CASES:
+            with self.subTest(case=label):
+                trailers = _trailers_from_body(body)
+                for surface, want in expected.items():
+                    got = vbc.surface_trailer_override(
+                        trailers, "Version-Bump", surface,
+                    )
+                    self.assertEqual(
+                        got, want,
+                        f"[{label}] surface={surface}: "
+                        f"want={want!r}, got={got!r}",
+                    )
+                diag = vbc.collect_trailer_diagnostics(
+                    trailers, "Version-Bump", KNOWN_SURFACES,
+                )
+                if expect_diag:
+                    self.assertTrue(
+                        diag,
+                        f"[{label}] expected at least one diagnostic, "
+                        f"got none.",
+                    )
+                else:
+                    self.assertFalse(
+                        diag,
+                        f"[{label}] expected no diagnostic, got {diag!r}.",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/version_bump_check.py
+++ b/tools/scripts/version_bump_check.py
@@ -510,6 +510,33 @@ def heuristic_for_surface(
     return "patch"
 
 
+# Valid trailer levels (per the documented grammar). `none` is a sentinel
+# inside the heuristic pipeline only; it is NOT accepted from a trailer.
+_TRAILER_LEVELS = frozenset({"patch", "minor", "major", "skip"})
+
+# Anchored surface-name match: surface name must be at the start of the
+# value OR follow a whitespace / comma / semicolon boundary. Prevents
+# `mysdk=skip` from silently parsing as `sdk=skip` (substring bug
+# documented in issue #1054).
+def _surface_name_regex(surface_name: str) -> "re.Pattern[str]":
+    return re.compile(
+        rf"(?:^|[\s,;]){re.escape(surface_name)}\s*=\s*([A-Za-z]+)\b"
+    )
+
+
+# Reason="..." must be present AND non-empty for any trailer that wants
+# to be honored as a bypass. Issue #1054: `Version-Bump: sdk=skip` (no
+# reason) and `Version-Bump: sdk=skip reason=""` previously parsed as
+# valid skip overrides — silent acceptance of a bypass without the
+# author recording WHY defeats the trailer's purpose.
+_REASON_RE = re.compile(r'reason\s*=\s*"([^"]*)"')
+
+
+def _has_nonempty_reason(value: str) -> bool:
+    m = _REASON_RE.search(value)
+    return bool(m and m.group(1).strip())
+
+
 def surface_trailer_override(
     trailers: dict[str, list[str]],
     trailer_key: str,
@@ -525,17 +552,149 @@ def surface_trailer_override(
     `major` heuristic to "no bump needed", bypassing the gate. Codex
     review on PR #629 caught this. Reject `none` here as defense-in-
     depth; the call site at `assess_surfaces` also filters it out.
+
+    Issue #1054 hardening:
+        - Surface match is anchored on a word boundary; `mysdk=skip` no
+          longer parses as `sdk=skip`.
+        - A non-empty `reason="..."` is required. Bypasses without a
+          reason (or with `reason=""`) fall through, and the gate
+          remains active. `collect_trailer_diagnostics` emits a clear
+          diagnostic so the author understands why their bypass was
+          rejected.
     """
+    pat = _surface_name_regex(surface_name)
     for v in trailers.get(trailer_key.lower(), []):
-        m = re.search(rf"{re.escape(surface_name)}\s*=\s*([A-Za-z]+)", v)
+        m = pat.search(v)
         if not m:
             continue
         level = m.group(1).lower()
         if level == "none":
             continue
-        if level in LEVELS or level == "skip":
-            return level
+        if level not in _TRAILER_LEVELS:
+            continue
+        # Bypass without a recorded justification is rejected — the
+        # `reason="..."` string is the audit-trail-of-record. See
+        # collect_trailer_diagnostics for the user-visible message.
+        if not _has_nonempty_reason(v):
+            continue
+        return level
     return None
+
+
+# ── Trailer diagnostics (issue #1054) ───────────────────────────────────
+
+
+def _suggest_surface(unknown: str, known: list[str]) -> str | None:
+    """Return the closest known surface name (Levenshtein-ish) or None.
+
+    Only suggests when the edit distance is small enough that a typo is
+    plausible — otherwise returns None and the caller skips the hint.
+    """
+    if not known:
+        return None
+    # Tiny distance = max(2, len/3): tolerates 1-char typos always,
+    # and ~33% mangling on longer names (`pluggin` for `plugin`).
+    threshold = max(2, len(unknown) // 3)
+    best = None
+    best_dist = threshold + 1
+    for cand in known:
+        # Standard iterative DP Levenshtein (small strings).
+        a, b = unknown, cand
+        if abs(len(a) - len(b)) > threshold:
+            continue
+        prev = list(range(len(b) + 1))
+        for i, ca in enumerate(a, 1):
+            cur = [i]
+            for j, cb in enumerate(b, 1):
+                ins = cur[j - 1] + 1
+                dele = prev[j] + 1
+                sub = prev[j - 1] + (0 if ca == cb else 1)
+                cur.append(min(ins, dele, sub))
+            prev = cur
+        d = prev[-1]
+        if d < best_dist:
+            best_dist = d
+            best = cand
+    return best
+
+
+def collect_trailer_diagnostics(
+    trailers: dict[str, list[str]],
+    trailer_key: str,
+    known_surfaces: list[str],
+) -> list[str]:
+    """Inspect every `Version-Bump:` trailer and return human-readable
+    diagnostics for shapes that look like bypass attempts but were
+    rejected by `surface_trailer_override`.
+
+    Detects (issue #1054):
+        - Unknown surface names (`Version-Bump: cli=skip reason="x"`
+          when no `cli` surface exists) — suggests the closest known
+          surface if one looks like a typo.
+        - Missing or empty `reason="..."` — the bypass parses
+          structurally but is rejected because the audit-trail string
+          is empty.
+        - The `none` sentinel — silently rejected by parser (only valid
+          inside heuristic pipeline).
+        - Malformed level values not in {patch,minor,major,skip}.
+
+    Returns a list of `[trailer-warning] ...` strings. Empty list when
+    every trailer is either canonical or absent.
+    """
+    diagnostics: list[str] = []
+    # Match any `<token>=<level>` that LOOKS like a bypass attempt, even
+    # if the surface or level is unknown. Anchored the same way as
+    # `_surface_name_regex` so we only flag values that could have been
+    # intended as bypasses (not arbitrary `=` characters in prose).
+    bypass_re = re.compile(
+        r"(?:^|[\s,;])([A-Za-z][A-Za-z0-9_-]*)\s*=\s*([A-Za-z]+)\b"
+    )
+    for v in trailers.get(trailer_key.lower(), []):
+        for m in bypass_re.finditer(v):
+            surface = m.group(1)
+            level = m.group(2).lower()
+
+            # Sentinel `none` is a known-bad value (#629).
+            if level == "none":
+                diagnostics.append(
+                    f"[trailer-warning] `{surface}=none` is not a valid "
+                    "bypass level — only patch/minor/major/skip are accepted."
+                )
+                continue
+
+            if level not in _TRAILER_LEVELS:
+                diagnostics.append(
+                    f"[trailer-warning] `{surface}={level}` has an "
+                    "unrecognised level. Valid levels: patch, minor, "
+                    "major, skip."
+                )
+                continue
+
+            if surface not in known_surfaces:
+                hint = _suggest_surface(surface, known_surfaces)
+                if hint:
+                    diagnostics.append(
+                        f"[trailer-warning] `{surface}={level}` references "
+                        f"unknown surface `{surface}`. Did you mean "
+                        f"`{hint}`?  Known surfaces: "
+                        f"{', '.join(sorted(known_surfaces))}."
+                    )
+                else:
+                    diagnostics.append(
+                        f"[trailer-warning] `{surface}={level}` references "
+                        f"unknown surface `{surface}`. Known surfaces: "
+                        f"{', '.join(sorted(known_surfaces))}."
+                    )
+                continue
+
+            if not _has_nonempty_reason(v):
+                diagnostics.append(
+                    f"[trailer-warning] `{surface}={level}` is missing a "
+                    'non-empty `reason="..."`. Bypass without a recorded '
+                    "justification is rejected — add a reason explaining "
+                    "why this surface should not bump."
+                )
+    return diagnostics
 
 
 # ── Version bumping arithmetic ──────────────────────────────────────────
@@ -706,10 +865,20 @@ def render_report(
     mode: str,
     base: str,
     repo: Path,
+    diagnostics: list[str] | None = None,
 ) -> tuple[str, int]:
     lines: list[str] = []
     failures = 0
     warnings = 0
+    # Surface trailer-shape diagnostics first so authors see them BEFORE
+    # the per-surface verdicts. Issue #1054: a malformed bypass trailer
+    # used to silently no-op (or worse, silently bypass via substring
+    # match) — now we tell the author exactly which trailer was rejected
+    # and why, so they don't have to guess.
+    if diagnostics:
+        for d in diagnostics:
+            lines.append(d)
+        lines.append("")
     for v in verdicts:
         if v.final_level == "none":
             lines.append(f"[{v.surface.name}] {v.surface.label}: no bump needed")
@@ -984,11 +1153,23 @@ def main(argv: list[str]) -> int:
 
     verdicts = assess_surfaces(cfg, changed, args.base, args.head, root)
 
+    # Issue #1054: surface trailer-shape diagnostics so authors see
+    # exactly which malformed bypass trailer was rejected, instead of
+    # the generic "missing version bump" error.
+    range_trailers = git_range_trailers(args.base, args.head)
+    known_surfaces = [s.name for s in cfg.surfaces]
+    diagnostics = collect_trailer_diagnostics(
+        range_trailers, cfg.trailer_version_bump, known_surfaces
+    )
+
     if args.mode == "apply":
         edited = apply_bumps(verdicts, args.base, root)
         # Re-assess after editing: re-read current versions and re-check.
         verdicts_after = assess_surfaces(cfg, changed, args.base, args.head, root)
-        text, code = render_report(verdicts_after, mode="report", base=args.base, repo=root)
+        text, code = render_report(
+            verdicts_after, mode="report", base=args.base, repo=root,
+            diagnostics=diagnostics,
+        )
         if edited:
             print("Edited files:")
             for e in edited:
@@ -1012,7 +1193,9 @@ def main(argv: list[str]) -> int:
                 return 1
         return code
 
-    text, code = render_report(verdicts, args.mode, args.base, root)
+    text, code = render_report(
+        verdicts, args.mode, args.base, root, diagnostics=diagnostics,
+    )
     if text:
         print(text)
 


### PR DESCRIPTION
## Summary

Hardens `tools/scripts/version_bump_check.py` against four `Version-Bump:` trailer parsing edge cases identified in the issue #1054 audit:

1. **Substring left-attached typos** — `Version-Bump: mysdk=skip reason="x"` previously parsed as `sdk=skip` because the surface-match regex was unanchored on the left. Now anchored on `(?:^|[\s,;])` + trailing `\b`.
2. **Missing `reason=`** — `Version-Bump: sdk=skip` (no reason) was silently honored. Now the bypass falls through; the gate stays active.
3. **Empty / whitespace-only `reason`** — `reason=""` and `reason="   "` were silently honored. Now rejected via `_has_nonempty_reason()`.
4. **Unknown surface names** — `Version-Bump: cli=skip reason="x"` (typo) parsed as absent with no diagnostic. Now `collect_trailer_diagnostics()` emits a `[trailer-warning] ... Did you mean ...?` line in the report, surfacing the rejection BEFORE the per-surface verdicts.

The fix is purely additive — canonical bypasses (`Version-Bump: <surface>=<level> reason="..."`) continue to work unchanged, and the gate's behavior for absent trailers is identical.

## Audit findings (run against pre-fix script)

```
Case                          | sdk    | plugin | bug
substring left typo (mysdk)   | skip   | None   | silent acceptance
missing reason                | skip   | None   | silent acceptance
empty reason                  | skip   | None   | silent acceptance
typo: cli (unknown surface)   | None   | None   | silent no-op (no warning)
```

After the fix:

```
Case                          | sdk    | plugin | diagnostics
substring left typo (mysdk)   | None   | None   | mysdk references unknown surface. Did you mean sdk?
missing reason                | None   | None   | sdk=skip is missing a non-empty reason="..."
empty reason                  | None   | None   | sdk=skip is missing a non-empty reason="..."
typo: cli (unknown surface)   | None   | None   | cli=skip references unknown surface. Known: plugin, sdk
canonical sdk=skip reason="x" | skip   | None   | (none — well-formed)
```

## Anti-drift coverage

`tools/scripts/test_version_bump_check.py` adds 22 tests across three classes:
- `SurfaceTrailerOverrideHardening` — locks parser-rejection contract
- `CollectTrailerDiagnosticsHardening` — locks diagnostic-emission contract
- `TrailerParsingEdgeCases` — locks the audit recipe directly from #1054

Verified by reverting each hardening branch in turn (mirroring the precedent set in `efefe144` + `b258730c`):

| Hardening reverted        | Test failures |
|---------------------------|---------------|
| Surface anchor            | 1 (`mysdk`)   |
| Reason-required check     | 4 (missing/empty/whitespace/audit-recipe) |
| `collect_trailer_diagnostics` gutted | 9 (every diagnostic test) |

## Test plan

- [x] All 22 new tests pass (`python3 tools/scripts/test_version_bump_check.py`)
- [x] Existing 39 tests in `test_gates.py` still pass (no regression)
- [x] Sibling `test_skill_sync_check.py` still passes
- [x] End-to-end smoke test on synthetic repo: malformed `cli=skip` now produces the diagnostic + the gate fires correctly
- [x] Anti-drift verified: each hardening branch causes ≥1 test failure when reverted
- [x] `version_bump_check.py --mode=hint` runs cleanly on this branch

## Boundaries respected (per #1054)

- Did NOT weaken the version-bump gate — every change is additive (more strict rejection, more user-facing context)
- Did NOT touch the skill-sync gate (separate child issue)
- Did NOT rewrite the trailer format — extended validation, not replaced
- Did NOT touch coverage configs

Closes #1054
Refs #1049, #290