### PR TITLE
ci(perf): fast-CI / full-CI split via ctest labels (closes pulp #1589)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,7 +293,22 @@ jobs:
         # GH-hosted ubuntu/macos-15 runners also have ≥4 cores so this
         # doesn't regress their previous behavior. Higher parallelism
         # roughly halves test phase wall-time on multi-core hosts.
-        run: ctest --output-on-failure -C Release -LE validation -j8 --timeout 120 --exclude-regex "STFT|VisualizationBridge|Clipboard|Toolbar add items"
+        #
+        # Fast-CI / full-CI split (#1589). On `pull_request` events, the
+        # `slow` label is added to the existing `validation` exclusion so
+        # PRs skip wall-time-heavy tests (cmake-ios-auv3-configure ~3 min,
+        # filesystem-mtime sleep loops, Timer hammers, etc — see
+        # docs/guides/local-ci.md > Fast-CI vs full-CI). On push to main /
+        # nightly schedule / workflow_dispatch the full suite still runs
+        # so slow tests gate landing into the release lane.
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            LABELS_EXCLUDE="validation|slow"
+          else
+            LABELS_EXCLUDE="validation"
+          fi
+          ctest --output-on-failure -C Release -LE "$LABELS_EXCLUDE" -j8 --timeout 120 --exclude-regex "STFT|VisualizationBridge|Clipboard|Toolbar add items"
 
       - name: Test (Windows — UTF-8 code page wrapped)
         # Windows needs a UTF-8 console code page so ctest's child
@@ -310,9 +325,15 @@ jobs:
         if: runner.os == 'Windows'
         working-directory: build
         shell: cmd
+        # Fast-CI / full-CI split (#1589): same conditional as the
+        # non-Windows step above. cmd doesn't have bash conditionals so
+        # we lean on the GitHub Actions expression to pick the value
+        # before the cmd shell ever sees it.
+        env:
+          PULP_CTEST_LABELS_EXCLUDE: ${{ github.event_name == 'pull_request' && 'validation|slow' || 'validation' }}
         run: |
           chcp 65001
-          ctest --output-on-failure -C Release -LE validation -j8 --timeout 120 --exclude-regex "STFT|VisualizationBridge|Clipboard|Toolbar add items"
+          ctest --output-on-failure -C Release -LE "%PULP_CTEST_LABELS_EXCLUDE%" -j8 --timeout 120 --exclude-regex "STFT|VisualizationBridge|Clipboard|Toolbar add items"
 
       # Plugin bundle uploads only run on push/schedule events — pull_request
       # events skip example plugin builds (see Configure step's

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -299,6 +299,62 @@ Important constraints in the current phase:
   provider routing lives under the GitHub Actions workflow/provider config and
   the `cloud namespace` helper commands
 
+## Fast-CI vs full-CI (`build.yml`)
+
+Issue #1589 split the `Build and Test` workflow into two test
+trajectories without forking the YAML:
+
+- **Fast-CI** runs on `pull_request` events. The ctest invocation
+  excludes BOTH the `validation` and `slow` CTest labels, dropping the
+  longest-running tests so PR cycle time stays tight. Examples that
+  carry `LABELS slow` today (defined in `test/CMakeLists.txt`):
+  - `cmake-ios-auv3-configure` — fresh-cache ~3 min iOS-leg configure
+  - `cmake-pulp-add-binary-data-encoder` / `cmake-pulp-install-layout`
+  - `pulp-test-hot-reload`, `pulp-test-scripted-ui`, `pulp-test-scan-cache`,
+    `pulp-test-scan-blacklist` (filesystem-mtime sleep loops)
+  - `pulp-test-sync`, `pulp-test-sync-race-hammer`,
+    `pulp-test-events-timer-helpers` (race + timer hammers; also covered
+    under sanitizer.yml's TSan lane)
+
+- **Full-CI** runs on `push` to `main`, the nightly schedule, and
+  `workflow_dispatch`. Only the `validation` label is excluded — every
+  `slow`-labelled test runs before code lands on the release lane.
+
+Both paths satisfy the branch-protection-required `macos` /
+advisory `linux` / advisory `windows` alias gates because the alias
+jobs read each matrix leg's outcome via the GitHub API.
+
+### Tagging a new test as slow
+
+Add `LABELS slow` either to a single test's `set_tests_properties`, or
+to a Catch2 binary's `catch_discover_tests(... PROPERTIES LABELS slow)`
+so every discovered test inherits the label:
+
+```cmake
+add_test(NAME my-expensive-cmake-smoke COMMAND ...)
+set_tests_properties(my-expensive-cmake-smoke PROPERTIES
+    LABELS "smoke;slow"
+    TIMEOUT 600)
+
+add_executable(pulp-test-my-suite test_my_suite.cpp)
+target_link_libraries(pulp-test-my-suite PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-my-suite PROPERTIES LABELS slow)
+```
+
+Rule of thumb for `slow`: a test consistently >5 sec on at least one
+platform, OR a sleep-bounded smoke (file-mtime, hammer race, message-loop
+bound) whose value lies in soak coverage rather than per-PR feedback.
+Anything covered by sanitizers.yml or another scheduled lane is a
+strong candidate.
+
+### Demoting a fast test to slow (or vice versa)
+
+`ctest --test-dir build -L slow -N` lists every test currently tagged
+`slow`. To move a test in or out of the fast-CI surface, add or remove
+the `slow` label in `test/CMakeLists.txt` (or the appropriate subdir
+CMakeLists) and reconfigure. There's no separate registry to keep in
+sync.
+
 ## Switching a job's runner without a code change
 
 Every runner-selection decision in `.github/workflows/*.yml` is driven by

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,12 @@ if(APPLE AND NOT PULP_IOS)
                 ${CMAKE_SOURCE_DIR})
     set_tests_properties(cmake-ios-auv3-configure PROPERTIES
         SKIP_RETURN_CODE 77
-        TIMEOUT 900)
+        TIMEOUT 900
+        # Tagged `slow` for fast-CI exclusion (#1589): a fresh-cache
+        # configure spends ~3 minutes downloading + unpacking iOS-leg
+        # FetchContent sources before the actual smoke fires. Full-CI
+        # (push to main / nightly / workflow_dispatch) still runs it.
+        LABELS slow)
 endif()
 
 # AU v2 component-type selection smoke — hardens the aufx→aumf flip
@@ -37,7 +42,10 @@ add_test(NAME cmake-pulp-add-binary-data-encoder
     COMMAND ${CMAKE_COMMAND} -P
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_pulp_add_binary_data_encoder.cmake)
 set_tests_properties(cmake-pulp-add-binary-data-encoder PROPERTIES
-    LABELS "cmake;binary-data;issue-898"
+    # `slow` (#1589): runs `cmake -P` which spawns a CMake interpreter
+    # to encode a synthetic 1 MB asset; consistently 4-5 sec wall on
+    # all three platforms. Excluded from PR fast-CI.
+    LABELS "cmake;binary-data;issue-898;slow"
     TIMEOUT 60)
 
 # Install-layout regression for issue-905 follow-up: when the SDK is
@@ -51,7 +59,10 @@ add_test(NAME cmake-pulp-install-layout
         -DPULP_BUILD_DIR=${CMAKE_BINARY_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_pulp_install_layout.cmake)
 set_tests_properties(cmake-pulp-install-layout PROPERTIES
-    LABELS "cmake;binary-data;issue-905"
+    # `slow` (#1589): runs `cmake --install` from this build into a
+    # temp prefix and inspects the staged layout. Cheap on warm builds
+    # but pays a configure-amortised cost — pull it out of PR fast-CI.
+    LABELS "cmake;binary-data;issue-905;slow"
     TIMEOUT 120)
 
 # retry_git_clone unit test (setup.sh helper). Guards the #425 P1
@@ -575,7 +586,10 @@ catch_discover_tests(pulp-test-codesign)
 # Sync primitives tests (SeqLock, TripleBuffer)
 add_executable(pulp-test-sync test_sync_primitives.cpp)
 target_link_libraries(pulp-test-sync PRIVATE pulp::runtime Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-sync)
+# `slow` (#1589): hammer tests run a writer + readers for 500 ms each
+# to surface ordering bugs. Sanitizers.yml exercises the same code
+# under TSan; PR fast-CI can skip the redundant smoke.
+catch_discover_tests(pulp-test-sync PROPERTIES LABELS slow)
 
 # License and BigInteger tests
 add_executable(pulp-test-license test_license.cpp)
@@ -674,7 +688,9 @@ catch_discover_tests(pulp-test-view-host-bridge)
 # Scan blacklist (workstream 03 slice 3.3a)
 add_executable(pulp-test-scan-blacklist test_scan_blacklist.cpp)
 target_link_libraries(pulp-test-scan-blacklist PRIVATE pulp::host Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-scan-blacklist)
+# `slow` (#1589): file-mtime sleep loops (rebuilt-plugin-not-blacklisted
+# flow waits on filesystem timestamp resolution). Each test ~1s.
+catch_discover_tests(pulp-test-scan-blacklist PROPERTIES LABELS slow)
 # Hosted editor API (workstream 03 slice 3.4)
 add_executable(pulp-test-hosted-editor test_hosted_editor.cpp)
 target_link_libraries(pulp-test-hosted-editor PRIVATE pulp::host Catch2::Catch2WithMain)
@@ -694,7 +710,9 @@ catch_discover_tests(pulp-test-transport-hook)
 # Scan cache (workstream 03 slice 3.1)
 add_executable(pulp-test-scan-cache test_scan_cache.cpp)
 target_link_libraries(pulp-test-scan-cache PRIVATE pulp::host Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-scan-cache)
+# `slow` (#1589): each scenario waits for filesystem mtime resolution
+# (~1s each on every platform). Excluded from PR fast-CI.
+catch_discover_tests(pulp-test-scan-cache PROPERTIES LABELS slow)
 # Processor memory-pressure hook (workstream 05 slice 5.3)
 add_executable(pulp-test-memory-pressure test_memory_pressure.cpp)
 target_link_libraries(pulp-test-memory-pressure PRIVATE pulp::format Catch2::Catch2WithMain)
@@ -986,7 +1004,10 @@ catch_discover_tests(pulp-test-runtime)
 # alternation in sanitizers.yml's --tests-regex).
 add_executable(pulp-test-sync-race-hammer test_sync_race_hammer.cpp)
 target_link_libraries(pulp-test-sync-race-hammer PRIVATE pulp::runtime Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-sync-race-hammer)
+# `slow` (#1589): N-thread race smoke. Sanitizer builds also pick this
+# up via the dedicated sanitizers.yml workflow, so PR fast-CI doesn't
+# need to re-run it.
+catch_discover_tests(pulp-test-sync-race-hammer PROPERTIES LABELS slow)
 
 # Events tests
 add_executable(pulp-test-events test_events.cpp)
@@ -999,7 +1020,11 @@ catch_discover_tests(pulp-test-events-async-helpers)
 
 add_executable(pulp-test-events-timer-helpers test_events_timer_helpers.cpp)
 target_link_libraries(pulp-test-events-timer-helpers PRIVATE pulp::events Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-events-timer-helpers)
+# `slow` (#1589): Timer hammer + UAF-free destroy-while-dispatched
+# tests deliberately exercise message-loop pacing (~0.3-1.5 sec each
+# depending on platform). Excluded from PR fast-CI; sanitizers.yml
+# still covers Timer under TSan.
+catch_discover_tests(pulp-test-events-timer-helpers PROPERTIES LABELS slow)
 
 # Audio file I/O tests
 add_executable(pulp-test-audio-file test_audio_file.cpp)
@@ -1302,7 +1327,9 @@ catch_discover_tests(pulp-test-script)
 # Scripted UI hot reload/theme reload tests
 add_executable(pulp-test-scripted-ui test_scripted_ui.cpp)
 target_link_libraries(pulp-test-scripted-ui PRIVATE pulp::view Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-scripted-ui)
+# `slow` (#1589): ScriptedUiSession reload tests sleep on file-watcher
+# debounce + filesystem mtime; ~0.5-1 sec each. Excluded from PR fast-CI.
+catch_discover_tests(pulp-test-scripted-ui PROPERTIES LABELS slow)
 
 # JS engine abstraction tests (shared across all backends)
 add_executable(pulp-test-js-engine test_js_engine.cpp)
@@ -1475,8 +1502,12 @@ catch_discover_tests(pulp-test-widgets)
 # Hot-reload tests
 add_executable(pulp-test-hot-reload test_hot_reload.cpp)
 target_link_libraries(pulp-test-hot-reload PRIVATE pulp::view Catch2::Catch2WithMain)
+# `slow` (#1589): each HotReloader scenario sleeps on file-watcher
+# debounce + filesystem mtime resolution (~1-1.5 sec each).
 catch_discover_tests(pulp-test-hot-reload
-    PROPERTIES RESOURCE_LOCK hot-reload-file-watcher)
+    PROPERTIES
+        RESOURCE_LOCK hot-reload-file-watcher
+        LABELS slow)
 
 # Inspector tests — only when GPU is enabled (pulp-inspect requires GPU stack).
 if(PULP_ENABLE_GPU AND NOT ANDROID AND NOT IOS)
@@ -1617,7 +1648,10 @@ add_executable(pulp-test-web-compat-react-shims test_web_compat_react_shims.cpp)
 target_link_libraries(pulp-test-web-compat-react-shims PRIVATE pulp::view Catch2::Catch2WithMain)
 # issue #902 bound-pump test runs the 1M-job cap; budget headroom for slow
 # CI runners and sanitizer builds. Default discover timeout is too tight
-# when a regression of the bound would hang indefinitely.
+# when a regression of the bound would hang indefinitely. Other shim
+# scenarios in this binary stay in PR fast-CI — they're cheap and
+# important — so this binary is *not* labelled `slow` even though one
+# of its tests pays a 1-3 sec wall cost.
 catch_discover_tests(pulp-test-web-compat-react-shims
     PROPERTIES TIMEOUT 180
 )


### PR DESCRIPTION
## Summary

Closes pulp #1589 — split CI into fast-CI on PR events and full-CI on push to main / nightly / dispatch, using a single conditional `ctest -LE` instead of forking the workflow.

- **Fast-CI** (PR events): `ctest -LE "validation|slow"` excludes 46 wall-time-heavy tests so PR cycle time drops further on top of #1588.
- **Full-CI** (push to main, schedule, workflow_dispatch): `ctest -LE "validation"` runs the full suite, so any `LABELS slow` regression gets caught before the release lane.
- Same conditional applied to the Windows test step (cmd shell) via a GitHub Actions expression env var.
- Branch-protection contract preserved: `macos` alias gate is still authoritative, full-CI re-validates the slow surface post-merge.

## What got `LABELS slow`

Surfaced from the most recent green Build and Test run on `origin/main` — top wall-time hitters per platform:

**CMake-level (3 tests)**
- `cmake-ios-auv3-configure` — 187s on macOS (fresh-cache iOS configure dominates wall-clock)
- `cmake-pulp-add-binary-data-encoder` — ~5s every platform
- `cmake-pulp-install-layout` — ~1s every platform

**Catch2 binaries (label inherited via `catch_discover_tests PROPERTIES`)**
- `pulp-test-hot-reload` — HotReloader file-watcher sleep tests
- `pulp-test-scripted-ui` — ScriptedUiSession reload tests
- `pulp-test-scan-cache` — file-mtime sleep loops
- `pulp-test-scan-blacklist` — rebuild-detection sleeps
- `pulp-test-sync` — SeqLock / TripleBuffer hammers
- `pulp-test-sync-race-hammer` — N-thread race smoke (also TSan-covered)
- `pulp-test-events-timer-helpers` — Timer hammer + UAF-free destroy

`pulp-test-web-compat-react-shims` is intentionally NOT tagged slow even though one test inside it pays a 1-3s wall cost — the rest of the binary is cheap React-shim coverage that should stay in PR fast-CI.

## Why one workflow + a conditional, not a separate `fast-ci.yml`

Forking the workflow would double maintenance for a tiny readability win. The same per-event branching pattern already lives in the Configure step (`PULP_BUILD_EXAMPLES=OFF` on PR events from #1588) and the artifact-upload steps. One workflow keeps cache keys, ccache stats, and runner-resolution logic in one place.

## Doc

`docs/guides/local-ci.md` gains a "Fast-CI vs full-CI (build.yml)" section that:

- Lists every test currently tagged `slow`
- Gives the rule of thumb for adding `LABELS slow` to a new test (>5 sec on at least one platform OR sleep-bounded smoke whose value is in soak coverage)
- Documents `ctest --test-dir build -L slow -N` for inspecting the current surface

## Test plan

- [ ] PR fast-CI runs and finishes faster than #1588's baseline (verify via build duration delta on the macOS leg in particular — the 187s `cmake-ios-auv3-configure` alone should drop)
- [ ] On merge to main, full-CI runs with `-LE validation` only — verify slow tests appear in the test-phase log
- [ ] `workflow_dispatch` run also exercises full-CI (because the conditional only opts in fast-CI on `pull_request`)
- [ ] Local sanity: `ctest --test-dir build -L slow -N` reports 46 tests, `-LE "validation|slow"` reports 503 (vs 549 with `-LE validation`) — verified in the worktree

## Local validation

```
$ ctest --test-dir build -L slow -N | tail -3
  Test #490: cmake-pulp-install-layout
Total Tests: 46

$ ctest --test-dir build -LE "validation|slow" -N | tail -3
  Test #557: threejs_native_demo_capture_no_hang
Total Tests: 503

$ ctest --test-dir build -LE "validation" -N | tail -3
  Test #557: threejs_native_demo_capture_no_hang
Total Tests: 549
```

## Refs

Sequel to #1588 (runner-side perf — ctest -j8, persistent self-hosted workspace, PR-time `PULP_BUILD_EXAMPLES=OFF`, per-OS alias gates). Together these two PRs replace the larger "separate fast-ci.yml workflow + label-based test filtering" path that was on the table earlier this week.
