### PR TITLE
test(view): cover splash screen lifecycle

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1980,6 +1980,11 @@ add_executable(pulp-test-appearance test_appearance_tracker.cpp)
 target_link_libraries(pulp-test-appearance PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-appearance)
 
+# Splash screen lifecycle and paint behavior
+add_executable(pulp-test-splash-screen test_splash_screen.cpp)
+target_link_libraries(pulp-test-splash-screen PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-splash-screen)
+
 # New widgets (EqCurve, MidiKeyboard, ColorPicker, FileDropZone, SplitView, PropertyList, Breadcrumb)
 add_executable(pulp-test-phase9-widgets test_phase9_widgets.cpp)
 target_link_libraries(pulp-test-phase9-widgets PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_splash_screen.cpp
+++ b/test/test_splash_screen.cpp
@@ -1,0 +1,109 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/view/splash_screen.hpp>
+
+#include <algorithm>
+#include <string>
+
+using namespace pulp::view;
+using pulp::canvas::DrawCommand;
+using pulp::canvas::RecordingCanvas;
+
+namespace {
+
+bool has_text(const RecordingCanvas& canvas, const std::string& text) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const DrawCommand& cmd) {
+                           return cmd.type == DrawCommand::Type::fill_text &&
+                                  cmd.text == text;
+                       });
+}
+
+bool has_image(const RecordingCanvas& canvas, const std::string& path) {
+    return std::any_of(canvas.commands().begin(),
+                       canvas.commands().end(),
+                       [&](const DrawCommand& cmd) {
+                           return cmd.type == DrawCommand::Type::draw_image &&
+                                  cmd.text == path;
+                       });
+}
+
+} // namespace
+
+TEST_CASE("SplashScreen advances through automatic fade lifecycle",
+          "[view][splash]") {
+    SplashScreen splash;
+    REQUIRE_FALSE(splash.advance(0.1f));
+
+    int dismissed = 0;
+    splash.on_dismissed = [&] { ++dismissed; };
+    splash.set_fade_in(0.2f);
+    splash.set_duration(0.3f);
+    splash.set_fade_out(0.4f);
+
+    splash.show();
+    REQUIRE(splash.is_showing());
+
+    REQUIRE(splash.advance(0.1f));
+    REQUIRE(splash.advance(0.1f));
+    REQUIRE(splash.advance(0.3f));
+    REQUIRE(splash.advance(0.2f));
+    REQUIRE(splash.is_showing());
+
+    REQUIRE_FALSE(splash.advance(0.2f));
+    REQUIRE_FALSE(splash.is_showing());
+    REQUIRE(dismissed == 1);
+
+    REQUIRE_FALSE(splash.advance(1.0f));
+    REQUIRE(dismissed == 1);
+}
+
+TEST_CASE("SplashScreen click dismissal honors the click toggle",
+          "[view][splash]") {
+    SplashScreen splash;
+    splash.set_fade_in(0.1f);
+    splash.set_duration(10.0f);
+    splash.set_fade_out(0.25f);
+
+    int dismissed = 0;
+    splash.on_dismissed = [&] { ++dismissed; };
+
+    splash.show();
+    splash.set_dismiss_on_click(false);
+    splash.on_mouse_down({12.0f, 8.0f});
+    REQUIRE(splash.advance(0.5f));
+    REQUIRE(splash.is_showing());
+    REQUIRE(dismissed == 0);
+
+    splash.set_dismiss_on_click(true);
+    splash.on_mouse_down({12.0f, 8.0f});
+    REQUIRE_FALSE(splash.advance(0.25f));
+    REQUIRE_FALSE(splash.is_showing());
+    REQUIRE(dismissed == 1);
+}
+
+TEST_CASE("SplashScreen paint records default text and image paths",
+          "[view][splash][paint]") {
+    SplashScreen splash;
+    splash.set_bounds({0.0f, 0.0f, 240.0f, 120.0f});
+
+    RecordingCanvas hidden;
+    splash.paint(hidden);
+    REQUIRE(hidden.command_count() == 0);
+
+    splash.show();
+
+    RecordingCanvas default_canvas;
+    splash.paint(default_canvas);
+    REQUIRE(default_canvas.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(default_canvas.count(DrawCommand::Type::fill_text) == 1);
+    REQUIRE(has_text(default_canvas, "Loading..."));
+
+    splash.set_image("assets/splash.png");
+    RecordingCanvas image_canvas;
+    splash.paint(image_canvas);
+    REQUIRE(image_canvas.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(image_canvas.count(DrawCommand::Type::draw_image) == 1);
+    REQUIRE(has_image(image_canvas, "assets/splash.png"));
+}


### PR DESCRIPTION
## Summary
- Adds focused coverage for `core/view/src/splash_screen.cpp` lifecycle timing, click dismissal, and paint fallback/image paths.
- Registers a dedicated `pulp-test-splash-screen` target.

Refs #493. Refs #641.

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_BUILD_EXAMPLES=OFF -DFETCHCONTENT_SOURCE_DIR_MBEDTLS=/Users/danielraffel/Library/Caches/Pulp/fetchcontent-src/mbedtls-v3.6.2-tar`
- `cmake --build build --target pulp-test-splash-screen -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-splash-screen -r compact`
- `ctest --test-dir build -R "SplashScreen|splash-screen|splash" --output-on-failure`
- `pulp_cli_version_check`
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD`
- `git diff --check origin/main...HEAD`
- `git diff --check`