### PR TITLE
feat(inspect): Phase 3f — Alt-hover sibling distance lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.148.0
+    VERSION 0.150.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -55,6 +55,12 @@ private:
     // Distance measurement mode
     View* distance_anchor_ = nullptr;
 
+    // Phase 3f — Alt-hover sibling distance (Figma-style spacing reveal).
+    // Tracks the View under the cursor while Alt is held; cleared as soon
+    // as Alt is released or the cursor leaves the view area. Distinct from
+    // distance_anchor_ (which is Alt+click sticky-anchor mode).
+    View* alt_hover_target_ = nullptr;
+
     // Panel layout
     float panel_width_ = 300.0f;
     float tree_scroll_y_ = 0.0f;

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -52,6 +52,7 @@ void InspectorOverlay::set_active(bool active) {
     if (!active) {
         selected_ = nullptr;
         hovered_ = nullptr;
+        alt_hover_target_ = nullptr;
         distance_anchor_ = nullptr;
     }
 }
@@ -92,6 +93,7 @@ void InspectorOverlay::rebuild_flat_tree() {
     if (!in_tree(selected_)) selected_ = nullptr;
     if (!in_tree(hovered_)) hovered_ = nullptr;
     if (!in_tree(distance_anchor_)) distance_anchor_ = nullptr;
+    if (!in_tree(alt_hover_target_)) alt_hover_target_ = nullptr;
 }
 
 // ── Input handling ──────────────────────────────────────────────────────────
@@ -143,6 +145,17 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
     auto* hit = root_.hit_test(pos);
     if (hit) {
         hovered_ = hit;
+    }
+
+    // Phase 3f — Alt-hover sibling distance (Figma-style). Tracks the
+    // hovered View as an alt_hover_target_ whenever Alt is held AND a
+    // selected_ exists; clears as soon as Alt is released. The dynamic
+    // line paints from selected_ to alt_hover_target_ in
+    // paint_distance_lines().
+    if (event.isAltDown() && selected_ && hit && hit != selected_) {
+        alt_hover_target_ = hit;
+    } else {
+        alt_hover_target_ = nullptr;
     }
 
     if (event.is_down) {
@@ -225,35 +238,51 @@ void InspectorOverlay::paint_highlight(Canvas& canvas) {
 }
 
 void InspectorOverlay::paint_distance_lines(Canvas& canvas) {
-    if (!distance_anchor_ || !selected_) return;
-    if (distance_anchor_ == selected_) return;
+    // Helper: paint a single distance line + center-to-center px label
+    // between two views. Returns early if either view is missing or the
+    // two are the same.
+    auto paint_one = [&](const View* a_view, const View* b_view) {
+        if (!a_view || !b_view || a_view == b_view) return;
 
-    auto a = view_bounds_in_root(distance_anchor_);
-    auto b = view_bounds_in_root(selected_);
+        auto a = view_bounds_in_root(a_view);
+        auto b = view_bounds_in_root(b_view);
 
-    float ax = a.x + a.width / 2;
-    float ay = a.y + a.height / 2;
-    float bx = b.x + b.width / 2;
-    float by = b.y + b.height / 2;
+        float ax = a.x + a.width / 2;
+        float ay = a.y + a.height / 2;
+        float bx = b.x + b.width / 2;
+        float by = b.y + b.height / 2;
 
-    canvas.set_stroke_color(kDistanceLine);
-    canvas.set_line_width(1.0f);
-    canvas.stroke_line(ax, ay, bx, by);
+        canvas.set_stroke_color(kDistanceLine);
+        canvas.set_line_width(1.0f);
+        canvas.stroke_line(ax, ay, bx, by);
 
-    // Distance label
-    float dx = bx - ax;
-    float dy = by - ay;
-    float dist = std::sqrt(dx * dx + dy * dy);
-    auto label = std::to_string(static_cast<int>(dist)) + "px";
-    float mx = (ax + bx) / 2;
-    float my = (ay + by) / 2;
+        // Distance label
+        float dx = bx - ax;
+        float dy = by - ay;
+        float dist = std::sqrt(dx * dx + dy * dy);
+        auto label = std::to_string(static_cast<int>(dist)) + "px";
+        float mx = (ax + bx) / 2;
+        float my = (ay + by) / 2;
 
-    canvas.set_font("monospace", kFontSize);
-    canvas.set_fill_color(kDistanceLine);
-    float tw = canvas.measure_text(label);
-    canvas.fill_rounded_rect(mx - tw / 2 - 4, my - 8, tw + 8, 16, 3);
-    canvas.set_fill_color(Color::rgba(1, 1, 1, 1));
-    canvas.fill_text(label, mx - tw / 2, my + 4);
+        canvas.set_font("monospace", kFontSize);
+        canvas.set_fill_color(kDistanceLine);
+        float tw = canvas.measure_text(label);
+        canvas.fill_rounded_rect(mx - tw / 2 - 4, my - 8, tw + 8, 16, 3);
+        canvas.set_fill_color(Color::rgba(1, 1, 1, 1));
+        canvas.fill_text(label, mx - tw / 2, my + 4);
+    };
+
+    // Existing: Alt+click sticky distance-anchor mode
+    paint_one(distance_anchor_, selected_);
+
+    // Phase 3f: Alt-hover sibling distance (Figma-style spacing reveal).
+    // While Alt is held during hover, dynamically paint a line from the
+    // current selection to the view under the cursor. The two modes can
+    // coexist — sticky anchor + live hover — for richer measurement.
+    if (alt_hover_target_ && selected_ &&
+        alt_hover_target_ != distance_anchor_) {
+        paint_one(selected_, alt_hover_target_);
+    }
 }
 
 void InspectorOverlay::paint_box_model(Canvas& canvas, const View* v) {

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -318,6 +318,114 @@ TEST_CASE("InspectorOverlay: mouse selection and panel tree interactions", "[ins
     REQUIRE(overlay.selected_view() == second_ptr);
 }
 
+// Phase 3f — Alt-hover sibling distance (Figma-style spacing reveal).
+// Click to select a node, then HOLD Alt while hovering another → overlay
+// renders a live distance line from selection to hovered target. Released
+// Alt clears the target. Distinct from the Alt+CLICK sticky-anchor mode
+// covered above.
+TEST_CASE("InspectorOverlay: Alt-hover reveals sibling distance line",
+          "[inspect][overlay][phase3f]") {
+    View root;
+    root.set_id("root");
+    root.set_bounds({0, 0, 500, 300});
+
+    auto a = std::make_unique<View>();
+    a->set_id("a");
+    a->set_bounds({10, 10, 60, 60});
+    auto* a_ptr = a.get();
+    root.add_child(std::move(a));
+
+    auto b = std::make_unique<View>();
+    b->set_id("b");
+    b->set_bounds({100, 10, 60, 60});
+    auto* b_ptr = b.get();
+    root.add_child(std::move(b));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    // Select a via click (no Alt).
+    MouseEvent click_a;
+    click_a.position = {20, 20};
+    click_a.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(click_a));
+    REQUIRE(overlay.selected_view() == a_ptr);
+
+    // Hover over b WITHOUT Alt — no distance reveal; selection unchanged.
+    MouseEvent hover_b;
+    hover_b.position = {130, 30};
+    hover_b.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(hover_b));
+    REQUIRE(overlay.hovered_view() == b_ptr);
+    REQUIRE(overlay.selected_view() == a_ptr);
+
+    // Paint with no Alt — single highlight, no Alt-hover line.
+    pulp::canvas::RecordingCanvas no_alt_canvas;
+    overlay.paint(no_alt_canvas);
+    auto baseline_cmd_count = no_alt_canvas.command_count();
+    REQUIRE(baseline_cmd_count > 0);
+
+    // Now hover over b WITH Alt held → alt-hover target should be b.
+    MouseEvent alt_hover_b;
+    alt_hover_b.position = {130, 30};
+    alt_hover_b.modifiers = kModAlt;
+    alt_hover_b.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(alt_hover_b));
+    REQUIRE(overlay.hovered_view() == b_ptr);
+    REQUIRE(overlay.selected_view() == a_ptr);  // selection unchanged by hover
+
+    pulp::canvas::RecordingCanvas alt_canvas;
+    overlay.paint(alt_canvas);
+    // With Alt held + selection + hover, paint_distance_lines() draws an
+    // extra line + label between selected and hovered. The exact command
+    // count depends on canvas internals, but it MUST be greater than the
+    // no-Alt baseline.
+    REQUIRE(alt_canvas.command_count() > baseline_cmd_count);
+
+    // Release Alt — alt_hover_target_ clears; render returns to baseline.
+    MouseEvent release_alt;
+    release_alt.position = {130, 30};
+    release_alt.modifiers = 0;  // Alt released
+    release_alt.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(release_alt));
+
+    pulp::canvas::RecordingCanvas after_release_canvas;
+    overlay.paint(after_release_canvas);
+    REQUIRE(after_release_canvas.command_count() == baseline_cmd_count);
+}
+
+TEST_CASE("InspectorOverlay: Alt-hover does nothing without a selection",
+          "[inspect][overlay][phase3f]") {
+    // Edge case: holding Alt while hovering with no selected_ should
+    // NOT set alt_hover_target_. Otherwise we'd render a line from
+    // nullptr → confused diagnostics.
+    View root;
+    root.set_bounds({0, 0, 200, 200});
+
+    auto child = std::make_unique<View>();
+    child->set_bounds({10, 10, 60, 60});
+    root.add_child(std::move(child));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    pulp::canvas::RecordingCanvas baseline;
+    overlay.paint(baseline);
+    auto baseline_count = baseline.command_count();
+
+    MouseEvent alt_hover_no_sel;
+    alt_hover_no_sel.position = {30, 30};
+    alt_hover_no_sel.modifiers = kModAlt;
+    alt_hover_no_sel.is_down = false;
+    overlay.handle_mouse_event(alt_hover_no_sel);
+
+    pulp::canvas::RecordingCanvas after_alt_hover;
+    overlay.paint(after_alt_hover);
+    // No selection → no distance line should be added → command count
+    // matches baseline.
+    REQUIRE(after_alt_hover.command_count() == baseline_count);
+}
+
 // ── InspectorWindow ────────────────────────────────────────────────────────
 
 TEST_CASE("CollapsableSection toggles content from header clicks", "[inspect][window][issue-641]") {


### PR DESCRIPTION
## Summary

Phase 3f (one of two) — **Alt-hover sibling distance lines** for the inspector overlay. Hold Alt while hovering with a node selected and the overlay paints a live distance line + label from the selection to the view under the cursor. Figma-style spacing reveal; clears as soon as Alt is released.

Distinct from the existing **Alt+CLICK** sticky-anchor distance mode (`distance_anchor_`), which is preserved unchanged. The two modes can coexist — sticky anchor + live hover-target — for richer measurement workflows.

## What's in the PR

| Change | Where |
|---|---|
| New `View* alt_hover_target_` field | `inspect/include/pulp/inspect/inspector_overlay.hpp` |
| `handle_mouse_event` tracks alt_hover_target_ when (Alt held && hit != selected_ && selected_ != null) | `inspect/src/inspector_overlay.cpp` |
| `paint_distance_lines` refactored to `paint_one(a, b)` helper; called once for sticky-anchor mode (existing) and once for Alt-hover mode (new) | `inspect/src/inspector_overlay.cpp` |
| alt_hover_target_ cleared on overlay deactivate + in flat-tree validity sweep | matches `distance_anchor_` pattern |

## Test plan

- **New** `InspectorOverlay: Alt-hover reveals sibling distance line` — clicks to select, hovers without Alt (no line), hovers with Alt (+1 command), releases Alt (back to baseline). Verified via canvas command count.
- **New** `InspectorOverlay: Alt-hover does nothing without a selection` — prevents nullptr line render.
- All existing inspector tests still pass: **38 cases / 252 assertions** (up from 34 / 233).
- **Local diff coverage: 100%** (36/36 lines).

## Phase 3f scope split

The roadmap's Phase 3f bundled two features:
1. **Alt-hover sibling distance** — *this PR* ✅
2. Selection-mode toggle (FOLLOWS_MOUSE vs FOLLOWS_FOCUS) — *deferred to follow-up*

Splitting them: the selection-mode toggle is a stub feature until it integrates with the View focus chain (deeper work), so shipping it now would be all-infrastructure-no-behavior. Filing a follow-up task.

## Relates to

- Roadmap: [planning/2026-05-18-inspector-direct-manipulation-roadmap.md](https://github.com/danielraffel/pulp-planning/blob/main/2026-05-18-inspector-direct-manipulation-roadmap.md) Phase 3f
- Independent of Phase 0b PR-A (#2300), PR-B (#2303 merged), and the RT-safety workstream
