### PR TITLE
feat(canvas): UAX #29-lite cluster_step (font v2 Slice 3.6)

### DIFF
--- a/core/canvas/src/font_registry_stubs.cpp
+++ b/core/canvas/src/font_registry_stubs.cpp
@@ -1,26 +1,215 @@
 // font_registry_stubs.cpp — non-Skia fallback for the public font-registration
-// API declared in `pulp/canvas/bundled_fonts.hpp` (pulp #1150).
+// API + Skia-independent helpers in `pulp/canvas/bundled_fonts.hpp` (pulp #1150).
 //
-// `bundled_fonts.cpp` is only compiled when `PULP_HAS_SKIA` is on, because it
-// pulls in the generated `pulp-bundled-fonts_data.hpp`, the platform font
-// manager headers, and `SkTypeface`. Plugin authors should still be able to
-// call `pulp::canvas::register_font(...)` from startup code without guarding
-// every call site, so this TU compiles unconditionally and provides
-// always-fail stubs that the linker picks when Skia is not linked in.
-//
-// Why a separate file?
-//   * Adding `bundled_fonts.cpp` to the always-compiled source list would
-//     drag the bundled-fonts header (and thus the pulp_add_binary_data
-//     pipeline) into non-GPU builds that have no need for it.
-//   * Defining the stubs inside `bundled_fonts.cpp` outside the Skia guard
-//     would still leave them un-compiled on non-Skia builds because the
-//     CMakeLists only adds bundled_fonts.cpp to `pulp-canvas` when
-//     `PULP_HAS_SKIA` is true.
-//
-// When Skia is on, `bundled_fonts.cpp` provides the real implementations and
-// this file is a no-op (the `#ifndef PULP_HAS_SKIA` guard skips the body).
+// pulp #2163 — font v2 Slice 3.6. `cluster_step` is a UAX #29-lite
+// walker over UTF-8 input, byte-encoding-only (no Skia / no platform
+// dependency). It compiles in BOTH Skia and non-Skia builds; the rest
+// of this TU (`register_font` family, `validate_font_bytes`,
+// `register_font_woff2`) stays under the `#ifndef PULP_HAS_SKIA` guard
+// since those are stubs replaced by the real impls in
+// `bundled_fonts.cpp` when Skia is linked.
 
 #include <pulp/canvas/bundled_fonts.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace pulp::canvas {
+
+namespace {
+
+// Read one UTF-8 scalar at `p` (returns codepoint + byte length).
+// Returns {0,1} on malformed input so the walker advances by 1 byte
+// rather than getting stuck — matches the leniency of the legacy
+// naive walker this replaces.
+struct Utf8Decoded { std::uint32_t cp; std::size_t bytes; };
+
+inline Utf8Decoded utf8_decode_at(const std::string& s, std::size_t i) noexcept {
+    if (i >= s.size()) return {0, 0};
+    unsigned char c = static_cast<unsigned char>(s[i]);
+    if (c < 0x80) return {c, 1};
+    if ((c & 0xE0) == 0xC0 && i + 1 < s.size()) {
+        return {static_cast<std::uint32_t>(((c & 0x1Fu) << 6)
+                                         | (static_cast<unsigned char>(s[i + 1]) & 0x3Fu)), 2};
+    }
+    if ((c & 0xF0) == 0xE0 && i + 2 < s.size()) {
+        return {static_cast<std::uint32_t>(((c & 0x0Fu) << 12)
+                                         | ((static_cast<unsigned char>(s[i + 1]) & 0x3Fu) << 6)
+                                         | (static_cast<unsigned char>(s[i + 2]) & 0x3Fu)), 3};
+    }
+    if ((c & 0xF8) == 0xF0 && i + 3 < s.size()) {
+        return {static_cast<std::uint32_t>(((c & 0x07u) << 18)
+                                         | ((static_cast<unsigned char>(s[i + 1]) & 0x3Fu) << 12)
+                                         | ((static_cast<unsigned char>(s[i + 2]) & 0x3Fu) << 6)
+                                         | (static_cast<unsigned char>(s[i + 3]) & 0x3Fu)), 4};
+    }
+    return {0, 1};
+}
+
+// UAX #29-lite cluster joiners. A cluster_step starting on a base
+// codepoint absorbs any of these "extend" codepoints that follow:
+//   * Combining marks (U+0300..U+036F, U+1AB0..U+1AFF, U+1DC0..U+1DFF,
+//     U+20D0..U+20FF, U+FE20..U+FE2F) — Latin / IPA / generic
+//   * Variation selectors (U+FE00..U+FE0F, U+E0100..U+E01EF) — emoji
+//     presentation switches
+//   * Devanagari/Indic virama signs (U+094D, U+09CD, U+0A4D, U+0ACD,
+//     U+0B4D, U+0BCD, U+0C4D, U+0CCD, U+0D4D, U+0DCA) — explicit
+//     conjunct formers
+//   * Zero-Width Joiner (U+200D) — emoji ZWJ sequences
+//   * Emoji modifiers / skin-tone (U+1F3FB..U+1F3FF)
+//   * Hangul T (trailing) jamo (U+11A8..U+11FF, U+D7CB..U+D7FB)
+inline bool is_cluster_extend(std::uint32_t cp) noexcept {
+    if (cp >= 0x0300 && cp <= 0x036F) return true;
+    if (cp >= 0x1AB0 && cp <= 0x1AFF) return true;
+    if (cp >= 0x1DC0 && cp <= 0x1DFF) return true;
+    if (cp >= 0x20D0 && cp <= 0x20FF) return true;
+    if (cp >= 0xFE00 && cp <= 0xFE0F) return true;
+    if (cp >= 0xFE20 && cp <= 0xFE2F) return true;
+    if (cp == 0x200D)                  return true;  // ZWJ
+    if (cp == 0x094D || cp == 0x09CD || cp == 0x0A4D || cp == 0x0ACD ||
+        cp == 0x0B4D || cp == 0x0BCD || cp == 0x0C4D || cp == 0x0CCD ||
+        cp == 0x0D4D || cp == 0x0DCA) return true;
+    if (cp >= 0x1F3FB && cp <= 0x1F3FF) return true;  // skin tone
+    if (cp >= 0xE0100 && cp <= 0xE01EF) return true;  // variation selectors
+    if (cp >= 0x11A8  && cp <= 0x11FF)  return true;  // Hangul T jamo
+    if (cp >= 0xD7CB  && cp <= 0xD7FB)  return true;  // Hangul T jamo extended
+    return false;
+}
+
+// Regional indicator symbols (RI), used to form flag clusters as
+// PAIRS. Two consecutive RIs collapse to one cluster; a third RI
+// starts a new pair.
+inline bool is_regional_indicator(std::uint32_t cp) noexcept {
+    return cp >= 0x1F1E6 && cp <= 0x1F1FF;
+}
+
+// Pre-ZWJ extension: when the current codepoint follows a ZWJ, the
+// pair joins regardless of category. This lets ZWJ-joined emoji
+// sequences collapse into one cluster even when the post-ZWJ glyph
+// isn't itself an extender.
+inline bool joins_after_zwj(std::uint32_t cp) noexcept {
+    // Pictographic-ish ranges that are commonly ZWJ targets. Not a
+    // full Unicode `Extended_Pictographic` table; covers BMP symbols
+    // + emoji-block codepoints which is the practical 95% case for
+    // the corpus this slice targets.
+    if (cp >= 0x261D  && cp <= 0x270D)  return true;  // misc dingbats
+    if (cp >= 0x2600  && cp <= 0x26FF)  return true;  // misc symbols
+    if (cp >= 0x2700  && cp <= 0x27BF)  return true;  // dingbats
+    if (cp >= 0x1F300 && cp <= 0x1F9FF) return true;  // emoji blocks
+    if (cp >= 0x1FA70 && cp <= 0x1FAFF) return true;  // symbols + pictographs extended
+    return false;
+}
+
+inline std::size_t skip_utf8_back_to_lead(const std::string& s, std::size_t i) noexcept {
+    while (i > 0 && (static_cast<unsigned char>(s[i]) & 0xC0) == 0x80) --i;
+    return i;
+}
+
+} // namespace
+
+// Indic virama codepoints — explicit conjunct formers. A virama
+// chains the NEXT consonant into the same cluster (different from
+// ordinary extenders which only attach themselves).
+inline bool is_virama(std::uint32_t cp) noexcept {
+    return cp == 0x094D || cp == 0x09CD || cp == 0x0A4D || cp == 0x0ACD
+        || cp == 0x0B4D || cp == 0x0BCD || cp == 0x0C4D || cp == 0x0CCD
+        || cp == 0x0D4D || cp == 0x0DCA;
+}
+
+// Forward cluster boundary from `i` (which must be at a codepoint
+// start). Returns the byte offset of the next cluster boundary, or
+// `text.size()` if no further boundary exists.
+inline std::size_t cluster_boundary_after(const std::string& text, std::size_t i) noexcept {
+    if (i >= text.size()) return text.size();
+    Utf8Decoded base = utf8_decode_at(text, i);
+    if (base.bytes == 0) return text.size();
+    std::size_t cursor = i + base.bytes;
+
+    // Regional indicator pair: absorb exactly one partner if next is
+    // also RI; do not extend further (per UAX #29).
+    if (is_regional_indicator(base.cp)) {
+        if (cursor < text.size()) {
+            Utf8Decoded nxt = utf8_decode_at(text, cursor);
+            if (nxt.bytes && is_regional_indicator(nxt.cp)) {
+                cursor += nxt.bytes;
+            }
+        }
+        return cursor;
+    }
+
+    // General extension + ZWJ-joined + post-virama absorbing loop.
+    bool prev_was_zwj = false;
+    bool prev_was_virama = is_virama(base.cp);
+    while (cursor < text.size()) {
+        Utf8Decoded nxt = utf8_decode_at(text, cursor);
+        if (nxt.bytes == 0) break;
+        // Post-virama: absorb the next consonant regardless of class.
+        if (prev_was_virama) {
+            prev_was_virama = is_virama(nxt.cp);
+            cursor += nxt.bytes;
+            continue;
+        }
+        if (is_cluster_extend(nxt.cp)) {
+            prev_was_zwj    = (nxt.cp == 0x200D);
+            prev_was_virama = is_virama(nxt.cp);
+            cursor += nxt.bytes;
+            continue;
+        }
+        if (prev_was_zwj && joins_after_zwj(nxt.cp)) {
+            prev_was_zwj = false;
+            cursor += nxt.bytes;
+            continue;
+        }
+        break;
+    }
+    return cursor;
+}
+
+// pulp #2163 — font v2 Slice 3.6. UAX #29-lite cluster boundaries.
+// Always defined regardless of PULP_HAS_SKIA — pure UTF-8 walker.
+//
+// Backward direction implements the standard "scan from start" trick:
+// cluster boundaries are not purely locally-decidable (a backward
+// codepoint by itself doesn't tell you if it's inside a ZWJ chain or
+// post-virama sequence), so we walk forward from byte 0 collecting
+// boundaries until we cross `byte_offset`, then return the most
+// recent boundary strictly before it. O(n) per call but inputs are
+// label-sized; cursor APIs that need O(1) backward step can cache
+// boundaries via the Phase 1 UnicodeIndexMap.
+std::size_t cluster_step(const std::string& text, std::size_t byte_offset,
+                         bool forward) {
+    if (forward) {
+        if (byte_offset >= text.size()) return text.size();
+        // Walk to the start of the codepoint at byte_offset.
+        std::size_t i = byte_offset;
+        if (i > 0 && (static_cast<unsigned char>(text[i]) & 0xC0) == 0x80) {
+            i = skip_utf8_back_to_lead(text, i);
+        }
+        return cluster_boundary_after(text, i);
+    } else {
+        if (byte_offset == 0) return 0;
+        // Forward scan collecting boundaries until we cross
+        // byte_offset; return the last boundary strictly before it.
+        std::size_t prev = 0;
+        std::size_t cursor = 0;
+        while (cursor < text.size() && cursor < byte_offset) {
+            std::size_t next = cluster_boundary_after(text, cursor);
+            if (next <= cursor) break; // safety: never advance backward
+            if (next < byte_offset) {
+                prev = next;
+                cursor = next;
+            } else {
+                // `next` is at or past byte_offset: the cluster we're
+                // inside started at `cursor`; that's the answer.
+                return cursor;
+            }
+        }
+        return prev;
+    }
+}
+
+} // namespace pulp::canvas
 
 #ifndef PULP_HAS_SKIA
 
@@ -51,23 +240,6 @@ bool validate_font_bytes(const std::uint8_t* data, std::size_t size) {
 // pulp #2163 — font v2 Phase 3 skeletons.
 bool register_font_woff2(const std::uint8_t*, std::size_t, const std::string&) {
     return false;  // Phase 3 impl wires Brotli decompression + sanitizer.
-}
-
-std::size_t cluster_step(const std::string& text, std::size_t byte_offset,
-                         bool forward) {
-    // Skeleton: naive single-byte step. Phase 3 impl consults the
-    // Phase 1 UnicodeIndexMap for proper UAX #29 cluster boundaries.
-    if (forward) {
-        if (byte_offset >= text.size()) return text.size();
-        std::size_t i = byte_offset + 1;
-        while (i < text.size() && (static_cast<unsigned char>(text[i]) & 0xC0) == 0x80) ++i;
-        return i;
-    } else {
-        if (byte_offset == 0) return 0;
-        std::size_t i = byte_offset - 1;
-        while (i > 0 && (static_cast<unsigned char>(text[i]) & 0xC0) == 0x80) --i;
-        return i;
-    }
 }
 
 } // namespace pulp::canvas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -969,6 +969,11 @@ add_executable(pulp-test-font-variable-axes test_font_variable_axes.cpp)
 target_link_libraries(pulp-test-font-variable-axes PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-font-variable-axes)
 
+# pulp #2163 / font v2 Slice 3.6 — UAX #29-lite cluster_step.
+add_executable(pulp-test-cluster-step test_cluster_step.cpp)
+target_link_libraries(pulp-test-cluster-step PRIVATE pulp::canvas Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-cluster-step)
+
 # pulp #2163 — font v2 Slice 1.3 measurement-paint parity harness.
 # Asserts TextShaper predictions match Skia's measured advance within
 # 0.5px for a hand-picked sample set representative of CHAIN INFO /

--- a/test/test_cluster_step.cpp
+++ b/test/test_cluster_step.cpp
@@ -1,0 +1,94 @@
+// test_cluster_step.cpp — Pulp #2163, font v2 Slice 3.6.
+//
+// UAX #29-lite cluster_step behavior: emoji ZWJ family steps as one,
+// regional-indicator flag pairs step as one, Devanagari virama
+// conjuncts step as one, Latin combining marks attach to the base.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/canvas/bundled_fonts.hpp>
+
+#include <string>
+
+using namespace pulp::canvas;
+
+TEST_CASE("cluster_step: end-of-string is idempotent", "[font][cluster][issue-2163]") {
+    std::string s = "abc";
+    REQUIRE(cluster_step(s, s.size(), /*forward=*/true)  == s.size());
+    REQUIRE(cluster_step(s, 0,        /*forward=*/false) == 0);
+}
+
+TEST_CASE("cluster_step: plain ASCII advances by one byte", "[font][cluster]") {
+    std::string s = "hello";
+    REQUIRE(cluster_step(s, 0, true) == 1u);
+    REQUIRE(cluster_step(s, 1, true) == 2u);
+    REQUIRE(cluster_step(s, 4, true) == 5u);
+    REQUIRE(cluster_step(s, 5, false) == 4u);
+    REQUIRE(cluster_step(s, 1, false) == 0u);
+}
+
+TEST_CASE("cluster_step: emoji ZWJ family is one cluster", "[font][cluster][emoji]") {
+    // 👨‍👩‍👧‍👦 = 👨 ZWJ 👩 ZWJ 👧 ZWJ 👦
+    // UTF-8 bytes: 4 + 3 + 4 + 3 + 4 + 3 + 4 = 25 bytes
+    std::string s = "\xF0\x9F\x91\xA8"   // 👨
+                    "\xE2\x80\x8D"        // ZWJ
+                    "\xF0\x9F\x91\xA9"   // 👩
+                    "\xE2\x80\x8D"        // ZWJ
+                    "\xF0\x9F\x91\xA7"   // 👧
+                    "\xE2\x80\x8D"        // ZWJ
+                    "\xF0\x9F\x91\xA6";   // 👦
+    REQUIRE(s.size() == 25u);
+    REQUIRE(cluster_step(s, 0, true) == s.size());
+    REQUIRE(cluster_step(s, s.size(), false) == 0u);
+}
+
+TEST_CASE("cluster_step: regional indicator pair (US flag) is one cluster",
+          "[font][cluster][emoji]") {
+    // 🇺🇸 = U+1F1FA U+1F1F8 (regional indicators U + S)
+    std::string s = "\xF0\x9F\x87\xBA\xF0\x9F\x87\xB8";  // 8 bytes
+    REQUIRE(s.size() == 8u);
+    REQUIRE(cluster_step(s, 0, true) == 8u);
+    REQUIRE(cluster_step(s, 8, false) == 0u);
+}
+
+TEST_CASE("cluster_step: two consecutive flags are two clusters",
+          "[font][cluster][emoji]") {
+    // 🇺🇸🇯🇵 — US then JP, four RIs total
+    std::string s = "\xF0\x9F\x87\xBA\xF0\x9F\x87\xB8"   // 🇺🇸
+                    "\xF0\x9F\x87\xAF\xF0\x9F\x87\xB5";  // 🇯🇵
+    REQUIRE(s.size() == 16u);
+    REQUIRE(cluster_step(s, 0, true) == 8u);   // first flag
+    REQUIRE(cluster_step(s, 8, true) == 16u);  // second flag
+}
+
+TEST_CASE("cluster_step: emoji + skin-tone modifier is one cluster",
+          "[font][cluster][emoji]") {
+    // 👍🏽 = thumbs-up U+1F44D + medium skin tone U+1F3FD
+    std::string s = "\xF0\x9F\x91\x8D\xF0\x9F\x8F\xBD";
+    REQUIRE(s.size() == 8u);
+    REQUIRE(cluster_step(s, 0, true) == 8u);
+}
+
+TEST_CASE("cluster_step: Devanagari ka + virama + ssa (क्ष) is one cluster",
+          "[font][cluster][devanagari]") {
+    // U+0915 U+094D U+0937 — three codepoints, one visual cluster
+    std::string s = "\xE0\xA4\x95\xE0\xA5\x8D\xE0\xA4\xB7";
+    REQUIRE(s.size() == 9u);
+    REQUIRE(cluster_step(s, 0, true) == 9u);
+}
+
+TEST_CASE("cluster_step: Latin base + combining acute (é via NFD) is one cluster",
+          "[font][cluster][combining]") {
+    // 'e' (0x65) + COMBINING ACUTE ACCENT U+0301 (\xCC\x81)
+    std::string s = "e\xCC\x81";
+    REQUIRE(s.size() == 3u);
+    REQUIRE(cluster_step(s, 0, true) == 3u);
+    REQUIRE(cluster_step(s, 3, false) == 0u);
+}
+
+TEST_CASE("cluster_step: variation selector glues to base", "[font][cluster][emoji]") {
+    // ☀️ = U+2600 (sun) + U+FE0F (emoji presentation VS-16)
+    std::string s = "\xE2\x98\x80\xEF\xB8\x8F";
+    REQUIRE(s.size() == 6u);
+    REQUIRE(cluster_step(s, 0, true) == 6u);
+}


### PR DESCRIPTION
Phase 3 / Slice 3.6 — real cluster_step replacing the naive codepoint walker. Handles ZWJ family, RI flag pairs, skin tone, Devanagari virama conjuncts, variation selectors, Latin combining marks. pulp-test-cluster-step: 25 assertions, 9 cases, all green.