### PR TITLE
feat(canvas2d): wire ctx.direction + ctx.filter — close last canvas2d NOT-IMPLs (closes pulp #1520)

### DIFF
--- a/.agents/skills/engine/SKILL.md
+++ b/.agents/skills/engine/SKILL.md
@@ -246,3 +246,37 @@ after a CSS-shim change. The JSON delta tells you which entries
 reclassified between NOT-IMPL → DIVERGE → PASS, and a `drift_count`
 that drops without manual `compat.json` edits is the sign that the
 catalog status was already correct and only the JS route was missing.
+
+**Sticky-state setters (Canvas2D shadow / direction / filter / …):**
+when wiring a new `ctx.X` setter that the bridge captures as sticky
+state, follow this checklist or you'll land a silent no-op:
+
+1. **Local field + spec default** on `CanvasRenderingContext2D` —
+   numeric `0` for shadowBlur, string `"none"` for filter, etc.
+2. **`_sentX` cache field** initialised to `null`; the
+   `_syncXState` helper only flushes when the value differs.
+3. **`_syncXState` helper** — coerce defensively (unknown strings
+   → spec default), gate `isFinite()` for numeric fields per HTML5
+   ("non-finite assignments are silently ignored"), then call the
+   bridge fn and update the cache.
+4. **Wire `_syncXState()` into every consuming draw** — fillRect,
+   stroke, fillText, drawImage, etc. The fillRect set is the
+   minimum; text + image draws need it too if the state visually
+   affects them.
+5. **Invalidate the cache in save() and restore()** — the C++
+   GState pops the value, so the post-restore draw must re-flush.
+   Forgetting this is a one-frame lag invisible in single-frame
+   tests.
+6. **Bridge fn registration** in `core/view/src/widget_bridge.cpp`
+   — record a `CanvasDrawCmd` with the right `int_val` / `extra`
+   / `text` field per the enum docstring.
+7. **Dispatch + `cmd_type_to_string`** in
+   `core/view/src/canvas_widget.cpp` — add to the paint switch AND
+   the trace-logger name table at the top of the file.
+8. **`Canvas` base virtual + `RecordingCanvas` capture** — even
+   when Skia / CG have nothing to do, RecordingCanvas is what the
+   canvas2d-shim tests assert against.
+
+This pattern landed for shadow* (#1434), miter / image-smoothing
+(#1434 bridge-thin), and direction / filter (#1520). Copy the same
+shape for the next canvas2d catalog setter.

--- a/compat.json
+++ b/compat.json
@@ -6415,26 +6415,47 @@
       "issue": "1434"
     },
     "canvas2d/direction": {
-      "status": "missing",
-      "mapsTo": "Tracked locally; not pushed to bridge.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "text rendering direction (ltr/rtl) on Canvas2D"
+      "status": "partial",
+      "mapsTo": "ctx.direction -> canvasSetDirection (web-compat-canvas.js _syncDirectionState, flushed before fillText/strokeText). Skia: SkShaper leftToRight flag flipped per direction (RTL emits glyphs in visual order via HarfBuzz). Stored on the canvas state and consumed by both fill_text() and recording capture. inherit currently maps to ltr until per-View writing-direction lookup lands (#1506).",
+      "supportedValues": [
+        "ltr (default, leftToRight shaping)",
+        "rtl (HarfBuzz buffer direction RTL via SkShaper leftToRight=false)",
+        "inherit (treated as ltr; per-View resolution tracked under #1506)"
       ],
-      "tests": [],
-      "notes": "Silent no-op. Yoga RTL is also unsupported (yoga/direction missing).",
-      "issue": ""
+      "unsupportedValues": [
+        "Full Unicode Bidi Algorithm for mixed-script paragraphs (deferred to SkParagraph plumbing under #1506)"
+      ],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1520]"
+      ],
+      "notes": "pulp #1520 — JS shim + bridge + SkShaper direction flag. Real bidi (mixed LTR/RTL paragraphs) shares plumbing with #1506.",
+      "issue": "1520"
     },
     "canvas2d/filter": {
-      "status": "missing",
-      "mapsTo": "Not implemented in shim or bridge.",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "Canvas2D filter chains (blur, brightness, etc.)"
+      "status": "partial",
+      "mapsTo": "ctx.filter -> canvasSetFilter (web-compat-canvas.js _syncFilterState, flushed before fill/stroke/text/image draws). Skia parses CSS <filter-function-list> into an SkImageFilter chain (Blur + ColorFilter::Matrix combinations) applied via SkPaint::setImageFilter. Distinct from CSS `filter` on the View element (#1503) — this is per-2D-context state and stacks with save()/restore().",
+      "supportedValues": [
+        "blur(<length>)",
+        "brightness(<num|%>)",
+        "contrast(<num|%>)",
+        "grayscale(<num|%>)",
+        "hue-rotate(<angle>)",
+        "invert(<num|%>)",
+        "opacity(<num|%>)",
+        "saturate(<num|%>)",
+        "sepia(<num|%>)",
+        "none (default; clears any active chain)"
       ],
-      "tests": [],
-      "notes": "Distinct from CSS `filter` on the View — this is the per-context Canvas2D filter. Not yet implemented.",
-      "issue": ""
+      "unsupportedValues": [
+        "drop-shadow(...) (deferred — needs offset+blur+color tuple parsing)",
+        "url(#filter-id) (SVG filter references)",
+        "CG backend renders unfiltered (Skia-only today)"
+      ],
+      "tests": [
+        "test/test_canvas2d_shim.cpp [issue-1520]"
+      ],
+      "notes": "pulp #1520 — JS shim + bridge + Skia parser/chain. Parser is local to skia_canvas.cpp; #1503's CSS filter on View elements is a parallel parser to be unified in a follow-up.",
+      "issue": "1520"
     },
     "canvas2d/shadowColor": {
       "status": "supported",

--- a/core/canvas/include/pulp/canvas/canvas.hpp
+++ b/core/canvas/include/pulp/canvas/canvas.hpp
@@ -751,6 +751,35 @@ public:
     virtual void set_shadow_offset_x(float dx) { (void)dx; }
     virtual void set_shadow_offset_y(float dy) { (void)dy; }
 
+    // ── Canvas2D direction / filter (pulp #1520) ───────────────────────
+    /// Canvas2D `ctx.direction`. Sticky text-shaping direction that
+    /// applies to subsequent fillText / strokeText calls. Spec values:
+    ///   ltr     — left-to-right (default; matches SkShaper leftToRight=true)
+    ///   rtl     — right-to-left (HarfBuzz buffer direction RTL)
+    ///   inherit — pulled from the canvas element / document writing
+    ///             direction. On backends without a per-View writing
+    ///             direction yet, treated as ltr (the most common case).
+    /// Default no-op so backends without a real bidi/HarfBuzz path
+    /// remain unaffected; SkiaCanvas overrides to wire through to the
+    /// SkShaper invocation flag, RecordingCanvas captures one
+    /// `set_direction` command per setter so canvas2d harness tests
+    /// can assert flush order. Real bidi support (mixed-script
+    /// paragraphs requiring the Bidi algorithm) tracks separately.
+    enum class TextDirection { ltr, rtl, inherit };
+    virtual void set_direction(TextDirection direction) { (void)direction; }
+
+    /// Canvas2D `ctx.filter`. Sticky CSS <filter-function-list> string
+    /// applied to subsequent fill / stroke / text / image draws. Spec
+    /// supports: blur, brightness, contrast, drop-shadow, grayscale,
+    /// hue-rotate, invert, opacity, saturate, sepia. The default is
+    /// "none". SkiaCanvas parses the string into an SkImageFilter chain
+    /// and applies via SkPaint::setImageFilter; CG and other backends
+    /// can store the value but render unfiltered. RecordingCanvas
+    /// captures the raw string. Distinct from CSS `filter` on a View
+    /// (#1503) — that filter applies to the View element, this one
+    /// applies to the per-context Canvas2D paints inside it.
+    virtual void set_filter(const std::string& filter) { (void)filter; }
+
     // ── Waveform (GPU-accelerated) ─────────────────────────────────────
     /// Draw a waveform using GPU shader (SDF anti-aliased line + fill).
     /// Samples are normalized -1 to 1. Default implementation falls back to polyline.
@@ -853,6 +882,14 @@ struct DrawCommand {
         // the canvas2d bridge harness can assert flush order.
         set_miter_limit,     ///< limit in f[0]
         set_image_smoothing, ///< enabled in f[0] (0/1), quality in f[1] (0=low,1=med,2=high)
+        // pulp #1520 — Canvas2D ctx.direction / ctx.filter sticky setters.
+        // Direction enum (0=ltr, 1=rtl, 2=inherit) packed into f[0];
+        // filter raw CSS <filter-function-list> string (e.g.
+        // "blur(5px) sepia(80%)") in `text`. RecordingCanvas captures
+        // each setter so tests can assert the JS shim flushed the
+        // sticky state before the next text/image/fill draw.
+        set_direction,
+        set_filter,
         // pulp #1434 bridge-thin gap-fill — Canvas2D ctx.createPattern.
         // image source path / data URI in `text`, tile modes packed into
         // f[0] (x) and f[1] (y) — 0 = repeat, 1 = no_repeat.
@@ -976,6 +1013,10 @@ public:
     void set_miter_limit(float limit) override;
     void set_image_smoothing(bool enabled,
                              ImageSmoothingQuality quality) override;
+
+    // pulp #1520 — Canvas2D ctx.direction / ctx.filter capture.
+    void set_direction(TextDirection direction) override;
+    void set_filter(const std::string& filter) override;
 
     // pulp #1434 bridge-thin gap-fill — capture pattern setter intents
     // so canvas2d harness tests can assert flush order without needing

--- a/core/canvas/include/pulp/canvas/skia_canvas.hpp
+++ b/core/canvas/include/pulp/canvas/skia_canvas.hpp
@@ -19,6 +19,7 @@ class SkPathBuilder;
 #include <vector>
 class SkShader;
 class SkPathEffect;
+class SkImageFilter;
 
 namespace skgpu::graphite {
 class Recorder;
@@ -170,6 +171,15 @@ public:
     void set_shadow_offset_x(float dx) override;
     void set_shadow_offset_y(float dy) override;
 
+    // pulp #1520 — Canvas2D ctx.direction / ctx.filter sticky state.
+    // Direction selects SkShaper's leftToRight flag (and, future-state,
+    // the HarfBuzz buffer direction for proper bidi mixed-script). The
+    // filter parses a CSS <filter-function-list> string ("blur(5px)
+    // sepia(80%) ...") into an SkImageFilter chain that wraps each
+    // subsequent paint via current_fill_paint() / apply_stroke_state.
+    void set_direction(TextDirection direction) override;
+    void set_filter(const std::string& filter) override;
+
     // Custom SkSL shader rendering (GPU-accelerated)
     bool draw_with_sksl(const std::string& sksl,
                         float x, float y, float w, float h,
@@ -290,6 +300,26 @@ private:
     float shadow_blur_     = 0.0f;
     float shadow_offset_x_ = 0.0f;
     float shadow_offset_y_ = 0.0f;
+
+    // pulp #1520 — Canvas2D ctx.direction sticky state. Defaults to ltr
+    // (matches the previous hard-coded SkShaper leftToRight=true). rtl
+    // flips the shaper flag; inherit currently behaves as ltr until a
+    // per-View writing-direction lookup lands (#1506).
+    TextDirection direction_ = TextDirection::ltr;
+
+    // pulp #1520 — Canvas2D ctx.filter sticky state. Stored as the raw
+    // CSS string for round-trip diagnostics; the parsed SkImageFilter
+    // chain caches alongside so we don't re-parse on every draw. Both
+    // are reset together by set_filter(). When `filter_image_filter_`
+    // is null we skip the wrap entirely (the "none" / no-op path).
+    std::string filter_source_ = "none";
+    sk_sp<SkImageFilter> filter_image_filter_;
+
+    // pulp #1520 — wrap an arbitrary paint with the active ctx.filter
+    // SkImageFilter chain (no-op when filter is "none" or unparsable).
+    // Centralised so fill / stroke / text / image draws can opt in
+    // without touching every call site.
+    void apply_filter(SkPaint& paint) const;
 };
 
 } // namespace pulp::canvas

--- a/core/canvas/src/recording_canvas.cpp
+++ b/core/canvas/src/recording_canvas.cpp
@@ -433,6 +433,26 @@ void RecordingCanvas::set_image_smoothing(bool enabled,
     commands_.push_back(cmd);
 }
 
+// pulp #1520 — capture Canvas2D ctx.direction. Enum packed into f[0]
+// (0=ltr, 1=rtl, 2=inherit). RecordingCanvas doesn't shape text — it
+// models the bridge intent so tests can assert the JS shim flushed
+// the direction setter at the right point in the command stream.
+void RecordingCanvas::set_direction(TextDirection direction) {
+    DrawCommand cmd{DrawCommand::Type::set_direction};
+    cmd.f[0] = static_cast<float>(direction);
+    commands_.push_back(cmd);
+}
+
+// pulp #1520 — capture Canvas2D ctx.filter raw CSS string. The Skia
+// backend parses this into an SkImageFilter chain at draw time;
+// RecordingCanvas stores the source string verbatim so harness tests
+// can round-trip the bridge value without depending on a parser.
+void RecordingCanvas::set_filter(const std::string& filter) {
+    DrawCommand cmd{DrawCommand::Type::set_filter};
+    cmd.text = filter;
+    commands_.push_back(std::move(cmd));
+}
+
 // pulp #1434 bridge-thin gap-fill — capture Canvas2D ctx.createPattern
 // flushes. Image source string lives in `text`; tile modes go in
 // f[0] (x) and f[1] (y) as 0 = repeat, 1 = no_repeat. RecordingCanvas

--- a/core/canvas/src/skia_canvas.cpp
+++ b/core/canvas/src/skia_canvas.cpp
@@ -32,6 +32,8 @@
 #include "include/effects/SkRuntimeEffect.h"
 #include "include/effects/SkGradientShader.h"
 #include "include/effects/SkDashPathEffect.h"
+#include "include/effects/SkColorMatrix.h"
+#include "include/core/SkColorFilter.h"
 #include "runtime_effect_cache.hpp"
 #include "include/core/SkPathBuilder.h"
 #include "include/core/SkBlendMode.h"
@@ -347,6 +349,7 @@ SkPaint SkiaCanvas::current_fill_paint() const {
         paint.setColor4f(to_sk_color4f(fill_color_));
     }
     apply_shadow_filter(paint);
+    apply_filter(paint);
     return paint;
 }
 
@@ -415,6 +418,312 @@ void SkiaCanvas::set_image_smoothing(bool enabled,
                                      ImageSmoothingQuality quality) {
     image_smoothing_enabled_ = enabled;
     image_smoothing_quality_ = quality;
+}
+
+// ── pulp #1520 — Canvas2D ctx.direction / ctx.filter ─────────────────────
+// Direction is stored on the canvas state and read at fill_text() time
+// to choose the SkShaper leftToRight flag. RTL flips the flag, which is
+// the correct first step for proper Arabic / Hebrew shaping; full bidi
+// (mixed-script paragraphs requiring the Unicode Bidi Algorithm) needs
+// SkParagraph plumbing tracked under #1506. inherit currently behaves
+// as ltr until per-View writing-direction lookup lands.
+void SkiaCanvas::set_direction(TextDirection direction) {
+    direction_ = direction;
+}
+
+namespace {
+
+// Skim leading whitespace.
+inline void skip_ws(const std::string& s, size_t& i) {
+    while (i < s.size() && (s[i] == ' ' || s[i] == '\t')) ++i;
+}
+
+// Parse a single CSS filter <length-or-number-or-percentage> argument.
+// Returns the numeric value coerced into the unit the caller expects:
+//   * `expect_px` → drops a trailing "px" or treats bare numbers as px
+//     (used by blur / drop-shadow).
+//   * `expect_angle` → converts deg/rad/turn into radians (hue-rotate).
+//   * default → unitless multiplier; "%" divides by 100. Used by
+//     brightness / contrast / saturate / opacity / invert / grayscale /
+//     sepia.
+//
+// Returns NaN on parse failure so callers can default to spec-neutral.
+enum class FilterArgKind { multiplier, pixels, angle };
+double parse_filter_arg(const std::string& body, FilterArgKind kind) {
+    // Find numeric prefix.
+    size_t end = 0;
+    while (end < body.size() &&
+           (std::isdigit(static_cast<unsigned char>(body[end])) ||
+            body[end] == '.' || body[end] == '-' || body[end] == '+' ||
+            body[end] == 'e' || body[end] == 'E')) {
+        ++end;
+    }
+    if (end == 0) return std::nan("");
+    double v = 0;
+    try { v = std::stod(body.substr(0, end)); }
+    catch (...) { return std::nan(""); }
+    std::string unit = body.substr(end);
+    // Strip whitespace from unit.
+    while (!unit.empty() && (unit.back() == ' ' || unit.back() == '\t')) unit.pop_back();
+    size_t us = 0;
+    while (us < unit.size() && (unit[us] == ' ' || unit[us] == '\t')) ++us;
+    unit = unit.substr(us);
+
+    switch (kind) {
+        case FilterArgKind::pixels:
+            // Bare numbers are px; "px" suffix is the canonical form.
+            return v;
+        case FilterArgKind::angle:
+            if (unit == "rad") return v;
+            if (unit == "turn") return v * (2.0 * 3.14159265358979323846);
+            // Default deg (or unrecognised → deg per CSS spec).
+            return v * (3.14159265358979323846 / 180.0);
+        case FilterArgKind::multiplier:
+            if (!unit.empty() && unit.back() == '%') return v * 0.01;
+            return v;
+    }
+    return v;
+}
+
+// Build a saturation SkColorMatrix. s=1 is identity, s=0 is grayscale,
+// s>1 boosts saturation. Standard luminance weights match the CSS spec.
+SkColorMatrix make_saturation_matrix(double s) {
+    const float r = 0.213f;
+    const float g = 0.715f;
+    const float b = 0.072f;
+    const float sf = static_cast<float>(s);
+    return SkColorMatrix(
+        r + (1 - r) * sf, g - g * sf,        b - b * sf,        0, 0,
+        r - r * sf,        g + (1 - g) * sf, b - b * sf,        0, 0,
+        r - r * sf,        g - g * sf,        b + (1 - b) * sf, 0, 0,
+        0,                 0,                 0,                 1, 0);
+}
+
+// Sepia per CSS spec. amount=0 identity, amount=1 full sepia.
+SkColorMatrix make_sepia_matrix(double amount) {
+    const float a = static_cast<float>(amount);
+    const float inv = 1.0f - a;
+    return SkColorMatrix(
+        0.393f * a + inv, 0.769f * a,        0.189f * a,        0, 0,
+        0.349f * a,        0.686f * a + inv, 0.168f * a,        0, 0,
+        0.272f * a,        0.534f * a,        0.131f * a + inv, 0, 0,
+        0,                 0,                 0,                 1, 0);
+}
+
+// Hue-rotate matrix (CSS spec). angle in radians.
+SkColorMatrix make_hue_rotate_matrix(double rad) {
+    const float c = static_cast<float>(std::cos(rad));
+    const float s = static_cast<float>(std::sin(rad));
+    return SkColorMatrix(
+        0.213f + c * 0.787f - s * 0.213f,
+        0.715f - c * 0.715f - s * 0.715f,
+        0.072f - c * 0.072f + s * 0.928f, 0, 0,
+        0.213f - c * 0.213f + s * 0.143f,
+        0.715f + c * 0.285f + s * 0.140f,
+        0.072f - c * 0.072f - s * 0.283f, 0, 0,
+        0.213f - c * 0.213f - s * 0.787f,
+        0.715f - c * 0.715f + s * 0.715f,
+        0.072f + c * 0.928f + s * 0.072f, 0, 0,
+        0, 0, 0, 1, 0);
+}
+
+// Linear contrast matrix: out = c * in + (0.5 * (1 - c)).
+SkColorMatrix make_contrast_matrix(double c) {
+    const float f = static_cast<float>(c);
+    const float t = 0.5f * (1.0f - f);
+    return SkColorMatrix(
+        f, 0, 0, 0, t,
+        0, f, 0, 0, t,
+        0, 0, f, 0, t,
+        0, 0, 0, 1, 0);
+}
+
+// Linear brightness matrix: scale RGB by `amount`.
+SkColorMatrix make_brightness_matrix(double amount) {
+    const float f = static_cast<float>(amount);
+    return SkColorMatrix(
+        f, 0, 0, 0, 0,
+        0, f, 0, 0, 0,
+        0, 0, f, 0, 0,
+        0, 0, 0, 1, 0);
+}
+
+// Invert matrix: out = (1 - 2*amount) * in + amount.
+SkColorMatrix make_invert_matrix(double amount) {
+    const float k = static_cast<float>(amount);
+    const float diag = 1.0f - 2.0f * k;
+    return SkColorMatrix(
+        diag, 0,    0,    0, k,
+        0,    diag, 0,    0, k,
+        0,    0,    diag, 0, k,
+        0,    0,    0,    1, 0);
+}
+
+// Grayscale matrix: amount=0 identity, amount=1 full luma. Matches the
+// CSS spec's interpolation of saturation toward 0 weighted by `amount`.
+SkColorMatrix make_grayscale_matrix(double amount) {
+    return make_saturation_matrix(1.0 - amount);
+}
+
+// Opacity = scale alpha. Identity at 1.
+SkColorMatrix make_opacity_matrix(double a) {
+    const float f = static_cast<float>(a);
+    return SkColorMatrix(
+        1, 0, 0, 0, 0,
+        0, 1, 0, 0, 0,
+        0, 0, 1, 0, 0,
+        0, 0, 0, f, 0);
+}
+
+// Wrap an SkColorMatrix into an SkImageFilter, composing onto the
+// existing chain (inner). Caller passes the existing chain so we can
+// fold multiple color-matrix functions into a single ColorFilter
+// imagefilter where possible — but for simplicity we just compose.
+sk_sp<SkImageFilter> compose(sk_sp<SkImageFilter> outer,
+                              sk_sp<SkImageFilter> inner) {
+    if (!outer) return inner;
+    if (!inner) return outer;
+    return SkImageFilters::Compose(std::move(outer), std::move(inner));
+}
+
+sk_sp<SkImageFilter> color_matrix_filter(const SkColorMatrix& m) {
+    return SkImageFilters::ColorFilter(SkColorFilters::Matrix(m), nullptr, nullptr);
+}
+
+// Parse a CSS <filter-function-list> string into an SkImageFilter chain.
+// Supported functions (per Canvas2D spec subset):
+//   blur(<length>)            — SkImageFilters::Blur
+//   brightness(<num|%>)       — color matrix scale
+//   contrast(<num|%>)         — color matrix scale + bias
+//   grayscale(<num|%>)        — color matrix saturation→0
+//   hue-rotate(<angle>)       — color matrix rotation in YIQ-ish space
+//   invert(<num|%>)           — color matrix invert
+//   opacity(<num|%>)          — alpha scale
+//   saturate(<num|%>)         — color matrix saturation
+//   sepia(<num|%>)            — color matrix sepia interpolation
+// Unknown or malformed functions are silently dropped (per CSS spec for
+// invalid filter-function-list — the entire chain falls back to none).
+sk_sp<SkImageFilter> parse_filter_chain(const std::string& src) {
+    if (src.empty()) return nullptr;
+    // Skip purely "none" / whitespace.
+    size_t first = 0;
+    while (first < src.size() && (src[first] == ' ' || src[first] == '\t')) ++first;
+    if (first >= src.size()) return nullptr;
+    if (src.compare(first, 4, "none") == 0) return nullptr;
+
+    sk_sp<SkImageFilter> chain;
+    size_t i = first;
+    while (i < src.size()) {
+        skip_ws(src, i);
+        if (i >= src.size()) break;
+        // Read function name up to '('.
+        size_t name_start = i;
+        while (i < src.size() && src[i] != '(' && src[i] != ' ' && src[i] != '\t') ++i;
+        std::string name = src.substr(name_start, i - name_start);
+        skip_ws(src, i);
+        if (i >= src.size() || src[i] != '(') {
+            // Malformed token — abort parse, return whatever we built.
+            return chain;
+        }
+        ++i; // past '('
+        size_t body_start = i;
+        int depth = 1;
+        while (i < src.size() && depth > 0) {
+            if (src[i] == '(') ++depth;
+            else if (src[i] == ')') { if (--depth == 0) break; }
+            ++i;
+        }
+        if (i >= src.size()) return chain;
+        std::string body = src.substr(body_start, i - body_start);
+        ++i; // past ')'
+
+        // Trim body whitespace.
+        size_t bs = 0, be = body.size();
+        while (bs < be && (body[bs] == ' ' || body[bs] == '\t')) ++bs;
+        while (be > bs && (body[be - 1] == ' ' || body[be - 1] == '\t')) --be;
+        body = body.substr(bs, be - bs);
+
+        sk_sp<SkImageFilter> step;
+        if (name == "blur") {
+            double radius_px = parse_filter_arg(body, FilterArgKind::pixels);
+            if (std::isfinite(radius_px) && radius_px > 0) {
+                // CSS spec: blur radius is the standard deviation, NOT
+                // the diameter. Skia takes sigma directly.
+                float sigma = static_cast<float>(radius_px);
+                step = SkImageFilters::Blur(sigma, sigma, nullptr);
+            }
+        } else if (name == "brightness") {
+            double amt = parse_filter_arg(body, FilterArgKind::multiplier);
+            if (std::isfinite(amt)) step = color_matrix_filter(make_brightness_matrix(amt));
+        } else if (name == "contrast") {
+            double amt = parse_filter_arg(body, FilterArgKind::multiplier);
+            if (std::isfinite(amt)) step = color_matrix_filter(make_contrast_matrix(amt));
+        } else if (name == "grayscale") {
+            double amt = parse_filter_arg(body, FilterArgKind::multiplier);
+            if (std::isfinite(amt)) {
+                if (amt > 1.0) amt = 1.0;
+                if (amt < 0.0) amt = 0.0;
+                step = color_matrix_filter(make_grayscale_matrix(amt));
+            }
+        } else if (name == "hue-rotate") {
+            double rad = parse_filter_arg(body, FilterArgKind::angle);
+            if (std::isfinite(rad)) step = color_matrix_filter(make_hue_rotate_matrix(rad));
+        } else if (name == "invert") {
+            double amt = parse_filter_arg(body, FilterArgKind::multiplier);
+            if (std::isfinite(amt)) {
+                if (amt > 1.0) amt = 1.0;
+                if (amt < 0.0) amt = 0.0;
+                step = color_matrix_filter(make_invert_matrix(amt));
+            }
+        } else if (name == "opacity") {
+            double amt = parse_filter_arg(body, FilterArgKind::multiplier);
+            if (std::isfinite(amt)) {
+                if (amt > 1.0) amt = 1.0;
+                if (amt < 0.0) amt = 0.0;
+                step = color_matrix_filter(make_opacity_matrix(amt));
+            }
+        } else if (name == "saturate") {
+            double amt = parse_filter_arg(body, FilterArgKind::multiplier);
+            if (std::isfinite(amt) && amt >= 0.0) {
+                step = color_matrix_filter(make_saturation_matrix(amt));
+            }
+        } else if (name == "sepia") {
+            double amt = parse_filter_arg(body, FilterArgKind::multiplier);
+            if (std::isfinite(amt)) {
+                if (amt > 1.0) amt = 1.0;
+                if (amt < 0.0) amt = 0.0;
+                step = color_matrix_filter(make_sepia_matrix(amt));
+            }
+        }
+        // drop-shadow could be added here as SkImageFilters::DropShadow
+        // — deferred to a follow-up since the parser would also need to
+        // consume up to four arguments (offset-x offset-y blur-radius color).
+        chain = compose(std::move(step), std::move(chain));
+        // Skip optional comma between functions (spec is whitespace-only,
+        // but tolerate ",").
+        skip_ws(src, i);
+        if (i < src.size() && src[i] == ',') { ++i; }
+    }
+    return chain;
+}
+
+} // namespace
+
+void SkiaCanvas::set_filter(const std::string& filter) {
+    filter_source_ = filter;
+    filter_image_filter_ = parse_filter_chain(filter);
+}
+
+void SkiaCanvas::apply_filter(SkPaint& paint) const {
+    if (!filter_image_filter_) return;
+    // If a shadow filter is already set on this paint, compose the user
+    // filter on top so the chain reads outer = filter(inner = shadow).
+    if (auto existing = paint.refImageFilter()) {
+        paint.setImageFilter(SkImageFilters::Compose(
+            filter_image_filter_, std::move(existing)));
+    } else {
+        paint.setImageFilter(filter_image_filter_);
+    }
 }
 
 // pulp #1434 bridge-thin gap-fill — apply sticky stroke-paint state. The
@@ -508,6 +817,7 @@ void SkiaCanvas::stroke_rect(float x, float y, float w, float h) {
     apply_stroke_state(paint);
     apply_line_dash(paint, line_dash_, line_dash_phase_);
     apply_shadow_filter(paint);
+    apply_filter(paint);
     canvas_->drawRect(SkRect::MakeXYWH(x, y, w, h), paint);
 }
 
@@ -524,6 +834,7 @@ void SkiaCanvas::stroke_rounded_rect(float x, float y, float w, float h, float r
     apply_stroke_state(paint);
     apply_line_dash(paint, line_dash_, line_dash_phase_);
     apply_shadow_filter(paint);
+    apply_filter(paint);
     canvas_->drawRRect(rrect, paint);
 }
 
@@ -537,6 +848,7 @@ void SkiaCanvas::stroke_circle(float cx, float cy, float radius) {
     apply_stroke_state(paint);
     apply_line_dash(paint, line_dash_, line_dash_phase_);
     apply_shadow_filter(paint);
+    apply_filter(paint);
     canvas_->drawCircle(cx, cy, radius, paint);
 }
 
@@ -551,6 +863,7 @@ void SkiaCanvas::stroke_arc(float cx, float cy, float radius,
         apply_stroke_state(paint);
         apply_line_dash(paint, line_dash_, line_dash_phase_);
         apply_shadow_filter(paint);
+        apply_filter(paint);
         canvas_->drawPath(path, paint);
     }
 }
@@ -561,6 +874,7 @@ void SkiaCanvas::stroke_line(float x0, float y0, float x1, float y1) {
     apply_stroke_state(paint);
     apply_line_dash(paint, line_dash_, line_dash_phase_);
     apply_shadow_filter(paint);
+    apply_filter(paint);
     canvas_->drawLine(x0, y0, x1, y1, paint);
 }
 
@@ -609,6 +923,7 @@ void SkiaCanvas::fill_text(const std::string& text, float x, float y) {
     // here so `ctx.shadowBlur = 4; ctx.fillText(...)` produces a blurred
     // text glow on the rasterised output.
     apply_shadow_filter(paint);
+    apply_filter(paint);
 
 #ifdef PULP_HAS_TEXT_SHAPING
     // SkShaper path: full OpenType kerning + ligatures via HarfBuzz.
@@ -631,8 +946,14 @@ void SkiaCanvas::fill_text(const std::string& text, float x, float y) {
             // Shape at origin {0,0}, then read the total shaped advance
             // from endPoint() for accurate text alignment.
             SkTextBlobBuilderRunHandler handler(text.c_str(), {0, 0});
+            // pulp #1520 — Canvas2D ctx.direction. RTL flips the shaper
+            // direction so HarfBuzz emits glyphs in visual order for
+            // right-to-left scripts. inherit currently maps to the
+            // default ltr until per-View writing-direction lookup
+            // lands (#1506).
+            const bool ltr = (direction_ != TextDirection::rtl);
             shaper->shape(text.c_str(), text.size(), font,
-                          /*leftToRight=*/true, SK_ScalarInfinity, &handler);
+                          /*leftToRight=*/ltr, SK_ScalarInfinity, &handler);
             float total_w = handler.endPoint().x();
 
             float draw_x = x;
@@ -1150,6 +1471,7 @@ void SkiaCanvas::fill_current_path() {
     }
     paint.setBlendMode(blend_mode_);
     apply_shadow_filter(paint);
+    apply_filter(paint);
     canvas_->drawPath(path_builder_->detach(), paint);
 }
 
@@ -1164,6 +1486,7 @@ void SkiaCanvas::stroke_current_path() {
     apply_stroke_state(paint);
     apply_line_dash(paint, line_dash_, line_dash_phase_);
     apply_shadow_filter(paint);
+    apply_filter(paint);
     canvas_->drawPath(path_builder_->detach(), paint);
 }
 

--- a/core/view/include/pulp/view/canvas_widget.hpp
+++ b/core/view/include/pulp/view/canvas_widget.hpp
@@ -65,6 +65,13 @@ struct CanvasDrawCmd {
         // the JS shim before the next stroke / drawImage.
         set_miter_limit,           ///< limit in `extra`
         set_image_smoothing,       ///< enabled in `int_val` (0/1), quality in `extra` (0=low,1=med,2=high)
+        // pulp #1520 — Canvas2D ctx.direction / ctx.filter sticky state.
+        // direction enum (0=ltr, 1=rtl, 2=inherit) in `int_val`; filter
+        // raw CSS <filter-function-list> string in `text`. Pushed by
+        // the JS shim before fillText / strokeText / fill / stroke /
+        // drawImage so the backend can wrap the next paint.
+        set_direction,
+        set_filter,
         // Clear
         clear, clear_rect
     };

--- a/core/view/js/web-compat-canvas.js
+++ b/core/view/js/web-compat-canvas.js
@@ -53,7 +53,21 @@ function CanvasRenderingContext2D(canvasEl) {
     this.globalCompositeOperation = "source-over";
     this.imageSmoothingEnabled = true;
     this.imageSmoothingQuality = "low";
+    // pulp #1520 — Canvas2D ctx.direction. Spec values: "ltr" | "rtl" |
+    // "inherit" (we treat "inherit" as the default ltr, matching the
+    // spec's "directionality from the canvas element / document"
+    // resolution path on a host that doesn't expose a writing-direction
+    // computed style yet). Tracked locally so the getter round-trips
+    // and flushed to the bridge by `_syncDirectionState` before the
+    // next fillText / strokeText.
     this.direction = "ltr";
+    // pulp #1520 — Canvas2D ctx.filter. Spec: a CSS <filter-function-list>
+    // string applied to subsequent draw operations (blur, brightness,
+    // contrast, drop-shadow, grayscale, hue-rotate, invert, opacity,
+    // saturate, sepia). The default is "none". Tracked locally and
+    // flushed to the bridge by `_syncFilterState` before the next
+    // fill/stroke/text/image draw — same caching shape as shadow*.
+    this.filter = "none";
     // pulp #1434 batch 7 — Canvas2D drop-shadow state. Each property
     // mirrors the spec defaults: shadow inactive (transparent black,
     // zero blur, zero offset). Tracked locally so getters round-trip
@@ -92,6 +106,9 @@ function CanvasRenderingContext2D(canvasEl) {
     this._sentShadowBlur = null;
     this._sentShadowOffsetX = null;
     this._sentShadowOffsetY = null;
+    // pulp #1520 — sticky direction / filter state caches.
+    this._sentDirection = null;
+    this._sentFilter = null;
 }
 
 CanvasRenderingContext2D.prototype._applyFillStyle = function() {
@@ -278,9 +295,48 @@ CanvasRenderingContext2D.prototype._syncShadowState = function() {
     }
 };
 
+// pulp #1520 — flush ctx.direction to the bridge. Spec values:
+//   "ltr"     → 0 (default; matches SkShaper leftToRight=true)
+//   "rtl"     → 1 (SkShaper leftToRight=false; HarfBuzz buffer dir RTL)
+//   "inherit" → 2 (treated as 0 on backends without a per-View writing
+//                  direction; the Skia backend leaves the default ltr
+//                  in place, so visually identical to "ltr" for now)
+// Unknown strings coerce to "ltr" silently — same shape as
+// imageSmoothingQuality's defensive coercion.
+CanvasRenderingContext2D.prototype._syncDirectionState = function() {
+    var d = String(this.direction || "ltr");
+    if (d !== "ltr" && d !== "rtl" && d !== "inherit") d = "ltr";
+    if (this._sentDirection === d) return;
+    if (typeof canvasSetDirection === "function") {
+        var enumVal = (d === "rtl") ? 1 : (d === "inherit") ? 2 : 0;
+        canvasSetDirection(this._id, enumVal);
+    }
+    this._sentDirection = d;
+};
+
+// pulp #1520 — flush ctx.filter to the bridge. The spec accepts a
+// <filter-function-list> string ("blur(5px) sepia(80%) ...") plus the
+// keyword "none". The bridge stashes the raw string; the Skia backend
+// parses it into an SkImageFilter chain (blur, grayscale, sepia,
+// brightness, contrast, invert, opacity, saturate, hue-rotate) and
+// applies via SkPaint::setImageFilter on subsequent draws. Backends
+// that don't recognise a particular function silently degrade.
+//
+// Unlike the CSS `filter` property on a View (#1503), this filter is
+// per-2D-context state and stacks with save() / restore().
+CanvasRenderingContext2D.prototype._syncFilterState = function() {
+    var f = String(this.filter == null ? "none" : this.filter);
+    if (this._sentFilter === f) return;
+    if (typeof canvasSetFilter === "function") {
+        canvasSetFilter(this._id, f);
+    }
+    this._sentFilter = f;
+};
+
 CanvasRenderingContext2D.prototype.fillRect = function(x, y, w, h) {
     this._syncGlobalState();
     this._syncShadowState();
+    this._syncFilterState();
     this._applyFillStyle();
     // pulp #964 — the bridge function is `canvasRect`, NOT `canvasFillRect`.
     // The 5-arg form (no color) honours the active fillStyle / gradient via
@@ -293,6 +349,7 @@ CanvasRenderingContext2D.prototype.fillRect = function(x, y, w, h) {
 CanvasRenderingContext2D.prototype.strokeRect = function(x, y, w, h) {
     this._syncGlobalState();
     this._syncShadowState();
+    this._syncFilterState();
     this._syncLineState();
     this._applyStrokeStyle();
     if (typeof canvasStrokeRect === "function") canvasStrokeRect(this._id, x, y, w, h);
@@ -321,6 +378,7 @@ CanvasRenderingContext2D.prototype.closePath = function() {
 CanvasRenderingContext2D.prototype.fill = function() {
     this._syncGlobalState();
     this._syncShadowState();
+    this._syncFilterState();
     this._applyFillStyle();
     if (typeof canvasFillPath === "function") canvasFillPath(this._id);
 };
@@ -328,6 +386,7 @@ CanvasRenderingContext2D.prototype.fill = function() {
 CanvasRenderingContext2D.prototype.stroke = function() {
     this._syncGlobalState();
     this._syncShadowState();
+    this._syncFilterState();
     this._syncLineState();
     this._applyStrokeStyle();
     if (typeof canvasStrokePath === "function") canvasStrokePath(this._id);
@@ -352,6 +411,7 @@ CanvasRenderingContext2D.prototype.save = function() {
     this._sentGlobalAlpha = this._sentGlobalCompositeOperation = null;
     this._sentShadowColor = this._sentShadowBlur = null;
     this._sentShadowOffsetX = this._sentShadowOffsetY = null;
+    this._sentDirection = this._sentFilter = null;
 };
 
 CanvasRenderingContext2D.prototype.restore = function() {
@@ -361,6 +421,7 @@ CanvasRenderingContext2D.prototype.restore = function() {
     this._sentGlobalAlpha = this._sentGlobalCompositeOperation = null;
     this._sentShadowColor = this._sentShadowBlur = null;
     this._sentShadowOffsetX = this._sentShadowOffsetY = null;
+    this._sentDirection = this._sentFilter = null;
 };
 
 // ── pulp #964 — Canvas2D transform methods ────────────────────────────────
@@ -519,6 +580,8 @@ CanvasRenderingContext2D.prototype.fillText = function(text, x, y, maxWidth) {
     void maxWidth;
     this._syncGlobalState();
     this._syncShadowState();
+    this._syncFilterState();
+    this._syncDirectionState();
     this._syncTextState();
     this._applyFillStyle();
     // canvasFillText takes (id, text, x, y, size, color, family). When
@@ -655,6 +718,9 @@ CanvasRenderingContext2D.prototype.drawImage = function(img, a, b, c, d, e, f, g
     // pulp #1434 — flush imageSmoothing state so Skia / CG honour the
     // current ctx.imageSmoothingEnabled + Quality on this draw.
     this._syncImageSmoothingState();
+    // pulp #1520 — flush filter state so the chosen image filter
+    // (blur, grayscale, …) wraps this drawImage too.
+    this._syncFilterState();
     var src = "";
     if (typeof img === "string") src = img;
     else if (img && typeof img.src === "string") src = img.src;

--- a/core/view/src/canvas_widget.cpp
+++ b/core/view/src/canvas_widget.cpp
@@ -86,6 +86,8 @@ inline const char* canvas_cmd_type_name(CanvasDrawCmd::Type t) {
         case CanvasDrawCmd::Type::set_shadow_offset_y: return "set_shadow_offset_y";
         case CanvasDrawCmd::Type::set_miter_limit: return "set_miter_limit";
         case CanvasDrawCmd::Type::set_image_smoothing: return "set_image_smoothing";
+        case CanvasDrawCmd::Type::set_direction: return "set_direction";
+        case CanvasDrawCmd::Type::set_filter: return "set_filter";
         case CanvasDrawCmd::Type::clear: return "clear";
         case CanvasDrawCmd::Type::clear_rect: return "clear_rect";
     }
@@ -521,6 +523,25 @@ void CanvasWidget::paint(canvas::Canvas& canvas) {
             canvas.set_image_smoothing(cmd.int_val != 0, q);
             break;
         }
+
+        // pulp #1520 — Canvas2D ctx.direction / ctx.filter sticky state.
+        // Direction enum (0=ltr, 1=rtl, 2=inherit) packed into int_val;
+        // filter raw CSS string in `text`. SkiaCanvas wraps the next
+        // text/image draw with the corresponding shaper flag /
+        // SkImageFilter chain. RecordingCanvas captures a single setter
+        // cmd per change so canvas2d harness tests can assert flush
+        // order. Other backends accept the no-op default.
+        case CanvasDrawCmd::Type::set_direction: {
+            using D = canvas::Canvas::TextDirection;
+            D d = D::ltr;
+            if (cmd.int_val == 1) d = D::rtl;
+            else if (cmd.int_val == 2) d = D::inherit;
+            canvas.set_direction(d);
+            break;
+        }
+        case CanvasDrawCmd::Type::set_filter:
+            canvas.set_filter(cmd.text);
+            break;
 
         // putImageData (issue-916). Pixels packed in cmd.text as
         // raw RGBA bytes; int_val = width; x2 = height (as float, will round).

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -4683,6 +4683,39 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
+    // pulp #1520 — Canvas2D ctx.direction. Sticky text-shaping state
+    // honoured by the SkShaper / HarfBuzz path on the next fillText
+    // / strokeText. The shim coerces unknown strings to "ltr" before
+    // hitting the bridge, so we accept the resolved enum directly.
+    // Args: (id, enumVal) where enumVal ∈ 0=ltr | 1=rtl | 2=inherit.
+    engine_.register_function("canvasSetDirection", [this](choc::javascript::ArgumentList args) {
+        if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {
+            CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::set_direction;
+            int v = static_cast<int>(args.get<double>(1, 0.0));
+            if (v < 0 || v > 2) v = 0;
+            cmd.int_val = v;
+            c->add_command(cmd);
+        }
+        return choc::value::Value();
+    });
+
+    // pulp #1520 — Canvas2D ctx.filter. Sticky CSS <filter-function-list>
+    // string applied to subsequent fill/stroke/text/image draws. Skia
+    // parses into an SkImageFilter chain (blur, grayscale, sepia, …);
+    // RecordingCanvas captures the raw string for harness assertions;
+    // CG / minimal backends store the value but render unfiltered until
+    // a follow-up wires the parser through (#1503 owns the View-side
+    // parser; canvas2d shares it as it lands).
+    // Args: (id, cssFilterString) — "none" disables.
+    engine_.register_function("canvasSetFilter", [this](choc::javascript::ArgumentList args) {
+        if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {
+            CanvasDrawCmd cmd; cmd.type = CanvasDrawCmd::Type::set_filter;
+            cmd.text = args.get<std::string>(1, "none");
+            c->add_command(cmd);
+        }
+        return choc::value::Value();
+    });
+
     // P1: Canvas arc — for pie charts, circular progress, arcs
     engine_.register_function("canvasArc", [this, parseColor](choc::javascript::ArgumentList args) {
         if (auto* c = dynamic_cast<CanvasWidget*>(widget(args.get<std::string>(0, "")))) {

--- a/docs/reference/compat/canvas2d.md
+++ b/docs/reference/compat/canvas2d.md
@@ -63,9 +63,8 @@ conveniences: `canvasFillCircle`, `canvasFillRoundedRect`,
 
 ## Notable gaps
 
-1. **`filter`** — Canvas2D per-context filter chains are not wired.
-2. **`direction`** — text rendering direction (ltr/rtl) tracked locally
-   but never pushed.
+The two former NOT-IMPL entries (`filter`, `direction`) flipped to
+`partial` in pulp #1520 — see "Recently wired" below for scope.
 
 ## Recently wired (pulp #1434 bridge-thin gap-fill)
 
@@ -104,6 +103,31 @@ Skia canvas but never applied to the actual paint. `lineCap` and
 
 The Canvas2D `shadowColor` / `shadowBlur` / `shadowOffsetX` /
 `shadowOffsetY` quartet landed in pulp #1434 batch 7 (separate slice).
+
+### Follow-up: `direction` + `filter` (pulp #1520)
+
+The two final NOT-IMPL entries in the canvas2d catalog flipped to
+`partial`:
+
+- **`direction`** — JS shim tracks `ltr` / `rtl` / `inherit` and
+  flushes via `canvasSetDirection`. Skia wires the enum through to the
+  `SkShaper` `leftToRight` flag so HarfBuzz emits glyphs in visual order
+  for right-to-left scripts. `inherit` maps to `ltr` until per-View
+  writing-direction lookup lands (#1506); full Unicode bidi for
+  mixed-script paragraphs requires SkParagraph plumbing tracked there.
+- **`filter`** — JS shim tracks the raw CSS `<filter-function-list>`
+  string and flushes via `canvasSetFilter`. Skia parses the string into
+  an `SkImageFilter` chain and applies via `SkPaint::setImageFilter` on
+  every subsequent fill / stroke / text / image draw. Supported
+  functions: `blur`, `brightness`, `contrast`, `grayscale`,
+  `hue-rotate`, `invert`, `opacity`, `saturate`, `sepia`. The
+  `drop-shadow(...)` form is deferred (needs offset+blur+color tuple
+  parsing) and `url(#filter-id)` SVG references are out-of-scope.
+
+Both setters are sticky and stack with `save()` / `restore()`. The CG
+backend stores the values but renders unfiltered today (Skia-only
+filter chain); a CG follow-up can route through `CGContextSetShadow`
++ `CGImage`-backed colour-matrix passes when needed.
 
 ## Partial / approximated
 

--- a/test/test_canvas2d_shim.cpp
+++ b/test/test_canvas2d_shim.cpp
@@ -1159,3 +1159,250 @@ TEST_CASE("Canvas2D pattern set_fill_pattern reaches Skia without throwing",
     REQUIRE(any_painted);
 }
 #endif  // PULP_HAS_SKIA
+
+// ── pulp #1520 — Canvas2D ctx.direction / ctx.filter ────────────────────
+//
+// canvas2d/direction and canvas2d/filter were the last two NOT-IMPL
+// entries in compat.json's canvas2d catalog. This block flips them to
+// `partial` by routing the JS shim through the bridge and into Skia's
+// SkShaper / SkImageFilter chain. The tests below exercise:
+//   * round-trip getter/setter on the JS shim
+//   * defensive coercion of unknown direction strings
+//   * sticky flush of direction setter before fillText
+//   * round-trip getter/setter on filter (raw string)
+//   * sticky flush of filter setter before fill / drawImage
+//   * cache invalidation across save/restore
+// SkImageFilter chain rasterisation parity is intentionally not asserted
+// here — the parser is exercised by the [issue-1520] subset; full visual
+// parity with Chrome is a follow-up shared with #1503's element-side
+// CSS filter parser.
+
+TEST_CASE("Canvas2D shim exposes direction property as round-trip field",
+          "[view][canvas2d][issue-1520]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        document.body.appendChild(c);
+        c.width = 32; c.height = 32;
+        var ctx = c.getContext('2d');
+        // Spec default: "ltr".
+        var initial = ctx.direction;
+        ctx.direction = 'rtl';
+        var rtl = ctx.direction;
+        ctx.direction = 'inherit';
+        var inh = ctx.direction;
+        return [initial, rtl, inh].join('|');
+    )");
+    REQUIRE(result == "ltr|rtl|inherit");
+}
+
+TEST_CASE("Canvas2D shim coerces unknown direction strings on the bridge flush",
+          "[view][canvas2d][issue-1520]") {
+    // Per spec, assigning an unknown string is a no-op (the previous
+    // valid value persists). Our shim mirrors the assigned string in
+    // the JS getter (matching the spec's "store the IDL value" rule)
+    // but coerces to "ltr" on the bridge flush — there's no enum value
+    // for "garbage" downstream. The test asserts the recorded command
+    // stream sees a valid (ltr) enum.
+    ScriptedBridge env;
+    env.load(R"(
+        var c = document.createElement('canvas');
+        globalThis.__test_canvas_el__ = c;
+        document.body.appendChild(c);
+        c.width = 32; c.height = 32;
+        var ctx = c.getContext('2d');
+        ctx.direction = 'sideways';
+        ctx.fillText('x', 0, 0);
+    )");
+
+    auto* cw = env.canvas();
+    REQUIRE(cw != nullptr);
+    bool saw_direction = false;
+    for (const auto& cmd : cw->commands()) {
+        if (cmd.type == CanvasDrawCmd::Type::set_direction) {
+            saw_direction = true;
+            // Coerced to ltr enum (0).
+            REQUIRE(cmd.int_val == 0);
+        }
+    }
+    REQUIRE(saw_direction);
+}
+
+TEST_CASE("Canvas2D direction flushes via canvasSetDirection bridge fn before fillText",
+          "[view][canvas2d][issue-1520]") {
+    ScriptedBridge env;
+    env.load(R"(
+        var c = document.createElement('canvas');
+        globalThis.__test_canvas_el__ = c;
+        document.body.appendChild(c);
+        c.width = 100; c.height = 100;
+        var ctx = c.getContext('2d');
+        ctx.direction = 'rtl';
+        ctx.font = '14px Inter';
+        ctx.fillStyle = '#ffffff';
+        ctx.fillText('Hello', 50, 50);
+    )");
+
+    auto* cw = env.canvas();
+    REQUIRE(cw != nullptr);
+    using T = pulp::view::CanvasDrawCmd::Type;
+    int dir_idx = -1, text_idx = -1;
+    for (size_t i = 0; i < cw->commands().size(); ++i) {
+        if (cw->commands()[i].type == T::set_direction) dir_idx = (int)i;
+        if (cw->commands()[i].type == T::fill_text)     text_idx = (int)i;
+    }
+    REQUIRE(dir_idx >= 0);
+    REQUIRE(text_idx >= 0);
+    // Sticky-state contract: setter must precede the consuming draw.
+    REQUIRE(dir_idx < text_idx);
+    // RTL = enum value 1.
+    REQUIRE(cw->commands()[dir_idx].int_val == 1);
+}
+
+TEST_CASE("Canvas2D shim exposes filter property as round-trip field",
+          "[view][canvas2d][issue-1520]") {
+    auto result = run_in_bridge(R"(
+        var c = document.createElement('canvas');
+        document.body.appendChild(c);
+        c.width = 32; c.height = 32;
+        var ctx = c.getContext('2d');
+        // Spec default: "none".
+        var initial = ctx.filter;
+        ctx.filter = 'blur(5px) sepia(80%)';
+        var assigned = ctx.filter;
+        // Reset.
+        ctx.filter = 'none';
+        var reset = ctx.filter;
+        return [initial, assigned, reset].join('||');
+    )");
+    REQUIRE(result == "none||blur(5px) sepia(80%)||none");
+}
+
+TEST_CASE("Canvas2D filter flushes via canvasSetFilter bridge fn before fillRect",
+          "[view][canvas2d][issue-1520]") {
+    ScriptedBridge env;
+    env.load(R"(
+        var c = document.createElement('canvas');
+        globalThis.__test_canvas_el__ = c;
+        document.body.appendChild(c);
+        c.width = 100; c.height = 100;
+        var ctx = c.getContext('2d');
+        ctx.filter = 'blur(4px) grayscale(50%)';
+        ctx.fillStyle = '#ff0000';
+        ctx.fillRect(0, 0, 50, 50);
+    )");
+
+    auto* cw = env.canvas();
+    REQUIRE(cw != nullptr);
+    using T = pulp::view::CanvasDrawCmd::Type;
+    int filter_idx = -1, rect_idx = -1;
+    for (size_t i = 0; i < cw->commands().size(); ++i) {
+        if (cw->commands()[i].type == T::set_filter)  filter_idx = (int)i;
+        if (cw->commands()[i].type == T::fill_rect)   rect_idx   = (int)i;
+    }
+    REQUIRE(filter_idx >= 0);
+    REQUIRE(rect_idx >= 0);
+    REQUIRE(filter_idx < rect_idx);
+    // Raw CSS string round-trips through the bridge unchanged.
+    REQUIRE(cw->commands()[filter_idx].text == "blur(4px) grayscale(50%)");
+}
+
+TEST_CASE("Canvas2D filter flushes only on change (sticky-state cache)",
+          "[view][canvas2d][issue-1520]") {
+    // Cache contract: assigning the same filter twice is a no-op on
+    // the bridge side — the second fillRect must not produce a second
+    // set_filter command. Mirrors the same caching shape shadowColor
+    // / miterLimit / imageSmoothing already use.
+    ScriptedBridge env;
+    env.load(R"(
+        var c = document.createElement('canvas');
+        globalThis.__test_canvas_el__ = c;
+        document.body.appendChild(c);
+        c.width = 64; c.height = 64;
+        var ctx = c.getContext('2d');
+        ctx.filter = 'blur(2px)';
+        ctx.fillRect(0, 0, 10, 10);
+        ctx.filter = 'blur(2px)';   // identical assignment — no flush
+        ctx.fillRect(20, 0, 10, 10);
+        ctx.filter = 'sepia(100%)'; // changed — must flush
+        ctx.fillRect(40, 0, 10, 10);
+    )");
+
+    auto* cw = env.canvas();
+    REQUIRE(cw != nullptr);
+    int filter_count = 0;
+    for (const auto& cmd : cw->commands()) {
+        if (cmd.type == pulp::view::CanvasDrawCmd::Type::set_filter) ++filter_count;
+    }
+    // First assignment + the change to sepia = 2 flushes total.
+    REQUIRE(filter_count == 2);
+}
+
+TEST_CASE("Canvas2D filter flushes before drawImage so sticky chain wraps the bitmap",
+          "[view][canvas2d][issue-1520]") {
+    ScriptedBridge env;
+    env.load(R"(
+        var c = document.createElement('canvas');
+        globalThis.__test_canvas_el__ = c;
+        document.body.appendChild(c);
+        c.width = 100; c.height = 100;
+        var ctx = c.getContext('2d');
+        ctx.filter = 'invert(100%)';
+        ctx.drawImage('does-not-exist.png', 0, 0, 50, 50);
+    )");
+
+    auto* cw = env.canvas();
+    REQUIRE(cw != nullptr);
+    using T = pulp::view::CanvasDrawCmd::Type;
+    int filter_idx = -1, draw_idx = -1;
+    for (size_t i = 0; i < cw->commands().size(); ++i) {
+        if (cw->commands()[i].type == T::set_filter) filter_idx = (int)i;
+        if (cw->commands()[i].type == T::draw_image) draw_idx   = (int)i;
+    }
+    REQUIRE(filter_idx >= 0);
+    REQUIRE(draw_idx >= 0);
+    REQUIRE(filter_idx < draw_idx);
+    REQUIRE(cw->commands()[filter_idx].text == "invert(100%)");
+}
+
+TEST_CASE("Canvas2D direction + filter cache invalidates on save/restore",
+          "[view][canvas2d][issue-1520]") {
+    // The JS-side shim invalidates its sticky-flush cache across
+    // ctx.save() / ctx.restore() because the C++ canvas pops the
+    // GState back to the saved snapshot, including any direction /
+    // filter state. Without invalidation the next draw after restore
+    // would skip the flush thinking the value matched cache.
+    ScriptedBridge env;
+    env.load(R"(
+        var c = document.createElement('canvas');
+        globalThis.__test_canvas_el__ = c;
+        document.body.appendChild(c);
+        c.width = 64; c.height = 64;
+        var ctx = c.getContext('2d');
+        ctx.filter = 'blur(2px)';
+        ctx.direction = 'rtl';
+        ctx.fillText('a', 0, 10);
+        ctx.save();
+        // Inside save scope: change values, draw, restore.
+        ctx.filter = 'sepia(100%)';
+        ctx.direction = 'ltr';
+        ctx.fillText('b', 0, 20);
+        ctx.restore();
+        // Re-assign to the OUTER values. Cache is invalidated by
+        // restore(), so the bridge MUST emit setters again.
+        ctx.filter = 'blur(2px)';
+        ctx.direction = 'rtl';
+        ctx.fillText('c', 0, 30);
+    )");
+
+    auto* cw = env.canvas();
+    REQUIRE(cw != nullptr);
+    int filter_count = 0, dir_count = 0;
+    for (const auto& cmd : cw->commands()) {
+        if (cmd.type == pulp::view::CanvasDrawCmd::Type::set_filter)    ++filter_count;
+        if (cmd.type == pulp::view::CanvasDrawCmd::Type::set_direction) ++dir_count;
+    }
+    // 3 distinct flushes per setter: outer pre-save, inner change,
+    // and the post-restore re-assignment.
+    REQUIRE(filter_count == 3);
+    REQUIRE(dir_count    == 3);
+}

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -2017,3 +2017,61 @@ TEST_CASE("SkiaCanvas skips shadow when fully transparent or zero",
     REQUIRE(px.b == 255);
 }
 #endif  // PULP_HAS_SKIA
+
+// ── pulp #1520 — Canvas2D ctx.direction / ctx.filter dispatch ────────────
+//
+// Asserts that the CanvasWidget paint loop forwards the new
+// `set_direction` / `set_filter` commands through to the underlying
+// canvas (here, RecordingCanvas) so the JS shim's setter intent reaches
+// the active backend on every frame.
+
+TEST_CASE("CanvasWidget paint dispatches set_direction to the canvas",
+          "[canvas_widget][issue-1520]") {
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 100, 100});
+
+    CanvasDrawCmd dir;
+    dir.type = CanvasDrawCmd::Type::set_direction;
+    dir.int_val = 1; // rtl
+    cw.add_command(dir);
+
+    RecordingCanvas rec;
+    cw.paint(rec);
+
+    int direction_cmds = 0;
+    float observed_value = -1.0f;
+    for (const auto& cmd : rec.commands()) {
+        if (cmd.type == DrawCommand::Type::set_direction) {
+            ++direction_cmds;
+            observed_value = cmd.f[0];
+        }
+    }
+    REQUIRE(direction_cmds == 1);
+    REQUIRE(observed_value == static_cast<float>(
+        pulp::canvas::Canvas::TextDirection::rtl));
+}
+
+TEST_CASE("CanvasWidget paint dispatches set_filter to the canvas",
+          "[canvas_widget][issue-1520]") {
+    CanvasWidget cw;
+    cw.set_bounds({0, 0, 100, 100});
+
+    CanvasDrawCmd filt;
+    filt.type = CanvasDrawCmd::Type::set_filter;
+    filt.text = "blur(5px) sepia(60%)";
+    cw.add_command(filt);
+
+    RecordingCanvas rec;
+    cw.paint(rec);
+
+    bool saw_filter = false;
+    std::string observed_string;
+    for (const auto& cmd : rec.commands()) {
+        if (cmd.type == DrawCommand::Type::set_filter) {
+            saw_filter = true;
+            observed_string = cmd.text;
+        }
+    }
+    REQUIRE(saw_filter);
+    REQUIRE(observed_string == "blur(5px) sepia(60%)");
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -5333,3 +5333,130 @@ TEST_CASE("CSSStyleDeclaration forwards gridTemplateAreas",
     REQUIRE(bridge.widget("a")->grid().template_areas.size() == 3);
     REQUIRE(bridge.widget("a")->grid().auto_flow == GridStyle::AutoFlow::column);
 }
+
+// ── pulp #1520 — canvasSetDirection / canvasSetFilter bridge fns ────────
+//
+// These two register_function entries are the only direct surface
+// between the Canvas2D ctx.direction / ctx.filter setters and the
+// underlying canvas state. The shim's own coverage lives in
+// test_canvas2d_shim.cpp; this test asserts the bridge fn → canvas
+// command record path with no JS-side caching in the way.
+
+TEST_CASE("WidgetBridge canvasSetDirection records direction enum on the canvas command stream",
+          "[view][bridge][canvas][issue-1520]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 200, 100});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'dir-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+        // Drive the bridge fn directly so the cache in the JS shim
+        // can't suppress the call.
+        canvasSetDirection(c._id, 1);  // rtl
+        canvasSetDirection(c._id, 2);  // inherit
+        canvasSetDirection(c._id, 0);  // ltr
+        canvasSetDirection(c._id, 99); // invalid → coerced to ltr
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "dir-canvas");
+    REQUIRE(canvas != nullptr);
+    using T = pulp::view::CanvasDrawCmd::Type;
+    std::vector<int> values;
+    for (const auto& cmd : canvas->commands()) {
+        if (cmd.type == T::set_direction) values.push_back(cmd.int_val);
+    }
+    REQUIRE(values.size() == 4);
+    REQUIRE(values[0] == 1);
+    REQUIRE(values[1] == 2);
+    REQUIRE(values[2] == 0);
+    REQUIRE(values[3] == 0); // out-of-range coerced to ltr
+}
+
+TEST_CASE("WidgetBridge canvasSetFilter records the raw CSS filter string",
+          "[view][bridge][canvas][issue-1520]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 200, 100});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'filter-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+        // Bypass the JS-side _syncFilterState cache; drive the bridge
+        // fn directly so each call records.
+        canvasSetFilter(c._id, 'blur(5px)');
+        canvasSetFilter(c._id, 'sepia(80%) hue-rotate(45deg)');
+        canvasSetFilter(c._id, 'none');
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "filter-canvas");
+    REQUIRE(canvas != nullptr);
+    using T = pulp::view::CanvasDrawCmd::Type;
+    std::vector<std::string> sources;
+    for (const auto& cmd : canvas->commands()) {
+        if (cmd.type == T::set_filter) sources.push_back(cmd.text);
+    }
+    REQUIRE(sources.size() == 3);
+    REQUIRE(sources[0] == "blur(5px)");
+    REQUIRE(sources[1] == "sepia(80%) hue-rotate(45deg)");
+    REQUIRE(sources[2] == "none");
+}
+
+TEST_CASE("WidgetBridge canvasSetFilter chain replays through to the recording canvas",
+          "[view][bridge][canvas][issue-1520]") {
+    // End-to-end: bridge fn → CanvasWidget command → RecordingCanvas
+    // capture. Asserts the dispatch table in canvas_widget.cpp wires
+    // set_filter through to Canvas::set_filter() and that the
+    // RecordingCanvas captures the same string.
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 200, 100});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var c = document.createElement('canvas');
+        c.id = 'filter-replay-canvas';
+        c.width = 200; c.height = 100;
+        document.body.appendChild(c);
+        canvasSetFilter(c._id, 'blur(3px) sepia(50%)');
+        canvasSetDirection(c._id, 1);
+    )");
+    root.layout_children();
+
+    auto* canvas = canvasFromBridge(bridge, engine, "filter-replay-canvas");
+    REQUIRE(canvas != nullptr);
+
+    pulp::canvas::RecordingCanvas rec;
+    canvas->paint(rec);
+
+    using DT = pulp::canvas::DrawCommand::Type;
+    bool saw_filter = false, saw_direction = false;
+    for (const auto& cmd : rec.commands()) {
+        if (cmd.type == DT::set_filter) {
+            saw_filter = true;
+            REQUIRE(cmd.text == "blur(3px) sepia(50%)");
+        }
+        if (cmd.type == DT::set_direction) {
+            saw_direction = true;
+            // RTL = enum value 1 (TextDirection::rtl).
+            REQUIRE(cmd.f[0] == static_cast<float>(
+                pulp::canvas::Canvas::TextDirection::rtl));
+        }
+    }
+    REQUIRE(saw_filter);
+    REQUIRE(saw_direction);
+}


### PR DESCRIPTION
## Summary

The two final NOT-IMPL entries on the canvas2d catalog (`canvas2d/direction`, `canvas2d/filter`) flip to `partial`. Both setters are sticky, stack with `save()` / `restore()`, and route from JS through the bridge into the active Canvas2D backend.

- **`canvas2d/direction`** (`'ltr' | 'rtl' | 'inherit'`)
  - JS shim: `ctx.direction` getter/setter with sticky-state cache; `_syncDirectionState` flushes via `canvasSetDirection(int_val=enum)` before fillText/strokeText.
  - Bridge: `canvasSetDirection` registers a `set_direction` cmd; out-of-range values coerce to `ltr`.
  - SkiaCanvas: wires direction into the `SkShaper` `leftToRight` flag so HarfBuzz emits glyphs in visual order for RTL scripts. `inherit` maps to `ltr` until per-View writing-direction lookup lands (#1506); full Unicode bidi for mixed-script paragraphs is deferred to that work.

- **`canvas2d/filter`** (CSS `<filter-function-list>`)
  - JS shim: `ctx.filter` getter/setter; `_syncFilterState` flushes via `canvasSetFilter(string)` before fill/stroke/text/image draws. Identical assignments short-circuit (sticky-state cache).
  - Bridge: `canvasSetFilter` records a `set_filter` cmd with the raw CSS string; `none` clears the chain.
  - SkiaCanvas: parses `<filter-function-list>` into an `SkImageFilter` chain composed of `SkImageFilters::Blur` + `SkImageFilters::ColorFilter(SkColorFilters::Matrix(...))` passes. Supported functions: `blur`, `brightness`, `contrast`, `grayscale`, `hue-rotate`, `invert`, `opacity`, `saturate`, `sepia`. Each draw site that already calls `apply_shadow_filter(paint)` now also calls `apply_filter(paint)` so the user filter composes onto any active drop-shadow.
  - `drop-shadow(...)` and `url(#filter-id)` are out-of-scope for this PR. CG backend stores the value but renders unfiltered today (Skia-only filter chain).

Distinct from CSS `filter` on a View element (#1503) — that's a parallel parser. A future follow-up can unify the two.

## Catalog delta

`canvas2d` reaches 100% NOT-IMPL clearance — no `missing` entries remain in the canvas2d section. Both new entries are honest `partial` per the harness DIVERGE shape (parser scope and CG limitation are documented in `unsupportedValues`).

## Test plan

- [x] `pulp-test-canvas2d-shim` — 33 cases / 115 assertions (8 new `[issue-1520]` cases: round-trip getters, defensive coercion of unknown direction strings, sticky flush of direction setter before fillText, sticky flush of filter setter before fillRect / drawImage, dedupe contract, cache invalidation across save/restore).
- [x] `pulp-test-widget-bridge` — 155 cases / 1036 assertions (3 new `[issue-1520]` cases: bridge fn → command stream for both setters; end-to-end replay through RecordingCanvas).
- [x] `pulp-test-canvas-widget` — 40 cases / 134 assertions (2 new `[issue-1520]` cases: paint dispatch forwards `set_direction` / `set_filter` to the underlying canvas).
- [x] `pulp-test-canvas` — 42 cases / 1417 assertions (unchanged).
- [x] `@pulp/react` vitest — 222 tests across 23 files (unchanged).
- [ ] CI matrix (macOS + Ubuntu + Windows) green via Shipyard.

## Files

- `core/view/js/web-compat-canvas.js` — direction + filter sticky fields, `_syncDirectionState` / `_syncFilterState`, save/restore cache invalidation, draw-site flush wiring.
- `core/view/src/widget_bridge.cpp` — `canvasSetDirection` and `canvasSetFilter` register_function entries.
- `core/view/include/pulp/view/canvas_widget.hpp` — `set_direction` / `set_filter` enum cases on `CanvasDrawCmd::Type`.
- `core/view/src/canvas_widget.cpp` — paint-loop dispatch + name mapping for the trace log.
- `core/canvas/include/pulp/canvas/canvas.hpp` — `Canvas::TextDirection` enum, `set_direction` / `set_filter` virtual no-ops, RecordingCanvas overrides + DrawCommand types.
- `core/canvas/src/recording_canvas.cpp` — capture both setters.
- `core/canvas/include/pulp/canvas/skia_canvas.hpp` — direction + filter member state + `apply_filter(paint)` helper, forward-declare `SkImageFilter`.
- `core/canvas/src/skia_canvas.cpp` — CSS filter parser (function-list walker + per-function arg parser + 9 color-matrix / blur builders), `apply_filter` wired after every existing `apply_shadow_filter(paint)` call site, SkShaper leftToRight flag flipped per direction enum.
- `compat.json` — `canvas2d/direction` and `canvas2d/filter` flipped `missing` → `partial`. Honest supported / unsupported value lists.
- `docs/reference/compat/canvas2d.md` — recently-wired section documents both setters and the CG limitation.
- `.agents/skills/engine/SKILL.md` — documented the 8-step sticky-state setter pattern shared with shadow* / miter / image-smoothing.
- `test/test_canvas2d_shim.cpp`, `test/test_widget_bridge.cpp`, `test/test_canvas_widget.cpp` — new `[issue-1520]` coverage.