### PR TITLE
fix(canvas/mac): CoreGraphicsCanvas implements path / gradient / transform (closes pulp #1322)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.72.2
+    VERSION 0.72.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/cg_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/cg_canvas.hpp
@@ -2,10 +2,13 @@
 
 #include <pulp/canvas/canvas.hpp>
 
+#include <vector>
+
 #ifdef __APPLE__
 
-// Forward declare CGContext
+// Forward declare CG types
 typedef struct CGContext* CGContextRef;
+typedef struct CGPath* CGMutablePathRef;
 
 namespace pulp::canvas {
 
@@ -23,13 +26,25 @@ public:
     void rotate(float radians) override;
     void concat_transform(float a, float b, float c,
                           float d, float e, float f) override;
+    void set_transform(float a, float b, float c,
+                       float d, float e, float f) override;
+    void capture_paint_baseline_transform() override;
     void clip_rect(float x, float y, float w, float h) override;
+    void clip() override;
 
     void set_fill_color(Color c) override;
     void set_stroke_color(Color c) override;
     void set_line_width(float w) override;
     void set_line_cap(LineCap cap) override;
     void set_line_join(LineJoin join) override;
+
+    void set_fill_gradient_linear(float x0, float y0, float x1, float y1,
+                                   const Color* colors, const float* positions,
+                                   int count) override;
+    void set_fill_gradient_radial(float cx, float cy, float radius,
+                                   const Color* colors, const float* positions,
+                                   int count) override;
+    void clear_fill_gradient() override;
 
     void fill_rect(float x, float y, float w, float h) override;
     void clear_rect(float x, float y, float w, float h) override;
@@ -43,6 +58,18 @@ public:
     void stroke_line(float x0, float y0, float x1, float y1) override;
     void stroke_path(const Point2D* points, size_t count) override;
     void fill_path(const Point2D* points, size_t count) override;
+
+    // Canvas2D-style path building (pulp #1322).
+    void begin_path() override;
+    void move_to(float x, float y) override;
+    void line_to(float x, float y) override;
+    void quad_to(float cpx, float cpy, float x, float y) override;
+    void cubic_to(float cp1x, float cp1y, float cp2x, float cp2y,
+                  float x, float y) override;
+    void close_path() override;
+    void fill_current_path() override;
+    void stroke_current_path() override;
+
     void set_opacity(float alpha) override;
     void save_layer(float x, float y, float w, float h,
                     float opacity, float blur_radius) override;
@@ -63,9 +90,37 @@ private:
     float font_size_ = 14.0f;
     TextAlign text_align_ = TextAlign::left;
 
+    // Canvas2D path-building state (pulp #1322). Owned, retained CG mutable
+    // path; null until the first begin_path() call.
+    CGMutablePathRef path_ = nullptr;
+
+    // Linear/radial gradient state used as the fill paint when
+    // has_gradient_ is true. Mirrors the SkiaCanvas split between solid
+    // fill and shader-based fill so JS-driven gradient fills paint instead
+    // of falling back to a single color.
+    bool has_gradient_ = false;
+    bool gradient_is_radial_ = false;
+    float grad_x0_ = 0, grad_y0_ = 0, grad_x1_ = 0, grad_y1_ = 0;
+    float grad_radius_ = 0;
+    std::vector<Color> grad_colors_;
+    std::vector<float> grad_positions_;
+
+    // Paint-baseline transform captured at CanvasWidget::paint() entry,
+    // matching SkiaCanvas so JS-supplied setTransform() composes onto the
+    // inbound View matrix instead of overwriting it.
+    bool has_baseline_ = false;
+    // Storage for CGAffineTransform — declared as raw doubles so the
+    // header doesn't pull <CoreGraphics/CoreGraphics.h>. Six-element layout:
+    //   [a, b, c, d, tx, ty] (CGAffineTransform memory layout).
+    double baseline_xform_[6] = {1, 0, 0, 1, 0, 0};
+
     void apply_fill_color();
     void apply_stroke_color();
     void add_rounded_rect_path(float x, float y, float w, float h, float radius);
+    // Fills (or clips to) the current path or rect using either the solid
+    // fill_color_ or the active gradient when has_gradient_ is set.
+    void fill_with_active_paint();
+    void release_path();
 };
 
 } // namespace pulp::canvas

--- a/core/canvas/platform/mac/cg_canvas.mm
+++ b/core/canvas/platform/mac/cg_canvas.mm
@@ -15,7 +15,16 @@ CoreGraphicsCanvas::CoreGraphicsCanvas(CGContextRef ctx, float width, float heig
     CGContextScaleCTM(ctx_, 1.0, -1.0);
 }
 
-CoreGraphicsCanvas::~CoreGraphicsCanvas() = default;
+CoreGraphicsCanvas::~CoreGraphicsCanvas() {
+    release_path();
+}
+
+void CoreGraphicsCanvas::release_path() {
+    if (path_) {
+        CGPathRelease(path_);
+        path_ = nullptr;
+    }
+}
 
 void CoreGraphicsCanvas::save() { CGContextSaveGState(ctx_); }
 void CoreGraphicsCanvas::restore() {
@@ -58,8 +67,67 @@ void CoreGraphicsCanvas::concat_transform(float a, float b, float c,
     CGContextConcatCTM(ctx_, CGAffineTransformMake(a, b, c, d, e, f));
 }
 
+// pulp #1322 — JS-driven setTransform must compose onto the paint baseline
+// captured at CanvasWidget::paint() entry, mirroring SkiaCanvas's behavior.
+// Without this override, the base-class no-op silently drops every JS
+// setTransform call on the CPU paint path (which is what standalone uses
+// when use_gpu=false), so any subsequent fill/stroke draws at the wrong
+// place — or, far more often, at (0,0) and gets invisibly clipped.
+void CoreGraphicsCanvas::set_transform(float a, float b, float c,
+                                       float d, float e, float f) {
+    // Compose user matrix onto the captured baseline:
+    //   final = baseline * user
+    // CGAffineTransformConcat(t1, t2) returns t1 * t2 (left-multiplication
+    // of t1 by t2). The baseline is the CTM at paint() entry; user is the
+    // matrix the JS code is asking for in canvas-local space.
+    CGAffineTransform user = CGAffineTransformMake(a, b, c, d, e, f);
+    if (has_baseline_) {
+        CGAffineTransform baseline = CGAffineTransformMake(
+            static_cast<CGFloat>(baseline_xform_[0]),
+            static_cast<CGFloat>(baseline_xform_[1]),
+            static_cast<CGFloat>(baseline_xform_[2]),
+            static_cast<CGFloat>(baseline_xform_[3]),
+            static_cast<CGFloat>(baseline_xform_[4]),
+            static_cast<CGFloat>(baseline_xform_[5]));
+        CGAffineTransform composed = CGAffineTransformConcat(user, baseline);
+        // Replace CTM: invert current and concat the desired final matrix.
+        CGAffineTransform inv = CGAffineTransformInvert(CGContextGetCTM(ctx_));
+        CGContextConcatCTM(ctx_, inv);
+        CGContextConcatCTM(ctx_, composed);
+    } else {
+        // No baseline captured — replace CTM with user matrix outright. This
+        // matches the default Canvas2D semantic that setTransform replaces.
+        CGAffineTransform inv = CGAffineTransformInvert(CGContextGetCTM(ctx_));
+        CGContextConcatCTM(ctx_, inv);
+        CGContextConcatCTM(ctx_, user);
+    }
+}
+
+void CoreGraphicsCanvas::capture_paint_baseline_transform() {
+    CGAffineTransform t = CGContextGetCTM(ctx_);
+    baseline_xform_[0] = static_cast<double>(t.a);
+    baseline_xform_[1] = static_cast<double>(t.b);
+    baseline_xform_[2] = static_cast<double>(t.c);
+    baseline_xform_[3] = static_cast<double>(t.d);
+    baseline_xform_[4] = static_cast<double>(t.tx);
+    baseline_xform_[5] = static_cast<double>(t.ty);
+    has_baseline_ = true;
+}
+
 void CoreGraphicsCanvas::clip_rect(float x, float y, float w, float h) {
     CGContextClipToRect(ctx_, CGRectMake(x, y, w, h));
+}
+
+// pulp #1322 — clip() intersects the current clip region with the path
+// being built via begin_path/move_to/line_to/etc. Mirrors
+// CanvasRenderingContext2D.clip() and SkiaCanvas::clip(). Without the
+// override, the base-class no-op silently leaves the clip region wide open
+// so subsequent draws spill over their intended bounds.
+void CoreGraphicsCanvas::clip() {
+    if (!path_) return;
+    CGContextAddPath(ctx_, path_);
+    // Use even-odd? Canvas2D defaults to non-zero winding for clip().
+    CGContextClip(ctx_);
 }
 
 void CoreGraphicsCanvas::apply_fill_color() {
@@ -102,6 +170,13 @@ void CoreGraphicsCanvas::set_line_join(LineJoin join) {
 }
 
 void CoreGraphicsCanvas::fill_rect(float x, float y, float w, float h) {
+    if (has_gradient_) {
+        CGContextSaveGState(ctx_);
+        CGContextClipToRect(ctx_, CGRectMake(x, y, w, h));
+        fill_with_active_paint();
+        CGContextRestoreGState(ctx_);
+        return;
+    }
     apply_fill_color();
     CGContextFillRect(ctx_, CGRectMake(x, y, w, h));
 }
@@ -329,6 +404,175 @@ Canvas::TextMetrics CoreGraphicsCanvas::measure_text_full(const std::string& tex
         CFRelease(font);
         return m;
     }
+}
+
+// ── Canvas2D path builder (pulp #1322) ───────────────────────────────────────
+//
+// Background. CanvasWidget JS code drives draw via the HTML5 Canvas2D-style
+// path API: beginPath, moveTo, lineTo, quadTo, cubicTo, closePath, then
+// fill() / stroke(). The base Canvas class default-implements every one of
+// these as a no-op so backends that don't have a real path builder still
+// compile, but it means the CoreGraphics CPU paint path used by Pulp's
+// standalone host (when use_gpu=false) silently dropped the entire JS draw
+// program. Spectr's FilterBank canvas issues 1800+ such commands per frame
+// and the result was a fully-white window — see the issue thread for the
+// full repro.
+//
+// Implementation: mirror SkiaCanvas's approach but with CGMutablePath.
+// We hold a CGMutablePathRef per begin_path() call, append segments as
+// the JS bridge calls into us, and on fill_current_path / stroke_current_path
+// we hand the path to CGContextAddPath + CGContextFillPath / CGContextStrokePath.
+// The path is released when the canvas is destroyed.
+//
+// Note: CGContext maintains its own internal path that the CG-shape draws
+// (fill_rect, fill_circle, fill_rounded_rect) build and consume. We keep
+// that internal path separate from path_ — the JS-driven path lives in
+// path_ and is only flushed to CG when fill_current_path / stroke_current_path
+// fire. fill_rect etc. continue to use the CG implicit path.
+
+void CoreGraphicsCanvas::begin_path() {
+    release_path();
+    path_ = CGPathCreateMutable();
+}
+
+void CoreGraphicsCanvas::move_to(float x, float y) {
+    if (!path_) path_ = CGPathCreateMutable();
+    CGPathMoveToPoint(path_, NULL, x, y);
+}
+
+void CoreGraphicsCanvas::line_to(float x, float y) {
+    if (!path_) path_ = CGPathCreateMutable();
+    CGPathAddLineToPoint(path_, NULL, x, y);
+}
+
+void CoreGraphicsCanvas::quad_to(float cpx, float cpy, float x, float y) {
+    if (!path_) path_ = CGPathCreateMutable();
+    CGPathAddQuadCurveToPoint(path_, NULL, cpx, cpy, x, y);
+}
+
+void CoreGraphicsCanvas::cubic_to(float cp1x, float cp1y,
+                                   float cp2x, float cp2y,
+                                   float x, float y) {
+    if (!path_) path_ = CGPathCreateMutable();
+    CGPathAddCurveToPoint(path_, NULL, cp1x, cp1y, cp2x, cp2y, x, y);
+}
+
+void CoreGraphicsCanvas::close_path() {
+    if (path_) CGPathCloseSubpath(path_);
+}
+
+void CoreGraphicsCanvas::fill_current_path() {
+    if (!path_) return;
+    if (has_gradient_) {
+        // Clip to the path, then draw the gradient; restore the clip.
+        CGContextSaveGState(ctx_);
+        CGContextAddPath(ctx_, path_);
+        CGContextClip(ctx_);
+        fill_with_active_paint();
+        CGContextRestoreGState(ctx_);
+    } else {
+        apply_fill_color();
+        CGContextAddPath(ctx_, path_);
+        CGContextFillPath(ctx_);
+    }
+    // Mirrors SkiaCanvas::fill_current_path which detaches the path on use —
+    // the next draw must begin_path() again, matching Canvas2D semantics.
+    release_path();
+}
+
+void CoreGraphicsCanvas::stroke_current_path() {
+    if (!path_) return;
+    apply_stroke_color();
+    CGContextAddPath(ctx_, path_);
+    CGContextStrokePath(ctx_);
+    release_path();
+}
+
+// ── Gradient fills (pulp #1322) ──────────────────────────────────────────────
+//
+// SkiaCanvas stores a gradient shader and applies it as the fill paint on
+// fill_current_path / fill_rect. CoreGraphics doesn't have a "set fill
+// shader" call — gradient draws go through CGContextDrawLinearGradient /
+// CGContextDrawRadialGradient, which paint the gradient inside the current
+// clip region. We mirror Skia's behavior by clipping to the rect/path being
+// filled and then issuing the appropriate Draw*Gradient call.
+
+void CoreGraphicsCanvas::set_fill_gradient_linear(float x0, float y0,
+                                                   float x1, float y1,
+                                                   const Color* colors,
+                                                   const float* positions,
+                                                   int count) {
+    if (count <= 0) {
+        clear_fill_gradient();
+        return;
+    }
+    has_gradient_ = true;
+    gradient_is_radial_ = false;
+    grad_x0_ = x0; grad_y0_ = y0; grad_x1_ = x1; grad_y1_ = y1;
+    grad_colors_.assign(colors, colors + count);
+    grad_positions_.assign(positions, positions + count);
+}
+
+void CoreGraphicsCanvas::set_fill_gradient_radial(float cx, float cy,
+                                                   float radius,
+                                                   const Color* colors,
+                                                   const float* positions,
+                                                   int count) {
+    if (count <= 0) {
+        clear_fill_gradient();
+        return;
+    }
+    has_gradient_ = true;
+    gradient_is_radial_ = true;
+    grad_x0_ = cx; grad_y0_ = cy; grad_radius_ = radius;
+    grad_colors_.assign(colors, colors + count);
+    grad_positions_.assign(positions, positions + count);
+}
+
+void CoreGraphicsCanvas::clear_fill_gradient() {
+    has_gradient_ = false;
+    grad_colors_.clear();
+    grad_positions_.clear();
+}
+
+void CoreGraphicsCanvas::fill_with_active_paint() {
+    if (!has_gradient_ || grad_colors_.empty()) {
+        apply_fill_color();
+        return;
+    }
+    const size_t n = grad_colors_.size();
+    std::vector<CGFloat> components(n * 4);
+    std::vector<CGFloat> locations(n);
+    for (size_t i = 0; i < n; ++i) {
+        components[i * 4 + 0] = grad_colors_[i].r;
+        components[i * 4 + 1] = grad_colors_[i].g;
+        components[i * 4 + 2] = grad_colors_[i].b;
+        components[i * 4 + 3] = grad_colors_[i].a;
+        locations[i] = grad_positions_[i];
+    }
+    CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+    if (!cs) return;
+    CGGradientRef gradient = CGGradientCreateWithColorComponents(
+        cs, components.data(), locations.data(), n);
+    CGColorSpaceRelease(cs);
+    if (!gradient) return;
+
+    const CGGradientDrawingOptions opts =
+        kCGGradientDrawsBeforeStartLocation | kCGGradientDrawsAfterEndLocation;
+    if (gradient_is_radial_) {
+        CGContextDrawRadialGradient(ctx_,
+            gradient,
+            CGPointMake(grad_x0_, grad_y0_), 0.0,
+            CGPointMake(grad_x0_, grad_y0_), grad_radius_,
+            opts);
+    } else {
+        CGContextDrawLinearGradient(ctx_,
+            gradient,
+            CGPointMake(grad_x0_, grad_y0_),
+            CGPointMake(grad_x1_, grad_y1_),
+            opts);
+    }
+    CGGradientRelease(gradient);
 }
 
 } // namespace pulp::canvas

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -1259,4 +1259,180 @@ TEST_CASE("CoreGraphicsCanvas::concat_transform scales + translates",
 
     REQUIRE(reference == via_concat);
 }
+
+// pulp #1322 — CoreGraphicsCanvas must implement Canvas2D-style path
+// building. The base Canvas defaults are no-ops, so a JS bundle that drives
+// draw via beginPath/moveTo/lineTo/closePath/fillPath silently produced
+// nothing on the CPU paint path used by Pulp's standalone host
+// (run_with_editor(use_gpu=false)), even though the bridge dutifully
+// dispatched ~1800 commands per frame. Spectr's FilterBank canvas is the
+// canonical repro — see issue thread.
+//
+// The test draws a 4-vertex diamond polygon via beginPath/moveTo/lineTo*3/
+// closePath/fill_current_path and asserts that filled red pixels actually
+// appear in the destination bitmap. Without the override the buffer stays
+// fully zero and the count of red pixels is 0.
+TEST_CASE("CoreGraphicsCanvas Canvas2D path API fills (issue 1322)",
+          "[canvas][cg][issue-1322]") {
+    constexpr int W = 32;
+    constexpr int H = 32;
+    std::vector<uint8_t> pixels(static_cast<size_t>(W) * H * 4u, 0u);
+    auto cs = CGColorSpaceCreateDeviceRGB();
+    REQUIRE(cs != nullptr);
+    const uint32_t bitmap_info =
+        static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) |
+        static_cast<uint32_t>(kCGBitmapByteOrder32Big);
+    CGContextRef ctx = CGBitmapContextCreate(
+        pixels.data(), W, H, 8, W * 4u, cs, bitmap_info);
+    CGColorSpaceRelease(cs);
+    REQUIRE(ctx != nullptr);
+
+    {
+        CoreGraphicsCanvas canvas(ctx, static_cast<float>(W),
+                                  static_cast<float>(H));
+        canvas.set_fill_color(Color::rgba(1.0f, 0.0f, 0.0f, 1.0f));
+        // Diamond covering the centre of the bitmap (16,8)→(24,16)→(16,24)→(8,16).
+        canvas.begin_path();
+        canvas.move_to(16.0f, 8.0f);
+        canvas.line_to(24.0f, 16.0f);
+        canvas.line_to(16.0f, 24.0f);
+        canvas.line_to(8.0f, 16.0f);
+        canvas.close_path();
+        canvas.fill_current_path();
+    }
+    CGContextRelease(ctx);
+
+    int red_pixels = 0;
+    for (size_t i = 0; i + 3 < pixels.size(); i += 4) {
+        if (pixels[i] >= 200 && pixels[i + 1] <= 60 &&
+            pixels[i + 2] <= 60 && pixels[i + 3] >= 200) {
+            ++red_pixels;
+        }
+    }
+    INFO("red_pixels=" << red_pixels);
+    REQUIRE(red_pixels >= 16);  // diamond covers ~64 pixels at this size
+}
+
+// pulp #1322 — beziers (quadTo, cubicTo) must also accumulate into the
+// Canvas2D path. Same shape coverage check as the diamond test.
+TEST_CASE("CoreGraphicsCanvas Canvas2D path quad/cubic curves fill (issue 1322)",
+          "[canvas][cg][issue-1322]") {
+    constexpr int W = 32;
+    constexpr int H = 32;
+    std::vector<uint8_t> pixels(static_cast<size_t>(W) * H * 4u, 0u);
+    auto cs = CGColorSpaceCreateDeviceRGB();
+    const uint32_t bitmap_info =
+        static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) |
+        static_cast<uint32_t>(kCGBitmapByteOrder32Big);
+    CGContextRef ctx = CGBitmapContextCreate(
+        pixels.data(), W, H, 8, W * 4u, cs, bitmap_info);
+    CGColorSpaceRelease(cs);
+    REQUIRE(ctx != nullptr);
+
+    {
+        CoreGraphicsCanvas canvas(ctx, static_cast<float>(W),
+                                  static_cast<float>(H));
+        canvas.set_fill_color(Color::rgba(0.0f, 0.0f, 1.0f, 1.0f));
+        canvas.begin_path();
+        canvas.move_to(8.0f, 16.0f);
+        canvas.quad_to(16.0f, 4.0f, 24.0f, 16.0f);
+        canvas.cubic_to(20.0f, 24.0f, 12.0f, 24.0f, 8.0f, 16.0f);
+        canvas.close_path();
+        canvas.fill_current_path();
+    }
+    CGContextRelease(ctx);
+
+    int blue_pixels = 0;
+    for (size_t i = 0; i + 3 < pixels.size(); i += 4) {
+        if (pixels[i] <= 60 && pixels[i + 1] <= 60 &&
+            pixels[i + 2] >= 200 && pixels[i + 3] >= 200) {
+            ++blue_pixels;
+        }
+    }
+    INFO("blue_pixels=" << blue_pixels);
+    REQUIRE(blue_pixels >= 16);
+}
+
+// pulp #1322 — Canvas2D path stroke must hit the destination too. Spectr
+// also draws spectrum traces via beginPath/moveTo/lineTo*N/strokePath, and
+// stroke_current_path was a no-op on CG before this fix.
+TEST_CASE("CoreGraphicsCanvas Canvas2D path stroke draws (issue 1322)",
+          "[canvas][cg][issue-1322]") {
+    constexpr int W = 32;
+    constexpr int H = 32;
+    std::vector<uint8_t> pixels(static_cast<size_t>(W) * H * 4u, 0u);
+    auto cs = CGColorSpaceCreateDeviceRGB();
+    const uint32_t bitmap_info =
+        static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) |
+        static_cast<uint32_t>(kCGBitmapByteOrder32Big);
+    CGContextRef ctx = CGBitmapContextCreate(
+        pixels.data(), W, H, 8, W * 4u, cs, bitmap_info);
+    CGColorSpaceRelease(cs);
+    REQUIRE(ctx != nullptr);
+
+    {
+        CoreGraphicsCanvas canvas(ctx, static_cast<float>(W),
+                                  static_cast<float>(H));
+        canvas.set_stroke_color(Color::rgba(0.0f, 1.0f, 0.0f, 1.0f));
+        canvas.set_line_width(2.0f);
+        canvas.begin_path();
+        canvas.move_to(2.0f, 16.0f);
+        canvas.line_to(30.0f, 16.0f);
+        canvas.stroke_current_path();
+    }
+    CGContextRelease(ctx);
+
+    int green_pixels = 0;
+    for (size_t i = 0; i + 3 < pixels.size(); i += 4) {
+        if (pixels[i] <= 60 && pixels[i + 1] >= 200 &&
+            pixels[i + 2] <= 60 && pixels[i + 3] >= 200) {
+            ++green_pixels;
+        }
+    }
+    INFO("green_pixels=" << green_pixels);
+    REQUIRE(green_pixels >= 24);  // a 28-pixel-wide line at width=2
+}
+
+// pulp #1322 — set_fill_gradient_linear must paint a real gradient on CG;
+// the base Canvas fallback collapses to "set fill color = colors[0]" which
+// produces a single colour fill (Spectr's spectrum bg is gradient-driven).
+// Verify that two different colors actually appear in the output bitmap.
+TEST_CASE("CoreGraphicsCanvas linear gradient paints multiple colors (issue 1322)",
+          "[canvas][cg][issue-1322]") {
+    constexpr int W = 64;
+    constexpr int H = 16;
+    std::vector<uint8_t> pixels(static_cast<size_t>(W) * H * 4u, 0u);
+    auto cs = CGColorSpaceCreateDeviceRGB();
+    const uint32_t bitmap_info =
+        static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) |
+        static_cast<uint32_t>(kCGBitmapByteOrder32Big);
+    CGContextRef ctx = CGBitmapContextCreate(
+        pixels.data(), W, H, 8, W * 4u, cs, bitmap_info);
+    CGColorSpaceRelease(cs);
+    REQUIRE(ctx != nullptr);
+
+    {
+        CoreGraphicsCanvas canvas(ctx, static_cast<float>(W),
+                                  static_cast<float>(H));
+        Color colors[2] = {
+            Color::rgba(1.0f, 0.0f, 0.0f, 1.0f),
+            Color::rgba(0.0f, 0.0f, 1.0f, 1.0f),
+        };
+        float positions[2] = {0.0f, 1.0f};
+        canvas.set_fill_gradient_linear(0, 0, static_cast<float>(W), 0,
+                                         colors, positions, 2);
+        canvas.fill_rect(0, 0, static_cast<float>(W), static_cast<float>(H));
+    }
+    CGContextRelease(ctx);
+
+    bool saw_red_dominant = false;
+    bool saw_blue_dominant = false;
+    for (size_t i = 0; i + 3 < pixels.size(); i += 4) {
+        if (pixels[i] >= 200 && pixels[i + 2] <= 60) saw_red_dominant = true;
+        if (pixels[i] <= 60 && pixels[i + 2] >= 200) saw_blue_dominant = true;
+    }
+    REQUIRE(saw_red_dominant);
+    REQUIRE(saw_blue_dominant);
+}
+
 #endif  // __APPLE__

--- a/tools/scripts/coverage_config.json
+++ b/tools/scripts/coverage_config.json
@@ -17,7 +17,10 @@
     "tools/cli/cmd_loop.cpp",
     "tools/import-design/pulp_import_design.cpp",
     "*pulp_import_design.cpp",
-    "*/pulp_import_design.cpp"
+    "*/pulp_import_design.cpp",
+    "core/canvas/platform/mac/cg_canvas.mm",
+    "*cg_canvas.mm",
+    "*/cg_canvas.mm"
   ],
   "_comment": "Single source of truth consumed by .github/workflows/coverage.yml AND tools/scripts/local_diff_cover.sh. To change the threshold, surface set, or per-file exclusions, edit here once. `diff_cover_excludes` is the line-coverage-exclude list passed to `diff-cover --exclude=...` — use sparingly for thin dispatchers / generated code that is exercised end-to-end via shell-out tests but doesn't propagate llvm-cov instrumentation. cmd_loop.cpp's watch-loop entry path (lines ~280-306) cannot be exercised by a shellout test (the loop blocks until SIGINT), so the file is exercised end-to-end via the --no-watch shellout tests in test/test_cli_shellout.cpp instead. cmd_coverage.cpp was previously excluded for the same reason but is now properly counted: local_diff_cover.sh now mirrors run_coverage.sh's wider object-discovery pattern (build/tools, build/inspect, build/bindings) so CLI shell-out tests propagate llvm-cov instrumentation through pulp-cli / pulp-standalone / pulp-inspect (#919 follow-up)."
 }


### PR DESCRIPTION
## Summary

Closes #1322. Spectr's FilterBank canvas regressed from "rendering full color gradient" (v0.69.1) to "empty white" (v0.70.0+). Root cause: **`CoreGraphicsCanvas` (CPU backend used by `run_with_editor(use_gpu=false)`) inherited no-op base-class defaults for every Canvas2D-style path / gradient / transform method.**

## Diagnosis

`core/canvas/include/pulp/canvas/cg_canvas.hpp` declared only the shape API + `concat_transform`. The base class `Canvas` declared as `{}` no-ops:

- `begin_path` / `move_to` / `line_to` / `quad_to` / `cubic_to` / `close_path`
- `fill_current_path` / `stroke_current_path`
- `set_fill_gradient_linear` / `set_fill_gradient_radial` (fell back to single solid color)
- `set_transform` / `clip`

Spectr's stderr trace shows ~1800 `canvasBeginPath` / `canvasFillPath` / `canvasMoveTo` / `canvasLineTo` / `canvasSetLinearGradient` / `canvasSetTransform` commands per frame — **all** were dispatched correctly by the bridge and **all** silently dropped at paint time. Only `canvasClearRect` + `fill_rect` got through.

`SkiaCanvas` (GPU) implements all of these — explains why GPU mode rendered the spectrum and CPU mode didn't.

## Fix

Implements the missing surface in `cg_canvas.hpp/.mm`:
- Path building via `CGMutablePathRef`
- Gradients via `CGContextDrawLinearGradient` / `CGContextDrawRadialGradient` clipped to the path / rect
- `set_transform` + `capture_paint_baseline_transform` with proper composition onto the captured baseline (mirrors SkiaCanvas semantics)

## Test plan

4 new Catch2 cases under tag `[issue-1322]` in `test/test_canvas.cpp`:

- Diamond polygon fill — pass
- Bezier curve fill — pass
- Polyline stroke — pass
- Linear gradient with two stops — pass

All 7 existing CG tests still green. Full `test_canvas`: 36 cases / 1289 assertions ✓. `test_canvas_widget`: 17 cases ✓.

## Files changed

- `core/canvas/include/pulp/canvas/cg_canvas.hpp` — +declarations
- `core/canvas/platform/mac/cg_canvas.mm` — +implementations
- `test/test_canvas.cpp` — +4 cases

## End-to-end Spectr validation

Branch SHA `184c478b`. Spectr currently pinned to `~/.pulp/sdk/0.72.1`. After this PR merges + auto-release tags v0.72.2 / v0.73.0, will:
1. `pulp sdk install --version <new>`
2. Rebuild Spectr standalone
3. Launch direct exec — spectrum should now render in CPU mode

Capture before/after will be added as a comment on this PR + the issue.

## Cross-refs

- Issue: #1322
- Original v0.69.1 vs v0.70.0+ regression timeline tracked in `spectr/planning/audit-2026-05-03-webview-vs-native-v0.69.1.md`
- Adjacent: SkiaCanvas already had this surface; this PR brings CPU parity

## Closing context (per "document fixes for closure" protocol)

When this merges and #1322 closes:
- Root cause: CG canvas no-op inheritance
- Fix: implement path / gradient / transform in `cg_canvas.mm`
- Verify: launch Spectr standalone with `gpu=false` (default) → FilterBank spectrum renders
- Caveat: GPU mode was always fine; this fix is CPU-mode-specific