### PR TITLE
feat(view): Phase 0a — stable_anchor_id on IRNode (inspector round-trip foundation)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -252,6 +252,57 @@ itself lives inside a Pulp build tree. In generic PATH-installed or split repo/S
 | Variables (COLOR) | `theme.colors` |
 | Variables (FLOAT) | `theme.dimensions` |
 
+## Stable-Anchor Identity (Phase 0a — inspector round-trip prerequisite)
+
+Every tree-producing parser now stamps `IRNode::stable_anchor_id`,
+`source_node_id` (when the source has a native ID), `provenance`
+(adapter + version + source_uri), and `confidence` (PASS / DIVERGE /
+NOT_IMPL). These fields key the tweaks layer (`pulp-tweaks.json`) so
+inspector direct-manipulation edits survive re-import.
+
+**If you add a new parser, you MUST:**
+
+1. After the IR tree is built, stamp `ir.root.provenance` with the
+   adapter name (e.g. `"figma"`, `"stitch-html"`, `"pencil"`), the
+   adapter version, and the source URI.
+2. Stamp `ir.root.confidence`:
+   - `IRConfidence::pass` for a clean lowering
+   - `IRConfidence::diverge` for lossy / regex / best-effort paths
+   - `IRConfidence::not_impl` if the adapter can't lower the source yet
+3. Call `assign_anchors(ir.root, strategy, adapter_name)` with the
+   strategy that matches your source kind:
+   - **adapter** strategy when the source has native stable IDs
+     (Figma layer UUIDs, Pencil node IDs, Mitosis content-hash IDs).
+     Requires `adapter_name` (becomes the `"<name>:"` prefix) AND
+     `source_node_id` populated on each node.
+   - **content-hash** strategy when there are no native IDs
+     (Stitch HTML, v0 TSX, Claude Design HTML, raw JSX, generic HTML).
+     The hash is FNV-1a 32-bit base-36 over (tag, role, normalized
+     text, depth, sigIndex).
+   - **path** strategy for RN-style file exports / hand-edited code
+     where source position is the most stable identity.
+4. The strategy default lives in `default_anchor_strategy()` in
+   `core/view/include/pulp/view/anchor_strategy.hpp` — mirrors the TS
+   `DEFAULT_ANCHOR_STRATEGY` map in `packages/pulp-import-ir/src/anchors.ts`.
+
+**Why this matters:** Phase 1+ of the inspector roadmap writes user
+inspector edits to a sidecar `pulp-tweaks.json` keyed by
+`stable_anchor_id`. Without populated anchors the tweaks layer has
+nothing to match against on re-import — defeating the "edit anywhere,
+never lose work" principle. A parser that skips `assign_anchors` will
+silently produce a tree where inspector edits get orphaned on the
+next re-import.
+
+**Codegen contract:** `generate_pulp_js` (both web-compat and native
+modes) emits `// @pulp-anchor <id>` trail comments next to each
+element when `opts.include_comments == true`. The runtime inspector
+parses these to map generated elements back to their tweak-layer
+identity. If you write a custom codegen path, preserve this pattern
+so the inspector can still trace identity.
+
+Spec + design:
+[`planning/2026-05-18-inspector-direct-manipulation-roadmap.md`](../../../planning/2026-05-18-inspector-direct-manipulation-roadmap.md)
+
 ## Automated Validation Loop
 
 ### Freshness check (MUST run first)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.134.0
+    VERSION 0.135.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -215,6 +215,7 @@ target_sources(pulp-view PRIVATE
     src/auto_ui.cpp
     src/text_editor.cpp
     src/ui_components.cpp
+    src/anchor_strategy.cpp
     src/design_export.cpp
     src/design_import.cpp
     src/design_import_shortcuts.cpp

--- a/core/view/include/pulp/view/anchor_strategy.hpp
+++ b/core/view/include/pulp/view/anchor_strategy.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+/// @file anchor_strategy.hpp
+/// Stable-anchor-id assignment for design-import IR nodes. Mirrors the
+/// TS-side @pulp/import-ir/src/anchors.ts strategy so the C++ and TS
+/// import pipelines produce compatible anchors and the tweaks layer
+/// (pulp-tweaks.json) works for either path.
+///
+/// Phase 0a of the inspector direct-manipulation roadmap
+/// (planning/2026-05-18-inspector-direct-manipulation-roadmap.md).
+///
+/// Three strategies, per the umbrella spec (issue #1307, sub-issue #1299):
+///   • content-hash — used by stitch / v0 / claude / generic HTML.
+///                    Hash over (tag, role, normalized text, depth, sigIndex).
+///   • path         — used by RN file exports / hand-edited code.
+///                    "Tag[idx]/Tag[idx]/..." from root.
+///   • adapter      — used by Figma / Pencil / Mitosis (sources with
+///                    native IDs). "<adapter>:<source_node_id>".
+///
+/// The walker is purely traversal-shaped — it mutates IRNode::stable_anchor_id
+/// but otherwise leaves the tree alone. Adapters call assign_anchors() in
+/// the final stage of their parse path.
+
+#include <pulp/view/design_import.hpp>
+#include <string>
+#include <string_view>
+
+namespace pulp::view {
+
+/// Strategy for computing stable_anchor_id values. See header comment.
+enum class AnchorStrategy {
+    content_hash,
+    path,
+    adapter
+};
+
+/// Walk `root` and populate `stable_anchor_id` on every node according to
+/// `strategy`. For the `adapter` strategy, `adapter_name` is the prefix
+/// before `:<source_node_id>` (e.g. "figma", "pencil") — required for
+/// `adapter`, ignored otherwise.
+///
+/// For nodes that already have a non-empty `stable_anchor_id` (e.g. set
+/// explicitly by an authored override), the existing value is preserved.
+void assign_anchors(IRNode& root,
+                    AnchorStrategy strategy,
+                    std::string_view adapter_name = "");
+
+/// Compute a single anchor without walking. Public for tests and for
+/// adapter code that wants to assign anchors incrementally.
+///
+/// @param node The node to anchor (read-only).
+/// @param parent_anchor For `path` strategy: the parent's already-computed
+///                      anchor; otherwise ignored.
+/// @param sibling_tag_index_for_path For `path` strategy: how many earlier
+///                                   siblings share `node.type` as their tag.
+/// @param depth Tree depth (root = 0).
+/// @param sig_index_for_content_hash For `content-hash` strategy: how many
+///                                   earlier siblings share the same
+///                                   {tag, role, text} signature.
+/// @param strategy Strategy selector.
+/// @param adapter_name For `adapter` strategy only.
+std::string compute_anchor_id(const IRNode& node,
+                              std::string_view parent_anchor,
+                              std::size_t sibling_tag_index_for_path,
+                              std::size_t depth,
+                              std::size_t sig_index_for_content_hash,
+                              AnchorStrategy strategy,
+                              std::string_view adapter_name = "");
+
+/// Map a DesignSource to its default anchor strategy. Mirrors the
+/// DEFAULT_ANCHOR_STRATEGY map in @pulp/import-ir/src/anchors.ts.
+AnchorStrategy default_anchor_strategy(DesignSource source);
+
+}  // namespace pulp::view

--- a/core/view/include/pulp/view/design_import.hpp
+++ b/core/view/include/pulp/view/design_import.hpp
@@ -101,6 +101,38 @@ enum class AudioWidgetType {
     spectrum
 };
 
+// ── Phase 0a (planning/2026-05-18-inspector-direct-manipulation-roadmap.md):
+// additive identity fields on IRNode. The TS-side @pulp/import-ir package
+// already defines the canonical shape; the C++ IR lags. Phase 0a is
+// deliberately additive — IRStyle/IRLayout migration to TS-style
+// paint/text/layout is a separate ~1-month effort tracked elsewhere.
+//
+// stable_anchor_id is the key the tweaks layer (pulp-tweaks.json) uses to
+// match user edits back to nodes across re-imports. Computed by the
+// anchor strategies in <pulp/view/anchor_strategy.hpp> (mirror of
+// packages/pulp-import-ir/src/anchors.ts).
+//
+// provenance + confidence let the inspector (and downstream tooling) know
+// where a node came from and how confident the adapter was — critical
+// for surfacing "this was sampled from an image, not a literal" in the
+// future Lock-to-source UI.
+
+/// Confidence the adapter has that a node was lowered correctly. Maps to
+/// the TS Confidence enum (`PASS` | `DIVERGE` | `NOT_IMPL`). Drives the
+/// `pulp ui validate` exit code in CI.
+enum class IRConfidence {
+    pass,        // Adapter fully understood the source node
+    diverge,     // Adapter produced something close-but-not-equivalent
+    not_impl     // Adapter does not know how to lower this node yet
+};
+
+/// Adapter-side provenance: who lowered this node, from what source.
+struct IRProvenance {
+    std::string adapter;     // e.g. "figma", "stitch-html", "claude-design-html"
+    std::string version;     // adapter version string ("1.0.0" or schema rev)
+    std::string source_uri;  // source identifier (file path, URL, MCP handle)
+};
+
 /// A single node in the normalized design IR.
 struct IRNode {
     std::string type;   // "frame", "text", "image", "button", "input", "slider"
@@ -115,6 +147,21 @@ struct IRNode {
     float audio_default = 0.5f;
     std::vector<IRNode> children;
     std::unordered_map<std::string, std::string> attributes;  // Extra metadata
+
+    // ── Phase 0a additive identity fields ────────────────────────────────
+    /// Stable anchor for the tweaks layer. Empty until an anchor strategy
+    /// has populated it (call assign_anchors() in anchor_strategy.hpp).
+    std::optional<std::string> stable_anchor_id;
+    /// Source-side native ID (e.g. Figma layer UUID, Pencil node ID).
+    /// Only populated for sources that have native IDs.
+    std::optional<std::string> source_node_id;
+    /// Adapter provenance — typically set on the root node by each parser.
+    std::optional<IRProvenance> provenance;
+    /// Adapter's confidence in this node's lowering.
+    std::optional<IRConfidence> confidence;
+    /// Verbatim source slice for this node (debugging + AST-patch fallback).
+    /// Optional; adapters may leave empty when the source is binary or large.
+    std::optional<std::string> raw_source;
 };
 
 /// Design token collection (W3C-compatible).

--- a/core/view/src/anchor_strategy.cpp
+++ b/core/view/src/anchor_strategy.cpp
@@ -1,0 +1,258 @@
+/// @file anchor_strategy.cpp
+/// Implementation of stable_anchor_id strategies. Mirrors
+/// packages/pulp-import-ir/src/anchors.ts so the C++ and TS pipelines
+/// produce compatible anchors and the tweaks layer matches edits across
+/// either path.
+///
+/// Hash algorithm: FNV-1a 32-bit, base-36 encoded. Matches the TS hash
+/// exactly (FNV offset basis 0x811c9dc5, prime 0x01000193). The TS file
+/// notes the algorithm is lifted from MIT-licensed
+/// mitosis/packages/core/src/symbols/symbol-processor.ts.
+
+#include <pulp/view/anchor_strategy.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <sstream>
+#include <unordered_map>
+
+namespace pulp::view {
+
+namespace {
+
+// ── FNV-1a 32-bit hash, returned as base-36 string (matches TS) ──────────
+std::string fnv1a_base36(std::string_view input) {
+    std::uint32_t hash = 0x811c9dc5u;
+    for (char c : input) {
+        hash ^= static_cast<std::uint8_t>(c);
+        hash *= 0x01000193u;  // 32-bit overflow wraps, matching Math.imul()
+    }
+    if (hash == 0) return "0";
+    std::string out;
+    while (hash > 0) {
+        std::uint32_t d = hash % 36u;
+        out.push_back(d < 10 ? static_cast<char>('0' + d)
+                             : static_cast<char>('a' + d - 10));
+        hash /= 36u;
+    }
+    std::reverse(out.begin(), out.end());
+    return out;
+}
+
+// ── Normalize text the same way the TS path does: collapse runs of
+//    whitespace, trim, lowercase. So minor whitespace edits in the
+//    source don't rotate the hash.
+std::string normalize_text(std::string_view text) {
+    std::string out;
+    out.reserve(text.size());
+    bool in_ws = true;  // skip leading whitespace
+    for (char c : text) {
+        bool is_ws = (c == ' ' || c == '\t' || c == '\n' || c == '\r');
+        if (is_ws) {
+            if (!in_ws) { out.push_back(' '); in_ws = true; }
+        } else {
+            // ASCII lowercase only — matches JS toLowerCase() for the
+            // ASCII subset, which is what every existing adapter emits.
+            out.push_back((c >= 'A' && c <= 'Z') ? static_cast<char>(c + 32) : c);
+            in_ws = false;
+        }
+    }
+    // Trim trailing whitespace introduced by the loop.
+    while (!out.empty() && out.back() == ' ') out.pop_back();
+    return out;
+}
+
+// ── "Role" is held in IRNode::attributes["role"] (matches the
+//    convention parse_ir_node uses for ARIA-role-bearing tags).
+std::string node_role(const IRNode& node) {
+    auto it = node.attributes.find("role");
+    if (it == node.attributes.end()) return {};
+    return it->second;
+}
+
+// ── Stable stringify for the content-hash input. Sorts keys
+//    lexicographically so we never get key-order non-determinism.
+//    Matches the TS stableStringify pattern.
+std::string stable_stringify_content_hash_input(std::string_view tag,
+                                                std::string_view role,
+                                                std::string_view text,
+                                                std::size_t depth,
+                                                std::size_t sig_index) {
+    // Use std::map to get deterministic key ordering.
+    std::map<std::string, std::string> fields;
+    auto quote = [](std::string_view s) {
+        std::string out;
+        out.reserve(s.size() + 2);
+        out.push_back('"');
+        for (char c : s) {
+            if (c == '"' || c == '\\') out.push_back('\\');
+            out.push_back(c);
+        }
+        out.push_back('"');
+        return out;
+    };
+    fields["depth"] = std::to_string(depth);
+    fields["role"] = quote(role);
+    fields["sigIndex"] = std::to_string(sig_index);
+    fields["tag"] = quote(tag);
+    fields["text"] = quote(text);
+
+    std::ostringstream ss;
+    ss << '{';
+    bool first = true;
+    for (auto& [k, v] : fields) {
+        if (!first) ss << ',';
+        first = false;
+        ss << '"' << k << "\":" << v;
+    }
+    ss << '}';
+    return ss.str();
+}
+
+// Signature key for sibling-disambiguation in content-hash mode. Must
+// mirror the TS contentHashSignatureKey() exactly — JSON-encoded array
+// of [tag, role, text] so adjacent fields can't collapse to the same
+// key (e.g. tag="ab",role="" vs. tag="a",role="b").
+std::string content_hash_signature_key(const IRNode& node) {
+    std::string tag = node.type;
+    std::string role = node_role(node);
+    std::string text = normalize_text(node.text_content);
+    auto escape = [](std::string_view s) {
+        std::string out;
+        out.reserve(s.size());
+        for (char c : s) {
+            if (c == '"' || c == '\\') out.push_back('\\');
+            out.push_back(c);
+        }
+        return out;
+    };
+    std::ostringstream ss;
+    ss << "[\"" << escape(tag) << "\",\"" << escape(role) << "\",\""
+       << escape(text) << "\"]";
+    return ss.str();
+}
+
+void walk(IRNode& node,
+          std::string_view parent_anchor,
+          std::size_t parent_child_index,
+          std::size_t depth,
+          AnchorStrategy strategy,
+          std::string_view adapter_name,
+          IRNode* parent,
+          std::size_t sig_index) {
+    // For path strategy: count earlier siblings with the same tag.
+    std::size_t sibling_tag_index = 0;
+    if (parent != nullptr && strategy == AnchorStrategy::path) {
+        for (std::size_t i = 0; i < parent_child_index; ++i) {
+            if (parent->children[i].type == node.type) ++sibling_tag_index;
+        }
+    }
+
+    // Preserve any pre-existing anchor (e.g. from an authored override).
+    if (!node.stable_anchor_id || node.stable_anchor_id->empty()) {
+        node.stable_anchor_id = compute_anchor_id(
+            node, parent_anchor, sibling_tag_index, depth, sig_index,
+            strategy, adapter_name);
+    }
+
+    // Child-anchors are path-scoped under this node for the path strategy;
+    // for content-hash/adapter, each child computes independently.
+    std::string child_parent_anchor =
+        (strategy == AnchorStrategy::path) ? *node.stable_anchor_id : std::string{};
+
+    // For content-hash, count duplicate-signature siblings so each
+    // duplicate gets a distinct sig_index discriminator.
+    std::unordered_map<std::string, std::size_t> sig_counts;
+    for (std::size_t i = 0; i < node.children.size(); ++i) {
+        IRNode& c = node.children[i];
+        std::size_t child_sig_index = 0;
+        if (strategy == AnchorStrategy::content_hash) {
+            auto key = content_hash_signature_key(c);
+            auto& n = sig_counts[key];
+            child_sig_index = n;
+            ++n;
+        }
+        walk(c, child_parent_anchor, i, depth + 1, strategy, adapter_name,
+             &node, child_sig_index);
+    }
+}
+
+}  // namespace
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+std::string compute_anchor_id(const IRNode& node,
+                              std::string_view parent_anchor,
+                              std::size_t sibling_tag_index_for_path,
+                              std::size_t depth,
+                              std::size_t sig_index_for_content_hash,
+                              AnchorStrategy strategy,
+                              std::string_view adapter_name) {
+    if (strategy == AnchorStrategy::adapter) {
+        // Caller must populate source_node_id before invoking the
+        // adapter strategy. If they didn't, fall back to content-hash so
+        // we always produce SOME anchor — better than a crash inside the
+        // import pipeline.
+        if (node.source_node_id && !node.source_node_id->empty() &&
+            !adapter_name.empty()) {
+            std::string out;
+            out.reserve(adapter_name.size() + 1 + node.source_node_id->size());
+            out.append(adapter_name);
+            out.push_back(':');
+            out.append(*node.source_node_id);
+            return out;
+        }
+        // Fall through to content-hash as a safety net. Caller-side tests
+        // assert that adapter sources populate source_node_id properly,
+        // so this branch is for defense in depth, not normal operation.
+        // (Matches TS behavior of throwing — we soft-fail instead because
+        // a missing anchor breaks the inspector silently, while a
+        // recovered anchor at least lets the pipeline finish.)
+    }
+
+    if (strategy == AnchorStrategy::path) {
+        std::string seg = node.type;
+        seg.push_back('[');
+        seg += std::to_string(sibling_tag_index_for_path);
+        seg.push_back(']');
+        if (parent_anchor.empty()) return seg;
+        std::string out;
+        out.reserve(parent_anchor.size() + 1 + seg.size());
+        out.append(parent_anchor);
+        out.push_back('/');
+        out.append(seg);
+        return out;
+    }
+
+    // content_hash (default + adapter fallback)
+    std::string tag = node.type;
+    std::string role = node_role(node);
+    std::string text = normalize_text(node.text_content);
+    std::string input = stable_stringify_content_hash_input(
+        tag, role, text, depth, sig_index_for_content_hash);
+    return fnv1a_base36(input);
+}
+
+void assign_anchors(IRNode& root,
+                    AnchorStrategy strategy,
+                    std::string_view adapter_name) {
+    walk(root, /*parent_anchor=*/{}, /*parent_child_index=*/0, /*depth=*/0,
+         strategy, adapter_name, /*parent=*/nullptr, /*sig_index=*/0);
+}
+
+AnchorStrategy default_anchor_strategy(DesignSource source) {
+    // Mirror DEFAULT_ANCHOR_STRATEGY in @pulp/import-ir/src/anchors.ts.
+    switch (source) {
+        case DesignSource::figma:    return AnchorStrategy::adapter;
+        case DesignSource::pencil:   return AnchorStrategy::adapter;
+        case DesignSource::v0:       return AnchorStrategy::content_hash;
+        case DesignSource::stitch:   return AnchorStrategy::content_hash;
+        case DesignSource::claude:   return AnchorStrategy::content_hash;
+        case DesignSource::jsx:      return AnchorStrategy::content_hash;
+        case DesignSource::designmd: return AnchorStrategy::content_hash;
+    }
+    return AnchorStrategy::content_hash;
+}
+
+}  // namespace pulp::view

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -1,4 +1,5 @@
 #include <pulp/view/design_import.hpp>
+#include <pulp/view/anchor_strategy.hpp>
 #include <pulp/view/input_events.hpp>
 #include <pulp/runtime/base64.hpp>
 #include <pulp/runtime/zip.hpp>
@@ -69,6 +70,13 @@ DesignIR parse_claude_html(const std::string& html) {
     // exported HTML over directly — no Anthropic API integration.
     auto ir = parse_stitch_html(html);
     ir.source = DesignSource::claude;
+    // Phase 0a: re-tag provenance after the Stitch parser stamped it.
+    // Anchors were already assigned by parse_stitch_html with the
+    // content-hash strategy — same strategy claude-design-html uses
+    // (see DEFAULT_ANCHOR_STRATEGY in anchors.ts), so we don't reassign.
+    // parse_stitch_html always populates provenance on both its JSON and
+    // regex-fallback paths, so the optional is always set here.
+    if (ir.root.provenance) ir.root.provenance->adapter = "claude-design-html";
     return ir;
 }
 
@@ -2662,6 +2670,16 @@ DesignIR parse_claude_html_with_runtime(const std::string& html, ClaudeRuntimeOp
 
         // Clear error_out on success.
         if (opts.error_out) opts.error_out->clear();
+
+        // Phase 0a: stamp provenance and assign anchors on the
+        // runtime-walked DOM tree. The runtime walker doesn't have
+        // native IDs (DOM `id` attrs are author-supplied and not
+        // guaranteed unique across re-imports), so content-hash is the
+        // right strategy — matches DEFAULT_ANCHOR_STRATEGY for
+        // claude-design-html.
+        ir.root.provenance = IRProvenance{"claude-design-html", "1", {}};
+        ir.root.confidence = IRConfidence::pass;  // walker ran successfully
+        assign_anchors(ir.root, AnchorStrategy::content_hash);
         return ir;
     } catch (const std::exception& e) {
         return static_fallback(std::string("harness boot failed: ") + e.what());
@@ -2953,6 +2971,22 @@ static IRNode parse_ir_node(const choc::value::ValueView& obj) {
     node.name = get_string(obj, "name");
     node.text_content = get_string(obj, "content");
 
+    // Phase 0a (planning/2026-05-18-inspector-direct-manipulation-roadmap.md):
+    // capture the source-native ID so the `adapter` anchor strategy can use
+    // it as its anchor. Figma + Pencil + Mitosis-style exports all carry an
+    // ID under one of these field names; first non-empty wins. Sources
+    // without native IDs (Stitch HTML, v0 TSX, Claude HTML) leave this
+    // empty and fall through to the content-hash strategy.
+    for (const char* k : {"id", "nodeId", "node_id", "source_node_id"}) {
+        if (!obj.hasObjectMember(k)) continue;
+        auto v = obj[k];
+        if (!v.isString()) continue;
+        auto s = std::string(v.toString());
+        if (s.empty()) continue;
+        node.source_node_id = std::move(s);
+        break;
+    }
+
     if (obj.hasObjectMember("style"))
         node.style = parse_ir_style(obj["style"]);
     if (obj.hasObjectMember("layout"))
@@ -3196,6 +3230,16 @@ DesignIR parse_figma_json(const std::string& json) {
     if (root.hasObjectMember("tokens"))
         ir.tokens = parse_ir_tokens(root["tokens"]);
 
+    // Phase 0a: tag the root with adapter provenance + confidence, then
+    // assign stable_anchor_id values via the adapter strategy. Figma
+    // exports carry native layer UUIDs that parse_ir_node populates into
+    // source_node_id; the adapter strategy prefixes those with "figma:".
+    // Nodes that don't have a native ID (rare in Figma) silently fall
+    // through to the content-hash branch inside compute_anchor_id.
+    ir.root.provenance = IRProvenance{"figma", "1", /*source_uri=*/{}};
+    ir.root.confidence = IRConfidence::pass;
+    assign_anchors(ir.root, AnchorStrategy::adapter, "figma");
+
     return ir;
 }
 
@@ -3209,6 +3253,9 @@ DesignIR parse_stitch_html(const std::string& html) {
         ir.root = parse_ir_node(root);
         if (root.hasObjectMember("tokens"))
             ir.tokens = parse_ir_tokens(root["tokens"]);
+        ir.root.provenance = IRProvenance{"stitch-html", "1", {}};
+        ir.root.confidence = IRConfidence::pass;
+        assign_anchors(ir.root, AnchorStrategy::content_hash);
         return ir;
     } catch (...) {
         // Not JSON — minimal HTML extraction
@@ -3237,6 +3284,10 @@ DesignIR parse_stitch_html(const std::string& html) {
         ir.root.children.push_back(std::move(child));
     }
 
+    // Phase 0a: assign anchors to the regex-extracted tree.
+    ir.root.provenance = IRProvenance{"stitch-html", "1", {}};
+    ir.root.confidence = IRConfidence::diverge;  // regex fallback is lossy
+    assign_anchors(ir.root, AnchorStrategy::content_hash);
     return ir;
 }
 
@@ -3250,6 +3301,9 @@ DesignIR parse_v0_tsx(const std::string& tsx) {
         ir.root = parse_ir_node(root);
         if (root.hasObjectMember("tokens"))
             ir.tokens = parse_ir_tokens(root["tokens"]);
+        ir.root.provenance = IRProvenance{"v0-tsx", "1", {}};
+        ir.root.confidence = IRConfidence::pass;
+        assign_anchors(ir.root, AnchorStrategy::content_hash);
         return ir;
     } catch (...) {
         // Not JSON — TSX source
@@ -3279,6 +3333,10 @@ DesignIR parse_v0_tsx(const std::string& tsx) {
         ir.root.children.push_back(std::move(child));
     }
 
+    // Phase 0a: anchor the regex-extracted Tailwind tree.
+    ir.root.provenance = IRProvenance{"v0-tsx", "1", {}};
+    ir.root.confidence = IRConfidence::diverge;  // regex extraction is lossy
+    assign_anchors(ir.root, AnchorStrategy::content_hash);
     return ir;
 }
 
@@ -3295,6 +3353,12 @@ DesignIR parse_pencil_json(const std::string& json) {
         ir.tokens = parse_ir_tokens(root["tokens"]);
     if (root.hasObjectMember("variables"))
         ir.tokens = parse_ir_tokens(root["variables"]);
+
+    // Phase 0a: Pencil MCP nodes carry a stable `id` that parse_ir_node
+    // populates into source_node_id; the adapter strategy uses it directly.
+    ir.root.provenance = IRProvenance{"pencil", "1", {}};
+    ir.root.confidence = IRConfidence::pass;
+    assign_anchors(ir.root, AnchorStrategy::adapter, "pencil");
 
     return ir;
 }
@@ -3359,6 +3423,15 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
     else var = opts.root_variable;
 
     std::string ind = indent(depth, opts.indent_spaces);
+
+    // Phase 0a: anchor trail comment so the runtime inspector can map
+    // a generated element back to its stable_anchor_id (tweaks-layer key).
+    // Comments are gated on opts.include_comments so minified codegen
+    // strips them automatically.
+    if (opts.include_comments && node.stable_anchor_id &&
+        !node.stable_anchor_id->empty()) {
+        ss << ind << "// @pulp-anchor " << *node.stable_anchor_id << "\n";
+    }
 
     // Audio widgets get special treatment
     if (node.audio_widget != AudioWidgetType::none) {
@@ -3589,6 +3662,15 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
 
     std::string ind = indent(depth, opts.indent_spaces);
     std::string pid = parent_id.empty() ? "''" : ("'" + parent_id + "'");
+
+    // Phase 0a: emit the anchor trail in native-mode codegen too. Same
+    // gate + format as generate_node(), so downstream tooling has one
+    // pattern to grep for regardless of which codegen mode produced
+    // the JS.
+    if (opts.include_comments && node.stable_anchor_id &&
+        !node.stable_anchor_id->empty()) {
+        ss << ind << "// @pulp-anchor " << *node.stable_anchor_id << "\n";
+    }
 
     // Audio widgets use native widget API
     if (node.audio_widget != AudioWidgetType::none) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1884,6 +1884,13 @@ target_compile_definitions(pulp-test-design-import PRIVATE PULP_REPO_ROOT="${CMA
 catch_discover_tests(pulp-test-design-import
     PROPERTIES LABELS "parser-import")
 
+# Phase 0a: stable_anchor_id assignment per
+# planning/2026-05-18-inspector-direct-manipulation-roadmap.md
+add_executable(pulp-test-design-import-anchors test_design_import_anchors.cpp)
+target_link_libraries(pulp-test-design-import-anchors PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-design-import-anchors
+    PROPERTIES LABELS "parser-import")
+
 # DESIGN.md import (Google design.md, Apache-2.0 — pulp #1434 follow-up)
 # Compiles import_detect.cpp directly into the test target so the
 # detector tests do not require linking the whole pulp-import-design CLI.

--- a/test/test_design_import_anchors.cpp
+++ b/test/test_design_import_anchors.cpp
@@ -1,0 +1,400 @@
+// Phase 0a: tests for stable_anchor_id assignment on IRNode trees.
+// Spec: planning/2026-05-18-inspector-direct-manipulation-roadmap.md
+// Mirrors the TS-side tests in packages/pulp-import-ir/tests/anchors.test.ts.
+
+#include <catch2/catch_test_macros.hpp>
+#include <pulp/view/anchor_strategy.hpp>
+#include <pulp/view/design_import.hpp>
+
+#include <string>
+#include <unordered_set>
+
+using namespace pulp::view;
+
+namespace {
+
+// Tiny tree builder so test cases stay readable.
+IRNode make_node(std::string type, std::string text = {}, std::string role = {},
+                 std::string source_node_id = {}) {
+    IRNode n;
+    n.type = std::move(type);
+    n.text_content = std::move(text);
+    if (!role.empty()) n.attributes["role"] = std::move(role);
+    if (!source_node_id.empty()) n.source_node_id = std::move(source_node_id);
+    return n;
+}
+
+// Recursive count of nodes whose stable_anchor_id was populated.
+std::size_t count_anchored(const IRNode& node) {
+    std::size_t n = (node.stable_anchor_id && !node.stable_anchor_id->empty()) ? 1 : 0;
+    for (const auto& c : node.children) n += count_anchored(c);
+    return n;
+}
+
+// Collect every anchor in the tree (root + descendants).
+void collect_anchors(const IRNode& node, std::vector<std::string>& out) {
+    if (node.stable_anchor_id) out.push_back(*node.stable_anchor_id);
+    for (const auto& c : node.children) collect_anchors(c, out);
+}
+
+// Recursive total node count.
+std::size_t count_nodes(const IRNode& node) {
+    std::size_t n = 1;
+    for (const auto& c : node.children) n += count_nodes(c);
+    return n;
+}
+
+}  // namespace
+
+// ── default_anchor_strategy() — should match DEFAULT_ANCHOR_STRATEGY in
+//    @pulp/import-ir/src/anchors.ts.
+TEST_CASE("default_anchor_strategy mirrors the TS map", "[view][import][anchors]") {
+    REQUIRE(default_anchor_strategy(DesignSource::figma) == AnchorStrategy::adapter);
+    REQUIRE(default_anchor_strategy(DesignSource::pencil) == AnchorStrategy::adapter);
+    REQUIRE(default_anchor_strategy(DesignSource::stitch) == AnchorStrategy::content_hash);
+    REQUIRE(default_anchor_strategy(DesignSource::v0) == AnchorStrategy::content_hash);
+    REQUIRE(default_anchor_strategy(DesignSource::claude) == AnchorStrategy::content_hash);
+    REQUIRE(default_anchor_strategy(DesignSource::jsx) == AnchorStrategy::content_hash);
+}
+
+// ── content-hash strategy ───────────────────────────────────────────────
+
+TEST_CASE("content-hash anchors are populated on every node", "[view][import][anchors]") {
+    IRNode root = make_node("frame", {}, "container");
+    root.children.push_back(make_node("text", "Hello"));
+    root.children.push_back(make_node("button", "OK"));
+
+    assign_anchors(root, AnchorStrategy::content_hash);
+
+    REQUIRE(count_anchored(root) == 3);
+    REQUIRE(count_nodes(root) == 3);
+}
+
+TEST_CASE("content-hash anchors are deterministic across re-runs",
+          "[view][import][anchors]") {
+    auto build = []() {
+        IRNode r = make_node("frame", {}, "container");
+        r.children.push_back(make_node("text", "label"));
+        r.children.push_back(make_node("text", "value"));
+        return r;
+    };
+    IRNode a = build(), b = build();
+    assign_anchors(a, AnchorStrategy::content_hash);
+    assign_anchors(b, AnchorStrategy::content_hash);
+
+    std::vector<std::string> aa, bb;
+    collect_anchors(a, aa);
+    collect_anchors(b, bb);
+    REQUIRE(aa == bb);
+}
+
+TEST_CASE("content-hash discriminates duplicate-signature siblings",
+          "[view][import][anchors]") {
+    // Three identical {tag, role, text} buttons get three distinct
+    // anchors via the sigIndex discriminator. This is the bug the TS
+    // discriminator fixes (sibling collision).
+    IRNode root = make_node("frame");
+    for (int i = 0; i < 3; ++i) {
+        root.children.push_back(make_node("button", "OK"));
+    }
+
+    assign_anchors(root, AnchorStrategy::content_hash);
+
+    std::unordered_set<std::string> seen;
+    for (const auto& c : root.children) {
+        REQUIRE(c.stable_anchor_id.has_value());
+        REQUIRE(seen.insert(*c.stable_anchor_id).second);
+    }
+    REQUIRE(seen.size() == 3);
+}
+
+TEST_CASE("content-hash whitespace is normalized", "[view][import][anchors]") {
+    // Two semantically-identical text-only trees that differ only by
+    // surrounding whitespace should produce identical anchors at the
+    // text node.
+    IRNode a = make_node("text", "  hello  world  ");
+    IRNode b = make_node("text", "hello world");
+    assign_anchors(a, AnchorStrategy::content_hash);
+    assign_anchors(b, AnchorStrategy::content_hash);
+    REQUIRE(a.stable_anchor_id == b.stable_anchor_id);
+}
+
+// ── path strategy ───────────────────────────────────────────────────────
+
+TEST_CASE("path anchors encode tree position", "[view][import][anchors]") {
+    IRNode root = make_node("frame");
+    root.children.push_back(make_node("text", "A"));   // frame[0]/text[0]
+    root.children.push_back(make_node("text", "B"));   // frame[0]/text[1]
+    root.children.push_back(make_node("button", "C")); // frame[0]/button[0]
+
+    assign_anchors(root, AnchorStrategy::path);
+
+    REQUIRE(root.stable_anchor_id == "frame[0]");
+    REQUIRE(root.children[0].stable_anchor_id == "frame[0]/text[0]");
+    REQUIRE(root.children[1].stable_anchor_id == "frame[0]/text[1]");
+    REQUIRE(root.children[2].stable_anchor_id == "frame[0]/button[0]");
+}
+
+TEST_CASE("path anchors survive text edits but break on sibling reorder",
+          "[view][import][anchors]") {
+    // Edit the text of a leaf — path is unchanged.
+    IRNode a = make_node("frame");
+    a.children.push_back(make_node("text", "before"));
+    IRNode b = make_node("frame");
+    b.children.push_back(make_node("text", "after"));
+    assign_anchors(a, AnchorStrategy::path);
+    assign_anchors(b, AnchorStrategy::path);
+    REQUIRE(a.children[0].stable_anchor_id == b.children[0].stable_anchor_id);
+
+    // Reorder same-tag siblings — anchors swap, demonstrating the
+    // documented trade-off.
+    IRNode c = make_node("frame");
+    c.children.push_back(make_node("text", "X"));
+    c.children.push_back(make_node("text", "Y"));
+    IRNode d = make_node("frame");
+    d.children.push_back(make_node("text", "Y"));
+    d.children.push_back(make_node("text", "X"));
+    assign_anchors(c, AnchorStrategy::path);
+    assign_anchors(d, AnchorStrategy::path);
+    REQUIRE(c.children[0].stable_anchor_id == d.children[0].stable_anchor_id);
+}
+
+// ── adapter strategy ────────────────────────────────────────────────────
+
+TEST_CASE("adapter anchors use source_node_id when present",
+          "[view][import][anchors]") {
+    IRNode root = make_node("frame", {}, {}, "0:1");
+    root.children.push_back(make_node("button", "OK", {}, "0:42"));
+    root.children.push_back(make_node("text", "Hello", {}, "0:99"));
+
+    assign_anchors(root, AnchorStrategy::adapter, "figma");
+
+    REQUIRE(root.stable_anchor_id == "figma:0:1");
+    REQUIRE(root.children[0].stable_anchor_id == "figma:0:42");
+    REQUIRE(root.children[1].stable_anchor_id == "figma:0:99");
+}
+
+TEST_CASE("adapter strategy falls back to content-hash for nodes without IDs",
+          "[view][import][anchors]") {
+    // Phase 0a soft-fail: missing source_node_id shouldn't crash the
+    // pipeline. The fallback uses the content-hash branch so the node
+    // still gets SOME anchor — better for downstream inspector use than
+    // an empty anchor.
+    IRNode root = make_node("frame", {}, {}, "0:1");
+    root.children.push_back(make_node("button", "OK"));  // no source_node_id
+
+    assign_anchors(root, AnchorStrategy::adapter, "figma");
+
+    REQUIRE(root.stable_anchor_id == "figma:0:1");
+    REQUIRE(root.children[0].stable_anchor_id.has_value());
+    // Fallback is content-hash, so the value is NOT prefixed with "figma:".
+    REQUIRE(root.children[0].stable_anchor_id->find("figma:") == std::string::npos);
+}
+
+// ── pre-existing anchor preservation ────────────────────────────────────
+
+TEST_CASE("assign_anchors preserves pre-existing stable_anchor_id values",
+          "[view][import][anchors]") {
+    // If an authored override has already set stable_anchor_id, the
+    // walker must leave it alone. This is how Phase 1 will honor
+    // user-pinned anchors for elements they want to track precisely.
+    IRNode root = make_node("frame");
+    root.stable_anchor_id = "pinned-by-user";
+    root.children.push_back(make_node("text", "Hello"));
+
+    assign_anchors(root, AnchorStrategy::content_hash);
+
+    REQUIRE(root.stable_anchor_id == "pinned-by-user");
+    REQUIRE(root.children[0].stable_anchor_id.has_value());
+    REQUIRE(root.children[0].stable_anchor_id != "pinned-by-user");
+}
+
+// ── parser entry-point integration ──────────────────────────────────────
+//
+// These verify the parsers we wired in Phase 0a actually call
+// assign_anchors with the right strategy and produce stable output
+// across re-imports of the same source.
+
+TEST_CASE("parse_figma_json populates anchors via the adapter strategy",
+          "[view][import][anchors]") {
+    const std::string json = R"({
+        "type": "frame",
+        "id": "0:1",
+        "children": [
+            { "type": "button", "id": "0:42" },
+            { "type": "text", "content": "Hi", "id": "0:99" }
+        ]
+    })";
+
+    auto ir = parse_figma_json(json);
+
+    REQUIRE(ir.root.stable_anchor_id == "figma:0:1");
+    REQUIRE(ir.root.children.size() == 2);
+    REQUIRE(ir.root.children[0].stable_anchor_id == "figma:0:42");
+    REQUIRE(ir.root.children[1].stable_anchor_id == "figma:0:99");
+    REQUIRE(ir.root.provenance.has_value());
+    REQUIRE(ir.root.provenance->adapter == "figma");
+    REQUIRE(ir.root.confidence == IRConfidence::pass);
+}
+
+TEST_CASE("parse_pencil_json populates anchors via the adapter strategy",
+          "[view][import][anchors]") {
+    const std::string json = R"({
+        "type": "frame",
+        "id": "pencil-1",
+        "children": [
+            { "type": "button", "id": "pencil-42" }
+        ]
+    })";
+
+    auto ir = parse_pencil_json(json);
+
+    REQUIRE(ir.root.stable_anchor_id == "pencil:pencil-1");
+    REQUIRE(ir.root.children[0].stable_anchor_id == "pencil:pencil-42");
+    REQUIRE(ir.root.provenance->adapter == "pencil");
+}
+
+TEST_CASE("parse_stitch_html JSON path populates content-hash anchors",
+          "[view][import][anchors]") {
+    const std::string json = R"({
+        "type": "frame",
+        "children": [
+            { "type": "text", "content": "Hello" }
+        ]
+    })";
+
+    auto a = parse_stitch_html(json);
+    auto b = parse_stitch_html(json);
+
+    REQUIRE(a.root.stable_anchor_id.has_value());
+    REQUIRE(a.root.stable_anchor_id == b.root.stable_anchor_id);
+    REQUIRE(a.root.children[0].stable_anchor_id == b.root.children[0].stable_anchor_id);
+    REQUIRE(a.root.provenance->adapter == "stitch-html");
+}
+
+TEST_CASE("parse_claude_html re-tags provenance after delegating to stitch",
+          "[view][import][anchors]") {
+    const std::string json = R"({
+        "type": "frame",
+        "children": [{ "type": "text", "content": "Hi" }]
+    })";
+
+    auto ir = parse_claude_html(json);
+
+    REQUIRE(ir.source == DesignSource::claude);
+    REQUIRE(ir.root.provenance.has_value());
+    REQUIRE(ir.root.provenance->adapter == "claude-design-html");
+    // Anchors should be populated by the upstream stitch parser; we
+    // don't reassign in parse_claude_html (same strategy).
+    REQUIRE(ir.root.stable_anchor_id.has_value());
+}
+
+TEST_CASE("parse_stitch_html regex-fallback path also assigns anchors",
+          "[view][import][anchors]") {
+    // Non-JSON input forces the regex fallback at the end of
+    // parse_stitch_html. The Phase 0a additions stamp provenance +
+    // confidence=DIVERGE and call assign_anchors on the regex-built tree.
+    const std::string html = "<div><span>hello</span><span>world</span></div>";
+    auto ir = parse_stitch_html(html);
+
+    REQUIRE(ir.source == DesignSource::stitch);
+    REQUIRE(ir.root.provenance.has_value());
+    REQUIRE(ir.root.provenance->adapter == "stitch-html");
+    REQUIRE(ir.root.confidence == IRConfidence::diverge);
+    REQUIRE(ir.root.stable_anchor_id.has_value());
+    // Children built by regex extraction also get anchors.
+    REQUIRE(!ir.root.children.empty());
+    REQUIRE(ir.root.children[0].stable_anchor_id.has_value());
+}
+
+TEST_CASE("parse_v0_tsx JSON path populates content-hash anchors",
+          "[view][import][anchors]") {
+    const std::string json = R"({
+        "type": "frame",
+        "children": [{ "type": "text", "content": "Hello" }]
+    })";
+    auto ir = parse_v0_tsx(json);
+
+    REQUIRE(ir.source == DesignSource::v0);
+    REQUIRE(ir.root.provenance.has_value());
+    REQUIRE(ir.root.provenance->adapter == "v0-tsx");
+    REQUIRE(ir.root.confidence == IRConfidence::pass);
+    REQUIRE(ir.root.stable_anchor_id.has_value());
+    REQUIRE(ir.root.children[0].stable_anchor_id.has_value());
+}
+
+TEST_CASE("parse_v0_tsx regex-fallback path (Tailwind classes) assigns anchors",
+          "[view][import][anchors]") {
+    // Non-JSON TSX input forces the regex/Tailwind extraction at the
+    // tail of parse_v0_tsx. Phase 0a stamps DIVERGE confidence + anchors.
+    const std::string tsx =
+        "<div className=\"flex-row gap-2\">"
+        "<div className=\"flex-col p-2\">child</div>"
+        "</div>";
+    auto ir = parse_v0_tsx(tsx);
+
+    REQUIRE(ir.source == DesignSource::v0);
+    REQUIRE(ir.root.provenance.has_value());
+    REQUIRE(ir.root.provenance->adapter == "v0-tsx");
+    REQUIRE(ir.root.confidence == IRConfidence::diverge);
+    REQUIRE(ir.root.stable_anchor_id.has_value());
+    REQUIRE(!ir.root.children.empty());
+    REQUIRE(ir.root.children[0].stable_anchor_id.has_value());
+}
+
+// ── codegen integration: @pulp-anchor comment ───────────────────────────
+
+TEST_CASE("generate_pulp_js emits @pulp-anchor comments when include_comments",
+          "[view][import][anchors]") {
+    const std::string json = R"({
+        "type": "frame",
+        "id": "0:1",
+        "children": [{ "type": "text", "content": "X", "id": "0:42" }]
+    })";
+
+    auto ir = parse_figma_json(json);
+
+    CodeGenOptions opts;
+    opts.include_comments = true;
+    opts.mode = CodeGenMode::web_compat;
+    auto js = generate_pulp_js(ir, opts);
+
+    REQUIRE(js.find("// @pulp-anchor figma:0:1") != std::string::npos);
+    REQUIRE(js.find("// @pulp-anchor figma:0:42") != std::string::npos);
+}
+
+TEST_CASE("generate_pulp_js elides @pulp-anchor comments when include_comments=false",
+          "[view][import][anchors]") {
+    const std::string json = R"({
+        "type": "frame",
+        "id": "0:1"
+    })";
+
+    auto ir = parse_figma_json(json);
+
+    CodeGenOptions opts;
+    opts.include_comments = false;
+    opts.mode = CodeGenMode::web_compat;
+    auto js = generate_pulp_js(ir, opts);
+
+    // Minified codegen keeps the bundle slim; tooling can re-derive the
+    // anchor from re-parsing the source, so dropping the comment is safe.
+    REQUIRE(js.find("@pulp-anchor") == std::string::npos);
+}
+
+TEST_CASE("generate_pulp_js native mode emits @pulp-anchor comments",
+          "[view][import][anchors]") {
+    const std::string json = R"({
+        "type": "frame",
+        "id": "0:1"
+    })";
+
+    auto ir = parse_figma_json(json);
+
+    CodeGenOptions opts;
+    opts.include_comments = true;
+    opts.mode = CodeGenMode::native;
+    auto js = generate_pulp_js(ir, opts);
+
+    REQUIRE(js.find("// @pulp-anchor figma:0:1") != std::string::npos);
+}


### PR DESCRIPTION
## Summary

Implements **Phase 0a** of the inspector direct-manipulation roadmap (`planning/2026-05-18-inspector-direct-manipulation-roadmap.md`). This is the foundation every later phase consumes — without stable anchors, the tweaks layer has nothing to key on across re-imports.

Per Codex review the change is deliberately **additive**, not a wholesale migration of `IRStyle`/`IRLayout` to TS-style `paint/text/layout`. That larger migration is tracked separately and is closer to a month of work; the inspector workstream owns this additive slice for general use to unblock itself from the broader #1307 umbrella (currently blocked on #924 Spectr WebView↔Native parity).

## What's in the PR

- **New `IRNode` optionals** (default-empty, backwards compatible):
  - `stable_anchor_id` — key for the tweaks layer (`pulp-tweaks.json`)
  - `source_node_id` — source-native ID (Figma UUID, Pencil node ID)
  - `provenance` — adapter / version / source_uri triple
  - `confidence` — `PASS` / `DIVERGE` / `NOT_IMPL`
  - `raw_source` — verbatim source slice (debugging + future AST patch)
- **New `core/view/{include,src}/anchor_strategy.{hpp,cpp}`** implementing the three strategies from `packages/pulp-import-ir/src/anchors.ts`:
  - `content_hash` (FNV-1a 32-bit, base-36) — for stitch / v0 / claude / jsx
  - `path` (`Tag[idx]/...`) — for RN file exports
  - `adapter` (`<name>:<source_node_id>`) — for Figma / Pencil
- **All 5 tree-producing parsers** now call `assign_anchors` after building the tree and stamp `provenance` + `confidence` on the root.
- **`generate_pulp_js`** (web-compat and native modes) emits `// @pulp-anchor <id>` trail comments so the runtime inspector can map generated elements back to their tweak keys. Gated on `include_comments`.
- **New test target** `pulp-test-design-import-anchors` with **20 test cases / 74 assertions**: strategy determinism, sibling-signature discrimination, path/content-hash trade-offs, adapter fallback, pre-existing anchor preservation, parser integration, codegen comment emission.
- **Skill update** to `.agents/skills/import-design/SKILL.md` documenting the contract any future parser must follow.

## Local validation

- `pulp-test-design-import-anchors`: 20 tests / 74 assertions ✓
- Full `parser-import` label: 87/87 tests ✓ (no regressions)
- All design-import sibling tests (claude-bundle / claude-runtime / jsx-runtime / inline-babel / shortcuts / cli-import-design / cli-import-detect / cli-design-binding) ✓
- **Local diff coverage: 89.7%** (well over the 75% gate). Uncovered lines are the runtime-bundle success path (needs a real Claude bundle eval).

## Test plan

- [x] Strategy correctness verified locally
- [x] No regressions in any sibling design-import test
- [x] Local diff coverage gate passes at 89.7%
- [x] Skill-sync gate passes (SKILL.md updated)
- [ ] CI macOS gate green (in flight)

## Relates to

- Roadmap: [`planning/2026-05-18-inspector-direct-manipulation-roadmap.md`](https://github.com/danielraffel/pulp-planning/blob/main/2026-05-18-inspector-direct-manipulation-roadmap.md)
- Umbrella: #1307 (this PR implements the inspector-relevant subset of sub-issue #1299, generalized beyond Spectr)
- Predecessor: PR #2270 (RT-safety Slice 1 — listener tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)