### PR TITLE
feat(view): generalize overlay-click routing for React popovers (closes pulp #1148)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.71.0
+    VERSION 0.72.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -23,7 +23,13 @@ class FrameClock;
 class View {
 public:
     View() = default;
-    virtual ~View() = default;
+    virtual ~View() {
+        // pulp #1148 — clear the overlay slot if this dying View holds it.
+        // Without this, an unmounted React popover leaves a dangling
+        // pointer that the platform window host would dereference on
+        // the next click.
+        if (active_overlay_ == this) active_overlay_ = nullptr;
+    }
 
     View(const View&) = delete;
     View& operator=(const View&) = delete;
@@ -405,6 +411,39 @@ public:
     static void set_inspector_mouse_hook(std::function<bool(const MouseEvent&)> hook);
     static bool call_inspector_key_hook(const KeyEvent& e);
     static bool call_inspector_mouse_hook(const MouseEvent& e);
+
+    // ── Generalized overlay-click routing (pulp #1148) ───────────────────
+    //
+    // ComboBox already uses a `static ComboBox* active_popup_` pointer so
+    // the platform window-host layer can short-circuit hit-testing for
+    // paint-only overlays (the dropdown items render OUTSIDE the
+    // ComboBox's hit_test bounds). React popovers built from
+    // `<View position="absolute">` + nested buttons hit the same problem
+    // but have no widget-specific shortcut, so clicks fall through to
+    // whatever sibling/ancestor pixel is under the overlay.
+    //
+    // `active_overlay_` is the per-View opt-in equivalent: any View can
+    // claim itself as the global click-eligible overlay. The window host
+    // checks this AFTER `ComboBox::active_popup_` (so the ComboBox path
+    // stays exact-as-was) and BEFORE the regular tree hit_test. If the
+    // click falls inside the overlay's window-rect, it routes to the
+    // overlay; otherwise the overlay is auto-released and the click
+    // continues to the tree.
+    //
+    // The @pulp/react host config calls `claim_overlay()` from a JSX
+    // `<View overlay>` mount and `release_overlay()` from its unmount.
+    // The ComboBox path remains untouched and has its own state.
+    static View* active_overlay_;
+    void claim_overlay() { active_overlay_ = this; }
+    /// Clear the global overlay if (and only if) `this` currently holds it.
+    /// Idempotent — safe to call on unmount even if claim never happened.
+    void release_overlay() {
+        if (active_overlay_ == this) active_overlay_ = nullptr;
+    }
+    /// Bounds-test in window (root) coordinates. Walks the parent chain
+    /// to compute absolute origin and adds local_bounds(). Mirrors the
+    /// arithmetic the mac mouseDown path uses for the ComboBox dropdown.
+    bool overlay_contains(Point window_pt) const;
 
     /// Global click callback (fires on any view click with widget id). Set on root.
     std::function<void(const std::string& id, uint16_t modifiers)> on_global_click;

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -373,6 +373,55 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             }
         }
 
+        // pulp #1148 — generalized overlay-click routing for React popovers.
+        // Any View that called `claim_overlay()` (e.g. via @pulp/react's
+        // `<View overlay>` JSX prop) is checked AFTER the ComboBox path
+        // (which stays exact-as-was per regression test in
+        // test_combo_dropdown.cpp [issue-overlay]) and BEFORE the regular
+        // tree hit_test. If the click falls inside the overlay's window
+        // rect we route it directly there so absolutely-positioned popover
+        // children get the click instead of whatever sibling/ancestor view
+        // happens to occupy that pixel.
+        if (auto* overlay = pulp::view::View::active_overlay_) {
+            if (view_is_in_tree(overlay, self.rootView) &&
+                overlay->overlay_contains({pt.x, pt.y})) {
+                // Hit-test inside the overlay subtree so nested buttons /
+                // labels still receive the click. Falls back to the
+                // overlay itself if no descendant claims the point.
+                auto local_to_overlay = toLocal(pt, overlay, self.rootView);
+                pulp::view::View* sub = overlay->hit_test(local_to_overlay);
+                _dragTarget = sub ? sub : overlay;
+                auto local = toLocal(pt, _dragTarget, self.rootView);
+
+                if (_dragTarget->focusable()) {
+                    if (_focusedView && _focusedView != _dragTarget)
+                        _focusedView->on_focus_changed(false);
+                    _focusedView = _dragTarget;
+                    _focusedView->on_focus_changed(true);
+                } else if (_focusedView) {
+                    _focusedView->on_focus_changed(false);
+                    _focusedView = nullptr;
+                }
+
+                pulp::view::MouseEvent me;
+                me.position = local;
+                me.window_position = pt;
+                me.button = pulp::view::MouseButton::left;
+                me.modifiers = modifiersFromNSFlags(event.modifierFlags);
+                me.is_down = true;
+                me.click_count = static_cast<int>(event.clickCount);
+                _dragTarget->on_mouse_event(me);
+                _dragTarget->on_mouse_down(local);
+                [self setNeedsDisplay:YES];
+                return;
+            }
+            // Click landed outside the overlay — auto-release so the
+            // overlay's "dismiss on outside click" semantics work without
+            // every JSX caller needing a global click listener. The next
+            // mount cycle will re-claim if the popover is still open.
+            overlay->release_overlay();
+        }
+
         _dragTarget = self.rootView->hit_test(pt);
         pulp::view::ComboBox::notify_global_click(_dragTarget);
 

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -526,6 +526,25 @@ bool View::call_inspector_mouse_hook(const MouseEvent& e) {
     return s_inspector_mouse_hook ? s_inspector_mouse_hook(e) : false;
 }
 
+// pulp #1148 — generalized overlay-click routing.
+View* View::active_overlay_ = nullptr;
+
+bool View::overlay_contains(Point window_pt) const {
+    // Walk up to compute absolute origin in window/root coords. Same
+    // arithmetic the mac window-host uses for ComboBox::active_popup_.
+    float abs_x = 0.0f, abs_y = 0.0f;
+    const View* v = this;
+    while (v) {
+        abs_x += v->bounds().x;
+        abs_y += v->bounds().y;
+        v = v->parent();
+    }
+    const float w = local_bounds().width;
+    const float h = local_bounds().height;
+    return window_pt.x >= abs_x && window_pt.x <= abs_x + w &&
+           window_pt.y >= abs_y && window_pt.y <= abs_y + h;
+}
+
 void View::paint_overlays(canvas::Canvas& canvas) {
     auto& queue = overlay_queue();
     for (auto& req : queue) {

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1429,6 +1429,29 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
+    // claimOverlay(id) / releaseOverlay(id) — pulp #1148 generalized overlay
+    // click routing. JSX `<View overlay>` calls claimOverlay on mount and
+    // releaseOverlay on unmount via the @pulp/react prop-applier; the platform
+    // window host then short-circuits hit-testing for clicks that land inside
+    // the named view's bounds. ComboBox keeps its own active_popup_ path —
+    // these handlers drive the per-View `View::active_overlay_` mechanism.
+    engine_.register_function("claimOverlay", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto it = widgets_.find(id);
+        if (it != widgets_.end() && it->second) {
+            it->second->claim_overlay();
+        }
+        return choc::value::Value();
+    });
+    engine_.register_function("releaseOverlay", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto it = widgets_.find(id);
+        if (it != widgets_.end() && it->second) {
+            it->second->release_overlay();
+        }
+        return choc::value::Value();
+    });
+
     // ── Pointer events (P2) ─────────────────────────────────────────────
 
     // Helper: build JS object literal for pointer event data from MouseEvent

--- a/packages/pulp-react/src/bridge.ts
+++ b/packages/pulp-react/src/bridge.ts
@@ -132,6 +132,16 @@ declare global {
     /// `resetAfterCommit` so the host config owns commit-time flush.
     /// Declared as a const so consumers can branch on `typeof layout`.
     const layout: (() => void) | undefined;
+
+    // ── Overlay click routing (pulp #1148) ──────────────────────────
+    /// Claim the view as the active click-eligible overlay so the
+    /// platform window host short-circuits hit-testing for clicks that
+    /// land inside the view's bounds. Optional at runtime so older
+    /// bridges still link.
+    const claimOverlay: ((id: string) => void) | undefined;
+    /// Release the named view if (and only if) it currently holds the
+    /// active overlay slot. Idempotent. Optional at runtime.
+    const releaseOverlay: ((id: string) => void) | undefined;
 }
 
 /// Test-only mock-bridge for unit tests. Replaces all the global
@@ -176,6 +186,8 @@ export function createMockBridge(): MockBridge {
         // pulp #994 — SvgPath intrinsic surface
         'createSvgPath', 'setSvgPath', 'setSvgViewBox',
         'setSvgFill', 'setSvgStroke', 'setSvgStrokeWidth',
+        // pulp #1148 — generalized overlay-click routing
+        'claimOverlay', 'releaseOverlay',
     ];
     const saved: Record<string, unknown> = {};
     return {

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -218,6 +218,16 @@ function applyOne(id: string, type: string, key: string, value: unknown): void {
             if (type === 'Meter')      return call('setMeterLevel', id, value as number);
             return call('setValue', id, value as number);
 
+        // pulp #1148 — generalized overlay-click routing. `overlay={true}`
+        // claims the view as the active click-eligible overlay so React
+        // popovers built on `<View position="absolute">` receive clicks
+        // even though hit_test would otherwise resolve to a sibling. The
+        // matching releaseOverlay is emitted by applyChangedProps when
+        // the prop flips off, and by detach() at unmount.
+        case 'overlay':
+            if (value) return call('claimOverlay', id);
+            return call('releaseOverlay', id);
+
         // SvgPath (pulp #994) — wires the SvgPathWidget bridge surface
         // (createSvgPath / setSvgPath / setSvgViewBox / setSvgFill /
         // setSvgStroke / setSvgStrokeWidth) through a typed JSX intrinsic.
@@ -290,6 +300,13 @@ export function applyChangedProps(
             // Specific resets we can do meaningfully
             if (key === 'visible')  { call('setVisible', id, true); mutated = true; }
             if (key === 'opacity')  { call('setOpacity', id, 1.0); mutated = true; }
+            // pulp #1148 — overlay flipped off (or simply removed from
+            // props) must release the global overlay slot, otherwise the
+            // platform host keeps routing clicks to a stale popover.
+            if (key === 'overlay' && oldProps[key]) {
+                call('releaseOverlay', id);
+                mutated = true;
+            }
             // Other setters: no-op — let the next mount cycle handle it
         }
     }

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -87,6 +87,14 @@ export interface BaseProps extends FlexProps, StyleProps {
     key?: Key;
     /// Children — text or other intrinsics.
     children?: ReactNode;
+    /// pulp #1148 — opt this view in as the active click-eligible overlay.
+    /// When `true`, the prop-applier calls `claimOverlay(id)` on mount and
+    /// `releaseOverlay(id)` on unmount. The platform window host routes
+    /// any click that lands inside the view's window-rect to the overlay
+    /// subtree first, so absolutely-positioned popovers built from
+    /// `<View overlay style={{position: 'absolute', ...}}>` get clicks
+    /// instead of whatever sibling/ancestor view sits behind the popover.
+    overlay?: boolean;
 }
 
 // ── Container intrinsics ────────────────────────────────────────────

--- a/packages/pulp-react/test/prop-applier-overlay.test.ts
+++ b/packages/pulp-react/test/prop-applier-overlay.test.ts
@@ -1,0 +1,111 @@
+// pulp #1148 — generalized overlay-click routing.
+//
+// `<View overlay>` opts a JSX View in as the active click-eligible
+// overlay so the platform window host (window_host_mac.mm and siblings)
+// short-circuits hit-testing for clicks landing inside the view's
+// bounds. Without this, clicks fall through to whatever sibling /
+// ancestor pixel sits behind an absolutely-positioned popover.
+//
+// The prop-applier contract this test pins:
+//   - `overlay: true`  → call claimOverlay(id)
+//   - `overlay: false` → call releaseOverlay(id)
+//   - prop removed     → call releaseOverlay(id) on commitUpdate
+//   - prop never set   → no claim/release call
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyAllProps, applyChangedProps } from '../src/prop-applier.js';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import type { PulpInstance } from '../src/types.js';
+
+let bridge: MockBridge;
+
+beforeEach(() => {
+    bridge = createMockBridge();
+    bridge.install();
+});
+afterEach(() => {
+    bridge.uninstall();
+});
+
+function makeInstance(id: string = 'popover', type: string = 'View'): PulpInstance {
+    return {
+        id,
+        type: type as PulpInstance['type'],
+        props: {},
+        childIds: [],
+        onBridge: true,
+        pendingChildren: [],
+    };
+}
+
+describe('@pulp/react prop-applier — overlay routing (pulp #1148)', () => {
+    it('applyAllProps calls claimOverlay when overlay=true', () => {
+        applyAllProps({ ...makeInstance('p1'), props: { overlay: true } });
+        const claims = bridge.calls.filter((c) => c.fn === 'claimOverlay');
+        expect(claims.length).toBe(1);
+        expect(claims[0].args).toEqual(['p1']);
+        // releaseOverlay must NOT fire on the mount-claim path.
+        expect(bridge.calls.some((c) => c.fn === 'releaseOverlay')).toBe(false);
+    });
+
+    it('applyAllProps calls releaseOverlay when overlay=false', () => {
+        applyAllProps({ ...makeInstance('p2'), props: { overlay: false } });
+        const releases = bridge.calls.filter((c) => c.fn === 'releaseOverlay');
+        expect(releases.length).toBe(1);
+        expect(releases[0].args).toEqual(['p2']);
+        expect(bridge.calls.some((c) => c.fn === 'claimOverlay')).toBe(false);
+    });
+
+    it('does not touch overlay APIs when prop is absent', () => {
+        applyAllProps({ ...makeInstance('p3'), props: { background: '#000' } });
+        expect(bridge.calls.some((c) => c.fn === 'claimOverlay')).toBe(false);
+        expect(bridge.calls.some((c) => c.fn === 'releaseOverlay')).toBe(false);
+    });
+
+    it('commitUpdate flips overlay false → true via claimOverlay', () => {
+        applyChangedProps(
+            makeInstance('p4'),
+            { overlay: false },
+            { overlay: true },
+        );
+        const claims = bridge.calls.filter((c) => c.fn === 'claimOverlay');
+        expect(claims.length).toBe(1);
+        expect(claims[0].args).toEqual(['p4']);
+    });
+
+    it('commitUpdate flips overlay true → false via releaseOverlay', () => {
+        applyChangedProps(
+            makeInstance('p5'),
+            { overlay: true },
+            { overlay: false },
+        );
+        const releases = bridge.calls.filter((c) => c.fn === 'releaseOverlay');
+        expect(releases.length).toBe(1);
+        expect(releases[0].args).toEqual(['p5']);
+    });
+
+    it('commitUpdate releases on prop removal (oldProps had overlay=true)', () => {
+        // The "prop disappeared" path — equivalent to React unmounting just
+        // the overlay attribute without unmounting the whole view.
+        applyChangedProps(
+            makeInstance('p6'),
+            { overlay: true },
+            {},
+        );
+        const releases = bridge.calls.filter((c) => c.fn === 'releaseOverlay');
+        expect(releases.length).toBe(1);
+        expect(releases[0].args).toEqual(['p6']);
+    });
+
+    it('commitUpdate is a no-op when overlay was already truthy and stays truthy', () => {
+        applyChangedProps(
+            makeInstance('p7'),
+            { overlay: true },
+            { overlay: true, background: '#fff' },
+        );
+        // applyChangedProps only re-emits when value !==. Same-true → no
+        // additional claim/release; only the background change should fire.
+        expect(bridge.calls.some((c) => c.fn === 'claimOverlay')).toBe(false);
+        expect(bridge.calls.some((c) => c.fn === 'releaseOverlay')).toBe(false);
+    });
+});

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1534,6 +1534,11 @@ add_executable(pulp-test-combo-dropdown test_combo_dropdown.cpp)
 target_link_libraries(pulp-test-combo-dropdown PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-combo-dropdown)
 
+# pulp #1148 — generalized overlay-click routing (View::active_overlay_)
+add_executable(pulp-test-overlay-routing test_overlay_routing.cpp)
+target_link_libraries(pulp-test-overlay-routing PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-overlay-routing)
+
 # Panel widget tests (styled containers)
 add_executable(pulp-test-panel test_panel.cpp)
 target_link_libraries(pulp-test-panel PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_overlay_routing.cpp
+++ b/test/test_overlay_routing.cpp
@@ -1,0 +1,148 @@
+// pulp #1148 — generalized overlay-click routing.
+//
+// Pins the per-View `View::active_overlay_` mechanism that the platform
+// window host (window_host_mac.mm and platform siblings) consults
+// AFTER `ComboBox::active_popup_` and BEFORE the regular tree
+// `hit_test`. The ComboBox path is pinned separately by
+// test_combo_dropdown.cpp [issue-overlay] — these tests cover the
+// generic mechanism React popovers use.
+//
+// Contract under test:
+//   1. claim_overlay() / release_overlay() toggle the global slot
+//      and never null another holder.
+//   2. View destructor releases the slot if it currently holds it.
+//   3. overlay_contains() bounds-tests in window/root coordinates by
+//      walking the parent chain (matches the mac mouseDown arithmetic).
+//   4. release_overlay() is idempotent — safe to call when nothing
+//      claimed the slot.
+//
+// The mac mouseDown integration itself is exercised end-to-end by
+// the ComboBox regression test; for the per-View path we keep the
+// invariants pure C++ so the test runs on every CI lane.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/view.hpp>
+
+using pulp::view::View;
+using pulp::view::Point;
+
+namespace {
+
+class TestView : public View {
+public:
+    void paint(pulp::canvas::Canvas&) override {}
+};
+
+// Reset global state — other tests in this binary may leave it set.
+struct OverlayGuard {
+    OverlayGuard() { View::active_overlay_ = nullptr; }
+    ~OverlayGuard() { View::active_overlay_ = nullptr; }
+};
+
+}  // namespace
+
+TEST_CASE("View::active_overlay_ defaults to nullptr [issue-1148]",
+          "[view][overlay]") {
+    OverlayGuard g;
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("View::claim_overlay sets active_overlay_ to this [issue-1148]",
+          "[view][overlay]") {
+    OverlayGuard g;
+    TestView v;
+    v.claim_overlay();
+    REQUIRE(View::active_overlay_ == &v);
+}
+
+TEST_CASE("View::release_overlay clears only if this holds it [issue-1148]",
+          "[view][overlay]") {
+    OverlayGuard g;
+    TestView a;
+    TestView b;
+
+    a.claim_overlay();
+    REQUIRE(View::active_overlay_ == &a);
+
+    // Releasing a non-holder must NOT null a third party's slot.
+    b.release_overlay();
+    REQUIRE(View::active_overlay_ == &a);
+
+    a.release_overlay();
+    REQUIRE(View::active_overlay_ == nullptr);
+
+    // Idempotent — safe to call again.
+    a.release_overlay();
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("View::claim_overlay swaps the holder [issue-1148]",
+          "[view][overlay]") {
+    OverlayGuard g;
+    TestView a, b;
+
+    a.claim_overlay();
+    REQUIRE(View::active_overlay_ == &a);
+
+    // Mounting a second overlay supersedes the first — matches the
+    // ComboBox::open_dropdown semantics where opening a second popup
+    // closes the first.
+    b.claim_overlay();
+    REQUIRE(View::active_overlay_ == &b);
+}
+
+TEST_CASE("View destructor releases the overlay slot [issue-1148]",
+          "[view][overlay]") {
+    OverlayGuard g;
+    {
+        TestView v;
+        v.claim_overlay();
+        REQUIRE(View::active_overlay_ == &v);
+    }
+    // Without the dtor release, this would dangle and the next
+    // mouseDown would dereference freed memory.
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("View::overlay_contains uses absolute window coords [issue-1148]",
+          "[view][overlay]") {
+    OverlayGuard g;
+    // Build a parent → child tree so the overlay's absolute origin is
+    // offset from (0,0). The mac window-host walks the parent chain
+    // identically; this asserts the helper matches that arithmetic.
+    TestView parent;
+    parent.set_bounds({100.0f, 50.0f, 400.0f, 400.0f});
+
+    auto child_owned = std::make_unique<TestView>();
+    auto* child = child_owned.get();
+    child->set_bounds({20.0f, 30.0f, 80.0f, 60.0f});  // local to parent
+    parent.add_child(std::move(child_owned));
+
+    // Overlay's absolute window-rect is:
+    //   x: 100 + 20 = 120
+    //   y: 50  + 30 = 80
+    //   w: 80, h: 60
+    REQUIRE(child->overlay_contains({120.0f, 80.0f}));    // top-left corner
+    REQUIRE(child->overlay_contains({199.0f, 139.0f}));   // bottom-right inside
+    REQUIRE(child->overlay_contains({160.0f, 110.0f}));   // center
+
+    REQUIRE_FALSE(child->overlay_contains({119.0f, 80.0f}));   // just left
+    REQUIRE_FALSE(child->overlay_contains({120.0f, 79.0f}));   // just above
+    REQUIRE_FALSE(child->overlay_contains({201.0f, 110.0f})); // right of
+    REQUIRE_FALSE(child->overlay_contains({160.0f, 141.0f})); // below
+}
+
+TEST_CASE("View overlay routing: ComboBox::active_popup_ is independent "
+          "[issue-1148]",
+          "[view][overlay][regression]") {
+    // Belt-and-braces: the new generalized slot must not share storage
+    // with ComboBox's existing active_popup_. The mac mouseDown order
+    // checks ComboBox first, then this slot — if they collided the
+    // ComboBox regression test would still pass while breaking React
+    // popovers.
+    OverlayGuard g;
+    TestView v;
+    v.claim_overlay();
+    REQUIRE(View::active_overlay_ == &v);
+    // ComboBox state is in its own static; not touched by claim_overlay.
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -3678,3 +3678,40 @@ TEST_CASE("CSS shim: 'border:' shorthand preserves border-radius",
     // Radius must survive the shorthand assignment.
     REQUIRE_THAT(w->corner_radius(), WithinAbs(10.0f, 1e-5f));
 }
+
+// pulp #1148 — generalized overlay-click routing. The bridge must expose
+// claimOverlay(id) / releaseOverlay(id) so @pulp/react's `<View overlay>`
+// JSX prop can opt a widget in as the active click-eligible overlay.
+TEST_CASE("WidgetBridge claimOverlay / releaseOverlay drive View::active_overlay_",
+          "[view][bridge][issue-1148]") {
+    // Reset state — other tests may leave the slot set.
+    pulp::view::View::active_overlay_ = nullptr;
+
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createPanel('popover', '')");
+    auto* popover = bridge.widget("popover");
+    REQUIRE(popover != nullptr);
+    REQUIRE(pulp::view::View::active_overlay_ == nullptr);
+
+    bridge.load_script("claimOverlay('popover')");
+    REQUIRE(pulp::view::View::active_overlay_ == popover);
+
+    bridge.load_script("releaseOverlay('popover')");
+    REQUIRE(pulp::view::View::active_overlay_ == nullptr);
+
+    // releaseOverlay on a non-holder is a silent no-op (does not null
+    // a different widget's claim).
+    bridge.load_script("createPanel('other', ''); claimOverlay('other')");
+    auto* other = bridge.widget("other");
+    REQUIRE(pulp::view::View::active_overlay_ == other);
+    bridge.load_script("releaseOverlay('popover')");
+    REQUIRE(pulp::view::View::active_overlay_ == other);
+
+    // Cleanup so the global state doesn't leak into the next test.
+    pulp::view::View::active_overlay_ = nullptr;
+}


### PR DESCRIPTION
## Summary

Closes #1148. Generalizes the existing ComboBox overlay-click routing pattern (commit `41c05c35`, April 2026) into a reusable `View::active_overlay_` primitive, then exposes it through @pulp/react via a single `<View overlay>` boolean prop.

## Background

The ComboBox dropdown is a paint-only overlay queued via `View::overlay_queue()` — the dropdown ROWS aren't in the hit-test tree. Without a pre-`hit_test` bounds check in window-host `mouseDown`, clicks on dropdown items resolve to whichever sibling/ancestor sits at that pixel. The mac host (`window_host_mac.mm:347-374`) already had this check for ComboBox specifically (`pulp::view::ComboBox::active_popup_`).

React popovers built from `<View position="absolute">` + `<Button>` children get NONE of that — they fall through to `hit_test` and clicks land wherever the tree-z-order resolves. This is exactly the symptom Spectr's audit flagged: SCULPT/PEAK/PRESETS rows don't dispatch on inner click; the click sometimes leaks to the desktop app behind Spectr.

## What this PR adds

**C++ surface (`core/view/`)**:

```cpp
class View {
  static View* active_overlay_;            // generic equivalent of ComboBox::active_popup_
  void claim_overlay();                    // sets active_overlay_ = this
  void release_overlay();                  // clears if matches this
  bool overlay_contains(Point window) const;  // window-coord bounds via parent-chain walk
  ~View() override { release_overlay(); }  // safety
};
```

`window_host_mac.mm` mouseDown order:
1. Inspector intercept (unchanged)
2. ComboBox::active_popup_ (unchanged — pinned by regression test)
3. **NEW** — `View::active_overlay_` bounds check; route directly if hit
4. Tree `hit_test` (unchanged)

**JS bridge (`widget_bridge.cpp`)**:
- `claimOverlay(id)` / `releaseOverlay(id)` — global handlers

**@pulp/react (`packages/pulp-react/`)**:
- `<View overlay>` boolean prop in `ViewProps`
- prop-applier auto-calls `claimOverlay(id)` on mount when set, `releaseOverlay(id)` when unset / removed / unmount

## Tests added

C++ Catch2 (`test/test_overlay_routing.cpp`, tag `[issue-1148]`):
- defaults to nullptr
- claim sets, release this-only, swap behavior
- dtor releases (RAII safety)
- `overlay_contains` walks parent chain for absolute coords
- **ComboBox path untouched** (regression-pinned by existing `test_combo_dropdown.cpp`)

C++ Catch2 (`test/test_widget_bridge.cpp`):
- `claimOverlay`/`releaseOverlay` JS handlers drive `View::active_overlay_`

vitest (`packages/pulp-react/test/prop-applier-overlay.test.ts`):
- mount-claim, prop-absent no-op, false→true, true→false, prop-removal release, no-op on same-truthy

## Local validation (macOS, all green)

- pulp-cli build ✓
- pulp-test-overlay-routing: 7 cases / 18 assertions ✓
- pulp-test-combo-dropdown (regression): 8 cases / 25 assertions ✓ (ComboBox path verified untouched)
- pulp-test-widget-bridge: 95 cases / 702 assertions ✓
- pulp-test-view: 44 cases / 208 assertions ✓
- @pulp/react vitest: 33 tests / 5 files ✓

## Note on x11/win32

The original task brief mentioned mirroring into `window_host_x11.cpp` and `window_host_win32.cpp` but those don't exist on `origin/main` — only `mac/` and `ios/`. iOS is touch-driven and routes through `rootView->on_mouse_down(pos)` directly without `_dragTarget`/hit_test, so wiring the overlay short-circuit there would change semantics. Left iOS alone; future desktop hosts can pick up the API.

## Spectr-side follow-up

Spectr's `editor.js` popovers (built from `<View position="absolute">`) need to add `overlay` to those Views to opt in. After this PR ships in a release, Spectr's bundle re-emit will pick it up automatically; until then, the `<svg><path>` migration noted in the import-design skill applies similarly.

## Cross-refs

- Issue: #1148
- Pattern source: ComboBox routing at commit `41c05c35` (April 2026, pinned by `test/test_combo_dropdown.cpp`)
- Related: #1147 (popover render — separate from click dispatch), #1067/#1073 (top-level click bubble)
- Spectr-side: blocks SCULPT/PEAK/PRESETS popover inner clicks