### PR TITLE
fix(view): preserve unset border attributes when setting just one (audit PR #1166)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.68.0
+    VERSION 0.68.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -222,28 +222,40 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             break;
 
         // Border
+        // pulp #1027 (audit PR #1166 finding #4) — these used to lower onto
+        // the unified `setBorder(id, color, width, radius)` which clobbers
+        // ALL three slots on every call. Setting `borderRadius` then
+        // `borderColor` would silently drop the radius back to 0. The
+        // per-attribute bridge setters `setBorderColor` / `setBorderWidth`
+        // / `setBorderRadius` mutate exactly one field on the View, so
+        // routing to them preserves the unset siblings — matching CSS
+        // semantics.
         case "borderRadius": {
             var br = parseCSSLength(resolved);
-            if (br) setBorder(id, "", 0, br.value);
+            if (br) setBorderRadius(id, br.value);
             break;
         }
         case "border": {
-            // "1px solid #333"
+            // "1px solid #333" — CSS `border` shorthand sets width/style/color
+            // but NOT border-radius (per CSS Backgrounds & Borders L3). We
+            // route to the per-attribute setters so a previously-set
+            // border-radius is preserved across a `border:` shorthand assignment.
             var bp = resolved.match(/([\d.]+)px\s+\w+\s+(.+)/);
             if (bp) {
                 var bc = parseCSSColor(bp[2].trim());
-                setBorder(id, bc || bp[2].trim(), parseFloat(bp[1]), 0);
+                setBorderColor(id, bc || bp[2].trim());
+                setBorderWidth(id, parseFloat(bp[1]));
             }
             break;
         }
         case "borderColor": {
             var bcc = parseCSSColor(resolved);
-            if (bcc) setBorder(id, bcc, 1, 0);
+            if (bcc) setBorderColor(id, bcc);
             break;
         }
         case "borderWidth": {
             var bw = parseCSSLength(resolved);
-            if (bw) setBorder(id, "", bw.value, 0);
+            if (bw) setBorderWidth(id, bw.value);
             break;
         }
 
@@ -492,18 +504,49 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             }
             break;
         }
-        case "borderTopWidth": case "borderRightWidth": case "borderBottomWidth": case "borderLeftWidth": {
-            var side2 = key.replace("border", "").replace("Width", "").toLowerCase();
-            var bw2 = parseCSSLength(resolved);
-            if (bw2 && typeof setBorderSide === "function")
-                setBorderSide(id, side2, bw2.value, "");
+        // pulp #1027 (audit PR #1166 finding #4) — per-side flat props
+        // (RN parity). Route to setBorderTop/Right/Bottom/Left{Color,Width}
+        // which preserve the OTHER attribute on the View (see
+        // applyBorderSide in widget_bridge.cpp). Calling setBorderSide
+        // with a placeholder 0/"" for the unset slot would clobber it.
+        case "borderTopWidth": {
+            var bwT = parseCSSLength(resolved);
+            if (bwT && typeof setBorderTopWidth === "function") setBorderTopWidth(id, bwT.value);
             break;
         }
-        case "borderTopColor": case "borderRightColor": case "borderBottomColor": case "borderLeftColor": {
-            var side3 = key.replace("border", "").replace("Color", "").toLowerCase();
-            var bc3 = parseCSSColor(resolved);
-            if (bc3 && typeof setBorderSide === "function")
-                setBorderSide(id, side3, 0, bc3);
+        case "borderRightWidth": {
+            var bwR = parseCSSLength(resolved);
+            if (bwR && typeof setBorderRightWidth === "function") setBorderRightWidth(id, bwR.value);
+            break;
+        }
+        case "borderBottomWidth": {
+            var bwB = parseCSSLength(resolved);
+            if (bwB && typeof setBorderBottomWidth === "function") setBorderBottomWidth(id, bwB.value);
+            break;
+        }
+        case "borderLeftWidth": {
+            var bwL = parseCSSLength(resolved);
+            if (bwL && typeof setBorderLeftWidth === "function") setBorderLeftWidth(id, bwL.value);
+            break;
+        }
+        case "borderTopColor": {
+            var bcT = parseCSSColor(resolved);
+            if (bcT && typeof setBorderTopColor === "function") setBorderTopColor(id, bcT);
+            break;
+        }
+        case "borderRightColor": {
+            var bcR = parseCSSColor(resolved);
+            if (bcR && typeof setBorderRightColor === "function") setBorderRightColor(id, bcR);
+            break;
+        }
+        case "borderBottomColor": {
+            var bcB = parseCSSColor(resolved);
+            if (bcB && typeof setBorderBottomColor === "function") setBorderBottomColor(id, bcB);
+            break;
+        }
+        case "borderLeftColor": {
+            var bcL = parseCSSColor(resolved);
+            if (bcL && typeof setBorderLeftColor === "function") setBorderLeftColor(id, bcL);
             break;
         }
 

--- a/packages/pulp-react/src/bridge.ts
+++ b/packages/pulp-react/src/bridge.ts
@@ -89,6 +89,25 @@ declare global {
         width: number,
         hexColor: string,
     ): void;
+    // pulp #1027 — per-attribute border setters (preserve unset siblings).
+    // The unified `setBorder` clobbers all three slots; these mutate one
+    // field at a time on the View. Optional at runtime so older bridges
+    // still link, hence the `const | undefined` shape.
+    const setBorderColor: ((id: string, hexColor: string) => void) | undefined;
+    const setBorderWidth: ((id: string, width: number) => void) | undefined;
+    const setBorderRadius: ((id: string, radius: number) => void) | undefined;
+    const setBorderTopColor: ((id: string, hexColor: string) => void) | undefined;
+    const setBorderRightColor: ((id: string, hexColor: string) => void) | undefined;
+    const setBorderBottomColor: ((id: string, hexColor: string) => void) | undefined;
+    const setBorderLeftColor: ((id: string, hexColor: string) => void) | undefined;
+    const setBorderTopWidth: ((id: string, width: number) => void) | undefined;
+    const setBorderRightWidth: ((id: string, width: number) => void) | undefined;
+    const setBorderBottomWidth: ((id: string, width: number) => void) | undefined;
+    const setBorderLeftWidth: ((id: string, width: number) => void) | undefined;
+    const setBorderTopLeftRadius: ((id: string, radius: number) => void) | undefined;
+    const setBorderTopRightRadius: ((id: string, radius: number) => void) | undefined;
+    const setBorderBottomLeftRadius: ((id: string, radius: number) => void) | undefined;
+    const setBorderBottomRightRadius: ((id: string, radius: number) => void) | undefined;
     function setOpacity(id: string, alpha: number): void;
     function setVisible(id: string, visible: boolean): void;
     function setPosition(id: string, top: number, left: number, right?: number, bottom?: number): void;
@@ -141,6 +160,15 @@ export function createMockBridge(): MockBridge {
         'createImage', 'createIcon', 'createProgress', 'createMeter', 'createXYPad',
         'createGrid', 'removeWidget', 'moveWidget', 'insertChild',
         'setFlex', 'setBackground', 'setBackgroundGradient', 'setBorder',
+        // pulp #1027 — per-attribute border setters needed for the audit
+        // PR #1166 finding-#4 fix (preserve unset siblings).
+        'setBorderColor', 'setBorderWidth', 'setBorderRadius',
+        'setBorderTopColor', 'setBorderRightColor',
+        'setBorderBottomColor', 'setBorderLeftColor',
+        'setBorderTopWidth', 'setBorderRightWidth',
+        'setBorderBottomWidth', 'setBorderLeftWidth',
+        'setBorderTopLeftRadius', 'setBorderTopRightRadius',
+        'setBorderBottomLeftRadius', 'setBorderBottomRightRadius',
         'setBorderSide', 'setOpacity', 'setVisible', 'setPosition',
         'setText', 'setTextColor', 'setTextAlign',
         'setSpectrumData', 'setWaveformData', 'setMeterLevel', 'setProgress',

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -125,10 +125,33 @@ function applyOne(id: string, type: string, key: string, value: unknown): void {
             const b = value as { color: string; width?: number; radius?: number };
             return call('setBorder', id, b.color, b.width ?? 1, b.radius ?? 0);
         }
+        // pulp #1027 (audit PR #1166 finding #4) — RN-style flat border props.
+        // These MUST route through the per-attribute bridge setters so a
+        // commitUpdate that touches only one of them preserves the others.
+        // Lowering them onto the unified `setBorder(id, color, width, radius)`
+        // would clobber the unset slots back to 0/empty.
+        case 'borderColor':  return call('setBorderColor', id, value as string);
+        case 'borderWidth':  return call('setBorderWidth', id, value as number);
+        case 'borderRadius': return call('setBorderRadius', id, value as number);
         case 'borderTop':    { const b = value as { color: string; width: number }; return call('setBorderSide', id, 'top', b.width, b.color); }
         case 'borderRight':  { const b = value as { color: string; width: number }; return call('setBorderSide', id, 'right', b.width, b.color); }
         case 'borderBottom': { const b = value as { color: string; width: number }; return call('setBorderSide', id, 'bottom', b.width, b.color); }
         case 'borderLeft':   { const b = value as { color: string; width: number }; return call('setBorderSide', id, 'left', b.width, b.color); }
+        // RN per-side flat props — route to the per-side bridge setters
+        // that already preserve the unrelated attribute (see widget_bridge
+        // applyBorderSide helper introduced in pulp #1026).
+        case 'borderTopColor':       return call('setBorderTopColor', id, value as string);
+        case 'borderRightColor':     return call('setBorderRightColor', id, value as string);
+        case 'borderBottomColor':    return call('setBorderBottomColor', id, value as string);
+        case 'borderLeftColor':      return call('setBorderLeftColor', id, value as string);
+        case 'borderTopWidth':       return call('setBorderTopWidth', id, value as number);
+        case 'borderRightWidth':     return call('setBorderRightWidth', id, value as number);
+        case 'borderBottomWidth':    return call('setBorderBottomWidth', id, value as number);
+        case 'borderLeftWidth':      return call('setBorderLeftWidth', id, value as number);
+        case 'borderTopLeftRadius':     return call('setBorderTopLeftRadius', id, value as number);
+        case 'borderTopRightRadius':    return call('setBorderTopRightRadius', id, value as number);
+        case 'borderBottomLeftRadius':  return call('setBorderBottomLeftRadius', id, value as number);
+        case 'borderBottomRightRadius': return call('setBorderBottomRightRadius', id, value as number);
         case 'opacity':      return call('setOpacity', id, value as number);
         case 'visible':      return call('setVisible', id, value as boolean);
 

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -56,6 +56,24 @@ export interface StyleProps {
     borderRight?: { color: string; width: number };
     borderBottom?: { color: string; width: number };
     borderLeft?: { color: string; width: number };
+    // pulp #1027 — per-attribute (RN-style flat) border props. These map to
+    // the per-attribute bridge setters that mutate one slot in isolation,
+    // unlike `border:` which sets all three at once.
+    borderColor?: string;
+    borderWidth?: number;
+    borderRadius?: number;
+    borderTopColor?: string;
+    borderRightColor?: string;
+    borderBottomColor?: string;
+    borderLeftColor?: string;
+    borderTopWidth?: number;
+    borderRightWidth?: number;
+    borderBottomWidth?: number;
+    borderLeftWidth?: number;
+    borderTopLeftRadius?: number;
+    borderTopRightRadius?: number;
+    borderBottomLeftRadius?: number;
+    borderBottomRightRadius?: number;
     opacity?: number;
     visible?: boolean;
 }

--- a/packages/pulp-react/test/prop-applier-border.test.ts
+++ b/packages/pulp-react/test/prop-applier-border.test.ts
@@ -1,0 +1,98 @@
+// pulp #1027 (audit PR #1166 finding #4) — verify the prop-applier routes
+// borderColor / borderWidth / borderRadius (and per-side flat props) to the
+// per-attribute bridge setters that preserve unset siblings, not the unified
+// setBorder(id, color, width, radius) that clobbers everything.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyChangedProps } from '../src/prop-applier.js';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import type { PulpInstance } from '../src/types.js';
+
+let bridge: MockBridge;
+
+beforeEach(() => {
+    bridge = createMockBridge();
+    bridge.install();
+});
+afterEach(() => {
+    bridge.uninstall();
+});
+
+function makeInstance(id: string = 'k', type: string = 'View'): PulpInstance {
+    return {
+        id,
+        type: type as PulpInstance['type'],
+        props: {},
+        childIds: [],
+        onBridge: true,
+        pendingChildren: [],
+    };
+}
+
+describe('prop-applier border setters route to per-attribute bridge fns', () => {
+    it('borderColor calls setBorderColor (not setBorder)', () => {
+        applyChangedProps(makeInstance(), {}, { borderColor: '#ff0000' });
+        const names = bridge.calls.map((c) => c.fn);
+        expect(names).toContain('setBorderColor');
+        expect(names).not.toContain('setBorder');
+        const call = bridge.calls.find((c) => c.fn === 'setBorderColor');
+        expect(call?.args).toEqual(['k', '#ff0000']);
+    });
+
+    it('borderWidth calls setBorderWidth (not setBorder)', () => {
+        applyChangedProps(makeInstance(), {}, { borderWidth: 3 });
+        const names = bridge.calls.map((c) => c.fn);
+        expect(names).toContain('setBorderWidth');
+        expect(names).not.toContain('setBorder');
+        const call = bridge.calls.find((c) => c.fn === 'setBorderWidth');
+        expect(call?.args).toEqual(['k', 3]);
+    });
+
+    it('borderRadius calls setBorderRadius (not setBorder)', () => {
+        applyChangedProps(makeInstance(), {}, { borderRadius: 8 });
+        const names = bridge.calls.map((c) => c.fn);
+        expect(names).toContain('setBorderRadius');
+        expect(names).not.toContain('setBorder');
+        const call = bridge.calls.find((c) => c.fn === 'setBorderRadius');
+        expect(call?.args).toEqual(['k', 8]);
+    });
+
+    it('audit failing case: setting only borderRadius then only borderColor never emits setBorder', () => {
+        // First commit: just borderRadius.
+        applyChangedProps(makeInstance(), {}, { borderRadius: 8 });
+        // Second commit on top of first: add borderColor while radius stays unchanged.
+        applyChangedProps(makeInstance(), { borderRadius: 8 }, { borderRadius: 8, borderColor: 'red' });
+        const names = bridge.calls.map((c) => c.fn);
+        // The unified setBorder must NEVER be invoked from these flat props,
+        // because it would clobber the other slots.
+        expect(names).not.toContain('setBorder');
+        expect(names).toContain('setBorderRadius');
+        expect(names).toContain('setBorderColor');
+    });
+
+    it('per-side flat props route to per-side setters', () => {
+        applyChangedProps(makeInstance(), {}, {
+            borderTopColor: '#101010',
+            borderRightWidth: 2,
+            borderBottomLeftRadius: 5,
+        });
+        const names = bridge.calls.map((c) => c.fn);
+        expect(names).toContain('setBorderTopColor');
+        expect(names).toContain('setBorderRightWidth');
+        expect(names).toContain('setBorderBottomLeftRadius');
+        expect(names).not.toContain('setBorderSide');
+        expect(names).not.toContain('setBorder');
+    });
+
+    it('object-shape `border` prop still routes to unified setBorder', () => {
+        // The shorthand object form sets all three slots intentionally and
+        // should keep emitting the unified setter for parity with how
+        // CSSStyleDeclaration's `border:` shorthand still atomically sets
+        // width + color (radius is preserved by the JS shim, not here).
+        applyChangedProps(makeInstance(), {}, {
+            border: { color: '#222', width: 1, radius: 4 },
+        });
+        const names = bridge.calls.map((c) => c.fn);
+        expect(names).toContain('setBorder');
+    });
+});

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -3230,3 +3230,225 @@ TEST_CASE("WidgetBridge per-side setBorder*Color / Width route to BorderSide",
     REQUIRE_THAT(w->border_bottom_width(), WithinAbs(7.0f, 1e-5f));
     REQUIRE(w->border_bottom_color().r8() == 0xff);
 }
+
+// pulp #1027 (audit PR #1166 finding #4) — Interleaved single-attribute
+// border setters MUST preserve siblings. Audit found that the JS shim's
+// `el.style.borderRadius='8px'; el.style.borderColor='red'` sequence
+// silently dropped radius back to 0, because both lowered to
+// setBorder(id, color, width, radius) with 0 for unset args. After the
+// fix, the JS shim routes through setBorderColor / setBorderWidth /
+// setBorderRadius which mutate exactly one slot.
+TEST_CASE("WidgetBridge interleaved setBorderColor/Width/Radius preserves siblings",
+          "[view][bridge][issue-1027][issue-1166]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('k', 0, 0, 32, 32)");
+    auto* w = bridge.widget("k");
+    REQUIRE(w != nullptr);
+
+    SECTION("set width+color via setBorder, then change only color via setBorderColor") {
+        bridge.load_script("setBorder('k', '#112233', 3.0, 7.0)");
+        REQUIRE(w->has_border());
+        REQUIRE_THAT(w->border_width(), WithinAbs(3.0f, 1e-5f));
+        REQUIRE_THAT(w->corner_radius(), WithinAbs(7.0f, 1e-5f));
+
+        bridge.load_script("setBorderColor('k', '#aabbcc')");
+        REQUIRE(w->border_color().r8() == 0xaa);
+        REQUIRE(w->border_color().g8() == 0xbb);
+        REQUIRE(w->border_color().b8() == 0xcc);
+        // Width and radius must NOT have been clobbered.
+        REQUIRE_THAT(w->border_width(), WithinAbs(3.0f, 1e-5f));
+        REQUIRE_THAT(w->corner_radius(), WithinAbs(7.0f, 1e-5f));
+    }
+
+    SECTION("set width+color via setBorder, then change only radius via setBorderRadius") {
+        bridge.load_script("setBorder('k', '#112233', 4.0, 5.0)");
+        bridge.load_script("setBorderRadius('k', 11.0)");
+        REQUIRE_THAT(w->corner_radius(), WithinAbs(11.0f, 1e-5f));
+        // Color and width must NOT have been clobbered.
+        REQUIRE(w->border_color().r8() == 0x11);
+        REQUIRE(w->border_color().g8() == 0x22);
+        REQUIRE(w->border_color().b8() == 0x33);
+        REQUIRE_THAT(w->border_width(), WithinAbs(4.0f, 1e-5f));
+    }
+
+    SECTION("audit failing case: set radius first, then color via setBorderColor") {
+        // This is the exact case the audit called out: setting radius then
+        // color used to leave width=1, radius=0 in the broken JS shim.
+        // With the bridge setters routed correctly, radius survives.
+        bridge.load_script("setBorderRadius('k', 8.0)");
+        REQUIRE_THAT(w->corner_radius(), WithinAbs(8.0f, 1e-5f));
+
+        bridge.load_script("setBorderColor('k', '#ff0000')");
+        REQUIRE(w->border_color().r8() == 0xff);
+        // Radius MUST still be 8, not 0.
+        REQUIRE_THAT(w->corner_radius(), WithinAbs(8.0f, 1e-5f));
+    }
+
+    SECTION("set radius first, then width via setBorderWidth") {
+        bridge.load_script("setBorderRadius('k', 6.0)");
+        bridge.load_script("setBorderWidth('k', 2.5)");
+        REQUIRE_THAT(w->border_width(), WithinAbs(2.5f, 1e-5f));
+        // Radius MUST still be 6, not 0.
+        REQUIRE_THAT(w->corner_radius(), WithinAbs(6.0f, 1e-5f));
+    }
+
+    SECTION("set color first, then width via setBorderWidth") {
+        bridge.load_script("setBorderColor('k', '#00ff00')");
+        bridge.load_script("setBorderWidth('k', 4.0)");
+        REQUIRE_THAT(w->border_width(), WithinAbs(4.0f, 1e-5f));
+        // Color must NOT have been clobbered to default.
+        REQUIRE(w->border_color().g8() == 0xff);
+        REQUIRE(w->border_color().r8() == 0x00);
+    }
+
+    SECTION("per-side variants stay independent under interleaved updates") {
+        bridge.load_script("setBorderTopColor('k', '#101010'); setBorderTopWidth('k', 1.0)");
+        bridge.load_script("setBorderRightColor('k', '#202020'); setBorderRightWidth('k', 2.0)");
+        bridge.load_script("setBorderBottomColor('k', '#303030'); setBorderBottomWidth('k', 3.0)");
+        bridge.load_script("setBorderLeftColor('k', '#404040'); setBorderLeftWidth('k', 4.0)");
+
+        // Now change ONLY top color — every other side must be untouched.
+        bridge.load_script("setBorderTopColor('k', '#ffffff')");
+        REQUIRE(w->border_top_color().r8() == 0xff);
+        REQUIRE_THAT(w->border_top_width(), WithinAbs(1.0f, 1e-5f));
+        REQUIRE(w->border_right_color().r8() == 0x20);
+        REQUIRE_THAT(w->border_right_width(), WithinAbs(2.0f, 1e-5f));
+        REQUIRE(w->border_bottom_color().r8() == 0x30);
+        REQUIRE_THAT(w->border_bottom_width(), WithinAbs(3.0f, 1e-5f));
+        REQUIRE(w->border_left_color().r8() == 0x40);
+        REQUIRE_THAT(w->border_left_width(), WithinAbs(4.0f, 1e-5f));
+    }
+}
+
+// pulp #1027 — JS shim regression test: el.style.borderColor must NOT
+// clobber el.style.borderRadius. This walks the actual web-compat-style-decl.js
+// path (CSSStyleDeclaration._applyProperty) so we'd catch any future
+// regression where the shim re-routes to setBorder(id, c, w, r).
+TEST_CASE("CSS shim: setting borderRadius then borderColor preserves radius",
+          "[view][bridge][web-compat][issue-1027][issue-1166]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('k', 0, 0, 32, 32)");
+    auto* w = bridge.widget("k");
+    REQUIRE(w != nullptr);
+
+    // Build a minimal CSSStyleDeclaration around the widget. Use the same
+    // `_el._id` / `_el._nativeCreated` shape the prelude expects.
+    bridge.load_script(
+        "var __el = { _id: 'k', _nativeCreated: true };"
+        "var __sd = new CSSStyleDeclaration(__el);"
+        "__sd._applyProperty('borderRadius', '8px');"
+        "__sd._applyProperty('borderColor', '#ff0000');"
+    );
+    REQUIRE(w->border_color().r8() == 0xff);
+    REQUIRE(w->border_color().g8() == 0x00);
+    // The audit's failing case — radius MUST survive the borderColor write.
+    REQUIRE_THAT(w->corner_radius(), WithinAbs(8.0f, 1e-5f));
+
+    // Reverse order: borderColor first, then borderRadius. Both must stick.
+    bridge.load_script(
+        "var __el2 = { _id: 'k', _nativeCreated: true };"
+        "var __sd2 = new CSSStyleDeclaration(__el2);"
+        "__sd2._applyProperty('borderColor', '#00ff00');"
+        "__sd2._applyProperty('borderRadius', '12px');"
+    );
+    REQUIRE(w->border_color().g8() == 0xff);
+    REQUIRE_THAT(w->corner_radius(), WithinAbs(12.0f, 1e-5f));
+
+    // Setting borderWidth alone must not zero color or radius.
+    bridge.load_script(
+        "var __el3 = { _id: 'k', _nativeCreated: true };"
+        "var __sd3 = new CSSStyleDeclaration(__el3);"
+        "__sd3._applyProperty('borderWidth', '3px');"
+    );
+    REQUIRE_THAT(w->border_width(), WithinAbs(3.0f, 1e-5f));
+    REQUIRE(w->border_color().g8() == 0xff); // preserved from previous
+    REQUIRE_THAT(w->corner_radius(), WithinAbs(12.0f, 1e-5f)); // preserved
+}
+
+// pulp #1027 — Codex P1 review on PR #1166 follow-up: CSS per-side flat
+// props must NOT clobber the unrelated attribute. Before the fix, the
+// JS shim lowered `borderTopWidth: '2px'` to `setBorderSide(id, 'top', 2, "")`
+// which reset the side's color, and `borderTopColor: 'red'` to
+// `setBorderSide(id, 'top', 0, 'red')` which reset the side's width.
+TEST_CASE("CSS shim: per-side flat props preserve unset attribute",
+          "[view][bridge][web-compat][issue-1027][issue-1166]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('k', 0, 0, 32, 32)");
+    auto* w = bridge.widget("k");
+    REQUIRE(w != nullptr);
+
+    // Seed top side with both color and width, then mutate via the JS shim
+    // one attribute at a time and verify the other side-attribute survives.
+    bridge.load_script(
+        "var __el = { _id: 'k', _nativeCreated: true };"
+        "var __sd = new CSSStyleDeclaration(__el);"
+        "__sd._applyProperty('borderTop', '2px solid #112233');"
+    );
+    REQUIRE_THAT(w->border_top_width(), WithinAbs(2.0f, 1e-5f));
+    REQUIRE(w->border_top_color().r8() == 0x11);
+
+    // Set borderTopColor only — width must survive.
+    bridge.load_script("__sd._applyProperty('borderTopColor', '#ffaa00')");
+    REQUIRE(w->border_top_color().r8() == 0xff);
+    REQUIRE(w->border_top_color().g8() == 0xaa);
+    REQUIRE_THAT(w->border_top_width(), WithinAbs(2.0f, 1e-5f));
+
+    // Set borderTopWidth only — color must survive.
+    bridge.load_script("__sd._applyProperty('borderTopWidth', '5px')");
+    REQUIRE_THAT(w->border_top_width(), WithinAbs(5.0f, 1e-5f));
+    REQUIRE(w->border_top_color().r8() == 0xff);
+    REQUIRE(w->border_top_color().g8() == 0xaa);
+
+    // Reverse order — width first, then color, on the bottom side this time.
+    bridge.load_script(
+        "__sd._applyProperty('borderBottomWidth', '3px');"
+        "__sd._applyProperty('borderBottomColor', '#00ddee');"
+    );
+    REQUIRE_THAT(w->border_bottom_width(), WithinAbs(3.0f, 1e-5f));
+    REQUIRE(w->border_bottom_color().r8() == 0x00);
+    REQUIRE(w->border_bottom_color().g8() == 0xdd);
+    REQUIRE(w->border_bottom_color().b8() == 0xee);
+}
+
+// pulp #1027 — `border:` CSS shorthand must preserve a previously-set
+// border-radius (CSS L3 spec: shorthand sets only width/style/color).
+TEST_CASE("CSS shim: 'border:' shorthand preserves border-radius",
+          "[view][bridge][web-compat][issue-1027][issue-1166]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createKnob('k', 0, 0, 32, 32)");
+    auto* w = bridge.widget("k");
+    REQUIRE(w != nullptr);
+
+    bridge.load_script(
+        "var __el = { _id: 'k', _nativeCreated: true };"
+        "var __sd = new CSSStyleDeclaration(__el);"
+        "__sd._applyProperty('borderRadius', '10px');"
+        "__sd._applyProperty('border', '2px solid #336699');"
+    );
+    REQUIRE_THAT(w->border_width(), WithinAbs(2.0f, 1e-5f));
+    REQUIRE(w->border_color().r8() == 0x33);
+    REQUIRE(w->border_color().g8() == 0x66);
+    REQUIRE(w->border_color().b8() == 0x99);
+    // Radius must survive the shorthand assignment.
+    REQUIRE_THAT(w->corner_radius(), WithinAbs(10.0f, 1e-5f));
+}


### PR DESCRIPTION
Surfaced by compat-audit @ PR #1166 finding #4: setBorderColor and
setBorderRadius both lowered to setBorder(id, color, width, radius)
with 0 for unset args. Calling them in sequence wiped each other's
non-targeted state — setting radius then color silently dropped the
radius back to 0.

Now: the JS shim (web-compat-style-decl.js) and @pulp/react's
prop-applier route flat per-attribute props to the bridge's
setBorderColor / setBorderWidth / setBorderRadius (and per-side
setBorderTop/Right/Bottom/Left{Color,Width}) which mutate exactly one
field on the View. Per-side and per-corner variants remain
independent. The 'border:' CSS shorthand no longer clobbers
border-radius (matches CSS Backgrounds & Borders L3 spec — shorthand
sets only width/style/color).

Tests assert that interleaved single-attribute setters preserve
siblings, including the audit's specific failing case (set radius
first, then color).

Refs: #1027 (compat matrix meta), audit report.

Skill-Update: skip skill=engine reason="bridge-routing-only fix; no engine backend change"