### PR TITLE
feat(import-ir): Phase 1 spike — IR types + Claude Design HTML adapter + 5-scenario harness (closes pulp #1486 phase 1)

### DIFF
--- a/docs/guides/import-ir.md
+++ b/docs/guides/import-ir.md
@@ -1,0 +1,145 @@
+# Pulp design-import IR
+
+Pulp's design-import IR (`@pulp/import-ir`) is a typed intermediate
+representation that survives source re-import. Adapters lower source
+formats — Figma, Mitosis, Claude Design HTML, Stitch HTML, v0.dev,
+Pencil, etc. — into a common `IRNode` tree keyed by
+`stable_anchor_id`. The tweaks layer (`pulp-tweaks.json`) is keyed by
+the same anchors, so dev overrides survive when the designer
+regenerates the source.
+
+The full design lives at `pulp/issues/1486` (umbrella) and the spec
+draft (`/tmp/pulp-ir-spec-spike.md`). This guide is the consumer-facing
+summary.
+
+## Phase 1 spike (this PR)
+
+Phase 1 ships:
+
+- **Type definitions** (`packages/pulp-import-ir/src/types.ts`):
+  `IRNode`, `TypedLayout`, `TypedPaint`, `TypedText`, `TokenRef`,
+  `Drift`, `IRProvenance`, `Confidence`, `SourceAdapter`, `TweaksFile`,
+  `LowerOptions`.
+- **Three anchor strategies** (`anchors.ts`): `content-hash` (used by
+  HTML-based sources; lifted from Mitosis/Builder's MIT-licensed
+  `hashCodeAsString` algorithm — an FNV-1a fold over a stable-stringify
+  of `(tag, role, text, depth)`), `path` (used by source files where
+  reorders are explicit and rare), and `adapter` (used by Figma/Pencil
+  with native node IDs).
+- **Claude Design HTML adapter** (`adapters/claude-design-html/`):
+  parses an HTML payload into a tree of `BuildNode`s, extracts
+  `inline-style` properties into the typed `layout` / `paint` / `text`
+  fields, preserves the verbatim `outerHtml` under
+  `raw_source.outerHtml` for forward-compat, and resolves anchors via
+  the content-hash strategy.
+- **Tweaks layer** (`tweaks.ts`): `applyTweaks(node, tweaks)` deep-
+  merges dotted-path overrides; orphaned tweaks (anchors missing from
+  the freshly-lowered tree) attach to `meta.orphaned_tweaks` and
+  surface via `diff()` as `Drift.orphaned-tweak`. Pure-sync, no IO
+  in the core; `nodeFsTweaksIO()` wraps `node:fs/promises` for CLI
+  consumers.
+- **`diff()` (drift detection)** (`diff.ts`): sorted-by-anchor flat
+  list of `added` / `removed` / `changed` / `reordered` /
+  `orphaned-tweak` entries. Field-level diff over the typed sections.
+- **JSX-equivalent lowering** (`lower-via-prop-applier.ts`): IR →
+  `JSXLikeNode` tree → consumed by downstream renderers
+  (`React.createElement(tag, props, …)`). Per spec §10 Q7 user-locked
+  decision: route through the well-tested `@pulp/react` prop-applier
+  rather than build a parallel renderer.
+- **5-scenario validation harness** (`test/scenarios/scenarios.test.ts`):
+  - **S1** Pure regen — tweaks survive trivially. ✓
+  - **S2** Designer changed colors — tweaks survive (content-hash is
+    color-agnostic). ✓
+  - **S3** Designer added a new sibling section — existing IDs
+    preserved, new section gets a new ID. ✓
+  - **S4** Designer deleted a tweaked section — drift report flags
+    the orphaned tweak. ✓
+  - **S5** Designer reordered sections — content-hash preserves
+    anchors across reorder. ✓
+
+All 30 tests pass under `vitest run`.
+
+## Architectural decisions (user-locked, per spec §10)
+
+| Q | Decision |
+|---|----------|
+| Q2 — IR module location | TS-only at `packages/pulp-import-ir/`. Promote to C++ on profiling. |
+| Q3 — DTCG token resolution | Post-lowering. `TokenRef` strings preserved in IR; resolver runs after lowering. Token-tree edits propagate without reimport. |
+| Q7 — Lowering route | IR → JSX-equivalent intrinsics → existing `@pulp/react` prop-applier. Duplicative-but-safe; well-tested code path. |
+
+## Public API
+
+```ts
+import {
+    lowerClaudeDesignHtml,
+    applyTweaks,
+    diff,
+    emptyTweaksFile,
+    nodeFsTweaksIO,
+    toJSXLikeTree,
+    type IRNode,
+    type TweaksFile,
+} from '@pulp/import-ir';
+
+// Lower a Claude Design HTML payload to IR.
+const ir = await lowerClaudeDesignHtml(rawHtml);
+
+// Apply dev tweaks read from disk.
+const io = nodeFsTweaksIO();
+const tweaks = (await io.readTweaks('homepage.tweaks.json'))
+    ?? emptyTweaksFile('0.78.1', new Date().toISOString());
+const tweakedIR = applyTweaks(ir, tweaks);
+
+// Detect drift on next import.
+const newIR = await lowerClaudeDesignHtml(updatedHtml);
+const drifts = diff(ir, newIR);
+for (const d of drifts) {
+    if (d.kind === 'orphaned-tweak') {
+        console.warn(`tweak orphaned: ${d.anchor} (${d.reason})`);
+    }
+}
+
+// Hand off to @pulp/react via JSX-equivalent tree.
+const jsxTree = toJSXLikeTree(tweakedIR);
+// → render through React.createElement(tag, props, ...children).
+```
+
+## Per-source anchor strategy defaults (§4.4)
+
+| Source                | Default strategy        |
+|-----------------------|-------------------------|
+| Figma MCP             | `adapter`               |
+| Pencil MCP            | `adapter`               |
+| Mitosis source        | `adapter`               |
+| RN file export        | `path`                  |
+| Claude Design HTML    | `content-hash`          |
+| Stitch HTML           | `content-hash`          |
+| v0.dev export         | `content-hash`          |
+| Generic HTML/CSS      | `content-hash`          |
+
+Override via `LowerOptions.anchorStrategy` per import; per-node escape
+via `meta.anchor_id_override`.
+
+## Phase 2 — what's next
+
+The spec lays out follow-up adapters in priority order:
+
+1. Figma MCP / Figma ZIP adapter (~1.5 weeks; uses adapter strategy)
+2. Mitosis adapter (~1 week; adapter strategy)
+3. Stitch HTML / v0.dev adapters (~3-5 days each; content-hash)
+4. Pencil MCP adapter (~1 week; adapter strategy)
+5. RN file export adapter (~5 days; path strategy)
+
+Each adapter implements `SourceAdapter<R>` and reuses the shared
+anchors / tweaks / diff infrastructure. The CLI's `pulp import design`
+flow will pick the right adapter based on source kind.
+
+## References
+
+- Mitosis Builder content-hash IDs:
+  `mitosis/packages/core/src/parsers/builder/builder.ts:1163`,
+  `.../symbols/symbol-processor.ts:187` (MIT) — pattern lift, not
+  vendoring.
+- pulp #1486 (umbrella), pulp #1307 (CLI scaffolding), pulp #1432
+  (ZIP import path).
+- Codex /codex audit 2026-05-06 (architecture review).

--- a/packages/pulp-import-ir/README.md
+++ b/packages/pulp-import-ir/README.md
@@ -1,0 +1,46 @@
+# @pulp/import-ir
+
+Pulp design-import IR — typed intermediate representation that survives
+source re-import.
+
+## What it is
+
+When a designer regenerates a Figma / Claude Design / Mitosis source,
+Pulp re-imports it through an adapter into a tree of `IRNode`s. Every
+node carries a `stable_anchor_id` so dev tweaks (`pulp-tweaks.json`)
+keyed by the same anchor survive the re-import. A `diff()` produces a
+sorted Drift list — added / removed / changed / reordered / orphaned-
+tweak — for the CLI to surface as a "what changed" report.
+
+## Package layout
+
+```
+src/
+├── types.ts                 — IRNode, TypedLayout, TypedPaint, TypedText,
+│                              TokenRef, Drift, IRProvenance, Confidence,
+│                              SourceAdapter, TweaksFile, LowerOptions
+├── anchors.ts               — content-hash / path / adapter strategies
+├── tweaks.ts                — applyTweaks, setByDottedPath, fs IO wrapper
+├── diff.ts                  — sorted-by-anchor Drift list
+├── lower-via-prop-applier.ts — IR → JSX-equivalent tree (consumed by @pulp/react)
+├── adapters/
+│   └── claude-design-html/
+│       └── lower.ts         — first-spike adapter
+└── index.ts                 — public API
+```
+
+## Quick start
+
+```ts
+import { lowerClaudeDesignHtml, applyTweaks, diff } from '@pulp/import-ir';
+
+const ir = await lowerClaudeDesignHtml(rawHtml);
+const tweaked = applyTweaks(ir, tweaks);
+const drifts = diff(prevIR, ir);
+```
+
+See `docs/guides/import-ir.md` for the full guide.
+
+## License
+
+MIT — pulp #1486 spike.

--- a/packages/pulp-import-ir/package.json
+++ b/packages/pulp-import-ir/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@pulp/import-ir",
+  "version": "0.0.1",
+  "description": "Pulp design-import IR — typed intermediate representation that survives reimport. Adapters lower source formats (Figma / Mitosis / HTML / etc.) into IRNode trees keyed by stable_anchor_id; tweaks layer survives source regeneration. Phase 1 spike — Claude Design HTML adapter + 5-scenario harness (closes pulp #1486 phase 1).",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/pulp-import-ir/src/adapters/claude-design-html/lower.ts
+++ b/packages/pulp-import-ir/src/adapters/claude-design-html/lower.ts
@@ -1,0 +1,607 @@
+// pulp #1486 — Claude Design HTML adapter (Phase 1 spike target).
+//
+// Lowers a Claude-Design-style HTML payload (a single document or a
+// fragment) into an IRNode tree. Uses content-hash anchors per §4.4.
+//
+// First-spike scope: structural translation + the most common style
+// properties. Anything not yet typed is preserved verbatim under
+// `raw_source.outerHtml` so a future Pulp version can re-walk the
+// source without a re-import.
+
+import type {
+    IRNode,
+    LowerOptions,
+    SourceFormat,
+    TypedLayout,
+    TypedPaint,
+    TypedText,
+    Confidence,
+} from '../../types.js';
+import { assignAnchors, DEFAULT_ANCHOR_STRATEGY, type PreAnchorIRNode } from '../../anchors.js';
+
+export const ADAPTER_NAME = 'claude-design-html';
+export const ADAPTER_VERSION = '0.1.0';
+
+// Pre-anchor IRNode used during the build phase. The final `lower()`
+// call resolves anchors via assignAnchors() and produces the public
+// IRNode shape.
+interface BuildNode extends PreAnchorIRNode {
+    layout?: TypedLayout;
+    paint?: TypedPaint;
+    text?: TypedText;
+    children: BuildNode[];
+    rawHtml: string;
+    inlineStyle?: Record<string, string>;
+    confidence: Confidence;
+}
+
+/**
+ * Lower a Claude Design HTML string (or fragment) into an IRNode tree.
+ *
+ * The payload is parsed via a small DOM-like walker that the Phase 1
+ * spike implements without depending on a full HTML parser — Claude
+ * Design output is well-formed enough that a regex-driven walker
+ * suffices for the first spike. A real implementation would lean on
+ * `parse5` or `htmlparser2`; that lands when we move to a real
+ * parser-driven adapter (Phase 2).
+ */
+export async function lowerClaudeDesignHtml(
+    rawHtml: string,
+    opts: LowerOptions = {},
+): Promise<IRNode> {
+    const strategy = opts.anchorStrategy ?? DEFAULT_ANCHOR_STRATEGY['claude-design-html'];
+    const ts = new Date().toISOString();
+
+    // 1. Parse HTML → BuildNode tree.
+    const root = parseHtmlToBuildNode(rawHtml.trim(), opts.preserveRawSource ?? true);
+
+    // 2. Compute stable_anchor_ids over the tree.
+    const anchors = assignAnchors(root, strategy);
+
+    // 3. Materialize public IRNode tree with provenance + raw_source.
+    const irRoot = materialize(root, anchors, ts, /*isRoot=*/ true);
+    return irRoot;
+}
+
+function materialize(
+    node: BuildNode,
+    anchors: Map<BuildNode, string>,
+    ts: string,
+    isRoot: boolean,
+): IRNode {
+    const stableAnchor = anchors.get(node);
+    if (!stableAnchor) {
+        throw new Error('assignAnchors did not produce an anchor for this BuildNode');
+    }
+    const rawSource: SourceFormat = {
+        kind: 'claude-design-html',
+        outerHtml: node.rawHtml,
+        ...(node.inlineStyle ? { computedStyle: node.inlineStyle } : {}),
+    };
+    const provenance = {
+        adapter: ADAPTER_NAME,
+        version: ADAPTER_VERSION,
+        ts,
+        ...(isRoot ? { imported_at: ts, last_seen_at: ts } : {}),
+    };
+    return {
+        tag: node.tag,
+        stable_anchor_id: stableAnchor,
+        ...(node.layout ? { layout: node.layout } : {}),
+        ...(node.paint ? { paint: node.paint } : {}),
+        ...(node.text ? { text: node.text } : {}),
+        children: node.children.map((c) => materialize(c, anchors, ts, false)),
+        ...(node.meta ? { meta: node.meta } : {}),
+        provenance,
+        raw_source: rawSource,
+        confidence: node.confidence,
+    };
+}
+
+// ── HTML parser ───────────────────────────────────────────────────────
+//
+// Phase 1: a regex-driven walker over a small subset of HTML that
+// covers what Claude Design generates. We accept:
+//   <tag attr="..." style="...">…</tag>
+//   <tag />            — self-closing
+//   text runs between tags
+//
+// We do NOT yet handle: DOCTYPE, comments, CDATA, scripts, attributes
+// without quotes, malformed nesting (assumes well-formed). Phase 2
+// swaps to parse5.
+
+interface ParsedTag {
+    tagName: string;
+    attrs: Record<string, string>;
+    selfClosing: boolean;
+    /** Position in the input string where the inner content starts. */
+    contentStart: number;
+}
+
+const TAG_OPEN = /<([a-zA-Z][a-zA-Z0-9-]*)((?:\s+[a-zA-Z-]+="[^"]*")*)\s*(\/?)>/g;
+const ATTR = /([a-zA-Z-]+)="([^"]*)"/g;
+
+function parseHtmlToBuildNode(html: string, preserveRawSource: boolean): BuildNode {
+    // If the input has multiple roots, wrap them in an implicit View
+    // (the spec's "fragment becomes a synthetic root" pattern).
+    // We try to find a single outer tag first; if that consumes the
+    // whole input, use it as the root, otherwise wrap.
+    const trimmed = html.trim();
+    const singleRoot = matchSingleOuterTag(trimmed);
+    if (singleRoot) {
+        const node = buildFromTag(trimmed, 0, trimmed.length, preserveRawSource);
+        if (node) return node;
+    }
+    // Multi-root or text-only — wrap in a synthetic View.
+    const children = parseFragment(trimmed, preserveRawSource);
+    return {
+        tag: 'View',
+        children,
+        rawHtml: trimmed,
+        confidence: 'PASS',
+    };
+}
+
+function matchSingleOuterTag(html: string): boolean {
+    if (!html.startsWith('<')) return false;
+    // Quick check: does the first tag's matching close-tag end the string?
+    const firstOpenMatch = html.match(/^<([a-zA-Z][a-zA-Z0-9-]*)/);
+    if (!firstOpenMatch) return false;
+    const tag = firstOpenMatch[1];
+    const closeTag = `</${tag}>`;
+    return html.endsWith(closeTag);
+}
+
+function buildFromTag(
+    src: string,
+    start: number,
+    end: number,
+    preserveRawSource: boolean,
+): BuildNode | null {
+    // Parse the opening tag.
+    const openMatch = src.slice(start).match(/^<([a-zA-Z][a-zA-Z0-9-]*)((?:\s+[a-zA-Z-]+="[^"]*")*)\s*(\/?)>/);
+    if (!openMatch) return null;
+    const [openText, tagName, attrText, selfClose] = openMatch;
+    const attrs = parseAttrs(attrText);
+    const contentStart = start + openText.length;
+
+    if (selfClose === '/') {
+        return makeNode(
+            tagName,
+            attrs,
+            [],
+            src.slice(start, contentStart),
+            undefined,
+            preserveRawSource,
+        );
+    }
+
+    // Find the matching close-tag. Phase 1 simplification: assumes
+    // well-formed, no same-tag nesting that would confuse us. (Phase 2
+    // uses parse5 and this concern goes away.)
+    const closeTag = `</${tagName}>`;
+    const closeIdx = findMatchingCloseTag(src, contentStart, tagName);
+    if (closeIdx < 0) {
+        // Malformed — treat as self-closing on the whole remainder.
+        return makeNode(tagName, attrs, [], src.slice(start, end), undefined, preserveRawSource);
+    }
+
+    const innerSrc = src.slice(contentStart, closeIdx);
+    const children = parseFragment(innerSrc, preserveRawSource);
+    const ownText = extractDirectTextContent(innerSrc);
+
+    const outerEnd = closeIdx + closeTag.length;
+    return makeNode(
+        tagName,
+        attrs,
+        children,
+        src.slice(start, outerEnd),
+        ownText,
+        preserveRawSource,
+    );
+}
+
+function findMatchingCloseTag(src: string, fromIdx: number, tagName: string): number {
+    const open = `<${tagName}`;
+    const close = `</${tagName}>`;
+    let depth = 1;
+    let i = fromIdx;
+    while (i < src.length) {
+        const nextOpen = src.indexOf(open, i);
+        const nextClose = src.indexOf(close, i);
+        if (nextClose < 0) return -1;
+        if (nextOpen >= 0 && nextOpen < nextClose) {
+            // Could be a same-tag opening — verify it's actually a tag start.
+            const after = src.charAt(nextOpen + open.length);
+            if (after === ' ' || after === '>' || after === '\n' || after === '\t' || after === '/') {
+                depth++;
+                i = nextOpen + open.length;
+                continue;
+            }
+            i = nextOpen + 1;
+            continue;
+        }
+        depth--;
+        if (depth === 0) return nextClose;
+        i = nextClose + close.length;
+    }
+    return -1;
+}
+
+function parseAttrs(attrText: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    if (!attrText) return out;
+    let m: RegExpExecArray | null;
+    const re = new RegExp(ATTR.source, 'g');
+    while ((m = re.exec(attrText)) !== null) {
+        out[m[1]] = m[2];
+    }
+    return out;
+}
+
+function parseFragment(src: string, preserveRawSource: boolean): BuildNode[] {
+    const children: BuildNode[] = [];
+    let i = 0;
+    while (i < src.length) {
+        // Skip leading whitespace between tags but preserve text-runs.
+        if (src[i] === '<' && src[i + 1] !== '/') {
+            const node = buildFromTag(src, i, src.length, preserveRawSource);
+            if (!node) {
+                i++;
+                continue;
+            }
+            // Advance past the consumed range. node.rawHtml is the
+            // outer slice — find it from `i`.
+            const consumed = node.rawHtml.length;
+            i += consumed;
+            children.push(node);
+            continue;
+        }
+        // Text run — collect up to next tag.
+        const nextLt = src.indexOf('<', i);
+        const textEnd = nextLt < 0 ? src.length : nextLt;
+        const textRun = src.slice(i, textEnd).trim();
+        if (textRun) {
+            children.push({
+                tag: 'Label',
+                children: [],
+                rawHtml: src.slice(i, textEnd),
+                text: { text: textRun },
+                confidence: 'PASS',
+            });
+        }
+        i = textEnd;
+    }
+    return children;
+}
+
+function extractDirectTextContent(innerSrc: string): string | undefined {
+    // If the inner content has NO child tags, it's a leaf text-run.
+    if (innerSrc.indexOf('<') < 0) {
+        const trimmed = innerSrc.trim();
+        return trimmed || undefined;
+    }
+    return undefined;
+}
+
+function makeNode(
+    tagName: string,
+    attrs: Record<string, string>,
+    children: BuildNode[],
+    rawHtml: string,
+    leafText: string | undefined,
+    preserveRawSource: boolean,
+): BuildNode {
+    const tag = mapHtmlTagToIRTag(tagName);
+    const inlineStyle = parseInlineStyle(attrs.style);
+
+    const layout = extractLayout(inlineStyle, attrs);
+    const paint = extractPaint(inlineStyle, attrs);
+    const text = extractText(inlineStyle, attrs, leafText);
+
+    const node: BuildNode = {
+        tag,
+        children,
+        rawHtml: preserveRawSource ? rawHtml : '',
+        confidence: 'PASS',
+    };
+    if (layout) node.layout = layout;
+    if (paint) node.paint = paint;
+    if (text) node.text = text;
+    if (Object.keys(inlineStyle).length > 0) {
+        node.inlineStyle = inlineStyle;
+    }
+    if (attrs.role || attrs['data-pulp-role']) {
+        node.meta = { role: attrs.role ?? attrs['data-pulp-role'] };
+    }
+    if (attrs.id) {
+        node.source_node_id = attrs.id;
+        node._adapter = ADAPTER_NAME;
+    }
+    return node;
+}
+
+function mapHtmlTagToIRTag(htmlTag: string): string {
+    const lower = htmlTag.toLowerCase();
+    switch (lower) {
+        case 'p':
+        case 'span':
+        case 'h1':
+        case 'h2':
+        case 'h3':
+        case 'h4':
+        case 'h5':
+        case 'h6':
+        case 'label':
+            return 'Label';
+        case 'button':
+            return 'Button';
+        case 'img':
+            return 'Image';
+        case 'svg':
+        case 'path':
+            return 'Icon';
+        case 'input':
+            return 'TextEditor';
+        case 'div':
+        case 'section':
+        case 'article':
+        case 'header':
+        case 'footer':
+        case 'nav':
+        case 'main':
+        case 'aside':
+        default:
+            return 'View';
+    }
+}
+
+function parseInlineStyle(styleAttr: string | undefined): Record<string, string> {
+    if (!styleAttr) return {};
+    const out: Record<string, string> = {};
+    for (const decl of styleAttr.split(';')) {
+        const idx = decl.indexOf(':');
+        if (idx < 0) continue;
+        const k = decl.slice(0, idx).trim();
+        const v = decl.slice(idx + 1).trim();
+        if (k && v) out[k] = v;
+    }
+    return out;
+}
+
+function extractLayout(
+    style: Record<string, string>,
+    attrs: Record<string, string>,
+): TypedLayout | undefined {
+    const out: TypedLayout = {};
+    let any = false;
+    const setLen = (k: keyof TypedLayout, v: string | undefined) => {
+        if (v === undefined) return;
+        const parsed = parseLength(v);
+        if (parsed !== undefined) {
+            (out as Record<string, unknown>)[k] = parsed;
+            any = true;
+        }
+    };
+    setLen('width', style['width']);
+    setLen('height', style['height']);
+    setLen('minWidth', style['min-width']);
+    setLen('maxWidth', style['max-width']);
+    setLen('minHeight', style['min-height']);
+    setLen('maxHeight', style['max-height']);
+    setLen('padding', style['padding']);
+    setLen('paddingTop', style['padding-top']);
+    setLen('paddingRight', style['padding-right']);
+    setLen('paddingBottom', style['padding-bottom']);
+    setLen('paddingLeft', style['padding-left']);
+    setLen('margin', style['margin']);
+    setLen('marginTop', style['margin-top']);
+    setLen('marginRight', style['margin-right']);
+    setLen('marginBottom', style['margin-bottom']);
+    setLen('marginLeft', style['margin-left']);
+    setLen('top', style['top']);
+    setLen('right', style['right']);
+    setLen('bottom', style['bottom']);
+    setLen('left', style['left']);
+    setLen('gap', style['gap']);
+    setLen('rowGap', style['row-gap']);
+    setLen('columnGap', style['column-gap']);
+    setLen('flexBasis', style['flex-basis']);
+
+    const display = style['display'];
+    if (display) {
+        out.display = display as TypedLayout['display'];
+        any = true;
+    }
+    const flexDirection = style['flex-direction'];
+    if (flexDirection) {
+        out.flexDirection = flexDirection as TypedLayout['flexDirection'];
+        any = true;
+    }
+    const flexWrap = style['flex-wrap'];
+    if (flexWrap) {
+        out.flexWrap = flexWrap as TypedLayout['flexWrap'];
+        any = true;
+    }
+    const alignItems = style['align-items'];
+    if (alignItems) {
+        out.alignItems = alignItems as TypedLayout['alignItems'];
+        any = true;
+    }
+    const alignSelf = style['align-self'];
+    if (alignSelf) {
+        out.alignSelf = alignSelf as TypedLayout['alignSelf'];
+        any = true;
+    }
+    const justifyContent = style['justify-content'];
+    if (justifyContent) {
+        out.justifyContent = justifyContent as TypedLayout['justifyContent'];
+        any = true;
+    }
+    const position = style['position'];
+    if (position) {
+        out.position = position as TypedLayout['position'];
+        any = true;
+    }
+    const zIndex = style['z-index'];
+    if (zIndex && /^-?\d+$/.test(zIndex)) {
+        out.zIndex = parseInt(zIndex, 10);
+        any = true;
+    }
+    const flexGrow = style['flex-grow'];
+    if (flexGrow && !isNaN(parseFloat(flexGrow))) {
+        out.flexGrow = parseFloat(flexGrow);
+        any = true;
+    }
+    const flexShrink = style['flex-shrink'];
+    if (flexShrink && !isNaN(parseFloat(flexShrink))) {
+        out.flexShrink = parseFloat(flexShrink);
+        any = true;
+    }
+    const overflow = style['overflow'];
+    if (overflow) {
+        out.overflow = overflow as TypedLayout['overflow'];
+        any = true;
+    }
+    void attrs; // reserved for future data-* layout extensions
+    return any ? out : undefined;
+}
+
+function extractPaint(
+    style: Record<string, string>,
+    _attrs: Record<string, string>,
+): TypedPaint | undefined {
+    const out: TypedPaint = {};
+    let any = false;
+    if (style['background-color']) {
+        out.backgroundColor = style['background-color'];
+        any = true;
+    }
+    if (style['color']) {
+        out.color = style['color'];
+        any = true;
+    }
+    if (style['border-color']) {
+        out.borderColor = style['border-color'];
+        any = true;
+    }
+    if (style['border-style']) {
+        out.borderStyle = style['border-style'] as TypedPaint['borderStyle'];
+        any = true;
+    }
+    const setLen = (k: keyof TypedPaint, v: string | undefined) => {
+        if (v === undefined) return;
+        const parsed = parseLength(v);
+        if (typeof parsed === 'number') {
+            (out as Record<string, unknown>)[k] = parsed;
+            any = true;
+        }
+    };
+    setLen('borderWidth', style['border-width']);
+    setLen('borderTopWidth', style['border-top-width']);
+    setLen('borderRightWidth', style['border-right-width']);
+    setLen('borderBottomWidth', style['border-bottom-width']);
+    setLen('borderLeftWidth', style['border-left-width']);
+    setLen('borderRadius', style['border-radius']);
+    setLen('borderTopLeftRadius', style['border-top-left-radius']);
+    setLen('borderTopRightRadius', style['border-top-right-radius']);
+    setLen('borderBottomLeftRadius', style['border-bottom-left-radius']);
+    setLen('borderBottomRightRadius', style['border-bottom-right-radius']);
+    if (style['opacity']) {
+        const o = parseFloat(style['opacity']);
+        if (!isNaN(o)) {
+            out.opacity = o;
+            any = true;
+        }
+    }
+    return any ? out : undefined;
+}
+
+function extractText(
+    style: Record<string, string>,
+    _attrs: Record<string, string>,
+    leafText: string | undefined,
+): TypedText | undefined {
+    const out: TypedText = {};
+    let any = false;
+    if (leafText) {
+        out.text = leafText;
+        any = true;
+    }
+    if (style['font-family']) {
+        out.fontFamily = style['font-family'];
+        any = true;
+    }
+    if (style['font-size']) {
+        const fs = parseLength(style['font-size']);
+        if (typeof fs === 'number') {
+            out.fontSize = fs;
+            any = true;
+        }
+    }
+    if (style['font-weight']) {
+        const w = style['font-weight'];
+        out.fontWeight = /^\d+$/.test(w) ? (parseInt(w, 10) as number) : (w as TypedText['fontWeight']);
+        any = true;
+    }
+    if (style['font-style']) {
+        out.fontStyle = style['font-style'] as TypedText['fontStyle'];
+        any = true;
+    }
+    if (style['line-height']) {
+        const lh = parseLineHeight(style['line-height']);
+        if (lh !== undefined) {
+            out.lineHeight = lh;
+            any = true;
+        }
+    }
+    if (style['letter-spacing']) {
+        const ls = parseLength(style['letter-spacing']);
+        if (typeof ls === 'number') {
+            out.letterSpacing = ls;
+            any = true;
+        }
+    }
+    if (style['text-align']) {
+        out.textAlign = style['text-align'] as TypedText['textAlign'];
+        any = true;
+    }
+    if (style['text-transform']) {
+        out.textTransform = style['text-transform'] as TypedText['textTransform'];
+        any = true;
+    }
+    return any ? out : undefined;
+}
+
+// ── Length parsing ────────────────────────────────────────────────────
+
+function parseLength(raw: string | undefined): number | string | undefined {
+    if (!raw) return undefined;
+    const s = raw.trim();
+    if (s === 'auto') return 'auto';
+    // Token-ref: '{spacing.sm}' — DTCG resolution happens post-lowering.
+    if (s.startsWith('{') && s.endsWith('}')) return s as `{${string}}`;
+    if (s.endsWith('px')) {
+        const n = parseFloat(s);
+        if (!isNaN(n)) return n;
+    }
+    if (s.endsWith('%') || s.endsWith('vw') || s.endsWith('vh')
+        || s.endsWith('vmin') || s.endsWith('vmax')) {
+        return s; // forwarded verbatim to Yoga via Dimension struct
+    }
+    // Bare number → px (CSS quirk: only valid in some properties, but
+    // we accept it leniently at the IR layer).
+    const n = parseFloat(s);
+    if (!isNaN(n) && /^[\d.]+$/.test(s)) return n;
+    return undefined;
+}
+
+function parseLineHeight(raw: string): number | undefined {
+    const s = raw.trim();
+    if (s.endsWith('px')) {
+        const n = parseFloat(s);
+        return isNaN(n) ? undefined : n;
+    }
+    const n = parseFloat(s);
+    return isNaN(n) ? undefined : n;
+}

--- a/packages/pulp-import-ir/src/anchors.ts
+++ b/packages/pulp-import-ir/src/anchors.ts
@@ -1,0 +1,189 @@
+// pulp #1486 — stable_anchor_id strategies (§4 of the spec).
+//
+// Three strategies:
+//   • content-hash — used by Claude Design HTML / Stitch / generic HTML.
+//                     Hash over (tag, role, normalized text, depth).
+//   • path        — used by RN file exports / hand-edited code.
+//                    `Frame[2]/Section[0]/Button#0` w/ tiebreak.
+//   • adapter     — used by Figma / Pencil / Mitosis (sources with native IDs).
+//
+// Phase 1 spike: content-hash + path (adapter strategy is a thin
+// passthrough that the adapter populates during lower()).
+
+import type { IRNode, AnchorStrategy } from './types.js';
+
+// ── Mitosis-shape hash (lifted from MIT-licensed
+// mitosis/packages/core/src/symbols/symbol-processor.ts:187,
+// also referenced by Builder content-hash IDs). 32-bit FNV-style fold;
+// deterministic over sorted-key object input.
+//
+// We re-implement here rather than vendor — the algorithm is ~30 lines
+// and the upstream surface is liable to change in ways unrelated to
+// Pulp's needs (per CLAUDE.md "pattern lift, no vendoring").
+export function hashCodeAsString(input: unknown): string {
+    const str = stableStringify(input);
+    // FNV-1a 32-bit. Fast, stable, low collision rate at the scale we
+    // care about (a single design tree's worth of nodes — typically
+    // <10k). Output is base-36 for compact anchors.
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < str.length; i++) {
+        hash ^= str.charCodeAt(i);
+        // Math.imul for 32-bit multiplication w/o JS-number overflow.
+        hash = Math.imul(hash, 0x01000193);
+    }
+    // Force unsigned 32-bit.
+    return (hash >>> 0).toString(36);
+}
+
+// JSON.stringify is non-deterministic for objects (key order is
+// implementation-defined). Sort keys recursively for a stable hash.
+function stableStringify(v: unknown): string {
+    if (v === null || typeof v !== 'object') return JSON.stringify(v);
+    if (Array.isArray(v)) {
+        return '[' + v.map(stableStringify).join(',') + ']';
+    }
+    const obj = v as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    return (
+        '{' +
+        keys.map((k) => JSON.stringify(k) + ':' + stableStringify(obj[k])).join(',') +
+        '}'
+    );
+}
+
+// Pre-anchor input shape — what the adapter passes BEFORE the anchor is
+// computed. (anchor depends on the typed fields, but not on the anchor
+// itself, so we accept this lighter shape.)
+export interface PreAnchorIRNode {
+    tag: string;
+    text?: { text?: string };
+    meta?: { role?: string; anchor_id_override?: string };
+    children: PreAnchorIRNode[];
+    /** Adapter-side native ID (only used for the 'adapter' strategy). */
+    source_node_id?: string;
+    /** Adapter name — used for the 'adapter' strategy prefix. */
+    _adapter?: string;
+}
+
+/**
+ * Generate a stable_anchor_id for `node` according to `strategy`.
+ *
+ * - `content-hash`: hash of (tag, role, normalized text, depth).
+ *   Survives reorder; brittle to text edits.
+ * - `path`: `Tag[idx]/Tag[idx]/...` from root.
+ *   Survives text edits; brittle to reorder + sibling insert.
+ * - `adapter`: `<adapter-name>:<source_node_id>`.
+ *   Best-of-all for sources with native IDs.
+ */
+export function generateAnchorId(
+    node: PreAnchorIRNode,
+    parent: PreAnchorIRNode | null,
+    parentChildIndex: number,
+    depth: number,
+    strategy: AnchorStrategy,
+    parentAnchorId: string = '',
+    siblingTagCounter: Map<string, number> = new Map(),
+): string {
+    if (node.meta?.anchor_id_override) {
+        return node.meta.anchor_id_override;
+    }
+    if (strategy === 'adapter') {
+        if (!node._adapter || !node.source_node_id) {
+            throw new Error(
+                `anchor strategy='adapter' requires node._adapter + source_node_id; ` +
+                    `got adapter=${node._adapter}, source_node_id=${node.source_node_id}`,
+            );
+        }
+        return `${node._adapter}:${node.source_node_id}`;
+    }
+    if (strategy === 'path') {
+        const tag = node.tag;
+        const idxAmongSameTag = siblingTagCounter.get(tag) ?? 0;
+        siblingTagCounter.set(tag, idxAmongSameTag + 1);
+        const seg = `${tag}[${idxAmongSameTag}]`;
+        return parentAnchorId ? `${parentAnchorId}/${seg}` : seg;
+    }
+    // content-hash
+    const tag = node.tag;
+    const role = node.meta?.role ?? '';
+    const text = (node.text?.text ?? '').replace(/\s+/g, ' ').trim().toLowerCase();
+    return hashCodeAsString({ tag, role, text, depth });
+}
+
+/**
+ * Walk a pre-anchor tree and return a parallel tree where every node
+ * has a `stable_anchor_id`. Used by adapter `lower()` after the typed
+ * fields are populated.
+ *
+ * Purely traversal-shaped — no IR mutation. The adapter calls this in
+ * the final stage of `lower()`.
+ */
+export function assignAnchors<T extends PreAnchorIRNode>(
+    root: T,
+    strategy: AnchorStrategy,
+): Map<T, string> {
+    const out = new Map<T, string>();
+    walk(root, null, 0, 0, '', out, strategy);
+    return out;
+}
+
+function walk<T extends PreAnchorIRNode>(
+    node: T,
+    parent: T | null,
+    parentChildIndex: number,
+    depth: number,
+    parentAnchor: string,
+    out: Map<T, string>,
+    strategy: AnchorStrategy,
+): void {
+    const id = generateAnchorId(
+        node,
+        parent,
+        parentChildIndex,
+        depth,
+        strategy,
+        parentAnchor,
+        // path strategy needs a sibling counter across the parent's
+        // children — we re-build it per child-index so the count
+        // matches "previous siblings of the same tag".
+        countSiblingTags(parent, parentChildIndex),
+    );
+    out.set(node, id);
+
+    // For the 'path' strategy, child-anchors are scoped to this
+    // node's anchor. For 'content-hash' / 'adapter', children
+    // generate independently.
+    const childParentAnchor = strategy === 'path' ? id : '';
+
+    for (let i = 0; i < node.children.length; i++) {
+        const c = node.children[i] as T;
+        walk(c, node, i, depth + 1, childParentAnchor, out, strategy);
+    }
+}
+
+function countSiblingTags(
+    parent: PreAnchorIRNode | null,
+    upToIndex: number,
+): Map<string, number> {
+    const counter = new Map<string, number>();
+    if (!parent) return counter;
+    for (let i = 0; i < upToIndex; i++) {
+        const c = parent.children[i];
+        if (!c) continue;
+        counter.set(c.tag, (counter.get(c.tag) ?? 0) + 1);
+    }
+    return counter;
+}
+
+// Default per-source strategy, per §4.4 of the spec.
+export const DEFAULT_ANCHOR_STRATEGY: Record<string, AnchorStrategy> = {
+    'figma-mcp': 'adapter',
+    'figma-zip': 'adapter',
+    'pencil-mcp': 'adapter',
+    mitosis: 'adapter',
+    'rn-file': 'path',
+    'v0-tsx': 'content-hash',
+    'stitch-html': 'content-hash',
+    'claude-design-html': 'content-hash',
+    'generic-html': 'content-hash',
+};

--- a/packages/pulp-import-ir/src/diff.ts
+++ b/packages/pulp-import-ir/src/diff.ts
@@ -1,0 +1,140 @@
+// pulp #1486 — Drift diff (§7 of the spec).
+//
+// Compares two IR trees produced by the SAME adapter and emits a flat
+// list of Drift entries keyed by stable_anchor_id. Phase 1 supports:
+//   - added / removed / changed / reordered
+//   - orphaned-tweak (carried over from applyTweaks's meta.orphaned_tweaks)
+//
+// Field-level diff walks the typed top-level fields (layout/paint/text)
+// and emits 'changed' per differing dotted path. Same path-encoding as
+// the tweaks file, so a Drift.changed can be replayed against
+// applyTweaks() without reformatting.
+
+import type { IRNode, Drift } from './types.js';
+
+/**
+ * Two-tree diff. Pure-sync. Result is sorted by anchor for
+ * deterministic test fixtures.
+ */
+export function diff(prev: IRNode, next: IRNode): Drift[] {
+    const prevByAnchor = indexByAnchor(prev);
+    const nextByAnchor = indexByAnchor(next);
+    const result: Drift[] = [];
+
+    // added / changed / reordered
+    for (const [anchor, nextEntry] of nextByAnchor) {
+        const prevEntry = prevByAnchor.get(anchor);
+        if (!prevEntry) {
+            result.push({ kind: 'added', anchor, node: nextEntry.node });
+            continue;
+        }
+        // Field-level diff
+        const fieldDrifts = diffTypedFields(prevEntry.node, nextEntry.node);
+        for (const fd of fieldDrifts) result.push(fd);
+
+        // Reorder
+        if (
+            prevEntry.parentAnchor !== nextEntry.parentAnchor ||
+            prevEntry.childIndex !== nextEntry.childIndex
+        ) {
+            result.push({
+                kind: 'reordered',
+                anchor,
+                oldIndex: prevEntry.childIndex,
+                newIndex: nextEntry.childIndex,
+                parent: nextEntry.parentAnchor ?? '',
+            });
+        }
+    }
+
+    // removed
+    for (const [anchor, prevEntry] of prevByAnchor) {
+        if (!nextByAnchor.has(anchor)) {
+            result.push({ kind: 'removed', anchor, node: prevEntry.node });
+        }
+    }
+
+    // orphaned-tweak: passed through if next.meta.orphaned_tweaks is set.
+    const orphaned = next.meta?.orphaned_tweaks;
+    if (orphaned) {
+        for (const [anchor, tweak] of Object.entries(orphaned)) {
+            result.push({
+                kind: 'orphaned-tweak',
+                anchor,
+                tweak: tweak as { [path: string]: unknown },
+                reason: 'node-deleted',
+            });
+        }
+    }
+
+    // Deterministic order
+    result.sort((a, b) => {
+        if (a.anchor !== b.anchor) return a.anchor < b.anchor ? -1 : 1;
+        return a.kind < b.kind ? -1 : a.kind > b.kind ? 1 : 0;
+    });
+    return result;
+}
+
+interface IndexEntry {
+    node: IRNode;
+    parentAnchor: string | null;
+    childIndex: number;
+}
+
+function indexByAnchor(root: IRNode): Map<string, IndexEntry> {
+    const out = new Map<string, IndexEntry>();
+    walk(root, null, 0, out);
+    return out;
+}
+
+function walk(
+    node: IRNode,
+    parentAnchor: string | null,
+    childIndex: number,
+    out: Map<string, IndexEntry>,
+): void {
+    out.set(node.stable_anchor_id, { node, parentAnchor, childIndex });
+    for (let i = 0; i < node.children.length; i++) {
+        walk(node.children[i], node.stable_anchor_id, i, out);
+    }
+}
+
+function diffTypedFields(prev: IRNode, next: IRNode): Drift[] {
+    const out: Drift[] = [];
+    const sections = ['layout', 'paint', 'text'] as const;
+    for (const sec of sections) {
+        const a = (prev as unknown as Record<string, unknown>)[sec] as
+            | Record<string, unknown>
+            | undefined;
+        const b = (next as unknown as Record<string, unknown>)[sec] as
+            | Record<string, unknown>
+            | undefined;
+        const keys = new Set<string>([
+            ...(a ? Object.keys(a) : []),
+            ...(b ? Object.keys(b) : []),
+        ]);
+        for (const k of keys) {
+            const ov = a?.[k];
+            const nv = b?.[k];
+            if (!shallowEqual(ov, nv)) {
+                out.push({
+                    kind: 'changed',
+                    anchor: next.stable_anchor_id,
+                    field: `${sec}.${k}`,
+                    oldValue: ov,
+                    newValue: nv,
+                });
+            }
+        }
+    }
+    return out;
+}
+
+function shallowEqual(a: unknown, b: unknown): boolean {
+    if (a === b) return true;
+    if (a == null || b == null) return false;
+    if (typeof a !== typeof b) return false;
+    // For arrays / objects we go deep via JSON — values in the IR are
+    // either primitives or POJOs; this is a fine spike-quality check.
+    return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/packages/pulp-import-ir/src/index.ts
+++ b/packages/pulp-import-ir/src/index.ts
@@ -1,0 +1,34 @@
+// pulp #1486 — public surface for @pulp/import-ir.
+//
+// Phase 1 spike: types + content-hash anchors + Claude Design HTML
+// adapter + tweaks layer + JSX-like tree map. CLI integration
+// (`pulp import design path/x.html`) lives downstream; this package
+// stays renderer-agnostic so adapters (Figma MCP, Pencil, Mitosis, …)
+// can land independently against the same IR contract.
+
+export * from './types.js';
+export {
+    hashCodeAsString,
+    generateAnchorId,
+    assignAnchors,
+    DEFAULT_ANCHOR_STRATEGY,
+} from './anchors.js';
+export {
+    applyTweaks,
+    setByDottedPath,
+    nodeFsTweaksIO,
+    emptyTweaksFile,
+    orphanedTweakDrifts,
+    type TweaksIO,
+} from './tweaks.js';
+export { diff } from './diff.js';
+export {
+    toJSXLikeTree,
+    flattenJSXLike,
+    type JSXLikeNode,
+} from './lower-via-prop-applier.js';
+export {
+    lowerClaudeDesignHtml,
+    ADAPTER_NAME as CLAUDE_DESIGN_HTML_ADAPTER_NAME,
+    ADAPTER_VERSION as CLAUDE_DESIGN_HTML_ADAPTER_VERSION,
+} from './adapters/claude-design-html/lower.js';

--- a/packages/pulp-import-ir/src/lower-via-prop-applier.ts
+++ b/packages/pulp-import-ir/src/lower-via-prop-applier.ts
@@ -1,0 +1,103 @@
+// pulp #1486 — IR → JSX-equivalent intrinsics → @pulp/react prop-applier
+// dispatch (§10 Q7 of the spec, user-locked decision: duplicative-but-safe
+// route through the well-tested code path).
+//
+// Phase 1 spike: this is the SKELETON. The real wiring lives in the
+// CLI's `pulp import design` flow and uses @pulp/react's React
+// renderer. This file isolates the IR → React-tree translation so
+// downstream consumers (CLI / tests) don't have to know the IR shape.
+//
+// The translation is a pure tree map: each IRNode becomes a `{ tag,
+// props, children }` shape that a downstream renderer can feed into
+// `React.createElement` (or any equivalent tree-builder). Returning a
+// concrete JSX-equivalent shape rather than React elements lets the
+// IR package stay decoupled from a specific React version.
+
+import type { IRNode } from './types.js';
+
+/**
+ * JSX-equivalent shape — a concrete tree any tree-builder can consume.
+ * Caller chooses how to render: React.createElement(tag, props,
+ * ...children.map(toReactElement)) is the obvious bridge.
+ */
+export interface JSXLikeNode {
+    tag: string;
+    props: Record<string, unknown>;
+    children: JSXLikeNode[];
+}
+
+/**
+ * Convert an IRNode tree to a JSX-equivalent tree shape. Pure.
+ *
+ * The output's `props` map mirrors @pulp/react's StyleProps + FlexProps
+ * shape — which the prop-applier already knows how to dispatch through
+ * to the bridge. The flattening rule is:
+ *   - layout / paint / text typed fields flatten into one top-level
+ *     `style`-flavored object whose keys match the prop-applier's
+ *     `case 'X':` dispatchers.
+ *   - text leaf content becomes the `text` prop on Label / Button.
+ *   - children recurse.
+ *   - meta.role becomes a data-pulp-role marker on the props map for
+ *     diagnostics; non-mappable IR fields ride through unchanged so a
+ *     future renderer iteration can pick them up.
+ */
+export function toJSXLikeTree(node: IRNode): JSXLikeNode {
+    const props: Record<string, unknown> = {};
+
+    if (node.layout) {
+        for (const [k, v] of Object.entries(node.layout)) {
+            // The prop-applier's case keys map 1:1 to TypedLayout names.
+            props[k] = v;
+        }
+    }
+    if (node.paint) {
+        for (const [k, v] of Object.entries(node.paint)) {
+            props[k] = v;
+        }
+    }
+    if (node.text) {
+        for (const [k, v] of Object.entries(node.text)) {
+            // text leaf content goes via the `text` prop the bridge
+            // already understands; everything else (fontSize, etc.)
+            // flattens with its own name.
+            props[k] = v;
+        }
+    }
+
+    // Stable anchor ID rides through as React-key + data-* marker so
+    // the renderer can correlate back to the IR + tweaks layer when
+    // building dev-tools surfaces.
+    props['key'] = node.stable_anchor_id;
+    props['data-pulp-anchor'] = node.stable_anchor_id;
+    if (node.meta?.role) {
+        props['data-pulp-role'] = node.meta.role;
+    }
+
+    return {
+        tag: node.tag,
+        props,
+        children: node.children.map(toJSXLikeTree),
+    };
+}
+
+/**
+ * Walk a JSXLikeTree and produce a flat list of `(tag, props)` pairs
+ * for tests + dev-tools. The IR's tree-shape is preserved via parent
+ * indexing on every entry.
+ */
+export function flattenJSXLike(
+    root: JSXLikeNode,
+): { tag: string; props: Record<string, unknown>; depth: number }[] {
+    const out: { tag: string; props: Record<string, unknown>; depth: number }[] = [];
+    walk(root, 0, out);
+    return out;
+}
+
+function walk(
+    n: JSXLikeNode,
+    depth: number,
+    out: { tag: string; props: Record<string, unknown>; depth: number }[],
+): void {
+    out.push({ tag: n.tag, props: n.props, depth });
+    for (const c of n.children) walk(c, depth + 1, out);
+}

--- a/packages/pulp-import-ir/src/tweaks.ts
+++ b/packages/pulp-import-ir/src/tweaks.ts
@@ -1,0 +1,160 @@
+// pulp #1486 — Tweaks layer (§7, §8 of the spec).
+//
+// Reads `pulp-tweaks.json` from disk, applies dev overrides on top of
+// a freshly-lowered IRNode tree. Pure functions — no side effects.
+//
+// Tweaks are keyed by stable_anchor_id; values are dotted-path overrides
+// into the IRNode's typed fields:
+//   { "anchor-X": { "paint.backgroundColor": "#ff00aa", "text.fontSize": 18 } }
+
+import type { IRNode, TweaksFile, TweakValue, Drift } from './types.js';
+
+/**
+ * Apply tweaks on top of an IR tree. Pure — does not mutate `node` or
+ * `tweaks`. Tweaks whose anchor IS in the tree are deep-merged onto
+ * the typed fields; tweaks whose anchor is NOT found are attached to
+ * the root's `meta.orphaned_tweaks` and surfaced via diff() as
+ * Drift.orphaned-tweak.
+ */
+export function applyTweaks(node: IRNode, tweaks: TweaksFile): IRNode {
+    const seen = new Set<string>();
+    const result = applyToNode(node, tweaks, seen);
+
+    // Compute orphaned tweaks (anchors in the file that didn't appear
+    // in the tree). Attach them to the result root's meta so diff()
+    // can surface them in subsequent calls.
+    const orphaned: Record<string, TweakValue> = {};
+    for (const [anchor, tweak] of Object.entries(tweaks.tweaks)) {
+        if (!seen.has(anchor)) {
+            orphaned[anchor] = tweak;
+        }
+    }
+    if (Object.keys(orphaned).length > 0) {
+        return {
+            ...result,
+            meta: {
+                ...(result.meta ?? {}),
+                orphaned_tweaks: orphaned,
+            },
+        };
+    }
+    return result;
+}
+
+function applyToNode(
+    node: IRNode,
+    tweaks: TweaksFile,
+    seen: Set<string>,
+): IRNode {
+    const tweak = tweaks.tweaks[node.stable_anchor_id];
+    let nextNode: IRNode = {
+        ...node,
+        children: node.children.map((c) => applyToNode(c, tweaks, seen)),
+    };
+    if (tweak) {
+        seen.add(node.stable_anchor_id);
+        nextNode = applyTweakValue(nextNode, tweak);
+    }
+    return nextNode;
+}
+
+function applyTweakValue(node: IRNode, tweak: TweakValue): IRNode {
+    let next = node;
+    for (const [path, value] of Object.entries(tweak)) {
+        next = setByDottedPath(next, path, value);
+    }
+    return next;
+}
+
+/**
+ * Set a dotted-path field on an IRNode without mutating the original.
+ * Phase 1 supports flat paths into typed top-level fields:
+ *   'paint.backgroundColor'
+ *   'text.fontSize'
+ *   'layout.padding'
+ *   'meta.role'
+ * `null` value clears the field (deletion semantics per §8.3).
+ */
+export function setByDottedPath(node: IRNode, path: string, value: unknown): IRNode {
+    const segments = path.split('.');
+    if (segments.length < 2) return node;
+
+    const [section, ...rest] = segments;
+    const key = rest.join('.');
+
+    // Walk into the typed section, clone it, set the leaf, return a
+    // new node with the cloned section spliced in.
+    const sectionVal = (node as unknown as Record<string, unknown>)[section];
+    const sectionObj = (sectionVal && typeof sectionVal === 'object'
+        ? { ...(sectionVal as Record<string, unknown>) }
+        : {}) as Record<string, unknown>;
+
+    if (value === null) {
+        delete sectionObj[key];
+    } else {
+        sectionObj[key] = value;
+    }
+    return {
+        ...node,
+        [section]: sectionObj,
+    } as IRNode;
+}
+
+// ── File I/O — narrow API surface for the spike ──────────────────────
+//
+// Phase 1 keeps fs access optional so the IR core stays browser-loadable.
+// CLI integration (pulp import design ...) will inject the fs hook.
+
+export interface TweaksIO {
+    readTweaks(filePath: string): Promise<TweaksFile | null>;
+    writeTweaks(filePath: string, tweaks: TweaksFile): Promise<void>;
+}
+
+/**
+ * Default Node-fs implementation. Lazily imports `node:fs/promises` so
+ * browser bundlers don't try to resolve it.
+ */
+export function nodeFsTweaksIO(): TweaksIO {
+    return {
+        async readTweaks(filePath: string): Promise<TweaksFile | null> {
+            const fs = await import('node:fs/promises');
+            try {
+                const raw = await fs.readFile(filePath, 'utf8');
+                return JSON.parse(raw) as TweaksFile;
+            } catch (err: unknown) {
+                if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return null;
+                throw err;
+            }
+        },
+        async writeTweaks(filePath: string, tweaks: TweaksFile): Promise<void> {
+            const fs = await import('node:fs/promises');
+            await fs.writeFile(filePath, JSON.stringify(tweaks, null, 2) + '\n', 'utf8');
+        },
+    };
+}
+
+// ── Empty tweaks file helper (used at first import) ──────────────────
+
+export function emptyTweaksFile(pulpVersion: string, importSession: string): TweaksFile {
+    return {
+        $schema: 'pulp-tweaks://v1',
+        meta: { pulpVersion, importSession },
+        tweaks: {},
+    };
+}
+
+// ── Diff — produces orphaned-tweak Drift entries ─────────────────────
+//
+// Surfaced when applyTweaks() saw tweaks whose anchors weren't found
+// in the freshly-lowered tree. The CLI uses this to print a
+// "tweaks lost" report.
+export function orphanedTweakDrifts(node: IRNode): Drift[] {
+    const orphaned = node.meta?.orphaned_tweaks;
+    if (!orphaned) return [];
+    return Object.entries(orphaned).map(([anchor, tweak]) => ({
+        kind: 'orphaned-tweak' as const,
+        anchor,
+        tweak: tweak as TweakValue,
+        reason: 'node-deleted' as const,
+    }));
+}

--- a/packages/pulp-import-ir/src/types.ts
+++ b/packages/pulp-import-ir/src/types.ts
@@ -1,0 +1,334 @@
+// pulp #1486 — Pulp design-import IR (Phase 1 spike).
+//
+// IRNode is the typed intermediate representation that survives source
+// re-import. Adapters lower source formats (Figma / Mitosis / Claude
+// Design HTML / etc.) into IRNode trees keyed by `stable_anchor_id`;
+// the tweaks layer (`pulp-tweaks.json`) is keyed by the same anchors,
+// so dev overrides survive when the designer regenerates the source.
+//
+// Spec: /tmp/pulp-ir-spec-spike.md (sub-agent #25 draft).
+// Phase 1: types + Claude Design HTML adapter (content-hash anchors)
+// + tweaks read/write + 5-scenario harness.
+
+// ── Value types (§1.1, §2.1) ──────────────────────────────────────────
+
+export type TokenRef = `{${string}}`;
+
+export type Length =
+    | number
+    | `${number}%`
+    | `${number}vw`
+    | `${number}vh`
+    | `${number}vmin`
+    | `${number}vmax`
+    | 'auto'
+    | TokenRef;
+
+export type Color = string | TokenRef;
+export type Pixels = number | TokenRef;
+export type NumberRef = number | TokenRef;
+
+// ── TypedLayout (§1.2) ────────────────────────────────────────────────
+
+export interface TypedLayout {
+    display?: 'flex' | 'none' | 'contents' | 'block' | 'inline-flex' | string;
+
+    flexDirection?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
+    flexWrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
+    flexGrow?: number;
+    flexShrink?: number;
+    flexBasis?: Length;
+    order?: number;
+
+    alignItems?: 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline';
+    alignSelf?: 'auto' | 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline';
+    alignContent?: 'flex-start' | 'center' | 'flex-end' | 'stretch'
+        | 'space-between' | 'space-around' | 'space-evenly';
+    justifyContent?: 'flex-start' | 'center' | 'flex-end'
+        | 'space-between' | 'space-around' | 'space-evenly';
+
+    margin?: Length;
+    marginTop?: Length;
+    marginRight?: Length;
+    marginBottom?: Length;
+    marginLeft?: Length;
+    marginHorizontal?: Length;
+    marginVertical?: Length;
+
+    padding?: Length;
+    paddingTop?: Length;
+    paddingRight?: Length;
+    paddingBottom?: Length;
+    paddingLeft?: Length;
+    paddingHorizontal?: Length;
+    paddingVertical?: Length;
+
+    top?: Length;
+    right?: Length;
+    bottom?: Length;
+    left?: Length;
+    inset?: Length;
+
+    width?: Length;
+    height?: Length;
+    minWidth?: Length;
+    maxWidth?: Length;
+    minHeight?: Length;
+    maxHeight?: Length;
+
+    position?: 'static' | 'relative' | 'absolute' | 'fixed' | 'sticky';
+    zIndex?: number;
+
+    gap?: Length;
+    rowGap?: Length;
+    columnGap?: Length;
+
+    aspectRatio?: number | `${number}/${number}`;
+
+    overflow?: 'visible' | 'hidden' | 'scroll' | 'auto';
+    overflowX?: 'visible' | 'hidden' | 'scroll' | 'auto';
+    overflowY?: 'visible' | 'hidden' | 'scroll' | 'auto';
+}
+
+// ── TypedPaint (§2.2) ─────────────────────────────────────────────────
+
+export interface Gradient {
+    type: 'linear' | 'radial' | 'conic';
+    angle?: number;
+    stops: { offset: number; color: Color }[];
+}
+
+export interface BoxShadowOp {
+    offsetX: Pixels;
+    offsetY: Pixels;
+    blur: Pixels;
+    spread?: Pixels;
+    color: Color;
+    inset?: boolean;
+}
+
+export type FilterFn =
+    | { fn: 'blur'; px: Pixels }
+    | { fn: 'brightness'; amount: NumberRef }
+    | { fn: 'contrast'; amount: NumberRef }
+    | { fn: 'grayscale'; amount: NumberRef }
+    | { fn: 'sepia'; amount: NumberRef }
+    | { fn: 'hue-rotate'; deg: NumberRef }
+    | { fn: 'invert'; amount: NumberRef }
+    | { fn: 'saturate'; amount: NumberRef }
+    | { fn: 'opacity'; amount: NumberRef }
+    | { fn: 'drop-shadow'; offsetX: Pixels; offsetY: Pixels; blur: Pixels; color: Color };
+
+export type TransformOp =
+    | { op: 'scale'; x: NumberRef; y?: NumberRef }
+    | { op: 'scaleX'; x: NumberRef }
+    | { op: 'scaleY'; y: NumberRef }
+    | { op: 'translate'; x: Pixels; y: Pixels }
+    | { op: 'translateX'; x: Pixels }
+    | { op: 'translateY'; y: Pixels }
+    | { op: 'rotate'; deg: NumberRef }
+    | { op: 'rotateX'; deg: NumberRef }
+    | { op: 'rotateY'; deg: NumberRef }
+    | { op: 'rotateZ'; deg: NumberRef }
+    | { op: 'skewX'; deg: NumberRef }
+    | { op: 'skewY'; deg: NumberRef }
+    | { op: 'matrix'; values: [number, number, number, number, number, number] }
+    | { op: 'perspective'; distance: Pixels };
+
+export interface TypedPaint {
+    backgroundColor?: Color;
+    backgroundGradient?: Gradient;
+
+    color?: Color;
+
+    borderColor?: Color;
+    borderTopColor?: Color;
+    borderRightColor?: Color;
+    borderBottomColor?: Color;
+    borderLeftColor?: Color;
+    borderWidth?: Pixels;
+    borderTopWidth?: Pixels;
+    borderRightWidth?: Pixels;
+    borderBottomWidth?: Pixels;
+    borderLeftWidth?: Pixels;
+    borderStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove'
+        | 'ridge' | 'inset' | 'outset' | 'none' | 'hidden';
+
+    borderRadius?: Pixels;
+    borderTopLeftRadius?: Pixels;
+    borderTopRightRadius?: Pixels;
+    borderBottomLeftRadius?: Pixels;
+    borderBottomRightRadius?: Pixels;
+
+    boxShadow?: BoxShadowOp[];
+
+    opacity?: NumberRef;
+    filter?: FilterFn[];
+    backdropFilter?: FilterFn[];
+
+    transform?: TransformOp[];
+
+    cursor?: 'default' | 'pointer' | 'text' | 'crosshair' | 'grab' | 'grabbing' | 'not-allowed';
+}
+
+// ── TypedText (§3) ────────────────────────────────────────────────────
+
+export interface TypedText {
+    fontFamily?: string | TokenRef;
+    fontSize?: Pixels;
+    fontWeight?: number | 'normal' | 'bold' | 'lighter' | 'bolder';
+    fontStyle?: 'normal' | 'italic' | 'oblique';
+
+    lineHeight?: Pixels | number;
+    letterSpacing?: Pixels;
+    wordSpacing?: Pixels;
+
+    textAlign?: 'left' | 'center' | 'right' | 'justify' | 'auto';
+    textDecorationLine?: 'none' | 'underline' | 'line-through' | 'underline line-through';
+    textDecorationColor?: Color;
+    textDecorationStyle?: 'solid' | 'double' | 'dotted' | 'dashed' | 'wavy';
+    textTransform?: 'none' | 'uppercase' | 'lowercase' | 'capitalize';
+
+    whiteSpace?: 'normal' | 'nowrap' | 'pre' | 'pre-wrap' | 'pre-line';
+    wordWrap?: 'normal' | 'break-word';
+    overflowWrap?: 'normal' | 'break-word' | 'anywhere';
+    textOverflow?: 'clip' | 'ellipsis';
+    numberOfLines?: number;
+
+    text?: string;
+}
+
+// ── raw_source (§5) ──────────────────────────────────────────────────
+
+export type SourceFormat =
+    | { kind: 'figma-reconstruction'; spec: unknown }
+    | { kind: 'figma-mcp-design-context'; payload: unknown }
+    | { kind: 'html'; outerHtml: string; computedStyle?: Record<string, string> }
+    | { kind: 'mitosis'; node: unknown }
+    | { kind: 'pencil-mcp'; node: unknown }
+    | { kind: 'stitch-html'; outerHtml: string }
+    | { kind: 'v0-tsx'; jsxText: string }
+    | { kind: 'claude-design-html'; outerHtml: string; computedStyle?: Record<string, string> }
+    | { kind: 'rn-file'; jsxText: string }
+    | { kind: 'unknown'; payload: unknown };
+
+// ── provenance (§6) ──────────────────────────────────────────────────
+
+export interface IRProvenance {
+    adapter: string;
+    version: string;
+    ts: string;
+
+    source_uri?: string;
+    imported_at?: string;
+    last_seen_at?: string;
+    regen_count?: number;
+
+    source_url?: string;
+    source_commit?: string;
+}
+
+// ── confidence (§7.2) ────────────────────────────────────────────────
+
+export type Confidence = 'PASS' | 'DIVERGE' | 'NOT_IMPL';
+
+// ── IRNode (the unifying tree shape) ─────────────────────────────────
+
+export type IRTag =
+    | 'View'
+    | 'Label'
+    | 'Button'
+    | 'Image'
+    | 'Icon'
+    | 'TextEditor'
+    | 'ScrollView'
+    | 'Modal'
+    | string;
+
+export interface IRMeta {
+    role?: string;
+    anchor_id_override?: string;
+    /** Set by applyTweaks when a tweak's anchor isn't found in the tree. */
+    orphaned_tweaks?: Record<string, TweakValue>;
+    /** Allow adapter-specific extras without widening the surface area. */
+    [key: string]: unknown;
+}
+
+export interface IRNode {
+    tag: IRTag;
+    stable_anchor_id: string;
+    /** Optional adapter-side identifier — Figma node IDs, Pencil node IDs, etc. */
+    source_node_id?: string;
+
+    layout?: TypedLayout;
+    paint?: TypedPaint;
+    text?: TypedText;
+
+    children: IRNode[];
+
+    meta?: IRMeta;
+    provenance: IRProvenance;
+    raw_source: SourceFormat;
+    confidence: Confidence;
+}
+
+// ── Adapter contract (§7) ────────────────────────────────────────────
+
+export type AnchorStrategy = 'adapter' | 'content-hash' | 'path';
+
+export interface LowerOptions {
+    anchorStrategy?: AnchorStrategy;
+    preserveRawSource?: boolean;
+    resolveTokens?: boolean;
+    tokens?: DTCGTokenTree;
+}
+
+export type Drift =
+    | { kind: 'added'; anchor: string; node: IRNode }
+    | { kind: 'removed'; anchor: string; node: IRNode }
+    | { kind: 'changed'; anchor: string; field: string; oldValue: unknown; newValue: unknown }
+    | { kind: 'reordered'; anchor: string; oldIndex: number; newIndex: number; parent: string }
+    | {
+          kind: 'orphaned-tweak';
+          anchor: string;
+          tweak: TweakValue;
+          reason: 'node-deleted' | 'field-no-longer-supported' | 'anchor-strategy-changed';
+      };
+
+export interface SourceAdapter<R = unknown> {
+    readonly name: string;
+    readonly version: string;
+    lower(raw: R, opts?: LowerOptions): Promise<IRNode>;
+    diff(prev: IRNode, next: IRNode): Drift[];
+    applyTweaks(node: IRNode, tweaks: TweaksFile): IRNode;
+}
+
+// ── Tweaks layer (§8) ────────────────────────────────────────────────
+
+export interface TweaksFile {
+    $schema?: string;
+    meta: {
+        pulpVersion: string;
+        importSession: string;
+        anchorStrategy?: AnchorStrategy;
+    };
+    tweaks: Record<string, TweakValue>;
+}
+
+export type TweakValue = {
+    [path: string]: unknown;
+};
+
+// ── DTCG token tree (§10 Q3 — post-lowering resolution) ──────────────
+
+export interface DTCGTokenTree {
+    /** Recursive token map. Leaves carry `$value` per DTCG spec. */
+    [key: string]: { $value?: unknown; $type?: string; [k: string]: unknown } | DTCGTokenTree;
+}
+
+export class AdapterCapabilityError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'AdapterCapabilityError';
+    }
+}

--- a/packages/pulp-import-ir/test/anchors.test.ts
+++ b/packages/pulp-import-ir/test/anchors.test.ts
@@ -1,0 +1,141 @@
+// pulp #1486 — anchor strategy unit tests.
+
+import { describe, it, expect } from 'vitest';
+import { hashCodeAsString, generateAnchorId, assignAnchors } from '../src/anchors.js';
+
+describe('hashCodeAsString', () => {
+    it('is deterministic across runs', () => {
+        const a = hashCodeAsString({ tag: 'Button', role: 'cta', text: 'subscribe', depth: 2 });
+        const b = hashCodeAsString({ tag: 'Button', role: 'cta', text: 'subscribe', depth: 2 });
+        expect(a).toBe(b);
+    });
+
+    it('is order-stable (sorted keys)', () => {
+        const a = hashCodeAsString({ a: 1, b: 2, c: 3 });
+        const b = hashCodeAsString({ c: 3, a: 1, b: 2 });
+        expect(a).toBe(b);
+    });
+
+    it('produces different hashes for different content', () => {
+        const a = hashCodeAsString({ tag: 'Button', text: 'subscribe' });
+        const b = hashCodeAsString({ tag: 'Button', text: 'cancel' });
+        expect(a).not.toBe(b);
+    });
+});
+
+describe('generateAnchorId', () => {
+    it('content-hash strategy depends on tag + role + text + depth', () => {
+        const node = {
+            tag: 'Button',
+            text: { text: 'Click' },
+            meta: { role: 'cta' },
+            children: [],
+        };
+        const id = generateAnchorId(node, null, 0, 1, 'content-hash');
+        expect(id).toMatch(/^[0-9a-z]+$/);
+    });
+
+    it('content-hash collapses whitespace in text', () => {
+        const a = generateAnchorId(
+            { tag: 'Label', text: { text: 'hello\n   world' }, children: [] },
+            null,
+            0,
+            1,
+            'content-hash',
+        );
+        const b = generateAnchorId(
+            { tag: 'Label', text: { text: 'hello world' }, children: [] },
+            null,
+            0,
+            1,
+            'content-hash',
+        );
+        expect(a).toBe(b);
+    });
+
+    it('content-hash differs by depth', () => {
+        const node = { tag: 'Button', text: { text: 'X' }, children: [] };
+        const a = generateAnchorId(node, null, 0, 1, 'content-hash');
+        const b = generateAnchorId(node, null, 0, 2, 'content-hash');
+        expect(a).not.toBe(b);
+    });
+
+    it("path strategy emits 'Tag[idx]' segments", () => {
+        const id = generateAnchorId(
+            { tag: 'Button', children: [] },
+            { tag: 'Frame', children: [] },
+            0,
+            1,
+            'path',
+            'Frame[0]',
+        );
+        expect(id).toBe('Frame[0]/Button[0]');
+    });
+
+    it('adapter strategy uses _adapter:source_node_id', () => {
+        const id = generateAnchorId(
+            { tag: 'Button', children: [], _adapter: 'figma-mcp', source_node_id: '42:15' },
+            null,
+            0,
+            0,
+            'adapter',
+        );
+        expect(id).toBe('figma-mcp:42:15');
+    });
+
+    it('adapter strategy throws when source_node_id missing', () => {
+        expect(() =>
+            generateAnchorId(
+                { tag: 'Button', children: [] },
+                null,
+                0,
+                0,
+                'adapter',
+            ),
+        ).toThrow(/anchor strategy='adapter' requires/);
+    });
+
+    it('meta.anchor_id_override forces a specific anchor', () => {
+        const id = generateAnchorId(
+            { tag: 'Button', children: [], meta: { anchor_id_override: 'forced-1' } },
+            null,
+            0,
+            0,
+            'content-hash',
+        );
+        expect(id).toBe('forced-1');
+    });
+});
+
+describe('assignAnchors', () => {
+    it('produces an anchor for every node in the tree', () => {
+        const root = {
+            tag: 'View',
+            children: [
+                { tag: 'View', children: [{ tag: 'Button', text: { text: 'A' }, children: [] }] },
+                { tag: 'View', children: [{ tag: 'Button', text: { text: 'B' }, children: [] }] },
+            ],
+        };
+        const anchors = assignAnchors(root, 'content-hash');
+        // Root + 2 mid-Views + 2 Buttons = 5 nodes.
+        expect(anchors.size).toBe(5);
+        // All anchors are non-empty strings.
+        for (const id of anchors.values()) expect(id).toMatch(/^[0-9a-z]+$/);
+    });
+
+    it('path strategy: sibling tags get [0] / [1] / [2] ...', () => {
+        const root = {
+            tag: 'View',
+            children: [
+                { tag: 'Button', children: [] },
+                { tag: 'Button', children: [] },
+                { tag: 'Button', children: [] },
+            ],
+        };
+        const anchors = assignAnchors(root, 'path');
+        const childAnchors = root.children.map((c) => anchors.get(c));
+        expect(childAnchors[0]).toBe('View[0]/Button[0]');
+        expect(childAnchors[1]).toBe('View[0]/Button[1]');
+        expect(childAnchors[2]).toBe('View[0]/Button[2]');
+    });
+});

--- a/packages/pulp-import-ir/test/diff.test.ts
+++ b/packages/pulp-import-ir/test/diff.test.ts
@@ -1,0 +1,67 @@
+// pulp #1486 — diff() unit tests.
+
+import { describe, it, expect } from 'vitest';
+import { diff } from '../src/diff.js';
+import type { IRNode } from '../src/types.js';
+
+function n(anchor: string, paint?: Record<string, unknown>, children: IRNode[] = []): IRNode {
+    return {
+        tag: 'View',
+        stable_anchor_id: anchor,
+        ...(paint ? { paint: paint as IRNode['paint'] } : {}),
+        children,
+        provenance: { adapter: 'test', version: '0.0.0', ts: '2026-05-05T17:00:00Z' },
+        raw_source: { kind: 'unknown', payload: null },
+        confidence: 'PASS',
+    };
+}
+
+describe('diff', () => {
+    it('reports added nodes when next has anchors prev lacks', () => {
+        const prev = n('root', undefined, [n('a')]);
+        const next = n('root', undefined, [n('a'), n('b')]);
+        const drifts = diff(prev, next);
+        const added = drifts.filter((d) => d.kind === 'added');
+        expect(added).toHaveLength(1);
+        expect(added[0].anchor).toBe('b');
+    });
+
+    it('reports removed nodes when prev has anchors next lacks', () => {
+        const prev = n('root', undefined, [n('a'), n('b')]);
+        const next = n('root', undefined, [n('a')]);
+        const drifts = diff(prev, next);
+        const removed = drifts.filter((d) => d.kind === 'removed');
+        expect(removed).toHaveLength(1);
+        expect(removed[0].anchor).toBe('b');
+    });
+
+    it('reports field changes via dotted-path entries', () => {
+        const prev = n('root', undefined, [n('a', { backgroundColor: '#000' })]);
+        const next = n('root', undefined, [n('a', { backgroundColor: '#fff' })]);
+        const drifts = diff(prev, next);
+        const changed = drifts.filter((d) => d.kind === 'changed');
+        expect(changed).toHaveLength(1);
+        expect(changed[0].field).toBe('paint.backgroundColor');
+        if (changed[0].kind === 'changed') {
+            expect(changed[0].oldValue).toBe('#000');
+            expect(changed[0].newValue).toBe('#fff');
+        }
+    });
+
+    it('reports reorders when same anchor moves child-index', () => {
+        const prev = n('root', undefined, [n('a'), n('b')]);
+        const next = n('root', undefined, [n('b'), n('a')]);
+        const drifts = diff(prev, next);
+        const reorders = drifts.filter((d) => d.kind === 'reordered');
+        expect(reorders).toHaveLength(2);
+    });
+
+    it('result is sorted by anchor for deterministic fixtures', () => {
+        const prev = n('root', undefined, [n('z'), n('a')]);
+        const next = n('root', undefined, [n('a'), n('m'), n('z')]);
+        const drifts = diff(prev, next);
+        const anchors = drifts.map((d) => d.anchor);
+        const sorted = [...anchors].sort();
+        expect(anchors).toEqual(sorted);
+    });
+});

--- a/packages/pulp-import-ir/test/scenarios/scenarios.test.ts
+++ b/packages/pulp-import-ir/test/scenarios/scenarios.test.ts
@@ -1,0 +1,235 @@
+// pulp #1486 — 5-scenario validation harness (§4 of the spec).
+//
+//   S1 Pure regen, no source change                  → tweaks survive
+//   S2 Designer changed colors, structure preserved  → tweaks survive
+//   S3 Designer added a new sibling section          → existing IDs preserved
+//   S4 Designer deleted a tweaked section            → drift flags orphaned tweak
+//   S5 Designer reordered sections                   → content-hash strategy survives
+//
+// Acceptance for the Phase 1 spike: 4 of 5 pass. (S5 with content-hash
+// is expected to pass because the hash is depth+text-driven, not
+// path-driven.)
+
+import { describe, it, expect } from 'vitest';
+import {
+    lowerClaudeDesignHtml,
+    applyTweaks,
+    diff,
+    emptyTweaksFile,
+    type TweaksFile,
+    type IRNode,
+} from '../../src/index.js';
+
+// Minimal HTML fixtures. Phase 1's adapter handles inline `style`
+// attributes — these fixtures exercise the typed paint / text fields.
+const HOMEPAGE_V1 = `
+<div>
+  <header style="background-color: #0066ff; padding: 16px;">
+    <h1 style="color: white; font-size: 32px;">Welcome</h1>
+  </header>
+  <section style="padding: 24px;">
+    <p style="font-size: 14px; color: #333;">Sign up to get started.</p>
+    <button style="background-color: #0066ff; color: white; padding: 12px;">Subscribe</button>
+  </section>
+</div>
+`;
+
+// S2: designer changes the homepage's primary color from blue to green.
+const HOMEPAGE_V2_COLOR_CHANGE = `
+<div>
+  <header style="background-color: #00cc66; padding: 16px;">
+    <h1 style="color: white; font-size: 32px;">Welcome</h1>
+  </header>
+  <section style="padding: 24px;">
+    <p style="font-size: 14px; color: #333;">Sign up to get started.</p>
+    <button style="background-color: #00cc66; color: white; padding: 12px;">Subscribe</button>
+  </section>
+</div>
+`;
+
+// S3: designer adds a new "footer" section after the existing section.
+const HOMEPAGE_V3_NEW_SECTION = `
+<div>
+  <header style="background-color: #0066ff; padding: 16px;">
+    <h1 style="color: white; font-size: 32px;">Welcome</h1>
+  </header>
+  <section style="padding: 24px;">
+    <p style="font-size: 14px; color: #333;">Sign up to get started.</p>
+    <button style="background-color: #0066ff; color: white; padding: 12px;">Subscribe</button>
+  </section>
+  <footer style="padding: 8px; background-color: #f5f5f5;">
+    <p style="font-size: 12px; color: #999;">© 2026 Pulp</p>
+  </footer>
+</div>
+`;
+
+// S4: designer deletes the tweaked section (the button's parent).
+const HOMEPAGE_V4_DELETE = `
+<div>
+  <header style="background-color: #0066ff; padding: 16px;">
+    <h1 style="color: white; font-size: 32px;">Welcome</h1>
+  </header>
+</div>
+`;
+
+// S5: designer reorders the header and section.
+const HOMEPAGE_V5_REORDER = `
+<div>
+  <section style="padding: 24px;">
+    <p style="font-size: 14px; color: #333;">Sign up to get started.</p>
+    <button style="background-color: #0066ff; color: white; padding: 12px;">Subscribe</button>
+  </section>
+  <header style="background-color: #0066ff; padding: 16px;">
+    <h1 style="color: white; font-size: 32px;">Welcome</h1>
+  </header>
+</div>
+`;
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function findByText(root: IRNode, text: string): IRNode | null {
+    if (root.text?.text === text) return root;
+    for (const c of root.children) {
+        const f = findByText(c, text);
+        if (f) return f;
+    }
+    return null;
+}
+
+function makeTweaks(forAnchor: string, override: Record<string, unknown>): TweaksFile {
+    const base = emptyTweaksFile('0.78.1', '2026-05-05T17:03:22Z');
+    base.tweaks[forAnchor] = override;
+    base.meta.anchorStrategy = 'content-hash';
+    return base;
+}
+
+// ── S1 ───────────────────────────────────────────────────────────────
+
+describe('S1 — Pure regen, no source change', () => {
+    it('tweaks survive trivially when re-importing the same source', async () => {
+        const v1 = await lowerClaudeDesignHtml(HOMEPAGE_V1);
+        const button = findByText(v1, 'Subscribe');
+        expect(button).not.toBeNull();
+        const tweaks = makeTweaks(button!.stable_anchor_id, {
+            'paint.backgroundColor': '#ff00aa',
+        });
+
+        // Re-import identical source.
+        const v2 = await lowerClaudeDesignHtml(HOMEPAGE_V1);
+        const tweaked = applyTweaks(v2, tweaks);
+        const tweakedButton = findByText(tweaked, 'Subscribe');
+        expect(tweakedButton?.paint?.backgroundColor).toBe('#ff00aa');
+        expect(tweaked.meta?.orphaned_tweaks).toBeUndefined();
+    });
+});
+
+// ── S2 ───────────────────────────────────────────────────────────────
+
+describe('S2 — Designer changed colors, dev tweak survives', () => {
+    it("tweak survives when source colors change but structure doesn't", async () => {
+        const v1 = await lowerClaudeDesignHtml(HOMEPAGE_V1);
+        const button = findByText(v1, 'Subscribe');
+        const buttonAnchor = button!.stable_anchor_id;
+        // Dev tweaks the button's font-size locally.
+        const tweaks = makeTweaks(buttonAnchor, { 'text.fontSize': 18 });
+
+        // Designer changes primary color blue → green; structure
+        // identical. content-hash anchors don't depend on color, so the
+        // button's anchor stays stable.
+        const v2 = await lowerClaudeDesignHtml(HOMEPAGE_V2_COLOR_CHANGE);
+        const v2Button = findByText(v2, 'Subscribe');
+        expect(v2Button?.stable_anchor_id).toBe(buttonAnchor);
+
+        const tweaked = applyTweaks(v2, tweaks);
+        const tweakedButton = findByText(tweaked, 'Subscribe');
+        expect(tweakedButton?.text?.fontSize).toBe(18);
+        // Designer's color change comes through.
+        expect(tweakedButton?.paint?.backgroundColor).toBe('#00cc66');
+        expect(tweaked.meta?.orphaned_tweaks).toBeUndefined();
+    });
+});
+
+// ── S3 ───────────────────────────────────────────────────────────────
+
+describe('S3 — Designer added a new sibling section', () => {
+    it('existing IDs preserved; new section gets a new ID', async () => {
+        const v1 = await lowerClaudeDesignHtml(HOMEPAGE_V1);
+        const button = findByText(v1, 'Subscribe');
+        const buttonAnchor = button!.stable_anchor_id;
+        const tweaks = makeTweaks(buttonAnchor, { 'paint.opacity': 0.85 });
+
+        const v3 = await lowerClaudeDesignHtml(HOMEPAGE_V3_NEW_SECTION);
+        // Existing button anchor should still be present.
+        const v3Button = findByText(v3, 'Subscribe');
+        expect(v3Button?.stable_anchor_id).toBe(buttonAnchor);
+        // New footer-paragraph has a different anchor.
+        const newP = findByText(v3, '© 2026 Pulp');
+        expect(newP?.stable_anchor_id).toBeDefined();
+        expect(newP?.stable_anchor_id).not.toBe(buttonAnchor);
+
+        const tweaked = applyTweaks(v3, tweaks);
+        expect(findByText(tweaked, 'Subscribe')?.paint?.opacity).toBe(0.85);
+        expect(tweaked.meta?.orphaned_tweaks).toBeUndefined();
+    });
+});
+
+// ── S4 ───────────────────────────────────────────────────────────────
+
+describe('S4 — Designer deleted a tweaked section', () => {
+    it('drift report flags the orphaned tweak', async () => {
+        const v1 = await lowerClaudeDesignHtml(HOMEPAGE_V1);
+        const button = findByText(v1, 'Subscribe');
+        const buttonAnchor = button!.stable_anchor_id;
+        const tweaks = makeTweaks(buttonAnchor, { 'paint.backgroundColor': '#ff00aa' });
+
+        const v4 = await lowerClaudeDesignHtml(HOMEPAGE_V4_DELETE);
+        const v4Button = findByText(v4, 'Subscribe');
+        expect(v4Button).toBeNull(); // section was deleted
+
+        const tweaked = applyTweaks(v4, tweaks);
+        expect(tweaked.meta?.orphaned_tweaks).toBeDefined();
+        expect(tweaked.meta?.orphaned_tweaks?.[buttonAnchor]).toEqual({
+            'paint.backgroundColor': '#ff00aa',
+        });
+
+        const drifts = diff(v1, tweaked);
+        const orphan = drifts.find((d) => d.kind === 'orphaned-tweak');
+        expect(orphan).toBeDefined();
+        expect(orphan?.anchor).toBe(buttonAnchor);
+    });
+});
+
+// ── S5 ───────────────────────────────────────────────────────────────
+
+describe('S5 — Designer reordered sections', () => {
+    it('content-hash strategy preserves anchors across reorder', async () => {
+        const v1 = await lowerClaudeDesignHtml(HOMEPAGE_V1);
+        const button = findByText(v1, 'Subscribe');
+        const buttonAnchor = button!.stable_anchor_id;
+        const tweaks = makeTweaks(buttonAnchor, { 'paint.backgroundColor': '#ff00aa' });
+
+        // V5 swaps header and section's order — same content, same depths.
+        const v5 = await lowerClaudeDesignHtml(HOMEPAGE_V5_REORDER);
+        const v5Button = findByText(v5, 'Subscribe');
+        // Content-hash anchor is depth+tag+role+text — depth-from-root
+        // for the button is the same in both versions (root → section
+        // → button = depth 2), so the anchor should be stable.
+        expect(v5Button?.stable_anchor_id).toBe(buttonAnchor);
+
+        const tweaked = applyTweaks(v5, tweaks);
+        expect(findByText(tweaked, 'Subscribe')?.paint?.backgroundColor).toBe('#ff00aa');
+    });
+});
+
+// ── Acceptance summary ───────────────────────────────────────────────
+
+describe('Phase 1 acceptance — 4-of-5 scenarios pass', () => {
+    it('all five scenarios run without throwing', async () => {
+        // Smoke check the harness itself: every scenario completes.
+        await lowerClaudeDesignHtml(HOMEPAGE_V1);
+        await lowerClaudeDesignHtml(HOMEPAGE_V2_COLOR_CHANGE);
+        await lowerClaudeDesignHtml(HOMEPAGE_V3_NEW_SECTION);
+        await lowerClaudeDesignHtml(HOMEPAGE_V4_DELETE);
+        await lowerClaudeDesignHtml(HOMEPAGE_V5_REORDER);
+    });
+});

--- a/packages/pulp-import-ir/test/tweaks.test.ts
+++ b/packages/pulp-import-ir/test/tweaks.test.ts
@@ -1,0 +1,95 @@
+// pulp #1486 — tweaks layer unit tests.
+
+import { describe, it, expect } from 'vitest';
+import {
+    applyTweaks,
+    setByDottedPath,
+    emptyTweaksFile,
+    orphanedTweakDrifts,
+} from '../src/tweaks.js';
+import type { IRNode } from '../src/types.js';
+
+function makeNode(anchor: string, partial: Partial<IRNode> = {}): IRNode {
+    return {
+        tag: 'View',
+        stable_anchor_id: anchor,
+        children: [],
+        provenance: { adapter: 'test', version: '0.0.0', ts: '2026-05-05T17:00:00Z' },
+        raw_source: { kind: 'unknown', payload: null },
+        confidence: 'PASS',
+        ...partial,
+    };
+}
+
+describe('setByDottedPath', () => {
+    it('sets a typed-section field', () => {
+        const node = makeNode('a');
+        const next = setByDottedPath(node, 'paint.backgroundColor', '#ff0000');
+        expect(next.paint?.backgroundColor).toBe('#ff0000');
+        expect(node.paint).toBeUndefined();
+    });
+
+    it('clears a field when value is null', () => {
+        const node = makeNode('a', { paint: { backgroundColor: '#000' } });
+        const next = setByDottedPath(node, 'paint.backgroundColor', null);
+        expect(next.paint).toEqual({});
+        expect(node.paint?.backgroundColor).toBe('#000');
+    });
+
+    it('preserves other fields in the section', () => {
+        const node = makeNode('a', { paint: { backgroundColor: '#000', opacity: 0.5 } });
+        const next = setByDottedPath(node, 'paint.backgroundColor', '#ff0000');
+        expect(next.paint?.backgroundColor).toBe('#ff0000');
+        expect(next.paint?.opacity).toBe(0.5);
+    });
+});
+
+describe('applyTweaks', () => {
+    it('applies a tweak to the matching anchor', () => {
+        const root: IRNode = makeNode('root', {
+            children: [makeNode('a'), makeNode('b')],
+        });
+        const tweaks = emptyTweaksFile('0.78.1', 's-1');
+        tweaks.tweaks['a'] = { 'paint.backgroundColor': '#ff00aa' };
+
+        const next = applyTweaks(root, tweaks);
+        const childA = next.children[0];
+        expect(childA.paint?.backgroundColor).toBe('#ff00aa');
+        expect(next.meta?.orphaned_tweaks).toBeUndefined();
+    });
+
+    it('attaches orphaned tweaks to the root meta when anchor missing', () => {
+        const root = makeNode('root', { children: [makeNode('a')] });
+        const tweaks = emptyTweaksFile('0.78.1', 's-1');
+        tweaks.tweaks['ghost'] = { 'paint.backgroundColor': '#ff00aa' };
+
+        const next = applyTweaks(root, tweaks);
+        expect(next.meta?.orphaned_tweaks?.['ghost']).toEqual({
+            'paint.backgroundColor': '#ff00aa',
+        });
+    });
+
+    it('orphanedTweakDrifts reports each orphan', () => {
+        const node = makeNode('root', {
+            meta: {
+                orphaned_tweaks: {
+                    ghost1: { 'paint.opacity': 0.5 },
+                    ghost2: { 'text.fontSize': 14 },
+                },
+            },
+        });
+        const drifts = orphanedTweakDrifts(node);
+        expect(drifts).toHaveLength(2);
+        expect(drifts.every((d) => d.kind === 'orphaned-tweak')).toBe(true);
+    });
+
+    it('does not mutate the input tree', () => {
+        const root = makeNode('root', { children: [makeNode('a')] });
+        const tweaks = emptyTweaksFile('0.78.1', 's-1');
+        tweaks.tweaks['a'] = { 'paint.opacity': 0.5 };
+
+        const next = applyTweaks(root, tweaks);
+        expect(root.children[0].paint).toBeUndefined();
+        expect(next.children[0].paint?.opacity).toBe(0.5);
+    });
+});

--- a/packages/pulp-import-ir/tsconfig.json
+++ b/packages/pulp-import-ir/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "lib": ["ES2022", "DOM"],
+        "strict": true,
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/pulp-import-ir/vitest.config.ts
+++ b/packages/pulp-import-ir/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['test/**/*.test.ts'],
+        environment: 'node',
+    },
+});


### PR DESCRIPTION
## Summary

Phase 1 spike for **Pulp design-import IR** (pulp #1486). Ships a typed intermediate representation that survives source re-import — adapters lower source formats into a common `IRNode` tree keyed by `stable_anchor_id`; the tweaks layer (`pulp-tweaks.json`) is keyed by the same anchors so dev overrides survive when the designer regenerates the source.

```ts
import { lowerClaudeDesignHtml, applyTweaks, diff } from '@pulp/import-ir';

const ir = await lowerClaudeDesignHtml(rawHtml);
const tweaked = applyTweaks(ir, tweaks);
const drifts = diff(prevIR, ir);
```

## What ships in Phase 1

| Surface | What's implemented |
|---------|-------------------|
| **`types.ts`** | `IRNode`, `TypedLayout` (§1.2), `TypedPaint` (§2.2), `TypedText` (§3), `TokenRef`, `Drift`, `IRProvenance`, `Confidence`, `SourceAdapter` interface, `TweaksFile`, `LowerOptions`, `DTCGTokenTree` |
| **`anchors.ts`** | 3 stable_anchor_id strategies — `content-hash` (FNV-1a fold over `{tag, role, text, depth}`; pattern-lifted from Mitosis/Builder MIT), `path` (`Tag[idx]/Tag[idx]/...`), `adapter` (native node IDs). Default-strategy-per-source map per spec §4.4. |
| **Claude Design HTML adapter** | First-spike adapter. Regex-walker over well-formed HTML; tag mapping; inline `style` lowering into typed fields; `outerHtml` preserved under `raw_source`. |
| **`tweaks.ts`** | Pure-sync `applyTweaks`; `setByDottedPath` deep-merge; `nodeFsTweaksIO()` lazy-imports `node:fs/promises`; orphaned-tweak detection. |
| **`diff.ts`** | Sorted-by-anchor `Drift[]` — added / removed / changed / reordered / orphaned-tweak. Field-level diff over typed sections. |
| **`lower-via-prop-applier.ts`** | IR → `JSXLikeNode` tree (consumed by `@pulp/react`'s renderer). |
| **5-scenario harness** | All 5 spec scenarios pass (S1 pure regen, S2 color change, S3 sibling insert, S4 deletion-orphan, S5 reorder). |

## User-locked architectural decisions (spec §10)

| Q | Decision |
|---|----------|
| **Q2** IR module location | TS-only at `packages/pulp-import-ir/`. Promote to C++ on profiling. |
| **Q3** DTCG token resolution | Post-lowering. `TokenRef`s preserved in IR; resolver runs after lowering. Token-tree edits propagate without reimport. |
| **Q7** Lowering route | IR → JSX-equivalent intrinsics → existing `@pulp/react` prop-applier. Duplicative-but-safe; well-tested code path. |

## Test plan

- [x] **5-scenario harness** (`test/scenarios/scenarios.test.ts`) — S1/S2/S3/S4/S5 all pass under content-hash strategy. Spec target was 4-of-5; we ship 5-of-5 because the depth+text content-hash survives the S5 reorder cleanly.
- [x] **anchor strategy units** — 12 cases (deterministic hash, key-order stability, content sensitivity, path strategy `Tag[idx]` shape, adapter strategy guard, override mechanism).
- [x] **tweaks layer units** — 7 cases (set-by-dotted-path, null-clears, applyTweaks merge, orphaned-tweak detection, immutability).
- [x] **diff units** — 5 cases (added / removed / changed / reordered / sorted determinism).
- [x] **TypeScript build** clean (`tsc -p tsconfig.json` zero errors).
- [x] **Vitest** — 4 files / 30 tests pass in 309ms.

## Phase 2 roadmap (per spec §9)

1. Figma MCP / Figma ZIP adapter (~1.5 weeks; adapter strategy)
2. Mitosis adapter (~1 week; adapter strategy)
3. Stitch HTML / v0.dev adapters (~3-5 days each; content-hash)
4. Pencil MCP adapter (~1 week; adapter strategy)
5. RN file export adapter (~5 days; path strategy)

CLI integration (`pulp import design path/x.html --reimport`) lands in pulp #1307's CLI scaffolding follow-up; this PR ships the IR core that the CLI will call.

## Refs

- pulp #1486 (umbrella — IR design + Phase 1 acceptance)
- pulp #1307 (CLI scaffolding — `pulp import design`)
- pulp #1432 (ZIP-import path)
- pulp #1434 (framework-import-readiness umbrella; IR is the structural complement to that umbrella's per-property gap-fills)
- Codex /codex audit 2026-05-06 (architecture review)
- Sub-agent #25 spec draft `/tmp/pulp-ir-spec-spike.md`
- Mitosis Builder content-hash IDs (`mitosis/packages/core/src/parsers/builder/builder.ts:1163`, `.../symbols/symbol-processor.ts:187`) — MIT, pattern-lifted

5 trailers (no widget_bridge.cpp / no JS shim / no compat.json touched — `Compat-Update` not required; only `Version-Bump: skip` family + `Skill-Update: skip` engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
