### PR TITLE
fix(view/css): yoga RN-alias fan-out (closes pulp #1434 batch 4)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -31,10 +31,11 @@
     "_notes_on_consumer_surfaces": "The same prop can have different status across consumer surfaces. 'css/*' tracks what core/view/js/web-compat-style-decl.js (the DOM-lite el.style adapter) routes; 'rn/*' tracks what packages/pulp-react/src/prop-applier.ts (the React renderer for @pulp/react JSX intrinsics) routes; 'yoga/*' tracks the underlying Yoga-shaped layout surface in core/view/include/pulp/view/geometry.hpp::FlexStyle; 'canvas2d/*' tracks the Canvas2D shim in web-compat-canvas.js paired with the canvas* family in widget_bridge.cpp + the Skia/CG backends in core/canvas/; 'html/*' tracks the DOM-lite Element / HTMLElement surface in web-compat-element.js + web-compat-document.js. Where a prop is supported by one consumer but not another, both are noted explicitly in 'notes'.",
     "_changelog": {
       "2026-04-30": "Initial population \u2014 361 entries across css/, rn/, yoga/. react/, html/, canvas2d/ stubbed. PR #1166.",
-      "2026-05-04": "Refresh after PRs #1167, #1169, #1173, #1174, #1291, #1297, #1344, #1345, #1347, #1348, #1353. Populated canvas2d/ (~60 entries) and html/ (~30 entries). Added rn/d, rn/viewBox, rn/fill, rn/stroke, rn/strokeWidth, rn/overlay (SvgPath + overlay-routing). Updated css/border, css/borderRadius, css/borderColor, css/fontFamily status to reflect per-attribute setter routing. Added css/_hover_pseudo for :hover stylesheet support."
+      "2026-05-04": "Refresh after PRs #1167, #1169, #1173, #1174, #1291, #1297, #1344, #1345, #1347, #1348, #1353. Populated canvas2d/ (~60 entries) and html/ (~30 entries). Added rn/d, rn/viewBox, rn/fill, rn/stroke, rn/strokeWidth, rn/overlay (SvgPath + overlay-routing). Updated css/border, css/borderRadius, css/borderColor, css/fontFamily status to reflect per-attribute setter routing. Added css/_hover_pseudo for :hover stylesheet support.",
+      "2026-05-05": "pulp #1434 batch 4: React Native shorthand aliases marginHorizontal / marginVertical / paddingHorizontal / paddingVertical now fan out at the JS-side translators (web-compat-style-decl.js + prop-applier.ts) to the existing per-edge bridge setters. Reclassified rn/* + yoga/* entries from missing -> supported and added new css/* entries (4 new keys; css count 195 -> 199)."
     },
     "counts": {
-      "css": 195,
+      "css": 199,
       "rn": 120,
       "yoga": 53,
       "react": 0,
@@ -1540,6 +1541,22 @@
       "notes": "",
       "issue": ""
     },
+    "css/marginHorizontal": {
+      "status": "supported",
+      "mapsTo": "marginHorizontal -> setFlex(margin_left, px) + setFlex(margin_right, px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "auto"
+      ],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: React Native shorthand alias surfaced through the DOM-lite el.style adapter so RN snippets ported verbatim work in the CSS surface too. Web CSS does not define this property; provided for cross-tool import-readiness.",
+      "issue": ""
+    },
     "css/marginInline": {
       "status": "supported",
       "mapsTo": "expandShorthand -> setFlex(id, 'margin_left'/'margin_right', px)",
@@ -1613,6 +1630,22 @@
       ],
       "tests": [],
       "notes": "",
+      "issue": ""
+    },
+    "css/marginVertical": {
+      "status": "supported",
+      "mapsTo": "marginVertical -> setFlex(margin_top, px) + setFlex(margin_bottom, px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%",
+        "auto"
+      ],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: React Native shorthand alias surfaced through the DOM-lite el.style adapter so RN snippets ported verbatim work in the CSS surface too. Web CSS does not define this property; provided for cross-tool import-readiness.",
       "issue": ""
     },
     "css/mask": {
@@ -1907,6 +1940,21 @@
       "notes": "",
       "issue": ""
     },
+    "css/paddingHorizontal": {
+      "status": "supported",
+      "mapsTo": "paddingHorizontal -> setFlex(padding_left, px) + setFlex(padding_right, px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: React Native shorthand alias surfaced through the DOM-lite el.style adapter so RN snippets ported verbatim work in the CSS surface too. Web CSS does not define this property; provided for cross-tool import-readiness.",
+      "issue": ""
+    },
     "css/paddingInline": {
       "status": "supported",
       "mapsTo": "expandShorthand -> setFlex(id, 'padding_left/right', px)",
@@ -1977,6 +2025,21 @@
       ],
       "tests": [],
       "notes": "",
+      "issue": ""
+    },
+    "css/paddingVertical": {
+      "status": "supported",
+      "mapsTo": "paddingVertical -> setFlex(padding_top, px) + setFlex(padding_bottom, px)",
+      "supportedValues": [
+        "px"
+      ],
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: React Native shorthand alias surfaced through the DOM-lite el.style adapter so RN snippets ported verbatim work in the CSS surface too. Web CSS does not define this property; provided for cross-tool import-readiness.",
       "issue": ""
     },
     "css/pageBreakAfter": {
@@ -3393,14 +3456,16 @@
       "issue": ""
     },
     "rn/marginHorizontal": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: marginHorizontal -> setFlex(margin_left) + setFlex(margin_right)",
+      "supportedValues": [
         "number"
       ],
-      "tests": [],
-      "notes": "RN-specific shorthand for marginLeft + marginRight.",
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: RN shorthand fans out to the per-edge bridge setters at the @pulp/react entry point.",
       "issue": ""
     },
     "rn/marginLeft": {
@@ -3448,14 +3513,16 @@
       "issue": ""
     },
     "rn/marginVertical": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: marginVertical -> setFlex(margin_top) + setFlex(margin_bottom)",
+      "supportedValues": [
         "number"
       ],
-      "tests": [],
-      "notes": "RN-specific shorthand for marginTop + marginBottom.",
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: RN shorthand fans out to the per-edge bridge setters at the @pulp/react entry point.",
       "issue": ""
     },
     "rn/maxHeight": {
@@ -3637,14 +3704,16 @@
       "issue": ""
     },
     "rn/paddingHorizontal": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: paddingHorizontal -> setFlex(padding_left) + setFlex(padding_right)",
+      "supportedValues": [
         "number"
       ],
-      "tests": [],
-      "notes": "Common RN pattern; awkward to port.",
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: RN shorthand fans out to the per-edge bridge setters at the @pulp/react entry point.",
       "issue": ""
     },
     "rn/paddingLeft": {
@@ -3692,14 +3761,16 @@
       "issue": ""
     },
     "rn/paddingVertical": {
-      "status": "missing",
-      "mapsTo": "no branch",
-      "supportedValues": [],
-      "unsupportedValues": [
+      "status": "supported",
+      "mapsTo": "prop-applier.ts: paddingVertical -> setFlex(padding_top) + setFlex(padding_bottom)",
+      "supportedValues": [
         "number"
       ],
-      "tests": [],
-      "notes": "Common RN pattern; awkward to port.",
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: RN shorthand fans out to the per-edge bridge setters at the @pulp/react entry point.",
       "issue": ""
     },
     "rn/pointerEvents": {
@@ -4365,25 +4436,33 @@
       "issue": ""
     },
     "yoga/marginHorizontal": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "translator fan-out -> FlexStyle.margin_left + FlexStyle.margin_right (web-compat-style-decl.js + prop-applier.ts)",
+      "supportedValues": [
+        "px"
       ],
-      "tests": [],
-      "notes": "Yoga shorthand.",
+      "unsupportedValues": [
+        "auto"
+      ],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: RN shorthand. No dedicated FlexStyle field; the JS-side translators (DOM-lite + @pulp/react) decompose to the existing per-edge slots before reaching the bridge. Inherits the per-edge yoga gap on auto (same as yoga/marginLeft).",
       "issue": ""
     },
     "yoga/marginVertical": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "translator fan-out -> FlexStyle.margin_top + FlexStyle.margin_bottom (web-compat-style-decl.js + prop-applier.ts)",
+      "supportedValues": [
+        "px"
       ],
-      "tests": [],
-      "notes": "Yoga shorthand.",
+      "unsupportedValues": [
+        "auto"
+      ],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: RN shorthand. No dedicated FlexStyle field; the JS-side translators (DOM-lite + @pulp/react) decompose to the existing per-edge slots before reaching the bridge. Inherits the per-edge yoga gap on auto (same as yoga/marginTop).",
       "issue": ""
     },
     "yoga/padding": {
@@ -4474,25 +4553,33 @@
       "issue": ""
     },
     "yoga/paddingHorizontal": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "translator fan-out -> FlexStyle.padding_left + FlexStyle.padding_right (web-compat-style-decl.js + prop-applier.ts)",
+      "supportedValues": [
+        "px"
       ],
-      "tests": [],
-      "notes": "",
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: RN shorthand. No dedicated FlexStyle field; the JS-side translators (DOM-lite + @pulp/react) decompose to the existing per-edge slots before reaching the bridge. Inherits the per-edge yoga gap on % (same as yoga/paddingLeft).",
       "issue": ""
     },
     "yoga/paddingVertical": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "translator fan-out -> FlexStyle.padding_top + FlexStyle.padding_bottom (web-compat-style-decl.js + prop-applier.ts)",
+      "supportedValues": [
+        "px"
       ],
-      "tests": [],
-      "notes": "",
+      "unsupportedValues": [
+        "%"
+      ],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-rn-aliases.test.ts"
+      ],
+      "notes": "pulp #1434 batch 4: RN shorthand. No dedicated FlexStyle field; the JS-side translators (DOM-lite + @pulp/react) decompose to the existing per-edge slots before reaching the bridge. Inherits the per-edge yoga gap on % (same as yoga/paddingTop).",
       "issue": ""
     },
     "yoga/borderWidth": {

--- a/core/view/js/web-compat-style-decl.js
+++ b/core/view/js/web-compat-style-decl.js
@@ -245,6 +245,31 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             setFlex(id, "margin_left", ms[3]);
             break;
         }
+        // pulp #1434 batch 4 — React Native shorthand aliases. RN code
+        // commonly writes `style={{ marginHorizontal: 8 }}` which CSS
+        // doesn't recognize, but the DOM-lite el.style adapter sees the
+        // raw key when consumers port RN snippets verbatim. Fan out to
+        // the same per-edge bridge calls the CSS marginInline / margin
+        // shorthand uses so the behavior is identical regardless of the
+        // entry surface. `auto` is a no-op for now (parseCSSLength returns
+        // null for non-numeric input); numeric and percent paths route
+        // through the same setFlex per-edge dispatch as marginLeft etc.
+        case "marginHorizontal": {
+            var mhv = parseCSSLength(resolved);
+            if (mhv) {
+                setFlex(id, "margin_left", mhv.value);
+                setFlex(id, "margin_right", mhv.value);
+            }
+            break;
+        }
+        case "marginVertical": {
+            var mvv = parseCSSLength(resolved);
+            if (mvv) {
+                setFlex(id, "margin_top", mvv.value);
+                setFlex(id, "margin_bottom", mvv.value);
+            }
+            break;
+        }
 
         // Padding (individual)
         case "paddingTop": {
@@ -274,6 +299,26 @@ CSSStyleDeclaration.prototype._applyProperty = function(key, value) {
             setFlex(id, "padding_right", ps[1]);
             setFlex(id, "padding_bottom", ps[2]);
             setFlex(id, "padding_left", ps[3]);
+            break;
+        }
+        // pulp #1434 batch 4 — React Native shorthand aliases for padding.
+        // Same fan-out pattern as marginHorizontal / marginVertical above
+        // — paddingHorizontal sets padding_left + padding_right to the
+        // same value, paddingVertical sets padding_top + padding_bottom.
+        case "paddingHorizontal": {
+            var phv = parseCSSLength(resolved);
+            if (phv) {
+                setFlex(id, "padding_left", phv.value);
+                setFlex(id, "padding_right", phv.value);
+            }
+            break;
+        }
+        case "paddingVertical": {
+            var pvv = parseCSSLength(resolved);
+            if (pvv) {
+                setFlex(id, "padding_top", pvv.value);
+                setFlex(id, "padding_bottom", pvv.value);
+            }
             break;
         }
 
@@ -877,8 +922,11 @@ var __cssProperties__ = [
     "aspectRatio", "boxSizing",
     "margin", "marginTop", "marginRight", "marginBottom", "marginLeft",
     "marginInline", "marginBlock",
+    // pulp #1434 batch 4 — React Native shorthand aliases.
+    "marginHorizontal", "marginVertical",
     "padding", "paddingTop", "paddingRight", "paddingBottom", "paddingLeft",
     "paddingInline", "paddingBlock",
+    "paddingHorizontal", "paddingVertical",
     "backgroundColor", "color",
     "fontSize", "fontWeight", "fontStyle", "fontFamily", "letterSpacing", "lineHeight",
     "textAlign", "textTransform", "textDecoration", "textOverflow", "textShadow",

--- a/docs/reference/compat/css.md
+++ b/docs/reference/compat/css.md
@@ -33,6 +33,14 @@ specifics are out of scope.
 
 ## Recently changed
 
+- **2026-05-05 (pulp #1434 batch 4)** — added `css/marginHorizontal`,
+  `css/marginVertical`, `css/paddingHorizontal`, `css/paddingVertical`
+  RN-shorthand entries. The DOM-lite el.style adapter now recognizes
+  these aliases and fans them out to the matching pair of per-edge
+  `setFlex` calls (`margin_left + margin_right`, etc.). Web CSS does
+  not define these properties; they ship for cross-tool import-readiness
+  so RN snippets pasted into a DOM-lite plugin work as written. css
+  total entry count 195 → 199; progress 55.38% → 56.28%.
 - `css/border` / `css/borderRadius` / `css/borderColor`: flipped from
   `partial` (clobbered each other) to `supported`. PR #1169 routed each
   through its dedicated per-attribute setter so unset siblings are

--- a/docs/reference/compat/rn.md
+++ b/docs/reference/compat/rn.md
@@ -27,6 +27,13 @@ Spec walk:
 
 ## Recently changed
 
+- **2026-05-05 (pulp #1434 batch 4)** — RN shorthand aliases
+  `rn/marginHorizontal`, `rn/marginVertical`, `rn/paddingHorizontal`,
+  `rn/paddingVertical` are now surfaced at the `@pulp/react` JSX
+  intrinsic. The prop-applier fans out each alias to the matching pair
+  of per-edge `setFlex(margin_*|padding_*, value)` calls. Reclassified
+  missing → supported (PASS on the harness rn surface). Lets RN
+  snippets that write `style={{ marginHorizontal: 8 }}` port verbatim.
 - New `rn/d`, `rn/viewBox`, `rn/fill`, `rn/stroke`, `rn/strokeWidth`
   entries. Wired by the `@pulp/react` `<SvgPath>` JSX intrinsic in
   PR #1291 (pulp #994). Bridge surface lands on `SvgPathWidget`.
@@ -44,17 +51,15 @@ Spec walk:
 2. `rn/flex` shorthand — RN's `style={{flex: 1}}` is the most common
    pattern in tutorials. `@pulp/react` users must type
    `flexGrow={1} flexShrink={1} flexBasis={0}`.
-3. `rn/marginHorizontal`, `rn/marginVertical`, `rn/paddingHorizontal`,
-   `rn/paddingVertical` — RN-specific shorthands not surfaced.
-4. `rn/marginStart` / `rn/marginEnd`, `rn/paddingStart` / `rn/paddingEnd`
+3. `rn/marginStart` / `rn/marginEnd`, `rn/paddingStart` / `rn/paddingEnd`
    — direction-aware logical props not wired (Yoga RTL is also
    unsupported).
-5. `rn/shadowColor` / `rn/shadowOffset` / `rn/shadowOpacity` /
+4. `rn/shadowColor` / `rn/shadowOffset` / `rn/shadowOpacity` /
    `rn/shadowRadius` — iOS shadow surface; routed via
    `boxShadow` instead.
-6. `rn/elevation` — Android-only; not modeled.
-7. `rn/borderCurve` — iOS 13+ continuous-corners; not modeled.
-8. `rn/mixBlendMode`, `rn/isolation` — not yet wired (Skia / CG can
+5. `rn/elevation` — Android-only; not modeled.
+6. `rn/borderCurve` — iOS 13+ continuous-corners; not modeled.
+7. `rn/mixBlendMode`, `rn/isolation` — not yet wired (Skia / CG can
    support; bridge plumbing absent).
 
 ## SvgPath (#994 / #1291)

--- a/docs/reference/compat/yoga.md
+++ b/docs/reference/compat/yoga.md
@@ -40,6 +40,18 @@ which mirrors the upstream Yoga API.
 
 ## Recent updates
 
+- **2026-05-05 (pulp #1434 batch 4)** — React Native shorthand aliases
+  `yoga/marginHorizontal`, `yoga/marginVertical`, `yoga/paddingHorizontal`,
+  `yoga/paddingVertical` now fan out to the existing per-edge FlexStyle
+  fields (`margin_left + margin_right`, `margin_top + margin_bottom`,
+  `padding_left + padding_right`, `padding_top + padding_bottom`). No
+  new FlexStyle fields — both JS-side translators
+  (`web-compat-style-decl.js` for the DOM-lite el.style adapter and
+  `prop-applier.ts` for the @pulp/react JSX intrinsic) decompose the
+  shorthand before reaching the bridge. Reclassified NOT-IMPL → DIVERGE
+  (parity with `yoga/marginLeft` etc — `auto` remains unsupported on
+  margin, `%` remains unsupported on padding). progress_pct 69.81% →
+  77.36%.
 - **2026-05-05 (pulp #1423)** — `yoga/width` and `yoga/height` now
   accept percentage values (`'100%'`, `'50%'`). The CSS translator
   passes `'NN%'` strings verbatim to the bridge; `FlexStyle.dim_width`

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -218,6 +218,30 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         case 'marginRight':     return call('setFlex', id, 'margin_right', value as number);
         case 'marginBottom':    return call('setFlex', id, 'margin_bottom', value as number);
         case 'marginLeft':      return call('setFlex', id, 'margin_left', value as number);
+        // pulp #1434 batch 4 — React Native shorthand aliases. RN code
+        // commonly writes `style={{ marginHorizontal: 8 }}` and expects
+        // it to fan out to marginLeft + marginRight on the underlying
+        // layout. Same pattern for marginVertical / paddingHorizontal /
+        // paddingVertical. We dispatch to the existing per-edge bridge
+        // setters so the value reaches the same FlexStyle slot whether
+        // it arrived through this alias or through the explicit edge
+        // prop. No FlexStyle field change required.
+        case 'marginHorizontal':
+            call('setFlex', id, 'margin_left', value as number);
+            call('setFlex', id, 'margin_right', value as number);
+            return;
+        case 'marginVertical':
+            call('setFlex', id, 'margin_top', value as number);
+            call('setFlex', id, 'margin_bottom', value as number);
+            return;
+        case 'paddingHorizontal':
+            call('setFlex', id, 'padding_left', value as number);
+            call('setFlex', id, 'padding_right', value as number);
+            return;
+        case 'paddingVertical':
+            call('setFlex', id, 'padding_top', value as number);
+            call('setFlex', id, 'padding_bottom', value as number);
+            return;
         case 'flexGrow':        return call('setFlex', id, 'flex_grow', value as number);
         case 'flexShrink':      return call('setFlex', id, 'flex_shrink', value as number);
         case 'flexBasis':       return call('setFlex', id, 'flex_basis', value as number);

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -26,11 +26,24 @@ export interface FlexProps {
     paddingRight?: number;
     paddingBottom?: number;
     paddingLeft?: number;
+    /// pulp #1434 batch 4 — `paddingHorizontal` fans out to `paddingLeft` +
+    /// `paddingRight`.
+    paddingHorizontal?: number;
+    /// pulp #1434 batch 4 — `paddingVertical` fans out to `paddingTop` +
+    /// `paddingBottom`.
+    paddingVertical?: number;
     margin?: number;
     marginTop?: number;
     marginRight?: number;
     marginBottom?: number;
     marginLeft?: number;
+    /// pulp #1434 batch 4 — React Native shorthand alias. `marginHorizontal`
+    /// fans out to `marginLeft` + `marginRight` in the prop-applier; same
+    /// value applied to both edges. Useful for porting RN code as-is.
+    marginHorizontal?: number;
+    /// pulp #1434 batch 4 — `marginVertical` fans out to `marginTop` +
+    /// `marginBottom`.
+    marginVertical?: number;
     flexGrow?: number;
     flexShrink?: number;
     flexBasis?: number;

--- a/packages/pulp-react/test/prop-applier-rn-aliases.test.ts
+++ b/packages/pulp-react/test/prop-applier-rn-aliases.test.ts
@@ -1,0 +1,165 @@
+// pulp #1434 batch 4 — verify the @pulp/react prop-applier fans out
+// React Native shorthand aliases (marginHorizontal, marginVertical,
+// paddingHorizontal, paddingVertical) to the per-edge bridge setters.
+//
+// Pulp's value is broad import-readiness from {Figma, Pencil.dev, v0,
+// Claude Design HTML, RN, generic HTML/CSS/React}. RN code commonly
+// writes `style={{ marginHorizontal: 8 }}` and expects the framework to
+// decompose the shorthand to marginLeft + marginRight on the underlying
+// layout. Without a fan-out path the alias was silently dropped at the
+// JSX entry point, so RN snippets ported verbatim lost their padding /
+// margin information. The fan-out lands at two layers:
+//
+//   - core/view/js/web-compat-style-decl.js — DOM-lite el.style adapter
+//     (covered by harness coverage on the css/* surface).
+//   - packages/pulp-react/src/prop-applier.ts — @pulp/react JSX
+//     intrinsic (covered by *this* test file plus the harness rn/*
+//     surface adapter).
+//
+// Each test asserts that ONE alias triggers exactly TWO setFlex calls
+// targeting the matching per-edge slots with the supplied value.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyChangedProps } from '../src/prop-applier.js';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import type { PulpInstance } from '../src/types.js';
+
+let bridge: MockBridge;
+
+beforeEach(() => {
+    bridge = createMockBridge();
+    bridge.install();
+});
+afterEach(() => {
+    bridge.uninstall();
+});
+
+function makeInstance(id: string = 'k', type: string = 'View'): PulpInstance {
+    return {
+        id,
+        type: type as PulpInstance['type'],
+        props: {},
+        childIds: [],
+        onBridge: true,
+        pendingChildren: [],
+    };
+}
+
+function flexCalls(b: MockBridge, slot: string) {
+    return b.calls.filter((c) => c.fn === 'setFlex' && c.args[1] === slot);
+}
+
+describe('prop-applier RN shorthand aliases (pulp #1434 batch 4)', () => {
+    it('marginHorizontal fans out to margin_left + margin_right', () => {
+        applyChangedProps(makeInstance(), {}, { marginHorizontal: 8 });
+
+        const left = flexCalls(bridge, 'margin_left');
+        const right = flexCalls(bridge, 'margin_right');
+        expect(left).toHaveLength(1);
+        expect(right).toHaveLength(1);
+        expect(left[0].args).toEqual(['k', 'margin_left', 8]);
+        expect(right[0].args).toEqual(['k', 'margin_right', 8]);
+
+        // Sanity — no stray top/bottom emission from this alias.
+        expect(flexCalls(bridge, 'margin_top')).toHaveLength(0);
+        expect(flexCalls(bridge, 'margin_bottom')).toHaveLength(0);
+    });
+
+    it('marginVertical fans out to margin_top + margin_bottom', () => {
+        applyChangedProps(makeInstance(), {}, { marginVertical: 12 });
+
+        const top = flexCalls(bridge, 'margin_top');
+        const bot = flexCalls(bridge, 'margin_bottom');
+        expect(top).toHaveLength(1);
+        expect(bot).toHaveLength(1);
+        expect(top[0].args).toEqual(['k', 'margin_top', 12]);
+        expect(bot[0].args).toEqual(['k', 'margin_bottom', 12]);
+
+        expect(flexCalls(bridge, 'margin_left')).toHaveLength(0);
+        expect(flexCalls(bridge, 'margin_right')).toHaveLength(0);
+    });
+
+    it('paddingHorizontal fans out to padding_left + padding_right', () => {
+        applyChangedProps(makeInstance(), {}, { paddingHorizontal: 16 });
+
+        const left = flexCalls(bridge, 'padding_left');
+        const right = flexCalls(bridge, 'padding_right');
+        expect(left).toHaveLength(1);
+        expect(right).toHaveLength(1);
+        expect(left[0].args).toEqual(['k', 'padding_left', 16]);
+        expect(right[0].args).toEqual(['k', 'padding_right', 16]);
+
+        expect(flexCalls(bridge, 'padding_top')).toHaveLength(0);
+        expect(flexCalls(bridge, 'padding_bottom')).toHaveLength(0);
+    });
+
+    it('paddingVertical fans out to padding_top + padding_bottom', () => {
+        applyChangedProps(makeInstance(), {}, { paddingVertical: 4 });
+
+        const top = flexCalls(bridge, 'padding_top');
+        const bot = flexCalls(bridge, 'padding_bottom');
+        expect(top).toHaveLength(1);
+        expect(bot).toHaveLength(1);
+        expect(top[0].args).toEqual(['k', 'padding_top', 4]);
+        expect(bot[0].args).toEqual(['k', 'padding_bottom', 4]);
+
+        expect(flexCalls(bridge, 'padding_left')).toHaveLength(0);
+        expect(flexCalls(bridge, 'padding_right')).toHaveLength(0);
+    });
+
+    it('zero is a real value (not a no-op) and fans out unchanged', () => {
+        // RN zero is meaningful — explicit "no margin/padding" override
+        // when a parent style was setting it. The fan-out must not gate
+        // on truthiness.
+        applyChangedProps(makeInstance(), {}, { marginHorizontal: 0 });
+        const left = flexCalls(bridge, 'margin_left');
+        const right = flexCalls(bridge, 'margin_right');
+        expect(left[0]?.args[2]).toBe(0);
+        expect(right[0]?.args[2]).toBe(0);
+    });
+
+    it('combining horizontal + vertical aliases hits all four edges', () => {
+        applyChangedProps(makeInstance(), {}, {
+            marginHorizontal: 8,
+            marginVertical: 12,
+            paddingHorizontal: 16,
+            paddingVertical: 4,
+        });
+
+        // 4 aliases × 2 edges = 8 setFlex calls.
+        const allFlex = bridge.calls.filter((c) => c.fn === 'setFlex');
+        expect(allFlex).toHaveLength(8);
+
+        expect(flexCalls(bridge, 'margin_left')[0]?.args[2]).toBe(8);
+        expect(flexCalls(bridge, 'margin_right')[0]?.args[2]).toBe(8);
+        expect(flexCalls(bridge, 'margin_top')[0]?.args[2]).toBe(12);
+        expect(flexCalls(bridge, 'margin_bottom')[0]?.args[2]).toBe(12);
+        expect(flexCalls(bridge, 'padding_left')[0]?.args[2]).toBe(16);
+        expect(flexCalls(bridge, 'padding_right')[0]?.args[2]).toBe(16);
+        expect(flexCalls(bridge, 'padding_top')[0]?.args[2]).toBe(4);
+        expect(flexCalls(bridge, 'padding_bottom')[0]?.args[2]).toBe(4);
+    });
+
+    it('explicit per-edge prop set alongside an alias reaches both edges', () => {
+        // The prop-applier processes prop-keys in iteration order.
+        // marginHorizontal sets BOTH edges to its value; a subsequent
+        // marginRight in the same props bag overrides only the right
+        // edge. This mirrors RN behavior where per-edge wins.
+        applyChangedProps(makeInstance(), {}, {
+            marginHorizontal: 8,
+            marginRight: 24,
+        });
+        // margin_left set once (from alias) at 8; margin_right set
+        // twice — once at 8 from the alias, once at 24 from the
+        // explicit prop. The bridge uses the latest value, and the
+        // prop-applier emits both calls.
+        const right = flexCalls(bridge, 'margin_right');
+        expect(right.length).toBeGreaterThanOrEqual(1);
+        // The last setFlex call for margin_right wins on the bridge
+        // side, so assert the most recent value reflects the explicit
+        // override.
+        expect(right[right.length - 1].args[2]).toBe(24);
+        const left = flexCalls(bridge, 'margin_left');
+        expect(left[0].args[2]).toBe(8);
+    });
+});


### PR DESCRIPTION
## Summary

- Fan out React Native shorthand aliases `marginHorizontal` / `marginVertical` / `paddingHorizontal` / `paddingVertical` to the existing per-edge `setFlex` setters in two layers — `core/view/js/web-compat-style-decl.js` (DOM-lite el.style adapter) and `packages/pulp-react/src/prop-applier.ts` (@pulp/react JSX intrinsic).
- No FlexStyle field change; existing per-edge yoga setters consume the fanned values. RN code that writes `style={{ marginHorizontal: 8 }}` now ports verbatim into both surfaces.
- `compat.json` reclassifies the 4 keys × 3 surfaces (`css/`, `rn/`, `yoga/`) from drift / NOT-IMPL to supported (PASS on rn; DIVERGE on yoga + css to match the parity of `yoga/marginLeft` / `css/marginLeft` which lose `auto` on margin and `%` on padding). Adds 4 new `css/*` entries (CSS surface didn't track these RN aliases before).

## Files changed (5)

| File | Purpose |
|---|---|
| `core/view/js/web-compat-style-decl.js` | Add 4 fan-out switch cases + register the alias names in the known-keys list. |
| `packages/pulp-react/src/prop-applier.ts` | Add 4 fan-out cases in the JSX prop dispatch switch. |
| `packages/pulp-react/src/types.ts` | Surface the 4 new aliases on `FlexProps` so TS consumers get type-checking. |
| `compat.json` | Reclassify `rn/*`, `yoga/*` entries; add 4 new `css/*` entries; bump `_audit.counts.css` 195 → 199; append changelog entry. |
| `packages/pulp-react/test/prop-applier-rn-aliases.test.ts` | New vitest suite with 7 cases — 1 per alias plus zero-value, combined four-axis, and explicit-edge override. |
| `docs/reference/compat/{yoga,rn,css}.md` | Describe the fan-out and remove the stale "RN-specific shorthands not surfaced" gap entry from rn.md. |

## Test plan

- [x] `npm test` in `packages/pulp-react/` — 11 test files, **98 / 98 tests pass** (including the new 7-case `prop-applier-rn-aliases.test.ts`).
- [x] `npm run build` builds `dist/index.mjs` clean (38.2 KB; no React inlined).
- [x] `python3 tools/harness/verifier.py --all --no-docs --json` shows the expected coverage delta:
    - **yoga**: NOT_IMPL 16 → 12 (-4), DIVERGE 27 → 31 (+4), `progress_pct` 69.81% → **77.36%**.
    - **rn**: NOT_IMPL 55 → 51 (-4), PASS 27 → 31 (+4), `progress_pct` 44.17% → **47.50%**.
    - **css**: total 195 → 199 (+4 new entries, all wired DIVERGE — matching the parity of `css/marginLeft` etc), `progress_pct` 55.38% → **56.28%**.
- [x] All 4 `rn/*` aliases land on **PASS** since the rn adapter accepts non-enum kinds with no meaningful unsupported values; the `yoga/*` and `css/*` siblings inherit the `auto` / `%` gaps the per-edge entries already advertise.
- [x] Pre-push compat-sync, skill-sync, and version-bump gates all green (skill-sync gates with explicit `Skill-Update: skip skill=engine` trailer — translator fan-out, no JS-engine backend change).

## Constraints honored

- No mocks: tests exercise the real `prop-applier.ts` switch via the existing `createMockBridge` recording surface (already used by the sibling `prop-applier-aspect-ratio.test.ts`, `prop-applier-border.test.ts`, etc.).
- No C++ bridge change — RN aliases never reach `widget_bridge.cpp`; both JS-side translators decompose them to per-edge `setFlex` calls before the bridge boundary.
- `Version-Bump: sdk=skip` and `plugin=skip` trailers on the implementation commit (catalog + JS-side translator only; no SDK ABI change).

## Ties

- Umbrella: pulp #1434 batch 4.
- Batch 5 (`aspectRatio` flex routing) and batch 1 (`marginInlineStart` partial reclass) already landed; batch 3 (CSS-translator gap fills) and batch 7 (canvas2d shadows) are running in parallel sub-agents.