### PR TITLE
test: expand phase 3 codecov coverage batch 731

### DIFF
--- a/core/canvas/include/pulp/canvas/image_convolution.hpp
+++ b/core/canvas/include/pulp/canvas/image_convolution.hpp
@@ -39,7 +39,7 @@ public:
         if (stride == 0) stride = width * 4;
         int half = size_ / 2;
 
-        std::vector<uint8_t> temp(static_cast<size_t>(height * stride));
+        std::vector<uint8_t> temp(pixels, pixels + static_cast<size_t>(height * stride));
 
         for (int y = 0; y < height; ++y) {
             for (int x = 0; x < width; ++x) {

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -223,6 +223,23 @@ TEST_CASE("Device metadata defaults and custom configs are stable",
     REQUIRE(config.output_channels == 6);
 }
 
+TEST_CASE("CallbackContext defaults and sample position remain explicit",
+          "[audio][device][codecov]") {
+    CallbackContext empty;
+    REQUIRE(empty.sample_rate == 0.0);
+    REQUIRE(empty.buffer_size == 0);
+    REQUIRE(empty.sample_position == 0);
+
+    CallbackContext block;
+    block.sample_rate = 44100.0;
+    block.buffer_size = 512;
+    block.sample_position = 4096;
+
+    REQUIRE(block.sample_rate == 44100.0);
+    REQUIRE(block.buffer_size == 512);
+    REQUIRE(block.sample_position == 4096);
+}
+
 TEST_CASE("ChannelSet maps standard layouts by count and name",
           "[audio][channel-set][issue-640]") {
     REQUIRE(ChannelSet::from_channel_count(0).name == "Discrete 0");

--- a/test/test_audio_focus.cpp
+++ b/test/test_audio_focus.cpp
@@ -157,6 +157,36 @@ TEST_CASE("AudioFocusRegistry: multiple subscribers all receive the signal",
     REQUIRE(count_c == 1);
 }
 
+TEST_CASE("AudioFocusRegistry: publish snapshots subscribers before dispatch",
+          "[audio][focus][coverage][phase3-large]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    std::vector<AudioFocusState> first_seen;
+    std::vector<AudioFocusState> late_seen;
+    AudioFocusRegistry::Token late_token;
+
+    auto first = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState state) {
+            first_seen.push_back(state);
+            if (!late_token.id()) {
+                late_token = AudioFocusRegistry::instance().subscribe(
+                    [&](AudioFocusState late_state) {
+                        late_seen.push_back(late_state);
+                    });
+            }
+        });
+
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    REQUIRE(first_seen == std::vector<AudioFocusState>{AudioFocusState::duck});
+    REQUIRE(late_seen.empty());
+
+    AudioFocusRegistry::instance().publish(AudioFocusState::lost);
+    REQUIRE(first_seen == std::vector<AudioFocusState>{
+        AudioFocusState::duck,
+        AudioFocusState::lost,
+    });
+    REQUIRE(late_seen == std::vector<AudioFocusState>{AudioFocusState::lost});
+}
+
 TEST_CASE("AudioFocusRegistry: current() is lock-free / audio-thread safe",
           "[audio][focus][issue-334]") {
     AudioFocusRegistry::instance().reset_for_test();

--- a/test/test_cli_json_parser.cpp
+++ b/test/test_cli_json_parser.cpp
@@ -125,6 +125,33 @@ TEST_CASE("json parser: nested object paths remain readable through get",
     CHECK(leaf->as_string() == "value");
 }
 
+TEST_CASE("json parser: duplicate object keys keep first-match lookup semantics",
+          "[cli][json-parser][coverage][phase3-large]") {
+    auto value = parse_json(R"({"name":"first","name":"second"})");
+    REQUIRE(value.type == json::JsonValue::Object);
+    REQUIRE(value.obj().size() == 2);
+    REQUIRE(value.get("name") != nullptr);
+    CHECK(value.get("name")->as_string() == "first");
+}
+
+TEST_CASE("json parser: unknown escapes preserve escaped byte",
+          "[cli][json-parser][coverage][phase3-large]") {
+    auto value = parse_json(R"({"path":"a\qb","slash":"c\/d"})");
+    REQUIRE(value.get("path") != nullptr);
+    REQUIRE(value.get("slash") != nullptr);
+    CHECK(value.get("path")->as_string() == "aqb");
+    CHECK(value.get("slash")->as_string() == "c/d");
+}
+
+TEST_CASE("json parser: scalar empty accessors share immutable defaults",
+          "[cli][json-parser][coverage][phase3-large]") {
+    const auto value = parse_json(R"("not an array or object")");
+    REQUIRE(value.type == json::JsonValue::String);
+    CHECK(value.arr().empty());
+    CHECK(value.obj().empty());
+    CHECK(value.as_string_array().empty());
+}
+
 TEST_CASE("json parser: whitespace is accepted around tokens",
           "[cli][json-parser][coverage][phase3-large]") {
     auto value = parse_json(" \n\t { \r\n \"k\" \t : \n [ true , false ] \n } ");

--- a/test/test_cli_shell_quote.cpp
+++ b/test/test_cli_shell_quote.cpp
@@ -17,6 +17,8 @@
 
 #include "../tools/cli/cli_common.hpp"
 
+#include <filesystem>
+
 #ifdef _WIN32
 
 TEST_CASE("shell_quote leaves Windows path backslashes literal", "[cli][shell-quote][issue-776]") {
@@ -73,6 +75,16 @@ TEST_CASE("shell_quote escapes backslash and quote on POSIX", "[cli][shell-quote
     // Input:  say "hi"
     // Output: "say \"hi\""
     REQUIRE(shell_quote(std::string("say \"hi\"")) == "\"say \\\"hi\\\"\"");
+}
+
+TEST_CASE("shell_quote wraps empty and POSIX metacharacter arguments", "[cli][shell-quote]") {
+    REQUIRE(shell_quote(std::string()) == "\"\"");
+    REQUIRE(shell_quote(std::string("a;b$(c)`d e")) == "\"a;b$(c)`d e\"");
+}
+
+TEST_CASE("shell_quote path overload matches string overload on POSIX", "[cli][shell-quote]") {
+    const std::filesystem::path path = "/tmp/pulp path/with\"quote";
+    REQUIRE(shell_quote(path) == shell_quote(path.string()));
 }
 
 #endif

--- a/test/test_events_timer_helpers.cpp
+++ b/test/test_events_timer_helpers.cpp
@@ -43,3 +43,48 @@ TEST_CASE("Timer one-shot deactivates after firing and can be restarted",
     REQUIRE(wait_until([&] { return calls.load() == 2; }, 500ms));
     REQUIRE_FALSE(timer.is_active());
 }
+
+TEST_CASE("Timer start is idempotent while active",
+          "[events][timer][coverage][phase3-batch]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+    Timer timer(loop, 5ms, [&] { calls.fetch_add(1); }, false);
+
+    timer.start();
+    timer.start();
+    timer.start();
+
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 500ms));
+    std::this_thread::sleep_for(25ms);
+    REQUIRE(calls.load() == 1);
+    REQUIRE_FALSE(timer.is_active());
+}
+
+TEST_CASE("Timer stop cancels stale queued dispatch",
+          "[events][timer][coverage][phase3-batch]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+    Timer timer(loop, 40ms, [&] { calls.fetch_add(1); }, false);
+
+    timer.start();
+    REQUIRE(timer.is_active());
+    timer.stop();
+    REQUIRE_FALSE(timer.is_active());
+
+    std::this_thread::sleep_for(80ms);
+    REQUIRE(calls.load() == 0);
+}
+
+TEST_CASE("Timer interval setter applies to later starts",
+          "[events][timer][coverage][phase3-batch]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+    Timer timer(loop, 100ms, [&] { calls.fetch_add(1); }, false);
+
+    timer.set_interval(5ms);
+    REQUIRE(timer.interval() == 5ms);
+
+    timer.start();
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 500ms));
+    REQUIRE_FALSE(timer.is_active());
+}

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -50,11 +50,25 @@ TEST_CASE("FastMath exp2 approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::exp2(0.5f), WithinAbs(std::sqrt(2.0f), 0.01));
 }
 
+TEST_CASE("FastMath exp2 covers fractional octaves across zero",
+          "[signal][fast_math][coverage][phase3-large]") {
+    REQUIRE_THAT(FastMath::exp2(-0.5f), WithinAbs(std::exp2(-0.5f), 0.01f));
+    REQUIRE_THAT(FastMath::exp2(1.25f), WithinRel(std::exp2(1.25f), 0.01f));
+    REQUIRE_THAT(FastMath::exp2(7.75f), WithinRel(std::exp2(7.75f), 0.01f));
+}
+
 TEST_CASE("FastMath log2 approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::log2(1.0f), WithinAbs(0.0, 0.01));
     REQUIRE_THAT(FastMath::log2(2.0f), WithinAbs(1.0, 0.01));
     REQUIRE_THAT(FastMath::log2(8.0f), WithinAbs(3.0, 0.02));
     REQUIRE_THAT(FastMath::log2(0.5f), WithinAbs(-1.0, 0.02));
+}
+
+TEST_CASE("FastMath log2 tracks mantissa-heavy values",
+          "[signal][fast_math][coverage][phase3-large]") {
+    REQUIRE_THAT(FastMath::log2(1.5f), WithinAbs(std::log2(1.5f), 0.02f));
+    REQUIRE_THAT(FastMath::log2(3.25f), WithinAbs(std::log2(3.25f), 0.04f));
+    REQUIRE_THAT(FastMath::log2(96.0f), WithinAbs(std::log2(96.0f), 0.03f));
 }
 
 TEST_CASE("FastMath pow approximation", "[signal][fast_math]") {
@@ -71,6 +85,13 @@ TEST_CASE("FastMath pow and reciprocal guard edge inputs",
 
     REQUIRE_THAT(FastMath::rcp(4.0f), WithinAbs(0.25f, 0.001f));
     REQUIRE_THAT(FastMath::rcp(-2.0f), WithinAbs(-0.5f, 0.001f));
+}
+
+TEST_CASE("FastMath pow handles fractional and identity exponents",
+          "[signal][fast_math][coverage][phase3-large]") {
+    REQUIRE_THAT(FastMath::pow(9.0f, 0.5f), WithinAbs(3.0f, 0.08f));
+    REQUIRE_THAT(FastMath::pow(7.0f, 0.0f), WithinAbs(1.0f, 0.02f));
+    REQUIRE_THAT(FastMath::pow(1.0f, 32.0f), WithinAbs(1.0f, 0.02f));
 }
 
 TEST_CASE("FastMath db_to_gain", "[signal][fast_math]") {

--- a/test/test_file_dialog.cpp
+++ b/test/test_file_dialog.cpp
@@ -240,6 +240,47 @@ TEST_CASE("PopupMenu stores item metadata without showing native UI",
     REQUIRE(menu.items()[2].is_separator);
 }
 
+TEST_CASE("PopupMenu preserves insertion order and separator defaults",
+          "[platform][popup-menu][issue-640]") {
+    PopupMenu menu;
+    menu.add_separator();
+    menu.add_item(1, "");
+    menu.add_item(42, "Muted", true, true);
+    menu.add_separator();
+    menu.add_item(-7, "Disabled", false, false);
+
+    const auto& items = menu.items();
+    REQUIRE(items.size() == 5);
+
+    REQUIRE(items[0].is_separator);
+    REQUIRE(items[0].id == 0);
+    REQUIRE(items[0].label.empty());
+    REQUIRE(items[0].enabled);
+    REQUIRE_FALSE(items[0].checked);
+
+    REQUIRE_FALSE(items[1].is_separator);
+    REQUIRE(items[1].id == 1);
+    REQUIRE(items[1].label.empty());
+    REQUIRE(items[1].enabled);
+    REQUIRE_FALSE(items[1].checked);
+
+    REQUIRE_FALSE(items[2].is_separator);
+    REQUIRE(items[2].id == 42);
+    REQUIRE(items[2].label == "Muted");
+    REQUIRE(items[2].enabled);
+    REQUIRE(items[2].checked);
+
+    REQUIRE(items[3].is_separator);
+    REQUIRE(items[3].id == 0);
+    REQUIRE(items[3].label.empty());
+
+    REQUIRE_FALSE(items[4].is_separator);
+    REQUIRE(items[4].id == -7);
+    REQUIRE(items[4].label == "Disabled");
+    REQUIRE_FALSE(items[4].enabled);
+    REQUIRE_FALSE(items[4].checked);
+}
+
 #if !defined(__APPLE__)
 TEST_CASE("PopupMenu non-Apple stub returns no selection",
           "[platform][popup-menu][issue-640]") {

--- a/test/test_image_cache.cpp
+++ b/test/test_image_cache.cpp
@@ -42,6 +42,27 @@ TEST_CASE("miss then hit", "[view][image-cache]") {
     REQUIRE(calls.load() == 1);
 }
 
+TEST_CASE("decoder replacement does not invalidate cached image entries",
+          "[view][image-cache][coverage][phase3-large]") {
+    ImageCache c;
+    std::atomic<int> first_calls{0};
+    std::atomic<int> second_calls{0};
+    c.set_decoder(make_fake_decoder(first_calls));
+
+    auto* first = c.get("stable");
+    REQUIRE(first != nullptr);
+    auto* first_handle = first->native_handle;
+
+    c.set_decoder(make_fake_decoder(second_calls));
+    auto* cached = c.get("stable");
+    REQUIRE(cached == first);
+    REQUIRE(cached->native_handle == first_handle);
+    REQUIRE(first_calls.load() == 1);
+    REQUIRE(second_calls.load() == 0);
+    REQUIRE(c.stats().hits == 1);
+    REQUIRE(c.stats().misses == 1);
+}
+
 TEST_CASE("no-decoder returns nullptr", "[view][image-cache]") {
     ImageCache c;
     REQUIRE(c.get("a") == nullptr);
@@ -125,6 +146,27 @@ TEST_CASE("clear invokes releaser for every entry",
     REQUIRE(released.load() == 3);
     REQUIRE(c.stats().entry_count == 0);
     REQUIRE(c.stats().total_bytes == 0);
+}
+
+TEST_CASE("clear keeps accumulated cache statistics while dropping entries",
+          "[view][image-cache][coverage][phase3-large]") {
+    ImageCache c;
+    std::atomic<int> calls{0};
+    c.set_decoder(make_fake_decoder(calls));
+
+    REQUIRE(c.get("a") != nullptr);
+    REQUIRE(c.get("a") != nullptr);
+    auto before = c.stats();
+    REQUIRE(before.hits == 1);
+    REQUIRE(before.misses == 1);
+
+    c.clear();
+    auto after = c.stats();
+    REQUIRE(after.entry_count == 0);
+    REQUIRE(after.total_bytes == 0);
+    REQUIRE(after.hits == before.hits);
+    REQUIRE(after.misses == before.misses);
+    REQUIRE(after.evictions == before.evictions);
 }
 
 TEST_CASE("zero budget disables trimming", "[view][image-cache]") {

--- a/test/test_image_convolution.cpp
+++ b/test/test_image_convolution.cpp
@@ -78,6 +78,31 @@ TEST_CASE("Identity kernel supports explicit row stride", "[canvas][convolution]
     REQUIRE(pixels == original);
 }
 
+TEST_CASE("Convolution preserves padded row stride bytes",
+          "[canvas][convolution][coverage][phase3-large]") {
+    ImageConvolutionKernel identity(1);
+    identity.set(0, 0, 1.0f);
+
+    constexpr int width = 2;
+    constexpr int height = 2;
+    constexpr int stride = 12;
+    std::vector<uint8_t> pixels = {
+        10, 20, 30, 40, 50, 60, 70, 80, 0xA1, 0xA2, 0xA3, 0xA4,
+        90, 91, 92, 93, 94, 95, 96, 97, 0xB1, 0xB2, 0xB3, 0xB4,
+    };
+
+    identity.apply(pixels.data(), width, height, stride);
+
+    REQUIRE(pixels[8] == 0xA1);
+    REQUIRE(pixels[9] == 0xA2);
+    REQUIRE(pixels[10] == 0xA3);
+    REQUIRE(pixels[11] == 0xA4);
+    REQUIRE(pixels[20] == 0xB1);
+    REQUIRE(pixels[21] == 0xB2);
+    REQUIRE(pixels[22] == 0xB3);
+    REQUIRE(pixels[23] == 0xB4);
+}
+
 TEST_CASE("ImageConvolutionKernel clamps color output", "[canvas][convolution][issue-641]") {
     ImageConvolutionKernel boost(1);
     boost.set(0, 0, 3.0f);

--- a/test/test_midi_buffer_ump.cpp
+++ b/test/test_midi_buffer_ump.cpp
@@ -42,6 +42,31 @@ TEST_CASE("plugin-side consumer can iterate UMP packets via the sidecar",
     REQUIRE((*buf.ump())[0].packet.message_type() == UmpMessageType::Midi2ChannelVoice);
 }
 
+TEST_CASE("UmpBuffer sorts, iterates, and clears sample-accurate events",
+          "[midi][buffer][ump][coverage][phase3-large]") {
+    UmpBuffer ump;
+    ump.add(UmpPacket::note_on_2(0, 2, 67, 0x4000), 96);
+    ump.add(UmpEvent{UmpPacket::note_off_2(0, 1, 60, 0), 12});
+    ump.add(UmpPacket::note_on_2(0, 1, 60, 0x8000), 48);
+
+    REQUIRE_FALSE(ump.empty());
+    REQUIRE(ump.size() == 3);
+
+    ump.sort();
+    REQUIRE(ump[0].sample_offset == 12);
+    REQUIRE(ump[1].sample_offset == 48);
+    REQUIRE(ump[2].sample_offset == 96);
+
+    int total_offsets = 0;
+    for (const auto& event : ump)
+        total_offsets += event.sample_offset;
+    REQUIRE(total_offsets == 156);
+
+    ump.clear();
+    REQUIRE(ump.empty());
+    REQUIRE(ump.size() == 0);
+}
+
 TEST_CASE("attached UMP sidecar remains externally owned across MidiBuffer edits",
           "[midi][buffer][ump][issue-645]") {
     MidiBuffer buf;

--- a/test/test_midi_file.cpp
+++ b/test/test_midi_file.cpp
@@ -50,6 +50,27 @@ std::vector<uint8_t> read_bytes(const fs::path& path) {
 
 } // namespace
 
+TEST_CASE("MidiFileData aggregates duration and event counts across tracks",
+          "[midi][file][coverage][phase3]") {
+    MidiFileData data;
+    REQUIRE(data.total_events() == 0);
+    REQUIRE(data.duration_seconds() == Approx(0.0).margin(1e-9));
+
+    MidiTrack first;
+    first.events.push_back({0.25, MidiEvent::note_on(0, 60, 100)});
+    first.events.push_back({0.75, MidiEvent::note_off(0, 60, 0)});
+
+    MidiTrack second;
+    second.events.push_back({0.5, MidiEvent::cc(1, 74, 64)});
+    second.events.push_back({1.25, MidiEvent::program_change(1, 4)});
+
+    data.tracks.push_back(std::move(first));
+    data.tracks.push_back(std::move(second));
+
+    REQUIRE(data.total_events() == 4);
+    REQUIRE(data.duration_seconds() == Approx(1.25).margin(1e-9));
+}
+
 TEST_CASE("read_midi_file decodes running status byte fixtures",
           "[midi][file][issue-645]") {
     TempDir tmp;
@@ -187,4 +208,15 @@ TEST_CASE("write_midi_file emits a readable SMF header",
     REQUIRE(read->ticks_per_quarter == 960);
     REQUIRE(read->total_events() == 2);
     REQUIRE(read->duration_seconds() == Approx(0.5).margin(0.05));
+}
+
+TEST_CASE("write_midi_file rejects directory destinations",
+          "[midi][file][coverage][phase3]") {
+    TempDir tmp;
+    MidiFileData data;
+    MidiTrack track;
+    track.events.push_back({0.0, MidiEvent::note_on(0, 60, 100)});
+    data.tracks.push_back(std::move(track));
+
+    REQUIRE_FALSE(write_midi_file(tmp.path.string(), data));
 }

--- a/test/test_motion_cost.cpp
+++ b/test/test_motion_cost.cpp
@@ -277,6 +277,16 @@ TEST_CASE("CostSample zeroes render fields when no probe is wired",
     REQUIRE(fx.samples[0].dirty_rect_count == 0);
 }
 
+TEST_CASE("Cost buffer sink tolerates a null destination",
+          "[motion-cost][coverage][phase3]") {
+    auto sink = make_cost_buffer_sink(nullptr);
+
+    CostSample s;
+    s.frame = 5;
+
+    REQUIRE_NOTHROW(sink(s));
+}
+
 // ── Bridge probe pulls real RenderPassManager + DirtyTracker stats ──
 
 TEST_CASE("make_render_cost_probe surfaces RenderPassManager + DirtyTracker",
@@ -369,6 +379,28 @@ TEST_CASE("CostSample JSONL serialization round-trips a stream", "[motion-cost]"
     REQUIRE(found_any_prov);
 
     std::remove(path.c_str());
+}
+
+TEST_CASE("load_cost_stream rejects missing or unsupported headers",
+          "[motion-cost][coverage][phase3]") {
+    REQUIRE(load_cost_stream(unique_path("missing")).empty());
+
+    const std::string no_header = unique_path("no-header");
+    {
+        std::ofstream out(no_header);
+        out << serialize_cost_sample(CostSample{}) << "\n";
+    }
+    REQUIRE(load_cost_stream(no_header).empty());
+    std::remove(no_header.c_str());
+
+    const std::string unsupported = unique_path("unsupported");
+    {
+        std::ofstream out(unsupported);
+        out << "{\"motion_cost_version\":2}\n"
+            << serialize_cost_sample(CostSample{}) << "\n";
+    }
+    REQUIRE(load_cost_stream(unsupported).empty());
+    std::remove(unsupported.c_str());
 }
 
 // ── serialize_cost_sample produces well-formed JSON ──────────────────

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -153,6 +153,26 @@ TEST_CASE("motion_policy_to_string / from_string round-trip",
     REQUIRE(motion_policy_from_string("bogus") == MotionPolicy::Full);
 }
 
+TEST_CASE("Motion policy duration helpers honor full reduced and off",
+          "[motion-preferences][coverage][phase3]") {
+    using namespace pulp::view;
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+
+    prefs.set_override(MotionPolicy::Full);
+    prefs.set_duration_scale(0.25);
+    REQUIRE(apply_motion_policy_to_duration(2.0f) == Approx(2.0f));
+    REQUIRE_FALSE(motion_policy_is_off());
+
+    prefs.set_override(MotionPolicy::Reduced);
+    REQUIRE(apply_motion_policy_to_duration(2.0f) == Approx(0.5f));
+    REQUIRE_FALSE(motion_policy_is_off());
+
+    prefs.set_override(MotionPolicy::Off);
+    REQUIRE(apply_motion_policy_to_duration(2.0f) == Approx(0.0f));
+    REQUIRE(motion_policy_is_off());
+}
+
 // ── Tween honors MotionPolicy ────────────────────────────────────────
 
 TEST_CASE("Tween under MotionPolicy::Off is finished from construction",

--- a/test/test_phase9_widgets.cpp
+++ b/test/test_phase9_widgets.cpp
@@ -712,6 +712,42 @@ TEST_CASE("SplitView paint emits horizontal and vertical divider grips",
     REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_circle) == 3);
 }
 
+TEST_CASE("SplitView can replace panes and lays out with custom divider width",
+          "[view][split_view][coverage][phase3-batch]") {
+    SplitView split;
+    split.set_bounds({0, 0, 300, 120});
+    split.set_split_fraction(0.25f);
+    split.set_divider_width(10.0f);
+
+    auto first = std::make_unique<View>();
+    auto second = std::make_unique<View>();
+    auto* original_first = first.get();
+    auto* second_ptr = second.get();
+    split.set_first(std::move(first));
+    split.set_second(std::move(second));
+    split.layout_children();
+
+    REQUIRE(split.first() == original_first);
+    REQUIRE(split.second() == second_ptr);
+    REQUIRE_THAT(split.divider_width(), WithinAbs(10.0f, 0.001f));
+    REQUIRE_THAT(original_first->bounds().width, WithinAbs(70.0f, 0.001f));
+    REQUIRE_THAT(second_ptr->bounds().x, WithinAbs(80.0f, 0.001f));
+
+    auto replacement = std::make_unique<View>();
+    auto* replacement_ptr = replacement.get();
+    split.set_first(std::move(replacement));
+    split.layout_children();
+
+    REQUIRE(split.first() == replacement_ptr);
+    REQUIRE(split.second() == second_ptr);
+    REQUIRE_THAT(replacement_ptr->bounds().width, WithinAbs(70.0f, 0.001f));
+
+    split.set_second(nullptr);
+    REQUIRE(split.second() == nullptr);
+    split.layout_children();
+    REQUIRE(split.first() == replacement_ptr);
+}
+
 // ── PropertyList ────────────────────────────────────────────────────────────
 
 TEST_CASE("PropertyList basic operations", "[view][property_list]") {

--- a/test/test_property_list.cpp
+++ b/test/test_property_list.cpp
@@ -76,6 +76,26 @@ TEST_CASE("PropertyList intrinsic height accounts for category display", "[view]
     REQUIRE(list.intrinsic_height() == 40.0f);
 }
 
+TEST_CASE("PropertyList empty model still paints background only",
+          "[view][property_list][coverage][phase3-large]") {
+    PropertyList list;
+    list.set_bounds({0, 0, 160, 80});
+    list.set_row_height(18.0f);
+    list.set_label_width_fraction(0.65f);
+
+    REQUIRE(list.row_height() == 18.0f);
+    REQUIRE(list.label_width_fraction() == 0.65f);
+    REQUIRE(list.show_categories());
+    REQUIRE(list.intrinsic_height() == 0.0f);
+    REQUIRE(list.find_property("missing") == nullptr);
+
+    RecordingCanvas canvas;
+    list.paint(canvas);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_text) == 0);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_line) == 0);
+}
+
 TEST_CASE("PropertyList mouse toggles editable bools and skips read-only values",
           "[view][property_list]") {
     PropertyList list;
@@ -123,6 +143,31 @@ TEST_CASE("PropertyList set_value only mutates existing keys", "[view][property_
     auto* gain = list.find_property("gain");
     REQUIRE(gain != nullptr);
     REQUIRE(std::get<float>(gain->value) == 0.75f);
+}
+
+TEST_CASE("PropertyList set_value preserves variant-specific value types",
+          "[view][property_list][coverage][phase3-large]") {
+    PropertyList list;
+    list.set_properties({
+        {"name", "Name", std::string("Old"), false, ""},
+        {"count", "Count", 1, false, ""},
+        {"enabled", "Enabled", false, false, ""},
+        {"color", "Color", Color::rgba8(0, 0, 0), false, ""},
+    });
+
+    list.set_value("name", std::string("New"));
+    list.set_value("count", 42);
+    list.set_value("enabled", true);
+    list.set_value("color", Color::rgba8(255, 128, 0));
+
+    REQUIRE(std::get<std::string>(list.find_property("name")->value) == "New");
+    REQUIRE(std::get<int>(list.find_property("count")->value) == 42);
+    REQUIRE(std::get<bool>(list.find_property("enabled")->value));
+    const auto color = std::get<Color>(list.find_property("color")->value);
+    REQUIRE(color.r == 1.0f);
+    REQUIRE(color.g > 0.49f);
+    REQUIRE(color.g < 0.51f);
+    REQUIRE(color.b == 0.0f);
 }
 
 TEST_CASE("PropertyList category visibility and label fallback paint paths",

--- a/test/test_rectangle_list.cpp
+++ b/test/test_rectangle_list.cpp
@@ -88,6 +88,22 @@ TEST_CASE("RectangleList subtract handles no-op and full-cover cases",
     REQUIRE(rl.empty());
 }
 
+TEST_CASE("RectangleList subtract emits all side bands around a center cut",
+          "[canvas][rect][coverage][phase3-large]") {
+    RectangleList rl;
+    rl.add({0, 0, 10, 10});
+
+    rl.subtract({3, 2, 4, 5});
+
+    REQUIRE(rl.size() == 4);
+    require_rect(rl[0], 0, 0, 10, 2);
+    require_rect(rl[1], 0, 7, 10, 3);
+    require_rect(rl[2], 0, 2, 3, 5);
+    require_rect(rl[3], 7, 2, 3, 5);
+    REQUIRE_FALSE(rl.contains(5, 4));
+    REQUIRE(rl.total_area() == Catch::Approx(80.0f));
+}
+
 TEST_CASE("RectangleList empty clip and subtract are no-ops",
           "[canvas][rect][issue-641]") {
     RectangleList rl;

--- a/test/test_resizable_shell.cpp
+++ b/test/test_resizable_shell.cpp
@@ -71,6 +71,37 @@ TEST_CASE("serialize + deserialize round-trip", "[ui][resizable-shell]") {
     REQUIRE(other.current().height == 700);
 }
 
+TEST_CASE("serialize stores little-endian width and height bytes",
+          "[ui][resizable-shell][coverage][phase3]") {
+    ResizableShell s({.initial_size = {0x0304u, 0x020Du}});
+
+    const auto blob = s.serialize();
+
+    REQUIRE(blob.size() == 8);
+    REQUIRE(blob[0] == 0x04);
+    REQUIRE(blob[1] == 0x03);
+    REQUIRE(blob[2] == 0x00);
+    REQUIRE(blob[3] == 0x00);
+    REQUIRE(blob[4] == 0x0D);
+    REQUIRE(blob[5] == 0x02);
+    REQUIRE(blob[6] == 0x00);
+    REQUIRE(blob[7] == 0x00);
+}
+
+TEST_CASE("deserialize ignores trailing bytes after the size payload",
+          "[ui][resizable-shell][coverage][phase3]") {
+    uint8_t blob[] = {
+        0x2Cu, 0x01u, 0x00u, 0x00u, // 300
+        0xC8u, 0x00u, 0x00u, 0x00u, // 200
+        0xAAu, 0xBBu,
+    };
+
+    ResizableShell s({.initial_size = {640, 480}});
+    REQUIRE(s.deserialize({blob, sizeof(blob)}));
+    REQUIRE(s.current().width == 300);
+    REQUIRE(s.current().height == 200);
+}
+
 TEST_CASE("deserialize clamps against current config",
           "[ui][resizable-shell]") {
     ResizableShell wide({.initial_size = {4096, 4096}});
@@ -112,4 +143,23 @@ TEST_CASE("constructor normalizes initial size through negotiate",
                       .initial_size = {640, 480}});
     REQUIRE(s.current().width  <= 300);
     REQUIRE(s.current().height <= 300);
+}
+
+TEST_CASE("non-positive aspect ratio uses plain min max clamping",
+          "[ui][resizable-shell][coverage][phase3]") {
+    ResizableShell zero({.min_size = {100, 80},
+                         .max_size = {500, 400},
+                         .initial_size = {300, 300},
+                         .aspect_ratio = 0.0});
+    auto z = zero.apply({900, 10});
+    REQUIRE(z.width == 500);
+    REQUIRE(z.height == 80);
+
+    ResizableShell negative({.min_size = {120, 90},
+                             .max_size = {600, 450},
+                             .initial_size = {300, 300},
+                             .aspect_ratio = -2.0});
+    auto n = negative.negotiate({10, 900});
+    REQUIRE(n.width == 120);
+    REQUIRE(n.height == 450);
 }

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -675,6 +675,18 @@ TEST_CASE("text_diff handles empty inputs", "[runtime][text-diff][issue-641]") {
     REQUIRE(format_diff(diff).empty());
 }
 
+TEST_CASE("text_diff formats unchanged lines as context",
+          "[runtime][text-diff][coverage][phase3]") {
+    auto diff = text_diff("alpha\nbeta", "alpha\nbeta");
+
+    REQUIRE(diff.size() == 2);
+    REQUIRE(diff[0].op == DiffOp::Equal);
+    REQUIRE(diff[0].text == "alpha");
+    REQUIRE(diff[1].op == DiffOp::Equal);
+    REQUIRE(diff[1].text == "beta");
+    REQUIRE(format_diff(diff) == "  alpha\n  beta\n");
+}
+
 TEST_CASE("text_diff reports pure inserts and deletes",
           "[runtime][text-diff][issue-641]") {
     auto inserted = text_diff("", "one\ntwo");

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -536,6 +536,37 @@ TEST_CASE("base64 handles explicit byte pointers and exact quartet decoding",
     REQUIRE(*quartet == std::vector<uint8_t>{0xff, 0xff, 0xff});
 }
 
+TEST_CASE("base64 covers full alphabet and padded binary tails",
+          "[runtime][base64][coverage][phase3-large]") {
+    const uint8_t alphabet_bytes[] = {
+        0x00, 0x10, 0x83, 0x10, 0x51, 0x87, 0x20, 0x92,
+        0x8b, 0x30, 0xd3, 0x8f, 0x41, 0x14, 0x93, 0x51,
+        0x55, 0x97, 0x61, 0x96, 0x9b, 0x71, 0xd7, 0x9f,
+        0x82, 0x18, 0xa3, 0x92, 0x59, 0xa7, 0xa2, 0x9a,
+        0xab, 0xb2, 0xdb, 0xaf, 0xc3, 0x1c, 0xb3, 0xd3,
+        0x5d, 0xb7, 0xe3, 0x9e, 0xbb, 0xf3, 0xdf, 0xbf,
+    };
+
+    auto encoded = base64_encode(alphabet_bytes, sizeof(alphabet_bytes));
+    REQUIRE(encoded == "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+
+    auto decoded = base64_decode(encoded);
+    REQUIRE(decoded.has_value());
+    REQUIRE(std::equal(decoded->begin(), decoded->end(), std::begin(alphabet_bytes)));
+
+    const uint8_t one_tail[] = {0xfb};
+    const uint8_t two_tail[] = {0xfb, 0xff};
+    REQUIRE(base64_encode(one_tail, sizeof(one_tail)) == "+w==");
+    REQUIRE(base64_encode(two_tail, sizeof(two_tail)) == "+/8=");
+}
+
+TEST_CASE("base64 decode tolerates whitespace inside unpadded input",
+          "[runtime][base64][coverage][phase3-large]") {
+    auto decoded = base64_decode("\n Y W J \t j Z A \r");
+    REQUIRE(decoded.has_value());
+    REQUIRE(std::string(decoded->begin(), decoded->end()) == "abcd");
+}
+
 // ── Expression ─────────────────────────────────────────────────────────
 
 TEST_CASE("Expression evaluator handles precedence and exponent edge cases",

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -655,6 +655,18 @@ TEST_CASE("ObservableValue skips empty listeners", "[state][observable][codecov]
     REQUIRE(count == 1);
 }
 
+TEST_CASE("ObservableValue removing an unknown listener is a no-op",
+          "[state][observable][coverage][phase3]") {
+    ObservableValue<int> val(1);
+    int count = 0;
+    val.add_listener([&](const int&, const int&) { ++count; });
+
+    val.remove_listener(999);
+    val.set(2);
+
+    REQUIRE(count == 1);
+}
+
 // ── CachedProperty ──────────────────────────────────────────────────────
 
 TEST_CASE("CachedProperty binds default and follows tree updates", "[state][cached]") {
@@ -709,6 +721,17 @@ TEST_CASE("CachedProperty unbound set only updates local cache", "[state][cached
 
     size.set(512);
     REQUIRE(size.get() == 512);
+}
+
+TEST_CASE("CachedProperty move of unbound property preserves cached value",
+          "[state][cached][coverage][phase3]") {
+    CachedProperty<int64_t> size;
+    size.set(256);
+
+    CachedProperty<int64_t> moved(std::move(size));
+
+    REQUIRE_FALSE(moved.is_bound());
+    REQUIRE(moved.get() == 256);
 }
 
 TEST_CASE("CachedProperty ignores mismatched external updates",

--- a/test/test_table_model.cpp
+++ b/test/test_table_model.cpp
@@ -70,6 +70,35 @@ TEST_CASE("sort_by falls back to text when numeric keys are mixed",
     REQUIRE(m.cell(2, 0).text == "2");
 }
 
+TEST_CASE("sort_by preserves insertion order for equal sort keys",
+          "[ui][table-model][coverage][phase3]") {
+    TableModel m;
+    m.add_column({"Name"});
+    m.add_column({"Rank"});
+    m.add_row({{"First"}, {"A", 1.0}});
+    m.add_row({{"Second"}, {"B", 1.0}});
+    m.add_row({{"Third"}, {"C", 2.0}});
+
+    m.sort_by(1, TableSortOrder::Ascending);
+
+    REQUIRE(m.cell(0, 0).text == "First");
+    REQUIRE(m.cell(1, 0).text == "Second");
+    REQUIRE(m.cell(2, 0).text == "Third");
+}
+
+TEST_CASE("sort_by None records state without reordering rows",
+          "[ui][table-model][coverage][phase3]") {
+    auto m = make_preset_table();
+
+    m.sort_by(0, TableSortOrder::None);
+
+    REQUIRE(m.sort_column() == 0);
+    REQUIRE(m.sort_order() == TableSortOrder::None);
+    REQUIRE(m.cell(0, 0).text == "Dreamy Pad");
+    REQUIRE(m.cell(1, 0).text == "Stab");
+    REQUIRE(m.cell(2, 0).text == "Lush");
+}
+
 TEST_CASE("toggle_sort cycles ascending -> descending -> none",
           "[ui][table-model]") {
     auto m = make_preset_table();

--- a/test/test_theme_contrast.cpp
+++ b/test/test_theme_contrast.cpp
@@ -97,6 +97,37 @@ TEST_CASE("Adjust for contrast returns meeting color", "[view][contrast]") {
     REQUIRE(meets_contrast(*result, Color::rgba8(255, 255, 255), ContrastLevel::aa_normal));
 }
 
+TEST_CASE("Auto contrast falls back to the higher-ratio endpoint",
+          "[view][contrast][coverage][phase3]") {
+    auto background = Color::rgba8(120, 120, 120);
+    REQUIRE_FALSE(meets_contrast(Color::rgba8(255, 255, 255),
+                                 background,
+                                 ContrastLevel::aaa_normal));
+    REQUIRE_FALSE(meets_contrast(Color::rgba8(0, 0, 0),
+                                 background,
+                                 ContrastLevel::aaa_normal));
+
+    auto fg = auto_contrast_foreground(background, ContrastLevel::aaa_normal);
+
+    REQUIRE(fg.r == Catch::Approx(0.0f));
+    REQUIRE(fg.g == Catch::Approx(0.0f));
+    REQUIRE(fg.b == Catch::Approx(0.0f));
+}
+
+TEST_CASE("Adjust for contrast returns an already valid foreground unchanged",
+          "[view][contrast][coverage][phase3]") {
+    auto foreground = Color::rgba8(255, 255, 255, 128);
+    auto background = Color::rgba8(0, 0, 0);
+
+    auto result = adjust_for_contrast(foreground, background, ContrastLevel::aaa_normal);
+
+    REQUIRE(result.has_value());
+    REQUIRE_THAT(result->r, WithinAbs(foreground.r, 0.001));
+    REQUIRE_THAT(result->g, WithinAbs(foreground.g, 0.001));
+    REQUIRE_THAT(result->b, WithinAbs(foreground.b, 0.001));
+    REQUIRE_THAT(result->a, WithinAbs(foreground.a, 0.001));
+}
+
 // ── HSL Conversion ──────────────────────────────────────────────────────────
 
 TEST_CASE("HSL round-trip for pure red", "[view][contrast][hsl]") {

--- a/test/test_theme_presets.cpp
+++ b/test/test_theme_presets.cpp
@@ -149,6 +149,53 @@ TEST_CASE("theme_from_preset applies variant-specific overrides",
     REQUIRE(dark.string_token("font.family").value() == "DarkFace");
 }
 
+TEST_CASE("derive_theme maps semantic colors to audio-specific tokens",
+          "[view][presets][derive][coverage][phase3-batch]") {
+    SemanticColors colors{
+        color_from_hex(0x101112),
+        color_from_hex(0xE0E1E2),
+        color_from_hex(0x202122),
+        color_from_hex(0x304050),
+        color_from_hex(0x405060),
+        color_from_hex(0x506070),
+        color_from_hex(0x607080),
+        color_from_hex(0xC01020),
+        color_from_hex(0x708090),
+        color_from_hex(0x8090A0),
+        color_from_hex(0x90A0B0),
+        color_from_hex(0x111111),
+        color_from_hex(0x222222),
+        color_from_hex(0x333333),
+        color_from_hex(0x444444),
+        color_from_hex(0x555555),
+    };
+
+    auto theme = derive_theme(colors);
+
+    REQUIRE(theme.color("bg.primary").value() == colors.background);
+    REQUIRE(theme.color("bg.secondary").value() == colors.secondary);
+    REQUIRE(theme.color("bg.surface").value() == colors.input);
+    REQUIRE(theme.color("bg.elevated").value() == colors.card);
+
+    REQUIRE(theme.color("control.track").value() == colors.muted);
+    REQUIRE(theme.color("control.fill").value() == colors.primary);
+    REQUIRE(theme.color("control.thumb").value() == colors.foreground);
+    REQUIRE(theme.color("control.border").value() == colors.border);
+
+    REQUIRE(theme.color("knob.arc").value() == colors.primary);
+    REQUIRE(theme.color("slider.fill").value() == colors.primary);
+    REQUIRE(theme.color("progress.fill").value() == colors.primary);
+    REQUIRE(theme.color("spinner").value() == colors.primary);
+    REQUIRE(theme.color("tab.active").value() == colors.primary);
+
+    REQUIRE(theme.color("meter.red").value() == colors.destructive);
+    REQUIRE(theme.color("card.empty").value() == colors.card);
+    REQUIRE(theme.color("card.ready").value() == colors.card);
+    REQUIRE(theme.color("modal.border").value() == colors.border);
+    REQUIRE(theme.color("gradient.start").value() == colors.primary);
+    REQUIRE(theme.color("gradient.end").value() == colors.secondary);
+}
+
 // ── Specific Presets ────────────────────────────────────────────────────────
 
 TEST_CASE("Known presets exist", "[view][presets]") {

--- a/test/test_vendor_url.cpp
+++ b/test/test_vendor_url.cpp
@@ -33,3 +33,37 @@ TEST_CASE("copy preserves url + email", "[format][vendor-url]") {
     REQUIRE(b.vendor_email == "hello@pulp.audio");
     REQUIRE(b.manufacturer == "PulpCo");
 }
+
+TEST_CASE("PluginDescriptor bus helpers handle empty and populated layouts",
+          "[format][vendor-url][coverage][phase3-large]") {
+    PluginDescriptor d;
+    REQUIRE(d.default_input_channels() == 2);
+    REQUIRE(d.default_output_channels() == 2);
+
+    d.input_buses.clear();
+    d.output_buses.clear();
+    REQUIRE(d.default_input_channels() == 0);
+    REQUIRE(d.default_output_channels() == 0);
+
+    d.input_buses.push_back({"Sidechain", 1, true});
+    d.input_buses.push_back({"Main In", 2, false});
+    d.output_buses.push_back({"Main Out", 4, false});
+
+    REQUIRE(d.default_input_channels() == 1);
+    REQUIRE(d.default_output_channels() == 4);
+}
+
+TEST_CASE("PluginDescriptor modern capability flags default off",
+          "[format][vendor-url][coverage][phase3-large]") {
+    PluginDescriptor d;
+    REQUIRE_FALSE(d.supports_mpe);
+    REQUIRE_FALSE(d.supports_ump);
+    REQUIRE_FALSE(d.ios_requires_background_audio);
+
+    d.supports_mpe = true;
+    d.supports_ump = true;
+    d.ios_requires_background_audio = true;
+    REQUIRE(d.supports_mpe);
+    REQUIRE(d.supports_ump);
+    REQUIRE(d.ios_requires_background_audio);
+}

--- a/test/test_waveform_editor.cpp
+++ b/test/test_waveform_editor.cpp
@@ -205,6 +205,26 @@ TEST_CASE("WaveformEditor regions", "[view][waveform_editor]") {
     REQUIRE(editor.regions().empty());
 }
 
+TEST_CASE("WaveformRegion length reflects exclusive end sample",
+          "[view][waveform_editor][coverage][phase3-batch]") {
+    WaveformRegion region{120, 360, "Loop"};
+    REQUIRE(region.length() == 240);
+
+    WaveformRegion reversed{360, 120, "Reverse marker"};
+    REQUIRE(reversed.length() == -240);
+}
+
+TEST_CASE("WaveformEditor paint is empty without audio data",
+          "[view][waveform_editor][coverage][phase3-batch]") {
+    WaveformEditor editor;
+    editor.set_bounds({0, 0, 400, 150});
+
+    RecordingCanvas canvas;
+    editor.paint(canvas);
+
+    REQUIRE(canvas.commands().empty());
+}
+
 TEST_CASE("WaveformEditor paint produces draw commands", "[view][waveform_editor]") {
     WaveformEditor editor;
     auto data = make_sine(1000);
@@ -273,6 +293,27 @@ TEST_CASE("WaveformEditor key scrolls and release events are ignored", "[view][w
     left.key = KeyCode::left;
     REQUIRE(editor.on_key_event(left));
     REQUIRE(editor.visible_start() == 200);
+}
+
+TEST_CASE("WaveformEditor key Cmd+0 zooms to fit",
+          "[view][waveform_editor][coverage][phase3-batch]") {
+    WaveformEditor editor;
+    auto data = make_sine(1000);
+    editor.set_audio_data(data.data(), 1000, 44100.0f);
+    editor.set_visible_range(200, 200);
+
+    KeyEvent reset;
+    reset.key = KeyCode::num0;
+#ifdef __APPLE__
+    reset.modifiers = kModCmd;
+#else
+    reset.modifiers = kModCtrl;
+#endif
+    reset.is_down = true;
+
+    REQUIRE(editor.on_key_event(reset));
+    REQUIRE(editor.visible_start() == 0);
+    REQUIRE(editor.visible_length() == 1000);
 }
 
 TEST_CASE("WaveformEditor mouse click and shift extend selection", "[view][waveform_editor]") {


### PR DESCRIPTION
## Summary
- adds a 24-commit Phase 3 Codecov coverage batch across view, runtime, audio, MIDI, CLI, platform, canvas, signal, events, state, and format tests
- includes a small ImageConvolution padded-row-stride preservation fix covered by tests
- keeps validation on GitHub-hosted CI only; no Namespace dispatch

## Local validation
- built all changed test targets
- ran all selected changed test binaries, including `pulp-test-audio "~[coreaudio]"`
- `git diff --check`

Version-Bump: sdk=skip reason="test-only code coverage batch"