### PR TITLE
fix(a11y): surface ARIA state attributes through NSAccessibility + snapshot (Codex P1+P2 on #1766)

### DIFF
--- a/core/view/include/pulp/view/accessibility_tree.hpp
+++ b/core/view/include/pulp/view/accessibility_tree.hpp
@@ -32,6 +32,17 @@ struct AccessibilityNodeSnapshot {
     double current_value = 0.0;
     std::string value_string;
 
+    // pulp #1737 — ARIA state attributes. Tri-state per ARIA 1.2:
+    // `true` / `false` / `mixed` / unset (empty string). Platform AT
+    // bridges (NSAccessibility today; AT-SPI / UIA when those land
+    // per pulp #217) read these to expose the toggle/checkbox state.
+    // Stored on View::access_pressed_/_checked_/_disabled_/_hidden_;
+    // surfaced through this snapshot for the cross-platform tree path.
+    std::string pressed;   // aria-pressed
+    std::string checked;   // aria-checked
+    std::string disabled;  // aria-disabled
+    std::string hidden;    // aria-hidden
+
     // Nesting depth under the root; the root itself is depth 0.
     int depth = 0;
 };

--- a/core/view/platform/mac/accessibility_mac.mm
+++ b/core/view/platform/mac/accessibility_mac.mm
@@ -59,10 +59,52 @@ static void collect_accessible(View& root, std::vector<View*>& out) {
 }
 
 - (id)accessibilityValue {
+    // pulp #1737 — surface ARIA state attributes (aria-pressed,
+    // aria-checked) through accessibilityValue. NSAccessibility's
+    // toggle/checkbox VoiceOver output reads accessibilityValue and
+    // expects @(YES) / @(NO) / @"mixed" / nil. Tri-state mapping per
+    // ARIA 1.2:
+    //   "true"  → @YES (announced as "checked" / "on" / "pressed")
+    //   "false" → @NO  (announced as "unchecked" / "off" / "not pressed")
+    //   "mixed" → @"mixed" (announced as "mixed")
+    //   unset / other → fall through to legacy access_value()
+    // aria-checked takes priority over aria-pressed when both set
+    // because checkbox/radio states are more semantic-load-bearing
+    // than toggle-button pressed state.
+    if (_view) {
+        const std::string& checked = _view->access_checked();
+        if (!checked.empty()) {
+            if (checked == "true")  return @YES;
+            if (checked == "false") return @NO;
+            if (checked == "mixed") return @"mixed";
+        }
+        const std::string& pressed = _view->access_pressed();
+        if (!pressed.empty()) {
+            if (pressed == "true")  return @YES;
+            if (pressed == "false") return @NO;
+            if (pressed == "mixed") return @"mixed";
+        }
+    }
     if (!_view || _view->access_value().empty()) return nil;
     return [NSString stringWithUTF8String:_view->access_value().c_str()];
 }
 
+// pulp #1737 — surface aria-disabled. NSAccessibility's
+// isAccessibilityEnabled returns YES by default; we flip to NO when
+// aria-disabled is "true". `false` and unset both leave the view
+// enabled. Note: this does NOT change actual interaction handling —
+// View::set_enabled() is the C++-side gate for that. This only affects
+// what VoiceOver announces.
+- (BOOL)isAccessibilityEnabled {
+    if (!_view) return YES;
+    return _view->access_disabled() == "true" ? NO : YES;
+}
+
+// pulp #1737 — surface aria-hidden. NSAccessibility's accessibility
+// element flag should return NO when aria-hidden="true" so VoiceOver
+// skips the element. The legacy isAccessibilityElement check
+// (role != AccessRole::none) still applies — aria-hidden is an
+// additional gate.
 - (BOOL)isAccessibilityFocused {
     return _view ? _view->has_focus() : NO;
 }
@@ -88,7 +130,12 @@ static void collect_accessible(View& root, std::vector<View*>& out) {
 }
 
 - (BOOL)isAccessibilityElement {
-    return _view && _view->access_role() != pulp::view::View::AccessRole::none;
+    if (!_view) return NO;
+    // pulp #1737 — aria-hidden="true" suppresses the element regardless
+    // of role. Other aria-hidden values (false, unset) keep the legacy
+    // role-based gate.
+    if (_view->access_hidden() == "true") return NO;
+    return _view->access_role() != pulp::view::View::AccessRole::none;
 }
 
 @end

--- a/core/view/src/accessibility_tree.cpp
+++ b/core/view/src/accessibility_tree.cpp
@@ -11,6 +11,15 @@ void walk(const View& v, int depth,
     snap.role  = v.access_role();
     snap.label = v.access_label();
     snap.value = v.access_value();
+    // pulp #1737 — surface ARIA state attributes through the cross-
+    // platform snapshot so AT bridges (and offline tests) see the state
+    // alongside role/label/value. Platform bridges (NSAccessibility
+    // here; AT-SPI / UIA when wired per #217) read the same View slots
+    // directly; the snapshot is the cross-platform mirror.
+    snap.pressed  = v.access_pressed();
+    snap.checked  = v.access_checked();
+    snap.disabled = v.access_disabled();
+    snap.hidden   = v.access_hidden();
     snap.depth = depth;
 
     // If the view implements AccessibilityValueInterface, fill value range.

--- a/test/test_accessibility_tree.cpp
+++ b/test/test_accessibility_tree.cpp
@@ -157,3 +157,52 @@ TEST_CASE("snapshot captures nested range metadata", "[a11y][harness]") {
     REQUIRE(nodes[1].current_value == 6.0);
     REQUIRE(nodes[1].value_string == "75%");
 }
+
+// pulp #1737 — ARIA state attributes (aria-pressed, aria-checked,
+// aria-disabled, aria-hidden) must surface through the cross-platform
+// AccessibilityNodeSnapshot so AT bridges (NSAccessibility today;
+// AT-SPI / UIA when wired per #217) and offline tests can read them.
+// Pre-fix the View slots existed but the snapshot only carried role/
+// label/value — assistive tech never saw the state.
+TEST_CASE("Accessibility snapshot surfaces ARIA state attributes",
+          "[a11y][issue-1737]") {
+    using namespace pulp::view;
+    Probe root;
+
+    auto btn = std::make_unique<Probe>();
+    btn->set_access_role(View::AccessRole::toggle);
+    btn->set_access_label("Mute");
+    btn->set_access_pressed("true");
+
+    auto chk = std::make_unique<Probe>();
+    chk->set_access_role(View::AccessRole::toggle);
+    chk->set_access_label("Tri-state filter");
+    chk->set_access_checked("mixed");
+    chk->set_access_disabled("false");
+
+    auto hidden = std::make_unique<Probe>();
+    hidden->set_access_role(View::AccessRole::label);
+    hidden->set_access_label("Decorative icon");
+    hidden->set_access_hidden("true");
+
+    root.add_child(std::move(btn));
+    root.add_child(std::move(chk));
+    root.add_child(std::move(hidden));
+
+    auto nodes = snapshot_accessibility_tree(root);
+    REQUIRE(nodes.size() == 3);
+
+    REQUIRE(nodes[0].label == "Mute");
+    REQUIRE(nodes[0].pressed  == "true");
+    REQUIRE(nodes[0].checked.empty());
+    REQUIRE(nodes[0].disabled.empty());
+    REQUIRE(nodes[0].hidden.empty());
+
+    REQUIRE(nodes[1].label == "Tri-state filter");
+    REQUIRE(nodes[1].checked  == "mixed");
+    REQUIRE(nodes[1].disabled == "false");
+    REQUIRE(nodes[1].pressed.empty());
+
+    REQUIRE(nodes[2].label == "Decorative icon");
+    REQUIRE(nodes[2].hidden == "true");
+}


### PR DESCRIPTION
## Summary

Closes Codex P1+P2 findings on #1766. The original PR added ARIA state slots on View but the accessibility exporters (NSAccessibility + cross-platform snapshot) didn’t read them — assistive tech saw nothing change. Catalog flip to `supported` was premature.

**This PR wires the surfacing**:

- `core/view/src/accessibility_tree.cpp` — snapshot now copies all 4 ARIA state slots into AccessibilityNodeSnapshot fields.
- `core/view/include/pulp/view/accessibility_tree.hpp` — adds pressed/checked/disabled/hidden fields (tri-state per ARIA 1.2).
- `core/view/platform/mac/accessibility_mac.mm`:
  - `accessibilityValue` returns `@YES` / `@NO` / `@"mixed"` for aria-checked (priority) or aria-pressed; falls through to legacy access_value() otherwise.
  - new `isAccessibilityEnabled` returns NO when aria-disabled="true".
  - `isAccessibilityElement` suppresses aria-hidden="true" elements.

## Test plan

- [x] test/test_accessibility_tree.cpp [issue-1737] — new TEST_CASE drives 4 state attrs across 3 views; asserts snapshot carries each value (12 new assertions).
- [x] All 7 accessibility-tree tests pass (was 6, +1 new).
- [x] Catalog html/ARIA stays supported — now actually accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)