### PR TITLE
test(events): cover IPC endpoint parse edges

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -781,6 +781,10 @@ add_executable(pulp-test-ipc test_ipc.cpp)
 target_link_libraries(pulp-test-ipc PRIVATE pulp::events pulp::runtime Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-ipc)
 
+add_executable(pulp-test-ipc-endpoints test_ipc_endpoints.cpp)
+target_link_libraries(pulp-test-ipc-endpoints PRIVATE pulp::events pulp::runtime Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-ipc-endpoints)
+
 # AttributedString and TextLayout tests
 add_executable(pulp-test-attributed-string test_attributed_string.cpp)
 target_link_libraries(pulp-test-attributed-string PRIVATE pulp::canvas Catch2::Catch2WithMain)

--- a/test/test_ipc_endpoints.cpp
+++ b/test/test_ipc_endpoints.cpp
@@ -1,0 +1,34 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/events/interprocess_connection.hpp>
+
+using namespace pulp::events;
+
+TEST_CASE("IPC socket endpoints reject empty ports without opening connections",
+          "[events][ipc][issue-642]") {
+    InterprocessConnection client;
+    REQUIRE_FALSE(client.connect("127.0.0.1:", IpcTransport::Socket));
+    REQUIRE(client.state() == IpcState::Error);
+    REQUIRE_FALSE(client.is_connected());
+
+    client.disconnect();
+    REQUIRE(client.state() == IpcState::Disconnected);
+
+    InterprocessConnection server_connection;
+    REQUIRE_FALSE(server_connection.create_server("127.0.0.1:", IpcTransport::Socket));
+    REQUIRE(server_connection.state() == IpcState::Error);
+    REQUIRE_FALSE(server_connection.is_connected());
+}
+
+TEST_CASE("IPC socket listener rejects empty endpoint strings",
+          "[events][ipc][issue-642]") {
+    InterprocessConnectionServer server;
+
+    REQUIRE_FALSE(server.start("", IpcTransport::Socket));
+    REQUIRE_FALSE(server.is_running());
+
+    REQUIRE_FALSE(server.start("127.0.0.1:", IpcTransport::Socket));
+    REQUIRE_FALSE(server.is_running());
+
+    server.stop();
+    REQUIRE_FALSE(server.is_running());
+}


### PR DESCRIPTION
Covers part of #642. Related to #641.