### PR TITLE
feat(view): Phase 0b PR-B — View::anchor_id + setAnchor bridge wiring

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -300,6 +300,23 @@ parses these to map generated elements back to their tweak-layer
 identity. If you write a custom codegen path, preserve this pattern
 so the inspector can still trace identity.
 
+**Phase 0b — `setAnchor()` bridge wiring:** the web-compat codegen
+path *also* emits a functional `setAnchor('<var>', '<anchor>')` call
+after each createElement, AND the call is emitted unconditionally —
+NOT gated on `opts.include_comments`. Rationale: the
+`// @pulp-anchor` trail is cosmetic (for grep / debugging), but
+`setAnchor()` is functional — the inspector cannot find a widget's
+anchor without it, so dropping it in minified codegen would silently
+break inspector tweaks in production. If you write a custom codegen
+path, emit both: the comment (gated) for debuggability and the
+setAnchor call (unconditional) for the runtime. The bridge side
+(`WidgetBridge::setAnchor`) is a silent no-op on unknown widget IDs,
+matching the rest of the bridge's tolerance for unmounted ids.
+
+Native-mode codegen does NOT yet emit `setAnchor` (small follow-up;
+the native codegen has many early-return branches that need each to
+be wired). Web-compat is the default mode for imports — covered.
+
 Spec + design:
 [`planning/2026-05-18-inspector-direct-manipulation-roadmap.md`](../../../planning/2026-05-18-inspector-direct-manipulation-roadmap.md)
 

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -326,6 +326,17 @@ public:
     void set_id(std::string id) { id_ = std::move(id); }
     const std::string& id() const { return id_; }
 
+    /// Phase 0b: stable anchor identity from the design-import IR (the
+    /// `// @pulp-anchor <id>` codegen trail from Phase 0a). The
+    /// inspector (Phase 0b PR-C) uses this to key tweaks against the
+    /// originating source element so they survive re-import.
+    ///
+    /// Empty by default. Populated by the JS bridge's setAnchor() call
+    /// for views constructed from imported designs; user-authored
+    /// views that aren't part of an imported tree leave it empty.
+    void set_anchor_id(std::string anchor) { anchor_id_ = std::move(anchor); }
+    const std::string& anchor_id() const { return anchor_id_; }
+
     // ── Visual properties (CSS Box Model) ────────────────────────────────
 
     /// Opacity (0.0 = transparent, 1.0 = opaque). Applied as layer alpha.
@@ -1247,6 +1258,9 @@ private:
     View* parent_ = nullptr;
     std::vector<std::unique_ptr<View>> children_;
     std::string id_;
+    // Phase 0b: design-import anchor identity. Empty for views not
+    // constructed from an imported tree. See set_anchor_id().
+    std::string anchor_id_;
     AccessRole access_role_ = AccessRole::none;
     std::string access_label_;
     std::string access_value_;

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -3563,6 +3563,17 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
     if (!parent_var.empty())
         ss << ind << parent_var << ".appendChild(" << var << ");\n";
 
+    // Phase 0b: bind the anchor to the live widget so the inspector
+    // can key tweaks against it. Emitted unconditionally (NOT gated on
+    // include_comments) — the inspector needs the anchor to function
+    // even in minified bundles. js_single_quote_escape() is defensive;
+    // anchors are typically [a-z0-9:/-] but adapters can supply
+    // anything.
+    if (node.stable_anchor_id && !node.stable_anchor_id->empty()) {
+        ss << ind << "setAnchor('" << var << "', '"
+           << js_single_quote_escape(*node.stable_anchor_id) << "');\n";
+    }
+
     ss << "\n";
 
     // Recurse into children
@@ -3671,6 +3682,14 @@ static void generate_native_node(std::ostringstream& ss, const IRNode& node,
         !node.stable_anchor_id->empty()) {
         ss << ind << "// @pulp-anchor " << *node.stable_anchor_id << "\n";
     }
+    // Phase 0b: TODO — emit `setAnchor(id, anchor)` calls in this
+    // native-mode codegen path too. The web-compat path
+    // (generate_node) is wired; native mode has many early returns
+    // and several create call sites, so a small follow-up PR will
+    // factor that out cleanly. For now, native-mode imports do not
+    // bind anchors to live widgets — affects inspector tweaks for
+    // imports that opted into native codegen. Web-compat is the
+    // default mode, so most imports are unaffected.
 
     // Audio widgets use native widget API
     if (node.audio_widget != AudioWidgetType::none) {

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -3416,6 +3416,18 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
+    // Phase 0b: bind a design-import anchor (the `// @pulp-anchor`
+    // codegen trail from Phase 0a) to a live widget. The inspector
+    // (Phase 0b PR-C) reads anchor_id back to key tweaks against the
+    // originating source element. Silent no-op on unknown widget id —
+    // matches the rest of the bridge's tolerance for unmounted ids.
+    engine_.register_function("setAnchor", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto anchor = args.get<std::string>(1, "");
+        if (auto* v = widget(id)) v->set_anchor_id(std::move(anchor));
+        return choc::value::Value();
+    });
+
     // setStyle — placeholder until KnobStyle/ToggleStyle enums added to main widgets
     engine_.register_function("setStyle", [](choc::javascript::ArgumentList) {
         return choc::value::Value();

--- a/test/test_design_import_anchors.cpp
+++ b/test/test_design_import_anchors.cpp
@@ -398,3 +398,83 @@ TEST_CASE("generate_pulp_js native mode emits @pulp-anchor comments",
 
     REQUIRE(js.find("// @pulp-anchor figma:0:1") != std::string::npos);
 }
+
+// ── Phase 0b: setAnchor() codegen — binds anchor to the live widget ─────
+
+TEST_CASE("web-compat codegen emits setAnchor calls per node",
+          "[view][import][anchors][setAnchor]") {
+    const std::string json = R"({
+        "type": "frame",
+        "id": "0:1",
+        "children": [{ "type": "text", "content": "X", "id": "0:42" }]
+    })";
+
+    auto ir = parse_figma_json(json);
+
+    CodeGenOptions opts;
+    opts.include_comments = true;
+    opts.mode = CodeGenMode::web_compat;
+    auto js = generate_pulp_js(ir, opts);
+
+    // Both anchors should appear in setAnchor() calls — the inspector
+    // needs this to map live widgets back to their tweak-layer key.
+    REQUIRE(js.find("setAnchor(") != std::string::npos);
+    REQUIRE(js.find("'figma:0:1'") != std::string::npos);
+    REQUIRE(js.find("'figma:0:42'") != std::string::npos);
+}
+
+TEST_CASE("web-compat codegen emits setAnchor even when include_comments=false",
+          "[view][import][anchors][setAnchor]") {
+    const std::string json = R"({
+        "type": "frame",
+        "id": "0:1"
+    })";
+
+    auto ir = parse_figma_json(json);
+
+    CodeGenOptions opts;
+    opts.include_comments = false;
+    opts.mode = CodeGenMode::web_compat;
+    auto js = generate_pulp_js(ir, opts);
+
+    // include_comments=false strips the // @pulp-anchor trail (cosmetic)
+    // but setAnchor() is FUNCTIONAL — the inspector cannot find a
+    // widget's anchor without it. Must survive minified codegen.
+    REQUIRE(js.find("@pulp-anchor") == std::string::npos);
+    REQUIRE(js.find("setAnchor(") != std::string::npos);
+    REQUIRE(js.find("'figma:0:1'") != std::string::npos);
+}
+
+TEST_CASE("setAnchor escapes single quotes in anchor strings",
+          "[view][import][anchors][setAnchor]") {
+    // Synthesize an IR where the anchor contains a single-quote (rare
+    // but possible if an adapter ever produces one). The codegen helper
+    // js_single_quote_escape() must handle it so the emitted JS still
+    // parses cleanly.
+    pulp::view::DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+    ir.root.stable_anchor_id = "weird'anchor";
+
+    CodeGenOptions opts;
+    opts.mode = CodeGenMode::web_compat;
+    auto js = generate_pulp_js(ir, opts);
+
+    REQUIRE(js.find("setAnchor(") != std::string::npos);
+    // The escaped form should be `weird\'anchor`.
+    REQUIRE(js.find(R"(weird\'anchor)") != std::string::npos);
+}
+
+TEST_CASE("nodes without stable_anchor_id emit no setAnchor call",
+          "[view][import][anchors][setAnchor]") {
+    pulp::view::DesignIR ir;
+    ir.root.type = "frame";
+    ir.root.name = "Root";
+    // intentionally no stable_anchor_id — like a manually constructed IR
+
+    CodeGenOptions opts;
+    opts.mode = CodeGenMode::web_compat;
+    auto js = generate_pulp_js(ir, opts);
+
+    REQUIRE(js.find("setAnchor(") == std::string::npos);
+}

--- a/test/test_widget_bridge.cpp
+++ b/test/test_widget_bridge.cpp
@@ -86,6 +86,53 @@ TEST_CASE("WidgetBridge creates knob from JS", "[view][bridge]") {
     REQUIRE(dynamic_cast<Knob*>(w) != nullptr);
 }
 
+// Phase 0b: setAnchor() bridge call binds an anchor to a live widget so
+// the inspector can key tweaks back to the originating source element.
+TEST_CASE("WidgetBridge setAnchor binds the anchor to the live widget",
+          "[view][bridge][anchor]") {
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    bridge.load_script(
+        "createKnob('gain', 10, 10, 48, 48);"
+        "setAnchor('gain', 'figma:0:42');"
+    );
+
+    auto* w = bridge.widget("gain");
+    REQUIRE(w != nullptr);
+    REQUIRE(w->anchor_id() == "figma:0:42");
+}
+
+TEST_CASE("WidgetBridge setAnchor is a silent no-op on unknown widget id",
+          "[view][bridge][anchor]") {
+    // Mirror the pattern used by every other property setter — silent
+    // no-op on unmounted ids. Avoids load-order coupling between
+    // setAnchor() and createX().
+    ScriptEngine engine;
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    StateStore store;
+    WidgetBridge bridge(engine, root, store);
+
+    // Should not throw / crash. No assertion required beyond the
+    // absence of exceptions; the run finishing cleanly is the test.
+    bridge.load_script("setAnchor('nope', 'figma:0:1');");
+    REQUIRE(bridge.widget("nope") == nullptr);
+}
+
+TEST_CASE("View::anchor_id() defaults to empty for non-imported views",
+          "[view][anchor]") {
+    View v;
+    REQUIRE(v.anchor_id().empty());
+    v.set_anchor_id("figma:0:99");
+    REQUIRE(v.anchor_id() == "figma:0:99");
+    v.set_anchor_id("");
+    REQUIRE(v.anchor_id().empty());
+}
+
 TEST_CASE("WidgetBridge creates fader from JS", "[view][bridge]") {
     ScriptEngine engine;
     View root;


### PR DESCRIPTION
## Summary

Second slice of **Phase 0b** of the inspector direct-manipulation roadmap (`planning/2026-05-18-inspector-direct-manipulation-roadmap.md`). PR-A (#2300) landed the data layer; PR-B (this one) connects the runtime side: every live widget now carries its `stable_anchor_id` so the inspector (PR-C, next) can look up a hovered/selected View and key tweaks against it.

**PR-B is independent of PR-A** — touches `View` / `WidgetBridge` / codegen only, no `TweakStore` dependency. The two can land in either order.

## What ships

| Surface | Change |
|---|---|
| `View::set_anchor_id() / anchor_id()` | Runtime accessor on every View. Empty by default; populated by the bridge's `setAnchor` call for views from imported designs. |
| `WidgetBridge::setAnchor(id, anchor)` | JS bridge function. Silent no-op on unknown widget ids. |
| `generate_pulp_js` (web-compat mode) | Now emits `setAnchor('<var>', '<anchor>')` after each createElement, *unconditionally* — the inspector cannot find a widget's anchor without it, so dropping it in minified codegen would silently break inspector tweaks in production. |
| `import-design` skill | New section documents the bridge contract any future codegen path must follow. |

Native-mode codegen is **not** yet wired (TODO note in source + skill). The native codegen has many early-return branches that need each wired individually; left as a small follow-up. Web-compat is the default for imports.

## Test plan

- `test_design_import_anchors.cpp` (+4 cases)
- `test_widget_bridge.cpp` (+3 cases): bridge round-trip, silent no-op, View accessor
- All existing tests pass — no regressions
- **Local diff coverage: 100%** (12/12 lines)

## Why direct merge anticipated

Shipyard CLI still broken on its own cloud cutover (#2299 fixes it but hasn't merged yet). Auto-merge enabled; required CI gates will land it.

## Relates to

- Phase 0a: #2295
- Phase 0b PR-A: #2300
- Shipyard fix: #2299
- Umbrella: #1307

Generated with Claude Code.
