### PR TITLE
fix(ci): per-surface Version-Bump: skip requires non-empty reason (closes #1054)

### DIFF
--- a/tools/scripts/test_version_bump_check_extra.py
+++ b/tools/scripts/test_version_bump_check_extra.py
@@ -842,5 +842,59 @@ class MainTests(unittest.TestCase):
         self.assertIn("hint only", stdout.getvalue())
 
 
+class PerSurfaceTrailerSkipRequiresReason(unittest.TestCase):
+    """pulp #1054 — Version-Bump: <surface>=skip MUST carry a non-empty
+    reason="..." (mirrors PR #1315's enforcement on the unscoped form).
+    Earlier shapes silently accepted bare `cli=skip` and `cli=skip reason=""`.
+    """
+
+    def test_canonical_per_surface_skip_with_reason(self) -> None:
+        result = vbc.surface_trailer_override(
+            {"version-bump": ['cli=skip reason="legitimate"']},
+            "version-bump",
+            "cli",
+        )
+        self.assertEqual(result, "skip")
+
+    def test_per_surface_skip_without_reason_rejected(self) -> None:
+        # Bare `cli=skip` is rejected — author must explain why.
+        result = vbc.surface_trailer_override(
+            {"version-bump": ['cli=skip']},
+            "version-bump",
+            "cli",
+        )
+        self.assertIsNone(result)
+
+    def test_per_surface_skip_with_empty_reason_rejected(self) -> None:
+        # `cli=skip reason=""` is rejected (empty quotes don't count).
+        result = vbc.surface_trailer_override(
+            {"version-bump": ['cli=skip reason=""']},
+            "version-bump",
+            "cli",
+        )
+        self.assertIsNone(result)
+
+    def test_per_surface_skip_with_whitespace_only_reason_rejected(self) -> None:
+        # `cli=skip reason="   "` is rejected (whitespace-only doesn't count).
+        result = vbc.surface_trailer_override(
+            {"version-bump": ['cli=skip reason="   "']},
+            "version-bump",
+            "cli",
+        )
+        self.assertIsNone(result)
+
+    def test_per_surface_patch_minor_major_dont_require_reason(self) -> None:
+        # Bump-level trailers don't need a reason — the level itself
+        # documents intent (the bump verdict IS the explanation).
+        for level in ("patch", "minor", "major"):
+            with self.subTest(level=level):
+                result = vbc.surface_trailer_override(
+                    {"version-bump": [f"cli={level}"]},
+                    "version-bump",
+                    "cli",
+                )
+                self.assertEqual(result, level)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/scripts/version_bump_check.py
+++ b/tools/scripts/version_bump_check.py
@@ -533,6 +533,17 @@ def surface_trailer_override(
         level = m.group(1).lower()
         if level == "none":
             continue
+        # pulp #1054 — `skip` levels MUST carry a non-empty
+        # `reason="..."` (the level itself doesn't document intent —
+        # the reason does). Mirrors the unscoped-form enforcement at
+        # `_range_has_version_bump_skip_trailer()` (Codex P2 #1310 →
+        # PR #1315). Per-surface `<surface>=patch|minor|major` levels
+        # are explicit bump verdicts and don't need a reason — the
+        # level itself is the documented intent.
+        if level == "skip":
+            rm = re.search(r'reason\s*=\s*"([^"]+)"', v)
+            if not (rm and rm.group(1).strip()):
+                continue
         if level in LEVELS or level == "skip":
             return level
     return None


### PR DESCRIPTION
## Summary

Closes #1054. The per-surface Version-Bump trailer (\`Version-Bump: <surface>=skip reason=\"...\"\`) silently accepted bare \`cli=skip\` and \`cli=skip reason=\"\"\` — the parser captured the level but never validated the reason.

Same shape as the unscoped-form bug Codex flagged on #1310 (closed by PR #1315). Now applied to the per-surface form found in the audit posted on #1054.

## Fix

Tighten \`surface_trailer_override()\` in \`tools/scripts/version_bump_check.py\` to require non-empty \`reason=\"...\"\` when \`level == \"skip\"\`. Bump-level trailers (\`patch\`/\`minor\`/\`major\`) don't need a reason — the level itself documents intent.

## Tests

5 new cases in \`tools/scripts/test_version_bump_check_extra.py\`. All 32 tests pass locally.

## Cross-refs

- Audit: #1054 (this fix)
- Sibling: PR #1315 (unscoped-form bug)
- Parent: #1049 silent-no-op audit epic