### PR TITLE
fix(harness): canvas2d adapter reads split preludes (Codex P1 on #2253)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.64.0",
+      "version": "0.64.1",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.64.0"
+  "version": "0.64.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v01352"></a>
+## [0.135.2] - 2026-05-19
+
+- fix(harness): canvas2d adapter reads split preludes — addresses Codex P1 on #2253 (verifier now reports 66/66 pass instead of 60/66 with 6 NOT-IMPL)
+
 <a id="v01351"></a>
 ## [0.135.1] - 2026-05-18
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.135.1
+    VERSION 0.135.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/harness/adapters/canvas2d.py
+++ b/tools/harness/adapters/canvas2d.py
@@ -106,7 +106,20 @@ class Canvas2dAdapter(AdapterBase):
         super().__init__(repo_root)
         self._oracle = self._load_oracle()
         self._bridge_text = self._read("core/view/src/widget_bridge.cpp")
-        self._shim_text = self._read("core/view/js/web-compat-canvas.js")
+        # P5-6 + P5-6 follow-up extracted prelude content out of the original
+        # web-compat-canvas.js into sibling files (matrix helper, image API,
+        # native-GPU helpers). The shim text the adapter reasons about is the
+        # union of all three so prototype methods + ctx attributes that moved
+        # don't get mis-classified as NOT-IMPL.
+        self._shim_text = "\n".join(
+            self._read(f"core/view/js/{name}")
+            for name in (
+                "web-compat-canvas.js",
+                "web-compat-canvas-gpu.js",
+                "web-compat-canvas-matrix.js",
+                "web-compat-canvas-image.js",
+            )
+        )
         self._bridge_fns = self._extract_bridge_fns()
         self._shim_methods = self._extract_shim_methods()
         self._shim_attrs = self._extract_shim_attrs()

--- a/tools/harness/tests/test_canvas2d_adapter_shim_files.py
+++ b/tools/harness/tests/test_canvas2d_adapter_shim_files.py
@@ -1,0 +1,68 @@
+"""Regression test for the Canvas2dAdapter shim-file union (post-P5-6 split).
+
+Pulp #2253 (P5-6 follow-up) extracted `measureText` / `drawImage` /
+`setLineDash` / `getLineDash` / `getImageData` / `putImageData` out of
+`web-compat-canvas.js` into a sibling prelude `web-compat-canvas-image.js`,
+and `_PulpCanvasMatrix` into `web-compat-canvas-matrix.js`. The harness
+adapter previously read only `web-compat-canvas.js`, so the canvas2d
+compat verifier mis-classified the six extracted APIs as `NOT-IMPL`
+(Codex P1 on PR #2253).
+
+This test pins the contract that the adapter's shim text is the *union*
+of the parent file + its sibling preludes — if a future split moves a
+prototype method out into another prelude file that isn't in the union,
+this fails loudly.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.harness.adapters.canvas2d import Canvas2dAdapter  # noqa: E402
+
+
+class Canvas2dShimFileUnionTests(unittest.TestCase):
+    """Pin the prototype methods that live in the extracted preludes."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.adapter = Canvas2dAdapter(REPO_ROOT)
+
+    def test_image_prelude_methods_resolve(self) -> None:
+        """The six API gap-closure methods from `web-compat-canvas-image.js`
+        must appear in the adapter's prototype-method set, otherwise the
+        verifier reports `canvas2d/measureText` etc. as NOT-IMPL."""
+        moved_to_image_prelude = {
+            "measureText",
+            "drawImage",
+            "setLineDash",
+            "getLineDash",
+            "getImageData",
+            "putImageData",
+        }
+        missing = moved_to_image_prelude - self.adapter._shim_methods
+        self.assertFalse(
+            missing,
+            f"Adapter is not reading web-compat-canvas-image.js — missing: {sorted(missing)}",
+        )
+
+    def test_parent_canvas_methods_still_resolve(self) -> None:
+        """Methods that stayed in `web-compat-canvas.js` must still appear
+        (i.e. the union didn't accidentally drop the parent file)."""
+        kept_in_parent = {"fillRect", "strokeRect", "fill", "stroke", "beginPath"}
+        missing = kept_in_parent - self.adapter._shim_methods
+        self.assertFalse(
+            missing,
+            f"Adapter dropped the parent web-compat-canvas.js — missing: {sorted(missing)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses **Codex P1 on PR #2253**: the Canvas2D harness adapter still read only `core/view/js/web-compat-canvas.js`, but PR #2253 (P5-6 follow-up) extracted six prototype methods (`measureText` / `drawImage` / `setLineDash` / `getLineDash` / `getImageData` / `putImageData`) into the sibling prelude `web-compat-canvas-image.js`. Result: the canvas2d verifier mis-classified those six supported APIs as `NOT-IMPL`, breaking the compat coverage signal.

### Fix

`tools/harness/adapters/canvas2d.py` now reads the **union** of the parent shim plus its three sibling preludes for prototype-method extraction:

```python
self._shim_text = "\n".join(
    self._read(f"core/view/js/{name}")
    for name in (
        "web-compat-canvas.js",
        "web-compat-canvas-gpu.js",
        "web-compat-canvas-matrix.js",
        "web-compat-canvas-image.js",
    )
)
```

### Verifier output

| State | pass | not_impl |
|-------|-----:|---------:|
| Before fix (current main) | 60/66 | 6 |
| After fix | **66/66** | **0** |

### Regression test

`tools/harness/tests/test_canvas2d_adapter_shim_files.py` pins both directions:
- The six methods that moved to `web-compat-canvas-image.js` must resolve through `_shim_methods` (catches the P1 regression).
- Methods still in the parent file (`fillRect`, `strokeRect`, `fill`, `stroke`, `beginPath`) must keep resolving (catches a future split that drops the parent from the union).

## Test plan

- [x] `python3 -m unittest tools.harness.tests.test_canvas2d_adapter_shim_files -v` — 2/2 pass
- [x] `python3 tools/harness/verifier.py --surface=canvas2d --json --repo-root .` — 66/66 pass, 0 NOT-IMPL
- [x] Same verifier on origin/main (stash applied/reverted) — confirmed 60/66 pass, 6 NOT-IMPL on the current broken state
- [ ] Lane CI green