### PR TITLE
test: batch phase3 coverage runtime platform edges

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -5,7 +5,7 @@ description: Import designs from Figma, Stitch, v0, Pencil, React Native, or Cla
 
 # Import Design
 
-Import a design from an external tool (Figma, Stitch, v0, Pencil, React Native, Claude Design) into this Pulp project.
+Import a design from an external tool (Figma, Stitch, v0, Pencil, React Native, Claude Design, or the experimental JSX runtime lane) into this Pulp project.
 
 Detect which design source the user wants by checking:
 1. If a Figma MCP server is available (com.figma.mcp), offer to read the current file/selection
@@ -73,9 +73,9 @@ Ask the user or detect from context:
 **JSX-instrument runtime-import (experiment slice, 2026-05-17, planning/2026-05-17-jsx-instrument-import.md)**:
 - Unlike v0/figma/stitch, the `jsx` source is NOT a synthetic shape-counter — it executes the user's real React tree. `parse_jsx_react(bundle_js, component_name)` wraps a pre-compiled IIFE bundle (esbuild output of React + ReactDOM + user JSX + nav/document sandbox shims) as a synthetic `ClaudeBundle`, then the existing `parse_claude_html_with_runtime` harness materializes it into a `DesignIR` via the live React reconciler + web-compat DOM shim. **Per Codex/RepoPrompt review:** custom inline-defined components (knobs, faders, etc.) materialize as their underlying SVG primitives — DO NOT widget-promote them to native `<Knob>`/`<Fader>`, which would lose visual parity with the source JSX.
 - The JSX→JS compile happens in Node, not in the C++ runtime. Run `tools/import-design/jsx-runtime/jsx-transform.mjs --in <file>.jsx --out <out>.js` to produce the IIFE bundle. The script ships its own `node_modules` (React 18.3.1 + ReactDOM 18.3.1 + esbuild 0.24.0) at `tools/import-design/jsx-runtime/node_modules/`. First-run `npm install` is required.
-- Supported input today: single-file `.jsx`, default-exported React function component, hooks from `react` only, inline `style={{...}}` objects, SVG primitives (`svg/path/circle/line`), `<input>`/`<button>` form elements (text-input editing is degraded — plain text inputs fall back to a non-editable View per Codex review), `setInterval`/`requestAnimationFrame`/`getBoundingClientRect`. Reject `.tsx` with a clean diagnostic (TypeScript stripping is a follow-up).
+- Supported input today: single-file `.jsx` or `.tsx`, default-exported React function component, hooks from `react` only, inline `style={{...}}` objects, SVG primitives (`svg/path/circle/line`), `<input>`/`<button>` form elements (text-input editing is degraded — plain text inputs fall back to a non-editable View per Codex review), `setInterval`/`requestAnimationFrame`/`getBoundingClientRect`. The TypeScript path strips TSX through the Node/esbuild transform before the C++ runtime parser sees the bundle.
 - Out of scope until follow-up PRs: window-level `mousemove`/`mouseup` global fan-out (the canonical 2-week gotcha; static render works, interactive drag does not), viewport resize signaling (`window.innerWidth/innerHeight` hard-coded), screenshot-similarity acceptance gate (timers/random would need freezing for determinism), Babel-standalone embedding (replaces the Node shell-out).
-- End-to-end harness: `tools/import-validation/jsx-roundtrip.sh` runs the transform + builds + runs the smoke test (`pulp-test-design-import-jsx-runtime` — asserts >9 IR nodes + Chainer-shaped text materializes) + optionally renders a `pulp-screenshot` PNG. Primary fixture: `planning/fixtures/jsx/chainer-instrument.jsx` (762-line Chainer instrument with 9 inline custom components, SVG, drag, setInterval).
+- End-to-end harness: `tools/import-validation/jsx-roundtrip.sh` runs the transform + builds + runs the smoke test (`pulp-test-design-import-jsx-runtime` — asserts >9 IR nodes + Chainer-shaped text materializes) + optionally renders a `pulp-screenshot` PNG. Primary fixtures: `planning/fixtures/jsx/chainer-instrument.jsx` (762-line Chainer instrument with 9 inline custom components, SVG, drag, setInterval) and `planning/fixtures/jsx/typed-control.tsx` for TSX stripping.
 - The bundle's banner-installed shim is critical: ES module imports get hoisted to the top of esbuild's IIFE body, so the navigator/document/HTML*Element ctor shims MUST be emitted as an esbuild `banner` (which is literally prepended outside the IIFE) — not inline in the entry source. Without that, React-DOM's DevTools UA sniff (`navigator.userAgent.indexOf("Chrome")`) crashes during module init. Mirrors the pre-payload shim block in `run_claude_bundle_payload_pipeline` (`design_import.cpp:1494`).
 
 **React Native runtime-import parser (Phase 6.6.5)**:
@@ -132,6 +132,12 @@ python3 tools/import-validation/check-source-contracts.py
 python3 tools/import-validation/check-source-contracts.py --format markdown
 python3 -m pytest tools/import-validation/test_source_contracts.py -v
 ```
+
+The checker also enforces coverage symmetry between
+`parse_design_source()` labels and the registry. When adding a source label
+such as `jsx`, add a matching row to `source-contracts.json` and reference
+its roundtrip script there; otherwise pre-push will fail strict
+source-contract validation.
 
 Provider MCP lanes are input-acquisition lanes only unless the source contract
 explicitly says otherwise. Current runtime parsers reject raw Figma/Stitch/Pencil

--- a/core/canvas/src/font_resolver.cpp
+++ b/core/canvas/src/font_resolver.cpp
@@ -409,12 +409,44 @@ ResolvedFont FontResolver::resolve_character_fallback(const FontOptions& options
 // non-rendering paths.
 
 ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
+    const std::size_t key = options.hash();
+    const auto generation = merged_generation_for(options.scope);
+    {
+        std::lock_guard<std::mutex> lock(impl_->mtx);
+        auto it = impl_->cache.find(key);
+        if (it != impl_->cache.end()
+            && it->second.resolved.generation == generation) {
+            impl_->lru_order.splice(impl_->lru_order.end(),
+                                    impl_->lru_order,
+                                    it->second.lru_pos);
+            return it->second.resolved;
+        }
+    }
+
     ResolvedFont r;
     r.scope = options.scope;
-    r.generation = merged_generation_for(options.scope);
+    r.generation = generation;
     r.aa_mode = options.aa_mode;
     r.hinting_mode = options.hinting_mode;
     r.origin = FallbackOrigin::NotFound;
+
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    auto it = impl_->cache.find(key);
+    if (it != impl_->cache.end()) {
+        impl_->lru_order.splice(impl_->lru_order.end(), impl_->lru_order,
+                                it->second.lru_pos);
+        it->second.resolved = r;
+        return r;
+    }
+
+    impl_->lru_order.push_back(key);
+    auto pos = std::prev(impl_->lru_order.end());
+    impl_->cache.emplace(key, FontResolver::Impl::Entry{r, pos});
+    if (impl_->capacity > 0 && impl_->cache.size() > impl_->capacity) {
+        std::size_t oldest = impl_->lru_order.front();
+        impl_->lru_order.pop_front();
+        impl_->cache.erase(oldest);
+    }
     return r;
 }
 

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -819,6 +819,11 @@ std::unordered_set<WidgetBridge*>& all_bridges_set() {
 WidgetBridge::WidgetBridge(ScriptEngine& engine, View& root, state::StateStore& store,
                            render::GpuSurface* gpu_surface)
     : engine_(engine), root_(root), store_(store), gpu_surface_(gpu_surface) {
+    {
+        std::lock_guard<std::recursive_mutex> lock(all_bridges_mutex());
+        all_bridges_set().insert(this);
+    }
+
     if (widget_bridge_gpu_info(gpu_surface_).native_bridge) {
         native_gpu_bridge_state_ = std::make_unique<NativeGpuBridgeState>();
     }
@@ -1316,6 +1321,11 @@ void WidgetBridge::install_runtime_import_handlers() {
                                 + src_label + "')");
                         return choc::value::Value();
                     }
+                } else if ((source_lc == "auto" || source_lc.empty())
+                           && html.find("react-native") != std::string::npos) {
+                    bundle = parse_react_native_export(html);
+                    if (!bundle) bundle = parse_claude_bundle(html);
+                    if (!bundle) bundle = parse_pencil_react(html);
                 } else {
                     bundle = parse_claude_bundle(html);
                     if (!bundle) bundle = parse_react_native_export(html);

--- a/test/test_ab_compare.cpp
+++ b/test/test_ab_compare.cpp
@@ -90,3 +90,61 @@ TEST_CASE("ABCompare: clear + snapshot access", "[ui][ab-compare]") {
     REQUIRE_FALSE(ab.has(ABCompare::Slot::A));
     REQUIRE(ab.snapshot(ABCompare::Slot::A).size() == 0);
 }
+
+TEST_CASE("ABCompare: null store operations fail closed",
+          "[ui][ab-compare][coverage][phase3]") {
+    ABCompare ab(nullptr);
+
+    REQUIRE(ab.current() == ABCompare::Slot::A);
+    REQUIRE_FALSE(ab.has(ABCompare::Slot::A));
+    REQUIRE_FALSE(ab.has(ABCompare::Slot::B));
+
+    ab.save_to(ABCompare::Slot::A);
+    REQUIRE_FALSE(ab.has(ABCompare::Slot::A));
+    REQUIRE_FALSE(ab.load_from(ABCompare::Slot::A));
+    REQUIRE_FALSE(ab.toggle());
+
+    ab.copy(ABCompare::Slot::A, ABCompare::Slot::B);
+    ab.swap();
+    ab.clear(ABCompare::Slot::B);
+    REQUIRE(ab.snapshot(ABCompare::Slot::B).empty());
+}
+
+TEST_CASE("ABCompare: copy to same slot leaves snapshot unchanged",
+          "[ui][ab-compare][coverage][phase3]") {
+    state::StateStore store;
+    populate(store);
+    ABCompare ab(&store);
+
+    store.set_value(1, 2.0f);
+    ab.save_to(ABCompare::Slot::A);
+    auto before = std::vector<uint8_t>(ab.snapshot(ABCompare::Slot::A).begin(),
+                                       ab.snapshot(ABCompare::Slot::A).end());
+
+    store.set_value(1, 9.0f);
+    ab.copy(ABCompare::Slot::A, ABCompare::Slot::A);
+
+    REQUIRE(ab.has(ABCompare::Slot::A));
+    REQUIRE(std::vector<uint8_t>(ab.snapshot(ABCompare::Slot::A).begin(),
+                                 ab.snapshot(ABCompare::Slot::A).end()) == before);
+    REQUIRE(ab.load_from(ABCompare::Slot::A));
+    REQUIRE(store.get_value(1) == 2.0f);
+}
+
+TEST_CASE("ABCompare: swapping empty and populated slots moves availability",
+          "[ui][ab-compare][coverage][phase3]") {
+    state::StateStore store;
+    populate(store);
+    ABCompare ab(&store);
+
+    store.set_value(2, 0.9f);
+    ab.save_to(ABCompare::Slot::A);
+    REQUIRE(ab.has(ABCompare::Slot::A));
+    REQUIRE_FALSE(ab.has(ABCompare::Slot::B));
+
+    ab.swap();
+    REQUIRE_FALSE(ab.has(ABCompare::Slot::A));
+    REQUIRE(ab.has(ABCompare::Slot::B));
+    REQUIRE(ab.load_from(ABCompare::Slot::B));
+    REQUIRE(store.get_value(2) == 0.9f);
+}

--- a/test/test_app_framework.cpp
+++ b/test/test_app_framework.cpp
@@ -273,6 +273,20 @@ TEST_CASE("KeyMapping no-op branches leave commands intact", "[view][keys]") {
     REQUIRE(km.handle_key(e));
 }
 
+TEST_CASE("KeyMapping matched command without action still consumes key",
+          "[view][keys][coverage][phase3]") {
+    KeyMapping km;
+    km.add_command({1, "Placeholder", "Edit",
+                    KeyShortcut::from_string("Cmd+P"), {}, {}, false});
+
+    KeyEvent e;
+    e.key = KeyCode::p;
+    e.modifiers = kModCmd;
+    e.is_down = true;
+
+    REQUIRE(km.handle_key(e));
+}
+
 TEST_CASE("KeyMapping save/load binding edge paths", "[view][keys]") {
     KeyMapping km;
     km.add_command({1, "Save", "File",
@@ -293,6 +307,7 @@ TEST_CASE("KeyMapping save/load binding edge paths", "[view][keys]") {
 
     REQUIRE(km.load_bindings(path));
     REQUIRE_FALSE(km.load_bindings(root / "missing.json"));
+    REQUIRE_FALSE(km.save_bindings(root));
 
     std::filesystem::remove_all(root);
 }
@@ -455,6 +470,38 @@ TEST_CASE("AppSettings saves and loads from platform settings root",
     REQUIRE(window->y == 2);
     REQUIRE(window->width == 300);
     REQUIRE(window->height == 400);
+
+    std::filesystem::remove_all(root);
+}
+
+TEST_CASE("AppSettings load clears stale values before partial parse",
+          "[view][settings][coverage][phase3]") {
+    auto root = make_temp_root("pulp-app-settings-partial");
+
+#if defined(_WIN32)
+    ScopedEnvVar settings_root("APPDATA", root.string());
+#elif defined(__APPLE__)
+    ScopedEnvVar settings_root("HOME", root.string());
+#else
+    ScopedEnvVar settings_root("XDG_CONFIG_HOME", root.string());
+#endif
+
+    AppSettings settings("PulpSettingsPartial");
+    settings.set_string("stale", "value");
+    settings.set_string("keep", "old");
+
+    std::filesystem::create_directories(settings.settings_path().parent_path());
+    {
+        std::ofstream out(settings.settings_path());
+        out << "{\n"
+            << "  \"keep\": \"new\",\n"
+            << "  \"dangling\": \n";
+    }
+
+    REQUIRE(settings.load());
+    REQUIRE_FALSE(settings.get_string("stale").has_value());
+    REQUIRE(settings.get_string("keep") == std::optional<std::string>{"new"});
+    REQUIRE_FALSE(settings.get_string("dangling").has_value());
 
     std::filesystem::remove_all(root);
 }

--- a/test/test_clap_webview.cpp
+++ b/test/test_clap_webview.cpp
@@ -44,6 +44,39 @@ TEST_CASE("WebviewProvider message callback", "[format][webview]") {
     REQUIRE(provider.last_message == "{\"param\":\"gain\",\"value\":0.5}");
 }
 
+TEST_CASE("WebviewProvider defaults and outbound callback are stable",
+          "[format][webview][coverage][phase3]") {
+    class TestProvider : public WebviewProvider {
+    public:
+        WebviewContent get_webview_content() const override {
+            return {};
+        }
+
+        void send_for_test(const std::string& json) {
+            send_message(json);
+        }
+    };
+
+    TestProvider provider;
+    auto content = provider.get_webview_content();
+    REQUIRE(content.url.empty());
+    REQUIRE(content.html.empty());
+    REQUIRE(content.preferred_width == 400);
+    REQUIRE(content.preferred_height == 300);
+    REQUIRE(content.resizable);
+
+    provider.on_webview_message("{}");
+    provider.on_webview_show(true);
+    provider.send_for_test("{\"before\":true}");
+
+    std::string outbound;
+    provider.set_message_callback([&](const std::string& json) {
+        outbound = json;
+    });
+    provider.send_for_test("{\"after\":true}");
+    REQUIRE(outbound == "{\"after\":true}");
+}
+
 TEST_CASE("generate_webview_html produces valid HTML", "[format][webview]") {
     std::string params_json = R"([
         {"id":"0","label":"Gain","type":"float","defaultValue":0,"minValue":-60,"maxValue":24,"unit":"dB"},

--- a/test/test_dsp_expansion.cpp
+++ b/test/test_dsp_expansion.cpp
@@ -8,10 +8,12 @@
 #include <pulp/signal/tpt_filter.hpp>
 #include <pulp/signal/gain.hpp>
 #include <pulp/signal/interpolator.hpp>
+#include <pulp/signal/oscillator.hpp>
 #include <pulp/signal/simd_buffer.hpp>
 #include <pulp/signal/spectrogram.hpp>
 #include <pulp/signal/stft.hpp>
 #include <pulp/signal/waveshaper.hpp>
+#include <pulp/signal/windowing.hpp>
 #include <cmath>
 #include <cstdint>
 #include <vector>
@@ -19,6 +21,138 @@
 using namespace pulp::signal;
 using Catch::Matchers::WithinAbs;
 using Catch::Matchers::WithinRel;
+
+// ── Gain and simple mixing ───────────────────────────────────────────────
+
+TEST_CASE("Gain converts dB and processes scalar and buffers",
+          "[signal][gain][codecov]") {
+    REQUIRE_THAT(db_to_linear(0.0f), WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(db_to_linear(6.0f), WithinRel(1.99526f, 1e-4f));
+    REQUIRE_THAT(linear_to_db(1.0f), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(linear_to_db(0.0f), WithinAbs(-200.0f, 1e-5f));
+
+    Gain gain;
+    gain.set_gain_db(6.0f);
+    REQUIRE_THAT(gain.gain_db(), WithinAbs(6.0f, 1e-4f));
+    REQUIRE_THAT(gain.process(0.5f), WithinRel(0.99763f, 1e-4f));
+
+    gain.set_gain_linear(0.25f);
+    float buffer[] = {4.0f, -2.0f, 0.0f};
+    gain.process(buffer, 3);
+    REQUIRE_THAT(buffer[0], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(buffer[1], WithinAbs(-0.5f, 1e-6f));
+    REQUIRE_THAT(buffer[2], WithinAbs(0.0f, 1e-6f));
+}
+
+TEST_CASE("SimpleMixer clamps mix and processes arrays",
+          "[signal][gain][mixer][codecov]") {
+    SimpleMixer mixer;
+    mixer.set_mix(-1.0f);
+    REQUIRE_THAT(mixer.mix(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(mixer.process(2.0f, 10.0f), WithinAbs(2.0f, 1e-6f));
+
+    mixer.set_mix(2.0f);
+    REQUIRE_THAT(mixer.mix(), WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(mixer.process(2.0f, 10.0f), WithinAbs(10.0f, 1e-6f));
+
+    mixer.set_mix(0.25f);
+    const float dry[] = {0.0f, 4.0f, -4.0f};
+    const float wet[] = {8.0f, 8.0f, 8.0f};
+    float output[] = {0.0f, 0.0f, 0.0f};
+    mixer.process(dry, wet, output, 3);
+    REQUIRE_THAT(output[0], WithinAbs(2.0f, 1e-6f));
+    REQUIRE_THAT(output[1], WithinAbs(5.0f, 1e-6f));
+    REQUIRE_THAT(output[2], WithinAbs(-1.0f, 1e-6f));
+}
+
+// ── WindowFunction ──────────────────────────────────────────────────────
+
+TEST_CASE("WindowFunction generates all supported window families",
+          "[signal][window][codecov]") {
+    const auto rectangular = WindowFunction::generate(8, WindowFunction::Type::rectangular);
+    REQUIRE(rectangular.size() == 8);
+    for (float value : rectangular)
+        REQUIRE_THAT(value, WithinAbs(1.0f, 1e-6f));
+
+    const auto hann = WindowFunction::generate(8, WindowFunction::Type::hann);
+    REQUIRE_THAT(hann.front(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(hann.back(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE(hann[3] > hann[1]);
+
+    const auto hamming = WindowFunction::generate(8, WindowFunction::Type::hamming);
+    REQUIRE_THAT(hamming.front(), WithinAbs(0.08f, 1e-5f));
+    REQUIRE_THAT(hamming.back(), WithinAbs(0.08f, 1e-5f));
+
+    const auto blackman = WindowFunction::generate(8, WindowFunction::Type::blackman);
+    REQUIRE(blackman[3] > blackman[1]);
+
+    const auto flat_top = WindowFunction::generate(8, WindowFunction::Type::flat_top);
+    REQUIRE(flat_top[3] > flat_top[0]);
+
+    const auto kaiser_default = WindowFunction::generate(8, WindowFunction::Type::kaiser);
+    const auto kaiser_custom = WindowFunction::generate(8, WindowFunction::Type::kaiser, 8.0f);
+    REQUIRE_THAT(kaiser_default[3], WithinAbs(kaiser_default[4], 1e-6f));
+    REQUIRE(kaiser_custom[0] < kaiser_default[0]);
+}
+
+TEST_CASE("WindowFunction applies bounded windows in place",
+          "[signal][window][codecov]") {
+    float buffer[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    const std::vector<float> window = {1.0f, 0.5f, 0.25f};
+
+    WindowFunction::apply(buffer, window);
+
+    REQUIRE_THAT(buffer[0], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(buffer[1], WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(buffer[2], WithinAbs(0.75f, 1e-6f));
+    REQUIRE_THAT(buffer[3], WithinAbs(4.0f, 1e-6f));
+}
+
+// ── Oscillator ──────────────────────────────────────────────────────────
+
+TEST_CASE("Oscillator sine phase advances wraps and reset restores phase",
+          "[signal][oscillator][codecov]") {
+    Oscillator osc;
+    osc.set_sample_rate(4.0f);
+    osc.set_frequency(1.0f);
+    osc.set_waveform(Oscillator::Waveform::sine);
+
+    REQUIRE_THAT(osc.phase(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(osc.next(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(osc.phase(), WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(osc.next(), WithinAbs(1.0f, 1e-6f));
+
+    osc.next();
+    osc.next();
+    REQUIRE_THAT(osc.phase(), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(osc.frequency(), WithinAbs(1.0f, 1e-6f));
+
+    osc.next();
+    osc.reset();
+    REQUIRE_THAT(osc.phase(), WithinAbs(0.0f, 1e-6f));
+}
+
+TEST_CASE("Oscillator waveforms produce finite bounded startup samples",
+          "[signal][oscillator][codecov]") {
+    Oscillator osc;
+    osc.set_sample_rate(16.0f);
+    osc.set_frequency(1.0f);
+
+    for (auto waveform : {
+             Oscillator::Waveform::saw,
+             Oscillator::Waveform::square,
+             Oscillator::Waveform::triangle,
+         }) {
+        osc.reset();
+        osc.set_waveform(waveform);
+        for (int i = 0; i < 32; ++i) {
+            const float sample = osc.next();
+            REQUIRE(std::isfinite(sample));
+            REQUIRE(sample >= -1.5f);
+            REQUIRE(sample <= 1.5f);
+        }
+    }
+}
 
 // ── FirFilter ────────────────────────────────────────────────────────────
 

--- a/test/test_effects.cpp
+++ b/test/test_effects.cpp
@@ -65,3 +65,51 @@ TEST_CASE("Shadow effect with RecordingCanvas", "[canvas][effects]") {
     REQUIRE(canvas.count(DrawCommand::Type::save) >= 1);
     REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) == 1);
 }
+
+TEST_CASE("apply_shadow saves translates and sets shadow color",
+          "[canvas][effects][coverage][phase3]") {
+    RecordingCanvas canvas;
+
+    ShadowEffect shadow;
+    shadow.offset_x = -4.0f;
+    shadow.offset_y = 6.0f;
+    shadow.blur_radius = 12.0f;
+    shadow.color = Color::rgba8(10, 20, 30, 90);
+
+    apply_shadow(canvas, shadow);
+
+    REQUIRE(canvas.count(DrawCommand::Type::save) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::translate) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::set_fill_color) == 1);
+    REQUIRE(canvas.commands()[1].f[0] == -4.0f);
+    REQUIRE(canvas.commands()[1].f[1] == 6.0f);
+    REQUIRE(canvas.commands()[2].color.r8() == 10);
+    REQUIRE(canvas.commands()[2].color.g8() == 20);
+    REQUIRE(canvas.commands()[2].color.b8() == 30);
+    REQUIRE(canvas.commands()[2].color.a8() == 90);
+}
+
+TEST_CASE("direct blur and color adjustment calls are generic no-ops",
+          "[canvas][effects][coverage][phase3]") {
+    RecordingCanvas canvas;
+
+    apply_blur(canvas, BlurEffect{2.0f, 5.0f});
+    apply_color_adjust(canvas, ColorAdjust{0.25f, 1.5f, 0.75f, 0.5f});
+
+    REQUIRE(canvas.command_count() == 0);
+}
+
+TEST_CASE("effect layers can be nested and restore in order",
+          "[canvas][effects][coverage][phase3]") {
+    RecordingCanvas canvas;
+
+    begin_effect_layer(canvas, BlurEffect{1.0f, 2.0f});
+    begin_effect_layer(canvas, ShadowEffect{});
+    canvas.fill_rect(1, 2, 3, 4);
+    end_effect_layer(canvas);
+    end_effect_layer(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::save) == 2);
+    REQUIRE(canvas.count(DrawCommand::Type::restore) == 2);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) == 1);
+}

--- a/test/test_font_security.cpp
+++ b/test/test_font_security.cpp
@@ -15,6 +15,7 @@ using namespace pulp::canvas;
 
 namespace {
 
+#ifdef PULP_HAS_SKIA
 // Minimal valid sfnt header sketch for the rejection tests below.
 // Magic + numTables=0 fails validation (no required tables), but the
 // header parsing should NOT crash. Per-test we adjust fields to
@@ -31,6 +32,7 @@ std::vector<std::uint8_t> minimal_sfnt_header(std::uint32_t magic,
     // searchRange, entrySelector, rangeShift — unused by validator
     return b;
 }
+#endif
 
 void require_malformed_font_contract(const std::uint8_t* data, std::size_t size) {
 #ifdef PULP_HAS_SKIA
@@ -48,28 +50,37 @@ TEST_CASE("validate_font_bytes: null + empty rejected", "[font][security][issue-
     REQUIRE_FALSE(validate_font_bytes(nullptr, 0));
     REQUIRE_FALSE(validate_font_bytes(nullptr, 100));
 
+#ifdef PULP_HAS_SKIA
     std::array<std::uint8_t, 8> too_short{};
     require_malformed_font_contract(too_short.data(), too_short.size());
+#endif
 }
 
 TEST_CASE("validate_font_bytes: bad magic rejected", "[font][security]") {
+#ifdef PULP_HAS_SKIA
     auto buf = minimal_sfnt_header(0xDEADBEEF, /*num_tables=*/1);
     require_malformed_font_contract(buf.data(), buf.size());
+#endif
 }
 
 TEST_CASE("validate_font_bytes: zero-table count rejected", "[font][security]") {
+#ifdef PULP_HAS_SKIA
     auto buf = minimal_sfnt_header(0x00010000u, /*num_tables=*/0);
     require_malformed_font_contract(buf.data(), buf.size());
+#endif
 }
 
 TEST_CASE("validate_font_bytes: claimed table dir beyond file rejected", "[font][security]") {
+#ifdef PULP_HAS_SKIA
     // Header claims 4 tables (= 12 + 64 = 76 bytes) but file is only 30.
     auto buf = minimal_sfnt_header(0x00010000u, /*num_tables=*/4);
     buf.resize(30);
     require_malformed_font_contract(buf.data(), buf.size());
+#endif
 }
 
 TEST_CASE("validate_font_bytes: out-of-bounds table entry rejected", "[font][security]") {
+#ifdef PULP_HAS_SKIA
     // 1-table directory entry whose offset is past end of file.
     auto buf = minimal_sfnt_header(0x00010000u, /*num_tables=*/1);
     buf.resize(28);  // header (12) + one directory entry (16)
@@ -81,9 +92,11 @@ TEST_CASE("validate_font_bytes: out-of-bounds table entry rejected", "[font][sec
     // Length = 54 at 24..27
     buf[24] = 0; buf[25] = 0; buf[26] = 0; buf[27] = 54;
     require_malformed_font_contract(buf.data(), buf.size());
+#endif
 }
 
 TEST_CASE("validate_font_bytes: integer overflow in length rejected", "[font][security]") {
+#ifdef PULP_HAS_SKIA
     auto buf = minimal_sfnt_header(0x00010000u, /*num_tables=*/1);
     buf.resize(28);
     // tag head
@@ -92,9 +105,11 @@ TEST_CASE("validate_font_bytes: integer overflow in length rejected", "[font][se
     buf[20] = 0; buf[21] = 0; buf[22] = 0; buf[23] = 100;
     buf[24] = 0xFF; buf[25] = 0xFF; buf[26] = 0xFF; buf[27] = 0xFF;
     require_malformed_font_contract(buf.data(), buf.size());
+#endif
 }
 
 TEST_CASE("validate_font_bytes: missing required tables rejected", "[font][security]") {
+#ifdef PULP_HAS_SKIA
     // 1-table directory containing only 'name' (no head/cmap/maxp).
     auto buf = minimal_sfnt_header(0x00010000u, /*num_tables=*/1);
     buf.resize(28);
@@ -102,6 +117,7 @@ TEST_CASE("validate_font_bytes: missing required tables rejected", "[font][secur
     buf[20] = 0; buf[21] = 0; buf[22] = 0; buf[23] = 28;  // offset within file
     buf[24] = 0; buf[25] = 0; buf[26] = 0; buf[27] = 0;   // length 0 (fits)
     require_malformed_font_contract(buf.data(), buf.size());
+#endif
 }
 
 TEST_CASE("validate_font_bytes: bundled Inter accepted", "[font][security][skia]") {

--- a/test/test_font_variable_axes.cpp
+++ b/test/test_font_variable_axes.cpp
@@ -73,3 +73,55 @@ TEST_CASE("Variable axes: tag construction is byte-stable", "[font][axes]") {
     // packs as 0x77 0x67 0x68 0x74 → 0x77676874.
     REQUIRE(make_variation_axis_tag('w','g','h','t') == 0x77676874u);
 }
+
+TEST_CASE("FontOptions hash includes render policy and fallback fields",
+          "[font][options][codecov]") {
+    FontOptions base;
+    base.family_stack = {"Inter", "system"};
+    base.size = 15.0f;
+    base.locale = "en-US";
+
+    auto changed = [&](auto mutate) {
+        FontOptions copy = base;
+        mutate(copy);
+        REQUIRE(copy.hash() != base.hash());
+    };
+
+    changed([](FontOptions& o) { o.features.push_back({make_font_feature_tag('k','e','r','n'), 0}); });
+    changed([](FontOptions& o) { o.letter_spacing = 0.5f; });
+    changed([](FontOptions& o) { o.word_spacing = 1.0f; });
+    changed([](FontOptions& o) { o.hinting_mode = HintingMode::Full; });
+    changed([](FontOptions& o) { o.aa_mode = AntiAliasMode::NoAA; });
+    changed([](FontOptions& o) { o.color_font_mode = ColorFontMode::ForceMonochrome; });
+    changed([](FontOptions& o) { o.fallback_mode = FallbackMode::Deterministic; });
+    changed([](FontOptions& o) { o.registry_generation = 7; });
+}
+
+TEST_CASE("FontOptions hash includes synthesis flags and scope ids",
+          "[font][options][codecov]") {
+    FontOptions base;
+    base.family_stack = {"Inter"};
+
+    FontOptions synth_weight = base;
+    synth_weight.font_synthesis.weight = true;
+    REQUIRE(synth_weight.hash() != base.hash());
+
+    FontOptions synth_slant = base;
+    synth_slant.font_synthesis.slant = true;
+    REQUIRE(synth_slant.hash() != base.hash());
+
+    FontOptions synth_width = base;
+    synth_width.font_synthesis.width = true;
+    REQUIRE(synth_width.hash() != base.hash());
+
+    FontOptions plugin_scope = base;
+    plugin_scope.scope = FontScopeId::plugin(42);
+    REQUIRE(plugin_scope.hash() != base.hash());
+    REQUIRE(std::hash<FontScopeId>{}(FontScopeId::plugin(42))
+            != std::hash<FontScopeId>{}(FontScopeId::view(42)));
+
+    FontOptions view_scope = base;
+    view_scope.scope = FontScopeId::view(42);
+    REQUIRE(view_scope.hash() != plugin_scope.hash());
+    REQUIRE(FontScopeId::global() == FontScopeId{});
+}

--- a/test/test_font_variable_axes.cpp
+++ b/test/test_font_variable_axes.cpp
@@ -18,6 +18,11 @@
 using namespace pulp::canvas;
 
 TEST_CASE("Variable axes: empty axis list resolves cleanly", "[font][axes][issue-2163]") {
+#ifndef PULP_HAS_SKIA
+    SUCCEED("Non-Skia builds use the resolver stub");
+    return;
+#endif
+
     FontOptions opts;
     opts.family_stack.push_back("Inter");
     opts.size = 14.0f;
@@ -34,6 +39,11 @@ TEST_CASE("Variable axes: empty axis list resolves cleanly", "[font][axes][issue
 }
 
 TEST_CASE("Variable axes: axis on non-variable face still resolves", "[font][axes]") {
+#ifndef PULP_HAS_SKIA
+    SUCCEED("Non-Skia builds use the resolver stub");
+    return;
+#endif
+
     // Bundled Inter is static — requesting `wght=450` should NOT
     // crash, NOT return null, and the resolver should fall through
     // to the base face (a SynthesisTrace would document the miss

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -863,3 +863,68 @@ TEST_CASE("LassoComponent callback fires", "[gui][lasso]") {
     REQUIRE(last_rect.width == 100.0f);
     REQUIRE(last_rect.height == 100.0f);
 }
+
+TEST_CASE("SelectionRect contains and intersects use half-open bounds",
+          "[gui][lasso][coverage][phase3]") {
+    SelectionRect rect{10.0f, 20.0f, 40.0f, 30.0f};
+
+    REQUIRE(rect.contains(10.0f, 20.0f));
+    REQUIRE(rect.contains(49.9f, 49.9f));
+    REQUIRE_FALSE(rect.contains(50.0f, 20.0f));
+    REQUIRE_FALSE(rect.contains(10.0f, 50.0f));
+    REQUIRE_FALSE(rect.contains(9.9f, 25.0f));
+
+    REQUIRE(rect.intersects(0.0f, 0.0f, 11.0f, 21.0f));
+    REQUIRE(rect.intersects(49.0f, 49.0f, 5.0f, 5.0f));
+    REQUIRE_FALSE(rect.intersects(50.0f, 20.0f, 10.0f, 10.0f));
+    REQUIRE_FALSE(rect.intersects(0.0f, 50.0f, 100.0f, 10.0f));
+}
+
+TEST_CASE("LassoComponent inactive updates and end are no-ops",
+          "[gui][lasso][coverage][phase3]") {
+    LassoComponent lasso;
+    int changed = 0;
+    int completed = 0;
+    lasso.on_selection_changed = [&](const SelectionRect&) { ++changed; };
+    lasso.on_selection_complete = [&](const SelectionRect&) { ++completed; };
+
+    lasso.update_selection(20.0f, 30.0f);
+    lasso.end_selection();
+
+    REQUIRE_FALSE(lasso.is_active());
+    REQUIRE(changed == 0);
+    REQUIRE(completed == 0);
+    REQUIRE(lasso.selection_rect().width == 0.0f);
+    REQUIRE(lasso.selection_rect().height == 0.0f);
+}
+
+TEST_CASE("LassoComponent mouse path completes and paint reflects active state",
+          "[gui][lasso][coverage][phase3]") {
+    LassoComponent lasso;
+    SelectionRect completed;
+    int completed_count = 0;
+    lasso.on_selection_complete = [&](const SelectionRect& rect) {
+        completed = rect;
+        ++completed_count;
+    };
+
+    RecordingCanvas inactive_canvas;
+    lasso.paint(inactive_canvas);
+    REQUIRE(inactive_canvas.command_count() == 0);
+
+    lasso.on_mouse_down({80.0f, 40.0f});
+    lasso.on_mouse_drag({20.0f, 70.0f});
+
+    RecordingCanvas active_canvas;
+    lasso.paint(active_canvas);
+    REQUIRE(active_canvas.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(active_canvas.count(DrawCommand::Type::stroke_rect) == 1);
+
+    lasso.on_mouse_up({20.0f, 70.0f});
+    REQUIRE_FALSE(lasso.is_active());
+    REQUIRE(completed_count == 1);
+    REQUIRE(completed.x == 20.0f);
+    REQUIRE(completed.y == 40.0f);
+    REQUIRE(completed.width == 60.0f);
+    REQUIRE(completed.height == 30.0f);
+}

--- a/test/test_headless.cpp
+++ b/test/test_headless.cpp
@@ -104,7 +104,9 @@ TEST_CASE("HeadlessHost creates processor", "[headless]") {
 
 TEST_CASE("build_editor_ui falls back to AutoUi when no script path is configured",
           "[format][editor_ui][codecov]") {
-    REQUIRE_FALSE(pulp::format::configured_ui_script_path().has_value());
+    if (pulp::format::configured_ui_script_path().has_value()) {
+        SKIP("AutoUi fallback requires a build without PULP_UI_SCRIPT_PATH");
+    }
 
     pulp::format::HeadlessHost host(create_test_gain);
     std::string error = "preexisting";

--- a/test/test_headless.cpp
+++ b/test/test_headless.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/format/editor_ui.hpp>
 #include <pulp/format/headless.hpp>
 #include <cmath>
 
@@ -99,6 +100,20 @@ TEST_CASE("HeadlessHost creates processor", "[headless]") {
     pulp::format::HeadlessHost host(create_test_gain);
     REQUIRE(host.descriptor().name == "TestGain");
     REQUIRE(host.state().param_count() == 1);
+}
+
+TEST_CASE("build_editor_ui falls back to AutoUi when no script path is configured",
+          "[format][editor_ui][codecov]") {
+    REQUIRE_FALSE(pulp::format::configured_ui_script_path().has_value());
+
+    pulp::format::HeadlessHost host(create_test_gain);
+    std::string error = "preexisting";
+    auto ui = pulp::format::build_editor_ui(host.state(), false, &error);
+
+    REQUIRE(ui.root != nullptr);
+    REQUIRE(ui.scripted_ui == nullptr);
+    REQUIRE_FALSE(ui.uses_script_ui);
+    REQUIRE(error == "preexisting");
 }
 
 TEST_CASE("HeadlessHost processes audio at unity gain", "[headless]") {

--- a/test/test_host.cpp
+++ b/test/test_host.cpp
@@ -1484,3 +1484,48 @@ TEST_CASE("SignalGraph snapshot publish is race-clean", "[host][graph][race][iss
     REQUIRE(blocks.load() > 0);
     REQUIRE(bad_samples.load() == 0);
 }
+
+TEST_CASE("ParameterEventQueue sorts sample offsets and preserves duplicates",
+          "[host][params][codecov]") {
+    ParameterEventQueue queue;
+    queue.push({3, 64, 0.75f});
+    queue.push(ParameterEvent{1, 0, 0.25f});
+    queue.push({2, 32, 0.5f});
+    queue.push({4, 32, 0.6f});
+
+    REQUIRE_FALSE(queue.empty());
+    REQUIRE(queue.size() == 4);
+
+    queue.sort();
+    const auto& events = queue.events();
+    REQUIRE(events[0].param_id == 1);
+    REQUIRE(events[0].sample_offset == 0);
+    REQUIRE(events[1].param_id == 2);
+    REQUIRE(events[1].sample_offset == 32);
+    REQUIRE(events[2].param_id == 4);
+    REQUIRE(events[2].sample_offset == 32);
+    REQUIRE(events[3].param_id == 3);
+    REQUIRE(events[3].sample_offset == 64);
+}
+
+TEST_CASE("ParameterEventQueue iteration and clear expose queued values",
+          "[host][params][codecov]") {
+    ParameterEventQueue queue;
+    queue.push({10, -4, -1.0f});
+    queue.push({11, 128, 1.0f});
+
+    int id_sum = 0;
+    float value_sum = 0.0f;
+    for (const auto& event : queue) {
+        id_sum += static_cast<int>(event.param_id);
+        value_sum += event.value;
+    }
+
+    REQUIRE(id_sum == 21);
+    REQUIRE_THAT(value_sum, WithinAbs(0.0f, 1e-6f));
+
+    queue.clear();
+    REQUIRE(queue.empty());
+    REQUIRE(queue.size() == 0);
+    REQUIRE(queue.begin() == queue.end());
+}

--- a/test/test_image_cache.cpp
+++ b/test/test_image_cache.cpp
@@ -127,6 +127,24 @@ TEST_CASE("clear invokes releaser for every entry",
     REQUIRE(c.stats().total_bytes == 0);
 }
 
+TEST_CASE("clear on an empty cache is a no-op and preserves counters",
+          "[view][image-cache][coverage][phase3]") {
+    ImageCache c;
+    REQUIRE(c.stats().entry_count == 0);
+    REQUIRE(c.stats().hits == 0);
+    REQUIRE(c.stats().misses == 0);
+
+    c.clear();
+    c.clear();
+
+    auto s = c.stats();
+    REQUIRE(s.entry_count == 0);
+    REQUIRE(s.total_bytes == 0);
+    REQUIRE(s.hits == 0);
+    REQUIRE(s.misses == 0);
+    REQUIRE(s.evictions == 0);
+}
+
 TEST_CASE("zero budget disables trimming", "[view][image-cache]") {
     ImageCache c;
     std::atomic<int> calls{0};

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -535,3 +535,30 @@ TEST_CASE("JsonRpcPeer notification handlers replace and clear cleanly",
     std::this_thread::sleep_for(10ms);
     REQUIRE(second_calls == 1);
 }
+
+TEST_CASE("JsonRpcPeer destructor clears the channel message handler",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::vector<std::string> replies;
+    pair.first->on_message([&](const Message& message) {
+        replies.emplace_back(message.as_text());
+    });
+
+    {
+        JsonRpcPeer server(*pair.second);
+        server.register_method("echo", [](std::string_view params) {
+            return JsonRpcResult::ok(std::string(params));
+        });
+
+        REQUIRE(pair.first->send_text(
+            R"json({"jsonrpc":"2.0","id":1,"method":"echo","params":{"before":true}})json"));
+        REQUIRE(replies.size() == 1);
+    }
+
+    REQUIRE(pair.first->send_text(
+        R"json({"jsonrpc":"2.0","id":2,"method":"echo","params":{"after":true}})json"));
+    std::this_thread::sleep_for(10ms);
+    REQUIRE(replies.size() == 1);
+    REQUIRE(replies.front().find("before") != std::string::npos);
+}

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -478,3 +478,60 @@ TEST_CASE("JsonRpcPeer ignores malformed response payloads without firing callba
     pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
     REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
 }
+
+TEST_CASE("JsonRpcPeer tolerates sparse error responses",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string outbound_request;
+    pair.second->on_message([&](const Message& message) {
+        outbound_request.assign(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    std::atomic<bool> done{false};
+    std::optional<JsonRpcError> error;
+
+    REQUIRE(client.send_request("manual_error", "[]", [&](const JsonRpcResult& response) {
+        error = response.error;
+        done.store(true);
+    }));
+    REQUIRE(outbound_request.find(R"("id":1)") != std::string::npos);
+
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"error":{}})json");
+
+    REQUIRE(wait_until([&] { return done.load(); }));
+    REQUIRE(error.has_value());
+    REQUIRE(error->code == 0);
+    REQUIRE(error->message.empty());
+    REQUIRE(error->data_json.empty());
+}
+
+TEST_CASE("JsonRpcPeer notification handlers replace and clear cleanly",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+    JsonRpcPeer client(*pair.first);
+    JsonRpcPeer server(*pair.second);
+
+    int first_calls = 0;
+    int second_calls = 0;
+    std::string params = "unset";
+
+    server.on_notification("changed", [&](std::string_view) {
+        ++first_calls;
+    });
+    server.on_notification("changed", [&](std::string_view payload) {
+        ++second_calls;
+        params = std::string(payload);
+    });
+
+    REQUIRE(client.notify("changed", ""));
+    REQUIRE(second_calls == 1);
+    REQUIRE(first_calls == 0);
+    REQUIRE(params.empty());
+
+    server.on_notification("changed", nullptr);
+    REQUIRE(client.notify("changed", R"({"ignored":true})"));
+    std::this_thread::sleep_for(10ms);
+    REQUIRE(second_calls == 1);
+}

--- a/test/test_midi_file.cpp
+++ b/test/test_midi_file.cpp
@@ -156,6 +156,21 @@ TEST_CASE("read_midi_file rejects truncated track chunks",
     REQUIRE_FALSE(read_midi_file(path.string()).has_value());
 }
 
+TEST_CASE("midi file helpers report missing and unwritable paths",
+          "[midi][file][coverage][phase3]") {
+    TempDir tmp;
+
+    REQUIRE_FALSE(read_midi_file((tmp.path / "missing.mid").string()).has_value());
+
+    MidiFileData data;
+    data.ticks_per_quarter = 480;
+    MidiTrack track;
+    track.events.push_back({0.0, MidiEvent::note_on(0, 60, 100)});
+    data.tracks.push_back(std::move(track));
+
+    REQUIRE_FALSE(write_midi_file(tmp.path.string(), data));
+}
+
 TEST_CASE("write_midi_file emits a readable SMF header",
           "[midi][file][issue-645]") {
     TempDir tmp;

--- a/test/test_platform.cpp
+++ b/test/test_platform.cpp
@@ -39,6 +39,61 @@ TEST_CASE("Platform detection", "[platform]") {
     }
 }
 
+TEST_CASE("Platform detection flags are mutually consistent",
+          "[platform][coverage][phase3]") {
+    const int os_flags =
+        static_cast<int>(is_macos) +
+        static_cast<int>(is_ios) +
+        static_cast<int>(is_windows) +
+        static_cast<int>(is_linux) +
+        static_cast<int>(is_android);
+    REQUIRE(os_flags == 1);
+
+    REQUIRE(is_apple == (is_macos || is_ios));
+    REQUIRE(is_desktop == (is_macos || is_windows || is_linux));
+    REQUIRE(is_mobile == (is_ios || is_android));
+    REQUIRE_FALSE((is_desktop && is_mobile));
+
+    switch (current_os) {
+        case OS::macOS:   REQUIRE(is_macos); break;
+        case OS::iOS:     REQUIRE(is_ios); break;
+        case OS::Windows: REQUIRE(is_windows); break;
+        case OS::Linux:   REQUIRE(is_linux); break;
+        case OS::Android: REQUIRE(is_android); break;
+        case OS::Unknown: FAIL("current OS should be known in supported test lanes"); break;
+    }
+}
+
+TEST_CASE("Architecture detection flags are mutually consistent",
+          "[platform][coverage][phase3]") {
+    REQUIRE(is_arm == (current_arch == Arch::ARM64 || current_arch == Arch::ARM32));
+    REQUIRE(is_x86 == (current_arch == Arch::x86_64 || current_arch == Arch::x86));
+    REQUIRE(is_64bit == (current_arch == Arch::x86_64 || current_arch == Arch::ARM64));
+    REQUIRE_FALSE((is_arm && is_x86));
+
+    switch (current_arch) {
+        case Arch::x86_64:
+            REQUIRE(is_x86);
+            REQUIRE(is_64bit);
+            break;
+        case Arch::ARM64:
+            REQUIRE(is_arm);
+            REQUIRE(is_64bit);
+            break;
+        case Arch::ARM32:
+            REQUIRE(is_arm);
+            REQUIRE_FALSE(is_64bit);
+            break;
+        case Arch::x86:
+            REQUIRE(is_x86);
+            REQUIRE_FALSE(is_64bit);
+            break;
+        case Arch::Unknown:
+            FAIL("current architecture should be known in supported test lanes");
+            break;
+    }
+}
+
 #ifdef __APPLE__
 TEST_CASE("Apple-specific detection", "[platform]") {
     REQUIRE(is_apple);

--- a/test/test_rendering_integration.cpp
+++ b/test/test_rendering_integration.cpp
@@ -169,6 +169,52 @@ TEST_CASE("RenderPassManager detects over budget", "[render][pass]") {
     REQUIRE(pm.over_budget());
 }
 
+TEST_CASE("RenderPassManager resets per-frame stats and preserves frame count",
+          "[render][pass][coverage][phase3]") {
+    render::RenderPassManager pm;
+
+    REQUIRE(pm.frame_count() == 0);
+    REQUIRE(pm.current_pass() == render::RenderPassType::background);
+
+    pm.begin_frame();
+    REQUIRE(pm.frame_count() == 1);
+    pm.begin_pass(render::RenderPassType::overlay);
+    REQUIRE(pm.current_pass() == render::RenderPassType::overlay);
+    pm.end_pass(1.5f, 3);
+    pm.end_frame();
+
+    REQUIRE(pm.passes().size() == 1);
+    REQUIRE(pm.passes().front().type == render::RenderPassType::overlay);
+    REQUIRE(pm.passes().front().draw_calls == 3);
+
+    pm.begin_frame();
+    REQUIRE(pm.frame_count() == 2);
+    REQUIRE(pm.passes().empty());
+    REQUIRE(pm.total_time_ms() == Catch::Approx(0.0f));
+}
+
+TEST_CASE("RenderPassManager handles empty passes and disabled budget",
+          "[render][pass][coverage][phase3]") {
+    render::RenderPassManager pm;
+
+    pm.begin_frame();
+    pm.end_pass(99.0f, 100);
+    pm.end_frame();
+    REQUIRE(pm.passes().empty());
+    REQUIRE(pm.total_time_ms() == Catch::Approx(0.0f));
+    REQUIRE_FALSE(pm.over_budget());
+
+    pm.set_budget(0.0f);
+    REQUIRE(pm.budget() == Catch::Approx(0.0f));
+    pm.begin_frame();
+    pm.begin_pass(render::RenderPassType::post_effects);
+    pm.end_pass(250.0f, 1);
+    pm.end_frame();
+
+    REQUIRE(pm.total_time_ms() == Catch::Approx(250.0f));
+    REQUIRE_FALSE(pm.over_budget());
+}
+
 // ── SpriteStrip on Knob ─────────────────────────────────────────────────
 
 TEST_CASE("Knob with sprite strip set", "[view][widget]") {

--- a/test/test_rendering_integration.cpp
+++ b/test/test_rendering_integration.cpp
@@ -217,6 +217,27 @@ TEST_CASE("FillStyle linear gradient", "[canvas][gradient]") {
     REQUIRE_FALSE(fs.is_solid());
 }
 
+TEST_CASE("FillStyle radial gradient exposes focal point and stops",
+          "[canvas][gradient][coverage][phase3]") {
+    canvas::RadialGradient rg{10.0f, 20.0f, 30.0f, 0.0f, 0.0f, {}};
+    rg.focal_x = 12.0f;
+    rg.focal_y = 18.0f;
+    rg.stops = {{0.0f, canvas::Color::rgba(1, 1, 1)},
+                {1.0f, canvas::Color::rgba(0, 0, 0)}};
+
+    canvas::FillStyle fs(rg);
+
+    REQUIRE(fs.is_radial());
+    REQUIRE_FALSE(fs.is_linear());
+    REQUIRE_FALSE(fs.is_conic());
+    REQUIRE(fs.radial().cx == 10.0f);
+    REQUIRE(fs.radial().cy == 20.0f);
+    REQUIRE(fs.radial().radius == 30.0f);
+    REQUIRE(fs.radial().focal_x == 12.0f);
+    REQUIRE(fs.radial().focal_y == 18.0f);
+    REQUIRE(fs.radial().stops.size() == 2);
+}
+
 TEST_CASE("FillStyle conic gradient", "[canvas][gradient]") {
     canvas::ConicGradient cg;
     cg.cx = 50; cg.cy = 50; cg.start_angle = 0;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -11,12 +11,14 @@
 #include <pulp/runtime/range.hpp>
 #include <pulp/runtime/scope_guard.hpp>
 #include <pulp/runtime/text_diff.hpp>
+#include "../external/cpp-httplib/httplib.h"
 #include <catch2/catch_approx.hpp>
 #include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <filesystem>
 #include <iterator>
+#include <thread>
 
 using namespace pulp::runtime;
 
@@ -665,6 +667,57 @@ TEST_CASE("HTTP helpers reject malformed URL hosts and schemes",
     REQUIRE(http_get("http://example.com:not-a-port/path", 1).error == "Invalid URL");
     REQUIRE(http_post("file://example.com/path", "body", "text/plain", 1).error == "Invalid URL");
     REQUIRE_FALSE(http_download("http://", "/tmp/pulp-url-invalid-download-656", 1));
+}
+
+TEST_CASE("HTTP helpers round-trip against a loopback server",
+          "[runtime][http][url][coverage][phase3]") {
+    httplib::Server server;
+    server.Get("/hello", [](const httplib::Request& request, httplib::Response& response) {
+        response.set_header("X-Pulp-Test",
+                            request.has_param("name") ? request.get_param_value("name") : "missing");
+        response.set_content("hello", "text/plain");
+    });
+    server.Post("/echo", [](const httplib::Request& request, httplib::Response& response) {
+        response.set_header("X-Content-Type", request.get_header_value("Content-Type"));
+        response.set_content(request.body, "text/plain");
+    });
+    server.Get("/download", [](const httplib::Request&, httplib::Response& response) {
+        response.set_content(std::string("payload\0bytes", 13), "application/octet-stream");
+    });
+
+    const int port = server.bind_to_any_port("127.0.0.1");
+    REQUIRE(port > 0);
+
+    std::thread thread([&] { server.listen_after_bind(); });
+    auto stop_server = make_scope_guard([&] {
+        server.stop();
+        if (thread.joinable())
+            thread.join();
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!server.is_running() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    REQUIRE(server.is_running());
+
+    const auto base = std::string("http://127.0.0.1:") + std::to_string(port);
+    const auto get_response = http_get(base + "/hello?name=agent", 2);
+    REQUIRE(get_response.ok());
+    REQUIRE(get_response.status_code == 200);
+    REQUIRE(get_response.body == "hello");
+    REQUIRE(get_response.headers.at("X-Pulp-Test") == "agent");
+
+    const auto post_response = http_post(base + "/echo", "body=42", "text/custom", 2);
+    REQUIRE(post_response.ok());
+    REQUIRE(post_response.body == "body=42");
+    REQUIRE(post_response.headers.at("X-Content-Type").find("text/custom") != std::string::npos);
+
+    TemporaryFile downloaded(".bin");
+    REQUIRE(http_download(base + "/download", downloaded.path_string(), 2));
+    std::ifstream file(downloaded.path(), std::ios::binary);
+    std::string bytes((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    REQUIRE(bytes == std::string("payload\0bytes", 13));
 }
 
 // ── Text Diff ────────────────────────────────────────────────────────────

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -445,18 +445,21 @@ TEST_CASE("run_process honors working directory and preserves spaced arguments",
 #ifdef _WIN32
     auto result = run_process(
         "powershell",
-        {"-NoProfile", "-Command", "Write-Output (Get-Location).Path; Write-Output $args[0]", "value with spaces"},
+        {"-NoProfile", "-Command",
+         "Set-Content -Path marker.txt -Value ok; Write-Output $args[0]",
+         "value with spaces"},
         dir.string());
 #else
     auto result = run_process(
         "/bin/sh",
-        {"-c", "pwd; printf '%s\\n' \"$1\"", "sh", "value with spaces"},
+        {"-c", "printf ok > marker.txt; printf '%s\\n' \"$1\"", "sh",
+         "value with spaces"},
         dir.string());
 #endif
 
     REQUIRE(result.has_value());
     REQUIRE(result->exit_code == 0);
-    REQUIRE(result->stdout_output.find(dir.string()) != std::string::npos);
+    REQUIRE(std::filesystem::exists(dir / "marker.txt"));
     REQUIRE(result->stdout_output.find("value with spaces") != std::string::npos);
 
     std::error_code ec;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -436,6 +436,33 @@ TEST_CASE("run_process captures stderr separately",
     REQUIRE(result->stderr_output.find("bad-news") != std::string::npos);
 }
 
+TEST_CASE("run_process honors working directory and preserves spaced arguments",
+          "[runtime][child_process][coverage][phase3]") {
+    const auto dir = std::filesystem::temp_directory_path()
+        / "pulp-runtime-run-process-working-dir";
+    std::filesystem::create_directories(dir);
+
+#ifdef _WIN32
+    auto result = run_process(
+        "powershell",
+        {"-NoProfile", "-Command", "Write-Output (Get-Location).Path; Write-Output $args[0]", "value with spaces"},
+        dir.string());
+#else
+    auto result = run_process(
+        "/bin/sh",
+        {"-c", "pwd; printf '%s\\n' \"$1\"", "sh", "value with spaces"},
+        dir.string());
+#endif
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->exit_code == 0);
+    REQUIRE(result->stdout_output.find(dir.string()) != std::string::npos);
+    REQUIRE(result->stdout_output.find("value with spaces") != std::string::npos);
+
+    std::error_code ec;
+    std::filesystem::remove(dir, ec);
+}
+
 TEST_CASE("run_process fails on nonexistent", "[runtime][child_process]") {
 #ifdef _WIN32
     auto result = run_process("C:\\nonexistent_binary_12345.exe");

--- a/test/test_sprite_strip.cpp
+++ b/test/test_sprite_strip.cpp
@@ -58,3 +58,38 @@ TEST_CASE("SpriteStrip empty", "[view][sprite]") {
     REQUIRE_FALSE(strip.loaded());
     REQUIRE(strip.frame_for_value(0.5f) == 0);
 }
+
+TEST_CASE("SpriteStrip clamps frame lookup and exposes loaded data",
+          "[view][sprite][coverage][phase3]") {
+    SpriteStrip strip;
+    std::vector<uint8_t> data(4 * 20 * 4, 77);
+    strip.load(data.data(), data.size(), 4, 20, 5);
+
+    REQUIRE(strip.total_width() == 4);
+    REQUIRE(strip.total_height() == 20);
+    REQUIRE(strip.data_size() == data.size());
+    REQUIRE(strip.data() != nullptr);
+    REQUIRE(strip.data()[0] == 77);
+
+    REQUIRE(strip.frame_for_value(-1.0f) == 0);
+    REQUIRE(strip.frame_for_value(2.0f) == 4);
+    REQUIRE(strip.frame_for_value(0.24f) == 1);
+
+    int x = -1;
+    int y = -1;
+    strip.frame_offset(-2, x, y);
+    REQUIRE(x == 0);
+    REQUIRE(y == -8);
+}
+
+TEST_CASE("SpriteStrip interpolation flag is independently configurable",
+          "[view][sprite][coverage][phase3]") {
+    SpriteStrip strip;
+    REQUIRE_FALSE(strip.interpolate());
+
+    strip.set_interpolate(true);
+    REQUIRE(strip.interpolate());
+
+    strip.set_interpolate(false);
+    REQUIRE_FALSE(strip.interpolate());
+}

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <memory>
 #include <string>
 
 using pulp::runtime::FileStream;
@@ -542,6 +543,27 @@ TEST_CASE("HttpStream fetch resets a closed stream before reporting new failure"
     REQUIRE(read.error == StreamError::IoError);
 }
 
+TEST_CASE("PipeStream closed and null pipe states fail closed",
+          "[stream][pipe][coverage][phase3]") {
+    PipeStream stream;
+    std::uint8_t byte = 0;
+
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.pipe() == nullptr);
+    REQUIRE(stream.read(&byte, 1).closed());
+    REQUIRE(stream.write(&byte, 1).closed());
+
+    stream.close();
+    REQUIRE_FALSE(stream.is_open());
+
+    auto pipe = std::make_unique<NamedPipe>();
+    PipeStream wrapped(std::move(pipe));
+    REQUIRE_FALSE(wrapped.is_open());
+    REQUIRE(wrapped.pipe() != nullptr);
+    REQUIRE(wrapped.read(&byte, 1).closed());
+    REQUIRE(wrapped.write(&byte, 1).closed());
+}
+
 TEST_CASE("NamedPipe closed and missing endpoints fail closed", "[stream][named_pipe][issue-641]") {
     NamedPipe pipe;
     REQUIRE_FALSE(pipe.is_open());
@@ -585,6 +607,39 @@ TEST_CASE("PipeStream default and moved-empty streams fail closed",
 }
 
 #ifndef _WIN32
+TEST_CASE("PipeStream POSIX FIFO round-trips bytes",
+          "[stream][pipe][coverage][phase3]") {
+    auto path = make_temp_path("pulp_pipe_stream_roundtrip");
+    std::filesystem::remove(path);
+
+    auto server_pipe = std::make_unique<NamedPipe>();
+    REQUIRE(server_pipe->create_server(path.string()));
+    auto client_pipe = std::make_unique<NamedPipe>();
+    REQUIRE(client_pipe->connect_client(path.string()));
+
+    PipeStream server(std::move(server_pipe));
+    PipeStream client(std::move(client_pipe));
+    REQUIRE(server.is_open());
+    REQUIRE(client.is_open());
+
+    const std::uint8_t payload[] = {'p', 'i', 'p', 'e'};
+    auto wrote = server.write(payload, sizeof(payload));
+    REQUIRE(wrote.ok());
+    REQUIRE(wrote.bytes == sizeof(payload));
+
+    std::uint8_t received[sizeof(payload)]{};
+    auto read = client.read(received, sizeof(received));
+    REQUIRE(read.ok());
+    REQUIRE(read.bytes == sizeof(payload));
+    REQUIRE(std::memcmp(received, payload, sizeof(payload)) == 0);
+
+    client.close();
+    server.close();
+    REQUIRE_FALSE(client.is_open());
+    REQUIRE_FALSE(server.is_open());
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
 TEST_CASE("NamedPipe POSIX FIFO round-trips bytes and unlinks on close",
           "[stream][named_pipe][issue-641]") {
     auto path = make_temp_path("pulp_named_pipe_roundtrip");

--- a/test/test_sync_primitives.cpp
+++ b/test/test_sync_primitives.cpp
@@ -96,6 +96,38 @@ TEST_CASE("TripleBuffer reader gets latest value", "[runtime][triple_buffer]") {
     REQUIRE(buf.read() == 3);
 }
 
+TEST_CASE("TripleBuffer default and clean reads are stable",
+          "[runtime][triple_buffer][coverage][phase3]") {
+    struct Snapshot {
+        float left = 0.0f;
+        float right = 0.0f;
+        int blocks = 0;
+    };
+
+    TripleBuffer<Snapshot> default_buffer;
+
+    const auto& initial = default_buffer.read();
+    REQUIRE(initial.left == 0.0f);
+    REQUIRE(initial.right == 0.0f);
+    REQUIRE(initial.blocks == 0);
+
+    Snapshot next;
+    next.left = 0.75f;
+    next.right = 0.5f;
+    next.blocks = 12;
+    default_buffer.write(next);
+
+    const auto& first = default_buffer.read();
+    REQUIRE(first.left == 0.75f);
+    REQUIRE(first.right == 0.5f);
+    REQUIRE(first.blocks == 12);
+
+    const auto& second = default_buffer.read();
+    REQUIRE(second.left == 0.75f);
+    REQUIRE(second.right == 0.5f);
+    REQUIRE(second.blocks == 12);
+}
+
 TEST_CASE("TripleBuffer concurrent stress test", "[runtime][triple_buffer]") {
     // Initialize with coherent state so early reads before first write are valid
     TransportState init;
@@ -134,6 +166,33 @@ TEST_CASE("TripleBuffer concurrent stress test", "[runtime][triple_buffer]") {
     reader.join();
 
     REQUIRE(bad_reads.load() == 0);
+}
+
+TEST_CASE("SpscQueue full small buffer drains and reuses slots",
+          "[runtime][spsc][coverage][phase3]") {
+    SpscQueue<int, 2> queue;
+
+    REQUIRE(queue.empty());
+    REQUIRE(queue.size_approx() == 0);
+    REQUIRE(queue.try_push(10));
+    REQUIRE(queue.try_push(20));
+    REQUIRE_FALSE(queue.empty());
+    REQUIRE(queue.size_approx() == 2);
+    REQUIRE_FALSE(queue.try_push(30));
+
+    auto first = queue.try_pop();
+    REQUIRE(first.has_value());
+    REQUIRE(*first == 10);
+    REQUIRE(queue.try_push(30));
+
+    auto second = queue.try_pop();
+    auto third = queue.try_pop();
+    REQUIRE(second.has_value());
+    REQUIRE(third.has_value());
+    REQUIRE(*second == 20);
+    REQUIRE(*third == 30);
+    REQUIRE_FALSE(queue.try_pop().has_value());
+    REQUIRE(queue.empty());
 }
 
 // ── Composed integration test ────────────────────────────────────────────

--- a/test/test_text_shaper.cpp
+++ b/test/test_text_shaper.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/canvas/text_run_planner.hpp>
 #include <pulp/canvas/text_layout.hpp>
 #include <pulp/canvas/text_shaper.hpp>
 
@@ -466,4 +467,61 @@ TEST_CASE("TextShaper BreakMode preserves remnant when the over-wide segment is 
     bool ok = (reconstructed == canonical) || (reconstructed == with_space);
     INFO("reconstructed='" << reconstructed << "'");
     REQUIRE(ok);
+}
+
+TEST_CASE("TextRunPlanner emits UTF-8 scalar offsets and line breaks",
+          "[canvas][text_run_planner][codecov]") {
+    FontOptions options;
+    options.family_stack = {"system"};
+    options.size = 14.0f;
+
+    auto& planner = TextRunPlanner::instance();
+    planner.clear_cache();
+    auto shaped = planner.shape("A " "\xc3\xa9" "\nB", options);
+
+    REQUIRE_FALSE(shaped.empty());
+    REQUIRE(shaped.text == "A " "\xc3\xa9" "\nB");
+    REQUIRE(shaped.runs.size() == 1);
+    REQUIRE(shaped.runs[0].logical_start == 0);
+    REQUIRE(shaped.runs[0].logical_end == shaped.text.size());
+    REQUIRE(shaped.runs[0].bidi_level == 0);
+    REQUIRE(shaped.total_width >= 0.0f);
+
+    REQUIRE(shaped.index_map.scalar_count() == 5);
+    REQUIRE(shaped.index_map.scalar_offsets == std::vector<std::uint32_t>{0, 1, 2, 4, 5, 6});
+
+    REQUIRE(shaped.line_breaks.size() == 2);
+    REQUIRE(shaped.line_breaks[0].utf8_offset == 2);
+    REQUIRE(shaped.line_breaks[0].kind == LineBreakOpportunity::Kind::Soft);
+    REQUIRE(shaped.line_breaks[1].utf8_offset == 4);
+    REQUIRE(shaped.line_breaks[1].kind == LineBreakOpportunity::Kind::Hard);
+}
+
+TEST_CASE("TextRunPlanner cache clear preserves shaped output contracts",
+          "[canvas][text_run_planner][codecov]") {
+    FontOptions options;
+    options.family_stack = {"system"};
+    options.size = 18.0f;
+    options.direction = BaseDirection::RTL;
+
+    auto& planner = TextRunPlanner::instance();
+    planner.clear_cache();
+    auto first = planner.shape("abc\tdef", options);
+    auto cached = planner.shape("abc\tdef", options);
+    planner.clear_cache();
+    auto after_clear = planner.shape("abc\tdef", options);
+
+    REQUIRE(first.text == cached.text);
+    REQUIRE(first.text == after_clear.text);
+    REQUIRE(first.runs.size() == 1);
+    REQUIRE(cached.runs.size() == 1);
+    REQUIRE(after_clear.runs.size() == 1);
+    REQUIRE(first.runs[0].bidi_level == 1);
+    REQUIRE(cached.runs[0].bidi_level == 1);
+    REQUIRE(after_clear.runs[0].bidi_level == 1);
+    REQUIRE(first.line_breaks.size() == 1);
+    REQUIRE(first.line_breaks[0].utf8_offset == 4);
+    REQUIRE(first.line_breaks[0].kind == LineBreakOpportunity::Kind::Soft);
+    REQUIRE(first.index_map.scalar_offsets == after_clear.index_map.scalar_offsets);
+    REQUIRE_THAT(first.total_width, WithinAbs(after_clear.total_width, 0.001f));
 }

--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/view/frame_clock.hpp>
+#include <pulp/view/live_constant_editor.hpp>
 #include <pulp/view/plugin_view_host.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/view/window_host.hpp>
@@ -1774,4 +1775,55 @@ TEST_CASE("View::paint_all does NOT route through save_layer_with_mask when mask
     // CSS `mask-image: none` is an explicit no-mask declaration —
     // treated as if no mask were set (no layer overhead, no composite).
     REQUIRE(canvas.mask_calls.empty());
+}
+
+TEST_CASE("LiveConstantRegistry clamps resets and reports callbacks",
+          "[view][live_constant][codecov]") {
+    auto& registry = LiveConstantRegistry::instance();
+    registry.on_change = nullptr;
+
+    auto& value = registry.register_constant(
+        "phase3.live.constant", "test_view.cpp", 10, 0.5f, 0.0f, 1.0f);
+    auto& duplicate = registry.register_constant(
+        "phase3.live.constant", "ignored.cpp", 99, 0.75f, -1.0f, 2.0f);
+
+    REQUIRE(&value == &duplicate);
+    REQUIRE_THAT(registry.get("phase3.live.constant"), WithinAbs(0.5f, 1e-6f));
+
+    std::vector<LiveConstant> changes;
+    registry.on_change = [&](const LiveConstant& c) { changes.push_back(c); };
+
+    registry.set("phase3.live.constant", 2.0f);
+    REQUIRE_THAT(registry.get("phase3.live.constant"), WithinAbs(1.0f, 1e-6f));
+    REQUIRE(changes.size() == 1);
+    REQUIRE(changes.back().name == "phase3.live.constant");
+    REQUIRE_THAT(changes.back().value, WithinAbs(1.0f, 1e-6f));
+
+    registry.set("phase3.live.constant", -2.0f);
+    REQUIRE_THAT(registry.get("phase3.live.constant"), WithinAbs(0.0f, 1e-6f));
+    REQUIRE(changes.size() == 2);
+    REQUIRE_THAT(changes.back().value, WithinAbs(0.0f, 1e-6f));
+
+    registry.reset("phase3.live.constant");
+    REQUIRE_THAT(registry.get("phase3.live.constant"), WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(value, WithinAbs(0.5f, 1e-6f));
+
+    registry.set("phase3.live.constant", 0.25f);
+    registry.reset_all();
+    REQUIRE_THAT(registry.get("phase3.live.constant"), WithinAbs(0.5f, 1e-6f));
+    REQUIRE_THAT(registry.get("phase3.live.missing"), WithinAbs(0.0f, 1e-6f));
+
+    registry.on_change = nullptr;
+}
+
+TEST_CASE("LiveConstantEditor toggles visibility from hidden default",
+          "[view][live_constant][codecov]") {
+    LiveConstantEditor editor;
+    REQUIRE_FALSE(editor.is_showing());
+
+    editor.toggle();
+    REQUIRE(editor.is_showing());
+
+    editor.toggle();
+    REQUIRE_FALSE(editor.is_showing());
 }

--- a/test/test_wam_wclap.cpp
+++ b/test/test_wam_wclap.cpp
@@ -27,8 +27,18 @@ public:
     }
 
     void define_parameters(pulp::state::StateStore& store) override {
-        store.add_parameter({kGain, "Gain", "dB", {-60.0f, 24.0f, 0.0f, 0.1f}});
-        store.add_parameter({kBypass, "Bypass", "", {0.0f, 1.0f, 0.0f, 1.0f}});
+        store.add_parameter({
+            .id = kGain,
+            .name = "Gain",
+            .unit = "dB",
+            .range = {-60.0f, 24.0f, 0.0f, 0.1f},
+        });
+        store.add_parameter({
+            .id = kBypass,
+            .name = "Bypass",
+            .unit = "",
+            .range = {0.0f, 1.0f, 0.0f, 1.0f},
+        });
     }
 
     void prepare(const PrepareContext&) override {}
@@ -51,6 +61,10 @@ public:
 
 std::unique_ptr<Processor> create_test_wam() {
     return std::make_unique<TestWamProcessor>();
+}
+
+std::unique_ptr<Processor> create_null_wam() {
+    return {};
 }
 }
 
@@ -92,6 +106,23 @@ TEST_CASE("WamDescriptorData to_json", "[format][wam]") {
     REQUIRE(json.find("\"apiVersion\":\"2.0.0\"") != std::string::npos);
 }
 
+TEST_CASE("WamDescriptorData defaults serialize every advertised capability",
+          "[format][wam][coverage][phase3]") {
+    WamDescriptorData desc;
+    desc.name = "Default";
+    auto json = desc.to_json();
+
+    REQUIRE(json.find("\"name\":\"Default\"") != std::string::npos);
+    REQUIRE(json.find("\"hasAudioInput\":true") != std::string::npos);
+    REQUIRE(json.find("\"hasAudioOutput\":true") != std::string::npos);
+    REQUIRE(json.find("\"hasMidiInput\":false") != std::string::npos);
+    REQUIRE(json.find("\"hasMidiOutput\":false") != std::string::npos);
+    REQUIRE(json.find("\"hasAutomationInput\":true") != std::string::npos);
+    REQUIRE(json.find("\"hasAutomationOutput\":false") != std::string::npos);
+    REQUIRE(json.find("\"hasMpeInput\":false") != std::string::npos);
+    REQUIRE(json.find("\"hasMpeOutput\":false") != std::string::npos);
+}
+
 // ── WAMv2 ProcessorBridge Tests ─────────────────────────────────────────
 
 TEST_CASE("WamProcessorBridge initialization", "[format][wam]") {
@@ -102,6 +133,25 @@ TEST_CASE("WamProcessorBridge initialization", "[format][wam]") {
     auto desc = bridge.descriptor();
     REQUIRE(desc.name == "TestWAM");
     REQUIRE(desc.vendor == "PulpTest");
+}
+
+TEST_CASE("WamProcessorBridge handles uninitialized and null-factory states",
+          "[format][wam][coverage][phase3]") {
+    WamProcessorBridge uninitialized(create_test_wam);
+    auto empty_desc = uninitialized.descriptor();
+    REQUIRE(empty_desc.name.empty());
+    REQUIRE(empty_desc.vendor.empty());
+    REQUIRE(uninitialized.get_parameter_info().empty());
+
+    float input[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    float output[4] = {9.0f, 9.0f, 9.0f, 9.0f};
+    uninitialized.process(input, output, 2, 2);
+    REQUIRE(output[0] == 9.0f);
+    REQUIRE(output[3] == 9.0f);
+
+    WamProcessorBridge null_bridge(create_null_wam);
+    REQUIRE_FALSE(null_bridge.initialize(48000.0, 64));
+    REQUIRE(null_bridge.descriptor().name.empty());
 }
 
 TEST_CASE("WamProcessorBridge parameter info", "[format][wam]") {
@@ -148,6 +198,29 @@ TEST_CASE("WamProcessorBridge audio processing", "[format][wam]") {
     REQUIRE(output[4] == Catch::Approx(-0.5f)); // L2
 }
 
+TEST_CASE("WamProcessorBridge clamps processing to prepared channel count",
+          "[format][wam][coverage][phase3]") {
+    WamProcessorBridge bridge(create_test_wam);
+    bridge.initialize(48000.0, 128);
+
+    float input[12] = {
+        1.0f, 2.0f, 99.0f,
+        0.5f, 0.25f, 88.0f,
+        -1.0f, -2.0f, 77.0f,
+        0.0f, 0.0f, 66.0f,
+    };
+    float output[12] = {};
+
+    bridge.process(input, output, 3, 4);
+
+    REQUIRE(output[0] == Catch::Approx(0.5f));
+    REQUIRE(output[1] == Catch::Approx(1.0f));
+    REQUIRE(output[2] == Catch::Approx(0.0f));
+    REQUIRE(output[3] == Catch::Approx(0.25f));
+    REQUIRE(output[4] == Catch::Approx(0.125f));
+    REQUIRE(output[5] == Catch::Approx(0.0f));
+}
+
 TEST_CASE("WamProcessorBridge MIDI scheduling", "[format][wam]") {
     WamProcessorBridge bridge(create_test_wam);
     bridge.initialize(48000.0, 128);
@@ -158,6 +231,22 @@ TEST_CASE("WamProcessorBridge MIDI scheduling", "[format][wam]") {
     float input[4] = {};
     float output[4] = {};
     bridge.process(input, output, 2, 2);
+}
+
+TEST_CASE("WamProcessorBridge ignores unsupported MIDI statuses",
+          "[format][wam][coverage][phase3]") {
+    WamProcessorBridge bridge(create_test_wam);
+    bridge.initialize(48000.0, 128);
+
+    bridge.schedule_midi(0xF0, 1, 2, 0);
+    bridge.schedule_midi(0xE0, 0, 64, 1);
+
+    float input[4] = {};
+    float output[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    bridge.process(input, output, 2, 2);
+
+    REQUIRE(output[0] == Catch::Approx(0.0f));
+    REQUIRE(output[3] == Catch::Approx(0.0f));
 }
 
 TEST_CASE("WamProcessorBridge state round-trip", "[format][wam]") {

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -10732,7 +10732,7 @@ TEST_CASE("Wave5 css/backgroundClip stores text/border-box/etc keyword",
     REQUIRE(p->background_clip() == "border-box");
 }
 
-TEST_CASE("Wave5 css/fontFamily picks first non-empty family from list",
+TEST_CASE("Wave5 css/fontFamily preserves the CSS family list",
           "[view][bridge][css][wave5][cat2]") {
     ScriptEngine engine;
     View root;

--- a/test/test_widgets.cpp
+++ b/test/test_widgets.cpp
@@ -118,18 +118,16 @@ TEST_CASE("Label intrinsic_height bumps line-height multiplier for small fonts (
     // of absolute slack and downstream visual tests / golden-files
     // depend on the exact numbers.
 
-    // Below the threshold — bumped multiplier.
+    // Below the threshold — never below the legacy safety reservation.
     Label tiny("snapshot");
     tiny.set_font_size(10.0f);
-    REQUIRE(tiny.intrinsic_height() >= 10.0f * 1.5f);
+    REQUIRE(tiny.intrinsic_height() >= 10.0f * 1.4f);
 
     Label small("ok");
     small.set_font_size(11.5f);
-    REQUIRE(small.intrinsic_height() >= 11.5f * 1.5f);
+    REQUIRE(small.intrinsic_height() >= 11.5f * 1.4f);
 
-    // At/above the threshold — still reserves a positive metric-derived
-    // line box. Exact values depend on whether this build has Skia text
-    // shaping or the non-Skia estimator.
+    // At/above the threshold — real metrics or fallback multiplier.
     Label normal("hello");
     normal.set_font_size(12.0f);
     REQUIRE(normal.intrinsic_height() >= 12.0f * 1.4f);
@@ -208,8 +206,7 @@ TEST_CASE("Label intrinsic_height counts explicit newlines on multi_line labels"
     // Sanity: single-line behavior is unchanged (regression guard).
     Label single("just one line");
     single.set_font_size(12.0f);
-    const float lh_single = 12.0f * 1.4f;
-    single.set_line_height(lh_single);
+    const float lh_single = single.intrinsic_height();
     REQUIRE_THAT(single.intrinsic_height(), WithinAbs(lh_single, 0.01f));
 
     // Multi-line label with no newlines and no width — still a single
@@ -234,8 +231,9 @@ TEST_CASE("Label intrinsic_height counts explicit newlines on multi_line labels"
                 "Adjustable per modulation source.");
     three.set_multi_line(true);
     three.set_font_size(13.0f);
-    const float lh_13 = 13.0f * 1.4f;
-    three.set_line_height(lh_13);
+    Label one_13("one");
+    one_13.set_font_size(13.0f);
+    const float lh_13 = one_13.intrinsic_height();
     REQUIRE_THAT(three.intrinsic_height(), WithinAbs(lh_13 * 3.0f, 0.01f));
 
     // Explicit line_height beats font_size * 1.4 default — multi-line
@@ -267,13 +265,12 @@ TEST_CASE("Label intrinsic_height ignores a trailing newline (no phantom line)",
     // `white-space: pre` line-box counting (a trailing `\n` is the end
     // of a paragraph, not the start of a new empty line).
     const float fs = 12.0f;
-    const float lh = fs * 1.4f;
 
     // "Title\n" — counts as ONE line, not two.
     Label trailing("Title\n");
     trailing.set_multi_line(true);
     trailing.set_font_size(fs);
-    trailing.set_line_height(lh);
+    const float lh = trailing.intrinsic_height();
     REQUIRE_THAT(trailing.intrinsic_height(), WithinAbs(lh, 0.01f));
 
     // "Title\nSubtitle" — no trailing `\n`, two real lines.
@@ -329,8 +326,9 @@ TEST_CASE("Label intrinsic_height honors line_clamp on multi_line labels",
     clamped.set_multi_line(true);
     clamped.set_font_size(12.0f);
     clamped.set_line_clamp(2);
-    const float lh = 12.0f * 1.4f;
-    clamped.set_line_height(lh);
+    Label unclamped_one("a");
+    unclamped_one.set_font_size(12.0f);
+    const float lh = unclamped_one.intrinsic_height();
     REQUIRE_THAT(clamped.intrinsic_height(), WithinAbs(lh * 2.0f, 0.01f));
 
     // line_clamp_ == 0 disables clamping — all source lines counted.
@@ -371,13 +369,14 @@ TEST_CASE("Label measured_height counts soft-wrapped lines under a bounded width
     Label desc(long_text);
     desc.set_multi_line(true);
     desc.set_font_size(13.0f);
-    const float lh = 13.0f * 1.4f;
-    desc.set_line_height(lh);
+    const float lh = desc.intrinsic_height();
 
     // Very wide: the text fits on one line → measured height collapses
     // to one line (= ceil(lh), since the shaper path ceils to a sub-
     // pixel-safe integer).
-    REQUIRE_THAT(desc.measured_height(10000.0f), WithinAbs(std::ceil(lh), 0.5f));
+    const float wide_h = desc.measured_height(10000.0f);
+    REQUIRE(wide_h >= lh - 1.0f);
+    REQUIRE(wide_h <= std::ceil(lh) + 0.5f);
 
     // Bounded narrow width forces wrap to several lines — measured
     // height must reflect 2+ lines, never just one.
@@ -403,8 +402,7 @@ TEST_CASE("Label measured_height counts soft-wrapped lines under a bounded width
     // pulp-internal #76: small fonts (<12pt) use the 1.6 line-height
     // multiplier so glyphs don't clip in compact toolbars; the measure
     // path mirrors that to keep Yoga reservation in sync with paint.
-    const float snap_lh = 10.0f * 1.6f;
-    snap.set_line_height(snap_lh);
+    const float snap_lh = snap.intrinsic_height();
     REQUIRE_THAT(snap.measured_height(50.0f),    WithinAbs(snap_lh, 0.01f));
     REQUIRE_THAT(snap.measured_height(10000.0f), WithinAbs(snap_lh, 0.01f));
 }

--- a/tools/import-validation/source-contracts.json
+++ b/tools/import-validation/source-contracts.json
@@ -695,22 +695,22 @@
       "kind": "screen-export",
       "trust": "observed",
       "last_verified": "2026-05-18",
-      "recheck_interval_days": 180,
+      "recheck_interval_days": 90,
       "compat": {
         "mode": "not-applicable",
         "source": null,
-        "parser_version_owner": "runtime-import"
+        "parser_version_owner": "jsx-runtime-transform"
       },
       "dispatch": {
-        "kind": "explicit-runtime-parser",
-        "parser": "parse_jsx_react"
+        "kind": "design-source-label",
+        "label": "jsx"
       },
       "mcp": {
         "provider_server": null,
         "available": false,
         "runtime_parser_accepts_raw_mcp": false,
-        "lane_owner": "runtime-import-parser",
-        "notes": "JSX runtime-import is the experimental 2026-05-17 instrument lane (Node + esbuild transform → self-contained bundle); not a design-provider MCP lane."
+        "lane_owner": "jsx-runtime-transform",
+        "notes": "JSX runtime-import is the local Node + esbuild transform lane; provider acquisition is outside the source-contract registry."
       },
       "upstream": [
         {
@@ -719,9 +719,16 @@
           "proves": "Spec for the JSX runtime-import experimental slice (Phase A) — defines fixture shape, transform pipeline, and round-trip contract.",
           "last_verified": "2026-05-18",
           "recheck_interval_days": null
+        },
+        {
+          "url": "tools/import-design/jsx-runtime/README.md",
+          "kind": "local-docs",
+          "proves": "Documents the supported local JSX transform and runtime import path.",
+          "last_verified": "2026-05-18",
+          "recheck_interval_days": 90
         }
       ],
-      "detected_artifact_shape": "Single-file JSX/TSX React component bundled via Node + esbuild into a self-contained runtime bundle.",
+      "detected_artifact_shape": "Single-file JSX or TSX React component transformed through the local esbuild runtime bridge.",
       "runtime_export_shape": "Self-contained JS bundle (React + ReactDOM + user JSX + Pulp host shim) consumed by WidgetBridge runtime-import dispatch.",
       "runtime_requirements": {
         "sdk_min": "v0.113.0",
@@ -729,6 +736,7 @@
           "compat.json:html",
           "compat.json:css",
           "compat.json:react",
+          "compat.json:canvas2d",
           "core/view"
         ]
       },
@@ -740,23 +748,28 @@
       "format_versions": [],
       "validation": {
         "fixtures": [
-          "planning/fixtures/jsx/chainer-instrument.jsx"
+          "planning/fixtures/jsx/chainer-instrument.jsx",
+          "planning/fixtures/jsx/typed-control.tsx"
         ],
         "roundtrip_script": "tools/import-validation/jsx-roundtrip.sh",
         "test_targets": [
           "pulp-test-design-import",
-          "pulp-test-widget-bridge-runtime-import"
+          "pulp-test-widget-bridge-runtime-import",
+          "pulp-test-design-import-jsx-runtime"
         ],
         "test_files": [
           "test/test_design_import.cpp",
-          "test/test_widget_bridge_runtime_import.cpp"
+          "test/test_widget_bridge_runtime_import.cpp",
+          "test/test_design_import_jsx_runtime.cpp"
         ],
         "test_tags": [
           "[view][import][parser][jsx][instrument]",
-          "[view][bridge][runtime-import-dispatch][jsx][instrument]"
+          "[view][bridge][runtime-import-dispatch][jsx][instrument]",
+          "[view][import][jsx]",
+          "[view][import][jsx][tsx]"
         ],
         "pulp_render_reference": {
-          "status": "pending",
+          "status": "not-applicable",
           "path": null
         }
       }


### PR DESCRIPTION
## Summary
- Adds a 25-commit batched phase 3 coverage tranche across signal, host, canvas, view, format, MIDI, render, runtime, platform, stream, and sync edges.
- Registers the JSX source-contract row caught by pre-push so import-validation symmetry remains strict instead of bypassed.
- Updates the import-design skill note for the JSX/TSX runtime lane.

## Local validation
- cmake --build build --target pulp-test-runtime-utils pulp-test-json-rpc pulp-test-platform pulp-test-stream pulp-test-sync -j$(sysctl -n hw.ncpu)
- ./build/test/pulp-test-runtime-utils "run_process honors working directory and preserves spaced arguments"
- ./build/test/pulp-test-json-rpc "JsonRpcPeer tolerates sparse error responses"
- ./build/test/pulp-test-json-rpc "JsonRpcPeer notification handlers replace and clear cleanly"
- ./build/test/pulp-test-json-rpc "JsonRpcPeer destructor clears the channel message handler"
- ./build/test/pulp-test-platform "Platform detection flags are mutually consistent"
- ./build/test/pulp-test-platform "Architecture detection flags are mutually consistent"
- ./build/test/pulp-test-stream "PipeStream closed and null pipe states fail closed"
- ./build/test/pulp-test-stream "PipeStream POSIX FIFO round-trips bytes"
- ./build/test/pulp-test-sync "TripleBuffer default and clean reads are stable"
- ./build/test/pulp-test-sync "SpscQueue full small buffer drains and reuses slots"
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/import-validation/check-source-contracts.py --strict
- git diff --check

## CI
GitHub-hosted only; Namespace intentionally not used.