### PR TITLE
fix(ci): thread lcov --remove --filter region through coverage pipeline (closes #1058)

### DIFF
--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -326,6 +326,7 @@ llvm-cov show \
 # a vendored copy of https://github.com/eriwen/lcov-to-cobertura-xml
 # (Apache 2.0, MIT-compatible).
 COBERTURA_XML="${BUILD_DIR}/coverage.cobertura.xml"
+RAW_LCOV_FILE="${REPORT_DIR}/coverage.raw.lcov"
 LCOV_FILE="${REPORT_DIR}/coverage.lcov"
 LCOV_COBERTURA="${REPO_ROOT}/tools/scripts/lcov_cobertura.py"
 
@@ -340,7 +341,42 @@ llvm-cov export --format=lcov \
     "${BINARIES[@]}" \
     -instr-profile="${PROFDATA}" \
     -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
-    > "${LCOV_FILE}"
+    > "${RAW_LCOV_FILE}"
+
+# Issue #1058: `llvm-cov export --format=lcov` is not gcov-aware and does NOT
+# honor `LCOV_EXCL_START` / `LCOV_EXCL_STOP` markers in source. Without the
+# `lcov --remove` pass below, those markers are silently documentation-only
+# and excluded ranges still appear as Missing in diff-cover output. Run the
+# raw .lcov through `lcov --remove` so its gcov parser strips the excluded
+# ranges before lcov_cobertura.py converts to Cobertura XML. Falls back to
+# a straight copy + warning when `lcov` isn't installed (CI / Linux dev
+# machines often lack it) so the existing pipeline keeps working with the
+# prior behavior.
+echo "=== LCOV → LCOV (honor LCOV_EXCL markers via lcov --filter region) ==="
+if command -v lcov >/dev/null 2>&1; then
+    # The dummy `--remove` pattern matches no real source path, so the
+    # remove step is a no-op file-wise; what we actually want is the
+    # source-aware re-read triggered by `--filter region`, which scans
+    # the SF: source files for LCOV_EXCL_START/STOP and drops the
+    # excluded line ranges. `--ignore-errors unused` keeps the dummy
+    # pattern from being a fatal error in lcov 2.x. If the lcov binary
+    # is too old to recognize `--filter region` (lcov 1.x), fall back
+    # to a straight copy and print a hint.
+    if ! lcov --remove "${RAW_LCOV_FILE}" '/__pulp_unmatched__/*' \
+              --output-file "${LCOV_FILE}" \
+              --filter region \
+              --ignore-errors unused \
+              --rc branch_coverage=1 \
+              >/dev/null 2>&1; then
+        cp "${RAW_LCOV_FILE}" "${LCOV_FILE}"
+        echo "run_coverage.sh: WARN: lcov --filter region failed; falling back to raw .lcov" >&2
+        echo "run_coverage.sh:       (LCOV_EXCL markers will not be honored — needs lcov >= 2.0)" >&2
+    fi
+else
+    cp "${RAW_LCOV_FILE}" "${LCOV_FILE}"
+    echo "run_coverage.sh: note: lcov not installed — LCOV_EXCL markers won't be honored." >&2
+    echo "run_coverage.sh: install with: brew install lcov  /  sudo apt install lcov" >&2
+fi
 
 echo "=== LCOV → Cobertura XML ==="
 python3 "${LCOV_COBERTURA}" "${LCOV_FILE}" \

--- a/setup.sh
+++ b/setup.sh
@@ -720,6 +720,29 @@ if [ "$PLATFORM" = "Linux" ]; then
     fi
 fi
 
+# ── Optional: lcov (for full LCOV_EXCL_* marker support) ──────────────────
+#
+# Issue #1058: Pulp's coverage pipeline (scripts/run_coverage.sh +
+# tools/scripts/local_diff_cover.sh) pipes the raw .lcov from
+# `llvm-cov export` through `lcov --filter region` so source-level
+# `LCOV_EXCL_START` / `LCOV_EXCL_STOP` markers actually propagate to
+# diff-cover. The pipeline still works without lcov (it falls back to
+# the unfiltered .lcov + a warning); installing lcov just unlocks the
+# per-block exclusions.
+
+step "Checking lcov (optional, for LCOV_EXCL markers)"
+
+if command -v lcov &>/dev/null; then
+    info "lcov: $(lcov --version 2>&1 | head -1)"
+else
+    warn "lcov not found — LCOV_EXCL_START/STOP markers won't be honored in coverage reports"
+    if [ "$PLATFORM" = "macOS" ]; then
+        echo "    Optional fix: brew install lcov"
+    elif [ "$PLATFORM" = "Linux" ]; then
+        echo "    Optional fix: sudo apt install lcov"
+    fi
+fi
+
 # ── Summary before build ───────────────────────────────────────────────────
 
 if [ $ERRORS -gt 0 ]; then

--- a/tools/scripts/local_diff_cover.sh
+++ b/tools/scripts/local_diff_cover.sh
@@ -253,7 +253,18 @@ fi
 # ── Generate Cobertura XML via lcov_cobertura.py ───────────────────────────
 # Same pipeline scripts/run_coverage.sh uses — `llvm-cov export --format=lcov`
 # then the vendored lcov_cobertura.py converter.
+#
+# Issue #1058: `llvm-cov export --format=lcov` is not gcov-aware and does NOT
+# honor `LCOV_EXCL_START` / `LCOV_EXCL_STOP` markers in source. Without the
+# `lcov --remove` pass below, those markers are silently documentation-only
+# and excluded ranges still appear as Missing in diff-cover output. We pipe
+# through `lcov --remove <raw> '*'` (which exercises lcov's gcov parser
+# WITHOUT actually removing any files via the wildcard) so excluded ranges
+# get stripped before the Cobertura conversion. Falls back to a straight
+# copy + warning when `lcov` isn't installed (CI / Linux dev machines often
+# lack it) so the existing pipeline keeps working with the prior behavior.
 COVERAGE_IGNORE_REGEX='(^|/)(_deps|external|test|[Cc]atch2|build|build-cov|build-coverage|examples|fetchcontent-src|sandbox-e2e)/'
+RAW_LCOV_FILE="${BUILD_DIR}/coverage/coverage.raw.lcov"
 LCOV_FILE="${BUILD_DIR}/coverage/coverage.lcov"
 COBERTURA_XML="${BUILD_DIR}/coverage.cobertura.xml"
 LCOV_COBERTURA="${REPO_ROOT}/tools/scripts/lcov_cobertura.py"
@@ -268,7 +279,33 @@ llvm-cov export --format=lcov \
     "${BINARIES[@]}" \
     -instr-profile="${PROFDATA}" \
     -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" \
-    > "${LCOV_FILE}"
+    > "${RAW_LCOV_FILE}"
+
+echo "=== LCOV → LCOV (honor LCOV_EXCL markers via lcov --filter region) ==="
+if command -v lcov >/dev/null 2>&1; then
+    # The dummy `--remove` pattern matches no real source path, so the
+    # remove step is a no-op file-wise; what we actually want is the
+    # source-aware re-read triggered by `--filter region`, which scans
+    # the SF: source files for LCOV_EXCL_START/STOP and drops the
+    # excluded line ranges. `--ignore-errors unused` keeps the dummy
+    # pattern from being a fatal error in lcov 2.x. If the lcov binary
+    # is too old to recognize `--filter region` (lcov 1.x), fall back
+    # to a straight copy and print a hint.
+    if ! lcov --remove "${RAW_LCOV_FILE}" '/__pulp_unmatched__/*' \
+              --output-file "${LCOV_FILE}" \
+              --filter region \
+              --ignore-errors unused \
+              --rc branch_coverage=1 \
+              >/dev/null 2>&1; then
+        cp "${RAW_LCOV_FILE}" "${LCOV_FILE}"
+        echo "[local_diff_cover] WARN: lcov --filter region failed; falling back to raw .lcov" >&2
+        echo "[local_diff_cover]       (LCOV_EXCL markers will not be honored — needs lcov >= 2.0)" >&2
+    fi
+else
+    cp "${RAW_LCOV_FILE}" "${LCOV_FILE}"
+    echo "[local_diff_cover] note: lcov not installed — LCOV_EXCL markers won't be honored." >&2
+    echo "[local_diff_cover] install with: brew install lcov  /  sudo apt install lcov" >&2
+fi
 
 echo "=== LCOV → Cobertura XML ==="
 python3 "${LCOV_COBERTURA}" "${LCOV_FILE}" \

--- a/tools/scripts/test_lcov_excl_propagation.py
+++ b/tools/scripts/test_lcov_excl_propagation.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Contract test for issue #1058: LCOV_EXCL markers must propagate.
+
+Background
+----------
+`llvm-cov export --format=lcov` is not gcov-aware; it does NOT honor
+`LCOV_EXCL_START` / `LCOV_EXCL_STOP` comments in source. Pulp's coverage
+pipeline historically went straight from llvm-cov to lcov_cobertura.py,
+so any LCOV_EXCL block was silently documentation-only.
+
+Fix (Path A from issue #1058)
+-----------------------------
+Pipe the raw .lcov through `lcov --remove <raw> '<no-op-pattern>'
+--filter region --output-file <out>` so lcov's source-aware filter
+strips lines that fall inside an `LCOV_EXCL_START..STOP` range before
+the cobertura conversion sees them.
+
+What this test verifies
+-----------------------
+1. Build a synthetic source file with a known LCOV_EXCL_START/STOP
+   block on a specific line range.
+2. Synthesize a matching .lcov tracefile that includes hit counts for
+   lines INSIDE the excluded range.
+3. Run the same `lcov --filter region` invocation the production shell
+   scripts use.
+4. Assert the excluded line numbers are absent from the output and
+   non-excluded lines remain.
+
+Skipped cleanly when `lcov` is not on PATH so this test does not block
+contributors / CI lanes that haven't installed lcov yet.
+
+Run:
+    python3 tools/scripts/test_lcov_excl_propagation.py
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+LCOV_AVAILABLE = shutil.which("lcov") is not None
+
+
+@unittest.skipUnless(LCOV_AVAILABLE, "lcov not installed (brew install lcov / apt install lcov)")
+class LcovExclPropagation(unittest.TestCase):
+    """`lcov --filter region` strips LCOV_EXCL'd line ranges from .lcov."""
+
+    def test_lcov_excl_block_strips_lines_from_lcov_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_str:
+            tmp = pathlib.Path(tmp_str)
+
+            # Source with a clearly delineated EXCL block on lines 6-8.
+            source = tmp / "sample.cpp"
+            source.write_text(textwrap.dedent(
+                """\
+                int keep_me(int x) {
+                    return x + 1;
+                }
+
+                // LCOV_EXCL_START
+                int drop_me(int x) {
+                    return x * 2;
+                }
+                // LCOV_EXCL_STOP
+
+                int also_keep(int x) {
+                    return x - 1;
+                }
+                """
+            ))
+
+            # Synthesize a tracefile with hit counts on lines 2 (kept),
+            # 7 (excluded — inside the EXCL block), and 12 (kept).
+            raw_lcov = tmp / "coverage.raw.lcov"
+            raw_lcov.write_text(
+                "TN:\n"
+                f"SF:{source}\n"
+                "DA:2,5\n"
+                "DA:7,3\n"
+                "DA:12,1\n"
+                "LF:3\n"
+                "LH:3\n"
+                "end_of_record\n"
+            )
+
+            filtered_lcov = tmp / "coverage.lcov"
+
+            result = subprocess.run(
+                [
+                    "lcov",
+                    "--remove", str(raw_lcov),
+                    "/__pulp_unmatched__/*",
+                    "--output-file", str(filtered_lcov),
+                    "--filter", "region",
+                    "--ignore-errors", "unused",
+                    "--rc", "branch_coverage=1",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(
+                result.returncode, 0,
+                msg=f"lcov failed: stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertTrue(
+                filtered_lcov.exists(),
+                msg="lcov did not write output file",
+            )
+
+            content = filtered_lcov.read_text()
+
+            # Excluded line (inside LCOV_EXCL_START..STOP) MUST be gone.
+            self.assertNotIn(
+                "DA:7,",
+                content,
+                msg=(
+                    "Line 7 is inside an LCOV_EXCL_START..STOP block but still "
+                    "appears in the filtered output. The toolchain is not "
+                    "honoring LCOV_EXCL markers — issue #1058 has regressed."
+                ),
+            )
+
+            # Non-excluded lines must survive.
+            self.assertIn("DA:2,5", content, msg="non-excluded line 2 disappeared")
+            self.assertIn("DA:12,1", content, msg="non-excluded line 12 disappeared")
+
+            # Line totals should reflect the drop (3 → 2).
+            self.assertIn(
+                "LF:2",
+                content,
+                msg="line count summary did not update after filter",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #1058. Audit confirmed the toolchain doesn't honor \`LCOV_EXCL_*\` markers — \`llvm-cov export --format=lcov\` is not gcov-aware, and \`lcov_cobertura.py\` is a pure converter. So if anyone added \`// LCOV_EXCL_START ... LCOV_EXCL_STOP\` blocks, they were silently documentation-only.

## Fix (Path A from the audit)

Insert \`lcov --remove\` between \`llvm-cov export\` and \`lcov_cobertura.py\`:

```bash
llvm-cov export --format=lcov ... > coverage.raw.lcov
if command -v lcov >/dev/null 2>&1; then
    lcov --remove coverage.raw.lcov '<no-op-pattern>' \
         --filter region --ignore-errors unused \
         --output-file coverage.lcov
else
    cp coverage.raw.lcov coverage.lcov   # graceful degradation
    echo "[coverage] note: lcov not installed — LCOV_EXCL markers won't be honored." >&2
fi
python3 lcov_cobertura.py coverage.lcov ...
```

## Critical correction to the audit recommendation

The audit suggested \`lcov --remove <raw> '*' --output-file ...\` — but that pattern strips every file. The correct invocation that activates lcov's source-aware marker scan is:

```
lcov --remove <raw> '<no-op-pattern>' --filter region --ignore-errors unused
```

Verified empirically against \`/opt/homebrew/Cellar/lcov/2.4_1/lib/lcov/lcovutil.pm\` — \`parseLines()\` (which honors \`LCOV_EXCL_START\`/\`STOP\`) only fires when \`FILTER_EXCLUDE_REGION\` is active, which requires \`--filter region\`.

## Files changed

- \`tools/scripts/local_diff_cover.sh\` — insertion + fallback
- \`scripts/run_coverage.sh\` — insertion + fallback (matching shape)
- \`setup.sh\` — new optional \`step "Checking lcov"\` with non-fatal warn + brew/apt hint
- \`tools/scripts/test_lcov_excl_propagation.py\` (new) — contract test

## Tests

\`test_lcov_excl_propagation.py\` runs locally with lcov 2.4 installed and **passes**. Uses \`unittest.skipUnless(LCOV_AVAILABLE)\` so CI/dev machines without lcov skip cleanly.

## Environment behavior

- **Windows MSVC / clang-cl lanes**: \`lcov\` is a Perl tool not commonly installed; fallback path preserves existing pipeline (raw copy + warning). No regression.
- **CI runners without lcov**: same fallback; coverage pipeline keeps working; LCOV_EXCL markers just don't get honored (matches today's behavior).
- **lcov 1.x machines**: \`--filter region\` is lcov 2.x. The \`if !\` guard catches command failure and falls back with a "needs lcov >= 2.0" hint.

No hard dependency added; no diff-cover threshold or tier targets touched.

## Cross-refs

- Audit: #1058
- Parent: #1049 silent-no-op audit epic
- Companion fixes shipped this session: #1053 (#1325), #1054 (#1318), #1055 (#1324), #1056 (#1319), #1144 (#1317)