### PR TITLE
chore(ci): apply Namespace macOS overflow routing on workflow_dispatch too (refs #2314)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1760,3 +1760,16 @@ Wiring:
 Adding a new top-level entry requires the same-PR allowlist update — the gate's error message points contributors to the exact line in the script. See the new "Repo-root hygiene" section in `CONTRIBUTING.md` for the contributor-facing explanation.
 
 Companion-track item U-1 in `planning/2026-05-17-refactor-roadmap-final.md`.
+
+## Namespace macOS overflow on `workflow_dispatch`
+
+`resolve-provider` in `.github/workflows/build.yml` applies the Namespace macOS overflow logic on both `pull_request` AND `workflow_dispatch` events (since 2026-05-19, closes #2314).
+
+Pre-2026-05-19 behavior gated overflow on `EVENT_NAME == "pull_request"` only, which silently routed `shipyard pr` ship cycles (`workflow_dispatch`-triggered) back to the local self-hosted Mac. That defeated the 2026-05-18 cloud cutover for the path most contributors hit.
+
+Precedence on `workflow_dispatch`:
+1. `inputs.macos_runner_selector_json` (operator override) — always wins.
+2. Namespace overflow when local Mac BUSY ≥ threshold.
+3. Local default (`PULP_LOCAL_MACOS_RUNS_ON_JSON`).
+
+Manual `workflow_dispatch` with an explicit selector input still overrides; the fix only changes behavior for dispatches that arrive without one (which is the `shipyard pr` shape).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,17 @@ jobs:
           if workflow_dispatch_selector:
               macos_route = "operator-override"
               chosen_macos_selector = workflow_dispatch_selector
-          elif namespace_macos_selector and EVENT_NAME == "pull_request":
+          elif namespace_macos_selector and EVENT_NAME in ("pull_request", "workflow_dispatch"):
+              # 2026-05-19: Namespace overflow logic now also applies to
+              # workflow_dispatch (Codex post-merge P2 on PR #2269).
+              # Before: condition was `EVENT_NAME == "pull_request"` only,
+              # which silently routed `shipyard pr` (which uses
+              # workflow_dispatch via the Shipyard `[targets.mac]
+              # backend = "cloud"` path) back to the local self-hosted
+              # Mac — defeating the cutover for ship cycles. The
+              # explicit-override path above (workflow_dispatch_selector)
+              # still wins; this branch only fires when the operator
+              # didn't supply an explicit selector.
               busy = _count_busy_local_mac_runners()
               if busy >= overflow_threshold:
                   macos_route = f"overflow (BUSY={busy} >= {overflow_threshold})"
@@ -256,7 +266,6 @@ jobs:
                   macos_route = f"local (BUSY={busy} < {overflow_threshold})"
                   chosen_macos_selector = local_macos_selector
           else:
-              # workflow_dispatch without an explicit override, or
               # Namespace not configured. Stay local.
               macos_route = "local (default)"
               chosen_macos_selector = local_macos_selector


### PR DESCRIPTION
## Summary

Closes #2314 (post-merge Codex P2 on PR #2269 Shipyard cloud cutover).

The `resolve-provider` step's macOS overflow logic in `.github/workflows/build.yml` was gated on `EVENT_NAME == "pull_request"` only. After the 2026-05-18 cutover, `.shipyard/config.toml [targets.mac]` is `backend = "cloud"` + `workflow = "build"` — so `shipyard pr` ship cycles dispatch `build.yml` via `workflow_dispatch`, which silently fell through to the local self-hosted Mac selector instead of Namespace.

**Net effect before this fix:** the cutover worked for normal PR-triggered builds (which is why the companion-track PRs eventually merged through Namespace) but did NOT work for `shipyard pr` ship cycles — those continued to queue on `Daniels-MacBook-Pro`, defeating the cost/parallelism win the cutover was supposed to deliver.

## Fix

One-line condition broadened from `EVENT_NAME == "pull_request"` to `EVENT_NAME in ("pull_request", "workflow_dispatch")`. The explicit operator-override path (`workflow_dispatch_selector` from `inputs.macos_runner_selector_json`) still takes precedence — this branch only fires when no explicit selector is supplied on dispatch.

## What stays the same

- Required `macos` branch-protection check is unchanged.
- Repo variables (`PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON`, `PULP_LOCAL_MAC_OVERFLOW_THRESHOLD`, etc.) are unchanged.
- `.shipyard/config.toml` is unchanged.
- The local-Mac fallback (`Daniels-MacBook-Pro`) is unchanged.
- Manual `workflow_dispatch` with explicit `macos_runner_selector_json` input still overrides.

## Test plan

- [x] YAML validates (`yaml.safe_load`).
- [ ] After merge, the next `shipyard pr` cycle's `resolve-provider` step should log `macos route = overflow (BUSY=N >= 1)` instead of `macos route = local (default)`.
- [ ] Daniels-MacBook-Pro queue depth stays at 0 for ship-cycle workflow_dispatch runs.

## Provenance

Filed during the 2026-05-18 companion-track session. Found via post-merge PR-comment sweep on the Shipyard cutover PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)