### PR TITLE
fix(examples): gate ui-preview --font-probe behind PULP_HAS_SKIA

### DIFF
--- a/examples/ui-preview/main.cpp
+++ b/examples/ui-preview/main.cpp
@@ -527,6 +527,11 @@ int main(int argc, char* argv[]) {
             // Prints one JSON line per (family, codepoint) and exits with
             // status 0 iff every probe was OK (family resolved AND glyph
             // present). Used by import-design validation, not human eyes.
+#ifndef PULP_HAS_SKIA
+            std::cerr << "[ui-preview] --font-probe requires Skia "
+                         "(built without PULP_HAS_SKIA)\n";
+            return 2;
+#else
             std::string spec = argv[i] + 13;
             auto colon = spec.find(':');
             if (colon == std::string::npos || colon == 0 || colon + 1 == spec.size()) {
@@ -567,6 +572,7 @@ int main(int argc, char* argv[]) {
                 if (!pr.family_resolved || !pr.glyph_present) all_ok = false;
             }
             return all_ok ? 0 : 1;
+#endif // PULP_HAS_SKIA
         } else if (starts_with(argv[i], "--font-dir=")) {
             // pulp #2163 — `--font-dir=/path/to/fonts` walks a directory and
             // registers every .ttf / .otf under it. The font family name


### PR DESCRIPTION
probe_font_glyph is declared inside #endif // PULP_HAS_SKIA in
core/canvas/include/pulp/canvas/bundled_fonts.hpp but the
--font-probe codepath in examples/ui-preview/main.cpp called it
unconditionally. Builds without Skia (release-cli + sign-and-release
GitHub-hosted macOS images) failed with "no member named
'probe_font_glyph' in namespace 'pulp::canvas'", silently blocking
every SDK release since v0.115.0.

Same class of bug as #2271 (FontResolver LRU cache tests). When
Skia isn't linked, --font-probe now prints a clear error and
returns 2 instead of failing to compile the example.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>