### PR TITLE
fix(harness): HtmlAdapter reads element-events split (Codex P2 on #2337)

### DIFF
--- a/tools/harness/adapters/html.py
+++ b/tools/harness/adapters/html.py
@@ -78,10 +78,19 @@ class HtmlAdapter(AdapterBase):
         # second pass after element.js loads), and the legacy
         # web-compat.js bundle (still hosts a few entries). Concatenate
         # them once so the prototype-evidence regex sees the full surface.
+        # P5-7 follow-up (PR #2337) extracted Element.prototype's Event +
+        # Pointer-capture methods (addEventListener / removeEventListener /
+        # dispatchEvent / setPointerCapture / releasePointerCapture /
+        # hasPointerCapture + the synthetic event payloads) into
+        # web-compat-element-events.js. Without it in the union, the
+        # `html/Element_setPointerCapture` oracle false-classifies as
+        # NOT_IMPL (Codex P2 on PR #2337 — same class as #2253's
+        # canvas2d adapter gap fixed by #2317).
         self._element_js = "\n".join(
             self._read(p)
             for p in (
                 "core/view/js/web-compat-element.js",
+                "core/view/js/web-compat-element-events.js",
                 "core/view/js/web-compat-dom-ops.js",
                 "core/view/js/web-compat.js",
             )

--- a/tools/harness/tests/test_html_adapter_element_events_union.py
+++ b/tools/harness/tests/test_html_adapter_element_events_union.py
@@ -1,0 +1,84 @@
+"""Regression test for the HtmlAdapter element-shim union (post-P5-7 split).
+
+Pulp #2337 extracted Element.prototype's Event + Pointer-capture methods
+(addEventListener / removeEventListener / dispatchEvent /
+setPointerCapture / releasePointerCapture) out of
+`web-compat-element.js` into a sibling prelude
+`web-compat-element-events.js`. The harness `HtmlAdapter` previously
+unioned only the parent file + web-compat-dom-ops.js + the legacy
+web-compat.js bundle, so the `html/Element_setPointerCapture` oracle
+would false-classify as NOT_IMPL after the split (Codex P2 on #2337).
+
+This test pins the contract that the adapter's element-shim text is
+the *union* of the four prelude files — if a future split moves a
+prototype method into another file that isn't in the union, this
+fails loudly. Mirrors the canvas2d-adapter regression test from #2317.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.harness.adapters.html import HtmlAdapter  # noqa: E402
+
+
+def _prototype_methods(text: str) -> set[str]:
+    return set(re.findall(r"Element\.prototype\.([A-Za-z_][A-Za-z0-9_]*)\s*=", text))
+
+
+class HtmlAdapterElementEventsUnionTests(unittest.TestCase):
+    """Pin the methods that moved into the extracted prelude."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.adapter = HtmlAdapter(REPO_ROOT)
+        cls.methods = _prototype_methods(cls.adapter._element_js)
+
+    def test_events_prelude_methods_resolve(self) -> None:
+        """Methods moved into web-compat-element-events.js must appear in
+        the union. Without this, html/Element_setPointerCapture (et al.)
+        false-classifies as NOT_IMPL."""
+        moved_to_events_prelude = {
+            "addEventListener",
+            "removeEventListener",
+            "dispatchEvent",
+            "setPointerCapture",
+            "releasePointerCapture",
+        }
+        missing = moved_to_events_prelude - self.methods
+        self.assertFalse(
+            missing,
+            f"HtmlAdapter not unioning web-compat-element-events.js — missing: {sorted(missing)}",
+        )
+
+    def test_parent_element_methods_still_resolve(self) -> None:
+        """Methods that stayed in `web-compat-element.js` must still appear
+        (catches a future split that drops the parent from the union)."""
+        kept_in_parent = {"setAttribute", "removeAttribute", "getBoundingClientRect"}
+        missing = kept_in_parent - self.methods
+        self.assertFalse(
+            missing,
+            f"HtmlAdapter dropped the parent web-compat-element.js — missing: {sorted(missing)}",
+        )
+
+    def test_dom_ops_methods_still_resolve(self) -> None:
+        """Methods from web-compat-dom-ops.js must still appear (catches
+        a future refactor that drops it from the union)."""
+        dom_ops_methods = {"appendChild", "removeChild", "insertBefore", "replaceChild"}
+        missing = dom_ops_methods - self.methods
+        self.assertFalse(
+            missing,
+            f"HtmlAdapter dropped web-compat-dom-ops.js — missing: {sorted(missing)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses **Codex P2 on PR #2337**: HtmlAdapter previously read only `web-compat-element.js` + `web-compat-dom-ops.js` + `web-compat.js`, but #2337 moved Element.prototype's setPointerCapture / addEventListener / etc. into the new sibling `web-compat-element-events.js`. Result: the `html/Element_setPointerCapture` oracle would false-classify as NOT_IMPL.

Same class as #2253 (canvas2d adapter) → #2317 (canvas2d fix). Codex's P2 sweep is catching exactly the pattern.

### Fix
- `tools/harness/adapters/html.py` — `_element_js` now unions four files including the new `web-compat-element-events.js`.

### Regression test
`tools/harness/tests/test_html_adapter_element_events_union.py` pins three directions:
- Methods moved into events prelude must resolve (catches the P2 regression).
- Methods that stayed in the parent file must keep resolving.
- Methods from `web-compat-dom-ops.js` must keep resolving.

3/3 pass.