### PR TITLE
fix(harness): css catalog hygiene — flip 8 stale entries, drift 60 → 54 (refs pulp #1434)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -381,7 +381,7 @@
       "issue": ""
     },
     "css/backgroundPosition": {
-      "status": "missing",
+      "status": "partial",
       "mapsTo": "web-compat calls setBackgroundPosition if defined -- bridge does NOT register it",
       "supportedValues": [],
       "unsupportedValues": [
@@ -390,11 +390,11 @@
         "px/%"
       ],
       "tests": [],
-      "notes": "Silent no-op.",
+      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:794 routes through setBackgroundPosition. Bridge function is not yet registered, so values are silently dropped at runtime.",
       "issue": ""
     },
     "css/backgroundRepeat": {
-      "status": "missing",
+      "status": "partial",
       "mapsTo": "web-compat calls setBackgroundRepeat if defined -- bridge does NOT register it",
       "supportedValues": [],
       "unsupportedValues": [
@@ -406,11 +406,11 @@
         "round"
       ],
       "tests": [],
-      "notes": "Silent no-op.",
+      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:994 routes through setBackgroundRepeat. Bridge function is not yet registered, so values are silently dropped at runtime.",
       "issue": ""
     },
     "css/backgroundSize": {
-      "status": "missing",
+      "status": "partial",
       "mapsTo": "web-compat calls setBackgroundSize if defined -- bridge does NOT register it",
       "supportedValues": [],
       "unsupportedValues": [
@@ -421,7 +421,7 @@
         "%"
       ],
       "tests": [],
-      "notes": "Silent no-op. Tied to backgroundImage url() which is also missing.",
+      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:789 routes through setBackgroundSize. Bridge function is not yet registered, so values are silently dropped at runtime; tied to backgroundImage url() which is also missing.",
       "issue": ""
     },
     "css/border": {
@@ -1320,12 +1320,12 @@
     },
     "css/height": {
       "status": "partial",
-      "mapsTo": "setFlex(id, 'height', px)",
+      "mapsTo": "setFlex(id, 'height', px) for numeric, setFlex(id, 'height', 'NN%') for percent (yoga/height path via FlexStyle.dim_height)",
       "supportedValues": [
-        "px (number)"
+        "px (number)",
+        "%"
       ],
       "unsupportedValues": [
-        "%",
         "em",
         "rem",
         "auto",
@@ -1334,8 +1334,8 @@
         "fit-content"
       ],
       "tests": [],
-      "notes": "Same as width. dim_height supports DimensionUnit::vw/vh/percent/vmin/vmax internally but the setFlex bridge only accepts a single double.",
-      "issue": ""
+      "notes": "pulp #1434 batch (catalog hygiene): mirrors yoga/height post-#1426. The CSS translator at web-compat-style-decl.js:199 detects `'NN%'` strings and forwards them verbatim; the bridge dispatches to FlexStyle.dim_height (DimensionUnit::percent) and YGNodeStyleSetHeightPercent. Numeric values still flow through FlexStyle.preferred_height. `auto` and relative units (em/rem/vh/vw) remain deferred follow-ups.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1423"
     },
     "css/inset": {
       "status": "supported",
@@ -1412,14 +1412,14 @@
       "issue": ""
     },
     "css/lineClamp": {
-      "status": "missing",
+      "status": "partial",
       "mapsTo": "web-compat calls setLineClamp if defined -- bridge does NOT register it",
       "supportedValues": [],
       "unsupportedValues": [
         "integer"
       ],
       "tests": [],
-      "notes": "Silent no-op. Both 'line-clamp' and '-webkit-line-clamp' route here.",
+      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:988-990 parses an integer via parseInt and routes through setLineClamp. Both 'line-clamp' and '-webkit-line-clamp' funnel through the same shared case. Bridge function is not yet registered, so values are silently dropped at runtime.",
       "issue": ""
     },
     "css/lineHeight": {
@@ -2580,14 +2580,14 @@
       "issue": ""
     },
     "css/webkitLineClamp": {
-      "status": "missing",
+      "status": "partial",
       "mapsTo": "same as lineClamp",
       "supportedValues": [],
       "unsupportedValues": [
         "integer"
       ],
       "tests": [],
-      "notes": "Silent no-op.",
+      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:988 funnels '-webkit-line-clamp' through the same setLineClamp case as 'line-clamp'. Bridge function is not yet registered, so values are silently dropped at runtime.",
       "issue": ""
     },
     "css/whiteSpace": {
@@ -2609,12 +2609,12 @@
     },
     "css/width": {
       "status": "partial",
-      "mapsTo": "setFlex(id, 'width', px)",
+      "mapsTo": "setFlex(id, 'width', px) for numeric, setFlex(id, 'width', 'NN%') for percent (yoga/width path via FlexStyle.dim_width)",
       "supportedValues": [
-        "px (number)"
+        "px (number)",
+        "%"
       ],
       "unsupportedValues": [
-        "%",
         "em",
         "rem",
         "auto",
@@ -2624,8 +2624,8 @@
         "calc()"
       ],
       "tests": [],
-      "notes": "FlexStyle.preferred_width is a float. Yoga in upstream supports % and auto, but Pulp's C++ port loses that on the JSON wire -- only floats are accepted by setFlex.",
-      "issue": ""
+      "notes": "pulp #1434 batch (catalog hygiene): mirrors yoga/width post-#1426. The CSS translator at web-compat-style-decl.js:192 detects `'NN%'` strings and forwards them verbatim to the bridge, which routes to FlexStyle.dim_width (DimensionUnit::percent) and YGNodeStyleSetWidthPercent. Numeric values still go through FlexStyle.preferred_width. `auto` and relative units (em/rem/calc) remain deferred follow-ups.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1423"
     },
     "css/willChange": {
       "status": "wontfix",
@@ -2653,14 +2653,16 @@
       "issue": ""
     },
     "css/wordWrap": {
-      "status": "missing",
+      "status": "partial",
       "mapsTo": "same as wordBreak -- never registered",
       "supportedValues": [],
       "unsupportedValues": [
-        "all"
+        "break-word",
+        "normal",
+        "anywhere"
       ],
       "tests": [],
-      "notes": "Legacy alias of overflow-wrap. Silent no-op.",
+      "notes": "pulp #1434 batch (catalog hygiene): status flipped missing -> partial. CSS translator at web-compat-style-decl.js:728-729 funnels `wordWrap`, `overflowWrap`, and `wordBreak` through the same setWordBreak case. Bridge function is not yet registered, so values are silently dropped at runtime. Legacy alias of overflow-wrap.",
       "issue": ""
     },
     "css/writingMode": {

--- a/docs/reference/compat/css.md
+++ b/docs/reference/compat/css.md
@@ -33,6 +33,22 @@ specifics are out of scope.
 
 ## Recently changed
 
+- **2026-05-05 (pulp #1434 css catalog hygiene)** — eight catalog-only
+  refreshes: `css/width` and `css/height` now list `%` in
+  `supportedValues` (mirroring `yoga/width` / `yoga/height` post-#1426 —
+  the CSS translator forwards `'NN%'` strings verbatim and the bridge
+  routes them via `FlexStyle.dim_*` / `YGNodeStyleSet*Percent`).
+  `css/backgroundSize`, `css/backgroundPosition`, `css/backgroundRepeat`,
+  `css/lineClamp`, `css/webkitLineClamp`, and `css/wordWrap` flipped
+  `missing` → `partial` to reflect that the JS translator (in
+  `web-compat-style-decl.js`) already routes them; the bridge functions
+  remain unregistered so the values silently drop at runtime, but the
+  catalog status now matches the harness verdict (DIVERGE). Drift on
+  these six entries is cleared. Nine remaining `css/animation*` and
+  `css/touchAction` entries continue to drift as harness `NO-OP`
+  because the catalog has no `status` value that maps to NO-OP — that
+  is a verifier-side classification gap (no catalog edit can clear it
+  today) and is tracked as a follow-up.
 - **2026-05-05 (pulp #1434 Triage #11)** — `css/textAlign` now accepts
   `start`, `end`, `auto`, and `justify` alongside the existing `left`,
   `center`, `right`. `start`/`end` map symmetrically to `left`/`right`


### PR DESCRIPTION
## Summary

Catalog-only hygiene sweep on the `css` surface — second batch from the framework-import-readiness umbrella (#1434). Mirrors the shape of #1436 (catalog hygiene + status flips) and #1472 (canvas2d hygiene).

- Edits to `compat.json` (8 entries) and a "Recently changed" note in `docs/reference/compat/css.md`.
- **No source code changes.**
- css drift: **60 → 54 (-6)** per `tools/harness/verifier.py --all`.

## Why

Sub-agent triage at `/tmp/css-drift-import-triage.md` flagged 17 css catalog-hygiene candidates against `origin/main` SHA `83271a94`. Investigation showed:

- **8 entries are catalog-only fixes** (Group A: 2 stale-after-#1426 + Group B: 6 missing→partial). These cleanly mirror the work done in #1436's text-shadow / outline batch.
- **9 NO-OP entries cannot be cleared via catalog edits** (Group C, see below) — that requires verifier work, not catalog work.

## Per-entry table

### Group A — stale-after-#1426 (2 entries — drift was already False, but data is now refreshed to mirror `yoga/width` / `yoga/height`)

| Entry | status (before/after) | Change |
|---|---|---|
| `css/width`  | partial / partial | `%` moved from `unsupportedValues` to `supportedValues`; `mapsTo`, `notes`, `issue` updated to match `yoga/width`. |
| `css/height` | partial / partial | Same shape as `css/width`; mirrors `yoga/height` post-#1426. |

### Group B — missing → partial (6 entries — drift cleared)

| Entry | status (before/after) | Translator line | Drift before / after |
|---|---|---|---|
| `css/backgroundSize`     | missing / partial | `web-compat-style-decl.js:789` | True / False |
| `css/backgroundPosition` | missing / partial | `web-compat-style-decl.js:794` | True / False |
| `css/backgroundRepeat`   | missing / partial | `web-compat-style-decl.js:994` | True / False |
| `css/lineClamp`          | missing / partial | `web-compat-style-decl.js:988-990` | True / False |
| `css/webkitLineClamp`    | missing / partial | shared with `lineClamp` | True / False |
| `css/wordWrap`           | missing / partial | `web-compat-style-decl.js:728-729` | True / False |

`css/wordWrap` also tightened `unsupportedValues` from the placeholder `['all']` to the concrete spec values `['break-word', 'normal', 'anywhere']`.

Bridge functions (`setBackgroundSize`, `setBackgroundPosition`, `setBackgroundRepeat`, `setLineClamp`, `setWordBreak`) remain unregistered, so values still silently drop at runtime — but the catalog now honestly reflects "translator wires it, bridge fn not registered" the same way `css/textShadow` / `css/outline` did after #1436.

### Group C — 9 NO-OP entries deferred (verifier-side gap, NOT a catalog issue)

After investigating `tools/harness/adapters/css.py` (`NO_OP_MARKERS` ⊃ `"stub"`, `"no-op"`, `"stored on element"`) and `tools/harness/status.py` (`map_catalog_status_to_expected`), I confirmed that **the catalog `status` field has no value that maps to harness `NO_OP`**:

```python
# tools/harness/status.py, map_catalog_status_to_expected:
#   supported -> PASS
#   partial   -> DIVERGE
#   missing   -> NOT_IMPL
#   wontfix   -> OOS
#   (no path to NO_OP)
```

So the 9 entries (`css/animation`, `css/animationDelay`, `css/animationDirection`, `css/animationDuration`, `css/animationFillMode`, `css/animationIterationCount`, `css/animationName`, `css/animationTimingFunction`, `css/touchAction`) **will continue to drift no matter what status the catalog claims** — the harness verdict is NO-OP (translator wires it but `mapsTo` text matches `"stub"` / `"stored on element"`), and no catalog status maps to NO-OP.

Across all five surfaces this is the only cluster of NO-OP-classified entries on the harness, so there's no precedent for clearing NO-OP drift to mirror. Closing those 9 drift entries requires either:

1. **Verifier extension** — add a `noop` status to the catalog vocabulary, update `map_catalog_status_to_expected`, and document the convention. ≤30 line change in `tools/harness/status.py`.
2. **Implementation** — wire `setAnimation` and `set_touch_action` bridge fns; harness will then reclassify them away from NO-OP. Tracked as separate work (transitions / animation runtime is a Phase B lift).

Track as follow-up; not in scope for catalog hygiene.

## Harness delta

```
$ python3 -m tools.harness.verifier --all --json | jq '.surfaces.css'

                  before    after   Δ
total              199       199     0
pass               33        33      0
diverge            83        83      0
no_op              9         9       0
not_impl           51        51      0
oos                23        23      0
pass+diverge%      58.3%     58.3%   0
drift_count        60        54     -6
```

PASS+DIVERGE % stays put because the 6 Group B entries flipped from NOT_IMPL → DIVERGE in the catalog reading, but they were already DIVERGE in the harness reading. The win here is drift reduction and catalog↔harness honesty, not progress%. Cross-surface counts (yoga / rn / canvas2d / html) are unchanged.

`docs/reports/harness-coverage.md` regenerates cleanly via `python3 -m tools.harness.verifier --all` but is not bundled in this PR — that file has multiple deltas pre-dating this change (last regen at sha `c3bdcc3e`); a separate regen pass is the cleaner shape.

## Test plan

Catalog-only PRs don't ship new tests — the harness verifier IS the test. Verification commands:

- [ ] `python3 -m tools.harness.verifier --all --json | jq '.surfaces.css.drift_count'` — should print `54`.
- [ ] `python3 -m tools.harness.verifier --surface css --json | jq '.surfaces.css.results[] | select(.name == "css/backgroundSize") | .drift'` — should print `false`.
- [ ] `python3 -c "import json; json.load(open('compat.json')); print('OK')"` — JSON validity.
- [ ] `python3 tools/scripts/compat_sync_check.py --mode=report` — should print "no mapped paths touched".
- [ ] `python3 tools/scripts/skill_sync_check.py --mode=report` — should print "no mapped paths touched".

## Refs

- pulp #1434 (framework-import-readiness umbrella)
- pulp #1426 (yoga width/height percent — Group A mirrors this)
- pulp #1436 (first catalog hygiene + css OOS reclassification — same shape)
- pulp #1472 (canvas2d catalog hygiene — same shape, parallel surface)