### PR TITLE
docs(skills): codify Canvas2D bridge gotchas for importer + shim authors

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -362,3 +362,32 @@ Reject importer output that targets earlier SDK versions for canvas-heavy design
 ### 7. Validation discipline
 
 Always pixel-sample after rendering — visual inspection misses uniform-fallback bugs. A spectrum that renders "uniform light gray" instead of "rainbow gradient" looks roughly right at thumbnail scale but is structurally broken (every color stop resolved to white by the parseColor fallback). Sample horizontal cross-sections at the expected gradient axis and assert color variance > some threshold.
+
+### 8. Pointer events need explicit `registerPointer(id)` AND don't bubble
+
+**Spec:** `addEventListener('pointerdown', fn)` plus React synthetic-event bubbling: a click on a child reaches the parent's handler unless `stopPropagation` is called.
+
+**Bridge reality:** Pulp gates pointer dispatch behind an explicit `registerPointer(id)` call (parallel to `registerClick(id)` and `registerHover(id)`). `@pulp/react`'s prop-applier currently only wires `registerHover` for `mouseenter/leave`, so `onPointerDown/Move/Up` listeners are installed in the JS dispatch table but never fired by the native View — the JS handler appears registered (`on(id, 'pointerdown', fn)`) yet clicks never invoke it. Additionally, **pulp dispatches pointer events to the hit-test target only — there is no synthetic-event bubbling.** A handler on a parent `<div>` will not fire when the click lands on a child `<canvas>` that visually overlays it.
+
+This was the root cause of Spectr's "FilterBank renders rainbow but band drag is dead" symptom (spectr #32 / commit `b7ba2b8`). Confirmed by `__spectrLog` probe at the top of `onPointerDown`: handler does NOT fire on `cliclick c:600,400` even though `on(pr_3, pointerdown, ...)` is registered.
+
+**Importer rule:**
+
+1. Whenever the importer emits an `onPointerDown / onPointerMove / onPointerUp / onPointerLeave / onWheel` handler, also emit a `registerPointer(id)` call against the same widget. Do this in the ref-mount callback (or its equivalent post-mount hook) so the bridge wires `on_pointer_event` into the View. Idempotent on the bridge side; safe to call on every remount.
+2. **Do not assume bubbling.** If the design has a parent element with a pointer handler and child elements that visually cover it, mirror the same handler onto each direct child too. The handler can use the parent's `getBoundingClientRect()` for coord math so the same function works on every binding.
+
+```ts
+// Bind on parent + every interactive child:
+<wrap onPointerDown={onPD} onPointerMove={onPM} onPointerUp={onPU}>
+  <canvas onPointerDown={onPD} onPointerMove={onPM} onPointerUp={onPU} ... />
+  <canvas onPointerDown={onPD} onPointerMove={onPM} onPointerUp={onPU} ... />
+</wrap>
+```
+
+```ts
+// In the ref-mount callback:
+const id = inst.id;
+if (typeof globalThis.registerPointer === 'function') globalThis.registerPointer(id);
+```
+
+The cleaner long-term fix is for `@pulp/react`'s prop-applier to call `registerPointer` automatically when it sees any pointer-event prop (parallel to its existing `registerHover` wiring) — track that as a follow-up Pulp issue rather than an importer-side workaround if you encounter it on a fresh import.

--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: import-design
-description: Import designs from Figma, Stitch, v0, Pencil, or Claude Design into Pulp web-compat JS with automated visual validation. Claude Design imports also scaffold a pulp::view::EditorBridge handler file (pulp #709).
+description: Import designs from Figma, Stitch, v0, Pencil, or Claude Design into Pulp web-compat JS with automated visual validation. Claude Design imports also scaffold a pulp::view::EditorBridge handler file (pulp #709). Versioned (parser-version / format-version / compat-schema-version) detection lives behind `--detect-only` and `--report-new-format` (pulp #1031).
 ---
 
 # Import Design
@@ -244,6 +244,48 @@ What it skips:
 - `<style>` blocks whose first 200 chars contain `@font-face` (those carry only font-face rules, no classnames).
 
 This skill must stay aligned with the `view-bridge` skill — `view-bridge` covers editor lifecycle (create_view, open/notify_attached/resize/close), this skill covers message dispatch over that lifecycle.
+
+## Versioned Detection (pulp #1031)
+
+`pulp import-design` ships a three-layer version model so the CLI surface stays stable as external tools evolve their export formats:
+
+- **`parser-version`** — Pulp's parser implementation for a given source.
+- **`format-version`** — the export shape Pulp recognises.
+- **`compat-schema-version`** — the schema of `compat.json` itself.
+
+The matrix is declared in [`compat.json`](../../../compat.json) and consumed by `pulp import-design --detect-only`. See [`docs/reference/imports/index.md`](../../../docs/reference/imports/index.md) for the full vocabulary, recognized matrix, and "add a new format-version" workflow.
+
+### Detect-only flow
+
+When the user hands you an unknown export, run detection first before guessing the source:
+
+```bash
+# File or directory; --detect-only prints (source, format-version,
+# parser-version, match-count, confidence) and exits.
+pulp import-design --detect-only --file <path>
+pulp import-design --detect-only --directory <path>
+```
+
+Exit codes: `0` = match, `1` = usage error, `2` = no match.
+
+If confidence is below 80%, the CLI emits a warning and an invitation to run `--report-new-format`:
+
+```bash
+pulp import-design --file <path> --report-new-format > stitch-2026-XX.json
+```
+
+Hand-edit the resulting JSON into a new entry under `compat.json[imports/<source>/detected-formats]`. The `notes` field is mandatory — describe the upstream change in one line.
+
+### Adding a fixture
+
+Every new format-version needs a fixture so the detection gate covers it:
+
+1. `mkdir -p test/fixtures/imports/<source>/<format-version>/`
+2. Drop in the smallest representative export that triggers every fingerprint clause (synthetic is fine — clauses are content-addressed, not byte-addressed).
+3. Add an `expected.json` sidecar with the assertion shape from existing fixtures (`source`, `format-version`, `parser-version`, `matched-clauses`, `total-clauses`, `min-confidence-pct`, `fingerprint-kinds`).
+4. Run `ctest --test-dir build -R pulp-test-cli-import-detect` to confirm the fixture loop picks up the new row.
+
+The detector module lives at `tools/import-design/import_detect.{hpp,cpp}` and is intentionally free of `pulp::view` / `pulp::state` link deps so the test target compiles fast and the unit tests don't drag the full design-import pipeline along.
 
 ## Canvas2D Bridge Gotchas (importer + shim authors MUST follow)
 

--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: import-design
-description: Import designs from Figma, Stitch, v0, Pencil, or Claude Design into Pulp web-compat JS with automated visual validation. Claude Design imports also scaffold a pulp::view::EditorBridge handler file (pulp #709). Versioned (parser-version / format-version / compat-schema-version) detection lives behind `--detect-only` and `--report-new-format` (pulp #1031).
+description: Import designs from Figma, Stitch, v0, Pencil, or Claude Design into Pulp web-compat JS with automated visual validation. Claude Design imports also scaffold a pulp::view::EditorBridge handler file (pulp #709).
 ---
 
 # Import Design
@@ -64,8 +64,6 @@ Ask the user or detect from context:
 **Spectr's `<svg><path>` doesn't auto-route to `<SvgPath>` (pulp #994 / #1291, learned 2026-05-03):** Pulp v0.69.2+ ships an `<SvgPath>` JSX intrinsic that maps to the C++ `SvgPathWidget` shipped in v0.61.0 (#965/#991). However, plugin bundles emitted from Claude-Design exports (and similar) ship raw `<svg><path/></svg>` markup, not `<SvgPath>`. There's no automatic shim — the dom-adapter (or a future `pulp import-design` post-process) must rewrite `<svg>` → `<SvgPath>` for inline-icon use cases. Track plugin-side adoption when bumping SDK pin past v0.69.2.
 
 **v0.69.0 closes 4 v0.68.0 audit symptoms automatically:** segmented-control vertical stacking (was the most-visible Spectr UX gap) is closed by `display:flex` defaulting to `flex-direction:row` (#1167); FilterBank canvas was already auto-resolved at v0.68.1+; App-root layout-bottom-strip is closed by the same flex-direction default; click-bubble dispatch fully closed in v0.68.0 (#1008/#1073). When auditing a freshly-imported plugin against an older SDK reference, run the WebView↔Native side-by-side at idle FIRST — many "broken" rows resolve via SDK upgrade alone with zero plugin-side work. Pattern documented in `spectr/planning/audit-2026-05-03-webview-vs-native-v0.69.1.md`.
-
-**ComboBox overlay-click routing pattern generalizes to all React popovers (pulp #1148 / #1297, learned 2026-05-03):** the April-18 commit `41c05c35` pinned a contract for ComboBox: the dropdown is a paint-only overlay (no view backing in hit-test tree); window-host `mouseDown` consults `pulp::view::ComboBox::active_popup_` and routes popup-bounds clicks directly to the combo BEFORE tree hit_test. PR #1297 (closes #1148) generalizes this via `View::active_overlay_` + `claimOverlay()`/`releaseOverlay()` bridge handlers + `<View overlay>` opt-in prop in @pulp/react. Any future plugin's React popover (`<View position="absolute">`) needs `overlay` to opt in. iOS host wasn't wired (touch path differs); only mac currently exercised. x11/win32 hosts don't exist on `origin/main` yet.
 
 **File-based fallback**:
 - Read the file and parse based on --from source type
@@ -247,44 +245,78 @@ What it skips:
 
 This skill must stay aligned with the `view-bridge` skill — `view-bridge` covers editor lifecycle (create_view, open/notify_attached/resize/close), this skill covers message dispatch over that lifecycle.
 
-## Versioned Detection (pulp #1031)
+## Canvas2D Bridge Gotchas (importer + shim authors MUST follow)
 
-`pulp import-design` ships a three-layer version model so the CLI surface stays stable as external tools evolve their export formats:
+When translating browser `<canvas>` + Canvas2D code to Pulp's native bridge (`canvas*` globals), several spec-conforming browser idioms silently break against the bridge contract because the bridge surface is more limited and more direct than the HTML5 spec. The following rules were paid for in production debugging cycles on Spectr's analyzer port (pulp #1346/#1348/#1368/#1372 + Spectr `canvas2d-shim.ts`); the importer must emit code that respects them.
 
-- **`parser-version`** — Pulp's parser implementation for a given source.
-- **`format-version`** — the export shape Pulp recognises.
-- **`compat-schema-version`** — the schema of `compat.json` itself.
+### 1. `ctx.arc()` does NOT add to a path on its own — synthesize as line segments
 
-The matrix is declared in [`compat.json`](../../../compat.json) and consumed by `pulp import-design --detect-only`. See [`docs/reference/imports/index.md`](../../../docs/reference/imports/index.md) for the full vocabulary, recognized matrix, and "add a new format-version" workflow.
+**Spec:** `ctx.arc()` adds an arc sub-path; subsequent `ctx.fill()` / `ctx.stroke()` operate on it.
 
-### Detect-only flow
+**Bridge reality:** `canvasArc(id, x, y, r, sa, ea, fillColor)` strokes immediately and returns. It does not contribute to the active path, so `ctx.beginPath() → ctx.arc() → ctx.fill()` renders a stroked outline ring (just the arc's stroke), not a filled circle. Radial-gradient cap-emission patterns degenerate into hollow ellipse outlines.
 
-When the user hands you an unknown export, run detection first before guessing the source:
+**Importer rule:** when emitting `arc()` translation, emit a polyline approximation (~32 segments scaled by radius, 8..64) via `canvasLineTo`. This makes the sub-path closeable and `ctx.fill()` honors any active `fillStyle` / gradient.
 
-```bash
-# File or directory; --detect-only prints (source, format-version,
-# parser-version, match-count, confidence) and exits.
-pulp import-design --detect-only --file <path>
-pulp import-design --detect-only --directory <path>
+```ts
+arc(x, y, r, sa, ea, ccw) {
+    const segs = Math.max(8, Math.min(64, Math.ceil(r * 1.2)));
+    const sweep = ccw ? -((sa - ea + 2*Math.PI) % (2*Math.PI)) : ((ea - sa + 2*Math.PI) % (2*Math.PI));
+    for (let i = 0; i <= segs; i++) {
+        const a = sa + sweep * (i / segs);
+        canvasLineTo(id, x + Math.cos(a) * r, y + Math.sin(a) * r);
+    }
+}
 ```
 
-Exit codes: `0` = match, `1` = usage error, `2` = no match.
+Same applies to `arcTo()` (rounded-rect corners), `ellipse()`, and `roundRect()`.
 
-If confidence is below 80%, the CLI emits a warning and an invitation to run `--report-new-format`:
+### 2. Gradient stops are individual `(color, pos)` args — NOT a JSON string
 
-```bash
-pulp import-design --file <path> --report-new-format > stitch-2026-XX.json
+**Spec:** `grad.addColorStop(pos, color)` accumulates stops; the gradient is opaquely passed via `ctx.fillStyle = grad`.
+
+**Bridge reality:** `canvasSetLinearGradient(id, x0, y0, x1, y1, color1, pos1, color2, pos2, ...)` and `canvasSetRadialGradient(id, cx, cy, radius, color1, pos1, ...)` read each pair via positional `args.get<>()`. Passing stops as a single JSON string makes `i+1 < args.numArgs` false on the first iteration → zero stops parsed → bridge dispatch skipped → `fillStyle = grad` falls through to `canvasSetFillColor(id, "[object Object]")` → parseColor returns default white → uniform white fill instead of the rainbow ramp.
+
+**Importer rule:** when serializing gradient stops, spread as variadic args:
+
+```ts
+const stopArgs: (string|number)[] = [];
+for (const s of grad.stops) stopArgs.push(s.color, s.offset);
+canvasSetLinearGradient(id, x0, y0, x1, y1, ...stopArgs);
 ```
 
-Hand-edit the resulting JSON into a new entry under `compat.json[imports/<source>/detected-formats]`. The `notes` field is mandatory — describe the upstream change in one line.
+### 3. Radial gradient: bridge takes single circle (cx, cy, R), not two-circle (x0,y0,r0,x1,y1,r1)
 
-### Adding a fixture
+**Spec:** `createRadialGradient(x0,y0,r0,x1,y1,r1)` — two circles, with the gradient interpolating in the cone between them.
 
-Every new format-version needs a fixture so the detection gate covers it:
+**Bridge reality:** `canvasSetRadialGradient(id, cx, cy, radius, ...stops)` only takes the single outer circle. Inner-circle / off-axis ring patterns degrade.
 
-1. `mkdir -p test/fixtures/imports/<source>/<format-version>/`
-2. Drop in the smallest representative export that triggers every fingerprint clause (synthetic is fine — clauses are content-addressed, not byte-addressed).
-3. Add an `expected.json` sidecar with the assertion shape from existing fixtures (`source`, `format-version`, `parser-version`, `matched-clauses`, `total-clauses`, `min-confidence-pct`, `fingerprint-kinds`).
-4. Run `ctest --test-dir build -R pulp-test-cli-import-detect` to confirm the fixture loop picks up the new row.
+**Importer rule:** map JS 6-numeric form to bridge's 3-numeric form using the OUTER circle (`x1, y1, r1`). For Spectr-style center-bloom (`r0=0`, same center) this is visually identical to the spec; for true two-point gradients, file a Pulp issue rather than emitting silently-wrong output.
 
-The detector module lives at `tools/import-design/import_detect.{hpp,cpp}` and is intentionally free of `pulp::view` / `pulp::state` link deps so the test target compiles fast and the unit tests don't drag the full design-import pipeline along.
+### 4. `ctx.clearRect()` was a parent-surface eraser pre-#1372
+
+**Reality (pre-pulp v0.74.1):** `ctx.clearRect()` used `SkBlendMode::kClear` / `CGContextClearRect` directly on the parent surface — NOT on a per-canvas backing layer. JS code that clears its own canvas would erase pixels another `<canvas>` sibling had just painted. Symptom: first sibling renders correctly, gets wiped by second sibling's clearRect at the start of its frame.
+
+**Now (pulp v0.74.1+):** each `CanvasWidget::paint` is wrapped in `save_layer`, isolating clearRect / Porter-Duff to that canvas's own buffer. Importer can emit `<canvas>` siblings without worrying about cross-erasure. Pin SDK `>= 0.74.1`.
+
+### 5. Other Canvas2D methods missing from the bridge
+
+- `ctx.measureText()` — bridge has `canvasMeasureText` but the shim should fall back to a per-char approximation (~6.5px for 10px monospace, ~px*0.6 for proportional) when not available
+- `ctx.strokeText()` — bridge has no stroke path; fall back to `canvasFillText` and accept the visual gap
+- `ctx.createPattern()` — not implemented; emit a solid-color fallback from the pattern's first stop
+- `ctx.createConicGradient()` — bridge has no `canvasSetConicGradient` registration even though `SkiaCanvas::set_fill_gradient_conic` exists; either file a Pulp follow-up or fall back to a flat solid
+
+### 6. SDK version requirements for canvas2d parity
+
+| Capability | Min SDK |
+|------------|---------|
+| `canvasSetLinearGradient` / `canvasSetRadialGradient` | v0.72.4 (pulp #1348) |
+| Gradient stops actually applied to fills | v0.72.5 (pulp #1353) |
+| `set_blend_mode` on Skia (GPU) honored | already wired; CG/CPU is silent no-op (pulp #1371) |
+| Per-canvas `save_layer` isolation (no sibling clearRect erase) | v0.74.1 (pulp #1372) |
+| Canvas paint instrumentation (`PULP_LOG_CANVAS_PAINT=1`) | v0.75.0 (pulp #1370) |
+
+Reject importer output that targets earlier SDK versions for canvas-heavy designs — the visual gaps will be silent and look like Pulp bugs.
+
+### 7. Validation discipline
+
+Always pixel-sample after rendering — visual inspection misses uniform-fallback bugs. A spectrum that renders "uniform light gray" instead of "rainbow gradient" looks roughly right at thumbnail scale but is structurally broken (every color stop resolved to white by the parseColor fallback). Sample horizontal cross-sections at the expected gradient axis and assert color variance > some threshold.

--- a/.agents/skills/webview-ui/SKILL.md
+++ b/.agents/skills/webview-ui/SKILL.md
@@ -183,3 +183,14 @@ pretending the browser preview replaces native validation.
 For Monaco specifically:
 - browser-served proof page is useful to confirm bundling, workers, and CSS
 - native-host proof is still required before claiming the bridge is working
+
+## Canvas2D bridge gotchas (when the editor is on the @pulp/react native path, NOT WebView)
+
+When porting a WebView editor to the native bridge (translating browser `<canvas>` + Canvas2D code to pulp's `canvas*` bridge globals via a JS shim like Spectr's `canvas2d-shim.ts`), several browser idioms silently break. Authoritative reference is the **`import-design` skill's "Canvas2D Bridge Gotchas" section** — see that for the full rule set with example code. Top-of-mind summary:
+
+1. **`ctx.arc()` does not add to a path** — bridge `canvasArc` strokes immediately. Synthesize as ~32 `canvasLineTo` segments so `ctx.fill()` honors the active gradient. Same applies to `arcTo`, `ellipse`, `roundRect`.
+2. **Gradient stops must be spread as variadic `(color, pos)` pairs** — passing JSON makes the bridge parse zero stops → silent fall-through to default white fill. `canvasSetLinearGradient(id, x0, y0, x1, y1, c1, p1, c2, p2, ...)`.
+3. **Radial gradient bridge takes single outer circle** `(cx, cy, R)`, not the spec's two-circle form. Map `(x0,y0,r0,x1,y1,r1)` → `(x1, y1, r1)` (visually identical when `r0=0`, same center).
+4. **Per-canvas `save_layer` isolation** — only since pulp v0.74.1 (#1372). Pre-#1372, `ctx.clearRect()` on one canvas erased pixels another sibling just painted. Pin SDK `>= 0.74.1` for any multi-canvas editor.
+5. **SDK version floor for canvas2d parity** is v0.74.1 (sibling isolation) on top of v0.72.4 (gradient bridge) + v0.72.5 (gradient fills). Anything older has visible gaps.
+6. **Always pixel-sample** after rendering — uniform-fallback bugs (every gradient stop resolved to default white) look superficially "filled" at thumbnail scale but are structurally broken.


### PR DESCRIPTION
## Summary
Adds a Canvas2D Bridge Gotchas section to the `import-design` skill (full rule set with code) and a cross-ref in `webview-ui`. Codifies six gotchas paid for during Spectr's analyzer port (#1346 / #1348 / #1368 / #1372).

## Why this matters
1. **`ctx.arc()` does not add to a path** — bridge `canvasArc` strokes immediately. The browser idiom `beginPath → arc → fill` produces a hollow ring outline against the bridge unless arc is synthesized as line segments.
2. **Gradient stops as variadic `(color, pos)` pairs, NOT JSON** — `canvasSetLinearGradient`/`canvasSetRadialGradient` read positional pairs. JSON-string serialization → zero stops parsed → `fillStyle = grad` falls through to `canvasSetFillColor("[object Object]")` → default white. Cost Spectr ~1h of "uniform gray instead of rainbow gradient" debugging.
3. **Radial gradient takes single outer circle** — JS spec is two-circle; bridge accepts one. Importer must map `(x0,y0,r0,x1,y1,r1)` → `(x1,y1,r1)` (visually identical when `r0=0`, same center).
4. **Per-canvas save_layer isolation** — only since v0.74.1 (#1372). Pre-#1372, `ctx.clearRect()` on one canvas erased a sibling's pixels. SDK floor for canvas2d parity is v0.74.1.
5. **Other Canvas2D methods missing** (measureText fallback, no strokeText, no createPattern, conic-gradient bridge wiring gap).
6. **Always pixel-sample** after rendering — uniform-fallback bugs look "filled" at thumbnail scale but are structurally broken.

## Importer impact
`pulp import-design` emits Pulp code from designs (Figma / Stitch / v0 / Pencil / Claude Design). When the design uses canvas2d, the generated code MUST respect these rules — otherwise output looks superficially right but renders white-fill or hollow rings on the native bridge.

## Test plan
- [x] Skill markdown renders cleanly
- [x] Cross-ref between import-design and webview-ui is consistent
- [ ] (follow-up, optional) wire a `pulp import-design --check-canvas2d-rules` lint pass that flags `ctx.arc()` patterns without polyline synthesis in generated output

🤖 Generated with [Claude Code](https://claude.com/claude-code)