### PR TITLE
fix(canvas+view): Codex review sweep across 7 font v2 PRs

### DIFF
--- a/core/canvas/include/pulp/canvas/font_resolver.hpp
+++ b/core/canvas/include/pulp/canvas/font_resolver.hpp
@@ -27,6 +27,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -69,25 +70,37 @@ namespace pulp::canvas {
 //   * HintingMode::Normal          → kNormal
 //   * HintingMode::Full            → kFull
 
-constexpr SkFont::Edging sk_edging_for(AntiAliasMode mode) noexcept {
+// Codex review on PR #2186 (P2): `AntiAliasMode::Default` is documented as
+// "follow the inside_non_opaque_layer() heuristic" (#1899) and
+// `HintingMode::PlatformDefault` as "let the platform pick". Hard-coding
+// either to a single Skia value erases the per-caller branch.
+//
+// Both helpers now return `std::optional`: `Default` / `PlatformDefault`
+// resolve to `nullopt` ("caller decides"); explicit modes resolve to the
+// fixed Skia enum. The convenience `ResolvedFont::sk_edging()` /
+// `sk_hinting()` accessors below pick a safe fallback for callers that
+// don't have an opaque-surface signal handy — but the structured path
+// keeps the heuristic intact.
+
+constexpr std::optional<SkFont::Edging> sk_edging_for(AntiAliasMode mode) noexcept {
     switch (mode) {
         case AntiAliasMode::LCD:       return SkFont::Edging::kSubpixelAntiAlias;
         case AntiAliasMode::Grayscale: return SkFont::Edging::kAntiAlias;
         case AntiAliasMode::NoAA:      return SkFont::Edging::kAlias;
-        case AntiAliasMode::Default:   break;
+        case AntiAliasMode::Default:   return std::nullopt;
     }
-    return SkFont::Edging::kAntiAlias;
+    return std::nullopt;
 }
 
-constexpr SkFontHinting sk_hinting_for(HintingMode mode) noexcept {
+constexpr std::optional<SkFontHinting> sk_hinting_for(HintingMode mode) noexcept {
     switch (mode) {
         case HintingMode::None:            return SkFontHinting::kNone;
         case HintingMode::Slight:          return SkFontHinting::kSlight;
         case HintingMode::Normal:          return SkFontHinting::kNormal;
         case HintingMode::Full:            return SkFontHinting::kFull;
-        case HintingMode::PlatformDefault: break;
+        case HintingMode::PlatformDefault: return std::nullopt;
     }
-    return SkFontHinting::kNormal;
+    return std::nullopt;
 }
 
 #endif  // PULP_HAS_SKIA
@@ -165,15 +178,18 @@ struct ResolvedFont {
     }
 
 #ifdef PULP_HAS_SKIA
-    /// Skia `SkFont::Edging` for the recorded `aa_mode`. See
-    /// `sk_edging_for(AntiAliasMode)` for the mapping table.
-    SkFont::Edging sk_edging() const noexcept {
+    /// Skia `SkFont::Edging` for the recorded `aa_mode`, or
+    /// `std::nullopt` for `AntiAliasMode::Default` (caller decides
+    /// — typically by branching on `inside_non_opaque_layer()` per
+    /// #1899). See `sk_edging_for(AntiAliasMode)` for the mapping.
+    std::optional<SkFont::Edging> sk_edging() const noexcept {
         return sk_edging_for(aa_mode);
     }
 
-    /// Skia `SkFontHinting` for the recorded `hinting_mode`. See
-    /// `sk_hinting_for(HintingMode)` for the mapping table.
-    SkFontHinting sk_hinting() const noexcept {
+    /// Skia `SkFontHinting` for the recorded `hinting_mode`, or
+    /// `std::nullopt` for `HintingMode::PlatformDefault` (caller
+    /// preserves backend-specific defaults). See `sk_hinting_for`.
+    std::optional<SkFontHinting> sk_hinting() const noexcept {
         return sk_hinting_for(hinting_mode);
     }
 #endif

--- a/core/canvas/src/bundled_fonts.cpp
+++ b/core/canvas/src/bundled_fonts.cpp
@@ -430,6 +430,13 @@ bool validate_font_bytes(const std::uint8_t* data, std::size_t size) {
     constexpr std::uint32_t kName = 0x6E616D65u; // 'name'
     constexpr std::uint32_t kCmap = 0x636D6170u; // 'cmap'
     constexpr std::uint32_t kMaxp = 0x6D617870u; // 'maxp'
+    // Codex #2177 P1 review: presence is not enough — a malformed
+    // font can list required tables with length=0 and still pass.
+    // Enforce minimum lengths derived from the OpenType spec.
+    //   head: 54 (full table)
+    //   name: 6  (numNameRecords + storageOffset + format)
+    //   cmap: 4  (version + numTables)
+    //   maxp: 6  (version + numGlyphs)
     bool has_head = false, has_name = false, has_cmap = false, has_maxp = false;
     std::uint32_t head_offset = 0, head_length = 0;
 
@@ -441,10 +448,19 @@ bool validate_font_bytes(const std::uint8_t* data, std::size_t size) {
         // Out-of-bounds or overflow.
         if (offset > size) return false;
         if (length > size - offset) return false;
-        if (tag == kHead) { has_head = true; head_offset = offset; head_length = length; }
-        else if (tag == kName) has_name = true;
-        else if (tag == kCmap) has_cmap = true;
-        else if (tag == kMaxp) has_maxp = true;
+        if (tag == kHead) {
+            if (length < 54) return false;
+            has_head = true; head_offset = offset; head_length = length;
+        } else if (tag == kName) {
+            if (length < 6) return false;
+            has_name = true;
+        } else if (tag == kCmap) {
+            if (length < 4) return false;
+            has_cmap = true;
+        } else if (tag == kMaxp) {
+            if (length < 6) return false;
+            has_maxp = true;
+        }
     }
     if (!has_head || !has_name || !has_cmap || !has_maxp) return false;
 

--- a/core/canvas/src/font_registry_stubs.cpp
+++ b/core/canvas/src/font_registry_stubs.cpp
@@ -26,24 +26,41 @@ namespace {
 // naive walker this replaces.
 struct Utf8Decoded { std::uint32_t cp; std::size_t bytes; };
 
+// Codex review on PR #2185 (P2): validate every trailing byte is a
+// proper UTF-8 continuation (top two bits == 0b10) before accepting
+// a multi-byte scalar. Malformed inputs like `0xC2 0x41` must fall
+// back to {0,1} so cluster_step doesn't skip bytes on invalid UTF-8.
+inline bool is_utf8_cont(unsigned char b) noexcept {
+    return (b & 0xC0u) == 0x80u;
+}
+
 inline Utf8Decoded utf8_decode_at(const std::string& s, std::size_t i) noexcept {
     if (i >= s.size()) return {0, 0};
     unsigned char c = static_cast<unsigned char>(s[i]);
     if (c < 0x80) return {c, 1};
     if ((c & 0xE0) == 0xC0 && i + 1 < s.size()) {
+        unsigned char b1 = static_cast<unsigned char>(s[i + 1]);
+        if (!is_utf8_cont(b1)) return {0, 1};
         return {static_cast<std::uint32_t>(((c & 0x1Fu) << 6)
-                                         | (static_cast<unsigned char>(s[i + 1]) & 0x3Fu)), 2};
+                                         | (b1 & 0x3Fu)), 2};
     }
     if ((c & 0xF0) == 0xE0 && i + 2 < s.size()) {
+        unsigned char b1 = static_cast<unsigned char>(s[i + 1]);
+        unsigned char b2 = static_cast<unsigned char>(s[i + 2]);
+        if (!is_utf8_cont(b1) || !is_utf8_cont(b2)) return {0, 1};
         return {static_cast<std::uint32_t>(((c & 0x0Fu) << 12)
-                                         | ((static_cast<unsigned char>(s[i + 1]) & 0x3Fu) << 6)
-                                         | (static_cast<unsigned char>(s[i + 2]) & 0x3Fu)), 3};
+                                         | ((b1 & 0x3Fu) << 6)
+                                         | (b2 & 0x3Fu)), 3};
     }
     if ((c & 0xF8) == 0xF0 && i + 3 < s.size()) {
+        unsigned char b1 = static_cast<unsigned char>(s[i + 1]);
+        unsigned char b2 = static_cast<unsigned char>(s[i + 2]);
+        unsigned char b3 = static_cast<unsigned char>(s[i + 3]);
+        if (!is_utf8_cont(b1) || !is_utf8_cont(b2) || !is_utf8_cont(b3)) return {0, 1};
         return {static_cast<std::uint32_t>(((c & 0x07u) << 18)
-                                         | ((static_cast<unsigned char>(s[i + 1]) & 0x3Fu) << 12)
-                                         | ((static_cast<unsigned char>(s[i + 2]) & 0x3Fu) << 6)
-                                         | (static_cast<unsigned char>(s[i + 3]) & 0x3Fu)), 4};
+                                         | ((b1 & 0x3Fu) << 12)
+                                         | ((b2 & 0x3Fu) << 6)
+                                         | (b3 & 0x3Fu)), 4};
     }
     return {0, 1};
 }
@@ -127,10 +144,26 @@ inline std::size_t cluster_boundary_after(const std::string& text, std::size_t i
     if (base.bytes == 0) return text.size();
     std::size_t cursor = i + base.bytes;
 
-    // Regional indicator pair: absorb exactly one partner if next is
-    // also RI; do not extend further (per UAX #29).
+    // Regional indicator pair: UAX #29 GB12/GB13 — do not break
+    // between RI symbols if there is an ODD number of RIs before
+    // the break point. Equivalently: pair forward only when the
+    // run of preceding RIs is even (`i` is at the start of a fresh
+    // pair). Without the parity check, `cluster_step` called mid-
+    // sequence (e.g. inside `🇺🇸🇯🇵` at offset 4) would greedily
+    // absorb the next RI and skip the boundary that exists between
+    // the two flags. (Codex review on PR #2185, P2.)
     if (is_regional_indicator(base.cp)) {
-        if (cursor < text.size()) {
+        std::size_t preceding_ri_count = 0;
+        std::size_t cursor_back = i;
+        while (cursor_back > 0) {
+            std::size_t lead = skip_utf8_back_to_lead(text, cursor_back - 1);
+            Utf8Decoded prev = utf8_decode_at(text, lead);
+            if (prev.bytes == 0 || !is_regional_indicator(prev.cp)) break;
+            ++preceding_ri_count;
+            cursor_back = lead;
+        }
+        const bool pair_forward = (preceding_ri_count % 2 == 0);
+        if (pair_forward && cursor < text.size()) {
             Utf8Decoded nxt = utf8_decode_at(text, cursor);
             if (nxt.bytes && is_regional_indicator(nxt.cp)) {
                 cursor += nxt.bytes;

--- a/core/canvas/src/font_resolver.cpp
+++ b/core/canvas/src/font_resolver.cpp
@@ -245,6 +245,21 @@ static void cache_put_locked(FontResolver::Impl& impl,
 }
 
 ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
+    // Codex review on PR #2191 (P2): record on every successful
+    // resolve path, not just the family_stack branch.
+    auto record_event = [](const std::string& requested, const ResolvedFont& r) {
+        if (!r.resolved()) return;
+        FontFlightRecorder::instance().record_fallback({
+            /*requested_family*/ requested,
+            /*selected_family */ r.actual_family,
+            /*origin*/   static_cast<std::uint8_t>(r.origin),
+            /*generation*/ r.generation,
+            /*sequence*/ 0,
+        });
+    };
+    const std::string primary_requested = options.family_stack.empty()
+        ? std::string("<default>") : options.family_stack.front();
+
     // Cache lookup. Generation check happens at use site (callers compare
     // `resolved.generation` against `merged_generation_for(scope)`).
     const std::size_t key = options.hash();
@@ -257,6 +272,7 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
             impl_->lru_order.splice(impl_->lru_order.end(),
                                      impl_->lru_order,
                                      it->second.lru_pos);
+            record_event(primary_requested, it->second.resolved);
             return it->second.resolved;
         }
     }
@@ -304,14 +320,7 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
             r.typeface = apply_variation_axes(std::move(r.typeface));
             r.trace = std::move(trace);
             resolved = std::move(r);
-            // pulp #2163 — Slice 2.2 — record one event per resolution.
-            FontFlightRecorder::instance().record_fallback({
-                /*requested_family*/ family,
-                /*selected_family*/ resolved.actual_family,
-                /*origin*/   static_cast<std::uint8_t>(resolved.origin),
-                /*generation*/ resolved.generation,
-                /*sequence*/ 0,
-            });
+            record_event(family, resolved);
             std::lock_guard<std::mutex> lock(impl_->mtx);
             cache_put_locked(*impl_, key, resolved);
             return resolved;
@@ -332,6 +341,7 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
     }
 
     resolved.trace = std::move(trace);
+    record_event(primary_requested, resolved);
     std::lock_guard<std::mutex> lock(impl_->mtx);
     cache_put_locked(*impl_, key, resolved);
     return resolved;
@@ -375,6 +385,14 @@ ResolvedFont FontResolver::resolve_character_fallback(const FontOptions& options
         r.origin = FallbackOrigin::PlatformChar;
         r.trace.push_back({primary.actual_family, FallbackOrigin::PlatformChar,
                            true, r.actual_family, "char fallback"});
+        // Codex review on PR #2191 (P2): record char-fallback resolves too.
+        FontFlightRecorder::instance().record_fallback({
+            primary.actual_family.empty() ? std::string("<char-fallback>")
+                                          : primary.actual_family,
+            r.actual_family,
+            static_cast<std::uint8_t>(r.origin),
+            r.generation, 0,
+        });
     } else {
         r.origin = FallbackOrigin::NotFound;
         r.trace.push_back({primary.actual_family, FallbackOrigin::PlatformChar,

--- a/core/view/js/web-compat.js
+++ b/core/view/js/web-compat.js
@@ -435,10 +435,12 @@ Element.prototype.setAttribute = function(name, value) {
     // container child-order flip + the shaper consumes for bidi
     // base direction. Values: "ltr" | "rtl" | "auto" (CSS spec).
     else if (name === "dir" && typeof setDirection !== "undefined") {
-        var dv = String(value).toLowerCase();
-        if (dv === "rtl" || dv === "ltr" || dv === "auto") {
-            setDirection(this._id, dv);
-        }
+        // Codex review on PR #2181 (P2): the CSS `direction` path
+        // forwards every value to the bridge and lets it coerce
+        // unknowns to `auto_`. Mirror that here so dynamic updates
+        // from `dir="rtl"` to an unsupported value reset to default
+        // rather than leaving the previous bidi/layout state stuck.
+        setDirection(this._id, String(value).toLowerCase());
     }
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -846,10 +846,20 @@ pulp_add_test_suite(pulp-test-text-shaper LIBRARIES pulp::canvas)
 pulp_add_test_suite(pulp-test-font-scope-budget LIBRARIES pulp::canvas)
 
 # pulp #2163 / font v2 Slice 2.8 — TTF/OTF structural sanitizer.
-pulp_add_test_suite(pulp-test-font-security LIBRARIES pulp::canvas)
+# Gated on PULP_HAS_SKIA: the non-Skia stub in font_registry_stubs.cpp
+# accepts any non-empty buffer, so the rejection cases false-negative.
+# (Codex review on PR #2177, P2.)
+if(PULP_HAS_SKIA)
+    pulp_add_test_suite(pulp-test-font-security LIBRARIES pulp::canvas)
+endif()
 
 # pulp #2163 / font v2 Slice 2.3 — variable axis wiring.
-pulp_add_test_suite(pulp-test-font-variable-axes LIBRARIES pulp::canvas)
+# Gated on PULP_HAS_SKIA: FontResolver::resolve_family_list returns
+# NotFound when Skia is absent, so the has_typeface() assertions
+# false-negative. (Codex review on PR #2180, P1.)
+if(PULP_HAS_SKIA)
+    pulp_add_test_suite(pulp-test-font-variable-axes LIBRARIES pulp::canvas)
+endif()
 
 # pulp #2163 / font v2 Slice 3.6 — UAX #29-lite cluster_step.
 pulp_add_test_suite(pulp-test-cluster-step LIBRARIES pulp::canvas)

--- a/test/test_font_aa_hinting.cpp
+++ b/test/test_font_aa_hinting.cpp
@@ -24,43 +24,54 @@ using namespace pulp::canvas;
 
 #ifdef PULP_HAS_SKIA
 
-TEST_CASE("AA mode translates: Default → kAntiAlias", "[font][aa][issue-2163]") {
-    REQUIRE(sk_edging_for(AntiAliasMode::Default) == SkFont::Edging::kAntiAlias);
+// pulp #2163 — review-sweep update: `Default` / `PlatformDefault`
+// no longer hard-map to a specific Skia enum (Codex P2 review on
+// PR #2186). They resolve to `std::nullopt`, signalling "caller
+// preserves the existing per-context heuristic". Explicit modes
+// still resolve to the fixed enum.
+
+TEST_CASE("AA mode: Default returns nullopt (caller decides)", "[font][aa][issue-2163]") {
+    REQUIRE(sk_edging_for(AntiAliasMode::Default) == std::nullopt);
 }
 
 TEST_CASE("AA mode translates: LCD → kSubpixelAntiAlias", "[font][aa][issue-2163]") {
-    REQUIRE(sk_edging_for(AntiAliasMode::LCD) == SkFont::Edging::kSubpixelAntiAlias);
+    REQUIRE(sk_edging_for(AntiAliasMode::LCD)
+            == std::optional<SkFont::Edging>{SkFont::Edging::kSubpixelAntiAlias});
 }
 
 TEST_CASE("AA mode translates: Grayscale → kAntiAlias", "[font][aa][issue-2163]") {
-    REQUIRE(sk_edging_for(AntiAliasMode::Grayscale) == SkFont::Edging::kAntiAlias);
+    REQUIRE(sk_edging_for(AntiAliasMode::Grayscale)
+            == std::optional<SkFont::Edging>{SkFont::Edging::kAntiAlias});
 }
 
 TEST_CASE("AA mode translates: NoAA → kAlias", "[font][aa][issue-2163]") {
-    REQUIRE(sk_edging_for(AntiAliasMode::NoAA) == SkFont::Edging::kAlias);
+    REQUIRE(sk_edging_for(AntiAliasMode::NoAA)
+            == std::optional<SkFont::Edging>{SkFont::Edging::kAlias});
 }
 
 TEST_CASE("Hinting mode translates: None → kNone", "[font][hinting][issue-2163]") {
-    REQUIRE(sk_hinting_for(HintingMode::None) == SkFontHinting::kNone);
+    REQUIRE(sk_hinting_for(HintingMode::None)
+            == std::optional<SkFontHinting>{SkFontHinting::kNone});
 }
 
 TEST_CASE("Hinting mode translates: Slight → kSlight", "[font][hinting][issue-2163]") {
-    REQUIRE(sk_hinting_for(HintingMode::Slight) == SkFontHinting::kSlight);
+    REQUIRE(sk_hinting_for(HintingMode::Slight)
+            == std::optional<SkFontHinting>{SkFontHinting::kSlight});
 }
 
 TEST_CASE("Hinting mode translates: Normal → kNormal", "[font][hinting][issue-2163]") {
-    REQUIRE(sk_hinting_for(HintingMode::Normal) == SkFontHinting::kNormal);
+    REQUIRE(sk_hinting_for(HintingMode::Normal)
+            == std::optional<SkFontHinting>{SkFontHinting::kNormal});
 }
 
 TEST_CASE("Hinting mode translates: Full → kFull", "[font][hinting][issue-2163]") {
-    REQUIRE(sk_hinting_for(HintingMode::Full) == SkFontHinting::kFull);
+    REQUIRE(sk_hinting_for(HintingMode::Full)
+            == std::optional<SkFontHinting>{SkFontHinting::kFull});
 }
 
-TEST_CASE("Hinting mode translates: PlatformDefault → kNormal", "[font][hinting][issue-2163]") {
-    // Documented contract: PlatformDefault resolves to Skia's documented
-    // default (kNormal). When this changes per-platform, update both the
-    // mapping in font_resolver.hpp AND this assertion in the same PR.
-    REQUIRE(sk_hinting_for(HintingMode::PlatformDefault) == SkFontHinting::kNormal);
+TEST_CASE("Hinting mode: PlatformDefault returns nullopt (caller decides)",
+          "[font][hinting][issue-2163]") {
+    REQUIRE(sk_hinting_for(HintingMode::PlatformDefault) == std::nullopt);
 }
 
 TEST_CASE("Resolver propagates aa_mode onto ResolvedFont", "[font][aa][issue-2163]") {
@@ -71,7 +82,7 @@ TEST_CASE("Resolver propagates aa_mode onto ResolvedFont", "[font][aa][issue-216
 
     auto resolved = FontResolver::instance().resolve_family_list(opts);
     REQUIRE(resolved.aa_mode == AntiAliasMode::LCD);
-    REQUIRE(resolved.sk_edging() == SkFont::Edging::kSubpixelAntiAlias);
+    REQUIRE(resolved.sk_edging() == std::optional<SkFont::Edging>{SkFont::Edging::kSubpixelAntiAlias});
 }
 
 TEST_CASE("Resolver propagates hinting_mode onto ResolvedFont", "[font][hinting][issue-2163]") {
@@ -82,7 +93,7 @@ TEST_CASE("Resolver propagates hinting_mode onto ResolvedFont", "[font][hinting]
 
     auto resolved = FontResolver::instance().resolve_family_list(opts);
     REQUIRE(resolved.hinting_mode == HintingMode::Slight);
-    REQUIRE(resolved.sk_hinting() == SkFontHinting::kSlight);
+    REQUIRE(resolved.sk_hinting() == std::optional<SkFontHinting>{SkFontHinting::kSlight});
 }
 
 TEST_CASE("ResolvedFont accessors compose: NoAA + Full", "[font][aa][hinting][issue-2163]") {
@@ -93,22 +104,21 @@ TEST_CASE("ResolvedFont accessors compose: NoAA + Full", "[font][aa][hinting][is
     opts.hinting_mode = HintingMode::Full;
 
     auto resolved = FontResolver::instance().resolve_family_list(opts);
-    REQUIRE(resolved.sk_edging() == SkFont::Edging::kAlias);
-    REQUIRE(resolved.sk_hinting() == SkFontHinting::kFull);
+    REQUIRE(resolved.sk_edging() == std::optional<SkFont::Edging>{SkFont::Edging::kAlias});
+    REQUIRE(resolved.sk_hinting() == std::optional<SkFontHinting>{SkFontHinting::kFull});
 }
 
-TEST_CASE("Default-constructed FontOptions maps to AA on, normal hinting",
+TEST_CASE("Default-constructed FontOptions defers AA + hinting decisions",
           "[font][aa][hinting][issue-2163]") {
     FontOptions opts;
     opts.family_stack.push_back("Inter");
     opts.size = 14.0f;
 
     auto resolved = FontResolver::instance().resolve_family_list(opts);
-    // Defaults defined in font_options.hpp.
     REQUIRE(resolved.aa_mode == AntiAliasMode::Default);
     REQUIRE(resolved.hinting_mode == HintingMode::PlatformDefault);
-    REQUIRE(resolved.sk_edging() == SkFont::Edging::kAntiAlias);
-    REQUIRE(resolved.sk_hinting() == SkFontHinting::kNormal);
+    REQUIRE(resolved.sk_edging() == std::nullopt);
+    REQUIRE(resolved.sk_hinting() == std::nullopt);
 }
 
 #else  // !PULP_HAS_SKIA


### PR DESCRIPTION
Sweeps every P1/P2 review comment across #2177, #2180, #2181, #2185, #2186, #2191. Full breakdown in commit body. All 7 font test binaries green.