### PR TITLE
feat(inspect): Phase 0b PR-A — Inspector.applyTweak protocol + TweakStore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.148.0
+    VERSION 0.150.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(pulp-inspect PRIVATE
     src/domain_handler.cpp
     src/motion_inspector.cpp
     src/motion_scrubber.cpp
+    src/tweak_store.cpp
 )
 
 target_link_libraries(pulp-inspect PUBLIC pulp::view pulp::render pulp::state pulp::events)

--- a/inspect/include/pulp/inspect/domain_handler.hpp
+++ b/inspect/include/pulp/inspect/domain_handler.hpp
@@ -14,6 +14,7 @@ class ConsoleCapture;
 class AudioInspector;
 class MotionInspector;
 class MotionScrubber;
+class TweakStore;
 
 /// Handles inspector protocol requests by delegating to the appropriate
 /// inspector component. All data sources are optional — missing sources
@@ -31,6 +32,7 @@ public:
     void set_motion_inspector(MotionInspector* motion) { motion_ = motion; }
     void set_motion_scrubber(MotionScrubber* scrubber) { motion_scrubber_ = scrubber; }
     void set_render_pass_manager(render::RenderPassManager* rpm) { rpm_ = rpm; }
+    void set_tweak_store(TweakStore* store) { tweak_store_ = store; }
 
     /// Tier A Slice 6: wire the per-frame dirty tracker so the inspector's
     /// Performance tab can toggle `DirtyTracker::set_debug_overlay()` at
@@ -51,6 +53,7 @@ private:
     MotionScrubber* motion_scrubber_ = nullptr;
     render::RenderPassManager* rpm_ = nullptr;
     render::DirtyTracker* dirty_ = nullptr;
+    TweakStore* tweak_store_ = nullptr;
 
     // Domain handlers
     InspectorMessage handle_inspector(const InspectorMessage& req);

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -37,6 +37,16 @@ namespace methods {
     constexpr auto kInspectorEnable    = "Inspector.enable";
     constexpr auto kInspectorDisable   = "Inspector.disable";
     constexpr auto kInspectorGetInfo   = "Inspector.getInfo";
+    // Phase 0b: direct-manipulation edit capture. In-memory only at
+    // this phase; Phase 1 lands the pulp-tweaks.json sidecar.
+    //   applyTweak — record a single (anchor, dottedPath, value) edit.
+    //   listTweaks — return the current in-memory tweak table.
+    //   clearTweaks — remove tweaks (optionally scoped to anchor/path).
+    //   setBypass — toggle the sibling `bypassed` overlay for an anchor.
+    constexpr auto kInspectorApplyTweak  = "Inspector.applyTweak";
+    constexpr auto kInspectorListTweaks  = "Inspector.listTweaks";
+    constexpr auto kInspectorClearTweaks = "Inspector.clearTweaks";
+    constexpr auto kInspectorSetBypass   = "Inspector.setBypass";
 
     // DOM domain
     constexpr auto kDOMGetDocument     = "DOM.getDocument";

--- a/inspect/include/pulp/inspect/tweak_store.hpp
+++ b/inspect/include/pulp/inspect/tweak_store.hpp
@@ -1,0 +1,127 @@
+// tweak_store.hpp — Phase 0b in-memory tweak table.
+//
+// Scope (planning/2026-05-18-inspector-direct-manipulation-roadmap.md):
+//   Phase 0b lands ONLY the data layer — protocol method + in-memory
+//   table + bridge handler stub. Disk persistence (`pulp-tweaks.json`)
+//   is Phase 1. Direct-manipulation gesture capture is Phase 0b PR-B.
+//   Property-panel dot indicators are Phase 0b PR-C.
+//
+// Schema mirrors @pulp/import-ir/src/tweaks.ts TweaksFile (see
+// packages/pulp-import-ir/src/tweaks.ts:138):
+//
+//   tweaks: Record<anchor, Record<dottedPath, value>>
+//   bypassed?: Record<anchor, true | string[]>
+//
+// Per Codex Phase 0b review: bypass MUST be a SIBLING overlay, not
+// `applied:false` mixed into the dotted-path tweak map. That preserves
+// v1 backwards compatibility when Phase 1 starts reading existing
+// tweaks files from disk.
+
+#pragma once
+
+#include <choc/containers/choc_Value.h>
+
+#include <cstddef>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace pulp::inspect {
+
+/// In-memory record of inspector direct-manipulation edits ("tweaks"),
+/// keyed by stable_anchor_id (Phase 0a) + dotted property path
+/// (e.g. "paint.backgroundColor", "layout.padding").
+///
+/// Thread-safety: external mutex; all public methods take the same
+/// internal mutex so the inspector can safely receive concurrent
+/// applyTweak / listTweaks calls from multiple connected clients.
+class TweakStore {
+public:
+    /// A single tweak record returned by list_tweaks().
+    struct Record {
+        std::string anchor_id;
+        std::string property_path;  // dotted, e.g. "paint.backgroundColor"
+        choc::value::Value value;
+        std::string source;         // optional adapter / origin tag (free-form)
+    };
+
+    /// Bypass overlay value — matches the TS `true | string[]` shape.
+    /// `bool=true` bypasses every tweak under an anchor; a non-empty
+    /// vector bypasses only the listed dotted paths.
+    using BypassValue = std::variant<bool, std::vector<std::string>>;
+
+    TweakStore() = default;
+
+    // ── Mutation ────────────────────────────────────────────────────
+
+    /// Record an edit. Overwrites any prior value at the same
+    /// (anchor_id, property_path). Returns the post-write tweak count.
+    std::size_t apply_tweak(std::string_view anchor_id,
+                            std::string_view property_path,
+                            choc::value::Value value,
+                            std::string_view source = {});
+
+    /// Remove a single (anchor_id, property_path) entry. Returns true
+    /// if something was removed.
+    bool remove_tweak(std::string_view anchor_id,
+                      std::string_view property_path);
+
+    /// Remove all entries for an anchor. Returns the number of entries
+    /// removed.
+    std::size_t remove_anchor(std::string_view anchor_id);
+
+    /// Clear the entire table (tweaks + bypass overlay).
+    void clear();
+
+    /// Set the bypass state for an anchor.
+    /// - `true` bypasses every tweak under the anchor.
+    /// - A non-empty vector bypasses only those dotted paths.
+    /// - An empty vector or `false` clears the bypass entirely.
+    void set_bypass(std::string_view anchor_id, BypassValue value);
+
+    /// Convenience: clear the bypass for an anchor (equivalent to
+    /// set_bypass(id, false)).
+    void clear_bypass(std::string_view anchor_id);
+
+    // ── Inspection ──────────────────────────────────────────────────
+
+    /// Total number of (anchor, property) entries.
+    std::size_t count() const;
+
+    /// Return every record. Order is insertion-stable within an anchor
+    /// and unspecified across anchors.
+    std::vector<Record> list_tweaks() const;
+
+    /// Look up a specific (anchor_id, property_path). Returns the value
+    /// if set, std::nullopt otherwise.
+    std::optional<choc::value::Value>
+    lookup(std::string_view anchor_id, std::string_view property_path) const;
+
+    /// Whether a specific (anchor_id, property_path) is currently
+    /// bypassed (either whole-anchor or path-specific).
+    bool is_bypassed(std::string_view anchor_id,
+                     std::string_view property_path) const;
+
+    /// Current bypass state for an anchor. Returns std::nullopt if the
+    /// anchor has no bypass entry; otherwise the live BypassValue.
+    std::optional<BypassValue>
+    bypass_for(std::string_view anchor_id) const;
+
+private:
+    mutable std::mutex mtx_;
+    // Outer key: anchor_id. Inner key: dotted property path.
+    // Inner value: the most-recent assigned value + source.
+    struct Entry {
+        choc::value::Value value;
+        std::string source;
+    };
+    std::unordered_map<std::string,
+                       std::unordered_map<std::string, Entry>> tweaks_;
+    std::unordered_map<std::string, BypassValue> bypassed_;
+};
+
+}  // namespace pulp::inspect

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -7,6 +7,7 @@
 #include <pulp/inspect/audio_inspector.hpp>
 #include <pulp/inspect/motion_inspector.hpp>
 #include <pulp/inspect/motion_scrubber.hpp>
+#include <pulp/inspect/tweak_store.hpp>
 #include <pulp/view/inspector.hpp>
 #include <pulp/view/view.hpp>
 #include <pulp/render/dirty_tracker.hpp>
@@ -17,6 +18,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <unordered_set>
 
 namespace pulp::inspect {
 
@@ -83,8 +85,150 @@ InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
         if (overlay_) {
             obj.addMember("inspector_active", choc::value::createBool(overlay_->is_active()));
         }
+        if (tweak_store_) {
+            obj.addMember("tweak_count", choc::value::createInt64(
+                static_cast<int64_t>(tweak_store_->count())));
+        }
         return make_response(req.id, choc::json::toString(obj, false));
     }
+
+    // ── Phase 0b: applyTweak / listTweaks / clearTweaks / setBypass ──
+    // All four require a TweakStore wired in (set_tweak_store(...)).
+    // Schema mirrors the TS @pulp/import-ir/src/tweaks.ts TweaksFile.
+    if (req.method == methods::kInspectorApplyTweak) {
+        if (!tweak_store_) return make_error(req.id, "No tweak store attached");
+        try {
+            auto params = choc::json::parse(req.params_json);
+            auto anchor = std::string(params["anchorId"].getString());
+            auto path = std::string(params["propertyPath"].getString());
+            std::string source;
+            if (params.hasObjectMember("source") && params["source"].isString())
+                source = std::string(params["source"].getString());
+            // `value` is arbitrary JSON — clone it into a value the
+            // store can own. (params is a ValueView over a temporary
+            // parsed-JSON document; addMember copies cleanly.)
+            auto value = choc::value::Value(params["value"]);
+            auto total = tweak_store_->apply_tweak(anchor, path, std::move(value), source);
+
+            auto resp = choc::value::createObject("");
+            resp.addMember("ok", choc::value::createBool(true));
+            resp.addMember("tweakCount", choc::value::createInt64(static_cast<int64_t>(total)));
+            return make_response(req.id, choc::json::toString(resp, false));
+        } catch (const std::exception& e) {
+            return make_error(req.id,
+                std::string("Invalid params for Inspector.applyTweak: ") + e.what());
+        } catch (...) {
+            return make_error(req.id, "Invalid params for Inspector.applyTweak");
+        }
+    }
+    if (req.method == methods::kInspectorListTweaks) {
+        if (!tweak_store_) return make_error(req.id, "No tweak store attached");
+        auto records = tweak_store_->list_tweaks();
+
+        // Build the response as { tweaks: { anchor: { path: value } },
+        // bypassed: { anchor: true | [paths] } } — mirrors the on-disk
+        // TweaksFile schema Phase 1 will adopt.
+        auto tweaks_obj = choc::value::createObject("");
+        std::unordered_map<std::string, choc::value::Value> anchor_objs;
+        for (auto& rec : records) {
+            auto it = anchor_objs.find(rec.anchor_id);
+            if (it == anchor_objs.end()) {
+                it = anchor_objs.emplace(rec.anchor_id,
+                                         choc::value::createObject("")).first;
+            }
+            it->second.addMember(rec.property_path, rec.value);
+        }
+        for (auto& [anchor, obj] : anchor_objs) {
+            tweaks_obj.addMember(anchor, obj);
+        }
+
+        auto bypassed_obj = choc::value::createObject("");
+        // Walk every anchor we know about (from tweaks or bypassed)
+        // and surface its bypass state if any.
+        std::unordered_set<std::string> all_anchors;
+        for (auto& rec : records) all_anchors.insert(rec.anchor_id);
+        for (auto& anchor : all_anchors) {
+            auto b = tweak_store_->bypass_for(anchor);
+            if (!b) continue;
+            std::visit([&](auto&& v) {
+                using T = std::decay_t<decltype(v)>;
+                if constexpr (std::is_same_v<T, bool>) {
+                    bypassed_obj.addMember(anchor, choc::value::createBool(v));
+                } else {
+                    auto arr = choc::value::createEmptyArray();
+                    for (auto& p : v) arr.addArrayElement(choc::value::createString(p));
+                    bypassed_obj.addMember(anchor, arr);
+                }
+            }, *b);
+        }
+
+        auto resp = choc::value::createObject("");
+        resp.addMember("tweaks", tweaks_obj);
+        resp.addMember("bypassed", bypassed_obj);
+        resp.addMember("count", choc::value::createInt64(static_cast<int64_t>(records.size())));
+        return make_response(req.id, choc::json::toString(resp, false));
+    }
+    if (req.method == methods::kInspectorClearTweaks) {
+        if (!tweak_store_) return make_error(req.id, "No tweak store attached");
+        try {
+            auto params = req.params_json.empty() || req.params_json == "{}"
+                ? choc::value::createObject("")
+                : choc::json::parse(req.params_json);
+            std::size_t removed = 0;
+            bool has_anchor = params.isObject() &&
+                              params.hasObjectMember("anchorId") &&
+                              params["anchorId"].isString();
+            bool has_path = params.isObject() &&
+                            params.hasObjectMember("propertyPath") &&
+                            params["propertyPath"].isString();
+            if (has_anchor && has_path) {
+                removed = tweak_store_->remove_tweak(
+                    std::string(params["anchorId"].getString()),
+                    std::string(params["propertyPath"].getString())) ? 1 : 0;
+            } else if (has_anchor) {
+                removed = tweak_store_->remove_anchor(
+                    std::string(params["anchorId"].getString()));
+            } else {
+                // No selector — wipe the whole table.
+                removed = tweak_store_->count();
+                tweak_store_->clear();
+            }
+            auto resp = choc::value::createObject("");
+            resp.addMember("ok", choc::value::createBool(true));
+            resp.addMember("removed", choc::value::createInt64(static_cast<int64_t>(removed)));
+            return make_response(req.id, choc::json::toString(resp, false));
+        } catch (...) {
+            return make_error(req.id, "Invalid params for Inspector.clearTweaks");
+        }
+    }
+    if (req.method == methods::kInspectorSetBypass) {
+        if (!tweak_store_) return make_error(req.id, "No tweak store attached");
+        try {
+            auto params = choc::json::parse(req.params_json);
+            auto anchor = std::string(params["anchorId"].getString());
+            // Value can be `true`/`false` (whole-anchor) or an array of
+            // dotted paths (path-scoped). Empty array / false clears.
+            if (params.hasObjectMember("value") && params["value"].isBool()) {
+                tweak_store_->set_bypass(anchor, params["value"].getBool());
+            } else if (params.hasObjectMember("value") && params["value"].isArray()) {
+                std::vector<std::string> paths;
+                auto arr = params["value"];
+                for (uint32_t i = 0; i < arr.size(); ++i) {
+                    if (arr[i].isString()) paths.push_back(std::string(arr[i].getString()));
+                }
+                tweak_store_->set_bypass(anchor, std::move(paths));
+            } else {
+                return make_error(req.id,
+                    "Inspector.setBypass requires `value` as bool or string[]");
+            }
+            auto resp = choc::value::createObject("");
+            resp.addMember("ok", choc::value::createBool(true));
+            return make_response(req.id, choc::json::toString(resp, false));
+        } catch (...) {
+            return make_error(req.id, "Invalid params for Inspector.setBypass");
+        }
+    }
+
     return make_error(req.id, "Unknown Inspector method: " + req.method);
 }
 

--- a/inspect/src/tweak_store.cpp
+++ b/inspect/src/tweak_store.cpp
@@ -1,0 +1,123 @@
+// tweak_store.cpp — Phase 0b in-memory tweak table.
+
+#include <pulp/inspect/tweak_store.hpp>
+
+#include <algorithm>
+
+namespace pulp::inspect {
+
+std::size_t TweakStore::apply_tweak(std::string_view anchor_id,
+                                    std::string_view property_path,
+                                    choc::value::Value value,
+                                    std::string_view source) {
+    std::lock_guard lock(mtx_);
+    auto& anchor_map = tweaks_[std::string(anchor_id)];
+    Entry entry{std::move(value), std::string(source)};
+    anchor_map[std::string(property_path)] = std::move(entry);
+
+    std::size_t total = 0;
+    for (auto& [_, m] : tweaks_) total += m.size();
+    return total;
+}
+
+bool TweakStore::remove_tweak(std::string_view anchor_id,
+                              std::string_view property_path) {
+    std::lock_guard lock(mtx_);
+    auto it = tweaks_.find(std::string(anchor_id));
+    if (it == tweaks_.end()) return false;
+    auto removed = it->second.erase(std::string(property_path));
+    if (it->second.empty()) tweaks_.erase(it);
+    return removed > 0;
+}
+
+std::size_t TweakStore::remove_anchor(std::string_view anchor_id) {
+    std::lock_guard lock(mtx_);
+    auto it = tweaks_.find(std::string(anchor_id));
+    if (it == tweaks_.end()) return 0;
+    auto n = it->second.size();
+    tweaks_.erase(it);
+    return n;
+}
+
+void TweakStore::clear() {
+    std::lock_guard lock(mtx_);
+    tweaks_.clear();
+    bypassed_.clear();
+}
+
+void TweakStore::set_bypass(std::string_view anchor_id, BypassValue value) {
+    std::lock_guard lock(mtx_);
+    // Normalize "empty bypass" (false OR empty vector) → erase the
+    // overlay so is_bypassed() short-circuits cleanly.
+    if (std::holds_alternative<bool>(value) && !std::get<bool>(value)) {
+        bypassed_.erase(std::string(anchor_id));
+        return;
+    }
+    if (std::holds_alternative<std::vector<std::string>>(value) &&
+        std::get<std::vector<std::string>>(value).empty()) {
+        bypassed_.erase(std::string(anchor_id));
+        return;
+    }
+    bypassed_[std::string(anchor_id)] = std::move(value);
+}
+
+void TweakStore::clear_bypass(std::string_view anchor_id) {
+    std::lock_guard lock(mtx_);
+    bypassed_.erase(std::string(anchor_id));
+}
+
+std::size_t TweakStore::count() const {
+    std::lock_guard lock(mtx_);
+    std::size_t total = 0;
+    for (auto& [_, m] : tweaks_) total += m.size();
+    return total;
+}
+
+std::vector<TweakStore::Record> TweakStore::list_tweaks() const {
+    std::lock_guard lock(mtx_);
+    std::vector<Record> out;
+    for (auto& [anchor, m] : tweaks_) {
+        for (auto& [path, entry] : m) {
+            out.push_back(Record{anchor, path, entry.value, entry.source});
+        }
+    }
+    return out;
+}
+
+std::optional<choc::value::Value>
+TweakStore::lookup(std::string_view anchor_id,
+                   std::string_view property_path) const {
+    std::lock_guard lock(mtx_);
+    auto it = tweaks_.find(std::string(anchor_id));
+    if (it == tweaks_.end()) return std::nullopt;
+    auto pit = it->second.find(std::string(property_path));
+    if (pit == it->second.end()) return std::nullopt;
+    return pit->second.value;
+}
+
+bool TweakStore::is_bypassed(std::string_view anchor_id,
+                             std::string_view property_path) const {
+    std::lock_guard lock(mtx_);
+    auto it = bypassed_.find(std::string(anchor_id));
+    if (it == bypassed_.end()) return false;
+    return std::visit([&](auto&& v) -> bool {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, bool>) {
+            return v;  // true = bypass all paths under this anchor
+        } else {
+            // Path-list — only bypassed if property_path is in the list.
+            auto path_str = std::string(property_path);
+            return std::find(v.begin(), v.end(), path_str) != v.end();
+        }
+    }, it->second);
+}
+
+std::optional<TweakStore::BypassValue>
+TweakStore::bypass_for(std::string_view anchor_id) const {
+    std::lock_guard lock(mtx_);
+    auto it = bypassed_.find(std::string(anchor_id));
+    if (it == bypassed_.end()) return std::nullopt;
+    return it->second;
+}
+
+}  // namespace pulp::inspect

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1821,6 +1821,12 @@ if(PULP_ENABLE_GPU AND NOT ANDROID AND NOT IOS)
     add_executable(pulp-test-inspector test_inspector.cpp)
     target_link_libraries(pulp-test-inspector PRIVATE pulp::view pulp::inspect pulp::state Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-inspector)
+
+    # Phase 0b PR-A: TweakStore + Inspector.applyTweak protocol surface.
+    # planning/2026-05-18-inspector-direct-manipulation-roadmap.md
+    add_executable(pulp-test-tweak-store test_tweak_store.cpp)
+    target_link_libraries(pulp-test-tweak-store PRIVATE pulp::view pulp::inspect pulp::state Catch2::Catch2WithMain)
+    catch_discover_tests(pulp-test-tweak-store)
 endif()
 
 # Widget bridge tests

--- a/test/test_tweak_store.cpp
+++ b/test/test_tweak_store.cpp
@@ -1,0 +1,355 @@
+// Phase 0b PR-A: TweakStore + Inspector.applyTweak/listTweaks/clearTweaks/setBypass.
+// Spec: planning/2026-05-18-inspector-direct-manipulation-roadmap.md
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/inspect/domain_handler.hpp>
+#include <pulp/inspect/protocol.hpp>
+#include <pulp/inspect/tweak_store.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+using namespace pulp::inspect;
+
+namespace {
+
+// Tiny request builder so call sites stay readable.
+InspectorMessage req(std::string method, std::string params) {
+    return make_request(/*id=*/1, std::move(method), std::move(params));
+}
+
+// Wire a DomainHandler with just the TweakStore for these tests.
+struct Fixture {
+    TweakStore store;
+    DomainHandler handler;
+    Fixture() { handler.set_tweak_store(&store); }
+};
+
+}  // namespace
+
+// ── TweakStore unit tests ───────────────────────────────────────────────
+
+TEST_CASE("TweakStore: apply_tweak records new entries", "[inspect][tweak-store]") {
+    TweakStore s;
+    REQUIRE(s.count() == 0);
+
+    auto n = s.apply_tweak("anchor:a", "layout.padding",
+                           choc::value::createInt32(12), "drag");
+    REQUIRE(n == 1);
+    REQUIRE(s.count() == 1);
+
+    auto v = s.lookup("anchor:a", "layout.padding");
+    REQUIRE(v.has_value());
+    REQUIRE(v->getInt32() == 12);
+}
+
+TEST_CASE("TweakStore: apply_tweak overwrites the same anchor + path",
+          "[inspect][tweak-store]") {
+    TweakStore s;
+    s.apply_tweak("anchor:a", "paint.bg", choc::value::createString("#abc"), "color-picker");
+    s.apply_tweak("anchor:a", "paint.bg", choc::value::createString("#def"), "color-picker");
+    REQUIRE(s.count() == 1);
+    REQUIRE(s.lookup("anchor:a", "paint.bg")->getString() == "#def");
+}
+
+TEST_CASE("TweakStore: multiple paths under one anchor coexist",
+          "[inspect][tweak-store]") {
+    TweakStore s;
+    s.apply_tweak("anchor:a", "layout.padding", choc::value::createInt32(12), {});
+    s.apply_tweak("anchor:a", "paint.bg", choc::value::createString("#abc"), {});
+    REQUIRE(s.count() == 2);
+    auto recs = s.list_tweaks();
+    REQUIRE(recs.size() == 2);
+}
+
+TEST_CASE("TweakStore: remove_tweak removes a single entry",
+          "[inspect][tweak-store]") {
+    TweakStore s;
+    s.apply_tweak("anchor:a", "layout.padding", choc::value::createInt32(12), {});
+    s.apply_tweak("anchor:a", "paint.bg", choc::value::createString("#abc"), {});
+    REQUIRE(s.remove_tweak("anchor:a", "layout.padding"));
+    REQUIRE_FALSE(s.remove_tweak("anchor:a", "layout.padding"));
+    REQUIRE(s.count() == 1);
+    REQUIRE(s.lookup("anchor:a", "paint.bg").has_value());
+}
+
+TEST_CASE("TweakStore: remove_anchor wipes all paths under an anchor",
+          "[inspect][tweak-store]") {
+    TweakStore s;
+    s.apply_tweak("anchor:a", "layout.padding", choc::value::createInt32(12), {});
+    s.apply_tweak("anchor:a", "paint.bg", choc::value::createString("#abc"), {});
+    s.apply_tweak("anchor:b", "layout.gap", choc::value::createInt32(4), {});
+    REQUIRE(s.remove_anchor("anchor:a") == 2);
+    REQUIRE(s.count() == 1);
+    REQUIRE(s.lookup("anchor:b", "layout.gap").has_value());
+}
+
+TEST_CASE("TweakStore: clear wipes tweaks + bypass overlay",
+          "[inspect][tweak-store]") {
+    TweakStore s;
+    s.apply_tweak("anchor:a", "layout.padding", choc::value::createInt32(12), {});
+    s.set_bypass("anchor:a", true);
+    s.clear();
+    REQUIRE(s.count() == 0);
+    REQUIRE_FALSE(s.bypass_for("anchor:a").has_value());
+}
+
+// ── Bypass overlay ──────────────────────────────────────────────────────
+
+TEST_CASE("TweakStore: bypass=true bypasses every path under the anchor",
+          "[inspect][tweak-store]") {
+    TweakStore s;
+    s.set_bypass("anchor:a", true);
+    REQUIRE(s.is_bypassed("anchor:a", "layout.padding"));
+    REQUIRE(s.is_bypassed("anchor:a", "paint.bg"));
+    REQUIRE_FALSE(s.is_bypassed("anchor:b", "layout.padding"));
+}
+
+TEST_CASE("TweakStore: bypass=string[] bypasses only listed paths",
+          "[inspect][tweak-store]") {
+    TweakStore s;
+    s.set_bypass("anchor:a", std::vector<std::string>{"layout.padding"});
+    REQUIRE(s.is_bypassed("anchor:a", "layout.padding"));
+    REQUIRE_FALSE(s.is_bypassed("anchor:a", "paint.bg"));
+}
+
+TEST_CASE("TweakStore: bypass=false clears the overlay",
+          "[inspect][tweak-store]") {
+    TweakStore s;
+    s.set_bypass("anchor:a", true);
+    REQUIRE(s.is_bypassed("anchor:a", "any.path"));
+    s.set_bypass("anchor:a", false);
+    REQUIRE_FALSE(s.is_bypassed("anchor:a", "any.path"));
+    REQUIRE_FALSE(s.bypass_for("anchor:a").has_value());
+}
+
+TEST_CASE("TweakStore: bypass=empty vector clears the overlay (per Codex spec)",
+          "[inspect][tweak-store]") {
+    TweakStore s;
+    s.set_bypass("anchor:a", std::vector<std::string>{"x"});
+    s.set_bypass("anchor:a", std::vector<std::string>{});
+    REQUIRE_FALSE(s.bypass_for("anchor:a").has_value());
+}
+
+// ── Protocol round-trip via DomainHandler ───────────────────────────────
+
+TEST_CASE("Inspector.applyTweak records the edit and returns tweakCount",
+          "[inspect][protocol][applyTweak]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorApplyTweak,
+        R"({"anchorId":"figma:0:1","propertyPath":"layout.padding","value":12,"source":"drag"})"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+    REQUIRE(parsed["ok"].getBool());
+    REQUIRE(parsed["tweakCount"].getInt64() == 1);
+    REQUIRE(f.store.count() == 1);
+    // choc::json parses JSON integer literals as int64 — the
+    // applyTweak handler stores the parsed Value verbatim, so the
+    // round-tripped lookup is int64, not int32.
+    REQUIRE(f.store.lookup("figma:0:1", "layout.padding")->getInt64() == 12);
+}
+
+TEST_CASE("Inspector.applyTweak accepts string / object / array values",
+          "[inspect][protocol][applyTweak]") {
+    Fixture f;
+    f.handler.handle(req(methods::kInspectorApplyTweak,
+        R"({"anchorId":"a","propertyPath":"paint.bg","value":"#abcdef"})"));
+    f.handler.handle(req(methods::kInspectorApplyTweak,
+        R"({"anchorId":"a","propertyPath":"paint.color","value":{"r":255,"g":128,"b":0}})"));
+    f.handler.handle(req(methods::kInspectorApplyTweak,
+        R"({"anchorId":"a","propertyPath":"paint.shadow","value":[1,2,3]})"));
+    REQUIRE(f.store.count() == 3);
+    REQUIRE(f.store.lookup("a", "paint.bg")->getString() == "#abcdef");
+    REQUIRE(f.store.lookup("a", "paint.color")->isObject());
+    REQUIRE(f.store.lookup("a", "paint.shadow")->isArray());
+}
+
+TEST_CASE("Inspector.applyTweak without a tweak store errors cleanly",
+          "[inspect][protocol][applyTweak]") {
+    DomainHandler h;  // no tweak store wired
+    auto resp = h.handle(req(methods::kInspectorApplyTweak,
+        R"({"anchorId":"a","propertyPath":"p","value":1})"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("Inspector.applyTweak with malformed params errors cleanly",
+          "[inspect][protocol][applyTweak]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorApplyTweak,
+        R"({"anchorId":"a"})"));  // missing propertyPath + value
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("Inspector.listTweaks returns the schema-shaped tweaks + bypassed maps",
+          "[inspect][protocol][listTweaks]") {
+    Fixture f;
+    f.store.apply_tweak("a", "layout.padding", choc::value::createInt32(12), "drag");
+    f.store.apply_tweak("a", "paint.bg", choc::value::createString("#abc"), "picker");
+    f.store.apply_tweak("b", "layout.gap", choc::value::createInt32(4), "drag");
+    f.store.set_bypass("b", true);
+
+    auto resp = f.handler.handle(req(methods::kInspectorListTweaks, "{}"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+
+    REQUIRE(parsed["count"].getInt64() == 3);
+    // choc::json int literals → int64. The applyTweak handler stored
+    // them via parsed Value; values written directly with
+    // createInt32() (as the test fixtures do here) retain int32. To
+    // keep the assertion tolerant of either width, use getWithDefault.
+    REQUIRE(parsed["tweaks"]["a"]["layout.padding"].getWithDefault<int64_t>(0) == 12);
+    REQUIRE(parsed["tweaks"]["a"]["paint.bg"].getString() == "#abc");
+    REQUIRE(parsed["tweaks"]["b"]["layout.gap"].getWithDefault<int64_t>(0) == 4);
+    REQUIRE(parsed["bypassed"]["b"].getBool());
+    // Anchor with no bypass shouldn't appear in `bypassed`.
+    REQUIRE_FALSE(parsed["bypassed"].hasObjectMember("a"));
+}
+
+TEST_CASE("Inspector.clearTweaks with no selector wipes the table",
+          "[inspect][protocol][clearTweaks]") {
+    Fixture f;
+    f.store.apply_tweak("a", "x", choc::value::createInt32(1), {});
+    f.store.apply_tweak("b", "y", choc::value::createInt32(2), {});
+
+    auto resp = f.handler.handle(req(methods::kInspectorClearTweaks, "{}"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+    REQUIRE(parsed["removed"].getInt64() == 2);
+    REQUIRE(f.store.count() == 0);
+}
+
+TEST_CASE("Inspector.clearTweaks with anchorId removes one anchor's entries",
+          "[inspect][protocol][clearTweaks]") {
+    Fixture f;
+    f.store.apply_tweak("a", "x", choc::value::createInt32(1), {});
+    f.store.apply_tweak("a", "y", choc::value::createInt32(2), {});
+    f.store.apply_tweak("b", "z", choc::value::createInt32(3), {});
+
+    auto resp = f.handler.handle(req(methods::kInspectorClearTweaks,
+        R"({"anchorId":"a"})"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+    REQUIRE(parsed["removed"].getInt64() == 2);
+    REQUIRE(f.store.count() == 1);
+    REQUIRE(f.store.lookup("b", "z").has_value());
+}
+
+TEST_CASE("Inspector.clearTweaks with anchorId + propertyPath removes one entry",
+          "[inspect][protocol][clearTweaks]") {
+    Fixture f;
+    f.store.apply_tweak("a", "x", choc::value::createInt32(1), {});
+    f.store.apply_tweak("a", "y", choc::value::createInt32(2), {});
+
+    auto resp = f.handler.handle(req(methods::kInspectorClearTweaks,
+        R"({"anchorId":"a","propertyPath":"x"})"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+    REQUIRE(parsed["removed"].getInt64() == 1);
+    REQUIRE_FALSE(f.store.lookup("a", "x").has_value());
+    REQUIRE(f.store.lookup("a", "y").has_value());
+}
+
+TEST_CASE("Inspector.setBypass with bool=true bypasses the whole anchor",
+          "[inspect][protocol][setBypass]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorSetBypass,
+        R"({"anchorId":"a","value":true})"));
+    REQUIRE_FALSE(resp.is_error);
+    REQUIRE(f.store.is_bypassed("a", "any.path"));
+}
+
+TEST_CASE("Inspector.setBypass with string[] bypasses only listed paths",
+          "[inspect][protocol][setBypass]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorSetBypass,
+        R"({"anchorId":"a","value":["layout.padding","paint.bg"]})"));
+    REQUIRE_FALSE(resp.is_error);
+    REQUIRE(f.store.is_bypassed("a", "layout.padding"));
+    REQUIRE(f.store.is_bypassed("a", "paint.bg"));
+    REQUIRE_FALSE(f.store.is_bypassed("a", "layout.gap"));
+}
+
+TEST_CASE("Inspector.setBypass with bool=false clears the bypass overlay",
+          "[inspect][protocol][setBypass]") {
+    Fixture f;
+    f.store.set_bypass("a", true);
+    auto resp = f.handler.handle(req(methods::kInspectorSetBypass,
+        R"({"anchorId":"a","value":false})"));
+    REQUIRE_FALSE(resp.is_error);
+    REQUIRE_FALSE(f.store.is_bypassed("a", "any.path"));
+}
+
+TEST_CASE("Inspector.setBypass with non-bool/non-array value errors",
+          "[inspect][protocol][setBypass]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorSetBypass,
+        R"({"anchorId":"a","value":42})"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("Inspector.listTweaks round-trips string[] bypass for an anchor",
+          "[inspect][protocol][listTweaks]") {
+    Fixture f;
+    f.store.apply_tweak("a", "layout.padding", choc::value::createInt32(8), {});
+    f.store.set_bypass("a", std::vector<std::string>{"layout.padding"});
+
+    auto resp = f.handler.handle(req(methods::kInspectorListTweaks, "{}"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+    // Array-form bypass should serialize back as a JSON array, not a bool.
+    // ValueView is a returned-by-value view; bind by value, not ref.
+    auto bypassed_a = parsed["bypassed"]["a"];
+    REQUIRE(bypassed_a.isArray());
+    REQUIRE(bypassed_a.size() == 1);
+    REQUIRE(bypassed_a[0].getString() == "layout.padding");
+}
+
+TEST_CASE("Inspector.applyTweak with un-parseable JSON errors cleanly",
+          "[inspect][protocol][applyTweak]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorApplyTweak, "not json"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("Inspector.clearTweaks with un-parseable JSON errors cleanly",
+          "[inspect][protocol][clearTweaks]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorClearTweaks, "{not json"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("Inspector.setBypass without a `value` key errors with a clear message",
+          "[inspect][protocol][setBypass]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorSetBypass,
+        R"({"anchorId":"a"})"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("Inspector.setBypass with un-parseable JSON errors cleanly",
+          "[inspect][protocol][setBypass]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorSetBypass, "{not json"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("Inspector.listTweaks / clearTweaks / setBypass without store error",
+          "[inspect][protocol][no-store]") {
+    DomainHandler h;  // no tweak store
+    REQUIRE(h.handle(req(methods::kInspectorListTweaks, "{}")).is_error);
+    REQUIRE(h.handle(req(methods::kInspectorClearTweaks, "{}")).is_error);
+    REQUIRE(h.handle(req(methods::kInspectorSetBypass,
+        R"({"anchorId":"a","value":true})")).is_error);
+}
+
+TEST_CASE("Inspector.getInfo surfaces tweak_count when a store is attached",
+          "[inspect][protocol][getInfo]") {
+    Fixture f;
+    f.store.apply_tweak("a", "x", choc::value::createInt32(1), {});
+    f.store.apply_tweak("b", "y", choc::value::createInt32(2), {});
+
+    auto resp = f.handler.handle(req(methods::kInspectorGetInfo, "{}"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+    REQUIRE(parsed["tweak_count"].getInt64() == 2);
+}


### PR DESCRIPTION
## Summary

First slice of **Phase 0b** of the inspector direct-manipulation roadmap (`planning/2026-05-18-inspector-direct-manipulation-roadmap.md`): the **data layer** for inspector edit capture. No UI, no disk persistence, no gesture wiring — those are PR-B (overlay gestures), Phase 1 (disk persistence), and PR-C (panel dot indicators) respectively.

This unblocks the visible-UI work in PR-B and PR-C by giving them a stable API to call into.

## What ships

**New `TweakStore`** (`inspect/{include,src}/tweak_store.{hpp,cpp}`):
- Per-session in-memory tweak table keyed by `stable_anchor_id` (Phase 0a from #2295) + dotted property path.
- Matches the TS `@pulp/import-ir/src/tweaks.ts` `TweaksFile` schema so Phase 1's disk read/write is straightforward.
- **Sibling `bypassed` overlay** (`bool | string[]`) per Codex Phase 0b review — *not* `applied: false` mixed into the dotted-path map. Preserves v1 backwards compatibility when Phase 1 reads existing tweaks files.
- Thread-safe so the inspector can serve concurrent `applyTweak` calls from multiple connected clients.

**New protocol methods** on the Inspector domain:
| Method | Params | Returns |
|---|---|---|
| `Inspector.applyTweak` | `{anchorId, propertyPath, value, source?}` | `{ok, tweakCount}` |
| `Inspector.listTweaks` | `{}` | `{tweaks, bypassed, count}` — schema-shaped |
| `Inspector.clearTweaks` | `{anchorId?, propertyPath?}` | `{ok, removed}` |
| `Inspector.setBypass` | `{anchorId, value: bool \| string[]}` | `{ok}` |

`DomainHandler` gains `set_tweak_store(TweakStore*)`. `Inspector.getInfo` now surfaces `tweak_count`.

## Test plan

`test/test_tweak_store.cpp` — **29 test cases / 78 assertions**:
- `TweakStore` unit behavior: apply / overwrite / remove / clear
- Bypass overlay semantics: bool, array, clearing (empty array → clear per Codex spec)
- Protocol round-trip for all four new methods
- Error paths: no store, malformed JSON, missing `value`, wrong type
- `listTweaks` round-trips both bool- and array-shaped bypass entries

Local diff coverage: **81.1%** (gate is 75%).

## Why direct merge anticipated

Shipyard CLI is broken on its own newly-flipped cloud backend (same workflow-lookup bug PR #2299 fixes). Auto-merge is enabled below — required CI gates will land it. Direct path is the same as #2295.

## Relates to

- **Phase 0a** (foundation): #2295 — IRNode now has `stable_anchor_id`
- **Roadmap**: [`planning/2026-05-18-inspector-direct-manipulation-roadmap.md`](https://github.com/danielraffel/pulp-planning/blob/main/2026-05-18-inspector-direct-manipulation-roadmap.md)
- **Shipyard CLI bug fix** (separate): #2299
- **Umbrella**: #1307 — implementing the inspector-relevant subset

## What this unlocks

- Phase 0b PR-B (overlay gesture capture) — drag/color-pick gestures call `Inspector.applyTweak`
- Phase 0b PR-C (property panel dot indicators) — UI calls `Inspector.listTweaks`
- Phase 1 (disk persistence) — `TweakStore` + serializer = `pulp-tweaks.json` sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)