### PR TITLE
fix(ci): clean up silent-no-op patterns in skill_path_map.json (closes #1053)

### DIFF
--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -9,16 +9,21 @@
         "core/format/include/pulp/format/aax*",
         "external/AAX-SDK/**",
         "tools/cmake/PulpAAX.cmake"
-      ]
+      ],
+      "_doc": {
+        "empty-ok": "external/AAX-SDK/** intentionally empty — AAX SDK is developer-supplied per docs/guides/ship.md and the aax skill"
+      }
     },
     "ara": {
       "paths": [
         "core/format/src/ara*",
-        "core/format/src/ara/**",
         "core/format/include/pulp/format/ara*",
         "core/format/include/pulp/format/ara/**",
         "external/ara-sdk/**"
-      ]
+      ],
+      "_doc": {
+        "empty-ok": "external/ara-sdk/** intentionally empty — ARA SDK is developer-supplied per the ara skill"
+      }
     },
     "auv3": {
       "paths": [
@@ -49,7 +54,6 @@
       "paths": [
         "core/format/src/au_v2_adapter.cpp",
         "core/format/src/au_v2_instrument.cpp",
-        "core/format/src/au_v2_entry.*",
         "core/format/src/au_v2_cocoa_view.mm",
         "core/format/include/pulp/format/au_v2_adapter.hpp",
         "core/format/include/pulp/format/au_v2_instrument.hpp",
@@ -91,33 +95,34 @@
       "paths": [
         "tools/scripts/cmajor_external.py",
         "tools/scripts/test_cmajor_external.py",
-        "examples/cmajor-*/**",
-        "core/**/*cmajor*"
+        "examples/cmajor-*/**"
       ]
     },
     "engine": {
       "paths": [
-        "core/view/src/js_bridge*",
-        "core/view/include/**/js_bridge*",
-        "core/view/src/engine*",
+        "core/view/src/js_*",
+        "core/view/include/pulp/view/js_engine*",
+        "core/view/src/script_engine*",
+        "core/view/include/pulp/view/script_engine*",
         "core/view/js/web-compat-*.js",
-        "external/quickjs*/**",
-        "tools/cmake/PulpJsEngine.cmake"
-      ]
+        "external/quickjs*/**"
+      ],
+      "_doc": {
+        "empty-ok": "external/quickjs*/** intentionally empty — QuickJS is fetched at configure time, not vendored"
+      }
     },
     "faust": {
       "paths": [
         "examples/faust-*/**",
-        "tools/scripts/faust*",
-        "core/signal/**/*faust*"
+        "core/dsl/include/pulp/dsl/faust*",
+        "tools/cmake/PulpFaust.cmake"
       ]
     },
     "hosting": {
       "paths": [
         "core/host/**",
         "examples/plugin-host-demo/**",
-        "tools/cli/commands/host.cpp",
-        "tools/cli/commands/scan.cpp"
+        "tools/cli/cmd_host.cpp"
       ]
     },
     "ios": {
@@ -142,15 +147,12 @@
       "paths": [
         "tools/scripts/jsfx_subset.py",
         "tools/scripts/test_jsfx_subset.py",
-        "examples/jsfx-*/**",
-        "core/signal/**/*jsfx*"
+        "examples/jsfx-*/**"
       ]
     },
     "mpe": {
       "paths": [
-        "core/midi/src/*mpe*",
         "core/midi/include/**/*mpe*",
-        "core/midi/src/*ump*",
         "core/midi/include/**/*ump*",
         "examples/mpe-*/**"
       ]
@@ -158,12 +160,6 @@
     "packages": {
       "paths": [
         "tools/packages/**",
-        "tools/cli/cmd_add.cpp",
-        "tools/cli/cmd_audit.cpp",
-        "tools/cli/cmd_fetch.cpp",
-        "tools/cli/cmd_install.cpp",
-        "tools/cli/cmd_remove.cpp",
-        "tools/cli/cmd_search.cpp",
         "DEPENDENCIES.md",
         "NOTICE.md",
         "tools/deps/manifest.json"
@@ -180,7 +176,6 @@
       "paths": [
         "core/canvas/src/*sdf*",
         "core/canvas/src/*msdf*",
-        "core/canvas/src/*psdf*",
         "core/canvas/include/**/*sdf*",
         "core/canvas/include/**/*msdf*",
         "core/canvas/include/**/*psdf*",
@@ -200,17 +195,12 @@
       "paths": [
         "core/runtime/src/*stream*",
         "core/runtime/include/**/*stream*",
-        "core/events/src/*stream*",
-        "core/events/include/**/*stream*",
-        "examples/streams-*/**"
+        "examples/stream-*/**"
       ]
     },
     "threejs-bridge": {
       "paths": [
-        "core/view/src/threejs*",
-        "core/view/include/**/threejs*",
-        "examples/threejs-*/**",
-        "tools/scripts/threejs*"
+        "examples/threejs-*/**"
       ]
     },
     "upgrade": {
@@ -252,9 +242,6 @@
     },
     "webview-ui": {
       "paths": [
-        "core/view/src/webview*",
-        "core/view/include/**/webview*",
-        "core/view/platform/**/webview*",
         "examples/webview-*/**"
       ]
     }

--- a/tools/scripts/test_skill_path_map.py
+++ b/tools/scripts/test_skill_path_map.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Contract test for ``tools/scripts/skill_path_map.json``.
+
+Catches the silent-no-op class of bugs documented in pulp #1053: a
+pattern that matches zero tracked files is a bug masquerading as
+working configuration. When a contributor edits the file the pattern
+*intended* to mark, ``skill_sync_check.py`` doesn't fire, the SKILL.md
+goes out of date, and CI never notices.
+
+This contract enforces:
+
+    Every pattern in ``skill_path_map.json`` must EITHER match at least
+    one tracked file in the repo, OR live under a skill entry that
+    declares a ``_doc.empty-ok`` annotation explaining why the empty
+    pattern is intentional (e.g. external SDK paths that are
+    developer-supplied and not committed).
+
+The matcher used here is the production gitignore-style matcher from
+``skill_sync_check._glob_match`` — keep that as the single source of
+truth so this test and the gate it backs can never disagree.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import skill_sync_check as ssc  # noqa: E402  — path inserted above
+
+PATH_MAP = REPO / "tools" / "scripts" / "skill_path_map.json"
+
+
+def _tracked_files() -> list[str]:
+    out = subprocess.check_output(
+        ["git", "ls-files"], cwd=REPO, text=True
+    )
+    return out.splitlines()
+
+
+def _load_skill_map() -> dict:
+    return json.loads(PATH_MAP.read_text())
+
+
+class NoSilentEmptyPatterns(unittest.TestCase):
+    """Every mapped pattern must match a tracked file or be annotated."""
+
+    def test_every_path_matches_at_least_one_tracked_file_or_has_empty_ok_annotation(
+        self,
+    ) -> None:
+        skill_map = _load_skill_map()
+        files = _tracked_files()
+
+        offenders: list[str] = []
+        for skill, entry in skill_map.get("skills", {}).items():
+            if not isinstance(entry, dict):
+                continue
+            patterns = entry.get("paths", []) or []
+            doc = entry.get("_doc") or {}
+            empty_ok = isinstance(doc, dict) and bool(doc.get("empty-ok"))
+
+            for pat in patterns:
+                hits = [f for f in files if ssc._glob_match(f, pat)]
+                if hits:
+                    continue
+                if empty_ok:
+                    continue
+                offenders.append(f"{skill}: {pat}")
+
+        if offenders:
+            joined = "\n  ".join(offenders)
+            self.fail(
+                "Silent-no-op patterns found in skill_path_map.json (see "
+                "pulp #1053). Each pattern below matches zero tracked "
+                "files. Either correct the pattern to point at the moved "
+                "code, drop it, or — if it intentionally references an "
+                "external/developer-supplied path — add a "
+                "_doc.empty-ok annotation on the skill entry.\n"
+                f"  {joined}"
+            )
+
+    def test_doc_empty_ok_only_used_for_external_sdk_paths(self) -> None:
+        """Conservative annotation policy from pulp #1053.
+
+        Empty patterns that aren't external SDK references are bugs,
+        not intentional. Restrict the ``_doc.empty-ok`` escape hatch to
+        ``external/*`` patterns so future edits can't silently re-open
+        the no-op door for in-tree code.
+        """
+        skill_map = _load_skill_map()
+        files = _tracked_files()
+
+        offenders: list[str] = []
+        for skill, entry in skill_map.get("skills", {}).items():
+            if not isinstance(entry, dict):
+                continue
+            doc = entry.get("_doc") or {}
+            if not (isinstance(doc, dict) and doc.get("empty-ok")):
+                continue
+            patterns = entry.get("paths", []) or []
+            for pat in patterns:
+                hits = [f for f in files if ssc._glob_match(f, pat)]
+                if hits:
+                    continue
+                if not pat.startswith("external/"):
+                    offenders.append(f"{skill}: {pat}")
+
+        if offenders:
+            joined = "\n  ".join(offenders)
+            self.fail(
+                "Non-external empty pattern relies on _doc.empty-ok "
+                "annotation. Per pulp #1053, only external/*-SDK paths "
+                "may be annotated as intentionally empty:\n"
+                f"  {joined}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #1053. Audit found 33 silent-no-op patterns across 14 skills in \`tools/scripts/skill_path_map.json\` — patterns that matched zero tracked files (renames / moves / typos that silently disabled the skill-sync gate for those paths).

## Fix

**Dropped 25 stale patterns** — leftovers from renames or already covered by sibling patterns. Examples:
- \`core/**/*cmajor*\` (no in-tree cmajor source)
- \`tools/cli/cmd_{add,audit,fetch,install,remove,search}.cpp\` (logic moved to \`tools/packages/**\`)
- \`core/events/{src,include}/*stream*\` (moved to \`core/runtime\`)
- \`core/view/{src,include,platform}/webview*\` (no in-tree webview source)

**Corrected 5 patterns** to point at moved code:
- \`engine\`: \`js_bridge*\`, \`engine*\` → \`core/view/src/{js_*,js_engine*,script_engine*}\` (post JS-engine rework)
- \`faust\`: \`core/signal/**/*faust*\` → \`core/dsl/include/pulp/dsl/faust*\`
- \`faust\`: \`tools/scripts/faust*\` → \`tools/cmake/PulpFaust.cmake\`
- \`hosting\`: \`tools/cli/commands/host.cpp\` → \`tools/cli/cmd_host.cpp\`
- \`streams\`: \`examples/streams-*/**\` → \`examples/stream-*/**\`

**Annotated 3 intentional empties** (external developer-supplied SDKs):
\`external/AAX-SDK/**\`, \`external/ara-sdk/**\`, \`external/quickjs*/**\` — each gets a \`_doc.empty-ok\` annotation explaining why the empty match is by design.

## Tests

\`tools/scripts/test_skill_path_map.py::NoSilentEmptyPatterns\` — 2 cases:
- Asserts every pattern matches ≥1 tracked file OR has \`_doc.empty-ok\` annotation
- Restricts the escape hatch to \`external/*\` paths so the no-op door can't silently re-open for in-tree code

Uses the production matcher (\`skill_sync_check._glob_match\`) so test and gate can never disagree.

Full skill-sync test suite (26 tests) still passes.

## Verification

Post-edit audit: 0 unannotated empty patterns (was 33), 3 intentional annotated empties.

## Side observation

\`\$schema\` reference at the top of \`skill_path_map.json\` points to a file that doesn't exist (\`./skill_path_map.schema.json\`). Kept out of scope.

## Cross-refs

- Audit: #1053
- Parent: #1049
- Sibling fixes shipped this session: #1054 (#1318), #1055 (#1324), #1056 (#1319), #1144 (#1317)