### PR TITLE
feat(canvas): centralize AA/hinting policy on ResolvedFont (font v2 Slice 3.2)

### DIFF
--- a/core/canvas/include/pulp/canvas/font_resolver.hpp
+++ b/core/canvas/include/pulp/canvas/font_resolver.hpp
@@ -31,11 +31,66 @@
 #include <vector>
 
 #ifdef PULP_HAS_SKIA
+#include "include/core/SkFont.h"
+#include "include/core/SkFontTypes.h"
 #include "include/core/SkRefCnt.h"
 class SkTypeface;
 #endif
 
 namespace pulp::canvas {
+
+#ifdef PULP_HAS_SKIA
+
+// ── AA / hinting policy (font v2 Slice 3.2) ──────────────────────────────
+//
+// Pure enum-to-enum translation from the platform-neutral FontOptions modes
+// (HintingMode, AntiAliasMode) to Skia's paint flags (SkFont::Edging,
+// SkFontHinting). Centralised here so every Skia-backed paint path —
+// SkiaCanvas, TextShaper, SDF glyph atlas — pulls the same policy out of
+// the resolver instead of inventing its own mapping. Stateless and
+// branch-free; safe to call from the audio thread (no allocations, no
+// locks, no Skia globals touched).
+//
+// Mapping rules (locked by test_font_aa_hinting):
+//   * AntiAliasMode::Default     → kAntiAlias (the existing in_non_opaque_layer
+//                                  heuristic in SkiaCanvas can still pick
+//                                  kSubpixelAntiAlias when it knows the
+//                                  destination is opaque; callers that want
+//                                  to bypass the heuristic explicitly opt in
+//                                  via LCD / Grayscale / NoAA).
+//   * AntiAliasMode::LCD         → kSubpixelAntiAlias
+//   * AntiAliasMode::Grayscale   → kAntiAlias
+//   * AntiAliasMode::NoAA        → kAlias
+//
+//   * HintingMode::PlatformDefault → kNormal (Skia's documented default for
+//                                    sk_app + most platform back-ends).
+//   * HintingMode::None            → kNone
+//   * HintingMode::Slight          → kSlight
+//   * HintingMode::Normal          → kNormal
+//   * HintingMode::Full            → kFull
+
+constexpr SkFont::Edging sk_edging_for(AntiAliasMode mode) noexcept {
+    switch (mode) {
+        case AntiAliasMode::LCD:       return SkFont::Edging::kSubpixelAntiAlias;
+        case AntiAliasMode::Grayscale: return SkFont::Edging::kAntiAlias;
+        case AntiAliasMode::NoAA:      return SkFont::Edging::kAlias;
+        case AntiAliasMode::Default:   break;
+    }
+    return SkFont::Edging::kAntiAlias;
+}
+
+constexpr SkFontHinting sk_hinting_for(HintingMode mode) noexcept {
+    switch (mode) {
+        case HintingMode::None:            return SkFontHinting::kNone;
+        case HintingMode::Slight:          return SkFontHinting::kSlight;
+        case HintingMode::Normal:          return SkFontHinting::kNormal;
+        case HintingMode::Full:            return SkFontHinting::kFull;
+        case HintingMode::PlatformDefault: break;
+    }
+    return SkFontHinting::kNormal;
+}
+
+#endif  // PULP_HAS_SKIA
 
 // ── Trace types ──────────────────────────────────────────────────────────
 
@@ -90,6 +145,13 @@ struct ResolvedFont {
     std::vector<FallbackTraceStep> trace;
     SynthesisTrace                 synthesis;
 
+    /// AA/hinting policy carried over from the originating `FontOptions`.
+    /// Recorded at resolve time so paint paths can derive Skia flags
+    /// without round-tripping through the original options blob.
+    /// (font v2 Slice 3.2)
+    AntiAliasMode aa_mode      = AntiAliasMode::Default;
+    HintingMode   hinting_mode = HintingMode::PlatformDefault;
+
     bool has_typeface() const noexcept {
 #ifdef PULP_HAS_SKIA
         return static_cast<bool>(typeface);
@@ -101,6 +163,20 @@ struct ResolvedFont {
     bool resolved() const noexcept {
         return origin != FallbackOrigin::NotFound;
     }
+
+#ifdef PULP_HAS_SKIA
+    /// Skia `SkFont::Edging` for the recorded `aa_mode`. See
+    /// `sk_edging_for(AntiAliasMode)` for the mapping table.
+    SkFont::Edging sk_edging() const noexcept {
+        return sk_edging_for(aa_mode);
+    }
+
+    /// Skia `SkFontHinting` for the recorded `hinting_mode`. See
+    /// `sk_hinting_for(HintingMode)` for the mapping table.
+    SkFontHinting sk_hinting() const noexcept {
+        return sk_hinting_for(hinting_mode);
+    }
+#endif
 };
 
 // ── FontResolver ─────────────────────────────────────────────────────────

--- a/core/canvas/src/font_resolver.cpp
+++ b/core/canvas/src/font_resolver.cpp
@@ -105,6 +105,9 @@ ResolvedFont resolve_one_family(const std::string& family,
     ResolvedFont r;
     r.scope = opts.scope;
     r.generation = merged_generation_for(opts.scope);
+    // Slice 3.2: AA / hinting policy travels alongside the resolved face.
+    r.aa_mode = opts.aa_mode;
+    r.hinting_mode = opts.hinting_mode;
 
     // 1) Registered (scoped). Phase 1.1.a only consults the global
     //    registered map; per-scope storage arrives in 1.1.b.
@@ -200,6 +203,12 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
     ResolvedFont resolved;
     resolved.scope = options.scope;
     resolved.generation = merged_generation_for(options.scope);
+    // pulp #2163 — font v2 Slice 3.2. AA / hinting policy carried straight
+    // out of FontOptions onto the ResolvedFont so paint paths derive Skia
+    // flags from one canonical source. See `sk_edging_for` / `sk_hinting_for`
+    // in font_resolver.hpp for the enum translation.
+    resolved.aa_mode = options.aa_mode;
+    resolved.hinting_mode = options.hinting_mode;
 
     // pulp #2163 — font v2 Slice 2.3. After a face resolves, if the
     // caller requested variation axes (`font-variation-settings`),
@@ -264,6 +273,10 @@ ResolvedFont FontResolver::resolve_character_fallback(const FontOptions& options
     ResolvedFont r;
     r.scope = options.scope;
     r.generation = merged_generation_for(options.scope);
+    // Slice 3.2: char-fallback faces carry the same AA / hinting policy
+    // as the primary so paint paths stay consistent across the run.
+    r.aa_mode = options.aa_mode;
+    r.hinting_mode = options.hinting_mode;
 
     sk_sp<SkFontMgr> mgr = platform_font_manager();
     if (!mgr) {
@@ -308,6 +321,8 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
     ResolvedFont r;
     r.scope = options.scope;
     r.generation = merged_generation_for(options.scope);
+    r.aa_mode = options.aa_mode;
+    r.hinting_mode = options.hinting_mode;
     r.origin = FallbackOrigin::NotFound;
     return r;
 }
@@ -318,6 +333,8 @@ ResolvedFont FontResolver::resolve_character_fallback(const FontOptions& options
     ResolvedFont r;
     r.scope = options.scope;
     r.generation = merged_generation_for(options.scope);
+    r.aa_mode = options.aa_mode;
+    r.hinting_mode = options.hinting_mode;
     r.origin = FallbackOrigin::NotFound;
     return r;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -974,6 +974,17 @@ add_executable(pulp-test-cluster-step test_cluster_step.cpp)
 target_link_libraries(pulp-test-cluster-step PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-cluster-step)
 
+# pulp #2163 / font v2 Slice 3.2 — AA / hinting / subpixel policy centralization.
+# Locks the enum-to-Skia translation table on ResolvedFont so a stealth change
+# (e.g. flipping AntiAliasMode::Default to kSubpixelAntiAlias) is caught by an
+# automated test instead of by goldens drift weeks later.
+add_executable(pulp-test-font-aa-hinting test_font_aa_hinting.cpp)
+target_link_libraries(pulp-test-font-aa-hinting PRIVATE pulp::canvas Catch2::Catch2WithMain)
+if(PULP_HAS_SKIA)
+    target_link_libraries(pulp-test-font-aa-hinting PRIVATE skia::skia)
+endif()
+catch_discover_tests(pulp-test-font-aa-hinting)
+
 # pulp #2163 — font v2 Slice 1.3 measurement-paint parity harness.
 # Asserts TextShaper predictions match Skia's measured advance within
 # 0.5px for a hand-picked sample set representative of CHAIN INFO /

--- a/test/test_font_aa_hinting.cpp
+++ b/test/test_font_aa_hinting.cpp
@@ -1,0 +1,120 @@
+// test_font_aa_hinting.cpp — Pulp #2163, font v2 Slice 3.2.
+//
+// Verifies that FontOptions.aa_mode / .hinting_mode are propagated by
+// FontResolver onto the returned ResolvedFont, and that the helper
+// translators on ResolvedFont (and the free `sk_edging_for` /
+// `sk_hinting_for` functions) map to the documented Skia enums.
+//
+// Locks in the policy table from font_resolver.hpp so a stealth change
+// (e.g. flipping AntiAliasMode::Default to kSubpixelAntiAlias) is caught
+// by an automated test instead of by a goldens regression weeks later.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/canvas/font_options.hpp>
+#include <pulp/canvas/font_resolver.hpp>
+
+#ifdef PULP_HAS_SKIA
+#include "include/core/SkFont.h"
+#include "include/core/SkFontTypes.h"
+#include "include/core/SkTypeface.h"
+#endif
+
+using namespace pulp::canvas;
+
+#ifdef PULP_HAS_SKIA
+
+TEST_CASE("AA mode translates: Default → kAntiAlias", "[font][aa][issue-2163]") {
+    REQUIRE(sk_edging_for(AntiAliasMode::Default) == SkFont::Edging::kAntiAlias);
+}
+
+TEST_CASE("AA mode translates: LCD → kSubpixelAntiAlias", "[font][aa][issue-2163]") {
+    REQUIRE(sk_edging_for(AntiAliasMode::LCD) == SkFont::Edging::kSubpixelAntiAlias);
+}
+
+TEST_CASE("AA mode translates: Grayscale → kAntiAlias", "[font][aa][issue-2163]") {
+    REQUIRE(sk_edging_for(AntiAliasMode::Grayscale) == SkFont::Edging::kAntiAlias);
+}
+
+TEST_CASE("AA mode translates: NoAA → kAlias", "[font][aa][issue-2163]") {
+    REQUIRE(sk_edging_for(AntiAliasMode::NoAA) == SkFont::Edging::kAlias);
+}
+
+TEST_CASE("Hinting mode translates: None → kNone", "[font][hinting][issue-2163]") {
+    REQUIRE(sk_hinting_for(HintingMode::None) == SkFontHinting::kNone);
+}
+
+TEST_CASE("Hinting mode translates: Slight → kSlight", "[font][hinting][issue-2163]") {
+    REQUIRE(sk_hinting_for(HintingMode::Slight) == SkFontHinting::kSlight);
+}
+
+TEST_CASE("Hinting mode translates: Normal → kNormal", "[font][hinting][issue-2163]") {
+    REQUIRE(sk_hinting_for(HintingMode::Normal) == SkFontHinting::kNormal);
+}
+
+TEST_CASE("Hinting mode translates: Full → kFull", "[font][hinting][issue-2163]") {
+    REQUIRE(sk_hinting_for(HintingMode::Full) == SkFontHinting::kFull);
+}
+
+TEST_CASE("Hinting mode translates: PlatformDefault → kNormal", "[font][hinting][issue-2163]") {
+    // Documented contract: PlatformDefault resolves to Skia's documented
+    // default (kNormal). When this changes per-platform, update both the
+    // mapping in font_resolver.hpp AND this assertion in the same PR.
+    REQUIRE(sk_hinting_for(HintingMode::PlatformDefault) == SkFontHinting::kNormal);
+}
+
+TEST_CASE("Resolver propagates aa_mode onto ResolvedFont", "[font][aa][issue-2163]") {
+    FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.size = 14.0f;
+    opts.aa_mode = AntiAliasMode::LCD;
+
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    REQUIRE(resolved.aa_mode == AntiAliasMode::LCD);
+    REQUIRE(resolved.sk_edging() == SkFont::Edging::kSubpixelAntiAlias);
+}
+
+TEST_CASE("Resolver propagates hinting_mode onto ResolvedFont", "[font][hinting][issue-2163]") {
+    FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.size = 14.0f;
+    opts.hinting_mode = HintingMode::Slight;
+
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    REQUIRE(resolved.hinting_mode == HintingMode::Slight);
+    REQUIRE(resolved.sk_hinting() == SkFontHinting::kSlight);
+}
+
+TEST_CASE("ResolvedFont accessors compose: NoAA + Full", "[font][aa][hinting][issue-2163]") {
+    FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.size = 14.0f;
+    opts.aa_mode = AntiAliasMode::NoAA;
+    opts.hinting_mode = HintingMode::Full;
+
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    REQUIRE(resolved.sk_edging() == SkFont::Edging::kAlias);
+    REQUIRE(resolved.sk_hinting() == SkFontHinting::kFull);
+}
+
+TEST_CASE("Default-constructed FontOptions maps to AA on, normal hinting",
+          "[font][aa][hinting][issue-2163]") {
+    FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.size = 14.0f;
+
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    // Defaults defined in font_options.hpp.
+    REQUIRE(resolved.aa_mode == AntiAliasMode::Default);
+    REQUIRE(resolved.hinting_mode == HintingMode::PlatformDefault);
+    REQUIRE(resolved.sk_edging() == SkFont::Edging::kAntiAlias);
+    REQUIRE(resolved.sk_hinting() == SkFontHinting::kNormal);
+}
+
+#else  // !PULP_HAS_SKIA
+
+TEST_CASE("AA / hinting helpers skipped without Skia", "[font][aa][issue-2163]") {
+    SUCCEED("PULP_HAS_SKIA not defined; sk_edging_for / sk_hinting_for unavailable");
+}
+
+#endif  // PULP_HAS_SKIA


### PR DESCRIPTION
## Summary

`FontOptions.aa_mode` and `FontOptions.hinting_mode` have lived on the typed-options blob since Slice 1.1.a but nothing consumed them. This slice wires them through `FontResolver::resolve_family_list` (and the character-fallback path) onto the returned `ResolvedFont`, and adds:

- Inline `ResolvedFont::sk_edging()` / `ResolvedFont::sk_hinting()` accessors (guarded by `PULP_HAS_SKIA`)
- Free `sk_edging_for(AntiAliasMode)` / `sk_hinting_for(HintingMode)` helpers — pure, constexpr, branch-only — that translate the platform-neutral enums to Skia's `SkFont::Edging` + `SkFontHinting`

The translation table now lives in exactly one place. Every Skia-backed paint path (SkiaCanvas, TextShaper, SDF glyph atlas) can pull policy from the resolver instead of inventing its own mapping.

## Mapping table (locked by `test_font_aa_hinting`)

| FontOptions mode | Skia value |
|------------------|------------|
| `AntiAliasMode::Default` | `SkFont::Edging::kAntiAlias` |
| `AntiAliasMode::LCD` | `SkFont::Edging::kSubpixelAntiAlias` |
| `AntiAliasMode::Grayscale` | `SkFont::Edging::kAntiAlias` |
| `AntiAliasMode::NoAA` | `SkFont::Edging::kAlias` |
| `HintingMode::None` | `SkFontHinting::kNone` |
| `HintingMode::Slight` | `SkFontHinting::kSlight` |
| `HintingMode::Normal` | `SkFontHinting::kNormal` |
| `HintingMode::Full` | `SkFontHinting::kFull` |
| `HintingMode::PlatformDefault` | `SkFontHinting::kNormal` |

## Test plan

- [x] `pulp-test-font-aa-hinting` — 13 cases / 19 assertions green (covers each enum, resolver propagation, default-construction defaults, composition)
- [x] `pulp-test-parity` unchanged (3 cases / 5 assertions, paint output not affected — `SkiaCanvas` doesn't yet read these accessors)
- [x] `pulp-canvas` library builds clean with `PULP_HAS_SKIA`

## LOC

224 lines added across 4 files (104 production / 120 test).