### PR TITLE
feat(canvas): WOFF2 runtime decoding (font v2 Slice 3.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.57.0",
+      "version": "0.58.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.57.0"
+  "version": "0.58.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.126.0
+    VERSION 0.127.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/include/pulp/canvas/bundled_fonts.hpp
+++ b/core/canvas/include/pulp/canvas/bundled_fonts.hpp
@@ -137,10 +137,38 @@ std::future<FontState> register_font_url(const std::string& url,
 
 /// Slice 3.5 — register a WOFF2-compressed font at runtime. Gated on
 /// the Phase 2 sanitizer (validate_font_bytes); rejects malformed
-/// payloads cleanly. Skeleton returns false; the implementation slice
-/// wires Brotli decompression behind the budget + consent path.
+/// payloads cleanly.
+///
+/// Behaviour today (security-gated, detection-only):
+///   * Null / empty input → false.
+///   * Bytes whose first 4 bytes are not the WOFF2 magic (`wOF2`,
+///     0x774F4632 big-endian) → false. This is the structural reject
+///     path and works on every build.
+///   * Bytes WITH valid WOFF2 magic, when no Brotli/woff2 decoder is
+///     linked into the build → false. Callers can probe this case
+///     ahead of time via `woff2_decoder_available()` and route
+///     through `register_font(...)` with a pre-decoded TTF/OTF
+///     payload instead.
+///   * Bytes WITH valid WOFF2 magic when a decoder IS linked → the
+///     payload is decompressed, validated via `validate_font_bytes`,
+///     and forwarded to `register_font(...)`.
+///
+/// Vendoring an in-tree woff2/Brotli decoder is intentionally deferred:
+/// Pulp's MIT release stays free of large third-party blobs until a
+/// real workload demands one. See `planning/2026-05-18-font-hardening-
+/// phase23-execution-plan.md` Slice 3.5.
 bool register_font_woff2(const std::uint8_t* woff2_data, std::size_t size,
                          const std::string& family_override = "");
+
+/// Slice 3.5 — runtime check for WOFF2 decoder availability. Returns
+/// `false` on builds where no Brotli/woff2 implementation is linked,
+/// meaning `register_font_woff2(...)` cannot succeed regardless of
+/// input. Callers can use this to fall back to a pre-decoded TTF/OTF
+/// payload registered via `register_font(...)` instead.
+///
+/// Available on every build (Skia or no Skia), so plugin startup can
+/// branch on it without `#ifdef`s leaking into user code.
+bool woff2_decoder_available() noexcept;
 
 /// Slice 3.6 — grapheme-aware cursor step for TextEditor. Returns the
 /// UTF-8 byte offset of the cluster boundary one step forward (or

--- a/core/canvas/src/bundled_fonts.cpp
+++ b/core/canvas/src/bundled_fonts.cpp
@@ -433,6 +433,84 @@ bool is_font_registered(const std::string& family) {
     return map.find(family) != map.end();
 }
 
+// pulp #2163 — font v2 Slice 3.5. WOFF2 runtime decoding.
+//
+// Pulp doesn't currently vendor Brotli or the Google `woff2` library,
+// and the prebuilt Skia we ship is configured without its WOFF2
+// converter exposed as a public symbol. That means the actual
+// decompression step is gated on `__has_include(<woff2/decode.h>)` —
+// if a downstream build vendors `external/woff2/` and links it into
+// `pulp-canvas`, the real path lights up automatically; otherwise the
+// surface stays at "structural-detect + fail cleanly", which is still
+// a strict improvement over the pre-3.5 unconditional `return false`
+// because callers can now distinguish "not a WOFF2 file" from
+// "WOFF2 file but no decoder linked" via `woff2_decoder_available()`.
+//
+// WOFF2 file signature is the 4-byte tag 'wOF2' = 0x77_4F_46_32 read
+// big-endian at offset 0. See W3C WOFF2 §3, table 1.
+namespace {
+constexpr std::uint32_t kWoff2Magic = 0x774F4632u; // 'wOF2'
+} // namespace
+
+#if __has_include(<woff2/decode.h>)
+#include <woff2/decode.h>
+#define PULP_WOFF2_DECODER 1
+#else
+#define PULP_WOFF2_DECODER 0
+#endif
+
+bool woff2_decoder_available() noexcept {
+#if PULP_WOFF2_DECODER
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool register_font_woff2(const std::uint8_t* woff2_data, std::size_t size,
+                         const std::string& family_override) {
+    // Null or too-short to hold the 4-byte signature → not a WOFF2
+    // file at all. Reject before we even probe the decoder so that
+    // truncated/garbage input returns false on every build.
+    if (!woff2_data || size < 4) return false;
+
+    const std::uint32_t magic =
+        (static_cast<std::uint32_t>(woff2_data[0]) << 24)
+      | (static_cast<std::uint32_t>(woff2_data[1]) << 16)
+      | (static_cast<std::uint32_t>(woff2_data[2]) <<  8)
+      |  static_cast<std::uint32_t>(woff2_data[3]);
+    if (magic != kWoff2Magic) return false;
+
+#if PULP_WOFF2_DECODER
+    // Real path: WOFF2 → sfnt → validator → register_font.
+    //
+    // The Google woff2 library exposes `ComputeWOFF2FinalSize` so we
+    // can pre-size the output buffer, and `ConvertWOFF2ToTTF` for the
+    // actual decompress. A WOFF2 header capping at 30MB is plenty for
+    // any reasonable plugin font; reject anything larger to keep the
+    // memory pressure bounded against hostile payloads. The Phase 2
+    // sanitizer (`validate_font_bytes`) runs on the decompressed sfnt
+    // before we touch Skia.
+    constexpr std::size_t kMaxDecompressed = 30u * 1024u * 1024u;
+    std::size_t out_size = woff2::ComputeWOFF2FinalSize(woff2_data, size);
+    if (out_size == 0 || out_size > kMaxDecompressed) return false;
+
+    std::vector<std::uint8_t> sfnt(out_size);
+    if (!woff2::ConvertWOFF2ToTTF(sfnt.data(), out_size, woff2_data, size)) {
+        return false;
+    }
+    if (!validate_font_bytes(sfnt.data(), out_size)) return false;
+    return register_font(sfnt.data(), out_size, family_override);
+#else
+    // No decoder linked. The bytes look like a WOFF2 file but we
+    // cannot decompress them on this build. Caller should consult
+    // `woff2_decoder_available()` and fall back to a pre-decoded
+    // TTF/OTF via `register_font(...)`.
+    (void)family_override;
+    return false;
+#endif
+}
+
 std::uint64_t font_registration_generation() noexcept {
     return registration_generation().load(std::memory_order_acquire);
 }

--- a/core/canvas/src/font_registry_stubs.cpp
+++ b/core/canvas/src/font_registry_stubs.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <future>
 #include <string>
 
 namespace pulp::canvas {
@@ -259,6 +260,17 @@ bool register_font_file(const std::string&, const std::string&) {
     return false;
 }
 
+// pulp #2163 — font v2 Slice 2.1 (non-Skia). register_font_url has
+// no register_font to land on, so every URL resolves to Failed.
+// Matches the contract of the Skia-side implementation: never block
+// the caller, always return a ready future.
+std::future<FontState> register_font_url(const std::string&,
+                                         const std::string&) {
+    std::promise<FontState> p;
+    p.set_value(FontState::Failed);
+    return p.get_future();
+}
+
 bool is_font_registered(const std::string&) {
     return false;
 }
@@ -273,9 +285,35 @@ bool validate_font_bytes(const std::uint8_t* data, std::size_t size) {
     return data != nullptr && size > 0;
 }
 
-// pulp #2163 — font v2 Phase 3 skeletons.
-bool register_font_woff2(const std::uint8_t*, std::size_t, const std::string&) {
-    return false;  // Phase 3 impl wires Brotli decompression + sanitizer.
+// pulp #2163 — font v2 Slice 3.5 (non-Skia). Without Skia we can't
+// register a typeface even if we had a decoder, so the result is
+// always false. Still validates the WOFF2 magic bytes so the
+// "is this even a WOFF2 file?" test surface returns the same answer
+// on both Skia and non-Skia builds — that property keeps the
+// `register_font_woff2` test suite uniform regardless of how Skia
+// was configured.
+bool register_font_woff2(const std::uint8_t* woff2_data, std::size_t size,
+                         const std::string&) {
+    if (!woff2_data || size < 4) return false;
+    const std::uint32_t magic =
+        (static_cast<std::uint32_t>(woff2_data[0]) << 24)
+      | (static_cast<std::uint32_t>(woff2_data[1]) << 16)
+      | (static_cast<std::uint32_t>(woff2_data[2]) <<  8)
+      |  static_cast<std::uint32_t>(woff2_data[3]);
+    if (magic != 0x774F4632u) return false;   // 'wOF2'
+    // Magic is correct but we have neither a decoder nor Skia to
+    // hand the result to. Surface as a clean failure; consult
+    // `woff2_decoder_available()` ahead of time to avoid this path.
+    return false;
+}
+
+bool woff2_decoder_available() noexcept {
+    // Non-Skia builds never carry the decoder regardless of whether
+    // `<woff2/decode.h>` happens to be present in the include path,
+    // because `register_font_woff2` has nowhere to land the
+    // decompressed sfnt — `register_font` is itself a `return false`
+    // stub on this build.
+    return false;
 }
 
 } // namespace pulp::canvas

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -892,6 +892,13 @@ add_executable(pulp-test-font-async-lifecycle test_font_async_lifecycle.cpp)
 target_link_libraries(pulp-test-font-async-lifecycle PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-font-async-lifecycle)
 
+# pulp #2163 / font v2 Slice 3.5 — WOFF2 runtime decoding (security-gated).
+# Structural rejection + decoder-availability probe; no Skia link
+# required because the negative paths are universal.
+add_executable(pulp-test-font-woff2 test_font_woff2.cpp)
+target_link_libraries(pulp-test-font-woff2 PRIVATE pulp::canvas Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-font-woff2)
+
 # pulp #2163 / font v2 Slice 3.1 — color-font predicate on ResolvedFont.
 # Gated on PULP_HAS_SKIA — the predicate returns false without a real
 # typeface so the resolver-bound assertions can't fire on non-Skia.

--- a/test/test_font_woff2.cpp
+++ b/test/test_font_woff2.cpp
@@ -1,0 +1,111 @@
+// test_font_woff2.cpp — Pulp #2163, font v2 Slice 3.5.
+//
+// Exercises the structural-rejection contract of
+// `pulp::canvas::register_font_woff2(...)` and the
+// `woff2_decoder_available()` feature probe. These tests are
+// deliberately decoder-agnostic: the negative paths (null, empty,
+// wrong-magic, truncated payload) must return false on every build
+// regardless of whether a Brotli/woff2 implementation is linked in.
+//
+// Building a real .woff2 fixture would require an actual encoder,
+// which Pulp does not ship. We test the structural surface only —
+// that's the point of Slice 3.5: even when full decompression is
+// unavailable, callers can still reliably distinguish "this isn't a
+// WOFF2 file" from "this is a WOFF2 file but the build can't process
+// it" through `woff2_decoder_available()`.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/canvas/bundled_fonts.hpp>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+using pulp::canvas::register_font_woff2;
+using pulp::canvas::woff2_decoder_available;
+
+namespace {
+
+// 'wOF2' big-endian.
+constexpr std::array<std::uint8_t, 4> kWoff2Magic = {0x77, 0x4F, 0x46, 0x32};
+
+// TrueType (sfnt) magic — definitely NOT WOFF2. register_font_woff2
+// must reject these even though they're a perfectly valid sfnt.
+constexpr std::array<std::uint8_t, 4> kSfntMagic  = {0x00, 0x01, 0x00, 0x00};
+
+} // namespace
+
+TEST_CASE("register_font_woff2: null pointer is rejected",
+          "[font][woff2][issue-2163]") {
+    REQUIRE_FALSE(register_font_woff2(nullptr, 0, ""));
+    REQUIRE_FALSE(register_font_woff2(nullptr, 4096, ""));
+}
+
+TEST_CASE("register_font_woff2: empty buffer is rejected",
+          "[font][woff2][issue-2163]") {
+    const std::uint8_t dummy = 0;
+    REQUIRE_FALSE(register_font_woff2(&dummy, 0, ""));
+}
+
+TEST_CASE("register_font_woff2: input shorter than the 4-byte magic is rejected",
+          "[font][woff2][issue-2163]") {
+    // Three bytes that happen to match the first three of `wOF2`.
+    // Without the fourth byte we cannot trust the signature, so the
+    // implementation must refuse — never read past the buffer.
+    std::array<std::uint8_t, 3> too_short = {0x77, 0x4F, 0x46};
+    REQUIRE_FALSE(register_font_woff2(too_short.data(), too_short.size(), ""));
+}
+
+TEST_CASE("register_font_woff2: TTF/sfnt magic is rejected (not WOFF2)",
+          "[font][woff2][issue-2163]") {
+    // 0x00 0x01 0x00 0x00 is a perfectly good TTF header — but this
+    // entry point is specifically for WOFF2-compressed input, so the
+    // wrong magic must be refused. Callers with raw TTF bytes should
+    // route through register_font(...) instead.
+    std::vector<std::uint8_t> bytes(kSfntMagic.begin(), kSfntMagic.end());
+    bytes.resize(64, 0);
+    REQUIRE_FALSE(register_font_woff2(bytes.data(), bytes.size(), ""));
+
+    // 'OTTO' (CFF/OpenType) — same rejection.
+    std::array<std::uint8_t, 4> otto = {'O', 'T', 'T', 'O'};
+    std::vector<std::uint8_t> otto_buf(otto.begin(), otto.end());
+    otto_buf.resize(64, 0);
+    REQUIRE_FALSE(register_font_woff2(otto_buf.data(), otto_buf.size(), ""));
+}
+
+TEST_CASE("register_font_woff2: valid magic + truncated payload is rejected",
+          "[font][woff2][issue-2163]") {
+    // The magic is correct so the structural pre-check passes, but
+    // there's no real WOFF2 header / Brotli stream behind it. On a
+    // build with a real decoder linked, ComputeWOFF2FinalSize returns
+    // 0 (header parse fails) and we reject. On a build without a
+    // decoder, the "no decoder linked" branch returns false. Either
+    // way the contract is the same: garbage with a correct magic
+    // must NOT be accepted.
+    std::vector<std::uint8_t> bytes(kWoff2Magic.begin(), kWoff2Magic.end());
+    bytes.resize(128, 0);
+    REQUIRE_FALSE(register_font_woff2(bytes.data(), bytes.size(), ""));
+
+    // Same family-override path.
+    REQUIRE_FALSE(register_font_woff2(bytes.data(), bytes.size(), "Acme Sans"));
+}
+
+TEST_CASE("woff2_decoder_available: returns a stable bool",
+          "[font][woff2][issue-2163]") {
+    // We don't hard-assert true or false because the answer depends on
+    // build configuration (Skia + a vendored woff2/ in external/). We
+    // assert the answer is stable across calls and that, if it claims
+    // unavailable, register_font_woff2 still rejects the structural
+    // failure modes — the universally-covered contract.
+    const bool first  = woff2_decoder_available();
+    const bool second = woff2_decoder_available();
+    REQUIRE(first == second);
+
+    // Structural rejection holds regardless of decoder availability.
+    REQUIRE_FALSE(register_font_woff2(nullptr, 0, ""));
+
+    std::vector<std::uint8_t> not_woff2(kSfntMagic.begin(), kSfntMagic.end());
+    not_woff2.resize(32, 0);
+    REQUIRE_FALSE(register_font_woff2(not_woff2.data(), not_woff2.size(), ""));
+}


### PR DESCRIPTION
## Summary

Slice 3.5 of font hardening v2 (pulp #2163) — wires `register_font_woff2(...)` as a security-gated structural decoder and adds a public `woff2_decoder_available()` feature probe.

## Scope

- Header: `woff2_decoder_available() noexcept` and updated contract docs for `register_font_woff2`.
- Impl (Skia path, `bundled_fonts.cpp`):
  - Always reject null / too-short / wrong-magic input (the universal contract).
  - Decoder path gated on `__has_include(<woff2/decode.h>)`: if a build vendors `external/woff2/`, decompress (bounded at 30MB), run through `validate_font_bytes`, forward to `register_font`.
  - Otherwise (today, default) return false after the magic check.
- Impl (non-Skia stub, `font_registry_stubs.cpp`): same structural pre-check, `woff2_decoder_available()` returns `false` since `register_font` itself is a stub.
- Tests: `test/test_font_woff2.cpp` covers null/empty/too-short/wrong-magic/valid-magic-bad-payload and probe stability. No Skia link required.

## Caveats

Pulp does not currently vendor Brotli or the Google `woff2` library, so today's behaviour is **structural-rejection + clean-fail**. That is still a strict improvement: callers can now distinguish "not a WOFF2 file" from "WOFF2 file but no decoder linked" via `woff2_decoder_available()` and fall back to a pre-decoded TTF/OTF through `register_font(...)`. A downstream build that drops `external/woff2/` in lights the real decompression path up automatically — no API break.

## Test plan

- [x] Configured + built `pulp-test-font-woff2` with `SKIA_DIR` set.
- [x] `./build/test/pulp-test-font-woff2` → all 11 assertions pass across 6 test cases.

Refs: `planning/2026-05-18-font-hardening-phase23-execution-plan.md` Slice 3.5.