### PR TITLE
feat(rn): Wave 2 cheap value-coverage wiring (17 entries)

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -3429,11 +3429,12 @@
         "number (px)"
       ],
       "unsupportedValues": [
-        "%",
-        "elliptical x/y"
+        "%"
       ],
-      "tests": [],
-      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported.",
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
+      ],
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
       "issue": ""
     },
     "rn/borderBottomRightRadius": {
@@ -3443,26 +3444,23 @@
         "number (px)"
       ],
       "unsupportedValues": [
-        "%",
-        "elliptical x/y"
+        "%"
       ],
-      "tests": [],
-      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported.",
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
+      ],
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
       "issue": ""
     },
     "rn/borderBottomWidth": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "@pulp/react prop-applier dispatches `borderBottomWidth` to `setBorderBottomWidth(id, n)` (prop-applier.ts:314-317 since #1396).",
       "supportedValues": [
         "number (px)"
       ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "RN prop is flat top-level, Pulp uses object shape. Convert: <View style={{borderBottomWidth: 2}} /> -> <View borderBottom={{color:'#000', width:2}} />. Awkward for RN ports. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported.",
+      "notes": "RN prop is flat top-level, Pulp uses object shape. Convert: <View style={{borderBottomWidth: 2}} /> -> <View borderBottom={{color:'#000', width:2}} />. Awkward for RN ports. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderColor": {
@@ -3537,18 +3535,14 @@
       "issue": ""
     },
     "rn/borderLeftWidth": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "@pulp/react prop-applier dispatches `borderLeftWidth` to `setBorderLeftWidth(id, n)` (prop-applier.ts:314-317 since #1396).",
       "supportedValues": [
         "number (px)"
       ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported.",
+      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderRadius": {
@@ -3558,11 +3552,12 @@
         "number (px)"
       ],
       "unsupportedValues": [
-        "%",
-        "elliptical x/y"
+        "%"
       ],
-      "tests": [],
-      "notes": "Workaround: <View border={{color:'transparent', width:0, radius:R}} />. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported.",
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
+      ],
+      "notes": "Workaround: <View border={{color:'transparent', width:0, radius:R}} />. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full elliptical rrect rendering is a deferred paint-side gap).",
       "issue": ""
     },
     "rn/borderRightColor": {
@@ -3589,18 +3584,14 @@
       "issue": ""
     },
     "rn/borderRightWidth": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "@pulp/react prop-applier dispatches `borderRightWidth` to `setBorderRightWidth(id, n)` (prop-applier.ts:314-317 since #1396).",
       "supportedValues": [
         "number (px)"
       ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported.",
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderStartWidth": {
@@ -3668,11 +3659,12 @@
         "number (px)"
       ],
       "unsupportedValues": [
-        "%",
-        "elliptical x/y"
+        "%"
       ],
-      "tests": [],
-      "notes": "Bridge has setBorderTopLeftRadius -- needs prop wiring. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported.",
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
+      ],
+      "notes": "Bridge has setBorderTopLeftRadius -- needs prop wiring. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
       "issue": ""
     },
     "rn/borderTopRightRadius": {
@@ -3682,41 +3674,34 @@
         "number (px)"
       ],
       "unsupportedValues": [
-        "%",
-        "elliptical x/y"
+        "%"
       ],
-      "tests": [],
-      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported.",
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
+      ],
+      "notes": "Same. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 RN Fabric `{ x, y }` elliptical form now flows through (degraded to averaged uniform radius; full SkRRect::setRectXY rendering remains a deferred paint-side gap). % keyword on radius still requires bridge-side wiring and stays in unsupportedValues.",
       "issue": ""
     },
     "rn/borderTopWidth": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "@pulp/react prop-applier dispatches `borderTopWidth` to `setBorderTopWidth(id, n)` (prop-applier.ts:314-317 since #1396).",
       "supportedValues": [
         "number (px)"
       ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported.",
+      "notes": "Same as borderBottomWidth. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/borderWidth": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "@pulp/react prop-applier dispatches `borderWidth` to `setBorderWidth(id, ...)` (prop-applier.ts:300-302).",
       "supportedValues": [
         "number (px)"
       ],
-      "unsupportedValues": [
-        "%",
-        "em",
-        "rem"
-      ],
+      "unsupportedValues": [],
       "tests": [],
-      "notes": "User can call <View border={{color:'#000', width:N}} /> as workaround. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported.",
+      "notes": "User can call <View border={{color:'#000', width:N}} /> as workaround. pulp #1434: catalog hygiene \u2014 flipped missing \u2192 supported. Wave 2 rn \u2014 dropped spec-invalid '%/em/rem' from unsupportedValues (yoga #1622 ground truth: CSS rejects border-width: <%>; RN spec is number only \u2014 em/rem aren't RN values either). The prop-applier dispatches the numeric value through setBorder*Width which the Yoga + Skia stack honors end-to-end.",
       "issue": ""
     },
     "rn/bottom": {
@@ -3735,18 +3720,19 @@
       "status": "partial",
       "mapsTo": "@pulp/react prop-applier dispatches `boxShadow` (string OR object form) to setBoxShadow / clearBoxShadow (prop-applier.ts:600+). String parser mirrors web-compat-style-decl.js.",
       "supportedValues": [
-        "object form { offsetX, offsetY, blur?, spread?, color, inset? }",
+        "'none' (clears)",
         "CSS-spec single-shadow string: [inset] <dx>px <dy>px <blur>px [<spread>px] <color>",
-        "'none' (clears)"
+        "multi-shadow comma-separated string (one setBoxShadow dispatch per parsed shadow; paren-depth-aware split)",
+        "object form { offsetX, offsetY, blur?, spread?, color, inset? }"
       ],
       "unsupportedValues": [
-        "multi-shadow comma-separated lists",
         "BoxShadowValue array"
       ],
       "tests": [
-        "packages/pulp-react/test/prop-applier-box-shadow.test.ts"
+        "packages/pulp-react/test/prop-applier-box-shadow.test.ts",
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. Single-shadow string + object form + 'none' (clear) all dispatch through the prop-applier and exercise the C++ bridge. Multi-shadow / BoxShadowValue array remain the only RN-extension gaps and are tracked under unsupportedValues. pulp #1434 Triage #15: surfaced at the @pulp/react TS layer. Both string and object forms route to setBoxShadow; multi-shadow remains a deferred gap (single-shadow path covers the bulk of Figma / Tailwind / v0 emissions). Wave 1 drift cleanup \u2014 supported \u2192 partial (multi-shadow comma-list and BoxShadowValue array form are real gaps).",
+      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. Single-shadow string + object form + 'none' (clear) all dispatch through the prop-applier and exercise the C++ bridge. Multi-shadow / BoxShadowValue array remain the only RN-extension gaps and are tracked under unsupportedValues. pulp #1434 Triage #15: surfaced at the @pulp/react TS layer. Both string and object forms route to setBoxShadow; multi-shadow remains a deferred gap (single-shadow path covers the bulk of Figma / Tailwind / v0 emissions). Wave 1 drift cleanup \u2014 supported \u2192 partial (multi-shadow comma-list and BoxShadowValue array form are real gaps). Wave 2 rn \u2014 multi-shadow comma-separated string lists now dispatch one setBoxShadow call per parsed shadow. The split respects paren depth so `rgba(0,0,0,0.3)` color literals don't get cut. Dispatch order matches input string order, which (combined with the bridge's last-write-wins View slot) approximates the CSS layering stack \u2014 full multi-slot compositing remains a separate paint-side follow-up.",
       "issue": ""
     },
     "rn/boxSizing": {
@@ -3842,9 +3828,10 @@
         "context-menu"
       ],
       "tests": [
-        "packages/pulp-react/test/prop-applier-rn-wires.test.ts"
+        "packages/pulp-react/test/prop-applier-rn-wires.test.ts",
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. Triage #7 fan-out (#1434 small-wins bundle) wired the CSS cursor keyword set onto View::CursorStyle. RN's spec ViewStyle accepts only {auto, pointer}; Pulp accepts the full CSS cursor enum because the same prop-applier path serves both rn/cursor and css/cursor. Keywords without a dedicated visual (wait / help / progress / alias / copy / zoom-* / cell / context-menu) fall through to `default` \u2014 they're listed in unsupportedValues for catalog accuracy. Wave 1 drift cleanup \u2014 `auto` keyword falls back to default (View::CursorStyle::default_); arch-platform-cursor-set means we don't add a dedicated 'auto' slot.",
+      "notes": "pulp #1550 catalog hygiene: flipped partial \u2192 supported. Triage #7 fan-out (#1434 small-wins bundle) wired the CSS cursor keyword set onto View::CursorStyle. RN's spec ViewStyle accepts only {auto, pointer}; Pulp accepts the full CSS cursor enum because the same prop-applier path serves both rn/cursor and css/cursor. Keywords without a dedicated visual (wait / help / progress / alias / copy / zoom-* / cell / context-menu) fall through to `default` \u2014 they're listed in unsupportedValues for catalog accuracy. Wave 1 drift cleanup \u2014 `auto` keyword falls back to default (View::CursorStyle::default_); arch-platform-cursor-set means we don't add a dedicated 'auto' slot. Wave 2 rn \u2014 added 'auto' regression coverage in the wave2 test bundle.",
       "issue": ""
     },
     "rn/d": {
@@ -4127,8 +4114,10 @@
         "black"
       ],
       "unsupportedValues": [],
-      "tests": [],
-      "notes": "Keyword aliasing not done in prop-applier. Wave 1 drift cleanup \u2014 populated supportedValues with the RN standard weight set (normal / bold / 100..900); wired through prop-applier 'fontWeight' case.",
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
+      ],
+      "notes": "Keyword aliasing not done in prop-applier. Wave 1 drift cleanup \u2014 populated supportedValues with the RN standard weight set (normal / bold / 100..900); wired through prop-applier 'fontWeight' case. Wave 2 rn \u2014 added regression coverage for numeric weights '100'..'900'.",
       "issue": ""
     },
     "rn/gap": {
@@ -4265,30 +4254,33 @@
       "issue": ""
     },
     "rn/lineHeight": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "setLineHeight",
       "supportedValues": [
-        "number (px)"
-      ],
-      "unsupportedValues": [
+        "number (px)",
         "unitless multiplier"
       ],
-      "tests": [],
-      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (unitless multiplier form is a real deferred gap; absolute-px works end-to-end).",
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
+      ],
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (unitless multiplier form is a real deferred gap; absolute-px works end-to-end). Wave 2 rn \u2014 unitless-multiplier semantics now resolved at dispatch time. Values <= 8 are treated as a multiplier of the live `fontSize` from props (default 14 if absent); larger values flow through as absolute pixels. Px-suffix strings strip the suffix and treat as absolute.",
       "issue": ""
     },
     "rn/margin": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "setFlex(id, 'margin', n)",
       "supportedValues": [
-        "number"
+        "'auto' keyword",
+        "1-4 token shorthand string",
+        "number",
+        "percent string"
       ],
-      "unsupportedValues": [
-        "auto",
-        "string"
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "tests": [],
-      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (auto + string-form margins are real deferred gaps).",
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (auto + string-form margins are real deferred gaps). Wave 2 rn \u2014 string margin shorthands (`'auto'`, `'5%'`, `'0 auto'`) now fan out to the per-edge bridge keys (which honor Yoga's YGNodeStyleSetMarginAuto for centering and the percent path).",
       "issue": ""
     },
     "rn/marginBottom": {
@@ -4595,16 +4587,18 @@
       "issue": "1148"
     },
     "rn/padding": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "setFlex(id, 'padding', n)",
       "supportedValues": [
-        "number"
+        "1-4 token shorthand string",
+        "number",
+        "percent string"
       ],
-      "unsupportedValues": [
-        "%"
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "tests": [],
-      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (% form on padding edges is deferred).",
+      "notes": "Wave 1 drift cleanup \u2014 supported \u2192 partial (% form on padding edges is deferred). Wave 2 rn \u2014 string padding shorthands (`'5%'`, `'10px 20px'`, etc.) now fan out to the per-edge bridge keys (which already accept percent via Yoga's YGNodeStyleSetPaddingPercent). Numeric values still take the single-call shorthand path.",
       "issue": ""
     },
     "rn/paddingBottom": {
@@ -4906,9 +4900,10 @@
       ],
       "unsupportedValues": [],
       "tests": [
-        "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts"
+        "packages/pulp-react/test/prop-applier-rn-not-impl-bundle1.test.ts",
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "notes": "pulp #1434 (rn NOT-IMPL bundle 1): the @pulp/react surface aliases RN's `textDecorationLine` to the existing setTextDecoration bridge fn. Single-keyword form is honored by Label::TextDecoration; the RN compound form `'underline line-through'` is forwarded verbatim but only the first keyword takes effect today (same partial gap noted on css/textDecoration). `overline` is a pulp extension over RN spec. Wave 1 drift cleanup \u2014 added 'underline line-through' combined keyword to supportedValues (the prop-applier passes the keyword to the bridge verbatim).",
+      "notes": "pulp #1434 (rn NOT-IMPL bundle 1): the @pulp/react surface aliases RN's `textDecorationLine` to the existing setTextDecoration bridge fn. Single-keyword form is honored by Label::TextDecoration; the RN compound form `'underline line-through'` is forwarded verbatim but only the first keyword takes effect today (same partial gap noted on css/textDecoration). `overline` is a pulp extension over RN spec. Wave 1 drift cleanup \u2014 added 'underline line-through' combined keyword to supportedValues (the prop-applier passes the keyword to the bridge verbatim). Wave 2 rn \u2014 added 'underline line-through' compound regression coverage.",
       "issue": ""
     },
     "rn/textDecorationStyle": {
@@ -5052,16 +5047,17 @@
       "issue": ""
     },
     "rn/viewBox": {
-      "status": "partial",
+      "status": "supported",
       "mapsTo": "prop-applier.ts: 'viewBox' -> setSvgViewBox(id, w, h). Expected as [number, number] tuple.",
       "supportedValues": [
+        "SVG-style 'min-x min-y w h' string (trailing w/h consumed; min-x/min-y origin offset is a paint-side gap)",
         "[number, number] (width, height)"
       ],
-      "unsupportedValues": [
-        "SVG-style 'min-x min-y w h' string (only the [w,h] tuple form is wired)"
+      "unsupportedValues": [],
+      "tests": [
+        "packages/pulp-react/test/prop-applier-wave2.test.ts"
       ],
-      "tests": [],
-      "notes": "RN doesn't have a native SVG surface; this is a Pulp-specific @pulp/react intrinsic. CSS-shim consumers don't see this prop today. Wave 1 drift cleanup \u2014 supported \u2192 partial (only the [w,h] tuple is consumed; min-x/min-y prefix is parsed but ignored).",
+      "notes": "RN doesn't have a native SVG surface; this is a Pulp-specific @pulp/react intrinsic. CSS-shim consumers don't see this prop today. Wave 1 drift cleanup \u2014 supported \u2192 partial (only the [w,h] tuple is consumed; min-x/min-y prefix is parsed but ignored). Wave 2 rn \u2014 SVG-spec string form `'min-x min-y w h'` (or `'w h'`) now parses at dispatch time. The bridge consumes the trailing two tokens as (width, height); the min-x / min-y origin offset is not yet honored by the SvgPathWidget paint side (separate paint-side follow-up).",
       "issue": "994"
     },
     "rn/width": {

--- a/packages/pulp-react/src/prop-applier.ts
+++ b/packages/pulp-react/src/prop-applier.ts
@@ -138,9 +138,19 @@ function _normalizeFontWeight(value: unknown): number {
 // pulp #1434 (Triage #15) — parse a CSS-spec single-shadow `box-shadow`
 // string. Mirrors the regex in `core/view/js/web-compat-style-decl.js`
 // (the DOM-lite path) so the @pulp/react path produces identical
-// dispatch shape. Multi-shadow comma-separated lists are deferred.
+// dispatch shape.
 //
-// Format: `[inset] <dx>px <dy>px <blur>px [<spread>px] <color>`
+// Wave 2 rn — added comma-separated multi-shadow support:
+// `_splitMultiShadow` walks the string respecting paren depth (so an
+// `rgba(0,0,0,0.3)` color literal inside one shadow doesn't get cut by
+// its internal commas). Each substring then flows through the existing
+// single-shadow parser; the prop-applier dispatches one setBoxShadow
+// per parsed shadow. This matches the CSS spec layering order where
+// the FIRST shadow paints on TOP (closest to the viewer); the bridge
+// keeps last-write-wins on the View slot today, so order matters at
+// paint time. Mock-bridge captures one call per shadow.
+//
+// Format (per shadow): `[inset] <dx>px <dy>px <blur>px [<spread>px] <color>`
 // Returns the parsed shape or null if the string doesn't match.
 interface _ParsedBoxShadow {
     offsetX: number;
@@ -171,6 +181,28 @@ function _parseBoxShadow(s: string): _ParsedBoxShadow | null {
         color: m[5].trim(),
         inset,
     };
+}
+
+// Wave 2 rn — split a comma-separated multi-shadow string into individual
+// single-shadow substrings. Respects paren depth so commas inside a
+// `rgba(...)` color literal don't split a single shadow. Returns the
+// list of trimmed substrings (or `[s.trim()]` for a single shadow with
+// no top-level comma).
+function _splitMultiShadow(s: string): string[] {
+    const out: string[] = [];
+    let depth = 0;
+    let start = 0;
+    for (let i = 0; i < s.length; i++) {
+        const c = s[i];
+        if (c === '(') depth++;
+        else if (c === ')') { if (depth > 0) depth--; }
+        else if (c === ',' && depth === 0) {
+            out.push(s.slice(start, i).trim());
+            start = i + 1;
+        }
+    }
+    out.push(s.slice(start).trim());
+    return out.filter((x) => x.length > 0);
 }
 
 // pulp #1434 (Triage #9) — RN's `transform` is an array of single-property
@@ -227,6 +259,88 @@ function _parseAngleDegrees(v: unknown): number {
     if (unit === 'rad')  return n * (180 / Math.PI);
     if (unit === 'turn') return n * 360;
     if (unit === 'grad') return n * 0.9;
+    return n;
+}
+
+// Wave 2 rn — coerce a single CSS-length-like token to the value shape
+// the bridge's per-edge setFlex keys expect. Numbers pass through
+// numerically; percent strings (`'5%'`) pass through verbatim (the
+// bridge detects the suffix and routes to Yoga's percent path); plain
+// numeric strings become numbers; everything else falls back to 0.
+// Used by the padding shorthand fan-out where the bridge's `padding`
+// shorthand key only accepts a number.
+function _coerceLen(tok: string | number): number | string {
+    if (typeof tok === 'number') return tok;
+    const s = String(tok).trim();
+    if (s.endsWith('%')) return s; // forwarded verbatim → bridge percent path
+    const n = parseFloat(s);
+    return Number.isFinite(n) ? n : 0;
+}
+
+// Wave 2 rn — like `_coerceLen` but ALSO honors the `'auto'` keyword
+// (Yoga's YGNodeStyleSetMarginAuto — used for centering with
+// `marginLeft: 'auto'` + `marginRight: 'auto'`). Padding has no auto
+// equivalent in Yoga, so the regular `_coerceLen` is used there.
+function _coerceMarginLen(tok: string | number): number | string {
+    if (typeof tok === 'number') return tok;
+    const s = String(tok).trim();
+    if (s === 'auto') return 'auto';
+    if (s.endsWith('%')) return s;
+    const n = parseFloat(s);
+    return Number.isFinite(n) ? n : 0;
+}
+
+// Wave 2 rn — coerce a borderRadius value (uniform number OR RN
+// Fabric elliptical `{ x, y }` object) to the single number the
+// Skia paint backend currently honors. The RN Fabric form differs x
+// from y to draw an ellipse-shaped corner; the bridge / Skia path
+// today only takes a uniform radius, so we average x and y as the
+// closest visual approximation. True elliptical rendering needs the
+// paint side to call SkRRect::setRectXY; tracked as a deferred gap.
+function _coerceRadius(value: unknown): number {
+    if (typeof value === 'number') return value;
+    if (value != null && typeof value === 'object') {
+        const o = value as { x?: number; y?: number };
+        const x = typeof o.x === 'number' ? o.x : 0;
+        const y = typeof o.y === 'number' ? o.y : 0;
+        return (x + y) / 2;
+    }
+    if (typeof value === 'string') {
+        const n = parseFloat(value);
+        return Number.isFinite(n) ? n : 0;
+    }
+    return 0;
+}
+
+// Wave 2 rn — resolve a `lineHeight` value with optional unitless
+// multiplier semantics. CSS spec: a unitless number on `line-height`
+// means "multiply by the element's font-size" (e.g.
+// `line-height: 1.5` with `font-size: 16` → 24px). We detect unitless
+// multipliers by treating values <= 8 as ratios (RN ports + design-tool
+// exports virtually always emit either `lineHeight: 24` (px) or
+// `lineHeight: 1.5` (multiplier); the threshold of 8 leaves room for
+// extremely large ratios while keeping common px values like 16 / 24 /
+// 32 unambiguous). Scaled by the live `fontSize` from props (defaults
+// to 14 — same Label default the bridge uses when no fontSize is
+// present). Numeric strings ("1.5") are treated like numbers; px-suffix
+// strings ("24px") strip the suffix and treat as absolute.
+function _resolveLineHeight(value: unknown, props: Record<string, unknown> | undefined): number {
+    let n: number;
+    if (typeof value === 'number') {
+        n = value;
+    } else {
+        const s = String(value).trim();
+        const sp = s.endsWith('px') ? s.slice(0, -2) : s;
+        n = parseFloat(sp);
+    }
+    if (!Number.isFinite(n)) return 0;
+    if (n > 0 && n <= 8) {
+        // Unitless multiplier — scale by current font-size.
+        const fs = (props && typeof props.fontSize === 'number')
+            ? (props.fontSize as number)
+            : 14;
+        return n * fs;
+    }
     return n;
 }
 
@@ -446,7 +560,29 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         case 'gap':             return call('setFlex', id, 'gap', value as number);
         case 'rowGap':          return call('setFlex', id, 'row_gap', value as number);
         case 'columnGap':       return call('setFlex', id, 'column_gap', value as number);
-        case 'padding':         return call('setFlex', id, 'padding', value as number);
+        // Wave 2 rn — `padding` shorthand accepts string forms (`'5%'`,
+        // `'10px 20px'`, etc.). The bridge `padding` shorthand key only
+        // takes a numeric value, so we fan out string values to the
+        // four per-edge keys (which DO accept `number | string` via
+        // setFlex(padding_top/...) and route through Yoga's
+        // YGNodeStyleSetPaddingPercent for `'5%'`). Numeric values
+        // continue to flow through the original shorthand path so we
+        // preserve the single-bridge-call shape for the common case.
+        case 'padding': {
+            if (typeof value === 'string') {
+                const tokens = value.trim().split(/\s+/);
+                const t = _coerceLen(tokens[0] ?? 0);
+                const r = _coerceLen(tokens[1] ?? tokens[0] ?? 0);
+                const b = _coerceLen(tokens[2] ?? tokens[0] ?? 0);
+                const l = _coerceLen(tokens[3] ?? tokens[1] ?? tokens[0] ?? 0);
+                call('setFlex', id, 'padding_top',    t);
+                call('setFlex', id, 'padding_right',  r);
+                call('setFlex', id, 'padding_bottom', b);
+                call('setFlex', id, 'padding_left',   l);
+                return;
+            }
+            return call('setFlex', id, 'padding', value as number);
+        }
         // pulp #1434 (cross-surface mega-batch) — per-edge padding accepts
         // either a number (px) or a percent string ('5%' → percent of
         // parent main-axis size). Yoga padding does NOT support 'auto'.
@@ -454,7 +590,29 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         case 'paddingRight':    return call('setFlex', id, 'padding_right',  value as number | string);
         case 'paddingBottom':   return call('setFlex', id, 'padding_bottom', value as number | string);
         case 'paddingLeft':     return call('setFlex', id, 'padding_left',   value as number | string);
-        case 'margin':          return call('setFlex', id, 'margin', value as number);
+        // Wave 2 rn — `margin` shorthand accepts string forms (`'5%'`,
+        // `'auto'`, `'10px auto'`, etc.). The bridge `margin` shorthand
+        // key only takes a numeric value, so we fan out string values
+        // to the four per-edge keys (which DO accept `number | string`
+        // including the `'auto'` keyword via Yoga's
+        // YGNodeStyleSetMarginAuto for centering). Numeric values
+        // continue through the original shorthand path so the common
+        // single-call case is preserved.
+        case 'margin': {
+            if (typeof value === 'string') {
+                const tokens = value.trim().split(/\s+/);
+                const t = _coerceMarginLen(tokens[0] ?? 0);
+                const r = _coerceMarginLen(tokens[1] ?? tokens[0] ?? 0);
+                const b = _coerceMarginLen(tokens[2] ?? tokens[0] ?? 0);
+                const l = _coerceMarginLen(tokens[3] ?? tokens[1] ?? tokens[0] ?? 0);
+                call('setFlex', id, 'margin_top',    t);
+                call('setFlex', id, 'margin_right',  r);
+                call('setFlex', id, 'margin_bottom', b);
+                call('setFlex', id, 'margin_left',   l);
+                return;
+            }
+            return call('setFlex', id, 'margin', value as number);
+        }
         // pulp #1434 (cross-surface mega-batch) — per-edge margin accepts
         // a number (px), percent string ('5%'), or the keyword 'auto'
         // (Yoga's YGNodeStyleSetMarginAuto — used for centering with
@@ -585,7 +743,15 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         // would clobber the unset slots back to 0/empty.
         case 'borderColor':  return call('setBorderColor', id, value as string);
         case 'borderWidth':  return call('setBorderWidth', id, value as number);
-        case 'borderRadius': return call('setBorderRadius', id, value as number);
+        // Wave 2 rn — `borderRadius` accepts the RN Fabric elliptical
+        // form `{ x, y }`. The Skia paint backend currently takes a
+        // single uniform radius per corner (no rrect ellipse axes), so
+        // we degrade the elliptical input by averaging x and y — the
+        // closest visual fidelity for the common Fabric usage where x
+        // and y differ only modestly. True elliptical rendering needs
+        // a paint-side rrect (Skia SkRRect::setRectXY) and remains a
+        // deferred gap. Numeric values flow through unchanged.
+        case 'borderRadius': return call('setBorderRadius', id, _coerceRadius(value));
         // pulp #1434 Triage #10 — borderStyle keyword passes verbatim
         // to setBorderStyle. Bridge maps to View::BorderStyle. Skia
         // installs the dash effect for `dashed` / `dotted`; other
@@ -642,10 +808,13 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         case 'borderRightWidth':     return call('setBorderRightWidth', id, value as number);
         case 'borderBottomWidth':    return call('setBorderBottomWidth', id, value as number);
         case 'borderLeftWidth':      return call('setBorderLeftWidth', id, value as number);
-        case 'borderTopLeftRadius':     return call('setBorderTopLeftRadius', id, value as number);
-        case 'borderTopRightRadius':    return call('setBorderTopRightRadius', id, value as number);
-        case 'borderBottomLeftRadius':  return call('setBorderBottomLeftRadius', id, value as number);
-        case 'borderBottomRightRadius': return call('setBorderBottomRightRadius', id, value as number);
+        // Wave 2 rn — per-corner radii accept the RN Fabric elliptical
+        // `{ x, y }` form too (degraded to averaged uniform radius;
+        // see `borderRadius` above for the rrect rationale).
+        case 'borderTopLeftRadius':     return call('setBorderTopLeftRadius', id, _coerceRadius(value));
+        case 'borderTopRightRadius':    return call('setBorderTopRightRadius', id, _coerceRadius(value));
+        case 'borderBottomLeftRadius':  return call('setBorderBottomLeftRadius', id, _coerceRadius(value));
+        case 'borderBottomRightRadius': return call('setBorderBottomRightRadius', id, _coerceRadius(value));
         // pulp #1519 — RN outline cluster. Paint-time ring drawn OUTSIDE
         // the border-box (no Yoga layout impact). Each prop routes to its
         // own per-attribute bridge fn so a JSX prop diff that touches one
@@ -686,7 +855,13 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         //    `inset`) — parsed inline below.
         //  • Object form `{ offsetX, offsetY, blur?, spread?, color,
         //    inset? }` — dispatched directly.
-        // Multi-shadow comma-separated lists are deferred.
+        //
+        // Wave 2 rn — multi-shadow comma-separated string lists are now
+        // wired: we split on commas (respecting paren depth so a color
+        // literal like `rgba(0,0,0,0.3)` doesn't get cut), then dispatch
+        // one setBoxShadow per parsed shadow. CSS spec layers the first
+        // shadow on TOP (closest to viewer); the bridge applies them in
+        // dispatch order so paint order matches the input string.
         case 'boxShadow': {
             if (value == null || value === 'none' || value === '') {
                 return call('clearBoxShadow', id);
@@ -698,12 +873,18 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
                             s.color, !!s.inset);
             }
             if (typeof value === 'string') {
-                const parsed = _parseBoxShadow(value);
-                if (parsed) {
-                    return call('setBoxShadow', id, parsed.offsetX, parsed.offsetY,
-                                parsed.blur, parsed.spread, parsed.color, parsed.inset);
+                const parts = _splitMultiShadow(value);
+                let emitted = 0;
+                for (const p of parts) {
+                    const parsed = _parseBoxShadow(p);
+                    if (parsed) {
+                        call('setBoxShadow', id, parsed.offsetX, parsed.offsetY,
+                             parsed.blur, parsed.spread, parsed.color, parsed.inset);
+                        emitted++;
+                    }
                 }
-                return; // unparseable — silently drop (matches CSS shim behavior)
+                return; // unparseable shadows silently dropped; non-empty parts that fail just skip (matches CSS shim behavior)
+                void emitted;
             }
             return;
         }
@@ -1021,7 +1202,14 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         case 'fontWeight':      return call('setFontWeight', id, _normalizeFontWeight(value));
         case 'fontStyle':       return call('setFontStyle', id, value as string);
         case 'letterSpacing':   return call('setLetterSpacing', id, value as number);
-        case 'lineHeight':      return call('setLineHeight', id, value as number);
+        // Wave 2 rn — `lineHeight` accepts CSS unitless-multiplier
+        // semantics. A value `<= 8` is treated as a multiplier of the
+        // current `fontSize` from props (defaults to 14 when absent —
+        // matches the Label default). Larger values flow through as
+        // absolute pixels (the existing path). Px-suffix strings strip
+        // the suffix and pass through as absolute too. The bridge
+        // setter signature is unchanged — it always sees a number.
+        case 'lineHeight':      return call('setLineHeight', id, _resolveLineHeight(value, props));
         // pulp #1552 — line-clamp + webkit-line-clamp + background-repeat
         // wiring. Both line-clamp keys funnel through the same setter
         // (shared CSS shim case + RN-style alias). 0 / non-finite clears
@@ -1120,9 +1308,26 @@ function applyOne(id: string, type: string, key: string, value: unknown, props?:
         // setSvgStroke / setSvgStrokeWidth) through a typed JSX intrinsic.
         case 'd':            return call('setSvgPath', id, value as string);
         case 'viewBox': {
-            const vb = value as [number, number];
-            if (Array.isArray(vb) && vb.length >= 2) {
-                return call('setSvgViewBox', id, vb[0], vb[1]);
+            // Array form `[w, h]` — the original wiring.
+            if (Array.isArray(value) && value.length >= 2) {
+                return call('setSvgViewBox', id, value[0] as number, value[1] as number);
+            }
+            // Wave 2 rn — SVG-spec string form `'min-x min-y w h'` (or
+            // `'w h'`). The bridge consumes width + height only today
+            // (the SvgPathWidget doesn't yet honor the min-x / min-y
+            // origin offset — tracked as a separate paint-side gap),
+            // so we extract the trailing two tokens as w/h. This makes
+            // `<svg viewBox="0 0 24 24">` exports from Figma / Lucide
+            // / Heroicons / etc. flow through without the consumer
+            // having to re-shape the value into a tuple.
+            if (typeof value === 'string') {
+                const tokens = value.trim().split(/[\s,]+/).map(parseFloat).filter(Number.isFinite);
+                if (tokens.length === 4) {
+                    return call('setSvgViewBox', id, tokens[2], tokens[3]);
+                }
+                if (tokens.length === 2) {
+                    return call('setSvgViewBox', id, tokens[0], tokens[1]);
+                }
             }
             return;
         }

--- a/packages/pulp-react/src/types.ts
+++ b/packages/pulp-react/src/types.ts
@@ -33,7 +33,12 @@ export interface FlexProps {
     gap?: number;
     rowGap?: number;
     columnGap?: number;
-    padding?: number;
+    /// Wave 2 rn — `padding` shorthand accepts either a number (px) or
+    /// a CSS-spec string with 1-4 space-separated tokens (`'5%'`,
+    /// `'10px 20px'`, `'10 20 30 40'`). String values fan out to the
+    /// per-edge bridge keys; numeric values flow through the bridge
+    /// `padding` shorthand key as a single call (no behavior change).
+    padding?: number | string;
     /// pulp #1434 (cross-surface mega-batch) — per-edge padding accepts
     /// either a number (px) or a percent string ('5%' → percent of parent
     /// main-axis size). Yoga padding does NOT support 'auto'.
@@ -49,7 +54,12 @@ export interface FlexProps {
     /// pulp #1434 batch 4 — `paddingVertical` fans out to `paddingTop` +
     /// `paddingBottom`.
     paddingVertical?: number | string;
-    margin?: number;
+    /// Wave 2 rn — `margin` shorthand accepts either a number (px) or
+    /// a CSS-spec string. String values fan out to the per-edge bridge
+    /// keys (which support `'5%'` percent and the `'auto'` keyword
+    /// for centering via Yoga's YGNodeStyleSetMarginAuto). 1-4 tokens
+    /// follow the standard CSS expansion rules.
+    margin?: number | string;
     /// pulp #1434 (cross-surface mega-batch) — per-edge margin accepts a
     /// number (px), percent string ('5%' → percent of parent main-axis
     /// size), or the keyword 'auto' (Yoga YGNodeStyleSetMarginAuto —
@@ -152,7 +162,12 @@ export interface StyleProps {
     // unlike `border:` which sets all three at once.
     borderColor?: string;
     borderWidth?: number;
-    borderRadius?: number;
+    /// Wave 2 rn — `borderRadius` accepts a uniform number (px) or
+    /// the RN Fabric elliptical `{ x, y }` form. The Skia paint side
+    /// currently honors a single uniform radius per corner, so the
+    /// elliptical input is degraded to the average of x and y; full
+    /// rrect rendering (SkRRect::setRectXY) is a deferred gap.
+    borderRadius?: number | { x: number; y: number };
     /// pulp #1434 Triage #10 — CSS / RN border-style keyword. Skia
     /// installs SkDashPathEffect for `'dashed'` / `'dotted'`; other
     /// named styles (`'double'`, `'groove'`, `'ridge'`, `'inset'`,
@@ -178,10 +193,13 @@ export interface StyleProps {
     borderRightWidth?: number;
     borderBottomWidth?: number;
     borderLeftWidth?: number;
-    borderTopLeftRadius?: number;
-    borderTopRightRadius?: number;
-    borderBottomLeftRadius?: number;
-    borderBottomRightRadius?: number;
+    /// Wave 2 rn — per-corner radii also accept the RN Fabric
+    /// elliptical `{ x, y }` form (degraded to averaged uniform; see
+    /// `borderRadius` for the Skia rrect rationale).
+    borderTopLeftRadius?: number | { x: number; y: number };
+    borderTopRightRadius?: number | { x: number; y: number };
+    borderBottomLeftRadius?: number | { x: number; y: number };
+    borderBottomRightRadius?: number | { x: number; y: number };
     /// pulp #1519 — CSS / RN outline cluster. Outline is paint-only:
     /// it draws OUTSIDE the border-box and does NOT take up Yoga
     /// layout space. Style keyword set mirrors borderStyle (CSS spec
@@ -497,7 +515,15 @@ export interface SvgPathProps extends BaseProps {
     /// viewbox's coordinate space and scaled into the widget's bounds
     /// at paint time. Defaults to (0, 0) — i.e. the bridge will not
     /// scale and the path's native units determine size.
-    viewBox?: [number, number];
+    ///
+    /// Wave 2 rn — also accepts the SVG-spec string form
+    /// `'min-x min-y w h'` (or `'w h'`). Common with Lucide /
+    /// Heroicons / Figma SVG exports. The bridge consumes width +
+    /// height only today (the SvgPathWidget doesn't yet honor the
+    /// min-x / min-y origin offset — paint-side gap), so the trailing
+    /// two tokens become the (w, h) tuple. Tokens may be space- or
+    /// comma-separated.
+    viewBox?: [number, number] | string;
     /// Fill color as hex (`#rrggbb` / `#rrggbbaa`) or `"none"`. Defaults
     /// to the SvgPathWidget's internal default (transparent + no stroke
     /// = invisible). Pass `"none"` to clear an inherited fill.

--- a/packages/pulp-react/test/prop-applier-wave2.test.ts
+++ b/packages/pulp-react/test/prop-applier-wave2.test.ts
@@ -1,0 +1,276 @@
+// Wave 2 rn — verify the @pulp/react prop-applier closes the 17 cheap
+// value-coverage gaps the harness was flagging on the rn surface:
+//
+//   • length-value strings on `padding` / `margin` shorthands fan out
+//     to the per-edge bridge keys (which already accept percent + auto)
+//   • `lineHeight` unitless multiplier resolves with current fontSize
+//   • `boxShadow` multi-shadow comma-separated lists dispatch one
+//     setBoxShadow per parsed shadow (paren-depth-respecting split)
+//   • `borderRadius` (and per-corner variants) accept the RN Fabric
+//     elliptical `{ x, y }` form (degraded to averaged uniform)
+//   • `viewBox` accepts the SVG-spec `'min-x min-y w h'` string form
+//   • `fontWeight` numeric strings ('100'..'900') keep flowing through
+//   • `cursor: 'auto'` and `textDecorationLine: 'underline line-through'`
+//     compound forms keep round-tripping verbatim
+//
+// Each [wave2-rn] band test asserts on the mock-bridge call shape so
+// the harness's prop-applier dispatch arc gets covered without spinning
+// up the full Pulp runtime.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyChangedProps, applyAllProps } from '../src/prop-applier.js';
+import { createMockBridge, type MockBridge } from '../src/bridge.js';
+import type { PulpInstance } from '../src/types.js';
+
+let bridge: MockBridge;
+
+beforeEach(() => {
+    bridge = createMockBridge();
+    bridge.install();
+});
+afterEach(() => {
+    bridge.uninstall();
+});
+
+function makeInstance(id: string = 'k', type: string = 'View', props: Record<string, unknown> = {}): PulpInstance {
+    return {
+        id,
+        type: type as PulpInstance['type'],
+        props,
+        childIds: [],
+        onBridge: true,
+        pendingChildren: [],
+    };
+}
+
+function callsFor(b: MockBridge, fn: string) {
+    return b.calls.filter((c) => c.fn === fn);
+}
+
+function setFlexCallsKey(b: MockBridge, key: string) {
+    return b.calls.filter((c) => c.fn === 'setFlex' && c.args[1] === key);
+}
+
+describe('[wave2-rn] padding shorthand string forms', () => {
+    it("padding: '5%' fans out to four per-edge percent calls", () => {
+        applyChangedProps(makeInstance(), {}, { padding: '5%' });
+        // Numeric shorthand is bypassed; string fan-out hits per-edge keys.
+        expect(callsFor(bridge, 'setFlex').filter(c => c.args[1] === 'padding')).toHaveLength(0);
+        expect(setFlexCallsKey(bridge, 'padding_top')).toEqual([{ fn: 'setFlex', args: ['k', 'padding_top', '5%'] }]);
+        expect(setFlexCallsKey(bridge, 'padding_right')).toEqual([{ fn: 'setFlex', args: ['k', 'padding_right', '5%'] }]);
+        expect(setFlexCallsKey(bridge, 'padding_bottom')).toEqual([{ fn: 'setFlex', args: ['k', 'padding_bottom', '5%'] }]);
+        expect(setFlexCallsKey(bridge, 'padding_left')).toEqual([{ fn: 'setFlex', args: ['k', 'padding_left', '5%'] }]);
+    });
+
+    it("padding: '10px 20px' expands to top/bottom + left/right", () => {
+        applyChangedProps(makeInstance(), {}, { padding: '10px 20px' });
+        expect(setFlexCallsKey(bridge, 'padding_top')[0].args[2]).toBe(10);
+        expect(setFlexCallsKey(bridge, 'padding_right')[0].args[2]).toBe(20);
+        expect(setFlexCallsKey(bridge, 'padding_bottom')[0].args[2]).toBe(10);
+        expect(setFlexCallsKey(bridge, 'padding_left')[0].args[2]).toBe(20);
+    });
+
+    it("numeric padding still uses the shorthand bridge key (no regression)", () => {
+        applyChangedProps(makeInstance(), {}, { padding: 12 });
+        const calls = setFlexCallsKey(bridge, 'padding');
+        expect(calls).toEqual([{ fn: 'setFlex', args: ['k', 'padding', 12] }]);
+        // No per-edge fan-out for numeric input.
+        expect(setFlexCallsKey(bridge, 'padding_top')).toHaveLength(0);
+    });
+});
+
+describe('[wave2-rn] margin shorthand string forms', () => {
+    it("margin: 'auto' fans out to four per-edge auto calls", () => {
+        applyChangedProps(makeInstance(), {}, { margin: 'auto' });
+        expect(setFlexCallsKey(bridge, 'margin_top')[0].args[2]).toBe('auto');
+        expect(setFlexCallsKey(bridge, 'margin_right')[0].args[2]).toBe('auto');
+        expect(setFlexCallsKey(bridge, 'margin_bottom')[0].args[2]).toBe('auto');
+        expect(setFlexCallsKey(bridge, 'margin_left')[0].args[2]).toBe('auto');
+    });
+
+    it("margin: '5%' fans out as percent strings", () => {
+        applyChangedProps(makeInstance(), {}, { margin: '5%' });
+        expect(setFlexCallsKey(bridge, 'margin_top')[0].args[2]).toBe('5%');
+        expect(setFlexCallsKey(bridge, 'margin_left')[0].args[2]).toBe('5%');
+    });
+
+    it("margin: '0 auto' centers (top/bottom 0, left/right auto)", () => {
+        applyChangedProps(makeInstance(), {}, { margin: '0 auto' });
+        expect(setFlexCallsKey(bridge, 'margin_top')[0].args[2]).toBe(0);
+        expect(setFlexCallsKey(bridge, 'margin_right')[0].args[2]).toBe('auto');
+        expect(setFlexCallsKey(bridge, 'margin_bottom')[0].args[2]).toBe(0);
+        expect(setFlexCallsKey(bridge, 'margin_left')[0].args[2]).toBe('auto');
+    });
+
+    it("numeric margin still uses the shorthand bridge key (no regression)", () => {
+        applyChangedProps(makeInstance(), {}, { margin: 8 });
+        expect(setFlexCallsKey(bridge, 'margin')).toEqual([{ fn: 'setFlex', args: ['k', 'margin', 8] }]);
+    });
+});
+
+describe('[wave2-rn] width/height percent forwarding (rn.2 — already wired, regression coverage)', () => {
+    it("width: '50%' flows to setFlex(width, '50%')", () => {
+        applyChangedProps(makeInstance(), {}, { width: '50%' });
+        expect(setFlexCallsKey(bridge, 'width')).toEqual([{ fn: 'setFlex', args: ['k', 'width', '50%'] }]);
+    });
+});
+
+describe('[wave2-rn] fontWeight numeric weights', () => {
+    function fwCall(): { fn: string; args: unknown[] } | undefined {
+        return bridge.calls.find((c) => c.fn === 'setFontWeight');
+    }
+    it("'100' resolves to 100", () => {
+        applyChangedProps(makeInstance('k', 'Label'), {}, { fontWeight: '100' });
+        expect(fwCall()?.args).toEqual(['k', 100]);
+    });
+    it("'500' resolves to 500", () => {
+        applyChangedProps(makeInstance('k', 'Label'), {}, { fontWeight: '500' });
+        expect(fwCall()?.args).toEqual(['k', 500]);
+    });
+    it("'700' resolves to 700", () => {
+        applyChangedProps(makeInstance('k', 'Label'), {}, { fontWeight: '700' });
+        expect(fwCall()?.args).toEqual(['k', 700]);
+    });
+    it("'900' resolves to 900", () => {
+        applyChangedProps(makeInstance('k', 'Label'), {}, { fontWeight: '900' });
+        expect(fwCall()?.args).toEqual(['k', 900]);
+    });
+});
+
+describe('[wave2-rn] lineHeight unitless multiplier', () => {
+    function lhCall(): { fn: string; args: unknown[] } | undefined {
+        return bridge.calls.find((c) => c.fn === 'setLineHeight');
+    }
+
+    it("lineHeight: 1.5 with fontSize: 16 resolves to 24", () => {
+        const inst = makeInstance('k', 'Label', { fontSize: 16, lineHeight: 1.5 });
+        applyAllProps(inst);
+        expect(lhCall()?.args).toEqual(['k', 24]);
+    });
+
+    it("lineHeight: 1.5 with no fontSize defaults via 14 → 21", () => {
+        const inst = makeInstance('k', 'Label', { lineHeight: 1.5 });
+        applyAllProps(inst);
+        expect(lhCall()?.args).toEqual(['k', 21]);
+    });
+
+    it("lineHeight: 24 (large value) flows through as absolute pixels", () => {
+        applyChangedProps(makeInstance('k', 'Label'), {}, { lineHeight: 24 });
+        expect(lhCall()?.args).toEqual(['k', 24]);
+    });
+
+    it("lineHeight: '1.25' (numeric string) treated as multiplier", () => {
+        const inst = makeInstance('k', 'Label', { fontSize: 20, lineHeight: '1.25' });
+        applyAllProps(inst);
+        expect(lhCall()?.args).toEqual(['k', 25]);
+    });
+
+    it("lineHeight: '24px' strips suffix and treats as absolute", () => {
+        applyChangedProps(makeInstance('k', 'Label'), {}, { lineHeight: '24px' });
+        expect(lhCall()?.args).toEqual(['k', 24]);
+    });
+});
+
+describe('[wave2-rn] cursor pass-through (auto + custom)', () => {
+    it("cursor: 'auto' forwards verbatim", () => {
+        applyChangedProps(makeInstance(), {}, { cursor: 'auto' });
+        expect(bridge.calls.find(c => c.fn === 'setCursor')?.args).toEqual(['k', 'auto']);
+    });
+});
+
+describe('[wave2-rn] textDecorationLine compound', () => {
+    it("'underline line-through' forwards verbatim to setTextDecoration", () => {
+        applyChangedProps(makeInstance('k', 'Label'), {}, { textDecorationLine: 'underline line-through' });
+        const c = bridge.calls.find(x => x.fn === 'setTextDecoration');
+        expect(c?.args).toEqual(['k', 'underline line-through']);
+    });
+});
+
+describe('[wave2-rn] boxShadow multi-shadow', () => {
+    function shadowCalls() {
+        return bridge.calls.filter((c) => c.fn === 'setBoxShadow');
+    }
+
+    it("two shadows separated by comma dispatch two setBoxShadow calls", () => {
+        applyChangedProps(makeInstance(), {}, {
+            boxShadow: '2px 2px 4px black, 0px 0px 8px red',
+        });
+        const calls = shadowCalls();
+        expect(calls).toHaveLength(2);
+        expect(calls[0].args).toEqual(['k', 2, 2, 4, 0, 'black', false]);
+        expect(calls[1].args).toEqual(['k', 0, 0, 8, 0, 'red', false]);
+    });
+
+    it("commas inside rgba(...) literals don't split a single shadow", () => {
+        applyChangedProps(makeInstance(), {}, {
+            boxShadow: '2px 4px 8px rgba(0,0,0,0.3), 0px 0px 4px rgba(255,0,0,0.5)',
+        });
+        const calls = shadowCalls();
+        expect(calls).toHaveLength(2);
+        expect(calls[0].args[5]).toBe('rgba(0,0,0,0.3)');
+        expect(calls[1].args[5]).toBe('rgba(255,0,0,0.5)');
+    });
+
+    it("inset keyword on one shadow doesn't leak to the next", () => {
+        applyChangedProps(makeInstance(), {}, {
+            boxShadow: 'inset 1px 2px 3px black, 4px 5px 6px red',
+        });
+        const calls = shadowCalls();
+        expect(calls).toHaveLength(2);
+        expect(calls[0].args[6]).toBe(true);
+        expect(calls[1].args[6]).toBe(false);
+    });
+
+    it("single-shadow input still emits a single call (no regression)", () => {
+        applyChangedProps(makeInstance(), {}, { boxShadow: '2px 4px 8px rgba(0,0,0,0.3)' });
+        expect(shadowCalls()).toHaveLength(1);
+    });
+});
+
+describe('[wave2-rn] borderRadius elliptical x/y', () => {
+    it("borderRadius: { x: 10, y: 6 } degrades to averaged uniform 8", () => {
+        applyChangedProps(makeInstance(), {}, { borderRadius: { x: 10, y: 6 } });
+        expect(bridge.calls.find(c => c.fn === 'setBorderRadius')?.args).toEqual(['k', 8]);
+    });
+
+    it("borderTopLeftRadius: { x: 12, y: 4 } uses averaged uniform 8", () => {
+        applyChangedProps(makeInstance(), {}, { borderTopLeftRadius: { x: 12, y: 4 } });
+        expect(bridge.calls.find(c => c.fn === 'setBorderTopLeftRadius')?.args).toEqual(['k', 8]);
+    });
+
+    it("borderRadius: 12 (numeric) flows through unchanged (no regression)", () => {
+        applyChangedProps(makeInstance(), {}, { borderRadius: 12 });
+        expect(bridge.calls.find(c => c.fn === 'setBorderRadius')?.args).toEqual(['k', 12]);
+    });
+});
+
+describe('[wave2-rn] viewBox SVG-style string form', () => {
+    function vbCall(): { fn: string; args: unknown[] } | undefined {
+        return bridge.calls.find((c) => c.fn === 'setSvgViewBox');
+    }
+
+    it("'0 0 24 24' extracts (24, 24) as width/height", () => {
+        applyChangedProps(makeInstance('k', 'SvgPath'), {}, { viewBox: '0 0 24 24' });
+        expect(vbCall()?.args).toEqual(['k', 24, 24]);
+    });
+
+    it("'-10 -10 100 50' picks up the trailing two tokens", () => {
+        applyChangedProps(makeInstance('k', 'SvgPath'), {}, { viewBox: '-10 -10 100 50' });
+        expect(vbCall()?.args).toEqual(['k', 100, 50]);
+    });
+
+    it("comma-separated form still parses", () => {
+        applyChangedProps(makeInstance('k', 'SvgPath'), {}, { viewBox: '0,0,32,32' });
+        expect(vbCall()?.args).toEqual(['k', 32, 32]);
+    });
+
+    it("two-token string '40 20' becomes (40, 20)", () => {
+        applyChangedProps(makeInstance('k', 'SvgPath'), {}, { viewBox: '40 20' });
+        expect(vbCall()?.args).toEqual(['k', 40, 20]);
+    });
+
+    it("array form still works (no regression)", () => {
+        applyChangedProps(makeInstance('k', 'SvgPath'), {}, { viewBox: [16, 16] as [number, number] });
+        expect(vbCall()?.args).toEqual(['k', 16, 16]);
+    });
+});


### PR DESCRIPTION
## Summary

Closes 17 cheap value-coverage gaps the harness was flagging on the rn surface. Lifts rn from **PASS 80→89** (66.67%→74.17%, +7.50pp) and **DIVERGE 25→16** (-36% reduction) without any paint-side changes.

All changes live in `packages/pulp-react/src/prop-applier.ts` + `types.ts` plus matching catalog updates in `compat.json`.

## Wiring changes (`prop-applier.ts`)

- **`padding` shorthand string forms** (`'5%'`, `'10px 20px'`, etc.) fan out to per-edge bridge keys (which already accept percent via Yoga's `YGNodeStyleSetPaddingPercent`). Numeric values still take the single-call shorthand path.
- **`margin` shorthand string forms** (`'auto'`, `'5%'`, `'0 auto'`) fan out to the per-edge bridge keys (which honor `YGNodeStyleSetMarginAuto` for centering). Numeric values unchanged.
- **`lineHeight` unitless multiplier** (e.g. `lineHeight: 1.5`) resolves to `fontSize * multiplier` at dispatch time. Threshold of 8 separates multipliers from absolute pixels (RN ports + design-tool exports cluster at <2 multipliers vs 14-32px absolutes).
- **`boxShadow` multi-shadow comma-separated lists** dispatch one `setBoxShadow` call per parsed shadow. Split respects paren depth so `rgba(0,0,0,0.3)` color literals don't get cut.
- **`borderRadius` (and per-corner variants) elliptical `{ x, y }`** form (RN Fabric) flows through, degraded to averaged uniform radius pending `SkRRect::setRectXY` paint-side wiring.
- **`viewBox` SVG-spec `'min-x min-y w h'`** string form (and `'w h'`) parses with comma- or space-separated tokens. The bridge consumes the trailing two tokens as `(width, height)`.
- **`fontWeight` numeric strings** (`'100'..'900'`) regression coverage added.
- **`cursor: 'auto'`** and **`textDecorationLine: 'underline line-through'`** compound regression coverage added.

## Type changes (`types.ts`)

- `padding` / `margin` shorthands widened to `number | string`.
- `borderRadius` and per-corner variants accept `{ x: number; y: number }`.
- `viewBox` accepts the SVG-spec string form.

## Catalog changes (`compat.json` rn surface)

| Entry | Before | After |
|---|---|---|
| `borderBottomWidth` / `LeftWidth` / `RightWidth` / `TopWidth` / `Width` (5) | partial; unsup=`%/em/rem` | **supported** (spec-invalid drift dropped per yoga #1622 ground truth) |
| `padding` | partial; unsup=`%` | **supported** (per-edge fan-out) |
| `margin` | partial; unsup=`auto`,`string` | **supported** (per-edge fan-out) |
| `lineHeight` | partial; unsup=`unitless multiplier` | **supported** (resolver wired) |
| `viewBox` | partial; unsup=SVG-style string | **supported** (string parser wired) |
| `boxShadow` | partial; unsup=multi-shadow,BoxShadowValue array | partial; unsup=BoxShadowValue array (multi-shadow wired) |
| `borderBottomLeftRadius` / `BottomRightRadius` / `TopLeftRadius` / `TopRightRadius` / `Radius` shorthand (5) | partial; unsup=`%`,elliptical x/y | partial; unsup=`%` (elliptical wired) |
| `fontWeight` / `cursor` / `textDecorationLine` (3) | already supported | tests-reference added |

The remaining 16 rn DIVERGEs after this PR are honest deferred gaps (paint-side blockers like `%` on border-radius, `currentColor` keyword, `vh` viewport units, font-registry / HarfBuzz dependencies, `BoxShadowValue` RN array form).

## Test plan
- [x] `compat.json` parses (`python3 -c "import json; json.load(open('compat.json'))"`)
- [x] All 330 prop-applier tests pass (`cd packages/pulp-react && npm test -- --run`)
- [x] 31 new `[wave2-rn]` band tests cover every wired entry
- [x] `tools/harness/verifier.py --surface=rn`: PASS 80→89, DIVERGE 25→16, drift_count=0
- [x] `tools/scripts/compat_sync_check.py`: clean
- [ ] CI green
