### PR TITLE
fix(cli): pulp upgrade refresh GitHub synchronously when cache is stale (closes pulp #1599)

### DIFF
--- a/test/test_cli_update_check.cpp
+++ b/test/test_cli_update_check.cpp
@@ -337,6 +337,145 @@ TEST_CASE("refresh_cache carries forward previous on fetch failure",
     REQUIRE(next.last_check_epoch_sec == 2'000);
 }
 
+// ── resolve_latest_with_persist (#1599) ─────────────────────────────────────
+//
+// Regression for the "cache permanently stuck at v0.73.0 despite v0.78.2
+// being live" trap: pulp_cli.cpp's detached background refresh gets reaped
+// at process exit before curl finishes, so the cache never gets updated
+// through that path. The upgrade surfaces have to refresh synchronously
+// AND persist the result themselves.
+
+TEST_CASE("resolve_latest_with_persist returns fresh-cache value without fetching",
+          "[cli][update-check][issue-1599]") {
+    auto dir = make_tmpdir("resolve-fresh");
+    auto path = dir / "update-cache.json";
+
+    uc::CacheEntry seed;
+    seed.last_check_epoch_sec = 1'000;   // 1h ago at "now"=4'600
+    seed.latest_version = "0.78.2";
+    seed.release_notes_url = "https://example/tag/v0.78.2";
+    REQUIRE(uc::write_cache_file(path, seed));
+
+    FakeFetcher fetcher;
+    fetcher.canned.ok = true;
+    fetcher.canned.latest_version = "9.9.9";   // would be returned if called
+
+    auto resolved = uc::resolve_latest_with_persist(
+        fetcher, path, "owner/repo", /*now=*/4'600, /*interval_hours=*/24);
+
+    REQUIRE(resolved.ok);
+    REQUIRE_FALSE(resolved.refreshed);
+    REQUIRE(resolved.latest_version == "0.78.2");
+    REQUIRE(fetcher.call_count == 0);
+}
+
+TEST_CASE("resolve_latest_with_persist refreshes + writes when cache is stale",
+          "[cli][update-check][issue-1599]") {
+    auto dir = make_tmpdir("resolve-stale");
+    auto path = dir / "update-cache.json";
+
+    uc::CacheEntry seed;
+    seed.last_check_epoch_sec = 1'000;
+    seed.latest_version = "0.73.0";   // stuck-stale value
+    seed.release_notes_url = "https://example/tag/v0.73.0";
+    REQUIRE(uc::write_cache_file(path, seed));
+
+    FakeFetcher fetcher;
+    fetcher.canned.ok = true;
+    fetcher.canned.latest_version = "0.78.2";
+    fetcher.canned.release_notes_url = "https://example/tag/v0.78.2";
+
+    // 25h later → stale
+    const std::int64_t now = 1'000 + 25 * 3600;
+    auto resolved = uc::resolve_latest_with_persist(
+        fetcher, path, "owner/repo", now, 24);
+
+    REQUIRE(resolved.ok);
+    REQUIRE(resolved.refreshed);
+    REQUIRE(resolved.latest_version == "0.78.2");
+    REQUIRE(fetcher.call_count == 1);
+
+    // Persisted to disk so the next invocation doesn't re-fetch.
+    auto on_disk = uc::read_cache_file(path);
+    REQUIRE(on_disk.has_value());
+    REQUIRE(on_disk->latest_version == "0.78.2");
+    REQUIRE(on_disk->last_check_epoch_sec == now);
+}
+
+TEST_CASE("resolve_latest_with_persist refreshes when no cache file exists",
+          "[cli][update-check][issue-1599]") {
+    auto dir = make_tmpdir("resolve-empty");
+    auto path = dir / "update-cache.json";   // intentionally not created
+
+    FakeFetcher fetcher;
+    fetcher.canned.ok = true;
+    fetcher.canned.latest_version = "1.2.3";
+    fetcher.canned.release_notes_url = "https://example/tag/v1.2.3";
+
+    auto resolved = uc::resolve_latest_with_persist(
+        fetcher, path, "owner/repo", /*now=*/5'000, /*interval_hours=*/24);
+
+    REQUIRE(resolved.ok);
+    REQUIRE(resolved.refreshed);
+    REQUIRE(resolved.latest_version == "1.2.3");
+
+    auto on_disk = uc::read_cache_file(path);
+    REQUIRE(on_disk.has_value());
+    REQUIRE(on_disk->latest_version == "1.2.3");
+}
+
+TEST_CASE("resolve_latest_with_persist leaves disk untouched on fetch failure",
+          "[cli][update-check][issue-1599]") {
+    auto dir = make_tmpdir("resolve-fail");
+    auto path = dir / "update-cache.json";
+
+    uc::CacheEntry seed;
+    seed.last_check_epoch_sec = 1'000;
+    seed.latest_version = "0.73.0";
+    seed.release_notes_url = "https://example/tag/v0.73.0";
+    REQUIRE(uc::write_cache_file(path, seed));
+
+    FakeFetcher fetcher;
+    fetcher.canned.ok = false;
+    fetcher.canned.error = "curl failed";
+
+    const std::int64_t now = 1'000 + 25 * 3600;
+    auto resolved = uc::resolve_latest_with_persist(
+        fetcher, path, "owner/repo", now, 24);
+
+    REQUIRE_FALSE(resolved.ok);
+    REQUIRE(resolved.refreshed);
+    REQUIRE(resolved.error == "curl failed");
+
+    // Don't clobber a known-good value with a transient failure.
+    auto on_disk = uc::read_cache_file(path);
+    REQUIRE(on_disk.has_value());
+    REQUIRE(on_disk->latest_version == "0.73.0");
+    REQUIRE(on_disk->last_check_epoch_sec == 1'000);
+}
+
+TEST_CASE("resolve_latest_with_persist refreshes when cached version is empty",
+          "[cli][update-check][issue-1599]") {
+    auto dir = make_tmpdir("resolve-empty-version");
+    auto path = dir / "update-cache.json";
+
+    uc::CacheEntry seed;
+    seed.last_check_epoch_sec = 4'500;   // recent timestamp
+    seed.latest_version = "";            // but no version
+    REQUIRE(uc::write_cache_file(path, seed));
+
+    FakeFetcher fetcher;
+    fetcher.canned.ok = true;
+    fetcher.canned.latest_version = "0.80.0";
+
+    auto resolved = uc::resolve_latest_with_persist(
+        fetcher, path, "owner/repo", /*now=*/5'000, /*interval_hours=*/24);
+
+    REQUIRE(resolved.ok);
+    REQUIRE(resolved.refreshed);
+    REQUIRE(resolved.latest_version == "0.80.0");
+}
+
 // ── Banner-suppression bookkeeping ──────────────────────────────────────────
 
 TEST_CASE("banner_shown_for_version gates banner reprint",

--- a/tools/cli/cmd_upgrade.cpp
+++ b/tools/cli/cmd_upgrade.cpp
@@ -109,35 +109,47 @@ int cmd_upgrade(const std::vector<std::string>& args) {
 
     // ── --check-only path (Slice 2 surface) ─────────────────────────────────
     //
-    // Reports what the banner would say without downloading. Reads the
-    // cache written by the on-every-invocation background refresh in
-    // pulp_cli.cpp. If the cache is empty (first run), we fall through
-    // to the legacy check to keep the UX useful.
+    // Reports what the banner would say. Uses uc::resolve_latest_with_persist
+    // so a stale or empty cache triggers a synchronous refresh. The
+    // on-every-invocation detached refresh in pulp_cli.cpp gets killed when
+    // short-lived commands exit before curl completes (#1599), so we
+    // cannot rely on it. The user is explicitly asking about updates here,
+    // so a 1–2s blocking GitHub call is the right tradeoff.
     if (check_only) {
         auto cache_path = update_cache_path();
         std::string installed = PULP_SDK_VERSION;
-        std::optional<uc::CacheEntry> cache;
-        if (!cache_path.empty()) cache = uc::read_cache_file(cache_path);
+        const bool disabled =
+            pulp::runtime::get_env("PULP_UPDATE_CHECK_DISABLED").has_value();
 
         std::string latest;
         std::string url;
-        if (cache && !cache->latest_version.empty()) {
-            latest = cache->latest_version;
-            url = cache->release_notes_url;
-        } else if (pulp::runtime::get_env("PULP_UPDATE_CHECK_DISABLED")) {
-            std::cout << "Installed:  v" << installed << "\n";
-            std::cout << "Latest:     update check disabled; not queried\n";
-            return 0;
+        if (disabled) {
+            // Honor the off-switch even when there's no cache yet — the
+            // contract is "zero network calls".
+            auto cache = !cache_path.empty() ? uc::read_cache_file(cache_path)
+                                             : std::nullopt;
+            if (cache && !cache->latest_version.empty()) {
+                latest = cache->latest_version;
+                url = cache->release_notes_url;
+            } else {
+                std::cout << "Installed:  v" << installed << "\n";
+                std::cout << "Latest:     update check disabled; not queried\n";
+                return 0;
+            }
         } else {
-            std::cout << "Cache empty; querying GitHub Releases...\n";
             uc::GitHubReleasesFetcher fetcher;
-            auto r = fetcher.fetch_latest_release(PULP_GITHUB_REPO);
-            if (!r.ok) {
-                std::cerr << "Error: could not fetch latest version: " << r.error << "\n";
+            auto resolved = uc::resolve_latest_with_persist(
+                fetcher, cache_path, PULP_GITHUB_REPO, uc::now_epoch_sec(), 24);
+            if (resolved.refreshed) {
+                std::cout << "Refreshing from GitHub Releases...\n";
+            }
+            if (!resolved.ok) {
+                std::cerr << "Error: could not fetch latest version: "
+                          << resolved.error << "\n";
                 return 1;
             }
-            latest = r.latest_version;
-            url = r.release_notes_url;
+            latest = resolved.latest_version;
+            url = resolved.release_notes_url;
         }
 
         std::cout << "Installed:  v" << installed << "\n";
@@ -154,25 +166,17 @@ int cmd_upgrade(const std::vector<std::string>& args) {
 
     std::cout << "Checking for updates...\n";
 
-    // Try the cache first so repeated `pulp upgrade` calls within the
-    // 24h window don't re-query GitHub.
+    // Resolve the latest version. resolve_latest_with_persist handles the
+    // empty/stale/fresh cases and writes the cache on a successful fetch
+    // so the next invocation isn't stuck behind the unreliable detached
+    // background refresh (#1599).
     std::string latest;
     if (target_version.empty()) {
-        auto cache_path = update_cache_path();
-        if (!cache_path.empty()) {
-            if (auto cache = uc::read_cache_file(cache_path)) {
-                if (!cache->latest_version.empty() &&
-                    !uc::is_cache_stale(*cache, uc::now_epoch_sec(), 24)) {
-                    latest = cache->latest_version;
-                }
-            }
-        }
-    }
-
-    if (latest.empty() && target_version.empty()) {
         uc::GitHubReleasesFetcher fetcher;
-        auto r = fetcher.fetch_latest_release(PULP_GITHUB_REPO);
-        if (r.ok) latest = r.latest_version;
+        auto resolved = uc::resolve_latest_with_persist(
+            fetcher, update_cache_path(), PULP_GITHUB_REPO,
+            uc::now_epoch_sec(), 24);
+        if (resolved.ok) latest = resolved.latest_version;
     }
 
     if (latest.empty() && target_version.empty()) {

--- a/tools/cli/update_check.cpp
+++ b/tools/cli/update_check.cpp
@@ -481,4 +481,48 @@ CacheEntry refresh_cache(Fetcher& fetcher,
     return next;
 }
 
+ResolvedLatest resolve_latest_with_persist(Fetcher& fetcher,
+                                           const fs::path& cache_path,
+                                           const std::string& owner_repo,
+                                           std::int64_t now_epoch_sec_val,
+                                           int interval_hours) {
+    ResolvedLatest out;
+
+    std::optional<CacheEntry> cache;
+    if (!cache_path.empty()) cache = read_cache_file(cache_path);
+
+    const bool cache_fresh =
+        cache && !cache->latest_version.empty() &&
+        !is_cache_stale(*cache, now_epoch_sec_val, interval_hours);
+
+    if (cache_fresh) {
+        out.ok = true;
+        out.refreshed = false;
+        out.latest_version = cache->latest_version;
+        out.release_notes_url = cache->release_notes_url;
+        return out;
+    }
+
+    auto r = fetcher.fetch_latest_release(owner_repo);
+    out.refreshed = true;
+    if (!r.ok) {
+        out.ok = false;
+        out.error = r.error;
+        return out;
+    }
+    out.ok = true;
+    out.latest_version = r.latest_version;
+    out.release_notes_url = r.release_notes_url;
+
+    if (!cache_path.empty()) {
+        CacheEntry next = cache.value_or(CacheEntry{});
+        next.schema = kCacheSchemaVersion;
+        next.last_check_epoch_sec = now_epoch_sec_val;
+        next.latest_version = out.latest_version;
+        next.release_notes_url = out.release_notes_url;
+        write_cache_file(cache_path, next);
+    }
+    return out;
+}
+
 }  // namespace pulp::cli::update_check

--- a/tools/cli/update_check.hpp
+++ b/tools/cli/update_check.hpp
@@ -196,4 +196,34 @@ CacheEntry refresh_cache(Fetcher& fetcher,
                          const std::string& owner_repo,
                          std::int64_t now_epoch_sec);
 
+// Resolved latest-version answer for `pulp upgrade` and friends.
+//
+// `refreshed` is true when the fetcher was actually called (cache was
+// empty or stale); false when a fresh cache entry served the answer.
+// On fetch failure (`ok=false`), the previous cache is left untouched on
+// disk — clobbering a known-good value with a network blip is worse than
+// a stale read.
+struct ResolvedLatest {
+    bool ok = false;
+    bool refreshed = false;
+    std::string latest_version;
+    std::string release_notes_url;
+    std::string error;
+};
+
+// Read the cache; if missing/empty/stale, query the fetcher and persist
+// the result to `cache_path` (best-effort). Returns the resolved value.
+//
+// This was extracted from cmd_upgrade.cpp's check-only and upgrade paths
+// so they share one source of truth and so the fallback behaviour is
+// directly unit-testable. The on-every-invocation detached refresh in
+// pulp_cli.cpp cannot be relied on for short-lived commands — it gets
+// reaped at process exit before curl returns (#1599) — so the upgrade
+// surfaces refresh synchronously.
+ResolvedLatest resolve_latest_with_persist(Fetcher& fetcher,
+                                           const fs::path& cache_path,
+                                           const std::string& owner_repo,
+                                           std::int64_t now_epoch_sec,
+                                           int interval_hours);
+
 }  // namespace pulp::cli::update_check


### PR DESCRIPTION
## Summary

Closes #1599. Fixes the bug where `pulp upgrade --check-only` (and the upgrade itself) reported v0.73.0 as latest despite v0.78.2 being a published, non-draft release.

## Root cause

`pulp_cli.cpp` kicks the on-every-invocation update-check refresh as a `std::thread(...).detach()`. Short-lived commands exit in <50ms — way before the 1-2s GitHub HTTP round-trip can complete. The OS reaps the detached thread; the cache write never lands.

Verified by `time pulp upgrade --check-only` reporting 11ms total. Even with a 30s shell wait afterward, `~/.pulp/update-cache.json` showed no version update — only the timestamp eventually got bumped (because the detached thread's pre-fetch update fires regardless of fetch outcome).

## Fix

The upgrade surfaces refresh **synchronously** and persist the result themselves. Extracted `resolve_latest_with_persist()` in `update_check.{hpp,cpp}` so:

- `cmd_upgrade --check-only` and the bare `pulp upgrade` path share one source of truth.
- The empty/stale/fresh/fail matrix is directly unit-testable.
- A successful sync fetch writes `~/.pulp/update-cache.json` so the next invocation starts fresh — even if the on-every-invocation detached refresh keeps getting reaped on other commands.
- A fetch failure leaves the on-disk cache untouched (don't clobber a known-good value with a transient network blip).

The behavior of `pulp_cli.cpp`'s detached refresh is intentionally not changed — for fast commands like `pulp build`, "occasionally stale" is the right tradeoff over "always block on curl."

## Test plan

- [x] 5 new Catch2 cases in `test_cli_update_check.cpp` (`[issue-1599]` tag) — all pass:
  - fresh cache returns cached value without calling fetcher
  - stale cache → fetch + write to disk + return new value
  - missing cache file → fetch + write to disk + return new value
  - fetch failure → don't clobber on-disk version, return error
  - empty `latest_version` field → treat as stale, refetch
- [ ] CI macOS / Linux / Windows builds clean
- [ ] Manually verify `pulp upgrade --check-only` reports v0.78.2 once the binary is on a network-up host (curl times out from this terminal right now, blocking local end-to-end run)

## Related

- Investigation history: filed as #1599