### PR TITLE
fix(view): TextEditor single-line snapshot honors horizontal scroll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.146.0
+    VERSION 0.146.1
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/include/pulp/view/text_editor.hpp
+++ b/core/view/include/pulp/view/text_editor.hpp
@@ -140,6 +140,11 @@ public:
     /// origin so IME hosts still get a sane (if non-precise) anchor.
     Rect caret_rect() const;
 
+    /// Current horizontal scroll offset (single-line) or vertical
+    /// scroll (multi-line). Exposed for IME hosts + tests that need to
+    /// reason about visible-vs-logical coordinates.
+    float scroll_offset() const { return scroll_offset_; }
+
 private:
     std::string text_;
     int caret_position_ = 0;     ///< Cursor position (character index)

--- a/core/view/src/text_editor.cpp
+++ b/core/view/src/text_editor.cpp
@@ -630,6 +630,12 @@ void TextEditor::paint(canvas::Canvas& canvas) {
         password_mode,
         /*placeholder_visible=*/display.empty() && !placeholder.empty() && !has_focus(),
     };
+    // Store `inner_x` in scrolled (visual) coordinates so snapshot
+    // readers (`char_index_at_point`, `caret_rect()`,
+    // `firstRectForCharacterRange`) match the painted text — which
+    // draws at `text_inner_x - scroll_offset_`. Cache key includes
+    // `scroll_offset_`, so the snapshot rebuilds when scroll changes.
+    const float visual_inner_x = text_inner_x - scroll_offset_;
     if (!(last_layout_key_ == key) || last_layout_.lines.size() != 1) {
         last_layout_.multi_line = false;
         last_layout_.fallback_char_w = canvas.measure_text("M");
@@ -640,7 +646,7 @@ void TextEditor::paint(canvas::Canvas& canvas) {
         line_snap.top_y = b.y + std::max(0.0f, (b.height - metrics.line_height) * 0.5f);
         line_snap.baseline_y = text_y;
         line_snap.line_height = metrics.line_height > 0.f ? metrics.line_height : font_size_;
-        line_snap.inner_x = text_inner_x;
+        line_snap.inner_x = visual_inner_x;
         line_snap.x_offsets.resize(display.size() + 1);
         line_snap.x_offsets[0] = 0.f;
         float cum = 0.f;
@@ -654,7 +660,7 @@ void TextEditor::paint(canvas::Canvas& canvas) {
         auto& dst = last_layout_.lines.front();
         dst.top_y = b.y + std::max(0.0f, (b.height - metrics.line_height) * 0.5f);
         dst.baseline_y = text_y;
-        dst.inner_x = text_inner_x;
+        dst.inner_x = visual_inner_x;
     }
     const float total_text_w = last_layout_.lines.front().x_offsets.back();
     const float caret_w = last_layout_.lines.front()
@@ -672,6 +678,13 @@ void TextEditor::paint(canvas::Canvas& canvas) {
     }
 
     float text_x = text_inner_x - scroll_offset_;
+    // After the scroll-offset update, re-write the snapshot's
+    // `inner_x` so readers (caret_rect, hit-test, IME) match the
+    // painted origin even on the first paint where scroll_offset_
+    // bumps from 0 to a non-zero value AFTER the snapshot was built.
+    if (!last_layout_.lines.empty()) {
+        last_layout_.lines.front().inner_x = text_x;
+    }
     auto text_primary = resolve_color("text.primary", canvas::Color::hex(0xe0e0e0));
     auto text_secondary = resolve_color("text.secondary", canvas::Color::hex(0x808090));
     auto selection_fill = resolve_color("accent.primary", canvas::Color::rgba8(65, 105, 225, 255));

--- a/test/test_text_editor_multiline.cpp
+++ b/test/test_text_editor_multiline.cpp
@@ -235,3 +235,55 @@ TEST_CASE("TextEditor multi-line click below the last row clamps to the last row
     REQUIRE(editor.caret_pos() >= 5);
     REQUIRE(editor.caret_pos() <= 7);
 }
+
+// ── Single-line horizontal scroll: hit-test + caret_rect must honor it ──
+
+TEST_CASE("TextEditor single-line hit-test honors horizontal scroll offset",
+          "[view][text_editor][multiline]") {
+    TextEditor editor;
+    // Narrow field; long text scrolls left so the leading chars are
+    // clipped out of view.
+    editor.set_bounds({0, 0, 60, 28});
+    editor.on_focus_changed(true);
+    editor.set_text("abcdefghijklmnop");
+    // Caret at end (set_text sets caret_position_ to size when focused),
+    // so scroll_offset_ becomes non-zero on the next paint.
+    prime_layout(editor);
+    REQUIRE(editor.scroll_offset() > 0.0f);
+
+    // Click at the same x where the visible caret lives — the right
+    // edge of the visible area. Pre-fix, this collapsed to ~index 0
+    // because the snapshot's inner_x ignored scroll.
+    const float scroll = editor.scroll_offset();
+    MouseEvent click;
+    click.is_down = true;
+    click.position.x = std::max(9.0f, 2.0f) + scroll + 0.5f * kRecChar;
+    click.position.y = 14.0f;
+    editor.on_mouse_event(click);
+
+    // The clicked position is one glyph past `scroll`px from the
+    // padded inner-x, which in measured coords is index
+    // `(scroll + 0.5*char_w) / char_w`. Confirm the hit-test landed
+    // well past index 0 — bug would collapse to ≤1.
+    const int floor_idx = static_cast<int>(scroll / kRecChar);
+    REQUIRE(editor.caret_pos() >= floor_idx);
+}
+
+TEST_CASE("TextEditor::caret_rect single-line subtracts scroll_offset",
+          "[view][text_editor][multiline]") {
+    TextEditor editor;
+    editor.set_bounds({0, 0, 60, 28});
+    editor.on_focus_changed(true);
+    editor.set_text("abcdefghijklmnop"); // caret at end
+    prime_layout(editor);
+
+    const float scroll = editor.scroll_offset();
+    REQUIRE(scroll > 0.0f);
+
+    auto r = editor.caret_rect();
+    // Caret must land within the visible field bounds. Pre-fix, x was
+    // off by `scroll` px (returned the unscrolled x) so it landed
+    // well beyond bounds.width.
+    REQUIRE(r.x >= 0.0f);
+    REQUIRE(r.x <= editor.bounds().width);
+}


### PR DESCRIPTION
Two unaddressed Codex P1 findings from the merged #2162:

P1 (`text_editor.cpp:783`) — Account for horizontal scroll in single-
line hit testing. When the field overflows and `scroll_offset_ > 0`,
the new snapshot path computed local_x from the unscrolled inner
origin, so clicks collapsed to ~index 0 regardless of pointer
position. The pre-#2162 `char_index_at_x` subtracted scroll;
the snapshot path needs to too.

P1 (`text_editor.cpp:833`) — Return caret_rect in scrolled
coordinates. `caret_rect()` builds `caret_x = row.inner_x + x_offsets`,
but in single-line mode `row.inner_x` was the unscrolled origin, so
the rect drifted right of the rendered caret by `scroll_offset_` px.
Since `firstRectForCharacterRange:` now reads this for IME candidate
positioning, candidate windows could land off-field.

Root cause: the single-line snapshot was built BEFORE the per-paint
`scroll_offset_` recompute, so it captured a stale (often zero)
scroll value. Two-step fix:
1. Initial snapshot build stores `text_inner_x - scroll_offset_`
   (used when scroll is already settled from the prior paint).
2. After the in-paint scroll recompute that may bump `scroll_offset_`
   on the first focused paint of a long string, re-write the
   snapshot's `inner_x` to the new `text_x`. The x_offsets table
   stays valid (offsets are content-relative).

Public API: added `TextEditor::scroll_offset()` getter so IME hosts
and tests can reason about visible-vs-logical coordinates.

Regression coverage in `pulp-test-text-editor-multiline`:
- single-line hit-test in a 60px-wide field with 16 chars: click at
  visible-caret x must NOT collapse to index 0.
- single-line `caret_rect()` x must fall inside `bounds.width` once
  the field has scrolled.

Tests: pulp-test-text-editor (148 / 37) and pulp-test-text-editor-
multiline (29 / 10; up from 24 / 8 baseline) green.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>