### PR TITLE
feat(@pulp/react): SvgRect + SvgLine intrinsics (closes pulp #1416)

### DIFF
--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -180,6 +180,8 @@ target_sources(pulp-view PRIVATE
     src/app_framework.cpp
     src/canvas_widget.cpp
     src/svg_path_widget.cpp
+    src/widgets/svg_rect.cpp
+    src/widgets/svg_line.cpp
     src/visualization_bridge.cpp
     src/frame_clock.cpp
     src/window_manager.cpp

--- a/core/view/include/pulp/view/widgets/svg_line.hpp
+++ b/core/view/include/pulp/view/widgets/svg_line.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+/// @file svg_line.hpp
+/// A View that renders an inline SVG `<line>` element. Targets HTML
+/// patterns of the form `<svg><line x1="0" y1="10" x2="100" y2="10"
+/// stroke="#000" stroke-width="1" /></svg>` — common for separators,
+/// chart axes, and threshold markers in React/HTML bundles.
+///
+/// Mirrors the SvgPathWidget / SvgRectWidget API (pulp #965 / #1291 /
+/// #1416): the same fill / stroke / stroke-width plumbing across all
+/// SVG-primitive intrinsics.
+
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/view/view.hpp>
+
+namespace pulp::view {
+
+/// Renders an inline SVG `<line x1 y1 x2 y2 stroke stroke-width />`.
+/// Endpoints are local to the widget origin (NOT bounds()-translated).
+///
+/// Default state: zero-length line at (0,0)→(0,0), opaque-black stroke,
+/// stroke-width 1. SVG `<line>` has no fill (it's a 1-D primitive); for
+/// API consistency with SvgRect / SvgPath we keep the fill setters as
+/// no-op-friendly stubs but paint() never fills a line.
+class SvgLineWidget : public View {
+public:
+    SvgLineWidget() = default;
+
+    /// Set the line endpoints. All coords are local to the widget
+    /// origin.
+    void set_line(float x1, float y1, float x2, float y2);
+
+    /// Solid-stroke paint. Pass an alpha-zero color or call
+    /// clear_stroke() to disable stroking. Default: opaque black,
+    /// stroke enabled.
+    void set_stroke_color(canvas::Color c);
+    void clear_stroke();
+
+    /// Stroke width in widget-local units. Default 1.
+    void set_stroke_width(float w);
+
+    // Accessors used by tests.
+    float x1() const { return x1_; }
+    float y1() const { return y1_; }
+    float x2() const { return x2_; }
+    float y2() const { return y2_; }
+    bool has_stroke() const { return has_stroke_; }
+    canvas::Color stroke_color() const { return stroke_color_; }
+    float stroke_width() const { return stroke_width_; }
+
+    void paint(canvas::Canvas& canvas) override;
+
+private:
+    float x1_ = 0.0f;
+    float y1_ = 0.0f;
+    float x2_ = 0.0f;
+    float y2_ = 0.0f;
+    canvas::Color stroke_color_{0.0f, 0.0f, 0.0f, 1.0f};
+    float stroke_width_ = 1.0f;
+    bool has_stroke_ = true;
+};
+
+} // namespace pulp::view

--- a/core/view/include/pulp/view/widgets/svg_rect.hpp
+++ b/core/view/include/pulp/view/widgets/svg_rect.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+/// @file svg_rect.hpp
+/// A View that renders an inline SVG `<rect>` element. Targets HTML
+/// patterns of the form `<svg><rect x="0" y="0" width="100" height="20"
+/// fill="#f00" /></svg>` — common for band-shape thumbnails and other
+/// chart-style SVG primitives in React/HTML bundles.
+///
+/// Mirrors the SvgPathWidget API (pulp #965 / #994 / #1291): fill +
+/// stroke + stroke-width plumbing kept consistent so JS/JSX consumers
+/// see the same surface across the SVG primitives.
+
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/view/view.hpp>
+
+namespace pulp::view {
+
+/// Renders an inline SVG `<rect x y width height fill stroke
+/// stroke-width />`. The geometry is local to the widget origin (the
+/// widget's `bounds_` translation is applied by the View::paint_all
+/// machinery; paint() draws in local space).
+///
+/// Default state: zero-sized rect, opaque-black fill, no stroke. Setting
+/// fill / stroke independently lets consumers express the SVG defaults
+/// `fill="black" stroke="none"` and the common Spectr pattern of
+/// `fill="#xxx" stroke="none"` for solid bars.
+class SvgRectWidget : public View {
+public:
+    SvgRectWidget() = default;
+
+    /// Set the rect geometry. x/y are local to the widget origin (NOT
+    /// bounds()-translated). width/height < 0 are clamped to 0.
+    void set_rect(float x, float y, float width, float height);
+
+    /// Solid-fill paint. Pass an alpha-zero color or call clear_fill()
+    /// to disable filling. Default: opaque black, fill enabled.
+    void set_fill_color(canvas::Color c);
+    void clear_fill();
+
+    /// Solid-stroke paint. Pass an alpha-zero color or call
+    /// clear_stroke() to disable stroking. Default: no stroke.
+    void set_stroke_color(canvas::Color c);
+    void clear_stroke();
+
+    /// Stroke width in widget-local units. Default 1.
+    void set_stroke_width(float w);
+
+    // Accessors used by tests.
+    float rect_x() const { return x_; }
+    float rect_y() const { return y_; }
+    float rect_width() const { return w_; }
+    float rect_height() const { return h_; }
+    bool has_fill() const { return has_fill_; }
+    bool has_stroke() const { return has_stroke_; }
+    canvas::Color fill_color() const { return fill_color_; }
+    canvas::Color stroke_color() const { return stroke_color_; }
+    float stroke_width() const { return stroke_width_; }
+
+    void paint(canvas::Canvas& canvas) override;
+
+private:
+    float x_ = 0.0f;
+    float y_ = 0.0f;
+    float w_ = 0.0f;
+    float h_ = 0.0f;
+    canvas::Color fill_color_{0.0f, 0.0f, 0.0f, 1.0f};
+    canvas::Color stroke_color_{0.0f, 0.0f, 0.0f, 1.0f};
+    float stroke_width_ = 1.0f;
+    bool has_fill_ = true;
+    bool has_stroke_ = false;
+};
+
+} // namespace pulp::view

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -5,6 +5,8 @@
 #include <pulp/view/text_editor.hpp>
 #include <pulp/view/canvas_widget.hpp>
 #include <pulp/view/svg_path_widget.hpp>
+#include <pulp/view/widgets/svg_rect.hpp>
+#include <pulp/view/widgets/svg_line.hpp>
 #include <pulp/view/modal.hpp>
 #include <pulp/view/asset_manager.hpp>
 #include <pulp/view/design_import.hpp>
@@ -2427,28 +2429,41 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
+    // pulp #1416 — setSvgFill / setSvgStroke / setSvgStrokeWidth are
+    // polymorphic across all SVG-primitive widgets so JSX consumers see
+    // a uniform fill/stroke surface. SvgPathWidget is the legacy path
+    // (#965 / #994); SvgRectWidget and SvgLineWidget mirror the API with
+    // the same hex / "none" / strokeWidth semantics.
     engine_.register_function("setSvgFill", [this, parseHexColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
+        const bool clear = hex.empty() || hex == "none";
         if (auto* w = dynamic_cast<SvgPathWidget*>(widget(id))) {
-            if (hex.empty() || hex == "none") {
-                w->clear_fill();
-            } else {
-                w->set_fill_color(parseHexColor(hex));
-            }
+            if (clear) w->clear_fill();
+            else       w->set_fill_color(parseHexColor(hex));
+        } else if (auto* r = dynamic_cast<SvgRectWidget*>(widget(id))) {
+            if (clear) r->clear_fill();
+            else       r->set_fill_color(parseHexColor(hex));
         }
+        // SvgLineWidget has no fill semantics — the call is intentionally
+        // a no-op for line widgets so JSX consumers can pass `fill="none"`
+        // without bridge-level dispatch failures.
         return choc::value::Value();
     });
 
     engine_.register_function("setSvgStroke", [this, parseHexColor](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto hex = args.get<std::string>(1, "");
+        const bool clear = hex.empty() || hex == "none";
         if (auto* w = dynamic_cast<SvgPathWidget*>(widget(id))) {
-            if (hex.empty() || hex == "none") {
-                w->clear_stroke();
-            } else {
-                w->set_stroke_color(parseHexColor(hex));
-            }
+            if (clear) w->clear_stroke();
+            else       w->set_stroke_color(parseHexColor(hex));
+        } else if (auto* r = dynamic_cast<SvgRectWidget*>(widget(id))) {
+            if (clear) r->clear_stroke();
+            else       r->set_stroke_color(parseHexColor(hex));
+        } else if (auto* l = dynamic_cast<SvgLineWidget*>(widget(id))) {
+            if (clear) l->clear_stroke();
+            else       l->set_stroke_color(parseHexColor(hex));
         }
         return choc::value::Value();
     });
@@ -2456,8 +2471,65 @@ void WidgetBridge::register_api() {
     engine_.register_function("setSvgStrokeWidth", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");
         auto width = args.get<double>(1, 1.0);
+        const float fw = static_cast<float>(width);
         if (auto* w = dynamic_cast<SvgPathWidget*>(widget(id))) {
-            w->set_stroke_width(static_cast<float>(width));
+            w->set_stroke_width(fw);
+        } else if (auto* r = dynamic_cast<SvgRectWidget*>(widget(id))) {
+            r->set_stroke_width(fw);
+        } else if (auto* l = dynamic_cast<SvgLineWidget*>(widget(id))) {
+            l->set_stroke_width(fw);
+        }
+        return choc::value::Value();
+    });
+
+    // pulp #1416 — SvgRectWidget bridge. Mirrors createSvgPath /
+    // setSvgPath. Geometry is local to the widget origin (NOT
+    // bounds()-translated). x/y default to 0, w/h default to 0 so an
+    // un-set rect is invisible by default.
+    engine_.register_function("createSvgRect", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto pid = args.get<std::string>(1, "");
+        auto w = std::make_unique<SvgRectWidget>();
+        w->set_id(id);
+        widgets_[id] = w.get();
+        resolve_parent(pid)->add_child(std::move(w));
+        return choc::value::createString(id);
+    });
+
+    engine_.register_function("setSvgRect", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto x = args.get<double>(1, 0.0);
+        auto y = args.get<double>(2, 0.0);
+        auto width = args.get<double>(3, 0.0);
+        auto height = args.get<double>(4, 0.0);
+        if (auto* w = dynamic_cast<SvgRectWidget*>(widget(id))) {
+            w->set_rect(static_cast<float>(x), static_cast<float>(y),
+                        static_cast<float>(width), static_cast<float>(height));
+        }
+        return choc::value::Value();
+    });
+
+    // pulp #1416 — SvgLineWidget bridge. Mirrors createSvgPath /
+    // setSvgRect. Endpoints are local to the widget origin.
+    engine_.register_function("createSvgLine", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto pid = args.get<std::string>(1, "");
+        auto w = std::make_unique<SvgLineWidget>();
+        w->set_id(id);
+        widgets_[id] = w.get();
+        resolve_parent(pid)->add_child(std::move(w));
+        return choc::value::createString(id);
+    });
+
+    engine_.register_function("setSvgLine", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto x1 = args.get<double>(1, 0.0);
+        auto y1 = args.get<double>(2, 0.0);
+        auto x2 = args.get<double>(3, 0.0);
+        auto y2 = args.get<double>(4, 0.0);
+        if (auto* w = dynamic_cast<SvgLineWidget*>(widget(id))) {
+            w->set_line(static_cast<float>(x1), static_cast<float>(y1),
+                        static_cast<float>(x2), static_cast<float>(y2));
         }
         return choc::value::Value();
     });

--- a/core/view/src/widgets/svg_line.cpp
+++ b/core/view/src/widgets/svg_line.cpp
@@ -1,0 +1,34 @@
+#include <pulp/view/widgets/svg_line.hpp>
+
+#include <algorithm>
+
+namespace pulp::view {
+
+void SvgLineWidget::set_line(float x1, float y1, float x2, float y2) {
+    x1_ = x1;
+    y1_ = y1;
+    x2_ = x2;
+    y2_ = y2;
+}
+
+void SvgLineWidget::set_stroke_color(canvas::Color c) {
+    stroke_color_ = c;
+    has_stroke_ = true;
+}
+
+void SvgLineWidget::clear_stroke() {
+    has_stroke_ = false;
+}
+
+void SvgLineWidget::set_stroke_width(float w) {
+    stroke_width_ = std::max(0.0f, w);
+}
+
+void SvgLineWidget::paint(canvas::Canvas& canvas) {
+    if (!has_stroke_ || stroke_width_ <= 0.0f) return;
+    canvas.set_stroke_color(stroke_color_);
+    canvas.set_line_width(stroke_width_);
+    canvas.stroke_line(x1_, y1_, x2_, y2_);
+}
+
+} // namespace pulp::view

--- a/core/view/src/widgets/svg_rect.cpp
+++ b/core/view/src/widgets/svg_rect.cpp
@@ -1,0 +1,51 @@
+#include <pulp/view/widgets/svg_rect.hpp>
+
+#include <algorithm>
+
+namespace pulp::view {
+
+void SvgRectWidget::set_rect(float x, float y, float width, float height) {
+    x_ = x;
+    y_ = y;
+    w_ = std::max(0.0f, width);
+    h_ = std::max(0.0f, height);
+}
+
+void SvgRectWidget::set_fill_color(canvas::Color c) {
+    fill_color_ = c;
+    has_fill_ = true;
+}
+
+void SvgRectWidget::clear_fill() {
+    has_fill_ = false;
+}
+
+void SvgRectWidget::set_stroke_color(canvas::Color c) {
+    stroke_color_ = c;
+    has_stroke_ = true;
+}
+
+void SvgRectWidget::clear_stroke() {
+    has_stroke_ = false;
+}
+
+void SvgRectWidget::set_stroke_width(float w) {
+    stroke_width_ = std::max(0.0f, w);
+}
+
+void SvgRectWidget::paint(canvas::Canvas& canvas) {
+    if (w_ <= 0.0f || h_ <= 0.0f) return;
+    if (!has_fill_ && !(has_stroke_ && stroke_width_ > 0.0f)) return;
+
+    if (has_fill_) {
+        canvas.set_fill_color(fill_color_);
+        canvas.fill_rect(x_, y_, w_, h_);
+    }
+    if (has_stroke_ && stroke_width_ > 0.0f) {
+        canvas.set_stroke_color(stroke_color_);
+        canvas.set_line_width(stroke_width_);
+        canvas.stroke_rect(x_, y_, w_, h_);
+    }
+}
+
+} // namespace pulp::view

--- a/packages/pulp-react/package-lock.json
+++ b/packages/pulp-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pulp/react",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pulp/react",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "react-reconciler": "^0.29.2",

--- a/packages/pulp-react/src/bridge.ts
+++ b/packages/pulp-react/src/bridge.ts
@@ -197,6 +197,9 @@ export function createMockBridge(): MockBridge {
         // pulp #994 — SvgPath intrinsic surface
         'createSvgPath', 'setSvgPath', 'setSvgViewBox',
         'setSvgFill', 'setSvgStroke', 'setSvgStrokeWidth',
+        // pulp #1416 — SvgRect + SvgLine intrinsic surface
+        'createSvgRect', 'setSvgRect',
+        'createSvgLine', 'setSvgLine',
         // pulp #1148 — generalized overlay-click routing
         'claimOverlay', 'releaseOverlay',
     ];

--- a/packages/pulp-react/src/host-config.ts
+++ b/packages/pulp-react/src/host-config.ts
@@ -100,6 +100,8 @@ function createWidget(type: Type, id: string, parentId: string, props: Props): v
         case 'Image':       call('createImage', id, parentId); return;
         case 'Icon':        call('createIcon', id, parentId); return;
         case 'SvgPath':     call('createSvgPath', id, parentId); return;
+        case 'SvgRect':     call('createSvgRect', id, parentId); return;
+        case 'SvgLine':     call('createSvgLine', id, parentId); return;
         default: {
             // Should be unreachable thanks to the typed intrinsics in types.ts.
             const _exhaustive: never = type;

--- a/packages/pulp-react/src/index.ts
+++ b/packages/pulp-react/src/index.ts
@@ -94,6 +94,7 @@ export type {
     KnobProps, FaderProps, SpectrumProps, WaveformProps, MeterProps,
     ProgressProps, XYPadProps, CheckboxProps, ToggleProps, ComboProps,
     ListBoxProps, CanvasProps, ImageProps, IconProps, SvgPathProps,
+    SvgRectProps, SvgLineProps,
     FlexDirection, FlexAlign, FlexAlignSelf, FlexJustify,
     FlexProps, StyleProps, BaseProps,
     IntrinsicElementMap, IntrinsicElementName,

--- a/packages/pulp-react/src/intrinsics.ts
+++ b/packages/pulp-react/src/intrinsics.ts
@@ -13,6 +13,7 @@ import type {
     KnobProps, FaderProps, SpectrumProps, WaveformProps, MeterProps,
     ProgressProps, XYPadProps, CheckboxProps, ToggleProps, ComboProps,
     ListBoxProps, CanvasProps, ImageProps, IconProps, SvgPathProps,
+    SvgRectProps, SvgLineProps,
 } from './types.js';
 
 // Each intrinsic is a function component that emits a host element with
@@ -45,3 +46,5 @@ export const Canvas = (props: CanvasProps): ReactElement => createElement('Canva
 export const Image = (props: ImageProps): ReactElement => createElement('Image' as unknown as 'div', props as unknown as object);
 export const Icon = (props: IconProps): ReactElement => createElement('Icon' as unknown as 'div', props as unknown as object);
 export const SvgPath = (props: SvgPathProps): ReactElement => createElement('SvgPath' as unknown as 'div', props as unknown as object);
+export const SvgRect = (props: SvgRectProps): ReactElement => createElement('SvgRect' as unknown as 'div', props as unknown as object);
+export const SvgLine = (props: SvgLineProps): ReactElement => createElement('SvgLine' as unknown as 'div', props as unknown as object);

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -150,13 +150,56 @@ function applyEventHandler(id: string, key: string, value: unknown): void {
     });
 }
 
+/// pulp #1416 — emit one setSvgRect call carrying the full geometry
+/// (x, y, width, height). Driven by applyOne when ANY of the four
+/// geometry props change so the bridge never sees a partial update
+/// that would clobber unset axes back to zero. Reads current values
+/// from `props` (the live React props snapshot) and falls back to 0
+/// for un-set axes — matches SVG `<rect>` defaults.
+function emitSvgRectGeometry(id: string, props: Record<string, unknown>): void {
+    const x = typeof props.x === 'number' ? props.x as number : 0;
+    const y = typeof props.y === 'number' ? props.y as number : 0;
+    const w = typeof props.width === 'number' ? props.width as number : 0;
+    const h = typeof props.height === 'number' ? props.height as number : 0;
+    call('setSvgRect', id, x, y, w, h);
+}
+
+/// pulp #1416 — emit one setSvgLine call carrying the full geometry
+/// (x1, y1, x2, y2). Same partial-update guard as emitSvgRectGeometry.
+function emitSvgLineGeometry(id: string, props: Record<string, unknown>): void {
+    const x1 = typeof props.x1 === 'number' ? props.x1 as number : 0;
+    const y1 = typeof props.y1 === 'number' ? props.y1 as number : 0;
+    const x2 = typeof props.x2 === 'number' ? props.x2 as number : 0;
+    const y2 = typeof props.y2 === 'number' ? props.y2 as number : 0;
+    call('setSvgLine', id, x1, y1, x2, y2);
+}
+
 /// Apply a single prop to its corresponding bridge setter.
-function applyOne(id: string, type: string, key: string, value: unknown): void {
+function applyOne(id: string, type: string, key: string, value: unknown, props?: Record<string, unknown>): void {
     if (value === undefined || value === null) {
         // No-op — Pulp has no "unset" for most setters; rely on React
         // unmount + recreate for full clears. Selective resets can be
         // added per-prop here if a regression appears.
         return;
+    }
+
+    // pulp #1416 — SvgRect / SvgLine geometry props collide with View
+    // flex props (width/height) and event/positioning props (x/y), so
+    // dispatch on `type` BEFORE the generic flex routing. The geometry
+    // setters are atomic — one bridge call per rect/line carries the
+    // full quad of coords — to avoid partial updates clobbering the
+    // unset axes back to zero.
+    if (type === 'SvgRect') {
+        if (key === 'x' || key === 'y' || key === 'width' || key === 'height') {
+            if (props) emitSvgRectGeometry(id, props);
+            return;
+        }
+    }
+    if (type === 'SvgLine') {
+        if (key === 'x1' || key === 'y1' || key === 'x2' || key === 'y2') {
+            if (props) emitSvgLineGeometry(id, props);
+            return;
+        }
     }
 
     switch (key) {
@@ -319,6 +362,22 @@ function applyOne(id: string, type: string, key: string, value: unknown): void {
 export function applyAllProps(instance: PulpInstance): void {
     const { id, type, props } = instance;
     logApply('applyAll', id, type, Object.keys(props).length);
+    // pulp #1416 — for SvgRect / SvgLine, emit the geometry call once
+    // up-front from the full props snapshot, then skip the per-prop
+    // dispatch for the four geometry keys (otherwise we'd issue four
+    // identical setSvgRect / setSvgLine calls during the loop).
+    let svgGeometryEmitted = false;
+    if (type === 'SvgRect') {
+        if (('x' in props) || ('y' in props) || ('width' in props) || ('height' in props)) {
+            emitSvgRectGeometry(id, props);
+            svgGeometryEmitted = true;
+        }
+    } else if (type === 'SvgLine') {
+        if (('x1' in props) || ('y1' in props) || ('x2' in props) || ('y2' in props)) {
+            emitSvgLineGeometry(id, props);
+            svgGeometryEmitted = true;
+        }
+    }
     for (const key of Object.keys(props)) {
         if (isReactInternal(key)) continue;
         if (key === 'children') continue;  // text children handled by caller
@@ -326,7 +385,11 @@ export function applyAllProps(instance: PulpInstance): void {
             applyEventHandler(id, key, props[key]);
             continue;
         }
-        applyOne(id, type, key, props[key]);
+        if (svgGeometryEmitted) {
+            if (type === 'SvgRect' && (key === 'x' || key === 'y' || key === 'width' || key === 'height')) continue;
+            if (type === 'SvgLine' && (key === 'x1' || key === 'y1' || key === 'x2' || key === 'y2')) continue;
+        }
+        applyOne(id, type, key, props[key], props);
     }
 }
 
@@ -340,15 +403,44 @@ export function applyChangedProps(
     const { id, type } = instance;
     let mutated = false;
 
+    // pulp #1416 — coalesce SvgRect / SvgLine geometry changes into a
+    // single setSvgRect / setSvgLine call sourced from the post-update
+    // props snapshot. Without this, four separate prop diffs would each
+    // try to emit a partial geometry update.
+    const svgRectGeoChanged = type === 'SvgRect' && (
+        oldProps.x !== newProps.x ||
+        oldProps.y !== newProps.y ||
+        oldProps.width !== newProps.width ||
+        oldProps.height !== newProps.height
+    );
+    const svgLineGeoChanged = type === 'SvgLine' && (
+        oldProps.x1 !== newProps.x1 ||
+        oldProps.y1 !== newProps.y1 ||
+        oldProps.x2 !== newProps.x2 ||
+        oldProps.y2 !== newProps.y2
+    );
+    if (svgRectGeoChanged) {
+        emitSvgRectGeometry(id, newProps);
+        mutated = true;
+    }
+    if (svgLineGeoChanged) {
+        emitSvgLineGeometry(id, newProps);
+        mutated = true;
+    }
+
     // Walk new props — set anything that changed value
     for (const key of Object.keys(newProps)) {
         if (isReactInternal(key)) continue;
         if (key === 'children') continue;
+        // SvgRect / SvgLine geometry already emitted above; skip the
+        // per-prop dispatch so we don't double-fire bridge calls.
+        if (svgRectGeoChanged && type === 'SvgRect' && (key === 'x' || key === 'y' || key === 'width' || key === 'height')) continue;
+        if (svgLineGeoChanged && type === 'SvgLine' && (key === 'x1' || key === 'y1' || key === 'x2' || key === 'y2')) continue;
         if (oldProps[key] !== newProps[key]) {
             if (isEventHandler(key)) {
                 applyEventHandler(id, key, newProps[key]);
             } else {
-                applyOne(id, type, key, newProps[key]);
+                applyOne(id, type, key, newProps[key], newProps);
             }
             mutated = true;
         }

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -217,6 +217,47 @@ export interface SvgPathProps extends BaseProps {
     strokeWidth?: number;
 }
 
+/// Inline SVG `<rect>` widget (pulp #1416). Renders a rectangle with
+/// the configured x/y/width/height + fill/stroke. Pairs with SvgLine
+/// for chart-style and band-shape thumbnail UIs (Spectr [G] preset
+/// manager).
+export interface SvgRectProps extends BaseProps {
+    /// Rect origin x in widget-local units. Defaults to 0.
+    x?: number;
+    /// Rect origin y in widget-local units. Defaults to 0.
+    y?: number;
+    /// Rect width in widget-local units. Defaults to 0 (invisible).
+    width?: number;
+    /// Rect height in widget-local units. Defaults to 0 (invisible).
+    height?: number;
+    /// Fill color as hex (`#rrggbb` / `#rrggbbaa`) or `"none"`. Default
+    /// is opaque black (matches SVG `<rect>` default of `fill="black"`).
+    fill?: string;
+    /// Stroke color as hex or `"none"`. Default: no stroke.
+    stroke?: string;
+    /// Stroke width in widget-local units. Default 1.
+    strokeWidth?: number;
+}
+
+/// Inline SVG `<line>` widget (pulp #1416). Renders a 1-D line from
+/// (x1, y1) to (x2, y2) with the configured stroke + width. SVG
+/// `<line>` has no fill; for API consistency with `<rect>` and
+/// `<path>` the bridge exposes `fill` but it's a no-op for lines.
+export interface SvgLineProps extends BaseProps {
+    /// Start endpoint x in widget-local units. Defaults to 0.
+    x1?: number;
+    /// Start endpoint y in widget-local units. Defaults to 0.
+    y1?: number;
+    /// End endpoint x in widget-local units. Defaults to 0.
+    x2?: number;
+    /// End endpoint y in widget-local units. Defaults to 0.
+    y2?: number;
+    /// Stroke color as hex or `"none"`. Default: opaque black.
+    stroke?: string;
+    /// Stroke width in widget-local units. Default 1.
+    strokeWidth?: number;
+}
+
 // ── Element-name → intrinsic-props map ──────────────────────────────
 // The host config consults this implicitly; tests assert names against it.
 export interface IntrinsicElementMap {
@@ -244,6 +285,8 @@ export interface IntrinsicElementMap {
     Image: ImageProps;
     Icon: IconProps;
     SvgPath: SvgPathProps;
+    SvgRect: SvgRectProps;
+    SvgLine: SvgLineProps;
 }
 
 export type IntrinsicElementName = keyof IntrinsicElementMap;

--- a/packages/pulp-react/test/svgrect-svgline-intrinsic.test.ts
+++ b/packages/pulp-react/test/svgrect-svgline-intrinsic.test.ts
@@ -1,0 +1,276 @@
+// Test for pulp #1416 — @pulp/react SvgRect + SvgLine intrinsics.
+//
+// The C++ side ships SvgRectWidget + SvgLineWidget + bridge handlers
+// (createSvgRect / setSvgRect / createSvgLine / setSvgLine, plus the
+// shared setSvgFill / setSvgStroke / setSvgStrokeWidth setters made
+// polymorphic across all three SVG-primitive widget types). This wires
+// the React-side intrinsics so JSX
+//   <SvgRect x={10} y={20} width={50} height={30} fill="#f00" />
+//   <SvgLine x1={0} y1={0} x2={100} y2={100} stroke="#0f0" />
+// reach the bridge.
+//
+// Closes Spectr [G] (preset manager band-shape thumbnails currently
+// blank — MiniPreview renders <svg><rect> per band + <line>, dom-adapter
+// maps to <View>, and without these intrinsics the geometry props are
+// dropped silently).
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import { SvgLine, SvgRect } from '../src/intrinsics.js';
+import { applyAllProps, applyChangedProps } from '../src/prop-applier.js';
+import type { PulpInstance } from '../src/types.js';
+
+function instance(id: string, type: string, props: Record<string, unknown>): PulpInstance {
+    return { id, type, props } as PulpInstance;
+}
+
+describe('@pulp/react SvgRect intrinsic (pulp #1416)', () => {
+    let bridge: MockBridge;
+    beforeEach(() => {
+        bridge = createMockBridge();
+        bridge.install();
+    });
+    afterEach(() => {
+        bridge.uninstall();
+    });
+
+    it('export is a function component', () => {
+        expect(typeof SvgRect).toBe('function');
+    });
+
+    it('forwards x/y/width/height to a single setSvgRect call', () => {
+        applyAllProps(instance('bar1', 'SvgRect', {
+            x: 10, y: 20, width: 50, height: 30,
+        }));
+        const setRect = bridge.calls.filter((c) => c.fn === 'setSvgRect');
+        // Critical: ONE atomic call carrying the full geometry, not four
+        // partial updates that would clobber unset axes back to zero.
+        expect(setRect.length).toBe(1);
+        expect(setRect[0].args).toEqual(['bar1', 10, 20, 50, 30]);
+    });
+
+    it('forwards `fill` to setSvgFill', () => {
+        applyAllProps(instance('bar2', 'SvgRect', {
+            x: 0, y: 0, width: 10, height: 10,
+            fill: '#ff0000',
+        }));
+        const setFill = bridge.calls.filter((c) => c.fn === 'setSvgFill');
+        expect(setFill.length).toBe(1);
+        expect(setFill[0].args).toEqual(['bar2', '#ff0000']);
+    });
+
+    it('forwards `fill="none"` (clears via bridge)', () => {
+        applyAllProps(instance('bar3', 'SvgRect', {
+            width: 10, height: 10, fill: 'none',
+        }));
+        const setFill = bridge.calls.filter((c) => c.fn === 'setSvgFill');
+        expect(setFill[0].args).toEqual(['bar3', 'none']);
+    });
+
+    it('forwards `stroke` and `strokeWidth` together', () => {
+        applyAllProps(instance('bar4', 'SvgRect', {
+            width: 10, height: 10,
+            stroke: '#000000', strokeWidth: 2,
+        }));
+        const setStroke = bridge.calls.filter((c) => c.fn === 'setSvgStroke');
+        const setSW = bridge.calls.filter((c) => c.fn === 'setSvgStrokeWidth');
+        expect(setStroke[0].args).toEqual(['bar4', '#000000']);
+        expect(setSW[0].args).toEqual(['bar4', 2]);
+    });
+
+    it('emits all setters when full prop set is applied', () => {
+        applyAllProps(instance('bar5', 'SvgRect', {
+            x: 1, y: 2, width: 30, height: 40,
+            fill: '#ffffff', stroke: '#000000', strokeWidth: 1.5,
+        }));
+        const fns = bridge.calls.map((c) => c.fn).filter((n) =>
+            ['setSvgRect', 'setSvgFill', 'setSvgStroke', 'setSvgStrokeWidth'].includes(n)
+        );
+        expect(fns.sort()).toEqual([
+            'setSvgFill', 'setSvgRect', 'setSvgStroke', 'setSvgStrokeWidth',
+        ]);
+        const setRect = bridge.calls.filter((c) => c.fn === 'setSvgRect');
+        expect(setRect[0].args).toEqual(['bar5', 1, 2, 30, 40]);
+    });
+
+    it('default-fills missing geometry props with 0', () => {
+        // Only width/height set — x/y default to 0 (matches SVG <rect>).
+        applyAllProps(instance('bar6', 'SvgRect', {
+            width: 100, height: 20,
+        }));
+        const setRect = bridge.calls.filter((c) => c.fn === 'setSvgRect');
+        expect(setRect.length).toBe(1);
+        expect(setRect[0].args).toEqual(['bar6', 0, 0, 100, 20]);
+    });
+
+    it('does NOT route width/height through setFlex for SvgRect', () => {
+        // Critical: width/height on a View intrinsic go through Yoga
+        // (setFlex), but on SvgRect they're rect-geometry. Type-aware
+        // dispatch must keep them out of the flex pipeline.
+        applyAllProps(instance('bar7', 'SvgRect', {
+            x: 0, y: 0, width: 50, height: 30,
+        }));
+        const flex = bridge.calls.filter((c) => c.fn === 'setFlex');
+        expect(flex.length).toBe(0);
+    });
+
+    it('commitUpdate coalesces a geometry change into one setSvgRect', () => {
+        applyChangedProps(
+            instance('bar8', 'SvgRect', {}),
+            { x: 0, y: 0, width: 10, height: 10, fill: '#aaa' },
+            { x: 0, y: 0, width: 20, height: 10, fill: '#aaa' },
+        );
+        const setRect = bridge.calls.filter((c) => c.fn === 'setSvgRect');
+        const setFill = bridge.calls.filter((c) => c.fn === 'setSvgFill');
+        expect(setRect.length).toBe(1);
+        expect(setRect[0].args).toEqual(['bar8', 0, 0, 20, 10]);
+        expect(setFill.length).toBe(0);  // unchanged
+    });
+
+    it('commitUpdate does not re-emit setSvgRect when only fill changed', () => {
+        applyChangedProps(
+            instance('bar9', 'SvgRect', {}),
+            { x: 0, y: 0, width: 10, height: 10, fill: '#aaa' },
+            { x: 0, y: 0, width: 10, height: 10, fill: '#bbb' },
+        );
+        const setRect = bridge.calls.filter((c) => c.fn === 'setSvgRect');
+        const setFill = bridge.calls.filter((c) => c.fn === 'setSvgFill');
+        expect(setRect.length).toBe(0);
+        expect(setFill.length).toBe(1);
+        expect(setFill[0].args).toEqual(['bar9', '#bbb']);
+    });
+});
+
+describe('@pulp/react SvgLine intrinsic (pulp #1416)', () => {
+    let bridge: MockBridge;
+    beforeEach(() => {
+        bridge = createMockBridge();
+        bridge.install();
+    });
+    afterEach(() => {
+        bridge.uninstall();
+    });
+
+    it('export is a function component', () => {
+        expect(typeof SvgLine).toBe('function');
+    });
+
+    it('forwards x1/y1/x2/y2 to a single setSvgLine call', () => {
+        applyAllProps(instance('axis1', 'SvgLine', {
+            x1: 0, y1: 0, x2: 100, y2: 100,
+        }));
+        const setLine = bridge.calls.filter((c) => c.fn === 'setSvgLine');
+        expect(setLine.length).toBe(1);
+        expect(setLine[0].args).toEqual(['axis1', 0, 0, 100, 100]);
+    });
+
+    it('forwards `stroke` to setSvgStroke', () => {
+        applyAllProps(instance('axis2', 'SvgLine', {
+            x1: 0, y1: 0, x2: 50, y2: 0,
+            stroke: '#00ff00',
+        }));
+        const setStroke = bridge.calls.filter((c) => c.fn === 'setSvgStroke');
+        expect(setStroke.length).toBe(1);
+        expect(setStroke[0].args).toEqual(['axis2', '#00ff00']);
+    });
+
+    it('forwards `strokeWidth`', () => {
+        applyAllProps(instance('axis3', 'SvgLine', {
+            x1: 0, y1: 0, x2: 10, y2: 0,
+            strokeWidth: 2.5,
+        }));
+        const setSW = bridge.calls.filter((c) => c.fn === 'setSvgStrokeWidth');
+        expect(setSW[0].args).toEqual(['axis3', 2.5]);
+    });
+
+    it('default-fills missing endpoint props with 0', () => {
+        applyAllProps(instance('axis4', 'SvgLine', {
+            x2: 100,
+        }));
+        const setLine = bridge.calls.filter((c) => c.fn === 'setSvgLine');
+        expect(setLine.length).toBe(1);
+        expect(setLine[0].args).toEqual(['axis4', 0, 0, 100, 0]);
+    });
+
+    it('does NOT emit setSvgLine when no geometry prop set', () => {
+        applyAllProps(instance('axis5', 'SvgLine', {
+            stroke: '#000',
+        }));
+        const setLine = bridge.calls.filter((c) => c.fn === 'setSvgLine');
+        expect(setLine.length).toBe(0);
+    });
+
+    it('emits all setters when full prop set is applied', () => {
+        applyAllProps(instance('axis6', 'SvgLine', {
+            x1: 0, y1: 10, x2: 100, y2: 10,
+            stroke: '#0f0', strokeWidth: 1,
+        }));
+        const fns = bridge.calls.map((c) => c.fn).filter((n) =>
+            ['setSvgLine', 'setSvgStroke', 'setSvgStrokeWidth'].includes(n)
+        );
+        expect(fns.sort()).toEqual([
+            'setSvgLine', 'setSvgStroke', 'setSvgStrokeWidth',
+        ]);
+    });
+
+    it('commitUpdate coalesces an endpoint change into one setSvgLine', () => {
+        applyChangedProps(
+            instance('axis7', 'SvgLine', {}),
+            { x1: 0, y1: 0, x2: 10, y2: 0, stroke: '#000' },
+            { x1: 0, y1: 0, x2: 20, y2: 0, stroke: '#000' },
+        );
+        const setLine = bridge.calls.filter((c) => c.fn === 'setSvgLine');
+        const setStroke = bridge.calls.filter((c) => c.fn === 'setSvgStroke');
+        expect(setLine.length).toBe(1);
+        expect(setLine[0].args).toEqual(['axis7', 0, 0, 20, 0]);
+        expect(setStroke.length).toBe(0);
+    });
+});
+
+describe('@pulp/react SvgRect/SvgLine host-config attachment (pulp #1416)', () => {
+    let bridge: MockBridge;
+    beforeEach(() => {
+        bridge = createMockBridge();
+        bridge.install();
+    });
+    afterEach(() => {
+        bridge.uninstall();
+    });
+
+    // The host config's createInstance does NOT call the bridge — it
+    // defers attachment to appendInitialChild / appendChild (the parent
+    // isn't known at createInstance time). So we exercise the full
+    // create+attach lifecycle here and assert the bridge sees the
+    // correct createX call for the new SVG primitives.
+    it('appendChildToContainer routes SvgRect through createSvgRect', async () => {
+        const hc = await import('../src/host-config.js');
+        const container = { rootId: 'root', nextId: 0 } as never;
+        const child = hc.PulpHostConfig.createInstance(
+            'SvgRect' as never,
+            { x: 0, y: 0, width: 10, height: 10 } as never,
+            container,
+            {} as never,
+            null as never,
+        );
+        // appendChildToContainer attaches under the bridge root (always
+        // on-bridge), so it's the trigger that flushes the createX call.
+        hc.PulpHostConfig.appendChildToContainer(container, child);
+        const created = bridge.calls.filter((c) => c.fn === 'createSvgRect');
+        expect(created.length).toBe(1);
+    });
+
+    it('appendChildToContainer routes SvgLine through createSvgLine', async () => {
+        const hc = await import('../src/host-config.js');
+        const container = { rootId: 'root', nextId: 0 } as never;
+        const child = hc.PulpHostConfig.createInstance(
+            'SvgLine' as never,
+            { x1: 0, y1: 0, x2: 10, y2: 10 } as never,
+            container,
+            {} as never,
+            null as never,
+        );
+        hc.PulpHostConfig.appendChildToContainer(container, child);
+        const created = bridge.calls.filter((c) => c.fn === 'createSvgLine');
+        expect(created.length).toBe(1);
+    });
+});

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1537,6 +1537,11 @@ add_executable(pulp-test-svg-path-widget test_svg_path_widget.cpp)
 target_link_libraries(pulp-test-svg-path-widget PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-svg-path-widget)
 
+# SvgRect + SvgLine widget tests (issue-1416)
+add_executable(pulp-test-svg-rect-widget test_svg_rect_widget.cpp)
+target_link_libraries(pulp-test-svg-rect-widget PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-svg-rect-widget)
+
 # ScrollView tests
 add_executable(pulp-test-scroll-view test_scroll_view.cpp)
 target_link_libraries(pulp-test-scroll-view PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/test_svg_rect_widget.cpp
+++ b/test/test_svg_rect_widget.cpp
@@ -1,0 +1,241 @@
+// SvgRect + SvgLine widget tests — pulp #1416.
+//
+// Coverage targets:
+//   * Defaults match SVG semantics (rect: fill=black, no stroke;
+//     line: opaque-black stroke, width 1).
+//   * paint() emits fill_rect at the configured x/y/w/h with the
+//     stored color.
+//   * paint() emits stroke_rect when has_stroke + width > 0.
+//   * paint() is a no-op when w/h is zero or both fill+stroke disabled.
+//   * stroke_line is emitted at the configured endpoints.
+//   * set_stroke_width clamps negatives to zero.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/view/widgets/svg_line.hpp>
+#include <pulp/view/widgets/svg_rect.hpp>
+
+using pulp::canvas::Color;
+using pulp::canvas::DrawCommand;
+using pulp::canvas::RecordingCanvas;
+using pulp::view::SvgLineWidget;
+using pulp::view::SvgRectWidget;
+
+namespace {
+
+const DrawCommand* find(const RecordingCanvas& rc, DrawCommand::Type t) {
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == t) return &cmd;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+TEST_CASE("SvgRectWidget defaults match SVG <rect>", "[svg_rect][issue-1416]") {
+    SvgRectWidget w;
+    REQUIRE(w.has_fill());
+    REQUIRE_FALSE(w.has_stroke());
+    REQUIRE(w.stroke_width() == 1.0f);
+    REQUIRE(w.rect_x() == 0.0f);
+    REQUIRE(w.rect_y() == 0.0f);
+    REQUIRE(w.rect_width() == 0.0f);
+    REQUIRE(w.rect_height() == 0.0f);
+}
+
+TEST_CASE("SvgRectWidget set_rect stores geometry, clamps negative size",
+          "[svg_rect][issue-1416]") {
+    SvgRectWidget w;
+    w.set_rect(10.0f, 20.0f, 50.0f, 30.0f);
+    REQUIRE(w.rect_x() == 10.0f);
+    REQUIRE(w.rect_y() == 20.0f);
+    REQUIRE(w.rect_width() == 50.0f);
+    REQUIRE(w.rect_height() == 30.0f);
+
+    // Negative width / height clamp to 0 — paint() then short-circuits.
+    w.set_rect(0.0f, 0.0f, -5.0f, -3.0f);
+    REQUIRE(w.rect_width() == 0.0f);
+    REQUIRE(w.rect_height() == 0.0f);
+}
+
+TEST_CASE("SvgRectWidget paint emits fill_rect with the configured color",
+          "[svg_rect][issue-1416]") {
+    SvgRectWidget w;
+    w.set_rect(10.0f, 20.0f, 50.0f, 30.0f);
+    w.set_fill_color(Color::rgba8(255, 0, 0));
+
+    RecordingCanvas rc;
+    w.paint(rc);
+
+    const auto* fill = find(rc, DrawCommand::Type::fill_rect);
+    REQUIRE(fill != nullptr);
+    REQUIRE(fill->f[0] == 10.0f);
+    REQUIRE(fill->f[1] == 20.0f);
+    REQUIRE(fill->f[2] == 50.0f);
+    REQUIRE(fill->f[3] == 30.0f);
+
+    // The set_fill_color call must precede the fill_rect so the stored
+    // color is the one the canvas applies — the recorded set_fill_color
+    // command therefore appears earlier in the stream.
+    const auto* set_color = find(rc, DrawCommand::Type::set_fill_color);
+    REQUIRE(set_color != nullptr);
+    REQUIRE(set_color->color.r8() == 255);
+    REQUIRE(set_color->color.g8() == 0);
+    REQUIRE(set_color->color.b8() == 0);
+}
+
+TEST_CASE("SvgRectWidget paint emits stroke_rect when stroke is set",
+          "[svg_rect][issue-1416]") {
+    SvgRectWidget w;
+    w.set_rect(0.0f, 0.0f, 12.0f, 8.0f);
+    w.clear_fill();
+    w.set_stroke_color(Color::rgba8(0, 0, 255));
+    w.set_stroke_width(2.0f);
+
+    RecordingCanvas rc;
+    w.paint(rc);
+
+    const auto* stroke = find(rc, DrawCommand::Type::stroke_rect);
+    REQUIRE(stroke != nullptr);
+    REQUIRE(stroke->f[0] == 0.0f);
+    REQUIRE(stroke->f[1] == 0.0f);
+    REQUIRE(stroke->f[2] == 12.0f);
+    REQUIRE(stroke->f[3] == 8.0f);
+
+    // No fill_rect should appear.
+    REQUIRE(find(rc, DrawCommand::Type::fill_rect) == nullptr);
+}
+
+TEST_CASE("SvgRectWidget paint is a no-op when geometry is zero",
+          "[svg_rect][issue-1416]") {
+    SvgRectWidget w;
+    w.set_fill_color(Color::rgba8(255, 0, 0));
+    // Default width/height = 0.
+
+    RecordingCanvas rc;
+    w.paint(rc);
+
+    REQUIRE(find(rc, DrawCommand::Type::fill_rect) == nullptr);
+    REQUIRE(find(rc, DrawCommand::Type::stroke_rect) == nullptr);
+}
+
+TEST_CASE("SvgRectWidget paint is a no-op when both fill and stroke disabled",
+          "[svg_rect][issue-1416]") {
+    SvgRectWidget w;
+    w.set_rect(0.0f, 0.0f, 10.0f, 10.0f);
+    w.clear_fill();
+    // Default has_stroke_ is false.
+
+    RecordingCanvas rc;
+    w.paint(rc);
+    REQUIRE(rc.commands().empty());
+}
+
+TEST_CASE("SvgRectWidget paint emits both fill and stroke when both enabled",
+          "[svg_rect][issue-1416]") {
+    SvgRectWidget w;
+    w.set_rect(1.0f, 2.0f, 30.0f, 40.0f);
+    w.set_fill_color(Color::rgba8(10, 20, 30));
+    w.set_stroke_color(Color::rgba8(40, 50, 60));
+    w.set_stroke_width(1.5f);
+
+    RecordingCanvas rc;
+    w.paint(rc);
+
+    REQUIRE(find(rc, DrawCommand::Type::fill_rect) != nullptr);
+    REQUIRE(find(rc, DrawCommand::Type::stroke_rect) != nullptr);
+}
+
+TEST_CASE("SvgRectWidget set_stroke_width clamps negatives to zero",
+          "[svg_rect][issue-1416]") {
+    SvgRectWidget w;
+    w.set_stroke_width(-3.0f);
+    REQUIRE(w.stroke_width() == 0.0f);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// SvgLineWidget tests
+// ─────────────────────────────────────────────────────────────────────
+
+TEST_CASE("SvgLineWidget defaults match SVG <line>", "[svg_line][issue-1416]") {
+    SvgLineWidget w;
+    REQUIRE(w.has_stroke());
+    REQUIRE(w.stroke_width() == 1.0f);
+    REQUIRE(w.x1() == 0.0f);
+    REQUIRE(w.y1() == 0.0f);
+    REQUIRE(w.x2() == 0.0f);
+    REQUIRE(w.y2() == 0.0f);
+}
+
+TEST_CASE("SvgLineWidget set_line stores endpoints", "[svg_line][issue-1416]") {
+    SvgLineWidget w;
+    w.set_line(1.0f, 2.0f, 100.0f, 200.0f);
+    REQUIRE(w.x1() == 1.0f);
+    REQUIRE(w.y1() == 2.0f);
+    REQUIRE(w.x2() == 100.0f);
+    REQUIRE(w.y2() == 200.0f);
+}
+
+TEST_CASE("SvgLineWidget paint emits stroke_line at configured endpoints",
+          "[svg_line][issue-1416]") {
+    SvgLineWidget w;
+    w.set_line(5.0f, 10.0f, 95.0f, 90.0f);
+    w.set_stroke_color(Color::rgba8(0, 255, 0));
+    w.set_stroke_width(3.0f);
+
+    RecordingCanvas rc;
+    w.paint(rc);
+
+    const auto* line = find(rc, DrawCommand::Type::stroke_line);
+    REQUIRE(line != nullptr);
+    REQUIRE(line->f[0] == 5.0f);
+    REQUIRE(line->f[1] == 10.0f);
+    REQUIRE(line->f[2] == 95.0f);
+    REQUIRE(line->f[3] == 90.0f);
+
+    const auto* set_color = find(rc, DrawCommand::Type::set_stroke_color);
+    REQUIRE(set_color != nullptr);
+    REQUIRE(set_color->color.r8() == 0);
+    REQUIRE(set_color->color.g8() == 255);
+    REQUIRE(set_color->color.b8() == 0);
+
+    // set_line_width must precede stroke_line so the recorded width
+    // applies to the segment.
+    bool saw_width = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == DrawCommand::Type::set_line_width) {
+            REQUIRE(cmd.f[0] == 3.0f);
+            saw_width = true;
+        }
+    }
+    REQUIRE(saw_width);
+}
+
+TEST_CASE("SvgLineWidget paint is a no-op when stroke disabled",
+          "[svg_line][issue-1416]") {
+    SvgLineWidget w;
+    w.set_line(0.0f, 0.0f, 10.0f, 10.0f);
+    w.clear_stroke();
+
+    RecordingCanvas rc;
+    w.paint(rc);
+    REQUIRE(rc.commands().empty());
+}
+
+TEST_CASE("SvgLineWidget paint is a no-op when stroke width is zero",
+          "[svg_line][issue-1416]") {
+    SvgLineWidget w;
+    w.set_line(0.0f, 0.0f, 10.0f, 10.0f);
+    w.set_stroke_width(0.0f);
+
+    RecordingCanvas rc;
+    w.paint(rc);
+    REQUIRE(rc.commands().empty());
+}
+
+TEST_CASE("SvgLineWidget set_stroke_width clamps negatives to zero",
+          "[svg_line][issue-1416]") {
+    SvgLineWidget w;
+    w.set_stroke_width(-1.0f);
+    REQUIRE(w.stroke_width() == 0.0f);
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -3809,3 +3809,190 @@ TEST_CASE("CSSStyleDeclaration translates textOverflow to setTextOverflow bridge
     REQUIRE(label != nullptr);
     REQUIRE(label->text_overflow_ellipsis());
 }
+
+// ── pulp #1416 — SvgRectWidget + SvgLineWidget JS bridge integration ─────────
+//
+// Mirrors the #965 SvgPath bridge tests. Closes Spectr [G] preset
+// manager band-shape thumbnails: MiniPreview renders <svg><rect> per
+// band + <line> separators, which dom-adapter routes to <View> with
+// SVG attribute props. Without these bridge handlers the geometry is
+// dropped on the floor and the tiles render blank.
+
+#include <pulp/view/widgets/svg_line.hpp>
+#include <pulp/view/widgets/svg_rect.hpp>
+
+TEST_CASE("WidgetBridge createSvgRect produces a SvgRectWidget the bridge can address",
+          "[view][bridge][issue-1416]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createSvgRect('bar', '')");
+    bridge.load_script("setSvgRect('bar', 10, 20, 50, 30)");
+    bridge.load_script("setSvgFill('bar', '#ff0000')");
+    bridge.load_script("setSvgStroke('bar', '#000000')");
+    bridge.load_script("setSvgStrokeWidth('bar', 2.0)");
+
+    auto* w = dynamic_cast<SvgRectWidget*>(bridge.widget("bar"));
+    REQUIRE(w != nullptr);
+    REQUIRE(w->rect_x() == 10.0f);
+    REQUIRE(w->rect_y() == 20.0f);
+    REQUIRE(w->rect_width() == 50.0f);
+    REQUIRE(w->rect_height() == 30.0f);
+    REQUIRE(w->has_fill());
+    REQUIRE(w->has_stroke());
+    REQUIRE(w->stroke_width() == 2.0f);
+    REQUIRE(w->fill_color().r8() == 255);
+    REQUIRE(w->fill_color().g8() == 0);
+    REQUIRE(w->fill_color().b8() == 0);
+}
+
+TEST_CASE("WidgetBridge setSvgFill 'none' disables fill on SvgRectWidget",
+          "[view][bridge][issue-1416]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createSvgRect('a', '')");
+    bridge.load_script("setSvgRect('a', 0, 0, 10, 10)");
+    bridge.load_script("setSvgFill('a', 'none')");
+    bridge.load_script("setSvgStroke('a', '#222222')");
+    bridge.load_script("setSvgStrokeWidth('a', 1.5)");
+
+    auto* w = dynamic_cast<SvgRectWidget*>(bridge.widget("a"));
+    REQUIRE(w != nullptr);
+    REQUIRE_FALSE(w->has_fill());
+    REQUIRE(w->has_stroke());
+    REQUIRE(w->stroke_width() == 1.5f);
+}
+
+TEST_CASE("WidgetBridge createSvgRect + paint produces fill_rect at expected geometry",
+          "[view][bridge][issue-1416]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createSvgRect('bar', '')");
+    bridge.load_script("setSvgRect('bar', 5, 6, 40, 8)");
+    bridge.load_script("setSvgFill('bar', '#00ff00')");
+
+    auto* w = dynamic_cast<SvgRectWidget*>(bridge.widget("bar"));
+    REQUIRE(w != nullptr);
+
+    pulp::canvas::RecordingCanvas rc;
+    w->paint(rc);
+
+    bool saw_fill = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::fill_rect) {
+            REQUIRE(cmd.f[0] == 5.0f);
+            REQUIRE(cmd.f[1] == 6.0f);
+            REQUIRE(cmd.f[2] == 40.0f);
+            REQUIRE(cmd.f[3] == 8.0f);
+            saw_fill = true;
+        }
+    }
+    REQUIRE(saw_fill);
+}
+
+TEST_CASE("WidgetBridge createSvgLine produces a SvgLineWidget the bridge can address",
+          "[view][bridge][issue-1416]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createSvgLine('sep', '')");
+    bridge.load_script("setSvgLine('sep', 0, 10, 100, 10)");
+    bridge.load_script("setSvgStroke('sep', '#0000ff')");
+    bridge.load_script("setSvgStrokeWidth('sep', 1.5)");
+
+    auto* w = dynamic_cast<SvgLineWidget*>(bridge.widget("sep"));
+    REQUIRE(w != nullptr);
+    REQUIRE(w->x1() == 0.0f);
+    REQUIRE(w->y1() == 10.0f);
+    REQUIRE(w->x2() == 100.0f);
+    REQUIRE(w->y2() == 10.0f);
+    REQUIRE(w->has_stroke());
+    REQUIRE(w->stroke_width() == 1.5f);
+    REQUIRE(w->stroke_color().r8() == 0);
+    REQUIRE(w->stroke_color().g8() == 0);
+    REQUIRE(w->stroke_color().b8() == 255);
+}
+
+TEST_CASE("WidgetBridge setSvgStroke 'none' disables stroke on SvgLineWidget",
+          "[view][bridge][issue-1416]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createSvgLine('l', '')");
+    bridge.load_script("setSvgLine('l', 0, 0, 10, 10)");
+    bridge.load_script("setSvgStroke('l', 'none')");
+
+    auto* w = dynamic_cast<SvgLineWidget*>(bridge.widget("l"));
+    REQUIRE(w != nullptr);
+    REQUIRE_FALSE(w->has_stroke());
+}
+
+TEST_CASE("WidgetBridge createSvgLine + paint emits stroke_line at endpoints",
+          "[view][bridge][issue-1416]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createSvgLine('sep', '')");
+    bridge.load_script("setSvgLine('sep', 1, 2, 11, 12)");
+    bridge.load_script("setSvgStroke('sep', '#ff00ff')");
+    bridge.load_script("setSvgStrokeWidth('sep', 2.5)");
+
+    auto* w = dynamic_cast<SvgLineWidget*>(bridge.widget("sep"));
+    REQUIRE(w != nullptr);
+
+    pulp::canvas::RecordingCanvas rc;
+    w->paint(rc);
+
+    bool saw_line = false;
+    for (const auto& cmd : rc.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::stroke_line) {
+            REQUIRE(cmd.f[0] == 1.0f);
+            REQUIRE(cmd.f[1] == 2.0f);
+            REQUIRE(cmd.f[2] == 11.0f);
+            REQUIRE(cmd.f[3] == 12.0f);
+            saw_line = true;
+        }
+    }
+    REQUIRE(saw_line);
+}
+
+TEST_CASE("WidgetBridge SvgRect uses parent for hierarchy attachment",
+          "[view][bridge][issue-1416]") {
+    // The createSvgRect bridge handler accepts a parent_id so JSX can
+    // mount band thumbnails inside their MiniPreview row.
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createCol('preview', '')");
+    bridge.load_script("createSvgRect('band1', 'preview')");
+    bridge.load_script("createSvgRect('band2', 'preview')");
+    bridge.load_script("createSvgLine('axis', 'preview')");
+
+    REQUIRE(bridge.widget("band1") != nullptr);
+    REQUIRE(bridge.widget("band2") != nullptr);
+    REQUIRE(bridge.widget("axis") != nullptr);
+    auto* preview = bridge.widget("preview");
+    REQUIRE(preview != nullptr);
+    REQUIRE(preview->child_count() == 3);
+}


### PR DESCRIPTION
## Summary

Closes pulp #1416. Closes Spectr [G] (preset manager band-shape thumbnails — currently blank because pulp-react has only `SvgPath`, no `SvgRect` / `SvgLine`).

Spectr's `MiniPreview` component renders `<svg><rect>` per band plus `<line>` separators. `dom-adapter.tsx` maps `svg` / `rect` / `line` → `View`, expecting pulp-react vector intrinsics to handle the SVG attributes. Without them the geometry props (`x` / `y` / `width` / `height` / `x1` / `y1` / `x2` / `y2`) get dropped silently.

Mirrors the SvgPath precedent (#1291) across three layers.

## What changed

**C++ widgets** — `core/view/include/pulp/view/widgets/svg_{rect,line}.hpp` + `core/view/src/widgets/svg_{rect,line}.cpp`:
- `SvgRectWidget` paints `fill_rect` and / or `stroke_rect` at the configured `x`/`y`/`w`/`h`. Defaults match SVG `<rect>`: opaque-black fill, no stroke.
- `SvgLineWidget` paints `stroke_line` at the configured endpoints with the configured stroke + width. Defaults: opaque-black stroke, width 1.
- Both reuse the SvgPath fill / stroke API shape.

**Bridge** — `core/view/src/widget_bridge.cpp`:
- `createSvgRect` / `setSvgRect` / `createSvgLine` / `setSvgLine`.
- `setSvgFill` / `setSvgStroke` / `setSvgStrokeWidth` made polymorphic across `SvgPathWidget` + `SvgRectWidget` + `SvgLineWidget`.

**@pulp/react** — `packages/pulp-react/src/`:
- `SvgRect` + `SvgLine` intrinsics (`intrinsics.ts`, `types.ts`, `index.ts` re-export).
- `host-config.ts` `createWidget` switch routes the new types to the bridge `createX` calls.
- `prop-applier.ts` coalesces geometry props into a single atomic `setSvgRect` / `setSvgLine` call (avoids partial-update clobbering).
- Type-aware dispatch: `SvgRect`'s `width` / `height` go to `setSvgRect`, NOT through the Yoga `setFlex` pipeline.
- `bridge.ts` mock-bridge installer covers the new bridge fns for downstream tests.

## Tests (project policy — ship with the fix)

- `test/test_svg_rect_widget.cpp` — 14 cases / 58 assertions covering defaults, geometry, fill/stroke, paint dispatch, no-op edges. New file; registered in `test/CMakeLists.txt` as `pulp-test-svg-rect-widget`.
- `test/test_widget_bridge.cpp` — +7 cases / 44 assertions under `[issue-1416]` for bridge round-trip, `'none'` clearing, parent attachment, paint integration.
- `packages/pulp-react/test/svgrect-svgline-intrinsic.test.ts` — 20 vitest cases covering prop forwarding, geometry coalescing, default-fill, type-aware dispatch, `commitUpdate`, `appendChildToContainer` lifecycle.

All four test layers run green locally:
- `pulp-test-svg-rect-widget [issue-1416]` — 14 cases, 58 assertions.
- `pulp-test-widget-bridge [issue-1416]` — 7 cases, 44 assertions.
- `pulp-test-svg-path-widget` (regression) — 21 cases, 133 assertions still pass.
- `pulp-test-widget-bridge [issue-965]` (regression) — 2 cases, 14 assertions still pass.
- `npm test` (pulp-react) — 86 / 86 pass (66 pre-existing + 20 new).

## Test plan
- [x] Catch2: paint an `SvgRect` with red fill, `RecordingCanvas` asserts `fill_rect` at the configured coords with the right color.
- [x] Catch2: paint an `SvgLine` with stroke=blue, asserts `stroke_line` command with the right endpoints + color.
- [x] Catch2: bridge round-trip `createSvgRect` + `setSvgRect` + `setSvgFill` + `setSvgStroke` + `setSvgStrokeWidth` produces the expected widget state.
- [x] Catch2: bridge round-trip `createSvgLine` + `setSvgLine` + `setSvgStroke` + `setSvgStrokeWidth` produces the expected widget state.
- [x] vitest: `<SvgRect x={10} y={20} width={50} height={30} fill="#f00" />` produces the expected `setSvgRect(id, 10, 20, 50, 30)` + `setSvgFill(id, '#f00')` call sequence.
- [x] vitest: `<SvgLine x1={0} y1={0} x2={100} y2={100} stroke="#0f0" />` produces the expected `setSvgLine(id, 0, 0, 100, 100)` + `setSvgStroke(id, '#0f0')` call sequence.
- [x] vitest: type-aware dispatch — `SvgRect`'s `width` / `height` do NOT route through `setFlex`.
- [x] vitest: `commitUpdate` coalesces a multi-axis geometry change into one `setSvgRect` call.
- [ ] Visual regression (manual, post-merge): Spectr preset manager band-shape thumbnails render the band shapes once Spectr rebuilds against the new pulp tag.

## Out of scope (per issue body)
- circle / ellipse / polygon / polyline. Add only what Spectr needs now.
- Inline SVG element parsing from a string. The pulp-react path is JSX intrinsics, not parsed SVG.
