### PR TITLE
test(view): regression guard for overflow:hidden parent clip-rect (refs #1409)

### DIFF
--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -1042,6 +1042,103 @@ TEST_CASE("Absolute child positioned outside parent's bounds still paints",
     REQUIRE_FALSE(saw_parent_clip);
 }
 
+// pulp #1409 paint-time probe series — empirical answer to the Spectr
+// [I] "preset items render outside overlay" report. The framework
+// already pushes a parent clip_rect before children paint when the
+// parent has overflow:hidden, so the symptom is consumer-side, not
+// framework-side. These tests stand as a regression guard — if any of
+// them flips to a fail, paint-time clipping has regressed.
+TEST_CASE("Probe: overflow:hidden parent clip-rect precedes child paint",
+          "[view][probe][issue-overlay-clip]") {
+    using namespace pulp::canvas;
+
+    View parent;
+    parent.set_bounds({0, 0, 100, 100});
+    parent.set_overflow(View::Overflow::hidden);
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({0, 0, 200, 100});
+    child->set_background_color(Color::rgba8(0, 255, 0, 255));
+    parent.add_child(std::move(child));
+
+    RecordingCanvas rc;
+    parent.paint_all(rc);
+
+    int parent_clip_idx = -1;
+    int child_fill_idx = -1;
+    Color last_fill{};
+    for (int i = 0; i < (int)rc.commands().size(); ++i) {
+        const auto& cmd = rc.commands()[i];
+        if (cmd.type == DrawCommand::Type::clip_rect &&
+            cmd.f[0] == 0.0f && cmd.f[1] == 0.0f &&
+            cmd.f[2] == 100.0f && cmd.f[3] == 100.0f &&
+            parent_clip_idx == -1) {
+            parent_clip_idx = i;
+        }
+        if (cmd.type == DrawCommand::Type::set_fill_color) last_fill = cmd.color;
+        if (cmd.type == DrawCommand::Type::fill_rect &&
+            cmd.f[2] == 200.0f && cmd.f[3] == 100.0f &&
+            last_fill.g8() == 255 && last_fill.r8() == 0 &&
+            child_fill_idx == -1) {
+            child_fill_idx = i;
+        }
+    }
+    INFO("parent_clip_idx=" << parent_clip_idx << " child_fill_idx=" << child_fill_idx
+         << " total_cmds=" << rc.commands().size());
+    REQUIRE(parent_clip_idx >= 0);
+    REQUIRE(child_fill_idx >= 0);
+    REQUIRE(parent_clip_idx < child_fill_idx);
+}
+
+// pulp #1409 paint-time probe — absolutely-positioned child translated
+// past the parent's right edge. Mirrors a Spectr preset-menu item
+// scenario where a row's `position: absolute; left: 80px` puts it past
+// a 100×40 dropdown's content rect. The clip must STILL precede the
+// child's paint command in the recording — translates do not reset the
+// active clip.
+TEST_CASE("Probe: overflow:hidden parent clips translated absolute child too",
+          "[view][probe][issue-overlay-clip]") {
+    using namespace pulp::canvas;
+
+    View parent;
+    parent.set_bounds({0, 0, 100, 40});
+    parent.set_overflow(View::Overflow::hidden);
+
+    auto child = std::make_unique<View>();
+    // Bounds-x positions the child at parent-x=80, so its 60px width
+    // extends 40px past the parent's right edge.
+    child->set_bounds({80, 0, 60, 40});
+    child->set_position(View::Position::absolute);
+    child->set_background_color(Color::rgba8(0, 0, 255, 255));
+    parent.add_child(std::move(child));
+
+    RecordingCanvas rc;
+    parent.paint_all(rc);
+
+    int parent_clip_idx = -1;
+    int child_fill_idx = -1;
+    Color last_fill{};
+    for (int i = 0; i < (int)rc.commands().size(); ++i) {
+        const auto& cmd = rc.commands()[i];
+        if (cmd.type == DrawCommand::Type::clip_rect &&
+            cmd.f[0] == 0.0f && cmd.f[1] == 0.0f &&
+            cmd.f[2] == 100.0f && cmd.f[3] == 40.0f &&
+            parent_clip_idx == -1) {
+            parent_clip_idx = i;
+        }
+        if (cmd.type == DrawCommand::Type::set_fill_color) last_fill = cmd.color;
+        if (cmd.type == DrawCommand::Type::fill_rect &&
+            cmd.f[2] == 60.0f && cmd.f[3] == 40.0f &&
+            last_fill.b8() == 255 && last_fill.r8() == 0 && last_fill.g8() == 0 &&
+            child_fill_idx == -1) {
+            child_fill_idx = i;
+        }
+    }
+    REQUIRE(parent_clip_idx >= 0);
+    REQUIRE(child_fill_idx >= 0);
+    REQUIRE(parent_clip_idx < child_fill_idx);
+}
+
 // ── pulp #1026: React Native pointerEvents 4-valued enum ────────────────────
 
 TEST_CASE("View::hit_test honors pointerEvents == auto (default)",


### PR DESCRIPTION
## Summary

Empirical regression guard for `View::paint_all` clip-rect propagation under `overflow: hidden`. Motivated by an investigation into the Spectr [I] "preset items render outside overlay" report.

The framework already pushes the parent's clip-rect before children paint via the `save → clip_rect → paint(self) → paint(children) → restore` sequence in `core/view/src/view.cpp` (line 80–290). These tests assert that invariant holds for two scenarios:

1. **Plain overflowing child** — a 200×100 child of a 100×100 `overflow: hidden` parent. The parent's `clip_rect(0, 0, 100, 100)` precedes the child's `fill_rect(0, 0, 200, 100)` in the recorded command stream.
2. **Absolute-positioned overflowing child** — a 60×40 child at `bounds.x=80` inside a 100×40 `overflow: hidden` parent (the Spectr preset-row pattern, where `position: absolute; left: 80px` puts the row past the dropdown's right edge). Same invariant — the clip is active when the absolute child paints.

Both probes PASS on origin/main. Conclusion: the Spectr [I] visible symptom is not a framework gap — `overflow: hidden` set on the actual overlay container would already clip absolute children. Likely consumer-side root cause: `overflow: hidden` not set on the perceived "overlay" ancestor (CSS-style ancestor confusion), or a `position: fixed` escape that's a separate CSS-spec concern.

These tests are added as a regression guard so any future paint-pipeline change that drops the child clip would be caught immediately. Pulp #1409's paint-time correctness harness will eventually formalize the assertion shape; this is the manual Catch2 placeholder.

## Test plan

- [x] `Probe: overflow:hidden parent clip-rect precedes child paint` — verifies clip_rect emitted before child fill_rect for a plain overflowing child.
- [x] `Probe: overflow:hidden parent clips translated absolute child too` — same invariant for an `position: absolute` child translated past the parent's right edge.
- [x] Both pass on rebased `origin/main` (post #1395 yoga-harness merge).

## Notes

- Tagged `[probe][issue-overlay-clip]`. Tests are diagnostic regression guards, not bug fixes — there's no production code change in this PR.
- Refs #1409 (paint-time correctness harness) — these are the manual placeholder for what that harness will eventually express programmatically.
- Bypass trailers (`Version-Bump: sdk=skip / plugin=skip / skip`) on the tip commit per the active batched-stack reconciliation.
