### PR TITLE
feat(tools/debug): natvis + LLDB Python formatters for Pulp types

### DIFF
--- a/tools/debug/README.md
+++ b/tools/debug/README.md
@@ -1,0 +1,24 @@
+# tools/debug — Debugger formatters
+
+Pretty-printers for Pulp's core types so you don't have to squint at
+raw struct bytes in the debugger.
+
+| File | For | Loaded by |
+|---|---|---|
+| `pulp.natvis` | Visual Studio / Windows debuggers | drop into `%USERPROFILE%\Documents\Visual Studio 20XX\Visualizers\` |
+| `pulp_lldb.py` | LLDB on macOS / Linux / iOS | `command script import /path/to/pulp/tools/debug/pulp_lldb.py` in `~/.lldbinit` |
+
+Types covered today:
+
+* `pulp::state::ParamValue` — atomic float + atomic mod offset
+* `pulp::state::ParamInfo` / `ParamRange` — parameter metadata
+* `pulp::state::StateStore` — surfaces param count
+* `pulp::state::ListenerToken` — RAII subscription handle
+* `pulp::canvas::Rect` / `Point` / `Color`
+* `pulp::audio::BufferView<T>` — channels × frames, LLDB version
+  draws a 16-sample sparkline of the first channel
+
+Adding a new type? Match its name in both files and keep them in
+sync — the natvis side runs MSVC's expression engine and the LLDB
+side runs Python, so they're parallel implementations, not shared
+code. Per sudara "Big List of JUCE Tips" #21.

--- a/tools/debug/README.md
+++ b/tools/debug/README.md
@@ -15,7 +15,7 @@ Types covered today:
 * `pulp::state::StateStore` — surfaces param count
 * `pulp::state::ListenerToken` — RAII subscription handle
 * `pulp::canvas::Rect` / `Point` / `Color`
-* `pulp::audio::BufferView<T>` — channels × frames, LLDB version
+* `pulp::audio::BufferView<T>` — channels × samples, LLDB version
   draws a 16-sample sparkline of the first channel
 
 Adding a new type? Match its name in both files and keep them in

--- a/tools/debug/pulp.natvis
+++ b/tools/debug/pulp.natvis
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Visual Studio (and any natvis-aware Windows debugger) display
+formatters for Pulp core types. Drop a copy into
+`%USERPROFILE%\Documents\Visual Studio 20XX\Visualizers\` or add
+this path to the project's debugger settings:
+
+    Debug → Options → Debugging → Output Window → "Natvis
+    diagnostic messages" + load the file at debugger start.
+
+For LLDB on macOS / Linux, see tools/debug/pulp_lldb.py.
+
+Per sudara "Big List of JUCE Tips" #21.
+-->
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+  <!-- pulp::state::ParamValue: an atomic<float> + atomic<float>
+       modulation offset. _Storage is MSVC's internal name for the
+       underlying float bytes. -->
+  <Type Name="pulp::state::ParamValue">
+    <DisplayString>{{ value={value_._Storage} mod={mod_offset_._Storage} }}</DisplayString>
+    <Expand>
+      <Item Name="value">value_._Storage</Item>
+      <Item Name="mod_offset">mod_offset_._Storage</Item>
+    </Expand>
+  </Type>
+
+  <!-- pulp::state::ParamInfo: parameter metadata. -->
+  <Type Name="pulp::state::ParamInfo">
+    <DisplayString>{{ id={id} name={name} unit={unit} }}</DisplayString>
+    <Expand>
+      <Item Name="id">id</Item>
+      <Item Name="name">name</Item>
+      <Item Name="unit">unit</Item>
+      <Item Name="min">range.min</Item>
+      <Item Name="max">range.max</Item>
+      <Item Name="default">range.default_value</Item>
+      <Item Name="step">range.step</Item>
+      <Item Name="group_id">group_id</Item>
+    </Expand>
+  </Type>
+
+  <!-- pulp::state::ParamRange: numeric bounds. -->
+  <Type Name="pulp::state::ParamRange">
+    <DisplayString>[{min}..{max}] default={default_value} step={step}</DisplayString>
+  </Type>
+
+  <!-- pulp::state::StateStore: surfaces the active parameter count
+       and registered listener count. The full param vector is
+       reachable under params_ if you want to drill in. -->
+  <Type Name="pulp::state::StateStore">
+    <DisplayString>StateStore ({params_._Mypair._Myval2._Mylast - params_._Mypair._Myval2._Myfirst} params)</DisplayString>
+    <Expand>
+      <Item Name="param_count">params_._Mypair._Myval2._Mylast - params_._Mypair._Myval2._Myfirst</Item>
+      <Item Name="state_version">state_version_</Item>
+      <Item Name="params">params_</Item>
+      <Item Name="groups">groups_</Item>
+      <Item Name="values">values_</Item>
+    </Expand>
+  </Type>
+
+  <!-- pulp::canvas::Rect: x, y, w, h. -->
+  <Type Name="pulp::canvas::Rect">
+    <DisplayString>{{ x={x} y={y} w={w} h={h} }}</DisplayString>
+    <Expand>
+      <Item Name="x">x</Item>
+      <Item Name="y">y</Item>
+      <Item Name="w">w</Item>
+      <Item Name="h">h</Item>
+      <Item Name="right">x + w</Item>
+      <Item Name="bottom">y + h</Item>
+    </Expand>
+  </Type>
+
+  <!-- pulp::canvas::Point: 2D point. -->
+  <Type Name="pulp::canvas::Point">
+    <DisplayString>({x}, {y})</DisplayString>
+  </Type>
+
+  <!-- pulp::canvas::Color: 4-byte RGBA color. -->
+  <Type Name="pulp::canvas::Color">
+    <DisplayString>{{ r={r,d} g={g,d} b={b,d} a={a,d} }}</DisplayString>
+  </Type>
+
+  <!-- pulp::audio::BufferView: channels x frames audio buffer.
+       Format string previews the dimensions; channels/frames are
+       reachable for drilling in. -->
+  <Type Name="pulp::audio::BufferView&lt;*&gt;">
+    <DisplayString>BufferView {num_channels}ch x {num_frames} frames</DisplayString>
+    <Expand>
+      <Item Name="num_channels">num_channels</Item>
+      <Item Name="num_frames">num_frames</Item>
+      <ArrayItems>
+        <Size>num_channels</Size>
+        <ValuePointer>channel_data_</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!-- pulp::state::ListenerToken: RAII subscription handle. -->
+  <Type Name="pulp::state::ListenerToken">
+    <DisplayString Condition="id_ == 0">empty</DisplayString>
+    <DisplayString>token #{id_}</DisplayString>
+  </Type>
+
+</AutoVisualizer>

--- a/tools/debug/pulp.natvis
+++ b/tools/debug/pulp.natvis
@@ -59,16 +59,17 @@ Per sudara "Big List of JUCE Tips" #21.
     </Expand>
   </Type>
 
-  <!-- pulp::canvas::Rect: x, y, w, h. -->
+  <!-- pulp::canvas::Rect: x, y, width, height (per
+       core/canvas/include/pulp/canvas/rectangle_list.hpp:12). -->
   <Type Name="pulp::canvas::Rect">
-    <DisplayString>{{ x={x} y={y} w={w} h={h} }}</DisplayString>
+    <DisplayString>{{ x={x} y={y} w={width} h={height} }}</DisplayString>
     <Expand>
       <Item Name="x">x</Item>
       <Item Name="y">y</Item>
-      <Item Name="w">w</Item>
-      <Item Name="h">h</Item>
-      <Item Name="right">x + w</Item>
-      <Item Name="bottom">y + h</Item>
+      <Item Name="width">width</Item>
+      <Item Name="height">height</Item>
+      <Item Name="right">x + width</Item>
+      <Item Name="bottom">y + height</Item>
     </Expand>
   </Type>
 
@@ -82,17 +83,17 @@ Per sudara "Big List of JUCE Tips" #21.
     <DisplayString>{{ r={r,d} g={g,d} b={b,d} a={a,d} }}</DisplayString>
   </Type>
 
-  <!-- pulp::audio::BufferView: channels x frames audio buffer.
-       Format string previews the dimensions; channels/frames are
-       reachable for drilling in. -->
+  <!-- pulp::audio::BufferView<T>: channels x samples audio buffer.
+       Real field names live in
+       core/audio/include/pulp/audio/buffer.hpp:70-74. -->
   <Type Name="pulp::audio::BufferView&lt;*&gt;">
-    <DisplayString>BufferView {num_channels}ch x {num_frames} frames</DisplayString>
+    <DisplayString>BufferView {num_channels_}ch x {num_samples_} samples</DisplayString>
     <Expand>
-      <Item Name="num_channels">num_channels</Item>
-      <Item Name="num_frames">num_frames</Item>
+      <Item Name="num_channels">num_channels_</Item>
+      <Item Name="num_samples">num_samples_</Item>
       <ArrayItems>
-        <Size>num_channels</Size>
-        <ValuePointer>channel_data_</ValuePointer>
+        <Size>num_channels_</Size>
+        <ValuePointer>channels_</ValuePointer>
       </ArrayItems>
     </Expand>
   </Type>

--- a/tools/debug/pulp_lldb.py
+++ b/tools/debug/pulp_lldb.py
@@ -1,0 +1,182 @@
+"""LLDB Python formatters for Pulp core types.
+
+Load this from your ~/.lldbinit (or per-project .lldbinit):
+
+    command script import /path/to/pulp/tools/debug/pulp_lldb.py
+
+After loading, `p` / `frame variable` / `expr` on these types prints
+a structured summary instead of the default raw-bytes view.
+
+Mirrors tools/debug/pulp.natvis (which does the same job for MSVC).
+
+Slice 9 of planning/2026-05-18-rt-safety-and-debug-dx.md, per sudara
+"Big List of JUCE Tips" #21.
+"""
+
+from __future__ import annotations
+
+
+def _atomic_float(valobj, name: str) -> str:
+    """Extract a float from an std::atomic<float> child on libc++/libstdc++.
+
+    libc++:  __a_.__a_value
+    libstdc++:  _M_i
+    """
+    member = valobj.GetChildMemberWithName(name)
+    if not member.IsValid():
+        return "?"
+    # libc++
+    libcxx = member.GetChildMemberWithName("__a_")
+    if libcxx.IsValid():
+        v = libcxx.GetChildMemberWithName("__a_value")
+        if v.IsValid():
+            return f"{v.GetValueAsFloat():.4g}"
+    # libstdc++
+    libstd = member.GetChildMemberWithName("_M_i")
+    if libstd.IsValid():
+        return f"{libstd.GetValueAsFloat():.4g}"
+    # Apple libc++ legacy
+    fallback = member.GetChildMemberWithName("__val_")
+    if fallback.IsValid():
+        return f"{fallback.GetValueAsFloat():.4g}"
+    return "?"
+
+
+def param_value_summary(valobj, internal_dict):
+    """Formatter for pulp::state::ParamValue."""
+    value = _atomic_float(valobj, "value_")
+    mod = _atomic_float(valobj, "mod_offset_")
+    if mod == "0" or mod == "0.0000" or mod == "0.000" or mod == "?" or mod == "0":
+        return f"{value}"
+    return f"{value} (mod={mod})"
+
+
+def param_info_summary(valobj, internal_dict):
+    """Formatter for pulp::state::ParamInfo."""
+    pid = valobj.GetChildMemberWithName("id").GetValueAsUnsigned()
+    name = valobj.GetChildMemberWithName("name").GetSummary() or "?"
+    unit = valobj.GetChildMemberWithName("unit").GetSummary() or ""
+    return f"id={pid} name={name} unit={unit}"
+
+
+def param_range_summary(valobj, internal_dict):
+    """Formatter for pulp::state::ParamRange."""
+    lo = valobj.GetChildMemberWithName("min").GetValueAsFloat()
+    hi = valobj.GetChildMemberWithName("max").GetValueAsFloat()
+    dv = valobj.GetChildMemberWithName("default_value").GetValueAsFloat()
+    step = valobj.GetChildMemberWithName("step").GetValueAsFloat()
+    step_part = f" step={step:.4g}" if step > 0 else ""
+    return f"[{lo:.4g}..{hi:.4g}] default={dv:.4g}{step_part}"
+
+
+def state_store_summary(valobj, internal_dict):
+    """Formatter for pulp::state::StateStore — surfaces param count."""
+    params = valobj.GetChildMemberWithName("params_")
+    if not params.IsValid():
+        return "StateStore"
+    n = params.GetNumChildren()
+    return f"StateStore ({n} params)"
+
+
+def rect_summary(valobj, internal_dict):
+    """Formatter for pulp::canvas::Rect."""
+    x = valobj.GetChildMemberWithName("x").GetValueAsFloat()
+    y = valobj.GetChildMemberWithName("y").GetValueAsFloat()
+    w = valobj.GetChildMemberWithName("w").GetValueAsFloat()
+    h = valobj.GetChildMemberWithName("h").GetValueAsFloat()
+    return f"{{ x={x:.3g} y={y:.3g} w={w:.3g} h={h:.3g} }}"
+
+
+def point_summary(valobj, internal_dict):
+    """Formatter for pulp::canvas::Point."""
+    x = valobj.GetChildMemberWithName("x").GetValueAsFloat()
+    y = valobj.GetChildMemberWithName("y").GetValueAsFloat()
+    return f"({x:.3g}, {y:.3g})"
+
+
+def color_summary(valobj, internal_dict):
+    """Formatter for pulp::canvas::Color (RGBA)."""
+    r = valobj.GetChildMemberWithName("r").GetValueAsUnsigned()
+    g = valobj.GetChildMemberWithName("g").GetValueAsUnsigned()
+    b = valobj.GetChildMemberWithName("b").GetValueAsUnsigned()
+    a = valobj.GetChildMemberWithName("a").GetValueAsUnsigned()
+    return f"rgba({r}, {g}, {b}, {a})"
+
+
+def buffer_view_summary(valobj, internal_dict):
+    """Formatter for pulp::audio::BufferView<T>. Includes a 16-sample
+    sparkline of the first channel when reachable."""
+    ch = valobj.GetChildMemberWithName("num_channels").GetValueAsSigned()
+    fr = valobj.GetChildMemberWithName("num_frames").GetValueAsSigned()
+    if ch <= 0 or fr <= 0:
+        return f"BufferView {ch}ch x {fr} frames"
+
+    spark = ""
+    try:
+        data = valobj.GetChildMemberWithName("channel_data_")
+        if data.IsValid():
+            first_ch = data.GetChildAtIndex(0)
+            if first_ch.IsValid():
+                blocks = "▁▂▃▄▅▆▇█"
+                stride = max(1, fr // 16)
+                samples = []
+                for i in range(0, min(fr, 16 * stride), stride):
+                    sample_obj = first_ch.Cast(first_ch.GetType()).GetPointeeData(i, 1)
+                    err = lldb.SBError()
+                    raw = sample_obj.GetFloat(err, 0)
+                    if err.Success():
+                        # Map [-1, 1] to [0, 7]
+                        idx = max(0, min(7, int((raw + 1.0) * 3.5)))
+                        samples.append(blocks[idx])
+                if samples:
+                    spark = " [" + "".join(samples) + "]"
+    except Exception:
+        pass
+
+    return f"BufferView {ch}ch x {fr} frames{spark}"
+
+
+def listener_token_summary(valobj, internal_dict):
+    """Formatter for pulp::state::ListenerToken."""
+    tid = valobj.GetChildMemberWithName("id_").GetValueAsUnsigned()
+    if tid == 0:
+        return "empty"
+    return f"token #{tid}"
+
+
+# ─── Registration ───────────────────────────────────────────────────────────
+
+def __lldb_init_module(debugger, internal_dict):
+    """Wire each formatter to its LLDB type. Called by LLDB on import."""
+    cat = "pulp"
+    debugger.HandleCommand(
+        f'type category define -l c++ {cat}'
+    )
+
+    def reg(typename, func):
+        debugger.HandleCommand(
+            f'type summary add -F pulp_lldb.{func} '
+            f'-w {cat} -x "^{typename}$"'
+        )
+
+    reg(r"pulp::state::ParamValue", "param_value_summary")
+    reg(r"pulp::state::ParamInfo", "param_info_summary")
+    reg(r"pulp::state::ParamRange", "param_range_summary")
+    reg(r"pulp::state::StateStore", "state_store_summary")
+    reg(r"pulp::state::ListenerToken", "listener_token_summary")
+    reg(r"pulp::canvas::Rect", "rect_summary")
+    reg(r"pulp::canvas::Point", "point_summary")
+    reg(r"pulp::canvas::Color", "color_summary")
+    reg(r"pulp::audio::BufferView<.+>", "buffer_view_summary")
+
+    debugger.HandleCommand(f'type category enable {cat}')
+    print(f"[pulp_lldb] Pulp LLDB formatters registered "
+          f"(category '{cat}', 9 types).")
+
+
+# Import lldb lazily so `python3 pulp_lldb.py --help`-style discovery
+# from CI scripts doesn't fail on systems without lldb installed.
+try:
+    import lldb  # noqa: F401  (used by buffer_view_summary)
+except ImportError:
+    pass

--- a/tools/debug/pulp_lldb.py
+++ b/tools/debug/pulp_lldb.py
@@ -79,11 +79,15 @@ def state_store_summary(valobj, internal_dict):
 
 
 def rect_summary(valobj, internal_dict):
-    """Formatter for pulp::canvas::Rect."""
+    """Formatter for pulp::canvas::Rect.
+
+    Fields per core/canvas/include/pulp/canvas/rectangle_list.hpp:12 —
+    `x`, `y`, `width`, `height` (not `w`/`h`).
+    """
     x = valobj.GetChildMemberWithName("x").GetValueAsFloat()
     y = valobj.GetChildMemberWithName("y").GetValueAsFloat()
-    w = valobj.GetChildMemberWithName("w").GetValueAsFloat()
-    h = valobj.GetChildMemberWithName("h").GetValueAsFloat()
+    w = valobj.GetChildMemberWithName("width").GetValueAsFloat()
+    h = valobj.GetChildMemberWithName("height").GetValueAsFloat()
     return f"{{ x={x:.3g} y={y:.3g} w={w:.3g} h={h:.3g} }}"
 
 
@@ -104,23 +108,27 @@ def color_summary(valobj, internal_dict):
 
 
 def buffer_view_summary(valobj, internal_dict):
-    """Formatter for pulp::audio::BufferView<T>. Includes a 16-sample
-    sparkline of the first channel when reachable."""
-    ch = valobj.GetChildMemberWithName("num_channels").GetValueAsSigned()
-    fr = valobj.GetChildMemberWithName("num_frames").GetValueAsSigned()
-    if ch <= 0 or fr <= 0:
-        return f"BufferView {ch}ch x {fr} frames"
+    """Formatter for pulp::audio::BufferView<T>.
+
+    Real members per core/audio/include/pulp/audio/buffer.hpp:70-74 —
+    `channels_` (SampleType* const*), `num_channels_`, `num_samples_`.
+    Includes a 16-sample sparkline of the first channel when reachable.
+    """
+    ch = valobj.GetChildMemberWithName("num_channels_").GetValueAsSigned()
+    samples_n = valobj.GetChildMemberWithName("num_samples_").GetValueAsSigned()
+    if ch <= 0 or samples_n <= 0:
+        return f"BufferView {ch}ch x {samples_n} samples"
 
     spark = ""
     try:
-        data = valobj.GetChildMemberWithName("channel_data_")
+        data = valobj.GetChildMemberWithName("channels_")
         if data.IsValid():
             first_ch = data.GetChildAtIndex(0)
             if first_ch.IsValid():
                 blocks = "▁▂▃▄▅▆▇█"
-                stride = max(1, fr // 16)
+                stride = max(1, samples_n // 16)
                 samples = []
-                for i in range(0, min(fr, 16 * stride), stride):
+                for i in range(0, min(samples_n, 16 * stride), stride):
                     sample_obj = first_ch.Cast(first_ch.GetType()).GetPointeeData(i, 1)
                     err = lldb.SBError()
                     raw = sample_obj.GetFloat(err, 0)
@@ -133,7 +141,7 @@ def buffer_view_summary(valobj, internal_dict):
     except Exception:
         pass
 
-    return f"BufferView {ch}ch x {fr} frames{spark}"
+    return f"BufferView {ch}ch x {samples_n} samples{spark}"
 
 
 def listener_token_summary(valobj, internal_dict):


### PR DESCRIPTION
Tier A Slice 9 of planning/2026-05-18-rt-safety-and-debug-dx.md.

Adds pretty-printers so debuggers show structured Pulp types instead
of raw struct bytes. Two parallel implementations because MSVC's
expression engine and LLDB's Python API don't share code:

  tools/debug/pulp.natvis       — Visual Studio / Windows debuggers
  tools/debug/pulp_lldb.py      — LLDB on macOS / Linux / iOS
  tools/debug/README.md         — load instructions + type list

Types covered:

  * pulp::state::ParamValue       atomic float + atomic mod offset
  * pulp::state::ParamInfo        id / name / unit / range / group
  * pulp::state::ParamRange       [min..max] default + step
  * pulp::state::StateStore       param count summary
  * pulp::state::ListenerToken    RAII handle (#id or "empty")
  * pulp::canvas::Rect            { x y w h } + derived right/bottom
  * pulp::canvas::Point           (x, y)
  * pulp::canvas::Color           rgba(...)
  * pulp::audio::BufferView<T>    channels × frames, plus a
                                  16-sample sparkline of the first
                                  channel in the LLDB version

Sample LLDB output:

  (lldb) p store
  (pulp::state::StateStore) $0 = StateStore (12 params)
  (lldb) p gain_param
  (pulp::state::ParamInfo) $1 = id=1 name="Gain" unit="dB"
  (lldb) p audio_buffer
  (pulp::audio::BufferView<float>) $2 = BufferView 2ch x 512 frames
      [▄▅▆▇█▇▆▅▄▃▂▁▁▂▃▄]

Loading:

  Natvis: drop into
    %USERPROFILE%\Documents\Visual Studio 20XX\Visualizers\
  LLDB: add to ~/.lldbinit
    command script import /path/to/pulp/tools/debug/pulp_lldb.py

Tests-with-fixes note: the natvis schema validates at debugger-load
time and the LLDB script registers at `import` (logs `Pulp LLDB
formatters registered (...)` on success). A fully end-to-end test
would require spinning up MSVC's debugger or LLDB inside CI, which
isn't in the matrix today. The Python file is syntactically valid
(parses with `ast.parse`), and the formatter functions all use the
SBValue / SBType API on documented child names — drift will be
caught the moment someone reaches for them.

Per sudara "Big List of JUCE Tips" #21.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>