### PR TITLE
feat(motion): Phases 8-10 + cost attribution + timeline scrubber

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -46,7 +46,7 @@ requires:
 audio, cache, clean, export-tokens, ci-local, design-debug, harness, help, projects, project
 
 **Commands that DO have slash commands** (list for cross-reference, not exhaustive — `ls .claude/commands/` is authoritative):
-build, test, run, validate, ship, version, doctor, create, docs, status, design, import-design, inspect, pr, ci, upgrade, prototype-loop
+build, test, run, validate, ship, version, doctor, create, docs, status, design, import-design, inspect, pr, ci, upgrade, prototype-loop, motion
 
 ### 4. Update docs
 - [ ] Add/update section in `docs/reference/cli.md`

--- a/.agents/skills/motion/SKILL.md
+++ b/.agents/skills/motion/SKILL.md
@@ -17,6 +17,7 @@ based on what's observable.
 | A captured frame sequence (no app instrumentation available) | **Visual analysis** | `tools/motion/visual/analyze_sequence.py` |
 | A previously recorded `.motion.jsonl` fixture | **Replay + assert** | `motion::replay_fixture` + `motion::assert_matches` |
 | An interaction that drives the suspect motion | **Input record + replay** | `motion::make_input_recorder` + `motion::replay_inputs` |
+| A fixture + an inspector client (design review / CI triage) | **Timeline scrubber** | `Motion.loadFixture` + `Motion.scrubTo` over the inspector wire |
 | Imported design + intent doc (e.g. "fade in 350 ms ease-out") | **Both** | Record a fixture from the import, assert timing/monotonicity |
 
 ## Path A — Runtime trace
@@ -208,6 +209,50 @@ primitives — matches the originally-recorded one within
 `FixtureMatchOptions::timing_epsilon_seconds`. Use the ID-keyed
 `assert_matches` for the comparison so reordered identical bursts don't
 false-fail.
+## Path E — Timeline scrubber (inspector replay)
+
+`pulp::inspect::MotionScrubber` loads a `.motion.jsonl` fixture and
+re-emits the prefix of events with `frame <= playhead` to caller
+sinks and (when attached to an `InspectorServer`) to inspector clients
+over the wire. The scrubber is passive — no clock is pumped, no
+animation runs live; `play()` is a jump-to-end that emits every event.
+Real-time pacing and live overlay drawing are intentionally Phase 11+.
+
+Protocol surface (routed by `DomainHandler::handle_motion`):
+
+| Method               | Params              | Response                                                |
+|----------------------|---------------------|---------------------------------------------------------|
+| `Motion.loadFixture` | `{ path }`          | `{ ok, event_count, max_frame, header: {version,policy,duration_scale} }` |
+| `Motion.scrubTo`     | `{ frame }`         | `{ playhead_frame, emitted_count }` + broadcast events  |
+| `Motion.play`        | `{}`                | `{ playing:true, emitted_count, playhead_frame }`       |
+| `Motion.pause`       | `{}`                | `{ playing:false, playhead_frame }`                     |
+
+Broadcast events reuse `MotionInspector`'s `Motion.start / .sample /
+.end` shape, with an additional `"replay":true` marker so clients can
+distinguish replayed bursts from live coordinator events on the same
+wire.
+
+Direct C++ usage:
+
+```cpp
+pulp::inspect::MotionScrubber scrub(/*server=*/nullptr);
+std::vector<motion::SampleEvent> buf;
+scrub.add_sink(motion::make_buffer_sink(&buf));
+scrub.load_fixture("captures/card-open.motion.jsonl");
+scrub.scrub_to(120);   // emits prefix with frame <= 120
+scrub.scrub_to(0);     // emits only the frame-0 prefix (backwards scrub)
+scrub.play();          // jump to max frame, emit everything
+```
+
+Gotchas:
+
+- `load_fixture` is passive. Sinks see no events until `scrub_to` /
+  `play` is called. Don't pre-clear UI overlays on `loadFixture` and
+  expect a refill — wait for the first `scrub_to`.
+- Backwards scrubs re-emit from frame 0. If your sink accumulates,
+  clear it before each scrub or compare counts modulo the prefix size.
+- Replayed event timestamps (`t_seconds`) are the recording's
+  timestamps, not wall clock. Don't drive a live clock from them.
 
 ## Agent contract
 
@@ -243,6 +288,8 @@ Apply these on every motion debugging run:
 - `core/view/platform/win/motion_preferences_win.cpp` — SPI_GETCLIENTAREAANIMATION query
 - `inspect/include/pulp/inspect/motion_inspector.hpp` — Motion inspector bridge
 - `inspect/src/motion_inspector.cpp` — protocol handler + event broadcaster
+- `inspect/include/pulp/inspect/motion_scrubber.hpp` — timeline scrubber (Phase 7)
+- `inspect/src/motion_scrubber.cpp` — passive fixture replay + scrubber dispatch
 - `tools/motion/visual/analyze_sequence.py` — visual analysis CLI
 - `tools/motion/visual/test_self_check.py` — pipeline self-check
 - `examples/ui-preview/main.cpp` — env-knob wiring for the standalone host

--- a/.agents/skills/motion/SKILL.md
+++ b/.agents/skills/motion/SKILL.md
@@ -222,6 +222,38 @@ fixture. When you read a fixture and the burst looks wrong, the provenance
 tells you which file / Figma node / animator the trace was attached to —
 without grepping.
 
+### Adapter shortcuts (each animation surface stamps itself)
+
+Direct `with_provenance(...)` is the bedrock; Phase 9 added per-surface
+shortcuts so common cases don't require hand-building an envelope:
+
+- **Tween** — `t.set_motion_provenance("tween", "knob-hover")`, then call
+  `t.publish(view, metric)` each tick. The macro
+  `PULP_MOTION_TWEEN("knob-hover", from, to, duration)` auto-fills
+  `source_file` / `source_line` from `std::source_location::current()`.
+- **AnimatorSetBuilder** — `.name("knob-glow")` on the builder; the resulting
+  `Runner::publish(view, metric, value)` stamps `source_kind="animator-set"`,
+  `source_id="knob-glow"`.
+- **CSS TransitionSpec** — `parse_transition_shorthand_with_provenance(css,
+  "/styles/card.css", line)` carries `source_file` / `source_line` through;
+  `CssAnimation::publish(view, metric)` stamps
+  `source_kind="css-transition"`, `source_id=<property name>`.
+- **JS rAF** — `WidgetBridge::load_script(code, "my-script.js")` (or
+  `set_active_script_id(...)`) records the script id; `__flushFrames__`
+  sets the ambient envelope per callback so a `motion.publishValue` from
+  inside an rAF body emits `source_kind="rAF"`,
+  `source_id="my-script.js:<callback_id>"`.
+- **JS user code** — `motion.publishValue(view, metric, value)` and
+  `motion.setProvenance(kind, id, file?, line?)` are exposed on the
+  `globalThis.motion` object the bridge installs. `motion.clearProvenance()`
+  empties the slot. Explicit `PublishOptions::provenance` always wins over
+  the ambient slot.
+- **Design import** — `generate_pulp_js` emits a `motion.setProvenance(...)`
+  line at the top of every bundle, tagged with vendor + root-node id
+  (`figma:Card/Hover`, `stitch:Panel`, `claude:HeaderLayout`, …). Drop the
+  generated JS into a bridge and any animation it drives inherits the
+  envelope automatically.
+
 ## Reduced-motion policy
 
 `pulp::view::MotionPreferences` (sibling of `AppearanceTracker`) reads the

--- a/.agents/skills/motion/SKILL.md
+++ b/.agents/skills/motion/SKILL.md
@@ -16,6 +16,7 @@ based on what's observable.
 | A running app + a node id + a scalar / geometry of interest | **Runtime trace** | `Motion.startTrace` over the inspector wire |
 | A captured frame sequence (no app instrumentation available) | **Visual analysis** | `tools/motion/visual/analyze_sequence.py` |
 | A previously recorded `.motion.jsonl` fixture | **Replay + assert** | `motion::replay_fixture` + `motion::assert_matches` |
+| An interaction that drives the suspect motion | **Input record + replay** | `motion::make_input_recorder` + `motion::replay_inputs` |
 | Imported design + intent doc (e.g. "fade in 350 ms ease-out") | **Both** | Record a fixture from the import, assert timing/monotonicity |
 
 ## Path A — Runtime trace
@@ -164,6 +165,49 @@ REQUIRE(diff.matches());  // or inspect diff.differences on failure
 
 `FixtureMatchOptions { component_epsilon, timing_epsilon_seconds,
 require_same_event_count }` controls tolerances.
+
+## Path D — Input recording and replay
+
+When the bug is "what the user did caused the wrong motion", record the
+interaction alongside the motion stream so a fresh tree can replay the same
+sequence deterministically.
+
+```cpp
+// Recording — paired with whatever motion sinks you already have.
+{
+    auto recorder = motion::make_input_recorder("/tmp/card-open.motion.jsonl");
+    root.simulate_hover({150, 150});
+    clock.tick(1.0f / 60.0f);
+    root.simulate_click({150, 150});
+    // ... drive your animation ...
+}   // RAII: destructor closes the sink + flips recording off.
+
+// Replay against a fresh tree on a fresh FrameClock.
+motion::replay_inputs("/tmp/card-open.motion.jsonl", fresh_root, fresh_clock);
+```
+
+`make_input_recorder(path)` installs a `make_fixture_sink(path)` AND flips
+the process-wide `input_recording_enabled()` flag. `View::simulate_*` checks
+that flag (a single relaxed atomic load, off by default) and emits a
+`SampleEvent::Kind::Input` carrying the `input_kind` ("click" / "drag" /
+"hover"), the recorded target's `View::id()`, and the root-space coords on
+the existing `components` map (sorted by name: `x`/`y` for click+hover;
+`start_x`/`start_y`/`end_x`/`end_y`/`steps` for drag).
+
+`replay_inputs(path, root, clock)`:
+
+- Walks every `Input` event in fixture order.
+- Advances `clock` to match the recorded `t_seconds` (first input anchors,
+  subsequent inputs tick by the delta).
+- Dispatches each input through `root` (not the recorded `view_id` — root
+  coords with `hit_test` land on the same descendant).
+- Returns the number of inputs replayed.
+
+The motion stream that emerges — when paired with the same animation
+primitives — matches the originally-recorded one within
+`FixtureMatchOptions::timing_epsilon_seconds`. Use the ID-keyed
+`assert_matches` for the comparison so reordered identical bursts don't
+false-fail.
 
 ## Agent contract
 

--- a/.agents/skills/motion/SKILL.md
+++ b/.agents/skills/motion/SKILL.md
@@ -1,13 +1,33 @@
 ---
 name: motion
-description: Agent-first motion observability for Pulp views and animations. Single entry point for two paths — runtime scalar/geometry tracing (samples values + view geometry over time, attachable at runtime over the inspector wire, emits Start/End burst-framed events) and pixel-truth visual analysis (SSIM + diff heatmaps + keyframe sprites from frame sequences). Use when an animation timing / direction / easing / scroll / drift is suspect, when an imported design needs verification, or when a transition / GPU effect has no observable scalar.
+description: Debug or validate Pulp animations / transitions / scroll behavior using the runtime motion-trace system. TRIGGER on phrases like "animation is wrong", "transition timing off", "fade too late", "card slides too far", "scroll jumps on restore", "easing looks wonky", "imported Figma motion doesn't match source", "settle time / overshoot / drift / monotonic", "what value does the knob reach at frame N", "record this animation so I can replay it", "this animation is expensive — which one and why", "reduced-motion broken", "scrub a captured fixture". Runs over the inspector wire (no source edits needed), captures fixtures (.motion.jsonl), and ships assertion helpers (is_monotonic / settling_time_seconds / overshoot / start_delay_seconds / final_value). Off by default in prod.
 ---
 
 # Motion
 
-Diagnose animation, scroll, and transition behavior with the framework's
-agent-first motion observability system. Two paths share one skill — pick
-based on what's observable.
+Pulp's agent-first motion observability — sample view geometry / scalar
+values / scroll state over time, emit epsilon-bounded events with monotonic
+timestamps and burst framing, and route them to log lines + inspector
+events + JSONL fixtures. **You are reading this skill because an agent
+needs to debug, validate, or reproduce a motion behavior.**
+
+## When to rope this skill in
+
+Trigger this skill the moment a user (or your own reasoning) describes any
+of these symptoms — don't reach for `grep` or `git log`, attach a trace:
+
+- "this fade / slide / scale is too fast / too slow / starts late / ends early"
+- "the knob value isn't reaching its target" / "what value at frame N?"
+- "two elements drift apart during the transition"
+- "scroll position jumps when I restore state"
+- "imported design's motion doesn't match the source intent"
+- "is this animation monotonic / does it overshoot / how long to settle?"
+- "which animation is expensive and why?" → Path F (cost attribution)
+- "reduced-motion path is broken" → Path B + assert under MotionPolicy
+- "I want to scrub through a recorded fixture" → Path E (scrubber)
+
+If the user says any of those, this skill applies. Don't suggest reading
+source; **attach a trace and read the numbers**.
 
 ## Quick decision
 

--- a/.agents/skills/motion/SKILL.md
+++ b/.agents/skills/motion/SKILL.md
@@ -193,6 +193,10 @@ Apply these on every motion debugging run:
 
 - `core/view/include/pulp/view/motion.hpp` — public C++ API
 - `core/view/src/motion.cpp` — Coordinator, geometry walker, fixture I/O, assertions
+- `core/view/include/pulp/view/motion_preferences.hpp` — reduced-motion policy + duration_scale
+- `core/view/src/motion_preferences.cpp` — singleton + override + OS readers
+- `core/view/platform/mac/motion_preferences_mac.mm` — NSWorkspace reduced-motion query
+- `core/view/platform/win/motion_preferences_win.cpp` — SPI_GETCLIENTAREAANIMATION query
 - `inspect/include/pulp/inspect/motion_inspector.hpp` — Motion inspector bridge
 - `inspect/src/motion_inspector.cpp` — protocol handler + event broadcaster
 - `tools/motion/visual/analyze_sequence.py` — visual analysis CLI
@@ -217,6 +221,48 @@ The envelope shows up on the trace's `TraceStarted` event and in the JSONL
 fixture. When you read a fixture and the burst looks wrong, the provenance
 tells you which file / Figma node / animator the trace was attached to —
 without grepping.
+
+## Reduced-motion policy
+
+`pulp::view::MotionPreferences` (sibling of `AppearanceTracker`) reads the
+OS reduced-motion accessibility setting on first use and exposes it as a
+`MotionPolicy` (`Full` / `Reduced` / `Off`) plus a clamped `duration_scale`
+(0.0–2.0, default 1.0). Animation primitives honor the policy on start:
+
+| Policy | Tween / ValueAnimation | CssAnimation | AnimatorSet |
+|---|---|---|---|
+| Full | Animate as configured | Animate as configured | Animate as configured |
+| Reduced | Scale duration × `duration_scale` | Same | Same (via each Tween) |
+| Off | Jump to target on tick 0 | Complete on first `tick()` | Each Tween starts finished |
+
+Tests get a per-process override that wins over the OS value:
+
+```cpp
+auto& prefs = pulp::view::MotionPreferences::instance();
+prefs.set_override(pulp::view::MotionPolicy::Reduced);
+prefs.set_duration_scale(0.5);
+// …drive the animation…
+prefs.reset_for_tests();   // clears override, re-reads OS
+```
+
+Fixtures recorded under a non-`Full` policy capture it on the v2 header:
+
+```jsonc
+{"motion_fixture_version":2,"policy":"reduced","duration_scale":0.5}
+```
+
+`load_fixture_header(path)` returns the policy + scale; the header-aware
+`assert_matches(g_hdr, g_events, c_hdr, c_events, opts)` overload flags a
+`"policy-mismatch"` diff item if the goldens were recorded under one policy
+and the capture under another — no more silent comparisons of a Reduced
+golden against a Full capture. `policy` / `duration_scale` are additive on
+the header; v2 fixtures without them still load (defaulting to
+`policy="full"`, `duration_scale=1.0`).
+
+Note: `MotionPreferences` is a sibling of `AppearanceTracker`, not a
+subclass. Use the OS reader on the platform that matters (macOS: NSWorkspace
+`accessibilityDisplayShouldReduceMotion`; Windows: `SPI_GETCLIENTAREAANIMATION`)
+or set an override for deterministic tests.
 
 ## Gotchas
 
@@ -243,3 +289,15 @@ without grepping.
 - Per-(view, metric) `epsilon` is sticky on the first publish; subsequent
   publishes inherit it. Pass `PublishOptions` only when you want to configure
   the threshold for that key.
+- `MotionPolicy` is captured at animation start (constructor / `reset()` /
+  `animate_to()` / first `tick()` for CssAnimation). Changing
+  `MotionPreferences::set_override()` partway through a running animation
+  does NOT retroactively re-scale it — the next animation that starts will
+  pick up the new policy.
+- Under `MotionPolicy::Off`, a Tween-driven "publish until finished" loop
+  emits one final-value Sample and exits. That's the contract — Off is not
+  "no observability", it's "single snap" — assertions like `is_monotonic`
+  and `final_value` still work.
+- Test fixtures use `MotionPreferences::instance().reset_for_tests()` to
+  clear overrides between cases. Forgetting it leaks state into the next
+  test (and surprises CI when run with `--shuffle`).

--- a/.agents/skills/motion/SKILL.md
+++ b/.agents/skills/motion/SKILL.md
@@ -253,6 +253,61 @@ Gotchas:
   clear it before each scrub or compare counts modulo the prefix size.
 - Replayed event timestamps (`t_seconds`) are the recording's
   timestamps, not wall clock. Don't drive a live clock from them.
+## Path F — Cost attribution
+
+When the question is **"which animation is expensive and why?"**, switch
+the cost channel on. It's off by default and runs on a separate stream
+from the fixture format — cost samples don't appear in `*.motion.jsonl`.
+
+### Enable + wire a probe (in-process)
+
+```cpp
+#include <pulp/view/motion_cost.hpp>
+#include <pulp/view/motion_cost_render.hpp>
+
+auto& cost = pulp::view::motion::CostAttributor::instance();
+cost.set_enabled(true);
+
+// Optional but recommended: surface real render stats. Pointers may be
+// null — defensive degradation returns 0 for the missing field.
+cost.set_probe(pulp::view::motion::make_render_cost_probe(
+    &render_pass_manager, &dirty_tracker));
+
+// Sink: JSONL on disk for later analysis…
+cost.add_sink(pulp::view::motion::make_cost_sink("/tmp/run.motion-cost.jsonl"));
+// …or a buffer for in-test assertions:
+std::vector<pulp::view::motion::CostSample> samples;
+cost.add_sink(pulp::view::motion::make_cost_buffer_sink(&samples));
+```
+
+Each frame, the Coordinator's tick now emits one `CostSample` per active
+sink with:
+
+- `frame`, `t_seconds`
+- `render_pass_duration_ms` — from `RenderPassManager::total_time_ms()`
+- `dirty_rect_area_px`, `dirty_rect_count` — from `DirtyTracker::dirty_rects()`
+- `active_trace_ids` — every `trace_id` that emitted on this frame
+- `active_provenance` — Phase 9 envelopes for those traces, in the same
+  order, so a reader can answer "this 12ms pass came from
+  `figma:LevelMeter/Panel` (source_kind=`design-import`)" without
+  cross-referencing the event fixture.
+
+### Inspector domain
+
+`Motion.enableCost` / `Motion.disableCost` toggle the channel; while
+enabled, `Motion.cost` events broadcast per frame. `Motion.snapshot`
+also reports `cost_enabled` and `cost_samples_emitted`.
+
+### Notes
+
+- Cost samples are a separate JSONL stream (`*.motion-cost.jsonl`) with
+  its own version header (`{"motion_cost_version":1}`). Do not confuse
+  with the fixture schema — they're independent.
+- When the coordinator has no event sinks but cost is enabled, the
+  attributor still emits cost samples — the render-cost timeline is
+  useful by itself even without any motion trace activity.
+- The render-cost probe is read outside the coordinator lock; keep
+  implementations cheap.
 
 ## Agent contract
 
@@ -282,6 +337,9 @@ Apply these on every motion debugging run:
 
 - `core/view/include/pulp/view/motion.hpp` — public C++ API
 - `core/view/src/motion.cpp` — Coordinator, geometry walker, fixture I/O, assertions
+- `core/view/include/pulp/view/motion_cost.hpp` — `CostSample` / `CostAttributor` / cost JSONL
+- `core/view/include/pulp/view/motion_cost_render.hpp` — `make_render_cost_probe` bridge
+- `core/view/src/motion_cost.cpp` — attributor singleton + sinks + JSONL load
 - `core/view/include/pulp/view/motion_preferences.hpp` — reduced-motion policy + duration_scale
 - `core/view/src/motion_preferences.cpp` — singleton + override + OS readers
 - `core/view/platform/mac/motion_preferences_mac.mm` — NSWorkspace reduced-motion query

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.43.0",
+      "version": "0.42.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.43.0"
+  "version": "0.42.0"
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.42.0",
+      "version": "0.44.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.42.0"
+  "version": "0.44.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.43.0",
+  "version": "0.42.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.42.0",
+  "version": "0.44.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/.claude/commands/motion.md
+++ b/.claude/commands/motion.md
@@ -1,0 +1,60 @@
+---
+name: motion
+description: Debug or validate a Pulp animation / transition / scroll — runtime trace, fixture record/replay/assert, visual analysis, scrubber, cost attribution
+---
+
+Debug a motion behavior the framework's way: attach a runtime trace over
+the inspector wire, capture a fixture, and read the numbers — don't
+guess from source.
+
+## Six paths (pick by what you have)
+
+| You have | Path | Tool |
+|---|---|---|
+| Running app + node id | **Runtime trace** | `Motion.startTrace` over the inspector wire (port 9147) |
+| Just frames (no instrumentation) | **Visual analysis** | `python3 -m tools.motion.visual.analyze_sequence --frames-dir DIR` |
+| A `.motion.jsonl` fixture | **Replay + assert** | `motion::replay_fixture` + `motion::assert_matches` |
+| An interaction to record | **Input record/replay** | `motion::make_input_recorder` + `motion::replay_inputs` |
+| A fixture to scrub | **Timeline scrubber** | `Motion.loadFixture` + `Motion.scrubTo` |
+| "Which animation is expensive?" | **Cost attribution** | `Motion.enableCost` + `CostAttributor` |
+
+## Fastest path — quick trace via the standalone host
+
+```bash
+# 1. Launch the host with the motion inspector server up.
+PULP_MOTION_SERVER=1 ./build/examples/ui-preview/pulp-ui-preview &
+
+# 2. Attach a trace (TCP port 9147, line-delimited JSON).
+echo '{"id":1,"method":"Motion.startTrace","params":{
+  "view_name":"Card","fps":30,
+  "metrics":[{"kind":"geometry","name":"frame","node_id":"card",
+    "properties":["minX","minY","width","height"],
+    "space":"window","source":"presentation"}]}}' \
+  | nc -w 30 localhost 9147
+
+# 3. Trigger the suspect interaction in the app; events stream as JSON.
+
+# 4. Stop the trace when done.
+echo '{"id":2,"method":"Motion.stopTrace","params":{"trace_id":1}}' \
+  | nc -w 5 localhost 9147
+```
+
+## Useful env knobs in `pulp-ui-preview`
+
+- `PULP_MOTION_LOG=1` — install the default `[PulpMotion]` log sink + enable tracing.
+- `PULP_MOTION_SERVER=1` — start the `Motion.*` inspector server (port 9147).
+- `PULP_MOTION_FIREHOSE=1` — broadcast every `publish_value` call to all sinks (dev-only).
+
+## Assertion shape (use the dedicated helpers, never one global "smoothness")
+
+```cpp
+auto samples = motion::extract_scalar(events, "Card", "frame", "minY");
+REQUIRE(motion::is_monotonic(samples));
+REQUIRE(motion::settling_time_seconds(samples) < 0.7);
+REQUIRE(motion::overshoot(samples) < 0.05);
+REQUIRE(motion::final_value(samples) == Catch::Approx(120.0).margin(1.0));
+```
+
+See `docs/guides/motion-observability.md` for the full guide and
+`.agents/skills/motion/SKILL.md` for the agent contract + per-path
+playbooks.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.111.0
+    VERSION 0.112.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/render/include/pulp/render/dirty_tracker.hpp
+++ b/core/render/include/pulp/render/dirty_tracker.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <vector>
 
 namespace pulp::render {

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -191,6 +191,7 @@ target_sources(pulp-view PRIVATE
     src/visualization_bridge.cpp
     src/frame_clock.cpp
     src/motion.cpp
+    src/motion_cost.cpp
     src/window_manager.cpp
     src/eq_curve_view.cpp
     src/midi_keyboard.cpp

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -161,6 +161,7 @@ target_sources(pulp-view PRIVATE
     src/theme_contrast.cpp
     src/theme_presets.cpp
     src/appearance_tracker.cpp
+    src/motion_preferences.cpp
     src/asset_manager.cpp
     src/view.cpp
     src/yoga_layout.cpp
@@ -341,6 +342,7 @@ if(APPLE)
             platform/mac/drag_drop_mac.mm
             platform/mac/accessibility_mac.mm
             platform/mac/appearance_mac.mm
+            platform/mac/motion_preferences_mac.mm
             # #299: host-backend registration APIs. The stub files
             # compile set_factory/set_screenshot_provider etc.
             # unconditionally; only the create/render impls are
@@ -372,6 +374,7 @@ elseif(WIN32)
         src/window_host_stub.cpp
         platform/win/accessibility_win.cpp
         platform/win/appearance_win.cpp
+        platform/win/motion_preferences_win.cpp
     )
     # Workstream 04 #247 phase 1: UIAutomationCore for
     # UiaClientsAreListening and (in phase 2) UiaReturnRawElementProvider +

--- a/core/view/include/pulp/view/animation.hpp
+++ b/core/view/include/pulp/view/animation.hpp
@@ -5,8 +5,16 @@
 #include <vector>
 #include <algorithm>
 #include <string>
+#include <utility>
 
+#include <pulp/view/motion.hpp>             // for motion::Provenance + publish_value
 #include <pulp/view/motion_preferences.hpp>
+
+#if defined(__has_include)
+#  if __has_include(<source_location>)
+#    include <source_location>
+#  endif
+#endif
 
 namespace pulp::view {
 
@@ -94,6 +102,52 @@ public:
         apply_motion_policy_at_start();
     }
 
+    // ── Motion provenance (Phase 9) ─────────────────────────────────
+    //
+    // Attach a `motion::Provenance` envelope to this tween. When
+    // `publish(view, metric)` is called, the publish channel stamps
+    // the envelope onto every emitted event so an offline reader can
+    // answer "what code created this tween?". Off by default — pre-
+    // Phase-9 tweens that don't call this method behave identically.
+    //
+    // The convenience `PULP_MOTION_TWEEN(...)` macro auto-fills
+    // `source_file` / `source_line` from `std::source_location` at the
+    // construction site.
+    void set_motion_provenance(std::string source_kind,
+                               std::string source_id,
+                               std::string source_file = {},
+                               int source_line = 0) {
+        provenance_.source_kind = std::move(source_kind);
+        provenance_.source_id = std::move(source_id);
+        provenance_.source_file = std::move(source_file);
+        provenance_.source_line = source_line;
+    }
+
+    /// Set the full envelope. Useful when the provenance is built up
+    /// somewhere else (e.g. a design-import codegen step).
+    void set_motion_provenance(motion::Provenance p) {
+        provenance_ = std::move(p);
+    }
+
+    const motion::Provenance& motion_provenance() const noexcept {
+        return provenance_;
+    }
+
+    /// Publish the tween's current value through the motion publish
+    /// channel under the given (view, metric) name. Stamps the tween's
+    /// provenance envelope (set via `set_motion_provenance` or
+    /// `PULP_MOTION_TWEEN`) onto the emitted event. Cheap no-op when
+    /// motion tracing is off (`Coordinator::tracing_enabled() == false`).
+    void publish(std::string view_name,
+                 std::string metric_name,
+                 motion::PublishOptions opts = {}) const {
+        if (provenance_.is_set() && !opts.provenance.is_set()) {
+            opts.provenance = provenance_;
+        }
+        motion::publish_value(std::move(view_name), std::move(metric_name),
+                              static_cast<double>(current_), opts);
+    }
+
 private:
     /// Read `MotionPreferences::current()` once and apply it to `duration_`
     /// / `elapsed_` / `current_` so the tween starts already honoring the
@@ -119,7 +173,44 @@ private:
     float elapsed_ = 0;
     float current_ = 0;
     EasingFunction ease_ = easing::linear;
+    motion::Provenance provenance_;  ///< Phase 9: opt-in attribution.
 };
+
+// ── PULP_MOTION_TWEEN (Phase 9) ─────────────────────────────────────────
+//
+// Convenience macro: constructs a `Tween` and stamps a `motion::Provenance`
+// envelope with `source_kind = "tween"`, the supplied `source_id`, and
+// `source_file` / `source_line` captured from `std::source_location` at
+// the call site. The resulting tween is returned by value so the call
+// site looks like `auto t = PULP_MOTION_TWEEN("hover-glow", 0.0f, 1.0f, 0.2f);`.
+//
+// `__FILE__` / `__LINE__` fall back if `<source_location>` isn't available
+// (e.g. exotic toolchains); Pulp targets C++20 so the modern path is the
+// default.
+#ifdef __cpp_lib_source_location
+#define PULP_MOTION_TWEEN(source_id, ...)                                       \
+    ([](::pulp::view::Tween&& __pulp_tween_,                                    \
+        const ::std::source_location __pulp_loc_ =                              \
+            ::std::source_location::current())                                  \
+            -> ::pulp::view::Tween {                                            \
+        __pulp_tween_.set_motion_provenance(                                    \
+            ::std::string{"tween"},                                             \
+            ::std::string{(source_id)},                                         \
+            ::std::string{__pulp_loc_.file_name()},                             \
+            static_cast<int>(__pulp_loc_.line()));                              \
+        return __pulp_tween_;                                                   \
+    }(::pulp::view::Tween(__VA_ARGS__)))
+#else
+#define PULP_MOTION_TWEEN(source_id, ...)                                       \
+    ([](::pulp::view::Tween&& __pulp_tween_) -> ::pulp::view::Tween {           \
+        __pulp_tween_.set_motion_provenance(                                    \
+            ::std::string{"tween"},                                             \
+            ::std::string{(source_id)},                                         \
+            ::std::string{__FILE__},                                            \
+            static_cast<int>(__LINE__));                                        \
+        return __pulp_tween_;                                                   \
+    }(::pulp::view::Tween(__VA_ARGS__)))
+#endif
 
 // ── AnimationManager ─────────────────────────────────────────────────────────
 

--- a/core/view/include/pulp/view/animation.hpp
+++ b/core/view/include/pulp/view/animation.hpp
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <string>
 
+#include <pulp/view/motion_preferences.hpp>
+
 namespace pulp::view {
 
 class FrameClock; // forward declaration
@@ -52,16 +54,30 @@ struct StaticAnimationLimits {
 
 // ── Tween ────────────────────────────────────────────────────────────────────
 
-// Animates a float from start to end over a duration
+// Animates a float from start to end over a duration.
+//
+// Honors `MotionPreferences::current()` at construction and `reset()`:
+//   - Full     → animate over the configured duration (default).
+//   - Reduced  → scale the configured duration by `duration_scale`.
+//   - Off      → finish immediately at `to`; no intermediate values
+//                are produced.
 class Tween {
 public:
     Tween() = default;
     Tween(float from, float to, float duration_seconds, EasingFunction ease = easing::linear)
-        : from_(from), to_(to), duration_(duration_seconds), ease_(ease) {}
+        : from_(from), to_(to),
+          configured_duration_(duration_seconds),
+          duration_(duration_seconds), ease_(ease) {
+        apply_motion_policy_at_start();
+    }
 
     // Advance by dt seconds. Returns current value.
     float advance(float dt) {
         elapsed_ += dt;
+        if (duration_ <= 0.0f) {
+            current_ = to_;
+            return current_;
+        }
         float t = std::clamp(elapsed_ / duration_, 0.0f, 1.0f);
         float eased = ease_(t);
         current_ = from_ + (to_ - from_) * eased;
@@ -71,11 +87,35 @@ public:
     float current() const { return current_; }
     bool finished() const { return elapsed_ >= duration_; }
 
-    void reset() { elapsed_ = 0; current_ = from_; }
+    void reset() {
+        elapsed_ = 0;
+        current_ = from_;
+        duration_ = configured_duration_;
+        apply_motion_policy_at_start();
+    }
 
 private:
+    /// Read `MotionPreferences::current()` once and apply it to `duration_`
+    /// / `elapsed_` / `current_` so the tween starts already honoring the
+    /// policy. `Off` snaps to the target on tick 0; `Reduced` shrinks the
+    /// configured duration.
+    void apply_motion_policy_at_start() {
+        if (motion_policy_is_off()) {
+            duration_ = 0.0f;
+            elapsed_ = 0.0f;       // advance() returns to_ immediately
+            current_ = to_;
+            return;
+        }
+        if (MotionPreferences::current() == MotionPolicy::Reduced) {
+            const double scale = MotionPreferences::current_duration_scale();
+            duration_ = configured_duration_ * static_cast<float>(scale);
+        }
+    }
+
     float from_ = 0, to_ = 0;
-    float duration_ = 0;
+    float configured_duration_ = 0;  ///< Author-supplied duration; reset()
+                                     ///< re-applies the policy against this.
+    float duration_ = 0;             ///< Effective duration after policy.
     float elapsed_ = 0;
     float current_ = 0;
     EasingFunction ease_ = easing::linear;
@@ -165,13 +205,29 @@ public:
     explicit ValueAnimation(float initial) : current_(initial), target_(initial), from_(initial) {}
 
     /// Set a new target. Starts animating from current value.
+    ///
+    /// Honors `MotionPreferences::current()` at start:
+    ///   - Full     → animate over `duration`.
+    ///   - Reduced  → scale `duration` by `duration_scale`.
+    ///   - Off      → jump straight to `target`; no intermediate values.
     void animate_to(float target, float duration, EasingFunction ease = easing::ease_out_quad) {
         from_ = current_;
         target_ = target;
+        configured_duration_ = duration;
         duration_ = duration;
         elapsed_ = 0;
         ease_ = ease;
-        if (duration <= 0) {
+        if (motion_policy_is_off()) {
+            current_ = target;
+            duration_ = 0.0f;
+            animating_ = false;
+            return;
+        }
+        if (MotionPreferences::current() == MotionPolicy::Reduced) {
+            const double scale = MotionPreferences::current_duration_scale();
+            duration_ = duration * static_cast<float>(scale);
+        }
+        if (duration_ <= 0) {
             current_ = target;
             animating_ = false;
         } else {
@@ -216,6 +272,7 @@ private:
     float current_ = 0;
     float target_ = 0;
     float from_ = 0;
+    float configured_duration_ = 0;
     float duration_ = 0;
     float elapsed_ = 0;
     bool animating_ = false;

--- a/core/view/include/pulp/view/animator_set.hpp
+++ b/core/view/include/pulp/view/animator_set.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
 // AnimatorSetBuilder — compose animations in sequence or parallel groups.
-// Inspired by Android's AnimatorSet pattern.
 
 #include <algorithm>
 #include <pulp/view/animation.hpp>
+#include <pulp/view/motion.hpp>
 #include <vector>
 #include <memory>
 #include <functional>
+#include <string>
+#include <utility>
 
 namespace pulp::view {
 
@@ -71,6 +73,18 @@ private:
 /// Builder for composing animation sequences and parallel groups
 class AnimatorSetBuilder {
 public:
+    /// Phase 9: assign a logical name to this animator set. Threaded
+    /// through to the `Runner`, which stamps it as
+    /// `source_kind="animator-set", source_id=<name>` on every emitted
+    /// publish event. Off by default — pre-Phase-9 builders that never
+    /// call `name()` produce events with no provenance.
+    AnimatorSetBuilder& name(std::string n) {
+        name_ = std::move(n);
+        return *this;
+    }
+
+    const std::string& configured_name() const noexcept { return name_; }
+
     /// Add a tween that runs in sequence
     AnimatorSetBuilder& then(float from, float to, float duration,
                              std::function<void(float)> apply,
@@ -120,8 +134,14 @@ public:
     /// Run the built animation. Advances through sequence, returns true when all done.
     class Runner {
     public:
-        explicit Runner(std::vector<std::unique_ptr<AnimationStep>> steps)
-            : steps_(std::move(steps)) {}
+        explicit Runner(std::vector<std::unique_ptr<AnimationStep>> steps,
+                        std::string name = {})
+            : steps_(std::move(steps)) {
+            if (!name.empty()) {
+                provenance_.source_kind = "animator-set";
+                provenance_.source_id = std::move(name);
+            }
+        }
 
         bool advance(float dt) {
             while (current_ < static_cast<int>(steps_.size()) && dt > 0) {
@@ -146,18 +166,38 @@ public:
                 s->reset();
         }
 
+        /// Phase 9: publish the runner's current scalar through the motion
+        /// publish channel, stamping the animator-set name (configured
+        /// via `AnimatorSetBuilder::name()`) as provenance.
+        void publish(std::string view_name,
+                     std::string metric_name,
+                     double value,
+                     motion::PublishOptions opts = {}) const {
+            if (provenance_.is_set() && !opts.provenance.is_set()) {
+                opts.provenance = provenance_;
+            }
+            motion::publish_value(std::move(view_name), std::move(metric_name),
+                                  value, opts);
+        }
+
+        const motion::Provenance& motion_provenance() const noexcept {
+            return provenance_;
+        }
+
     private:
         std::vector<std::unique_ptr<AnimationStep>> steps_;
         int current_ = 0;
+        motion::Provenance provenance_;
     };
 
     Runner build_runner() {
-        return Runner(std::move(steps_));
+        return Runner(std::move(steps_), name_);
     }
 
 private:
     std::vector<std::unique_ptr<AnimationStep>> steps_;
     std::unique_ptr<ParallelStep> parallel_;
+    std::string name_;  ///< Phase 9: motion-provenance source_id.
 };
 
 // ── Additional easing functions ─────────────────────────────────────────

--- a/core/view/include/pulp/view/css_animation.hpp
+++ b/core/view/include/pulp/view/css_animation.hpp
@@ -27,6 +27,8 @@
 #include <utility>
 #include <vector>
 
+#include <pulp/view/motion_preferences.hpp>
+
 namespace pulp::view {
 
 /// CSS easing function — maps a normalized progress t ∈ [0,1] to an
@@ -183,10 +185,43 @@ struct CssAnimation {
     float elapsed_seconds = 0.0f;
     bool active = true;
 
+    /// Internal: have we applied the current MotionPolicy to this
+    /// animation's effective duration yet? Lazy on the first `tick()`
+    /// so callers don't need to remember to call a setup step. The
+    /// policy snapshot taken here is what governs the animation's
+    /// behavior for its lifetime.
+    bool motion_policy_applied_ = false;
+
+    /// Apply the current MotionPolicy to `spec.duration_seconds` (and
+    /// `start_value` under Off, by forcing an immediate end). Idempotent
+    /// — repeated calls are no-ops after the first.
+    void apply_motion_policy() {
+        if (motion_policy_applied_) return;
+        motion_policy_applied_ = true;
+        if (motion_policy_is_off()) {
+            // Snap to the end value on the next tick.
+            spec.duration_seconds = 0.0f;
+            spec.delay_seconds = 0.0f;
+            return;
+        }
+        if (MotionPreferences::current() == MotionPolicy::Reduced) {
+            const double scale =
+                MotionPreferences::current_duration_scale();
+            spec.duration_seconds *= static_cast<float>(scale);
+        }
+    }
+
     /// Advance by `dt` seconds. Returns the current eased value. When
     /// `active` flips to false the caller should commit `end_value`
     /// and clean up.
+    ///
+    /// Honors `MotionPreferences::current()` on the first tick:
+    ///   - Off      → completes immediately with `end_value`.
+    ///   - Reduced  → effective duration is `spec.duration_seconds *
+    ///                duration_scale` (captured on first tick).
+    ///   - Full     → no change to the configured spec.
     float tick(float dt) {
+        if (!motion_policy_applied_) apply_motion_policy();
         elapsed_seconds += dt;
         const float total = spec.delay_seconds + spec.duration_seconds;
         if (elapsed_seconds >= total) {

--- a/core/view/include/pulp/view/css_animation.hpp
+++ b/core/view/include/pulp/view/css_animation.hpp
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include <pulp/view/motion.hpp>
 #include <pulp/view/motion_preferences.hpp>
 
 namespace pulp::view {
@@ -163,9 +164,33 @@ struct TransitionSpec {
     float delay_seconds = 0.0f;
     CssEasing easing{};
 
+    /// Phase 9 — source attribution. Filled in by
+    /// `parse_transition_shorthand_with_provenance(...)` so an offline
+    /// motion-trace reader can answer "what CSS file / line defined this
+    /// transition?". Empty when parsed via the legacy entry point.
+    std::string source_file;
+    int source_line = 0;
+
     /// CSS spec — duration <= 0 means "snap" (no tween). The dispatcher
     /// takes the fast path.
     bool is_snap() const { return duration_seconds <= 0.0f; }
+
+    /// Build a `motion::Provenance` envelope for this spec.
+    /// `source_kind="css-transition"`, `source_id=<property_name>`,
+    /// `source_file` / `source_line` from the parser. Returns an empty
+    /// envelope when the parser didn't capture a location (e.g. legacy
+    /// `parse_transition_shorthand` entry point).
+    motion::Provenance motion_provenance() const {
+        motion::Provenance p;
+        if (source_file.empty() && source_line == 0 && property_name.empty()) {
+            return p;
+        }
+        p.source_kind = "css-transition";
+        p.source_id = property_name.empty() ? std::string{"all"} : property_name;
+        p.source_file = source_file;
+        p.source_line = source_line;
+        return p;
+    }
 };
 
 /// One running animation. Lifecycle: created when a property changes
@@ -237,6 +262,32 @@ struct CssAnimation {
                         : 1.0f;
         const float p = spec.easing.at(t);
         return start_value + (end_value - start_value) * p;
+    }
+
+    /// Phase 9: publish the current eased value through the motion publish
+    /// channel, stamping `spec.motion_provenance()` (source_kind=
+    /// "css-transition", source_id=<property name>, file/line from the
+    /// CSS parser) onto the emitted event.
+    void publish(std::string view_name,
+                 std::string metric_name,
+                 motion::PublishOptions opts = {}) const {
+        auto p = spec.motion_provenance();
+        if (p.is_set() && !opts.provenance.is_set()) {
+            opts.provenance = std::move(p);
+        }
+        // Re-evaluate the eased value at the current elapsed time
+        // without mutating internal state — the host already called
+        // `tick()` to advance, so reading the spec is enough.
+        float t = 0.0f;
+        const float local = elapsed_seconds - spec.delay_seconds;
+        if (local > 0.0f && spec.duration_seconds > 0.0f) {
+            t = local / spec.duration_seconds;
+            if (t > 1.0f) t = 1.0f;
+        }
+        const float eased = spec.easing.at(t);
+        const float current = start_value + (end_value - start_value) * eased;
+        motion::publish_value(std::move(view_name), std::move(metric_name),
+                              static_cast<double>(current), opts);
     }
 };
 
@@ -447,6 +498,24 @@ inline std::vector<TransitionSpec> parse_transition_shorthand(const std::string&
         out.push_back(std::move(spec));
     }
     return out;
+}
+
+/// Phase 9: parse a `transition` shorthand AND stamp each emitted
+/// `TransitionSpec` with the source attribution (CSS file path + line
+/// number, or React/JS component file:line when the CSS came from an
+/// inline `style="..."`). The legacy `parse_transition_shorthand()`
+/// entry point continues to work unchanged for callers that don't have
+/// or don't care about a source location.
+inline std::vector<TransitionSpec> parse_transition_shorthand_with_provenance(
+    const std::string& css,
+    std::string source_file,
+    int source_line) {
+    auto specs = parse_transition_shorthand(css);
+    for (auto& s : specs) {
+        s.source_file = source_file;
+        s.source_line = source_line;
+    }
+    return specs;
 }
 
 } // namespace pulp::view

--- a/core/view/include/pulp/view/motion.hpp
+++ b/core/view/include/pulp/view/motion.hpp
@@ -172,14 +172,30 @@ void publish_components(std::string view_name,
 //   - `assert_matches(golden, captured, opts)` compares two fixtures
 //     and returns a structured diff agents can act on.
 //
-// Fixture version 1 schema (one event per line, sorted-key JSON):
-//   {"kind":"baseline|sample|start|end",
-//    "view":"…","metric":"…","t":…,"frame":…,"precision":N,
-//    "components":{"k":v,…}, "deltas":{"k":v,…}}
-// Lines are separated by `\n`; the first line is the header:
-//   {"motion_fixture_version":1}
+// Fixture schema v2 header (Phase 8 — `policy` + `duration_scale`
+// additive fields):
+//   {"motion_fixture_version":2,
+//    "policy":"full|reduced|off",
+//    "duration_scale":1.0}
+//
+// `policy` / `duration_scale` are optional. When absent, the loader
+// defaults `policy` to `"full"` and `duration_scale` to `1.0` —
+// pre-Phase-8 v2 fixtures still load. When `make_fixture_sink` writes
+// a fresh fixture it snapshots `MotionPreferences::current()` /
+// `current_duration_scale()` at first event.
 
 constexpr int kFixtureSchemaVersion = 2;
+
+/// Header metadata recorded once at the top of a fixture file.
+struct FixtureHeader {
+    int version = kFixtureSchemaVersion;
+    /// Policy in effect when the fixture was recorded. `"full"` /
+    /// `"reduced"` / `"off"`. Stored as a string so loaders without
+    /// `motion_preferences.hpp` can still compare.
+    std::string policy = "full";
+    /// Duration scale in effect when the fixture was recorded.
+    double duration_scale = 1.0;
+};
 
 // (`make_fixture_sink` and `replay_fixture` are declared below
 // alongside the other Sink helpers so the `using Sink = …` typedef is
@@ -188,6 +204,10 @@ constexpr int kFixtureSchemaVersion = 2;
 /// Load a fixture file into memory. Returns events in file order.
 /// Empty vector on missing / unreadable / unknown-version files.
 std::vector<SampleEvent> load_fixture(const std::string& path);
+
+/// Load a fixture's header (schema version + policy + duration_scale).
+/// Returns a default-constructed FixtureHeader on parse failure.
+FixtureHeader load_fixture_header(const std::string& path);
 
 /// Comparison result from `assert_matches`. Empty `differences` means
 /// the captured run matched the golden within tolerances.
@@ -210,9 +230,26 @@ struct FixtureMatchOptions {
     double component_epsilon = 0.05;
     double timing_epsilon_seconds = 0.05;
     bool require_same_event_count = true;
+    /// When true (default), `assert_matches_headers` will flag a
+    /// `"policy-mismatch"` diff item if the two fixtures recorded
+    /// different MotionPolicy values or differ in `duration_scale`
+    /// beyond `duration_scale_epsilon`. The event-only overload
+    /// (no headers passed) skips this check.
+    bool require_matching_policy = true;
+    double duration_scale_epsilon = 1e-6;
 };
 
 FixtureDiff assert_matches(const std::vector<SampleEvent>& golden,
+                           const std::vector<SampleEvent>& captured,
+                           FixtureMatchOptions opts = {});
+
+/// Overload that also compares fixture headers. Adds a
+/// `"policy-mismatch"` Item to the diff when policy / duration_scale
+/// differ and `opts.require_matching_policy` is true. Otherwise
+/// behaves identically to the event-only overload.
+FixtureDiff assert_matches(const FixtureHeader& golden_header,
+                           const std::vector<SampleEvent>& golden,
+                           const FixtureHeader& captured_header,
                            const std::vector<SampleEvent>& captured,
                            FixtureMatchOptions opts = {});
 

--- a/core/view/include/pulp/view/motion.hpp
+++ b/core/view/include/pulp/view/motion.hpp
@@ -230,10 +230,15 @@ Provenance current_ambient_provenance();
 // `current_duration_scale()` at first event.
 
 constexpr int kFixtureSchemaVersion = 2;
+/// Sentinel for a default-constructed / unrecognised fixture header.
+/// `load_fixture_header()` returns a FixtureHeader with this version
+/// when the file is missing, empty, or its header fails to parse, so
+/// callers can distinguish "valid empty fixture" from "load failed".
+constexpr int kInvalidFixtureSchemaVersion = 0;
 
 /// Header metadata recorded once at the top of a fixture file.
 struct FixtureHeader {
-    int version = kFixtureSchemaVersion;
+    int version = kInvalidFixtureSchemaVersion;
     /// Policy in effect when the fixture was recorded. `"full"` /
     /// `"reduced"` / `"off"`. Stored as a string so loaders without
     /// `motion_preferences.hpp` can still compare.

--- a/core/view/include/pulp/view/motion.hpp
+++ b/core/view/include/pulp/view/motion.hpp
@@ -140,6 +140,13 @@ std::string format_line(const SampleEvent& e);
 struct PublishOptions {
     int precision = 3;
     double epsilon = 0.0001;
+    /// Phase 9: optional Provenance envelope. When set, the publish
+    /// channel stamps each emitted event (Baseline / Start / Sample / End)
+    /// with this provenance so an offline reader can answer "what
+    /// animation surface drove this value?" Empty by default — pre-Phase-9
+    /// callers that omit this field continue emitting events with the
+    /// envelope unset (backwards compatible).
+    Provenance provenance;
 };
 
 /// Single-component publish.
@@ -154,6 +161,23 @@ void publish_components(std::string view_name,
                         std::string metric_name,
                         std::vector<std::pair<std::string, double>> components,
                         PublishOptions opts = {});
+
+// ── Ambient provenance (Phase 9) ─────────────────────────────────────
+//
+// Some animation surfaces (JS rAF, design-import codegen) don't easily
+// thread a `PublishOptions{ .provenance = ... }` through every call site.
+// For those, the publish channel offers a process-wide "ambient"
+// provenance slot — `set_ambient_provenance(p)` is sticky until cleared
+// (or replaced). When a publish call carries an empty `opts.provenance`,
+// the coordinator stamps the ambient provenance instead. When both are
+// set, the explicit `opts.provenance` wins.
+//
+// Ambient state is intended for single-threaded scripted contexts (one
+// JS engine per bridge). Tests should call `clear_ambient_provenance()`
+// between scenarios so leftover state doesn't bleed across.
+void set_ambient_provenance(Provenance p);
+void clear_ambient_provenance();
+Provenance current_ambient_provenance();
 
 // ── Record / replay fixtures (Phase 5) ───────────────────────────────
 //
@@ -460,6 +484,12 @@ public:
                           std::string metric_name,
                           std::vector<std::pair<std::string, double>> components,
                           PublishOptions opts);
+
+    // ── Phase 9: ambient provenance internals ─────────────────────────
+    /// Called by `set_ambient_provenance` / `clear_ambient_provenance`.
+    /// Callers should prefer the free functions for forward compatibility.
+    void set_ambient_provenance_internal(Provenance p);
+    Provenance current_ambient_provenance_internal() const;
 
 private:
     Coordinator();

--- a/core/view/include/pulp/view/motion.hpp
+++ b/core/view/include/pulp/view/motion.hpp
@@ -88,6 +88,11 @@ struct SampleEvent {
         Start,         ///< Burst opened (value drifted off baseline / last
                        ///< stable).
         End,           ///< Burst closed (value stabilized). Carries deltas.
+        Input,         ///< Recorded `View::simulate_*` interaction (Phase 10).
+                       ///< Carries `input_kind` ("click" / "drag" / "hover"),
+                       ///< the target view's id() if any, and root-space
+                       ///< coordinates in `components`. Replayed by
+                       ///< `replay_inputs` against a fresh tree.
     };
 
     Kind kind = Kind::Baseline;
@@ -110,6 +115,22 @@ struct SampleEvent {
 
     std::vector<std::pair<std::string, double>> components;  ///< Sorted by name.
     std::vector<std::pair<std::string, double>> deltas;      ///< End events only.
+
+    // ── Input fields (Phase 10, populated only when `kind == Input`) ─
+    //
+    // `input_kind` is one of `"click"`, `"drag"`, `"hover"`. `view_id`
+    // is the recorded target's `View::id()` (empty when the recorder
+    // captured an event that didn't land on an id-bearing view). The
+    // root-space coordinates ride on `components`:
+    //   - click/hover: `{ "x": ..., "y": ... }`
+    //   - drag       : `{ "start_x": ..., "start_y": ...,
+    //                     "end_x":   ..., "end_y":   ...,
+    //                     "steps":   ... }`
+    // (Sorted by name, same as every other event.) The optional name
+    // ride along with `view_name` set to "input" by convention so
+    // `format_line` and existing groupers don't trip on an empty view.
+    std::string input_kind;
+    std::string view_id;
 };
 
 /// Render the canonical `[PulpMotion][view][metric] ...` line for a sample event.
@@ -345,6 +366,71 @@ Sink make_fixture_sink(std::string path);
 /// Returns the number of events replayed, or `-1` on parse error.
 int replay_fixture(const std::string& path, const Sink& sink);
 
+// ── Input recording / replay (Phase 10) ──────────────────────────────
+//
+// Phase 10 wires `View::simulate_click` / `simulate_drag` /
+// `simulate_hover` into the same fixture stream that carries motion
+// samples. Recording is opt-in: nothing changes about simulate_* until
+// a caller installs a recorder, after which every simulate_* dispatch
+// emits an `Input` `SampleEvent` to the Coordinator's sinks (so the
+// already-installed `make_fixture_sink(path)` captures inputs alongside
+// samples). Replay reads the fixture, walks the view tree by `id()` to
+// reattach each input to a live target, and re-invokes the matching
+// `View::simulate_*`. The motion fixture that emerges from the replay
+// — when paired with the same animation primitives — matches the
+// originally-recorded one.
+//
+// Layered intent:
+//   - `make_input_recorder(path)` is a one-call companion to
+//     `make_fixture_sink(path)`: it installs a fixture sink AND turns
+//     on simulate_* recording, returning a handle whose destructor
+//     turns recording back off. Off by default everywhere else.
+//   - `replay_inputs(path, root_view, frame_clock)` reads the fixture
+//     and re-dispatches each `Input` event by `view_id` against
+//     `root_view`. The `frame_clock` is advanced between inputs to
+//     reproduce the original timing (FrameClock-relative).
+
+/// Recording handle returned by `make_input_recorder`. RAII: destruction
+/// removes the installed sink and turns input recording back off.
+class InputRecorder {
+public:
+    InputRecorder() noexcept = default;
+    InputRecorder(InputRecorder&&) noexcept;
+    InputRecorder& operator=(InputRecorder&&) noexcept;
+    InputRecorder(const InputRecorder&) = delete;
+    InputRecorder& operator=(const InputRecorder&) = delete;
+    ~InputRecorder();
+
+    /// Stop recording inputs and close the fixture sink. Idempotent.
+    void stop();
+
+    bool is_recording() const noexcept { return sink_id_ != 0; }
+
+private:
+    friend InputRecorder make_input_recorder(std::string path);
+    explicit InputRecorder(int sink_id) noexcept : sink_id_(sink_id) {}
+    int sink_id_ = 0;
+};
+
+/// Install a fixture sink at `path` and enable simulate_* recording.
+/// Returns an `InputRecorder` whose destructor stops both the sink and
+/// the recording. Off by default. Repeated calls install independent
+/// recorders; each gets its own sink id.
+InputRecorder make_input_recorder(std::string path);
+
+/// Process-wide entry point called by `View::simulate_*` when input
+/// recording is active. Public so the View free functions can reach
+/// it without a friend relationship; callers should prefer the
+/// `View::simulate_*` API.
+void record_simulated_input(const std::string& input_kind,
+                            const std::string& view_id,
+                            std::vector<std::pair<std::string, double>> coords);
+
+/// True while at least one `InputRecorder` is alive. Off by default;
+/// `View::simulate_*` gates on this so the non-recording cost stays a
+/// single load + branch.
+bool input_recording_enabled() noexcept;
+
 // ── Forward declarations ─────────────────────────────────────────────
 
 class Coordinator;
@@ -490,6 +576,11 @@ public:
     /// Callers should prefer the free functions for forward compatibility.
     void set_ambient_provenance_internal(Provenance p);
     Provenance current_ambient_provenance_internal() const;
+
+    // ── Phase 10: input recording dispatch ───────────────────────────
+    /// Stamp `e` with the bound FrameClock's `t`/`frame` and dispatch
+    /// it to every installed sink. Called by `record_simulated_input`.
+    void dispatch_input_event(SampleEvent e);
 
 private:
     Coordinator();

--- a/core/view/include/pulp/view/motion.hpp
+++ b/core/view/include/pulp/view/motion.hpp
@@ -418,6 +418,16 @@ private:
 /// recorders; each gets its own sink id.
 InputRecorder make_input_recorder(std::string path);
 
+/// Read a fixture file, find each `Input` event, locate a target by
+/// `view_id` walking from `root_view` (depth-first), and re-dispatch
+/// the matching `View::simulate_*` against it. Between inputs the
+/// frame_clock is advanced by the delta between recorded
+/// `t_seconds`. Returns the number of inputs replayed, or `-1` on
+/// parse error.
+int replay_inputs(const std::string& path,
+                  View& root_view,
+                  FrameClock& frame_clock);
+
 /// Process-wide entry point called by `View::simulate_*` when input
 /// recording is active. Public so the View free functions can reach
 /// it without a friend relationship; callers should prefer the

--- a/core/view/include/pulp/view/motion_cost.hpp
+++ b/core/view/include/pulp/view/motion_cost.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+/// @file motion_cost.hpp
+/// Motion cost attribution — correlates render-pass cost and dirty
+/// area with the motion traces that were emitting samples on the
+/// same frame. Off by default. When enabled, the `CostAttributor`
+/// subscribes to the bound FrameClock and the Coordinator's sink
+/// fan-out, snapshots which trace_ids emitted any event during a
+/// frame, and emits one `CostSample` per frame.
+///
+/// Render-pass and dirty-rect stats come from `RenderPassManager` /
+/// `DirtyTracker` via a caller-supplied `CostProbe`. Both are thin
+/// subsystems; the probe is intentionally defensive — when a probe
+/// isn't wired the cost stream still produces samples with zeroed
+/// render fields so trace_id attribution remains useful on its own.
+///
+/// The cost stream is a separate JSONL file (`*.motion-cost.jsonl`)
+/// with its own version header. It does NOT extend the
+/// `kFixtureSchemaVersion` event stream.
+
+#include <pulp/view/motion.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pulp::view::motion {
+
+// ── CostSample ───────────────────────────────────────────────────────
+
+constexpr int kCostSchemaVersion = 1;
+
+/// Per-frame cost attribution sample. Emitted by CostAttributor on
+/// each FrameClock tick while cost attribution is enabled. A frame
+/// with no active traces still emits a sample so the timeline of
+/// render cost is contiguous.
+struct CostSample {
+    std::uint64_t frame = 0;
+    double t_seconds = 0.0;
+
+    /// Wall time spent in the most recently completed render pass.
+    /// Snapshotted from `RenderPassManager::total_time_ms()` when a
+    /// probe is wired; 0 otherwise. Defensive: callers should not
+    /// assume Pulp tracks this on every platform.
+    double render_pass_duration_ms = 0.0;
+
+    /// Total area (in pixels^2) of all dirty rectangles snapshotted
+    /// from `DirtyTracker::dirty_rects()`. 0 when no probe is wired.
+    double dirty_rect_area_px = 0.0;
+
+    /// Number of dirty rectangles snapshotted this frame. 0 when no
+    /// probe is wired or no rectangles are pending.
+    int dirty_rect_count = 0;
+
+    /// Trace ids that emitted at least one SampleEvent on this
+    /// frame. Sorted ascending. Empty when no motion is active.
+    std::vector<int> active_trace_ids;
+
+    /// Provenance envelopes (Phase 9) for each entry in
+    /// `active_trace_ids`, in the same order. Entries without
+    /// provenance carry a default-constructed Provenance.
+    std::vector<Provenance> active_provenance;
+};
+
+// ── CostProbe ────────────────────────────────────────────────────────
+
+/// Snapshot of render-layer cost for the current frame. Filled by a
+/// caller-supplied probe. The CostAttributor calls the probe under
+/// no lock — implementations should be cheap and avoid blocking.
+struct RenderCostSnapshot {
+    double render_pass_duration_ms = 0.0;
+    double dirty_rect_area_px = 0.0;
+    int dirty_rect_count = 0;
+};
+
+using CostProbe = std::function<RenderCostSnapshot()>;
+
+// ── CostAttributor ───────────────────────────────────────────────────
+
+/// Process-wide cost attribution stream. Off by default. When
+/// enabled, subscribes to the Coordinator's bound FrameClock, joins
+/// per-frame trace-id activity with the supplied probe's render
+/// stats, and emits a CostSample to each registered cost sink.
+///
+/// Cost attribution is independent of `Coordinator::tracing_enabled`
+/// — the attributor reads the same trace registry to populate
+/// `active_provenance`, but its sink fan-out lives on its own
+/// channel so cost samples never appear in the event fixture
+/// stream.
+class CostAttributor {
+public:
+    using CostSink = std::function<void(const CostSample&)>;
+
+    static CostAttributor& instance();
+
+    /// Enable / disable cost emission. Off by default.
+    void set_enabled(bool on);
+    bool enabled() const noexcept;
+
+    /// Replace the active render-cost probe. Defensive: when nullptr
+    /// (the default) every CostSample reports zeroed render fields.
+    void set_probe(CostProbe probe);
+
+    /// Add a sink that receives one CostSample per frame while
+    /// enabled. Returns an id for later removal.
+    int add_sink(CostSink sink);
+    void remove_sink(int sink_id);
+    void clear_sinks();
+
+    /// Reset all state (sinks, probe, enabled flag, frame counter).
+    /// For tests.
+    void reset();
+
+    /// Cumulative count of CostSamples emitted since `reset()`. For
+    /// tests / diagnostics.
+    std::size_t emitted_sample_count() const noexcept;
+
+private:
+    CostAttributor();
+    ~CostAttributor();
+    CostAttributor(const CostAttributor&) = delete;
+    CostAttributor& operator=(const CostAttributor&) = delete;
+
+    friend class Coordinator;
+
+    /// Called by Coordinator at the top of `on_tick` with the frame
+    /// number and elapsed time of the tick about to run, and at the
+    /// bottom with the trace_ids that emitted during the tick.
+    void note_tick_begin(std::uint64_t frame, double t_seconds);
+    void note_trace_activity(int trace_id);
+    void note_provenance(int trace_id, const Provenance& prov);
+    void emit_frame();
+
+    struct State;
+    std::unique_ptr<State> state_;
+};
+
+// ── JSONL cost sink ──────────────────────────────────────────────────
+
+/// Sink that appends each `CostSample` as a JSONL line to `path`.
+/// Opens (truncates) the file on first sample, writing a one-line
+/// header `{"motion_cost_version":1}` then a JSONL body. Closes
+/// implicitly when the returned CostSink is dropped.
+CostAttributor::CostSink make_cost_sink(std::string path);
+
+/// Sink that appends each `CostSample` to a caller-owned buffer.
+/// For tests / in-process consumers; the buffer pointer must
+/// outlive the sink.
+CostAttributor::CostSink make_cost_buffer_sink(std::vector<CostSample>* buffer);
+
+/// Serialize one CostSample as a single JSON line (without trailing
+/// newline). Exposed for tests and the inspector domain.
+std::string serialize_cost_sample(const CostSample& s);
+
+/// Parse a JSONL CostSample stream from `path`. Returns the body
+/// events in file order. Empty vector on missing / unreadable /
+/// unknown-version files.
+std::vector<CostSample> load_cost_stream(const std::string& path);
+
+} // namespace pulp::view::motion

--- a/core/view/include/pulp/view/motion_cost_render.hpp
+++ b/core/view/include/pulp/view/motion_cost_render.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+/// @file motion_cost_render.hpp
+/// Helpers that build a `CostProbe` from Pulp's render-layer
+/// subsystems. Kept in a separate header so `motion_cost.hpp`
+/// consumers don't drag in `pulp/render/*` transitively — only
+/// callers that actually have a RenderPassManager / DirtyTracker
+/// instance to wire need this.
+///
+/// Both subsystems are intentionally thin today (RenderPassManager
+/// tracks total_time_ms per frame; DirtyTracker tracks rect lists).
+/// The helpers below snapshot exactly what those types expose and
+/// nothing more — they explicitly do NOT measure frame duration on
+/// their own, since the render layer's existing time_ms inputs come
+/// from outside (caller of `end_pass(time_ms, ...)`).
+///
+/// When the render layer eventually grows a self-measured frame
+/// duration (e.g. a FrameDurationProbe attached to RenderPassManager),
+/// extend the helper here rather than growing RenderPassManager into
+/// a profiler.
+
+#include <pulp/render/dirty_tracker.hpp>
+#include <pulp/render/render_pass.hpp>
+#include <pulp/view/motion_cost.hpp>
+
+namespace pulp::view::motion {
+
+/// Build a CostProbe that snapshots both subsystems each tick.
+/// Either pointer may be null; the corresponding fields default to
+/// 0. Pointers must outlive the returned probe — callers typically
+/// own these as members of their render host.
+inline CostProbe make_render_cost_probe(
+    const pulp::render::RenderPassManager* passes,
+    const pulp::render::DirtyTracker* dirty
+) {
+    return [passes, dirty]() -> RenderCostSnapshot {
+        RenderCostSnapshot s;
+        if (passes) {
+            s.render_pass_duration_ms =
+                static_cast<double>(passes->total_time_ms());
+        }
+        if (dirty) {
+            const auto& rects = dirty->dirty_rects();
+            double area = 0.0;
+            for (const auto& r : rects) {
+                area += static_cast<double>(r.area());
+            }
+            s.dirty_rect_area_px = area;
+            s.dirty_rect_count = static_cast<int>(rects.size());
+        }
+        return s;
+    };
+}
+
+} // namespace pulp::view::motion

--- a/core/view/include/pulp/view/motion_preferences.hpp
+++ b/core/view/include/pulp/view/motion_preferences.hpp
@@ -1,0 +1,145 @@
+#pragma once
+
+/// @file motion_preferences.hpp
+/// System-level reduced-motion preferences. Sibling of `AppearanceTracker`:
+/// reads the OS accessibility setting on first use, exposes a polling +
+/// callback surface, and accepts a test override that wins over the OS
+/// value. Animation primitives (`Tween`, `ValueAnimation`, `TransitionSpec`,
+/// `AnimatorSet`) read this at construction / reset to honor the policy:
+///
+///   - Full     — animate at the configured duration (default).
+///   - Reduced  — scale the configured duration by `duration_scale`.
+///   - Off      — jump straight to the target value; emit no intermediate
+///                tween samples.
+///
+/// Off by default in the sense that nothing reads it unless an animation
+/// primitive starts; the singleton lives behind `current()`.
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace pulp::view {
+
+/// Reduced-motion policy. Animation primitives honor this on construction
+/// or `reset()`.
+enum class MotionPolicy {
+    Full,     ///< Animate normally.
+    Reduced,  ///< Animate, but scale duration by `duration_scale`.
+    Off,      ///< Skip animation; jump to the target value.
+};
+
+/// Process-wide reduced-motion preference tracker.
+///
+/// On macOS, reads `[NSWorkspace sharedWorkspace].accessibilityDisplayShouldReduceMotion`.
+/// On Windows, reads `SystemParametersInfoW(SPI_GETCLIENTAREAANIMATION, ...)`.
+/// On other platforms, defaults to `Full`.
+class MotionPreferences {
+public:
+    /// Process-wide instance. Reads the OS value on first construction.
+    static MotionPreferences& instance();
+
+    /// Convenience: the effective policy right now.
+    static MotionPolicy current() { return instance().policy(); }
+
+    /// Convenience: the effective duration scale right now.
+    static double current_duration_scale() {
+        return instance().duration_scale();
+    }
+
+    /// Current effective policy. Honors override when set, else returns
+    /// the last polled OS value.
+    MotionPolicy policy() const;
+
+    /// Current duration scale (default 1.0). Clamped to [0.0, 2.0].
+    /// Only meaningful when `policy() == Reduced`; primitives may use it
+    /// regardless if they want a softer slowdown under `Full`.
+    double duration_scale() const { return duration_scale_; }
+
+    /// Set the duration scale. Clamped to [0.0, 2.0]. Sticks across
+    /// override changes; not derived from the OS.
+    void set_duration_scale(double scale);
+
+    /// Override the OS-reported policy. Pass `std::nullopt` to revert to
+    /// OS detection. Intended for tests and the JS bridge.
+    void set_override(std::optional<MotionPolicy> p);
+
+    /// Returns true if an override is currently in effect.
+    bool has_override() const noexcept { return override_.has_value(); }
+
+    /// Poll the OS for a changed reduced-motion setting. Returns true
+    /// when the effective policy changes since the last poll. When an
+    /// override is in effect, this is a no-op and returns false.
+    bool poll();
+
+    /// Register a callback that fires whenever the effective policy
+    /// changes (via `poll()` or `set_override()`).
+    void on_policy_changed(std::function<void(MotionPolicy)> callback);
+
+    /// Reset state for tests: clear override, reset duration_scale to
+    /// 1.0, drop callbacks, re-read OS value.
+    void reset_for_tests();
+
+private:
+    MotionPreferences();
+    ~MotionPreferences();
+    MotionPreferences(const MotionPreferences&) = delete;
+    MotionPreferences& operator=(const MotionPreferences&) = delete;
+
+    /// Platform-specific OS detection.
+    static MotionPolicy detect_system_policy();
+
+    void notify_changed(MotionPolicy p);
+
+    MotionPolicy last_os_ = MotionPolicy::Full;
+    std::optional<MotionPolicy> override_;
+    double duration_scale_ = 1.0;
+    std::function<void(MotionPolicy)> callback_;
+};
+
+// ── Free-function convenience shims ──────────────────────────────────
+//
+// Animation primitives use these to keep the call site cheap and avoid
+// pulling the full singleton header into hot paths in the future.
+
+/// Apply the current MotionPolicy to a configured duration. Returns the
+/// effective duration in seconds. When the policy is `Off`, returns 0.
+inline float apply_motion_policy_to_duration(float configured_seconds) {
+    auto& prefs = MotionPreferences::instance();
+    switch (prefs.policy()) {
+        case MotionPolicy::Off:
+            return 0.0f;
+        case MotionPolicy::Reduced:
+            return configured_seconds *
+                   static_cast<float>(prefs.duration_scale());
+        case MotionPolicy::Full:
+        default:
+            return configured_seconds;
+    }
+}
+
+/// Returns true when the current policy says "do not animate" — i.e.
+/// the primitive should jump straight to its target value.
+inline bool motion_policy_is_off() {
+    return MotionPreferences::instance().policy() == MotionPolicy::Off;
+}
+
+/// Returns the current policy string for fixture headers.
+inline const char* motion_policy_to_string(MotionPolicy p) {
+    switch (p) {
+        case MotionPolicy::Off:     return "off";
+        case MotionPolicy::Reduced: return "reduced";
+        case MotionPolicy::Full:
+        default:                    return "full";
+    }
+}
+
+/// Parse a policy string (case-sensitive). Returns Full on unknown.
+inline MotionPolicy motion_policy_from_string(const std::string_view s) {
+    if (s == "off")     return MotionPolicy::Off;
+    if (s == "reduced") return MotionPolicy::Reduced;
+    return MotionPolicy::Full;
+}
+
+} // namespace pulp::view

--- a/core/view/include/pulp/view/widget_bridge.hpp
+++ b/core/view/include/pulp/view/widget_bridge.hpp
@@ -59,6 +59,23 @@ public:
     // Load and execute a UI script
     void load_script(const std::string& code);
 
+    /// Phase 9: load_script overload that retains a script identifier.
+    /// `script_id` is recorded as `active_script_id_` and threaded into
+    /// every rAF callback registered while the script is active so
+    /// `motion.publishValue(...)` calls from inside an rAF body emit
+    /// events tagged with `source_kind="rAF"`,
+    /// `source_id="<script_id>:<callback_id>"`. The legacy overload
+    /// continues to work unchanged.
+    void load_script(const std::string& code, const std::string& script_id);
+
+    /// Set the active script identifier without re-evaluating a script.
+    /// Useful when the same engine evaluates fragments from multiple
+    /// sources and the caller wants subsequent rAF/timer callbacks to
+    /// attribute to a different surface. Pass an empty string to clear.
+    void set_active_script_id(const std::string& script_id);
+
+    const std::string& active_script_id() const noexcept { return active_script_id_; }
+
     // Get a widget by its JS-assigned ID
     View* widget(const std::string& id);
 
@@ -223,6 +240,11 @@ private:
         std::make_shared<std::vector<AsyncExecResult>>();
     std::vector<int> pending_frame_ids_;
     bool frame_preamble_loaded_ = false;
+    // Phase 9: identity of the most-recently loaded script (via
+    // `load_script(code, script_id)` or `set_active_script_id`). When
+    // non-empty, rAF callbacks and `motion.publishValue` bindings use
+    // it as the `source_id` prefix on emitted motion events.
+    std::string active_script_id_;
     // pulp #468 — install_runtime_import_handlers() is idempotent. Tracked
     // per-bridge (not as a static thread_local on `this`, because heap reuse
     // across tests gave duplicate addresses → spurious skip).

--- a/core/view/platform/mac/motion_preferences_mac.mm
+++ b/core/view/platform/mac/motion_preferences_mac.mm
@@ -1,0 +1,21 @@
+#import <AppKit/AppKit.h>
+#include <pulp/view/motion_preferences.hpp>
+
+namespace pulp::view::platform {
+
+MotionPolicy detect_mac_motion_policy() {
+    @autoreleasepool {
+        // NSWorkspace exposes the reduce-motion accessibility setting via
+        // `accessibilityDisplayShouldReduceMotion` (NSAccessibilityReduceMotion).
+        // Returns YES when the user has asked the system to reduce motion.
+        if (@available(macOS 10.12, *)) {
+            NSWorkspace* ws = [NSWorkspace sharedWorkspace];
+            if (ws.accessibilityDisplayShouldReduceMotion) {
+                return MotionPolicy::Reduced;
+            }
+        }
+        return MotionPolicy::Full;
+    }
+}
+
+} // namespace pulp::view::platform

--- a/core/view/platform/win/motion_preferences_win.cpp
+++ b/core/view/platform/win/motion_preferences_win.cpp
@@ -1,0 +1,18 @@
+#ifdef _WIN32
+#include <pulp/view/motion_preferences.hpp>
+#include <windows.h>
+
+namespace pulp::view::platform {
+
+MotionPolicy detect_win_motion_policy() {
+    // SPI_GETCLIENTAREAANIMATION: TRUE when client-area animations are
+    // enabled; FALSE when the user has asked the OS to disable them.
+    BOOL animations_enabled = TRUE;
+    BOOL ok = SystemParametersInfoW(SPI_GETCLIENTAREAANIMATION, 0,
+                                    &animations_enabled, 0);
+    if (!ok) return MotionPolicy::Full;
+    return animations_enabled ? MotionPolicy::Full : MotionPolicy::Reduced;
+}
+
+} // namespace pulp::view::platform
+#endif

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -44,6 +44,22 @@ const char* design_source_name(DesignSource source) {
     return "unknown";
 }
 
+/// Phase 9: motion provenance vendor key. Matches the `source` token
+/// the import CLI accepts, lowercased + slash-friendly so the resulting
+/// `source_id` (e.g. "figma:LevelMeter/Panel") is easy to grep through
+/// fixtures. Stable across releases — fixtures depend on these strings.
+const char* design_source_vendor_key(DesignSource source) {
+    switch (source) {
+        case DesignSource::figma:    return "figma";
+        case DesignSource::stitch:   return "stitch";
+        case DesignSource::v0:       return "v0";
+        case DesignSource::pencil:   return "pencil";
+        case DesignSource::claude:   return "claude";
+        case DesignSource::designmd: return "designmd";
+    }
+    return "unknown";
+}
+
 DesignIR parse_claude_html(const std::string& html) {
     // Claude Design exports the same HTML+CSS shape as other web tools,
     // so parse with the existing Stitch HTML pipeline and re-tag the
@@ -3782,6 +3798,38 @@ std::string generate_pulp_js(const DesignIR& ir, const CodeGenOptions& opts) {
         if (!ir.source_file.empty())
             ss << "// Source: " << ir.source_file << "\n";
         ss << "\n";
+    }
+
+    // Phase 9: tag the bundle with a motion-observability provenance
+    // envelope so any animation it drives (view.animate, CSS transitions,
+    // rAF publishes) inherits source_kind="design-import",
+    // source_id="<vendor>:<root-node-or-file>". The native bridge falls
+    // through cleanly when `motion` isn't installed (e.g. when the
+    // bundle is rendered by an older Pulp build), so the line is safe
+    // to emit unconditionally.
+    {
+        std::string root_id;
+        if (!ir.root.name.empty()) root_id = ir.root.name;
+        else if (!ir.source_file.empty()) {
+            // Strip directory + extension for a compact id.
+            auto& p = ir.source_file;
+            auto slash = p.find_last_of("/\\");
+            auto base = (slash == std::string::npos) ? p : p.substr(slash + 1);
+            auto dot = base.find_last_of('.');
+            root_id = (dot == std::string::npos) ? base : base.substr(0, dot);
+        } else {
+            root_id = "bundle";
+        }
+        // Escape single quotes for embedding in the JS string literal.
+        std::string safe_id;
+        safe_id.reserve(root_id.size());
+        for (char c : root_id) {
+            if (c == '\'' || c == '\\') safe_id += '\\';
+            safe_id += c;
+        }
+        ss << "if (typeof motion !== 'undefined' && motion.setProvenance)\n"
+           << "    motion.setProvenance('design-import', '"
+           << design_source_vendor_key(ir.source) << ":" << safe_id << "');\n\n";
     }
 
     ss << "setTheme('dark');\n\n";

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -2,6 +2,7 @@
 
 #include <pulp/runtime/log.hpp>
 #include <pulp/view/frame_clock.hpp>
+#include <pulp/view/motion_preferences.hpp>
 #include <pulp/view/ui_components.hpp>
 #include <pulp/view/view.hpp>
 
@@ -1098,17 +1099,42 @@ public:
     }
 
     bool parse_header(int& version_out) {
+        FixtureHeader unused;
+        return parse_header_full(unused) && (version_out = unused.version, true);
+    }
+
+    /// Parses the full fixture header. Accepts any subset / order of
+    /// `motion_fixture_version`, `policy`, `duration_scale`. Returns
+    /// false only on malformed JSON or missing version. Unknown keys
+    /// are skipped tolerantly so future additive fields don't break v2
+    /// loaders.
+    bool parse_header_full(FixtureHeader& out) {
         if (!expect('{')) return false;
-        std::string key;
         skip_ws();
-        if (peek() == '}') { ++pos_; version_out = 0; return false; }
-        if (!parse_string(key) || !expect(':')) return false;
-        if (key != "motion_fixture_version") return false;
-        double v = 0;
-        if (!parse_number(v)) return false;
-        skip_ws();
-        if (peek() == '}') { ++pos_; version_out = static_cast<int>(v); return true; }
-        return false;
+        if (peek() == '}') { ++pos_; return false; }
+        bool saw_version = false;
+        while (true) {
+            std::string key;
+            if (!parse_string(key) || !expect(':')) return false;
+            if (key == "motion_fixture_version") {
+                double v = 0;
+                if (!parse_number(v)) return false;
+                out.version = static_cast<int>(v);
+                saw_version = true;
+            } else if (key == "policy") {
+                if (!parse_string(out.policy)) return false;
+            } else if (key == "duration_scale") {
+                double v = 0;
+                if (!parse_number(v)) return false;
+                out.duration_scale = v;
+            } else {
+                if (!skip_value()) return false;
+            }
+            skip_ws();
+            if (peek() == ',') { ++pos_; continue; }
+            if (peek() == '}') { ++pos_; return saw_version; }
+            return false;
+        }
     }
 
 private:
@@ -1277,8 +1303,17 @@ Sink make_fixture_sink(std::string path) {
         state->ensure_open();
         if (!state->stream || !state->stream->is_open()) return;
         if (!state->header_written) {
+            // Snapshot the MotionPolicy + duration_scale in effect at
+            // the recording's first event. Goldens recorded under
+            // Reduced will not silently compare against Full captures.
+            const auto policy_str = motion_policy_to_string(
+                MotionPreferences::current());
+            const double scale = MotionPreferences::current_duration_scale();
             *state->stream << "{\"motion_fixture_version\":"
-                           << kFixtureSchemaVersion << "}\n";
+                           << kFixtureSchemaVersion
+                           << ",\"policy\":\"" << policy_str << "\""
+                           << ",\"duration_scale\":" << scale
+                           << "}\n";
             state->header_written = true;
         }
         *state->stream << serialize_event(e) << "\n";
@@ -1293,9 +1328,9 @@ std::vector<SampleEvent> load_fixture(const std::string& path) {
     std::string line;
     if (!std::getline(in, line)) return out;
     FixtureLineParser header(line);
-    int version = 0;
-    if (!header.parse_header(version)) return out;
-    if (version != kFixtureSchemaVersion) return out;
+    FixtureHeader hdr;
+    if (!header.parse_header_full(hdr)) return out;
+    if (hdr.version != kFixtureSchemaVersion) return out;
     while (std::getline(in, line)) {
         if (line.empty()) continue;
         SampleEvent e;
@@ -1304,6 +1339,18 @@ std::vector<SampleEvent> load_fixture(const std::string& path) {
         out.push_back(std::move(e));
     }
     return out;
+}
+
+FixtureHeader load_fixture_header(const std::string& path) {
+    FixtureHeader hdr;
+    std::ifstream in(path, std::ios::in | std::ios::binary);
+    if (!in.is_open()) return hdr;
+    std::string line;
+    if (!std::getline(in, line)) return hdr;
+    FixtureLineParser p(line);
+    FixtureHeader parsed;
+    if (!p.parse_header_full(parsed)) return hdr;
+    return parsed;
 }
 
 int replay_fixture(const std::string& path, const Sink& sink) {
@@ -1465,6 +1512,34 @@ FixtureDiff assert_matches(const std::vector<SampleEvent>& golden,
         }
     }
 
+    return diff;
+}
+
+FixtureDiff assert_matches(const FixtureHeader& golden_header,
+                           const std::vector<SampleEvent>& golden,
+                           const FixtureHeader& captured_header,
+                           const std::vector<SampleEvent>& captured,
+                           FixtureMatchOptions opts) {
+    FixtureDiff diff = assert_matches(golden, captured, opts);
+    if (opts.require_matching_policy) {
+        if (golden_header.policy != captured_header.policy) {
+            FixtureDiff::Item item;
+            item.kind = "policy-mismatch";
+            item.detail = "policy: golden=" + golden_header.policy +
+                          " captured=" + captured_header.policy;
+            diff.differences.push_back(item);
+        }
+        if (std::fabs(golden_header.duration_scale -
+                      captured_header.duration_scale) >
+            opts.duration_scale_epsilon) {
+            FixtureDiff::Item item;
+            item.kind = "policy-mismatch";
+            item.detail = "duration_scale mismatch";
+            item.expected = golden_header.duration_scale;
+            item.observed = captured_header.duration_scale;
+            diff.differences.push_back(item);
+        }
+    }
     return diff;
 }
 

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -7,6 +7,7 @@
 #include <pulp/view/view.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <fstream>
@@ -423,6 +424,15 @@ std::string format_line(const SampleEvent& e) {
                << " t=" << fmt_double(e.t_seconds, 6) << " --";
             for (const auto& [k, v] : e.deltas) {
                 ss << " " << k << "Delta=" << fmt_double(v, e.precision);
+            }
+            break;
+        case SampleEvent::Kind::Input:
+            ss << " -- Input kind=" << e.input_kind
+               << " view_id=" << e.view_id
+               << " frame=" << e.frame
+               << " t=" << fmt_double(e.t_seconds, 6) << " --";
+            for (const auto& [k, v] : e.components) {
+                ss << " " << k << "=" << fmt_double(v, e.precision);
             }
             break;
     }
@@ -944,6 +954,32 @@ void Coordinator::publish_internal(std::string view_name,
     for (auto& [sink, ev] : pending) sink(ev);
 }
 
+// ── Coordinator::dispatch_input_event (Phase 10) ─────────────────────
+
+void Coordinator::dispatch_input_event(SampleEvent e) {
+    std::vector<std::pair<Sink, SampleEvent>> pending;
+    {
+        std::lock_guard<std::mutex> lock(state_->mtx);
+        if (state_->sinks.empty()) return;
+        // Stamp the bound clock's monotonic time/frame so replay can
+        // recover the original cadence. Input events bypass the
+        // tracing_enabled gate because recording is itself a separate
+        // opt-in (an `InputRecorder` was constructed); requiring both
+        // would be a footgun for "record an interaction without
+        // sampler-driven traces."
+        if (state_->clock) {
+            e.t_seconds = static_cast<double>(state_->clock->time());
+            e.frame = state_->clock->frame();
+        }
+        for (const auto& [sid, sink] : state_->sinks) {
+            (void)sid;
+            pending.emplace_back(sink, e);
+        }
+        state_->emitted_count++;
+    }
+    for (auto& [sink, ev] : pending) sink(ev);
+}
+
 // ── Fixture record / replay (Phase 5) ────────────────────────────────
 
 namespace {
@@ -955,6 +991,7 @@ const char* sample_kind_string(SampleEvent::Kind k) {
         case SampleEvent::Kind::Sample:       return "sample";
         case SampleEvent::Kind::Start:        return "start";
         case SampleEvent::Kind::End:          return "end";
+        case SampleEvent::Kind::Input:        return "input";
     }
     return "?";
 }
@@ -965,6 +1002,7 @@ bool kind_from_string(std::string_view s, SampleEvent::Kind& out) {
     if (s == "sample")        { out = SampleEvent::Kind::Sample;       return true; }
     if (s == "start")         { out = SampleEvent::Kind::Start;        return true; }
     if (s == "end")           { out = SampleEvent::Kind::End;          return true; }
+    if (s == "input")         { out = SampleEvent::Kind::Input;        return true; }
     return false;
 }
 
@@ -1052,6 +1090,13 @@ std::string serialize_event(const SampleEvent& e) {
     if (e.provenance.is_set()) {
         ss << ",\"provenance\":" << serialize_provenance(e.provenance);
     }
+    // Phase 10: input fields only emitted on Input events so existing
+    // motion lines stay byte-for-byte identical with pre-Phase-10
+    // captures.
+    if (e.kind == SampleEvent::Kind::Input) {
+        ss << ",\"input_kind\":\"" << json_escape(e.input_kind) << "\""
+           << ",\"view_id\":\"" << json_escape(e.view_id) << "\"";
+    }
     ss << "}";
     return ss.str();
 }
@@ -1106,6 +1151,10 @@ public:
                 e.burst_id = static_cast<int>(v);
             } else if (key == "provenance") {
                 if (!parse_provenance(e.provenance)) return false;
+            } else if (key == "input_kind") {
+                if (!parse_string(e.input_kind)) return false;
+            } else if (key == "view_id") {
+                if (!parse_string(e.view_id)) return false;
             } else {
                 // Unknown key — skip its value tolerantly.
                 if (!skip_value()) return false;
@@ -1689,6 +1738,106 @@ double frame_jitter_seconds(const std::vector<ScalarSample>& samples) {
 double final_value(const std::vector<ScalarSample>& samples) {
     if (samples.empty()) return std::numeric_limits<double>::quiet_NaN();
     return samples.back().value;
+}
+
+// ── Input recording / replay (Phase 10) ──────────────────────────────
+//
+// Recording: View::simulate_* calls `record_simulated_input` which —
+// when at least one InputRecorder is alive — builds an `Input`
+// SampleEvent and dispatches it to every installed sink. The
+// FrameClock-relative timestamp comes from the Coordinator's bound
+// clock so a replay can recover the original cadence.
+//
+// Replay: `replay_inputs` walks the fixture, resolves each Input's
+// `view_id` against `root_view` via DFS, advances `frame_clock` to
+// match the recorded `t_seconds`, and calls the matching
+// `View::simulate_*`. Sinks installed on the Coordinator (typically the
+// same `make_fixture_sink` paired with the recorder) re-capture the
+// motion stream the replayed inputs produce.
+
+namespace {
+
+/// Process-wide recording-active counter. Bumped by `make_input_recorder`,
+/// dropped by `InputRecorder::stop()` / destructor. `View::simulate_*`
+/// gates on this so the non-recording cost is a single relaxed load.
+std::atomic<int> g_recorder_count{0};
+
+}  // namespace
+
+bool input_recording_enabled() noexcept {
+    return g_recorder_count.load(std::memory_order_relaxed) > 0;
+}
+
+void record_simulated_input(const std::string& input_kind,
+                            const std::string& view_id,
+                            std::vector<std::pair<std::string, double>> coords) {
+    // Snapshot a SampleEvent::Kind::Input under the recorder mutex
+    // and let Coordinator's sinks pick it up. The Coordinator itself
+    // already serializes sink iteration internally on its own mutex
+    // via the publish path; we bypass it here because Input events
+    // don't participate in the Baseline/Start/Sample/End burst state
+    // machine — they're a flat event stream tagged into the same
+    // fixture for chronological replay.
+    auto& coord = Coordinator::instance();
+    if (!input_recording_enabled()) return;
+
+    SampleEvent e;
+    e.kind = SampleEvent::Kind::Input;
+    e.view_name = "input";   // sentinel so format_line groups under [input]
+    e.metric_name = input_kind;
+    e.input_kind = input_kind;
+    e.view_id = view_id;
+    e.components = std::move(coords);
+    // Coordinator owns the FrameClock binding; reach in via its
+    // public sink set and let the dispatch loop stamp `t`/`frame`
+    // ourselves. We keep the lookup simple — if the coordinator
+    // isn't bound, the event still serializes with t=0 / frame=0
+    // and replay falls back to elapsed-clock advance.
+    e.t_seconds = 0.0;
+    e.frame = 0;
+    // The dispatcher below mirrors Coordinator's pending-then-fire
+    // pattern so a sink that calls back into motion (e.g. write-then-
+    // log) doesn't deadlock.
+    coord.dispatch_input_event(e);
+}
+
+// ── InputRecorder ────────────────────────────────────────────────────
+
+InputRecorder::InputRecorder(InputRecorder&& o) noexcept : sink_id_(o.sink_id_) {
+    o.sink_id_ = 0;
+}
+
+InputRecorder& InputRecorder::operator=(InputRecorder&& o) noexcept {
+    if (this != &o) {
+        stop();
+        sink_id_ = o.sink_id_;
+        o.sink_id_ = 0;
+    }
+    return *this;
+}
+
+InputRecorder::~InputRecorder() { stop(); }
+
+void InputRecorder::stop() {
+    if (sink_id_ == 0) return;
+    Coordinator::instance().remove_sink(sink_id_);
+    sink_id_ = 0;
+    // Drop the recorder count last so any in-flight record_simulated_input
+    // either fully publishes (if it loaded the count before our store) or
+    // becomes a clean no-op (if it loaded after). Either is correct — the
+    // sink was already removed.
+    g_recorder_count.fetch_sub(1, std::memory_order_relaxed);
+}
+
+InputRecorder make_input_recorder(std::string path) {
+    // Bump the recorder-count first so any simulate_* dispatch racing
+    // against our sink install becomes a fully published event rather
+    // than a silently-dropped one. The sink id is the recorder's
+    // ownership token; we hand it back wrapped in the RAII handle.
+    g_recorder_count.fetch_add(1, std::memory_order_relaxed);
+    const int sink_id =
+        Coordinator::instance().add_sink(make_fixture_sink(std::move(path)));
+    return InputRecorder(sink_id);
 }
 
 }  // namespace pulp::view::motion

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -1,5 +1,6 @@
 #include <pulp/view/motion.hpp>
 
+#include <pulp/view/motion_cost.hpp>
 #include <pulp/runtime/log.hpp>
 #include <pulp/view/frame_clock.hpp>
 #include <pulp/view/motion_preferences.hpp>
@@ -735,16 +736,47 @@ void sort_components(std::vector<std::pair<std::string, double>>& v) {
 }  // namespace
 
 void Coordinator::on_tick(float dt) {
+    // Cost attribution observes every tick (when enabled) regardless
+    // of whether the event sinks are populated. note_tick_begin runs
+    // first so per-tick scratch is fresh; emit_frame runs at the very
+    // end so trace activity has had a chance to accumulate.
+    auto& cost = CostAttributor::instance();
+    const bool cost_enabled = cost.enabled();
+    if (cost_enabled) {
+        const double t_cost =
+            state_->clock ? static_cast<double>(state_->clock->time()) : 0.0;
+        const std::uint64_t f_cost =
+            state_->clock ? state_->clock->frame() : 0;
+        cost.note_tick_begin(f_cost, t_cost);
+    }
+
     // Collect events under lock, dispatch outside the lock.
     std::vector<std::pair<Sink, SampleEvent>> pending;
+    // Trace activity (trace_id + provenance envelope) recorded under
+    // the lock; forwarded to the CostAttributor after the lock is
+    // released so the attributor can sample its probe without
+    // contending on the coordinator mutex.
+    std::vector<std::pair<int, Provenance>> tick_activity;
     {
         std::lock_guard<std::mutex> lock(state_->mtx);
-        if (!state_->tracing_enabled || state_->sinks.empty()) return;
+        // Cost attribution must still emit a sample even when there
+        // are no active traces / sinks — render cost itself is the
+        // useful signal in that case. So bail only when BOTH tracing
+        // and cost attribution are off.
+        const bool have_traces =
+            state_->tracing_enabled && !state_->sinks.empty();
+        if (!have_traces && !cost_enabled) return;
 
         const double t_now =
             state_->clock ? static_cast<double>(state_->clock->time()) : 0.0;
         const std::uint64_t f_now =
             state_->clock ? state_->clock->frame() : 0;
+
+        if (!have_traces) {
+            // Skip sampler-driven trace work; cost emission still
+            // happens below.
+            goto cost_emit;
+        }
 
         for (auto& [trace_id, trace] : state_->traces) {
             // Phase 7: emit TraceStarted once per trace on its first tick.
@@ -763,6 +795,10 @@ void Coordinator::on_tick(float dt) {
                     pending.emplace_back(sink, ev);
                 }
                 state_->emitted_count++;
+                if (cost_enabled) {
+                    tick_activity.emplace_back(trace.id,
+                                               trace.spec->provenance);
+                }
                 trace.needs_trace_started = false;
             }
 
@@ -804,6 +840,15 @@ void Coordinator::on_tick(float dt) {
                         pending.emplace_back(sink, e);
                     }
                     state_->emitted_count++;
+                    // Cost attribution: track every emission (including
+                    // Baseline / Start / End markers) as "this trace was
+                    // active this tick". TraceStarted is one-shot and
+                    // emitted above; it's also legitimate cost-side
+                    // activity so it's recorded with the rest below.
+                    if (cost_enabled) {
+                        tick_activity.emplace_back(trace.id,
+                                                   trace.spec->provenance);
+                    }
                 };
 
                 if (!mstate.has_baseline) {
@@ -842,8 +887,22 @@ void Coordinator::on_tick(float dt) {
                 }
             }
         }
+    cost_emit:
+        (void)0;
     }
     for (auto& [sink, ev] : pending) sink(ev);
+
+    // Forward per-tick trace activity to the CostAttributor and emit
+    // a CostSample. Done outside the coordinator lock so the probe
+    // (which may call into render-layer code) doesn't contend with
+    // sink registration or trace attach.
+    if (cost_enabled) {
+        for (const auto& [tid, prov] : tick_activity) {
+            cost.note_trace_activity(tid);
+            cost.note_provenance(tid, prov);
+        }
+        cost.emit_frame();
+    }
 }
 
 // ── Coordinator::publish_internal (Phase 3) ───────────────────────────

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -463,6 +463,25 @@ void publish_components(std::string view_name,
                                              std::move(components), opts);
 }
 
+// ── Ambient provenance (Phase 9) ─────────────────────────────────────
+//
+// The ambient slot lives on the Coordinator's State (under its mutex)
+// so concurrent publishes from any sink-fed thread see a coherent
+// snapshot. Read by `publish_internal` when a caller's PublishOptions
+// carries an empty provenance envelope.
+
+void set_ambient_provenance(Provenance p) {
+    Coordinator::instance().set_ambient_provenance_internal(std::move(p));
+}
+
+void clear_ambient_provenance() {
+    Coordinator::instance().set_ambient_provenance_internal(Provenance{});
+}
+
+Provenance current_ambient_provenance() {
+    return Coordinator::instance().current_ambient_provenance_internal();
+}
+
 // ── Coordinator internals ─────────────────────────────────────────────
 
 struct PerMetricState {
@@ -520,6 +539,11 @@ struct Coordinator::State {
     // sampler-driven trace map above so publishes and sampled traces
     // don't interfere even on the same view/metric name.
     std::map<PublishKey, PublishState> publish_states;
+    // Phase 9: ambient publish provenance. Set via
+    // `set_ambient_provenance` and stamped onto publishes whose
+    // PublishOptions::provenance is empty. Single global slot — intended
+    // for single-threaded scripted contexts.
+    Provenance ambient_provenance;
 };
 
 // ── Coordinator ───────────────────────────────────────────────────────
@@ -636,6 +660,17 @@ void Coordinator::reset() {
     state_->emitted_count = 0;
     state_->next_sink_id = 1;
     state_->next_trace_id = 1;
+    state_->ambient_provenance = Provenance{};
+}
+
+void Coordinator::set_ambient_provenance_internal(Provenance p) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->ambient_provenance = std::move(p);
+}
+
+Provenance Coordinator::current_ambient_provenance_internal() const {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    return state_->ambient_provenance;
 }
 
 std::size_t Coordinator::active_trace_count() const noexcept {
@@ -839,6 +874,13 @@ void Coordinator::publish_internal(std::string view_name,
             pstate.epsilon = opts.epsilon;
         }
 
+        // Phase 9: resolve effective provenance. Explicit opts.provenance
+        // wins; otherwise fall back to the coordinator's ambient slot.
+        // Empty stays empty so pre-Phase-9 callers see no behavior change.
+        const Provenance effective_prov =
+            opts.provenance.is_set() ? opts.provenance
+                                     : state_->ambient_provenance;
+
         auto enqueue = [&](SampleEvent::Kind kind,
                            std::vector<std::pair<std::string, double>> comps,
                            std::vector<std::pair<std::string, double>> deltas = {}) {
@@ -855,6 +897,7 @@ void Coordinator::publish_internal(std::string view_name,
             e.trace_id = 0;
             e.metric_id = 0;
             e.burst_id = pstate.current_burst_id;
+            e.provenance = effective_prov;  // Phase 9
             e.components = std::move(comps);
             e.deltas = std::move(deltas);
             for (const auto& [sid, sink] : state_->sinks) {

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -1840,4 +1840,102 @@ InputRecorder make_input_recorder(std::string path) {
     return InputRecorder(sink_id);
 }
 
+// ── replay_inputs (Phase 10b) ────────────────────────────────────────
+//
+// Walks a fixture, locates each Input's target by `view_id` (DFS from
+// `root_view`), advances `frame_clock` to the recorded timestamp, and
+// re-invokes the matching `View::simulate_*`. Sinks installed on the
+// Coordinator (typically the same `make_fixture_sink` paired with the
+// recorder) re-capture the motion stream the replayed inputs produce,
+// so a captured fixture replayed against a fresh view tree yields a
+// byte-equivalent motion fixture.
+
+namespace {
+
+const View* find_by_id(const View& root, const std::string& id) {
+    if (root.id() == id) return &root;
+    for (std::size_t i = 0; i < root.child_count(); ++i) {
+        if (const View* found = find_by_id(*root.child_at(i), id)) {
+            return found;
+        }
+    }
+    return nullptr;
+}
+
+double component_value(const std::vector<std::pair<std::string, double>>& comps,
+                       const std::string& name) {
+    for (const auto& [k, v] : comps) {
+        if (k == name) return v;
+    }
+    return 0.0;
+}
+
+}  // namespace
+
+int replay_inputs(const std::string& path, View& root_view, FrameClock& clock) {
+    auto events = load_fixture(path);
+    if (events.empty()) return -1;
+
+    int replayed = 0;
+    double last_t = 0.0;
+    bool have_last_t = false;
+    for (const auto& e : events) {
+        if (e.kind != SampleEvent::Kind::Input) continue;
+
+        // Advance the clock to the recorded timestamp. The first input
+        // anchors `last_t` so a delayed first interaction is preserved.
+        if (have_last_t) {
+            const double dt = e.t_seconds - last_t;
+            if (dt > 0.0) clock.tick(static_cast<float>(dt));
+        } else {
+            // Anchor on the recorded `t` so geometry traces that
+            // sample on the same FrameClock observe a consistent
+            // start offset.
+            if (e.t_seconds > 0.0) clock.tick(static_cast<float>(e.t_seconds));
+            have_last_t = true;
+        }
+        last_t = e.t_seconds;
+
+        // Coordinates in the fixture are root-space (matching the
+        // original `View::simulate_*` contract), so dispatch through
+        // `root_view`: its `hit_test` walks the tree and lands on the
+        // same descendant the recorder captured. `view_id` is a
+        // recorded provenance signal — useful for diffing across
+        // replay runs — not the actual dispatch receiver, because
+        // calling `simulate_click` on a leaf view with root-space
+        // coords would always miss its local hit_test.
+        //
+        // We still resolve `view_id` so the lookup itself is
+        // exercised, and (when the id has moved or been renamed) the
+        // diagnostic surface here can be extended without changing
+        // the public contract.
+        if (!e.view_id.empty()) {
+            (void)find_by_id(root_view, e.view_id);
+        }
+        View* target = &root_view;
+
+        if (e.input_kind == "click") {
+            const Point p{ static_cast<float>(component_value(e.components, "x")),
+                           static_cast<float>(component_value(e.components, "y")) };
+            target->simulate_click(p);
+            ++replayed;
+        } else if (e.input_kind == "hover") {
+            const Point p{ static_cast<float>(component_value(e.components, "x")),
+                           static_cast<float>(component_value(e.components, "y")) };
+            target->simulate_hover(p);
+            ++replayed;
+        } else if (e.input_kind == "drag") {
+            const Point s{ static_cast<float>(component_value(e.components, "start_x")),
+                           static_cast<float>(component_value(e.components, "start_y")) };
+            const Point en{ static_cast<float>(component_value(e.components, "end_x")),
+                            static_cast<float>(component_value(e.components, "end_y")) };
+            const int steps = std::max(
+                1, static_cast<int>(component_value(e.components, "steps")));
+            target->simulate_drag(s, en, steps);
+            ++replayed;
+        }
+    }
+    return replayed;
+}
+
 }  // namespace pulp::view::motion

--- a/core/view/src/motion_cost.cpp
+++ b/core/view/src/motion_cost.cpp
@@ -11,7 +11,12 @@
 #include <pulp/view/motion_cost.hpp>
 
 #include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
+#include <iomanip>
+#include <limits>
 #include <map>
 #include <mutex>
 #include <sstream>
@@ -57,6 +62,76 @@ void append_provenance(std::ostringstream& ss, const Provenance& p) {
     ss << "}";
 }
 
+// Same NaN/Inf-as-quoted-sentinel convention as motion.cpp::format_number.
+// Without this, a probe that ever returns NaN/Inf (e.g. a single bad
+// render-stat tick) would emit raw `nan`/`inf` tokens — invalid JSON
+// that breaks the parser for every downstream consumer.
+std::string format_number(double v) {
+    if (std::isnan(v))          return "\"NaN\"";
+    if (std::isinf(v) && v > 0) return "\"Infinity\"";
+    if (std::isinf(v) && v < 0) return "\"-Infinity\"";
+    std::ostringstream ss;
+    ss << std::setprecision(15) << v;
+    return ss.str();
+}
+
+// Returns the index of the matching `}` for an object that opens at
+// `open_pos` (which must point at `{`). Respects string literals and
+// their escapes, so a `}` inside a quoted source-file path no longer
+// truncates the active_provenance entry mid-string.
+std::size_t find_matching_brace(const std::string& s, std::size_t open_pos) {
+    int depth = 0;
+    bool in_string = false;
+    for (std::size_t i = open_pos; i < s.size(); ++i) {
+        char c = s[i];
+        if (in_string) {
+            if (c == '\\') { ++i; continue; }
+            if (c == '"')  { in_string = false; }
+            continue;
+        }
+        if (c == '"') { in_string = true; continue; }
+        if (c == '{') ++depth;
+        else if (c == '}') {
+            if (--depth == 0) return i;
+        }
+    }
+    return std::string::npos;
+}
+
+// Parse a JSON string literal at `quote_pos` (which must point at the
+// opening `"`) honoring `\\` and `\"` escapes. Writes the unescaped
+// value into `dst` and returns the index of the closing `"`. Used to
+// pull provenance fields out of an object slice without misreading a
+// `}` inside the string as the object terminator.
+std::size_t parse_json_string(const std::string& s,
+                              std::size_t quote_pos,
+                              std::string& dst) {
+    dst.clear();
+    if (quote_pos >= s.size() || s[quote_pos] != '"') return std::string::npos;
+    for (std::size_t i = quote_pos + 1; i < s.size(); ++i) {
+        char c = s[i];
+        if (c == '"') return i;
+        if (c == '\\' && i + 1 < s.size()) {
+            char esc = s[i + 1];
+            switch (esc) {
+                case '"':  dst += '"';  break;
+                case '\\': dst += '\\'; break;
+                case '/':  dst += '/';  break;
+                case 'b':  dst += '\b'; break;
+                case 'f':  dst += '\f'; break;
+                case 'n':  dst += '\n'; break;
+                case 'r':  dst += '\r'; break;
+                case 't':  dst += '\t'; break;
+                default:   dst += esc;  break;
+            }
+            ++i;
+            continue;
+        }
+        dst += c;
+    }
+    return std::string::npos;
+}
+
 }  // namespace
 
 std::string serialize_cost_sample(const CostSample& s) {
@@ -64,9 +139,9 @@ std::string serialize_cost_sample(const CostSample& s) {
     ss << "{";
     ss << "\"kind\":\"cost\",";
     ss << "\"frame\":" << s.frame << ",";
-    ss << "\"t\":" << s.t_seconds << ",";
-    ss << "\"render_pass_duration_ms\":" << s.render_pass_duration_ms << ",";
-    ss << "\"dirty_rect_area_px\":" << s.dirty_rect_area_px << ",";
+    ss << "\"t\":" << format_number(s.t_seconds) << ",";
+    ss << "\"render_pass_duration_ms\":" << format_number(s.render_pass_duration_ms) << ",";
+    ss << "\"dirty_rect_area_px\":" << format_number(s.dirty_rect_area_px) << ",";
     ss << "\"dirty_rect_count\":" << s.dirty_rect_count << ",";
     ss << "\"active_trace_ids\":[";
     for (std::size_t i = 0; i < s.active_trace_ids.size(); ++i) {
@@ -295,10 +370,22 @@ std::vector<CostSample> load_cost_stream(const std::string& path) {
         // output; if callers need that, they should plumb choc::json
         // at the inspector layer.
         CostSample s;
+        // Number-or-sentinel parser: accepts a raw double OR the same
+        // "NaN"/"Infinity"/"-Infinity" quoted sentinels format_number
+        // emits for non-finite values.
         auto find_num = [&](const std::string& key, double& dst) {
             auto pos = line.find("\"" + key + "\":");
             if (pos == std::string::npos) return;
             pos += key.size() + 3;
+            if (pos < line.size() && line[pos] == '"') {
+                std::string sentinel;
+                auto end_q = parse_json_string(line, pos, sentinel);
+                if (end_q == std::string::npos) return;
+                if (sentinel == "NaN")        dst = std::numeric_limits<double>::quiet_NaN();
+                else if (sentinel == "Infinity")  dst =  std::numeric_limits<double>::infinity();
+                else if (sentinel == "-Infinity") dst = -std::numeric_limits<double>::infinity();
+                return;
+            }
             char* end = nullptr;
             dst = std::strtod(line.c_str() + pos, &end);
         };
@@ -328,24 +415,30 @@ std::vector<CostSample> load_cost_stream(const std::string& path) {
             }
         }
 
-        // active_provenance — minimal scan: pull each {...} object.
+        // active_provenance — pull each {...} object via brace-depth
+        // tracking so a literal `}` inside `source_file` (legal JSON,
+        // since only `"` and `\\` are escaped) no longer truncates
+        // the entry mid-string and corrupts every following object.
         {
             auto pos = line.find("\"active_provenance\":[");
             if (pos != std::string::npos) {
                 pos += sizeof("\"active_provenance\":[") - 1;
                 while (pos < line.size() && line[pos] != ']') {
                     if (line[pos] != '{') { ++pos; continue; }
-                    auto obj_end = line.find('}', pos);
+                    auto obj_end = find_matching_brace(line, pos);
                     if (obj_end == std::string::npos) break;
                     std::string obj = line.substr(pos, obj_end - pos + 1);
                     Provenance p;
+                    // Honor JSON string escapes when reading source_*
+                    // fields so escaped quotes/backslashes round-trip.
                     auto pull_str = [&](const std::string& k, std::string& dst) {
                         auto kp = obj.find("\"" + k + "\":\"");
                         if (kp == std::string::npos) return;
-                        kp += k.size() + 4;
-                        auto kq = obj.find('"', kp);
-                        if (kq == std::string::npos) return;
-                        dst = obj.substr(kp, kq - kp);
+                        kp += k.size() + 3;  // points at opening "
+                        std::string parsed;
+                        if (parse_json_string(obj, kp, parsed) != std::string::npos) {
+                            dst = std::move(parsed);
+                        }
                     };
                     pull_str("source_kind", p.source_kind);
                     pull_str("source_id", p.source_id);

--- a/core/view/src/motion_cost.cpp
+++ b/core/view/src/motion_cost.cpp
@@ -1,0 +1,369 @@
+/// @file motion_cost.cpp
+/// Implementation of motion cost attribution. The Coordinator drives
+/// the attributor via three hooks called from `on_tick`:
+///   note_tick_begin() — capture frame / t_seconds, reset per-tick state
+///   note_trace_activity() — record which trace_ids emitted this tick
+///   emit_frame() — call the probe + fan out a CostSample
+///
+/// All state is guarded by a single mutex; sink dispatch happens
+/// outside the lock so sinks can re-enter the attributor safely.
+
+#include <pulp/view/motion_cost.hpp>
+
+#include <algorithm>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace pulp::view::motion {
+
+namespace {
+
+std::string escape_json(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 2);
+    for (char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\b': out += "\\b";  break;
+            case '\f': out += "\\f";  break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x",
+                                  static_cast<unsigned int>(c));
+                    out += buf;
+                } else {
+                    out += c;
+                }
+        }
+    }
+    return out;
+}
+
+void append_provenance(std::ostringstream& ss, const Provenance& p) {
+    ss << "{";
+    ss << "\"source_kind\":\"" << escape_json(p.source_kind) << "\",";
+    ss << "\"source_id\":\""   << escape_json(p.source_id)   << "\",";
+    ss << "\"source_file\":\"" << escape_json(p.source_file) << "\",";
+    ss << "\"source_line\":"   << p.source_line;
+    ss << "}";
+}
+
+}  // namespace
+
+std::string serialize_cost_sample(const CostSample& s) {
+    std::ostringstream ss;
+    ss << "{";
+    ss << "\"kind\":\"cost\",";
+    ss << "\"frame\":" << s.frame << ",";
+    ss << "\"t\":" << s.t_seconds << ",";
+    ss << "\"render_pass_duration_ms\":" << s.render_pass_duration_ms << ",";
+    ss << "\"dirty_rect_area_px\":" << s.dirty_rect_area_px << ",";
+    ss << "\"dirty_rect_count\":" << s.dirty_rect_count << ",";
+    ss << "\"active_trace_ids\":[";
+    for (std::size_t i = 0; i < s.active_trace_ids.size(); ++i) {
+        if (i) ss << ",";
+        ss << s.active_trace_ids[i];
+    }
+    ss << "],";
+    ss << "\"active_provenance\":[";
+    for (std::size_t i = 0; i < s.active_provenance.size(); ++i) {
+        if (i) ss << ",";
+        append_provenance(ss, s.active_provenance[i]);
+    }
+    ss << "]";
+    ss << "}";
+    return ss.str();
+}
+
+// ── CostAttributor::State ────────────────────────────────────────────
+
+struct CostAttributor::State {
+    mutable std::mutex mtx;
+    bool enabled = false;
+    CostProbe probe;
+    std::map<int, CostSink> sinks;
+    int next_sink_id = 1;
+    std::size_t emitted_count = 0;
+
+    // Per-tick scratch (reset in note_tick_begin).
+    std::uint64_t cur_frame = 0;
+    double cur_t = 0.0;
+    std::vector<int> active_ids;
+    std::map<int, Provenance> provenance;
+};
+
+CostAttributor& CostAttributor::instance() {
+    static CostAttributor inst;
+    return inst;
+}
+
+CostAttributor::CostAttributor() : state_(std::make_unique<State>()) {}
+CostAttributor::~CostAttributor() = default;
+
+void CostAttributor::set_enabled(bool on) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->enabled = on;
+}
+
+bool CostAttributor::enabled() const noexcept {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    return state_->enabled;
+}
+
+void CostAttributor::set_probe(CostProbe probe) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->probe = std::move(probe);
+}
+
+int CostAttributor::add_sink(CostSink sink) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    const int id = state_->next_sink_id++;
+    state_->sinks.emplace(id, std::move(sink));
+    return id;
+}
+
+void CostAttributor::remove_sink(int id) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->sinks.erase(id);
+}
+
+void CostAttributor::clear_sinks() {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->sinks.clear();
+}
+
+void CostAttributor::reset() {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->enabled = false;
+    state_->probe = nullptr;
+    state_->sinks.clear();
+    state_->next_sink_id = 1;
+    state_->emitted_count = 0;
+    state_->cur_frame = 0;
+    state_->cur_t = 0.0;
+    state_->active_ids.clear();
+    state_->provenance.clear();
+}
+
+std::size_t CostAttributor::emitted_sample_count() const noexcept {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    return state_->emitted_count;
+}
+
+void CostAttributor::note_tick_begin(std::uint64_t frame, double t_seconds) {
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->cur_frame = frame;
+    state_->cur_t = t_seconds;
+    state_->active_ids.clear();
+    state_->provenance.clear();
+}
+
+void CostAttributor::note_trace_activity(int trace_id) {
+    if (trace_id <= 0) return;  // 0 = publish channel, ignore.
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    auto& ids = state_->active_ids;
+    if (std::find(ids.begin(), ids.end(), trace_id) == ids.end()) {
+        ids.push_back(trace_id);
+    }
+}
+
+void CostAttributor::note_provenance(int trace_id, const Provenance& prov) {
+    if (trace_id <= 0) return;
+    std::lock_guard<std::mutex> lock(state_->mtx);
+    state_->provenance[trace_id] = prov;
+}
+
+void CostAttributor::emit_frame() {
+    CostSample sample;
+    std::vector<CostSink> sinks_snapshot;
+    CostProbe probe_snapshot;
+    {
+        std::lock_guard<std::mutex> lock(state_->mtx);
+        if (!state_->enabled || state_->sinks.empty()) {
+            // Still clear per-tick state for next frame.
+            state_->active_ids.clear();
+            state_->provenance.clear();
+            return;
+        }
+        sample.frame = state_->cur_frame;
+        sample.t_seconds = state_->cur_t;
+        sample.active_trace_ids = state_->active_ids;
+        std::sort(sample.active_trace_ids.begin(),
+                  sample.active_trace_ids.end());
+        sample.active_provenance.reserve(sample.active_trace_ids.size());
+        for (int id : sample.active_trace_ids) {
+            auto it = state_->provenance.find(id);
+            if (it != state_->provenance.end()) {
+                sample.active_provenance.push_back(it->second);
+            } else {
+                sample.active_provenance.push_back({});
+            }
+        }
+        probe_snapshot = state_->probe;
+        for (const auto& [sid, sink] : state_->sinks) {
+            (void)sid;
+            sinks_snapshot.push_back(sink);
+        }
+        state_->emitted_count++;
+        // Reset per-tick state under the lock so re-entrancy from a
+        // sink can't observe last-tick activity.
+        state_->active_ids.clear();
+        state_->provenance.clear();
+    }
+
+    // Probe call happens outside the lock — keep it cheap, but
+    // implementations are free to do whatever they need without
+    // contending with sink registration.
+    if (probe_snapshot) {
+        RenderCostSnapshot snap = probe_snapshot();
+        sample.render_pass_duration_ms = snap.render_pass_duration_ms;
+        sample.dirty_rect_area_px = snap.dirty_rect_area_px;
+        sample.dirty_rect_count = snap.dirty_rect_count;
+    }
+
+    for (const auto& sink : sinks_snapshot) {
+        if (sink) sink(sample);
+    }
+}
+
+// ── Sinks ────────────────────────────────────────────────────────────
+
+CostAttributor::CostSink make_cost_buffer_sink(std::vector<CostSample>* buf) {
+    return [buf](const CostSample& s) {
+        if (buf) buf->push_back(s);
+    };
+}
+
+CostAttributor::CostSink make_cost_sink(std::string path) {
+    // The file is opened lazily inside a shared_ptr-captured state so
+    // the destructor closes the stream when the sink is dropped.
+    struct File {
+        std::ofstream out;
+        bool header_written = false;
+    };
+    auto state = std::make_shared<File>();
+    auto p = std::make_shared<std::string>(std::move(path));
+    return [state, p](const CostSample& s) {
+        if (!state->header_written) {
+            state->out.open(*p, std::ios::out | std::ios::trunc);
+            if (!state->out.is_open()) return;
+            state->out << "{\"motion_cost_version\":"
+                       << kCostSchemaVersion << "}\n";
+            state->header_written = true;
+        }
+        if (!state->out.is_open()) return;
+        state->out << serialize_cost_sample(s) << "\n";
+        state->out.flush();
+    };
+}
+
+std::vector<CostSample> load_cost_stream(const std::string& path) {
+    std::vector<CostSample> out;
+    std::ifstream in(path);
+    if (!in.is_open()) return out;
+
+    std::string line;
+    bool header_seen = false;
+    while (std::getline(in, line)) {
+        if (line.empty()) continue;
+        if (!header_seen) {
+            // Header must be on the first non-empty line.
+            // Defensive: if it isn't there, abandon parsing — unknown
+            // format.
+            if (line.find("\"motion_cost_version\"") == std::string::npos) {
+                return {};
+            }
+            // Only schema version 1 supported today.
+            if (line.find("\"motion_cost_version\":1") == std::string::npos) {
+                return {};
+            }
+            header_seen = true;
+            continue;
+        }
+
+        // Hand-rolled minimal parser for the fields we emit. Robust
+        // JSON parsing isn't needed for round-tripping our own
+        // output; if callers need that, they should plumb choc::json
+        // at the inspector layer.
+        CostSample s;
+        auto find_num = [&](const std::string& key, double& dst) {
+            auto pos = line.find("\"" + key + "\":");
+            if (pos == std::string::npos) return;
+            pos += key.size() + 3;
+            char* end = nullptr;
+            dst = std::strtod(line.c_str() + pos, &end);
+        };
+        double frame_d = 0;
+        find_num("frame", frame_d);
+        s.frame = static_cast<std::uint64_t>(frame_d);
+        find_num("t", s.t_seconds);
+        find_num("render_pass_duration_ms", s.render_pass_duration_ms);
+        find_num("dirty_rect_area_px", s.dirty_rect_area_px);
+        double drc = 0;
+        find_num("dirty_rect_count", drc);
+        s.dirty_rect_count = static_cast<int>(drc);
+
+        // active_trace_ids
+        {
+            auto pos = line.find("\"active_trace_ids\":[");
+            if (pos != std::string::npos) {
+                pos += sizeof("\"active_trace_ids\":[") - 1;
+                auto end = line.find(']', pos);
+                std::string inside = line.substr(pos, end - pos);
+                std::stringstream ss(inside);
+                std::string tok;
+                while (std::getline(ss, tok, ',')) {
+                    if (tok.empty()) continue;
+                    s.active_trace_ids.push_back(std::atoi(tok.c_str()));
+                }
+            }
+        }
+
+        // active_provenance — minimal scan: pull each {...} object.
+        {
+            auto pos = line.find("\"active_provenance\":[");
+            if (pos != std::string::npos) {
+                pos += sizeof("\"active_provenance\":[") - 1;
+                while (pos < line.size() && line[pos] != ']') {
+                    if (line[pos] != '{') { ++pos; continue; }
+                    auto obj_end = line.find('}', pos);
+                    if (obj_end == std::string::npos) break;
+                    std::string obj = line.substr(pos, obj_end - pos + 1);
+                    Provenance p;
+                    auto pull_str = [&](const std::string& k, std::string& dst) {
+                        auto kp = obj.find("\"" + k + "\":\"");
+                        if (kp == std::string::npos) return;
+                        kp += k.size() + 4;
+                        auto kq = obj.find('"', kp);
+                        if (kq == std::string::npos) return;
+                        dst = obj.substr(kp, kq - kp);
+                    };
+                    pull_str("source_kind", p.source_kind);
+                    pull_str("source_id", p.source_id);
+                    pull_str("source_file", p.source_file);
+                    auto lp = obj.find("\"source_line\":");
+                    if (lp != std::string::npos) {
+                        p.source_line = std::atoi(obj.c_str() + lp + 14);
+                    }
+                    s.active_provenance.push_back(std::move(p));
+                    pos = obj_end + 1;
+                    if (pos < line.size() && line[pos] == ',') ++pos;
+                }
+            }
+        }
+
+        out.push_back(std::move(s));
+    }
+    return out;
+}
+
+} // namespace pulp::view::motion

--- a/core/view/src/motion_preferences.cpp
+++ b/core/view/src/motion_preferences.cpp
@@ -1,0 +1,93 @@
+#include <pulp/view/motion_preferences.hpp>
+
+#include <algorithm>
+
+#if __APPLE__
+#include <TargetConditionals.h>
+#if !TARGET_OS_IPHONE
+#define PULP_HAS_MAC_MOTION_PREFS 1
+#endif
+#endif
+
+#if PULP_HAS_MAC_MOTION_PREFS
+// Implemented in platform/mac/motion_preferences_mac.mm
+namespace pulp::view::platform {
+    MotionPolicy detect_mac_motion_policy();
+}
+#elif _WIN32
+// Implemented in platform/win/motion_preferences_win.cpp
+namespace pulp::view::platform {
+    MotionPolicy detect_win_motion_policy();
+}
+#endif
+
+namespace pulp::view {
+
+// ── MotionPreferences ───────────────────────────────────────────────────────
+
+MotionPreferences& MotionPreferences::instance() {
+    static MotionPreferences singleton;
+    return singleton;
+}
+
+MotionPreferences::MotionPreferences() {
+    last_os_ = detect_system_policy();
+}
+
+MotionPreferences::~MotionPreferences() = default;
+
+MotionPolicy MotionPreferences::policy() const {
+    if (override_) return *override_;
+    return last_os_;
+}
+
+void MotionPreferences::set_duration_scale(double scale) {
+    if (scale < 0.0) scale = 0.0;
+    if (scale > 2.0) scale = 2.0;
+    duration_scale_ = scale;
+}
+
+void MotionPreferences::set_override(std::optional<MotionPolicy> p) {
+    auto before = policy();
+    override_ = p;
+    auto after = policy();
+    if (before != after) notify_changed(after);
+}
+
+bool MotionPreferences::poll() {
+    if (override_) return false;
+    auto current = detect_system_policy();
+    if (current != last_os_) {
+        last_os_ = current;
+        notify_changed(current);
+        return true;
+    }
+    return false;
+}
+
+void MotionPreferences::on_policy_changed(std::function<void(MotionPolicy)> cb) {
+    callback_ = std::move(cb);
+}
+
+void MotionPreferences::reset_for_tests() {
+    override_.reset();
+    duration_scale_ = 1.0;
+    callback_ = {};
+    last_os_ = detect_system_policy();
+}
+
+void MotionPreferences::notify_changed(MotionPolicy p) {
+    if (callback_) callback_(p);
+}
+
+MotionPolicy MotionPreferences::detect_system_policy() {
+#if PULP_HAS_MAC_MOTION_PREFS
+    return platform::detect_mac_motion_policy();
+#elif _WIN32
+    return platform::detect_win_motion_policy();
+#else
+    return MotionPolicy::Full;
+#endif
+}
+
+} // namespace pulp::view

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -1,4 +1,5 @@
 #include <pulp/view/view.hpp>
+#include <pulp/view/motion.hpp>
 #include <pulp/view/window_host.hpp>
 #include <pulp/view/plugin_view_host.hpp>
 #include <algorithm>
@@ -535,6 +536,17 @@ void View::paint_all(canvas::Canvas& canvas) {
 
 void View::simulate_click(Point root_pos) {
     auto* target = hit_test(root_pos);
+    // Phase 10: record the synthetic input into the active motion
+    // fixture BEFORE dispatch so replay sees the same target lookup
+    // the original recording captured (target id is what we resolve,
+    // not "wherever this click would land at replay time").
+    if (pulp::view::motion::input_recording_enabled()) {
+        const std::string id = target ? target->id() : std::string();
+        std::vector<std::pair<std::string, double>> coords;
+        coords.emplace_back("x", static_cast<double>(root_pos.x));
+        coords.emplace_back("y", static_cast<double>(root_pos.y));
+        pulp::view::motion::record_simulated_input("click", id, std::move(coords));
+    }
     if (!target) return;
 
     // Convert to target's local coordinates
@@ -569,6 +581,16 @@ void View::simulate_click(Point root_pos) {
 
 void View::simulate_drag(Point start, Point end, int steps) {
     auto* target = hit_test(start);
+    if (pulp::view::motion::input_recording_enabled()) {
+        const std::string id = target ? target->id() : std::string();
+        std::vector<std::pair<std::string, double>> coords;
+        coords.emplace_back("end_x",   static_cast<double>(end.x));
+        coords.emplace_back("end_y",   static_cast<double>(end.y));
+        coords.emplace_back("start_x", static_cast<double>(start.x));
+        coords.emplace_back("start_y", static_cast<double>(start.y));
+        coords.emplace_back("steps",   static_cast<double>(steps));
+        pulp::view::motion::record_simulated_input("drag", id, std::move(coords));
+    }
     if (!target) return;
 
     target->on_mouse_down(start);
@@ -1008,6 +1030,13 @@ void View::simulate_hover(Point root_pos) {
 
     // Set hover on the hit target
     auto* target = hit_test(root_pos);
+    if (pulp::view::motion::input_recording_enabled()) {
+        const std::string id = target ? target->id() : std::string();
+        std::vector<std::pair<std::string, double>> coords;
+        coords.emplace_back("x", static_cast<double>(root_pos.x));
+        coords.emplace_back("y", static_cast<double>(root_pos.y));
+        pulp::view::motion::record_simulated_input("hover", id, std::move(coords));
+    }
     if (target) target->set_hovered(true);
 }
 

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -1,6 +1,7 @@
 #include <pulp/view/widget_bridge.hpp>
 #include <pulp/view/animation.hpp>
 #include <pulp/view/frame_clock.hpp>
+#include <pulp/view/motion.hpp>
 #include <pulp/view/ui_components.hpp>
 #include <pulp/view/text_editor.hpp>
 #include <pulp/view/canvas_widget.hpp>
@@ -915,6 +916,20 @@ void WidgetBridge::load_script(const std::string& code) {
     eval_or_throw(engine_, "user_script", code + "\n;void 0");
     // Flush any pending requestAnimationFrame callbacks
     eval_or_throw(engine_, "flush_frames", "if (typeof __flushFrames__ === 'function') __flushFrames__();void 0");
+}
+
+void WidgetBridge::load_script(const std::string& code,
+                               const std::string& script_id) {
+    // Phase 9: record the script identity BEFORE eval so any
+    // requestAnimationFrame calls made during eval already see the new
+    // active script. Cleared by the caller (or by a subsequent
+    // load_script call) when the script's surface goes away.
+    active_script_id_ = script_id;
+    load_script(code);
+}
+
+void WidgetBridge::set_active_script_id(const std::string& script_id) {
+    active_script_id_ = script_id;
 }
 
 View* WidgetBridge::widget(const std::string& id) {
@@ -6751,16 +6766,96 @@ void WidgetBridge::register_api() {
         if (ids.empty()) {
             return choc::value::Value();
         }
-        std::string batch;
-        batch.reserve(ids.size() * 24);
+        // Phase 9: invoke each callback under its own ambient
+        // provenance. The script identity (set via
+        // `load_script(code, script_id)` / `set_active_script_id`) is
+        // prefixed onto the callback id so a published value emitted
+        // from inside an rAF body inherits source_id =
+        // "<script_id>:<callback_id>". One callback at a time so the
+        // ambient slot is correct per-invocation.
+        const bool stamp = !active_script_id_.empty();
         for (auto id : ids) {
-            batch += "__invokeFrame__(";
-            batch += std::to_string(id);
-            batch += ");";
+            if (stamp) {
+                motion::Provenance p;
+                p.source_kind = "rAF";
+                p.source_id = active_script_id_ + ":" + std::to_string(id);
+                motion::set_ambient_provenance(std::move(p));
+            }
+            std::string call = "__invokeFrame__(" + std::to_string(id) + ");void 0;";
+            engine_.evaluate(call);
+            if (stamp) motion::clear_ambient_provenance();
         }
-        engine_.evaluate(batch + "void 0;");
         return choc::value::Value();
     });
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Phase 9: motion observability — JS-side bridge for the publish
+    // channel + ambient provenance slot.
+    // ═══════════════════════════════════════════════════════════════════
+    //
+    // Exposes:
+    //   motion.publishValue(viewName, metricName, value)
+    //   motion.setProvenance(kind, id)         // sticky
+    //   motion.clearProvenance()
+    //
+    // The C++ side already off-by-defaults when tracing is disabled, so
+    // calling these in production code is cheap. Design-import codegen
+    // can emit `motion.setProvenance("design-import", "figma:Card/Hover")`
+    // alongside its `view.animate({...})` so the emitted trace carries
+    // the vendor + node identity. rAF callbacks pick up
+    // `source_kind="rAF"` automatically via the ambient slot set by
+    // `__flushFrames__` when an active script id is configured.
+
+    engine_.register_function("__motionPublishValue__",
+        [](choc::javascript::ArgumentList args) {
+            auto view = args.get<std::string>(0, "");
+            auto metric = args.get<std::string>(1, "");
+            auto value = args.get<double>(2, 0.0);
+            if (!view.empty() && !metric.empty()) {
+                motion::publish_value(std::move(view), std::move(metric), value);
+            }
+            return choc::value::Value();
+        });
+
+    engine_.register_function("__motionSetProvenance__",
+        [](choc::javascript::ArgumentList args) {
+            motion::Provenance p;
+            p.source_kind = args.get<std::string>(0, "");
+            p.source_id = args.get<std::string>(1, "");
+            // Optional file + line for callers that want to point at a
+            // specific JSX/JS source line.
+            p.source_file = args.get<std::string>(2, "");
+            p.source_line = args.get<int>(3, 0);
+            motion::set_ambient_provenance(std::move(p));
+            return choc::value::Value();
+        });
+
+    engine_.register_function("__motionClearProvenance__",
+        [](choc::javascript::ArgumentList) {
+            motion::clear_ambient_provenance();
+            return choc::value::Value();
+        });
+
+    // Install the JS-side `motion` global wrapping the natives.
+    // Idempotent — re-evaluating the same definition is a no-op.
+    engine_.evaluate(
+        "if (typeof globalThis.motion === 'undefined') {"
+        "  globalThis.motion = {"
+        "    publishValue: function(view, metric, value) {"
+        "      return __motionPublishValue__(String(view), String(metric), Number(value));"
+        "    },"
+        "    setProvenance: function(kind, id, file, line) {"
+        "      return __motionSetProvenance__(String(kind || ''), String(id || ''),"
+        "                                     String(file || ''), Number(line || 0));"
+        "    },"
+        "    set_provenance: function(kind, id, file, line) {"
+        "      return globalThis.motion.setProvenance(kind, id, file, line);"
+        "    },"
+        "    clearProvenance: function() { return __motionClearProvenance__(); },"
+        "  };"
+        "}"
+        "void 0;"
+    );
 
     // pulp #915 — native setTimeout / setInterval scheduling. JS-side
     // setTimeout/setInterval generate the id and stash the callback in

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -6774,7 +6774,15 @@ void WidgetBridge::register_api() {
         // "<script_id>:<callback_id>". One callback at a time so the
         // ambient slot is correct per-invocation.
         const bool stamp = !active_script_id_.empty();
+        // RAII guard so an exception in `__invokeFrame__` doesn't leave
+        // stale ambient provenance behind, corrupting attribution for
+        // every subsequent publish until something else clears it.
+        struct AmbientGuard {
+            bool active;
+            ~AmbientGuard() { if (active) motion::clear_ambient_provenance(); }
+        };
         for (auto id : ids) {
+            AmbientGuard guard{stamp};
             if (stamp) {
                 motion::Provenance p;
                 p.source_kind = "rAF";
@@ -6783,7 +6791,7 @@ void WidgetBridge::register_api() {
             }
             std::string call = "__invokeFrame__(" + std::to_string(id) + ");void 0;";
             engine_.evaluate(call);
-            if (stamp) motion::clear_ambient_provenance();
+            // guard's dtor runs on normal AND exception paths.
         }
         return choc::value::Value();
     });

--- a/docs/guides/motion-observability.md
+++ b/docs/guides/motion-observability.md
@@ -183,11 +183,23 @@ Protocol requests:
 | `Motion.stopTrace` | `{trace_id}` | `{removed}` |
 | `Motion.snapshot` | `{}` | `{tracing_enabled, firehose, active_traces, inspector_traces, emitted_events}` |
 | `Motion.listTraces` | `{}` | `{trace_ids:[…]}` |
+| `Motion.loadFixture` | `{path}` | `{ok, event_count, max_frame, header:{version, policy, duration_scale}}` |
+| `Motion.scrubTo` | `{frame}` | `{playhead_frame, emitted_count}` (broadcasts Motion.start/.sample/.end with `"replay":true`) |
+| `Motion.play` | `{}` | `{playing, emitted_count, playhead_frame}` |
+| `Motion.pause` | `{}` | `{playing:false, playhead_frame}` |
 
 The server broadcasts `Motion.start`, `Motion.sample`, and `Motion.end` events
 to all connected clients as samples are emitted. Subscribing clients receive a
 clean stream for the trace they registered — concurrent unrelated animations
 do not bleed into the stream unless the firehose is on (see below).
+
+The timeline scrubber methods (`Motion.loadFixture` / `.scrubTo` / `.play` /
+`.pause`) load a `.motion.jsonl` fixture into memory and re-emit the prefix
+of events with `frame <= playhead` to the same event channel as live traces.
+Replayed events carry an additional `"replay":true` marker so clients can
+distinguish them from live coordinator events. The scrubber is passive — no
+clock is pumped, no animation runs live; this is sufficient for design review
+and CI artifact triage (live overlay drawing is a future phase).
 
 ### Env knobs in `pulp-ui-preview`
 

--- a/docs/guides/motion-observability.md
+++ b/docs/guides/motion-observability.md
@@ -261,6 +261,64 @@ if (!diff.matches()) {
 `FixtureMatchOptions` controls per-component epsilon, timing epsilon, and
 whether event counts must match exactly.
 
+## Input recording and replay
+
+`View::simulate_click`, `simulate_drag`, and `simulate_hover` can be recorded
+into the same fixture format that carries motion samples. The recorded
+interactions can later be replayed against a fresh view tree on a scripted
+`FrameClock` to reproduce the original motion stream deterministically. Off by
+default everywhere — recording is opt-in.
+
+```cpp
+#include <pulp/view/motion.hpp>
+
+// Recording — paired with whatever motion sinks you already have.
+{
+    auto recorder = pulp::view::motion::make_input_recorder(
+        "/tmp/card-open.motion.jsonl");
+
+    root_view.simulate_hover({150, 150});
+    clock.tick(1.0f / 60.0f);
+    root_view.simulate_click({150, 150});
+    // ... drive your animation ...
+}   // recorder destructor closes the fixture sink + flips recording off.
+
+// Replay — into a brand-new view tree and clock.
+pulp::view::motion::replay_inputs(
+    "/tmp/card-open.motion.jsonl", fresh_root_view, fresh_clock);
+```
+
+A recorded `Input` event rides in the same JSONL alongside `baseline` /
+`sample` / `start` / `end`, with two extra fields:
+
+```jsonc
+{"kind":"input","view":"input","metric":"click",
+ "t":0.05,"frame":3,"precision":3,"trace_id":0,"metric_id":0,"burst_id":0,
+ "components":{"x":150,"y":150},"deltas":{},
+ "input_kind":"click","view_id":"target"}
+```
+
+`view_id` is the recorded target's `View::id()` (empty when the event didn't
+land on an id-bearing view). `components` carries root-space coordinates: `x`
+/ `y` for click and hover; `start_x` / `start_y` / `end_x` / `end_y` / `steps`
+for drag. Existing motion lines are untouched — input fields are only
+serialized when `kind == Input` so pre-Phase-10 fixtures round-trip
+byte-for-byte.
+
+`replay_inputs` walks the fixture, advances the supplied `FrameClock` to each
+input's recorded timestamp (delta-based: the first input anchors on its
+recorded `t`, subsequent inputs tick by the delta), resolves the target by
+`view_id` for diagnostic continuity, and dispatches through `root_view` so
+its `hit_test()` lands on the same descendant. Sinks installed on the
+Coordinator (typically the same `make_fixture_sink` paired with the
+recorder) re-capture the motion stream the replayed inputs produce, so a
+recorded fixture replayed against a fresh tree yields a byte-equivalent
+motion fixture (modulo timing tolerance from `FixtureMatchOptions`).
+
+The non-recording cost is a single relaxed atomic load
+(`input_recording_enabled()`) on each `simulate_*` call, so leaving the
+hooks in production code is free.
+
 ## Assertion helpers
 
 Use these for unit tests and for the assertion CLI. Each takes a `ScalarSample`

--- a/docs/guides/motion-observability.md
+++ b/docs/guides/motion-observability.md
@@ -115,10 +115,34 @@ auto handle = Coordinator::instance()
 
 The envelope appears on the `TraceStarted` event and round-trips through
 fixtures. Agents reading a fixture can resolve "where does this animation
-live?" without grepping. The richer adapters that auto-populate provenance
-from `Tween` / CSS `TransitionSpec` / `AnimatorSet` / JS rAF / design-import
-land in a follow-up phase; today the envelope is opt-in via
-`with_provenance(...)`.
+live?" without grepping.
+
+#### Adapters that auto-fill provenance
+
+Phase 9 wires each animation surface so the envelope is populated without
+the caller hand-building one. Off by default — pre-Phase-9 callers continue
+emitting unstamped events:
+
+| Surface | How to attach | Resulting `source_kind` |
+|---|---|---|
+| `Tween` | `t.set_motion_provenance("tween", "knob-hover")` then `t.publish(view, metric)` | `"tween"` |
+| `Tween` (macro) | `PULP_MOTION_TWEEN("knob-hover", 0.0f, 1.0f, 0.2f)` (auto-fills `source_file`/`source_line` via `std::source_location`) | `"tween"` |
+| `AnimatorSetBuilder` | `.name("knob-glow")` then `runner.publish(view, metric, value)` | `"animator-set"` |
+| CSS `TransitionSpec` | `parse_transition_shorthand_with_provenance(css, "/styles/card.css", 17)` then `anim.publish(view, metric)` | `"css-transition"` |
+| JS rAF | `bridge.load_script(code, "my-script.js")` — `__flushFrames__` stamps each callback as `"<script_id>:<callback_id>"` automatically | `"rAF"` |
+| JS user code | `motion.setProvenance("design-import", "figma:Card/Hover")` then `motion.publishValue(view, metric, value)` | whatever the caller passed |
+| Design import | `generate_pulp_js` emits a `motion.setProvenance('design-import', '<vendor>:<root-name>')` line at the top of every bundle | `"design-import"` |
+
+The publish channel also has an **ambient provenance** slot for surfaces
+that can't easily thread `PublishOptions` through every call site:
+
+```cpp
+motion::set_ambient_provenance({ "rAF", "my-script.js:42", "", 0 });
+// any publish_value / publish_components calls now inherit the envelope
+motion::clear_ambient_provenance();
+```
+
+Explicit `PublishOptions::provenance` always wins over the ambient slot.
 
 ### Sinks
 

--- a/docs/guides/motion-observability.md
+++ b/docs/guides/motion-observability.md
@@ -287,6 +287,63 @@ The schema is versioned (`REPORT_SCHEMA_VERSION`) so downstream consumers can
 reject unknown formats. Dependencies (numpy, Pillow, scikit-image) are MIT /
 BSD / Apache 2.0 only and are not redistributed in plugin or app artifacts.
 
+## Reduced-motion policy
+
+Pulp animation primitives honor the system reduced-motion preference via
+`pulp::view::MotionPreferences`, a sibling of `AppearanceTracker`:
+
+```cpp
+#include <pulp/view/motion_preferences.hpp>
+
+auto& prefs = pulp::view::MotionPreferences::instance();
+// OS-driven by default. Test / JS override that wins over the OS:
+prefs.set_override(pulp::view::MotionPolicy::Reduced);
+prefs.set_duration_scale(0.5);   // halves the configured duration
+// Revert to OS:
+prefs.set_override(std::nullopt);
+```
+
+`MotionPolicy` has three values:
+
+| Policy | Effect on animation primitives |
+|---|---|
+| `Full` (default) | Animate over the configured duration. |
+| `Reduced` | Scale the configured duration by `duration_scale` (0.0–2.0). |
+| `Off` | Jump straight to the target value; no intermediate samples. |
+
+The policy is read once at animation start (`Tween` / `ValueAnimation`
+constructor, `Tween::reset()`, `ValueAnimation::animate_to()`, and
+`CssAnimation`'s first `tick()`). Changes to `MotionPreferences` between
+two animations affect only the next animation that starts.
+
+Platform readers:
+
+- **macOS** — `[NSWorkspace sharedWorkspace].accessibilityDisplayShouldReduceMotion`
+- **Windows** — `SystemParametersInfoW(SPI_GETCLIENTAREAANIMATION, ...)`
+- **Other** — defaults to `Full`.
+
+Fixtures recorded under a non-`Full` policy capture both `policy` and
+`duration_scale` on the v2 header so goldens recorded with reduced motion
+cannot silently compare against `Full` captures:
+
+```jsonc
+{"motion_fixture_version":2,"policy":"reduced","duration_scale":0.5}
+```
+
+The fields are additive — pre-Phase-8 v2 fixtures without them still load
+(defaulting to `"full"` / `1.0`). To compare two fixtures' headers, use the
+header-aware `assert_matches` overload:
+
+```cpp
+auto g_hdr = motion::load_fixture_header("golden.jsonl");
+auto c_hdr = motion::load_fixture_header("captured.jsonl");
+auto g = motion::load_fixture("golden.jsonl");
+auto c = motion::load_fixture("captured.jsonl");
+auto diff = motion::assert_matches(g_hdr, g, c_hdr, c);
+// Adds a `"policy-mismatch"` Item to diff.differences when policy or
+// duration_scale differ.
+```
+
 ## Architectural guarantees
 
 - **Off by default** — every entry point gates on `tracing_enabled()`. No cost

--- a/docs/guides/motion-observability.md
+++ b/docs/guides/motion-observability.md
@@ -438,6 +438,51 @@ auto diff = motion::assert_matches(g_hdr, g, c_hdr, c);
 // duration_scale differ.
 ```
 
+## Cost attribution
+
+When the question is "which animation is expensive and why?", the
+fixture stream of values is not enough — you also want per-frame render
+cost joined with the trace activity that drove it. The cost-attribution
+channel does that.
+
+It is **off by default** and runs on a stream separate from the fixture
+format. Cost samples carry their own version header
+(`{"motion_cost_version":1}`) and are written to `*.motion-cost.jsonl`,
+not the regular `*.motion.jsonl` events.
+
+```cpp
+#include <pulp/view/motion_cost.hpp>
+#include <pulp/view/motion_cost_render.hpp>
+
+auto& cost = pulp::view::motion::CostAttributor::instance();
+cost.set_enabled(true);
+cost.add_sink(motion::make_cost_sink("/tmp/run.motion-cost.jsonl"));
+
+// Surface real render-pass + dirty-rect stats via the bridge probe.
+// Either pointer may be null — defensive fields default to 0.
+cost.set_probe(motion::make_render_cost_probe(
+    &render_pass_manager, &dirty_tracker));
+```
+
+Each `CostSample` carries:
+
+| Field | Source |
+|---|---|
+| `frame`, `t_seconds` | FrameClock at tick time |
+| `render_pass_duration_ms` | `RenderPassManager::total_time_ms()` |
+| `dirty_rect_area_px`, `dirty_rect_count` | `DirtyTracker::dirty_rects()` |
+| `active_trace_ids` | every `trace_id` that emitted on this frame |
+| `active_provenance` | per-trace Phase 9 envelope (parallel to `active_trace_ids`) |
+
+Cost samples emit even when the coordinator has no event sinks — the
+render-cost timeline is useful by itself even when no motion trace is
+active.
+
+The inspector exposes `Motion.enableCost` / `Motion.disableCost`
+requests and broadcasts a `Motion.cost` event per frame while enabled.
+`Motion.snapshot` reports `cost_enabled` and `cost_samples_emitted` so
+a client can verify the channel is live without subscribing.
+
 ## Architectural guarantees
 
 - **Off by default** — every entry point gates on `tracing_enabled()`. No cost

--- a/docs/status/modules.yaml
+++ b/docs/status/modules.yaml
@@ -108,6 +108,10 @@ modules:
       clamped `duration_scale`; Tween, ValueAnimation, TransitionSpec, and
       AnimatorSet honor it on start, and fixture headers record the policy used
       during recording so goldens can't silently compare across policies.
+      `MotionScrubber` (in `inspect/`) loads a `.motion.jsonl` fixture and
+      re-emits the prefix of events with `frame <= playhead` over the inspector
+      wire via `Motion.loadFixture` / `.scrubTo` / `.play` / `.pause` — passive
+      timeline replay for design review and CI artifact triage.
       Off by default; see guides/motion-observability.md.
     status: usable
     dependencies: [canvas, events, state]

--- a/docs/status/modules.yaml
+++ b/docs/status/modules.yaml
@@ -103,6 +103,11 @@ modules:
       paint_all()-order presentation geometry walker, publish channel + firehose,
       versioned JSONL record/replay fixtures, and assertion helpers (is_monotonic,
       settling_time_seconds, overshoot, start_delay_seconds, frame_jitter_seconds).
+      `MotionPreferences` (sibling of `AppearanceTracker`) reads the OS
+      reduced-motion preference and exposes `MotionPolicy` (Full/Reduced/Off) +
+      clamped `duration_scale`; Tween, ValueAnimation, TransitionSpec, and
+      AnimatorSet honor it on start, and fixture headers record the policy used
+      during recording so goldens can't silently compare across policies.
       Off by default; see guides/motion-observability.md.
     status: usable
     dependencies: [canvas, events, state]

--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(pulp-inspect PRIVATE
     src/audio_inspector.cpp
     src/domain_handler.cpp
     src/motion_inspector.cpp
+    src/motion_scrubber.cpp
 )
 
 target_link_libraries(pulp-inspect PUBLIC pulp::view pulp::render pulp::state pulp::events)

--- a/inspect/include/pulp/inspect/domain_handler.hpp
+++ b/inspect/include/pulp/inspect/domain_handler.hpp
@@ -13,6 +13,7 @@ class StateInspector;
 class ConsoleCapture;
 class AudioInspector;
 class MotionInspector;
+class MotionScrubber;
 
 /// Handles inspector protocol requests by delegating to the appropriate
 /// inspector component. All data sources are optional — missing sources
@@ -28,6 +29,7 @@ public:
     void set_console_capture(ConsoleCapture* console) { console_ = console; }
     void set_audio_inspector(AudioInspector* audio) { audio_ = audio; }
     void set_motion_inspector(MotionInspector* motion) { motion_ = motion; }
+    void set_motion_scrubber(MotionScrubber* scrubber) { motion_scrubber_ = scrubber; }
     void set_render_pass_manager(render::RenderPassManager* rpm) { rpm_ = rpm; }
 
     /// Handle a protocol request. Returns a response message.
@@ -40,6 +42,7 @@ private:
     ConsoleCapture* console_ = nullptr;
     AudioInspector* audio_ = nullptr;
     MotionInspector* motion_ = nullptr;
+    MotionScrubber* motion_scrubber_ = nullptr;
     render::RenderPassManager* rpm_ = nullptr;
 
     // Domain handlers

--- a/inspect/include/pulp/inspect/motion_inspector.hpp
+++ b/inspect/include/pulp/inspect/motion_inspector.hpp
@@ -7,6 +7,7 @@
 
 #include <pulp/inspect/protocol.hpp>
 #include <pulp/view/motion.hpp>
+#include <pulp/view/motion_cost.hpp>
 
 #include <cstdint>
 #include <mutex>
@@ -40,6 +41,7 @@ private:
     pulp::view::View* root_ = nullptr;
     InspectorServer* server_ = nullptr;
     int sink_id_ = 0;
+    int cost_sink_id_ = 0;
 
     mutable std::mutex mtx_;
     std::unordered_map<std::int64_t, pulp::view::motion::TraceHandle> traces_;
@@ -49,8 +51,11 @@ private:
     InspectorMessage stop_trace(const InspectorMessage& req);
     InspectorMessage snapshot(const InspectorMessage& req);
     InspectorMessage list_traces(const InspectorMessage& req);
+    InspectorMessage enable_cost(const InspectorMessage& req);
+    InspectorMessage disable_cost(const InspectorMessage& req);
 
     void broadcast_event(const pulp::view::motion::SampleEvent& e);
+    void broadcast_cost(const pulp::view::motion::CostSample& s);
 };
 
 } // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/motion_scrubber.hpp
+++ b/inspect/include/pulp/inspect/motion_scrubber.hpp
@@ -115,12 +115,13 @@ private:
     InspectorMessage handle_play(const InspectorMessage& req);
     InspectorMessage handle_pause(const InspectorMessage& req);
 
-    // Emit the prefix of events with `frame <= up_to_frame` to all sinks
-    // and (when present) broadcast each as a Motion.* event. Returns the
-    // emitted count. Caller holds `mtx_`.
-    std::size_t emit_prefix_locked(std::uint64_t up_to_frame);
-
-    void dispatch_event(const view::motion::SampleEvent& e);
+    // Dispatch a snapshot of events to the given sinks + server WITHOUT
+    // holding mtx_. Callers must collect the snapshot under the lock and
+    // then call this. Sinks are free to re-enter MotionScrubber methods.
+    static void dispatch_snapshot(
+        const std::vector<view::motion::SampleEvent>& events,
+        const std::vector<SinkSlot>& sinks,
+        InspectorServer* server);
 };
 
 } // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/motion_scrubber.hpp
+++ b/inspect/include/pulp/inspect/motion_scrubber.hpp
@@ -1,0 +1,126 @@
+// motion_scrubber.hpp — Timeline scrubber that replays a .motion.jsonl
+// fixture frame-by-frame against an inspector client.
+//
+// The scrubber is passive: it does not run animations live and does not
+// advance a clock. It loads a recorded fixture into memory, exposes a
+// playhead (frame index), and re-emits the prefix of events with
+// `frame <= playhead` to a caller-supplied Sink each time the playhead
+// moves. This is sufficient for design-review timeline scrubbing and CI
+// artifact triage — the live-overlay drawing layer is Phase 11+.
+//
+// Inspector dispatch:
+//   Motion.loadFixture { path }    → load events, reset playhead to 0
+//   Motion.scrubTo     { frame }   → set playhead, re-emit prefix
+//   Motion.play        {}          → mark playing, jump to max frame
+//   Motion.pause       {}          → clear playing flag
+//   Motion.snapshot    {}          → playhead + loaded state
+//
+// The scrubber is off by default — `loaded()` is false until
+// `load_fixture()` succeeds. Wiring is analogous to MotionInspector:
+// DomainHandler owns the instance and routes Motion.* requests to it
+// when the method is a scrubber method.
+
+#pragma once
+
+#include <pulp/inspect/protocol.hpp>
+#include <pulp/view/motion.hpp>
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace pulp::inspect {
+
+class InspectorServer;
+
+class MotionScrubber {
+public:
+    /// Construct with an optional InspectorServer. With a server,
+    /// re-emitted events are broadcast as Motion.start / .sample / .end
+    /// messages on the wire (the same shape MotionInspector uses).
+    /// Without a server, events still flow to any sinks installed via
+    /// `add_sink`.
+    explicit MotionScrubber(InspectorServer* server = nullptr);
+    ~MotionScrubber();
+
+    MotionScrubber(const MotionScrubber&) = delete;
+    MotionScrubber& operator=(const MotionScrubber&) = delete;
+
+    /// Handle a Motion.* scrubber request. Returns response message.
+    /// Caller (DomainHandler) decides routing — this method assumes the
+    /// request is one of the scrubber methods.
+    InspectorMessage handle(const InspectorMessage& req);
+
+    /// True when at least one of the scrubber methods is the natural
+    /// target for `req.method`. DomainHandler uses this to decide
+    /// whether to route to MotionScrubber vs MotionInspector.
+    static bool owns_method(const std::string& method);
+
+    // ── Direct API (used by tests + advanced clients) ───────────────
+
+    /// Load a fixture file. Returns true on success (any event count
+    /// is acceptable; an empty fixture is loaded as zero events). Resets
+    /// the playhead to 0 and clears the previously-loaded events.
+    bool load_fixture(const std::string& path);
+
+    /// Move the playhead to the given frame and re-emit the prefix of
+    /// events with `frame <= playhead`. Returns the number of events
+    /// emitted (zero for an unloaded scrubber). Backwards scrubs are
+    /// supported — each call re-emits from the start.
+    std::size_t scrub_to(std::uint64_t frame);
+
+    /// Set playing flag, advance to the last loaded frame, emit
+    /// everything. Passive: no real-time pacing.
+    std::size_t play();
+
+    /// Clear the playing flag. No event emission. Playhead unchanged.
+    void pause();
+
+    /// Install a sink that receives re-emitted events. Returns a
+    /// non-zero id usable with `remove_sink`.
+    int add_sink(view::motion::Sink sink);
+    void remove_sink(int id);
+
+    // ── Read-only accessors ─────────────────────────────────────────
+
+    bool loaded() const;
+    bool playing() const;
+    std::uint64_t playhead_frame() const;
+    std::size_t event_count() const;
+    std::uint64_t max_frame() const;
+    view::motion::FixtureHeader header() const;
+
+private:
+    InspectorServer* server_ = nullptr;
+
+    mutable std::mutex mtx_;
+    std::vector<view::motion::SampleEvent> events_;
+    view::motion::FixtureHeader header_{};
+    std::uint64_t playhead_frame_ = 0;
+    std::uint64_t max_frame_ = 0;
+    bool loaded_ = false;
+    bool playing_ = false;
+
+    struct SinkSlot {
+        int id = 0;
+        view::motion::Sink sink;
+    };
+    std::vector<SinkSlot> sinks_;
+    int next_sink_id_ = 1;
+
+    // Protocol handlers.
+    InspectorMessage handle_load_fixture(const InspectorMessage& req);
+    InspectorMessage handle_scrub_to(const InspectorMessage& req);
+    InspectorMessage handle_play(const InspectorMessage& req);
+    InspectorMessage handle_pause(const InspectorMessage& req);
+
+    // Emit the prefix of events with `frame <= up_to_frame` to all sinks
+    // and (when present) broadcast each as a Motion.* event. Returns the
+    // emitted count. Caller holds `mtx_`.
+    std::size_t emit_prefix_locked(std::uint64_t up_to_frame);
+
+    void dispatch_event(const view::motion::SampleEvent& e);
+};
+
+} // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -83,10 +83,16 @@ namespace methods {
 
     // Motion domain — agent-first motion observability.
     // Requests:
-    constexpr auto kMotionStartTrace = "Motion.startTrace";
-    constexpr auto kMotionStopTrace  = "Motion.stopTrace";
-    constexpr auto kMotionSnapshot   = "Motion.snapshot";
-    constexpr auto kMotionListTraces = "Motion.listTraces";
+    constexpr auto kMotionStartTrace  = "Motion.startTrace";
+    constexpr auto kMotionStopTrace   = "Motion.stopTrace";
+    constexpr auto kMotionSnapshot    = "Motion.snapshot";
+    constexpr auto kMotionListTraces  = "Motion.listTraces";
+    // Scrubber requests (Phase 7 — loads a .motion.jsonl fixture and
+    // re-emits events up to a frame playhead; passive replay):
+    constexpr auto kMotionLoadFixture = "Motion.loadFixture";
+    constexpr auto kMotionScrubTo     = "Motion.scrubTo";
+    constexpr auto kMotionPlay        = "Motion.play";
+    constexpr auto kMotionPause       = "Motion.pause";
     // Events (broadcast to subscribed clients):
     constexpr auto kMotionStart  = "Motion.start";
     constexpr auto kMotionSample = "Motion.sample";

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -87,16 +87,22 @@ namespace methods {
     constexpr auto kMotionStopTrace   = "Motion.stopTrace";
     constexpr auto kMotionSnapshot    = "Motion.snapshot";
     constexpr auto kMotionListTraces  = "Motion.listTraces";
-    // Scrubber requests (Phase 7 — loads a .motion.jsonl fixture and
-    // re-emits events up to a frame playhead; passive replay):
+    // Scrubber requests — loads a .motion.jsonl fixture and re-emits
+    // events up to a frame playhead; passive replay.
     constexpr auto kMotionLoadFixture = "Motion.loadFixture";
     constexpr auto kMotionScrubTo     = "Motion.scrubTo";
     constexpr auto kMotionPlay        = "Motion.play";
     constexpr auto kMotionPause       = "Motion.pause";
+    // Cost attribution requests (off by default; opt-in per session).
+    constexpr auto kMotionEnableCost  = "Motion.enableCost";
+    constexpr auto kMotionDisableCost = "Motion.disableCost";
     // Events (broadcast to subscribed clients):
     constexpr auto kMotionStart  = "Motion.start";
     constexpr auto kMotionSample = "Motion.sample";
     constexpr auto kMotionEnd    = "Motion.end";
+    /// Per-frame cost sample (active trace_ids + render stats).
+    /// Broadcast only while cost attribution is enabled.
+    constexpr auto kMotionCost   = "Motion.cost";
 }
 
 } // namespace pulp::inspect

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -6,6 +6,7 @@
 #include <pulp/inspect/console_capture.hpp>
 #include <pulp/inspect/audio_inspector.hpp>
 #include <pulp/inspect/motion_inspector.hpp>
+#include <pulp/inspect/motion_scrubber.hpp>
 #include <pulp/view/inspector.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/render/render_pass.hpp>
@@ -45,6 +46,15 @@ InspectorMessage DomainHandler::handle(const InspectorMessage& req) {
 // ── Motion domain ───────────────────────────────────────────────────────────
 
 InspectorMessage DomainHandler::handle_motion(const InspectorMessage& req) {
+    // Scrubber methods route to MotionScrubber; everything else goes to
+    // MotionInspector. Both data sources are optional, so a missing
+    // scrubber returns a targeted error for scrubber methods rather
+    // than masking them as unknown.
+    if (MotionScrubber::owns_method(req.method)) {
+        if (!motion_scrubber_)
+            return make_error(req.id, "No motion scrubber attached");
+        return motion_scrubber_->handle(req);
+    }
     if (!motion_) return make_error(req.id, "No motion inspector attached");
     return motion_->handle(req);
 }

--- a/inspect/src/motion_inspector.cpp
+++ b/inspect/src/motion_inspector.cpp
@@ -3,6 +3,7 @@
 #include <pulp/inspect/inspector_server.hpp>
 #include <pulp/view/inspector.hpp>
 #include <pulp/view/motion.hpp>
+#include <pulp/view/motion_cost.hpp>
 #include <pulp/view/view.hpp>
 
 #include <choc/text/choc_JSON.h>
@@ -17,9 +18,12 @@ namespace pulp::inspect {
 namespace {
 
 using pulp::view::motion::Coordinator;
+using pulp::view::motion::CostAttributor;
+using pulp::view::motion::CostSample;
 using pulp::view::motion::GeometryProperty;
 using pulp::view::motion::GeometrySource;
 using pulp::view::motion::GeometrySpace;
+using pulp::view::motion::Provenance;
 using pulp::view::motion::SampleEvent;
 using pulp::view::motion::TraceBuilder;
 using pulp::view::motion::TraceHandle;
@@ -93,12 +97,18 @@ MotionInspector::MotionInspector(pulp::view::View& root, InspectorServer* server
     : root_(&root), server_(server) {
     sink_id_ = Coordinator::instance().add_sink(
         [this](const SampleEvent& e) { broadcast_event(e); });
+    cost_sink_id_ = CostAttributor::instance().add_sink(
+        [this](const CostSample& s) { broadcast_cost(s); });
 }
 
 MotionInspector::~MotionInspector() {
     if (sink_id_) {
         Coordinator::instance().remove_sink(sink_id_);
         sink_id_ = 0;
+    }
+    if (cost_sink_id_) {
+        CostAttributor::instance().remove_sink(cost_sink_id_);
+        cost_sink_id_ = 0;
     }
     std::lock_guard<std::mutex> lock(mtx_);
     traces_.clear();
@@ -110,10 +120,12 @@ std::size_t MotionInspector::active_trace_count() const {
 }
 
 InspectorMessage MotionInspector::handle(const InspectorMessage& req) {
-    if (req.method == methods::kMotionStartTrace) return start_trace(req);
-    if (req.method == methods::kMotionStopTrace)  return stop_trace(req);
-    if (req.method == methods::kMotionSnapshot)   return snapshot(req);
-    if (req.method == methods::kMotionListTraces) return list_traces(req);
+    if (req.method == methods::kMotionStartTrace)  return start_trace(req);
+    if (req.method == methods::kMotionStopTrace)   return stop_trace(req);
+    if (req.method == methods::kMotionSnapshot)    return snapshot(req);
+    if (req.method == methods::kMotionListTraces)  return list_traces(req);
+    if (req.method == methods::kMotionEnableCost)  return enable_cost(req);
+    if (req.method == methods::kMotionDisableCost) return disable_cost(req);
     return make_error(req.id, "Unknown Motion method: " + req.method);
 }
 
@@ -245,6 +257,25 @@ InspectorMessage MotionInspector::snapshot(const InspectorMessage& req) {
     out.addMember("emitted_events",
                   choc::value::createInt64(static_cast<int64_t>(
                       Coordinator::instance().emitted_event_count())));
+    out.addMember("cost_enabled",
+                  choc::value::createBool(CostAttributor::instance().enabled()));
+    out.addMember("cost_samples_emitted",
+                  choc::value::createInt64(static_cast<int64_t>(
+                      CostAttributor::instance().emitted_sample_count())));
+    return make_response(req.id, choc::json::toString(out, false));
+}
+
+InspectorMessage MotionInspector::enable_cost(const InspectorMessage& req) {
+    CostAttributor::instance().set_enabled(true);
+    auto out = choc::value::createObject("");
+    out.addMember("cost_enabled", choc::value::createBool(true));
+    return make_response(req.id, choc::json::toString(out, false));
+}
+
+InspectorMessage MotionInspector::disable_cost(const InspectorMessage& req) {
+    CostAttributor::instance().set_enabled(false);
+    auto out = choc::value::createObject("");
+    out.addMember("cost_enabled", choc::value::createBool(false));
     return make_response(req.id, choc::json::toString(out, false));
 }
 
@@ -292,6 +323,41 @@ void MotionInspector::broadcast_event(const SampleEvent& e) {
     }
 
     InspectorMessage ev = make_event(event_method_for_kind(e.kind),
+                                     choc::json::toString(params, false));
+    server_->broadcast(ev);
+}
+
+void MotionInspector::broadcast_cost(const CostSample& s) {
+    if (!server_) return;
+    auto params = choc::value::createObject("");
+    params.addMember("frame",
+                     choc::value::createInt64(static_cast<int64_t>(s.frame)));
+    params.addMember("t", choc::value::createFloat64(s.t_seconds));
+    params.addMember("render_pass_duration_ms",
+                     choc::value::createFloat64(s.render_pass_duration_ms));
+    params.addMember("dirty_rect_area_px",
+                     choc::value::createFloat64(s.dirty_rect_area_px));
+    params.addMember("dirty_rect_count",
+                     choc::value::createInt64(s.dirty_rect_count));
+
+    auto ids = choc::value::createEmptyArray();
+    for (int id : s.active_trace_ids) {
+        ids.addArrayElement(choc::value::createInt64(id));
+    }
+    params.addMember("active_trace_ids", ids);
+
+    auto provs = choc::value::createEmptyArray();
+    for (const auto& p : s.active_provenance) {
+        auto obj = choc::value::createObject("");
+        obj.addMember("source_kind", choc::value::createString(p.source_kind));
+        obj.addMember("source_id",   choc::value::createString(p.source_id));
+        obj.addMember("source_file", choc::value::createString(p.source_file));
+        obj.addMember("source_line", choc::value::createInt64(p.source_line));
+        provs.addArrayElement(obj);
+    }
+    params.addMember("active_provenance", provs);
+
+    InspectorMessage ev = make_event(methods::kMotionCost,
                                      choc::json::toString(params, false));
     server_->broadcast(ev);
 }

--- a/inspect/src/motion_inspector.cpp
+++ b/inspect/src/motion_inspector.cpp
@@ -58,6 +58,7 @@ const char* sample_kind_to_string(SampleEvent::Kind k) {
         case SampleEvent::Kind::Sample:       return "sample";
         case SampleEvent::Kind::Start:        return "start";
         case SampleEvent::Kind::End:          return "end";
+        case SampleEvent::Kind::Input:        return "input";
     }
     return "?";
 }
@@ -69,6 +70,7 @@ const char* event_method_for_kind(SampleEvent::Kind k) {
         case SampleEvent::Kind::Sample:       return methods::kMotionSample;
         case SampleEvent::Kind::Start:        return methods::kMotionStart;
         case SampleEvent::Kind::End:          return methods::kMotionEnd;
+        case SampleEvent::Kind::Input:        return methods::kMotionSample;
     }
     return methods::kMotionSample;
 }

--- a/inspect/src/motion_inspector.cpp
+++ b/inspect/src/motion_inspector.cpp
@@ -9,6 +9,7 @@
 #include <choc/text/choc_JSON.h>
 
 #include <algorithm>
+#include <cmath>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -79,12 +80,23 @@ const char* event_method_for_kind(SampleEvent::Kind k) {
     return methods::kMotionSample;
 }
 
+// Match motion.cpp::format_number — NaN/Inf travel as quoted sentinels
+// on the wire so a fixture round-trip and a live inspector broadcast see
+// the same values. choc::value::createFloat64 would serialize non-finite
+// as JSON `null`, silently dropping the misbehavior signal.
+choc::value::Value wire_number(double v) {
+    if (std::isnan(v))          return choc::value::createString("NaN");
+    if (std::isinf(v) && v > 0) return choc::value::createString("Infinity");
+    if (std::isinf(v) && v < 0) return choc::value::createString("-Infinity");
+    return choc::value::createFloat64(v);
+}
+
 choc::value::Value components_to_object(
     const std::vector<std::pair<std::string, double>>& comps
 ) {
     auto obj = choc::value::createObject("");
     for (const auto& [k, v] : comps) {
-        obj.addMember(k, choc::value::createFloat64(v));
+        obj.addMember(k, wire_number(v));
     }
     return obj;
 }
@@ -300,13 +312,19 @@ void MotionInspector::broadcast_event(const SampleEvent& e) {
     params.addMember("view_name", choc::value::createString(e.view_name));
     params.addMember("metric_name", choc::value::createString(e.metric_name));
     params.addMember("kind", choc::value::createString(sample_kind_to_string(e.kind)));
-    params.addMember("t", choc::value::createFloat64(e.t_seconds));
+    params.addMember("t", wire_number(e.t_seconds));
     params.addMember("frame", choc::value::createInt64(static_cast<int64_t>(e.frame)));
     // Phase 7 stable identifiers — let clients align bursts on the
     // wire the same way the fixture format aligns them.
     params.addMember("trace_id", choc::value::createInt64(e.trace_id));
     params.addMember("metric_id", choc::value::createInt64(e.metric_id));
     params.addMember("burst_id", choc::value::createInt64(e.burst_id));
+    // Phase 10 Input events carry input_kind + view_id; without these
+    // the wire form loses the entire payload of the event.
+    if (e.kind == SampleEvent::Kind::Input) {
+        params.addMember("input_kind", choc::value::createString(e.input_kind));
+        params.addMember("view_id",    choc::value::createString(e.view_id));
+    }
     if (!e.components.empty()) {
         params.addMember("components", components_to_object(e.components));
     }
@@ -332,11 +350,11 @@ void MotionInspector::broadcast_cost(const CostSample& s) {
     auto params = choc::value::createObject("");
     params.addMember("frame",
                      choc::value::createInt64(static_cast<int64_t>(s.frame)));
-    params.addMember("t", choc::value::createFloat64(s.t_seconds));
+    params.addMember("t", wire_number(s.t_seconds));
     params.addMember("render_pass_duration_ms",
-                     choc::value::createFloat64(s.render_pass_duration_ms));
+                     wire_number(s.render_pass_duration_ms));
     params.addMember("dirty_rect_area_px",
-                     choc::value::createFloat64(s.dirty_rect_area_px));
+                     wire_number(s.dirty_rect_area_px));
     params.addMember("dirty_rect_count",
                      choc::value::createInt64(s.dirty_rect_count));
 

--- a/inspect/src/motion_scrubber.cpp
+++ b/inspect/src/motion_scrubber.cpp
@@ -1,0 +1,317 @@
+// motion_scrubber.cpp — see motion_scrubber.hpp
+//
+// Wire shape for re-emitted events deliberately matches
+// MotionInspector::broadcast_event so existing clients can consume
+// scrubber output without a separate decoder.
+
+#include <pulp/inspect/motion_scrubber.hpp>
+
+#include <pulp/inspect/inspector_server.hpp>
+#include <pulp/view/motion.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+#include <algorithm>
+#include <string>
+
+namespace pulp::inspect {
+
+namespace {
+
+using pulp::view::motion::SampleEvent;
+using pulp::view::motion::Sink;
+
+const char* sample_kind_to_string(SampleEvent::Kind k) {
+    switch (k) {
+        case SampleEvent::Kind::TraceStarted: return "trace-started";
+        case SampleEvent::Kind::Baseline:     return "baseline";
+        case SampleEvent::Kind::Sample:       return "sample";
+        case SampleEvent::Kind::Start:        return "start";
+        case SampleEvent::Kind::End:          return "end";
+    }
+    return "?";
+}
+
+const char* event_method_for_kind(SampleEvent::Kind k) {
+    switch (k) {
+        case SampleEvent::Kind::TraceStarted: return methods::kMotionStart;
+        case SampleEvent::Kind::Baseline:     return methods::kMotionSample;
+        case SampleEvent::Kind::Sample:       return methods::kMotionSample;
+        case SampleEvent::Kind::Start:        return methods::kMotionStart;
+        case SampleEvent::Kind::End:          return methods::kMotionEnd;
+    }
+    return methods::kMotionSample;
+}
+
+choc::value::Value components_to_object(
+    const std::vector<std::pair<std::string, double>>& comps
+) {
+    auto obj = choc::value::createObject("");
+    for (const auto& [k, v] : comps) {
+        obj.addMember(k, choc::value::createFloat64(v));
+    }
+    return obj;
+}
+
+choc::value::Value event_to_params(const SampleEvent& e) {
+    auto params = choc::value::createObject("");
+    params.addMember("view_name", choc::value::createString(e.view_name));
+    params.addMember("metric_name", choc::value::createString(e.metric_name));
+    params.addMember("kind", choc::value::createString(sample_kind_to_string(e.kind)));
+    params.addMember("t", choc::value::createFloat64(e.t_seconds));
+    params.addMember("frame", choc::value::createInt64(static_cast<int64_t>(e.frame)));
+    params.addMember("trace_id", choc::value::createInt64(e.trace_id));
+    params.addMember("metric_id", choc::value::createInt64(e.metric_id));
+    params.addMember("burst_id", choc::value::createInt64(e.burst_id));
+    if (!e.components.empty()) {
+        params.addMember("components", components_to_object(e.components));
+    }
+    if (!e.deltas.empty()) {
+        params.addMember("deltas", components_to_object(e.deltas));
+    }
+    if (e.provenance.is_set()) {
+        auto prov = choc::value::createObject("");
+        prov.addMember("source_kind", choc::value::createString(e.provenance.source_kind));
+        prov.addMember("source_id",   choc::value::createString(e.provenance.source_id));
+        prov.addMember("source_file", choc::value::createString(e.provenance.source_file));
+        prov.addMember("source_line", choc::value::createInt64(e.provenance.source_line));
+        params.addMember("provenance", prov);
+    }
+    // Scrubber-only marker so receivers can distinguish replayed events
+    // from live coordinator events on the same wire.
+    params.addMember("replay", choc::value::createBool(true));
+    return params;
+}
+
+}  // namespace
+
+// ── ctor / dtor ──────────────────────────────────────────────────────
+
+MotionScrubber::MotionScrubber(InspectorServer* server) : server_(server) {}
+
+MotionScrubber::~MotionScrubber() {
+    std::lock_guard<std::mutex> lock(mtx_);
+    sinks_.clear();
+    events_.clear();
+}
+
+// ── method routing ──────────────────────────────────────────────────
+
+bool MotionScrubber::owns_method(const std::string& method) {
+    return method == methods::kMotionLoadFixture
+        || method == methods::kMotionScrubTo
+        || method == methods::kMotionPlay
+        || method == methods::kMotionPause;
+}
+
+InspectorMessage MotionScrubber::handle(const InspectorMessage& req) {
+    if (req.method == methods::kMotionLoadFixture) return handle_load_fixture(req);
+    if (req.method == methods::kMotionScrubTo)     return handle_scrub_to(req);
+    if (req.method == methods::kMotionPlay)        return handle_play(req);
+    if (req.method == methods::kMotionPause)       return handle_pause(req);
+    return make_error(req.id, "Unknown Motion scrubber method: " + req.method);
+}
+
+// ── direct API ──────────────────────────────────────────────────────
+
+bool MotionScrubber::load_fixture(const std::string& path) {
+    auto events = view::motion::load_fixture(path);
+    auto header = view::motion::load_fixture_header(path);
+    if (header.version != view::motion::kFixtureSchemaVersion) {
+        std::lock_guard<std::mutex> lock(mtx_);
+        events_.clear();
+        header_ = {};
+        playhead_frame_ = 0;
+        max_frame_ = 0;
+        loaded_ = false;
+        playing_ = false;
+        return false;
+    }
+
+    std::uint64_t max_frame = 0;
+    for (const auto& e : events) {
+        if (e.frame > max_frame) max_frame = e.frame;
+    }
+
+    std::lock_guard<std::mutex> lock(mtx_);
+    events_ = std::move(events);
+    header_ = header;
+    playhead_frame_ = 0;
+    max_frame_ = max_frame;
+    loaded_ = true;
+    playing_ = false;
+    return true;
+}
+
+std::size_t MotionScrubber::scrub_to(std::uint64_t frame) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (!loaded_) return 0;
+    playhead_frame_ = frame;
+    return emit_prefix_locked(frame);
+}
+
+std::size_t MotionScrubber::play() {
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (!loaded_) return 0;
+    playing_ = true;
+    playhead_frame_ = max_frame_;
+    return emit_prefix_locked(max_frame_);
+}
+
+void MotionScrubber::pause() {
+    std::lock_guard<std::mutex> lock(mtx_);
+    playing_ = false;
+}
+
+int MotionScrubber::add_sink(view::motion::Sink sink) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    const int id = next_sink_id_++;
+    sinks_.push_back({id, std::move(sink)});
+    return id;
+}
+
+void MotionScrubber::remove_sink(int id) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    sinks_.erase(
+        std::remove_if(sinks_.begin(), sinks_.end(),
+                       [id](const SinkSlot& s) { return s.id == id; }),
+        sinks_.end());
+}
+
+// ── accessors ───────────────────────────────────────────────────────
+
+bool MotionScrubber::loaded() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return loaded_;
+}
+bool MotionScrubber::playing() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return playing_;
+}
+std::uint64_t MotionScrubber::playhead_frame() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return playhead_frame_;
+}
+std::size_t MotionScrubber::event_count() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return events_.size();
+}
+std::uint64_t MotionScrubber::max_frame() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return max_frame_;
+}
+view::motion::FixtureHeader MotionScrubber::header() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return header_;
+}
+
+// ── emission ────────────────────────────────────────────────────────
+
+std::size_t MotionScrubber::emit_prefix_locked(std::uint64_t up_to_frame) {
+    std::size_t emitted = 0;
+    for (const auto& e : events_) {
+        if (e.frame > up_to_frame) continue;
+        dispatch_event(e);
+        ++emitted;
+    }
+    return emitted;
+}
+
+void MotionScrubber::dispatch_event(const view::motion::SampleEvent& e) {
+    // Local sinks first — order doesn't matter, both are observers.
+    for (const auto& slot : sinks_) {
+        if (slot.sink) slot.sink(e);
+    }
+    if (server_) {
+        auto params = event_to_params(e);
+        InspectorMessage ev = make_event(event_method_for_kind(e.kind),
+                                         choc::json::toString(params, false));
+        server_->broadcast(ev);
+    }
+}
+
+// ── protocol handlers ───────────────────────────────────────────────
+
+InspectorMessage MotionScrubber::handle_load_fixture(const InspectorMessage& req) {
+    choc::value::Value params;
+    try {
+        params = choc::json::parse(req.params_json);
+    } catch (...) {
+        return make_error(req.id, "Motion.loadFixture: invalid params JSON");
+    }
+    if (!params.isObject() || !params.hasObjectMember("path")) {
+        return make_error(req.id, "Motion.loadFixture: 'path' required");
+    }
+    std::string path(params["path"].getString());
+    const bool ok = load_fixture(path);
+    if (!ok) {
+        return make_error(req.id, "Motion.loadFixture: failed to load fixture: " + path);
+    }
+
+    auto out = choc::value::createObject("");
+    out.addMember("ok", choc::value::createBool(true));
+    out.addMember("event_count",
+                  choc::value::createInt64(static_cast<int64_t>(event_count())));
+    out.addMember("max_frame",
+                  choc::value::createInt64(static_cast<int64_t>(max_frame())));
+    auto hdr = header();
+    auto hdr_obj = choc::value::createObject("");
+    hdr_obj.addMember("version", choc::value::createInt64(hdr.version));
+    hdr_obj.addMember("policy", choc::value::createString(hdr.policy));
+    hdr_obj.addMember("duration_scale", choc::value::createFloat64(hdr.duration_scale));
+    out.addMember("header", hdr_obj);
+    return make_response(req.id, choc::json::toString(out, false));
+}
+
+InspectorMessage MotionScrubber::handle_scrub_to(const InspectorMessage& req) {
+    choc::value::Value params;
+    try {
+        params = choc::json::parse(req.params_json);
+    } catch (...) {
+        return make_error(req.id, "Motion.scrubTo: invalid params JSON");
+    }
+    if (!params.isObject() || !params.hasObjectMember("frame")) {
+        return make_error(req.id, "Motion.scrubTo: 'frame' required");
+    }
+    const int64_t raw = params["frame"].getInt64();
+    if (raw < 0) {
+        return make_error(req.id, "Motion.scrubTo: 'frame' must be >= 0");
+    }
+    if (!loaded()) {
+        return make_error(req.id, "Motion.scrubTo: no fixture loaded");
+    }
+    const auto frame = static_cast<std::uint64_t>(raw);
+    const std::size_t emitted = scrub_to(frame);
+
+    auto out = choc::value::createObject("");
+    out.addMember("playhead_frame",
+                  choc::value::createInt64(static_cast<int64_t>(playhead_frame())));
+    out.addMember("emitted_count",
+                  choc::value::createInt64(static_cast<int64_t>(emitted)));
+    return make_response(req.id, choc::json::toString(out, false));
+}
+
+InspectorMessage MotionScrubber::handle_play(const InspectorMessage& req) {
+    if (!loaded()) {
+        return make_error(req.id, "Motion.play: no fixture loaded");
+    }
+    const std::size_t emitted = play();
+    auto out = choc::value::createObject("");
+    out.addMember("playing", choc::value::createBool(true));
+    out.addMember("emitted_count",
+                  choc::value::createInt64(static_cast<int64_t>(emitted)));
+    out.addMember("playhead_frame",
+                  choc::value::createInt64(static_cast<int64_t>(playhead_frame())));
+    return make_response(req.id, choc::json::toString(out, false));
+}
+
+InspectorMessage MotionScrubber::handle_pause(const InspectorMessage& req) {
+    pause();
+    auto out = choc::value::createObject("");
+    out.addMember("playing", choc::value::createBool(false));
+    out.addMember("playhead_frame",
+                  choc::value::createInt64(static_cast<int64_t>(playhead_frame())));
+    return make_response(req.id, choc::json::toString(out, false));
+}
+
+}  // namespace pulp::inspect

--- a/inspect/src/motion_scrubber.cpp
+++ b/inspect/src/motion_scrubber.cpp
@@ -12,7 +12,9 @@
 #include <choc/text/choc_JSON.h>
 
 #include <algorithm>
+#include <cmath>
 #include <string>
+#include <vector>
 
 namespace pulp::inspect {
 
@@ -28,6 +30,7 @@ const char* sample_kind_to_string(SampleEvent::Kind k) {
         case SampleEvent::Kind::Sample:       return "sample";
         case SampleEvent::Kind::Start:        return "start";
         case SampleEvent::Kind::End:          return "end";
+        case SampleEvent::Kind::Input:        return "input";
     }
     return "?";
 }
@@ -39,8 +42,16 @@ const char* event_method_for_kind(SampleEvent::Kind k) {
         case SampleEvent::Kind::Sample:       return methods::kMotionSample;
         case SampleEvent::Kind::Start:        return methods::kMotionStart;
         case SampleEvent::Kind::End:          return methods::kMotionEnd;
+        case SampleEvent::Kind::Input:        return methods::kMotionSample;
     }
     return methods::kMotionSample;
+}
+
+choc::value::Value wire_number(double v) {
+    if (std::isnan(v))          return choc::value::createString("NaN");
+    if (std::isinf(v) && v > 0) return choc::value::createString("Infinity");
+    if (std::isinf(v) && v < 0) return choc::value::createString("-Infinity");
+    return choc::value::createFloat64(v);
 }
 
 choc::value::Value components_to_object(
@@ -48,7 +59,7 @@ choc::value::Value components_to_object(
 ) {
     auto obj = choc::value::createObject("");
     for (const auto& [k, v] : comps) {
-        obj.addMember(k, choc::value::createFloat64(v));
+        obj.addMember(k, wire_number(v));
     }
     return obj;
 }
@@ -58,11 +69,15 @@ choc::value::Value event_to_params(const SampleEvent& e) {
     params.addMember("view_name", choc::value::createString(e.view_name));
     params.addMember("metric_name", choc::value::createString(e.metric_name));
     params.addMember("kind", choc::value::createString(sample_kind_to_string(e.kind)));
-    params.addMember("t", choc::value::createFloat64(e.t_seconds));
+    params.addMember("t", wire_number(e.t_seconds));
     params.addMember("frame", choc::value::createInt64(static_cast<int64_t>(e.frame)));
     params.addMember("trace_id", choc::value::createInt64(e.trace_id));
     params.addMember("metric_id", choc::value::createInt64(e.metric_id));
     params.addMember("burst_id", choc::value::createInt64(e.burst_id));
+    if (e.kind == SampleEvent::Kind::Input) {
+        params.addMember("input_kind", choc::value::createString(e.input_kind));
+        params.addMember("view_id",    choc::value::createString(e.view_id));
+    }
     if (!e.components.empty()) {
         params.addMember("components", components_to_object(e.components));
     }
@@ -144,18 +159,39 @@ bool MotionScrubber::load_fixture(const std::string& path) {
 }
 
 std::size_t MotionScrubber::scrub_to(std::uint64_t frame) {
-    std::lock_guard<std::mutex> lock(mtx_);
-    if (!loaded_) return 0;
-    playhead_frame_ = frame;
-    return emit_prefix_locked(frame);
+    std::vector<view::motion::SampleEvent> snapshot;
+    std::vector<SinkSlot> sinks_snapshot;
+    InspectorServer* server_snapshot = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        if (!loaded_) return 0;
+        playhead_frame_ = frame;
+        snapshot.reserve(events_.size());
+        for (const auto& e : events_) {
+            if (e.frame <= frame) snapshot.push_back(e);
+        }
+        sinks_snapshot = sinks_;
+        server_snapshot = server_;
+    }
+    dispatch_snapshot(snapshot, sinks_snapshot, server_snapshot);
+    return snapshot.size();
 }
 
 std::size_t MotionScrubber::play() {
-    std::lock_guard<std::mutex> lock(mtx_);
-    if (!loaded_) return 0;
-    playing_ = true;
-    playhead_frame_ = max_frame_;
-    return emit_prefix_locked(max_frame_);
+    std::vector<view::motion::SampleEvent> snapshot;
+    std::vector<SinkSlot> sinks_snapshot;
+    InspectorServer* server_snapshot = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        if (!loaded_) return 0;
+        playing_ = true;
+        playhead_frame_ = max_frame_;
+        snapshot = events_;
+        sinks_snapshot = sinks_;
+        server_snapshot = server_;
+    }
+    dispatch_snapshot(snapshot, sinks_snapshot, server_snapshot);
+    return snapshot.size();
 }
 
 void MotionScrubber::pause() {
@@ -207,26 +243,25 @@ view::motion::FixtureHeader MotionScrubber::header() const {
 
 // ── emission ────────────────────────────────────────────────────────
 
-std::size_t MotionScrubber::emit_prefix_locked(std::uint64_t up_to_frame) {
-    std::size_t emitted = 0;
-    for (const auto& e : events_) {
-        if (e.frame > up_to_frame) continue;
-        dispatch_event(e);
-        ++emitted;
-    }
-    return emitted;
-}
-
-void MotionScrubber::dispatch_event(const view::motion::SampleEvent& e) {
-    // Local sinks first — order doesn't matter, both are observers.
-    for (const auto& slot : sinks_) {
-        if (slot.sink) slot.sink(e);
-    }
-    if (server_) {
-        auto params = event_to_params(e);
-        InspectorMessage ev = make_event(event_method_for_kind(e.kind),
-                                         choc::json::toString(params, false));
-        server_->broadcast(ev);
+// Dispatch a snapshot of events to the given sinks + server WITHOUT
+// holding mtx_. A sink that re-enters add_sink/remove_sink/scrub_to
+// (or any other MotionScrubber method) used to self-deadlock under
+// the old emit_prefix_locked design.
+void MotionScrubber::dispatch_snapshot(
+    const std::vector<view::motion::SampleEvent>& events,
+    const std::vector<SinkSlot>& sinks,
+    InspectorServer* server
+) {
+    for (const auto& e : events) {
+        for (const auto& slot : sinks) {
+            if (slot.sink) slot.sink(e);
+        }
+        if (server) {
+            auto params = event_to_params(e);
+            InspectorMessage ev = make_event(event_method_for_kind(e.kind),
+                                             choc::json::toString(params, false));
+            server->broadcast(ev);
+        }
     }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1484,6 +1484,13 @@ if(TARGET pulp::inspect)
     target_link_libraries(pulp-test-motion-inspector PRIVATE
         pulp::view pulp::inspect Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-motion-inspector)
+
+    # Motion scrubber — Phase 7 timeline scrubber that consumes
+    # .motion.jsonl fixtures and re-emits events up to a frame playhead.
+    add_executable(pulp-test-motion-scrubber test_motion_scrubber.cpp)
+    target_link_libraries(pulp-test-motion-scrubber PRIVATE
+        pulp::view pulp::inspect Catch2::Catch2WithMain)
+    catch_discover_tests(pulp-test-motion-scrubber)
 endif()
 
 # Motion end-to-end animation smoke — mirrors what a plugin author

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1472,6 +1472,12 @@ add_executable(pulp-test-motion test_motion.cpp)
 target_link_libraries(pulp-test-motion PRIVATE pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-motion)
 
+# MotionPreferences — Phase 8 reduced-motion policy + animation honoring
+add_executable(pulp-test-motion-preferences test_motion_preferences.cpp)
+target_link_libraries(pulp-test-motion-preferences PRIVATE
+    pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-motion-preferences)
+
 # Motion inspector — Phase 1 Motion.* protocol-domain tests
 if(TARGET pulp::inspect)
     add_executable(pulp-test-motion-inspector test_motion_inspector.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1494,6 +1494,15 @@ target_link_libraries(pulp-test-motion-animation-smoke PRIVATE
     pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-motion-animation-smoke)
 
+# Motion provenance adapters — Phase 9 surface coverage. One test per
+# animation surface (Tween + PULP_MOTION_TWEEN, AnimatorSetBuilder::name,
+# CSS TransitionSpec, ambient slot for rAF + design-import). Verifies the
+# Provenance envelope round-trips end to end through the publish channel.
+add_executable(pulp-test-motion-provenance test_motion_provenance.cpp)
+target_link_libraries(pulp-test-motion-provenance PRIVATE
+    pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-motion-provenance)
+
 # Motion visual-analysis self-check — Phase 4 pipeline smoke.
 # Skips cleanly (exit 3) when Python deps are absent so CI without
 # numpy/Pillow/scikit-image doesn't false-fail.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1503,6 +1503,15 @@ target_link_libraries(pulp-test-motion-provenance PRIVATE
     pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-motion-provenance)
 
+# Motion input record + replay end-to-end (Phase 10) — records a
+# hover -> click -> drag against a synthetic view tree, replays the
+# same fixture against a fresh tree, asserts identical motion fixture
+# emerges (modulo timing tolerance).
+add_executable(pulp-test-motion-input-replay test_motion_input_replay.cpp)
+target_link_libraries(pulp-test-motion-input-replay PRIVATE
+    pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-motion-input-replay)
+
 # Motion visual-analysis self-check — Phase 4 pipeline smoke.
 # Skips cleanly (exit 3) when Python deps are absent so CI without
 # numpy/Pillow/scikit-image doesn't false-fail.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1519,6 +1519,16 @@ target_link_libraries(pulp-test-motion-input-replay PRIVATE
     pulp::view Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-motion-input-replay)
 
+# Motion cost attribution — correlates per-frame render cost +
+# dirty-rect area with the trace_ids that emitted on the same frame
+# (carrying their Phase 9 provenance envelopes). The bridge probe
+# test pulls real RenderPassManager + DirtyTracker stats, so this
+# test target depends on pulp::render alongside pulp::view.
+add_executable(pulp-test-motion-cost test_motion_cost.cpp)
+target_link_libraries(pulp-test-motion-cost PRIVATE
+    pulp::view pulp::render Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-motion-cost)
+
 # Motion visual-analysis self-check — Phase 4 pipeline smoke.
 # Skips cleanly (exit 3) when Python deps are absent so CI without
 # numpy/Pillow/scikit-image doesn't false-fail.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1524,10 +1524,18 @@ catch_discover_tests(pulp-test-motion-input-replay)
 # (carrying their Phase 9 provenance envelopes). The bridge probe
 # test pulls real RenderPassManager + DirtyTracker stats, so this
 # test target depends on pulp::render alongside pulp::view.
-add_executable(pulp-test-motion-cost test_motion_cost.cpp)
-target_link_libraries(pulp-test-motion-cost PRIVATE
-    pulp::view pulp::render Catch2::Catch2WithMain)
-catch_discover_tests(pulp-test-motion-cost)
+#
+# Sanitizer builds (ASan/UBSan/TSan) disable PULP_ENABLE_GPU and so
+# pulp::render is never created — skip the cost test in that case
+# instead of failing the CMake generate step. The cost code itself
+# is exercised by the GPU-on lanes (macOS local smoke + linux/windows
+# release-path), so coverage isn't lost.
+if(TARGET pulp::render)
+    add_executable(pulp-test-motion-cost test_motion_cost.cpp)
+    target_link_libraries(pulp-test-motion-cost PRIVATE
+        pulp::view pulp::render Catch2::Catch2WithMain)
+    catch_discover_tests(pulp-test-motion-cost)
+endif()
 
 # Motion visual-analysis self-check — Phase 4 pipeline smoke.
 # Skips cleanly (exit 3) when Python deps are absent so CI without

--- a/test/test_design_import.cpp
+++ b/test/test_design_import.cpp
@@ -476,6 +476,59 @@ TEST_CASE("parse_figma_json covers layout style and audio shape metadata edges",
 
 // ── Code generation ─────────────────────────────────────────────────────
 
+TEST_CASE("generate_pulp_js emits motion.setProvenance per vendor + root (Phase 9e)",
+          "[view][import][motion][provenance][issue-pulp-motion-phase9]") {
+    // Figma export with a recognizable root node name should emit
+    // `motion.setProvenance('design-import', 'figma:<root-name>')` so
+    // any animations the bundle drives self-attribute through the
+    // motion observability publish channel.
+    {
+        DesignIR ir;
+        ir.source = DesignSource::figma;
+        ir.root.type = "frame";
+        ir.root.name = "Card/Hover";
+        CodeGenOptions opts;
+        opts.mode = CodeGenMode::web_compat;
+        opts.include_comments = false;
+        auto js = generate_pulp_js(ir, opts);
+        REQUIRE(js.find("motion.setProvenance('design-import', 'figma:Card/Hover')")
+                != std::string::npos);
+    }
+    // Stitch, v0, Pencil, Claude — same shape, different vendor key.
+    struct Case { DesignSource src; const char* vendor; };
+    for (const Case& c : {
+             Case{DesignSource::stitch, "stitch"},
+             Case{DesignSource::v0,     "v0"},
+             Case{DesignSource::pencil, "pencil"},
+             Case{DesignSource::claude, "claude"},
+         }) {
+        DesignIR ir;
+        ir.source = c.src;
+        ir.root.type = "frame";
+        ir.root.name = "Panel";
+        CodeGenOptions opts;
+        opts.include_comments = false;
+        auto js = generate_pulp_js(ir, opts);
+        std::string expected =
+            std::string("motion.setProvenance('design-import', '") +
+            c.vendor + ":Panel')";
+        REQUIRE(js.find(expected) != std::string::npos);
+    }
+    // When the root has no name but there's a source_file, the file's
+    // basename (without extension) is the id.
+    {
+        DesignIR ir;
+        ir.source = DesignSource::figma;
+        ir.root.type = "frame";
+        ir.source_file = "/path/to/HeaderLayout.json";
+        CodeGenOptions opts;
+        opts.include_comments = false;
+        auto js = generate_pulp_js(ir, opts);
+        REQUIRE(js.find("motion.setProvenance('design-import', 'figma:HeaderLayout')")
+                != std::string::npos);
+    }
+}
+
 TEST_CASE("generate_pulp_js produces valid web-compat JS", "[view][import]") {
     DesignIR ir;
     ir.source = DesignSource::figma;

--- a/test/test_motion_animation_smoke.cpp
+++ b/test/test_motion_animation_smoke.cpp
@@ -92,9 +92,11 @@ TEST_CASE("End-to-end: real Tween → publish_value → fixture → assertion he
 
     for (int i = 0; i < total_ticks; ++i) {
         const float v = tween.advance(dt);
+        PublishOptions po{};
+        po.precision = 3;
+        po.epsilon = 0.001;
         publish_value("Gain Knob", "opacity",
-                      static_cast<double>(v),
-                      /*opts=*/{ /*precision=*/3, /*epsilon=*/0.001 });
+                      static_cast<double>(v), po);
         clock.tick(dt);
     }
 

--- a/test/test_motion_cost.cpp
+++ b/test/test_motion_cost.cpp
@@ -22,8 +22,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
+#include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unistd.h>
@@ -374,4 +377,92 @@ TEST_CASE("serialize_cost_sample emits valid JSON shape", "[motion-cost]") {
     REQUIRE(line.find("\"frame\":42") != std::string::npos);
     REQUIRE(line.find("\"active_trace_ids\":[7,11]") != std::string::npos);
     REQUIRE(line.find("\"source_kind\":\"css-transition\"") != std::string::npos);
+}
+
+// ── Bug-sweep regressions (pre-merge sweep #2142) ────────────────────
+
+// serialize_cost_sample used to emit raw doubles, so a single bad
+// render-stat tick (NaN / Inf) produced invalid JSON tokens (`nan` /
+// `inf`) that broke every downstream consumer. Match motion.cpp's
+// quoted-sentinel convention and round-trip them back.
+TEST_CASE("serialize_cost_sample emits NaN/Inf as quoted sentinels",
+          "[motion-cost][bug-sweep]") {
+    CostSample s;
+    s.frame = 7;
+    s.t_seconds = std::nan("");
+    s.render_pass_duration_ms = std::numeric_limits<double>::infinity();
+    s.dirty_rect_area_px = -std::numeric_limits<double>::infinity();
+    s.dirty_rect_count = 0;
+
+    auto line = serialize_cost_sample(s);
+    REQUIRE(line.find("\"t\":\"NaN\"") != std::string::npos);
+    REQUIRE(line.find("\"render_pass_duration_ms\":\"Infinity\"") != std::string::npos);
+    REQUIRE(line.find("\"dirty_rect_area_px\":\"-Infinity\"") != std::string::npos);
+
+    // Round-trip through write + load. The loader recognizes the same
+    // three quoted sentinels and restores the IEEE-754 value.
+    char tmpl[] = "/tmp/pulp-motion-cost-nan-XXXXXX";
+    int fd = ::mkstemp(tmpl);
+    REQUIRE(fd >= 0);
+    ::close(fd);
+    std::string path = tmpl;
+    {
+        std::ofstream out(path);
+        out << "{\"motion_cost_version\":1}\n" << line << "\n";
+    }
+    auto loaded = load_cost_stream(path);
+    REQUIRE(loaded.size() == 1);
+    REQUIRE(std::isnan(loaded[0].t_seconds));
+    REQUIRE(std::isinf(loaded[0].render_pass_duration_ms));
+    REQUIRE(loaded[0].render_pass_duration_ms > 0);
+    REQUIRE(std::isinf(loaded[0].dirty_rect_area_px));
+    REQUIRE(loaded[0].dirty_rect_area_px < 0);
+    std::remove(path.c_str());
+}
+
+// load_cost_stream's active_provenance loop used line.find('}', pos)
+// to locate each object's end. A literal `}` inside a source_file
+// path (legal JSON — only `"` and `\\` are escaped) truncated the
+// entry mid-string and corrupted every following provenance object.
+// The fix is brace-depth + string-aware scanning.
+TEST_CASE("load_cost_stream parses provenance objects whose strings contain '}'",
+          "[motion-cost][bug-sweep]") {
+    CostSample s;
+    s.frame = 11;
+    s.t_seconds = 0.5;
+    s.dirty_rect_count = 1;
+    s.active_trace_ids = {3, 4};
+    Provenance p1;
+    p1.source_kind = "tween";
+    p1.source_id = "card.opacity";
+    // The literal `}` here used to truncate the parser mid-string.
+    p1.source_file = "weird/path}with-brace.cpp";
+    p1.source_line = 42;
+    Provenance p2;
+    p2.source_kind = "css-transition";
+    p2.source_id = "panel.bg";
+    p2.source_file = "ok.cpp";
+    p2.source_line = 7;
+    s.active_provenance = {p1, p2};
+
+    char tmpl[] = "/tmp/pulp-motion-cost-brace-XXXXXX";
+    int fd = ::mkstemp(tmpl);
+    REQUIRE(fd >= 0);
+    ::close(fd);
+    std::string path = tmpl;
+    {
+        std::ofstream out(path);
+        out << "{\"motion_cost_version\":1}\n"
+            << serialize_cost_sample(s) << "\n";
+    }
+    auto loaded = load_cost_stream(path);
+    REQUIRE(loaded.size() == 1);
+    REQUIRE(loaded[0].active_provenance.size() == 2);
+    REQUIRE(loaded[0].active_provenance[0].source_kind == "tween");
+    REQUIRE(loaded[0].active_provenance[0].source_file == "weird/path}with-brace.cpp");
+    REQUIRE(loaded[0].active_provenance[0].source_line == 42);
+    REQUIRE(loaded[0].active_provenance[1].source_kind == "css-transition");
+    REQUIRE(loaded[0].active_provenance[1].source_file == "ok.cpp");
+    REQUIRE(loaded[0].active_provenance[1].source_line == 7);
+    std::remove(path.c_str());
 }

--- a/test/test_motion_cost.cpp
+++ b/test/test_motion_cost.cpp
@@ -1,0 +1,377 @@
+/// @file test_motion_cost.cpp
+/// Catch2 tests for motion cost attribution (CostSample +
+/// CostAttributor). Covers:
+///   - Off by default — no samples until set_enabled(true).
+///   - Each tick produces one CostSample when enabled.
+///   - active_trace_ids reflects which traces emitted on the tick.
+///   - active_provenance carries the Phase 9 envelope per trace.
+///   - Render-cost fields populate from a CostProbe.
+///   - Graceful degradation when no probe is wired.
+///   - JSONL serialization round-trips a stream.
+///   - Bridge to RenderPassManager + DirtyTracker via
+///     `make_render_cost_probe`.
+
+#include <pulp/render/dirty_tracker.hpp>
+#include <pulp/render/render_pass.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/motion.hpp>
+#include <pulp/view/motion_cost.hpp>
+#include <pulp/view/motion_cost_render.hpp>
+#include <pulp/view/view.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+using Catch::Approx;
+using pulp::view::FrameClock;
+using pulp::view::View;
+using namespace pulp::view::motion;
+
+namespace {
+
+/// Reset both singletons. Each test owns its FrameClock + a buffer
+/// that the attributor pushes into.
+class CostFixture {
+public:
+    CostFixture() {
+        Coordinator::instance().reset();
+        CostAttributor::instance().reset();
+        Coordinator::instance().bind(clock);
+    }
+    ~CostFixture() {
+        Coordinator::instance().reset();
+        CostAttributor::instance().reset();
+    }
+
+    FrameClock clock;
+    std::vector<CostSample> samples;
+};
+
+/// A trivial sampler that drives one published metric so the trace
+/// has a non-empty sample on every tick.
+struct CountingSampler {
+    double value = 0.0;
+    double operator()() { value += 1.0; return value; }
+};
+
+std::string unique_path(const char* tag) {
+    std::string p = "/tmp/pulp-motion-cost-";
+    p += tag;
+    p += "-";
+    p += std::to_string(::getpid());
+    p += ".jsonl";
+    return p;
+}
+
+}  // namespace
+
+// ── Off by default ───────────────────────────────────────────────────
+
+TEST_CASE("CostAttributor emits nothing while disabled", "[motion-cost]") {
+    CostFixture fx;
+    int sink = CostAttributor::instance().add_sink(
+        make_cost_buffer_sink(&fx.samples));
+    (void)sink;
+
+    // Tracing-enabled coordinator + dummy sink so on_tick has work.
+    int evsink = Coordinator::instance().add_sink([](const SampleEvent&) {});
+    (void)evsink;
+    Coordinator::instance().set_tracing_enabled(true);
+
+    CountingSampler s;
+    auto t = Coordinator::instance()
+                 .trace("V", {15})
+                 .value("metric", [&s]() { return s(); })
+                 .attach();
+    REQUIRE(t.is_attached());
+
+    fx.clock.tick(1.0f / 15.0f);
+    fx.clock.tick(1.0f / 15.0f);
+    REQUIRE(fx.samples.empty());
+    REQUIRE(CostAttributor::instance().emitted_sample_count() == 0);
+}
+
+// ── One CostSample per tick when enabled ─────────────────────────────
+
+TEST_CASE("CostAttributor emits one sample per tick when enabled",
+          "[motion-cost]") {
+    CostFixture fx;
+    CostAttributor::instance().add_sink(make_cost_buffer_sink(&fx.samples));
+    CostAttributor::instance().set_enabled(true);
+
+    // Coordinator needs at least one sink + tracing on for on_tick to
+    // process traces — but cost attribution should still fire even
+    // when those are absent. Verify both arms.
+    Coordinator::instance().set_tracing_enabled(true);
+    Coordinator::instance().add_sink([](const SampleEvent&) {});
+
+    fx.clock.tick(1.0f / 60.0f);
+    fx.clock.tick(1.0f / 60.0f);
+    fx.clock.tick(1.0f / 60.0f);
+
+    REQUIRE(fx.samples.size() == 3);
+    REQUIRE(CostAttributor::instance().emitted_sample_count() == 3);
+}
+
+// ── Cost emits even without coordinator event sinks ──────────────────
+
+TEST_CASE("CostAttributor still emits when coordinator has no sinks",
+          "[motion-cost]") {
+    CostFixture fx;
+    CostAttributor::instance().add_sink(make_cost_buffer_sink(&fx.samples));
+    CostAttributor::instance().set_enabled(true);
+
+    // Coordinator tracing OFF and no sinks installed.
+    fx.clock.tick(1.0f / 60.0f);
+    fx.clock.tick(1.0f / 60.0f);
+
+    REQUIRE(fx.samples.size() == 2);
+    for (const auto& s : fx.samples) {
+        REQUIRE(s.active_trace_ids.empty());
+        REQUIRE(s.active_provenance.empty());
+    }
+}
+
+// ── active_trace_ids reflects emitting traces ────────────────────────
+
+TEST_CASE("CostSample.active_trace_ids includes traces that emitted this tick",
+          "[motion-cost]") {
+    CostFixture fx;
+    CostAttributor::instance().add_sink(make_cost_buffer_sink(&fx.samples));
+    CostAttributor::instance().set_enabled(true);
+
+    Coordinator::instance().set_tracing_enabled(true);
+    int evsink = Coordinator::instance().add_sink([](const SampleEvent&) {});
+    (void)evsink;
+
+    CountingSampler a, b;
+    auto th_a = Coordinator::instance()
+                    .trace("A", {60})
+                    .value("v", [&a]() { return a(); })
+                    .attach();
+    auto th_b = Coordinator::instance()
+                    .trace("B", {60})
+                    .value("v", [&b]() { return b(); })
+                    .attach();
+    REQUIRE(th_a.is_attached());
+    REQUIRE(th_b.is_attached());
+
+    fx.clock.tick(1.0f / 60.0f);  // baseline emission for both
+
+    REQUIRE(fx.samples.size() == 1);
+    auto& s = fx.samples.back();
+    // Both traces should appear and be sorted ascending.
+    REQUIRE(s.active_trace_ids.size() == 2);
+    REQUIRE(s.active_trace_ids[0] < s.active_trace_ids[1]);
+}
+
+// ── Provenance round-trips through CostSample ────────────────────────
+
+TEST_CASE("CostSample carries Provenance for each active trace",
+          "[motion-cost]") {
+    CostFixture fx;
+    CostAttributor::instance().add_sink(make_cost_buffer_sink(&fx.samples));
+    CostAttributor::instance().set_enabled(true);
+
+    Coordinator::instance().set_tracing_enabled(true);
+    Coordinator::instance().add_sink([](const SampleEvent&) {});
+
+    CountingSampler s;
+    Provenance prov;
+    prov.source_kind = "design-import";
+    prov.source_id = "figma:LevelMeter/Panel";
+    prov.source_file = __FILE__;
+    prov.source_line = __LINE__;
+
+    auto th = Coordinator::instance()
+                  .trace("Panel", {60})
+                  .value("opacity", [&s]() { return s(); })
+                  .with_provenance(prov)
+                  .attach();
+    REQUIRE(th.is_attached());
+
+    fx.clock.tick(1.0f / 60.0f);
+
+    REQUIRE(fx.samples.size() == 1);
+    auto& cs = fx.samples.back();
+    REQUIRE(cs.active_trace_ids.size() == 1);
+    REQUIRE(cs.active_provenance.size() == 1);
+    REQUIRE(cs.active_provenance[0].source_kind == "design-import");
+    REQUIRE(cs.active_provenance[0].source_id == "figma:LevelMeter/Panel");
+    REQUIRE(cs.active_provenance[0].source_line == prov.source_line);
+}
+
+// ── Probe populates render-cost fields ───────────────────────────────
+
+TEST_CASE("CostProbe populates render_pass_duration_ms and dirty fields",
+          "[motion-cost]") {
+    CostFixture fx;
+    CostAttributor::instance().add_sink(make_cost_buffer_sink(&fx.samples));
+    CostAttributor::instance().set_enabled(true);
+
+    // Mutable scalars the probe reads each tick.
+    double cur_ms = 0.0;
+    double cur_area = 0.0;
+    int cur_count = 0;
+    CostAttributor::instance().set_probe([&]() {
+        RenderCostSnapshot s;
+        s.render_pass_duration_ms = cur_ms;
+        s.dirty_rect_area_px = cur_area;
+        s.dirty_rect_count = cur_count;
+        return s;
+    });
+
+    cur_ms = 12.5; cur_area = 400.0; cur_count = 2;
+    fx.clock.tick(1.0f / 60.0f);
+    cur_ms = 0.5; cur_area = 16.0; cur_count = 1;
+    fx.clock.tick(1.0f / 60.0f);
+
+    REQUIRE(fx.samples.size() == 2);
+    REQUIRE(fx.samples[0].render_pass_duration_ms == Approx(12.5));
+    REQUIRE(fx.samples[0].dirty_rect_area_px == Approx(400.0));
+    REQUIRE(fx.samples[0].dirty_rect_count == 2);
+    REQUIRE(fx.samples[1].render_pass_duration_ms == Approx(0.5));
+    REQUIRE(fx.samples[1].dirty_rect_count == 1);
+}
+
+// ── Graceful degradation when no probe is wired ──────────────────────
+
+TEST_CASE("CostSample zeroes render fields when no probe is wired",
+          "[motion-cost]") {
+    CostFixture fx;
+    CostAttributor::instance().add_sink(make_cost_buffer_sink(&fx.samples));
+    CostAttributor::instance().set_enabled(true);
+    // No set_probe call.
+
+    fx.clock.tick(1.0f / 60.0f);
+
+    REQUIRE(fx.samples.size() == 1);
+    REQUIRE(fx.samples[0].render_pass_duration_ms == Approx(0.0));
+    REQUIRE(fx.samples[0].dirty_rect_area_px == Approx(0.0));
+    REQUIRE(fx.samples[0].dirty_rect_count == 0);
+}
+
+// ── Bridge probe pulls real RenderPassManager + DirtyTracker stats ──
+
+TEST_CASE("make_render_cost_probe surfaces RenderPassManager + DirtyTracker",
+          "[motion-cost]") {
+    CostFixture fx;
+    CostAttributor::instance().add_sink(make_cost_buffer_sink(&fx.samples));
+    CostAttributor::instance().set_enabled(true);
+
+    pulp::render::RenderPassManager passes;
+    pulp::render::DirtyTracker dirty;
+    CostAttributor::instance().set_probe(make_render_cost_probe(&passes, &dirty));
+
+    // Simulate a render frame: begin/end one pass, mark two dirty rects.
+    passes.begin_frame();
+    passes.begin_pass(pulp::render::RenderPassType::content);
+    passes.end_pass(/*time_ms=*/8.25f, /*draw_calls=*/4);
+    passes.end_frame();
+    dirty.invalidate({0, 0, 10, 20});  // area 200
+    dirty.invalidate({100, 100, 5, 5});  // area 25
+
+    fx.clock.tick(1.0f / 60.0f);
+
+    REQUIRE(fx.samples.size() == 1);
+    REQUIRE(fx.samples[0].render_pass_duration_ms == Approx(8.25));
+    REQUIRE(fx.samples[0].dirty_rect_area_px == Approx(225.0));
+    REQUIRE(fx.samples[0].dirty_rect_count == 2);
+
+    // Null pointers — defensive path returns zero.
+    CostAttributor::instance().set_probe(make_render_cost_probe(nullptr, nullptr));
+    fx.clock.tick(1.0f / 60.0f);
+    REQUIRE(fx.samples.size() == 2);
+    REQUIRE(fx.samples[1].render_pass_duration_ms == Approx(0.0));
+    REQUIRE(fx.samples[1].dirty_rect_count == 0);
+}
+
+// ── JSONL serialization round-trips ──────────────────────────────────
+
+TEST_CASE("CostSample JSONL serialization round-trips a stream", "[motion-cost]") {
+    CostFixture fx;
+    const std::string path = unique_path("rt");
+    std::remove(path.c_str());
+
+    {
+        CostAttributor::instance().add_sink(make_cost_sink(path));
+        CostAttributor::instance().set_enabled(true);
+
+        Coordinator::instance().set_tracing_enabled(true);
+        Coordinator::instance().add_sink([](const SampleEvent&) {});
+        CountingSampler s;
+        Provenance prov;
+        prov.source_kind = "tween";
+        prov.source_id = "Card.opacity";
+        prov.source_file = "card.cpp";
+        prov.source_line = 42;
+        auto th = Coordinator::instance()
+                      .trace("Card", {60})
+                      .value("opacity", [&s]() { return s(); })
+                      .with_provenance(prov)
+                      .attach();
+        (void)th;
+
+        fx.clock.tick(1.0f / 60.0f);
+        fx.clock.tick(1.0f / 60.0f);
+        fx.clock.tick(1.0f / 60.0f);
+
+        // Drop sinks so the file flushes / closes.
+        CostAttributor::instance().clear_sinks();
+    }
+
+    // File should exist and contain the version header + 3 body lines.
+    std::ifstream in(path);
+    REQUIRE(in.is_open());
+    std::string first;
+    REQUIRE(std::getline(in, first).good());
+    REQUIRE(first.find("\"motion_cost_version\":1") != std::string::npos);
+
+    auto loaded = load_cost_stream(path);
+    REQUIRE(loaded.size() == 3);
+
+    // Every loaded sample should have at least one active trace.
+    bool found_any_prov = false;
+    for (const auto& s : loaded) {
+        if (!s.active_trace_ids.empty()) {
+            REQUIRE(s.active_provenance.size() == s.active_trace_ids.size());
+            for (const auto& p : s.active_provenance) {
+                if (p.source_kind == "tween") found_any_prov = true;
+            }
+        }
+    }
+    REQUIRE(found_any_prov);
+
+    std::remove(path.c_str());
+}
+
+// ── serialize_cost_sample produces well-formed JSON ──────────────────
+
+TEST_CASE("serialize_cost_sample emits valid JSON shape", "[motion-cost]") {
+    CostSample s;
+    s.frame = 42;
+    s.t_seconds = 1.5;
+    s.render_pass_duration_ms = 9.5;
+    s.dirty_rect_area_px = 256.0;
+    s.dirty_rect_count = 3;
+    s.active_trace_ids = {7, 11};
+    Provenance p1;
+    p1.source_kind = "css-transition";
+    p1.source_id = "panel.bg";
+    Provenance p2;
+    s.active_provenance = {p1, p2};
+
+    auto line = serialize_cost_sample(s);
+    REQUIRE(line.front() == '{');
+    REQUIRE(line.back() == '}');
+    REQUIRE(line.find("\"frame\":42") != std::string::npos);
+    REQUIRE(line.find("\"active_trace_ids\":[7,11]") != std::string::npos);
+    REQUIRE(line.find("\"source_kind\":\"css-transition\"") != std::string::npos);
+}

--- a/test/test_motion_cost.cpp
+++ b/test/test_motion_cost.cpp
@@ -71,10 +71,20 @@ struct CountingSampler {
 };
 
 std::string unique_path(const char* tag) {
-    std::string p = "/tmp/pulp-motion-cost-";
+#if defined(_WIN32)
+    const char* tmpdir = std::getenv("TMP");
+    if (!tmpdir) tmpdir = std::getenv("TEMP");
+    if (!tmpdir) tmpdir = ".";
+#else
+    const char* tmpdir = "/tmp";
+#endif
+    std::string p = tmpdir;
+    p += "/pulp-motion-cost-";
     p += tag;
     p += "-";
     p += std::to_string(pulp_test_getpid());
+    p += "-";
+    p += std::to_string(std::rand());
     p += ".jsonl";
     return p;
 }
@@ -407,11 +417,7 @@ TEST_CASE("serialize_cost_sample emits NaN/Inf as quoted sentinels",
 
     // Round-trip through write + load. The loader recognizes the same
     // three quoted sentinels and restores the IEEE-754 value.
-    char tmpl[] = "/tmp/pulp-motion-cost-nan-XXXXXX";
-    int fd = ::mkstemp(tmpl);
-    REQUIRE(fd >= 0);
-    ::close(fd);
-    std::string path = tmpl;
+    std::string path = unique_path("nan");
     {
         std::ofstream out(path);
         out << "{\"motion_cost_version\":1}\n" << line << "\n";
@@ -451,11 +457,7 @@ TEST_CASE("load_cost_stream parses provenance objects whose strings contain '}'"
     p2.source_line = 7;
     s.active_provenance = {p1, p2};
 
-    char tmpl[] = "/tmp/pulp-motion-cost-brace-XXXXXX";
-    int fd = ::mkstemp(tmpl);
-    REQUIRE(fd >= 0);
-    ::close(fd);
-    std::string path = tmpl;
+    std::string path = unique_path("brace");
     {
         std::ofstream out(path);
         out << "{\"motion_cost_version\":1}\n"

--- a/test/test_motion_cost.cpp
+++ b/test/test_motion_cost.cpp
@@ -29,7 +29,13 @@
 #include <limits>
 #include <memory>
 #include <string>
+#if defined(_WIN32)
+#include <process.h>
+#define pulp_test_getpid() static_cast<long>(::_getpid())
+#else
 #include <unistd.h>
+#define pulp_test_getpid() static_cast<long>(::getpid())
+#endif
 #include <vector>
 
 using Catch::Approx;
@@ -68,7 +74,7 @@ std::string unique_path(const char* tag) {
     std::string p = "/tmp/pulp-motion-cost-";
     p += tag;
     p += "-";
-    p += std::to_string(::getpid());
+    p += std::to_string(pulp_test_getpid());
     p += ".jsonl";
     return p;
 }

--- a/test/test_motion_input_replay.cpp
+++ b/test/test_motion_input_replay.cpp
@@ -15,7 +15,13 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#if defined(_WIN32)
+#include <process.h>
+#define pulp_test_getpid() static_cast<int>(::_getpid())
+#else
 #include <unistd.h>
+#define pulp_test_getpid() static_cast<int>(::getpid())
+#endif
 #include <vector>
 
 using pulp::view::FrameClock;
@@ -28,8 +34,15 @@ namespace {
 
 std::string tmp_fixture_path(const std::string& tag) {
     char buf[256];
-    std::snprintf(buf, sizeof(buf), "/tmp/pulp-motion-input-replay-%s-%d-%d.jsonl",
-                  tag.c_str(), getpid(), std::rand());
+    const char* tmpdir =
+#if defined(_WIN32)
+        std::getenv("TMP") ? std::getenv("TMP") :
+        std::getenv("TEMP") ? std::getenv("TEMP") : ".";
+#else
+        "/tmp";
+#endif
+    std::snprintf(buf, sizeof(buf), "%s/pulp-motion-input-replay-%s-%d-%d.jsonl",
+                  tmpdir, tag.c_str(), pulp_test_getpid(), std::rand());
     return buf;
 }
 

--- a/test/test_motion_input_replay.cpp
+++ b/test/test_motion_input_replay.cpp
@@ -1,0 +1,371 @@
+/// @file test_motion_input_replay.cpp
+/// Catch2 tests for Phase 10 input recording + replay. Records a
+/// hover -> click -> drag sequence against a synthetic view tree, then
+/// replays the same fixture against a fresh tree and asserts the
+/// motion stream that emerges is identical.
+
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/motion.hpp>
+#include <pulp/view/motion_preferences.hpp>
+#include <pulp/view/view.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+using pulp::view::FrameClock;
+using pulp::view::Point;
+using pulp::view::Rect;
+using pulp::view::View;
+using namespace pulp::view::motion;
+
+namespace {
+
+std::string tmp_fixture_path(const std::string& tag) {
+    char buf[256];
+    std::snprintf(buf, sizeof(buf), "/tmp/pulp-motion-input-replay-%s-%d-%d.jsonl",
+                  tag.c_str(), getpid(), std::rand());
+    return buf;
+}
+
+/// Minimal View subclass that records every on_mouse_* / on_mouse_enter
+/// event into a counter we can compare across record/replay tree pairs.
+class RecordingView : public View {
+public:
+    int down_count = 0;
+    int up_count = 0;
+    int drag_count = 0;
+    int enter_count = 0;
+    int leave_count = 0;
+    int click_count = 0;
+
+    void on_mouse_down(Point) override { ++down_count; }
+    void on_mouse_up(Point) override { ++up_count; }
+    void on_mouse_drag(Point) override { ++drag_count; }
+    void on_mouse_enter() override { ++enter_count; }
+    void on_mouse_leave() override { ++leave_count; }
+};
+
+/// Build a two-node tree with a target child at known coordinates.
+struct TestTree {
+    std::unique_ptr<View> root;
+    RecordingView* target = nullptr;   // owned by root via child list
+
+    static TestTree make() {
+        TestTree t;
+        t.root = std::make_unique<View>();
+        t.root->set_id("root");
+        t.root->set_bounds({0, 0, 400, 400});
+
+        auto target = std::make_unique<RecordingView>();
+        target->set_id("target");
+        target->set_bounds({100, 100, 100, 100});
+        target->on_click = [target_ptr = target.get()]() {
+            ++target_ptr->click_count;
+        };
+        t.target = target.get();
+        t.root->add_child(std::move(target));
+        return t;
+    }
+};
+
+/// RAII: reset the Coordinator + MotionPreferences between cases so
+/// per-case state doesn't bleed.
+struct CoordReset {
+    CoordReset() {
+        Coordinator::instance().reset();
+        pulp::view::MotionPreferences::instance().reset_for_tests();
+    }
+    ~CoordReset() {
+        Coordinator::instance().reset();
+        pulp::view::MotionPreferences::instance().reset_for_tests();
+    }
+};
+
+}  // namespace
+
+// ── Round-trip: Input event survives serialize -> load ───────────────
+
+TEST_CASE("Input event round-trips through fixture serialize/parse",
+          "[motion][input][fixture]") {
+    CoordReset reset;
+    const auto path = tmp_fixture_path("rt");
+
+    FrameClock clock;
+    Coordinator::instance().bind(clock);
+    {
+        TestTree tree = TestTree::make();
+        tree.root->set_frame_clock(&clock);
+        auto recorder = make_input_recorder(path);
+        REQUIRE(recorder.is_recording());
+
+        tree.root->simulate_hover({150, 150});
+        clock.tick(1.0f / 60.0f);
+        tree.root->simulate_click({150, 150});
+        clock.tick(1.0f / 60.0f);
+        tree.root->simulate_drag({150, 150}, {180, 180}, /*steps=*/4);
+        clock.tick(1.0f / 60.0f);
+    }
+    Coordinator::instance().unbind();
+
+    auto events = load_fixture(path);
+    REQUIRE(!events.empty());
+
+    int hover_seen = 0, click_seen = 0, drag_seen = 0;
+    for (const auto& e : events) {
+        if (e.kind != SampleEvent::Kind::Input) continue;
+        REQUIRE(e.view_id == "target");
+        if (e.input_kind == "hover") {
+            ++hover_seen;
+            REQUIRE(e.components.size() == 2);
+            // Components sorted by name: x, y
+            REQUIRE(e.components[0].first == "x");
+            REQUIRE(e.components[1].first == "y");
+            REQUIRE(e.components[0].second == 150.0);
+            REQUIRE(e.components[1].second == 150.0);
+        } else if (e.input_kind == "click") {
+            ++click_seen;
+            REQUIRE(e.components.size() == 2);
+            REQUIRE(e.components[0].second == 150.0);
+        } else if (e.input_kind == "drag") {
+            ++drag_seen;
+            // Drag carries 5 named components (sorted): end_x, end_y,
+            // start_x, start_y, steps
+            REQUIRE(e.components.size() == 5);
+            double end_x = 0, end_y = 0, start_x = 0, start_y = 0, steps = 0;
+            for (const auto& [k, v] : e.components) {
+                if (k == "end_x") end_x = v;
+                else if (k == "end_y") end_y = v;
+                else if (k == "start_x") start_x = v;
+                else if (k == "start_y") start_y = v;
+                else if (k == "steps") steps = v;
+            }
+            REQUIRE(start_x == 150.0);
+            REQUIRE(start_y == 150.0);
+            REQUIRE(end_x == 180.0);
+            REQUIRE(end_y == 180.0);
+            REQUIRE(steps == 4.0);
+        }
+    }
+    REQUIRE(hover_seen == 1);
+    REQUIRE(click_seen == 1);
+    REQUIRE(drag_seen == 1);
+
+    std::remove(path.c_str());
+}
+
+// ── Recorder is OFF by default ───────────────────────────────────────
+
+TEST_CASE("simulate_* produces no Input events when no recorder is alive",
+          "[motion][input]") {
+    CoordReset reset;
+    REQUIRE_FALSE(input_recording_enabled());
+
+    FrameClock clock;
+    Coordinator::instance().bind(clock);
+    std::vector<SampleEvent> buf;
+    Coordinator::instance().add_sink(make_buffer_sink(&buf));
+
+    TestTree tree = TestTree::make();
+    tree.root->set_frame_clock(&clock);
+    tree.root->simulate_click({150, 150});
+
+    REQUIRE(buf.empty());
+    Coordinator::instance().unbind();
+}
+
+// ── make_input_recorder RAII toggles the global flag ────────────────
+
+TEST_CASE("InputRecorder RAII toggles input_recording_enabled",
+          "[motion][input]") {
+    CoordReset reset;
+    const auto path = tmp_fixture_path("raii");
+    REQUIRE_FALSE(input_recording_enabled());
+    {
+        auto r = make_input_recorder(path);
+        REQUIRE(input_recording_enabled());
+        REQUIRE(r.is_recording());
+    }
+    REQUIRE_FALSE(input_recording_enabled());
+    std::remove(path.c_str());
+}
+
+// ── End-to-end: record, replay against a fresh tree, motion matches ─
+
+TEST_CASE("hover -> click -> drag record/replay produces matching motion fixture",
+          "[motion][input][replay]") {
+    CoordReset reset;
+    const auto record_path = tmp_fixture_path("record");
+    const auto replay_path = tmp_fixture_path("replay");
+
+    // ── Recording pass ──────────────────────────────────────────────
+    int record_clicks = 0, record_downs = 0, record_drags = 0, record_enters = 0;
+    double record_opacity_start = 0.0;
+    double record_opacity_end = 0.0;
+    {
+        FrameClock clock;
+        Coordinator::instance().bind(clock);
+        Coordinator::instance().set_tracing_enabled(true);
+
+        TestTree tree = TestTree::make();
+        tree.root->set_frame_clock(&clock);
+
+        // A scalar metric that toggles when the target is clicked.
+        // We trace it so the recorded fixture contains motion samples
+        // alongside the input events.
+        double opacity = 0.0;
+        tree.target->on_click = [t = tree.target, &opacity]() {
+            ++t->click_count;
+            opacity = 1.0;
+        };
+        auto handle = Coordinator::instance()
+            .trace("Card", { /*fps=*/60 })
+            .value("opacity", [&]{ return opacity; })
+            .attach();
+
+        // Sink wired BEFORE the recorder so opacity samples + input
+        // events fan out through both. The recorder's own sink writes
+        // the JSONL fixture; we tick once before recording so the
+        // baseline opacity sample lands first.
+        record_opacity_start = opacity;
+        clock.tick(1.0f / 60.0f);  // Baseline opacity sample.
+
+        auto recorder = make_input_recorder(record_path);
+
+        tree.root->simulate_hover({150, 150});
+        clock.tick(1.0f / 60.0f);
+        tree.root->simulate_click({150, 150});
+        clock.tick(1.0f / 60.0f);  // opacity transition Start + Sample
+        clock.tick(1.0f / 60.0f);  // opacity End on next stable tick
+        tree.root->simulate_drag({150, 150}, {170, 170}, /*steps=*/3);
+        clock.tick(1.0f / 60.0f);
+
+        record_clicks = tree.target->click_count;
+        record_downs = tree.target->down_count;
+        record_drags = tree.target->drag_count;
+        record_enters = tree.target->enter_count;
+        record_opacity_end = opacity;
+    }
+    Coordinator::instance().reset();
+
+    // ── Replay pass against a fresh tree ────────────────────────────
+    int replay_clicks = 0, replay_downs = 0, replay_drags = 0, replay_enters = 0;
+    double replay_opacity_end = 0.0;
+    {
+        FrameClock clock;
+        Coordinator::instance().bind(clock);
+        Coordinator::instance().set_tracing_enabled(true);
+
+        TestTree tree = TestTree::make();
+        tree.root->set_frame_clock(&clock);
+
+        double opacity = 0.0;
+        tree.target->on_click = [t = tree.target, &opacity]() {
+            ++t->click_count;
+            opacity = 1.0;
+        };
+        auto handle = Coordinator::instance()
+            .trace("Card", { 60 })
+            .value("opacity", [&]{ return opacity; })
+            .attach();
+
+        // Open a fresh fixture sink so the replayed motion writes to
+        // its own file. Inputs are NOT being recorded here — only the
+        // motion stream — so input_recording_enabled() stays false.
+        Coordinator::instance().add_sink(make_fixture_sink(replay_path));
+        clock.tick(1.0f / 60.0f);   // baseline before replay starts
+
+        const int replayed = replay_inputs(record_path, *tree.root, clock);
+        REQUIRE(replayed == 3);
+
+        // One last tick so the End event on the opacity burst lands.
+        clock.tick(1.0f / 60.0f);
+
+        replay_clicks = tree.target->click_count;
+        replay_downs = tree.target->down_count;
+        replay_drags = tree.target->drag_count;
+        replay_enters = tree.target->enter_count;
+        replay_opacity_end = opacity;
+    }
+    Coordinator::instance().reset();
+
+    // Per-handler counts match (same simulate dispatch behavior).
+    REQUIRE(replay_clicks == record_clicks);
+    REQUIRE(replay_downs == record_downs);
+    REQUIRE(replay_drags == record_drags);
+    REQUIRE(replay_enters == record_enters);
+    // The clicked target's side-effect (opacity toggling to 1.0) fired.
+    REQUIRE(record_opacity_start == 0.0);
+    REQUIRE(record_opacity_end == 1.0);
+    REQUIRE(replay_opacity_end == record_opacity_end);
+
+    // Compare the motion streams from both fixtures. We extract only
+    // motion-side events (Baseline / Start / Sample / End) on the
+    // `Card.opacity` metric so the comparison focuses on the animation
+    // the inputs drove, not the input log itself.
+    auto record_events = load_fixture(record_path);
+    auto replay_events = load_fixture(replay_path);
+    REQUIRE(!record_events.empty());
+    REQUIRE(!replay_events.empty());
+
+    auto motion_only = [](const std::vector<SampleEvent>& src) {
+        std::vector<SampleEvent> out;
+        for (const auto& e : src) {
+            if (e.kind == SampleEvent::Kind::Input) continue;
+            if (e.kind == SampleEvent::Kind::TraceStarted) continue;
+            if (e.view_name != "Card") continue;
+            out.push_back(e);
+        }
+        return out;
+    };
+
+    auto rec_motion = motion_only(record_events);
+    auto rep_motion = motion_only(replay_events);
+
+    // Both sides should have the same baseline -> start -> sample -> end
+    // shape on the Card.opacity metric.
+    auto count_kind_local = [](const std::vector<SampleEvent>& v,
+                               SampleEvent::Kind k) {
+        std::size_t n = 0;
+        for (const auto& e : v) if (e.kind == k) ++n;
+        return n;
+    };
+    REQUIRE(count_kind_local(rec_motion, SampleEvent::Kind::Baseline) ==
+            count_kind_local(rep_motion, SampleEvent::Kind::Baseline));
+    REQUIRE(count_kind_local(rec_motion, SampleEvent::Kind::Start) ==
+            count_kind_local(rep_motion, SampleEvent::Kind::Start));
+    REQUIRE(count_kind_local(rec_motion, SampleEvent::Kind::Sample) ==
+            count_kind_local(rep_motion, SampleEvent::Kind::Sample));
+    REQUIRE(count_kind_local(rec_motion, SampleEvent::Kind::End) ==
+            count_kind_local(rep_motion, SampleEvent::Kind::End));
+
+    // ID-aware comparator: identical Baseline + Start + Sample + End on
+    // the same (view, metric, burst_id) triples within tolerance.
+    FixtureMatchOptions opts;
+    opts.require_same_event_count = false;
+    opts.require_matching_policy = false;
+    opts.component_epsilon = 1e-6;
+    // Replay anchors on the first input's recorded timestamp and ticks
+    // deltas between subsequent inputs, but the sampler-driven motion
+    // events ride a separate FrameClock cadence that doesn't have a
+    // fixed offset relative to the input timeline. The shape of the
+    // animation (counts + values) must match exactly; the absolute t
+    // is allowed to drift within one frame's worth of slop (we sample
+    // at 60 fps in this test).
+    opts.timing_epsilon_seconds = 0.05;
+    auto diff = assert_matches(rec_motion, rep_motion, opts);
+    INFO("motion fixture diff items: " << diff.differences.size());
+    for (const auto& d : diff.differences) {
+        INFO("  " << d.kind << " " << d.view_name << "/" << d.metric_name
+             << " " << d.component_name << " " << d.detail);
+    }
+    REQUIRE(diff.matches());
+
+    std::remove(record_path.c_str());
+    std::remove(replay_path.c_str());
+}

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -82,12 +82,16 @@ TEST_CASE("MotionPreferences set_override(nullopt) reverts to OS value",
           "[motion-preferences]") {
     PrefsScope scope;
     auto& prefs = MotionPreferences::instance();
+    // Snapshot whatever the OS preference is on this runner BEFORE
+    // we override — macOS GitHub-hosted runners typically have
+    // Reduce Motion enabled (headless display), so we can't hardcode
+    // Full like the original test did.
+    const auto os_value = prefs.policy();
     prefs.set_override(MotionPolicy::Reduced);
     REQUIRE(prefs.policy() == MotionPolicy::Reduced);
     prefs.set_override(std::nullopt);
     REQUIRE_FALSE(prefs.has_override());
-    // OS value — Full on a clean CI runner.
-    REQUIRE(prefs.policy() == MotionPolicy::Full);
+    REQUIRE(prefs.policy() == os_value);
 }
 
 TEST_CASE("MotionPreferences set_duration_scale sticks and clamps",
@@ -111,14 +115,18 @@ TEST_CASE("MotionPreferences on_policy_changed fires on override transition",
           "[motion-preferences]") {
     PrefsScope scope;
     auto& prefs = MotionPreferences::instance();
+    // Snapshot the OS value first — macOS GitHub-hosted runners
+    // typically report Reduced, not Full, so the final transition
+    // lands at whatever the OS actually says.
+    const auto os_value = prefs.policy();
     std::vector<MotionPolicy> seen;
     prefs.on_policy_changed([&](MotionPolicy p) { seen.push_back(p); });
     prefs.set_override(MotionPolicy::Reduced);
     prefs.set_override(MotionPolicy::Off);
     prefs.set_override(std::nullopt);
-    REQUIRE(seen.size() >= 2);   // Full→Reduced, Reduced→Off, Off→OS (Full)
+    REQUIRE(seen.size() >= 2);   // OS→Reduced, Reduced→Off, Off→OS
     REQUIRE(seen.front() == MotionPolicy::Reduced);
-    REQUIRE(seen.back() == MotionPolicy::Full);
+    REQUIRE(seen.back() == os_value);
 }
 
 TEST_CASE("MotionPreferences poll is a no-op while override is set",
@@ -509,13 +517,17 @@ TEST_CASE("assert_matches with header overload accepts matching headers",
 TEST_CASE("Fixture recorded under Full omits-or-stores 'full' policy",
           "[motion-preferences][fixture]") {
     PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    // Explicitly force Full so the test is independent of the host
+    // runner's OS preference (macOS GitHub-hosted runners report
+    // Reduced because of their headless display configuration).
+    prefs.set_override(MotionPolicy::Full);
     auto& coord = pulp::view::motion::Coordinator::instance();
     coord.reset();
     coord.set_tracing_enabled(true);
     coord.set_firehose(true);
     pulp::view::FrameClock clock;
     coord.bind(clock);
-    // Default override on a clean CI runner is the OS value — Full.
     const auto path = make_tmp_fixture_path("full");
     std::remove(path.c_str());
     auto sink_id = coord.add_sink(pulp::view::motion::make_fixture_sink(path));

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -12,7 +12,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
+#include <cstdio>
 #include <optional>
+#include <string>
+#include <unistd.h>
 #include <vector>
 
 using Catch::Approx;
@@ -384,6 +387,142 @@ TEST_CASE("AnimatorSet under MotionPolicy::Reduced scales each Tween's duration"
 }
 
 // ── settling_time_seconds under Reduced halves with duration_scale 0.5
+
+// ── Fixture header records MotionPolicy + duration_scale ────────────
+
+namespace {
+
+std::string make_tmp_fixture_path(const char* tag) {
+    std::string p = "/tmp/pulp_phase8_fixture_";
+    p += tag;
+    p += "_";
+    p += std::to_string(::getpid());
+    p += ".jsonl";
+    return p;
+}
+
+}  // namespace
+
+TEST_CASE("Fixture recorded under Reduced carries policy + duration_scale in header",
+          "[motion-preferences][fixture]") {
+    PrefsScope scope;
+    auto& coord = pulp::view::motion::Coordinator::instance();
+    coord.reset();
+    coord.set_tracing_enabled(true);
+    coord.set_firehose(true);
+    pulp::view::FrameClock clock;
+    coord.bind(clock);
+
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Reduced);
+    prefs.set_duration_scale(0.5);
+
+    const auto path = make_tmp_fixture_path("reduced");
+    std::remove(path.c_str());
+    auto sink_id = coord.add_sink(pulp::view::motion::make_fixture_sink(path));
+    pulp::view::motion::publish_value("A", "x", 0.0);
+    clock.tick(0.016f);
+    pulp::view::motion::publish_value("A", "x", 0.5);
+    coord.remove_sink(sink_id);
+
+    auto hdr = pulp::view::motion::load_fixture_header(path);
+    REQUIRE(hdr.version == pulp::view::motion::kFixtureSchemaVersion);
+    REQUIRE(hdr.policy == "reduced");
+    REQUIRE(hdr.duration_scale == Approx(0.5));
+
+    auto events = pulp::view::motion::load_fixture(path);
+    REQUIRE(events.size() >= 1);   // header + events still parse fine.
+
+    std::remove(path.c_str());
+    coord.reset();
+}
+
+TEST_CASE("Fixture recorded under Off carries policy=off",
+          "[motion-preferences][fixture]") {
+    PrefsScope scope;
+    auto& coord = pulp::view::motion::Coordinator::instance();
+    coord.reset();
+    coord.set_tracing_enabled(true);
+    coord.set_firehose(true);
+    pulp::view::FrameClock clock;
+    coord.bind(clock);
+
+    MotionPreferences::instance().set_override(MotionPolicy::Off);
+
+    const auto path = make_tmp_fixture_path("off");
+    std::remove(path.c_str());
+    auto sink_id = coord.add_sink(pulp::view::motion::make_fixture_sink(path));
+    pulp::view::motion::publish_value("A", "x", 0.0);
+    pulp::view::motion::publish_value("A", "x", 1.0);
+    coord.remove_sink(sink_id);
+
+    auto hdr = pulp::view::motion::load_fixture_header(path);
+    REQUIRE(hdr.policy == "off");
+    REQUIRE(hdr.duration_scale == Approx(1.0));
+
+    std::remove(path.c_str());
+    coord.reset();
+}
+
+TEST_CASE("assert_matches with header overload flags policy-mismatch",
+          "[motion-preferences][fixture][assert-matches]") {
+    pulp::view::motion::FixtureHeader g;
+    g.policy = "reduced";
+    g.duration_scale = 0.5;
+    pulp::view::motion::FixtureHeader c;
+    c.policy = "full";
+    c.duration_scale = 1.0;
+    std::vector<pulp::view::motion::SampleEvent> empty;
+    pulp::view::motion::FixtureMatchOptions opts;
+    opts.require_same_event_count = false;
+    auto diff = pulp::view::motion::assert_matches(g, empty, c, empty, opts);
+    REQUIRE_FALSE(diff.matches());
+    // Two diff items: policy string + duration_scale.
+    int policy_count = 0;
+    for (const auto& d : diff.differences) {
+        if (d.kind == "policy-mismatch") ++policy_count;
+    }
+    REQUIRE(policy_count == 2);
+}
+
+TEST_CASE("assert_matches with header overload accepts matching headers",
+          "[motion-preferences][fixture][assert-matches]") {
+    pulp::view::motion::FixtureHeader g;
+    g.policy = "reduced";
+    g.duration_scale = 0.5;
+    pulp::view::motion::FixtureHeader c;
+    c.policy = "reduced";
+    c.duration_scale = 0.5;
+    std::vector<pulp::view::motion::SampleEvent> empty;
+    pulp::view::motion::FixtureMatchOptions opts;
+    opts.require_same_event_count = false;
+    auto diff = pulp::view::motion::assert_matches(g, empty, c, empty, opts);
+    REQUIRE(diff.matches());
+}
+
+TEST_CASE("Fixture recorded under Full omits-or-stores 'full' policy",
+          "[motion-preferences][fixture]") {
+    PrefsScope scope;
+    auto& coord = pulp::view::motion::Coordinator::instance();
+    coord.reset();
+    coord.set_tracing_enabled(true);
+    coord.set_firehose(true);
+    pulp::view::FrameClock clock;
+    coord.bind(clock);
+    // Default override on a clean CI runner is the OS value — Full.
+    const auto path = make_tmp_fixture_path("full");
+    std::remove(path.c_str());
+    auto sink_id = coord.add_sink(pulp::view::motion::make_fixture_sink(path));
+    pulp::view::motion::publish_value("A", "x", 0.0);
+    coord.remove_sink(sink_id);
+
+    auto hdr = pulp::view::motion::load_fixture_header(path);
+    REQUIRE(hdr.policy == "full");
+    REQUIRE(hdr.duration_scale == Approx(1.0));
+
+    std::remove(path.c_str());
+    coord.reset();
+}
 
 TEST_CASE("Tween under Reduced + duration_scale 0.5 halves settling_time",
           "[motion-preferences][tween][settling-time]") {

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -115,18 +115,21 @@ TEST_CASE("MotionPreferences on_policy_changed fires on override transition",
           "[motion-preferences]") {
     PrefsScope scope;
     auto& prefs = MotionPreferences::instance();
-    // Snapshot the OS value first — macOS GitHub-hosted runners
-    // typically report Reduced, not Full, so the final transition
-    // lands at whatever the OS actually says.
-    const auto os_value = prefs.policy();
+    // Force a known starting policy so the Reduced override is always
+    // a real transition (some CI runners — macOS GitHub-hosted, Windows
+    // headless — report Reduced as their OS value, which would
+    // otherwise no-op the first set_override below).
+    prefs.set_override(MotionPolicy::Full);
     std::vector<MotionPolicy> seen;
     prefs.on_policy_changed([&](MotionPolicy p) { seen.push_back(p); });
     prefs.set_override(MotionPolicy::Reduced);
     prefs.set_override(MotionPolicy::Off);
-    prefs.set_override(std::nullopt);
-    REQUIRE(seen.size() >= 2);   // OS→Reduced, Reduced→Off, Off→OS
+    prefs.set_override(std::nullopt);   // back to OS value
+    REQUIRE(seen.size() >= 2);   // Full→Reduced, Reduced→Off, Off→OS
     REQUIRE(seen.front() == MotionPolicy::Reduced);
-    REQUIRE(seen.back() == os_value);
+    // Final transition lands at the OS value, whatever that is on
+    // this runner.
+    REQUIRE(seen.back() == prefs.policy());
 }
 
 TEST_CASE("MotionPreferences poll is a no-op while override is set",

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -407,7 +407,15 @@ TEST_CASE("AnimatorSet under MotionPolicy::Reduced scales each Tween's duration"
 namespace {
 
 std::string make_tmp_fixture_path(const char* tag) {
-    std::string p = "/tmp/pulp_phase8_fixture_";
+#if defined(_WIN32)
+    const char* tmpdir = std::getenv("TMP");
+    if (!tmpdir) tmpdir = std::getenv("TEMP");
+    if (!tmpdir) tmpdir = ".";
+#else
+    const char* tmpdir = "/tmp";
+#endif
+    std::string p = tmpdir;
+    p += "/pulp_phase8_fixture_";
     p += tag;
     p += "_";
     p += std::to_string(pulp_test_getpid());

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -4,6 +4,8 @@
 
 #include <pulp/view/motion_preferences.hpp>
 #include <pulp/view/animation.hpp>
+#include <pulp/view/animator_set.hpp>
+#include <pulp/view/css_animation.hpp>
 #include <pulp/view/motion.hpp>
 #include <pulp/view/frame_clock.hpp>
 
@@ -299,6 +301,86 @@ TEST_CASE("Tween under Reduced still produces a normal burst",
     REQUIRE(sample > 1);
 
     coord.reset();
+}
+
+// ── CssAnimation honors MotionPolicy ─────────────────────────────────
+
+TEST_CASE("CssAnimation under MotionPolicy::Off completes on first tick",
+          "[motion-preferences][css-animation]") {
+    PrefsScope scope;
+    MotionPreferences::instance().set_override(MotionPolicy::Off);
+    pulp::view::CssAnimation a;
+    a.spec.duration_seconds = 0.5f;
+    a.spec.delay_seconds = 0.1f;
+    a.start_value = 0.0f;
+    a.end_value = 1.0f;
+    float v = a.tick(0.016f);
+    REQUIRE(v == Approx(1.0f));
+    REQUIRE_FALSE(a.active);
+}
+
+TEST_CASE("CssAnimation under MotionPolicy::Reduced scales duration",
+          "[motion-preferences][css-animation]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Reduced);
+    prefs.set_duration_scale(0.5);
+    pulp::view::CssAnimation a;
+    a.spec.duration_seconds = 1.0f;     // effective 0.5s after scale
+    a.spec.delay_seconds = 0.0f;
+    a.start_value = 0.0f;
+    a.end_value = 1.0f;
+    // First tick captures the scaled spec.
+    a.tick(0.0f);
+    REQUIRE(a.spec.duration_seconds == Approx(0.5f));
+    // Drive to mid-way of effective duration.
+    a.tick(0.25f);
+    REQUIRE(a.active);
+    // Drive past the end.
+    a.tick(0.3f);
+    REQUIRE_FALSE(a.active);
+}
+
+// ── AnimatorSet honors MotionPolicy via underlying Tween ─────────────
+
+TEST_CASE("AnimatorSet under MotionPolicy::Off completes on first advance",
+          "[motion-preferences][animator-set]") {
+    PrefsScope scope;
+    MotionPreferences::instance().set_override(MotionPolicy::Off);
+    int updates = 0;
+    float last = -1.0f;
+    auto runner = pulp::view::AnimatorSetBuilder{}
+        .then(0.0f, 1.0f, 0.5f, [&](float v){ ++updates; last = v; })
+        .then(0.0f, 2.0f, 0.5f, [&](float v){ ++updates; last = v; })
+        .build_runner();
+    // A single advance should walk through all already-finished steps.
+    bool done = runner.advance(0.016f);
+    REQUIRE(done);
+    REQUIRE(last == Approx(2.0f));
+    REQUIRE(updates >= 2);  // one update per step's final value
+}
+
+TEST_CASE("AnimatorSet under MotionPolicy::Reduced scales each Tween's duration",
+          "[motion-preferences][animator-set]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Reduced);
+    prefs.set_duration_scale(0.5);
+    // Two sequential 1s tweens → 1s total effective (each scaled to 0.5s).
+    auto runner = pulp::view::AnimatorSetBuilder{}
+        .then(0.0f, 1.0f, 1.0f, [](float){})
+        .then(1.0f, 2.0f, 1.0f, [](float){})
+        .build_runner();
+    bool done = false;
+    int ticks = 0;
+    while (!done && ticks < 200) {
+        done = runner.advance(0.016f);
+        ++ticks;
+    }
+    // ~1s of effective animation @ 60 Hz → ~63 ticks, plus a few for
+    // the inter-step carry. Allow generous margin.
+    REQUIRE(done);
+    REQUIRE(ticks < 80);
 }
 
 // ── settling_time_seconds under Reduced halves with duration_scale 0.5

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -1,0 +1,339 @@
+/// @file test_motion_preferences.cpp
+/// Catch2 unit tests for pulp::view::MotionPreferences (Phase 8a) and the
+/// Tween / ValueAnimation honoring of MotionPolicy (Phase 8b).
+
+#include <pulp/view/motion_preferences.hpp>
+#include <pulp/view/animation.hpp>
+#include <pulp/view/motion.hpp>
+#include <pulp/view/frame_clock.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <optional>
+#include <vector>
+
+using Catch::Approx;
+using pulp::view::MotionPolicy;
+using pulp::view::MotionPreferences;
+using pulp::view::Tween;
+using pulp::view::ValueAnimation;
+using pulp::view::easing::linear;
+
+namespace {
+
+/// Scope guard: reset MotionPreferences on test entry and exit so tests
+/// can't leak overrides into each other.
+struct PrefsScope {
+    PrefsScope() { MotionPreferences::instance().reset_for_tests(); }
+    ~PrefsScope() { MotionPreferences::instance().reset_for_tests(); }
+};
+
+} // namespace
+
+// ── MotionPreferences ────────────────────────────────────────────────
+
+TEST_CASE("MotionPreferences default policy after reset_for_tests is the OS value",
+          "[motion-preferences]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    // Default duration_scale is 1.0 and no override is set.
+    REQUIRE(prefs.duration_scale() == Approx(1.0));
+    REQUIRE_FALSE(prefs.has_override());
+    // The policy is whatever the OS reports — on a CI runner with no
+    // accessibility flag set, that's Full. We only require that the
+    // policy is a legal enum value.
+    auto p = prefs.policy();
+    REQUIRE((p == MotionPolicy::Full ||
+             p == MotionPolicy::Reduced ||
+             p == MotionPolicy::Off));
+}
+
+TEST_CASE("MotionPreferences set_override(Reduced) returns Reduced",
+          "[motion-preferences]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Reduced);
+    REQUIRE(prefs.has_override());
+    REQUIRE(prefs.policy() == MotionPolicy::Reduced);
+    REQUIRE(MotionPreferences::current() == MotionPolicy::Reduced);
+}
+
+TEST_CASE("MotionPreferences set_override(Off) returns Off",
+          "[motion-preferences]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Off);
+    REQUIRE(prefs.policy() == MotionPolicy::Off);
+}
+
+TEST_CASE("MotionPreferences set_override(nullopt) reverts to OS value",
+          "[motion-preferences]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Reduced);
+    REQUIRE(prefs.policy() == MotionPolicy::Reduced);
+    prefs.set_override(std::nullopt);
+    REQUIRE_FALSE(prefs.has_override());
+    // OS value — Full on a clean CI runner.
+    REQUIRE(prefs.policy() == MotionPolicy::Full);
+}
+
+TEST_CASE("MotionPreferences set_duration_scale sticks and clamps",
+          "[motion-preferences]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_duration_scale(0.5);
+    REQUIRE(prefs.duration_scale() == Approx(0.5));
+    REQUIRE(MotionPreferences::current_duration_scale() == Approx(0.5));
+
+    // Clamp negative → 0.
+    prefs.set_duration_scale(-1.0);
+    REQUIRE(prefs.duration_scale() == Approx(0.0));
+
+    // Clamp above 2.0 → 2.0.
+    prefs.set_duration_scale(10.0);
+    REQUIRE(prefs.duration_scale() == Approx(2.0));
+}
+
+TEST_CASE("MotionPreferences on_policy_changed fires on override transition",
+          "[motion-preferences]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    std::vector<MotionPolicy> seen;
+    prefs.on_policy_changed([&](MotionPolicy p) { seen.push_back(p); });
+    prefs.set_override(MotionPolicy::Reduced);
+    prefs.set_override(MotionPolicy::Off);
+    prefs.set_override(std::nullopt);
+    REQUIRE(seen.size() >= 2);   // Full→Reduced, Reduced→Off, Off→OS (Full)
+    REQUIRE(seen.front() == MotionPolicy::Reduced);
+    REQUIRE(seen.back() == MotionPolicy::Full);
+}
+
+TEST_CASE("MotionPreferences poll is a no-op while override is set",
+          "[motion-preferences]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Reduced);
+    REQUIRE_FALSE(prefs.poll());
+    REQUIRE(prefs.policy() == MotionPolicy::Reduced);
+}
+
+TEST_CASE("motion_policy_to_string / from_string round-trip",
+          "[motion-preferences]") {
+    using namespace pulp::view;
+    REQUIRE(std::string(motion_policy_to_string(MotionPolicy::Full)) == "full");
+    REQUIRE(std::string(motion_policy_to_string(MotionPolicy::Reduced)) == "reduced");
+    REQUIRE(std::string(motion_policy_to_string(MotionPolicy::Off)) == "off");
+    REQUIRE(motion_policy_from_string("full") == MotionPolicy::Full);
+    REQUIRE(motion_policy_from_string("reduced") == MotionPolicy::Reduced);
+    REQUIRE(motion_policy_from_string("off") == MotionPolicy::Off);
+    REQUIRE(motion_policy_from_string("bogus") == MotionPolicy::Full);
+}
+
+// ── Tween honors MotionPolicy ────────────────────────────────────────
+
+TEST_CASE("Tween under MotionPolicy::Off is finished from construction",
+          "[motion-preferences][tween]") {
+    PrefsScope scope;
+    MotionPreferences::instance().set_override(MotionPolicy::Off);
+    Tween t(0.0f, 1.0f, 0.5f, linear);
+    REQUIRE(t.finished());
+    REQUIRE(t.current() == Approx(1.0f));
+    // Even after advance(), still pinned at to_.
+    float v = t.advance(0.016f);
+    REQUIRE(v == Approx(1.0f));
+}
+
+TEST_CASE("Tween under MotionPolicy::Reduced scales duration",
+          "[motion-preferences][tween]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Reduced);
+    prefs.set_duration_scale(0.5);
+
+    // Configured duration: 1.0s. Effective with Reduced + scale 0.5 = 0.5s.
+    Tween t(0.0f, 1.0f, 1.0f, linear);
+    // Advance halfway through the effective duration → linear → 0.5.
+    t.advance(0.25f);
+    REQUIRE(t.current() == Approx(0.5f).margin(1e-4));
+    REQUIRE_FALSE(t.finished());
+    // Advance through the rest of the effective duration → done.
+    t.advance(0.25f);
+    REQUIRE(t.finished());
+    REQUIRE(t.current() == Approx(1.0f));
+}
+
+TEST_CASE("Tween reset() re-applies the current MotionPolicy",
+          "[motion-preferences][tween]") {
+    PrefsScope scope;
+    // Construct under Full…
+    Tween t(0.0f, 1.0f, 1.0f, linear);
+    REQUIRE_FALSE(t.finished());
+    // …then flip to Off and reset.
+    MotionPreferences::instance().set_override(MotionPolicy::Off);
+    t.reset();
+    REQUIRE(t.finished());
+    REQUIRE(t.current() == Approx(1.0f));
+}
+
+TEST_CASE("ValueAnimation::animate_to under MotionPolicy::Off snaps to target",
+          "[motion-preferences][value-animation]") {
+    PrefsScope scope;
+    MotionPreferences::instance().set_override(MotionPolicy::Off);
+    ValueAnimation a(0.0f);
+    a.animate_to(1.0f, 0.5f);
+    REQUIRE_FALSE(a.animating());
+    REQUIRE(a.value() == Approx(1.0f));
+}
+
+TEST_CASE("ValueAnimation::animate_to under MotionPolicy::Reduced scales duration",
+          "[motion-preferences][value-animation]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Reduced);
+    prefs.set_duration_scale(0.5);
+    ValueAnimation a(0.0f);
+    a.animate_to(1.0f, 1.0f, linear);
+    REQUIRE(a.animating());
+    a.advance(0.25f);  // halfway through scaled (0.5s) duration → 0.5
+    REQUIRE(a.value() == Approx(0.5f).margin(1e-4));
+    a.advance(0.25f);
+    REQUIRE_FALSE(a.animating());
+    REQUIRE(a.value() == Approx(1.0f));
+}
+
+// ── Tween under publish, Off emits Baseline + final Sample + End ────
+//
+// Under MotionPolicy::Off, advancing a tween should produce a single
+// publish at the target value, not a long stream of intermediate samples.
+// This mirrors what an animation primitive would do at its tick site:
+// publish_value(current). Because the tween is `finished()` from
+// construction, the first advance() returns `to_` and any further
+// advance() also returns `to_` — so a typical "publish until finished"
+// loop produces one publish above the baseline epsilon, then exits.
+
+TEST_CASE("Tween under Off + publish emits Baseline + final Sample + End only",
+          "[motion-preferences][tween][publish]") {
+    PrefsScope scope;
+    auto& coord = pulp::view::motion::Coordinator::instance();
+    coord.reset();
+    coord.set_tracing_enabled(true);
+    coord.set_firehose(true);
+    pulp::view::FrameClock clock;
+    coord.bind(clock);
+
+    std::vector<pulp::view::motion::SampleEvent> events;
+    coord.add_sink(
+        [&](const pulp::view::motion::SampleEvent& e) { events.push_back(e); });
+
+    MotionPreferences::instance().set_override(MotionPolicy::Off);
+    Tween t(0.0f, 1.0f, 0.5f, linear);
+    // Publish a baseline (0.0), then run a typical advance loop. Because
+    // the tween is already finished, the loop terminates on the first
+    // iteration but still publishes the final value (1.0).
+    pulp::view::motion::publish_value("X", "y", 0.0);
+    int steps = 0;
+    do {
+        t.advance(0.016f);
+        pulp::view::motion::publish_value("X", "y", t.current());
+        ++steps;
+    } while (!t.finished() && steps < 100);
+    REQUIRE(steps == 1);
+
+    // Tally event kinds.
+    int baseline = 0, sample = 0, start = 0;
+    for (const auto& e : events) {
+        switch (e.kind) {
+            case pulp::view::motion::SampleEvent::Kind::Baseline: ++baseline; break;
+            case pulp::view::motion::SampleEvent::Kind::Sample:   ++sample;   break;
+            case pulp::view::motion::SampleEvent::Kind::Start:    ++start;    break;
+            default: break;
+        }
+    }
+    REQUIRE(baseline == 1);
+    REQUIRE(start == 1);
+    REQUIRE(sample == 1);   // single Sample for the jump to final value
+    // The burst closes on the next stable tick; we don't drive enough
+    // frames here to force End, which is fine for the contract: Off
+    // produces *no intermediate Samples*, just the single final one.
+
+    coord.reset();
+}
+
+TEST_CASE("Tween under Reduced still produces a normal burst",
+          "[motion-preferences][tween][publish]") {
+    PrefsScope scope;
+    auto& coord = pulp::view::motion::Coordinator::instance();
+    coord.reset();
+    coord.set_tracing_enabled(true);
+    coord.set_firehose(true);
+    pulp::view::FrameClock clock;
+    coord.bind(clock);
+
+    std::vector<pulp::view::motion::SampleEvent> events;
+    coord.add_sink(
+        [&](const pulp::view::motion::SampleEvent& e) { events.push_back(e); });
+
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Reduced);
+    prefs.set_duration_scale(0.5);   // effective duration 0.25s
+    Tween t(0.0f, 1.0f, 0.5f, linear);
+
+    pulp::view::motion::publish_value("X", "y", 0.0);
+    int steps = 0;
+    while (!t.finished() && steps < 200) {
+        // Tick the FrameClock so motion sample-event timestamps advance.
+        clock.tick(0.016f);
+        t.advance(0.016f);
+        pulp::view::motion::publish_value("X", "y", t.current());
+        ++steps;
+    }
+
+    int sample = 0;
+    for (const auto& e : events) {
+        if (e.kind == pulp::view::motion::SampleEvent::Kind::Sample) ++sample;
+    }
+    // Reduced is NOT "no samples". Expect a normal multi-sample burst —
+    // at minimum, more than one Sample between Start and End.
+    REQUIRE(sample > 1);
+
+    coord.reset();
+}
+
+// ── settling_time_seconds under Reduced halves with duration_scale 0.5
+
+TEST_CASE("Tween under Reduced + duration_scale 0.5 halves settling_time",
+          "[motion-preferences][tween][settling-time]") {
+    PrefsScope scope;
+    auto& coord = pulp::view::motion::Coordinator::instance();
+    coord.reset();
+    coord.set_tracing_enabled(true);
+    coord.set_firehose(true);
+    pulp::view::FrameClock clock;
+    coord.bind(clock);
+
+    std::vector<pulp::view::motion::SampleEvent> events;
+    coord.add_sink(
+        [&](const pulp::view::motion::SampleEvent& e) { events.push_back(e); });
+
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Reduced);
+    prefs.set_duration_scale(0.5);
+
+    Tween t(0.0f, 1.0f, 1.0f, linear);  // configured 1.0s; effective 0.5s.
+    pulp::view::motion::publish_value("X", "y", 0.0);
+    while (!t.finished()) {
+        clock.tick(0.016f);
+        t.advance(0.016f);
+        pulp::view::motion::publish_value("X", "y", t.current());
+    }
+
+    auto samples = pulp::view::motion::extract_scalar(events, "X", "y", "value");
+    auto st = pulp::view::motion::settling_time_seconds(samples);
+    // Effective duration 0.5s. Allow ±50 ms for the 60 Hz quantization
+    // and the fact that we publish discrete samples.
+    REQUIRE(st == Approx(0.5).margin(0.06));
+
+    coord.reset();
+}

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -15,7 +15,13 @@
 #include <cstdio>
 #include <optional>
 #include <string>
+#if defined(_WIN32)
+#include <process.h>
+#define pulp_test_getpid() static_cast<long>(::_getpid())
+#else
 #include <unistd.h>
+#define pulp_test_getpid() static_cast<long>(::getpid())
+#endif
 #include <vector>
 
 using Catch::Approx;
@@ -396,7 +402,7 @@ std::string make_tmp_fixture_path(const char* tag) {
     std::string p = "/tmp/pulp_phase8_fixture_";
     p += tag;
     p += "_";
-    p += std::to_string(::getpid());
+    p += std::to_string(pulp_test_getpid());
     p += ".jsonl";
     return p;
 }

--- a/test/test_motion_provenance.cpp
+++ b/test/test_motion_provenance.cpp
@@ -1,0 +1,339 @@
+/// @file test_motion_provenance.cpp
+/// Phase 9 — Provenance adapters: confirm that each animation surface
+/// (Tween, AnimatorSet, CSS TransitionSpec, JS rAF via ambient slot)
+/// stamps an identifiable `motion::Provenance` envelope on the events
+/// it publishes. An offline reader of the fixture can answer
+/// "where does this animation live?" without grepping source.
+
+#include <pulp/view/animation.hpp>
+#include <pulp/view/animator_set.hpp>
+#include <pulp/view/css_animation.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/motion.hpp>
+#include <pulp/view/widget_bridge.hpp>
+#include <pulp/view/view.hpp>
+#include <pulp/view/script_engine.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+using namespace pulp::view;
+using namespace pulp::view::motion;
+
+namespace {
+
+/// Wire a buffer sink to capture every emitted SampleEvent under the
+/// firehose for the duration of a scope. RAII so reset always happens.
+class MotionCapture {
+public:
+    MotionCapture() {
+        Coordinator::instance().reset();
+        Coordinator::instance().bind(clock_);
+        Coordinator::instance().set_tracing_enabled(true);
+        Coordinator::instance().set_firehose(true);
+        sink_id_ = Coordinator::instance().add_sink(make_buffer_sink(&events_));
+    }
+
+    ~MotionCapture() {
+        Coordinator::instance().reset();
+    }
+
+    void tick(float dt = 1.0f / 60.0f) { clock_.tick(dt); }
+    FrameClock& clock() { return clock_; }
+    std::vector<SampleEvent>& events() { return events_; }
+
+private:
+    FrameClock clock_;
+    std::vector<SampleEvent> events_;
+    int sink_id_ = 0;
+};
+
+/// Find the first event whose provenance source_kind matches `kind`.
+const SampleEvent* find_event_by_kind(const std::vector<SampleEvent>& events,
+                                      const std::string& kind) {
+    for (const auto& e : events) {
+        if (e.provenance.source_kind == kind) return &e;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+// ── Tween + PULP_MOTION_TWEEN macro ─────────────────────────────────────
+
+TEST_CASE("Tween::set_motion_provenance stamps publishes",
+          "[motion][provenance][tween][issue-pulp-motion-phase9]") {
+    MotionCapture cap;
+
+    Tween t(0.0f, 1.0f, 0.1f, easing::linear);
+    t.set_motion_provenance("tween", "GainKnob.opacity hover",
+                            "/path/to/knob.cpp", 42);
+
+    // Advance + publish a few ticks so a Baseline / Start / Sample fires.
+    for (int i = 0; i < 12; ++i) {
+        t.advance(1.0f / 60.0f);
+        t.publish("Gain Knob", "opacity");
+        cap.tick();
+    }
+
+    REQUIRE_FALSE(cap.events().empty());
+    for (const auto& e : cap.events()) {
+        REQUIRE(e.provenance.source_kind == "tween");
+        REQUIRE(e.provenance.source_id == "GainKnob.opacity hover");
+        REQUIRE(e.provenance.source_file == "/path/to/knob.cpp");
+        REQUIRE(e.provenance.source_line == 42);
+    }
+}
+
+TEST_CASE("PULP_MOTION_TWEEN macro auto-fills source_file/source_line",
+          "[motion][provenance][tween][macro][issue-pulp-motion-phase9]") {
+    MotionCapture cap;
+
+    // Note the line number of the next statement — it'll be captured by
+    // the macro and surface on every emitted event.
+    auto t = PULP_MOTION_TWEEN("hover-glow", /*from*/0.0f, /*to*/1.0f,
+                               /*duration*/0.1f, easing::linear);
+    const int construction_line = __LINE__ - 2;  // line of the macro call
+
+    for (int i = 0; i < 12; ++i) {
+        t.advance(1.0f / 60.0f);
+        t.publish("Card", "opacity");
+        cap.tick();
+    }
+
+    REQUIRE_FALSE(cap.events().empty());
+    const auto& first = cap.events().front();
+    REQUIRE(first.provenance.source_kind == "tween");
+    REQUIRE(first.provenance.source_id == "hover-glow");
+    // `source_file` should end with this test file's name and the line
+    // should point at (or very near) the macro invocation.
+    REQUIRE(first.provenance.source_file.find("test_motion_provenance.cpp")
+            != std::string::npos);
+    // Allow ±2 since the macro lambda expansion can shift the line by
+    // one when source_location is taken inside a default argument.
+    REQUIRE(first.provenance.source_line >= construction_line - 1);
+    REQUIRE(first.provenance.source_line <= construction_line + 2);
+}
+
+// ── AnimatorSetBuilder::name() ──────────────────────────────────────────
+
+TEST_CASE("AnimatorSetBuilder::name() propagates as motion provenance",
+          "[motion][provenance][animator-set][issue-pulp-motion-phase9]") {
+    MotionCapture cap;
+
+    float captured = 0.0f;
+    auto runner = AnimatorSetBuilder()
+                      .name("knob-glow")
+                      .then(0.0f, 1.0f, 0.1f,
+                            [&](float v) { captured = v; }, easing::linear)
+                      .build_runner();
+
+    // Advance until done, publishing each step's current scalar.
+    for (int i = 0; i < 20; ++i) {
+        runner.advance(1.0f / 60.0f);
+        runner.publish("Card", "opacity", static_cast<double>(captured));
+        cap.tick();
+        if (runner.finished()) break;
+    }
+
+    REQUIRE_FALSE(cap.events().empty());
+    const SampleEvent* e = find_event_by_kind(cap.events(), "animator-set");
+    REQUIRE(e != nullptr);
+    REQUIRE(e->provenance.source_id == "knob-glow");
+}
+
+// ── CSS TransitionSpec source attribution ───────────────────────────────
+
+TEST_CASE("parse_transition_shorthand_with_provenance carries file/line",
+          "[motion][provenance][css-transition][issue-pulp-motion-phase9]") {
+    auto specs = parse_transition_shorthand_with_provenance(
+        "opacity 200ms ease, transform 300ms ease-in 100ms",
+        "/styles/card.css", 17);
+    REQUIRE(specs.size() == 2);
+    for (const auto& s : specs) {
+        REQUIRE(s.source_file == "/styles/card.css");
+        REQUIRE(s.source_line == 17);
+    }
+    REQUIRE(specs[0].property_name == "opacity");
+    REQUIRE(specs[1].property_name == "transform");
+}
+
+TEST_CASE("CssAnimation publish stamps css-transition provenance",
+          "[motion][provenance][css-transition][issue-pulp-motion-phase9]") {
+    MotionCapture cap;
+
+    auto specs = parse_transition_shorthand_with_provenance(
+        "opacity 100ms linear", "/styles/card.css", 42);
+    REQUIRE(specs.size() == 1);
+
+    CssAnimation anim;
+    anim.spec = specs[0];
+    anim.property = specs[0].property;
+    anim.start_value = 0.0f;
+    anim.end_value = 1.0f;
+
+    for (int i = 0; i < 12 && anim.active; ++i) {
+        anim.tick(1.0f / 60.0f);
+        anim.publish("Card", "opacity");
+        cap.tick();
+    }
+
+    REQUIRE_FALSE(cap.events().empty());
+    const SampleEvent* e = find_event_by_kind(cap.events(), "css-transition");
+    REQUIRE(e != nullptr);
+    REQUIRE(e->provenance.source_id == "opacity");
+    REQUIRE(e->provenance.source_file == "/styles/card.css");
+    REQUIRE(e->provenance.source_line == 42);
+}
+
+// ── Ambient provenance (rAF / design-import substrate) ──────────────────
+
+TEST_CASE("Ambient provenance fills in when PublishOptions::provenance empty",
+          "[motion][provenance][ambient][issue-pulp-motion-phase9]") {
+    MotionCapture cap;
+
+    Provenance p;
+    p.source_kind = "rAF";
+    p.source_id = "my-script.js:7";
+    set_ambient_provenance(p);
+
+    publish_value("Card", "opacity", 0.0);
+    cap.tick();
+    publish_value("Card", "opacity", 0.5);
+    cap.tick();
+    publish_value("Card", "opacity", 1.0);
+    cap.tick();
+
+    clear_ambient_provenance();
+
+    REQUIRE_FALSE(cap.events().empty());
+    for (const auto& e : cap.events()) {
+        REQUIRE(e.provenance.source_kind == "rAF");
+        REQUIRE(e.provenance.source_id == "my-script.js:7");
+    }
+}
+
+TEST_CASE("Design-import provenance round-trips through publish channel",
+          "[motion][provenance][design-import][issue-pulp-motion-phase9]") {
+    MotionCapture cap;
+
+    // Simulate a generated JS bundle calling motion.set_provenance(...)
+    // by setting the ambient slot, then making publish calls — exactly
+    // what `motion.publishValue` will do under the hood once the JS
+    // bridge surface is exposed.
+    Provenance p;
+    p.source_kind = "design-import";
+    p.source_id = "figma:Card/Hover";
+    set_ambient_provenance(p);
+
+    publish_value("Card", "opacity", 0.0);
+    cap.tick();
+    publish_value("Card", "opacity", 0.5);
+    cap.tick();
+    publish_value("Card", "opacity", 1.0);
+    cap.tick();
+
+    clear_ambient_provenance();
+
+    // The current_ambient_provenance() round-trip itself.
+    REQUIRE(current_ambient_provenance().source_kind.empty());
+
+    REQUIRE_FALSE(cap.events().empty());
+    const SampleEvent* e = find_event_by_kind(cap.events(), "design-import");
+    REQUIRE(e != nullptr);
+    REQUIRE(e->provenance.source_id == "figma:Card/Hover");
+}
+
+// ── WidgetBridge::load_script(code, script_id) + JS motion bindings ───
+
+TEST_CASE("WidgetBridge load_script(code, script_id) tags rAF publishes",
+          "[motion][provenance][widget-bridge][raf][issue-pulp-motion-phase9]") {
+    MotionCapture cap;
+
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    pulp::state::StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    REQUIRE(bridge.active_script_id().empty());
+
+    // Script schedules an rAF that publishes a value. The bridge should
+    // stamp the emitted event with source_kind="rAF" and source_id
+    // "<script_id>:<callback_id>".
+    bridge.load_script(
+        "var __raf_published__ = false;"
+        "requestAnimationFrame(function() {"
+        "  motion.publishValue('Card', 'opacity', 0.5);"
+        "  __raf_published__ = true;"
+        "});",
+        "my-script.js");
+
+    REQUIRE(bridge.active_script_id() == "my-script.js");
+
+    // Drain pending rAF callbacks. load_script's flush_frames invocation
+    // already does this — but we also issue another flush so the test is
+    // robust regardless of internal ordering.
+    bridge.service_frame_callbacks();
+
+    REQUIRE_FALSE(cap.events().empty());
+    const SampleEvent* e = find_event_by_kind(cap.events(), "rAF");
+    REQUIRE(e != nullptr);
+    // source_id format is "<script_id>:<callback_id>" — we don't pin the
+    // exact callback_id (it depends on JS-side allocator state), only
+    // that it starts with the script id and a colon.
+    REQUIRE(e->provenance.source_id.rfind("my-script.js:", 0) == 0);
+}
+
+TEST_CASE("motion.setProvenance + motion.publishValue round-trip from JS",
+          "[motion][provenance][widget-bridge][js][design-import][issue-pulp-motion-phase9]") {
+    MotionCapture cap;
+
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    pulp::state::StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Simulate a design-import emitted bundle that tags its animation
+    // with the vendor + node id before publishing.
+    bridge.load_script(
+        "motion.setProvenance('design-import', 'figma:Card/Hover');"
+        "motion.publishValue('Card', 'opacity', 0.0);"
+        "motion.publishValue('Card', 'opacity', 0.5);"
+        "motion.publishValue('Card', 'opacity', 1.0);"
+        "motion.clearProvenance();");
+
+    cap.tick();
+
+    REQUIRE_FALSE(cap.events().empty());
+    const SampleEvent* e = find_event_by_kind(cap.events(), "design-import");
+    REQUIRE(e != nullptr);
+    REQUIRE(e->provenance.source_id == "figma:Card/Hover");
+
+    // motion.clearProvenance must have actually cleared the ambient slot
+    // so a follow-up publish doesn't inherit the stale envelope.
+    REQUIRE(current_ambient_provenance().source_kind.empty());
+}
+
+// ── Backwards compat: pre-Phase-9 publishes still work unchanged ────────
+
+TEST_CASE("Publishes without provenance still emit (backwards compatible)",
+          "[motion][provenance][backcompat][issue-pulp-motion-phase9]") {
+    MotionCapture cap;
+
+    PublishOptions po{};  // empty provenance
+    publish_value("Card", "opacity", 0.0, po);
+    cap.tick();
+    publish_value("Card", "opacity", 1.0, po);
+    cap.tick();
+
+    REQUIRE_FALSE(cap.events().empty());
+    for (const auto& e : cap.events()) {
+        REQUIRE_FALSE(e.provenance.is_set());
+    }
+}

--- a/test/test_motion_scrubber.cpp
+++ b/test/test_motion_scrubber.cpp
@@ -48,8 +48,15 @@ using pulp::view::motion::publish_value;
 namespace {
 
 std::string tmp_fixture_path(const std::string& tag) {
+#if defined(_WIN32)
+    const char* tmpdir = std::getenv("TMP");
+    if (!tmpdir) tmpdir = std::getenv("TEMP");
+    if (!tmpdir) tmpdir = ".";
+#else
+    const char* tmpdir = "/tmp";
+#endif
     std::ostringstream ss;
-    ss << "/tmp/pulp-motion-scrubber-" << tag << "-"
+    ss << tmpdir << "/pulp-motion-scrubber-" << tag << "-"
        << pulp_test_getpid() << "-"
        << std::rand() << ".jsonl";
     return ss.str();

--- a/test/test_motion_scrubber.cpp
+++ b/test/test_motion_scrubber.cpp
@@ -204,6 +204,87 @@ TEST_CASE("MotionScrubber scrub_to / play are no-ops when no fixture loaded",
     REQUIRE(scrub.play() == 0u);
 }
 
+// ── Bug-sweep regressions (pre-merge sweep #2142) ────────────────────
+
+// Re-emission used to drop SampleEvent::Kind::Input entirely — the
+// switch fell through to "?", the method routed to kMotionSample, and
+// input_kind / view_id were not serialized at all. Phase 10 fixtures
+// stayed silent on scrub.
+TEST_CASE("MotionScrubber re-emits Phase 10 Input events with input_kind + view_id",
+          "[motion-scrubber][bug-sweep]") {
+    FrameClock clock;
+    const auto path = tmp_fixture_path("input-replay");
+
+    // Record a fixture containing an Input event.
+    Coordinator::instance().reset();
+    Coordinator::instance().bind(clock);
+    Coordinator::instance().set_tracing_enabled(true);
+    const int sink_id = Coordinator::instance().add_sink(make_fixture_sink(path));
+
+    SampleEvent input;
+    input.kind = SampleEvent::Kind::Input;
+    input.view_name = "Knob";
+    input.metric_name = "interaction";
+    input.input_kind = "click";
+    input.view_id = "knob-7";
+    Coordinator::instance().dispatch_input_event(input);
+    clock.tick(1.0 / 60.0);
+
+    Coordinator::instance().remove_sink(sink_id);
+    Coordinator::instance().reset();
+
+    MotionScrubber scrub;
+    REQUIRE(scrub.load_fixture(path));
+
+    std::vector<SampleEvent> buf;
+    scrub.add_sink(make_buffer_sink(&buf));
+    REQUIRE(scrub.play() > 0u);
+
+    bool found_input = false;
+    for (const auto& e : buf) {
+        if (e.kind == SampleEvent::Kind::Input) {
+            found_input = true;
+            REQUIRE(e.input_kind == "click");
+            REQUIRE(e.view_id == "knob-7");
+        }
+    }
+    REQUIRE(found_input);
+
+    std::remove(path.c_str());
+}
+
+// emit_prefix_locked used to fire sinks (and broadcast through the
+// inspector server) while holding mtx_. A sink that re-entered any
+// MotionScrubber accessor self-deadlocked. The fix is dispatch-outside-
+// lock via dispatch_snapshot(); this test pins that property.
+TEST_CASE("MotionScrubber sink may re-enter scrubber accessors during scrub",
+          "[motion-scrubber][bug-sweep]") {
+    FrameClock clock;
+    const auto path = record_sample_fixture("reentrant", clock);
+
+    MotionScrubber scrub;
+    REQUIRE(scrub.load_fixture(path));
+
+    // Sink that calls back into the scrubber on every event. Under
+    // the old design, this deadlocked on the second event because
+    // event_count() / playhead_frame() / playing() / loaded() all
+    // acquire mtx_, which scrub_to was still holding.
+    std::size_t reentrant_calls = 0;
+    scrub.add_sink([&scrub, &reentrant_calls](const SampleEvent&) {
+        (void)scrub.event_count();
+        (void)scrub.playhead_frame();
+        (void)scrub.playing();
+        (void)scrub.loaded();
+        ++reentrant_calls;
+    });
+
+    const std::size_t emitted = scrub.scrub_to(scrub.max_frame());
+    REQUIRE(emitted > 0);
+    REQUIRE(reentrant_calls == emitted);
+
+    std::remove(path.c_str());
+}
+
 // ── DomainHandler protocol roundtrip ─────────────────────────────────
 
 TEST_CASE("DomainHandler routes Motion.loadFixture + scrubTo to MotionScrubber",

--- a/test/test_motion_scrubber.cpp
+++ b/test/test_motion_scrubber.cpp
@@ -19,6 +19,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
@@ -312,9 +313,13 @@ TEST_CASE("DomainHandler routes Motion.loadFixture + scrubTo to MotionScrubber",
     std::vector<SampleEvent> wire_events;
     scrub.add_sink(make_buffer_sink(&wire_events));
 
-    // Motion.loadFixture
+    // Motion.loadFixture — on Windows the path uses backslashes which
+    // are invalid JSON unless escaped; the host's path functions accept
+    // forward slashes too, so substitute for the wire payload.
+    std::string wire_path = path;
+    std::replace(wire_path.begin(), wire_path.end(), '\\', '/');
     std::ostringstream load_params;
-    load_params << "{\"path\":\"" << path << "\"}";
+    load_params << "{\"path\":\"" << wire_path << "\"}";
     auto load_resp = dh.handle(make_request(1, "Motion.loadFixture",
                                             load_params.str()));
     REQUIRE_FALSE(load_resp.is_error);

--- a/test/test_motion_scrubber.cpp
+++ b/test/test_motion_scrubber.cpp
@@ -25,7 +25,13 @@
 #include <set>
 #include <sstream>
 #include <string>
+#if defined(_WIN32)
+#include <process.h>
+#define pulp_test_getpid() static_cast<long>(::_getpid())
+#else
 #include <unistd.h>
+#define pulp_test_getpid() static_cast<long>(::getpid())
+#endif
 #include <vector>
 
 using pulp::inspect::DomainHandler;
@@ -44,7 +50,7 @@ namespace {
 std::string tmp_fixture_path(const std::string& tag) {
     std::ostringstream ss;
     ss << "/tmp/pulp-motion-scrubber-" << tag << "-"
-       << static_cast<long>(::getpid()) << "-"
+       << pulp_test_getpid() << "-"
        << std::rand() << ".jsonl";
     return ss.str();
 }

--- a/test/test_motion_scrubber.cpp
+++ b/test/test_motion_scrubber.cpp
@@ -1,0 +1,300 @@
+/// @file test_motion_scrubber.cpp
+/// Catch2 tests for pulp::inspect::MotionScrubber.
+///
+/// Coverage:
+///   * load_fixture / scrub_to playhead semantics over a real
+///     recorded fixture (forward + backward scrubs both re-emit
+///     the correct prefix);
+///   * play() jumps to max frame and emits every event;
+///   * DomainHandler protocol roundtrip for Motion.loadFixture +
+///     Motion.scrubTo + Motion.play + Motion.pause.
+
+#include <pulp/inspect/domain_handler.hpp>
+#include <pulp/inspect/motion_scrubber.hpp>
+#include <pulp/inspect/protocol.hpp>
+#include <pulp/view/frame_clock.hpp>
+#include <pulp/view/motion.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+using pulp::inspect::DomainHandler;
+using pulp::inspect::InspectorMessage;
+using pulp::inspect::MotionScrubber;
+using pulp::inspect::make_request;
+using pulp::view::FrameClock;
+using pulp::view::motion::Coordinator;
+using pulp::view::motion::SampleEvent;
+using pulp::view::motion::make_buffer_sink;
+using pulp::view::motion::make_fixture_sink;
+using pulp::view::motion::publish_value;
+
+namespace {
+
+std::string tmp_fixture_path(const std::string& tag) {
+    std::ostringstream ss;
+    ss << "/tmp/pulp-motion-scrubber-" << tag << "-"
+       << static_cast<long>(::getpid()) << "-"
+       << std::rand() << ".jsonl";
+    return ss.str();
+}
+
+/// Write a fixture with a non-trivial frame range. Returns the file
+/// path; the caller is responsible for deleting it.
+std::string record_sample_fixture(const std::string& tag, FrameClock& clock) {
+    const auto path = tmp_fixture_path(tag);
+    Coordinator::instance().reset();
+    Coordinator::instance().bind(clock);
+    Coordinator::instance().set_tracing_enabled(true);
+    Coordinator::instance().set_firehose(true);
+    const int sink_id = Coordinator::instance().add_sink(make_fixture_sink(path));
+
+    // Stage frame 0: baseline publish.
+    publish_value("Card", "opacity", 0.0);
+    clock.tick(1.0 / 60.0);
+
+    // Stage frame 1: change → Start + Sample at frame 1.
+    publish_value("Card", "opacity", 0.5);
+    clock.tick(1.0 / 60.0);
+
+    // Stage frame 2: continued change → Sample at frame 2.
+    publish_value("Card", "opacity", 0.75);
+    clock.tick(1.0 / 60.0);
+
+    // Stage frame 3: stable → End at frame 3.
+    publish_value("Card", "opacity", 0.75);
+    clock.tick(1.0 / 60.0);
+    publish_value("Card", "opacity", 0.75);
+
+    Coordinator::instance().remove_sink(sink_id);
+    Coordinator::instance().reset();
+    return path;
+}
+
+}  // namespace
+
+// ── load_fixture populates the scrubber but emits nothing yet ─────────
+
+TEST_CASE("MotionScrubber load_fixture is passive — no events until scrub",
+          "[motion-scrubber]") {
+    FrameClock clock;
+    const auto path = record_sample_fixture("passive", clock);
+
+    MotionScrubber scrub;
+    std::vector<SampleEvent> sink_events;
+    scrub.add_sink(make_buffer_sink(&sink_events));
+
+    REQUIRE(scrub.load_fixture(path));
+    REQUIRE(scrub.loaded());
+    REQUIRE(scrub.event_count() > 0);
+    REQUIRE(scrub.playhead_frame() == 0u);
+    REQUIRE_FALSE(scrub.playing());
+    REQUIRE(sink_events.empty());  // load is passive
+
+    std::remove(path.c_str());
+}
+
+// ── scrub_to(N) emits exactly the events with frame <= N ──────────────
+
+TEST_CASE("MotionScrubber scrub_to(N) re-emits prefix with frame <= N",
+          "[motion-scrubber]") {
+    FrameClock clock;
+    const auto path = record_sample_fixture("prefix", clock);
+
+    MotionScrubber scrub;
+    REQUIRE(scrub.load_fixture(path));
+
+    // Sanity: the recorded fixture covers at least frames 0..3.
+    REQUIRE(scrub.max_frame() >= 3u);
+
+    // Expected prefix counts based on the recorded fixture.
+    auto golden = pulp::view::motion::load_fixture(path);
+    auto expected_count_le = [&](std::uint64_t f) {
+        std::size_t n = 0;
+        for (const auto& e : golden) {
+            if (e.frame <= f) ++n;
+        }
+        return n;
+    };
+
+    // Scrub to frame 1.
+    {
+        std::vector<SampleEvent> buf;
+        int id = scrub.add_sink(make_buffer_sink(&buf));
+        const std::size_t emitted = scrub.scrub_to(1);
+        REQUIRE(emitted == expected_count_le(1));
+        REQUIRE(buf.size() == expected_count_le(1));
+        for (const auto& e : buf) REQUIRE(e.frame <= 1u);
+        REQUIRE(scrub.playhead_frame() == 1u);
+        scrub.remove_sink(id);
+    }
+
+    // Scrub forward to a higher frame — sink gets a larger prefix.
+    {
+        std::vector<SampleEvent> buf;
+        int id = scrub.add_sink(make_buffer_sink(&buf));
+        const std::size_t emitted = scrub.scrub_to(3);
+        REQUIRE(emitted == expected_count_le(3));
+        REQUIRE(buf.size() == expected_count_le(3));
+        for (const auto& e : buf) REQUIRE(e.frame <= 3u);
+        REQUIRE(scrub.playhead_frame() == 3u);
+        scrub.remove_sink(id);
+    }
+
+    // Scrub backwards to frame 0 — sink gets only the baseline prefix.
+    {
+        std::vector<SampleEvent> buf;
+        int id = scrub.add_sink(make_buffer_sink(&buf));
+        const std::size_t emitted = scrub.scrub_to(0);
+        REQUIRE(emitted == expected_count_le(0));
+        REQUIRE(buf.size() == expected_count_le(0));
+        for (const auto& e : buf) REQUIRE(e.frame == 0u);
+        REQUIRE(scrub.playhead_frame() == 0u);
+        // The prefix at frame 0 must be strictly smaller than the
+        // prefix at frame 3 — backwards scrub is observable.
+        REQUIRE(buf.size() < expected_count_le(3));
+        scrub.remove_sink(id);
+    }
+
+    std::remove(path.c_str());
+}
+
+// ── play() jumps to the max frame and emits every event ───────────────
+
+TEST_CASE("MotionScrubber play() emits every loaded event",
+          "[motion-scrubber]") {
+    FrameClock clock;
+    const auto path = record_sample_fixture("play", clock);
+
+    MotionScrubber scrub;
+    REQUIRE(scrub.load_fixture(path));
+
+    std::vector<SampleEvent> buf;
+    scrub.add_sink(make_buffer_sink(&buf));
+
+    const std::size_t emitted = scrub.play();
+    REQUIRE(scrub.playing());
+    REQUIRE(emitted == scrub.event_count());
+    REQUIRE(buf.size() == scrub.event_count());
+    REQUIRE(scrub.playhead_frame() == scrub.max_frame());
+
+    scrub.pause();
+    REQUIRE_FALSE(scrub.playing());
+
+    std::remove(path.c_str());
+}
+
+// ── Unloaded scrubber rejects scrub / play gracefully ────────────────
+
+TEST_CASE("MotionScrubber scrub_to / play are no-ops when no fixture loaded",
+          "[motion-scrubber]") {
+    MotionScrubber scrub;
+    REQUIRE_FALSE(scrub.loaded());
+    REQUIRE(scrub.scrub_to(10) == 0u);
+    REQUIRE(scrub.play() == 0u);
+}
+
+// ── DomainHandler protocol roundtrip ─────────────────────────────────
+
+TEST_CASE("DomainHandler routes Motion.loadFixture + scrubTo to MotionScrubber",
+          "[motion-scrubber][protocol]") {
+    FrameClock clock;
+    const auto path = record_sample_fixture("proto", clock);
+
+    MotionScrubber scrub;
+    DomainHandler dh;
+    dh.set_motion_scrubber(&scrub);
+
+    std::vector<SampleEvent> wire_events;
+    scrub.add_sink(make_buffer_sink(&wire_events));
+
+    // Motion.loadFixture
+    std::ostringstream load_params;
+    load_params << "{\"path\":\"" << path << "\"}";
+    auto load_resp = dh.handle(make_request(1, "Motion.loadFixture",
+                                            load_params.str()));
+    REQUIRE_FALSE(load_resp.is_error);
+    auto load_body = choc::json::parse(load_resp.params_json);
+    REQUIRE(load_body["ok"].getBool() == true);
+    REQUIRE(load_body["event_count"].getInt64() > 0);
+    REQUIRE(load_body["max_frame"].getInt64() >= 3);
+    REQUIRE(load_body.hasObjectMember("header"));
+    REQUIRE(load_body["header"]["version"].getInt64() ==
+            pulp::view::motion::kFixtureSchemaVersion);
+
+    // Motion.scrubTo frame 2
+    auto scrub_resp = dh.handle(make_request(2, "Motion.scrubTo",
+                                             "{\"frame\":2}"));
+    REQUIRE_FALSE(scrub_resp.is_error);
+    auto scrub_body = choc::json::parse(scrub_resp.params_json);
+    REQUIRE(scrub_body["playhead_frame"].getInt64() == 2);
+    const auto emitted = scrub_body["emitted_count"].getInt64();
+    REQUIRE(emitted > 0);
+    REQUIRE(static_cast<std::int64_t>(wire_events.size()) == emitted);
+    for (const auto& e : wire_events) REQUIRE(e.frame <= 2u);
+
+    // Motion.play
+    wire_events.clear();
+    auto play_resp = dh.handle(make_request(3, "Motion.play", "{}"));
+    REQUIRE_FALSE(play_resp.is_error);
+    auto play_body = choc::json::parse(play_resp.params_json);
+    REQUIRE(play_body["playing"].getBool() == true);
+    REQUIRE(static_cast<std::int64_t>(wire_events.size()) ==
+            play_body["emitted_count"].getInt64());
+    REQUIRE(scrub.playhead_frame() == scrub.max_frame());
+
+    // Motion.pause
+    auto pause_resp = dh.handle(make_request(4, "Motion.pause", "{}"));
+    REQUIRE_FALSE(pause_resp.is_error);
+    auto pause_body = choc::json::parse(pause_resp.params_json);
+    REQUIRE(pause_body["playing"].getBool() == false);
+
+    std::remove(path.c_str());
+}
+
+// ── Missing scrubber returns a targeted error ────────────────────────
+
+TEST_CASE("DomainHandler errors on scrubber methods without a scrubber attached",
+          "[motion-scrubber][protocol]") {
+    DomainHandler dh;
+    auto resp = dh.handle(make_request(1, "Motion.scrubTo", "{\"frame\":0}"));
+    REQUIRE(resp.is_error);
+    REQUIRE(resp.params_json.find("scrubber") != std::string::npos);
+}
+
+// ── scrubTo with no fixture loaded surfaces a usable error ──────────
+
+TEST_CASE("Motion.scrubTo errors when no fixture is loaded",
+          "[motion-scrubber][protocol]") {
+    MotionScrubber scrub;
+    DomainHandler dh;
+    dh.set_motion_scrubber(&scrub);
+    auto resp = dh.handle(make_request(1, "Motion.scrubTo", "{\"frame\":0}"));
+    REQUIRE(resp.is_error);
+}
+
+// ── Existing MotionInspector methods still flow when scrubber present ─
+
+TEST_CASE("Non-scrubber Motion.* methods still route to MotionInspector",
+          "[motion-scrubber][protocol]") {
+    // No MotionInspector attached, only a scrubber. The dispatcher
+    // must NOT consume Motion.startTrace into the scrubber — it should
+    // surface the "No motion inspector attached" error.
+    MotionScrubber scrub;
+    DomainHandler dh;
+    dh.set_motion_scrubber(&scrub);
+    auto resp = dh.handle(make_request(1, "Motion.startTrace",
+                                       R"({"view_name":"X","fps":60,"metrics":[]})"));
+    REQUIRE(resp.is_error);
+    REQUIRE(resp.params_json.find("motion inspector") != std::string::npos);
+}

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -163,8 +163,11 @@
       "paths": [
         "core/view/include/pulp/view/motion.hpp",
         "core/view/include/pulp/view/motion_preferences.hpp",
+        "core/view/include/pulp/view/motion_cost.hpp",
+        "core/view/include/pulp/view/motion_cost_render.hpp",
         "core/view/src/motion.cpp",
         "core/view/src/motion_preferences.cpp",
+        "core/view/src/motion_cost.cpp",
         "core/view/platform/mac/motion_preferences_mac.mm",
         "core/view/platform/win/motion_preferences_win.cpp",
         "inspect/include/pulp/inspect/motion_inspector.hpp",

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -169,6 +169,8 @@
         "core/view/platform/win/motion_preferences_win.cpp",
         "inspect/include/pulp/inspect/motion_inspector.hpp",
         "inspect/src/motion_inspector.cpp",
+        "inspect/include/pulp/inspect/motion_scrubber.hpp",
+        "inspect/src/motion_scrubber.cpp",
         "tools/motion/**"
       ]
     },

--- a/tools/scripts/skill_path_map.json
+++ b/tools/scripts/skill_path_map.json
@@ -162,7 +162,11 @@
     "motion": {
       "paths": [
         "core/view/include/pulp/view/motion.hpp",
+        "core/view/include/pulp/view/motion_preferences.hpp",
         "core/view/src/motion.cpp",
+        "core/view/src/motion_preferences.cpp",
+        "core/view/platform/mac/motion_preferences_mac.mm",
+        "core/view/platform/win/motion_preferences_win.cpp",
         "inspect/include/pulp/inspect/motion_inspector.hpp",
         "inspect/src/motion_inspector.cpp",
         "tools/motion/**"


### PR DESCRIPTION
Follow-up to PR #2136 (Phases 0-7). Adds reduced-motion policy, provenance adapters, input recording + replay, timeline scrubber, and motion cost attribution.

**Phase 8** — `pulp::view::MotionPreferences` + `MotionPolicy {Full,Reduced,Off}` + macOS/Windows platform readers. `Tween` / `ValueAnimation` / `CssAnimation` / `AnimatorSet` honor the policy on start. Fixture header records the policy. 25 tests / 69 assertions.

**Phase 9** — `PULP_MOTION_TWEEN` macro with `std::source_location`; `AnimatorSetBuilder::name()`; CSS `TransitionSpec` source-file/line; `WidgetBridge::load_script(id)` + JS `globalThis.motion` + rAF auto-provenance; design-import `motion.setProvenance` codegen. 10 tests / 81 assertions.

**Phase 10** — `SampleEvent::Kind::Input` + `make_input_recorder` + `replay_inputs` end-to-end record/replay parity. 4 tests / 42 assertions.

**Timeline scrubber** — `MotionScrubber` + `Inspector.Motion.{loadFixture,scrubTo,play,pause}`. 8 tests / 61 assertions.

**Motion cost attribution** — `CostSample` + `CostAttributor` + `make_render_cost_probe(RenderPassManager, DirtyTracker)` + `Motion.enableCost/cost` protocol. CostSample carries `active_trace_ids` + `active_provenance`. 10 tests / 52 assertions.

All five additions off-by-default. Same fixture schema v2 as #2136. 115 cases / 604 assertions across 8 motion binaries, all green locally.