### PR TITLE
fix(css): tie :root pseudo to body identity, not null parent (Codex P2 on #1779)

### DIFF
--- a/core/view/js/web-compat-document.js
+++ b/core/view/js/web-compat-document.js
@@ -577,20 +577,29 @@ function _matchesPseudoClass(el, pseudo) {
         return !!parent && parent._children && parent._children.length === 1
             && parent._children[0] === el;
     }
-    // pulp #1737 (Codex P2 followup #2 on #1773): `:root` matcher
-    // restored. The earlier removal broke StyleSheet._applyTo, which
-    // calls _matchesSelector directly to apply `:root { ... }` rules
-    // to the body — without the matcher branch, those rules silently
-    // stopped working (CSS token / theme patterns regressed).
+    // pulp #1737 (Codex P2 followup #3 on #1779): `:root` matches the
+    // document root element specifically (`__bodyElement__`), not any
+    // element with no parent. The previous `!el._parentElement` check
+    // also matched DETACHED elements (createElement before appendChild),
+    // which leaked `:root { ... }` theme/layout styles into normal
+    // nodes when they were later inserted. StyleSheet.attach() walks
+    // every entry in `__elements__` so the bug surfaced for any element
+    // created mid-stylesheet-life.
+    //
+    // Tied to the root via identity check — __bodyElement__ is the
+    // synthetic body element this shim creates at the top of
+    // web-compat-document.js. Detached elements still have a non-null
+    // _parentElement once mounted (and even pre-mount they're never
+    // === __bodyElement__), so this branch is safe.
     //
     // Catalog still doesn't claim :root for document.querySelector
     // because _findMatch starts traversal from root._children — the
     // root itself is never queued. So:
-    //   * stylesheet `:root { color: red }` → applies (this branch).
+    //   * stylesheet `:root { color: red }` → applies to body (this branch).
     //   * document.querySelector(':root') → returns null (traversal
     //     never sees the root). Catalog supportedValues notes the gap.
     if (lower === "root") {
-        return !el._parentElement;
+        return el === __bodyElement__;
     }
     if (lower === "empty") {
         return !el._children || el._children.length === 0;

--- a/test/web-compat/test_web_compat_prelude.cpp
+++ b/test/web-compat/test_web_compat_prelude.cpp
@@ -1349,3 +1349,37 @@ TEST_CASE("WebCompat: :root pseudo applies stylesheet rules to body element",
     auto applied = env.engine.evaluate("__bodyElement__.style._props.width");
     REQUIRE(std::string(applied.getWithDefault<std::string_view>("")) == "7px");
 }
+
+// pulp #1737 (Codex P2 followup #3 on #1779): `:root` must match the
+// actual document root (body), NOT any element with a null parent.
+// Pre-fix the matcher returned true for `!el._parentElement`, which
+// also matched DETACHED elements (createElement before appendChild),
+// leaking `:root { ... }` styles into normal nodes when they were
+// later inserted. Tied to identity check `el === __bodyElement__`.
+TEST_CASE("WebCompat: :root pseudo does not match detached elements",
+          "[webcompat][css-pseudo][issue-1737][issue-1779-followup]") {
+    TestEnvironment env;
+    env.eval(R"JS(
+        // Detached element — has no _parentElement but is NOT the root.
+        var __detached = document.createElement('div');
+        __detached.id = 'detached-target';
+        // Don't appendChild — leave detached.
+
+        var __rSheet = new StyleSheet({ ':root': { width: '99px' } });
+        __rSheet._parsedRules[0].parsed.pseudo = 'root';
+        __rSheet.attach();
+
+        // Pre-fix: detached element matched :root and got width:99px.
+        // Post-fix: detached element does NOT match — width slot stays
+        // empty (no rule applied).
+    )JS");
+    auto detached_width = env.engine.evaluate(
+        "__detached.style._props.width || ''");
+    REQUIRE(std::string(detached_width.getWithDefault<std::string_view>(""))
+            == "");
+    // Sanity: body still gets the rule.
+    auto body_width = env.engine.evaluate(
+        "__bodyElement__.style._props.width || ''");
+    REQUIRE(std::string(body_width.getWithDefault<std::string_view>(""))
+            == "99px");
+}


### PR DESCRIPTION
## Summary

Codex caught a real over-match in PR #1779: `!el._parentElement` also matched DETACHED elements (createElement before appendChild), leaking `:root { ... }` styles into normal nodes when they were later inserted.

Fix: identity check `el === __bodyElement__`. Tied to the actual document root; detached elements never match.

## Test plan

- [x] [issue-1779-followup] — detached element does NOT match :root; body still does.
- [x] [issue-1773-followup] — body still gets `:root { ... }` styles applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)