### PR TITLE
docs: document flex+grid layout model rationale (refs #1434)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,22 @@ Pulp uses a PreText-inspired text layout architecture (measure once, reflow fore
 - HarfBuzz, ICU, and SkParagraph are bundled in the Skia pre-built binaries — no separate vendoring needed
 - Fallback to character-width estimation when Skia unavailable
 
+### Layout Model — Flex + Grid only (deliberate)
+
+Pulp's layout engine is **Yoga** (`external/yoga/`), so the layout primitives are exactly what Yoga supports: **CSS Flexbox + CSS Grid** (Grid landed in Yoga 3.0, wired in PR #1509). CSS block flow, table layout, multi-column, floats, and print pagination are **out of scope by design**.
+
+When implementing a feature or assessing a compat gap, **don't reach for non-Yoga layout primitives**. If a property in `compat.json` is marked `wontfix` because it requires block/inline/table/multi-column/float/print primitives, that's the architectural ceiling — not a bug to fix. Reasons:
+
+1. **Yoga is the engine.** Adding non-Yoga layout means either a parallel layout engine (double maintenance) or block/table/columns reimplemented over Yoga (massive refactor).
+2. **React Native parity.** RN is also flex+grid-only. `@pulp/react` and the JS bridge depend on this contract.
+3. **GPU-first render pipeline.** Skia/Dawn favor a single tree-walk layout pass; multi-pass sequential algorithms (block flow, table cell auto-sizing, multi-column balancing, float wrap, paginated layout) don't compose with the render pipeline cleanly.
+4. **Use case is structured panels.** Pulp targets audio plugin UIs + cross-platform apps — knobs, faders, side panels, popovers. Newspaper columns and complex tables are not real Pulp use cases.
+5. **Modern design tools output flex/grid.** Figma, Stitch, v0, Pencil all produce flex containers + grid as their default layout primitives. Tooling alignment matters for the design-import path (#1434).
+
+The honest tradeoff: Pulp will never be a general-purpose web browser. It IS the right shape for cross-platform native UI. CSS coverage at ~95% raw / ~100% on non-OOS denominator IS the architectural ceiling, not a goal to push past by adding layout primitives.
+
+For the user-facing version of this rationale, see `docs/reference/layout-model.md`.
+
 ---
 
 ## Repo Standards

--- a/VISION.md
+++ b/VISION.md
@@ -11,7 +11,7 @@ It provides GPU-rendered UIs with hot reload, an extensible DSP layer supporting
 1. **Permissive licensing** — MIT. No royalties, no revenue thresholds, no copyleft.
 2. **Modular architecture** — use what you need, ignore the rest.
 3. **Native platform experiences** — Swift on Apple, C++ everywhere, GPU rendering on every platform.
-4. **Flexible rendering** — GPU-native UI without a browser, but WebView is there if you want it.
+4. **Flexible rendering** — GPU-native UI without a browser, but WebView is there if you want it. Layout is **Flexbox + Grid via Yoga** — the same primitives React Native and modern design tools use. Block flow, tables, multi-column, floats, and print pagination are deliberately out of scope; that's what makes the framework coherent and the design-import contract clean. (Details: [`docs/reference/layout-model.md`](docs/reference/layout-model.md).)
 5. **Modern workflows** — AI agents, design tools, hot-reload, and fast iteration from the start.
 
 ---

--- a/docs/reference/layout-model.md
+++ b/docs/reference/layout-model.md
@@ -1,0 +1,110 @@
+# Layout Model
+
+Pulp's layout engine is [Yoga](https://www.yogalayout.dev/), Facebook's
+cross-platform Flexbox implementation. Pulp supports the layout primitives
+Yoga supports — **CSS Flexbox and CSS Grid** — and nothing else.
+
+This is intentional, not aspirational.
+
+## What Pulp supports
+
+- **Flexbox** — `display: flex`, `flex-direction`, `flex-wrap`, `justify-content`,
+  `align-items`, `align-content`, `align-self`, `flex-grow`, `flex-shrink`,
+  `flex-basis`, `gap`, `order`, all variants.
+- **Grid** — `display: grid`, `grid-template-columns/rows`, `grid-area`,
+  `grid-column/row`, `grid-auto-flow`, named lines, gap, all spec'd track
+  sizing functions including `fr`, `minmax()`, `repeat()`.
+- **Position** — `position: absolute | relative | static | fixed`, with
+  `top`/`right`/`bottom`/`left`/`inset`. Logical-edge variants
+  (`marginInlineStart`, `paddingBlockEnd`, `start`, `end`) flip with
+  `direction: ltr | rtl`.
+- **Sizing** — `width`/`height`/`min-*`/`max-*` in `px`, `%`, `auto`,
+  `fr` (grid-only). `aspectRatio`. `boxSizing: border-box | content-box`.
+- **Overflow** — `overflow: hidden | scroll | visible` plus
+  `overflow-clip-margin` adjustments.
+- **Border + outline** — `border-width` per-edge, `border-radius`, `outline-*`
+  drawn outside the border box.
+- **Modern web** — `transform`, `opacity`, `filter`, `mask`, `clip-path`,
+  `mix-blend-mode`, `box-shadow`, `text-shadow`, gradients, animations,
+  transitions.
+
+## What Pulp does NOT support — by design
+
+The following CSS layout primitives are out of scope and will not be added.
+They're marked `wontfix` in `compat.json`.
+
+- **Block flow** — `display: block | inline | inline-block`, normal flow
+  with line boxes.
+- **Tables** — `display: table | table-row | table-cell`, `border-collapse`,
+  `border-spacing`, `caption-side`, `empty-cells`, `table-layout`.
+- **Multi-column layout** — `columns`, `column-count`, `column-width`,
+  `column-rule`, `break-inside`.
+- **Floats** — `float`, `clear`. (Modern alternatives: flex/grid.)
+- **Print** — `page-break-*`, `print-margin`, paginated layout.
+- **List item primitives** — `display: list-item` with auto-generated
+  markers. (Pulp DOES support `list-style*` properties for explicit
+  marker rendering — just not the auto-flow that block list-item layout
+  provides.)
+- **Vertical writing modes** — `writing-mode: vertical-rl | vertical-lr`.
+  (Logical-edge properties work for RTL horizontal flow, but vertical
+  text layout is not supported.)
+
+## Why
+
+1. **Yoga is the engine.** Pulp uses Yoga directly. Yoga doesn't implement
+   block flow, table layout, multi-column, or floats. Adding those would
+   require either running a different layout engine alongside Yoga (double
+   maintenance) or reimplementing block/table/columns on top of Yoga
+   (massive refactor — likely an architectural rewrite).
+
+2. **React Native parity.** React Native is also flex-and-grid-only. Pulp's
+   `@pulp/react` package and JS-bridge component model are intentionally
+   RN-aligned. Adding non-RN layout primitives would diverge from the
+   React component-tree contract.
+
+3. **GPU-first render pipeline.** Pulp renders via Skia + Dawn (WebGPU).
+   This pipeline favors a single tree-walk layout pass that produces a
+   geometry buffer. Block flow with mixed inline children, table cell
+   auto-sizing, multi-column balancing, float wrap, and paginated
+   layout all require complex multi-pass sequential algorithms that
+   don't compose cleanly with that pipeline.
+
+4. **Audio plugin and cross-platform app target.** Pulp targets structured
+   UI: knobs, faders, sliders, side panels, popovers, parameter grids.
+   Newspaper-column layouts, complex `<table>` styling, magazine flow,
+   print pagination — none of these are real Pulp use cases.
+
+5. **Modern design tools output flex/grid.** Figma, Stitch, v0, Pencil all
+   produce flex containers + CSS Grid as their primary layout primitives.
+   None export `display: block`, tables, or floats as default structure.
+   Tool alignment matters for Pulp's design-import workflow.
+
+## What this means for design imports
+
+When importing from Figma/Stitch/v0/Pencil into Pulp, the source design's
+auto-layout (which is itself flex/grid-shaped) maps directly to Pulp
+primitives. There is no impedance mismatch.
+
+If a source design happens to use `<table>` or floats (rare in modern
+tools), the import path will reject those nodes or rewrite them into
+flex containers — depending on the importer. See `docs/reference/design-import.md`.
+
+## What this means for compat coverage numbers
+
+Pulp's CSS compat coverage maxes out around **~85% raw / ~100% on non-OOS
+denominator**. The remaining gap is exactly the layout primitives listed
+above. Pushing past 85% raw on the unfiltered catalog would require
+implementing the wontfix items, which contradicts this design.
+
+When you read a coverage report, the raw percentage and the non-OOS
+percentage tell different stories: the non-OOS percentage is the honest
+"what fraction of in-scope CSS does Pulp support" number.
+
+## Honest tradeoff
+
+Pulp will never be a general-purpose web browser. It IS the right shape
+for cross-platform native UI. The fixed scope is what makes the framework
+coherent, the runtime fast, and the design-import contract clean.
+
+If you need block flow, tables, multi-column, or print layout, use a
+WebView. Pulp ships a WebView widget for exactly this case.


### PR DESCRIPTION
## Summary
- New CLAUDE.md "Layout Model" subsection explaining why Pulp is flex+grid-only
- New docs/reference/layout-model.md user-facing reference: what's supported, what's not, why
- Tightened VISION.md principle 4 to mention Flexbox + Grid via Yoga + design-import contract

## Why now

As the property-coverage harness drives css/rn/yoga past 90% (today: yoga 92.5%, rn 91.7%, canvas2d 95.5%, html 100%, css 72.7%), the residual css gap is exactly the layout primitives Pulp deliberately doesn't implement (block flow, tables, multi-column, floats, print). Documenting the rationale prevents future churn over 'why don't we support X' and gives agents a stable reference when auditing `wontfix` entries in compat.json.

## Test plan
- [x] Markdown renders cleanly
- [x] Doc links resolve (CLAUDE.md → docs/reference/layout-model.md, VISION.md → docs/reference/layout-model.md)
- [x] No SDK / plugin / runtime changes — docs-only