### PR TITLE
fix(canvas): address Codex review findings — async future safety, UTF-8/16 bridge, color mode strictness, golden ink probe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.135.0
+    VERSION 0.135.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/src/bundled_fonts.cpp
+++ b/core/canvas/src/bundled_fonts.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -388,12 +389,29 @@ std::future<FontState> register_font_url(const std::string& url,
         path = url;
     }
 
-    return std::async(std::launch::async,
-        [path = std::move(path), family_override]() -> FontState {
-            return register_font_file(path, family_override)
-                ? FontState::Loaded
-                : FontState::Failed;
-        });
+    // pulp #2246 follow-up (Codex review): `std::async(std::launch::async, ...)`
+    // returns a future whose destructor BLOCKS the caller until the task
+    // completes when the future is dropped without `.get()` / `.wait()`.
+    // That contradicts the docstring above ("safe to detach"). Switch to
+    // the promise + detached-thread pattern: the caller's future is decoupled
+    // from the worker thread, so dropping it is genuinely non-blocking. If
+    // the future goes out of scope before the worker finishes, the promise's
+    // value is set into a moved-from broken-promise sink and the worker
+    // exits cleanly without touching the caller's stack.
+    auto promise = std::make_shared<std::promise<FontState>>();
+    std::future<FontState> fut = promise->get_future();
+    std::thread([promise, path = std::move(path), family_override]() mutable {
+        const FontState state = register_font_file(path, family_override)
+            ? FontState::Loaded
+            : FontState::Failed;
+        try {
+            promise->set_value(state);
+        } catch (const std::future_error&) {
+            // Promise already satisfied or abandoned — fine, we're a
+            // detached worker. The caller's future is gone.
+        }
+    }).detach();
+    return fut;
 }
 
 FontProbe probe_font_glyph(const std::string& family,

--- a/core/canvas/src/font_registry_stubs.cpp
+++ b/core/canvas/src/font_registry_stubs.cpp
@@ -310,14 +310,38 @@ struct Utf8Utf16Bridge {
 // Inline UTF-8 scalar decode used by the bridge. The anonymous-
 // namespace helper above is not reachable here (different TU scope);
 // keep this duplicate trivially small.
+//
+// pulp #2249 follow-up (Codex review P2): validate continuation bytes
+// match `0b10xxxxxx`. Without this, a malformed lead byte followed by
+// an ASCII byte (e.g. `0xC2 0x41`) would be parsed as a 2-byte scalar,
+// while ICU's `fromUTF8` substitutes U+FFFD and advances 1 byte —
+// desyncing the bridge. Match ICU's substitution length (1 byte) by
+// returning 1 for any sequence where the trailing bytes are not valid
+// UTF-8 continuation bytes.
+inline bool is_utf8_continuation(unsigned char b) {
+    return (b & 0xC0) == 0x80;
+}
+
 inline std::size_t utf8_scalar_len(const std::string& s, std::size_t i) {
     if (i >= s.size()) return 0;
     unsigned char c = static_cast<unsigned char>(s[i]);
     if (c < 0x80) return 1;
-    if ((c & 0xE0) == 0xC0 && i + 1 < s.size()) return 2;
-    if ((c & 0xF0) == 0xE0 && i + 2 < s.size()) return 3;
-    if ((c & 0xF8) == 0xF0 && i + 3 < s.size()) return 4;
-    return 1; // malformed: advance by 1 byte
+    if ((c & 0xE0) == 0xC0 && i + 1 < s.size()
+        && is_utf8_continuation(static_cast<unsigned char>(s[i + 1]))) {
+        return 2;
+    }
+    if ((c & 0xF0) == 0xE0 && i + 2 < s.size()
+        && is_utf8_continuation(static_cast<unsigned char>(s[i + 1]))
+        && is_utf8_continuation(static_cast<unsigned char>(s[i + 2]))) {
+        return 3;
+    }
+    if ((c & 0xF8) == 0xF0 && i + 3 < s.size()
+        && is_utf8_continuation(static_cast<unsigned char>(s[i + 1]))
+        && is_utf8_continuation(static_cast<unsigned char>(s[i + 2]))
+        && is_utf8_continuation(static_cast<unsigned char>(s[i + 3]))) {
+        return 4;
+    }
+    return 1; // malformed: advance by 1 byte (matches ICU U+FFFD length)
 }
 
 inline Utf8Utf16Bridge build_bridge(const std::string& text) {
@@ -353,15 +377,25 @@ inline Utf8Utf16Bridge build_bridge(const std::string& text) {
 
 inline std::size_t utf16_for_utf8(const Utf8Utf16Bridge& b,
                                   std::size_t utf8_offset) {
-    // Binary search via std::lower_bound on the sorted (monotonic
-    // non-decreasing) utf8_for_utf16 vector.
-    auto it = std::lower_bound(b.utf8_for_utf16.begin(),
+    // pulp #2249 follow-up (Codex review P2): clamp byte offsets that
+    // land STRICTLY INSIDE a multi-byte UTF-8 scalar to the FLOOR
+    // UTF-16 index (the scalar that *contains* the offset), not the
+    // next scalar's start. ICU's `BreakIterator::following`/`preceding`
+    // are strictly after/before, so rounding up would cascade an
+    // off-by-one through every word-break call whose caller hands us
+    // a mid-codepoint cursor.
+    //
+    // Use upper_bound: the iterator points to the first scalar whose
+    // UTF-8 start is *greater than* `utf8_offset`. Stepping back one
+    // gives the scalar that contains `utf8_offset` (or matches it
+    // exactly when the offset lands on a scalar boundary).
+    auto it = std::upper_bound(b.utf8_for_utf16.begin(),
                                b.utf8_for_utf16.end(),
                                utf8_offset);
-    if (it == b.utf8_for_utf16.end()) {
-        return b.utf8_for_utf16.size() - 1;
+    if (it == b.utf8_for_utf16.begin()) {
+        return 0;
     }
-    return static_cast<std::size_t>(it - b.utf8_for_utf16.begin());
+    return static_cast<std::size_t>((it - 1) - b.utf8_for_utf16.begin());
 }
 
 } // namespace

--- a/core/canvas/src/font_resolver.cpp
+++ b/core/canvas/src/font_resolver.cpp
@@ -443,29 +443,55 @@ ResolvedFont FontResolver::resolve_character_fallback(const FontOptions& options
 
 // Color-font predicates — Skia-conditional method bodies that compile
 // in both Skia and non-Skia builds. (Slice 3.1)
-bool ResolvedFont::supports_color_font() const noexcept {
+
 #ifdef PULP_HAS_SKIA
-    if (!typeface) return false;
+namespace {
+
+// pulp #2243 follow-up (Codex review P2): enumerate which specific
+// color tables a typeface carries so `color_font_active()` can honor
+// explicit `ColorFontMode` requests strictly (Bitmap / COLR / SVG must
+// match the requested table, not just *some* color table).
+//
+// Tags packed big-endian:
+constexpr SkFontTableTag kCOLR = 0x434F4C52u;
+constexpr SkFontTableTag kCPAL = 0x4350414Cu;
+constexpr SkFontTableTag kCBDT = 0x43424454u;
+constexpr SkFontTableTag kCBLC = 0x43424C43u;
+constexpr SkFontTableTag kSBIX = 0x73626978u;
+constexpr SkFontTableTag kSVG  = 0x53564720u;  // 'SVG '
+
+struct ColorTablePresence {
+    bool any_color = false;  // Any of the six tags below.
+    bool colr = false;       // COLR or CPAL.
+    bool bitmap = false;     // CBDT/CBLC or sbix.
+    bool svg = false;        // SVG table.
+};
+
+ColorTablePresence scan_color_tables(const SkTypeface* typeface) {
+    ColorTablePresence p;
+    if (!typeface) return p;
     const int count = typeface->countTables();
-    if (count <= 0) return false;
+    if (count <= 0) return p;
     std::vector<SkFontTableTag> tags(static_cast<std::size_t>(count));
     // `readTableTags` is the canonical span-based API in this Skia
     // version; `getTableTags(tags[])` is gated behind a legacy macro.
     typeface->readTableTags({tags.data(), tags.size()});
-    // Tags packed big-endian: 'COLR' = 0x434F4C52, etc.
-    constexpr SkFontTableTag kCOLR = 0x434F4C52u;
-    constexpr SkFontTableTag kCPAL = 0x4350414Cu;
-    constexpr SkFontTableTag kCBDT = 0x43424454u;
-    constexpr SkFontTableTag kCBLC = 0x43424C43u;
-    constexpr SkFontTableTag kSBIX = 0x73626978u;
-    constexpr SkFontTableTag kSVG  = 0x53564720u;  // 'SVG '
     for (SkFontTableTag t : tags) {
-        if (t == kCOLR || t == kCPAL || t == kCBDT || t == kCBLC
-            || t == kSBIX || t == kSVG) {
-            return true;
+        if (t == kCOLR || t == kCPAL) { p.colr = true; p.any_color = true; }
+        else if (t == kCBDT || t == kCBLC || t == kSBIX) {
+            p.bitmap = true; p.any_color = true;
         }
+        else if (t == kSVG) { p.svg = true; p.any_color = true; }
     }
-    return false;
+    return p;
+}
+
+} // namespace
+#endif // PULP_HAS_SKIA
+
+bool ResolvedFont::supports_color_font() const noexcept {
+#ifdef PULP_HAS_SKIA
+    return scan_color_tables(typeface.get()).any_color;
 #else
     return false;
 #endif
@@ -474,7 +500,21 @@ bool ResolvedFont::supports_color_font() const noexcept {
 bool ResolvedFont::color_font_active() const noexcept {
 #ifdef PULP_HAS_SKIA
     if (color_font_mode == ColorFontMode::ForceMonochrome) return false;
-    return supports_color_font();
+    if (!typeface) return false;
+    const ColorTablePresence p = scan_color_tables(typeface.get());
+    // pulp #2243 follow-up (Codex review P2): explicit modes are
+    // STRICT — they request a specific color format, so the typeface
+    // must carry that specific table. Treating explicit modes as
+    // Auto-equivalent silently degrades to "any color table will do",
+    // which contradicts the ColorFontMode contract.
+    switch (color_font_mode) {
+        case ColorFontMode::Auto:           return p.any_color;
+        case ColorFontMode::Bitmap:         return p.bitmap;
+        case ColorFontMode::COLR:           return p.colr;
+        case ColorFontMode::SVG:            return p.svg;
+        case ColorFontMode::ForceMonochrome: return false;
+    }
+    return false;
 #else
     return false;
 #endif

--- a/test/test_font_async_lifecycle.cpp
+++ b/test/test_font_async_lifecycle.cpp
@@ -90,3 +90,40 @@ TEST_CASE("register_font_url: bare absolute path with invalid bytes → Failed",
     REQUIRE(fut.get() == FontState::Failed);
     std::remove(path.c_str());
 }
+
+// pulp #2246 follow-up (Codex review P1): the docstring on
+// register_font_url promises "the future is safe to detach", but the
+// pre-fix implementation used `std::async(std::launch::async, ...)`
+// whose returned future's destructor BLOCKS the caller until the
+// task completes if dropped without `.get()` / `.wait()`. That made
+// the docstring a lie. Verify the post-fix behavior: scheduling a
+// long-running registration and then dropping the future must NOT
+// block the caller — the test must complete promptly even though
+// the worker thread is still running in the background.
+TEST_CASE("register_font_url: dropping the future does not block the caller",
+          "[font][async][issue-2246]") {
+    namespace fs = std::filesystem;
+    std::string path = write_temp_dummy_font_bytes();
+
+    const auto t0 = std::chrono::steady_clock::now();
+    {
+        // Scope the future so its destructor runs before we measure
+        // elapsed time below.
+        auto fut = register_font_url(path);
+        (void)fut;
+        // Deliberately do NOT call wait()/get(). With std::async-based
+        // implementation, the future's destructor at scope exit would
+        // join the worker (~ms-to-seconds on a real font). With the
+        // promise + detached-thread fix, the destructor is a no-op.
+    }
+    const auto t1 = std::chrono::steady_clock::now();
+    const auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
+
+    // A reasonable bound: even on a slow CI host, decoupling from the
+    // worker thread should take well under 100ms. Pre-fix, this would
+    // have blocked for the full register_font_file duration.
+    REQUIRE(elapsed.count() < 100);
+
+    std::remove(path.c_str());
+}

--- a/test/test_font_color_mode.cpp
+++ b/test/test_font_color_mode.cpp
@@ -98,3 +98,79 @@ TEST_CASE("ColorFont: no typeface => supports_color_font is false",
     REQUIRE_FALSE(r.supports_color_font());
     REQUIRE_FALSE(r.color_font_active());
 }
+
+// pulp #2243 follow-up (Codex review P2): the explicit ColorFontMode
+// values (Bitmap / COLR / SVG) request a SPECIFIC color format. The
+// pre-fix `color_font_active()` returned true for any of those modes
+// whenever `supports_color_font()` returned true — i.e. it treated
+// every explicit mode like Auto, silently accepting "I have CBDT" as
+// satisfying "I asked for COLR".
+//
+// On macOS, Apple Color Emoji uses the `sbix` (bitmap) table and
+// does NOT carry COLR. Ask for ColorFontMode::COLR against it and
+// assert color_font_active() is FALSE — the contract is "strict
+// match", not "any color table will do".
+TEST_CASE("ColorFont: explicit COLR mode rejects font without COLR table",
+          "[font][color][issue-2243]") {
+#if defined(__APPLE__) && defined(PULP_HAS_SKIA)
+    FontOptions opts;
+    opts.family_stack.push_back("Apple Color Emoji");
+    opts.size = 14.0f;
+    opts.color_font_mode = ColorFontMode::COLR;
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    if (!resolved.has_typeface()) {
+        SUCCEED("Apple Color Emoji not resolvable on this host; skipped");
+        return;
+    }
+    // Apple Color Emoji uses sbix bitmaps, not COLR → supports_color_font
+    // is still true (any color table) but color_font_active under an
+    // explicit COLR request must be false (strict match).
+    REQUIRE(resolved.supports_color_font());
+    REQUIRE_FALSE(resolved.color_font_active());
+#else
+    SUCCEED("requires macOS + Skia for Apple Color Emoji probe");
+#endif
+}
+
+// Companion check: Bitmap mode against a bitmap-strikes font must
+// still activate. Apple Color Emoji on macOS uses sbix (bitmap), so
+// asking for Bitmap mode must succeed.
+TEST_CASE("ColorFont: explicit Bitmap mode accepts sbix-strikes font",
+          "[font][color][issue-2243]") {
+#if defined(__APPLE__) && defined(PULP_HAS_SKIA)
+    FontOptions opts;
+    opts.family_stack.push_back("Apple Color Emoji");
+    opts.size = 14.0f;
+    opts.color_font_mode = ColorFontMode::Bitmap;
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    if (!resolved.has_typeface()) {
+        SUCCEED("Apple Color Emoji not resolvable on this host; skipped");
+        return;
+    }
+    REQUIRE(resolved.supports_color_font());
+    REQUIRE(resolved.color_font_active());
+#else
+    SUCCEED("requires macOS + Skia for Apple Color Emoji probe");
+#endif
+}
+
+// Companion check: SVG mode against a font without an SVG table must
+// reject. Apple Color Emoji is sbix-only, no SVG.
+TEST_CASE("ColorFont: explicit SVG mode rejects font without SVG table",
+          "[font][color][issue-2243]") {
+#if defined(__APPLE__) && defined(PULP_HAS_SKIA)
+    FontOptions opts;
+    opts.family_stack.push_back("Apple Color Emoji");
+    opts.size = 14.0f;
+    opts.color_font_mode = ColorFontMode::SVG;
+    auto resolved = FontResolver::instance().resolve_family_list(opts);
+    if (!resolved.has_typeface()) {
+        SUCCEED("Apple Color Emoji not resolvable on this host; skipped");
+        return;
+    }
+    REQUIRE(resolved.supports_color_font());
+    REQUIRE_FALSE(resolved.color_font_active());
+#else
+    SUCCEED("requires macOS + Skia for Apple Color Emoji probe");
+#endif
+}

--- a/test/test_font_locale_shaping.cpp
+++ b/test/test_font_locale_shaping.cpp
@@ -108,3 +108,62 @@ TEST_CASE("word_break_step: backward from end yields offset < end", "[font][loca
     const std::size_t out = word_break_step(s, s.size(), "en-US", /*forward=*/false);
     REQUIRE(out < s.size());
 }
+
+// pulp #2249 follow-up (Codex review P2): byte offsets that land
+// strictly inside a multi-byte UTF-8 scalar must be mapped to the
+// FLOOR UTF-16 index (the scalar that contains the offset), not the
+// next scalar's start. With the pre-fix `lower_bound` mapping a
+// mid-codepoint cursor jumped *past* the codepoint, and the off-by-
+// one cascaded through every word-break call. Verify with U+00E9 'é'
+// (UTF-8 `0xC3 0xA9`): step forward from byte offset 1 (the middle
+// of the scalar) and assert the returned position is on a cluster
+// boundary — i.e. either 0 (start of é) or 2 (end of é), never 1.
+TEST_CASE("word_break_step: mid-codepoint cursor rounds down to cluster boundary",
+          "[font][locale][issue-2249]") {
+    // "café " — the 'é' occupies bytes 3..4 (`0xC3 0xA9`), so byte
+    // offset 4 is strictly inside that scalar. Forward and backward
+    // steps from inside the scalar must return cluster-aligned
+    // offsets — never 4 (mid-codepoint).
+    const std::string s = "caf\xC3\xA9 word";
+    {
+        const std::size_t out = word_break_step(s, 4, "en-US", /*forward=*/true);
+        // Must NOT report 4 (mid-codepoint). Acceptable values are
+        // any cluster-aligned offset > 4 OR exactly 3 (the scalar
+        // start, if the implementation snaps backward first).
+        REQUIRE(out != 4u);
+        REQUIRE((out == 3u || out >= 5u));
+        REQUIRE(out <= s.size());
+    }
+    {
+        const std::size_t out = word_break_step(s, 4, "en-US", /*forward=*/false);
+        REQUIRE(out != 4u);
+        // Backward from inside é must not land deeper than the scalar
+        // start.
+        REQUIRE(out <= 3u);
+    }
+}
+
+// pulp #2249 follow-up (Codex review P2): malformed UTF-8 lead bytes
+// whose continuation bytes don't match `0b10xxxxxx` must be advanced
+// by exactly 1 byte (matching ICU's U+FFFD substitution length). A
+// pre-fix `utf8_scalar_len` that accepted `0xC2 0x41` as a 2-byte
+// scalar desynced the bridge: build_bridge advanced 2, ICU advanced
+// 1, and subsequent byte→UTF-16 lookups returned wrong offsets.
+// Verify with `"\xC2A"` — a lead byte claiming 2 bytes followed by
+// ASCII 'A'. Calling word_break_step over this input must not crash,
+// must return a valid offset in [0, text.size()], and must treat the
+// input as non-empty (forward step from 0 must move forward).
+TEST_CASE("word_break_step: malformed continuation byte does not desync bridge",
+          "[font][locale][issue-2249]") {
+    // Lead byte 0xC2 claims a 2-byte scalar, but the next byte 'A'
+    // (0x41) is not a valid continuation byte. Build the string via
+    // explicit byte concatenation to avoid C++ hex-escape ambiguity
+    // (`"\xC2A"` parses as a single 3-digit hex escape).
+    std::string s;
+    s.push_back(static_cast<char>(0xC2));
+    s.append("A bc");
+    REQUIRE_NOTHROW(word_break_step(s, 0, "en-US", /*forward=*/true));
+    const std::size_t out = word_break_step(s, 0, "en-US", /*forward=*/true);
+    REQUIRE(out > 0u);
+    REQUIRE(out <= s.size());
+}

--- a/test/test_font_rendering_goldens.cpp
+++ b/test/test_font_rendering_goldens.cpp
@@ -57,6 +57,8 @@
 
 #include <pulp/canvas/canvas.hpp>
 #include <pulp/canvas/bundled_fonts.hpp>
+#include <pulp/canvas/font_options.hpp>
+#include <pulp/canvas/font_resolver.hpp>
 
 #include <cstdint>
 #include <cstdio>
@@ -277,6 +279,31 @@ TEST_CASE("font v2 Slice 3.4 — golden Inter 14px CJK 日本語 on raster",
     // fontconfig it will paint nothing — we soft-skip in that
     // case so this test stays a useful guard on the platforms
     // that DO have a CJK fallback.
+    //
+    // pulp #2261 follow-up (Codex review P1): use a DETERMINISTIC
+    // probe instead of the post-render `opaque_pixels < 20`
+    // threshold. The threshold approach is unsound because Skia's
+    // `fill_text` paints the `.notdef` glyph (tofu boxes) when no
+    // CJK face is found — those tofu pixels easily exceed 20,
+    // bypassing the soft-skip and producing spurious golden
+    // mismatches. Ask the resolver directly: does the cascade
+    // produce a face that covers U+65E5 (日)? If not, skip.
+    {
+        FontOptions probe_opts;
+        probe_opts.family_stack.push_back("Inter");
+        probe_opts.size = 14.0f;
+        ResolvedFont primary =
+            FontResolver::instance().resolve_family_list(probe_opts);
+        ResolvedFont cjk = FontResolver::instance()
+            .resolve_character_fallback(probe_opts, primary,
+                                        /*U+65E5 日*/ 0x65E5);
+        if (!cjk.has_typeface()) {
+            SUCCEED("CJK fallback unavailable on this host — "
+                    "golden skipped (resolver probe negative).");
+            return;
+        }
+    }
+
     SkBitmap bm = render_text_bitmap("Inter", 14.0f, "日本語");
     SkPixmap pm;
     REQUIRE(bm.peekPixels(&pm));
@@ -285,11 +312,6 @@ TEST_CASE("font v2 Slice 3.4 — golden Inter 14px CJK 日本語 on raster",
     REQUIRE(d.width  == kCjkInter14.width);
     REQUIRE(d.height == kCjkInter14.height);
 
-    // Soft-skip: no CJK fallback installed (Linux-stock CI).
-    if (d.opaque_pixels < 20) {
-        SUCCEED("CJK fallback unavailable on this host — golden skipped.");
-        return;
-    }
     expect_digest_matches(d, kCjkInter14, "cjk-inter-14", bm);
 }
 


### PR DESCRIPTION
## Summary

Batches 5 unresolved Codex review findings across 4 already-merged font v2
PRs into a single follow-up so the review history stays consolidated.

Source threads:
- [#2243 — color font support](https://github.com/danielraffel/pulp/pull/2243)
- [#2246 — async font lifecycle](https://github.com/danielraffel/pulp/pull/2246)
- [#2249 — locale-aware word/line breaking](https://github.com/danielraffel/pulp/pull/2249)
- [#2261 — cross-backend rendering goldens](https://github.com/danielraffel/pulp/pull/2261)

## Findings addressed

### P1

**1. #2246 — `register_font_url` returned a `std::async`-launched future whose destructor BLOCKS the caller.**
The pre-fix path used `std::async(std::launch::async, ...)` whose returned
future's destructor blocks until the worker completes when the caller drops
it without `.get()` / `.wait()`. That contradicts the docstring's
"safe to detach" promise. Switch to the promise + detached-thread pattern:
the caller's future is decoupled from the worker thread, so dropping it is
genuinely non-blocking.

- Fix: `core/canvas/src/bundled_fonts.cpp:391`.
- Test: `register_font_url: dropping the future does not block the caller`
  at `test/test_font_async_lifecycle.cpp:94` — scopes a future, drops it
  without waiting, asserts elapsed time < 100ms.

**2. #2261 — golden CJK render used an unsound `opaque_pixels < 20` soft-skip.**
Skia's `fill_text` draws `.notdef` (tofu) glyphs when no CJK fallback is
found, easily exceeding 20 opaque pixels and producing spurious golden
mismatches. Replace with a deterministic resolver probe: query
`FontResolver::resolve_character_fallback` for U+65E5 (日) BEFORE
rendering, and skip the case only when no CJK-capable face is resolvable.

- Fix: `test/test_font_rendering_goldens.cpp:289`.
- Test: same case — the predicate IS the test of the corrected behavior.
  Comment explains why a probe is sound where a pixel threshold is not.

### P2

**3. #2249 — `utf16_for_utf8` rounded mid-codepoint offsets UP, off-by-one cascade.**
`std::lower_bound` on the bridge table mapped a byte offset that lands
INSIDE a multi-byte UTF-8 scalar to the NEXT UTF-16 position. ICU's
`BreakIterator::following`/`preceding` are strictly after/before, so the
off-by-one cascaded through every word-break call that handed us a
mid-codepoint cursor. Switch to `upper_bound - 1` so mid-codepoint
offsets clamp to the FLOOR (containing scalar).

- Fix: `core/canvas/src/font_registry_stubs.cpp:373` (now `utf16_for_utf8`).
- Test: `word_break_step: mid-codepoint cursor rounds down to cluster
  boundary` at `test/test_font_locale_shaping.cpp:122`. Exercises the
  middle of `é` (UTF-8 `0xC3 0xA9`) and asserts the returned offset is
  cluster-aligned, never mid-codepoint.

**4. #2249 — `utf8_scalar_len` didn't validate continuation bytes.**
A 2/3/4-byte sequence was accepted purely on lead-byte bit pattern + remaining
length. Malformed input like `0xC2 0x41` (lead claims 2 bytes, continuation
is ASCII 'A') was parsed as a 2-byte scalar; `build_bridge` advanced 2 bytes
but ICU's `fromUTF8` substituted U+FFFD and advanced 1, desyncing the bridge.
Add continuation-byte validation (`(b & 0xC0) == 0x80`); fall back to 1-byte
advance on malformed input to match ICU's substitution length.

- Fix: `core/canvas/src/font_registry_stubs.cpp:313`.
- Test: `word_break_step: malformed continuation byte does not desync bridge`
  at `test/test_font_locale_shaping.cpp:156`. Exercises a lead byte 0xC2
  followed by ASCII 'A'.

**5. #2243 — `color_font_active()` ignored explicit `ColorFontMode` values.**
The documented contract says explicit `Bitmap`, `COLR`, `SVG` request a
SPECIFIC color format; if the font doesn't have that table, `color_font_active()`
should return false. The pre-fix path treated those modes as `Auto` — any
color table satisfied them. Refactor into a single `scan_color_tables` helper
that reports which specific table categories are present (COLR/CPAL, CBDT/CBLC
or sbix, SVG), then gate `color_font_active()` on the requested mode.

- Fix: `core/canvas/src/font_resolver.cpp:474`.
- Tests at `test/test_font_color_mode.cpp:108`:
  - `explicit COLR mode rejects font without COLR table` — Apple Color Emoji
    (sbix-only) is correctly rejected under `ColorFontMode::COLR`.
  - `explicit Bitmap mode accepts sbix-strikes font` — same font is correctly
    accepted under `ColorFontMode::Bitmap`.
  - `explicit SVG mode rejects font without SVG table` — same font is
    correctly rejected under `ColorFontMode::SVG`.

### Already-fixed (verification only)

**6. #2246 — async font-lifecycle test gated wrong on non-Skia builds.**
Verified: PR #2271 added a non-Skia stub for `register_font_url` in
`core/canvas/src/font_registry_stubs.cpp:477` that resolves immediately
to `FontState::Failed`. The async-lifecycle test compiles and runs on
non-Skia builds against that stub — no additional change required.

## Test plan

- [x] `pulp-test-font-async-lifecycle` — 6 cases / 13 assertions, all green
- [x] `pulp-test-font-rendering-goldens` — 4 cases / 22 assertions, all green
- [x] `pulp-test-font-locale-shaping` — 9 cases / 23 assertions, all green
- [x] `pulp-test-font-color-mode` — 9 cases / 14 assertions, all green
- [x] Full repo build green on macOS-arm64 with Skia linked
- [x] No regressions in adjacent font tests (`pulp-test-canvas-fonts`
      shows one pre-existing failure unrelated to this PR — also fails
      on pristine `origin/main`, see local-CI output)

REST-merge gated on the macOS lane + version-skill-sync.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
