### PR TITLE
fix(ci): require non-empty Version-Bump skip reason in watchdog regex (Codex P2 on #1310)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -81,15 +81,21 @@ jobs:
           # here keeps the two layers in lock-step instead of having
           # the post-merge layer second-guess the explicit opt-out.
           #
-          # Match shape: unscoped `Version-Bump: skip reason="..."` ONLY.
+          # Match shape: unscoped `Version-Bump: skip reason="<non-empty>"` ONLY.
           # Per-surface forms like `Version-Bump: sdk=skip` mean "skip
           # this surface's bump" but don't opt out of the whole release
           # gate (they're handled by the per-surface verdict pipeline
           # in version_bump_check.py). Mirrors the same matching shape
           # as `_range_has_version_bump_skip_trailer()` in
-          # tools/scripts/version_bump_check.py.
+          # tools/scripts/version_bump_check.py — including the
+          # requirement that the reason be NON-EMPTY (Codex P2 on the
+          # original #1310 fix; the earlier regex allowed bare
+          # `reason=` with no value, but the Python gate rejects it).
+          # If the two layers disagreed on validity, an author could
+          # write `reason=""` that passes here but fails at PR time
+          # (or vice-versa) — making the bypass inconsistent.
           if echo "$body" | git interpret-trailers --parse | \
-              grep -iE '^version-bump:[[:space:]]+skip[[:space:]]+reason='; then
+              grep -iE '^version-bump:[[:space:]]+skip\b.*reason[[:space:]]*=[[:space:]]*"[^"]+"'; then
               echo "Version-Bump: skip trailer present — no tagging."
               echo "skip=1" >> "$GITHUB_OUTPUT"
               exit 0


### PR DESCRIPTION
## Summary

Codex P2 follow-up on #1310. The new guard in \`auto-release.yml\` accepted any trailer matching \`Version-Bump: skip reason=\` without validating that the reason was non-empty/quoted, but the PR-time gate (\`tools/scripts/version_bump_check.py::_range_has_version_bump_skip_trailer\`) only honors a non-empty \`reason=\"...\"\`.

**Inconsistency:** an author could write \`reason=\"\"\` that passed the post-merge guard but was rejected at PR time (or vice-versa once the regex shapes drifted). Bypass becomes unreliable.

## Fix

Tighten the bash regex to mirror the Python regex's strictness — require non-empty quoted content after \`reason=\`:

```diff
- '^version-bump:[[:space:]]+skip[[:space:]]+reason='
+ '^version-bump:[[:space:]]+skip\\\\b.*reason[[:space:]]*=[[:space:]]*\"[^\"]+\"'
```

Mirrors \`re.search(r'reason\\\\s*=\\\\s*\"([^\"]+)\"', rest)\` in version_bump_check.py.

## Cross-refs

- Codex P2 review on #1310
- #1308 (original watchdog parity issue)