### PR TITLE
fix(canvas): repair PR #2183 split-build regression

### DIFF
--- a/core/canvas/src/skia_canvas_box_shadow.cpp
+++ b/core/canvas/src/skia_canvas_box_shadow.cpp
@@ -21,10 +21,16 @@
 #include "include/core/SkPath.h"
 #include "include/core/SkRRect.h"
 #include "include/core/SkRect.h"
+// pulp #2183 hot-fix: box-shadow uses SkImageFilters::DropShadowOnly +
+// SkImageFilters::Blur; missing from the original split.
+#include "include/effects/SkImageFilters.h"
 
 #endif  // PULP_HAS_SKIA
 
 #include <pulp/canvas/skia_canvas.hpp>
+#ifdef PULP_HAS_SKIA
+#include "skia_canvas_internal.hpp"
+#endif
 
 #ifdef PULP_HAS_SKIA
 

--- a/core/canvas/src/skia_canvas_internal.hpp
+++ b/core/canvas/src/skia_canvas_internal.hpp
@@ -1,0 +1,86 @@
+// skia_canvas_internal.hpp — TU-internal helpers shared between
+// skia_canvas.cpp and the per-feature split files (skia_canvas_box_shadow,
+// skia_canvas_opacity, skia_canvas_shaders, skia_canvas_gradients,
+// skia_canvas_mask). Internal to core/canvas/src; not part of the public
+// API.
+//
+// Background: PR #2183 (Phase 4 R2-3 follow-up) split skia_canvas.cpp
+// into per-feature TUs but left the shared static helpers
+// (`to_sk_color4f`, `skia_blend_mode_for`, the webgpu→SkColorType /
+// SkColorSpace mappers) only in skia_canvas.cpp. The split files
+// referenced them and failed to link. This header consolidates the
+// helpers as `inline` so every split TU sees the same definition.
+
+#pragma once
+
+#ifdef PULP_HAS_SKIA
+
+#include "include/core/SkBlendMode.h"
+#include "include/core/SkColor.h"
+#include "include/core/SkColorSpace.h"
+
+#include "pulp/canvas/canvas.hpp"  // Color, Canvas::BlendMode
+
+#include <string>
+
+namespace pulp::canvas {
+
+// Color conversion — RGBA float quad from Pulp's `Color`.
+inline SkColor4f to_sk_color4f(Color c) {
+    return {c.r, c.g, c.b, c.a};
+}
+
+// Canvas2D `globalCompositeOperation` → Skia blend mode mapping. Mirrors
+// the table in skia_canvas.cpp (kept side-by-side with the canonical
+// definition; static_cast pattern matches the legacy switch).
+inline SkBlendMode skia_blend_mode_for(Canvas::BlendMode mode) {
+    using BM = Canvas::BlendMode;
+    switch (mode) {
+        case BM::source_over:      return SkBlendMode::kSrcOver;
+        case BM::source_in:        return SkBlendMode::kSrcIn;
+        case BM::source_out:       return SkBlendMode::kSrcOut;
+        case BM::source_atop:      return SkBlendMode::kSrcATop;
+        case BM::destination_over: return SkBlendMode::kDstOver;
+        case BM::destination_in:   return SkBlendMode::kDstIn;
+        case BM::destination_out:  return SkBlendMode::kDstOut;
+        case BM::destination_atop: return SkBlendMode::kDstATop;
+        case BM::lighter:          return SkBlendMode::kPlus;
+        case BM::copy:             return SkBlendMode::kSrc;
+        case BM::xor_mode:         return SkBlendMode::kXor;
+        case BM::multiply:         return SkBlendMode::kMultiply;
+        case BM::screen:           return SkBlendMode::kScreen;
+        case BM::overlay:          return SkBlendMode::kOverlay;
+        case BM::darken:           return SkBlendMode::kDarken;
+        case BM::lighten:          return SkBlendMode::kLighten;
+        case BM::color_dodge:      return SkBlendMode::kColorDodge;
+        case BM::color_burn:       return SkBlendMode::kColorBurn;
+        case BM::hard_light:       return SkBlendMode::kHardLight;
+        case BM::soft_light:       return SkBlendMode::kSoftLight;
+        case BM::difference:       return SkBlendMode::kDifference;
+        case BM::exclusion:        return SkBlendMode::kExclusion;
+        case BM::hue:              return SkBlendMode::kHue;
+        case BM::saturation:       return SkBlendMode::kSaturation;
+        case BM::color:            return SkBlendMode::kColor;
+        case BM::luminosity:       return SkBlendMode::kLuminosity;
+    }
+    return SkBlendMode::kSrcOver;
+}
+
+// WebGPU texture format → Skia color type. Used by the offscreen-
+// surface wrap path in skia_canvas_shaders.cpp.
+inline SkColorType sk_color_type_from_webgpu_format(const std::string& format) {
+    if (format == "rgba16float") return kRGBA_F16_SkColorType;
+    if (format == "rgba8unorm" || format == "rgba8unorm-srgb") return kRGBA_8888_SkColorType;
+    return kBGRA_8888_SkColorType;
+}
+
+// WebGPU texture format → SkColorSpace. RGBA16F is linear sRGB; the
+// rest are gamma-corrected sRGB.
+inline sk_sp<SkColorSpace> sk_color_space_from_webgpu_format(const std::string& format) {
+    if (format == "rgba16float") return SkColorSpace::MakeSRGBLinear();
+    return SkColorSpace::MakeSRGB();
+}
+
+} // namespace pulp::canvas
+
+#endif // PULP_HAS_SKIA

--- a/core/canvas/src/skia_canvas_opacity.cpp
+++ b/core/canvas/src/skia_canvas_opacity.cpp
@@ -45,6 +45,9 @@
 #endif  // PULP_HAS_SKIA
 
 #include <pulp/canvas/skia_canvas.hpp>
+#ifdef PULP_HAS_SKIA
+#include "skia_canvas_internal.hpp"  // skia_blend_mode_for, to_sk_color4f
+#endif
 
 #ifdef PULP_HAS_SKIA
 

--- a/core/canvas/src/skia_canvas_shaders.cpp
+++ b/core/canvas/src/skia_canvas_shaders.cpp
@@ -41,10 +41,19 @@
 #include "include/core/SkTileMode.h"
 #include "include/effects/SkImageFilters.h"
 #include "include/effects/SkRuntimeEffect.h"
+// pulp #2183 hot-fix: WebGPU/Graphite native-texture wrap path was
+// missing these heavy includes after the split.
+#include "include/gpu/graphite/BackendTexture.h"
+#include "include/gpu/graphite/Image.h"
+#include "webgpu/webgpu_cpp.h"
 
 #endif  // PULP_HAS_SKIA
 
 #include <pulp/canvas/skia_canvas.hpp>
+#ifdef PULP_HAS_SKIA
+#include "skia_canvas_internal.hpp"  // to_sk_color4f, webgpu-format helpers
+#include "runtime_effect_cache.hpp"  // RuntimeEffectCache (sibling header)
+#endif
 
 #ifdef PULP_HAS_SKIA
 
@@ -324,31 +333,18 @@ bool SkiaCanvas::draw_native_dawn_texture(void* texture_handle,
                                           float y,
                                           float w,
                                           float h) {
-    if (!canvas_ || !recorder_ || texture_handle == nullptr || width == 0 || height == 0) {
-        return false;
-    }
-
-    auto* texture_ptr = static_cast<wgpu::Texture*>(texture_handle);
-    if (texture_ptr == nullptr || !(*texture_ptr)) {
-        return false;
-    }
-
-    auto backend_texture = skgpu::graphite::BackendTextures::MakeDawn(texture_ptr->Get());
-    if (!backend_texture.isValid()) {
-        return false;
-    }
-
-    auto image = SkImages::WrapTexture(recorder_,
-                                       backend_texture,
-                                       sk_color_type_from_webgpu_format(format),
-                                       kPremul_SkAlphaType,
-                                       sk_color_space_from_webgpu_format(format));
-    if (!image) {
-        return false;
-    }
-
-    canvas_->drawImageRect(image, SkRect::MakeXYWH(x, y, w, h), SkSamplingOptions());
-    return true;
+    // pulp #2183 hot-fix: the original body referenced
+    // `skgpu::graphite::BackendTextures::MakeDawn(wgpu::Texture::Handle)`,
+    // an API that does not exist in this Skia release. Stubbed to
+    // return false so the canvas widget (core/view/src/canvas_widget.cpp)
+    // falls back to its non-native rendering path until whoever owns
+    // the Dawn-native-texture wrap path lands the correct
+    // `BackendTexture` factory call for the bundled Skia.
+    (void) texture_handle;
+    (void) width; (void) height;
+    (void) format;
+    (void) x; (void) y; (void) w; (void) h;
+    return false;
 }
 
 // ── Blur backdrop ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Hot-fix for origin/main build break introduced by PR #2183. Shared TU-private internal header for split skia_canvas files; missing SkImageFilters.h include in box_shadow; stub draw_native_dawn_texture pending correct Skia Dawn API.