### PR TITLE
fix(ci): add core/dsl/** to infrastructure tier (closes #1056)

### DIFF
--- a/ci/coverage-targets.yaml
+++ b/ci/coverage-targets.yaml
@@ -48,6 +48,7 @@ tiers:
     line_target: 50
     paths:
       - core/events/**
+      - core/dsl/**          # pulp #1056 — DSL processor scaffolding (Faust wrapper headers)
       - core/runtime/**
       - core/state/**
       - core/canvas/**


### PR DESCRIPTION
## Summary

Closes #1056 (partial). Audit found \`core/dsl/\` was silently exempt from per-tier coverage targets — the 3 DSL processor headers fell back to global 75% instead of an explicit tier verdict.

Adds \`core/dsl/**\` to the \`infrastructure\` tier (50%). DSL is a header-only Faust-wrapper scaffold — interface code, not audio-critical.

## Verification

```
$ python3 audit-recipe.py
core/dsl files matched per tier:
  infrastructure (50%): 3 files
    core/dsl/include/pulp/dsl/dsl_processor.hpp
    core/dsl/include/pulp/dsl/faust_base.hpp
    core/dsl/include/pulp/dsl/faust_processor.hpp
```

## Deferred

Audit also found 26 native bridge files (Android Kotlin, Apple Swift) outside every tier. May be intentional fallback-to-75% — left for a follow-up to either tier them explicitly or document the policy in coverage-targets.yaml's \`_comment\` block.

## Cross-refs

- Audit: #1056
- Parent: #1049