### PR TITLE
feat(view): TextAccessibilityNode scaffold (font v2 Slice 2.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.58.0",
+      "version": "0.59.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.58.0"
+  "version": "0.59.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.127.0
+    VERSION 0.128.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -184,6 +184,7 @@ endif()
 target_sources(pulp-view PRIVATE
     ${PULP_JS_ENGINE_SOURCES}
     src/accessibility.cpp
+    src/text_accessibility.cpp
     src/table_model.cpp
     src/modulation_matrix.cpp
     src/modulation_matrix_widget.cpp

--- a/core/view/include/pulp/view/text_accessibility.hpp
+++ b/core/view/include/pulp/view/text_accessibility.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+// Cross-platform text accessibility scaffold (font v2 Slice 2.6).
+//
+// Most of Pulp's painted text bypasses the platform a11y APIs
+// (NSAccessibility on macOS, UIA on Windows, AccessKit on Linux) because
+// glyphs land directly on the GPU canvas without ever entering the
+// platform's accessibility tree. This header defines the cross-platform
+// SURFACE — a value type that captures the minimum a screen reader needs
+// and a registration entry point — plus a no-op default backend that
+// stores nodes in a process-local table.
+//
+// The full per-platform glue (NSAccessibility selectors, UIA com objects,
+// AccessKit serialization) is intentionally out of scope here; that lands
+// in follow-up slices that overlay this default backend.
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pulp::view {
+
+/// Coarse semantic role for a piece of accessible text. The platform
+/// backend maps this to its native role (NSAccessibilityStaticTextRole,
+/// UIA_TextControlTypeId, AccessKit Role::StaticText, etc.).
+enum class TextAccessibilityRole : std::uint8_t {
+    Label,
+    Button,
+    TextEditor,
+    Heading,
+    Other,
+};
+
+/// A single accessible text node — the minimum a screen reader needs to
+/// describe a piece of painted text. All offsets are byte offsets into
+/// `text` (UTF-8) or code-unit offsets when expressed in UTF-16.
+struct TextAccessibilityNode {
+    /// Caller-stable identifier. Used as the registration key.
+    std::string id;
+
+    /// UTF-8 content of the node.
+    std::string text;
+
+    /// Semantic role hint.
+    TextAccessibilityRole role = TextAccessibilityRole::Label;
+
+    /// Cluster boundaries in UTF-8 byte offsets. Each entry is the
+    /// starting byte index of a grapheme cluster; the vector should
+    /// typically include 0 and text.size() as bookends.
+    std::vector<std::size_t> cluster_boundaries_utf8;
+
+    /// Cluster boundaries in UTF-16 code units. Mirrors the UTF-8
+    /// vector but expressed in the encoding most platform a11y APIs
+    /// (NSAccessibility, UIA) expose.
+    std::vector<std::size_t> cluster_boundaries_utf16;
+
+    /// Active selection range in UTF-8 byte offsets. Both fields == 0
+    /// means "no selection" (i.e. the node has no caret).
+    std::size_t selection_start_utf8 = 0;
+    std::size_t selection_end_utf8 = 0;
+};
+
+/// Returns the active accessibility backend identifier. The default
+/// backend is "none"; per-platform overlays return "macos-ax",
+/// "windows-uia", or "linux-accesskit". Stable across calls for the
+/// lifetime of the process.
+std::string_view accessibility_backend_name() noexcept;
+
+/// Register or replace a text node with the active a11y backend. The
+/// default backend stores the node in a process-local table that tests
+/// can read back via `snapshot_accessibility_nodes()`. Registering with
+/// an `id` that already exists replaces the previous entry — registration
+/// is idempotent on the id.
+void register_text_accessibility_node(const TextAccessibilityNode& node);
+
+/// Drop the node registered under `id`. Silently does nothing if no
+/// such node is registered.
+void unregister_text_accessibility_node(std::string_view id);
+
+/// Read back the currently-registered nodes. Returns by value (a copy)
+/// so callers do not race with concurrent register/unregister activity.
+/// Order is unspecified.
+std::vector<TextAccessibilityNode> snapshot_accessibility_nodes();
+
+}  // namespace pulp::view

--- a/core/view/src/text_accessibility.cpp
+++ b/core/view/src/text_accessibility.cpp
@@ -1,0 +1,70 @@
+// Cross-platform text accessibility scaffold (font v2 Slice 2.6).
+//
+// Implements the default "none" backend: a process-local mutex-guarded
+// table of TextAccessibilityNode entries keyed by id. Per-platform
+// backends (NSAccessibility, UIA, AccessKit) overlay this in future
+// slices; until they land, this gives the text-paint sites a stable API
+// surface to call against and gives tests a snapshot they can introspect.
+
+#include <pulp/view/text_accessibility.hpp>
+
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace pulp::view {
+
+namespace {
+
+struct Registry {
+    std::mutex mu;
+    std::unordered_map<std::string, TextAccessibilityNode> nodes;
+};
+
+Registry& registry() {
+    // Function-local static: thread-safe initialization, no global
+    // constructor ordering hazard. Lives for the lifetime of the
+    // process, which is what we want for the default backend.
+    static Registry r;
+    return r;
+}
+
+}  // namespace
+
+std::string_view accessibility_backend_name() noexcept {
+    // The default backend does not talk to any platform a11y API. Per-
+    // platform overlays replace this symbol at link time (or via a
+    // future plug-in registration point) with "macos-ax",
+    // "windows-uia", or "linux-accesskit".
+    return "none";
+}
+
+void register_text_accessibility_node(const TextAccessibilityNode& node) {
+    auto& r = registry();
+    std::lock_guard<std::mutex> lock(r.mu);
+    // Idempotent on id: operator[] + assignment so that a second
+    // register with the same id replaces the first.
+    r.nodes[node.id] = node;
+}
+
+void unregister_text_accessibility_node(std::string_view id) {
+    auto& r = registry();
+    std::lock_guard<std::mutex> lock(r.mu);
+    // unordered_map::erase only takes a key by value for the
+    // heterogeneous-lookup-less default, so materialize once.
+    r.nodes.erase(std::string(id));
+}
+
+std::vector<TextAccessibilityNode> snapshot_accessibility_nodes() {
+    auto& r = registry();
+    std::lock_guard<std::mutex> lock(r.mu);
+    std::vector<TextAccessibilityNode> out;
+    out.reserve(r.nodes.size());
+    for (const auto& [_, node] : r.nodes) {
+        out.push_back(node);
+    }
+    return out;
+}
+
+}  // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -745,6 +745,8 @@ pulp_add_test_suite(pulp-test-image-view-cache LIBRARIES pulp::view)
 
 # Accessibility tree snapshot (workstream 04 slice 4.4)
 pulp_add_test_suite(pulp-test-accessibility-tree LIBRARIES pulp::view)
+# Text-accessibility scaffold (font v2 Slice 2.6)
+pulp_add_test_suite(pulp-test-text-accessibility LIBRARIES pulp::view)
 # A/B compare (workstream 07 slice 7.2)
 pulp_add_test_suite(pulp-test-ab-compare LIBRARIES pulp::view)
 # ViewSize::aspect_ratio field (workstream 07 slice 7.5b)

--- a/test/test_text_accessibility.cpp
+++ b/test/test_text_accessibility.cpp
@@ -1,0 +1,206 @@
+// Cross-platform text-accessibility scaffold (font v2 Slice 2.6).
+//
+// Validates the default no-op backend: a process-local registry that
+// stores TextAccessibilityNode entries keyed by id. The platform
+// overlays (NSAccessibility, UIA, AccessKit) will replace
+// accessibility_backend_name() and the register/unregister symbols in
+// a follow-up slice; this test pins down the cross-platform surface.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/text_accessibility.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace pulp::view;
+
+namespace {
+
+void clear_registry() {
+    for (const auto& node : snapshot_accessibility_nodes()) {
+        unregister_text_accessibility_node(node.id);
+    }
+    REQUIRE(snapshot_accessibility_nodes().empty());
+}
+
+const TextAccessibilityNode* find_by_id(
+    const std::vector<TextAccessibilityNode>& nodes, std::string_view id) {
+    for (const auto& n : nodes) {
+        if (n.id == id) return &n;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+TEST_CASE("TextAccessibilityNode: register label round-trips through snapshot",
+          "[view][text-a11y][issue-2255]") {
+    clear_registry();
+
+    TextAccessibilityNode node;
+    node.id = "label-1";
+    node.text = "Hello";
+    node.role = TextAccessibilityRole::Label;
+    node.cluster_boundaries_utf8 = {0, 1, 2, 3, 4, 5};
+    node.cluster_boundaries_utf16 = {0, 1, 2, 3, 4, 5};
+
+    register_text_accessibility_node(node);
+
+    auto snap = snapshot_accessibility_nodes();
+    REQUIRE(snap.size() == 1);
+    REQUIRE(snap[0].id == "label-1");
+    REQUIRE(snap[0].text == "Hello");
+    REQUIRE(snap[0].role == TextAccessibilityRole::Label);
+    REQUIRE(snap[0].cluster_boundaries_utf8.size() == 6);
+
+    clear_registry();
+}
+
+TEST_CASE("TextAccessibilityNode: two distinct ids coexist in registry",
+          "[view][text-a11y][issue-2255]") {
+    clear_registry();
+
+    TextAccessibilityNode a;
+    a.id = "alpha";
+    a.text = "A";
+    a.role = TextAccessibilityRole::Label;
+
+    TextAccessibilityNode b;
+    b.id = "beta";
+    b.text = "B";
+    b.role = TextAccessibilityRole::Button;
+
+    register_text_accessibility_node(a);
+    register_text_accessibility_node(b);
+
+    auto snap = snapshot_accessibility_nodes();
+    REQUIRE(snap.size() == 2);
+    const auto* found_a = find_by_id(snap, "alpha");
+    const auto* found_b = find_by_id(snap, "beta");
+    REQUIRE(found_a != nullptr);
+    REQUIRE(found_b != nullptr);
+    REQUIRE(found_a->text == "A");
+    REQUIRE(found_b->text == "B");
+    REQUIRE(found_b->role == TextAccessibilityRole::Button);
+
+    clear_registry();
+}
+
+TEST_CASE("TextAccessibilityNode: same-id register replaces previous entry",
+          "[view][text-a11y][issue-2255]") {
+    clear_registry();
+
+    TextAccessibilityNode first;
+    first.id = "dup";
+    first.text = "old";
+    first.role = TextAccessibilityRole::Label;
+    register_text_accessibility_node(first);
+
+    TextAccessibilityNode second;
+    second.id = "dup";
+    second.text = "new";
+    second.role = TextAccessibilityRole::Heading;
+    register_text_accessibility_node(second);
+
+    auto snap = snapshot_accessibility_nodes();
+    REQUIRE(snap.size() == 1);
+    REQUIRE(snap[0].id == "dup");
+    REQUIRE(snap[0].text == "new");
+    REQUIRE(snap[0].role == TextAccessibilityRole::Heading);
+
+    clear_registry();
+}
+
+TEST_CASE("TextAccessibilityNode: unregister drops entry by id",
+          "[view][text-a11y][issue-2255]") {
+    clear_registry();
+
+    TextAccessibilityNode node;
+    node.id = "to-drop";
+    node.text = "bye";
+    register_text_accessibility_node(node);
+    REQUIRE(snapshot_accessibility_nodes().size() == 1);
+
+    unregister_text_accessibility_node("to-drop");
+    REQUIRE(snapshot_accessibility_nodes().empty());
+
+    // Unregistering a missing id is a silent no-op.
+    unregister_text_accessibility_node("never-registered");
+    REQUIRE(snapshot_accessibility_nodes().empty());
+}
+
+TEST_CASE("TextAccessibilityNode: default backend probe is stable and 'none'",
+          "[view][text-a11y][issue-2255]") {
+    const auto first = accessibility_backend_name();
+    const auto second = accessibility_backend_name();
+    REQUIRE(first == second);
+    // The scaffold ships only the default backend; per-platform overlays
+    // replace this symbol in follow-up slices.
+    REQUIRE(first == "none");
+}
+
+TEST_CASE("TextAccessibilityNode: cluster boundary vectors round-trip",
+          "[view][text-a11y][issue-2255]") {
+    clear_registry();
+
+    TextAccessibilityNode node;
+    node.id = "clusters";
+    node.text = "Hi  there";  // contrived: boundaries don't need to match text
+    node.cluster_boundaries_utf8 = {0, 2, 5, 7};
+    node.cluster_boundaries_utf16 = {0, 1, 3, 4};
+    node.selection_start_utf8 = 2;
+    node.selection_end_utf8 = 5;
+    register_text_accessibility_node(node);
+
+    auto snap = snapshot_accessibility_nodes();
+    REQUIRE(snap.size() == 1);
+    REQUIRE(snap[0].cluster_boundaries_utf8 == std::vector<std::size_t>{0, 2, 5, 7});
+    REQUIRE(snap[0].cluster_boundaries_utf16 == std::vector<std::size_t>{0, 1, 3, 4});
+    REQUIRE(snap[0].selection_start_utf8 == 2);
+    REQUIRE(snap[0].selection_end_utf8 == 5);
+
+    clear_registry();
+}
+
+TEST_CASE("TextAccessibilityNode: concurrent register from N threads is race-free",
+          "[view][text-a11y][issue-2255]") {
+    clear_registry();
+
+    constexpr int kThreads = 10;
+    constexpr int kPerThread = 25;
+
+    std::vector<std::thread> workers;
+    workers.reserve(kThreads);
+    std::atomic<int> registered{0};
+
+    for (int t = 0; t < kThreads; ++t) {
+        workers.emplace_back([t, &registered] {
+            for (int i = 0; i < kPerThread; ++i) {
+                TextAccessibilityNode node;
+                node.id = "t" + std::to_string(t) + "-i" + std::to_string(i);
+                node.text = node.id;
+                node.role = TextAccessibilityRole::Other;
+                register_text_accessibility_node(node);
+                registered.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    for (auto& w : workers) w.join();
+
+    REQUIRE(registered.load() == kThreads * kPerThread);
+    auto snap = snapshot_accessibility_nodes();
+    REQUIRE(static_cast<int>(snap.size()) == kThreads * kPerThread);
+
+    // Every node id is distinct; the registry must hold them all.
+    std::vector<std::string> ids;
+    ids.reserve(snap.size());
+    for (const auto& n : snap) ids.push_back(n.id);
+    std::sort(ids.begin(), ids.end());
+    REQUIRE(std::adjacent_find(ids.begin(), ids.end()) == ids.end());
+
+    clear_registry();
+}


### PR DESCRIPTION
## Summary

Font v2 **Slice 2.6 — Accessibility text exposure (scaffold only)**.

Most painted text in Pulp bypasses the platform a11y APIs (NSAccessibility, UIA, AccessKit) because glyphs land directly on the GPU canvas. This PR lands the cross-platform **surface** so text-paint sites can opt in, plus a no-op default backend that compiles on every platform.

## API surface (`pulp::view`)

- `struct TextAccessibilityNode { id, text, role, cluster_boundaries_utf8, cluster_boundaries_utf16, selection_start_utf8, selection_end_utf8 }`
- `enum class TextAccessibilityRole { Label, Button, TextEditor, Heading, Other }`
- `register_text_accessibility_node(node)` / `unregister_text_accessibility_node(id)`
- `snapshot_accessibility_nodes()` — by value, for tests + future a11y debug overlay
- `accessibility_backend_name()` — probe returning `"none"` on the default backend; per-platform overlays return `"macos-ax"`, `"windows-uia"`, or `"linux-accesskit"`

Default backend is a `std::mutex`-guarded `std::unordered_map` keyed by id. Idempotent on id (second register replaces previous).

## What's NOT in this PR (follow-up slices)

- macOS `NSAccessibility` selectors / element subclassing
- Windows UIA COM objects
- Linux AccessKit serialization
- Wiring text-paint sites in `core/canvas/` and `core/view/widgets/` to call `register_text_accessibility_node`

## Test plan

`test/test_text_accessibility.cpp` — 7 cases, 39 assertions:

- [x] Single register round-trip
- [x] Two distinct ids coexist
- [x] Same-id register replaces previous entry
- [x] Unregister drops entry; unregistering missing id is a silent no-op
- [x] `accessibility_backend_name()` stable and returns `"none"`
- [x] Cluster boundary vectors round-trip exactly (UTF-8 + UTF-16)
- [x] 10-thread × 25-register concurrent hammer is race-free