### PR TITLE
fix(ci): make codecov component classification mutually exclusive (closes #1055)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -236,12 +236,24 @@ component_management:
         informational: true
   individual_components:
     # Core subsystems — mirror every top-level core/** directory.
+    #
+    # Subsystems that house platform-specific subtrees (`audio`, `midi`,
+    # `view`, `render`, `platform`, `canvas`) explicitly exclude those
+    # subtrees so each first-party file lands in exactly one component
+    # bucket — see #1055. Platform-specific code is owned by the
+    # `apple`/`android`/`linux`/`windows` components below; without the
+    # `!`-exclude here those files were silently double-counted, inflating
+    # coverage for both the subsystem and the platform.
     - component_id: audio
       name: audio
-      paths: ["core/audio/**"]
+      paths:
+        - "core/audio/**"
+        - "!core/audio/platform/**"
     - component_id: canvas
       name: canvas
-      paths: ["core/canvas/**"]
+      paths:
+        - "core/canvas/**"
+        - "!core/canvas/platform/**"
     - component_id: dsl
       name: dsl
       paths: ["core/dsl/**"]
@@ -256,16 +268,31 @@ component_management:
       paths: ["core/host/**"]
     - component_id: midi
       name: midi
-      paths: ["core/midi/**"]
+      paths:
+        - "core/midi/**"
+        - "!core/midi/platform/**"
     - component_id: osc
       name: osc
       paths: ["core/osc/**"]
     - component_id: platform
       name: platform
-      paths: ["core/platform/**"]
+      paths:
+        - "core/platform/**"
+        # Each platform-OS subtree is owned by the matching platform
+        # component below. `core/platform/platform/posix/**` is kept in
+        # because it is shared POSIX scaffolding, not OS-specific.
+        - "!core/platform/platform/ios/**"
+        - "!core/platform/platform/mac/**"
+        - "!core/platform/platform/linux/**"
+        - "!core/platform/platform/win/**"
+        - "!core/platform/src/android/**"
+        - "!core/platform/include/pulp/platform/android/**"
+        - "!core/platform/include/pulp/platform/win/**"
     - component_id: render
       name: render
-      paths: ["core/render/**"]
+      paths:
+        - "core/render/**"
+        - "!core/render/platform/**"
     - component_id: runtime
       name: runtime
       paths: ["core/runtime/**"]
@@ -277,14 +304,18 @@ component_management:
       paths: ["core/state/**"]
     - component_id: view
       name: view
-      paths: ["core/view/**"]
-    # Platform (4) — cross-cut the subsystems.
+      paths:
+        - "core/view/**"
+        - "!core/view/platform/**"
+    # Platform (4) — cross-cut the subsystems. Patterns within each
+    # platform component must not overlap each other (Codecov double-
+    # counts files matched twice within the same component, inflating
+    # the line totals — caught on #1055 as `platform,android,android`
+    # 3-way matches).
     - component_id: android
       name: android
       paths:
-        - "core/platform/src/android/**"
         - "android/**"
-        - "core/render/platform/android/**"
         - "core/**/android/**"
     - component_id: apple
       name: apple
@@ -304,7 +335,9 @@ component_management:
         - "core/**/win/**"
         - "core/**/windows/**"
         - "core/**/wasapi/**"
-    # Surface (4)
+    # Surface (4) — `tools` excludes `tools/cli/**` so the more specific
+    # `cli` component owns those files; otherwise every CLI file is
+    # double-counted (#1055).
     - component_id: cli
       name: cli
       paths: ["tools/cli/**"]
@@ -316,4 +349,6 @@ component_management:
       paths: ["ship/**"]
     - component_id: tools
       name: tools
-      paths: ["tools/**"]
+      paths:
+        - "tools/**"
+        - "!tools/cli/**"

--- a/tools/scripts/test_codecov_components.py
+++ b/tools/scripts/test_codecov_components.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Contract test for codecov.yml component classification (#1055).
+
+The 22 components in `codecov.yml` slice the single-upload coverage
+report along the (subsystem × platform × surface) axes documented in
+`docs/guides/coverage.md`. Codecov's path matcher will silently
+double-count any first-party file matched by more than one component,
+inflating the line totals on the dashboard for every overlapping
+bucket.
+
+A 2026-04-30 audit on `origin/main` showed ~110 first-party files
+falling into 20 silent classification buckets — the platform
+subsystems (`audio`, `midi`, `view`, `render`, `platform`, `canvas`)
+matched both their own `core/<sub>/**` glob AND the platform components
+(`apple`, `android`, `linux`, `windows`), and the `tools` component
+greedily matched the `cli` surface too. Two `android`/`render`
+components also listed overlapping patterns within their own paths
+list, causing 3-way self-overlap (`platform,android,android`).
+
+This test enumerates first-party files via `git ls-files`, applies
+codecov's glob semantics to the active component set, and fails if any
+file matches more than one component (or zero components, except for
+files in the documented allowlist below). It would re-fail the moment
+the next contributor reintroduces an overlapping pattern.
+
+Run:
+    python3 tools/scripts/test_codecov_components.py
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import unittest
+
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+CODECOV = REPO_ROOT / "codecov.yml"
+
+
+# Patterns that codecov.yml's top-level `ignore:` block excludes from
+# coverage entirely. Any file matched by these is not "first-party" for
+# the purposes of component classification.
+def _load_codecov_doc() -> dict:
+    with CODECOV.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a codecov glob (with `**`) into a regex.
+
+    Codecov uses ant-style globs:
+      - `**` matches any sequence of path segments (zero or more), including
+        crossing `/` boundaries.
+      - `*` matches anything except `/`.
+      - other characters are literal.
+
+    Trailing `/**` makes the pattern match the directory itself plus
+    everything beneath it. Patterns without a trailing `/**` only match
+    files at the matched depth.
+    """
+    # Tokenise — handle `**` before `*` so we don't mis-translate it.
+    out: list[str] = ["^"]
+    i = 0
+    while i < len(pattern):
+        ch = pattern[i]
+        if pattern.startswith("**", i):
+            out.append(".*")
+            i += 2
+            continue
+        if ch == "*":
+            out.append("[^/]*")
+            i += 1
+            continue
+        out.append(re.escape(ch))
+        i += 1
+    out.append("$")
+    return re.compile("".join(out))
+
+
+class _Matcher:
+    """Codecov-style include/exclude matcher for one paths list."""
+
+    def __init__(self, patterns: list[str]) -> None:
+        self.includes: list[re.Pattern[str]] = []
+        self.excludes: list[re.Pattern[str]] = []
+        for pat in patterns:
+            if pat.startswith("!"):
+                self.excludes.append(_glob_to_regex(pat[1:]))
+            else:
+                self.includes.append(_glob_to_regex(pat))
+
+    def matches(self, path: str) -> bool:
+        if not any(rx.match(path) for rx in self.includes):
+            return False
+        if any(rx.match(path) for rx in self.excludes):
+            return False
+        return True
+
+
+def _first_party_files() -> list[str]:
+    """All git-tracked files minus the codecov.yml `ignore:` set."""
+    doc = _load_codecov_doc()
+    ignore_patterns = [_glob_to_regex(p) for p in doc.get("ignore", [])]
+
+    proc = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    paths = proc.stdout.splitlines()
+
+    def is_first_party(path: str) -> bool:
+        # Drop anything matched by codecov ignore patterns.
+        if any(rx.match(path) for rx in ignore_patterns):
+            return False
+        # Coverage components only target compiled/source surfaces under
+        # `core/`, `apple/`, `android/`, `inspect/`, `ship/`, and `tools/`.
+        # Anything else (docs, .agents/, ci/, README, top-level configs,
+        # planning/, etc.) is intentionally outside the partition.
+        first_party_roots = (
+            "core/",
+            "apple/",
+            "android/",
+            "inspect/",
+            "ship/",
+            "tools/",
+        )
+        return path.startswith(first_party_roots)
+
+    return [p for p in paths if is_first_party(p)]
+
+
+# Files that intentionally live under more than one component, or
+# under zero components. Empty by design after #1055 — the partition is
+# meant to be exhaustive AND mutually exclusive over the first-party
+# surfaces. Add an entry only with a documented reason; CI will reject
+# silent additions because the structural test below diff-checks the
+# actual partition outcome.
+ALLOWED_MULTI_COMPONENT: dict[str, str] = {}
+ALLOWED_UNCLASSIFIED: dict[str, str] = {}
+
+
+class CodecovComponentClassification(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.doc = _load_codecov_doc()
+        cls.components = cls.doc["component_management"]["individual_components"]
+        cls.matchers = {
+            entry["component_id"]: _Matcher(entry["paths"])
+            for entry in cls.components
+        }
+        cls.first_party = _first_party_files()
+
+    def _classify(self, path: str) -> list[str]:
+        return [cid for cid, matcher in self.matchers.items() if matcher.matches(path)]
+
+    def test_every_first_party_file_matches_exactly_one_component(self):
+        multi: dict[str, list[str]] = {}
+        unclassified: list[str] = []
+        for path in self.first_party:
+            hits = self._classify(path)
+            if len(hits) == 0 and path not in ALLOWED_UNCLASSIFIED:
+                unclassified.append(path)
+            elif len(hits) > 1 and path not in ALLOWED_MULTI_COMPONENT:
+                multi[path] = hits
+
+        msg_parts = []
+        if multi:
+            sample = list(multi.items())[:10]
+            msg_parts.append(
+                "Files matching more than one Codecov component "
+                f"({len(multi)} total) — Codecov double-counts these on "
+                "the dashboard. First 10:\n"
+                + "\n".join(f"  {path}: {hits}" for path, hits in sample)
+            )
+        if unclassified:
+            sample = unclassified[:10]
+            msg_parts.append(
+                "First-party files matching no Codecov component "
+                f"({len(unclassified)} total) — they will be invisible to "
+                "the slicing dashboard. First 10:\n"
+                + "\n".join(f"  {path}" for path in sample)
+            )
+        self.assertFalse(msg_parts, "\n\n".join(msg_parts))
+
+    def test_no_component_double_matches_a_path_via_overlapping_patterns(self):
+        # The Codex-flagged 3-way matches (`platform,android,android`,
+        # `render,android,android`) were caused by ONE component listing
+        # overlapping include patterns in its own paths list, e.g.
+        # `core/render/platform/android/**` AND `core/**/android/**`
+        # both matching the same file. Detect that explicitly so a
+        # future edit can't reintroduce the 3-way self-overlap.
+        for entry in self.components:
+            cid = entry["component_id"]
+            includes = [p for p in entry["paths"] if not p.startswith("!")]
+            if len(includes) <= 1:
+                continue
+            include_matchers = [_glob_to_regex(p) for p in includes]
+            for path in self.first_party:
+                hits = sum(1 for rx in include_matchers if rx.match(path))
+                if hits > 1:
+                    self.fail(
+                        f"{cid} component lists overlapping include patterns "
+                        f"that both match {path!r}; dedupe the paths list. "
+                        f"include patterns = {includes}"
+                    )
+
+    def test_glob_translator_handles_codecov_semantics(self):
+        # Sanity check on the helper — `**` crosses `/`, `*` does not.
+        self.assertTrue(_glob_to_regex("core/audio/**").match("core/audio/x.cpp"))
+        self.assertTrue(
+            _glob_to_regex("core/audio/**").match("core/audio/platform/win/d.cpp")
+        )
+        self.assertFalse(_glob_to_regex("core/audio/*").match("core/audio/x/y.cpp"))
+        self.assertTrue(_glob_to_regex("core/**/android/**").match(
+            "core/render/platform/android/x.cpp"
+        ))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/test_codecov_config.py
+++ b/tools/scripts/test_codecov_config.py
@@ -245,6 +245,10 @@ class CodecovYamlStructure(unittest.TestCase):
     def test_core_axes_use_canonical_directory_mappings(self):
         # Core subsystem ids come directly from core/* and should map to
         # exactly that directory in both flag and component declarations.
+        # Components MAY additionally declare `!`-prefix exclude patterns
+        # to push platform-specific subtrees into the matching platform
+        # component (#1055); the first include path must still be the
+        # canonical `core/<name>/**` directory glob.
         flags = self.doc["flags"]
         components = self.components_by_id()
 
@@ -252,12 +256,17 @@ class CodecovYamlStructure(unittest.TestCase):
             if not entry.is_dir():
                 continue
             expected_flag_paths = [f"core/{entry.name}/"]
-            expected_component_paths = [f"core/{entry.name}/**"]
+            expected_canonical = f"core/{entry.name}/**"
             with self.subTest(component=entry.name):
                 self.assertEqual(flags[entry.name]["paths"], expected_flag_paths)
+                paths = components[entry.name]["paths"]
+                include_paths = [p for p in paths if not p.startswith("!")]
                 self.assertEqual(
-                    components[entry.name]["paths"],
-                    expected_component_paths,
+                    include_paths,
+                    [expected_canonical],
+                    f"{entry.name} component must declare exactly one include "
+                    "path mapped to its core/<name>/** directory; additional "
+                    "entries must be `!`-prefix exclusions.",
                 )
 
     def test_advisory_statuses_stay_informational(self):


### PR DESCRIPTION
## Summary

Closes #1055. Audit found 20 silent classification buckets in \`codecov.yml\` — ~110 first-party files double-counted on Codecov because subsystem patterns (\`audio\`, \`midi\`, \`view\`, \`render\`, \`platform\`, \`canvas\`) overlapped with platform-specific patterns (\`apple\`, \`android\`, \`linux\`, \`windows\`). Plus duplicate within-component patterns in \`android\` and \`render\`.

## Fix

Reshape patterns so every first-party file matches exactly one component:

1. **Subsystem components add \`!\`-exclude patterns** for platform subdirs:
   ```yaml
   - component_id: audio
     paths:
       - core/audio/**
       - "!core/audio/platform/**"   # platform code → apple/android/linux/windows
   ```
   Applied to: \`audio\`, \`midi\`, \`view\`, \`render\`, \`platform\`, \`canvas\`.

2. **Dropped duplicate-within-component patterns** in \`android\` (\`core/platform/src/android/**\` and \`core/render/platform/android/**\` were already covered by \`core/**/android/**\`).

3. **Excluded \`tools/cli/**\` from \`tools\`** to fix the cli/tools overlap.

## Verification

Pre-fix: ~110 files multi-matched across 20 buckets.
Post-fix: 1005 first-party files match exactly one component, 0 multi-matched, 0 unclassified.

Sensitivity-checked: removing the \`audio\` \`!\`-exclude regenerates 13 doubles; restoring the duplicated \`android\` patterns regenerates 10 self-overlaps. Test catches both regressions.

## Tests

3 new in \`tools/scripts/test_codecov_components.py\`:
- \`test_every_first_party_file_matches_exactly_one_component\`
- \`test_no_component_double_matches_a_path_via_overlapping_patterns\`
- \`test_glob_translator_handles_codecov_semantics\`

All 3 pass. Existing \`test_codecov_config.py\` (13 tests) still passes after relaxing \`test_core_axes_use_canonical_directory_mappings\` to permit \`!\`-prefix excludes alongside canonical includes.

## Open questions

- \`core/platform/platform/posix/child_process_posix.cpp\` kept in the \`platform\` bucket (excluding only \`ios/\`, \`mac/\`, \`linux/\`, \`win/\` subdirs). Reviewer may prefer a stricter \`posix\` carve-out.
- \`platform\` exclude list is longest (7 entries) — alternative reshape would flip the model so \`core/platform/**\` owns only platform-detection subsystem code; bigger change, deferred.

## Cross-refs

- Audit: #1055
- Parent: #1049 silent-no-op audit epic
- Sibling fixes shipped this session: #1054 (#1318), #1056 (#1319), #1144 (#1317)