### PR TITLE
fix(pulp-react): auto-register hover dispatch when onMouseEnter is set (#1149)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.68.0
+    VERSION 0.68.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/packages/pulp-react/src/bridge.ts
+++ b/packages/pulp-react/src/bridge.ts
@@ -108,6 +108,14 @@ declare global {
     // ── Theme ───────────────────────────────────────────────────────
     function setTheme(name: 'dark' | 'light' | 'pro_audio' | string): void;
 
+    // ── Event opt-in registrars ─────────────────────────────────────
+    /// Arm `mouseenter` / `mouseleave` dispatch on a widget. Must be
+    /// called once per widget that has an `onMouseEnter` / `onMouseLeave`
+    /// (or `onPointerEnter` / `onPointerLeave`) handler — otherwise the
+    /// listener registered via `on(id, 'mouseenter', fn)` stays dormant.
+    /// pulp #1149.
+    function registerHover(id: string): void;
+
     // ── Layout flush + frame service ────────────────────────────────
     /// Force a layout pass on the root container. Used in
     /// `resetAfterCommit` so the host config owns commit-time flush.
@@ -144,7 +152,7 @@ export function createMockBridge(): MockBridge {
         'setBorderSide', 'setOpacity', 'setVisible', 'setPosition',
         'setText', 'setTextColor', 'setTextAlign',
         'setSpectrumData', 'setWaveformData', 'setMeterLevel', 'setProgress',
-        'setValue', 'setTheme', 'layout', 'on',
+        'setValue', 'setTheme', 'layout', 'on', 'registerHover',
     ];
     const saved: Record<string, unknown> = {};
     return {

--- a/packages/pulp-react/src/host-config.ts
+++ b/packages/pulp-react/src/host-config.ts
@@ -18,7 +18,7 @@ import type {
     PulpContainer,
     IntrinsicElementName,
 } from './types.js';
-import { applyAllProps, applyChangedProps } from './prop-applier.js';
+import { applyAllProps, applyChangedProps, clearHoverFor } from './prop-applier.js';
 
 type Type = IntrinsicElementName;
 type Props = Record<string, unknown>;
@@ -173,7 +173,7 @@ export const PulpHostConfig: HostConfig<
         // (Codex + RepoPrompt review both flagged the original plan that
         // tried createX(id, parent) here as the wrong lifecycle point.)
         const id = (props.id as string) ?? autoId(rootContainer);
-        return {
+        const inst: Instance = {
             id,
             type,
             // parentId stays undefined until attached
@@ -182,6 +182,10 @@ export const PulpHostConfig: HostConfig<
             onBridge: false,
             pendingChildren: [],
         };
+        // Track the instance so removeChild can walk its subtree
+        // and clear hover bookkeeping for descendants (pulp #1149).
+        instanceById.set(id, inst);
+        return inst;
     },
 
     createTextInstance(
@@ -204,14 +208,16 @@ export const PulpHostConfig: HostConfig<
         // reconciler treats it as an opaque host-text type, but our
         // appendChild path will materialize it via createLabel + setText
         // when its parent attaches.
-        return {
+        const inst: Instance = {
             id,
             type: 'Label',
             props: { children: String(text), text: String(text) },
             childIds: [],
             onBridge: false,
             pendingChildren: [],
-        } as unknown as TextInstance;
+        };
+        instanceById.set(id, inst);
+        return inst as unknown as TextInstance;
     },
 
     shouldSetTextContent(type, _props) {
@@ -271,6 +277,10 @@ export const PulpHostConfig: HostConfig<
     removeChildFromContainer(_container, child) {
         // Detach from root and let the bridge clean up the subtree.
         if (typeof g.removeWidget === 'function') call('removeWidget', child.id);
+        // Mirror detach()'s hover bookkeeping cleanup (pulp #1149) —
+        // recursive because removeWidget destroys the whole subtree on
+        // the native side.
+        clearHoverForSubtree(child);
     },
 
     clearContainer(_container) {
@@ -404,8 +414,43 @@ function detach(parent: Instance, child: Instance): void {
     const idx = parent.childIds.indexOf(child.id);
     if (idx >= 0) parent.childIds.splice(idx, 1);
     if (typeof g.removeWidget === 'function') call('removeWidget', child.id);
+    // Clear hover-armed bookkeeping so a re-mount under the same id
+    // re-arms registerHover (pulp #1149). Native side already dropped
+    // its on_hover_enter/leave closures when removeWidget destroyed
+    // the View — there's no unregisterHover primitive needed.
+    // Recursive because removeWidget walks the whole subtree on the
+    // native side; descendants would otherwise be left with stale
+    // hoverArmed entries.
+    clearHoverForSubtree(child);
     child.parentId = undefined;
 }
+
+/// Recursively clear hover bookkeeping for a widget and all its
+/// descendants. React's commitDeletion only calls removeChild on the
+/// root of the deleted subtree — descendants are NOT torn down via
+/// per-child host-config calls — but native `removeWidget(parent)`
+/// recursively destroys child Views. So we must walk our own
+/// instance graph here to keep `hoverArmed` in sync (pulp #1149,
+/// Codex P1 review).
+function clearHoverForSubtree(node: Instance): void {
+    clearHoverFor(node.id);
+    for (const childId of node.childIds) {
+        const childInst = instanceById.get(childId);
+        if (childInst) clearHoverForSubtree(childInst);
+        else clearHoverFor(childId); // best-effort if descendant ref is gone
+    }
+    instanceById.delete(node.id);
+}
+
+/// id → Instance registry, populated at createInstance and cleared
+/// when an instance is detached. Lets us walk the subtree of a
+/// removed node so hover bookkeeping stays consistent with the
+/// native side's recursive removeWidget. Module-scope (single
+/// renderer per JS engine, matching the createReactReconciler call
+/// in index.ts) so test isolation between separate render() calls
+/// in the same engine does NOT cross-contaminate — but the entries
+/// live only as long as React keeps the corresponding instance.
+const instanceById: Map<string, Instance> = new Map();
 
 // ── Auto-ID generation ─────────────────────────────────────────────
 function autoId(container: Container): string {

--- a/packages/pulp-react/src/index.ts
+++ b/packages/pulp-react/src/index.ts
@@ -95,7 +95,7 @@ export type {
     ProgressProps, XYPadProps, CheckboxProps, ToggleProps, ComboProps,
     ListBoxProps, CanvasProps, ImageProps, IconProps,
     FlexDirection, FlexAlign, FlexAlignSelf, FlexJustify,
-    FlexProps, StyleProps, BaseProps,
+    FlexProps, StyleProps, HoverProps, BaseProps,
     IntrinsicElementMap, IntrinsicElementName,
     PulpContainer,
 } from './types.js';

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -59,19 +59,81 @@ function isEventHandler(key: string): boolean {
     return key.startsWith('on') && key.length > 2 && key[2] === key[2]?.toUpperCase();
 }
 
+/// React-style hover-shaped handlers. When any of these is set, the
+/// native bridge needs `registerHover(id)` called once to arm the
+/// `mouseenter` / `mouseleave` dispatch (pulp #1149). The four prop
+/// names all share the SAME native dispatch — the bridge only fires
+/// `mouseenter` / `mouseleave`, so onPointerEnter / onPointerLeave
+/// must be aliased to those event names or the listener never runs.
+const HOVER_PROPS: Set<string> = new Set([
+    'onMouseEnter',
+    'onMouseLeave',
+    'onPointerEnter',
+    'onPointerLeave',
+]);
+
 /// Map a React-style on* prop to the bridge event name. The bridge
 /// dispatches:
 ///   on_click → 'click'        (Button, Panel, etc.)
 ///   on_change → 'change'      (Knob, Fader, Checkbox, TextEditor)
 ///   on_toggle → 'toggle'      (Toggle, ToggleButton)
-///   mouseenter / mouseleave   (Hover)
+///   mouseenter / mouseleave   (Hover; onPointerEnter / onPointerLeave
+///                              alias here too because registerHover
+///                              only dispatches mouseenter / mouseleave)
 ///   dismiss                   (Modal close)
 function eventNameFor(propName: string): string {
+    // pulp #1149: alias pointer-enter/leave to mouse-enter/leave so the
+    // listener key matches what __dispatch__ sends from registerHover.
+    if (propName === 'onPointerEnter') return 'mouseenter';
+    if (propName === 'onPointerLeave') return 'mouseleave';
     return propName.slice(2).toLowerCase();
+}
+
+/// Track which widget ids have already had `registerHover` called so
+/// we don't re-arm when a second hover-shaped handler (e.g. consumer
+/// sets both onMouseEnter AND onPointerEnter) lands on the same widget,
+/// or when applyChangedProps fires for an already-armed widget.
+///
+/// The bridge's JS preamble (widget_bridge.cpp:483-518) ALSO auto-arms
+/// `registerHover` from `on(id, 'mouseenter'|'mouseleave', fn)` via
+/// __ensureNativeRegistered__. Calling `registerHover` here is therefore
+/// idempotent on the native side (the C++ map assignment is a no-op
+/// rebind), and our local `hoverArmed` set just shaves the redundant
+/// JS→native call. Defensive armor: mock-bridge tests and any older
+/// preamble that lacks the auto-arm still get the correct behavior
+/// because we call registerHover explicitly.
+///
+/// Native cleanup is automatic — `removeWidget` destroys the View and
+/// its `on_hover_enter` / `on_hover_leave` closures with it. There is
+/// no `unregisterHover` primitive on the bridge today (filed as a
+/// follow-up; non-blocking because the closures don't outlive the
+/// widget). We clear the bookkeeping entry on unmount via `clearHoverFor`
+/// so a future re-mount under the same id (test harnesses, hot-reload)
+/// re-arms cleanly.
+const hoverArmed: Set<string> = new Set();
+
+function ensureHoverArmed(id: string): void {
+    if (hoverArmed.has(id)) return;
+    hoverArmed.add(id);
+    call('registerHover', id);
+}
+
+/// Drop the bookkeeping entry for a widget id. Called from the host
+/// config's removeChild path. The host config is responsible for
+/// recursing over its own subtree (it owns `childIds`); this function
+/// only clears the single id passed in.
+export function clearHoverFor(id: string): void {
+    hoverArmed.delete(id);
 }
 
 function applyEventHandler(id: string, key: string, value: unknown): void {
     if (typeof value !== 'function') return;
+    // Hover dispatch is opt-in on the native side: registering an
+    // 'on' listener for 'mouseenter' / 'mouseleave' is necessary but
+    // not sufficient — the bridge's `registerHover(id)` is what wires
+    // View::on_hover_enter / on_hover_leave to fire __dispatch__.
+    // Without this call the listener stays dormant (pulp #1149).
+    if (HOVER_PROPS.has(key)) ensureHoverArmed(id);
     const eventName = eventNameFor(key);
     // Wrap the React handler so the bridge's __dispatch__ can call it.
     // The bridge passes positional args after id+eventName; just forward.

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -61,7 +61,7 @@ export interface StyleProps {
 }
 
 // ── Common base props ──────────────────────────────────────────────
-export interface BaseProps extends FlexProps, StyleProps {
+export interface BaseProps extends FlexProps, StyleProps, HoverProps {
     /// Optional explicit ID. If omitted, an auto-incrementing ID is
     /// generated. Useful for testing + debugging the bridge log.
     id?: string;
@@ -69,6 +69,19 @@ export interface BaseProps extends FlexProps, StyleProps {
     key?: Key;
     /// Children — text or other intrinsics.
     children?: ReactNode;
+}
+
+// ── Hover / pointer-enter handlers ──────────────────────────────────
+// pulp #1149: any widget can opt into hover dispatch by attaching one
+// of these handlers. The prop-applier auto-arms `registerHover(id)` and
+// aliases the pointer-shaped names to mouseenter / mouseleave (the
+// native bridge only dispatches mouse-enter/leave, not pointer-enter/
+// leave).
+export interface HoverProps {
+    onMouseEnter?: () => void;
+    onMouseLeave?: () => void;
+    onPointerEnter?: () => void;
+    onPointerLeave?: () => void;
 }
 
 // ── Container intrinsics ────────────────────────────────────────────

--- a/packages/pulp-react/test/hover-subtree.test.ts
+++ b/packages/pulp-react/test/hover-subtree.test.ts
@@ -1,0 +1,123 @@
+// hover-subtree.test.ts — recursive hover cleanup on subtree removal
+// (pulp #1149, Codex P1 review).
+//
+// React's commitDeletion only calls removeChild on the ROOT of a
+// deleted subtree — descendants are NOT torn down via per-child
+// host-config calls. But the native bridge's removeWidget(parent)
+// recursively destroys child Views. So when a parent with hover-armed
+// descendants unmounts, the host config must walk its own instance
+// graph and clear hover bookkeeping for every descendant.
+//
+// Without this walk, a re-mount that re-uses any descendant id would
+// skip registerHover (because hoverArmed still has the stale entry)
+// and that re-mounted widget's hover handlers would silently never
+// fire — exactly the original #1149 bug shape, just at a different
+// trigger point.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import { PulpHostConfig } from '../src/host-config.js';
+import { applyAllProps, clearHoverFor } from '../src/prop-applier.js';
+import type { PulpContainer, PulpInstance } from '../src/types.js';
+
+function hoverCalls(bridge: MockBridge): MockBridge['calls'] {
+    return bridge.calls.filter((c) => c.fn === 'registerHover');
+}
+
+describe('@pulp/react hover subtree cleanup (#1149)', () => {
+    let bridge: MockBridge;
+
+    beforeEach(() => {
+        bridge = createMockBridge();
+        bridge.install();
+        for (const id of ['parent1', 'leaf1', 'leaf2', 'leaf3', 'mid1']) {
+            clearHoverFor(id);
+        }
+    });
+
+    it('removeChild on a parent walks the subtree and clears descendants', () => {
+        const container: PulpContainer = { rootId: '', nextId: 0 };
+
+        // Build a small tree with hover-armed leaves at multiple depths:
+        //   parent1
+        //     ├── mid1
+        //     │     └── leaf1   (onMouseEnter)
+        //     ├── leaf2         (onMouseEnter)
+        //     └── leaf3         (no hover handler)
+        const parent: PulpInstance = (PulpHostConfig.createInstance!(
+            'View',
+            { id: 'parent1' },
+            container,
+            {},
+            null,
+        ) as unknown) as PulpInstance;
+
+        const mid: PulpInstance = (PulpHostConfig.createInstance!(
+            'View',
+            { id: 'mid1' },
+            container,
+            {},
+            null,
+        ) as unknown) as PulpInstance;
+
+        const leaf1: PulpInstance = (PulpHostConfig.createInstance!(
+            'Button',
+            { id: 'leaf1', text: 'L1', onMouseEnter: () => { /* noop */ } },
+            container,
+            {},
+            null,
+        ) as unknown) as PulpInstance;
+
+        const leaf2: PulpInstance = (PulpHostConfig.createInstance!(
+            'Button',
+            { id: 'leaf2', text: 'L2', onMouseEnter: () => { /* noop */ } },
+            container,
+            {},
+            null,
+        ) as unknown) as PulpInstance;
+
+        const leaf3: PulpInstance = (PulpHostConfig.createInstance!(
+            'Button',
+            { id: 'leaf3', text: 'L3', onClick: () => { /* noop */ } },
+            container,
+            {},
+            null,
+        ) as unknown) as PulpInstance;
+
+        // Wire the React-side parent/child relationship by hand,
+        // mirroring what attach() does. We don't go through React's
+        // appendChild because we want to test removeChild's cleanup
+        // in isolation, not the full mount path.
+        parent.childIds = ['mid1', 'leaf2', 'leaf3'];
+        mid.childIds = ['leaf1'];
+
+        // Arm hover on the two hover-shaped leaves.
+        applyAllProps(leaf1);
+        applyAllProps(leaf2);
+        applyAllProps(leaf3);
+        // leaf1 + leaf2 should each have armed registerHover once.
+        expect(hoverCalls(bridge).length).toBe(2);
+
+        // Now React unmounts the parent — single removeChild call,
+        // not one per descendant. The host config must walk the
+        // subtree itself and clear hoverArmed for every descendant.
+        PulpHostConfig.removeChild!(parent as never, parent as never);
+
+        // Re-mount a fresh widget under the SAME id as a former
+        // descendant. If subtree cleanup ran, registerHover should
+        // fire again (third time total). If cleanup was only single-
+        // level, hoverArmed still contains 'leaf1' / 'leaf2' and the
+        // re-mount silently skips arming, leaving hover dead.
+        const reMounted: PulpInstance = (PulpHostConfig.createInstance!(
+            'Button',
+            { id: 'leaf1', text: 'NEW', onMouseEnter: () => { /* noop */ } },
+            container,
+            {},
+            null,
+        ) as unknown) as PulpInstance;
+        applyAllProps(reMounted);
+
+        // 2 from initial mount + 1 from the post-cleanup re-mount = 3.
+        expect(hoverCalls(bridge).length).toBe(3);
+    });
+});

--- a/packages/pulp-react/test/hover.test.ts
+++ b/packages/pulp-react/test/hover.test.ts
@@ -1,0 +1,226 @@
+// hover.test.ts — registerHover wiring (pulp #1149).
+//
+// The bridge has a `registerHover(id)` opt-in that arms the
+// `mouseenter`/`mouseleave` dispatch for a widget. Before #1149 the
+// prop-applier registered `onMouseEnter`/`onMouseLeave` listeners via
+// `on()` but never called `registerHover`, so the dispatch never fired
+// and React-style hover handlers were silently dead.
+//
+// These tests assert that:
+//   - `registerHover(id)` fires once when any hover-shaped handler
+//     (onMouseEnter / onMouseLeave / onPointerEnter / onPointerLeave)
+//     is set on a widget.
+//   - It does NOT fire for widgets with no hover handlers.
+//   - It is idempotent — setting both onMouseEnter and onPointerEnter
+//     together arms the bridge once, not twice.
+//   - applyChangedProps re-arms when a hover handler is added by a
+//     later commit (handler attached conditionally).
+//   - clearHoverFor (called from detach) drops bookkeeping so a
+//     re-mount under the same id re-arms cleanly.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import {
+    applyAllProps,
+    applyChangedProps,
+    clearHoverFor,
+} from '../src/prop-applier.js';
+import type { PulpInstance } from '../src/types.js';
+
+function instance(id: string, type: PulpInstance['type'], props: Record<string, unknown>): PulpInstance {
+    return {
+        id,
+        type,
+        props,
+        childIds: [],
+        onBridge: false,
+        pendingChildren: [],
+    };
+}
+
+function hoverCalls(bridge: MockBridge): MockBridge['calls'] {
+    return bridge.calls.filter((c) => c.fn === 'registerHover');
+}
+
+function onCalls(bridge: MockBridge): MockBridge['calls'] {
+    return bridge.calls.filter((c) => c.fn === 'on');
+}
+
+describe('@pulp/react hover wiring (#1149)', () => {
+    let bridge: MockBridge;
+
+    beforeEach(() => {
+        bridge = createMockBridge();
+        bridge.install();
+        // Each test starts with no widgets armed. Bridge bookkeeping is
+        // module-level state in prop-applier; clear any leftovers from
+        // prior tests via the public clear helper.
+        clearHoverFor('btn1');
+        clearHoverFor('btn2');
+        clearHoverFor('btn3');
+        clearHoverFor('btn4');
+    });
+
+    it('arms registerHover once when onMouseEnter is set on mount', () => {
+        const inst = instance('btn1', 'Button', {
+            text: 'Hover me',
+            onMouseEnter: () => { /* noop */ },
+        });
+        applyAllProps(inst);
+
+        const arms = hoverCalls(bridge);
+        expect(arms.length).toBe(1);
+        expect(arms[0].args).toEqual(['btn1']);
+    });
+
+    it('arms registerHover once when onMouseLeave alone is set', () => {
+        const inst = instance('btn2', 'Button', {
+            text: 'Leave me',
+            onMouseLeave: () => { /* noop */ },
+        });
+        applyAllProps(inst);
+
+        const arms = hoverCalls(bridge);
+        expect(arms.length).toBe(1);
+        expect(arms[0].args).toEqual(['btn2']);
+    });
+
+    it('does NOT arm registerHover when no hover handlers are present', () => {
+        const inst = instance('btn3', 'Button', {
+            text: 'Click me',
+            onClick: () => { /* noop */ },
+        });
+        applyAllProps(inst);
+
+        expect(hoverCalls(bridge).length).toBe(0);
+    });
+
+    it('arms registerHover exactly once when both onMouseEnter and onPointerEnter are set together', () => {
+        const inst = instance('btn4', 'Button', {
+            text: 'Both',
+            onMouseEnter: () => { /* noop */ },
+            onPointerEnter: () => { /* noop */ },
+        });
+        applyAllProps(inst);
+
+        const arms = hoverCalls(bridge);
+        expect(arms.length).toBe(1);
+        expect(arms[0].args).toEqual(['btn4']);
+    });
+
+    it('arms registerHover once even when all four hover-shaped handlers are set', () => {
+        const inst = instance('btn1', 'Button', {
+            text: 'All four',
+            onMouseEnter: () => { /* noop */ },
+            onMouseLeave: () => { /* noop */ },
+            onPointerEnter: () => { /* noop */ },
+            onPointerLeave: () => { /* noop */ },
+        });
+        applyAllProps(inst);
+
+        expect(hoverCalls(bridge).length).toBe(1);
+    });
+
+    it('re-arms via applyChangedProps when onMouseEnter is added by a later commit', () => {
+        const inst = instance('btn2', 'Button', { text: 'Conditional' });
+        applyAllProps(inst);
+        // No hover handler at mount → nothing armed.
+        expect(hoverCalls(bridge).length).toBe(0);
+
+        // A later commit attaches onMouseEnter. applyChangedProps should
+        // detect the new hover-shaped key and call registerHover.
+        const newProps = { text: 'Conditional', onMouseEnter: () => { /* noop */ } };
+        applyChangedProps(inst, inst.props, newProps);
+
+        const arms = hoverCalls(bridge);
+        expect(arms.length).toBe(1);
+        expect(arms[0].args).toEqual(['btn2']);
+    });
+
+    it('does NOT re-arm registerHover on subsequent prop updates if already armed', () => {
+        const handler1 = () => { /* noop */ };
+        const handler2 = () => { /* noop */ };
+        const inst = instance('btn3', 'Button', {
+            text: 'X',
+            onMouseEnter: handler1,
+        });
+        applyAllProps(inst);
+        expect(hoverCalls(bridge).length).toBe(1);
+
+        // Change the handler reference. applyChangedProps re-applies
+        // the event, but registerHover should NOT fire a second time.
+        applyChangedProps(
+            inst,
+            { text: 'X', onMouseEnter: handler1 },
+            { text: 'X', onMouseEnter: handler2 },
+        );
+        expect(hoverCalls(bridge).length).toBe(1);
+    });
+
+    it('aliases onPointerEnter to the mouseenter event name', () => {
+        // Native registerHover dispatches `mouseenter` / `mouseleave`
+        // only — never `pointerenter` / `pointerleave`. The prop-applier
+        // must alias the React-style pointer prop names to mouse event
+        // names so the listener registered via `on()` matches the
+        // dispatch key the bridge actually sends (pulp #1149, Codex P1).
+        const inst = instance('btn1', 'Button', {
+            text: 'Pointer',
+            onPointerEnter: () => { /* noop */ },
+            onPointerLeave: () => { /* noop */ },
+        });
+        applyAllProps(inst);
+
+        const ons = onCalls(bridge);
+        const eventNames = ons.map((c) => c.args[1]);
+        // The two pointer-shaped handlers should register under the
+        // mouseenter / mouseleave keys, NOT pointerenter / pointerleave.
+        expect(eventNames).toContain('mouseenter');
+        expect(eventNames).toContain('mouseleave');
+        expect(eventNames).not.toContain('pointerenter');
+        expect(eventNames).not.toContain('pointerleave');
+    });
+
+    it('mouseenter+pointerenter together collapse to a single mouseenter listener', () => {
+        // When a consumer sets BOTH onMouseEnter and onPointerEnter,
+        // both alias to the `mouseenter` event name. The second `on()`
+        // call simply overwrites the first listener — only the latest
+        // one wins (last-write semantics on the bridge's __callbacks__
+        // map). registerHover stays armed exactly once.
+        const inst = instance('btn2', 'Button', {
+            text: 'Both pointer + mouse',
+            onMouseEnter: () => { /* noop */ },
+            onPointerEnter: () => { /* noop */ },
+        });
+        applyAllProps(inst);
+
+        expect(hoverCalls(bridge).length).toBe(1);
+        const mouseenterRegs = onCalls(bridge).filter((c) => c.args[1] === 'mouseenter');
+        // Both handlers are routed to the mouseenter key — that's two
+        // on() calls, both targeting the same dispatch slot.
+        expect(mouseenterRegs.length).toBe(2);
+    });
+
+    it('clearHoverFor lets a re-mount under the same id re-arm cleanly', () => {
+        const inst1 = instance('btn4', 'Button', {
+            text: 'First',
+            onMouseEnter: () => { /* noop */ },
+        });
+        applyAllProps(inst1);
+        expect(hoverCalls(bridge).length).toBe(1);
+
+        // Simulate the host config's detach() path clearing bookkeeping
+        // when the widget is removed.
+        clearHoverFor('btn4');
+
+        // Re-mount under the same id (rare but possible — id reuse,
+        // hot-reload, certain test harnesses).
+        const inst2 = instance('btn4', 'Button', {
+            text: 'Second',
+            onMouseEnter: () => { /* noop */ },
+        });
+        applyAllProps(inst2);
+
+        // Should have armed twice across the two mounts.
+        expect(hoverCalls(bridge).length).toBe(2);
+    });
+});


### PR DESCRIPTION
The native bridge has had `registerHover(id)` since da48acf6 (initial
hover-callback work pre-#652 import) and the JS preamble at
core/view/src/widget_bridge.cpp:483-518 even auto-arms it from any
`on(id, 'mouseenter'|'mouseleave', fn)` call (added in df11a88b /
#1008). But @pulp/react's prop-applier left two real gaps that kept
hover dispatch dormant for typed React consumers:

  1. `onPointerEnter` / `onPointerLeave` registered listeners under
     'pointerenter' / 'pointerleave' event keys. The native dispatch
     only fires 'mouseenter' / 'mouseleave' though, so those handlers
     never ran. Now `eventNameFor` aliases the pointer-shaped names
     to the mouse event names so the listener key matches what
     __dispatch__ sends.

  2. The bridge JS preamble's auto-arm relies on `on()` being called
     with the right event name, but that's wired through the bridge's
     C++ string preamble — mock-bridge tests, embedded harnesses, or
     any older runtime without the #1008 preamble drop the auto-arm.
     `applyEventHandler` now calls `registerHover(id)` directly when
     it sees any of the four hover-shaped React props, deduped via
     a module-scope `hoverArmed` Set. Native registerHover is
     idempotent (assignment-rebind on the View's callback slots), so
     the redundant call when the preamble auto-arms is a no-op.

Cleanup is recursive on subtree removal: React's commitDeletion only
calls removeChild on the root of a deleted subtree, but the native
removeWidget walks the full subtree on the C++ side. host-config now
maintains an `instanceById` registry and `clearHoverForSubtree` walks
the children so re-mounts that re-use a former descendant id re-arm
cleanly. (Codex P1 review caught this; would have leaked stale
hoverArmed entries otherwise.)

Public types: BaseProps now extends a new HoverProps interface so
typed consumers writing `<Button onMouseEnter={...} />` or
`<View onPointerEnter={...} />` type-check correctly. HoverProps is
re-exported from index.ts.

Tests cover: arm-once on mount, no-arm without hover handler, dedup
across the four hover props, dedup across mount + applyChangedProps,
re-arm via applyChangedProps when the handler is added later, the
pointer→mouse event-name aliasing, the mouseenter+pointerenter
collapse-to-single-listener path, clearHoverFor + re-mount, and the
recursive subtree cleanup (build → arm leaves → removeChild on the
root → re-mount under a former descendant id → re-arm fires).

Codex consult verdict: GOOD after addressing all P1s (idempotency,
pointer aliasing, recursive cleanup, public type exposure). 16 tests
pass; tsc + esbuild produce a clean 950kb ESM bundle. Spectr v0.68.0
build-out via /tmp/pulp-react/packages/pulp-react/pulp-react-0.0.1.tgz
confirms the wired bundle includes the hover code. Headless render
(planning/screenshots/pulp-1149-hover-demo.png) shows registerHover
fires once for a button with onMouseEnter and not at all for a button
with only onClick.

No `unregisterHover` primitive exists on the bridge, but it's not
needed: removeWidget destroys the View and its on_hover_enter /
on_hover_leave closures atomically. Filed as a follow-up only if a
future widget API needs to detach hover without destroying the view.

Closes #1149.