### PR TITLE
fix(view): make overflow:visible hit_test extension symmetric on all 4 sides (pulp #1148 slice a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.72.1
+    VERSION 0.72.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/src/ui_components.cpp
+++ b/core/view/src/ui_components.cpp
@@ -608,11 +608,15 @@ View* ScrollView::hit_test(Point local_point) {
             Point child_point = {local_point.x + sx - child->bounds().x,
                                  local_point.y + sy - child->bounds().y};
 
+            // overflow:visible: expand hit area symmetrically on all four
+            // sides for popovers that extend in any direction (pulp #1148).
             bool in_bounds = child->local_bounds().contains(child_point);
             if (!in_bounds && child->overflow() == Overflow::visible) {
                 auto lb = child->local_bounds();
-                in_bounds = child_point.x >= lb.x && child_point.x <= lb.x + lb.width &&
-                            child_point.y >= lb.y && child_point.y <= lb.y + lb.height + 500;
+                in_bounds = child_point.x >= lb.x - 500 &&
+                            child_point.x <= lb.x + lb.width + 500 &&
+                            child_point.y >= lb.y - 500 &&
+                            child_point.y <= lb.y + lb.height + 500;
             }
 
             if (in_bounds) {

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -469,14 +469,19 @@ View* View::hit_test(Point local_point) {
             Point child_point = {local_point.x - child->bounds_.x,
                                 local_point.y - child->bounds_.y};
 
-            // For overflow:visible, expand the hit area to include content
-            // that extends beyond the child's bounds (e.g., dropdown menus)
+            // For overflow:visible, expand the hit area on all four sides
+            // to include content that extends beyond the child's bounds
+            // (e.g. dropdowns/popovers that grow downward, leftward, etc.).
+            // The 500px slack is symmetric so left-extending popovers
+            // (e.g. the Spectr bands picker) get hit-tested correctly —
+            // see pulp #1148 for the original right/down-only asymmetry.
             bool in_bounds = child->local_bounds().contains(child_point);
             if (!in_bounds && child->overflow() == Overflow::visible) {
-                // Allow hit testing up to 500px below the child (for dropdowns)
                 auto lb = child->local_bounds();
-                in_bounds = child_point.x >= lb.x && child_point.x <= lb.x + lb.width &&
-                        child_point.y >= lb.y && child_point.y <= lb.y + lb.height + 500;
+                in_bounds = child_point.x >= lb.x - 500 &&
+                            child_point.x <= lb.x + lb.width + 500 &&
+                            child_point.y >= lb.y - 500 &&
+                            child_point.y <= lb.y + lb.height + 500;
             }
 
             if (in_bounds) {

--- a/test/test_scroll_view.cpp
+++ b/test/test_scroll_view.cpp
@@ -153,3 +153,66 @@ TEST_CASE("ScrollView::hit_test box-none also suppresses scrollbar self-target (
     // and return self; box_none must suppress that.
     REQUIRE(sv.hit_test({195, 50}) == nullptr);
 }
+
+// ── pulp #1148 slice (a) — symmetric overflow:visible hit-test extension ──
+//
+// ScrollView::hit_test had the same right/down-only asymmetry as
+// View::hit_test. Lock the symmetric ±500px slack here too so left- or
+// up-extending popovers anchored inside a scroll container hit-test
+// correctly.
+//
+// Same fixture pattern as test_view.cpp: place a popover grandchild
+// outside an overflow:visible container in each direction, assert the
+// ScrollView routes the click into the popover via the symmetric slack.
+namespace {
+struct ScrollPopoverFixture {
+    ScrollView sv;
+    View* container{nullptr};
+    View* popover{nullptr};
+
+    ScrollPopoverFixture(float dx, float dy) {
+        sv.set_bounds({0, 0, 2000, 2000});
+        sv.set_content_size({2000, 2000});
+        auto c = std::make_unique<View>();
+        c->set_bounds({600, 600, 100, 100});
+        c->set_overflow(View::Overflow::visible);
+        container = c.get();
+
+        auto p = std::make_unique<View>();
+        p->set_bounds({dx, dy, 50, 50});
+        popover = p.get();
+        c->add_child(std::move(p));
+        sv.add_child(std::move(c));
+    }
+};
+} // namespace
+
+TEST_CASE("ScrollView::hit_test extends overflow:visible 500px to the LEFT",
+          "[scrollview][hit_test][issue-1148][overflow-symmetric]") {
+    ScrollPopoverFixture f(-200, 25);
+    REQUIRE(f.sv.hit_test({425, 650}) == f.popover);
+}
+
+TEST_CASE("ScrollView::hit_test extends overflow:visible 500px to the RIGHT",
+          "[scrollview][hit_test][issue-1148][overflow-symmetric]") {
+    ScrollPopoverFixture f(200, 25);
+    REQUIRE(f.sv.hit_test({825, 650}) == f.popover);
+}
+
+TEST_CASE("ScrollView::hit_test extends overflow:visible 500px UPWARD",
+          "[scrollview][hit_test][issue-1148][overflow-symmetric]") {
+    ScrollPopoverFixture f(25, -200);
+    REQUIRE(f.sv.hit_test({650, 425}) == f.popover);
+}
+
+TEST_CASE("ScrollView::hit_test extends overflow:visible 500px DOWNWARD",
+          "[scrollview][hit_test][issue-1148][overflow-symmetric]") {
+    ScrollPopoverFixture f(25, 200);
+    REQUIRE(f.sv.hit_test({650, 825}) == f.popover);
+}
+
+TEST_CASE("ScrollView::hit_test does NOT extend overflow:visible past 500px LEFT",
+          "[scrollview][hit_test][issue-1148][overflow-symmetric]") {
+    ScrollPopoverFixture f(-650, 25);
+    REQUIRE(f.sv.hit_test({0, 650}) != f.popover);
+}

--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -1421,3 +1421,86 @@ TEST_CASE("Window resize honors a fixed-size sibling next to a flex child "
     REQUIRE(toolbar_ptr->bounds().height == Catch::Approx(48.0f));
     REQUIRE(content_ptr->bounds().height == Catch::Approx(952.0f));
 }
+
+// ── pulp #1148 slice (a) — symmetric overflow:visible hit-test extension ──
+//
+// PR #1297 added overflow:visible hit-test extension so that absolutely-
+// positioned popovers / dropdowns whose content escapes their bounds box
+// still receive clicks. The original implementation only extended the box
+// 500px DOWNWARD, which broke left-extending popovers (e.g. Spectr's bands
+// picker that opens to the left of its trigger). This suite locks the
+// extension to ±500px on all four sides.
+//
+// Each direction places a "popover" grandchild positioned outside its
+// overflow:visible parent in the tested direction — overflow:visible
+// passes the click through to the parent's hit_test recursion, which
+// then matches the grandchild's local_bounds. Without symmetric slack,
+// the parent rejects the click before recursion happens for left/right/up.
+namespace {
+struct PopoverFixture {
+    View root;
+    View* container{nullptr};   // overflow:visible host
+    View* popover{nullptr};     // grandchild positioned outside container
+
+    // dx/dy are the popover's offset *relative to the container's local
+    // origin* — negative values escape the container in the −x/−y direction.
+    PopoverFixture(float dx, float dy) {
+        root.set_bounds({0, 0, 2000, 2000});
+        auto c = std::make_unique<View>();
+        c->set_bounds({600, 600, 100, 100});
+        c->set_overflow(View::Overflow::visible);
+        container = c.get();
+
+        auto p = std::make_unique<View>();
+        // 50x50 popover anchored at (dx, dy) inside container's local space.
+        p->set_bounds({dx, dy, 50, 50});
+        popover = p.get();
+        c->add_child(std::move(p));
+        root.add_child(std::move(c));
+    }
+};
+} // namespace
+
+TEST_CASE("View::hit_test extends overflow:visible 500px to the LEFT",
+          "[view][hit_test][issue-1148][overflow-symmetric]") {
+    // Popover at container-local (-200, 25) → root-space (400..450, 625..675).
+    // 100px to the LEFT of container.x=600 covers root.x = 425.
+    PopoverFixture f(-200, 25);
+    REQUIRE(f.root.hit_test({425, 650}) == f.popover);
+}
+
+TEST_CASE("View::hit_test extends overflow:visible 500px to the RIGHT",
+          "[view][hit_test][issue-1148][overflow-symmetric]") {
+    // Popover at container-local (200, 25) → root-space (800..850, 625..675).
+    // 100px to the RIGHT of container.right=700 covers root.x = 825.
+    PopoverFixture f(200, 25);
+    REQUIRE(f.root.hit_test({825, 650}) == f.popover);
+}
+
+TEST_CASE("View::hit_test extends overflow:visible 500px UPWARD",
+          "[view][hit_test][issue-1148][overflow-symmetric]") {
+    // Popover at container-local (25, -200) → root-space (625..675, 400..450).
+    // 100px ABOVE container.y=600 covers root.y = 425.
+    PopoverFixture f(25, -200);
+    REQUIRE(f.root.hit_test({650, 425}) == f.popover);
+}
+
+TEST_CASE("View::hit_test extends overflow:visible 500px DOWNWARD",
+          "[view][hit_test][issue-1148][overflow-symmetric]") {
+    // Popover at container-local (25, 200) → root-space (625..675, 800..850).
+    // 100px BELOW container.bottom=700 covers root.y = 825.
+    // This direction was already supported pre-#1148 — guards regression.
+    PopoverFixture f(25, 200);
+    REQUIRE(f.root.hit_test({650, 825}) == f.popover);
+}
+
+TEST_CASE("View::hit_test does NOT extend overflow:visible past 500px LEFT",
+          "[view][hit_test][issue-1148][overflow-symmetric]") {
+    // Popover anchored 600px LEFT of container — outside the symmetric
+    // ±500px slack, so the click must miss the popover entirely. With
+    // container x=600, popover at container-local x=-650 lands at
+    // root.x = -50..0; we probe root.x = 0 → container-local x = -600,
+    // beyond the -500 slack.
+    PopoverFixture f(-650, 25);
+    REQUIRE(f.root.hit_test({0, 650}) != f.popover);
+}


### PR DESCRIPTION
## Summary

Closes pulp #1148 slice (a). The existing `overflow: visible` hit_test extension in `View::hit_test` (and the mirrored copy in `ScrollView::hit_test`) only extended **500px DOWNWARD** from a child's bounds. That worked for popovers that drop down (e.g. menus opening below their trigger), but **left-extending popovers fell through** because the extension didn't cover the left edge — Spectr's bands picker is the canonical victim.

## Fix

Make the slack symmetric on all 4 sides: the hit-test extension now reaches `±500px` left, right, up, and down from the child's local bounds.

```cpp
// before:
in_bounds = child_point.x >= lb.x && child_point.x <= lb.x + lb.width &&
            child_point.y >= lb.y && child_point.y <= lb.y + lb.height + 500;

// after:
in_bounds = child_point.x >= lb.x - 500 && child_point.x <= lb.x + lb.width + 500 &&
            child_point.y >= lb.y - 500 && child_point.y <= lb.y + lb.height + 500;
```

Applied in both `core/view/src/view.cpp::View::hit_test` and `core/view/src/ui_components.cpp::ScrollView::hit_test`.

## Tests

10 new cases tagged `[issue-1148][overflow-symmetric]` (5 per surface):
- Click 100px **left** of child → hits child
- Click 100px **right** of child → hits child
- Click 100px **above** child → hits child
- Click 100px **below** child → hits child (was already passing)
- Click 600px outside (beyond ±500) → does NOT hit

Full suites still green: `pulp-test-view` (54 cases / 241 assertions), `pulp-test-scroll-view` (15 cases / 19 assertions).

## Subtle gotcha worth noting

`child_point` is in the child's local space; the slack-check is anchored at (0,0). The slack only opens the door for **descendant recursion** — placing popover content directly inside the overflow:visible child wouldn't hit; it has to be a positioned grandchild. Mirrors Spectr's actual JSX shape.

## Cross-refs

- Audit: #1148
- Sibling: #1148(b) auto-overlay from CSS — separate PR (pulp-side)
- Sibling: #1147 popover row template — separate PR (pulp-side)
- Sibling: #1323 CSS `:hover` translation — separate PR (pulp-side)