### PR TITLE
feat(canvas): FontFlightRecorder — diagnostics foundation (font v2 Slice 2.2)

### DIFF
--- a/core/canvas/CMakeLists.txt
+++ b/core/canvas/CMakeLists.txt
@@ -46,6 +46,11 @@ target_sources(pulp-canvas PRIVATE
     # internally; the real bidi/script iterator swap is the finish
     # half of 1.2.a.
     src/text_run_planner.cpp
+    # Pulp #2163 — Phase 2 / Slice 2.2. FontFlightRecorder is the
+    # bounded process-global trace buffer that callers (the --font-
+    # trace CLI flag, the import-missing-font-advisor, debug overlays)
+    # drain to see every typeface resolution the resolver performed.
+    src/font_flight_recorder.cpp
 )
 
 # Text shaping via SkParagraph (default ON when Skia available, can be disabled)

--- a/core/canvas/include/pulp/canvas/font_flight_recorder.hpp
+++ b/core/canvas/include/pulp/canvas/font_flight_recorder.hpp
@@ -1,0 +1,78 @@
+// font_flight_recorder.hpp
+//
+// Pulp #2163 — font v2 Slice 2.2. The FontFlightRecorder is the
+// process-global sink for FallbackTraceRecord events produced by
+// FontResolver every time a typeface resolves. It's a bounded
+// ring buffer; callers (the --font-trace CLI flag, the import-
+// missing-font-advisor, a developer's debug overlay) can drain it
+// to see exactly which font cascade step produced each glyph.
+//
+// The recorder runs always-on with a reasonable default capacity
+// (1024 records) — there's no measurable overhead at typical UI
+// rates and the diagnostic value of "what fonts did the last
+// frame use" is high. Callers that need a different cap can call
+// set_capacity(); 0 disables recording entirely.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pulp::canvas {
+
+/// One resolution event. Mirrors `FallbackTraceStep` in
+/// `font_resolver.hpp` but is self-contained so the recorder
+/// header doesn't need to drag the resolver header in.
+struct FallbackTraceRecord {
+    std::string  requested_family;
+    std::string  selected_family;
+    std::uint8_t origin;        ///< matches FallbackOrigin enum cast to u8
+    std::uint64_t generation;   ///< registry generation at resolve time
+    std::uint64_t sequence;     ///< monotonic per-recorder sequence number
+};
+
+class FontFlightRecorder {
+public:
+    static FontFlightRecorder& instance();
+
+    /// Append a resolution event. No-op when `capacity() == 0`. When
+    /// the buffer is full, the oldest record is dropped to make room.
+    void record_fallback(const FallbackTraceRecord& record);
+
+    /// Snapshot + clear the buffered records. Returns oldest-first.
+    std::vector<FallbackTraceRecord> drain();
+
+    /// Snapshot only (does not clear). Returns oldest-first.
+    std::vector<FallbackTraceRecord> snapshot() const;
+
+    /// Drop all buffered records.
+    void clear();
+
+    /// Set the ring-buffer capacity. `0` disables recording.
+    /// Default 1024. Shrinking drops the oldest entries.
+    void set_capacity(std::size_t capacity);
+    std::size_t capacity() const noexcept;
+
+    /// Number of records currently buffered.
+    std::size_t size() const noexcept;
+
+private:
+    FontFlightRecorder();
+    ~FontFlightRecorder();
+    FontFlightRecorder(const FontFlightRecorder&)            = delete;
+    FontFlightRecorder& operator=(const FontFlightRecorder&) = delete;
+
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+/// Convenience: drain the global recorder and emit one JSON object per
+/// record to `out`. Used by `pulp-ui-preview --font-trace --format=json`
+/// (Slice 2.2.b CLI wiring lands separately) + the import-missing-font-
+/// advisor.
+std::string flight_recorder_drain_json();
+
+} // namespace pulp::canvas

--- a/core/canvas/src/font_flight_recorder.cpp
+++ b/core/canvas/src/font_flight_recorder.cpp
@@ -1,0 +1,119 @@
+// font_flight_recorder.cpp — Pulp #2163, font v2 Slice 2.2.
+
+#include "pulp/canvas/font_flight_recorder.hpp"
+
+#include <atomic>
+#include <deque>
+#include <mutex>
+#include <sstream>
+
+namespace pulp::canvas {
+
+struct FontFlightRecorder::Impl {
+    mutable std::mutex mtx;
+    std::deque<FallbackTraceRecord> buffer;
+    std::size_t cap = 1024;
+    std::atomic<std::uint64_t> seq{0};
+};
+
+FontFlightRecorder::FontFlightRecorder()
+    : impl_(std::make_unique<Impl>()) {}
+FontFlightRecorder::~FontFlightRecorder() = default;
+
+FontFlightRecorder& FontFlightRecorder::instance() {
+    static FontFlightRecorder inst;
+    return inst;
+}
+
+void FontFlightRecorder::record_fallback(const FallbackTraceRecord& record_in) {
+    // Sequence stamp lives outside the lock so two concurrent
+    // resolves get strictly monotonic sequence numbers regardless
+    // of which one wins the buffer mutex.
+    FallbackTraceRecord rec = record_in;
+    rec.sequence = impl_->seq.fetch_add(1, std::memory_order_acq_rel);
+
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    if (impl_->cap == 0) return;
+    if (impl_->buffer.size() >= impl_->cap) impl_->buffer.pop_front();
+    impl_->buffer.push_back(std::move(rec));
+}
+
+std::vector<FallbackTraceRecord> FontFlightRecorder::drain() {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    std::vector<FallbackTraceRecord> out(impl_->buffer.begin(),
+                                          impl_->buffer.end());
+    impl_->buffer.clear();
+    return out;
+}
+
+std::vector<FallbackTraceRecord> FontFlightRecorder::snapshot() const {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    return {impl_->buffer.begin(), impl_->buffer.end()};
+}
+
+void FontFlightRecorder::clear() {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    impl_->buffer.clear();
+}
+
+void FontFlightRecorder::set_capacity(std::size_t capacity) {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    impl_->cap = capacity;
+    while (impl_->buffer.size() > impl_->cap) impl_->buffer.pop_front();
+}
+
+std::size_t FontFlightRecorder::capacity() const noexcept {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    return impl_->cap;
+}
+
+std::size_t FontFlightRecorder::size() const noexcept {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    return impl_->buffer.size();
+}
+
+namespace {
+void json_escape(std::ostringstream& out, const std::string& s) {
+    out << '"';
+    for (char c : s) {
+        switch (c) {
+            case '"':  out << "\\\""; break;
+            case '\\': out << "\\\\"; break;
+            case '\n': out << "\\n";  break;
+            case '\r': out << "\\r";  break;
+            case '\t': out << "\\t";  break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out << buf;
+                } else {
+                    out << c;
+                }
+        }
+    }
+    out << '"';
+}
+} // namespace
+
+std::string flight_recorder_drain_json() {
+    auto records = FontFlightRecorder::instance().drain();
+    std::ostringstream out;
+    out << "{\"records\":[";
+    bool first = true;
+    for (const auto& r : records) {
+        if (!first) out << ',';
+        first = false;
+        out << "{\"requested_family\":";
+        json_escape(out, r.requested_family);
+        out << ",\"selected_family\":";
+        json_escape(out, r.selected_family);
+        out << ",\"origin\":" << static_cast<int>(r.origin)
+            << ",\"generation\":" << r.generation
+            << ",\"sequence\":" << r.sequence << '}';
+    }
+    out << "]}";
+    return out.str();
+}
+
+} // namespace pulp::canvas

--- a/core/canvas/src/font_resolver.cpp
+++ b/core/canvas/src/font_resolver.cpp
@@ -12,6 +12,7 @@
 #include "pulp/canvas/font_resolver.hpp"
 #include "pulp/canvas/font_scope.hpp"
 #include "pulp/canvas/bundled_fonts.hpp"
+#include "pulp/canvas/font_flight_recorder.hpp"
 
 #include <mutex>
 #include <string>
@@ -239,6 +240,14 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
             r.typeface = apply_variation_axes(std::move(r.typeface));
             r.trace = std::move(trace);
             resolved = std::move(r);
+            // pulp #2163 — Slice 2.2 — record one event per resolution.
+            FontFlightRecorder::instance().record_fallback({
+                /*requested_family*/ family,
+                /*selected_family*/ resolved.actual_family,
+                /*origin*/   static_cast<std::uint8_t>(resolved.origin),
+                /*generation*/ resolved.generation,
+                /*sequence*/ 0,
+            });
             std::lock_guard<std::mutex> lock(impl_->mtx);
             impl_->cache[key] = resolved;
             return resolved;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -975,15 +975,17 @@ target_link_libraries(pulp-test-cluster-step PRIVATE pulp::canvas Catch2::Catch2
 catch_discover_tests(pulp-test-cluster-step)
 
 # pulp #2163 / font v2 Slice 3.2 — AA / hinting / subpixel policy centralization.
-# Locks the enum-to-Skia translation table on ResolvedFont so a stealth change
-# (e.g. flipping AntiAliasMode::Default to kSubpixelAntiAlias) is caught by an
-# automated test instead of by goldens drift weeks later.
 add_executable(pulp-test-font-aa-hinting test_font_aa_hinting.cpp)
 target_link_libraries(pulp-test-font-aa-hinting PRIVATE pulp::canvas Catch2::Catch2WithMain)
 if(PULP_HAS_SKIA)
     target_link_libraries(pulp-test-font-aa-hinting PRIVATE skia::skia)
 endif()
 catch_discover_tests(pulp-test-font-aa-hinting)
+
+# pulp #2163 / font v2 Slice 2.2 — FontFlightRecorder + JSON drain.
+add_executable(pulp-test-font-flight-recorder test_font_flight_recorder.cpp)
+target_link_libraries(pulp-test-font-flight-recorder PRIVATE pulp::canvas Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-font-flight-recorder)
 
 # pulp #2163 — font v2 Slice 1.3 measurement-paint parity harness.
 # Asserts TextShaper predictions match Skia's measured advance within

--- a/test/test_font_flight_recorder.cpp
+++ b/test/test_font_flight_recorder.cpp
@@ -1,0 +1,102 @@
+// test_font_flight_recorder.cpp — Pulp #2163, font v2 Slice 2.2.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/canvas/font_flight_recorder.hpp>
+#include <pulp/canvas/font_resolver.hpp>
+#include <pulp/canvas/font_options.hpp>
+
+#ifdef PULP_HAS_SKIA
+#include "include/core/SkTypeface.h"
+#endif
+
+#include <string>
+
+using namespace pulp::canvas;
+
+TEST_CASE("FlightRecorder: default capacity is non-zero", "[font][diagnostics][issue-2163]") {
+    auto& r = FontFlightRecorder::instance();
+    REQUIRE(r.capacity() > 0u);
+}
+
+TEST_CASE("FlightRecorder: record + drain round-trip", "[font][diagnostics]") {
+    auto& r = FontFlightRecorder::instance();
+    r.clear();
+    REQUIRE(r.size() == 0u);
+
+    r.record_fallback({"Inter", "Inter", 2u, 0u, 0u});
+    r.record_fallback({"JetBrains Mono", "JetBrains Mono", 3u, 0u, 0u});
+    REQUIRE(r.size() == 2u);
+
+    auto out = r.drain();
+    REQUIRE(out.size() == 2u);
+    REQUIRE(r.size() == 0u);
+    REQUIRE(out[0].requested_family == "Inter");
+    REQUIRE(out[1].requested_family == "JetBrains Mono");
+    REQUIRE(out[0].sequence < out[1].sequence);  // monotonic
+}
+
+TEST_CASE("FlightRecorder: capacity overflow drops oldest", "[font][diagnostics]") {
+    auto& r = FontFlightRecorder::instance();
+    r.clear();
+    r.set_capacity(3);
+
+    r.record_fallback({"a", "a", 0u, 0u, 0u});
+    r.record_fallback({"b", "b", 0u, 0u, 0u});
+    r.record_fallback({"c", "c", 0u, 0u, 0u});
+    r.record_fallback({"d", "d", 0u, 0u, 0u});  // pushes 'a' off
+
+    auto out = r.snapshot();
+    REQUIRE(out.size() == 3u);
+    REQUIRE(out[0].requested_family == "b");
+    REQUIRE(out[2].requested_family == "d");
+
+    r.set_capacity(1024);  // restore default
+    r.clear();
+}
+
+TEST_CASE("FlightRecorder: capacity=0 disables recording", "[font][diagnostics]") {
+    auto& r = FontFlightRecorder::instance();
+    r.clear();
+    r.set_capacity(0);
+
+    r.record_fallback({"x", "x", 0u, 0u, 0u});
+    REQUIRE(r.size() == 0u);
+
+    r.set_capacity(1024);
+}
+
+TEST_CASE("FlightRecorder: JSON drain is well-formed", "[font][diagnostics]") {
+    auto& r = FontFlightRecorder::instance();
+    r.clear();
+    r.record_fallback({"Inter", "Inter", 2u, 7u, 0u});
+    std::string json = flight_recorder_drain_json();
+
+    REQUIRE(json.find("\"records\"") != std::string::npos);
+    REQUIRE(json.find("\"requested_family\":\"Inter\"") != std::string::npos);
+    REQUIRE(json.find("\"selected_family\":\"Inter\"") != std::string::npos);
+    REQUIRE(json.find("\"origin\":2") != std::string::npos);
+    REQUIRE(json.find("\"generation\":7") != std::string::npos);
+}
+
+TEST_CASE("FlightRecorder: FontResolver pushes events on resolve",
+          "[font][diagnostics][skia]") {
+#ifdef PULP_HAS_SKIA
+    auto& r = FontFlightRecorder::instance();
+    r.clear();
+    REQUIRE(r.size() == 0u);
+
+    FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.size = 14.0f;
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    if (resolved.resolved()) {
+        // At least one record should have been pushed.
+        REQUIRE(r.size() >= 1u);
+        auto out = r.drain();
+        REQUIRE(out.front().requested_family == "Inter");
+    }
+#else
+    SUCCEED("Skia not compiled");
+#endif
+}


### PR DESCRIPTION
Phase 2 / Slice 2.2. Bounded process-global trace buffer recording every FontResolver typeface resolution. Foundation for --font-trace CLI, import-missing-font-advisor, debug overlays. 6 cases / 20 assertions, all green.