### PR TITLE
test(bindings): cover python helper edges

### DIFF
--- a/test/test_python_bindings.py
+++ b/test/test_python_bindings.py
@@ -44,6 +44,10 @@ def assert_param_range_bindings(pulp) -> None:
     assert math.isclose(equal_range.normalize(3.0), 0.0)
     assert math.isclose(equal_range.denormalize(0.75), 3.0)
 
+    clamped_range = pulp.ParamRange(-1.0, 1.0, 0.0)
+    assert math.isclose(clamped_range.normalize(-2.0), 0.0)
+    assert math.isclose(clamped_range.normalize(2.0), 1.0)
+
     info = pulp.ParamInfo()
     info.id = 101
     info.name = "Gain"
@@ -68,6 +72,21 @@ def assert_midi_bindings(pulp) -> None:
     midi = pulp.MidiBuffer()
     assert midi.empty()
     assert midi.size() == 0
+
+    note_on = pulp.MidiEvent.note_on(1, 60, 100)
+    note_on.sample_offset = 3
+    midi.add(note_on)
+    midi.add(pulp.MidiEvent.note_off(1, 60))
+    midi.add(pulp.MidiEvent.cc(1, 74, 64))
+    midi.add(pulp.MidiEvent.pitch_bend(1, 8192))
+    assert midi.size() == 4
+    midi.clear()
+    assert midi.empty()
+
+    midi.add(note_on)
+    midi.add(pulp.MidiEvent.note_off(1, 60))
+    assert midi.size() == 2
+    assert not midi.empty()
     midi.clear()
     assert midi.empty()
 


### PR DESCRIPTION
Adds focused Phase 3 Python binding coverage for ParamRange clamp/zero-span normalization and MidiBuffer clear/reuse edge behavior.

Refs #641.