### PR TITLE
[codex] Document Rust Shipyard pin workflow

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -35,8 +35,8 @@ When the user says any of: **"push to main"**, **"ship this"**, **"ship it"**,
 **"we're done"**, **"merge this"**, **"push it"**, **"run CI"**, **"push a PR"** —
 run `shipyard pr` (not `gh pr create` + `shipyard ship` separately).
 
-`shipyard pr` is the single orchestrator (Shipyard v0.19.1+; pinned at
-v0.29.0 in `tools/shipyard.toml`). It:
+`shipyard pr` is the single orchestrator (Shipyard v0.19.1+; currently pinned
+in `tools/shipyard.toml`). It:
 
 1. Calls `tools/scripts/skill_sync_check.py` (resolved via Shipyard's
    `[validation]` path-discovery, explicit in `.shipyard/config.toml`) and
@@ -62,7 +62,11 @@ Backward compatibility: raw `shipyard ship` / `shipyard run` still work for
 diagnostics, experimental branches, or when `shipyard pr` itself is being
 debugged. Do not use them as the primary ship path.
 
-### Behaviour notes at the current pin (v0.29.0)
+### Shipyard pin and behaviour notes
+
+Pin bumps must go through `shipyard pin bump --to vX.Y.Z`, not a hand edit.
+Shipyard v0.50.0+ is Rust-backed and macOS ships as an Apple-Silicon-only
+signed/notarized `.dmg`, so the version and asset metadata must move together.
 
 - **Release SDKs are expected to include desktop WebView symbols**
   (pulp #695). `.github/workflows/release-cli.yml` now configures the

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -13,10 +13,17 @@ Pulp validates branches on macOS (local), Ubuntu (SSH), and Windows (SSH) before
 
 ```bash
 ./tools/install-shipyard.sh              # install pinned version
+./tools/install-shipyard.sh --status     # compare installed vs pinned
 shipyard run                              # validate current branch
 shipyard ship                             # PR + validate + merge on green
 shipyard cloud run build <branch>         # dispatch to Namespace
 ```
+
+Pulp intentionally pins Shipyard in `tools/shipyard.toml` even if your daily
+global `shipyard` is newer. Use `shipyard pin bump --to vX.Y.Z` for pin
+updates instead of hand-editing the file; newer Rust Shipyard releases changed
+the macOS asset shape to a signed/notarized `.dmg`, and the bump command keeps
+the version and asset metadata in sync.
 
 ### Shipping a PR: `pulp pr`
 

--- a/docs/guides/versioning.md
+++ b/docs/guides/versioning.md
@@ -256,8 +256,14 @@ dependency-pin update, not a Pulp-versioning event:
 
 ```bash
 python3 tools/deps/audit.py --strict --check-upstream --format markdown
-# edit tools/shipyard.toml
+shipyard pin bump --to vX.Y.Z
 python3 tools/deps/validate_hosts.py
 ```
+
+Prefer `shipyard pin bump` over hand-editing `tools/shipyard.toml`. It owns
+the stale-worktree, downgrade, redundant-main-pin, version, and release-asset
+guards. This matters for Rust Shipyard releases because v0.50.0+ changed the
+macOS distribution shape to Apple-Silicon-only signed `.dmg` assets; the pin
+and asset metadata should move together.
 
 See [CLAUDE.md § Dependency Update Workflow](https://github.com/danielraffel/pulp/blob/main/CLAUDE.md#dependency-update-workflow) for the full procedure. The `ci` skill's path map catches the file change and demands a SKILL.md review.

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -17,6 +17,11 @@
 # That flow owns the pin edit and worktree-safety checks; keep the
 # lockstep doc skim below as part of the bump PR.
 #
+# Do not hand-edit the platform assets when moving to newer Shipyard
+# releases. Shipyard v0.50.0+ is Rust-backed, macOS is Apple-Silicon-only,
+# and the macOS asset is a signed/notarized/stapled `.dmg`; let
+# `shipyard pin bump` update the version/asset shape together.
+#
 # Lockstep docs:
 # When bumping the pin, also re-check that the following docs still
 # accurately describe what Shipyard provides at the new version:


### PR DESCRIPTION
## Summary

Document how Pulp should handle Shipyard now that Shipyard is Rust-backed:

- clarify that Shipyard pin bumps should use `shipyard pin bump --to vX.Y.Z` instead of hand-editing `tools/shipyard.toml`
- note that Shipyard v0.50.0+ uses Apple-Silicon-only signed/notarized macOS DMG assets, so the pin and asset metadata should move together
- update local CI/versioning docs and the CI skill guidance without changing Pulp's current pinned Shipyard version

## Validation

- `python3 tools/scripts/skill_sync_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `python3 tools/scripts/version_bump_check.py --base origin/main --config tools/scripts/versioning.json --mode=report`
- `git diff --check`

No consumer pin is changed in this PR.