### PR TITLE
fix(cli): install upgrade sibling payloads

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -333,6 +333,12 @@ Gotchas:
   version and every upgrade 404'd. `test_cli_upgrade_url.cpp` explicitly
   fails if the version reappears in the filename.
 - **Use `x64`, not `x86_64`.** The release workflow uploads under `x64`.
+- **Install sibling payloads before replacing `pulp`.** Phase 8+
+  archives contain Rust `pulp`, `pulp-cpp`, and the runtime library.
+  Pre-cutover C++ CLIs still run `cmd_upgrade.cpp` during that hop, so
+  the helper in `upgrade_install.hpp` must copy `pulp-cpp` and other
+  top-level payload files next to the current binary before self-replace
+  (#1673).
 - **If you change `upgrade_url.hpp`, update the regression test in the
   same PR.** Both live at HEAD; drift between them is the whole reason
   the header exists.

--- a/.agents/skills/upgrade/SKILL.md
+++ b/.agents/skills/upgrade/SKILL.md
@@ -54,6 +54,10 @@ as the C++ fallthrough delegate. A healthy install has both
 `~/.pulp/bin/pulp` and `~/.pulp/bin/pulp-cpp`; use `PULP_USE_CPP=1
 pulp <args>` or direct `pulp-cpp <args>` only for rollback/debug
 comparisons. Do not hand-swap binaries in user/system locations.
+The C++ `cmd_upgrade.cpp` path still matters for pre-cutover users
+upgrading into a Rust release: it must copy the archive's sibling
+payloads, including `pulp-cpp`, before replacing the running `pulp`
+binary (#1673).
 
 `pulp upgrade --notes` prints migration notes for the hop without
 downloading anything. `pulp upgrade --notes --json` emits the same data

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1130,7 +1130,7 @@ pulp upgrade --notes --json                       # same, stable-shape JSON (age
 pulp upgrade --notes --from 0.25.0 --to 0.29.0    # explicit hop override
 ```
 
-Downloads the release from GitHub, replaces the current binary, and verifies. Requires `curl`.
+Downloads the release from GitHub, installs the archive's top-level companion payloads next to the current binary, replaces the current binary, and verifies. Phase 8+ archives install Rust `pulp` plus the `pulp-cpp` fallthrough delegate together. Requires `curl`.
 
 `--check-only` reads the on-disk cache written by the on-every-invocation background refresh (release-discovery #547 Slice 2) and prints installed/latest/notes. If the cache is empty (first run), it falls through to a single live GitHub query.
 

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -329,7 +329,7 @@ commands:
 
   - name: upgrade
     status: usable
-    summary: Update the Pulp CLI binary to the latest or a specific version. `--check-only` reports the cached latest release without downloading. `--notes` prints embedded migration notes for the upgrade hop.
+    summary: Update the Pulp CLI install to the latest or a specific version, including companion artifacts such as `pulp-cpp`. `--check-only` reports the cached latest release without downloading. `--notes` prints embedded migration notes for the upgrade hop.
     args:
       - name: version
         kind: positional

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -221,6 +221,14 @@ target_include_directories(pulp-test-cli-upgrade-url PRIVATE ${CMAKE_SOURCE_DIR}
 target_link_libraries(pulp-test-cli-upgrade-url PRIVATE Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-cli-upgrade-url)
 
+# CLI upgrade install regression (#1673): a pre-cutover C++ CLI
+# upgrading into a Rust archive must install sibling payloads such as
+# pulp-cpp before replacing the user-facing pulp binary.
+add_executable(pulp-test-cli-upgrade-install test_cli_upgrade_install.cpp)
+target_include_directories(pulp-test-cli-upgrade-install PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(pulp-test-cli-upgrade-install PRIVATE Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-cli-upgrade-install)
+
 # CLI version diagnostics (#499 Slice 1): pure-logic tests for the
 # semver parser, plugin.json scraper, and skew analyzer that sit
 # behind `pulp doctor --versions`. version_diag is deliberately free

--- a/test/test_cli_upgrade_install.cpp
+++ b/test/test_cli_upgrade_install.cpp
@@ -1,0 +1,117 @@
+// Regression coverage for the C++ `pulp upgrade` install helper.
+//
+// Older pre-cutover C++ CLIs can upgrade straight into a Phase 8 Rust
+// archive. That archive contains `pulp` plus sibling artifacts such as
+// `pulp-cpp` and the wgpu runtime library; copying only `pulp` strands
+// the new Rust CLI without its C++ fallthrough delegate (#1673).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "tools/cli/upgrade_install.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#ifdef _WIN32
+#  include <process.h>
+#  define pulp_test_pid() _getpid()
+#else
+#  include <unistd.h>
+#  define pulp_test_pid() ::getpid()
+#endif
+
+namespace fs = std::filesystem;
+namespace ui = pulp::cli::upgrade_install;
+
+namespace {
+
+fs::path make_tmpdir(const std::string& tag) {
+    auto dir = fs::temp_directory_path() /
+               ("pulp-test-upgrade-install-" + tag + "-" +
+                std::to_string(pulp_test_pid()) + "-" +
+                std::to_string(std::chrono::steady_clock::now()
+                                   .time_since_epoch()
+                                   .count()));
+    fs::create_directories(dir);
+    return dir;
+}
+
+const char* runtime_library_name() {
+#ifdef _WIN32
+    return "wgpu_native.dll";
+#elif defined(__APPLE__)
+    return "libwgpu_native.dylib";
+#else
+    return "libwgpu_native.so";
+#endif
+}
+
+void write_file(const fs::path& path, const std::string& body) {
+    std::ofstream out(path, std::ios::binary);
+    out << body;
+}
+
+std::string read_file(const fs::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(in),
+                       std::istreambuf_iterator<char>());
+}
+
+}  // namespace
+
+TEST_CASE("upgrade install copies sibling payloads before self replacement",
+          "[cli][upgrade][issue-1673]") {
+    auto extracted = make_tmpdir("extracted");
+    auto install = make_tmpdir("install");
+
+    auto primary = extracted / ui::primary_binary_name();
+    auto cpp = extracted / ui::cpp_binary_name();
+    auto runtime = extracted / runtime_library_name();
+    auto archive = extracted / "pulp-darwin-arm64.tar.gz";
+
+    write_file(primary, "new-rust-pulp");
+    write_file(cpp, "new-cpp-delegate");
+    write_file(runtime, "new-runtime-lib");
+    write_file(archive, "downloaded-archive");
+
+    auto installed_primary = install / ui::primary_binary_name();
+    write_file(installed_primary, "old-cpp-pulp");
+
+    auto installed = ui::install_sibling_payloads(extracted, install, primary, archive);
+
+    REQUIRE(ui::installed_cpp_delegate(installed));
+    REQUIRE(read_file(installed_primary) == "old-cpp-pulp");
+    REQUIRE(read_file(install / ui::cpp_binary_name()) == "new-cpp-delegate");
+    REQUIRE(read_file(install / runtime.filename()) == "new-runtime-lib");
+    REQUIRE_FALSE(fs::exists(install / archive.filename()));
+
+#ifndef _WIN32
+    const auto cpp_perms = fs::status(install / ui::cpp_binary_name()).permissions();
+    REQUIRE((cpp_perms & fs::perms::owner_exec) != fs::perms::none);
+#endif
+
+    fs::remove_all(extracted);
+    fs::remove_all(install);
+}
+
+TEST_CASE("upgrade install tolerates archives without a cpp delegate",
+          "[cli][upgrade][issue-1673]") {
+    auto extracted = make_tmpdir("single");
+    auto install = make_tmpdir("single-install");
+
+    auto primary = extracted / ui::primary_binary_name();
+    auto archive = extracted / "pulp-linux-x64.tar.gz";
+    write_file(primary, "new-pulp");
+    write_file(archive, "downloaded-archive");
+
+    auto installed = ui::install_sibling_payloads(extracted, install, primary, archive);
+
+    REQUIRE(installed.empty());
+    REQUIRE_FALSE(fs::exists(install / ui::cpp_binary_name()));
+
+    fs::remove_all(extracted);
+    fs::remove_all(install);
+}

--- a/tools/cli/cmd_upgrade.cpp
+++ b/tools/cli/cmd_upgrade.cpp
@@ -18,6 +18,7 @@
 #include "cli_common.hpp"
 #include "migration_index.hpp"
 #include "update_check.hpp"
+#include "upgrade_install.hpp"
 #include "upgrade_url.hpp"
 
 #include <atomic>
@@ -234,26 +235,40 @@ int cmd_upgrade(const std::vector<std::string>& args) {
         return 1;
     }
 
-    std::string new_binary = tmp_dir + "/pulp";
+    fs::path tmp_path = tmp_dir;
+    fs::path archive_path = tmp_path / tarball;
+    fs::path new_binary = tmp_path / pulp::cli::upgrade_install::primary_binary_name();
     if (!fs::exists(new_binary)) {
-        std::cerr << "Error: extracted archive does not contain 'pulp' binary.\n";
+        std::cerr << "Error: extracted archive does not contain '"
+                  << pulp::cli::upgrade_install::primary_binary_name()
+                  << "' binary.\n";
         run("rm -rf " + tmp_dir);
         return 1;
     }
 
+    fs::path self = self_path;
+    fs::path install_dir = self.parent_path();
+    if (install_dir.empty()) install_dir = fs::current_path();
     std::string backup = self_path + ".bak";
+    std::vector<fs::path> installed_payloads;
     try {
+        // Copy sibling payloads first. If this fails, leave the current
+        // `pulp` binary untouched; after self-replace, Rust needs the
+        // sibling `pulp-cpp` delegate to service unported commands.
+        installed_payloads = pulp::cli::upgrade_install::install_sibling_payloads(
+            tmp_path, install_dir, new_binary, archive_path);
+
         if (fs::exists(backup)) fs::remove(backup);
-        fs::rename(self_path, backup);
-        fs::copy_file(new_binary, self_path);
-        fs::permissions(self_path, fs::perms::owner_exec | fs::perms::owner_read | fs::perms::owner_write
+        fs::rename(self, backup);
+        fs::copy_file(new_binary, self);
+        fs::permissions(self, fs::perms::owner_exec | fs::perms::owner_read | fs::perms::owner_write
                                  | fs::perms::group_exec | fs::perms::group_read
                                  | fs::perms::others_exec | fs::perms::others_read);
         fs::remove(backup);
     } catch (const std::exception& e) {
-        std::cerr << "Error replacing binary: " << e.what() << "\n";
-        if (fs::exists(backup) && !fs::exists(self_path)) {
-            fs::rename(backup, self_path);
+        std::cerr << "Error installing upgrade payload: " << e.what() << "\n";
+        if (fs::exists(backup) && !fs::exists(self)) {
+            fs::rename(backup, self);
         }
         run("rm -rf " + tmp_dir);
         return 1;
@@ -262,6 +277,9 @@ int cmd_upgrade(const std::vector<std::string>& args) {
     run("rm -rf " + tmp_dir);
 
     std::cout << "\n  \xe2\x9c\x93 Pulp CLI upgraded to v" << version << "\n";
+    if (pulp::cli::upgrade_install::installed_cpp_delegate(installed_payloads)) {
+        std::cout << "    Installed pulp-cpp delegate alongside pulp.\n";
+    }
 
     // Hint about the embedded migration notes — the `--notes` surface
     // lives in this same binary so the just-installed CLI can replay

--- a/tools/cli/upgrade_install.hpp
+++ b/tools/cli/upgrade_install.hpp
@@ -1,0 +1,103 @@
+// upgrade_install.hpp -- helpers for installing release-archive payloads.
+//
+// The pre-Phase-8 C++ CLI can upgrade directly into a post-cutover
+// Rust release archive. In that archive `pulp` is the Rust binary and
+// `pulp-cpp` is the C++ delegate required by fallthrough commands, so
+// the old one-file self-replace path must also copy sibling artifacts.
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace pulp::cli::upgrade_install {
+
+namespace fs = std::filesystem;
+
+inline std::string primary_binary_name() {
+#ifdef _WIN32
+    return "pulp.exe";
+#else
+    return "pulp";
+#endif
+}
+
+inline std::string cpp_binary_name() {
+#ifdef _WIN32
+    return "pulp-cpp.exe";
+#else
+    return "pulp-cpp";
+#endif
+}
+
+inline bool has_any_exec_bit(const fs::path& path) {
+#ifdef _WIN32
+    (void)path;
+    return false;
+#else
+    std::error_code ec;
+    const auto perms = fs::status(path, ec).permissions();
+    if (ec) return false;
+    return (perms & (fs::perms::owner_exec | fs::perms::group_exec |
+                     fs::perms::others_exec)) != fs::perms::none;
+#endif
+}
+
+inline bool should_add_exec_permissions(const fs::path& source) {
+    const auto name = source.filename().string();
+    return name == primary_binary_name() || name == cpp_binary_name() ||
+           has_any_exec_bit(source);
+}
+
+inline void add_exec_permissions(const fs::path& path) {
+#ifndef _WIN32
+    fs::permissions(path,
+                    fs::perms::owner_exec | fs::perms::group_exec |
+                        fs::perms::others_exec,
+                    fs::perm_options::add);
+#else
+    (void)path;
+#endif
+}
+
+inline bool same_path(const fs::path& a, const fs::path& b) {
+    std::error_code ec;
+    if (fs::equivalent(a, b, ec)) return true;
+    return a.lexically_normal() == b.lexically_normal();
+}
+
+inline std::vector<fs::path> install_sibling_payloads(
+    const fs::path& extracted_root,
+    const fs::path& install_dir,
+    const fs::path& primary_binary,
+    const fs::path& downloaded_archive) {
+    std::vector<fs::path> installed;
+    for (const auto& entry : fs::directory_iterator(extracted_root)) {
+        if (!entry.is_regular_file()) continue;
+
+        const auto src = entry.path();
+        if (same_path(src, primary_binary) || same_path(src, downloaded_archive)) {
+            continue;
+        }
+
+        const auto dst = install_dir / src.filename();
+        fs::copy_file(src, dst, fs::copy_options::overwrite_existing);
+        if (should_add_exec_permissions(src)) {
+            add_exec_permissions(dst);
+        }
+        installed.push_back(dst);
+    }
+    return installed;
+}
+
+inline bool installed_cpp_delegate(const std::vector<fs::path>& installed) {
+    const auto cpp_name = cpp_binary_name();
+    for (const auto& path : installed) {
+        if (path.filename() == cpp_name) return true;
+    }
+    return false;
+}
+
+}  // namespace pulp::cli::upgrade_install


### PR DESCRIPTION
Fixes #1673

Version-Bump: sdk=patch reason="fix pulp upgrade installs pulp-cpp delegate"