### PR TITLE
fix(ci): avoid PR cloud cache uploads on mac runner

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -430,6 +430,14 @@ GitHub-hosted Ubuntu must create a `docker-container` Buildx builder before
 calling the wrapper; the default `docker` driver on that image rejects
 `type=local` cache export unless containerd image storage is enabled.
 
+For macOS visual/layout jobs, do not use the combined `actions/cache` action
+for `ccache` or FetchContent on the local self-hosted runner. Its home
+directory persists between jobs, so GitHub cloud-cache saves can spend
+20+ minutes uploading multi-GB compiler caches that the runner already has
+locally. Use `actions/cache/restore` for GitHub-hosted fallback runners and
+`actions/cache/save` only on `push` to `main`; PRs should restore existing
+remote caches at most, not publish PR-scoped ccache blobs.
+
 The container is a reproducible smoke/developer environment. It does not
 replace the future canonical arm64-darwin raster-golden gate.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,13 +240,14 @@ jobs:
         run: choco install ccache --no-progress -y
 
       # ── Caches (#420) ──────────────────────────────────────────────────
-      # FetchContent source cache: Skia / Dawn / Yoga / SDL3 / Catch2 /
-      # mbedtls / CHOC / CLAP / LV2 / VST3 SDK, keyed on setup.sh's
-      # content (which pins every ref). Hit → setup.sh finds everything
-      # already unpacked and returns in seconds. Cold → ~3-5 min
-      # downloading + unpacking.
-      - name: Cache FetchContent sources
-        uses: actions/cache@v4
+      # The local macOS runner keeps these paths on disk between jobs.
+      # Avoid round-tripping multi-GB compiler/source caches through
+      # GitHub's cloud cache there; GitHub-hosted runners restore main's
+      # cache and only main pushes publish fresh cache entries.
+      - name: Restore FetchContent sources (GitHub-hosted)
+        if: runner.os != 'macOS' || runner.environment == 'github-hosted'
+        id: fetchcontent-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/Library/Caches/Pulp/fetchcontent-src
@@ -256,12 +257,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.key || 'build' }}-fetchcontent-
 
-      # ccache: skip compilation of unchanged translation units. Keyed
-      # on CMakeLists + PR ref so each PR has its own warm cache. The
-      # restore-key fallback shares warm cache across PRs on the same
-      # base branch, so first-run-per-PR starts near-warm.
-      - name: Cache ccache
-        uses: actions/cache@v4
+      - name: Restore ccache (GitHub-hosted)
+        if: runner.os != 'macOS' || runner.environment == 'github-hosted'
+        id: ccache-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/Library/Caches/ccache
@@ -275,6 +274,16 @@ jobs:
       - name: Bootstrap repository dependencies
         run: ./setup.sh --ci --deps-only
         shell: bash
+
+      - name: Save FetchContent sources (main GitHub-hosted)
+        if: (runner.os != 'macOS' || runner.environment == 'github-hosted') && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.fetchcontent-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/Library/Caches/Pulp/fetchcontent-src
+            ~/.cache/Pulp/fetchcontent-src
+            ~/AppData/Local/Pulp/Cache/fetchcontent-src
+          key: ${{ steps.fetchcontent-cache.outputs.cache-primary-key }}
 
       - name: Configure
         # On pull_request events, skip example plugin builds
@@ -307,6 +316,16 @@ jobs:
             echo "ccache not available; skipping stats"
           fi
         shell: bash
+
+      - name: Save ccache (main GitHub-hosted)
+        if: (runner.os != 'macOS' || runner.environment == 'github-hosted') && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.ccache-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/Library/Caches/ccache
+            ~/.cache/ccache
+            ~/AppData/Local/ccache
+          key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
 
       - name: Test (non-Windows)
         if: runner.os != 'Windows'

--- a/.github/workflows/visual-harness.yml
+++ b/.github/workflows/visual-harness.yml
@@ -110,8 +110,13 @@ jobs:
       - name: Install ccache
         run: brew install ccache
 
-      - name: Cache FetchContent sources
-        uses: actions/cache@v4
+      # Self-hosted macOS keeps these caches on local disk between jobs.
+      # Only GitHub-hosted fallback runners use GitHub's cloud cache, and
+      # only main pushes publish fresh cache entries.
+      - name: Restore FetchContent sources (GitHub-hosted)
+        if: runner.environment == 'github-hosted'
+        id: fetchcontent-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/Library/Caches/Pulp/fetchcontent-src
@@ -120,8 +125,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-visual-fetchcontent-
 
-      - name: Cache ccache
-        uses: actions/cache@v4
+      - name: Restore ccache (GitHub-hosted)
+        if: runner.environment == 'github-hosted'
+        id: ccache-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/Library/Caches/ccache
@@ -133,6 +140,15 @@ jobs:
 
       - name: Bootstrap repository dependencies
         run: ./setup.sh --ci --deps-only
+
+      - name: Save FetchContent sources (main GitHub-hosted)
+        if: runner.environment == 'github-hosted' && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.fetchcontent-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/Library/Caches/Pulp/fetchcontent-src
+            ~/.cache/Pulp/fetchcontent-src
+          key: ${{ steps.fetchcontent-cache.outputs.cache-primary-key }}
 
       - name: Configure visual harness
         run: cmake -S . -B build-visual -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_EXAMPLES=OFF
@@ -151,3 +167,12 @@ jobs:
           else
             echo "ccache not available; skipping stats"
           fi
+
+      - name: Save ccache (main GitHub-hosted)
+        if: runner.environment == 'github-hosted' && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.ccache-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/Library/Caches/ccache
+            ~/.cache/ccache
+          key: ${{ steps.ccache-cache.outputs.cache-primary-key }}

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -852,8 +852,8 @@ TEST_CASE("Checkbox, toggle button, icons, and image placeholders cover widget p
 
     RecordingCanvas path_image_canvas;
     path_image.paint(path_image_canvas);
-    REQUIRE(path_image_canvas.count(DrawCommand::Type::fill_rounded_rect) == 1);
-    REQUIRE(commands_of(path_image_canvas, DrawCommand::Type::fill_text).front().text == "pulp-widget-preview.png");
+    REQUIRE(path_image_canvas.count(DrawCommand::Type::draw_image) == 1);
+    REQUIRE(commands_of(path_image_canvas, DrawCommand::Type::draw_image).front().text == "/tmp/pulp-widget-preview.png");
 }
 
 TEST_CASE("Meter set_level", "[view][widget]") {


### PR DESCRIPTION
Use split restore/save cache actions so pull requests do not publish multi-GB ccache or FetchContent archives from the local macOS runner. GitHub-hosted fallback runners can still restore cache, while main pushes remain the only cache publisher.

Version-Bump: sdk=skip reason="CI workflow cache routing only; no SDK release surface"
Version-Bump: plugin=skip reason="CI workflow cache routing only; no Claude plugin release surface"
Version-Bump: skip reason="CI-only cache policy change; no package version bump needed"