### PR TITLE
fix(harness/yoga): normalize annotated catalog values before exact-string match (Codex P1 on #1395)

### DIFF
--- a/test/harness/test_yoga_adapter.py
+++ b/test/harness/test_yoga_adapter.py
@@ -165,6 +165,159 @@ class YogaAdapterClassifyTest(unittest.TestCase):
         self.assertTrue(result.drifts)
 
 
+class YogaAdapterEnumNormalizeTest(unittest.TestCase):
+    """Annotated catalog values must normalize against bare oracle values.
+
+    Codex P1 follow-up on PR #1395 (issue #1413). The catalog frequently
+    decorates enum values with parenthetical context (``"flex (implicit)"``,
+    ``"none (via setVisible(false))"``). Before the fix, those entries
+    didn't string-equal the oracle's bare ``"flex"`` / ``"none"`` and were
+    misclassified as NOT-IMPL even when the adapter found a binding.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.adapter = YogaAdapter(REPO_ROOT)
+
+    # ── Pure helper: _normalize_enum_value ───────────────────────────
+
+    def test_normalize_strips_trailing_annotation(self):
+        self.assertEqual(YogaAdapter._normalize_enum_value("flex (implicit)"), "flex")
+        self.assertEqual(YogaAdapter._normalize_enum_value("row-reverse (RTL)"), "row-reverse")
+
+    def test_normalize_handles_nested_parens(self):
+        # The Codex P1 motivating example: yoga/display's "none (via setVisible(false))".
+        self.assertEqual(
+            YogaAdapter._normalize_enum_value("none (via setVisible(false))"),
+            "none",
+        )
+        self.assertEqual(
+            YogaAdapter._normalize_enum_value("foo (with (nested) parens)"),
+            "foo",
+        )
+
+    def test_normalize_passes_through_bare_values(self):
+        for v in ("flex", "none", "row", "row-reverse", "wrap-reverse"):
+            self.assertEqual(YogaAdapter._normalize_enum_value(v), v)
+
+    def test_normalize_is_idempotent(self):
+        once = YogaAdapter._normalize_enum_value("flex (implicit)")
+        twice = YogaAdapter._normalize_enum_value(once)
+        self.assertEqual(once, twice)
+
+    def test_normalize_only_strips_trailing_group(self):
+        """A parenthetical mid-string is NOT an annotation and must survive."""
+        self.assertEqual(
+            YogaAdapter._normalize_enum_value("mid (paren) inside"),
+            "mid (paren) inside",
+        )
+
+    def test_normalize_strips_exactly_one_trailing_group(self):
+        """Two consecutive trailing groups: only the outermost is stripped."""
+        self.assertEqual(YogaAdapter._normalize_enum_value("foo (a) (b)"), "foo (a)")
+
+    def test_normalize_leaves_unbalanced_input_alone(self):
+        self.assertEqual(YogaAdapter._normalize_enum_value("unbalanced ("), "unbalanced (")
+
+    def test_normalize_handles_empty_and_whitespace(self):
+        self.assertEqual(YogaAdapter._normalize_enum_value(""), "")
+        self.assertEqual(YogaAdapter._normalize_enum_value(None), "")
+        self.assertEqual(YogaAdapter._normalize_enum_value("   "), "")
+        self.assertEqual(YogaAdapter._normalize_enum_value("  flex  "), "flex")
+
+    # ── Adapter-level: classification of yoga/display ────────────────
+
+    def test_yoga_display_annotated_values_pass(self):
+        """yoga/display's annotated catalog values must match the bare oracle.
+
+        With the fix in place, this entry classifies as PASS (oracle =
+        {flex, none}, normalized supportedValues = {flex, none}).
+        """
+        e = CatalogEntry(
+            surface="yoga",
+            name="yoga/display",
+            status="partial",
+            maps_to="View::set_visible (binding via visibility)",
+            supported_values=["flex (implicit)", "none (via setVisible(false))"],
+            unsupported_values=[],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.PASS, msg=result.detail)
+
+    def test_annotated_values_with_no_oracle_overlap_diverge(self):
+        """Annotation-stripping must not invent matches.
+
+        Catalog claims ``"foo (annotation)"``, oracle expects ``["bar"]``.
+        After normalization the supported set is ``{foo}`` which still has
+        no overlap with ``{bar}`` — verdict must be NOT_IMPL (binding-OK
+        path, no oracle value claimed) rather than a spurious PASS.
+        """
+        # Use a real prop so the binding lookup succeeds — then override
+        # the supported_values to force the no-overlap branch.
+        e = CatalogEntry(
+            surface="yoga",
+            name="yoga/flexDirection",
+            status="partial",
+            maps_to="FlexStyle.direction",
+            supported_values=["foo (annotation)"],
+            unsupported_values=[],
+        )
+        result = self.adapter.run(e)
+        # Oracle is {row, row-reverse, column, column-reverse}; 'foo' has
+        # zero overlap so no oracle value is claimed -> NOT_IMPL.
+        self.assertEqual(result.status, Status.NOT_IMPL, msg=result.detail)
+        self.assertNotIn("foo", result.unmatched_supported)
+
+    def test_unannotated_entries_classify_unchanged(self):
+        """Regression guard: pre-existing entries without annotations
+        classify the same as before the normalization patch."""
+        # flexDirection: partial, 2 of 4 oracle values supported -> DIVERGE.
+        e = CatalogEntry(
+            surface="yoga",
+            name="yoga/flexDirection",
+            status="partial",
+            maps_to="FlexStyle.direction",
+            supported_values=["row", "column"],
+            unsupported_values=["row-reverse", "column-reverse"],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.DIVERGE)
+        self.assertEqual(set(result.matched_supported), {"row", "column"})
+
+        # flexGrow: numeric supported -> PASS (non-enum branch, untouched).
+        e2 = CatalogEntry(
+            surface="yoga",
+            name="yoga/flexGrow",
+            status="supported",
+            maps_to="FlexStyle.flex_grow (float)",
+            supported_values=["any number"],
+            unsupported_values=[],
+        )
+        self.assertEqual(self.adapter.run(e2).status, Status.PASS)
+
+    def test_unsupported_annotation_still_excludes_value(self):
+        """Annotated entries in unsupportedValues must also normalize.
+
+        If the catalog says ``unsupportedValues: ["row-reverse (TODO)"]``
+        and the oracle has ``"row-reverse"``, the harness must treat
+        ``row-reverse`` as un-supported, not as a phantom new token.
+        """
+        e = CatalogEntry(
+            surface="yoga",
+            name="yoga/flexDirection",
+            status="partial",
+            maps_to="FlexStyle.direction",
+            supported_values=["row", "column", "column-reverse"],
+            unsupported_values=["row-reverse (TODO RTL)"],
+        )
+        result = self.adapter.run(e)
+        self.assertEqual(result.status, Status.DIVERGE, msg=result.detail)
+        # row-reverse is normalized in BOTH directions: it's flagged as
+        # extra_unsupported (oracle ∩ unsup) AND missing from supported.
+        self.assertIn("row-reverse", result.extra_unsupported)
+        self.assertIn("row-reverse", result.unmatched_supported)
+
+
 class VerifierEndToEndTest(unittest.TestCase):
     """Full pipeline — compat.json -> all 53 yoga entries -> coverage report."""
 

--- a/tools/harness/adapters/yoga.py
+++ b/tools/harness/adapters/yoga.py
@@ -144,6 +144,72 @@ class YogaAdapter(AdapterBase):
     def _camel_to_snake(name: str) -> str:
         return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
 
+    # ── Enum-value normalization ─────────────────────────────────────
+    #
+    # Catalog `supportedValues` entries are hand-edited and frequently carry
+    # human-readable annotations in trailing parentheses to explain the
+    # binding nuance, e.g.::
+    #
+    #     "flex (implicit)"
+    #     "none (via setVisible(false))"
+    #     "row-reverse (RTL)"
+    #
+    # The Yoga oracle stores bare CSS-style tokens (`flex`, `none`,
+    # `row-reverse`). Naive string equality between the two surfaces
+    # mis-classifies annotated catalog entries as NOT-IMPL even when the
+    # adapter found a binding, inflating the drift count (Codex P1 on
+    # PR #1395, tracked as #1413).
+    #
+    # Normalize by stripping a single trailing parenthetical group plus any
+    # surrounding whitespace. Apply on BOTH sides so the contract is
+    # symmetric — if the oracle ever grows annotations, comparison stays
+    # well-defined. We deliberately do NOT strip mid-string parentheses
+    # because no Yoga value contains them today; if that changes the rule
+    # widens at that point, not now.
+
+    @staticmethod
+    def _normalize_enum_value(v: str) -> str:
+        """Strip a trailing ``" (...)"`` annotation from a catalog/oracle value.
+
+        ``"flex (implicit)"`` -> ``"flex"``;
+        ``"none (via setVisible(false))"`` -> ``"none"`` (handles nested ``()``);
+        ``"row-reverse"`` -> ``"row-reverse"`` (unchanged);
+        ``"mid (paren) inside"`` -> ``"mid (paren) inside"`` (only trailing);
+        ``"unbalanced ("`` -> ``"unbalanced ("`` (no balanced group at end).
+        Empty / non-string inputs round-trip to ``""``.
+        """
+        if not v:
+            return ""
+        s = str(v).strip()
+        # Strip exactly ONE trailing balanced parenthetical group. We can't
+        # use a flat regex because annotations may themselves contain ``()``
+        # (e.g. ``"none (via setVisible(false))"``). Walk backward from the
+        # end maintaining a paren-depth counter; when depth returns to 0,
+        # we've found the matching opening ``(`` and can slice it off.
+        if s.endswith(")"):
+            depth = 0
+            for i in range(len(s) - 1, -1, -1):
+                c = s[i]
+                if c == ")":
+                    depth += 1
+                elif c == "(":
+                    depth -= 1
+                    if depth == 0:
+                        return s[:i].rstrip()
+            # Unbalanced — no opening paren found. Leave as-is rather than
+            # silently truncating; the catalog reviewer will spot it.
+        return s
+
+    @classmethod
+    def _normalize_enum_values(cls, values) -> set[str]:
+        """Return a set of normalized non-empty values, preserving uniqueness."""
+        out: set[str] = set()
+        for v in values or []:
+            n = cls._normalize_enum_value(v)
+            if n:
+                out.add(n)
+        return out
+
     # ── Main classification ──────────────────────────────────────────
 
     def run(self, entry: CatalogEntry) -> Result:
@@ -209,10 +275,13 @@ class YogaAdapter(AdapterBase):
             )
 
         # 4. Compare supportedValues vs the oracle's enum value set.
+        #    Normalize annotated values like "flex (implicit)" -> "flex" on
+        #    BOTH sides so the comparison is robust to either surface
+        #    growing parenthetical context. (Codex P1 on PR #1395 / #1413.)
         if kind == "enum" and oracle_values:
-            sup = set(entry.supported_values or [])
-            unsup = set(entry.unsupported_values or [])
-            oracle_set = set(oracle_values)
+            sup = self._normalize_enum_values(entry.supported_values)
+            unsup = self._normalize_enum_values(entry.unsupported_values)
+            oracle_set = self._normalize_enum_values(oracle_values)
 
             matched = sorted(oracle_set & sup)
             missing_from_supported = sorted(oracle_set - sup)


### PR DESCRIPTION
## Summary

- Catalog `supportedValues` and `unsupportedValues` carry parenthetical
  annotations that explain binding nuance — `"flex (implicit)"`,
  `"none (via setVisible(false))"`, `"row-reverse (RTL)"`. The Yoga
  oracle stores bare CSS-style tokens. Naive equality between the two
  surfaces misclassified annotated entries as `NOT-IMPL` even when the
  adapter found a binding, inflating the drift count.
- Adds `YogaAdapter._normalize_enum_value(v)` and applies it on BOTH
  sides of the enum comparison (catalog `supportedValues` /
  `unsupportedValues` AND oracle `values`).
- Concrete impact: `yoga/display` (catalog `partial`, supportedValues
  `["flex (implicit)", "none (via setVisible(false))"]`) now correctly
  classifies as `PASS`. Pre-fix it landed in the
  "field exists but no oracle value claimed" `NOT-IMPL` fallback.

## Implementation notes

The naive regex `\s*\([^)]*\)\s*$` doesn't survive nested parens — the
motivating example `"none (via setVisible(false))"` has an interior `)`
that breaks `[^)]*`. Instead the helper walks the string backward
maintaining a paren-depth counter; when depth returns to 0 we've found
the matching opening `(` and slice it off. This:

- Strips exactly one trailing balanced parenthetical group.
- Handles nested annotations (`"foo (with (nested) parens)"` → `"foo"`).
- Leaves mid-string parens alone (`"mid (paren) inside"` unchanged).
- Leaves unbalanced inputs alone (`"unbalanced ("` unchanged).
- Is idempotent and tolerates empty / whitespace / `None` input.

Applied symmetrically to `supportedValues`, `unsupportedValues`, and
oracle `values` so the contract stays well-defined if the oracle ever
grows annotations.

## Test plan

- [x] 12 new unit tests in `test/harness/test_yoga_adapter.py`
  (`YogaAdapterEnumNormalizeTest`):
  - trailing annotation, nested parens, bare pass-through, idempotence
  - mid-string survival, single-group stripping, unbalanced-input safety
  - empty / whitespace / `None` handling
  - `yoga/display` motivating example → `PASS`
  - no-overlap negative case (annotation-stripping doesn't invent matches)
  - regression-guard: pre-existing un-annotated entries classify unchanged
  - `unsupportedValues` annotation also normalizes
- [x] Full harness suite still passes (27 tests, 0 failures).
- [x] End-to-end verifier on the real `compat.json` confirms
  `yoga/display` now reports `harness=PASS` (previously `NOT-IMPL`).

## Closes

- Closes #1413 (Codex P1 follow-up on PR #1395).

## Notes for reviewer

- This is intentionally a stand-alone fix; the catalog itself still says
  `partial` for `yoga/display`, so the harness now reports `drift=True`
  against the catalog. That's the correct signal — the catalog should be
  updated separately to claim `supported` once a maintainer confirms.
- Trailers on the tip commit batch the version bump for the stack
  follow-up PR (per current multi-agent coordination cadence).
