### PR TITLE
fix(view): yoga aspect-ratio support (closes pulp #1434 batch 5)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -243,15 +243,19 @@
       "issue": ""
     },
     "css/aspectRatio": {
-      "status": "partial",
-      "mapsTo": "web-compat-style-decl.js parses '16/9' and calls setFlex(id, 'aspect_ratio', ratio); but FlexStyle has NO aspect_ratio field, so setFlex silently drops it",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "web-compat-style-decl.js parses '<n>', '<num>/<den>', and 'auto'; calls setFlex(id, 'aspect_ratio', ratio); widget_bridge writes FlexStyle.aspect_ratio; yoga_layout dispatches to YGNodeStyleSetAspectRatio",
+      "supportedValues": [
+        "number",
+        "ratio (n/d)",
+        "auto"
       ],
-      "tests": [],
-      "notes": "MAJOR GAP -- the parser exists but the layout backend doesn't honor it. The setFlex switch in widget_bridge.cpp:1624-1685 has no 'aspect_ratio' branch.",
-      "issue": ""
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_layout_aspect_ratio.cpp"
+      ],
+      "notes": "pulp #1434 — three value forms accepted: plain number ('1.5'), 'width / height' ratio ('16/9' -> 1.778), and 'auto' (clears slot). Both 'aspectRatio' (camelCase) and 'aspect-ratio' (kebab-case) work; setProperty auto-converts kebab to camel.",
+      "issue": "1434"
     },
     "css/backdropFilter": {
       "status": "supported",
@@ -2659,16 +2663,18 @@
       "issue": ""
     },
     "rn/aspectRatio": {
-      "status": "missing",
-      "mapsTo": "@pulp/react does not expose aspectRatio. CSS surface attempts to set it via setFlex 'aspect_ratio' but FlexStyle has no field.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "number",
-        "string"
+      "status": "supported",
+      "mapsTo": "@pulp/react FlexProps.aspectRatio -> setFlex(id, 'aspect_ratio', value) -> FlexStyle.aspect_ratio -> YGNodeStyleSetAspectRatio",
+      "supportedValues": [
+        "number"
       ],
-      "tests": [],
-      "notes": "MAJOR -- aspect-ratio is in RN's layout-props surface but not at the @pulp/react JSX surface.",
-      "issue": ""
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-aspect-ratio.test.ts",
+        "test/web-compat/test_layout_aspect_ratio.cpp"
+      ],
+      "notes": "pulp #1434 — JSX surface accepts numeric aspectRatio (RN parity per oracle 'kind: number'). String forms ('16/9', 'auto') reach FlexStyle through the CSS shim path (web-compat-style-decl.js), not the @pulp/react TS surface.",
+      "issue": "1434"
     },
     "rn/backfaceVisibility": {
       "status": "missing",
@@ -4256,15 +4262,17 @@
       "issue": ""
     },
     "yoga/aspectRatio": {
-      "status": "missing",
-      "mapsTo": "no FlexStyle field; setFlex 'aspect_ratio' silently dropped",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "FlexStyle.aspect_ratio (std::optional<float>) -> YGNodeStyleSetAspectRatio",
+      "supportedValues": [
+        "number"
       ],
-      "tests": [],
-      "notes": "Yoga upstream supports it. Pulp's parser exists in CSS shim but the field is missing.",
-      "issue": ""
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_layout_aspect_ratio.cpp"
+      ],
+      "notes": "pulp #1434 — added FlexStyle.aspect_ratio + Yoga dispatch + bridge setFlex 'aspect_ratio' branch + @pulp/react aspectRatio prop. CSS shim accepts plain numbers ('1.5'), 'width/height' ratios ('16/9'), and 'auto' (clears slot).",
+      "issue": "1434"
     },
     "yoga/margin": {
       "status": "supported",

--- a/core/view/include/pulp/view/geometry.hpp
+++ b/core/view/include/pulp/view/geometry.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -184,6 +185,18 @@ struct FlexStyle {
 
     bool flex_wrap = false;     ///< Wrap to next line when main axis overflows
     int order = 0;              ///< Layout order (lower values first, default 0)
+
+    /// Aspect ratio (width / height). When set, Yoga sizes the cross axis
+    /// to match `main_axis / aspect_ratio` (or the inverse, depending on
+    /// which dimension is constrained). pulp #1434 — RN exports use
+    /// `aspectRatio` for image cards / video tiles; Figma exports for
+    /// fixed-ratio frames; v0/Claude Design generate it for hero images.
+    /// std::optional distinguishes "unset" from a literal 0 value (which
+    /// would be invalid anyway, but the optional makes the intent explicit
+    /// at the dispatcher boundary). Accepts plain numbers (1.5),
+    /// `width/height` parsed by web-compat-style-decl.js (16/9 -> 1.778),
+    /// and `auto` which clears the slot.
+    std::optional<float> aspect_ratio;
 
     // Helper: resolve per-side margin
     float margin_t() const { return margin_top >= 0 ? margin_top : margin; }

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -505,11 +505,35 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
 
         // ── P1: New CSS properties ──────────────────────────────────────
 
-        // aspect-ratio: "16/9" or "1"
+        // aspect-ratio: "16/9", "1.5", or "auto" (pulp #1434).
+        // Three value forms accepted — RN exports use the plain number form,
+        // CSS exports use the `width / height` form, "auto" clears the slot.
+        // Both `aspectRatio` (camelCase, set via `style.aspectRatio = ...`)
+        // and `aspect-ratio` (kebab-case via `style.setProperty(...)`) reach
+        // this branch — `setProperty` converts kebab to camel before
+        // dispatching through the descriptor setter.
         case "aspectRatio": {
-            var arParts = resolved.split("/");
-            var ratio = parseFloat(arParts[0]) || 1;
-            if (arParts[1]) ratio /= parseFloat(arParts[1]) || 1;
+            var trimmed = String(resolved).trim();
+            if (trimmed === "" || trimmed === "auto") {
+                // Clear: bridge interprets non-positive as "unset".
+                setFlex(id, "aspect_ratio", 0);
+                break;
+            }
+            var arParts = trimmed.split("/");
+            var num = parseFloat(arParts[0]);
+            if (!isFinite(num) || num <= 0) {
+                setFlex(id, "aspect_ratio", 0);
+                break;
+            }
+            var ratio = num;
+            if (arParts[1] !== undefined) {
+                var den = parseFloat(arParts[1]);
+                if (!isFinite(den) || den <= 0) {
+                    setFlex(id, "aspect_ratio", 0);
+                    break;
+                }
+                ratio = num / den;
+            }
             setFlex(id, "aspect_ratio", ratio);
             break;
         }

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1686,6 +1686,16 @@ void WidgetBridge::register_api() {
         else if (key == "min_height") f.min_height = (float)val;
         else if (key == "max_width") f.max_width = (float)val;
         else if (key == "max_height") f.max_height = (float)val;
+        // Aspect ratio (pulp #1434) — width/height ratio. A value <= 0 or
+        // NaN clears the slot (matches CSS `aspect-ratio: auto`); a finite
+        // positive value pins the slot. The CSS shim in
+        // web-compat-style-decl.js parses both `1.5` and `16/9` forms
+        // before reaching here, and the @pulp/react prop-applier accepts
+        // `aspectRatio` directly as a number.
+        else if (key == "aspect_ratio" || key == "aspectRatio") {
+            if (val > 0.0 && std::isfinite(val)) f.aspect_ratio = (float)val;
+            else f.aspect_ratio.reset();
+        }
         // Margin
         else if (key == "margin") f.margin = (float)val;
         else if (key == "margin_top") f.margin_top = (float)val;

--- a/core/view/src/yoga_layout.cpp
+++ b/core/view/src/yoga_layout.cpp
@@ -109,6 +109,16 @@ static void apply_flex_style(YGNodeRef node, const FlexStyle& f, bool is_absolut
     if (f.max_width > 0) YGNodeStyleSetMaxWidth(node, f.max_width);
     if (f.max_height > 0) YGNodeStyleSetMaxHeight(node, f.max_height);
 
+    // Aspect ratio (pulp #1434) — Yoga sizes the cross axis from the main
+    // axis using `width / height`. Only forward when explicitly set so the
+    // default (no aspect constraint) doesn't fight other size constraints.
+    // Negative / zero values are nonsensical for ratio semantics; treat
+    // those as "clear" so an "auto" or invalid value flowing through the
+    // CSS path doesn't pin the cross axis to 0.
+    if (f.aspect_ratio.has_value() && *f.aspect_ratio > 0.0f) {
+        YGNodeStyleSetAspectRatio(node, *f.aspect_ratio);
+    }
+
     // Order (Yoga doesn't support order directly — we handle it via child insertion order)
 }
 

--- a/packages/pulp-react/src/bridge.ts
+++ b/packages/pulp-react/src/bridge.ts
@@ -75,7 +75,10 @@ declare global {
             | 'max_height'
             | 'align_items'
             | 'align_self'
-            | 'justify_content',
+            | 'justify_content'
+            // pulp #1434 — width/height ratio. Value is a finite positive
+            // number; 0 / non-finite clears the slot on the bridge side.
+            | 'aspect_ratio',
         value: number | string,
     ): void;
 

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -232,6 +232,12 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         case 'alignItems':      return call('setFlex', id, 'align_items', value as string);
         case 'alignSelf':       return call('setFlex', id, 'align_self', value as string);
         case 'justifyContent':  return call('setFlex', id, 'justify_content', value as string);
+        // pulp #1434 — aspectRatio routes through setFlex like the other
+        // flex props. Accepts a finite positive number (RN-style); strings
+        // ("16/9", "auto") are NOT accepted at the JSX surface — those
+        // belong to the CSS shim path (web-compat-style-decl.js). A value
+        // of 0 / NaN / undefined clears the slot on the bridge side.
+        case 'aspectRatio':     return call('setFlex', id, 'aspect_ratio', value as number);
 
         // Visual style
         case 'background':         return call('setBackground', id, value as string);

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -45,6 +45,11 @@ export interface FlexProps {
     alignItems?: FlexAlign;
     alignSelf?: FlexAlignSelf;
     justifyContent?: FlexJustify;
+    /// pulp #1434 — width/height ratio for the cross axis. RN-compatible.
+    /// When set on a View with `width: 100, aspectRatio: 1.5`, the layout
+    /// produces `height = 100 / 1.5 ≈ 66.67`. When `height` is set instead,
+    /// the width is derived. Pass `0` or omit to clear.
+    aspectRatio?: number;
 }
 
 // ── Visual style ────────────────────────────────────────────────────

--- a/packages/pulp-react/test/prop-applier-aspect-ratio.test.ts
+++ b/packages/pulp-react/test/prop-applier-aspect-ratio.test.ts
@@ -1,0 +1,80 @@
+// pulp #1434 batch 5 — verify the @pulp/react prop-applier routes
+// `aspectRatio` through `setFlex(id, "aspect_ratio", value)`. Mirrors RN's
+// flex-prop surface so design-tool exports (Figma fixed-ratio frames,
+// v0/Claude Design hero images, RN image cards) reach the bridge.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyChangedProps } from '../src/prop-applier.js';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import type { PulpInstance } from '../src/types.js';
+
+let bridge: MockBridge;
+
+beforeEach(() => {
+    bridge = createMockBridge();
+    bridge.install();
+});
+afterEach(() => {
+    bridge.uninstall();
+});
+
+function makeInstance(id: string = 'k', type: string = 'View'): PulpInstance {
+    return {
+        id,
+        type: type as PulpInstance['type'],
+        props: {},
+        childIds: [],
+        onBridge: true,
+        pendingChildren: [],
+    };
+}
+
+describe('prop-applier aspectRatio (pulp #1434)', () => {
+    it('aspectRatio number routes through setFlex with snake-case key', () => {
+        applyChangedProps(makeInstance(), {}, { aspectRatio: 1.5 });
+        const call = bridge.calls.find(
+            (c) => c.fn === 'setFlex' && c.args[1] === 'aspect_ratio'
+        );
+        expect(call).toBeDefined();
+        expect(call?.args).toEqual(['k', 'aspect_ratio', 1.5]);
+    });
+
+    it('aspectRatio 16/9 ratio (computed by caller) flows through unchanged', () => {
+        const ratio = 16 / 9;
+        applyChangedProps(makeInstance(), {}, { aspectRatio: ratio });
+        const call = bridge.calls.find(
+            (c) => c.fn === 'setFlex' && c.args[1] === 'aspect_ratio'
+        );
+        expect(call).toBeDefined();
+        expect(call?.args[2]).toBeCloseTo(ratio, 5);
+    });
+
+    it('aspectRatio 0 routes through (bridge interprets as clear)', () => {
+        applyChangedProps(makeInstance(), {}, { aspectRatio: 0 });
+        const call = bridge.calls.find(
+            (c) => c.fn === 'setFlex' && c.args[1] === 'aspect_ratio'
+        );
+        expect(call).toBeDefined();
+        expect(call?.args[2]).toBe(0);
+    });
+
+    it('aspectRatio undefined is a no-op (no setFlex call)', () => {
+        applyChangedProps(makeInstance(), {}, { aspectRatio: undefined });
+        const call = bridge.calls.find(
+            (c) => c.fn === 'setFlex' && c.args[1] === 'aspect_ratio'
+        );
+        expect(call).toBeUndefined();
+    });
+
+    it('does not collide with width / height routing', () => {
+        applyChangedProps(makeInstance(), {}, {
+            width: 100,
+            aspectRatio: 1.5,
+        });
+        const calls = bridge.calls.filter((c) => c.fn === 'setFlex');
+        const widthCall = calls.find((c) => c.args[1] === 'width');
+        const arCall = calls.find((c) => c.args[1] === 'aspect_ratio');
+        expect(widthCall?.args).toEqual(['k', 'width', 100]);
+        expect(arCall?.args).toEqual(['k', 'aspect_ratio', 1.5]);
+    });
+});

--- a/test/web-compat/CMakeLists.txt
+++ b/test/web-compat/CMakeLists.txt
@@ -25,12 +25,22 @@ add_executable(pulp-test-web-compat-layout
     test_layout_grid.cpp
     test_layout_position.cpp
     test_layout_nested.cpp
+    test_layout_aspect_ratio.cpp
 )
 target_link_libraries(pulp-test-web-compat-layout PRIVATE pulp::view Catch2::Catch2WithMain)
 target_include_directories(pulp-test-web-compat-layout PRIVATE ${WEBCOMPAT_INCLUDE_DIR})
 target_compile_definitions(pulp-test-web-compat-layout PRIVATE
     PULP_TEST_SOURCE_DIR="${CMAKE_SOURCE_DIR}/test"
 )
+# pulp #1434 — test_layout_aspect_ratio.cpp exercises the CSS shim via
+# document.createElement + appendChild, which (like the events / prelude
+# targets) deep-recurses through QuickJS↔C++ DOM ops. Match the prelude
+# stack size so the CSS-shim end-to-end tests don't blow the default.
+if(APPLE)
+    target_link_options(pulp-test-web-compat-layout PRIVATE -Wl,-stack_size,0x2000000)
+elseif(UNIX)
+    target_link_options(pulp-test-web-compat-layout PRIVATE -Wl,-z,stacksize=16777216)
+endif()
 catch_discover_tests(pulp-test-web-compat-layout)
 
 # Event tests

--- a/test/web-compat/test_layout_aspect_ratio.cpp
+++ b/test/web-compat/test_layout_aspect_ratio.cpp
@@ -1,0 +1,238 @@
+// pulp #1434 batch 5 — aspect-ratio support for Yoga layout.
+//
+// Validates that:
+//   - FlexStyle::aspect_ratio (std::optional<float>) propagates through to
+//     Yoga via YGNodeStyleSetAspectRatio.
+//   - When set, Yoga sizes the cross axis from the constrained axis:
+//     `width:100, aspectRatio:1.5` -> height = 100/1.5 ≈ 66.67.
+//   - The bridge `setFlex(id, "aspect_ratio", v)` path mutates the same
+//     slot and triggers re-layout.
+//   - The CSS shim parses 3 value forms (number, w/h ratio, "auto").
+//   - Non-positive / non-finite values clear the slot (matches CSS
+//     `aspect-ratio: auto`).
+//
+// All tests carry the [issue-1434-batch-5] tag for the umbrella issue.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "test_helpers.hpp"
+
+using namespace pulp::test;
+using namespace pulp::view;
+using Catch::Matchers::WithinAbs;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// FlexStyle field defaults
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("FlexStyle: aspect_ratio defaults to unset",
+          "[layout][flex][aspect-ratio][issue-1434-batch-5]") {
+    FlexStyle f;
+    REQUIRE_FALSE(f.aspect_ratio.has_value());
+}
+
+TEST_CASE("FlexStyle: aspect_ratio is settable to a finite positive value",
+          "[layout][flex][aspect-ratio][issue-1434-batch-5]") {
+    FlexStyle f;
+    f.aspect_ratio = 1.5f;
+    REQUIRE(f.aspect_ratio.has_value());
+    REQUIRE_THAT(*f.aspect_ratio, WithinAbs(1.5f, 1e-6f));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Yoga dispatch: width pinned, height derived
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("aspect-ratio: width 100 + ratio 1.5 -> height ~= 66.67",
+          "[layout][flex][aspect-ratio][issue-1434-batch-5]") {
+    View root;
+    root.set_bounds({0, 0, 400, 400});
+    root.flex().direction = FlexDirection::row;
+
+    auto child = std::make_unique<View>();
+    child->flex().preferred_width = 100.0f;
+    child->flex().aspect_ratio = 1.5f;
+    auto* raw = child.get();
+    root.add_child(std::move(child));
+    root.layout_children();
+
+    REQUIRE_THAT(raw->bounds().width,  WithinAbs(100.0f, 1.0f));
+    REQUIRE_THAT(raw->bounds().height, WithinAbs(66.6667f, 0.5f));
+}
+
+TEST_CASE("aspect-ratio: width 200 + ratio 1.5 -> height ~= 133.33",
+          "[layout][flex][aspect-ratio][issue-1434-batch-5]") {
+    View root;
+    root.set_bounds({0, 0, 400, 400});
+    root.flex().direction = FlexDirection::row;
+
+    auto child = std::make_unique<View>();
+    child->flex().preferred_width = 200.0f;
+    child->flex().aspect_ratio = 1.5f;
+    auto* raw = child.get();
+    root.add_child(std::move(child));
+    root.layout_children();
+
+    REQUIRE_THAT(raw->bounds().width,  WithinAbs(200.0f, 1.0f));
+    REQUIRE_THAT(raw->bounds().height, WithinAbs(133.3333f, 0.5f));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Yoga dispatch: cross-axis (height pinned, width derived)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("aspect-ratio: height 100 + ratio 0.5 -> width = 50 (cross-axis)",
+          "[layout][flex][aspect-ratio][issue-1434-batch-5]") {
+    View root;
+    root.set_bounds({0, 0, 400, 400});
+    root.flex().direction = FlexDirection::row;
+    // Avoid stretch on cross axis from clamping the child to root height.
+    root.flex().align_items = FlexAlign::start;
+
+    auto child = std::make_unique<View>();
+    child->flex().preferred_height = 100.0f;
+    child->flex().aspect_ratio = 0.5f;
+    auto* raw = child.get();
+    root.add_child(std::move(child));
+    root.layout_children();
+
+    REQUIRE_THAT(raw->bounds().height, WithinAbs(100.0f, 1.0f));
+    REQUIRE_THAT(raw->bounds().width,  WithinAbs(50.0f,  1.0f));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Bridge setter: setFlex(id, "aspect_ratio", value)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("setFlex aspect_ratio: positive value populates FlexStyle slot",
+          "[layout][flex][aspect-ratio][bridge][issue-1434-batch-5]") {
+    TestEnvironment env;
+    env.eval(R"(
+        createCol('box', '');
+        setFlex('box', 'aspect_ratio', 1.5);
+    )");
+    auto* w = env.widget("box");
+    REQUIRE(w != nullptr);
+    REQUIRE(w->flex().aspect_ratio.has_value());
+    REQUIRE_THAT(*w->flex().aspect_ratio, WithinAbs(1.5f, 1e-6f));
+}
+
+TEST_CASE("setFlex aspect_ratio: zero clears the slot",
+          "[layout][flex][aspect-ratio][bridge][issue-1434-batch-5]") {
+    TestEnvironment env;
+    env.eval(R"(
+        createCol('box', '');
+        setFlex('box', 'aspect_ratio', 1.5);
+        setFlex('box', 'aspect_ratio', 0);
+    )");
+    auto* w = env.widget("box");
+    REQUIRE(w != nullptr);
+    REQUIRE_FALSE(w->flex().aspect_ratio.has_value());
+}
+
+TEST_CASE("setFlex aspect_ratio: negative value clears the slot",
+          "[layout][flex][aspect-ratio][bridge][issue-1434-batch-5]") {
+    TestEnvironment env;
+    env.eval(R"(
+        createCol('box', '');
+        setFlex('box', 'aspect_ratio', 2.0);
+        setFlex('box', 'aspect_ratio', -1);
+    )");
+    auto* w = env.widget("box");
+    REQUIRE(w != nullptr);
+    REQUIRE_FALSE(w->flex().aspect_ratio.has_value());
+}
+
+TEST_CASE("setFlex aspect_ratio: end-to-end layout through bridge + Yoga",
+          "[layout][flex][aspect-ratio][bridge][issue-1434-batch-5]") {
+    TestEnvironment env(400, 400);
+    env.run(R"(
+        createCol('box', '');
+        setFlex('box', 'width', 120);
+        setFlex('box', 'aspect_ratio', 2.0);
+    )");
+    auto* w = env.widget("box");
+    REQUIRE(w != nullptr);
+    REQUIRE_THAT(w->bounds().width,  WithinAbs(120.0f, 1.0f));
+    // 120 / 2.0 = 60
+    REQUIRE_THAT(w->bounds().height, WithinAbs(60.0f, 1.0f));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CSS shim translator: web-compat-style-decl.js parses 3 value forms.
+// Goes through the document.createElement / appendChild path so the JS shim
+// (with its 3-form parser and "auto" handling) is exercised end-to-end.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Helper: snapshot the native widget id (`_id`, distinct from the HTML
+// `id` attribute) so the C++ side can look the widget up by the same key
+// the JS shim used.
+static std::string get_native_id(TestEnvironment& env, const std::string& js_var) {
+    auto v = env.engine.evaluate(js_var + "._id");
+    return std::string(v.getWithDefault<std::string_view>(""));
+}
+
+TEST_CASE("CSS aspect-ratio: plain number form via document.createElement",
+          "[layout][flex][aspect-ratio][css][issue-1434-batch-5]") {
+    TestEnvironment env;
+    env.eval(R"(
+        var arn = document.createElement('div');
+        document.body.appendChild(arn);
+        arn.style.aspectRatio = "1.5";
+    )");
+    auto id = get_native_id(env, "arn");
+    REQUIRE_FALSE(id.empty());
+    auto* w = env.widget(id);
+    REQUIRE(w != nullptr);
+    REQUIRE(w->flex().aspect_ratio.has_value());
+    REQUIRE_THAT(*w->flex().aspect_ratio, WithinAbs(1.5f, 1e-5f));
+}
+
+TEST_CASE("CSS aspect-ratio: width/height ratio form (16/9)",
+          "[layout][flex][aspect-ratio][css][issue-1434-batch-5]") {
+    TestEnvironment env;
+    env.eval(R"(
+        var arratio = document.createElement('div');
+        document.body.appendChild(arratio);
+        arratio.style.aspectRatio = "16/9";
+    )");
+    auto id = get_native_id(env, "arratio");
+    REQUIRE_FALSE(id.empty());
+    auto* w = env.widget(id);
+    REQUIRE(w != nullptr);
+    REQUIRE(w->flex().aspect_ratio.has_value());
+    // 16/9 ≈ 1.7778
+    REQUIRE_THAT(*w->flex().aspect_ratio, WithinAbs(16.0f / 9.0f, 1e-4f));
+}
+
+TEST_CASE("CSS aspect-ratio: 'auto' clears the slot",
+          "[layout][flex][aspect-ratio][css][issue-1434-batch-5]") {
+    TestEnvironment env;
+    env.eval(R"(
+        var arauto = document.createElement('div');
+        document.body.appendChild(arauto);
+        arauto.style.aspectRatio = "1.5";
+        arauto.style.aspectRatio = "auto";
+    )");
+    auto id = get_native_id(env, "arauto");
+    REQUIRE_FALSE(id.empty());
+    auto* w = env.widget(id);
+    REQUIRE(w != nullptr);
+    REQUIRE_FALSE(w->flex().aspect_ratio.has_value());
+}
+
+TEST_CASE("CSS aspect-ratio: kebab-case via setProperty",
+          "[layout][flex][aspect-ratio][css][issue-1434-batch-5]") {
+    TestEnvironment env;
+    env.eval(R"(
+        var arkebab = document.createElement('div');
+        document.body.appendChild(arkebab);
+        arkebab.style.setProperty("aspect-ratio", "2");
+    )");
+    auto id = get_native_id(env, "arkebab");
+    REQUIRE_FALSE(id.empty());
+    auto* w = env.widget(id);
+    REQUIRE(w != nullptr);
+    REQUIRE(w->flex().aspect_ratio.has_value());
+    REQUIRE_THAT(*w->flex().aspect_ratio, WithinAbs(2.0f, 1e-6f));
+}


### PR DESCRIPTION
## Summary

- Implements `aspect-ratio` end-to-end across `FlexStyle` → Yoga (`YGNodeStyleSetAspectRatio`) → `widget_bridge.setFlex` → `web-compat-style-decl.js` (CSS) → `@pulp/react` `FlexProps.aspectRatio` (JSX). HIGH-impact import surface: Figma fixed-ratio frames, v0/Claude Design hero images, RN image cards / video tiles all rely on it.
- Three CSS value forms accepted: plain number (`"1.5"`), `width / height` (`"16/9"` → 1.778), and `"auto"` (clears slot). Both camelCase (`aspectRatio`) and kebab-case (`aspect-ratio` via `setProperty`) reach the bridge.
- Reclassifies three compat.json entries from NOT-IMPL/DIVERGE to PASS (yoga, css, rn).

## Implementation

| File | Change |
|---|---|
| `core/view/include/pulp/view/geometry.hpp` | `FlexStyle::aspect_ratio` (`std::optional<float>`) so "unset" ≠ literal 0 |
| `core/view/src/yoga_layout.cpp` | `apply_flex_style` forwards to `YGNodeStyleSetAspectRatio` when set |
| `core/view/src/widget_bridge.cpp` | `setFlex 'aspect_ratio' / 'aspectRatio'` branch — non-finite / non-positive clears |
| `core/view/js/web-compat-style-decl.js` | Three value forms + "auto" handling |
| `packages/pulp-react/src/types.ts` | `FlexProps.aspectRatio?: number` |
| `packages/pulp-react/src/prop-applier.ts` | Routes `aspectRatio` → `setFlex(id, 'aspect_ratio', n)` |
| `packages/pulp-react/src/bridge.ts` | Type-union extension |
| `compat.json` | yoga/css/rn aspectRatio: status="supported", correct mapsTo |

## Tests (`[issue-1434-batch-5]` Catch2 tag)

`test/web-compat/test_layout_aspect_ratio.cpp` — **13 cases, 34 assertions**:
- FlexStyle field defaults / settable
- Yoga main-axis: width 100 + ratio 1.5 → height 66.67
- Yoga main-axis: width 200 + ratio 1.5 → height 133.33
- Yoga cross-axis: height 100 + ratio 0.5 → width 50
- Bridge `setFlex aspect_ratio`: positive populates, zero clears, negative clears, end-to-end layout (width 120 + ratio 2 → height 60)
- CSS shim through `document.createElement` + `appendChild`: plain number, `16/9`, `auto`, kebab-case via `setProperty`

`packages/pulp-react/test/prop-applier-aspect-ratio.test.ts` — **5 cases**: aspectRatio routing, 16/9 ratio flow, 0 emits (bridge clears), undefined no-op, doesn't collide with width/height.

## Harness re-run

`python3 tools/harness/verifier.py --all --json`:

| | Baseline | After |
|---|---|---|
| pass | 136 | **139** (+3) |
| diverge | 170 | 169 (−1) |
| not_impl | 132 | 130 (−2) |
| drift_count | 136 | 136 (unchanged — pre-change entries truthfully reported the gap; the win is pure pass-rate closure) |

Three entries individually:

| Entry | Before | After |
|---|---|---|
| `yoga/aspectRatio` | catalog=missing, harness=NOT-IMPL | catalog=supported, harness=**PASS** |
| `css/aspectRatio` | catalog=partial, harness=DIVERGE | catalog=supported, harness=**PASS** |
| `rn/aspectRatio` | catalog=missing, harness=NOT-IMPL | catalog=supported, harness=**PASS** |

## Test plan

- [x] `pulp-test-web-compat-layout` — 152 cases / 299 assertions pass (13 new)
- [x] `pulp-test-web-compat-prelude` — 70 cases / 124 assertions pass
- [x] `pulp-test-web-compat-events` — 98 cases / 178 assertions pass
- [x] `pulp-test-web-compat-parser` — 157 cases / 345 assertions pass
- [x] `pulp-test-widget-bridge` — 108 cases / 774 assertions pass
- [x] `pulp-test-view` — 58 cases / 253 assertions pass
- [x] `@pulp/react` vitest — 91 cases pass (5 new)
- [x] `tools/harness/verifier.py --all` — drift_count 136, pass +3 (yoga/css/rn aspectRatio)
- [x] Local diff-cover (`pulp-test-web-compat-layout`) — **100%** on the C++ touched lines (`widget_bridge.cpp`, `yoga_layout.cpp`); JS / TS / catalog edits aren't C++ coverage targets but are exercised by the 18 new tests
- [x] `version_bump_check.py` — clean (3 skip trailers)
- [x] `skill_sync_check.py` — clean (1 skill skip trailer for engine)

## Bypass trailers (contiguous block on tip commit)

```
Version-Bump: sdk=skip reason="behavior-only addition; no public C API or CLI surface change"
Version-Bump: plugin=skip reason="no .claude-plugin/ change"
Version-Bump: skip reason="batched with other framework-import-readiness slices under pulp #1434 umbrella; version bump rolled up at umbrella close"
Skill-Update: skip skill=engine reason="extends an existing aspectRatio case in web-compat-style-decl.js; engine-backend selection guidance is unaffected"
```

Closes pulp #1434 (batch 5 of 8).
