### PR TITLE
guard: strengthen pollution check with positive `project(Pulp` assertion (incident follow-up)

### DIFF
--- a/tools/scripts/source_tree_pollution_check.py
+++ b/tools/scripts/source_tree_pollution_check.py
@@ -40,6 +40,7 @@ import sys
 from pathlib import Path
 
 CLOCK_FIXTURE_SIGNATURE = "project(Clock VERSION 1.0.0"
+PULP_PROJECT_SIGNATURE = "project(Pulp"
 TEMP_FIXTURE_PATH_HINTS = ("/private/var/folders/", "pulp-shellout-")
 
 
@@ -95,7 +96,13 @@ def check(files: list[str], rev: str | None) -> tuple[list[str], list[str]]:
                 "file (`git rm pulp.toml`) and re-stage."
             )
             continue
-        # Block #2 — CMakeLists.txt at repo root with the Clock fixture.
+        # Block #2 — CMakeLists.txt at repo root must declare project(Pulp.
+        # Two-pronged check: explicit Clock-fixture signature catches the
+        # known #1755 case with a precise error message; positive
+        # `project(Pulp` assertion catches ANY future fixture / unrelated
+        # CMakeLists.txt being committed at the root (the parallel agent's
+        # broader proposal — e.g. somebody pastes an `examples/foo`
+        # CMakeLists.txt at the root accidentally).
         if path == "CMakeLists.txt":
             content = _read_blob(rev, path)
             if CLOCK_FIXTURE_SIGNATURE in content:
@@ -108,6 +115,22 @@ def check(files: list[str], rev: str | None) -> tuple[list[str], list[str]]:
                     "main: `git show origin/main:CMakeLists.txt > CMakeLists.txt`. "
                     "PR #1755 accidentally shipped this corruption; #1757 "
                     "was the hotfix; this guard prevents a repeat."
+                )
+                continue
+            # Positive assertion — first ~10 lines must contain
+            # `project(Pulp`. Catches any non-Pulp CMakeLists.txt at the
+            # root regardless of the specific fixture, including future
+            # examples/foo/CMakeLists.txt accidents.
+            head = "\n".join(content.splitlines()[:10])
+            if content.strip() and PULP_PROJECT_SIGNATURE not in head:
+                errors.append(
+                    f"  {path}: first 10 lines do not contain "
+                    f"`{PULP_PROJECT_SIGNATURE}`. The root CMakeLists.txt "
+                    "must declare `project(Pulp ...)` — anything else is "
+                    "almost certainly an example or fixture file pasted "
+                    "into the wrong place. If you genuinely intended to "
+                    "rename the project, update both this guard and the "
+                    "test in tools/scripts/test_source_tree_pollution_check.py."
                 )
                 continue
         # Warn — paths that look like test-fixture leakage.

--- a/tools/scripts/test_source_tree_pollution_check.py
+++ b/tools/scripts/test_source_tree_pollution_check.py
@@ -71,6 +71,29 @@ class SourceTreePollutionTests(unittest.TestCase):
         result = self._run("CMakeLists.txt")
         self.assertEqual(result.returncode, 0, msg=result.stderr)
 
+    def test_blocks_arbitrary_non_pulp_cmakelists(self) -> None:
+        """Even a non-Clock CMakeLists.txt is blocked if it doesn't say
+        project(Pulp — catches any example or fixture pasted at the root.
+        This is the parallel agent's positive-assertion proposal: protects
+        against future `examples/foo/CMakeLists.txt` accidents that the
+        Clock-specific signature wouldn't catch."""
+        Path("CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.20)\n"
+            "project(SomeOtherExample VERSION 2.0.0 LANGUAGES CXX)\n"
+        )
+        result = self._run("CMakeLists.txt")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("first 10 lines do not contain", result.stderr)
+        self.assertIn("project(Pulp", result.stderr)
+
+    def test_empty_cmakelists_does_not_trigger_positive_assertion(self) -> None:
+        """Empty file (e.g. `git rm` with no replacement) shouldn't trigger
+        the positive `project(Pulp` assertion — that's a different concern
+        (file deletion, not corruption). Other gates handle removed files."""
+        Path("CMakeLists.txt").write_text("")
+        result = self._run("CMakeLists.txt")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
     def test_warns_on_temp_fixture_path_hint(self) -> None:
         """A file path containing /private/var/folders/ → warning, not block."""
         # The check looks at the path string, not the file content.


### PR DESCRIPTION
## Summary

Follow-up to PR #1761. Adds the parallel agents positive-assertion proposal: root `CMakeLists.txt` MUST contain `project(Pulp` in its first 10 lines. Catches ANY non-Pulp CMakeLists.txt at root, not just the Clock-specific signature from #1755.

The original Clock-fixture check stays (precise error message). The new positive assertion is the broader safety net — future `examples/foo` paste-accidents or unrelated `pulp project init` invocations all trip it.

## Test plan

- [x] `tools/scripts/test_source_tree_pollution_check.py` — 8 unit tests pass (6 pre-existing + 2 new: `test_blocks_arbitrary_non_pulp_cmakelists` + `test_empty_cmakelists_does_not_trigger_positive_assertion`).
- [x] `python3 tools/scripts/source_tree_pollution_check.py --mode=push --base origin/main` against this branch — exit 0.
- [x] Self-test: feeding `project(Clock VERSION 1.0.0` triggers the original block; feeding `project(SomeOther VERSION 2.0.0` triggers the new positive-assertion block; feeding `project(Pulp VERSION 0.81.0` passes; empty file passes (different concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)