### PR TITLE
fix(release): supersede only past latest-published — stop SDK starvation cascade

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -432,6 +432,41 @@ jobs:
                   return None
               return r.stdout
 
+          # The 2026-05-18 starvation incident (pulp #2226 / this fix):
+          # the original supersede policy "cancel any tag strictly older
+          # than NEW_TAG" cascaded when main moved faster than
+          # release-cli.yml could finish. Every new tag cancelled the
+          # previous tag's release-cli, and itself got cancelled by the
+          # NEXT tag, leaving 10 SDK versions (v0.111.0 → v0.115.0)
+          # tagged-but-never-published. No watchdog caught it because
+          # release-cli was `cancelled` (not `failure`), draft was
+          # deleted (so draft-stuck didn't fire), and tag existed (so
+          # cadence-check was happy).
+          #
+          # New policy: never cancel any tag ≥ the LATEST PUBLISHED
+          # release. We only supersede builds that we already know are
+          # obsolete (the published `latest` link has moved past them).
+          # Until a newer release actually publishes, every in-flight
+          # build is a candidate to be the next published release —
+          # cancelling them is what creates the starvation.
+          raw = gh([
+              f"/repos/{REPO}/releases?per_page=100",
+              "--jq", ".[] | select(.draft == false) | .tag_name",
+          ])
+          latest_published = None
+          if raw:
+              for line in raw.strip().splitlines():
+                  v = parse(line.strip())
+                  if v and (latest_published is None or v > latest_published):
+                      latest_published = v
+
+          if latest_published is None:
+              print("No published release yet; skipping supersede entirely (cannot establish threshold).")
+              sys.exit(0)
+
+          print(f"Supersede threshold = latest published {latest_published} "
+                f"(new tag {new_ver} > threshold; will cancel runs < threshold only)")
+
           # Workflow IDs to scan. release-cli.yml + sign-and-release.yml.
           workflows = [
               ("release-cli.yml", "release-cli"),
@@ -462,15 +497,21 @@ jobs:
                   old_ver = parse(tag)
                   if not old_ver:
                       continue
-                  if old_ver >= new_ver:
+                  # Never cancel anything ≥ latest published. That tag
+                  # might be the next release; cancelling it is what
+                  # caused the v0.111..v0.115 starvation.
+                  if old_ver >= latest_published:
                       continue
-                  print(f"  superseding {wf_label} run {run['id']} (tag {tag} < {NEW_TAG}, status={run.get('status')})")
+                  print(f"  superseding {wf_label} run {run['id']} (tag {tag} < latest published {latest_published}, status={run.get('status')})")
                   subprocess.run([
                       "gh", "api", "-X", "POST",
                       f"/repos/{REPO}/actions/runs/{run['id']}/cancel",
                   ], capture_output=True)
 
-          # Delete strictly-older draft releases. Never touch published.
+          # Delete drafts strictly older than the latest PUBLISHED release.
+          # Never touch published. Never delete drafts ≥ latest published
+          # (those drafts might still publish — deleting them recreates
+          # the 2026-05-18 starvation).
           raw = gh([
               f"/repos/{REPO}/releases?per_page=50",
               "--jq", ".[] | select(.draft) | {id, tag: .tag_name}",
@@ -479,9 +520,9 @@ jobs:
               for line in raw.strip().splitlines():
                   rel = json.loads(line)
                   old_ver = parse(rel["tag"])
-                  if not old_ver or old_ver >= new_ver:
+                  if not old_ver or old_ver >= latest_published:
                       continue
-                  print(f"  deleting draft release {rel['tag']} (id {rel['id']})")
+                  print(f"  deleting draft release {rel['tag']} (id {rel['id']}; < latest published {latest_published})")
                   subprocess.run([
                       "gh", "api", "-X", "DELETE",
                       f"/repos/{REPO}/releases/{rel['id']}",

--- a/.github/workflows/release-draft-stuck-check.yml
+++ b/.github/workflows/release-draft-stuck-check.yml
@@ -120,12 +120,20 @@ jobs:
                   return None
               return tuple(int(g) for g in m.groups())
 
-          # Find the newest semver tag we know about (any draft state).
-          newest = None
+          # 2026-05-18 fix (pulp #2226): "superseded" must be relative
+          # to the latest PUBLISHED release, not any newer tag. The old
+          # criterion ("a strictly-newer semver tag exists in the set")
+          # silently suppressed legitimate stuck-draft alerts whenever
+          # *any* newer tag (even another stuck draft) existed. Combined
+          # with the auto-release.yml supersede bug, this hid the
+          # v0.111..v0.115 starvation completely.
+          newest_published = None
           for r in rels:
+              if r.get('draft'):
+                  continue
               v = parse(r.get('tag_name', ''))
-              if v and (newest is None or v > newest):
-                  newest = v
+              if v and (newest_published is None or v > newest_published):
+                  newest_published = v
 
           for r in rels:
               tag = r.get('tag_name') or ''
@@ -133,10 +141,15 @@ jobs:
               created = r.get('created_at') or ''
               if not tag:
                   continue
-              # Mark as superseded if a strictly-newer semver tag exists
-              # in the releases set. Downstream awk reads the fourth col.
+              # Mark as superseded only if a strictly-newer PUBLISHED tag
+              # exists. A newer draft does NOT supersede — it might be
+              # stuck too. Downstream awk reads the fourth col.
               v = parse(tag)
-              superseded = (v is not None and newest is not None and v < newest)
+              superseded = (
+                  v is not None
+                  and newest_published is not None
+                  and v < newest_published
+              )
               print('\t'.join([tag, str(draft).lower(), created, str(superseded).lower()]))
           PY
           )


### PR DESCRIPTION
Stops the v0.111..v0.115 starvation cascade that left 10 SDK tags without published releases.

## Root cause

PR #2075's "Supersede older in-flight release builds" step in `auto-release.yml` cascaded under high merge cadence: when main moves faster than `release-cli.yml` can finish (~10-15 min between pushes; release-cli takes 30+ min), every new tag cancelled the previous tag's `release-cli`, and itself got cancelled by the next tag. Confirmed: 10/10 tags from v0.111 onward had their release-cli `cancelled`. No watchdog caught it — release-cli was `cancelled` not `failure`, drafts were deleted (so draft-stuck didn't fire), and tags existed (so cadence-check was happy). Perfect blind spot.

## Fix

**.github/workflows/auto-release.yml**: change supersede criterion from "strictly older than NEW_TAG" to "strictly older than the LATEST PUBLISHED release." Builds for tags between latest-published and HEAD might still be the next release — cancelling them is what creates the starvation.

**.github/workflows/release-draft-stuck-check.yml**: change "superseded" filter from "any newer SemVer tag" to "any newer PUBLISHED tag." A newer draft doesn't supersede — it might be stuck too.

## Containment

\`PULP_RELEASE_MODE=land-all\` repo var already set as immediate containment so v0.115.0's queued release-cli can finish. Variable can be removed once this PR merges.

## Recovery

Scope: just v0.115.0 (current main HEAD per user direction). Backfilling v0.111..v0.114 burns the exact macos-15 minutes the supersede was trying to save and consumers don't need historical SDKs.

## Codex consult

Diagnosed + designed via /codex-consult (high effort) — confirmed root cause, recommended this fix shape, flagged the watchdog gap as a separate defense-in-depth issue.

## Deferred follow-ups (not in this PR)

- Add "git tag exists with NO release" scan to release-draft-stuck-check.yml (would have caught this starvation too).
- Post-action asset guards (assert draft exists after sign-and-release; assert non-draft + SDK assets after release-cli).