### PR TITLE
refactor(render): extract texture_atlas.hpp impl bodies to .cpp (U-10)

### DIFF
--- a/core/render/CMakeLists.txt
+++ b/core/render/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(pulp-render PRIVATE
     src/render_loop.cpp
     src/draco_decoder.cpp
     src/ktx2_decoder.cpp
+    src/texture_atlas.cpp
 )
 # SDL3 surface is desktop-only (Android uses PulpSurfaceView via JNI)
 if(NOT ANDROID)

--- a/core/render/include/pulp/render/texture_atlas.hpp
+++ b/core/render/include/pulp/render/texture_atlas.hpp
@@ -19,31 +19,7 @@ public:
         : width_(width), height_(height), shelf_y_(0), shelf_h_(0), shelf_x_(0) {}
 
     /// Try to allocate a region of the given size. Returns false if full.
-    bool allocate(int w, int h, Region& out) {
-        if (w <= 0 || h <= 0 || w > width_ || h > height_) return false;
-
-        // Try current shelf
-        if (shelf_x_ + w <= width_ && shelf_y_ + std::max(h, shelf_h_) <= height_) {
-            out = {shelf_x_, shelf_y_, w, h};
-            shelf_x_ += w;
-            shelf_h_ = std::max(shelf_h_, h);
-            return true;
-        }
-
-        // Start new shelf
-        shelf_y_ += shelf_h_;
-        shelf_x_ = 0;
-        shelf_h_ = 0;
-
-        if (shelf_x_ + w <= width_ && shelf_y_ + h <= height_) {
-            out = {shelf_x_, shelf_y_, w, h};
-            shelf_x_ += w;
-            shelf_h_ = h;
-            return true;
-        }
-
-        return false; // Atlas full
-    }
+    bool allocate(int w, int h, Region& out);
 
     void reset() { shelf_y_ = 0; shelf_h_ = 0; shelf_x_ = 0; }
     int width() const { return width_; }
@@ -67,45 +43,14 @@ public:
     };
 
     /// Try to allocate space for an image. Returns the region, or empty on failure.
-    bool allocate(uint64_t key, int w, int h, AtlasPacker::Region& out) {
-        auto it = entries_.find(key);
-        if (it != entries_.end()) {
-            it->second.ref_count++;
-            out = it->second.region;
-            return true;
-        }
-        if (!packer_.allocate(w, h, out)) return false;
-        entries_[key] = {out, 1, 0};
-        return true;
-    }
+    bool allocate(uint64_t key, int w, int h, AtlasPacker::Region& out);
 
-    void release(uint64_t key) {
-        auto it = entries_.find(key);
-        if (it != entries_.end() && it->second.ref_count > 0) {
-            --it->second.ref_count;
-        }
-    }
+    void release(uint64_t key);
 
     /// Evict entries not used since the given frame.
-    size_t evict_stale(uint64_t current_frame, uint64_t max_age = 120) {
-        size_t evicted = 0;
-        for (auto it = entries_.begin(); it != entries_.end(); ) {
-            if (it->second.ref_count == 0 &&
-                current_frame > it->second.last_used_frame &&
-                current_frame - it->second.last_used_frame > max_age) {
-                it = entries_.erase(it);
-                ++evicted;
-            } else {
-                ++it;
-            }
-        }
-        return evicted;
-    }
+    size_t evict_stale(uint64_t current_frame, uint64_t max_age = 120);
 
-    void mark_used(uint64_t key, uint64_t frame) {
-        auto it = entries_.find(key);
-        if (it != entries_.end()) it->second.last_used_frame = frame;
-    }
+    void mark_used(uint64_t key, uint64_t frame);
 
     size_t entry_count() const { return entries_.size(); }
 
@@ -125,36 +70,11 @@ public:
 
     bool has(uint64_t key) const { return entries_.find(key) != entries_.end(); }
 
-    bool allocate(uint64_t key, int& row) {
-        auto it = entries_.find(key);
-        if (it != entries_.end()) {
-            row = it->second.row;
-            return true;
-        }
-        if (next_row_ >= max_rows_) return false;
-        row = next_row_++;
-        entries_[key] = {row, 0};
-        return true;
-    }
+    bool allocate(uint64_t key, int& row);
 
-    void mark_used(uint64_t key, uint64_t frame) {
-        auto it = entries_.find(key);
-        if (it != entries_.end()) it->second.last_used = frame;
-    }
+    void mark_used(uint64_t key, uint64_t frame);
 
-    size_t evict_stale(uint64_t current_frame, uint64_t max_age = 120) {
-        size_t evicted = 0;
-        for (auto it = entries_.begin(); it != entries_.end(); ) {
-            if (current_frame > it->second.last_used &&
-                current_frame - it->second.last_used > max_age) {
-                it = entries_.erase(it);
-                ++evicted;
-            } else {
-                ++it;
-            }
-        }
-        return evicted;
-    }
+    size_t evict_stale(uint64_t current_frame, uint64_t max_age = 120);
 
     size_t entry_count() const { return entries_.size(); }
 
@@ -176,29 +96,11 @@ public:
 
     explicit GlyphAtlas(int size = 1024) : packer_(size, size) {}
 
-    bool allocate(uint64_t glyph_key, int w, int h, AtlasPacker::Region& out) {
-        auto it = entries_.find(glyph_key);
-        if (it != entries_.end()) { out = it->second.region; return true; }
-        if (!packer_.allocate(w, h, out)) return false;
-        entries_[glyph_key] = {out, 0};
-        return true;
-    }
+    bool allocate(uint64_t glyph_key, int w, int h, AtlasPacker::Region& out);
 
-    void mark_used(uint64_t key, uint64_t frame) {
-        auto it = entries_.find(key);
-        if (it != entries_.end()) it->second.last_used = frame;
-    }
+    void mark_used(uint64_t key, uint64_t frame);
 
-    size_t evict_stale(uint64_t current_frame, uint64_t max_age = 300) {
-        size_t evicted = 0;
-        for (auto it = entries_.begin(); it != entries_.end(); ) {
-            if (current_frame > it->second.last_used &&
-                current_frame - it->second.last_used > max_age) {
-                it = entries_.erase(it); ++evicted;
-            } else { ++it; }
-        }
-        return evicted;
-    }
+    size_t evict_stale(uint64_t current_frame, uint64_t max_age = 300);
 
     size_t entry_count() const { return entries_.size(); }
 
@@ -218,29 +120,11 @@ public:
 
     explicit PathAtlas(int size = 2048) : packer_(size, size) {}
 
-    bool allocate(uint64_t path_hash, int w, int h, AtlasPacker::Region& out) {
-        auto it = entries_.find(path_hash);
-        if (it != entries_.end()) { out = it->second.region; return true; }
-        if (!packer_.allocate(w, h, out)) return false;
-        entries_[path_hash] = {out, 0};
-        return true;
-    }
+    bool allocate(uint64_t path_hash, int w, int h, AtlasPacker::Region& out);
 
-    void mark_used(uint64_t key, uint64_t frame) {
-        auto it = entries_.find(key);
-        if (it != entries_.end()) it->second.last_used = frame;
-    }
+    void mark_used(uint64_t key, uint64_t frame);
 
-    size_t evict_stale(uint64_t current_frame, uint64_t max_age = 600) {
-        size_t evicted = 0;
-        for (auto it = entries_.begin(); it != entries_.end(); ) {
-            if (current_frame > it->second.last_used &&
-                current_frame - it->second.last_used > max_age) {
-                it = entries_.erase(it); ++evicted;
-            } else { ++it; }
-        }
-        return evicted;
-    }
+    size_t evict_stale(uint64_t current_frame, uint64_t max_age = 600);
 
     size_t entry_count() const { return entries_.size(); }
 

--- a/core/render/src/texture_atlas.cpp
+++ b/core/render/src/texture_atlas.cpp
@@ -1,0 +1,171 @@
+#include <pulp/render/texture_atlas.hpp>
+
+#include <algorithm>
+
+namespace pulp::render {
+
+// ---------------------------------------------------------------------------
+// AtlasPacker
+// ---------------------------------------------------------------------------
+
+bool AtlasPacker::allocate(int w, int h, Region& out) {
+    if (w <= 0 || h <= 0 || w > width_ || h > height_) return false;
+
+    // Try current shelf
+    if (shelf_x_ + w <= width_ && shelf_y_ + std::max(h, shelf_h_) <= height_) {
+        out = {shelf_x_, shelf_y_, w, h};
+        shelf_x_ += w;
+        shelf_h_ = std::max(shelf_h_, h);
+        return true;
+    }
+
+    // Start new shelf
+    shelf_y_ += shelf_h_;
+    shelf_x_ = 0;
+    shelf_h_ = 0;
+
+    if (shelf_x_ + w <= width_ && shelf_y_ + h <= height_) {
+        out = {shelf_x_, shelf_y_, w, h};
+        shelf_x_ += w;
+        shelf_h_ = h;
+        return true;
+    }
+
+    return false; // Atlas full
+}
+
+// ---------------------------------------------------------------------------
+// ImageAtlas
+// ---------------------------------------------------------------------------
+
+bool ImageAtlas::allocate(uint64_t key, int w, int h, AtlasPacker::Region& out) {
+    auto it = entries_.find(key);
+    if (it != entries_.end()) {
+        it->second.ref_count++;
+        out = it->second.region;
+        return true;
+    }
+    if (!packer_.allocate(w, h, out)) return false;
+    entries_[key] = {out, 1, 0};
+    return true;
+}
+
+void ImageAtlas::release(uint64_t key) {
+    auto it = entries_.find(key);
+    if (it != entries_.end() && it->second.ref_count > 0) {
+        --it->second.ref_count;
+    }
+}
+
+size_t ImageAtlas::evict_stale(uint64_t current_frame, uint64_t max_age) {
+    size_t evicted = 0;
+    for (auto it = entries_.begin(); it != entries_.end(); ) {
+        if (it->second.ref_count == 0 &&
+            current_frame > it->second.last_used_frame &&
+            current_frame - it->second.last_used_frame > max_age) {
+            it = entries_.erase(it);
+            ++evicted;
+        } else {
+            ++it;
+        }
+    }
+    return evicted;
+}
+
+void ImageAtlas::mark_used(uint64_t key, uint64_t frame) {
+    auto it = entries_.find(key);
+    if (it != entries_.end()) it->second.last_used_frame = frame;
+}
+
+// ---------------------------------------------------------------------------
+// GradientAtlas
+// ---------------------------------------------------------------------------
+
+bool GradientAtlas::allocate(uint64_t key, int& row) {
+    auto it = entries_.find(key);
+    if (it != entries_.end()) {
+        row = it->second.row;
+        return true;
+    }
+    if (next_row_ >= max_rows_) return false;
+    row = next_row_++;
+    entries_[key] = {row, 0};
+    return true;
+}
+
+void GradientAtlas::mark_used(uint64_t key, uint64_t frame) {
+    auto it = entries_.find(key);
+    if (it != entries_.end()) it->second.last_used = frame;
+}
+
+size_t GradientAtlas::evict_stale(uint64_t current_frame, uint64_t max_age) {
+    size_t evicted = 0;
+    for (auto it = entries_.begin(); it != entries_.end(); ) {
+        if (current_frame > it->second.last_used &&
+            current_frame - it->second.last_used > max_age) {
+            it = entries_.erase(it);
+            ++evicted;
+        } else {
+            ++it;
+        }
+    }
+    return evicted;
+}
+
+// ---------------------------------------------------------------------------
+// GlyphAtlas
+// ---------------------------------------------------------------------------
+
+bool GlyphAtlas::allocate(uint64_t glyph_key, int w, int h, AtlasPacker::Region& out) {
+    auto it = entries_.find(glyph_key);
+    if (it != entries_.end()) { out = it->second.region; return true; }
+    if (!packer_.allocate(w, h, out)) return false;
+    entries_[glyph_key] = {out, 0};
+    return true;
+}
+
+void GlyphAtlas::mark_used(uint64_t key, uint64_t frame) {
+    auto it = entries_.find(key);
+    if (it != entries_.end()) it->second.last_used = frame;
+}
+
+size_t GlyphAtlas::evict_stale(uint64_t current_frame, uint64_t max_age) {
+    size_t evicted = 0;
+    for (auto it = entries_.begin(); it != entries_.end(); ) {
+        if (current_frame > it->second.last_used &&
+            current_frame - it->second.last_used > max_age) {
+            it = entries_.erase(it); ++evicted;
+        } else { ++it; }
+    }
+    return evicted;
+}
+
+// ---------------------------------------------------------------------------
+// PathAtlas
+// ---------------------------------------------------------------------------
+
+bool PathAtlas::allocate(uint64_t path_hash, int w, int h, AtlasPacker::Region& out) {
+    auto it = entries_.find(path_hash);
+    if (it != entries_.end()) { out = it->second.region; return true; }
+    if (!packer_.allocate(w, h, out)) return false;
+    entries_[path_hash] = {out, 0};
+    return true;
+}
+
+void PathAtlas::mark_used(uint64_t key, uint64_t frame) {
+    auto it = entries_.find(key);
+    if (it != entries_.end()) it->second.last_used = frame;
+}
+
+size_t PathAtlas::evict_stale(uint64_t current_frame, uint64_t max_age) {
+    size_t evicted = 0;
+    for (auto it = entries_.begin(); it != entries_.end(); ) {
+        if (current_frame > it->second.last_used &&
+            current_frame - it->second.last_used > max_age) {
+            it = entries_.erase(it); ++evicted;
+        } else { ++it; }
+    }
+    return evicted;
+}
+
+} // namespace pulp::render

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1710,9 +1710,13 @@ if(PULP_ENABLE_GPU)
 
 endif()
 
-# Texture atlas helpers are header-only; keep this pure test available in
-# GPU-off builds so sanitizer and local coverage lanes do not fetch GPU assets.
-add_executable(pulp-test-texture-atlas test_texture_atlas.cpp)
+# Texture atlas helpers compile cleanly without GPU deps; keep this pure
+# test available in GPU-off builds so sanitizer and local coverage lanes do
+# not fetch GPU assets. The atlas .cpp impl is compiled directly into the
+# test target rather than linking pulp::render (which would pull in Skia/Dawn).
+add_executable(pulp-test-texture-atlas
+    test_texture_atlas.cpp
+    ${CMAKE_SOURCE_DIR}/core/render/src/texture_atlas.cpp)
 target_include_directories(pulp-test-texture-atlas PRIVATE
     ${CMAKE_SOURCE_DIR}/core/render/include)
 target_link_libraries(pulp-test-texture-atlas PRIVATE Catch2::Catch2WithMain)


### PR DESCRIPTION
## Summary

Companion-track item **U-10** from `planning/2026-05-17-refactor-roadmap-final.md`.

Move method bodies out of `core/render/include/pulp/render/texture_atlas.hpp` (279 LOC, NOT a template) into `core/render/src/texture_atlas.cpp`. The header has five atlas classes (`AtlasPacker`, `ImageAtlas`, `GradientAtlas`, `GlyphAtlas`, `PathAtlas`) — every TU that includes this header was recompiling all of them. After this PR the header is just declarations + trivial getters + the (templated) `BufferPool`.

## What stays in the header

- Class declarations
- Struct definitions (`AtlasPacker::Region`, per-atlas `Entry`)
- Member variable declarations
- Trivial inline getters (`width()`, `height()`, `entry_count()`, `has()`, `reset()`)
- The templated `BufferPool<T>` (must stay inline because it's a template)

## What moves to the .cpp

Non-trivial method bodies (~12 methods): `AtlasPacker::allocate`, `ImageAtlas::allocate`, `ImageAtlas::release`, `ImageAtlas::evict_stale`, `ImageAtlas::mark_used`, `GradientAtlas::allocate`, `GradientAtlas::mark_used`, `GradientAtlas::evict_stale`, `GlyphAtlas::allocate`, `GlyphAtlas::mark_used`, `GlyphAtlas::evict_stale`, `PathAtlas::allocate`, `PathAtlas::mark_used`, `PathAtlas::evict_stale`.

## Line counts

| File | Before | After |
|---|---|---|
| `core/render/include/pulp/render/texture_atlas.hpp` | 279 | 163 |
| `core/render/src/texture_atlas.cpp` | 0 | 171 |

## Test plan

- [x] `pulp-render` builds cleanly
- [x] `pulp-test-texture-atlas` builds + 28 cases / 1689 assertions pass
- [x] No public API change (header still exposes the same classes / signatures)

## Build-config note

`pulp-test-texture-atlas` is intentionally kept link-free of `pulp::render` (so it remains usable in GPU-off sanitizer / coverage lanes without fetching Skia/Dawn). The test target now compiles `core/render/src/texture_atlas.cpp` directly into itself rather than linking the full render library — preserves the GPU-off guarantee.

## Provenance

Filed per `planning/2026-05-18-audio-midi-render-audit.md` Finding R-2.

[Generated with Claude Code](https://claude.com/claude-code)