### PR TITLE
test: batch phase3 coverage host and view edges

### DIFF
--- a/core/view/include/pulp/view/animation.hpp
+++ b/core/view/include/pulp/view/animation.hpp
@@ -398,7 +398,7 @@ public:
     void set_fill_mode(FillMode f) { fill_ = f; }
     void set_easing(EasingFunction e) { ease_ = e; }
 
-    void start() { elapsed_ = 0; running_ = true; completed_iterations_ = 0; }
+    void start() { elapsed_ = 0; running_ = true; finished_ = false; completed_iterations_ = 0; }
     void stop() { running_ = false; }
     void pause() { running_ = false; }
     void resume() { running_ = true; }
@@ -418,9 +418,16 @@ public:
             iteration_progress = iterations_;
         }
 
-        // Current iteration number and progress within it
+        // Current iteration number and progress within it. When a finite
+        // animation finishes exactly on an iteration boundary, keep the
+        // terminal frame at t=1 for the final iteration instead of wrapping
+        // to t=0 of the next iteration.
         float iter_num = std::floor(iteration_progress);
         float t = iteration_progress - iter_num;
+        if (finished_ && iterations_ > 0.0f && t == 0.0f && iteration_progress > 0.0f) {
+            iter_num -= 1.0f;
+            t = 1.0f;
+        }
         completed_iterations_ = static_cast<int>(iter_num);
 
         // Direction

--- a/core/view/src/asset_manager.cpp
+++ b/core/view/src/asset_manager.cpp
@@ -44,6 +44,9 @@ void AssetManager::touch(CacheEntry& entry) const {
 }
 
 void AssetManager::add_to_cache(const std::string& key, CacheEntry entry) {
+    if (auto existing = cache_.find(key); existing != cache_.end()) {
+        cache_bytes_ -= existing->second.byte_size;
+    }
     cache_bytes_ += entry.byte_size;
     cache_[key] = std::move(entry);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -738,6 +738,8 @@ pulp_add_test_suite(pulp-test-modulation-matrix LIBRARIES pulp::view)
 pulp_add_test_suite(pulp-test-modulation-matrix-widget LIBRARIES pulp::view)
 # Lasso selection overlay
 pulp_add_test_suite(pulp-test-lasso LIBRARIES pulp::view)
+# Split pane layout widget
+pulp_add_test_suite(pulp-test-split-view LIBRARIES pulp::view)
 # PluginDescriptor vendor_url + vendor_email (workstream 01 slice 1.8)
 pulp_add_test_suite(pulp-test-vendor-url LIBRARIES pulp::format)
 # Image cache (workstream 07 slice 7.4)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -736,6 +736,8 @@ pulp_add_test_suite(pulp-test-table-model LIBRARIES pulp::view)
 pulp_add_test_suite(pulp-test-modulation-matrix LIBRARIES pulp::view)
 # ModulationMatrixWidget canvas widget (workstream 07 slice B5)
 pulp_add_test_suite(pulp-test-modulation-matrix-widget LIBRARIES pulp::view)
+# Lasso selection overlay
+pulp_add_test_suite(pulp-test-lasso LIBRARIES pulp::view)
 # PluginDescriptor vendor_url + vendor_email (workstream 01 slice 1.8)
 pulp_add_test_suite(pulp-test-vendor-url LIBRARIES pulp::format)
 # Image cache (workstream 07 slice 7.4)

--- a/test/test_accessibility_tree.cpp
+++ b/test/test_accessibility_tree.cpp
@@ -169,6 +169,41 @@ TEST_CASE("find_by_role_and_label returns nullptr when absent",
             == nullptr);
 }
 
+TEST_CASE("snapshot preserves depth-first order and first matching view pointer",
+          "[a11y][harness][coverage][phase3]") {
+    Probe root;
+
+    auto group = std::make_unique<Probe>();
+    group->set_access_role(View::AccessRole::group);
+    group->set_access_label("Strip");
+    auto* group_ptr = group.get();
+
+    auto first_gain = std::make_unique<Probe>();
+    first_gain->set_access_role(View::AccessRole::slider);
+    first_gain->set_access_label("Gain");
+    auto* first_gain_ptr = first_gain.get();
+    group->add_child(std::move(first_gain));
+
+    auto second_gain = std::make_unique<Probe>();
+    second_gain->set_access_role(View::AccessRole::slider);
+    second_gain->set_access_label("Gain");
+    auto* second_gain_ptr = second_gain.get();
+    root.add_child(std::move(group));
+    root.add_child(std::move(second_gain));
+
+    auto nodes = snapshot_accessibility_tree(root);
+    REQUIRE(nodes.size() == 3);
+    REQUIRE(nodes[0].view == group_ptr);
+    REQUIRE(nodes[0].depth == 0);
+    REQUIRE(nodes[1].view == first_gain_ptr);
+    REQUIRE(nodes[1].depth == 1);
+    REQUIRE(nodes[2].view == second_gain_ptr);
+    REQUIRE(nodes[2].depth == 0);
+
+    REQUIRE(find_by_role_and_label(root, View::AccessRole::slider, "Gain")
+            == first_gain_ptr);
+}
+
 TEST_CASE("snapshot captures nested range metadata", "[a11y][harness]") {
     Probe root;
 

--- a/test/test_animation.cpp
+++ b/test/test_animation.cpp
@@ -165,6 +165,86 @@ TEST_CASE("ValueAnimation advance returns false when not animating", "[view][ani
     REQUIRE_FALSE(a.advance(0.016f)); // no longer animating
 }
 
+// ── KeyframeAnimation tests ──────────────────────────────────────────────────
+
+TEST_CASE("KeyframeAnimation sorts keyframes and interpolates local spans",
+          "[view][animation][keyframe][coverage][phase3]") {
+    KeyframeAnimation anim;
+    anim.set_keyframes({{1.0f, 100.0f}, {0.0f, 0.0f}, {0.25f, 40.0f}});
+    anim.set_duration(1.0f);
+    anim.start();
+
+    REQUIRE_THAT(anim.advance(0.125f), WithinAbs(20.0f, 0.001f));
+    REQUIRE_THAT(anim.advance(0.125f), WithinAbs(40.0f, 0.001f));
+    REQUIRE_THAT(anim.advance(0.375f), WithinAbs(70.0f, 0.001f));
+}
+
+TEST_CASE("KeyframeAnimation honors reverse direction and forwards fill",
+          "[view][animation][keyframe][coverage][phase3]") {
+    KeyframeAnimation anim;
+    anim.set_keyframes({{0.0f, 0.0f}, {1.0f, 10.0f}});
+    anim.set_duration(1.0f);
+    anim.set_direction(KeyframeAnimation::Direction::reverse);
+    anim.set_fill_mode(KeyframeAnimation::FillMode::forwards);
+    anim.start();
+
+    REQUIRE_THAT(anim.advance(0.25f), WithinAbs(7.5f, 0.001f));
+    REQUIRE_THAT(anim.advance(1.0f), WithinAbs(0.0f, 0.001f));
+    REQUIRE(anim.is_finished());
+    REQUIRE_FALSE(anim.is_running());
+}
+
+TEST_CASE("KeyframeAnimation alternate direction flips odd iterations",
+          "[view][animation][keyframe][coverage][phase3]") {
+    KeyframeAnimation anim;
+    anim.set_keyframes({{0.0f, 0.0f}, {1.0f, 10.0f}});
+    anim.set_duration(1.0f);
+    anim.set_iterations(3.0f);
+    anim.set_direction(KeyframeAnimation::Direction::alternate);
+    anim.start();
+
+    REQUIRE_THAT(anim.advance(0.5f), WithinAbs(5.0f, 0.001f));
+    REQUIRE_THAT(anim.advance(1.0f), WithinAbs(5.0f, 0.001f));
+    REQUIRE_THAT(anim.advance(1.0f), WithinAbs(5.0f, 0.001f));
+    REQUIRE_FALSE(anim.is_finished());
+}
+
+TEST_CASE("KeyframeAnimation start resets a previously finished animation",
+          "[view][animation][keyframe][coverage][phase3]") {
+    KeyframeAnimation anim;
+    anim.set_keyframes({{0.0f, 0.0f}, {1.0f, 1.0f}});
+    anim.set_duration(0.1f);
+    anim.start();
+    REQUIRE_THAT(anim.advance(0.2f), WithinAbs(1.0f, 0.001f));
+    REQUIRE(anim.is_finished());
+
+    anim.start();
+    REQUIRE(anim.is_running());
+    REQUIRE_FALSE(anim.is_finished());
+    REQUIRE_THAT(anim.advance(0.05f), WithinAbs(0.5f, 0.001f));
+}
+
+TEST_CASE("KeyframeAnimation pause resume stop and invalid inputs keep value",
+          "[view][animation][keyframe][coverage][phase3]") {
+    KeyframeAnimation anim;
+    anim.set_duration(1.0f);
+    anim.start();
+    REQUIRE_THAT(anim.advance(0.5f), WithinAbs(0.0f, 0.001f));
+
+    anim.set_keyframes({{0.0f, 0.0f}, {1.0f, 100.0f}});
+    anim.pause();
+    REQUIRE_FALSE(anim.is_running());
+    REQUIRE_THAT(anim.advance(0.5f), WithinAbs(0.0f, 0.001f));
+
+    anim.resume();
+    REQUIRE(anim.is_running());
+    REQUIRE_THAT(anim.advance(0.25f), WithinAbs(25.0f, 0.001f));
+
+    anim.stop();
+    REQUIRE_FALSE(anim.is_running());
+    REQUIRE_THAT(anim.advance(0.25f), WithinAbs(25.0f, 0.001f));
+}
+
 // ── easing_by_name tests ────────────────────────────────────────────────────
 
 TEST_CASE("easing_by_name resolves known easings", "[view][animation]") {

--- a/test/test_animator_set.cpp
+++ b/test/test_animator_set.cpp
@@ -62,6 +62,53 @@ TEST_CASE("AnimatorSetBuilder reset", "[view][animation]") {
     REQUIRE_FALSE(runner.finished());
 }
 
+TEST_CASE("AnimatorSetBuilder empty and ignored parallel inputs are safe",
+          "[view][animation][coverage][phase3]") {
+    auto empty = AnimatorSetBuilder().build_runner();
+    REQUIRE(empty.finished());
+    REQUIRE(empty.advance(0.016f));
+    empty.reset();
+    REQUIRE(empty.finished());
+
+    float value = 0.0f;
+    auto ignored = AnimatorSetBuilder()
+        .with(0.0f, 1.0f, 0.1f, [&](float v) { value = v; })
+        .end_parallel()
+        .build_runner();
+    REQUIRE(ignored.finished());
+    REQUIRE(ignored.advance(0.1f));
+    REQUIRE(value == Catch::Approx(0.0f));
+}
+
+TEST_CASE("AnimatorSetBuilder parallel group updates members until all finish",
+          "[view][animation][coverage][phase3]") {
+    float fast = 0.0f;
+    float slow = 0.0f;
+    auto runner = AnimatorSetBuilder()
+        .begin_parallel()
+        .with(0.0f, 1.0f, 0.1f, [&](float v) { fast = v; })
+        .with(10.0f, 20.0f, 0.3f, [&](float v) { slow = v; })
+        .end_parallel()
+        .build_runner();
+
+    REQUIRE_FALSE(runner.advance(0.1f));
+    REQUIRE(fast == Catch::Approx(1.0f));
+    REQUIRE(slow > 10.0f);
+    REQUIRE(slow < 20.0f);
+
+    REQUIRE(runner.advance(0.3f));
+    REQUIRE(fast == Catch::Approx(1.0f));
+    REQUIRE(slow == Catch::Approx(20.0f));
+
+    runner.reset();
+    REQUIRE_FALSE(runner.finished());
+    fast = 0.0f;
+    slow = 0.0f;
+    REQUIRE_FALSE(runner.advance(0.1f));
+    REQUIRE(fast == Catch::Approx(1.0f));
+    REQUIRE(slow > 10.0f);
+}
+
 // ── Vector3D ────────────────────────────────────────────────────────────
 
 TEST_CASE("Vector3D arithmetic", "[view][3d]") {
@@ -79,6 +126,22 @@ TEST_CASE("Vector3D arithmetic", "[view][3d]") {
 
     auto n = a.normalized();
     REQUIRE(n.length() == Catch::Approx(1.0f).margin(0.001f));
+}
+
+TEST_CASE("Vector3D subtraction and zero normalization are stable",
+          "[view][3d][coverage][phase3]") {
+    Vector3D a{3, 2, 1};
+    Vector3D b{1, 5, -2};
+
+    auto diff = a - b;
+    REQUIRE(diff.x == Catch::Approx(2.0f));
+    REQUIRE(diff.y == Catch::Approx(-3.0f));
+    REQUIRE(diff.z == Catch::Approx(3.0f));
+
+    auto zero = Vector3D{}.normalized();
+    REQUIRE(zero.x == Catch::Approx(0.0f));
+    REQUIRE(zero.y == Catch::Approx(0.0f));
+    REQUIRE(zero.z == Catch::Approx(0.0f));
 }
 
 TEST_CASE("Vector3D dot and cross product", "[view][3d]") {
@@ -110,4 +173,59 @@ TEST_CASE("Quaternion multiply identity", "[view][3d]") {
     auto id = Quaternion::identity();
     auto result = q * id;
     REQUIRE(result.w == Catch::Approx(q.w).margin(0.001f));
+}
+
+TEST_CASE("Quaternion rotates vectors and normalizes zero quaternions",
+          "[view][3d][coverage][phase3]") {
+    auto quarter_turn = Quaternion::from_axis_angle({0, 0, 1}, 3.14159265f * 0.5f);
+    auto rotated = quarter_turn.rotate({1, 0, 0});
+    REQUIRE(rotated.x == Catch::Approx(0.0f).margin(0.001f));
+    REQUIRE(rotated.y == Catch::Approx(1.0f).margin(0.001f));
+    REQUIRE(rotated.z == Catch::Approx(0.0f).margin(0.001f));
+
+    auto normalized = Quaternion{0, 0, 0, 0}.normalized();
+    REQUIRE(normalized.w == Catch::Approx(1.0f));
+    REQUIRE(normalized.x == Catch::Approx(0.0f));
+    REQUIRE(normalized.y == Catch::Approx(0.0f));
+    REQUIRE(normalized.z == Catch::Approx(0.0f));
+}
+
+TEST_CASE("Quaternion slerp handles near and opposite hemispheres",
+          "[view][3d][coverage][phase3]") {
+    const auto identity = Quaternion::identity();
+    const auto near = Quaternion::from_axis_angle({0, 1, 0}, 0.001f);
+    auto blended_near = Quaternion::slerp(identity, near, 0.5f);
+    REQUIRE(blended_near.length() == Catch::Approx(1.0f).margin(0.001f));
+
+    const Quaternion opposite{-identity.w, -identity.x, -identity.y, -identity.z};
+    auto blended_opposite = Quaternion::slerp(identity, opposite, 0.5f);
+    REQUIRE(blended_opposite.w == Catch::Approx(1.0f).margin(0.001f));
+    REQUIRE(blended_opposite.length() == Catch::Approx(1.0f).margin(0.001f));
+}
+
+TEST_CASE("Draggable3DOrientation drag lifecycle updates and resets orientation",
+          "[view][3d][coverage][phase3]") {
+    Draggable3DOrientation orientation;
+    const auto initial = orientation.orientation();
+
+    orientation.update_drag(0.5f, 0.0f);
+    REQUIRE(orientation.orientation().w == Catch::Approx(initial.w));
+    REQUIRE(orientation.orientation().x == Catch::Approx(initial.x));
+    REQUIRE(orientation.orientation().y == Catch::Approx(initial.y));
+    REQUIRE(orientation.orientation().z == Catch::Approx(initial.z));
+
+    orientation.begin_drag(0.0f, 0.0f);
+    orientation.update_drag(0.5f, 0.0f);
+    REQUIRE(orientation.orientation().length() == Catch::Approx(1.0f).margin(0.001f));
+    REQUIRE(orientation.orientation().y != Catch::Approx(0.0f));
+
+    orientation.end_drag();
+    orientation.update_drag(-0.5f, 0.0f);
+    REQUIRE(orientation.orientation().y != Catch::Approx(0.0f));
+
+    orientation.reset();
+    REQUIRE(orientation.orientation().w == Catch::Approx(1.0f));
+    REQUIRE(orientation.orientation().x == Catch::Approx(0.0f));
+    REQUIRE(orientation.orientation().y == Catch::Approx(0.0f));
+    REQUIRE(orientation.orientation().z == Catch::Approx(0.0f));
 }

--- a/test/test_app_framework.cpp
+++ b/test/test_app_framework.cpp
@@ -307,6 +307,22 @@ TEST_CASE("KeyMapping save/load binding edge paths", "[view][keys]") {
     std::filesystem::remove_all(root);
 }
 
+TEST_CASE("KeyMapping save_bindings fails when parent is missing",
+          "[view][keys][coverage]") {
+    KeyMapping km;
+    km.add_command({1, "Save", "File",
+                    KeyShortcut::from_string("Cmd+S"), [] {}, {}, false});
+
+    auto root = make_temp_root("pulp-keymapping-missing-parent");
+    auto path = root / "missing" / "bindings.json";
+    REQUIRE_FALSE(std::filesystem::exists(path.parent_path()));
+
+    REQUIRE_FALSE(km.save_bindings(path));
+    REQUIRE_FALSE(std::filesystem::exists(path));
+
+    std::filesystem::remove_all(root);
+}
+
 // ── MenuBar ──────────────────────────────────────────────────────────────
 
 TEST_CASE("MenuBar add menu", "[view][menu]") {

--- a/test/test_app_framework.cpp
+++ b/test/test_app_framework.cpp
@@ -106,6 +106,16 @@ TEST_CASE("KeyShortcut parses named keys and rejects invalid function keys",
     REQUIRE(KeyShortcut::from_string("Down").key == KeyCode::down);
 }
 
+TEST_CASE("KeyShortcut parses modifiers independent of their order",
+          "[view][keys][coverage][phase3]") {
+    auto ks = KeyShortcut::from_string("Shift+Meta+Cmd+A");
+    REQUIRE(ks.key == KeyCode::a);
+    REQUIRE((ks.modifiers & kModShift) != 0);
+    REQUIRE((ks.modifiers & kModMeta) != 0);
+    REQUIRE((ks.modifiers & kModCmd) != 0);
+    REQUIRE(ks.to_string() == "Cmd+Shift+Meta+A");
+}
+
 TEST_CASE("KeyShortcut to_string covers modifiers and named keys",
           "[view][keys]") {
     KeyShortcut ks;
@@ -455,6 +465,35 @@ TEST_CASE("AppSettings saves and loads from platform settings root",
     REQUIRE(window->y == 2);
     REQUIRE(window->width == 300);
     REQUIRE(window->height == 400);
+
+    std::filesystem::remove_all(root);
+}
+
+TEST_CASE("AppSettings load clears stale values from an empty settings file",
+          "[view][settings][coverage][phase3]") {
+    auto root = make_temp_root("pulp-app-settings-empty");
+
+#if defined(_WIN32)
+    ScopedEnvVar settings_root("APPDATA", root.string());
+#elif defined(__APPLE__)
+    ScopedEnvVar settings_root("HOME", root.string());
+#else
+    ScopedEnvVar settings_root("XDG_CONFIG_HOME", root.string());
+#endif
+
+    AppSettings settings("PulpSettingsEmptyCoverage");
+    settings.set_string("stale", "value");
+    REQUIRE(settings.get_string("stale").has_value());
+
+    std::filesystem::create_directories(settings.settings_path().parent_path());
+    {
+        std::ofstream f(settings.settings_path());
+        f << "{}\n";
+    }
+
+    REQUIRE(settings.load());
+    REQUIRE_FALSE(settings.get_string("stale").has_value());
+    REQUIRE_FALSE(settings.load_window_state().has_value());
 
     std::filesystem::remove_all(root);
 }

--- a/test/test_asset_manager.cpp
+++ b/test/test_asset_manager.cpp
@@ -143,6 +143,26 @@ TEST_CASE("AssetManager register and retrieve shader", "[view][assets]") {
     REQUIRE(shader.source.find("uniform") != std::string::npos);
 }
 
+TEST_CASE("AssetManager replacing cached shader keeps cache accounting stable",
+          "[view][assets][coverage][phase3]") {
+    auto& mgr = AssetManager::instance();
+    const auto old_max = mgr.max_cache_size();
+    mgr.clear_cache();
+    mgr.set_max_cache_size(1024 * 1024);
+
+    mgr.register_shader("replaceable_shader", "abc");
+    REQUIRE(mgr.cache_count() == 1);
+    REQUIRE(mgr.cache_usage() == 3);
+
+    mgr.register_shader("replaceable_shader", "abcdef");
+    REQUIRE(mgr.cache_count() == 1);
+    REQUIRE(mgr.cache_usage() == 6);
+    REQUIRE(mgr.shader("replaceable_shader").source == "abcdef");
+
+    mgr.clear_cache();
+    mgr.set_max_cache_size(old_max);
+}
+
 TEST_CASE("AssetManager missing shader returns invalid", "[view][assets]") {
     auto& mgr = AssetManager::instance();
     auto shader = mgr.shader("nonexistent_shader_xyz");

--- a/test/test_auto_ui.cpp
+++ b/test/test_auto_ui.cpp
@@ -66,6 +66,18 @@ TEST_CASE("AutoUi builds from parameter store", "[view][auto_ui]") {
     REQUIRE(grid->child_count() == 3);  // Gain + Mix + Bypass
 }
 
+TEST_CASE("AutoUi builds empty parameter grids", "[view][auto_ui][coverage]") {
+    StateStore store;
+    auto root = AutoUi::build(store);
+    REQUIRE(root != nullptr);
+    REQUIRE(root->child_count() == 2);
+
+    auto* body = root->child_at(1);
+    REQUIRE(body->child_count() == 1);
+    auto* grid = body->child_at(0);
+    REQUIRE(grid->child_count() == 0);
+}
+
 // ── pulp #97 — layout invariants for the centered-wrapping-grid design ──
 //
 // These assertions encode the design contract the visual fix relies on
@@ -259,4 +271,22 @@ TEST_CASE("AutoUi sync updates generated toggles and existing faders",
     store.set_normalized(1, 0.0f);
     AutoUi::sync(*root, store);
     REQUIRE_FALSE(bypass->is_on());
+}
+
+TEST_CASE("AutoUi sync ignores unmatched widget identifiers",
+          "[view][auto_ui][coverage]") {
+    StateStore store;
+    store.add_parameter(make_param(1, "Level", "", {0.0f, 1.0f, 0.0f}));
+
+    auto root = AutoUi::build(store);
+    auto orphan = std::make_unique<Knob>();
+    auto* orphan_ptr = orphan.get();
+    orphan->set_id("Missing");
+    orphan->set_value(0.25f);
+    root->add_child(std::move(orphan));
+
+    store.set_normalized(1, 0.75f);
+    AutoUi::sync(*root, store);
+
+    REQUIRE_THAT(orphan_ptr->value(), WithinAbs(0.25f, 0.001f));
 }

--- a/test/test_background_scanner.cpp
+++ b/test/test_background_scanner.cpp
@@ -96,6 +96,18 @@ TEST_CASE("BackgroundScanner: idle cancel and join are no-ops",
     REQUIRE_FALSE(bs.is_running());
 }
 
+TEST_CASE("CancelToken request and reset toggle the shared flag",
+          "[host][bg-scan][coverage]") {
+    CancelToken token;
+    REQUIRE_FALSE(token.requested());
+
+    token.request();
+    REQUIRE(token.requested());
+
+    token.reset();
+    REQUIRE_FALSE(token.requested());
+}
+
 TEST_CASE("BackgroundScanner: second start while running returns false",
           "[host][bg-scan]") {
     BackgroundScanner bs;

--- a/test/test_code_editor.cpp
+++ b/test/test_code_editor.cpp
@@ -172,6 +172,18 @@ TEST_CASE("CodeEditor paint emits gutter line numbers when enabled",
     REQUIRE(has_text(rc, "beta"));
 }
 
+TEST_CASE("SystemTrayIcon lifecycle methods are safe without native handles",
+          "[gui][code-editor][coverage]") {
+    SystemTrayIcon tray;
+    tray.set_icon("pulp-status");
+    tray.set_tooltip("Pulp");
+    tray.show();
+    tray.hide();
+    tray.on_click = [] {};
+    tray.on_right_click = [] {};
+    SUCCEED("SystemTrayIcon public lifecycle completed");
+}
+
 TEST_CASE("FileBasedDocument title from path", "[gui][code-editor]") {
     TestDoc doc;
     doc.load("/tmp/my_plugin.txt");

--- a/test/test_drag_drop.cpp
+++ b/test/test_drag_drop.cpp
@@ -22,6 +22,19 @@ TEST_CASE("DropData text", "[view][dnd]") {
     REQUIRE(data.text == "Hello from drag");
 }
 
+TEST_CASE("DropData custom payloads preserve type and bytes", "[view][dnd]") {
+    DropData data;
+    data.type = DropData::Type::custom;
+    data.custom_type = "application/x-pulp-preset";
+    data.custom_data = {0x50, 0x55, 0x4c, 0x50};
+
+    REQUIRE(data.type == DropData::Type::custom);
+    REQUIRE(data.custom_type == "application/x-pulp-preset");
+    REQUIRE(data.custom_data.size() == 4);
+    REQUIRE(data.custom_data.front() == 0x50);
+    REQUIRE(data.custom_data.back() == 0x50);
+}
+
 TEST_CASE("DropTarget default rejects", "[view][dnd]") {
     // Default DropTarget rejects everything
     class TestTarget : public DropTarget {};
@@ -31,6 +44,8 @@ TEST_CASE("DropTarget default rejects", "[view][dnd]") {
     data.type = DropData::Type::files;
 
     REQUIRE_FALSE(target.on_drag_enter(data, {0, 0}));
+    target.on_drag_move({10, 20});
+    target.on_drag_exit();
     REQUIRE_FALSE(target.on_drop(data, {0, 0}));
 }
 

--- a/test/test_file_browser.cpp
+++ b/test/test_file_browser.cpp
@@ -150,6 +150,35 @@ TEST_CASE("FileBrowser paint clips rows and keeps directories through filters",
     REQUIRE_FALSE(contains_text(texts, "gamma.wav"));
 }
 
+TEST_CASE("FileBrowser navigate refreshes entries for the new directory",
+          "[view][file-browser][coverage]") {
+    TempDir tmp("navigate");
+    std::filesystem::create_directory(tmp.path / "samples");
+    write_file(tmp.path / "root.wav");
+    write_file(tmp.path / "samples" / "nested.wav");
+
+    FileBrowser browser;
+    browser.set_bounds({0, 0, 320, 120});
+    browser.set_filters({"*.wav"});
+    browser.set_root(tmp.path);
+
+    RecordingCanvas root_canvas;
+    browser.paint(root_canvas);
+    auto root_texts = fill_texts(root_canvas);
+    REQUIRE(contains_text(root_texts, "samples"));
+    REQUIRE(contains_text(root_texts, "root.wav"));
+    REQUIRE_FALSE(contains_text(root_texts, "nested.wav"));
+
+    browser.navigate(tmp.path / "samples");
+    REQUIRE(browser.current_directory() == tmp.path / "samples");
+
+    RecordingCanvas nested_canvas;
+    browser.paint(nested_canvas);
+    auto nested_texts = fill_texts(nested_canvas);
+    REQUIRE(contains_text(nested_texts, "nested.wav"));
+    REQUIRE_FALSE(contains_text(nested_texts, "root.wav"));
+}
+
 TEST_CASE("FileTree skips hidden nodes and paints one expanded directory level",
           "[view][file-tree][coverage][issue-493][issue-641]") {
     TempDir tmp("tree");
@@ -187,6 +216,28 @@ TEST_CASE("FileTree skips hidden nodes and paints one expanded directory level",
     REQUIRE(x_for_exact_text(canvas, "root.txt") == 16.0f);
     REQUIRE(x_for_exact_text(canvas, "deeper") == 32.0f);
     REQUIRE(x_for_exact_text(canvas, "nested.txt") == 32.0f);
+}
+
+TEST_CASE("FileTree missing roots clear previously painted nodes",
+          "[view][file-tree][coverage]") {
+    TempDir tmp("tree-missing-root");
+    write_file(tmp.path / "visible.txt");
+
+    FileTree tree;
+    tree.set_bounds({0, 0, 240, 120});
+    tree.set_root(tmp.path);
+
+    RecordingCanvas before;
+    tree.paint(before);
+    REQUIRE(contains_text(fill_texts(before), "visible.txt"));
+
+    const auto missing = tmp.path / "missing";
+    tree.set_root(missing);
+    REQUIRE(tree.root() == missing);
+
+    RecordingCanvas after;
+    tree.paint(after);
+    REQUIRE(after.count(DrawCommand::Type::fill_text) == 0);
 }
 
 TEST_CASE("MultiDocumentPanel remove_document preserves active document callbacks",

--- a/test/test_lasso.cpp
+++ b/test/test_lasso.cpp
@@ -1,0 +1,82 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/view/lasso.hpp>
+
+#include <vector>
+
+using namespace pulp::view;
+using pulp::canvas::DrawCommand;
+using pulp::canvas::RecordingCanvas;
+
+TEST_CASE("SelectionRect contains and intersects use half-open bounds",
+          "[view][lasso]") {
+    SelectionRect rect{10.0f, 20.0f, 30.0f, 40.0f};
+
+    REQUIRE(rect.contains(10.0f, 20.0f));
+    REQUIRE(rect.contains(39.9f, 59.9f));
+    REQUIRE_FALSE(rect.contains(40.0f, 60.0f));
+    REQUIRE_FALSE(rect.contains(9.9f, 20.0f));
+
+    REQUIRE(rect.intersects(0.0f, 0.0f, 11.0f, 21.0f));
+    REQUIRE(rect.intersects(39.0f, 59.0f, 10.0f, 10.0f));
+    REQUIRE_FALSE(rect.intersects(40.0f, 20.0f, 10.0f, 10.0f));
+    REQUIRE_FALSE(rect.intersects(0.0f, 0.0f, 10.0f, 10.0f));
+}
+
+TEST_CASE("LassoComponent normalizes reverse drags and fires callbacks",
+          "[view][lasso]") {
+    LassoComponent lasso;
+    std::vector<SelectionRect> changed;
+    std::vector<SelectionRect> completed;
+    lasso.on_selection_changed = [&](const SelectionRect& rect) {
+        changed.push_back(rect);
+    };
+    lasso.on_selection_complete = [&](const SelectionRect& rect) {
+        completed.push_back(rect);
+    };
+
+    lasso.begin_selection(50.0f, 60.0f);
+    REQUIRE(lasso.is_active());
+
+    lasso.update_selection(20.0f, 10.0f);
+    REQUIRE(changed.size() == 1);
+    REQUIRE(changed[0].x == 20.0f);
+    REQUIRE(changed[0].y == 10.0f);
+    REQUIRE(changed[0].width == 30.0f);
+    REQUIRE(changed[0].height == 50.0f);
+
+    lasso.end_selection();
+    REQUIRE_FALSE(lasso.is_active());
+    REQUIRE(completed.size() == 1);
+    REQUIRE(completed[0].x == 20.0f);
+    REQUIRE(completed[0].height == 50.0f);
+
+    lasso.update_selection(100.0f, 100.0f);
+    lasso.end_selection();
+    REQUIRE(changed.size() == 1);
+    REQUIRE(completed.size() == 1);
+}
+
+TEST_CASE("LassoComponent mouse helpers drive paint lifecycle",
+          "[view][lasso]") {
+    LassoComponent lasso;
+
+    RecordingCanvas inactive;
+    lasso.paint(inactive);
+    REQUIRE(inactive.commands().empty());
+
+    lasso.on_mouse_down({5.0f, 6.0f});
+    lasso.on_mouse_drag({25.0f, 16.0f});
+
+    RecordingCanvas active;
+    lasso.paint(active);
+    REQUIRE(active.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(active.count(DrawCommand::Type::stroke_rect) == 1);
+
+    lasso.on_mouse_up({25.0f, 16.0f});
+    REQUIRE_FALSE(lasso.is_active());
+
+    RecordingCanvas after;
+    lasso.paint(after);
+    REQUIRE(after.commands().empty());
+}

--- a/test/test_midi_buffer_sysex.cpp
+++ b/test/test_midi_buffer_sysex.cpp
@@ -137,3 +137,31 @@ TEST_CASE("MidiBuffer copies sysex sidecar independently",
     REQUIRE(copy.sysex()[0].data == std::vector<uint8_t>{0xF0, 0x7D, 0x04, 0xF7});
     REQUIRE(copy.sysex()[0].sample_offset == 64);
 }
+
+TEST_CASE("MidiBuffer moves sysex sidecar with short messages",
+          "[midi][buffer][sysex][coverage][phase3]") {
+    MidiBuffer original;
+    auto note = MidiEvent::note_on(1, 72, 110);
+    note.sample_offset = 24;
+    original.add(note);
+    original.add_sysex({0xF0, 0x7D, 0x55, 0xF7}, 96, 1.25);
+
+    MidiBuffer moved(std::move(original));
+    REQUIRE(moved.size() == 1);
+    REQUIRE(moved[0].sample_offset == 24);
+    REQUIRE(moved.sysex_size() == 1);
+    REQUIRE(moved.sysex()[0].data == std::vector<uint8_t>{0xF0, 0x7D, 0x55, 0xF7});
+    REQUIRE(moved.sysex()[0].sample_offset == 96);
+    REQUIRE(moved.sysex()[0].timestamp == 1.25);
+
+    MidiBuffer assigned;
+    assigned.add_sysex({0xF0, 0x00, 0xF7}, 4, 0.125);
+    assigned = std::move(moved);
+
+    REQUIRE(assigned.size() == 1);
+    REQUIRE(assigned[0].sample_offset == 24);
+    REQUIRE(assigned.sysex_size() == 1);
+    REQUIRE(assigned.sysex()[0].data == std::vector<uint8_t>{0xF0, 0x7D, 0x55, 0xF7});
+    REQUIRE(assigned.sysex()[0].sample_offset == 96);
+    REQUIRE(assigned.sysex()[0].timestamp == 1.25);
+}

--- a/test/test_modulation_matrix.cpp
+++ b/test/test_modulation_matrix.cpp
@@ -41,6 +41,22 @@ TEST_CASE("remove + remove_by_destination", "[view][mod-matrix]") {
     REQUIRE(m.routes()[0].destination == 200);
 }
 
+TEST_CASE("remove out of range and clear keep matrix reusable",
+          "[view][mod-matrix]") {
+    ModulationMatrix m;
+    m.add({1, 100, 0.5f, false, ModCurve::Linear});
+    m.remove(99);
+    REQUIRE(m.size() == 1);
+    REQUIRE(m.routes()[0].source == 1);
+
+    m.clear();
+    REQUIRE(m.empty());
+
+    m.add({2, 200, -0.25f, true, ModCurve::SCurve});
+    REQUIRE(m.size() == 1);
+    REQUIRE(m.find(2, 200).has_value());
+}
+
 TEST_CASE("serialize + deserialize round-trip", "[view][mod-matrix]") {
     ModulationMatrix a;
     a.add({1, 100, 0.5f, false, ModCurve::Linear});

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -153,6 +153,26 @@ TEST_CASE("motion_policy_to_string / from_string round-trip",
     REQUIRE(motion_policy_from_string("bogus") == MotionPolicy::Full);
 }
 
+TEST_CASE("apply_motion_policy_to_duration follows override and scale",
+          "[motion-preferences][coverage][phase3]") {
+    using pulp::view::apply_motion_policy_to_duration;
+
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+
+    prefs.set_override(MotionPolicy::Full);
+    prefs.set_duration_scale(0.25);
+    REQUIRE(apply_motion_policy_to_duration(2.0f) == Approx(2.0f));
+
+    prefs.set_override(MotionPolicy::Reduced);
+    REQUIRE(apply_motion_policy_to_duration(2.0f) == Approx(0.5f));
+    REQUIRE(apply_motion_policy_to_duration(-2.0f) == Approx(-0.5f));
+
+    prefs.set_override(MotionPolicy::Off);
+    REQUIRE(apply_motion_policy_to_duration(2.0f) == Approx(0.0f));
+    REQUIRE(pulp::view::motion_policy_is_off());
+}
+
 // ── Tween honors MotionPolicy ────────────────────────────────────────
 
 TEST_CASE("Tween under MotionPolicy::Off is finished from construction",

--- a/test/test_platform.cpp
+++ b/test/test_platform.cpp
@@ -116,6 +116,26 @@ TEST_CASE("ProgressParser ignores non-progress lines and tolerates empty callbac
     SUCCEED("empty callbacks are inert");
 }
 
+TEST_CASE("ProgressParser preserves payload colons and empty event types",
+          "[platform][progress][coverage][phase3]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) {
+        events.push_back(e);
+    });
+
+    parser.feed_line("PROGRESS:URL:https://example.test/a:b:c");
+    parser.feed_line("PROGRESS::payload-with-empty-type");
+    parser.feed_line("PROGRESS:");
+
+    REQUIRE(events.size() == 3);
+    REQUIRE(events[0].type == "URL");
+    REQUIRE(events[0].payload == "https://example.test/a:b:c");
+    REQUIRE(events[1].type.empty());
+    REQUIRE(events[1].payload == "payload-with-empty-type");
+    REQUIRE(events[2].type.empty());
+    REQUIRE(events[2].payload.empty());
+}
+
 #if !defined(__APPLE__)
 TEST_CASE("PopupMenu fallback returns no selection on non-Apple platforms",
           "[platform][popup-menu][issue-640]") {

--- a/test/test_plugin_info_metadata.cpp
+++ b/test/test_plugin_info_metadata.cpp
@@ -146,6 +146,43 @@ TEST_CASE("PluginFormat enum covers the 5 shipping formats",
     }
 }
 
+TEST_CASE("PluginScanner default paths match platform format support",
+          "[host][plugin-info][format][coverage][phase3]") {
+#if defined(__APPLE__)
+    auto vst3 = PluginScanner::default_paths(PluginFormat::VST3);
+    auto au = PluginScanner::default_paths(PluginFormat::AudioUnit);
+    auto auv3 = PluginScanner::default_paths(PluginFormat::AudioUnitV3);
+    auto clap = PluginScanner::default_paths(PluginFormat::CLAP);
+    auto lv2 = PluginScanner::default_paths(PluginFormat::LV2);
+
+    REQUIRE(vst3.size() == 2);
+    REQUIRE(vst3[0].find("/Library/Audio/Plug-Ins/VST3") != std::string::npos);
+    REQUIRE(au.size() == 2);
+    REQUIRE(auv3 == au);
+    REQUIRE(clap.size() == 2);
+    REQUIRE(lv2.empty());
+#elif defined(_WIN32)
+    auto vst3 = PluginScanner::default_paths(PluginFormat::VST3);
+    auto au = PluginScanner::default_paths(PluginFormat::AudioUnit);
+
+    REQUIRE(vst3.size() == 2);
+    REQUIRE(vst3[0].find("VST3") != std::string::npos);
+    REQUIRE(au.size() == 2);
+#elif defined(__linux__)
+    auto vst3 = PluginScanner::default_paths(PluginFormat::VST3);
+    auto clap = PluginScanner::default_paths(PluginFormat::CLAP);
+    auto lv2 = PluginScanner::default_paths(PluginFormat::LV2);
+    auto au = PluginScanner::default_paths(PluginFormat::AudioUnit);
+
+    REQUIRE(vst3.size() == 3);
+    REQUIRE(clap.size() == 2);
+    REQUIRE(lv2.size() == 3);
+    REQUIRE(au.empty());
+#else
+    REQUIRE(PluginScanner::default_paths(PluginFormat::VST3).empty());
+#endif
+}
+
 TEST_CASE("PluginScanner identifies bundle suffixes for each host format",
           "[host][plugin-info][format]") {
     REQUIRE(PluginScanner::is_plugin_bundle("/Library/Audio/Plug-Ins/VST3/Test.vst3",

--- a/test/test_resizable_shell.cpp
+++ b/test/test_resizable_shell.cpp
@@ -25,6 +25,17 @@ TEST_CASE("max clamp", "[ui][resizable-shell]") {
     REQUIRE(got.height == 600);
 }
 
+TEST_CASE("negotiate reports clamped size without mutating current",
+          "[ui][resizable-shell]") {
+    ResizableShell s({.min_size = {320, 240}, .initial_size = {400, 300}});
+
+    auto got = s.negotiate({10, 10});
+    REQUIRE(got.width == 320);
+    REQUIRE(got.height == 240);
+    REQUIRE(s.current().width == 400);
+    REQUIRE(s.current().height == 300);
+}
+
 TEST_CASE("aspect lock shrinks the overgrown dimension",
           "[ui][resizable-shell]") {
     // 16:9 aspect — target ratio ≈ 1.7778
@@ -64,6 +75,9 @@ TEST_CASE("serialize + deserialize round-trip", "[ui][resizable-shell]") {
     ResizableShell s({.initial_size = {1024, 768}});
     s.apply({1000, 700});
     auto blob = s.serialize();
+
+    REQUIRE(blob == std::vector<uint8_t>{0xE8, 0x03, 0x00, 0x00,
+                                         0xBC, 0x02, 0x00, 0x00});
 
     ResizableShell other({.initial_size = {640, 480}});
     REQUIRE(other.deserialize(blob));

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <pulp/runtime/dynamic_library.hpp>
 #include <pulp/runtime/high_resolution_timer.hpp>
+#include <pulp/runtime/range.hpp>
 #include <pulp/runtime/runtime.hpp>
 #include <pulp/runtime/temporary_file.hpp>
 #include <array>
@@ -209,6 +210,45 @@ TEST_CASE("PULP_ON_SCOPE_EXIT runs at block exit",
         REQUIRE(calls == 0);
     }
     REQUIRE(calls == 1);
+}
+
+TEST_CASE("Range reports containment intersections and empty spans",
+          "[runtime][range][codecov]") {
+    const IntRange range{10, 20};
+
+    REQUIRE(range.length() == 10);
+    REQUIRE_FALSE(range.empty());
+    REQUIRE(range.contains(10));
+    REQUIRE(range.contains(19));
+    REQUIRE_FALSE(range.contains(20));
+    REQUIRE(range.contains(IntRange{12, 18}));
+    REQUIRE_FALSE(range.contains(IntRange{9, 18}));
+
+    REQUIRE(range.intersects(IntRange{0, 11}));
+    REQUIRE(range.intersects(IntRange{19, 30}));
+    REQUIRE_FALSE(range.intersects(IntRange{20, 30}));
+
+    REQUIRE(range.intersection(IntRange{15, 25}) == IntRange{15, 20});
+    REQUIRE(range.intersection(IntRange{20, 25}).empty());
+    REQUIRE(IntRange{5, 5}.empty());
+    REQUIRE(IntRange{7, 3}.empty());
+}
+
+TEST_CASE("Range union constrain and expansion handle edge inputs",
+          "[runtime][range][codecov]") {
+    REQUIRE(IntRange{5, 5}.enclosing_union(IntRange{2, 4}) == IntRange{2, 4});
+    REQUIRE(IntRange{2, 4}.enclosing_union(IntRange{8, 10}) == IntRange{2, 10});
+
+    const IntRange range{3, 7};
+    REQUIRE(range.constrain(1) == 3);
+    REQUIRE(range.constrain(5) == 5);
+    REQUIRE(range.constrain(99) == 6);
+    REQUIRE(IntRange{4, 4}.constrain(99) == 4);
+
+    REQUIRE(IntRange{4, 4}.expanded(9) == IntRange{9, 10});
+    REQUIRE(range.expanded(1) == IntRange{1, 7});
+    REQUIRE(range.expanded(9) == IntRange{3, 10});
+    REQUIRE(IntRange::from_start_length(8, 3) == IntRange{8, 11});
 }
 
 TEST_CASE("Logging does not crash", "[runtime][log]") {

--- a/test/test_splash_screen.cpp
+++ b/test/test_splash_screen.cpp
@@ -174,3 +174,23 @@ TEST_CASE("SplashScreen can be shown again after completion",
     REQUIRE_FALSE(splash.advance(0.01f));
     REQUIRE(dismissed == 2);
 }
+
+TEST_CASE("SplashScreen zero-duration phases finish deterministically",
+          "[view][splash][coverage][phase3]") {
+    SplashScreen splash;
+    splash.set_fade_in(0.0f);
+    splash.set_duration(0.0f);
+    splash.set_fade_out(0.0f);
+
+    int dismissed = 0;
+    splash.on_dismissed = [&] { ++dismissed; };
+
+    splash.show();
+    REQUIRE(splash.is_showing());
+
+    REQUIRE(splash.advance(0.0f));
+    REQUIRE(splash.advance(0.0f));
+    REQUIRE_FALSE(splash.advance(0.0f));
+    REQUIRE_FALSE(splash.is_showing());
+    REQUIRE(dismissed == 1);
+}

--- a/test/test_split_view.cpp
+++ b/test/test_split_view.cpp
@@ -1,0 +1,90 @@
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/canvas/canvas.hpp>
+#include <pulp/view/split_view.hpp>
+
+#include <vector>
+
+using namespace pulp::view;
+using pulp::canvas::DrawCommand;
+using pulp::canvas::RecordingCanvas;
+
+TEST_CASE("SplitView clamps explicit split fractions", "[view][split]") {
+    SplitView split;
+    REQUIRE(split.split_fraction() == 0.5f);
+
+    split.set_split_fraction(-1.0f);
+    REQUIRE(split.split_fraction() == 0.0f);
+
+    split.set_split_fraction(2.0f);
+    REQUIRE(split.split_fraction() == 1.0f);
+}
+
+TEST_CASE("SplitView lays out horizontal and vertical children",
+          "[view][split]") {
+    SplitView split;
+    auto first = std::make_unique<View>();
+    auto second = std::make_unique<View>();
+    auto* first_ptr = first.get();
+    auto* second_ptr = second.get();
+
+    split.set_first(std::move(first));
+    split.set_second(std::move(second));
+    split.set_bounds({0.0f, 0.0f, 200.0f, 100.0f});
+    split.set_divider_width(4.0f);
+    split.set_split_fraction(0.5f);
+    split.layout_children();
+
+    REQUIRE(first_ptr->bounds().width == 98.0f);
+    REQUIRE(second_ptr->bounds().x == 102.0f);
+    REQUIRE(second_ptr->bounds().width == 98.0f);
+
+    split.set_orientation(SplitView::Orientation::vertical);
+    split.layout_children();
+    REQUIRE(first_ptr->bounds().height == 48.0f);
+    REQUIRE(second_ptr->bounds().y == 52.0f);
+    REQUIRE(second_ptr->bounds().height == 48.0f);
+}
+
+TEST_CASE("SplitView drag honors minimum pane sizes and fires callbacks",
+          "[view][split]") {
+    SplitView split;
+    split.set_bounds({0.0f, 0.0f, 200.0f, 100.0f});
+    split.set_divider_width(4.0f);
+    split.set_min_first_size(40.0f);
+    split.set_min_second_size(60.0f);
+
+    std::vector<float> callbacks;
+    split.on_split_changed = [&](float fraction) { callbacks.push_back(fraction); };
+
+    split.on_mouse_down({100.0f, 50.0f});
+    split.on_mouse_drag({10.0f, 50.0f});
+    REQUIRE(split.split_fraction() == 0.2f);
+    REQUIRE(callbacks.back() == 0.2f);
+
+    split.on_mouse_drag({190.0f, 50.0f});
+    REQUIRE(split.split_fraction() == 0.7f);
+    REQUIRE(callbacks.back() == 0.7f);
+
+    split.on_mouse_up({190.0f, 50.0f});
+    const auto callback_count = callbacks.size();
+    split.on_mouse_drag({100.0f, 50.0f});
+    REQUIRE(callbacks.size() == callback_count);
+}
+
+TEST_CASE("SplitView paint draws divider and orientation-specific grips",
+          "[view][split]") {
+    SplitView split;
+    split.set_bounds({0.0f, 0.0f, 200.0f, 100.0f});
+    split.set_divider_width(4.0f);
+
+    RecordingCanvas horizontal;
+    split.paint(horizontal);
+    REQUIRE(horizontal.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(horizontal.count(DrawCommand::Type::fill_circle) == 3);
+
+    split.set_orientation(SplitView::Orientation::vertical);
+    RecordingCanvas vertical;
+    split.paint(vertical);
+    REQUIRE(vertical.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(vertical.count(DrawCommand::Type::fill_circle) == 3);
+}

--- a/test/test_table_list_box.cpp
+++ b/test/test_table_list_box.cpp
@@ -174,6 +174,24 @@ TEST_CASE("SimpleTableModel handles negative sort columns and sparse rows",
     REQUIRE(model.cell_text(1, 1) == "two");
 }
 
+TEST_CASE("SimpleTableModel set_data replaces rows and sorts descending",
+          "[gui][table][coverage]") {
+    SimpleTableModel model;
+    model.add_row({"stale"});
+    model.set_data({{"A", "2"}, {"C", "1"}, {"B", "3"}});
+
+    REQUIRE(model.row_count() == 3);
+    REQUIRE(model.cell_text(0, 0) == "A");
+    REQUIRE(model.sort(0, false));
+    REQUIRE(model.cell_text(0, 0) == "C");
+    REQUIRE(model.cell_text(1, 0) == "B");
+    REQUIRE(model.cell_text(2, 0) == "A");
+
+    REQUIRE(model.sort(1, true));
+    REQUIRE(model.cell_text(0, 1) == "1");
+    REQUIRE(model.cell_text(2, 1) == "3");
+}
+
 TEST_CASE("TableListBox clear columns and model-less clicks are stable",
           "[gui][table][coverage][issue-653]") {
     TableListBox table;

--- a/test/test_theme.cpp
+++ b/test/test_theme.cpp
@@ -66,15 +66,32 @@ TEST_CASE("Theme apply_overrides", "[view][theme]") {
     Theme overrides;
     overrides.colors["bg.primary"] = color_from_hex(0xFF0000);
     overrides.dimensions["spacing.md"] = 99.0f;
+    overrides.strings["font.family"] = "Override Sans";
 
     base.apply_overrides(overrides);
 
     REQUIRE(base.color("bg.primary")->r8() == 0xFF);
     REQUIRE(base.color("bg.primary")->g8() == 0x00);
     REQUIRE_THAT(base.dimension("spacing.md").value(), WithinAbs(99.0, 0.001));
+    REQUIRE(base.string_token("font.family").value() == "Override Sans");
 
     // Non-overridden tokens should still be there
     REQUIRE(base.color("text.primary").has_value());
+}
+
+TEST_CASE("Theme apply_overrides with empty theme preserves existing tokens",
+          "[view][theme][coverage][phase3]") {
+    auto base = Theme::dark();
+    const auto bg = base.color("bg.primary");
+    const auto spacing = base.dimension("spacing.md");
+    const auto font = base.string_token("font.family");
+
+    base.apply_overrides(Theme{});
+
+    REQUIRE(base.color("bg.primary") == bg);
+    REQUIRE(base.dimension("spacing.md") == spacing);
+    REQUIRE(base.string_token("font.family") == font);
+    REQUIRE(base.is_complete());
 }
 
 TEST_CASE("Theme JSON round-trip", "[view][theme]") {

--- a/test/test_undo_manager.cpp
+++ b/test/test_undo_manager.cpp
@@ -215,6 +215,37 @@ TEST_CASE("UndoManager add_without_executing", "[state][undo]") {
     REQUIRE(v == 0);
 }
 
+TEST_CASE("UndoManager add_without_executing participates in transactions",
+          "[state][undo][coverage][phase3]") {
+    UndoManager um;
+    int x = 10;
+    int y = 20;
+
+    um.begin_transaction("Already moved");
+    um.add_without_executing(UndoAction::create("Set X",
+        [&] { x = 0; },
+        [&] { x = 10; }));
+    um.add_without_executing(UndoAction::create("Set Y",
+        [&] { y = 0; },
+        [&] { y = 20; }));
+    um.end_transaction();
+
+    REQUIRE(x == 10);
+    REQUIRE(y == 20);
+    REQUIRE(um.undo_count() == 1);
+    REQUIRE(um.undo_name() == "Already moved");
+
+    REQUIRE(um.undo());
+    REQUIRE(x == 0);
+    REQUIRE(y == 0);
+    REQUIRE(um.redo_count() == 1);
+    REQUIRE(um.redo_name() == "Already moved");
+
+    REQUIRE(um.redo());
+    REQUIRE(x == 10);
+    REQUIRE(y == 20);
+}
+
 TEST_CASE("UndoManager multiple undo/redo sequence", "[state][undo]") {
     UndoManager um;
     int v = 0;


### PR DESCRIPTION
## Summary
- Add a larger Phase 3 code coverage batch across runtime, platform, MIDI, state, host, and view utilities.
- Cover deterministic edge paths for animation, theme overrides, asset cache replacement accounting, scanner defaults, file browser/tree navigation, lasso/split view, auto UI, table/code editor utilities, and more.
- Includes two small fixes found by tests: keyframe animation finite-boundary/start reset behavior and asset cache byte accounting on replacement.

## Local validation
- `pulp-test-runtime "[runtime][range]"`
- `pulp-test-platform "[platform][progress]"`
- `pulp-test-midi-buffer-sysex "MidiBuffer moves sysex sidecar with short messages"`
- `pulp-test-undo-manager "UndoManager add_without_executing participates in transactions"`
- `pulp-test-theme "[view][theme]"`
- `pulp-test-animation "[view][animation]"`
- `pulp-test-motion-preferences "[motion-preferences]"`
- `pulp-test-animator-set "[view][animation],[view][3d]"`
- `pulp-test-accessibility-tree "[a11y][harness]"`
- `pulp-test-app-framework "[view][keys]"`
- `pulp-test-asset-manager "[view][assets]"`
- `pulp-test-plugin-info-metadata "[host][plugin-info]"`
- `pulp-test-splash-screen "[view][splash]"`
- `pulp-test-background-scanner "[host][bg-scan]"`
- `pulp-test-dnd "[view][dnd]"`
- `pulp-test-file-browser "[view][file-browser],[view][file-tree]"`
- `pulp-test-modulation-matrix "[view][mod-matrix]"`
- `pulp-test-lasso "[view][lasso]"`
- `pulp-test-split-view "[view][split]"`
- `pulp-test-resizable-shell "[ui][resizable-shell]"`
- `pulp-test-auto-ui "[view][auto_ui]"`
- `pulp-test-table-list-box "[gui][table]"`
- `pulp-test-code-editor "[gui][code-editor]"`
- `git diff --check`

Note: local pre-push diff coverage was skipped because its clean coverage configure hit the known FetchContent mbedtls tag checkout failure locally; GitHub CI is the validation source for this PR.