### PR TITLE
feat(harness): auto-discover surface adapters via pkgutil + decorator (closes #1401)

### DIFF
--- a/tools/harness/adapters/base.py
+++ b/tools/harness/adapters/base.py
@@ -1,11 +1,54 @@
-"""Adapter interface shared by every surface."""
+"""Adapter interface shared by every surface.
+
+Auto-discovery (pulp #1401)
+---------------------------
+Adapter modules under :mod:`tools.harness.adapters` self-register via the
+:func:`register_adapter` decorator on their :class:`AdapterBase` subclass.
+``verifier.py`` imports every sibling module via ``pkgutil.iter_modules``
+at startup, and the decorator side-effect populates the module-level
+:data:`ADAPTERS` mapping. Adding a new surface adapter is therefore a
+pure file-drop — no edits to ``verifier.py`` or this module are needed.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from ..status import Status, map_catalog_status_to_expected
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Adapter registry — populated by @register_adapter decorator side-effects
+# when adapter modules are imported (see verifier._discover_adapters).
+# ─────────────────────────────────────────────────────────────────────────────
+
+ADAPTERS: dict[str, type] = {}
+
+
+def register_adapter(name: str) -> Callable[[type], type]:
+    """Class decorator that registers an :class:`AdapterBase` subclass under
+    ``name`` (the surface key, e.g. ``"yoga"``) in :data:`ADAPTERS`.
+
+    Re-registering the same name overwrites the previous entry — useful in
+    tests that monkey-patch a surface, but it means the *last* import wins.
+    The decorator also stamps ``cls.surface`` with the registered name so
+    adapters don't have to repeat themselves.
+    """
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"register_adapter requires a non-empty surface name, got {name!r}")
+
+    def decorator(cls: type) -> type:
+        ADAPTERS[name] = cls
+        # Stamp the canonical surface name on the class for symmetry with
+        # the manual `surface = "..."` assignment some adapters carry.
+        try:
+            cls.surface = name  # type: ignore[attr-defined]
+        except (AttributeError, TypeError):
+            pass
+        return cls
+
+    return decorator
 
 
 @dataclass

--- a/tools/harness/adapters/yoga.py
+++ b/tools/harness/adapters/yoga.py
@@ -22,7 +22,7 @@ import re
 from pathlib import Path
 
 from ..status import Status
-from .base import AdapterBase, CatalogEntry, Result
+from .base import AdapterBase, CatalogEntry, Result, register_adapter
 
 
 # Markers in the catalog `mapsTo` field that imply "no real binding".
@@ -58,6 +58,7 @@ NO_OP_MARKERS = (
 )
 
 
+@register_adapter("yoga")
 class YogaAdapter(AdapterBase):
     surface = "yoga"
 

--- a/tools/harness/tests/__init__.py
+++ b/tools/harness/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the catalog harness — pulp #1401 (adapter auto-discovery)."""

--- a/tools/harness/tests/test_auto_discover.py
+++ b/tools/harness/tests/test_auto_discover.py
@@ -1,0 +1,334 @@
+"""Tests for adapter auto-discovery — pulp #1401.
+
+The harness used to require editing ``verifier.py`` for every new surface
+adapter, which serialised parallel work and forced sequential rebases on
+sibling PRs (#1395 / #1396 / #1397 / #1398 / #1399). The fix replaces the
+manual ``ADAPTERS = {...}`` registry with a decorator + ``pkgutil.iter_modules``
+walk over ``tools/harness/adapters/``.
+
+These tests pin down the three behaviours the issue's test plan calls out:
+
+1. A new adapter file dropped into ``tools/harness/adapters/`` is picked up
+   without ``verifier.py`` edits.
+2. An adapter file that throws on import does NOT crash the verifier — it is
+   logged and skipped.
+3. The yoga adapter still classifies the same way after the refactor (no
+   PASS / DIVERGE / NO-OP / NOT-IMPL / OOS regression vs. the baseline that
+   landed in #1395).
+
+Plus a couple of unit tests for the ``register_adapter`` decorator itself.
+
+Invocation::
+
+    python3 -m unittest tools.harness.tests.test_auto_discover
+
+The tests are pure ``unittest`` — no pytest dependency — so they run on a
+clean Python install with only the repo on ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+# Make the repo root importable when this file is run directly.
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.harness import verifier  # noqa: E402
+from tools.harness.adapters import base as adapters_base  # noqa: E402
+from tools.harness.adapters.base import (  # noqa: E402
+    AdapterBase,
+    CatalogEntry,
+    Result,
+    register_adapter,
+)
+from tools.harness.status import Status  # noqa: E402
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _adapters_dir() -> Path:
+    """Filesystem path to the adapters package."""
+    import tools.harness.adapters as adapters_pkg
+
+    return Path(next(iter(adapters_pkg.__path__)))
+
+
+class _RegistrySnapshot:
+    """Save & restore the adapter registry around a test that mutates it.
+
+    Also clears any drop-in adapter modules from ``sys.modules`` so the
+    next test session sees a clean slate.
+    """
+
+    def __init__(self) -> None:
+        self._saved: dict[str, type] = {}
+        self._drop_in_module_names: list[str] = []
+
+    def __enter__(self) -> "_RegistrySnapshot":
+        self._saved = dict(adapters_base.ADAPTERS)
+        return self
+
+    def track_module(self, name: str) -> None:
+        self._drop_in_module_names.append(name)
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        # Restore the registry exactly as we found it.
+        adapters_base.ADAPTERS.clear()
+        adapters_base.ADAPTERS.update(self._saved)
+        # Evict any temp modules we imported so subsequent imports re-run.
+        for mod_name in self._drop_in_module_names:
+            sys.modules.pop(mod_name, None)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Decorator unit tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class RegisterAdapterDecoratorTests(unittest.TestCase):
+    def test_decorator_registers_class_and_stamps_surface(self) -> None:
+        with _RegistrySnapshot():
+
+            @register_adapter("__test_decorator__")
+            class _TmpAdapter(AdapterBase):
+                pass
+
+            self.assertIs(adapters_base.ADAPTERS["__test_decorator__"], _TmpAdapter)
+            self.assertEqual(_TmpAdapter.surface, "__test_decorator__")
+
+    def test_decorator_returns_class_unchanged(self) -> None:
+        with _RegistrySnapshot():
+
+            @register_adapter("__test_returns_cls__")
+            class _TmpAdapter(AdapterBase):
+                pass
+
+            # Decorator must still return the class so users can `from foo import Bar`.
+            self.assertTrue(issubclass(_TmpAdapter, AdapterBase))
+
+    def test_decorator_rejects_empty_name(self) -> None:
+        with self.assertRaises(ValueError):
+            register_adapter("")
+        with self.assertRaises(ValueError):
+            register_adapter(None)  # type: ignore[arg-type]
+
+    def test_re_registration_overrides_previous(self) -> None:
+        with _RegistrySnapshot():
+
+            @register_adapter("__rebind__")
+            class A(AdapterBase):
+                pass
+
+            @register_adapter("__rebind__")
+            class B(AdapterBase):
+                pass
+
+            self.assertIs(adapters_base.ADAPTERS["__rebind__"], B)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Drop-in pickup
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class DropInAdapterPickupTests(unittest.TestCase):
+    """A new file in ``adapters/`` is auto-discovered without verifier edits."""
+
+    SURFACE_NAME = "__test_dropin_surface__"
+    # Module name MUST NOT start with "_" or it will be skipped by the
+    # discovery walk's underscore guard.
+    MODULE_BASENAME = "test_dropin_adapter_1401"
+
+    def setUp(self) -> None:
+        self.adapters_dir = _adapters_dir()
+        self.module_path = self.adapters_dir / f"{self.MODULE_BASENAME}.py"
+        # Module is intentionally NOT prefixed with ``_`` so the discovery
+        # walk picks it up. (The skip rule covers ``_<name>``, ``base``.)
+        # We use a unique dunder-style surface name instead to namespace it.
+        # Drop the file.
+        self.module_path.write_text(
+            textwrap.dedent(
+                f"""
+                \"\"\"Test fixture for pulp #1401 — drop-in adapter pickup.\"\"\"
+
+                from tools.harness.adapters.base import (
+                    AdapterBase,
+                    CatalogEntry,
+                    Result,
+                    register_adapter,
+                )
+                from tools.harness.status import Status
+
+
+                @register_adapter("{self.SURFACE_NAME}")
+                class DropInAdapter(AdapterBase):
+                    surface = "{self.SURFACE_NAME}"
+
+                    def run(self, entry):  # type: ignore[override]
+                        return Result(entry=entry, status=Status.PASS, detail="dropin ok")
+                """
+            ).lstrip()
+        )
+
+    def tearDown(self) -> None:
+        try:
+            self.module_path.unlink()
+        except FileNotFoundError:
+            pass
+        # Clean up the ADAPTERS entry the import side-effect created.
+        adapters_base.ADAPTERS.pop(self.SURFACE_NAME, None)
+        # Evict the imported module so a re-discover run picks it up fresh
+        # next time it's needed.
+        sys.modules.pop(
+            f"tools.harness.adapters.{self.MODULE_BASENAME}", None
+        )
+
+    def test_new_adapter_is_picked_up_without_verifier_edits(self) -> None:
+        # Sanity: the surface should NOT be in the registry before discovery
+        # (we just created the file; nothing has imported it yet).
+        adapters_base.ADAPTERS.pop(self.SURFACE_NAME, None)
+        sys.modules.pop(
+            f"tools.harness.adapters.{self.MODULE_BASENAME}", None
+        )
+        self.assertNotIn(self.SURFACE_NAME, adapters_base.ADAPTERS)
+
+        # Calling _discover_adapters() should import the new file and the
+        # decorator should land it in the registry.
+        verifier._discover_adapters(reload=True)
+        self.assertIn(
+            self.SURFACE_NAME,
+            adapters_base.ADAPTERS,
+            "drop-in adapter file was not picked up by _discover_adapters()",
+        )
+        # The aliased re-export on verifier must reflect the same dict.
+        self.assertIn(self.SURFACE_NAME, verifier.ADAPTERS)
+        # ADAPTERS on verifier and in adapters_base should be the same object,
+        # so callers that imported either symbol see the same entries.
+        self.assertIs(verifier.ADAPTERS, adapters_base.ADAPTERS)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Broken adapter — must be logged + skipped, not crash
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class BrokenAdapterIsSkippedTests(unittest.TestCase):
+    """A module that raises on import must NOT crash the verifier."""
+
+    MODULE_BASENAME = "_test_broken_adapter_1401_will_raise"
+
+    def setUp(self) -> None:
+        self.adapters_dir = _adapters_dir()
+        # IMPORTANT: we pick a name that does NOT start with "_" because the
+        # discovery walk skips underscore-prefixed modules. A module that
+        # starts with "_" would never be imported at all and would
+        # silently bypass this regression. Strip the leading underscore.
+        self.basename = self.MODULE_BASENAME.lstrip("_")
+        self.module_path = self.adapters_dir / f"{self.basename}.py"
+        self.module_path.write_text(
+            textwrap.dedent(
+                """
+                \"\"\"Test fixture for pulp #1401 — broken adapter.
+
+                This module raises ImportError on import to verify the
+                discovery loop logs and skips it without crashing.
+                \"\"\"
+
+                raise ImportError("intentional failure for pulp #1401 test")
+                """
+            ).lstrip()
+        )
+
+    def tearDown(self) -> None:
+        try:
+            self.module_path.unlink()
+        except FileNotFoundError:
+            pass
+        sys.modules.pop(f"tools.harness.adapters.{self.basename}", None)
+
+    def test_broken_adapter_is_logged_and_skipped(self) -> None:
+        # Capture WARNING records emitted by the verifier's logger.
+        with self.assertLogs(verifier.logger, level=logging.WARNING) as cap:
+            registry = verifier._discover_adapters(reload=True)
+
+        # Expected outcomes:
+        #   1. _discover_adapters returned the live registry (didn't raise).
+        #   2. The yoga adapter is still present (broken sibling didn't
+        #      poison the rest of the discovery walk).
+        #   3. A warning log named the broken module.
+        self.assertIs(registry, adapters_base.ADAPTERS)
+        self.assertIn(
+            "yoga",
+            registry,
+            "broken sibling adapter caused yoga to drop out of the registry",
+        )
+        joined = "\n".join(cap.output)
+        self.assertIn("failed to load", joined)
+        self.assertIn(self.basename, joined)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Yoga regression — same verdict on every entry as before the refactor
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class YogaAdapterNoRegressionTests(unittest.TestCase):
+    """Yoga must be discovered and classify entries identically to before.
+
+    This is the issue's "Existing PASS/DIVERGE/NO-OP/NOT-IMPL/OOS
+    classification unchanged" criterion.
+
+    The expected status counts here mirror the on-main baseline at
+    sha 189255c2 (yoga harness scaffold landed in #1395).
+    """
+
+    EXPECTED = {
+        "total": 53,
+        "pass": 7,
+        "diverge": 28,
+        "no_op": 0,
+        "not_impl": 18,
+        "oos": 0,
+    }
+
+    def test_yoga_adapter_present_after_discovery(self) -> None:
+        verifier._discover_adapters(reload=True)
+        self.assertIn("yoga", verifier.ADAPTERS)
+        # The class registered under "yoga" must be a real AdapterBase.
+        self.assertTrue(issubclass(verifier.ADAPTERS["yoga"], AdapterBase))
+
+    def test_yoga_results_match_baseline(self) -> None:
+        repo_root = verifier.find_repo_root(REPO_ROOT)
+        results = verifier.run_surface(repo_root, "yoga")
+
+        bucketed = {st: 0 for st in (
+            Status.PASS,
+            Status.DIVERGE,
+            Status.NO_OP,
+            Status.NOT_IMPL,
+            Status.OOS,
+        )}
+        for r in results:
+            bucketed[r.status] = bucketed.get(r.status, 0) + 1
+
+        self.assertEqual(len(results), self.EXPECTED["total"])
+        self.assertEqual(bucketed[Status.PASS], self.EXPECTED["pass"])
+        self.assertEqual(bucketed[Status.DIVERGE], self.EXPECTED["diverge"])
+        self.assertEqual(bucketed[Status.NO_OP], self.EXPECTED["no_op"])
+        self.assertEqual(bucketed[Status.NOT_IMPL], self.EXPECTED["not_impl"])
+        self.assertEqual(bucketed[Status.OOS], self.EXPECTED["oos"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/harness/verifier.py
+++ b/tools/harness/verifier.py
@@ -21,8 +21,11 @@ This script is wired through the CLI as `pulp harness coverage`.
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
+import logging
 import os
+import pkgutil
 import shutil
 import subprocess
 import sys
@@ -37,19 +40,70 @@ REPO_ROOT_GUESS = HERE.parent.parent
 if str(REPO_ROOT_GUESS) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT_GUESS))
 
+from tools.harness.adapters import base as adapters_base  # noqa: E402
 from tools.harness.adapters.base import CatalogEntry, Result  # noqa: E402
-from tools.harness.adapters.yoga import YogaAdapter  # noqa: E402
 from tools.harness.status import STATUS_ORDER, Status, StatusCounts  # noqa: E402
 
-# Surface -> Adapter class. New adapters land here. Surfaces present in
-# compat.json but absent from this map are reported as "not yet wired".
-ADAPTERS = {
-    "yoga": YogaAdapter,
-}
+logger = logging.getLogger("pulp.harness.verifier")
 
 # Surfaces tracked in compat.json that we know about. Used so we can call out
 # "not yet wired" cleanly when the user asks for `--all`.
 KNOWN_SURFACES = ["yoga", "css", "rn", "html", "canvas2d", "imports"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Adapter auto-discovery (pulp #1401)
+#
+# Each adapter module under ``tools/harness/adapters/`` is imported in
+# alphabetical order. The :func:`tools.harness.adapters.base.register_adapter`
+# decorator side-effect populates :data:`adapters_base.ADAPTERS`. We expose
+# that dict as the module-level :data:`ADAPTERS` for backward compatibility
+# with anything that imported the symbol from the old hand-rolled registry.
+#
+# A broken adapter module (raises on import) is logged and skipped; it does
+# not crash the verifier or other surfaces. This is the property covered by
+# the issue's "verifier still works when one adapter throws on import" test.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _discover_adapters(reload: bool = False) -> dict[str, type]:
+    """Import every sibling module of :mod:`tools.harness.adapters` so the
+    ``@register_adapter`` decorators populate :data:`adapters_base.ADAPTERS`.
+
+    Returns the live registry dict (the same object as
+    :data:`adapters_base.ADAPTERS`) for callers that want to inspect it.
+
+    Modules whose name starts with ``_`` or that equal ``"base"`` are
+    skipped; everything else is imported. Import failures are logged at
+    WARNING and the offending surface is left out of the registry — they
+    do not propagate to the caller.
+    """
+    import tools.harness.adapters as adapters_pkg
+
+    for _, mod_name, _ in pkgutil.iter_modules(adapters_pkg.__path__):
+        if mod_name.startswith("_") or mod_name == "base":
+            continue
+        full_name = f"{adapters_pkg.__name__}.{mod_name}"
+        try:
+            if reload and full_name in sys.modules:
+                importlib.reload(sys.modules[full_name])
+            else:
+                importlib.import_module(full_name)
+        except Exception as e:  # noqa: BLE001 — we genuinely want to swallow
+            logger.warning(
+                "harness: adapter %r failed to load and will be skipped: %s",
+                mod_name,
+                e,
+            )
+    return adapters_base.ADAPTERS
+
+
+_discover_adapters()
+
+# Surface -> Adapter class. Populated at import time by
+# ``_discover_adapters``. Re-export so callers that did
+# ``from verifier import ADAPTERS`` keep working.
+ADAPTERS = adapters_base.ADAPTERS
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces the manual `ADAPTERS = {...}` dict in `tools/harness/verifier.py` with
`pkgutil.iter_modules` over `tools/harness/adapters/` plus a
`@register_adapter("name")` class decorator. Adding a new surface adapter is
now a pure file drop — no shared edits to `verifier.py` or any other module.

Closes #1401.

## Why

The week-1 adapter PRs (#1395 yoga, #1396 rn, #1397 css, #1398 html,
#1399 canvas2d) all needed sequential rebases because each touched the same
two lines (the `import` + the `ADAPTERS` dict entry). With auto-discovery,
those siblings can land independently and any future surface (SVG,
webview-bridge, OSC, …) inherits the same friction-free flow.

This is the issue's **Option A** (decorator + module walk).

## Changes

- `tools/harness/adapters/base.py` — adds module-level
  `ADAPTERS: dict[str, type]` registry and `register_adapter(name)` class
  decorator. The decorator stamps `cls.surface = name` on the class for
  symmetry with the existing manual `surface = "..."` assignment.
- `tools/harness/adapters/yoga.py` — annotates `YogaAdapter` with
  `@register_adapter("yoga")`. No behavior change.
- `tools/harness/verifier.py` — drops the `from .yoga import YogaAdapter`
  import and the hand-rolled `ADAPTERS = {"yoga": YogaAdapter}` dict; adds
  `_discover_adapters()` which walks the adapters package via
  `pkgutil.iter_modules`, importing each non-`base`, non-underscore module.
  Import failures are logged at WARNING and skipped — a broken sibling does
  not poison discovery for the rest. The module-level `ADAPTERS` is now a
  re-export of `adapters_base.ADAPTERS`, so anything that imported the
  symbol from the old registry keeps working.

## Tests

Per project policy ("tests ship with fixes"), a new
`tools/harness/tests/test_auto_discover.py` covers all four bullets from the
issue's test plan plus decorator unit tests:

| Test class | Covers |
|---|---|
| `RegisterAdapterDecoratorTests` | Happy path, class returned unchanged, empty-name rejection, re-registration overrides previous. |
| `DropInAdapterPickupTests` | Drops a fixture adapter file into `tools/harness/adapters/`, calls `_discover_adapters(reload=True)`, asserts the new surface lands in `verifier.ADAPTERS` **without any verifier edits**. |
| `BrokenAdapterIsSkippedTests` | Drops a sibling adapter that raises `ImportError`. Asserts the discovery loop logs a warning, the broken module is skipped, and the yoga adapter is still in the registry. |
| `YogaAdapterNoRegressionTests` | Pins the post-#1395 baseline counts (53 total / 7 PASS / 28 DIVERGE / 0 NO-OP / 18 NOT-IMPL / 0 OOS). Any refactor that changes yoga classification trips it. |

```
$ python3 -m unittest tools.harness.tests.test_auto_discover -v
...
Ran 8 tests in 0.456s

OK
```

`tools/harness/**` is outside the diff-coverage gate's filter set (`core/**`,
`tools/cli/**`, `tools/scripts/**` per `tools/scripts/coverage_config.json`),
so no diff-cover impact for this PR.

## Test plan

- [x] `python3 -m unittest tools.harness.tests.test_auto_discover` — 8/8 pass
- [x] `python3 tools/harness/verifier.py --surface=yoga --json` — counts match pre-refactor baseline (53 total, 7 PASS, 28 DIVERGE, 18 NOT-IMPL, drift=23)
- [x] `python3 tools/harness/verifier.py --all` — yoga still discovered + run
- [x] Bypass trailers parsed by `git interpret-trailers` (3 `Version-Bump:` entries)
- [x] No skill mapping for `tools/harness/**` (verified against `tools/scripts/skill_path_map.json`)

## Coordination

Drafted in worktree `/tmp/pulp-1401-auto-discover` against `origin/main` at
189255c2 (post-#1395 yoga harness merge). Branched off main per the
multi-agent protocol; the batched-stack version-bump branch reconciles
SDK/plugin versions after merge — hence the `Version-Bump: skip` trailers
on the tip commit.

Sibling adapter PRs (#1396 / #1397 / #1398 / #1399) become conflict-free
once this lands.
