### PR TITLE
fix(harness): canvas2d catalog hygiene — re-status 5 over-claimed entries to partial (refs pulp #1434)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -5663,7 +5663,7 @@
       "issue": "1346"
     },
     "canvas2d/fill": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "ctx.fill -> _syncGlobalState + _applyFillStyle + canvasFillPath.",
       "supportedValues": [],
       "unsupportedValues": [
@@ -5683,7 +5683,7 @@
       "issue": ""
     },
     "canvas2d/clip": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "ctx.clip(fillRule) -> canvasClip (intersects current clip with current path). Falls back to no-op if canvasClip absent.",
       "supportedValues": [],
       "unsupportedValues": [
@@ -5770,7 +5770,7 @@
       "issue": "1346"
     },
     "canvas2d/fillText": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "ctx.fillText(text,x,y,maxWidth) -> _syncGlobalState + _syncTextState + _applyFillStyle + canvasFillText(id, text, x, y, size, color). maxWidth is ignored; gradient fillStyle uses the first stop's color.",
       "supportedValues": [],
       "unsupportedValues": [
@@ -5932,7 +5932,7 @@
       "issue": ""
     },
     "canvas2d/fillStyle": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "Settable to a CSS-color string OR a CanvasGradient object. Solid colors push via canvasSetFillColor; gradients push via canvasSetLinearGradient / canvasSetRadialGradient on the next draw.",
       "supportedValues": [
         "CSS color strings",
@@ -6052,7 +6052,7 @@
       "issue": "1346"
     },
     "canvas2d/font": {
-      "status": "supported",
+      "status": "partial",
       "mapsTo": "Locally tracked; canvasSetFont(id, family, size) on the next draw. Shim parses '<size>px <family>'.",
       "supportedValues": [
         "'<size>px <family>'"


### PR DESCRIPTION
## Summary

5-line catalog hygiene PR identified by the canvas2d drift triage.
Re-status `clip` / `fill` / `fillStyle` / `fillText` / `font` from
`supported` → `partial` so the verifier's step-9 generic-DIVERGE
classification stops flagging them as drift.

## Why

These five entries each have an accurate `unsupportedValues` block
already documenting the real gap, but the over-claim at status
level (`status=supported` + non-empty `unsupportedValues`) trips the
verifier into flagging them as drift. This is the rn-A-equivalent
finding for canvas2d — just smaller (5 entries vs rn-A's 17).

The catalog content is unchanged. Only the status field flips.

## Harness delta

| Surface | Before | After |
|---|---|---|
| canvas2d | drift=5, PASS+DIVERGE=88.9% | drift=0, PASS+DIVERGE=88.9% |

PASS+DIVERGE% is unchanged — DIVERGE entries don't move on the score, they just stop being flagged as drift.

## Tests

No code changed; no new tests needed. The verifier classification change is mechanical.

## Identified by

`/tmp/canvas2d-drift-import-triage.md` (sub-agent #15 research-only triage).

Refs: pulp #1434.