### PR TITLE
feat(canvas): LRU cache cap for variable-font animation (font v2 Slice 3.3)

### DIFF
--- a/core/canvas/include/pulp/canvas/font_resolver.hpp
+++ b/core/canvas/include/pulp/canvas/font_resolver.hpp
@@ -210,13 +210,34 @@ public:
     /// bumps baked into cache keys.
     void clear_cache();
 
+    /// pulp #2163 — font v2 Slice 3.3 (variable-font animation).
+    /// Cap the resolver cache so per-frame axis-instance variation
+    /// (60fps animation across `wght` 100→900 = 60 distinct cache
+    /// keys per second per animation) doesn't grow unbounded. Default
+    /// 256 entries — enough to hold a handful of animations + the
+    /// static set, small enough that the LRU eviction reliably fires
+    /// on real animations. Setting 0 disables the cap (back to the
+    /// pre-3.3 unbounded behavior). Setting a value shrinks the cache
+    /// immediately if it's currently over the new cap.
+    void set_cache_capacity(std::size_t entries);
+    std::size_t cache_capacity() const noexcept;
+
+    /// Current number of cached entries. Test-only — production code
+    /// should not rely on cache size directly.
+    std::size_t cache_size() const noexcept;
+
+    /// Implementation detail — exposed publicly only so the
+    /// slice-3.3 LRU helper (`cache_put_locked_impl` in
+    /// font_resolver.cpp) can reach the nested type. The struct
+    /// definition still lives in the .cpp; this is name-only.
+    struct Impl;
+
 private:
     FontResolver();
     ~FontResolver();
     FontResolver(const FontResolver&) = delete;
     FontResolver& operator=(const FontResolver&) = delete;
 
-    struct Impl;
     std::unique_ptr<Impl> impl_;
 };
 

--- a/core/canvas/src/font_resolver.cpp
+++ b/core/canvas/src/font_resolver.cpp
@@ -14,6 +14,8 @@
 #include "pulp/canvas/bundled_fonts.hpp"
 #include "pulp/canvas/font_flight_recorder.hpp"
 
+#include <iterator>
+#include <list>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -44,11 +46,23 @@ const char* to_string(FallbackOrigin o) noexcept {
 
 // ── FontResolver::Impl ───────────────────────────────────────────────────
 
+// pulp #2163 — font v2 Slice 3.3. The resolver cache is LRU-with-cap
+// so variable-font animations (60fps `wght` interpolation produces 60
+// distinct keys/sec) don't grow unbounded. Default cap is 256 entries
+// — a small static UI has ~10-30 cached faces, animations spike then
+// settle, and the LRU eviction keeps the working set in cache.
 struct FontResolver::Impl {
     mutable std::mutex mtx;
-    // Cache keyed on the full FontOptions hash; the value carries its
-    // own generation so a stale entry can be detected on lookup.
-    std::unordered_map<std::size_t, ResolvedFont> cache;
+    // hash → cache entry. The list iterator points at this entry's
+    // position in the LRU order list; hit -> move-to-back, evict ->
+    // pop-front. `value.first` mirrors the map key for fast eviction.
+    struct Entry {
+        ResolvedFont                                                resolved;
+        std::list<std::size_t>::iterator                            lru_pos;
+    };
+    std::unordered_map<std::size_t, Entry> cache;
+    std::list<std::size_t>                 lru_order;  // oldest at front
+    std::size_t                            capacity = 256;
 };
 
 FontResolver::FontResolver() : impl_(std::make_unique<Impl>()) {}
@@ -62,6 +76,28 @@ FontResolver& FontResolver::instance() {
 void FontResolver::clear_cache() {
     std::lock_guard<std::mutex> lock(impl_->mtx);
     impl_->cache.clear();
+    impl_->lru_order.clear();
+}
+
+void FontResolver::set_cache_capacity(std::size_t entries) {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    impl_->capacity = entries;
+    if (impl_->capacity == 0) return;  // 0 disables cap (legacy mode)
+    while (impl_->cache.size() > impl_->capacity) {
+        std::size_t oldest = impl_->lru_order.front();
+        impl_->lru_order.pop_front();
+        impl_->cache.erase(oldest);
+    }
+}
+
+std::size_t FontResolver::cache_capacity() const noexcept {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    return impl_->capacity;
+}
+
+std::size_t FontResolver::cache_size() const noexcept {
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    return impl_->cache.size();
 }
 
 #ifdef PULP_HAS_SKIA
@@ -184,6 +220,30 @@ ResolvedFont resolve_one_family(const std::string& family,
 
 } // namespace
 
+// pulp #2163 — Slice 3.3 helper. Insert `resolved` into the LRU
+// cache under `key`. Promotes existing entries to the back. Evicts
+// the oldest entry when the cap is exceeded. Caller must hold
+// `impl.mtx`.
+static void cache_put_locked(FontResolver::Impl& impl,
+                             std::size_t key,
+                             const ResolvedFont& resolved) {
+    auto it = impl.cache.find(key);
+    if (it != impl.cache.end()) {
+        impl.lru_order.splice(impl.lru_order.end(), impl.lru_order,
+                              it->second.lru_pos);
+        it->second.resolved = resolved;
+        return;
+    }
+    impl.lru_order.push_back(key);
+    auto pos = std::prev(impl.lru_order.end());
+    impl.cache.emplace(key, FontResolver::Impl::Entry{resolved, pos});
+    if (impl.capacity > 0 && impl.cache.size() > impl.capacity) {
+        std::size_t oldest = impl.lru_order.front();
+        impl.lru_order.pop_front();
+        impl.cache.erase(oldest);
+    }
+}
+
 ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
     // Cache lookup. Generation check happens at use site (callers compare
     // `resolved.generation` against `merged_generation_for(scope)`).
@@ -192,8 +252,12 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
         std::lock_guard<std::mutex> lock(impl_->mtx);
         auto it = impl_->cache.find(key);
         if (it != impl_->cache.end()
-            && it->second.generation == merged_generation_for(options.scope)) {
-            return it->second;
+            && it->second.resolved.generation == merged_generation_for(options.scope)) {
+            // LRU hit — promote to back.
+            impl_->lru_order.splice(impl_->lru_order.end(),
+                                     impl_->lru_order,
+                                     it->second.lru_pos);
+            return it->second.resolved;
         }
     }
 
@@ -249,7 +313,7 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
                 /*sequence*/ 0,
             });
             std::lock_guard<std::mutex> lock(impl_->mtx);
-            impl_->cache[key] = resolved;
+            cache_put_locked(*impl_, key, resolved);
             return resolved;
         }
     }
@@ -269,7 +333,7 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
 
     resolved.trace = std::move(trace);
     std::lock_guard<std::mutex> lock(impl_->mtx);
-    impl_->cache[key] = resolved;
+    cache_put_locked(*impl_, key, resolved);
     return resolved;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -867,6 +867,11 @@ add_executable(pulp-test-font-flight-recorder test_font_flight_recorder.cpp)
 target_link_libraries(pulp-test-font-flight-recorder PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-font-flight-recorder)
 
+# pulp #2163 / font v2 Slice 3.3 — variable-font axis-animation LRU cache.
+add_executable(pulp-test-font-axis-animation test_font_axis_animation.cpp)
+target_link_libraries(pulp-test-font-axis-animation PRIVATE pulp::canvas Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-font-axis-animation)
+
 # Font subsystem typed options and scope generation tests
 add_executable(pulp-test-font-options test_font_options.cpp)
 target_link_libraries(pulp-test-font-options PRIVATE pulp::canvas Catch2::Catch2WithMain)

--- a/test/test_font_axis_animation.cpp
+++ b/test/test_font_axis_animation.cpp
@@ -1,0 +1,132 @@
+// test_font_axis_animation.cpp — Pulp #2163, font v2 Slice 3.3.
+//
+// Variable-font animation cache eviction. 60fps `wght` interpolation
+// produces 60 distinct FontOptions hashes per second per family.
+// Without an LRU cap, the resolver cache grows unbounded; this test
+// pins the contract that animations stay within `set_cache_capacity`.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/canvas/font_resolver.hpp>
+#include <pulp/canvas/font_options.hpp>
+
+#ifdef PULP_HAS_SKIA
+#include "include/core/SkTypeface.h"
+#endif
+
+using namespace pulp::canvas;
+
+TEST_CASE("FontResolver: default cache capacity is non-zero", "[font][axes][issue-2163]") {
+    auto& r = FontResolver::instance();
+    REQUIRE(r.cache_capacity() > 0u);
+}
+
+TEST_CASE("FontResolver: set_cache_capacity round-trip", "[font][axes]") {
+    auto& r = FontResolver::instance();
+    auto original = r.cache_capacity();
+
+    r.set_cache_capacity(64);
+    REQUIRE(r.cache_capacity() == 64u);
+
+    r.set_cache_capacity(0);  // disabled
+    REQUIRE(r.cache_capacity() == 0u);
+
+    r.set_cache_capacity(original);
+}
+
+TEST_CASE("FontResolver: animation respects LRU cache cap", "[font][axes]") {
+    auto& r = FontResolver::instance();
+    r.clear_cache();
+    r.set_cache_capacity(16);
+
+    // Simulate a 60fps weight animation: 100 distinct axis values
+    // crossing the 16-entry cap should evict steadily.
+    for (int i = 0; i < 100; ++i) {
+        FontOptions opts;
+        opts.family_stack.push_back("Inter");
+        opts.size = 14.0f;
+        opts.variation_axes.push_back({
+            make_variation_axis_tag('w','g','h','t'),
+            100.0f + static_cast<float>(i) * 8.0f,
+        });
+        (void) r.resolve_family_list(opts);
+    }
+    REQUIRE(r.cache_size() <= 16u);
+    REQUIRE(r.cache_size() >= 1u);  // at least one entry survived
+
+    r.set_cache_capacity(256);  // restore default-ish
+    r.clear_cache();
+}
+
+TEST_CASE("FontResolver: capacity=0 disables cap (legacy unbounded)", "[font][axes]") {
+    auto& r = FontResolver::instance();
+    r.clear_cache();
+    r.set_cache_capacity(0);
+
+    for (int i = 0; i < 50; ++i) {
+        FontOptions opts;
+        opts.family_stack.push_back("Inter");
+        opts.size = 14.0f + static_cast<float>(i) * 0.1f;  // distinct size each iter
+        (void) r.resolve_family_list(opts);
+    }
+    // No cap → cache holds every distinct key.
+    REQUIRE(r.cache_size() >= 40u);
+
+    r.set_cache_capacity(256);
+    r.clear_cache();
+}
+
+TEST_CASE("FontResolver: shrinking the cap evicts oldest immediately",
+          "[font][axes]") {
+    auto& r = FontResolver::instance();
+    r.clear_cache();
+    r.set_cache_capacity(64);
+
+    for (int i = 0; i < 32; ++i) {
+        FontOptions opts;
+        opts.family_stack.push_back("Inter");
+        opts.size = 14.0f + static_cast<float>(i) * 0.5f;
+        (void) r.resolve_family_list(opts);
+    }
+    REQUIRE(r.cache_size() == 32u);
+
+    r.set_cache_capacity(8);
+    REQUIRE(r.cache_size() == 8u);
+
+    r.set_cache_capacity(256);
+    r.clear_cache();
+}
+
+TEST_CASE("FontResolver: LRU hit promotes entry past eviction line",
+          "[font][axes]") {
+    auto& r = FontResolver::instance();
+    r.clear_cache();
+    r.set_cache_capacity(4);
+
+    // Insert 4 entries: A, B, C, D (oldest-to-newest)
+    auto resolve_size = [&](float size) {
+        FontOptions opts;
+        opts.family_stack.push_back("Inter");
+        opts.size = size;
+        return r.resolve_family_list(opts);
+    };
+    resolve_size(10.0f);
+    resolve_size(11.0f);
+    resolve_size(12.0f);
+    resolve_size(13.0f);
+    REQUIRE(r.cache_size() == 4u);
+
+    // Touch the oldest (10.0f) — promotes it to most-recent.
+    resolve_size(10.0f);
+    // Insert one more (14.0f) — evicts the now-oldest (11.0f).
+    resolve_size(14.0f);
+    REQUIRE(r.cache_size() == 4u);
+
+    // 10.0f should still be cached (we just promoted it).
+    auto before_size = r.cache_size();
+    resolve_size(10.0f);  // hit, no insert
+    REQUIRE(r.cache_size() == before_size);
+
+    r.set_cache_capacity(256);
+    r.clear_cache();
+}


### PR DESCRIPTION
Phase 3 / Slice 3.3. Variable-font animation cache bounded at 256 entries by default (configurable via set_cache_capacity). 6 cases / 11 assertions green. No regression in 2.3 or 1.3 tests.