### PR TITLE
fix(view): host idle pumps drain timers + frames + async results (closes pulp #1412, Codex P1)

### DIFF
--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -143,6 +143,27 @@ Phase 4's `attach_remote_view(url)` (WebSocket-backed) will land as a
    `WindowHost::Factory`) need the same propagation; reading only
    `preferred_*` leaves the OS host with a zero minimum and lets
    plugins shrink below their declared floor.
+6. **Idle-pump must drain timers + frames + async results — not just
+   frames.** The platform host idle entry point (Mac CVDisplayLink,
+   iOS CADisplayLink, Android AChoreographer) is the only thing that
+   drives `WidgetBridge` per vsync when no input event fires. There
+   are TWO bridge methods that drain different queues:
+   - `poll_async_results()`: async-shell results (`execAsync` callbacks)
+     + rAF callbacks (`__flushFrames__`). Does NOT pump message loop
+     or drain timers.
+   - `service_frame_callbacks()`: pumps engine message loop + drains
+     native-tracked `setTimeout` / `setInterval` (`__flushTimers__`)
+     + rAF callbacks. Does NOT drain async-shell results.
+
+   Host idle paths must call BOTH (`poll_async_results()` first, then
+   `service_frame_callbacks()`). Calling only the first drops timer
+   callbacks on the floor — `setTimeout(fn, 100)` queues forever and
+   only fires when an unrelated event happens to pump the message
+   loop (pulp #1412, regression of PRs #1400/#1404/#1405).
+   `ScriptedUiSession::poll()` does this pair on Mac/iOS standalone;
+   `core/render/platform/android/gpu_surface_android.cpp::android_render_frame()`
+   does the same pair on Android. Tests live under `[issue-1412]` in
+   `test/test_widget_bridge.cpp`.
 
 ## Tests
 

--- a/core/render/platform/android/gpu_surface_android.cpp
+++ b/core/render/platform/android/gpu_surface_android.cpp
@@ -825,12 +825,21 @@ void android_render_frame(float dt) {
     // get drained without depending on a touch event to trigger
     // request_repaint. Without this, requestAnimationFrame(cb) callbacks
     // queue forever and only fire when an unrelated touch happens to
-    // call poll_async_results elsewhere. poll_async_results internally
-    // evaluates __flushFrames__ when pending_frame_ids_ is non-empty,
-    // and request_repaint chains the next vsync. Identical pattern to
+    // call poll_async_results elsewhere. Identical pattern to
     // the macOS CVDisplayLink wiring in PR #1400.
+    //
+    // pulp #1412 — host idle pump must drain BOTH async-shell results
+    // (poll_async_results) AND timers + rAF callbacks
+    // (service_frame_callbacks). Without the second call,
+    // setTimeout / setInterval callbacks queue forever because nothing
+    // else drives the bridge's message loop on the AChoreographer
+    // cadence. poll_async_results drains async-exec results + flushes
+    // frames; service_frame_callbacks pumps the engine message loop
+    // and drains native-tracked timers + flushes frames. Together they
+    // form the full per-vsync bridge pump.
     if (g_widget_bridge) {
         g_widget_bridge->poll_async_results();
+        g_widget_bridge->service_frame_callbacks();
     }
 
     if (g_gpu_surface->begin_frame()) {

--- a/core/view/src/scripted_ui.cpp
+++ b/core/view/src/scripted_ui.cpp
@@ -67,7 +67,18 @@ bool ScriptedUiSession::load(std::string* error) {
 bool ScriptedUiSession::poll(std::string* error) {
     bool changed = false;
     if (bridge_) {
+        // pulp #1412 — host idle pump must drain BOTH async-shell results
+        // (poll_async_results) AND timers + rAF callbacks
+        // (service_frame_callbacks). Without the second call, JS
+        // setTimeout / setInterval callbacks queue forever on Mac/iOS
+        // because nothing else drives the bridge's message loop on the
+        // host idle cadence (CVDisplayLink / CADisplayLink).
+        // poll_async_results: drains async-exec results + flushes frames.
+        // service_frame_callbacks: pumps engine message loop + drains
+        //   native-tracked timers + flushes frames.
+        // Together they form the full per-vsync bridge pump.
         bridge_->poll_async_results();
+        bridge_->service_frame_callbacks();
     }
     if (reloader_ && reloader_->poll_reload()) {
         changed = true;

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -1317,6 +1317,143 @@ TEST_CASE("WidgetBridge requestAnimationFrame callbacks continue during poll loo
     REQUIRE(engine.evaluate("frame_count").getWithDefault<int>(-1) == 3);
 }
 
+// pulp #1412 — host idle pump must drain timers, not just rAF + async results.
+//
+// The platform host idle entry point (Mac CVDisplayLink, iOS CADisplayLink,
+// Android AChoreographer) is the only thing that drives the bridge per
+// vsync when no input event fires. PRs #1400/#1404/#1405 wired the host
+// idle to call poll_async_results(), which only drains async-shell
+// results and rAF frame callbacks — NOT setTimeout / setInterval. The
+// fix routes the host idle through poll_async_results() AND
+// service_frame_callbacks() so timers also fire. These tests exercise
+// the combined "host idle pump" pattern directly.
+
+namespace {
+// Mirrors what the host idle paths now do per-vsync:
+//   ScriptedUiSession::poll() → bridge.poll_async_results()
+//                              + bridge.service_frame_callbacks()
+//   Android android_render_frame() → same pair.
+inline void host_idle_pump(WidgetBridge& bridge) {
+    bridge.poll_async_results();
+    bridge.service_frame_callbacks();
+}
+}  // namespace
+
+TEST_CASE("WidgetBridge host idle pump fires setTimeout callbacks",
+          "[view][bridge][issue-1412]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var fired = 0;
+        setTimeout(function () { fired += 1; }, 50);
+    )");
+
+    // Before the deadline, the timer must not fire even after several
+    // host idle pumps.
+    host_idle_pump(bridge);
+    REQUIRE(engine.evaluate("fired").getWithDefault<int>(-1) == 0);
+
+    // Walk past the 50ms deadline with the same per-vsync pump the
+    // host idle paths run. With only poll_async_results() this loop
+    // would never fire `fired += 1` — that's the #1412 bug.
+    for (int i = 0; i < 60; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        host_idle_pump(bridge);
+        if (engine.evaluate("fired").getWithDefault<int>(-1) >= 1)
+            break;
+    }
+
+    REQUIRE(engine.evaluate("fired").getWithDefault<int>(-1) == 1);
+}
+
+TEST_CASE("WidgetBridge host idle pump fires setInterval callbacks repeatedly",
+          "[view][bridge][issue-1412]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var hits = 0;
+        var id = setInterval(function () {
+            hits += 1;
+            if (hits >= 3) clearInterval(id);
+        }, 50);
+    )");
+
+    // Pump on the same cadence the host idle would, walking ~250ms
+    // simulated wall time so the interval re-arms ~3 times.
+    for (int i = 0; i < 200; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        host_idle_pump(bridge);
+        if (engine.evaluate("hits").getWithDefault<int>(-1) >= 3)
+            break;
+    }
+
+    REQUIRE(engine.evaluate("hits").getWithDefault<int>(-1) >= 3);
+}
+
+TEST_CASE("WidgetBridge host idle pump drains rAF + setTimeout in same call",
+          "[view][bridge][issue-1412]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var raf_count = 0;
+        var timer_count = 0;
+        window.requestAnimationFrame(function () { raf_count += 1; });
+        // 0ms timeout: deadline already in the past by the time the
+        // host idle pump runs, so it must fire on the first pump.
+        setTimeout(function () { timer_count += 1; }, 0);
+    )");
+
+    // A single host idle pump must drain BOTH the rAF callback (via
+    // poll_async_results → __flushFrames__) AND the expired timer
+    // (via service_frame_callbacks → __flushTimers__).
+    host_idle_pump(bridge);
+
+    REQUIRE(engine.evaluate("raf_count").getWithDefault<int>(-1) == 1);
+    REQUIRE(engine.evaluate("timer_count").getWithDefault<int>(-1) == 1);
+}
+
+TEST_CASE("WidgetBridge poll_async_results alone does NOT fire setTimeout (regression guard)",
+          "[view][bridge][issue-1412]") {
+    // This test is the inverse of the fix: it asserts the historical
+    // behavior that was the actual #1412 bug. It documents WHY the
+    // host idle pump can't be just poll_async_results().
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var fired = 0;
+        setTimeout(function () { fired += 1; }, 0);
+    )");
+
+    // Pump only poll_async_results several times across enough wall
+    // time that a 0ms timer would have fired if it were drained.
+    for (int i = 0; i < 20; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        bridge.poll_async_results();
+    }
+
+    REQUIRE(engine.evaluate("fired").getWithDefault<int>(-1) == 0);
+
+    // Now the full host idle pump must drain it.
+    host_idle_pump(bridge);
+    REQUIRE(engine.evaluate("fired").getWithDefault<int>(-1) == 1);
+}
+
 TEST_CASE("WidgetBridge execAsync preserves JSON-heavy results", "[view][bridge][async]") {
     ScriptEngine engine;
     View root;


### PR DESCRIPTION
## Summary

Closes pulp #1412 (Codex P1 from #1404 review).

PRs #1400 / #1404 / #1405 wired host idle to call `bridge.poll_async_results()` only — directly on Android, indirectly via `scripted_ui->poll()` on Mac/iOS. `poll_async_results()` covers async-exec results + rAF (`__flushFrames__`), but NOT `__flushTimers__`. Result: `setTimeout(fn, 100)` and `setInterval` callbacks queued forever, only firing when something else triggered `service_frame_callbacks()`.

## Fix (Option A refined)

Host idle paths now call BOTH `poll_async_results()` AND `service_frame_callbacks()`:
- `core/view/src/scripted_ui.cpp` — `ScriptedUiSession::poll()` calls both. Covers Mac CVDisplayLink + iOS CADisplayLink (both standalone hosts route `idle_callback_` through `scripted_ui->poll()` per `core/format/src/standalone.cpp:278`).
- `core/render/platform/android/gpu_surface_android.cpp` — `android_render_frame()` calls both directly (Android doesn't use `ScriptedUiSession`).

Why both rather than collapsing into one: the two methods drain *different* queues (`poll_async_results()` covers async-exec results + rAF; `service_frame_callbacks()` covers engine message loop + native timers + rAF). Conflating them would leak the message-loop pump and async-exec mutex acquisition into a method whose name doesn't suggest it. Keeping the two methods clear-named and having hosts pump both is the clean choice.

## Tests

4 new Catch2 cases in `test/test_widget_bridge.cpp` under `[issue-1412]`:
1. host idle pump fires `setTimeout` callbacks
2. host idle pump fires `setInterval` callbacks repeatedly
3. host idle pump drains rAF + setTimeout in the same call
4. regression guard: `poll_async_results()` alone does NOT fire setTimeout (documents the historical bug; asserts the full pump fires it)

Full file regression: 100 test cases / 716 assertions pass on macOS GPU build. Existing rAF + timers tests unaffected.

## Skill update

`view-bridge` skill gains pitfall #6 documenting the idle-pump-must-drain-timers-too gotcha. Android skill update bypassed via `Skill-Update: skip` trailer (one-line idle-pump call addition; gotcha already in view-bridge).

## Cross-references

- Codex P1 origin: PR #1404 review comment
- Original rAF fixes: #1400 (Mac), #1404 (Android), #1405 (iOS) — all merged
- Umbrella: pulp #1387 (bridge hardening)

## Notes

- Sub-agent implementation; reviewed by main session before push.
- Bypass-trailer pattern (3 Version-Bump trailers + 1 Skill-Update trailer for android — quoted reasons).
- Diff-cover gate skipped locally (xcrun llvm-cov path issue on the script); CI runs the real check.