### PR TITLE
fix(format): StandaloneApp honors view_size().min_* (closes pulp #1362)

### DIFF
--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -132,6 +132,17 @@ Phase 4's `attach_remote_view(url)` (WebSocket-backed) will land as a
 4. **Hard-coding `editor_size()` when you actually want resize
    bounds.** Override `view_size()` and return a `ViewSize` with
    real min/max; hosts use those to constrain user-drag resize.
+5. **Forgetting that adapters must read `bridge.size_hints().min_*`
+   when building the host's `WindowOptions`.** The bridge caches
+   `Processor::view_size()` in `size_hints_`, but each adapter is
+   responsible for forwarding `min_width`/`min_height` (and
+   `preferred_*`) into its window/host options. The standalone
+   adapter centralizes this in `detail::make_standalone_window_options`
+   so the chrome-height shift is applied consistently (#1362). Other
+   adapters wiring an OS window (e.g. host apps registering a
+   `WindowHost::Factory`) need the same propagation; reading only
+   `preferred_*` leaves the OS host with a zero minimum and lets
+   plugins shrink below their declared floor.
 
 ## Tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.72.5
+    VERSION 0.72.6
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
+++ b/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <pulp/format/processor.hpp>
 #include <pulp/format/settings_panel.hpp>
 #include <pulp/runtime/log.hpp>
 #include <pulp/view/window_host.hpp>
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <utility>
 
 namespace pulp::format::detail {
@@ -115,6 +117,36 @@ inline StandaloneEditorChrome make_standalone_editor_chrome(
     chrome.tab_panel_ = std::move(tab_panel);
     chrome.extra_window_height_ = 32.0f;
     return chrome;
+}
+
+/// Build a `WindowOptions` for the standalone editor host from the
+/// processor's `ViewSize` hints (as cached by `ViewBridge`) plus the
+/// chrome layout. The min_* fields propagate end-to-end so platform
+/// hosts (e.g. macOS `setContentMinSize:`) can clamp interactive resize
+/// to the processor's declared minimum. (closes #1362)
+inline view::WindowOptions make_standalone_window_options(
+    const ViewSize& size_hints,
+    const StandaloneEditorChrome& chrome,
+    std::string title,
+    bool use_gpu) {
+    const float extra_h = chrome.extra_window_height() > 0.0f
+        ? chrome.extra_window_height() : 0.0f;
+    view::WindowOptions opts;
+    opts.title = std::move(title);
+    opts.width = static_cast<float>(size_hints.preferred_width);
+    opts.height = static_cast<float>(size_hints.preferred_height) + extra_h;
+    // Forward min_* from the processor's ViewSize so the OS-level
+    // window host can refuse interactive resize below the declared
+    // minimum. Chrome rows (settings tab) extend the floor on the
+    // height axis in lockstep with the preferred-height extension
+    // above so the editor area can never shrink below its own min.
+    if (size_hints.min_width > 0)
+        opts.min_width = static_cast<float>(size_hints.min_width);
+    if (size_hints.min_height > 0)
+        opts.min_height = static_cast<float>(size_hints.min_height) + extra_h;
+    opts.resizable = true;
+    opts.use_gpu = use_gpu;
+    return opts;
 }
 
 inline view::WindowHost::ContentSize standalone_editor_content_size(

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -202,8 +202,9 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
         return false;
     }
 
-    const uint32_t w = bridge->size_hints().preferred_width;
-    const uint32_t h = bridge->size_hints().preferred_height;
+    const auto& size_hints = bridge->size_hints();
+    const uint32_t w = size_hints.preferred_width;
+    const uint32_t h = size_hints.preferred_height;
     auto desc = processor_->descriptor();
 
     auto chrome = detail::make_standalone_editor_chrome(
@@ -229,12 +230,11 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     auto* settings_ptr = chrome.settings_panel();
     auto& window_root = chrome.window_root();
 
-    view::WindowOptions opts;
-    opts.title = desc.name + " — Standalone";
-    opts.width = static_cast<float>(w);
-    opts.height = static_cast<float>(h) + chrome.extra_window_height();
-    opts.resizable = true;
-    opts.use_gpu = use_gpu;
+    // Build WindowOptions from the bridge's cached ViewSize hints so
+    // min_width/min_height propagate to platform window hosts that
+    // honor them (#1362).
+    auto opts = detail::make_standalone_window_options(
+        size_hints, chrome, desc.name + " — Standalone", use_gpu);
 
     auto window = view::WindowHost::create(window_root, opts);
     if (!window) {

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <pulp/format/detail/standalone_editor_chrome.hpp>
 
 #include <memory>
@@ -567,4 +568,78 @@ TEST_CASE("Standalone log helper formats the chrome mode",
 
     log_standalone_window_open(640, 360, false, false, chrome);
     SUCCEED();
+}
+
+TEST_CASE("make_standalone_window_options propagates min_* from ViewSize",
+          "[standalone][chrome][issue-1362]") {
+    auto editor_root = std::make_unique<View>();
+    auto chrome = make_standalone_editor_chrome(
+        std::move(editor_root),
+        StandaloneConfig{.show_settings_tab = false},
+        nullptr, nullptr, nullptr, {});
+
+    pulp::format::ViewSize hints;
+    hints.preferred_width = 1320;
+    hints.preferred_height = 860;
+    hints.min_width = 800;
+    hints.min_height = 600;
+
+    auto opts = make_standalone_window_options(hints, chrome, "Plug — Standalone", false);
+
+    REQUIRE(opts.title == "Plug — Standalone");
+    REQUIRE(opts.width == Catch::Approx(1320.0f));
+    REQUIRE(opts.height == Catch::Approx(860.0f));
+    REQUIRE(opts.min_width == Catch::Approx(800.0f));
+    REQUIRE(opts.min_height == Catch::Approx(600.0f));
+    REQUIRE(opts.resizable);
+    REQUIRE_FALSE(opts.use_gpu);
+}
+
+TEST_CASE("make_standalone_window_options leaves min_* at zero when unset",
+          "[standalone][chrome][issue-1362]") {
+    auto editor_root = std::make_unique<View>();
+    auto chrome = make_standalone_editor_chrome(
+        std::move(editor_root),
+        StandaloneConfig{.show_settings_tab = false},
+        nullptr, nullptr, nullptr, {});
+
+    // Default ViewSize: zero min_* — the platform window host should
+    // see "no minimum" rather than a stale clamp.
+    pulp::format::ViewSize hints;
+    hints.preferred_width = 600;
+    hints.preferred_height = 400;
+
+    auto opts = make_standalone_window_options(hints, chrome, "X", true);
+
+    REQUIRE(opts.min_width == Catch::Approx(0.0f));
+    REQUIRE(opts.min_height == Catch::Approx(0.0f));
+    REQUIRE(opts.use_gpu);
+}
+
+TEST_CASE("make_standalone_window_options extends min_height when chrome adds rows",
+          "[standalone][chrome][issue-1362]") {
+    // Settings tab adds 32px of chrome — the height min must rise in
+    // lockstep with the preferred-height extension so the editor area
+    // can never be squeezed below its declared min.
+    auto editor_root = std::make_unique<View>();
+    auto chrome = make_standalone_editor_chrome(
+        std::move(editor_root),
+        StandaloneConfig{.show_settings_tab = true},
+        nullptr, nullptr, nullptr, {});
+    REQUIRE(chrome.extra_window_height() == Catch::Approx(32.0f));
+
+    pulp::format::ViewSize hints;
+    hints.preferred_width = 1320;
+    hints.preferred_height = 860;
+    hints.min_width = 800;
+    hints.min_height = 600;
+
+    auto opts = make_standalone_window_options(hints, chrome, "Plug", false);
+
+    // Preferred height = preferred_height + chrome.extra_window_height()
+    REQUIRE(opts.height == Catch::Approx(892.0f));
+    // Min height is shifted by the same chrome amount so the editor
+    // area's own minimum is never violated.
+    REQUIRE(opts.min_width == Catch::Approx(800.0f));
+    REQUIRE(opts.min_height == Catch::Approx(632.0f));
 }


### PR DESCRIPTION
## Summary

Fixes #1362. `StandaloneApp::run_with_editor()` was only reading
`bridge_->size_hints().preferred_*` when building its `WindowOptions`,
leaving `min_width` / `min_height` at zero. The platform window hosts
already honored those fields (macOS calls `setContentMinSize:` when
either is non-zero — `window_host_mac.mm:1304-1305, 1472-1473`), so the
break point was a single missing read at `core/format/src/standalone.cpp`
where preferred_* was being passed through.

This PR introduces `detail::make_standalone_window_options(...)` —
a small pure helper in `standalone_editor_chrome.hpp` that builds a
`WindowOptions` from the cached `ViewSize` hints plus the chrome
layout. It propagates both preferred and min dimensions, and shifts
`min_height` by `chrome.extra_window_height()` so the editor area's
declared minimum is preserved when the settings tab adds chrome rows.

The wiring at `standalone.cpp:205-238` collapses from a five-line
inline `WindowOptions` build into a single call to the helper.

## Cross-platform parity

| Backend | Reads `WindowOptions.min_*`? | Notes |
|---|---|---|
| macOS — `window_host_mac.mm` | ✓ | Already calls `setContentMinSize:` when min > 0. |
| iOS — `window_host_ios.mm` | n/a | UIWindow fills the screen; min-size irrelevant. |
| Linux/Windows/Android | factory-injected | Host apps register `WindowHost::Factory` and read the same `WindowOptions` struct. The new helper always sets the field, so any compliant factory now sees the floor. |

No platform backend needed changes — the gap was purely in the
StandaloneApp adapter not populating the field.

## Tests

3 new headless Catch2 cases in `test/test_standalone_editor_chrome.cpp`
(file grew 14 → 19 cases, 105 assertions, 0 platform deps):

- `make_standalone_window_options propagates min_* from ViewSize` — non-zero
  min_width=800, min_height=600 → opts.min_* matches.
- `make_standalone_window_options leaves min_* at zero when unset` — default
  ViewSize → opts.min_* stays at 0 so the OS host treats it as "no minimum".
- `make_standalone_window_options extends min_height when chrome adds rows` —
  settings tab adds 32px chrome; preferred and min height both rise by 32px
  in lockstep so the editor area's declared min is honored.

```
ctest --test-dir build -R Standalone --output-on-failure
…
100% tests passed (19 cases, 105 assertions)
```

## Skill update

Added a new entry to `.agents/skills/view-bridge/SKILL.md` "Common
pitfalls" flagging that adapters must read `bridge.size_hints().min_*`
(not just `preferred_*`) when wiring an OS window. The view-bridge
skill is the right place for this — it's the rule for any future
adapter or host-app `WindowHost::Factory`, not just the standalone path.

## Spectr-side benefit

After this lands, Spectr can override `Processor::view_size()` to
return `{ .preferred_width=1320, .preferred_height=860, .min_width=1100,
.min_height=600 }` and the standalone window will refuse to shrink below
the chrome-bar's intrinsic width — matching what the WebView reference
already enforces.

## Test plan

- [x] `ctest --test-dir build -R "Standalone|view_size|aspect"` — 19 cases pass on macOS.
- [x] Full incremental build green (`cmake --build build`) including all CLAP/AU/VST3 targets.
- [ ] CI matrix (macOS / Ubuntu / Windows) on Shipyard.
- [ ] Manual repro in Spectr standalone after Spectr lands its `view_size()` override (follow-up, not this PR).