### PR TITLE
fix(view): overlay fast-path honors hit_test guards (Codex P1 #1313 + P2 #1314)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.72.0
+    VERSION 0.72.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -386,40 +386,63 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             if (view_is_in_tree(overlay, self.rootView) &&
                 overlay->overlay_contains({pt.x, pt.y})) {
                 // Hit-test inside the overlay subtree so nested buttons /
-                // labels still receive the click. Falls back to the
-                // overlay itself if no descendant claims the point.
+                // labels still receive the click.
+                //
+                // pulp #1313 (Codex P1 on #1297) — only dispatch when
+                // hit_test returns a real view. If hit_test returns
+                // nullptr, the overlay (or some ancestor in its
+                // subtree) failed the visible / enabled / hit_testable
+                // / pointer_events check; force-dispatching to the
+                // overlay anyway would bypass those guards. Fall
+                // through to the standard hit_test below instead.
                 auto local_to_overlay = toLocal(pt, overlay, self.rootView);
-                pulp::view::View* sub = overlay->hit_test(local_to_overlay);
-                _dragTarget = sub ? sub : overlay;
-                auto local = toLocal(pt, _dragTarget, self.rootView);
+                if (auto* sub = overlay->hit_test(local_to_overlay)) {
+                    // pulp #1314 (Codex P2 on #1297) — when the
+                    // overlay handles a click, the standard ComboBox
+                    // outside-click notification at the bottom of
+                    // mouseDown: is bypassed via the early return
+                    // below. Run it here so an open ComboBox dropdown
+                    // still closes when the user clicks on a separate
+                    // active overlay.
+                    pulp::view::ComboBox::notify_global_click(sub);
 
-                if (_dragTarget->focusable()) {
-                    if (_focusedView && _focusedView != _dragTarget)
+                    _dragTarget = sub;
+                    auto local = toLocal(pt, _dragTarget, self.rootView);
+
+                    if (_dragTarget->focusable()) {
+                        if (_focusedView && _focusedView != _dragTarget)
+                            _focusedView->on_focus_changed(false);
+                        _focusedView = _dragTarget;
+                        _focusedView->on_focus_changed(true);
+                    } else if (_focusedView) {
                         _focusedView->on_focus_changed(false);
-                    _focusedView = _dragTarget;
-                    _focusedView->on_focus_changed(true);
-                } else if (_focusedView) {
-                    _focusedView->on_focus_changed(false);
-                    _focusedView = nullptr;
-                }
+                        _focusedView = nullptr;
+                    }
 
-                pulp::view::MouseEvent me;
-                me.position = local;
-                me.window_position = pt;
-                me.button = pulp::view::MouseButton::left;
-                me.modifiers = modifiersFromNSFlags(event.modifierFlags);
-                me.is_down = true;
-                me.click_count = static_cast<int>(event.clickCount);
-                _dragTarget->on_mouse_event(me);
-                _dragTarget->on_mouse_down(local);
-                [self setNeedsDisplay:YES];
-                return;
+                    pulp::view::MouseEvent me;
+                    me.position = local;
+                    me.window_position = pt;
+                    me.button = pulp::view::MouseButton::left;
+                    me.modifiers = modifiersFromNSFlags(event.modifierFlags);
+                    me.is_down = true;
+                    me.click_count = static_cast<int>(event.clickCount);
+                    _dragTarget->on_mouse_event(me);
+                    _dragTarget->on_mouse_down(local);
+                    [self setNeedsDisplay:YES];
+                    return;
+                }
+                // hit_test returned null — the overlay's guards rejected
+                // the click. Don't dispatch and don't release_overlay
+                // (the overlay is still mounted, just not currently
+                // interactive at this position). Fall through to the
+                // standard hit_test path below.
+            } else {
+                // Click landed outside the overlay — auto-release so the
+                // overlay's "dismiss on outside click" semantics work without
+                // every JSX caller needing a global click listener. The next
+                // mount cycle will re-claim if the popover is still open.
+                overlay->release_overlay();
             }
-            // Click landed outside the overlay — auto-release so the
-            // overlay's "dismiss on outside click" semantics work without
-            // every JSX caller needing a global click listener. The next
-            // mount cycle will re-claim if the popover is still open.
-            overlay->release_overlay();
         }
 
         _dragTarget = self.rootView->hit_test(pt);


### PR DESCRIPTION
## Summary

Two Codex findings on PR #1297 (overlay click routing for #1148), fixed in the same hot spot in \`core/view/platform/mac/window_host_mac.mm\`.

## #1313 (P1) — Fast-path bypassed hit_test guards

\`_dragTarget = sub ? sub : overlay;\` force-dispatched to the overlay when its \`hit_test\` returned null. \`overlay_contains()\` only checks the rect, not the policy — so a claimed overlay with \`pointer-events: none\` / \`visible=false\` / \`disabled\` still received \`on_mouse_event(...)\`, bypassing the same guards \`View::hit_test\` applies elsewhere (and that #1170 just established for ScrollView).

**Fix:** only dispatch when \`hit_test\` returns a real view; otherwise fall through to the standard \`hit_test\` path below, which respects the same guards. Don't call \`release_overlay()\` in this case — the overlay is still mounted, just not currently interactive at this position.

## #1314 (P2) — ComboBox outside-click broken when overlay handled click

The overlay fast-path returned early before reaching the standard \`ComboBox::notify_global_click(_dragTarget)\` at the bottom of \`mouseDown:\`. Result: clicking a separate active overlay while a ComboBox dropdown was open didn't close the dropdown.

**Fix:** call \`notify_global_click(sub)\` inside the dispatch branch so the standard cleanup runs. The outside-click path (overlay rect doesn't contain the point) is unchanged — still calls \`release_overlay()\`.

## Cross-refs

- Codex P1 review on #1297 → #1313
- Codex P2 review on #1297 → #1314
- Original PR: #1297 / #1148
- Sibling guard policy: #1170 (ScrollView::hit_test pointer_events)