### PR TITLE
fix(view): overlay_contains walks overflow:visible children (closes pulp #1320)

### DIFF
--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -529,6 +529,44 @@ bool View::call_inspector_mouse_hook(const MouseEvent& e) {
 // pulp #1148 — generalized overlay-click routing.
 View* View::active_overlay_ = nullptr;
 
+namespace {
+
+// pulp #1320 — recursively expand a child's painted-bounds contribution
+// up through any `overflow:visible` descendants. Returns the bounding
+// rect (in window coords) of `v` and every transitive descendant whose
+// chain back to `v` is entirely overflow:visible. A descendant inside
+// an `overflow:hidden` ancestor is clipped, so it stops contributing.
+//
+// `parent_abs_x` / `parent_abs_y` are the absolute window-coord origin
+// of `v->parent()`. The function consumes those, applies `v`'s own
+// `bounds().x/y`, and recurses.
+void accumulate_overflow_extent(const View* v,
+                                float parent_abs_x,
+                                float parent_abs_y,
+                                float& min_x,
+                                float& min_y,
+                                float& max_x,
+                                float& max_y) {
+    if (!v) return;
+    const float abs_x = parent_abs_x + v->bounds().x;
+    const float abs_y = parent_abs_y + v->bounds().y;
+    const auto lb = v->local_bounds();
+    if (abs_x < min_x) min_x = abs_x;
+    if (abs_y < min_y) min_y = abs_y;
+    if (abs_x + lb.width > max_x) max_x = abs_x + lb.width;
+    if (abs_y + lb.height > max_y) max_y = abs_y + lb.height;
+    // Only recurse through children whose own overflow is visible —
+    // that's the CSS rule. An `overflow:hidden` child clips its own
+    // descendants, so they don't contribute painted pixels above us.
+    if (v->overflow() != View::Overflow::visible) return;
+    for (size_t i = 0; i < v->child_count(); ++i) {
+        accumulate_overflow_extent(v->child_at(i), abs_x, abs_y,
+                                   min_x, min_y, max_x, max_y);
+    }
+}
+
+}  // namespace
+
 bool View::overlay_contains(Point window_pt) const {
     // Walk up to compute absolute origin in window/root coords. Same
     // arithmetic the mac window-host uses for ComboBox::active_popup_.
@@ -541,8 +579,35 @@ bool View::overlay_contains(Point window_pt) const {
     }
     const float w = local_bounds().width;
     const float h = local_bounds().height;
-    return window_pt.x >= abs_x && window_pt.x <= abs_x + w &&
-           window_pt.y >= abs_y && window_pt.y <= abs_y + h;
+    // Fast-path: own painted rect contains the point.
+    if (window_pt.x >= abs_x && window_pt.x <= abs_x + w &&
+        window_pt.y >= abs_y && window_pt.y <= abs_y + h) {
+        return true;
+    }
+
+    // pulp #1320 — extend the hit area to include the painted bounding
+    // box of any `overflow:visible` descendants. CSS `overflow:visible`
+    // semantics: a child painting outside the parent is still
+    // visible/clickable. Without this, a popover positioned via
+    // `position:absolute; top: 28; right: 0` extends LEFTWARD beyond
+    // its short trigger button — clicks on the leftward cells then
+    // miss `overlay_contains` and fall through to whatever sibling
+    // happens to occupy that pixel.
+    //
+    // Only meaningful when this overlay itself has overflow:visible
+    // (otherwise its own clip rect bounds the painted pixels).
+    if (overflow() != Overflow::visible) return false;
+
+    // Compute parent_abs_{x,y}: this->bounds().x/y were already added
+    // by the walk above, so subtract them to get the parent origin.
+    const float parent_abs_x = abs_x - bounds().x;
+    const float parent_abs_y = abs_y - bounds().y;
+    float min_x = abs_x, min_y = abs_y;
+    float max_x = abs_x + w, max_y = abs_y + h;
+    accumulate_overflow_extent(this, parent_abs_x, parent_abs_y,
+                               min_x, min_y, max_x, max_y);
+    return window_pt.x >= min_x && window_pt.x <= max_x &&
+           window_pt.y >= min_y && window_pt.y <= max_y;
 }
 
 void View::paint_overlays(canvas::Canvas& canvas) {

--- a/test/test_overlay_routing.cpp
+++ b/test/test_overlay_routing.cpp
@@ -132,6 +132,119 @@ TEST_CASE("View::overlay_contains uses absolute window coords [issue-1148]",
     REQUIRE_FALSE(child->overlay_contains({160.0f, 141.0f})); // below
 }
 
+// ── pulp #1320 — overlay_contains walks overflow:visible children ──────────
+//
+// Background (Spectr bands picker, v0.68.0 audit): a popover panel is built
+// as `<View position="absolute"; right: 0>` inside a short trigger button's
+// `position: relative` parent. The popover paints LEFTWARD beyond its
+// parent's bounds. Before #1320, `overlay_contains` only tested the
+// claiming View's own bounds, so clicks on the leftward cells of the
+// popover failed `overlay_contains` and fell through to siblings.
+//
+// CSS `overflow:visible` semantics: a child painting outside its parent
+// is still visible AND clickable. The fix expands `overlay_contains` to
+// include the bounding box of all overflow:visible descendants (the
+// painted union), matching the web rule.
+
+TEST_CASE("View::overlay_contains includes overflow:visible child painted "
+          "outside parent bounds [issue-1320]",
+          "[view][overlay][1320]") {
+    OverlayGuard g;
+    // Simulate the Spectr bands picker layout:
+    //   parent (relative wrapper):  bounds (200, 33, 60, 22)  ← short button
+    //   child  (absolute popover):  bounds (-120, 28, 180, 30) ← extends LEFT
+    //
+    // The popover's window-coord rect is:
+    //   x: 200 + (-120) = 80
+    //   y: 33  + 28     = 61
+    //   w: 180, h: 30
+    //
+    // A click at (100, 70) is INSIDE the popover but OUTSIDE the parent
+    // (parent's right edge is 260, but 100 < 200 so the click is left of
+    // the parent's left edge). Pre-fix: overlay_contains returns false.
+    // Post-fix: overlay_contains returns true because the painted union
+    // of the parent + overflow:visible children covers that pixel.
+    TestView parent;
+    parent.set_bounds({200.0f, 33.0f, 60.0f, 22.0f});
+    parent.set_overflow(View::Overflow::visible);
+
+    auto popover_owned = std::make_unique<TestView>();
+    auto* popover = popover_owned.get();
+    popover->set_bounds({-120.0f, 28.0f, 180.0f, 30.0f});
+    popover->set_overflow(View::Overflow::visible);
+    parent.add_child(std::move(popover_owned));
+
+    parent.claim_overlay();
+    REQUIRE(View::active_overlay_ == &parent);
+
+    // Click on the leftward popover cell (the bug's "32" / "40" cells).
+    REQUIRE(parent.overlay_contains({100.0f, 70.0f}));
+    // Click in the middle of the popover.
+    REQUIRE(parent.overlay_contains({170.0f, 70.0f}));
+    // Click on the rightward portion (still inside popover, also inside parent).
+    REQUIRE(parent.overlay_contains({250.0f, 70.0f}));
+    // Click on the parent's own button area (regression — must still pass).
+    REQUIRE(parent.overlay_contains({230.0f, 40.0f}));
+    // Click clearly outside both parent AND popover — must still be false.
+    REQUIRE_FALSE(parent.overlay_contains({50.0f, 70.0f}));    // left of popover
+    REQUIRE_FALSE(parent.overlay_contains({270.0f, 70.0f}));   // right of popover
+    REQUIRE_FALSE(parent.overlay_contains({170.0f, 100.0f})); // below popover
+    REQUIRE_FALSE(parent.overlay_contains({170.0f, 30.0f})); // above (popover y=61, parent y=33; 30 is above both)
+}
+
+TEST_CASE("View::overlay_contains stops walking at overflow:hidden child "
+          "[issue-1320]",
+          "[view][overlay][1320]") {
+    OverlayGuard g;
+    // overflow:hidden clips its descendants — they don't contribute
+    // painted pixels above us. Mirrors CSS rule.
+    TestView parent;
+    parent.set_bounds({100.0f, 100.0f, 50.0f, 50.0f});
+    parent.set_overflow(View::Overflow::visible);
+
+    auto clipped_owned = std::make_unique<TestView>();
+    auto* clipped = clipped_owned.get();
+    clipped->set_bounds({0.0f, 0.0f, 50.0f, 50.0f});
+    clipped->set_overflow(View::Overflow::hidden);
+    parent.add_child(std::move(clipped_owned));
+
+    // Even if clipped has a wild child, we should NOT count it.
+    auto wild_owned = std::make_unique<TestView>();
+    auto* wild = wild_owned.get();
+    wild->set_bounds({-1000.0f, -1000.0f, 100.0f, 100.0f});
+    wild->set_overflow(View::Overflow::visible);
+    clipped->add_child(std::move(wild_owned));
+    (void)wild;
+
+    parent.claim_overlay();
+    // Inside parent — true.
+    REQUIRE(parent.overlay_contains({120.0f, 120.0f}));
+    // Inside the wild grandchild's painted rect — but it's clipped by
+    // the overflow:hidden middle layer, so it must NOT contribute.
+    REQUIRE_FALSE(parent.overlay_contains({-500.0f, -500.0f}));
+}
+
+TEST_CASE("View::overlay_contains: own overflow:hidden disables expansion "
+          "[issue-1320]",
+          "[view][overlay][1320]") {
+    OverlayGuard g;
+    // If the overlay View itself has overflow:hidden, its own painted
+    // rect is the limit — children CAN'T paint outside it. Don't expand.
+    TestView parent;
+    parent.set_bounds({100.0f, 100.0f, 50.0f, 50.0f});
+    parent.set_overflow(View::Overflow::hidden);
+
+    auto child_owned = std::make_unique<TestView>();
+    auto* child = child_owned.get();
+    child->set_bounds({-100.0f, -100.0f, 50.0f, 50.0f});  // way outside
+    parent.add_child(std::move(child_owned));
+    (void)child;
+
+    parent.claim_overlay();
+    REQUIRE(parent.overlay_contains({120.0f, 120.0f}));     // inside parent
+    REQUIRE_FALSE(parent.overlay_contains({0.0f, 0.0f})); // child's pixel — clipped
+}
+
 TEST_CASE("View overlay routing: ComboBox::active_popup_ is independent "
           "[issue-1148]",
           "[view][overlay][regression]") {


### PR DESCRIPTION
## Summary

Closes #1320. Generalizes `View::overlay_contains` to include the painted bounding box of `overflow:visible` descendants, matching CSS semantics. Without this expansion, clicks on overflow children of an overlay View fell through to tree hit_test.

## Tests

3 new Catch2 cases tagged `[issue-1320]`:
- includes overflow:visible child painted outside parent bounds — pass
- stops walking at overflow:hidden child — pass  
- own overflow:hidden disables expansion — pass

`pulp-test-overlay-routing`: 31/31 assertions, 10/10 cases pass.

## Important caveat re: the bands-picker bug

This fix lands the framework primitive correctly, but Spectr's `editor.js` bundle doesn't currently use `<View overlay>` for the bands picker — it uses bare `<div style="position:absolute">`. So this fix is unreachable for the specific symptom on Spectr today.

The bands picker bug (32/40 fail, 48/56/64 work) actually triggers in `View::hit_test()` at `core/view/src/view.cpp:475-480` where the existing `overflow:visible` extension is asymmetric — only +500px DOWNWARD. The bands picker extends LEFTWARD beyond its narrow trigger button, so the parent's hit_test returns nullptr before the click reaches the absolute-positioned dropdown child.

Two possible follow-ups:
1. Make `View::hit_test`'s overflow:visible extension symmetric (left/right/up, not just down) — separate slice
2. Spectr-side bundle change to opt into `overlay={true}` on the bands-picker wrapper

This PR addresses (1) the framework primitive; (2) is bundle-side; the symmetric hit_test extension is the next slice if we want overflow-visible to "just work" without explicit overlay opt-in.

## Files

- `core/view/src/view.cpp` (+69 lines)
- `test/test_overlay_routing.cpp` (+113 lines, 3 cases)

## Cross-refs

- Issue: #1320
- Related: #1148 / #1297 (overlay click routing), #1316 (Codex P1 follow-up)
- Spectr-side: bands picker still asymmetric until either #1320b (symmetric extension) or bundle opt-in