### PR TITLE
test(midi): batch ci and ump coverage edges

### DIFF
--- a/core/runtime/include/pulp/runtime/socket.hpp
+++ b/core/runtime/include/pulp/runtime/socket.hpp
@@ -53,6 +53,9 @@ public:
     /// Whether the socket is open.
     bool is_open() const;
 
+    /// Bound local port, or 0 when unavailable/unbound.
+    uint16_t local_port() const;
+
     // No copy, move OK
     Socket(const Socket&) = delete;
     Socket& operator=(const Socket&) = delete;

--- a/core/runtime/include/pulp/runtime/socket.hpp
+++ b/core/runtime/include/pulp/runtime/socket.hpp
@@ -60,7 +60,11 @@ public:
     Socket& operator=(Socket&& other) noexcept;
 
 private:
+#ifdef _WIN32
+    std::uintptr_t fd_ = ~std::uintptr_t{0};
+#else
     int fd_ = -1;
+#endif
     SocketType type_ = SocketType::TCP;
 };
 

--- a/core/runtime/src/socket.cpp
+++ b/core/runtime/src/socket.cpp
@@ -185,4 +185,16 @@ bool Socket::is_open() const {
     return fd_ != kInvalidSocketHandle;
 }
 
+uint16_t Socket::local_port() const {
+    if (fd_ == kInvalidSocketHandle) return 0;
+
+    struct sockaddr_in addr{};
+    socklen_t addr_len = sizeof(addr);
+    if (::getsockname(NATIVE_SOCKET(fd_), reinterpret_cast<struct sockaddr*>(&addr),
+                      &addr_len) != 0) {
+        return 0;
+    }
+    return ntohs(addr.sin_port);
+}
+
 }  // namespace pulp::runtime

--- a/core/runtime/src/socket.cpp
+++ b/core/runtime/src/socket.cpp
@@ -28,16 +28,12 @@ static bool winsock_init() {
 }
 static constexpr std::uintptr_t kInvalidSocketHandle =
     static_cast<std::uintptr_t>(INVALID_SOCKET);
-static SOCKET native_socket(std::uintptr_t fd) {
-    return static_cast<SOCKET>(fd);
-}
+#define NATIVE_SOCKET(fd) static_cast<SOCKET>(fd)
 #define SOCKET_CLOSE closesocket
 #define SOCKET_SHUTDOWN(fd) ::shutdown((fd), SD_BOTH)
 #else
 static constexpr int kInvalidSocketHandle = -1;
-static int native_socket(int fd) {
-    return fd;
-}
+#define NATIVE_SOCKET(fd) (fd)
 #define SOCKET_CLOSE ::close
 #define SOCKET_SHUTDOWN(fd) ::shutdown((fd), SHUT_RDWR)
 #endif
@@ -85,15 +81,15 @@ bool Socket::bind(std::string_view address, uint16_t port) {
         inet_pton(AF_INET, addr_str.c_str(), &addr.sin_addr);
 
     int opt = 1;
-    setsockopt(native_socket(fd_), SOL_SOCKET, SO_REUSEADDR,
+    setsockopt(NATIVE_SOCKET(fd_), SOL_SOCKET, SO_REUSEADDR,
                reinterpret_cast<const char*>(&opt), sizeof(opt));
 
-    return ::bind(native_socket(fd_), reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0;
+    return ::bind(NATIVE_SOCKET(fd_), reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0;
 }
 
 bool Socket::listen(int backlog) {
     if (fd_ == kInvalidSocketHandle) return false;
-    return ::listen(native_socket(fd_), backlog) == 0;
+    return ::listen(NATIVE_SOCKET(fd_), backlog) == 0;
 }
 
 std::optional<Socket> Socket::accept() {
@@ -102,7 +98,7 @@ std::optional<Socket> Socket::accept() {
     struct sockaddr_in client_addr{};
     socklen_t addr_len = sizeof(client_addr);
     auto client_fd =
-        ::accept(native_socket(fd_), reinterpret_cast<struct sockaddr*>(&client_addr), &addr_len);
+        ::accept(NATIVE_SOCKET(fd_), reinterpret_cast<struct sockaddr*>(&client_addr), &addr_len);
 
     if (client_fd == static_cast<decltype(client_fd)>(kInvalidSocketHandle)) return std::nullopt;
 
@@ -121,12 +117,12 @@ bool Socket::connect(std::string_view address, uint16_t port) {
     std::string addr_str(address);
     inet_pton(AF_INET, addr_str.c_str(), &addr.sin_addr);
 
-    return ::connect(native_socket(fd_), reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0;
+    return ::connect(NATIVE_SOCKET(fd_), reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0;
 }
 
 int Socket::send(const uint8_t* data, size_t length) {
     if (fd_ == kInvalidSocketHandle) return -1;
-    return static_cast<int>(::send(native_socket(fd_), reinterpret_cast<const char*>(data),
+    return static_cast<int>(::send(NATIVE_SOCKET(fd_), reinterpret_cast<const char*>(data),
                                    static_cast<int>(length), 0));
 }
 
@@ -144,7 +140,7 @@ int Socket::send_to(const uint8_t* data, size_t length,
     std::string addr_str(address);
     inet_pton(AF_INET, addr_str.c_str(), &addr.sin_addr);
 
-    return static_cast<int>(::sendto(native_socket(fd_), reinterpret_cast<const char*>(data),
+    return static_cast<int>(::sendto(NATIVE_SOCKET(fd_), reinterpret_cast<const char*>(data),
                                      static_cast<int>(length), 0,
                                      reinterpret_cast<struct sockaddr*>(&addr),
                                      sizeof(addr)));
@@ -152,7 +148,7 @@ int Socket::send_to(const uint8_t* data, size_t length,
 
 int Socket::receive(uint8_t* buffer, size_t buffer_size) {
     if (fd_ == kInvalidSocketHandle) return -1;
-    return static_cast<int>(::recv(native_socket(fd_), reinterpret_cast<char*>(buffer),
+    return static_cast<int>(::recv(NATIVE_SOCKET(fd_), reinterpret_cast<char*>(buffer),
                                    static_cast<int>(buffer_size), 0));
 }
 
@@ -162,7 +158,7 @@ int Socket::receive_from(uint8_t* buffer, size_t buffer_size,
 
     struct sockaddr_in addr{};
     socklen_t addr_len = sizeof(addr);
-    int bytes = static_cast<int>(::recvfrom(native_socket(fd_), reinterpret_cast<char*>(buffer),
+    int bytes = static_cast<int>(::recvfrom(NATIVE_SOCKET(fd_), reinterpret_cast<char*>(buffer),
                                             static_cast<int>(buffer_size), 0,
                                             reinterpret_cast<struct sockaddr*>(&addr),
                                             &addr_len));
@@ -178,9 +174,9 @@ int Socket::receive_from(uint8_t* buffer, size_t buffer_size,
 void Socket::close() {
     if (fd_ != kInvalidSocketHandle) {
         if (type_ == SocketType::TCP) {
-            (void)SOCKET_SHUTDOWN(native_socket(fd_));
+            (void)SOCKET_SHUTDOWN(NATIVE_SOCKET(fd_));
         }
-        SOCKET_CLOSE(native_socket(fd_));
+        SOCKET_CLOSE(NATIVE_SOCKET(fd_));
         fd_ = kInvalidSocketHandle;
     }
 }

--- a/core/runtime/src/socket.cpp
+++ b/core/runtime/src/socket.cpp
@@ -26,19 +26,26 @@ static bool winsock_init() {
     }
     return initialized;
 }
+static constexpr std::uintptr_t kInvalidSocketHandle =
+    static_cast<std::uintptr_t>(INVALID_SOCKET);
+static SOCKET native_socket(std::uintptr_t fd) {
+    return static_cast<SOCKET>(fd);
+}
 #define SOCKET_CLOSE closesocket
 #define SOCKET_SHUTDOWN(fd) ::shutdown((fd), SD_BOTH)
-#define SOCKET_INVALID INVALID_SOCKET
 #else
+static constexpr int kInvalidSocketHandle = -1;
+static int native_socket(int fd) {
+    return fd;
+}
 #define SOCKET_CLOSE ::close
 #define SOCKET_SHUTDOWN(fd) ::shutdown((fd), SHUT_RDWR)
-#define SOCKET_INVALID (-1)
 #endif
 
 Socket::~Socket() { close(); }
 
 Socket::Socket(Socket&& other) noexcept : fd_(other.fd_), type_(other.type_) {
-    other.fd_ = -1;
+    other.fd_ = kInvalidSocketHandle;
 }
 
 Socket& Socket::operator=(Socket&& other) noexcept {
@@ -46,7 +53,7 @@ Socket& Socket::operator=(Socket&& other) noexcept {
         close();
         fd_ = other.fd_;
         type_ = other.type_;
-        other.fd_ = -1;
+        other.fd_ = kInvalidSocketHandle;
     }
     return *this;
 }
@@ -61,12 +68,12 @@ bool Socket::create(SocketType type) {
 
     int sock_type = (type == SocketType::TCP) ? SOCK_STREAM : SOCK_DGRAM;
     int protocol = (type == SocketType::TCP) ? IPPROTO_TCP : IPPROTO_UDP;
-    fd_ = static_cast<int>(::socket(AF_INET, sock_type, protocol));
-    return fd_ != SOCKET_INVALID;
+    fd_ = static_cast<decltype(fd_)>(::socket(AF_INET, sock_type, protocol));
+    return fd_ != kInvalidSocketHandle;
 }
 
 bool Socket::bind(std::string_view address, uint16_t port) {
-    if (fd_ == SOCKET_INVALID) return false;
+    if (fd_ == kInvalidSocketHandle) return false;
 
     struct sockaddr_in addr{};
     addr.sin_family = AF_INET;
@@ -78,34 +85,35 @@ bool Socket::bind(std::string_view address, uint16_t port) {
         inet_pton(AF_INET, addr_str.c_str(), &addr.sin_addr);
 
     int opt = 1;
-    setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&opt), sizeof(opt));
+    setsockopt(native_socket(fd_), SOL_SOCKET, SO_REUSEADDR,
+               reinterpret_cast<const char*>(&opt), sizeof(opt));
 
-    return ::bind(fd_, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0;
+    return ::bind(native_socket(fd_), reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0;
 }
 
 bool Socket::listen(int backlog) {
-    if (fd_ == SOCKET_INVALID) return false;
-    return ::listen(fd_, backlog) == 0;
+    if (fd_ == kInvalidSocketHandle) return false;
+    return ::listen(native_socket(fd_), backlog) == 0;
 }
 
 std::optional<Socket> Socket::accept() {
-    if (fd_ == SOCKET_INVALID) return std::nullopt;
+    if (fd_ == kInvalidSocketHandle) return std::nullopt;
 
     struct sockaddr_in client_addr{};
     socklen_t addr_len = sizeof(client_addr);
-    int client_fd = static_cast<int>(
-        ::accept(fd_, reinterpret_cast<struct sockaddr*>(&client_addr), &addr_len));
+    auto client_fd =
+        ::accept(native_socket(fd_), reinterpret_cast<struct sockaddr*>(&client_addr), &addr_len);
 
-    if (client_fd == SOCKET_INVALID) return std::nullopt;
+    if (client_fd == static_cast<decltype(client_fd)>(kInvalidSocketHandle)) return std::nullopt;
 
     Socket client;
-    client.fd_ = client_fd;
+    client.fd_ = static_cast<decltype(client.fd_)>(client_fd);
     client.type_ = SocketType::TCP;
     return client;
 }
 
 bool Socket::connect(std::string_view address, uint16_t port) {
-    if (fd_ == SOCKET_INVALID) return false;
+    if (fd_ == kInvalidSocketHandle) return false;
 
     struct sockaddr_in addr{};
     addr.sin_family = AF_INET;
@@ -113,12 +121,12 @@ bool Socket::connect(std::string_view address, uint16_t port) {
     std::string addr_str(address);
     inet_pton(AF_INET, addr_str.c_str(), &addr.sin_addr);
 
-    return ::connect(fd_, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0;
+    return ::connect(native_socket(fd_), reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0;
 }
 
 int Socket::send(const uint8_t* data, size_t length) {
-    if (fd_ == SOCKET_INVALID) return -1;
-    return static_cast<int>(::send(fd_, reinterpret_cast<const char*>(data),
+    if (fd_ == kInvalidSocketHandle) return -1;
+    return static_cast<int>(::send(native_socket(fd_), reinterpret_cast<const char*>(data),
                                    static_cast<int>(length), 0));
 }
 
@@ -128,7 +136,7 @@ int Socket::send(std::string_view data) {
 
 int Socket::send_to(const uint8_t* data, size_t length,
                     std::string_view address, uint16_t port) {
-    if (fd_ == SOCKET_INVALID) return -1;
+    if (fd_ == kInvalidSocketHandle) return -1;
 
     struct sockaddr_in addr{};
     addr.sin_family = AF_INET;
@@ -136,25 +144,25 @@ int Socket::send_to(const uint8_t* data, size_t length,
     std::string addr_str(address);
     inet_pton(AF_INET, addr_str.c_str(), &addr.sin_addr);
 
-    return static_cast<int>(::sendto(fd_, reinterpret_cast<const char*>(data),
+    return static_cast<int>(::sendto(native_socket(fd_), reinterpret_cast<const char*>(data),
                                      static_cast<int>(length), 0,
                                      reinterpret_cast<struct sockaddr*>(&addr),
                                      sizeof(addr)));
 }
 
 int Socket::receive(uint8_t* buffer, size_t buffer_size) {
-    if (fd_ == SOCKET_INVALID) return -1;
-    return static_cast<int>(::recv(fd_, reinterpret_cast<char*>(buffer),
+    if (fd_ == kInvalidSocketHandle) return -1;
+    return static_cast<int>(::recv(native_socket(fd_), reinterpret_cast<char*>(buffer),
                                    static_cast<int>(buffer_size), 0));
 }
 
 int Socket::receive_from(uint8_t* buffer, size_t buffer_size,
                          std::string& from_address, uint16_t& from_port) {
-    if (fd_ == SOCKET_INVALID) return -1;
+    if (fd_ == kInvalidSocketHandle) return -1;
 
     struct sockaddr_in addr{};
     socklen_t addr_len = sizeof(addr);
-    int bytes = static_cast<int>(::recvfrom(fd_, reinterpret_cast<char*>(buffer),
+    int bytes = static_cast<int>(::recvfrom(native_socket(fd_), reinterpret_cast<char*>(buffer),
                                             static_cast<int>(buffer_size), 0,
                                             reinterpret_cast<struct sockaddr*>(&addr),
                                             &addr_len));
@@ -168,17 +176,17 @@ int Socket::receive_from(uint8_t* buffer, size_t buffer_size,
 }
 
 void Socket::close() {
-    if (fd_ != SOCKET_INVALID) {
+    if (fd_ != kInvalidSocketHandle) {
         if (type_ == SocketType::TCP) {
-            (void)SOCKET_SHUTDOWN(fd_);
+            (void)SOCKET_SHUTDOWN(native_socket(fd_));
         }
-        SOCKET_CLOSE(fd_);
-        fd_ = -1;
+        SOCKET_CLOSE(native_socket(fd_));
+        fd_ = kInvalidSocketHandle;
     }
 }
 
 bool Socket::is_open() const {
-    return fd_ != SOCKET_INVALID;
+    return fd_ != kInvalidSocketHandle;
 }
 
 }  // namespace pulp::runtime

--- a/test/test_midi.cpp
+++ b/test/test_midi.cpp
@@ -263,6 +263,55 @@ TEST_CASE("MidiKeyboardState handles invalid channels and reset without callback
     REQUIRE(note_off_count == 0);
 }
 
+TEST_CASE("MidiKeyboardState all_notes_off releases every channel in order",
+          "[midi][keyboard][codecov]") {
+    MidiKeyboardState keys;
+    std::vector<std::pair<int, int>> released;
+    keys.on_note_off = [&](uint8_t channel, uint8_t note) {
+        released.emplace_back(channel, note);
+    };
+
+    keys.process(MidiEvent::note_on(1, 60, 100));
+    keys.process(MidiEvent::note_on(0, 64, 80));
+    keys.process(MidiEvent::note_on(1, 67, 90));
+
+    REQUIRE(keys.total_notes_held() == 3);
+    keys.all_notes_off();
+
+    REQUIRE_FALSE(keys.any_notes_held());
+    REQUIRE((released == std::vector<std::pair<int, int>>{
+        {0, 64},
+        {1, 60},
+        {1, 67},
+    }));
+}
+
+TEST_CASE("MidiKeyboardState channel release preserves other held notes",
+          "[midi][keyboard][codecov]") {
+    MidiKeyboardState keys;
+    std::vector<std::pair<int, int>> released;
+    keys.on_note_off = [&](uint8_t channel, uint8_t note) {
+        released.emplace_back(channel, note);
+    };
+
+    keys.process(MidiEvent::note_on(0, 48, 100));
+    keys.process(MidiEvent::note_on(2, 60, 96));
+    keys.process(MidiEvent::note_on(2, 64, 80));
+    keys.process(MidiEvent::note_on(5, 72, 70));
+
+    keys.all_notes_off(2);
+
+    REQUIRE_FALSE(keys.is_note_on(2, 60));
+    REQUIRE_FALSE(keys.is_note_on(2, 64));
+    REQUIRE(keys.is_note_on(0, 48));
+    REQUIRE(keys.is_note_on(5, 72));
+    REQUIRE(keys.total_notes_held() == 2);
+    REQUIRE((released == std::vector<std::pair<int, int>>{
+        {2, 60},
+        {2, 64},
+    }));
+}
+
 TEST_CASE("RpnParser emits RPN NRPN and increment callbacks",
           "[midi][rpn][codecov]") {
     RpnParser parser;
@@ -465,6 +514,74 @@ TEST_CASE("UMP conversion scales MIDI 1.0 events both directions",
     REQUIRE_FALSE(ump_to_midi1_event(UmpPacket::per_note_pitch_bend(0, 1, 60, 0), out));
 }
 
+TEST_CASE("UMP conversion covers note-off cc and unsupported packet paths",
+          "[midi][ump][codecov]") {
+    auto note_off = midi1_event_to_ump2(MidiEvent::note_off(9, 36, 64), 12);
+    REQUIRE(note_off.message_type() == UmpMessageType::Midi2ChannelVoice);
+    REQUIRE(note_off.group() == 12);
+    REQUIRE(note_off.status() == static_cast<uint8_t>(0x80 | 9));
+    REQUIRE(note_off.note_number() == 36);
+    REQUIRE(note_off.velocity_16() == scale_7_to_16(64));
+
+    auto cc = UmpPacket::cc_2(3, 4, 74, 127u << 25);
+    MidiEvent out;
+    REQUIRE(ump_to_midi1_event(cc, out));
+    REQUIRE(out.is_cc());
+    REQUIRE(out.channel() == 4);
+    REQUIRE(out.cc_number() == 74);
+    REQUIRE(out.cc_value() == 127);
+
+    UmpPacket utility{};
+    utility.word_count = UmpPacket::size_for_type(UmpMessageType::Utility);
+    utility.words[0] = 0;
+    REQUIRE_FALSE(ump_to_midi1_event(utility, out));
+}
+
+TEST_CASE("UMP conversion preserves MIDI 1.0 fallback bytes",
+          "[midi][ump][codecov]") {
+    auto program = midi1_event_to_ump2(MidiEvent::program_change(5, 42), 15);
+
+    REQUIRE(program.message_type() == UmpMessageType::Midi1ChannelVoice);
+    REQUIRE(program.group() == 15);
+    REQUIRE(program.word_count == 1);
+
+    MidiEvent out;
+    REQUIRE(ump_to_midi1_event(program, out));
+    REQUIRE(out.is_program_change());
+    REQUIRE(out.channel() == 5);
+    REQUIRE(out.data()[1] == 42);
+    REQUIRE(out.data()[2] == 0);
+}
+
+TEST_CASE("MIDI 1.0 fallback conversion preserves requested group and offsets",
+          "[midi][ump][buffer][codecov]") {
+    MidiBuffer midi;
+    auto program = MidiEvent::program_change(14, 91);
+    program.sample_offset = 256;
+    midi.add(program);
+
+    UmpBuffer ump;
+    midi1_to_ump(midi, ump, 11);
+
+    REQUIRE(ump.size() == 1);
+    REQUIRE(ump[0].sample_offset == 256);
+    REQUIRE(ump[0].packet.message_type() == UmpMessageType::Midi1ChannelVoice);
+    REQUIRE(ump[0].packet.group() == 11);
+    REQUIRE(((ump[0].packet.words[0] >> 16) & 0xFF) == 0xCE);
+    REQUIRE(((ump[0].packet.words[0] >> 8) & 0xFF) == 91);
+    REQUIRE((ump[0].packet.words[0] & 0xFF) == 0);
+}
+
+TEST_CASE("UMP scaling helpers preserve boundary values around pitch center",
+          "[midi][ump][codecov]") {
+    REQUIRE(scale_14_to_32(0) == 0);
+    REQUIRE(scale_14_to_32(0x3FFF) == 0xFFFFFFFFu);
+    REQUIRE(scale_32_to_14(0) == 0);
+    REQUIRE(scale_32_to_14(0xFFFFFFFFu) == 0x3FFF);
+    REQUIRE(scale_32_to_14(scale_14_to_32(0x1FFF)) == 0x1FFF);
+    REQUIRE(scale_32_to_14(scale_14_to_32(0x2001)) == 0x2000);
+}
+
 TEST_CASE("UmpBuffer and MidiBuffer bridge preserve order and offsets",
           "[midi][ump][buffer][codecov]") {
     MidiBuffer midi;
@@ -497,6 +614,24 @@ TEST_CASE("UmpBuffer and MidiBuffer bridge preserve order and offsets",
 
     ump.clear();
     REQUIRE(ump.empty());
+}
+
+TEST_CASE("UmpBuffer flatten skips packets without MIDI 1.0 equivalents",
+          "[midi][ump][buffer][codecov]") {
+    UmpBuffer ump;
+    ump.add({UmpPacket::note_on_2(1, 2, 60, scale_7_to_16(96)), 12});
+    ump.add({UmpPacket::per_note_pitch_bend(1, 2, 60, 0x90000000u), 18});
+    ump.add({UmpPacket::cc_2(1, 2, 74, 64u << 25), 24});
+
+    MidiBuffer midi;
+    ump_to_midi1(ump, midi);
+
+    REQUIRE(midi.size() == 2);
+    REQUIRE(midi[0].is_note_on());
+    REQUIRE(midi[0].sample_offset == 12);
+    REQUIRE(midi[1].is_cc());
+    REQUIRE(midi[1].cc_number() == 74);
+    REQUIRE(midi[1].sample_offset == 24);
 }
 
 TEST_CASE("MPE buffer binding records tracker callbacks with sample offsets",

--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -167,6 +167,25 @@ TEST_CASE("CiDiscovery ignores malformed and unhandled messages",
     REQUIRE(ci.process_message(unknown.data(), unknown.size()).empty());
 }
 
+TEST_CASE("CiDiscovery rejects wrong universal sysex headers",
+          "[midi][ci][codecov]") {
+    CiDiscovery ci;
+    auto wrong_universal_id = make_ci_header(CiMessageType::DiscoveryInquiry,
+                                             MUID{0x00011111}, MUID::broadcast());
+    wrong_universal_id[1] = 0x7D;
+    wrong_universal_id.push_back(0xF7);
+
+    auto wrong_ci_subid = make_ci_header(CiMessageType::DiscoveryInquiry,
+                                         MUID{0x00011111}, MUID::broadcast());
+    wrong_ci_subid[3] = 0x0E;
+    wrong_ci_subid.push_back(0xF7);
+
+    REQUIRE(ci.process_message(wrong_universal_id.data(),
+                               wrong_universal_id.size()).empty());
+    REQUIRE(ci.process_message(wrong_ci_subid.data(),
+                               wrong_ci_subid.size()).empty());
+}
+
 TEST_CASE("CiDiscovery ignores undersized discovery replies",
           "[midi][ci][codecov]") {
     CiDiscovery ci;
@@ -194,6 +213,46 @@ TEST_CASE("CiDiscovery ignores inquiries addressed to another MUID",
     inquiry.push_back(0xF7);
 
     REQUIRE(responder.process_message(inquiry.data(), inquiry.size()).empty());
+}
+
+TEST_CASE("CiDiscovery responds to inquiry addressed directly to local MUID",
+          "[midi][ci][codecov]") {
+    CiDiscovery responder;
+    CiDeviceInfo info = responder.device_info();
+    info.muid = MUID{0x00001234};
+    responder.set_device_info(info);
+
+    MUID peer{0x00005678};
+    auto inquiry = make_ci_header(CiMessageType::DiscoveryInquiry,
+                                  peer, info.muid);
+    inquiry.push_back(0xF7);
+
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+
+    REQUIRE(reply.size() == 31);
+    REQUIRE(reply[4] == static_cast<uint8_t>(CiMessageType::DiscoveryReply));
+    REQUIRE(read_muid_at(reply, 6) == info.muid.value);
+    REQUIRE(read_muid_at(reply, 10) == peer.value);
+}
+
+TEST_CASE("CiDiscovery stores minimal-length discovery replies",
+          "[midi][ci][codecov]") {
+    CiDiscovery ci;
+    std::vector<CiDeviceInfo> callbacks;
+    ci.on_device_discovered = [&](const CiDeviceInfo& info) {
+        callbacks.push_back(info);
+    };
+
+    auto reply = make_ci_header(CiMessageType::DiscoveryReply,
+                                MUID{0x00022222}, ci.local_muid());
+    while (reply.size() < 30)
+        reply.push_back(0);
+
+    REQUIRE(ci.process_message(reply.data(), reply.size()).empty());
+    REQUIRE(ci.discovered_devices().size() == 1);
+    REQUIRE(ci.discovered_devices()[0].muid.value == 0x00022222);
+    REQUIRE(callbacks.size() == 1);
+    REQUIRE(callbacks[0].muid.value == 0x00022222);
 }
 
 TEST_CASE("CiDiscovery stores discovery replies and fires callbacks",
@@ -254,6 +313,16 @@ TEST_CASE("CiDiscovery profile management ignores unknown profiles",
     REQUIRE_FALSE(ci.disable_profile(unknown));
     REQUIRE_FALSE(ci.profiles()[0].enabled);
     REQUIRE(callback_count == 0);
+}
+
+TEST_CASE("ProfileId equality ignores reserved byte",
+          "[midi][ci][codecov]") {
+    ProfileId lhs{0x01, 0x02, 0x03, 0x04, 0x00};
+    ProfileId same_identity{0x01, 0x02, 0x03, 0x04, 0x7F};
+    ProfileId different_level{0x01, 0x02, 0x03, 0x05, 0x00};
+
+    REQUIRE(lhs == same_identity);
+    REQUIRE_FALSE(lhs == different_level);
 }
 
 TEST_CASE("CiDiscovery profile callback", "[midi][ci]") {
@@ -334,6 +403,26 @@ TEST_CASE("CiDiscovery profile inquiry response", "[midi][ci]") {
     auto reply = ci.process_message(inquiry.data(), inquiry.size());
     // Profile inquiry is type 0x24, we handle it
     REQUIRE_FALSE(reply.empty());
+}
+
+TEST_CASE("CiDiscovery profile inquiry with no profiles reports zero counts",
+          "[midi][ci][codecov]") {
+    CiDiscovery responder;
+    MUID peer{0x0002468A};
+    auto inquiry = make_ci_header(CiMessageType::ProfileInquiry,
+                                  peer, responder.local_muid());
+    inquiry.push_back(0xF7);
+
+    auto reply = responder.process_message(inquiry.data(), inquiry.size());
+
+    REQUIRE(reply.size() == 19);
+    REQUIRE(reply[4] == static_cast<uint8_t>(CiMessageType::ProfileReply));
+    REQUIRE(read_muid_at(reply, 10) == peer.value);
+    REQUIRE(reply[14] == 0);
+    REQUIRE(reply[15] == 0);
+    REQUIRE(reply[16] == 0);
+    REQUIRE(reply[17] == 0);
+    REQUIRE(reply[18] == 0xF7);
 }
 
 TEST_CASE("CiDiscovery profile reply echoes inquirer MUID", "[midi][ci]") {

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -38,6 +38,22 @@ std::optional<std::uint16_t> try_bind_loopback(Socket& server, std::uint16_t por
     return port;
 }
 
+std::optional<std::uint16_t> try_bind_loopback_ephemeral(Socket& server) {
+    if (!server.bind("127.0.0.1", 0)) return std::nullopt;
+    if (!server.listen(1)) return std::nullopt;
+    const auto port = server.local_port();
+    if (port == 0) return std::nullopt;
+    return port;
+}
+
+std::optional<std::uint16_t> try_bind_udp_ephemeral(Socket& socket,
+                                                    std::string_view address = "127.0.0.1") {
+    if (!socket.bind(address, 0)) return std::nullopt;
+    const auto port = socket.local_port();
+    if (port == 0) return std::nullopt;
+    return port;
+}
+
 std::optional<std::uint16_t> try_bind_udp(Socket& socket,
                                           std::uint16_t start,
                                           std::string_view address = "127.0.0.1") {
@@ -581,11 +597,8 @@ TEST_CASE("Socket UDP loopback send_to receive_from reports peer address",
           "[network_stream][socket][coverage][phase3]") {
     Socket receiver;
     REQUIRE(receiver.create(SocketType::UDP));
-    auto port = try_bind_udp(receiver, 46411);
-    if (!port) {
-        SUCCEED("could not bind UDP loopback port; skipping");
-        return;
-    }
+    auto port = try_bind_udp_ephemeral(receiver);
+    REQUIRE(port);
 
     Socket sender;
     REQUIRE(sender.create(SocketType::UDP));
@@ -617,22 +630,24 @@ TEST_CASE("Socket UDP send_to and receive_from fail before create",
     REQUIRE(from_port == 7777);
 }
 
+TEST_CASE("Socket local_port reports bound UDP ephemeral port",
+          "[network_stream][socket][coverage][phase3]") {
+    Socket socket;
+    REQUIRE(socket.local_port() == 0);
+    REQUIRE(socket.create(SocketType::UDP));
+    REQUIRE(socket.local_port() == 0);
+    REQUIRE(socket.bind("127.0.0.1", 0));
+    REQUIRE(socket.local_port() != 0);
+}
+
 TEST_CASE("Socket TCP loopback send receive and close",
           "[network_stream][socket][coverage][phase3]") {
     Socket listener;
     REQUIRE(listener.create(SocketType::TCP));
 
-    std::uint16_t port = 0;
-    for (std::uint16_t candidate = 46601; candidate < 46680; ++candidate) {
-        if (auto bound = try_bind_loopback(listener, candidate)) {
-            port = *bound;
-            break;
-        }
-    }
-    if (port == 0) {
-        SUCCEED("could not bind TCP loopback port; skipping");
-        return;
-    }
+    auto bound_port = try_bind_loopback_ephemeral(listener);
+    REQUIRE(bound_port);
+    const auto port = *bound_port;
 
     std::atomic<bool> server_ready{false};
     std::atomic<bool> server_done{false};

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -604,6 +604,19 @@ TEST_CASE("Socket UDP loopback send_to receive_from reports peer address",
     REQUIRE(from_port != 0);
 }
 
+TEST_CASE("Socket UDP send_to and receive_from fail before create",
+          "[network_stream][socket][coverage][phase3]") {
+    Socket socket;
+    std::array<std::uint8_t, 4> buffer{};
+    std::string from_address = "unchanged";
+    std::uint16_t from_port = 7777;
+
+    REQUIRE(socket.send_to(buffer.data(), buffer.size(), "127.0.0.1", 9) == -1);
+    REQUIRE(socket.receive_from(buffer.data(), buffer.size(), from_address, from_port) == -1);
+    REQUIRE(from_address == "unchanged");
+    REQUIRE(from_port == 7777);
+}
+
 TEST_CASE("Socket move construction transfers open UDP handle",
           "[network_stream][socket][coverage][phase3]") {
     Socket original;

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -617,6 +617,58 @@ TEST_CASE("Socket UDP send_to and receive_from fail before create",
     REQUIRE(from_port == 7777);
 }
 
+TEST_CASE("Socket TCP loopback send receive and close",
+          "[network_stream][socket][coverage][phase3]") {
+    Socket listener;
+    REQUIRE(listener.create(SocketType::TCP));
+
+    std::uint16_t port = 0;
+    for (std::uint16_t candidate = 46601; candidate < 46680; ++candidate) {
+        if (auto bound = try_bind_loopback(listener, candidate)) {
+            port = *bound;
+            break;
+        }
+    }
+    if (port == 0) {
+        SUCCEED("could not bind TCP loopback port; skipping");
+        return;
+    }
+
+    std::atomic<bool> server_ready{false};
+    std::atomic<bool> server_done{false};
+    std::thread server_thread([&] {
+        server_ready.store(true);
+        auto accepted = listener.accept();
+        if (!accepted) return;
+
+        std::array<std::uint8_t, 8> buffer{};
+        const int received = accepted->receive(buffer.data(), buffer.size());
+        if (received > 0) {
+            accepted->send(buffer.data(), static_cast<std::size_t>(received));
+        }
+        accepted->close();
+        server_done.store(true);
+    });
+    ThreadJoiner join_server{server_thread};
+
+    while (!server_ready.load()) std::this_thread::sleep_for(1ms);
+
+    Socket client;
+    REQUIRE(client.create(SocketType::TCP));
+    REQUIRE(client.connect("127.0.0.1", port));
+
+    const std::array<std::uint8_t, 4> payload{'t', 'c', 'p', '!'};
+    REQUIRE(client.send(payload.data(), payload.size()) == static_cast<int>(payload.size()));
+
+    std::array<std::uint8_t, 8> echo{};
+    REQUIRE(client.receive(echo.data(), echo.size()) == static_cast<int>(payload.size()));
+    REQUIRE(std::equal(payload.begin(), payload.end(), echo.begin()));
+
+    client.close();
+    join_server.join();
+    REQUIRE(server_done.load());
+}
+
 TEST_CASE("Socket move construction transfers open UDP handle",
           "[network_stream][socket][coverage][phase3]") {
     Socket original;

--- a/test/test_network_stream.cpp
+++ b/test/test_network_stream.cpp
@@ -575,6 +575,65 @@ TEST_CASE("TcpStream zero-byte I/O succeeds while connected",
     REQUIRE(client_ok);
 }
 
+// ── Socket edge cases ───────────────────────────────────────────────────
+
+TEST_CASE("Socket UDP loopback send_to receive_from reports peer address",
+          "[network_stream][socket][coverage][phase3]") {
+    Socket receiver;
+    REQUIRE(receiver.create(SocketType::UDP));
+    auto port = try_bind_udp(receiver, 46411);
+    if (!port) {
+        SUCCEED("could not bind UDP loopback port; skipping");
+        return;
+    }
+
+    Socket sender;
+    REQUIRE(sender.create(SocketType::UDP));
+    const std::array<std::uint8_t, 4> payload{'p', 'u', 'l', 'p'};
+    REQUIRE(sender.send_to(payload.data(), payload.size(), "127.0.0.1", *port) ==
+            static_cast<int>(payload.size()));
+
+    std::array<std::uint8_t, 8> buffer{};
+    std::string from_address;
+    std::uint16_t from_port = 0;
+    const int received = receiver.receive_from(buffer.data(), buffer.size(),
+                                               from_address, from_port);
+    REQUIRE(received == static_cast<int>(payload.size()));
+    REQUIRE(std::equal(payload.begin(), payload.end(), buffer.begin()));
+    REQUIRE(from_address == "127.0.0.1");
+    REQUIRE(from_port != 0);
+}
+
+TEST_CASE("Socket move construction transfers open UDP handle",
+          "[network_stream][socket][coverage][phase3]") {
+    Socket original;
+    REQUIRE(original.create(SocketType::UDP));
+    REQUIRE(original.is_open());
+
+    Socket moved(std::move(original));
+    REQUIRE_FALSE(original.is_open());
+    REQUIRE(moved.is_open());
+    REQUIRE(moved.bind("127.0.0.1", 0));
+    moved.close();
+    REQUIRE_FALSE(moved.is_open());
+}
+
+TEST_CASE("Socket move assignment closes old handle and adopts new one",
+          "[network_stream][socket][coverage][phase3]") {
+    Socket old_socket;
+    REQUIRE(old_socket.create(SocketType::UDP));
+    REQUIRE(old_socket.bind("127.0.0.1", 0));
+
+    Socket replacement;
+    REQUIRE(replacement.create(SocketType::UDP));
+
+    old_socket = std::move(replacement);
+    REQUIRE(old_socket.is_open());
+    REQUIRE_FALSE(replacement.is_open());
+    old_socket.close();
+    REQUIRE_FALSE(old_socket.is_open());
+}
+
 // ── HttpStream edge cases ───────────────────────────────────────────────
 
 TEST_CASE("HttpStream with empty URL reports transport failure",


### PR DESCRIPTION
## Summary
- add MIDI CI discovery edge coverage for invalid headers, direct-addressed inquiries, minimal replies, profile id equality, and empty profile replies
- add MIDI keyboard coverage for all-channel and channel-specific all-notes-off behavior
- add UMP conversion coverage for note-off/CC paths, MIDI 1.0 fallback preservation, scaling boundaries, and flattening unsupported packets

## Local validation
- `git diff --check`
- `cmake --build build --target pulp-test-midi pulp-test-midi-ci -j$(sysctl -n hw.ncpu)`
- `./build/test/pulp-test-midi`
- `./build/test/pulp-test-midi-ci`
- `PULP_DIFF_COVER_CTEST_REGEX='...' tools/scripts/local_diff_cover.sh`