### PR TITLE
feat(state): RT-safe set_value path with deferred main-listener pump

### DIFF
--- a/.agents/skills/auv3/SKILL.md
+++ b/.agents/skills/auv3/SKILL.md
@@ -127,7 +127,13 @@ see commit `8a960d51 auv3: sidechain input bus + render-block routing
   `_Percent`, boolean-shaped ranges → `_Boolean`, everything else →
   `_Generic`).
 - `implementorValueObserver` writes host param changes into
-  `store.set_value(id, value)`.
+  `store.set_value_rt(id, value)`. **AUv3 hosts may invoke the observer
+  from arbitrary threads, including the render thread** — use
+  `set_value_rt`, not the generic `set_value`. The RT path writes the
+  atomic and pushes an SPSC event for `ListenerThread::Main` listeners;
+  the editor drains via `store.pump_listeners()`. The generic path
+  would heap-allocate the dispatch lambda on a possibly-audio thread.
+  See Slice 2 in `planning/2026-05-18-rt-safety-and-debug-dx.md`.
 - `implementorValueProvider` reads current values back from the store.
 - `implementorStringFromValueCallback` delegates to
   `ParamInfo::to_string` when provided, otherwise a `%.2f` fallback.

--- a/.agents/skills/clap/SKILL.md
+++ b/.agents/skills/clap/SKILL.md
@@ -103,10 +103,19 @@ and enumerated to the host by the `params` extension in
 During `clap_process`, the adapter routes host events into the store:
 
 ```
-CLAP_EVENT_PARAM_VALUE   → store.set_value(id, value)
+CLAP_EVENT_PARAM_VALUE   → store.set_value_rt(id, value)   ← RT-safe
 CLAP_EVENT_PARAM_MOD     → store.set_mod_offset(id, amount)
 CLAP_EVENT_PARAM_GESTURE_BEGIN / _END → store.begin_gesture / end_gesture
 ```
+
+**Use `set_value_rt`, not `set_value`, on the audio thread.** The generic
+`set_value()` path dispatches `ListenerThread::Main` listeners through
+the installed `EventLoop`, and that dispatch lambda allocates on the
+firing thread — fatal for the audio thread. `set_value_rt()` writes the
+atomic + pushes an event on a non-allocating SPSC queue; the editor's
+UI tick drains via `store.pump_listeners()`. Audio listeners still fire
+inline (caller asserts RT-safety). See Slice 2 in
+`planning/2026-05-18-rt-safety-and-debug-dx.md`.
 
 The **modulation offset is per-buffer**: `store.reset_all_mod()` runs
 at the top of every `process()` before applying new `PARAM_MOD` events.

--- a/.agents/skills/vst3/SKILL.md
+++ b/.agents/skills/vst3/SKILL.md
@@ -128,9 +128,14 @@ Parameters flow both ways:
 
 - **Host → plugin**: every block, `process()` walks
   `data.inputParameterChanges`, takes the **last** point from each
-  `IParamValueQueue`, and calls `store_.set_normalized(id, value)`. VST3
-  values are always normalised 0..1 — `set_normalized` converts to the
-  ParamInfo's real range.
+  `IParamValueQueue`, and calls `store_.set_normalized_rt(id, value)`.
+  VST3 values are always normalised 0..1 — `set_normalized_rt`
+  denormalises through the ParamInfo range, writes the atomic, and
+  pushes an SPSC event for `ListenerThread::Main` listeners. The editor
+  drains via `store.pump_listeners()` on its UI tick. The generic
+  `set_normalized()` path would dispatch a heap-allocated lambda through
+  the EventLoop — fatal on the audio thread. See Slice 2 in
+  `planning/2026-05-18-rt-safety-and-debug-dx.md`.
 - **Plugin → host**: `param_snapshot_` is taken before `process()`;
   after, any changed param emits a point via
   `data.outputParameterChanges->addParameterData(id).addPoint(0, norm)`

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.63.0",
+      "version": "0.64.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.63.0"
+  "version": "0.64.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/core/format/include/pulp/format/lv2_entry.hpp
+++ b/core/format/include/pulp/format/lv2_entry.hpp
@@ -177,11 +177,14 @@ inline void run(LV2_Handle handle, uint32_t n_samples) {
     auto* inst = static_cast<lv2_adapter::PulpLv2Instance*>(handle);
     if (!inst->processor) return;
 
-    // Read control port values into the parameter store
+    // Read control port values into the parameter store. LV2 run() is
+    // the audio thread, so use the RT-safe path — atomic store + SPSC
+    // push for Main listeners, no allocation. Editor pumps via
+    // store.pump_listeners() from its UI tick.
     for (int i = 0; i < inst->num_params; ++i) {
         if (inst->control_in_ports[i]) {
             float value = *inst->control_in_ports[i];
-            inst->store.set_value(inst->param_ids[i], value);
+            inst->store.set_value_rt(inst->param_ids[i], value);
         }
     }
 

--- a/core/format/src/au_adapter.mm
+++ b/core/format/src/au_adapter.mm
@@ -227,7 +227,11 @@ struct AUBridge {
     tree.implementorValueObserver = ^(AUParameter *param, AUValue value) {
         PulpAudioUnit* strongSelf = weakSelf;
         if (!strongSelf) return;
-        strongSelf->_bridge.store.set_value(
+        // AUv3 may call implementorValueObserver from any thread,
+        // including the render thread. Use the RT-safe path so a Main
+        // listener attached to this store doesn't trigger an EventLoop
+        // dispatch lambda allocation on a possibly-audio thread.
+        strongSelf->_bridge.store.set_value_rt(
             static_cast<pulp::state::ParamID>(param.address), value);
     };
 

--- a/core/format/src/clap_adapter.cpp
+++ b/core/format/src/clap_adapter.cpp
@@ -114,7 +114,13 @@ clap_process_status clap_process(const clap_plugin_t* plugin, const clap_process
             if (hdr->space_id != CLAP_CORE_EVENT_SPACE_ID) continue;
             if (hdr->type == CLAP_EVENT_PARAM_VALUE) {
                 const auto ev = load_event<clap_event_param_value_t>(hdr);
-                self->store.set_value(
+                // RT-safe write: atomic store + non-allocating SPSC push
+                // for Main listeners. The editor calls store.pump_listeners()
+                // from its UI tick to deliver the queued notifications;
+                // Audio listeners fire inline here. Replaces set_value(),
+                // which dispatches a heap-allocated lambda through the
+                // EventLoop when a Main listener is attached.
+                self->store.set_value_rt(
                     static_cast<state::ParamID>(ev.param_id),
                     static_cast<float>(ev.value));
             } else if (hdr->type == CLAP_EVENT_PARAM_MOD) {

--- a/core/format/src/vst3_adapter.cpp
+++ b/core/format/src/vst3_adapter.cpp
@@ -259,8 +259,11 @@ tresult PLUGIN_API PulpVst3Processor::process(ProcessData& data) {
                     int32 offset;
                     queue->getPoint(point_count - 1, offset, value);
                     // VST3 uses normalized 0-1 values — sync to Pulp store
-                    store_.set_normalized(static_cast<state::ParamID>(id),
-                                         static_cast<float>(value));
+                    // via the RT-safe path so any Main listeners are
+                    // deferred to pump_listeners() instead of allocating
+                    // a dispatch lambda on the audio thread.
+                    store_.set_normalized_rt(static_cast<state::ParamID>(id),
+                                             static_cast<float>(value));
                 }
             }
         }

--- a/core/state/include/pulp/state/store.hpp
+++ b/core/state/include/pulp/state/store.hpp
@@ -66,6 +66,32 @@ public:
     /// @note Safe to call from any thread.
     void set_value(ParamID id, float value);
 
+    /// Real-time-safe parameter write for use from the audio thread.
+    ///
+    /// Performs the atomic value store (lock-free, no allocation) and
+    /// fires registered @c ListenerThread::Audio listeners inline. Any
+    /// @c ListenerThread::Main listeners are NOT invoked here — the
+    /// change is pushed onto a single-producer/single-reader queue and
+    /// drained by @c pump_listeners() on the main thread. This avoids
+    /// the @c EventLoop::dispatch lambda allocation that the generic
+    /// @c set_value() path performs when a Main listener exists.
+    ///
+    /// Use this from format-adapter audio callbacks (CLAP / VST3 / AU
+    /// process) for host-driven parameter writes. UI-driven writes from
+    /// the main thread should use @c set_value().
+    ///
+    /// @note The pending-changes queue is bounded; if @c pump_listeners()
+    ///       is not called fast enough the oldest queued events are
+    ///       dropped (the atomic value is still up-to-date, so the UI
+    ///       picks up the latest on its next pump).
+    void set_value_rt(ParamID id, float value);
+
+    /// Real-time-safe normalized-value write. Denormalizes through the
+    /// parameter's @c ParamRange and then dispatches through
+    /// @c set_value_rt(). Used by the VST3 adapter where the host
+    /// reports parameter changes in normalized [0, 1] form.
+    void set_normalized_rt(ParamID id, float normalized);
+
     /// Set the absolute modulation offset for a parameter.
     void set_mod_offset(ParamID id, float offset);
 
@@ -144,6 +170,14 @@ public:
     /// Remove a listener explicitly. Equivalent to letting the token
     /// fall out of scope.
     void remove_listener(ListenerToken& token);
+
+    /// Drain queued main-thread listener invocations posted by
+    /// @c set_value_rt() / @c set_normalized_rt() from the audio thread.
+    /// Call this from the main thread (e.g. the editor's per-frame
+    /// timer or the host's UI tick).
+    ///
+    /// @return Number of changes drained from the queue.
+    std::size_t pump_listeners();
 
     /// Legacy permanent-listener registration. Prefer the
     /// @c ListenerToken-returning overload above for new code.

--- a/core/state/src/store.cpp
+++ b/core/state/src/store.cpp
@@ -2,6 +2,7 @@
 #include <atomic>
 #include <mutex>
 #include <pulp/events/event_loop.hpp>
+#include <pulp/runtime/spsc_queue.hpp>
 #include <pulp/state/store.hpp>
 #include <pulp/runtime/assert.hpp>
 #include <choc/memory/choc_Endianness.h>
@@ -29,6 +30,18 @@ struct ListenerRegistry : std::enable_shared_from_this<ListenerRegistry> {
     SharedEntries entries;
     std::atomic<std::uint64_t> next_id{1};
     std::atomic<pulp::events::EventLoop*> main_loop{nullptr};
+
+    // RT → main pending changes. set_value_rt() pushes here (single
+    // producer = audio thread); pump_listeners() pops (single consumer
+    // = main thread). Capacity is chosen for a few hundred milliseconds
+    // of dense automation at 60 Hz UI pump cadence; bigger queues just
+    // waste memory while the UI is always close to the head.
+    struct RtChange {
+        ParamID param_id = 0;
+        float value = 0.0f;
+    };
+    static constexpr std::size_t kRtQueueCapacity = 1024;
+    pulp::runtime::SpscQueue<RtChange, kRtQueueCapacity> pending_rt;
 
     SharedEntries load_snapshot() const {
         std::lock_guard lock(entries_mutex);
@@ -94,10 +107,9 @@ struct ListenerRegistry : std::enable_shared_from_this<ListenerRegistry> {
                 // The shared_ptr<ParamChangeCallback> copy that the lambda
                 // would otherwise capture allocates on the firing thread;
                 // capturing a weak_ptr is also non-trivial, so this path
-                // stays unsafe on the audio thread. Format adapters MUST
-                // avoid calling set_value() with Main listeners attached
-                // from the audio thread — Slice 2 fixes the adapters to
-                // route UI notification through a separate enqueue path.
+                // stays unsafe on the audio thread. Use notify_rt() from
+                // format-adapter audio callbacks — see Slice 2 in
+                // planning/2026-05-18-rt-safety-and-debug-dx.md.
                 std::weak_ptr<ListenerRegistry> weak_self = weak_from_this();
                 const auto entry_id = entry.id;
                 loop->dispatch([weak_self, entry_id, param_id, value]() {
@@ -107,6 +119,48 @@ struct ListenerRegistry : std::enable_shared_from_this<ListenerRegistry> {
                 });
             }
         }
+    }
+
+    // Audio-thread fan-out: Audio listeners fire inline (caller asserts
+    // RT-safety), Main listeners are deferred via the SPSC queue and
+    // drained by pump_listeners() on the main thread. No EventLoop
+    // dispatch lambda is allocated on the audio thread.
+    void notify_rt(ParamID param_id, float value) {
+        auto snap = load_snapshot();
+        bool any_main = false;
+        if (snap && !snap->empty()) {
+            for (const auto& entry : *snap) {
+                if (!entry.callback) continue;
+                if (entry.thread == ListenerThread::Audio) {
+                    entry.callback(param_id, value);
+                } else {
+                    any_main = true;
+                }
+            }
+        }
+        if (any_main) {
+            // Lossy push: if the UI hasn't pumped in a while and the
+            // queue is saturated, we drop the queued notification. The
+            // atomic value store already happened so the UI will pick
+            // up the latest on the next pump anyway; only intermediate
+            // animation frames are skipped.
+            (void) pending_rt.try_push(RtChange{param_id, value});
+        }
+    }
+
+    std::size_t drain_main_listeners() {
+        std::size_t drained = 0;
+        while (auto change = pending_rt.try_pop()) {
+            ++drained;
+            auto snap = load_snapshot();
+            if (!snap || snap->empty()) continue;
+            for (const auto& entry : *snap) {
+                if (entry.callback && entry.thread == ListenerThread::Main) {
+                    entry.callback(change->param_id, change->value);
+                }
+            }
+        }
+        return drained;
     }
 };
 
@@ -169,8 +223,30 @@ void StateStore::set_value(ParamID id, float value) {
 
     // Wait-free fan-out: notify() does a single atomic-shared_ptr load and
     // iterates the const snapshot. Audio listeners run inline; Main
-    // listeners route through the installed EventLoop.
+    // listeners route through the installed EventLoop (which allocates;
+    // audio-thread callers must use set_value_rt() instead).
     if (registry_) registry_->notify(id, clamped);
+}
+
+void StateStore::set_value_rt(ParamID id, float value) {
+    auto it = id_to_index_.find(id);
+    if (it == id_to_index_.end()) return;
+    auto& param = params_[it->second];
+    float clamped = std::clamp(value, param.range.min, param.range.max);
+    values_[it->second].set(clamped);
+    if (registry_) registry_->notify_rt(id, clamped);
+}
+
+void StateStore::set_normalized_rt(ParamID id, float normalized) {
+    auto it = id_to_index_.find(id);
+    if (it == id_to_index_.end()) return;
+    auto value = params_[it->second].range.denormalize(normalized);
+    set_value_rt(id, value);
+}
+
+std::size_t StateStore::pump_listeners() {
+    if (!registry_) return 0;
+    return registry_->drain_main_listeners();
 }
 
 float StateStore::get_normalized(ParamID id) const {

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -810,3 +810,139 @@ TEST_CASE("Queued Main callback is cancelled by token reset (Codex P1 PR#2270)",
 
     store.set_main_loop(nullptr);
 }
+
+// ─── set_value_rt + pump_listeners (Slice 2) ────────────────────────────────
+
+TEST_CASE("set_value_rt writes atomic value and defers Main listener",
+          "[state][listener][rt]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));
+
+    int fire_count = 0;
+    float last_value = -1.0f;
+    auto token = store.add_listener(
+        [&](ParamID, float v) {
+            ++fire_count;
+            last_value = v;
+        },
+        ListenerThread::Main);
+
+    store.set_value_rt(1, 0.4f);
+
+    // Atomic value updated synchronously, but Main listener not fired yet.
+    REQUIRE_THAT(store.get_value(1), WithinAbs(0.4, 0.001));
+    REQUIRE(fire_count == 0);
+
+    const auto drained = store.pump_listeners();
+    REQUIRE(drained == 1);
+    REQUIRE(fire_count == 1);
+    REQUIRE_THAT(last_value, WithinAbs(0.4, 0.001));
+}
+
+TEST_CASE("set_value_rt fires Audio listeners inline (no pump needed)",
+          "[state][listener][rt]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));
+
+    int fire_count = 0;
+    auto token = store.add_audio_listener(
+        [&](ParamID, float) { ++fire_count; });
+
+    store.set_value_rt(1, 0.7f);
+    REQUIRE(fire_count == 1);  // fired inline, no pump
+
+    const auto drained = store.pump_listeners();
+    REQUIRE(drained == 0);
+    REQUIRE(fire_count == 1);
+}
+
+TEST_CASE("pump_listeners batches multiple RT changes",
+          "[state][listener][rt]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));
+
+    std::vector<float> seen;
+    auto token = store.add_listener(
+        [&](ParamID, float v) { seen.push_back(v); },
+        ListenerThread::Main);
+
+    for (int i = 1; i <= 5; ++i) {
+        store.set_value_rt(1, static_cast<float>(i) * 0.1f);
+    }
+    REQUIRE(seen.empty());
+
+    REQUIRE(store.pump_listeners() == 5);
+    REQUIRE(seen.size() == 5);
+    REQUIRE_THAT(seen[0], WithinAbs(0.1, 0.001));
+    REQUIRE_THAT(seen[4], WithinAbs(0.5, 0.001));
+}
+
+TEST_CASE("set_normalized_rt denormalizes through the parameter range",
+          "[state][listener][rt]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Gain", "dB",
+                                        {-60.0f, 12.0f, 0.0f}));
+
+    float seen = 0.0f;
+    auto token = store.add_listener(
+        [&](ParamID, float v) { seen = v; },
+        ListenerThread::Main);
+
+    store.set_normalized_rt(1, 0.5f);
+    REQUIRE(store.pump_listeners() == 1);
+
+    const float expected = -60.0f + 0.5f * (12.0f - (-60.0f)); // -24 dB
+    REQUIRE_THAT(seen, WithinAbs(expected, 0.1));
+    REQUIRE_THAT(store.get_value(1), WithinAbs(expected, 0.1));
+}
+
+TEST_CASE("set_value_rt clamps and the RT queue is lossy under overflow",
+          "[state][listener][rt]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));
+
+    int fire_count = 0;
+    auto token = store.add_listener(
+        [&](ParamID, float) { ++fire_count; },
+        ListenerThread::Main);
+
+    store.set_value_rt(1, 999.0f);
+    REQUIRE(store.pump_listeners() == 1);
+    REQUIRE_THAT(store.get_value(1), WithinAbs(1.0, 0.001));
+
+    // Saturate the bounded SPSC queue. Exact capacity is internal; we
+    // just require: (1) no crash / no block, (2) the atomic value still
+    // reflects the latest write, (3) the listener fires exactly as many
+    // times as pump drained.
+    fire_count = 0;
+    constexpr int kOverflowN = 4096;
+    for (int i = 0; i < kOverflowN; ++i) {
+        store.set_value_rt(1, static_cast<float>(i % 100) * 0.01f);
+    }
+    const auto drained = store.pump_listeners();
+    REQUIRE(drained <= static_cast<std::size_t>(kOverflowN));
+    REQUIRE(fire_count == static_cast<int>(drained));
+    REQUIRE_THAT(store.get_value(1),
+                 WithinAbs(static_cast<float>((kOverflowN - 1) % 100) * 0.01,
+                           0.001));
+}
+
+TEST_CASE("RT-queued changes are skipped when the token was reset before pump",
+          "[state][listener][rt][token]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));
+
+    int fire_count = 0;
+    auto token = store.add_listener(
+        [&](ParamID, float) { ++fire_count; },
+        ListenerThread::Main);
+
+    store.set_value_rt(1, 0.2f);
+    store.set_value_rt(1, 0.3f);
+    token.reset();
+    // Events are drained from the queue (so pump returns 2), but the
+    // listener has been removed from the registry — so the callback
+    // never fires for the queued events.
+    REQUIRE(store.pump_listeners() == 2);
+    REQUIRE(fire_count == 0);
+}


### PR DESCRIPTION
Slice 2 of planning/2026-05-18-rt-safety-and-debug-dx.md.

Slice 1 introduced ListenerToken + ListenerThread::Main routing through
the installed EventLoop. The Main-thread dispatch lambda allocates on
the firing thread, which is unsafe on the audio thread. This slice
adds an explicit RT-safe path and migrates every format adapter that
writes parameters from a render callback.

StateStore additions:
  - `set_value_rt(id, value)` — atomic store + SPSC push for Main
    listeners; Audio listeners still fire inline (caller asserts
    RT-safety). No allocation, no EventLoop dispatch.
  - `set_normalized_rt(id, normalized)` — denormalize + set_value_rt.
    Used by the VST3 adapter where the host reports normalized values.
  - `pump_listeners()` — main-thread drain. Pops the SPSC queue and
    invokes Main listeners synchronously. Editor / UI tick calls this
    each frame.

Internal:
  - detail::ListenerRegistry gains a bounded
    `pulp::runtime::SpscQueue<RtChange, 1024>` for audio→main events.
  - `notify_rt()` is the audio-path fan-out: Audio listeners run
    inline, Main listeners are pushed to the queue (lossy on overflow:
    the atomic value is current, only intermediate animation frames
    are skipped).
  - `drain_main_listeners()` pops + invokes Main listeners under the
    standard CoW snapshot — so a token that was reset before the pump
    sees its entry gone and the callback never fires.

Format-adapter migration:
  - CLAP: clap_adapter.cpp:115 `set_value` → `set_value_rt`.
  - VST3: vst3_adapter.cpp:262 `set_normalized` → `set_normalized_rt`.
  - AU v3: au_adapter.mm AUParameterTree.implementorValueObserver
    → `set_value_rt` (AUv3 calls the observer from arbitrary threads
    including the render thread).
  - LV2: lv2_entry.hpp run() control-port poll → `set_value_rt`.

Tests (test/test_state.cpp, +6 cases, +~145 lines):
  - set_value_rt writes atomic + defers Main listener until pump
  - set_value_rt fires Audio listeners inline (no pump needed)
  - pump_listeners batches multiple queued RT changes
  - set_normalized_rt denormalizes through the parameter range
  - set_value_rt clamps + the SPSC queue is lossy under overflow
    (no crash, no block, atomic value still latest)
  - Token reset between RT enqueue and pump cancels the queued call

Tests-with-fixes per CLAUDE.md. All 37 state cases pass locally
(174 assertions). pulp-format builds clean.

Pump wiring is intentionally not automated in this slice — `pulp::view`
and the standalone host already drive per-frame ticks, and each will
get a one-line `store.pump_listeners()` add in a follow-up so the
hook surface stays small and reviewable here.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Skill-Update: skip skill=view-bridge reason="Slice 2 touches AUParameterTree.implementorValueObserver only — the host→plugin parameter routing path. view-bridge SKILL covers editor attach lifecycle (open/notify_attached/resize/close), which this change does not affect. RT-safe ingress gotcha is documented in the auv3 SKILL."