### PR TITLE
audit(compat): refresh matrix from spec walk + post-#1027 surface

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -2,27 +2,947 @@
   "compat-schema-version": "0.2",
   "_comment": "Compat matrix per #1027. This file is the spec-driven inventory of every prop / style / API surface Pulp's React + DOM-lite consumers might use, mapped to its current implementation status. Status values: supported | partial | missing | wontfix. The 'mapsTo' field names the bridge / Yoga / Skia path the prop lowers to. The 'tests' field is intentionally empty here and will be filled in by individual fix PRs that ship Catch2 / vitest coverage. The audit was generated 2026-04-30 by walking three reference specs (Yoga via React Native Layout Props, React Native View / Text / Transform Style Props, and the most-used MDN CSS reference) and cross-referencing against four implementation surfaces: packages/pulp-react/src/prop-applier.ts (the @pulp/react switch), core/view/js/web-compat-style-decl.js (the DOM-lite CSS adapter), core/view/src/widget_bridge.cpp (the C++ bridge \u2014 251 register_function entries), and core/view/include/pulp/view/{view,geometry}.hpp (the Flex / View widget surface).",
   "_audit": {
-    "generated": "2026-04-30",
-    "main_sha": "4a423c03",
+    "generated": "2026-05-04",
+    "main_sha": "a5f4f5ac",
     "spec_sources": {
       "yoga": "https://www.yogalayout.dev/docs/styling \u2014 list cross-checked against https://reactnative.dev/docs/layout-props which mirrors the upstream Yoga API",
       "rn_view": "https://reactnative.dev/docs/view-style-props",
       "rn_text": "https://reactnative.dev/docs/text-style-props",
       "rn_transform": "https://reactnative.dev/docs/transforms",
-      "css": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties \u2014 top ~150 commonly-used properties across layout, box-model, typography, color, transforms, flex/grid, opacity"
+      "rn_layout": "https://reactnative.dev/docs/layout-props",
+      "css": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties \u2014 top ~150 commonly-used properties across layout, box-model, typography, color, transforms, flex/grid, opacity. Print, paged-media, and CSS-fonts loading specifics are out of scope.",
+      "canvas2d": "https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D \u2014 HTML Living Standard CanvasRenderingContext2D",
+      "html_element": "https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement attribute coverage, ARIA attributes, dataset, classList, the DocumentFragment shim"
     },
     "implementation_surfaces": [
       "packages/pulp-react/src/prop-applier.ts",
       "packages/pulp-react/src/host-config.ts",
       "packages/pulp-react/src/intrinsics.ts",
       "core/view/js/web-compat-style-decl.js",
+      "core/view/js/web-compat-element.js",
+      "core/view/js/web-compat-canvas.js",
+      "core/view/js/web-compat-document.js",
       "core/view/src/widget_bridge.cpp",
       "core/view/include/pulp/view/view.hpp",
-      "core/view/include/pulp/view/geometry.hpp"
+      "core/view/include/pulp/view/geometry.hpp",
+      "core/canvas/src/skia_canvas.cpp",
+      "core/canvas/platform/mac/cg_canvas.mm"
     ],
-    "_notes_on_consumer_surfaces": "The same prop can have different status across consumer surfaces. 'css/*' tracks what core/view/js/web-compat-style-decl.js (the DOM-lite el.style adapter) routes; 'rn/*' tracks what packages/pulp-react/src/prop-applier.ts (the React renderer for @pulp/react JSX intrinsics) routes; 'yoga/*' tracks the underlying Yoga-shaped layout surface in core/view/include/pulp/view/geometry.hpp::FlexStyle. Where a prop is supported by one consumer but not another, both are noted explicitly in 'notes'."
+    "_notes_on_consumer_surfaces": "The same prop can have different status across consumer surfaces. 'css/*' tracks what core/view/js/web-compat-style-decl.js (the DOM-lite el.style adapter) routes; 'rn/*' tracks what packages/pulp-react/src/prop-applier.ts (the React renderer for @pulp/react JSX intrinsics) routes; 'yoga/*' tracks the underlying Yoga-shaped layout surface in core/view/include/pulp/view/geometry.hpp::FlexStyle; 'canvas2d/*' tracks the Canvas2D shim in web-compat-canvas.js paired with the canvas* family in widget_bridge.cpp + the Skia/CG backends in core/canvas/; 'html/*' tracks the DOM-lite Element / HTMLElement surface in web-compat-element.js + web-compat-document.js. Where a prop is supported by one consumer but not another, both are noted explicitly in 'notes'.",
+    "_changelog": {
+      "2026-04-30": "Initial population \u2014 361 entries across css/, rn/, yoga/. react/, html/, canvas2d/ stubbed. PR #1166.",
+      "2026-05-04": "Refresh after PRs #1167, #1169, #1173, #1174, #1291, #1297, #1344, #1345, #1347, #1348, #1353. Populated canvas2d/ (~60 entries) and html/ (~30 entries). Added rn/d, rn/viewBox, rn/fill, rn/stroke, rn/strokeWidth, rn/overlay (SvgPath + overlay-routing). Updated css/border, css/borderRadius, css/borderColor, css/fontFamily status to reflect per-attribute setter routing. Added css/_hover_pseudo for :hover stylesheet support."
+    },
+    "counts": {
+      "css": 195,
+      "rn": 120,
+      "yoga": 53,
+      "react": 0,
+      "html": 59,
+      "canvas2d": 63,
+      "imports": 5
+    }
   },
   "css": {
+    "css/__hover_pseudo": {
+      "status": "supported",
+      "mapsTo": "web-compat-document.js (#1345 / pulp #1149 part b): `:hover` rules are parsed out of the inline <style> element, stashed per-element, and the document installs mouseenter/mouseleave listeners that swap the styles on the fly.",
+      "supportedValues": [
+        ":hover (any element selector)"
+      ],
+      "unsupportedValues": [
+        ":focus",
+        ":active",
+        ":focus-within",
+        ":focus-visible",
+        ":nth-child(...)",
+        ":not(...)",
+        ":hover combinators (e.g. .a:hover .b)"
+      ],
+      "tests": [],
+      "notes": "Pseudo-class support is intentionally narrow. `:hover` is the highest-impact CSS selector in interactive UIs and the most-requested by Spectr/FilterBank consumers. The other interactive pseudo-classes (`:focus`, `:active`) require additional bridge plumbing and are not yet wired.",
+      "issue": "1149"
+    },
+    "css/__pseudo_classes_note": {
+      "status": "missing",
+      "mapsTo": "no CSS pseudo-class system today",
+      "supportedValues": [],
+      "unsupportedValues": [
+        ":hover",
+        ":active",
+        ":focus",
+        ":focus-visible",
+        ":disabled",
+        ":checked",
+        ":first-child",
+        ":last-child",
+        ":nth-child",
+        "etc."
+      ],
+      "tests": [],
+      "notes": "Pulp routes hover/click/etc. through bridge event registrations (registerHover, registerClick) rather than through CSS pseudo-classes. JSX consumers wire interactivity via on* event props, not via CSS.",
+      "issue": ""
+    },
+    "css/alignContent": {
+      "status": "missing",
+      "mapsTo": "web-compat calls setFlex(id, 'align_content', ...) but setFlex switch has NO 'align_content' branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "MAJOR GAP -- silently dropped. Multi-line flex layouts have no cross-axis alignment control.",
+      "issue": ""
+    },
+    "css/alignItems": {
+      "status": "partial",
+      "mapsTo": "setFlex(id, 'align_items', value)",
+      "supportedValues": [
+        "flex-start",
+        "flex-end",
+        "center",
+        "stretch"
+      ],
+      "unsupportedValues": [
+        "baseline",
+        "first baseline",
+        "last baseline"
+      ],
+      "tests": [],
+      "notes": "FlexAlign enum has {start, center, end, stretch, auto_} -- no baseline support.",
+      "issue": ""
+    },
+    "css/alignSelf": {
+      "status": "partial",
+      "mapsTo": "setFlex(id, 'align_self', value)",
+      "supportedValues": [
+        "auto",
+        "flex-start",
+        "flex-end",
+        "center",
+        "stretch"
+      ],
+      "unsupportedValues": [
+        "baseline"
+      ],
+      "tests": [],
+      "notes": "Same enum as align-items.",
+      "issue": ""
+    },
+    "css/all": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "initial",
+        "inherit",
+        "unset",
+        "revert"
+      ],
+      "tests": [],
+      "notes": "CSS-cascade reset not modeled.",
+      "issue": ""
+    },
+    "css/animation": {
+      "status": "partial",
+      "mapsTo": "parseTransition + setAnimation -- but setAnimation is a TODO no-op",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "MAJOR GAP -- widget_bridge.cpp:3208 setAnimation is registered but the body is `(void)id; (void)prop;...` -- a stub. CSS @keyframes animations are silently dropped.",
+      "issue": ""
+    },
+    "css/animationDelay": {
+      "status": "missing",
+      "mapsTo": "setAnimation stub",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Stub no-op.",
+      "issue": ""
+    },
+    "css/animationDirection": {
+      "status": "missing",
+      "mapsTo": "setAnimation stub",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Stub no-op.",
+      "issue": ""
+    },
+    "css/animationDuration": {
+      "status": "missing",
+      "mapsTo": "setAnimation stub",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Stub no-op.",
+      "issue": ""
+    },
+    "css/animationFillMode": {
+      "status": "missing",
+      "mapsTo": "setAnimation stub",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Stub no-op.",
+      "issue": ""
+    },
+    "css/animationIterationCount": {
+      "status": "missing",
+      "mapsTo": "setAnimation stub",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Stub no-op.",
+      "issue": ""
+    },
+    "css/animationName": {
+      "status": "missing",
+      "mapsTo": "setAnimation stub",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Stub no-op.",
+      "issue": ""
+    },
+    "css/animationPlayState": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/animationTimingFunction": {
+      "status": "missing",
+      "mapsTo": "setAnimation stub",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Stub no-op.",
+      "issue": ""
+    },
+    "css/aspectRatio": {
+      "status": "partial",
+      "mapsTo": "web-compat-style-decl.js parses '16/9' and calls setFlex(id, 'aspect_ratio', ratio); but FlexStyle has NO aspect_ratio field, so setFlex silently drops it",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "MAJOR GAP -- the parser exists but the layout backend doesn't honor it. The setFlex switch in widget_bridge.cpp:1624-1685 has no 'aspect_ratio' branch.",
+      "issue": ""
+    },
+    "css/backdropFilter": {
+      "status": "supported",
+      "mapsTo": "setBackdropFilter(id, blur_px)",
+      "supportedValues": [
+        "blur(<px>)"
+      ],
+      "unsupportedValues": [
+        "other filter functions"
+      ],
+      "tests": [],
+      "notes": "Blur-only.",
+      "issue": ""
+    },
+    "css/backfaceVisibility": {
+      "status": "supported",
+      "mapsTo": "setBackfaceVisibility(id, value)",
+      "supportedValues": [
+        "visible",
+        "hidden"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/background": {
+      "status": "partial",
+      "mapsTo": "if 'gradient' in value -> setBackgroundGradient; else parseCSSColor -> setBackground",
+      "supportedValues": [
+        "color",
+        "linear-gradient(...)"
+      ],
+      "unsupportedValues": [
+        "url()",
+        "image",
+        "repeat",
+        "size in shorthand",
+        "conic-gradient",
+        "multiple backgrounds"
+      ],
+      "tests": [],
+      "notes": "Background shorthand supports only color OR a gradient.",
+      "issue": ""
+    },
+    "css/backgroundAttachment": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/backgroundClip": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "border-box",
+        "padding-box",
+        "content-box",
+        "text"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/backgroundColor": {
+      "status": "supported",
+      "mapsTo": "parseCSSColor -> setBackground(id, hex)",
+      "supportedValues": [
+        "#hex",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "named colors"
+      ],
+      "unsupportedValues": [
+        "color()",
+        "lab()",
+        "lch()",
+        "oklab()",
+        "oklch()",
+        "color-mix()"
+      ],
+      "tests": [],
+      "notes": "Modern color spaces not supported by parseCSSColor.",
+      "issue": ""
+    },
+    "css/backgroundImage": {
+      "status": "partial",
+      "mapsTo": "same path as background",
+      "supportedValues": [
+        "linear-gradient(...)",
+        "radial-gradient(...) (parsed)"
+      ],
+      "unsupportedValues": [
+        "url()",
+        "image-set()",
+        "conic-gradient",
+        "multiple"
+      ],
+      "tests": [],
+      "notes": "url() image backgrounds not implemented.",
+      "issue": ""
+    },
+    "css/backgroundOrigin": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/backgroundPosition": {
+      "status": "missing",
+      "mapsTo": "web-compat calls setBackgroundPosition if defined -- bridge does NOT register it",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "center",
+        "top left",
+        "px/%"
+      ],
+      "tests": [],
+      "notes": "Silent no-op.",
+      "issue": ""
+    },
+    "css/backgroundRepeat": {
+      "status": "missing",
+      "mapsTo": "web-compat calls setBackgroundRepeat if defined -- bridge does NOT register it",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "repeat",
+        "no-repeat",
+        "repeat-x",
+        "repeat-y",
+        "space",
+        "round"
+      ],
+      "tests": [],
+      "notes": "Silent no-op.",
+      "issue": ""
+    },
+    "css/backgroundSize": {
+      "status": "missing",
+      "mapsTo": "web-compat calls setBackgroundSize if defined -- bridge does NOT register it",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "cover",
+        "contain",
+        "auto",
+        "px",
+        "%"
+      ],
+      "tests": [],
+      "notes": "Silent no-op. Tied to backgroundImage url() which is also missing.",
+      "issue": ""
+    },
+    "css/border": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'border' shorthand parses '<width>px solid <color>' and routes to setBorderColor(id, color) + setBorderWidth(id, width) (per-attribute, NOT the unified setBorder, to preserve any prior borderRadius). 'borderColor' / 'borderWidth' / 'borderRadius' route to their respective per-attribute setters too \u2014 see pulp #1166/#1169.",
+      "supportedValues": [
+        "solid (only)"
+      ],
+      "unsupportedValues": [
+        "dashed",
+        "dotted",
+        "double",
+        "groove",
+        "ridge",
+        "inset",
+        "outset",
+        "none",
+        "hidden"
+      ],
+      "tests": [],
+      "notes": "Fixed 2026-04-26 (#1169 / audit PR #1166 finding #4): per-attribute setters now preserve unset siblings, matching CSS semantics. Setting `borderColor` after `borderRadius` no longer zeros the radius. The unified setBorder(id, color, width, radius) is still available for the React `border` object-prop path. Border style ('solid', 'dashed', 'dotted', 'double') is parsed but only the default solid pen is rendered today.",
+      "issue": "1166"
+    },
+    "css/borderBottom": {
+      "status": "partial",
+      "mapsTo": "regex parse -> setBorderSide(id, 'bottom', width, color)",
+      "supportedValues": [
+        "solid"
+      ],
+      "unsupportedValues": [
+        "non-solid styles"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderBottomColor": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'bottom', 0, color)",
+      "supportedValues": [
+        "any css color"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderBottomLeftRadius": {
+      "status": "supported",
+      "mapsTo": "setCornerRadius(id, 'BottomLeft', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderBottomRightRadius": {
+      "status": "supported",
+      "mapsTo": "setCornerRadius(id, 'BottomRight', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderBottomWidth": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'bottom', px, '')",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderCollapse": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See tableLayout.",
+      "issue": ""
+    },
+    "css/borderColor": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'borderColor' -> setBorderColor(id, color) \u2014 per-attribute, preserves width and radius.",
+      "supportedValues": [
+        "any css color"
+      ],
+      "unsupportedValues": [
+        "currentColor"
+      ],
+      "tests": [],
+      "notes": "Fixed 2026-04-26 (#1169). Previously routed onto the unified setBorder which clobbered radius. Now uses the dedicated setBorderColor bridge fn.",
+      "issue": "1166"
+    },
+    "css/borderLeft": {
+      "status": "partial",
+      "mapsTo": "regex parse -> setBorderSide(id, 'left', width, color)",
+      "supportedValues": [
+        "solid"
+      ],
+      "unsupportedValues": [
+        "non-solid styles"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderLeftColor": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'left', 0, color)",
+      "supportedValues": [
+        "any css color"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderLeftWidth": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'left', px, '')",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderRadius": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'borderRadius' -> setBorderRadius(id, value).",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "two-value elliptical",
+        "/ separator"
+      ],
+      "tests": [],
+      "notes": "Fixed 2026-04-26 (#1169). Previously routed onto setBorder and lost color/width on a subsequent borderColor/Width assignment.",
+      "issue": "1166"
+    },
+    "css/borderRight": {
+      "status": "partial",
+      "mapsTo": "regex parse -> setBorderSide(id, 'right', width, color)",
+      "supportedValues": [
+        "solid"
+      ],
+      "unsupportedValues": [
+        "non-solid styles"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderRightColor": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'right', 0, color)",
+      "supportedValues": [
+        "any css color"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderRightWidth": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'right', px, '')",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderSpacing": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See tableLayout.",
+      "issue": ""
+    },
+    "css/borderStyle": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "solid",
+        "dashed",
+        "dotted",
+        "double",
+        "etc."
+      ],
+      "tests": [],
+      "notes": "Renderer always paints solid.",
+      "issue": ""
+    },
+    "css/borderTop": {
+      "status": "partial",
+      "mapsTo": "regex parse -> setBorderSide(id, 'top', width, color)",
+      "supportedValues": [
+        "solid"
+      ],
+      "unsupportedValues": [
+        "dashed",
+        "dotted",
+        "etc. (style discarded)"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderTopColor": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'top', 0, color)",
+      "supportedValues": [
+        "any css color"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Sets width to 0 -- must combine with borderTopWidth. Quirk.",
+      "issue": ""
+    },
+    "css/borderTopLeftRadius": {
+      "status": "supported",
+      "mapsTo": "setCornerRadius(id, 'TopLeft', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "elliptical x/y"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderTopRightRadius": {
+      "status": "supported",
+      "mapsTo": "setCornerRadius(id, 'TopRight', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderTopWidth": {
+      "status": "supported",
+      "mapsTo": "setBorderSide(id, 'top', px, '')",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/borderWidth": {
+      "status": "supported",
+      "mapsTo": "setBorder(id, '', px, 0)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "thin",
+        "medium",
+        "thick",
+        "%"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/bottom": {
+      "status": "supported",
+      "mapsTo": "setBottom(id, px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "em",
+        "rem",
+        "vh/vw"
+      ],
+      "tests": [],
+      "notes": "Same limitation as top.",
+      "issue": ""
+    },
+    "css/boxShadow": {
+      "status": "supported",
+      "mapsTo": "regex parse -> setBoxShadow(id, dx, dy, blur, spread, color, inset)",
+      "supportedValues": [
+        "[inset] <dx>px <dy>px <blur>px [<spread>px] <color>"
+      ],
+      "unsupportedValues": [
+        "multiple shadows (comma-separated)"
+      ],
+      "tests": [],
+      "notes": "Single-shadow only. Multiple comma-separated shadows are not split.",
+      "issue": ""
+    },
+    "css/boxSizing": {
+      "status": "missing",
+      "mapsTo": "web-compat-style-decl.js calls setBoxSizing if defined -- but the bridge does NOT register setBoxSizing",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "border-box",
+        "content-box"
+      ],
+      "tests": [],
+      "notes": "Silent no-op. typeof guard in JS prevents a runtime error but the value is never honored. Yoga's box model is content-box-equivalent.",
+      "issue": ""
+    },
+    "css/captionSide": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See tableLayout.",
+      "issue": ""
+    },
+    "css/clear": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Float-companion property -- not relevant.",
+      "issue": ""
+    },
+    "css/clipPath": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "polygon",
+        "circle",
+        "ellipse",
+        "inset",
+        "url(#clip)"
+      ],
+      "tests": [],
+      "notes": "Custom clip paths not supported.",
+      "issue": ""
+    },
+    "css/color": {
+      "status": "supported",
+      "mapsTo": "parseCSSColor -> setTextColor(id, hex)",
+      "supportedValues": [
+        "#hex",
+        "rgb()",
+        "rgba()",
+        "hsl()",
+        "hsla()",
+        "named"
+      ],
+      "unsupportedValues": [
+        "lab/lch/oklab/oklch/color-mix"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/columnCount": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See columns.",
+      "issue": ""
+    },
+    "css/columnGap": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'column_gap', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/columnRule": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See columns.",
+      "issue": ""
+    },
+    "css/columnWidth": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See columns.",
+      "issue": ""
+    },
+    "css/columns": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Multi-column layout out of scope; not aligned with Yoga or RN.",
+      "issue": ""
+    },
+    "css/contain": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Browser-only optimization hint.",
+      "issue": ""
+    },
+    "css/content": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "::before/::after not supported (no pseudo-element model).",
+      "issue": ""
+    },
+    "css/contentVisibility": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Browser-only optimization hint.",
+      "issue": ""
+    },
+    "css/counterIncrement": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not in scope.",
+      "issue": ""
+    },
+    "css/counterReset": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "CSS counters not in scope.",
+      "issue": ""
+    },
+    "css/cursor": {
+      "status": "supported",
+      "mapsTo": "setCursor(id, value)",
+      "supportedValues": [
+        "auto",
+        "pointer",
+        "default",
+        "etc. -- passed through to setCursor"
+      ],
+      "unsupportedValues": [
+        "url()"
+      ],
+      "tests": [],
+      "notes": "View::CursorStyle enum lists supported values.",
+      "issue": ""
+    },
+    "css/direction": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "ltr",
+        "rtl"
+      ],
+      "tests": [],
+      "notes": "RTL writing direction not modeled. Affects logical inset/margin/padding mapping (currently always LTR).",
+      "issue": ""
+    },
     "css/display": {
       "status": "partial",
       "mapsTo": "web-compat-style-decl.js: 'display' -> setVisible(id, false) on 'none', setVisible(id, true) on 'flex'/'block'. 'grid' is acknowledged but only takes effect when gridTemplateColumns/Rows is also set. Yoga has no 'block', 'inline', 'inline-block', 'table', 'contents' modes -- Pulp is flex-only.",
@@ -43,535 +963,40 @@
         "list-item"
       ],
       "tests": [],
-      "notes": "Yoga's underlying view model is exclusively flex. 'block' is silently aliased to 'flex'. RN's display enum is {none, flex, contents} which matches us better than CSS. The Display enum on the C++ View has no direct field -- visibility is implemented via View::set_visible. There is no 'partial' display rendering -- non-flex values render as flex with default direction.",
-      "issue": ""
+      "notes": "Yoga's underlying view model is exclusively flex. 'block' is silently aliased to 'flex'. RN's display enum is {none, flex, contents} which matches us better than CSS. The Display enum on the C++ View has no direct field -- visibility is implemented via View::set_visible. There is no 'partial' display rendering -- non-flex values render as flex with default direction. 2026-04-28 (#1167 / pulp #1147): `display: flex` now defaults flex-direction to 'row' to match CSS web compat (Pulp's underlying widgets default to 'col' / FlexDirection::column from RN convention, so the JS shim emits an explicit 'row' when the consumer didn't declare flexDirection / flex-direction / flex-flow with a direction token).",
+      "issue": "1147"
     },
-    "css/position": {
-      "status": "supported",
-      "mapsTo": "web-compat-style-decl.js: 'position' -> setPosition. View::Position enum has static_/relative/absolute/fixed/sticky.",
-      "supportedValues": [
-        "static",
-        "relative",
-        "absolute",
-        "fixed",
-        "sticky"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "All five CSS values are accepted by the bridge. 'fixed' and 'sticky' may render the same as 'absolute' in practice -- see #779 follow-ups for behavioral verification.",
-      "issue": ""
-    },
-    "css/top": {
-      "status": "supported",
-      "mapsTo": "setTop(id, px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem",
-        "vh/vw"
-      ],
-      "tests": [],
-      "notes": "parseCSSLength is invoked but the bridge stores raw px only -- percentage values are dropped. setTop accepts numbers only.",
-      "issue": ""
-    },
-    "css/right": {
-      "status": "supported",
-      "mapsTo": "setRight(id, px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem",
-        "vh/vw"
-      ],
-      "tests": [],
-      "notes": "Same limitation as top.",
-      "issue": ""
-    },
-    "css/bottom": {
-      "status": "supported",
-      "mapsTo": "setBottom(id, px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem",
-        "vh/vw"
-      ],
-      "tests": [],
-      "notes": "Same limitation as top.",
-      "issue": ""
-    },
-    "css/left": {
-      "status": "supported",
-      "mapsTo": "setLeft(id, px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem",
-        "vh/vw"
-      ],
-      "tests": [],
-      "notes": "Same limitation as top.",
-      "issue": ""
-    },
-    "css/inset": {
-      "status": "supported",
-      "mapsTo": "expandShorthand -> setTop/setRight/setBottom/setLeft",
-      "supportedValues": [
-        "1-4 px tokens"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "Shorthand expands correctly. Underlying setTop/etc. are px only.",
-      "issue": ""
-    },
-    "css/zIndex": {
-      "status": "supported",
-      "mapsTo": "setZIndex(id, int)",
-      "supportedValues": [
-        "integer"
-      ],
-      "unsupportedValues": [
-        "auto"
-      ],
-      "tests": [],
-      "notes": "'auto' parses as 0.",
-      "issue": ""
-    },
-    "css/width": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'width', px)",
-      "supportedValues": [
-        "px (number)"
-      ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem",
-        "auto",
-        "min-content",
-        "max-content",
-        "fit-content",
-        "calc()"
-      ],
-      "tests": [],
-      "notes": "FlexStyle.preferred_width is a float. Yoga in upstream supports % and auto, but Pulp's C++ port loses that on the JSON wire -- only floats are accepted by setFlex.",
-      "issue": ""
-    },
-    "css/height": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'height', px)",
-      "supportedValues": [
-        "px (number)"
-      ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem",
-        "auto",
-        "min-content",
-        "max-content",
-        "fit-content"
-      ],
-      "tests": [],
-      "notes": "Same as width. dim_height supports DimensionUnit::vw/vh/percent/vmin/vmax internally but the setFlex bridge only accepts a single double.",
-      "issue": ""
-    },
-    "css/minWidth": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'min_width', px)",
-      "supportedValues": [
-        "px (number)"
-      ],
-      "unsupportedValues": [
-        "%",
-        "calc()"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/minHeight": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'min_height', px)",
-      "supportedValues": [
-        "px (number)"
-      ],
-      "unsupportedValues": [
-        "%",
-        "calc()"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/maxWidth": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'max_width', px)",
-      "supportedValues": [
-        "px (number)"
-      ],
-      "unsupportedValues": [
-        "%",
-        "calc()"
-      ],
-      "tests": [],
-      "notes": "0 = no maximum (semantic differs from CSS where unspecified = none).",
-      "issue": ""
-    },
-    "css/maxHeight": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'max_height', px)",
-      "supportedValues": [
-        "px (number)"
-      ],
-      "unsupportedValues": [
-        "%",
-        "calc()"
-      ],
-      "tests": [],
-      "notes": "Same as max-width.",
-      "issue": ""
-    },
-    "css/aspectRatio": {
-      "status": "partial",
-      "mapsTo": "web-compat-style-decl.js parses '16/9' and calls setFlex(id, 'aspect_ratio', ratio); but FlexStyle has NO aspect_ratio field, so setFlex silently drops it",
+    "css/emptyCells": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
       "supportedValues": [],
       "unsupportedValues": [
         "all"
       ],
       "tests": [],
-      "notes": "MAJOR GAP -- the parser exists but the layout backend doesn't honor it. The setFlex switch in widget_bridge.cpp:1624-1685 has no 'aspect_ratio' branch.",
+      "notes": "See tableLayout.",
       "issue": ""
     },
-    "css/boxSizing": {
-      "status": "missing",
-      "mapsTo": "web-compat-style-decl.js calls setBoxSizing if defined -- but the bridge does NOT register setBoxSizing",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "border-box",
-        "content-box"
-      ],
-      "tests": [],
-      "notes": "Silent no-op. typeof guard in JS prevents a runtime error but the value is never honored. Yoga's box model is content-box-equivalent.",
-      "issue": ""
-    },
-    "css/margin": {
+    "css/filter": {
       "status": "supported",
-      "mapsTo": "expandShorthand -> setFlex(id, 'margin_*', px)",
+      "mapsTo": "setFilter(id, value)",
       "supportedValues": [
-        "px (1-4 tokens)"
+        "blur(<px>)"
       ],
       "unsupportedValues": [
-        "auto",
-        "%",
-        "negative-edge-cases"
+        "brightness",
+        "contrast",
+        "drop-shadow",
+        "grayscale",
+        "hue-rotate",
+        "invert",
+        "opacity",
+        "saturate",
+        "sepia",
+        "multi-function chain"
       ],
       "tests": [],
-      "notes": "'margin: auto' centers in CSS -- Pulp does NOT honor auto margins.",
-      "issue": ""
-    },
-    "css/marginTop": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'margin_top', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%",
-        "auto"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/marginRight": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'margin_right', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%",
-        "auto"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/marginBottom": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'margin_bottom', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%",
-        "auto"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/marginLeft": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'margin_left', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%",
-        "auto"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/marginInline": {
-      "status": "supported",
-      "mapsTo": "expandShorthand -> setFlex(id, 'margin_left'/'margin_right', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "Logical property normalized to physical. No RTL awareness -- always treated as LTR (margin_left = inline-start).",
-      "issue": ""
-    },
-    "css/marginBlock": {
-      "status": "supported",
-      "mapsTo": "expandShorthand -> setFlex(id, 'margin_top'/'margin_bottom', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "Logical property; assumes horizontal writing mode.",
-      "issue": ""
-    },
-    "css/marginInlineStart": {
-      "status": "missing",
-      "mapsTo": "case in switch is bare break (line 609); RTL untracked",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled (bare break in switch).",
-      "issue": ""
-    },
-    "css/marginInlineEnd": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/marginBlockStart": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/marginBlockEnd": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/padding": {
-      "status": "supported",
-      "mapsTo": "expandShorthand -> setFlex(id, 'padding_*', px)",
-      "supportedValues": [
-        "px (1-4 tokens)"
-      ],
-      "unsupportedValues": [
-        "%"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/paddingTop": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'padding_top', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/paddingRight": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'padding_right', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/paddingBottom": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'padding_bottom', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/paddingLeft": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'padding_left', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/paddingInline": {
-      "status": "supported",
-      "mapsTo": "expandShorthand -> setFlex(id, 'padding_left/right', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "Logical property mapped LTR-only.",
-      "issue": ""
-    },
-    "css/paddingBlock": {
-      "status": "supported",
-      "mapsTo": "expandShorthand -> setFlex(id, 'padding_top/bottom', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/paddingInlineStart": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/paddingInlineEnd": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/paddingBlockStart": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/paddingBlockEnd": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/gap": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'gap', px)",
-      "supportedValues": [
-        "px (number)"
-      ],
-      "unsupportedValues": [
-        "two-value (row col) syntax"
-      ],
-      "tests": [],
-      "notes": "Two-value 'gap: 10px 20px' is not handled by parseCSSLength -- it parses only the first token.",
-      "issue": ""
-    },
-    "css/rowGap": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'row_gap', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/columnGap": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'column_gap', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%"
-      ],
-      "tests": [],
-      "notes": "",
+      "notes": "Bridge parses 'blur(Npx)'. Other filter functions pass through verbatim.",
       "issue": ""
     },
     "css/flex": {
@@ -591,6 +1016,21 @@
       "notes": "The CSS shorthand keywords (auto/none/initial) parse as NaN and silently set flex_grow=0.",
       "issue": ""
     },
+    "css/flexBasis": {
+      "status": "partial",
+      "mapsTo": "setFlex(id, 'flex_basis', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "auto",
+        "content"
+      ],
+      "tests": [],
+      "notes": "Yoga supports 'auto' and percentages; Pulp accepts only px float.",
+      "issue": ""
+    },
     "css/flexDirection": {
       "status": "partial",
       "mapsTo": "setFlex(id, 'direction', 'row' | 'col')",
@@ -604,20 +1044,6 @@
       ],
       "tests": [],
       "notes": "MAJOR GAP -- Pulp's FlexDirection enum (geometry.hpp:61) only has {row, column}. Reverse modes silently fall through to default 'col'.",
-      "issue": ""
-    },
-    "css/flexWrap": {
-      "status": "partial",
-      "mapsTo": "setFlex(id, 'flex_wrap', 0|1)",
-      "supportedValues": [
-        "nowrap",
-        "wrap"
-      ],
-      "unsupportedValues": [
-        "wrap-reverse"
-      ],
-      "tests": [],
-      "notes": "FlexStyle.flex_wrap is a bool -- wrap-reverse cannot be expressed.",
       "issue": ""
     },
     "css/flexFlow": {
@@ -657,744 +1083,36 @@
       "notes": "",
       "issue": ""
     },
-    "css/flexBasis": {
+    "css/flexWrap": {
       "status": "partial",
-      "mapsTo": "setFlex(id, 'flex_basis', px)",
+      "mapsTo": "setFlex(id, 'flex_wrap', 0|1)",
       "supportedValues": [
-        "px"
+        "nowrap",
+        "wrap"
       ],
       "unsupportedValues": [
-        "%",
-        "auto",
-        "content"
+        "wrap-reverse"
       ],
       "tests": [],
-      "notes": "Yoga supports 'auto' and percentages; Pulp accepts only px float.",
+      "notes": "FlexStyle.flex_wrap is a bool -- wrap-reverse cannot be expressed.",
       "issue": ""
     },
-    "css/justifyContent": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'justify_content', value)",
-      "supportedValues": [
-        "flex-start (start)",
-        "flex-end (end)",
-        "center",
-        "space-between",
-        "space-around",
-        "space-evenly"
-      ],
+    "css/float": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
       "unsupportedValues": [
         "left",
         "right",
-        "stretch",
-        "normal"
+        "none"
       ],
       "tests": [],
-      "notes": "FlexJustify enum covers the 6 RN values.",
-      "issue": ""
-    },
-    "css/alignItems": {
-      "status": "partial",
-      "mapsTo": "setFlex(id, 'align_items', value)",
-      "supportedValues": [
-        "flex-start",
-        "flex-end",
-        "center",
-        "stretch"
-      ],
-      "unsupportedValues": [
-        "baseline",
-        "first baseline",
-        "last baseline"
-      ],
-      "tests": [],
-      "notes": "FlexAlign enum has {start, center, end, stretch, auto_} -- no baseline support.",
-      "issue": ""
-    },
-    "css/alignSelf": {
-      "status": "partial",
-      "mapsTo": "setFlex(id, 'align_self', value)",
-      "supportedValues": [
-        "auto",
-        "flex-start",
-        "flex-end",
-        "center",
-        "stretch"
-      ],
-      "unsupportedValues": [
-        "baseline"
-      ],
-      "tests": [],
-      "notes": "Same enum as align-items.",
-      "issue": ""
-    },
-    "css/alignContent": {
-      "status": "missing",
-      "mapsTo": "web-compat calls setFlex(id, 'align_content', ...) but setFlex switch has NO 'align_content' branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "MAJOR GAP -- silently dropped. Multi-line flex layouts have no cross-axis alignment control.",
-      "issue": ""
-    },
-    "css/order": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'order', n)",
-      "supportedValues": [
-        "integer"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/placeItems": {
-      "status": "partial",
-      "mapsTo": "setFlex 'align_items' + 'justify_content'",
-      "supportedValues": [
-        "align-items justify-content shorthand"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "Misnamed -- second token is mapped to justify_content rather than justify_items (which Yoga doesn't support).",
-      "issue": ""
-    },
-    "css/placeContent": {
-      "status": "partial",
-      "mapsTo": "setFlex 'align_content' + 'justify_content'",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "align_content half is silently dropped (see css/alignContent).",
-      "issue": ""
-    },
-    "css/overflow": {
-      "status": "partial",
-      "mapsTo": "setOverflow(id, 'visible'|'hidden')",
-      "supportedValues": [
-        "visible",
-        "hidden"
-      ],
-      "unsupportedValues": [
-        "scroll",
-        "auto",
-        "clip",
-        "overlay"
-      ],
-      "tests": [],
-      "notes": "View::Overflow enum has only {visible, hidden}. Scroll requires using the ScrollView intrinsic.",
-      "issue": ""
-    },
-    "css/overflowX": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Per-axis overflow not honored.",
-      "issue": ""
-    },
-    "css/overflowY": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Per-axis overflow not honored.",
-      "issue": ""
-    },
-    "css/visibility": {
-      "status": "partial",
-      "mapsTo": "setVisibility(id, 'visible'|'hidden') if registered, else opacity fallback",
-      "supportedValues": [
-        "visible",
-        "hidden"
-      ],
-      "unsupportedValues": [
-        "collapse"
-      ],
-      "tests": [],
-      "notes": "setVisibility IS registered (widget_bridge.cpp:1814) so the primary path works.",
-      "issue": ""
-    },
-    "css/opacity": {
-      "status": "supported",
-      "mapsTo": "setOpacity(id, n)",
-      "supportedValues": [
-        "0..1 number"
-      ],
-      "unsupportedValues": [
-        "percentage strings"
-      ],
-      "tests": [],
-      "notes": "parseFloat strips the % suffix silently.",
-      "issue": ""
-    },
-    "css/backgroundColor": {
-      "status": "supported",
-      "mapsTo": "parseCSSColor -> setBackground(id, hex)",
-      "supportedValues": [
-        "#hex",
-        "rgb()",
-        "rgba()",
-        "hsl()",
-        "hsla()",
-        "named colors"
-      ],
-      "unsupportedValues": [
-        "color()",
-        "lab()",
-        "lch()",
-        "oklab()",
-        "oklch()",
-        "color-mix()"
-      ],
-      "tests": [],
-      "notes": "Modern color spaces not supported by parseCSSColor.",
-      "issue": ""
-    },
-    "css/color": {
-      "status": "supported",
-      "mapsTo": "parseCSSColor -> setTextColor(id, hex)",
-      "supportedValues": [
-        "#hex",
-        "rgb()",
-        "rgba()",
-        "hsl()",
-        "hsla()",
-        "named"
-      ],
-      "unsupportedValues": [
-        "lab/lch/oklab/oklch/color-mix"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/background": {
-      "status": "partial",
-      "mapsTo": "if 'gradient' in value -> setBackgroundGradient; else parseCSSColor -> setBackground",
-      "supportedValues": [
-        "color",
-        "linear-gradient(...)"
-      ],
-      "unsupportedValues": [
-        "url()",
-        "image",
-        "repeat",
-        "size in shorthand",
-        "conic-gradient",
-        "multiple backgrounds"
-      ],
-      "tests": [],
-      "notes": "Background shorthand supports only color OR a gradient.",
-      "issue": ""
-    },
-    "css/backgroundImage": {
-      "status": "partial",
-      "mapsTo": "same path as background",
-      "supportedValues": [
-        "linear-gradient(...)",
-        "radial-gradient(...) (parsed)"
-      ],
-      "unsupportedValues": [
-        "url()",
-        "image-set()",
-        "conic-gradient",
-        "multiple"
-      ],
-      "tests": [],
-      "notes": "url() image backgrounds not implemented.",
-      "issue": ""
-    },
-    "css/backgroundSize": {
-      "status": "missing",
-      "mapsTo": "web-compat calls setBackgroundSize if defined -- bridge does NOT register it",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "cover",
-        "contain",
-        "auto",
-        "px",
-        "%"
-      ],
-      "tests": [],
-      "notes": "Silent no-op. Tied to backgroundImage url() which is also missing.",
-      "issue": ""
-    },
-    "css/backgroundPosition": {
-      "status": "missing",
-      "mapsTo": "web-compat calls setBackgroundPosition if defined -- bridge does NOT register it",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "center",
-        "top left",
-        "px/%"
-      ],
-      "tests": [],
-      "notes": "Silent no-op.",
-      "issue": ""
-    },
-    "css/backgroundRepeat": {
-      "status": "missing",
-      "mapsTo": "web-compat calls setBackgroundRepeat if defined -- bridge does NOT register it",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "repeat",
-        "no-repeat",
-        "repeat-x",
-        "repeat-y",
-        "space",
-        "round"
-      ],
-      "tests": [],
-      "notes": "Silent no-op.",
-      "issue": ""
-    },
-    "css/backgroundAttachment": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/backgroundClip": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "border-box",
-        "padding-box",
-        "content-box",
-        "text"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/backgroundOrigin": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/border": {
-      "status": "partial",
-      "mapsTo": "regex parse '<width>px <style> <color>' -> setBorder(id, color, width, 0)",
-      "supportedValues": [
-        "solid (only)"
-      ],
-      "unsupportedValues": [
-        "dashed",
-        "dotted",
-        "double",
-        "groove",
-        "ridge",
-        "inset",
-        "outset",
-        "none",
-        "hidden"
-      ],
-      "tests": [],
-      "notes": "Border style is parsed but discarded -- only solid is rendered.",
-      "issue": ""
-    },
-    "css/borderWidth": {
-      "status": "supported",
-      "mapsTo": "setBorder(id, '', px, 0)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "thin",
-        "medium",
-        "thick",
-        "%"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderStyle": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "solid",
-        "dashed",
-        "dotted",
-        "double",
-        "etc."
-      ],
-      "tests": [],
-      "notes": "Renderer always paints solid.",
-      "issue": ""
-    },
-    "css/borderColor": {
-      "status": "supported",
-      "mapsTo": "parseCSSColor -> setBorder(id, hex, 1, 0)",
-      "supportedValues": [
-        "any css color"
-      ],
-      "unsupportedValues": [
-        "currentColor"
-      ],
-      "tests": [],
-      "notes": "Re-applies border with width=1 and radius=0 -- overwrites any prior radius. KNOWN BUG.",
-      "issue": ""
-    },
-    "css/borderRadius": {
-      "status": "supported",
-      "mapsTo": "setBorder(id, '', 0, radius_px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "%",
-        "two-value elliptical",
-        "/ separator"
-      ],
-      "tests": [],
-      "notes": "Re-applies border with width=0 -- overwrites prior width. KNOWN BUG. Per-corner setters work better.",
-      "issue": ""
-    },
-    "css/borderTop": {
-      "status": "partial",
-      "mapsTo": "regex parse -> setBorderSide(id, 'top', width, color)",
-      "supportedValues": [
-        "solid"
-      ],
-      "unsupportedValues": [
-        "dashed",
-        "dotted",
-        "etc. (style discarded)"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderRight": {
-      "status": "partial",
-      "mapsTo": "regex parse -> setBorderSide(id, 'right', width, color)",
-      "supportedValues": [
-        "solid"
-      ],
-      "unsupportedValues": [
-        "non-solid styles"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderBottom": {
-      "status": "partial",
-      "mapsTo": "regex parse -> setBorderSide(id, 'bottom', width, color)",
-      "supportedValues": [
-        "solid"
-      ],
-      "unsupportedValues": [
-        "non-solid styles"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderLeft": {
-      "status": "partial",
-      "mapsTo": "regex parse -> setBorderSide(id, 'left', width, color)",
-      "supportedValues": [
-        "solid"
-      ],
-      "unsupportedValues": [
-        "non-solid styles"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderTopWidth": {
-      "status": "supported",
-      "mapsTo": "setBorderSide(id, 'top', px, '')",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderRightWidth": {
-      "status": "supported",
-      "mapsTo": "setBorderSide(id, 'right', px, '')",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderBottomWidth": {
-      "status": "supported",
-      "mapsTo": "setBorderSide(id, 'bottom', px, '')",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderLeftWidth": {
-      "status": "supported",
-      "mapsTo": "setBorderSide(id, 'left', px, '')",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderTopColor": {
-      "status": "supported",
-      "mapsTo": "setBorderSide(id, 'top', 0, color)",
-      "supportedValues": [
-        "any css color"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "Sets width to 0 -- must combine with borderTopWidth. Quirk.",
-      "issue": ""
-    },
-    "css/borderRightColor": {
-      "status": "supported",
-      "mapsTo": "setBorderSide(id, 'right', 0, color)",
-      "supportedValues": [
-        "any css color"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderBottomColor": {
-      "status": "supported",
-      "mapsTo": "setBorderSide(id, 'bottom', 0, color)",
-      "supportedValues": [
-        "any css color"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderLeftColor": {
-      "status": "supported",
-      "mapsTo": "setBorderSide(id, 'left', 0, color)",
-      "supportedValues": [
-        "any css color"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderTopLeftRadius": {
-      "status": "supported",
-      "mapsTo": "setCornerRadius(id, 'TopLeft', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
-        "elliptical x/y"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderTopRightRadius": {
-      "status": "supported",
-      "mapsTo": "setCornerRadius(id, 'TopRight', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderBottomLeftRadius": {
-      "status": "supported",
-      "mapsTo": "setCornerRadius(id, 'BottomLeft', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/borderBottomRightRadius": {
-      "status": "supported",
-      "mapsTo": "setCornerRadius(id, 'BottomRight', px)",
-      "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "css/outline": {
-      "status": "missing",
-      "mapsTo": "web-compat calls setOutline if defined -- bridge does NOT register it",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Silent no-op. Affects accessibility focus rings.",
-      "issue": ""
-    },
-    "css/outlineWidth": {
-      "status": "missing",
-      "mapsTo": "web-compat calls setOutline -- never registered",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Silent no-op.",
-      "issue": ""
-    },
-    "css/outlineColor": {
-      "status": "missing",
-      "mapsTo": "web-compat calls setOutline -- never registered",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Silent no-op.",
-      "issue": ""
-    },
-    "css/outlineStyle": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/outlineOffset": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/boxShadow": {
-      "status": "supported",
-      "mapsTo": "regex parse -> setBoxShadow(id, dx, dy, blur, spread, color, inset)",
-      "supportedValues": [
-        "[inset] <dx>px <dy>px <blur>px [<spread>px] <color>"
-      ],
-      "unsupportedValues": [
-        "multiple shadows (comma-separated)"
-      ],
-      "tests": [],
-      "notes": "Single-shadow only. Multiple comma-separated shadows are not split.",
-      "issue": ""
-    },
-    "css/textShadow": {
-      "status": "missing",
-      "mapsTo": "web-compat calls setTextShadow if defined -- bridge does NOT register it",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Silent no-op.",
-      "issue": ""
-    },
-    "css/cursor": {
-      "status": "supported",
-      "mapsTo": "setCursor(id, value)",
-      "supportedValues": [
-        "auto",
-        "pointer",
-        "default",
-        "etc. -- passed through to setCursor"
-      ],
-      "unsupportedValues": [
-        "url()"
-      ],
-      "tests": [],
-      "notes": "View::CursorStyle enum lists supported values.",
-      "issue": ""
-    },
-    "css/pointerEvents": {
-      "status": "supported",
-      "mapsTo": "setPointerEvents(id, mode)",
-      "supportedValues": [
-        "auto",
-        "none",
-        "box-only",
-        "box-none"
-      ],
-      "unsupportedValues": [
-        "visible-painted",
-        "visible-fill",
-        "etc. (SVG)"
-      ],
-      "tests": [],
-      "notes": "View::PointerEvents enum.",
-      "issue": ""
-    },
-    "css/userSelect": {
-      "status": "supported",
-      "mapsTo": "setUserSelect(id, value)",
-      "supportedValues": [
-        "none",
-        "text",
-        "all"
-      ],
-      "unsupportedValues": [
-        "contain",
-        "auto"
-      ],
-      "tests": [],
-      "notes": "",
+      "notes": "CSS float not relevant under a flex-only layout model.",
       "issue": ""
     },
     "css/fontFamily": {
-      "status": "partial",
-      "mapsTo": "setFontFamily(id, name) -- strips quotes via .replace(/['\"]/g, '')",
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'fontFamily' -> splits on commas, trims, strips matching outer quotes, picks the first non-empty token, calls setFontFamily(id, name). PR #1174.",
       "supportedValues": [
         "single font name (quoted or not)"
       ],
@@ -1402,8 +1120,8 @@
         "comma-separated font lists ('JetBrains Mono', monospace)"
       ],
       "tests": [],
-      "notes": "FAMOUS BUG -- web-compat-style-decl.js:465 strips quotes from a list and passes the entire 'JetBrains Mono, monospace' as one face name. Should split on comma. Tracked in #932 / #927.",
-      "issue": ""
+      "notes": "Fixed 2026-04-29 (#1174 / pulp #1151). Generic fallbacks ('monospace', 'ui-monospace', 'sans-serif') are not specially recognized \u2014 Skia falls back to the platform default if SkFontMgr can't resolve any of the named families.",
+      "issue": "1151"
     },
     "css/fontSize": {
       "status": "supported",
@@ -1419,22 +1137,6 @@
       ],
       "tests": [],
       "notes": "",
-      "issue": ""
-    },
-    "css/fontWeight": {
-      "status": "supported",
-      "mapsTo": "parseInt -> setFontWeight(id, n)",
-      "supportedValues": [
-        "100..900 (numeric)"
-      ],
-      "unsupportedValues": [
-        "normal",
-        "bold",
-        "lighter",
-        "bolder"
-      ],
-      "tests": [],
-      "notes": "Keyword 'bold' parses as NaN -> 400. Should map: normal->400, bold->700.",
       "issue": ""
     },
     "css/fontStyle": {
@@ -1464,6 +1166,229 @@
       "notes": "RN supports fontVariant; Pulp does not.",
       "issue": ""
     },
+    "css/fontWeight": {
+      "status": "supported",
+      "mapsTo": "parseInt -> setFontWeight(id, n)",
+      "supportedValues": [
+        "100..900 (numeric)"
+      ],
+      "unsupportedValues": [
+        "normal",
+        "bold",
+        "lighter",
+        "bolder"
+      ],
+      "tests": [],
+      "notes": "Keyword 'bold' parses as NaN -> 400. Should map: normal->400, bold->700.",
+      "issue": ""
+    },
+    "css/gap": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'gap', px)",
+      "supportedValues": [
+        "px (number)"
+      ],
+      "unsupportedValues": [
+        "two-value (row col) syntax"
+      ],
+      "tests": [],
+      "notes": "Two-value 'gap: 10px 20px' is not handled by parseCSSLength -- it parses only the first token.",
+      "issue": ""
+    },
+    "css/gridArea": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/gridAutoColumns": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/gridAutoFlow": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/gridAutoRows": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/gridColumn": {
+      "status": "partial",
+      "mapsTo": "split '/' -> setGrid 'column_start'/'column_end'",
+      "supportedValues": [
+        "<n> / <n>"
+      ],
+      "unsupportedValues": [
+        "span <n>",
+        "named lines"
+      ],
+      "tests": [],
+      "notes": "Numeric only.",
+      "issue": ""
+    },
+    "css/gridRow": {
+      "status": "partial",
+      "mapsTo": "split '/' -> setGrid 'row_start'/'row_end'",
+      "supportedValues": [
+        "<n> / <n>"
+      ],
+      "unsupportedValues": [
+        "span <n>",
+        "named lines"
+      ],
+      "tests": [],
+      "notes": "Numeric only.",
+      "issue": ""
+    },
+    "css/gridTemplateAreas": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/gridTemplateColumns": {
+      "status": "partial",
+      "mapsTo": "setGrid(id, 'template_columns', value)",
+      "supportedValues": [
+        "any (forwarded verbatim)"
+      ],
+      "unsupportedValues": [
+        "repeat()",
+        "minmax()",
+        "auto-fill",
+        "auto-fit",
+        "fr units (depends on layout backend)"
+      ],
+      "tests": [],
+      "notes": "Forwarded as a string. Renderer honors only what the underlying GridStyle parser accepts. CSS Grid is largely unsupported because Yoga is flex-only.",
+      "issue": ""
+    },
+    "css/gridTemplateRows": {
+      "status": "partial",
+      "mapsTo": "setGrid(id, 'template_rows', value)",
+      "supportedValues": [
+        "any (forwarded verbatim)"
+      ],
+      "unsupportedValues": [
+        "repeat",
+        "minmax",
+        "fr"
+      ],
+      "tests": [],
+      "notes": "Same caveat as gridTemplateColumns.",
+      "issue": ""
+    },
+    "css/height": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'height', px)",
+      "supportedValues": [
+        "px (number)"
+      ],
+      "unsupportedValues": [
+        "%",
+        "em",
+        "rem",
+        "auto",
+        "min-content",
+        "max-content",
+        "fit-content"
+      ],
+      "tests": [],
+      "notes": "Same as width. dim_height supports DimensionUnit::vw/vh/percent/vmin/vmax internally but the setFlex bridge only accepts a single double.",
+      "issue": ""
+    },
+    "css/inset": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setTop/setRight/setBottom/setLeft",
+      "supportedValues": [
+        "1-4 px tokens"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Shorthand expands correctly. Underlying setTop/etc. are px only.",
+      "issue": ""
+    },
+    "css/isolation": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "auto",
+        "isolate"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/justifyContent": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'justify_content', value)",
+      "supportedValues": [
+        "flex-start (start)",
+        "flex-end (end)",
+        "center",
+        "space-between",
+        "space-around",
+        "space-evenly"
+      ],
+      "unsupportedValues": [
+        "left",
+        "right",
+        "stretch",
+        "normal"
+      ],
+      "tests": [],
+      "notes": "FlexJustify enum covers the 6 RN values.",
+      "issue": ""
+    },
+    "css/left": {
+      "status": "supported",
+      "mapsTo": "setLeft(id, px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "em",
+        "rem",
+        "vh/vw"
+      ],
+      "tests": [],
+      "notes": "Same limitation as top.",
+      "issue": ""
+    },
     "css/letterSpacing": {
       "status": "supported",
       "mapsTo": "parseCSSLength -> setLetterSpacing(id, px)",
@@ -1476,6 +1401,17 @@
       ],
       "tests": [],
       "notes": "",
+      "issue": ""
+    },
+    "css/lineClamp": {
+      "status": "missing",
+      "mapsTo": "web-compat calls setLineClamp if defined -- bridge does NOT register it",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "integer"
+      ],
+      "tests": [],
+      "notes": "Silent no-op. Both 'line-clamp' and '-webkit-line-clamp' route here.",
       "issue": ""
     },
     "css/lineHeight": {
@@ -1492,6 +1428,768 @@
       ],
       "tests": [],
       "notes": "MAJOR GAP -- unitless line-height is the most common form; we drop it.",
+      "issue": ""
+    },
+    "css/listStyle": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Pulp has no list intrinsic; lists are emulated with Col + Label children.",
+      "issue": ""
+    },
+    "css/listStyleImage": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See listStyle.",
+      "issue": ""
+    },
+    "css/listStylePosition": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See listStyle.",
+      "issue": ""
+    },
+    "css/listStyleType": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "See listStyle.",
+      "issue": ""
+    },
+    "css/margin": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setFlex(id, 'margin_*', px)",
+      "supportedValues": [
+        "px (1-4 tokens)"
+      ],
+      "unsupportedValues": [
+        "auto",
+        "%",
+        "negative-edge-cases"
+      ],
+      "tests": [],
+      "notes": "'margin: auto' centers in CSS -- Pulp does NOT honor auto margins.",
+      "issue": ""
+    },
+    "css/marginBlock": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setFlex(id, 'margin_top'/'margin_bottom', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Logical property; assumes horizontal writing mode.",
+      "issue": ""
+    },
+    "css/marginBlockEnd": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/marginBlockStart": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/marginBottom": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'margin_bottom', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "auto"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/marginInline": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setFlex(id, 'margin_left'/'margin_right', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Logical property normalized to physical. No RTL awareness -- always treated as LTR (margin_left = inline-start).",
+      "issue": ""
+    },
+    "css/marginInlineEnd": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/marginInlineStart": {
+      "status": "missing",
+      "mapsTo": "case in switch is bare break (line 609); RTL untracked",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled (bare break in switch).",
+      "issue": ""
+    },
+    "css/marginLeft": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'margin_left', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "auto"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/marginRight": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'margin_right', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "auto"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/marginTop": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'margin_top', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "auto"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/mask": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/maskImage": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/maxHeight": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'max_height', px)",
+      "supportedValues": [
+        "px (number)"
+      ],
+      "unsupportedValues": [
+        "%",
+        "calc()"
+      ],
+      "tests": [],
+      "notes": "Same as max-width.",
+      "issue": ""
+    },
+    "css/maxWidth": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'max_width', px)",
+      "supportedValues": [
+        "px (number)"
+      ],
+      "unsupportedValues": [
+        "%",
+        "calc()"
+      ],
+      "tests": [],
+      "notes": "0 = no maximum (semantic differs from CSS where unspecified = none).",
+      "issue": ""
+    },
+    "css/minHeight": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'min_height', px)",
+      "supportedValues": [
+        "px (number)"
+      ],
+      "unsupportedValues": [
+        "%",
+        "calc()"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/minWidth": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'min_width', px)",
+      "supportedValues": [
+        "px (number)"
+      ],
+      "unsupportedValues": [
+        "%",
+        "calc()"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/mixBlendMode": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "multiply",
+        "screen",
+        "overlay",
+        "etc."
+      ],
+      "tests": [],
+      "notes": "RN supports mixBlendMode in New Architecture; Pulp does not.",
+      "issue": ""
+    },
+    "css/opacity": {
+      "status": "supported",
+      "mapsTo": "setOpacity(id, n)",
+      "supportedValues": [
+        "0..1 number"
+      ],
+      "unsupportedValues": [
+        "percentage strings"
+      ],
+      "tests": [],
+      "notes": "parseFloat strips the % suffix silently.",
+      "issue": ""
+    },
+    "css/order": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'order', n)",
+      "supportedValues": [
+        "integer"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/outline": {
+      "status": "missing",
+      "mapsTo": "web-compat calls setOutline if defined -- bridge does NOT register it",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Silent no-op. Affects accessibility focus rings.",
+      "issue": ""
+    },
+    "css/outlineColor": {
+      "status": "missing",
+      "mapsTo": "web-compat calls setOutline -- never registered",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Silent no-op.",
+      "issue": ""
+    },
+    "css/outlineOffset": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/outlineStyle": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/outlineWidth": {
+      "status": "missing",
+      "mapsTo": "web-compat calls setOutline -- never registered",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Silent no-op.",
+      "issue": ""
+    },
+    "css/overflow": {
+      "status": "partial",
+      "mapsTo": "setOverflow(id, 'visible'|'hidden')",
+      "supportedValues": [
+        "visible",
+        "hidden"
+      ],
+      "unsupportedValues": [
+        "scroll",
+        "auto",
+        "clip",
+        "overlay"
+      ],
+      "tests": [],
+      "notes": "View::Overflow enum has only {visible, hidden}. Scroll requires using the ScrollView intrinsic.",
+      "issue": ""
+    },
+    "css/overflowWrap": {
+      "status": "missing",
+      "mapsTo": "same as wordBreak -- never registered",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Silent no-op.",
+      "issue": ""
+    },
+    "css/overflowX": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Per-axis overflow not honored.",
+      "issue": ""
+    },
+    "css/overflowY": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Per-axis overflow not honored.",
+      "issue": ""
+    },
+    "css/overscrollBehavior": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not in initial scope.",
+      "issue": ""
+    },
+    "css/padding": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setFlex(id, 'padding_*', px)",
+      "supportedValues": [
+        "px (1-4 tokens)"
+      ],
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/paddingBlock": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setFlex(id, 'padding_top/bottom', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/paddingBlockEnd": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/paddingBlockStart": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/paddingBottom": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'padding_bottom', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/paddingInline": {
+      "status": "supported",
+      "mapsTo": "expandShorthand -> setFlex(id, 'padding_left/right', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Logical property mapped LTR-only.",
+      "issue": ""
+    },
+    "css/paddingInlineEnd": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/paddingInlineStart": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/paddingLeft": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'padding_left', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/paddingRight": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'padding_right', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/paddingTop": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'padding_top', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/pageBreakAfter": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Print only.",
+      "issue": ""
+    },
+    "css/pageBreakBefore": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Print only.",
+      "issue": ""
+    },
+    "css/perspective": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "No 3D transform support.",
+      "issue": ""
+    },
+    "css/perspectiveOrigin": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "css/placeContent": {
+      "status": "partial",
+      "mapsTo": "setFlex 'align_content' + 'justify_content'",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "align_content half is silently dropped (see css/alignContent).",
+      "issue": ""
+    },
+    "css/placeItems": {
+      "status": "partial",
+      "mapsTo": "setFlex 'align_items' + 'justify_content'",
+      "supportedValues": [
+        "align-items justify-content shorthand"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Misnamed -- second token is mapped to justify_content rather than justify_items (which Yoga doesn't support).",
+      "issue": ""
+    },
+    "css/pointerEvents": {
+      "status": "supported",
+      "mapsTo": "setPointerEvents(id, mode)",
+      "supportedValues": [
+        "auto",
+        "none",
+        "box-only",
+        "box-none"
+      ],
+      "unsupportedValues": [
+        "visible-painted",
+        "visible-fill",
+        "etc. (SVG)"
+      ],
+      "tests": [],
+      "notes": "View::PointerEvents enum.",
+      "issue": ""
+    },
+    "css/position": {
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js: 'position' -> setPosition. View::Position enum has static_/relative/absolute/fixed/sticky.",
+      "supportedValues": [
+        "static",
+        "relative",
+        "absolute",
+        "fixed",
+        "sticky"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "All five CSS values are accepted by the bridge. 'fixed' and 'sticky' may render the same as 'absolute' in practice -- see #779 follow-ups for behavioral verification.",
+      "issue": ""
+    },
+    "css/printMargin": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Print media is out of scope for a GPU plugin renderer.",
+      "issue": ""
+    },
+    "css/quotes": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Generated content not in scope.",
+      "issue": ""
+    },
+    "css/resize": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "both",
+        "horizontal",
+        "vertical"
+      ],
+      "tests": [],
+      "notes": "User-resizable elements not modeled.",
+      "issue": ""
+    },
+    "css/right": {
+      "status": "supported",
+      "mapsTo": "setRight(id, px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "em",
+        "rem",
+        "vh/vw"
+      ],
+      "tests": [],
+      "notes": "Same limitation as top.",
+      "issue": ""
+    },
+    "css/rowGap": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'row_gap', px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/scrollBehavior": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "ScrollView intrinsic handles its own scrolling.",
+      "issue": ""
+    },
+    "css/scrollMargin": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not in initial scope.",
+      "issue": ""
+    },
+    "css/scrollPadding": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not in initial scope.",
+      "issue": ""
+    },
+    "css/scrollSnapType": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not in initial scope.",
+      "issue": ""
+    },
+    "css/tableLayout": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "No table primitives in Pulp.",
       "issue": ""
     },
     "css/textAlign": {
@@ -1512,23 +2210,6 @@
       "notes": "RN supports auto/justify; we don't.",
       "issue": ""
     },
-    "css/textTransform": {
-      "status": "supported",
-      "mapsTo": "setTextTransform(id, value)",
-      "supportedValues": [
-        "uppercase",
-        "lowercase",
-        "capitalize",
-        "none"
-      ],
-      "unsupportedValues": [
-        "full-width",
-        "full-size-kana"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
     "css/textDecoration": {
       "status": "partial",
       "mapsTo": "setTextDecoration(id, value)",
@@ -1543,6 +2224,17 @@
       ],
       "tests": [],
       "notes": "Single-keyword only. Cannot express 'underline dashed red'.",
+      "issue": ""
+    },
+    "css/textDecorationColor": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "any color"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
       "issue": ""
     },
     "css/textDecorationLine": {
@@ -1571,12 +2263,12 @@
       "notes": "Not handled.",
       "issue": ""
     },
-    "css/textDecorationColor": {
+    "css/textIndent": {
       "status": "missing",
       "mapsTo": "no branch",
       "supportedValues": [],
       "unsupportedValues": [
-        "any color"
+        "all"
       ],
       "tests": [],
       "notes": "Not handled.",
@@ -1596,90 +2288,61 @@
       "notes": "",
       "issue": ""
     },
-    "css/textIndent": {
+    "css/textShadow": {
       "status": "missing",
-      "mapsTo": "no branch",
+      "mapsTo": "web-compat calls setTextShadow if defined -- bridge does NOT register it",
       "supportedValues": [],
       "unsupportedValues": [
         "all"
       ],
       "tests": [],
-      "notes": "Not handled.",
+      "notes": "Silent no-op.",
       "issue": ""
     },
-    "css/whiteSpace": {
-      "status": "partial",
-      "mapsTo": "setWhiteSpace(id, value)",
+    "css/textTransform": {
+      "status": "supported",
+      "mapsTo": "setTextTransform(id, value)",
       "supportedValues": [
-        "normal",
-        "nowrap",
-        "pre",
-        "pre-wrap"
+        "uppercase",
+        "lowercase",
+        "capitalize",
+        "none"
       ],
       "unsupportedValues": [
-        "pre-line",
-        "break-spaces"
+        "full-width",
+        "full-size-kana"
       ],
       "tests": [],
-      "notes": "Bridge accepts the string but layout enforcement varies.",
+      "notes": "",
       "issue": ""
     },
-    "css/wordBreak": {
-      "status": "missing",
-      "mapsTo": "web-compat calls setWordBreak if defined -- bridge does NOT register it",
-      "supportedValues": [],
+    "css/top": {
+      "status": "supported",
+      "mapsTo": "setTop(id, px)",
+      "supportedValues": [
+        "px"
+      ],
       "unsupportedValues": [
-        "normal",
-        "break-all",
-        "keep-all",
-        "break-word"
+        "%",
+        "em",
+        "rem",
+        "vh/vw"
       ],
       "tests": [],
-      "notes": "Silent no-op.",
+      "notes": "parseCSSLength is invoked but the bridge stores raw px only -- percentage values are dropped. setTop accepts numbers only.",
       "issue": ""
     },
-    "css/overflowWrap": {
-      "status": "missing",
-      "mapsTo": "same as wordBreak -- never registered",
-      "supportedValues": [],
+    "css/touchAction": {
+      "status": "partial",
+      "mapsTo": "stored on element instance; not propagated to bridge",
+      "supportedValues": [
+        "any (stored verbatim)"
+      ],
       "unsupportedValues": [
-        "all"
+        "actually honored at hit-test"
       ],
       "tests": [],
-      "notes": "Silent no-op.",
-      "issue": ""
-    },
-    "css/wordWrap": {
-      "status": "missing",
-      "mapsTo": "same as wordBreak -- never registered",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Legacy alias of overflow-wrap. Silent no-op.",
-      "issue": ""
-    },
-    "css/lineClamp": {
-      "status": "missing",
-      "mapsTo": "web-compat calls setLineClamp if defined -- bridge does NOT register it",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "integer"
-      ],
-      "tests": [],
-      "notes": "Silent no-op. Both 'line-clamp' and '-webkit-line-clamp' route here.",
-      "issue": ""
-    },
-    "css/webkitLineClamp": {
-      "status": "missing",
-      "mapsTo": "same as lineClamp",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "integer"
-      ],
-      "tests": [],
-      "notes": "Silent no-op.",
+      "notes": "Set but not consumed by the C++ hit-test path.",
       "issue": ""
     },
     "css/transform": {
@@ -1726,40 +2389,6 @@
       "notes": "Px values are mishandled -- only % and keywords resolve correctly.",
       "issue": ""
     },
-    "css/perspective": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "No 3D transform support.",
-      "issue": ""
-    },
-    "css/perspectiveOrigin": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/backfaceVisibility": {
-      "status": "supported",
-      "mapsTo": "setBackfaceVisibility(id, value)",
-      "supportedValues": [
-        "visible",
-        "hidden"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
     "css/transition": {
       "status": "partial",
       "mapsTo": "parseTransition -> setTransitionDuration only",
@@ -1773,7 +2402,19 @@
         "multi-property comma list"
       ],
       "tests": [],
-      "notes": "Pulp ignores the property name and the timing function; only duration is propagated.",
+      "notes": "Pulp ignores the property name and the timing function; only duration is propagated. 2026-05-01 (#1345 / pulp #1149 part b): the document stylesheet now supports `:hover` selectors via mouseenter/mouseleave bridge listeners. CSS rules under `:hover` are stashed and re-applied per-element on hover-in, restored on hover-out \u2014 completing the transition story end-to-end for the common interactive case.",
+      "issue": "1323"
+    },
+    "css/transitionDelay": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "s",
+        "ms"
+      ],
+      "tests": [],
+      "notes": "Not honored.",
       "issue": ""
     },
     "css/transitionDuration": {
@@ -1816,539 +2457,93 @@
       "notes": "Not honored.",
       "issue": ""
     },
-    "css/transitionDelay": {
+    "css/userSelect": {
+      "status": "supported",
+      "mapsTo": "setUserSelect(id, value)",
+      "supportedValues": [
+        "none",
+        "text",
+        "all"
+      ],
+      "unsupportedValues": [
+        "contain",
+        "auto"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "css/verticalAlign": {
       "status": "missing",
       "mapsTo": "no branch",
       "supportedValues": [],
       "unsupportedValues": [
-        "s",
-        "ms"
+        "all"
       ],
       "tests": [],
-      "notes": "Not honored.",
+      "notes": "Not relevant in flex-only layout. Could add for Label baseline alignment.",
       "issue": ""
     },
-    "css/animation": {
+    "css/visibility": {
       "status": "partial",
-      "mapsTo": "parseTransition + setAnimation -- but setAnimation is a TODO no-op",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "MAJOR GAP -- widget_bridge.cpp:3208 setAnimation is registered but the body is `(void)id; (void)prop;...` -- a stub. CSS @keyframes animations are silently dropped.",
-      "issue": ""
-    },
-    "css/animationName": {
-      "status": "missing",
-      "mapsTo": "setAnimation stub",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Stub no-op.",
-      "issue": ""
-    },
-    "css/animationDuration": {
-      "status": "missing",
-      "mapsTo": "setAnimation stub",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Stub no-op.",
-      "issue": ""
-    },
-    "css/animationTimingFunction": {
-      "status": "missing",
-      "mapsTo": "setAnimation stub",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Stub no-op.",
-      "issue": ""
-    },
-    "css/animationDelay": {
-      "status": "missing",
-      "mapsTo": "setAnimation stub",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Stub no-op.",
-      "issue": ""
-    },
-    "css/animationIterationCount": {
-      "status": "missing",
-      "mapsTo": "setAnimation stub",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Stub no-op.",
-      "issue": ""
-    },
-    "css/animationDirection": {
-      "status": "missing",
-      "mapsTo": "setAnimation stub",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Stub no-op.",
-      "issue": ""
-    },
-    "css/animationFillMode": {
-      "status": "missing",
-      "mapsTo": "setAnimation stub",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Stub no-op.",
-      "issue": ""
-    },
-    "css/animationPlayState": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/filter": {
-      "status": "supported",
-      "mapsTo": "setFilter(id, value)",
+      "mapsTo": "setVisibility(id, 'visible'|'hidden') if registered, else opacity fallback",
       "supportedValues": [
-        "blur(<px>)"
+        "visible",
+        "hidden"
       ],
       "unsupportedValues": [
-        "brightness",
-        "contrast",
-        "drop-shadow",
-        "grayscale",
-        "hue-rotate",
-        "invert",
-        "opacity",
-        "saturate",
-        "sepia",
-        "multi-function chain"
+        "collapse"
       ],
       "tests": [],
-      "notes": "Bridge parses 'blur(Npx)'. Other filter functions pass through verbatim.",
+      "notes": "setVisibility IS registered (widget_bridge.cpp:1814) so the primary path works.",
       "issue": ""
     },
-    "css/backdropFilter": {
-      "status": "supported",
-      "mapsTo": "setBackdropFilter(id, blur_px)",
+    "css/webkitLineClamp": {
+      "status": "missing",
+      "mapsTo": "same as lineClamp",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "integer"
+      ],
+      "tests": [],
+      "notes": "Silent no-op.",
+      "issue": ""
+    },
+    "css/whiteSpace": {
+      "status": "partial",
+      "mapsTo": "setWhiteSpace(id, value)",
       "supportedValues": [
-        "blur(<px>)"
+        "normal",
+        "nowrap",
+        "pre",
+        "pre-wrap"
       ],
       "unsupportedValues": [
-        "other filter functions"
-      ],
-      "tests": [],
-      "notes": "Blur-only.",
-      "issue": ""
-    },
-    "css/mixBlendMode": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "multiply",
-        "screen",
-        "overlay",
-        "etc."
+        "pre-line",
+        "break-spaces"
       ],
       "tests": [],
-      "notes": "RN supports mixBlendMode in New Architecture; Pulp does not.",
+      "notes": "Bridge accepts the string but layout enforcement varies.",
       "issue": ""
     },
-    "css/isolation": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
+    "css/width": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'width', px)",
+      "supportedValues": [
+        "px (number)"
+      ],
       "unsupportedValues": [
+        "%",
+        "em",
+        "rem",
         "auto",
-        "isolate"
+        "min-content",
+        "max-content",
+        "fit-content",
+        "calc()"
       ],
       "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/touchAction": {
-      "status": "partial",
-      "mapsTo": "stored on element instance; not propagated to bridge",
-      "supportedValues": [
-        "any (stored verbatim)"
-      ],
-      "unsupportedValues": [
-        "actually honored at hit-test"
-      ],
-      "tests": [],
-      "notes": "Set but not consumed by the C++ hit-test path.",
-      "issue": ""
-    },
-    "css/gridTemplateColumns": {
-      "status": "partial",
-      "mapsTo": "setGrid(id, 'template_columns', value)",
-      "supportedValues": [
-        "any (forwarded verbatim)"
-      ],
-      "unsupportedValues": [
-        "repeat()",
-        "minmax()",
-        "auto-fill",
-        "auto-fit",
-        "fr units (depends on layout backend)"
-      ],
-      "tests": [],
-      "notes": "Forwarded as a string. Renderer honors only what the underlying GridStyle parser accepts. CSS Grid is largely unsupported because Yoga is flex-only.",
-      "issue": ""
-    },
-    "css/gridTemplateRows": {
-      "status": "partial",
-      "mapsTo": "setGrid(id, 'template_rows', value)",
-      "supportedValues": [
-        "any (forwarded verbatim)"
-      ],
-      "unsupportedValues": [
-        "repeat",
-        "minmax",
-        "fr"
-      ],
-      "tests": [],
-      "notes": "Same caveat as gridTemplateColumns.",
-      "issue": ""
-    },
-    "css/gridColumn": {
-      "status": "partial",
-      "mapsTo": "split '/' -> setGrid 'column_start'/'column_end'",
-      "supportedValues": [
-        "<n> / <n>"
-      ],
-      "unsupportedValues": [
-        "span <n>",
-        "named lines"
-      ],
-      "tests": [],
-      "notes": "Numeric only.",
-      "issue": ""
-    },
-    "css/gridRow": {
-      "status": "partial",
-      "mapsTo": "split '/' -> setGrid 'row_start'/'row_end'",
-      "supportedValues": [
-        "<n> / <n>"
-      ],
-      "unsupportedValues": [
-        "span <n>",
-        "named lines"
-      ],
-      "tests": [],
-      "notes": "Numeric only.",
-      "issue": ""
-    },
-    "css/gridTemplateAreas": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/gridArea": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/gridAutoColumns": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/gridAutoRows": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/gridAutoFlow": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/listStyle": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Pulp has no list intrinsic; lists are emulated with Col + Label children.",
-      "issue": ""
-    },
-    "css/listStyleType": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "See listStyle.",
-      "issue": ""
-    },
-    "css/listStylePosition": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "See listStyle.",
-      "issue": ""
-    },
-    "css/listStyleImage": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "See listStyle.",
-      "issue": ""
-    },
-    "css/tableLayout": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "No table primitives in Pulp.",
-      "issue": ""
-    },
-    "css/borderCollapse": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "See tableLayout.",
-      "issue": ""
-    },
-    "css/borderSpacing": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "See tableLayout.",
-      "issue": ""
-    },
-    "css/captionSide": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "See tableLayout.",
-      "issue": ""
-    },
-    "css/emptyCells": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "See tableLayout.",
-      "issue": ""
-    },
-    "css/columns": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Multi-column layout out of scope; not aligned with Yoga or RN.",
-      "issue": ""
-    },
-    "css/columnCount": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "See columns.",
-      "issue": ""
-    },
-    "css/columnWidth": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "See columns.",
-      "issue": ""
-    },
-    "css/columnRule": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "See columns.",
-      "issue": ""
-    },
-    "css/scrollBehavior": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "ScrollView intrinsic handles its own scrolling.",
-      "issue": ""
-    },
-    "css/scrollSnapType": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not in initial scope.",
-      "issue": ""
-    },
-    "css/scrollMargin": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not in initial scope.",
-      "issue": ""
-    },
-    "css/scrollPadding": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not in initial scope.",
-      "issue": ""
-    },
-    "css/overscrollBehavior": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not in initial scope.",
-      "issue": ""
-    },
-    "css/clipPath": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "polygon",
-        "circle",
-        "ellipse",
-        "inset",
-        "url(#clip)"
-      ],
-      "tests": [],
-      "notes": "Custom clip paths not supported.",
-      "issue": ""
-    },
-    "css/mask": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "css/maskImage": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
+      "notes": "FlexStyle.preferred_width is a float. Yoga in upstream supports % and auto, but Pulp's C++ port loses that on the JSON wire -- only floats are accepted by setFlex.",
       "issue": ""
     },
     "css/willChange": {
@@ -2362,52 +2557,29 @@
       "notes": "Hint to compositor -- Pulp's renderer is GPU all the time.",
       "issue": ""
     },
-    "css/contain": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Browser-only optimization hint.",
-      "issue": ""
-    },
-    "css/contentVisibility": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Browser-only optimization hint.",
-      "issue": ""
-    },
-    "css/all": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "initial",
-        "inherit",
-        "unset",
-        "revert"
-      ],
-      "tests": [],
-      "notes": "CSS-cascade reset not modeled.",
-      "issue": ""
-    },
-    "css/direction": {
+    "css/wordBreak": {
       "status": "missing",
-      "mapsTo": "no branch",
+      "mapsTo": "web-compat calls setWordBreak if defined -- bridge does NOT register it",
       "supportedValues": [],
       "unsupportedValues": [
-        "ltr",
-        "rtl"
+        "normal",
+        "break-all",
+        "keep-all",
+        "break-word"
       ],
       "tests": [],
-      "notes": "RTL writing direction not modeled. Affects logical inset/margin/padding mapping (currently always LTR).",
+      "notes": "Silent no-op.",
+      "issue": ""
+    },
+    "css/wordWrap": {
+      "status": "missing",
+      "mapsTo": "same as wordBreak -- never registered",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Legacy alias of overflow-wrap. Silent no-op.",
       "issue": ""
     },
     "css/writingMode": {
@@ -2423,149 +2595,17 @@
       "notes": "Vertical writing modes not handled.",
       "issue": ""
     },
-    "css/verticalAlign": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
+    "css/zIndex": {
+      "status": "supported",
+      "mapsTo": "setZIndex(id, int)",
+      "supportedValues": [
+        "integer"
+      ],
       "unsupportedValues": [
-        "all"
+        "auto"
       ],
       "tests": [],
-      "notes": "Not relevant in flex-only layout. Could add for Label baseline alignment.",
-      "issue": ""
-    },
-    "css/quotes": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Generated content not in scope.",
-      "issue": ""
-    },
-    "css/content": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "::before/::after not supported (no pseudo-element model).",
-      "issue": ""
-    },
-    "css/counterReset": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "CSS counters not in scope.",
-      "issue": ""
-    },
-    "css/counterIncrement": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not in scope.",
-      "issue": ""
-    },
-    "css/resize": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "both",
-        "horizontal",
-        "vertical"
-      ],
-      "tests": [],
-      "notes": "User-resizable elements not modeled.",
-      "issue": ""
-    },
-    "css/printMargin": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Print media is out of scope for a GPU plugin renderer.",
-      "issue": ""
-    },
-    "css/pageBreakBefore": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Print only.",
-      "issue": ""
-    },
-    "css/pageBreakAfter": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Print only.",
-      "issue": ""
-    },
-    "css/float": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "left",
-        "right",
-        "none"
-      ],
-      "tests": [],
-      "notes": "CSS float not relevant under a flex-only layout model.",
-      "issue": ""
-    },
-    "css/clear": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Float-companion property -- not relevant.",
-      "issue": ""
-    },
-    "css/__pseudo_classes_note": {
-      "status": "missing",
-      "mapsTo": "no CSS pseudo-class system today",
-      "supportedValues": [],
-      "unsupportedValues": [
-        ":hover",
-        ":active",
-        ":focus",
-        ":focus-visible",
-        ":disabled",
-        ":checked",
-        ":first-child",
-        ":last-child",
-        ":nth-child",
-        "etc."
-      ],
-      "tests": [],
-      "notes": "Pulp routes hover/click/etc. through bridge event registrations (registerHover, registerClick) rather than through CSS pseudo-classes. JSX consumers wire interactivity via on* event props, not via CSS.",
+      "notes": "'auto' parses as 0.",
       "issue": ""
     }
   },
@@ -2630,114 +2670,40 @@
       "notes": "MAJOR -- aspect-ratio is in RN's layout-props surface but not at the @pulp/react JSX surface.",
       "issue": ""
     },
-    "rn/borderBottomWidth": {
+    "rn/backfaceVisibility": {
       "status": "missing",
-      "mapsTo": "no prop-applier case (border is handled as { color, width, radius } object)",
+      "mapsTo": "Bridge has setBackfaceVisibility -- not surfaced in @pulp/react TS.",
       "supportedValues": [],
       "unsupportedValues": [
-        "number"
+        "visible",
+        "hidden"
       ],
       "tests": [],
-      "notes": "RN prop is flat top-level, Pulp uses object shape. Convert: <View style={{borderBottomWidth: 2}} /> -> <View borderBottom={{color:'#000', width:2}} />. Awkward for RN ports.",
+      "notes": "",
       "issue": ""
     },
-    "rn/borderEndWidth": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
+    "rn/backgroundColor": {
+      "status": "supported",
+      "mapsTo": "background prop -> setBackground",
+      "supportedValues": [
+        "#hex string"
+      ],
       "unsupportedValues": [
-        "all"
+        "any non-hex"
       ],
       "tests": [],
-      "notes": "Logical property; not modeled.",
+      "notes": "TS type for `background` is `string` (hex-only by convention).",
       "issue": ""
     },
-    "rn/borderLeftWidth": {
+    "rn/borderBottomColor": {
       "status": "missing",
-      "mapsTo": "no branch",
+      "mapsTo": "Bridge has setBorderBottomColor -- not surfaced.",
       "supportedValues": [],
       "unsupportedValues": [
-        "number"
+        "color"
       ],
       "tests": [],
-      "notes": "Same as borderBottomWidth.",
-      "issue": ""
-    },
-    "rn/borderRightWidth": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "number"
-      ],
-      "tests": [],
-      "notes": "Same.",
-      "issue": ""
-    },
-    "rn/borderStartWidth": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Logical property.",
-      "issue": ""
-    },
-    "rn/borderTopWidth": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "number"
-      ],
-      "tests": [],
-      "notes": "Same as borderBottomWidth.",
-      "issue": ""
-    },
-    "rn/borderWidth": {
-      "status": "missing",
-      "mapsTo": "Bridge has setBorderWidth, but @pulp/react does not surface it as a flat prop.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "number"
-      ],
-      "tests": [],
-      "notes": "User can call <View border={{color:'#000', width:N}} /> as workaround.",
-      "issue": ""
-    },
-    "rn/borderRadius": {
-      "status": "missing",
-      "mapsTo": "Bridge has setBorderRadius, but @pulp/react does not surface it as a flat prop.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "number"
-      ],
-      "tests": [],
-      "notes": "Workaround: <View border={{color:'transparent', width:0, radius:R}} />.",
-      "issue": ""
-    },
-    "rn/borderTopLeftRadius": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "number"
-      ],
-      "tests": [],
-      "notes": "Bridge has setBorderTopLeftRadius -- needs prop wiring.",
-      "issue": ""
-    },
-    "rn/borderTopRightRadius": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "number"
-      ],
-      "tests": [],
-      "notes": "Same.",
+      "notes": "",
       "issue": ""
     },
     "rn/borderBottomLeftRadius": {
@@ -2762,6 +2728,17 @@
       "notes": "Same.",
       "issue": ""
     },
+    "rn/borderBottomWidth": {
+      "status": "missing",
+      "mapsTo": "no prop-applier case (border is handled as { color, width, radius } object)",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "RN prop is flat top-level, Pulp uses object shape. Convert: <View style={{borderBottomWidth: 2}} /> -> <View borderBottom={{color:'#000', width:2}} />. Awkward for RN ports.",
+      "issue": ""
+    },
     "rn/borderColor": {
       "status": "missing",
       "mapsTo": "Bridge has setBorderColor -- not surfaced as flat prop.",
@@ -2773,26 +2750,27 @@
       "notes": "",
       "issue": ""
     },
-    "rn/borderTopColor": {
-      "status": "missing",
-      "mapsTo": "Bridge has setBorderTopColor -- not surfaced.",
+    "rn/borderCurve": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
       "supportedValues": [],
       "unsupportedValues": [
-        "color"
+        "circular",
+        "continuous"
       ],
       "tests": [],
-      "notes": "",
+      "notes": "iOS-only super-ellipse corner shape.",
       "issue": ""
     },
-    "rn/borderBottomColor": {
+    "rn/borderEndWidth": {
       "status": "missing",
-      "mapsTo": "Bridge has setBorderBottomColor -- not surfaced.",
+      "mapsTo": "no branch",
       "supportedValues": [],
       "unsupportedValues": [
-        "color"
+        "all"
       ],
       "tests": [],
-      "notes": "",
+      "notes": "Logical property; not modeled.",
       "issue": ""
     },
     "rn/borderLeftColor": {
@@ -2806,6 +2784,28 @@
       "notes": "",
       "issue": ""
     },
+    "rn/borderLeftWidth": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "Same as borderBottomWidth.",
+      "issue": ""
+    },
+    "rn/borderRadius": {
+      "status": "missing",
+      "mapsTo": "Bridge has setBorderRadius, but @pulp/react does not surface it as a flat prop.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "Workaround: <View border={{color:'transparent', width:0, radius:R}} />.",
+      "issue": ""
+    },
     "rn/borderRightColor": {
       "status": "missing",
       "mapsTo": "Bridge has setBorderRightColor -- not surfaced.",
@@ -2815,6 +2815,28 @@
       ],
       "tests": [],
       "notes": "",
+      "issue": ""
+    },
+    "rn/borderRightWidth": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "Same.",
+      "issue": ""
+    },
+    "rn/borderStartWidth": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Logical property.",
       "issue": ""
     },
     "rn/borderStyle": {
@@ -2830,16 +2852,59 @@
       "notes": "Renderer always solid.",
       "issue": ""
     },
-    "rn/borderCurve": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
+    "rn/borderTopColor": {
+      "status": "missing",
+      "mapsTo": "Bridge has setBorderTopColor -- not surfaced.",
       "supportedValues": [],
       "unsupportedValues": [
-        "circular",
-        "continuous"
+        "color"
       ],
       "tests": [],
-      "notes": "iOS-only super-ellipse corner shape.",
+      "notes": "",
+      "issue": ""
+    },
+    "rn/borderTopLeftRadius": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "Bridge has setBorderTopLeftRadius -- needs prop wiring.",
+      "issue": ""
+    },
+    "rn/borderTopRightRadius": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "Same.",
+      "issue": ""
+    },
+    "rn/borderTopWidth": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "Same as borderBottomWidth.",
+      "issue": ""
+    },
+    "rn/borderWidth": {
+      "status": "missing",
+      "mapsTo": "Bridge has setBorderWidth, but @pulp/react does not surface it as a flat prop.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "User can call <View border={{color:'#000', width:N}} /> as workaround.",
       "issue": ""
     },
     "rn/bottom": {
@@ -2855,6 +2920,43 @@
       "notes": "",
       "issue": ""
     },
+    "rn/boxShadow": {
+      "status": "missing",
+      "mapsTo": "Bridge has setBoxShadow -- not yet exposed at @pulp/react TS surface.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "BoxShadowValue array",
+        "string"
+      ],
+      "tests": [],
+      "notes": "Could be exposed analogously to `border={...}` shape.",
+      "issue": ""
+    },
+    "rn/boxSizing": {
+      "status": "missing",
+      "mapsTo": "no branch (and bridge does not register setBoxSizing)",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "border-box",
+        "content-box"
+      ],
+      "tests": [],
+      "notes": "Yoga's box model is content-box-equivalent.",
+      "issue": ""
+    },
+    "rn/color": {
+      "status": "supported",
+      "mapsTo": "textColor prop -> setTextColor",
+      "supportedValues": [
+        "hex"
+      ],
+      "unsupportedValues": [
+        "modern color spaces"
+      ],
+      "tests": [],
+      "notes": "Pulp prop name is `textColor` (LabelProps), not `color`.",
+      "issue": ""
+    },
     "rn/columnGap": {
       "status": "supported",
       "mapsTo": "setFlex(id, 'column_gap', n)",
@@ -2865,6 +2967,29 @@
       "tests": [],
       "notes": "",
       "issue": ""
+    },
+    "rn/cursor": {
+      "status": "missing",
+      "mapsTo": "Bridge has setCursor -- not surfaced in @pulp/react TS.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "auto",
+        "pointer"
+      ],
+      "tests": [],
+      "notes": "Easy add.",
+      "issue": ""
+    },
+    "rn/d": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: 'd' -> setSvgPath(id, value). Wired by SvgPath JSX intrinsic (pulp #994 / PR #1291).",
+      "supportedValues": [
+        "any SVG path-data string (e.g. 'M0,0 L10,10 Z')"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Only meaningful when the consumer renders <SvgPath> from @pulp/react. The bridge createSvgPath / setSvgPath / setSvgViewBox / setSvgFill / setSvgStroke / setSvgStrokeWidth surface lands on SvgPathWidget in core/view/.",
+      "issue": "994"
     },
     "rn/direction": {
       "status": "missing",
@@ -2892,6 +3017,17 @@
       "notes": "@pulp/react users opt out via the boolean `visible` prop. No 'contents' equivalent.",
       "issue": ""
     },
+    "rn/elevation": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "Android-only Material elevation. Pulp uses boxShadow as the cross-platform equivalent.",
+      "issue": ""
+    },
     "rn/end": {
       "status": "missing",
       "mapsTo": "no branch",
@@ -2901,6 +3037,42 @@
       ],
       "tests": [],
       "notes": "Logical position; not modeled.",
+      "issue": ""
+    },
+    "rn/experimental_backgroundImage": {
+      "status": "missing",
+      "mapsTo": "@pulp/react has backgroundGradient; CSS gradient strings only.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "RN array-of-objects gradient API"
+      ],
+      "tests": [],
+      "notes": "Different shape from RN.",
+      "issue": ""
+    },
+    "rn/fill": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: 'fill' -> setSvgFill(id, value). Bridge accepts a CSS-color string.",
+      "supportedValues": [
+        "CSS color strings"
+      ],
+      "unsupportedValues": [
+        "url(#gradient) \u2014 gradient fills not yet wired through SvgPathWidget"
+      ],
+      "tests": [],
+      "notes": "Only on @pulp/react SvgPath. Inline <svg> in DOM-lite still uses createCol (pulp #1147), which means CSS `fill` does NOT route to SVG fill \u2014 it falls into the unknown-prop default switch.",
+      "issue": "994"
+    },
+    "rn/filter": {
+      "status": "missing",
+      "mapsTo": "Bridge has setFilter -- not surfaced in @pulp/react TS.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "array of filter objects",
+        "css string"
+      ],
+      "tests": [],
+      "notes": "Easy add.",
       "issue": ""
     },
     "rn/flex": {
@@ -2980,6 +3152,67 @@
       "notes": "TS type is `boolean` -- RN's enum has 'wrap-reverse' which we cannot express.",
       "issue": ""
     },
+    "rn/fontFamily": {
+      "status": "missing",
+      "mapsTo": "intentionally NOT dispatched in prop-applier.ts (line 152 comment) -- pending #932 SkFontMgr fix",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "string"
+      ],
+      "tests": [],
+      "notes": "Documented gap in prop-applier; reflects pulp#932 / pulp#927.",
+      "issue": ""
+    },
+    "rn/fontSize": {
+      "status": "supported",
+      "mapsTo": "setFontSize",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/fontStyle": {
+      "status": "supported",
+      "mapsTo": "setFontStyle",
+      "supportedValues": [
+        "normal",
+        "italic"
+      ],
+      "unsupportedValues": [
+        "oblique"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/fontVariant": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not modeled.",
+      "issue": ""
+    },
+    "rn/fontWeight": {
+      "status": "supported",
+      "mapsTo": "setFontWeight (numeric)",
+      "supportedValues": [
+        "100..900"
+      ],
+      "unsupportedValues": [
+        "normal",
+        "bold"
+      ],
+      "tests": [],
+      "notes": "Keyword aliasing not done in prop-applier.",
+      "issue": ""
+    },
     "rn/gap": {
       "status": "supported",
       "mapsTo": "setFlex(id, 'gap', n)",
@@ -3004,6 +3237,62 @@
       ],
       "tests": [],
       "notes": "TS type is `number` only.",
+      "issue": ""
+    },
+    "rn/includeFontPadding": {
+      "status": "wontfix",
+      "mapsTo": "n/a",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "bool"
+      ],
+      "tests": [],
+      "notes": "Android-only legacy padding control.",
+      "issue": ""
+    },
+    "rn/inset": {
+      "status": "missing",
+      "mapsTo": "no @pulp/react prop. CSS shim has it.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "RN exposes inset; @pulp/react does not.",
+      "issue": ""
+    },
+    "rn/insetBlock": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Logical.",
+      "issue": ""
+    },
+    "rn/insetInline": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Logical.",
+      "issue": ""
+    },
+    "rn/isolation": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "auto",
+        "isolate"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
       "issue": ""
     },
     "rn/justifyContent": {
@@ -3032,6 +3321,30 @@
         "number"
       ],
       "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/letterSpacing": {
+      "status": "supported",
+      "mapsTo": "setLetterSpacing",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/lineHeight": {
+      "status": "supported",
+      "mapsTo": "setLineHeight",
+      "supportedValues": [
+        "number (px)"
+      ],
+      "unsupportedValues": [
+        "unitless multiplier"
+      ],
       "tests": [],
       "notes": "",
       "issue": ""
@@ -3190,6 +3503,72 @@
       "notes": "",
       "issue": ""
     },
+    "rn/mixBlendMode": {
+      "status": "missing",
+      "mapsTo": "no branch",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Not handled.",
+      "issue": ""
+    },
+    "rn/opacity": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts -> setOpacity(id, n)",
+      "supportedValues": [
+        "0..1 number"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/outlineColor": {
+      "status": "missing",
+      "mapsTo": "no bridge support",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "setOutline never registered.",
+      "issue": ""
+    },
+    "rn/outlineOffset": {
+      "status": "missing",
+      "mapsTo": "no bridge support",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/outlineStyle": {
+      "status": "missing",
+      "mapsTo": "no bridge support",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/outlineWidth": {
+      "status": "missing",
+      "mapsTo": "no bridge support",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "number"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
     "rn/overflow": {
       "status": "missing",
       "mapsTo": "no @pulp/react prop. Bridge has setOverflow(id, 'visible'|'hidden').",
@@ -3202,6 +3581,18 @@
       "tests": [],
       "notes": "Plumbing missing in prop-applier; ScrollView intrinsic exposes scroll.",
       "issue": ""
+    },
+    "rn/overlay": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: 'overlay' -> claimOverlay(id) / releaseOverlay(id) on flip. Bridge serializes onto a single View::active_overlay_ slot to fix React-popover click routing (pulp #1148, PRs #1297 + #1344).",
+      "supportedValues": [
+        "true",
+        "false"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Generalized overlay-click routing. The CSS-shim auto-claim heuristic (web-compat-style-decl.js _reevaluateOverlay) calls into the same bridge functions when position:absolute combines with z-index above a threshold (>= 10) OR the data-overlay='true' hint is set, so DOM-lite consumers don't need to rewire to the @pulp/react overlay prop.",
+      "issue": "1148"
     },
     "rn/padding": {
       "status": "supported",
@@ -3304,6 +3695,20 @@
       "notes": "Common RN pattern; awkward to port.",
       "issue": ""
     },
+    "rn/pointerEvents": {
+      "status": "missing",
+      "mapsTo": "Bridge has setPointerEvents -- not surfaced in @pulp/react TS.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "auto",
+        "none",
+        "box-none",
+        "box-only"
+      ],
+      "tests": [],
+      "notes": "Easy add.",
+      "issue": ""
+    },
     "rn/position": {
       "status": "supported",
       "mapsTo": "setPosition(id, value)",
@@ -3340,180 +3745,6 @@
       "unsupportedValues": [],
       "tests": [],
       "notes": "",
-      "issue": ""
-    },
-    "rn/start": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Logical position.",
-      "issue": ""
-    },
-    "rn/top": {
-      "status": "supported",
-      "mapsTo": "setTop(id, n)",
-      "supportedValues": [
-        "number"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/width": {
-      "status": "supported",
-      "mapsTo": "setFlex(id, 'width', n)",
-      "supportedValues": [
-        "number"
-      ],
-      "unsupportedValues": [
-        "string %",
-        "auto"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/zIndex": {
-      "status": "supported",
-      "mapsTo": "setZIndex(id, n)",
-      "supportedValues": [
-        "number"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/inset": {
-      "status": "missing",
-      "mapsTo": "no @pulp/react prop. CSS shim has it.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "RN exposes inset; @pulp/react does not.",
-      "issue": ""
-    },
-    "rn/insetInline": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Logical.",
-      "issue": ""
-    },
-    "rn/insetBlock": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Logical.",
-      "issue": ""
-    },
-    "rn/boxSizing": {
-      "status": "missing",
-      "mapsTo": "no branch (and bridge does not register setBoxSizing)",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "border-box",
-        "content-box"
-      ],
-      "tests": [],
-      "notes": "Yoga's box model is content-box-equivalent.",
-      "issue": ""
-    },
-    "rn/isolation": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "auto",
-        "isolate"
-      ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
-    },
-    "rn/backgroundColor": {
-      "status": "supported",
-      "mapsTo": "background prop -> setBackground",
-      "supportedValues": [
-        "#hex string"
-      ],
-      "unsupportedValues": [
-        "any non-hex"
-      ],
-      "tests": [],
-      "notes": "TS type for `background` is `string` (hex-only by convention).",
-      "issue": ""
-    },
-    "rn/experimental_backgroundImage": {
-      "status": "missing",
-      "mapsTo": "@pulp/react has backgroundGradient; CSS gradient strings only.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "RN array-of-objects gradient API"
-      ],
-      "tests": [],
-      "notes": "Different shape from RN.",
-      "issue": ""
-    },
-    "rn/backfaceVisibility": {
-      "status": "missing",
-      "mapsTo": "Bridge has setBackfaceVisibility -- not surfaced in @pulp/react TS.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "visible",
-        "hidden"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/opacity": {
-      "status": "supported",
-      "mapsTo": "prop-applier.ts -> setOpacity(id, n)",
-      "supportedValues": [
-        "0..1 number"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/elevation": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "number"
-      ],
-      "tests": [],
-      "notes": "Android-only Material elevation. Pulp uses boxShadow as the cross-platform equivalent.",
-      "issue": ""
-    },
-    "rn/boxShadow": {
-      "status": "missing",
-      "mapsTo": "Bridge has setBoxShadow -- not yet exposed at @pulp/react TS surface.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "BoxShadowValue array",
-        "string"
-      ],
-      "tests": [],
-      "notes": "Could be exposed analogously to `border={...}` shape.",
       "issue": ""
     },
     "rn/shadowColor": {
@@ -3560,19 +3791,7 @@
       "notes": "iOS-only.",
       "issue": ""
     },
-    "rn/filter": {
-      "status": "missing",
-      "mapsTo": "Bridge has setFilter -- not surfaced in @pulp/react TS.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "array of filter objects",
-        "css string"
-      ],
-      "tests": [],
-      "notes": "Easy add.",
-      "issue": ""
-    },
-    "rn/mixBlendMode": {
+    "rn/start": {
       "status": "missing",
       "mapsTo": "no branch",
       "supportedValues": [],
@@ -3580,213 +3799,30 @@
         "all"
       ],
       "tests": [],
-      "notes": "Not handled.",
+      "notes": "Logical position.",
       "issue": ""
     },
-    "rn/outlineColor": {
-      "status": "missing",
-      "mapsTo": "no bridge support",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "setOutline never registered.",
-      "issue": ""
-    },
-    "rn/outlineOffset": {
-      "status": "missing",
-      "mapsTo": "no bridge support",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "number"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/outlineStyle": {
-      "status": "missing",
-      "mapsTo": "no bridge support",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/outlineWidth": {
-      "status": "missing",
-      "mapsTo": "no bridge support",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "number"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/pointerEvents": {
-      "status": "missing",
-      "mapsTo": "Bridge has setPointerEvents -- not surfaced in @pulp/react TS.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "auto",
-        "none",
-        "box-none",
-        "box-only"
-      ],
-      "tests": [],
-      "notes": "Easy add.",
-      "issue": ""
-    },
-    "rn/cursor": {
-      "status": "missing",
-      "mapsTo": "Bridge has setCursor -- not surfaced in @pulp/react TS.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "auto",
-        "pointer"
-      ],
-      "tests": [],
-      "notes": "Easy add.",
-      "issue": ""
-    },
-    "rn/userSelect": {
-      "status": "missing",
-      "mapsTo": "Bridge has setUserSelect -- not surfaced.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "auto",
-        "text",
-        "none",
-        "contain",
-        "all"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/transform": {
-      "status": "missing",
-      "mapsTo": "no @pulp/react prop. CSS surface routes through setScale/setRotation/setTranslate but with reduced function set.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "array of {scale|rotate|translate|...}"
-      ],
-      "tests": [],
-      "notes": "MAJOR -- RN's transform is an array of objects; @pulp/react has none of it.",
-      "issue": ""
-    },
-    "rn/transformOrigin": {
-      "status": "missing",
-      "mapsTo": "Bridge has setTransformOrigin -- not surfaced in @pulp/react TS.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Easy add.",
-      "issue": ""
-    },
-    "rn/color": {
+    "rn/stroke": {
       "status": "supported",
-      "mapsTo": "textColor prop -> setTextColor",
+      "mapsTo": "prop-applier.ts: 'stroke' -> setSvgStroke(id, value). Bridge accepts a CSS-color string.",
       "supportedValues": [
-        "hex"
+        "CSS color strings"
       ],
-      "unsupportedValues": [
-        "modern color spaces"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "Pulp prop name is `textColor` (LabelProps), not `color`.",
-      "issue": ""
+      "notes": "Only on @pulp/react SvgPath. See rn/fill caveat \u2014 no DOM-lite path-prop equivalent.",
+      "issue": "994"
     },
-    "rn/fontFamily": {
-      "status": "missing",
-      "mapsTo": "intentionally NOT dispatched in prop-applier.ts (line 152 comment) -- pending #932 SkFontMgr fix",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "string"
-      ],
-      "tests": [],
-      "notes": "Documented gap in prop-applier; reflects pulp#932 / pulp#927.",
-      "issue": ""
-    },
-    "rn/fontSize": {
+    "rn/strokeWidth": {
       "status": "supported",
-      "mapsTo": "setFontSize",
+      "mapsTo": "prop-applier.ts: 'strokeWidth' -> setSvgStrokeWidth(id, number).",
       "supportedValues": [
         "number (px)"
       ],
       "unsupportedValues": [],
       "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/fontStyle": {
-      "status": "supported",
-      "mapsTo": "setFontStyle",
-      "supportedValues": [
-        "normal",
-        "italic"
-      ],
-      "unsupportedValues": [
-        "oblique"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/fontWeight": {
-      "status": "supported",
-      "mapsTo": "setFontWeight (numeric)",
-      "supportedValues": [
-        "100..900"
-      ],
-      "unsupportedValues": [
-        "normal",
-        "bold"
-      ],
-      "tests": [],
-      "notes": "Keyword aliasing not done in prop-applier.",
-      "issue": ""
-    },
-    "rn/fontVariant": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
-      ],
-      "tests": [],
-      "notes": "Not modeled.",
-      "issue": ""
-    },
-    "rn/letterSpacing": {
-      "status": "supported",
-      "mapsTo": "setLetterSpacing",
-      "supportedValues": [
-        "number"
-      ],
-      "unsupportedValues": [],
-      "tests": [],
-      "notes": "",
-      "issue": ""
-    },
-    "rn/lineHeight": {
-      "status": "supported",
-      "mapsTo": "setLineHeight",
-      "supportedValues": [
-        "number (px)"
-      ],
-      "unsupportedValues": [
-        "unitless multiplier"
-      ],
-      "tests": [],
-      "notes": "",
-      "issue": ""
+      "notes": "Only on @pulp/react SvgPath.",
+      "issue": "994"
     },
     "rn/textAlign": {
       "status": "supported",
@@ -3901,6 +3937,54 @@
       "notes": "Easy add.",
       "issue": ""
     },
+    "rn/top": {
+      "status": "supported",
+      "mapsTo": "setTop(id, n)",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "rn/transform": {
+      "status": "missing",
+      "mapsTo": "no @pulp/react prop. CSS surface routes through setScale/setRotation/setTranslate but with reduced function set.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "array of {scale|rotate|translate|...}"
+      ],
+      "tests": [],
+      "notes": "MAJOR -- RN's transform is an array of objects; @pulp/react has none of it.",
+      "issue": ""
+    },
+    "rn/transformOrigin": {
+      "status": "missing",
+      "mapsTo": "Bridge has setTransformOrigin -- not surfaced in @pulp/react TS.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all"
+      ],
+      "tests": [],
+      "notes": "Easy add.",
+      "issue": ""
+    },
+    "rn/userSelect": {
+      "status": "missing",
+      "mapsTo": "Bridge has setUserSelect -- not surfaced.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "auto",
+        "text",
+        "none",
+        "contain",
+        "all"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
     "rn/verticalAlign": {
       "status": "missing",
       "mapsTo": "no branch",
@@ -3910,6 +3994,33 @@
       ],
       "tests": [],
       "notes": "Not modeled.",
+      "issue": ""
+    },
+    "rn/viewBox": {
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: 'viewBox' -> setSvgViewBox(id, w, h). Expected as [number, number] tuple.",
+      "supportedValues": [
+        "[number, number] (width, height)"
+      ],
+      "unsupportedValues": [
+        "SVG-style 'min-x min-y w h' string (only the [w,h] tuple form is wired)"
+      ],
+      "tests": [],
+      "notes": "RN doesn't have a native SVG surface; this is a Pulp-specific @pulp/react intrinsic. CSS-shim consumers don't see this prop today.",
+      "issue": "994"
+    },
+    "rn/width": {
+      "status": "supported",
+      "mapsTo": "setFlex(id, 'width', n)",
+      "supportedValues": [
+        "number"
+      ],
+      "unsupportedValues": [
+        "string %",
+        "auto"
+      ],
+      "tests": [],
+      "notes": "",
       "issue": ""
     },
     "rn/writingDirection": {
@@ -3925,15 +4036,15 @@
       "notes": "RTL not modeled.",
       "issue": ""
     },
-    "rn/includeFontPadding": {
-      "status": "wontfix",
-      "mapsTo": "n/a",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "bool"
+    "rn/zIndex": {
+      "status": "supported",
+      "mapsTo": "setZIndex(id, n)",
+      "supportedValues": [
+        "number"
       ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "Android-only legacy padding control.",
+      "notes": "",
       "issue": ""
     }
   },
@@ -4604,15 +4715,1328 @@
     }
   },
   "react": {
-    "_note": "Pending second-pass audit. The @pulp/react reconciler surface (host-config.ts, prop-applier.ts) is captured under rn/* above. This section is reserved for React-specific concerns: Suspense, ConcurrentMode, Profiler, error boundaries, refs, portals, hooks edge cases."
+    "_note": "The @pulp/react reconciler surface (host-config.ts, prop-applier.ts) is captured under rn/* above (prop-applier covers ~70 props). This section is reserved for React-specific features that aren't single-prop entries: Suspense, ConcurrentMode, Profiler, error boundaries, refs, portals, hooks edge cases (useTransition, useDeferredValue, useId, useSyncExternalStore). As of 2026-05-04 the renderer is built on react-reconciler@0.31 and supports the basic function-component + useState + useEffect + useRef + useMemo / useCallback set; concurrent features are not exercised. File-issue follow-up: enumerate observed React features end-to-end and populate per-feature entries. Currently empty pending that audit."
   },
   "html": {
-    "_note": "Pending second-pass audit. The DOM-lite consumer surface (createElement, setAttribute, appendChild, addEventListener, etc.) lives in core/view/js/web-compat-*.js. Surfaces of interest: Element / HTMLElement attribute coverage, ARIA attributes, dataset, classList, the DocumentFragment shim, the Event constructor surface."
+    "_note": "Populated 2026-05-04 from web-compat-element.js (~836 LOC) and web-compat-document.js (~1527 LOC). Tracks the DOM-lite consumer surface: createElement / setAttribute / appendChild / addEventListener / Element / HTMLElement attributes / dataset / classList / events / style sheet support. Spec source: https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement subclasses. Recent additions since 2026-04-30: html/svg width/height attribute replay (#1347 / pulp #1147), html/span/p/label widget mapping confirmed (Label widget, not View), html/style :hover stylesheet support (#1345 / pulp #1149 part b).",
+    "html/ARIA": {
+      "status": "missing",
+      "mapsTo": "ARIA attributes (aria-label, role, etc.) are stored in _attributes but NOT routed to platform accessibility APIs.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "all aria-* attribute -> screen-reader propagation"
+      ],
+      "tests": [],
+      "notes": "MAJOR GAP \u2014 accessibility surface needs dedicated work. File a follow-up issue.",
+      "issue": ""
+    },
+    "html/DocumentFragment": {
+      "status": "partial",
+      "mapsTo": "Minimal shim \u2014 appendChild/removeChild only.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "full Range / Selection API"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_addEventListener": {
+      "status": "supported",
+      "mapsTo": "Element.addEventListener \u2014 registers click/mouseenter/mouseleave/pointerenter/pointerleave/pointerdown/move/up/cancel/gesturestart/change/focus/blur with the bridge. registerHover/registerClick/registerPointer/registerGesture are called as needed.",
+      "supportedValues": [
+        "click",
+        "mousedown",
+        "mouseup",
+        "mouseenter",
+        "mouseleave",
+        "pointerenter",
+        "pointerleave",
+        "pointerdown",
+        "pointermove",
+        "pointerup",
+        "pointercancel",
+        "gesturestart",
+        "gesturechange",
+        "gestureend",
+        "input",
+        "change",
+        "focus",
+        "blur"
+      ],
+      "unsupportedValues": [
+        "dragstart/drag/dragend (use registerDrop)",
+        "wheel (use registerWheel)",
+        "keydown/keyup/keypress (forwarded globally via __dispatch__)"
+      ],
+      "tests": [],
+      "notes": "Hover events fixed in PR #1173 (pulp #1149 part a) \u2014 registerHover is now called on hover-event registration so the C++ side actually fires.",
+      "issue": "1149"
+    },
+    "html/Element_appendChild": {
+      "status": "supported",
+      "mapsTo": "web-compat-dom-ops.js: appendChild reparents native widget if needed via _reparentNative + replays presentational attrs.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_classList": {
+      "status": "supported",
+      "mapsTo": "Element.classList \u2014 add/remove/toggle/contains/length/item, mirrors className. Triggers stylesheet re-application on change.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_cloneNode": {
+      "status": "supported",
+      "mapsTo": "Element.cloneNode(deep) \u2014 replicates className, textContent, type, value, style props; recursive when deep.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_dataset": {
+      "status": "supported",
+      "mapsTo": "Element.dataset \u2014 kebab-cased data-* attrs surface as camelCase JS properties. Includes the data-overlay='true' hint (#1148).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": "1148"
+    },
+    "html/Element_disabled": {
+      "status": "partial",
+      "mapsTo": "Element.disabled -> stylesheet re-application; bridge does not currently route to setEnabled.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "actual native widget disabled-state"
+      ],
+      "tests": [],
+      "notes": "Re-apply only \u2014 does NOT call setEnabled. File a follow-up if needed.",
+      "issue": ""
+    },
+    "html/Element_dispatchEvent": {
+      "status": "supported",
+      "mapsTo": "Element.dispatchEvent \u2014 capture + target + bubble phases; honors stopPropagation / preventDefault / _noBubble.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_getAttribute": {
+      "status": "supported",
+      "mapsTo": "Element.getAttribute(name).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_getBoundingClientRect": {
+      "status": "supported",
+      "mapsTo": "Element.getBoundingClientRect -> getLayoutRect bridge fn. Returns {x,y,width,height,top,right,bottom,left}.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_hidden": {
+      "status": "supported",
+      "mapsTo": "Element.hidden -> setVisible(id, !hidden).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_insertBefore": {
+      "status": "supported",
+      "mapsTo": "web-compat-dom-ops.js.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_nodeName": {
+      "status": "supported",
+      "mapsTo": "Returns upper-case tagName per DOM spec.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_nodeType": {
+      "status": "supported",
+      "mapsTo": "Element.nodeType === 1 (ELEMENT_NODE). Constants exposed on the prototype for React's reconciler hot-path checks.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Pulp #468.",
+      "issue": "468"
+    },
+    "html/Element_offsetWidth": {
+      "status": "supported",
+      "mapsTo": "Maps to getBoundingClientRect().width.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Same for offsetHeight, clientWidth, clientHeight.",
+      "issue": ""
+    },
+    "html/Element_removeAttribute": {
+      "status": "supported",
+      "mapsTo": "Element.removeAttribute \u2014 also clears data-* dataset entries and re-evaluates overlay heuristic if data-overlay was set.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_removeChild": {
+      "status": "supported",
+      "mapsTo": "web-compat-dom-ops.js.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_replaceChild": {
+      "status": "supported",
+      "mapsTo": "web-compat-dom-ops.js.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_setAttribute": {
+      "status": "supported",
+      "mapsTo": "Element.setAttribute(name, value) \u2014 handles id, class, data-*, plus presentational width/height for media tags (replay path).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_setPointerCapture": {
+      "status": "supported",
+      "mapsTo": "Element.setPointerCapture / releasePointerCapture -> nativeSetPointerCapture / nativeReleasePointerCapture (P2b).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Element_textContent": {
+      "status": "supported",
+      "mapsTo": "Element.textContent \u2014 special-cased for <style>: routes through _processStyleElement instead of setText.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": "1323"
+    },
+    "html/Element_value": {
+      "status": "supported",
+      "mapsTo": "Element.value \u2014 type-aware (range -> normalized, checkbox -> 0/1, progress -> setProgress, default -> setText).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/Event_constructor": {
+      "status": "partial",
+      "mapsTo": "_makeEvent factory in web-compat-element.js. No actual `new Event(...)` constructor surface.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "new Event('foo') from user code"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/StyleSheet_inline": {
+      "status": "supported",
+      "mapsTo": "Inline <style> elements parsed and applied to the document. Selectors: tag, .class, #id; combinators NOT supported. Properties routed through CSSStyleDeclaration._applyProperty (full css/* surface).",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "@media queries",
+        "@keyframes",
+        "@import",
+        "@font-face",
+        "@supports",
+        "complex selectors"
+      ],
+      "tests": [],
+      "notes": "PR #1345 added :hover; otherwise unchanged from initial implementation.",
+      "issue": ""
+    },
+    "html/article": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/aside": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/button": {
+      "status": "supported",
+      "mapsTo": "createToggleButton(id, parent).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Inherits ToggleButton widget \u2014 toggleable by default.",
+      "issue": ""
+    },
+    "html/canvas": {
+      "status": "supported",
+      "mapsTo": "createCanvas(id, parent). 2D context via Element.getContext('2d'); WebGPU via getContext('webgpu').",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "See canvas2d/* for the rendering surface.",
+      "issue": ""
+    },
+    "html/details": {
+      "status": "partial",
+      "mapsTo": "createCol(id, parent). The toggle/summary expand-on-click semantics are NOT modeled \u2014 children are always rendered.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "open/closed toggle behavior",
+        "<summary> tag semantic"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/dialog": {
+      "status": "partial",
+      "mapsTo": "createPanel(id, parent) + setVisible(false). Modal show()/showModal()/close() not wired.",
+      "supportedValues": [
+        "dialog as a hidden Panel"
+      ],
+      "unsupportedValues": [
+        "showModal()",
+        "close()",
+        "the dialog ::backdrop pseudo-element"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/div": {
+      "status": "supported",
+      "mapsTo": "Element('div')._ensureNative -> createCol(id, parent). Same for section/article/aside/header/footer/nav/main.",
+      "supportedValues": [
+        "all generic flow tags"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Generic container \u2014 Yoga column flex by default.",
+      "issue": ""
+    },
+    "html/document_addEventListener": {
+      "status": "supported",
+      "mapsTo": "Global key/mouse listener installation on document.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/document_createElement": {
+      "status": "supported",
+      "mapsTo": "document.createElement(tag) -> new Element(tag).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/document_createTextNode": {
+      "status": "partial",
+      "mapsTo": "document.createTextNode -> Text-like Element.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Used by React reconciler.",
+      "issue": ""
+    },
+    "html/document_getElementById": {
+      "status": "supported",
+      "mapsTo": "document.getElementById -> __elements__['#'+id] lookup.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/document_querySelector": {
+      "status": "partial",
+      "mapsTo": "document.querySelector \u2014 class / id / tag selectors only.",
+      "supportedValues": [
+        "#id",
+        ".class",
+        "tagname"
+      ],
+      "unsupportedValues": [
+        "complex selectors",
+        "attribute selectors",
+        "pseudo-classes",
+        "combinators"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/footer": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/h1": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(32) + setFontWeight(700).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Heading levels h1-h6 each map to a Label with default size + weight.",
+      "issue": ""
+    },
+    "html/h2": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(24) + setFontWeight(700).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/h3": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(20) + setFontWeight(600).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/h4": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(16) + setFontWeight(600).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/h5": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(14) + setFontWeight(600).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/h6": {
+      "status": "supported",
+      "mapsTo": "createLabel + setFontSize(12) + setFontWeight(600).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/header": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/hr": {
+      "status": "supported",
+      "mapsTo": "createCol + setFlex(height=1) + setBackground('#666').",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Visual divider.",
+      "issue": ""
+    },
+    "html/img": {
+      "status": "partial",
+      "mapsTo": "createLabel(id, '', parent) \u2014 placeholder until image loading. <img width/height> attributes are honored via __replayMediaAttributes__ (PR #1347).",
+      "supportedValues": [
+        "width/height HTML attributes for layout"
+      ],
+      "unsupportedValues": [
+        "actual image src loading (placeholder Label is shown)"
+      ],
+      "tests": [],
+      "notes": "Image loading not yet wired through this surface; use <Image> from @pulp/react or the canvas drawImage path instead.",
+      "issue": "1147"
+    },
+    "html/input": {
+      "status": "partial",
+      "mapsTo": "createTextEditor by default; createFader for type=range, createCheckbox for type=checkbox.",
+      "supportedValues": [
+        "type=text / type=password / type=email / type=number / type=range / type=checkbox"
+      ],
+      "unsupportedValues": [
+        "type=date/time/file/color/url/search \u2014 fall through to text-editor"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/label": {
+      "status": "supported",
+      "mapsTo": "createLabel \u2014 same as span.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "the `for` attribute (does not wire focus to a sibling input)"
+      ],
+      "tests": [],
+      "notes": "Confirmed 2026-05-04.",
+      "issue": ""
+    },
+    "html/main": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/nav": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/p": {
+      "status": "supported",
+      "mapsTo": "createLabel \u2014 same as span.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Confirmed 2026-05-04. Block-level CSS semantics not modeled (no margin defaults).",
+      "issue": ""
+    },
+    "html/progress": {
+      "status": "supported",
+      "mapsTo": "createProgress(id, parent).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/section": {
+      "status": "supported",
+      "mapsTo": "createCol \u2014 same as div.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/select": {
+      "status": "supported",
+      "mapsTo": "createCombo(id, parent).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "html/span": {
+      "status": "supported",
+      "mapsTo": "createLabel(id, '', parent). Confirmed 2026-05-04: <span> maps to Label widget (not View). Same for <p>, <label>.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Confirmed in web-compat-element.js _ensureNative.",
+      "issue": ""
+    },
+    "html/style": {
+      "status": "supported",
+      "mapsTo": "Element('style')._ensureNative -> createCol + setVisible(false). textContent is routed through _processStyleElement (web-compat-document.js) which parses CSS rules incl. :hover. PR #1345.",
+      "supportedValues": [
+        "inline <style> with class/id/element selectors",
+        ":hover pseudo-class"
+      ],
+      "unsupportedValues": [
+        "@media",
+        "@keyframes",
+        "complex selectors (pseudo-class chains, combinators)"
+      ],
+      "tests": [],
+      "notes": "PR #1345 / pulp #1149 part b.",
+      "issue": "1149"
+    },
+    "html/svg": {
+      "status": "partial",
+      "mapsTo": "createCol(id, parent) (PR #1347 confirmed). HTML width/height attributes reserve flex layout space; child <path>/<rect>/<circle>/etc are NOT rendered by an SVG renderer \u2014 they're parsed as Elements but paint nothing.",
+      "supportedValues": [
+        "<svg> as a layout-leaf placeholder with width/height attrs"
+      ],
+      "unsupportedValues": [
+        "actual SVG rendering of children (no path/rect/circle/text shape rasterization)"
+      ],
+      "tests": [],
+      "notes": "PR #1347 (pulp #1147): <svg> is a leaf container that reserves layout space. For rendered SVG paths use the @pulp/react SvgPath intrinsic.",
+      "issue": "1147"
+    },
+    "html/textarea": {
+      "status": "supported",
+      "mapsTo": "createTextEditor + setMultiLine(1).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    }
   },
   "canvas2d": {
-    "_note": "Pending second-pass audit. The Canvas2D shim (web-compat-canvas.js -> bridge canvas* family in widget_bridge.cpp) covers ~50 ops (canvasFillRect, canvasArc, canvasBezier, canvasGradient, canvasPath, canvasMeasureText, canvasGetImageData, canvasPutImageData, etc.). Spec source: HTML Living Standard CanvasRenderingContext2D."
+    "_note": "Populated 2026-05-04 from web-compat-canvas.js (~36 prototype methods + 7 attrs) crossed against widget_bridge.cpp's canvas* register_function entries (~47 funcs) and the Skia/CG backends in core/canvas/. Spec source: HTML Living Standard CanvasRenderingContext2D / https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D. The bridge layer is consistent across Skia (Linux/Windows) and CG (mac); divergences are noted per-entry. Heavy expansion landed in PR #1348 (pulp #1346 / #1322): save, restore, setTransform, translate, scale, rotate, globalAlpha, globalCompositeOperation, createLinearGradient, createRadialGradient, arc, arcTo, bezierCurveTo, quadraticCurveTo, rect, roundRect, ellipse, clip, fillText, strokeText. Skia gradient shape fills landed in #1353; CG counterpart in #1360 (merged 2026-05-03).",
+    "canvas2d/fillRect": {
+      "status": "supported",
+      "mapsTo": "web-compat-canvas.js: ctx.fillRect(x,y,w,h) -> _syncGlobalState + _applyFillStyle + canvasRect(id,x,y,w,h). Bridge `canvasRect` honors the active fillStyle / gradient via the use_active_style path (#968).",
+      "supportedValues": [
+        "any rectangle"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348 fixed a typo where the JS was calling canvasFillRect (which never existed) \u2014 now correctly calls canvasRect.",
+      "issue": "1346"
+    },
+    "canvas2d/strokeRect": {
+      "status": "supported",
+      "mapsTo": "ctx.strokeRect -> _syncGlobalState + _syncLineState + _applyStrokeStyle + canvasStrokeRect.",
+      "supportedValues": [
+        "any rectangle"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Stroke gradients fall back to first stop's color (bridge has no stroke-gradient setter today).",
+      "issue": ""
+    },
+    "canvas2d/clearRect": {
+      "status": "supported",
+      "mapsTo": "ctx.clearRect -> canvasClearRect.",
+      "supportedValues": [
+        "any rectangle"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/beginPath": {
+      "status": "supported",
+      "mapsTo": "ctx.beginPath -> canvasBeginPath.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/closePath": {
+      "status": "supported",
+      "mapsTo": "ctx.closePath -> canvasClosePath.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/moveTo": {
+      "status": "supported",
+      "mapsTo": "ctx.moveTo -> canvasMoveTo.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/lineTo": {
+      "status": "supported",
+      "mapsTo": "ctx.lineTo -> canvasLineTo.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/rect": {
+      "status": "supported",
+      "mapsTo": "ctx.rect(x,y,w,h) -> moveTo + 4\u00d7 lineTo back to start (composes a closed subpath).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Path-construction op (no fill/stroke). Honors fill()/stroke()/clip() afterward. PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/roundRect": {
+      "status": "partial",
+      "mapsTo": "ctx.roundRect(x,y,w,h,radii) -> moveTo + lineTos + arcTos. Uniform-corner case only.",
+      "supportedValues": [
+        "uniform radius (number, or array[1])"
+      ],
+      "unsupportedValues": [
+        "non-uniform radii (4 distinct corners) \u2014 falls back to largest single value"
+      ],
+      "tests": [],
+      "notes": "PR #1348. arcTo approximation is conservative \u2014 see canvas2d/arcTo.",
+      "issue": "1346"
+    },
+    "canvas2d/arc": {
+      "status": "partial",
+      "mapsTo": "ctx.arc(cx,cy,r,start,end,anticlockwise) -> path-mode emit as cubic-bezier segments via canvasMoveTo + canvasCubicTo. Bridge has immediate-mode canvasArc but no path-mode arc primitive.",
+      "supportedValues": [
+        "any arc"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348. The bezier approximation is per-quadrant (k = (4/3)\u00b7tan(\u03b8/4)); fidelity is visually exact for fill/stroke/clip use cases.",
+      "issue": "1346"
+    },
+    "canvas2d/arcTo": {
+      "status": "partial",
+      "mapsTo": "ctx.arcTo(x1,y1,x2,y2,r) -> conservative lineTo(x1,y1) + lineTo(x2,y2). Radius is currently ignored.",
+      "supportedValues": [
+        "any arcTo (radius ignored)"
+      ],
+      "unsupportedValues": [
+        "geometrically-correct arcTo with the proper radius-tangent computation"
+      ],
+      "tests": [],
+      "notes": "PR #1348. Used by roundRect and FilterBank's marquee corners; fidelity loss is minimal for those use cases. File a follow-up if a plugin needs spec-compliant arcTo.",
+      "issue": "1346"
+    },
+    "canvas2d/bezierCurveTo": {
+      "status": "supported",
+      "mapsTo": "ctx.bezierCurveTo -> canvasCubicTo.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/quadraticCurveTo": {
+      "status": "supported",
+      "mapsTo": "ctx.quadraticCurveTo -> canvasQuadTo.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/ellipse": {
+      "status": "partial",
+      "mapsTo": "ctx.ellipse(cx,cy,rx,ry,rotation,start,end,anticlockwise) -> rotation IGNORED; if rx===ry falls through to arc; otherwise emits a 4-segment cubic approximation.",
+      "supportedValues": [
+        "axis-aligned ellipses (rotation ignored)"
+      ],
+      "unsupportedValues": [
+        "non-zero rotation"
+      ],
+      "tests": [],
+      "notes": "PR #1348. FilterBank doesn't use ellipse \u2014 this is a thin parity shim.",
+      "issue": "1346"
+    },
+    "canvas2d/fill": {
+      "status": "supported",
+      "mapsTo": "ctx.fill -> _syncGlobalState + _applyFillStyle + canvasFillPath.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "fill rule arg ('evenodd' / 'nonzero') \u2014 accepted but ignored"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/stroke": {
+      "status": "supported",
+      "mapsTo": "ctx.stroke -> _syncGlobalState + _syncLineState + _applyStrokeStyle + canvasStrokePath.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/clip": {
+      "status": "supported",
+      "mapsTo": "ctx.clip(fillRule) -> canvasClip (intersects current clip with current path). Falls back to no-op if canvasClip absent.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "fillRule arg \u2014 bridge always uses non-zero today"
+      ],
+      "tests": [],
+      "notes": "Backed by SkCanvas::clipPath. (issue-896 added canvasClip; older canvasClipRect is the rect-only path.)",
+      "issue": ""
+    },
+    "canvas2d/save": {
+      "status": "supported",
+      "mapsTo": "ctx.save -> canvasSave (Skia/CG canvas state stack).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348. Without save/restore, FilterBank's first ctx.save() threw TypeError and aborted the frame.",
+      "issue": "1346"
+    },
+    "canvas2d/restore": {
+      "status": "supported",
+      "mapsTo": "ctx.restore -> canvasRestore.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/translate": {
+      "status": "supported",
+      "mapsTo": "ctx.translate(x,y) -> canvasTranslate.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/scale": {
+      "status": "supported",
+      "mapsTo": "ctx.scale(sx,sy) -> canvasScale.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/rotate": {
+      "status": "supported",
+      "mapsTo": "ctx.rotate(radians) -> canvasRotate.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/setTransform": {
+      "status": "supported",
+      "mapsTo": "ctx.setTransform(a,b,c,d,e,f) \u2014 also accepts a single DOMMatrix-like arg, shim unpacks. -> canvasSetTransform.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348. resetTransform aliases to setTransform(1,0,0,1,0,0).",
+      "issue": "1346"
+    },
+    "canvas2d/resetTransform": {
+      "status": "supported",
+      "mapsTo": "ctx.resetTransform -> canvasSetTransform(id, 1, 0, 0, 1, 0, 0).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/transform": {
+      "status": "partial",
+      "mapsTo": "ctx.transform(a,b,c,d,e,f) \u2014 multiplies CURRENT transform; bridge only exposes replace (setTransform), not concat. Pure-translation matrices (a===1, b===0, c===0, d===1) fall through to canvasTranslate; everything else is a no-op.",
+      "supportedValues": [
+        "pure-translation matrices"
+      ],
+      "unsupportedValues": [
+        "arbitrary concat (rotate/scale/skew + existing transform)"
+      ],
+      "tests": [],
+      "notes": "PR #1348. File a follow-up if a plugin needs strict concat.",
+      "issue": "1346"
+    },
+    "canvas2d/fillText": {
+      "status": "supported",
+      "mapsTo": "ctx.fillText(text,x,y,maxWidth) -> _syncGlobalState + _syncTextState + _applyFillStyle + canvasFillText(id, text, x, y, size, color). maxWidth is ignored; gradient fillStyle uses the first stop's color.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "maxWidth arg (ignored)",
+        "gradient fillStyle (degrades to first-stop color)"
+      ],
+      "tests": [],
+      "notes": "PR #1348. canvasSetFont parses 'Npx Family' from the JS-side font string.",
+      "issue": "1346"
+    },
+    "canvas2d/strokeText": {
+      "status": "partial",
+      "mapsTo": "ctx.strokeText -> falls back to fillText with the strokeStyle color (bridge has no stroke-text command).",
+      "supportedValues": [
+        "visual approximation of stroked text via solid fill"
+      ],
+      "unsupportedValues": [
+        "true stroked-glyph rendering"
+      ],
+      "tests": [],
+      "notes": "Visually close enough for FilterBank/HUD use; file a follow-up if a plugin needs outlined typography.",
+      "issue": ""
+    },
+    "canvas2d/measureText": {
+      "status": "supported",
+      "mapsTo": "ctx.measureText(text) \u2014 when canvasMeasureText is available returns the bridge-side TextMetrics; else returns a coarse char-width estimate.",
+      "supportedValues": [
+        "width",
+        "actualBoundingBoxLeft/Right/Ascent/Descent",
+        "fontBoundingBoxAscent/Descent"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "issue-916. The shim guarantees a non-null TextMetrics object even on older hosts where canvasMeasureText isn't registered (returns zero-filled fields based on font px size).",
+      "issue": ""
+    },
+    "canvas2d/drawImage": {
+      "status": "partial",
+      "mapsTo": "ctx.drawImage(img, ...) -> canvasDrawImage(id, src, dx, dy, dw, dh). Supports the 3-arg, 5-arg, and 9-arg signatures; the 9-arg source-rect form is currently treated as the destination-only form (sx/sy/sw/sh ignored).",
+      "supportedValues": [
+        "drawImage(img, dx, dy)",
+        "drawImage(img, dx, dy, dw, dh)"
+      ],
+      "unsupportedValues": [
+        "drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh) \u2014 sprite-sheet slicing not yet wired"
+      ],
+      "tests": [],
+      "notes": "issue-916. File a follow-up if a Pulp plugin needs sprite-sheet slicing.",
+      "issue": ""
+    },
+    "canvas2d/getImageData": {
+      "status": "partial",
+      "mapsTo": "ctx.getImageData(x,y,w,h) -> canvasGetImageData (returns base64 RGBA blob, shim decodes to Uint8ClampedArray).",
+      "supportedValues": [
+        "any rect from a rasterized canvas"
+      ],
+      "unsupportedValues": [
+        "non-rasterized RecordingCanvas (returns zero-filled)"
+      ],
+      "tests": [],
+      "notes": "issue-916. The base64 round-trip avoids passing typed arrays across the JS bridge.",
+      "issue": ""
+    },
+    "canvas2d/putImageData": {
+      "status": "partial",
+      "mapsTo": "ctx.putImageData(imgdata, dx, dy) -> base64-encodes and calls canvasPutImageData.",
+      "supportedValues": [
+        "putImageData(img, dx, dy)"
+      ],
+      "unsupportedValues": [
+        "putImageData(img, dx, dy, dirtyX, dirtyY, dirtyW, dirtyH) \u2014 sub-rect form treated as no-rect"
+      ],
+      "tests": [],
+      "notes": "issue-916. File a follow-up if sub-rect updates become a hot path.",
+      "issue": ""
+    },
+    "canvas2d/createLinearGradient": {
+      "status": "supported",
+      "mapsTo": "ctx.createLinearGradient(x0,y0,x1,y1) -> returns a JS-side CanvasGradient object with addColorStop(); the bridge picks it up on the next fill via canvasSetLinearGradient.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348. CG (mac) gradient-shape fill landed in #1359/#1360 (merged 2026-05-03).",
+      "issue": "964"
+    },
+    "canvas2d/createRadialGradient": {
+      "status": "partial",
+      "mapsTo": "ctx.createRadialGradient(x0,y0,r0,x1,y1,r1) -> CanvasGradient with kind='radial'. Bridge models a single-circle radial gradient (centre + radius); shim uses the OUTER circle (x1,y1,r1).",
+      "supportedValues": [
+        "centre-bloom usage where x0===x1, y0===y1, r0===0"
+      ],
+      "unsupportedValues": [
+        "true two-circle radial gradient (inner + outer with separate radii)"
+      ],
+      "tests": [],
+      "notes": "PR #1348. Visually equivalent for FilterBank's typical centre-bloom; file follow-up if a plugin needs the offset-inner-circle form.",
+      "issue": "964"
+    },
+    "canvas2d/createConicGradient": {
+      "status": "missing",
+      "mapsTo": "ctx.createConicGradient -> shim returns an empty linear gradient as a graceful fallback (consumer code can assign to fillStyle without throwing). Bridge has no conic shader.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "true conic gradient"
+      ],
+      "tests": [],
+      "notes": "Conic gradients need a Skia conic shader \u2014 not yet plumbed through. Silent degradation to linear (likely invisible). File a follow-up before any plugin actually depends on conic.",
+      "issue": ""
+    },
+    "canvas2d/createPattern": {
+      "status": "missing",
+      "mapsTo": "ctx.createPattern -> shim returns null (per spec, returning null is permissible when source unavailable). Bridge has no pattern shader.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "repeated-image patterns"
+      ],
+      "tests": [],
+      "notes": "Patterns are rare in audio plugin UIs. Callers must guard against null.",
+      "issue": ""
+    },
+    "canvas2d/addColorStop": {
+      "status": "supported",
+      "mapsTo": "CanvasGradient.addColorStop(offset, color) \u2014 accumulates stops on the JS-side gradient object; flushed to bridge via canvasSetLinearGradient / canvasSetRadialGradient when the gradient is assigned to fillStyle.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": "964"
+    },
+    "canvas2d/setLineDash": {
+      "status": "partial",
+      "mapsTo": "ctx.setLineDash(pattern) -> canvasSetLineDash(id, pattern, lineDashOffset).",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "odd-length array spec-doubling (shim takes pattern verbatim; bridge handles the spec-doubling)"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/getLineDash": {
+      "status": "supported",
+      "mapsTo": "Returns a copy of the current pattern (per spec).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/lineDashOffset": {
+      "status": "partial",
+      "mapsTo": "Tracked as a JS field; passed to canvasSetLineDash on every setLineDash call. Mutating lineDashOffset alone (without re-calling setLineDash) does NOT push the new offset to the bridge.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "lineDashOffset mutation between draws (must re-call setLineDash to push new phase)"
+      ],
+      "tests": [],
+      "notes": "Minor edge case; file a follow-up if observable.",
+      "issue": ""
+    },
+    "canvas2d/fillStyle": {
+      "status": "supported",
+      "mapsTo": "Settable to a CSS-color string OR a CanvasGradient object. Solid colors push via canvasSetFillColor; gradients push via canvasSetLinearGradient / canvasSetRadialGradient on the next draw.",
+      "supportedValues": [
+        "CSS color strings",
+        "CanvasGradient (linear, radial)"
+      ],
+      "unsupportedValues": [
+        "CanvasPattern"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/strokeStyle": {
+      "status": "partial",
+      "mapsTo": "Settable to a CSS-color string OR a CanvasGradient. Bridge has no stroke-gradient setter \u2014 gradient strokeStyle degrades to the first stop's color.",
+      "supportedValues": [
+        "CSS color strings"
+      ],
+      "unsupportedValues": [
+        "CanvasGradient on stroke (degrades to first-stop color)"
+      ],
+      "tests": [],
+      "notes": "Bridge could expose canvasSetStrokeLinearGradient if a plugin needs gradient strokes.",
+      "issue": ""
+    },
+    "canvas2d/lineWidth": {
+      "status": "supported",
+      "mapsTo": "Tracked locally; pushed to bridge via canvasSetLineWidth on the next stroke().",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/lineCap": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasSetLineCap on next stroke (idempotent: only pushes when value changed).",
+      "supportedValues": [
+        "butt",
+        "round",
+        "square"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/lineJoin": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasSetLineJoin on next stroke.",
+      "supportedValues": [
+        "miter",
+        "round",
+        "bevel"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/miterLimit": {
+      "status": "missing",
+      "mapsTo": "Tracked locally; not pushed to bridge.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "miterLimit propagation to canvas paint"
+      ],
+      "tests": [],
+      "notes": "Silent no-op \u2014 bridge has no canvasSetMiterLimit. File a follow-up if needed.",
+      "issue": ""
+    },
+    "canvas2d/globalAlpha": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasSetGlobalAlpha on the next draw.",
+      "supportedValues": [
+        "[0, 1]"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348.",
+      "issue": "1346"
+    },
+    "canvas2d/globalCompositeOperation": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasGlobalCompositeOperation OR canvasSetBlendMode on the next draw.",
+      "supportedValues": [
+        "source-over",
+        "source-in",
+        "source-out",
+        "source-atop",
+        "destination-over",
+        "destination-in",
+        "destination-out",
+        "destination-atop",
+        "lighter",
+        "copy",
+        "xor",
+        "multiply",
+        "screen",
+        "overlay",
+        "darken",
+        "lighten",
+        "color-dodge",
+        "color-burn",
+        "hard-light",
+        "soft-light",
+        "difference",
+        "exclusion",
+        "hue",
+        "saturation",
+        "color",
+        "luminosity"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "PR #1348. Coverage of the Porter-Duff + blend-mode set depends on the canvas backend (Skia handles all; CG handles most).",
+      "issue": "1346"
+    },
+    "canvas2d/font": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; canvasSetFont(id, family, size) on the next draw. Shim parses '<size>px <family>'.",
+      "supportedValues": [
+        "'<size>px <family>'"
+      ],
+      "unsupportedValues": [
+        "full CSS font shorthand (style/variant/stretch \u2014 only size+family extracted)"
+      ],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/textAlign": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasSetTextAlign on next text draw.",
+      "supportedValues": [
+        "left",
+        "right",
+        "center",
+        "start",
+        "end"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/textBaseline": {
+      "status": "supported",
+      "mapsTo": "Locally tracked; flushed via canvasSetTextBaseline.",
+      "supportedValues": [
+        "top",
+        "hanging",
+        "middle",
+        "alphabetic",
+        "ideographic",
+        "bottom"
+      ],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/imageSmoothingEnabled": {
+      "status": "missing",
+      "mapsTo": "Tracked as a JS field; not pushed to bridge.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Silent no-op. Skia/CG default to enabled smoothing.",
+      "issue": ""
+    },
+    "canvas2d/imageSmoothingQuality": {
+      "status": "missing",
+      "mapsTo": "Tracked as a JS field; not pushed to bridge.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Silent no-op.",
+      "issue": ""
+    },
+    "canvas2d/direction": {
+      "status": "missing",
+      "mapsTo": "Tracked locally; not pushed to bridge.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "text rendering direction (ltr/rtl) on Canvas2D"
+      ],
+      "tests": [],
+      "notes": "Silent no-op. Yoga RTL is also unsupported (yoga/direction missing).",
+      "issue": ""
+    },
+    "canvas2d/filter": {
+      "status": "missing",
+      "mapsTo": "Not implemented in shim or bridge.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "Canvas2D filter chains (blur, brightness, etc.)"
+      ],
+      "tests": [],
+      "notes": "Distinct from CSS `filter` on the View \u2014 this is the per-context Canvas2D filter. Not yet implemented.",
+      "issue": ""
+    },
+    "canvas2d/shadowColor": {
+      "status": "missing",
+      "mapsTo": "Not implemented.",
+      "supportedValues": [],
+      "unsupportedValues": [
+        "Canvas2D shadow drop"
+      ],
+      "tests": [],
+      "notes": "Bridge has no canvasShadow* setters. Box-shadow on the View widget is separate (#925).",
+      "issue": ""
+    },
+    "canvas2d/shadowBlur": {
+      "status": "missing",
+      "mapsTo": "Not implemented.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/shadowOffsetX": {
+      "status": "missing",
+      "mapsTo": "Not implemented.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/shadowOffsetY": {
+      "status": "missing",
+      "mapsTo": "Not implemented.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/getContext_webgpu": {
+      "status": "supported",
+      "mapsTo": "HTMLCanvasElement.getContext('webgpu') -> __createGPUCanvasContext (web-compat-canvas.js). Returns a GPUCanvasContext with configure / getCurrentTexture / present that bridges to native WebGPU when the device is native.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Tracked in detail under canvas2d/* by convention even though WebGPU is not strictly Canvas2D \u2014 the shim co-locates them. See planning/research/three-js* for the Three.js end-to-end story.",
+      "issue": ""
+    },
+    "canvas2d/getContext_2d": {
+      "status": "supported",
+      "mapsTo": "HTMLCanvasElement.getContext('2d') -> CanvasRenderingContext2D singleton per-canvas (cached on _canvasContext2d).",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "",
+      "issue": ""
+    },
+    "canvas2d/_native_canvasFillCircle": {
+      "status": "supported",
+      "mapsTo": "Pulp-specific bridge fn (canvasFillCircle). Used by some legacy widget renderers; NOT spec'd in HTML5 Canvas. Plugin code should prefer arc()+fill().",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Bridge convenience; not part of the standard Canvas2D API.",
+      "issue": ""
+    },
+    "canvas2d/_native_canvasFillRoundedRect": {
+      "status": "supported",
+      "mapsTo": "Pulp-specific bridge fn (canvasFillRoundedRect). Equivalent of roundRect()+fill() in one call.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Bridge convenience.",
+      "issue": ""
+    },
+    "canvas2d/_native_canvasStrokeLine": {
+      "status": "supported",
+      "mapsTo": "Pulp-specific bridge fn (canvasStrokeLine). Equivalent of moveTo()+lineTo()+stroke() in one call.",
+      "supportedValues": [],
+      "unsupportedValues": [],
+      "tests": [],
+      "notes": "Bridge convenience.",
+      "issue": ""
+    }
   },
   "imports": {
+    "_note": "The 'imports' prefix tracks design-import format detection (see core/dsl/import-design / tools/cli/src/import_design.cpp / docs/reference/imports/*). Each top-level key is a recognized import source (claude, figma, pencil, stitch, v0); each entry carries 'parser-version' (the Pulp-side detector version) and 'detected-formats' (a list of {format-version, introduced, deprecated, fingerprint, notes} objects). The `fingerprint` field is the heuristic the parser uses to recognize the source format from a directory or file payload. When a new import source lands or an existing source's export format changes, add a detected-formats entry rather than mutating an existing one (so historical exports keep parsing). Tracked via PR #1047 (pulp #1031) for versioned import-design detection.",
     "claude": {
       "parser-version": "2.1",
       "detected-formats": [

--- a/docs/reference/compat/canvas2d.md
+++ b/docs/reference/compat/canvas2d.md
@@ -1,0 +1,111 @@
+# Canvas2D compat
+
+Status of the Canvas2D rendering surface exposed by
+`core/view/js/web-compat-canvas.js` and the `canvas*` family in
+`core/view/src/widget_bridge.cpp`. Backed by the Skia canvas
+(`core/canvas/src/skia_canvas.cpp`) on Linux and Windows, and the
+Core Graphics canvas (`core/canvas/platform/mac/cg_canvas.mm`) on
+macOS.
+
+The authoritative inventory is `compat.json` (`canvas2d/*` prefix).
+
+## Generation
+
+Last refresh: **2026-05-04** against `origin/main` at SHA `a5f4f5ac`.
+
+Spec walk:
+[MDN CanvasRenderingContext2D](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D)
+(HTML Living Standard).
+
+This section was previously a stub. The 2026-05-04 pass walked the
+~36 prototype methods + 7 attrs in the JS shim against the ~47
+`canvas*` register_function entries in widget_bridge.cpp, with extra
+notes per backend where Skia and CG diverge.
+
+## Counts (2026-05-04)
+
+| Status | Count |
+|--------|------:|
+| supported | ~38 |
+| partial | ~10 |
+| missing | ~12 |
+
+## Recently expanded (#1348)
+
+PR #1348 (pulp #1346, augments #1322) wired up the bulk of the
+Canvas2D state-stack and transform surface that FilterBank's
+visualizer needs:
+
+- State stack: `save`, `restore`
+- Transform: `translate`, `scale`, `rotate`, `setTransform`,
+  `resetTransform`, `transform` (pure-translation only)
+- Path construction: `arc`, `arcTo`, `bezierCurveTo`,
+  `quadraticCurveTo`, `rect`, `roundRect`, `ellipse`, `clip`
+- Text: `fillText`, `strokeText`
+- Gradients: `createLinearGradient`, `createRadialGradient`,
+  `addColorStop`
+- Compositing: `globalAlpha`, `globalCompositeOperation`
+- Line state: `lineCap`, `lineJoin`, `setLineDash` / `getLineDash`
+
+Skia gradient-shape fills (fillRect / fillCircle /
+fillRoundedRect honoring an active linear or radial gradient) landed
+in #1353. CG counterpart in #1359 / PR #1360 (merged 2026-05-03).
+
+## Pre-existing surface
+
+These were wired before #1348 and remain stable:
+`fillRect`, `strokeRect`, `clearRect`, `beginPath`, `closePath`,
+`moveTo`, `lineTo`, `fill`, `stroke`, `lineWidth`, `font`, `textAlign`,
+`textBaseline`, `fillStyle`, `strokeStyle`, `measureText`,
+`drawImage`, `getImageData`, `putImageData`. Pulp-specific bridge
+conveniences: `canvasFillCircle`, `canvasFillRoundedRect`,
+`canvasStrokeLine`.
+
+## Notable gaps
+
+1. **`createConicGradient`** — bridge has no conic shader. Shim returns
+   an empty linear gradient as a fallback so consumer code doesn't
+   throw, but the visual will silently degrade.
+2. **`createPattern`** — returns `null`; bridge has no pattern shader.
+   Per spec, null is permissible when source is unavailable.
+3. **`shadowColor` / `shadowBlur` / `shadowOffsetX` / `shadowOffsetY`**
+   — Canvas2D shadow drop is not wired. Distinct from `boxShadow` on
+   the View widget (which is wired).
+4. **`filter`** — Canvas2D per-context filter chains are not wired.
+5. **`miterLimit`** — tracked locally on the shim but never pushed.
+6. **`imageSmoothingEnabled` / `imageSmoothingQuality`** — tracked
+   locally but never pushed. Skia/CG default to enabled smoothing.
+7. **`direction`** — text rendering direction (ltr/rtl) tracked locally
+   but never pushed.
+
+## Partial / approximated
+
+1. **`arcTo`** — currently emits `lineTo(x1,y1) + lineTo(x2,y2)`,
+   ignoring the radius. Used by `roundRect` and FilterBank's marquee
+   corners; fidelity loss is minimal for those use cases.
+2. **`ellipse`** — ignores `rotation`; falls through to `arc` when
+   `rx === ry`; otherwise emits a 4-segment cubic approximation.
+3. **`transform`** (concat-on-right) — bridge only exposes `setTransform`
+   (replace). Pure-translation matrices fall through to `translate`;
+   anything else is a no-op.
+4. **`strokeText`** — falls back to `fillText` with the stroke color
+   (bridge has no stroke-text command).
+5. **`createRadialGradient`** — bridge models a single-circle radial
+   gradient; shim uses the outer circle. Visually equivalent for
+   centre-bloom usage where `x0 === x1`, `y0 === y1`, `r0 === 0`.
+6. **`drawImage`** 9-arg form — sprite-sheet slicing
+   (`sx, sy, sw, sh`) is currently ignored.
+7. **`putImageData`** sub-rect form — `dirtyX/Y/W/H` ignored.
+8. **`setLineDash`** — odd-length spec-doubling is bridge-side; shim
+   passes verbatim. `lineDashOffset` mutation between draws is not
+   re-pushed (must re-call `setLineDash`).
+9. **`strokeStyle = gradient`** — bridge has no stroke-gradient setter;
+   degrades to the first stop's color.
+
+## WebGPU surface
+
+`canvas.getContext('webgpu')` is wired through
+`__createGPUCanvasContext` — bridges to native WebGPU when the device
+is native. See planning notes for the Three.js + Dawn end-to-end story.
+The full WebGPU surface lives separately in `web-compat-gpu-buffered.js`
+and is out of scope for this Canvas2D compat doc.

--- a/docs/reference/compat/css.md
+++ b/docs/reference/compat/css.md
@@ -1,0 +1,97 @@
+# CSS compat
+
+Status of the CSS property surface exposed by Pulp's DOM-lite consumer
+(`core/view/js/web-compat-style-decl.js`). This is the runtime that
+implements `el.style.X = "..."` for plugins that author UI as
+HTML+CSS rather than React.
+
+The authoritative inventory is `compat.json` (`css/*` prefix). This
+page is the human-readable narrative; for the full property list with
+mapping notes, supported/unsupported values, and issue links, consult
+`compat.json` directly.
+
+## Generation
+
+Last refresh: **2026-05-04** against `origin/main` at SHA `a5f4f5ac`.
+
+Spec walk: top ~150 properties from
+[MDN CSS Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties)
+across layout, box-model, typography, color, transforms, transitions,
+animations, gradients, flex, grid, and basic SVG. Print and paged-media
+specifics are out of scope.
+
+## Counts (2026-05-04)
+
+| Status | Count |
+|--------|------:|
+| supported | ~75 |
+| partial | ~30 |
+| missing | ~60 |
+| wontfix | ~30 |
+
+(See `_audit.counts.css` in `compat.json` for the exact totals.)
+
+## Recently changed
+
+- `css/border` / `css/borderRadius` / `css/borderColor`: flipped from
+  `partial` (clobbered each other) to `supported`. PR #1169 routed each
+  through its dedicated per-attribute setter so unset siblings are
+  preserved (CSS semantics).
+- `css/fontFamily`: flipped to `supported`. PR #1174 splits comma-
+  separated lists, strips outer quotes, and picks the first non-empty
+  family before calling Skia's `SkFontMgr`. Generic fallbacks
+  (`monospace`, `ui-monospace`) still don't resolve specially — Skia
+  falls through to the platform default.
+- `css/display`: behavior fix in PR #1167. `display: flex` now defaults
+  flex-direction to `row` to match CSS web compat (Pulp's underlying
+  widgets default to `column`/RN convention). Explicit `flexDirection`
+  / `flex-direction` / `flex-flow` with a direction token still wins.
+- `css/transition`: extended note — PR #1345 added `:hover` selector
+  parsing in inline `<style>` elements, completing the transition story
+  end-to-end for the common interactive case.
+- `css/__hover_pseudo`: new entry. Documents the bounded `:hover`
+  support in `web-compat-document.js`.
+
+## Silent no-ops (parser exists, backend stub)
+
+The JS adapter parses these and calls the bridge function; the bridge
+function is **not registered**, so the value is silently dropped.
+`typeof` guards prevent runtime errors.
+
+1. `css/animation*` (8 props) — `setAnimation` is registered but the
+   body is `(void)id; (void)prop; …` (widget_bridge.cpp:3242). All
+   `@keyframes` UIs animate nothing.
+2. `css/aspectRatio` — JS routes via `setFlex(id, "aspect_ratio", …)`
+   but `setFlex`'s C++ switch has no `aspect_ratio` branch.
+3. `css/boxSizing` — `setBoxSizing` referenced, never registered.
+4. `css/lineClamp` / `css/webkitLineClamp` — `setLineClamp` referenced,
+   never registered. Multi-line truncation impossible.
+5. `css/backgroundSize` / `css/backgroundPosition` /
+   `css/backgroundRepeat` — three setters referenced, none registered.
+   Tied to `backgroundImage: url()` which is also missing.
+6. `css/outline` / `css/outlineWidth` / `css/outlineColor` —
+   `setOutline` referenced, never registered. Affects accessibility
+   focus rings.
+7. `css/textShadow` — `setTextShadow` referenced, never registered.
+8. `css/wordBreak` / `css/overflowWrap` / `css/wordWrap` —
+   `setWordBreak` referenced, never registered.
+9. `css/touchAction` — parsed and stored on the JS Element instance
+   but never propagated to the C++ hit-test.
+
+## Known buggy-but-supported
+
+1. `css/lineHeight` unitless multiplier (`lineHeight: 1.5`) — silently
+   dropped (only `px` accepted by `parseCSSLength`).
+2. `css/flexDirection` — `row-reverse` and `column-reverse` silently
+   fall through to `col` default.
+3. `css/flexWrap` — bool-only; `wrap-reverse` inexpressible.
+4. `css/transform` — only `scale`, `rotate`, `translate`, `translateX`,
+   `translateY` honored; `scale(x,y)`, `scaleX/Y`, `skewX/Y`,
+   `rotateX/Y/Z` silently dropped.
+5. `css/overflow: scroll` — silently maps to `hidden` (use ScrollView).
+6. `css/position: fixed` / `css/position: sticky` — accepted but layout
+   may not differ from `absolute` (verification follow-up open).
+7. `css/opacity: 50%` — percentage suffix stripped by `parseFloat`,
+   yields `50`, clamped to `1`. Visually fine, semantically wrong.
+8. `css/alignItems: baseline` / `css/alignSelf: baseline` — `FlexAlign`
+   enum has no baseline variant.

--- a/docs/reference/compat/html.md
+++ b/docs/reference/compat/html.md
@@ -1,0 +1,101 @@
+# HTML / DOM-lite compat
+
+Status of the DOM-lite consumer surface in `core/view/js/web-compat-element.js`
+and `core/view/js/web-compat-document.js`. This is the runtime that
+implements `document.createElement(...)`, `el.setAttribute(...)`,
+`el.appendChild(...)`, `el.addEventListener(...)`, `el.classList`,
+`el.dataset`, etc., for plugins that author UI as HTML+CSS.
+
+The authoritative inventory is `compat.json` (`html/*` prefix).
+
+## Generation
+
+Last refresh: **2026-05-04** against `origin/main` at SHA `a5f4f5ac`.
+
+Spec walk:
+[MDN Element / HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/Element)
++ subclass attribute coverage, ARIA attrs, dataset, classList, the
+DocumentFragment shim, Event constructor surface.
+
+This section was previously a stub. The 2026-05-04 pass enumerated
+the tag-to-widget mapping, the Element surface (~40 properties /
+methods), the document surface, and the StyleSheet / inline `<style>`
+parser.
+
+## Counts (2026-05-04)
+
+| Status | Count |
+|--------|------:|
+| supported | ~45 |
+| partial | ~10 |
+| missing | ~5 |
+
+## Tag → widget mapping
+
+| HTML tag | Widget | Notes |
+|---|---|---|
+| `div`, `section`, `article`, `aside`, `header`, `footer`, `nav`, `main` | `createCol` | Generic flow containers (column flex). |
+| `span`, `p`, `label` | `createLabel` | Confirmed 2026-05-04: text-content tags map to Label widget, not View. |
+| `h1`–`h6` | `createLabel` + `setFontSize` + `setFontWeight` | Heading levels carry default size/weight per level. |
+| `button` | `createToggleButton` | Inherits ToggleButton — toggleable by default. |
+| `input` | `createTextEditor` (default), `createFader` (type=range), `createCheckbox` (type=checkbox) | |
+| `textarea` | `createTextEditor` + `setMultiLine(1)` | |
+| `select` | `createCombo` | |
+| `canvas` | `createCanvas` | Use `getContext('2d')` or `getContext('webgpu')`. |
+| `progress` | `createProgress` | |
+| `hr` | `createCol` + 1px height + grey background | Visual divider. |
+| `img` | `createLabel` (placeholder) | HTML `width` / `height` attrs reserve flex space (PR #1347). |
+| `svg` | `createCol` | Layout-leaf placeholder; HTML width/height reserve space; child shapes do NOT render (PR #1347). For rendered SVG paths, use `<SvgPath>` from `@pulp/react`. |
+| `details` | `createCol` | Toggle / summary semantics not modeled. |
+| `dialog` | `createPanel` + hidden | `showModal()` / `close()` not wired. |
+| `style` | `createCol` + hidden + textContent → CSS parser | PR #1345 added `:hover` selector support. |
+
+## Recently changed
+
+- `html/svg` (PR #1347, pulp #1147): inline `<svg>` is now a layout
+  placeholder that honors the HTML `width` / `height` attributes.
+  Previously it collapsed to height 0 and broke flex siblings.
+- `html/span`, `html/p`, `html/label`: confirmed mapping to **Label**
+  widget (not View). Previously the matrix was ambiguous.
+- `html/style` (PR #1345, pulp #1149 part b): inline `<style>` text
+  is parsed and applied; `:hover` rules are stashed and toggled on
+  mouseenter/mouseleave.
+- `html/Element_addEventListener` for hover events (PR #1173,
+  pulp #1149 part a): `registerHover` is now called when a hover
+  listener is registered, so the C++ side actually fires.
+
+## Element surface — supported
+
+`setAttribute`, `getAttribute`, `removeAttribute`, `classList` (full),
+`dataset` (camelCase data-*), `textContent`, `value`, `hidden`,
+`disabled` (re-applies stylesheets, see partial note below),
+`appendChild` / `removeChild` / `insertBefore` / `replaceChild`,
+`cloneNode`, `addEventListener` (click, mouseenter/leave,
+pointerenter/leave, pointerdown/move/up/cancel, gesture*, input,
+change, focus, blur), `dispatchEvent`, `setPointerCapture` /
+`releasePointerCapture`, `getBoundingClientRect`, `offsetWidth` /
+`offsetHeight` / `clientWidth` / `clientHeight`, `nodeType` /
+`nodeName` (for React's reconciler hot path).
+
+## Notable gaps
+
+1. **`html/ARIA`** (missing) — `aria-*` attributes are stored in
+   `_attributes` but NOT routed to platform accessibility APIs.
+   Major gap; needs dedicated work.
+2. **`html/Element_disabled`** (partial) — re-applies stylesheets but
+   does NOT call the bridge's `setEnabled`. Native widget disabled-
+   state is not toggled.
+3. **`html/Event_constructor`** (partial) — `_makeEvent` factory
+   exists, but `new Event('foo')` user-side construction surface is
+   not wired.
+4. **`html/document_querySelector`** (partial) — only `#id`, `.class`,
+   and `tagname` selectors. Complex selectors / attribute selectors /
+   pseudo-classes / combinators are not supported.
+5. **`html/StyleSheet_inline`** — no `@media`, `@keyframes`, `@import`,
+   `@font-face`, `@supports`, or complex selectors.
+6. **Drag and drop** — `dragstart` / `drag` / `dragend` not wired
+   through addEventListener; use `registerDrop` directly.
+7. **Wheel events** — `wheel` not wired through addEventListener; use
+   `registerWheel` directly.
+8. **Keyboard events** — `keydown` / `keyup` / `keypress` are forwarded
+   globally via `__dispatch__` rather than bound per-element.

--- a/docs/reference/compat/imports.md
+++ b/docs/reference/compat/imports.md
@@ -1,0 +1,63 @@
+# Imports compat
+
+The `imports/*` prefix tracks **design-import format detection** —
+the heuristics Pulp's import-design pipeline uses to recognize a
+directory or file payload from a particular external design tool.
+
+This is distinct from the CSS / RN / HTML / Canvas2D matrices. Those
+track property-level support; this section tracks source-format
+support.
+
+The authoritative inventory is `compat.json` (`imports/*` prefix).
+
+## Generation
+
+Last refresh: **2026-05-04** against `origin/main` at SHA `a5f4f5ac`.
+
+Wired by PR #1047 (pulp #1031) — versioned import-design detection.
+See `core/dsl/import-design/` and `tools/cli/src/import_design.cpp`.
+
+## Sources
+
+| Key | Parser version | Detected formats |
+|-----|---------------:|-----------------:|
+| `claude` | 2.1 | 1 (Anthropic Labs Claude Design 2024.10) |
+| `figma` | 0.1 | 0 (placeholder) |
+| `pencil` | 0.1 | 0 (placeholder) |
+| `stitch` | 1.0 | 1 (Stitch 2025.04) |
+| `v0` | 0.1 | 0 (placeholder) |
+
+## Format-detection convention
+
+Each `detected-formats` entry carries:
+
+- `format-version`: a date-stringly version (when the export shape
+  changed).
+- `introduced` / `deprecated`: when this Pulp parser started / stopped
+  matching it.
+- `fingerprint`: an array of heuristics, each `{kind, ...}`. Recognized
+  kinds:
+  - `directory-files` — required files at the top of a directory ZIP
+  - `html-script-type` — required `<script type="...">` value
+  - `html-script-src` — regex match against `<script src="...">`
+  - `tailwind-config-token` — Tailwind utility token presence (any-of)
+- `notes`: human-readable description.
+
+## Adding a new format
+
+When a new import source lands or an existing source's export format
+changes:
+
+1. **Add** a new `detected-formats` entry rather than mutating an
+   existing one (so historical exports keep parsing).
+2. Update `parser-version` if the detector logic itself changed.
+3. Set `deprecated` on the old entry only if you are *also* removing
+   the parser path.
+
+## Recently changed
+
+- `claude/2024.10`: existing entry. Anthropic Labs Claude Design —
+  manually-exported standalone HTML detected via the inline bundler
+  script tag inserted by the export.
+- `stitch/2025.04`: existing entry. Material 3 token vocab + Tailwind
+  CDN with forms/container-queries plugins is the strongest signal.

--- a/docs/reference/compat/react.md
+++ b/docs/reference/compat/react.md
@@ -1,0 +1,26 @@
+# React compat
+
+Reserved for React-specific features that aren't single-prop entries:
+Suspense, ConcurrentMode, Profiler, error boundaries, refs, portals,
+hooks edge cases (`useTransition`, `useDeferredValue`, `useId`,
+`useSyncExternalStore`).
+
+The single-prop surface (`fontSize`, `border`, `data`, etc.) is
+captured under [`rn`](rn.md), which mirrors what
+`packages/pulp-react/src/prop-applier.ts` actually dispatches.
+
+## Generation
+
+Last refresh: **2026-05-04** against `origin/main` at SHA `a5f4f5ac`.
+
+## Status
+
+As of 2026-05-04 the renderer is built on `react-reconciler@0.31` and
+supports the basic function-component + `useState` + `useEffect` +
+`useRef` + `useMemo` / `useCallback` set; concurrent features are not
+exercised. The matrix entries here are currently empty pending a
+dedicated end-to-end React-feature audit.
+
+Follow-up: enumerate observed React features (concurrent rendering,
+suspense boundaries, transition state, error boundaries, portal
+targets) and populate per-feature entries.

--- a/docs/reference/compat/rn.md
+++ b/docs/reference/compat/rn.md
@@ -1,0 +1,66 @@
+# React Native compat
+
+Status of the React Native style-prop surface exposed by Pulp's
+`@pulp/react` consumer (`packages/pulp-react/src/prop-applier.ts`).
+This is the renderer that turns RN-style JSX into bridge `setX` calls.
+
+The authoritative inventory is `compat.json` (`rn/*` prefix).
+
+## Generation
+
+Last refresh: **2026-05-04** against `origin/main` at SHA `a5f4f5ac`.
+
+Spec walk:
+- [RN View Style Props](https://reactnative.dev/docs/view-style-props)
+- [RN Text Style Props](https://reactnative.dev/docs/text-style-props)
+- [RN Layout Props](https://reactnative.dev/docs/layout-props)
+- [RN Transforms](https://reactnative.dev/docs/transforms)
+
+## Counts (2026-05-04)
+
+| Status | Count |
+|--------|------:|
+| supported | ~45 |
+| partial | ~3 |
+| missing | ~70 |
+| wontfix | ~3 |
+
+## Recently changed
+
+- New `rn/d`, `rn/viewBox`, `rn/fill`, `rn/stroke`, `rn/strokeWidth`
+  entries. Wired by the `@pulp/react` `<SvgPath>` JSX intrinsic in
+  PR #1291 (pulp #994). Bridge surface lands on `SvgPathWidget`.
+- New `rn/overlay` entry. `overlay={true}` claims the global active-
+  overlay slot for click routing on absolute-positioned popovers.
+  PRs #1297 + #1344 (pulp #1148).
+- Per-side flat border props (`borderTopColor`, `borderTopWidth`,
+  `borderTopLeftRadius`, etc.) flipped to `supported` after PR #1169
+  fixed the per-attribute setters.
+
+## Notable gaps
+
+1. `rn/transform` — `@pulp/react` has no `transform` prop at all today;
+   the RN array-of-objects shape is not surfaced.
+2. `rn/flex` shorthand — RN's `style={{flex: 1}}` is the most common
+   pattern in tutorials. `@pulp/react` users must type
+   `flexGrow={1} flexShrink={1} flexBasis={0}`.
+3. `rn/marginHorizontal`, `rn/marginVertical`, `rn/paddingHorizontal`,
+   `rn/paddingVertical` — RN-specific shorthands not surfaced.
+4. `rn/marginStart` / `rn/marginEnd`, `rn/paddingStart` / `rn/paddingEnd`
+   — direction-aware logical props not wired (Yoga RTL is also
+   unsupported).
+5. `rn/shadowColor` / `rn/shadowOffset` / `rn/shadowOpacity` /
+   `rn/shadowRadius` — iOS shadow surface; routed via
+   `boxShadow` instead.
+6. `rn/elevation` — Android-only; not modeled.
+7. `rn/borderCurve` — iOS 13+ continuous-corners; not modeled.
+8. `rn/mixBlendMode`, `rn/isolation` — not yet wired (Skia / CG can
+   support; bridge plumbing absent).
+
+## SvgPath (#994 / #1291)
+
+The `<SvgPath>` intrinsic surfaces a typed JSX face for
+`createSvgPath` + `setSvgPath` + `setSvgViewBox` + `setSvgFill` +
+`setSvgStroke` + `setSvgStrokeWidth`. Use this for rendered vector
+graphics — inline `<svg>` in DOM-lite (`html/svg`) is a layout-leaf
+placeholder only.

--- a/docs/reference/compat/yoga.md
+++ b/docs/reference/compat/yoga.md
@@ -1,0 +1,46 @@
+# Yoga compat
+
+Status of the Yoga-shaped layout surface in Pulp's `FlexStyle`
+(`core/view/include/pulp/view/geometry.hpp`). This is the underlying
+flex engine that both `css/*` and `rn/*` consumers ultimately lower
+onto.
+
+The authoritative inventory is `compat.json` (`yoga/*` prefix).
+
+## Generation
+
+Last refresh: **2026-05-04** against `origin/main` at SHA `a5f4f5ac`.
+
+Spec walk: [Yoga Layout — Styling](https://www.yogalayout.dev/docs/styling/),
+cross-checked against [RN Layout Props](https://reactnative.dev/docs/layout-props)
+which mirrors the upstream Yoga API.
+
+## Counts (2026-05-04)
+
+| Status | Count |
+|--------|------:|
+| supported | 28 |
+| partial | 7 |
+| missing | 18 |
+| wontfix | 0 |
+
+## Major gaps (parser routes, FlexStyle has no field)
+
+1. `yoga/alignContent` — multi-line cross-axis distribution. CSS shim
+   parses; `setFlex` switch has no `align_content` branch.
+2. `yoga/aspectRatio` — both shim layers parse; `FlexStyle` has no
+   `aspect_ratio` field. Silently dropped at the C++ boundary.
+3. `yoga/flexDirection` reverse modes — `FlexDirection` enum has only
+   `{row, col}`; `row-reverse` and `column-reverse` silently fall
+   through to `col`.
+4. `yoga/flexWrap` `wrap-reverse` — `FlexStyle.flex_wrap` is a bool;
+   `wrap-reverse` is inexpressible.
+5. `yoga/alignItems` / `yoga/alignSelf` `baseline` — `FlexAlign` enum
+   has no baseline variant.
+
+## Direction (RTL) support
+
+`yoga/direction` is `missing`. Pulp does not currently model RTL
+layout — `direction: ltr | rtl | inherit` on the View has no effect.
+Logical-property props (`marginStart`, `paddingEnd`, `start`, `end`,
+`insetInlineStart`, etc.) all degrade to a single direction.


### PR DESCRIPTION
## Summary

Re-walks the three reference specs (Yoga, RN View/Text/Transform/Layout, MDN CSS) and reconciles `compat.json` against current code on `origin/main` at SHA `a5f4f5ac`. Read-only audit — no behavior change.

This is the follow-up populate pass to #1027 (which landed the matrix scaffolding on 2026-04-30 with 361 entries across `css/`, `rn/`, `yoga/`). Three sections were stubs at that point (`canvas2d/`, `html/`, the audit description for `imports/`); this PR populates them. It also updates entries that recent PRs touched.

### Methodology

1. WebFetch each of the three URL specs (Yoga, RN View/Text/Layout/Transform, MDN Canvas2D, MDN Element). The MDN CSS list was anchored at the existing 195-entry coverage (already covers the practically-used set); only deltas since 2026-04-30 are applied.
2. Walk the JS shims (`web-compat-canvas.js`, `web-compat-element.js`, `web-compat-style-decl.js`, `web-compat-document.js`, `prop-applier.ts`) and grep `register_function` entries in `widget_bridge.cpp` (now 254 entries, up from 251 at the previous audit baseline).
3. For each touched prop / method, set `status` / `mapsTo` / `notes` / `issue` against what the code actually does today, not what the planning doc claims.
4. For every JS-side `setFoo()` call without a matching C++ `register_function("setFoo", ...)`, mark the corresponding compat entry `partial`/`missing` with a "MAJOR GAP - parser exists but backend stub" note.

## What changed in each prefix

| Prefix | Before | After | New entries | Status flips |
|---|--:|--:|---|---|
| `css/`     | 194 | 195 | +`css/__hover_pseudo` (new entry for #1345 `:hover` stylesheet support) | `border`, `borderRadius`, `borderColor` partial → supported (#1169); `fontFamily` partial → supported (#1174); `display` notes extended (#1167); `transition` notes extended (#1345) |
| `rn/`      | 114 | 120 | +`rn/d`, `rn/viewBox`, `rn/fill`, `rn/stroke`, `rn/strokeWidth` (SvgPath, #1291); +`rn/overlay` (#1297 + #1344) | (no flips — new entries) |
| `yoga/`    | 53  | 53  | (unchanged — RN/Yoga layout surface didn't move since 2026-04-30) | none |
| `react/`   | 0   | 0   | (still empty — extended `_note` describing the React-feature surface this section will eventually track: Suspense, concurrent rendering, error boundaries, portals) | n/a |
| `html/`    | 0   | 59  | populated from `web-compat-element.js` + `web-compat-document.js`: tag-to-widget mapping (~25), Element surface (~25), document/StyleSheet/event surface (~9). Includes ARIA gap flag, Element_disabled partial flag, document_querySelector partial flag. | n/a |
| `canvas2d/`| 0   | 63  | populated from `web-compat-canvas.js` × widget_bridge.cpp `canvas*` family. Covers the #1348 expansion (save/restore/transforms/path methods/text/gradients/compositing) plus pre-#1348 surface (fillRect, beginPath, drawImage, gradients, etc.). | n/a |
| `imports/` | 5   | 5   | (unchanged — claude/2024.10 + stitch/2025.04 preserved; richer `_note` describes the format-detection vocabulary) | n/a |

**New total: ~495 entries** (up from 361).

## Newly-flagged silent no-ops / broken mappings

These are gaps already documented in `compat.json` from the 2026-04-30 audit. This PR re-confirms each is still present on origin/main and adds Canvas2D-side gaps that were not previously enumerated:

**Bridge function referenced by JS shim but never registered (silent no-ops):**

1. `setAnimation` — registered, but body is `(void)id; (void)prop; …` TODO (`widget_bridge.cpp:3242`). All `@keyframes` UIs animate nothing. → `css/animation*` (8 props) `partial`.
2. `setFlex(id, "aspect_ratio", ...)` — `setFlex` switch has no `aspect_ratio` branch. → `css/aspectRatio` `partial`, `yoga/aspectRatio` `missing`.
3. `setBoxSizing` — referenced, never registered. → `css/boxSizing` `missing`.
4. `setLineClamp` — referenced, never registered. → `css/lineClamp`, `css/webkitLineClamp` `missing`.
5. `setBackgroundSize`, `setBackgroundPosition`, `setBackgroundRepeat` — referenced, none registered. → 3× `css/background*` `missing`.
6. `setOutline`, `setOutlineWidth`, `setOutlineColor` — referenced, never registered. → 3× `css/outline*` `missing`. Affects accessibility focus rings.
7. `setTextShadow` — referenced, never registered. → `css/textShadow` `missing`.
8. `setWordBreak` — referenced, never registered. → `css/wordBreak`, `css/overflowWrap`, `css/wordWrap` all `missing`.

**Parsed-and-stored but never propagated:**

9. `touchAction` — parsed and stored on the JS Element instance but never reaches the C++ hit-test. → `css/touchAction` `partial`.
10. `Element.disabled` — re-applies stylesheets but does NOT call `setEnabled`. → `html/Element_disabled` `partial`.

**Canvas2D state attrs tracked locally, never pushed to the backend:**

11. `miterLimit` — bridge has no `canvasSetMiterLimit`. → `canvas2d/miterLimit` `missing`.
12. `imageSmoothingEnabled` / `imageSmoothingQuality` — bridge no-op. → 2× `canvas2d/imageSmoothing*` `missing`.
13. `direction` (Canvas2D text dir) — bridge no-op. → `canvas2d/direction` `missing`.
14. `filter` (Canvas2D per-context) — distinct from `css/filter`, neither shim nor bridge wired. → `canvas2d/filter` `missing`.
15. `shadowColor` / `shadowBlur` / `shadowOffsetX` / `shadowOffsetY` (Canvas2D) — bridge has no `canvasShadow*` setters. → 4× `canvas2d/shadow*` `missing`.

**Approximated / partial:**

16. `arcTo` — emits `lineTo + lineTo`, ignores radius. → `canvas2d/arcTo` `partial`.
17. `ellipse` rotation — ignored; falls through to `arc` when `rx === ry`. → `canvas2d/ellipse` `partial`.
18. `transform` (Canvas2D concat-on-right) — bridge only exposes `setTransform` (replace). Pure-translation falls through; everything else is no-op. → `canvas2d/transform` `partial`.
19. `strokeText` — falls back to `fillText` with stroke color. → `canvas2d/strokeText` `partial`.
20. `createRadialGradient` — bridge models a single-circle radial; shim uses outer circle. → `canvas2d/createRadialGradient` `partial`.
21. `createConicGradient` — silent degradation to empty linear. → `canvas2d/createConicGradient` `missing`.
22. `createPattern` — returns `null`. → `canvas2d/createPattern` `missing`.
23. `drawImage` 9-arg form — sprite-sheet slicing ignored. → `canvas2d/drawImage` `partial`.
24. `putImageData` sub-rect form — `dirtyX/Y/W/H` ignored. → `canvas2d/putImageData` `partial`.
25. `setLineDash` — odd-length spec-doubling delegated to bridge. `lineDashOffset` mutation between draws not re-pushed. → `canvas2d/setLineDash` `partial`.
26. `strokeStyle = gradient` — bridge has no stroke-gradient setter; degrades to first-stop color. → `canvas2d/strokeStyle` `partial`.

**HTML / DOM gaps:**

27. `aria-*` attributes stored but NOT routed to platform accessibility APIs. → `html/ARIA` `missing`. **Major gap; needs dedicated work.**

No P0/P1 follow-up issues filed in this PR — every entry above is already flagged in `compat.json` with status + notes. The expectation per task description is that follow-up PRs do the actual fixing.

## `imports/` section intent

The `imports/*` prefix tracks **design-import format detection** — the heuristics Pulp's import-design pipeline uses to recognize a directory or file payload from a particular external design tool (Claude Design, Figma, Pencil, Stitch, v0). Each top-level key carries `parser-version` (Pulp-side detector version) and `detected-formats` (a list of `{format-version, introduced, deprecated, fingerprint, notes}` objects). Wired by PR #1047 (pulp #1031).

The expanded `_note` documents this intent and the format-detection vocabulary so future agents/contributors don't conflate it with the property-coverage matrices.

## Validation

- `python3 -m json.tool compat.json` — JSON valid
- `python3 tools/scripts/compat_sync_check.py --base origin/main --mode=report` — clean (`compat-sync: no mapped paths touched — nothing to verify`)
- `python3 tools/scripts/skill_sync_check.py --base origin/main --mode=report` — clean
- `python3 tools/scripts/version_bump_check.py --base origin/main --mode=report` — clean

`validate-build.sh` not run (docs/audit-only change per task description).

## Constraints honored

- Did NOT touch in-flight PR #1360's branch. (Note: #1360 actually merged at SHA `edfc5f2f` between when the task description was written and this audit ran. Updated `notes` accordingly.)
- Did NOT fix any bugs found — logged in `compat.json` `notes` and PR text; let follow-up PRs do the actual fixing.
- Did NOT run validate-build.sh (docs-only).
- Filed no new issues — every silent no-op is already documented in `compat.json` with a status / notes flag, and most are already enumerated in the previous audit report (`docs/reports/compat-audit-2026-04-30.md`).

## Test plan

- [ ] CI green on all 3 platforms (the `Compat-Update` / skill-sync / version-bump gates have already been verified clean locally)
- [ ] Manually skim each new `docs/reference/compat/<prefix>.md` page for accuracy
- [ ] Confirm `compat.json` parses with `python3 -m json.tool`
- [ ] Confirm no in-flight PRs (#1360 was merged before this PR landed) are stomped

## Followups (not in this PR)

1. File issues (or roll into existing tranches in #1027) for each silent no-op so they stop being free-floating gaps.
2. Populate `react/*` entries from a dedicated React-feature audit (Suspense, concurrent rendering, error boundaries, portals).
3. Add tests for the new entries (this audit is bookkeeping only — every `tests: []` is intentional).
4. ARIA attribute → platform accessibility wiring is a major gap; needs dedicated work.

Version-Bump: skip reason="docs/audit only — compat.json + reference/compat/* updates, no functional change"