### PR TITLE
fix(pulp-react): externalize react/reconciler/scheduler in dist build (closes pulp #1292)

### DIFF
--- a/packages/pulp-react/package.json
+++ b/packages/pulp-react/package.json
@@ -20,7 +20,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --format=esm --outfile=dist/index.mjs --platform=neutral",
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --format=esm --outfile=dist/index.mjs --platform=neutral --external:react --external:react-reconciler --external:react-reconciler/constants.js --external:scheduler",
     "build:embed": "esbuild src/index.ts --bundle --format=iife --global-name=pulpReact --outfile=dist/pulp-react.embed.js --platform=neutral",
     "test": "vitest run"
   },

--- a/packages/pulp-react/test/build-output-externals.test.ts
+++ b/packages/pulp-react/test/build-output-externals.test.ts
@@ -1,0 +1,70 @@
+// Regression test for pulp #1292 — the React-dispatcher-null crash.
+//
+// Root cause: when @pulp/react was published with React (and friends)
+// inlined inside dist/index.mjs, downstream consumers (esbuild bundling
+// Spectr's editor.js) ended up with TWO copies of React in the final
+// IIFE — one inside the pre-bundled @pulp/react.mjs and one resolved
+// from the consumer's npm-installed `react` package via host-shims.
+//
+// React 18's dispatcher lives on a per-React-module singleton
+// (`__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentDispatcher`),
+// so two React instances => two dispatchers. The reconciler set the
+// dispatcher on its (bundled) React, but the user's App() called
+// `useState` against the *other* React's dispatcher, which was still
+// `null` => `cannot read property 'useState' of null` at boot.
+//
+// Fix: the pulp-react build externalizes `react`, `react-reconciler`,
+// `react-reconciler/constants.js`, and `scheduler`. The published
+// `dist/index.mjs` keeps `import` declarations for those packages, so
+// downstream esbuild can dedupe them against the consumer's own
+// `node_modules/react` resolution. One React in the final bundle =>
+// one dispatcher => no crash.
+//
+// This test guards the build output: if any of the four packages get
+// inlined back into the bundle (because someone removed an
+// `--external:` flag from the build script), the test fails before
+// the regression hits Spectr.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const distMjs = resolve(__dirname, '..', 'dist', 'index.mjs');
+
+describe('@pulp/react build output (pulp #1292)', () => {
+  it('dist/index.mjs exists and is small (no React inlined)', () => {
+    const st = statSync(distMjs);
+    // After externalizing react / react-reconciler / scheduler the bundle
+    // is ~27 KB. If anyone re-inlines react it jumps to ~950 KB. A 100 KB
+    // ceiling gives us comfortable headroom for the non-React surface to
+    // grow without letting React back in.
+    expect(st.size).toBeLessThan(100 * 1024);
+  });
+
+  it('keeps `react` as an external ESM import (not inlined)', () => {
+    const src = readFileSync(distMjs, 'utf8');
+    // No copy of react.production.min.js shipped inside the bundle.
+    expect(src).not.toMatch(/react\.production\.min\.js/);
+    // No ReactCurrentDispatcher object literal — that's the React
+    // module-internal singleton that pulp #1292 was creating two of.
+    expect(src).not.toMatch(/ReactCurrentDispatcher\s*[:=]\s*\{/);
+  });
+
+  it('keeps `react-reconciler` as an external ESM import (not inlined)', () => {
+    const src = readFileSync(distMjs, 'utf8');
+    // Verify the import declaration survives the build.
+    expect(src).toMatch(/from\s+["']react-reconciler["']/);
+    expect(src).toMatch(/from\s+["']react-reconciler\/constants\.js["']/);
+    // No copy of react-reconciler's source bundled inline.
+    expect(src).not.toMatch(/react-reconciler\.production\.min\.js/);
+    expect(src).not.toMatch(/react-reconciler\.development\.js/);
+  });
+
+  it('keeps `scheduler` as an external import (not inlined)', () => {
+    const src = readFileSync(distMjs, 'utf8');
+    // scheduler is pulled in transitively by react-reconciler. If it
+    // gets inlined here, downstream esbuild has to dedup it manually.
+    expect(src).not.toMatch(/scheduler\.production\.min\.js/);
+    expect(src).not.toMatch(/scheduler\.development\.js/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1292 at the **root cause** rather than the symptom.

The crash `cannot read property 'useState' of null` happens because @pulp/react's published `dist/index.mjs` self-bundles React + react-reconciler + scheduler. When a downstream consumer (Spectr) builds its bundle with esbuild + react, esbuild can't dedup across @pulp/react's pre-bundled boundary, so the consumer's `editor.js` ends up with **two independent React module instances** — one for user code (which destructures `useState` from React), one for the reconciler. Each has its own `ReactCurrentDispatcher` singleton. The reconciler sets dispatcher on instance #2; user code reads dispatcher on instance #1 → null → throw.

Hard evidence + repro detail in [#1292 comment](https://github.com/danielraffel/pulp/issues/1292#issuecomment-4365502118).

## The fix (1 line)

Add `--external:react --external:react-reconciler --external:react-reconciler/constants.js --external:scheduler` to the `build` script in `packages/pulp-react/package.json`. esbuild then emits a bundle that imports from `react` at the consumer level, where natural dedup applies.

## Bundle size impact

- before: 953 KB (carries React + reconciler + scheduler)
- after: 27 KB (just @pulp/react's reconciler-host-config + intrinsics + types + bridge shim)

Consumers always have React in their `node_modules` already (it's a peerDep), so this is pure dead-weight removal.

## Test plan

- [x] Reproduced crash 5/5 against pre-fix `editor.js` via pulp-screenshot
- [x] Validated fix 6/6 against post-fix `editor.js` (rebuilt with externalized pulp-react)
- [x] PNG renders Spectr chrome correctly (SPECTR header, LIVE/PRECISION/IIR/FFT/HYBRID tabs, CLEAR/SCULPT/PEAK/PRESETS/SNAPSHOT row)
- [x] New `packages/pulp-react/test/build-output-externals.test.ts` (4 assertions) regression-guards future re-inlining
- [ ] CI green on macos/linux/windows

## Relationship to #1293

#1293 (microtask deferral) addresses the timing window where the race fires; this PR addresses the duplicate-React-instance cause. A microtask delay can hide the immediate crash but won't fix the downstream split-state issues (useContext, useRef identity, error-boundary cross-talk) that the duplicate React causes post-mount.

Recommend landing this as the canonical fix and either dropping #1293 or keeping as defense-in-depth.

## Cross-refs

- Issue: #1292
- Alternative PR: #1293
- Spectr-side proof: builds Spectr.app for direct exec without crash