### PR TITLE
fix(view): NaN/Inf defense in CanvasWidget::add_command (closes pulp #1387 gap #2)

### DIFF
--- a/core/view/include/pulp/view/canvas_widget.hpp
+++ b/core/view/include/pulp/view/canvas_widget.hpp
@@ -6,6 +6,7 @@
 
 #include <pulp/view/view.hpp>
 #include <pulp/canvas/canvas.hpp>
+#include <cmath>
 #include <functional>
 #include <string>
 #include <vector>
@@ -83,7 +84,34 @@ public:
     CanvasWidget() = default;
 
     void clear_commands() { commands_.clear(); }
-    void add_command(CanvasDrawCmd cmd) { commands_.push_back(std::move(cmd)); }
+    /// pulp #1387 gap #2 — NaN / ±Infinity defense at the recording
+    /// boundary. JS callers can produce non-finite numerics from any
+    /// arithmetic mishap (divide-by-zero on a zero parent rect during a
+    /// transient layout, NaN bubbling through pointer-event coords, etc).
+    /// If a non-finite reaches Skia or CoreGraphics, it can taint the
+    /// entire CGContext / Skia surface for the rest of the frame —
+    /// Spectr saw this as bands rendering as solid grey blobs after an
+    /// off-screen drag produced one NaN coord. Sanitize each cmd's
+    /// numeric fields to 0 on non-finite. The fields cover every coord
+    /// path the dispatch table consumes (move_to, line_to, quad/cubic,
+    /// rects, circles, arcs, text, transforms, clip, image draw).
+    /// Color / int_val / text fields are unaffected. Sanitizing at the
+    /// recording boundary means every backend (Skia GPU, CG CPU,
+    /// RecordingCanvas, headless capture) gets clean numerics without
+    /// a per-backend retrofit.
+    void add_command(CanvasDrawCmd cmd) {
+        cmd.x       = sanitize_finite(cmd.x);
+        cmd.y       = sanitize_finite(cmd.y);
+        cmd.w       = sanitize_finite(cmd.w);
+        cmd.h       = sanitize_finite(cmd.h);
+        cmd.x2      = sanitize_finite(cmd.x2);
+        cmd.y2      = sanitize_finite(cmd.y2);
+        cmd.x3      = sanitize_finite(cmd.x3);
+        cmd.y3      = sanitize_finite(cmd.y3);
+        cmd.extra   = sanitize_finite(cmd.extra);
+        for (auto& p : cmd.gradient_positions) p = sanitize_finite(p);
+        commands_.push_back(std::move(cmd));
+    }
     size_t command_count() const { return commands_.size(); }
     /// pulp #964 — accessor for tests asserting on the recorded JS command
     /// stream. Read-only; the bridge owns mutation via add_command /
@@ -98,6 +126,14 @@ public:
     void paint(canvas::Canvas& canvas) override;
 
 private:
+    /// pulp #1387 gap #2 — return 0 on NaN / ±Infinity, value otherwise.
+    /// Inlined helper kept in the header so the compiler folds it into
+    /// the move-constructor copy in add_command. <cmath>'s std::isfinite
+    /// is constexpr-safe and consteval-eligible on C++20 toolchains.
+    static float sanitize_finite(float v) noexcept {
+        return std::isfinite(v) ? v : 0.0f;
+    }
+
     std::vector<CanvasDrawCmd> commands_;
     NativeGpuTextureProvider native_gpu_texture_provider_;
     bool last_native_gpu_texture_draw_succeeded_ = false;

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -3,6 +3,8 @@
 #include <pulp/view/canvas_widget.hpp>
 #include <pulp/view/theme.hpp>
 #include <pulp/canvas/canvas.hpp>
+#include <cmath>
+#include <limits>
 
 #ifdef PULP_HAS_SKIA
 #include <pulp/canvas/skia_canvas.hpp>
@@ -1664,4 +1666,139 @@ TEST_CASE("CanvasWidget::paint logging path is silent when env unset or empty",
         ScopedEnv ge("PULP_LOG_CANVAS_PAINT", "");
         REQUIRE_NOTHROW(cw.paint(rc));
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// pulp #1387 gap #2 — NaN / Infinity defense at add_command boundary
+// ─────────────────────────────────────────────────────────────────────
+//
+// Spectr's filterbank reproduced this: an off-screen drag computed a
+// gain that briefly went through divide-by-zero on a transient layout
+// (canvas-y/halfH where halfH was 0 mid-resize), feeding NaN into one
+// canvasLineTo call. Skia/CG's coordinate state then carried the NaN
+// for the rest of the frame, painting the bands as solid grey blobs
+// (the same color all subsequent draws inherited from the corrupted
+// transform). One bad coord was enough to taint the whole frame.
+//
+// The defense lives at CanvasWidget::add_command. Sanitization is
+// recording-side (not paint-side) so every backend — Skia GPU, CG
+// CPU, RecordingCanvas, headless capture — gets clean numerics
+// without retrofitting each one.
+
+TEST_CASE("CanvasWidget::add_command sanitizes NaN to 0 (pulp #1387 gap #2)",
+          "[canvas_widget][issue-1387]") {
+    CanvasWidget cw;
+
+    CanvasDrawCmd cmd;
+    cmd.type = CanvasDrawCmd::Type::line_to;
+    cmd.x = std::nanf("");
+    cmd.y = 100.0f;
+    cw.add_command(cmd);
+
+    REQUIRE(cw.command_count() == 1);
+    const auto& stored = cw.commands()[0];
+    REQUIRE(stored.x == 0.0f);   // NaN -> 0
+    REQUIRE(stored.y == 100.0f); // finite -> passthrough
+}
+
+TEST_CASE("CanvasWidget::add_command sanitizes ±Infinity to 0",
+          "[canvas_widget][issue-1387]") {
+    CanvasWidget cw;
+
+    {
+        CanvasDrawCmd cmd;
+        cmd.type = CanvasDrawCmd::Type::move_to;
+        cmd.x = std::numeric_limits<float>::infinity();
+        cmd.y = 50.0f;
+        cw.add_command(cmd);
+    }
+    {
+        CanvasDrawCmd cmd;
+        cmd.type = CanvasDrawCmd::Type::move_to;
+        cmd.x = -std::numeric_limits<float>::infinity();
+        cmd.y = 60.0f;
+        cw.add_command(cmd);
+    }
+
+    REQUIRE(cw.command_count() == 2);
+    REQUIRE(cw.commands()[0].x == 0.0f);
+    REQUIRE(cw.commands()[1].x == 0.0f);
+    REQUIRE(cw.commands()[0].y == 50.0f);
+    REQUIRE(cw.commands()[1].y == 60.0f);
+}
+
+TEST_CASE("CanvasWidget::add_command sanitizes every coord field",
+          "[canvas_widget][issue-1387]") {
+    // Quad / cubic carry x2/y2/x3/y3; rect carries w/h; arc carries extra.
+    // Verify all numeric coord/extra slots are sanitized in one shot.
+    CanvasWidget cw;
+
+    CanvasDrawCmd cmd;
+    cmd.type = CanvasDrawCmd::Type::cubic_to;
+    cmd.x  = std::nanf("");
+    cmd.y  = std::nanf("");
+    cmd.x2 = std::nanf("");
+    cmd.y2 = std::nanf("");
+    cmd.x3 = std::nanf("");
+    cmd.y3 = std::nanf("");
+    cmd.w  = std::numeric_limits<float>::infinity();
+    cmd.h  = -std::numeric_limits<float>::infinity();
+    cmd.extra = std::nanf("");
+    cw.add_command(cmd);
+
+    const auto& s = cw.commands()[0];
+    REQUIRE(s.x == 0.0f);
+    REQUIRE(s.y == 0.0f);
+    REQUIRE(s.x2 == 0.0f);
+    REQUIRE(s.y2 == 0.0f);
+    REQUIRE(s.x3 == 0.0f);
+    REQUIRE(s.y3 == 0.0f);
+    REQUIRE(s.w == 0.0f);
+    REQUIRE(s.h == 0.0f);
+    REQUIRE(s.extra == 0.0f);
+}
+
+TEST_CASE("CanvasWidget::add_command sanitizes gradient stop positions",
+          "[canvas_widget][issue-1387]") {
+    // gradient_positions is the only std::vector<float> in CanvasDrawCmd.
+    // A NaN stop position would make Skia's gradient shader produce
+    // undefined output. Sanitize each entry.
+    CanvasWidget cw;
+
+    CanvasDrawCmd cmd;
+    cmd.type = CanvasDrawCmd::Type::set_fill_gradient_linear;
+    cmd.gradient_positions = {0.0f, std::nanf(""), 0.5f, std::numeric_limits<float>::infinity(), 1.0f};
+    cw.add_command(cmd);
+
+    const auto& positions = cw.commands()[0].gradient_positions;
+    REQUIRE(positions.size() == 5);
+    REQUIRE(positions[0] == 0.0f);
+    REQUIRE(positions[1] == 0.0f);  // NaN -> 0
+    REQUIRE(positions[2] == 0.5f);
+    REQUIRE(positions[3] == 0.0f);  // +inf -> 0
+    REQUIRE(positions[4] == 1.0f);
+}
+
+TEST_CASE("CanvasWidget::add_command preserves finite values exactly",
+          "[canvas_widget][issue-1387]") {
+    // Sanity check: finite values pass through unmodified — no precision
+    // loss from the std::isfinite check. (isfinite is a pure predicate;
+    // the value is returned unchanged when it passes.)
+    CanvasWidget cw;
+
+    CanvasDrawCmd cmd;
+    cmd.type = CanvasDrawCmd::Type::fill_rect;
+    cmd.x = 12.345f;
+    cmd.y = -987.654f;
+    cmd.w = 0.0f;     // valid zero
+    cmd.h = 1e-6f;    // tiny finite
+    cmd.extra = -0.0f; // negative zero is finite
+    cw.add_command(cmd);
+
+    const auto& s = cw.commands()[0];
+    REQUIRE(s.x == 12.345f);
+    REQUIRE(s.y == -987.654f);
+    REQUIRE(s.w == 0.0f);
+    REQUIRE(s.h == 1e-6f);
+    REQUIRE(s.extra == -0.0f);
 }


### PR DESCRIPTION
Closes #1387 gap #2 — Spectr's filterbank reproduced bands rendering as solid grey blobs after a transient layout produced one NaN canvas coord that tainted the entire frame's transform.

## Root cause

A single NaN coord reaches Skia / CoreGraphics, the backend's coordinate state carries NaN forward, every subsequent draw inherits the corrupted transform. JS callers can produce a non-finite numeric from countless arithmetic mishaps (divide-by-zero on a transient parent rect, NaN bubbling through pointer-event coords, etc).

## Fix

Single chokepoint at `CanvasWidget::add_command`. Sanitize x / y / w / h / x2 / y2 / x3 / y3 / extra and gradient_positions[] elements: NaN or ±Infinity → 0, finite values pass through unchanged. Recording-side defense covers every backend (Skia GPU, CG CPU, RecordingCanvas, headless capture) without retrofitting each one.

## Why bridge boundary, not user code

JS-side guards in consumer drawing logic (Spectr's approach so far) catch one path and miss the next. The bridge is the right layer: any path that funnels through `canvasLineTo / MoveTo / Arc / FillRect / etc.` ends up at `add_command`, so the defense is exhaustive by construction.

## Test plan

5 new test cases in `test/test_canvas_widget.cpp` (28 assertions, tagged `[issue-1387]`):

- single NaN coord on line_to → x sanitized, y passthrough
- ±Infinity → 0
- every coord field at once on cubic_to + extra → all sanitized
- gradient_positions[] vector elements sanitized in-place
- finite values (incl. negative zero, tiny floats) pass through bit-exact

All 36 pre-existing canvas-widget tests still pass (114 assertions).

Bumps to v0.75.4 (patch — defensive bug fix, no API change).

## Cross-references

- pulp #1387 — bridge hardening umbrella (this is gap #2 of the catalog)
- Spectr-side: `canvas2d-shim.ts`'s NaN reporting (logged via `_canvasNanSummary`) can be kept as belt-and-suspenders; once Spectr bumps SDK pin, the bands-render-as-grey symptom should resolve regardless of what JS produces upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)