### PR TITLE
test: batch phase3 coverage runtime view audio edges

### DIFF
--- a/core/format/include/pulp/format/diagnostic_reporter.hpp
+++ b/core/format/include/pulp/format/diagnostic_reporter.hpp
@@ -147,13 +147,13 @@ public:
         ss << std::fixed << std::setprecision(4);
 
         ss << "{\n";
-        ss << "  \"timestamp\": \"" << timestamp() << "\",\n";
-        ss << "  \"platform\": \"" << os_name() << "\",\n";
-        ss << "  \"arch\": \"" << arch() << "\",\n";
+        ss << "  \"timestamp\": \"" << json_escape(timestamp()) << "\",\n";
+        ss << "  \"platform\": \"" << json_escape(os_name()) << "\",\n";
+        ss << "  \"arch\": \"" << json_escape(arch()) << "\",\n";
         ss << "  \"plugin\": {\n";
-        ss << "    \"name\": \"" << plugin_name_ << "\",\n";
-        ss << "    \"manufacturer\": \"" << plugin_manufacturer_ << "\",\n";
-        ss << "    \"version\": \"" << plugin_version_ << "\",\n";
+        ss << "    \"name\": \"" << json_escape(plugin_name_) << "\",\n";
+        ss << "    \"manufacturer\": \"" << json_escape(plugin_manufacturer_) << "\",\n";
+        ss << "    \"version\": \"" << json_escape(plugin_version_) << "\",\n";
         ss << "    \"type\": \"" << (is_instrument_ ? "instrument" : "effect") << "\"\n";
         ss << "  },\n";
         ss << "  \"audio\": {\n";
@@ -166,7 +166,7 @@ public:
         for (size_t i = 0; i < param_snapshot_.size(); ++i) {
             const auto& p = param_snapshot_[i];
             ss << "    {\"id\": " << p.id
-               << ", \"name\": \"" << p.name
+               << ", \"name\": \"" << json_escape(p.name)
                << "\", \"value\": " << p.value
                << ", \"normalized\": " << p.normalized << "}";
             if (i + 1 < param_snapshot_.size()) ss << ",";
@@ -211,6 +211,33 @@ private:
         const auto local = runtime::localtime_local(now);
         std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &local);
         return buf;
+    }
+
+    static std::string json_escape(const std::string& text) {
+        std::string out;
+        out.reserve(text.size());
+        for (unsigned char c : text) {
+            switch (c) {
+                case '\"': out += "\\\""; break;
+                case '\\': out += "\\\\"; break;
+                case '\b': out += "\\b"; break;
+                case '\f': out += "\\f"; break;
+                case '\n': out += "\\n"; break;
+                case '\r': out += "\\r"; break;
+                case '\t': out += "\\t"; break;
+                default:
+                    if (c < 0x20) {
+                        static constexpr char hex[] = "0123456789abcdef";
+                        out += "\\u00";
+                        out += hex[(c >> 4) & 0x0f];
+                        out += hex[c & 0x0f];
+                    } else {
+                        out.push_back(static_cast<char>(c));
+                    }
+                    break;
+            }
+        }
+        return out;
     }
 
     static std::string os_name() {

--- a/core/format/include/pulp/format/headless.hpp
+++ b/core/format/include/pulp/format/headless.hpp
@@ -43,8 +43,8 @@ public:
                  const audio::BufferView<const float>& input);
 
     /// Process a block of audio with explicit transport/timeline context.
-    /// Any zero-valued `sample_rate` / `num_samples` fields are defaulted from
-    /// the prepared host configuration and current buffer size.
+    /// Any non-positive `sample_rate` / `num_samples` fields are defaulted
+    /// from the prepared host configuration and current buffer size.
     void process(audio::BufferView<float>& output,
                  const audio::BufferView<const float>& input,
                  ProcessContext context);

--- a/core/format/src/settings_panel.cpp
+++ b/core/format/src/settings_panel.cpp
@@ -185,7 +185,9 @@ void SettingsPanel::bind_systems(audio::AudioSystem* audio_sys, midi::MidiSystem
     }
 
     rebuild_device_lists();
+    rebuild_rate_and_buffer_lists();
     rebuild_midi_list();
+    update_latency_label();
 }
 
 void SettingsPanel::set_current_config(const StandaloneConfig& cfg) {

--- a/core/runtime/include/pulp/runtime/range.hpp
+++ b/core/runtime/include/pulp/runtime/range.hpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <type_traits>
 
 namespace pulp::runtime {
 
@@ -50,7 +51,11 @@ struct Range {
 
     /// Constrain a value to this range [start, end)
     constexpr T constrain(T value) const {
-        return std::clamp(value, start, end > start ? end - T(1) : start);
+        if constexpr (std::is_integral_v<T>) {
+            return std::clamp(value, start, end > start ? end - T(1) : start);
+        } else {
+            return std::clamp(value, start, end > start ? end : start);
+        }
     }
 
     /// Expand range to include a value

--- a/core/runtime/src/expression.cpp
+++ b/core/runtime/src/expression.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cctype>
+#include <cstdlib>
 #include <stdexcept>
 
 namespace pulp::runtime {
@@ -95,7 +96,12 @@ private:
                 while (pos_ < input_.size() && std::isdigit(input_[pos_])) pos_++;
                 if (pos_ == exponent_start) throw std::runtime_error("Malformed exponent");
             }
-            return std::stod(std::string(input_.substr(start, pos_ - start)));
+            std::string token(input_.substr(start, pos_ - start));
+            char* end = nullptr;
+            double value = std::strtod(token.c_str(), &end);
+            if (end != token.c_str() + token.size())
+                throw std::runtime_error("Malformed number");
+            return value;
         }
 
         // Identifier (variable or function)

--- a/core/runtime/src/http.cpp
+++ b/core/runtime/src/http.cpp
@@ -11,6 +11,7 @@
 #include <charconv>
 #include <fstream>
 #include <regex>
+#include <algorithm>
 
 namespace pulp::runtime {
 
@@ -18,13 +19,16 @@ namespace pulp::runtime {
 static bool parse_url(std::string_view url, std::string& scheme,
                       std::string& host, int& port, std::string& path) {
     std::string url_str(url);
-    std::regex url_regex(R"(^(https?)://([^/:]+)(?::(\d+))?(/.*)?)");
+    std::regex url_regex(R"(^(https?)://([^/:]+)(?::(\d+))?(/.*)?)",
+                         std::regex::icase);
     std::smatch match;
 
     if (!std::regex_match(url_str, match, url_regex))
         return false;
 
     scheme = match[1];
+    std::transform(scheme.begin(), scheme.end(), scheme.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     host = match[2];
     port = scheme == "https" ? 443 : 80;
     if (match[3].length() > 0) {

--- a/test/test_ara_types.cpp
+++ b/test/test_ara_types.cpp
@@ -19,6 +19,23 @@ TEST_CASE("AudioSourceContentChange is a bitset", "[ara][types]") {
                       AudioSourceContentChange::Notes));
 }
 
+TEST_CASE("AudioSourceContentChange supports combined invalidation masks",
+          "[ara][types][coverage][phase3]") {
+    auto flags = AudioSourceContentChange::Notes
+               | AudioSourceContentChange::Tempo
+               | AudioSourceContentChange::Tuning
+               | AudioSourceContentChange::KeySignatures
+               | AudioSourceContentChange::Samples;
+
+    REQUIRE(any(flags));
+    REQUIRE(has(flags, AudioSourceContentChange::Notes));
+    REQUIRE(has(flags, AudioSourceContentChange::Tempo));
+    REQUIRE(has(flags, AudioSourceContentChange::Tuning));
+    REQUIRE(has(flags, AudioSourceContentChange::KeySignatures));
+    REQUIRE(has(flags, AudioSourceContentChange::Samples));
+    REQUIRE_FALSE(has(flags, AudioSourceContentChange::None));
+}
+
 TEST_CASE("AraAudioSource has expected default-constructed shape", "[ara][types]") {
     AraAudioSource src;
     REQUIRE(src.id == 0);

--- a/test/test_audio_excerpt.cpp
+++ b/test/test_audio_excerpt.cpp
@@ -263,6 +263,28 @@ TEST_CASE("AudioSubsectionReader handles empty and past-end ranges",
     REQUIRE(dest[1] == 8.0f);
 }
 
+TEST_CASE("AudioSubsectionReader zero-length ranges retain source shape",
+          "[audio][subsection][coverage][phase3]") {
+    AudioFileData audio;
+    audio.sample_rate = 96000;
+    audio.channels = {{0.0f, 0.5f}, {1.0f, 1.5f}};
+
+    AudioSubsectionReader reader(audio, 1, 0);
+    REQUIRE_FALSE(reader.is_valid());
+    REQUIRE(reader.num_channels() == 2);
+    REQUIRE(reader.num_frames() == 0);
+    REQUIRE(reader.sample_rate() == 96000);
+    REQUIRE(reader.duration_seconds() == 0.0);
+    REQUIRE(reader.sample(0, 0) == 0.0f);
+
+    auto extracted = reader.extract();
+    REQUIRE(extracted.sample_rate == 96000);
+    REQUIRE(extracted.num_channels() == 2);
+    REQUIRE(extracted.num_frames() == 0);
+    REQUIRE(extracted.channels[0].empty());
+    REQUIRE(extracted.channels[1].empty());
+}
+
 TEST_CASE("AudioSubsectionReader ignores invalid read destinations",
           "[audio][subsection][codecov]") {
     AudioFileData audio;

--- a/test/test_audio_file.cpp
+++ b/test/test_audio_file.cpp
@@ -425,6 +425,43 @@ TEST_CASE("Read nonexistent file returns nullopt", "[audio][file]") {
     REQUIRE_FALSE(info.has_value());
 }
 
+TEST_CASE("WAV reader reports zero-frame metadata but rejects loading data",
+          "[audio][file][coverage]") {
+    auto path = unique_temp_audio_path("_zero_frames.wav");
+    std::filesystem::remove(path);
+
+    const std::vector<uint8_t> wav = {
+        'R', 'I', 'F', 'F',
+        36, 0, 0, 0,
+        'W', 'A', 'V', 'E',
+        'f', 'm', 't', ' ',
+        16, 0, 0, 0,
+        1, 0,
+        1, 0,
+        0x44, 0xAC, 0, 0,
+        0x88, 0x58, 0x01, 0,
+        2, 0,
+        16, 0,
+        'd', 'a', 't', 'a',
+        0, 0, 0, 0,
+    };
+    {
+        std::ofstream f(path, std::ios::binary);
+        f.write(reinterpret_cast<const char*>(wav.data()),
+                static_cast<std::streamsize>(wav.size()));
+    }
+
+    auto info = read_audio_file_info(path.string());
+    REQUIRE(info.has_value());
+    REQUIRE(info->sample_rate == 44100);
+    REQUIRE(info->num_channels == 1);
+    REQUIRE(info->num_frames == 0);
+    REQUIRE(info->duration_seconds == 0.0);
+
+    REQUIRE_FALSE(read_audio_file(path.string()).has_value());
+    std::filesystem::remove(path);
+}
+
 TEST_CASE("AudioFileData shape helpers and WAV writer reject first-channel empties",
           "[audio][file][issue-640]") {
     AudioFileData data;

--- a/test/test_diagnostic_reporter.cpp
+++ b/test/test_diagnostic_reporter.cpp
@@ -192,6 +192,27 @@ TEST_CASE("DiagnosticReporter JSON reflects instrument/effect type and parameter
     REQUIRE(json.find("\"value\": 25.0000") != std::string::npos);
 }
 
+TEST_CASE("DiagnosticReporter JSON escapes string fields",
+          "[format][diagnostic][coverage][phase3]") {
+    DiagnosticReporter diag;
+    PluginDescriptor desc;
+    desc.name = R"(Quote "Synth")";
+    desc.manufacturer = R"(Back\Slash)";
+    desc.version = "1.0\nbeta";
+    desc.bundle_id = "com.test.escaped";
+
+    StateStore store;
+    store.add_parameter({.id = 5, .name = R"(Cutoff "Hz")", .unit = "Hz", .range = {20, 20000, 440}});
+    store.set_value(5, 880.0f);
+    diag.set_plugin_info(desc, store);
+
+    auto json = diag.generate_json();
+    REQUIRE(json.find(R"("name": "Quote \"Synth\"")") != std::string::npos);
+    REQUIRE(json.find(R"("manufacturer": "Back\\Slash")") != std::string::npos);
+    REQUIRE(json.find(R"("version": "1.0\nbeta")") != std::string::npos);
+    REQUIRE(json.find(R"("name": "Cutoff \"Hz\"")") != std::string::npos);
+}
+
 TEST_CASE("DiagnosticReporter replacing plugin info clears stale parameter snapshot",
           "[format][diagnostic][coverage][phase3]") {
     DiagnosticReporter diag;

--- a/test/test_effects.cpp
+++ b/test/test_effects.cpp
@@ -65,3 +65,28 @@ TEST_CASE("Shadow effect with RecordingCanvas", "[canvas][effects]") {
     REQUIRE(canvas.count(DrawCommand::Type::save) >= 1);
     REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) == 1);
 }
+
+TEST_CASE("apply_shadow records generic canvas setup commands",
+          "[canvas][effects][coverage]") {
+    RecordingCanvas canvas;
+    ShadowEffect shadow;
+    shadow.offset_x = 6.0f;
+    shadow.offset_y = -3.0f;
+    shadow.color = Color::rgba8(10, 20, 30, 160);
+
+    apply_shadow(canvas, shadow);
+
+    REQUIRE(canvas.save_count() == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::save) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::translate) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::set_fill_color) == 1);
+
+    const auto& commands = canvas.commands();
+    REQUIRE(commands[1].type == DrawCommand::Type::translate);
+    REQUIRE(commands[1].f[0] == 6.0f);
+    REQUIRE(commands[1].f[1] == -3.0f);
+    REQUIRE(commands[2].color == shadow.color);
+
+    canvas.restore();
+    REQUIRE(canvas.save_count() == 0);
+}

--- a/test/test_events_async_helpers.cpp
+++ b/test/test_events_async_helpers.cpp
@@ -160,6 +160,50 @@ TEST_CASE("ActionBroadcaster handles empty actions and no-listener sends",
     REQUIRE(seen.size() == 2);
 }
 
+TEST_CASE("ActionBroadcaster snapshots listeners during dispatch",
+          "[events][async_updater][action_broadcaster][coverage]") {
+    ActionBroadcaster broadcaster;
+    std::vector<std::string> seen;
+    int first_id = -1;
+
+    first_id = broadcaster.add_listener([&](std::string_view action) {
+        seen.emplace_back("first:" + std::string(action));
+        broadcaster.remove_listener(first_id);
+    });
+    const auto second_id = broadcaster.add_listener([&](std::string_view action) {
+        seen.emplace_back("second:" + std::string(action));
+    });
+
+    broadcaster.send_action("one");
+    REQUIRE(seen == std::vector<std::string>{"first:one", "second:one"});
+
+    broadcaster.send_action("two");
+    REQUIRE(seen == std::vector<std::string>{
+        "first:one", "second:one", "second:two"});
+
+    broadcaster.remove_listener(second_id);
+    broadcaster.send_action("ignored");
+    REQUIRE(seen.size() == 3);
+}
+
+TEST_CASE("ActionBroadcaster tolerates null listeners",
+          "[events][async_updater][action_broadcaster][coverage]") {
+    ActionBroadcaster broadcaster;
+    std::vector<std::string> seen;
+
+    const auto null_id = broadcaster.add_listener({});
+    const auto live_id = broadcaster.add_listener(
+        [&](std::string_view action) { seen.emplace_back(action); });
+
+    broadcaster.send_action("dispatch");
+    REQUIRE(seen == std::vector<std::string>{"dispatch"});
+
+    broadcaster.remove_listener(null_id);
+    broadcaster.remove_listener(live_id);
+    broadcaster.send_action("ignored");
+    REQUIRE(seen.size() == 1);
+}
+
 TEST_CASE("MultiTimer stop all permits selective restart",
           "[events][async_updater][multi_timer][issue-642]") {
     RecordingMultiTimer timers;
@@ -201,6 +245,38 @@ TEST_CASE("MultiTimer restart keeps one running entry per id",
     timers.stop_all_timers();
     timers.stop_all_timers();
     REQUIRE_FALSE(timers.is_timer_running(7));
+}
+
+TEST_CASE("MultiTimer supports zero and negative timer ids",
+          "[events][async_updater][multi_timer][coverage]") {
+    RecordingMultiTimer timers;
+
+    timers.start_timer(0, 1);
+    timers.start_timer(-4, 2);
+    REQUIRE(timers.is_timer_running(0));
+    REQUIRE(timers.is_timer_running(-4));
+    REQUIRE_FALSE(timers.is_timer_running(4));
+
+    timers.stop_timer(-4);
+    REQUIRE(timers.is_timer_running(0));
+    REQUIRE_FALSE(timers.is_timer_running(-4));
+}
+
+TEST_CASE("MultiTimer restart after stop_all works for existing entries",
+          "[events][async_updater][multi_timer][coverage]") {
+    RecordingMultiTimer timers;
+
+    timers.start_timer(3, 10);
+    timers.start_timer(4, 20);
+    timers.stop_all_timers();
+
+    timers.start_timer(4, 1);
+    REQUIRE_FALSE(timers.is_timer_running(3));
+    REQUIRE(timers.is_timer_running(4));
+
+    timers.start_timer(3, 1);
+    REQUIRE(timers.is_timer_running(3));
+    REQUIRE(timers.is_timer_running(4));
 }
 
 TEST_CASE("ScopedLowPowerModeDisabler has no observable test-lane side effects",

--- a/test/test_events_timer_helpers.cpp
+++ b/test/test_events_timer_helpers.cpp
@@ -43,3 +43,61 @@ TEST_CASE("Timer one-shot deactivates after firing and can be restarted",
     REQUIRE(wait_until([&] { return calls.load() == 2; }, 500ms));
     REQUIRE_FALSE(timer.is_active());
 }
+
+TEST_CASE("Timer start is idempotent while active",
+          "[events][timer][coverage]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+    Timer timer(loop, 10ms, [&] { calls.fetch_add(1); }, false);
+
+    timer.start();
+    timer.start();
+    timer.start();
+    REQUIRE(timer.is_active());
+
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 500ms));
+    REQUIRE_FALSE(timer.is_active());
+
+    std::this_thread::sleep_for(35ms);
+    REQUIRE(calls.load() == 1);
+}
+
+TEST_CASE("Timer stop cancels queued one-shot callback",
+          "[events][timer][coverage]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+    Timer timer(loop, 25ms, [&] { calls.fetch_add(1); }, false);
+
+    timer.start();
+    REQUIRE(timer.is_active());
+    timer.stop();
+    REQUIRE_FALSE(timer.is_active());
+
+    std::this_thread::sleep_for(75ms);
+    REQUIRE(calls.load() == 0);
+}
+
+TEST_CASE("Timer interval can be changed before restart",
+          "[events][timer][coverage]") {
+    EventLoop loop;
+    std::atomic<int> calls{0};
+    Timer timer(loop, 100ms, [&] { calls.fetch_add(1); }, false);
+
+    REQUIRE(timer.interval() == 100ms);
+    timer.set_interval(5ms);
+    REQUIRE(timer.interval() == 5ms);
+
+    timer.start();
+    REQUIRE(wait_until([&] { return calls.load() == 1; }, 500ms));
+    REQUIRE_FALSE(timer.is_active());
+}
+
+TEST_CASE("Timer with empty callback still tracks one-shot lifecycle",
+          "[events][timer][coverage]") {
+    EventLoop loop;
+    Timer timer(loop, 5ms, {}, false);
+
+    timer.start();
+    REQUIRE(timer.is_active());
+    REQUIRE(wait_until([&] { return !timer.is_active(); }, 500ms));
+}

--- a/test/test_headless.cpp
+++ b/test/test_headless.cpp
@@ -155,6 +155,35 @@ TEST_CASE("HeadlessHost fills default process context",
     REQUIRE(last_context.num_samples == 32);
 }
 
+TEST_CASE("HeadlessHost defaults non-positive context fields",
+          "[headless][coverage][phase3]") {
+    pulp::format::HeadlessHost host(create_test_gain);
+    host.prepare(88200.0, 512);
+
+    pulp::audio::Buffer<float> in(1, 8), out(1, 8);
+    const float* in_ptrs[1] = {in.channel(0).data()};
+    pulp::audio::BufferView<const float> in_view(in_ptrs, 1, 8);
+    auto out_view = out.view();
+
+    pulp::format::ProcessContext zero_ctx;
+    host.process(out_view, in_view, zero_ctx);
+    REQUIRE_THAT(last_context.sample_rate, WithinAbs(88200.0, 0.001));
+    REQUIRE(last_context.num_samples == 8);
+
+    pulp::format::ProcessContext explicit_ctx;
+    explicit_ctx.sample_rate = -1.0;
+    explicit_ctx.num_samples = -32;
+    host.process(out_view, in_view, explicit_ctx);
+    REQUIRE_THAT(last_context.sample_rate, WithinAbs(88200.0, 0.001));
+    REQUIRE(last_context.num_samples == 8);
+
+    explicit_ctx.sample_rate = 44100.0;
+    explicit_ctx.num_samples = 4;
+    host.process(out_view, in_view, explicit_ctx);
+    REQUIRE_THAT(last_context.sample_rate, WithinAbs(44100.0, 0.001));
+    REQUIRE(last_context.num_samples == 4);
+}
+
 TEST_CASE("HeadlessHost applies parameter changes", "[headless]") {
     pulp::format::HeadlessHost host(create_test_gain);
     host.prepare(48000.0, 256);

--- a/test/test_image_cache.cpp
+++ b/test/test_image_cache.cpp
@@ -127,6 +127,33 @@ TEST_CASE("clear invokes releaser for every entry",
     REQUIRE(c.stats().total_bytes == 0);
 }
 
+TEST_CASE("clear preserves cache counters while removing entries",
+          "[view][image-cache][coverage][phase3]") {
+    ImageCache c;
+    std::atomic<int> calls{0};
+    c.set_decoder(make_fake_decoder(calls));
+
+    const auto* first = c.get("a");
+    REQUIRE(first != nullptr);
+    REQUIRE(c.get("a") == first);
+
+    c.clear();
+
+    auto s = c.stats();
+    REQUIRE(s.entry_count == 0);
+    REQUIRE(s.total_bytes == 0);
+    REQUIRE(s.misses == 1);
+    REQUIRE(s.hits == 1);
+    REQUIRE(calls.load() == 1);
+
+    REQUIRE(c.get("a") != nullptr);
+    s = c.stats();
+    REQUIRE(s.entry_count == 1);
+    REQUIRE(s.misses == 2);
+    REQUIRE(s.hits == 1);
+    REQUIRE(calls.load() == 2);
+}
+
 TEST_CASE("zero budget disables trimming", "[view][image-cache]") {
     ImageCache c;
     std::atomic<int> calls{0};

--- a/test/test_ios_background_audio_flag.cpp
+++ b/test/test_ios_background_audio_flag.cpp
@@ -26,3 +26,25 @@ TEST_CASE("ios_requires_background_audio is settable per plugin",
     live_synth.ios_requires_background_audio = true;
     REQUIRE(live_synth.ios_requires_background_audio);
 }
+
+TEST_CASE("ios_requires_background_audio survives descriptor copies",
+          "[ios][descriptor][coverage][phase3]") {
+    PluginDescriptor live_looper;
+    live_looper.name = "LiveLooper";
+    live_looper.category = PluginCategory::Effect;
+    live_looper.ios_requires_background_audio = true;
+
+    PluginDescriptor copied = live_looper;
+    REQUIRE(copied.name == "LiveLooper");
+    REQUIRE(copied.category == PluginCategory::Effect);
+    REQUIRE(copied.ios_requires_background_audio);
+
+    PluginDescriptor assigned;
+    assigned = copied;
+    REQUIRE(assigned.name == "LiveLooper");
+    REQUIRE(assigned.ios_requires_background_audio);
+
+    copied.ios_requires_background_audio = false;
+    REQUIRE_FALSE(copied.ios_requires_background_audio);
+    REQUIRE(assigned.ios_requires_background_audio);
+}

--- a/test/test_midi.cpp
+++ b/test/test_midi.cpp
@@ -427,6 +427,38 @@ TEST_CASE("MidiMessageSequence sorts ranges and matches note-offs",
     REQUIRE(sequence.duration() == Approx(0.0));
 }
 
+TEST_CASE("MidiMessageSequence preserves same-timestamp insertion and SysEx events",
+          "[midi][sequence][coverage]") {
+    MidiMessageSequence sequence;
+
+    TimestampedMidiEvent sysex;
+    sysex.timestamp = 1.0;
+    sysex.status = 0xF0;
+    sysex.sysex = {0xF0, 0x7D, 0x01, 0xF7};
+
+    TimestampedMidiEvent note_on_zero_velocity;
+    note_on_zero_velocity.timestamp = 1.0;
+    note_on_zero_velocity.status = 0x90;
+    note_on_zero_velocity.data1 = 60;
+    note_on_zero_velocity.data2 = 0;
+
+    sequence.add_event(sysex);
+    sequence.add_event(note_on_zero_velocity);
+    sequence.add_cc(0.5, 2, 74, 64);
+
+    REQUIRE(sequence.size() == 3);
+    REQUIRE(sequence[0].is_cc());
+    REQUIRE(sequence[1].is_note_off());
+    REQUIRE_FALSE(sequence[1].is_note_on());
+    REQUIRE(sequence[2].is_sysex());
+    REQUIRE(sequence[2].sysex == std::vector<uint8_t>{0xF0, 0x7D, 0x01, 0xF7});
+
+    auto at_one_second = sequence.events_in_range(1.0, 1.1);
+    REQUIRE(at_one_second.size() == 2);
+    REQUIRE(at_one_second[0]->is_note_off());
+    REQUIRE(at_one_second[1]->is_sysex());
+}
+
 TEST_CASE("UmpPacket factories expose MIDI 2.0 fields", "[midi][ump][codecov]") {
     auto note = UmpPacket::note_on_2(0x1F, 0x2F, 0xC0, 0xABCD, 0xEE, 0x1234);
     REQUIRE(note.word_count == 2);

--- a/test/test_midi.cpp
+++ b/test/test_midi.cpp
@@ -616,6 +616,27 @@ TEST_CASE("UmpBuffer and MidiBuffer bridge preserve order and offsets",
     REQUIRE(ump.empty());
 }
 
+TEST_CASE("MidiBuffer UMP sidecar pointer can be replaced and detached",
+          "[midi][ump][buffer][coverage]") {
+    MidiBuffer midi;
+    UmpBuffer first;
+    UmpBuffer second;
+
+    REQUIRE(midi.ump() == nullptr);
+
+    midi.attach_ump(&first);
+    REQUIRE(midi.ump() == &first);
+    const auto& const_midi = midi;
+    REQUIRE(const_midi.ump() == &first);
+
+    midi.attach_ump(&second);
+    REQUIRE(midi.ump() == &second);
+
+    midi.attach_ump(nullptr);
+    REQUIRE(midi.ump() == nullptr);
+    REQUIRE(const_midi.ump() == nullptr);
+}
+
 TEST_CASE("UmpBuffer flatten skips packets without MIDI 1.0 equivalents",
           "[midi][ump][buffer][codecov]") {
     UmpBuffer ump;

--- a/test/test_midi_ci.cpp
+++ b/test/test_midi_ci.cpp
@@ -368,6 +368,29 @@ TEST_CASE("CiDiscovery profile callback reports enable and disable",
     REQUIRE(ci.profiles()[0].channel_count == 4);
 }
 
+TEST_CASE("CiDiscovery profile enable and disable repeat notifications are explicit",
+          "[midi][ci][coverage]") {
+    CiDiscovery ci;
+    ProfileId profile{0x04, 0x05, 0x06, 0x07, 0x00};
+    ci.add_profile({profile, false, 2});
+
+    std::vector<bool> states;
+    ci.on_profile_changed = [&](const ProfileId& id, bool enabled) {
+        REQUIRE(id == profile);
+        states.push_back(enabled);
+    };
+
+    REQUIRE(ci.enable_profile(profile));
+    REQUIRE(ci.enable_profile(profile));
+    REQUIRE(ci.profiles()[0].enabled);
+
+    REQUIRE(ci.disable_profile(profile));
+    REQUIRE(ci.disable_profile(profile));
+    REQUIRE_FALSE(ci.profiles()[0].enabled);
+
+    REQUIRE(states == std::vector<bool>{true, true, false, false});
+}
+
 TEST_CASE("CiDiscovery property exchange", "[midi][ci]") {
     CiDiscovery ci;
 

--- a/test/test_osc.cpp
+++ b/test/test_osc.cpp
@@ -226,6 +226,23 @@ TEST_CASE("OSC decode skips unknown tags without consuming later argument bytes"
     REQUIRE(decoded.get_int(0) == 42);
 }
 
+TEST_CASE("OSC decode truncated typed payloads return safe defaults",
+          "[osc][codec][coverage]") {
+    std::vector<uint8_t> data;
+    append_osc_string(data, "/truncated");
+    append_osc_string(data, ",ifsb");
+    data.insert(data.end(), {0x00, 0x00});  // partial int, then no remaining payload
+
+    auto decoded = decode(data.data(), data.size());
+
+    REQUIRE(decoded.address == "/truncated");
+    REQUIRE(decoded.args.size() == 4);
+    REQUIRE(decoded.get_int(0, -1) == 0);
+    REQUIRE_THAT(decoded.get_float(1, -1.0f), WithinAbs(0.0, 0.001));
+    REQUIRE(decoded.get_string(2, "fallback").empty());
+    REQUIRE(std::get<std::vector<uint8_t>>(decoded.args[3]).empty());
+}
+
 TEST_CASE("OSC decode handles non-null-terminated bounded address payload",
           "[osc][codec][codecov]") {
     const std::vector<uint8_t> data{'/', 'b', 'a', 'r'};

--- a/test/test_processor_defaults.cpp
+++ b/test/test_processor_defaults.cpp
@@ -339,3 +339,38 @@ TEST_CASE("Processor sidechain, MPE, and UMP sidecar pointers can be set and cle
     REQUIRE(p.mpe_input() == nullptr);
     REQUIRE(p.ump_input() == nullptr);
 }
+
+TEST_CASE("Processor sidecar pointers replace independently between blocks",
+          "[format][processor-defaults][sidecars][coverage]") {
+    PlainProcessor p;
+
+    const float first_samples[2] = {0.1f, 0.2f};
+    const float second_samples[2] = {0.3f, 0.4f};
+    const float* first_channels[1] = {first_samples};
+    const float* second_channels[1] = {second_samples};
+    pulp::audio::BufferView<const float> first_sidechain(first_channels, 1, 2);
+    pulp::audio::BufferView<const float> second_sidechain(second_channels, 1, 2);
+    pulp::midi::MpeBuffer first_mpe;
+    pulp::midi::MpeBuffer second_mpe;
+    pulp::midi::UmpBuffer first_ump;
+    pulp::midi::UmpBuffer second_ump;
+
+    p.set_sidechain(&first_sidechain);
+    p.set_mpe_input(&first_mpe);
+    p.set_ump_input(&first_ump);
+    REQUIRE(p.sidechain_input() == &first_sidechain);
+    REQUIRE(p.mpe_input() == &first_mpe);
+    REQUIRE(p.ump_input() == &first_ump);
+
+    p.set_sidechain(&second_sidechain);
+    p.set_mpe_input(&second_mpe);
+    p.set_ump_input(&second_ump);
+    REQUIRE(p.sidechain_input() == &second_sidechain);
+    REQUIRE(p.mpe_input() == &second_mpe);
+    REQUIRE(p.ump_input() == &second_ump);
+
+    p.set_mpe_input(nullptr);
+    REQUIRE(p.sidechain_input() == &second_sidechain);
+    REQUIRE(p.mpe_input() == nullptr);
+    REQUIRE(p.ump_input() == &second_ump);
+}

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -466,6 +466,46 @@ TEST_CASE("DynamicLibrary move transfers an open handle", "[runtime][dynamic_lib
     REQUIRE(assigned.find_symbol(symbol) != nullptr);
 }
 
+TEST_CASE("DynamicLibrary failed reopen closes the previous handle",
+          "[runtime][dynamic_library][coverage]") {
+    DynamicLibrary library;
+#ifdef __APPLE__
+    REQUIRE(library.open("/usr/lib/libSystem.B.dylib"));
+    const char* symbol = "malloc";
+#elif defined(__linux__)
+    REQUIRE(library.open("libc.so.6"));
+    const char* symbol = "malloc";
+#elif defined(_WIN32)
+    REQUIRE(library.open("kernel32.dll"));
+    const char* symbol = "GetCurrentProcess";
+#else
+    const char* symbol = nullptr;
+    SUCCEED("No stable system library fixture on this platform.");
+    return;
+#endif
+
+    REQUIRE(library.is_open());
+    REQUIRE(library.find_symbol(symbol) != nullptr);
+
+    auto missing_path = std::filesystem::temp_directory_path() /
+                        "pulp_missing_reopen_library_for_test";
+#ifdef _WIN32
+    missing_path += ".dll";
+#elif defined(__APPLE__)
+    missing_path += ".dylib";
+#else
+    missing_path += ".so";
+#endif
+
+    REQUIRE_FALSE(std::filesystem::exists(missing_path));
+    REQUIRE_FALSE(library.open(missing_path.string()));
+    REQUIRE_FALSE(library.is_open());
+    REQUIRE_FALSE(library.error().empty());
+
+    library.close();
+    REQUIRE_FALSE(library.is_open());
+}
+
 TEST_CASE("HighResolutionTimer starts stops and reports running state",
           "[runtime][timer][coverage][phase3]") {
     HighResolutionTimer timer;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -907,6 +907,18 @@ TEST_CASE("SizeRange and FloatRange cover containment and expansion helpers",
     REQUIRE_THAT(overlap.end, Catch::Matchers::WithinAbs(1.0f, 1e-6f));
 }
 
+TEST_CASE("Floating Range constrain clamps to the continuous upper bound",
+          "[runtime][range][coverage][phase3]") {
+    FloatRange unit(0.0f, 1.0f);
+    REQUIRE_THAT(unit.constrain(-2.0f), Catch::Matchers::WithinAbs(0.0f, 1e-6f));
+    REQUIRE_THAT(unit.constrain(0.25f), Catch::Matchers::WithinAbs(0.25f, 1e-6f));
+    REQUIRE_THAT(unit.constrain(2.0f), Catch::Matchers::WithinAbs(1.0f, 1e-6f));
+
+    DoubleRange bipolar(-1.0, 1.0);
+    REQUIRE_THAT(bipolar.constrain(-2.0), Catch::Matchers::WithinAbs(-1.0, 1e-12));
+    REQUIRE_THAT(bipolar.constrain(2.0), Catch::Matchers::WithinAbs(1.0, 1e-12));
+}
+
 TEST_CASE("Range boundary touch points remain non-intersections",
           "[runtime][range][coverage][issue-641]") {
     REQUIRE_FALSE(IntRange(0, 10).intersects(IntRange(10, 20)));

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -693,6 +693,13 @@ TEST_CASE("HTTP helpers reject malformed URL hosts and schemes",
     REQUIRE_FALSE(http_download("http://", "/tmp/pulp-url-invalid-download-656", 1));
 }
 
+TEST_CASE("HTTP helpers accept case-insensitive URL schemes during parsing",
+          "[runtime][http][url][coverage][phase3]") {
+    const auto response = http_get("HTTP://127.0.0.1:1/path", 1);
+    REQUIRE(response.status_code == 0);
+    REQUIRE(response.error != "Invalid URL");
+}
+
 // ── Text Diff ────────────────────────────────────────────────────────────
 
 TEST_CASE("text_diff handles empty inputs", "[runtime][text-diff][issue-641]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -601,6 +601,14 @@ TEST_CASE("Expression evaluator resolves variables and rejects malformed inputs"
     REQUIRE_FALSE(evaluate("2 + @").has_value());
 }
 
+TEST_CASE("Expression evaluator rejects malformed decimal tokens",
+          "[runtime][expression][coverage][phase3]") {
+    REQUIRE_FALSE(evaluate(".").has_value());
+    REQUIRE_FALSE(evaluate("1..2").has_value());
+    REQUIRE_FALSE(evaluate("1.2.3").has_value());
+    REQUIRE_FALSE(evaluate("..5").has_value());
+}
+
 TEST_CASE("ExpressionEvaluator stores variables and clears them",
           "[runtime][expression][coverage][issue-641]") {
     ExpressionEvaluator evaluator;

--- a/test/test_scan_cache.cpp
+++ b/test/test_scan_cache.cpp
@@ -432,6 +432,41 @@ TEST_CASE("ScanCache duplicate JSON entries keep the last valid record",
     REQUIRE(entry.info.num_outputs == 2);
 }
 
+TEST_CASE("ScanCache JSON round-trip preserves every plugin format",
+          "[scan_cache][codecov][phase3]") {
+    HostScanCache written;
+
+    const std::vector<std::pair<PluginFormat, std::string>> formats = {
+        {PluginFormat::VST3, "/tmp/cache-format.vst3"},
+        {PluginFormat::AudioUnit, "/tmp/cache-format.component"},
+        {PluginFormat::AudioUnitV3, "/tmp/cache-format-auv3.component"},
+        {PluginFormat::CLAP, "/tmp/cache-format.clap"},
+        {PluginFormat::LV2, "/tmp/cache-format.lv2"},
+    };
+
+    for (std::size_t i = 0; i < formats.size(); ++i) {
+        auto info = sample_info();
+        info.name = "Format" + std::to_string(i);
+        info.path = formats[i].second;
+        info.unique_id = "format-" + std::to_string(i);
+        info.format = formats[i].first;
+        written.put(formats[i].second, info);
+    }
+
+    HostScanCache read;
+    REQUIRE(read.from_json(written.to_json()));
+    REQUIRE(read.size() == formats.size());
+
+    for (std::size_t i = 0; i < formats.size(); ++i) {
+        const auto& entry = read.entries().at(formats[i].second);
+        CAPTURE(formats[i].second);
+        REQUIRE(entry.info.name == "Format" + std::to_string(i));
+        REQUIRE(entry.info.path == formats[i].second);
+        REQUIRE(entry.info.unique_id == "format-" + std::to_string(i));
+        REQUIRE(entry.info.format == formats[i].first);
+    }
+}
+
 TEST_CASE("ScanCache save_to creates nested parent directories",
           "[scan_cache][codecov]") {
     TempFile f;

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -366,6 +366,55 @@ TEST_CASE("SettingsPanel refreshes hotplug lists and test tone callbacks",
     REQUIRE(last_signal.sine_frequency_hz == 880.0f);
 }
 
+TEST_CASE("SettingsPanel uses fallback rate and buffer choices without output devices",
+          "[standalone][settings][coverage][phase3]") {
+    StubAudioSystem audio;
+    audio.devices = {
+        {.id = "mic-only",
+         .name = "Mic Only",
+         .max_input_channels = 1,
+         .sample_rates = {48000.0},
+         .buffer_sizes = {128},
+         .is_default_input = true},
+    };
+
+    SettingsPanel panel;
+    panel.bind_systems(&audio, nullptr);
+
+    StandaloneConfig applied;
+    applied.audio_device_id = "stale";
+    int apply_calls = 0;
+    panel.set_callbacks(SettingsPanelCallbacks{
+        .on_config_apply = [&](const StandaloneConfig& cfg) {
+            applied = cfg;
+            ++apply_calls;
+        },
+    });
+
+    auto& tabs = settings_tabs(panel);
+    auto* audio_tab = tabs.child_at(0);
+    REQUIRE(audio_tab != nullptr);
+
+    auto combos = descendants<ComboBox>(*audio_tab);
+    REQUIRE(combos.size() >= 4);
+    REQUIRE(combos[0]->items().empty());
+    REQUIRE(combos[1]->items().size() == 2);
+    REQUIRE(combos[2]->items().size() >= 6);
+    REQUIRE(combos[3]->items().size() >= 7);
+
+    combos[2]->set_selected(1);
+    REQUIRE(apply_calls == 1);
+    REQUIRE(applied.audio_device_id.empty());
+    REQUIRE(applied.sample_rate == 48000.0);
+    REQUIRE(applied.buffer_size == 64);
+
+    combos[3]->set_selected(2);
+    REQUIRE(apply_calls == 2);
+    REQUIRE(applied.audio_device_id.empty());
+    REQUIRE(applied.sample_rate == 48000.0);
+    REQUIRE(applied.buffer_size == 256);
+}
+
 TEST_CASE("Standalone editor chrome keeps the editor root when settings are hidden",
           "[standalone][chrome]") {
     auto editor_root = std::make_unique<View>();

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -461,6 +461,29 @@ TEST_CASE("StateTree JSON round-trip", "[state][tree][json]") {
     REQUIRE_THAT(filter_restored->get_double("cutoff"), WithinAbs(1200.5, 0.1));
 }
 
+TEST_CASE("StateTree JSON round-trip preserves escaped strings",
+          "[state][tree][json][coverage][phase3]") {
+    auto root = StateTree::create(R"(preset "A")");
+    root->set(R"(display\name)", std::string("Line 1\nLine \"2\" \\ tail"));
+
+    auto child = StateTree::create(R"(child\type)");
+    child->set("label", std::string(R"(quoted "child")"));
+    root->add_child(child);
+
+    const auto json = root->to_json();
+    REQUIRE(json.find("\\\"") != std::string::npos);
+    REQUIRE(json.find("\\\\") != std::string::npos);
+    REQUIRE(json.find("\\n") != std::string::npos);
+
+    auto restored = StateTree::from_json(json);
+    REQUIRE(restored != nullptr);
+    REQUIRE(restored->type_name() == R"(preset "A")");
+    REQUIRE(restored->get_string(R"(display\name)") == "Line 1\nLine \"2\" \\ tail");
+    REQUIRE(restored->child_count() == 1);
+    REQUIRE(restored->child(0)->type_name() == R"(child\type)");
+    REQUIRE(restored->child(0)->get_string("label") == R"(quoted "child")");
+}
+
 TEST_CASE("StateTree from_json with invalid JSON returns nullptr", "[state][tree][json]") {
     auto result = StateTree::from_json("not json at all {{{");
     REQUIRE(result == nullptr);

--- a/test/test_table_model.cpp
+++ b/test/test_table_model.cpp
@@ -209,3 +209,23 @@ TEST_CASE("add_column pads existing rows", "[ui][table-model][issue-493]") {
     REQUIRE(m.cell(0, 1).text.empty());
     REQUIRE(m.cell(1, 1).text.empty());
 }
+
+TEST_CASE("adding a column after short rows preserves padded cells",
+          "[ui][table-model][coverage][phase3]") {
+    TableModel m;
+    m.add_column({"Name"});
+    m.add_column({"Author"});
+    m.add_row({{"Dreamy Pad"}});
+    m.add_row({{"Stab"}, {"Bob"}});
+
+    m.add_column({"Rating"});
+
+    REQUIRE(m.column_count() == 3);
+    REQUIRE(m.row_count() == 2);
+    REQUIRE(m.cell(0, 0).text == "Dreamy Pad");
+    REQUIRE(m.cell(0, 1).text.empty());
+    REQUIRE(m.cell(0, 2).text.empty());
+    REQUIRE(m.cell(1, 0).text == "Stab");
+    REQUIRE(m.cell(1, 1).text == "Bob");
+    REQUIRE(m.cell(1, 2).text.empty());
+}

--- a/test/test_test_signal.cpp
+++ b/test/test_test_signal.cpp
@@ -269,6 +269,25 @@ TEST_CASE("TestSignalSource: zero-amplitude sine stays active but silent",
     REQUIRE(src.is_active());
 }
 
+TEST_CASE("TestSignalSource: zero-sized fills apply pending config without writing",
+          "[format][test_signal][coverage][phase3]") {
+    TestSignalSource src;
+    src.set_sample_rate(4.0);
+    src.set_config({TestSignalType::sine, 1.0f, 0.5f});
+
+    float sample = 123.0f;
+    float* output = &sample;
+    src.fill(&output, 1, 0);
+
+    REQUIRE(sample == 123.0f);
+    REQUIRE(src.config().type == TestSignalType::sine);
+    REQUIRE(src.config().sine_frequency_hz == 1.0f);
+    REQUIRE(src.config().sine_amplitude == 0.5f);
+
+    src.fill(nullptr, 0, 16);
+    REQUIRE(src.config().type == TestSignalType::sine);
+}
+
 TEST_CASE("TestSignalSource: file mode without loaded data is silent and not playing",
           "[format][test_signal][coverage][phase3]") {
     TestSignalSource src;

--- a/test/test_view_bridge.cpp
+++ b/test/test_view_bridge.cpp
@@ -227,6 +227,46 @@ TEST_CASE("ViewBridge defers on_view_opened until notify_attached", "[view_bridg
     REQUIRE(p.closed_count == 1);
 }
 
+TEST_CASE("ViewBridge stores detached resize state and resets on reopen",
+          "[view_bridge][coverage][phase3]") {
+    StubProcessor p;
+    state::StateStore store;
+    p.set_state_store(&store);
+    p.define_parameters(store);
+
+    format::ViewBridge bridge(p, store);
+    REQUIRE(bridge.width() == 480);
+    REQUIRE(bridge.height() == 320);
+
+    bridge.resize(700, 500);
+    REQUIRE(bridge.width() == 700);
+    REQUIRE(bridge.height() == 500);
+    REQUIRE(p.resize_count == 0);
+
+    REQUIRE(bridge.open());
+    REQUIRE(bridge.width() == 480);
+    REQUIRE(bridge.height() == 320);
+
+    bridge.resize(900, 600);
+    REQUIRE(bridge.width() == 900);
+    REQUIRE(bridge.height() == 600);
+    REQUIRE(p.resize_count == 0);
+
+    bridge.notify_attached();
+    bridge.resize(1024, 768);
+    REQUIRE(p.resize_count == 1);
+    REQUIRE(p.last_w == 1024);
+    REQUIRE(p.last_h == 768);
+
+    bridge.close();
+    REQUIRE(bridge.width() == 1024);
+    REQUIRE(bridge.height() == 768);
+
+    REQUIRE(bridge.open());
+    REQUIRE(bridge.width() == 480);
+    REQUIRE(bridge.height() == 320);
+}
+
 TEST_CASE("ViewBridge close without attach does not fire on_view_closed", "[view_bridge]") {
     // Simulates: adapter called open(), then host attach failed, so
     // notify_attached() was never invoked. close() must NOT fire


### PR DESCRIPTION
## Summary
- add 24 focused phase 3 code coverage slices across runtime, events, MIDI, OSC, audio, host, format, ARA, state, standalone, and view cache/table model surfaces
- include small production fixes where tests exposed real edge behavior: URL scheme case handling, malformed expression number rejection, floating range clamping, diagnostic JSON escaping, settings fallback refresh
- keep this as one larger GitHub-hosted batch to reduce CI runner pressure

## Local validation
- `cmake --build build --target pulp-test-events-timer-helpers pulp-test-events-async-helpers pulp-test-runtime pulp-test-runtime-utils pulp-test-processor-defaults pulp-test-midi pulp-test-midi-ci pulp-test-osc pulp-test-effects pulp-test-audio-file pulp-test-audio-excerpt pulp-test-scan-cache pulp-test-ios-background-audio-flag pulp-test-ara-types pulp-test-view-bridge pulp-test-headless pulp-test-diagnostic pulp-test-test-signal pulp-test-standalone-editor-chrome pulp-test-state-tree pulp-test-table-model pulp-test-image-cache`
- direct execution of all 22 touched test binaries with `--reporter compact`
- `git diff --check`

## CI note
GitHub-hosted CI only; no Namespace dispatch requested.