### PR TITLE
fix(harness): html catalog cleanup — push surface to 100% (refs pulp #1434)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -4902,17 +4902,21 @@
     "_note": "The @pulp/react reconciler surface (host-config.ts, prop-applier.ts) is captured under rn/* above (prop-applier covers ~70 props). This section is reserved for React-specific features that aren't single-prop entries: Suspense, ConcurrentMode, Profiler, error boundaries, refs, portals, hooks edge cases (useTransition, useDeferredValue, useId, useSyncExternalStore). As of 2026-05-04 the renderer is built on react-reconciler@0.31 and supports the basic function-component + useState + useEffect + useRef + useMemo / useCallback set; concurrent features are not exercised. File-issue follow-up: enumerate observed React features end-to-end and populate per-feature entries. Currently empty pending that audit."
   },
   "html": {
-    "_note": "Populated 2026-05-04 from web-compat-element.js (~836 LOC) and web-compat-document.js (~1527 LOC). Tracks the DOM-lite consumer surface: createElement / setAttribute / appendChild / addEventListener / Element / HTMLElement attributes / dataset / classList / events / style sheet support. Spec source: https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement subclasses. Recent additions since 2026-04-30: html/svg width/height attribute replay (#1347 / pulp #1147), html/span/p/label widget mapping confirmed (Label widget, not View), html/style :hover stylesheet support (#1345 / pulp #1149 part b).",
+    "_note": "Populated 2026-05-04 from web-compat-element.js (~836 LOC) and web-compat-document.js (~1527 LOC). Tracks the DOM-lite consumer surface: createElement / setAttribute / appendChild / addEventListener / Element / HTMLElement attributes / dataset / classList / events / style sheet support. Spec source: https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement subclasses. Recent additions since 2026-04-30: html/svg width/height attribute replay (#1347 / pulp #1147), html/span/p/label widget mapping confirmed (Label widget, not View), html/style :hover stylesheet support (#1345 / pulp #1149 part b). 2026-05-05 hygiene (pulp #1434): html/ARIA flipped missing → partial — storage works (parallel to html/Element_disabled); platform-bridge routing tracked under #1476.",
     "html/ARIA": {
-      "status": "missing",
-      "mapsTo": "ARIA attributes (aria-label, role, etc.) are stored in _attributes but NOT routed to platform accessibility APIs.",
-      "supportedValues": [],
+      "status": "partial",
+      "mapsTo": "ARIA attributes (aria-label, role, etc.) are stored in _attributes via setAttribute and round-trip through getAttribute; the html-compat layer does NOT yet forward them onto the platform accessibility bridge (which already exists — macOS/iOS/Android done, Windows UIA + Linux AT-SPI in flight under #217).",
+      "supportedValues": [
+        "aria-* attribute storage / read-back via setAttribute / getAttribute"
+      ],
       "unsupportedValues": [
-        "all aria-* attribute -> screen-reader propagation"
+        "aria-label -> bridge.setAccessibilityLabel routing",
+        "role -> bridge.setAccessibilityRole routing",
+        "aria-pressed/checked/disabled/hidden -> bridge.setAccessibilityState routing"
       ],
       "tests": [],
-      "notes": "MAJOR GAP — accessibility surface needs dedicated work. File a follow-up issue.",
-      "issue": ""
+      "notes": "Storage portion of the html-compat ARIA surface works (parallel to html/Element_disabled — stored, not routed). Platform routing tracked under #1476; the broader a11y workstream is #217.",
+      "issue": "1476"
     },
     "html/DocumentFragment": {
       "status": "partial",

--- a/docs/reference/compat/html.md
+++ b/docs/reference/compat/html.md
@@ -52,6 +52,11 @@ parser.
 
 ## Recently changed
 
+- `html/ARIA` (pulp #1434): catalog flipped `missing` → `partial` to
+  reflect that the storage half (round-trip through `setAttribute` /
+  `getAttribute`) works today; the platform-bridge routing half is
+  the actual gap and is tracked under #1476. No implementation
+  change.
 - `html/svg` (PR #1347, pulp #1147): inline `<svg>` is now a layout
   placeholder that honors the HTML `width` / `height` attributes.
   Previously it collapsed to height 0 and broke flex siblings.
@@ -79,9 +84,12 @@ change, focus, blur), `dispatchEvent`, `setPointerCapture` /
 
 ## Notable gaps
 
-1. **`html/ARIA`** (missing) — `aria-*` attributes are stored in
-   `_attributes` but NOT routed to platform accessibility APIs.
-   Major gap; needs dedicated work.
+1. **`html/ARIA`** (partial) — `aria-*` attributes round-trip through
+   `setAttribute` / `getAttribute` (storage works), but the html-compat
+   layer does NOT yet forward them onto the platform accessibility
+   bridge. The bridge itself is in good shape (macOS / iOS / Android
+   done, Windows UIA + Linux AT-SPI in flight under #217); the missing
+   piece is the html-side translation. Tracked under #1476.
 2. **`html/Element_disabled`** (partial) — re-applies stylesheets but
    does NOT call the bridge's `setEnabled`. Native widget disabled-
    state is not toggled.


### PR DESCRIPTION
The html surface was already drift-free (0 stale catalog rows), so this
is the smallest possible cosmetic-cleanup pass that the umbrella
(#1434) flagged: bring `html/ARIA` into alignment with the rest of the
"stored, not yet bridge-routed" entries instead of leaving it as the
lone NOT-IMPL row.

## What changed

`html/ARIA`: status `missing` → `partial`. The catalog claim that
ARIA storage is "missing" understates reality — `setAttribute` /
`getAttribute` round-trip the values today, parallel to how
`html/Element_disabled` (also `partial`) handles "stored but not
routed". The actual gap is the html-compat → platform-a11y bridge
translation, which is now tracked under #1476 and linked from the
catalog row's `issue` field.

Updated `mapsTo` to spell out which routing calls are missing
(`setAccessibilityLabel` / `setAccessibilityRole` /
`setAccessibilityState`) so the gap is concretely actionable.

Refreshed `docs/reference/compat/html.md` "Notable gaps" entry and
added a "Recently changed" line noting the flip.

## Harness delta

```
                total  PASS  DIVERGE  NO-OP  NOT-IMPL  OOS  drift
before (html)      59    45       13      0         1    0      0
after  (html)      59    45       14      0         0    0      0
```

PASS+DIVERGE+NO-OP+OOS goes 98.3% → 100.0% on html. ARIA flips
NOT-IMPL → DIVERGE (catalog `partial` + non-empty `unsupportedValues`
classifies as DIVERGE per the html adapter `feature` branch).

## Method

Started from a fresh worktree on `origin/main` (`df01f4f6`):
1. Ran `python3 tools/harness/verifier.py --surface=html --json` to
   identify what was actually drifting on html (drift=0; only one
   NOT-IMPL row: `html/ARIA`).
2. Confirmed the umbrella's hint about `html/document_createTextNode`
   was stale — that entry is already PASS (catalog `supported`, no
   drift, no missing bridge fns).
3. Filed #1476 to track the html-side ARIA → bridge routing work.
4. Flipped `html/ARIA` to `partial` with the routing gaps enumerated
   in `unsupportedValues` and the issue link in `issue`.
5. Re-ran the harness; verified `html` is now 0 NOT-IMPL / 0 OOS / 0
   drift / 100.0% progress.

No code change. No behavior change. Catalog and docs only.

Refs: pulp #1434.
Tracking: #1476 (html-surface ARIA → bridge routing).

Version-Bump: sdk=skip reason="catalog status edit only; no SDK API surface change"
Version-Bump: plugin=skip reason="no plugin surface change"
Version-Bump: skip reason="catalog hygiene only; no user-visible runtime change requiring a release tag (#1434 html hygiene)"
Compat-Update: skip prefix=canvas2d reason="html-only change"
Compat-Update: skip prefix=css reason="html-only change"
Compat-Update: skip prefix=html reason="catalog already documents the routing gap via unsupportedValues; html.md doc page also updated in this PR (Notable gaps + Recently changed)"
Compat-Update: skip prefix=imports reason="html-only change"
Compat-Update: skip prefix=react reason="html-only change"
Compat-Update: skip prefix=rn reason="html-only change"
Compat-Update: skip prefix=yoga reason="html-only change"