### PR TITLE
fix(shipyard): workflow name must be filename, not basename

### DIFF
--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -162,7 +162,12 @@ build     = "cmake --build build --config Release --parallel; if ($LASTEXITCODE 
 # or by raising the threshold back to 1.
 backend  = "cloud"
 platform = "macos-arm64"
-workflow = "build"
+# Must be the workflow filename, not display name. `gh run list
+# --workflow build` returns no matches (gh requires `.yml` suffix or
+# the workflow's display name). Discovered when shipping PR #2295 —
+# `shipyard ship` failed with "could not find any workflows named
+# build" until this was changed from "build" to "build.yml".
+workflow = "build.yml"
 # Phase 8 timeout bump (Dawn + Skia + mbedtls + cargo build); see
 # git history for context. Kept at 1h because Namespace cold-start
 # + cache-miss cases still run long.
@@ -187,7 +192,9 @@ timeout_secs = 3600
 
 [cloud]
 provider   = "namespace"
-workflow   = "build"
+# Same gh-CLI lookup requirement as [targets.mac].workflow above —
+# filename, not display name.
+workflow   = "build.yml"
 repository = "danielraffel/pulp"
 
 # ── Merge gating ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

One-line fix to `.shipyard/config.toml` — `workflow = "build"` → `workflow = "build.yml"`.

Discovered when shipping PR #2295. `shipyard ship` failed with:

```
Failed to inspect existing workflow run: gh run list
--workflow build ... could not find any workflows named build
```

`gh run list --workflow` accepts either the workflow's filename (`build.yml`) or its display name (`"Build and Test"`), but not just the basename `build`. The shipyard config was using the basename, which silently worked on the previous local backend but breaks on the freshly-flipped cloud/Namespace backend (per `planning/2026-05-18-shipyard-namespace-cutover.md`).

Fixes both `[targets.mac].workflow` and `[cloud].workflow`. Inline comments explain the constraint so it doesn't regress.

## Why direct gh PR instead of `shipyard pr`

Because `shipyard pr` / `shipyard ship` is broken by the very bug this PR fixes — it's the bootstrap case. Once this PR merges, the next `shipyard ship` invocation can use the wrapper normally.

## Test plan

- [x] `gh run list --workflow build.yml --branch <any> --limit 1 --repo danielraffel/pulp` returns a result (verified manually)
- [ ] First `shipyard ship` after this lands successfully (validation in production)

## Related

- PR #2295 — Phase 0a, where this bug was discovered
- `planning/2026-05-18-shipyard-namespace-cutover.md` — the cutover that exposed the latent typo

🤖 Generated with [Claude Code](https://claude.com/claude-code)