### PR TITLE
chore(shipyard): bump pin v0.56.2 -> v0.57.0 (PR #302)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -18,7 +18,7 @@ Validate branches and ship code safely. This skill handles all CI workflows for 
 > One-shot recovery is `shipyard rescue <PR>` (Shipyard v0.53.0+).
 > Continuous prevention is `shipyard runner watch --kill-hung-workers`
 > (v0.54.0+). Keep Shipyard itself current with `shipyard update`
-> (v0.55.0+; Pulp currently pins v0.56.2+). All three replace the
+> (v0.55.0+; Pulp currently pins v0.57.0+). All three replace the
 > legacy `planning/scripts/runner-watchdog.sh --fix` workflow, which is
 > now an anti-pattern (cancels queued runs but registers `failure` on
 > required checks).
@@ -548,7 +548,7 @@ the same `--base` flag for develop branches. Shipyard adds evidence-gated
 merge that checks per-platform proof for the exact merge-candidate SHA, which
 is stricter than `local_ci.py`'s `job.passed` check.
 
-## Recovery + maintenance toolkit (>= v0.56.2)
+## Recovery + maintenance toolkit (>= v0.57.0)
 
 Three operational commands cover the prevention → recovery → maintenance
 lifecycle for self-hosted-runner CI. The authoritative reference lives in
@@ -602,7 +602,7 @@ existing service.
 ```bash
 shipyard update --check --json   # report installed vs available (safe in CI / cron)
 shipyard update                  # apply latest stable
-shipyard update --to v0.56.2     # pin / rollback to a specific version
+shipyard update --to v0.57.0     # pin / rollback to a specific version
 shipyard update --dry-run        # plan only
 ```
 
@@ -1540,11 +1540,12 @@ land in `mergeable_state=blocked`.
 
 Shipyard v0.55.0+ ships a complete operational toolkit for this
 class of problem — **prevent → recover → keep current**. Pulp pins
-Shipyard ≥ 0.56.2 in `tools/shipyard.toml` so recovery, update, and
+Shipyard ≥ 0.57.0 in `tools/shipyard.toml` so recovery, update, and
 `shipyard wait pr` all have REST fallback paths when GraphQL is rate-limited
-or unavailable. The authoritative reference lives in Shipyard's
-`skills/ci/SKILL.md`; this section is the Pulp-side quick reference +
-Pulp-specific gotchas.
+or unavailable — plus the `#266` env-var handoff fix and the sha-gated
+`405` merge-API retry from Shipyard PR #302. The authoritative reference
+lives in Shipyard's `skills/ci/SKILL.md`; this section is the Pulp-side
+quick reference + Pulp-specific gotchas.
 
 ### Recover — `shipyard rescue <PR>` (v0.53.0+)
 
@@ -1565,8 +1566,10 @@ manual sweep). Safe under load — does not mark required checks as
 runners-shipyard-rescue`.
 
 After a rescue, prefer `shipyard wait pr <PR> --state green` over manual
-polling. Shipyard v0.56.2 adds a REST fallback for this wait path; use
-`--no-fallback` only when a caller must fail instead of polling.
+polling. Shipyard v0.56.2 added a REST fallback for this wait path;
+v0.57.0 hardens the GraphQL-secondary-rate-limit backoff so a single 429
+no longer eats the entire wait budget. Use `--no-fallback` only when a
+caller must fail instead of polling.
 
 ### Prevent — `shipyard runner watch --kill-hung-workers` (v0.54.0+)
 
@@ -1591,7 +1594,7 @@ watch--kill-hung-workers`.
 ```bash
 shipyard update --check --json   # report installed vs available
 shipyard update                  # apply latest stable
-shipyard update --to v0.56.2     # pin / rollback to Pulp's minimum
+shipyard update --to v0.57.0     # pin / rollback to Pulp's minimum
 shipyard update --dry-run        # plan only
 ```
 

--- a/docs/guides/local-ci.md
+++ b/docs/guides/local-ci.md
@@ -296,8 +296,9 @@ The watcher is **safe to run alongside the overflow probe in `build.yml`** — t
 ### Self-hosted runner operations: prevent, recover, maintain
 
 Shipyard v0.55.0+ is the minimum pin for the full self-hosted-runner
-operational toolkit, and Pulp pins v0.56.2+ so rescue, update, and
-`shipyard wait pr` have REST fallback paths when GraphQL is rate-limited. The
+operational toolkit, and Pulp pins v0.57.0+ so rescue, update, and
+`shipyard wait pr` have REST fallback paths when GraphQL is rate-limited,
+plus the `#266` env-var handoff fix and sha-gated 405 merge retry. The
 commands are discoverable from `shipyard --help` and replace the legacy
 `planning/scripts/runner-watchdog.sh` + manual reinstall workflow.
 
@@ -315,11 +316,12 @@ shipyard runner watch --kill-hung-workers # implies --fix; pair with launchd/sys
 # Keep the installed Shipyard CLI current
 shipyard update --check --json            # report installed vs available
 shipyard update                           # apply latest stable
-shipyard update --to v0.56.2              # pin or roll back to Pulp's minimum
+shipyard update --to v0.57.0              # pin or roll back to Pulp's minimum
 shipyard update --dry-run                 # plan only
 
 # Wait after handoff/rescue without depending solely on GraphQL
-shipyard wait pr <PR> --state green       # REST fallback as of v0.56.2
+shipyard wait pr <PR> --state green       # REST fallback (added v0.56.2,
+                                          # hardened in v0.57.0 PR #302)
 ```
 
 ### GraphQL quota fallback for PR sweeps

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -251,7 +251,7 @@
 # The older `~/.pulp/bin/shipyard` path is cleaned up on install to
 # prevent shadow-on-PATH bugs.
 #
-# v0.56.2 (current pin) — completes and hardens the self-hosted-runner
+# v0.56.2 — completes and hardens the self-hosted-runner
 # operational toolkit (prevent → recover → maintain) shipped 2026-05-13:
 #   v0.53.0 — `shipyard rescue <PR>`: one-shot recovery for queued runs.
 #             Replaces the legacy 5-step `runner-watchdog --fix` →
@@ -283,7 +283,36 @@
 # Pulp-side quick-reference + Pulp-specific wedge gotchas (iOS AUv3
 # try-compile, dev-mac window popups). Authoritative reference lives
 # in Shipyard's own `skills/ci/SKILL.md`.
-version = "v0.56.2"
+#
+# v0.57.0 — `#266` env-var handoff fix + GraphQL rate-limit polish +
+#   `405` sha-gated merge retry (Shipyard PR #302). Hardens the
+#   `shipyard pr` / `shipyard wait pr` flow against:
+#     - the `SHIPYARD_PR_NUMBER`/`SHIPYARD_PR_BRANCH` env-var handoff
+#       gap that bit us during multi-step PR ship recovery,
+#     - GraphQL secondary-rate-limit bursts (REST fallback path now
+#       gets exercised more aggressively, with backoff that doesn't
+#       eat the whole wait budget on a single 429), and
+#     - the `405 Method Not Allowed` GitHub merge-API quirk where the
+#       merge call races head-SHA updates; retry is now sha-gated so
+#       we don't re-merge with a stale head.
+#   This is the Phase-1 bump the agent loop is consuming today.
+#
+# v0.58.0 — Phase 1 failure diagnostics (Shipyard PR #304, issue #303).
+#   When cloud validation fails, `shipyard pr` / `shipyard ship` now
+#   emits a structured block with the failing GitHub job, its URL, the
+#   failing step, and a bounded list of failing tests (CTest / Catch2 /
+#   pytest / Go parsers + auto-detect). Replaces the lossy single-line
+#   "Validation failed. PR #N not merged." emit. Persists GHA run/job
+#   metadata through the validation pipeline so the failing-job URL is
+#   actually correct (was previously overwritten by Shipyard's internal
+#   job id). Adds optional `[targets.<name>] failure_parser = "..."`
+#   config knob (ctest|catch2|pytest|go|auto). Phase 2 (`shipyard
+#   watch` enrichment) and Phase 3 (sandboxed `failure_parser_cmd`
+#   escape hatch) are tracked separately. This release is staged as a
+#   follow-on pin bump once Shipyard's macOS sign-and-upload publishes
+#   the v0.58.0 `.dmg` asset (currently a draft release; tracked in
+#   the Shipyard repo).
+version = "v0.57.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Picks up Shipyard PR #302 (issue #266): env-var handoff fix +
GraphQL secondary-rate-limit polish + sha-gated 405 merge retry.

Why this bump matters for Pulp's ship loop:

1. `SHIPYARD_PR_NUMBER`/`SHIPYARD_PR_BRANCH` handoff fix — multi-step
   `shipyard pr` / `shipyard ship` recovery paths now propagate the
   tracked PR identifiers correctly, so a resumed ship no longer
   forgets which PR it was driving.

2. GraphQL secondary-rate-limit polish — when GitHub throws a 429 on
   GraphQL (common during back-to-back merges), the wait loop now
   exercises the REST fallback aggressively and backs off without
   burning the entire wait budget on a single throttled call. Pairs
   with the v0.56.2 REST-fallback for `shipyard wait pr`.

3. `405 Method Not Allowed` sha-gated merge retry — the merge API
   call now retries on transient 405s only when the head SHA still
   matches what we tried to merge, so we never silently re-merge a
   stale head after a fast-follow push.

Pulp-side touchpoints:

- `tools/shipyard.toml`: version pin v0.56.2 -> v0.57.0, with a
  fresh changelog block describing v0.57.0 and a forward-looking
  v0.58.0 block (Phase 1 failure diagnostics — staged for a
  follow-on bump once Shipyard publishes the v0.58.0 macOS `.dmg`
  asset, which is currently a draft release pending sign+upload).
- `docs/guides/local-ci.md`: lockstep skim — minimum-pin call-out
  and `shipyard update --to vX.Y.Z` examples bumped to v0.57.0.
- `.agents/skills/ci/SKILL.md`: lockstep skim — minimum-pin call-out
  + REST-fallback narrative updated to credit v0.56.2 (introduced)
  and v0.57.0 (hardened backoff).

Local verification:

  $ ./tools/install-shipyard.sh
  → Installing Shipyard v0.57.0 via upstream install.sh
  ✓ Shipyard v0.57.0 installed at /Users/danielraffel/.local/bin/shipyard.

  $ shipyard --version
  shipyard 0.57.0

  $ shipyard doctor
  ready: yes  (gh / nsc / git / gatekeeper / on-path / ssh /
                RELEASE_BOT_TOKEN / tag_drift all green)

The v0.58.0 follow-on (Phase 1 failure diagnostics) is intentionally
deferred: Shipyard's v0.58.0 release is still a draft on the upstream
repo — the `sign-and-upload-macos` job is queued on the self-hosted
runner and has not produced the `.dmg` asset yet. Once that publishes,
a one-line pin bump can land separately. Phase 2 (`shipyard watch`
enrichment) and Phase 3 (sandboxed `failure_parser_cmd`) are upstream
follow-ups tracked in Shipyard, not Pulp.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>