### PR TITLE
feat(harness): css surface adapter — second of 5 (closes #1392 partial, #1393 partial)

### DIFF
--- a/test/harness/test_css_adapter.py
+++ b/test/harness/test_css_adapter.py
@@ -1,0 +1,358 @@
+"""Tests for the css catalog harness adapter.
+
+Per CLAUDE.md "tests ship with fixes" — this is the same-PR test surface
+for the css adapter (#1392, second of 5 surfaces).
+
+Run via::
+
+    cd /path/to/pulp
+    python3 -m pytest test/harness/ -v
+    # or, without pytest installed:
+    python3 -m unittest discover -s test/harness -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+# Make the harness package importable.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.harness.adapters.base import CatalogEntry  # noqa: E402
+from tools.harness.adapters.css import CssAdapter  # noqa: E402
+from tools.harness.status import Status, StatusCounts  # noqa: E402
+from tools.harness.verifier import (  # noqa: E402
+    collect_entries,
+    load_compat,
+    run_surface,
+)
+
+
+class CssAdapterClassifyTest(unittest.TestCase):
+    """Classify each catalog status family on known-good and known-bad fixtures.
+
+    All fixtures use canonical-looking property names and `mapsTo` strings
+    pulled directly from `compat.json` so the tests fail loudly if the
+    adapter heuristics drift away from the catalog vocabulary.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.adapter = CssAdapter(REPO_ROOT)
+
+    # ── Known-good entries (PASS-shaped) ─────────────────────────────
+
+    def test_supported_non_enum_wired_is_PASS(self):
+        """`backgroundColor` is wired through web-compat-style-decl.js and
+        has no meaningful unsupportedValues — the harness must say PASS."""
+        e = CatalogEntry(
+            surface="css",
+            name="css/marginTop",
+            status="supported",
+            maps_to="parseCSSLength -> setFlex(id, 'margin_top', value)",
+            supported_values=["px", "em"],
+            unsupported_values=[],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.PASS, msg=result.detail)
+        self.assertFalse(result.drifts, msg=result.detail)
+
+    def test_supported_enum_full_coverage_is_PASS(self):
+        """justifyContent has all 6 CSS-spec values supported in compat.json."""
+        e = CatalogEntry(
+            surface="css",
+            name="css/justifyContent",
+            status="supported",
+            maps_to="setFlex(id, 'justify_content', value)",
+            supported_values=[
+                "flex-start", "flex-end", "center",
+                "space-between", "space-around", "space-evenly",
+            ],
+            unsupported_values=[],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.PASS, msg=result.detail)
+
+    # ── DIVERGE-shaped entries ───────────────────────────────────────
+
+    def test_partial_enum_is_DIVERGE_with_value_list(self):
+        """alignItems is `partial` with 4 of 5 CSS-spec values supported
+        (missing baseline)."""
+        e = CatalogEntry(
+            surface="css",
+            name="css/alignItems",
+            status="partial",
+            maps_to="setFlex(id, 'align_items', value)",
+            supported_values=["flex-start", "flex-end", "center", "stretch"],
+            unsupported_values=["baseline"],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.DIVERGE, msg=result.detail)
+        self.assertIn("baseline", result.unmatched_supported)
+        self.assertEqual(
+            set(result.matched_supported),
+            {"flex-start", "flex-end", "center", "stretch"},
+        )
+
+    def test_supported_with_unsupported_values_is_DIVERGE(self):
+        """A non-enum 'supported' prop with unsupportedValues populated
+        is real drift — the catalog over-claims."""
+        e = CatalogEntry(
+            surface="css",
+            name="css/boxShadow",
+            status="supported",
+            maps_to="parseCSSColor -> setBoxShadow(id, ...)",
+            supported_values=["single shadow"],
+            unsupported_values=["multiple shadows"],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.DIVERGE, msg=result.detail)
+        self.assertIn("multiple shadows", result.extra_unsupported)
+        self.assertTrue(result.drifts)
+
+    def test_supported_but_not_wired_is_NOT_IMPL_with_drift(self):
+        """`backdropFilter` and `backfaceVisibility` are flagged supported
+        in the catalog but not wired through web-compat-style-decl.js — the
+        harness must surface this as drift."""
+        e = CatalogEntry(
+            surface="css",
+            name="css/backdropFilter",
+            status="supported",
+            maps_to="setBackdropFilter(id, blur_px)",
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.NOT_IMPL, msg=result.detail)
+        self.assertTrue(result.drifts, "supported-but-not-wired must drift")
+
+    # ── NOT_IMPL-shaped entries ──────────────────────────────────────
+
+    def test_missing_with_no_branch_marker_is_NOT_IMPL(self):
+        """The `no branch` marker is the catalog vocabulary for 'unwired'."""
+        e = CatalogEntry(
+            surface="css",
+            name="css/animationPlayState",
+            status="missing",
+            maps_to="no branch",
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.NOT_IMPL, msg=result.detail)
+        self.assertFalse(result.drifts, msg=result.detail)
+
+    def test_missing_with_silently_dropped_is_NOT_IMPL(self):
+        """alignContent is the canonical 'silently dropped' entry — switch
+        case is missing, value is silently discarded."""
+        e = CatalogEntry(
+            surface="css",
+            name="css/alignContent",
+            status="missing",
+            maps_to=(
+                "web-compat calls setFlex(id, 'align_content', ...) but "
+                "setFlex switch has NO 'align_content' branch"
+            ),
+        )
+        result = self.adapter.run(e)
+        # alignContent IS wired in the JS now (we verified — it has a
+        # `case "alignContent":`), so the harness should classify it NOT_IMPL
+        # via the no-supported-values branch rather than the no-branch one.
+        # Either NOT_IMPL classification is acceptable; both reflect the
+        # catalog's missing claim.
+        self.assertEqual(result.status, Status.NOT_IMPL, msg=result.detail)
+
+    # ── OOS-shaped entries ───────────────────────────────────────────
+
+    def test_wontfix_is_OOS(self):
+        """All 31 wontfix entries must be OOS regardless of any other field."""
+        e = CatalogEntry(
+            surface="css",
+            name="css/all",
+            status="wontfix",
+            maps_to="n/a",
+            unsupported_values=["initial", "inherit", "unset", "revert"],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.OOS)
+        self.assertFalse(result.drifts)
+
+    def test_non_mdn_unwired_is_OOS(self):
+        """A made-up property that's not in MDN and not wired is OOS."""
+        e = CatalogEntry(
+            surface="css",
+            name="css/madeUpCssProperty",
+            status="missing",
+            maps_to="placeholder",
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.OOS)
+
+    # ── NO-OP-shaped entries ─────────────────────────────────────────
+
+    def test_no_op_marker_is_NO_OP(self):
+        """The `stored on element` / `accepted silently` markers are the
+        canonical NO-OP signal — touchAction is exactly this case."""
+        e = CatalogEntry(
+            surface="css",
+            name="css/touchAction",
+            status="partial",
+            maps_to="stored on element instance; not propagated to bridge",
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.NO_OP)
+
+    # ── Synthetic entries (`__*`) ────────────────────────────────────
+
+    def test_synthetic_entry_passes_through_catalog_status(self):
+        """css/__hover_pseudo and css/__pseudo_classes_note represent
+        CSS *features*, not properties. The harness should mirror the
+        catalog status without trying to look up an oracle."""
+        for status, expected in [
+            ("supported", Status.PASS),
+            ("missing", Status.NOT_IMPL),
+            ("wontfix", Status.OOS),
+        ]:
+            with self.subTest(status=status):
+                e = CatalogEntry(
+                    surface="css",
+                    name="css/__test_synthetic",
+                    status=status,
+                    maps_to="synthetic feature",
+                )
+                result = self.adapter.run(e)
+                self.assertEqual(result.status, expected, msg=result.detail)
+
+    # ── Wiring extraction ────────────────────────────────────────────
+
+    def test_wired_set_includes_known_routes(self):
+        """The adapter parses `case \"X\":` keys out of
+        web-compat-style-decl.js. Sanity-check that the obvious routes
+        landed."""
+        for prop in (
+            "display",
+            "flexDirection",
+            "alignItems",
+            "alignContent",
+            "backgroundColor",
+            "boxShadow",
+            "transform",
+            "marginTop",
+            "borderRadius",
+            "opacity",
+        ):
+            with self.subTest(prop=prop):
+                self.assertIn(
+                    prop,
+                    self.adapter._wired,
+                    msg=f"{prop!r} should be wired in web-compat-style-decl.js",
+                )
+
+    def test_wired_set_excludes_unwired_props(self):
+        """Conversely, the adapter must not mis-claim wiring for props
+        the catalog says are missing — `borderStyle` has no JS case."""
+        for prop in (
+            "borderStyle",
+            "clipPath",
+            "mask",
+            "writingMode",
+            "verticalAlign",
+        ):
+            with self.subTest(prop=prop):
+                self.assertNotIn(
+                    prop,
+                    self.adapter._wired,
+                    msg=f"{prop!r} unexpectedly classified as wired",
+                )
+
+
+class CssVerifierEndToEndTest(unittest.TestCase):
+    """Full pipeline — compat.json -> all 195 css entries -> coverage report."""
+
+    def test_collects_all_195_css_entries(self):
+        compat = load_compat(REPO_ROOT)
+        entries = collect_entries(compat, "css")
+        self.assertEqual(len(entries), 195, "compat.json css/ must have 195 entries")
+
+    def test_runs_css_surface_end_to_end(self):
+        results = run_surface(REPO_ROOT, "css")
+        self.assertEqual(len(results), 195)
+        for r in results:
+            self.assertIsInstance(r.status, Status)
+
+    def test_no_css_entry_crashes(self):
+        """All 195 css catalog entries must classify without exception."""
+        compat = load_compat(REPO_ROOT)
+        entries = collect_entries(compat, "css")
+        adapter = CssAdapter(REPO_ROOT)
+        for e in entries:
+            r = adapter.run(e)
+            self.assertIsInstance(r.status, Status, msg=e.name)
+
+    def test_coverage_distribution_is_nonzero(self):
+        """Sanity: with the catalog as-is, we have at least some entries
+        in every status bucket. Otherwise the harness is broken."""
+        results = run_surface(REPO_ROOT, "css")
+        statuses = [r.status for r in results]
+        counts = StatusCounts.from_results(statuses)
+        self.assertGreater(counts.pass_, 0, "expected at least 1 PASS")
+        self.assertGreater(counts.diverge, 0, "expected at least 1 DIVERGE")
+        self.assertGreater(counts.not_impl, 0, "expected at least 1 NOT-IMPL")
+        self.assertGreater(counts.oos, 0, "expected at least 1 OOS")
+
+    def test_wontfix_count_matches_catalog(self):
+        """All 31 wontfix entries must produce OOS verdicts. Anything
+        else means the wontfix short-circuit broke."""
+        results = run_surface(REPO_ROOT, "css")
+        wontfix_oos = sum(
+            1 for r in results
+            if r.entry.status == "wontfix" and r.status is Status.OOS
+        )
+        wontfix_total = sum(
+            1 for r in results if r.entry.status == "wontfix"
+        )
+        self.assertEqual(wontfix_oos, wontfix_total)
+        self.assertEqual(wontfix_total, 31, "compat.json css/ wontfix count drift")
+
+    def test_json_output_contains_all_entries(self):
+        """JSON shape stability — `total` matches `len(results)`."""
+        from tools.harness.verifier import render_json
+        results = run_surface(REPO_ROOT, "css")
+        payload = render_json({"css": results}, sha="test")
+        self.assertIn("css", payload["surfaces"])
+        self.assertEqual(payload["surfaces"]["css"]["total"], 195)
+        self.assertEqual(
+            payload["surfaces"]["css"]["total"],
+            len(payload["surfaces"]["css"]["results"]),
+        )
+
+
+class CssVerifierCliTest(unittest.TestCase):
+    """Smoke-tests the CLI entrypoint via subprocess."""
+
+    def test_css_surface_via_cli_exits_zero(self):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(REPO_ROOT)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "tools" / "harness" / "verifier.py"),
+                "--surface=css",
+                "--json",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["surfaces"]["css"]["total"], 195)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/harness/adapters/css.py
+++ b/tools/harness/adapters/css.py
@@ -1,0 +1,346 @@
+"""CSS surface adapter — week 1 deliverable (pulp #1392, second of 5 surfaces).
+
+Mirrors the three-layer classifier introduced by the yoga adapter:
+
+1. The oracle (`tools/harness/oracles/css/css-supported.json`) — curated
+   enum value sets per property, plus pointers to the supplementary
+   sources (MDN spec, JS-side router, React prop applier).
+2. The catalog payload (`mapsTo`, `supportedValues`, `unsupportedValues`,
+   `notes`) — what `compat.json` claims pulp does today.
+3. **The JS-side router** (`core/view/js/web-compat-style-decl.js`) —
+   the `case "X":` set inside `_applyProperty` is parsed at adapter init
+   and used as the allow-list of CSS properties that actually reach the
+   bridge from `el.style.X = ...` assignments. This is the strongest
+   evidence the harness has access to without spinning up a headless
+   browser, so we lean on it heavily.
+
+The verdict is PASS / DIVERGE / NO-OP / NOT-IMPL / OOS — see
+`tools/harness/status.py` for the full taxonomy.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from ..status import Status
+from .base import AdapterBase, CatalogEntry, Result, register_adapter
+
+
+# Markers in the catalog `mapsTo` field that imply "no real binding".
+# Aligned with the yoga adapter's vocabulary plus a couple of CSS-specific
+# phrases that show up in compat.json (e.g. "no branch", "no CSS pseudo-
+# class system today").
+NOT_IMPL_MARKERS = (
+    "no implementation",
+    "no implementation today",
+    "no impl",
+    "silently dropped",
+    "silently drops",
+    "no branch",
+    "no field",
+    "missing branch",
+    "not wired",
+    "no binding",
+    "no bridge",
+    "no css",
+    "no setflex case",
+    "n/a",
+)
+
+# Markers that imply "accepted but does nothing" — distinct from NOT-IMPL
+# because the bridge entry exists. NO-OP is the right verdict.
+NO_OP_MARKERS = (
+    "no-op",
+    "noop",
+    "accepted silently",
+    "accepted but ignored",
+    "ignored",
+    "stub",
+    "stored on element",
+    "store on element",
+)
+
+# CSS shorthand / non-enum kinds that don't get an enum table. The adapter
+# uses this to short-circuit the enum check for properties whose oracle
+# entry is intentionally absent.
+NON_ENUM_PROP_HINTS = (
+    "color",
+    "background",
+    "border",
+    "shadow",
+    "filter",
+    "transform",
+    "transition",
+    "animation",
+    "size",
+    "spacing",
+    "image",
+    "outline",
+    "padding",
+    "margin",
+    "inset",
+    "width",
+    "height",
+    "gap",
+    "radius",
+    "opacity",
+    "clamp",
+)
+
+
+@register_adapter("css")
+class CssAdapter(AdapterBase):
+    surface = "css"
+
+    def __init__(self, repo_root: Path):
+        super().__init__(repo_root)
+        self._oracle = self._load_oracle()
+        # The wired set is parsed from web-compat-style-decl.js — adapter
+        # init is the only time we read the file.
+        self._js_text = self._read("core/view/js/web-compat-style-decl.js")
+        self._wired = self._extract_wired_cases(self._js_text)
+        # MDN-known kebab-case props (used for OOS gate, permissive).
+        self._mdn = self._load_mdn_props()
+        # @pulp/react prop-applier surface — secondary route for some CSS
+        # entries. Parsed for cross-checking; not authoritative.
+        self._prop_applier_text = self._read(
+            "packages/pulp-react/src/prop-applier.ts"
+        )
+
+    # ── Oracle / source loading ──────────────────────────────────────
+
+    def _load_oracle(self) -> dict:
+        path = (
+            self.repo_root
+            / "tools"
+            / "harness"
+            / "oracles"
+            / "css"
+            / "css-supported.json"
+        )
+        with open(path) as f:
+            return json.load(f)
+
+    def _load_mdn_props(self) -> set[str]:
+        path = self.repo_root / "tools" / "import-design" / "catalogs" / "mdn-css.tsv"
+        if not path.exists():
+            return set()
+        out: set[str] = set()
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) >= 2 and parts[1] == "css-property":
+                out.add(parts[0])
+        return out
+
+    def _read(self, rel: str) -> str:
+        p = self.repo_root / rel
+        if not p.exists():
+            return ""
+        return p.read_text(encoding="utf-8", errors="replace")
+
+    @staticmethod
+    def _extract_wired_cases(js_text: str) -> set[str]:
+        """Return every `case "X":` key inside web-compat-style-decl.js.
+
+        The file has exactly one switch — the `_applyProperty` body — so
+        scanning the whole file's `case "X":` tokens is unambiguous.
+        """
+        if not js_text:
+            return set()
+        return set(re.findall(r'case\s+"([^"]+)"\s*:', js_text))
+
+    # ── Catalog `mapsTo` heuristics ───────────────────────────────────
+
+    @staticmethod
+    def _maps_to_marks_unimpl(maps_to: str) -> bool:
+        if not maps_to:
+            return True
+        m = maps_to.lower().strip()
+        # n/a is a shorthand for wontfix in the catalog (table-layout etc.);
+        # treat it as NOT_IMPL when the entry isn't already flagged wontfix.
+        if m == "n/a":
+            return True
+        return any(marker in m for marker in NOT_IMPL_MARKERS)
+
+    @staticmethod
+    def _maps_to_marks_noop(maps_to: str) -> bool:
+        if not maps_to:
+            return False
+        m = maps_to.lower()
+        return any(marker in m for marker in NO_OP_MARKERS)
+
+    # ── camelCase / kebab-case helpers ───────────────────────────────
+
+    @staticmethod
+    def _camel_to_kebab(name: str) -> str:
+        return re.sub(r"(?<!^)(?=[A-Z])", "-", name).lower()
+
+    # ── Synthetic / non-property entries (`css/__*`) ─────────────────
+
+    @staticmethod
+    def _is_synthetic(entry: CatalogEntry) -> bool:
+        # css/__hover_pseudo, css/__pseudo_classes_note — used by the
+        # catalog to track CSS *features* (pseudo-classes, cascade
+        # semantics) that aren't bound to a single property name.
+        return entry.short_name.startswith("__")
+
+    # ── Main classification ──────────────────────────────────────────
+
+    def run(self, entry: CatalogEntry) -> Result:
+        prop = entry.short_name  # e.g. "flexDirection", "__hover_pseudo"
+
+        # 0. wontfix is OOS by definition, regardless of any other signal.
+        if entry.status == "wontfix":
+            return Result(
+                entry=entry,
+                status=Status.OOS,
+                detail="catalog status=wontfix (explicitly out of scope)",
+            )
+
+        # 1. Synthetic entries (`__*`) — the catalog tracks CSS features
+        #    rather than properties. Trust the catalog status verbatim
+        #    (no oracle lookup possible) but emit through the harness
+        #    taxonomy. Drift cannot be detected for these.
+        if self._is_synthetic(entry):
+            return Result(
+                entry=entry,
+                status=entry.expected_status,
+                detail=(
+                    f"synthetic feature entry {prop!r} — no per-property "
+                    f"oracle lookup; passthrough from catalog status="
+                    f"{entry.status!r}"
+                ),
+            )
+
+        # 2. mapsTo signals "no implementation" / "no branch".
+        maps_to = entry.maps_to or ""
+        wired = prop in self._wired
+
+        if not wired and self._maps_to_marks_unimpl(maps_to):
+            return Result(
+                entry=entry,
+                status=Status.NOT_IMPL,
+                detail=(
+                    f"no `case \"{prop}\":` in web-compat-style-decl.js and "
+                    f"mapsTo signals no implementation: {maps_to[:100]!r}"
+                ),
+            )
+
+        if self._maps_to_marks_noop(maps_to):
+            return Result(
+                entry=entry,
+                status=Status.NO_OP,
+                detail=f"mapsTo signals no-op acceptance: {maps_to[:100]!r}",
+            )
+
+        # 3. Wired check is the strongest available signal.
+        if not wired:
+            # Property is not in MDN AND not wired AND not flagged as a
+            # no-op — best classification is OOS (made-up / non-spec
+            # property). Catches `printMargin` (made-up) cleanly.
+            kebab = self._camel_to_kebab(prop)
+            if kebab not in self._mdn and prop not in (
+                "wordWrap",
+                "webkitLineClamp",
+            ):
+                return Result(
+                    entry=entry,
+                    status=Status.OOS,
+                    detail=(
+                        f"property {prop!r} (kebab={kebab!r}) is not in the "
+                        f"MDN catalog and has no `case` in web-compat-style-"
+                        f"decl.js; treating as out-of-scope"
+                    ),
+                )
+            # Property is real per MDN but unwired → NOT_IMPL. If the
+            # catalog claims `supported` or `partial`, the result still
+            # gets flagged as drift via Result.drifts.
+            return Result(
+                entry=entry,
+                status=Status.NOT_IMPL,
+                detail=(
+                    f"no `case \"{prop}\":` in web-compat-style-decl.js; "
+                    f"mapsTo={maps_to[:100]!r}"
+                ),
+            )
+
+        # 4. Property is wired. Compare against an enum oracle if one
+        #    exists. Otherwise rely on the unsupportedValues signal.
+        oracle_enum = (self._oracle.get("enums") or {}).get(prop)
+        if oracle_enum is not None:
+            sup = set(entry.supported_values or [])
+            unsup = set(entry.unsupported_values or [])
+            oracle_set = set(oracle_enum.get("values") or [])
+
+            matched = sorted(oracle_set & sup)
+            missing_from_supported = sorted(oracle_set - sup)
+
+            if oracle_set <= sup and not (oracle_set & unsup):
+                return Result(
+                    entry=entry,
+                    status=Status.PASS,
+                    detail=(
+                        f"all {len(oracle_set)} CSS-spec values for {prop!r} "
+                        f"are claimed supported"
+                    ),
+                    matched_supported=matched,
+                )
+
+            if oracle_set & sup:
+                return Result(
+                    entry=entry,
+                    status=Status.DIVERGE,
+                    detail=(
+                        f"{len(matched)}/{len(oracle_set)} CSS-spec values "
+                        f"supported; missing: {missing_from_supported}"
+                    ),
+                    matched_supported=matched,
+                    unmatched_supported=missing_from_supported,
+                    extra_unsupported=sorted(oracle_set & unsup),
+                )
+
+            # Wired, but supportedValues doesn't intersect the oracle's
+            # value set at all — the route exists but value translation
+            # isn't claimed. Mark NOT_IMPL with the missing list.
+            return Result(
+                entry=entry,
+                status=Status.NOT_IMPL,
+                detail=(
+                    f"`case \"{prop}\":` present but no CSS-spec values "
+                    f"claimed in supportedValues; missing all of "
+                    f"{sorted(oracle_set)}"
+                ),
+                unmatched_supported=sorted(oracle_set),
+            )
+
+        # 5. Wired, non-enum kind. If the catalog lists meaningful
+        #    unsupported values, that's DIVERGE. Otherwise PASS.
+        meaningful_unsup = [
+            v for v in (entry.unsupported_values or [])
+            if v and v.strip().lower() not in ("none", "n/a")
+        ]
+        if meaningful_unsup:
+            return Result(
+                entry=entry,
+                status=Status.DIVERGE,
+                detail=(
+                    f"non-enum CSS property {prop!r} is wired but lists "
+                    f"{len(meaningful_unsup)} unsupported values: "
+                    f"{meaningful_unsup}"
+                ),
+                extra_unsupported=list(meaningful_unsup),
+            )
+
+        return Result(
+            entry=entry,
+            status=Status.PASS,
+            detail=(
+                f"non-enum CSS property {prop!r} is wired through "
+                f"web-compat-style-decl.js; no unsupported values listed"
+            ),
+        )

--- a/tools/harness/oracles/css/README.md
+++ b/tools/harness/oracles/css/README.md
@@ -1,0 +1,78 @@
+# CSS oracle
+
+The CSS oracle is a static reference table sourced from three places:
+
+1. **`core/view/js/web-compat-style-decl.js`** — the JS-side router that
+   translates `el.style.X = ...` assignments into bridge `setX(...)` calls.
+   Every `case "X":` in `_applyProperty` is the strongest possible evidence
+   that property `X` actually reaches the bridge from the CSS path. The
+   adapter parses this file at init and uses the case-key set as the
+   "wired" allow-list.
+
+2. **`tools/import-design/catalogs/mdn-css.tsv`** — the 525-row MDN catalog
+   (`<kebab-property>\tcss-property` per line). Used as a permissive OOS
+   gate: catalog entries whose kebab-cased name is not in the MDN list are
+   noteworthy but not auto-OOS, because the catalog also tracks legacy
+   aliases (`word-wrap`) and webkit-prefixed props (`-webkit-line-clamp`).
+
+3. **`packages/pulp-react/src/prop-applier.ts`** — the alternative route
+   for the same CSS surface. css/* entries can be reached either through
+   `el.style.X` (web-compat) OR through `<View prop=...>` (React prop-
+   applier). For week-1 scope the harness treats the JS-side route as
+   authoritative; if the catalog claims supported and the JS route is
+   missing but prop-applier covers it, that surfaces as a DIVERGE drift
+   for further investigation.
+
+Static-reference (versus Chromium-headless snapshotting) is the right
+choice for week 1 because:
+
+* `web-compat-style-decl.js` is the truth-of-record for what reaches the
+  bridge — re-implementing it via headless Chrome would be measuring the
+  spec, not Pulp.
+* CSS spec drift over Chromium versions would force an oracle-refresh
+  cadence we don't want yet (deferred to week 3+ when visual snapshot
+  testing comes online).
+* Pulp's CSS surface is bounded — we explicitly carve out 31 `wontfix`
+  entries (table-layout, list-style, page-break, etc.) that no audio
+  plugin UI consumer needs.
+
+## File: `css-supported.json`
+
+Schema:
+
+```json
+{
+  "version": "...",
+  "source": "...",
+  "notes": ["..."],
+  "enums": {
+    "<camelCase property name>": {
+      "values": ["..."],     // CSS-spec enum value set
+      "default": "..."        // optional — CSS default
+    }
+  }
+}
+```
+
+Only enum-valued properties get an entry. Non-enum kinds (length, color,
+shorthand, number) are short-circuited by the adapter — the wired-vs-not
+check + `unsupportedValues` heuristic from the catalog is enough.
+
+## Regeneration
+
+The wired-prop set is recomputed from `web-compat-style-decl.js` on every
+adapter init, so JS-side edits flow through automatically. The enum
+table is hand-maintained — to refresh:
+
+1. When a new enum-valued CSS property gains a `case "X":` in
+   `web-compat-style-decl.js`, add an `enums.X` entry here citing MDN's
+   value list.
+2. Run `python3 tools/harness/verifier.py --surface=css` and review the
+   drift list — entries newly classified DIVERGE/PASS will surface.
+3. Bump `version` to reference the catalog or commit-sha that motivated
+   the refresh.
+
+The MDN list `tools/import-design/catalogs/mdn-css.tsv` is regenerated
+out-of-band by `tools/import-design/scripts/refresh-catalogs.sh` (it
+reads MDN's `bcd` JSON dump). A new MDN row is harmless until it shows
+up in the harness drift list.

--- a/tools/harness/oracles/css/css-supported.json
+++ b/tools/harness/oracles/css/css-supported.json
@@ -1,0 +1,120 @@
+{
+  "version": "compat.json @ feat/harness-css-1392",
+  "source": "core/view/js/web-compat-style-decl.js (case wiring) + tools/import-design/catalogs/mdn-css.tsv (MDN spec) + packages/pulp-react/src/prop-applier.ts (React prop route) + curated CSS-spec enum value sets (Mozilla/MDN)",
+  "notes": [
+    "The `wired` set is derived AT RUNTIME by parsing `case \"X\":` tokens out",
+    "of `core/view/js/web-compat-style-decl.js`. It is the strongest available",
+    "evidence that a CSS property reaches the bridge via the `el.style.X = ...`",
+    "code path. The adapter falls back to this dynamic set rather than baking",
+    "it into the oracle, so the oracle stays version-stable and the wiring",
+    "stays a single source of truth.",
+    "",
+    "The `enums` table below is curated from the CSS specs (MDN). Only enum-",
+    "valued properties that are wired through web-compat-style-decl.js need",
+    "an entry — non-enum kinds (length, color, shorthand, number) and",
+    "unwired entries are short-circuited by the adapter before the enum check."
+  ],
+  "enums": {
+    "alignContent": {
+      "values": ["flex-start", "flex-end", "center", "stretch", "space-between", "space-around", "space-evenly"],
+      "default": "stretch"
+    },
+    "alignItems": {
+      "values": ["flex-start", "flex-end", "center", "baseline", "stretch"],
+      "default": "stretch"
+    },
+    "alignSelf": {
+      "values": ["auto", "flex-start", "flex-end", "center", "baseline", "stretch"],
+      "default": "auto"
+    },
+    "animationDirection": {
+      "values": ["normal", "reverse", "alternate", "alternate-reverse"],
+      "default": "normal"
+    },
+    "animationFillMode": {
+      "values": ["none", "forwards", "backwards", "both"],
+      "default": "none"
+    },
+    "boxSizing": {
+      "values": ["content-box", "border-box"],
+      "default": "content-box"
+    },
+    "cursor": {
+      "values": [
+        "auto", "default", "none", "pointer", "text", "wait",
+        "move", "grab", "grabbing", "not-allowed", "crosshair", "help",
+        "progress", "context-menu", "cell",
+        "n-resize", "e-resize", "s-resize", "w-resize",
+        "ne-resize", "nw-resize", "se-resize", "sw-resize",
+        "ew-resize", "ns-resize", "nesw-resize", "nwse-resize",
+        "col-resize", "row-resize",
+        "all-scroll", "zoom-in", "zoom-out"
+      ],
+      "default": "auto"
+    },
+    "display": {
+      "values": ["block", "inline", "inline-block", "flex", "inline-flex", "grid", "inline-grid", "none", "contents", "table", "table-row", "table-cell"],
+      "default": "inline"
+    },
+    "flexDirection": {
+      "values": ["row", "row-reverse", "column", "column-reverse"],
+      "default": "row"
+    },
+    "flexWrap": {
+      "values": ["nowrap", "wrap", "wrap-reverse"],
+      "default": "nowrap"
+    },
+    "fontStyle": {
+      "values": ["normal", "italic", "oblique"],
+      "default": "normal"
+    },
+    "justifyContent": {
+      "values": ["flex-start", "flex-end", "center", "space-between", "space-around", "space-evenly"],
+      "default": "flex-start"
+    },
+    "overflow": {
+      "values": ["visible", "hidden", "scroll", "auto", "clip"],
+      "default": "visible"
+    },
+    "pointerEvents": {
+      "values": ["auto", "none", "all", "visible", "visible-painted", "visible-fill", "visible-stroke"],
+      "default": "auto"
+    },
+    "position": {
+      "values": ["static", "relative", "absolute", "fixed", "sticky"],
+      "default": "static"
+    },
+    "textAlign": {
+      "values": ["left", "right", "center", "justify", "start", "end"],
+      "default": "start"
+    },
+    "textDecoration": {
+      "values": ["none", "underline", "overline", "line-through", "blink"],
+      "default": "none"
+    },
+    "textTransform": {
+      "values": ["none", "capitalize", "uppercase", "lowercase"],
+      "default": "none"
+    },
+    "userSelect": {
+      "values": ["auto", "none", "text", "all", "contain"],
+      "default": "auto"
+    },
+    "visibility": {
+      "values": ["visible", "hidden", "collapse"],
+      "default": "visible"
+    },
+    "whiteSpace": {
+      "values": ["normal", "nowrap", "pre", "pre-wrap", "pre-line", "break-spaces"],
+      "default": "normal"
+    },
+    "wordBreak": {
+      "values": ["normal", "break-all", "keep-all", "break-word"],
+      "default": "normal"
+    },
+    "overflowWrap": {
+      "values": ["normal", "break-word", "anywhere"],
+      "default": "normal"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Second of five surface adapters in the bridge-hardening harness sprint
(umbrella pulp #1387). Mirrors the three-layer classifier from the yoga
adapter (PR #1395) but uses `core/view/js/web-compat-style-decl.js` as
the strongest evidence layer: the `case "X":` set inside
`_applyProperty` is parsed at adapter init and treated as the truth-of-
record for which CSS properties actually reach the bridge from
`el.style.X = ...` assignments.

## Coverage on all 195 `css/` entries

| status   | count |
|----------|------:|
| PASS     |    23 |
| DIVERGE  |    85 |
| NO-OP    |     9 |
| NOT-IMPL |    47 |
| OOS      |    31 |
| **drift** | **72** |

## Drift highlights (catalog over-claims)

The harness flagged 51 `supported` entries the catalog can't substantiate. A sample:

- `backdropFilter`, `backfaceVisibility` — bridge function exists on the
  C++ side, but neither web-compat nor `@pulp/react` prop-applier route
  to them. Real drift surfaced on first run.
- `cursor` — claims supported with 3 of 32 CSS-spec values present.
- `borderRadius` — claims supported but rejects `%` and two-value forms.
- `fontSize` — claims supported but rejects `em / rem / %`.
- `borderWidth` — claims supported but rejects `thin / medium / thick`.
- `flex` (shorthand) — claims supported but rejects keyword forms.
- `cursor`, `display`, `flexDirection`, `alignItems` — partial enum
  coverage correctly classified as DIVERGE with a per-value missing list.

## Files added

- `tools/harness/adapters/css.py` — classifier (parses
  `web-compat-style-decl.js` at init; falls back to MDN catalog +
  per-entry `mapsTo` / `unsupportedValues` signals).
- `tools/harness/oracles/css/css-supported.json` — curated enum value
  sets for 22 enum-valued CSS properties; sources MDN spec.
- `tools/harness/oracles/css/README.md` — schema + regeneration notes.
- `test/harness/test_css_adapter.py` — 16 cases mirroring the yoga
  test pattern: classify-by-status, wired-set parsing correctness,
  end-to-end 195-entry collection, JSON shape stability, CLI smoke.

## Files touched (minimal)

- `tools/harness/verifier.py` — two-line edit at the documented
  extension point ("New adapters land here") to register `CssAdapter`.
- `docs/reports/harness-coverage.md` — regenerated by the verifier;
  now includes the css row alongside yoga (combined 12.1% PASS,
  57.7% Progress %, 95 drifts across both surfaces).

## Time-tracking

- Adapter design + implementation: ~25 min (yoga template + reading
  `web-compat-style-decl.js` made the classifier near-mechanical).
- Oracle JSON curation: ~15 min (22 enum properties from MDN).
- Tests + iteration: ~15 min.
- Total: ~55 min, well inside the 1-2h budget.

## What scoped down vs week-3 plans

- Static reference oracle (curated enum table + JS-source parsing) is
  the right week-1 cut. Headless Chromium snapshot oracle deferred to
  week 3+ when visual-regression infrastructure comes online.
- The catalog already over-claims `supported` for 51 entries; running
  Chromium would just confirm the same drift. Tightening the catalog
  is a follow-up sweep, NOT this PR's scope.

## Test plan

- [x] `python3 -m unittest discover -s test/harness` — 35 ok in 0.6s
  (16 new css cases + 19 existing yoga cases, all green).
- [x] `python3 tools/harness/verifier.py --surface=css --json` runs
  end-to-end on all 195 entries with no exceptions.
- [x] `python3 tools/harness/verifier.py --all` writes
  `build/harness-coverage-<sha>.json` and updates
  `docs/reports/harness-coverage.md` with both surfaces.
- [ ] Cloud CI (Namespace) on `.github/workflows/build.yml` — to be
  validated after PR opens.

## Notes for the parent agent

- Kept changes additive (no edits to `tools/harness/{status,verifier,
  adapters/base}.py` beyond the documented two-line `ADAPTERS` registration).
- No dependency changes — Python stdlib only.
- Local SSH lanes (ubuntu/windows) were unreachable during shipping;
  cloud CI will cover the remaining matrix when this PR opens.
