### PR TITLE
test: batch phase3 coverage view runtime cli edges

### DIFF
--- a/.agents/skills/cli-maintenance/SKILL.md
+++ b/.agents/skills/cli-maintenance/SKILL.md
@@ -145,6 +145,14 @@ that was tried and gives the exact `cmake --build` line to remediate;
 do not regress to "Run `pulp build` first" — that's misleading if the
 top-level target doesn't depend on the missing helper.
 
+### Numeric CLI flags
+
+For count-like flags such as `pulp run --frames`, parsers should accept only
+plain non-negative decimal digits and reject a leading `+`. C++ `from_chars`
+acceptance varies by implementation for signed prefixes, and the Rust-facing
+CLI surface should stay deterministic across platforms. Add regression tests
+for boundary spelling when changing these parsers.
+
 **Sidecar output anchoring:** when a CLI command takes `--output
 <path>/main.ext` and also emits sidecar artifacts (e.g.
 `pulp import-design` writes `bridge_handlers.cpp`, `classnames.json`,

--- a/.agents/skills/streams/SKILL.md
+++ b/.agents/skills/streams/SKILL.md
@@ -52,7 +52,21 @@ fine for tests, usually wrong for UI state.
 `StreamError::Closed`. Do not write code that assumes a cancel
 "silently forgets" in-flight writes — the callback will fire.
 
-### 4. Writes and auto-reads run on separate threads
+### 4. Restarting after cancel resets the token
+
+`AsyncStream::start()` clears a previously cancelled token before launching
+workers. A stream can therefore be cancelled, stopped, and started again for
+tests or reusable transports. Do not preserve a stale cancelled token across
+restart.
+
+### 5. Null writes are invalid unless size is zero
+
+`write_async(nullptr, 0, cb)` is the normal zero-byte no-op and completes
+successfully. `write_async(nullptr, nonzero, cb)` queues the callback with
+`StreamError::Invalid` instead of dereferencing the pointer. Keep that
+distinction when adding transport wrappers.
+
+### 6. Writes and auto-reads run on separate threads
 
 When `options.auto_read = true` the reader and writer run on
 **separate** threads so a blocking `read()` on a `TcpStream` cannot

--- a/core/runtime/src/analytics.cpp
+++ b/core/runtime/src/analytics.cpp
@@ -78,6 +78,7 @@ Analytics& Analytics::instance() {
 }
 
 void Analytics::add_destination(std::unique_ptr<AnalyticsDestination> dest) {
+    if (!dest) return;
     std::lock_guard<std::mutex> lock(mutex_);
     destinations_.push_back(std::move(dest));
 }

--- a/core/runtime/src/async_stream.cpp
+++ b/core/runtime/src/async_stream.cpp
@@ -77,6 +77,10 @@ bool AsyncStream::write_async(const std::uint8_t* data, std::size_t size,
         if (callback) dispatch([cb = std::move(callback)] { cb(0, StreamError::Ok); });
         return true;
     }
+    if (data == nullptr) {
+        if (callback) dispatch([cb = std::move(callback)] { cb(0, StreamError::Invalid); });
+        return true;
+    }
 
     PendingWrite pw;
     pw.data.assign(data, data + size);

--- a/core/runtime/src/async_stream.cpp
+++ b/core/runtime/src/async_stream.cpp
@@ -35,6 +35,7 @@ void AsyncStream::on_drain(AsyncCloseCallback cb) { on_drain_ = std::move(cb); }
 void AsyncStream::start() {
     std::lock_guard<std::mutex> lock(mutex_);
     if (running_) return;
+    if (token_.is_cancelled()) token_ = CancellationToken();
     running_ = true;
     close_fired_ = false;
     writer_thread_ = std::thread([this] { write_loop(); });

--- a/core/runtime/src/big_integer.cpp
+++ b/core/runtime/src/big_integer.cpp
@@ -1,6 +1,8 @@
 #include <pulp/runtime/big_integer.hpp>
 #include <mbedtls/bignum.h>
 #include <cstring>
+#include <limits>
+#include <string>
 
 namespace pulp::runtime {
 
@@ -18,7 +20,12 @@ struct BigInteger::Impl {
 
 BigInteger::BigInteger() : impl_(new Impl) {}
 BigInteger::BigInteger(uint64_t value) : impl_(new Impl) {
-    mbedtls_mpi_lset(&impl_->mpi, static_cast<mbedtls_mpi_sint>(value));
+    if (value <= static_cast<uint64_t>(std::numeric_limits<mbedtls_mpi_sint>::max())) {
+        mbedtls_mpi_lset(&impl_->mpi, static_cast<mbedtls_mpi_sint>(value));
+    } else {
+        auto decimal = std::to_string(value);
+        mbedtls_mpi_read_string(&impl_->mpi, 10, decimal.c_str());
+    }
 }
 BigInteger::BigInteger(const BigInteger& other) : impl_(new Impl(*other.impl_)) {}
 BigInteger::BigInteger(BigInteger&& other) noexcept : impl_(other.impl_) { other.impl_ = new Impl; }

--- a/core/view/include/pulp/view/tree_view.hpp
+++ b/core/view/include/pulp/view/tree_view.hpp
@@ -120,7 +120,7 @@ public:
                 if (hit->has_children() && event.position.x < triangle_end) {
                     hit->toggle();
                     if (on_toggle) on_toggle(*hit, hit->expanded);
-                } else {
+                } else if (hit->selectable) {
                     selected_ = hit;
                     if (on_select) on_select(*hit);
                 }

--- a/core/view/src/asset_manager.cpp
+++ b/core/view/src/asset_manager.cpp
@@ -44,6 +44,10 @@ void AssetManager::touch(CacheEntry& entry) const {
 }
 
 void AssetManager::add_to_cache(const std::string& key, CacheEntry entry) {
+    auto existing = cache_.find(key);
+    if (existing != cache_.end())
+        cache_bytes_ -= existing->second.byte_size;
+
     cache_bytes_ += entry.byte_size;
     cache_[key] = std::move(entry);
 

--- a/core/view/src/theme.cpp
+++ b/core/view/src/theme.cpp
@@ -31,7 +31,15 @@ void Theme::apply_overrides(const Theme& overrides) {
 
 static Color parse_hex_color(const std::string& hex) {
     if (hex.empty() || hex[0] != '#') return {};
-    auto val = std::stoul(hex.substr(1), nullptr, 16);
+    uint32_t val = 0;
+    try {
+        std::size_t consumed = 0;
+        const auto parsed = std::stoul(hex.substr(1), &consumed, 16);
+        if (consumed != hex.size() - 1 || parsed > 0xFFFFFFFFu) return {};
+        val = static_cast<uint32_t>(parsed);
+    } catch (...) {
+        return {};
+    }
     if (hex.size() == 7) return color_from_hex(static_cast<uint32_t>(val));
     if (hex.size() == 9) return color_from_hex_alpha(static_cast<uint32_t>(val));
     return {};

--- a/core/view/src/window_manager.cpp
+++ b/core/view/src/window_manager.cpp
@@ -135,6 +135,7 @@ void WindowManager::broadcast_message(const WindowMessage& msg) {
 }
 
 void WindowManager::set_message_handler(WindowId id, MessageHandler handler) {
+    if (windows_.find(id) == windows_.end()) return;
     handlers_[id] = std::move(handler);
 }
 

--- a/test/test_ab_compare.cpp
+++ b/test/test_ab_compare.cpp
@@ -90,3 +90,25 @@ TEST_CASE("ABCompare: clear + snapshot access", "[ui][ab-compare]") {
     REQUIRE_FALSE(ab.has(ABCompare::Slot::A));
     REQUIRE(ab.snapshot(ABCompare::Slot::A).size() == 0);
 }
+
+TEST_CASE("ABCompare: null store and same-slot copy are no-ops",
+          "[ui][ab-compare][coverage][phase3]") {
+    ABCompare null_ab(nullptr);
+    null_ab.save_to(ABCompare::Slot::A);
+    REQUIRE_FALSE(null_ab.has(ABCompare::Slot::A));
+    REQUIRE_FALSE(null_ab.load_from(ABCompare::Slot::A));
+    REQUIRE_FALSE(null_ab.toggle());
+    REQUIRE(null_ab.current() == ABCompare::Slot::A);
+
+    state::StateStore store;
+    populate(store);
+    ABCompare ab(&store);
+    store.set_value(1, 4.0f);
+    ab.save_to(ABCompare::Slot::A);
+    auto before_size = ab.snapshot(ABCompare::Slot::A).size();
+
+    ab.copy(ABCompare::Slot::A, ABCompare::Slot::A);
+    REQUIRE(ab.has(ABCompare::Slot::A));
+    REQUIRE_FALSE(ab.has(ABCompare::Slot::B));
+    REQUIRE(ab.snapshot(ABCompare::Slot::A).size() == before_size);
+}

--- a/test/test_analytics.cpp
+++ b/test/test_analytics.cpp
@@ -395,6 +395,24 @@ TEST_CASE("Analytics forwards simple log with empty property map",
     REQUIRE(events->back().properties.empty());
 }
 
+TEST_CASE("Analytics ignores null destinations",
+          "[runtime][analytics][coverage][phase3]") {
+    auto events = std::make_shared<std::vector<AnalyticsEvent>>();
+    auto flushes = std::make_shared<int>(0);
+
+    auto& a = Analytics::instance();
+    a.set_enabled(true);
+    a.add_destination(nullptr);
+    a.add_destination(std::make_unique<RecordingDestination>(events, flushes));
+
+    a.log("after_null_destination");
+    a.flush();
+
+    REQUIRE(events->size() == 1);
+    REQUIRE(events->back().name == "after_null_destination");
+    REQUIRE(*flushes == 1);
+}
+
 TEST_CASE("Analytics disabled widget tracker calls skip destinations",
           "[runtime][analytics][coverage][phase3-large]") {
     auto events = std::make_shared<std::vector<AnalyticsEvent>>();

--- a/test/test_appearance_tracker.cpp
+++ b/test/test_appearance_tracker.cpp
@@ -41,6 +41,22 @@ TEST_CASE("AppearanceTracker callback fires on lock", "[view][appearance]") {
     REQUIRE(received == Appearance::light);
 }
 
+TEST_CASE("AppearanceTracker replacing callback uses latest handler only",
+          "[view][appearance][coverage][phase3]") {
+    AppearanceTracker tracker;
+    int first_calls = 0;
+    std::vector<Appearance> latest;
+
+    tracker.on_appearance_changed([&](Appearance) { ++first_calls; });
+    tracker.on_appearance_changed([&](Appearance a) { latest.push_back(a); });
+
+    tracker.lock(Appearance::light);
+    tracker.lock(Appearance::dark);
+
+    REQUIRE(first_calls == 0);
+    REQUIRE(latest == std::vector<Appearance>{Appearance::light, Appearance::dark});
+}
+
 TEST_CASE("AppearanceTracker callbacks follow repeated locks and locked poll no-op",
           "[view][appearance][coverage][issue-493]") {
     AppearanceTracker tracker;
@@ -111,6 +127,30 @@ TEST_CASE("ThemeManager callback fires on theme change", "[view][appearance]") {
     mgr.lock_appearance(Appearance::light);
 
     REQUIRE(called);
+}
+
+TEST_CASE("ThemeManager replacing callback uses latest handler only",
+          "[view][appearance][coverage][phase3]") {
+    ThemeManager mgr;
+    int first_calls = 0;
+    std::vector<uint8_t> latest_red;
+
+    Theme light;
+    light.colors["bg.primary"] = color_from_hex(0x110000);
+    Theme dark;
+    dark.colors["bg.primary"] = color_from_hex(0x220000);
+    mgr.set_theme_pair(light, dark);
+
+    mgr.on_theme_changed([&](const Theme&) { ++first_calls; });
+    mgr.on_theme_changed([&](const Theme& theme) {
+        latest_red.push_back(theme.color("bg.primary")->r8());
+    });
+
+    mgr.lock_appearance(Appearance::light);
+    mgr.lock_appearance(Appearance::dark);
+
+    REQUIRE(first_calls == 0);
+    REQUIRE(latest_red == std::vector<uint8_t>{0x11, 0x22});
 }
 
 TEST_CASE("ThemeManager callbacks cover locked theme poll and unlock",

--- a/test/test_asset_manager.cpp
+++ b/test/test_asset_manager.cpp
@@ -143,6 +143,26 @@ TEST_CASE("AssetManager register and retrieve shader", "[view][assets]") {
     REQUIRE(shader.source.find("uniform") != std::string::npos);
 }
 
+TEST_CASE("AssetManager replacing cached shader keeps cache usage accurate",
+          "[view][assets][coverage][issue-651]") {
+    auto& mgr = AssetManager::instance();
+    mgr.clear_cache();
+
+    mgr.register_shader("replaceable_effect", "void main() {}");
+    REQUIRE(mgr.cache_count() == 1);
+    REQUIRE(mgr.cache_usage() == std::string("void main() {}").size());
+
+    mgr.register_shader("replaceable_effect", "uniform float phase; void main() {}");
+    auto shader = mgr.shader("replaceable_effect");
+
+    REQUIRE(shader.valid());
+    REQUIRE(shader.source == "uniform float phase; void main() {}");
+    REQUIRE(mgr.cache_count() == 1);
+    REQUIRE(mgr.cache_usage() == shader.source.size());
+
+    mgr.clear_cache();
+}
+
 TEST_CASE("AssetManager missing shader returns invalid", "[view][assets]") {
     auto& mgr = AssetManager::instance();
     auto shader = mgr.shader("nonexistent_shader_xyz");

--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -321,6 +321,38 @@ TEST_CASE("AsyncStream rejects nonempty null writes via callback",
     REQUIRE(stream.pending_write_bytes() == 0);
 }
 
+TEST_CASE("AsyncStream start after stop refreshes cancellation state",
+          "[async_stream][coverage][phase3]") {
+    auto backing = std::make_unique<TestStream>();
+    auto* raw = backing.get();
+
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    stream.start();
+    stream.stop();
+
+    std::atomic<int> callbacks{0};
+    std::atomic<std::size_t> bytes{0};
+    std::atomic<StreamError> error{StreamError::Closed};
+    const std::uint8_t payload[] = {'r', 'e', 's', 't', 'a', 'r', 't'};
+
+    stream.start();
+    REQUIRE(stream.write_async(payload, sizeof(payload),
+                               [&](std::size_t n, StreamError err) {
+                                   bytes.store(n);
+                                   error.store(err);
+                                   callbacks.fetch_add(1);
+                               }));
+
+    REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
+    REQUIRE(bytes.load() == sizeof(payload));
+    REQUIRE(error.load() == StreamError::Ok);
+    REQUIRE(raw->captured_writes() ==
+            std::vector<std::uint8_t>{'r', 'e', 's', 't', 'a', 'r', 't'});
+}
+
 TEST_CASE("CancellationToken sharing and idempotent cancel", "[async_stream]") {
     CancellationToken token;
     CancellationToken copy = token;

--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -297,6 +297,30 @@ TEST_CASE("AsyncStream zero-byte write dispatches completion without worker", "[
     REQUIRE(error.load() == StreamError::Ok);
 }
 
+TEST_CASE("AsyncStream rejects nonempty null writes via callback",
+          "[async_stream][coverage][phase3]") {
+    auto backing = std::make_unique<TestStream>();
+
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<int> callbacks{0};
+    std::atomic<std::size_t> bytes{99};
+    std::atomic<StreamError> error{StreamError::Ok};
+
+    REQUIRE(stream.write_async(nullptr, 3, [&](std::size_t n, StreamError err) {
+        bytes.store(n);
+        error.store(err);
+        callbacks.fetch_add(1);
+    }));
+
+    REQUIRE(callbacks.load() == 1);
+    REQUIRE(bytes.load() == 0);
+    REQUIRE(error.load() == StreamError::Invalid);
+    REQUIRE(stream.pending_write_bytes() == 0);
+}
+
 TEST_CASE("CancellationToken sharing and idempotent cancel", "[async_stream]") {
     CancellationToken token;
     CancellationToken copy = token;

--- a/test/test_cli_project_bump.cpp
+++ b/test/test_cli_project_bump.cpp
@@ -201,6 +201,10 @@ TEST_CASE("refuse_dynamic_pin rejects branch names and SHAs",
     site.current_pin = "abc1234";
     REQUIRE(pb::refuse_dynamic_pin(site));
 
+    // Uppercase hex is still a SHA-like pin.
+    site.current_pin = "ABCDEF0";
+    REQUIRE(pb::refuse_dynamic_pin(site));
+
     // Semver is safe.
     site.current_pin = "0.23.0";
     REQUIRE_FALSE(pb::refuse_dynamic_pin(site));

--- a/test/test_cli_run_options.cpp
+++ b/test/test_cli_run_options.cpp
@@ -106,10 +106,12 @@ TEST_CASE("pulp run --frames rejects non-positive and non-integer values",
     REQUIRE_FALSE(parse_run_options({"--frames", "abc"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames", "12x"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames", "12.5"}).error.empty());
+    REQUIRE_FALSE(parse_run_options({"--frames", "+5"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames=zero"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames=12x"}).error.empty());
     REQUIRE_FALSE(parse_run_options({"--frames=12.5"}).error.empty());
+    REQUIRE_FALSE(parse_run_options({"--frames=+5"}).error.empty());
 
     auto partial = parse_run_options({"--frames=12x"});
     REQUIRE(partial.frames == 1);

--- a/test/test_cli_sdk_tarball_filename.cpp
+++ b/test/test_cli_sdk_tarball_filename.cpp
@@ -82,3 +82,11 @@ TEST_CASE("legacy_unversioned_sdk_tarball_filename: empty platform keeps legacy 
           "[cli][cache][coverage][phase3-large]") {
     REQUIRE(legacy_unversioned_sdk_tarball_filename("") == "pulp-sdk-.tar.gz");
 }
+
+TEST_CASE("sdk_tarball_filename: empty components remain literal",
+          "[cli][cache][coverage][phase3]") {
+    REQUIRE(sdk_tarball_filename("", "darwin-arm64") ==
+            "pulp-sdk-v-darwin-arm64.tar.gz");
+    REQUIRE(sdk_tarball_filename("0.92.0", "") ==
+            "pulp-sdk-v0.92.0-.tar.gz");
+}

--- a/test/test_cli_update_check.cpp
+++ b/test/test_cli_update_check.cpp
@@ -298,6 +298,39 @@ TEST_CASE("read_toml_key_in_section ignores commented examples",
     REQUIRE(uc::read_toml_key_in_section(src, "update", "mode") == "prompt");
 }
 
+TEST_CASE("read_toml_key_in_section trims quoted values before inline comments",
+          "[cli][update-check][coverage][phase3]") {
+    std::string src =
+        "[update]\n"
+        "mode =   \"manual\"   # selected by user\n"
+        "channel = beta\n";
+
+    REQUIRE(uc::read_toml_key_in_section(src, "update", "mode") == "manual");
+    REQUIRE(uc::read_toml_key_in_section(src, "update", "channel") == "beta");
+}
+
+TEST_CASE("write_toml_key_in_section appends into empty section before the next section",
+          "[cli][update-check][coverage][phase3]") {
+    std::string src =
+        "[update]\n"
+        "\n"
+        "[pr]\n"
+        "workflow = \"github\"\n";
+
+    auto out = uc::write_toml_key_in_section(src, "update", "mode", "manual");
+    REQUIRE(uc::read_toml_key_in_section(out, "update", "mode") == "manual");
+    REQUIRE(uc::read_toml_key_in_section(out, "pr", "workflow") == "github");
+
+    auto update_pos = out.find("[update]");
+    auto mode_pos = out.find("mode = \"manual\"");
+    auto pr_pos = out.find("[pr]");
+    REQUIRE(update_pos != std::string::npos);
+    REQUIRE(mode_pos != std::string::npos);
+    REQUIRE(pr_pos != std::string::npos);
+    REQUIRE(update_pos < mode_pos);
+    REQUIRE(mode_pos < pr_pos);
+}
+
 // ── Fetcher injection ───────────────────────────────────────────────────────
 
 TEST_CASE("refresh_cache consumes fake fetcher, no network",

--- a/test/test_cli_update_mode.cpp
+++ b/test/test_cli_update_mode.cpp
@@ -95,6 +95,13 @@ TEST_CASE("parse_snooze tolerates whitespace and trailing content",
     REQUIRE(um::parse_snooze("-5") == -5);
 }
 
+TEST_CASE("parse_snooze starts at the first numeric run",
+          "[cli][update-mode][coverage][phase3]") {
+    REQUIRE(um::parse_snooze("expires: 1700000000") == 1'700'000'000);
+    REQUIRE(um::parse_snooze("abc -42 trailing 99") == -42);
+    REQUIRE(um::parse_snooze("12 34") == 12);
+}
+
 TEST_CASE("parse_snooze returns 0 on malformed input (failure-open)",
           "[cli][update-mode][issue-550]") {
     REQUIRE(um::parse_snooze("") == 0);

--- a/test/test_cli_version_diag.cpp
+++ b/test/test_cli_version_diag.cpp
@@ -624,3 +624,25 @@ TEST_CASE("render_report_json emits JSON with projects[] and findings[]",
     REQUIRE(out.find("\"name\": \"A\"") != std::string::npos);
     REQUIRE(out.find("\"severity\": \"warn\"") != std::string::npos);
 }
+
+TEST_CASE("render_report_json escapes project fields",
+          "[version-diag][coverage][phase3]") {
+    VersionReport r;
+    r.cli = parse_semver("0.31.0");
+
+    ProjectEntry p;
+    p.path = "/tmp/project\"with\\chars";
+    p.name = "Quoted \"Project\"\nName";
+    p.sdk = parse_semver("0.31.0");
+    r.projects.push_back(p);
+
+    std::stringstream capture;
+    auto* prev = std::cout.rdbuf(capture.rdbuf());
+    int rc = render_report_json(r);
+    std::cout.rdbuf(prev);
+
+    REQUIRE(rc == 0);
+    auto out = capture.str();
+    REQUIRE(out.find(R"("path": "/tmp/project\"with\\chars")") != std::string::npos);
+    REQUIRE(out.find(R"("name": "Quoted \"Project\"\nName")") != std::string::npos);
+}

--- a/test/test_cli_version_diag.cpp
+++ b/test/test_cli_version_diag.cpp
@@ -133,6 +133,23 @@ TEST_CASE("read_plugin_version returns empty when manifest has no version field"
     REQUIRE(v.raw.empty());
 }
 
+TEST_CASE("read_plugin_version accepts tag-style version strings",
+          "[version-diag][coverage][phase3]") {
+    TempDir tmp;
+    auto plugin_json = tmp.path / ".claude-plugin" / "plugin.json";
+    write_file(plugin_json, R"({
+        "name": "pulp",
+        "version": "v1.2.3"
+    })");
+
+    auto v = read_plugin_version(plugin_json);
+    REQUIRE(v.comparable);
+    REQUIRE(v.raw == "v1.2.3");
+    REQUIRE(v.major == 1);
+    REQUIRE(v.minor == 2);
+    REQUIRE(v.patch == 3);
+}
+
 TEST_CASE("locate_plugin_json prefers an explicit override",
           "[version-diag][issue-499]") {
     TempDir tmp;

--- a/test/test_gui_components.cpp
+++ b/test/test_gui_components.cpp
@@ -863,3 +863,37 @@ TEST_CASE("LassoComponent callback fires", "[gui][lasso]") {
     REQUIRE(last_rect.width == 100.0f);
     REQUIRE(last_rect.height == 100.0f);
 }
+
+TEST_CASE("LassoComponent completes selection and only paints while active",
+          "[gui][lasso][coverage][phase3]") {
+    LassoComponent lasso;
+    SelectionRect completed;
+    int complete_calls = 0;
+    lasso.on_selection_complete = [&](const SelectionRect& r) {
+        completed = r;
+        ++complete_calls;
+    };
+
+    RecordingCanvas inactive;
+    lasso.paint(inactive);
+    REQUIRE(inactive.commands().empty());
+
+    lasso.on_mouse_down({40.0f, 30.0f});
+    lasso.on_mouse_drag({10.0f, 70.0f});
+
+    RecordingCanvas active;
+    lasso.paint(active);
+    REQUIRE(active.count(DrawCommand::Type::fill_rect) == 1);
+    REQUIRE(active.count(DrawCommand::Type::stroke_rect) == 1);
+
+    lasso.on_mouse_up({10.0f, 70.0f});
+    REQUIRE_FALSE(lasso.is_active());
+    REQUIRE(complete_calls == 1);
+    REQUIRE(completed.x == 10.0f);
+    REQUIRE(completed.y == 30.0f);
+    REQUIRE(completed.width == 30.0f);
+    REQUIRE(completed.height == 40.0f);
+
+    lasso.end_selection();
+    REQUIRE(complete_calls == 1);
+}

--- a/test/test_image_view_cache.cpp
+++ b/test/test_image_view_cache.cpp
@@ -254,6 +254,44 @@ TEST_CASE("object-position: percentage offsets the centred dst",
     REQUIRE_THAT(cv2.draws[0].dy, WithinAbs(0.0f, 0.001f));     // 100 - 100
 }
 
+TEST_CASE("object-fit unknown keyword falls back to fill",
+          "[widgets][image][object-fit][coverage][phase3]") {
+    using Catch::Matchers::WithinAbs;
+    ImageView v;
+    configure_view(v, 200, 100, "stretchy");
+    ImageStubCanvas cv;
+    cv.img_w = 50.0f;
+    cv.img_h = 50.0f;
+
+    v.paint(cv);
+
+    REQUIRE(cv.draws.size() == 1);
+    REQUIRE_FALSE(cv.draws[0].has_src);
+    REQUIRE_THAT(cv.draws[0].dx, WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(cv.draws[0].dy, WithinAbs(0.0f, 0.001f));
+    REQUIRE_THAT(cv.draws[0].dw, WithinAbs(200.0f, 0.001f));
+    REQUIRE_THAT(cv.draws[0].dh, WithinAbs(100.0f, 0.001f));
+}
+
+TEST_CASE("object-position pixel lengths offset by slack",
+          "[widgets][image][object-position][coverage][phase3]") {
+    using Catch::Matchers::WithinAbs;
+    ImageView v;
+    configure_view(v, 200, 140, "contain", "25px 10px");
+    ImageStubCanvas cv;
+    cv.img_w = 100.0f;
+    cv.img_h = 100.0f;
+
+    v.paint(cv);
+
+    REQUIRE(cv.draws.size() == 1);
+    REQUIRE_FALSE(cv.draws[0].has_src);
+    REQUIRE_THAT(cv.draws[0].dw, WithinAbs(140.0f, 0.001f));
+    REQUIRE_THAT(cv.draws[0].dh, WithinAbs(140.0f, 0.001f));
+    REQUIRE_THAT(cv.draws[0].dx, WithinAbs(25.0f, 0.001f));
+    REQUIRE_THAT(cv.draws[0].dy, WithinAbs(0.0f, 0.001f));
+}
+
 TEST_CASE("object-fit graceful fallback when measure_image_from_file fails",
           "[widgets][image][object-fit][issue-1737]") {
     using Catch::Matchers::WithinAbs;

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -511,3 +511,32 @@ TEST_CASE("JsonRpcPeer destructor releases the channel callback",
     REQUIRE(pair.first->send_text("raw after peer"));
     REQUIRE(raw_message == "raw after peer");
 }
+
+TEST_CASE("JsonRpcPeer consumes pending callbacks after the first response",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string outbound_request;
+    pair.second->on_message([&](const Message& message) {
+        outbound_request.assign(message.as_text());
+    });
+
+    JsonRpcPeer client(*pair.first);
+    std::atomic<int> callbacks{0};
+    std::string last_result;
+
+    REQUIRE(client.send_request("once", "[]", [&](const JsonRpcResult& response) {
+        last_result = response.result_json;
+        callbacks.fetch_add(1);
+    }));
+    REQUIRE(outbound_request.find(R"("id":1)") != std::string::npos);
+
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":"first"})json");
+    REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
+    REQUIRE(last_result == R"("first")");
+
+    pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":"duplicate"})json");
+    std::this_thread::sleep_for(10ms);
+    REQUIRE(callbacks.load() == 1);
+    REQUIRE(last_result == R"("first")");
+}

--- a/test/test_json_rpc.cpp
+++ b/test/test_json_rpc.cpp
@@ -478,3 +478,36 @@ TEST_CASE("JsonRpcPeer ignores malformed response payloads without firing callba
     pair.second->send_text(R"json({"jsonrpc":"2.0","id":1,"result":true})json");
     REQUIRE(wait_until([&] { return callbacks.load() == 1; }));
 }
+
+TEST_CASE("JsonRpcPeer destructor releases the channel callback",
+          "[json_rpc][coverage][phase3]") {
+    auto pair = MemoryMessageChannel::make_pair();
+
+    std::string reply;
+    pair.first->on_message([&](const Message& message) {
+        reply.assign(message.as_text());
+    });
+
+    {
+        JsonRpcPeer server(*pair.second);
+        server.register_method("echo", [](std::string_view params) {
+            return JsonRpcResult::ok(std::string(params));
+        });
+
+        REQUIRE(pair.first->send_text(
+            R"json({"jsonrpc":"2.0","id":1,"method":"echo","params":{"first":true}})json"));
+        REQUIRE(reply.find(R"("first")") != std::string::npos);
+    }
+
+    reply.clear();
+    REQUIRE(pair.first->send_text(
+        R"json({"jsonrpc":"2.0","id":2,"method":"echo","params":{"stale":true}})json"));
+    REQUIRE(reply.empty());
+
+    std::string raw_message;
+    pair.second->on_message([&](const Message& message) {
+        raw_message.assign(message.as_text());
+    });
+    REQUIRE(pair.first->send_text("raw after peer"));
+    REQUIRE(raw_message == "raw after peer");
+}

--- a/test/test_license.cpp
+++ b/test/test_license.cpp
@@ -5,6 +5,7 @@
 #include <pulp/runtime/temporary_file.hpp>
 
 #include <fstream>
+#include <limits>
 #include <utility>
 
 using namespace pulp::runtime;
@@ -146,6 +147,16 @@ TEST_CASE("BigInteger self assignment and identity arithmetic stay stable",
     REQUIRE((value * BigInteger(1)).to_string() == "144");
     REQUIRE((BigInteger(3) % BigInteger(10)).to_string() == "3");
     REQUIRE(value.mod_pow(BigInteger(0), BigInteger(17)).to_string() == "1");
+}
+
+TEST_CASE("BigInteger uint64 constructor preserves unsigned high values",
+          "[crypto][bigint][coverage][phase3]") {
+    BigInteger max_value(std::numeric_limits<std::uint64_t>::max());
+
+    REQUIRE(max_value.to_string() == "18446744073709551615");
+    REQUIRE(max_value.to_hex() == "FFFFFFFFFFFFFFFF");
+    REQUIRE(max_value.bit_count() == 64);
+    REQUIRE_FALSE(max_value.is_zero());
 }
 
 // ── License ─────────────────────────────────────────────────────────────

--- a/test/test_motion_preferences.cpp
+++ b/test/test_motion_preferences.cpp
@@ -135,6 +135,24 @@ TEST_CASE("MotionPreferences on_policy_changed fires on override transition",
     REQUIRE(seen.back() == prefs.policy());
 }
 
+TEST_CASE("MotionPreferences policy callback may re-enter preferences",
+          "[motion-preferences][coverage][phase3]") {
+    PrefsScope scope;
+    auto& prefs = MotionPreferences::instance();
+    prefs.set_override(MotionPolicy::Full);
+
+    std::vector<MotionPolicy> seen;
+    prefs.on_policy_changed([&](MotionPolicy p) {
+        seen.push_back(p);
+        prefs.set_duration_scale(p == MotionPolicy::Reduced ? 0.25 : 1.0);
+    });
+
+    prefs.set_override(MotionPolicy::Reduced);
+
+    REQUIRE(seen == std::vector<MotionPolicy>{MotionPolicy::Reduced});
+    REQUIRE(prefs.duration_scale() == Approx(0.25));
+}
+
 TEST_CASE("MotionPreferences poll is a no-op while override is set",
           "[motion-preferences]") {
     PrefsScope scope;

--- a/test/test_param_attachment.cpp
+++ b/test/test_param_attachment.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pulp/canvas/canvas.hpp>
 #include <pulp/view/param_attachment.hpp>
 
 using namespace pulp::view;
@@ -109,6 +110,28 @@ TEST_CASE("attach_knob on_change writes to store", "[view][attachment]") {
     // Simulate user dragging knob to 0.5 normalized
     if (knob->on_change) knob->on_change(0.5f);
     REQUIRE_THAT(store.get_normalized(1), WithinAbs(0.5, 0.01));
+}
+
+TEST_CASE("attach_knob formatter denormalizes values with units",
+          "[view][attachment][coverage][phase3]") {
+    StateStore store;
+    setup_store(store);
+
+    auto [knob, binding] = attach_knob(store, 1, 80.0f);
+    knob->set_bounds({0, 0, 80, 80});
+    knob->set_value(0.0f);
+
+    pulp::canvas::RecordingCanvas canvas;
+    knob->paint(canvas);
+
+    bool saw_min_hz = false;
+    for (const auto& command : canvas.commands()) {
+        if (command.type == pulp::canvas::DrawCommand::Type::fill_text &&
+            command.text == "20.0 Hz") {
+            saw_min_hz = true;
+        }
+    }
+    REQUIRE(saw_min_hz);
 }
 
 TEST_CASE("param attachments forward fader toggle and combo edits",

--- a/test/test_table_list_box.cpp
+++ b/test/test_table_list_box.cpp
@@ -174,6 +174,30 @@ TEST_CASE("SimpleTableModel handles negative sort columns and sparse rows",
     REQUIRE(model.cell_text(1, 1) == "two");
 }
 
+TEST_CASE("SimpleTableModel sorts descending and guards out-of-range cells",
+          "[gui][table][coverage][phase3]") {
+    SimpleTableModel model;
+    model.set_data({
+        {"Alpha", "3"},
+        {"Gamma", "1"},
+        {"Beta", "2"},
+    });
+
+    REQUIRE(model.cell_text(-1, 0).empty());
+    REQUIRE(model.cell_text(99, 0).empty());
+    REQUIRE(model.cell_text(0, -1).empty());
+    REQUIRE(model.cell_text(0, 99).empty());
+
+    REQUIRE(model.sort(0, false));
+    REQUIRE(model.cell_text(0, 0) == "Gamma");
+    REQUIRE(model.cell_text(1, 0) == "Beta");
+    REQUIRE(model.cell_text(2, 0) == "Alpha");
+
+    REQUIRE(model.sort(1, true));
+    REQUIRE(model.cell_text(0, 1) == "1");
+    REQUIRE(model.cell_text(2, 1) == "3");
+}
+
 TEST_CASE("TableListBox clear columns and model-less clicks are stable",
           "[gui][table][coverage][issue-653]") {
     TableListBox table;

--- a/test/test_theme.cpp
+++ b/test/test_theme.cpp
@@ -232,6 +232,21 @@ TEST_CASE("Theme from_json maps malformed color strings to default color",
     REQUIRE(theme.color("bad.short").value() == Color{});
 }
 
+TEST_CASE("Theme from_json maps invalid hex digits to default color",
+          "[view][theme][coverage][phase3]") {
+    auto theme = Theme::from_json(R"({
+        "colors": {
+            "bad.digit": "#12xx56",
+            "bad.tail": "#123456zz",
+            "bad.long": "#fffffffff"
+        }
+    })");
+
+    REQUIRE(theme.color("bad.digit").value() == Color{});
+    REQUIRE(theme.color("bad.tail").value() == Color{});
+    REQUIRE(theme.color("bad.long").value() == Color{});
+}
+
 TEST_CASE("Theme JSON parser covers optional sections and alpha colors",
           "[view][theme][coverage][issue-651]") {
     auto theme = Theme::from_json(R"({

--- a/test/test_theme_contrast.cpp
+++ b/test/test_theme_contrast.cpp
@@ -97,6 +97,20 @@ TEST_CASE("Adjust for contrast returns meeting color", "[view][contrast]") {
     REQUIRE(meets_contrast(*result, Color::rgba8(255, 255, 255), ContrastLevel::aa_normal));
 }
 
+TEST_CASE("Adjust for contrast preserves already compliant colors",
+          "[view][contrast][coverage][phase3]") {
+    auto foreground = Color::rgba8(255, 255, 255, 128);
+    auto background = Color::rgba8(0, 0, 0);
+
+    auto result = adjust_for_contrast(foreground, background, ContrastLevel::aaa_normal);
+
+    REQUIRE(result.has_value());
+    REQUIRE(result->r8() == foreground.r8());
+    REQUIRE(result->g8() == foreground.g8());
+    REQUIRE(result->b8() == foreground.b8());
+    REQUIRE(result->a8() == foreground.a8());
+}
+
 // ── HSL Conversion ──────────────────────────────────────────────────────────
 
 TEST_CASE("HSL round-trip for pure red", "[view][contrast][hsl]") {

--- a/test/test_tree_view.cpp
+++ b/test/test_tree_view.cpp
@@ -117,6 +117,26 @@ TEST_CASE("TreeView ignores mouse up and misses", "[view][tree]") {
     REQUIRE(tree.selected_node() == nullptr);
 }
 
+TEST_CASE("TreeView skips selection callback for non-selectable rows",
+          "[view][tree][coverage][phase3]") {
+    TreeView tree;
+    auto& header = tree.root().add_child("Header");
+    header.selectable = false;
+    auto& selectable = tree.root().add_child("Selectable");
+    tree.set_bounds({0, 0, 300, 400});
+
+    int selected_count = 0;
+    tree.on_select = [&](TreeNode&) { ++selected_count; };
+
+    tree.on_mouse_event(mouse_down(50, 5));
+    REQUIRE(selected_count == 0);
+    REQUIRE(tree.selected_node() == nullptr);
+
+    tree.on_mouse_event(mouse_down(50, 28));
+    REQUIRE(selected_count == 1);
+    REQUIRE(tree.selected_node() == &selectable);
+}
+
 TEST_CASE("TreeView triangle click toggles without selecting", "[view][tree]") {
     TreeView tree;
     auto& synths = tree.root().add_child("Synths");

--- a/test/test_ui_components.cpp
+++ b/test/test_ui_components.cpp
@@ -240,6 +240,25 @@ TEST_CASE("ComboBox opening another popup closes the previous one",
     ComboBox::close_active_popup();
 }
 
+TEST_CASE("ComboBox destructor clears active popup slot",
+          "[view][combo][coverage][phase3]") {
+    ComboBox::close_active_popup();
+
+    {
+        ComboBox combo;
+        combo.set_items({"One", "Two"});
+
+        KeyEvent space;
+        space.key = KeyCode::space;
+        space.is_down = true;
+        REQUIRE(combo.on_key_event(space));
+        REQUIRE(combo.is_open());
+        REQUIRE(ComboBox::active_popup_ == &combo);
+    }
+
+    REQUIRE(ComboBox::active_popup_ == nullptr);
+}
+
 // ── Tooltip ──────────────────────────────────────────────────────────────
 
 TEST_CASE("Tooltip show and hide", "[view][tooltip]") {

--- a/test/test_view_layout_widgets.cpp
+++ b/test/test_view_layout_widgets.cpp
@@ -66,6 +66,34 @@ TEST_CASE("SplitView lays out horizontal and vertical panes around divider",
     REQUIRE_THAT(second_ptr->bounds().height, WithinAbs(146.0f, 0.001f));
 }
 
+TEST_CASE("SplitView clamps split fraction and supports pane replacement",
+          "[view][split_view][coverage][phase3]") {
+    SplitView split;
+    auto first = std::make_unique<View>();
+    auto second = std::make_unique<View>();
+    auto replacement = std::make_unique<View>();
+    auto* first_ptr = first.get();
+    auto* replacement_ptr = replacement.get();
+
+    split.set_first(std::move(first));
+    split.set_second(std::move(second));
+    REQUIRE(split.child_count() == 2);
+    REQUIRE(split.first() == first_ptr);
+
+    split.set_split_fraction(-1.0f);
+    REQUIRE_THAT(split.split_fraction(), WithinAbs(0.0f, 0.001f));
+    split.set_split_fraction(2.0f);
+    REQUIRE_THAT(split.split_fraction(), WithinAbs(1.0f, 0.001f));
+
+    split.set_first(std::move(replacement));
+    REQUIRE(split.child_count() == 2);
+    REQUIRE(split.first() == replacement_ptr);
+
+    split.set_second(nullptr);
+    REQUIRE(split.second() == nullptr);
+    REQUIRE(split.child_count() == 1);
+}
+
 TEST_CASE("SplitView drag clamps to minimum pane sizes and reports changes",
           "[view][split_view][interaction]") {
     SplitView split;

--- a/test/test_window_manager.cpp
+++ b/test/test_window_manager.cpp
@@ -337,6 +337,23 @@ TEST_CASE("WindowManager send and broadcast skip missing handlers",
     REQUIRE(count == 1);
 }
 
+TEST_CASE("WindowManager ignores handlers for unknown windows",
+          "[view][multiwindow][coverage][phase3]") {
+    WindowManager mgr;
+    int count = 0;
+
+    mgr.set_message_handler(42, [&](const WindowMessage&) {
+        ++count;
+    });
+
+    WindowMessage msg;
+    msg.type = "orphan";
+    mgr.send_message(42, msg);
+    mgr.broadcast_message(msg);
+
+    REQUIRE(count == 0);
+}
+
 // ── Window state save / restore ─────────────────────────────────────────────
 
 TEST_CASE("WindowManager state save and restore", "[view][multiwindow]") {

--- a/tools/cli/cmd_run_parse.cpp
+++ b/tools/cli/cmd_run_parse.cpp
@@ -16,6 +16,7 @@ namespace {
 
 bool parse_frame_count(const std::string& value, int& frames) {
     if (value.empty()) return false;
+    if (value.front() == '+') return false;
     int parsed = 0;
     const char* first = value.data();
     const char* last = first + value.size();


### PR DESCRIPTION
## Summary
- batch 28 Phase 3 Codecov coverage commits across view, runtime, and CLI edge cases
- include targeted hardening found while writing tests (theme parsing, asset replacement accounting, tree row selectability, async stream restart/null-write handling, BigInteger uint64 high values, analytics null destinations, CLI parsing/reporting edges)
- GitHub-hosted CI only; no Namespace dispatch

## Local validation
- git diff --check
- version_bump_check.py --mode=report --require-bump-for-fix-feat
- targeted macOS builds/tests passed for 24 test binaries: theme, window-manager, theme-contrast, asset-manager, appearance, motion-preferences, image-view-cache, tree-view, view-layout-widgets, gui-components, ab-compare, param-attachment, table-list-box, ui-components, json-rpc, async-stream, license, analytics, cli-run-options, cli-update-mode, cli-update-check, cli-sdk-tarball-filename, cli-project-bump, cli-version-diag

## CI policy
- Batched PR to reduce GitHub macOS runner load
- Monitor to green and merge when checks pass
