### PR TITLE
ci: route macOS leg to local self-hosted runner; Linux + Windows on GitHub-hosted

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,12 @@ jobs:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.PULP_DEFAULT_RUNNER_PROVIDER || 'namespace' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
-          EXPLICIT_MACOS_RUNNER_SELECTOR_JSON: ${{ inputs.macos_runner_selector_json || '' }}
+          # Falls back to the PULP_LOCAL_MACOS_RUNS_ON_JSON repo var so the
+          # macOS leg routes to the local self-hosted runner (label `sanitizer`)
+          # without a workflow_dispatch input on auto pull_request triggers.
+          # Mirrors Shipyard's local-mac runner pattern; allows Linux + Windows
+          # to fall through to GitHub-hosted defaults via PULP_DEFAULT_RUNNER_PROVIDER='github-hosted'.
+          EXPLICIT_MACOS_RUNNER_SELECTOR_JSON: ${{ inputs.macos_runner_selector_json || vars.PULP_LOCAL_MACOS_RUNS_ON_JSON || '' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON }}
           NAMESPACE_WINDOWS_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON }}
           NAMESPACE_MACOS_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON }}


### PR DESCRIPTION
## Summary

Migrates pulp's CI off Namespace for the macOS leg by adding a repo-var fallback to `EXPLICIT_MACOS_RUNNER_SELECTOR_JSON` in `build.yml`. Mirrors Shipyard PR #272 for parity.

When no `workflow_dispatch` input is provided, the resolver picks up `vars.PULP_LOCAL_MACOS_RUNS_ON_JSON` and routes the macOS leg to the local self-hosted runner (label `sanitizer`).

`coverage.yml` and `sanitizers.yml` already have repo-var override paths via their existing `mode=default` resolver — they pick up the new vars without YAML changes.

## Repo vars to set after merge

```bash
gh variable set PULP_LOCAL_MACOS_RUNS_ON_JSON --body '["self-hosted","sanitizer"]' --repo danielraffel/pulp
gh variable set PULP_COVERAGE_MACOS_RUNS_ON_JSON --body '["self-hosted","sanitizer"]' --repo danielraffel/pulp
gh variable set PULP_SANITIZER_ASAN_RUNS_ON_JSON --body '["self-hosted","sanitizer"]' --repo danielraffel/pulp
gh variable set PULP_SANITIZER_TSAN_RUNS_ON_JSON --body '["self-hosted","sanitizer"]' --repo danielraffel/pulp
gh variable set PULP_SANITIZER_UBSAN_RUNS_ON_JSON --body '["self-hosted","sanitizer"]' --repo danielraffel/pulp
gh variable set PULP_SANITIZER_RTSAN_RUNS_ON_JSON --body '["self-hosted","sanitizer"]' --repo danielraffel/pulp
gh variable set PULP_DEFAULT_RUNNER_PROVIDER --body 'github-hosted' --repo danielraffel/pulp
```

## Vars to delete (so Linux + Windows fall to GH-hosted)

```bash
gh variable delete PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON --repo danielraffel/pulp 2>/dev/null
gh variable delete PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON --repo danielraffel/pulp 2>/dev/null
gh variable delete PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON --repo danielraffel/pulp 2>/dev/null
```

## Release artifacts unchanged

Same matrix (macOS / Linux / Windows); only the hardware shifts.

## Rollback

```bash
gh variable delete PULP_LOCAL_MACOS_RUNS_ON_JSON --repo danielraffel/pulp
gh variable set PULP_DEFAULT_RUNNER_PROVIDER --body 'namespace' --repo danielraffel/pulp
```

## Test plan

- [ ] Set the 7 repo vars + delete the 3 namespace vars
- [ ] Open a tiny test PR — confirm macOS lands on `Daniels-MacBook-Pro` runner; Linux + Windows on `ubuntu-latest` / `windows-latest`