### PR TITLE
test(android): cover audio controller lifecycle edges

### DIFF
--- a/android/app/src/test/kotlin/com/pulp/audio/PulpAudioControllerTest.kt
+++ b/android/app/src/test/kotlin/com/pulp/audio/PulpAudioControllerTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -70,6 +71,51 @@ class PulpAudioControllerTest {
     }
 
     @Test
+    fun stopAudioIsNoOpWhenNotRunning() {
+        val context = mock<Context>()
+        val controller = PulpAudioController(context)
+
+        controller.stopAudio()
+
+        verify(context, never()).startService(any())
+        verify(context, never()).unbindService(any())
+        assertFalse(controller.isRunning)
+    }
+
+    @Test
+    fun stopAudioIsIdempotentAfterSuccessfulStop() {
+        val context = mock<Context>()
+        whenever(context.bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))).thenReturn(true)
+        val controller = PulpAudioController(context)
+
+        controller.startAudio()
+        controller.stopAudio()
+        controller.stopAudio()
+
+        verify(context, times(1)).startService(any())
+        verify(context, times(1)).unbindService(any())
+        assertFalse(controller.isRunning)
+    }
+
+    @Test
+    fun connectCallbackKeepsRunningState() {
+        val context = mock<Context>()
+        whenever(context.bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))).thenReturn(true)
+        val connectionCaptor = argumentCaptor<ServiceConnection>()
+        val controller = PulpAudioController(context)
+
+        controller.startAudio(isRecording = true)
+        verify(context).bindService(any(), connectionCaptor.capture(), eq(Context.BIND_AUTO_CREATE))
+
+        connectionCaptor.firstValue.onServiceConnected(
+            ComponentName("com.pulp.app", "com.pulp.PulpAudioService"),
+            null
+        )
+
+        assertTrue(controller.isRunning)
+    }
+
+    @Test
     fun disconnectCallbackClearsRunningState() {
         val context = mock<Context>()
         whenever(context.bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))).thenReturn(true)
@@ -84,5 +130,25 @@ class PulpAudioControllerTest {
         )
 
         assertFalse(controller.isRunning)
+    }
+
+    @Test
+    fun startAudioCanRestartAfterServiceDisconnect() {
+        val context = mock<Context>()
+        whenever(context.bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))).thenReturn(true)
+        val connectionCaptor = argumentCaptor<ServiceConnection>()
+        val controller = PulpAudioController(context)
+
+        controller.startAudio()
+        verify(context).bindService(any(), connectionCaptor.capture(), eq(Context.BIND_AUTO_CREATE))
+        connectionCaptor.firstValue.onServiceDisconnected(
+            ComponentName("com.pulp.app", "com.pulp.PulpAudioService")
+        )
+
+        controller.startAudio(isRecording = true)
+
+        verify(context, times(2)).startForegroundService(any())
+        verify(context, times(2)).bindService(any(), any(), eq(Context.BIND_AUTO_CREATE))
+        assertTrue(controller.isRunning)
     }
 }


### PR DESCRIPTION
Refs #641

Skill-Update: skip skill=android reason="test-only coverage tranche; no Android workflow guidance changed"