### PR TITLE
test: batch phase3 coverage for runtime stream edges

### DIFF
--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -665,6 +665,13 @@ TEST_CASE("Expression evaluator rejects trailing operators",
     REQUIRE_FALSE(evaluate("pow(2,)").has_value());
 }
 
+TEST_CASE("Expression evaluator handles nested function calls",
+          "[runtime][expression][coverage][phase3]") {
+    auto value = evaluate("max(min(10, 4), abs(-7))");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == Catch::Approx(7.0));
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -794,6 +794,16 @@ TEST_CASE("text_diff keeps repeated-line matches stable",
     REQUIRE(diff[5].text == "same");
 }
 
+TEST_CASE("text_diff treats identical multiline inputs as equal entries",
+          "[runtime][text-diff][coverage][phase3]") {
+    auto diff = text_diff("one\ntwo\nthree", "one\ntwo\nthree");
+    REQUIRE(diff.size() == 3);
+    for (const auto& entry : diff) {
+        REQUIRE(entry.op == DiffOp::Equal);
+    }
+    REQUIRE(format_diff(diff) == "  one\n  two\n  three\n");
+}
+
 TEST_CASE("text_diff handles replacement ties and empty line formatting",
           "[runtime][text-diff][coverage][phase3]") {
     auto diff = text_diff("old-a\n\nold-b", "new-a\nnew-b");

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -978,3 +978,11 @@ TEST_CASE("Range boundary touch points remain non-intersections",
     REQUIRE(IntRange(5, 4).empty());
     REQUIRE(IntRange(5, 5).constrain(100) == 5);
 }
+
+TEST_CASE("Range intersection is commutative for overlapping integer ranges",
+          "[runtime][range][coverage][phase3]") {
+    IntRange a(-4, 8);
+    IntRange b(3, 12);
+    REQUIRE(a.intersection(b) == IntRange(3, 8));
+    REQUIRE(b.intersection(a) == IntRange(3, 8));
+}

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -658,6 +658,13 @@ TEST_CASE("ExpressionEvaluator variables can be overwritten",
     REQUIRE(*evaluator.evaluate("amount * amount") == Catch::Approx(4.0));
 }
 
+TEST_CASE("Expression evaluator rejects trailing operators",
+          "[runtime][expression][coverage][phase3]") {
+    REQUIRE_FALSE(evaluate("1 +").has_value());
+    REQUIRE_FALSE(evaluate("2 *").has_value());
+    REQUIRE_FALSE(evaluate("pow(2,)").has_value());
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1006,10 +1006,10 @@ TEST_CASE("Range expansion handles negative domains",
 
 TEST_CASE("FloatRange constrain clamps fractional values",
           "[runtime][range][coverage][phase3]") {
-    FloatRange range(-1.0f, 1.0f);
+    FloatRange range(-1.0f, 3.0f);
     REQUIRE_THAT(range.constrain(-2.5f), Catch::Matchers::WithinAbs(-1.0f, 1e-6f));
     REQUIRE_THAT(range.constrain(0.25f), Catch::Matchers::WithinAbs(0.25f, 1e-6f));
-    REQUIRE_THAT(range.constrain(2.5f), Catch::Matchers::WithinAbs(1.0f, 1e-6f));
+    REQUIRE_THAT(range.constrain(2.5f), Catch::Matchers::WithinAbs(2.0f, 1e-6f));
 }
 
 TEST_CASE("DoubleRange empty constrain returns start",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -615,6 +615,21 @@ TEST_CASE("ExpressionEvaluator dispatches registered unary functions",
     REQUIRE_FALSE(evaluator.evaluate("missing_fn(1)").has_value());
 }
 
+TEST_CASE("Expression evaluator handles binary math functions",
+          "[runtime][expression][coverage][phase3]") {
+    auto minimum = evaluate("min(9, 4)");
+    REQUIRE(minimum.has_value());
+    REQUIRE(*minimum == Catch::Approx(4.0));
+
+    auto maximum = evaluate("max(-2, 3)");
+    REQUIRE(maximum.has_value());
+    REQUIRE(*maximum == Catch::Approx(3.0));
+
+    auto power = evaluate("pow(3, 3)");
+    REQUIRE(power.has_value());
+    REQUIRE(*power == Catch::Approx(27.0));
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -807,15 +807,13 @@ TEST_CASE("text_diff treats identical multiline inputs as equal entries",
 TEST_CASE("text_diff preserves leading and trailing empty lines",
           "[runtime][text-diff][coverage][phase3]") {
     auto diff = text_diff("\nbody\n", "\nbody\nnext\n");
-    REQUIRE(diff.size() == 4);
+    REQUIRE(diff.size() == 3);
     REQUIRE(diff[0].op == DiffOp::Equal);
     REQUIRE(diff[0].text.empty());
     REQUIRE(diff[1].op == DiffOp::Equal);
     REQUIRE(diff[1].text == "body");
-    REQUIRE(diff[2].op == DiffOp::Equal);
-    REQUIRE(diff[2].text.empty());
-    REQUIRE(diff[3].op == DiffOp::Insert);
-    REQUIRE(diff[3].text == "next");
+    REQUIRE(diff[2].op == DiffOp::Insert);
+    REQUIRE(diff[2].text == "next");
 }
 
 TEST_CASE("text_diff handles replacement ties and empty line formatting",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1003,3 +1003,11 @@ TEST_CASE("Range expansion handles negative domains",
     REQUIRE(range.expanded(-1) == IntRange(-10, 0));
     REQUIRE(range.expanded(-7) == range);
 }
+
+TEST_CASE("FloatRange constrain clamps fractional values",
+          "[runtime][range][coverage][phase3]") {
+    FloatRange range(-1.0f, 1.0f);
+    REQUIRE_THAT(range.constrain(-2.5f), Catch::Matchers::WithinAbs(-1.0f, 1e-6f));
+    REQUIRE_THAT(range.constrain(0.25f), Catch::Matchers::WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(range.constrain(2.5f), Catch::Matchers::WithinAbs(1.0f, 1e-6f));
+}

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -647,6 +647,17 @@ TEST_CASE("ExpressionEvaluator replaces registered unary functions",
     REQUIRE(*evaluator.evaluate("shape(4)") == Catch::Approx(8.0));
 }
 
+TEST_CASE("ExpressionEvaluator variables can be overwritten",
+          "[runtime][expression][coverage][phase3]") {
+    ExpressionEvaluator evaluator;
+    evaluator.set("amount", 1.5);
+    REQUIRE(*evaluator.evaluate("amount + 1") == Catch::Approx(2.5));
+
+    evaluator.set("amount", -2.0);
+    REQUIRE(*evaluator.get("amount") == Catch::Approx(-2.0));
+    REQUIRE(*evaluator.evaluate("amount * amount") == Catch::Approx(4.0));
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -1011,3 +1011,11 @@ TEST_CASE("FloatRange constrain clamps fractional values",
     REQUIRE_THAT(range.constrain(0.25f), Catch::Matchers::WithinAbs(0.25f, 1e-6f));
     REQUIRE_THAT(range.constrain(2.5f), Catch::Matchers::WithinAbs(1.0f, 1e-6f));
 }
+
+TEST_CASE("DoubleRange empty constrain returns start",
+          "[runtime][range][coverage][phase3]") {
+    DoubleRange empty(4.5, 4.5);
+    REQUIRE(empty.empty());
+    REQUIRE_THAT(empty.constrain(-100.0), Catch::Matchers::WithinAbs(4.5, 1e-12));
+    REQUIRE_THAT(empty.constrain(100.0), Catch::Matchers::WithinAbs(4.5, 1e-12));
+}

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -986,3 +986,12 @@ TEST_CASE("Range intersection is commutative for overlapping integer ranges",
     REQUIRE(a.intersection(b) == IntRange(3, 8));
     REQUIRE(b.intersection(a) == IntRange(3, 8));
 }
+
+TEST_CASE("Range enclosing union keeps reversed ranges isolated",
+          "[runtime][range][coverage][phase3]") {
+    IntRange reversed(8, 3);
+    IntRange normal(1, 4);
+    REQUIRE(reversed.empty());
+    REQUIRE(reversed.enclosing_union(normal) == normal);
+    REQUIRE(normal.enclosing_union(reversed) == normal);
+}

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -637,6 +637,16 @@ TEST_CASE("Expression evaluator tolerates whitespace around tokens",
     REQUIRE(*value == Catch::Approx(9.0));
 }
 
+TEST_CASE("ExpressionEvaluator replaces registered unary functions",
+          "[runtime][expression][coverage][phase3]") {
+    ExpressionEvaluator evaluator;
+    evaluator.register_function("shape", [](double x) { return x + 1.0; });
+    REQUIRE(*evaluator.evaluate("shape(4)") == Catch::Approx(5.0));
+
+    evaluator.register_function("shape", [](double x) { return x * 2.0; });
+    REQUIRE(*evaluator.evaluate("shape(4)") == Catch::Approx(8.0));
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -630,6 +630,13 @@ TEST_CASE("Expression evaluator handles binary math functions",
     REQUIRE(*power == Catch::Approx(27.0));
 }
 
+TEST_CASE("Expression evaluator tolerates whitespace around tokens",
+          "[runtime][expression][coverage][phase3]") {
+    auto value = evaluate("  ( 1 + 2 ) *\t3  ");
+    REQUIRE(value.has_value());
+    REQUIRE(*value == Catch::Approx(9.0));
+}
+
 // ── HTTP URL parsing ───────────────────────────────────────────────────
 
 TEST_CASE("HTTP helpers reject malformed URLs without transport work",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -804,6 +804,20 @@ TEST_CASE("text_diff treats identical multiline inputs as equal entries",
     REQUIRE(format_diff(diff) == "  one\n  two\n  three\n");
 }
 
+TEST_CASE("text_diff preserves leading and trailing empty lines",
+          "[runtime][text-diff][coverage][phase3]") {
+    auto diff = text_diff("\nbody\n", "\nbody\nnext\n");
+    REQUIRE(diff.size() == 4);
+    REQUIRE(diff[0].op == DiffOp::Equal);
+    REQUIRE(diff[0].text.empty());
+    REQUIRE(diff[1].op == DiffOp::Equal);
+    REQUIRE(diff[1].text == "body");
+    REQUIRE(diff[2].op == DiffOp::Equal);
+    REQUIRE(diff[2].text.empty());
+    REQUIRE(diff[3].op == DiffOp::Insert);
+    REQUIRE(diff[3].text == "next");
+}
+
 TEST_CASE("text_diff handles replacement ties and empty line formatting",
           "[runtime][text-diff][coverage][phase3]") {
     auto diff = text_diff("old-a\n\nold-b", "new-a\nnew-b");

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -995,3 +995,11 @@ TEST_CASE("Range enclosing union keeps reversed ranges isolated",
     REQUIRE(reversed.enclosing_union(normal) == normal);
     REQUIRE(normal.enclosing_union(reversed) == normal);
 }
+
+TEST_CASE("Range expansion handles negative domains",
+          "[runtime][range][coverage][phase3]") {
+    IntRange range(-10, -4);
+    REQUIRE(range.expanded(-12) == IntRange(-12, -4));
+    REQUIRE(range.expanded(-1) == IntRange(-10, 0));
+    REQUIRE(range.expanded(-7) == range);
+}

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -132,6 +132,21 @@ TEST_CASE("MemoryStream read cursor remains at end after EOF",
     REQUIRE(stream.read_position() == 2);
 }
 
+TEST_CASE("MemoryStream rewind after EOF allows replay",
+          "[stream][memory][coverage][phase3]") {
+    MemoryStream stream(std::vector<std::uint8_t>{4, 5, 6});
+    std::uint8_t out[3]{};
+
+    REQUIRE(stream.read(out, sizeof(out)).bytes == 3);
+    REQUIRE(stream.read(out, 1).closed());
+
+    stream.rewind();
+    REQUIRE(stream.read_position() == 0);
+    REQUIRE(stream.read(out, 2).bytes == 2);
+    REQUIRE(out[0] == 4);
+    REQUIRE(out[1] == 5);
+}
+
 TEST_CASE("MemoryStream close rejects further I/O", "[stream]") {
     MemoryStream s;
     s.close();

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -118,6 +118,20 @@ TEST_CASE("MemoryStream partial read", "[stream]") {
     REQUIRE(out[1] == 40);
 }
 
+TEST_CASE("MemoryStream read cursor remains at end after EOF",
+          "[stream][memory][coverage][phase3]") {
+    MemoryStream stream(std::vector<std::uint8_t>{11, 22});
+    std::uint8_t out[4]{};
+
+    REQUIRE(stream.read(out, sizeof(out)).bytes == 2);
+    REQUIRE(stream.read_position() == 2);
+
+    auto eof = stream.read(out, 1);
+    REQUIRE_FALSE(eof.ok());
+    REQUIRE(eof.closed());
+    REQUIRE(stream.read_position() == 2);
+}
+
 TEST_CASE("MemoryStream close rejects further I/O", "[stream]") {
     MemoryStream s;
     s.close();

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -159,6 +159,19 @@ TEST_CASE("MemoryStream close is idempotent",
     REQUIRE(stream.write(&byte, 1).closed());
 }
 
+TEST_CASE("MemoryStream write copies caller storage",
+          "[stream][memory][coverage][phase3]") {
+    MemoryStream stream;
+    std::uint8_t payload[] = {1, 2, 3};
+    REQUIRE(stream.write(payload, sizeof(payload)).bytes == sizeof(payload));
+
+    payload[0] = 9;
+    payload[1] = 9;
+    payload[2] = 9;
+
+    REQUIRE(stream.buffer() == std::vector<std::uint8_t>{1, 2, 3});
+}
+
 TEST_CASE("MemoryStream close rejects further I/O", "[stream]") {
     MemoryStream s;
     s.close();

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -59,6 +59,15 @@ TEST_CASE("StreamResult factory preserves explicit zero-byte success",
     REQUIRE(result.bytes == 0);
 }
 
+TEST_CASE("StreamResult closed failure has no transferred bytes",
+          "[stream][coverage][phase3]") {
+    auto result = StreamResult::fail(StreamError::Closed);
+    REQUIRE_FALSE(result.ok());
+    REQUIRE_FALSE(result.would_block());
+    REQUIRE(result.closed());
+    REQUIRE(result.bytes == 0);
+}
+
 TEST_CASE("MemoryStream round-trip", "[stream]") {
     MemoryStream s;
     const std::uint8_t msg[] = {1, 2, 3, 4, 5};

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -88,6 +88,19 @@ TEST_CASE("MemoryStream round-trip", "[stream]") {
     REQUIRE(eof.closed());
 }
 
+TEST_CASE("MemoryStream default starts open and empty",
+          "[stream][memory][coverage][phase3]") {
+    MemoryStream stream;
+    REQUIRE(stream.is_open());
+    REQUIRE(stream.size() == 0);
+    REQUIRE(stream.read_position() == 0);
+
+    std::uint8_t byte = 0;
+    auto result = stream.read(&byte, 1);
+    REQUIRE_FALSE(result.ok());
+    REQUIRE(result.closed());
+}
+
 TEST_CASE("MemoryStream partial read", "[stream]") {
     MemoryStream s(std::vector<std::uint8_t>{10, 20, 30, 40});
     std::uint8_t out[2]{};

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -50,6 +50,15 @@ TEST_CASE("StreamResult helper predicates classify errors",
     REQUIRE_FALSE(invalid.closed());
 }
 
+TEST_CASE("StreamResult factory preserves explicit zero-byte success",
+          "[stream][coverage][phase3]") {
+    auto result = StreamResult::make(0);
+    REQUIRE(result.ok());
+    REQUIRE_FALSE(result.would_block());
+    REQUIRE_FALSE(result.closed());
+    REQUIRE(result.bytes == 0);
+}
+
 TEST_CASE("MemoryStream round-trip", "[stream]") {
     MemoryStream s;
     const std::uint8_t msg[] = {1, 2, 3, 4, 5};

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -187,6 +187,17 @@ TEST_CASE("MemoryStream write preserves existing unread prefix",
     REQUIRE(out[1] == 30);
 }
 
+TEST_CASE("MemoryStream clear is idempotent on open streams",
+          "[stream][memory][coverage][phase3]") {
+    MemoryStream stream(std::vector<std::uint8_t>{1, 2, 3});
+    stream.clear();
+    stream.clear();
+
+    REQUIRE(stream.is_open());
+    REQUIRE(stream.size() == 0);
+    REQUIRE(stream.read_position() == 0);
+}
+
 TEST_CASE("MemoryStream close rejects further I/O", "[stream]") {
     MemoryStream s;
     s.close();

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -172,6 +172,21 @@ TEST_CASE("MemoryStream write copies caller storage",
     REQUIRE(stream.buffer() == std::vector<std::uint8_t>{1, 2, 3});
 }
 
+TEST_CASE("MemoryStream write preserves existing unread prefix",
+          "[stream][memory][coverage][phase3]") {
+    MemoryStream stream(std::vector<std::uint8_t>{10, 20, 30});
+    std::uint8_t out[2]{};
+    REQUIRE(stream.read(out, 1).bytes == 1);
+
+    const std::uint8_t suffix[] = {40, 50};
+    REQUIRE(stream.write(suffix, sizeof(suffix)).bytes == sizeof(suffix));
+    REQUIRE(stream.buffer() == std::vector<std::uint8_t>{10, 20, 30, 40, 50});
+
+    REQUIRE(stream.read(out, sizeof(out)).bytes == 2);
+    REQUIRE(out[0] == 20);
+    REQUIRE(out[1] == 30);
+}
+
 TEST_CASE("MemoryStream close rejects further I/O", "[stream]") {
     MemoryStream s;
     s.close();

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -147,6 +147,18 @@ TEST_CASE("MemoryStream rewind after EOF allows replay",
     REQUIRE(out[1] == 5);
 }
 
+TEST_CASE("MemoryStream close is idempotent",
+          "[stream][memory][coverage][phase3]") {
+    MemoryStream stream(std::vector<std::uint8_t>{1});
+    stream.close();
+    stream.close();
+
+    REQUIRE_FALSE(stream.is_open());
+    std::uint8_t byte = 0;
+    REQUIRE(stream.read(&byte, 1).closed());
+    REQUIRE(stream.write(&byte, 1).closed());
+}
+
 TEST_CASE("MemoryStream close rejects further I/O", "[stream]") {
     MemoryStream s;
     s.close();

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -198,6 +198,17 @@ TEST_CASE("MemoryStream clear is idempotent on open streams",
     REQUIRE(stream.read_position() == 0);
 }
 
+TEST_CASE("MemoryStream zero-byte write on closed stream reports closed",
+          "[stream][memory][coverage][phase3]") {
+    MemoryStream stream;
+    stream.close();
+
+    const std::uint8_t byte = 0;
+    auto result = stream.write(&byte, 0);
+    REQUIRE_FALSE(result.ok());
+    REQUIRE(result.closed());
+}
+
 TEST_CASE("MemoryStream close rejects further I/O", "[stream]") {
     MemoryStream s;
     s.close();


### PR DESCRIPTION
Phase 3 Codecov batch: deterministic runtime stream, expression, text diff, and range coverage.

Local validation:
- `cmake --build build --target pulp-test-stream pulp-test-runtime-utils`
- `./build/test/pulp-test-stream`
- `./build/test/pulp-test-runtime-utils`
- `git diff --check origin/main...HEAD`

Notes:
- GitHub-hosted CI only.
- Namespace dispatch intentionally not used.
