### PR TITLE
fix(rn): wire display: flex / none to existing visible/yoga path (refs pulp #1434)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -3158,16 +3158,17 @@
       "issue": ""
     },
     "rn/display": {
-      "status": "missing",
-      "mapsTo": "no prop. Use 'visible' (boolean) instead.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "none",
+      "status": "supported",
+      "mapsTo": "@pulp/react prop-applier dispatches `display: 'flex'` to setVisible(true) and `display: 'none'` to setVisible(false) (pulp #1434 Triage #12, prop-applier.ts:323+).",
+      "supportedValues": [
         "flex",
+        "none"
+      ],
+      "unsupportedValues": [
         "contents"
       ],
       "tests": [],
-      "notes": "@pulp/react users opt out via the boolean `visible` prop. No 'contents' equivalent.",
+      "notes": "@pulp/react users opt out via the boolean `visible` prop. No 'contents' equivalent. pulp #1434 (Triage #12): the prop-applier now accepts display: flex / none, mirroring the yoga side wired in #1422. \"contents\" remains unsupported (Yoga has no equivalent).",
       "issue": ""
     },
     "rn/elevation": {

--- a/docs/reference/compat/rn.md
+++ b/docs/reference/compat/rn.md
@@ -27,6 +27,12 @@ Spec walk:
 
 ## Recently changed
 
+- **2026-05-05 (pulp #1434 Triage #12)** — `rn/display` now accepts
+  `'flex'` and `'none'`. The `@pulp/react` prop-applier dispatches
+  `display: 'flex'` → `setVisible(id, true)` and `display: 'none'` →
+  `setVisible(id, false)`. Mirrors the yoga side wired in #1422.
+  Reclassified `missing` → `partial` (`'contents'` remains unsupported
+  — Yoga has no equivalent).
 - **2026-05-05 (pulp #1434 batch 6)** — `rn/top`, `rn/right`,
   `rn/bottom`, `rn/left` now accept percent strings (`'50%'`)
   alongside numeric pixel values. The `@pulp/react` prop-applier

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -321,6 +321,29 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         case 'borderBottomRightRadius': return call('setBorderBottomRightRadius', id, value as number);
         case 'opacity':      return call('setOpacity', id, value as number);
         case 'visible':      return call('setVisible', id, value as boolean);
+        // pulp #1434 (rn batch — Triage #12) — `display: 'flex' | 'none'`.
+        // RN exports + Figma / v0 / Claude Design HTML routinely emit
+        // `style={{ display: 'flex' }}` (the implicit default in pulp,
+        // but the prop-applier shouldn't drop it as unknown) or
+        // `style={{ display: 'none' }}` to hide a subtree. The yoga
+        // surface wired this for the CSS shim in #1422; this branch
+        // makes the same path reachable from RN-flavored JSX without a
+        // round-trip through the el.style proxy.
+        //
+        // 'none'  → setVisible(id, false). View::visible() is the
+        //           canonical "skip render + don't lay out" signal.
+        // 'flex'  → setVisible(id, true). Yoga's flex layout is pulp's
+        //           default; explicit 'flex' just confirms it.
+        // Anything else (block / inline-block / inline-flex / grid)
+        // is silently ignored at this layer — the CSS shim handles
+        // those for the el.style path; for RN consumers, the typical
+        // emission is just 'flex' / 'none'.
+        case 'display': {
+            const sval = String(value);
+            if (sval === 'none') return call('setVisible', id, false);
+            if (sval === 'flex') return call('setVisible', id, true);
+            return; // unknown display value — leave View at current visibility
+        }
         // pulp #1387 gap #1 — overflow was reachable via the DOM-lite
         // path (web-compat-style-decl.js routes 'overflow' to setOverflow)
         // but missing from the @pulp/react prop-applier, so JSX consumers

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -94,6 +94,13 @@ export interface StyleProps {
     borderBottomRightRadius?: number;
     opacity?: number;
     visible?: boolean;
+    /// CSS / RN `display` keyword (pulp #1434 Triage #12). `'none'`
+    /// hides the View (sets visible=false). `'flex'` is pulp's
+    /// implicit default and is accepted as a no-op confirmation. Other
+    /// keywords (`'block'` / `'inline-block'` / `'inline-flex'` /
+    /// `'grid'`) flow through the CSS shim only — for RN-flavored JSX
+    /// consumers, just `'flex'` / `'none'` are the meaningful values.
+    display?: 'flex' | 'none' | string;
 }
 
 // ── Common base props ──────────────────────────────────────────────

--- a/packages/pulp-react/test/prop-applier-display.test.ts
+++ b/packages/pulp-react/test/prop-applier-display.test.ts
@@ -1,0 +1,82 @@
+// pulp #1434 (Triage #12) — verify the @pulp/react prop-applier
+// dispatches `display: 'flex' | 'none'` to the right setVisible call.
+//
+// RN exports + Figma / v0.dev / Claude Design HTML routinely emit
+// `style={{ display: 'flex' }}` (the implicit default in pulp, but
+// the prop-applier shouldn't drop it as unknown) or `display: 'none'`
+// to hide a subtree. The yoga / CSS-shim side was wired for the
+// el.style proxy in #1422; this test guards the parallel RN-flavored
+// JSX path so RN consumers don't have to round-trip through el.style
+// (which costs a bridge call + DOM-lite proxy walk).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyChangedProps } from '../src/prop-applier.js';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import type { PulpInstance } from '../src/types.js';
+
+let bridge: MockBridge;
+
+beforeEach(() => {
+    bridge = createMockBridge();
+    bridge.install();
+});
+afterEach(() => {
+    bridge.uninstall();
+});
+
+function makeInstance(id: string = 'k', type: string = 'View'): PulpInstance {
+    return {
+        id,
+        type: type as PulpInstance['type'],
+        props: {},
+        childIds: [],
+        onBridge: true,
+        pendingChildren: [],
+    };
+}
+
+function visibleCalls(b: MockBridge) {
+    return b.calls.filter((c) => c.fn === 'setVisible');
+}
+
+describe('prop-applier display: flex / none (pulp #1434 Triage #12)', () => {
+    it("display: 'none' calls setVisible(id, false)", () => {
+        applyChangedProps(makeInstance(), {}, { display: 'none' });
+        const calls = visibleCalls(bridge);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['k', false]);
+    });
+
+    it("display: 'flex' calls setVisible(id, true)", () => {
+        applyChangedProps(makeInstance(), {}, { display: 'flex' });
+        const calls = visibleCalls(bridge);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].args).toEqual(['k', true]);
+    });
+
+    it('unknown display values are silently dropped', () => {
+        applyChangedProps(makeInstance(), {}, { display: 'block' });
+        // Other JSX intrinsics (e.g. block / inline-block / grid) flow
+        // through the CSS shim only — for RN consumers, the prop-applier
+        // intentionally leaves the View at its current visibility.
+        expect(visibleCalls(bridge)).toHaveLength(0);
+    });
+
+    it('display change from none to flex re-shows the View', () => {
+        const inst = makeInstance();
+        // First: hide.
+        applyChangedProps(inst, {}, { display: 'none' });
+        expect(visibleCalls(bridge)).toEqual([
+            expect.objectContaining({ args: ['k', false] }),
+        ]);
+
+        // Then: re-show via display: 'flex'. applyChangedProps should
+        // fire setVisible(true) because display moved from 'none' to
+        // 'flex' and the value differs.
+        applyChangedProps(inst, { display: 'none' }, { display: 'flex' });
+        const calls = visibleCalls(bridge);
+        // 1 from the first call + 1 from the change = 2 total.
+        expect(calls).toHaveLength(2);
+        expect(calls[1].args).toEqual(['k', true]);
+    });
+});


### PR DESCRIPTION
## Summary

Triage #12 from the rn drift triage — small contained fix. RN exports + Figma / v0.dev / Claude Design HTML routinely emit `style={{ display: 'flex' }}` or `style={{ display: 'none' }}`. The yoga side wired this for the el.style proxy in #1422; this PR makes the same path reachable from RN-flavored JSX without round-tripping through el.style.

## Changes

1. **`packages/pulp-react/src/prop-applier.ts`** — added `display` case:
   - `'none'` → `setVisible(id, false)` (canonical CSS-spec "skip render")
   - `'flex'` → `setVisible(id, true)` (Yoga's flex is pulp's default)
   - Other keywords (`block`/`inline-block`/`inline-flex`/`grid`) silently ignored at this layer — CSS shim handles those for the el.style path.

2. **`packages/pulp-react/src/types.ts`** — added `display?: 'flex' | 'none' | string` to `StyleProps`.

3. **`compat.json`** — `rn/display` flipped `missing` → `supported`, `supportedValues = ['flex', 'none']`. `'contents'` stays in `unsupportedValues` (Yoga has no equivalent).

4. **`docs/reference/compat/rn.md`** — "Recently changed" entry.

5. **vitest** (`prop-applier-display.test.ts`, 4 cases):
   - `display: 'none'` → `setVisible(false)`
   - `display: 'flex'` → `setVisible(true)`
   - Unknown values silently dropped (no setVisible)
   - `'none'` → `'flex'` change re-shows the View

## Test plan

| Suite | Result |
|-------|--------|
| `prop-applier-display.test.ts` | 4 / 4 cases ✓ |
| `@pulp/react` vitest (full) | 13 files / 111 cases ✓ |

## Verification — `python3 tools/harness/verifier.py --surface=rn`

| Metric | Before | After | Δ |
|--------|-------:|------:|--:|
| PASS | 31 | **32** | +1 |
| DIVERGE | 39 | 39 | 0 |
| NOT-IMPL | — | −1 | −1 |
| drift_count | 29 | 29 | 0 |
| progress (PASS+DIVERGE) | 58.3% | **59.2%** | +0.9 pp |

Single-entry move (NOT-IMPL → PASS), no regressions elsewhere.

## Notes

- 3 Version-Bump skip trailers (incl. bare no-surface form).
- No Skill-Update / Compat-Update needed — `web-compat-style-decl.js` and `widget_bridge.cpp` not touched. compat-sync + skill-sync gates both report "no mapped paths touched".
- No conflict with PRs #1446 / #1451 / #1452 / #1455.

Refs pulp #1434.
