### PR TITLE
feat(release): drop example plugin .pkg artifacts from GitHub release page (closes task #49)

### DIFF
--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -170,8 +170,20 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         # v1 is too old per actionlint (GH deprecated its runner version);
         # v2 uses the Node 20 runner and is a drop-in replacement.
+        #
+        # pulp #1737 — only upload appcast.xml to the release page. The
+        # example plugin .pkg files (PulpEffect, PulpCompressor, PulpDrums,
+        # PulpGain, PulpPluck, PulpTone, PulpSynth, PulpSampler,
+        # PulpMpeSynth, AraPitchTracker — across AU/CLAP/VST3) still build
+        # in the steps above as smoke tests (catches regressions when the
+        # SDK touches examples/), and they're still uploaded to the
+        # workflow run via actions/upload-artifact for debugging. They are
+        # just NOT promoted to the user-facing release page, where they
+        # would imply they're production-quality installers ready to drop
+        # into ~/Library/Audio/Plug-Ins/. The SDK + CLI artifacts (pulp-*,
+        # pulp-sdk-*) are uploaded by .github/workflows/release-cli.yml.
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/*
+          files: artifacts/appcast.xml
           draft: true
           generate_release_notes: true


### PR DESCRIPTION
## Summary

User-confirmed plan from earlier today (task #49). Drops the ~20 example plugin .pkg files from the user-facing release page upload while keeping the build/sign/notarize/upload-artifact steps intact (so the .pkgs remain CI smoke tests + downloadable from the workflow run for debugging).

**Keep on release page** (10 artifacts):
- `appcast.xml` (Sparkle/auto-update feed)
- `pulp-{darwin,linux,windows}-{arm64,x64}.{tar.gz,zip}` (CLI binaries — uploaded by release-cli.yml, unchanged)
- `pulp-sdk-{darwin,linux,windows}-{arm64,x64}.tar.gz` (SDK bundles — uploaded by release-cli.yml, unchanged)

**Drop from release page** (~20 artifacts):
- All Pulp{Compressor,Drums,Effect,Gain,Pluck,Tone,Synth,Sampler,MpeSynth,AraPitchTracker}-{AU,CLAP,VST3}-*.pkg example plugin packages.

## Change

One workflow file (.github/workflows/sign-and-release.yml). softprops/action-gh-release@v2 files: input changed from artifacts/* to artifacts/appcast.xml. Build/sign/notarize/upload-artifact steps stay intact.

## Test plan

- [x] YAML validates.
- [x] Diff is minimal: only files: line + explanatory comment.
- [ ] Next release tag exercises the new path (verify via release page absence of .pkg artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)