### PR TITLE
fix(canvas/mac): shape fills honor active gradient (closes pulp #1359)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.72.4
+    VERSION 0.72.5
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/platform/mac/cg_canvas.mm
+++ b/core/canvas/platform/mac/cg_canvas.mm
@@ -213,6 +213,17 @@ void CoreGraphicsCanvas::add_rounded_rect_path(float x, float y, float w, float 
 
 void CoreGraphicsCanvas::fill_rounded_rect(float x, float y, float w, float h, float radius) {
     add_rounded_rect_path(x, y, w, h, radius);
+    // pulp #1359 — gate on has_gradient_ so the active gradient paints the
+    // rounded rect, mirroring fill_rect / fill_current_path. Without this,
+    // a gradient set via set_fill_gradient_linear/_radial silently dropped
+    // back to apply_fill_color() (Spectr's CPU-mode FilterBank backplate).
+    if (has_gradient_) {
+        CGContextSaveGState(ctx_);
+        CGContextClip(ctx_);  // clip to the path we just built
+        fill_with_active_paint();
+        CGContextRestoreGState(ctx_);
+        return;
+    }
     apply_fill_color();
     CGContextFillPath(ctx_);
 }
@@ -224,8 +235,21 @@ void CoreGraphicsCanvas::stroke_rounded_rect(float x, float y, float w, float h,
 }
 
 void CoreGraphicsCanvas::fill_circle(float cx, float cy, float radius) {
+    const CGRect bounds = CGRectMake(cx - radius, cy - radius, radius * 2, radius * 2);
+    // pulp #1359 — when a gradient is active, build an ellipse path and clip
+    // to it so fill_with_active_paint() paints the gradient inside the circle.
+    // Mirrors fill_rect / fill_rounded_rect / fill_current_path.
+    if (has_gradient_) {
+        CGContextSaveGState(ctx_);
+        CGContextBeginPath(ctx_);
+        CGContextAddEllipseInRect(ctx_, bounds);
+        CGContextClip(ctx_);
+        fill_with_active_paint();
+        CGContextRestoreGState(ctx_);
+        return;
+    }
     apply_fill_color();
-    CGContextFillEllipseInRect(ctx_, CGRectMake(cx - radius, cy - radius, radius * 2, radius * 2));
+    CGContextFillEllipseInRect(ctx_, bounds);
 }
 
 void CoreGraphicsCanvas::stroke_circle(float cx, float cy, float radius) {
@@ -264,13 +288,23 @@ void CoreGraphicsCanvas::stroke_path(const Point2D* points, size_t count) {
 
 void CoreGraphicsCanvas::fill_path(const Point2D* points, size_t count) {
     if (count < 3) return;
-    apply_fill_color();
     CGContextSetShouldAntialias(ctx_, true);
     CGContextBeginPath(ctx_);
     CGContextMoveToPoint(ctx_, points[0].x, points[0].y);
     for (size_t i = 1; i < count; ++i)
         CGContextAddLineToPoint(ctx_, points[i].x, points[i].y);
     CGContextClosePath(ctx_);
+    // pulp #1359 — honor active gradient on closed point-array fills, the
+    // direct CG parallel of SkiaCanvas::fill_path (#1353). Without this,
+    // shapes drawn via the Point2D* overload silently dropped the gradient.
+    if (has_gradient_) {
+        CGContextSaveGState(ctx_);
+        CGContextClip(ctx_);  // clip to the path we just built
+        fill_with_active_paint();
+        CGContextRestoreGState(ctx_);
+        return;
+    }
+    apply_fill_color();
     CGContextFillPath(ctx_);
 }
 

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -1482,4 +1482,119 @@ TEST_CASE("CoreGraphicsCanvas linear gradient paints multiple colors (issue 1322
     REQUIRE(saw_blue_dominant);
 }
 
+// pulp #1359 — fill_rect already routes the active gradient through
+// fill_with_active_paint(), but fill_path / fill_circle / fill_rounded_rect
+// silently dropped the gradient and fell back to apply_fill_color(). This
+// is the direct CG parallel of pulp #1350/#1353 on the Skia side. Spectr's
+// CPU-mode FilterBank backplate is the canonical repro — it paints solid
+// white instead of the dark-gradient backplate without this fix.
+//
+// Verify a 64x8 rect filled with a red→green linear gradient produces a
+// red-dominant left endpoint and a green-dominant right endpoint.
+TEST_CASE("CoreGraphicsCanvas::fill_rect honors active linear gradient",
+          "[canvas][cg][gradient][issue-1359]") {
+    constexpr int W = 64;
+    constexpr int H = 8;
+    std::vector<uint8_t> pixels(static_cast<size_t>(W) * H * 4u, 0u);
+    auto cs = CGColorSpaceCreateDeviceRGB();
+    REQUIRE(cs != nullptr);
+    const uint32_t bitmap_info =
+        static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) |
+        static_cast<uint32_t>(kCGBitmapByteOrder32Big);
+    CGContextRef ctx = CGBitmapContextCreate(
+        pixels.data(), W, H, 8, W * 4u, cs, bitmap_info);
+    CGColorSpaceRelease(cs);
+    REQUIRE(ctx != nullptr);
+
+    {
+        CoreGraphicsCanvas canvas(ctx, static_cast<float>(W),
+                                  static_cast<float>(H));
+        Color colors[2] = {
+            Color::rgba(1.0f, 0.0f, 0.0f, 1.0f),
+            Color::rgba(0.0f, 1.0f, 0.0f, 1.0f),
+        };
+        float positions[2] = {0.0f, 1.0f};
+        canvas.set_fill_gradient_linear(0, 0, static_cast<float>(W), 0,
+                                         colors, positions, 2);
+        canvas.fill_rect(0, 0, static_cast<float>(W), static_cast<float>(H));
+    }
+    CGContextRelease(ctx);
+
+    // Sample two pixels — one near the left edge, one near the right edge,
+    // both on a middle row to dodge any antialiasing along the top/bottom.
+    auto sample = [&](int x, int y) {
+        const size_t idx = (static_cast<size_t>(y) * W + x) * 4u;
+        return std::tuple<int, int, int, int>{pixels[idx], pixels[idx + 1],
+                                              pixels[idx + 2], pixels[idx + 3]};
+    };
+    auto [lr, lg, lb, la] = sample(2, H / 2);
+    auto [rr, rg, rb, rb_a] = sample(W - 3, H / 2);
+    INFO("left rgba=" << lr << "," << lg << "," << lb << "," << la);
+    INFO("right rgba=" << rr << "," << rg << "," << rb << "," << rb_a);
+    // Directional check: left endpoint must be more red than green; right
+    // endpoint must be more green than red. Tolerant of CG color-space drift.
+    REQUIRE(lr > lg);
+    REQUIRE(rg > rr);
+}
+
+// pulp #1359 — same test for fill_path. Build a triangle path and verify
+// at least two pixels inside the rendered triangle differ in color, proving
+// the gradient was actually painted (not a single solid colour).
+TEST_CASE("CoreGraphicsCanvas::fill_path honors active linear gradient",
+          "[canvas][cg][gradient][issue-1359]") {
+    constexpr int W = 64;
+    constexpr int H = 32;
+    std::vector<uint8_t> pixels(static_cast<size_t>(W) * H * 4u, 0u);
+    auto cs = CGColorSpaceCreateDeviceRGB();
+    REQUIRE(cs != nullptr);
+    const uint32_t bitmap_info =
+        static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) |
+        static_cast<uint32_t>(kCGBitmapByteOrder32Big);
+    CGContextRef ctx = CGBitmapContextCreate(
+        pixels.data(), W, H, 8, W * 4u, cs, bitmap_info);
+    CGColorSpaceRelease(cs);
+    REQUIRE(ctx != nullptr);
+
+    {
+        CoreGraphicsCanvas canvas(ctx, static_cast<float>(W),
+                                  static_cast<float>(H));
+        Color colors[2] = {
+            Color::rgba(1.0f, 0.0f, 0.0f, 1.0f),
+            Color::rgba(0.0f, 1.0f, 0.0f, 1.0f),
+        };
+        float positions[2] = {0.0f, 1.0f};
+        canvas.set_fill_gradient_linear(0, 0, static_cast<float>(W), 0,
+                                         colors, positions, 2);
+
+        // Triangle covering most of the bitmap horizontally so the gradient
+        // is sampled across its full extent.
+        Canvas::Point2D tri[3] = {
+            {4.0f, 4.0f},
+            {static_cast<float>(W) - 4.0f, static_cast<float>(H) / 2.0f},
+            {4.0f, static_cast<float>(H) - 4.0f},
+        };
+        canvas.fill_path(tri, 3);
+    }
+    CGContextRelease(ctx);
+
+    // Walk the bitmap and count pixels that look red-dominant vs
+    // green-dominant. If fill_path dropped the gradient and fell back to
+    // apply_fill_color(), every painted pixel would be a single colour and
+    // exactly one of these counts would be non-zero.
+    int red_dominant = 0;
+    int green_dominant = 0;
+    for (size_t i = 0; i + 3 < pixels.size(); i += 4) {
+        const int r = pixels[i];
+        const int g = pixels[i + 1];
+        const int a = pixels[i + 3];
+        if (a < 10) continue;  // background
+        if (r >= 150 && g <= 60) ++red_dominant;
+        if (g >= 150 && r <= 60) ++green_dominant;
+    }
+    INFO("red_dominant=" << red_dominant
+         << " green_dominant=" << green_dominant);
+    REQUIRE(red_dominant > 0);
+    REQUIRE(green_dominant > 0);
+}
+
 #endif  // __APPLE__


### PR DESCRIPTION
## Summary

Direct CG parallel of pulp #1350 / #1353 (Skia side, merged in v0.72.4). On macOS / iOS CPU paint paths, `CoreGraphicsCanvas::fill_path`, `fill_circle`, and `fill_rounded_rect` called `apply_fill_color()` unconditionally and silently dropped any gradient set via `set_fill_gradient_linear` / `set_fill_gradient_radial`. `fill_rect` already had the right shape — gate on `has_gradient_`, clip the rect, route through `fill_with_active_paint()` — but its three siblings did not.

Closes the CG-side residual of pulp #1322. Spectr's CPU-mode FilterBank now paints the dark-gradient backplate instead of solid white, matching the WebView reference.

- `fill_rounded_rect`: builds the rounded path, then if `has_gradient_` saves the GState, clips to the path, paints the gradient, restores. Otherwise falls back to the existing `apply_fill_color()` + `CGContextFillPath`.
- `fill_circle`: now adds an explicit ellipse path so `CGContextClip` has something to clip to under the gradient branch. Non-gradient branch still uses the simpler `CGContextFillEllipseInRect`.
- `fill_path` (Point2D* overload): same shape — build the path, gate on `has_gradient_`, clip + `fill_with_active_paint()` or fall back.
- All three mirror `fill_rect` and `fill_current_path` exactly.

## Test plan

- [x] New `[issue-1359]` test cases in `test/test_canvas.cpp`:
  - `CoreGraphicsCanvas::fill_rect honors active linear gradient` — 64x8 bitmap, red→green linear gradient, samples both endpoints, asserts left-pixel red > green and right-pixel green > red. Tolerant of CG color-space drift (directional only).
  - `CoreGraphicsCanvas::fill_path honors active linear gradient` — triangle path with same gradient, walks the bitmap and asserts both red-dominant and green-dominant pixels appear (proves multi-stop gradient was painted, not collapsed to one colour).
- [x] `./build/test/pulp-test-canvas "[issue-1359]"` — 8 assertions / 2 cases pass on macOS (arm64 darwin25)
- [x] Full `pulp-test-canvas` suite remains green (1297 assertions / 38 cases)
- [ ] CI matrix (macOS / Ubuntu / Windows) green