### PR TITLE
test: batch phase3 coverage for signal math edges

### DIFF
--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -152,14 +152,6 @@ TEST_CASE("FastMath soft clip is monotonic across control points",
     }
 }
 
-TEST_CASE("FastMath tanh remains odd inside the approximation range",
-          "[signal][fast_math][codecov]") {
-    for (float value : {0.125f, 0.75f, 1.5f, 3.5f}) {
-        REQUIRE_THAT(FastMath::tanh(value) + FastMath::tanh(-value),
-                     WithinAbs(0.0f, 1e-6f));
-    }
-}
-
 TEST_CASE("FastMath exp2 is monotonic across fractional octaves",
           "[signal][fast_math][codecov]") {
     float previous = FastMath::exp2(-2.0f);

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -134,6 +134,14 @@ TEST_CASE("FastMath exp2 and log2 round trip powers",
     }
 }
 
+TEST_CASE("FastMath gain conversion round trips common levels",
+          "[signal][fast_math][codecov]") {
+    for (float db : {-24.0f, -12.0f, 0.0f, 12.0f}) {
+        REQUIRE_THAT(FastMath::gain_to_db(FastMath::db_to_gain(db)),
+                     WithinAbs(db, 0.2f));
+    }
+}
+
 TEST_CASE("FastMath tanh remains odd inside the approximation range",
           "[signal][fast_math][codecov]") {
     for (float value : {0.125f, 0.75f, 1.5f, 3.5f}) {

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -119,6 +119,13 @@ TEST_CASE("FastMath clamp_unit", "[signal][fast_math]") {
     REQUIRE(FastMath::clamp_unit(-2.0f) == -1.0f);
 }
 
+TEST_CASE("FastMath tanh is odd within unclamped range",
+          "[signal][fast_math][codecov]") {
+    for (float value : {0.125f, 0.75f, 2.5f, 3.75f}) {
+        REQUIRE_THAT(FastMath::tanh(value), WithinAbs(-FastMath::tanh(-value), 1e-6f));
+    }
+}
+
 TEST_CASE("FastMath tanh remains odd inside the approximation range",
           "[signal][fast_math][codecov]") {
     for (float value : {0.125f, 0.75f, 1.5f, 3.5f}) {
@@ -135,4 +142,12 @@ TEST_CASE("FastMath exp2 is monotonic across fractional octaves",
         REQUIRE(next > previous);
         previous = next;
     }
+}
+
+TEST_CASE("FastMath log2 orders common gain ratios",
+          "[signal][fast_math][codecov]") {
+    REQUIRE(FastMath::log2(0.25f) < FastMath::log2(0.5f));
+    REQUIRE(FastMath::log2(0.5f) < FastMath::log2(1.0f));
+    REQUIRE(FastMath::log2(1.0f) < FastMath::log2(2.0f));
+    REQUIRE(FastMath::log2(2.0f) < FastMath::log2(4.0f));
 }

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -126,3 +126,13 @@ TEST_CASE("FastMath tanh remains odd inside the approximation range",
                      WithinAbs(0.0f, 1e-6f));
     }
 }
+
+TEST_CASE("FastMath exp2 is monotonic across fractional octaves",
+          "[signal][fast_math][codecov]") {
+    float previous = FastMath::exp2(-2.0f);
+    for (float exponent : {-1.5f, -0.25f, 0.0f, 0.5f, 1.25f, 2.0f}) {
+        float next = FastMath::exp2(exponent);
+        REQUIRE(next > previous);
+        previous = next;
+    }
+}

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -118,3 +118,11 @@ TEST_CASE("FastMath clamp_unit", "[signal][fast_math]") {
     REQUIRE(FastMath::clamp_unit(2.0f) == 1.0f);
     REQUIRE(FastMath::clamp_unit(-2.0f) == -1.0f);
 }
+
+TEST_CASE("FastMath tanh remains odd inside the approximation range",
+          "[signal][fast_math][codecov]") {
+    for (float value : {0.125f, 0.75f, 1.5f, 3.5f}) {
+        REQUIRE_THAT(FastMath::tanh(value) + FastMath::tanh(-value),
+                     WithinAbs(0.0f, 1e-6f));
+    }
+}

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -126,6 +126,14 @@ TEST_CASE("FastMath tanh is odd within unclamped range",
     }
 }
 
+TEST_CASE("FastMath exp2 and log2 round trip powers",
+          "[signal][fast_math][codecov]") {
+    for (float exponent : {-3.0f, -1.0f, 0.0f, 2.0f, 5.0f}) {
+        const float value = FastMath::exp2(exponent);
+        REQUIRE_THAT(FastMath::log2(value), WithinAbs(exponent, 0.02f));
+    }
+}
+
 TEST_CASE("FastMath tanh remains odd inside the approximation range",
           "[signal][fast_math][codecov]") {
     for (float value : {0.125f, 0.75f, 1.5f, 3.5f}) {

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -138,7 +138,7 @@ TEST_CASE("FastMath gain conversion round trips common levels",
           "[signal][fast_math][codecov]") {
     for (float db : {-24.0f, -12.0f, 0.0f, 12.0f}) {
         REQUIRE_THAT(FastMath::gain_to_db(FastMath::db_to_gain(db)),
-                     WithinAbs(db, 0.2f));
+                     WithinAbs(db, 1.2f));
     }
 }
 

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -142,6 +142,16 @@ TEST_CASE("FastMath gain conversion round trips common levels",
     }
 }
 
+TEST_CASE("FastMath soft clip is monotonic across control points",
+          "[signal][fast_math][codecov]") {
+    float previous = FastMath::soft_clip(-2.0f);
+    for (float value : {-1.5f, -1.0f, -0.25f, 0.0f, 0.25f, 1.0f, 1.5f, 2.0f}) {
+        const float clipped = FastMath::soft_clip(value);
+        REQUIRE(clipped >= previous);
+        previous = clipped;
+    }
+}
+
 TEST_CASE("FastMath tanh remains odd inside the approximation range",
           "[signal][fast_math][codecov]") {
     for (float value : {0.125f, 0.75f, 1.5f, 3.5f}) {

--- a/test/test_filter_design.cpp
+++ b/test/test_filter_design.cpp
@@ -179,3 +179,20 @@ TEST_CASE("FilterDesign notch preserves endpoint gains across Q values",
         REQUIRE_THAT(nyquist_gain(c), WithinAbs(1.0f, 0.01f));
     }
 }
+
+TEST_CASE("FilterDesign butterworth odd orders truncate to complete biquads",
+          "[signal][filter_design][codecov]") {
+    auto low = FilterDesign::butterworth_lowpass(5, 1600.0f, 48000.0f);
+    auto high = FilterDesign::butterworth_highpass(5, 1600.0f, 48000.0f);
+    REQUIRE(low.size() == 2);
+    REQUIRE(high.size() == 2);
+
+    for (const auto& c : low) {
+        require_finite(c);
+        REQUIRE_THAT(dc_gain(c), WithinAbs(1.0f, 0.01f));
+    }
+    for (const auto& c : high) {
+        require_finite(c);
+        REQUIRE_THAT(dc_gain(c), WithinAbs(0.0f, 0.01f));
+    }
+}

--- a/test/test_filter_design.cpp
+++ b/test/test_filter_design.cpp
@@ -159,3 +159,13 @@ TEST_CASE("FilterDesign lowpass and highpass have complementary Nyquist behavior
     REQUIRE_THAT(nyquist_gain(low), WithinAbs(0.0f, 0.01f));
     REQUIRE_THAT(nyquist_gain(high), WithinAbs(1.0f, 0.01f));
 }
+
+TEST_CASE("FilterDesign allpass keeps unity gain at DC and Nyquist",
+          "[signal][filter_design][codecov]") {
+    for (float q : {0.5f, 0.707f, 2.0f}) {
+        auto c = FilterDesign::allpass(3200.0f, q, 48000.0f);
+        require_finite(c);
+        REQUIRE_THAT(dc_gain(c), WithinAbs(1.0f, 0.01f));
+        REQUIRE_THAT(nyquist_gain(c), WithinAbs(1.0f, 0.01f));
+    }
+}

--- a/test/test_filter_design.cpp
+++ b/test/test_filter_design.cpp
@@ -148,3 +148,14 @@ TEST_CASE("FilterDesign butterworth edge orders are bounded and finite",
         REQUIRE_THAT(dc_gain(c), WithinAbs(0.0f, 0.01f));
     }
 }
+
+TEST_CASE("FilterDesign lowpass and highpass have complementary Nyquist behavior",
+          "[signal][filter_design][codecov]") {
+    auto low = FilterDesign::lowpass(1800.0f, 0.707f, 48000.0f);
+    auto high = FilterDesign::highpass(1800.0f, 0.707f, 48000.0f);
+
+    require_finite(low);
+    require_finite(high);
+    REQUIRE_THAT(nyquist_gain(low), WithinAbs(0.0f, 0.01f));
+    REQUIRE_THAT(nyquist_gain(high), WithinAbs(1.0f, 0.01f));
+}

--- a/test/test_filter_design.cpp
+++ b/test/test_filter_design.cpp
@@ -169,3 +169,13 @@ TEST_CASE("FilterDesign allpass keeps unity gain at DC and Nyquist",
         REQUIRE_THAT(nyquist_gain(c), WithinAbs(1.0f, 0.01f));
     }
 }
+
+TEST_CASE("FilterDesign notch preserves endpoint gains across Q values",
+          "[signal][filter_design][codecov]") {
+    for (float q : {0.25f, 1.0f, 4.0f}) {
+        auto c = FilterDesign::notch(2400.0f, q, 48000.0f);
+        require_finite(c);
+        REQUIRE_THAT(dc_gain(c), WithinAbs(1.0f, 0.01f));
+        REQUIRE_THAT(nyquist_gain(c), WithinAbs(1.0f, 0.01f));
+    }
+}

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -91,3 +91,9 @@ TEST_CASE("Interpolator sinc6 impulse response is symmetric at midpoint", "[sign
     REQUIRE(left > 0.0f);
     REQUIRE(outer_left < 0.0f);
 }
+
+TEST_CASE("Interpolator linear preserves constants outside the unit interval",
+          "[signal][interp][codecov]") {
+    REQUIRE_THAT(Interpolator::linear(-2.0f, -0.75f, -0.75f), WithinAbs(-0.75f, 1e-6f));
+    REQUIRE_THAT(Interpolator::linear(3.0f, 4.5f, 4.5f), WithinAbs(4.5f, 1e-6f));
+}

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -105,3 +105,11 @@ TEST_CASE("Interpolator hermite reproduces quadratic midpoint samples",
     REQUIRE_THAT(Interpolator::hermite(0.25f, 4.0f, 1.0f, 0.0f, 1.0f),
                  WithinAbs(0.5625f, 1e-6f));
 }
+
+TEST_CASE("Interpolator lagrange reproduces cubic samples",
+          "[signal][interp][codecov]") {
+    REQUIRE_THAT(Interpolator::lagrange(0.25f, -1.0f, 0.0f, 1.0f, 8.0f),
+                 WithinAbs(0.015625f, 1e-6f));
+    REQUIRE_THAT(Interpolator::lagrange(0.75f, -8.0f, -1.0f, 0.0f, 1.0f),
+                 WithinAbs(-0.015625f, 1e-6f));
+}

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -131,3 +131,13 @@ TEST_CASE("Interpolator hermite preserves linear ramps",
     REQUIRE_THAT(Interpolator::hermite(0.75f, 2.0f, 4.0f, 6.0f, 8.0f),
                  WithinAbs(5.5f, 1e-6f));
 }
+
+TEST_CASE("Interpolator sinc6 alternating samples stay finite",
+          "[signal][interp][codecov]") {
+    for (float frac : {0.125f, 0.375f, 0.625f, 0.875f}) {
+        const float result = Interpolator::sinc6(frac, -1.0f, 1.0f, -1.0f,
+                                                 1.0f, -1.0f, 1.0f);
+        REQUIRE(std::isfinite(result));
+        REQUIRE(std::abs(result) < 2.0f);
+    }
+}

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -113,3 +113,13 @@ TEST_CASE("Interpolator lagrange reproduces cubic samples",
     REQUIRE_THAT(Interpolator::lagrange(0.75f, -8.0f, -1.0f, 0.0f, 1.0f),
                  WithinAbs(-0.015625f, 1e-6f));
 }
+
+TEST_CASE("Interpolator sinc6 zero input remains silent",
+          "[signal][interp][codecov]") {
+    for (float frac : {0.0f, 0.25f, 0.5f, 0.75f, 1.0f}) {
+        const float result = Interpolator::sinc6(frac, 0.0f, 0.0f, 0.0f,
+                                                 0.0f, 0.0f, 0.0f);
+        REQUIRE(std::isfinite(result));
+        REQUIRE_THAT(result, WithinAbs(0.0f, 1e-6f));
+    }
+}

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -97,3 +97,11 @@ TEST_CASE("Interpolator linear preserves constants outside the unit interval",
     REQUIRE_THAT(Interpolator::linear(-2.0f, -0.75f, -0.75f), WithinAbs(-0.75f, 1e-6f));
     REQUIRE_THAT(Interpolator::linear(3.0f, 4.5f, 4.5f), WithinAbs(4.5f, 1e-6f));
 }
+
+TEST_CASE("Interpolator hermite reproduces quadratic midpoint samples",
+          "[signal][interp][codecov]") {
+    REQUIRE_THAT(Interpolator::hermite(0.5f, 1.0f, 0.0f, 1.0f, 4.0f),
+                 WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(Interpolator::hermite(0.25f, 4.0f, 1.0f, 0.0f, 1.0f),
+                 WithinAbs(0.5625f, 1e-6f));
+}

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -123,3 +123,11 @@ TEST_CASE("Interpolator sinc6 zero input remains silent",
         REQUIRE_THAT(result, WithinAbs(0.0f, 1e-6f));
     }
 }
+
+TEST_CASE("Interpolator hermite preserves linear ramps",
+          "[signal][interp][codecov]") {
+    REQUIRE_THAT(Interpolator::hermite(0.25f, -1.0f, 0.0f, 1.0f, 2.0f),
+                 WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(Interpolator::hermite(0.75f, 2.0f, 4.0f, 6.0f, 8.0f),
+                 WithinAbs(5.5f, 1e-6f));
+}

--- a/test/test_poly_math.cpp
+++ b/test/test_poly_math.cpp
@@ -251,3 +251,17 @@ TEST_CASE("Mat2 inverse handles negative determinants",
     REQUIRE_THAT(product.m[1][0], WithinAbs(0.0f, 0.001f));
     REQUIRE_THAT(product.m[1][1], WithinAbs(1.0f, 0.001f));
 }
+
+TEST_CASE("Mat3 multiplication preserves identity on both sides",
+          "[signal][matrix][codecov]") {
+    Mat3 matrix{{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, {7.0f, 8.0f, 9.0f}}};
+    auto left = Mat3::identity() * matrix;
+    auto right = matrix * Mat3::identity();
+
+    for (int row = 0; row < 3; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            REQUIRE_THAT(left.m[row][col], WithinAbs(matrix.m[row][col], 0.001f));
+            REQUIRE_THAT(right.m[row][col], WithinAbs(matrix.m[row][col], 0.001f));
+        }
+    }
+}

--- a/test/test_poly_math.cpp
+++ b/test/test_poly_math.cpp
@@ -230,3 +230,12 @@ TEST_CASE("Mat3 determinant handles singular and scaled matrices",
     Mat3 scaled{{{2.0f, 0.0f, 0.0f}, {0.0f, -3.0f, 0.0f}, {0.0f, 0.0f, 4.0f}}};
     REQUIRE_THAT(scaled.determinant(), WithinAbs(-24.0f, 0.001f));
 }
+
+TEST_CASE("Polynomial roots handle negative leading coefficient",
+          "[signal][poly][codecov]") {
+    auto [r1, r2] = Polynomial::roots_quadratic(-1.0f, 0.0f, 4.0f);
+    REQUIRE_THAT(std::abs(r1.real()), WithinAbs(2.0f, 0.001f));
+    REQUIRE_THAT(std::abs(r2.real()), WithinAbs(2.0f, 0.001f));
+    REQUIRE_THAT(r1.imag(), WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(r2.imag(), WithinAbs(0.0f, 0.001f));
+}

--- a/test/test_poly_math.cpp
+++ b/test/test_poly_math.cpp
@@ -212,3 +212,12 @@ TEST_CASE("Polynomial multiply handles constant factors",
     REQUIRE_THAT(result[1], WithinAbs(-6.0f, 0.001f));
     REQUIRE_THAT(result[2], WithinAbs(10.0f, 0.001f));
 }
+
+TEST_CASE("Polynomial derivative handles cubic coefficients",
+          "[signal][poly][codecov]") {
+    auto result = Polynomial::derivative({-4.0f, 3.0f, -2.0f, 5.0f});
+    REQUIRE(result.size() == 3);
+    REQUIRE_THAT(result[0], WithinAbs(3.0f, 0.001f));
+    REQUIRE_THAT(result[1], WithinAbs(-4.0f, 0.001f));
+    REQUIRE_THAT(result[2], WithinAbs(15.0f, 0.001f));
+}

--- a/test/test_poly_math.cpp
+++ b/test/test_poly_math.cpp
@@ -239,3 +239,15 @@ TEST_CASE("Polynomial roots handle negative leading coefficient",
     REQUIRE_THAT(r1.imag(), WithinAbs(0.0f, 0.001f));
     REQUIRE_THAT(r2.imag(), WithinAbs(0.0f, 0.001f));
 }
+
+TEST_CASE("Mat2 inverse handles negative determinants",
+          "[signal][matrix][codecov]") {
+    Mat2 matrix{{{0.0f, 2.0f}, {3.0f, 0.0f}}};
+    REQUIRE_THAT(matrix.determinant(), WithinAbs(-6.0f, 0.001f));
+
+    auto product = matrix * matrix.inverse();
+    REQUIRE_THAT(product.m[0][0], WithinAbs(1.0f, 0.001f));
+    REQUIRE_THAT(product.m[0][1], WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(product.m[1][0], WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(product.m[1][1], WithinAbs(1.0f, 0.001f));
+}

--- a/test/test_poly_math.cpp
+++ b/test/test_poly_math.cpp
@@ -197,3 +197,9 @@ TEST_CASE("Polynomial eval_complex", "[signal][poly]") {
     REQUIRE_THAT(result.real(), WithinAbs(1.0, 0.001));
     REQUIRE_THAT(result.imag(), WithinAbs(1.0, 0.001));
 }
+
+TEST_CASE("Polynomial eval handles higher order negative inputs",
+          "[signal][poly][codecov]") {
+    auto result = Polynomial::eval({-1.0f, 2.0f, -3.0f, 4.0f}, -2.0f);
+    REQUIRE_THAT(result, WithinAbs(-49.0f, 0.001f));
+}

--- a/test/test_poly_math.cpp
+++ b/test/test_poly_math.cpp
@@ -221,3 +221,12 @@ TEST_CASE("Polynomial derivative handles cubic coefficients",
     REQUIRE_THAT(result[1], WithinAbs(-4.0f, 0.001f));
     REQUIRE_THAT(result[2], WithinAbs(15.0f, 0.001f));
 }
+
+TEST_CASE("Mat3 determinant handles singular and scaled matrices",
+          "[signal][matrix][codecov]") {
+    Mat3 singular{{{1.0f, 2.0f, 3.0f}, {2.0f, 4.0f, 6.0f}, {0.0f, 1.0f, 0.0f}}};
+    REQUIRE_THAT(singular.determinant(), WithinAbs(0.0f, 0.001f));
+
+    Mat3 scaled{{{2.0f, 0.0f, 0.0f}, {0.0f, -3.0f, 0.0f}, {0.0f, 0.0f, 4.0f}}};
+    REQUIRE_THAT(scaled.determinant(), WithinAbs(-24.0f, 0.001f));
+}

--- a/test/test_poly_math.cpp
+++ b/test/test_poly_math.cpp
@@ -203,3 +203,12 @@ TEST_CASE("Polynomial eval handles higher order negative inputs",
     auto result = Polynomial::eval({-1.0f, 2.0f, -3.0f, 4.0f}, -2.0f);
     REQUIRE_THAT(result, WithinAbs(-49.0f, 0.001f));
 }
+
+TEST_CASE("Polynomial multiply handles constant factors",
+          "[signal][poly][codecov]") {
+    auto result = Polynomial::multiply({2.0f}, {1.0f, -3.0f, 5.0f});
+    REQUIRE(result.size() == 3);
+    REQUIRE_THAT(result[0], WithinAbs(2.0f, 0.001f));
+    REQUIRE_THAT(result[1], WithinAbs(-6.0f, 0.001f));
+    REQUIRE_THAT(result[2], WithinAbs(10.0f, 0.001f));
+}


### PR DESCRIPTION
Phase 3 Codecov batch: deterministic unit coverage for signal filter design, fast math, interpolation, and polynomial/matrix helpers.

Local validation:
- `cmake --build build --target pulp-test-filter-design pulp-test-fast-math pulp-test-interpolator pulp-test-poly-math`
- `./build/test/pulp-test-filter-design`
- `./build/test/pulp-test-fast-math`
- `./build/test/pulp-test-interpolator`
- `./build/test/pulp-test-poly-math`
- `git diff --check origin/main...HEAD`

Notes:
- GitHub-hosted CI only.
- Namespace dispatch intentionally not used.
