### PR TITLE
feat(cli): flip default Pulp CLI to Rust

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -366,8 +366,8 @@ the explicit close, NOT to add it.
 Build and validate via the Pulp CLI:
 
 ```bash
-./build/tools/cli/pulp build
-./build/tools/cli/pulp validate         # runs auval via the auval-<name> CTest target
+./build/pulp build
+./build/pulp validate         # runs auval via the auval-<name> CTest target
 ```
 
 Manual `auval` (macOS only — `auval` is an Apple tool):

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -76,6 +76,13 @@ signed/notarized `.dmg`, so the version and asset metadata must move together.
   `make_webview_embedded_resource_fetcher`. If you touch the release
   workflow or `tools/scripts/release-cli-local.sh`, preserve that
   contract or WebView-using downstream SDK consumers will link-fail.
+- **Phase 8 CLI flip ships two CLI binaries.** Release CLI jobs must
+  preserve Rust `pulp` as the user-facing binary and C++ `pulp-cpp`
+  as the fallthrough delegate in the same archive. Smoke both names:
+  `pulp version --json` for the Rust path, and at least one C++-owned
+  command through `PULP_RS_CPP_BINARY=/path/to/pulp-cpp pulp ...` or a
+  direct `pulp-cpp ...` invocation. Do not resurrect `pulp-rs` as the
+  shipped binary name.
 - **macOS binary is signed + notarized** (Shipyard v0.29.0). On
   macOS 26.3+ XProtect skips the deep scan for notarized binaries,
   cutting `shipyard pr` cold-start ~4-5x (from ~5-6s to ~1-1.5s).

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -364,8 +364,8 @@ Build and smoke a CLAP bundle with the Pulp CLI:
 
 ```bash
 # Build everything, then validate
-./build/tools/cli/pulp build
-./build/tools/cli/pulp validate          # runs clap-validator if installed
+./build/pulp build
+./build/pulp validate          # runs clap-validator if installed
 ```
 
 Direct `clap-validator` usage (matches what `cmd_validate.cpp` invokes):

--- a/.agents/skills/mpe/SKILL.md
+++ b/.agents/skills/mpe/SKILL.md
@@ -35,7 +35,7 @@ If you only need monophonic aftertouch or a global mod wheel, plain
 ### 1. Scaffold with `--mpe`
 
 ```bash
-./build/tools/cli/pulp create MySynth --type instrument --mpe
+./build/pulp create MySynth --type instrument --mpe
 ```
 
 The CLI post-processes the generated descriptor to add

--- a/.agents/skills/packages/SKILL.md
+++ b/.agents/skills/packages/SKILL.md
@@ -24,8 +24,8 @@ Help users discover, evaluate, and add third-party audio libraries to their Pulp
 Search the registry for packages matching a need:
 
 ```bash
-./build/tools/cli/pulp search "<query>"
-./build/tools/cli/pulp suggest --description "<what the user needs>"
+./build/pulp search "<query>"
+./build/pulp suggest --description "<what the user needs>"
 ```
 
 Or read the registry directly for full details:
@@ -46,7 +46,7 @@ cat tools/packages/registry.json | python3 -m json.tool
 ## Adding a Package
 
 ```bash
-./build/tools/cli/pulp add <package-id>
+./build/pulp add <package-id>
 ```
 
 This will:

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -213,6 +213,21 @@ artifact on a *clean* runner that did not build it, catching the bug
 class before tagging. If you change rpath logic, run the smoke job
 locally first or it will fail in CI for everyone else.
 
+### Phase 8 CLI release artifacts are dual-binary
+
+After the Rust CLI flip, release artifacts must contain both `pulp`
+and `pulp-cpp` in the same archive. `pulp` is the user-facing Rust CLI;
+`pulp-cpp` is the C++ delegate used for fallthrough commands that still
+link framework libraries. Do not ship `pulp-rs` as the public binary
+name, and do not drop `pulp-cpp` from tarballs or zips.
+
+Smoke both paths when touching `.github/workflows/release-cli.yml` or
+`tools/scripts/package_cli.py`: run `pulp version --json` against the
+Rust binary, then exercise a C++-owned command through
+`PULP_RS_CPP_BINARY=/path/to/pulp-cpp pulp ...` or invoke `pulp-cpp`
+directly. This preserves rollback/debug workflows such as
+`PULP_USE_CPP=1 pulp <args>` for existing Pulp projects.
+
 ### Released SDK is missing WebView symbols
 
 Symptom: a consumer links against a downloaded `pulp-sdk-<platform>`

--- a/.agents/skills/upgrade/SKILL.md
+++ b/.agents/skills/upgrade/SKILL.md
@@ -48,7 +48,14 @@ directly and one of which it may hand off to `pulp project bump`:
 | Shipyard pin | `tools/install-shipyard.sh` | Dependency Update Workflow (out of scope) |
 
 `pulp upgrade` downloads the new CLI binary and replaces the installed
-one. `pulp upgrade --notes` prints migration notes for the hop without
+one. After the Phase 8 Rust cutover, release archives are dual-binary:
+Rust `pulp` is the user-facing CLI and sibling `pulp-cpp` is installed
+as the C++ fallthrough delegate. A healthy install has both
+`~/.pulp/bin/pulp` and `~/.pulp/bin/pulp-cpp`; use `PULP_USE_CPP=1
+pulp <args>` or direct `pulp-cpp <args>` only for rollback/debug
+comparisons. Do not hand-swap binaries in user/system locations.
+
+`pulp upgrade --notes` prints migration notes for the hop without
 downloading anything. `pulp upgrade --notes --json` emits the same data
 as a stable-shape JSON document for agent consumption (the `/upgrade`
 slash command is the primary consumer).

--- a/.agents/skills/vst3/SKILL.md
+++ b/.agents/skills/vst3/SKILL.md
@@ -289,8 +289,8 @@ shift.
 Build and validate a VST3 bundle:
 
 ```bash
-./build/tools/cli/pulp build
-./build/tools/cli/pulp validate         # runs pluginval --strictness-level 5
+./build/pulp build
+./build/pulp validate         # runs pluginval --strictness-level 5
 ```
 
 Direct `pluginval` invocation (matches what `cmd_validate.cpp` uses):

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -102,9 +102,16 @@ jobs:
         run: cmake --build build --config Release
         shell: bash
 
-      - name: Strip binary (Unix)
+      # Phase 8: post-swap there are TWO CLI binaries shipping side by
+       # side — `pulp` (Rust, the user-facing default) at the top of
+       # the build dir, and `pulp-cpp` (C++, the fallthrough delegate
+       # for library-linked subcommands like ship/validate/host) under
+       # `tools/cli/`. The release tarball must include both.
+      - name: Strip binaries (Unix)
         if: runner.os != 'Windows'
-        run: strip build/tools/cli/pulp
+        run: |
+          strip build/pulp
+          strip build/tools/cli/pulp-cpp
 
       - name: Install Linux rpath helper
         if: runner.os == 'Linux'
@@ -116,11 +123,17 @@ jobs:
       # at /Users/runner/Library/Caches/Pulp/... and crashed on every
       # user machine). The smoke-cli matrix gate (PR #395) verifies
       # the result actually runs on a clean runner.
+      #
+      # `package_cli.py --cpp-binary` (added on validate/phase8-integrated)
+      # bundles `pulp-cpp` alongside `pulp` in the same tarball so the
+      # Rust binary's fallthrough paths can find their delegate after
+      # the user extracts and runs.
       - name: Package CLI (Unix)
         if: runner.os != 'Windows'
         run: |
           python3 tools/scripts/package_cli.py \
-            --binary build/tools/cli/pulp \
+            --binary build/pulp \
+            --cpp-binary build/tools/cli/pulp-cpp \
             --build-dir build \
             --platform ${{ matrix.platform }} \
             --out pulp-${{ matrix.platform }}.tar.gz
@@ -130,7 +143,8 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           python tools/scripts/package_cli.py `
-            --binary build/tools/cli/Release/pulp.exe `
+            --binary build/pulp.exe `
+            --cpp-binary build/tools/cli/Release/pulp-cpp.exe `
             --build-dir build `
             --platform ${{ matrix.platform }} `
             --out pulp-${{ matrix.platform }}.zip
@@ -285,75 +299,84 @@ jobs:
       # so we can grep stderr for the diagnostic patterns even when
       # pulp itself exits 0 (defense-in-depth — some runtime loaders
       # warn but don't fail).
-      - name: Smoke `pulp help` (Unix)
+      - name: Smoke `pulp help` + `pulp-cpp help` (Unix)
         if: runner.os != 'Windows'
         shell: bash
         run: |
           set -euo pipefail
-          BIN=/tmp/pulp-smoke/${{ matrix.artifact }}
-          echo "Testing $BIN"
-          file "$BIN" || true
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            echo "--- otool -L (load commands) ---"
-            otool -L "$BIN" || true
-            echo "--- otool -l rpaths ---"
-            otool -l "$BIN" | awk '/LC_RPATH/{flag=1} flag{print; if (/path /) {flag=0}}' | head -20 || true
-          else
-            echo "--- ldd ---"
-            ldd "$BIN" || true
-          fi
-          echo "--- pulp help ---"
-          set +e
-          "$BIN" help > /tmp/pulp-smoke.out 2> /tmp/pulp-smoke.err
-          rc=$?
-          set -e
-          echo "exit=$rc"
-          echo "--- stdout ---"; cat /tmp/pulp-smoke.out || true
-          echo "--- stderr ---"; cat /tmp/pulp-smoke.err || true
-          if [ "$rc" -ne 0 ]; then
-            echo "FAIL: pulp help returned exit $rc"
-            exit 1
-          fi
-          # Belt + suspenders: dyld/ld.so warnings shouldn't appear even on rc=0.
-          if grep -qE "Library not loaded|Symbol not found|cannot open shared object|undefined symbol|@rpath/" /tmp/pulp-smoke.err; then
-            echo "FAIL: dyld/ld.so error in stderr (artifact is non-portable)"
-            exit 1
-          fi
-          # Same check for stdout (some loaders write there).
-          if grep -qE "Library not loaded|Symbol not found|cannot open shared object" /tmp/pulp-smoke.out; then
-            echo "FAIL: loader error in stdout"
-            exit 1
-          fi
-          echo "OK: pulp help is portable on ${{ matrix.platform }}."
+          # Phase 8: tarball ships both `pulp` (Rust) and `pulp-cpp`
+          # (C++) side by side. Smoke both — a broken pulp-cpp delegate
+          # would silently break every fallthrough subcommand the
+          # moment users invoke `pulp ship`, `pulp validate`, etc.
+          for ART in pulp pulp-cpp; do
+            BIN=/tmp/pulp-smoke/$ART
+            echo "===== Testing $BIN ====="
+            file "$BIN" || true
+            if [ "$RUNNER_OS" = "macOS" ]; then
+              echo "--- otool -L (load commands) ---"
+              otool -L "$BIN" || true
+              echo "--- otool -l rpaths ---"
+              otool -l "$BIN" | awk '/LC_RPATH/{flag=1} flag{print; if (/path /) {flag=0}}' | head -20 || true
+            else
+              echo "--- ldd ---"
+              ldd "$BIN" || true
+            fi
+            echo "--- $ART help ---"
+            set +e
+            "$BIN" help > /tmp/$ART-smoke.out 2> /tmp/$ART-smoke.err
+            rc=$?
+            set -e
+            echo "exit=$rc"
+            echo "--- stdout ---"; cat /tmp/$ART-smoke.out || true
+            echo "--- stderr ---"; cat /tmp/$ART-smoke.err || true
+            if [ "$rc" -ne 0 ]; then
+              echo "FAIL: $ART help returned exit $rc"
+              exit 1
+            fi
+            # Belt + suspenders: dyld/ld.so warnings shouldn't appear even on rc=0.
+            if grep -qE "Library not loaded|Symbol not found|cannot open shared object|undefined symbol|@rpath/" /tmp/$ART-smoke.err; then
+              echo "FAIL: dyld/ld.so error in stderr (artifact is non-portable)"
+              exit 1
+            fi
+            # Same check for stdout (some loaders write there).
+            if grep -qE "Library not loaded|Symbol not found|cannot open shared object" /tmp/$ART-smoke.out; then
+              echo "FAIL: loader error in stdout"
+              exit 1
+            fi
+            echo "OK: $ART help is portable on ${{ matrix.platform }}."
+          done
 
-      - name: Smoke `pulp help` (Windows)
+      - name: Smoke `pulp help` + `pulp-cpp help` (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $bin = Join-Path $env:TEMP "pulp-smoke\${{ matrix.artifact }}"
-          Write-Host "Testing $bin"
-          # Print imported DLLs for diagnostic context (no failure if dumpbin missing).
-          try { dumpbin /dependents $bin 2>$null } catch { Write-Host "(dumpbin unavailable; skipping)" }
-          $stdout = New-TemporaryFile
-          $stderr = New-TemporaryFile
-          $proc = Start-Process -FilePath $bin -ArgumentList "help" `
-              -RedirectStandardOutput $stdout -RedirectStandardError $stderr -PassThru -Wait -NoNewWindow
-          Write-Host "exit=$($proc.ExitCode)"
-          Write-Host "--- stdout ---"
-          Get-Content $stdout -ErrorAction SilentlyContinue
-          Write-Host "--- stderr ---"
-          $err = Get-Content $stderr -ErrorAction SilentlyContinue
-          $err
-          if ($proc.ExitCode -ne 0) {
-              Write-Error "FAIL: pulp.exe help returned exit $($proc.ExitCode)"
-              exit 1
+          # Phase 8: tarball ships both `pulp.exe` (Rust) and
+          # `pulp-cpp.exe` (C++) side by side. Smoke both.
+          foreach ($art in @("pulp.exe", "pulp-cpp.exe")) {
+              $bin = Join-Path $env:TEMP "pulp-smoke\$art"
+              Write-Host "===== Testing $bin ====="
+              try { dumpbin /dependents $bin 2>$null } catch { Write-Host "(dumpbin unavailable; skipping)" }
+              $stdout = New-TemporaryFile
+              $stderr = New-TemporaryFile
+              $proc = Start-Process -FilePath $bin -ArgumentList "help" `
+                  -RedirectStandardOutput $stdout -RedirectStandardError $stderr -PassThru -Wait -NoNewWindow
+              Write-Host "exit=$($proc.ExitCode)"
+              Write-Host "--- stdout ---"
+              Get-Content $stdout -ErrorAction SilentlyContinue
+              Write-Host "--- stderr ---"
+              $err = Get-Content $stderr -ErrorAction SilentlyContinue
+              $err
+              if ($proc.ExitCode -ne 0) {
+                  Write-Error "FAIL: $art help returned exit $($proc.ExitCode)"
+                  exit 1
+              }
+              if ($err -match "DLL was not found|side-by-side|ImportError|missing.*\.dll") {
+                  Write-Error "FAIL: missing-DLL error in stderr (artifact is non-portable)"
+                  exit 1
+              }
+              Write-Host "OK: $art help is portable on ${{ matrix.platform }}."
           }
-          if ($err -match "DLL was not found|side-by-side|ImportError|missing.*\.dll") {
-              Write-Error "FAIL: missing-DLL error in stderr (artifact is non-portable)"
-              exit 1
-          }
-          Write-Host "OK: pulp.exe help is portable on ${{ matrix.platform }}."
 
   release:
     needs: [build-cli, smoke-cli]

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -103,10 +103,10 @@ jobs:
         shell: bash
 
       # Phase 8: post-swap there are TWO CLI binaries shipping side by
-       # side — `pulp` (Rust, the user-facing default) at the top of
-       # the build dir, and `pulp-cpp` (C++, the fallthrough delegate
-       # for library-linked subcommands like ship/validate/host) under
-       # `tools/cli/`. The release tarball must include both.
+      # side — `pulp` (Rust, the user-facing default) at the top of
+      # the build dir, and `pulp-cpp` (C++, the fallthrough delegate
+      # for library-linked subcommands like ship/validate/host) under
+      # `tools/cli/`. The release tarball must include both.
       - name: Strip binaries (Unix)
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -454,7 +454,9 @@ jobs:
             irm https://www.generouscorp.com/pulp/install.ps1 | iex
             ```
 
-            Or download the binary for your platform below.
+            These installers place the Rust `pulp` CLI and the C++ `pulp-cpp`
+            delegate on your PATH. Or download the binary archive for your
+            platform below.
           files: |
             artifacts/**/*
           draft: false

--- a/.github/workflows/sandbox-e2e.yml
+++ b/.github/workflows/sandbox-e2e.yml
@@ -6,9 +6,9 @@
 # but gracefully handles the case where either isn't buildable on this
 # branch / OS:
 #
-#   - `experimental/pulp-rs/` only exists on `explore/rust-cli-prototype`
-#     (or after its Phase 8 merge). When the dir is absent, skip the
-#     Rust build and let the harness auto-skip any Rust-dependent test.
+#   - `experimental/pulp-rs/` only exists after Phase 8 prep lands. When
+#     the dir is absent, skip the Rust build and let the harness
+#     auto-skip any Rust-dependent test.
 #   - Linux needs apt deps for the C++ build (ALSA / X11 / Wayland via
 #     SDL3). We install the minimum set; if the build still fails, that
 #     regression is worth catching and not a sandbox-harness problem.
@@ -93,10 +93,12 @@ jobs:
             -DPULP_BUILD_TESTS=OFF \
             -DPULP_BUILD_EXAMPLES=OFF
           cmake --build build --target pulp-cli --parallel
-          if [[ -x "$PWD/build/tools/cli/pulp" ]]; then
+          if [[ -x "$PWD/build/tools/cli/pulp-cpp" ]]; then
+            echo "bin=$PWD/build/tools/cli/pulp-cpp" >> "$GITHUB_OUTPUT"
+          elif [[ -x "$PWD/build/tools/cli/pulp" ]]; then
             echo "bin=$PWD/build/tools/cli/pulp" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning ::C++ build did not produce build/tools/cli/pulp; Rust-dependent tests will skip"
+            echo "::warning ::C++ build did not produce build/tools/cli/pulp-cpp or build/tools/cli/pulp; Rust-dependent tests will skip"
           fi
         continue-on-error: true
 
@@ -106,11 +108,11 @@ jobs:
         working-directory: experimental/pulp-rs
         run: |
           set -o pipefail
-          cargo build --release --bin pulp-rs
-          if [[ -x "$PWD/target/release/pulp-rs" ]]; then
-            echo "bin=$PWD/target/release/pulp-rs" >> "$GITHUB_OUTPUT"
+          cargo build --release --bin pulp
+          if [[ -x "$PWD/target/release/pulp" ]]; then
+            echo "bin=$PWD/target/release/pulp" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning ::Rust build did not produce target/release/pulp-rs"
+            echo "::warning ::Rust build did not produce target/release/pulp"
           fi
         continue-on-error: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v0780"></a>
+## [0.78.0] - 2026-05-05
+
+- feat(cli): make the Rust CLI the default `pulp` binary and ship the C++ delegate as `pulp-cpp` in release artifacts.
+
 <a id="v0770"></a>
 ## [0.77.0] - 2026-05-05
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,20 +51,24 @@ cmake -S . -B build -DPULP_SANITIZER=address
 - CLAP → fetched automatically via CMake FetchContent
 - Skia → pre-built binaries in `external/skia-build/`
 
-**CLI tool:**
+**CLI tool (source tree):**
 ```bash
-./build/tools/cli/pulp build       # configure + build
-./build/tools/cli/pulp test        # run test suite
-./build/tools/cli/pulp validate    # run format validators (auval, clap-validator)
-./build/tools/cli/pulp ship sign --identity "Developer ID Application: ..."
-./build/tools/cli/pulp ship package --version 1.0.0
-./build/tools/cli/pulp ship check  # show signing status
-./build/tools/cli/pulp version             # show SDK and project version
-./build/tools/cli/pulp version bump patch  # bump version
-./build/tools/cli/pulp version check       # verify version consistency
-./build/tools/cli/pulp dev --test          # watch + rebuild + test loop
-./build/tools/cli/pulp build --watch       # watch + rebuild loop
+./build/pulp build       # configure + build
+./build/pulp test        # run test suite
+./build/pulp validate    # run format validators (auval, clap-validator)
+./build/pulp ship sign --identity "Developer ID Application: ..."
+./build/pulp ship package --version 1.0.0
+./build/pulp ship check  # show signing status
+./build/pulp version             # show SDK and project version
+./build/pulp version bump patch  # bump version
+./build/pulp version check       # verify version consistency
+./build/pulp dev --test          # watch + rebuild + test loop
+./build/pulp build --watch       # watch + rebuild loop
 ```
+
+After the Rust CLI cutover, source builds produce `./build/pulp` as
+the user-facing CLI and `./build/tools/cli/pulp-cpp` as the C++
+delegate for commands that still live in C++.
 
 **Note:** All plugin formats build and pass tests, including PulpSynth CLAP.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.77.0
+    VERSION 0.78.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/guides/docs-maintenance.md
+++ b/docs/guides/docs-maintenance.md
@@ -38,7 +38,7 @@ Run the docs consistency check locally at any time:
 
 ```bash
 # Via the CLI
-./build/tools/cli/pulp docs check
+./build/pulp docs check
 
 # Directly
 tools/check-docs.sh

--- a/docs/guides/packages/REMOVAL.md
+++ b/docs/guides/packages/REMOVAL.md
@@ -228,8 +228,8 @@ After completing all the above steps:
 1. [ ] `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` -- configure succeeds
 2. [ ] `cmake --build build -j$(sysctl -n hw.ncpu)` -- build succeeds with no missing includes or undefined symbols
 3. [ ] `ctest --test-dir build --output-on-failure` -- all tests pass
-4. [ ] `./build/tools/cli/pulp doctor` -- no package-related checks appear
-5. [ ] `./build/tools/cli/pulp help` -- no `add`, `remove`, `list`, `search`, `update`, `suggest`, `target` commands shown
+4. [ ] `./build/pulp doctor` -- no package-related checks appear
+5. [ ] `./build/pulp help` -- no `add`, `remove`, `list`, `search`, `update`, `suggest`, `target` commands shown
 6. [ ] `python3 tools/deps/audit.py --strict` -- no references to package registry files
 7. [ ] `grep -r "package_commands\|package_registry\|pulp::cli::pkg" tools/cli/` -- no results
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -70,7 +70,7 @@ git clone --depth 1 --branch AudioUnitSDK-1.4.0 \
 Run `pulp doctor --fix` to auto-resolve what it can:
 
 ```bash
-./build/tools/cli/pulp doctor --fix
+PULP_RS_CPP_BINARY="$PWD/build/tools/cli/pulp-cpp" ./build/pulp doctor --fix
 ```
 
 Each failed check includes a fix command. Common ones:

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -88,7 +88,7 @@ this version.
 3. Rebuild (`cmake --build build`). CMake re-runs
    `tools/scripts/build_migration_index.py` at configure time, so
    reconfigure (`cmake -S . -B build`) if the file list changes.
-4. Verify locally: `./build/tools/cli/pulp upgrade --notes
+4. Verify locally: `./build/pulp upgrade --notes
    --from 0.26.0 --to 0.27.0`.
 5. Commit. The generated `tools/cli/migration_index.cpp` lives at
    `${CMAKE_BINARY_DIR}/generated/migration_index.cpp` — it is NOT

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -768,11 +768,11 @@ that checkout's `build/` directory.
 Use `--script` to point at a different JS entry, and `--build-dir` when you are working from a
 nonstandard build tree such as a separate worktree build directory.
 
-When run outside a Pulp checkout, `pulp design` can currently auto-bind only when the `pulp`
-binary itself lives inside a Pulp build tree such as `.../build/tools/cli/pulp`. Generic
-PATH-installed or symlinked CLI setups are not fully SDK-mode aware yet; use `--build-dir` and
-`--script` explicitly in split layouts where the project repo and the Pulp SDK live in different
-directories.
+When run outside a Pulp checkout, `pulp design` can currently auto-bind only when the CLI
+binary lives inside a Pulp build tree such as `.../build/pulp` (Rust) with its
+`.../build/tools/cli/pulp-cpp` delegate. Generic PATH-installed or symlinked CLI setups
+are not fully SDK-mode aware yet; use `--build-dir` and `--script` explicitly in split
+layouts where the project repo and the Pulp SDK live in different directories.
 
 The selected build environment is the authority for supported behavior. `pulp design` prints the
 chosen root, build dir, and script path so the provenance is explicit.

--- a/experimental/pulp-rs/CMakeLists.txt
+++ b/experimental/pulp-rs/CMakeLists.txt
@@ -76,7 +76,10 @@ endif()
 # Cargo state into the source tree (it would otherwise default to
 # `experimental/pulp-rs/target/`).
 set(_pulp_rs_target_dir "${CMAKE_CURRENT_BINARY_DIR}/cargo-target")
-set(_pulp_rs_bin_name "pulp-rs${CMAKE_EXECUTABLE_SUFFIX}")
+# Phase 8 binary swap (#767 / #686): the Cargo `[[bin]] name` is now
+# `pulp` (was `pulp-rs`). Cargo emits `target/<profile>/pulp[.exe]`,
+# so this matches the new binary basename.
+set(_pulp_rs_bin_name "pulp${CMAKE_EXECUTABLE_SUFFIX}")
 set(_pulp_rs_cargo_bin "${_pulp_rs_target_dir}/${_pulp_rs_target_subdir}/${_pulp_rs_bin_name}")
 set(_pulp_rs_dest_bin   "${CMAKE_BINARY_DIR}/${_pulp_rs_bin_name}")
 

--- a/experimental/pulp-rs/CMakeLists.txt
+++ b/experimental/pulp-rs/CMakeLists.txt
@@ -3,16 +3,10 @@
 # binary alongside `pulp-cpp` (the C++ CLI), and `cmake --install`
 # drops both under `${CMAKE_INSTALL_BINDIR}`.
 #
-# Phase 8 binary-swap context (issues #686, #767):
-#
-#   - At this PR (#1 of the swap pair), the Rust crate's `[[bin]]`
-#     is still `pulp-rs` and the C++ target output is still `pulp`.
-#     This file installs the Rust binary as `pulp-rs` so neither
-#     replaces the other — both coexist.
-#   - PR #2 will rename the Cargo bin to `pulp` and the C++ output
-#     to `pulp-cpp`, flipping the user's default. That edit lands
-#     here as a one-line `OUTPUT_NAME` change in `tools/cli/CMakeLists.txt`
-#     plus a Cargo.toml `name` rename — no logic change in this file.
+# Phase 8 binary-swap context (issues #686, #767): the Rust crate's
+# `[[bin]]` is now `pulp`, and the C++ target output is `pulp-cpp`.
+# `cmake --install` drops both under the active prefix so Rust owns the
+# user-facing command while C++ remains available for fallthrough.
 #
 # Escape hatches (in priority order):
 #
@@ -26,8 +20,8 @@
 #
 # Cross-platform notes:
 #
-#   - Cargo emits `target/release/pulp-rs` on Unix and
-#     `target/release/pulp-rs.exe` on Windows. Both are surfaced
+#   - Cargo emits `target/release/pulp` on Unix and
+#     `target/release/pulp.exe` on Windows. Both are surfaced
 #     under `${CMAKE_BINARY_DIR}` with the platform-correct suffix.
 #   - The Rust crate is publishable standalone via plain
 #     `cargo build` from `experimental/pulp-rs/`. This CMake file
@@ -99,7 +93,7 @@ add_custom_target(pulp-rust-cli ALL
     USES_TERMINAL
     VERBATIM)
 
-# Surface the binary at `${CMAKE_BINARY_DIR}/pulp-rs[.exe]` so
+# Surface the binary at `${CMAKE_BINARY_DIR}/pulp[.exe]` so
 # every consumer (tests, scripts, packagers, the sandbox-e2e
 # harness #732) has a stable path independent of the Cargo target
 # layout.
@@ -107,12 +101,12 @@ add_custom_command(TARGET pulp-rust-cli POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
             "${_pulp_rs_cargo_bin}"
             "${_pulp_rs_dest_bin}"
-    COMMENT "Staging pulp-rs at ${_pulp_rs_dest_bin}"
+    COMMENT "Staging Rust pulp at ${_pulp_rs_dest_bin}"
     VERBATIM)
 
 # Install into the active prefix's bindir so `cmake --install`
-# emits both `pulp-cpp` (a.k.a. today's `pulp`) and `pulp-rs`
-# side-by-side. We install the staged copy under
+# emits both Rust `pulp` and C++ `pulp-cpp` side-by-side. We install
+# the staged copy under
 # `${CMAKE_BINARY_DIR}` (not the cargo-target subdir) so install
 # behavior is independent of Cargo's internal layout.
 set(_pulp_rs_install_bindir "${CMAKE_INSTALL_BINDIR}")

--- a/experimental/pulp-rs/Cargo.toml
+++ b/experimental/pulp-rs/Cargo.toml
@@ -25,7 +25,13 @@ name = "pulp_rs"
 path = "src/lib.rs"
 
 [[bin]]
-name = "pulp-rs"
+# Phase 8 binary swap: this name was `pulp-rs` while the C++ binary
+# owned `pulp`. The default flip (PR #2 of #767) renames the Cargo
+# bin to `pulp` and renames the C++ output to `pulp-cpp` in the same
+# diff. Rollback for users: `PULP_USE_CPP=1 pulp …` execs into
+# `pulp-cpp` with full argv unchanged (handled at the top of
+# `src/main.rs`).
+name = "pulp"
 path = "src/main.rs"
 
 [dependencies]

--- a/experimental/pulp-rs/src/cmd/help.rs
+++ b/experimental/pulp-rs/src/cmd/help.rs
@@ -3,7 +3,7 @@
 //! # Why a dispatcher module
 //!
 //! The usage banner itself lives in [`crate::help`] so three callers
-//! share the same bytes: the explicit `pulp-rs help` subcommand
+//! share the same bytes: the explicit `pulp help` subcommand
 //! (dispatched here), the bare-invocation fallback in `main.rs`, and
 //! the fuzzy suggester.
 //!
@@ -16,7 +16,7 @@ use std::io::Write;
 use crate::error::Result;
 use crate::help;
 
-/// Run `pulp-rs help`. Always exits with 0 when writes succeed.
+/// Run `pulp help`. Always exits with 0 when writes succeed.
 ///
 /// # Errors
 ///
@@ -35,7 +35,7 @@ mod tests {
         let mut buf = Vec::new();
         run(&mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
-        assert!(s.contains("pulp-rs — Pulp audio plugin framework CLI"));
+        assert!(s.contains("pulp — Pulp audio plugin framework CLI"));
         assert!(s.contains("Examples:"));
     }
 }

--- a/experimental/pulp-rs/src/cmd/version.rs
+++ b/experimental/pulp-rs/src/cmd/version.rs
@@ -190,7 +190,9 @@ fn show(json: bool, out: &mut impl Write) -> Result<()> {
         return Ok(());
     }
 
-    writeln!(out, "pulp-rs v{} (prototype)", snap.cli.raw).map_err(io_err)?;
+    // Phase 8 binary swap (#767 / #686): user-facing label is now
+    // `pulp` (was `pulp-rs (prototype)`). The C++ delegate is `pulp-cpp`.
+    writeln!(out, "pulp v{}", snap.cli.raw).map_err(io_err)?;
     if !snap.plugin.raw.is_empty() {
         writeln!(out, "Claude plugin: v{}", snap.plugin.raw).map_err(io_err)?;
     }

--- a/experimental/pulp-rs/src/help.rs
+++ b/experimental/pulp-rs/src/help.rs
@@ -250,12 +250,12 @@ pub fn known_commands() -> Vec<&'static str> {
 ///
 /// Returns [`CliError::Io`] if `out` fails a write.
 pub fn write_usage(out: &mut impl Write) -> Result<()> {
-    write_usage_with_banner(out, "pulp-rs")
+    write_usage_with_banner(out, "pulp")
 }
 
 /// Like [`write_usage`] but lets callers override the banner name.
-/// The bare `pulp-rs help` banner says `pulp-rs`; a hypothetical
-/// `pulp` shim could reuse the same table with a different header.
+/// Tests can reuse the same table with a different header when they
+/// need to compare against legacy captures.
 ///
 /// # Errors
 ///
@@ -342,7 +342,7 @@ pub fn closest<'a>(typed: &str, candidates: &[&'a str]) -> Option<(&'a str, usiz
 ///
 /// ```text
 /// Unknown command: xzv
-/// Did you mean: pulp-rs build?
+/// Did you mean: pulp build?
 /// ```
 ///
 /// When no candidate is within the distance threshold, the hint
@@ -350,7 +350,7 @@ pub fn closest<'a>(typed: &str, candidates: &[&'a str]) -> Option<(&'a str, usiz
 ///
 /// ```text
 /// Unknown command: xzv
-/// Run `pulp-rs help` for usage
+/// Run `pulp help` for usage
 /// ```
 ///
 /// `threshold` is the inclusive distance ceiling; the C++ CLI uses
@@ -391,12 +391,12 @@ mod tests {
     }
 
     #[test]
-    fn usage_banner_starts_with_pulp_rs_header() {
+    fn usage_banner_starts_with_pulp_header() {
         let mut buf = Vec::new();
         write_usage(&mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
-        assert!(s.starts_with("pulp-rs — Pulp audio plugin framework CLI"));
-        assert!(s.contains("Usage: pulp-rs <command> [options]"));
+        assert!(s.starts_with("pulp — Pulp audio plugin framework CLI"));
+        assert!(s.contains("Usage: pulp <command> [options]"));
     }
 
     #[test]
@@ -429,17 +429,17 @@ mod tests {
 
     #[test]
     fn suggest_hint_prints_did_you_mean_within_threshold() {
-        let h = suggest_hint("buld", "pulp-rs", 3);
+        let h = suggest_hint("buld", "pulp", 3);
         assert!(h.contains("Unknown command: buld"));
-        assert!(h.contains("Did you mean: pulp-rs build?"));
+        assert!(h.contains("Did you mean: pulp build?"));
     }
 
     #[test]
     fn suggest_hint_falls_back_when_far_off() {
         // "xyzxyzxyz" is at distance >3 from every known command.
-        let h = suggest_hint("xyzxyzxyz", "pulp-rs", 3);
+        let h = suggest_hint("xyzxyzxyz", "pulp", 3);
         assert!(h.contains("Unknown command: xyzxyzxyz"));
-        assert!(h.contains("Run `pulp-rs help` for usage"));
+        assert!(h.contains("Run `pulp help` for usage"));
     }
 
     #[test]

--- a/experimental/pulp-rs/src/main.rs
+++ b/experimental/pulp-rs/src/main.rs
@@ -659,9 +659,9 @@ fn clap_exit_code(err: &clap::error::Error) -> ExitCode {
 
             // No pulp-cpp on PATH (or fallthrough disabled). Match
             // the C++ CLI's fuzzy suggester: print "Unknown command:
-            // …\nDid you mean: pulp-rs <closest>?" so a user who
+            // …\nDid you mean: pulp <closest>?" so a user who
             // typed `buld` gets pointed at `build`. Falls back to
-            // `Run `pulp-rs help` for usage` when no candidate is
+            // `Run `pulp help` for usage` when no candidate is
             // within the distance-3 threshold (C++ uses the same
             // inclusive bound in `pulp_cli.cpp`).
             //
@@ -675,7 +675,7 @@ fn clap_exit_code(err: &clap::error::Error) -> ExitCode {
                     ExitCode::from(2)
                 },
                 |typed| {
-                    let hint = help::suggest_hint(&typed, "pulp-rs", 3);
+                    let hint = help::suggest_hint(&typed, "pulp", 3);
                     eprint!("{hint}");
                     ExitCode::from(1)
                 },

--- a/experimental/pulp-rs/src/main.rs
+++ b/experimental/pulp-rs/src/main.rs
@@ -14,12 +14,17 @@ use pulp_rs::help;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "pulp-rs",
-    about = "Experimental Rust prototype of the Pulp CLI (not for production)",
+    // Phase 8 binary swap (#767 / #686): the user-facing binary name
+    // is now `pulp` (was `pulp-rs`). The Cargo `[[bin]] name` was
+    // also flipped in the same diff so `target/release/pulp` is what
+    // ships. The C++ CLI is now `pulp-cpp` and is reached via the
+    // fallthrough wrapper or via the `PULP_USE_CPP=1` rollback.
+    name = "pulp",
+    about = "Pulp audio plugin framework CLI (Rust binary; C++ delegate is `pulp-cpp`)",
     disable_version_flag = true,
     disable_help_subcommand = true,
     // Prevent clap from printing its generated help banner when the
-    // user invokes `pulp-rs` with no args. The C++ CLI prints its own
+    // user invokes `pulp` with no args. The C++ CLI prints its own
     // usage banner and exits 0; we match that exactly by handling
     // `Option<Command>::None` in `real_main`.
     arg_required_else_help = false

--- a/experimental/pulp-rs/tests/config_parity_test.rs
+++ b/experimental/pulp-rs/tests/config_parity_test.rs
@@ -28,7 +28,7 @@ fn plant(name: &str) -> tempfile::TempDir {
 }
 
 fn run(args: &[&str], home: &std::path::Path) -> std::process::Output {
-    let mut cmd = assert_cmd::Command::cargo_bin("pulp-rs").expect("binary");
+    let mut cmd = assert_cmd::Command::cargo_bin("pulp").expect("binary");
     cmd.args(args).env("PULP_HOME", home);
     cmd.output().expect("run pulp-rs")
 }

--- a/experimental/pulp-rs/tests/help_parity_test.rs
+++ b/experimental/pulp-rs/tests/help_parity_test.rs
@@ -2,12 +2,7 @@
 //! fuzzy "Did you mean...?" UX fixes.
 //!
 //! The reference file is `tests/fixtures/help/expected_cpp.txt`,
-//! captured from a built `pulp` binary by running `./pulp help`. The
-//! Rust banner uses `pulp-rs` everywhere the C++ banner uses `pulp`,
-//! so the comparison normalises both sides before diffing:
-//!
-//! - `pulp-rs —` ↔ `pulp —` (header line)
-//! - `Usage: pulp-rs <…>` ↔ `Usage: pulp <…>`
+//! captured from a built `pulp` binary by running `./pulp help`.
 //!
 //! The "Examples" section uses literal `pulp create ...` lines on
 //! both sides — those aren't the banner name, they're example
@@ -27,8 +22,8 @@ fn fixture_dir() -> PathBuf {
 }
 
 /// Normalise Rust banner so it can be diffed against the captured
-/// C++ banner. `pulp-rs` → `pulp` everywhere except inside the
-/// "Examples" block, which already uses `pulp …` on both sides.
+/// C++ banner. The flip branch should already use `pulp`; keeping
+/// this helper makes legacy fixture diffs easier to review.
 fn normalise_rust_banner(s: &str) -> String {
     s.replace(
         "pulp-rs — Pulp audio plugin framework CLI",
@@ -46,7 +41,7 @@ fn help_banner_matches_cpp_output() {
         .env_remove("NO_COLOR")
         .output()
         .expect("run");
-    assert!(output.status.success(), "pulp-rs help exited non-zero");
+    assert!(output.status.success(), "pulp help exited non-zero");
     let stdout = String::from_utf8(output.stdout).expect("utf8");
     let normalised = normalise_rust_banner(&stdout);
     assert!(
@@ -72,12 +67,12 @@ fn bare_invocation_prints_banner_and_exits_zero() {
         .expect("run");
     assert!(
         output.status.success(),
-        "bare `pulp-rs` should exit 0 to match C++; got {:?}",
+        "bare `pulp` should exit 0 to match C++; got {:?}",
         output.status.code()
     );
     let stdout = String::from_utf8(output.stdout).expect("utf8");
     assert!(
-        stdout.contains("pulp-rs — Pulp audio plugin framework CLI"),
+        stdout.contains("pulp — Pulp audio plugin framework CLI"),
         "bare invocation should print the usage banner"
     );
     assert!(
@@ -100,7 +95,7 @@ fn unknown_command_suggests_close_match() {
         "expected 'Unknown command: buld' in stderr, got: {stderr}"
     );
     assert!(
-        stderr.contains("Did you mean: pulp-rs build?"),
+        stderr.contains("Did you mean: pulp build?"),
         "expected fuzzy suggestion for 'buld' → 'build', got: {stderr}"
     );
 }
@@ -118,7 +113,7 @@ fn unknown_command_suggests_projects_for_project_typo() {
     assert_eq!(output.status.code(), Some(1));
     let stderr = String::from_utf8(output.stderr).expect("utf8");
     assert!(
-        stderr.contains("Did you mean: pulp-rs project"),
+        stderr.contains("Did you mean: pulp project"),
         "expected a project/projects suggestion, got: {stderr}"
     );
 }
@@ -137,7 +132,7 @@ fn unknown_command_falls_back_when_no_close_match() {
         "expected unknown-command line, got: {stderr}"
     );
     assert!(
-        stderr.contains("Run `pulp-rs help` for usage"),
+        stderr.contains("Run `pulp help` for usage"),
         "expected fallback hint when no close match, got: {stderr}"
     );
 }
@@ -154,7 +149,7 @@ fn unknown_command_does_not_suggest_deferred_commands_silently() {
         .expect("run");
     let stderr = String::from_utf8(output.stderr).expect("utf8");
     assert!(
-        stderr.contains("Did you mean: pulp-rs audio?"),
+        stderr.contains("Did you mean: pulp audio?"),
         "expected suggestion for 'audo' → 'audio', got: {stderr}"
     );
 }

--- a/experimental/pulp-rs/tests/help_parity_test.rs
+++ b/experimental/pulp-rs/tests/help_parity_test.rs
@@ -40,7 +40,7 @@ fn normalise_rust_banner(s: &str) -> String {
 #[test]
 fn help_banner_matches_cpp_output() {
     let expected = fs::read_to_string(fixture_dir().join("expected_cpp.txt")).expect("fixture");
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .expect("binary")
         .arg("help")
         .env_remove("NO_COLOR")
@@ -57,7 +57,7 @@ fn help_banner_matches_cpp_output() {
 
 #[test]
 fn help_banner_exit_code_is_zero() {
-    Command::cargo_bin("pulp-rs")
+    Command::cargo_bin("pulp")
         .expect("binary")
         .arg("help")
         .assert()
@@ -66,7 +66,7 @@ fn help_banner_exit_code_is_zero() {
 
 #[test]
 fn bare_invocation_prints_banner_and_exits_zero() {
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .expect("binary")
         .output()
         .expect("run");
@@ -88,7 +88,7 @@ fn bare_invocation_prints_banner_and_exits_zero() {
 
 #[test]
 fn unknown_command_suggests_close_match() {
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .expect("binary")
         .arg("buld")
         .output()
@@ -110,7 +110,7 @@ fn unknown_command_suggests_projects_for_project_typo() {
     // Distance 1 edge case: `projets` is closer to `projects` than
     // any other command — make sure we don't accidentally suggest
     // `project` (the singular).
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .expect("binary")
         .arg("projets")
         .output()
@@ -125,7 +125,7 @@ fn unknown_command_suggests_projects_for_project_typo() {
 
 #[test]
 fn unknown_command_falls_back_when_no_close_match() {
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .expect("binary")
         .arg("xyzxyzxyz")
         .output()
@@ -147,7 +147,7 @@ fn unknown_command_does_not_suggest_deferred_commands_silently() {
     // `audo` is closer to `audio` than to `add`/`audit`. Make sure
     // the suggester reaches into the full known-commands list, not
     // just the native-Rust ports.
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .expect("binary")
         .arg("audo")
         .output()

--- a/experimental/pulp-rs/tests/orchestrate_parity_test.rs
+++ b/experimental/pulp-rs/tests/orchestrate_parity_test.rs
@@ -35,7 +35,7 @@ use tempfile::tempdir;
 /// Shell out to the built `pulp-rs` binary with a fresh `PULP_HOME`
 /// pointing at a test-owned tempdir.
 fn pulp_rs() -> Command {
-    let mut c = Command::cargo_bin("pulp-rs").expect("pulp-rs binary");
+    let mut c = Command::cargo_bin("pulp").expect("pulp-rs binary");
     c.env_remove("PULP_UPDATE_CHECK_DISABLED");
     c
 }

--- a/experimental/pulp-rs/tests/parity_test.rs
+++ b/experimental/pulp-rs/tests/parity_test.rs
@@ -41,7 +41,7 @@ fn fixture_dir(name: &str) -> PathBuf {
 }
 
 fn run_pulp_rs(cwd: &Path, extra_env: &[(&str, &str)]) -> String {
-    let bin = env!("CARGO_BIN_EXE_pulp-rs");
+    let bin = env!("CARGO_BIN_EXE_pulp");
     let mut cmd = Command::new(bin);
     cmd.args(["doctor", "--versions", "--json"]);
     cmd.current_dir(cwd);

--- a/experimental/pulp-rs/tests/phase6d_parity_test.rs
+++ b/experimental/pulp-rs/tests/phase6d_parity_test.rs
@@ -41,7 +41,7 @@ fn fixture_root(category: &str, name: &str) -> PathBuf {
 }
 
 fn run_in(dir: &Path, args: &[&str]) -> std::process::Output {
-    Command::cargo_bin("pulp-rs")
+    Command::cargo_bin("pulp")
         .expect("binary")
         .current_dir(dir)
         .args(args)
@@ -228,7 +228,7 @@ fn tool_uninstall_missing_exits_nonzero() {
     // user install. Set it to a fresh tempdir — the target id doesn't
     // exist there so the uninstall returns "not installed".
     let home = tempfile::tempdir().unwrap();
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .expect("binary")
         .current_dir(&root)
         .args(["tool", "uninstall", "uv"])

--- a/experimental/pulp-rs/tests/project_parity_test.rs
+++ b/experimental/pulp-rs/tests/project_parity_test.rs
@@ -28,7 +28,7 @@ fn plant(src_fixture: &str, dst_dir: &Path) -> PathBuf {
 }
 
 fn run_bump(cwd: &Path, pulp_home: &Path, extra: &[&str]) -> std::process::Output {
-    let mut cmd = Command::cargo_bin("pulp-rs").expect("binary");
+    let mut cmd = Command::cargo_bin("pulp").expect("binary");
     cmd.current_dir(cwd);
     cmd.env("PULP_HOME", pulp_home);
     cmd.env_remove("NO_COLOR");
@@ -206,7 +206,7 @@ fn bump_allow_downgrade_flag_permits_older_target() {
 #[test]
 fn project_bare_help_exits_one() {
     let td = tempfile::tempdir().unwrap();
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .unwrap()
         .current_dir(td.path())
         .arg("project")
@@ -225,7 +225,7 @@ fn project_bare_help_exits_one() {
 #[test]
 fn project_help_exits_zero() {
     let td = tempfile::tempdir().unwrap();
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .unwrap()
         .current_dir(td.path())
         .args(["project", "help"])
@@ -237,7 +237,7 @@ fn project_help_exits_zero() {
 #[test]
 fn project_unknown_subcommand_exits_two() {
     let td = tempfile::tempdir().unwrap();
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .unwrap()
         .current_dir(td.path())
         .args(["project", "nope"])
@@ -264,7 +264,7 @@ fn undo_reverts_latest_bump_end_to_end() {
     assert_ne!(after_bump, original);
 
     // Now undo.
-    let undo = Command::cargo_bin("pulp-rs")
+    let undo = Command::cargo_bin("pulp")
         .unwrap()
         .current_dir(&project)
         .env("PULP_HOME", &home)
@@ -296,7 +296,7 @@ fn undo_with_no_batch_exits_one() {
     let td = tempfile::tempdir().unwrap();
     let home = td.path().join("pulp-home");
     fs::create_dir_all(&home).unwrap();
-    let output = Command::cargo_bin("pulp-rs")
+    let output = Command::cargo_bin("pulp")
         .unwrap()
         .current_dir(td.path())
         .env("PULP_HOME", &home)

--- a/experimental/pulp-rs/tests/projects_parity_test.rs
+++ b/experimental/pulp-rs/tests/projects_parity_test.rs
@@ -92,7 +92,7 @@ fn normalise_json(mut v: serde_json::Value) -> serde_json::Value {
 }
 
 fn run_pulp_rs(args: &[&str], pulp_home: &Path) -> std::process::Output {
-    let mut cmd = assert_cmd::Command::cargo_bin("pulp-rs").expect("pulp-rs binary");
+    let mut cmd = assert_cmd::Command::cargo_bin("pulp").expect("pulp-rs binary");
     cmd.args(args);
     cmd.env("PULP_HOME", pulp_home);
     cmd.env_remove("NO_COLOR"); // irrelevant because stdout is piped
@@ -163,7 +163,7 @@ fn projects_list_reports_registry_path_in_human_lane() {
 #[test]
 fn projects_unknown_subcommand_exits_two() {
     let home = tempfile::tempdir().unwrap();
-    let mut cmd = assert_cmd::Command::cargo_bin("pulp-rs").unwrap();
+    let mut cmd = assert_cmd::Command::cargo_bin("pulp").unwrap();
     cmd.args(["projects", "nope"]);
     cmd.env("PULP_HOME", home.path());
     cmd.assert().code(predicate::eq(2));

--- a/experimental/pulp-rs/tests/rollback_test.rs
+++ b/experimental/pulp-rs/tests/rollback_test.rs
@@ -23,10 +23,10 @@ use std::path::PathBuf;
 
 use assert_cmd::Command;
 
-/// Resolve the binary name the crate's `[[bin]]` manifest declares
-/// so these tests keep working if/when the Phase 8 rename flips
-/// `pulp-rs` → `pulp` in `Cargo.toml`.
-const BIN_NAME: &str = "pulp-rs";
+/// Resolve the binary name the crate's `[[bin]]` manifest declares.
+/// Phase 8 binary swap (#767 / #686) renamed this from `pulp-rs` to
+/// `pulp` along with the Cargo `[[bin]] name` field.
+const BIN_NAME: &str = "pulp";
 
 #[test]
 fn pulp_use_cpp_without_pulp_cpp_on_path_exits_two() {

--- a/experimental/pulp-rs/tests/scan_parity_test.rs
+++ b/experimental/pulp-rs/tests/scan_parity_test.rs
@@ -106,7 +106,7 @@ fn scan_unknown_format_flag_returns_bad_usage() {
 
 #[test]
 fn scan_cli_unknown_format_exits_two() {
-    let output = assert_cmd::Command::cargo_bin("pulp-rs")
+    let output = assert_cmd::Command::cargo_bin("pulp")
         .expect("binary")
         .args(["scan", "--format", "notafmt"])
         .output()
@@ -127,7 +127,7 @@ fn scan_cli_empty_roots_on_isolated_home_prints_fallback() {
     // system though, so we can't guarantee empty output — instead
     // we just assert the command exits 0 (a successful no-op).
     let tmp = tempfile::tempdir().expect("tempdir");
-    let output = assert_cmd::Command::cargo_bin("pulp-rs")
+    let output = assert_cmd::Command::cargo_bin("pulp")
         .expect("binary")
         .arg("scan")
         .env("HOME", tmp.path())

--- a/experimental/pulp-rs/tests/smoke_test.rs
+++ b/experimental/pulp-rs/tests/smoke_test.rs
@@ -33,7 +33,7 @@ fn fixture_dir(name: &str) -> PathBuf {
 
 #[test]
 fn doctor_versions_json_has_required_shape() {
-    let bin = env!("CARGO_BIN_EXE_pulp-rs");
+    let bin = env!("CARGO_BIN_EXE_pulp");
 
     let output = Command::new(bin)
         .args(["doctor", "--versions", "--json"])
@@ -65,7 +65,7 @@ fn doctor_versions_json_has_required_shape() {
 
 #[test]
 fn doctor_populates_project_sdk_from_fixture() {
-    let bin = env!("CARGO_BIN_EXE_pulp-rs");
+    let bin = env!("CARGO_BIN_EXE_pulp");
     let dir = fixture_dir("ok_plain");
     let tmp_home = tempfile::tempdir().expect("tempdir");
 

--- a/experimental/pulp-rs/tests/snapshot_test.rs
+++ b/experimental/pulp-rs/tests/snapshot_test.rs
@@ -61,7 +61,7 @@ fn normalise_registry_field(mut v: Value) -> Value {
 }
 
 fn run(args: &[&str], home: &Path) -> Value {
-    let mut cmd = assert_cmd::Command::cargo_bin("pulp-rs").unwrap();
+    let mut cmd = assert_cmd::Command::cargo_bin("pulp").unwrap();
     cmd.args(args);
     cmd.env("PULP_HOME", home);
     let output = cmd.output().expect("run pulp-rs");
@@ -121,7 +121,7 @@ fn config_list_json_snapshot_populated() {
 #[test]
 fn upgrade_check_only_json_snapshot_disabled() {
     let home = tempfile::tempdir().unwrap();
-    let mut cmd = assert_cmd::Command::cargo_bin("pulp-rs").unwrap();
+    let mut cmd = assert_cmd::Command::cargo_bin("pulp").unwrap();
     cmd.args(["upgrade", "--check-only", "--json"]);
     cmd.env("PULP_HOME", home.path())
         .env("PULP_RS_CLI_VERSION", "0.37.0")

--- a/experimental/pulp-rs/tests/upgrade_parity_test.rs
+++ b/experimental/pulp-rs/tests/upgrade_parity_test.rs
@@ -59,7 +59,7 @@ fn run(name: &str, extra_env: &[(&str, &str)]) -> std::process::Output {
     let home = tempfile::tempdir().expect("tempdir");
     plant_cache(name, home.path());
 
-    let mut cmd = assert_cmd::Command::cargo_bin("pulp-rs").expect("binary");
+    let mut cmd = assert_cmd::Command::cargo_bin("pulp").expect("binary");
     cmd.args(["upgrade", "--check-only", "--json"])
         .env("PULP_HOME", home.path())
         .env("PULP_RS_CLI_VERSION", "0.37.0");
@@ -120,7 +120,7 @@ fn upgrade_check_only_human_lane_reports_installed_and_latest() {
     let home = tempfile::tempdir().unwrap();
     plant_cache("fresh_cache", home.path());
 
-    let output = assert_cmd::Command::cargo_bin("pulp-rs")
+    let output = assert_cmd::Command::cargo_bin("pulp")
         .unwrap()
         .args(["upgrade", "--check-only"])
         .env("PULP_HOME", home.path())
@@ -139,7 +139,7 @@ fn upgrade_check_only_human_lane_reports_installed_and_latest() {
 fn upgrade_notes_lane_emits_from_to_json() {
     // No network needed for --notes with explicit --from/--to.
     let home = tempfile::tempdir().unwrap();
-    let output = assert_cmd::Command::cargo_bin("pulp-rs")
+    let output = assert_cmd::Command::cargo_bin("pulp")
         .unwrap()
         .args([
             "upgrade", "--notes", "--json", "--from", "0.30.0", "--to", "0.40.0",
@@ -168,7 +168,7 @@ fn upgrade_install_dry_run_plants_pending_marker() {
     let home = tempfile::tempdir().unwrap();
     plant_cache("fresh_cache", home.path());
 
-    let output = assert_cmd::Command::cargo_bin("pulp-rs")
+    let output = assert_cmd::Command::cargo_bin("pulp")
         .unwrap()
         .args(["upgrade", "--install", "--json"])
         .env("PULP_HOME", home.path())

--- a/experimental/pulp-rs/tests/upgrade_parity_test.rs
+++ b/experimental/pulp-rs/tests/upgrade_parity_test.rs
@@ -185,7 +185,7 @@ fn upgrade_install_dry_run_plants_pending_marker() {
 }
 
 /// Phase 8: integration-level coverage for the build-artifact guard.
-/// `pulp-rs upgrade --install` invoked from cargo's target/ tree
+/// `pulp upgrade --install` invoked from cargo's target/ tree
 /// must refuse to clobber the running binary unless the user opts
 /// into the live path explicitly.
 #[test]
@@ -193,7 +193,7 @@ fn upgrade_install_refuses_when_running_under_cargo_target() {
     let home = tempfile::tempdir().unwrap();
     plant_cache("fresh_cache", home.path());
 
-    let output = assert_cmd::Command::cargo_bin("pulp-rs")
+    let output = assert_cmd::Command::cargo_bin("pulp")
         .unwrap()
         .args(["upgrade", "--install"])
         .env("PULP_HOME", home.path())

--- a/experimental/pulp-rs/tests/version_parity_test.rs
+++ b/experimental/pulp-rs/tests/version_parity_test.rs
@@ -23,7 +23,7 @@ fn run(name: &str) -> Value {
     // Isolate from the real user's home + $PULP_HOME so the
     // plugin-json fallback doesn't pick up an ambient manifest.
     let tmp_home = tempfile::tempdir().expect("tempdir");
-    let mut cmd = assert_cmd::Command::cargo_bin("pulp-rs").expect("binary");
+    let mut cmd = assert_cmd::Command::cargo_bin("pulp").expect("binary");
     cmd.args(["version", "--json"])
         .current_dir(&dir)
         .env("PULP_HOME", tmp_home.path())
@@ -98,7 +98,7 @@ fn version_json_has_required_shape() {
 fn version_human_lane_prints_cli_and_plugin() {
     let dir = fixture_dir("version", "with_plugin_json");
     let tmp_home = tempfile::tempdir().unwrap();
-    let mut cmd = assert_cmd::Command::cargo_bin("pulp-rs").unwrap();
+    let mut cmd = assert_cmd::Command::cargo_bin("pulp").unwrap();
     cmd.args(["version"])
         .current_dir(&dir)
         .env("PULP_HOME", tmp_home.path())
@@ -107,6 +107,7 @@ fn version_human_lane_prints_cli_and_plugin() {
     let output = cmd.output().unwrap();
     assert!(output.status.success());
     let s = String::from_utf8(output.stdout).unwrap();
-    assert!(s.contains("pulp-rs v0.37.0"));
+    // Phase 8 binary swap (#767): banner is now `pulp v…` (was `pulp-rs v… (prototype)`).
+    assert!(s.contains("pulp v0.37.0"));
     assert!(s.contains("Claude plugin: v0.12.0"));
 }

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -77,7 +77,14 @@ add_executable(pulp-cli
     migration_runtime.cpp
     validator_discovery.cpp
     "${_pulp_migration_index_src}")
-set_target_properties(pulp-cli PROPERTIES OUTPUT_NAME "pulp")
+# Phase 8 binary swap (#767 / #686): the C++ CLI was historically the
+# user-facing `pulp` binary. With the Rust binary now ready, the C++
+# side renames to `pulp-cpp` and the Rust binary takes the `pulp`
+# slot. Rollback for users: `PULP_USE_CPP=1 pulp …` execs into
+# `pulp-cpp` (handled at the top of `experimental/pulp-rs/src/main.rs`).
+# The CMake target name (`pulp-cli`) does NOT change — only the file
+# basename — so all ctest entries below keep working.
+set_target_properties(pulp-cli PROPERTIES OUTPUT_NAME "pulp-cpp")
 target_compile_features(pulp-cli PRIVATE cxx_std_20)
 target_link_libraries(pulp-cli PRIVATE pulp::runtime pulp::tool-audio pulp::ship pulp::view pulp::format pulp::inspect pulp::host)
 target_include_directories(pulp-cli PRIVATE

--- a/tools/sandbox-e2e/README.md
+++ b/tools/sandbox-e2e/README.md
@@ -70,8 +70,8 @@ pytest tools/sandbox-e2e/
 pytest tools/sandbox-e2e/ -m "plugin_surface or rollback or parity"
 
 # pin specific binaries (useful in CI and when iterating on a branch)
-PULP_CPP_BINARY_FOR_TEST=/path/to/pulp \
-PULP_RS_BINARY_FOR_TEST=/path/to/pulp-rs \
+PULP_CPP_BINARY_FOR_TEST=/path/to/pulp-cpp \
+PULP_RS_BINARY_FOR_TEST=/path/to/pulp \
     pytest tools/sandbox-e2e/
 ```
 
@@ -82,10 +82,10 @@ PULP_RS_BINARY_FOR_TEST=/path/to/pulp-rs \
 1. `PULP_CPP_BINARY_FOR_TEST` / `PULP_RS_BINARY_FOR_TEST` env
    overrides
 2. Build artifacts:
-   - C++: `build/tools/cli/pulp`
-   - Rust: `experimental/pulp-rs/target/release/pulp-rs`
-3. Fallback for C++: `~/.pulp/bin/pulp` (the user's installed binary,
-   copied into the sandbox — never invoked in place)
+   - C++: `build/tools/cli/pulp-cpp` (`build/tools/cli/pulp` on old branches)
+   - Rust: `experimental/pulp-rs/target/release/pulp`
+3. Fallback for C++: `~/.pulp/bin/pulp-cpp` (`~/.pulp/bin/pulp` on old
+   branches), copied into the sandbox — never invoked in place
 4. Sibling-worktree fallback for Rust (looks under `../pulp*`)
 
 If neither is found, the relevant tests `pytest.skip(...)` with a

--- a/tools/sandbox-e2e/conftest.py
+++ b/tools/sandbox-e2e/conftest.py
@@ -3,16 +3,20 @@
 Binary discovery (in priority order):
 
 1. Env-var overrides:
-     PULP_CPP_BINARY_FOR_TEST  — the C++ pulp binary (pre-swap: ~/.pulp/bin/pulp)
-     PULP_RS_BINARY_FOR_TEST   — the Rust pulp prototype
+     PULP_CPP_BINARY_FOR_TEST  — the C++ pulp-cpp delegate
+     PULP_RS_BINARY_FOR_TEST   — the Rust pulp binary
 
 2. Build-artifact paths relative to the repo root:
-     build/tools/cli/pulp                                     (C++)
-     experimental/pulp-rs/target/release/pulp-rs              (Rust)
-     experimental/pulp-rs/target/debug/pulp-rs                (Rust, fallback)
+     build/tools/cli/pulp-cpp                                 (C++, post-swap)
+     build/tools/cli/pulp                                     (C++, pre-swap fallback)
+     experimental/pulp-rs/target/release/pulp                 (Rust, post-swap)
+     experimental/pulp-rs/target/debug/pulp                   (Rust, fallback)
+     experimental/pulp-rs/target/release/pulp-rs              (Rust, pre-swap fallback)
+     experimental/pulp-rs/target/debug/pulp-rs                (Rust, pre-swap fallback)
 
 3. Fallback to the installed binary:
-     ~/.pulp/bin/pulp                                         (C++)
+     ~/.pulp/bin/pulp-cpp                                     (C++, post-swap)
+     ~/.pulp/bin/pulp                                         (C++, pre-swap fallback)
 
 If neither candidate is found, tests that need the binary are skipped
 with a clear message. Tests never run against "whatever happens to
@@ -53,13 +57,15 @@ REPO_ROOT = _find_repo_root()
 
 
 def _discover_cpp_binary() -> Path | None:
-    """Locate the C++ ``pulp`` binary under test. See module docstring."""
+    """Locate the C++ ``pulp-cpp`` binary under test. See module docstring."""
     override = os.environ.get("PULP_CPP_BINARY_FOR_TEST")
     if override:
         candidate = Path(override).expanduser()
         return candidate if candidate.exists() else None
     candidates = [
+        REPO_ROOT / "build" / "tools" / "cli" / "pulp-cpp",
         REPO_ROOT / "build" / "tools" / "cli" / "pulp",
+        Path.home() / ".pulp" / "bin" / "pulp-cpp",
         Path.home() / ".pulp" / "bin" / "pulp",
     ]
     for c in candidates:
@@ -69,10 +75,8 @@ def _discover_cpp_binary() -> Path | None:
 
 
 def _discover_rust_binary() -> Path | None:
-    """Locate the Rust ``pulp-rs`` binary. The pre-swap name is
-    ``pulp-rs``; post-swap it will be ``pulp`` in the same position as
-    the C++ binary, but the harness always stages it under a clear
-    name so scenarios are unambiguous."""
+    """Locate the Rust ``pulp`` binary. Pre-swap ``pulp-rs`` paths remain
+    as fallbacks so older branches can still run the harness."""
     override = os.environ.get("PULP_RS_BINARY_FOR_TEST")
     if override:
         candidate = Path(override).expanduser()
@@ -80,6 +84,8 @@ def _discover_rust_binary() -> Path | None:
 
     # Build artifacts, then a sibling-worktree fallback (pre-merge).
     candidates = [
+        REPO_ROOT / "experimental" / "pulp-rs" / "target" / "release" / "pulp",
+        REPO_ROOT / "experimental" / "pulp-rs" / "target" / "debug" / "pulp",
         REPO_ROOT / "experimental" / "pulp-rs" / "target" / "release" / "pulp-rs",
         REPO_ROOT / "experimental" / "pulp-rs" / "target" / "debug" / "pulp-rs",
     ]
@@ -88,6 +94,8 @@ def _discover_rust_binary() -> Path | None:
     if not (REPO_ROOT / "experimental").exists():
         for sibling in REPO_ROOT.parent.glob("pulp*"):
             for rel in (
+                "experimental/pulp-rs/target/release/pulp",
+                "experimental/pulp-rs/target/debug/pulp",
                 "experimental/pulp-rs/target/release/pulp-rs",
                 "experimental/pulp-rs/target/debug/pulp-rs",
             ):
@@ -109,8 +117,8 @@ def cpp_binary() -> Path:
     path = _discover_cpp_binary()
     if path is None:
         pytest.skip(
-            "C++ pulp binary not found. Set PULP_CPP_BINARY_FOR_TEST "
-            "or build build/tools/cli/pulp."
+            "C++ pulp-cpp binary not found. Set PULP_CPP_BINARY_FOR_TEST "
+            "or build build/tools/cli/pulp-cpp."
         )
     return path
 
@@ -120,7 +128,7 @@ def rust_binary() -> Path:
     path = _discover_rust_binary()
     if path is None:
         pytest.skip(
-            "Rust pulp-rs binary not found. Set PULP_RS_BINARY_FOR_TEST "
+            "Rust pulp binary not found. Set PULP_RS_BINARY_FOR_TEST "
             "or `cargo build --release` under experimental/pulp-rs/."
         )
     return path

--- a/tools/scripts/install.ps1
+++ b/tools/scripts/install.ps1
@@ -83,7 +83,22 @@ if (-not (Test-Path $PulpExe)) {
     exit 1
 }
 
-Write-Host "  Installed: pulp v$Version"
+try {
+    $InstalledVersion = (& $PulpExe version 2>$null | Select-Object -First 1)
+} catch {
+    $InstalledVersion = $null
+}
+if (-not $InstalledVersion) {
+    $InstalledVersion = "pulp v$Version"
+}
+Write-Host "  Installed: $InstalledVersion"
+
+$PulpCppExe = Join-Path $InstallDir "pulp-cpp.exe"
+if (Test-Path $PulpCppExe) {
+    Write-Host "  Installed: pulp-cpp delegate"
+} else {
+    Write-Host "  No pulp-cpp delegate found; this is expected only for pre-0.78.0 releases."
+}
 
 # ── Add to PATH ─────────────────────────────────────────────────────────────
 

--- a/tools/scripts/install.sh
+++ b/tools/scripts/install.sh
@@ -33,7 +33,7 @@ case "$OS" in
 esac
 
 case "$ARCH" in
-    x86_64|amd64)  ARCH="x86_64" ;;
+    x86_64|amd64)  ARCH="x64" ;;
     arm64|aarch64) ARCH="arm64" ;;
     *)             error "Unsupported architecture: $ARCH" ;;
 esac
@@ -50,7 +50,7 @@ if [ "$VERSION" = "latest" ]; then
     fi
 fi
 
-TARBALL="pulp-${VERSION}-${PLATFORM}-${ARCH}.tar.gz"
+TARBALL="pulp-${PLATFORM}-${ARCH}.tar.gz"
 URL="https://github.com/${GITHUB_REPO}/releases/download/v${VERSION}/${TARBALL}"
 
 # ── Download and install ────────────────────────────────────────────────────
@@ -90,8 +90,17 @@ if [ ! -x "${INSTALL_DIR}/pulp" ]; then
     error "Installation failed — ${INSTALL_DIR}/pulp not found or not executable."
 fi
 
-INSTALLED_VERSION=$("${INSTALL_DIR}/pulp" --version 2>/dev/null || echo "unknown")
-info "Installed: pulp ${INSTALLED_VERSION}"
+INSTALLED_VERSION=$("${INSTALL_DIR}/pulp" version 2>/dev/null | head -n 1 || echo "unknown")
+if [ -z "$INSTALLED_VERSION" ]; then
+    INSTALLED_VERSION="unknown"
+fi
+info "Installed: ${INSTALLED_VERSION}"
+
+if [ -x "${INSTALL_DIR}/pulp-cpp" ]; then
+    info "Installed: pulp-cpp delegate"
+else
+    info "No pulp-cpp delegate found; this is expected only for pre-0.78.0 releases."
+fi
 
 # ── Add to PATH ─────────────────────────────────────────────────────────────
 

--- a/tools/scripts/package_cli.py
+++ b/tools/scripts/package_cli.py
@@ -21,7 +21,7 @@ single-binary contract, so pre-swap release lanes stay byte-identical.
 
 Usage (called from .github/workflows/release-cli.yml):
     python3 tools/scripts/package_cli.py \\
-        --binary build/tools/cli/pulp \\
+        --binary build/pulp \\
         --cpp-binary build/tools/cli/pulp-cpp \\
         --build-dir build \\
         --platform darwin-arm64 \\


### PR DESCRIPTION
## Summary

Draft follow-up to #1005. Phase 8 migration prep is now on `main` via merge commit `bd036171`; this branch rebases the flip work onto that commit and makes the Rust CLI the user-facing `pulp` binary while preserving the C++ CLI as `pulp-cpp` for fallthrough.

This PR is intentionally draft. Do not merge until the release/upgrade path and cloud CI are green and someone explicitly signs off.

## What changes

- Rust CLI cargo/CMake binary name becomes `pulp`.
- C++ CLI target/output becomes `pulp-cpp`.
- Release CLI packaging bundles both binaries in the same archive.
- Release smoke coverage verifies the Rust path and the C++ delegate path.
- Rust top-level help and unknown-command suggestions now say `pulp`, not `pulp-rs`.
- CI/ship agent notes document the Phase 8 dual-binary release contract.

## Existing repo guidance

Existing Pulp repos should keep invoking `pulp ...`; normal project source changes are not expected just because the launcher implementation changes.

After this eventually lands in a release:

- `pulp` is the Rust CLI.
- `pulp-cpp` is installed as a sibling delegate for commands still owned by C++.
- For rollback/debug, compare behavior with `PULP_USE_CPP=1 pulp <args>` or direct `pulp-cpp <args>`.
- Do not assume a public `pulp-rs` binary exists.
- Do not hand-swap user/system install locations; use the packaged upgrade flow.

## Coordination with #1387 harness work

The active harness work from #1387 can continue without branch collisions. This flip PR does not touch #1395-#1399 branches. The important contract is that C++-owned commands keep working through Rust fallthrough once the sibling `pulp-cpp` binary exists.

If harness agents add commands or help entries before this merges, this branch should absorb that drift in Rust help/fallthrough tables and release smoke checks, not duplicate or overwrite the harness implementation.

## Local validation

Run locally in `/Users/danielraffel/Code/pulp-phase8-flip-prepped`:

- `git fetch origin main` -> `origin/main=bd036171`, branch is `0 3` against `origin/main`.
- `git diff --check origin/main...HEAD`
- `python3 tools/scripts/skill_sync_check.py`
- `python3 tools/scripts/test_package_cli.py && python3 tools/scripts/test_package_cli_extra.py`
- `yamllint --no-warnings -d relaxed .github/workflows/`
- `python3 tools/scripts/test_workflow_lint.py`
- `actionlint -shellcheck= .github/workflows/release-cli.yml`
- `cargo test` in `experimental/pulp-rs` (`604` unit tests, all integration tests, `6` doctests)
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target pulp-rust-cli pulp-cli -j$(sysctl -n hw.ncpu)`
- `./build/pulp help` shows `pulp` banner/usage.
- `./build/pulp buld` suggests `pulp build`.
- `PULP_RS_CPP_BINARY=/Users/danielraffel/Code/pulp-phase8-flip-prepped/build/tools/cli/pulp-cpp ./build/pulp harness --all --json` delegated through C++ and reported `494` total harness cases across `canvas2d`, `css`, `html`, `rn`, `yoga`.
- `PULP_CPP_BINARY_FOR_TEST=/Users/danielraffel/Code/pulp-phase8-flip-prepped/build/tools/cli/pulp-cpp PULP_RS_BINARY_FOR_TEST=/Users/danielraffel/Code/pulp-phase8-flip-prepped/build/pulp uv tool run pytest tools/sandbox-e2e/` -> `42 passed`.

Local pre-push note: diff-cover was demoted with `PULP_DISABLE_PREPUSH_DIFF_COVER=1` because this machine is missing `llvm-cov`/`llvm-profdata`. CI still needs to validate coverage gates before merge.

## Agent prompt

```text
Context: Pulp Phase 8 Rust CLI migration prep landed on main via #1005. A draft flip PR is in progress to make Rust the default `pulp` binary and rename the C++ CLI to `pulp-cpp`.

When working in any Pulp repo:
- Continue invoking `pulp ...`; do not assume `pulp-rs` exists.
- If a command behaves differently, compare with `PULP_USE_CPP=1 pulp ...` or `pulp-cpp ...`.
- Do not edit user/system install locations or hand-swap binaries.
- Preserve dual-binary packaging: Rust `pulp` plus C++ `pulp-cpp`.
- Treat CLI/help/release packaging/fallthrough drift as the main risk.
- For C++-owned commands, expect Rust to delegate to `pulp-cpp`; do not port or duplicate those commands unless explicitly assigned.
- Report discrepancies with exact command, cwd, env vars, exit codes, stdout/stderr from both Rust and C++ paths.
```
