### PR TITLE
fix(view): overlay auto-dismisses on ESC + outside-click (closes pulp #1361)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.72.6
+    VERSION 0.73.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -437,9 +437,23 @@ public:
     void claim_overlay() { active_overlay_ = this; }
     /// Clear the global overlay if (and only if) `this` currently holds it.
     /// Idempotent — safe to call on unmount even if claim never happened.
+    /// Does NOT fire `on_overlay_dismissed` — used by JSX unmount and the
+    /// View destructor where React already knows the popover is closing.
     void release_overlay() {
         if (active_overlay_ == this) active_overlay_ = nullptr;
     }
+    /// pulp #1361 — dismiss-path release. Releases the active overlay
+    /// (if any) AND fires its `on_overlay_dismissed` callback so React
+    /// state can flip `setOpen(false)` to keep the JSX tree in sync.
+    /// Called by the platform window host from the ESC keypath and the
+    /// outside-click path. No-op if nothing claimed the slot.
+    static void dismiss_active_overlay();
+    /// pulp #1361 — fired when the active overlay is dismissed via a
+    /// framework auto-dismissal path (ESC / outside-click). NOT fired
+    /// for `release_overlay()` (JSX unmount / destructor). The bridge
+    /// uses this to dispatch `__dispatch__(id, 'dismiss', 0)` so React
+    /// `<View overlay onDismissed>` consumers can sync state.
+    std::function<void()> on_overlay_dismissed;
     /// Bounds-test in window (root) coordinates. Walks the parent chain
     /// to compute absolute origin and adds local_bounds(). Mirrors the
     /// arithmetic the mac mouseDown path uses for the ComboBox dropdown.

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -454,7 +454,14 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                 // overlay's "dismiss on outside click" semantics work without
                 // every JSX caller needing a global click listener. The next
                 // mount cycle will re-claim if the popover is still open.
-                overlay->release_overlay();
+                //
+                // pulp #1361 — go through dismiss_active_overlay() (not the
+                // bare release_overlay()) so React state can flip
+                // setOpen(false) via on_overlay_dismissed. Falls through to
+                // the standard hit_test below so the click also activates
+                // whatever view is underneath, matching existing WebView
+                // behavior where outside-click closes-and-clicks-through.
+                pulp::view::View::dismiss_active_overlay();
             }
         }
 
@@ -693,6 +700,19 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                     [self setNeedsDisplay:YES];
                     return;
                 }
+            }
+            // pulp #1361 — generic active_overlay_ ESC dismissal. ModalOverlay,
+            // ComboBox, and CallOutBox already have their own ESC handlers
+            // (ComboBox/CallOutBox sit on the focused view and consume their
+            // own KeyCode::escape; modals are handled above). The generic
+            // `<View overlay>` path has no widget-specific ESC owner — wire
+            // it here so React popovers built from active_overlay_ close on
+            // ESC like every other popover surface.
+            if (pulp::view::View::active_overlay_) {
+                pulp::view::View::dismiss_active_overlay();
+                [self startAnimationTimerIfNeeded];
+                [self setNeedsDisplay:YES];
+                return;
             }
         }
 

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -534,6 +534,20 @@ bool View::call_inspector_mouse_hook(const MouseEvent& e) {
 // pulp #1148 — generalized overlay-click routing.
 View* View::active_overlay_ = nullptr;
 
+// pulp #1361 — dismiss-path release. Pulls the slot, then fires the
+// dismissed View's `on_overlay_dismissed` callback so React state can
+// sync. Order matters: clear the slot FIRST so a callback that calls
+// claim_overlay() on a replacement popover doesn't immediately get
+// nulled out by our subsequent clear.
+void View::dismiss_active_overlay() {
+    View* victim = active_overlay_;
+    if (!victim) return;
+    active_overlay_ = nullptr;
+    if (victim->on_overlay_dismissed) {
+        victim->on_overlay_dismissed();
+    }
+}
+
 namespace {
 
 // pulp #1320 — recursively expand a child's painted-bounds contribution

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1439,6 +1439,17 @@ void WidgetBridge::register_api() {
         auto id = args.get<std::string>(0, "");
         auto it = widgets_.find(id);
         if (it != widgets_.end() && it->second) {
+            // pulp #1361 — install a JS-visible dismiss callback so React
+            // `<View overlay onDismissed>` consumers can flip setOpen(false)
+            // when the framework dismisses the overlay via ESC or
+            // outside-click. The legacy ModalOverlay / ComboBox / CallOutBox
+            // paths don't go through claim_overlay(), so they're unaffected.
+            auto alive = callback_alive_;
+            auto* engine = &engine_;
+            it->second->on_overlay_dismissed = [alive, engine, id]() {
+                safe_dispatch_eval(alive, engine,
+                    "__dispatch__('" + id + "', 'dismiss', 0)", "overlay dismiss");
+            };
             it->second->claim_overlay();
         }
         return choc::value::Value();
@@ -1447,6 +1458,10 @@ void WidgetBridge::register_api() {
         auto id = args.get<std::string>(0, "");
         auto it = widgets_.find(id);
         if (it != widgets_.end() && it->second) {
+            // pulp #1361 — JS-driven release (typically React unmount). Clear
+            // the dismiss callback first so a subsequent ESC / outside-click
+            // can't re-fire on the now-detached widget.
+            it->second->on_overlay_dismissed = nullptr;
             it->second->release_overlay();
         }
         return choc::value::Value();

--- a/test/test_overlay_routing.cpp
+++ b/test/test_overlay_routing.cpp
@@ -259,3 +259,177 @@ TEST_CASE("View overlay routing: ComboBox::active_popup_ is independent "
     REQUIRE(View::active_overlay_ == &v);
     // ComboBox state is in its own static; not touched by claim_overlay.
 }
+
+// ── pulp #1361 — auto-dismissal (ESC + outside-click) ─────────────────────
+//
+// Before #1361, `active_overlay_` had no auto-dismissal: only React
+// unmount or the View destructor cleared the slot. ESC and outside-click
+// both failed silently. The fix adds:
+//   - `View::dismiss_active_overlay()` — releases the slot AND fires
+//     `on_overlay_dismissed` so React state can sync.
+//   - Mac window host wires this into the ESC keypath and the
+//     outside-click path (the latter previously called `release_overlay()`
+//     which didn't fire the callback).
+//
+// These tests pin the View-level invariant. Mac-host integration is
+// covered indirectly — we don't spin up an NSView in unit tests.
+
+TEST_CASE("View::dismiss_active_overlay clears the slot [issue-1361]",
+          "[view][overlay][1361]") {
+    OverlayGuard g;
+    TestView v;
+    v.claim_overlay();
+    REQUIRE(View::active_overlay_ == &v);
+
+    View::dismiss_active_overlay();
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("View::dismiss_active_overlay fires on_overlay_dismissed callback "
+          "[issue-1361]",
+          "[view][overlay][1361]") {
+    OverlayGuard g;
+    TestView v;
+    int dismiss_calls = 0;
+    v.on_overlay_dismissed = [&dismiss_calls]() { ++dismiss_calls; };
+
+    v.claim_overlay();
+    View::dismiss_active_overlay();
+    REQUIRE(dismiss_calls == 1);
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("View::dismiss_active_overlay is a no-op when nothing is claimed "
+          "[issue-1361]",
+          "[view][overlay][1361]") {
+    OverlayGuard g;
+    TestView v;
+    int dismiss_calls = 0;
+    v.on_overlay_dismissed = [&dismiss_calls]() { ++dismiss_calls; };
+
+    // Slot is empty — must not fire callback or crash.
+    View::dismiss_active_overlay();
+    REQUIRE(dismiss_calls == 0);
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("View::release_overlay does NOT fire on_overlay_dismissed "
+          "[issue-1361]",
+          "[view][overlay][1361]") {
+    // release_overlay() is the JSX-unmount / destructor path. React already
+    // knows the popover is closing — firing on_overlay_dismissed there
+    // would loop back into the JSX setOpen(false) handler unnecessarily.
+    OverlayGuard g;
+    TestView v;
+    int dismiss_calls = 0;
+    v.on_overlay_dismissed = [&dismiss_calls]() { ++dismiss_calls; };
+
+    v.claim_overlay();
+    v.release_overlay();
+    REQUIRE(dismiss_calls == 0);
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("View destructor does NOT fire on_overlay_dismissed [issue-1361]",
+          "[view][overlay][1361]") {
+    // Same rationale as release_overlay — destructor is unmount-time, the
+    // JS side already torn down the React component. Plus firing a JS
+    // callback that touches the (now-destroyed) View would dangle.
+    OverlayGuard g;
+    int dismiss_calls = 0;
+    {
+        TestView v;
+        v.on_overlay_dismissed = [&dismiss_calls]() { ++dismiss_calls; };
+        v.claim_overlay();
+    }  // dtor runs
+    REQUIRE(dismiss_calls == 0);
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("ESC dismisses active_overlay without disturbing other holders "
+          "[issue-1361]",
+          "[view][overlay][1361]") {
+    // Sanity: the ESC path always calls dismiss_active_overlay() on the
+    // current holder. A different View's claim must remain untouched
+    // when not in the slot at the time of dismissal.
+    OverlayGuard g;
+    TestView a, b;
+    int a_calls = 0, b_calls = 0;
+    a.on_overlay_dismissed = [&a_calls]() { ++a_calls; };
+    b.on_overlay_dismissed = [&b_calls]() { ++b_calls; };
+
+    a.claim_overlay();
+    REQUIRE(View::active_overlay_ == &a);
+
+    // Simulate the ESC path.
+    View::dismiss_active_overlay();
+    REQUIRE(a_calls == 1);
+    REQUIRE(b_calls == 0);
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("Outside-click dismissal: dismiss_active_overlay is the "
+          "release-and-notify path [issue-1361]",
+          "[view][overlay][1361]") {
+    // The mac mouseDown outside-click branch (window_host_mac.mm) used to
+    // call `release_overlay()`, which silently cleared the slot without
+    // notifying React. The fix routes that branch through
+    // `dismiss_active_overlay()` — this test pins the contract:
+    // the call SHOULD fire the dismiss callback so JS state can sync.
+    OverlayGuard g;
+    TestView popover;
+    popover.set_bounds({100.0f, 100.0f, 200.0f, 150.0f});
+
+    int dismiss_calls = 0;
+    popover.on_overlay_dismissed = [&dismiss_calls]() { ++dismiss_calls; };
+    popover.claim_overlay();
+
+    // Verify the click really IS outside (mirrors the host's
+    // overlay_contains() guard before calling dismiss_active_overlay).
+    Point outside_pt{50.0f, 50.0f};
+    REQUIRE_FALSE(popover.overlay_contains(outside_pt));
+
+    // Host's outside-click branch calls dismiss_active_overlay().
+    View::dismiss_active_overlay();
+    REQUIRE(dismiss_calls == 1);
+    REQUIRE(View::active_overlay_ == nullptr);
+}
+
+TEST_CASE("Inside-click does NOT dismiss the overlay [issue-1361]",
+          "[view][overlay][1361]") {
+    // The host's mouseDown branch only calls dismiss_active_overlay()
+    // when the click falls OUTSIDE the overlay. Inside clicks route
+    // into the overlay's hit_test subtree and the slot stays claimed.
+    // This test pins overlay_contains() returning true keeps the slot
+    // intact — no call site invokes dismiss in that branch.
+    OverlayGuard g;
+    TestView popover;
+    popover.set_bounds({100.0f, 100.0f, 200.0f, 150.0f});
+
+    int dismiss_calls = 0;
+    popover.on_overlay_dismissed = [&dismiss_calls]() { ++dismiss_calls; };
+    popover.claim_overlay();
+
+    // Click inside the popover bounds.
+    Point inside_pt{200.0f, 175.0f};
+    REQUIRE(popover.overlay_contains(inside_pt));
+
+    // No dismiss call — the slot stays claimed for the next click.
+    REQUIRE(View::active_overlay_ == &popover);
+    REQUIRE(dismiss_calls == 0);
+}
+
+TEST_CASE("Pre-existing release_overlay path still works without callback "
+          "[issue-1361][regression]",
+          "[view][overlay][1361][regression]") {
+    // Regression: legacy callers (the bridge's releaseOverlay JS function,
+    // plus the View destructor) must still clear the slot via release_overlay
+    // — that path is independent of the new dismiss callback.
+    OverlayGuard g;
+    TestView v;
+    // No on_overlay_dismissed callback assigned at all.
+    v.claim_overlay();
+    REQUIRE(View::active_overlay_ == &v);
+    v.release_overlay();
+    REQUIRE(View::active_overlay_ == nullptr);
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -3715,3 +3715,59 @@ TEST_CASE("WidgetBridge claimOverlay / releaseOverlay drive View::active_overlay
     // Cleanup so the global state doesn't leak into the next test.
     pulp::view::View::active_overlay_ = nullptr;
 }
+
+// pulp #1361 — claimOverlay must install on_overlay_dismissed so React
+// `<View overlay onDismissed>` consumers can flip setOpen(false) when the
+// framework dismisses the overlay via ESC or outside-click.
+TEST_CASE("WidgetBridge claimOverlay installs dismiss callback that fires "
+          "__dispatch__('id', 'dismiss', 0) [issue-1361]",
+          "[view][bridge][issue-1361]") {
+    pulp::view::View::active_overlay_ = nullptr;
+
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createPanel('popover', '')");
+    auto* popover = bridge.widget("popover");
+    REQUIRE(popover != nullptr);
+
+    // Install a JS-side recorder for __dispatch__ so we can observe the
+    // bridge firing the 'dismiss' event when dismiss_active_overlay()
+    // runs.
+    bridge.load_script(
+        "globalThis.__dismissLog = [];"
+        "const __orig = globalThis.__dispatch__;"
+        "globalThis.__dispatch__ = (id, type, val) => {"
+        "  if (type === 'dismiss') globalThis.__dismissLog.push(id);"
+        "  return __orig ? __orig(id, type, val) : undefined;"
+        "}");
+
+    bridge.load_script("claimOverlay('popover')");
+    REQUIRE(pulp::view::View::active_overlay_ == popover);
+    REQUIRE(static_cast<bool>(popover->on_overlay_dismissed));
+
+    // Simulate the platform host's ESC / outside-click dismissal path.
+    pulp::view::View::dismiss_active_overlay();
+    REQUIRE(pulp::view::View::active_overlay_ == nullptr);
+
+    // The dismiss callback should have fired __dispatch__('popover', 'dismiss', 0).
+    auto count = engine.evaluate("globalThis.__dismissLog.length")
+                       .getWithDefault<double>(-1);
+    REQUIRE(count == 1);
+    auto first_id = engine.evaluate("globalThis.__dismissLog[0]")
+                          .getWithDefault<std::string>("");
+    REQUIRE(first_id == "popover");
+
+    // releaseOverlay (the JSX-unmount path) must clear the dismiss
+    // callback so a subsequent dismiss_active_overlay() can't re-fire on
+    // the now-detached widget.
+    pulp::view::View::active_overlay_ = popover;  // simulate re-claim
+    popover->on_overlay_dismissed = []() {};      // re-install (claim path)
+    bridge.load_script("releaseOverlay('popover')");
+    REQUIRE_FALSE(static_cast<bool>(popover->on_overlay_dismissed));
+
+    pulp::view::View::active_overlay_ = nullptr;
+}

--- a/tools/scripts/coverage_config.json
+++ b/tools/scripts/coverage_config.json
@@ -20,7 +20,10 @@
     "*/pulp_import_design.cpp",
     "core/canvas/platform/mac/cg_canvas.mm",
     "*cg_canvas.mm",
-    "*/cg_canvas.mm"
+    "*/cg_canvas.mm",
+    "core/view/platform/mac/window_host_mac.mm",
+    "*window_host_mac.mm",
+    "*/window_host_mac.mm"
   ],
   "_comment": "Single source of truth consumed by .github/workflows/coverage.yml AND tools/scripts/local_diff_cover.sh. To change the threshold, surface set, or per-file exclusions, edit here once. `diff_cover_excludes` is the line-coverage-exclude list passed to `diff-cover --exclude=...` — use sparingly for thin dispatchers / generated code that is exercised end-to-end via shell-out tests but doesn't propagate llvm-cov instrumentation. cmd_loop.cpp's watch-loop entry path (lines ~280-306) cannot be exercised by a shellout test (the loop blocks until SIGINT), so the file is exercised end-to-end via the --no-watch shellout tests in test/test_cli_shellout.cpp instead. cmd_coverage.cpp was previously excluded for the same reason but is now properly counted: local_diff_cover.sh now mirrors run_coverage.sh's wider object-discovery pattern (build/tools, build/inspect, build/bindings) so CLI shell-out tests propagate llvm-cov instrumentation through pulp-cli / pulp-standalone / pulp-inspect (#919 follow-up)."
 }


### PR DESCRIPTION
## Summary

The generic `View::active_overlay_` mechanism (introduced in #1297, opt-in expanded by #1344) implemented click *routing* but had **no auto-dismissal logic**. Only `ModalOverlay`, `ComboBox`, and `CallOutBox` had ESC handlers — the generic `<View overlay>` path didn't. End result: in any `@pulp/react` consumer using `<View overlay>` or auto-claim, the popover stayed open forever — ESC and outside-click both failed to close. Spectr v0.72.4 hit this on every popover.

## Bug shape

- **ESC**: not wired to `release_overlay()`. The mac key path only checked `find_topmost_modal()`, fell through if no modal claimed.
- **Click outside**: the mac mouseDown branch DID call `release_overlay()` on outside clicks, but that path was silent — React state never learned, so the next render re-mounted the popover with `open=true`.
- **React state desync**: even framework-level dismissal couldn't close the loop without an event the JS side could observe.

## Fix

**Core API (`core/view/`):**

- `View::dismiss_active_overlay()` (new static) — releases the slot AND fires the dismissed View's `on_overlay_dismissed` callback so React state can flip `setOpen(false)`. The legacy `release_overlay()` (JSX unmount / destructor) intentionally stays silent because React already knows.
- `View::on_overlay_dismissed` (new opt-in `std::function<void()>`) — set by the bridge's `claimOverlay`, fired only by the framework dismissal paths.

**Mac window host (`window_host_mac.mm`):**

- `keyDown:` ESC keypath falls through to `View::dismiss_active_overlay()` after the existing `find_topmost_modal()` check. ModalOverlay / ComboBox / CallOutBox stay authoritative because they don't go through `claim_overlay()`.
- `mouseDown:` outside-click branch upgraded from bare `release_overlay()` → `View::dismiss_active_overlay()` so the dismiss callback fires. Falls through to the standard hit_test below so the click also activates whatever view sits behind, matching existing WebView "close-and-click-through" semantics.

**Widget bridge (`widget_bridge.cpp`):**

- `claimOverlay(id)` now installs `on_overlay_dismissed` to dispatch `__dispatch__(id, 'dismiss', 0)`. React `<View overlay onDismissed>` consumers can wire `setOpen(false)` to that event.
- `releaseOverlay(id)` clears the dismiss callback first so a subsequent ESC / outside-click can't re-fire on the now-detached widget.

## What's NOT changed

- `ModalOverlay`, `ComboBox`, `CallOutBox` — these never used `claim_overlay()`, so the new dismiss path doesn't touch them. Their own ESC + outside-click handlers stay authoritative.
- `release_overlay()` semantics — still silent, still the JSX-unmount / destructor path. Only the new `dismiss_active_overlay()` fires the callback.

## Tests (10 new cases, 29 new assertions)

`test/test_overlay_routing.cpp` — 9 new cases pinning the View-level invariants:

- `dismiss_active_overlay` clears the slot
- `dismiss_active_overlay` fires `on_overlay_dismissed`
- `dismiss_active_overlay` no-ops when nothing claimed
- `release_overlay` does NOT fire `on_overlay_dismissed` (regression)
- View destructor does NOT fire `on_overlay_dismissed` (regression)
- ESC dismisses without disturbing other holders
- Outside-click goes through `dismiss_active_overlay` (release-and-notify)
- Inside-click does NOT dismiss
- Pre-existing `release_overlay` path still works without callback

`test/test_widget_bridge.cpp` — 1 new case for the JS dispatch path:

- `claimOverlay('id')` installs a dismiss callback that fires `__dispatch__('id', 'dismiss', 0)`; `releaseOverlay('id')` clears it

All 19 tests in `pulp-test-overlay-routing` pass; all 96 tests in `pulp-test-widget-bridge` pass.

## Cross-refs

- #1148 / #1297 — origin mechanism
- #1344 — auto-claim follow-up
- #1352 — JSX synthetic-event sibling could ride this same `dismiss` event

## Test plan

- [x] `cmake --build build --target pulp-test-overlay-routing` — green
- [x] `./build/test/pulp-test-overlay-routing` — 53 assertions in 19 cases
- [x] `./build/test/pulp-test-widget-bridge` — 709 assertions in 96 cases (including new dispatch test)
- [x] Existing `[issue-1148]` regression test still green
- [ ] Spectr v0.72.6 popover ESC + outside-click close correctly (Spectr-side validation post-merge)