### PR TITLE
feat(state): StateStore::snapshot() block-local helper + DSP threading guide

### DIFF
--- a/core/state/include/pulp/state/store.hpp
+++ b/core/state/include/pulp/state/store.hpp
@@ -2,6 +2,7 @@
 
 #include <pulp/state/listener_token.hpp>
 #include <pulp/state/parameter.hpp>
+#include <array>
 #include <vector>
 #include <unordered_map>
 #include <cstdint>
@@ -120,6 +121,41 @@ public:
     /// @return Pointer to ParamInfo, or nullptr if @p id is not registered.
     const ParamInfo* info(ParamID id) const;
 
+    /// Block-local snapshot of @p N parameter values.
+    ///
+    /// Loads each parameter once and returns the values in a stack-
+    /// allocated @c std::array. DSP code should call this once at the
+    /// top of @c process() and read from the returned array inside
+    /// the per-sample loop, instead of calling @c get_value() per
+    /// sample (each per-sample atomic load is a memory fence and
+    /// fans out across cores). Mirrors the "snapshot the world
+    /// before you start" pattern called out in sudara "Big List of
+    /// JUCE Tips" #29.
+    ///
+    /// @tparam N  Compile-time count of parameter IDs to read.
+    /// @param ids  Parameter IDs to snapshot, in the desired output
+    ///             order. Unknown IDs yield @c 0.0f at their slot.
+    /// @return std::array<float, N> — same order as @p ids.
+    ///
+    /// @code
+    /// constexpr std::array<ParamID, 2> kIds = { kGainId, kMixId };
+    /// auto p = store.snapshot(kIds);
+    /// for (int s = 0; s < n; ++s) {
+    ///     out[s] = in[s] * p[0] + dry[s] * (1.f - p[1]);
+    /// }
+    /// @endcode
+    template <std::size_t N>
+    [[nodiscard]] std::array<float, N> snapshot(
+        const std::array<ParamID, N>& ids) const noexcept;
+
+    /// Modulated variant of @c snapshot — returns each parameter's
+    /// base + per-buffer modulation offset (see
+    /// @c set_mod_offset). Use this from a synth that consumes
+    /// CLAP's modulated values inside the voice loop.
+    template <std::size_t N>
+    [[nodiscard]] std::array<float, N> snapshot_modulated(
+        const std::array<ParamID, N>& ids) const noexcept;
+
     /// View of all registered parameters (in registration order).
     std::span<const ParamInfo> all_params() const { return params_; }
 
@@ -234,5 +270,29 @@ public:
         on_end_gesture_ = std::move(end_fn);
     }
 };
+
+// ─── Template definitions ──────────────────────────────────────────────────
+
+template <std::size_t N>
+std::array<float, N> StateStore::snapshot(
+    const std::array<ParamID, N>& ids) const noexcept
+{
+    std::array<float, N> out{};
+    for (std::size_t i = 0; i < N; ++i) {
+        out[i] = get_value(ids[i]);
+    }
+    return out;
+}
+
+template <std::size_t N>
+std::array<float, N> StateStore::snapshot_modulated(
+    const std::array<ParamID, N>& ids) const noexcept
+{
+    std::array<float, N> out{};
+    for (std::size_t i = 0; i < N; ++i) {
+        out[i] = get_modulated(ids[i]);
+    }
+    return out;
+}
 
 } // namespace pulp::state

--- a/docs/guides/dsp-threading.md
+++ b/docs/guides/dsp-threading.md
@@ -1,0 +1,123 @@
+# DSP threading — the audio-thread contract
+
+Pulp's audio thread runs at hard real-time priority. Anything that
+blocks it — a lock, an allocation, a system call — causes the
+listener to hear a dropout. This page covers the small set of rules
+that keep your `Processor::process()` callback safe.
+
+If you're coming from JUCE: the rules are almost identical (and the
+gotchas are the same). Pulp's API just makes the safe pattern the
+default.
+
+## The three rules
+
+1. **Don't allocate.** No `new`, no `std::vector::push_back`, no
+   `std::string` construction. Allocate everything up-front in
+   `Processor::prepare()`.
+2. **Don't lock.** No `std::mutex::lock()`, no `std::condition_variable`,
+   no spinlock with unbounded wait. The atomic accessors on Pulp's
+   `state::ParamValue` / `state::StateStore` are lock-free.
+3. **Don't block on the main thread.** No `std::cout`, no file I/O,
+   no `std::async`, no `dispatch_to_main()`-and-wait. If the audio
+   thread sends work to the main thread, it does so via a non-blocking
+   queue.
+
+`pulp::runtime::ScopedNoAlloc` (debug builds) tracks rule #1 — Pulp
+wraps `View::paint_all` and every adapter's call to
+`Processor::process()` in one, so opt-in debug-allocator hooks can
+shout when rule #1 is violated. Future tooling can read
+`pulp::runtime::is_in_no_alloc_scope()` to flag a violation.
+
+## Read parameters once per block, not per sample
+
+`store.get_value(id)` is a `std::atomic<float>::load(relaxed)` —
+about 1 ns on Apple silicon and similar on x86. Cheap, but not free:
+every load is a memory fence that the CPU has to round-trip
+through the cache hierarchy, and the compiler can't hoist it out of
+your inner loop.
+
+The right pattern is to **snapshot** the parameters you need at the
+top of `process()`, then read from the snapshot inside the per-sample
+loop:
+
+```cpp
+// ❌ Don't: re-read atomic per sample. Each call is a fence.
+for (int s = 0; s < n; ++s) {
+    out[s] = in[s] * store.get_value(kGainId);
+}
+
+// ✅ Do: snapshot once, read locals.
+const float gain = store.get_value(kGainId);
+for (int s = 0; s < n; ++s) {
+    out[s] = in[s] * gain;
+}
+```
+
+For multiple parameters, Pulp's `StateStore::snapshot()` returns a
+stack-allocated `std::array<float, N>` so you can grab them all in
+one go:
+
+```cpp
+constexpr std::array<state::ParamID, 3> kIds = {
+    kGainId, kMixId, kCutoffId,
+};
+
+void MyPlugin::process(audio::BufferView<float>& out,
+                       const audio::BufferView<const float>& in,
+                       midi::MidiBuffer&, midi::MidiBuffer&,
+                       const ProcessContext&) {
+    const auto p = state_store().snapshot(kIds);
+    const float gain   = p[0];
+    const float mix    = p[1];
+    const float cutoff = p[2];
+
+    for (int ch = 0; ch < out.num_channels; ++ch) {
+        for (int s = 0; s < out.num_frames; ++s) {
+            // ... per-sample DSP using locals ...
+        }
+    }
+}
+```
+
+For modulated reads (the CLAP per-voice modulation path), use
+`snapshot_modulated()` — same idea, but each slot is
+`base + mod_offset` instead of just `base`.
+
+## How parameter changes reach the UI
+
+Format adapters now write host-driven parameter changes via
+`store.set_value_rt()` (CLAP / VST3 / AU / LV2 — see
+[planning/2026-05-18-rt-safety-and-debug-dx.md](../../planning/2026-05-18-rt-safety-and-debug-dx.md)
+Slice 2). The RT path is wait-free + alloc-free: it stores the
+atomic, then pushes a small `(id, value)` event on a bounded SPSC
+queue.
+
+The UI thread drains the queue by calling `store.pump_listeners()`
+each frame; that's where `ListenerThread::Main` listeners actually
+fire. So:
+
+* **Audio thread:** atomic write + lock-free queue push, no `new`,
+  no `EventLoop::dispatch` lambda.
+* **UI thread:** drain the queue, fan out to listeners.
+
+You don't usually call `pump_listeners()` yourself — `pulp::view`'s
+editor tick does it. But it's the right hook if you embed the
+StateStore in a non-Pulp host.
+
+## Block-level vs sample-level changes
+
+If you want the parameter change to take effect *within* a block
+(smooth ramps, automation), snapshot once at the top of the block
+and interpolate. Pulp doesn't ship a smoother — most DSP that needs
+one rolls a tiny `LinearSmoother { current, target, step }`
+manually. Future helper TBD.
+
+## See also
+
+* [`core/state/include/pulp/state/store.hpp`](../../core/state/include/pulp/state/store.hpp)
+  — `snapshot()`, `snapshot_modulated()`, `set_value_rt()`,
+  `pump_listeners()`.
+* [`core/runtime/include/pulp/runtime/scoped_no_alloc.hpp`](../../core/runtime/include/pulp/runtime/scoped_no_alloc.hpp)
+  — the no-allocation contract.
+* sudara, *"Big List of JUCE Tips and Tricks"* #28 (paint = audio)
+  and #29 (don't deref atomics per sample).

--- a/test/test_state.cpp
+++ b/test/test_state.cpp
@@ -946,3 +946,77 @@ TEST_CASE("RT-queued changes are skipped when the token was reset before pump",
     REQUIRE(store.pump_listeners() == 2);
     REQUIRE(fire_count == 0);
 }
+
+// ─── snapshot() block-local helper (Slice 5) ────────────────────────────────
+
+TEST_CASE("StateStore::snapshot returns values in the requested order",
+          "[state][snapshot]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Gain", "dB",
+                                        {-60.0f, 12.0f, 0.0f}));
+    store.add_parameter(make_param_info(2, "Mix", "%",
+                                        {0.0f, 100.0f, 50.0f}));
+    store.add_parameter(make_param_info(3, "Cutoff", "Hz",
+                                        {20.0f, 20000.0f, 1000.0f}));
+
+    store.set_value(1, -6.0f);
+    store.set_value(2, 75.0f);
+    store.set_value(3, 4400.0f);
+
+    constexpr std::array<ParamID, 3> ids{ 1, 2, 3 };
+    const auto snap = store.snapshot(ids);
+
+    REQUIRE_THAT(snap[0], WithinAbs(-6.0, 0.001));
+    REQUIRE_THAT(snap[1], WithinAbs(75.0, 0.001));
+    REQUIRE_THAT(snap[2], WithinAbs(4400.0, 0.001));
+}
+
+TEST_CASE("StateStore::snapshot handles unknown ids by returning 0",
+          "[state][snapshot]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.5f}));
+    store.set_value(1, 0.7f);
+
+    constexpr std::array<ParamID, 3> ids{ 1, 999, 1 };
+    const auto snap = store.snapshot(ids);
+
+    REQUIRE_THAT(snap[0], WithinAbs(0.7, 0.001));
+    REQUIRE(snap[1] == 0.0f);  // unknown
+    REQUIRE_THAT(snap[2], WithinAbs(0.7, 0.001));
+}
+
+TEST_CASE("StateStore::snapshot_modulated includes mod offsets",
+          "[state][snapshot]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "Pitch", "st",
+                                        {-12.0f, 12.0f, 0.0f}));
+    store.add_parameter(make_param_info(2, "Cutoff", "Hz",
+                                        {20.0f, 20000.0f, 1000.0f}));
+
+    store.set_value(1, 3.0f);
+    store.set_value(2, 2000.0f);
+    store.set_mod_offset(1, 0.5f);  // pitch +0.5 from modulation
+    store.set_mod_offset(2, 100.0f); // cutoff +100 from modulation
+
+    constexpr std::array<ParamID, 2> ids{ 1, 2 };
+
+    const auto base_snap = store.snapshot(ids);
+    REQUIRE_THAT(base_snap[0], WithinAbs(3.0, 0.001));
+    REQUIRE_THAT(base_snap[1], WithinAbs(2000.0, 0.001));
+
+    const auto mod_snap = store.snapshot_modulated(ids);
+    REQUIRE_THAT(mod_snap[0], WithinAbs(3.5, 0.001));
+    REQUIRE_THAT(mod_snap[1], WithinAbs(2100.0, 0.001));
+}
+
+TEST_CASE("StateStore::snapshot works with a single parameter",
+          "[state][snapshot]") {
+    StateStore store;
+    store.add_parameter(make_param_info(1, "X", "", {0.0f, 1.0f, 0.0f}));
+    store.set_value(1, 0.33f);
+
+    constexpr std::array<ParamID, 1> ids{ 1 };
+    const auto snap = store.snapshot(ids);
+    REQUIRE(snap.size() == 1);
+    REQUIRE_THAT(snap[0], WithinAbs(0.33, 0.001));
+}


### PR DESCRIPTION
Slice 5 of planning/2026-05-18-rt-safety-and-debug-dx.md.

Closes the Tier S RT-safety series. The earlier slices made the
infrastructure safe (Slice 1 listener token, Slice 2 adapter ingress,
Slice 4 ScopedNoAlloc); this one teaches plugin authors the right
per-block parameter-read pattern so their own DSP code doesn't
re-introduce the per-sample atomic-fence regression.

StateStore additions (header-only templates):

  template <std::size_t N>
  std::array<float, N> snapshot(
      const std::array<ParamID, N>& ids) const noexcept;

  template <std::size_t N>
  std::array<float, N> snapshot_modulated(
      const std::array<ParamID, N>& ids) const noexcept;

Each one loads N parameter values into a stack-allocated array. DSP
code calls it once at the top of `process()` and reads from locals
inside the per-sample loop, instead of fanning out N atomic fences
per sample.

The `_modulated` variant returns `base + mod_offset` and is what
synths feeding CLAP per-voice modulation through the voice loop
should use.

Unknown IDs yield 0.0f at their slot (matches the existing
get_value() contract) — that's intentional so a caller can use a
fixed kIds array even if a feature flag drops a parameter.

Tests (test/test_state.cpp, +4 cases):
  - snapshot returns values in the requested order
  - snapshot handles unknown ids by returning 0
  - snapshot_modulated includes mod offsets
  - snapshot works with a single parameter

41 state cases pass locally (186 assertions).

Docs (docs/guides/dsp-threading.md, new):

  The "audio-thread contract" guide. Three rules (don't allocate,
  don't lock, don't block on main), the snapshot-once-per-block
  pattern with a worked example, and pointers to the Slice 1 /
  Slice 2 / Slice 4 surfaces. Lands the Tier S story in one
  place plugin authors can read first.

Examples audit:
  - examples/pulp-gain — already snapshots gain locally; nothing
    to migrate. The pattern was correct in the example to begin
    with; this slice just makes it the documented norm.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>