### PR TITLE
fix(view): split web-compat fontFamily list and resolve each candidate (#1151)

### DIFF
--- a/.agents/skills/engine/SKILL.md
+++ b/.agents/skills/engine/SKILL.md
@@ -145,3 +145,16 @@ Don't refactor this into a "pure native" shape — there's no way to do it witho
 `setTimeout(fn, 0)` deliberately bypasses `__scheduleTimer__` and routes through `Promise.resolve().then(...)` so it drains on the next `pump_message_loop()` call. This matches React's scheduler expectations and makes tests deterministic (no host frame loop needed). Positive-delay timeouts go through the native deadline tracker and only fire when `service_frame_callbacks()` runs.
 
 If a consumer reports "my setTimeout(fn, 1) never fires", check that the host is actually calling `service_frame_callbacks()` from its frame loop — that's the drain hook for non-zero delays.
+
+### CSS font-family lists are joined with `;` across the JS↔C++ boundary (#1151)
+
+`web-compat-style-decl.js` parses a comma-separated CSS `font-family` value into an ordered candidate list, joins it with `;`, and hands the joined string to the existing `setFontFamily(id, family)` bridge call. The C++ side (`get_cached_typeface` in `core/canvas/src/skia_canvas.cpp` and `create_font_with_fallback` in `core/canvas/platform/mac/cg_canvas.mm`) splits on `;` and walks the chain.
+
+We use `;` (not `,`) because:
+
+1. `,` is a legal character inside CSS quoted family names (`"Foo, Bar"` is one family) and the C++ bridge has no way to know which commas were "list separators" vs "literal name characters" once the string crosses the boundary. The JS parser is the only layer that has full quoting context.
+2. `;` is *not* legal anywhere inside an unquoted CSS family name (per CSS Fonts grammar), so it's a safe delimiter.
+
+If you ever change the delimiter, change both sides in lockstep — the cache key in `get_cached_typeface` hashes the joined string verbatim, so a mismatch silently bypasses the cache and may also bypass the chain-walk entirely.
+
+The CG path additionally uses `CTFontDescriptorCreateMatchingFontDescriptor` to verify each candidate is *actually installed* before accepting it, because `CTFontCreateWithName` silently substitutes the system default for a missing name — that would short-circuit the chain walk to whatever CoreText guesses is closest.

--- a/core/canvas/platform/mac/cg_canvas.mm
+++ b/core/canvas/platform/mac/cg_canvas.mm
@@ -2,6 +2,9 @@
 
 #ifdef __APPLE__
 
+#include <cctype>
+#include <cstddef>
+
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreText/CoreText.h>
 #import <Foundation/Foundation.h>
@@ -226,11 +229,88 @@ void CoreGraphicsCanvas::set_text_align(TextAlign align) {
     text_align_ = align;
 }
 
+// Generic CSS family keywords that should resolve to the platform default
+// rather than ever passing through CTFontCreateWithName (which would either
+// return null or — worse — match an unrelated installed face like a system
+// font that happens to share a substring).
+static bool cg_is_generic_family(const std::string& f) {
+    return f == "serif" || f == "sans-serif" || f == "monospace"
+        || f == "cursive" || f == "fantasy" || f == "system-ui"
+        || f == "ui-serif" || f == "ui-sans-serif" || f == "ui-monospace"
+        || f == "ui-rounded";
+}
+
+// pulp #1151 P1 (Codex review): `CTFontCreateWithName` is not a reliable
+// "is this family installed?" probe — CoreText silently substitutes a
+// fallback face when the name doesn't exist on the system, so it always
+// returns a non-null CTFontRef. To walk a fallback chain correctly we
+// match each candidate against the installed font catalogue via a
+// CTFontDescriptor and verify the resolver returned the family we asked
+// for. Only an actual installed family (case-insensitive compare) advances
+// past the probe.
+static bool cg_family_is_installed(const std::string& name) {
+    if (name.empty() || cg_is_generic_family(name)) return false;
+    @autoreleasepool {
+        NSString* ns_name = [NSString stringWithUTF8String:name.c_str()];
+        if (!ns_name) return false;
+
+        NSDictionary* attrs = @{
+            (__bridge NSString*)kCTFontFamilyNameAttribute: ns_name
+        };
+        CTFontDescriptorRef base = CTFontDescriptorCreateWithAttributes(
+            (__bridge CFDictionaryRef)attrs);
+        if (!base) return false;
+
+        CTFontDescriptorRef matched =
+            CTFontDescriptorCreateMatchingFontDescriptor(base, NULL);
+        CFRelease(base);
+        if (!matched) return false;
+
+        bool ok = false;
+        CFTypeRef resolved = CTFontDescriptorCopyAttribute(
+            matched, kCTFontFamilyNameAttribute);
+        if (resolved) {
+            if (CFGetTypeID(resolved) == CFStringGetTypeID()) {
+                CFStringRef rs = static_cast<CFStringRef>(resolved);
+                ok = (CFStringCompare(rs, (__bridge CFStringRef)ns_name,
+                                      kCFCompareCaseInsensitive) ==
+                      kCFCompareEqualTo);
+            }
+            CFRelease(resolved);
+        }
+        CFRelease(matched);
+        return ok;
+    }
+}
+
+// pulp #1151: `family` may be a ';'-joined fallback chain produced by the
+// web-compat JS layer (e.g. "JetBrains Mono;ui-monospace;monospace"). Walk
+// each candidate in order and return the first CTFont that resolves; if no
+// candidate matches, fall back to the platform's UI system font so the
+// caller never gets a null typeface.
 static CTFontRef create_font_with_fallback(const std::string& family, float size) {
-    NSString* ns_font = [NSString stringWithUTF8String:family.c_str()];
-    CTFontRef font = CTFontCreateWithName((__bridge CFStringRef)ns_font, size, NULL);
+    CTFontRef font = nullptr;
+    std::size_t start = 0;
+    while (start <= family.size() && !font) {
+        std::size_t sep = family.find(';', start);
+        std::size_t end = (sep == std::string::npos) ? family.size() : sep;
+        std::size_t lo = start;
+        std::size_t hi = end;
+        while (lo < hi && std::isspace(static_cast<unsigned char>(family[lo]))) ++lo;
+        while (hi > lo && std::isspace(static_cast<unsigned char>(family[hi - 1]))) --hi;
+        std::string candidate = family.substr(lo, hi - lo);
+        if (cg_family_is_installed(candidate)) {
+            NSString* ns_font = [NSString stringWithUTF8String:candidate.c_str()];
+            font = CTFontCreateWithName((__bridge CFStringRef)ns_font, size, NULL);
+        }
+        if (sep == std::string::npos) break;
+        start = sep + 1;
+    }
+
     if (!font) {
-        // Requested family not available — fall back to system font
+        // No named family was actually installed on the system (or every
+        // candidate was a CSS generic keyword). Fall back to the platform
+        // UI system font so the caller never gets a null typeface.
         font = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, size, NULL);
     }
     return font;

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cctype>
 #include <unordered_map>
 #include <pulp/canvas/skia_canvas.hpp>
 #include <pulp/canvas/bundled_fonts.hpp>
@@ -105,10 +106,68 @@ static SkPaint make_stroke_paint(Color c, float width) {
     return paint;
 }
 
+// pulp #1151: a CSS font-family value may be a fallback chain. The web-compat
+// JS layer parses the chain and joins the candidates with ';' before handing
+// them to the bridge, so a value like
+//     "JetBrains Mono;ui-monospace;monospace"
+// arrives here as a single std::string. Splitting and walking happens at
+// resolve time (not in the cache key) so the cache can hash the original
+// joined string verbatim — repeated calls with the same chain stay O(1).
+
+// Try to resolve a single family name (no ';' chain). Returns nullptr when
+// no bundled or system match is available; the caller decides whether to
+// keep walking the chain or fall through to the platform default.
+//
+// Generic CSS keywords (`monospace`, `serif`, …) are intentionally allowed
+// to reach SkFontMgr::matchFamilyStyle: some platform managers know how to
+// map them to a platform-appropriate face. When the manager doesn't
+// recognise the keyword it returns nullptr and the chain walker (in
+// get_cached_typeface) eventually drops back to matchFamilyStyle(nullptr,
+// …) — which is the unconditional platform default.
+static sk_sp<SkTypeface> resolve_single_typeface(const std::string& family,
+                                                  SkFontStyle sk_style,
+                                                  int weight, int slant) {
+    sk_sp<SkTypeface> typeface;
+
+#if defined(__ANDROID__)
+    if (weight == 400 && slant == 0 &&
+        (family == "sans-serif" || family == "Roboto" || family.empty())) {
+        auto mgr = get_font_manager();
+        if (mgr) {
+            typeface = mgr->makeFromFile("/system/fonts/Roboto-Regular.ttf");
+        }
+    }
+#else
+    (void)weight; (void)slant;
+#endif
+
+    if (!typeface && !family.empty()) {
+        auto mgr = get_font_manager();
+        if (mgr) {
+            typeface = match_bundled_typeface(mgr.get(), family, sk_style);
+        }
+    }
+
+    if (!typeface && !family.empty()) {
+        auto mgr = get_font_manager();
+        if (mgr && mgr->countFamilies() > 0) {
+            typeface = mgr->matchFamilyStyle(family.c_str(), sk_style);
+        }
+    }
+
+    return typeface;
+}
+
 // Cached typeface loaded directly from a known path — bypasses family name
 // matching for deterministic metrics (Visage-style approach). Cache key
 // includes weight + slant so setFontWeight(700) actually returns a bold
 // typeface rather than the same Regular blob (pulp #927).
+//
+// pulp #1151: `family` may be a ';'-joined fallback chain. We split and
+// walk each candidate, returning the first typeface that resolves. If none
+// of the named candidates match we ask the platform font manager for its
+// default face (preserves the previous "always render something" behaviour
+// for unknown families).
 static sk_sp<SkTypeface> get_cached_typeface(const std::string& family,
                                              int weight, int slant) {
     struct Key { std::string family; int weight; int slant; };
@@ -138,41 +197,39 @@ static sk_sp<SkTypeface> get_cached_typeface(const std::string& family,
 
     sk_sp<SkTypeface> typeface;
 
-#if defined(__ANDROID__)
-    // Load Roboto directly from filesystem for deterministic rendering.
-    // This avoids the font manager's family matching which can return
-    // different fonts depending on the device/API level. Only the
-    // Regular/Upright path has a baked-in file; bold/italic still go
-    // through the family matcher below.
-    if (weight == 400 && slant == 0 &&
-        (family == "sans-serif" || family == "Roboto" || family.empty())) {
-        auto mgr = get_font_manager();
-        if (mgr) {
-            typeface = mgr->makeFromFile("/system/fonts/Roboto-Regular.ttf");
-        }
-    }
-#endif
-
-    // Bundled fonts take precedence over the system font manager so plugin
-    // UIs render the same on a stock machine as on a developer's machine
-    // with the same families installed (#932). Without this, calling
-    // canvas.set_font("JetBrains Mono", ...) on macOS-without-JetBrainsMono
-    // resolves to a null typeface and crashes the first time a non-ASCII
-    // glyph triggers SkFontMgr-driven fallback.
-    if (!typeface && !family.empty()) {
-        auto mgr = get_font_manager();
-        if (mgr) {
-            typeface = match_bundled_typeface(mgr.get(), family, sk_style);
+    // Walk the ';'-joined fallback chain produced by web-compat-style-decl.js.
+    // Single-family inputs (no ';') hit this loop once, so the no-chain code
+    // path stays a one-iteration walk.
+    {
+        std::size_t start = 0;
+        while (start <= family.size() && !typeface) {
+            std::size_t sep = family.find(';', start);
+            std::size_t end = (sep == std::string::npos) ? family.size() : sep;
+            // Trim leading/trailing ASCII whitespace inside each segment so
+            // a developer-friendly "Inter, monospace" (post-JS-split: just
+            // "Inter;monospace") survives a stray space introduced by some
+            // future code path.
+            std::size_t lo = start;
+            std::size_t hi = end;
+            while (lo < hi && std::isspace(static_cast<unsigned char>(family[lo]))) ++lo;
+            while (hi > lo && std::isspace(static_cast<unsigned char>(family[hi - 1]))) --hi;
+            std::string candidate = family.substr(lo, hi - lo);
+            if (!candidate.empty()) {
+                typeface = resolve_single_typeface(candidate, sk_style, weight, slant);
+            }
+            if (sep == std::string::npos) break;
+            start = sep + 1;
         }
     }
 
-    // Fall back to family name matching
+    // No named candidate matched — fall through to the platform default
+    // face so the caller still gets *some* typeface back. This mirrors
+    // the previous single-family behaviour where a missing family name
+    // also fell through to matchFamilyStyle(nullptr, ...).
     if (!typeface) {
         auto mgr = get_font_manager();
         if (mgr && mgr->countFamilies() > 0) {
-            typeface = mgr->matchFamilyStyle(family.c_str(), sk_style);
-            if (!typeface)
-                typeface = mgr->matchFamilyStyle(nullptr, sk_style);
+            typeface = mgr->matchFamilyStyle(nullptr, sk_style);
         }
     }
 

--- a/core/view/js/css-parser.js
+++ b/core/view/js/css-parser.js
@@ -320,6 +320,46 @@ function _splitCalcArgs(str) {
     return args;
 }
 
+// Parse a CSS font-family value into an ordered candidate list, respecting
+// quoted segments (a quoted family with an internal comma is one name) and
+// stripping outer quotes / surrounding whitespace from each candidate.
+//
+// Example: `'JetBrains Mono', "Foo, Bar", ui-monospace, monospace`
+//   -> ["JetBrains Mono", "Foo, Bar", "ui-monospace", "monospace"]
+//
+// pulp #1151: this used to be a naïve `value.replace(/['"]/g, "")` which
+// passed the entire comma-separated list to setFontFamily verbatim, so
+// SkFontMgr::matchFamilyStyle never matched any of the candidates.
+function _parseFontFamilyList(value) {
+    var out = [];
+    if (value == null) return out;
+    var s = String(value);
+    var depth = 0;       // paren depth (defensive — font-family doesn't use them, but be safe)
+    var quote = "";      // active quote char, "" when outside a quoted segment
+    var current = "";
+    for (var i = 0; i < s.length; i++) {
+        var c = s.charAt(i);
+        if (quote) {
+            if (c === quote) { quote = ""; }
+            else { current += c; }
+            continue;
+        }
+        if (c === "'" || c === '"') { quote = c; continue; }
+        if (c === "(") depth++;
+        else if (c === ")") depth--;
+        if (c === "," && depth === 0) {
+            var t = current.replace(/^\s+|\s+$/g, "");
+            if (t.length > 0) out.push(t);
+            current = "";
+            continue;
+        }
+        current += c;
+    }
+    var tail = current.replace(/^\s+|\s+$/g, "");
+    if (tail.length > 0) out.push(tail);
+    return out;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // matchMedia — responsive breakpoint queries
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -460,9 +460,23 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             if (typeof setPointerEvents === "function") setPointerEvents(id, resolved);
             break;
 
-        // font-family
+        // font-family — pulp #1151: split the comma-separated list into an
+        // ordered candidate list (preserving commas inside quoted families),
+        // then hand it to setFontFamily as a `;`-joined chain. The C++
+        // resolver walks each candidate via the existing typeface-lookup
+        // path and the first match wins; generic keywords (monospace,
+        // sans-serif, …) fall through to the platform default.
         case "fontFamily":
-            if (typeof setFontFamily === "function") setFontFamily(id, resolved.replace(/['"]/g, ""));
+            if (typeof setFontFamily === "function") {
+                var fams = _parseFontFamilyList(resolved);
+                if (fams.length === 0) {
+                    setFontFamily(id, "");
+                } else if (fams.length === 1) {
+                    setFontFamily(id, fams[0]);
+                } else {
+                    setFontFamily(id, fams.join(";"));
+                }
+            }
             break;
 
         // background-size: "cover", "contain", "100px 200px"

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -642,6 +642,55 @@ TEST_CASE("SkiaCanvas::measure_text_with_font picks up bundled "
     REQUIRE(a.width > 0.0f);
     REQUIRE(b.width > a.width);
 }
+
+// pulp #1151 — fontFamily fallback chains arrive here as a ';'-joined
+// string. The resolver must walk each candidate and pick the first one
+// that resolves, even when earlier candidates fail to match. Without this,
+// a fallback chain like "DefinitelyMissingFamily;JetBrains Mono;monospace"
+// would have produced a system-default-face measurement; with the fix it
+// must produce the same advance as a direct "JetBrains Mono" lookup.
+TEST_CASE("SkiaCanvas::measure_text_with_font walks fontFamily fallback chain "
+          "and picks bundled JetBrains Mono mid-chain (#1151)",
+          "[canvas][skia][fonts][issue-1151]") {
+    auto direct = SkiaCanvas::measure_text_with_font(
+        "JetBrains Mono", 18.0f, "Hello World");
+    REQUIRE(direct.width > 0.0f);
+
+    auto chained = SkiaCanvas::measure_text_with_font(
+        "DefinitelyMissingFamily-1151;JetBrains Mono;monospace",
+        18.0f, "Hello World");
+    REQUIRE(chained.width > 0.0f);
+    // Bit-exact equivalence — the chain walked past the missing first
+    // candidate and resolved the bundled JetBrains Mono face for the
+    // measurement, exactly as if the caller had passed the second
+    // candidate directly.
+    REQUIRE(chained.width == Catch::Approx(direct.width));
+    REQUIRE(chained.ascent == Catch::Approx(direct.ascent));
+    REQUIRE(chained.descent == Catch::Approx(direct.descent));
+}
+
+TEST_CASE("SkiaCanvas::measure_text_with_font generic-only chain falls through "
+          "to platform default (#1151)",
+          "[canvas][skia][fonts][issue-1151]") {
+    // A chain of CSS generic keywords ("monospace", "sans-serif", …) must
+    // not crash and must produce a positive width — the resolver should
+    // fall through to SkFontMgr::matchFamilyStyle(nullptr, …) so the
+    // platform's default face renders the text.
+    auto m = SkiaCanvas::measure_text_with_font(
+        "monospace;sans-serif", 16.0f, "abc");
+    REQUIRE(m.width > 0.0f);
+}
+
+TEST_CASE("SkiaCanvas::measure_text_with_font all-missing chain still produces "
+          "a positive width via platform default (#1151)",
+          "[canvas][skia][fonts][issue-1151]") {
+    // Every candidate in the chain is unknown. Falling through to the
+    // platform default keeps the previous behaviour where a single bogus
+    // family also produced *something* renderable instead of a hard error.
+    auto m = SkiaCanvas::measure_text_with_font(
+        "PulpMissingA-1151;PulpMissingB-1151", 16.0f, "abc");
+    REQUIRE(m.width > 0.0f);
+}
 #endif
 
 // ── pulp #929 — Canvas::clear_rect default + CoreGraphics override ──────────
@@ -717,6 +766,42 @@ TEST_CASE("RecordingCanvas::clear_rect emits a dedicated clear_rect command",
 }
 
 #ifdef __APPLE__
+// pulp #1151 — `set_font` may receive a ';'-joined fallback chain. The CG
+// backend must walk it and use the first installed family. Smoke test:
+// verify a chain like "DefinitelyMissing-1151;Helvetica" still produces a
+// positive measure_text result (which means CTFont resolution succeeded
+// without crashing). Going further to assert *which* family resolved is
+// platform-fragile — we'd need to inspect the CTFont post-creation —
+// but the Skia tests cover the equality semantics; this just guards the
+// chain-walk itself doesn't return null.
+TEST_CASE("CoreGraphicsCanvas::set_font accepts fallback chain (#1151)",
+          "[canvas][cg][issue-1151]") {
+    constexpr int W = 32;
+    constexpr int H = 16;
+    std::vector<uint8_t> pixels(static_cast<size_t>(W) * H * 4u, 0u);
+    auto cs = CGColorSpaceCreateDeviceRGB();
+    REQUIRE(cs != nullptr);
+    const uint32_t bitmap_info =
+        static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) |
+        static_cast<uint32_t>(kCGBitmapByteOrder32Big);
+    CGContextRef ctx = CGBitmapContextCreate(
+        pixels.data(), W, H, 8, W * 4u, cs, bitmap_info);
+    CGColorSpaceRelease(cs);
+    REQUIRE(ctx != nullptr);
+
+    {
+        CoreGraphicsCanvas canvas(ctx, static_cast<float>(W),
+                                  static_cast<float>(H));
+        // First candidate is uninstalled, second is system-bundled on
+        // every macOS version we support, third is the CSS generic.
+        canvas.set_font("DefinitelyMissingFamily-1151;Helvetica;monospace",
+                         14.0f);
+        float w = canvas.measure_text("Hello");
+        REQUIRE(w > 0.0f);
+    }
+    CGContextRelease(ctx);
+}
+
 TEST_CASE("CoreGraphicsCanvas::clear_rect zeroes destination pixels",
           "[canvas][cg][issue-929]") {
     // Build a 16x16 RGBA8 CGBitmapContext, fill it with opaque red, then

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -3230,3 +3230,82 @@ TEST_CASE("WidgetBridge per-side setBorder*Color / Width route to BorderSide",
     REQUIRE_THAT(w->border_bottom_width(), WithinAbs(7.0f, 1e-5f));
     REQUIRE(w->border_bottom_color().r8() == 0xff);
 }
+
+// pulp #1151 — el.style.fontFamily = "'JetBrains Mono', ui-monospace, monospace"
+// must propagate the full ordered fallback chain to Label::font_family() so
+// the canvas resolver can walk it. Before #1151 the bridge received the raw
+// comma-separated string with quotes stripped (e.g. "JetBrains Mono, ui-
+// monospace, monospace"), which SkFontMgr::matchFamilyStyle never matched.
+//
+// Widgets are looked up via their native bridge id (el._id), not the JS id
+// the test sets — mirrors the canvas-fillRect test pattern at line ~440.
+TEST_CASE("WidgetBridge fontFamily list propagates as joined chain (issue 1151)",
+          "[view][bridge][issue-1151]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var label = document.createElement('span');
+        label.textContent = 'mono';
+        document.body.appendChild(label);
+        label.style.fontFamily = "'JetBrains Mono', ui-monospace, monospace";
+        var lblId = label._id;
+    )");
+
+    auto idValue = engine.evaluate("lblId");
+    auto nativeId = std::string(idValue.getWithDefault<std::string_view>(""));
+    auto* lbl = dynamic_cast<Label*>(bridge.widget(nativeId));
+    REQUIRE(lbl != nullptr);
+    // The bridge stores a ';'-joined chain so the canvas can split-and-walk.
+    REQUIRE(lbl->font_family() == "JetBrains Mono;ui-monospace;monospace");
+}
+
+TEST_CASE("WidgetBridge fontFamily quoted family with internal comma stays whole (issue 1151)",
+          "[view][bridge][issue-1151]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var label = document.createElement('span');
+        label.textContent = 'mono';
+        document.body.appendChild(label);
+        label.style.fontFamily = '"Helvetica Neue, Bold", "Arial"';
+        var lblId = label._id;
+    )");
+
+    auto idValue = engine.evaluate("lblId");
+    auto nativeId = std::string(idValue.getWithDefault<std::string_view>(""));
+    auto* lbl = dynamic_cast<Label*>(bridge.widget(nativeId));
+    REQUIRE(lbl != nullptr);
+    REQUIRE(lbl->font_family() == "Helvetica Neue, Bold;Arial");
+}
+
+TEST_CASE("WidgetBridge fontFamily single quoted name unwraps quotes (issue 1151)",
+          "[view][bridge][issue-1151]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var label = document.createElement('span');
+        label.textContent = 'x';
+        document.body.appendChild(label);
+        label.style.fontFamily = "'Inter Tight'";
+        var lblId = label._id;
+    )");
+
+    auto idValue = engine.evaluate("lblId");
+    auto nativeId = std::string(idValue.getWithDefault<std::string_view>(""));
+    auto* lbl = dynamic_cast<Label*>(bridge.widget(nativeId));
+    REQUIRE(lbl != nullptr);
+    // Single-name input — no ';' separator, just the bare family.
+    REQUIRE(lbl->font_family() == "Inter Tight");
+}

--- a/test/web-compat/test_web_compat_prelude.cpp
+++ b/test/web-compat/test_web_compat_prelude.cpp
@@ -164,6 +164,89 @@ TEST_CASE("WebCompat: parseTransition", "[webcompat][parser]") {
     REQUIRE(std::string(result.getWithDefault<std::string_view>("")) == "opacity");
 }
 
+// pulp #1151 — _parseFontFamilyList must split on top-level commas, leave
+// commas inside quoted segments alone, strip outer quotes, and trim
+// whitespace. The previous behaviour passed the entire CSS value to
+// setFontFamily verbatim (after stripping quotes), so SkFontMgr never
+// matched any of the candidates in a fallback chain.
+TEST_CASE("WebCompat: parseFontFamilyList exists", "[webcompat][parser][issue-1151]") {
+    TestEnvironment env;
+    auto result = env.engine.evaluate("typeof _parseFontFamilyList");
+    REQUIRE(std::string(result.getWithDefault<std::string_view>("")) == "function");
+}
+
+TEST_CASE("WebCompat: parseFontFamilyList splits comma list", "[webcompat][parser][issue-1151]") {
+    TestEnvironment env;
+    auto result = env.engine.evaluate(
+        "JSON.stringify(_parseFontFamilyList(\"'JetBrains Mono', ui-monospace, monospace\"))");
+    REQUIRE(std::string(result.getWithDefault<std::string_view>("")) ==
+            "[\"JetBrains Mono\",\"ui-monospace\",\"monospace\"]");
+}
+
+TEST_CASE("WebCompat: parseFontFamilyList preserves comma in quotes", "[webcompat][parser][issue-1151]") {
+    TestEnvironment env;
+    auto result = env.engine.evaluate(
+        "JSON.stringify(_parseFontFamilyList('\"Foo, Bar\", monospace'))");
+    REQUIRE(std::string(result.getWithDefault<std::string_view>("")) ==
+            "[\"Foo, Bar\",\"monospace\"]");
+}
+
+TEST_CASE("WebCompat: parseFontFamilyList single name", "[webcompat][parser][issue-1151]") {
+    TestEnvironment env;
+    auto result = env.engine.evaluate(
+        "JSON.stringify(_parseFontFamilyList('Inter'))");
+    REQUIRE(std::string(result.getWithDefault<std::string_view>("")) ==
+            "[\"Inter\"]");
+}
+
+TEST_CASE("WebCompat: parseFontFamilyList strips outer single quotes", "[webcompat][parser][issue-1151]") {
+    TestEnvironment env;
+    auto result = env.engine.evaluate(
+        "JSON.stringify(_parseFontFamilyList(\"'Inter Tight'\"))");
+    REQUIRE(std::string(result.getWithDefault<std::string_view>("")) ==
+            "[\"Inter Tight\"]");
+}
+
+TEST_CASE("WebCompat: parseFontFamilyList trims whitespace", "[webcompat][parser][issue-1151]") {
+    TestEnvironment env;
+    auto result = env.engine.evaluate(
+        "JSON.stringify(_parseFontFamilyList('   Inter  ,   monospace   '))");
+    REQUIRE(std::string(result.getWithDefault<std::string_view>("")) ==
+            "[\"Inter\",\"monospace\"]");
+}
+
+TEST_CASE("WebCompat: parseFontFamilyList empty string", "[webcompat][parser][issue-1151]") {
+    TestEnvironment env;
+    auto result = env.engine.evaluate(
+        "JSON.stringify(_parseFontFamilyList(''))");
+    REQUIRE(std::string(result.getWithDefault<std::string_view>("")) == "[]");
+}
+
+TEST_CASE("WebCompat: parseFontFamilyList generic only", "[webcompat][parser][issue-1151]") {
+    TestEnvironment env;
+    auto result = env.engine.evaluate(
+        "JSON.stringify(_parseFontFamilyList('monospace'))");
+    REQUIRE(std::string(result.getWithDefault<std::string_view>("")) ==
+            "[\"monospace\"]");
+}
+
+TEST_CASE("WebCompat: parseFontFamilyList drops empty segments", "[webcompat][parser][issue-1151]") {
+    TestEnvironment env;
+    // Trailing comma + double comma should not produce empty entries.
+    auto result = env.engine.evaluate(
+        "JSON.stringify(_parseFontFamilyList('Inter,,monospace,'))");
+    REQUIRE(std::string(result.getWithDefault<std::string_view>("")) ==
+            "[\"Inter\",\"monospace\"]");
+}
+
+TEST_CASE("WebCompat: parseFontFamilyList double-quoted with internal comma keeps as one", "[webcompat][parser][issue-1151]") {
+    TestEnvironment env;
+    auto result = env.engine.evaluate(
+        "JSON.stringify(_parseFontFamilyList('\"Helvetica Neue, Bold\", \"Arial\"'))");
+    REQUIRE(std::string(result.getWithDefault<std::string_view>("")) ==
+            "[\"Helvetica Neue, Bold\",\"Arial\"]");
+}
+
 TEST_CASE("WebCompat: matchMedia min-width", "[webcompat][parser]") {
     TestEnvironment env(800, 600);
     auto result = env.engine.evaluate("typeof _matchMediaQuery === 'function' && _matchMediaQuery('(min-width: 600px)')");


### PR DESCRIPTION
web-compat-style-decl.js:465 stripped outer quotes but passed the entire
comma-separated CSS font-family value to setFontFamily as one string.
SkFontMgr::matchFamilyStyle never matched, so any plugin using a
fallback chain (e.g. `'JetBrains Mono', ui-monospace, monospace`) drifted
to the platform default font even when a listed candidate was bundled or
installed.

This change:

- adds `_parseFontFamilyList` to css-parser.js that splits on top-level
  commas (skipping commas inside single- or double-quoted segments),
  trims whitespace and strips outer quotes from each candidate. The
  candidates are joined with `;` and handed to the existing
  setFontFamily bridge call — no new bridge primitive.

- updates Skia `get_cached_typeface` to walk the `;`-joined chain and
  return the first typeface that resolves via the existing bundled +
  matchFamilyStyle path. When every named candidate misses, it falls
  through to `matchFamilyStyle(nullptr, ...)` for the platform default,
  preserving the prior single-family "always render something" behaviour.

- updates the macOS CoreGraphics path to walk the same chain. Because
  CTFontCreateWithName silently substitutes a fallback face for an
  uninstalled name, each candidate is first probed via
  CTFontDescriptorCreateMatchingFontDescriptor and a case-insensitive
  family-name comparison so missing candidates don't short-circuit the
  walk to a substituted face (Codex P1 on the v1 patch).

Tests added in the same PR (`[issue-1151]`):
- 10 JS-side parser tests (test_web_compat_prelude.cpp): comma list,
  quoted-with-internal-comma, single name, leading whitespace,
  generic-only, empty string, double-quoted comma family, drop-empty.
- 3 widget-bridge integration tests (test_widget_bridge.cpp): assert
  the bridge stores the joined chain on `Label::font_family()`.
- 1 CoreGraphics chain test (test_canvas.cpp): walk past a missing
  first candidate and still render text.
- 3 Skia chain tests (gated behind `#ifdef PULP_HAS_SKIA`): mid-chain
  match equivalence with direct lookup, generic-only fallback,
  all-missing fallback to platform default.

All targeted tests pass locally; existing 87 widget-bridge and 71
web-compat-prelude tests still green.

Closes #1151.