### PR TITLE
ci(release): route macOS legs through Namespace + tighten ui-preview gate

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -323,6 +323,35 @@ Plan source: `planning/2026-05-13-namespace-overflow-implementation.md`
 (reviewed by `/codex` 2026-05-13). Full operator docs:
 `docs/guides/local-ci.md` § "macOS overflow routing".
 
+### Release workflows: Namespace routing (post-2026-05-18 incident)
+
+`.github/workflows/sign-and-release.yml` and `.github/workflows/release-cli.yml`
+also route their macOS legs through Namespace when
+`PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON` is set. Unlike `build.yml` (which
+has the full overflow logic above), release workflows take a simpler
+"namespace if configured, GitHub-hosted otherwise" approach via a tiny
+`resolve-macos-runner` job at the top of each file.
+
+**Why this matters:** during the 2026-05-18 SDK starvation incident,
+the GitHub-hosted `macos-14` / `macos-15` queue backed up for hours and
+blocked every release-cli darwin-arm64 leg and every sign-and-release
+build from v0.111.0 through v0.134.0 (25 tags piled up). PR work was
+already routing through Namespace post-cutover; releases were still
+hitting the GitHub-hosted pool because release-cli.yml and
+sign-and-release.yml had hardcoded `runs-on: macos-14` / `macos-15`.
+
+**Fall-back behavior:** when `PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON`
+is unset, both workflows revert to the previous GitHub-hosted runners —
+so removing the variable doesn't break releases.
+
+**Caveat:** this does NOT include the `PULP_LOCAL_MAC_OVERFLOW_THRESHOLD`
+logic from build.yml. Releases are infrequent enough that overflow isn't
+the bottleneck; sending all release macOS legs to Namespace directly is
+simpler and matches what the user has already configured.
+
+See pulp #2238 (supersede cascade fix), pulp #2281 (Skia gate fix),
+and the post-mortem-driven follow-up that introduced this routing.
+
 ### Per-PR macOS retargeting: `pulp macos`
 
 The matrix in `build.yml` couples Linux/Windows/macOS into a single

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -41,7 +41,35 @@ env:
   SHIPYARD_VERSION: "0.56.2"
 
 jobs:
+  # Resolve the macOS runner for the darwin-arm64 matrix legs. When
+  # PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON is set (the same repo
+  # variable build.yml uses for PR macOS routing post-2026-05-18
+  # cutover), route release-cli's macOS leg through Namespace cloud
+  # runners instead of GitHub-hosted macos-15. Falls back to macos-15
+  # when unset so reverting the cutover doesn't break releases.
+  # Background: 2026-05-18 SDK starvation — the GitHub-hosted macos-15
+  # queue backed up for hours and blocked v0.111..v0.134 release-cli
+  # runs from completing (compound with the supersede bug fixed in
+  # pulp #2238 and the Skia gate fix in pulp #2281).
+  resolve-macos-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      runs_on_json: ${{ steps.resolve.outputs.runs_on_json }}
+    steps:
+      - id: resolve
+        env:
+          NAMESPACE_JSON: ${{ vars.PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON }}
+        run: |
+          if [ -n "${NAMESPACE_JSON:-}" ]; then
+            echo "runs_on_json=${NAMESPACE_JSON}" >> "$GITHUB_OUTPUT"
+            echo "Routing macOS release-cli through Namespace: ${NAMESPACE_JSON}"
+          else
+            echo 'runs_on_json=["macos-15"]' >> "$GITHUB_OUTPUT"
+            echo "Routing macOS release-cli through GitHub-hosted macos-15"
+          fi
+
   build-cli:
+    needs: resolve-macos-runner
     strategy:
       fail-fast: false
       matrix:
@@ -62,7 +90,7 @@ jobs:
             platform: windows-arm64
             artifact: pulp.exe
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os == 'macos-15' && fromJSON(needs.resolve-macos-runner.outputs.runs_on_json) || matrix.os }}
     name: CLI ${{ matrix.platform }}
 
     steps:
@@ -390,7 +418,7 @@ jobs:
   # added in #349, but at the artifact-portability axis instead of
   # MSVC compile-time.
   smoke-cli:
-    needs: build-cli
+    needs: [build-cli, resolve-macos-runner]
     strategy:
       fail-fast: false
       matrix:
@@ -410,7 +438,7 @@ jobs:
           - os: windows-11-arm
             platform: windows-arm64
             artifact: pulp.exe
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os == 'macos-15' && fromJSON(needs.resolve-macos-runner.outputs.runs_on_json) || matrix.os }}
     name: Smoke ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -18,8 +18,35 @@ env:
   BUILD_TYPE: Release
 
 jobs:
+  # Resolve the macOS runner. When PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON
+  # is set (the same repo variable build.yml uses for PR macOS routing
+  # post-2026-05-18 cutover), route the release build through Namespace
+  # cloud runners instead of the GitHub-hosted macos-14 pool. Falls back
+  # to macos-14 when unset so reverting the cutover doesn't break releases.
+  # Background: 2026-05-18 SDK starvation — GitHub-hosted macos-14 queue
+  # backed up for hours and blocked v0.111..v0.134 from publishing
+  # (compound with the supersede bug fixed in pulp #2238 and the Skia
+  # gate fix in pulp #2281).
+  resolve-macos-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      runs_on_json: ${{ steps.resolve.outputs.runs_on_json }}
+    steps:
+      - id: resolve
+        env:
+          NAMESPACE_JSON: ${{ vars.PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON }}
+        run: |
+          if [ -n "${NAMESPACE_JSON:-}" ]; then
+            echo "runs_on_json=${NAMESPACE_JSON}" >> "$GITHUB_OUTPUT"
+            echo "Routing macOS sign-and-release through Namespace: ${NAMESPACE_JSON}"
+          else
+            echo 'runs_on_json=["macos-14"]' >> "$GITHUB_OUTPUT"
+            echo "Routing macOS sign-and-release through GitHub-hosted macos-14"
+          fi
+
   build-and-sign-macos:
-    runs-on: macos-14
+    needs: resolve-macos-runner
+    runs-on: ${{ fromJSON(needs.resolve-macos-runner.outputs.runs_on_json) }}
     name: Build, Sign, Notarize (macOS)
     # pulp #724: without `contents: write`, the final `Create GitHub Release`
     # step fails with "Resource not accessible by integration" because

--- a/examples/ui-preview/CMakeLists.txt
+++ b/examples/ui-preview/CMakeLists.txt
@@ -1,6 +1,14 @@
 # UI Preview — standalone app for validating the rendering pipeline.
 # Desktop-only: depends on pulp::inspect which needs the GPU stack.
-if(APPLE AND NOT PULP_IOS AND PULP_ENABLE_GPU AND TARGET pulp::inspect)
+# Skia is required because main.cpp's --font-probe codepath calls
+# pulp::canvas::probe_font_glyph which is only declared when
+# PULP_HAS_SKIA is defined. Without this gate, configurations with
+# PULP_ENABLE_GPU=ON but Skia binaries missing (e.g. the SDK release
+# build on a GitHub-hosted macOS image that hasn't bootstrapped Skia)
+# would attempt to build ui-preview and fail at compile time. The
+# #ifndef PULP_HAS_SKIA guard in main.cpp (pulp #2281) is a belt; this
+# is the suspenders.
+if(APPLE AND NOT PULP_IOS AND PULP_ENABLE_GPU AND PULP_HAS_SKIA AND TARGET pulp::inspect)
     add_executable(pulp-ui-preview main.cpp)
     target_link_libraries(pulp-ui-preview PRIVATE
         pulp::view


### PR DESCRIPTION
Post-mortem follow-ups from the 2026-05-18 SDK starvation incident
(v0.110.0 → v0.135.0 gap, 25 tags piled up):

1. sign-and-release.yml + release-cli.yml now route their macOS legs
   through the same Namespace cloud runners that build.yml uses for
   PR macOS routing (PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON repo
   variable, set during the 2026-05-18 cutover). When the variable
   is unset, both workflows fall back to the previous github-hosted
   macos-14 / macos-15 runners — no behavior change without the var.

   GitHub-hosted macOS queue starvation was the bottleneck that kept
   v0.115.0 release-cli queued for ~6 hours and starved every
   subsequent tag's release-cli darwin-arm64 leg. Reusing the
   Namespace pool that PR work already routes through avoids the
   GitHub-hosted pool entirely for release builds.

2. examples/ui-preview/CMakeLists.txt now requires PULP_HAS_SKIA in
   addition to PULP_ENABLE_GPU. The #2281 fix gated the
   probe_font_glyph call at the source level with #ifndef
   PULP_HAS_SKIA; this is the matching CMake gate so the target
   isn't built at all when Skia is missing (belt + suspenders).
   pulp::inspect needs the GPU stack anyway, so a no-Skia build
   would fail at link time even without the probe_font_glyph
   compile error.

3. .agents/skills/ci/SKILL.md documents the new release-workflow
   routing pattern alongside the existing build.yml overflow logic.

Related: #2238 (supersede cascade fix), #2281 (Skia gate fix).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Version-Bump: skip reason="CI workflow + example CMake guard + skill docs; no consumer-visible SDK surface or behavior change when Namespace var is unset"
Skill-Update: skip skill=ship reason="signing/notarization/packaging mechanics unchanged; only the runner pool serving the macOS build job changed"