### PR TITLE
chore: bump versions v0.69.2 → v0.69.3 (catch-up after #1295 — closes #1308)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.69.2
+    VERSION 0.69.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Summary

PR #1295 ([root-cause fix for #1292 — React-instance dedup via @pulp/react bundle externals](https://github.com/danielraffel/pulp/pull/1295)) merged to main at \`aa2876fc\` with `Version-Bump: skip` trailer. Auto-release watchdog #1308 fired because consumers can't reach the fix until a tagged release exists.

This PR adds the catch-up bump so v0.69.3 ships the React dispatcher fix.

## What lands in v0.69.3

- **#1292 / #1295** — @pulp/react externalizes `react`, `react-reconciler`, `react-reconciler/constants.js`, `scheduler`. Resolves the "two React instances → useState=null on App() render" crash that's been blocking Spectr direct-exec ~100% of cold starts.

## Spectr-side impact

Once this merges + release-cli.yml publishes:
1. `pulp sdk install --version 0.69.3` will succeed
2. Bump Spectr's CMakeLists.txt `find_package(Pulp 0.69.3 REQUIRED)`
3. Rebuild Spectr standalone
4. Direct-exec stability test (5/5 cold launches should NOT crash)
5. Resume the popover-tap audit (deferred since v0.69.1)

## Test plan

- [x] CMakeLists.txt diff is the bump from 0.69.2 → 0.69.3 only
- [ ] CI green on macos / linux / windows
- [ ] Auto-release tags v0.69.3 post-merge
- [ ] release-cli publishes SDK tarball
- [ ] Watchdog #1308 auto-closes on recovery detection

## Cross-refs

- Closes #1308
- Ships #1295's #1292 fix
- Coordination CHANGELOG at `spectr/planning/.watch/CHANGELOG.md` will be updated when release artifact lands