### PR TITLE
fix(test): use pid+chrono+counter for temp WAV paths to avoid ctest -j parallel collisions (pulp #1257)

### DIFF
--- a/test/test_test_signal.cpp
+++ b/test/test_test_signal.cpp
@@ -2,11 +2,21 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/audio/audio_file.hpp>
 #include <pulp/format/test_signal.hpp>
+#include <atomic>
+#include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <string>
 #include <string_view>
 #include <vector>
+
+#ifdef _WIN32
+#  include <process.h>
+#  define pulp_getpid() _getpid()
+#else
+#  include <unistd.h>
+#  define pulp_getpid() ::getpid()
+#endif
 
 using namespace pulp::format;
 using Catch::Matchers::WithinAbs;
@@ -14,9 +24,16 @@ using Catch::Matchers::WithinAbs;
 namespace {
 
 std::filesystem::path unique_temp_wav_path(std::string_view suffix) {
-    static int counter = 0;
+    // Combine pid + steady-clock nanoseconds + per-process counter so parallel
+    // ctest invocations (`ctest -j4` in CI) don't collide on /tmp/pulp-test-signal-*.wav.
+    // See pulp #1257 review comment r3175949820.
+    static std::atomic<unsigned long long> counter{0};
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto pid = static_cast<long long>(pulp_getpid());
+    const auto seq = counter.fetch_add(1, std::memory_order_relaxed);
     return std::filesystem::temp_directory_path() /
-           ("pulp-test-signal-" + std::to_string(++counter) + std::string(suffix));
+           ("pulp-test-signal-" + std::to_string(pid) + "-" +
+            std::to_string(now) + "-" + std::to_string(seq) + std::string(suffix));
 }
 
 pulp::audio::AudioFileData make_test_audio() {


### PR DESCRIPTION
## Summary

`unique_temp_wav_path()` in `test/test_test_signal.cpp` used a process-local `static int counter`, so when Catch2 tests are registered via `catch_discover_tests` and ctest runs them in parallel (`ctest -j4` in `.github/workflows/build.yml`), each process started from `counter=0` and could reuse the same `/tmp/pulp-test-signal-*.wav` names — a non-deterministic CI flake.

Switch to the same pattern used in `test/test_cli_update_check.cpp`'s `make_tmpdir`: pid + `steady_clock::now().time_since_epoch().count()` + an atomic per-process counter. Now every WAV path is unique across processes and threads.

Refs: pulp #1257 review comment [r3175949820](https://github.com/danielraffel/pulp/pull/1257#discussion_r3175949820)

## Test plan

- [x] Pattern mirrors the verified `make_tmpdir` helper in `test/test_cli_update_check.cpp`
- [ ] CI green on `ctest -j4` parallel run