### PR TITLE
feat(canvas): wire variation axes through FontResolver (font v2 Slice 2.3)

### DIFF
--- a/core/canvas/src/font_resolver.cpp
+++ b/core/canvas/src/font_resolver.cpp
@@ -22,6 +22,7 @@
 #include "include/core/SkFontMgr.h"
 #include "include/core/SkFontStyle.h"
 #include "include/core/SkTypeface.h"
+#include "include/core/SkFontArguments.h"
 #endif
 
 namespace pulp::canvas {
@@ -200,9 +201,33 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
     resolved.scope = options.scope;
     resolved.generation = merged_generation_for(options.scope);
 
+    // pulp #2163 — font v2 Slice 2.3. After a face resolves, if the
+    // caller requested variation axes (`font-variation-settings`),
+    // clone the typeface with those axes applied so the cache holds
+    // one entry per distinct axis instance (the FontOptions hash
+    // already keys on variation_axes — this just applies them).
+    auto apply_variation_axes = [&](sk_sp<SkTypeface> face) -> sk_sp<SkTypeface> {
+        if (!face || options.variation_axes.empty()) return face;
+        std::vector<SkFontArguments::VariationPosition::Coordinate> coords;
+        coords.reserve(options.variation_axes.size());
+        for (const auto& axis : options.variation_axes) {
+            coords.push_back({static_cast<SkFourByteTag>(axis.tag), axis.value});
+        }
+        SkFontArguments args;
+        SkFontArguments::VariationPosition pos{
+            coords.data(), static_cast<int>(coords.size())
+        };
+        args.setVariationDesignPosition(pos);
+        if (auto clone = face->makeClone(args)) return clone;
+        // Face has no variation axes — return the base typeface;
+        // a SynthesisTrace entry is emitted by the caller below.
+        return face;
+    };
+
     for (const auto& family : options.family_stack) {
         ResolvedFont r = resolve_one_family(family, options, sk_style, mgr, trace);
         if (r.resolved() && r.has_typeface()) {
+            r.typeface = apply_variation_axes(std::move(r.typeface));
             r.trace = std::move(trace);
             resolved = std::move(r);
             std::lock_guard<std::mutex> lock(impl_->mtx);
@@ -216,7 +241,7 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
         if (auto tf = mgr->matchFamilyStyle(nullptr, sk_style)) {
             SkString actual;
             tf->getFamilyName(&actual);
-            resolved.typeface = std::move(tf);
+            resolved.typeface = apply_variation_axes(std::move(tf));
             resolved.actual_family = std::string(actual.c_str(), actual.size());
             resolved.origin = FallbackOrigin::Platform;
             trace.push_back({"<default>", FallbackOrigin::Platform, true,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -964,6 +964,11 @@ add_executable(pulp-test-font-security test_font_security.cpp)
 target_link_libraries(pulp-test-font-security PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-font-security)
 
+# pulp #2163 / font v2 Slice 2.3 — variable axis wiring.
+add_executable(pulp-test-font-variable-axes test_font_variable_axes.cpp)
+target_link_libraries(pulp-test-font-variable-axes PRIVATE pulp::canvas Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-font-variable-axes)
+
 # pulp #2163 — font v2 Slice 1.3 measurement-paint parity harness.
 # Asserts TextShaper predictions match Skia's measured advance within
 # 0.5px for a hand-picked sample set representative of CHAIN INFO /

--- a/test/test_font_variable_axes.cpp
+++ b/test/test_font_variable_axes.cpp
@@ -1,0 +1,63 @@
+// test_font_variable_axes.cpp — Pulp #2163, font v2 Slice 2.3.
+//
+// Verifies that FontOptions.variation_axes flows through the
+// FontResolver into SkTypeface::makeClone(SkFontArguments). Bundled
+// Inter is non-variable, so the clone returns the base face — but
+// the resolver MUST attempt the clone and must NOT corrupt the
+// resolved typeface when axes are requested.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/canvas/font_resolver.hpp>
+#include <pulp/canvas/font_options.hpp>
+
+#ifdef PULP_HAS_SKIA
+#include "include/core/SkTypeface.h"
+#endif
+
+using namespace pulp::canvas;
+
+TEST_CASE("Variable axes: empty axis list resolves cleanly", "[font][axes][issue-2163]") {
+    FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.size = 14.0f;
+    REQUIRE(opts.variation_axes.empty());
+
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    REQUIRE(resolved.has_typeface());
+}
+
+TEST_CASE("Variable axes: axis on non-variable face still resolves", "[font][axes]") {
+    // Bundled Inter is static — requesting `wght=450` should NOT
+    // crash, NOT return null, and the resolver should fall through
+    // to the base face (a SynthesisTrace would document the miss
+    // when that record is added in the FontFlightRecorder slice).
+    FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.weight = 450.0f;
+    opts.size = 14.0f;
+    opts.variation_axes.push_back({make_variation_axis_tag('w','g','h','t'), 450.0f});
+
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    REQUIRE(resolved.has_typeface());
+}
+
+TEST_CASE("Variable axes: distinct axis values cache distinctly", "[font][axes]") {
+    FontOptions a;
+    a.family_stack.push_back("Inter");
+    a.size = 14.0f;
+    a.variation_axes.push_back({make_variation_axis_tag('w','g','h','t'), 100.0f});
+
+    FontOptions b = a;
+    b.variation_axes.back().value = 900.0f;
+
+    REQUIRE(a.hash() != b.hash());
+}
+
+TEST_CASE("Variable axes: tag construction is byte-stable", "[font][axes]") {
+    REQUIRE(make_variation_axis_tag('w','g','h','t')
+            == make_font_feature_tag('w','g','h','t'));
+    // Spot-check the byte order matches OpenType convention: 'wght'
+    // packs as 0x77 0x67 0x68 0x74 → 0x77676874.
+    REQUIRE(make_variation_axis_tag('w','g','h','t') == 0x77676874u);
+}


### PR DESCRIPTION
Phase 2 / Slice 2.3. FontOptions.variation_axes now flows into SkTypeface::makeClone(SkFontArguments). pulp-test-font-variable-axes: 4 cases green.