### PR TITLE
test(runtime): cover named pipe edge paths

### DIFF
--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <pulp/runtime/named_pipe.hpp>
 #include <pulp/runtime/stream.hpp>
 
 #include <array>
@@ -11,6 +12,7 @@
 
 using pulp::runtime::FileStream;
 using pulp::runtime::MemoryStream;
+using pulp::runtime::NamedPipe;
 using pulp::runtime::Stream;
 using pulp::runtime::StreamError;
 using pulp::runtime::StreamResult;
@@ -208,3 +210,107 @@ TEST_CASE("Stream polymorphic usage", "[stream]") {
     REQUIRE(r.bytes == std::strlen(msg));
     REQUIRE(std::memcmp(buf.data(), msg, std::strlen(msg)) == 0);
 }
+
+TEST_CASE("NamedPipe closed and missing endpoints fail closed", "[stream][named_pipe][issue-641]") {
+    NamedPipe pipe;
+    REQUIRE_FALSE(pipe.is_open());
+
+    std::uint8_t buf[4]{};
+    REQUIRE(pipe.read(buf, sizeof(buf)) == -1);
+    REQUIRE(pipe.write(buf, sizeof(buf)) == -1);
+    REQUIRE(pipe.write(std::string_view{"closed"}) == -1);
+    REQUIRE_FALSE(pipe.read_string(8).has_value());
+    pipe.close();
+    REQUIRE_FALSE(pipe.is_open());
+
+    auto missing = make_temp_path("pulp_missing_pipe");
+    std::filesystem::remove(missing);
+    REQUIRE_FALSE(pipe.connect_client(missing.string()));
+    REQUIRE_FALSE(pipe.is_open());
+    REQUIRE(pipe.read(buf, sizeof(buf)) == -1);
+}
+
+#ifndef _WIN32
+TEST_CASE("NamedPipe POSIX FIFO round-trips bytes and unlinks on close",
+          "[stream][named_pipe][issue-641]") {
+    auto path = make_temp_path("pulp_named_pipe_roundtrip");
+    std::filesystem::remove(path);
+
+    NamedPipe server;
+    REQUIRE(server.create_server(path.string()));
+    REQUIRE(server.is_open());
+    REQUIRE(std::filesystem::exists(path));
+
+    NamedPipe client;
+    REQUIRE(client.connect_client(path.string()));
+    REQUIRE(client.is_open());
+
+    REQUIRE(server.write(std::string_view{"ping"}) == 4);
+    auto from_server = client.read_string(16);
+    REQUIRE(from_server.has_value());
+    REQUIRE(*from_server == "ping");
+
+    const std::uint8_t reply[] = {'p', 'o', 'n', 'g'};
+    REQUIRE(client.write(reply, sizeof(reply)) == static_cast<int>(sizeof(reply)));
+
+    std::array<std::uint8_t, sizeof(reply)> got{};
+    REQUIRE(server.read(got.data(), got.size()) == static_cast<int>(got.size()));
+    REQUIRE(std::memcmp(got.data(), reply, got.size()) == 0);
+
+    client.close();
+    REQUIRE_FALSE(client.is_open());
+    REQUIRE(std::filesystem::exists(path));
+
+    server.close();
+    REQUIRE_FALSE(server.is_open());
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
+TEST_CASE("NamedPipe POSIX move transfers FIFO cleanup ownership",
+          "[stream][named_pipe][issue-641]") {
+    auto first = make_temp_path("pulp_named_pipe_move_first");
+    auto second = make_temp_path("pulp_named_pipe_move_second");
+    std::filesystem::remove(first);
+    std::filesystem::remove(second);
+
+    NamedPipe original;
+    REQUIRE(original.create_server(first.string()));
+    REQUIRE(std::filesystem::exists(first));
+
+    NamedPipe moved(std::move(original));
+    REQUIRE_FALSE(original.is_open());
+    REQUIRE(moved.is_open());
+    REQUIRE(std::filesystem::exists(first));
+
+    NamedPipe replacement;
+    REQUIRE(replacement.create_server(second.string()));
+    REQUIRE(std::filesystem::exists(second));
+
+    moved = std::move(replacement);
+    REQUIRE_FALSE(replacement.is_open());
+    REQUIRE(moved.is_open());
+    REQUIRE_FALSE(std::filesystem::exists(first));
+    REQUIRE(std::filesystem::exists(second));
+
+    moved.close();
+    REQUIRE_FALSE(moved.is_open());
+    REQUIRE_FALSE(std::filesystem::exists(second));
+}
+
+TEST_CASE("NamedPipe POSIX create failure leaves pipe closed",
+          "[stream][named_pipe][issue-641]") {
+    auto directory = make_temp_path("pulp_named_pipe_directory_collision");
+    std::filesystem::remove(directory);
+    std::filesystem::create_directory(directory);
+
+    NamedPipe pipe;
+    REQUIRE_FALSE(pipe.create_server(directory.string()));
+    REQUIRE_FALSE(pipe.is_open());
+
+    std::uint8_t buf[1]{};
+    REQUIRE(pipe.read(buf, sizeof(buf)) == -1);
+    REQUIRE(pipe.write(buf, sizeof(buf)) == -1);
+    pipe.close();
+    std::filesystem::remove(directory);
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds focused coverage for `core/runtime/src/named_pipe.cpp` closed/missing endpoint fail-closed behavior.
- Covers POSIX FIFO round-trip, cleanup, move-ownership, and create-failure paths through `test/test_stream.cpp`.

Refs #641.

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_ENABLE_GPU=OFF -DPULP_TEXT_SHAPING=OFF -DPULP_BUILD_EXAMPLES=OFF`
- `cmake --build build --target pulp-test-stream -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-stream -r compact`
- `ctest --test-dir build -R "NamedPipe|Stream" --output-on-failure`
- `pulp_cli_version_check`
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main --head HEAD`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main --head HEAD`
- `git diff --check origin/main...HEAD`
- `git diff --check`