### PR TITLE
fix(events): deactivate one-shot timers after firing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.69.0
+    VERSION 0.69.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/events/src/timer.cpp
+++ b/core/events/src/timer.cpp
@@ -71,6 +71,8 @@ void Timer::schedule_next(std::shared_ptr<Impl> impl, std::uint64_t gen) {
             return;
         if (impl->generation.load(std::memory_order_acquire) != gen)
             return;
+        if (!impl->repeating)
+            impl->active.store(false, std::memory_order_release);
         impl->callback();
         if (!impl->repeating)
             return;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -975,6 +975,10 @@ add_executable(pulp-test-events-async-helpers test_events_async_helpers.cpp)
 target_link_libraries(pulp-test-events-async-helpers PRIVATE pulp::events Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-events-async-helpers)
 
+add_executable(pulp-test-events-timer-helpers test_events_timer_helpers.cpp)
+target_link_libraries(pulp-test-events-timer-helpers PRIVATE pulp::events Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-events-timer-helpers)
+
 # Audio file I/O tests
 add_executable(pulp-test-audio-file test_audio_file.cpp)
 target_link_libraries(pulp-test-audio-file PRIVATE pulp::audio Catch2::Catch2WithMain)

--- a/test/test_events_timer_helpers.cpp
+++ b/test/test_events_timer_helpers.cpp
@@ -1,0 +1,45 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/events/events.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace pulp::events;
+using namespace std::chrono_literals;
+
+namespace {
+
+template <typename Predicate>
+bool wait_until(Predicate&& predicate, std::chrono::milliseconds timeout) {
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (predicate()) {
+            return true;
+        }
+        std::this_thread::sleep_for(2ms);
+    }
+    return predicate();
+}
+
+}  // namespace
+
+TEST_CASE("Timer one-shot deactivates after firing and can be restarted",
+          "[events][timer][issue-642]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+    Timer timer(loop, 5ms, [&] { calls.fetch_add(1); }, false);
+
+    timer.start();
+    REQUIRE(timer.is_active());
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 500ms));
+    REQUIRE_FALSE(timer.is_active());
+
+    std::this_thread::sleep_for(25ms);
+    REQUIRE(calls.load() == 1);
+
+    timer.start();
+    REQUIRE(timer.is_active());
+    REQUIRE(wait_until([&] { return calls.load() == 2; }, 500ms));
+    REQUIRE_FALSE(timer.is_active());
+}


### PR DESCRIPTION
Mark non-repeating timers inactive before invoking their callback so callers can observe completion and restart the timer after it fires.

Add a dedicated #642 timer-helper regression test without touching the shared events test file.

Refs #642.
Refs #641.