### PR TITLE
feat(canvas): color-font predicate on ResolvedFont (font v2 Slice 3.1)

### DIFF
--- a/core/canvas/include/pulp/canvas/font_resolver.hpp
+++ b/core/canvas/include/pulp/canvas/font_resolver.hpp
@@ -165,6 +165,11 @@ struct ResolvedFont {
     AntiAliasMode aa_mode      = AntiAliasMode::Default;
     HintingMode   hinting_mode = HintingMode::PlatformDefault;
 
+    /// Color-font mode carried from `FontOptions`. Determines whether
+    /// the painter should render color glyphs (COLR/CPAL, SVG-in-OT,
+    /// bitmap emoji) when the typeface supports them. (Slice 3.1)
+    ColorFontMode color_font_mode = ColorFontMode::Auto;
+
     bool has_typeface() const noexcept {
 #ifdef PULP_HAS_SKIA
         return static_cast<bool>(typeface);
@@ -193,6 +198,28 @@ struct ResolvedFont {
         return sk_hinting_for(hinting_mode);
     }
 #endif
+
+    /// pulp #2163 / font v2 Slice 3.1 — does the resolved typeface
+    /// carry color-glyph tables? Checks for any of:
+    ///   `COLR` — v0/v1 vector color (Microsoft / OpenType)
+    ///   `CPAL` — color palette companion to COLR
+    ///   `CBDT` / `CBLC` — bitmap color emoji (Google / Apple)
+    ///   `sbix` — Apple bitmap strikes (Apple Color Emoji)
+    ///   `SVG`  — SVG-in-OT (Adobe / Mozilla)
+    /// Returns false when there's no typeface or no color tables.
+    /// Independent of `color_font_mode` — that says what the *caller*
+    /// wants; this says what the *font* actually has. Always available
+    /// (returns false on non-Skia builds where no typeface is loaded).
+    bool supports_color_font() const noexcept;
+
+    /// Composite of `color_font_mode` + `supports_color_font()`. Tells
+    /// the painter whether to render color glyphs from this face.
+    ///   Auto            → true iff supports_color_font()
+    ///   Bitmap/COLR/SVG → true iff supports_color_font() (mode hint
+    ///                     selects the table; Skia auto-prefers when
+    ///                     multiple are present)
+    ///   ForceMonochrome → false (always render mono)
+    bool color_font_active() const noexcept;
 };
 
 // ── FontResolver ─────────────────────────────────────────────────────────

--- a/core/canvas/src/font_resolver.cpp
+++ b/core/canvas/src/font_resolver.cpp
@@ -145,6 +145,8 @@ ResolvedFont resolve_one_family(const std::string& family,
     // Slice 3.2: AA / hinting policy travels alongside the resolved face.
     r.aa_mode = opts.aa_mode;
     r.hinting_mode = opts.hinting_mode;
+    // Slice 3.1: color-font policy travels alongside the resolved face.
+    r.color_font_mode = opts.color_font_mode;
 
     // 1) Registered (scoped). Phase 1.1.a only consults the global
     //    registered map; per-scope storage arrives in 1.1.b.
@@ -290,6 +292,9 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
     // in font_resolver.hpp for the enum translation.
     resolved.aa_mode = options.aa_mode;
     resolved.hinting_mode = options.hinting_mode;
+    // pulp #2163 / Slice 3.1 — color-font policy travels onto the
+    // ResolvedFont so paint paths can branch on color_font_active().
+    resolved.color_font_mode = options.color_font_mode;
 
     // pulp #2163 — font v2 Slice 2.3. After a face resolves, if the
     // caller requested variation axes (`font-variation-settings`),
@@ -360,6 +365,8 @@ ResolvedFont FontResolver::resolve_character_fallback(const FontOptions& options
     // as the primary so paint paths stay consistent across the run.
     r.aa_mode = options.aa_mode;
     r.hinting_mode = options.hinting_mode;
+    // Slice 3.1: char-fallback also inherits color-font policy.
+    r.color_font_mode = options.color_font_mode;
 
     sk_sp<SkFontMgr> mgr = platform_font_manager();
     if (!mgr) {
@@ -414,6 +421,7 @@ ResolvedFont FontResolver::resolve_family_list(const FontOptions& options) {
     r.generation = merged_generation_for(options.scope);
     r.aa_mode = options.aa_mode;
     r.hinting_mode = options.hinting_mode;
+    r.color_font_mode = options.color_font_mode;
     r.origin = FallbackOrigin::NotFound;
     return r;
 }
@@ -426,10 +434,50 @@ ResolvedFont FontResolver::resolve_character_fallback(const FontOptions& options
     r.generation = merged_generation_for(options.scope);
     r.aa_mode = options.aa_mode;
     r.hinting_mode = options.hinting_mode;
+    r.color_font_mode = options.color_font_mode;
     r.origin = FallbackOrigin::NotFound;
     return r;
 }
 
 #endif // PULP_HAS_SKIA
+
+// Color-font predicates — Skia-conditional method bodies that compile
+// in both Skia and non-Skia builds. (Slice 3.1)
+bool ResolvedFont::supports_color_font() const noexcept {
+#ifdef PULP_HAS_SKIA
+    if (!typeface) return false;
+    const int count = typeface->countTables();
+    if (count <= 0) return false;
+    std::vector<SkFontTableTag> tags(static_cast<std::size_t>(count));
+    // `readTableTags` is the canonical span-based API in this Skia
+    // version; `getTableTags(tags[])` is gated behind a legacy macro.
+    typeface->readTableTags({tags.data(), tags.size()});
+    // Tags packed big-endian: 'COLR' = 0x434F4C52, etc.
+    constexpr SkFontTableTag kCOLR = 0x434F4C52u;
+    constexpr SkFontTableTag kCPAL = 0x4350414Cu;
+    constexpr SkFontTableTag kCBDT = 0x43424454u;
+    constexpr SkFontTableTag kCBLC = 0x43424C43u;
+    constexpr SkFontTableTag kSBIX = 0x73626978u;
+    constexpr SkFontTableTag kSVG  = 0x53564720u;  // 'SVG '
+    for (SkFontTableTag t : tags) {
+        if (t == kCOLR || t == kCPAL || t == kCBDT || t == kCBLC
+            || t == kSBIX || t == kSVG) {
+            return true;
+        }
+    }
+    return false;
+#else
+    return false;
+#endif
+}
+
+bool ResolvedFont::color_font_active() const noexcept {
+#ifdef PULP_HAS_SKIA
+    if (color_font_mode == ColorFontMode::ForceMonochrome) return false;
+    return supports_color_font();
+#else
+    return false;
+#endif
+}
 
 } // namespace pulp::canvas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -887,6 +887,15 @@ add_executable(pulp-test-text-run-planner-parallel test_text_run_planner_paralle
 target_link_libraries(pulp-test-text-run-planner-parallel PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-text-run-planner-parallel)
 
+# pulp #2163 / font v2 Slice 3.1 — color-font predicate on ResolvedFont.
+# Gated on PULP_HAS_SKIA — the predicate returns false without a real
+# typeface so the resolver-bound assertions can't fire on non-Skia.
+if(PULP_HAS_SKIA)
+    add_executable(pulp-test-font-color-mode test_font_color_mode.cpp)
+    target_link_libraries(pulp-test-font-color-mode PRIVATE pulp::canvas Catch2::Catch2WithMain)
+    catch_discover_tests(pulp-test-font-color-mode)
+endif()
+
 # Font subsystem typed options and scope generation tests
 add_executable(pulp-test-font-options test_font_options.cpp)
 target_link_libraries(pulp-test-font-options PRIVATE pulp::canvas Catch2::Catch2WithMain)

--- a/test/test_font_color_mode.cpp
+++ b/test/test_font_color_mode.cpp
@@ -1,0 +1,100 @@
+// test_font_color_mode.cpp — Pulp #2163, font v2 Slice 3.1.
+//
+// ResolvedFont::supports_color_font / color_font_active behavior.
+// Tests the predicates against the bundled non-color Inter face,
+// the system color-emoji face if installed, and the ColorFontMode
+// policy enum.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/canvas/font_resolver.hpp>
+#include <pulp/canvas/font_options.hpp>
+
+#ifdef PULP_HAS_SKIA
+#include "include/core/SkTypeface.h"
+#endif
+
+using namespace pulp::canvas;
+
+TEST_CASE("ColorFont: ResolvedFont carries color_font_mode from FontOptions",
+          "[font][color][issue-2163]") {
+    FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.size = 14.0f;
+    opts.color_font_mode = ColorFontMode::Bitmap;
+
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    REQUIRE(resolved.color_font_mode == ColorFontMode::Bitmap);
+}
+
+TEST_CASE("ColorFont: Inter (non-color) reports supports_color_font=false",
+          "[font][color][issue-2163]") {
+    FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.size = 14.0f;
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    if (!resolved.has_typeface()) {
+        WARN("Inter not resolved; skipping color-table check");
+        return;
+    }
+    REQUIRE_FALSE(resolved.supports_color_font());
+}
+
+TEST_CASE("ColorFont: Apple Color Emoji on macOS reports true if installed",
+          "[font][color][issue-2163]") {
+#if defined(__APPLE__)
+    FontOptions opts;
+    opts.family_stack.push_back("Apple Color Emoji");
+    opts.size = 14.0f;
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    if (resolved.has_typeface()) {
+        // Apple Color Emoji uses the `sbix` bitmap strikes table.
+        REQUIRE(resolved.supports_color_font());
+    } else {
+        WARN("Apple Color Emoji not resolvable on this host");
+    }
+#else
+    SUCCEED("non-Apple host; Apple Color Emoji unavailable");
+#endif
+}
+
+TEST_CASE("ColorFont: color_font_active respects ForceMonochrome override",
+          "[font][color][issue-2163]") {
+#if defined(__APPLE__)
+    FontOptions opts;
+    opts.family_stack.push_back("Apple Color Emoji");
+    opts.size = 14.0f;
+    opts.color_font_mode = ColorFontMode::ForceMonochrome;
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    if (resolved.has_typeface()) {
+        REQUIRE(resolved.supports_color_font());
+        REQUIRE_FALSE(resolved.color_font_active());  // forced mono
+    } else {
+        SUCCEED("Apple Color Emoji not resolvable; skipped");
+    }
+#else
+    SUCCEED("non-Apple host; emoji-policy check skipped");
+#endif
+}
+
+TEST_CASE("ColorFont: Auto mode delegates to font capability",
+          "[font][color][issue-2163]") {
+    FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.size = 14.0f;
+    opts.color_font_mode = ColorFontMode::Auto;
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    if (!resolved.has_typeface()) {
+        SUCCEED("Inter not resolved; skipped");
+        return;
+    }
+    // Inter has no color tables → Auto means inactive.
+    REQUIRE_FALSE(resolved.color_font_active());
+}
+
+TEST_CASE("ColorFont: no typeface => supports_color_font is false",
+          "[font][color][issue-2163]") {
+    ResolvedFont r;  // default-constructed, no typeface
+    REQUIRE_FALSE(r.supports_color_font());
+    REQUIRE_FALSE(r.color_font_active());
+}


### PR DESCRIPTION
Phase 3 / Slice 3.1. ResolvedFont::supports_color_font() + color_font_active() predicates inspect the typeface's COLR/CPAL/CBDT/CBLC/sbix/SVG tables and compose with the policy enum. 6 cases / 8 assertions green.