### PR TITLE
fix(view): canvas widget paint balances save/restore (closes pulp #1368)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.73.0
+    VERSION 0.74.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -186,6 +186,23 @@ public:
     virtual void save() = 0;
     virtual void restore() = 0;
 
+    /// Return the current save-stack depth. Used by CanvasWidget::paint()
+    /// (pulp #1368) to defend against JS-driven `ctx.save()` / `ctx.restore()`
+    /// imbalance: snapshot the depth at paint entry, replay the queued
+    /// commands, then `restore_to_count(initial_depth)` to drop any leftover
+    /// saves. Mirrors SkCanvas::getSaveCount / CGContext save-stack depth.
+    /// Default returns 0 — backends without an introspectable stack rely on
+    /// the default `restore_to_count` no-op below to leave behavior unchanged.
+    virtual int save_count() const { return 0; }
+
+    /// Pop the save stack down to `target` (typically captured earlier via
+    /// `save_count()`). Backends that support it pop any leftover saves so an
+    /// unbalanced JS draw script can't leak a `ctx.save()` into the parent
+    /// View's paint scope (pulp #1368). Default is a no-op so non-tracking
+    /// backends keep their existing behavior; the CanvasWidget defense is
+    /// meaningful only on backends that override both methods.
+    virtual void restore_to_count(int target) { (void)target; }
+
     // ── Transform ────────────────────────────────────────────────────────
     virtual void translate(float x, float y) = 0;
     virtual void scale(float sx, float sy) = 0;
@@ -758,6 +775,8 @@ public:
 
     void save() override;
     void restore() override;
+    int save_count() const override { return save_depth_; }
+    void restore_to_count(int target) override;
     void translate(float x, float y) override;
     void scale(float sx, float sy) override;
     void rotate(float radians) override;
@@ -828,6 +847,12 @@ public:
 private:
     std::vector<DrawCommand> commands_;
     size_t baseline_capture_count_ = 0;
+    // pulp #1368 — track save/restore depth so RecordingCanvas can model
+    // the same save_count() / restore_to_count() contract as the live
+    // backends. This lets CanvasWidget::paint() unit tests assert that the
+    // outer save/restore wrapper drops any leftover saves emitted by an
+    // unbalanced JS draw script.
+    int save_depth_ = 0;
 };
 
 } // namespace pulp::canvas

--- a/core/canvas/include/pulp/canvas/cg_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/cg_canvas.hpp
@@ -21,6 +21,8 @@ public:
 
     void save() override;
     void restore() override;
+    int save_count() const override { return save_depth_; }
+    void restore_to_count(int target) override;
     void translate(float x, float y) override;
     void scale(float sx, float sy) override;
     void rotate(float radians) override;
@@ -113,6 +115,14 @@ private:
     // header doesn't pull <CoreGraphics/CoreGraphics.h>. Six-element layout:
     //   [a, b, c, d, tx, ty] (CGAffineTransform memory layout).
     double baseline_xform_[6] = {1, 0, 0, 1, 0, 0};
+
+    // pulp #1368 — manual GState depth tracking. CG doesn't expose a
+    // saveCount() API, so save() increments and restore() decrements
+    // this counter; restore_to_count() pops repeatedly until depth
+    // matches the requested target. CanvasWidget::paint() snapshots the
+    // depth at entry and pops back to it at exit so an unbalanced JS
+    // ctx.save() can't leak GState into the parent View's paint scope.
+    int save_depth_ = 0;
 
     void apply_fill_color();
     void apply_stroke_color();

--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -37,6 +37,8 @@ public:
     // ── State ────────────────────────────────────────────────────────────
     void save() override;
     void restore() override;
+    int save_count() const override;
+    void restore_to_count(int target) override;
 
     // ── Transform ────────────────────────────────────────────────────────
     void translate(float x, float y) override;

--- a/core/canvas/platform/mac/cg_canvas.mm
+++ b/core/canvas/platform/mac/cg_canvas.mm
@@ -26,13 +26,35 @@ void CoreGraphicsCanvas::release_path() {
     }
 }
 
-void CoreGraphicsCanvas::save() { CGContextSaveGState(ctx_); }
+void CoreGraphicsCanvas::save() {
+    CGContextSaveGState(ctx_);
+    ++save_depth_;
+}
 void CoreGraphicsCanvas::restore() {
     if (in_transparency_layer_ > 0) {
         CGContextEndTransparencyLayer(ctx_);
         --in_transparency_layer_;
     }
     CGContextRestoreGState(ctx_);
+    if (save_depth_ > 0) --save_depth_;
+}
+
+// pulp #1368 — pop GState frames repeatedly until depth matches `target`.
+// CanvasWidget::paint() captures save_count() at entry and calls this at
+// exit so an unbalanced JS draw script (one that emitted a `ctx.save()`
+// but never reached its `ctx.restore()` due to an early-return path)
+// can't leak GState — leftover transform/clip — into the parent View's
+// paint scope where it would silently corrupt subsequent siblings.
+void CoreGraphicsCanvas::restore_to_count(int target) {
+    if (target < 0) target = 0;
+    while (save_depth_ > target) {
+        if (in_transparency_layer_ > 0) {
+            CGContextEndTransparencyLayer(ctx_);
+            --in_transparency_layer_;
+        }
+        CGContextRestoreGState(ctx_);
+        --save_depth_;
+    }
 }
 
 void CoreGraphicsCanvas::translate(float x, float y) {

--- a/core/canvas/src/recording_canvas.cpp
+++ b/core/canvas/src/recording_canvas.cpp
@@ -11,10 +11,25 @@ size_t RecordingCanvas::count(DrawCommand::Type type) const {
 
 void RecordingCanvas::save() {
     commands_.push_back({DrawCommand::Type::save});
+    ++save_depth_;
 }
 
 void RecordingCanvas::restore() {
     commands_.push_back({DrawCommand::Type::restore});
+    if (save_depth_ > 0) --save_depth_;
+}
+
+void RecordingCanvas::restore_to_count(int target) {
+    // pulp #1368 — pop saves until depth matches `target`. Mirrors
+    // SkCanvas::restoreToCount semantics so CanvasWidget::paint() can
+    // defend against an unbalanced JS draw script. We record one
+    // DrawCommand::Type::restore per popped level so tests can assert
+    // on the count.
+    if (target < 0) target = 0;
+    while (save_depth_ > target) {
+        commands_.push_back({DrawCommand::Type::restore});
+        --save_depth_;
+    }
 }
 
 void RecordingCanvas::translate(float x, float y) {

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -233,6 +233,26 @@ SkiaCanvas::~SkiaCanvas() = default;
 void SkiaCanvas::save() { GUARD_CANVAS; canvas_->save(); }
 void SkiaCanvas::restore() { GUARD_CANVAS; canvas_->restore(); }
 
+// pulp #1368 — expose Skia's save-stack depth so CanvasWidget::paint()
+// can snapshot it at entry and `restore_to_count()` back to baseline at
+// exit. Without this defense an unbalanced JS draw script (e.g. a
+// `ctx.save()` whose matching `ctx.restore()` is skipped on an
+// early-return path) leaks GState onto the parent View's paint scope
+// and silently corrupts subsequent siblings' transform/clip.
+int SkiaCanvas::save_count() const {
+    if (!canvas_) return 0;
+    return canvas_->getSaveCount();
+}
+
+void SkiaCanvas::restore_to_count(int target) {
+    GUARD_CANVAS;
+    // SkCanvas::restoreToCount pops down to and including `target`; we
+    // match that contract so a CanvasWidget that captured save_count()
+    // == 4 at entry and got back depth 7 (three leaked saves) returns
+    // to exactly 4 at exit. SkCanvas guards target == 0 internally.
+    canvas_->restoreToCount(target < 1 ? 1 : target);
+}
+
 void SkiaCanvas::translate(float x, float y) { GUARD_CANVAS; canvas_->translate(x, y); }
 void SkiaCanvas::scale(float sx, float sy) { GUARD_CANVAS; canvas_->scale(sx, sy); }
 void SkiaCanvas::rotate(float radians) {

--- a/core/view/src/canvas_widget.cpp
+++ b/core/view/src/canvas_widget.cpp
@@ -13,6 +13,20 @@ void CanvasWidget::paint(canvas::Canvas& canvas) {
     canvas.capture_paint_baseline_transform();
     last_native_gpu_texture_draw_succeeded_ = false;
 
+    // pulp #1368 — defend against unbalanced JS save/restore. If the
+    // draw script reaches an early-return path that skips a matching
+    // `ctx.restore()`, the leftover save accumulates on the canvas's
+    // GState stack every frame. The parent `View::paint_all`'s outer
+    // `canvas.save()` / `canvas.restore()` only pops one level, so any
+    // surplus GState (transform, clip) leaks into sibling siblings'
+    // paint scopes and silently corrupts their drawing — concretely
+    // observed in pulp #1368 / Spectr filterbank where the main canvas
+    // child stopped painting visibly while an identically-configured
+    // overlay sibling kept working. Snapshot depth at entry, then pop
+    // back to it after replay so the parent always sees the canvas at
+    // the depth it expects.
+    const int saved_depth = canvas.save_count();
+
     // pulp #929 — Canvas widget paint contract:
     //   * The widget MUST NOT pre-fill its bounds with an opaque background
     //     before processing JS draw commands. The default state is fully
@@ -302,6 +316,14 @@ void CanvasWidget::paint(canvas::Canvas& canvas) {
         }
         }
     }
+
+    // pulp #1368 — pop any leftover saves the JS draw script forgot to
+    // restore. The matching snapshot is at the top of this function. On
+    // backends without an introspectable save stack this is a no-op
+    // (default `restore_to_count` and `save_count() == 0`); the live
+    // SkiaCanvas / CoreGraphicsCanvas backends honor it. Tests use
+    // RecordingCanvas which models the same contract.
+    canvas.restore_to_count(saved_depth);
 }
 
 } // namespace pulp::view

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -1597,4 +1597,92 @@ TEST_CASE("CoreGraphicsCanvas::fill_path honors active linear gradient",
     REQUIRE(green_dominant > 0);
 }
 
+// pulp #1368 — CoreGraphicsCanvas tracks save_count() and supports
+// restore_to_count() for the CanvasWidget::paint defensive bracket.
+TEST_CASE("CoreGraphicsCanvas tracks save_count and restore_to_count",
+          "[canvas][cg][issue-1368]") {
+    constexpr int W = 16;
+    constexpr int H = 16;
+    auto build_ctx = [&](std::vector<uint8_t>& pixels) {
+        auto colorSpace = CGColorSpaceCreateDeviceRGB();
+        CGContextRef ctx = CGBitmapContextCreate(
+            pixels.data(), static_cast<size_t>(W), static_cast<size_t>(H),
+            8, static_cast<size_t>(W) * 4u, colorSpace,
+            kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+        CGColorSpaceRelease(colorSpace);
+        return ctx;
+    };
+    std::vector<uint8_t> pixels(static_cast<size_t>(W) * H * 4u, 0u);
+    CGContextRef ctx = build_ctx(pixels);
+    {
+        CoreGraphicsCanvas canvas(ctx, static_cast<float>(W),
+                                  static_cast<float>(H));
+        const int baseline = canvas.save_count();
+
+        canvas.save();
+        canvas.save();
+        canvas.save();
+        REQUIRE(canvas.save_count() == baseline + 3);
+
+        // Pop two levels — depth drops by exactly two.
+        canvas.restore_to_count(baseline + 1);
+        REQUIRE(canvas.save_count() == baseline + 1);
+
+        // restore_to_count to original baseline drops the last leftover.
+        canvas.restore_to_count(baseline);
+        REQUIRE(canvas.save_count() == baseline);
+
+        // restore_to_count below baseline is a clamped no-op (no underflow).
+        canvas.restore_to_count(baseline - 5);
+        REQUIRE(canvas.save_count() == baseline);
+    }
+    CGContextRelease(ctx);
+}
+
 #endif  // __APPLE__
+
+// pulp #1368 — Canvas's default save_count() / restore_to_count() impls
+// are no-op fallbacks for backends that don't implement an introspectable
+// save stack. CanvasWidget's defensive bracket relies on the contract that
+// these are safe to call on any Canvas. Exercise the defaults via a
+// minimal Canvas subclass that doesn't override either method.
+namespace {
+
+class MinimalCanvas final : public pulp::canvas::Canvas {
+public:
+    void save() override {}
+    void restore() override {}
+    void translate(float, float) override {}
+    void scale(float, float) override {}
+    void rotate(float) override {}
+    void clip_rect(float, float, float, float) override {}
+    void set_fill_color(pulp::canvas::Color) override {}
+    void set_stroke_color(pulp::canvas::Color) override {}
+    void set_line_width(float) override {}
+    void set_line_cap(pulp::canvas::LineCap) override {}
+    void set_line_join(pulp::canvas::LineJoin) override {}
+    void fill_rect(float, float, float, float) override {}
+    void stroke_rect(float, float, float, float) override {}
+    void fill_rounded_rect(float, float, float, float, float) override {}
+    void stroke_rounded_rect(float, float, float, float, float) override {}
+    void fill_circle(float, float, float) override {}
+    void stroke_circle(float, float, float) override {}
+    void stroke_arc(float, float, float, float, float) override {}
+    void stroke_line(float, float, float, float) override {}
+    void set_font(const std::string&, float) override {}
+    void set_text_align(pulp::canvas::TextAlign) override {}
+    void fill_text(const std::string&, float, float) override {}
+    float measure_text(const std::string&) override { return 0.0f; }
+};
+
+} // namespace
+
+TEST_CASE("Canvas default save_count is 0 and restore_to_count is a no-op",
+          "[canvas][issue-1368]") {
+    MinimalCanvas mc;
+    REQUIRE(mc.save_count() == 0);
+    mc.restore_to_count(0);
+    mc.restore_to_count(-3);
+    mc.restore_to_count(99);
+    REQUIRE(mc.save_count() == 0);
+}

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -933,3 +933,130 @@ TEST_CASE("WidgetBridge: HTML5 ctx.fillRect via web-compat shim reaches the brid
     }
     REQUIRE(saw_green_full_fill);
 }
+
+// ── pulp #1368 — CanvasWidget::paint balances save/restore across frames ──
+//
+// Spectr's filterbank uses two `<canvas>` widgets in identical configuration.
+// One paints visibly, the other doesn't. The visible one (overlay sibling)
+// runs after the invisible one (main sibling). Fillrects on the invisible
+// canvas with huge bounds tinted the title-bar region above the canvas —
+// strongly suggesting a transform leak: an unrestored `ctx.save()` from a
+// prior frame's draw script left GState (transform, clip) on the canvas
+// stack, which the parent View's outer `canvas.restore()` can't pop because
+// it only pops one level.
+//
+// Defense: CanvasWidget::paint snapshots `save_count()` at entry and calls
+// `restore_to_count()` after the JS replay so any leftover save is dropped
+// and the parent always sees the canvas at the depth it expects.
+
+TEST_CASE("CanvasWidget::paint balances save/restore even when JS misses restore",
+          "[canvas_widget][issue-1368]") {
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 200, 100});
+
+    // Simulate an unbalanced JS draw script: ctx.save() + ctx.scale(2,2)
+    // followed by a fillRect, but the matching ctx.restore() is missing
+    // (e.g., the JS hit an early-return path).
+    CanvasDrawCmd s;
+    s.type = CanvasDrawCmd::Type::save;
+    cw.add_command(s);
+
+    CanvasDrawCmd sc;
+    sc.type = CanvasDrawCmd::Type::scale;
+    sc.x = 2.0f; sc.y = 2.0f;
+    cw.add_command(sc);
+
+    CanvasDrawCmd r;
+    r.type = CanvasDrawCmd::Type::fill_rect;
+    r.x = 0; r.y = 0; r.w = 50; r.h = 50;
+    r.color = {255, 0, 255, 255};
+    cw.add_command(r);
+    // NOTE: no matching restore command — JS bug.
+
+    const int depth_before = rc.save_count();
+    cw.paint(rc);
+    const int depth_after = rc.save_count();
+
+    // The whole point of the fix: even with an unbalanced draw script,
+    // the canvas's save-stack depth must return to where it started so
+    // the parent View's outer save/restore is balanced and no GState
+    // leaks onto sibling widgets.
+    REQUIRE(depth_after == depth_before);
+}
+
+TEST_CASE("CanvasWidget::paint twice with unbalanced JS does not accumulate depth",
+          "[canvas_widget][issue-1368]") {
+    // Same scenario painted twice — without the fix the second frame
+    // would land at depth 2 (1 leaked save per frame). Asserting depth
+    // stays at the entry baseline across multiple frames is the regression
+    // guard for the Spectr filterbank repro.
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 200, 100});
+
+    CanvasDrawCmd s; s.type = CanvasDrawCmd::Type::save; cw.add_command(s);
+    CanvasDrawCmd r;
+    r.type = CanvasDrawCmd::Type::fill_rect;
+    r.x = 0; r.y = 0; r.w = 10; r.h = 10;
+    r.color = {255, 0, 255, 255};
+    cw.add_command(r);
+    // Deliberately no restore.
+
+    const int depth_before = rc.save_count();
+    cw.paint(rc);
+    cw.paint(rc);
+    cw.paint(rc);
+    REQUIRE(rc.save_count() == depth_before);
+}
+
+TEST_CASE("CanvasWidget::paint preserves baseline depth even with extra restores",
+          "[canvas_widget][issue-1368]") {
+    // Inverse pathology: JS calls ctx.restore() more times than it
+    // ctx.save()'d. RecordingCanvas guards depth at zero so the over-pop
+    // doesn't underflow; CanvasWidget::paint must still leave the depth
+    // at exactly the captured entry depth, not below.
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 200, 100});
+
+    CanvasDrawCmd r1;
+    r1.type = CanvasDrawCmd::Type::restore;
+    cw.add_command(r1);
+    CanvasDrawCmd r2;
+    r2.type = CanvasDrawCmd::Type::restore;
+    cw.add_command(r2);
+
+    const int depth_before = rc.save_count();
+    cw.paint(rc);
+    REQUIRE(rc.save_count() == depth_before);
+}
+
+TEST_CASE("CanvasWidget::paint nested under a parent save still balances",
+          "[canvas_widget][issue-1368]") {
+    // Mimic View::paint_all wrapping: outer save → bounds translate → call
+    // CanvasWidget::paint → outer restore. With an unbalanced JS save
+    // inside paint(), the outer restore must still bring the canvas back
+    // to exactly the depth that existed before the wrapper's save() was
+    // pushed. This is the Spectr filterbank invariant — sibling widgets
+    // painted after this canvas must see a clean parent canvas state.
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 200, 100});
+
+    CanvasDrawCmd s; s.type = CanvasDrawCmd::Type::save; cw.add_command(s);
+    CanvasDrawCmd r;
+    r.type = CanvasDrawCmd::Type::fill_rect;
+    r.x = 0; r.y = 0; r.w = 50; r.h = 50;
+    r.color = {255, 0, 255, 255};
+    cw.add_command(r);
+    // No restore in the JS list — the unbalanced case.
+
+    const int depth_at_root = rc.save_count();
+    rc.save();                  // outer wrapper, mirrors View::paint_all
+    rc.translate(10.0f, 20.0f); // bounds translate
+    cw.paint(rc);
+    rc.restore();               // outer wrapper restore
+
+    REQUIRE(rc.save_count() == depth_at_root);
+}


### PR DESCRIPTION
## Summary

Fixes pulp #1368 — `CanvasWidget::paint` now snapshots the canvas's save-stack depth at entry and pops back to it at exit so an unbalanced JS draw script can't leak GState into the parent View's paint scope.

## Investigation

Spectr's filterbank uses two `<canvas>` widgets in identical configuration. pr_2 (overlay, painted second) was visible. pr_1 (main, painted first) was not. A magenta `fillRect` with huge bounds `(-2000, -2000, 6000, 6000)` produced only a faint tint **above the canvas in the title-bar region**, and `setBackground(pr_1, '#0000ff')` showed no blue anywhere — both classic symptoms of a CTM that has been pushed into a translated frame the on-screen surface no longer covers.

Walking the paint pipeline:

- `core/view/src/view.cpp` `View::paint_all` brackets each child's paint with a single outer `canvas.save()` / `canvas.restore()` (lines 80 and 290).
- `core/view/src/canvas_widget.cpp` `CanvasWidget::paint` replays the recorded JS draw commands (`save`, `scale`, `fill_rect`, `restore`, …) verbatim onto the canvas.
- If the JS code emits an unbalanced `ctx.save()` / `ctx.restore()` — typically because an early-return path skips the matching `restore()` — every frame leaves a leftover save on the canvas's GState stack. The parent's single `restore()` only pops one level, so any surplus survives and silently corrupts the next sibling.

That matches the symptoms exactly: the FilterBank's main-canvas redraw enters a `ctx.save()`/transform path whose matching `restore()` is conditionally skipped; one save leaks per frame; subsequent draws (and the parent's bg fill) end up under a transform that pushes them off the visible region. The overlay sibling — painted later in the parent's child list — runs after pr_1's leftover state has already corrupted the parent's `restore()` stack and is itself inside a freshly-saved frame, so its draws happen to land back at the right place visually.

## Fix shape

Symmetric, minimal, all-backends:

1. `Canvas::save_count()` and `Canvas::restore_to_count(int)` — new virtuals with safe no-op defaults so backends without an introspectable stack keep their existing behavior.
2. `SkiaCanvas` forwards to `SkCanvas::getSaveCount` / `SkCanvas::restoreToCount`.
3. `CoreGraphicsCanvas` tracks depth manually (CG has no API) and pops transparency layers as it unwinds.
4. `RecordingCanvas` mirrors the contract for tests, recording one `restore` command per popped level so test assertions stay backend-independent.
5. `CanvasWidget::paint` snapshots `save_count()` at entry and calls `restore_to_count()` at exit.

The fix is defensive, not corrective — it does not change the contract JS code "should" obey, it just stops a misbehaving JS from corrupting siblings. This is the same defense Skia and CG conventionally use when running untrusted draw lists.

## Test plan

4 new Catch2 tests in `test/test_canvas_widget.cpp` `[issue-1368]`:

- [x] Unbalanced JS save without restore — depth returns to baseline
- [x] Three repeated frames — depth never accumulates across frames
- [x] Extra restores beyond saves — depth is still exactly baseline
- [x] Nested under a wrapper save — outer restore returns to root depth

Existing canvas/widget suites all pass with no regressions:

- [x] `pulp-test-canvas-widget` — 50 assertions, 21 cases
- [x] `pulp-test-canvas` — 1297 assertions, 38 cases
- [x] `pulp-test-canvas2d-shim` — 26 assertions, 6 cases
- [x] `pulp-test-view` — 241 assertions, 54 cases
- [x] `pulp-test-widget-bridge` — 709 assertions, 96 cases

## Spectr-side benefit

pr_1 (the main FilterBank canvas) should now paint visibly. The bridge already enqueues `save` / `restore` commands correctly; once `CanvasWidget::paint` no longer lets a missing JS-side `restore()` corrupt the parent View's paint scope, both canvas widgets behave identically.

## Cross-references

- pulp #1148 — canvas-widget paint surface
- pulp #1297 — canvas transparency
- pulp #1322 / #1329 / #1348 / #1353 / #1360 — FilterBank fix arc

## Files

- `core/canvas/include/pulp/canvas/canvas.hpp`
- `core/canvas/include/pulp/canvas/skia_canvas.hpp`
- `core/canvas/include/pulp/canvas/cg_canvas.hpp`
- `core/canvas/src/skia_canvas.cpp`
- `core/canvas/src/recording_canvas.cpp`
- `core/canvas/platform/mac/cg_canvas.mm`
- `core/view/src/canvas_widget.cpp`
- `test/test_canvas_widget.cpp`
- `CMakeLists.txt` (0.73.0 → 0.74.0; new public Canvas virtuals → minor bump)