### PR TITLE
chore(deps): bump shipyard 0.56.2 → 0.58.0 for #303 phase 1 failure diagnostics

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -548,6 +548,32 @@ the same `--base` flag for develop branches. Shipyard adds evidence-gated
 merge that checks per-platform proof for the exact merge-candidate SHA, which
 is stricter than `local_ci.py`'s `job.passed` check.
 
+## Phase 1 failure diagnostics (>= v0.58.0)
+
+Shipyard v0.58.0 (Shipyard PR #304, 2026-05-18) replaces the lossy
+`Validation failed. PR #<N> not merged.` emit with a structured failure
+block carrying the failing job URL, the failing step name, and a parsed
+test-framework footer (CTest by default; `failure_parser` config knob
+allows opting into catch2 / pytest / go / auto in a future phase). On a
+real failure you now see:
+
+```
+✗ Validation failed
+  Target: mac (cloud=namespace)
+  Job:    macOS (ARM64) [github-hosted]
+  URL:    https://github.com/<org>/<repo>/actions/runs/<R>/job/<J>
+  Step:   "Test (non-Windows)" — exit 8
+  Tests:
+    1236 - FontResolver: animation respects LRU cache cap (Failed)
+    ...
+```
+
+Same data lands in the JSON event under `diagnostics: {...}` so
+machine-readers (auto-resolution routines, agent-status dashboards)
+can act on it without parsing the human text. Source design:
+`https://github.com/danielraffel/Shipyard/issues/303` + the codex-
+vetted comment thread there.
+
 ## Recovery + maintenance toolkit (>= v0.56.2)
 
 Three operational commands cover the prevention → recovery → maintenance

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -283,7 +283,20 @@
 # Pulp-side quick-reference + Pulp-specific wedge gotchas (iOS AUv3
 # try-compile, dev-mac window popups). Authoritative reference lives
 # in Shipyard's own `skills/ci/SKILL.md`.
-version = "v0.56.2"
+#
+# v0.58.0 — Phase 1 failure diagnostics (Shipyard #303). When cloud
+#   validation fails, `shipyard pr` / `shipyard ship` now emits a
+#   structured block with the failing GitHub job, its URL, the failing
+#   step, and a bounded list of failing tests (CTest / Catch2 / pytest /
+#   Go parsers + auto-detect). Replaces the lossy single-line
+#   "Validation failed. PR #N not merged." emit. Persists GHA run/job
+#   metadata through the validation pipeline so the failing-job URL is
+#   actually correct (was previously overwritten by Shipyard's internal
+#   job id). Adds optional `[targets.<name>] failure_parser = "..."`
+#   config knob (ctest|catch2|pytest|go|auto). Phase 2 (`shipyard watch`
+#   enrichment) and Phase 3 (sandboxed `failure_parser_cmd` escape
+#   hatch) tracked separately. See Shipyard PR #304 / issue #303.
+version = "v0.58.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
## Summary

Bumps the Shipyard pin from v0.56.2 to v0.58.0 (Shipyard PR [#304](https://github.com/danielraffel/Shipyard/pull/304) / issue [#303](https://github.com/danielraffel/Shipyard/issues/303)). Phase 1 failure diagnostics replace the lossy `Validation failed. PR #N not merged.` emit with a structured block listing the failing GitHub job, its URL, the failing step, and a bounded list of failing tests.

## Before vs after

Captured from the real pulp PR #2271 macOS failure (Namespace runner, job 76630095261):

```
=== BEFORE (Shipyard <= 0.57.0) ===
Validation failed. PR #2271 not merged.

=== AFTER (Phase 1, v0.58.0) ===
✗ Validation failed. PR #2271 not merged.
    Target:  mac (cloud=namespace)
    Job:     macOS (ARM64) [github-hosted]
    URL:     https://github.com/danielraffel/pulp/actions/runs/26063806409/job/76630095261
    Step:    "Test (non-Windows)"
    Tests:
      1236 - FontResolver: animation respects LRU cache cap (Failed)
      1237 - FontResolver: capacity=0 disables cap (legacy unbounded) (Failed)
      1238 - FontResolver: shrinking the cap evicts oldest immediately (Failed)
      1239 - FontResolver: LRU hit promotes entry past eviction line (Failed)
    Action:  run `shipyard watch --pr 2271` to follow recovery, or push fix.
```

Eliminates the 30s context-switch to the GitHub UI per failed PR. Agent loops also gain an actionable failing-test list instead of just "rerun or give up".

## What changed in Shipyard

- New `src/diagnostics.rs` module: parser registry (CTest / Catch2 / pytest / Go / auto) + `gh api`-backed fetcher + ANSI/group/timestamp-stripping log-tail.
- `TargetResult` gains `cloud_run_id` / `cloud_job_id` / `cloud_job_url` / `cloud_failed_step` / `failure_parser` (all optional, all `skip_serializing_if = none` for back-compat).
- `CloudExecutor::poll_run` now persists the GHA run_id onto the failing result; `ship.rs:dispatched_run` prefers it over Shipyard's internal job id.
- New `[targets.<name>] failure_parser = "ctest|catch2|pytest|go|auto"` config knob (allow-listed; unknown values fail dispatch resolution).
- Structured renderer in `src/app/ship_cmd.rs` for both human + JSON output.
- 17 new unit tests; 684 existing tests pass; clippy strict clean; fmt clean.

## Test plan

- [ ] CI green on this PR (validates that the v0.58.0 binary installs and runs)
- [ ] Local upgrade: `./tools/install-shipyard.sh` succeeds
- [ ] `shipyard --version` reports `0.58.0`
- [ ] Next deliberately-failing Pulp PR shows the new structured block instead of the lossy single-line emit

## Deferred upstream

- **Phase 2:** `shipyard watch --pr N --follow` failure-transition enrichment.
- **Phase 3:** Sandboxed `failure_parser_cmd` escape hatch (deferred for security gates around tracked-repo shell execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)