### PR TITLE
feat(html): Wave 3 — ARIA setters + minimal querySelector engine

### DIFF
--- a/compat.json
+++ b/compat.json
@@ -5913,18 +5913,20 @@
   "html": {
     "_note": "Populated 2026-05-04 from web-compat-element.js (~836 LOC) and web-compat-document.js (~1527 LOC). Tracks the DOM-lite consumer surface: createElement / setAttribute / appendChild / addEventListener / Element / HTMLElement attributes / dataset / classList / events / style sheet support. Spec source: https://developer.mozilla.org/en-US/docs/Web/API/Element + HTMLElement subclasses. Recent additions since 2026-04-30: html/svg width/height attribute replay (#1347 / pulp #1147), html/span/p/label widget mapping confirmed (Label widget, not View), html/style :hover stylesheet support (#1345 / pulp #1149 part b). 2026-05-05 hygiene (pulp #1434): html/ARIA flipped missing \u2192 partial \u2014 storage works (parallel to html/Element_disabled); platform-bridge routing tracked under #1476.",
     "html/ARIA": {
-      "status": "partial",
-      "mapsTo": "ARIA attributes (aria-label, role, etc.) are stored in _attributes via setAttribute and round-trip through getAttribute; the html-compat layer does NOT yet forward them onto the platform accessibility bridge (which already exists \u2014 macOS/iOS/Android done, Windows UIA + Linux AT-SPI in flight under #217).",
+      "status": "supported",
+      "mapsTo": "Element.setAttribute('aria-label', ...) -> bridge.setAccessibilityLabel(id, value) -> View::set_access_label(); Element.setAttribute('role', ...) -> bridge.setAccessibilityRole(id, role) -> View::set_access_role() with ARIA->AccessRole bucket mapping (slider/checkbox/switch/radio/img/progressbar/meter/heading/label collapse onto Pulp's enum; the long ARIA tail collapses to AccessRole::group). Storage round-trips through getAttribute either way. macOS NSAccessibility bridge in core/view/platform/mac/accessibility_mac.mm reads these slots directly; AccessibilityTree snapshot picks them up cross-platform.",
       "supportedValues": [
+        "aria-label -> setAccessibilityLabel routing",
+        "role -> setAccessibilityRole routing",
         "aria-* attribute storage / read-back via setAttribute / getAttribute"
       ],
       "unsupportedValues": [
-        "aria-label -> bridge.setAccessibilityLabel routing",
-        "role -> bridge.setAccessibilityRole routing",
-        "aria-pressed/checked/disabled/hidden -> bridge.setAccessibilityState routing"
+        "aria-pressed / aria-checked / aria-disabled / aria-hidden -> bridge.setAccessibilityState routing (state slot not yet on View)"
       ],
-      "tests": [],
-      "notes": "Storage portion of the html-compat ARIA surface works (parallel to html/Element_disabled \u2014 stored, not routed). Platform routing tracked under #1476; the broader a11y workstream is #217.",
+      "tests": [
+        "test/test_widget_bridge.cpp: HTML aria-label + role attributes route to View access slots [wave3-html]"
+      ],
+      "notes": "Wave 3 html.2 \u2014 setAccessibilityLabel / setAccessibilityRole bridge fns wired; web-compat-element.js setAttribute() fast-paths aria-label and role. Replay path on _ensureNative + _reparentNative covers the React/JSX setAttribute-before-mount commit order. macOS NSAccessibility wired; Linux AT-SPI / Windows UIA platform routing remains storage-only (tracked under #217).",
       "issue": "1476"
     },
     "html/DocumentFragment": {
@@ -6312,21 +6314,34 @@
       "issue": ""
     },
     "html/document_querySelector": {
-      "status": "partial",
-      "mapsTo": "document.querySelector \u2014 class / id / tag selectors only.",
+      "status": "supported",
+      "mapsTo": "document.querySelector / querySelectorAll \u2014 _parseSelector + _matchesSelector in web-compat-document.js. Tokenizes the rightmost simple selector (tag / #id / .class / [attr] / [attr=value] / [attr^=v] / [attr$=v] / [attr*=v] / [attr|=v] / [attr~=v]) plus descendant (`a b`) and child (`a > b`) combinators, walking left to right with bracket-aware splitting.",
       "supportedValues": [
         "#id",
         ".class",
-        "tagname"
+        "tagname",
+        "[attr]",
+        "[attr=value]",
+        "[attr^=value]",
+        "[attr$=value]",
+        "[attr*=value]",
+        "[attr|=value]",
+        "[attr~=value]",
+        "compound (tag.class, tag#id, tag[attr], #id.class[attr])",
+        "descendant (a b)",
+        "child (a > b)"
       ],
       "unsupportedValues": [
-        "complex selectors",
-        "attribute selectors",
-        "pseudo-classes",
-        "combinators"
+        "pseudo-classes (:hover, :nth-child, :not, :is, :where, ...)",
+        "pseudo-elements (::before, ::after)",
+        "sibling combinators (+, ~)",
+        "selector lists (a, b)",
+        "attribute case-insensitive flag ([attr=value i])"
       ],
-      "tests": [],
-      "notes": "",
+      "tests": [
+        "test/test_widget_bridge.cpp: querySelector minimal selector engine [wave3-html]"
+      ],
+      "notes": "Wave 3 html.3 \u2014 tag/.class/#id/[attr]/[attr=value]/descendant/child wired; pseudo-classes (:hover, :nth-child) and sibling combinators not implemented (parser tolerates trailing `:pseudo` for forward compat \u2014 it's stored but unmatched). Selectors that include unsupported features fall through to no-match rather than throwing. CSS StyleSheet `_applyTo` rides the same code path.",
       "issue": ""
     },
     "html/footer": {

--- a/core/view/js/web-compat-document.js
+++ b/core/view/js/web-compat-document.js
@@ -293,41 +293,124 @@ function _setupPseudoActive(el, props) {
 // Selector parsing and matching
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// pulp Wave 3 html.3 — minimal CSS selector parser.
+//
+// Supports the subset that React / Three.js helper code actually uses
+// in practice:
+//   tag           — element.tagName.toLowerCase() === tag
+//   #id           — element.id === id
+//   .class        — element.classList.contains(class)
+//   [attr]        — element.hasAttribute(attr)
+//   [attr=value]  — element.getAttribute(attr) === value
+//   [attr^=v]     — startsWith
+//   [attr$=v]     — endsWith
+//   [attr*=v]     — contains
+//   [attr|=v]     — value or value-prefixed-by-hyphen
+//   [attr~=v]     — token-match in whitespace-separated list
+//   compound      — tag.class, tag#id, tag[attr], #id.class.class[attr]
+//   descendant    — `a b`     (ancestor anywhere in the chain)
+//   child         — `a > b`   (immediate parent only)
+//
+// Pseudo-classes (`:hover`, `:nth-child`, etc.) are recognised by the
+// tokenizer for forward-compat (so they don't blow up the parser) but
+// are stored unmatched — the gotcha string in compat.json keeps them
+// listed as unsupported.  Sibling combinators (`+`, `~`) are not
+// implemented; selectors that include them silently fall through to
+// no-match (legacy behaviour).
 function _parseSelector(str) {
-    var result = { tag: null, id: null, classes: [], pseudo: null, parent: null, direct: false };
+    var result = { tag: null, id: null, classes: [], attrs: [], pseudo: null,
+                   parent: null, direct: false };
 
-    // Split pseudo-class
-    var pseudoIdx = str.indexOf(":");
+    if (!str) return result;
+    str = String(str);
+
+    // Strip trailing pseudo-class (`:hover`, `:nth-child(2n)`, …) — pulp
+    // doesn't implement them, but we tolerate them at the tokenizer
+    // level so a real-world selector like `div.foo:hover` still
+    // matches `div.foo` instead of refusing to parse.
+    var pseudoIdx = str.search(/(?<!\\):/);
     var mainPart = str;
     if (pseudoIdx >= 0) {
         result.pseudo = str.slice(pseudoIdx + 1);
         mainPart = str.slice(0, pseudoIdx);
     }
+    mainPart = mainPart.trim();
 
-    // Check for descendant/child combinators
-    if (mainPart.indexOf(" > ") >= 0) {
-        var cp = mainPart.split(" > ");
-        result.parent = _parseSelector(cp.slice(0, -1).join(" > "));
-        result.direct = true;
-        mainPart = cp[cp.length - 1].trim();
-    } else if (mainPart.indexOf(" ") >= 0) {
-        var sp = mainPart.split(/\s+/);
-        result.parent = _parseSelector(sp.slice(0, -1).join(" "));
-        result.direct = false;
-        mainPart = sp[sp.length - 1].trim();
+    // Check for child / descendant combinators on the OUTERMOST level
+    // (combinators inside `[attr=" > "]` are protected by the bracket
+    // check below since we scan left-to-right respecting brackets).
+    var splitIdx = -1;
+    var splitDirect = false;
+    var depth = 0;
+    for (var ci = mainPart.length - 1; ci >= 0; ci--) {
+        var ch = mainPart[ci];
+        if (ch === "]") depth++;
+        else if (ch === "[") depth--;
+        else if (depth === 0 && ch === ">") { splitIdx = ci; splitDirect = true; break; }
+        else if (depth === 0 && ch === " " && ci < mainPart.length - 1 &&
+                 mainPart[ci + 1] !== ">" && (ci === 0 || mainPart[ci - 1] !== ">")) {
+            splitIdx = ci; splitDirect = false;
+            // Don't break — keep walking left to find the *rightmost*
+            // descendant boundary so the parent selector accumulates
+            // correctly for `a b c` -> parent=`a b`, child=`c`.
+            break;
+        }
     }
 
-    // Parse tag, id, classes from main part
-    var parts = mainPart.match(/^([a-zA-Z][\w-]*)?([#.][^#.]+)*/);
-    if (parts && parts[0]) {
-        var tokens = mainPart.match(/([#.][a-zA-Z][\w-]*)|^([a-zA-Z][\w-]*)/g);
-        if (tokens) {
-            for (var i = 0; i < tokens.length; i++) {
-                var t = tokens[i];
-                if (t[0] === "#") result.id = t.slice(1);
-                else if (t[0] === ".") result.classes.push(t.slice(1));
-                else result.tag = t.toLowerCase();
+    if (splitIdx >= 0) {
+        var leftRaw = mainPart.slice(0, splitIdx).trim();
+        var rightRaw = mainPart.slice(splitIdx + 1).trim();
+        if (leftRaw.length && rightRaw.length) {
+            result.parent = _parseSelector(leftRaw);
+            result.direct = splitDirect;
+            mainPart = rightRaw;
+        }
+    }
+
+    // Tokenize `tag`, `#id`, `.class`, `[attr...]` from the rightmost
+    // simple selector.  Regex covers all four forms in one pass; brackets
+    // are matched non-greedily so two adjacent `[attr][attr2]` work.
+    var tokenRe = /\[[^\]]+\]|#[A-Za-z_][\w-]*|\.[A-Za-z_][\w-]*|[A-Za-z_][\w-]*/g;
+    var match;
+    while ((match = tokenRe.exec(mainPart)) !== null) {
+        var t = match[0];
+        if (!t) continue;
+        if (t[0] === "#") {
+            result.id = t.slice(1);
+        } else if (t[0] === ".") {
+            result.classes.push(t.slice(1));
+        } else if (t[0] === "[") {
+            // Strip `[` and `]`
+            var inner = t.slice(1, -1);
+            // Recognised operators (longest first so `^=` doesn't eat `=`):
+            var op = null;
+            var opIdx = -1;
+            var ops = ["^=", "$=", "*=", "|=", "~=", "="];
+            for (var oi = 0; oi < ops.length; oi++) {
+                var idx = inner.indexOf(ops[oi]);
+                if (idx >= 0 && (opIdx < 0 || idx < opIdx)) {
+                    op = ops[oi]; opIdx = idx;
+                }
             }
+            if (op === null) {
+                result.attrs.push({ name: inner.trim(), op: null, value: null });
+            } else {
+                var aname = inner.slice(0, opIdx).trim();
+                var aval = inner.slice(opIdx + op.length).trim();
+                // Strip optional surrounding quotes (single or double).
+                if (aval.length >= 2 &&
+                    ((aval[0] === '"' && aval[aval.length - 1] === '"') ||
+                     (aval[0] === "'" && aval[aval.length - 1] === "'"))) {
+                    aval = aval.slice(1, -1);
+                }
+                result.attrs.push({ name: aname, op: op, value: aval });
+            }
+        } else {
+            // Bare identifier — first one is the tag.  Multiple bare
+            // identifiers in a single compound selector are spec-invalid
+            // (`div span` is a descendant combinator, not compound) so
+            // any later bare token is ignored.
+            if (result.tag === null) result.tag = t.toLowerCase();
         }
     }
 
@@ -344,6 +427,47 @@ function _matchesSelector(el, parsed) {
     // Match classes
     for (var i = 0; i < parsed.classes.length; i++) {
         if (!el.classList.contains(parsed.classes[i])) return false;
+    }
+
+    // pulp Wave 3 html.3 — attribute selectors.
+    if (parsed.attrs && parsed.attrs.length) {
+        for (var ai = 0; ai < parsed.attrs.length; ai++) {
+            var a = parsed.attrs[ai];
+            if (a.op === null) {
+                if (!el.hasAttribute(a.name)) return false;
+                continue;
+            }
+            var av = el.getAttribute(a.name);
+            if (av === null || av === undefined) return false;
+            switch (a.op) {
+                case "=":  if (av !== a.value) return false; break;
+                case "^=": if (a.value === "" || String(av).indexOf(a.value) !== 0) return false; break;
+                case "$=": {
+                    if (a.value === "") return false;
+                    var s = String(av);
+                    if (s.length < a.value.length) return false;
+                    if (s.slice(s.length - a.value.length) !== a.value) return false;
+                    break;
+                }
+                case "*=": if (a.value === "" || String(av).indexOf(a.value) < 0) return false; break;
+                case "|=": {
+                    var s2 = String(av);
+                    if (s2 !== a.value && s2.indexOf(a.value + "-") !== 0) return false;
+                    break;
+                }
+                case "~=": {
+                    if (!a.value || /\s/.test(a.value)) return false;
+                    var tokens = String(av).split(/\s+/);
+                    var foundTok = false;
+                    for (var ti = 0; ti < tokens.length; ti++) {
+                        if (tokens[ti] === a.value) { foundTok = true; break; }
+                    }
+                    if (!foundTok) return false;
+                    break;
+                }
+                default: return false;
+            }
+        }
     }
 
     // Match parent constraint

--- a/core/view/js/web-compat-dom-ops.js
+++ b/core/view/js/web-compat-dom-ops.js
@@ -49,6 +49,13 @@ if (!Element.prototype.appendChild ||
         if (typeof __replayMediaAttributes__ === "function") {
             __replayMediaAttributes__(child);
         }
+        // pulp Wave 3 html.2 / #1476 — same flush for ARIA attributes
+        // (`aria-label` / `role`) captured before mount. Without this
+        // the React commit order (setAttribute -> appendChild) leaves
+        // the access slots empty even though _attributes carries them.
+        if (typeof __replayAriaAttributes__ === "function") {
+            __replayAriaAttributes__(child);
+        }
         child.style._flushAll();
         child._reapplyStylesheets();
         // pulp #1323 — `<style>` elements receive CSS via either direct
@@ -104,6 +111,14 @@ if (!Element.prototype.appendChild ||
         __domAppend(this._id, newChild._id, newChild.tagName.toLowerCase());
         newChild._nativeCreated = true;
         if (newChild._textContent) setText(newChild._id, newChild._textContent);
+        // pulp #1147 / Wave 3 html.2 — same pre-mount attribute replay
+        // path as appendChild, including ARIA attributes.
+        if (typeof __replayMediaAttributes__ === "function") {
+            __replayMediaAttributes__(newChild);
+        }
+        if (typeof __replayAriaAttributes__ === "function") {
+            __replayAriaAttributes__(newChild);
+        }
         newChild.style._flushAll();
         newChild._reapplyStylesheets();
         return newChild;

--- a/core/view/js/web-compat-element.js
+++ b/core/view/js/web-compat-element.js
@@ -146,6 +146,11 @@ Element.prototype._ensureNative = function() {
     if (typeof __replayMediaAttributes__ === "function") {
         __replayMediaAttributes__(this);
     }
+    // pulp Wave 3 html.2 / #1476 — replay any ARIA attributes that were
+    // set on this element before the native widget existed.
+    if (typeof __replayAriaAttributes__ === "function") {
+        __replayAriaAttributes__(this);
+    }
 };
 
 // pulp #1147 — shared helper that maps presentational HTML attributes
@@ -166,6 +171,26 @@ function __replayMediaAttributes__(el) {
     }
     if (h !== undefined) {
         var ph = parseFloat(h); if (ph === ph) setFlex(el._id, "height", ph);
+    }
+}
+
+// pulp Wave 3 html.2 / #1476 — replay ARIA attributes (`aria-label` /
+// `role`) when the native widget comes online.  React/JSX commits
+// attributes before `appendChild` mounts the node, so by the time
+// `setAttribute('aria-label', ...)` runs the bridge has no native id
+// yet; we capture the value in `_attributes` (the existing path) and
+// flush it through the bridge once `_nativeCreated` is true.
+// Idempotent: safe to call from `_ensureNative` and from any later
+// mount path (`appendChild`, `insertBefore`, etc.).
+function __replayAriaAttributes__(el) {
+    if (!el || !el._nativeCreated || !el._attributes) return;
+    var label = el._attributes["aria-label"];
+    if (label !== undefined && typeof setAccessibilityLabel === "function") {
+        setAccessibilityLabel(el._id, String(label));
+    }
+    var role = el._attributes["role"];
+    if (role !== undefined && typeof setAccessibilityRole === "function") {
+        setAccessibilityRole(el._id, String(role));
     }
 }
 
@@ -615,6 +640,25 @@ Element.prototype.setAttribute = function(name, value) {
     else if (name === "for" && this.tagName === "LABEL") {
         this._installLabelForRouting();
     }
+    // pulp Wave 3 html.2 / #1476 — ARIA accessibility setters.
+    // `aria-label` / `role` round-trip through native View::access_label_
+    // and View::access_role_ so the macOS NSAccessibility bridge (and
+    // the cross-platform AccessibilityTree snapshot) can read them.
+    // Other ARIA attributes still store via _attributes for getAttribute
+    // round-tripping; only the two with a Pulp storage slot are
+    // forwarded today.  The bridge is a no-op when the widget hasn't
+    // been created yet — a follow-up appendChild path replays the
+    // attribute through the same code path.
+    else if (name === "aria-label") {
+        if (this._nativeCreated && typeof setAccessibilityLabel === "function") {
+            setAccessibilityLabel(this._id, String(value));
+        }
+    }
+    else if (name === "role") {
+        if (this._nativeCreated && typeof setAccessibilityRole === "function") {
+            setAccessibilityRole(this._id, String(value));
+        }
+    }
 };
 
 Element.prototype.getAttribute = function(name) {
@@ -1052,6 +1096,10 @@ function _reparentNative(child, parentId) {
     // node is recreated so the new flex sizing matches the original.
     if (typeof __replayMediaAttributes__ === "function") {
         __replayMediaAttributes__(child);
+    }
+    // pulp Wave 3 html.2 / #1476 — replay ARIA attributes after reparent.
+    if (typeof __replayAriaAttributes__ === "function") {
+        __replayAriaAttributes__(child);
     }
 
     // Recursively reparent children

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1355,6 +1355,75 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
+    // ── Accessibility (pulp Wave 3 html.2 / #1476) ───────────────────────
+    //
+    // setAccessibilityLabel / setAccessibilityRole are the bridge-side
+    // entry points the html-compat layer calls when JS does
+    //   el.setAttribute('aria-label', '...')
+    //   el.setAttribute('role',       '...').
+    //
+    // Storage lives on View::access_label_ / View::access_role_ (the
+    // existing widget-level a11y slots — already consumed by the macOS
+    // NSAccessibility bridge in core/view/platform/mac/accessibility_mac.mm
+    // and the cross-platform AccessibilityTree snapshot in
+    // accessibility_tree.cpp).  Linux AT-SPI / Windows UIA platform
+    // routing remains a separate concern (#217) — the bridge entry point
+    // is platform-agnostic; JS-side authors can rely on the same surface
+    // on every platform and the storage round-trips through getAttribute
+    // either way.
+    //
+    // Role mapping mirrors the W3C ARIA -> AccessRole bucket used by the
+    // existing widget setters: ARIA roles outside Pulp's enum collapse to
+    // `group` (the most neutral container role) so VoiceOver still
+    // announces the element as an interactive group rather than an
+    // unknown blob, and the JS-author intent ("yes, this is exposed to
+    // assistive tech") is preserved.  Unknown / empty role clears the
+    // role back to AccessRole::none.
+    engine_.register_function("setAccessibilityLabel",
+                              [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto label = args.get<std::string>(1, "");
+        auto it = widgets_.find(id);
+        if (it != widgets_.end()) it->second->set_access_label(std::move(label));
+        return choc::value::Value();
+    });
+
+    engine_.register_function("setAccessibilityRole",
+                              [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto role = args.get<std::string>(1, "");
+        auto it = widgets_.find(id);
+        if (it == widgets_.end()) return choc::value::Value();
+
+        // ARIA role token -> View::AccessRole bucket.  Mirrors the spirit
+        // of NSAccessibilityRole / UIA control-type mapping: collapse the
+        // long ARIA tail onto the small Pulp enum, but keep semantic
+        // hints alive so the platform layer announces something sensible.
+        View::AccessRole r = View::AccessRole::none;
+        if (role.empty() || role == "none" || role == "presentation") {
+            r = View::AccessRole::none;
+        } else if (role == "slider") {
+            r = View::AccessRole::slider;
+        } else if (role == "checkbox" || role == "switch" || role == "radio") {
+            r = View::AccessRole::toggle;
+        } else if (role == "img" || role == "image") {
+            r = View::AccessRole::image;
+        } else if (role == "progressbar" || role == "meter") {
+            r = View::AccessRole::meter;
+        } else if (role == "heading" || role == "label" ||
+                   role == "text"    || role == "paragraph") {
+            r = View::AccessRole::label;
+        } else {
+            // Everything else (button, link, navigation, region, dialog,
+            // listbox, menu, ...) collapses to `group` — VoiceOver
+            // announces it as a generic interactive group, which is
+            // strictly better than treating it as untyped.
+            r = View::AccessRole::group;
+        }
+        it->second->set_access_role(r);
+        return choc::value::Value();
+    });
+
     // registerHover(id) — enables "mouseenter"/"mouseleave" JS callbacks (CSS :hover)
     engine_.register_function("registerHover", [this](choc::javascript::ArgumentList args) {
         auto id = args.get<std::string>(0, "");

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -8381,6 +8381,28 @@ TEST_CASE("CSSStyleDeclaration mixBlendMode plus-lighter -> kPlus",
     ScriptEngine engine;
     View root;
     root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        createPanel('a', '');
+        createPanel('b', '');
+        var sa = new CSSStyleDeclaration({ _id: 'a', _nativeCreated: true });
+        var sb = new CSSStyleDeclaration({ _id: 'b', _nativeCreated: true });
+        sa._applyProperty('mixBlendMode', 'plus-lighter');
+        sb._applyProperty('mixBlendMode', 'plus-darker');
+    )");
+
+    auto* a = bridge.widget("a");
+    auto* b = bridge.widget("b");
+    REQUIRE(a != nullptr);
+    REQUIRE(b != nullptr);
+    REQUIRE(a->mix_blend_mode() == BM::lighter);
+    REQUIRE(b->mix_blend_mode() == BM::lighter);
+    REQUIRE(a->has_non_default_blend_mode());
+    REQUIRE(b->has_non_default_blend_mode());
+}
+
 // ── pulp Wave 2 canvas2d cheap wiring (DIVERGE → PASS) ───────────────────
 //
 // These tests close the loop on the five compat.json entries that flipped
@@ -8416,31 +8438,6 @@ TEST_CASE("Wave 2 canvas2d — ctx.fill('evenodd') reaches Canvas::fill_current_
     WidgetBridge bridge(engine, root, store);
 
     bridge.load_script(R"(
-        createPanel('a', '');
-        createPanel('b', '');
-        var sa = new CSSStyleDeclaration({ _id: 'a', _nativeCreated: true });
-        var sb = new CSSStyleDeclaration({ _id: 'b', _nativeCreated: true });
-        sa._applyProperty('mixBlendMode', 'plus-lighter');
-        sb._applyProperty('mixBlendMode', 'plus-darker');
-    )");
-
-    auto* a = bridge.widget("a");
-    auto* b = bridge.widget("b");
-    REQUIRE(a != nullptr);
-    REQUIRE(b != nullptr);
-    REQUIRE(a->mix_blend_mode() == BM::lighter);
-    REQUIRE(b->mix_blend_mode() == BM::lighter);
-    REQUIRE(a->has_non_default_blend_mode());
-    REQUIRE(b->has_non_default_blend_mode());
-}
-
-TEST_CASE("CSSStyleDeclaration borderWidth keyword expansion thin/medium/thick",
-          "[view][bridge][css][wave2-css]") {
-    // Wave 2 css.2 — CSS Backgrounds & Borders L3 named widths.
-    // Pulp picks 1/2/4 px (slightly thinner than browsers' canonical
-    // 1/3/5 — see compat.json css/borderWidth note).
-    ScriptEngine engine;
-    View root;
         var c = document.createElement('canvas');
         c.id = 'evenodd-fill';
         c.width = 100; c.height = 100;
@@ -8476,12 +8473,13 @@ TEST_CASE("CSSStyleDeclaration borderWidth keyword expansion thin/medium/thick",
     REQUIRE(rules[1] == 0.0f);  // nonzero default
 }
 
-TEST_CASE("Wave 2 canvas2d — ctx.clip('evenodd') reaches Canvas::clip with FillRule::evenodd",
-          "[view][bridge][canvas][wave2-canvas2d]") {
+TEST_CASE("CSSStyleDeclaration borderWidth keyword expansion thin/medium/thick",
+          "[view][bridge][css][wave2-css]") {
+    // Wave 2 css.2 — CSS Backgrounds & Borders L3 named widths.
+    // Pulp picks 1/2/4 px (slightly thinner than browsers' canonical
+    // 1/3/5 — see compat.json css/borderWidth note).
     ScriptEngine engine;
     View root;
-    root.set_bounds({0, 0, 200, 200});
-    root.set_theme(Theme::dark());
     StateStore store;
     WidgetBridge bridge(engine, root, store);
 
@@ -8502,14 +8500,16 @@ TEST_CASE("Wave 2 canvas2d — ctx.clip('evenodd') reaches Canvas::clip with Fil
     REQUIRE_THAT(bridge.widget("thick")->border_width(), WithinAbs(4.0f, 0.001f));
 }
 
-TEST_CASE("CSSStyleDeclaration fontStyle oblique aliases to italic",
-          "[view][bridge][css][wave2-css]") {
-    // Wave 2 css.4 — Skia distinguishes italic-vs-oblique only via
-    // the `slnt` font variation axis, which most bundled fonts don't
-    // ship. Aliasing oblique -> italic upgrades a silent no-op to the
-    // closest visual approximation.
+TEST_CASE("Wave 2 canvas2d — ctx.clip('evenodd') reaches Canvas::clip with FillRule::evenodd",
+          "[view][bridge][canvas][wave2-canvas2d]") {
     ScriptEngine engine;
     View root;
+    root.set_bounds({0, 0, 200, 200});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
         var c = document.createElement('canvas');
         c.id = 'evenodd-clip';
         c.width = 100; c.height = 100;
@@ -8542,12 +8542,14 @@ TEST_CASE("CSSStyleDeclaration fontStyle oblique aliases to italic",
     REQUIRE(rules[1] == 0.0f);  // nonzero default
 }
 
-TEST_CASE("Wave 2 canvas2d — ctx.roundRect with 4 distinct corners produces 4 distinct radii",
-          "[view][bridge][canvas][wave2-canvas2d]") {
+TEST_CASE("CSSStyleDeclaration fontStyle oblique aliases to italic",
+          "[view][bridge][css][wave2-css]") {
+    // Wave 2 css.4 — Skia distinguishes italic-vs-oblique only via
+    // the `slnt` font variation axis, which most bundled fonts don't
+    // ship. Aliasing oblique -> italic upgrades a silent no-op to the
+    // closest visual approximation.
     ScriptEngine engine;
     View root;
-    root.set_bounds({0, 0, 200, 200});
-    root.set_theme(Theme::dark());
     StateStore store;
     WidgetBridge bridge(engine, root, store);
 
@@ -8568,12 +8570,16 @@ TEST_CASE("Wave 2 canvas2d — ctx.roundRect with 4 distinct corners produces 4 
     REQUIRE(lb->font_style() == 1);   // italic (angle ignored)
 }
 
-TEST_CASE("CSSStyleDeclaration top em/vh resolves to default font-size/viewport",
-          "[view][bridge][css][wave2-css]") {
-    // Wave 2 css.2 — em/rem default to 14 px, vh/vw default to a
-    // 600x800 viewport (matches resolveLength fallback).
+TEST_CASE("Wave 2 canvas2d — ctx.roundRect with 4 distinct corners produces 4 distinct radii",
+          "[view][bridge][canvas][wave2-canvas2d]") {
     ScriptEngine engine;
     View root;
+    root.set_bounds({0, 0, 200, 200});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
         var c = document.createElement('canvas');
         c.id = 'roundrect-4';
         c.width = 100; c.height = 100;
@@ -8616,12 +8622,12 @@ TEST_CASE("CSSStyleDeclaration top em/vh resolves to default font-size/viewport"
     REQUIRE_THAT(rrCmd.floats[5], WithinAbs(16.0f, 1e-5f));  // bl_y
 }
 
-TEST_CASE("Wave 2 canvas2d — ctx.ellipse with non-zero rotation threads through to a single ellipse command",
-          "[view][bridge][canvas][wave2-canvas2d]") {
+TEST_CASE("CSSStyleDeclaration top em/vh resolves to default font-size/viewport",
+          "[view][bridge][css][wave2-css]") {
+    // Wave 2 css.2 — em/rem default to 14 px, vh/vw default to a
+    // 600x800 viewport (matches resolveLength fallback).
     ScriptEngine engine;
     View root;
-    root.set_bounds({0, 0, 200, 200});
-    root.set_theme(Theme::dark());
     StateStore store;
     WidgetBridge bridge(engine, root, store);
 
@@ -8646,14 +8652,16 @@ TEST_CASE("Wave 2 canvas2d — ctx.ellipse with non-zero rotation threads throug
     REQUIRE_THAT(bridge.widget("d")->left(), WithinAbs(200.0f, 0.05f));
 }
 
-TEST_CASE("CSSStyleDeclaration margin shorthand honors auto + percent per token",
-          "[view][bridge][css][wave2-css]") {
-    // Wave 2 css.2 — margin shorthand re-tokenized so each edge
-    // routes through the same string-aware setFlex pathway as the
-    // per-edge longhands. `margin: auto` centers via Yoga's
-    // YGNodeStyleSetMarginAuto when paired across opposing edges.
+TEST_CASE("Wave 2 canvas2d — ctx.ellipse with non-zero rotation threads through to a single ellipse command",
+          "[view][bridge][canvas][wave2-canvas2d]") {
     ScriptEngine engine;
     View root;
+    root.set_bounds({0, 0, 200, 200});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
         var c = document.createElement('canvas');
         c.id = 'ellipse-rot';
         c.width = 100; c.height = 100;
@@ -8692,12 +8700,14 @@ TEST_CASE("CSSStyleDeclaration margin shorthand honors auto + percent per token"
     REQUIRE_THAT(eCmd.f[4], WithinAbs(static_cast<float>(M_PI / 4.0), 1e-4f));
 }
 
-TEST_CASE("Wave 2 canvas2d — ctx.strokeText routes through dedicated stroke_text command",
-          "[view][bridge][canvas][wave2-canvas2d]") {
+TEST_CASE("CSSStyleDeclaration margin shorthand honors auto + percent per token",
+          "[view][bridge][css][wave2-css]") {
+    // Wave 2 css.2 — margin shorthand re-tokenized so each edge
+    // routes through the same string-aware setFlex pathway as the
+    // per-edge longhands. `margin: auto` centers via Yoga's
+    // YGNodeStyleSetMarginAuto when paired across opposing edges.
     ScriptEngine engine;
     View root;
-    root.set_bounds({0, 0, 400, 200});
-    root.set_theme(Theme::dark());
     StateStore store;
     WidgetBridge bridge(engine, root, store);
 
@@ -8725,6 +8735,18 @@ TEST_CASE("Wave 2 canvas2d — ctx.strokeText routes through dedicated stroke_te
     REQUIRE_THAT(fb.dim_margin_bottom.value, WithinAbs(10.0f, 0.001f));
     REQUIRE(fb.dim_margin_left.unit   == DimensionUnit::px);
     REQUIRE_THAT(fb.dim_margin_left.value,   WithinAbs(20.0f, 0.001f));
+}
+
+TEST_CASE("Wave 2 canvas2d — ctx.strokeText routes through dedicated stroke_text command",
+          "[view][bridge][canvas][wave2-canvas2d]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 200});
+    root.set_theme(Theme::dark());
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
         var c = document.createElement('canvas');
         c.id = 'stroke-text';
         c.width = 200; c.height = 100;
@@ -8757,4 +8779,259 @@ TEST_CASE("Wave 2 canvas2d — ctx.strokeText routes through dedicated stroke_te
     // (the pre-#1525 approximation).
     REQUIRE(strokeTextCount == 1);
     REQUIRE(fillTextCount == 0);
+}
+
+// ── pulp Wave 3 html bundle (ARIA + querySelector) ─────────────────────
+//
+// Wave 3 html.2 / #1476: aria-label / role attributes flow through the
+// html-compat shim into View::access_label_ / View::access_role_ slots
+// that the macOS NSAccessibility bridge already consumes.  Wave 3 html.3:
+// document.querySelector accepts attribute selectors, compound selectors,
+// and descendant / child combinators in addition to the previously
+// supported tag/.class/#id forms.
+
+TEST_CASE("HTML aria-label routes to View access_label",
+          "[view][bridge][wave3-html][html-aria]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Direct bridge fn — exercises the C++ entry point JS-side
+    // setAttribute('aria-label', ...) collapses onto.
+    bridge.load_script(R"(
+        createPanel('a', '');
+        setAccessibilityLabel('a', 'Volume control');
+    )");
+
+    auto* a = bridge.widget("a");
+    REQUIRE(a != nullptr);
+    REQUIRE(a->access_label() == "Volume control");
+}
+
+TEST_CASE("HTML role attribute routes through ARIA->AccessRole bucket",
+          "[view][bridge][wave3-html][html-aria]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Mirror the seven ARIA role buckets we collapse the spec onto.
+    bridge.load_script(R"(
+        createPanel('s', '');  setAccessibilityRole('s', 'slider');
+        createPanel('cb', ''); setAccessibilityRole('cb', 'checkbox');
+        createPanel('sw', ''); setAccessibilityRole('sw', 'switch');
+        createPanel('im', ''); setAccessibilityRole('im', 'img');
+        createPanel('pb', ''); setAccessibilityRole('pb', 'progressbar');
+        createPanel('hd', ''); setAccessibilityRole('hd', 'heading');
+        createPanel('bn', ''); setAccessibilityRole('bn', 'button');
+        createPanel('un', ''); setAccessibilityRole('un', '');
+    )");
+
+    REQUIRE(bridge.widget("s")->access_role()  == View::AccessRole::slider);
+    REQUIRE(bridge.widget("cb")->access_role() == View::AccessRole::toggle);
+    REQUIRE(bridge.widget("sw")->access_role() == View::AccessRole::toggle);
+    REQUIRE(bridge.widget("im")->access_role() == View::AccessRole::image);
+    REQUIRE(bridge.widget("pb")->access_role() == View::AccessRole::meter);
+    REQUIRE(bridge.widget("hd")->access_role() == View::AccessRole::label);
+    // 'button' has no Pulp enum slot — collapses to `group`.
+    REQUIRE(bridge.widget("bn")->access_role() == View::AccessRole::group);
+    // Empty / unknown role clears to none.
+    REQUIRE(bridge.widget("un")->access_role() == View::AccessRole::none);
+}
+
+TEST_CASE("HTML setAttribute(aria-label) flushes through web-compat shim",
+          "[view][bridge][wave3-html][html-aria]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // End-to-end: createElement -> appendChild (so _nativeCreated is true)
+    // -> setAttribute('aria-label', ...) goes through the shim's fast path
+    // and reaches View::access_label_ via the bridge fn.
+    bridge.load_script(R"(
+        var d = document.createElement('div');
+        d.id = 'a11y-target';
+        document.body.appendChild(d);
+        d.setAttribute('aria-label', 'Save preset');
+        d.setAttribute('role', 'button');
+    )");
+
+    auto idVal = engine.evaluate("document.getElementById('a11y-target')._id");
+    auto id = std::string(idVal.getWithDefault<std::string_view>(""));
+    auto* v = bridge.widget(id);
+    REQUIRE(v != nullptr);
+    REQUIRE(v->access_label() == "Save preset");
+    // 'button' -> group bucket.
+    REQUIRE(v->access_role() == View::AccessRole::group);
+}
+
+TEST_CASE("HTML setAttribute before mount replays ARIA on appendChild",
+          "[view][bridge][wave3-html][html-aria]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // React commits attributes BEFORE mounting in some commit orders, so
+    // setAttribute('aria-label', ...) sees _nativeCreated === false.  The
+    // shim must replay through __replayAriaAttributes__ once the native
+    // node lands via appendChild.
+    bridge.load_script(R"(
+        var d = document.createElement('div');
+        d.id = 'a11y-replay';
+        // NOTE — appendChild has not run yet, so the element isn't native.
+        // Force the pre-mount path by clearing the flag the createElement
+        // helper sets after the createCol call.
+        d._nativeCreated = false;
+        d.setAttribute('aria-label', 'Filter cutoff');
+        d.setAttribute('role', 'slider');
+        // Now mount.  appendChild -> _ensureNative -> __replayAriaAttributes__
+        document.body.appendChild(d);
+    )");
+
+    auto idVal = engine.evaluate("document.getElementById('a11y-replay')._id");
+    auto id = std::string(idVal.getWithDefault<std::string_view>(""));
+    auto* v = bridge.widget(id);
+    REQUIRE(v != nullptr);
+    REQUIRE(v->access_label() == "Filter cutoff");
+    REQUIRE(v->access_role() == View::AccessRole::slider);
+}
+
+TEST_CASE("querySelector matches tag / .class / #id forms",
+          "[view][bridge][wave3-html][html-querySelector]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var p = document.createElement('div');
+        p.id = 'qs-root';
+        document.body.appendChild(p);
+        var a = document.createElement('span'); a.id = 'a'; a.className = 'foo';
+        var b = document.createElement('span'); b.id = 'b'; b.className = 'bar baz';
+        var c = document.createElement('p');    c.id = 'c'; c.className = 'foo qux';
+        p.appendChild(a); p.appendChild(b); p.appendChild(c);
+
+        globalThis.__byTag    = document.querySelector('p') !== null;
+        globalThis.__byId     = document.querySelector('#b') !== null;
+        globalThis.__byCls    = document.querySelectorAll('.foo').length;
+        globalThis.__compound = document.querySelector('span.foo')   !== null;
+        globalThis.__missing  = document.querySelector('.nope');
+    )");
+
+    REQUIRE(engine.evaluate("__byTag").getWithDefault<bool>(false));
+    REQUIRE(engine.evaluate("__byId").getWithDefault<bool>(false));
+    REQUIRE(engine.evaluate("__byCls").getWithDefault<int64_t>(0) == 2);
+    REQUIRE(engine.evaluate("__compound").getWithDefault<bool>(false));
+    // Missing match returns null, which the value bridge marshals as
+    // "is null" — encode as a JS boolean for the test assertion.
+    auto missingIsNull = engine.evaluate("__missing === null").getWithDefault<bool>(false);
+    REQUIRE(missingIsNull);
+}
+
+TEST_CASE("querySelector matches attribute selectors",
+          "[view][bridge][wave3-html][html-querySelector]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var d1 = document.createElement('div'); d1.id='d1';
+        d1.setAttribute('data-kind', 'preset');
+        var d2 = document.createElement('div'); d2.id='d2';
+        d2.setAttribute('data-kind', 'preset-named');
+        var d3 = document.createElement('div'); d3.id='d3';
+        d3.setAttribute('data-kind', 'cooked');
+        var d4 = document.createElement('div'); d4.id='d4';
+        d4.setAttribute('aria-label', 'X');
+        document.body.appendChild(d1);
+        document.body.appendChild(d2);
+        document.body.appendChild(d3);
+        document.body.appendChild(d4);
+
+        globalThis.__hasAttr = document.querySelectorAll('[data-kind]').length;
+        globalThis.__eqAttr  = document.querySelector('[data-kind="preset"]') !== null;
+        globalThis.__eqId    = document.querySelector('[data-kind="preset"]').id;
+        globalThis.__prefix  = document.querySelectorAll('[data-kind^="preset"]').length;
+        globalThis.__contain = document.querySelectorAll('[data-kind*="ook"]').length;
+        globalThis.__suffix  = document.querySelectorAll('[data-kind$="ed"]').length;
+        globalThis.__withAria= document.querySelector('[aria-label]').id;
+    )");
+
+    REQUIRE(engine.evaluate("__hasAttr").getWithDefault<int64_t>(0)  == 3);
+    REQUIRE(engine.evaluate("__eqAttr").getWithDefault<bool>(false));
+    REQUIRE(std::string(engine.evaluate("__eqId").getWithDefault<std::string_view>("")) == "d1");
+    REQUIRE(engine.evaluate("__prefix").getWithDefault<int64_t>(0)   == 2);
+    REQUIRE(engine.evaluate("__contain").getWithDefault<int64_t>(0)  == 1);
+    REQUIRE(engine.evaluate("__suffix").getWithDefault<int64_t>(0)   == 2);
+    REQUIRE(std::string(engine.evaluate("__withAria").getWithDefault<std::string_view>("")) == "d4");
+}
+
+TEST_CASE("querySelector descendant and child combinators",
+          "[view][bridge][wave3-html][html-querySelector]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(R"(
+        var outer = document.createElement('section');
+        outer.className = 'panel';
+        var mid   = document.createElement('div');
+        mid.className   = 'mid';
+        var inner = document.createElement('span'); inner.id = 'inner';
+        var sibling = document.createElement('span'); sibling.id = 'sib';
+        // tree: section.panel > div.mid > span#inner ; section.panel > span#sib
+        document.body.appendChild(outer);
+        outer.appendChild(mid);
+        mid.appendChild(inner);
+        outer.appendChild(sibling);
+
+        globalThis.__desc        = document.querySelector('section span') !== null;
+        globalThis.__descId      = document.querySelector('section.panel span').id;
+        globalThis.__directHit   = document.querySelector('section.panel > span').id;
+        globalThis.__directMiss  = document.querySelector('section.panel > p');
+        globalThis.__deepDescAll = document.querySelectorAll('.panel span').length;
+    )");
+
+    REQUIRE(engine.evaluate("__desc").getWithDefault<bool>(false));
+    // descendant `section.panel span` finds the deepest match first per
+    // BFS — `span#inner` (or `span#sib` — both match; the first BFS hit
+    // wins).  We only require that the result IS one of the two, which
+    // it must be when the matcher works.
+    auto descId = std::string(engine.evaluate("__descId").getWithDefault<std::string_view>(""));
+    REQUIRE((descId == "inner" || descId == "sib"));
+    // child `section.panel > span` matches only `sib` (mid is the
+    // immediate parent of `inner`, not section).
+    REQUIRE(std::string(engine.evaluate("__directHit").getWithDefault<std::string_view>("")) == "sib");
+    REQUIRE(engine.evaluate("__directMiss === null").getWithDefault<bool>(false));
+    REQUIRE(engine.evaluate("__deepDescAll").getWithDefault<int64_t>(0) == 2);
+}
+
+TEST_CASE("querySelector tolerates unsupported pseudo-classes",
+          "[view][bridge][wave3-html][html-querySelector]") {
+    ScriptEngine engine;
+    View root;
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // `div.foo:hover` MUST NOT throw — we strip the pseudo-class and
+    // match the rest so React-style code that hands us `selector + :hover`
+    // still resolves (the `:hover` semantics are implemented separately
+    // via the StyleSheet :hover pipeline).
+    bridge.load_script(R"(
+        var d = document.createElement('div');
+        d.id = 'pseudo'; d.className = 'foo';
+        document.body.appendChild(d);
+
+        globalThis.__pseudoOk = document.querySelector('div.foo:hover') !== null;
+        globalThis.__pseudoId = document.querySelector('div.foo:hover').id;
+    )");
+
+    REQUIRE(engine.evaluate("__pseudoOk").getWithDefault<bool>(false));
+    REQUIRE(std::string(engine.evaluate("__pseudoId").getWithDefault<std::string_view>("")) == "pseudo");
 }


### PR DESCRIPTION
## Summary

Closes 2 of html surface's 7 remaining DIVERGE entries.

- **html.2** (`html/ARIA`, #1476): `aria-label` / `role` attributes route through the html-compat shim into `View::access_label_` / `View::access_role_`. New bridge fns `setAccessibilityLabel` / `setAccessibilityRole`; the role setter maps the long ARIA tail onto Pulp's seven-bucket `AccessRole` enum (slider / checkbox+switch+radio→toggle / img→image / progressbar+meter→meter / heading+label+text+paragraph→label / everything else→group / empty→none). `web-compat-element.js` `setAttribute()` fast-paths `aria-label` and `role`; pre-mount values replay through `__replayAriaAttributes__` on `_ensureNative` / `appendChild` / `insertBefore` / `_reparentNative` so the React/JSX commit order doesn't drop the value. macOS NSAccessibility bridge already consumes these slots.

- **html.3** (`html/document_querySelector`): `document.querySelector` / `querySelectorAll` grow attribute selectors (`[attr]`, `[attr=v]`, `[attr^=v]`, `[attr$=v]`, `[attr*=v]`, `[attr|=v]`, `[attr~=v]`) and bracket-aware splitting for compound selectors and descendant / child combinators. Tokenizer is regex-based (~50 LOC); pseudo-class trailers (`:hover`, `:nth-child`, …) are tolerated at the tokenizer for forward compat — the gotcha string in `compat.json` keeps them listed as unsupported.

- **drive-by fix**: pre-existing merge bug in `test/test_widget_bridge.cpp` from PR #1638 (Wave 2 css) where five new `CSSStyleDeclaration` `TEST_CASE`s were inserted in the wrong position relative to the Wave 2 canvas2d tests landed in #1636, swapping the bodies of nine tests and leaving `mixBlendMode` without a closing brace. The reconstruction restores the correct interleaving — `pulp-test-widget-bridge` now builds again on `origin/main`'s contents and all 273 cases pass.

## Test plan

- [x] `cmake --build build --target pulp-test-widget-bridge`
- [x] `./build/test/pulp-test-widget-bridge "[wave3-html]"` — 8 cases / 35 assertions pass
- [x] `./build/test/pulp-test-widget-bridge "[wave2-css]"` — 9 cases / 51 assertions pass (was broken on main)
- [x] `./build/test/pulp-test-widget-bridge "[wave2-canvas2d]"` — 5 cases / 33 assertions pass (was broken on main)
- [x] `./build/test/pulp-test-widget-bridge` — 273 cases / 1618 assertions pass
- [x] `python3 -c "import json; json.load(open('compat.json'))"` valid

## Compat catalog

- `html/ARIA` flipped `partial → supported` with gotcha "macOS NSAccessibility wired; Linux/Windows accessibility platform stubs are storage-only".
- `html/document_querySelector` flipped `partial → supported` with gotcha "tag/.class/#id/[attr]/descendant/child wired; pseudo-classes (:hover, :nth-child) and complex combinators not implemented".
- html DIVERGE drops by 2.

## New TEST_CASEs (`[wave3-html]`)

- `HTML aria-label routes to View access_label`
- `HTML role attribute routes through ARIA->AccessRole bucket`
- `HTML setAttribute(aria-label) flushes through web-compat shim`
- `HTML setAttribute before mount replays ARIA on appendChild`
- `querySelector matches tag / .class / #id forms`
- `querySelector matches attribute selectors`
- `querySelector descendant and child combinators`
- `querySelector tolerates unsupported pseudo-classes`