### PR TITLE
fix(view/skia): shape fills honor active gradient_shader_ (closes #1350)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.72.2
+    VERSION 0.72.3
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -167,6 +167,11 @@ public:
                     float opacity, float blur_radius) override;
 
 private:
+    // Build the active fill paint, honoring `gradient_shader_` when set
+    // so shape fills (rect / rrect / circle / arc / oval / polygon) render
+    // gradients consistently with `fill_current_path()` (#1350).
+    SkPaint current_fill_paint() const;
+
     SkCanvas* canvas_;        // Non-owning — owned by surface or caller
     skgpu::graphite::Recorder* recorder_ = nullptr; // Non-owning — owned by SkiaSurface
     Color fill_color_ = Color::rgba(1.0f, 1.0f, 1.0f);

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -88,7 +88,9 @@ static SkColor4f to_sk_color4f(Color c) {
     return {c.r, c.g, c.b, c.a};
 }
 
-static SkPaint make_fill_paint(Color c) {
+// Solid-color fill paint. For shape fills that should honor an active
+// gradient, prefer SkiaCanvas::current_fill_paint() — see #1350.
+static SkPaint make_solid_fill_paint(Color c) {
     SkPaint paint;
     paint.setColor4f(to_sk_color4f(c));
     paint.setStyle(SkPaint::kFill_Style);
@@ -289,6 +291,25 @@ void SkiaCanvas::clip() {
     canvas_->clipPath(path_builder_->snapshot(), /*doAntiAlias=*/true);
 }
 
+// pulp #1350 — single source of truth for shape-fill paints. Mirrors
+// `fill_current_path()` so a gradient set via `set_fill_gradient_*`
+// is honored by every shape helper (rect / rrect / circle / arc /
+// oval / polygon), not just path fills. The free `make_solid_fill_paint`
+// remains for paths that intentionally want a solid color regardless
+// of the active gradient (text glyphs today).
+SkPaint SkiaCanvas::current_fill_paint() const {
+    SkPaint paint;
+    paint.setStyle(SkPaint::kFill_Style);
+    paint.setAntiAlias(true);
+    paint.setBlendMode(blend_mode_);
+    if (has_gradient_ && gradient_shader_) {
+        paint.setShader(gradient_shader_);
+    } else {
+        paint.setColor4f(to_sk_color4f(fill_color_));
+    }
+    return paint;
+}
+
 void SkiaCanvas::set_fill_color(Color c) { fill_color_ = c; }
 void SkiaCanvas::set_stroke_color(Color c) { stroke_color_ = c; }
 void SkiaCanvas::set_line_width(float w) { line_width_ = w; }
@@ -302,7 +323,7 @@ void SkiaCanvas::set_line_join(LineJoin join) {
 }
 
 void SkiaCanvas::fill_rect(float x, float y, float w, float h) {
-    GUARD_CANVAS; canvas_->drawRect(SkRect::MakeXYWH(x, y, w, h), make_fill_paint(fill_color_));
+    GUARD_CANVAS; canvas_->drawRect(SkRect::MakeXYWH(x, y, w, h), current_fill_paint());
 }
 
 // pulp #929 — clearRect must actually clear pixels rather than compose a
@@ -342,7 +363,7 @@ void SkiaCanvas::stroke_rect(float x, float y, float w, float h) {
 void SkiaCanvas::fill_rounded_rect(float x, float y, float w, float h, float radius) {
     GUARD_CANVAS; SkRRect rrect;
     rrect.setRectXY(SkRect::MakeXYWH(x, y, w, h), radius, radius);
-    canvas_->drawRRect(rrect, make_fill_paint(fill_color_));
+    canvas_->drawRRect(rrect, current_fill_paint());
 }
 
 void SkiaCanvas::stroke_rounded_rect(float x, float y, float w, float h, float radius) {
@@ -354,7 +375,7 @@ void SkiaCanvas::stroke_rounded_rect(float x, float y, float w, float h, float r
 }
 
 void SkiaCanvas::fill_circle(float cx, float cy, float radius) {
-    GUARD_CANVAS; canvas_->drawCircle(cx, cy, radius, make_fill_paint(fill_color_));
+    GUARD_CANVAS; canvas_->drawCircle(cx, cy, radius, current_fill_paint());
 }
 
 void SkiaCanvas::stroke_circle(float cx, float cy, float radius) {
@@ -419,7 +440,9 @@ void SkiaCanvas::fill_text(const std::string& text, float x, float y) {
     SkFont font = make_font(font_family_, font_size_, font_weight_, font_slant_);
     if (!font.getTypeface()) return;
 
-    auto paint = make_fill_paint(fill_color_);
+    // Text glyphs use solid color today; gradient text-fill is a separate
+    // Canvas2D `fillText` path (#1350 scoped to shape fills only).
+    auto paint = make_solid_fill_paint(fill_color_);
 
 #ifdef PULP_HAS_TEXT_SHAPING
     // SkShaper path: full OpenType kerning + ligatures via HarfBuzz.
@@ -560,7 +583,9 @@ void SkiaCanvas::fill_text_sdf(const std::string& text, float x, float y,
     // Draw each glyph as a textured quad with the SDF alpha channel.
     // The smoothstep is applied per-pixel by Skia's shader pipeline
     // when we use kAlpha_8 — we just draw with the fill color's paint.
-    auto paint = make_fill_paint(fill_color_);
+    // Text glyphs use solid color today; gradient text-fill is a separate
+    // Canvas2D `fillText` path (#1350 scoped to shape fills only).
+    auto paint = make_solid_fill_paint(fill_color_);
     for (auto& [g, x_off] : draws) {
         float gx = draw_x + x_off + g->bearing_x * scale;
         float gy = y - g->bearing_y * scale;

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -1018,6 +1018,53 @@ TEST_CASE("Unregistered families don't resolve through the registry (#1150)",
         "/this/path/does/not/exist/font.ttf", "AlsoAnything"));
 }
 
+// pulp #1350 — fill_rect / fill_rounded_rect / fill_circle on SkiaCanvas
+// must honor an active linear gradient set via set_fill_gradient_linear,
+// matching the behavior of fill_current_path. Pre-fix the rect-family
+// helpers all went through a free `make_fill_paint(Color)` that only
+// knew about the solid fill color, so a Canvas2D consumer that called
+// `ctx.fillStyle = ctx.createLinearGradient(...); ctx.fillRect(...)`
+// got a flat first-stop color instead of the gradient.
+TEST_CASE("SkiaCanvas::fill_rect honors active linear gradient",
+          "[canvas][skia][gradient][issue-1350]") {
+    constexpr int kW = 64;
+    constexpr int kH = 8;
+    SkImageInfo info = SkImageInfo::Make(kW, kH, kN32_SkColorType,
+                                         kPremul_SkAlphaType,
+                                         SkColorSpace::MakeSRGB());
+    auto surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    auto* sk_canvas = surface->getCanvas();
+    REQUIRE(sk_canvas != nullptr);
+    sk_canvas->clear(SK_ColorBLACK);
+
+    SkiaCanvas canvas(sk_canvas);
+
+    Color stops[2] = {
+        Color::rgba(1.0f, 0.0f, 0.0f, 1.0f),  // red at x=0
+        Color::rgba(0.0f, 1.0f, 0.0f, 1.0f),  // green at x=kW
+    };
+    float positions[2] = {0.0f, 1.0f};
+    canvas.set_fill_gradient_linear(0.0f, 0.0f,
+                                     static_cast<float>(kW), 0.0f,
+                                     stops, positions, 2);
+    canvas.fill_rect(0.0f, 0.0f,
+                     static_cast<float>(kW), static_cast<float>(kH));
+
+    // Read back two pixels at the gradient endpoints. If the rect ignored
+    // the gradient and used the solid fill_color_ default, both pixels
+    // would be identical white. With the fix they must differ — and the
+    // left pixel must skew red while the right pixel skews green.
+    SkPixmap pm;
+    REQUIRE(surface->peekPixels(&pm));
+    SkColor left = pm.getColor(2, kH / 2);
+    SkColor right = pm.getColor(kW - 3, kH / 2);
+
+    REQUIRE(left != right);
+    REQUIRE(SkColorGetR(left)  > SkColorGetG(left));   // left is red-dominant
+    REQUIRE(SkColorGetG(right) > SkColorGetR(right));  // right is green-dominant
+}
+
 #endif  // PULP_HAS_SKIA
 
 // ── pulp #929 — Canvas::clear_rect default + CoreGraphics override ──────────


### PR DESCRIPTION
## Summary

Closes pulp #1350 (filed today during #1346 investigation). `SkiaCanvas`'s shape helpers (`fill_rect`, `fill_rounded_rect`, `fill_circle`) silently dropped an active gradient set via `set_fill_gradient_linear` / `radial` / `conic`. Path fills (`fill_current_path`) already honored the gradient, so the bug was a consistency gap between two paint paths.

## Root cause

`core/canvas/src/skia_canvas.cpp:91-97` was a free function that only consumed a solid `Color`. `fill_current_path()` at line 871 already had the correct gradient-aware logic. The fix lifts that logic into a `SkiaCanvas::current_fill_paint()` member so all shape helpers share one source of truth.

## Fix

- New `SkiaCanvas::current_fill_paint()` member. Consults `has_gradient_` / `gradient_shader_` / `blend_mode_` / `fill_color_`.
- `fill_rect`, `fill_rounded_rect`, `fill_circle` now call `current_fill_paint()`.
- Text glyph paths (`fill_text` non-SDF + SDF) keep using the renamed `make_solid_fill_paint(Color)`. Gradient text-fill is a separate Canvas2D concern that needs additional work in both rasterized and SDF text paths.

## Test plan

- [x] `test_canvas.cpp::"SkiaCanvas::fill_rect honors active linear gradient"` — sets red→green linear gradient, fills a 64×8 rect, reads back two pixels at the endpoints. Pre-fix: identical solid color (failing). Post-fix: left pixel red-dominant, right pixel green-dominant.
- [x] All 1279 non-Skia canvas assertions still pass locally.
- [ ] Local PULP_HAS_SKIA build wasn't enabled in this worktree, so the gradient test is exercised by the existing CI macOS/Linux/Windows + Coverage matrix where Skia is built. CI is the authoritative validation.

## Cross-refs

- #1346 GPU FilterBank (separate root cause: missing JS shim methods, fixed by #1348).
- #1322 / #1329 CG-canvas counterpart (#1329 fixed CG path/gradient).

Closes #1350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)