### PR TITLE
feat(view): @pulp/react SvgPath intrinsic (closes pulp #994)

### DIFF
--- a/packages/pulp-react/src/bridge.ts
+++ b/packages/pulp-react/src/bridge.ts
@@ -173,6 +173,9 @@ export function createMockBridge(): MockBridge {
         'setText', 'setTextColor', 'setTextAlign',
         'setSpectrumData', 'setWaveformData', 'setMeterLevel', 'setProgress',
         'setValue', 'setTheme', 'layout', 'on', 'registerHover',
+        // pulp #994 — SvgPath intrinsic surface
+        'createSvgPath', 'setSvgPath', 'setSvgViewBox',
+        'setSvgFill', 'setSvgStroke', 'setSvgStrokeWidth',
     ];
     const saved: Record<string, unknown> = {};
     return {

--- a/packages/pulp-react/src/host-config.ts
+++ b/packages/pulp-react/src/host-config.ts
@@ -99,6 +99,7 @@ function createWidget(type: Type, id: string, parentId: string, props: Props): v
         case 'Canvas':      call('createCanvas', id, parentId); return;
         case 'Image':       call('createImage', id, parentId); return;
         case 'Icon':        call('createIcon', id, parentId); return;
+        case 'SvgPath':     call('createSvgPath', id, parentId); return;
         default: {
             // Should be unreachable thanks to the typed intrinsics in types.ts.
             const _exhaustive: never = type;

--- a/packages/pulp-react/src/index.ts
+++ b/packages/pulp-react/src/index.ts
@@ -93,7 +93,7 @@ export type {
     LabelProps, ButtonProps, TextEditorProps,
     KnobProps, FaderProps, SpectrumProps, WaveformProps, MeterProps,
     ProgressProps, XYPadProps, CheckboxProps, ToggleProps, ComboProps,
-    ListBoxProps, CanvasProps, ImageProps, IconProps,
+    ListBoxProps, CanvasProps, ImageProps, IconProps, SvgPathProps,
     FlexDirection, FlexAlign, FlexAlignSelf, FlexJustify,
     FlexProps, StyleProps, BaseProps,
     IntrinsicElementMap, IntrinsicElementName,

--- a/packages/pulp-react/src/intrinsics.ts
+++ b/packages/pulp-react/src/intrinsics.ts
@@ -12,7 +12,7 @@ import type {
     LabelProps, ButtonProps, TextEditorProps,
     KnobProps, FaderProps, SpectrumProps, WaveformProps, MeterProps,
     ProgressProps, XYPadProps, CheckboxProps, ToggleProps, ComboProps,
-    ListBoxProps, CanvasProps, ImageProps, IconProps,
+    ListBoxProps, CanvasProps, ImageProps, IconProps, SvgPathProps,
 } from './types.js';
 
 // Each intrinsic is a function component that emits a host element with
@@ -44,3 +44,4 @@ export const ListBox = (props: ListBoxProps): ReactElement => createElement('Lis
 export const Canvas = (props: CanvasProps): ReactElement => createElement('Canvas' as unknown as 'div', props as unknown as object);
 export const Image = (props: ImageProps): ReactElement => createElement('Image' as unknown as 'div', props as unknown as object);
 export const Icon = (props: IconProps): ReactElement => createElement('Icon' as unknown as 'div', props as unknown as object);
+export const SvgPath = (props: SvgPathProps): ReactElement => createElement('SvgPath' as unknown as 'div', props as unknown as object);

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -218,6 +218,21 @@ function applyOne(id: string, type: string, key: string, value: unknown): void {
             if (type === 'Meter')      return call('setMeterLevel', id, value as number);
             return call('setValue', id, value as number);
 
+        // SvgPath (pulp #994) — wires the SvgPathWidget bridge surface
+        // (createSvgPath / setSvgPath / setSvgViewBox / setSvgFill /
+        // setSvgStroke / setSvgStrokeWidth) through a typed JSX intrinsic.
+        case 'd':            return call('setSvgPath', id, value as string);
+        case 'viewBox': {
+            const vb = value as [number, number];
+            if (Array.isArray(vb) && vb.length >= 2) {
+                return call('setSvgViewBox', id, vb[0], vb[1]);
+            }
+            return;
+        }
+        case 'fill':         return call('setSvgFill', id, value as string);
+        case 'stroke':       return call('setSvgStroke', id, value as string);
+        case 'strokeWidth':  return call('setSvgStrokeWidth', id, value as number);
+
         default:
             // Unknown prop — silently ignore. We could warn here in DEV
             // builds, but staying chatty in prod is annoying. The

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -186,6 +186,29 @@ export interface IconProps extends BaseProps {
     name?: string;
 }
 
+/// Inline SVG path widget (pulp #994 / #991). Renders an `<svg><path/></svg>`
+/// from a path-data string + paint attributes. Use this for icon glyphs
+/// inside React-rendered UIs that previously sent raw `<svg>` markup
+/// (which the bridge has no DOM equivalent for).
+export interface SvgPathProps extends BaseProps {
+    /// SVG path-data string (the `d=` attribute on `<path>`).
+    /// Supports M/m, L/l, H/h, V/v, C/c, S/s, Q/q, T/t, A/a, Z/z.
+    d?: string;
+    /// Two-number viewbox (width, height). The path is parsed in the
+    /// viewbox's coordinate space and scaled into the widget's bounds
+    /// at paint time. Defaults to (0, 0) — i.e. the bridge will not
+    /// scale and the path's native units determine size.
+    viewBox?: [number, number];
+    /// Fill color as hex (`#rrggbb` / `#rrggbbaa`) or `"none"`. Defaults
+    /// to the SvgPathWidget's internal default (transparent + no stroke
+    /// = invisible). Pass `"none"` to clear an inherited fill.
+    fill?: string;
+    /// Stroke color as hex or `"none"`.
+    stroke?: string;
+    /// Stroke width in widget-local units. Defaults to 1.
+    strokeWidth?: number;
+}
+
 // ── Element-name → intrinsic-props map ──────────────────────────────
 // The host config consults this implicitly; tests assert names against it.
 export interface IntrinsicElementMap {
@@ -212,6 +235,7 @@ export interface IntrinsicElementMap {
     Canvas: CanvasProps;
     Image: ImageProps;
     Icon: IconProps;
+    SvgPath: SvgPathProps;
 }
 
 export type IntrinsicElementName = keyof IntrinsicElementMap;

--- a/packages/pulp-react/test/svgpath-intrinsic.test.ts
+++ b/packages/pulp-react/test/svgpath-intrinsic.test.ts
@@ -1,0 +1,114 @@
+// Test for pulp #994 — @pulp/react SvgPath intrinsic.
+//
+// The C++ side has shipped SvgPathWidget + bridge handlers (createSvgPath,
+// setSvgPath, setSvgViewBox, setSvgFill, setSvgStroke, setSvgStrokeWidth)
+// since v0.61.0 (#965/#991). This wires the React-side intrinsic so JSX
+// `<SvgPath d="..." viewBox={[w,h]} fill="#fff" stroke="#000" strokeWidth={1} />`
+// reaches the bridge.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import { applyAllProps, applyChangedProps } from '../src/prop-applier.js';
+import { SvgPath } from '../src/intrinsics.js';
+import type { PulpInstance } from '../src/types.js';
+
+function instance(id: string, type: string, props: Record<string, unknown>): PulpInstance {
+    return { id, type, props } as PulpInstance;
+}
+
+describe('@pulp/react SvgPath intrinsic (pulp #994)', () => {
+    let bridge: MockBridge;
+    beforeEach(() => {
+        bridge = createMockBridge();
+        bridge.install();
+    });
+    afterEach(() => {
+        bridge.uninstall();
+    });
+
+    it('export is a function component', () => {
+        expect(typeof SvgPath).toBe('function');
+    });
+
+    it('forwards `d` prop to setSvgPath', () => {
+        applyAllProps(instance('icon1', 'SvgPath', {
+            d: 'M0 0 L10 10 Z',
+        }));
+        const setPath = bridge.calls.filter((c) => c.fn === 'setSvgPath');
+        expect(setPath.length).toBe(1);
+        expect(setPath[0].args).toEqual(['icon1', 'M0 0 L10 10 Z']);
+    });
+
+    it('forwards `viewBox` array to setSvgViewBox(id, w, h)', () => {
+        applyAllProps(instance('icon2', 'SvgPath', {
+            viewBox: [24, 24],
+        }));
+        const setVB = bridge.calls.filter((c) => c.fn === 'setSvgViewBox');
+        expect(setVB.length).toBe(1);
+        expect(setVB[0].args).toEqual(['icon2', 24, 24]);
+    });
+
+    it('drops viewBox when not a length-2 array', () => {
+        applyAllProps(instance('icon3', 'SvgPath', {
+            viewBox: 'not-an-array' as unknown as [number, number],
+        }));
+        expect(bridge.calls.filter((c) => c.fn === 'setSvgViewBox').length).toBe(0);
+    });
+
+    it('forwards `fill` to setSvgFill', () => {
+        applyAllProps(instance('icon4', 'SvgPath', {
+            fill: '#ff8800',
+        }));
+        const setFill = bridge.calls.filter((c) => c.fn === 'setSvgFill');
+        expect(setFill.length).toBe(1);
+        expect(setFill[0].args).toEqual(['icon4', '#ff8800']);
+    });
+
+    it('forwards `fill="none"` to setSvgFill (clears via bridge)', () => {
+        applyAllProps(instance('icon5', 'SvgPath', {
+            fill: 'none',
+        }));
+        const setFill = bridge.calls.filter((c) => c.fn === 'setSvgFill');
+        expect(setFill[0].args).toEqual(['icon5', 'none']);
+    });
+
+    it('forwards `stroke` and `strokeWidth` together', () => {
+        applyAllProps(instance('icon6', 'SvgPath', {
+            stroke: '#000000',
+            strokeWidth: 1.5,
+        }));
+        const setStroke = bridge.calls.filter((c) => c.fn === 'setSvgStroke');
+        const setSW = bridge.calls.filter((c) => c.fn === 'setSvgStrokeWidth');
+        expect(setStroke[0].args).toEqual(['icon6', '#000000']);
+        expect(setSW[0].args).toEqual(['icon6', 1.5]);
+    });
+
+    it('emits all 5 setters when full prop set is applied', () => {
+        applyAllProps(instance('icon7', 'SvgPath', {
+            d: 'M5 5 L15 15',
+            viewBox: [16, 16],
+            fill: '#ffffff',
+            stroke: '#000000',
+            strokeWidth: 2,
+        }));
+        const fns = bridge.calls.map((c) => c.fn).filter((n) =>
+            ['setSvgPath', 'setSvgViewBox', 'setSvgFill', 'setSvgStroke', 'setSvgStrokeWidth'].includes(n)
+        );
+        expect(fns.sort()).toEqual([
+            'setSvgFill', 'setSvgPath', 'setSvgStroke', 'setSvgStrokeWidth', 'setSvgViewBox',
+        ]);
+    });
+
+    it('commitUpdate replaces only changed props', () => {
+        applyChangedProps(
+            instance('icon8', 'SvgPath', {}),
+            { d: 'M0 0 L1 1', fill: '#aaa' },
+            { d: 'M0 0 L1 1', fill: '#bbb' },
+        );
+        const setPath = bridge.calls.filter((c) => c.fn === 'setSvgPath');
+        const setFill = bridge.calls.filter((c) => c.fn === 'setSvgFill');
+        expect(setPath.length).toBe(0);  // unchanged
+        expect(setFill.length).toBe(1);
+        expect(setFill[0].args).toEqual(['icon8', '#bbb']);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #994. Adds the `<SvgPath>` JSX intrinsic to `@pulp/react` so plugin authors can reach the existing C++ `SvgPathWidget` (shipped in v0.61.0 via #965/#991) from React.

## Surface

```tsx
<SvgPath
  d="M0 0 L24 24 Z"
  viewBox={[24, 24]}
  fill="#ff8800"
  stroke="#000"
  strokeWidth={1.5}
/>
```

Wires through to bridge calls: `createSvgPath(id, parentId)` then `setSvgPath`, `setSvgViewBox(id, w, h)`, `setSvgFill`, `setSvgStroke`, `setSvgStrokeWidth`.

## Files

- `packages/pulp-react/src/types.ts` — `SvgPathProps` interface
- `packages/pulp-react/src/intrinsics.ts` — `SvgPath` component export
- `packages/pulp-react/src/host-config.ts` — `'SvgPath'` createWidget case
- `packages/pulp-react/src/prop-applier.ts` — `d` / `viewBox` / `fill` / `stroke` / `strokeWidth` dispatch
- `packages/pulp-react/src/bridge.ts` — `createMockBridge` records the 6 SvgPath bridge fns
- `packages/pulp-react/src/index.ts` — re-export `SvgPathProps`
- `packages/pulp-react/test/svgpath-intrinsic.test.ts` — 9 vitest cases

## Test plan

- [x] All 26 vitest tests pass locally (9 new + 17 pre-existing)
- [x] Type-correct (TypeScript strict)
- [ ] CI green on macos / linux / windows
- [ ] Spectr re-build verifies SCULPT/PEAK SVG icons render

## Spectr-side follow-up

After merge, `spectr/native-react/dom-adapter.tsx` can drop the `0897c38` ref-callback workaround and use `<SvgPath>` directly. Tracked in spectr branch `feature/native-react-editor`.

## Cross-refs

- Issue: #994
- Parent umbrella: #924
- Wires C++ widget shipped via: #991