### PR TITLE
ci(shipyard): route mac validation through Namespace cloud

### DIFF
--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -152,15 +152,20 @@ build     = "cmake --build build --config Release --parallel; if ($LASTEXITCODE 
 # Per-host details live in .shipyard.local/config.toml.
 
 [targets.mac]
-backend  = "local"
+# 2026-05-18: backend flipped local → cloud per
+# planning/2026-05-18-shipyard-namespace-cutover.md. Mac validation
+# now dispatches to the GHA `build` workflow, which routes the macOS
+# leg to Namespace via PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON +
+# PULP_LOCAL_MAC_OVERFLOW_THRESHOLD=0 (Phase A). The local
+# self-hosted Mac (Daniels-MacBook-Pro) stays registered as a
+# manual fallback the operator can invoke via workflow_dispatch
+# or by raising the threshold back to 1.
+backend  = "cloud"
 platform = "macos-arm64"
-# Phase 8 brings the Rust CLI crate into the build graph (Dawn,
-# Skia, mbedtls, plus a fresh `cargo build` of pulp-rs). On a cold
-# FetchContent cache the configure+build runs ~35–45 min on this
-# host, well past Shipyard's default 30 min budget. Two parallel
-# ships (#790, #791) both timed out at 30:02 / 30:10 in the same
-# CMake configure stage on the Phase 8 prep branch; bump matches
-# the windows lane that already exempts itself for the same reason.
+workflow = "build"
+# Phase 8 timeout bump (Dawn + Skia + mbedtls + cargo build); see
+# git history for context. Kept at 1h because Namespace cold-start
+# + cache-miss cases still run long.
 timeout_secs = 3600
 
 [targets.ubuntu]


### PR DESCRIPTION
## Summary

**Phase B** of the 2026-05-18 Pulp CI cutover to Namespace Business. Source plan: `planning/2026-05-18-shipyard-namespace-cutover.md`.

Flips `.shipyard/config.toml` `[targets.mac]` from `backend = "local"` to `backend = "cloud"` and adds `workflow = "build"`. Mac validation now dispatches to the GHA `build` workflow, which routes the macOS leg to Namespace via `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` + `PULP_LOCAL_MAC_OVERFLOW_THRESHOLD=0`.

The local self-hosted Mac (`Daniels-MacBook-Pro`) stays registered as a manual fallback the operator can invoke via `workflow_dispatch` or by raising the threshold back to 1.

## Phase ordering

| Phase | Action | Owner |
|---|---|---|
| **A** | Flip `PULP_LOCAL_MAC_OVERFLOW_THRESHOLD` 1 → 0; ensure `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON = "macos-15"` | user (repo-variable edit) |
| **B** | This PR — `.shipyard/config.toml` flip | agent |

**As of this PR being opened**, Phase A is **not yet complete** — `PULP_LOCAL_MAC_OVERFLOW_THRESHOLD` is still `1`. The user must flip it to `0` before this PR delivers its benefit. Ordering between A and B doesn't matter for correctness, only for when the cutover takes effect.

## What stays the same

- The required branch-protection check is still named literally `macos`. **Not renamed.**
- `[cloud]` block in `.shipyard/config.toml` (already configured with `provider = "namespace"`) is **unchanged**.
- Default ship path stays `shipyard pr`.
- `Daniels-MacBook-Pro` self-hosted runner stays registered (manual fallback).

## Expected impact

| Signal | Before | After |
|---|---|---|
| GHA macOS check time-to-green p50 | ~25–40 min | ~15–20 min |
| `shipyard pr` wall time | ~30–50 min | ~20–30 min |
| Local Mac queue depth | 1–3 PRs serial | 0 |
| Cost trajectory | $thousands/mo (10× macOS) | ~$290/mo |

## Why this PR was opened via REST (not `shipyard pr`)

Chicken-and-egg: the pinned Shipyard's `[targets.mac]` still points at `local` until this PR merges, so `shipyard pr` would queue this PR on the saturated local Mac runner and likely timeout. Opening via REST API to bypass the local Mac queue. Post-merge `shipyard ship` cycles will pick up the new cloud target automatically.

## Test plan

- [x] Diff matches the spec in `planning/2026-05-18-shipyard-namespace-cutover.md` byte-for-byte.
- [ ] After merge: next `shipyard pr` dispatches Mac validation to GHA `build` workflow on Namespace.
- [ ] After merge: Mac check time-to-green drops ~30 → ~15-20 min p50.
- [ ] After merge: `Daniels-MacBook-Pro` stays idle (queue depth 0).

## Rollback signals (per source doc — do NOT roll back agent-side; ping user)

- macOS check stuck queued >30 min on Namespace.
- Namespace runner registration errors in `resolve-provider` log.
- Branch protection blocking PRs because `macos` alias never reports.
- `shipyard pr` preflight failing on the cloud mac target.

Source docs:
- `planning/2026-05-18-ci-runner-routing-namespace-strategy.md`
- `planning/2026-05-18-shipyard-namespace-cutover.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)