### PR TITLE
test(cli): cover create target edge formats

### DIFF
--- a/test/test_cli_create_targets.cpp
+++ b/test/test_cli_create_targets.cpp
@@ -35,3 +35,31 @@ TEST_CASE("CLI create targets use the app target name for bare projects", "[cli]
         "PulpBare",
     });
 }
+
+TEST_CASE("CLI create targets include optional plugin format suffixes once",
+          "[cli][create][issue-643]") {
+    const auto targets =
+        create_default_build_targets("PulpPlugin",
+                                     "instrument",
+                                     "VST3 CLAP AU AUv3 LV2 AAX Standalone VST3");
+
+    CHECK(targets == std::vector<std::string>{
+        "PulpPlugin-test",
+        "PulpPlugin_VST3",
+        "PulpPlugin_CLAP",
+        "PulpPlugin_AU",
+        "PulpPlugin_AUv3",
+        "PulpPlugin_LV2",
+        "PulpPlugin_AAX",
+        "PulpPlugin_Standalone",
+    });
+}
+
+TEST_CASE("CLI create targets skip empty standalone app targets",
+          "[cli][create][issue-643]") {
+    const auto targets = create_default_build_targets("", "app", "Standalone");
+
+    CHECK(targets == std::vector<std::string>{
+        "-test",
+    });
+}


### PR DESCRIPTION
Covers part of #643. Related to #641.

Adds focused CLI create-target coverage for optional AU/AUv3/LV2/AAX suffix generation, duplicate target de-duplication, and empty standalone app target filtering.

Local validation:
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar
- cmake --build build --target pulp-test-cli-create-targets -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-cli-create-targets -r compact
- ctest --test-dir build -R "CLI create targets|cli-create-targets|create targets" --output-on-failure
- CLI skew check
- skill_sync_check.py --mode=report
- version_bump_check.py --mode=report
- git diff --check; git diff --cached --check