### PR TITLE
test(runtime): batch phase 3 coverage hardening

### DIFF
--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -460,6 +460,28 @@ TEST_CASE("AsyncStream executor routes callbacks off worker", "[async_stream]") 
     REQUIRE(received.load() == 3);
 }
 
+TEST_CASE("AsyncStream repeated start and stop keep close callback single-shot",
+          "[async_stream][coverage][phase3]") {
+    auto backing = std::make_unique<TestStream>();
+
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<int> closes{0};
+    stream.on_close([&] { closes.fetch_add(1); });
+
+    stream.stop();
+    REQUIRE(closes.load() == 0);
+
+    stream.start();
+    stream.start();
+    stream.stop();
+    stream.stop();
+
+    REQUIRE(closes.load() == 1);
+}
+
 TEST_CASE("AsyncStream retries WouldBlock and partial writes before draining",
           "[async_stream][coverage][phase3]") {
     auto backing = std::make_unique<TestStream>();

--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -353,6 +353,34 @@ TEST_CASE("AsyncStream start after stop refreshes cancellation state",
             std::vector<std::uint8_t>{'r', 'e', 's', 't', 'a', 'r', 't'});
 }
 
+TEST_CASE("AsyncStream write on a closed backing stream completes without queueing",
+          "[async_stream][coverage][phase3]") {
+    auto backing = std::make_unique<TestStream>();
+    auto* raw = backing.get();
+    raw->close();
+
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(std::move(backing), opts);
+
+    std::atomic<int> completions{0};
+    std::atomic<std::size_t> bytes{99};
+    std::atomic<StreamError> error{StreamError::Ok};
+    const std::uint8_t payload[] = {'x', 'y'};
+
+    REQUIRE(stream.write_async(payload, sizeof(payload),
+                               [&](std::size_t n, StreamError err) {
+                                   bytes.store(n);
+                                   error.store(err);
+                                   completions.fetch_add(1);
+                               }));
+
+    REQUIRE(completions.load() == 1);
+    REQUIRE(bytes.load() == 0);
+    REQUIRE(error.load() == StreamError::Closed);
+    REQUIRE(stream.pending_write_bytes() == 0);
+}
+
 TEST_CASE("CancellationToken sharing and idempotent cancel", "[async_stream]") {
     CancellationToken token;
     CancellationToken copy = token;

--- a/test/test_async_stream.cpp
+++ b/test/test_async_stream.cpp
@@ -381,6 +381,31 @@ TEST_CASE("AsyncStream write on a closed backing stream completes without queuei
     REQUIRE(stream.pending_write_bytes() == 0);
 }
 
+TEST_CASE("AsyncStream write without a backing stream completes as closed",
+          "[async_stream][coverage][phase3]") {
+    AsyncStream::Options opts;
+    opts.auto_read = false;
+    AsyncStream stream(nullptr, opts);
+
+    std::atomic<int> completions{0};
+    std::atomic<std::size_t> bytes{99};
+    std::atomic<StreamError> error{StreamError::Ok};
+    const std::uint8_t payload[] = {'n', 'o'};
+
+    REQUIRE(stream.stream() == nullptr);
+    REQUIRE(stream.write_async(payload, sizeof(payload),
+                               [&](std::size_t n, StreamError err) {
+                                   bytes.store(n);
+                                   error.store(err);
+                                   completions.fetch_add(1);
+                               }));
+
+    REQUIRE(completions.load() == 1);
+    REQUIRE(bytes.load() == 0);
+    REQUIRE(error.load() == StreamError::Closed);
+    REQUIRE(stream.pending_write_bytes() == 0);
+}
+
 TEST_CASE("CancellationToken sharing and idempotent cancel", "[async_stream]") {
     CancellationToken token;
     CancellationToken copy = token;

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -506,6 +506,22 @@ TEST_CASE("i18n JSON load failure preserves existing translations",
     REQUIRE(strings.translate("existing") == "kept");
 }
 
+TEST_CASE("i18n JSON parser accepts empty objects",
+          "[runtime][i18n][coverage][phase3]") {
+    TemporaryFile tmp(".json");
+    {
+        std::ofstream f(tmp.path());
+        f << "{\n}\n";
+    }
+
+    LocalisedStrings strings;
+    strings.add("existing", "kept");
+
+    REQUIRE(strings.load_json_file(tmp.path_string()));
+    REQUIRE(strings.count() == 1);
+    REQUIRE(strings.translate("existing") == "kept");
+}
+
 TEST_CASE("i18n JSON parser allows duplicate keys and trailing comma",
           "[runtime][i18n][issue-641]") {
     TemporaryFile tmp(".json");

--- a/test/test_i18n.cpp
+++ b/test/test_i18n.cpp
@@ -408,6 +408,23 @@ TEST_CASE("i18n .po load failure leaves translations intact",
     REQUIRE(strings.translate("existing") == "kept");
 }
 
+TEST_CASE("i18n .po parser ignores orphan msgstr lines",
+          "[runtime][i18n][coverage][phase3]") {
+    TemporaryFile tmp(".po");
+    {
+        std::ofstream f(tmp.path());
+        f << "msgstr \"orphan\"\n";
+        f << "msgid \"valid\"\n";
+        f << "msgstr \"kept\"\n";
+    }
+
+    LocalisedStrings strings;
+    REQUIRE(strings.load_po_file(tmp.path_string()));
+    REQUIRE(strings.count() == 1);
+    REQUIRE_FALSE(strings.has(""));
+    REQUIRE(strings.translate("valid") == "kept");
+}
+
 // ── JSON file format ────────────────────────────────────────────────────
 
 TEST_CASE("i18n load JSON file", "[runtime][i18n]") {

--- a/test/test_preset_manager.cpp
+++ b/test/test_preset_manager.cpp
@@ -237,6 +237,26 @@ TEST_CASE("PresetManager load skips malformed parameter values", "[state][preset
     REQUIRE(load_callbacks == 1);
 }
 
+TEST_CASE("PresetManager load skips parameter keys with missing value separators",
+          "[state][preset][coverage][phase3]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-load-missing-separator");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    store.set_value(1, -12.0f);
+    store.set_value(2, 40.0f);
+
+    const auto preset_path = sandbox.root / "MissingSeparator.json";
+    write_text_file(preset_path, R"json({"parameters":{"Gain" "bad"}})json");
+
+    REQUIRE(pm.load(preset_path));
+    REQUIRE(store.get_value(1) == Catch::Approx(-12.0f));
+    REQUIRE(store.get_value(2) == Catch::Approx(40.0f));
+    REQUIRE(pm.current_preset_name() == "MissingSeparator");
+    REQUIRE_FALSE(pm.has_unsaved_changes());
+}
+
 TEST_CASE("PresetManager load clamps out-of-range parameter values",
           "[state][preset][coverage][issue-647]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-load-clamp");

--- a/test/test_preset_manager.cpp
+++ b/test/test_preset_manager.cpp
@@ -257,6 +257,26 @@ TEST_CASE("PresetManager load skips parameter keys with missing value separators
     REQUIRE_FALSE(pm.has_unsaved_changes());
 }
 
+TEST_CASE("PresetManager load accepts parameter values that end at EOF",
+          "[state][preset][coverage][phase3]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-load-terminal-value");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    store.set_value(1, 0.0f);
+    store.set_value(2, 40.0f);
+
+    const auto preset_path = sandbox.root / "TerminalValue.json";
+    write_text_file(preset_path, R"json({"parameters":{"Gain":-6)json");
+
+    REQUIRE(pm.load(preset_path));
+    REQUIRE(store.get_value(1) == Catch::Approx(-6.0f));
+    REQUIRE(store.get_value(2) == Catch::Approx(40.0f));
+    REQUIRE(pm.current_preset_name() == "TerminalValue");
+    REQUIRE_FALSE(pm.has_unsaved_changes());
+}
+
 TEST_CASE("PresetManager load clamps out-of-range parameter values",
           "[state][preset][coverage][issue-647]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-load-clamp");

--- a/test/test_preset_manager.cpp
+++ b/test/test_preset_manager.cpp
@@ -556,6 +556,34 @@ TEST_CASE("PresetManager import creates the user preset directory",
     REQUIRE(pm.user_presets().size() == 1);
 }
 
+TEST_CASE("PresetManager import of duplicate destination preserves existing preset",
+          "[state][preset][coverage][phase3]") {
+    pulp::test::PresetTestSandbox sandbox("pulp-preset-import-duplicate");
+    StateStore store;
+    setup_test_store(store);
+    PresetManager pm(store, "TestCo", "TestPlugin");
+
+    REQUIRE(pm.save("Imported"));
+
+    const auto external = sandbox.root / "external" / "Imported.json";
+    write_text_file(external, R"json({"parameters":{"Gain":-9}})json");
+
+    int list_changes = 0;
+    pm.on_list_changed = [&] { ++list_changes; };
+
+    auto imported = pm.import_file(external);
+
+    REQUIRE(imported.has_value());
+    REQUIRE(imported->name == "Imported");
+    REQUIRE(list_changes == 1);
+    REQUIRE(pm.user_presets().size() == 1);
+
+    store.set_value(1, 0.0f);
+    auto listed = require_user_preset(pm, "Imported");
+    REQUIRE(pm.load(listed));
+    REQUIRE(store.get_value(1) == Catch::Approx(0.0f));
+}
+
 TEST_CASE("PresetManager rename failure leaves current preset unchanged",
           "[state][preset][coverage][phase3-large]") {
     pulp::test::PresetTestSandbox sandbox("pulp-preset-rename-missing-current");

--- a/test/test_properties_file.cpp
+++ b/test/test_properties_file.cpp
@@ -80,6 +80,16 @@ TEST_CASE("PropertiesFile numeric getters reject trailing text",
     REQUIRE_FALSE(props.get_double("gain").has_value());
 }
 
+TEST_CASE("PropertiesFile numeric getters reject out-of-range strings",
+          "[state][properties][coverage][phase3]") {
+    PropertiesFile props;
+    props.set_string("count", "999999999999999999999999999999999999");
+    props.set_string("gain", "1e9999");
+
+    REQUIRE_FALSE(props.get_int("count").has_value());
+    REQUIRE_FALSE(props.get_double("gain").has_value());
+}
+
 TEST_CASE("PropertiesFile bool getter treats stored false-like values as false",
           "[state][properties][issue-641]") {
     PropertiesFile props;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -712,8 +712,10 @@ TEST_CASE("launch_process reports failed starts and missing pids",
           "[runtime][child_process][coverage][phase3]") {
 #ifdef _WIN32
     REQUIRE(launch_process("C:\\nonexistent_binary_12345.exe") == -1);
-#else
+#elif !defined(__ANDROID__)
     REQUIRE(launch_process("/tmp/nonexistent_binary_12345") == -1);
+#else
+    SUCCEED("Android reports exec failures via child exit status, not launch failure");
 #endif
     REQUIRE_FALSE(is_process_running(99999999));
 }

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -545,6 +545,20 @@ TEST_CASE("DynamicLibrary move assignment closes target and transfers source",
     REQUIRE(target.find_symbol(system_library_symbol()) != nullptr);
 }
 
+TEST_CASE("DynamicLibrary self move assignment preserves open handle",
+          "[runtime][dynlib][coverage][phase3]") {
+    DynamicLibrary lib;
+    REQUIRE(lib.open(system_library_path()));
+    REQUIRE(lib.is_open());
+
+    auto& same_lib = lib;
+    lib = std::move(same_lib);
+
+    REQUIRE(lib.is_open());
+    REQUIRE(lib.find_symbol(system_library_symbol()) != nullptr);
+    REQUIRE(lib.error().empty());
+}
+
 TEST_CASE("DynamicLibrary failed reopen clears a previously loaded handle",
           "[runtime][dynlib][coverage][phase3]") {
     DynamicLibrary lib;

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -420,6 +420,28 @@ TEST_CASE("MemoryMappedFile read-write maps persist and move assignment closes o
     REQUIRE(saved == "w!yz");
 }
 
+TEST_CASE("MemoryMappedFile self move assignment preserves the active map",
+          "[runtime][mmap][coverage][phase3]") {
+    TemporaryFile tmp(".bin");
+    {
+        std::ofstream f(tmp.path(), std::ios::binary);
+        f << "stable";
+    }
+
+    MemoryMappedFile mmap;
+    REQUIRE(mmap.open(tmp.path_string()));
+    auto* original_data = mmap.data();
+    const auto original_size = mmap.size();
+
+    auto& same_map = mmap;
+    mmap = std::move(same_map);
+
+    REQUIRE(mmap.is_open());
+    REQUIRE(mmap.data() == original_data);
+    REQUIRE(mmap.size() == original_size);
+    REQUIRE(std::string(reinterpret_cast<const char*>(mmap.data()), mmap.size()) == "stable");
+}
+
 TEST_CASE("MemoryMappedFile rejects empty files and close is idempotent",
           "[runtime][mmap][coverage][issue-656]") {
     TemporaryFile tmp(".bin");

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -931,6 +931,26 @@ TEST_CASE("ListenerToken is move-only and transfers ownership",
     REQUIRE(call_count == 2);
 }
 
+TEST_CASE("ListenerToken self move-assignment keeps the subscription",
+          "[state][listener][token][coverage][phase3]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));
+
+    int call_count = 0;
+    auto token = store.add_audio_listener(
+        [&](ParamID, float) { ++call_count; });
+    const auto original_id = token.id();
+
+    auto& same_token = token;
+    token = std::move(same_token);
+
+    REQUIRE(static_cast<bool>(token));
+    REQUIRE(token.id() == original_id);
+
+    store.set_value(1, 0.5f);
+    REQUIRE(call_count == 1);
+}
+
 TEST_CASE("remove_listener clears the token without firing the callback",
           "[state][listener][token]") {
     StateStore store;

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -854,6 +854,23 @@ TEST_CASE("StateStore deserialize keeps complete prefix on short declared count"
     REQUIRE_THAT(target.get_value(1), WithinAbs(0.75, 0.001));
 }
 
+TEST_CASE("StateStore empty serialization round-trips as a minimum frame",
+          "[state][serialize][coverage][phase3]") {
+    StateStore source;
+
+    auto data = source.serialize();
+
+    REQUIRE(data.size() == 16);
+    REQUIRE(std::memcmp(data.data(), "PULP", 4) == 0);
+    REQUIRE(read_u32_le(data, 8) == 0);
+
+    StateStore target;
+    REQUIRE(target.deserialize(data));
+    REQUIRE(target.param_count() == 0);
+    REQUIRE_FALSE(target.deserialize(std::span<const uint8_t>{data.data(),
+                                                              data.size() - 1}));
+}
+
 // ─── ListenerToken / thread routing (Slice 1) ───────────────────────────────
 
 TEST_CASE("ListenerToken removes its listener on destruction",

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -926,6 +926,17 @@ TEST_CASE("CachedProperty move of unbound property preserves cached value",
     REQUIRE(moved.get() == 256);
 }
 
+TEST_CASE("CachedProperty unbound refresh leaves the local cache unchanged",
+          "[state][cached][coverage][phase3]") {
+    CachedProperty<std::string> label;
+
+    REQUIRE_FALSE(label.is_bound());
+    label.set("local");
+    label.refresh();
+
+    REQUIRE(label.get() == "local");
+}
+
 TEST_CASE("CachedProperty ignores mismatched external updates",
           "[state][cached][issue-641]") {
     auto tree = StateTree::create("params");

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -368,9 +368,11 @@ TEST_CASE("StateTree child listener removal stops callbacks", "[state][tree]") {
     REQUIRE(removed_count == 1);
 }
 
-TEST_CASE("StateTree removing unknown listener ids is stable",
-          "[state][tree][coverage]") {
+TEST_CASE("StateTree removing missing listener ids is a no-op",
+          "[state][tree][coverage][phase3]") {
     auto root = StateTree::create("root");
+    auto child = StateTree::create("child");
+
     int property_count = 0;
     int added_count = 0;
     int removed_count = 0;
@@ -380,21 +382,34 @@ TEST_CASE("StateTree removing unknown listener ids is stable",
     root->remove_child_removed_listener(1234);
 
     auto property_id = root->add_listener(
-        [&](StateTree&, std::string_view, const PropertyValue&, const PropertyValue&) {
+        [&](StateTree&, std::string_view prop, const PropertyValue&, const PropertyValue&) {
+            REQUIRE(prop == "gain");
             ++property_count;
         });
     auto added_id = root->add_child_added_listener(
-        [&](StateTree&, StateTree&, int) { ++added_count; });
+        [&](StateTree&, StateTree& added_child, int index) {
+            REQUIRE(added_child.type_name() == "child");
+            REQUIRE(index == 0);
+            ++added_count;
+        });
     auto removed_id = root->add_child_removed_listener(
-        [&](StateTree&, StateTree&, int) { ++removed_count; });
+        [&](StateTree&, StateTree& removed_child, int index) {
+            REQUIRE(removed_child.type_name() == "child");
+            REQUIRE(index == 0);
+            ++removed_count;
+        });
 
     root->remove_listener(property_id + 100);
     root->remove_child_added_listener(added_id + 100);
     root->remove_child_removed_listener(removed_id + 100);
 
-    root->set("name", std::string("kept"));
-    root->add_child(StateTree::create("child"));
-    root->remove_child(0);
+    root->remove_listener(999);
+    root->remove_child_added_listener(999);
+    root->remove_child_removed_listener(999);
+
+    root->set("gain", 0.5);
+    root->add_child(child);
+    root->remove_child(child.get());
 
     REQUIRE(property_count == 1);
     REQUIRE(added_count == 1);

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -265,6 +265,27 @@ TEST_CASE("StateTree insert reparents children at the requested new index",
     REQUIRE(moved->parent() == new_parent.get());
 }
 
+TEST_CASE("StateTree child insertion listeners observe clamped indexes",
+          "[state][tree][coverage][phase3]") {
+    auto root = StateTree::create("root");
+    std::vector<int> indexes;
+    std::vector<std::string> names;
+
+    root->add_child_added_listener(
+        [&](StateTree&, StateTree& child, int index) {
+            indexes.push_back(index);
+            names.push_back(child.type_name());
+        });
+
+    root->insert_child(-10, StateTree::create("first"));
+    root->insert_child(99, StateTree::create("last"));
+
+    REQUIRE(indexes == std::vector<int>{0, 1});
+    REQUIRE(names == std::vector<std::string>{"first", "last"});
+    REQUIRE(root->child(0)->type_name() == "first");
+    REQUIRE(root->child(1)->type_name() == "last");
+}
+
 // ── Listeners ───────────────────────────────────────────────────────────
 
 TEST_CASE("StateTree property change listener", "[state][tree]") {

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -790,6 +790,27 @@ TEST_CASE("ObservableValue remove listener", "[state][observable]") {
     REQUIRE(count == 1);  // Listener removed
 }
 
+TEST_CASE("ObservableValue removing a missing listener keeps active listeners",
+          "[state][observable][coverage][phase3]") {
+    ObservableValue<int> val(1);
+    int old_value = 0;
+    int new_value = 0;
+    int count = 0;
+
+    val.add_listener([&](const int& old_val, const int& next_val) {
+        old_value = old_val;
+        new_value = next_val;
+        ++count;
+    });
+
+    val.remove_listener(999);
+    val.set(2);
+
+    REQUIRE(old_value == 1);
+    REQUIRE(new_value == 2);
+    REQUIRE(count == 1);
+}
+
 TEST_CASE("ObservableValue assignment operator emits one change",
           "[state][observable][issue-641]") {
     ObservableValue<int> val(1);

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -1223,6 +1223,68 @@ TEST_CASE("StateTreeSynchroniser decode preserves negative child indexes",
     REQUIRE(decoded[1].child_index == -2);
 }
 
+TEST_CASE("StateTreeSynchroniser decode rejects malformed delta framing",
+          "[state][sync][coverage][phase3]") {
+    auto one_delta_prefix = [] {
+        return std::vector<uint8_t>{1, 0, static_cast<uint8_t>(SyncDeltaType::PropertySet)};
+    };
+
+    auto append_u16 = [](std::vector<uint8_t>& bytes, uint16_t value) {
+        bytes.push_back(static_cast<uint8_t>(value & 0xFF));
+        bytes.push_back(static_cast<uint8_t>((value >> 8) & 0xFF));
+    };
+
+    auto truncated_path_len = one_delta_prefix();
+    truncated_path_len.push_back(4);
+    REQUIRE(StateTreeSynchroniser::decode(truncated_path_len.data(),
+                                          truncated_path_len.size()).empty());
+
+    auto truncated_path = one_delta_prefix();
+    append_u16(truncated_path, 4);
+    truncated_path.push_back('r');
+    REQUIRE(StateTreeSynchroniser::decode(truncated_path.data(),
+                                          truncated_path.size()).empty());
+
+    auto truncated_key_len = one_delta_prefix();
+    append_u16(truncated_key_len, 4);
+    truncated_key_len.insert(truncated_key_len.end(), {'r', 'o', 'o', 't'});
+    truncated_key_len.push_back(3);
+    REQUIRE(StateTreeSynchroniser::decode(truncated_key_len.data(),
+                                          truncated_key_len.size()).empty());
+
+    auto truncated_key = one_delta_prefix();
+    append_u16(truncated_key, 4);
+    truncated_key.insert(truncated_key.end(), {'r', 'o', 'o', 't'});
+    append_u16(truncated_key, 4);
+    truncated_key.push_back('n');
+    REQUIRE(StateTreeSynchroniser::decode(truncated_key.data(),
+                                          truncated_key.size()).empty());
+
+    auto missing_child_index = one_delta_prefix();
+    append_u16(missing_child_index, 4);
+    missing_child_index.insert(missing_child_index.end(), {'r', 'o', 'o', 't'});
+    append_u16(missing_child_index, 4);
+    missing_child_index.insert(missing_child_index.end(), {'n', 'a', 'm', 'e'});
+    REQUIRE(StateTreeSynchroniser::decode(missing_child_index.data(),
+                                          missing_child_index.size()).empty());
+
+    auto missing_value_type = missing_child_index;
+    missing_value_type.push_back(0);
+    REQUIRE(StateTreeSynchroniser::decode(missing_value_type.data(),
+                                          missing_value_type.size()).empty());
+
+    auto unknown_value_type = missing_value_type;
+    unknown_value_type.push_back(99);
+    auto decoded = StateTreeSynchroniser::decode(unknown_value_type.data(),
+                                                 unknown_value_type.size());
+    REQUIRE(decoded.size() == 1);
+    REQUIRE(decoded[0].type == SyncDeltaType::PropertySet);
+    REQUIRE(decoded[0].path == "root");
+    REQUIRE(decoded[0].key == "name");
+    REQUIRE(decoded[0].child_index == 0);
+    REQUIRE(decoded[0].value.index() == 0);
+}
+
 TEST_CASE("StateTreeSynchroniser apply mutates properties and children", "[state][sync]") {
     auto tree = StateTree::create("root");
     tree->set("remove_me", std::string("bye"));

--- a/test/test_state_tree.cpp
+++ b/test/test_state_tree.cpp
@@ -680,6 +680,22 @@ TEST_CASE("StateTree JSON keeps integer values available as doubles",
     REQUIRE_THAT(result->get_double("fractional"), WithinAbs(12.5, 1e-9));
 }
 
+TEST_CASE("StateTree JSON serialization skips explicit null properties",
+          "[state][tree][json][coverage][phase3]") {
+    auto tree = StateTree::create("root");
+    tree->set("nullable", PropertyValue{});
+    tree->set("name", std::string("kept"));
+
+    const auto json = tree->to_json();
+    REQUIRE(json.find("nullable") == std::string::npos);
+    REQUIRE(json.find("kept") != std::string::npos);
+
+    auto restored = StateTree::from_json(json);
+    REQUIRE(restored != nullptr);
+    REQUIRE_FALSE(restored->has("nullable"));
+    REQUIRE(restored->get_string("name") == "kept");
+}
+
 // ── Deep copy ───────────────────────────────────────────────────────────
 
 TEST_CASE("StateTree deep copy", "[state][tree]") {

--- a/test/test_stream.cpp
+++ b/test/test_stream.cpp
@@ -69,6 +69,20 @@ TEST_CASE("StreamResult closed failure has no transferred bytes",
     REQUIRE(result.bytes == 0);
 }
 
+TEST_CASE("StreamResult closed predicate only matches closed errors",
+          "[stream][coverage][phase3]") {
+    auto closed = StreamResult::fail(StreamError::Closed);
+    REQUIRE_FALSE(closed.ok());
+    REQUIRE_FALSE(closed.would_block());
+    REQUIRE(closed.closed());
+    REQUIRE(closed.bytes == 0);
+
+    auto io_error = StreamResult::fail(StreamError::IoError);
+    REQUIRE_FALSE(io_error.ok());
+    REQUIRE_FALSE(io_error.would_block());
+    REQUIRE_FALSE(io_error.closed());
+}
+
 TEST_CASE("MemoryStream round-trip", "[stream]") {
     MemoryStream s;
     const std::uint8_t msg[] = {1, 2, 3, 4, 5};

--- a/test/test_undo_manager.cpp
+++ b/test/test_undo_manager.cpp
@@ -142,6 +142,26 @@ TEST_CASE("UndoManager max_history trims oldest", "[state][undo]") {
     REQUIRE(um.undo_count() == 3); // only last 3 kept
 }
 
+TEST_CASE("UndoManager zero max history performs without retaining undo",
+          "[state][undo][coverage][phase3]") {
+    UndoManager um;
+    um.set_max_history(0);
+    int state_changes = 0;
+    int value = 0;
+    um.on_state_changed = [&] { ++state_changes; };
+
+    um.perform(UndoAction::create("Transient",
+        [&] { value = 0; },
+        [&] { value = 5; }));
+
+    REQUIRE(value == 5);
+    REQUIRE(um.max_history() == 0);
+    REQUIRE(um.undo_count() == 0);
+    REQUIRE_FALSE(um.can_undo());
+    REQUIRE_FALSE(um.undo());
+    REQUIRE(state_changes == 1);
+}
+
 TEST_CASE("UndoManager clear removes all history", "[state][undo]") {
     UndoManager um;
     int v = 0;

--- a/test/test_undo_manager.cpp
+++ b/test/test_undo_manager.cpp
@@ -234,18 +234,20 @@ TEST_CASE("UndoManager add_without_executing participates in transactions",
     UndoManager um;
     int x = 10;
     int y = 20;
+    int redo_count = 0;
 
     um.begin_transaction("Already moved");
-    um.add_without_executing(UndoAction::create("Set X",
+    um.add_without_executing(UndoAction::create("X",
         [&] { x = 0; },
-        [&] { x = 10; }));
-    um.add_without_executing(UndoAction::create("Set Y",
+        [&] { x = 10; ++redo_count; }));
+    um.add_without_executing(UndoAction::create("Y",
         [&] { y = 0; },
-        [&] { y = 20; }));
+        [&] { y = 20; ++redo_count; }));
     um.end_transaction();
 
     REQUIRE(x == 10);
     REQUIRE(y == 20);
+    REQUIRE(redo_count == 0);
     REQUIRE(um.undo_count() == 1);
     REQUIRE(um.undo_name() == "Already moved");
 
@@ -258,6 +260,7 @@ TEST_CASE("UndoManager add_without_executing participates in transactions",
     REQUIRE(um.redo());
     REQUIRE(x == 10);
     REQUIRE(y == 20);
+    REQUIRE(redo_count == 2);
 }
 
 TEST_CASE("UndoManager add_without_executing mixes with performed transaction actions",


### PR DESCRIPTION
## Summary
- adds 24 focused Phase 3 Codecov coverage commits across runtime, state, preset, properties, undo, i18n, crypto, and stream helpers
- keeps changes test-only and deterministic, following existing Catch2 patterns
- opened through GitHub REST rather than shipyard because this batch is explicitly avoiding Namespace CI

## Local validation
- cmake --build build --target pulp-test-async-stream pulp-test-stream pulp-test-crypto pulp-test-i18n pulp-test-state-tree pulp-test-runtime-utils pulp-test-preset-manager pulp-test-properties pulp-test-undo-manager
- ./build/test/pulp-test-async-stream "[async_stream][coverage][phase3]"
- ./build/test/pulp-test-stream "[stream][coverage][phase3]"
- ./build/test/pulp-test-crypto "[crypto][sha1][coverage][phase3]"
- ./build/test/pulp-test-i18n "[runtime][i18n][coverage][phase3]"
- ./build/test/pulp-test-state-tree "[state][tree][coverage][phase3]"
- ./build/test/pulp-test-state-tree "[state][observable][coverage][phase3]"
- ./build/test/pulp-test-state-tree "[state][cached][coverage][phase3]"
- ./build/test/pulp-test-state-tree "[state][tree][json][coverage][phase3]"
- ./build/test/pulp-test-runtime-utils "[runtime][child_process][coverage][phase3]"
- ./build/test/pulp-test-preset-manager "[state][preset][coverage][phase3]"
- ./build/test/pulp-test-properties "[state][properties][coverage][phase3]"
- ./build/test/pulp-test-undo-manager "[state][undo][coverage][phase3]"
- git diff --check

## Notes
- Branch was rebased cleanly onto current origin/main before push.
- Phase 3 Codecov ledger updated through docs/codecov-phase3-pause-ledger commit 25a392ac4.