### PR TITLE
feat(harness): rn surface adapter — third of 5 (closes #1392 partial, #1393 partial)

### DIFF
--- a/test/harness/test_rn_adapter.py
+++ b/test/harness/test_rn_adapter.py
@@ -1,0 +1,334 @@
+"""Tests for the rn (React Native ViewStyle) catalog harness adapter.
+
+Per CLAUDE.md "tests ship with fixes" — this is the same-PR test surface
+for the rn adapter (#1392, week 1 cut, third of 5 surfaces).
+
+Run via::
+
+    cd /path/to/pulp
+    python3 -m pytest test/harness/test_rn_adapter.py -v
+    # or, without pytest installed:
+    python3 -m unittest test.harness.test_rn_adapter -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+# Make the harness package importable.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.harness.adapters.base import CatalogEntry  # noqa: E402
+from tools.harness.adapters.rn import RnAdapter  # noqa: E402
+from tools.harness.status import Status, StatusCounts  # noqa: E402
+from tools.harness.verifier import (  # noqa: E402
+    collect_entries,
+    load_compat,
+    run_surface,
+)
+
+
+class RnAdapterClassifyTest(unittest.TestCase):
+    """Classify each catalog status family on known-good and known-bad fixtures."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.adapter = RnAdapter(REPO_ROOT)
+
+    # ── Known-good entries ───────────────────────────────────────────
+
+    def test_supported_non_enum_clean_is_PASS(self):
+        """opacity is `supported`, prop-applier wires it, no unsupportedValues."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/opacity",
+            status="supported",
+            maps_to="prop-applier.ts -> setOpacity(id, n)",
+            supported_values=["0..1"],
+            unsupported_values=[],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.PASS, msg=result.detail)
+        self.assertFalse(result.drifts, msg=result.detail)
+
+    def test_supported_full_enum_is_PASS(self):
+        """fontStyle's only RN values are normal+italic and prop-applier handles
+        it through setFontStyle."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/fontStyle",
+            status="supported",
+            maps_to="setFontStyle",
+            supported_values=["normal", "italic"],
+            unsupported_values=[],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.PASS, msg=result.detail)
+        self.assertFalse(result.drifts, msg=result.detail)
+
+    # ── DIVERGE (catalog claims supported, but values incomplete) ──
+
+    def test_partial_enum_is_DIVERGE(self):
+        """alignItems is `supported` but missing baseline + flex-* long forms."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/alignItems",
+            status="supported",
+            maps_to="prop-applier.ts -> setFlex(id, 'align_items', value)",
+            supported_values=["start", "center", "end", "stretch"],
+            unsupported_values=["baseline", "flex-start", "flex-end (long forms)"],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.DIVERGE, msg=result.detail)
+        # Catalog said supported, harness says DIVERGE → drift
+        self.assertTrue(result.drifts, msg=result.detail)
+        self.assertIn("center", result.matched_supported)
+        self.assertIn("baseline", result.unmatched_supported)
+        self.assertIn("flex-start", result.unmatched_supported)
+
+    def test_partial_enum_status_partial_is_DIVERGE_no_drift(self):
+        """flexDirection catalog status=partial → expected DIVERGE → no drift."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/flexDirection",
+            status="partial",
+            maps_to=(
+                "prop-applier 'direction' -> setFlex(id, 'direction', value); "
+                "but RN says 'row'|'row-reverse'|'column'|'column-reverse'"
+            ),
+            supported_values=["row"],
+            unsupported_values=["row-reverse", "column", "column-reverse"],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.DIVERGE, msg=result.detail)
+        # partial maps to DIVERGE in expected_status, so this is NOT a drift
+        self.assertFalse(result.drifts, msg=result.detail)
+
+    # ── NOT_IMPL ─────────────────────────────────────────────────────
+
+    def test_missing_no_branch_marker_is_NOT_IMPL(self):
+        """borderEndWidth is `missing` with `no branch` marker."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/borderEndWidth",
+            status="missing",
+            maps_to="no branch",
+            supported_values=[],
+            unsupported_values=["all"],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.NOT_IMPL, msg=result.detail)
+        self.assertFalse(result.drifts, msg=result.detail)
+
+    def test_missing_at_pulp_react_marker_is_NOT_IMPL(self):
+        """alignContent — bridge field exists but @pulp/react TS doesn't expose it."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/alignContent",
+            status="missing",
+            maps_to="@pulp/react does not expose alignContent on FlexProps",
+            supported_values=[],
+            unsupported_values=["all"],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.NOT_IMPL, msg=result.detail)
+
+    def test_missing_intentionally_not_dispatched_is_NOT_IMPL(self):
+        """fontFamily — explicitly NOT dispatched in prop-applier."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/fontFamily",
+            status="missing",
+            maps_to=(
+                "intentionally NOT dispatched in prop-applier.ts (line 152 "
+                "comment) -- pending #932 SkFontMgr fix"
+            ),
+            supported_values=[],
+            unsupported_values=["all"],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.NOT_IMPL, msg=result.detail)
+
+    # ── OOS ──────────────────────────────────────────────────────────
+
+    def test_wontfix_is_OOS(self):
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/borderCurve",
+            status="wontfix",
+            maps_to="n/a",
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.OOS)
+        self.assertFalse(result.drifts)
+
+    def test_ios_only_prop_is_OOS(self):
+        """shadowColor is iOS-only in RN; cross-platform pulp surface = OOS."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/shadowColor",
+            status="missing",
+            maps_to="no branch -- would route to setShadow / setBoxShadow",
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.OOS, msg=result.detail)
+        self.assertIn("ios-only", result.detail.lower())
+
+    def test_android_only_prop_is_OOS(self):
+        """textAlignVertical is Android-only in RN."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/textAlignVertical",
+            status="missing",
+            maps_to="no branch",
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.OOS, msg=result.detail)
+        self.assertIn("android-only", result.detail.lower())
+
+    def test_unknown_property_is_OOS(self):
+        """A made-up property the RN oracle doesn't define is OOS."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/madeUpProp",
+            status="missing",
+            maps_to="placeholder",
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.OOS)
+        self.assertIn("unknown surface", result.detail)
+
+    # ── Aliasing ─────────────────────────────────────────────────────
+
+    def test_alt_prop_aliasing_is_recognized(self):
+        """rn/backgroundColor maps to @pulp/react's `background` prop —
+        the adapter should recognize the alias rather than calling NOT_IMPL."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/backgroundColor",
+            status="supported",
+            maps_to="background prop -> setBackground",
+            supported_values=["#rgb", "#rrggbb"],
+            unsupported_values=[],
+        )
+        result = self.adapter.run(e)
+        # Should be PASS (color kind, no unsupported listed)
+        self.assertEqual(result.status, Status.PASS, msg=result.detail)
+
+    def test_prop_applier_quoted_alias_is_recognized(self):
+        """flexDirection's mapsTo references "prop-applier 'direction' -> ...";
+        the adapter must recognize 'direction' as the alias, even though the
+        prop name is flexDirection."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/flexDirection",
+            status="partial",
+            maps_to="prop-applier 'direction' -> setFlex(id, 'direction', value)",
+            supported_values=["row"],
+            unsupported_values=["row-reverse", "column", "column-reverse"],
+        )
+        result = self.adapter.run(e)
+        # Adapter should NOT say NOT_IMPL — it should detect the alias and
+        # then DIVERGE on the missing values.
+        self.assertEqual(result.status, Status.DIVERGE, msg=result.detail)
+
+    # ── Bridge-fn drift detection ────────────────────────────────────
+
+    def test_unregistered_bridge_fn_is_DIVERGE(self):
+        """A catalog claim citing a setX bridge fn that doesn't actually exist
+        should be flagged as DIVERGE (catalog drift)."""
+        e = CatalogEntry(
+            surface="rn",
+            name="rn/cursor",
+            status="supported",
+            # setCursor IS registered; setMadeUpFn is NOT. Claim this entry
+            # routes through a fake fn — should DIVERGE.
+            maps_to="cursor prop -> setMadeUpFn(id, value)",
+            supported_values=["auto", "pointer"],
+            unsupported_values=[],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.DIVERGE, msg=result.detail)
+        self.assertIn("setMadeUpFn", result.detail)
+
+
+class VerifierEndToEndTest(unittest.TestCase):
+    """Full pipeline — compat.json -> all 120 rn entries -> coverage report."""
+
+    def test_collects_all_120_rn_entries(self):
+        compat = load_compat(REPO_ROOT)
+        entries = collect_entries(compat, "rn")
+        self.assertEqual(len(entries), 120, "compat.json rn/ must have 120 entries")
+
+    def test_runs_rn_surface_end_to_end(self):
+        results = run_surface(REPO_ROOT, "rn")
+        self.assertEqual(len(results), 120)
+        for r in results:
+            self.assertIsInstance(r.status, Status)
+
+    def test_no_rn_entry_crashes(self):
+        """All 120 rn catalog entries must classify without exception."""
+        compat = load_compat(REPO_ROOT)
+        entries = collect_entries(compat, "rn")
+        adapter = RnAdapter(REPO_ROOT)
+        for e in entries:
+            r = adapter.run(e)
+            self.assertIsInstance(r.status, Status, msg=e.name)
+
+    def test_coverage_distribution_is_nonzero(self):
+        """Sanity: with the catalog as-is, we have at least some PASS, some
+        DIVERGE, some NOT-IMPL, and some OOS."""
+        results = run_surface(REPO_ROOT, "rn")
+        statuses = [r.status for r in results]
+        counts = StatusCounts.from_results(statuses)
+        self.assertGreater(counts.pass_, 0, "expected at least 1 PASS")
+        self.assertGreater(counts.diverge, 0, "expected at least 1 DIVERGE")
+        self.assertGreater(counts.not_impl, 0, "expected at least 1 NOT-IMPL")
+        self.assertGreater(counts.oos, 0, "expected at least 1 OOS (iOS/Android only props)")
+
+    def test_json_output_contains_all_entries(self):
+        results = run_surface(REPO_ROOT, "rn")
+        from tools.harness.verifier import render_json
+
+        payload = render_json({"rn": results}, sha="test")
+        self.assertIn("rn", payload["surfaces"])
+        self.assertEqual(payload["surfaces"]["rn"]["total"], 120)
+        self.assertEqual(
+            payload["surfaces"]["rn"]["total"],
+            len(payload["surfaces"]["rn"]["results"]),
+        )
+
+
+class VerifierCliTest(unittest.TestCase):
+    """Smoke-tests the CLI entrypoint via subprocess."""
+
+    def test_json_subcommand_exits_zero(self):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(REPO_ROOT)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "tools" / "harness" / "verifier.py"),
+                "--surface=rn",
+                "--json",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["surfaces"]["rn"]["total"], 120)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/harness/adapters/rn.py
+++ b/tools/harness/adapters/rn.py
@@ -1,0 +1,342 @@
+"""RN ViewStyle surface adapter — week 1 deliverable (third of 5).
+
+Classifies each `rn/*` entry in compat.json against three layers of evidence:
+
+1. The oracle (`tools/harness/oracles/rn/rn-viewstyle.json`) — what RN
+   itself supports for this property, including platform flags (iOS / Android),
+   third-party extension markers (react-native-svg), and Pulp extensions.
+2. The catalog payload (`mapsTo`, `supportedValues`, `unsupportedValues`,
+   `notes`) — what the catalog claims pulp does today.
+3. The bridge surface — `packages/pulp-react/src/prop-applier.ts` switch
+   cases (the JSX-prop-to-bridge-setter router) plus the actual bridge
+   function registration list embedded in the oracle. We grep prop-applier
+   once at adapter init for cheap presence checks.
+
+The verdict is PASS / DIVERGE / NO-OP / NOT-IMPL / OOS — see
+`tools/harness/status.py` for the full taxonomy.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from ..status import Status
+from .base import AdapterBase, CatalogEntry, Result, register_adapter
+
+
+# Catalog `mapsTo` markers that imply "no binding exists in @pulp/react TS".
+NOT_IMPL_MARKERS = (
+    "no branch",
+    "no prop-applier case",
+    "no @pulp/react prop",
+    "no shorthand prop in @pulp/react",
+    "not surfaced in @pulp/react",
+    "not surfaced as a flat prop",
+    "not surfaced.",
+    "not yet exposed at @pulp/react",
+    "not yet exposed",
+    "intentionally not dispatched",
+    "no bridge support",
+    "no bridge (",
+    "no bridge --",
+    "no field",
+    "no implementation",
+    "no impl",
+    "silently dropped",
+    "silently drops",
+    "no prop ",
+    "not wired",
+    "no binding",
+    "no setbridge",
+)
+
+NO_OP_MARKERS = (
+    "no-op",
+    "noop",
+    "accepted silently",
+    "accepted but ignored",
+    "ignored",
+    "stub",
+)
+
+
+@register_adapter("rn")
+class RnAdapter(AdapterBase):
+    surface = "rn"
+
+    def __init__(self, repo_root: Path):
+        super().__init__(repo_root)
+        self._oracle = self._load_oracle()
+        self._prop_applier_text = self._read(
+            "packages/pulp-react/src/prop-applier.ts"
+        )
+        self._prop_applier_cases = self._extract_prop_applier_cases(
+            self._prop_applier_text
+        )
+        self._registered_bridge_fns = set(
+            self._oracle.get("bridgeFunctions", {}).get("registered", [])
+        )
+
+    # ── Oracle + source loading ──────────────────────────────────────
+
+    def _load_oracle(self) -> dict:
+        path = (
+            self.repo_root
+            / "tools"
+            / "harness"
+            / "oracles"
+            / "rn"
+            / "rn-viewstyle.json"
+        )
+        with open(path) as f:
+            return json.load(f)
+
+    def _read(self, rel: str) -> str:
+        p = self.repo_root / rel
+        if not p.exists():
+            return ""
+        return p.read_text(encoding="utf-8", errors="replace")
+
+    @staticmethod
+    def _extract_prop_applier_cases(src: str) -> set[str]:
+        """Set of `case 'X':` prop names that prop-applier handles."""
+        if not src:
+            return set()
+        return set(re.findall(r"case\s+'([A-Za-z_][A-Za-z0-9_]*)'\s*:", src))
+
+    # ── Catalog `mapsTo` heuristics ───────────────────────────────────
+
+    @staticmethod
+    def _maps_to_marks_unimpl(maps_to: str) -> bool:
+        if not maps_to:
+            return True
+        m = maps_to.lower()
+        return any(marker in m for marker in NOT_IMPL_MARKERS)
+
+    @staticmethod
+    def _maps_to_marks_noop(maps_to: str) -> bool:
+        if not maps_to:
+            return False
+        m = maps_to.lower()
+        return any(marker in m for marker in NO_OP_MARKERS)
+
+    @staticmethod
+    def _bridge_fns_in_maps_to(maps_to: str) -> list[str]:
+        """Pull every `setX` identifier referenced in mapsTo."""
+        if not maps_to:
+            return []
+        return re.findall(r"\b(set[A-Z][A-Za-z0-9_]*)\b", maps_to)
+
+    # ── Main classification ──────────────────────────────────────────
+
+    def run(self, entry: CatalogEntry) -> Result:
+        prop = entry.short_name  # e.g. "alignItems"
+        maps_to = entry.maps_to or ""
+
+        # 0. wontfix is OOS by definition.
+        if entry.status == "wontfix":
+            return Result(
+                entry=entry,
+                status=Status.OOS,
+                detail="catalog status=wontfix (explicitly out of scope)",
+            )
+
+        oracle_entry = self._oracle["properties"].get(prop)
+
+        # 1. Property not in the RN oracle at all → OOS (unknown surface).
+        if oracle_entry is None:
+            return Result(
+                entry=entry,
+                status=Status.OOS,
+                detail=(
+                    f"property {prop!r} not present in RN ViewStyle oracle "
+                    f"(unknown surface)"
+                ),
+            )
+
+        # 2. Platform-only props (iOS-only or Android-only) are out of scope
+        #    for the cross-platform pulp surface unless we've explicitly
+        #    decided to ship them. The catalog typically marks these
+        #    `wontfix` already; if it doesn't, we still treat them as OOS
+        #    because the cross-platform "missing" is not a bug.
+        platform_only = oracle_entry.get("platformOnly")
+        if platform_only:
+            return Result(
+                entry=entry,
+                status=Status.OOS,
+                detail=(
+                    f"RN {platform_only}-only prop; out of scope for the "
+                    f"cross-platform pulp surface"
+                ),
+            )
+
+        kind = oracle_entry.get("kind", "string")
+        oracle_values = list(oracle_entry.get("values") or [])
+
+        # 3. Look at the catalog mapsTo string and the prop-applier surface.
+        case_present = prop in self._prop_applier_cases
+        # Some catalog entries route through a *different* prop-applier case
+        # (e.g. rn/backgroundColor → @pulp/react's `background` prop, rn/color
+        # → @pulp/react's `textColor` prop, rn/flexDirection → @pulp/react's
+        # `direction` prop). The mapsTo field cites the alternate prop-name;
+        # pull it out so we don't miscount these as missing.
+        # Patterns we handle (captured group is the alternate prop name):
+        #   "background prop -> setBackground"            (backgroundColor)
+        #   "textColor prop -> setTextColor"              (color)
+        #   "prop-applier 'direction' -> setFlex(...)"    (flexDirection alias)
+        #   "prop-applier.ts: 'd' -> setSvgPath(...)"     (d, fill, stroke, ...)
+        alt_props_in_maps_to: list[str] = []
+        alt_props_in_maps_to += re.findall(
+            r"\b([a-z][a-zA-Z]*)\s+prop\b", maps_to
+        )
+        alt_props_in_maps_to += re.findall(
+            r"prop-applier(?:\.ts)?[:\s]+'([A-Za-z_][A-Za-z0-9_]*)'",
+            maps_to,
+        )
+        alt_case_present = any(
+            p in self._prop_applier_cases for p in alt_props_in_maps_to
+        )
+        has_binding = case_present or alt_case_present
+
+        # 4. Cross-check any `setX` referenced in mapsTo against the
+        #    actually-registered bridge surface. A claim like
+        #    "Bridge has setBackfaceVisibility -- not surfaced" is honest
+        #    about the @pulp/react gap, but a claim like
+        #    "Bridge has setFooBar" with setFooBar absent is a DIVERGE we
+        #    should surface to the user.
+        bridge_fns_cited = self._bridge_fns_in_maps_to(maps_to)
+        unregistered_cited = [
+            fn for fn in bridge_fns_cited if fn not in self._registered_bridge_fns
+        ]
+
+        # 5. NO_OP markers (rare for rn).
+        if self._maps_to_marks_noop(maps_to):
+            return Result(
+                entry=entry,
+                status=Status.NO_OP,
+                detail=f"mapsTo signals no-op acceptance: {maps_to!r}",
+            )
+
+        # 6. NOT-IMPL markers (most common reason for `missing`).
+        if self._maps_to_marks_unimpl(maps_to):
+            return Result(
+                entry=entry,
+                status=Status.NOT_IMPL,
+                detail=f"mapsTo signals no implementation: {maps_to!r}",
+            )
+
+        # 7. If the catalog cites a bridge function that doesn't actually
+        #    exist, that's a documentation drift — DIVERGE.
+        if unregistered_cited:
+            return Result(
+                entry=entry,
+                status=Status.DIVERGE,
+                detail=(
+                    f"mapsTo cites bridge fn(s) not in widget_bridge.cpp: "
+                    f"{unregistered_cited}"
+                ),
+            )
+
+        # 8. No prop-applier binding and no helpful marker — fall back to
+        #    NOT_IMPL.
+        if not has_binding:
+            return Result(
+                entry=entry,
+                status=Status.NOT_IMPL,
+                detail=(
+                    f"no prop-applier case for {prop!r} (or alias); "
+                    f"mapsTo={maps_to!r}"
+                ),
+            )
+
+        # 9. Compare supportedValues vs the oracle's enum value set.
+        if kind in ("enum", "enum-or-number") and oracle_values:
+            sup = set(entry.supported_values or [])
+            unsup = set(entry.unsupported_values or [])
+            oracle_set = set(oracle_values)
+
+            matched = sorted(oracle_set & sup)
+            missing_from_supported = sorted(oracle_set - sup)
+
+            # PASS iff every oracle value is in supportedValues AND
+            # nothing the oracle defines is listed as unsupported.
+            if oracle_set <= sup and not (oracle_set & unsup):
+                return Result(
+                    entry=entry,
+                    status=Status.PASS,
+                    detail=(
+                        f"all {len(oracle_set)} RN values for {prop!r} are "
+                        f"claimed supported"
+                    ),
+                    matched_supported=matched,
+                )
+
+            # If at least one oracle value is in supported, it's DIVERGE.
+            if oracle_set & sup:
+                return Result(
+                    entry=entry,
+                    status=Status.DIVERGE,
+                    detail=(
+                        f"{len(matched)}/{len(oracle_set)} RN values supported; "
+                        f"missing: {missing_from_supported}"
+                    ),
+                    matched_supported=matched,
+                    unmatched_supported=missing_from_supported,
+                    extra_unsupported=sorted(oracle_set & unsup),
+                )
+
+            # Binding exists but no oracle value claimed — treat as DIVERGE
+            # (the surface is wired but the value translation isn't).
+            return Result(
+                entry=entry,
+                status=Status.DIVERGE,
+                detail=(
+                    f"prop-applier case for {prop!r} present but no RN "
+                    f"values claimed in supportedValues; missing all of "
+                    f"{sorted(oracle_set)}"
+                ),
+                unmatched_supported=sorted(oracle_set),
+            )
+
+        # 10. Non-enum kinds (number, length, color, etc).
+        # If supportedValues has nothing and unsupportedValues has nothing
+        # meaningful, call PASS. If unsupportedValues lists real values,
+        # DIVERGE.
+        meaningful_unsup = [
+            v
+            for v in (entry.unsupported_values or [])
+            if v.strip() and v.strip().lower() not in ("none", "all")
+        ]
+        if meaningful_unsup:
+            return Result(
+                entry=entry,
+                status=Status.DIVERGE,
+                detail=(
+                    f"non-enum {kind!r} property has "
+                    f"{len(meaningful_unsup)} unsupported values listed: "
+                    f"{meaningful_unsup}"
+                ),
+                extra_unsupported=meaningful_unsup,
+            )
+
+        # If supportedValues has [] but unsupported is ['all'], that's
+        # really a NOT_IMPL claim dressed in non-enum garb — treat it as
+        # such for honesty.
+        unsup_lower = [v.strip().lower() for v in (entry.unsupported_values or [])]
+        if unsup_lower == ["all"]:
+            return Result(
+                entry=entry,
+                status=Status.NOT_IMPL,
+                detail=(
+                    f"unsupportedValues=['all'] indicates the prop-applier "
+                    f"case is present but rejects every value"
+                ),
+            )
+
+        return Result(
+            entry=entry,
+            status=Status.PASS,
+            detail=f"non-enum {kind!r} property bound; no unsupported values listed",
+        )

--- a/tools/harness/oracles/rn/README.md
+++ b/tools/harness/oracles/rn/README.md
@@ -1,0 +1,88 @@
+# RN ViewStyle oracle
+
+The rn oracle is a static reference table sourced from React Native's
+`ViewStyle`/`TextStyle`/`TransformsStyle` type definitions (RN 0.79) plus
+`tools/import-design/catalogs/rn-viewstyle.tsv`. The harness uses it to
+classify each `rn/*` entry in `compat.json` against three layers of
+evidence:
+
+1. **The oracle** (`rn-viewstyle.json`) — what RN itself supports for
+   this prop, including platform flags (iOS-only / Android-only / RN
+   New-Architecture-only) and pulp/RN extension markers (e.g.
+   `overlay` is a Pulp-only extension; `d`/`fill`/`stroke` are
+   `react-native-svg` props that @pulp/react re-exposes).
+2. **The catalog payload** (`mapsTo`, `supportedValues`,
+   `unsupportedValues`, `notes`) — what the catalog claims pulp does
+   today.
+3. **The bridge surface** (`packages/pulp-react/src/prop-applier.ts`
+   switch-cases + `core/view/src/widget_bridge.cpp` register_function
+   calls). The adapter parses prop-applier once at init and stores the
+   set of `case 'X':` keys; it cross-references catalog `mapsTo`
+   bridge-function names against the registered set in
+   `widget_bridge.cpp`.
+
+We chose "static reference" over "shell out to the live RN typechecker"
+for the same reasons as yoga: portability, no extra build dependency
+at verifier-runtime, small bounded surface (~120 properties).
+
+## File: `rn-viewstyle.json`
+
+Schema:
+
+```json
+{
+  "version": "rn-0.79",
+  "source": "...",
+  "properties": {
+    "<camelCase prop>": {
+      "kind": "enum | number | color | length | length-or-percentage | length-or-percentage-or-auto | edge-set | string | transform-array | shadow-offset | tuple | enum-or-number | string-array | boolean",
+      "values": ["..."],         // for enum: full RN-supported value list
+      "default": "...",          // optional — RN default
+      "platformOnly": "ios | android",  // optional — narrows scope
+      "rnExtension": "react-native-svg",  // optional — third-party RN ext
+      "pulpExtension": true,     // optional — Pulp-only addition
+      "notes": "..."             // optional
+    }
+  },
+  "bridgeFunctions": {
+    "registered": ["setX", "setY", ...]  // currently-registered bridge fns
+  }
+}
+```
+
+## How the adapter classifies entries
+
+* `wontfix` (catalog) → **OOS**
+* `platformOnly` (oracle) → **OOS** (iOS-only / Android-only props
+  aren't in the cross-platform pulp surface)
+* `pulpExtension` (oracle) — the entry is unique to pulp, treated as
+  a normal entry (typically PASS when prop-applier wires it).
+* `mapsTo` markers signalling no-implementation (`no branch`,
+  `no @pulp/react prop`, `not surfaced`, `intentionally NOT
+  dispatched`, `no bridge support`, `no prop-applier case`) →
+  **NOT_IMPL**.
+* `mapsTo` references a `setX` bridge function that **isn't** in the
+  registered list → **DIVERGE** (catalog disagrees with reality).
+* prop-applier has a matching `case 'X':` → has binding. For enum
+  kinds we then compare `supportedValues` against the oracle's full
+  enum value set:
+  * superset (every oracle value is supported) → **PASS**
+  * subset (some oracle values supported) → **DIVERGE**
+  * empty / disjoint → **NOT_IMPL** (binding exists but no values
+    claimed)
+* Non-enum kinds with no listed `unsupportedValues` and a binding →
+  **PASS**; otherwise **DIVERGE**.
+
+## Regeneration
+
+The oracle is hand-maintained for now. To refresh:
+
+1. Bump the RN version pin in `version`.
+2. Walk RN's `Libraries/StyleSheet/StyleSheetTypes.d.ts` (or the
+   public docs at <https://reactnative.dev/docs/view-style-props>)
+   for new props / values / platform flags.
+3. Re-run `grep -nE '"set[A-Z]' core/view/src/widget_bridge.cpp` and
+   refresh `bridgeFunctions.registered`.
+4. Mirror changes into `rn-viewstyle.json` and bump `version`.
+5. Run `python3 tools/harness/verifier.py --surface=rn` and review
+   the drift list.

--- a/tools/harness/oracles/rn/rn-viewstyle.json
+++ b/tools/harness/oracles/rn/rn-viewstyle.json
@@ -1,0 +1,291 @@
+{
+  "version": "rn-0.79",
+  "source": "tools/import-design/catalogs/rn-viewstyle.tsv + reactnative.dev/docs/view-style-props + reactnative.dev/docs/text-style-props + react-native types (RN 0.79 ViewStyle / TextStyle / ImageStyle / TransformsStyle)",
+  "notes": "RN ViewStyle is a closed-vocabulary union of layout (Yoga subset), visual (border/shadow/etc), text, and platform-flagged props. The oracle below covers the 120 entries tracked in compat.json[rn]. Properties marked platformOnly are OOS for the cross-platform pulp surface unless explicitly ported. Properties marked rnExtension or pulpExtension are non-standard add-ons.",
+  "properties": {
+    "alignContent": {
+      "kind": "enum",
+      "values": ["flex-start", "flex-end", "center", "stretch", "space-between", "space-around", "space-evenly"],
+      "default": "flex-start"
+    },
+    "alignItems": {
+      "kind": "enum",
+      "values": ["flex-start", "flex-end", "center", "stretch", "baseline"],
+      "default": "stretch"
+    },
+    "alignSelf": {
+      "kind": "enum",
+      "values": ["auto", "flex-start", "flex-end", "center", "stretch", "baseline"],
+      "default": "auto"
+    },
+    "aspectRatio": {"kind": "number", "notes": "width/height ratio"},
+    "backfaceVisibility": {
+      "kind": "enum",
+      "values": ["visible", "hidden"],
+      "default": "visible"
+    },
+    "backgroundColor": {"kind": "color"},
+    "borderBottomColor": {"kind": "color"},
+    "borderBottomLeftRadius": {"kind": "length-or-percentage"},
+    "borderBottomRightRadius": {"kind": "length-or-percentage"},
+    "borderBottomWidth": {"kind": "length"},
+    "borderColor": {"kind": "color", "notes": "shorthand for all edges"},
+    "borderCurve": {
+      "kind": "enum",
+      "values": ["circular", "continuous"],
+      "platformOnly": "ios",
+      "notes": "iOS only — not part of cross-platform pulp surface"
+    },
+    "borderEndWidth": {"kind": "length", "notes": "writing-direction relative"},
+    "borderLeftColor": {"kind": "color"},
+    "borderLeftWidth": {"kind": "length"},
+    "borderRadius": {"kind": "length-or-percentage", "notes": "shorthand"},
+    "borderRightColor": {"kind": "color"},
+    "borderRightWidth": {"kind": "length"},
+    "borderStartWidth": {"kind": "length", "notes": "writing-direction relative"},
+    "borderStyle": {
+      "kind": "enum",
+      "values": ["solid", "dotted", "dashed"],
+      "default": "solid"
+    },
+    "borderTopColor": {"kind": "color"},
+    "borderTopLeftRadius": {"kind": "length-or-percentage"},
+    "borderTopRightRadius": {"kind": "length-or-percentage"},
+    "borderTopWidth": {"kind": "length"},
+    "borderWidth": {"kind": "length", "notes": "shorthand for all edges"},
+    "bottom": {"kind": "length-or-percentage", "notes": "physical edge"},
+    "boxShadow": {"kind": "string", "notes": "RN New Architecture only; CSS box-shadow syntax"},
+    "boxSizing": {
+      "kind": "enum",
+      "values": ["border-box", "content-box"],
+      "default": "border-box",
+      "notes": "RN New Architecture only"
+    },
+    "color": {"kind": "color", "notes": "TextStyle, but RN ViewStyle accepts it for inheritance"},
+    "columnGap": {"kind": "length-or-percentage"},
+    "cursor": {
+      "kind": "enum",
+      "values": ["auto", "pointer"],
+      "default": "auto"
+    },
+    "d": {"kind": "string", "rnExtension": "react-native-svg", "notes": "SVG path data — not core ViewStyle but tracked because @pulp/react routes it"},
+    "direction": {
+      "kind": "enum",
+      "values": ["inherit", "ltr", "rtl"],
+      "default": "inherit",
+      "notes": "writing direction; iOS only in classic RN, cross-platform with Fabric"
+    },
+    "display": {
+      "kind": "enum",
+      "values": ["flex", "none"],
+      "default": "flex"
+    },
+    "elevation": {
+      "kind": "number",
+      "platformOnly": "android",
+      "notes": "Android 5.0+ only; integer dp"
+    },
+    "end": {"kind": "length-or-percentage", "notes": "writing-direction relative (RTL-aware)"},
+    "experimental_backgroundImage": {"kind": "string", "notes": "linear-gradient / radial-gradient string; New Architecture only"},
+    "fill": {"kind": "color", "rnExtension": "react-native-svg", "notes": "SVG fill — not core ViewStyle"},
+    "filter": {"kind": "string", "notes": "RN New Architecture only; CSS filter syntax"},
+    "flex": {"kind": "number", "notes": "positive=flex-grow, negative=flex-shrink semantics"},
+    "flexBasis": {"kind": "length-or-percentage-or-auto"},
+    "flexDirection": {
+      "kind": "enum",
+      "values": ["row", "row-reverse", "column", "column-reverse"],
+      "default": "column",
+      "notes": "RN default is column (CSS default is row)"
+    },
+    "flexGrow": {"kind": "number", "default": 0},
+    "flexShrink": {"kind": "number", "default": 0, "notes": "RN default is 0 (CSS default is 1)"},
+    "flexWrap": {
+      "kind": "enum",
+      "values": ["nowrap", "wrap", "wrap-reverse"],
+      "default": "nowrap"
+    },
+    "fontFamily": {"kind": "string"},
+    "fontSize": {"kind": "number"},
+    "fontStyle": {
+      "kind": "enum",
+      "values": ["normal", "italic"],
+      "default": "normal"
+    },
+    "fontVariant": {
+      "kind": "string-array",
+      "values": ["small-caps", "oldstyle-nums", "lining-nums", "tabular-nums", "proportional-nums"],
+      "notes": "array of variant strings"
+    },
+    "fontWeight": {
+      "kind": "enum-or-number",
+      "values": ["normal", "bold", "100", "200", "300", "400", "500", "600", "700", "800", "900", "ultralight", "thin", "light", "medium", "regular", "semibold", "condensedBold", "condensed", "heavy", "black"],
+      "default": "normal"
+    },
+    "gap": {"kind": "length-or-percentage", "notes": "shorthand for row-gap and column-gap"},
+    "height": {"kind": "length-or-percentage-or-auto"},
+    "includeFontPadding": {
+      "kind": "boolean",
+      "platformOnly": "android",
+      "notes": "Android only; vertical font padding workaround"
+    },
+    "inset": {"kind": "length-or-percentage", "notes": "shorthand top/right/bottom/left"},
+    "insetBlock": {"kind": "length-or-percentage"},
+    "insetInline": {"kind": "length-or-percentage"},
+    "isolation": {
+      "kind": "enum",
+      "values": ["auto", "isolate"],
+      "default": "auto",
+      "notes": "RN New Architecture only"
+    },
+    "justifyContent": {
+      "kind": "enum",
+      "values": ["flex-start", "flex-end", "center", "space-between", "space-around", "space-evenly"],
+      "default": "flex-start"
+    },
+    "left": {"kind": "length-or-percentage", "notes": "physical edge"},
+    "letterSpacing": {"kind": "number"},
+    "lineHeight": {"kind": "number"},
+    "margin": {"kind": "edge-set", "notes": "shorthand for all edges"},
+    "marginBottom": {"kind": "length-or-percentage-or-auto"},
+    "marginEnd": {"kind": "length-or-percentage-or-auto", "notes": "writing-direction relative"},
+    "marginHorizontal": {"kind": "length-or-percentage-or-auto", "notes": "left+right shorthand (RN extension)"},
+    "marginLeft": {"kind": "length-or-percentage-or-auto"},
+    "marginRight": {"kind": "length-or-percentage-or-auto"},
+    "marginStart": {"kind": "length-or-percentage-or-auto", "notes": "writing-direction relative"},
+    "marginTop": {"kind": "length-or-percentage-or-auto"},
+    "marginVertical": {"kind": "length-or-percentage-or-auto", "notes": "top+bottom shorthand (RN extension)"},
+    "maxHeight": {"kind": "length-or-percentage"},
+    "maxWidth": {"kind": "length-or-percentage"},
+    "minHeight": {"kind": "length-or-percentage"},
+    "minWidth": {"kind": "length-or-percentage"},
+    "mixBlendMode": {
+      "kind": "enum",
+      "values": [
+        "normal", "multiply", "screen", "overlay", "darken", "lighten",
+        "color-dodge", "color-burn", "hard-light", "soft-light",
+        "difference", "exclusion", "hue", "saturation", "color", "luminosity"
+      ],
+      "default": "normal",
+      "notes": "RN New Architecture only"
+    },
+    "opacity": {"kind": "number", "notes": "0..1"},
+    "outlineColor": {"kind": "color", "notes": "RN New Architecture only"},
+    "outlineOffset": {"kind": "number", "notes": "RN New Architecture only"},
+    "outlineStyle": {
+      "kind": "enum",
+      "values": ["solid", "dotted", "dashed"],
+      "notes": "RN New Architecture only"
+    },
+    "outlineWidth": {"kind": "number", "notes": "RN New Architecture only"},
+    "overflow": {
+      "kind": "enum",
+      "values": ["visible", "hidden", "scroll"],
+      "default": "visible"
+    },
+    "overlay": {"kind": "boolean", "pulpExtension": true, "notes": "Pulp-only extension; not part of RN ViewStyle. Routes to claimOverlay/releaseOverlay for popover click routing (pulp #1148)."},
+    "padding": {"kind": "edge-set", "notes": "shorthand for all edges"},
+    "paddingBottom": {"kind": "length-or-percentage"},
+    "paddingEnd": {"kind": "length-or-percentage", "notes": "writing-direction relative"},
+    "paddingHorizontal": {"kind": "length-or-percentage", "notes": "left+right shorthand (RN extension)"},
+    "paddingLeft": {"kind": "length-or-percentage"},
+    "paddingRight": {"kind": "length-or-percentage"},
+    "paddingStart": {"kind": "length-or-percentage", "notes": "writing-direction relative"},
+    "paddingTop": {"kind": "length-or-percentage"},
+    "paddingVertical": {"kind": "length-or-percentage", "notes": "top+bottom shorthand (RN extension)"},
+    "pointerEvents": {
+      "kind": "enum",
+      "values": ["auto", "box-none", "box-only", "none"],
+      "default": "auto"
+    },
+    "position": {
+      "kind": "enum",
+      "values": ["absolute", "relative", "static"],
+      "default": "relative",
+      "notes": "RN historically only allowed absolute/relative; static added later"
+    },
+    "right": {"kind": "length-or-percentage", "notes": "physical edge"},
+    "rowGap": {"kind": "length-or-percentage"},
+    "shadowColor": {"kind": "color", "platformOnly": "ios", "notes": "iOS only in RN; web maps to box-shadow color"},
+    "shadowOffset": {"kind": "shadow-offset", "platformOnly": "ios", "notes": "iOS only; { width, height }"},
+    "shadowOpacity": {"kind": "number", "platformOnly": "ios", "notes": "iOS only; 0..1"},
+    "shadowRadius": {"kind": "number", "platformOnly": "ios", "notes": "iOS only"},
+    "start": {"kind": "length-or-percentage", "notes": "writing-direction relative (RTL-aware)"},
+    "stroke": {"kind": "color", "rnExtension": "react-native-svg", "notes": "SVG stroke — not core ViewStyle"},
+    "strokeWidth": {"kind": "number", "rnExtension": "react-native-svg", "notes": "SVG stroke width — not core ViewStyle"},
+    "textAlign": {
+      "kind": "enum",
+      "values": ["auto", "left", "right", "center", "justify"],
+      "default": "auto"
+    },
+    "textAlignVertical": {
+      "kind": "enum",
+      "values": ["auto", "top", "bottom", "center"],
+      "platformOnly": "android",
+      "notes": "Android only"
+    },
+    "textDecorationColor": {"kind": "color", "platformOnly": "ios", "notes": "iOS only in RN"},
+    "textDecorationLine": {
+      "kind": "enum",
+      "values": ["none", "underline", "line-through", "underline line-through"],
+      "default": "none"
+    },
+    "textDecorationStyle": {
+      "kind": "enum",
+      "values": ["solid", "double", "dotted", "dashed"],
+      "platformOnly": "ios",
+      "notes": "iOS only in RN"
+    },
+    "textShadowColor": {"kind": "color"},
+    "textShadowOffset": {"kind": "shadow-offset", "notes": "{ width, height }"},
+    "textShadowRadius": {"kind": "number"},
+    "textTransform": {
+      "kind": "enum",
+      "values": ["none", "uppercase", "lowercase", "capitalize"],
+      "default": "none"
+    },
+    "top": {"kind": "length-or-percentage", "notes": "physical edge"},
+    "transform": {"kind": "transform-array", "notes": "[{ translateX }, { translateY }, { rotate }, { scale }, ...]"},
+    "transformOrigin": {"kind": "string", "notes": "default '50% 50% 0'"},
+    "userSelect": {
+      "kind": "enum",
+      "values": ["auto", "none", "text", "contain", "all"],
+      "default": "auto"
+    },
+    "verticalAlign": {
+      "kind": "enum",
+      "values": ["auto", "top", "bottom", "middle"],
+      "platformOnly": "android",
+      "notes": "Android only equivalent of textAlignVertical"
+    },
+    "viewBox": {"kind": "tuple", "rnExtension": "react-native-svg", "notes": "SVG viewBox — [width, height] in @pulp/react usage"},
+    "width": {"kind": "length-or-percentage-or-auto"},
+    "writingDirection": {
+      "kind": "enum",
+      "values": ["auto", "ltr", "rtl"],
+      "platformOnly": "ios",
+      "default": "auto",
+      "notes": "iOS only in RN; superseded by direction on cross-platform"
+    },
+    "zIndex": {"kind": "number"}
+  },
+  "bridgeFunctions": {
+    "_doc": "List of widget_bridge.cpp register_function setX names referenced by rn entries' mapsTo. Used by the adapter to detect catalog claims about bridge functions that don't actually exist.",
+    "registered": [
+      "setBackfaceVisibility", "setBackground", "setBackgroundGradient",
+      "setBorder", "setBorderBottomColor", "setBorderBottomLeftRadius",
+      "setBorderBottomRightRadius", "setBorderBottomWidth", "setBorderColor",
+      "setBorderLeftColor", "setBorderLeftWidth", "setBorderRadius",
+      "setBorderRightColor", "setBorderRightWidth", "setBorderSide",
+      "setBorderTopColor", "setBorderTopLeftRadius", "setBorderTopRightRadius",
+      "setBorderTopWidth", "setBorderWidth", "setBottom", "setBoxShadow",
+      "setCursor", "setFilter", "setFlex", "setFontSize", "setFontStyle",
+      "setFontWeight", "setLeft", "setLetterSpacing", "setLineHeight",
+      "setOpacity", "setOverflow", "setPointerEvents", "setPosition",
+      "setRight", "setSvgFill", "setSvgPath", "setSvgStroke",
+      "setSvgStrokeWidth", "setSvgViewBox", "setText", "setTextAlign",
+      "setTextColor", "setTextDecoration", "setTextTransform", "setTop",
+      "setTransform", "setTransformOrigin", "setUserSelect", "setVisible",
+      "setZIndex"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Third of five surface adapters for the bridge-hardening harness sprint
(umbrella pulp #1387). Builds on the yoga template shipped in PR #1395
(commit 51bf7cc8) and walks all 120 `rn/*` entries in `compat.json`,
classifying each through `prop-applier.ts` switch cases, the actually-
registered `widget_bridge.cpp` setX functions, and a static RN-0.79
oracle.

* Adapter: `tools/harness/adapters/rn.py`
* Oracle: `tools/harness/oracles/rn/{README.md, rn-viewstyle.json}`
* Tests: `test/harness/test_rn_adapter.py` (20 cases — 14 classifier + 5 e2e + 1 CLI smoke)
* Wire-up: 2-line patch to `tools/harness/verifier.py` (import + ADAPTERS dict entry)
* Regenerated `docs/reports/harness-coverage.md` with both yoga and rn rows

## Coverage (this branch, rn surface)

| Surface | Total | PASS | DIVERGE | NO-OP | NOT-IMPL | OOS | PASS % | Progress % | Drift |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| `yoga/` | 53 | 7 | 28 | 0 | 18 | 0 | 13.2% | 66.0% | 23 |
| `rn/` | 120 | 26 | 26 | 0 | 56 | 12 | 21.7% | 43.3% | 32 |
| **TOTAL** | 173 | 33 | 54 | 0 | 74 | 12 | 19.1% | 50.3% | 55 |

The 12 OOS entries are platform-only props (iOS `shadow*` /
`textDecoration*` / `writingDirection`, Android `textAlignVertical` /
`verticalAlign`) that the catalog flagged as `missing`; the harness
correctly reframes them as out-of-scope for the cross-platform pulp
surface. The 32-entry drift list is dominated by `supported`-claimed
props with `unsupportedValues` listing missing % / string / unitless
variants — legitimate DIVERGE flags worth reviewing.

## Why an alias-aware adapter

RN ViewStyle's truth source isn't a single file like Yoga's
`FlexStyle`; it's the @pulp/react JSX prop router. Several catalog
entries route through differently-named prop-applier cases (e.g.
`rn/backgroundColor` → `background` prop, `rn/color` → `textColor`
prop, `rn/flexDirection` → `direction` prop alias). The adapter's
`mapsTo` parser handles three alias patterns:

* `"<name> prop -> setX"` (background, textColor)
* `"prop-applier 'X' -> ..."` (direction alias for flexDirection)
* `"prop-applier.ts: 'X' -> ..."` (svg props: d, fill, stroke, viewBox)

It also cross-checks every `setX` identifier in `mapsTo` against the
actually-registered bridge function list (embedded in the oracle as
`bridgeFunctions.registered`). A claim citing an unregistered `setX`
becomes a DIVERGE — surfacing documentation-vs-reality drift.

## Hard-rule compliance (per agent prompt)

* Touches only the rn-surface files plus the 2-line `verifier.py`
  ADAPTERS-dict registration. Did not edit `status.py`, `verifier.py`
  beyond the dict, `adapters/base.py`, oracle/yoga, or any sibling
  surface (css/canvas2d/html).
* No catalog "missing" entries fixed — measure-not-fix per spec.
* No dependency changes.
* No Spectr-side work.

## Test plan

- [x] `python3 -m unittest discover -s test/harness` — 35 pass (19 yoga
  unchanged + 16 rn new).
- [x] `python3 tools/harness/verifier.py --surface=rn --json` returns
  the expected 120-entry coverage payload.
- [x] `python3 tools/harness/verifier.py --surface=yoga --surface=rn`
  produces a combined report; yoga distribution unchanged
  (7/28/0/18/0).
- [x] All 120 rn entries classify without exceptions.

Refs pulp #1387 (umbrella), #1391 (verifier core, shipped), #1392
(per-surface adapters, third of 5), #1393 (reference oracles, third of
5), #1394 (CLI + first coverage report).