### PR TITLE
test: batch phase3 coverage state runtime signal edges

### DIFF
--- a/test/test_binding.cpp
+++ b/test/test_binding.cpp
@@ -427,3 +427,29 @@ TEST_CASE("Binding poll updates baseline after the first notification",
     REQUIRE_FALSE(b.poll());
     REQUIRE(call_count == 1);
 }
+
+TEST_CASE("Binding copies retain store identity and callback state",
+          "[binding][coverage][phase3-large]") {
+    auto store = make_store();
+    Binding original(*store, 1);
+    std::vector<float> original_values;
+    original.on_change([&](float value) {
+        original_values.push_back(value);
+    });
+
+    Binding copied = original;
+    std::vector<float> copied_values;
+    copied.on_change([&](float value) {
+        copied_values.push_back(value);
+    });
+
+    original.set(-3.0f);
+    copied.set(-6.0f);
+
+    REQUIRE(original.id() == copied.id());
+    REQUIRE(original.info() == copied.info());
+    REQUIRE_THAT(original.get(), WithinAbs(-6.0, 0.01));
+    REQUIRE_THAT(copied.get(), WithinAbs(-6.0, 0.01));
+    REQUIRE(original_values == std::vector<float>{-3.0f, -6.0f});
+    REQUIRE(copied_values == std::vector<float>{-6.0f});
+}

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -85,6 +85,16 @@ TEST_CASE("MD5 binary data returns raw digest bytes",
     REQUIRE(md5(data.data(), data.size()) == expected);
 }
 
+TEST_CASE("MD5 hex string_view preserves embedded NUL bytes",
+          "[crypto][md5][coverage][phase3-large]") {
+    std::string payload = "abc";
+    payload.push_back('\0');
+    payload += "def";
+
+    REQUIRE(md5_hex(std::string_view(payload.data(), payload.size())) ==
+            "a5e4d5963ae44c1f4bfb37b1a3d55a3c");
+}
+
 // ── AES-256-CBC ─────────────────────────────────────────────────────────
 
 TEST_CASE("AES encrypt/decrypt round-trip", "[crypto][aes]") {

--- a/test/test_dsp_enhancements.cpp
+++ b/test/test_dsp_enhancements.cpp
@@ -29,6 +29,14 @@ TEST_CASE("FastMath soft clip covers linear and saturated regions",
     REQUIRE_THAT(FastMath::soft_clip(-0.75f), WithinAbs(-0.6875f, 1e-6f));
 }
 
+TEST_CASE("FastMath dB conversion covers silent and unity cases",
+          "[dsp][fast_math][coverage][phase3-large]") {
+    REQUIRE_THAT(FastMath::db_to_gain(0.0f), WithinAbs(1.0f, 1e-5f));
+    REQUIRE(FastMath::gain_to_db(0.0f) == -200.0f);
+    REQUIRE(FastMath::gain_to_db(-1.0f) == -200.0f);
+    REQUIRE_THAT(FastMath::gain_to_db(1.0f), WithinAbs(0.0f, 1e-4f));
+}
+
 // ── DryWetMixer ─────────────────────────────────────────────────────────
 
 TEST_CASE("DryWetMixer fully wet", "[dsp][dry_wet]") {

--- a/test/test_dsp_enhancements.cpp
+++ b/test/test_dsp_enhancements.cpp
@@ -48,6 +48,16 @@ TEST_CASE("FastMath tanh covers clamps and odd symmetry",
     REQUIRE_THAT(negative, WithinAbs(-positive, 1e-6f));
 }
 
+TEST_CASE("FastMath pow and reciprocal helpers cover scalar edges",
+          "[dsp][fast_math][coverage][phase3-large]") {
+    REQUIRE_THAT(FastMath::pow(0.0f, 2.0f), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(FastMath::pow(-2.0f, 3.0f), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(FastMath::pow(4.0f, 0.5f), WithinAbs(2.0f, 0.02f));
+
+    REQUIRE_THAT(FastMath::rcp(4.0f), WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(FastMath::rsqrt(4.0f), WithinAbs(0.5f, 0.001f));
+}
+
 // ── DryWetMixer ─────────────────────────────────────────────────────────
 
 TEST_CASE("DryWetMixer fully wet", "[dsp][dry_wet]") {

--- a/test/test_dsp_enhancements.cpp
+++ b/test/test_dsp_enhancements.cpp
@@ -20,6 +20,15 @@ TEST_CASE("FastMath clamps saturation helper boundaries",
     REQUIRE_THAT(FastMath::clamp_unit(2.0f), WithinAbs(1.0f, 1e-6f));
 }
 
+TEST_CASE("FastMath soft clip covers linear and saturated regions",
+          "[dsp][fast_math][coverage][phase3-large]") {
+    REQUIRE_THAT(FastMath::soft_clip(-2.0f), WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(FastMath::soft_clip(2.0f), WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(FastMath::soft_clip(0.0f), WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(FastMath::soft_clip(0.75f), WithinAbs(0.6875f, 1e-6f));
+    REQUIRE_THAT(FastMath::soft_clip(-0.75f), WithinAbs(-0.6875f, 1e-6f));
+}
+
 // ── DryWetMixer ─────────────────────────────────────────────────────────
 
 TEST_CASE("DryWetMixer fully wet", "[dsp][dry_wet]") {

--- a/test/test_dsp_enhancements.cpp
+++ b/test/test_dsp_enhancements.cpp
@@ -5,11 +5,20 @@
 #include <pulp/signal/matrix.hpp>
 #include <pulp/signal/special_functions.hpp>
 #include <pulp/signal/compressor.hpp>
+#include <pulp/signal/fast_math.hpp>
 #include <vector>
 #include <cmath>
 
 using namespace pulp::signal;
 using Catch::Matchers::WithinAbs;
+
+TEST_CASE("FastMath clamps saturation helper boundaries",
+          "[dsp][fast_math][coverage][phase3-large]") {
+    REQUIRE_THAT(FastMath::clamp_unit(-2.0f), WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(FastMath::clamp_unit(-0.25f), WithinAbs(-0.25f, 1e-6f));
+    REQUIRE_THAT(FastMath::clamp_unit(0.25f), WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(FastMath::clamp_unit(2.0f), WithinAbs(1.0f, 1e-6f));
+}
 
 // ── DryWetMixer ─────────────────────────────────────────────────────────
 

--- a/test/test_dsp_enhancements.cpp
+++ b/test/test_dsp_enhancements.cpp
@@ -37,6 +37,17 @@ TEST_CASE("FastMath dB conversion covers silent and unity cases",
     REQUIRE_THAT(FastMath::gain_to_db(1.0f), WithinAbs(0.0f, 1e-4f));
 }
 
+TEST_CASE("FastMath tanh covers clamps and odd symmetry",
+          "[dsp][fast_math][coverage][phase3-large]") {
+    REQUIRE_THAT(FastMath::tanh(-5.0f), WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(FastMath::tanh(5.0f), WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(FastMath::tanh(0.0f), WithinAbs(0.0f, 1e-6f));
+
+    const auto positive = FastMath::tanh(0.75f);
+    const auto negative = FastMath::tanh(-0.75f);
+    REQUIRE_THAT(negative, WithinAbs(-positive, 1e-6f));
+}
+
 // ── DryWetMixer ─────────────────────────────────────────────────────────
 
 TEST_CASE("DryWetMixer fully wet", "[dsp][dry_wet]") {

--- a/test/test_filter_design.cpp
+++ b/test/test_filter_design.cpp
@@ -148,3 +148,23 @@ TEST_CASE("FilterDesign butterworth edge orders are bounded and finite",
         REQUIRE_THAT(dc_gain(c), WithinAbs(0.0f, 0.01f));
     }
 }
+
+TEST_CASE("FilterDesign near-Nyquist biquads remain finite",
+          "[signal][filter_design][coverage][phase3-large]") {
+    const float sample_rate = 48000.0f;
+    const float near_nyquist = 0.49f * sample_rate;
+
+    auto low = FilterDesign::lowpass(near_nyquist, 0.707f, sample_rate);
+    auto high = FilterDesign::highpass(near_nyquist, 0.707f, sample_rate);
+    auto notch = FilterDesign::notch(near_nyquist, 1.0f, sample_rate);
+    auto allpass = FilterDesign::allpass(near_nyquist, 0.707f, sample_rate);
+
+    for (const auto& c : {low, high, notch, allpass}) {
+        require_finite(c);
+    }
+
+    REQUIRE(std::abs(nyquist_gain(low)) < 0.01f);
+    REQUIRE(nyquist_gain(high) > 0.9f);
+    REQUIRE_THAT(nyquist_gain(notch), WithinAbs(1.0f, 0.01f));
+    REQUIRE_THAT(nyquist_gain(allpass), WithinAbs(1.0f, 0.01f));
+}

--- a/test/test_image_convolution.cpp
+++ b/test/test_image_convolution.cpp
@@ -191,3 +191,22 @@ TEST_CASE("Standard kernel weights cover blur edge and emboss paths",
     REQUIRE(emboss.get(0, 0) == -2.0f);
     REQUIRE(emboss.get(2, 2) == 2.0f);
 }
+
+TEST_CASE("Single-pixel convolution clamps repeated edge samples",
+          "[canvas][convolution][coverage][phase3-large]") {
+    uint8_t sharpened[4] = {40, 80, 120, 77};
+    auto sharpen = ImageConvolutionKernel::sharpen();
+    sharpen.apply(sharpened, 1, 1);
+    REQUIRE(sharpened[0] == 40);
+    REQUIRE(sharpened[1] == 80);
+    REQUIRE(sharpened[2] == 120);
+    REQUIRE(sharpened[3] == 77);
+
+    uint8_t edge[4] = {40, 80, 120, 88};
+    auto edge_detect = ImageConvolutionKernel::edge_detect();
+    edge_detect.apply(edge, 1, 1);
+    REQUIRE(edge[0] == 0);
+    REQUIRE(edge[1] == 0);
+    REQUIRE(edge[2] == 0);
+    REQUIRE(edge[3] == 88);
+}

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -478,3 +478,27 @@ TEST_CASE("JsonRpcPeer ignores malformed response payloads without firing callba
     pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
     REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
 }
+
+TEST_CASE("JsonRpcPeer destructor clears the channel message callback",
+          "[json_rpc][coverage][phase3-large]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string reply;
+    pair.first->on_message([&](const Message& message) {
+        reply.assign(message.as_text());
+    });
+
+    {
+        JsonRpcPeer server(*pair.second);
+        server.register_method("echo", [](std::string_view params) {
+            return JsonRpcResult::ok(std::string(params));
+        });
+        REQUIRE(pair.first->send_text(
+            R"json({"jsonrpc":"2.0","id":1,"method":"echo","params":7})json"));
+        REQUIRE(reply.find(R"("result":7)") != std::string::npos);
+    }
+
+    reply.clear();
+    REQUIRE(pair.first->send_text("{not-json"));
+    REQUIRE(reply.empty());
+}

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -148,6 +148,19 @@ TEST_CASE("BigInteger self assignment and identity arithmetic stay stable",
     REQUIRE(value.mod_pow(BigInteger(0), BigInteger(17)).to_string() == "1");
 }
 
+TEST_CASE("BigInteger ordering covers equal and greater comparisons",
+          "[crypto][bigint][coverage][phase3-large]") {
+    BigInteger low(99);
+    BigInteger same_low(99);
+    BigInteger high(100);
+
+    REQUIRE_FALSE(low < same_low);
+    REQUIRE_FALSE(high < low);
+    REQUIRE(low < high);
+    REQUIRE(low == same_low);
+    REQUIRE(high != low);
+}
+
 // ── License ─────────────────────────────────────────────────────────────
 
 TEST_CASE("LicenseValidator invalid format", "[crypto][license]") {

--- a/test/test_properties_file.cpp
+++ b/test/test_properties_file.cpp
@@ -370,6 +370,20 @@ TEST_CASE("PropertiesFile save and reload preserves escaped string values",
     REQUIRE(reloaded.get_string("newline").value_or("") == "line one\nline two");
 }
 
+TEST_CASE("PropertiesFile round-trips mixed JSON string escapes",
+          "[state][properties][coverage]") {
+    TemporaryFile tmp(".json");
+    const std::string value = "path\\\\plugin\t\"quoted\"\nnext line";
+
+    PropertiesFile props;
+    props.set_string("escaped", value);
+    REQUIRE(props.save(tmp.path_string()));
+
+    PropertiesFile reloaded;
+    REQUIRE(reloaded.load(tmp.path_string()));
+    REQUIRE(reloaded.get_string("escaped").value_or("") == value);
+}
+
 TEST_CASE("PropertiesFile set_path can clear the implicit save destination",
           "[state][properties][coverage][phase3-large]") {
     TemporaryFile tmp(".json");

--- a/test/test_properties_file.cpp
+++ b/test/test_properties_file.cpp
@@ -444,6 +444,22 @@ TEST_CASE("PropertiesFile remove and reinsert keeps sorted key enumeration",
     REQUIRE(props.get_string("b").value_or("") == "new");
 }
 
+TEST_CASE("PropertiesFile contains tracks string-view keys across mutation",
+          "[state][properties][coverage][phase3-large]") {
+    PropertiesFile props;
+    std::string key = "dynamic";
+
+    props.set_int(std::string_view(key), 12);
+    key = "changed";
+
+    REQUIRE(props.contains("dynamic"));
+    REQUIRE_FALSE(props.contains("changed"));
+
+    props.remove(std::string_view("dynamic"));
+    REQUIRE_FALSE(props.contains("dynamic"));
+    REQUIRE(props.size() == 0);
+}
+
 // ── ApplicationProperties ───────────────────────────────────────────────
 
 TEST_CASE("ApplicationProperties paths are platform-appropriate", "[state][properties]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -790,6 +790,20 @@ TEST_CASE("text_diff handles replacement ties and empty line formatting",
             "+ new-b\n");
 }
 
+TEST_CASE("text_diff treats trailing newline as no synthetic blank line",
+          "[runtime][text-diff][coverage][phase3-large]") {
+    auto diff = text_diff("alpha\nbeta\n", "alpha\nbeta");
+
+    REQUIRE(diff.size() == 2);
+    REQUIRE(diff[0].op == DiffOp::Equal);
+    REQUIRE(diff[0].text == "alpha");
+    REQUIRE(diff[1].op == DiffOp::Equal);
+    REQUIRE(diff[1].text == "beta");
+    REQUIRE(format_diff(diff) ==
+            "  alpha\n"
+            "  beta\n");
+}
+
 // ── Range ───────────────────────────────────────────────────────────────
 
 TEST_CASE("Range basic operations", "[runtime][range]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -615,6 +615,23 @@ TEST_CASE("ExpressionEvaluator dispatches registered unary functions",
     REQUIRE_FALSE(evaluator.evaluate("missing_fn(1)").has_value());
 }
 
+TEST_CASE("Expression evaluator covers multi-argument builtins",
+          "[runtime][expression][coverage][phase3-large]") {
+    REQUIRE(evaluate("min(5, 3)") == Catch::Approx(3.0));
+    REQUIRE(evaluate("max(5, 3)") == Catch::Approx(5.0));
+    REQUIRE(evaluate("pow(2, 5)") == Catch::Approx(32.0));
+    REQUIRE(evaluate("clamp(8, 5)") == Catch::Approx(5.0));
+    REQUIRE(evaluate("clamp(-2, 5)") == Catch::Approx(0.0));
+}
+
+TEST_CASE("Expression evaluator rejects incomplete multi-argument calls",
+          "[runtime][expression][coverage][phase3-large]") {
+    REQUIRE_FALSE(evaluate("min(1)").has_value());
+    REQUIRE_FALSE(evaluate("max(1)").has_value());
+    REQUIRE_FALSE(evaluate("pow(2)").has_value());
+    REQUIRE_FALSE(evaluate("clamp(2)").has_value());
+}
+
 // ── ScopeGuard ─────────────────────────────────────────────────────────
 
 TEST_CASE("ScopeGuard dismiss and move transfer ownership",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -615,6 +615,35 @@ TEST_CASE("ExpressionEvaluator dispatches registered unary functions",
     REQUIRE_FALSE(evaluator.evaluate("missing_fn(1)").has_value());
 }
 
+// ── ScopeGuard ─────────────────────────────────────────────────────────
+
+TEST_CASE("ScopeGuard dismiss and move transfer ownership",
+          "[runtime][scope_guard][coverage][phase3-large]") {
+    int calls = 0;
+    {
+        auto guard = make_scope_guard([&] { ++calls; });
+        guard.dismiss();
+    }
+    REQUIRE(calls == 0);
+
+    {
+        auto guard = make_scope_guard([&] { ++calls; });
+        auto moved = std::move(guard);
+        REQUIRE(calls == 0);
+    }
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("PULP_ON_SCOPE_EXIT runs at block exit",
+          "[runtime][scope_guard][coverage][phase3-large]") {
+    int value = 0;
+    {
+        PULP_ON_SCOPE_EXIT(value = 42);
+        REQUIRE(value == 0);
+    }
+    REQUIRE(value == 42);
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -555,3 +555,24 @@ TEST_CASE("StateStore deserialize keeps complete prefix on short declared count"
     REQUIRE(target.deserialize(data));
     REQUIRE_THAT(target.get_value(1), WithinAbs(0.75, 0.001));
 }
+
+TEST_CASE("StateStore serializes custom state version",
+          "[state][serialize][coverage][phase3-large]") {
+    StateStore store;
+    store.set_state_version(7);
+    store.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+    store.set_value(42, 64.0f);
+
+    auto data = store.serialize();
+
+    REQUIRE(read_u32_le(data, 4) == 7);
+    REQUIRE(read_u32_le(data, 8) == 1);
+    REQUIRE(read_u32_le(data, 12) == 42);
+
+    StateStore target;
+    target.set_state_version(7);
+    target.add_parameter(make_param_info(42, "Answer", "", {0.0f, 100.0f, 10.0f}));
+
+    REQUIRE(target.deserialize(data));
+    REQUIRE_THAT(target.get_value(42), WithinAbs(64.0, 0.001));
+}

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -576,3 +576,26 @@ TEST_CASE("StateStore serializes custom state version",
     REQUIRE(target.deserialize(data));
     REQUIRE_THAT(target.get_value(42), WithinAbs(64.0, 0.001));
 }
+
+TEST_CASE("StateStore reset_all_to_defaults notifies in registration order",
+          "[state][listener][coverage][phase3-large]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Gain", "", {-60.0f, 12.0f, 0.0f}));
+    store.add_parameter(make_param_info(2, "Mix", "", {0.0f, 100.0f, 50.0f}));
+    store.set_value(1, -12.0f);
+    store.set_value(2, 75.0f);
+
+    std::vector<ParamID> ids;
+    std::vector<float> values;
+    store.add_listener([&](ParamID id, float value) {
+        ids.push_back(id);
+        values.push_back(value);
+    });
+
+    store.reset_all_to_defaults();
+
+    REQUIRE(ids == std::vector<ParamID>{1, 2});
+    REQUIRE(values.size() == 2);
+    REQUIRE_THAT(values[0], WithinAbs(0.0, 0.001));
+    REQUIRE_THAT(values[1], WithinAbs(50.0, 0.001));
+}

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -738,6 +738,19 @@ TEST_CASE("CachedProperty bool ignores mismatched refresh values",
     REQUIRE(enabled.get());
 }
 
+TEST_CASE("CachedProperty int64 move tracks later tree updates",
+          "[state][cached][coverage][phase3-large]") {
+    auto tree = StateTree::create("params");
+    tree->set("voices", int64_t(8));
+    CachedProperty<int64_t> voices(tree, "voices", 1);
+    CachedProperty<int64_t> moved(std::move(voices));
+
+    tree->set("voices", int64_t(16));
+
+    REQUIRE(moved.is_bound());
+    REQUIRE(moved.get() == 16);
+}
+
 // ── StateTreeSynchroniser ───────────────────────────────────────────────
 
 TEST_CASE("StateTreeSynchroniser records property and child deltas", "[state][sync]") {

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -724,6 +724,20 @@ TEST_CASE("CachedProperty ignores mismatched external updates",
     REQUIRE(tree->get_string("name") == "Restored");
 }
 
+TEST_CASE("CachedProperty bool ignores mismatched refresh values",
+          "[state][cached][coverage][phase3-large]") {
+    auto tree = StateTree::create("params");
+    tree->set("enabled", true);
+    CachedProperty<bool> enabled(tree, "enabled", false);
+
+    REQUIRE(enabled.get());
+
+    tree->set("enabled", std::string("false"));
+    enabled.refresh();
+
+    REQUIRE(enabled.get());
+}
+
 // ── StateTreeSynchroniser ───────────────────────────────────────────────
 
 TEST_CASE("StateTreeSynchroniser records property and child deltas", "[state][sync]") {

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -140,6 +140,21 @@ TEST_CASE("MemoryStream zero-size, rewind, and clear edge paths", "[stream]") {
     REQUIRE(eof.closed());
 }
 
+TEST_CASE("MemoryStream clear does not reopen a closed stream",
+          "[stream][coverage][phase3-large]") {
+    MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
+    stream.close();
+    stream.clear();
+
+    REQUIRE_FALSE(stream.is_open());
+    REQUIRE(stream.size() == 0);
+    REQUIRE(stream.read_position() == 0);
+
+    std::uint8_t byte = 0;
+    REQUIRE(stream.read(&byte, 1).closed());
+    REQUIRE(stream.write(&byte, 1).closed());
+}
+
 TEST_CASE("StreamResult helpers classify non-ok states", "[stream][coverage][issue-656]") {
     auto ok = StreamResult::make(3);
     REQUIRE(ok.ok());

--- a/test/test_undo_manager.cpp
+++ b/test/test_undo_manager.cpp
@@ -256,3 +256,18 @@ TEST_CASE("UndoManager transaction redo preserves action order",
     REQUIRE(um.redo());
     REQUIRE(events == std::vector<int>{1, 2, -2, -1, 1, 2});
 }
+
+TEST_CASE("UndoManager clear notifies even when history is empty",
+          "[state][undo][coverage][phase3-large]") {
+    UndoManager um;
+    int changes = 0;
+    um.on_state_changed = [&] { ++changes; };
+
+    um.clear();
+
+    REQUIRE(changes == 1);
+    REQUIRE_FALSE(um.can_undo());
+    REQUIRE_FALSE(um.can_redo());
+    REQUIRE(um.undo_name().empty());
+    REQUIRE(um.redo_name().empty());
+}

--- a/test/test_undo_manager.cpp
+++ b/test/test_undo_manager.cpp
@@ -231,3 +231,28 @@ TEST_CASE("UndoManager multiple undo/redo sequence", "[state][undo]") {
     um.undo(); REQUIRE(v == 0);
     REQUIRE_FALSE(um.can_undo());
 }
+
+TEST_CASE("UndoManager transaction redo preserves action order",
+          "[state][undo][coverage][phase3-large]") {
+    UndoManager um;
+    std::vector<int> events;
+
+    um.begin_transaction("Ordered");
+    um.perform(UndoAction::create("A",
+        [&] { events.push_back(-1); },
+        [&] { events.push_back(1); }));
+    um.perform(UndoAction::create("B",
+        [&] { events.push_back(-2); },
+        [&] { events.push_back(2); }));
+    um.end_transaction();
+
+    REQUIRE(events == std::vector<int>{1, 2});
+    REQUIRE(um.undo_name() == "Ordered");
+
+    REQUIRE(um.undo());
+    REQUIRE(events == std::vector<int>{1, 2, -2, -1});
+    REQUIRE(um.redo_name() == "Ordered");
+
+    REQUIRE(um.redo());
+    REQUIRE(events == std::vector<int>{1, 2, -2, -1, 1, 2});
+}

--- a/test/test_v3_gaps.cpp
+++ b/test/test_v3_gaps.cpp
@@ -47,6 +47,18 @@ TEST_CASE("Bias reports state and processes separate buffers",
     REQUIRE_THAT(bias.process(0.5f), WithinAbs(0.25f, 1e-6f));
 }
 
+TEST_CASE("Bias handles zero-length in-place buffers",
+          "[signal][bias][coverage][phase3-large]") {
+    pulp::signal::Bias bias;
+    bias.set_bias(2.0f);
+
+    float sample = 5.0f;
+    bias.process(&sample, 0);
+
+    REQUIRE_THAT(sample, WithinAbs(5.0f, 1e-6f));
+    REQUIRE_THAT(bias.bias(), WithinAbs(2.0f, 1e-6f));
+}
+
 // ── MidiMessageSequence ─────────────────────────────────────────────────
 
 TEST_CASE("MidiMessageSequence maintains order", "[midi][sequence]") {


### PR DESCRIPTION
## Summary
- Adds a 24-commit Phase 3 Codecov batch across state, runtime, signal, canvas, and audio-adjacent test surfaces.
- Covers additional edge behavior in properties parsing, bindings, undo/state tree, streams/crypto/license helpers, image convolution, filter design, FastMath, and Bias.
- Keeps this as a GitHub-hosted CI batch; no Namespace dispatch.

## Local validation
- `cmake --build build --target pulp-test-properties pulp-test-filter-design pulp-test-image-convolution pulp-test-binding pulp-test-state pulp-test-runtime-utils pulp-test-json-rpc pulp-test-stream pulp-test-crypto pulp-test-license pulp-test-undo-manager pulp-test-state-tree pulp-test-dsp-enhancements pulp-test-v3-gaps`
- Targeted Catch2 filters for all touched test cases
- `git diff --check`
- Rebased on latest `origin/main` before push
