### PR TITLE
fix(view): ScrollView::hit_test honors pointer_events (Codex P1, closes #1170)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.69.1
+    VERSION 0.69.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -576,6 +576,12 @@ View* ScrollView::hit_test(Point local_point) {
     if (!visible() || !enabled() || !hit_testable()) return nullptr;
     if (!local_bounds().contains(local_point)) return nullptr;
 
+    // React Native pointerEvents parity (pulp #1170 Codex P1 on #1044/#1026):
+    // ScrollView shadows the base View::hit_test, so without this honor the
+    // setPointerEvents(box-only/box-none/none) path silently no-ops on
+    // scrollables. Mirror View::hit_test's policy here.
+    if (pointer_events() == PointerEvents::none) return nullptr;
+
     auto b = local_bounds();
     float bar_w = bar_width_.value();
     bool in_v_bar = direction_ != Direction::horizontal &&
@@ -584,32 +590,40 @@ View* ScrollView::hit_test(Point local_point) {
     bool in_h_bar = direction_ != Direction::vertical &&
                     content_size_.width > b.width &&
                     local_point.y >= b.y + b.height - bar_w - 6;
-    if (in_v_bar || in_h_bar)
-        return this;
+    // Scrollbar hits target the ScrollView itself. box_none disables
+    // self-targeting; box_only still routes scrollbar interactions to
+    // self (the chrome belongs to the container, not its children).
+    if (in_v_bar || in_h_bar) {
+        return pointer_events() == PointerEvents::box_none ? nullptr : this;
+    }
 
     float sx = smooth_scroll_x_.value();
     float sy = smooth_scroll_y_.value();
 
-    for (size_t i = child_count(); i > 0; --i) {
-        auto* child = child_at(i - 1);
-        if (!child->visible()) continue;
+    if (pointer_events() != PointerEvents::box_only) {
+        for (size_t i = child_count(); i > 0; --i) {
+            auto* child = child_at(i - 1);
+            if (!child->visible()) continue;
 
-        Point child_point = {local_point.x + sx - child->bounds().x,
-                             local_point.y + sy - child->bounds().y};
+            Point child_point = {local_point.x + sx - child->bounds().x,
+                                 local_point.y + sy - child->bounds().y};
 
-        bool in_bounds = child->local_bounds().contains(child_point);
-        if (!in_bounds && child->overflow() == Overflow::visible) {
-            auto lb = child->local_bounds();
-            in_bounds = child_point.x >= lb.x && child_point.x <= lb.x + lb.width &&
-                        child_point.y >= lb.y && child_point.y <= lb.y + lb.height + 500;
-        }
+            bool in_bounds = child->local_bounds().contains(child_point);
+            if (!in_bounds && child->overflow() == Overflow::visible) {
+                auto lb = child->local_bounds();
+                in_bounds = child_point.x >= lb.x && child_point.x <= lb.x + lb.width &&
+                            child_point.y >= lb.y && child_point.y <= lb.y + lb.height + 500;
+            }
 
-        if (in_bounds) {
-            if (auto* hit = child->hit_test(child_point))
-                return hit;
+            if (in_bounds) {
+                if (auto* hit = child->hit_test(child_point))
+                    return hit;
+            }
         }
     }
 
+    // box_none suppresses self-targeting even when no child was hit.
+    if (pointer_events() == PointerEvents::box_none) return nullptr;
     return this;
 }
 

--- a/test/test_scroll_view.cpp
+++ b/test/test_scroll_view.cpp
@@ -84,3 +84,72 @@ TEST_CASE("ScrollView: hit testing follows scrolled content", "[scrollview]") {
     auto* hit = sv.hit_test({10, 30});
     REQUIRE(hit == label_ptr);
 }
+
+// ── pulp #1170: ScrollView honors React Native pointerEvents ───────────────
+//
+// Codex P1 follow-up on #1044 — ScrollView::hit_test shadowed View::hit_test
+// without honoring pointer_events(), so setPointerEvents("box-only"/"box-none"
+// /"none") was a silent no-op for any scrollable container.
+
+TEST_CASE("ScrollView::hit_test honors pointerEvents == none (#1170)",
+          "[scrollview][hit_test][issue-1170]") {
+    ScrollView sv;
+    sv.set_bounds({0, 0, 200, 200});
+    sv.set_content_size({200, 200});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({50, 50, 100, 100});
+    sv.add_child(std::move(child));
+
+    sv.set_pointer_events(View::PointerEvents::none);
+    REQUIRE(sv.hit_test({75, 75}) == nullptr);
+    REQUIRE(sv.hit_test({10, 10}) == nullptr);
+}
+
+TEST_CASE("ScrollView::hit_test honors pointerEvents == box-only (#1170)",
+          "[scrollview][hit_test][issue-1170]") {
+    ScrollView sv;
+    sv.set_bounds({0, 0, 200, 200});
+    sv.set_content_size({200, 200});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({50, 50, 100, 100});
+    sv.add_child(std::move(child));
+
+    // box_only: descent skipped — hits inside child bounds resolve to the
+    // ScrollView itself, not to the child.
+    sv.set_pointer_events(View::PointerEvents::box_only);
+    REQUIRE(sv.hit_test({75, 75}) == &sv);
+    REQUIRE(sv.hit_test({10, 10}) == &sv);
+}
+
+TEST_CASE("ScrollView::hit_test honors pointerEvents == box-none (#1170)",
+          "[scrollview][hit_test][issue-1170]") {
+    ScrollView sv;
+    sv.set_bounds({0, 0, 200, 200});
+    sv.set_content_size({200, 200});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({50, 50, 100, 100});
+    auto* child_ptr = child.get();
+    sv.add_child(std::move(child));
+
+    // box_none: child is hit-testable, but a point in the ScrollView's
+    // own bounds (not on a child) returns nullptr — never self.
+    sv.set_pointer_events(View::PointerEvents::box_none);
+    REQUIRE(sv.hit_test({75, 75}) == child_ptr);
+    REQUIRE(sv.hit_test({10, 10}) == nullptr);
+}
+
+TEST_CASE("ScrollView::hit_test box-none also suppresses scrollbar self-target (#1170)",
+          "[scrollview][hit_test][issue-1170]") {
+    ScrollView sv;
+    sv.set_bounds({0, 0, 200, 100});
+    // Content taller than view → vertical scrollbar appears at the right edge.
+    sv.set_content_size({200, 400});
+
+    sv.set_pointer_events(View::PointerEvents::box_none);
+    // Hit near the right edge would normally land on the v-scrollbar
+    // and return self; box_none must suppress that.
+    REQUIRE(sv.hit_test({195, 50}) == nullptr);
+}


### PR DESCRIPTION
## Summary

Closes #1170 (Codex P1 follow-up on #1044/#1026). `ScrollView::hit_test` shadowed `View::hit_test` without honoring `pointer_events()`, so `setPointerEvents("box-only" / "box-none" / "none")` silently no-op'd on every scrollable container.

## Fix

Mirror `View::hit_test`'s policy in `ScrollView::hit_test`:

| Mode | ScrollView behavior |
|------|---------------------|
| `none` | return nullptr (no self, no children) |
| `box_only` | descent skipped — children never hit-tested; ScrollView (incl. scrollbars) returns self |
| `box_none` | children hit-testable; ScrollView (incl. scrollbars) never returns self |
| `auto_` | unchanged |

Scrollbar hits are part of the container chrome — `box_only` still routes them to self (the scrollbar belongs to the ScrollView, not its content), but `box_none` suppresses self-targeting even for scrollbar regions.

## Tests

4 new cases in `test/test_scroll_view.cpp` (tag `[issue-1170]`):
- `pointerEvents == none` blocks both child + self
- `pointerEvents == box-only` skips child descent
- `pointerEvents == box-none` keeps child but suppresses self
- `pointerEvents == box-none` also suppresses scrollbar self-target

All 10 ScrollView tests pass locally.

## Cross-refs

- Codex P1 review on #1044
- #1170 (this fix)
- #1044/#1026 (where `pointer_events` landed)
- #1049 silent-no-op audit epic — instance of the pattern this PR fixes