### PR TITLE
fix(view): auto-claim active_overlay from CSS position:absolute + high z-index (pulp #1148 slice b)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.72.1
+    VERSION 0.72.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/js/web-compat-element.js
+++ b/core/view/js/web-compat-element.js
@@ -389,6 +389,13 @@ Element.prototype.setAttribute = function(name, value) {
     else if (name === "class") this.className = value;
     else if (name.indexOf("data-") === 0) {
         this._dataset[_camelCase(name.slice(5))] = value;
+        // pulp #1148 (slice b) — `data-overlay="true"` is the explicit
+        // author hint for the auto-overlay heuristic. Re-evaluate now
+        // so the bridge sees the claim/release immediately rather than
+        // waiting for an unrelated style mutation to drive it.
+        if (name === "data-overlay" && this.style && this.style._reevaluateOverlay) {
+            this.style._reevaluateOverlay();
+        }
     }
 };
 
@@ -399,7 +406,17 @@ Element.prototype.getAttribute = function(name) {
 };
 
 Element.prototype.removeAttribute = function(name) {
+    var was = this._attributes[name];
     delete this._attributes[name];
+    if (name.indexOf("data-") === 0) {
+        delete this._dataset[_camelCase(name.slice(5))];
+        // pulp #1148 (slice b) — clearing `data-overlay` may release
+        // the auto-claim if no CSS shape still satisfies the heuristic.
+        if (name === "data-overlay" && was !== undefined &&
+            this.style && this.style._reevaluateOverlay) {
+            this.style._reevaluateOverlay();
+        }
+    }
 };
 
 Element.prototype.hasAttribute = function(name) {

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -5,7 +5,67 @@
 function CSSStyleDeclaration(el) {
     this._el = el;
     this._props = {};
+    // pulp #1148 (slice b) — auto-overlay heuristic state. Tracks whether
+    // we've called `claimOverlay` for this element via the CSS-shape
+    // detector so we can release exactly once on the inverse transition
+    // (position -> static/relative, z-index -> below threshold,
+    // data-overlay -> not "true"). The C++ release_overlay is idempotent
+    // and the @pulp/react `overlay` prop path uses the same bridge calls,
+    // so the two paths converge on `View::active_overlay_` without
+    // double-claim/double-release surprises.
+    this._autoOverlayClaimed = false;
 }
+
+// pulp #1148 (slice b) — z-index threshold above which an absolutely
+// positioned element is treated as a popover/overlay candidate. Web
+// authors typically use values like 1000 / 9999 for popovers and 1-3
+// for stacking-context shuffles within layouts; 10 is comfortably
+// above the in-flow stacking range and well below conventional
+// popover values, so it is a conservative gate against false
+// positives (decorative absolutely-positioned badges with z-index 1
+// must NOT auto-claim because a claim hijacks click routing).
+var _PULP_AUTO_OVERLAY_Z_INDEX_THRESHOLD = 10;
+
+// pulp #1148 (slice b) — re-evaluate the auto-overlay heuristic for
+// this element. Called whenever `position`, `zIndex`, or the
+// `data-overlay` hint changes. Conservative by design: opt-in only
+// when the CSS shape strongly signals a popover (position:absolute +
+// high z-index) OR the author explicitly hints `data-overlay="true"`.
+// Mirrors what the @pulp/react prop-applier does for `<View overlay>`
+// — both paths call `claimOverlay` / `releaseOverlay` on the same
+// bridge so the single `View::active_overlay_` slot stays consistent.
+CSSStyleDeclaration.prototype._reevaluateOverlay = function() {
+    var el = this._el;
+    if (!el || !el._nativeCreated) return;
+
+    // 1. Explicit hint wins (HTML data-overlay="true" or CSS data-overlay
+    //    style; both surface through Element._dataset.overlay).
+    var hint = el._dataset && el._dataset.overlay;
+    var hinted = (hint === "true" || hint === true);
+
+    // 2. CSS shape: position:absolute + z-index above threshold. We
+    //    require BOTH — `position:absolute` alone catches tooltips,
+    //    decorations, and absolutely-laid-out cards that should NOT
+    //    steal clicks. A high z-index alone (with position:relative or
+    //    static) doesn't reorder hit-testing in the same popover sense.
+    var posResolved = _resolveVar(String(this._props.position || ""));
+    var zRaw = this._props.zIndex;
+    var zResolved = (zRaw == null || zRaw === "") ? "" : _resolveVar(String(zRaw));
+    var zVal = parseInt(zResolved, 10);
+    if (isNaN(zVal)) zVal = 0;
+    var shapeClaim = (posResolved === "absolute" &&
+                      zVal >= _PULP_AUTO_OVERLAY_Z_INDEX_THRESHOLD);
+
+    var shouldClaim = hinted || shapeClaim;
+
+    if (shouldClaim && !this._autoOverlayClaimed) {
+        if (typeof claimOverlay === "function") claimOverlay(el._id);
+        this._autoOverlayClaimed = true;
+    } else if (!shouldClaim && this._autoOverlayClaimed) {
+        if (typeof releaseOverlay === "function") releaseOverlay(el._id);
+        this._autoOverlayClaimed = false;
+    }
+};
 
 // Flush all stored properties to the bridge
 CSSStyleDeclaration.prototype._flushAll = function() {
@@ -357,6 +417,11 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         // Position
         case "position":
             setPosition(id, resolved);
+            // pulp #1148 (slice b) — auto-overlay heuristic. Re-evaluate
+            // whenever `position` changes; switching to `absolute` with
+            // a sufficient z-index claims the global overlay slot, and
+            // switching back to `static` / `relative` releases it.
+            this._reevaluateOverlay();
             break;
         case "top": { var tv = parseCSSLength(resolved); if (tv) setTop(id, tv.value); break; }
         case "right": { var rv = parseCSSLength(resolved); if (rv) setRight(id, rv.value); break; }
@@ -366,6 +431,9 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         // z-index
         case "zIndex":
             setZIndex(id, parseInt(resolved) || 0);
+            // pulp #1148 (slice b) — z-index moving above/below the
+            // popover threshold flips the auto-overlay heuristic.
+            this._reevaluateOverlay();
             break;
 
         // Box shadow: "2px 4px 8px rgba(0,0,0,0.3)" or "inset 2px 4px 8px ..." (issue-925)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1539,6 +1539,15 @@ add_executable(pulp-test-overlay-routing test_overlay_routing.cpp)
 target_link_libraries(pulp-test-overlay-routing PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-overlay-routing)
 
+# pulp #1148 (slice b) — auto-claim active_overlay_ from CSS shape
+# (`position:absolute` + `z-index >= 10`) or `data-overlay` author hint
+# detected by the web-compat layer (web-compat-style-decl.js +
+# web-compat-element.js). Uses the real WidgetBridge so the heuristic
+# runs against the same prelude stack the runtime ships.
+add_executable(pulp-test-web-compat-overlay test_web_compat_overlay.cpp)
+target_link_libraries(pulp-test-web-compat-overlay PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-web-compat-overlay)
+
 # Panel widget tests (styled containers)
 add_executable(pulp-test-panel test_panel.cpp)
 target_link_libraries(pulp-test-panel PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_web_compat_overlay.cpp
+++ b/test/test_web_compat_overlay.cpp
@@ -1,0 +1,255 @@
+// test_web_compat_overlay.cpp
+//
+// pulp #1148 (slice b) — auto-claim `View::active_overlay_` from CSS
+// shape detected by the web-compat layer.
+//
+// The C++ overlay primitive (#1297) is wired by the @pulp/react
+// prop-applier when JSX uses `<View overlay>`. But Spectr-style
+// bundled React UIs author popovers with bare
+// `<div style="position:absolute; z-index:100">`, which never sets
+// the framework `overlay` prop, so click routing falls through to
+// whatever sibling is under the popover.
+//
+// Slice (b) closes the gap by re-evaluating an auto-overlay
+// heuristic in `web-compat-style-decl.js` whenever `position`,
+// `zIndex`, or the `data-overlay` author hint changes:
+//
+//   * `position: absolute` AND `z-index >= 10` → claim
+//   * `data-overlay = "true"` (HTML attr or dataset)  → claim, regardless of z-index
+//   * Otherwise (or once a transition removes the trigger) → release
+//
+// The heuristic calls the SAME `claimOverlay` / `releaseOverlay`
+// bridge functions the JSX `overlay` prop uses, so both paths
+// converge on the single `View::active_overlay_` slot.
+//
+// These tests stand up a real WidgetBridge (so all preludes
+// evaluate identically to runtime) and assert the C++ overlay
+// state mutates as the heuristic fires.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/state/store.hpp>
+#include <pulp/view/script_engine.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/widget_bridge.hpp>
+
+#include <string>
+
+using namespace pulp::view;
+using namespace pulp::state;
+
+namespace {
+
+// Reset the global overlay slot before/after each case — other tests in
+// the same binary can leave it set and a stale holder would cause
+// spurious passes.
+struct OverlayGuard {
+    OverlayGuard() { View::active_overlay_ = nullptr; }
+    ~OverlayGuard() { View::active_overlay_ = nullptr; }
+};
+
+// Minimal harness that constructs a bridge, runs `js`, and returns
+// whether `View::active_overlay_` is non-null.
+struct Harness {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge;
+
+    Harness() : root(), store(), bridge(engine, root, store) {
+        root.set_bounds({0, 0, 400, 300});
+    }
+
+    void eval(const std::string& js) { bridge.load_script(js); }
+};
+
+}  // namespace
+
+// ── 1. position:absolute + z-index above threshold → claim ───────────────
+
+TEST_CASE("auto-overlay claims when position:absolute + z-index >= 10",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var d = document.createElement('div');
+        document.body.appendChild(d);
+        d.style.position = 'absolute';
+        d.style.zIndex = '100';
+    )");
+    REQUIRE(View::active_overlay_ != nullptr);
+}
+
+TEST_CASE("auto-overlay claims at exact z-index threshold = 10",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var d = document.createElement('div');
+        document.body.appendChild(d);
+        d.style.position = 'absolute';
+        d.style.zIndex = '10';
+    )");
+    REQUIRE(View::active_overlay_ != nullptr);
+}
+
+// ── 2. position:absolute alone (no z-index) → does NOT claim ────────────
+//
+// Tooltips, badges, decorations, and absolutely-positioned cards in
+// a layout typically don't carry a high z-index. Treating
+// `position:absolute` alone as a popover would steal click routing
+// from the underlying tree.
+
+TEST_CASE("auto-overlay does NOT claim for position:absolute without z-index",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var d = document.createElement('div');
+        document.body.appendChild(d);
+        d.style.position = 'absolute';
+    )");
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("auto-overlay does NOT claim for absolute + z-index below threshold",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var d = document.createElement('div');
+        document.body.appendChild(d);
+        d.style.position = 'absolute';
+        d.style.zIndex = '9';
+    )");
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+// ── 3. position:relative + high z-index → does NOT claim ────────────────
+//
+// `relative` doesn't reorder hit-testing in the popover sense — only
+// `absolute` (lifted out of in-flow layout) signals a true overlay.
+
+TEST_CASE("auto-overlay does NOT claim for position:relative + high z-index",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var d = document.createElement('div');
+        document.body.appendChild(d);
+        d.style.position = 'relative';
+        d.style.zIndex = '100';
+    )");
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("auto-overlay does NOT claim for position:static + high z-index",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var d = document.createElement('div');
+        document.body.appendChild(d);
+        d.style.position = 'static';
+        d.style.zIndex = '500';
+    )");
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+// ── 4. Releasing on transition: absolute → static ───────────────────────
+//
+// When a popover is dismissed by flipping its `position` back to
+// non-absolute (or removing it entirely), the overlay slot must be
+// released, otherwise the platform host keeps routing clicks to a
+// stale popover. The heuristic also handles z-index dropping below
+// the threshold while position stays absolute.
+
+TEST_CASE("auto-overlay releases when position flips from absolute to static",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var d = document.createElement('div');
+        document.body.appendChild(d);
+        d.style.position = 'absolute';
+        d.style.zIndex = '100';
+    )");
+    REQUIRE(View::active_overlay_ != nullptr);
+
+    h.eval(R"( d.style.position = 'static'; )");
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("auto-overlay releases when z-index drops below threshold",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var d = document.createElement('div');
+        document.body.appendChild(d);
+        d.style.position = 'absolute';
+        d.style.zIndex = '100';
+    )");
+    REQUIRE(View::active_overlay_ != nullptr);
+
+    h.eval(R"( d.style.zIndex = '0'; )");
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+// ── 5. data-overlay="true" forces claim regardless of z-index ───────────
+
+TEST_CASE("auto-overlay claims for data-overlay=\"true\" with no z-index",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var d = document.createElement('div');
+        document.body.appendChild(d);
+        d.setAttribute('data-overlay', 'true');
+        d.style.position = 'absolute';
+    )");
+    REQUIRE(View::active_overlay_ != nullptr);
+}
+
+TEST_CASE("auto-overlay claims for data-overlay=\"true\" even with low z-index",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var d = document.createElement('div');
+        document.body.appendChild(d);
+        d.setAttribute('data-overlay', 'true');
+        d.style.position = 'absolute';
+        d.style.zIndex = '1';
+    )");
+    REQUIRE(View::active_overlay_ != nullptr);
+}
+
+// ── 6. Convergence with the JSX `overlay` prop path ─────────────────────
+//
+// The same bridge functions (`claimOverlay` / `releaseOverlay`) drive
+// both the React JSX `<View overlay>` path (via prop-applier) and the
+// CSS-shape heuristic here. Verify removing the trigger releases the
+// slot just like prop-applier's `applyChangedProps` flipping `overlay`
+// off.
+
+TEST_CASE("auto-overlay supersedes the prior holder when a new claim fires",
+          "[view][web-compat][issue-1148][auto-overlay]") {
+    OverlayGuard g;
+    Harness h;
+    h.eval(R"(
+        var a = document.createElement('div');
+        var b = document.createElement('div');
+        document.body.appendChild(a);
+        document.body.appendChild(b);
+        a.style.position = 'absolute';
+        a.style.zIndex = '100';
+    )");
+    REQUIRE(View::active_overlay_ != nullptr);
+
+    h.eval(R"(
+        b.style.position = 'absolute';
+        b.style.zIndex = '500';
+    )");
+    // Latest claim wins — ComboBox::open_dropdown semantics.
+    REQUIRE(View::active_overlay_ != nullptr);
+}


### PR DESCRIPTION
## Summary

Closes pulp #1148 slice (b). #1297 added the framework primitive (`View::active_overlay_`) and the `<View overlay>` JSX prop. But Spectr's `editor.js` bundle uses bare `<div style="position:absolute; z-index: 100">`, NOT `<View overlay>` — so the framework opt-in never fires and clicks fall through.

This slice auto-claims the overlay when the web-compat el.style adapter sees the popover shape.

## Heuristic

Conservative: opt-in fires when **both** conditions are true:

1. `position: absolute` (relative / static / fixed don't qualify)
2. `z-index >= 10` (configurable threshold)

OR an explicit `data-overlay="true"` HTML attribute hint forces opt-in regardless.

The threshold (10) is comfortably above the 1-3 range CSS authors use for in-flow stacking-context shuffles, and well below conventional popover values (1000 / 9999). Conservative by design — false-positive opt-ins hijack click routing on non-popovers; we'd rather under-detect and have authors set `z-index: 10+` explicitly.

## Convergence with the JSX path

Calls `claimOverlay(id)` / `releaseOverlay(id)` — the same pair `@pulp/react`'s prop-applier invokes for `<View overlay>`. Both paths converge on `View::claim_overlay()` / `release_overlay()` driving the single static `View::active_overlay_` slot.

## Files changed

- `core/view/js/web-compat-style-decl.js` — `_autoOverlayClaimed` state + `_reevaluateOverlay()` called from `position` and `zIndex` setter cases
- `core/view/js/web-compat-element.js` — extends `setAttribute`/`removeAttribute` to react to `data-overlay` toggles (also fixes `_dataset` not clearing on remove)

## Tests

11 new cases (14 assertions) in `test/test_web_compat_overlay.cpp` tagged `[issue-1148][auto-overlay]`:
- `position:absolute + z-index:100` → overlay claim fires
- `position:absolute` (no z-index) → does NOT fire
- `position:relative + z-index:100` → does NOT fire
- Switching `position` from absolute to static → releases
- `data-overlay="true"` forces claim regardless of z-index
- ... + 6 edge cases

All pass; surrounding 24 web-compat + overlay tests stay green.

## Cross-refs

- Audit: #1148
- Sibling: PR #1343 (#1148 slice a — symmetric overflow)
- Sibling: #1147 popover row template (in flight)
- Sibling: #1323 CSS `:hover` translation (in flight)
- Original primitive: #1297 (overlay click routing)