### PR TITLE
chore: bump SDK to v0.72.4 — catch-up tag for #1348 GPU FilterBank fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.72.3
+    VERSION 0.72.4
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C


### PR DESCRIPTION
## Summary

Catch-up bump to land a release tag for #1348 (GPU FilterBank Canvas2D shim fix, merged to main but not tagged).

## Why

#1348 was opened with a chore commit bumping to v0.72.3. By the time it landed, #1329 had already merged and bumped main to v0.72.3. auto-release.yml saw no version change → didn't dispatch → no v0.72.4 tag was created. #1348's content sits on main at the v0.72.3 commit but is not in any release.

Spectr is waiting for a release that contains #1348 to bump its SDK pin and unblock GPU-mode FilterBank rendering.

## Test plan

- [x] One-line bump: 0.72.3 → 0.72.4 in `CMakeLists.txt`.
- [ ] CI green (no source changes — should pass everything).
- [ ] On merge, auto-release.yml dispatches a tag for v0.72.4.
- [ ] Spectr-side: bump SDK pin to v0.72.4 to consume #1348.

## Notes

This is a chore commit, no functional change. The only diff is a single integer bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)