### PR TITLE
fix(motion): MotionPreferences mutex + PulpMotionProbe ambient race + FixtureFileSink mutex (closes #2148 #2150 #2151)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.114.0
+    VERSION 0.115.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/apple/Sources/PulpSwift/PulpMotion.swift
+++ b/apple/Sources/PulpSwift/PulpMotion.swift
@@ -157,6 +157,11 @@ public struct PulpMotionBackend {
 /// Process-wide accessor — the host wires its backend in at launch.
 public enum PulpMotionRuntime {
     private static let lock = NSLock()
+    /// Separate ambient-provenance lock so SwiftUI `PulpMotionProbe`
+    /// attaches that briefly set + clear the C-side ambient slot can
+    /// serialize without contending with backend installation. See
+    /// `withAmbientProvenance(...)` below — issue #2150.
+    private static let ambientLock = NSLock()
     private static var _backend = PulpMotionBackend()
 
     /// Install a backend (host app calls this at launch). Pass `nil`
@@ -174,6 +179,27 @@ public enum PulpMotionRuntime {
     static var backend: PulpMotionBackend {
         lock.lock(); defer { lock.unlock() }
         return _backend
+    }
+
+    /// Run `body` with the process-wide ambient provenance set to
+    /// (`kind`, `id`, `file`, `line`) and unconditionally cleared on
+    /// exit. The set / body / clear triple runs under a dedicated lock
+    /// so two SwiftUI view bodies in the same runloop tick can't
+    /// interleave ambient slot mutations (issue #2150). The body should
+    /// be short — typically just the publish calls that need the
+    /// ambient stamp. The C ABI ambient slot is itself unsynchronized
+    /// across runtimes, so this guard only protects Swift-side
+    /// callers; it does not synchronize against arbitrary C++ writers.
+    public static func withAmbientProvenance(
+        kind: String, id: String,
+        file: String = #fileID, line: Int = #line,
+        _ body: () -> Void
+    ) {
+        ambientLock.lock(); defer { ambientLock.unlock() }
+        let b = backend
+        b.setAmbientProvenance(kind, id, file, line)
+        body()
+        b.clearAmbientProvenance()
     }
 }
 

--- a/apple/Sources/PulpSwift/PulpMotionProbe.swift
+++ b/apple/Sources/PulpSwift/PulpMotionProbe.swift
@@ -52,19 +52,26 @@ public struct PulpMotionTraceModifier: ViewModifier {
         // Walk the metric set; geometry / scrollGeometry metrics are
         // fed by the GeometryReader probe, scalar `value` metrics ride
         // the publish channel synchronously.
-        PulpMotion.setAmbientProvenance(kind: "swiftui", id: name)
-        for metric in metrics {
-            switch metric.kind {
-            case .value(let v):
-                PulpMotion.publishValue(view: name, metric: metric.name,
-                                        value: v,
-                                        epsilon: metric.epsilon,
-                                        precision: metric.precision)
-            case .geometry, .scrollGeometry:
-                break  // fed by handleFrame / preference change
+        //
+        // SwiftUI may invoke `body` / `onAppear` from multiple view
+        // bodies in the same runloop tick — two concurrent
+        // `pulpMotionTrace` attaches would otherwise race the global
+        // ambient provenance slot. Serialize the set / publish / clear
+        // triple under `PulpMotionRuntime.withAmbientProvenance` so
+        // each attach sees its own provenance stamp (issue #2150).
+        PulpMotionRuntime.withAmbientProvenance(kind: "swiftui", id: name) {
+            for metric in metrics {
+                switch metric.kind {
+                case .value(let v):
+                    PulpMotion.publishValue(view: name, metric: metric.name,
+                                            value: v,
+                                            epsilon: metric.epsilon,
+                                            precision: metric.precision)
+                case .geometry, .scrollGeometry:
+                    break  // fed by handleFrame / preference change
+                }
             }
         }
-        PulpMotion.clearAmbientProvenance()
     }
 
     private func detach() {
@@ -132,9 +139,14 @@ public final class PulpMotionGeometryProbe {
         self.name = name
         self.metricName = metric
         if PulpMotion.isTracingEnabled {
-            PulpMotion.setAmbientProvenance(kind: "swiftui", id: name)
-            traceId = PulpMotion.registerGeometryTrace(view: name, fps: fps)
-            PulpMotion.clearAmbientProvenance()
+            // Same race surface as `PulpMotionTraceModifier.attachIfNeeded`
+            // (issue #2150): serialize the set / register / clear under
+            // the runtime's ambient lock so concurrent UIKit / AppKit
+            // probe constructions can't interleave ambient slot
+            // mutations.
+            PulpMotionRuntime.withAmbientProvenance(kind: "swiftui", id: name) {
+                traceId = PulpMotion.registerGeometryTrace(view: name, fps: fps)
+            }
         }
     }
 

--- a/apple/Tests/PulpSwiftTests/PulpMotionTests.swift
+++ b/apple/Tests/PulpSwiftTests/PulpMotionTests.swift
@@ -180,4 +180,71 @@ final class PulpMotionTests: XCTestCase {
         probe.update(minX: 0, minY: 0, width: 10, height: 10)
         XCTAssertTrue(rec.updateCalls.isEmpty)
     }
+
+    // MARK: - withAmbientProvenance race-guard (#2150)
+    //
+    // Pre-#2150, two SwiftUI view bodies in the same runloop tick that
+    // both invoked `attachIfNeeded()` would race the process-wide
+    // ambient slot — view A's `setAmbientProvenance` could be
+    // immediately clobbered by view B's, then A's publishes would be
+    // stamped with B's provenance. `PulpMotionRuntime.withAmbientProvenance`
+    // serializes the set / body / clear triple so each attach observes
+    // its own stamp.
+
+    func testWithAmbientProvenanceSerializesSetClearAcrossThreads() async {
+        rec.tracingEnabled = true
+
+        // Record the sequence of ambient mutations (set / clear) the
+        // backend observes. After two concurrent attaches, the
+        // sequence must contain pairs of set→clear with no interleaved
+        // sets — i.e. between every `set` and its matching `clear`,
+        // no second `set` appears.
+        let mutationLock = NSLock()
+        var mutations: [String] = []
+        var backend = PulpMotionRuntime.backend
+        backend.setAmbientProvenance = { kind, id, _, _ in
+            mutationLock.lock(); defer { mutationLock.unlock() }
+            mutations.append("set:\(kind)/\(id)")
+        }
+        backend.clearAmbientProvenance = {
+            mutationLock.lock(); defer { mutationLock.unlock() }
+            mutations.append("clear")
+        }
+        PulpMotionRuntime.installTestBackend(backend)
+
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<8 {
+                group.addTask {
+                    let viewName = "View\(i)"
+                    PulpMotionRuntime.withAmbientProvenance(
+                        kind: "swiftui", id: viewName
+                    ) {
+                        // Brief artificial work inside the critical
+                        // section to widen the race window if the
+                        // guard is removed.
+                        for _ in 0..<200 { _ = viewName.uppercased() }
+                    }
+                }
+            }
+        }
+
+        // Validate: every `set` is followed by exactly one `clear`
+        // before the next `set`. Reject any nested `set:..`/`set:..`
+        // pair — that would be the racing bug #2150 was filed for.
+        var depth = 0
+        for m in mutations {
+            if m.hasPrefix("set:") {
+                XCTAssertEqual(depth, 0,
+                    "nested set with no intervening clear at \(m)")
+                depth += 1
+            } else if m == "clear" {
+                XCTAssertEqual(depth, 1,
+                    "clear without matching set")
+                depth -= 1
+            }
+        }
+        XCTAssertEqual(depth, 0, "trailing unmatched set")
+        // 8 tasks → 16 mutations (8 set + 8 clear).
+        XCTAssertEqual(mutations.count, 16)
+    }
 }

--- a/core/view/include/pulp/view/motion_preferences.hpp
+++ b/core/view/include/pulp/view/motion_preferences.hpp
@@ -16,6 +16,7 @@
 /// primitive starts; the singleton lives behind `current()`.
 
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -55,7 +56,7 @@ public:
     /// Current duration scale (default 1.0). Clamped to [0.0, 2.0].
     /// Only meaningful when `policy() == Reduced`; primitives may use it
     /// regardless if they want a softer slowdown under `Full`.
-    double duration_scale() const { return duration_scale_; }
+    double duration_scale() const;
 
     /// Set the duration scale. Clamped to [0.0, 2.0]. Sticks across
     /// override changes; not derived from the OS.
@@ -66,7 +67,7 @@ public:
     void set_override(std::optional<MotionPolicy> p);
 
     /// Returns true if an override is currently in effect.
-    bool has_override() const noexcept { return override_.has_value(); }
+    bool has_override() const noexcept;
 
     /// Poll the OS for a changed reduced-motion setting. Returns true
     /// when the effective policy changes since the last poll. When an
@@ -90,8 +91,16 @@ private:
     /// Platform-specific OS detection.
     static MotionPolicy detect_system_policy();
 
+    /// Compute the effective policy under `mtx_`. Caller holds the lock.
+    MotionPolicy policy_locked() const;
+
+    /// Snapshot a copy of the callback under `mtx_`, drop the lock, and
+    /// invoke. Avoids self-deadlock when a callback re-enters
+    /// `MotionPreferences::set_override` / `set_duration_scale`.
     void notify_changed(MotionPolicy p);
 
+    /// Protects every member below; never held across a callback fire.
+    mutable std::mutex mtx_;
     MotionPolicy last_os_ = MotionPolicy::Full;
     std::optional<MotionPolicy> override_;
     double duration_scale_ = 1.0;

--- a/core/view/src/motion.cpp
+++ b/core/view/src/motion.cpp
@@ -1528,10 +1528,19 @@ private:
 /// Shared file handle owned by the sink lambda. Lazily opens on first
 /// event so empty traces don't create stale files. Header is written
 /// once; subsequent events are appended.
+///
+/// `mtx` serializes the open / header-write / body-write sequence.
+/// Coordinator::fire_sinks does not hold a lock across sink calls, and
+/// the same `make_fixture_sink(path)` lambda is sometimes registered
+/// on both `Coordinator::add_sink` AND `MotionScrubber::add_sink` (see
+/// docstring on `make_fixture_sink` callers); two sink-fire threads
+/// could otherwise interleave writes mid-line. The mutex is cheap and
+/// uncontended in the single-registration case (issue #2151).
 struct FixtureFileSink {
     std::string path;
     std::shared_ptr<std::ofstream> stream;
     bool header_written = false;
+    std::mutex mtx;
 
     void ensure_open() {
         if (!stream) {
@@ -1547,6 +1556,7 @@ Sink make_fixture_sink(std::string path) {
     auto state = std::make_shared<FixtureFileSink>();
     state->path = std::move(path);
     return [state](const SampleEvent& e) {
+        std::lock_guard<std::mutex> lock(state->mtx);
         state->ensure_open();
         if (!state->stream || !state->stream->is_open()) return;
         if (!state->header_written) {

--- a/core/view/src/motion_preferences.cpp
+++ b/core/view/src/motion_preferences.cpp
@@ -31,45 +31,76 @@ MotionPreferences& MotionPreferences::instance() {
 }
 
 MotionPreferences::MotionPreferences() {
+    // Construction runs once under the `static` init guard; no
+    // contention on `mtx_` is possible at this point.
     last_os_ = detect_system_policy();
 }
 
 MotionPreferences::~MotionPreferences() = default;
 
-MotionPolicy MotionPreferences::policy() const {
+MotionPolicy MotionPreferences::policy_locked() const {
     if (override_) return *override_;
     return last_os_;
+}
+
+MotionPolicy MotionPreferences::policy() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return policy_locked();
+}
+
+double MotionPreferences::duration_scale() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return duration_scale_;
+}
+
+bool MotionPreferences::has_override() const noexcept {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return override_.has_value();
 }
 
 void MotionPreferences::set_duration_scale(double scale) {
     if (scale < 0.0) scale = 0.0;
     if (scale > 2.0) scale = 2.0;
+    std::lock_guard<std::mutex> lock(mtx_);
     duration_scale_ = scale;
 }
 
 void MotionPreferences::set_override(std::optional<MotionPolicy> p) {
-    auto before = policy();
-    override_ = p;
-    auto after = policy();
-    if (before != after) notify_changed(after);
+    MotionPolicy after{};
+    bool changed = false;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        const auto before = policy_locked();
+        override_ = p;
+        after = policy_locked();
+        changed = (before != after);
+    }
+    if (changed) notify_changed(after);
 }
 
 bool MotionPreferences::poll() {
-    if (override_) return false;
-    auto current = detect_system_policy();
-    if (current != last_os_) {
-        last_os_ = current;
-        notify_changed(current);
-        return true;
+    MotionPolicy current{};
+    bool changed = false;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        if (override_) return false;
+        current = detect_system_policy();
+        if (current != last_os_) {
+            last_os_ = current;
+            changed = true;
+        }
     }
-    return false;
+    if (changed) notify_changed(current);
+    return changed;
 }
 
 void MotionPreferences::on_policy_changed(std::function<void(MotionPolicy)> cb) {
+    std::lock_guard<std::mutex> lock(mtx_);
     callback_ = std::move(cb);
 }
 
 void MotionPreferences::reset_for_tests() {
+    std::lock_guard<std::mutex> lock(mtx_);
     override_.reset();
     duration_scale_ = 1.0;
     callback_ = {};
@@ -77,7 +108,15 @@ void MotionPreferences::reset_for_tests() {
 }
 
 void MotionPreferences::notify_changed(MotionPolicy p) {
-    if (callback_) callback_(p);
+    // Snapshot the callback under the lock so a re-entrant callback
+    // (one that calls back into MotionPreferences::set_override or
+    // set_duration_scale) can't self-deadlock.
+    std::function<void(MotionPolicy)> cb_copy;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        cb_copy = callback_;
+    }
+    if (cb_copy) cb_copy(p);
 }
 
 MotionPolicy MotionPreferences::detect_system_policy() {

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -12,9 +12,12 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
+#include <atomic>
 #include <cstdio>
 #include <optional>
+#include <set>
 #include <string>
+#include <thread>
 #if defined(_WIN32)
 #include <process.h>
 #define pulp_test_getpid() static_cast<long>(::_getpid())
@@ -586,4 +589,151 @@ TEST_CASE("Tween under Reduced + duration_scale 0.5 halves settling_time",
     REQUIRE(st == Approx(0.5).margin(0.06));
 
     coord.reset();
+}
+
+// ── Thread-safety smoke (bug #2148) ──────────────────────────────────
+//
+// The process-wide MotionPreferences singleton was guarded by zero
+// synchronization pre-#2148: today only tests call setters, but the JS
+// bridge and any future async OS-poll thread would tear. These cases
+// hammer the setter / getter / callback surface from multiple threads
+// and assert "no torn reads" + "no crash" — the same shape we want
+// future async callers to be safe under.
+//
+// True data-race detection is the job of TSan; these are deterministic
+// smoke tests that any host can run. Every observed policy value must
+// be from the closed set we wrote ({Reduced, Off, nullopt-back-to-OS});
+// every observed duration scale must be one of the values we set.
+
+TEST_CASE("MotionPreferences set_override hammered from N threads stays consistent",
+          "[motion-preferences][bug-sweep][thread-safety]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+
+    const int writers = 4;
+    const int readers = 4;
+    const int iters = 2000;
+    std::atomic<bool> go{false};
+    std::atomic<bool> stop{false};
+
+    auto os_policy = prefs.policy();   // baseline before any override
+
+    std::vector<std::thread> threads;
+    threads.reserve(writers + readers);
+
+    for (int w = 0; w < writers; ++w) {
+        threads.emplace_back([&, w] {
+            while (!go.load(std::memory_order_acquire)) {}
+            for (int i = 0; i < iters; ++i) {
+                switch ((w + i) % 3) {
+                    case 0: prefs.set_override(MotionPolicy::Reduced); break;
+                    case 1: prefs.set_override(MotionPolicy::Off);     break;
+                    case 2: prefs.set_override(std::nullopt);          break;
+                }
+            }
+        });
+    }
+
+    // Collect observed policy values in each reader to assert every
+    // observation is from the legal write set + the baseline OS value.
+    std::vector<std::vector<MotionPolicy>> observations(readers);
+    for (int r = 0; r < readers; ++r) {
+        threads.emplace_back([&, r] {
+            while (!go.load(std::memory_order_acquire)) {}
+            while (!stop.load(std::memory_order_acquire)) {
+                observations[r].push_back(prefs.policy());
+                (void)prefs.duration_scale();
+                (void)prefs.has_override();
+            }
+        });
+    }
+
+    go.store(true, std::memory_order_release);
+
+    // Wait for writers to finish then signal readers to stop.
+    for (int t = 0; t < writers; ++t) threads[t].join();
+    stop.store(true, std::memory_order_release);
+    for (int t = writers; t < writers + readers; ++t) threads[t].join();
+
+    // Every observed value must be a legal write or the OS baseline.
+    std::set<MotionPolicy> legal{MotionPolicy::Reduced, MotionPolicy::Off,
+                                 os_policy};
+    for (const auto& obs : observations) {
+        for (auto p : obs) {
+            REQUIRE(legal.count(p) == 1);
+        }
+    }
+}
+
+TEST_CASE("MotionPreferences set_duration_scale hammered from N threads",
+          "[motion-preferences][bug-sweep][thread-safety]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+
+    const int writers = 4;
+    const int readers = 4;
+    const int iters = 2000;
+    std::atomic<bool> go{false};
+    std::atomic<bool> stop{false};
+
+    const std::vector<double> values{0.0, 0.25, 0.5, 1.0, 1.5, 2.0};
+
+    std::vector<std::thread> threads;
+    threads.reserve(writers + readers);
+
+    for (int w = 0; w < writers; ++w) {
+        threads.emplace_back([&, w] {
+            while (!go.load(std::memory_order_acquire)) {}
+            for (int i = 0; i < iters; ++i) {
+                prefs.set_duration_scale(values[(w + i) % values.size()]);
+            }
+        });
+    }
+
+    std::vector<std::vector<double>> observations(readers);
+    for (int r = 0; r < readers; ++r) {
+        threads.emplace_back([&, r] {
+            while (!go.load(std::memory_order_acquire)) {}
+            while (!stop.load(std::memory_order_acquire)) {
+                observations[r].push_back(prefs.duration_scale());
+            }
+        });
+    }
+
+    go.store(true, std::memory_order_release);
+    for (int t = 0; t < writers; ++t) threads[t].join();
+    stop.store(true, std::memory_order_release);
+    for (int t = writers; t < writers + readers; ++t) threads[t].join();
+
+    // Every observed scale must be in [0.0, 2.0]: the setter clamps,
+    // and torn reads would manifest as out-of-range garbage.
+    for (const auto& obs : observations) {
+        for (auto v : obs) {
+            REQUIRE(v >= 0.0);
+            REQUIRE(v <= 2.0);
+        }
+    }
+}
+
+TEST_CASE("MotionPreferences callback that re-enters set_override does not deadlock",
+          "[motion-preferences][bug-sweep][thread-safety]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    // Force a known starting policy so the first set_override(Reduced)
+    // is a real transition even on runners that default to Reduced.
+    prefs.set_override(MotionPolicy::Full);
+
+    std::atomic<int> fired{0};
+    // Inside the callback, mutate the duration scale — a setter call
+    // that grabs `mtx_`. If notify_changed held `mtx_` across the
+    // callback fire, this would self-deadlock.
+    prefs.on_policy_changed([&](MotionPolicy) {
+        prefs.set_duration_scale(0.5);
+        ++fired;
+    });
+
+    prefs.set_override(MotionPolicy::Reduced);
+    prefs.set_override(MotionPolicy::Off);
+    REQUIRE(fired.load() == 2);
+    REQUIRE(prefs.duration_scale() == Approx(0.5));
 }

--- a/test/test_motion_scrubber.cpp
+++ b/test/test_motion_scrubber.cpp
@@ -20,12 +20,14 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <set>
 #include <sstream>
 #include <string>
+#include <thread>
 #if defined(_WIN32)
 #include <process.h>
 #define pulp_test_getpid() static_cast<long>(::_getpid())
@@ -396,4 +398,96 @@ TEST_CASE("Non-scrubber Motion.* methods still route to MotionInspector",
                                        R"({"view_name":"X","fps":60,"metrics":[]})"));
     REQUIRE(resp.is_error);
     REQUIRE(resp.params_json.find("motion inspector") != std::string::npos);
+}
+
+// ── FixtureFileSink double-registration regression (bug #2151) ───────
+//
+// `make_fixture_sink(path)` returns a Sink that owns a shared
+// `FixtureFileSink` state (file handle + header_written flag). If the
+// SAME sink is registered on both `Coordinator::add_sink` AND
+// `MotionScrubber::add_sink`, two sink-fire threads can interleave
+// writes to the underlying `std::ofstream` — header gets emitted
+// twice, or a body line gets cut in half by another thread's line.
+//
+// Pre-#2151 the sink had no internal synchronization. Post-fix, the
+// sink takes a `std::mutex` around the open + header-write + body-
+// write sequence. This test drives N threads invoking the SAME sink
+// in parallel and asserts the resulting file parses cleanly: exactly
+// one header line, every body line a valid JSON event.
+
+TEST_CASE("FixtureFileSink shared by N threads writes intact lines",
+          "[motion-fixture-sink][bug-sweep][thread-safety][issue-2151]") {
+    const auto path = tmp_fixture_path("shared-2151");
+    std::remove(path.c_str());
+
+    auto sink = pulp::view::motion::make_fixture_sink(path);
+
+    // Construct a SampleEvent template. We use the same shape on
+    // every thread but tag `frame` with the worker id so we can
+    // verify after the fact that every published event made it
+    // through (no dropped or truncated lines).
+    const int workers = 8;
+    const int iters = 250;
+    std::atomic<bool> go{false};
+
+    std::vector<std::thread> threads;
+    threads.reserve(workers);
+    for (int w = 0; w < workers; ++w) {
+        threads.emplace_back([&, w] {
+            while (!go.load(std::memory_order_acquire)) {}
+            for (int i = 0; i < iters; ++i) {
+                SampleEvent e;
+                e.kind = SampleEvent::Kind::Sample;
+                e.view_name = "View";
+                e.metric_name = "value";
+                e.t_seconds = static_cast<double>(w) + 0.001 * i;
+                e.frame = static_cast<std::uint64_t>(w * iters + i);
+                e.precision = 3;
+                e.components.emplace_back("value", static_cast<double>(i));
+                sink(e);
+            }
+        });
+    }
+    go.store(true, std::memory_order_release);
+    for (auto& t : threads) t.join();
+
+    // 1. The fixture loader must succeed (any torn header or truncated
+    //    event line would surface as an empty vector — load_fixture
+    //    bails on parse failure).
+    auto events = pulp::view::motion::load_fixture(path);
+    REQUIRE(events.size() == static_cast<std::size_t>(workers * iters));
+
+    // 2. The header must have parsed: schema version present.
+    auto hdr = pulp::view::motion::load_fixture_header(path);
+    REQUIRE(hdr.version == pulp::view::motion::kFixtureSchemaVersion);
+
+    // 3. Re-read the raw file: must have exactly one header line, and
+    //    every subsequent line must start with `{"kind":` (i.e. is a
+    //    full event line, not a torn fragment).
+    std::ifstream in(path);
+    REQUIRE(in.is_open());
+    std::string line;
+    REQUIRE(std::getline(in, line));   // header
+    REQUIRE(line.find("motion_fixture_version") != std::string::npos);
+    int header_dupes = 0;
+    int body_lines = 0;
+    while (std::getline(in, line)) {
+        if (line.empty()) continue;
+        if (line.find("motion_fixture_version") != std::string::npos) {
+            ++header_dupes;
+        } else {
+            // Must look like a JSON object literal. A torn write
+            // would either leave a non-`{` opener or omit the
+            // closing `}`. Both conditions would also have made
+            // load_fixture return empty, but check the raw bytes
+            // too so a regression surfaces with a clear locator.
+            REQUIRE(line.front() == '{');
+            REQUIRE(line.back()  == '}');
+            ++body_lines;
+        }
+    }
+    REQUIRE(header_dupes == 0);
+    REQUIRE(body_lines == workers * iters);
+
+    std::remove(path.c_str());
 }


### PR DESCRIPTION
3-MINOR motion follow-up bundle from the pre-merge bug sweep on #2142.

## Closes

- **#2148** — `MotionPreferences` process-wide singleton lacks mutex
- **#2150** — SwiftUI `PulpMotionProbe` races on global ambient `Provenance`
- **#2151** — `FixtureFileSink` double-registration can interleave writes

## Fixes

### #2148 — `MotionPreferences` thread-safety

`MotionPreferences` is a process-wide singleton. `override_`, `last_os_`, `duration_scale_`, and `callback_` were all written from `set_override` / `poll` / `set_duration_scale` and read from the fixture-sink hot path inside `Coordinator::on_tick` without any synchronization. Today only tests call setters; but the JS bridge and any future async OS-poll thread will tear.

**Fix**: added `mutable std::mutex mtx_`; lock-guard every setter, getter, and callback invocation. Snapshot-then-fire pattern for the callback (snapshot under lock, invoke outside) so a callback that re-enters MotionPreferences can't self-deadlock.

### #2150 — SwiftUI `PulpMotionProbe` ambient-provenance race

`PulpMotionProbe.attachIfNeeded()` set process-wide ambient `Provenance` via `pulp_motion_set_ambient_provenance` and immediately published `.value` metrics. SwiftUI can invoke `body` / `onAppear` from multiple view bodies in the same runloop tick — two concurrent `pulpMotionTrace` views raced the global ambient slot.

**Fix**: NSLock fallback (explicit-per-call-provenance would have needed C ABI extensions beyond the ~50 LOC budget for a follow-up PR). Added `PulpMotionRuntime.withAmbientProvenance` helper that serializes set/publish/clear. `PulpMotionTraceModifier.attachIfNeeded` and `PulpMotionGeometryProbe.init` now route through it. ~25 LOC Swift-only change.

### #2151 — `FixtureFileSink` double-registration race

`FixtureFileSink` wrote the underlying `std::ofstream` without internal synchronization. If the **same** `make_fixture_sink(path)` lambda were registered on **both** `Coordinator::add_sink` AND `MotionScrubber::add_sink`, the two paths could interleave writes from different threads.

**Fix**: added an internal `std::mutex` to the shared state inside `make_fixture_sink`. Locks around the open + header-write + body-write sequence. Cheap (single mutex per sink, no contention in the single-registration case).

## Verification

All motion test binaries green locally:
- `pulp-test-motion-preferences`: 28 cases / 14,696 assertions (3 new cases for #2148)
- `pulp-test-motion-scrubber`: 11 cases / 4,076 assertions (1 new case for #2151)
- Swift `PulpMotionTests.swift`: 20 cases / 0 failures (1 new ambient-provenance race-guard test for #2150)
- All 9 other motion binaries unchanged + green.

Thread-safety tests are smoke tests, not race reproducers (these races are classically flaky and TSan's job to surface deterministically).