### PR TITLE
test(state): cover binding gesture edges

### DIFF
--- a/test/test_binding.cpp
+++ b/test/test_binding.cpp
@@ -24,6 +24,33 @@ TEST_CASE("Binding get/set", "[binding]") {
     REQUIRE_THAT(b.get(), WithinAbs(-12.0, 0.01));
 }
 
+TEST_CASE("Binding unbound operations are inert", "[binding]") {
+    Binding b;
+    int call_count = 0;
+    b.on_change([&](float) { ++call_count; });
+
+    REQUIRE_FALSE(b.is_bound());
+    REQUIRE(b.id() == 0);
+    REQUIRE(b.info() == nullptr);
+    REQUIRE(b.edit_history() == nullptr);
+    REQUIRE_THAT(b.get(), WithinAbs(0.0, 0.01));
+    REQUIRE_THAT(b.get_normalized(), WithinAbs(0.0, 0.01));
+
+    EditHistory history;
+    b.set_edit_history(&history);
+    REQUIRE(b.edit_history() == &history);
+
+    b.set(10.0f);
+    b.set_normalized(0.5f);
+    b.begin_gesture();
+    b.end_gesture();
+    b.reset();
+
+    REQUIRE_FALSE(b.poll());
+    REQUIRE(call_count == 0);
+    REQUIRE_FALSE(history.can_undo());
+}
+
 TEST_CASE("Binding normalized", "[binding]") {
     auto store = make_store();
     Binding b(*store,1); // range -60..24
@@ -32,6 +59,21 @@ TEST_CASE("Binding normalized", "[binding]") {
     REQUIRE_THAT(b.get(), WithinAbs(-60.0, 0.1));
     b.set_normalized(1.0f);
     REQUIRE_THAT(b.get(), WithinAbs(24.0, 0.1));
+}
+
+TEST_CASE("Binding set_normalized only notifies when value changes", "[binding]") {
+    auto store = make_store();
+    Binding b(*store,2); // range 0..100, default 50
+
+    int call_count = 0;
+    b.on_change([&](float) { ++call_count; });
+
+    b.set_normalized(0.5f);
+    REQUIRE(call_count == 0);
+
+    b.set_normalized(0.75f);
+    REQUIRE(call_count == 1);
+    REQUIRE_THAT(b.get(), WithinAbs(75.0, 0.01));
 }
 
 TEST_CASE("Binding on_change fires", "[binding]") {
@@ -78,6 +120,18 @@ TEST_CASE("Binding poll detects external changes", "[binding]") {
     REQUIRE_FALSE(b.poll());
 }
 
+TEST_CASE("Binding poll reports non-zero default once", "[binding]") {
+    auto store = make_store();
+    Binding b(*store,2); // default 50, last_polled_ starts at 0
+
+    float received = -1.0f;
+    b.on_change([&](float v) { received = v; });
+
+    REQUIRE(b.poll());
+    REQUIRE_THAT(received, WithinAbs(50.0, 0.01));
+    REQUIRE_FALSE(b.poll());
+}
+
 TEST_CASE("Binding reset to default", "[binding]") {
     auto store = make_store();
     Binding b(*store,1);
@@ -87,6 +141,82 @@ TEST_CASE("Binding reset to default", "[binding]") {
 
     b.reset();
     REQUIRE_THAT(b.get(), WithinAbs(0.0, 0.01)); // default is 0.0
+}
+
+TEST_CASE("Binding reset always notifies with current default", "[binding]") {
+    auto store = make_store();
+    Binding b(*store,2);
+
+    int call_count = 0;
+    float last_value = -1.0f;
+    b.on_change([&](float v) {
+        ++call_count;
+        last_value = v;
+    });
+
+    b.reset();
+    REQUIRE(call_count == 1);
+    REQUIRE_THAT(last_value, WithinAbs(50.0, 0.01));
+
+    b.set(25.0f);
+    b.reset();
+    REQUIRE(call_count == 3); // set + reset
+    REQUIRE_THAT(last_value, WithinAbs(50.0, 0.01));
+}
+
+TEST_CASE("Binding gestures forward callbacks and create undo entries",
+          "[binding]") {
+    auto store = make_store();
+    Binding b(*store,1);
+    EditHistory history;
+
+    int begin_count = 0;
+    int end_count = 0;
+    ParamID begin_id = 0;
+    ParamID end_id = 0;
+    store->set_gesture_callbacks(
+        [&](ParamID id) {
+            ++begin_count;
+            begin_id = id;
+        },
+        [&](ParamID id) {
+            ++end_count;
+            end_id = id;
+        });
+
+    b.set_edit_history(&history);
+    b.begin_gesture();
+    b.set(-12.0f);
+    b.end_gesture();
+
+    REQUIRE(begin_count == 1);
+    REQUIRE(end_count == 1);
+    REQUIRE(begin_id == 1);
+    REQUIRE(end_id == 1);
+    REQUIRE(history.can_undo());
+    REQUIRE(history.undo_count() == 1);
+    REQUIRE(history.undo_description() == "Gain");
+    REQUIRE_THAT(b.get(), WithinAbs(-12.0, 0.01));
+
+    REQUIRE(history.undo());
+    REQUIRE_THAT(b.get(), WithinAbs(0.0, 0.01));
+    REQUIRE(history.redo());
+    REQUIRE_THAT(b.get(), WithinAbs(-12.0, 0.01));
+}
+
+TEST_CASE("Binding gestures skip undo history when value is unchanged",
+          "[binding]") {
+    auto store = make_store();
+    Binding b(*store,1);
+    EditHistory history;
+    b.set_edit_history(&history);
+
+    b.begin_gesture();
+    b.set(0.0f);
+    b.end_gesture();
+
+    REQUIRE_FALSE(history.can_undo());
+    REQUIRE(history.undo_count() == 0);
 }
 
 TEST_CASE("Binding clamps to range", "[binding]") {


### PR DESCRIPTION
Adds focused Binding coverage for unbound no-ops, normalized no-change notification behavior, non-zero default polling, reset notifications, gesture callbacks, and EditHistory undo/redo integration.

Version-Bump: skip reason="coverage-only state binding tests; no SDK release surface change"