### PR TITLE
fix(rn): forward percent strings + 'auto' for width/height/min/max/flexBasis (rn Batch C, refs pulp #1434)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -1028,15 +1028,15 @@
       "status": "partial",
       "mapsTo": "setFlex(id, 'flex_basis', px)",
       "supportedValues": [
-        "px"
+        "px",
+        "%",
+        "auto"
       ],
       "unsupportedValues": [
-        "%",
-        "auto",
         "content"
       ],
       "tests": [],
-      "notes": "Yoga supports 'auto' and percentages; Pulp accepts only px float.",
+      "notes": "Yoga supports 'auto' and percentages; Pulp accepts only px float. pulp #1434 rn batch C: % and auto wired via FlexStyle::dim_flex_basis.",
       "issue": ""
     },
     "css/flexDirection": {
@@ -1321,7 +1321,7 @@
       "issue": ""
     },
     "css/height": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "setFlex(id, 'height', px)",
       "supportedValues": [
         "px (number)"
@@ -1676,59 +1676,59 @@
       "issue": ""
     },
     "css/maxHeight": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "setFlex(id, 'max_height', px)",
       "supportedValues": [
-        "px (number)"
+        "px (number)",
+        "%"
       ],
       "unsupportedValues": [
-        "%",
         "calc()"
       ],
       "tests": [],
-      "notes": "Same as max-width.",
+      "notes": "Same as max-width. pulp #1434 rn batch C: % values now route through FlexStyle::dim_*.unit \u2192 Yoga percent API.",
       "issue": ""
     },
     "css/maxWidth": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "setFlex(id, 'max_width', px)",
       "supportedValues": [
-        "px (number)"
+        "px (number)",
+        "%"
       ],
       "unsupportedValues": [
-        "%",
         "calc()"
       ],
       "tests": [],
-      "notes": "0 = no maximum (semantic differs from CSS where unspecified = none).",
+      "notes": "0 = no maximum (semantic differs from CSS where unspecified = none). pulp #1434 rn batch C: % values now route through FlexStyle::dim_*.unit \u2192 Yoga percent API.",
       "issue": ""
     },
     "css/minHeight": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "setFlex(id, 'min_height', px)",
       "supportedValues": [
-        "px (number)"
+        "px (number)",
+        "%"
       ],
       "unsupportedValues": [
-        "%",
         "calc()"
       ],
       "tests": [],
-      "notes": "",
+      "notes": "pulp #1434 rn batch C: % values now route through FlexStyle::dim_*.unit \u2192 Yoga percent API.",
       "issue": ""
     },
     "css/minWidth": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "setFlex(id, 'min_width', px)",
       "supportedValues": [
-        "px (number)"
+        "px (number)",
+        "%"
       ],
       "unsupportedValues": [
-        "%",
         "calc()"
       ],
       "tests": [],
-      "notes": "",
+      "notes": "pulp #1434 rn batch C: % values now route through FlexStyle::dim_*.unit \u2192 Yoga percent API.",
       "issue": ""
     },
     "css/mixBlendMode": {
@@ -2609,7 +2609,7 @@
       "issue": ""
     },
     "css/width": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "setFlex(id, 'width', px)",
       "supportedValues": [
         "px (number)"
@@ -3243,14 +3243,15 @@
       "status": "partial",
       "mapsTo": "setFlex(id, 'flex_basis', n)",
       "supportedValues": [
-        "number (px)"
+        "number (px)",
+        "string % (e.g. '40%')",
+        "'auto'"
       ],
       "unsupportedValues": [
-        "string %",
-        "auto"
+        "content"
       ],
       "tests": [],
-      "notes": "TS type is 'number' only.",
+      "notes": "TS type is 'number' only. pulp #1434 rn batch C: bridge accepts number / \"NN%\" / \"auto\"; FlexStyle::dim_flex_basis.unit drives YGNodeStyleSetFlexBasis{,Percent,Auto}.",
       "issue": ""
     },
     "rn/flexDirection": {
@@ -3378,18 +3379,18 @@
       "issue": ""
     },
     "rn/height": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "setFlex(id, 'height', n)",
       "supportedValues": [
-        "number"
+        "number (px)",
+        "string % (e.g. '50%')"
       ],
       "unsupportedValues": [
-        "string %",
         "string vh",
         "auto"
       ],
       "tests": [],
-      "notes": "TS type is `number` only.",
+      "notes": "TS type is `number` only. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_height.unit. auto remains a follow-up.",
       "issue": ""
     },
     "rn/includeFontPadding": {
@@ -3613,52 +3614,48 @@
       "status": "supported",
       "mapsTo": "setFlex(id, 'max_height', n)",
       "supportedValues": [
-        "number"
+        "number (px)",
+        "string % (e.g. '50%')"
       ],
-      "unsupportedValues": [
-        "%"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_height.unit \u2192 YGNodeStyleSetMaxHeightPercent.",
       "issue": ""
     },
     "rn/maxWidth": {
       "status": "supported",
       "mapsTo": "setFlex(id, 'max_width', n)",
       "supportedValues": [
-        "number"
+        "number (px)",
+        "string % (e.g. '50%')"
       ],
-      "unsupportedValues": [
-        "%"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMaxWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_max_width.unit \u2192 YGNodeStyleSetMaxWidthPercent.",
       "issue": ""
     },
     "rn/minHeight": {
       "status": "supported",
       "mapsTo": "setFlex(id, 'min_height', n)",
       "supportedValues": [
-        "number"
+        "number (px)",
+        "string % (e.g. '50%')"
       ],
-      "unsupportedValues": [
-        "%"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit; yoga_layout.cpp routes to YGNodeStyleSetMinHeightPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_height.unit \u2192 YGNodeStyleSetMinHeightPercent.",
       "issue": ""
     },
     "rn/minWidth": {
       "status": "supported",
       "mapsTo": "setFlex(id, 'min_width', n)",
       "supportedValues": [
-        "number"
+        "number (px)",
+        "string % (e.g. '50%')"
       ],
-      "unsupportedValues": [
-        "%"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit; yoga_layout.cpp routes to YGNodeStyleSetMinWidthPercent. pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_min_width.unit \u2192 YGNodeStyleSetMinWidthPercent.",
       "issue": ""
     },
     "rn/mixBlendMode": {
@@ -4175,17 +4172,17 @@
       "issue": "994"
     },
     "rn/width": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "setFlex(id, 'width', n)",
       "supportedValues": [
-        "number"
+        "number (px)",
+        "string % (e.g. '50%')"
       ],
       "unsupportedValues": [
-        "string %",
         "auto"
       ],
       "tests": [],
-      "notes": "",
+      "notes": "pulp #1434 rn batch C: prop-applier forwards string|number; bridge dispatches percent via FlexStyle::dim_width.unit (#1426 path). auto remains a follow-up.",
       "issue": ""
     },
     "rn/writingDirection": {
@@ -4269,15 +4266,15 @@
       "status": "partial",
       "mapsTo": "FlexStyle.flex_basis (float, -1 = preferred)",
       "supportedValues": [
-        "px"
+        "px",
+        "%",
+        "auto"
       ],
       "unsupportedValues": [
-        "auto",
-        "%",
         "content"
       ],
       "tests": [],
-      "notes": "Yoga upstream supports YGAuto / percent; Pulp accepts only px float.",
+      "notes": "Yoga upstream supports YGAuto / percent; Pulp accepts only px float. pulp #1434 rn batch C: bridge accepts NN% and the \"auto\" keyword; FlexStyle::dim_flex_basis drives YGNodeStyleSetFlexBasis{,Percent,Auto}. content remains unsupported.",
       "issue": ""
     },
     "yoga/justifyContent": {
@@ -4374,52 +4371,48 @@
       "status": "supported",
       "mapsTo": "FlexStyle.min_width",
       "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
+        "px",
         "%"
       ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "",
+      "notes": "pulp #1434 rn batch C: bridge populates FlexStyle::dim_min_width.unit; yoga_layout.cpp dispatches to YGNodeStyleSetMinWidthPercent.",
       "issue": ""
     },
     "yoga/minHeight": {
       "status": "supported",
       "mapsTo": "FlexStyle.min_height",
       "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
+        "px",
         "%"
       ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "",
+      "notes": "pulp #1434 rn batch C: bridge populates FlexStyle::dim_min_height.unit; yoga_layout.cpp dispatches to YGNodeStyleSetMinHeightPercent.",
       "issue": ""
     },
     "yoga/maxWidth": {
       "status": "supported",
       "mapsTo": "FlexStyle.max_width (0 = no max)",
       "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
+        "px",
         "%"
       ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "Semantic of 0 differs from CSS unspecified.",
+      "notes": "Semantic of 0 differs from CSS unspecified. pulp #1434 rn batch C: bridge populates FlexStyle::dim_max_width.unit; yoga_layout.cpp dispatches to YGNodeStyleSetMaxWidthPercent.",
       "issue": ""
     },
     "yoga/maxHeight": {
       "status": "supported",
       "mapsTo": "FlexStyle.max_height",
       "supportedValues": [
-        "px"
-      ],
-      "unsupportedValues": [
+        "px",
         "%"
       ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "",
+      "notes": "pulp #1434 rn batch C: bridge populates FlexStyle::dim_max_height.unit; yoga_layout.cpp dispatches to YGNodeStyleSetMaxHeightPercent.",
       "issue": ""
     },
     "yoga/aspectRatio": {

--- a/core/view/include/pulp/view/geometry.hpp
+++ b/core/view/include/pulp/view/geometry.hpp
@@ -164,10 +164,20 @@ struct FlexStyle {
 
     /// Viewport-relative dimension overrides. When set (unit != px with value 0),
     /// these are resolved before layout and override the corresponding float fields.
+    /// Yoga's native percent / auto APIs are dispatched on these in
+    /// `yoga_layout.cpp::apply_flex_style` when `unit != px`.
+    /// pulp #1434 (rn batch C) — added `dim_max_width` / `dim_max_height` /
+    /// `dim_flex_basis` so percent and `auto` strings on max-* and flex-basis
+    /// reach Yoga's `YGNodeStyleSet{MaxWidth,MaxHeight,FlexBasis}Percent` and
+    /// `YGNodeStyleSetFlexBasisAuto` instead of being truncated to plain
+    /// floats. min_* already had Dimension fields from earlier work.
     Dimension dim_width;
     Dimension dim_height;
     Dimension dim_min_width;
     Dimension dim_min_height;
+    Dimension dim_max_width;
+    Dimension dim_max_height;
+    Dimension dim_flex_basis;
 
     /// Resolve viewport-relative dimensions and apply to float fields.
     /// Call before layout pass with the viewport size.

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1677,7 +1677,29 @@ void WidgetBridge::register_api() {
         else if (key == "padding_left") f.padding_left = (float)val;
         else if (key == "flex_grow") f.flex_grow = (float)val;
         else if (key == "flex_shrink") f.flex_shrink = (float)val;
-        else if (key == "flex_basis") f.flex_basis = (float)val;
+        // pulp #1434 (rn batch C) — flex_basis accepts a number ("100"
+        // → px), a percentage string ("50%" → percent of parent), or
+        // the keyword "auto" (Yoga's YGAuto: "use the preferred size").
+        // The unit lives on FlexStyle::dim_flex_basis; yoga_layout.cpp
+        // dispatches to YGNodeStyleSetFlexBasis{Percent,Auto} for the
+        // non-px paths.
+        else if (key == "flex_basis") {
+            auto sval = args.get<std::string>(2, "");
+            if (sval == "auto") {
+                f.dim_flex_basis.unit = pulp::view::DimensionUnit::auto_;
+                f.flex_basis = -1; // sentinel: use preferred
+            } else if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_flex_basis.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_flex_basis.unit = pulp::view::DimensionUnit::percent;
+                    f.flex_basis = -1;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.flex_basis = (float)val;
+                f.dim_flex_basis.value = (float)val;
+                f.dim_flex_basis.unit = pulp::view::DimensionUnit::px;
+            }
+        }
         else if (key == "flex_wrap") f.flex_wrap = val > 0;
         else if (key == "order") f.order = (int)val;
         // pulp #1423 — width/height accept either a number ("100" → px)
@@ -1714,10 +1736,68 @@ void WidgetBridge::register_api() {
                 f.dim_height.unit = pulp::view::DimensionUnit::px;
             }
         }
-        else if (key == "min_width") f.min_width = (float)val;
-        else if (key == "min_height") f.min_height = (float)val;
-        else if (key == "max_width") f.max_width = (float)val;
-        else if (key == "max_height") f.max_height = (float)val;
+        // pulp #1434 (rn batch C) — min/max width/height accept either a
+        // number ("100" → px) or a percentage string ("50%" → percent of
+        // parent). Same shape as #1426's width/height: store unit on
+        // FlexStyle::dim_*; yoga_layout.cpp dispatches to
+        // YGNodeStyleSet{Min,Max}{Width,Height}Percent for the percent
+        // path and the existing px API otherwise.
+        else if (key == "min_width") {
+            auto sval = args.get<std::string>(2, "");
+            if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_min_width.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_min_width.unit = pulp::view::DimensionUnit::percent;
+                    f.min_width = 0;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.min_width = (float)val;
+                f.dim_min_width.value = (float)val;
+                f.dim_min_width.unit = pulp::view::DimensionUnit::px;
+            }
+        }
+        else if (key == "min_height") {
+            auto sval = args.get<std::string>(2, "");
+            if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_min_height.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_min_height.unit = pulp::view::DimensionUnit::percent;
+                    f.min_height = 0;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.min_height = (float)val;
+                f.dim_min_height.value = (float)val;
+                f.dim_min_height.unit = pulp::view::DimensionUnit::px;
+            }
+        }
+        else if (key == "max_width") {
+            auto sval = args.get<std::string>(2, "");
+            if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_max_width.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_max_width.unit = pulp::view::DimensionUnit::percent;
+                    f.max_width = 0;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.max_width = (float)val;
+                f.dim_max_width.value = (float)val;
+                f.dim_max_width.unit = pulp::view::DimensionUnit::px;
+            }
+        }
+        else if (key == "max_height") {
+            auto sval = args.get<std::string>(2, "");
+            if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_max_height.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_max_height.unit = pulp::view::DimensionUnit::percent;
+                    f.max_height = 0;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.max_height = (float)val;
+                f.dim_max_height.value = (float)val;
+                f.dim_max_height.unit = pulp::view::DimensionUnit::px;
+            }
+        }
         // Aspect ratio (pulp #1434) — width/height ratio. A value <= 0 or
         // NaN clears the slot (matches CSS `aspect-ratio: auto`); a finite
         // positive value pins the slot. The CSS shim in

--- a/core/view/src/yoga_layout.cpp
+++ b/core/view/src/yoga_layout.cpp
@@ -63,7 +63,16 @@ static void apply_flex_style(YGNodeRef node, const FlexStyle& f, bool is_absolut
         // containing block sizing path, not the flex line.
         YGNodeStyleSetFlexGrow(node, f.flex_grow);
         YGNodeStyleSetFlexShrink(node, f.flex_shrink);
-        if (f.flex_basis >= 0) YGNodeStyleSetFlexBasis(node, f.flex_basis);
+        // pulp #1434 (rn batch C) — dispatch flex_basis on dim_*.unit:
+        // `'auto'` → YGNodeStyleSetFlexBasisAuto; `'50%'` →
+        // YGNodeStyleSetFlexBasisPercent; numeric → existing px API.
+        if (f.dim_flex_basis.unit == DimensionUnit::auto_) {
+            YGNodeStyleSetFlexBasisAuto(node);
+        } else if (f.dim_flex_basis.unit == DimensionUnit::percent && f.dim_flex_basis.value > 0) {
+            YGNodeStyleSetFlexBasisPercent(node, f.dim_flex_basis.value);
+        } else if (f.flex_basis >= 0) {
+            YGNodeStyleSetFlexBasis(node, f.flex_basis);
+        }
     } else {
         // Be explicit: zero them so a previously-set Yoga node (we don't
         // recycle here today, but defensively) doesn't carry residue, and
@@ -116,10 +125,20 @@ static void apply_flex_style(YGNodeRef node, const FlexStyle& f, bool is_absolut
     } else if (f.preferred_height > 0) {
         YGNodeStyleSetHeight(node, f.preferred_height);
     }
-    if (f.min_width > 0) YGNodeStyleSetMinWidth(node, f.min_width);
-    if (f.min_height > 0) YGNodeStyleSetMinHeight(node, f.min_height);
-    if (f.max_width > 0) YGNodeStyleSetMaxWidth(node, f.max_width);
-    if (f.max_height > 0) YGNodeStyleSetMaxHeight(node, f.max_height);
+    // pulp #1434 (rn batch C) — min/max width/height dispatch on dim_*.unit
+    // for the percent path; existing px path stays for numeric values.
+    if (f.dim_min_width.unit == DimensionUnit::percent && f.dim_min_width.value > 0) {
+        YGNodeStyleSetMinWidthPercent(node, f.dim_min_width.value);
+    } else if (f.min_width > 0) YGNodeStyleSetMinWidth(node, f.min_width);
+    if (f.dim_min_height.unit == DimensionUnit::percent && f.dim_min_height.value > 0) {
+        YGNodeStyleSetMinHeightPercent(node, f.dim_min_height.value);
+    } else if (f.min_height > 0) YGNodeStyleSetMinHeight(node, f.min_height);
+    if (f.dim_max_width.unit == DimensionUnit::percent && f.dim_max_width.value > 0) {
+        YGNodeStyleSetMaxWidthPercent(node, f.dim_max_width.value);
+    } else if (f.max_width > 0) YGNodeStyleSetMaxWidth(node, f.max_width);
+    if (f.dim_max_height.unit == DimensionUnit::percent && f.dim_max_height.value > 0) {
+        YGNodeStyleSetMaxHeightPercent(node, f.dim_max_height.value);
+    } else if (f.max_height > 0) YGNodeStyleSetMaxHeight(node, f.max_height);
 
     // Aspect ratio (pulp #1434) — Yoga sizes the cross axis from the main
     // axis using `width / height`. Only forward when explicitly set so the

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -266,15 +266,21 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
             return;
         case 'flexGrow':        return call('setFlex', id, 'flex_grow', value as number);
         case 'flexShrink':      return call('setFlex', id, 'flex_shrink', value as number);
-        case 'flexBasis':       return call('setFlex', id, 'flex_basis', value as number);
+        // pulp #1434 (rn batch C) — dimension keys forward
+        // `number | string` so the bridge sees `'50%'` / `'auto'`
+        // verbatim. Numeric values still flow through unchanged.
+        // The bridge's setFlex case for each key inspects the third
+        // arg as a string and detects '%' / 'auto' suffix; otherwise
+        // it falls back to the numeric path.
+        case 'flexBasis':       return call('setFlex', id, 'flex_basis', value as number | string);
         case 'flexWrap':        return call('setFlex', id, 'flex_wrap', value ? 1 : 0);
         case 'order':           return call('setFlex', id, 'order', value as number);
-        case 'width':           return call('setFlex', id, 'width', value as number);
-        case 'height':          return call('setFlex', id, 'height', value as number);
-        case 'minWidth':        return call('setFlex', id, 'min_width', value as number);
-        case 'minHeight':       return call('setFlex', id, 'min_height', value as number);
-        case 'maxWidth':        return call('setFlex', id, 'max_width', value as number);
-        case 'maxHeight':       return call('setFlex', id, 'max_height', value as number);
+        case 'width':           return call('setFlex', id, 'width', value as number | string);
+        case 'height':          return call('setFlex', id, 'height', value as number | string);
+        case 'minWidth':        return call('setFlex', id, 'min_width', value as number | string);
+        case 'minHeight':       return call('setFlex', id, 'min_height', value as number | string);
+        case 'maxWidth':        return call('setFlex', id, 'max_width', value as number | string);
+        case 'maxHeight':       return call('setFlex', id, 'max_height', value as number | string);
         case 'alignItems':      return call('setFlex', id, 'align_items', value as string);
         case 'alignSelf':       return call('setFlex', id, 'align_self', value as string);
         case 'justifyContent':  return call('setFlex', id, 'justify_content', value as string);

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -46,15 +46,22 @@ export interface FlexProps {
     marginVertical?: number;
     flexGrow?: number;
     flexShrink?: number;
-    flexBasis?: number;
+    /// pulp #1434 (rn batch C) — accepts number (px), percentage string
+    /// (`'50%'`), or the keyword `'auto'`. The keyword maps to Yoga's
+    /// `YGNodeStyleSetFlexBasisAuto`; percent maps to
+    /// `YGNodeStyleSetFlexBasisPercent`.
+    flexBasis?: number | string;
     flexWrap?: boolean;
     order?: number;
-    width?: number;
-    height?: number;
-    minWidth?: number;
-    minHeight?: number;
-    maxWidth?: number;
-    maxHeight?: number;
+    /// pulp #1434 (rn batch C) — number (px) or percent string
+    /// (`'100%'`). Yoga's percent API is dispatched on
+    /// `FlexStyle::dim_*.unit` in `yoga_layout.cpp`.
+    width?: number | string;
+    height?: number | string;
+    minWidth?: number | string;
+    minHeight?: number | string;
+    maxWidth?: number | string;
+    maxHeight?: number | string;
     alignItems?: FlexAlign;
     alignSelf?: FlexAlignSelf;
     justifyContent?: FlexJustify;

--- a/packages/pulp-react/test/prop-applier-dimensions.test.ts
+++ b/packages/pulp-react/test/prop-applier-dimensions.test.ts
@@ -1,0 +1,92 @@
+// pulp #1434 (rn batch C) — verify the @pulp/react prop-applier
+// forwards dimension props as `number | string` so percent strings
+// (`'50%'`) and the `'auto'` keyword (flexBasis) reach the bridge
+// verbatim. The bridge's setFlex case for each dimension key
+// dispatches percent values to Yoga's
+// `YGNodeStyleSet{Width,Height,Min*,Max*,FlexBasis}Percent` API and
+// `'auto'` to `YGNodeStyleSetFlexBasisAuto`.
+//
+// Before this batch, the prop-applier cast `value as number` for these
+// keys, which silently coerced strings to NaN at the bridge boundary
+// and dropped the percent / auto signal entirely.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyChangedProps } from '../src/prop-applier.js';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import type { PulpInstance } from '../src/types.js';
+
+let bridge: MockBridge;
+
+beforeEach(() => {
+    bridge = createMockBridge();
+    bridge.install();
+});
+afterEach(() => {
+    bridge.uninstall();
+});
+
+function makeInstance(id: string = 'k', type: string = 'View'): PulpInstance {
+    return {
+        id,
+        type: type as PulpInstance['type'],
+        props: {},
+        childIds: [],
+        onBridge: true,
+        pendingChildren: [],
+    };
+}
+
+function flexCalls(b: MockBridge, slot: string) {
+    return b.calls.filter((c) => c.fn === 'setFlex' && c.args[1] === slot);
+}
+
+describe('prop-applier dimension percent strings (pulp #1434 batch C)', () => {
+    it.each([
+        ['width',     'width'],
+        ['height',    'height'],
+        ['minWidth',  'min_width'],
+        ['minHeight', 'min_height'],
+        ['maxWidth',  'max_width'],
+        ['maxHeight', 'max_height'],
+    ])('%s forwards percent string verbatim to setFlex(%s)', (jsxKey, slot) => {
+        applyChangedProps(makeInstance(), {}, { [jsxKey]: '50%' });
+        const calls = flexCalls(bridge, slot);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['k', slot, '50%']);
+    });
+
+    it.each([
+        ['width',     'width',      120],
+        ['height',    'height',     80],
+        ['minWidth',  'min_width',  40],
+        ['minHeight', 'min_height', 30],
+        ['maxWidth',  'max_width',  200],
+        ['maxHeight', 'max_height', 150],
+    ])('%s forwards numeric value verbatim to setFlex(%s)', (jsxKey, slot, value) => {
+        applyChangedProps(makeInstance(), {}, { [jsxKey]: value });
+        const calls = flexCalls(bridge, slot);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['k', slot, value]);
+    });
+
+    it('flexBasis forwards percent string verbatim', () => {
+        applyChangedProps(makeInstance(), {}, { flexBasis: '40%' });
+        const calls = flexCalls(bridge, 'flex_basis');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['k', 'flex_basis', '40%']);
+    });
+
+    it('flexBasis forwards "auto" keyword verbatim', () => {
+        applyChangedProps(makeInstance(), {}, { flexBasis: 'auto' });
+        const calls = flexCalls(bridge, 'flex_basis');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['k', 'flex_basis', 'auto']);
+    });
+
+    it('flexBasis forwards numeric value as number', () => {
+        applyChangedProps(makeInstance(), {}, { flexBasis: 80 });
+        const calls = flexCalls(bridge, 'flex_basis');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['k', 'flex_basis', 80]);
+    });
+});

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -4494,3 +4494,110 @@ TEST_CASE("setTop/setRight/setBottom/setLeft accept percent strings directly",
     REQUIRE(child->left_unit() == DimensionUnit::percent);
     REQUIRE_THAT(child->left(), WithinAbs(0.0f, 0.001f));
 }
+
+// ── pulp #1434 (rn batch C) — dimension percent strings ─────────────────────
+//
+// `min_width`/`min_height`/`max_width`/`max_height`/`flex_basis` accept
+// either a number (px) or a percentage string (`'50%'`). `flex_basis`
+// also accepts `'auto'`. Yoga's `YGNodeStyleSet*Percent` /
+// `YGNodeStyleSetFlexBasisAuto` APIs are dispatched on
+// `FlexStyle::dim_*.unit` in `yoga_layout.cpp`.
+
+TEST_CASE("setFlex min/max width/height accept percent strings",
+          "[view][bridge][css][issue-1434-rn-batch-c]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 200});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('child', '');
+        setFlex('child', 'min_width', '25%');
+        setFlex('child', 'min_height', '15%');
+        setFlex('child', 'max_width', '75%');
+        setFlex('child', 'max_height', '90%');
+    )");
+
+    auto* child = bridge.widget("child");
+    REQUIRE(child != nullptr);
+    const auto& f = child->flex();
+
+    REQUIRE(f.dim_min_width.unit == DimensionUnit::percent);
+    REQUIRE_THAT(f.dim_min_width.value, WithinAbs(25.0f, 0.001f));
+    REQUIRE(f.dim_min_height.unit == DimensionUnit::percent);
+    REQUIRE_THAT(f.dim_min_height.value, WithinAbs(15.0f, 0.001f));
+    REQUIRE(f.dim_max_width.unit == DimensionUnit::percent);
+    REQUIRE_THAT(f.dim_max_width.value, WithinAbs(75.0f, 0.001f));
+    REQUIRE(f.dim_max_height.unit == DimensionUnit::percent);
+    REQUIRE_THAT(f.dim_max_height.value, WithinAbs(90.0f, 0.001f));
+}
+
+TEST_CASE("setFlex min/max width/height numeric path stays px",
+          "[view][bridge][css][issue-1434-rn-batch-c]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('child', '');
+        setFlex('child', 'min_width', 50);
+        setFlex('child', 'min_height', 30);
+        setFlex('child', 'max_width', 200);
+        setFlex('child', 'max_height', 150);
+    )");
+
+    const auto& f = bridge.widget("child")->flex();
+    REQUIRE(f.dim_min_width.unit == DimensionUnit::px);
+    REQUIRE_THAT(f.min_width, WithinAbs(50.0f, 0.001f));
+    REQUIRE_THAT(f.min_height, WithinAbs(30.0f, 0.001f));
+    REQUIRE_THAT(f.max_width, WithinAbs(200.0f, 0.001f));
+    REQUIRE_THAT(f.max_height, WithinAbs(150.0f, 0.001f));
+}
+
+TEST_CASE("setFlex flex_basis accepts 'auto', percent string, and number",
+          "[view][bridge][css][issue-1434-rn-batch-c]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('a','');  setFlex('a', 'flex_basis', 'auto');
+        createPanel('b','');  setFlex('b', 'flex_basis', '40%');
+        createPanel('c','');  setFlex('c', 'flex_basis', 80);
+    )");
+
+    const auto& fa = bridge.widget("a")->flex();
+    REQUIRE(fa.dim_flex_basis.unit == DimensionUnit::auto_);
+
+    const auto& fb = bridge.widget("b")->flex();
+    REQUIRE(fb.dim_flex_basis.unit == DimensionUnit::percent);
+    REQUIRE_THAT(fb.dim_flex_basis.value, WithinAbs(40.0f, 0.001f));
+
+    const auto& fc = bridge.widget("c")->flex();
+    REQUIRE(fc.dim_flex_basis.unit == DimensionUnit::px);
+    REQUIRE_THAT(fc.flex_basis, WithinAbs(80.0f, 0.001f));
+}
+
+TEST_CASE("max_width percent caps the child at the resolved pixel size",
+          "[view][bridge][css][issue-1434-rn-batch-c]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 200});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('child', '');
+        setFlex('child', 'max_width', '50%');
+        setFlex('child', 'flex_grow', 1);
+    )");
+
+    auto* child = bridge.widget("child");
+    REQUIRE(child != nullptr);
+
+    root.layout_children();
+    REQUIRE(child->bounds().width <= 200.5f);
+}


### PR DESCRIPTION
## Summary

Cross-surface dimension percent forwarding fix. Mirrors #1426 (width/height) and #1451 (top/right/bottom/left) for the remaining 5 dimension keys: **min-width, min-height, max-width, max-height, flex-basis**. Plus the **`'auto'` keyword** on flex-basis (Yoga's YGAuto).

## Three-layer fix

**1. FlexStyle** (`geometry.hpp`) — added `dim_max_width`, `dim_max_height`, `dim_flex_basis` to mirror existing `dim_*` fields.

**2. Bridge** (`widget_bridge.cpp::setFlex`) — each affected key inspects 3rd arg as string:
- min/max width/height: detect `'NN%'` → populate `dim_*.unit = percent`
- flex_basis: also detects `'auto'` keyword → `dim_flex_basis.unit = auto_`
- Numeric values still flow through unchanged (px path)

**3. Yoga adapter** (`yoga_layout.cpp`) — dispatches on each key's `dim_*.unit`:
- min/max → `YGNodeStyleSet{Min,Max}{Width,Height}Percent` for percent path
- flex_basis → `YGNodeStyleSetFlexBasisAuto` for auto, `FlexBasisPercent` for percent

**4. @pulp/react prop-applier** (`prop-applier.ts`) — `as number` → `as number | string` for the 7 dimension keys (`width`, `height`, `minWidth`, `minHeight`, `maxWidth`, `maxHeight`, `flexBasis`). Numeric values still flow through unchanged.

**5. types.ts** — broadened `FlexProps` types for these 7 keys to `number | string`.

**6. Catalog** (`compat.json`) — 17 entries updated across yoga/css/rn:
- yoga + rn × {minWidth, minHeight, maxWidth, maxHeight}: claim `[px, %]`, status → supported (lifts to PASS).
- css × same 4 keys: claim `[px, %]`, status `partial` (calc() still unsupported — drift clears).
- yoga + css + rn × flexBasis: claim `[px, %, auto]`, status `partial` (content still unsupported — drift clears).
- rn/width, rn/height: status `supported` → `partial`; supportedValues add `'string %'`. Stays partial because `auto` is a separate follow-up.

## Test plan

**Catch2** (`test_widget_bridge.cpp` `[issue-1434-rn-batch-c]`):
- min/max width/height percent strings round-trip through the bridge → `dim_*.unit = percent`
- min/max numeric path stays px (regression guard)
- flex_basis 3-way dispatch: `'auto'` / `'40%'` / `80`
- Full Yoga round-trip: `max_width: '50%'` + `flex_grow: 1` on a 400px parent caps child at ≤200px

**vitest** (`packages/pulp-react/test/prop-applier-dimensions.test.ts`, **15 cases**):
- 6 keys × 2 (percent string + numeric) parameterized cases
- 3 flexBasis cases (`'auto'`, percent, number)

| Suite | Result |
|-------|--------|
| `pulp-test-widget-bridge [issue-1434-rn-batch-c]` | 4 cases / 21 assertions ✓ |
| `pulp-test-widget-bridge` (full) | 119 / 838 ✓ |
| `pulp-test-view` / `pulp-test-widgets` / `pulp-test-view-layout-widgets` | all green |
| `@pulp/react vitest` (full) | 13 files / 122 cases ✓ |

## Verification — `python3 tools/harness/verifier.py --all`

Origin/main baseline → after this PR:

| Surface | PASS | DIVERGE | drift | Δ PASS | Δ drift |
|---------|----:|--------:|------:|-------:|--------:|
| yoga | 10 → **14** | 31 → 27 | 23 → 19 | **+4** | **−4** |
| css | 29 → 29 | 87 → 87 | 68 → **62** | 0 | **−6** |
| rn | 31 → **35** | 26 → 22 | 32 → **26** | **+4** | **−6** |

**+8 PASS, −16 drift cleared.** Headline: yoga + rn × {minWidth, minHeight, maxWidth, maxHeight} → PASS (8 entries). css equivalents stay DIVERGE because `calc()` is still legitimately unsupported, but drift clears (status `partial` matches DIVERGE). flexBasis on all 3 surfaces clears drift the same way.

## Notes

- 3 Version-Bump skip trailers (incl. bare no-surface form) per the active batched-stack pattern.
- No Skill-Update needed — `web-compat-style-decl.js` was NOT touched (the JS shim already routes width/height through; min/max/flexBasis flow through prop-applier only).
- compat-sync + skill-sync gates both report "no mapped paths touched".
- No conflict with PR #1446 (canvas2d shadows), #1451 (yoga TRBL %), #1452 (yoga value-aliasing).

Refs pulp #1434.
