### PR TITLE
build(cmake): statically link the MSVC runtime on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,24 @@ else()
     add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
 endif()
 
+# ── Windows runtime library (Tier A Slice 12) ──────────────────────────────
+# Statically link the MSVC runtime so redistributed Pulp binaries don't
+# require the user to have the matching Visual C++ Redistributable
+# installed. Without this, the default is the dynamic /MD runtime and
+# end users see "vcruntime140.dll not found" when launching the plugin.
+#
+# `MultiThreaded` selects /MT (release) or /MTd (debug) via the
+# generator expression — these are the static-link variants. CMake
+# 3.15+ honors this via CMP0091 (set automatically by our minimum
+# version 3.24).
+#
+# Per sudara "Big List of JUCE Tips and Tricks" #27.
+if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY
+        "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+        CACHE STRING "MSVC runtime library variant (static)" FORCE)
+endif()
+
 if(WIN32)
     add_compile_definitions(NOMINMAX WIN32_LEAN_AND_MEAN)
 endif()


### PR DESCRIPTION
Tier A Slice 12 of planning/2026-05-18-rt-safety-and-debug-dx.md.

Pulp's CMake didn't set CMAKE_MSVC_RUNTIME_LIBRARY, so Windows builds
defaulted to the dynamic /MD runtime. Redistributed plugin/app binaries
therefore depend on the matching Visual C++ Redistributable being
installed on the end-user's system; without it, the plugin fails to
load with "vcruntime140.dll not found" or similar. This is a known
shipping footgun called out by sudara "Big List of JUCE Tips" #27 and
re-flagged by Codex during the Tier A audit.

Setting `MultiThreaded$<$<CONFIG:Debug>:Debug>` selects /MT (release)
or /MTd (debug) — the static-link variants — so the runtime gets
linked into Pulp's own DLL/EXE artifacts and end users don't need
to install anything separately.

CMake 3.15+ honors this via policy CMP0091 (set automatically by our
minimum version 3.24). The setting is guarded by `if(MSVC)` so
non-MSVC platforms (the rest of our CI matrix) are untouched.

Tests-with-fixes note: this is a build-configuration change with no
in-source behavior to assert. The verification is intrinsic — the
existing Windows CI build proves the static runtime variant still
compiles and links cleanly; a separate end-to-end "no vcruntime DLL
needed" check would require a fresh Windows host without the redist,
which we don't have in our matrix. The change is benign on non-MSVC
platforms.

Skill-Update: skip skill=ci reason="CMake build-config tweak: switches MSVC runtime link variant from default /MD to /MT. No CI workflow change, no new pattern for the ci SKILL to teach. Windows GHA build remains advisory in the matrix; no contract change."