### PR TITLE
test: batch phase3 coverage runtime state edges

### DIFF
--- a/core/canvas/src/font_resolver.cpp
+++ b/core/canvas/src/font_resolver.cpp
@@ -409,12 +409,44 @@ ResolvedFont FontResolver::resolve_character_fallback(const FontOptions& options
 // non-rendering paths.
 
 ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
+    const std::size_t key = options.hash();
+    const auto generation = merged_generation_for(options.scope);
+    {
+        std::lock_guard<std::mutex> lock(impl_->mtx);
+        auto it = impl_->cache.find(key);
+        if (it != impl_->cache.end()
+            && it->second.resolved.generation == generation) {
+            impl_->lru_order.splice(impl_->lru_order.end(),
+                                    impl_->lru_order,
+                                    it->second.lru_pos);
+            return it->second.resolved;
+        }
+    }
+
     ResolvedFont r;
     r.scope = options.scope;
-    r.generation = merged_generation_for(options.scope);
+    r.generation = generation;
     r.aa_mode = options.aa_mode;
     r.hinting_mode = options.hinting_mode;
     r.origin = FallbackOrigin::NotFound;
+
+    std::lock_guard<std::mutex> lock(impl_->mtx);
+    auto it = impl_->cache.find(key);
+    if (it != impl_->cache.end()) {
+        impl_->lru_order.splice(impl_->lru_order.end(), impl_->lru_order,
+                                it->second.lru_pos);
+        it->second.resolved = r;
+        return r;
+    }
+
+    impl_->lru_order.push_back(key);
+    auto pos = std::prev(impl_->lru_order.end());
+    impl_->cache.emplace(key, FontResolver::Impl::Entry{r, pos});
+    if (impl_->capacity > 0 && impl_->cache.size() > impl_->capacity) {
+        std::size_t oldest = impl_->lru_order.front();
+        impl_->lru_order.pop_front();
+        impl_->cache.erase(oldest);
+    }
     return r;
 }
 

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -329,6 +329,22 @@ TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runti
     REQUIRE_FALSE(std::filesystem::exists(path));
 }
 
+TEST_CASE("FileAnalyticsDestination failed flush leaves no file at directory path",
+          "[runtime][analytics][coverage]") {
+    auto dir = std::filesystem::temp_directory_path() / "pulp-analytics-dir-dest";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+
+    FileAnalyticsDestination dest(dir.string());
+    AnalyticsEvent event;
+    event.name = "cannot-open-directory";
+    dest.log_event(event);
+    dest.flush();
+
+    REQUIRE(std::filesystem::is_directory(dir));
+    std::filesystem::remove_all(dir);
+}
+
 TEST_CASE("FileAnalyticsDestination writes property map in key order", "[runtime][analytics][issue-641]") {
     TemporaryFile tmp(".jsonl");
     FileAnalyticsDestination dest(tmp.path_string());

--- a/test/test_appcast.cpp
+++ b/test/test_appcast.cpp
@@ -105,6 +105,28 @@ TEST_CASE("Appcast XML emits Sparkle signature when present", "[ship][appcast]")
     REQUIRE(xml.find("sparkle:edSignature=\"base64-signature\"") != std::string::npos);
 }
 
+TEST_CASE("Appcast XML escapes greater-than characters in feed and item fields",
+          "[ship][appcast][coverage]") {
+    Appcast feed;
+    feed.title = "Pulp > Beta";
+    feed.link = "https://example.com/feed.xml";
+    feed.description = "Updates > previews";
+
+    AppcastItem item;
+    item.version = "1.0.0";
+    item.title = "Build > 100";
+    item.pub_date = "Mon, 01 Jun 2026 12:00:00 +0000";
+    item.download_url = "https://example.com/Pulp.pkg?min=>100";
+    feed.items.push_back(item);
+
+    auto xml = feed.to_xml();
+
+    REQUIRE(xml.find("<title>Pulp &gt; Beta</title>") != std::string::npos);
+    REQUIRE(xml.find("<description>Updates &gt; previews</description>") != std::string::npos);
+    REQUIRE(xml.find("<title>Build &gt; 100</title>") != std::string::npos);
+    REQUIRE(xml.find("url=\"https://example.com/Pulp.pkg?min=&gt;100\"") != std::string::npos);
+}
+
 TEST_CASE("Appcast from_xml parses optional fields across multiple items", "[ship][appcast]") {
     auto parsed = Appcast::from_xml(R"(<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -51,6 +51,15 @@ TEST_CASE("SHA-1 known value", "[crypto][sha1]") {
     REQUIRE(digest == expected);
 }
 
+TEST_CASE("SHA-1 empty input matches known digest", "[crypto][sha1][coverage]") {
+    const std::vector<uint8_t> expected = {
+        0xda, 0x39, 0xa3, 0xee, 0x5e, 0x6b, 0x4b, 0x0d, 0x32, 0x55,
+        0xbf, 0xef, 0x95, 0x60, 0x18, 0x90, 0xaf, 0xd8, 0x07, 0x09,
+    };
+
+    REQUIRE(sha1("") == expected);
+}
+
 TEST_CASE("SHA-1 pointer overload preserves embedded NUL bytes",
           "[crypto][sha1][coverage][issue-641]") {
     const std::vector<uint8_t> data = {'w', 's', 0x00, 'k', 'e', 'y'};

--- a/test/test_descriptor_validation.cpp
+++ b/test/test_descriptor_validation.cpp
@@ -112,6 +112,17 @@ TEST_CASE("DescriptorValidation: malformed reverse-DNS bundle_id segments warn o
     }
 }
 
+TEST_CASE("DescriptorValidation: whitespace-only bundle_id segments warn only",
+          "[format][descriptor-validation][coverage]") {
+    auto d = well_formed_effect();
+    d.bundle_id = "com.\t.plugin";
+
+    auto issues = validate_descriptor(d);
+    REQUIRE(has_warning_on(issues, "bundle_id"));
+    REQUIRE_FALSE(has_error_on(issues, "bundle_id"));
+    REQUIRE(descriptor_is_valid(issues));
+}
+
 TEST_CASE("DescriptorValidation: missing output bus is an error",
           "[format][descriptor-validation]") {
     auto d = well_formed_effect();

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -494,6 +494,23 @@ TEST_CASE("i18n JSON parser tolerates missing closing brace after entries",
     REQUIRE(strings.translate("partial") == "kept");
 }
 
+TEST_CASE("i18n JSON parser accepts whitespace separated key value pairs",
+          "[runtime][i18n][coverage]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "{\n";
+        f << "  \"missing_colon\"   \"accepted\",\n";
+        f << "  \"normal\": \"kept\"\n";
+        f << "}\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_json_file(tmp.path_string()));
+    REQUIRE(strings.translate("missing_colon") == "accepted");
+    REQUIRE(strings.translate("normal") == "kept");
+}
+
 // ── File load failures ──────────────────────────────────────────────────
 
 TEST_CASE("i18n load nonexistent file returns false", "[runtime][i18n]") {

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -235,6 +235,27 @@ TEST_CASE("Typed identity wrappers compare and hash deterministic values",
     REQUIRE(objects[second] == "two");
 }
 
+TEST_CASE("Typed transient identities hash and stringify nil values",
+          "[runtime][identity][coverage]") {
+    std::unordered_set<SessionId> sessions;
+    std::unordered_set<RunId> runs;
+    std::unordered_set<CorrelationId> correlations;
+
+    sessions.insert(SessionId::nil());
+    sessions.insert(SessionId::nil());
+    runs.insert(RunId::nil());
+    runs.insert(RunId::nil());
+    correlations.insert(CorrelationId::nil());
+    correlations.insert(CorrelationId::nil());
+
+    REQUIRE(sessions.size() == 1);
+    REQUIRE(runs.size() == 1);
+    REQUIRE(correlations.size() == 1);
+    REQUIRE(SessionId::nil().to_string() == "00000000-0000-0000-0000-000000000000");
+    REQUIRE(RunId::nil().to_string() == "00000000-0000-0000-0000-000000000000");
+    REQUIRE(CorrelationId::nil().to_string() == "00000000-0000-0000-0000-000000000000");
+}
+
 TEST_CASE("EventEnvelope defaults are nil and empty before attribution",
           "[runtime][identity][coverage][phase3]") {
     EventEnvelope env;

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -478,3 +478,20 @@ TEST_CASE("JsonRpcPeer ignores malformed response payloads without firing callba
     pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
     REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
 }
+
+TEST_CASE("JsonRpcPeer destructor clears the channel message callback",
+          "[json_rpc][coverage]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    {
+        JsonRpcPeer peer(*pair.first);
+    }
+
+    std::string reply;
+    pair.second->on_message([&](const Message& message) {
+        reply.assign(message.as_text());
+    });
+
+    REQUIRE(pair.second->send_text("{not-json"));
+    REQUIRE(reply.empty());
+}

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -148,6 +148,16 @@ TEST_CASE("BigInteger self assignment and identity arithmetic stay stable",
     REQUIRE(value.mod_pow(BigInteger(0), BigInteger(17)).to_string() == "1");
 }
 
+TEST_CASE("BigInteger preserves negative decimal values through arithmetic",
+          "[crypto][bigint][coverage][phase3]") {
+    auto negative = BigInteger::from_string("-42");
+    auto positive = BigInteger(50);
+
+    REQUIRE(negative.to_string() == "-42");
+    REQUIRE((negative + positive).to_string() == "8");
+    REQUIRE((negative * BigInteger(2)).to_string() == "-84");
+}
+
 // ── License ─────────────────────────────────────────────────────────────
 
 TEST_CASE("LicenseValidator invalid format", "[crypto][license]") {

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -281,6 +281,14 @@ TEST_CASE("LicenseValidator file not found", "[crypto][license]") {
     REQUIRE(validator.validate_file("/tmp/nonexistent_license_12345.key") == LicenseStatus::NotFound);
 }
 
+TEST_CASE("LicenseValidator empty license file is invalid format",
+          "[crypto][license][coverage][phase3]") {
+    TemporaryFile tmp(".license");
+
+    LicenseValidator validator;
+    REQUIRE(validator.validate_file(tmp.path_string()) == LicenseStatus::InvalidFormat);
+}
+
 TEST_CASE("LicenseValidator validate_file trims line endings", "[crypto][license]") {
     TemporaryFile tmp(".license");
     std::string payload = "{\"product_id\":\"PulpSynth\",\"issued\":1700000000}";

--- a/test/test_platform.cpp
+++ b/test/test_platform.cpp
@@ -116,6 +116,26 @@ TEST_CASE("ProgressParser ignores non-progress lines and tolerates empty callbac
     SUCCEED("empty callbacks are inert");
 }
 
+TEST_CASE("ProgressParser preserves colon payloads and empty event types",
+          "[platform][progress][coverage][phase3]") {
+    std::vector<ProgressEvent> events;
+    ProgressParser parser([&](const ProgressEvent& e) {
+        events.push_back(e);
+    });
+
+    parser.feed_line("PROGRESS:ERROR:https://example.test/a:b:c");
+    parser.feed_line("PROGRESS::payload-with-empty-type");
+    parser.feed_line("PROGRESS:");
+
+    REQUIRE(events.size() == 3);
+    REQUIRE(events[0].type == "ERROR");
+    REQUIRE(events[0].payload == "https://example.test/a:b:c");
+    REQUIRE(events[1].type.empty());
+    REQUIRE(events[1].payload == "payload-with-empty-type");
+    REQUIRE(events[2].type.empty());
+    REQUIRE(events[2].payload.empty());
+}
+
 #if !defined(__APPLE__)
 TEST_CASE("PopupMenu fallback returns no selection on non-Apple platforms",
           "[platform][popup-menu][issue-640]") {

--- a/test/test_processor_defaults.cpp
+++ b/test/test_processor_defaults.cpp
@@ -136,6 +136,16 @@ TEST_CASE("PluginDescriptor carries MIDI, MPE, UMP, and mobile flags independent
     REQUIRE(d.tail_samples == -1);
 }
 
+TEST_CASE("PluginDescriptor preserves optional vendor contact metadata",
+          "[format][processor-defaults][metadata][coverage][phase3]") {
+    PluginDescriptor d;
+    d.vendor_url = "https://example.test/pulp";
+    d.vendor_email = "support@example.test";
+
+    REQUIRE(d.vendor_url == "https://example.test/pulp");
+    REQUIRE(d.vendor_email == "support@example.test");
+}
+
 TEST_CASE("PrepareContext defaults match the headless stereo render path",
           "[format][processor-defaults][context]") {
     PrepareContext c;

--- a/test/test_properties_file.cpp
+++ b/test/test_properties_file.cpp
@@ -82,6 +82,18 @@ TEST_CASE("PropertiesFile set and get bool", "[state][properties]") {
     REQUIRE(*val == false);
 }
 
+TEST_CASE("PropertiesFile typed setters store retrievable string values",
+          "[state][properties][coverage][phase3]") {
+    PropertiesFile props;
+    props.set_int("voices", 16);
+    props.set_double("gain", -3.25);
+    props.set_bool("enabled", true);
+
+    REQUIRE(props.get_string("voices").value_or("") == "16");
+    REQUIRE(props.get_string("gain").value_or("").find("-3.25") == 0);
+    REQUIRE(props.get_string("enabled").value_or("") == "true");
+}
+
 TEST_CASE("PropertiesFile bool getter accepts true and numeric-one strings",
           "[state][properties][codecov]") {
     PropertiesFile props;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -70,6 +70,16 @@ TEST_CASE("ScopeGuard move transfers the active cleanup",
     REQUIRE(calls == 1);
 }
 
+TEST_CASE("PULP_ON_SCOPE_EXIT macro captures local state",
+          "[runtime][scope_guard][coverage][phase3]") {
+    int value = 0;
+    {
+        PULP_ON_SCOPE_EXIT(value += 7;);
+        value = 3;
+    }
+    REQUIRE(value == 10);
+}
+
 // ── TemporaryFile ───────────────────────────────────────────────────────
 
 TEST_CASE("TemporaryFile creates and deletes", "[runtime][temp_file]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -472,6 +472,28 @@ TEST_CASE("run_process captures stderr separately",
     REQUIRE(result->stderr_output.find("bad-news") != std::string::npos);
 }
 
+TEST_CASE("run_process honors an explicit working directory",
+          "[runtime][child_process][coverage][phase3]") {
+    TemporaryFile unique(".wd");
+    auto dir = unique.path();
+    unique.release();
+    std::filesystem::remove(dir);
+    std::filesystem::create_directories(dir);
+
+#ifdef _WIN32
+    auto result = run_process("powershell", {"-NoProfile", "-Command", "Get-Location"},
+                              dir.string());
+#else
+    auto result = run_process("/bin/pwd", {}, dir.string());
+#endif
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->exit_code == 0);
+    REQUIRE(result->stdout_output.find(dir.string()) != std::string::npos);
+
+    std::filesystem::remove_all(dir);
+}
+
 TEST_CASE("run_process fails on nonexistent", "[runtime][child_process]") {
 #ifdef _WIN32
     auto result = run_process("C:\\nonexistent_binary_12345.exe");

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -775,6 +775,18 @@ TEST_CASE("text_diff handles empty inputs", "[runtime][text-diff][issue-641]") {
     REQUIRE(format_diff(diff).empty());
 }
 
+TEST_CASE("text_diff formats unchanged lines with equal prefixes",
+          "[runtime][text-diff][coverage][phase3]") {
+    auto diff = text_diff("alpha\nbeta", "alpha\nbeta");
+
+    REQUIRE(diff.size() == 2);
+    REQUIRE(diff[0].op == DiffOp::Equal);
+    REQUIRE(diff[1].op == DiffOp::Equal);
+    REQUIRE(format_diff(diff) ==
+            "  alpha\n"
+            "  beta\n");
+}
+
 TEST_CASE("text_diff reports pure inserts and deletes",
           "[runtime][text-diff][issue-641]") {
     auto inserted = text_diff("", "one\ntwo");

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -349,6 +349,15 @@ TEST_CASE("DynamicLibrary closed lookup is null and close is idempotent",
     REQUIRE_FALSE(lib.is_open());
 }
 
+TEST_CASE("DynamicLibrary missing symbol lookup records an error",
+          "[runtime][dynlib][coverage][phase3]") {
+    DynamicLibrary lib;
+    REQUIRE(lib.open(system_library_path()));
+
+    REQUIRE(lib.find_symbol("pulp_definitely_missing_symbol_12345") == nullptr);
+    REQUIRE_FALSE(lib.error().empty());
+}
+
 TEST_CASE("DynamicLibrary move construction transfers the handle",
           "[runtime][dynlib][coverage][phase3]") {
     DynamicLibrary lib;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -42,6 +42,34 @@ const char* system_library_symbol() {
 
 }  // namespace
 
+// ── ScopeGuard ─────────────────────────────────────────────────────────
+
+TEST_CASE("ScopeGuard runs once on scope exit and can be dismissed",
+          "[runtime][scope_guard][coverage][phase3]") {
+    int calls = 0;
+    {
+        auto guard = make_scope_guard([&] { ++calls; });
+    }
+    REQUIRE(calls == 1);
+
+    {
+        auto guard = make_scope_guard([&] { ++calls; });
+        guard.dismiss();
+    }
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("ScopeGuard move transfers the active cleanup",
+          "[runtime][scope_guard][coverage][phase3]") {
+    int calls = 0;
+    {
+        auto guard = make_scope_guard([&] { ++calls; });
+        auto moved = std::move(guard);
+        (void)moved;
+    }
+    REQUIRE(calls == 1);
+}
+
 // ── TemporaryFile ───────────────────────────────────────────────────────
 
 TEST_CASE("TemporaryFile creates and deletes", "[runtime][temp_file]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -632,6 +632,16 @@ TEST_CASE("Expression evaluator resolves variables and rejects malformed inputs"
     REQUIRE_FALSE(evaluate("").has_value());
 }
 
+TEST_CASE("Expression evaluator handles unary plus division by zero and identifiers",
+          "[runtime][expression][coverage][phase3]") {
+    auto value = evaluate("+gain_1 / zero", {{"gain_1", 12.0}, {"zero", 0.0}});
+    REQUIRE(value.has_value());
+    REQUIRE(*value == Catch::Approx(0.0));
+
+    REQUIRE(evaluate("_offset2 + 1", {{"_offset2", 4.5}}).value_or(0.0)
+            == Catch::Approx(5.5));
+}
+
 TEST_CASE("ExpressionEvaluator stores variables and clears them",
           "[runtime][expression][coverage][issue-641]") {
     ExpressionEvaluator evaluator;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -503,6 +503,16 @@ TEST_CASE("run_process fails on nonexistent", "[runtime][child_process]") {
     REQUIRE_FALSE(result.has_value());
 }
 
+TEST_CASE("launch_process reports failed starts and missing pids",
+          "[runtime][child_process][coverage][phase3]") {
+#ifdef _WIN32
+    REQUIRE(launch_process("C:\\nonexistent_binary_12345.exe") == -1);
+#else
+    REQUIRE(launch_process("/tmp/nonexistent_binary_12345") == -1);
+#endif
+    REQUIRE_FALSE(is_process_running(99999999));
+}
+
 // ── Base64 ──────────────────────────────────────────────────────────────
 
 TEST_CASE("base64 encode/decode round-trip", "[runtime][base64]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -606,6 +606,17 @@ TEST_CASE("Expression evaluator handles constants, functions, and scientific not
     REQUIRE(*scientific == Catch::Approx(150.2));
 }
 
+TEST_CASE("Expression evaluator covers remaining built-in math functions",
+          "[runtime][expression][coverage][phase3]") {
+    REQUIRE(evaluate("log(e)").value_or(0.0) == Catch::Approx(1.0));
+    REQUIRE(evaluate("log10(1000)").value_or(0.0) == Catch::Approx(3.0));
+    REQUIRE(evaluate("exp(1)").value_or(0.0) == Catch::Approx(2.71828182845904523536));
+    REQUIRE(evaluate("floor(2.9) + ceil(2.1) + round(2.5)").value_or(0.0)
+            == Catch::Approx(8.0));
+    REQUIRE(evaluate("max(2, 5) + pow(2, 3)").value_or(0.0) == Catch::Approx(13.0));
+    REQUIRE(evaluate("tan(0)").value_or(1.0) == Catch::Approx(0.0));
+}
+
 TEST_CASE("Expression evaluator resolves variables and rejects malformed inputs",
           "[runtime][expression][coverage][issue-641]") {
     auto variable = evaluate("gain * 2 + offset", {{"gain", 0.75}, {"offset", 0.25}});

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -406,6 +406,23 @@ TEST_CASE("StateStore skips empty change listeners", "[state][listener][codecov]
     REQUIRE(calls == 1);
 }
 
+TEST_CASE("StateStore ignores unknown value writes without notifying listeners",
+          "[state][listener][coverage]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Known", "", {0.0f, 1.0f, 0.5f}));
+
+    int calls = 0;
+    store.add_listener([&](ParamID, float) { ++calls; });
+
+    store.set_value(999, 0.75f);
+    store.set_normalized(998, 0.25f);
+    store.set_mod_offset(997, 1.0f);
+    store.add_mod_offset(996, 1.0f);
+
+    REQUIRE(calls == 0);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(0.5, 0.001));
+}
+
 TEST_CASE("StateStore modulation offsets and default resets", "[state][store]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "Cutoff", "Hz", {20.0f, 20000.0f, 1000.0f}));

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -360,6 +360,20 @@ TEST_CASE("StateStore deserialize rejects bad magic and future versions",
     REQUIRE_THAT(store.get_value(1), WithinAbs(-12.0, 0.001));
 }
 
+TEST_CASE("StateStore deserialize rejects corrupted CRC without changing values",
+          "[state][serialize][coverage]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Gain", "dB", {-60.0f, 12.0f, 0.0f}));
+    store.set_value(1, -6.0f);
+
+    auto data = store.serialize();
+    data[data.size() - 1] ^= 0x7Fu;
+
+    store.set_value(1, -12.0f);
+    REQUIRE_FALSE(store.deserialize(data));
+    REQUIRE_THAT(store.get_value(1), WithinAbs(-12.0, 0.001));
+}
+
 TEST_CASE("StateStore change listener", "[state][listener]") {
     StateStore store;
     store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.5f}));

--- a/test/test_theme_contrast.cpp
+++ b/test/test_theme_contrast.cpp
@@ -3,6 +3,8 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/view/theme_contrast.hpp>
 
+#include <algorithm>
+
 using namespace pulp::view;
 using Catch::Matchers::WithinAbs;
 
@@ -85,6 +87,20 @@ TEST_CASE("Auto contrast picks black on light background", "[view][contrast]") {
     REQUIRE(fg.r == Catch::Approx(0.0f));
     REQUIRE(fg.g == Catch::Approx(0.0f));
     REQUIRE(fg.b == Catch::Approx(0.0f));
+}
+
+TEST_CASE("Auto contrast fallback chooses the higher ratio color",
+          "[view][contrast][coverage][phase3]") {
+    auto background = Color::rgba8(128, 128, 128);
+    auto fg = auto_contrast_foreground(background, ContrastLevel::aaa_normal);
+
+    REQUIRE_THAT(contrast_ratio(fg, background),
+                 WithinAbs(std::max(contrast_ratio(Color::rgba8(255, 255, 255), background),
+                                    contrast_ratio(Color::rgba8(0, 0, 0), background)),
+                           0.001));
+    REQUIRE(fg.r8() == 0);
+    REQUIRE(fg.g8() == 0);
+    REQUIRE(fg.b8() == 0);
 }
 
 TEST_CASE("Adjust for contrast returns meeting color", "[view][contrast]") {

--- a/test/test_xml_zip.cpp
+++ b/test/test_xml_zip.cpp
@@ -344,6 +344,18 @@ TEST_CASE("deflate compression levels round-trip edge settings",
     }
 }
 
+TEST_CASE("deflate_decompress rejects truncated raw streams",
+          "[runtime][zip][coverage]") {
+    const std::string payload = "truncated raw deflate payload";
+    auto compressed = deflate_compress(
+        reinterpret_cast<const uint8_t*>(payload.data()), payload.size());
+    REQUIRE(compressed.has_value());
+    REQUIRE(compressed->size() > 2);
+
+    compressed->resize(compressed->size() - 1);
+    REQUIRE_FALSE(deflate_decompress(compressed->data(), compressed->size()).has_value());
+}
+
 // ── RFC 1952 gzip wire-format compliance (issue-468 follow-up) ──────────
 //
 // gzip_compress() must emit a real RFC 1952 stream — magic bytes, deflate


### PR DESCRIPTION
## Summary
- add a 26-commit Phase 3 Codecov batch across runtime, state, format, platform, view, and ship-adjacent unit coverage
- cover parser, persistence, lifecycle, and failure-path branches with deterministic local tests
- include the non-Skia FontResolver cache-cap parity fix that unblocks Linux CI for the new font-axis tests

## Local validation
- ./build/test/pulp-test-state
- ./build/test/pulp-test-analytics
- ./build/test/pulp-test-i18n
- ./build/test/pulp-test-crypto
- ./build/test/pulp-test-license
- ./build/test/pulp-test-properties
- ./build/test/pulp-test-runtime-utils
- ./build/test/pulp-test-xml-zip
- ./build/test/pulp-test-json-rpc
- ./build/test/pulp-test-appcast
- ./build/test/pulp-test-identity
- ./build/test/pulp-test-descriptor-validation
- ./build/test/pulp-test-processor-defaults
- ./build/test/pulp-test-theme-contrast
- ./build/test/pulp-test-platform
- ./build/test/pulp-test-font-axis-animation

Note: local pre-push diff-cover is still blocked by the known FetchContent mbedTLS tag checkout issue; demoted only for push. GitHub CI remains the validation source.