### PR TITLE
fix(view/css): translate `text-overflow: ellipsis` to native truncation (closes #1407)

### DIFF
--- a/core/view/include/pulp/view/text_overflow.hpp
+++ b/core/view/include/pulp/view/text_overflow.hpp
@@ -57,13 +57,17 @@ inline std::size_t utf8_codepoint_count(std::string_view text) {
 /// Otherwise return the longest UTF-8 prefix of `text` that — appended
 /// with U+2026 — still fits. Falls back to "…" alone if no prefix fits.
 ///
+/// `available_width <= 0.0f` (zero / collapsed content-box) returns
+/// "…" rather than the original — leaking the full text on a tiny
+/// button defeats the whole point of the feature.
+///
 /// Uses binary search over codepoint indices, so cost is
 /// O(log N · measure_text). The caller is responsible for setting the
 /// canvas's font state before invoking; this helper only measures.
 inline std::string truncate_to_width(canvas::Canvas& canvas,
                                      std::string_view text,
                                      float available_width) {
-    if (available_width <= 0.0f) return std::string(text);
+    if (available_width <= 0.0f) return std::string(kEllipsis);
     if (canvas.measure_text(std::string(text)) <= available_width)
         return std::string(text);
 

--- a/core/view/include/pulp/view/text_overflow.hpp
+++ b/core/view/include/pulp/view/text_overflow.hpp
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+//
+// pulp #1407 — CSS `text-overflow: ellipsis` truncation helper.
+//
+// Translates a string to its ellipsised form when its measured width
+// exceeds the available content-box. Operates on UTF-8 codepoints so
+// truncation never splits a multibyte sequence, and uses U+2026 (…)
+// rather than three ASCII dots, matching CSS behavior.
+
+#pragma once
+
+#include <pulp/canvas/canvas.hpp>
+#include <string>
+#include <string_view>
+
+namespace pulp::view {
+
+/// UTF-8 horizontal ellipsis character (U+2026, "…"). Three bytes:
+/// 0xE2 0x80 0xA6. Exposed for tests that need to assert paint output.
+inline constexpr const char* kEllipsis = "\xe2\x80\xa6";
+
+/// Walk forward over UTF-8 leading bytes. Returns the byte index after
+/// `count` codepoints, or text.size() if `count` runs off the end.
+inline std::size_t utf8_advance(std::string_view text, std::size_t count) {
+    std::size_t i = 0;
+    while (count > 0 && i < text.size()) {
+        unsigned char c = static_cast<unsigned char>(text[i]);
+        if (c < 0x80)        i += 1;
+        else if (c < 0xC0)   i += 1;        // stray continuation byte → skip
+        else if (c < 0xE0)   i += 2;
+        else if (c < 0xF0)   i += 3;
+        else                 i += 4;
+        if (i > text.size()) i = text.size();
+        --count;
+    }
+    return i;
+}
+
+/// Count the number of UTF-8 leading-byte codepoints in `text`. Stray
+/// continuation bytes are skipped silently (best-effort, never panics).
+inline std::size_t utf8_codepoint_count(std::string_view text) {
+    std::size_t n = 0;
+    for (std::size_t i = 0; i < text.size();) {
+        unsigned char c = static_cast<unsigned char>(text[i]);
+        if (c < 0x80)        i += 1;
+        else if (c < 0xC0)   i += 1;
+        else if (c < 0xE0)   i += 2;
+        else if (c < 0xF0)   i += 3;
+        else                 i += 4;
+        if (i > text.size()) i = text.size();
+        ++n;
+    }
+    return n;
+}
+
+/// If `text` already fits within `available_width`, return it as-is.
+/// Otherwise return the longest UTF-8 prefix of `text` that — appended
+/// with U+2026 — still fits. Falls back to "…" alone if no prefix fits.
+///
+/// Uses binary search over codepoint indices, so cost is
+/// O(log N · measure_text). The caller is responsible for setting the
+/// canvas's font state before invoking; this helper only measures.
+inline std::string truncate_to_width(canvas::Canvas& canvas,
+                                     std::string_view text,
+                                     float available_width) {
+    if (available_width <= 0.0f) return std::string(text);
+    if (canvas.measure_text(std::string(text)) <= available_width)
+        return std::string(text);
+
+    const std::size_t total = utf8_codepoint_count(text);
+    if (total == 0) return std::string(text);
+
+    // Reserve at least the ellipsis itself.
+    if (canvas.measure_text(kEllipsis) > available_width) {
+        // Even "…" doesn't fit — return "…" anyway so callers can still
+        // signal truncation. The widget will visually clip via its
+        // bounding box.
+        return std::string(kEllipsis);
+    }
+
+    // Binary search for the largest codepoint prefix that fits with "…".
+    std::size_t lo = 0;          // always fits (with ellipsis) — invariant: 0-prefix + "…"
+    std::size_t hi = total;      // never fits at hi (we know total doesn't fit)
+    while (lo + 1 < hi) {
+        std::size_t mid = (lo + hi) / 2;
+        std::string candidate(text.substr(0, utf8_advance(text, mid)));
+        candidate.append(kEllipsis);
+        if (canvas.measure_text(candidate) <= available_width) lo = mid;
+        else                                                    hi = mid;
+    }
+
+    std::string out(text.substr(0, utf8_advance(text, lo)));
+    out.append(kEllipsis);
+    return out;
+}
+
+} // namespace pulp::view

--- a/core/view/src/buttons.cpp
+++ b/core/view/src/buttons.cpp
@@ -1,5 +1,7 @@
 #include <pulp/view/buttons.hpp>
 #include <pulp/canvas/canvas.hpp>
+#include <pulp/view/text_overflow.hpp>
+#include <algorithm>
 
 namespace pulp::view {
 
@@ -20,12 +22,18 @@ void TextButton::paint(canvas::Canvas& canvas) {
     canvas.set_line_width(1.0f);
     canvas.stroke_rect(0, 0, w, h);
 
-    // Label
+    // Label — pulp #1407 honors CSS text-overflow: ellipsis when set on
+    // the button via setTextOverflow(id, "ellipsis"). Reserves a small
+    // horizontal padding so the ellipsis doesn't touch the rounded edge.
     auto text_color = enabled_ ? canvas::Color::rgba(220, 220, 230) : canvas::Color::rgba(120, 120, 130);
     canvas.set_fill_color(text_color);
     canvas.set_font("system", 14.0f);
-    float text_w = canvas.measure_text(label_);
-    canvas.fill_text(label_, (w - text_w) / 2.0f, h * 0.65f);
+    constexpr float kButtonHPad = 8.0f;
+    std::string draw_label = text_overflow_ellipsis()
+        ? truncate_to_width(canvas, label_, std::max(0.0f, w - kButtonHPad * 2.0f))
+        : label_;
+    float text_w = canvas.measure_text(draw_label);
+    canvas.fill_text(draw_label, (w - text_w) / 2.0f, h * 0.65f);
 }
 
 void TextButton::on_mouse_down(Point) {

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -4,6 +4,7 @@
 #include <pulp/view/animation.hpp>
 #include <pulp/view/frame_clock.hpp>
 #include <pulp/view/image_cache.hpp>
+#include <pulp/view/text_overflow.hpp>
 #include <pulp/view/window_host.hpp>
 #include <pulp/canvas/text_shaper.hpp>
 #include <choc/text/choc_JSON.h>
@@ -456,23 +457,14 @@ void Label::paint(canvas::Canvas& canvas) {
     }
 
     if (!multi_line_) {
-        // Text overflow ellipsis
-        if (text_overflow_ellipsis() && effective_text_align == LabelAlign::left) {
-            float avail = bounds().width;
-            float text_w = canvas.measure_text(display_text);
-            if (text_w > avail && display_text.size() > 3) {
-                std::string truncated = display_text;
-                while (truncated.size() > 1) {
-                    truncated.pop_back();
-                    float w = canvas.measure_text(truncated + "...");
-                    if (w <= avail) {
-                        canvas.fill_text(truncated + "...", x, baseline_y);
-                        goto decoration;
-                    }
-                }
-            }
-        }
-        canvas.fill_text(display_text, x, baseline_y);
+        // pulp #1407 — CSS `text-overflow: ellipsis`. Truncate with U+2026
+        // when the measured text exceeds the content-box, regardless of
+        // text-align (CSS truncates at the trailing edge for all three).
+        // UTF-8-safe via codepoint binary-search in truncate_to_width().
+        std::string draw_text = text_overflow_ellipsis()
+            ? truncate_to_width(canvas, display_text, bounds().width)
+            : display_text;
+        canvas.fill_text(draw_text, x, baseline_y);
     } else {
         float y = effective_font_size * 0.85f;
         size_t pos = 0;
@@ -486,7 +478,6 @@ void Label::paint(canvas::Canvas& canvas) {
     }
 
     // Text decoration (underline, line-through, overline)
-    decoration:
     if (text_decoration_ != TextDecoration::none) {
         auto dec_color = has_decoration_color_ ? decoration_color_ : text_color;
         canvas.set_stroke_color(dec_color);

--- a/core/view/src/widgets.cpp
+++ b/core/view/src/widgets.cpp
@@ -456,14 +456,18 @@ void Label::paint(canvas::Canvas& canvas) {
             break;
     }
 
+    // pulp #1407 — track the actually-painted single-line string so the
+    // decoration block below measures the truncated text, not the
+    // original. Multi-line keeps using display_text since it paints the
+    // full string across multiple draw calls.
+    std::string draw_text = display_text;
     if (!multi_line_) {
         // pulp #1407 — CSS `text-overflow: ellipsis`. Truncate with U+2026
         // when the measured text exceeds the content-box, regardless of
         // text-align (CSS truncates at the trailing edge for all three).
         // UTF-8-safe via codepoint binary-search in truncate_to_width().
-        std::string draw_text = text_overflow_ellipsis()
-            ? truncate_to_width(canvas, display_text, bounds().width)
-            : display_text;
+        if (text_overflow_ellipsis())
+            draw_text = truncate_to_width(canvas, display_text, bounds().width);
         canvas.fill_text(draw_text, x, baseline_y);
     } else {
         float y = effective_font_size * 0.85f;
@@ -482,7 +486,10 @@ void Label::paint(canvas::Canvas& canvas) {
         auto dec_color = has_decoration_color_ ? decoration_color_ : text_color;
         canvas.set_stroke_color(dec_color);
         canvas.set_line_width(1.0f);
-        float text_w = canvas.measure_text(display_text);
+        // pulp #1407 — measure the actually-drawn (possibly truncated)
+        // text so a decoration line on an ellipsised label doesn't
+        // escape past the visible glyphs.
+        float text_w = canvas.measure_text(draw_text);
         float draw_x = x;
         if (effective_text_align == LabelAlign::center) draw_x = x - text_w * 0.5f;
         else if (effective_text_align == LabelAlign::right) draw_x = x - text_w;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1489,6 +1489,11 @@ add_executable(pulp-test-typography-inheritance test_typography_inheritance.cpp)
 target_link_libraries(pulp-test-typography-inheritance PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-typography-inheritance)
 
+# Text-overflow ellipsis helper — pulp #1407
+add_executable(pulp-test-text-overflow test_text_overflow.cpp)
+target_link_libraries(pulp-test-text-overflow PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-text-overflow)
+
 # Editor bridge tests (pulp #709 — renderer-agnostic envelope/dispatcher)
 add_executable(pulp-test-editor-bridge test_editor_bridge.cpp)
 target_link_libraries(pulp-test-editor-bridge PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -333,6 +333,31 @@ TEST_CASE("TextButton paint covers enabled hover and disabled states",
     REQUIRE_FALSE(btn.is_enabled());
 }
 
+// pulp #1407 — CSS `text-overflow: ellipsis` on a TextButton truncates the
+// painted label so a long string never bleeds past the rounded background.
+TEST_CASE("TextButton paint truncates long labels with U+2026 when text-overflow set",
+          "[gui][button][issue-1407]") {
+    static constexpr const char* kEllipsis = "\xe2\x80\xa6";
+
+    TextButton btn("Mid-band attenuation with high-shelf compensation");
+    btn.set_bounds({0, 0, 80, 28});
+    btn.set_text_overflow_ellipsis(true);
+
+    RecordingCanvas canvas;
+    btn.paint(canvas);
+
+    std::string drawn;
+    int fill_text_count = 0;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == DrawCommand::Type::fill_text) { drawn = cmd.text; ++fill_text_count; }
+    }
+    REQUIRE(fill_text_count == 1);
+    REQUIRE(drawn.size() >= 3);
+    REQUIRE(drawn.compare(drawn.size() - 3, 3, kEllipsis) == 0);
+    // Drawn label fits inside the button minus its 8 px horizontal padding.
+    REQUIRE(canvas.measure_text(drawn) <= 80.0f - 16.0f);
+}
+
 TEST_CASE("HyperlinkButton paint underlines only while hovered",
           "[gui][button][coverage]") {
     HyperlinkButton link("Docs", "https://example.invalid/docs");

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -358,6 +358,32 @@ TEST_CASE("TextButton paint truncates long labels with U+2026 when text-overflow
     REQUIRE(canvas.measure_text(drawn) <= 80.0f - 16.0f);
 }
 
+// pulp #1407 (Codex post-merge sweep) — a TextButton narrower than its
+// 2 × 8 px horizontal padding budget collapses the available text-box
+// to ≤ 0. Without the non-positive guard inside truncate_to_width, the
+// helper would short-circuit to the full string and visibly leak the
+// label past the button's rounded background. After the guard the
+// tiny button paints just "…", which is what the bounding box can hold.
+TEST_CASE("TextButton paint with tiny width still truncates instead of leaking the label",
+          "[gui][button][issue-1407]") {
+    static constexpr const char* kEllipsis = "\xe2\x80\xa6";
+
+    TextButton btn("Mid-band attenuation with high-shelf compensation");
+    btn.set_bounds({0, 0, 12, 28});  // 12 < 2 * 8 px padding
+    btn.set_text_overflow_ellipsis(true);
+
+    RecordingCanvas canvas;
+    btn.paint(canvas);
+
+    std::string drawn;
+    int fill_text_count = 0;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == DrawCommand::Type::fill_text) { drawn = cmd.text; ++fill_text_count; }
+    }
+    REQUIRE(fill_text_count == 1);
+    REQUIRE(drawn == kEllipsis);
+}
+
 TEST_CASE("HyperlinkButton paint underlines only while hovered",
           "[gui][button][coverage]") {
     HyperlinkButton link("Docs", "https://example.invalid/docs");

--- a/test/test_text_overflow.cpp
+++ b/test/test_text_overflow.cpp
@@ -71,6 +71,18 @@ TEST_CASE("truncate_to_width returns lone ellipsis when ellipsis itself doesn't 
     REQUIRE(out == kEllipsis);
 }
 
+TEST_CASE("truncate_to_width returns ellipsis when available_width is non-positive",
+          "[view][text-overflow][issue-1407]") {
+    // Codex post-merge sweep: a TextButton with width <= 16 px passes 0
+    // (or negative) here after subtracting its 8 px horizontal padding.
+    // Returning the original string would visibly leak the unwrapped
+    // label past the button's rounded background — exactly the symptom
+    // pulp #1407 is meant to eliminate.
+    RecordingCanvas canvas;
+    REQUIRE(truncate_to_width(canvas, "Mid-band attenuation", 0.0f) == kEllipsis);
+    REQUIRE(truncate_to_width(canvas, "anything", -3.0f) == kEllipsis);
+}
+
 TEST_CASE("utf8 helpers count and advance over leading bytes correctly",
           "[view][text-overflow][issue-1407]") {
     REQUIRE(utf8_codepoint_count("hello") == 5);

--- a/test/test_text_overflow.cpp
+++ b/test/test_text_overflow.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+//
+// pulp #1407 — focused unit tests for the truncate_to_width helper that
+// translates CSS `text-overflow: ellipsis` into a UTF-8-safe truncated
+// string. Pairs with the integration tests in test_widgets.cpp and
+// test_gui_components.cpp that drive Label/TextButton paint paths.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/view/text_overflow.hpp>
+
+using namespace pulp::canvas;
+using namespace pulp::view;
+
+// RecordingCanvas::measure_text returns 7 px per byte. ASCII chars are
+// 1 byte each, so plain ASCII strings cost 7 px per character. We reuse
+// pulp::view::kEllipsis (UTF-8 0xE2 0x80 0xA6) from the helper header.
+
+TEST_CASE("truncate_to_width returns input verbatim when it already fits",
+          "[view][text-overflow][issue-1407]") {
+    RecordingCanvas canvas;
+    REQUIRE(truncate_to_width(canvas, "ok", 100.0f) == "ok");
+    REQUIRE(truncate_to_width(canvas, "", 100.0f) == "");
+}
+
+TEST_CASE("truncate_to_width appends U+2026 when text overflows",
+          "[view][text-overflow][issue-1407]") {
+    RecordingCanvas canvas;
+    auto out = truncate_to_width(canvas, "Mid-band attenuation with high-shelf compensation", 100.0f);
+    REQUIRE(out.size() >= 3);
+    REQUIRE(out.compare(out.size() - 3, 3, kEllipsis) == 0);
+    REQUIRE(canvas.measure_text(out) <= 100.0f);
+    // Should not be the unmodified input.
+    REQUIRE(out != "Mid-band attenuation with high-shelf compensation");
+}
+
+TEST_CASE("truncate_to_width never splits a multibyte UTF-8 codepoint",
+          "[view][text-overflow][issue-1407]") {
+    RecordingCanvas canvas;
+    // "ñoño" has two 2-byte codepoints (ñ = 0xC3 0xB1) plus two 1-byte
+    // codepoints, total 6 bytes. Mix with ASCII so the truncation point
+    // lands inside a multibyte sequence if the helper were buggy.
+    std::string input = "\xc3\xb1o\xc3\xb1o is fine";  // "ñoño is fine"
+    auto out = truncate_to_width(canvas, input, 35.0f);  // ~5 ASCII chars + ellipsis
+    REQUIRE(out.size() >= 3);
+    REQUIRE(out.compare(out.size() - 3, 3, kEllipsis) == 0);
+    // Walk the UTF-8 leading bytes and ensure no continuation byte is a
+    // standalone trailing byte before the ellipsis (i.e. no split).
+    std::size_t i = 0;
+    while (i + 3 < out.size()) {
+        unsigned char c = static_cast<unsigned char>(out[i]);
+        std::size_t step = 1;
+        if (c < 0x80)      step = 1;
+        else if (c < 0xC0) {  // stray continuation byte → bug
+            FAIL("truncated string contains stray UTF-8 continuation byte");
+        } else if (c < 0xE0) step = 2;
+        else if (c < 0xF0) step = 3;
+        else                step = 4;
+        REQUIRE(i + step <= out.size() - 3);  // doesn't split into the ellipsis
+        i += step;
+    }
+}
+
+TEST_CASE("truncate_to_width returns lone ellipsis when ellipsis itself doesn't fit",
+          "[view][text-overflow][issue-1407]") {
+    RecordingCanvas canvas;
+    // RecordingCanvas measures the 3-byte ellipsis at 21 px. With
+    // available_width = 5 px, even the ellipsis alone overflows; the
+    // helper still returns "…" so the widget can clip via its bounds.
+    auto out = truncate_to_width(canvas, "abcdef", 5.0f);
+    REQUIRE(out == kEllipsis);
+}
+
+TEST_CASE("utf8 helpers count and advance over leading bytes correctly",
+          "[view][text-overflow][issue-1407]") {
+    REQUIRE(utf8_codepoint_count("hello") == 5);
+    REQUIRE(utf8_codepoint_count("\xc3\xb1o") == 2);  // "ño"
+    REQUIRE(utf8_codepoint_count("") == 0);
+
+    REQUIRE(utf8_advance("hello", 3) == 3);
+    REQUIRE(utf8_advance("\xc3\xb1o", 1) == 2);  // skip past 2-byte ñ
+    REQUIRE(utf8_advance("hello", 99) == 5);     // clamps to size
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -3771,3 +3771,41 @@ TEST_CASE("WidgetBridge claimOverlay installs dismiss callback that fires "
 
     pulp::view::View::active_overlay_ = nullptr;
 }
+
+// pulp #1407 — CSS translator must route `style.textOverflow = 'ellipsis'`
+// through the `setTextOverflow` bridge call. Stubs the bridge function in
+// JS-land to record the call (ID + mode) so the test verifies BOTH
+// directions: the CSS-translator emits the call AND the resolved value
+// makes it through to the native View flag.
+TEST_CASE("CSSStyleDeclaration translates textOverflow to setTextOverflow bridge call",
+          "[view][bridge][css][issue-1407]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        globalThis.__textOverflowCalls = [];
+        var __native_setTextOverflow = setTextOverflow;
+        setTextOverflow = function(id, mode) {
+            globalThis.__textOverflowCalls.push(id + '|' + mode);
+            return __native_setTextOverflow(id, mode);
+        };
+        createLabel('mytitle', 'long string that will be truncated', '');
+        var stub_el = { _id: 'mytitle', _nativeCreated: true };
+        var sd = new CSSStyleDeclaration(stub_el);
+        sd._applyProperty('textOverflow', 'ellipsis');
+    )");
+
+    auto count = engine.evaluate("globalThis.__textOverflowCalls.length")
+                       .getWithDefault<double>(-1);
+    REQUIRE(count == 1);
+    auto recorded = engine.evaluate("globalThis.__textOverflowCalls[0]")
+                          .getWithDefault<std::string>("");
+    REQUIRE(recorded == "mytitle|ellipsis");
+
+    auto* label = dynamic_cast<Label*>(bridge.widget("mytitle"));
+    REQUIRE(label != nullptr);
+    REQUIRE(label->text_overflow_ellipsis());
+}

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -293,6 +293,83 @@ TEST_CASE("Label paints explicit lines and decorations", "[view][widget]") {
     REQUIRE(canvas.count(DrawCommand::Type::stroke_line) == 1);
 }
 
+// pulp #1407 — CSS `text-overflow: ellipsis` translates to native truncation.
+// RecordingCanvas::measure_text returns 7 px per byte, so a 100 px wide label
+// can fit ≈ 14 ASCII bytes plus the 3-byte U+2026 ellipsis (≈ 21 px) for a
+// 14 + 3 = 17-byte total ≤ 119 px. The truncate_to_width helper must
+// produce a string that ends with "…" (U+2026: 0xE2 0x80 0xA6) and whose
+// measured width ≤ the bounds.
+TEST_CASE("Label paints ellipsis when text-overflow set and text overflows bounds",
+          "[view][widget][issue-1407]") {
+    static constexpr const char* kEllipsis = "\xe2\x80\xa6";
+
+    Label label("Mid-band attenuation with high-shelf compensation");
+    label.set_bounds({0, 0, 100, 24});
+    label.set_text_overflow_ellipsis(true);
+
+    RecordingCanvas canvas;
+    label.paint(canvas);
+
+    auto fills = commands_of(canvas, DrawCommand::Type::fill_text);
+    REQUIRE(fills.size() == 1);
+    const auto& drawn = fills.front().text;
+
+    REQUIRE(drawn.size() >= 3);
+    REQUIRE(drawn.compare(drawn.size() - 3, 3, kEllipsis) == 0);
+    REQUIRE(canvas.measure_text(drawn) <= 100.0f);
+    REQUIRE(drawn != "Mid-band attenuation with high-shelf compensation");
+}
+
+TEST_CASE("Label leaves short text untruncated even when ellipsis is set",
+          "[view][widget][issue-1407]") {
+    Label label("OK");
+    label.set_bounds({0, 0, 200, 24});
+    label.set_text_overflow_ellipsis(true);
+
+    RecordingCanvas canvas;
+    label.paint(canvas);
+
+    auto fills = commands_of(canvas, DrawCommand::Type::fill_text);
+    REQUIRE(fills.size() == 1);
+    REQUIRE(fills.front().text == "OK");
+}
+
+TEST_CASE("Label truncates with center and right alignment too",
+          "[view][widget][issue-1407]") {
+    static constexpr const char* kEllipsis = "\xe2\x80\xa6";
+
+    for (auto align : {LabelAlign::center, LabelAlign::right}) {
+        Label label("Mid-band attenuation with high-shelf compensation");
+        label.set_bounds({0, 0, 100, 24});
+        label.set_text_overflow_ellipsis(true);
+        label.set_text_align(align);
+
+        RecordingCanvas canvas;
+        label.paint(canvas);
+
+        auto fills = commands_of(canvas, DrawCommand::Type::fill_text);
+        REQUIRE(fills.size() == 1);
+        const auto& drawn = fills.front().text;
+        REQUIRE(drawn.size() >= 3);
+        REQUIRE(drawn.compare(drawn.size() - 3, 3, kEllipsis) == 0);
+        REQUIRE(canvas.measure_text(drawn) <= 100.0f);
+    }
+}
+
+TEST_CASE("Label without text-overflow draws full string even if it overflows",
+          "[view][widget][issue-1407]") {
+    Label label("Mid-band attenuation with high-shelf compensation");
+    label.set_bounds({0, 0, 100, 24});
+    // text_overflow_ellipsis defaults to false.
+
+    RecordingCanvas canvas;
+    label.paint(canvas);
+
+    auto fills = commands_of(canvas, DrawCommand::Type::fill_text);
+    REQUIRE(fills.size() == 1);
+    REQUIRE(fills.front().text == "Mid-band attenuation with high-shelf compensation");
+}
+
 TEST_CASE("Label vertical text direction wraps paint in transforms", "[view][widget]") {
     Label label("Gain");
     label.set_bounds({0, 0, 32, 80});

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -356,6 +356,38 @@ TEST_CASE("Label truncates with center and right alignment too",
     }
 }
 
+// pulp #1407 (Codex post-merge sweep) — a decorated ellipsised Label
+// must draw its underline / strikethrough / overline at the truncated
+// width, not the original string's width. Otherwise the line escapes
+// past the visible glyphs into empty bounds.
+TEST_CASE("Label decoration line spans the truncated width when ellipsis truncates",
+          "[view][widget][issue-1407]") {
+    Label label("Mid-band attenuation with high-shelf compensation");
+    label.set_bounds({0, 0, 100, 24});
+    label.set_text_overflow_ellipsis(true);
+    label.set_text_decoration(Label::TextDecoration::underline);
+
+    RecordingCanvas canvas;
+    label.paint(canvas);
+
+    auto fills = commands_of(canvas, DrawCommand::Type::fill_text);
+    REQUIRE(fills.size() == 1);
+    const auto& drawn = fills.front().text;
+    const float drawn_width = canvas.measure_text(drawn);
+
+    auto lines = commands_of(canvas, DrawCommand::Type::stroke_line);
+    REQUIRE(lines.size() == 1);
+    // RecordingCanvas stroke_line stores x0,y0,x1,y1 in f[0..3]; its
+    // span is f[2] - f[0]. The decoration must NOT span the original
+    // (unwrapped) string's width — it must span the drawn-string width.
+    const float decoration_span = lines.front().f[2] - lines.front().f[0];
+    REQUIRE_THAT(decoration_span, WithinAbs(drawn_width, 0.001f));
+    // And that drawn_width is strictly less than what the full text
+    // would have measured — proves we're not falsely passing the test
+    // by accidentally matching the unwrapped width.
+    REQUIRE(drawn_width < canvas.measure_text("Mid-band attenuation with high-shelf compensation"));
+}
+
 TEST_CASE("Label without text-overflow draws full string even if it overflows",
           "[view][widget][issue-1407]") {
     Label label("Mid-band attenuation with high-shelf compensation");


### PR DESCRIPTION
## Summary

Translates CSS `text-overflow: ellipsis` to native widget truncation on Label and TextButton paint paths, closing #1407 and unblocking Spectr's `[A]` dropdown overflow.

The CSS translator and bridge wiring already existed (`web-compat-style-decl.js:308` → `setTextOverflow` → `View::set_text_overflow_ellipsis`). What was missing: paint-time honoring of the flag. The previous Label-only path used three ASCII dots, was UTF-8 unsafe, ran O(N) shrinking, ignored center/right alignment, and skipped strings ≤ 3 bytes.

This PR:

- **Helper**: `core/view/include/pulp/view/text_overflow.hpp` — UTF-8-safe `truncate_to_width(canvas, text, available_width)` that binary-searches codepoint prefixes and appends U+2026 (`…`).
- **Label** (`core/view/src/widgets.cpp:459-467`): single-line paint now calls the helper for **all** alignments.
- **TextButton** (`core/view/src/buttons.cpp:23-35`): honors the flag, reserving 8 px horizontal padding so the ellipsis doesn't touch the rounded edge.
- **Out of scope** (per issue body): `text-overflow: clip` (already no-op), multi-line ellipsis, `white-space: nowrap` (already wired to `Label::set_multi_line(false)`).

After this lands, Spectr's `dom-adapter.tsx:508` "Drop-quietly" list can drop `'textOverflow'`.

## Test plan

Tests ship in the same PR per the project's "tests ship with fixes" rule. All `[issue-1407]` cases pass locally.

- [x] `test/test_text_overflow.cpp` — helper unit tests: passthrough, U+2026 append, UTF-8 safety (mixed `ñ` + ASCII), lone-ellipsis fallback when even `…` overflows, `utf8_advance` / `utf8_codepoint_count`.
- [x] `test/test_widgets.cpp` — Label paint: ellipsis appears in fill_text command for left **and** center/right alignment; short text passes through; widget without `text_overflow_ellipsis` paints full string.
- [x] `test/test_gui_components.cpp` — TextButton paint: drawn label fits `width - 2*8 px` padding and ends with U+2026.
- [x] `test/test_widget_bridge.cpp` — CSS-translator round-trip: `CSSStyleDeclaration._applyProperty('textOverflow','ellipsis')` emits exactly one `setTextOverflow(id, 'ellipsis')` bridge call and the native View flag flips.
- [x] Pre-existing test suites (`pulp-test-widgets`, `pulp-test-gui-components`, `pulp-test-widget-bridge`, `pulp-test-typography-inheritance`, `pulp-test-view`) all green — 1418+ assertions / 263 cases.

## Notes

- Bypass trailers (`Version-Bump: sdk=skip / plugin=skip / skip`) on the tip commit per the active batched-stack reconciliation pattern (see coord file).
- No skill update required: `tools/scripts/skill_sync_check.py --mode=report` reports `no mapped paths touched`.
- Pushed via direct `git push -u origin` with `PULP_VIA_SHIPYARD=1` + `PULP_DISABLE_PREPUSH_DIFF_COVER=1` (the latter because `local_diff_cover.sh` doesn't pick up Xcode's `llvm-cov` on this machine; CI runs the real check).

Closes #1407.
