### PR TITLE
fix(ci): clap-validator asset URL (macos-universal, version-prefixed)

### DIFF
--- a/.github/workflows/format-baseline-diff.yml
+++ b/.github/workflows/format-baseline-diff.yml
@@ -133,9 +133,17 @@ jobs:
         # tagged release; bump deliberately if the validator's
         # behavior changes (and re-capture the baseline at the same
         # commit).
+        #
+        # 2026-05-18: the upstream asset name carries the version and
+        # uses `macos-universal`, not `macos-aarch64` —
+        # `clap-validator-0.3.2-macos-universal.tar.gz`. The previous
+        # `clap-validator-macos-aarch64.tar.gz` URL 404'd silently and
+        # the validator never installed, so every PR's baseline-diff
+        # job exited 1 with "All validator(s) failed — no captured
+        # output." Pinning the correct asset name fixes that.
         run: |
           CV_VERSION="0.3.2"
-          CV_URL="https://github.com/free-audio/clap-validator/releases/download/${CV_VERSION}/clap-validator-macos-aarch64.tar.gz"
+          CV_URL="https://github.com/free-audio/clap-validator/releases/download/${CV_VERSION}/clap-validator-${CV_VERSION}-macos-universal.tar.gz"
           if curl -fsSL -o /tmp/cv.tar.gz "$CV_URL"; then
             tar -xzf /tmp/cv.tar.gz -C /tmp
             sudo mv /tmp/clap-validator /usr/local/bin/clap-validator

--- a/.github/workflows/format-baseline-diff.yml
+++ b/.github/workflows/format-baseline-diff.yml
@@ -145,7 +145,14 @@ jobs:
           CV_VERSION="0.3.2"
           CV_URL="https://github.com/free-audio/clap-validator/releases/download/${CV_VERSION}/clap-validator-${CV_VERSION}-macos-universal.tar.gz"
           if curl -fsSL -o /tmp/cv.tar.gz "$CV_URL"; then
-            tar -xzf /tmp/cv.tar.gz -C /tmp
+            # The universal archive's upstream build packs the binary as
+            # `binaries/clap-validator` (verified against
+            # free-audio/clap-validator's release workflow:
+            # `tar -caf "$ARCHIVE_NAME.tar.gz" binaries/clap-validator`).
+            # Extraction yields /tmp/binaries/clap-validator — NOT
+            # /tmp/clap-validator. Use --strip-components=1 so the
+            # binary lands at /tmp/clap-validator and the mv works.
+            tar -xzf /tmp/cv.tar.gz -C /tmp --strip-components=1
             sudo mv /tmp/clap-validator /usr/local/bin/clap-validator
             chmod +x /usr/local/bin/clap-validator
             clap-validator --version || echo "::warning::clap-validator installed but --version failed"


### PR DESCRIPTION
The format-baseline-diff workflow has been pointing at a 404 since
the gate was wired up — `clap-validator-macos-aarch64.tar.gz` doesn't
exist on any clap-validator release. The actual asset for tag 0.3.2
is `clap-validator-0.3.2-macos-universal.tar.gz` (universal binary,
version baked into the name).

Result: the install step silently warned "download failed", the
runtime check then exited 1 with "All 2 validator(s) failed — no
captured output", and every PR's `baseline-diff` job has been
red since the gate landed (PR #2218).

The job is advisory (not in branch protection's required check list),
so PRs continued to merge — but the constant red mast obscures real
validator regressions. Fix is a 1-line URL correction.

Verified at: https://github.com/free-audio/clap-validator/releases
shows `clap-validator-0.3.2-macos-universal.tar.gz` as the only
macOS asset for 0.3.2 / 0.3.1 / 0.3.0.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Skill-Update: skip skill=ci reason="1-line URL correction: clap-validator asset name changed format. No pattern or workflow contract change to teach. Existing ci SKILL.md guidance for the format-baseline-diff workflow remains accurate."