### PR TITLE
test: batch phase3 coverage signal runtime audio edges

### DIFF
--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -169,6 +169,25 @@ TEST_CASE("Buffer zero-channel and zero-sample states remain well formed",
     default_view.clear();
 }
 
+TEST_CASE("Buffer resize to smaller shape remaps channel spans",
+          "[audio][buffer][coverage][phase3]") {
+    Buffer<float> buffer(3, 5);
+    buffer.channel(0)[4] = 0.25f;
+    buffer.channel(2)[4] = -0.5f;
+
+    buffer.resize(2, 3);
+    REQUIRE(buffer.num_channels() == 2);
+    REQUIRE(buffer.num_samples() == 3);
+
+    auto view = buffer.view();
+    REQUIRE(view.num_channels() == 2);
+    REQUIRE(view.num_samples() == 3);
+    REQUIRE(view.channel_ptr(0) == buffer.channel(0).data());
+    REQUIRE(view.channel_ptr(1) == buffer.channel(1).data());
+    REQUIRE(buffer.channel(0).size() == 3);
+    REQUIRE(buffer.channel(1).size() == 3);
+}
+
 TEST_CASE("AudioFileData reports shape from first channel",
           "[audio][file][codecov]") {
     AudioFileData empty;

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -2,6 +2,7 @@
 #include <pulp/audio/audio.hpp>
 #include <pulp/audio/audio_file.hpp>
 #include <pulp/audio/channel_set.hpp>
+#include <pulp/audio/load_measurer.hpp>
 #include <cmath>
 #include <numbers>
 #include <thread>
@@ -240,6 +241,21 @@ TEST_CASE("Device metadata defaults and custom configs are stable",
     REQUIRE(config.buffer_size == 128);
     REQUIRE(config.input_channels == 2);
     REQUIRE(config.output_channels == 6);
+}
+
+TEST_CASE("AudioProcessLoadMeasurer ignores invalid callback geometry",
+          "[audio][load][coverage][phase3]") {
+    AudioProcessLoadMeasurer measurer;
+
+    measurer.begin(0, 48000.0f);
+    measurer.end();
+    REQUIRE(measurer.load() == 0.0f);
+    REQUIRE(measurer.peak_load() == 0.0f);
+
+    measurer.begin(64, 0.0f);
+    measurer.end();
+    REQUIRE(measurer.load() == 0.0f);
+    REQUIRE(measurer.peak_load() == 0.0f);
 }
 
 TEST_CASE("ChannelSet maps standard layouts by count and name",

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -4,6 +4,7 @@
 #include <pulp/audio/channel_set.hpp>
 #include <pulp/audio/load_measurer.hpp>
 #include <cmath>
+#include <limits>
 #include <numbers>
 #include <thread>
 #include <chrono>
@@ -253,6 +254,21 @@ TEST_CASE("AudioProcessLoadMeasurer ignores invalid callback geometry",
     REQUIRE(measurer.peak_load() == 0.0f);
 
     measurer.begin(64, 0.0f);
+    measurer.end();
+    REQUIRE(measurer.load() == 0.0f);
+    REQUIRE(measurer.peak_load() == 0.0f);
+}
+
+TEST_CASE("AudioProcessLoadMeasurer rejects non-finite timing budgets",
+          "[audio][load][coverage][phase3]") {
+    AudioProcessLoadMeasurer measurer;
+
+    measurer.begin(64, std::numeric_limits<float>::infinity());
+    measurer.end();
+    REQUIRE(measurer.load() == 0.0f);
+    REQUIRE(measurer.peak_load() == 0.0f);
+
+    measurer.begin(std::numeric_limits<int>::max(), 1.0e-30f);
     measurer.end();
     REQUIRE(measurer.load() == 0.0f);
     REQUIRE(measurer.peak_load() == 0.0f);

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -258,6 +258,32 @@ TEST_CASE("AudioProcessLoadMeasurer ignores invalid callback geometry",
     REQUIRE(measurer.peak_load() == 0.0f);
 }
 
+TEST_CASE("AudioProcessLoadMeasurer clamps smoothing and resets peak load",
+          "[audio][load][coverage][phase3]") {
+    AudioProcessLoadMeasurer measurer;
+
+    measurer.set_smoothing(-1.0f);
+    measurer.begin(64, 48000.0f);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    measurer.end();
+    REQUIRE(measurer.load() == 0.0f);
+    REQUIRE(measurer.peak_load() > 0.0f);
+
+    measurer.reset_peak();
+    REQUIRE(measurer.peak_load() == 0.0f);
+
+    measurer.set_smoothing(2.0f);
+    measurer.begin(64, 48000.0f);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    measurer.end();
+    REQUIRE(measurer.load() > 0.0f);
+    REQUIRE(measurer.peak_load() >= measurer.load());
+
+    measurer.reset();
+    REQUIRE(measurer.load() == 0.0f);
+    REQUIRE(measurer.peak_load() == 0.0f);
+}
+
 TEST_CASE("ChannelSet maps standard layouts by count and name",
           "[audio][channel-set][issue-640]") {
     REQUIRE(ChannelSet::from_channel_count(0).name == "Discrete 0");

--- a/test/test_audio_focus.cpp
+++ b/test/test_audio_focus.cpp
@@ -157,6 +157,31 @@ TEST_CASE("AudioFocusRegistry: multiple subscribers all receive the signal",
     REQUIRE(count_c == 1);
 }
 
+TEST_CASE("AudioFocusRegistry: subscribers added during publish wait for next signal",
+          "[audio][focus][coverage][phase3]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    int first_count = 0;
+    int second_count = 0;
+    AudioFocusRegistry::Token second;
+
+    auto first = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState) {
+            ++first_count;
+            if (second.id() == 0) {
+                second = AudioFocusRegistry::instance().subscribe(
+                    [&](AudioFocusState) { ++second_count; });
+            }
+        });
+
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    REQUIRE(first_count == 1);
+    REQUIRE(second_count == 0);
+
+    AudioFocusRegistry::instance().publish(AudioFocusState::gained);
+    REQUIRE(first_count == 2);
+    REQUIRE(second_count == 1);
+}
+
 TEST_CASE("AudioFocusRegistry: current() is lock-free / audio-thread safe",
           "[audio][focus][issue-334]") {
     AudioFocusRegistry::instance().reset_for_test();

--- a/test/test_audio_focus.cpp
+++ b/test/test_audio_focus.cpp
@@ -84,6 +84,22 @@ TEST_CASE("AudioFocusRegistry: token move transfers ownership",
     REQUIRE(count == 1);  // outer now dropped → no more callbacks
 }
 
+TEST_CASE("AudioFocusRegistry: move construction empties source token",
+          "[audio][focus][coverage][phase3]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    int count = 0;
+    auto source = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState) { ++count; });
+    const int id = source.id();
+
+    AudioFocusRegistry::Token moved(std::move(source));
+    REQUIRE(source.id() == 0);
+    REQUIRE(moved.id() == id);
+
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    REQUIRE(count == 1);
+}
+
 TEST_CASE("AudioFocusRegistry: move assignment replaces an existing subscription",
           "[audio][focus][issue-640]") {
     AudioFocusRegistry::instance().reset_for_test();

--- a/test/test_biquad.cpp
+++ b/test/test_biquad.cpp
@@ -53,6 +53,20 @@ TEST_CASE("Biquad default coefficients are an identity bypass",
     require_buffer_matches(buffer, expected);
 }
 
+TEST_CASE("Biquad zero and negative block lengths are no-ops",
+          "[signal][biquad][coverage][phase3]") {
+    Biquad filter;
+    filter.set_coefficients(Biquad::Type::lowpass, 1000.0f, 0.707f, kSampleRate);
+    filter.process(1.0f);
+
+    std::array<float, 3> buffer{{0.25f, -0.5f, 0.75f}};
+    const auto expected = buffer;
+    filter.process(buffer.data(), 0);
+    filter.process(buffer.data(), -4);
+
+    require_buffer_matches(buffer, expected);
+}
+
 TEST_CASE("Biquad sample and block processing paths match",
           "[signal][biquad][issue-645]") {
     const std::array<BiquadCase, 10> cases{{

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -58,6 +58,17 @@ TEST_CASE("FastMath exp2 approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::exp2(0.5f), WithinAbs(std::sqrt(2.0f), 0.01));
 }
 
+TEST_CASE("FastMath exp2 preserves ordering across integer boundaries",
+          "[signal][fast_math][coverage][phase3]") {
+    const float below = FastMath::exp2(1.999f);
+    const float exact = FastMath::exp2(2.0f);
+    const float above = FastMath::exp2(2.001f);
+
+    REQUIRE(below < exact);
+    REQUIRE(exact < above);
+    REQUIRE_THAT(exact, WithinAbs(4.0f, 0.01f));
+}
+
 TEST_CASE("FastMath log2 approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::log2(1.0f), WithinAbs(0.0, 0.01));
     REQUIRE_THAT(FastMath::log2(2.0f), WithinAbs(1.0, 0.01));

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -76,6 +76,13 @@ TEST_CASE("FastMath log2 approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::log2(0.5f), WithinAbs(-1.0, 0.02));
 }
 
+TEST_CASE("FastMath log2 handles normalized power-of-two range",
+          "[signal][fast_math][coverage][phase3]") {
+    REQUIRE_THAT(FastMath::log2(0.25f), WithinAbs(-2.0f, 0.02f));
+    REQUIRE_THAT(FastMath::log2(16.0f), WithinAbs(4.0f, 0.02f));
+    REQUIRE_THAT(FastMath::log2(1024.0f), WithinAbs(10.0f, 0.02f));
+}
+
 TEST_CASE("FastMath pow approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::pow(2.0f, 3.0f), WithinAbs(8.0, 0.1));
     REQUIRE_THAT(FastMath::pow(10.0f, 2.0f), WithinAbs(100.0, 1.0));

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -18,6 +18,14 @@ TEST_CASE("FastMath tanh approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::tanh(5.0f), WithinAbs(1.0, 0.001));
 }
 
+TEST_CASE("FastMath tanh clamps exactly beyond approximation range",
+          "[signal][fast_math][coverage][phase3]") {
+    REQUIRE(FastMath::tanh(-100.0f) == -1.0f);
+    REQUIRE(FastMath::tanh(-4.0001f) == -1.0f);
+    REQUIRE(FastMath::tanh(4.0001f) == 1.0f);
+    REQUIRE(FastMath::tanh(100.0f) == 1.0f);
+}
+
 TEST_CASE("FastMath sin approximation", "[signal][fast_math]") {
     REQUIRE_THAT(FastMath::sin(0.0f), WithinAbs(0.0, 0.01));
     REQUIRE_THAT(FastMath::sin(1.5707963f), WithinAbs(1.0, 0.01)); // pi/2

--- a/test/test_filter_design.cpp
+++ b/test/test_filter_design.cpp
@@ -52,6 +52,13 @@ TEST_CASE("FilterDesign allpass passes DC", "[signal][filter_design]") {
     REQUIRE_THAT(dc_gain(c), WithinAbs(1.0, 0.01));
 }
 
+TEST_CASE("FilterDesign allpass keeps unity magnitude at Nyquist",
+          "[signal][filter_design][coverage][phase3]") {
+    auto c = FilterDesign::allpass(5000.0f, 0.9f, 48000.0f);
+    require_finite(c);
+    REQUIRE_THAT(std::abs(nyquist_gain(c)), WithinAbs(1.0f, 0.01f));
+}
+
 TEST_CASE("FilterDesign peaking_eq with 0dB gain is unity", "[signal][filter_design]") {
     auto c = FilterDesign::peaking_eq(1000.0f, 1.0f, 0.0f, 44100.0f);
     // 0 dB gain = no change, coefficients should be identity-like

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -41,6 +41,14 @@ TEST_CASE("Interpolator hermite impulse response spans adjacent samples", "[sign
     REQUIRE_THAT(Interpolator::hermite(0.5f, 0.0f, 0.0f, 0.0f, 1.0f), WithinAbs(-0.0625, 0.001));
 }
 
+TEST_CASE("Interpolator hermite preserves affine sample ramps",
+          "[signal][interp][coverage][phase3]") {
+    REQUIRE_THAT(Interpolator::hermite(0.25f, -1.0f, 1.0f, 3.0f, 5.0f),
+                 WithinAbs(1.5f, 0.001f));
+    REQUIRE_THAT(Interpolator::hermite(0.75f, -1.0f, 1.0f, 3.0f, 5.0f),
+                 WithinAbs(2.5f, 0.001f));
+}
+
 TEST_CASE("Interpolator lagrange at frac=0 returns y0", "[signal][interp]") {
     float result = Interpolator::lagrange(0.0f, 0.0f, 5.0f, 10.0f, 15.0f);
     REQUIRE_THAT(result, WithinAbs(5.0, 0.01));

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -66,6 +66,15 @@ TEST_CASE("Interpolator lagrange for linear data", "[signal][interp]") {
     REQUIRE_THAT(result, WithinAbs(1.5, 0.01));
 }
 
+TEST_CASE("Interpolator lagrange preserves quadratic curves",
+          "[signal][interp][coverage][phase3]") {
+    // Samples from f(x) = x^2 at x=-1,0,1,2.
+    REQUIRE_THAT(Interpolator::lagrange(0.25f, 1.0f, 0.0f, 1.0f, 4.0f),
+                 WithinAbs(0.0625f, 0.001f));
+    REQUIRE_THAT(Interpolator::lagrange(0.75f, 1.0f, 0.0f, 1.0f, 4.0f),
+                 WithinAbs(0.5625f, 0.001f));
+}
+
 TEST_CASE("Interpolator lagrange impulse response spans four samples", "[signal][interp]") {
     REQUIRE_THAT(Interpolator::lagrange(0.5f, 1.0f, 0.0f, 0.0f, 0.0f), WithinAbs(-0.0625, 0.001));
     REQUIRE_THAT(Interpolator::lagrange(0.5f, 0.0f, 1.0f, 0.0f, 0.0f), WithinAbs(0.5625, 0.001));

--- a/test/test_ios_audio_session.cpp
+++ b/test/test_ios_audio_session.cpp
@@ -117,6 +117,33 @@ TEST_CASE("C ABI ignores null events and prefers C++ listeners over raw callback
     pulp_ios_audio_session_set_callback(nullptr, nullptr);
 }
 
+TEST_CASE("C ABI callback replacement uses latest user data",
+          "[ios][audio-session][c-abi][coverage][phase3]") {
+    set_ios_audio_session_listener({});
+    int first_calls = 0;
+    int second_calls = 0;
+
+    pulp_ios_audio_session_set_callback(
+        [](const PulpIosAudioSessionEvent*, void* ud) {
+            ++(*static_cast<int*>(ud));
+        },
+        &first_calls);
+    pulp_ios_audio_session_set_callback(
+        [](const PulpIosAudioSessionEvent*, void* ud) {
+            ++(*static_cast<int*>(ud));
+        },
+        &second_calls);
+
+    PulpIosAudioSessionEvent e{};
+    e.event = PULP_IOS_AUDIO_EVENT_INTERRUPTION_BEGAN;
+    pulp_ios_audio_session_emit(&e);
+
+    REQUIRE(first_calls == 0);
+    REQUIRE(second_calls == 1);
+
+    pulp_ios_audio_session_set_callback(nullptr, nullptr);
+}
+
 TEST_CASE("audio session listener replacement detaches the previous sink",
           "[ios][audio-session][coverage][issue-648]") {
     int first_calls = 0;

--- a/test/test_ios_audio_session.cpp
+++ b/test/test_ios_audio_session.cpp
@@ -149,3 +149,12 @@ TEST_CASE("to_string covers every event code",
             "silence_secondary_audio_ended");
     REQUIRE(to_string(999) == "unknown");
 }
+
+TEST_CASE("typed audio session event names route through integer mapping",
+          "[ios][audio-session][coverage][phase3]") {
+    REQUIRE(to_string(PulpIosAudioEvent::PULP_IOS_AUDIO_EVENT_NONE) == "none");
+    REQUIRE(to_string(PulpIosAudioEvent::PULP_IOS_AUDIO_EVENT_ROUTE_CHANGED) ==
+            "route_changed");
+    REQUIRE(to_string(PulpIosAudioEvent::PULP_IOS_AUDIO_EVENT_SILENCE_SECONDARY_AUDIO_ENDED) ==
+            "silence_secondary_audio_ended");
+}

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -86,6 +86,24 @@ TEST_CASE("JsonRpcPeer request/response over an in-memory channel", "[json_rpc]"
     REQUIRE(response_payload == "5");
 }
 
+TEST_CASE("JsonRpcError factories expose spec codes and messages",
+          "[json_rpc][coverage][phase3]") {
+    const auto parse = JsonRpcError::parse_error();
+    const auto invalid = JsonRpcError::invalid_request();
+    const auto params = JsonRpcError::invalid_params();
+    const auto internal = JsonRpcError::internal_error();
+
+    REQUIRE(parse.code == -32700);
+    REQUIRE(parse.message == "Parse error");
+    REQUIRE(invalid.code == -32600);
+    REQUIRE(invalid.message == "Invalid Request");
+    REQUIRE(params.code == -32602);
+    REQUIRE(params.message == "Invalid params");
+    REQUIRE(internal.code == -32603);
+    REQUIRE(internal.message == "Internal error");
+    REQUIRE(internal.data_json.empty());
+}
+
 TEST_CASE("JsonRpcPeer returns method_not_found for unknown methods", "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -104,6 +104,20 @@ TEST_CASE("JsonRpcError factories expose spec codes and messages",
     REQUIRE(internal.data_json.empty());
 }
 
+TEST_CASE("JsonRpcResult factories separate success payloads from failures",
+          "[json_rpc][coverage][phase3]") {
+    const auto ok = JsonRpcResult::ok(R"({"ready":true})");
+    REQUIRE(ok.result_json == R"({"ready":true})");
+    REQUIRE_FALSE(ok.error.has_value());
+
+    const auto failed = JsonRpcResult::fail({-32001, "server busy", R"({"retry":true})"});
+    REQUIRE(failed.result_json.empty());
+    REQUIRE(failed.error.has_value());
+    REQUIRE(failed.error->code == -32001);
+    REQUIRE(failed.error->message == "server busy");
+    REQUIRE(failed.error->data_json == R"({"retry":true})");
+}
+
 TEST_CASE("JsonRpcPeer returns method_not_found for unknown methods", "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
     JsonRpcPeer client(*pair.first);

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -159,6 +159,21 @@ TEST_CASE("JsonRpcPeer fires notification handler and expects no response", "[js
     REQUIRE(last_params == "[\"again\"]");
 }
 
+TEST_CASE("JsonRpcPeer delivers empty notification params when omitted",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+    JsonRpcPeer server(*pair.second);
+
+    std::string captured = "unset";
+    server.on_notification("bare", [&](std::string_view params) {
+        captured = std::string(params);
+    });
+
+    REQUIRE(pair.first->send_text(
+        R"json({"jsonrpc":"2.0","method":"bare"})json"));
+    REQUIRE(captured.empty());
+}
+
 TEST_CASE("JsonRpcPeer reports scalar parse errors and ignores batches", "[json_rpc]") {
     auto pair = MemoryMessageChannel::make_pair();
 

--- a/test/test_midi_file.cpp
+++ b/test/test_midi_file.cpp
@@ -209,3 +209,16 @@ TEST_CASE("write_midi_file emits a readable SMF header",
     REQUIRE(read->total_events() == 2);
     REQUIRE(read->duration_seconds() == Approx(0.5).margin(0.05));
 }
+
+TEST_CASE("write_midi_file rejects missing parent directories",
+          "[midi][file][coverage][phase3]") {
+    TempDir tmp;
+    MidiFileData data;
+    MidiTrack track;
+    track.events.push_back({0.0, MidiEvent::note_on(0, 60, 100)});
+    data.tracks.push_back(std::move(track));
+
+    const auto path = tmp.path / "missing" / "out.mid";
+    REQUIRE_FALSE(write_midi_file(path.string(), data));
+    REQUIRE_FALSE(fs::exists(path));
+}

--- a/test/test_midi_file.cpp
+++ b/test/test_midi_file.cpp
@@ -50,6 +50,27 @@ std::vector<uint8_t> read_bytes(const fs::path& path) {
 
 } // namespace
 
+TEST_CASE("MidiFileData aggregates empty and multi-track metadata",
+          "[midi][file][coverage][phase3]") {
+    MidiFileData empty;
+    REQUIRE(empty.duration_seconds() == Approx(0.0).margin(1e-9));
+    REQUIRE(empty.total_events() == 0);
+
+    MidiFileData data;
+    MidiTrack early;
+    early.events.push_back({0.125, MidiEvent::note_on(0, 60, 100)});
+    early.events.push_back({0.25, MidiEvent::note_off(0, 60)});
+
+    MidiTrack late;
+    late.events.push_back({1.5, MidiEvent::cc(1, 74, 64)});
+
+    data.tracks.push_back(std::move(early));
+    data.tracks.push_back(std::move(late));
+
+    REQUIRE(data.total_events() == 3);
+    REQUIRE(data.duration_seconds() == Approx(1.5).margin(1e-9));
+}
+
 TEST_CASE("read_midi_file decodes running status byte fixtures",
           "[midi][file][issue-645]") {
     TempDir tmp;

--- a/test/test_osc_channel.cpp
+++ b/test/test_osc_channel.cpp
@@ -123,6 +123,30 @@ TEST_CASE("OscChannel close is idempotent and on_closed fires exactly once",
     REQUIRE(closed_count.load() == 1);
 }
 
+TEST_CASE("OscChannel routes close callbacks through custom executor",
+          "[osc_channel][lifecycle][coverage][phase3]") {
+    std::vector<std::function<void()>> queued;
+    OscChannelOptions options;
+    options.executor = [&](std::function<void()> fn) {
+        queued.push_back(std::move(fn));
+    };
+
+    auto a = OscChannel::open("127.0.0.1", 49919, 49920, options);
+    if (!a) {
+        SUCCEED("could not open loopback UDP pair; skipping");
+        return;
+    }
+
+    int closed_count = 0;
+    a->on_closed([&] { ++closed_count; });
+    a->close();
+
+    REQUIRE(closed_count == 0);
+    REQUIRE(queued.size() == 1);
+    queued.front()();
+    REQUIRE(closed_count == 1);
+}
+
 TEST_CASE("OscChannel delivers raw send() bytes verbatim to the peer",
           "[osc_channel][raw]") {
     auto a = OscChannel::open("127.0.0.1", 49917, 49918);

--- a/test/test_osc_channel.cpp
+++ b/test/test_osc_channel.cpp
@@ -186,3 +186,51 @@ TEST_CASE("OscChannel delivers raw send() bytes verbatim to the peer",
     a->close();
     b->close();
 }
+
+TEST_CASE("OscChannel routes received messages through custom executor",
+          "[osc_channel][raw][coverage][phase3]") {
+    std::mutex queue_mu;
+    std::vector<std::function<void()>> queued;
+    OscChannelOptions options;
+    options.executor = [&](std::function<void()> fn) {
+        std::lock_guard<std::mutex> lock(queue_mu);
+        queued.push_back(std::move(fn));
+    };
+
+    auto a = OscChannel::open("127.0.0.1", 49921, 49922);
+    auto b = OscChannel::open("127.0.0.1", 49922, 49921, options);
+    if (!a || !b) {
+        SUCCEED("could not open loopback UDP pair; skipping");
+        return;
+    }
+
+    std::vector<uint8_t> received;
+    b->on_message([&](const pulp::runtime::Message& m) {
+        received = m.payload;
+    });
+
+    Message msg("/queued");
+    msg.add(int32_t{9});
+    const auto encoded = encode(msg);
+    REQUIRE(a->send(encoded.data(), encoded.size()));
+
+    REQUIRE(wait_until([&] {
+        std::lock_guard<std::mutex> lock(queue_mu);
+        return !queued.empty();
+    }));
+    REQUIRE(received.empty());
+
+    std::function<void()> deliver;
+    {
+        std::lock_guard<std::mutex> lock(queue_mu);
+        deliver = std::move(queued.front());
+    }
+    deliver();
+
+    auto decoded = decode(received.data(), received.size());
+    REQUIRE(decoded.address == "/queued");
+    REQUIRE(decoded.get_int(0) == 9);
+
+    a->close();
+    b->close();
+}

--- a/test/test_sync_primitives.cpp
+++ b/test/test_sync_primitives.cpp
@@ -85,6 +85,17 @@ TEST_CASE("SeqLock concurrent stress test", "[runtime][seqlock]") {
 
 // ── TripleBuffer tests ────────────────────────────────────────────────────
 
+TEST_CASE("TripleBuffer default constructor exposes value-initialized front buffer",
+          "[runtime][triple_buffer][coverage][phase3]") {
+    TripleBuffer<TransportState> buf;
+
+    const auto& initial = buf.read();
+    REQUIRE(initial.tempo == 120.0);
+    REQUIRE(initial.beat_position == 0.0);
+    REQUIRE(initial.time_sig_num == 4);
+    REQUIRE(initial.time_sig_den == 4);
+}
+
 TEST_CASE("TripleBuffer basic read/write", "[runtime][triple_buffer]") {
     TripleBuffer<int> buf(0);
 

--- a/test/test_sync_primitives.cpp
+++ b/test/test_sync_primitives.cpp
@@ -17,6 +17,17 @@ struct TransportState {
     int time_sig_den = 4;
 };
 
+TEST_CASE("SeqLock default constructor publishes value-initialized snapshots",
+          "[runtime][seqlock][coverage][phase3]") {
+    SeqLock<TransportState> lock;
+
+    auto result = lock.read();
+    REQUIRE(result.tempo == 120.0);
+    REQUIRE(result.beat_position == 0.0);
+    REQUIRE(result.time_sig_num == 4);
+    REQUIRE(result.time_sig_den == 4);
+}
+
 TEST_CASE("SeqLock basic read/write", "[runtime][seqlock]") {
     SeqLock<TransportState> lock;
 


### PR DESCRIPTION
## Summary
- add Phase 3 Codecov coverage across signal math/interpolation/filter edges
- cover MIDI file metadata/write failure paths, audio focus token/subscriber behavior, and iOS audio session callback mapping
- add runtime coverage for JSON-RPC factories/notifications, sync primitive defaults, OSC executor dispatch, and audio buffer/load measurer edges

## Local validation
- `cmake --build build --target pulp-test-json-rpc pulp-test-sync pulp-test-audio pulp-test-fast-math pulp-test-interpolator pulp-test-biquad pulp-test-filter-design pulp-test-midi-file pulp-test-audio-focus pulp-test-ios-audio-session pulp-test-osc-channel`
- `./build/test/pulp-test-json-rpc`
- `./build/test/pulp-test-sync`
- `./build/test/pulp-test-audio "[audio][buffer]","[audio][load]"`
- `./build/test/pulp-test-fast-math`
- `./build/test/pulp-test-interpolator`
- `./build/test/pulp-test-biquad`
- `./build/test/pulp-test-filter-design`
- `./build/test/pulp-test-midi-file`
- `./build/test/pulp-test-audio-focus`
- `./build/test/pulp-test-ios-audio-session`
- `./build/test/pulp-test-osc-channel`
- `git diff --check`
