### PR TITLE
fix(view/ios): wire IOSGpuWindowHost::set_idle_callback into CADisplayLink (closes pulp #1402 — iOS slice)

### DIFF
--- a/.agents/skills/ios/SKILL.md
+++ b/.agents/skills/ios/SKILL.md
@@ -297,6 +297,16 @@ Builds the `.appex` only. The App Store container host-app target is authored se
 
 Touched here because `core/format/src/au_view_controller_ios.mm` is dual-owned by `ios` + `auv3` + `view-bridge`. The view controller's ivars `_bridge`, `_viewHost`, `_fallbackView` are destroyed in REVERSE declaration order by the runtime; the resulting sequence (host destroyed before bridge) is what makes the `root_.set_plugin_view_host(nullptr)` call in `~PluginViewHost` safe. Calling `_bridge->close()` explicitly in `dealloc` reverses that order, frees the View first, and the host's destructor then dereferences a dangling reference — crashes AUv3 editor close. Codex P1 review on PR #653. Full rationale lives in the `auv3` skill under "PulpAUViewController::dealloc — never call `_bridge->close()` explicitly".
 
+### iOS GPU host must run idle_callback inside the CADisplayLink tick (pulp #1402)
+
+`IOSGpuWindowHost::tick()` (in `core/view/platform/ios/window_host_ios.mm`) is the per-vsync entry point and MUST invoke `idle_callback_()` BEFORE the `needs_repaint` check. Without this, JS `requestAnimationFrame` / `setTimeout` / async-result queues never fire on iOS GPU because `set_idle_callback` was inheriting the `WindowHost` base class no-op (parallel gap to the macOS one fixed in PR #1400 and the Android one in #1404).
+
+The fix is two pieces:
+1. Override `set_idle_callback` to store the callback in a non-atomic field (CADisplayLink fires on `mainRunLoop` so the read-and-invoke happens on main only — no atomic guard needed unlike macOS GPU's CV thread).
+2. In `tick()`, run `idle_callback_()` first; the callback can `request_repaint`, which arms `needs_repaint_` and triggers `render_frame()` in the same tick.
+
+CPU iOS host (`IOSWindowHost`) has the same gap but no display link; `repaint()` just calls `[root_view_ setNeedsDisplay]` and UIKit drives `drawRect:` only on user interaction. A separate CADisplayLink-on-CPU-path fix is owed; not blocking AUv3 use cases since AUv3 host apps go through the GPU path.
+
 ## See Also
 
 - `android` skill — parallel structure for Android NDK.

--- a/core/view/platform/ios/window_host_ios.mm
+++ b/core/view/platform/ios/window_host_ios.mm
@@ -396,6 +396,15 @@ public:
     }
 
     void tick() {
+        // pulp #1402 / #1387 gap #3 (iOS parity with macOS PR #1400) —
+        // pump JS rAF / setTimeout / async-result queues each vsync.
+        // Without this, requestAnimationFrame(cb) callbacks queue
+        // forever and only fire when an unrelated touch event triggers
+        // a poll. Run the idle callback first so any request_repaint
+        // it triggers arms needs_repaint_ for the same vsync tick.
+        if (idle_callback_) {
+            idle_callback_();
+        }
         if (needs_repaint_.exchange(false, std::memory_order_relaxed)) {
             render_frame();
         }
@@ -403,6 +412,16 @@ public:
 
     void set_close_callback(std::function<void()> cb) override {
         close_callback_ = std::move(cb);
+    }
+
+    void set_idle_callback(std::function<void()> cb) override {
+        // pulp #1402 — wire the host's idle callback into the
+        // CADisplayLink dispatch (see tick()). Mirrors the macOS GPU
+        // host fix in PR #1400; before the override existed the base
+        // class no-op silently dropped standalone's
+        // `scripted_ui->poll()`, so JS animation queues never
+        // got a vsync-paced pump.
+        idle_callback_ = std::move(cb);
     }
 
     void set_resize_callback(ResizeCallback cb) override {
@@ -489,6 +508,10 @@ private:
     std::unique_ptr<render::GpuSurface> gpu_surface_;
     std::unique_ptr<render::SkiaSurface> skia_surface_;
     std::function<void()> close_callback_;
+    // pulp #1402 — idle callback wiring for iOS GPU host. tick() reads
+    // and invokes on the main thread (CADisplayLink fires on main
+    // run loop in NSRunLoopCommonModes), so no atomic is needed.
+    std::function<void()> idle_callback_;
     std::atomic<bool> needs_repaint_{false};
     CADisplayLink* display_link_ = nil;
     PulpIOSDisplayLinkTarget* display_link_target_ = nil;


### PR DESCRIPTION
## Summary

Closes pulp #1402 (iOS slice — companion to macOS #1400 and Android #1404).

`IOSGpuWindowHost::tick()` is the per-vsync entry point but never called any bridge service or poll function. JS `requestAnimationFrame` / `setTimeout` / async-result queues never fired on iOS GPU because `set_idle_callback` was inheriting the `WindowHost` base no-op.

## Symptoms (now fixed)

- `requestAnimationFrame(loop)` chain queues forever, never animates
- `setTimeout(cb, 100)` never fires
- Animations only advance during touch events

## Fix

Two pieces:
1. **Override `set_idle_callback`** to store the callback. CADisplayLink fires on `mainRunLoop` so a non-atomic `std::function` is sufficient — no atomic guard needed unlike the Mac CV-thread path.
2. **Invoke `idle_callback_()` at the top of `tick()`** before the `needs_repaint` exchange. Any `request_repaint` triggered by an rAF callback arms `needs_repaint_` for the same vsync tick.

## Out of scope

CPU iOS host (`IOSWindowHost`, line 227) has the same gap but no display link; `repaint()` just calls `[root_view_ setNeedsDisplay]` and UIKit drives `drawRect:` only on user interaction. A separate CADisplayLink-on-CPU fix is owed but not blocking AUv3 use cases — those go through GPU.

## Test plan

- [x] Bridge contract (`poll_async_results` flushes pending rAFs + emits repaints) covered by `test_widget_bridge.cpp`'s `[issue-921]` cases
- [x] ios skill updated with new gotcha section
- [ ] Simulator/device manual integration validation (iOS CI not yet wired — known gap per ios skill follow-ups)

## Cross-platform sweep status (#1402 umbrella)

- [x] **macOS** — PR #1400 (CI in flight)
- [x] **Android** — PR #1404 (CI in flight)
- [x] **iOS GPU** — this PR
- [ ] **iOS CPU** — separate, not blocking
- [ ] **Linux/Windows (SDL)** — separate; SDL host's render loop has the same gap

## Notes

- Diff-coverage gate skipped locally (missing `llvm-profdata` / `llvm-cov`); CI will run it.
- ios skill update touches `core/view/platform/ios/**` mapped path; SKILL.md updated in same commit.