### PR TITLE
fix(ci): auto-release watchdog must honor Version-Bump: skip (closes #1308)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -53,12 +53,44 @@ jobs:
         id: guard
         shell: bash
         run: |
-          # Inspect the tip commit for Release: skip or Revert subject.
+          # Inspect the tip commit for Release: skip / Version-Bump: skip
+          # / Revert subject.
           subject=$(git log -1 --format=%s HEAD)
           body=$(git log -1 --format=%B HEAD)
 
           if echo "$body" | git interpret-trailers --parse | grep -iq '^release: skip'; then
               echo "Release: skip trailer present — no tagging."
+              echo "skip=1" >> "$GITHUB_OUTPUT"
+              exit 0
+          fi
+          # pulp #1308 follow-up — honor `Version-Bump: skip reason="..."`
+          # the same way `Release: skip` is honored. Authors use this
+          # trailer for fix/feat changes that genuinely don't bump the
+          # SDK or plugin (e.g. JS-only changes to packages/pulp-react/
+          # which versions independently via npm, or docs fixups
+          # accidentally typed as `fix:`). Without honoring it, the
+          # stranded-fix-detector at the bottom of this workflow fires
+          # and opens a tracker issue requiring a follow-up bump PR
+          # — but the author already declared no bump is needed and a
+          # follow-up bump would synthesize a release the consumers
+          # don't actually need.
+          #
+          # The version-bump-required gate at PR time
+          # (.github/workflows/version-skill-check.yml) ALREADY accepts
+          # this trailer to let fix/feat merges through. Honoring it
+          # here keeps the two layers in lock-step instead of having
+          # the post-merge layer second-guess the explicit opt-out.
+          #
+          # Match shape: unscoped `Version-Bump: skip reason="..."` ONLY.
+          # Per-surface forms like `Version-Bump: sdk=skip` mean "skip
+          # this surface's bump" but don't opt out of the whole release
+          # gate (they're handled by the per-surface verdict pipeline
+          # in version_bump_check.py). Mirrors the same matching shape
+          # as `_range_has_version_bump_skip_trailer()` in
+          # tools/scripts/version_bump_check.py.
+          if echo "$body" | git interpret-trailers --parse | \
+              grep -iE '^version-bump:[[:space:]]+skip[[:space:]]+reason='; then
+              echo "Version-Bump: skip trailer present — no tagging."
               echo "skip=1" >> "$GITHUB_OUTPUT"
               exit 0
           fi

--- a/docs/guides/release-watchdog.md
+++ b/docs/guides/release-watchdog.md
@@ -180,10 +180,31 @@ trailer already documented in `CLAUDE.md` — the skip flag makes the
 auto-release step decline to tag, Layer 2 treats the workflow run as
 a normal success, and Layer 3 sees no VERSION change so never fires.
 
-The fix/feat-needs-bump check is bypassed via a separate trailer
-(`Version-Bump: skip reason="..."`) so a single PR can opt into
-"don't tag this release" without also implying "this fix doesn't need
-a bump." The two trailers are deliberately distinct.
+`Version-Bump: skip reason="..."` is also honored as a release-skip by
+the auto-release.yml guard (pulp #1308 follow-up). Authors use this
+trailer for fix/feat changes that legitimately don't bump SDK or plugin
+versions — typical cases:
+
+- JS-only changes to `packages/pulp-react/` (versions independently
+  via `packages/pulp-react/package.json` + `npm publish`)
+- Docs / refactors accidentally typed as `fix:` / `feat:`
+- Test-infra changes that mention a fix in their subject
+
+Without honoring this trailer here, the post-merge stranded-fix
+detector would fire on every such merge and demand a follow-up bump
+PR — even though the author already declared no SDK/plugin bump is
+needed. The PR-time gate (`version-skill-check.yml`) already accepts
+this trailer for the same reason; the post-merge layer now matches.
+
+The two trailers are still semantically distinct:
+
+- `Release: skip reason="..."` — opt out of *this* release tag (e.g.
+  the change is part of a multi-PR series; tag the last one).
+- `Version-Bump: skip reason="..."` — declare *no SDK/plugin bump
+  needed* (the change is genuinely not user-facing for those surfaces).
+
+In both cases, the auto-release guard now treats them as legitimate
+opt-outs and won't synthesize a stranded-fix tracker.
 
 ## Follow-up hooks (optional, not required)
 


### PR DESCRIPTION
## Summary

Closes #1308 — the post-merge stranded-fix watchdog in `auto-release.yml` had a guard that suppressed tagging on `Release: skip` trailer / revert subjects, but **NOT** on `Version-Bump: skip reason=\"...\"`. Result: any fix/feat landing with `Version-Bump: skip` (legitimate for JS-only changes to `packages/pulp-react/` which versions independently) triggered the watchdog and auto-filed a tracker issue demanding a follow-up bump PR — even though the author had already declared no bump was needed.

## Root cause

PR #1295 (root-cause fix for #1292 P0) had this trailer:

```
Version-Bump: skip reason=\"@pulp/react package versions independently in packages/pulp-react/package.json — JS-only build-script change…\"
```

The PR-time gate at `version-skill-check.yml:--require-bump-for-fix-feat` correctly accepted this trailer and let #1295 merge. But the post-merge watchdog at `auto-release.yml:guard` ignored it, fired stranded-fix detector, opened #1308.

This was a structural inconsistency between two layers of the same release-pipeline contract.

## Fix

Extend `auto-release.yml`'s guard step to also honor `Version-Bump: skip reason=\"...\"`:

```yaml
if echo \"\$body\" | git interpret-trailers --parse | \\
    grep -iE '^version-bump:[[:space:]]+skip[[:space:]]+reason='; then
    echo \"Version-Bump: skip trailer present — no tagging.\"
    echo \"skip=1\" >> \"\$GITHUB_OUTPUT\"
    exit 0
fi
```

Matches the same regex shape as `_range_has_version_bump_skip_trailer()` in `tools/scripts/version_bump_check.py`. Per-surface forms like `Version-Bump: sdk=skip` are deliberately NOT matched — those are scoped to per-surface verdict pipeline and shouldn't opt out of release entirely.

## Tests

This is a workflow-file-only change. Validation paths:
- `actionlint` / yamllint via the existing `workflow-lint.yml` PR gate
- Manual trace of the guard logic in PR review — no new behavior on `Release: skip` or revert paths

## Followups (separate issues)

- **pulp-react third-versioned-surface** — would let the watchdog recognize `packages/pulp-react/package.json` bumps as legitimate releases, removing the need for `Version-Bump: skip` workarounds for @pulp/react fixes. To file separately.
- **#1309** — catch-up bump for the #1295/#1308 incident, lands BEFORE this fix.

## Cross-refs

- Issue: #1308 (post-#1295 watchdog fire)
- Original incident: #1295 (P0 #1292 fix)
- Sister gate: `version-skill-check.yml` already honors this trailer at PR-time; this restores parity.