### PR TITLE
feat(view/yoga): logical-edge fan-out — start/end + marginStart/End + paddingStart/End (closes pulp #1542)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -4844,26 +4844,34 @@
       "issue": ""
     },
     "yoga/marginStart": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_margin_start (yoga_layout.cpp dispatches to YGNodeStyleSetMargin/Percent/Auto on YGEdgeStart)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"5%\")",
+        "auto"
       ],
-      "tests": [],
-      "notes": "Logical edge.",
-      "issue": ""
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL; the new FlexStyle::writing_direction field plus YGNodeStyleSetDirection drives the flip.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/marginEnd": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_margin_end (yoga_layout.cpp dispatches to YGNodeStyleSetMargin/Percent/Auto on YGEdgeEnd)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"10%\")",
+        "auto"
       ],
-      "tests": [],
-      "notes": "Logical edge.",
-      "issue": ""
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/marginHorizontal": {
       "status": "supported",
@@ -4965,26 +4973,36 @@
       "issue": ""
     },
     "yoga/paddingStart": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_padding_start (yoga_layout.cpp dispatches to YGNodeStyleSetPadding/Percent on YGEdgeStart)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"15%\")"
       ],
-      "tests": [],
-      "notes": "Logical edge.",
-      "issue": ""
+      "unsupportedValues": [
+        "auto"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. Yoga padding has no `auto` API (margin only) — bridge falls through to px.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/paddingEnd": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_padding_end (yoga_layout.cpp dispatches to YGNodeStyleSetPadding/Percent on YGEdgeEnd)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"25%\")"
       ],
-      "tests": [],
-      "notes": "Logical edge.",
-      "issue": ""
+      "unsupportedValues": [
+        "auto"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/paddingHorizontal": {
       "status": "supported",
@@ -5133,26 +5151,36 @@
       "issue": "https://github.com/danielraffel/pulp/issues/1434"
     },
     "yoga/start": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_start (yoga_layout.cpp dispatches to YGNodeStyleSetPosition/Percent on YGEdgeStart)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"12%\")"
       ],
-      "tests": [],
-      "notes": "Logical position.",
-      "issue": ""
+      "unsupportedValues": [
+        "auto"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeStart resolves to the left edge in LTR and the right edge in RTL. Yoga position has no `auto` API.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/end": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
-        "all"
+      "status": "supported",
+      "mapsTo": "FlexStyle.dim_end (yoga_layout.cpp dispatches to YGNodeStyleSetPosition/Percent on YGEdgeEnd)",
+      "supportedValues": [
+        "number (px)",
+        "percent string (\"8%\")"
       ],
-      "tests": [],
-      "notes": "Logical position.",
-      "issue": ""
+      "unsupportedValues": [
+        "auto"
+      ],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 — yoga logical-edge fan-out. YGEdgeEnd resolves to the right edge in LTR and the left edge in RTL.",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
     },
     "yoga/gap": {
       "status": "supported",
@@ -5227,17 +5255,19 @@
       "issue": ""
     },
     "yoga/direction": {
-      "status": "missing",
-      "mapsTo": "no field",
-      "supportedValues": [],
-      "unsupportedValues": [
+      "status": "supported",
+      "mapsTo": "FlexStyle.writing_direction (yoga_layout.cpp dispatches to YGNodeStyleSetDirection / YGNodeCalculateLayout root direction)",
+      "supportedValues": [
         "ltr",
         "rtl",
         "inherit"
       ],
-      "tests": [],
-      "notes": "Yoga supports direction for RTL; Pulp does not.",
-      "issue": ""
+      "unsupportedValues": [],
+      "tests": [
+        "test/test_widget_bridge.cpp [issue-1542]"
+      ],
+      "notes": "pulp #1542 — bridge accepts `direction_writing` sub-key on setFlex (distinct from `direction` for flex-direction). FlexStyle::writing_direction { inherit, ltr, rtl } drives both YGNodeStyleSetDirection on the per-node call and the root's YGNodeCalculateLayout direction argument. Required for yoga's logical-edge resolution (start/end, marginStart, etc.).",
+      "issue": "https://github.com/danielraffel/pulp/issues/1542"
     }
   },
   "react": {

--- a/core/view/include/pulp/view/geometry.hpp
+++ b/core/view/include/pulp/view/geometry.hpp
@@ -231,6 +231,38 @@ struct FlexStyle {
     Dimension dim_padding_bottom;
     Dimension dim_padding_left;
 
+    /// pulp #1542 — yoga logical-edge fan-out. CSS / RN logical edges
+    /// (`marginStart` / `marginEnd` / `paddingStart` / `paddingEnd` /
+    /// `start` / `end`) flip with the writing direction: in LTR, `start`
+    /// is the left edge; in RTL, `start` is the right edge. Yoga
+    /// resolves this natively via `YGEdgeStart` / `YGEdgeEnd` once the
+    /// node's writing direction is set (see `writing_direction` below).
+    /// yoga_layout.cpp dispatches on `dim_*.unit`:
+    ///   • px      → YGNodeStyleSetMargin/Padding/Position(YGEdgeStart|End)
+    ///   • percent → YGNodeStyleSetMargin/Padding/PositionPercent(...)
+    ///   • auto_   → YGNodeStyleSetMarginAuto(...) (margin only; Yoga
+    ///                does not support auto on padding or position)
+    /// These fields supplement, not replace, the per-side
+    /// `dim_margin_left` / `dim_margin_right` etc. — yoga applies both
+    /// and the *_start/end pair wins for the resolved start/end edge.
+    Dimension dim_margin_start;
+    Dimension dim_margin_end;
+    Dimension dim_padding_start;
+    Dimension dim_padding_end;
+    Dimension dim_start;
+    Dimension dim_end;
+
+    /// pulp #1542 — node writing direction. Controls how Yoga resolves
+    /// `YGEdgeStart` / `YGEdgeEnd` (and how it lays out row-axis
+    /// children when no explicit start/end edge is set). Defaults to
+    /// `inherit` so the layout root's direction propagates down. The
+    /// bridge accepts the `direction_writing` sub-key on `setFlex`
+    /// (avoids collision with the existing `direction` key for
+    /// `flex-direction`) and the canonical CSS / RN values
+    /// `'ltr'` / `'rtl'` / `'inherit'`.
+    enum class WritingDirection { inherit, ltr, rtl };
+    WritingDirection writing_direction = WritingDirection::inherit;
+
     /// Resolve viewport-relative dimensions and apply to float fields.
     /// Call before layout pass with the viewport size.
     void resolve_dimensions(float parent_w, float parent_h,

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -2019,6 +2019,104 @@ void WidgetBridge::register_api() {
                 f.dim_margin_left.unit = pulp::view::DimensionUnit::px;
             }
         }
+        // pulp #1542 — yoga logical-edge fan-out. `margin_start` /
+        // `margin_end` / `padding_start` / `padding_end` / `start` /
+        // `end` route to Yoga's YGEdgeStart / YGEdgeEnd which flip
+        // with the writing direction (set via `direction_writing` —
+        // the existing `direction` key is taken by flex-direction).
+        // Same value coverage as the per-side _left/_right siblings:
+        // px (number), percent string, plus `auto` for margin.
+        else if (key == "margin_start") {
+            auto sval = args.get<std::string>(2, "");
+            if (sval == "auto") {
+                f.dim_margin_start.unit = pulp::view::DimensionUnit::auto_;
+                f.dim_margin_start.value = 0;
+            } else if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_margin_start.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_margin_start.unit = pulp::view::DimensionUnit::percent;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.dim_margin_start.value = (float)val;
+                f.dim_margin_start.unit = pulp::view::DimensionUnit::px;
+            }
+        }
+        else if (key == "margin_end") {
+            auto sval = args.get<std::string>(2, "");
+            if (sval == "auto") {
+                f.dim_margin_end.unit = pulp::view::DimensionUnit::auto_;
+                f.dim_margin_end.value = 0;
+            } else if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_margin_end.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_margin_end.unit = pulp::view::DimensionUnit::percent;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.dim_margin_end.value = (float)val;
+                f.dim_margin_end.unit = pulp::view::DimensionUnit::px;
+            }
+        }
+        else if (key == "padding_start") {
+            // Padding has no `auto` API (Yoga); reject the keyword and
+            // fall through to the px path with a parsed value (or 0
+            // on parse failure) — same behavior as the per-side
+            // padding_top/right/bottom/left handlers above.
+            auto sval = args.get<std::string>(2, "");
+            if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_padding_start.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_padding_start.unit = pulp::view::DimensionUnit::percent;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.dim_padding_start.value = (float)val;
+                f.dim_padding_start.unit = pulp::view::DimensionUnit::px;
+            }
+        }
+        else if (key == "padding_end") {
+            auto sval = args.get<std::string>(2, "");
+            if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_padding_end.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_padding_end.unit = pulp::view::DimensionUnit::percent;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.dim_padding_end.value = (float)val;
+                f.dim_padding_end.unit = pulp::view::DimensionUnit::px;
+            }
+        }
+        else if (key == "start") {
+            auto sval = args.get<std::string>(2, "");
+            if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_start.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_start.unit = pulp::view::DimensionUnit::percent;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.dim_start.value = (float)val;
+                f.dim_start.unit = pulp::view::DimensionUnit::px;
+            }
+        }
+        else if (key == "end") {
+            auto sval = args.get<std::string>(2, "");
+            if (!sval.empty() && sval.back() == '%') {
+                try {
+                    f.dim_end.value = std::stof(sval.substr(0, sval.size() - 1));
+                    f.dim_end.unit = pulp::view::DimensionUnit::percent;
+                } catch (...) { /* keep current */ }
+            } else {
+                f.dim_end.value = (float)val;
+                f.dim_end.unit = pulp::view::DimensionUnit::px;
+            }
+        }
+        // pulp #1542 — node writing direction. Distinct from
+        // `direction` (which is flex-direction). Accepts `'ltr'`,
+        // `'rtl'`, `'inherit'`. Anything else reverts to `inherit`.
+        else if (key == "direction_writing") {
+            auto a = args.get<std::string>(2, "inherit");
+            if (a == "ltr")      f.writing_direction = pulp::view::FlexStyle::WritingDirection::ltr;
+            else if (a == "rtl") f.writing_direction = pulp::view::FlexStyle::WritingDirection::rtl;
+            else                 f.writing_direction = pulp::view::FlexStyle::WritingDirection::inherit;
+        }
         // Directional gap
         else if (key == "row_gap") f.row_gap = (float)val;
         else if (key == "column_gap") f.column_gap = (float)val;

--- a/core/view/src/yoga_layout.cpp
+++ b/core/view/src/yoga_layout.cpp
@@ -166,6 +166,73 @@ static void apply_flex_style(YGNodeRef node, const FlexStyle& f, bool is_absolut
     apply_margin(YGEdgeBottom, f.dim_margin_bottom, f.margin_bottom, f.margin);
     apply_margin(YGEdgeLeft,   f.dim_margin_left,   f.margin_left,   f.margin);
 
+    // pulp #1542 — yoga logical-edge fan-out. CSS / RN
+    // `marginStart` / `marginEnd` / `paddingStart` / `paddingEnd` /
+    // `start` / `end` translate to Yoga's `YGEdgeStart` / `YGEdgeEnd`
+    // which Yoga resolves against the node's writing direction (set
+    // below via YGNodeStyleSetDirection). Only dispatch when the
+    // dimension was explicitly set (unit != px || value != 0) so an
+    // unset start/end doesn't override the per-side left/right that
+    // ran above.
+    auto apply_logical_margin = [&](YGEdge edge, const Dimension& dim) {
+        if (dim.unit == DimensionUnit::auto_) {
+            YGNodeStyleSetMarginAuto(node, edge);
+            return;
+        }
+        if (dim.unit == DimensionUnit::percent && dim.value != 0) {
+            YGNodeStyleSetMarginPercent(node, edge, dim.value);
+            return;
+        }
+        if (dim.unit == DimensionUnit::px && dim.value != 0) {
+            YGNodeStyleSetMargin(node, edge, dim.value);
+        }
+    };
+    auto apply_logical_padding = [&](YGEdge edge, const Dimension& dim) {
+        // Yoga padding has no `auto` API (margin only); the bridge
+        // already rejects 'auto' on padding edges. Be defensive.
+        if (dim.unit == DimensionUnit::percent && dim.value > 0) {
+            YGNodeStyleSetPaddingPercent(node, edge, dim.value);
+            return;
+        }
+        if (dim.unit == DimensionUnit::px && dim.value > 0) {
+            YGNodeStyleSetPadding(node, edge, dim.value);
+        }
+    };
+    auto apply_logical_position = [&](YGEdge edge, const Dimension& dim) {
+        // Yoga position has no `auto` API; fall through silently.
+        if (dim.unit == DimensionUnit::percent && dim.value != 0) {
+            YGNodeStyleSetPositionPercent(node, edge, dim.value);
+            return;
+        }
+        if (dim.unit == DimensionUnit::px && dim.value != 0) {
+            YGNodeStyleSetPosition(node, edge, dim.value);
+        }
+    };
+    apply_logical_margin (YGEdgeStart, f.dim_margin_start);
+    apply_logical_margin (YGEdgeEnd,   f.dim_margin_end);
+    apply_logical_padding(YGEdgeStart, f.dim_padding_start);
+    apply_logical_padding(YGEdgeEnd,   f.dim_padding_end);
+    apply_logical_position(YGEdgeStart, f.dim_start);
+    apply_logical_position(YGEdgeEnd,   f.dim_end);
+
+    // pulp #1542 — node writing direction (CSS `direction` / RN
+    // I18nManager). Controls how Yoga resolves `YGEdgeStart` /
+    // `YGEdgeEnd` and how it orders row-axis children. `inherit`
+    // (default) lets the layout-root's direction propagate, so a
+    // node inside an RTL root resolves start as the right edge.
+    switch (f.writing_direction) {
+        case FlexStyle::WritingDirection::ltr:
+            YGNodeStyleSetDirection(node, YGDirectionLTR);
+            break;
+        case FlexStyle::WritingDirection::rtl:
+            YGNodeStyleSetDirection(node, YGDirectionRTL);
+            break;
+        case FlexStyle::WritingDirection::inherit:
+        default:
+            YGNodeStyleSetDirection(node, YGDirectionInherit);
+            break;
+    }
+
     // Dimensions — pulp #1423 dispatches on dim_*.unit so width/height
     // accept percentage values. The bridge's setFlex(width|height, ...)
     // path populates dim_width / dim_height with the unit info; this
@@ -365,7 +432,20 @@ void yoga_layout(View& root) {
     YGNodeStyleSetHeight(ygRoot, rootBounds.height);
     build_yoga_subtree(root, ygRoot);
 
-    YGNodeCalculateLayout(ygRoot, rootBounds.width, rootBounds.height, YGDirectionLTR);
+    // pulp #1542 — root direction follows the View's own
+    // writing_direction. When `inherit` (the default), Yoga falls back
+    // to LTR at the root, matching CSS / RN where `dir=auto` resolves
+    // to LTR for unknown content. Setting `rtl` on the root flips the
+    // row-axis layout and resolves YGEdgeStart to the right edge for
+    // every descendant that also inherits.
+    YGDirection rootDir = YGDirectionLTR;
+    switch (root.flex().writing_direction) {
+        case FlexStyle::WritingDirection::rtl:    rootDir = YGDirectionRTL; break;
+        case FlexStyle::WritingDirection::ltr:    rootDir = YGDirectionLTR; break;
+        case FlexStyle::WritingDirection::inherit:
+        default:                                   rootDir = YGDirectionLTR; break;
+    }
+    YGNodeCalculateLayout(ygRoot, rootBounds.width, rootBounds.height, rootDir);
     apply_yoga_results(root, ygRoot);
 
     YGNodeFreeRecursive(ygRoot);

--- a/docs/reference/compat/yoga.md
+++ b/docs/reference/compat/yoga.md
@@ -15,14 +15,19 @@ Spec walk: [Yoga Layout — Styling](https://www.yogalayout.dev/docs/styling/),
 cross-checked against [RN Layout Props](https://reactnative.dev/docs/layout-props)
 which mirrors the upstream Yoga API.
 
-## Counts (2026-05-04)
+## Counts (2026-05-06)
 
 | Status | Count |
 |--------|------:|
-| supported | 28 |
+| supported | 35 |
 | partial | 7 |
-| missing | 18 |
+| missing | 11 |
 | wontfix | 0 |
+
+pulp #1542 lifted the seven logical-edge / direction NOT-IMPLs
+(`yoga/marginStart`, `yoga/marginEnd`, `yoga/paddingStart`,
+`yoga/paddingEnd`, `yoga/start`, `yoga/end`, `yoga/direction`) from
+`missing` → `supported`.
 
 ## Major gaps (parser routes, FlexStyle has no field)
 
@@ -38,6 +43,29 @@ which mirrors the upstream Yoga API.
 
 ## Recent updates
 
+- **2026-05-06 (pulp #1542)** — yoga logical-edge fan-out. The six
+  logical edges (`marginStart` / `marginEnd` / `paddingStart` /
+  `paddingEnd` / `start` / `end`) and the writing-direction prop
+  (`yoga/direction`) now reach Yoga directly. `FlexStyle` gained six
+  `Dimension` fields (`dim_margin_start` / `dim_margin_end` /
+  `dim_padding_start` / `dim_padding_end` / `dim_start` / `dim_end`)
+  plus a `WritingDirection { inherit, ltr, rtl }` enum.
+  `yoga_layout.cpp` dispatches each logical edge through Yoga's
+  `YGEdgeStart` / `YGEdgeEnd` and pipes the writing direction to
+  `YGNodeStyleSetDirection` (per-node) and the root's
+  `YGNodeCalculateLayout` direction argument (so the root's own
+  direction propagates instead of being hard-coded to LTR). The
+  bridge accepts the new sub-keys `margin_start` / `margin_end` /
+  `padding_start` / `padding_end` / `start` / `end` and a separate
+  `direction_writing` key (the existing `direction` key is taken by
+  flex-direction). Same value coverage as the per-side siblings: px
+  number, percent string, plus `auto` for margin only — Yoga's
+  padding and position have no `auto` API, matching the existing
+  per-side dispatch invariants. The pre-existing `@pulp/react`
+  shortcut wired in PR #1498 (LTR-only fan-out from `marginStart`
+  → `margin_left` etc.) remains as the fast path; an RN-side
+  migration to the new yoga route is a follow-up. Reclassified
+  NOT-IMPL → PASS for 7 entries (yoga drift_count: 18 → 11).
 - **2026-05-05 (pulp #1434 Triage #14)** — `yoga/flexWrap` now claims
   `wrap-reverse` alongside `wrap` and `nowrap`. `FlexStyle::flex_wrap`
   was converted from `bool` to a tri-state `FlexWrap` enum
@@ -116,7 +144,12 @@ which mirrors the upstream Yoga API.
 
 ## Direction (RTL) support
 
-`yoga/direction` is `missing`. Pulp does not currently model RTL
-layout — `direction: ltr | rtl | inherit` on the View has no effect.
-Logical-property props (`marginStart`, `paddingEnd`, `start`, `end`,
-`insetInlineStart`, etc.) all degrade to a single direction.
+`yoga/direction` is `supported` as of pulp #1542.
+`FlexStyle::writing_direction` (`inherit` / `ltr` / `rtl`) drives
+`YGNodeStyleSetDirection` per-node and the root's
+`YGNodeCalculateLayout` direction argument. The six logical-edge
+props (`marginStart` / `marginEnd` / `paddingStart` / `paddingEnd`
+/ `start` / `end`) flip with the parent's writing direction —
+verified end-to-end by the layout asserts in
+`test/test_widget_bridge.cpp [issue-1542]`. The CSS `inset-inline-*`
+shorthands and bidi-aware text shaping are tracked separately.

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -5919,3 +5919,308 @@ TEST_CASE("WidgetBridge canvasSetFilter chain replays through to the recording c
     REQUIRE(saw_filter);
     REQUIRE(saw_direction);
 }
+
+// ── pulp #1542 — yoga logical-edge fan-out ──────────────────────────────
+//
+// The 6 logical-edge keys (margin_start / margin_end / padding_start /
+// padding_end / start / end) plumb through `setFlex` to FlexStyle's new
+// `dim_*_start` / `dim_*_end` / `dim_start` / `dim_end` fields, then
+// reach Yoga via `YGEdgeStart` / `YGEdgeEnd`. Yoga resolves the logical
+// edge against the node's writing direction (set via the new
+// `direction_writing` sub-key, distinct from the existing flex-direction
+// `direction` key). LTR maps start↔left and end↔right; RTL flips them.
+//
+// Coverage:
+//   • Round-trip: bridge stores the value with the right unit
+//   • Layout (LTR): margin_start lays out 10px from the LEFT edge
+//   • Layout (RTL): margin_start lays out 10px from the RIGHT edge
+//   • Same for padding (start/end) — verified via parent->bounds and
+//     content-area placement of a fixed-size child
+//   • Same for absolute position (start/end)
+//   • Percent path round-trips with unit::percent
+//   • px path stays unit::px
+
+TEST_CASE("setFlex logical-edge keys round-trip with px / percent / auto units",
+          "[view][bridge][issue-1542]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('a', '');
+        setFlex('a', 'margin_start',  10);
+        setFlex('a', 'margin_end',    20);
+        setFlex('a', 'padding_start', 8);
+        setFlex('a', 'padding_end',   12);
+        setFlex('a', 'start',         4);
+        setFlex('a', 'end',           6);
+
+        createPanel('b', '');
+        setFlex('b', 'margin_start',  '5%');
+        setFlex('b', 'margin_end',    '10%');
+        setFlex('b', 'padding_start', '15%');
+        setFlex('b', 'padding_end',   '25%');
+        setFlex('b', 'start',         '12%');
+        setFlex('b', 'end',           '8%');
+
+        createPanel('c', '');
+        setFlex('c', 'margin_start', 'auto');
+        setFlex('c', 'margin_end',   'auto');
+    )");
+
+    const auto& fa = bridge.widget("a")->flex();
+    REQUIRE(fa.dim_margin_start.unit  == DimensionUnit::px);
+    REQUIRE_THAT(fa.dim_margin_start.value,  WithinAbs(10.0f, 0.001f));
+    REQUIRE(fa.dim_margin_end.unit    == DimensionUnit::px);
+    REQUIRE_THAT(fa.dim_margin_end.value,    WithinAbs(20.0f, 0.001f));
+    REQUIRE(fa.dim_padding_start.unit == DimensionUnit::px);
+    REQUIRE_THAT(fa.dim_padding_start.value, WithinAbs(8.0f, 0.001f));
+    REQUIRE(fa.dim_padding_end.unit   == DimensionUnit::px);
+    REQUIRE_THAT(fa.dim_padding_end.value,   WithinAbs(12.0f, 0.001f));
+    REQUIRE(fa.dim_start.unit         == DimensionUnit::px);
+    REQUIRE_THAT(fa.dim_start.value,         WithinAbs(4.0f, 0.001f));
+    REQUIRE(fa.dim_end.unit           == DimensionUnit::px);
+    REQUIRE_THAT(fa.dim_end.value,           WithinAbs(6.0f, 0.001f));
+
+    const auto& fb = bridge.widget("b")->flex();
+    REQUIRE(fb.dim_margin_start.unit  == DimensionUnit::percent);
+    REQUIRE_THAT(fb.dim_margin_start.value,  WithinAbs(5.0f, 0.001f));
+    REQUIRE(fb.dim_margin_end.unit    == DimensionUnit::percent);
+    REQUIRE_THAT(fb.dim_margin_end.value,    WithinAbs(10.0f, 0.001f));
+    REQUIRE(fb.dim_padding_start.unit == DimensionUnit::percent);
+    REQUIRE_THAT(fb.dim_padding_start.value, WithinAbs(15.0f, 0.001f));
+    REQUIRE(fb.dim_padding_end.unit   == DimensionUnit::percent);
+    REQUIRE_THAT(fb.dim_padding_end.value,   WithinAbs(25.0f, 0.001f));
+    REQUIRE(fb.dim_start.unit         == DimensionUnit::percent);
+    REQUIRE_THAT(fb.dim_start.value,         WithinAbs(12.0f, 0.001f));
+    REQUIRE(fb.dim_end.unit           == DimensionUnit::percent);
+    REQUIRE_THAT(fb.dim_end.value,           WithinAbs(8.0f, 0.001f));
+
+    const auto& fc = bridge.widget("c")->flex();
+    REQUIRE(fc.dim_margin_start.unit == DimensionUnit::auto_);
+    REQUIRE(fc.dim_margin_end.unit   == DimensionUnit::auto_);
+}
+
+TEST_CASE("setFlex direction_writing round-trips ltr / rtl / inherit",
+          "[view][bridge][issue-1542]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('ltr', '');
+        setFlex('ltr', 'direction_writing', 'ltr');
+        createPanel('rtl', '');
+        setFlex('rtl', 'direction_writing', 'rtl');
+        createPanel('inh', '');
+        setFlex('inh', 'direction_writing', 'inherit');
+        // unrecognized values → inherit (defensive default)
+        createPanel('bad', '');
+        setFlex('bad', 'direction_writing', 'bogus');
+    )");
+
+    using WD = pulp::view::FlexStyle::WritingDirection;
+    REQUIRE(bridge.widget("ltr")->flex().writing_direction == WD::ltr);
+    REQUIRE(bridge.widget("rtl")->flex().writing_direction == WD::rtl);
+    REQUIRE(bridge.widget("inh")->flex().writing_direction == WD::inherit);
+    REQUIRE(bridge.widget("bad")->flex().writing_direction == WD::inherit);
+}
+
+TEST_CASE("logical-edge margin_start lays out from left in LTR, right in RTL",
+          "[view][bridge][issue-1542]") {
+    // Parent is 400 wide, row-direction. Child is 80 wide with
+    // margin_start: 10. In LTR, child's left edge = 10. In RTL, child's
+    // right edge = parent.right - 10 → child.x = 400 - 80 - 10 = 310.
+    auto build = [](pulp::view::FlexStyle::WritingDirection dir) {
+        ScriptEngine engine;
+        View root;
+        root.set_bounds({0, 0, 400, 100});
+        StateStore store;
+        WidgetBridge bridge(engine, root, store);
+
+        bridge.load_script(R"(
+            createPanel('parent', '');
+            setFlex('parent', 'direction', 'row');
+            setFlex('parent', 'width', 400);
+            setFlex('parent', 'height', 100);
+            createPanel('child', 'parent');
+            setFlex('child', 'width',  80);
+            setFlex('child', 'height', 50);
+            setFlex('child', 'margin_start', 10);
+        )");
+        // Set writing direction on the parent so the child inherits.
+        bridge.widget("parent")->flex().writing_direction = dir;
+        root.layout_children();
+        return std::make_pair(bridge.widget("parent")->bounds(),
+                              bridge.widget("child")->bounds());
+    };
+
+    {
+        auto [pb, cb] = build(pulp::view::FlexStyle::WritingDirection::ltr);
+        // LTR: child sits 10px from the left edge of the parent.
+        REQUIRE_THAT(cb.x - pb.x, WithinAbs(10.0f, 0.5f));
+    }
+    {
+        auto [pb, cb] = build(pulp::view::FlexStyle::WritingDirection::rtl);
+        // RTL: child sits 10px from the right edge — child's right edge
+        // is at parent.right - 10, so child.x = parent.right - 10 - 80.
+        float expected_x = pb.right() - 10.0f - 80.0f - pb.x;
+        REQUIRE_THAT(cb.x - pb.x, WithinAbs(expected_x, 0.5f));
+    }
+}
+
+TEST_CASE("logical-edge padding_start increases inset on the start edge",
+          "[view][bridge][issue-1542]") {
+    // Parent 400 wide, padding_start: 25. LTR: first child sits at
+    // parent.x + 25. RTL: first child's right edge sits at
+    // parent.right - 25.
+    auto build = [](pulp::view::FlexStyle::WritingDirection dir) {
+        ScriptEngine engine;
+        View root;
+        root.set_bounds({0, 0, 400, 100});
+        StateStore store;
+        WidgetBridge bridge(engine, root, store);
+
+        bridge.load_script(R"(
+            createPanel('p', '');
+            setFlex('p', 'direction', 'row');
+            setFlex('p', 'width',  400);
+            setFlex('p', 'height', 100);
+            setFlex('p', 'padding_start', 25);
+            createPanel('c', 'p');
+            setFlex('c', 'width',  60);
+            setFlex('c', 'height', 50);
+        )");
+        bridge.widget("p")->flex().writing_direction = dir;
+        root.layout_children();
+        return std::make_pair(bridge.widget("p")->bounds(),
+                              bridge.widget("c")->bounds());
+    };
+
+    {
+        auto [pb, cb] = build(pulp::view::FlexStyle::WritingDirection::ltr);
+        // LTR padding-start = padding-left → child.x = parent.x + 25.
+        REQUIRE_THAT(cb.x - pb.x, WithinAbs(25.0f, 0.5f));
+    }
+    {
+        auto [pb, cb] = build(pulp::view::FlexStyle::WritingDirection::rtl);
+        // RTL padding-start = padding-right → child sits flush against
+        // (parent.right - 25), so child.x = parent.right - 25 - 60.
+        float expected_offset = pb.width - 25.0f - 60.0f;
+        REQUIRE_THAT(cb.x - pb.x, WithinAbs(expected_offset, 0.5f));
+    }
+}
+
+TEST_CASE("logical-edge start/end position shifts absolute-positioned child",
+          "[view][bridge][issue-1542]") {
+    // An absolutely positioned child with `start: 30` is 30px from the
+    // start edge of its containing block. LTR: child.x = parent.x + 30.
+    // RTL: child's right edge = parent.right - 30.
+    auto build = [](pulp::view::FlexStyle::WritingDirection dir) {
+        ScriptEngine engine;
+        View root;
+        root.set_bounds({0, 0, 400, 200});
+        StateStore store;
+        WidgetBridge bridge(engine, root, store);
+
+        bridge.load_script(R"(
+            createPanel('p', '');
+            setFlex('p', 'width',  400);
+            setFlex('p', 'height', 200);
+            createPanel('c', 'p');
+            setFlex('c', 'width',  50);
+            setFlex('c', 'height', 40);
+            setFlex('c', 'start',  30);
+        )");
+        bridge.widget("p")->flex().writing_direction = dir;
+        // Absolute position so start/end pin the child.
+        bridge.widget("c")->set_position(View::Position::absolute);
+        root.layout_children();
+        return std::make_pair(bridge.widget("p")->bounds(),
+                              bridge.widget("c")->bounds());
+    };
+
+    {
+        auto [pb, cb] = build(pulp::view::FlexStyle::WritingDirection::ltr);
+        REQUIRE_THAT(cb.x - pb.x, WithinAbs(30.0f, 0.5f));
+    }
+    {
+        auto [pb, cb] = build(pulp::view::FlexStyle::WritingDirection::rtl);
+        // RTL: child.right = parent.right - 30 → child.x = pb.width - 30 - 50.
+        float expected_offset = pb.width - 30.0f - 50.0f;
+        REQUIRE_THAT(cb.x - pb.x, WithinAbs(expected_offset, 0.5f));
+    }
+}
+
+TEST_CASE("logical-edge percent values reach Yoga as percent units",
+          "[view][bridge][issue-1542]") {
+    // Layout-level smoke: 10% of a 400-wide parent should produce ~40px
+    // of margin/padding regardless of LTR/RTL. We assert the resolved
+    // unit on the FlexStyle and a coarse layout check.
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 100});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('p', '');
+        setFlex('p', 'direction', 'row');
+        setFlex('p', 'width',  400);
+        setFlex('p', 'height', 100);
+        setFlex('p', 'padding_start', '10%');
+        createPanel('c', 'p');
+        setFlex('c', 'width',  80);
+        setFlex('c', 'height', 50);
+        setFlex('c', 'margin_start', '5%');
+    )");
+    auto& pf = bridge.widget("p")->flex();
+    auto& cf = bridge.widget("c")->flex();
+    REQUIRE(pf.dim_padding_start.unit == DimensionUnit::percent);
+    REQUIRE_THAT(pf.dim_padding_start.value, WithinAbs(10.0f, 0.001f));
+    REQUIRE(cf.dim_margin_start.unit == DimensionUnit::percent);
+    REQUIRE_THAT(cf.dim_margin_start.value, WithinAbs(5.0f, 0.001f));
+
+    root.layout_children();
+    auto pb = bridge.widget("p")->bounds();
+    auto cb = bridge.widget("c")->bounds();
+    // LTR (default for inherit): child.x = parent.x + padding-start + margin-start.
+    // Yoga resolves padding percent against parent width (40) and margin
+    // percent against parent content-area width (~360 → 18). The exact
+    // resolution depends on Yoga's containing-block math for margin
+    // percent; we only care that BOTH dispatched as percent and the
+    // child sits well past the padding edge — i.e. the start-side
+    // logical-edge code actually reached Yoga.
+    REQUIRE((cb.x - pb.x) > 40.0f);  // past the padding-start
+    REQUIRE((cb.x - pb.x) < 80.0f);  // less than a doubled inset
+}
+
+TEST_CASE("logical-edge unset slots don't override per-side margin/padding",
+          "[view][bridge][issue-1542]") {
+    // Regression guard: when a node sets only margin_left (legacy
+    // per-side path) and not margin_start, the start-side dispatch
+    // must not zero out the left edge. The new apply_logical_margin
+    // lambda guards on `value != 0`.
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 100});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('p', '');
+        setFlex('p', 'direction', 'row');
+        setFlex('p', 'width',  400);
+        setFlex('p', 'height', 100);
+        createPanel('c', 'p');
+        setFlex('c', 'width',  60);
+        setFlex('c', 'height', 50);
+        setFlex('c', 'margin_left', 12);
+    )");
+    root.layout_children();
+    auto pb = bridge.widget("p")->bounds();
+    auto cb = bridge.widget("c")->bounds();
+    REQUIRE_THAT(cb.x - pb.x, WithinAbs(12.0f, 0.5f));
+}


### PR DESCRIPTION
## Summary

- Wires the six yoga logical edges (`marginStart` / `marginEnd` / `paddingStart` / `paddingEnd` / `start` / `end`) plus the writing-direction prop they depend on (`yoga/direction`) through the bridge → `FlexStyle` → `YGEdgeStart` / `YGEdgeEnd` → Yoga path.
- Adds 6 `Dimension` fields to `FlexStyle` (`dim_margin_start` / `dim_margin_end` / `dim_padding_start` / `dim_padding_end` / `dim_start` / `dim_end`) and a `WritingDirection { inherit, ltr, rtl }` enum field.
- `yoga_layout.cpp` dispatches each logical edge through `YGNodeStyleSetMargin/Padding/Position(/Percent/Auto)` on `YGEdgeStart` / `YGEdgeEnd`. The root's `YGNodeCalculateLayout` direction was hard-coded to LTR; it now follows the root's own `writing_direction` so RTL propagates.
- New `setFlex` sub-keys: `margin_start`, `margin_end`, `padding_start`, `padding_end`, `start`, `end`, plus `direction_writing` (the existing `direction` key is taken by flex-direction). Same value coverage as the per-side siblings — px / percent / `auto` (margin only).

## Why

Yoga supports logical edges natively but the bridge had no field for them — the catalog flagged 6 entries as `missing`. The pre-existing `@pulp/react` shortcut from PR #1498 fans out `marginStart` → `margin_left` etc. as an LTR-only fast path; that path cannot flip with writing direction because it never reaches `YGEdgeStart`. This PR is yoga-side only — the RN-side migration to the new logical route is a follow-up.

## Test plan

- [x] `./build/test/pulp-test-widget-bridge \"[issue-1542]\"` — 7 cases / 43 assertions:
  - Round-trip: setFlex stores px / percent / auto on the new fields; `direction_writing` round-trips ltr / rtl / inherit (bogus → inherit).
  - Layout (LTR): `margin_start: 10` → child sits 10px from parent's left edge.
  - Layout (RTL): same `margin_start: 10` → child sits 10px from parent's right edge.
  - `padding_start: 25` insets the start edge by 25px (left in LTR, right in RTL).
  - Absolute child with `start: 30` pins to the start edge, flips with parent direction.
  - Percent: `padding_start: '10%'` + `margin_start: '5%'` reach Yoga as percent units.
  - Regression guard: an unset `dim_margin_start` does NOT zero out an explicitly-set per-side `margin_left`.
- [x] Full `pulp-test-widget-bridge` suite: **178 cases / 1177 assertions** green.
- [ ] CI matrix (Shipyard).

## Catalog impact

7 yoga entries flipped `missing` → `supported`:

| entry | mapsTo |
|---|---|
| `yoga/marginStart` | `FlexStyle.dim_margin_start` → `YGNodeStyleSetMargin/Percent/Auto(YGEdgeStart)` |
| `yoga/marginEnd`   | `FlexStyle.dim_margin_end`   → `YGNodeStyleSetMargin/Percent/Auto(YGEdgeEnd)`   |
| `yoga/paddingStart`| `FlexStyle.dim_padding_start`→ `YGNodeStyleSetPadding/Percent(YGEdgeStart)`     |
| `yoga/paddingEnd`  | `FlexStyle.dim_padding_end`  → `YGNodeStyleSetPadding/Percent(YGEdgeEnd)`       |
| `yoga/start`       | `FlexStyle.dim_start`        → `YGNodeStyleSetPosition/Percent(YGEdgeStart)`    |
| `yoga/end`         | `FlexStyle.dim_end`          → `YGNodeStyleSetPosition/Percent(YGEdgeEnd)`      |
| `yoga/direction`   | `FlexStyle.writing_direction`→ `YGNodeStyleSetDirection` + root `YGNodeCalculateLayout` direction |

`docs/reference/compat/yoga.md`: counts updated (28 → 35 supported, 18 → 11 missing); new \"2026-05-06 (pulp #1542)\" entry under Recent updates; the \"Direction (RTL) support\" section flipped to describe the supported state.

Net: yoga drift_count -7. Phase A3 Bundle 1 inside #1434 umbrella.

Closes #1542.