### PR TITLE
fix(canvas): canonicalize signed zero in FontOptions hash (Codex P2 on #2169)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.137.1
+    VERSION 0.137.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/canvas/src/font_options.cpp
+++ b/core/canvas/src/font_options.cpp
@@ -19,11 +19,25 @@ inline std::size_t mix(std::size_t seed, std::size_t v) noexcept {
 }
 
 inline std::size_t hash_float(float f) noexcept {
-    // Hash the bit pattern so +0.0 == -0.0 collide consistently; NaN
-    // hashes are intentionally not normalised because two NaN-bearing
-    // FontOptions values that hash differently is benign for cache keys.
+    // Codex P2 on #2169: `FontOptions::operator==` is `= default`, which
+    // compares each float member with `==`. IEEE-754 says `+0.0f == -0.0f`,
+    // but their bit patterns differ (0x00000000 vs 0x80000000). Hashing
+    // the raw bits violates the hash/equality contract for
+    // `std::hash<FontOptions>` and can cause missed lookups or duplicate
+    // equivalent entries in unordered caches when signed zero appears in
+    // font option inputs. Canonicalize the sign-bit of zero BEFORE memcpy
+    // by working on the bit pattern directly — `if (f == 0.0f) f = 0.0f;`
+    // is unsafe because the compiler can optimize it away.
+    //
+    // NaN hashes are intentionally not normalised — two NaN-bearing
+    // FontOptions values that hash differently is benign (and `operator==`
+    // also reports them as non-equal under IEEE-754).
     std::uint32_t bits;
     std::memcpy(&bits, &f, sizeof(bits));
+    // 0x80000000 is the sign-only -0.0f bit pattern; collapse to +0.0f.
+    if (bits == 0x80000000u) {
+        bits = 0u;
+    }
     return std::hash<std::uint32_t>{}(bits);
 }
 

--- a/test/test_font_options.cpp
+++ b/test/test_font_options.cpp
@@ -82,6 +82,44 @@ TEST_CASE("FontOptions hash includes full resolver cache key",
     REQUIRE(changed.hash() != base.hash());
 }
 
+TEST_CASE("FontOptions hash canonicalizes signed zero on float members",
+          "[canvas][font][options][coverage][issue-2169]") {
+    // Codex P2 on #2169 — `FontOptions::operator==` is `= default` (per-member
+    // float comparison). IEEE-754 reports `+0.0f == -0.0f` as true, so two
+    // FontOptions whose only difference is a signed-zero float field must
+    // ALSO hash equal — otherwise unordered caches keyed on FontOptions
+    // would create duplicate-equivalent entries or miss lookups.
+    //
+    // The float fields in FontOptions are: weight, width, oblique_angle,
+    // size, letter_spacing, word_spacing, and the per-axis value in
+    // variation_axes. Pin every one of them.
+    FontOptions plus;
+    plus.weight = +0.0f;
+    plus.width = +0.0f;
+    plus.oblique_angle = +0.0f;
+    plus.size = +0.0f;
+    plus.letter_spacing = +0.0f;
+    plus.word_spacing = +0.0f;
+    plus.variation_axes = {
+        {make_variation_axis_tag('w', 'g', 'h', 't'), +0.0f},
+    };
+
+    FontOptions minus = plus;
+    minus.weight = -0.0f;
+    minus.width = -0.0f;
+    minus.oblique_angle = -0.0f;
+    minus.size = -0.0f;
+    minus.letter_spacing = -0.0f;
+    minus.word_spacing = -0.0f;
+    minus.variation_axes[0].value = -0.0f;
+
+    // operator== is defaulted, so IEEE-754 semantics apply: signed zeros
+    // compare equal. The hash contract must agree.
+    REQUIRE(plus == minus);
+    REQUIRE(plus.hash() == minus.hash());
+    REQUIRE(std::hash<FontOptions>{}(plus) == std::hash<FontOptions>{}(minus));
+}
+
 TEST_CASE("Font tag helpers pack OpenType tags in byte order",
           "[canvas][font][options][coverage]") {
     REQUIRE(make_font_feature_tag('k', 'e', 'r', 'n') == 0x6B65726Eu);


### PR DESCRIPTION
## Summary

Single-finding follow-up from the 2026-05-18 session-wide Codex review sweep.

Sweep report (full session): `/tmp/pr-comment-sweep-2026-05-18.md`. Across the 18 Pulp PRs touched this session, every Codex P1 against current `origin/main` is already-fixed or covered by previously merged batches (#2308 + #2271 + #2323). Open-PR findings (#2306/#2307/#2311/#2324/#2326) belong inside their own PR branches, not in a main-fix batch. That leaves **one** unaddressed P2 on current `origin/main`.

## The finding

**Codex P2 on #2169 — Canonicalize signed zero before hashing float fields**

> `FontOptions::operator==` uses float equality, so `+0.0f` and `-0.0f` compare equal, but `hash_float` hashes raw bit patterns and produces different hashes for those equal values. That violates the hash/equality contract for `std::hash<FontOptions>` and can cause missed lookups or duplicate-equivalent entries in unordered caches when signed zero appears in font option inputs.

Verified on `origin/main:core/canvas/src/font_options.cpp:21-28`: the existing comment claimed +0.0/-0.0 collide, but `std::memcpy` of the raw bit pattern was producing 0x00000000 vs 0x80000000 — different hashes. `FontOptions::operator==` is `= default`, so by IEEE-754 the two compare equal. Hash/equality contract violated.

## Fix

Bit-level canonicalization in `core/canvas/src/font_options.cpp:hash_float`:

```cpp
std::uint32_t bits;
std::memcpy(&bits, &f, sizeof(bits));
if (bits == 0x80000000u) {       // -0.0f bit pattern
    bits = 0u;                   // → +0.0f
}
return std::hash<std::uint32_t>{}(bits);
```

A naive `if (f == 0.0f) f = 0.0f;` is unsafe because the compiler can elide it (both compare equal). The bit-pattern check is unambiguous. This covers all seven `FontOptions` float fields: `weight`, `width`, `oblique_angle`, `size`, `letter_spacing`, `word_spacing`, and per-axis `variation_axes[].value` — all of which route through `hash_float`.

## Test

New TEST_CASE in `test/test_font_options.cpp`:

```
FontOptions hash canonicalizes signed zero on float members  [issue-2169]
```

Builds an options pair where every float field differs ONLY by the sign of zero; asserts `operator==`, `hash()`, and `std::hash<FontOptions>{}` all agree. The test fails against the pre-fix `hash_float` and passes after.

## Sweep cross-checks

- #2243, #2246, #2249, #2261 — N/A, batched into #2308 (`d0776c277`).
- #2308 own follow-up (P2 detached worker exception) — N/A, merged via #2323 mid-sweep (`29873b4d2`).
- #2169 P1 dispatch registry — N/A, fixed on main (constructor inserts at `widget_bridge.cpp:824`, destructor erases at `:911`).
- #2169 P1 RN/Pencil dispatch — N/A, fixed on main (`widget_bridge.cpp:1333-1349`).
- #2269 — out of scope (CI/Shipyard config) per session constraints.
- #2307/#2311/#2323 — in flight (agent af073e); not re-processed.
- #2306/#2324 — no Codex review comments.
- #2326 — 2 P2s, but those concerns don't yet apply to main (sits on open PR); should be addressed inside #2326's own branch.

## Test plan

- [x] `pulp-test-font-options` green locally on macOS-arm64 with Skia linked — 138 assertions / 13 cases, including new signed-zero case
- [x] Adjacent targets (`pulp-test-canvas-fonts`) build cleanly
- [x] Two-commit pattern: `fix(canvas):` + canonical `chore: bump versions` for the patch SDK bump (0.137.1 → 0.137.2)

Generated with [Claude Code](https://claude.com/claude-code)