### PR TITLE
fix(cli): bake SDK version into Rust release binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v0781"></a>
+## [0.78.1] - 2026-05-05
+
+- fix(cli): bake SDK version into Rust release binary
+
 <a id="v0780"></a>
 ## [0.78.0] - 2026-05-05
 
@@ -1293,6 +1298,7 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
 - Phase 1 follow-up: glTF textures, NSIS fixes, issue #3 crash/mirror/run ([#4](https://github.com/danielraffel/pulp/pull/4))
 - Phase 1: Commercial readiness — convolver, image rendering, packaging, MSVC fix ([#2](https://github.com/danielraffel/pulp/pull/2))
 
+[0.78.1]: https://github.com/danielraffel/pulp/releases/tag/v0.78.1
 [0.78.0]: https://github.com/danielraffel/pulp/releases/tag/v0.78.0
 [0.77.0]: https://github.com/danielraffel/pulp/releases/tag/v0.77.0
 [0.76.0]: https://github.com/danielraffel/pulp/releases/tag/v0.76.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.78.0
+    VERSION 0.78.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/experimental/pulp-rs/CMakeLists.txt
+++ b/experimental/pulp-rs/CMakeLists.txt
@@ -85,6 +85,7 @@ set(_pulp_rs_dest_bin   "${CMAKE_BINARY_DIR}/${_pulp_rs_bin_name}")
 add_custom_target(pulp-rust-cli ALL
     COMMAND ${CMAKE_COMMAND} -E env
         "CARGO_TARGET_DIR=${_pulp_rs_target_dir}"
+        "PULP_RS_BUILD_VERSION=${PROJECT_VERSION}"
         ${CARGO_EXECUTABLE} build ${_pulp_rs_cargo_args}
         --manifest-path "${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml"
     BYPRODUCTS "${_pulp_rs_cargo_bin}"

--- a/experimental/pulp-rs/Cargo.toml
+++ b/experimental/pulp-rs/Cargo.toml
@@ -1,19 +1,16 @@
 # pulp-rs
 #
-# EXPERIMENTAL Rust prototype of the Pulp CLI.
+# Rust implementation of the Pulp CLI.
 #
-# This crate is NOT production code and is NOT shipped.
-# It exists to evaluate whether rewriting `tools/cli/*.cpp` in Rust
-# is worthwhile. See GitHub issue #686 for the decision framework.
-#
-# This crate is intentionally NOT wired into CMake. It runs only via cargo.
+# Release/install builds are driven by CMake so the binary can carry
+# the SDK version while Cargo keeps an internal crate version.
 
 [package]
 name        = "pulp-rs"
 version     = "0.0.1"
 edition     = "2021"
 rust-version = "1.79"
-description = "Experimental Rust prototype of the Pulp CLI (not for production)"
+description = "Rust implementation of the Pulp CLI"
 license     = "MIT"
 publish     = false
 

--- a/experimental/pulp-rs/build.rs
+++ b/experimental/pulp-rs/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=PULP_RS_BUILD_VERSION");
+
+    if let Ok(version) = std::env::var("PULP_RS_BUILD_VERSION") {
+        if !version.is_empty() {
+            println!("cargo:rustc-env=PULP_RS_BUILD_VERSION={version}");
+        }
+    }
+}

--- a/experimental/pulp-rs/src/build_info.rs
+++ b/experimental/pulp-rs/src/build_info.rs
@@ -1,0 +1,56 @@
+//! Build-time identity for the Rust CLI.
+//!
+//! Release binaries are built through CMake, which passes the Pulp SDK
+//! version into Cargo as `PULP_RS_BUILD_VERSION`. Direct `cargo build`
+//! prototype runs keep falling back to the crate's package version.
+
+/// Version baked into this binary at build time.
+#[must_use]
+pub fn baked_cli_version() -> &'static str {
+    option_env!("PULP_RS_BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
+}
+
+/// CLI version string, honoring the `PULP_RS_CLI_VERSION` override so
+/// tests can pin a version without rebuilding the binary.
+#[must_use]
+pub fn cli_version_string() -> String {
+    if let Ok(v) = std::env::var("PULP_RS_CLI_VERSION") {
+        if !v.is_empty() {
+            return v;
+        }
+    }
+    baked_cli_version().to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::ENV_LOCK;
+
+    #[test]
+    fn cli_version_prefers_env_override() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prev = std::env::var_os("PULP_RS_CLI_VERSION");
+        std::env::set_var("PULP_RS_CLI_VERSION", "9.8.7");
+        assert_eq!(cli_version_string(), "9.8.7");
+        match prev {
+            Some(v) => std::env::set_var("PULP_RS_CLI_VERSION", v),
+            None => std::env::remove_var("PULP_RS_CLI_VERSION"),
+        }
+    }
+
+    #[test]
+    fn cli_version_falls_back_to_baked_version() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prev = std::env::var_os("PULP_RS_CLI_VERSION");
+        std::env::remove_var("PULP_RS_CLI_VERSION");
+        assert_eq!(cli_version_string(), baked_cli_version());
+        if let Some(v) = prev {
+            std::env::set_var("PULP_RS_CLI_VERSION", v);
+        }
+    }
+}

--- a/experimental/pulp-rs/src/cmd/upgrade.rs
+++ b/experimental/pulp-rs/src/cmd/upgrade.rs
@@ -4,10 +4,8 @@
 //!
 //! Phase 5 ports the *discovery* half of the C++ `pulp upgrade` path:
 //! check for a newer release, print the delta, stage a pending-upgrade
-//! marker. The *install* half (download + swap the binary) is
-//! deliberately stubbed to a dry-run notice — hot-swapping the running
-//! test binary is hostile to `cargo test`, and the prototype isn't
-//! shipped so nobody's waiting on a live install.
+//! marker, and install a release binary when requested. Tests use a
+//! dry-run override so they never hot-swap the running test binary.
 //!
 //! # Flag surface
 //!
@@ -407,20 +405,15 @@ fn write_pending_marker(args: &UpgradeArgs, out: &mut impl Write) -> Result<()> 
     Ok(())
 }
 
-/// Installed-version probe with `--from` override and the env
-/// fallback used by the shared [`version_info`] code path.
+/// Installed-version probe with `--from` override and the shared
+/// CLI-version fallback.
 fn effective_installed(args: &UpgradeArgs) -> String {
     if let Some(ref v) = args.from_override {
         if !v.is_empty() {
             return v.clone();
         }
     }
-    if let Ok(v) = std::env::var("PULP_RS_CLI_VERSION") {
-        if !v.is_empty() {
-            return v;
-        }
-    }
-    env!("CARGO_PKG_VERSION").to_owned()
+    crate::build_info::cli_version_string()
 }
 
 /// Normalise an incoming version string so a leading `v` doesn't
@@ -796,7 +789,7 @@ mod tests {
     fn effective_installed_empty_from_override_falls_through_to_env() {
         let _l = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Empty string → not used, fall through to PULP_RS_CLI_VERSION
-        // / CARGO_PKG_VERSION. Pin the env var to make this hermetic.
+        // / baked version. Pin the env var to make this hermetic.
         std::env::set_var("PULP_RS_CLI_VERSION", "1.2.3");
         let args = UpgradeArgs {
             from_override: Some(String::new()),
@@ -807,11 +800,11 @@ mod tests {
     }
 
     #[test]
-    fn effective_installed_falls_back_to_cargo_pkg_version() {
+    fn effective_installed_falls_back_to_baked_version() {
         let _l = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("PULP_RS_CLI_VERSION");
         let args = UpgradeArgs::default();
-        // Whatever Cargo.toml says — we just assert non-empty.
+        // Whatever the build baked in — we just assert non-empty.
         assert!(!effective_installed(&args).is_empty());
     }
 }

--- a/experimental/pulp-rs/src/cmd/version.rs
+++ b/experimental/pulp-rs/src/cmd/version.rs
@@ -15,15 +15,10 @@
 //!
 //! # `check` semantics caveat
 //!
-//! The C++ side compares the project's CMakeLists.txt `VERSION` against
-//! a compile-time `PULP_SDK_VERSION`. The Rust binary has no such macro
-//! — its version comes from `CARGO_PKG_VERSION` (or
-//! `PULP_RS_CLI_VERSION` for tests). Until Phase 8 swaps the Rust
-//! binary in as the SDK CLI, the reported "SDK version consistent /
-//! mismatch" line compares the project against the Rust CLI version.
-//! In the interim this still catches drift between CMakeLists.txt /
-//! CHANGELOG / plugin.json / marketplace.json, which is where the
-//! majority of historical drift bugs have come from.
+//! The Rust binary now receives the SDK version through the CMake build
+//! bridge, so the reported "SDK version consistent / mismatch" line
+//! compares projects against the released CLI version. Direct Cargo
+//! prototype builds fall back to the crate version.
 
 use std::io::Write;
 use std::path::Path;

--- a/experimental/pulp-rs/src/diag/mod.rs
+++ b/experimental/pulp-rs/src/diag/mod.rs
@@ -30,6 +30,7 @@ pub use findings::{analyze, Finding, Inputs, ProjectEntry, Severity};
 
 use std::path::{Path, PathBuf};
 
+use crate::build_info;
 use crate::error::Result;
 use crate::parse::SemverCompat;
 use crate::registry;
@@ -40,9 +41,8 @@ use crate::registry;
 /// `findings[]` list.
 #[derive(Debug, Default)]
 pub struct VersionDiag {
-    /// Installed CLI version (we lie a bit: this is actually
-    /// `PULP_RS_CLI_VERSION` env override or the Cargo package
-    /// version, since the prototype isn't bound to the C++ `PULP_SDK_VERSION`).
+    /// Installed CLI version (`PULP_RS_CLI_VERSION` test override or
+    /// the Pulp SDK version baked into the CMake-built binary).
     pub cli: SemverCompat,
     /// Plugin `version` field.
     pub plugin: SemverCompat,
@@ -88,20 +88,6 @@ pub fn resolve_active_project_root(start: &Path) -> (Option<PathBuf>, bool) {
     (None, false)
 }
 
-/// Determine the CLI version for reporting purposes.
-///
-/// Precedence:
-/// 1. `PULP_RS_CLI_VERSION` env — only used in tests and benches.
-/// 2. `CARGO_PKG_VERSION` — the prototype's own version.
-fn cli_version_string() -> String {
-    if let Ok(v) = std::env::var("PULP_RS_CLI_VERSION") {
-        if !v.is_empty() {
-            return v;
-        }
-    }
-    env!("CARGO_PKG_VERSION").to_owned()
-}
-
 /// Runtime overrides that let callers inject values that would
 /// otherwise come from environment probing.
 ///
@@ -136,7 +122,10 @@ pub fn collect(cwd: &Path) -> Result<VersionDiag> {
 ///
 /// See [`collect`].
 pub fn collect_with(cwd: &Path, opts: &CollectOpts) -> Result<VersionDiag> {
-    let cli_raw = opts.cli_version.clone().unwrap_or_else(cli_version_string);
+    let cli_raw = opts
+        .cli_version
+        .clone()
+        .unwrap_or_else(build_info::cli_version_string);
     let mut d = VersionDiag {
         cli: SemverCompat::parse(&cli_raw),
         ..Default::default()

--- a/experimental/pulp-rs/src/lib.rs
+++ b/experimental/pulp-rs/src/lib.rs
@@ -1,8 +1,9 @@
-//! `pulp-rs` — experimental Rust prototype of the Pulp CLI.
+//! `pulp-rs` — Rust implementation of the Pulp CLI.
 //!
-//! **Not production. Not shipped. Not wired into `CMake`.** The crate
-//! exists to answer a single question tracked in [issue #686]:
-//! *should Pulp migrate its CLI from C++ (`tools/cli/*.cpp`) to Rust?*
+//! The crate owns the user-facing `pulp` binary after the Phase 8
+//! cutover. CMake still builds and installs the legacy C++ CLI as
+//! `pulp-cpp` so Rust can fall through for commands that have not moved
+//! yet.
 //!
 //! [issue #686]: https://github.com/danielraffel/pulp/issues/686
 //!
@@ -75,6 +76,7 @@
 // in idiomatic error-composition code. Allowed per-site, not globally,
 // to avoid suppressing real issues.
 
+pub mod build_info;
 pub mod bump;
 pub mod cmd;
 pub mod color;

--- a/experimental/pulp-rs/src/version_info.rs
+++ b/experimental/pulp-rs/src/version_info.rs
@@ -15,8 +15,9 @@
 //!
 //! - The `cli` field prefers the `PULP_RS_CLI_VERSION` environment
 //!   override (so tests can pin a version without mutating the running
-//!   binary). Falling back to `CARGO_PKG_VERSION` keeps the prototype
-//!   self-describing outside tests.
+//!   binary). Falling back to the CMake-baked Pulp SDK version keeps
+//!   release binaries aligned with their tag; direct Cargo prototype
+//!   builds fall back to `CARGO_PKG_VERSION`.
 //! - The `plugin` probe walks `.claude-plugin/plugin.json` *from the
 //!   working directory or any ancestor that looks like a project root*
 //!   — identical to the C++ `locate_plugin_json` precedence, reused
@@ -28,6 +29,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
+use crate::build_info;
 use crate::diag::resolve_active_project_root;
 use crate::parse::{plugin_json, PluginJson, SemverCompat};
 
@@ -53,7 +55,7 @@ pub struct VersionSnapshot {
 /// triple, matching the C++ "diagnostic never critical" rule.
 #[must_use]
 pub fn collect(cwd: &Path) -> VersionSnapshot {
-    let cli = SemverCompat::parse(&cli_version_string());
+    let cli = SemverCompat::parse(&build_info::cli_version_string());
     let (root, is_standalone) = resolve_active_project_root(cwd);
 
     // Mirror the doctor-side quirk: when the active project is a
@@ -105,17 +107,6 @@ fn generic(p: &Path) -> String {
     p.to_string_lossy().replace('\\', "/")
 }
 
-/// CLI version string, honouring the `PULP_RS_CLI_VERSION` override so
-/// tests can pin a version without rebuilding the binary.
-fn cli_version_string() -> String {
-    if let Ok(v) = std::env::var("PULP_RS_CLI_VERSION") {
-        if !v.is_empty() {
-            return v;
-        }
-    }
-    env!("CARGO_PKG_VERSION").to_owned()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -137,7 +128,7 @@ mod tests {
     }
 
     #[test]
-    fn cli_version_defaults_to_cargo_pkg_when_env_unset() {
+    fn cli_version_defaults_to_baked_version_when_env_unset() {
         // Serialise every test that mutates process-wide env via
         // the shared `ENV_LOCK` in `crate::test_support` so
         // `cmd::upgrade` tests and this one don't collide.
@@ -146,7 +137,10 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var_os("PULP_RS_CLI_VERSION");
         std::env::remove_var("PULP_RS_CLI_VERSION");
-        assert_eq!(cli_version_string(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            build_info::cli_version_string(),
+            build_info::baked_cli_version()
+        );
         if let Some(v) = prev {
             std::env::set_var("PULP_RS_CLI_VERSION", v);
         }


### PR DESCRIPTION
## Summary

- Bake the Pulp SDK version into CMake-built Rust CLI binaries via `PULP_RS_BUILD_VERSION`.
- Route `pulp version`, `pulp doctor --versions`, and upgrade installed-version fallback through the shared Rust build-info helper.
- Bump SDK/changelog to `0.78.1` so the corrected release artifacts publish after merge.

## Validation

- `cargo test --manifest-path experimental/pulp-rs/Cargo.toml build_info -- --nocapture`
- `cargo test --manifest-path experimental/pulp-rs/Cargo.toml`
- `cmake -E env CARGO_TARGET_DIR=<tmp>/cargo-target PULP_RS_BUILD_VERSION=0.78.1 cargo build --manifest-path experimental/pulp-rs/Cargo.toml`
- `<tmp>/cargo-target/debug/pulp version` → `pulp v0.78.1`
- `<tmp>/cargo-target/debug/pulp doctor --versions --json` includes CLI raw `0.78.1`
- `python3 tools/scripts/version_bump_check.py --mode=report`
- `python3 tools/scripts/skill_sync_check.py --mode=report`
- `git diff --check`

## Shipyard fallback note

`shipyard pr` was attempted first and stopped before opening a PR because the configured Windows SSH target was unreachable (`ssh: connect to host 100.92.174.43 port 22: Operation timed out`). This PR is opened via REST so GitHub Actions can validate the release fix while the SSH backend is unavailable.