### PR TITLE
test(platform): cover popup menu fallback paths

### DIFF
--- a/test/test_platform.cpp
+++ b/test/test_platform.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/platform/platform.hpp>
+#include <pulp/platform/popup_menu.hpp>
 #include <pulp/platform/win/registry.hpp>
 
 using namespace pulp::platform;
@@ -40,6 +41,46 @@ TEST_CASE("Apple-specific detection", "[platform]") {
     REQUIRE(is_apple);
     REQUIRE((is_macos || is_ios));
     REQUIRE((current_compiler == Compiler::AppleClang || current_compiler == Compiler::Clang));
+}
+#endif
+
+TEST_CASE("PopupMenu records items and separators",
+          "[platform][popup-menu][issue-640]") {
+    PopupMenu menu;
+
+    menu.add_item(10, "Open", true, false);
+    menu.add_separator();
+    menu.add_item(20, "Pinned", false, true);
+
+    const auto& items = menu.items();
+    REQUIRE(items.size() == 3);
+    REQUIRE(items[0].id == 10);
+    REQUIRE(items[0].label == "Open");
+    REQUIRE(items[0].enabled);
+    REQUIRE_FALSE(items[0].checked);
+    REQUIRE_FALSE(items[0].is_separator);
+
+    REQUIRE(items[1].id == 0);
+    REQUIRE(items[1].label.empty());
+    REQUIRE(items[1].enabled);
+    REQUIRE_FALSE(items[1].checked);
+    REQUIRE(items[1].is_separator);
+
+    REQUIRE(items[2].id == 20);
+    REQUIRE(items[2].label == "Pinned");
+    REQUIRE_FALSE(items[2].enabled);
+    REQUIRE(items[2].checked);
+    REQUIRE_FALSE(items[2].is_separator);
+}
+
+#if !defined(__APPLE__)
+TEST_CASE("PopupMenu fallback returns no selection on non-Apple platforms",
+          "[platform][popup-menu][issue-640]") {
+    PopupMenu menu;
+    menu.add_item(1, "Only action");
+
+    REQUIRE_FALSE(menu.show(12.0f, 34.0f).has_value());
+    REQUIRE_FALSE(menu.show_at_view(reinterpret_cast<void*>(0x1)).has_value());
 }
 #endif
 


### PR DESCRIPTION
Cover platform popup menu item/separator bookkeeping and the non-Apple fallback no-selection paths.

Covers part of #640

Related to #641