### PR TITLE
feat(canvas): real ICU bidi + script run iterators (font v2 Slice 1.2.a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.139.0
+    VERSION 0.142.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/src/text_run_planner.cpp
+++ b/core/canvas/src/text_run_planner.cpp
@@ -298,8 +298,15 @@ segment_with_icu(std::string_view text, std::uint8_t base_level) {
         BidiScriptSegment seg;
         seg.start      = cursor;
         seg.end        = end;
-        seg.bidi_level = be ? base_level : bidi->currentLevel();
-        seg.script_tag = se ? 0u        : scr->currentScript();
+        // SkShaper RunIterator contract: after the final consume() on
+        // a one-run input (e.g. pure Hebrew "שלום", pure CJK "日本語"),
+        // atEnd() reports true but currentLevel() / currentScript()
+        // remain valid for the just-consumed run. Substituting
+        // base_level / 0 here would shape pure-RTL text as LTR and
+        // drop the script tag for any final or single-script run.
+        // See Codex review on PR #2311.
+        seg.bidi_level = bidi->currentLevel();
+        seg.script_tag = scr->currentScript();
 
         // Merge with the previous segment when both properties match,
         // which happens at seams where one iterator's run ended and

--- a/core/canvas/src/text_run_planner.cpp
+++ b/core/canvas/src/text_run_planner.cpp
@@ -1,24 +1,63 @@
 // text_run_planner.cpp — Pulp #2163 follow-up, Phase 1 / Slice 1.2.a.
 //
-// Skeleton implementation of `TextRunPlanner`. Wraps the existing
-// TextShaper / SkShaper path behind a single-run `ShapedText` so
-// downstream consumers can target the canonical-artifact API today
-// without forcing the bidi/script/cluster correctness work in the
-// same commit. Slice 1.2.a finish replaces the trivial single-run
-// path with real ICU/HarfBuzz iterators emitting multiple runs;
-// the API surface is stable across that swap.
+// Slice 1.2.a finish: real ICU/HarfBuzz iterators replace the trivial
+// single-run skeleton. Bidi level + script tag are computed per run via
+// `SkShaper::MakeIcuBiDiRunIterator` + `SkShaper::MakeHbIcuScriptRunIterator`
+// (available because `external/skia-build/build/mac-gpu/lib/Release/libskshaper.a`
+// statically links the ICU-backed builders — verified with `nm` at
+// implementation time). When Skia is not linked (PULP_HAS_SKIA undefined),
+// the planner falls back to a single run with bidi level / script tag
+// inferred from `FontOptions::direction`. The data shape produced is the
+// same in both paths; only the run count varies.
+//
+// Cluster construction: the public `cluster_step()` walker
+// (font_registry_stubs.cpp) is UAX #29-lite — it knows ZWJ, regional-
+// indicator parity, virama+consonant, combining marks, skin-tone
+// modifiers, and Hangul T jamo. The planner walks it forward through
+// every run-spanning region to build `ShapedText::clusters` and the
+// `byte_to_cluster` index map. This is the same walker `TextEditor`'s
+// caret-motion uses (Slice 3.6) so the cluster boundaries the painter
+// and editor see are identical.
+//
+// UnicodeIndexMap: scalar_offsets (per-codepoint UTF-8 byte offsets +
+// trailing sentinel), utf16_offsets (per-codepoint UTF-16 code unit
+// offsets — single-unit for BMP, surrogate-pair for supplementary
+// planes), and byte_to_cluster (per-UTF-8-byte cluster index). The
+// trailing sentinel is included in each array so cluster_count =
+// scalar_offsets.size() - 1, and byte_to_cluster[text.size()] equals
+// clusters.size() — every downstream consumer (a11y selection ranges,
+// IME composition, locale shaping) can subtract two entries without a
+// bounds check.
 
 #include "pulp/canvas/text_run_planner.hpp"
 #include "pulp/canvas/text_shaper.hpp"
 #include "pulp/canvas/font_resolver.hpp"
 #include "pulp/canvas/font_scope.hpp"
+#include "pulp/canvas/bundled_fonts.hpp"   // cluster_step()
 
 #include <algorithm>
 #include <future>
 #include <thread>
 
 #ifdef PULP_HAS_SKIA
+// The bundled Skia archive ships `libskshaper.a` + `libskunicode_icu.a`
+// with the ICU-backed bidi + HarfBuzz/ICU-backed script run-iterator
+// builders linked in (verified at impl time with
+// `nm libskshaper.a | grep MakeIcuBiDi`). The corresponding
+// declarations in `SkShaper.h` are gated by
+// `SK_SHAPER_UNICODE_AVAILABLE` / `SK_SHAPER_HARFBUZZ_AVAILABLE`, which
+// upstream's prebuilt distribution doesn't pre-define for downstream
+// consumers. We define both *before* including the header so the
+// declarations are visible and the call sites compile — the link step
+// then resolves them against the static libs as expected.
+#  ifndef SK_SHAPER_UNICODE_AVAILABLE
+#    define SK_SHAPER_UNICODE_AVAILABLE 1
+#  endif
+#  ifndef SK_SHAPER_HARFBUZZ_AVAILABLE
+#    define SK_SHAPER_HARFBUZZ_AVAILABLE 1
+#  endif
 #include "include/core/SkTypeface.h"
+#include "modules/skshaper/include/SkShaper.h"
 #endif
 
 #include <mutex>
@@ -61,30 +100,134 @@ void TextRunPlanner::clear_cache() {
 
 namespace {
 
-// Slice 1.2.a skeleton: build a per-codepoint cluster table by
-// scanning UTF-8 byte by byte. Each codepoint becomes its own
-// cluster. Slice 1.2.a finish replaces this with UAX #29 grapheme
-// segmentation (ZWJ + RI-pair + combining-mark grouping).
-void populate_index_map(std::string_view text, UnicodeIndexMap& map) {
+// Decode the next UTF-8 codepoint at `text[i]`. Returns
+// {codepoint, byte_length}; malformed sequences return {0, 1} so the
+// walker always makes progress. Local to this TU to keep
+// font_registry_stubs.cpp's identical helper at internal linkage.
+struct Utf8Cp { std::uint32_t cp; std::size_t bytes; };
+
+inline bool utf8_cont(unsigned char b) noexcept {
+    return (b & 0xC0u) == 0x80u;
+}
+
+inline Utf8Cp decode_utf8(std::string_view s, std::size_t i) noexcept {
+    if (i >= s.size()) return {0, 0};
+    unsigned char c = static_cast<unsigned char>(s[i]);
+    if (c < 0x80) return {c, 1};
+    if ((c & 0xE0) == 0xC0 && i + 1 < s.size()) {
+        unsigned char b1 = static_cast<unsigned char>(s[i + 1]);
+        if (!utf8_cont(b1)) return {0, 1};
+        return {static_cast<std::uint32_t>(((c & 0x1Fu) << 6) | (b1 & 0x3Fu)), 2};
+    }
+    if ((c & 0xF0) == 0xE0 && i + 2 < s.size()) {
+        unsigned char b1 = static_cast<unsigned char>(s[i + 1]);
+        unsigned char b2 = static_cast<unsigned char>(s[i + 2]);
+        if (!utf8_cont(b1) || !utf8_cont(b2)) return {0, 1};
+        return {static_cast<std::uint32_t>(((c & 0x0Fu) << 12) | ((b1 & 0x3Fu) << 6) | (b2 & 0x3Fu)), 3};
+    }
+    if ((c & 0xF8) == 0xF0 && i + 3 < s.size()) {
+        unsigned char b1 = static_cast<unsigned char>(s[i + 1]);
+        unsigned char b2 = static_cast<unsigned char>(s[i + 2]);
+        unsigned char b3 = static_cast<unsigned char>(s[i + 3]);
+        if (!utf8_cont(b1) || !utf8_cont(b2) || !utf8_cont(b3)) return {0, 1};
+        return {static_cast<std::uint32_t>(((c & 0x07u) << 18) | ((b1 & 0x3Fu) << 12)
+                                         | ((b2 & 0x3Fu) << 6) | (b3 & 0x3Fu)), 4};
+    }
+    return {0, 1};
+}
+
+// UTF-16 code-unit length of a Unicode scalar value: 2 for non-BMP
+// (supplementary plane, U+10000..U+10FFFF, surrogate pair), 1
+// otherwise. ICU's UText API and HarfBuzz both use the same rule.
+inline std::uint32_t utf16_units(std::uint32_t cp) noexcept {
+    return cp >= 0x10000u ? 2u : 1u;
+}
+
+// Build per-codepoint UTF-8 offsets + UTF-16 offsets. Both arrays end
+// with a trailing sentinel equal to the total UTF-8 byte size /
+// UTF-16 code unit count so callers can compute scalar widths with a
+// single subtraction.
+void populate_codepoint_offsets(std::string_view text, UnicodeIndexMap& map) {
     map.scalar_offsets.clear();
+    map.utf16_offsets.clear();
     map.scalar_offsets.reserve(text.size() + 1);
+    map.utf16_offsets.reserve(text.size() + 1);
+
+    std::uint32_t utf16_idx = 0;
     for (std::size_t i = 0; i < text.size();) {
+        Utf8Cp cp = decode_utf8(text, i);
         map.scalar_offsets.push_back(static_cast<std::uint32_t>(i));
-        unsigned char c = static_cast<unsigned char>(text[i]);
-        if      (c < 0x80) ++i;             // 1-byte
-        else if ((c & 0xE0) == 0xC0) i += 2; // 2-byte
-        else if ((c & 0xF0) == 0xE0) i += 3; // 3-byte
-        else if ((c & 0xF8) == 0xF0) i += 4; // 4-byte
-        else ++i;                            // invalid continuation; skip
+        map.utf16_offsets.push_back(utf16_idx);
+        utf16_idx += utf16_units(cp.cp);
+        i += cp.bytes;
     }
     map.scalar_offsets.push_back(static_cast<std::uint32_t>(text.size()));
+    map.utf16_offsets.push_back(utf16_idx);
+}
+
+// Walk the public UAX #29 `cluster_step` (Slice 3.6) forward through
+// `text`, emitting one `ClusterEntry` per grapheme cluster. The walker
+// honors ZWJ, RI parity, virama+consonant, combining marks, skin-tone
+// modifiers, Hangul T jamo, and variation selectors. Each cluster
+// stores its UTF-8 byte range plus the run index it belongs to; glyph
+// counts and starts are intentionally left at 0 in this slice — the
+// painter does not consume them yet, and populating them requires
+// driving SkShaper end-to-end which is the Phase-2 follow-on. The
+// run index is computed by binary-searching `run_starts`.
+void populate_clusters(std::string_view text,
+                       const std::vector<std::size_t>& run_starts,
+                       std::vector<ClusterEntry>& clusters,
+                       std::vector<std::uint32_t>& byte_to_cluster) {
+    clusters.clear();
+    byte_to_cluster.assign(text.size() + 1, 0);
+
+    // Promote the string_view to a std::string once — the public
+    // `cluster_step` takes `const std::string&`. The cost is one copy
+    // per shape() call, which we already pay for `ShapedText::text`.
+    const std::string owned(text);
+
+    std::size_t cursor = 0;
+    while (cursor < owned.size()) {
+        std::size_t next = cluster_step(owned, cursor, /*forward=*/true);
+        if (next <= cursor) next = cursor + 1;   // safety: forward progress
+        if (next > owned.size()) next = owned.size();
+
+        ClusterEntry e;
+        e.utf8_start = static_cast<std::uint32_t>(cursor);
+        e.utf8_end   = static_cast<std::uint32_t>(next);
+
+        // Find which run this cluster's *start* falls into. Runs are
+        // contiguous and disjoint, so a linear search over the sorted
+        // run_starts is fine — paragraph-sized inputs cap run_count
+        // in single digits in practice.
+        std::uint32_t run_idx = 0;
+        for (std::size_t r = 0; r < run_starts.size(); ++r) {
+            if (run_starts[r] <= cursor) run_idx = static_cast<std::uint32_t>(r);
+            else break;
+        }
+        e.run_index = run_idx;
+
+        const std::uint32_t cluster_idx = static_cast<std::uint32_t>(clusters.size());
+        for (std::size_t b = cursor; b < next && b < byte_to_cluster.size(); ++b) {
+            byte_to_cluster[b] = cluster_idx;
+        }
+        clusters.push_back(e);
+        cursor = next;
+    }
+    // Trailing sentinel: byte_to_cluster[text.size()] == clusters.size()
+    // so the half-open interval [byte_to_cluster[i], byte_to_cluster[j])
+    // gives the cluster span for any UTF-8 byte slice [i, j].
+    if (!byte_to_cluster.empty()) {
+        byte_to_cluster.back() = static_cast<std::uint32_t>(clusters.size());
+    }
 }
 
 void populate_line_breaks(std::string_view text,
                           std::vector<LineBreakOpportunity>& out) {
     out.clear();
-    // Skeleton: ASCII whitespace + hard newline. ICU-driven locale-
-    // aware break opportunities arrive in Phase 2 / Slice 2.4.
+    // Slice 1.2.a finish keeps the heuristic break opportunities; the
+    // ICU BreakIterator-driven path is Slice 2.4 (locale-aware line
+    // breaking) and consumes the same out array.
     for (std::size_t i = 0; i < text.size(); ++i) {
         char c = text[i];
         if (c == '\n') {
@@ -95,6 +238,165 @@ void populate_line_breaks(std::string_view text,
                            LineBreakOpportunity::Kind::Soft});
         }
     }
+}
+
+// A bidi+script segment of the input. Half-open UTF-8 byte range
+// [start, end). Always non-empty.
+struct BidiScriptSegment {
+    std::size_t  start;
+    std::size_t  end;
+    std::uint8_t bidi_level;
+    std::uint32_t script_tag;
+};
+
+#ifdef PULP_HAS_SKIA
+// Walk both ICU iterators in lockstep, emitting one segment per
+// (bidi, script) tuple. Modelled on Skia's own `RunIteratorQueue`
+// (SkShaper_harfbuzz.cpp): at each step, find the iterator with the
+// earlier `endOfCurrentRun()`, read both currently-active states,
+// advance any iterator whose run ends at the chosen endpoint. This
+// produces a sequence of maximal segments where bidi level and
+// script tag are both constant — exactly the shaping units the
+// HarfBuzz / SkShaper engine wants when called with explicit
+// iterators.
+//
+// Returns an empty vector if either iterator construction fails
+// (e.g. ICU not actually linked at runtime), letting the caller fall
+// back to a single segment for the whole input.
+std::vector<BidiScriptSegment>
+segment_with_icu(std::string_view text, std::uint8_t base_level) {
+    std::vector<BidiScriptSegment> out;
+    if (text.empty()) return out;
+
+    auto bidi = SkShaper::MakeIcuBiDiRunIterator(text.data(), text.size(), base_level);
+    auto scr  = SkShaper::MakeHbIcuScriptRunIterator(text.data(), text.size());
+    if (!bidi || !scr) return out;   // caller will degrade gracefully
+
+    // SkShaper RunIterator contract: post-construction, the FIRST
+    // consume() advances state INTO the first run. After consume(),
+    // `endOfCurrentRun()` is the end offset of the just-consumed run
+    // and `current*()` reports its properties. Subsequent consume()
+    // calls advance to the next run. `atEnd()` becomes true only
+    // after consuming the LAST run.
+    bidi->consume();
+    scr->consume();
+
+    std::size_t cursor = 0;
+    // Loop invariant at the top of each iteration:
+    //   * cursor is the start offset of the next segment to emit.
+    //   * Both iterators have consumed at least one run AND their
+    //     endOfCurrentRun() is strictly > cursor (or atEnd() is true).
+    constexpr std::size_t kMaxSegments = 1 << 16;
+    while (cursor < text.size() && out.size() < kMaxSegments) {
+        const bool be = bidi->atEnd();
+        const bool se = scr->atEnd();
+        const std::size_t bidi_end = be ? text.size() : bidi->endOfCurrentRun();
+        const std::size_t scr_end  = se ? text.size() : scr->endOfCurrentRun();
+        const std::size_t end      = std::min(bidi_end, scr_end);
+        if (end <= cursor) break;   // safety: forward progress
+
+        BidiScriptSegment seg;
+        seg.start      = cursor;
+        seg.end        = end;
+        seg.bidi_level = be ? base_level : bidi->currentLevel();
+        seg.script_tag = se ? 0u        : scr->currentScript();
+
+        // Merge with the previous segment when both properties match,
+        // which happens at seams where one iterator's run ended and
+        // the other didn't — without the merge those would be two
+        // identical-property segments back-to-back.
+        if (!out.empty()
+            && out.back().end        == seg.start
+            && out.back().bidi_level == seg.bidi_level
+            && out.back().script_tag == seg.script_tag) {
+            out.back().end = seg.end;
+        } else {
+            out.push_back(seg);
+        }
+
+        cursor = end;
+        // Advance any iterator whose current run ended exactly at
+        // `cursor`. Both can advance in the same step if their runs
+        // line up; one will advance while the other waits if they
+        // don't.
+        if (!be && bidi->endOfCurrentRun() <= cursor && !bidi->atEnd()) {
+            bidi->consume();
+        }
+        if (!se && scr->endOfCurrentRun() <= cursor && !scr->atEnd()) {
+            scr->consume();
+        }
+    }
+    return out;
+}
+#endif  // PULP_HAS_SKIA
+
+// SkShaper iterator endpoints aren't guaranteed to land on cluster
+// boundaries — for the input we care about they overwhelmingly do
+// (Han / Latin / Arabic are all script-pure, bidi flips at script
+// boundaries that already correspond to grapheme boundaries), but the
+// API contract is "UTF-8 byte offsets" not "cluster offsets". This
+// helper snaps any run boundary to the nearest enclosing cluster
+// boundary by walking `cluster_step` from byte 0, which is O(n) per
+// shape() call — acceptable for label-sized inputs.
+void snap_runs_to_cluster_boundaries(const std::string& text,
+                                     std::vector<BidiScriptSegment>& segs) {
+    if (segs.empty()) return;
+
+    // Build a sorted vector of cluster boundary offsets.
+    std::vector<std::size_t> boundaries;
+    boundaries.reserve(text.size() / 4 + 2);
+    boundaries.push_back(0);
+    std::size_t cursor = 0;
+    while (cursor < text.size()) {
+        std::size_t next = cluster_step(text, cursor, /*forward=*/true);
+        if (next <= cursor) next = cursor + 1;
+        if (next > text.size()) next = text.size();
+        boundaries.push_back(next);
+        cursor = next;
+    }
+
+    auto snap_to_le_boundary = [&boundaries](std::size_t off) -> std::size_t {
+        // Largest boundary <= off.
+        auto it = std::upper_bound(boundaries.begin(), boundaries.end(), off);
+        if (it == boundaries.begin()) return 0;
+        --it;
+        return *it;
+    };
+    auto snap_to_ge_boundary = [&boundaries](std::size_t off) -> std::size_t {
+        auto it = std::lower_bound(boundaries.begin(), boundaries.end(), off);
+        if (it == boundaries.end()) return boundaries.back();
+        return *it;
+    };
+
+    // First pass: snap each segment's end to a boundary >= its end so
+    // we never cleave a cluster, then re-thread the starts.
+    for (auto& s : segs) {
+        s.end = snap_to_ge_boundary(s.end);
+    }
+    segs.front().start = 0;
+    for (std::size_t i = 1; i < segs.size(); ++i) {
+        segs[i].start = segs[i - 1].end;
+    }
+    // Drop empties (can happen if two iterator boundaries collapsed
+    // onto the same cluster).
+    segs.erase(std::remove_if(segs.begin(), segs.end(),
+                              [](const BidiScriptSegment& s) { return s.end <= s.start; }),
+               segs.end());
+    // Coalesce adjacent same-property segments after the snap.
+    std::vector<BidiScriptSegment> merged;
+    merged.reserve(segs.size());
+    for (const auto& s : segs) {
+        if (!merged.empty()
+            && merged.back().end == s.start
+            && merged.back().bidi_level == s.bidi_level
+            && merged.back().script_tag == s.script_tag) {
+            merged.back().end = s.end;
+        } else {
+            merged.push_back(s);
+        }
+    }
+    segs.swap(merged);
+    (void)snap_to_le_boundary;   // reserved for the inverse direction
 }
 
 } // namespace
@@ -117,43 +419,125 @@ ShapedText TextRunPlanner::shape(std::string_view text,
     out.text = std::string(text);
     out.options = opts;
 
-    populate_index_map(text, out.index_map);
+    populate_codepoint_offsets(text, out.index_map);
     populate_line_breaks(text, out.line_breaks);
 
     // Resolve the typeface via FontResolver (same path
     // SkiaCanvas/TextShaper use post-Slice-1.1.a). The resolved
     // ResolvedFont carries the trace + scope + generation we record
-    // on the run.
+    // on every run we emit.
     ResolvedFont resolved = FontResolver::instance().resolve_family_list(opts);
 
-    // Skeleton: one ShapedRun spanning the full input. Shaping data
-    // (glyph_ids, advances, offsets) is populated from TextShaper's
-    // prepared-text path so width matches what the painter draws.
-    // Slice 1.2.a finish swaps in real SkShaper output with per-run
-    // bidi/script split.
-    ShapedRun run;
-    run.font = std::move(resolved);
-    run.logical_start = 0;
-    run.logical_end = text.size();
-    run.bidi_level = (opts.direction == BaseDirection::RTL) ? 1 : 0;
+    if (text.empty()) {
+        // Preserve the pre-1.2.a-finish contract: even empty input
+        // yields exactly one zero-width run so callers can rely on
+        // `out.runs[0]` existing for ascender/leading queries on an
+        // empty label without branching on size. The test target
+        // pulp-test-font-options (TextRunPlanner handles empty text)
+        // asserts this shape.
+        ShapedRun run;
+        run.font          = std::move(resolved);
+        run.logical_start = 0;
+        run.logical_end   = 0;
+        run.bidi_level    = (opts.direction == BaseDirection::RTL) ? 1u : 0u;
+        out.runs.push_back(std::move(run));
+        // byte_to_cluster keeps its single sentinel entry (== 0 clusters).
+        out.index_map.byte_to_cluster.assign(1, 0u);
 
+        std::lock_guard<std::mutex> lock(impl_->mtx);
+        impl_->cache[key] = out;
+        return out;
+    }
+
+    const std::uint8_t base_level =
+        (opts.direction == BaseDirection::RTL) ? 1u : 0u;
+
+    // ── Build bidi+script segments ────────────────────────────────────────
+    std::vector<BidiScriptSegment> segments;
+#ifdef PULP_HAS_SKIA
+    segments = segment_with_icu(text, base_level);
+#endif
+    if (segments.empty()) {
+        // Degraded path (non-Skia or ICU iterator construction failed):
+        // single segment, level / script inferred from FontOptions.
+        BidiScriptSegment seg;
+        seg.start      = 0;
+        seg.end        = text.size();
+        seg.bidi_level = base_level;
+        seg.script_tag = 0;
+        segments.push_back(seg);
+    } else {
+        // Ensure full coverage. ICU iterators sometimes stop short on
+        // malformed UTF-8; we cap the last segment at text.size() and
+        // synthesize a trailing run if any bytes weren't covered.
+        if (segments.back().end < text.size()) {
+            BidiScriptSegment tail;
+            tail.start      = segments.back().end;
+            tail.end        = text.size();
+            tail.bidi_level = segments.back().bidi_level;
+            tail.script_tag = segments.back().script_tag;
+            segments.push_back(tail);
+        }
+        // Snap to UAX #29 cluster boundaries so a single grapheme is
+        // never split across runs (e.g. an emoji ZWJ family at the
+        // bidi-script boundary stays inside one run).
+        snap_runs_to_cluster_boundaries(out.text, segments);
+    }
+
+    // ── Emit one ShapedRun per segment ────────────────────────────────────
+    out.runs.reserve(segments.size());
     auto& shaper = global_text_shaper();
-    // Build the family string for the shaper using the resolved
-    // typeface's actual family — the shaper will hit the resolver's
-    // cache as well, so this is consistent.
-    std::string family_str = run.font.actual_family;
+    std::string family_str = resolved.actual_family;
     if (family_str.empty() && !opts.family_stack.empty()) {
         family_str = opts.family_stack.front();
     }
-    auto prepared = shaper.prepare(text, family_str, opts.size);
-    run.advance_total = prepared.total_width();
-    run.metrics.ascent  = prepared.ascent();
-    run.metrics.descent = prepared.descent();
-    run.metrics.leading = prepared.leading();
 
-    out.total_width = run.advance_total;
-    out.overall_metrics = run.metrics;
-    out.runs.push_back(std::move(run));
+    float ascent_max  = 0.0f;
+    float descent_max = 0.0f;
+    float leading_max = 0.0f;
+    float width_total = 0.0f;
+
+    std::vector<std::size_t> run_starts;
+    run_starts.reserve(segments.size());
+
+    for (const auto& seg : segments) {
+        ShapedRun run;
+        run.font          = resolved;   // same resolved face for all runs in v1
+        run.logical_start = seg.start;
+        run.logical_end   = seg.end;
+        run.bidi_level    = seg.bidi_level;
+        run.script_tag    = seg.script_tag;
+
+        std::string_view segment_view = text.substr(seg.start, seg.end - seg.start);
+
+        // Measurement uses the existing TextShaper path — the SkShaper
+        // glyph buffers + per-glyph advances are downstream consumers'
+        // job (Phase 2 / Slice 2.4 locale-aware line breaking exercises
+        // them). What matters here is that each run reports its own
+        // sub-string width so `total_width` is the sum of run widths,
+        // not a re-measurement of the whole input.
+        auto prepared = shaper.prepare(segment_view, family_str, opts.size);
+        run.advance_total  = prepared.total_width();
+        run.metrics.ascent  = prepared.ascent();
+        run.metrics.descent = prepared.descent();
+        run.metrics.leading = prepared.leading();
+
+        ascent_max  = std::max(ascent_max,  run.metrics.ascent);
+        descent_max = std::max(descent_max, run.metrics.descent);
+        leading_max = std::max(leading_max, run.metrics.leading);
+        width_total += run.advance_total;
+
+        run_starts.push_back(seg.start);
+        out.runs.push_back(std::move(run));
+    }
+
+    // ── Cluster table + byte_to_cluster index map ────────────────────────
+    populate_clusters(text, run_starts, out.clusters, out.index_map.byte_to_cluster);
+
+    out.total_width            = width_total;
+    out.overall_metrics.ascent  = ascent_max;
+    out.overall_metrics.descent = descent_max;
+    out.overall_metrics.leading = leading_max;
 
     {
         std::lock_guard<std::mutex> lock(impl_->mtx);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -897,6 +897,23 @@ add_executable(pulp-test-text-run-planner-parallel test_text_run_planner_paralle
 target_link_libraries(pulp-test-text-run-planner-parallel PRIVATE pulp::canvas Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-text-run-planner-parallel)
 
+# pulp #2163 / font v2 Slice 1.2.a finish — real ICU bidi + script run
+# iterators. Verifies multi-run shaping on bidi / script boundaries and
+# UAX #29 cluster grouping (ZWJ, regional-indicator-pair, virama,
+# combining marks). Cluster-grouping cases run on every build; the
+# bidi / script cases auto-skip under non-Skia builds via SUCCEED.
+#
+# Add PULP_HAS_SKIA explicitly so the ICU-path assertions register
+# (mirrors test_canvas_fonts.cpp's pattern — pulp::canvas exports the
+# define PUBLIC but CMake's PUBLIC propagation doesn't always reach
+# sibling test targets, depending on configure ordering).
+add_executable(pulp-test-text-run-planner-icu test_text_run_planner_icu.cpp)
+target_link_libraries(pulp-test-text-run-planner-icu PRIVATE pulp::canvas Catch2::Catch2WithMain)
+if(PULP_HAS_SKIA)
+    target_compile_definitions(pulp-test-text-run-planner-icu PRIVATE PULP_HAS_SKIA=1)
+endif()
+catch_discover_tests(pulp-test-text-run-planner-icu)
+
 # pulp #2163 / font v2 Slice 2.1 — async font lifecycle (register_font_url).
 add_executable(pulp-test-font-async-lifecycle test_font_async_lifecycle.cpp)
 target_link_libraries(pulp-test-font-async-lifecycle PRIVATE pulp::canvas Catch2::Catch2WithMain)

--- a/test/test_text_run_planner_icu.cpp
+++ b/test/test_text_run_planner_icu.cpp
@@ -122,6 +122,61 @@ TEST_CASE("planner — script split for Hello 日本語 world",
 #endif
 }
 
+// ── Single-run bidi: pure-RTL Hebrew keeps RTL level (Codex review on #2311) ─
+//
+// `"שלום"` is one bidi run AND one script run. SkShaper iterators report
+// `atEnd()` true after the first consume(), but `currentLevel()` still
+// reports the RTL level (1) for the just-consumed run. The planner must
+// trust currentLevel(), not substitute `base_level` (0 for LTR default),
+// or pure RTL strings get shaped as LTR.
+TEST_CASE("planner — single-run RTL preserves bidi level after atEnd",
+          "[font][planner][bidi][issue-2311]") {
+#ifndef PULP_HAS_SKIA
+    SUCCEED("Skia not linked — real ICU iterators not available");
+    return;
+#else
+    const std::string text = "\xD7\xA9\xD7\x9C\xD7\x95\xD7\x9D";  // שלום
+    auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+
+    REQUIRE(out.runs.size() >= 1);
+    // Every run must report an odd (RTL) bidi level — if the planner
+    // substituted base_level on the atEnd branch we'd see level 0 here.
+    bool any_rtl = false;
+    for (const auto& r : out.runs) {
+        if ((r.bidi_level & 1u) != 0u) any_rtl = true;
+    }
+    REQUIRE(any_rtl);
+#endif
+}
+
+// ── Single-run script: pure CJK keeps Hani tag after atEnd (Codex review on #2311) ─
+//
+// `"日本語"` is one script run. After consume() the script iterator's
+// `atEnd()` returns true, but `currentScript()` still reports 'Hani'
+// (0x48616E69) for the just-consumed run. Substituting 0 here drops
+// the script tag for any final / single-script run.
+TEST_CASE("planner — single-run CJK preserves script tag after atEnd",
+          "[font][planner][script][issue-2311]") {
+#ifndef PULP_HAS_SKIA
+    SUCCEED("Skia not linked — real ICU iterators not available");
+    return;
+#else
+    const std::string text = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E";  // 日本語
+    auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+
+    REQUIRE(out.runs.size() >= 1);
+    // 'Hani' = 0x48616E69 (big-endian ASCII tag).
+    constexpr std::uint32_t kHani = 0x48616E69u;
+    bool saw_hani = false;
+    for (const auto& r : out.runs) {
+        if (r.script_tag == kHani) saw_hani = true;
+    }
+    // If the planner substituted 0 on the atEnd branch, no run would
+    // carry the 'Hani' tag and saw_hani would stay false.
+    REQUIRE(saw_hani);
+#endif
+}
+
 // ── Devanagari virama: क्ष is one cluster ─────────────────────────────────
 //
 // `"क्ष"` decomposes as ka (U+0915) + virama (U+094D) + ssa (U+0937).

--- a/test/test_text_run_planner_icu.cpp
+++ b/test/test_text_run_planner_icu.cpp
@@ -1,0 +1,285 @@
+// test_text_run_planner_icu.cpp — Pulp #2163, font v2 Slice 1.2.a finish.
+//
+// Real ICU bidi + script run iterators. Verifies that
+// `TextRunPlanner::shape` emits multiple `ShapedRun`s on bidi /
+// script boundaries (instead of one trivial run), and that the
+// `ShapedText::clusters` table groups graphemes per UAX #29 (ZWJ,
+// regional-indicator-pair, virama, combining marks, skin-tone
+// modifiers all collapse into one cluster). Also asserts
+// `UnicodeIndexMap` fully populates `utf16_offsets` + `byte_to_cluster`.
+//
+// Each test below targets a single corpus row from the v2 multilingual
+// torture corpus (`test/text_corpus/corpus.json`). When ICU is not
+// linked into Skia, the planner falls back to one segment and the
+// assertions are skipped via `SUCCEED`. The single-segment fallback
+// path is still exercised by `test_text_run_planner_parallel.cpp`.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/canvas/text_run_planner.hpp>
+#include <pulp/canvas/font_options.hpp>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+pulp::canvas::FontOptions default_opts() {
+    pulp::canvas::FontOptions opts;
+    opts.family_stack.push_back("Inter");
+    opts.size = 14.0f;
+    return opts;
+}
+
+// Helper: count distinct (bidi_level, script_tag) tuples across runs.
+// Used as an informational lower bound; tests on specific corpus rows
+// assert exact run counts. `[[maybe_unused]]` because the only call
+// site is inside `#ifdef PULP_HAS_SKIA` and the helper has to stay at
+// file scope for Catch2 to pick it up from every TEST_CASE.
+[[maybe_unused]] std::size_t distinct_run_keys(const pulp::canvas::ShapedText& s) {
+    std::vector<std::pair<std::uint8_t, std::uint32_t>> seen;
+    for (const auto& r : s.runs) {
+        std::pair<std::uint8_t, std::uint32_t> key{r.bidi_level, r.script_tag};
+        bool present = false;
+        for (const auto& k : seen) {
+            if (k == key) { present = true; break; }
+        }
+        if (!present) seen.push_back(key);
+    }
+    return seen.size();
+}
+
+} // namespace
+
+// ── Bidi split — Hebrew embedded in English ───────────────────────────────
+//
+// `"Hello עברית world"` — LTR Latin, RTL Hebrew, LTR Latin. ICU's bidi
+// algorithm must mark the middle segment with an odd bidi level (RTL)
+// and the outer two with an even level (LTR). The planner produces
+// three runs (one per maximal same-level segment). Trivial iterators
+// would collapse this to one run.
+TEST_CASE("planner — bidi split for Hello עברית world",
+          "[font][planner][bidi][issue-2163]") {
+#ifndef PULP_HAS_SKIA
+    SUCCEED("Skia not linked — real ICU iterators not available");
+    return;
+#else
+    const std::string text = "Hello \xD7\xA2\xD7\x91\xD7\xA8\xD7\x99\xD7\xAA world";
+    auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+
+    // Strict assertion: bidi must produce >=2 runs. The Hebrew middle
+    // segment is RTL (level 1) and the outer Latin is LTR (level 0).
+    REQUIRE(out.runs.size() >= 2);
+
+    // Confirm the run set actually contains both an even and an odd
+    // level — if ICU only ran the trivial iterator we'd get a single
+    // run with level 0.
+    bool saw_ltr = false, saw_rtl = false;
+    for (const auto& r : out.runs) {
+        if (r.bidi_level == 0) saw_ltr = true;
+        if (r.bidi_level == 1) saw_rtl = true;
+    }
+    REQUIRE(saw_ltr);
+    REQUIRE(saw_rtl);
+
+    // Runs cover the full input contiguously.
+    std::size_t covered = 0;
+    for (const auto& r : out.runs) {
+        REQUIRE(r.logical_start == covered);
+        REQUIRE(r.logical_end   >= r.logical_start);
+        covered = r.logical_end;
+    }
+    REQUIRE(covered == text.size());
+#endif
+}
+
+// ── Script split — Latin + Han + Latin ────────────────────────────────────
+//
+// `"Hello 日本語 world"` — Latin "Hello ", Han 日本語, Latin " world".
+// ICU's HarfBuzz-script iterator labels the Han codepoints with script
+// tag `'Hani'` (0x48616E69) and the Latin codepoints with `'Latn'`
+// (0x4C61746E). The planner must emit >= 3 runs.
+TEST_CASE("planner — script split for Hello 日本語 world",
+          "[font][planner][script][issue-2163]") {
+#ifndef PULP_HAS_SKIA
+    SUCCEED("Skia not linked — real ICU iterators not available");
+    return;
+#else
+    const std::string text = "Hello \xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E world";
+    auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+
+    REQUIRE(out.runs.size() >= 3);
+    REQUIRE(distinct_run_keys(out) >= 2);  // Latin + Han at minimum
+
+    // Total UTF-8 byte coverage = input size, runs disjoint + contiguous.
+    std::size_t covered = 0;
+    for (const auto& r : out.runs) {
+        REQUIRE(r.logical_start == covered);
+        covered = r.logical_end;
+    }
+    REQUIRE(covered == text.size());
+#endif
+}
+
+// ── Devanagari virama: क्ष is one cluster ─────────────────────────────────
+//
+// `"क्ष"` decomposes as ka (U+0915) + virama (U+094D) + ssa (U+0937).
+// UAX #29 says: virama joins the following consonant into one extended
+// grapheme cluster. cluster_step (Slice 3.6) already implements this;
+// the planner must surface it in `ShapedText::clusters`.
+TEST_CASE("planner — Devanagari virama: क्ष is one cluster",
+          "[font][planner][cluster][issue-2163]") {
+    const std::string text = "\xE0\xA4\x95\xE0\xA5\x8D\xE0\xA4\xB7";  // क्ष
+    auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+
+    REQUIRE(out.clusters.size() == 1);
+    REQUIRE(out.clusters[0].utf8_start == 0);
+    REQUIRE(out.clusters[0].utf8_end   == text.size());
+}
+
+// ── Emoji ZWJ family — single cluster ─────────────────────────────────────
+//
+// 👨‍👩‍👧‍👦 = man + ZWJ + woman + ZWJ + girl + ZWJ + boy. UAX #29 emoji
+// ZWJ rule (GB11) collapses these into one grapheme cluster.
+TEST_CASE("planner — emoji ZWJ family is one cluster",
+          "[font][planner][cluster][emoji-zwj][issue-2163]") {
+    const std::string text =
+        "\xF0\x9F\x91\xA8"          // U+1F468 man
+        "\xE2\x80\x8D"              // U+200D ZWJ
+        "\xF0\x9F\x91\xA9"          // U+1F469 woman
+        "\xE2\x80\x8D"              // U+200D ZWJ
+        "\xF0\x9F\x91\xA7"          // U+1F467 girl
+        "\xE2\x80\x8D"              // U+200D ZWJ
+        "\xF0\x9F\x91\xA6";         // U+1F466 boy
+    auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+
+    REQUIRE(out.clusters.size() == 1);
+    REQUIRE(out.clusters[0].utf8_start == 0);
+    REQUIRE(out.clusters[0].utf8_end   == text.size());
+}
+
+// ── Regional indicator pair — flag is one cluster ─────────────────────────
+//
+// 🇺🇸 = U+1F1FA + U+1F1F8 (Regional Indicator U + S). Two RI codepoints
+// form one flag cluster per UAX #29 GB12/GB13.
+TEST_CASE("planner — regional indicator pair is one cluster",
+          "[font][planner][cluster][regional-indicators][issue-2163]") {
+    const std::string text =
+        "\xF0\x9F\x87\xBA"          // U+1F1FA RI-U
+        "\xF0\x9F\x87\xB8";         // U+1F1F8 RI-S
+    auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+
+    REQUIRE(out.clusters.size() == 1);
+    REQUIRE(out.clusters[0].utf8_start == 0);
+    REQUIRE(out.clusters[0].utf8_end   == text.size());
+}
+
+// ── Combining mark — é is one cluster regardless of NFC/NFD ───────────────
+//
+// NFC: U+00E9 (precomposed 'é', 2 UTF-8 bytes).
+// NFD: U+0065 (e) + U+0301 (combining acute, 3 UTF-8 bytes total).
+// Both must collapse to one cluster.
+TEST_CASE("planner — combining mark é is one cluster",
+          "[font][planner][cluster][combining-marks][issue-2163]") {
+    SECTION("NFC precomposed") {
+        const std::string text = "\xC3\xA9";   // U+00E9
+        auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+        REQUIRE(out.clusters.size() == 1);
+        REQUIRE(out.clusters[0].utf8_end == text.size());
+    }
+    SECTION("NFD decomposed") {
+        const std::string text = "e\xCC\x81";  // U+0065 U+0301
+        auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+        REQUIRE(out.clusters.size() == 1);
+        REQUIRE(out.clusters[0].utf8_end == text.size());
+    }
+}
+
+// ── UnicodeIndexMap fully populated ────────────────────────────────────────
+//
+// Every UTF-16 surface (JS, IME, macOS / Windows a11y) needs UTF-16
+// code-unit offsets. Every cluster surface (TextEditor caret motion,
+// IME composition, selection) needs `byte_to_cluster`. Both are
+// populated by Slice 1.2.a finish.
+TEST_CASE("planner — UnicodeIndexMap utf16_offsets + byte_to_cluster",
+          "[font][planner][index-map][issue-2163]") {
+    SECTION("BMP-only Latin: utf16_offsets parallel scalar_offsets") {
+        const std::string text = "Hello";
+        auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+        // 5 codepoints + sentinel
+        REQUIRE(out.index_map.scalar_offsets.size() == 6);
+        REQUIRE(out.index_map.utf16_offsets.size() == 6);
+        // BMP-only → UTF-16 units match scalar count
+        REQUIRE(out.index_map.utf16_offsets.back() == 5);
+        // byte_to_cluster covers every byte + trailing sentinel
+        REQUIRE(out.index_map.byte_to_cluster.size() == text.size() + 1);
+        REQUIRE(out.index_map.byte_to_cluster.back() ==
+                static_cast<std::uint32_t>(out.clusters.size()));
+    }
+
+    SECTION("Supplementary plane (non-BMP) doubles utf16 units") {
+        // U+1F600 grinning face — non-BMP, 4 UTF-8 bytes, 2 UTF-16 units.
+        const std::string text = "\xF0\x9F\x98\x80";
+        auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+        REQUIRE(out.index_map.scalar_offsets.size() == 2);   // 1 codepoint + sentinel
+        REQUIRE(out.index_map.utf16_offsets.size() == 2);
+        REQUIRE(out.index_map.utf16_offsets.back() == 2);    // surrogate pair
+        // Single cluster (no extender / mark).
+        REQUIRE(out.clusters.size() == 1);
+        REQUIRE(out.clusters[0].utf8_end == text.size());
+    }
+
+    SECTION("Cluster mapping invariant — byte_to_cluster[utf8_start] == cluster idx") {
+        // 👨‍👩‍👧‍👦 family — 7 codepoints, 1 cluster. Every byte should
+        // map to cluster 0; the sentinel byte (== text.size()) should
+        // map to clusters.size().
+        const std::string text =
+            "\xF0\x9F\x91\xA8\xE2\x80\x8D\xF0\x9F\x91\xA9\xE2\x80\x8D"
+            "\xF0\x9F\x91\xA7\xE2\x80\x8D\xF0\x9F\x91\xA6";
+        auto out = pulp::canvas::TextRunPlanner::instance().shape(text, default_opts());
+        REQUIRE(out.clusters.size() == 1);
+        REQUIRE(out.index_map.byte_to_cluster.size() == text.size() + 1);
+        for (std::size_t i = 0; i < text.size(); ++i) {
+            INFO("byte " << i << " of " << text.size());
+            REQUIRE(out.index_map.byte_to_cluster[i] == 0u);
+        }
+        REQUIRE(out.index_map.byte_to_cluster.back() == 1u);
+    }
+}
+
+// ── Sanity: empty input remains valid ────────────────────────────────────
+//
+// Per the pre-1.2.a-finish contract (asserted in test_font_options.cpp's
+// "TextRunPlanner handles empty text" case), empty input still yields
+// exactly one zero-width ShapedRun so callers can index `runs[0]` for
+// ascender/leading queries without branching on size.
+TEST_CASE("planner — empty text shapes to single zero-width run",
+          "[font][planner][issue-2163]") {
+    auto out = pulp::canvas::TextRunPlanner::instance().shape("", default_opts());
+    REQUIRE(out.runs.size() == 1);
+    REQUIRE(out.runs[0].logical_start == 0);
+    REQUIRE(out.runs[0].logical_end == 0);
+    REQUIRE(out.clusters.empty());
+    REQUIRE(out.total_width == 0.0f);
+    // scalar_offsets always carries the trailing sentinel.
+    REQUIRE(out.index_map.scalar_offsets.size() == 1);
+    REQUIRE(out.index_map.utf16_offsets.size() == 1);
+    REQUIRE(out.index_map.scalar_offsets.back() == 0u);
+    REQUIRE(out.index_map.utf16_offsets.back() == 0u);
+}
+
+// ── ASCII-only input — runs stay simple ──────────────────────────────────
+//
+// Plain Latin should still produce well-formed output (single bidi
+// level, single script tag, clusters one-per-codepoint).
+TEST_CASE("planner — ASCII Hello produces a contiguous run set",
+          "[font][planner][issue-2163]") {
+    auto out = pulp::canvas::TextRunPlanner::instance().shape("Hello", default_opts());
+    REQUIRE_FALSE(out.runs.empty());
+    REQUIRE(out.clusters.size() == 5);  // H, e, l, l, o
+    // Every cluster is one byte (no combining marks).
+    for (const auto& c : out.clusters) {
+        REQUIRE(c.utf8_end == c.utf8_start + 1);
+    }
+}


### PR DESCRIPTION
## Summary

Slice 1.2.a **finish** — real ICU/HarfBuzz iterators in
`TextRunPlanner::shape`. Replaces the single-run skeleton (PR #2169) with
the canonical bidi/script-split + UAX #29 clustering path the v2
planning doc staked itself on.

The bundled Skia archive already statically links
`libskunicode_icu.a` and the HarfBuzz/ICU script-iterator builder
(verified pre-change with `nm libskshaper.a | grep MakeIcuBiDi`). The
trivial single-run path was only a skeleton stand-in; this change wires
the real iterators behind the same `ShapedText` artifact so every
downstream consumer (measurement, paint, a11y, IME) benefits at once.

## What landed

- **Real bidi + script iterators** in `TextRunPlanner::shape`
  (`core/canvas/src/text_run_planner.cpp`). Uses
  `SkShaper::MakeIcuBiDiRunIterator` + `SkShaper::MakeHbIcuScriptRunIterator`
  and walks both in lockstep (modelled on Skia's own
  `RunIteratorQueue` in `SkShaper_harfbuzz.cpp`) to emit one
  `ShapedRun` per maximal `(bidi_level, script_tag)` segment.
- **UAX #29 clustering** via the existing `cluster_step()` walker
  (Slice 3.6). The planner snaps every iterator boundary to a cluster
  boundary so a grapheme is never split across runs, then walks the
  text forward to populate `ShapedText::clusters` (one `ClusterEntry`
  per cluster: utf8_start, utf8_end, owning run_index). Honors ZWJ,
  regional-indicator parity, virama+consonant, combining marks,
  skin-tone modifiers, and Hangul T jamo — same walker
  TextEditor / cursor motion already use.
- **`UnicodeIndexMap` fully populated**:
  - `scalar_offsets` — UTF-8 byte offset per codepoint + trailing sentinel.
  - `utf16_offsets` — UTF-16 code-unit index per codepoint
    (surrogate-pair-aware for non-BMP). Empty in the skeleton; populated
    now. Consumed by JS, IME, macOS/Windows a11y trees.
  - `byte_to_cluster` — UTF-8 byte → cluster-index lookup. Trailing
    sentinel equals `clusters.size()` so half-open slices map without
    a bounds check.
- **Graceful degradation** when ICU isn't linked (non-Skia builds):
  falls back to one segment, level/script inferred from
  `FontOptions::direction`. Same data shape, just one run.
- **Header gating workaround** for Pulp's prebuilt Skia distribution
  not defining `SK_SHAPER_UNICODE_AVAILABLE` /
  `SK_SHAPER_HARFBUZZ_AVAILABLE` — the planner TU defines both before
  including `SkShaper.h`. The static lib already contains the
  implementations, so the link step resolves them as expected.

## Tests

New test target `pulp-test-text-run-planner-icu`
(`test/test_text_run_planner_icu.cpp`) with 9 test cases covering:

- **Bidi split**: `"Hello עברית world"` produces ≥2 runs with both
  LTR (level 0) and RTL (level 1) bidi levels present.
- **Script split**: `"Hello 日本語 world"` produces ≥3 runs with
  distinct (level, script) keys (Latin + Han).
- **Devanagari virama**: `"क्ष"` collapses to one cluster (ka + virama
  + ssa).
- **Emoji ZWJ family**: 👨‍👩‍👧‍👦 collapses to one cluster regardless of
  fallback (7 codepoints, 1 cluster).
- **Regional indicator pair**: 🇺🇸 collapses to one cluster
  (UAX #29 GB12/GB13).
- **Combining mark**: `é` collapses to one cluster in both NFC and NFD
  forms.
- **UnicodeIndexMap parity**: BMP-only Latin produces scalar_offsets ≡
  utf16_offsets, supplementary planes (U+1F600) double the UTF-16
  units (surrogate pair). `byte_to_cluster` covers every byte + the
  trailing sentinel.

Bidi/script test cases auto-skip with `SUCCEED` under non-Skia builds.
Cluster tests run on every build because they exercise the
Skia-independent `cluster_step` walker.

## Existing tests still pass

- `pulp-test-parity` (5 assertions, 3 cases) — measurement-paint width
  parity within 0.5 px.
- `pulp-test-cluster-step` (48 assertions, 13 cases) — UAX #29 walker.
- `pulp-test-text-run-planner-parallel` (87 assertions, 6 cases) —
  parallel shaping via `shape_batch`.
- `pulp-test-font-options` "TextRunPlanner handles empty text" — empty
  input still yields exactly one zero-width run (pre-1.2.a-finish
  contract preserved explicitly).

## Test plan

- [x] Build pulp-canvas with the new planner
- [x] Build pulp-test-text-run-planner-icu and run — all 83 assertions
      pass (67 under non-Skia, +16 ICU-gated under Skia)
- [x] Re-run pulp-test-parity — 5 assertions still pass
- [x] Re-run pulp-test-cluster-step — 48 assertions still pass
- [x] Re-run pulp-test-text-run-planner-parallel — 87 assertions still pass
- [x] Full incremental `cmake --build build -j8` succeeds
- [ ] CI matrix (Linux / Windows advisory, macOS required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)