### PR TITLE
test(visual): add yoga layout snapshot harness

### DIFF
--- a/.github/workflows/visual-harness.yml
+++ b/.github/workflows/visual-harness.yml
@@ -10,7 +10,10 @@ on:
       - 'external/fonts/**'
       - 'external/skia-build/VERSION.md'
       - 'tools/deps/manifest.json'
+      - 'tools/harness/verifier.py'
       - 'tools/harness/visual/**'
+      - 'test/CMakeLists.txt'
+      - 'test/visual/**'
   push:
     branches: [main]
     paths:
@@ -20,7 +23,10 @@ on:
       - 'external/fonts/**'
       - 'external/skia-build/VERSION.md'
       - 'tools/deps/manifest.json'
+      - 'tools/harness/verifier.py'
       - 'tools/harness/visual/**'
+      - 'test/CMakeLists.txt'
+      - 'test/visual/**'
   workflow_dispatch:
 
 permissions:
@@ -83,3 +89,57 @@ jobs:
         env:
           PULP_VISUAL_REQUIRE_SKIA: '1'
         run: .visual-harness-venv/bin/python -m pytest tools/harness/visual/tests/ -q
+
+  layout-snapshots:
+    name: Yoga layout snapshots
+    runs-on: ${{ fromJSON(vars.PULP_LOCAL_MACOS_RUNS_ON_JSON || '"macos-15"') }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Install ccache
+        run: brew install ccache
+
+      - name: Cache FetchContent sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Pulp/fetchcontent-src
+            ~/.cache/Pulp/fetchcontent-src
+          key: ${{ runner.os }}-visual-fetchcontent-${{ hashFiles('setup.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-visual-fetchcontent-
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/ccache
+            ~/.cache/ccache
+          key: ${{ runner.os }}-visual-ccache-${{ hashFiles('**/CMakeLists.txt', 'tools/cmake/*.cmake') }}-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-visual-ccache-${{ hashFiles('**/CMakeLists.txt', 'tools/cmake/*.cmake') }}-
+            ${{ runner.os }}-visual-ccache-
+
+      - name: Bootstrap repository dependencies
+        run: ./setup.sh --ci --deps-only
+
+      - name: Configure visual harness
+        run: cmake -S . -B build-visual -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_EXAMPLES=OFF
+
+      - name: Build visual harness
+        run: cmake --build build-visual --config Release --target pulp-test-visual
+
+      - name: Verify Yoga layout goldens
+        run: python3 tools/harness/verifier.py visual --verify --all --build-dir build-visual
+
+      - name: Ccache stats
+        if: always()
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            ccache --show-stats
+          else
+            echo "ccache not available; skipping stats"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -789,7 +789,9 @@ Pulp ships as a Claude Code plugin with slash commands (`/build`, `/test`, `/cre
 
 ### CI Workflow
 
-**Never merge a PR without green CI on all three platforms (macOS, Ubuntu, Windows).** Use the `ci` skill for all merges — it handles the full workflow.
+Use Shipyard for all merges. Current Pulp branch protection requires the
+macOS lane; Linux and Windows still run in GitHub Actions but are advisory
+unless branch protection changes.
 
 #### The `ship` workflow (primary path for all agents)
 
@@ -812,7 +814,6 @@ pulp pr
 # default ship path:
 shipyard run                              # validate current branch
 shipyard ship                             # resume/operate on an existing Shipyard-managed PR
-shipyard cloud run build <branch>         # dispatch to Namespace
 
 # SSH preflight (v0.20.0+ / Shipyard #106): exit codes are distinct.
 #   0 — success
@@ -829,24 +830,30 @@ The CI skill (`.agents/skills/ci/SKILL.md`) is the single source of truth for la
 
 1. Run `shipyard pr` — never `gh pr create` + `shipyard ship` separately (that bypasses the skill-sync and version-bump gates)
 2. The orchestrator runs skill-sync + version-bump gates, commits any bumps, pushes, opens/tracks the PR, and invokes Shipyard validation
-3. Shipyard validates on macOS (locally), Ubuntu (SSH), and Windows (SSH)
-4. Merges only when ALL targets pass
+3. Shipyard validates the macOS lane through the local self-hosted runner path
+4. GitHub Actions runs Linux and Windows on GitHub-hosted runners as advisory checks
 5. Posts a closeout comment
 
 `local_ci.py` remains in the repo as a legacy fallback but is scheduled for removal (see issue #120).
 
-#### GitHub Actions (backup gate)
+#### GitHub Actions
 
-PRs also trigger `.github/workflows/build.yml` which builds and tests on all three platforms via Namespace runners. This is a redundant safety net — Shipyard's local validation is the primary path.
+PRs trigger `.github/workflows/build.yml` on all three platforms. macOS routes
+to the local self-hosted runner through `PULP_LOCAL_MACOS_RUNS_ON_JSON` when
+that repo variable is set. Linux and Windows use GitHub-hosted runners and are
+advisory unless explicitly required by branch protection.
 
 #### Runner priority (hard rule)
 
-**Always use Namespace for cloud CI. Never rely on GitHub-hosted runners as the primary path.**
+Namespace is decommissioned for Pulp CI. Do not use `--mode namespace` or set
+`*_NAMESPACE_*_RUNS_ON_JSON` repo variables.
 
-1. **Namespace** (default): `shipyard cloud run build <branch>`
-2. **Local VMs** (fallback): `ssh ubuntu`, `ssh win` via `shipyard run`
-3. **GitHub-hosted** (last resort): Only if Namespace is unavailable.
+1. **macOS local runner**: primary required gate.
+2. **GitHub-hosted Linux/Windows**: advisory cross-platform signal.
+3. **SSH Ubuntu/Windows**: use only when a human explicitly asks for those local hosts.
 
-macOS runs locally in parallel with Namespace/SSH Ubuntu/Windows builds.
+If Shipyard tries to probe SSH Ubuntu or Windows for a macOS-focused PR where
+those hosts are not in scope, use `--skip-target ubuntu --skip-target windows`
+and file a Shipyard issue if the CLI should have inferred that from config.
 
 See `docs/guides/local-ci.md` for setup.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -633,7 +633,7 @@ Namespace profile setup note:
 
 ### harness
 
-Run the catalog coverage harness. The command delegates to `tools/harness/verifier.py` and compares `compat.json` support claims against machine-derived oracles. The first wired adapter is the Yoga surface from #1395.
+Run the catalog coverage harness and deterministic visual snapshot harness. Coverage mode delegates to `tools/harness/verifier.py` and compares `compat.json` support claims against machine-derived oracles. Visual mode delegates to `tools/harness/visual/runner.py` and compares semantic Yoga layout snapshots against checked-in goldens.
 
 ```bash
 pulp harness --surface=yoga
@@ -641,9 +641,13 @@ pulp harness coverage --surface=yoga
 pulp harness --all
 pulp harness --surface=yoga --json
 pulp harness --surface=yoga --no-docs
+pulp harness visual --verify --all
+pulp harness visual --generate --surface=yoga --entry=yoga/box-sizing
 ```
 
-By default, the harness writes `build/harness-coverage-<sha>.json`, `build/harness-coverage.md`, and `docs/reports/harness-coverage.md`. Use `--json` for stdout-only machine output.
+By default, coverage mode writes `build/harness-coverage-<sha>.json`, `build/harness-coverage.md`, and `docs/reports/harness-coverage.md`. Use `--json` for stdout-only machine output. Coverage JSON includes `visual_pass` per surface, counted from checked-in visual goldens against the current `compat.json` surface total.
+
+Visual mode requires the `pulp-test-visual` target to be built first. Use `--build-dir` or `--binary` when the binary is not under the default `build/` or `build-visual/` directories.
 
 ### ship
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -704,24 +704,43 @@ commands:
 
   - name: harness
     status: experimental
-    summary: Catalog-driven coverage harness. Delegates to tools/harness/verifier.py to compare compat.json support claims against machine-derived oracles, starting with the Yoga surface.
+    summary: Catalog and visual regression harness. Delegates to tools/harness/verifier.py for compat coverage and tools/harness/visual/runner.py for semantic Yoga layout snapshots.
     args:
       - name: coverage
         kind: positional
         required: false
         description: Optional compatibility subcommand; accepted for the documented `pulp harness coverage` form and stripped before verifier argument parsing.
+      - name: visual
+        kind: positional
+        required: false
+        description: Run the deterministic visual snapshot harness (`pulp harness visual --verify --all`).
       - name: --surface
         kind: option
-        description: Run one surface adapter, such as yoga. May be repeated.
+        description: Run one surface adapter or visual fixture surface, such as yoga. May be repeated.
       - name: --all
         kind: flag
-        description: Run every wired surface adapter.
+        description: Run every wired coverage adapter, or all visual fixtures for the selected visual surface.
       - name: --json
         kind: flag
         description: Print the JSON report to stdout instead of writing build/docs report files.
       - name: --no-docs
         kind: flag
         description: Skip writing docs/reports/harness-coverage.md.
+      - name: --verify
+        kind: flag
+        description: Visual subcommand only; verify fixtures against checked-in semantic goldens.
+      - name: --generate
+        kind: flag
+        description: Visual subcommand only; regenerate checked-in semantic goldens.
+      - name: --entry
+        kind: option
+        description: Visual subcommand only; run one fixture entry, such as yoga/box-sizing. May be repeated.
+      - name: --binary
+        kind: option
+        description: Visual subcommand only; override the pulp-test-visual binary path.
+      - name: --build-dir
+        kind: option
+        description: Visual subcommand only; CMake build directory used to locate pulp-test-visual.
       - name: --repo-root
         kind: option
         description: Override repo-root discovery.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1525,6 +1525,16 @@ add_executable(pulp-test-layout-w3c test_layout_w3c.cpp)
 target_link_libraries(pulp-test-layout-w3c PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-layout-w3c)
 
+# Visual semantic snapshot harness. This is a custom-main Catch2 binary:
+# --self-test runs its focused tests, while --fixture emits a stable JSON
+# snapshot for tools/harness/visual/runner.py.
+add_executable(pulp-test-visual visual/pulp-test-visual.cpp)
+target_link_libraries(pulp-test-visual PRIVATE pulp::view Catch2::Catch2)
+add_test(NAME visual-harness-self-test COMMAND pulp-test-visual --self-test)
+set_tests_properties(visual-harness-self-test PROPERTIES
+    LABELS "visual;harness;yoga"
+    TIMEOUT 30)
+
 # CanvasWidget tests (JS-driven custom drawing)
 add_executable(pulp-test-canvas-widget test_canvas_widget.cpp)
 target_link_libraries(pulp-test-canvas-widget PRIVATE pulp::view Catch2::Catch2WithMain)

--- a/test/visual/pulp-test-visual.cpp
+++ b/test/visual/pulp-test-visual.cpp
@@ -1,0 +1,512 @@
+// Semantic visual snapshot harness for deterministic Yoga layout fixtures.
+
+#include <pulp/view/view.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <choc/text/choc_JSON.h>
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <initializer_list>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+namespace fs = std::filesystem;
+using pulp::view::Dimension;
+using pulp::view::DimensionUnit;
+using pulp::view::FlexAlign;
+using pulp::view::FlexDirection;
+using pulp::view::FlexJustify;
+using pulp::view::FlexStyle;
+using pulp::view::FlexWrap;
+using pulp::view::Rect;
+using pulp::view::View;
+
+struct FixtureTree {
+    std::unique_ptr<View> root;
+    std::unordered_map<const View*, std::string> types;
+};
+
+struct BuildContext {
+    int next_id = 0;
+    std::unordered_map<const View*, std::string> types;
+};
+
+std::string read_file(const fs::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) throw std::runtime_error("could not open fixture: " + path.string());
+    std::ostringstream out;
+    out << in.rdbuf();
+    return out.str();
+}
+
+std::optional<choc::value::ValueView> get_any(const choc::value::ValueView& obj,
+                                              std::initializer_list<const char*> keys) {
+    if (!obj.isObject()) return std::nullopt;
+    for (auto* key : keys) {
+        if (obj.hasObjectMember(key)) return obj[key];
+    }
+    return std::nullopt;
+}
+
+bool is_number(const choc::value::ValueView& value) {
+    return value.isInt32() || value.isInt64() || value.isFloat32() || value.isFloat64();
+}
+
+double number_value(const choc::value::ValueView& value, double fallback = 0.0) {
+    if (value.isInt32() || value.isInt64()) return static_cast<double>(value.getInt64());
+    if (value.isFloat32() || value.isFloat64()) return value.getFloat64();
+    return fallback;
+}
+
+std::optional<double> get_number(const choc::value::ValueView& obj,
+                                 std::initializer_list<const char*> keys) {
+    auto value = get_any(obj, keys);
+    if (!value || !is_number(*value)) return std::nullopt;
+    return number_value(*value);
+}
+
+std::optional<std::string> get_string(const choc::value::ValueView& obj,
+                                      std::initializer_list<const char*> keys) {
+    auto value = get_any(obj, keys);
+    if (!value || !value->isString()) return std::nullopt;
+    return value->getWithDefault<std::string>("");
+}
+
+std::optional<bool> get_bool(const choc::value::ValueView& obj,
+                             std::initializer_list<const char*> keys) {
+    auto value = get_any(obj, keys);
+    if (!value || !value->isBool()) return std::nullopt;
+    return value->getWithDefault<bool>(false);
+}
+
+std::optional<Dimension> get_dimension(const choc::value::ValueView& obj,
+                                       std::initializer_list<const char*> keys) {
+    auto value = get_any(obj, keys);
+    if (!value) return std::nullopt;
+    if (is_number(*value)) {
+        return Dimension{static_cast<float>(number_value(*value)), DimensionUnit::px};
+    }
+    if (value->isString()) {
+        return Dimension::parse(value->getWithDefault<std::string>(""));
+    }
+    return std::nullopt;
+}
+
+FlexDirection parse_direction(std::string_view s) {
+    if (s == "row") return FlexDirection::row;
+    if (s == "row_reverse" || s == "row-reverse") return FlexDirection::row_reverse;
+    if (s == "column_reverse" || s == "column-reverse") return FlexDirection::column_reverse;
+    return FlexDirection::column;
+}
+
+FlexAlign parse_align(std::string_view s, FlexAlign fallback) {
+    if (s == "start" || s == "flex-start") return FlexAlign::start;
+    if (s == "center") return FlexAlign::center;
+    if (s == "end" || s == "flex-end") return FlexAlign::end;
+    if (s == "stretch") return FlexAlign::stretch;
+    if (s == "auto") return FlexAlign::auto_;
+    if (s == "baseline") return FlexAlign::baseline;
+    return fallback;
+}
+
+FlexJustify parse_justify(std::string_view s) {
+    if (s == "center") return FlexJustify::center;
+    if (s == "end" || s == "flex-end") return FlexJustify::end_;
+    if (s == "space_between" || s == "space-between") return FlexJustify::space_between;
+    if (s == "space_around" || s == "space-around") return FlexJustify::space_around;
+    if (s == "space_evenly" || s == "space-evenly") return FlexJustify::space_evenly;
+    return FlexJustify::start;
+}
+
+FlexWrap parse_wrap(std::string_view s) {
+    if (s == "wrap") return FlexWrap::wrap;
+    if (s == "wrap_reverse" || s == "wrap-reverse") return FlexWrap::wrap_reverse;
+    return FlexWrap::no_wrap;
+}
+
+void apply_dimension_to(float& legacy, Dimension& dim_slot, const std::optional<Dimension>& dim) {
+    if (!dim) return;
+    if (dim->unit == DimensionUnit::px) {
+        legacy = dim->value;
+    } else {
+        dim_slot = *dim;
+    }
+}
+
+void apply_style(View& view, const choc::value::ValueView& style) {
+    if (!style.isObject()) return;
+    auto& flex = view.flex();
+
+    if (auto value = get_string(style, {"direction", "flex_direction", "flexDirection"}))
+        flex.direction = parse_direction(*value);
+    if (auto value = get_string(style, {"align_items", "alignItems"}))
+        flex.align_items = parse_align(*value, flex.align_items);
+    if (auto value = get_string(style, {"align_self", "alignSelf"}))
+        flex.align_self = parse_align(*value, flex.align_self);
+    if (auto value = get_string(style, {"justify_content", "justifyContent"}))
+        flex.justify_content = parse_justify(*value);
+    if (auto value = get_string(style, {"flex_wrap", "flexWrap", "wrap"}))
+        flex.flex_wrap = parse_wrap(*value);
+
+    if (auto value = get_number(style, {"gap"})) flex.gap = static_cast<float>(*value);
+    if (auto value = get_number(style, {"row_gap", "rowGap"})) flex.row_gap = static_cast<float>(*value);
+    if (auto value = get_number(style, {"column_gap", "columnGap"})) flex.column_gap = static_cast<float>(*value);
+
+    if (auto value = get_number(style, {"padding"})) flex.padding = static_cast<float>(*value);
+    apply_dimension_to(flex.padding_top, flex.dim_padding_top,
+                       get_dimension(style, {"padding_top", "paddingTop"}));
+    apply_dimension_to(flex.padding_right, flex.dim_padding_right,
+                       get_dimension(style, {"padding_right", "paddingRight"}));
+    apply_dimension_to(flex.padding_bottom, flex.dim_padding_bottom,
+                       get_dimension(style, {"padding_bottom", "paddingBottom"}));
+    apply_dimension_to(flex.padding_left, flex.dim_padding_left,
+                       get_dimension(style, {"padding_left", "paddingLeft"}));
+
+    if (auto value = get_number(style, {"margin"})) flex.margin = static_cast<float>(*value);
+    apply_dimension_to(flex.margin_top, flex.dim_margin_top,
+                       get_dimension(style, {"margin_top", "marginTop"}));
+    apply_dimension_to(flex.margin_right, flex.dim_margin_right,
+                       get_dimension(style, {"margin_right", "marginRight"}));
+    apply_dimension_to(flex.margin_bottom, flex.dim_margin_bottom,
+                       get_dimension(style, {"margin_bottom", "marginBottom"}));
+    apply_dimension_to(flex.margin_left, flex.dim_margin_left,
+                       get_dimension(style, {"margin_left", "marginLeft"}));
+
+    if (auto value = get_number(style, {"flex_grow", "flexGrow"})) flex.flex_grow = static_cast<float>(*value);
+    if (auto value = get_number(style, {"flex_shrink", "flexShrink"})) flex.flex_shrink = static_cast<float>(*value);
+    apply_dimension_to(flex.flex_basis, flex.dim_flex_basis,
+                       get_dimension(style, {"flex_basis", "flexBasis"}));
+
+    apply_dimension_to(flex.preferred_width, flex.dim_width, get_dimension(style, {"width"}));
+    apply_dimension_to(flex.preferred_height, flex.dim_height, get_dimension(style, {"height"}));
+    apply_dimension_to(flex.min_width, flex.dim_min_width, get_dimension(style, {"min_width", "minWidth"}));
+    apply_dimension_to(flex.min_height, flex.dim_min_height, get_dimension(style, {"min_height", "minHeight"}));
+    apply_dimension_to(flex.max_width, flex.dim_max_width, get_dimension(style, {"max_width", "maxWidth"}));
+    apply_dimension_to(flex.max_height, flex.dim_max_height, get_dimension(style, {"max_height", "maxHeight"}));
+
+    if (auto value = get_number(style, {"aspect_ratio", "aspectRatio"}))
+        flex.aspect_ratio = static_cast<float>(*value);
+    if (auto value = get_number(style, {"order"})) flex.order = static_cast<int>(*value);
+
+    if (auto value = get_string(style, {"position"})) {
+        if (*value == "absolute") view.set_position(View::Position::absolute);
+        else if (*value == "fixed") view.set_position(View::Position::fixed);
+        else if (*value == "static") view.set_position(View::Position::static_);
+        else view.set_position(View::Position::relative);
+    }
+
+    if (auto dim = get_dimension(style, {"top"})) {
+        if (dim->unit == DimensionUnit::percent) view.set_top(dim->value, DimensionUnit::percent);
+        else if (dim->unit == DimensionUnit::px) view.set_top(dim->value);
+    }
+    if (auto dim = get_dimension(style, {"right"})) {
+        if (dim->unit == DimensionUnit::percent) view.set_right(dim->value, DimensionUnit::percent);
+        else if (dim->unit == DimensionUnit::px) view.set_right(dim->value);
+    }
+    if (auto dim = get_dimension(style, {"bottom"})) {
+        if (dim->unit == DimensionUnit::percent) view.set_bottom(dim->value, DimensionUnit::percent);
+        else if (dim->unit == DimensionUnit::px) view.set_bottom(dim->value);
+    }
+    if (auto dim = get_dimension(style, {"left"})) {
+        if (dim->unit == DimensionUnit::percent) view.set_left(dim->value, DimensionUnit::percent);
+        else if (dim->unit == DimensionUnit::px) view.set_left(dim->value);
+    }
+
+    if (auto value = get_number(style, {"z_index", "zIndex"})) view.set_z_index(static_cast<int>(*value));
+    if (auto value = get_string(style, {"overflow"}))
+        view.set_overflow(*value == "hidden" ? View::Overflow::hidden : View::Overflow::visible);
+    if (auto value = get_bool(style, {"visible"})) view.set_visible(*value);
+    if (auto value = get_bool(style, {"hit_testable", "hitTestable"})) view.set_hit_testable(*value);
+
+    if (auto value = get_number(style, {"border_width", "borderWidth"}))
+        view.set_border_width(static_cast<float>(*value));
+    if (auto value = get_number(style, {"border_top_width", "borderTopWidth"}))
+        view.set_border_top_width(static_cast<float>(*value));
+    if (auto value = get_number(style, {"border_right_width", "borderRightWidth"}))
+        view.set_border_right_width(static_cast<float>(*value));
+    if (auto value = get_number(style, {"border_bottom_width", "borderBottomWidth"}))
+        view.set_border_bottom_width(static_cast<float>(*value));
+    if (auto value = get_number(style, {"border_left_width", "borderLeftWidth"}))
+        view.set_border_left_width(static_cast<float>(*value));
+}
+
+std::unique_ptr<View> build_view(const choc::value::ValueView& spec, BuildContext& ctx) {
+    auto view = std::make_unique<View>();
+    auto id = get_string(spec, {"id"}).value_or("node-" + std::to_string(ctx.next_id++));
+    auto type = get_string(spec, {"type"}).value_or("View");
+    view->set_id(id);
+    ctx.types[view.get()] = type;
+
+    if (auto style = get_any(spec, {"style"})) apply_style(*view, *style);
+
+    if (auto children = get_any(spec, {"children"}); children && children->isArray()) {
+        for (uint32_t i = 0; i < children->size(); ++i)
+            view->add_child(build_view((*children)[i], ctx));
+    }
+
+    return view;
+}
+
+FixtureTree build_tree(const choc::value::ValueView& fixture) {
+    if (!fixture.isObject()) throw std::runtime_error("fixture root must be a JSON object");
+    auto tree = get_any(fixture, {"tree"});
+    if (!tree || !tree->isObject()) throw std::runtime_error("fixture missing object field: tree");
+
+    BuildContext ctx;
+    FixtureTree out;
+    out.root = build_view(*tree, ctx);
+    out.types = std::move(ctx.types);
+    return out;
+}
+
+float rounded(float value) {
+    return std::round(value * 1000.0f) / 1000.0f;
+}
+
+Rect intersect_rect(Rect a, Rect b) {
+    const float x1 = std::max(a.x, b.x);
+    const float y1 = std::max(a.y, b.y);
+    const float x2 = std::min(a.x + a.width, b.x + b.width);
+    const float y2 = std::min(a.y + a.height, b.y + b.height);
+    return {x1, y1, std::max(0.0f, x2 - x1), std::max(0.0f, y2 - y1)};
+}
+
+choc::value::Value rect_json(Rect rect) {
+    auto out = choc::value::createObject("");
+    out.addMember("x", choc::value::createFloat64(rounded(rect.x)));
+    out.addMember("y", choc::value::createFloat64(rounded(rect.y)));
+    out.addMember("w", choc::value::createFloat64(rounded(rect.width)));
+    out.addMember("h", choc::value::createFloat64(rounded(rect.height)));
+    return out;
+}
+
+void append_node_snapshot(const View& view,
+                          Rect parent_abs,
+                          Rect inherited_clip,
+                          const std::unordered_map<const View*, std::string>& types,
+                          choc::value::Value& nodes,
+                          int& paint_order) {
+    const auto b = view.bounds();
+    const Rect abs{parent_abs.x + b.x, parent_abs.y + b.y, b.width, b.height};
+    const Rect clip = view.overflow() == View::Overflow::hidden
+        ? intersect_rect(inherited_clip, abs)
+        : inherited_clip;
+
+    auto node = choc::value::createObject("");
+    node.addMember("id", choc::value::createString(view.id()));
+    auto type_it = types.find(&view);
+    node.addMember("type", choc::value::createString(type_it == types.end() ? "View" : type_it->second));
+    node.addMember("rect", rect_json(abs));
+
+    auto z = choc::value::createObject("");
+    z.addMember("paint", choc::value::createInt32(paint_order++));
+    z.addMember("z_index", choc::value::createInt32(view.z_index()));
+    node.addMember("z_order", z);
+
+    auto clipping = choc::value::createObject("");
+    clipping.addMember("rect", rect_json(clip));
+    node.addMember("clipping", clipping);
+
+    node.addMember("measured_text_boxes", choc::value::createEmptyArray());
+
+    auto hit_regions = choc::value::createEmptyArray();
+    if (view.visible() && view.hit_testable() && !abs.is_empty()) {
+        auto hit = choc::value::createObject("");
+        hit.addMember("rect", rect_json(abs));
+        hit_regions.addArrayElement(hit);
+    }
+    node.addMember("hit_regions", hit_regions);
+    nodes.addArrayElement(node);
+
+    for (auto* child : view.sorted_children_by_z_index())
+        append_node_snapshot(*child, abs, clip, types, nodes, paint_order);
+}
+
+choc::value::Value render_snapshot(const choc::value::ValueView& fixture) {
+    auto built = build_tree(fixture);
+    auto viewport = get_any(fixture, {"viewport"});
+    const float width = viewport && viewport->isObject()
+        ? static_cast<float>(get_number(*viewport, {"w", "width"}).value_or(0.0))
+        : 0.0f;
+    const float height = viewport && viewport->isObject()
+        ? static_cast<float>(get_number(*viewport, {"h", "height"}).value_or(0.0))
+        : 0.0f;
+    if (width <= 0.0f || height <= 0.0f)
+        throw std::runtime_error("fixture viewport must include positive w/h");
+
+    built.root->set_bounds({0.0f, 0.0f, width, height});
+    built.root->layout_children();
+
+    auto out = choc::value::createObject("");
+    const auto fixture_id = get_string(fixture, {"id"}).value_or("unknown");
+    const auto surface = get_string(fixture, {"surface"}).value_or("yoga");
+    out.addMember("schema_version", choc::value::createString("visual-layout-snapshot-v1"));
+    out.addMember("surface", choc::value::createString(surface));
+    out.addMember("fixture", choc::value::createString(fixture_id));
+    if (auto slash = fixture_id.find('/'); slash != std::string::npos)
+        out.addMember("entry", choc::value::createString(fixture_id.substr(slash + 1)));
+    else
+        out.addMember("entry", choc::value::createString(fixture_id));
+
+    auto viewport_out = choc::value::createObject("");
+    viewport_out.addMember("w", choc::value::createFloat64(width));
+    viewport_out.addMember("h", choc::value::createFloat64(height));
+    out.addMember("viewport", viewport_out);
+
+    auto nodes = choc::value::createEmptyArray();
+    int paint_order = 0;
+    append_node_snapshot(*built.root, {0, 0, 0, 0}, {0, 0, width, height},
+                         built.types, nodes, paint_order);
+    out.addMember("nodes", nodes);
+    return out;
+}
+
+std::string render_fixture_file(const fs::path& path) {
+    auto fixture = choc::json::parse(read_file(path));
+    return choc::json::toString(render_snapshot(fixture), true);
+}
+
+std::optional<choc::value::ValueView> find_node(const choc::value::ValueView& snapshot,
+                                                std::string_view id) {
+    if (!snapshot.isObject() || !snapshot.hasObjectMember("nodes") ||
+        !snapshot["nodes"].isArray()) {
+        return std::nullopt;
+    }
+
+    auto nodes = snapshot["nodes"];
+    for (uint32_t i = 0; i < nodes.size(); ++i) {
+        auto node = nodes[i];
+        if (node.isObject() && get_string(node, {"id"}).value_or("") == id) {
+            return node;
+        }
+    }
+    return std::nullopt;
+}
+
+int run_fixture_mode(const fs::path& fixture_path, const std::optional<fs::path>& out_path) {
+    try {
+        const auto rendered = render_fixture_file(fixture_path);
+        if (out_path) {
+            std::ofstream out(*out_path, std::ios::binary);
+            if (!out) {
+                std::cerr << "pulp-test-visual: could not write " << out_path->string() << "\n";
+                return 2;
+            }
+            out << rendered << "\n";
+        } else {
+            std::cout << rendered << "\n";
+        }
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "pulp-test-visual: " << e.what() << "\n";
+        return 1;
+    }
+}
+
+void print_usage(const char* argv0) {
+    std::cerr << "usage: " << argv0 << " --fixture <path> [--out <path>]\n"
+              << "       " << argv0 << " --self-test [catch2 args...]\n";
+}
+
+}  // namespace
+
+TEST_CASE("visual fixture renderer emits deterministic Yoga layout JSON",
+          "[visual][layout][yoga]") {
+    const auto fixture = choc::json::parse(R"JSON({
+      "id": "yoga/self-test",
+      "surface": "yoga",
+      "viewport": { "w": 120, "h": 60 },
+      "tree": {
+        "id": "root",
+        "style": { "direction": "row" },
+        "children": [
+          { "id": "left", "style": { "width": 40, "height": 20 } },
+          { "id": "right", "style": { "flex_grow": 1, "height": 20 } }
+        ]
+      }
+    })JSON");
+
+    const auto snapshot = render_snapshot(fixture);
+    const auto rendered = choc::json::toString(snapshot, true);
+    const auto left = find_node(snapshot, "left");
+    const auto right = find_node(snapshot, "right");
+
+    REQUIRE(rendered.find("\"fixture\": \"yoga/self-test\"") != std::string::npos);
+    REQUIRE(left);
+    REQUIRE(right);
+    REQUIRE(get_number((*left)["rect"], {"w"}).value_or(-1.0) == Catch::Approx(40.0));
+    REQUIRE(get_number((*right)["rect"], {"w"}).value_or(-1.0) == Catch::Approx(80.0));
+    REQUIRE(rendered.find("\"measured_text_boxes\": []") != std::string::npos);
+    REQUIRE(rendered.find("\"hit_regions\"") != std::string::npos);
+}
+
+TEST_CASE("visual fixture renderer preserves z-index paint ordering",
+          "[visual][layout][z-order]") {
+    const auto fixture = choc::json::parse(R"JSON({
+      "id": "yoga/z-order-self-test",
+      "surface": "yoga",
+      "viewport": { "w": 80, "h": 80 },
+      "tree": {
+        "id": "root",
+        "children": [
+          { "id": "back", "style": { "z_index": 0, "width": 10, "height": 10 } },
+          { "id": "front", "style": { "z_index": 10, "width": 10, "height": 10 } }
+        ]
+      }
+    })JSON");
+
+    const auto rendered = choc::json::toString(render_snapshot(fixture), true);
+    REQUIRE(rendered.find("\"id\": \"back\"") < rendered.find("\"id\": \"front\""));
+    REQUIRE(rendered.find("\"z_index\": 10") != std::string::npos);
+}
+
+int main(int argc, char* argv[]) {
+    std::optional<fs::path> fixture_path;
+    std::optional<fs::path> out_path;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--self-test") {
+            std::vector<char*> catch_argv;
+            catch_argv.push_back(argv[0]);
+            for (int j = i + 1; j < argc; ++j) catch_argv.push_back(argv[j]);
+            return Catch::Session().run(static_cast<int>(catch_argv.size()), catch_argv.data());
+        }
+        if (arg == "--fixture" && i + 1 < argc) {
+            fixture_path = fs::path(argv[++i]);
+            continue;
+        }
+        if (arg == "--out" && i + 1 < argc) {
+            out_path = fs::path(argv[++i]);
+            continue;
+        }
+        if (arg == "--help" || arg == "-h") {
+            print_usage(argv[0]);
+            return 0;
+        }
+        std::cerr << "pulp-test-visual: unknown argument " << arg << "\n";
+        print_usage(argv[0]);
+        return 2;
+    }
+
+    if (!fixture_path) {
+        print_usage(argv[0]);
+        return 2;
+    }
+
+    return run_fixture_mode(*fixture_path, out_path);
+}

--- a/tools/harness/verifier.py
+++ b/tools/harness/verifier.py
@@ -43,6 +43,7 @@ if str(REPO_ROOT_GUESS) not in sys.path:
 from tools.harness.adapters import base as adapters_base  # noqa: E402
 from tools.harness.adapters.base import CatalogEntry, Result  # noqa: E402
 from tools.harness.status import STATUS_ORDER, Status, StatusCounts  # noqa: E402
+from tools.harness.visual import runner as visual_runner  # noqa: E402
 
 logger = logging.getLogger("pulp.harness.verifier")
 
@@ -180,7 +181,12 @@ def get_short_sha(repo_root: Path) -> str:
         return "unknown"
 
 
-def render_markdown(results_by_surface: dict[str, list[Result]], sha: str) -> str:
+def render_markdown(
+    results_by_surface: dict[str, list[Result]],
+    sha: str,
+    visual_counts: Optional[dict[str, dict]] = None,
+) -> str:
+    visual_counts = visual_counts or {}
     lines: list[str] = []
     lines.append("# Harness coverage")
     lines.append("")
@@ -199,13 +205,14 @@ def render_markdown(results_by_surface: dict[str, list[Result]], sha: str) -> st
     )
     lines.append("## Summary")
     lines.append("")
-    lines.append("| Surface | Total | PASS | DIVERGE | NO-OP | NOT-IMPL | OOS | PASS % | Progress % | Drift |")
-    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    lines.append("| Surface | Total | PASS | DIVERGE | NO-OP | NOT-IMPL | OOS | PASS % | Progress % | Drift | Visual pass |")
+    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
     for surface, results in results_by_surface.items():
         counts = StatusCounts.from_results([r.status for r in results])
         drifts = sum(1 for r in results if r.drifts)
+        visual = visual_counts.get(surface, {"label": "0/0"})
         lines.append(
-            "| `{}/` | {} | {} | {} | {} | {} | {} | {:.1f}% | {:.1f}% | {} |".format(
+            "| `{}/` | {} | {} | {} | {} | {} | {} | {:.1f}% | {:.1f}% | {} | {} |".format(
                 surface,
                 counts.total,
                 counts.pass_,
@@ -216,6 +223,7 @@ def render_markdown(results_by_surface: dict[str, list[Result]], sha: str) -> st
                 counts.pass_pct,
                 counts.progress_pct,
                 drifts,
+                visual["label"],
             )
         )
     if len(results_by_surface) > 1:
@@ -225,8 +233,10 @@ def render_markdown(results_by_surface: dict[str, list[Result]], sha: str) -> st
             for r in results
             if r.drifts
         )
+        visual_pass = sum(int(v.get("pass", 0)) for v in visual_counts.values())
+        visual_total = sum(int(v.get("total", 0)) for v in visual_counts.values())
         lines.append(
-            "| **TOTAL** | {} | {} | {} | {} | {} | {} | {:.1f}% | {:.1f}% | {} |".format(
+            "| **TOTAL** | {} | {} | {} | {} | {} | {} | {:.1f}% | {:.1f}% | {} | {}/{} |".format(
                 total_counts.total,
                 total_counts.pass_,
                 total_counts.diverge,
@@ -236,6 +246,8 @@ def render_markdown(results_by_surface: dict[str, list[Result]], sha: str) -> st
                 total_counts.pass_pct,
                 total_counts.progress_pct,
                 all_drifts,
+                visual_pass,
+                visual_total,
             )
         )
     lines.append("")
@@ -283,7 +295,12 @@ def render_markdown(results_by_surface: dict[str, list[Result]], sha: str) -> st
     return "\n".join(lines)
 
 
-def render_json(results_by_surface: dict[str, list[Result]], sha: str) -> dict:
+def render_json(
+    results_by_surface: dict[str, list[Result]],
+    sha: str,
+    visual_counts: Optional[dict[str, dict]] = None,
+) -> dict:
+    visual_counts = visual_counts or {}
     out_surfaces = {}
     for surface, results in results_by_surface.items():
         counts = StatusCounts.from_results([r.status for r in results])
@@ -297,11 +314,14 @@ def render_json(results_by_surface: dict[str, list[Result]], sha: str) -> dict:
             "pass_pct": round(counts.pass_pct, 2),
             "progress_pct": round(counts.progress_pct, 2),
             "drift_count": sum(1 for r in results if r.drifts),
+            "visual_pass": visual_counts.get(surface, {"pass": 0, "total": 0, "label": "0/0"}),
             "results": [r.to_dict() for r in results],
         }
     total_counts = StatusCounts.from_results(
         [r.status for results in results_by_surface.values() for r in results]
     )
+    visual_pass = sum(int(v.get("pass", 0)) for v in visual_counts.values())
+    visual_total = sum(int(v.get("total", 0)) for v in visual_counts.values())
     return {
         "schema_version": "0.1",
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -321,6 +341,11 @@ def render_json(results_by_surface: dict[str, list[Result]], sha: str) -> dict:
                 for r in results
                 if r.drifts
             ),
+            "visual_pass": {
+                "pass": visual_pass,
+                "total": visual_total,
+                "label": f"{visual_pass}/{visual_total}" if visual_total else f"{visual_pass}/0",
+            },
         },
         "surfaces": out_surfaces,
     }
@@ -343,8 +368,9 @@ def write_outputs(
     json_path = build_dir / f"harness-coverage-{sha}.json"
     md_path = build_dir / "harness-coverage.md"
 
-    json_payload = render_json(results_by_surface, sha)
-    md_payload = render_markdown(results_by_surface, sha)
+    visual_counts = visual_runner.visual_pass_counts(repo_root, results_by_surface.keys())
+    json_payload = render_json(results_by_surface, sha, visual_counts)
+    md_payload = render_markdown(results_by_surface, sha, visual_counts)
 
     json_path.write_text(json.dumps(json_payload, indent=2))
     md_path.write_text(md_payload)
@@ -405,6 +431,8 @@ def main(argv: Optional[list[str]] = None) -> int:
     # Trim a leading "coverage" subcommand if invoked via `pulp harness coverage`.
     if argv is None:
         argv = sys.argv[1:]
+    if argv and argv[0] == "visual":
+        return visual_runner.main(argv)
     if argv and argv[0] == "coverage":
         argv = argv[1:]
 
@@ -440,9 +468,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         results_by_surface[s] = run_surface(repo_root, s)
 
     sha = get_short_sha(repo_root)
+    visual_counts = visual_runner.visual_pass_counts(repo_root, results_by_surface.keys())
 
     if args.json:
-        print(json.dumps(render_json(results_by_surface, sha), indent=2))
+        print(json.dumps(render_json(results_by_surface, sha, visual_counts), indent=2))
         return 0
 
     written = write_outputs(
@@ -459,13 +488,15 @@ def main(argv: Optional[list[str]] = None) -> int:
     print(f"# pulp harness coverage @ {sha}")
     print(f"")
     print(f"{'surface':<10} {'total':>6} {'PASS':>6} {'DIVERGE':>8} {'NO-OP':>6} "
-          f"{'NOT-IMPL':>9} {'OOS':>5} {'PASS%':>7} {'drift':>6}")
+          f"{'NOT-IMPL':>9} {'OOS':>5} {'PASS%':>7} {'drift':>6} {'visual':>8}")
     for surface, results in results_by_surface.items():
         c = StatusCounts.from_results([r.status for r in results])
         drifts = sum(1 for r in results if r.drifts)
+        visual = visual_counts.get(surface, {"label": "0/0"})
         print(
             f"{surface:<10} {c.total:>6} {c.pass_:>6} {c.diverge:>8} "
-            f"{c.no_op:>6} {c.not_impl:>9} {c.oos:>5} {c.pass_pct:>6.1f}% {drifts:>6}"
+            f"{c.no_op:>6} {c.not_impl:>9} {c.oos:>5} {c.pass_pct:>6.1f}% "
+            f"{drifts:>6} {visual['label']:>8}"
         )
     if len(results_by_surface) > 1:
         c = total_counts
@@ -475,9 +506,12 @@ def main(argv: Optional[list[str]] = None) -> int:
             for r in results
             if r.drifts
         )
+        visual_pass = sum(int(v.get("pass", 0)) for v in visual_counts.values())
+        visual_total = sum(int(v.get("total", 0)) for v in visual_counts.values())
         print(
             f"{'TOTAL':<10} {c.total:>6} {c.pass_:>6} {c.diverge:>8} "
-            f"{c.no_op:>6} {c.not_impl:>9} {c.oos:>5} {c.pass_pct:>6.1f}% {all_drifts:>6}"
+            f"{c.no_op:>6} {c.not_impl:>9} {c.oos:>5} {c.pass_pct:>6.1f}% "
+            f"{all_drifts:>6} {f'{visual_pass}/{visual_total}':>8}"
         )
     print()
     for label, path in written.items():

--- a/tools/harness/visual/README.md
+++ b/tools/harness/visual/README.md
@@ -59,6 +59,23 @@ python3 -m pytest tools/harness/visual/tests/
 If `skia-python==144.0.post2` is not installed, the SkPicture render smoke
 skips with an explicit reason. The pin and font integrity tests still run.
 
+Build the semantic Yoga snapshot binary and verify checked-in B.1 goldens:
+
+```bash
+cmake --build build --target pulp-test-visual
+pulp harness visual --verify --all
+```
+
+Regenerate one golden after an intentional layout contract change:
+
+```bash
+pulp harness visual --generate --surface=yoga --entry=yoga/box-sizing
+```
+
+`pulp harness coverage --surface=yoga --json` includes a `visual_pass` count
+for the checked-in semantic goldens, so coverage reports show both catalog
+oracle progress and visual regression coverage for the same surface.
+
 To run the smoke in the stable Linux container once Docker is available:
 
 ```bash

--- a/tools/harness/visual/differ.py
+++ b/tools/harness/visual/differ.py
@@ -1,0 +1,107 @@
+"""Semantic JSON differ for visual layout snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Difference:
+    path: str
+    expected: Any
+    actual: Any
+    message: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}: {self.message}; "
+            f"expected={self.expected!r} actual={self.actual!r}"
+        )
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def tolerance_from_fixture(fixture: dict[str, Any] | None, default: float = 0.001) -> float:
+    if not fixture:
+        return default
+    tolerance = fixture.get("tolerance")
+    if not isinstance(tolerance, dict):
+        return default
+    value = tolerance.get("semantic", tolerance.get("rect", tolerance.get("number", default)))
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def compare(expected: Any, actual: Any, *, tolerance: float = 0.001) -> list[Difference]:
+    differences: list[Difference] = []
+    _compare_value(expected, actual, "$", tolerance, differences)
+    return differences
+
+
+def diff_files(expected_path: Path, actual_path: Path, *, tolerance: float = 0.001) -> list[Difference]:
+    return compare(load_json(expected_path), load_json(actual_path), tolerance=tolerance)
+
+
+def format_differences(differences: list[Difference], *, limit: int = 20) -> str:
+    if not differences:
+        return ""
+    shown = differences[:limit]
+    lines = [d.format() for d in shown]
+    if len(differences) > limit:
+        lines.append(f"... {len(differences) - limit} more difference(s)")
+    return "\n".join(lines)
+
+
+def _compare_value(
+    expected: Any,
+    actual: Any,
+    path: str,
+    tolerance: float,
+    differences: list[Difference],
+) -> None:
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        if expected is not actual:
+            differences.append(Difference(path, expected, actual, "boolean mismatch"))
+        return
+
+    if _is_number(expected) and _is_number(actual):
+        delta = abs(float(expected) - float(actual))
+        if delta > tolerance:
+            differences.append(
+                Difference(path, expected, actual, f"numeric delta {delta:.6g} > {tolerance:g}")
+            )
+        return
+
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        expected_keys = set(expected)
+        actual_keys = set(actual)
+        for key in sorted(expected_keys - actual_keys):
+            differences.append(Difference(f"{path}.{key}", expected[key], None, "missing key"))
+        for key in sorted(actual_keys - expected_keys):
+            differences.append(Difference(f"{path}.{key}", None, actual[key], "unexpected key"))
+        for key in sorted(expected_keys & actual_keys):
+            _compare_value(expected[key], actual[key], f"{path}.{key}", tolerance, differences)
+        return
+
+    if isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            differences.append(
+                Difference(path, len(expected), len(actual), "array length mismatch")
+            )
+        for i, (exp, act) in enumerate(zip(expected, actual)):
+            _compare_value(exp, act, f"{path}[{i}]", tolerance, differences)
+        return
+
+    if expected != actual:
+        differences.append(Difference(path, expected, actual, "value mismatch"))
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)

--- a/tools/harness/visual/fixtures/yoga/aspect-ratio.json
+++ b/tools/harness/visual/fixtures/yoga/aspect-ratio.json
@@ -1,0 +1,25 @@
+{
+  "id": "yoga/aspect-ratio",
+  "surface": "yoga",
+  "kind": "layout",
+  "viewport": { "w": 220, "h": 160 },
+  "tolerance": { "rect": 0.001 },
+  "tree": {
+    "id": "root",
+    "type": "View",
+    "style": {
+      "direction": "column",
+      "align_items": "start"
+    },
+    "children": [
+      {
+        "id": "ratio-box",
+        "type": "View",
+        "style": {
+          "width": 120,
+          "aspect_ratio": 1.5
+        }
+      }
+    ]
+  }
+}

--- a/tools/harness/visual/fixtures/yoga/box-sizing.json
+++ b/tools/harness/visual/fixtures/yoga/box-sizing.json
@@ -1,0 +1,25 @@
+{
+  "id": "yoga/box-sizing",
+  "surface": "yoga",
+  "kind": "layout",
+  "viewport": { "w": 200, "h": 120 },
+  "tolerance": { "rect": 0.001 },
+  "tree": {
+    "id": "root",
+    "type": "View",
+    "style": {
+      "direction": "column",
+      "padding": 10,
+      "border_width": 4
+    },
+    "children": [
+      {
+        "id": "content",
+        "type": "View",
+        "style": {
+          "flex_grow": 1
+        }
+      }
+    ]
+  }
+}

--- a/tools/harness/visual/fixtures/yoga/flex-grow-shrink.json
+++ b/tools/harness/visual/fixtures/yoga/flex-grow-shrink.json
@@ -1,0 +1,41 @@
+{
+  "id": "yoga/flex-grow-shrink",
+  "surface": "yoga",
+  "kind": "layout",
+  "viewport": { "w": 260, "h": 64 },
+  "tolerance": { "rect": 0.001 },
+  "tree": {
+    "id": "root",
+    "type": "View",
+    "style": {
+      "direction": "row",
+      "align_items": "stretch"
+    },
+    "children": [
+      {
+        "id": "fixed",
+        "type": "View",
+        "style": {
+          "width": 80,
+          "flex_shrink": 0
+        }
+      },
+      {
+        "id": "growing",
+        "type": "View",
+        "style": {
+          "flex_grow": 1,
+          "flex_basis": 40
+        }
+      },
+      {
+        "id": "shrinking",
+        "type": "View",
+        "style": {
+          "width": 180,
+          "flex_shrink": 1
+        }
+      }
+    ]
+  }
+}

--- a/tools/harness/visual/fixtures/yoga/percentage-sizing.json
+++ b/tools/harness/visual/fixtures/yoga/percentage-sizing.json
@@ -1,0 +1,25 @@
+{
+  "id": "yoga/percentage-sizing",
+  "surface": "yoga",
+  "kind": "layout",
+  "viewport": { "w": 300, "h": 200 },
+  "tolerance": { "rect": 0.001 },
+  "tree": {
+    "id": "root",
+    "type": "View",
+    "style": {
+      "direction": "row",
+      "align_items": "start"
+    },
+    "children": [
+      {
+        "id": "percent-child",
+        "type": "View",
+        "style": {
+          "width": "50%",
+          "height": "25%"
+        }
+      }
+    ]
+  }
+}

--- a/tools/harness/visual/fixtures/yoga/position-absolute.json
+++ b/tools/harness/visual/fixtures/yoga/position-absolute.json
@@ -1,0 +1,37 @@
+{
+  "id": "yoga/position-absolute",
+  "surface": "yoga",
+  "kind": "layout",
+  "viewport": { "w": 200, "h": 160 },
+  "tolerance": { "rect": 0.001 },
+  "tree": {
+    "id": "root",
+    "type": "View",
+    "style": {
+      "direction": "column",
+      "overflow": "hidden"
+    },
+    "children": [
+      {
+        "id": "flow-child",
+        "type": "View",
+        "style": {
+          "width": 80,
+          "height": 40
+        }
+      },
+      {
+        "id": "absolute-child",
+        "type": "View",
+        "style": {
+          "position": "absolute",
+          "left": 30,
+          "top": 20,
+          "width": 70,
+          "height": 50,
+          "z_index": 5
+        }
+      }
+    ]
+  }
+}

--- a/tools/harness/visual/goldens/yoga/aspect-ratio.json
+++ b/tools/harness/visual/goldens/yoga/aspect-ratio.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "visual-layout-snapshot-v1",
+  "surface": "yoga",
+  "fixture": "yoga/aspect-ratio",
+  "entry": "aspect-ratio",
+  "viewport": {
+    "w": 220,
+    "h": 160
+  },
+  "nodes": [
+    {
+      "id": "root",
+      "type": "View",
+      "rect": {
+        "x": 0.0,
+        "y": 0.0,
+        "w": 220,
+        "h": 160
+      },
+      "z_order": {
+        "paint": 0,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 220,
+          "h": 160
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 0.0,
+            "y": 0.0,
+            "w": 220,
+            "h": 160
+          }
+        }
+      ]
+    },
+    {
+      "id": "ratio-box",
+      "type": "View",
+      "rect": {
+        "x": 0.0,
+        "y": 0.0,
+        "w": 120,
+        "h": 80
+      },
+      "z_order": {
+        "paint": 1,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 220,
+          "h": 160
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 0.0,
+            "y": 0.0,
+            "w": 120,
+            "h": 80
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tools/harness/visual/goldens/yoga/box-sizing.json
+++ b/tools/harness/visual/goldens/yoga/box-sizing.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "visual-layout-snapshot-v1",
+  "surface": "yoga",
+  "fixture": "yoga/box-sizing",
+  "entry": "box-sizing",
+  "viewport": {
+    "w": 200,
+    "h": 120
+  },
+  "nodes": [
+    {
+      "id": "root",
+      "type": "View",
+      "rect": {
+        "x": 0.0,
+        "y": 0.0,
+        "w": 200,
+        "h": 120
+      },
+      "z_order": {
+        "paint": 0,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 200,
+          "h": 120
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 0.0,
+            "y": 0.0,
+            "w": 200,
+            "h": 120
+          }
+        }
+      ]
+    },
+    {
+      "id": "content",
+      "type": "View",
+      "rect": {
+        "x": 14,
+        "y": 14,
+        "w": 172,
+        "h": 92
+      },
+      "z_order": {
+        "paint": 1,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 200,
+          "h": 120
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 14,
+            "y": 14,
+            "w": 172,
+            "h": 92
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tools/harness/visual/goldens/yoga/flex-grow-shrink.json
+++ b/tools/harness/visual/goldens/yoga/flex-grow-shrink.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": "visual-layout-snapshot-v1",
+  "surface": "yoga",
+  "fixture": "yoga/flex-grow-shrink",
+  "entry": "flex-grow-shrink",
+  "viewport": {
+    "w": 260,
+    "h": 64
+  },
+  "nodes": [
+    {
+      "id": "root",
+      "type": "View",
+      "rect": {
+        "x": 0.0,
+        "y": 0.0,
+        "w": 260,
+        "h": 64
+      },
+      "z_order": {
+        "paint": 0,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 260,
+          "h": 64
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 0.0,
+            "y": 0.0,
+            "w": 260,
+            "h": 64
+          }
+        }
+      ]
+    },
+    {
+      "id": "fixed",
+      "type": "View",
+      "rect": {
+        "x": 0.0,
+        "y": 0.0,
+        "w": 80,
+        "h": 64
+      },
+      "z_order": {
+        "paint": 1,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 260,
+          "h": 64
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 0.0,
+            "y": 0.0,
+            "w": 80,
+            "h": 64
+          }
+        }
+      ]
+    },
+    {
+      "id": "growing",
+      "type": "View",
+      "rect": {
+        "x": 80,
+        "y": 0.0,
+        "w": 33,
+        "h": 64
+      },
+      "z_order": {
+        "paint": 2,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 260,
+          "h": 64
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 80,
+            "y": 0.0,
+            "w": 33,
+            "h": 64
+          }
+        }
+      ]
+    },
+    {
+      "id": "shrinking",
+      "type": "View",
+      "rect": {
+        "x": 113,
+        "y": 0.0,
+        "w": 147,
+        "h": 64
+      },
+      "z_order": {
+        "paint": 3,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 260,
+          "h": 64
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 113,
+            "y": 0.0,
+            "w": 147,
+            "h": 64
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tools/harness/visual/goldens/yoga/percentage-sizing.json
+++ b/tools/harness/visual/goldens/yoga/percentage-sizing.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "visual-layout-snapshot-v1",
+  "surface": "yoga",
+  "fixture": "yoga/percentage-sizing",
+  "entry": "percentage-sizing",
+  "viewport": {
+    "w": 300,
+    "h": 200
+  },
+  "nodes": [
+    {
+      "id": "root",
+      "type": "View",
+      "rect": {
+        "x": 0.0,
+        "y": 0.0,
+        "w": 300,
+        "h": 200
+      },
+      "z_order": {
+        "paint": 0,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 300,
+          "h": 200
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 0.0,
+            "y": 0.0,
+            "w": 300,
+            "h": 200
+          }
+        }
+      ]
+    },
+    {
+      "id": "percent-child",
+      "type": "View",
+      "rect": {
+        "x": 0.0,
+        "y": 0.0,
+        "w": 150,
+        "h": 50
+      },
+      "z_order": {
+        "paint": 1,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 300,
+          "h": 200
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 0.0,
+            "y": 0.0,
+            "w": 150,
+            "h": 50
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tools/harness/visual/goldens/yoga/position-absolute.json
+++ b/tools/harness/visual/goldens/yoga/position-absolute.json
@@ -1,0 +1,111 @@
+{
+  "schema_version": "visual-layout-snapshot-v1",
+  "surface": "yoga",
+  "fixture": "yoga/position-absolute",
+  "entry": "position-absolute",
+  "viewport": {
+    "w": 200,
+    "h": 160
+  },
+  "nodes": [
+    {
+      "id": "root",
+      "type": "View",
+      "rect": {
+        "x": 0.0,
+        "y": 0.0,
+        "w": 200,
+        "h": 160
+      },
+      "z_order": {
+        "paint": 0,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 200,
+          "h": 160
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 0.0,
+            "y": 0.0,
+            "w": 200,
+            "h": 160
+          }
+        }
+      ]
+    },
+    {
+      "id": "flow-child",
+      "type": "View",
+      "rect": {
+        "x": 0.0,
+        "y": 0.0,
+        "w": 80,
+        "h": 40
+      },
+      "z_order": {
+        "paint": 1,
+        "z_index": 0
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 200,
+          "h": 160
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 0.0,
+            "y": 0.0,
+            "w": 80,
+            "h": 40
+          }
+        }
+      ]
+    },
+    {
+      "id": "absolute-child",
+      "type": "View",
+      "rect": {
+        "x": 30,
+        "y": 20,
+        "w": 70,
+        "h": 50
+      },
+      "z_order": {
+        "paint": 2,
+        "z_index": 5
+      },
+      "clipping": {
+        "rect": {
+          "x": 0.0,
+          "y": 0.0,
+          "w": 200,
+          "h": 160
+        }
+      },
+      "measured_text_boxes": [],
+      "hit_regions": [
+        {
+          "rect": {
+            "x": 30,
+            "y": 20,
+            "w": 70,
+            "h": 50
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tools/harness/visual/runner.py
+++ b/tools/harness/visual/runner.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Runner for deterministic visual layout snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT_GUESS = HERE.parent.parent.parent
+if str(REPO_ROOT_GUESS) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT_GUESS))
+
+from tools.harness.visual import differ  # noqa: E402
+
+
+def find_repo_root(start: Path) -> Path:
+    cur = start.resolve()
+    for _ in range(10):
+        if (cur / "compat.json").exists() and (cur / "CMakeLists.txt").exists():
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    return start.resolve()
+
+
+def fixtures_dir(repo_root: Path, surface: str) -> Path:
+    return repo_root / "tools" / "harness" / "visual" / "fixtures" / surface
+
+
+def goldens_dir(repo_root: Path, surface: str) -> Path:
+    return repo_root / "tools" / "harness" / "visual" / "goldens" / surface
+
+
+def list_fixtures(repo_root: Path, surface: str) -> list[Path]:
+    root = fixtures_dir(repo_root, surface)
+    if not root.exists():
+        return []
+    return sorted(root.glob("*.json"))
+
+
+def entry_name(path: Path) -> str:
+    return path.stem
+
+
+def resolve_fixtures(repo_root: Path, surface: str, entries: Iterable[str] | None) -> list[Path]:
+    fixtures = list_fixtures(repo_root, surface)
+    by_name = {entry_name(path): path for path in fixtures}
+    by_surface_name = {f"{surface}/{entry_name(path)}": path for path in fixtures}
+
+    selected = list(entries or [])
+    if not selected:
+        return fixtures
+
+    out: list[Path] = []
+    missing: list[str] = []
+    for item in selected:
+        path = Path(item)
+        if path.exists():
+            out.append(path)
+        elif item in by_name:
+            out.append(by_name[item])
+        elif item in by_surface_name:
+            out.append(by_surface_name[item])
+        else:
+            missing.append(item)
+    if missing:
+        known = ", ".join(sorted(by_surface_name))
+        raise ValueError(f"unknown visual fixture(s): {', '.join(missing)} (known: {known})")
+    return out
+
+
+def golden_path_for(repo_root: Path, surface: str, fixture_path: Path) -> Path:
+    return goldens_dir(repo_root, surface) / f"{entry_name(fixture_path)}.json"
+
+
+def locate_binary(repo_root: Path, build_dir: Path | None, override: Path | None) -> Path:
+    suffix = ".exe" if os.name == "nt" else ""
+    if override:
+        return override
+
+    candidates: list[Path] = []
+    if build_dir:
+        candidates.extend(
+            [
+                build_dir / "test" / f"pulp-test-visual{suffix}",
+                build_dir / "test" / "Debug" / f"pulp-test-visual{suffix}",
+                build_dir / "test" / "Release" / f"pulp-test-visual{suffix}",
+                build_dir / f"pulp-test-visual{suffix}",
+            ]
+        )
+    candidates.extend(
+        [
+            repo_root / "build" / "test" / f"pulp-test-visual{suffix}",
+            repo_root / "build-visual" / "test" / f"pulp-test-visual{suffix}",
+        ]
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    found = shutil.which(f"pulp-test-visual{suffix}")
+    if found:
+        return Path(found)
+    searched = "\n  ".join(str(p) for p in candidates)
+    raise FileNotFoundError(
+        "pulp-test-visual binary not found. Build it first with "
+        "`cmake --build <build-dir> --target pulp-test-visual`.\n"
+        f"Searched:\n  {searched}"
+    )
+
+
+def run_snapshot(binary: Path, fixture_path: Path) -> dict[str, Any]:
+    proc = subprocess.run(
+        [str(binary), "--fixture", str(fixture_path)],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{binary} failed for {fixture_path} with exit {proc.returncode}\n"
+            f"{proc.stderr.strip()}"
+        )
+    return json.loads(proc.stdout)
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def generate(binary: Path, repo_root: Path, surface: str, fixtures: list[Path]) -> int:
+    for fixture in fixtures:
+        payload = run_snapshot(binary, fixture)
+        out = golden_path_for(repo_root, surface, fixture)
+        write_json(out, payload)
+        print(f"generated {out.relative_to(repo_root)}")
+    return 0
+
+
+def verify(binary: Path, repo_root: Path, surface: str, fixtures: list[Path]) -> int:
+    failures: list[str] = []
+    for fixture in fixtures:
+        golden = golden_path_for(repo_root, surface, fixture)
+        if not golden.exists():
+            failures.append(
+                f"{surface}/{entry_name(fixture)}: missing golden {golden.relative_to(repo_root)}"
+            )
+            continue
+
+        actual = run_snapshot(binary, fixture)
+        expected = json.loads(golden.read_text(encoding="utf-8"))
+        tolerance = differ.tolerance_from_fixture(load_fixture(fixture))
+        diffs = differ.compare(expected, actual, tolerance=tolerance)
+        if diffs:
+            failures.append(
+                f"{surface}/{entry_name(fixture)} failed semantic diff:\n"
+                f"{differ.format_differences(diffs)}"
+            )
+        else:
+            print(f"ok {surface}/{entry_name(fixture)}")
+
+    if failures:
+        print("\n\n".join(failures), file=sys.stderr)
+        print(
+            "regenerate with: pulp harness visual --generate --surface "
+            f"{surface} --all",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def visual_pass_counts(repo_root: Path, surfaces: Iterable[str] | None = None) -> dict[str, dict[str, Any]]:
+    compat_path = repo_root / "compat.json"
+    compat = json.loads(compat_path.read_text(encoding="utf-8")) if compat_path.exists() else {}
+    surface_list = list(surfaces or sorted(compat))
+    out: dict[str, dict[str, Any]] = {}
+    for surface in surface_list:
+        golden_count = len(list(goldens_dir(repo_root, surface).glob("*.json")))
+        total = len(compat.get(surface, {}))
+        out[surface] = {
+            "pass": golden_count,
+            "total": total,
+            "label": f"{golden_count}/{total}" if total else f"{golden_count}/0",
+        }
+    return out
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="pulp harness visual",
+        description="Generate or verify deterministic semantic visual snapshots.",
+    )
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--generate", action="store_true", help="Regenerate checked-in goldens.")
+    mode.add_argument("--verify", action="store_true", help="Verify fixtures against checked-in goldens.")
+    p.add_argument("--surface", action="append", default=None, help="Surface to run, default: yoga.")
+    p.add_argument("--entry", action="append", default=None, help="Fixture entry name. May be repeated.")
+    p.add_argument("--all", action="store_true", help="Run all fixtures for the selected surface.")
+    p.add_argument("--binary", type=Path, default=None, help="Path to pulp-test-visual.")
+    p.add_argument("--build-dir", type=Path, default=None, help="CMake build directory.")
+    p.add_argument("--repo-root", type=Path, default=None, help="Override repo root discovery.")
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+    if argv and argv[0] == "visual":
+        argv = argv[1:]
+
+    args = parse_args(argv)
+    repo_root = (args.repo_root or find_repo_root(Path.cwd())).resolve()
+    surfaces = args.surface or ["yoga"]
+    mode_generate = bool(args.generate)
+    mode_verify = bool(args.verify or not args.generate)
+
+    if args.all and args.entry:
+        print("error: pass --all OR --entry, not both", file=sys.stderr)
+        return 2
+
+    try:
+        binary = locate_binary(repo_root, args.build_dir, args.binary)
+        for surface in surfaces:
+            fixtures = resolve_fixtures(repo_root, surface, args.entry)
+            if not fixtures:
+                print(f"error: no visual fixtures found for surface {surface!r}", file=sys.stderr)
+                return 2
+            if mode_generate:
+                rc = generate(binary, repo_root, surface, fixtures)
+            elif mode_verify:
+                rc = verify(binary, repo_root, surface, fixtures)
+            else:
+                rc = 2
+            if rc != 0:
+                return rc
+    except (FileNotFoundError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/harness/visual/tests/test_differ.py
+++ b/tools/harness/visual/tests/test_differ.py
@@ -1,0 +1,48 @@
+"""Tests for the semantic visual snapshot differ."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.harness.visual import differ  # noqa: E402
+
+
+class DifferTests(unittest.TestCase):
+    def test_numeric_tolerance_accepts_small_rect_deltas(self) -> None:
+        expected = {"nodes": [{"rect": {"x": 10.0, "y": 20.0, "w": 30.0, "h": 40.0}}]}
+        actual = {"nodes": [{"rect": {"x": 10.0004, "y": 20.0, "w": 30.0, "h": 40.0}}]}
+
+        self.assertEqual(differ.compare(expected, actual, tolerance=0.001), [])
+
+    def test_numeric_tolerance_reports_large_deltas(self) -> None:
+        expected = {"nodes": [{"rect": {"x": 10.0}}]}
+        actual = {"nodes": [{"rect": {"x": 10.01}}]}
+
+        diffs = differ.compare(expected, actual, tolerance=0.001)
+
+        self.assertEqual(len(diffs), 1)
+        self.assertEqual(diffs[0].path, "$.nodes[0].rect.x")
+
+    def test_missing_key_is_reported(self) -> None:
+        diffs = differ.compare({"a": 1, "b": 2}, {"a": 1})
+
+        self.assertEqual(len(diffs), 1)
+        self.assertEqual(diffs[0].path, "$.b")
+        self.assertEqual(diffs[0].message, "missing key")
+
+    def test_tolerance_from_fixture_prefers_rect_value(self) -> None:
+        self.assertEqual(
+            differ.tolerance_from_fixture({"tolerance": {"rect": 0.25}}),
+            0.25,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/harness/visual/tests/test_runner.py
+++ b/tools/harness/visual/tests/test_runner.py
@@ -1,0 +1,53 @@
+"""Tests for visual snapshot fixture discovery and coverage counts."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.harness.visual import runner  # noqa: E402
+
+
+class RunnerTests(unittest.TestCase):
+    def test_resolve_fixtures_accepts_surface_prefixed_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture_dir = root / "tools" / "harness" / "visual" / "fixtures" / "yoga"
+            fixture_dir.mkdir(parents=True)
+            fixture = fixture_dir / "box-sizing.json"
+            fixture.write_text("{}", encoding="utf-8")
+
+            self.assertEqual(
+                runner.resolve_fixtures(root, "yoga", ["yoga/box-sizing"]),
+                [fixture],
+            )
+
+    def test_visual_pass_counts_uses_compat_total_and_checked_in_goldens(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "compat.json").write_text(
+                json.dumps({"yoga": {"a": {}, "b": {}, "c": {}}}),
+                encoding="utf-8",
+            )
+            golden_dir = root / "tools" / "harness" / "visual" / "goldens" / "yoga"
+            golden_dir.mkdir(parents=True)
+            (golden_dir / "a.json").write_text("{}", encoding="utf-8")
+            (golden_dir / "b.json").write_text("{}", encoding="utf-8")
+
+            counts = runner.visual_pass_counts(root, ["yoga"])
+
+            self.assertEqual(counts["yoga"]["pass"], 2)
+            self.assertEqual(counts["yoga"]["total"], 3)
+            self.assertEqual(counts["yoga"]["label"], "2/3")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add the B.1 semantic visual regression path for Yoga layouts: a custom-main C++ snapshot binary, fixture/golden runner, JSON differ, five initial Yoga goldens, coverage visual_pass reporting, and a macOS layout snapshot workflow.

The in-tree pulp-cpp harness command verifies the snapshots; the installed ~/.pulp/bin/pulp binary was stale locally and not treated as a Rust CLI bug.

Compat-Update: skip prefix=canvas2d reason="visual harness infrastructure only; no canvas2d catalog claim change"
Compat-Update: skip prefix=css reason="visual harness infrastructure only; no css catalog claim change"
Compat-Update: skip prefix=html reason="visual harness infrastructure only; no html catalog claim change"
Compat-Update: skip prefix=imports reason="visual harness infrastructure only; no imports catalog claim change"
Compat-Update: skip prefix=react reason="visual harness infrastructure only; no react catalog claim change"
Compat-Update: skip prefix=rn reason="visual harness infrastructure only; no rn catalog claim change"
Compat-Update: skip prefix=yoga reason="B.1 adds semantic Yoga goldens; no compat catalog claim change"
Skill-Update: skip skill=ci reason="CLAUDE/workflow runner guidance updated; CI skill flow remains current"
Skill-Update: skip skill=cli-maintenance reason="CLI reference/status updated for harness visual; skill body remains current"
Version-Bump: sdk=skip reason="B.1 visual harness infrastructure; no SDK/API release surface change"
Version-Bump: plugin=skip reason="B.1 visual harness infrastructure; no Claude plugin runtime behavior change"
Version-Bump: skip reason="B.1 visual harness infrastructure and tests only"