### PR TITLE
chore: bump versions (catch-up after #1167/#1169/#1173)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.68.1
+    VERSION 0.68.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Summary

Catch-up version bump from 0.68.1 → 0.68.2 to release the user-facing fixes that merged to main since v0.68.1 (#1146):

- #1167 — fix(view): default display:flex to flex-direction:row (#1147)
- #1169 — fix(view): preserve unset border attributes (audit finding #4)
- #1173 — fix(view): wire prop-applier to call registerHover for hover handlers (#1149)

Each PR's branch had its own \`chore: bump versions\` commit going 0.68.0 → 0.68.1, but those bumps became no-ops at squash-merge time because main was already at 0.68.1 (from #1146). Result: all three fixes are stranded in main without an SDK release.

This PR moves the version forward so auto-release.yml can tag v0.68.2 and consumers (Spectr) can pick up these fixes.

## Test plan
- [x] CMakeLists VERSION bumped 0.68.1 → 0.68.2
- [ ] CI green
- [ ] auto-release tags v0.68.2 on merge