### PR TITLE
fix(view/mac): wire MacGpuWindowHost::set_idle_callback into CVDisplayLink (closes pulp #1387 gap #3)

### DIFF
--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -1673,6 +1673,25 @@ public:
         resize_callback_ = std::move(cb);
     }
 
+    // pulp #1387 gap #3 — wire the host's idle callback into the
+    // CVDisplayLink dispatch so JS rAF / setTimeout / async-result
+    // queues are pumped each vsync. Without this override the GPU
+    // host inherited the WindowHost base no-op, which dropped
+    // standalone's `scripted_ui->poll()` on the floor: every
+    // requestAnimationFrame() call would queue a callback, set
+    // needs_repaint_=true via request_repaint, render one frame —
+    // and then never fire the JS callback because nothing called
+    // poll_async_results to drain pending_frame_ids_. The CPU host
+    // has set_idle_callback wired to a 30Hz NSTimer (line ~1429);
+    // GPU is now wired vsync-aligned via the display link instead
+    // of a separate timer to keep pump cadence locked to the same
+    // frame the renderer is about to emit.
+    void set_idle_callback(std::function<void()> cb) override {
+        idle_callback_ = std::move(cb);
+        has_idle_callback_.store(static_cast<bool>(idle_callback_),
+                                  std::memory_order_release);
+    }
+
     void run_event_loop() override {
         @autoreleasepool {
             [NSApplication sharedApplication];
@@ -1769,6 +1788,11 @@ private:
     int frame_ok_count_ = 0;
     float width_ = 0, height_ = 0;
     ResizeCallback resize_callback_;
+    // pulp #1387 gap #3 — idle callback wiring. CVDisplayLink reads
+    // has_idle_callback_ on the display thread; idle_callback_ is
+    // invoked on main only.
+    std::function<void()> idle_callback_;
+    std::atomic<bool> has_idle_callback_{false};
 
     static bool view_needs_continuous_frames(View* view) {
         if (!view) return false;
@@ -1934,8 +1958,17 @@ private:
         CVOptionFlags, CVOptionFlags*, void* context)
     {
         auto* self = static_cast<MacGpuWindowHost*>(context);
+        // pulp #1387 gap #3 — guard now also fires when an idle
+        // callback is installed, so JS rAF / setTimeout / async-result
+        // queues get a vsync-paced pump even when no native widget is
+        // animating and no prior request_repaint set needs_repaint_.
+        // The idle pump (`scripted_ui->poll()` → `bridge.poll_async_results()`)
+        // drains pending_frame_ids_ via __flushFrames__ and re-arms
+        // needs_repaint_ for any frame that requested another paint.
+        const bool has_idle = self->has_idle_callback_.load(std::memory_order_acquire);
         if (self->needs_repaint_.load(std::memory_order_relaxed) ||
-            self->continuous_frames_.load(std::memory_order_relaxed)) {
+            self->continuous_frames_.load(std::memory_order_relaxed) ||
+            has_idle) {
             bool expected = false;
             if (!self->render_dispatch_queued_.compare_exchange_strong(expected, true,
                                                                        std::memory_order_acq_rel,
@@ -1945,6 +1978,13 @@ private:
             // Dispatch rendering to the main thread (required for Cocoa + Metal)
             dispatch_async(dispatch_get_main_queue(), ^{
                 @autoreleasepool {
+                    // Pump idle FIRST so JS rAF callbacks fire (and any
+                    // request_repaint they trigger arms needs_repaint_)
+                    // before we evaluate whether to render this frame.
+                    if (self->idle_callback_) {
+                        self->idle_callback_();
+                    }
+
                     bool animate = view_needs_continuous_frames(&self->root_);
                     bool tick_subscribers = self->frame_clock_.has_active_subscribers();
                     if (!self->needs_repaint_.load(std::memory_order_relaxed) && !animate && !tick_subscribers) {

--- a/test/test_view_host_bridge_mac.mm
+++ b/test/test_view_host_bridge_mac.mm
@@ -68,6 +68,63 @@ TEST_CASE("macOS WindowHost reports content size and fires resize callbacks",
     }
 }
 
+// pulp #1387 gap #3 — GPU `MacGpuWindowHost` previously inherited the
+// `WindowHost` base no-op for `set_idle_callback`, so standalone's
+// `scripted_ui->poll()` (which flushes JS rAF / setTimeout / async
+// queues via `bridge.poll_async_results()`) was silently dropped.
+// Spectr's filterbank canvas could call `requestAnimationFrame(cb)`
+// 60×/sec but `cb` never ran until a pointer event happened to call
+// `request_repaint`, which is why the spectrum needed mouse motion to
+// animate. The fix wires `set_idle_callback` into the CVDisplayLink
+// dispatch so the idle pump runs each vsync.
+//
+// This regression locks in the symbol-level override: the GPU host
+// must accept and store the callback (not silently drop it). A full
+// vsync-driven integration test would require driving the display
+// link from a Catch2 fixture, which `[NSApp run]` blocks; the
+// behavioral contract (`poll_async_results` flushes pending rAFs +
+// `request_repaint`s) is already covered by
+// `test_widget_bridge.cpp`'s issue-921 cases.
+TEST_CASE("macOS GPU WindowHost accepts set_idle_callback (pulp #1387 gap #3)",
+          "[view][hosts][gpu][issue-1387]") {
+    @autoreleasepool {
+        [NSApplication sharedApplication];
+
+        View root;
+        WindowOptions opts;
+        opts.title = "WindowHost issue-1387";
+        opts.width = 200.0f;
+        opts.height = 200.0f;
+        opts.use_gpu = true;
+
+        auto host = WindowHost::create(root, opts);
+        if (!host) {
+            // GPU build path unavailable (no Skia / no Dawn) — skip.
+            SUCCEED("GPU host unavailable in this build");
+            return;
+        }
+
+        // Install + clear must both be no-throw and idempotent. Before
+        // the fix, set_idle_callback dispatched to the base class no-op
+        // which dropped the callback on the floor; after the fix the
+        // override stores it and arms `has_idle_callback_` for the
+        // display-link guard.
+        host->set_idle_callback([] {});
+        host->set_idle_callback({});
+        host->set_idle_callback([] {});
+
+        // Re-installing must not crash or leak the previous callback's
+        // captures (std::function move-assignment handles this; pin it
+        // so a future refactor can't regress).
+        std::vector<int> sink;
+        host->set_idle_callback([&sink] { sink.push_back(1); });
+        host->set_idle_callback({});
+        REQUIRE(sink.empty());
+
+        host->hide();
+    }
+}
+
 // pulp #992 — `-[PulpView mouseUp:]` SIGSEGV regression test.
 //
 // Repro: a click on a child View triggers a state change (in real apps,


### PR DESCRIPTION
## Summary

Closes pulp #1387 gap #3.

GPU host previously inherited the `WindowHost` base no-op for `set_idle_callback`, silently dropping standalone's `scripted_ui->poll()` callback. JS `requestAnimationFrame` / `setTimeout` / async-result queues never got a host pump on the GPU path — spectrum animations, rAF loops, and any vsync-driven JS code only advanced when an unrelated mouse / resize event happened to call `request_repaint`.

This is the root cause for several Spectr-tracked symptoms:
- [C] Spectr: mouse-move drives waveform animation (should be procedural-only)
- [D] Spectr: spectrum doesn't auto-animate on idle

## Fix

`MacGpuWindowHost` now overrides `set_idle_callback`, stores the callback, and invokes it from the `CVDisplayLink` dispatch each vsync — *before* the `needs_repaint` / `continuous_frames` check so any rAF callback's `request_repaint` arms the same frame for rendering.

CPU host already had this override (~30Hz NSTimer); GPU now matches behaviorally and is vsync-aligned, which keeps pump cadence locked to the same frame the renderer is about to emit.

## Why not also fix Windows / Linux GPU hosts?

Same gap exists on those platforms (only Mac CPU + Mac GPU have any `set_idle_callback` override at all), but each is an independent platform port. Filing as separate follow-ups.

## Test plan
- [x] Build `pulp-view` clean — verified locally on macOS arm64
- [x] New test: `macOS GPU WindowHost accepts set_idle_callback (pulp #1387 gap #3)` — symbol-level idempotency
- [x] Regression: `pulp-test-view-host-bridge` passes (38 assertions / 6 cases)
- [x] Regression: `pulp-test-widget-bridge [issue-921]` passes (rAF→repaint chain still wired)
- [x] Regression: full `pulp-test-widget-bridge` (709 assertions / 96 cases)
- [ ] CI: macOS / Ubuntu / Windows full matrix
- [ ] Manual validation: Spectr standalone — verify spectrum auto-animates on idle without mouse motion

## Notes
- A full vsync-driven integration test would require driving the display link from a Catch2 fixture, but `[NSApp run]` blocks. The behavioral contract (`poll_async_results` flushes pending rAFs + emits repaints) is already covered by `test_widget_bridge.cpp`'s issue-921 cases, and the GPU override is now exercised end-to-end whenever Spectr launches.
- Diff-coverage gate skipped locally (missing `llvm-profdata` / `llvm-cov`); CI will run it.