### PR TITLE
chore(tools): root-allowlist mode for source-tree pollution check (U-1)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1716,3 +1716,18 @@ tools/scripts/format_baseline_capture.sh --build --plugin PulpEffect
 Commit the updated `test/fixtures/format-baseline/*.txt` files in the same PR. No exception path — intentional behavior changes update the baseline; unintentional regressions get fixed at the source.
 
 Companion-track item U-3 in `planning/2026-05-17-refactor-roadmap-final.md`.
+
+## Source-tree pollution: root-allowlist mode
+
+`tools/scripts/source_tree_pollution_check.py` now has a fourth mode beyond `stage` / `push` / `files`: **`--mode=root-allowlist`**.
+
+The root-allowlist mode reads `git ls-tree --name-only <rev>` and fails if any top-level entry is not in `ALLOWED_ROOT_PATHS` (a frozenset declared at the top of the script — ~51 entries covering hidden config, root docs, root build/config files, and subsystem directories).
+
+Wiring:
+
+- `.githooks/pre-push` invokes `--mode=root-allowlist --rev HEAD` right after the existing `--mode=push` check. Hard-fail; no env-var bypass.
+- `.github/workflows/source-tree-pollution-check.yml` runs the same mode in CI. Triggers on `paths: ['**']` (the check is ~5s — no point gating). Catches direct REST / admin merges that skip the pre-push hook.
+
+Adding a new top-level entry requires the same-PR allowlist update — the gate's error message points contributors to the exact line in the script. See the new "Repo-root hygiene" section in `CONTRIBUTING.md` for the contributor-facing explanation.
+
+Companion-track item U-1 in `planning/2026-05-17-refactor-roadmap-final.md`.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -112,6 +112,14 @@ if [ -f "$SOURCE_TREE_POLLUTION_PY" ]; then
         echo "[pre-push] (this gate has no env-var bypass — there is no legitimate reason to commit a Clock fixture.)" >&2
         exit 1
     fi
+    # Companion-track U-1 — top-level allowlist gate. Catches new
+    # root paths not in ALLOWED_ROOT_PATHS (almost always a stray
+    # fixture, mis-placed module, or an intentional addition whose
+    # allowlist update was forgotten).
+    if ! "$PYTHON" "$SOURCE_TREE_POLLUTION_PY" --mode=root-allowlist --rev HEAD; then
+        echo "[pre-push] root-allowlist gate: BLOCKED. Either move the file(s) under the correct subdirectory or add them to ALLOWED_ROOT_PATHS in tools/scripts/source_tree_pollution_check.py in the same commit." >&2
+        exit 1
+    fi
 fi
 
 # Skill-sync first — it fails fast and the output is the most actionable.

--- a/.github/workflows/source-tree-pollution-check.yml
+++ b/.github/workflows/source-tree-pollution-check.yml
@@ -13,10 +13,11 @@ name: Source-tree pollution check
 
 on:
   pull_request:
+    # Companion-track U-1: trigger on every PR so the root-allowlist
+    # check catches new top-level paths regardless of which files
+    # changed. The check is cheap (~5s) — no point gating it.
     paths:
-      - 'CMakeLists.txt'
-      - 'pulp.toml'
-      - 'tools/scripts/source_tree_pollution_check.py'
+      - '**'
 
 permissions:
   contents: read
@@ -45,3 +46,13 @@ jobs:
           fi
           python3 tools/scripts/source_tree_pollution_check.py \
             --mode=push --base "$base"
+
+      - name: Run root-allowlist check
+        # Companion-track U-1: catches new top-level paths that aren't
+        # in tools/scripts/source_tree_pollution_check.py's
+        # ALLOWED_ROOT_PATHS. Almost always either a stray fixture, a
+        # mis-placed module, or an intentional new entry whose
+        # allowlist update was forgotten.
+        run: |
+          python3 tools/scripts/source_tree_pollution_check.py \
+            --mode=root-allowlist --rev HEAD

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ Thumbs.db
 /pulp
 /tokens.json
 /examples/design-tool/.design-tool-*.tmp.js
+# Companion-track U-1 — stray top-level artifacts observed in 2026-05-17
+# audit. Already blocked from landing by --mode=root-allowlist but
+# ignoring them here keeps `git status` quiet too.
+/screenshot.png
+/.mcp.json.disabled-*
 
 
 # Dependencies (fetched at build time)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,3 +54,24 @@ Before adding any dependency:
 1. Check its license (MIT, BSD, Apache 2.0, ISC, zlib, BSL-1.0 only)
 2. Add it to `DEPENDENCIES.md` (alphabetical order)
 3. Add its license text to `NOTICE.md` (alphabetical order)
+
+## Repo-root hygiene
+
+The set of files and directories at the repo root is small and stable
+on purpose. New top-level paths are blocked by
+`tools/scripts/source_tree_pollution_check.py --mode=root-allowlist`,
+which runs in the pre-push hook and in the `Source-tree pollution check`
+CI workflow.
+
+When you genuinely need to add a new top-level path:
+
+1. Make sure it actually belongs at the root and not under
+   `core/`, `tools/`, `examples/`, `docs/`, etc. — almost everything
+   belongs in a subdirectory.
+2. Add the path to `ALLOWED_ROOT_PATHS` in
+   `tools/scripts/source_tree_pollution_check.py` in the same commit.
+3. Note in the PR description why the new top-level entry is justified.
+
+For local-only stray artifacts (screenshots, coverage profiles,
+disabled config files), prefer adding the pattern to `.gitignore`
+rather than committing them.

--- a/tools/scripts/source_tree_pollution_check.py
+++ b/tools/scripts/source_tree_pollution_check.py
@@ -22,10 +22,14 @@ Patterns warned about (non-blocking):
     isn't one of the two above).
 
 Modes:
-  --mode=stage    inspect `git diff --cached` (pre-commit). Default.
-  --mode=push     inspect `BASE...HEAD` (pre-push).
-  --mode=files    inspect explicit file list passed positionally
-                  (CI workflow use — pass the PR diff file list).
+  --mode=stage           inspect `git diff --cached` (pre-commit). Default.
+  --mode=push            inspect `BASE...HEAD` (pre-push).
+  --mode=files           inspect explicit file list passed positionally
+                         (CI workflow use — pass the PR diff file list).
+  --mode=root-allowlist  inspect top-level paths on `--rev` (default HEAD)
+                         and fail if any are not in ALLOWED_ROOT_PATHS.
+                         Companion-track U-1 — see
+                         planning/2026-05-17-refactor-roadmap-final.md.
 
 Exit codes:
   0  no pollution detected
@@ -47,6 +51,71 @@ CLOCK_FIXTURE_SIGNATURE = "project(Clock VERSION 1.0.0"
 # are valid. Substring match was too strict; use a regex.
 PULP_PROJECT_PATTERN = re.compile(r"\bproject\s*\(\s*Pulp\b", re.IGNORECASE)
 TEMP_FIXTURE_PATH_HINTS = ("/private/var/folders/", "pulp-shellout-")
+
+# Companion-track U-1 (planning/2026-05-17-refactor-roadmap-final.md):
+# Allowlist of legitimate top-level repo entries. Used by
+# --mode=root-allowlist to fail when an unexpected top-level path
+# appears, which is almost always either a stray temp/test artifact
+# or a mis-placed module that should live under a subdirectory.
+#
+# To add a new top-level entry: add it here in the same PR, with a
+# brief comment if the reason isn't obvious from the name.
+ALLOWED_ROOT_PATHS = frozenset({
+    # Hidden config / metadata
+    ".agents",
+    ".claude",
+    ".claude-plugin",
+    ".gitattributes",
+    ".githooks",
+    ".github",
+    ".gitignore",
+    ".gitmodules",
+    ".iwyu-mappings.imp",
+    ".mcp.json",
+    ".shipyard",
+    ".shipyard.local",
+    ".status-ladder-waivers.txt",
+    # Top-level docs
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "CLAUDE.md",
+    "CONTRIBUTING.md",
+    "DEPENDENCIES.md",
+    "LICENSE.md",
+    "NOTICE.md",
+    "README.md",
+    "VISION.md",
+    # Top-level build / config
+    "CMakeLists.txt",
+    "codecov.yml",
+    "compat.json",
+    "config.example.toml",
+    "mkdocs.yml",
+    "requirements-docs.txt",
+    "setup.ps1",
+    "setup.sh",
+    "validate-build.ps1",
+    "validate-build.sh",
+    # Top-level subsystem dirs
+    "android",
+    "apple",
+    "bindings",
+    "ci",
+    "core",
+    "docs",
+    "examples",
+    "experimental",
+    "external",
+    "hooks",
+    "inspect",
+    "packages",
+    "planning",
+    "scripts",
+    "ship",
+    "templates",
+    "test",
+    "tools",
+})
 
 
 # Sentinel returned by _git_diff_files when the diff itself failed.
@@ -99,6 +168,51 @@ def _read_blob(rev: str | None, path: str) -> str:
         except OSError:
             return ""
     return ""
+
+
+def check_root_allowlist(rev: str) -> list[str]:
+    """Companion-track U-1 — return error messages for any top-level path
+    on `rev` that is not in ALLOWED_ROOT_PATHS.
+
+    Threat model: a new directory or file appears at the repo root
+    unexpectedly. The most likely cause is (a) a test fixture that
+    leaked out of /tmp, (b) a stray screenshot or coverage profile not
+    covered by .gitignore, or (c) a module that should live under a
+    subdirectory but was mis-placed. PR review catches some of this;
+    this check catches the rest.
+
+    Adding a legitimate root path requires a same-PR allowlist update.
+    The allowlist is short and stable — Pulp's top-level shape rarely
+    changes — so the maintenance burden is minimal.
+    """
+    out = subprocess.run(
+        ["git", "ls-tree", "--name-only", rev],
+        capture_output=True, text=True, check=False,
+    )
+    if out.returncode != 0:
+        # Treat git failure as hard-block (same posture as _git_diff_files
+        # under Codex P1 finding on #1761 — never let the gate silently
+        # pass when the underlying git invocation fails).
+        return [
+            f"git ls-tree {rev} exited {out.returncode}: "
+            f"{(out.stderr or '').strip()[:200]}"
+        ]
+    errors: list[str] = []
+    for entry in out.stdout.splitlines():
+        name = entry.strip()
+        if not name:
+            continue
+        if name in ALLOWED_ROOT_PATHS:
+            continue
+        errors.append(
+            f"  {name}: unexpected top-level path. If this is "
+            "legitimate, add it to ALLOWED_ROOT_PATHS in "
+            "tools/scripts/source_tree_pollution_check.py in the "
+            "same PR. Otherwise, this is almost certainly a stray "
+            "fixture, screenshot, or mis-placed module — move it "
+            "under the correct subdirectory or delete it."
+        )
+    return errors
 
 
 def check(files: list[str], rev: str | None) -> tuple[list[str], list[str]]:
@@ -173,13 +287,27 @@ def check(files: list[str], rev: str | None) -> tuple[list[str], list[str]]:
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--mode", choices=("stage", "push", "files"),
+    parser.add_argument("--mode", choices=("stage", "push", "files",
+                                            "root-allowlist"),
                         default="stage")
     parser.add_argument("--base", default="origin/main",
                         help="for --mode=push, base ref (default origin/main)")
+    parser.add_argument("--rev", default="HEAD",
+                        help="for --mode=root-allowlist, ref to inspect "
+                             "(default HEAD)")
     parser.add_argument("files", nargs="*",
                         help="for --mode=files, explicit file list")
     args = parser.parse_args(argv)
+
+    # Companion-track U-1 — top-level allowlist mode.
+    if args.mode == "root-allowlist":
+        root_errors = check_root_allowlist(args.rev)
+        if root_errors:
+            sys.stderr.write("[source-tree-pollution] BLOCKED (root-allowlist):\n")
+            for e in root_errors:
+                sys.stderr.write(e + "\n")
+            return 1
+        return 0
 
     try:
         if args.mode == "stage":

--- a/tools/scripts/test_source_tree_pollution_check.py
+++ b/tools/scripts/test_source_tree_pollution_check.py
@@ -154,5 +154,101 @@ class SourceTreePollutionTests(unittest.TestCase):
         self.assertIn("pulp.toml", result.stderr)
 
 
+class RootAllowlistTests(unittest.TestCase):
+    """Companion-track U-1 — tests for --mode=root-allowlist."""
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp(prefix="pulp-pollution-root-test-")
+        self.cwd = os.getcwd()
+        os.chdir(self.tmpdir)
+        # Initialize a real git repo so `git ls-tree HEAD` resolves.
+        subprocess.run(["git", "init", "-q", "-b", "main"], check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], check=True)
+
+    def tearDown(self) -> None:
+        os.chdir(self.cwd)
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _commit_allowlisted_only(self) -> None:
+        # Create a minimal allowlisted root: just CMakeLists.txt + README.md.
+        Path("CMakeLists.txt").write_text(
+            "project(Pulp VERSION 0.1.0 LANGUAGES CXX)\n"
+        )
+        Path("README.md").write_text("# Pulp\n")
+        subprocess.run(["git", "add", "."], check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], check=True)
+
+    def _run_root_allowlist(self) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--mode=root-allowlist",
+             "--rev", "HEAD"],
+            capture_output=True, text=True, check=False,
+        )
+
+    def test_allowlisted_root_passes(self) -> None:
+        self._commit_allowlisted_only()
+        result = self._run_root_allowlist()
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_stray_top_level_file_blocks(self) -> None:
+        self._commit_allowlisted_only()
+        Path("screenshot.png").write_bytes(b"\x89PNG")
+        subprocess.run(["git", "add", "screenshot.png"], check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "add stray"], check=True)
+        result = self._run_root_allowlist()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("screenshot.png", result.stderr)
+        self.assertIn("unexpected top-level path", result.stderr)
+        self.assertIn("ALLOWED_ROOT_PATHS", result.stderr)
+
+    def test_stray_top_level_dir_blocks(self) -> None:
+        self._commit_allowlisted_only()
+        Path("misplaced_module").mkdir()
+        Path("misplaced_module/main.cpp").write_text("int main() {}\n")
+        subprocess.run(["git", "add", "misplaced_module"], check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "add dir"], check=True)
+        result = self._run_root_allowlist()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("misplaced_module", result.stderr)
+
+    def test_handles_missing_rev_with_block(self) -> None:
+        """git ls-tree failure → hard block (consistent with #1761 posture)."""
+        # Fresh git repo with no commits → HEAD doesn't resolve.
+        result = self._run_root_allowlist()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("git ls-tree", result.stderr)
+
+    def test_skips_blank_lines_in_ls_tree_output(self) -> None:
+        """Empty entries in `git ls-tree` output should be ignored without
+        crashing. Exercises the `if not name: continue` branch directly —
+        git in practice doesn't emit blanks, but the script defends against
+        it because `splitlines()` on edge inputs can.
+        """
+        # Import the function and stub subprocess.run to return blank lines
+        # interleaved with one allowlisted entry. Confirms (a) blanks are
+        # skipped without error, and (b) the allowlisted entry still passes.
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("stpc", str(SCRIPT))
+        stpc = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(stpc)
+
+        # Use a class with the subprocess.CompletedProcess shape.
+        class FakeResult:
+            returncode = 0
+            stdout = "\n\nREADME.md\n\n   \nCMakeLists.txt\n"
+            stderr = ""
+
+        orig_run = stpc.subprocess.run
+        stpc.subprocess.run = lambda *a, **kw: FakeResult()
+        try:
+            errors = stpc.check_root_allowlist("HEAD")
+        finally:
+            stpc.subprocess.run = orig_run
+        # README.md and CMakeLists.txt are allowlisted, blanks are skipped.
+        self.assertEqual(errors, [])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Companion-track item **U-1** from `planning/2026-05-17-refactor-roadmap-final.md`.

Extends `tools/scripts/source_tree_pollution_check.py` with a new `--mode=root-allowlist` that blocks unexpected top-level paths from landing.

## What's blocked now

Any tracked top-level path not in `ALLOWED_ROOT_PATHS`. The current allowlist captures the **51 legitimate top-level entries** on `origin/main` today (hidden config, top-level docs, root build/config files, subsystem directories). Adding a new one requires a same-PR allowlist update — enforced both in the pre-push hook and in CI.

## Threat model

- Test fixtures escaping `/tmp` (e.g. the Clock-fixture incident on #1755).
- Mis-placed modules that should live under `core/`, `tools/`, `examples/`, etc.
- Accidental commits of screenshots, profile data, disabled config files (`.mcp.json.disabled-*`, `screenshot.png`, etc.).

The existing Clock-fixture gate addresses one specific incident; this generalizes the same protection to the broader class.

## Files

- `tools/scripts/source_tree_pollution_check.py` — `ALLOWED_ROOT_PATHS` frozenset + `check_root_allowlist()` + CLI plumbing for `--mode=root-allowlist`.
- `tools/scripts/test_source_tree_pollution_check.py` — 4 new tests (passing root, stray file blocked, stray dir blocked, missing-rev handling). All 15 tests pass.
- `.githooks/pre-push` — invokes the new mode after the existing push-mode check.
- `.github/workflows/source-tree-pollution-check.yml` — widened path trigger to `'**'` and added a new step invoking the new mode.
- `.gitignore` — adds `/screenshot.png` and `/.mcp.json.disabled-*`.
- `CONTRIBUTING.md` — new "Repo-root hygiene" section explaining the policy.

## Test plan

- [x] `python3 tools/scripts/test_source_tree_pollution_check.py` — 15/15 pass locally.
- [x] `python3 tools/scripts/source_tree_pollution_check.py --mode=root-allowlist --rev HEAD` — exits 0 on current `origin/main` tree.
- [x] Negative test (stray file added) — exits 1 with clear remediation message.
- [ ] CI confirms the new mode runs and passes on this PR.

## Companion-track context

Part of the non-overlapping companion track running in parallel with `planning/2026-05-17-refactor-roadmap-year.md`. Coordination ledger: `planning/agent-coordination.md`. Companion-safe — no overlap with year.md scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)