### PR TITLE
fix(ci): enable manual main cache saves

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -435,8 +435,10 @@ for `ccache` or FetchContent on the local self-hosted runner. Its home
 directory persists between jobs, so GitHub cloud-cache saves can spend
 20+ minutes uploading multi-GB compiler caches that the runner already has
 locally. Use `actions/cache/restore` for GitHub-hosted fallback runners and
-`actions/cache/save` only on `push` to `main`; PRs should restore existing
-remote caches at most, not publish PR-scoped ccache blobs.
+`actions/cache/save` only on non-PR `main` runs (`push` where the workflow has
+a push trigger, or `workflow_dispatch` on `main` for manual cache seeding).
+PRs should restore existing remote caches at most, not publish PR-scoped
+ccache blobs.
 
 The container is a reproducible smoke/developer environment. It does not
 replace the future canonical arm64-darwin raster-golden gate.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,7 +243,7 @@ jobs:
       # The local macOS runner keeps these paths on disk between jobs.
       # Avoid round-tripping multi-GB compiler/source caches through
       # GitHub's cloud cache there; GitHub-hosted runners restore main's
-      # cache and only main pushes publish fresh cache entries.
+      # cache and only non-PR main runs publish fresh cache entries.
       - name: Restore FetchContent sources (GitHub-hosted)
         if: runner.os != 'macOS' || runner.environment == 'github-hosted'
         id: fetchcontent-cache
@@ -275,8 +275,8 @@ jobs:
         run: ./setup.sh --ci --deps-only
         shell: bash
 
-      - name: Save FetchContent sources (main GitHub-hosted)
-        if: (runner.os != 'macOS' || runner.environment == 'github-hosted') && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.fetchcontent-cache.outputs.cache-hit != 'true'
+      - name: Save FetchContent sources (main non-PR GitHub-hosted)
+        if: (runner.os != 'macOS' || runner.environment == 'github-hosted') && github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && steps.fetchcontent-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
@@ -293,8 +293,8 @@ jobs:
         # example-plugin product bundles. Trades ~10-20 min per PR
         # for a deferred validation that examples still compile —
         # which runs in full on push to main / schedule.
-        # On push to main + scheduled nightly + workflow_dispatch:
-        # the full build runs (PULP_BUILD_EXAMPLES default = ON).
+        # On workflow_dispatch, the full build runs
+        # (PULP_BUILD_EXAMPLES default = ON).
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -317,8 +317,8 @@ jobs:
           fi
         shell: bash
 
-      - name: Save ccache (main GitHub-hosted)
-        if: (runner.os != 'macOS' || runner.environment == 'github-hosted') && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.ccache-cache.outputs.cache-hit != 'true'
+      - name: Save ccache (main non-PR GitHub-hosted)
+        if: (runner.os != 'macOS' || runner.environment == 'github-hosted') && github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && steps.ccache-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |


### PR DESCRIPTION
Address the unresolved PR #1681 review thread by making build.yml cache saves reachable without allowing pull_request runs to publish PR-scoped ccache or FetchContent blobs.

Version-Bump: sdk=skip reason="CI-only cache save condition follow-up for PR #1681; no SDK release surface"
Version-Bump: plugin=skip reason="CI-only cache save condition follow-up for PR #1681; no Claude plugin release surface"
Version-Bump: skip reason="CI-only cache save condition follow-up for PR #1681; no package version bump needed"