### PR TITLE
fix(ci): flip pre-push gates from advisory to enforcing by default (closes #1144)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 # Pulp pre-push hook (agent-agnostic).
 #
-# Runs the versioning + skill-sync gates against origin/main before pushing.
-# Advisory by default — warnings print but don't block. Set
-# PULP_ENFORCE_PREPUSH=1 to upgrade warnings to hard errors (CI does this).
+# Runs the versioning + skill-sync + compat-sync + deps-audit + diff-coverage
+# gates against origin/main before pushing. **Enforcing by default** as of
+# pulp #1144 — gate failures block the push locally so contributors don't
+# burn 20-min CI roundtrips on the same problem.
 #
 # Install once via tools/scripts/install-githooks.sh (or setup.sh):
 #   git config core.hooksPath .githooks
 #
-# To skip on a single push (emergencies only):
-#   PULP_SKIP_PREPUSH=1 git push
+# Bypass knobs (use sparingly — CI runs the same gates):
+#   PULP_DISABLE_PREPUSH_GATES=1   # demote ALL gates to advisory (skill/version/compat/deps)
+#   PULP_DISABLE_PREPUSH_DIFF_COVER=1  # demote diff-cover gate only
+#   PULP_SKIP_PREPUSH=1            # skip ALL gates entirely (true emergencies)
+#
+# Migration note (pulp #1144): the old `PULP_ENFORCE_PREPUSH=1` and
+# `PULP_ENFORCE_PREPUSH_DIFF_COVER=1` env vars used to *promote* advisory
+# warnings to hard failures. Defaults are now flipped — promotion is the
+# default; the new env vars *demote* failures back to advisory. The legacy
+# env vars are accepted as silent no-ops (they were the default anyway —
+# setting them just confirmed the new default behavior).
 
 set -u
 
@@ -53,8 +63,7 @@ case $? in
     *) echo "[pre-push] version_bump_check: internal error" >&2 ;;
 esac
 
-# Compat-sync (#1029). Advisory unless PULP_ENFORCE_PREPUSH=1 — the
-# script reads the env var directly, so just pass --mode=report.
+# Compat-sync (#1029).
 if [ -f "$CSC" ] && [ -f "$COMPAT_MAP" ]; then
     "$PYTHON" "$CSC" --base "$BASE" --mode=report
     case $? in
@@ -65,8 +74,7 @@ if [ -f "$CSC" ] && [ -f "$COMPAT_MAP" ]; then
 fi
 
 # Dependency attribution drift — fails if manifest entries are missing from
-# DEPENDENCIES.md, NOTICE.md, or docs/reference/licensing.md. Advisory by
-# default; PULP_ENFORCE_PREPUSH=1 promotes it along with the other gates.
+# DEPENDENCIES.md, NOTICE.md, or docs/reference/licensing.md.
 DEPS_AUDIT="$ROOT/tools/deps/audit.py"
 if [ -f "$DEPS_AUDIT" ]; then
     if ! "$PYTHON" "$DEPS_AUDIT" --strict >/dev/null; then
@@ -77,37 +85,55 @@ fi
 
 # Local diff-coverage check — mirror the CI `Diff coverage required` gate
 # (75% by default; threshold lives in tools/scripts/coverage_config.json).
-# Advisory by default; PULP_ENFORCE_PREPUSH_DIFF_COVER=1 upgrades to hard
-# fail. We only run the script when the diff actually touches a mapped
-# coverage surface (core/, tools/cli/, tools/scripts/) — otherwise we'd
-# pay the configure+build cost on doc-only or workflow-only PRs that
-# CI's coverage workflow itself bypasses for the gate.
+# We only run the script when the diff actually touches a mapped coverage
+# surface (core/, tools/cli/, tools/scripts/) — otherwise we'd pay the
+# configure+build cost on doc-only or workflow-only PRs that CI's coverage
+# workflow itself bypasses for the gate.
+diff_cover_failed=0
 DIFF_COVER_SH="$ROOT/tools/scripts/local_diff_cover.sh"
 if [ -f "$DIFF_COVER_SH" ] && [ "${PULP_SKIP_DIFF_COVER:-0}" != "1" ]; then
     if changed=$(git diff --name-only "$BASE...HEAD" 2>/dev/null); then
         if echo "$changed" | grep -qE '^(core/|tools/cli/|tools/scripts/)'; then
             echo "[pre-push] running local diff-coverage check (set PULP_SKIP_DIFF_COVER=1 to bypass)…" >&2
             if ! bash "$DIFF_COVER_SH"; then
-                if [ "${PULP_ENFORCE_PREPUSH_DIFF_COVER:-0}" = "1" ]; then
-                    echo "[pre-push] PULP_ENFORCE_PREPUSH_DIFF_COVER=1 — blocking push due to diff-coverage failure." >&2
-                    fail=1
-                else
-                    echo "[pre-push] diff-coverage advisory: failure above is non-blocking (export PULP_ENFORCE_PREPUSH_DIFF_COVER=1 to block)." >&2
-                fi
+                diff_cover_failed=1
             fi
         fi
     fi
 fi
 
-if [ "$fail" = "0" ]; then
+# pulp #1144 — defaults are flipped: gate failures BLOCK the push.
+# `PULP_DISABLE_PREPUSH_GATES=1` demotes the four primary gates back
+# to advisory; `PULP_DISABLE_PREPUSH_DIFF_COVER=1` demotes the
+# diff-cover gate only.
+
+if [ "$fail" = "0" ] && [ "$diff_cover_failed" = "0" ]; then
     echo "[pre-push] gates clean." >&2
     exit 0
 fi
 
-if [ "${PULP_ENFORCE_PREPUSH:-0}" = "1" ]; then
-    echo "[pre-push] PULP_ENFORCE_PREPUSH=1 — blocking push due to gate failures above." >&2
-    exit 1
+# Apply demotion knobs.
+disable_main="${PULP_DISABLE_PREPUSH_GATES:-0}"
+disable_diff="${PULP_DISABLE_PREPUSH_DIFF_COVER:-0}"
+
+if [ "$diff_cover_failed" = "1" ] && [ "$disable_diff" = "1" ]; then
+    echo "[pre-push] PULP_DISABLE_PREPUSH_DIFF_COVER=1 — diff-coverage failure DEMOTED to advisory." >&2
+    diff_cover_failed=0
 fi
 
-echo "[pre-push] warnings above are advisory (export PULP_ENFORCE_PREPUSH=1 to block)." >&2
-exit 0
+if [ "$fail" = "1" ] && [ "$disable_main" = "1" ]; then
+    echo "[pre-push] PULP_DISABLE_PREPUSH_GATES=1 — skill/version/compat/deps gate failures DEMOTED to advisory." >&2
+    fail=0
+fi
+
+if [ "$fail" = "0" ] && [ "$diff_cover_failed" = "0" ]; then
+    echo "[pre-push] gate failures present but demoted by env override; push allowed. Fix before merging." >&2
+    exit 0
+fi
+
+echo "[pre-push] gate failure(s) above; blocking push." >&2
+echo "[pre-push] To bypass (use sparingly; CI still runs the same gates):" >&2
+echo "[pre-push]   PULP_DISABLE_PREPUSH_GATES=1 git push          # demote skill/version/compat/deps" >&2
+echo "[pre-push]   PULP_DISABLE_PREPUSH_DIFF_COVER=1 git push     # demote diff-cover only" >&2
+echo "[pre-push]   PULP_SKIP_PREPUSH=1 git push                   # skip ALL gates (emergencies)" >&2
+exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,8 +482,8 @@ Pulp versions three surfaces independently: SDK/CLI (`CMakeLists.txt`), Claude p
 **Enforcement (three layers, one source of truth):**
 
 1. **Agent hooks (Layer 1)** — `hooks/scripts/cli-plugin-sync.sh` runs `version_bump_check.py` and `skill_sync_check.py` in `--mode=hint` on every PostToolUse so you see drift while iterating. Advisory only.
-2. **Pre-push hook (Layer 2)** — `.githooks/pre-push` runs both scripts in `--mode=report`. Advisory by default; `PULP_ENFORCE_PREPUSH=1` upgrades to hard failure.
-3. **CI + Shipyard (Layer 3, authoritative)** — `.github/workflows/version-skill-check.yml` and the `validation.gates` stage in `.shipyard/config.toml` both invoke the same scripts in `--mode=report` with `PULP_ENFORCE_PREPUSH=1`. No bypass other than the commit trailers below.
+2. **Pre-push hook (Layer 2)** — `.githooks/pre-push` runs both scripts in `--mode=report`. **Enforcing by default** (pulp #1144 — was advisory pre-#1144 and burned 80+ minutes per multi-touch PR on CI roundtrips). `PULP_DISABLE_PREPUSH_GATES=1` demotes back to advisory; `PULP_SKIP_PREPUSH=1` skips entirely (emergencies only).
+3. **CI + Shipyard (Layer 3, authoritative)** — `.github/workflows/version-skill-check.yml` and the `validation.gates` stage in `.shipyard/config.toml` both invoke the same scripts in `--mode=report`. CI is hard-failing (no env-var demotion). No bypass other than the commit trailers below.
 
 **Shipping a PR** — when the user says any of "push a PR", "ship this", "ship it", "we're done", "merge this", or "push it", invoke `shipyard pr` (the existing `ci` skill routes through this). Never run `gh pr create` + `shipyard ship` separately; never run the version-bump or skill-sync scripts by hand. `shipyard pr` orchestrates:
 
@@ -611,8 +611,9 @@ pulp coverage diff pulp-test-widget-bridge
 The threshold + surface filters live in
 `tools/scripts/coverage_config.json` — edit there once and CI
 (`.github/workflows/coverage.yml`) plus this local script stay in
-sync. The pre-push hook runs this check advisory-by-default;
-`PULP_ENFORCE_PREPUSH_DIFF_COVER=1` upgrades it to a hard block.
+sync. The pre-push hook runs this check enforcing-by-default
+(pulp #1144); `PULP_DISABLE_PREPUSH_DIFF_COVER=1` demotes it to
+advisory if you genuinely need to push a known coverage gap.
 
 The Claude Code slash command `/coverage-diff` invokes the same
 script with the same args, so all four invocation surfaces share

--- a/docs/guides/versioning.md
+++ b/docs/guides/versioning.md
@@ -26,10 +26,12 @@ Layer 1 (fast, per-edit, agent-specific)
     hooks/scripts/cli-plugin-sync.sh, Claude Code PostToolUse hooks
     → advisory "hint" mode output only
 
-Layer 2 (pre-push, agent-agnostic, advisory)
+Layer 2 (pre-push, agent-agnostic, ENFORCING — pulp #1144)
     .githooks/pre-push
-    → same scripts, "report" mode, warns by default
-    → PULP_ENFORCE_PREPUSH=1 upgrades to hard fail
+    → same scripts, "report" mode, BLOCKS push by default
+    → PULP_DISABLE_PREPUSH_GATES=1 demotes to advisory (the old default)
+    → PULP_DISABLE_PREPUSH_DIFF_COVER=1 demotes the diff-cover gate only
+    → PULP_SKIP_PREPUSH=1 skips ALL gates (true emergencies)
 
 Layer 3 (PR gate, authoritative)
     .github/workflows/version-skill-check.yml
@@ -85,11 +87,15 @@ tools/scripts/install-githooks.sh
 git config core.hooksPath .githooks
 ```
 
-After that, every `git push` runs both scripts. By default warnings print but don't block — set `PULP_ENFORCE_PREPUSH=1` (CI does this) to upgrade to hard failures. Single-push bypass for emergencies:
+After that, every `git push` runs both scripts. **As of pulp #1144 the gates block the push by default** — fix the violation locally rather than burning a 20-min CI roundtrip. Bypass knobs (use sparingly; CI runs the same gates regardless):
 
 ```bash
-PULP_SKIP_PREPUSH=1 git push
+PULP_DISABLE_PREPUSH_GATES=1 git push          # demote skill/version/compat/deps to advisory
+PULP_DISABLE_PREPUSH_DIFF_COVER=1 git push     # demote diff-cover gate only
+PULP_SKIP_PREPUSH=1 git push                   # skip ALL gates (true emergencies)
 ```
+
+The legacy `PULP_ENFORCE_PREPUSH=1` and `PULP_ENFORCE_PREPUSH_DIFF_COVER=1` env vars are accepted as silent no-ops — they used to *promote* advisory warnings to hard failures, which is now the default. Setting them just confirms what you already get.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #1144. The \`.githooks/pre-push\` hook ran 5 policy gates (skill-sync, version-bump, compat-sync, deps-audit, diff-cover) but ALL of them were advisory by default. Gate failures printed warnings then exited 0, so contributors pushed anyway and CI failed the same gates 20 minutes later. **PR #1005 burned 7 push iterations** for a single fix because of this.

## Behavior change

| Before | After |
|--------|-------|
| Gate failure → warning, push allowed | **Gate failure → push blocked** |
| \`PULP_ENFORCE_PREPUSH=1\` upgrades to hard fail | New default; env var becomes no-op |
| \`PULP_ENFORCE_PREPUSH_DIFF_COVER=1\` upgrades diff-cover | New default; env var becomes no-op |
| (no demotion knob existed) | **\`PULP_DISABLE_PREPUSH_GATES=1\`** demotes skill/version/compat/deps |
| (no demotion knob existed) | **\`PULP_DISABLE_PREPUSH_DIFF_COVER=1\`** demotes diff-cover only |
| \`PULP_SKIP_PREPUSH=1\` skips all gates | unchanged |

## Files changed

- \`.githooks/pre-push\` — flip the default exit code; add the new disable env vars; update bypass-message
- \`CLAUDE.md\` — Layer 2 enforcement description updated to "Enforcing by default"
- \`docs/guides/versioning.md\` — Layer 2 description + bypass-knobs section

## Why this matters

Estimated savings on a typical multi-touch PR: **~80 minutes of CI roundtrips per iteration**. Local enforcement catches drift in < 5 seconds; CI takes ~20 minutes per iteration to surface the same finding.

The behavior is uniform for humans + agents — both benefit equally from short-circuiting the iteration cycle locally.

## Boundaries observed

- Did NOT add new gates (defaults flip is the scope per #1144)
- Did NOT remove \`PULP_SKIP_PREPUSH\` (total bypass stays for emergencies)
- Did NOT make the flip conditional on agent-detection
- Did NOT silently change env var names — the legacy \`PULP_ENFORCE_*\` vars are accepted as silent no-ops; the new \`PULP_DISABLE_*\` vars are documented loudly

## Cross-refs

- Issue: #1144 (this fix)
- Parent: #1049 (silent-no-op audit epic)
- Motivating churn: PR #1005