### PR TITLE
fix(view/css): close CSS-translator gap-fill batch (closes pulp #1434 batch 3)

### DIFF
--- a/.agents/skills/engine/SKILL.md
+++ b/.agents/skills/engine/SKILL.md
@@ -200,3 +200,49 @@ The setter trap stores into `_props` BEFORE `_applyProperty` runs, so the displa
 `flexFlow` is content-aware: `flexFlow: 'wrap'` does NOT block the row default (CSS shorthand semantics — omitted `flex-direction` defaults to row), but `flexFlow: 'column wrap'` does. The check uses a `\b(row|column)\b` regex against `_props.flexFlow`.
 
 Not changed by this fix: `createCol` / `createRow` / `createPanel` C++ paths preserve their explicit direction; typed React props in `pulp-react/prop-applier.ts` route directly through bridge setters and don't touch `style`.
+
+### CSS-shim gap fills — translator vs. bridge contract (#1434)
+
+Three classes of "silent drop" recur in `web-compat-style-decl.js`. When
+adding a CSS property, walk all three before declaring done:
+
+1. **Missing `case "X":`** — the property is nowhere in the switch, so
+   `el.style.X = ...` writes to `_props[X]` and never reaches the
+   bridge. Harness verdict: NOT-IMPL. Examples: `backdropFilter`
+   (pulp #1434 batch 3 — bridge `setBackdropFilter` was wired by
+   pulp #1366, the JS route was the only missing piece).
+
+2. **Coalesced shorthand only** — the shorthand routes (e.g.
+   `textDecoration`) but the longhands (`textDecorationLine` /
+   `-Color` / `-Style`) silently no-op. Per-attribute longhands MUST
+   route to per-attribute bridge setters so a previously-set sibling
+   isn't clobbered — the same pattern as the per-side border fix
+   from PR #1166 finding #4. Don't try to coalesce three independent
+   property assignments into a single `setX(id, line, color, style)`
+   call; the JS shim iterates assignments in source order, so the
+   first call would always overwrite the next two with defaults.
+
+3. **Keyword-vs-numeric coercion** — CSS / RN accept both keyword
+   forms (`fontWeight: 'bold'`) and numeric (`fontWeight: 700`).
+   `parseInt('bold')` returns `NaN`, the `|| 400` fallback then
+   silently maps bold → normal. Translate before reaching the
+   bridge. The same translation lives in
+   `packages/pulp-react/src/prop-applier.ts` (`_normalizeFontWeight`)
+   for parity with React-Native style objects — both paths must
+   emit the same numeric weight.
+
+**`__cssProperties__` array gotcha:** properties also need an entry in
+the `__cssProperties__` array near the bottom of
+`web-compat-style-decl.js` for `el.style.X = ...` to set the trap.
+Properties only reachable via `setProperty('x-y', ...)` work without
+this because `setProperty` converts kebab to camel and goes through the
+same `_applyProperty` switch — but JSX consumers writing
+`style.backdropFilter = "blur(10px)"` need both the array entry AND the
+`case` block.
+
+**Verifier harness ground truth:** run
+`python3 tools/harness/verifier.py --surface=css --json` before and
+after a CSS-shim change. The JSON delta tells you which entries
+reclassified between NOT-IMPL → DIVERGE → PASS, and a `drift_count`
+that drops without manual `compat.json` edits is the sign that the
+catalog status was already correct and only the JS route was missing.

--- a/compat.json
+++ b/compat.json
@@ -254,21 +254,24 @@
       "tests": [
         "test/web-compat/test_layout_aspect_ratio.cpp"
       ],
-      "notes": "pulp #1434 — three value forms accepted: plain number ('1.5'), 'width / height' ratio ('16/9' -> 1.778), and 'auto' (clears slot). Both 'aspectRatio' (camelCase) and 'aspect-ratio' (kebab-case) work; setProperty auto-converts kebab to camel.",
+      "notes": "pulp #1434 \u2014 three value forms accepted: plain number ('1.5'), 'width / height' ratio ('16/9' -> 1.778), and 'auto' (clears slot). Both 'aspectRatio' (camelCase) and 'aspect-ratio' (kebab-case) work; setProperty auto-converts kebab to camel.",
       "issue": "1434"
     },
     "css/backdropFilter": {
-      "status": "supported",
-      "mapsTo": "setBackdropFilter(id, blur_px)",
+      "status": "partial",
+      "mapsTo": "parses blur(Npx) \u2192 setBackdropFilter(id, blur_px)",
       "supportedValues": [
-        "blur(<px>)"
+        "blur(<px>)",
+        "none"
       ],
       "unsupportedValues": [
         "other filter functions"
       ],
-      "tests": [],
-      "notes": "Blur-only.",
-      "issue": ""
+      "tests": [
+        "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]"
+      ],
+      "notes": "Blur-only. CSS shim parses the blur(Npx) substring; non-matching filter functions are ignored. None / empty clears the slot.",
+      "issue": "1434"
     },
     "css/backfaceVisibility": {
       "status": "supported",
@@ -1172,19 +1175,21 @@
     },
     "css/fontWeight": {
       "status": "supported",
-      "mapsTo": "parseInt -> setFontWeight(id, n)",
+      "mapsTo": "translate keyword/numeric \u2192 setFontWeight(id, n)",
       "supportedValues": [
-        "100..900 (numeric)"
-      ],
-      "unsupportedValues": [
+        "100..900 (numeric)",
         "normal",
         "bold",
         "lighter",
         "bolder"
       ],
-      "tests": [],
-      "notes": "Keyword 'bold' parses as NaN -> 400. Should map: normal->400, bold->700.",
-      "issue": ""
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]",
+        "packages/pulp-react/test/prop-applier-fontweight.test.ts"
+      ],
+      "notes": "Keyword-to-numeric: normal\u2192400, bold\u2192700, lighter\u2192300, bolder\u2192700. Numeric keywords parse unchanged. Mirrored in @pulp/react prop-applier (_normalizeFontWeight).",
+      "issue": "1434"
     },
     "css/gap": {
       "status": "supported",
@@ -2232,41 +2237,50 @@
       "issue": ""
     },
     "css/textDecorationColor": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
+      "status": "supported",
+      "mapsTo": "setTextDecorationColor(id, color)",
+      "supportedValues": [
         "any color"
       ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]"
+      ],
+      "notes": "Bridge calls Label::set_text_decoration_color. Painted color falls back to the text color when unset.",
+      "issue": "1434"
     },
     "css/textDecorationLine": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "setTextDecoration(id, line)",
+      "supportedValues": [
+        "underline",
+        "line-through",
+        "overline",
+        "none"
       ],
-      "tests": [],
-      "notes": "RN distinguishes textDecoration[Line/Style/Color]; we collapse to one.",
-      "issue": ""
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]"
+      ],
+      "notes": "Routes to the same Label::TextDecoration setter as the shorthand. Per-attribute longhand preserves any previously-set sibling longhand (color/style). The deprecated 'blink' value is intentionally not supported (matches modern UA behavior).",
+      "issue": "1434"
     },
     "css/textDecorationStyle": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
+      "status": "supported",
+      "mapsTo": "setTextDecorationStyle(id, style)",
+      "supportedValues": [
         "solid",
         "double",
         "dotted",
         "dashed",
         "wavy"
       ],
-      "tests": [],
-      "notes": "Not handled.",
-      "issue": ""
+      "unsupportedValues": [],
+      "tests": [
+        "test/web-compat/test_css_translator_gaps_1434.cpp [issue-1434-batch-3]"
+      ],
+      "notes": "CSS shim + bridge accept all 5 spec values and store them on Label. Paint path renders solid regardless today; non-solid styles fall back to solid (spec-allowed).",
+      "issue": "1434"
     },
     "css/textIndent": {
       "status": "missing",
@@ -2674,7 +2688,7 @@
         "packages/pulp-react/test/prop-applier-aspect-ratio.test.ts",
         "test/web-compat/test_layout_aspect_ratio.cpp"
       ],
-      "notes": "pulp #1434 — JSX surface accepts numeric aspectRatio (RN parity per oracle 'kind: number'). String forms ('16/9', 'auto') reach FlexStyle through the CSS shim path (web-compat-style-decl.js), not the @pulp/react TS surface.",
+      "notes": "pulp #1434 \u2014 JSX surface accepts numeric aspectRatio (RN parity per oracle 'kind: number'). String forms ('16/9', 'auto') reach FlexStyle through the CSS shim path (web-compat-style-decl.js), not the @pulp/react TS surface.",
       "issue": "1434"
     },
     "rn/backfaceVisibility": {
@@ -4274,7 +4288,7 @@
       "tests": [
         "test/web-compat/test_layout_aspect_ratio.cpp"
       ],
-      "notes": "pulp #1434 — added FlexStyle.aspect_ratio + Yoga dispatch + bridge setFlex 'aspect_ratio' branch + @pulp/react aspectRatio prop. CSS shim accepts plain numbers ('1.5'), 'width/height' ratios ('16/9'), and 'auto' (clears slot).",
+      "notes": "pulp #1434 \u2014 added FlexStyle.aspect_ratio + Yoga dispatch + bridge setFlex 'aspect_ratio' branch + @pulp/react aspectRatio prop. CSS shim accepts plain numbers ('1.5'), 'width/height' ratios ('16/9'), and 'auto' (clears slot).",
       "issue": "1434"
     },
     "yoga/margin": {

--- a/core/view/include/pulp/view/widgets.hpp
+++ b/core/view/include/pulp/view/widgets.hpp
@@ -79,7 +79,20 @@ public:
     /// CSS text-decoration: none, underline, line-through, overline
     enum class TextDecoration { none, underline, line_through, overline };
     void set_text_decoration(TextDecoration d) { text_decoration_ = d; }
+    TextDecoration text_decoration() const { return text_decoration_; }
     void set_text_decoration_color(canvas::Color c) { decoration_color_ = c; has_decoration_color_ = true; }
+    canvas::Color text_decoration_color() const { return decoration_color_; }
+    bool has_text_decoration_color() const { return has_decoration_color_; }
+
+    /// CSS text-decoration-style: solid, double, dotted, dashed, wavy.
+    /// pulp #1434 — accepted via the JS CSS shim and the bridge so authors
+    /// can express the per-style longhand. Today the paint path always
+    /// renders as `solid`; the value is stored so future paint logic can
+    /// honor it without an API break (matches the spec's optional fallback
+    /// to solid for renderers that don't implement non-solid styles).
+    enum class TextDecorationStyle { solid, double_, dotted, dashed, wavy };
+    void set_text_decoration_style(TextDecorationStyle s) { text_decoration_style_ = s; }
+    TextDecorationStyle text_decoration_style() const { return text_decoration_style_; }
 
     void paint(canvas::Canvas& canvas) override;
 
@@ -111,6 +124,7 @@ private:
     TextDecoration text_decoration_ = TextDecoration::none;
     canvas::Color decoration_color_{};
     bool has_decoration_color_ = false;
+    TextDecorationStyle text_decoration_style_ = TextDecorationStyle::solid;
     canvas::TextDirection text_direction_ = canvas::TextDirection::left_to_right;
     canvas::TextVerticalAlign vertical_align_ = canvas::TextVerticalAlign::top;
     // issue-969: explicit-vs-inherited tracking. Fields keep their default

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -296,7 +296,28 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             break;
         }
         case "fontWeight":
-            setFontWeight(id, parseInt(resolved) || 400);
+            // pulp #1434 (batch 3) — translate CSS keyword forms to
+            // numeric weight before reaching the bridge. Numeric values
+            // ("400", "500") still flow through unchanged. The previous
+            // `parseInt` path returned NaN for keywords, which fell back
+            // to the `|| 400` default — silently mapping `"bold"` to
+            // `normal`. CSS spec values:
+            //   normal  → 400
+            //   bold    → 700
+            //   lighter → 300 (relative to inherited; pulp has no font
+            //                  inheritance cascade today, so a fixed
+            //                  "one step lighter than normal" is the
+            //                  closest safe default)
+            //   bolder  → 700 (likewise: "one step bolder than normal")
+            // Numeric keywords ("100".."900") parseInt cleanly.
+            var fwResolved = String(resolved).trim().toLowerCase();
+            var fwNumeric;
+            if (fwResolved === "normal") fwNumeric = 400;
+            else if (fwResolved === "bold") fwNumeric = 700;
+            else if (fwResolved === "lighter") fwNumeric = 300;
+            else if (fwResolved === "bolder") fwNumeric = 700;
+            else fwNumeric = parseInt(fwResolved, 10) || 400;
+            setFontWeight(id, fwNumeric);
             break;
         case "fontStyle":
             setFontStyle(id, resolved);
@@ -319,6 +340,28 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             break;
         case "textDecoration":
             setTextDecoration(id, resolved);
+            break;
+        // pulp #1434 (batch 3) — text-decoration longhands. CSS exposes
+        // the shorthand `text-decoration` plus three independent
+        // longhands: `-line` / `-color` / `-style`. Routing each to its
+        // own bridge setter (instead of coalescing into a shorthand
+        // string) means a previously-set sibling longhand is preserved
+        // — matching the per-attribute border-color/width fix from PR
+        // #1166 finding #4. Same pattern, same reasoning.
+        case "textDecorationLine":
+            // Reuse the shorthand setter — same line keyword surface
+            // (underline / line-through / overline / none).
+            setTextDecoration(id, resolved);
+            break;
+        case "textDecorationColor": {
+            var tdc = parseCSSColor(resolved);
+            if (tdc && typeof setTextDecorationColor === "function")
+                setTextDecorationColor(id, tdc);
+            break;
+        }
+        case "textDecorationStyle":
+            if (typeof setTextDecorationStyle === "function")
+                setTextDecorationStyle(id, resolved);
             break;
         case "textOverflow":
             setTextOverflow(id, resolved);
@@ -480,6 +523,29 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
         case "filter":
             setFilter(id, resolved);
             break;
+
+        // pulp #1434 (batch 3) — backdrop-filter route. The bridge
+        // setter is numeric (`setBackdropFilter(id, blur_px)`), so we
+        // parse a `blur(Npx)` substring out of the CSS value. This
+        // matches what `setFilter` already does on the bridge side
+        // (see widget_bridge.cpp::setFilter — same blur-only surface).
+        // Any other filter function is intentionally ignored here;
+        // matching the `unsupportedValues: ["other filter functions"]`
+        // entry in compat.json. `none` / empty / 0 clears the slot.
+        case "backdropFilter": {
+            if (typeof setBackdropFilter !== "function") break;
+            var bdf = String(resolved).trim().toLowerCase();
+            if (bdf === "" || bdf === "none") {
+                setBackdropFilter(id, 0);
+                break;
+            }
+            // Match `blur(Npx)` or `blur(N)` (treat unitless as px).
+            var bdm = bdf.match(/blur\(\s*([\d.]+)\s*(px)?\s*\)/);
+            if (bdm) {
+                setBackdropFilter(id, parseFloat(bdm[1]) || 0);
+            }
+            break;
+        }
 
         // Background gradient
         case "backgroundImage":
@@ -881,7 +947,10 @@ var __cssProperties__ = [
     "paddingInline", "paddingBlock",
     "backgroundColor", "color",
     "fontSize", "fontWeight", "fontStyle", "fontFamily", "letterSpacing", "lineHeight",
-    "textAlign", "textTransform", "textDecoration", "textOverflow", "textShadow",
+    "textAlign", "textTransform",
+    // pulp #1434 (batch 3) — text-decoration shorthand + 3 longhands.
+    "textDecoration", "textDecorationLine", "textDecorationColor", "textDecorationStyle",
+    "textOverflow", "textShadow",
     "whiteSpace", "wordBreak", "overflowWrap", "wordWrap",
     "border", "borderColor", "borderWidth", "borderRadius",
     "borderTop", "borderRight", "borderBottom", "borderLeft",
@@ -896,7 +965,7 @@ var __cssProperties__ = [
     "animation", "animationName", "animationDuration", "animationTimingFunction",
     "animationDelay", "animationIterationCount", "animationDirection", "animationFillMode",
     "position", "top", "right", "bottom", "left", "zIndex", "inset",
-    "boxShadow", "filter", "background", "backgroundImage",
+    "boxShadow", "filter", "backdropFilter", "background", "backgroundImage",
     "backgroundSize", "backgroundPosition", "backgroundRepeat",
     "gridTemplateColumns", "gridTemplateRows", "gridColumn", "gridRow",
     "lineClamp", "webkitLineClamp"

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -3257,6 +3257,45 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
+    // pulp #1434 (batch 3) — text-decoration longhands. CSS shorthand
+    // `text-decoration` historically routed through `setTextDecoration`
+    // above (line keyword only). The longhand triplet
+    // `text-decoration-line` / `-color` / `-style` reaches each setter
+    // independently so authors can build the decoration up piece-by-piece
+    // without losing previously-set siblings (mirrors the per-attribute
+    // border-fix from PR #1166 finding #4).
+
+    // setTextDecorationColor(id, "#rrggbb"|color-token)
+    engine_.register_function("setTextDecorationColor",
+        [this, parseHexColor](choc::javascript::ArgumentList args) {
+            auto* v = widget(args.get<std::string>(0, ""));
+            auto hex = args.get<std::string>(1, "");
+            if (auto* l = dynamic_cast<Label*>(v); l && !hex.empty()) {
+                l->set_text_decoration_color(parseHexColor(hex));
+            }
+            return choc::value::Value();
+        });
+
+    // setTextDecorationStyle(id, "solid"|"double"|"dotted"|"dashed"|"wavy")
+    // The paint path renders `solid` regardless today, but the value is
+    // stored on the Label so future paint logic can honor it without an
+    // API break — and so the JS shim's longhand → setter route doesn't
+    // silently drop the property (which was the catalog's `missing`
+    // status before this PR).
+    engine_.register_function("setTextDecorationStyle",
+        [this](choc::javascript::ArgumentList args) {
+            auto* v = widget(args.get<std::string>(0, ""));
+            auto s = args.get<std::string>(1, "solid");
+            if (auto* l = dynamic_cast<Label*>(v)) {
+                if (s == "double") l->set_text_decoration_style(Label::TextDecorationStyle::double_);
+                else if (s == "dotted") l->set_text_decoration_style(Label::TextDecorationStyle::dotted);
+                else if (s == "dashed") l->set_text_decoration_style(Label::TextDecorationStyle::dashed);
+                else if (s == "wavy") l->set_text_decoration_style(Label::TextDecorationStyle::wavy);
+                else l->set_text_decoration_style(Label::TextDecorationStyle::solid);
+            }
+            return choc::value::Value();
+        });
+
     // setPosition(id, "static"/"relative"/"absolute"/"fixed") — CSS position
     engine_.register_function("setPosition", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");

--- a/packages/pulp-react/src/bridge.ts
+++ b/packages/pulp-react/src/bridge.ts
@@ -184,6 +184,19 @@ export function createMockBridge(): MockBridge {
         'setBorderBottomLeftRadius', 'setBorderBottomRightRadius',
         'setBorderSide', 'setOpacity', 'setVisible', 'setPosition',
         'setText', 'setTextColor', 'setTextAlign',
+        // pulp #1434 batch 3 — typography keyword translation needs the
+        // mock bridge to capture setFontWeight calls so the prop-applier
+        // fontWeight test can assert on the numeric value handed off
+        // post-translation. Same surface for fontSize / fontStyle /
+        // letterSpacing / lineHeight / fontFamily / textTransform /
+        // textDecoration which the prop-applier already dispatches.
+        'setFontSize', 'setFontWeight', 'setFontStyle', 'setFontFamily',
+        'setLetterSpacing', 'setLineHeight',
+        'setTextTransform', 'setTextDecoration',
+        // pulp #1434 batch 3 — text-decoration longhands.
+        'setTextDecorationColor', 'setTextDecorationStyle',
+        // pulp #1366 / #1434 — backdrop-filter (numeric blur arg).
+        'setBackdropFilter',
         'setSpectrumData', 'setWaveformData', 'setMeterLevel', 'setProgress',
         'setValue', 'setTheme', 'layout', 'on', 'registerHover',
         // pulp #1381 — registerPointer arms the bridge's on_pointer_event

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -113,6 +113,28 @@ function isWheelEvent(eventName: string): boolean {
     return eventName === 'wheel';
 }
 
+// pulp #1434 (batch 3) — translate CSS / React-Native fontWeight keyword
+// values to numeric weights before reaching the bridge. Mirrors the same
+// logic in the JS CSS shim (`web-compat-style-decl.js`). Numeric values
+// (`400`, `'500'`) flow through unchanged. The previous `Number(value)`
+// fallback returned NaN for keywords like `'bold'`, which the bridge
+// then coerced to 400 — silently mapping bold to normal. CSS spec:
+//   normal  → 400
+//   bold    → 700
+//   lighter → 300 (no font cascade in pulp; safe lower default)
+//   bolder  → 700 (no font cascade in pulp; "one step bolder than
+//                  normal" lands on bold)
+function _normalizeFontWeight(value: unknown): number {
+    if (typeof value === 'number') return value;
+    const s = String(value).trim().toLowerCase();
+    if (s === 'normal') return 400;
+    if (s === 'bold') return 700;
+    if (s === 'lighter') return 300;
+    if (s === 'bolder') return 700;
+    const n = Number(s);
+    return Number.isFinite(n) ? n : 400;
+}
+
 function applyEventHandler(id: string, key: string, value: unknown): void {
     if (typeof value !== 'function') return;
     const eventName = eventNameFor(key);
@@ -307,7 +329,7 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         // bundle's chrome layout (especially Label widths under #935 auto-grow)
         // depends on letter-spacing and font-size being set correctly.
         case 'fontSize':        return call('setFontSize', id, value as number);
-        case 'fontWeight':      return call('setFontWeight', id, typeof value === 'number' ? value : Number(value));
+        case 'fontWeight':      return call('setFontWeight', id, _normalizeFontWeight(value));
         case 'fontStyle':       return call('setFontStyle', id, value as string);
         case 'letterSpacing':   return call('setLetterSpacing', id, value as number);
         case 'lineHeight':      return call('setLineHeight', id, value as number);

--- a/packages/pulp-react/test/prop-applier-fontweight.test.ts
+++ b/packages/pulp-react/test/prop-applier-fontweight.test.ts
@@ -1,0 +1,87 @@
+// pulp #1434 batch 3 — verify the @pulp/react prop-applier translates
+// CSS / RN fontWeight keyword forms (`'normal'`, `'bold'`, `'lighter'`,
+// `'bolder'`) to numeric weights before reaching the bridge.
+//
+// Pre-fix: `Number('bold')` returned NaN, the bridge then defaulted to
+// 400 — silently mapping bold to normal. This drift is recorded in
+// compat.json (`css/fontWeight`) and mirrored on the JS CSS shim
+// (`web-compat-style-decl.js`). Both paths must agree so design-tool
+// exports (Figma, Stitch, v0, Claude Design) and React-Native style
+// objects produce the same Label::font_weight() result.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyChangedProps } from '../src/prop-applier.js';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import type { PulpInstance } from '../src/types.js';
+
+let bridge: MockBridge;
+
+beforeEach(() => {
+    bridge = createMockBridge();
+    bridge.install();
+});
+afterEach(() => {
+    bridge.uninstall();
+});
+
+function makeInstance(id: string = 'k', type: string = 'Label'): PulpInstance {
+    return {
+        id,
+        type: type as PulpInstance['type'],
+        props: {},
+        childIds: [],
+        onBridge: true,
+        pendingChildren: [],
+    };
+}
+
+function fontWeightCall(): { fn: string; args: unknown[] } | undefined {
+    return bridge.calls.find((c) => c.fn === 'setFontWeight');
+}
+
+describe("prop-applier fontWeight keyword translation (pulp #1434 batch 3)", () => {
+    it("'normal' keyword maps to 400", () => {
+        applyChangedProps(makeInstance(), {}, { fontWeight: 'normal' });
+        expect(fontWeightCall()?.args).toEqual(['k', 400]);
+    });
+
+    it("'bold' keyword maps to 700", () => {
+        applyChangedProps(makeInstance(), {}, { fontWeight: 'bold' });
+        expect(fontWeightCall()?.args).toEqual(['k', 700]);
+    });
+
+    it("'lighter' keyword maps to 300", () => {
+        applyChangedProps(makeInstance(), {}, { fontWeight: 'lighter' });
+        expect(fontWeightCall()?.args).toEqual(['k', 300]);
+    });
+
+    it("'bolder' keyword maps to 700", () => {
+        applyChangedProps(makeInstance(), {}, { fontWeight: 'bolder' });
+        expect(fontWeightCall()?.args).toEqual(['k', 700]);
+    });
+
+    it('numeric values still flow through unchanged (no regression)', () => {
+        applyChangedProps(makeInstance(), {}, { fontWeight: 500 });
+        expect(fontWeightCall()?.args).toEqual(['k', 500]);
+    });
+
+    it('numeric string flows through as a number', () => {
+        applyChangedProps(makeInstance(), {}, { fontWeight: '700' });
+        expect(fontWeightCall()?.args).toEqual(['k', 700]);
+    });
+
+    it('case-insensitive keywords still translate', () => {
+        applyChangedProps(makeInstance(), {}, { fontWeight: 'BOLD' });
+        expect(fontWeightCall()?.args).toEqual(['k', 700]);
+    });
+
+    it('unknown keyword falls back to 400 (defensive default)', () => {
+        applyChangedProps(makeInstance(), {}, { fontWeight: 'definitely-not-a-weight' });
+        expect(fontWeightCall()?.args).toEqual(['k', 400]);
+    });
+
+    it('extra-bold numeric (800) flows through unchanged', () => {
+        applyChangedProps(makeInstance(), {}, { fontWeight: 800 });
+        expect(fontWeightCall()?.args).toEqual(['k', 800]);
+    });
+});

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -2926,6 +2926,83 @@ TEST_CASE("WidgetBridge setTransform stores affine matrix on the target View",
     REQUIRE_FALSE(v->has_transform_matrix());
 }
 
+// ── pulp #1434 batch 3: text-decoration longhands ────────────────────────────
+
+TEST_CASE("WidgetBridge setTextDecorationColor stores color on Label",
+          "[view][bridge][issue-1434-batch-3]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createLabel('lab', 'hello', '')");
+    auto* lab = dynamic_cast<Label*>(bridge.widget("lab"));
+    REQUIRE(lab != nullptr);
+    REQUIRE_FALSE(lab->has_text_decoration_color());
+
+    bridge.load_script("setTextDecorationColor('lab', '#ff0000')");
+    REQUIRE(lab->has_text_decoration_color());
+    REQUIRE(lab->text_decoration_color().r8() == 255);
+    REQUIRE(lab->text_decoration_color().g8() == 0);
+    REQUIRE(lab->text_decoration_color().b8() == 0);
+}
+
+TEST_CASE("WidgetBridge setTextDecorationStyle stores enum on Label",
+          "[view][bridge][issue-1434-batch-3]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script("createLabel('lab', 'hello', '')");
+    auto* lab = dynamic_cast<Label*>(bridge.widget("lab"));
+    REQUIRE(lab != nullptr);
+    // Default is solid.
+    REQUIRE(lab->text_decoration_style() == Label::TextDecorationStyle::solid);
+
+    bridge.load_script("setTextDecorationStyle('lab', 'dashed')");
+    REQUIRE(lab->text_decoration_style() == Label::TextDecorationStyle::dashed);
+
+    bridge.load_script("setTextDecorationStyle('lab', 'wavy')");
+    REQUIRE(lab->text_decoration_style() == Label::TextDecorationStyle::wavy);
+
+    bridge.load_script("setTextDecorationStyle('lab', 'dotted')");
+    REQUIRE(lab->text_decoration_style() == Label::TextDecorationStyle::dotted);
+
+    bridge.load_script("setTextDecorationStyle('lab', 'double')");
+    REQUIRE(lab->text_decoration_style() == Label::TextDecorationStyle::double_);
+
+    // Unknown value → solid (defensive default).
+    bridge.load_script("setTextDecorationStyle('lab', 'wat')");
+    REQUIRE(lab->text_decoration_style() == Label::TextDecorationStyle::solid);
+}
+
+TEST_CASE("WidgetBridge text-decoration longhand setters preserve siblings",
+          "[view][bridge][issue-1434-batch-3]") {
+    // Mirrors the per-attribute border-fix from PR #1166 finding #4 —
+    // setting one longhand must not clobber a previously-set sibling.
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createLabel('lab', 'hello', '');
+        setTextDecoration('lab', 'underline');
+        setTextDecorationColor('lab', '#00ff00');
+        setTextDecorationStyle('lab', 'wavy');
+    )");
+    auto* lab = dynamic_cast<Label*>(bridge.widget("lab"));
+    REQUIRE(lab != nullptr);
+    REQUIRE(lab->text_decoration() == Label::TextDecoration::underline);
+    REQUIRE(lab->has_text_decoration_color());
+    REQUIRE(lab->text_decoration_color().g8() == 255);
+    REQUIRE(lab->text_decoration_style() == Label::TextDecorationStyle::wavy);
+}
+
 // ── issue-926: setBackdropFilter ─────────────────────────────────────────────
 
 TEST_CASE("WidgetBridge setBackdropFilter sets backdrop_blur on the View",

--- a/test/web-compat/CMakeLists.txt
+++ b/test/web-compat/CMakeLists.txt
@@ -136,6 +136,25 @@ elseif(UNIX)
 endif()
 catch_discover_tests(pulp-test-headless-frame-pump)
 
+# pulp #1434 batch 3 — CSS translator gap fills: backdropFilter,
+# textDecoration{Line,Color,Style}, fontWeight keyword translation.
+# Exercises the JS shim → bridge round trip via
+# document.createElement / appendChild / style.X = ... — same DOM-shim
+# stack-depth profile as the prelude / aspect-ratio targets, so match
+# the 16 MB stack the rest of the web-compat suite uses.
+add_executable(pulp-test-css-translator-gaps-1434 test_css_translator_gaps_1434.cpp)
+target_link_libraries(pulp-test-css-translator-gaps-1434 PRIVATE pulp::view Catch2::Catch2WithMain)
+target_include_directories(pulp-test-css-translator-gaps-1434 PRIVATE ${WEBCOMPAT_INCLUDE_DIR})
+target_compile_definitions(pulp-test-css-translator-gaps-1434 PRIVATE
+    PULP_TEST_SOURCE_DIR="${CMAKE_SOURCE_DIR}/test"
+)
+if(APPLE)
+    target_link_options(pulp-test-css-translator-gaps-1434 PRIVATE -Wl,-stack_size,0x2000000)
+elseif(UNIX)
+    target_link_options(pulp-test-css-translator-gaps-1434 PRIVATE -Wl,-z,stacksize=16777216)
+endif()
+catch_discover_tests(pulp-test-css-translator-gaps-1434)
+
 # #1147 regression: nested-flex popover row template — inline <svg> with
 # width/height attributes must reserve layout space, and a <span> with
 # nested flex children must lay out those children instead of clobbering

--- a/test/web-compat/test_css_translator_gaps_1434.cpp
+++ b/test/web-compat/test_css_translator_gaps_1434.cpp
@@ -1,0 +1,360 @@
+// pulp #1434 (batch 3) — CSS translator gap fills.
+//
+// Verifies that the JS CSS shim (`web-compat-style-decl.js`) routes the
+// three previously-dropped property families through to their bridge
+// setters end-to-end:
+//
+//   1. `style.backdropFilter` — parses `blur(Npx)`, calls
+//      setBackdropFilter (numeric form). Pre-fix: NOT-IMPL (silent
+//      drop). Bridge from pulp #1366 was already wired.
+//
+//   2. `style.textDecorationLine` / `-Color` / `-Style` — three
+//      longhands routed independently so a previously-set sibling is
+//      preserved (mirrors PR #1166 finding #4 per-attribute border
+//      pattern). Pre-fix: NOT-IMPL (no `case` block).
+//
+//   3. `style.fontWeight` — keyword forms (`normal` / `bold` /
+//      `lighter` / `bolder`) translate to numeric weights before
+//      reaching the bridge. Pre-fix: `parseInt('bold')` → NaN → 400
+//      default, silently making `bold` look identical to `normal`.
+//
+// The DOM-shim path (document.createElement → appendChild → style.X = ...)
+// is the canonical end-to-end exercise — same pattern as
+// test_layout_aspect_ratio.cpp.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "test_helpers.hpp"
+
+using namespace pulp::test;
+using namespace pulp::view;
+using Catch::Matchers::WithinAbs;
+
+// Snapshot the native widget id (`_id`) so the C++ side can look the
+// widget up by the same key the JS shim used. Same helper as
+// test_layout_aspect_ratio.cpp — kept local so this file is self-
+// contained for [issue-1434-batch-3] coverage.
+static std::string native_id(TestEnvironment& env, const std::string& js_var) {
+    auto v = env.engine.evaluate(js_var + "._id");
+    return std::string(v.getWithDefault<std::string_view>(""));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 1. backdrop-filter
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("CSS backdropFilter: blur(10px) reaches setBackdropFilter as numeric",
+          "[css][shim][backdropFilter][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var bdf = document.createElement('div');
+        document.body.appendChild(bdf);
+        bdf.style.backdropFilter = "blur(10px)";
+    )JS");
+    auto id = native_id(env, "bdf");
+    REQUIRE_FALSE(id.empty());
+    auto* w = env.widget(id);
+    REQUIRE(w != nullptr);
+    REQUIRE_THAT(w->backdrop_blur(), WithinAbs(10.0f, 1e-5f));
+}
+
+TEST_CASE("CSS backdropFilter: blur(0) clears the slot",
+          "[css][shim][backdropFilter][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var bdf2 = document.createElement('div');
+        document.body.appendChild(bdf2);
+        bdf2.style.backdropFilter = "blur(8px)";
+        bdf2.style.backdropFilter = "blur(0)";
+    )JS");
+    auto* w = env.widget(native_id(env, "bdf2"));
+    REQUIRE(w != nullptr);
+    REQUIRE(w->backdrop_blur() == 0.0f);
+}
+
+TEST_CASE("CSS backdropFilter: 'none' clears the slot",
+          "[css][shim][backdropFilter][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var bdf3 = document.createElement('div');
+        document.body.appendChild(bdf3);
+        bdf3.style.backdropFilter = "blur(6px)";
+        bdf3.style.backdropFilter = "none";
+    )JS");
+    auto* w = env.widget(native_id(env, "bdf3"));
+    REQUIRE(w != nullptr);
+    REQUIRE(w->backdrop_blur() == 0.0f);
+}
+
+TEST_CASE("CSS backdropFilter: kebab-case via setProperty",
+          "[css][shim][backdropFilter][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var bdf4 = document.createElement('div');
+        document.body.appendChild(bdf4);
+        bdf4.style.setProperty("backdrop-filter", "blur(15px)");
+    )JS");
+    auto* w = env.widget(native_id(env, "bdf4"));
+    REQUIRE(w != nullptr);
+    REQUIRE_THAT(w->backdrop_blur(), WithinAbs(15.0f, 1e-5f));
+}
+
+TEST_CASE("CSS backdropFilter: unsupported filter functions are ignored (no crash)",
+          "[css][shim][backdropFilter][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var bdf5 = document.createElement('div');
+        document.body.appendChild(bdf5);
+        bdf5.style.backdropFilter = "brightness(0.5) contrast(1.2)";
+    )JS");
+    auto* w = env.widget(native_id(env, "bdf5"));
+    REQUIRE(w != nullptr);
+    // No blur() function → bridge is not called → backdrop_blur stays 0.
+    REQUIRE(w->backdrop_blur() == 0.0f);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 2. text-decoration longhands (line / color / style)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("CSS textDecorationLine: routes 'underline' through setTextDecoration",
+          "[css][shim][textDecoration][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var tdl = document.createElement('span');
+        document.body.appendChild(tdl);
+        tdl.style.textDecorationLine = "underline";
+    )JS");
+    auto* l = dynamic_cast<Label*>(env.widget(native_id(env, "tdl")));
+    REQUIRE(l != nullptr);
+    REQUIRE(l->text_decoration() == Label::TextDecoration::underline);
+}
+
+TEST_CASE("CSS textDecorationLine: 'line-through' / 'overline' / 'none' all route",
+          "[css][shim][textDecoration][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var a = document.createElement('span');
+        var b = document.createElement('span');
+        var c = document.createElement('span');
+        document.body.appendChild(a);
+        document.body.appendChild(b);
+        document.body.appendChild(c);
+        a.style.textDecorationLine = "line-through";
+        b.style.textDecorationLine = "overline";
+        c.style.textDecorationLine = "underline";
+        c.style.textDecorationLine = "none";
+    )JS");
+    auto* la = dynamic_cast<Label*>(env.widget(native_id(env, "a")));
+    auto* lb = dynamic_cast<Label*>(env.widget(native_id(env, "b")));
+    auto* lc = dynamic_cast<Label*>(env.widget(native_id(env, "c")));
+    REQUIRE(la);
+    REQUIRE(lb);
+    REQUIRE(lc);
+    REQUIRE(la->text_decoration() == Label::TextDecoration::line_through);
+    REQUIRE(lb->text_decoration() == Label::TextDecoration::overline);
+    REQUIRE(lc->text_decoration() == Label::TextDecoration::none);
+}
+
+TEST_CASE("CSS textDecorationColor: hex sets the decoration color",
+          "[css][shim][textDecoration][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var tdc = document.createElement('span');
+        document.body.appendChild(tdc);
+        tdc.style.textDecorationLine = "underline";
+        tdc.style.textDecorationColor = "#ff0000";
+    )JS");
+    auto* l = dynamic_cast<Label*>(env.widget(native_id(env, "tdc")));
+    REQUIRE(l);
+    REQUIRE(l->has_text_decoration_color());
+    auto c = l->text_decoration_color();
+    // Pure red. canvas::Color stores float channels [0,1]; r8/g8/b8 round
+    // to the 8-bit form for hex parity.
+    REQUIRE(c.r8() == 255);
+    REQUIRE(c.g8() == 0);
+    REQUIRE(c.b8() == 0);
+}
+
+TEST_CASE("CSS textDecorationStyle: all 5 spec values map to enum",
+          "[css][shim][textDecoration][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var s1 = document.createElement('span');
+        var s2 = document.createElement('span');
+        var s3 = document.createElement('span');
+        var s4 = document.createElement('span');
+        var s5 = document.createElement('span');
+        document.body.appendChild(s1);
+        document.body.appendChild(s2);
+        document.body.appendChild(s3);
+        document.body.appendChild(s4);
+        document.body.appendChild(s5);
+        s1.style.textDecorationStyle = "solid";
+        s2.style.textDecorationStyle = "double";
+        s3.style.textDecorationStyle = "dotted";
+        s4.style.textDecorationStyle = "dashed";
+        s5.style.textDecorationStyle = "wavy";
+    )JS");
+    auto get_style = [&](const char* name) {
+        auto* l = dynamic_cast<Label*>(env.widget(native_id(env, name)));
+        REQUIRE(l);
+        return l->text_decoration_style();
+    };
+    REQUIRE(get_style("s1") == Label::TextDecorationStyle::solid);
+    REQUIRE(get_style("s2") == Label::TextDecorationStyle::double_);
+    REQUIRE(get_style("s3") == Label::TextDecorationStyle::dotted);
+    REQUIRE(get_style("s4") == Label::TextDecorationStyle::dashed);
+    REQUIRE(get_style("s5") == Label::TextDecorationStyle::wavy);
+}
+
+TEST_CASE("CSS textDecoration longhands compose: line + color + style independently",
+          "[css][shim][textDecoration][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var combo = document.createElement('span');
+        document.body.appendChild(combo);
+        combo.style.textDecorationLine = "underline";
+        combo.style.textDecorationColor = "#00ff00";
+        combo.style.textDecorationStyle = "dashed";
+    )JS");
+    auto* l = dynamic_cast<Label*>(env.widget(native_id(env, "combo")));
+    REQUIRE(l);
+    REQUIRE(l->text_decoration() == Label::TextDecoration::underline);
+    REQUIRE(l->has_text_decoration_color());
+    auto c = l->text_decoration_color();
+    REQUIRE(c.r8() == 0);
+    REQUIRE(c.g8() == 255);
+    REQUIRE(c.b8() == 0);
+    REQUIRE(l->text_decoration_style() == Label::TextDecorationStyle::dashed);
+}
+
+TEST_CASE("CSS textDecorationColor: setting color preserves previously-set line",
+          "[css][shim][textDecoration][issue-1434-batch-3]") {
+    // Per-attribute longhand parity test — same idea as the per-side
+    // border fix from PR #1166 finding #4. Setting color must NOT clobber
+    // line.
+    TestEnvironment env;
+    env.eval(R"JS(
+        var preserve = document.createElement('span');
+        document.body.appendChild(preserve);
+        preserve.style.textDecorationLine = "line-through";
+        preserve.style.textDecorationColor = "#0000ff";
+    )JS");
+    auto* l = dynamic_cast<Label*>(env.widget(native_id(env, "preserve")));
+    REQUIRE(l);
+    REQUIRE(l->text_decoration() == Label::TextDecoration::line_through);
+    REQUIRE(l->has_text_decoration_color());
+}
+
+TEST_CASE("CSS textDecorationStyle: kebab-case via setProperty",
+          "[css][shim][textDecoration][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var k = document.createElement('span');
+        document.body.appendChild(k);
+        k.style.setProperty("text-decoration-style", "wavy");
+    )JS");
+    auto* l = dynamic_cast<Label*>(env.widget(native_id(env, "k")));
+    REQUIRE(l);
+    REQUIRE(l->text_decoration_style() == Label::TextDecorationStyle::wavy);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 3. font-weight keyword translation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("CSS fontWeight: 'normal' keyword maps to 400",
+          "[css][shim][fontWeight][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var fw = document.createElement('span');
+        document.body.appendChild(fw);
+        fw.style.fontWeight = "normal";
+    )JS");
+    auto* l = dynamic_cast<Label*>(env.widget(native_id(env, "fw")));
+    REQUIRE(l);
+    REQUIRE(l->font_weight() == 400);
+}
+
+TEST_CASE("CSS fontWeight: 'bold' keyword maps to 700",
+          "[css][shim][fontWeight][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var fwb = document.createElement('span');
+        document.body.appendChild(fwb);
+        fwb.style.fontWeight = "bold";
+    )JS");
+    auto* l = dynamic_cast<Label*>(env.widget(native_id(env, "fwb")));
+    REQUIRE(l);
+    REQUIRE(l->font_weight() == 700);
+}
+
+TEST_CASE("CSS fontWeight: 'lighter' maps to 300, 'bolder' maps to 700",
+          "[css][shim][fontWeight][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var lighter = document.createElement('span');
+        var bolder = document.createElement('span');
+        document.body.appendChild(lighter);
+        document.body.appendChild(bolder);
+        lighter.style.fontWeight = "lighter";
+        bolder.style.fontWeight = "bolder";
+    )JS");
+    auto* a = dynamic_cast<Label*>(env.widget(native_id(env, "lighter")));
+    auto* b = dynamic_cast<Label*>(env.widget(native_id(env, "bolder")));
+    REQUIRE(a);
+    REQUIRE(b);
+    REQUIRE(a->font_weight() == 300);
+    REQUIRE(b->font_weight() == 700);
+}
+
+TEST_CASE("CSS fontWeight: numeric values still flow through (no regression)",
+          "[css][shim][fontWeight][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var n100 = document.createElement('span');
+        var n500 = document.createElement('span');
+        var n900 = document.createElement('span');
+        document.body.appendChild(n100);
+        document.body.appendChild(n500);
+        document.body.appendChild(n900);
+        n100.style.fontWeight = 100;
+        n500.style.fontWeight = "500";
+        n900.style.fontWeight = 900;
+    )JS");
+    auto fw = [&](const char* name) {
+        auto* l = dynamic_cast<Label*>(env.widget(native_id(env, name)));
+        REQUIRE(l);
+        return l->font_weight();
+    };
+    REQUIRE(fw("n100") == 100);
+    REQUIRE(fw("n500") == 500);
+    REQUIRE(fw("n900") == 900);
+}
+
+TEST_CASE("CSS fontWeight: case-insensitive keyword forms still translate",
+          "[css][shim][fontWeight][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var upr = document.createElement('span');
+        document.body.appendChild(upr);
+        upr.style.fontWeight = "BOLD";
+    )JS");
+    auto* l = dynamic_cast<Label*>(env.widget(native_id(env, "upr")));
+    REQUIRE(l);
+    REQUIRE(l->font_weight() == 700);
+}
+
+TEST_CASE("CSS fontWeight: kebab-case via setProperty works",
+          "[css][shim][fontWeight][issue-1434-batch-3]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        var kbb = document.createElement('span');
+        document.body.appendChild(kbb);
+        kbb.style.setProperty("font-weight", "bold");
+    )JS");
+    auto* l = dynamic_cast<Label*>(env.widget(native_id(env, "kbb")));
+    REQUIRE(l);
+    REQUIRE(l->font_weight() == 700);
+}


### PR DESCRIPTION
## Summary

- Wires three CSS translator entries that were silently dropped by the JS shim despite their bridge support being in place: `style.backdropFilter` (NOT-IMPL → DIVERGE / `partial`), `style.textDecorationLine` / `-Color` / `-Style` (3 × NOT-IMPL → PASS), and `style.fontWeight` keyword forms `normal` / `bold` / `lighter` / `bolder` (DIVERGE → PASS).
- Mirrors the `fontWeight` keyword translation in `@pulp/react`'s prop-applier (`_normalizeFontWeight`) so React-Native style objects produce the same `Label::font_weight()` result as the CSS shim — no design-tool export silently mapping `bold` to `normal`.
- Adds two new bridge registrations (`setTextDecorationColor` / `setTextDecorationStyle`) that route to per-attribute Label setters, mirroring the per-side border fix from PR #1166 finding #4 — assigning one longhand never clobbers a previously-set sibling.

Part of pulp #1434 framework-import-readiness umbrella (batch 3 of 5).

## Harness verifier delta (`tools/harness/verifier.py --surface=css`)

```
BEFORE: pass=25 diverge=83 no_op=9 not_impl=55 oos=23 drift=66
AFTER:  pass=29 diverge=83 no_op=9 not_impl=51 oos=23 drift=64
DELTA:  pass=+4 diverge=+0 not_impl=-4 drift=-2
```

Per-entry reclassification:

| Entry | Before | After |
|---|---|---|
| `css/backdropFilter` | NOT-IMPL (drift) | DIVERGE (matches `partial`, drift resolved) |
| `css/textDecorationLine` | NOT-IMPL | PASS |
| `css/textDecorationColor` | NOT-IMPL | PASS |
| `css/textDecorationStyle` | NOT-IMPL | PASS |
| `css/fontWeight` | DIVERGE (drift) | PASS |

5 entries reclassified. Drift count dropped by 2 without manual catalog status changes — the catalog already claimed `supported` / `partial` for the entries the JS shim was silently dropping, which is exactly the gap this batch closes.

## Files modified

| File | Why |
|---|---|
| `core/view/js/web-compat-style-decl.js` | Added `case "backdropFilter":`, three text-decoration longhand cases, fontWeight keyword translation, and new entries in `__cssProperties__` array |
| `core/view/src/widget_bridge.cpp` | Registered new `setTextDecorationColor` and `setTextDecorationStyle` bridge fns |
| `core/view/include/pulp/view/widgets.hpp` | Added `text_decoration()` / `text_decoration_color()` / `has_text_decoration_color()` getters and `TextDecorationStyle` enum + setter/getter |
| `packages/pulp-react/src/prop-applier.ts` | Added `_normalizeFontWeight` keyword→numeric helper, route fontWeight through it |
| `packages/pulp-react/src/bridge.ts` | Added typography setters to MockBridge fn list so vitest can capture the calls |
| `compat.json` | Updated 5 css surface entries (status, mapsTo, supportedValues, tests, notes, issue) |
| `.agents/skills/engine/SKILL.md` | New section documenting the three CSS-shim gap-fill classes (missing case, coalesced shorthand only, keyword/numeric coercion) and the `__cssProperties__` array gotcha |
| `test/web-compat/test_css_translator_gaps_1434.cpp` | **New** — 18 Catch2 cases covering all three property families end-to-end through the DOM shim |
| `test/web-compat/CMakeLists.txt` | Wired the new test executable with the 16 MB stack used by the rest of the web-compat suite |
| `test/test_widget_bridge.cpp` | 3 new bridge unit tests (color, style, longhand-composition preservation) |
| `packages/pulp-react/test/prop-applier-fontweight.test.ts` | **New** — 9 vitest cases for the React-Native fontWeight keyword translation parity |

## Test plan

- [ ] `cmake --build build --target pulp-test-css-translator-gaps-1434 && ./build/test/web-compat/pulp-test-css-translator-gaps-1434` — 18 cases / 64 assertions pass.
- [ ] `cmake --build build --target pulp-test-widget-bridge && ./build/test/pulp-test-widget-bridge "[issue-1434-batch-3]"` — 3 cases / 18 assertions pass.
- [ ] `cmake --build build --target pulp-test-widget-bridge && ./build/test/pulp-test-widget-bridge` — full bridge suite (115 cases / 817 assertions) passes — no regression.
- [ ] `cd packages/pulp-react && npx vitest run prop-applier-fontweight.test.ts` — 9 new cases pass.
- [ ] `cd packages/pulp-react && npm run build && npx vitest run` — full vitest suite (100 cases) passes.
- [ ] `python3 tools/harness/verifier.py --surface=css --json` — drift_count drops by 2 (66 → 64), pass count rises by 4 (25 → 29).
- [ ] `tools/scripts/local_diff_cover.sh pulp-test-css-translator-gaps-1434 pulp-test-widget-bridge` — diff coverage 100% on the C++ surface (`widgets.hpp` + `widget_bridge.cpp`), comfortably above the 75% gate.
- [ ] `python3 tools/scripts/skill_sync_check.py --mode=report` — `[engine] ✓ SKILL.md updated`.
- [ ] `python3 tools/scripts/version_bump_check.py --mode=report` — `no bump needed` for both sdk and plugin (Version-Bump: skip trailers honored).

## Watch-outs for reviewers

1. **Bridge `setTextDecoration` signature unchanged** — the longhand `textDecorationLine` reuses the existing bridge fn (line keyword surface is identical). Only color and style needed new registrations.
2. **`text_decoration_style` storage without paint enforcement** — by design. The CSS spec allows a renderer to fall back to `solid` for non-solid styles; storing the value lets future paint logic honor it without an API break, and means the JS shim's longhand → setter route doesn't silently no-op on values like `dashed` / `wavy`.
3. **`lighter` / `bolder` are NOT computed relative to inherited weight** — pulp doesn't have a font-inheritance cascade today. Mapping `lighter → 300` and `bolder → 700` is the closest safe fixed default; documented inline in both the JS shim and the React prop-applier.
4. **MockBridge typography surface expansion** — adding `setFontWeight` (and the other typography fns the prop-applier already dispatches) to `createMockBridge`'s fn list was needed for the vitest to capture the calls. Pre-existing tests (`prop-applier-aspect-ratio.test.ts` etc.) only used the bridge fns already in the list.