### PR TITLE
fix(view/css): translate width/height percent values through to Yoga (closes #1423)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -4185,32 +4185,32 @@
       "issue": ""
     },
     "yoga/width": {
-      "status": "supported",
-      "mapsTo": "FlexStyle.preferred_width (float)",
+      "status": "partial",
+      "mapsTo": "FlexStyle.preferred_width (px) + FlexStyle.dim_width (percent)",
       "supportedValues": [
-        "px (number)"
+        "px",
+        "%"
       ],
       "unsupportedValues": [
-        "%",
         "auto"
       ],
       "tests": [],
-      "notes": "Internal Dimension struct supports vw/vh/% but is not exposed via the setFlex bridge.",
-      "issue": ""
+      "notes": "pulp #1423: percent values route through FlexStyle.dim_width (DimensionUnit::percent) and yoga_layout.cpp calls YGNodeStyleSetWidthPercent. CSS translator passes 'NN%' strings verbatim to the bridge. `auto` remains unsupported (deferred follow-up).",
+      "issue": "https://github.com/danielraffel/pulp/issues/1423"
     },
     "yoga/height": {
-      "status": "supported",
-      "mapsTo": "FlexStyle.preferred_height (float)",
+      "status": "partial",
+      "mapsTo": "FlexStyle.preferred_height (px) + FlexStyle.dim_height (percent)",
       "supportedValues": [
-        "px"
+        "px",
+        "%"
       ],
       "unsupportedValues": [
-        "%",
         "auto"
       ],
       "tests": [],
-      "notes": "Same as width.",
-      "issue": ""
+      "notes": "pulp #1423: same as width (YGNodeStyleSetHeightPercent path via FlexStyle.dim_height). `auto` remains unsupported (deferred follow-up).",
+      "issue": "https://github.com/danielraffel/pulp/issues/1423"
     },
     "yoga/minWidth": {
       "status": "supported",

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -174,14 +174,24 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         }
 
         // Dimensions
+        // pulp #1423 — pass the resolved string verbatim for width/height
+        // when it is a percent value. The bridge's setFlex(width|height,
+        // ...) inspects the third arg as a string and detects '%' suffix.
+        // This keeps the existing px path numeric (no JS-side regression)
+        // while letting "100%" survive through to Yoga's native
+        // YGNodeStyleSet{Width,Height}Percent path.
         case "width": {
             var w = parseCSSLength(resolved);
-            if (w) setFlex(id, "width", w.value);
+            if (!w) break;
+            if (w.unit === "%") setFlex(id, "width", w.value + "%");
+            else setFlex(id, "width", w.value);
             break;
         }
         case "height": {
             var h = parseCSSLength(resolved);
-            if (h) setFlex(id, "height", h.value);
+            if (!h) break;
+            if (h.unit === "%") setFlex(id, "height", h.value + "%");
+            else setFlex(id, "height", h.value);
             break;
         }
         case "minWidth": {

--- a/core/view/js/web-compat.js
+++ b/core/view/js/web-compat.js
@@ -1149,15 +1149,20 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             break;
         }
 
-        // Dimensions
+        // Dimensions — pulp #1423 forwards percent values verbatim so
+        // the bridge can route to Yoga's percent API.
         case "width": {
             var w = parseCSSLength(resolved);
-            if (w) setFlex(id, "width", w.value);
+            if (!w) break;
+            if (w.unit === "%") setFlex(id, "width", w.value + "%");
+            else setFlex(id, "width", w.value);
             break;
         }
         case "height": {
             var h = parseCSSLength(resolved);
-            if (h) setFlex(id, "height", h.value);
+            if (!h) break;
+            if (h.unit === "%") setFlex(id, "height", h.value + "%");
+            else setFlex(id, "height", h.value);
             break;
         }
         case "minWidth": {

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1680,8 +1680,40 @@ void WidgetBridge::register_api() {
         else if (key == "flex_basis") f.flex_basis = (float)val;
         else if (key == "flex_wrap") f.flex_wrap = val > 0;
         else if (key == "order") f.order = (int)val;
-        else if (key == "width") f.preferred_width = (float)val;
-        else if (key == "height") f.preferred_height = (float)val;
+        // pulp #1423 — width/height accept either a number ("100" → px)
+        // or a percentage string ("100%" → percent of parent). The CSS
+        // translator passes the raw resolved string for these two keys
+        // so the unit survives the bridge boundary; Yoga's native
+        // YGNodeStyleSet{Width,Height}Percent path is reached via
+        // FlexStyle::dim_width / dim_height in yoga_layout.cpp.
+        else if (key == "width") {
+            auto sval = args.get<std::string>(2, "");
+            if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_width.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_width.unit = pulp::view::DimensionUnit::percent;
+                    f.preferred_width = 0;  // disambiguate: percent path
+                } catch (...) { /* keep current state on parse fail */ }
+            } else {
+                f.preferred_width = (float)val;
+                f.dim_width.value = (float)val;
+                f.dim_width.unit = pulp::view::DimensionUnit::px;
+            }
+        }
+        else if (key == "height") {
+            auto sval = args.get<std::string>(2, "");
+            if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_height.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_height.unit = pulp::view::DimensionUnit::percent;
+                    f.preferred_height = 0;
+                } catch (...) { /* keep current state on parse fail */ }
+            } else {
+                f.preferred_height = (float)val;
+                f.dim_height.value = (float)val;
+                f.dim_height.unit = pulp::view::DimensionUnit::px;
+            }
+        }
         else if (key == "min_width") f.min_width = (float)val;
         else if (key == "min_height") f.min_height = (float)val;
         else if (key == "max_width") f.max_width = (float)val;

--- a/core/view/src/yoga_layout.cpp
+++ b/core/view/src/yoga_layout.cpp
@@ -101,9 +101,21 @@ static void apply_flex_style(YGNodeRef node, const FlexStyle& f, bool is_absolut
     if (mb > 0) YGNodeStyleSetMargin(node, YGEdgeBottom, mb);
     if (ml > 0) YGNodeStyleSetMargin(node, YGEdgeLeft, ml);
 
-    // Dimensions
-    if (f.preferred_width > 0) YGNodeStyleSetWidth(node, f.preferred_width);
-    if (f.preferred_height > 0) YGNodeStyleSetHeight(node, f.preferred_height);
+    // Dimensions — pulp #1423 dispatches on dim_*.unit so width/height
+    // accept percentage values. The bridge's setFlex(width|height, ...)
+    // path populates dim_width / dim_height with the unit info; this
+    // adapter routes percent values to Yoga's native percent API
+    // instead of treating "100%" as 100 px.
+    if (f.dim_width.unit == DimensionUnit::percent && f.dim_width.value > 0) {
+        YGNodeStyleSetWidthPercent(node, f.dim_width.value);
+    } else if (f.preferred_width > 0) {
+        YGNodeStyleSetWidth(node, f.preferred_width);
+    }
+    if (f.dim_height.unit == DimensionUnit::percent && f.dim_height.value > 0) {
+        YGNodeStyleSetHeightPercent(node, f.dim_height.value);
+    } else if (f.preferred_height > 0) {
+        YGNodeStyleSetHeight(node, f.preferred_height);
+    }
     if (f.min_width > 0) YGNodeStyleSetMinWidth(node, f.min_width);
     if (f.min_height > 0) YGNodeStyleSetMinHeight(node, f.min_height);
     if (f.max_width > 0) YGNodeStyleSetMaxWidth(node, f.max_width);

--- a/docs/reference/compat/yoga.md
+++ b/docs/reference/compat/yoga.md
@@ -38,6 +38,21 @@ which mirrors the upstream Yoga API.
 5. `yoga/alignItems` / `yoga/alignSelf` `baseline` — `FlexAlign` enum
    has no baseline variant.
 
+## Recent updates
+
+- **2026-05-05 (pulp #1423)** — `yoga/width` and `yoga/height` now
+  accept percentage values (`'100%'`, `'50%'`). The CSS translator
+  passes `'NN%'` strings verbatim to the bridge; `FlexStyle.dim_width`
+  / `dim_height` carry the unit; `yoga_layout.cpp` dispatches to
+  Yoga's native `YGNodeStyleSetWidthPercent` / `HeightPercent`. `auto`
+  remains unsupported (deferred). Drift cleared on both entries
+  (drift_count: 23 → 21).
+- **2026-05-05 (pulp #1420)** — `yoga/display` catalog claims `flex`
+  and `none` cleanly; reclassified NOT-IMPL → PASS. Bonus:
+  `inline-block` ≡ `block`, `inline-flex` ≡ `flex` in the CSS
+  translator (matches RN + CSS spec for non-text-flowing formatting
+  contexts).
+
 ## Direction (RTL) support
 
 `yoga/direction` is `missing`. Pulp does not currently model RTL

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -4234,3 +4234,72 @@ TEST_CASE("CSSStyleDeclaration translates whiteSpace to setWhiteSpace bridge cal
     REQUIRE(label != nullptr);
     REQUIRE(label->white_space_nowrap());
 }
+
+// pulp #1423 — `width: '100%'` and `height: '100%'` propagate through the
+// CSS translator and bridge to Yoga's percent API. Spectr uses the
+// `width:'100%'` form at spectr-editor-extracted.js:2377 and :3414.
+TEST_CASE("CSS width/height percent strings propagate to Yoga via setFlex",
+          "[view][bridge][css][issue-1423]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 200});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('child', '');
+        var stub = { _id: 'child', _nativeCreated: true };
+        var sd = new CSSStyleDeclaration(stub);
+        sd._applyProperty('width', '100%');
+        sd._applyProperty('height', '50%');
+    )");
+
+    auto* child = bridge.widget("child");
+    REQUIRE(child != nullptr);
+
+    // FlexStyle.dim_width / dim_height now carry the percent unit, so
+    // yoga_layout.cpp will emit YGNodeStyleSetWidthPercent/HeightPercent.
+    const auto& f = child->flex();
+    REQUIRE(f.dim_width.unit == DimensionUnit::percent);
+    REQUIRE_THAT(f.dim_width.value, WithinAbs(100.0f, 0.001f));
+    REQUIRE(f.dim_height.unit == DimensionUnit::percent);
+    REQUIRE_THAT(f.dim_height.value, WithinAbs(50.0f, 0.001f));
+
+    // After layout against the 400x200 root, the child should be laid
+    // out as 400 wide (100% of parent) and 100 tall (50% of parent).
+    root.layout_children();
+    REQUIRE_THAT(child->bounds().width, WithinAbs(400.0f, 0.5f));
+    REQUIRE_THAT(child->bounds().height, WithinAbs(100.0f, 0.5f));
+}
+
+// pulp #1423 — px values still work after the percent-aware refactor.
+// Regression guard: the old code path stored only `preferred_width`;
+// the new path also stores into `dim_width.unit = px`. Layout must keep
+// using the px size when no percent was specified.
+TEST_CASE("CSS width/height px paths unchanged by percent support",
+          "[view][bridge][css][issue-1423]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 200});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('child', '');
+        var stub = { _id: 'child', _nativeCreated: true };
+        var sd = new CSSStyleDeclaration(stub);
+        sd._applyProperty('width', '120px');
+        sd._applyProperty('height', '80px');
+    )");
+
+    auto* child = bridge.widget("child");
+    REQUIRE(child != nullptr);
+    const auto& f = child->flex();
+    REQUIRE(f.dim_width.unit == DimensionUnit::px);
+    REQUIRE_THAT(f.preferred_width, WithinAbs(120.0f, 0.001f));
+    REQUIRE_THAT(f.preferred_height, WithinAbs(80.0f, 0.001f));
+
+    root.layout_children();
+    REQUIRE_THAT(child->bounds().width, WithinAbs(120.0f, 0.5f));
+    REQUIRE_THAT(child->bounds().height, WithinAbs(80.0f, 0.5f));
+}


### PR DESCRIPTION
## Summary

Closes pulp #1423 — Spectr-impact #2 yoga drift entry from the Task 5 triage. `width:'100%'` and `height:'100%'` now propagate end-to-end into Yoga's native percent API.

## Three-layer fix

1. **CSS translator** (`web-compat-style-decl.js`, `web-compat.js`) — passes the resolved value-with-unit string verbatim to the bridge when the unit is `%`. Numeric path unchanged for px values.
2. **Bridge** (`widget_bridge.cpp:setFlex`, width/height cases) — inspects the third arg as a string. `NN%` form populates `FlexStyle::dim_width` / `dim_height` with `DimensionUnit::percent`; numeric args populate `preferred_*` AND `dim_*.unit = px` so the Yoga adapter has a single source of truth.
3. **Yoga adapter** (`yoga_layout.cpp`) — dispatches on `FlexStyle::dim_*.unit`: percent values reach Yoga via `YGNodeStyleSetWidthPercent` / `HeightPercent`; px values keep the existing `YGNodeStyleSetWidth` / `Height` path.
4. **Catalog** (`compat.json`) — `yoga/width` / `yoga/height` `supportedValues` claim `px` AND `%`. `auto` stays in `unsupportedValues` (legitimate gap, deferred). Status flipped to `partial` so catalog accurately matches harness DIVERGE — drift cleared (drift_count: 23 → 21).
5. **Doc** (`docs/reference/compat/yoga.md`) — `Recent updates` section noting #1420 and #1423 outcomes.

## Test plan

Two `[issue-1423]` cases in `test/test_widget_bridge.cpp`:

- [x] `style.width = '100%'` + `style.height = '50%'` on a child of a 400×200 root → `dim_*.unit == percent`, value populated; after `layout_children()` the child's bounds are 400 wide / 100 tall.
- [x] `style.width = '120px'` + `style.height = '80px'` (regression guard) → `dim_*.unit == px`, `preferred_*` populated, layout produces 120 / 80.
- [x] Pre-existing `pulp-test-widget-bridge` (722 / 98) and `pulp-test-view-layout-widgets` (49 / 10) green — no regression.

**Verifier output:**

Before:
```
Total: 53 | PASS: 7 | DIVERGE: 28 | NOT-IMPL: 18 | drift_count: 23
yoga/width:  DIVERGE, drift=True
yoga/height: DIVERGE, drift=True
```
After:
```
Total: 53 | PASS: 7 | DIVERGE: 28 | NOT-IMPL: 18 | drift_count: 21
yoga/width:  DIVERGE, drift=False
yoga/height: DIVERGE, drift=False
```

(PASS count stays at 7 because catalog status moved to `partial` to honestly reflect the remaining `auto` gap. The drift signal — that catalog claim and harness verdict disagree — is what's cleared.)

## Out of scope (deferred follow-ups)

- `width:'auto'` / `height:'auto'` — Yoga supports `YGNodeStyleSetWidthAuto`; pulp doesn't model it yet.
- `left:'50%'` / `right`/`top`/`bottom` percent — different code path (View positional fields, no Dimension wrapper). Spectr's `translateX(-50%)` centering idiom uses this; will file as a separate issue.
- `min-width`/`max-width`/`padding`/`margin` percent — zero confirmed Spectr usage of percent values per Task 5 triage.

## Notes

- 10 trailers contiguous on the tip commit (`git interpret-trailers --parse` parses all): 3 Version-Bump skips (batched-stack), 1 Skill-Update skip (engine — CSS-translator change isn't JS-engine concern), 6 Compat-Update skips (widget_bridge.cpp path-maps to canvas2d/css/html/imports/react/rn but the catalog change is yoga-only).

Closes #1423.
