### PR TITLE
fix(view): wire prop-applier to call registerHover (pulp #1149 part a)

### DIFF
--- a/packages/pulp-react/src/bridge.ts
+++ b/packages/pulp-react/src/bridge.ts
@@ -144,7 +144,7 @@ export function createMockBridge(): MockBridge {
         'setBorderSide', 'setOpacity', 'setVisible', 'setPosition',
         'setText', 'setTextColor', 'setTextAlign',
         'setSpectrumData', 'setWaveformData', 'setMeterLevel', 'setProgress',
-        'setValue', 'setTheme', 'layout', 'on',
+        'setValue', 'setTheme', 'layout', 'on', 'registerHover',
     ];
     const saved: Record<string, unknown> = {};
     return {

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -70,9 +70,28 @@ function eventNameFor(propName: string): string {
     return propName.slice(2).toLowerCase();
 }
 
+/// Hover/pointer events the bridge gates behind registerHover(id).
+/// onMouseEnter/onMouseLeave + their pointer-event aliases all map to
+/// the bridge's mouseenter/mouseleave dispatch path; without
+/// registerHover, the C++ side never fires the events even though the
+/// JS listener is installed (pulp #1149).
+function isHoverEvent(eventName: string): boolean {
+    return (
+        eventName === 'mouseenter' ||
+        eventName === 'mouseleave' ||
+        eventName === 'pointerenter' ||
+        eventName === 'pointerleave'
+    );
+}
+
 function applyEventHandler(id: string, key: string, value: unknown): void {
     if (typeof value !== 'function') return;
     const eventName = eventNameFor(key);
+    if (isHoverEvent(eventName)) {
+        // Arm the native hover dispatchers exactly once (idempotent on
+        // the bridge — re-registers replace the lambdas, same shape).
+        call('registerHover', id);
+    }
     // Wrap the React handler so the bridge's __dispatch__ can call it.
     // The bridge passes positional args after id+eventName; just forward.
     call('on', id, eventName, (...a: unknown[]) => (value as (...x: unknown[]) => void)(...a));

--- a/packages/pulp-react/test/prop-applier-hover.test.ts
+++ b/packages/pulp-react/test/prop-applier-hover.test.ts
@@ -1,0 +1,82 @@
+// Test for pulp #1149 — prop-applier must call registerHover(id) when a
+// hover-class event handler (onMouseEnter / onMouseLeave / pointer aliases)
+// is set, otherwise the native bridge never fires the corresponding
+// events even though the JS listener is installed.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import { applyAllProps, applyChangedProps } from '../src/prop-applier.js';
+import type { PulpInstance } from '../src/types.js';
+
+function instance(id: string, type: string, props: Record<string, unknown>): PulpInstance {
+    return { id, type, props } as PulpInstance;
+}
+
+describe('@pulp/react prop-applier — hover registration (pulp #1149)', () => {
+    let bridge: MockBridge;
+    beforeEach(() => {
+        bridge = createMockBridge();
+        bridge.install();
+    });
+    afterEach(() => {
+        bridge.uninstall();
+    });
+
+    it('calls registerHover when onMouseEnter is set', () => {
+        applyAllProps(instance('btn1', 'Button', {
+            onMouseEnter: () => {},
+        }));
+        const reg = bridge.calls.filter((c) => c.fn === 'registerHover');
+        expect(reg.length).toBe(1);
+        expect(reg[0].args).toEqual(['btn1']);
+    });
+
+    it('calls registerHover when onMouseLeave is set', () => {
+        applyAllProps(instance('btn2', 'Button', {
+            onMouseLeave: () => {},
+        }));
+        const reg = bridge.calls.filter((c) => c.fn === 'registerHover');
+        expect(reg.length).toBe(1);
+        expect(reg[0].args).toEqual(['btn2']);
+    });
+
+    it('calls registerHover for pointerenter/pointerleave too', () => {
+        applyAllProps(instance('btn3', 'Button', {
+            onPointerEnter: () => {},
+            onPointerLeave: () => {},
+        }));
+        const reg = bridge.calls.filter((c) => c.fn === 'registerHover');
+        // One call per hover-class handler installed; idempotent on the bridge.
+        expect(reg.length).toBe(2);
+        expect(reg.every((c) => c.args[0] === 'btn3')).toBe(true);
+    });
+
+    it('does NOT call registerHover when only onClick is set', () => {
+        applyAllProps(instance('btn4', 'Button', {
+            onClick: () => {},
+        }));
+        const reg = bridge.calls.filter((c) => c.fn === 'registerHover');
+        expect(reg.length).toBe(0);
+    });
+
+    it('still installs the on() listener alongside registerHover', () => {
+        applyAllProps(instance('btn5', 'Button', {
+            onMouseEnter: () => {},
+        }));
+        const on = bridge.calls.filter((c) => c.fn === 'on');
+        expect(on.length).toBe(1);
+        expect(on[0].args[0]).toBe('btn5');
+        expect(on[0].args[1]).toBe('mouseenter');
+    });
+
+    it('calls registerHover on commitUpdate when adding hover handler', () => {
+        applyChangedProps(
+            instance('btn6', 'Button', {}),
+            { onClick: () => {} },
+            { onClick: () => {}, onMouseEnter: () => {} },
+        );
+        const reg = bridge.calls.filter((c) => c.fn === 'registerHover');
+        expect(reg.length).toBe(1);
+        expect(reg[0].args).toEqual(['btn6']);
+    });
+});


### PR DESCRIPTION
## Summary

Closes part (a) of #1149. The native `WidgetBridge::registerHover(id)` primitive already exists and arms `mouseenter`/`mouseleave` dispatchers on the View, but @pulp/react's prop-applier never called it — so `onMouseEnter` / `onMouseLeave` React handlers silently no-op'd in native builds.

This PR wires it: when `applyEventHandler` sees a hover-class event (mouseenter/mouseleave/pointerenter/pointerleave), it calls `registerHover(id)` before installing the JS listener. Idempotent on the bridge side.

Parts (b) (CSS `:hover` translation) and (c) (`e.currentTarget.style` synthetic event-target) are deferred — see #1149 for scope.

## Test plan

- [x] 6 new tests in `packages/pulp-react/test/prop-applier-hover.test.ts`
- [x] All 11 tests pass locally (`npm test`)
- [x] Existing smoke tests still pass
- [ ] CI green on macos / linux / windows
- [ ] Manual verification in Spectr `feature/native-react-editor` after merge — bottom toolbar `onMouseEnter` styling

## Cross-refs

- Issue: #1149
- Sister issues: #1147 (popover render), #1148 (overlay click dispatch)
- Umbrella: #924
- Bridge primitive added pre-#1042 import; this wires it from the new pulp-react monorepo source.