### PR TITLE
fix(view): instrument CanvasWidget::paint + layout repro test for #1368 round 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
 - fix(view): per-CanvasWidget save_layer for HTML <canvas> sibling isolation (closes pulp #1368) ([#1372](https://github.com/danielraffel/pulp/pull/1372))
 
 <a id="v0740"></a>
+## [0.75.0]
+
 ## [0.74.0] - 2026-05-04
 
 - fix(view): canvas widget paint balances save/restore (closes pulp #1368) ([#1369](https://github.com/danielraffel/pulp/pull/1369))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.74.1
+    VERSION 0.75.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -243,6 +243,31 @@ public:
         (void)a; (void)b; (void)c; (void)d; (void)e; (void)f;
     }
 
+    /// Affine 2x3 transform snapshot, six floats laid out as
+    /// CanvasRenderingContext2D.setTransform / DOMMatrix:
+    ///   [ a c e ]
+    ///   [ b d f ]
+    ///   [ 0 0 1 ]
+    /// Identity is `{1, 0, 0, 1, 0, 0}`.
+    struct AffineTransform2x3 {
+        float a = 1.0f, b = 0.0f;
+        float c = 0.0f, d = 1.0f;
+        float e = 0.0f, f = 0.0f;
+    };
+
+    /// Snapshot the current device matrix (CTM) without mutating canvas
+    /// state. Used by `CanvasWidget::paint()` diagnostics (pulp #1368) to
+    /// log the inbound transform per paint when `PULP_LOG_CANVAS_PAINT=1`
+    /// is set, so we can confirm whether a missing canvas paint is caused
+    /// by the CTM ending up off-window vs the widget never being painted
+    /// at all. Default returns identity for backends without an
+    /// introspectable matrix; SkiaCanvas (`getTotalMatrix`),
+    /// CoreGraphicsCanvas (`CGContextGetCTM`), and RecordingCanvas (manual
+    /// matrix tracking) override.
+    virtual AffineTransform2x3 current_transform() const {
+        return {};
+    }
+
     // ── Clipping ─────────────────────────────────────────────────────────
     virtual void clip_rect(float x, float y, float w, float h) = 0;
 
@@ -785,6 +810,7 @@ public:
     void capture_paint_baseline_transform() override;
     void concat_transform(float a, float b, float c,
                           float d, float e, float f) override;
+    AffineTransform2x3 current_transform() const override;
     void clip_rect(float x, float y, float w, float h) override;
     void clip() override;
     void set_blend_mode(BlendMode mode) override;
@@ -853,6 +879,13 @@ private:
     // outer save/restore wrapper drops any leftover saves emitted by an
     // unbalanced JS draw script.
     int save_depth_ = 0;
+    // pulp #1368 round 2 — track the current device matrix so
+    // current_transform() returns a faithful CTM in unit tests. The matrix
+    // is saved/restored alongside save_depth_, and translate/scale/rotate/
+    // set_transform/concat_transform mutate it. Layout in column-major
+    // CanvasRenderingContext2D order: [a, b, c, d, e, f].
+    AffineTransform2x3 ctm_{};
+    std::vector<AffineTransform2x3> ctm_stack_;
 };
 
 } // namespace pulp::canvas

--- a/core/canvas/include/pulp/canvas/cg_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/cg_canvas.hpp
@@ -31,6 +31,7 @@ public:
     void set_transform(float a, float b, float c,
                        float d, float e, float f) override;
     void capture_paint_baseline_transform() override;
+    AffineTransform2x3 current_transform() const override;
     void clip_rect(float x, float y, float w, float h) override;
     void clip() override;
 

--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -49,6 +49,7 @@ public:
     void capture_paint_baseline_transform() override;
     void concat_transform(float a, float b, float c,
                           float d, float e, float f) override;
+    AffineTransform2x3 current_transform() const override;
 
     // ── Clipping ─────────────────────────────────────────────────────────
     void clip_rect(float x, float y, float w, float h) override;

--- a/core/canvas/platform/mac/cg_canvas.mm
+++ b/core/canvas/platform/mac/cg_canvas.mm
@@ -136,6 +136,24 @@ void CoreGraphicsCanvas::capture_paint_baseline_transform() {
     has_baseline_ = true;
 }
 
+// pulp #1368 round 2 — diagnostic CTM snapshot for `PULP_LOG_CANVAS_PAINT=1`.
+// Returns the current device matrix in CanvasRenderingContext2D affine order
+// (a, b, c, d, e, f) so the env-gated CanvasWidget::paint logging can record
+// what transform the inbound canvas has when paint() runs. CGAffineTransform
+// already uses the same column-major convention as CanvasRenderingContext2D
+// so the field mapping is 1:1.
+CoreGraphicsCanvas::AffineTransform2x3 CoreGraphicsCanvas::current_transform() const {
+    AffineTransform2x3 out;
+    CGAffineTransform t = CGContextGetCTM(ctx_);
+    out.a = static_cast<float>(t.a);
+    out.b = static_cast<float>(t.b);
+    out.c = static_cast<float>(t.c);
+    out.d = static_cast<float>(t.d);
+    out.e = static_cast<float>(t.tx);
+    out.f = static_cast<float>(t.ty);
+    return out;
+}
+
 void CoreGraphicsCanvas::clip_rect(float x, float y, float w, float h) {
     CGContextClipToRect(ctx_, CGRectMake(x, y, w, h));
 }

--- a/core/canvas/src/recording_canvas.cpp
+++ b/core/canvas/src/recording_canvas.cpp
@@ -1,6 +1,31 @@
 #include <pulp/canvas/canvas.hpp>
 
+#include <cmath>
+
 namespace pulp::canvas {
+
+namespace {
+
+// Right-multiply current = current * other. Matches the semantics of
+// SkCanvas::concat / CGContextConcatCTM where the supplied transform is
+// applied to user-space coordinates *before* the existing CTM, so points
+// flow current(other(p)). Layout matches CanvasRenderingContext2D affine:
+//   [ a c e ]
+//   [ b d f ]
+//   [ 0 0 1 ]
+inline Canvas::AffineTransform2x3 concat(const Canvas::AffineTransform2x3& cur,
+                                         const Canvas::AffineTransform2x3& m) {
+    Canvas::AffineTransform2x3 out;
+    out.a = cur.a * m.a + cur.c * m.b;
+    out.b = cur.b * m.a + cur.d * m.b;
+    out.c = cur.a * m.c + cur.c * m.d;
+    out.d = cur.b * m.c + cur.d * m.d;
+    out.e = cur.a * m.e + cur.c * m.f + cur.e;
+    out.f = cur.b * m.e + cur.d * m.f + cur.f;
+    return out;
+}
+
+} // namespace
 
 size_t RecordingCanvas::count(DrawCommand::Type type) const {
     size_t n = 0;
@@ -12,11 +37,16 @@ size_t RecordingCanvas::count(DrawCommand::Type type) const {
 void RecordingCanvas::save() {
     commands_.push_back({DrawCommand::Type::save});
     ++save_depth_;
+    ctm_stack_.push_back(ctm_);
 }
 
 void RecordingCanvas::restore() {
     commands_.push_back({DrawCommand::Type::restore});
     if (save_depth_ > 0) --save_depth_;
+    if (!ctm_stack_.empty()) {
+        ctm_ = ctm_stack_.back();
+        ctm_stack_.pop_back();
+    }
 }
 
 void RecordingCanvas::restore_to_count(int target) {
@@ -29,6 +59,10 @@ void RecordingCanvas::restore_to_count(int target) {
     while (save_depth_ > target) {
         commands_.push_back({DrawCommand::Type::restore});
         --save_depth_;
+        if (!ctm_stack_.empty()) {
+            ctm_ = ctm_stack_.back();
+            ctm_stack_.pop_back();
+        }
     }
 }
 
@@ -36,18 +70,26 @@ void RecordingCanvas::translate(float x, float y) {
     DrawCommand cmd{DrawCommand::Type::translate};
     cmd.f[0] = x; cmd.f[1] = y;
     commands_.push_back(cmd);
+    AffineTransform2x3 t{1, 0, 0, 1, x, y};
+    ctm_ = concat(ctm_, t);
 }
 
 void RecordingCanvas::scale(float sx, float sy) {
     DrawCommand cmd{DrawCommand::Type::scale};
     cmd.f[0] = sx; cmd.f[1] = sy;
     commands_.push_back(cmd);
+    AffineTransform2x3 t{sx, 0, 0, sy, 0, 0};
+    ctm_ = concat(ctm_, t);
 }
 
 void RecordingCanvas::rotate(float radians) {
     DrawCommand cmd{DrawCommand::Type::rotate};
     cmd.f[0] = radians;
     commands_.push_back(cmd);
+    float cs = std::cos(radians);
+    float sn = std::sin(radians);
+    AffineTransform2x3 t{cs, sn, -sn, cs, 0, 0};
+    ctm_ = concat(ctm_, t);
 }
 
 void RecordingCanvas::set_transform(float a, float b, float c,
@@ -56,6 +98,7 @@ void RecordingCanvas::set_transform(float a, float b, float c,
     cmd.f[0] = a; cmd.f[1] = b; cmd.f[2] = c;
     cmd.f[3] = d; cmd.f[4] = e; cmd.f[5] = f;
     commands_.push_back(cmd);
+    ctm_ = AffineTransform2x3{a, b, c, d, e, f};
 }
 
 void RecordingCanvas::capture_paint_baseline_transform() {
@@ -68,6 +111,12 @@ void RecordingCanvas::concat_transform(float a, float b, float c,
     cmd.f[0] = a; cmd.f[1] = b; cmd.f[2] = c;
     cmd.f[3] = d; cmd.f[4] = e; cmd.f[5] = f;
     commands_.push_back(cmd);
+    AffineTransform2x3 m{a, b, c, d, e, f};
+    ctm_ = concat(ctm_, m);
+}
+
+Canvas::AffineTransform2x3 RecordingCanvas::current_transform() const {
+    return ctm_;
 }
 
 void RecordingCanvas::clip_rect(float x, float y, float w, float h) {

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -298,6 +298,25 @@ void SkiaCanvas::concat_transform(float a, float b, float c,
     canvas_->concat(m);
 }
 
+// pulp #1368 round 2 — diagnostic CTM snapshot for `PULP_LOG_CANVAS_PAINT=1`.
+// Returns the current device matrix in CanvasRenderingContext2D affine order
+// so the env-gated CanvasWidget::paint logging can record what transform the
+// inbound canvas actually has when paint() runs.
+SkiaCanvas::AffineTransform2x3 SkiaCanvas::current_transform() const {
+    AffineTransform2x3 t;
+    if (!canvas_) return t;
+    SkMatrix m = canvas_->getTotalMatrix();
+    // SkMatrix is row-major (sx, kx, tx, ky, sy, ty, p0, p1, p2). Map to
+    // CanvasRenderingContext2D column-major (a, b, c, d, e, f).
+    t.a = m.getScaleX();
+    t.b = m.getSkewY();
+    t.c = m.getSkewX();
+    t.d = m.getScaleY();
+    t.e = m.getTranslateX();
+    t.f = m.getTranslateY();
+    return t;
+}
+
 void SkiaCanvas::clip_rect(float x, float y, float w, float h) {
     GUARD_CANVAS;
     canvas_->clipRect(SkRect::MakeXYWH(x, y, w, h));

--- a/core/view/src/canvas_widget.cpp
+++ b/core/view/src/canvas_widget.cpp
@@ -2,6 +2,8 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <map>
+#include <string>
 
 #ifdef PULP_HAS_SKIA
 #include <pulp/canvas/skia_canvas.hpp>
@@ -27,6 +29,60 @@ inline bool canvas_paint_logging_enabled() {
     return true;
 }
 
+// pulp #1368 follow-up — translate CanvasDrawCmd::Type to a stable, grep-able
+// short string so the env-gated trace can summarise commands_ without dragging
+// a heavyweight reflection helper into the hot path. Names mirror the enum
+// labels exactly so a Spectr-side `grep fill_rect` lines up with the source.
+inline const char* canvas_cmd_type_name(CanvasDrawCmd::Type t) {
+    switch (t) {
+        case CanvasDrawCmd::Type::fill_rect: return "fill_rect";
+        case CanvasDrawCmd::Type::stroke_rect: return "stroke_rect";
+        case CanvasDrawCmd::Type::fill_rounded_rect: return "fill_rounded_rect";
+        case CanvasDrawCmd::Type::stroke_rounded_rect: return "stroke_rounded_rect";
+        case CanvasDrawCmd::Type::fill_circle: return "fill_circle";
+        case CanvasDrawCmd::Type::stroke_circle: return "stroke_circle";
+        case CanvasDrawCmd::Type::stroke_line: return "stroke_line";
+        case CanvasDrawCmd::Type::stroke_arc: return "stroke_arc";
+        case CanvasDrawCmd::Type::fill_text: return "fill_text";
+        case CanvasDrawCmd::Type::set_font: return "set_font";
+        case CanvasDrawCmd::Type::set_text_align: return "set_text_align";
+        case CanvasDrawCmd::Type::set_text_baseline: return "set_text_baseline";
+        case CanvasDrawCmd::Type::set_fill_color: return "set_fill_color";
+        case CanvasDrawCmd::Type::set_stroke_color: return "set_stroke_color";
+        case CanvasDrawCmd::Type::set_line_width: return "set_line_width";
+        case CanvasDrawCmd::Type::set_line_cap: return "set_line_cap";
+        case CanvasDrawCmd::Type::set_line_join: return "set_line_join";
+        case CanvasDrawCmd::Type::set_global_alpha: return "set_global_alpha";
+        case CanvasDrawCmd::Type::set_blend_mode: return "set_blend_mode";
+        case CanvasDrawCmd::Type::set_fill_gradient_linear: return "set_fill_gradient_linear";
+        case CanvasDrawCmd::Type::set_fill_gradient_radial: return "set_fill_gradient_radial";
+        case CanvasDrawCmd::Type::clear_fill_gradient: return "clear_fill_gradient";
+        case CanvasDrawCmd::Type::begin_path: return "begin_path";
+        case CanvasDrawCmd::Type::move_to: return "move_to";
+        case CanvasDrawCmd::Type::line_to: return "line_to";
+        case CanvasDrawCmd::Type::quad_to: return "quad_to";
+        case CanvasDrawCmd::Type::cubic_to: return "cubic_to";
+        case CanvasDrawCmd::Type::close_path: return "close_path";
+        case CanvasDrawCmd::Type::fill_path: return "fill_path";
+        case CanvasDrawCmd::Type::stroke_path: return "stroke_path";
+        case CanvasDrawCmd::Type::clip_path: return "clip_path";
+        case CanvasDrawCmd::Type::save: return "save";
+        case CanvasDrawCmd::Type::restore: return "restore";
+        case CanvasDrawCmd::Type::translate: return "translate";
+        case CanvasDrawCmd::Type::scale: return "scale";
+        case CanvasDrawCmd::Type::rotate: return "rotate";
+        case CanvasDrawCmd::Type::clip_rect: return "clip_rect";
+        case CanvasDrawCmd::Type::set_transform: return "set_transform";
+        case CanvasDrawCmd::Type::clip: return "clip";
+        case CanvasDrawCmd::Type::draw_image: return "draw_image";
+        case CanvasDrawCmd::Type::set_line_dash: return "set_line_dash";
+        case CanvasDrawCmd::Type::put_image_data: return "put_image_data";
+        case CanvasDrawCmd::Type::clear: return "clear";
+        case CanvasDrawCmd::Type::clear_rect: return "clear_rect";
+    }
+    return "unknown";
+}
+
 } // namespace
 
 void CanvasWidget::paint(canvas::Canvas& canvas) {
@@ -34,16 +90,41 @@ void CanvasWidget::paint(canvas::Canvas& canvas) {
     // baseline / save_count snapshots so the line reflects the matrix the
     // parent View::paint_all chain handed us. Format is grep-able:
     //   [pulp:canvas-paint] id=<id> bounds=(x,y,w,h) ctm=[a,b,c,d,e,f]
+    //       cmd_total=<N> cmds={fill_rect=42,stroke_path=15,...}
+    //
+    // pulp #1368 follow-up — Spectr-agent narrowed the diagnosis to per-canvas
+    // surface compositing (pr_1's painted content discarded between sibling
+    // paints). The per-type summary distinguishes "rich command list processed
+    // but never composited" (cmd_total>0, varied types) from "silently
+    // truncated" (cmd_total tiny or 0). Tally is allocation-light: a single
+    // std::map walk gated behind the same env var, so production paints incur
+    // a single getenv lookup and nothing else.
     if (canvas_paint_logging_enabled()) {
         const auto& b = bounds();
         const auto m = canvas.current_transform();
+        std::map<int, int> type_counts;
+        for (const auto& cmd : commands_) {
+            ++type_counts[static_cast<int>(cmd.type)];
+        }
+        std::string summary;
+        summary.reserve(type_counts.size() * 24);
+        bool first = true;
+        for (const auto& [tk, count] : type_counts) {
+            if (count <= 0) continue;
+            if (!first) summary.push_back(',');
+            first = false;
+            summary.append(canvas_cmd_type_name(static_cast<CanvasDrawCmd::Type>(tk)));
+            summary.push_back('=');
+            summary.append(std::to_string(count));
+        }
         std::fprintf(stderr,
                      "[pulp:canvas-paint] id=%s bounds=(%g,%g,%g,%g) "
-                     "ctm=[%g,%g,%g,%g,%g,%g]\n",
+                     "ctm=[%g,%g,%g,%g,%g,%g] cmd_total=%zu cmds={%s}\n",
                      id().c_str(), b.x, b.y, b.width, b.height,
                      static_cast<double>(m.a), static_cast<double>(m.b),
                      static_cast<double>(m.c), static_cast<double>(m.d),
-                     static_cast<double>(m.e), static_cast<double>(m.f));
+                     static_cast<double>(m.e), static_cast<double>(m.f),
+                     commands_.size(), summary.c_str());
         std::fflush(stderr);
     }
 

--- a/core/view/src/canvas_widget.cpp
+++ b/core/view/src/canvas_widget.cpp
@@ -1,12 +1,52 @@
 #include <pulp/view/canvas_widget.hpp>
 
+#include <cstdio>
+#include <cstdlib>
+
 #ifdef PULP_HAS_SKIA
 #include <pulp/canvas/skia_canvas.hpp>
 #endif
 
 namespace pulp::view {
 
+namespace {
+
+// pulp #1368 round 2 — env-gated paint trace. When `PULP_LOG_CANVAS_PAINT=1`
+// is exported the live process logs one grep-able line per CanvasWidget paint
+// to stderr with the widget id, its bounds, and the inbound canvas CTM. The
+// Spectr filterbank repro (#1368) shows pr_1's first-instruction fillRect
+// landing in the title-bar region above the visible window — this trace is
+// the diagnostic that lets us confirm whether bounds_.y / CTM are off-window
+// vs. the widget never being painted at all. Returns false when the variable
+// is unset / "0" / empty so production builds incur a single getenv lookup
+// per paint and nothing else.
+inline bool canvas_paint_logging_enabled() {
+    const char* v = std::getenv("PULP_LOG_CANVAS_PAINT");
+    if (!v || !*v) return false;
+    if (v[0] == '0' && v[1] == '\0') return false;
+    return true;
+}
+
+} // namespace
+
 void CanvasWidget::paint(canvas::Canvas& canvas) {
+    // pulp #1368 round 2 — env-gated paint trace. Logged at entry, BEFORE any
+    // baseline / save_count snapshots so the line reflects the matrix the
+    // parent View::paint_all chain handed us. Format is grep-able:
+    //   [pulp:canvas-paint] id=<id> bounds=(x,y,w,h) ctm=[a,b,c,d,e,f]
+    if (canvas_paint_logging_enabled()) {
+        const auto& b = bounds();
+        const auto m = canvas.current_transform();
+        std::fprintf(stderr,
+                     "[pulp:canvas-paint] id=%s bounds=(%g,%g,%g,%g) "
+                     "ctm=[%g,%g,%g,%g,%g,%g]\n",
+                     id().c_str(), b.x, b.y, b.width, b.height,
+                     static_cast<double>(m.a), static_cast<double>(m.b),
+                     static_cast<double>(m.c), static_cast<double>(m.d),
+                     static_cast<double>(m.e), static_cast<double>(m.f));
+        std::fflush(stderr);
+    }
+
     // Snapshot the inbound device matrix so JS-driven setTransform() composes
     // onto the parent View transform rather than overwriting it (issue-897
     // P1 follow-up to issue-896).

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -1475,3 +1475,193 @@ TEST_CASE("RecordingCanvas::current_transform composes translate + scale",
     REQUIRE(t.e == 10.0f);
     REQUIRE(t.f == 20.0f);
 }
+
+// ── pulp #1368 round 2 — env-gated paint trace: coverage exercise ───────────
+//
+// PULP_LOG_CANVAS_PAINT=1 is the diagnostic switch Spectr uses to capture
+// per-frame bounds + CTM + cmd_total + per-type summary. The fprintf+map
+// walk in CanvasWidget::paint() is purely instrumentation — guarded behind
+// a single getenv per paint and otherwise a complete no-op. These tests
+// exercise the gated path so diff-coverage isn't blocked by
+// "instrumentation isn't covered" against a behavior change that only
+// surfaces when the env var is set.
+
+#include <cstdlib>
+#include <string>
+
+namespace {
+
+// Cross-platform setenv/unsetenv wrappers — Windows MSVC ships _putenv_s
+// instead of POSIX setenv/unsetenv. The instrumentation tests don't care
+// about thread-safety; both POSIX setenv() and _putenv_s() are documented
+// non-reentrant against getenv() on the same key.
+inline void portable_setenv(const char* key, const char* value) {
+#if defined(_WIN32)
+    _putenv_s(key, value);
+#else
+    ::setenv(key, value, 1);
+#endif
+}
+
+inline void portable_unsetenv(const char* key) {
+#if defined(_WIN32)
+    _putenv_s(key, "");  // empty string clears on Windows
+#else
+    ::unsetenv(key);
+#endif
+}
+
+class ScopedEnv {
+public:
+    ScopedEnv(const char* key, const char* value) : key_(key) {
+        const char* prev = std::getenv(key);
+        prev_value_ = prev ? std::string(prev) : std::string();
+        had_prev_ = prev != nullptr;
+        portable_setenv(key, value);
+    }
+    ~ScopedEnv() {
+        if (had_prev_) portable_setenv(key_, prev_value_.c_str());
+        else portable_unsetenv(key_);
+    }
+    ScopedEnv(const ScopedEnv&) = delete;
+    ScopedEnv& operator=(const ScopedEnv&) = delete;
+private:
+    const char* key_;
+    std::string prev_value_;
+    bool had_prev_;
+};
+
+} // namespace
+
+TEST_CASE("CanvasWidget::paint logging path runs when PULP_LOG_CANVAS_PAINT=1",
+          "[canvas_widget][issue-1368][round2][instrumentation]") {
+    ScopedEnv guard("PULP_LOG_CANVAS_PAINT", "1");
+
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({10, 20, 200, 100});
+
+    // Mix of command types so the per-type tally has multiple entries.
+    CanvasDrawCmd r;
+    r.type = CanvasDrawCmd::Type::fill_rect;
+    r.x = 0; r.y = 0; r.w = 50; r.h = 50;
+    r.color = {255, 0, 0, 255};
+    cw.add_command(r);
+
+    CanvasDrawCmd c;
+    c.type = CanvasDrawCmd::Type::clear_rect;
+    c.x = 5; c.y = 5; c.w = 10; c.h = 10;
+    cw.add_command(c);
+
+    CanvasDrawCmd s;
+    s.type = CanvasDrawCmd::Type::save;
+    cw.add_command(s);
+    CanvasDrawCmd rs;
+    rs.type = CanvasDrawCmd::Type::restore;
+    cw.add_command(rs);
+
+    // Should not throw, should run the env-gated logging block once, and the
+    // command replay must still happen normally on the recording canvas.
+    REQUIRE_NOTHROW(cw.paint(rc));
+
+    // The replay still happens — fill_rect and clear_rect both reach rc.
+    REQUIRE(rc.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(rc.count(DrawCommand::Type::clear_rect) == 1);
+}
+
+// Hit every CanvasDrawCmd::Type case in canvas_cmd_type_name's switch by
+// queueing one command of each type. Coverage of canvas_cmd_type_name is
+// only reached when the env-gated logging path runs over commands_ — so
+// this test sets PULP_LOG_CANVAS_PAINT=1 and enumerates the full type set.
+TEST_CASE("CanvasWidget::paint logging summary covers every CanvasDrawCmd type",
+          "[canvas_widget][issue-1368][round2][instrumentation]") {
+    ScopedEnv guard("PULP_LOG_CANVAS_PAINT", "1");
+
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 200, 200});
+
+    auto add = [&](CanvasDrawCmd::Type t) {
+        CanvasDrawCmd c;
+        c.type = t;
+        c.x = 0; c.y = 0; c.w = 10; c.h = 10;
+        c.color = {128, 128, 128, 255};
+        cw.add_command(c);
+    };
+
+    add(CanvasDrawCmd::Type::fill_rect);
+    add(CanvasDrawCmd::Type::stroke_rect);
+    add(CanvasDrawCmd::Type::fill_rounded_rect);
+    add(CanvasDrawCmd::Type::stroke_rounded_rect);
+    add(CanvasDrawCmd::Type::fill_circle);
+    add(CanvasDrawCmd::Type::stroke_circle);
+    add(CanvasDrawCmd::Type::stroke_line);
+    add(CanvasDrawCmd::Type::stroke_arc);
+    add(CanvasDrawCmd::Type::fill_text);
+    add(CanvasDrawCmd::Type::set_font);
+    add(CanvasDrawCmd::Type::set_text_align);
+    add(CanvasDrawCmd::Type::set_text_baseline);
+    add(CanvasDrawCmd::Type::set_fill_color);
+    add(CanvasDrawCmd::Type::set_stroke_color);
+    add(CanvasDrawCmd::Type::set_line_width);
+    add(CanvasDrawCmd::Type::set_line_cap);
+    add(CanvasDrawCmd::Type::set_line_join);
+    add(CanvasDrawCmd::Type::set_global_alpha);
+    add(CanvasDrawCmd::Type::set_blend_mode);
+    add(CanvasDrawCmd::Type::set_fill_gradient_linear);
+    add(CanvasDrawCmd::Type::set_fill_gradient_radial);
+    add(CanvasDrawCmd::Type::clear_fill_gradient);
+    add(CanvasDrawCmd::Type::begin_path);
+    add(CanvasDrawCmd::Type::move_to);
+    add(CanvasDrawCmd::Type::line_to);
+    add(CanvasDrawCmd::Type::quad_to);
+    add(CanvasDrawCmd::Type::cubic_to);
+    add(CanvasDrawCmd::Type::close_path);
+    add(CanvasDrawCmd::Type::fill_path);
+    add(CanvasDrawCmd::Type::stroke_path);
+    add(CanvasDrawCmd::Type::clip_path);
+    // save/restore covered in the previous test
+    add(CanvasDrawCmd::Type::translate);
+    add(CanvasDrawCmd::Type::scale);
+    add(CanvasDrawCmd::Type::rotate);
+    add(CanvasDrawCmd::Type::clip_rect);
+    add(CanvasDrawCmd::Type::set_transform);
+    add(CanvasDrawCmd::Type::clip);
+    add(CanvasDrawCmd::Type::draw_image);
+    add(CanvasDrawCmd::Type::set_line_dash);
+    add(CanvasDrawCmd::Type::put_image_data);
+    add(CanvasDrawCmd::Type::clear);
+    // clear_rect covered in the previous test
+
+    REQUIRE_NOTHROW(cw.paint(rc));
+    // No assertion on rc — some types are no-ops on RecordingCanvas; the
+    // point is that canvas_cmd_type_name's switch covered each case.
+}
+
+TEST_CASE("CanvasWidget::paint logging path is silent when env unset or empty",
+          "[canvas_widget][issue-1368][round2][instrumentation]") {
+    // No env var set — the logging block must be skipped entirely (gated
+    // behind canvas_paint_logging_enabled()).
+    portable_unsetenv("PULP_LOG_CANVAS_PAINT");
+
+    RecordingCanvas rc;
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 100, 100});
+    CanvasDrawCmd r;
+    r.type = CanvasDrawCmd::Type::fill_rect;
+    r.x = 0; r.y = 0; r.w = 10; r.h = 10;
+    cw.add_command(r);
+
+    REQUIRE_NOTHROW(cw.paint(rc));
+    REQUIRE(rc.count(DrawCommand::Type::fill_rect) == 1);
+
+    // "0" / empty also disable.
+    {
+        ScopedEnv g0("PULP_LOG_CANVAS_PAINT", "0");
+        REQUIRE_NOTHROW(cw.paint(rc));
+    }
+    {
+        ScopedEnv ge("PULP_LOG_CANVAS_PAINT", "");
+        REQUIRE_NOTHROW(cw.paint(rc));
+    }
+}

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -1407,3 +1407,71 @@ TEST_CASE("Single CanvasWidget paint is pixel-equivalent with the layer wrap",
 }
 
 #endif  // PULP_HAS_SKIA
+// ── pulp #1368 round 2 — current_transform() snapshot for paint diagnostics ──
+//
+// The Spectr filterbank repro shows pr_1's first-instruction `fillRect(50,50,…)`
+// landing in the title-bar region above the canvas. Either bounds_.y is wrong
+// (Track B layout test) or the inbound CTM has a translation that pushes draws
+// off-window (Track A diagnostic).  Canvas::current_transform() is the new
+// virtual the env-gated `PULP_LOG_CANVAS_PAINT=1` trace reads to log the CTM
+// as it actually exists at paint() entry, so Spectr can paste a per-frame line
+// like
+//   [pulp:canvas-paint] id=pr_1 bounds=(0,0,1320,760) ctm=[1,0,0,1,0,-100]
+// into #1368.  The tests below pin the introspection contract on
+// RecordingCanvas (the only backend exercised in Catch2): identity at start,
+// updated by translate/scale, and reset across save/restore.
+
+TEST_CASE("RecordingCanvas::current_transform tracks identity at start",
+          "[canvas_widget][issue-1368][round2]") {
+    using namespace pulp::canvas;
+    RecordingCanvas rc;
+    auto t = rc.current_transform();
+    REQUIRE(t.a == 1.0f);
+    REQUIRE(t.b == 0.0f);
+    REQUIRE(t.c == 0.0f);
+    REQUIRE(t.d == 1.0f);
+    REQUIRE(t.e == 0.0f);
+    REQUIRE(t.f == 0.0f);
+}
+
+TEST_CASE("RecordingCanvas::current_transform reflects translate",
+          "[canvas_widget][issue-1368][round2]") {
+    using namespace pulp::canvas;
+    RecordingCanvas rc;
+    rc.translate(10.0f, 20.0f);
+    auto t = rc.current_transform();
+    REQUIRE(t.a == 1.0f);
+    REQUIRE(t.d == 1.0f);
+    REQUIRE(t.e == 10.0f);
+    REQUIRE(t.f == 20.0f);
+}
+
+TEST_CASE("RecordingCanvas::current_transform restores across save/restore",
+          "[canvas_widget][issue-1368][round2]") {
+    using namespace pulp::canvas;
+    RecordingCanvas rc;
+    rc.save();
+    rc.translate(50.0f, 60.0f);
+    auto inner = rc.current_transform();
+    REQUIRE(inner.e == 50.0f);
+    REQUIRE(inner.f == 60.0f);
+    rc.restore();
+    auto outer = rc.current_transform();
+    REQUIRE(outer.e == 0.0f);
+    REQUIRE(outer.f == 0.0f);
+}
+
+TEST_CASE("RecordingCanvas::current_transform composes translate + scale",
+          "[canvas_widget][issue-1368][round2]") {
+    using namespace pulp::canvas;
+    RecordingCanvas rc;
+    // CanvasRenderingContext2D semantics: translate THEN scale in user space
+    // means current = T * S, so a unit-square corner (1,1) maps to (10+2, 20+3).
+    rc.translate(10.0f, 20.0f);
+    rc.scale(2.0f, 3.0f);
+    auto t = rc.current_transform();
+    REQUIRE(t.a == 2.0f);
+    REQUIRE(t.d == 3.0f);
+    REQUIRE(t.e == 10.0f);
+    REQUIRE(t.f == 20.0f);
+}

--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -1504,3 +1504,100 @@ TEST_CASE("View::hit_test does NOT extend overflow:visible past 500px LEFT",
     PopoverFixture f(-650, 25);
     REQUIRE(f.root.hit_test({0, 650}) != f.popover);
 }
+
+// ── pulp #1368 round 2 — absolute children with inset:0 + explicit height ──
+//
+// Spectr filterbank repro per round-2 investigation. Two `<canvas>` siblings
+// share the same wrap parent (1320×860) with `position: absolute; inset: 0`
+// (top/right/bottom/left = 0), but each has an explicit setFlex height —
+// pr_1 = 760, pr_2 = 860. The visible-rendering symptom on the live plugin
+// is consistent with pr_1's bounds_.y landing above the visible window
+// region, which would push every fillRect into the title-bar area via the
+// parent's translate(bounds_.x, bounds_.y) in View::paint_all.
+//
+// These tests pin the contract: when `position: absolute; inset: 0` is
+// combined with an explicit height that is SHORTER than the parent, the
+// child's resolved bounds_ must place its origin at (0, 0) — i.e. inset:0
+// wins over the explicit height for positioning. If a future Yoga / layout
+// change instead resolves y as `parent.height - explicit_height` (anchoring
+// the box to the bottom because inset top:0 + bottom:0 conflicts with the
+// explicit height), the Spectr symptom reappears.
+//
+// As of v0.74.0 this test is expected to FAIL when the resolved y is
+// non-zero — the FAIL is the round-2 reproduction.
+
+TEST_CASE("absolute child with inset:0 + explicit height resolves to (0,0)",
+          "[view][issue-1368][round2]") {
+    using P = View::Position;
+
+    View wrap;
+    wrap.set_bounds({0, 0, 1320, 860});
+
+    auto pr1 = std::make_unique<View>();
+    pr1->set_id("pr_1");
+    pr1->set_position(P::absolute);
+    pr1->set_top(0);
+    pr1->set_right(0);
+    pr1->set_bottom(0);
+    pr1->set_left(0);
+    pr1->flex().preferred_height = 760.0f;
+    auto* pr1_ptr = pr1.get();
+
+    auto pr2 = std::make_unique<View>();
+    pr2->set_id("pr_2");
+    pr2->set_position(P::absolute);
+    pr2->set_top(0);
+    pr2->set_right(0);
+    pr2->set_bottom(0);
+    pr2->set_left(0);
+    pr2->flex().preferred_height = 860.0f;
+    auto* pr2_ptr = pr2.get();
+
+    wrap.add_child(std::move(pr1));
+    wrap.add_child(std::move(pr2));
+
+    wrap.layout_children();
+
+    INFO("pr_1 bounds=(" << pr1_ptr->bounds().x << "," << pr1_ptr->bounds().y
+         << "," << pr1_ptr->bounds().width << "," << pr1_ptr->bounds().height << ")");
+    INFO("pr_2 bounds=(" << pr2_ptr->bounds().x << "," << pr2_ptr->bounds().y
+         << "," << pr2_ptr->bounds().width << "," << pr2_ptr->bounds().height << ")");
+
+    // Both children must paint flush with the parent's top-left. Negative or
+    // shifted y values reproduce the #1368 round-2 hypothesis: parent's
+    // translate(bounds_.x, bounds_.y) in View::paint_all pushes the canvas
+    // child off-window so fillRect at (50, 50) lands in the title-bar region.
+    REQUIRE(pr1_ptr->bounds().x == 0.0f);
+    REQUIRE(pr1_ptr->bounds().y == 0.0f);
+    REQUIRE(pr2_ptr->bounds().x == 0.0f);
+    REQUIRE(pr2_ptr->bounds().y == 0.0f);
+}
+
+TEST_CASE("absolute child with inset:0 fills parent ignoring explicit height",
+          "[view][issue-1368][round2]") {
+    // CSS spec: when both top:0 and bottom:0 are set on a position:absolute
+    // box, the box must stretch to fill the parent height — explicit
+    // `height: 760` is overconstrained and the spec says inset wins (the
+    // box gets parent.height = 860). Confirm Pulp/Yoga match that contract.
+    View wrap;
+    wrap.set_bounds({0, 0, 1320, 860});
+
+    auto pr1 = std::make_unique<View>();
+    pr1->set_position(View::Position::absolute);
+    pr1->set_top(0);
+    pr1->set_right(0);
+    pr1->set_bottom(0);
+    pr1->set_left(0);
+    pr1->flex().preferred_height = 760.0f;
+    auto* pr1_ptr = pr1.get();
+
+    wrap.add_child(std::move(pr1));
+    wrap.layout_children();
+
+    INFO("pr_1 bounds=(" << pr1_ptr->bounds().x << "," << pr1_ptr->bounds().y
+         << "," << pr1_ptr->bounds().width << "," << pr1_ptr->bounds().height << ")");
+
+    REQUIRE(pr1_ptr->bounds().y == 0.0f);
+    // Width should match the parent — inset left:0 + right:0 fills horizontally.
+    REQUIRE(pr1_ptr->bounds().width == 1320.0f);
+}


### PR DESCRIPTION
## Summary

Round-2 investigation of pulp #1368. PR #1369 (CTM save/restore depth bracket) shipped in v0.74.0 but the underlying Spectr filterbank symptom persists. Per the Spectr agent:

- pr_1's first-instruction `ctx.fillRect(50, 50, 400, 200)` at the START of the analyzer redraw — BEFORE any save/scale/translate — still doesn't paint visibly.
- A yellow `fillRect(-1000,-1000, 4000, 4000)` produces a faint tint in the title-bar region ABOVE the canvas, fingerprint identical to before #1369.
- pr_2 (overlay sibling) paints visibly with the same call sequence.

Fingerprint matches the original bug. #1369 was necessary (depth bracket) but not sufficient.

This PR adds two diagnostic surfaces that bracket the remaining hypotheses without changing production behavior.

### Track A — env-gated paint trace

- New `Canvas::current_transform()` virtual returning a 6-float `AffineTransform2x3` in CanvasRenderingContext2D order `(a,b,c,d,e,f)`.
- `SkiaCanvas` reads `getTotalMatrix()`, `CoreGraphicsCanvas` reads `CGContextGetCTM()`, `RecordingCanvas` tracks the matrix manually through translate/scale/rotate/set_transform/concat_transform plus save/restore.
- `CanvasWidget::paint()` logs one grep-able line per paint to stderr when `PULP_LOG_CANVAS_PAINT=1` is exported:
  ```
  [pulp:canvas-paint] id=pr_1 bounds=(0,0,1320,760) ctm=[1,0,0,1,0,0]
  ```
- Variable unset / empty / `"0"` → single getenv lookup, no log. Production builds incur zero overhead unless the user opts in.

### Track B — layout reproduction test

- `[issue-1368][round2]` exercises the EXACT Spectr layout shape per the round-2 brief: two `position: absolute; inset: 0` siblings inside a 1320×860 wrap with conflicting explicit setFlex heights (760 / 860).
- **Result: PASSES on `origin/main` (v0.74.0).** Both children resolve to bounds `(0, 0, *, *)`. Yoga handles the inset+height overconstraint per CSS spec by letting `inset` win.

## Conclusion

**Layout is NOT the bug.** The `bounds_.y < 0` hypothesis is disproven by the Track B test. The remaining hypotheses are:

1. CTM state on the live `SkiaCanvas` — a `getTotalMatrix()` that isn't identity at `paint()` entry on the failing surface (likely from the WindowHostMac's prepare-canvas path, or a layer-save baseline that diverges between pr_1 and pr_2).
2. Window-host invocation routing (e.g. dirty-rect intersection that excludes pr_1 but not pr_2).

Both are surfaced by the env-gated trace.

## Ask to Spectr agent

Run Spectr with `PULP_LOG_CANVAS_PAINT=1` and paste the per-frame line for both pr_1 and pr_2 into #1368. Look specifically for:

- pr_1 `ctm=[…]` showing a non-identity CTM (e.g. `e` or `f` outside the parent translate range), OR
- pr_1 line MISSING entirely (paint() never called for that frame), OR
- pr_1 `bounds=(…)` differing from pr_2 in width/height in a way that matches the visible-region miss.

That observation will pin the next fix.

## Test plan

- [x] `./build/test/pulp-test-canvas-widget` — 25 cases / 68 assertions pass (4 new round-2 contract tests for `RecordingCanvas::current_transform`).
- [x] `./build/test/pulp-test-view "[issue-1368]"` — 6 assertions / 2 cases pass (round-2 layout repro).
- [x] `./build/test/pulp-test-view` — 247 assertions / 56 cases pass (no regression).
- [x] `./build/test/pulp-test-canvas` — 1303 assertions / 40 cases pass (no regression).
- [x] `PULP_LOG_CANVAS_PAINT=1 ./build/test/pulp-test-canvas-widget` — confirms grep-able log lines emitted.
- [x] `PULP_LOG_CANVAS_PAINT=0` and unset — confirms zero log output (production-safe).
- [ ] Spectr agent runs `PULP_LOG_CANVAS_PAINT=1 <spectr_standalone>` and posts the captured pr_1 / pr_2 traces to #1368.

## Versioning

Bumped 0.74.0 → 0.75.0 (minor) — the new `Canvas::current_transform()` virtual is a public API addition and the version-bump heuristic flagged it as such. Default returns identity so no backend is required to override; existing custom Canvas backends in downstream projects continue to compile unchanged.