### PR TITLE
test: batch phase3 coverage for runtime parser edges

### DIFF
--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -50,6 +50,17 @@ TEST_CASE("Analytics disabled doesn't log", "[runtime][analytics]") {
     a.set_enabled(true);
 }
 
+TEST_CASE("Analytics exposes enabled state toggles",
+          "[runtime][analytics][coverage][phase3-batch742]") {
+    auto& a = Analytics::instance();
+
+    a.set_enabled(false);
+    REQUIRE_FALSE(a.is_enabled());
+
+    a.set_enabled(true);
+    REQUIRE(a.is_enabled());
+}
+
 TEST_CASE("Analytics log with properties", "[runtime][analytics]") {
     auto& a = Analytics::instance();
     uint64_t before = a.event_count();

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -215,6 +215,32 @@ TEST_CASE("FileAnalyticsDestination empty flush does not create output", "[runti
     REQUIRE_FALSE(std::filesystem::exists(path));
 }
 
+TEST_CASE("FileAnalyticsDestination keeps buffered events when open fails",
+          "[runtime][analytics][coverage][phase3-batch742]") {
+    auto root = std::filesystem::temp_directory_path() / "pulp_analytics_missing_parent_742";
+    auto path = root / "events.jsonl";
+    std::filesystem::remove_all(root);
+
+    FileAnalyticsDestination dest(path.string());
+    AnalyticsEvent event;
+    event.name = "retry";
+    event.timestamp = 42.0;
+    dest.log_event(event);
+
+    dest.flush();
+    REQUIRE_FALSE(std::filesystem::exists(path));
+
+    std::filesystem::create_directories(root);
+    dest.flush();
+
+    std::ifstream f(path);
+    std::string line;
+    REQUIRE(std::getline(f, line));
+    REQUIRE(line.find("\"event\":\"retry\"") != std::string::npos);
+
+    std::filesystem::remove_all(root);
+}
+
 TEST_CASE("FileAnalyticsDestination auto flushes at batch threshold", "[runtime][analytics]") {
     TemporaryFile tmp(".jsonl");
     FileAnalyticsDestination dest(tmp.path_string());

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -236,6 +236,21 @@ TEST_CASE("AES decrypt rejects empty ciphertext",
     REQUIRE_FALSE(result.has_value());
 }
 
+TEST_CASE("AES decrypt rejects explicit zero padding byte",
+          "[crypto][aes][coverage][phase3-batch742]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+
+    auto encrypted = aes_encrypt(nullptr, 0, key, iv);
+    REQUIRE(encrypted.has_value());
+
+    uint8_t tampered_iv[16] = {};
+    tampered_iv[15] = 0x10;
+
+    auto result = aes_decrypt(encrypted->data(), encrypted->size(), key, tampered_iv);
+    REQUIRE_FALSE(result.has_value());
+}
+
 TEST_CASE("AES decrypt rejects invalid PKCS7 padding bytes",
           "[crypto][aes][coverage][issue-641]") {
     uint8_t key[32] = {};

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -92,6 +92,16 @@ TEST_CASE("MD5 known value", "[crypto][md5]") {
     REQUIRE(hex == "5d41402abc4b2a76b9719d911017c592");
 }
 
+TEST_CASE("MD5 pointer overload handles empty input",
+          "[crypto][md5][coverage][phase3-batch742]") {
+    const std::vector<uint8_t> expected = {
+        0xd4, 0x1d, 0x8c, 0xd9, 0x8f, 0x00, 0xb2, 0x04,
+        0xe9, 0x80, 0x09, 0x98, 0xec, 0xf8, 0x42, 0x7e,
+    };
+
+    REQUIRE(md5(nullptr, 0) == expected);
+}
+
 TEST_CASE("MD5 binary data returns raw digest bytes",
           "[crypto][md5][coverage][issue-641]") {
     const std::vector<uint8_t> data = {0x00, 0xff, 0x10, 0x20, 0x00};

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -25,6 +25,15 @@ TEST_CASE("SHA-256 binary data", "[crypto][sha256]") {
     REQUIRE(digest.size() == 32);
 }
 
+TEST_CASE("SHA-256 pointer hex overload handles empty input",
+          "[crypto][sha256][coverage][phase3-batch742]") {
+    auto digest = sha256(nullptr, 0);
+    auto hex = sha256_hex(nullptr, 0);
+
+    REQUIRE(digest.size() == 32);
+    REQUIRE(hex == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
 TEST_CASE("SHA-256 pointer overload preserves embedded NUL bytes",
           "[crypto][sha256][coverage][issue-641]") {
     const std::vector<uint8_t> data = {'a', 'b', 'c', 0x00, 'd', 'e', 'f'};

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -50,6 +50,15 @@ TEST_CASE("SHA-256 pointer overload preserves embedded NUL bytes",
 
 // ── SHA-1 ───────────────────────────────────────────────────────────────
 
+TEST_CASE("SHA-1 empty string", "[crypto][sha1][coverage][phase3-batch742]") {
+    const std::vector<uint8_t> expected = {
+        0xda, 0x39, 0xa3, 0xee, 0x5e, 0x6b, 0x4b, 0x0d, 0x32, 0x55,
+        0xbf, 0xef, 0x95, 0x60, 0x18, 0x90, 0xaf, 0xd8, 0x07, 0x09,
+    };
+
+    REQUIRE(sha1("") == expected);
+}
+
 TEST_CASE("SHA-1 known value", "[crypto][sha1]") {
     auto digest = sha1("hello");
     const std::vector<uint8_t> expected = {

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -169,6 +169,23 @@ TEST_CASE("AES binary plaintext preserves embedded zero bytes",
     REQUIRE(*decrypted == plaintext);
 }
 
+TEST_CASE("AES one-byte plaintext round-trips with padding",
+          "[crypto][aes][coverage][phase3-batch742]") {
+    uint8_t key[32] = {};
+    uint8_t iv[16] = {};
+    std::memset(key, 0x11, 32);
+    std::memset(iv, 0x22, 16);
+
+    const uint8_t plaintext[] = {0x7b};
+    auto encrypted = aes_encrypt(plaintext, sizeof(plaintext), key, iv);
+    REQUIRE(encrypted.has_value());
+    REQUIRE(encrypted->size() == 16);
+
+    auto decrypted = aes_decrypt(encrypted->data(), encrypted->size(), key, iv);
+    REQUIRE(decrypted.has_value());
+    REQUIRE(*decrypted == std::vector<uint8_t>{0x7b});
+}
+
 TEST_CASE("AES exact block plaintext adds and removes full padding block",
           "[crypto][aes][coverage][issue-641]") {
     uint8_t key[32] = {};

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -251,6 +251,16 @@ TEST_CASE("i18n .strings parser permits empty keys",
     REQUIRE(strings.translate("") == "metadata");
 }
 
+TEST_CASE("i18n .strings load failure leaves existing translations intact",
+          "[runtime][i18n][coverage][phase3-batch742]") {
+    LocalisedStrings strings;
+    strings.add("existing", "kept");
+
+    REQUIRE_FALSE(strings.load_strings_file("/tmp/pulp_missing_strings_742.strings"));
+    REQUIRE(strings.count() == 1);
+    REQUIRE(strings.translate("existing") == "kept");
+}
+
 // ── .po file format ─────────────────────────────────────────────────────
 
 TEST_CASE("i18n load .po file", "[runtime][i18n]") {

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -373,6 +373,16 @@ TEST_CASE("i18n .po parser accepts empty msgid continuations",
     REQUIRE(strings.translate("prefix_suffix") == "value");
 }
 
+TEST_CASE("i18n .po load failure leaves translations intact",
+          "[runtime][i18n][coverage][phase3-batch742]") {
+    LocalisedStrings strings;
+    strings.add("existing", "kept");
+
+    REQUIRE_FALSE(strings.load_po_file("/tmp/pulp_missing_po_742.po"));
+    REQUIRE(strings.count() == 1);
+    REQUIRE(strings.translate("existing") == "kept");
+}
+
 // ── JSON file format ────────────────────────────────────────────────────
 
 TEST_CASE("i18n load JSON file", "[runtime][i18n]") {

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -455,6 +455,22 @@ TEST_CASE("i18n JSON parser rejects missing object opener", "[runtime][i18n]") {
     REQUIRE(strings.count() == 0);
 }
 
+TEST_CASE("i18n JSON load failure preserves existing translations",
+          "[runtime][i18n][coverage][phase3-batch742]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "[]";
+    }
+
+    LocalisedStrings strings;
+    strings.add("existing", "kept");
+
+    REQUIRE_FALSE(strings.load_json_file(tmp.path_string()));
+    REQUIRE(strings.count() == 1);
+    REQUIRE(strings.translate("existing") == "kept");
+}
+
 TEST_CASE("i18n JSON parser allows duplicate keys and trailing comma",
           "[runtime][i18n][issue-641]") {
     TemporaryFile tmp(".json");

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -72,6 +72,17 @@ TEST_CASE("i18n duplicate keys overwrite previous values", "[runtime][i18n][cove
     REQUIRE(strings.translate("mode") == "new");
 }
 
+TEST_CASE("i18n accepts empty in-memory keys", "[runtime][i18n][coverage][phase3-batch742]") {
+    LocalisedStrings strings;
+    strings.add("", "metadata");
+    strings.add("normal", "value");
+
+    REQUIRE(strings.count() == 2);
+    REQUIRE(strings.has(""));
+    REQUIRE(strings.translate("") == "metadata");
+    REQUIRE(strings.translate("normal") == "value");
+}
+
 TEST_CASE("i18n translate missing key returns key", "[runtime][i18n]") {
     LocalisedStrings strings;
     REQUIRE(strings.translate("missing_key") == "missing_key");

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -222,6 +222,14 @@ TEST_CASE("Typed identity nil and hashing are stable", "[runtime][identity][issu
     REQUIRE(objects.size() == 1);
 }
 
+TEST_CASE("Typed identity nil strings use canonical uuid format",
+          "[runtime][identity][coverage][phase3-batch742]") {
+    REQUIRE(SessionId::nil().to_string() == "00000000-0000-0000-0000-000000000000");
+    REQUIRE(RunId::nil().to_string() == "00000000-0000-0000-0000-000000000000");
+    REQUIRE(ObjectId::nil().to_string() == "00000000-0000-0000-0000-000000000000");
+    REQUIRE(CorrelationId::nil().to_string() == "00000000-0000-0000-0000-000000000000");
+}
+
 TEST_CASE("Typed identity wrappers compare and hash deterministic values",
           "[runtime][identity][coverage][phase3]") {
     auto first = ObjectId::from_string("00000000-0000-0000-0000-000000000001");

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -115,6 +115,13 @@ TEST_CASE("Uuid parsing rejects malformed dashed layout",
     REQUIRE(parsed.is_nil());
 }
 
+TEST_CASE("Uuid parsing rejects dashed strings with empty groups",
+          "[runtime][identity][coverage][phase3-batch742]") {
+    REQUIRE(Uuid::from_string("-0112233-4455-6677-8899-aabbccddeeff").is_nil());
+    REQUIRE(Uuid::from_string("00112233--455-6677-8899-aabbccddeeff").is_nil());
+    REQUIRE(Uuid::from_string("00112233-4455-6677-8899-aabbccddee-").is_nil());
+}
+
 TEST_CASE("Uuid parsing accepts uppercase dashed and compact hex",
           "[runtime][identity][issue-641]") {
     Uuid id;

--- a/test/test_identity.cpp
+++ b/test/test_identity.cpp
@@ -277,6 +277,14 @@ TEST_CASE("Typed transient identity wrappers hash deterministic values",
     REQUIRE(correlations.size() == 1);
 }
 
+TEST_CASE("Typed identity generated strings parse back where supported",
+          "[runtime][identity][coverage][phase3-batch742]") {
+    auto object = ObjectId::generate();
+
+    REQUIRE_FALSE(object.is_nil());
+    REQUIRE(ObjectId::from_string(object.to_string()) == object);
+}
+
 TEST_CASE("EventEnvelope defaults are nil and empty before attribution",
           "[runtime][identity][coverage][phase3]") {
     EventEnvelope env;

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -332,6 +332,22 @@ TEST_CASE("JsonRpcPeer rejects sends after direct channel close",
     REQUIRE_FALSE(callback_called);
 }
 
+TEST_CASE("JsonRpcPeer destructor detaches its message callback",
+          "[json_rpc][coverage][phase3-batch742]") {
+    auto pair = MemoryMessageChannel::make_pair();
+    std::string reply;
+    pair.second->on_message([&](const Message& message) {
+        reply.assign(message.as_text());
+    });
+
+    {
+        JsonRpcPeer client(*pair.first);
+    }
+
+    REQUIRE(pair.second->send_text("{not-json"));
+    REQUIRE(reply.empty());
+}
+
 TEST_CASE("JsonRpcPeer omits params for empty request payloads",
           "[json_rpc][coverage][issue-641]") {
     auto pair = MemoryMessageChannel::make_pair();

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -317,6 +317,21 @@ TEST_CASE("JsonRpcPeer reports closed and failed sends", "[json_rpc]") {
     REQUIRE_FALSE(callback_called);
 }
 
+TEST_CASE("JsonRpcPeer rejects sends after direct channel close",
+          "[json_rpc][coverage][phase3-batch742]") {
+    auto pair = MemoryMessageChannel::make_pair();
+    JsonRpcPeer client(*pair.first);
+
+    pair.first->close();
+
+    bool callback_called = false;
+    REQUIRE_FALSE(client.send_request("closed", "[]", [&](const JsonRpcResult&) {
+        callback_called = true;
+    }));
+    REQUIRE_FALSE(client.notify("closed", "[]"));
+    REQUIRE_FALSE(callback_called);
+}
+
 TEST_CASE("JsonRpcPeer omits params for empty request payloads",
           "[json_rpc][coverage][issue-641]") {
     auto pair = MemoryMessageChannel::make_pair();

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -165,6 +165,13 @@ TEST_CASE("LicenseValidator rejects undecodable payload", "[crypto][license]") {
     REQUIRE(validator.validate("###.sig") == LicenseStatus::InvalidFormat);
 }
 
+TEST_CASE("LicenseValidator rejects impossible base64 payload lengths",
+          "[crypto][license][coverage][phase3-batch742]") {
+    LicenseValidator validator;
+    REQUIRE(validator.validate("A.sig") == LicenseStatus::InvalidFormat);
+    REQUIRE_FALSE(validator.validate_and_parse("A.sig"));
+}
+
 TEST_CASE("LicenseValidator parse payload", "[crypto][license]") {
     LicenseValidator validator;
 

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -331,6 +331,14 @@ TEST_CASE("LicenseValidator validate rejects empty payload section",
     REQUIRE(validator.validate(".sig") == LicenseStatus::InvalidSignature);
 }
 
+TEST_CASE("LicenseValidator validate rejects an empty signature section",
+          "[crypto][license][coverage][phase3-batch742]") {
+    LicenseValidator validator;
+    std::string payload = "{\"product_id\":\"PulpSynth\"}";
+
+    REQUIRE(validator.validate(base64_encode(payload) + ".") == LicenseStatus::InvalidSignature);
+}
+
 TEST_CASE("LicenseValidator validate rejects malformed signature encoding",
           "[crypto][license][coverage][phase3-large]") {
     LicenseValidator validator;

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -358,6 +358,15 @@ TEST_CASE("LicenseValidator validate_and_parse accepts minimal product payload",
     REQUIRE(info->expiry_timestamp == 0);
 }
 
+TEST_CASE("LicenseValidator validate_and_parse ignores an empty signature section",
+          "[crypto][license][coverage][phase3-batch742]") {
+    LicenseValidator validator;
+    auto info = validator.validate_and_parse(base64_encode("{\"product_id\":\"PulpParseOnly\"}") + ".");
+
+    REQUIRE(info.has_value());
+    REQUIRE(info->product_id == "PulpParseOnly");
+}
+
 TEST_CASE("LicenseValidator validate_and_parse ignores malformed optional integers",
           "[crypto][license][coverage][phase3-large]") {
     LicenseValidator validator;

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -375,6 +375,16 @@ TEST_CASE("LicenseValidator validate_and_parse ignores an empty signature sectio
     REQUIRE(info->product_id == "PulpParseOnly");
 }
 
+TEST_CASE("LicenseValidator validate_and_parse keeps first dotted payload split",
+          "[crypto][license][coverage][phase3-batch742]") {
+    LicenseValidator validator;
+    std::string payload = "{\"product_id\":\"PulpDot\"}";
+    auto info = validator.validate_and_parse(base64_encode(payload) + ".sig.with.dots");
+
+    REQUIRE(info.has_value());
+    REQUIRE(info->product_id == "PulpDot");
+}
+
 TEST_CASE("LicenseValidator validate_and_parse ignores malformed optional integers",
           "[crypto][license][coverage][phase3-large]") {
     LicenseValidator validator;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -547,6 +547,14 @@ TEST_CASE("IPv4 validation accepts boundary octets",
     REQUIRE(is_valid_ipv4("255.255.255.255"));
 }
 
+TEST_CASE("IPv4 validation rejects malformed octet counts",
+          "[runtime][ip][coverage][phase3-batch742]") {
+    REQUIRE_FALSE(is_valid_ipv4(""));
+    REQUIRE_FALSE(is_valid_ipv4("127.0.0"));
+    REQUIRE_FALSE(is_valid_ipv4("127.0.0.1.2"));
+    REQUIRE_FALSE(is_valid_ipv4("127..0.1"));
+}
+
 // ── Expression ─────────────────────────────────────────────────────────
 
 TEST_CASE("Expression evaluator handles precedence and exponent edge cases",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -555,6 +555,14 @@ TEST_CASE("IPv4 validation rejects malformed octet counts",
     REQUIRE_FALSE(is_valid_ipv4("127..0.1"));
 }
 
+TEST_CASE("IPv4 validation rejects out-of-range and signed octets",
+          "[runtime][ip][coverage][phase3-batch742]") {
+    REQUIRE_FALSE(is_valid_ipv4("256.0.0.1"));
+    REQUIRE_FALSE(is_valid_ipv4("1.2.3.-4"));
+    REQUIRE_FALSE(is_valid_ipv4("+1.2.3.4"));
+    REQUIRE_FALSE(is_valid_ipv4("1.2.3.999"));
+}
+
 // ── Expression ─────────────────────────────────────────────────────────
 
 TEST_CASE("Expression evaluator handles precedence and exponent edge cases",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -8,6 +8,7 @@
 #include <pulp/runtime/base64.hpp>
 #include <pulp/runtime/expression.hpp>
 #include <pulp/runtime/http.hpp>
+#include <pulp/runtime/ip_address.hpp>
 #include <pulp/runtime/range.hpp>
 #include <pulp/runtime/scope_guard.hpp>
 #include <pulp/runtime/text_diff.hpp>
@@ -534,6 +535,16 @@ TEST_CASE("base64 handles explicit byte pointers and exact quartet decoding",
     auto quartet = base64_decode("////");
     REQUIRE(quartet.has_value());
     REQUIRE(*quartet == std::vector<uint8_t>{0xff, 0xff, 0xff});
+}
+
+// ── IP address helpers ─────────────────────────────────────────────────
+
+TEST_CASE("IPv4 validation accepts boundary octets",
+          "[runtime][ip][coverage][phase3-batch742]") {
+    REQUIRE(is_valid_ipv4("0.0.0.0"));
+    REQUIRE(is_valid_ipv4("127.0.0.1"));
+    REQUIRE(is_valid_ipv4("192.168.1.20"));
+    REQUIRE(is_valid_ipv4("255.255.255.255"));
 }
 
 // ── Expression ─────────────────────────────────────────────────────────

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -563,6 +563,14 @@ TEST_CASE("IPv4 validation rejects out-of-range and signed octets",
     REQUIRE_FALSE(is_valid_ipv4("1.2.3.999"));
 }
 
+TEST_CASE("IPv4 validation rejects whitespace-padded addresses",
+          "[runtime][ip][coverage][phase3-batch742]") {
+    REQUIRE_FALSE(is_valid_ipv4(" 127.0.0.1"));
+    REQUIRE_FALSE(is_valid_ipv4("127.0.0.1 "));
+    REQUIRE_FALSE(is_valid_ipv4("127.0.0.1\n"));
+    REQUIRE_FALSE(is_valid_ipv4("\t127.0.0.1"));
+}
+
 // ── Expression ─────────────────────────────────────────────────────────
 
 TEST_CASE("Expression evaluator handles precedence and exponent edge cases",


### PR DESCRIPTION
## Summary
- expands Phase 3 Codecov unit coverage with 24 focused runtime test commits
- covers i18n load failure preservation, JSON-RPC close/detach paths, analytics flush retry/state, IPv4 parser edges, license parser boundaries, crypto hash/AES edges, and identity formatting/parse edges
- keeps the batch local to existing deterministic unit targets to reduce CI fan-out

## Local validation
- `cmake --build build --target pulp-test-i18n pulp-test-json-rpc pulp-test-analytics pulp-test-runtime-utils pulp-test-license pulp-test-crypto pulp-test-identity`
- `./build/test/pulp-test-i18n`
- `./build/test/pulp-test-json-rpc`
- `./build/test/pulp-test-analytics`
- `./build/test/pulp-test-runtime-utils`
- `./build/test/pulp-test-license`
- `./build/test/pulp-test-crypto`
- `./build/test/pulp-test-identity`
- `git diff --check origin/main...HEAD`
