### PR TITLE
feat(inspect): Performance.setRepaintFlash toggles DirtyTracker overlay

### DIFF
--- a/inspect/include/pulp/inspect/domain_handler.hpp
+++ b/inspect/include/pulp/inspect/domain_handler.hpp
@@ -4,7 +4,7 @@
 #include <pulp/inspect/protocol.hpp>
 
 namespace pulp::view { class View; }
-namespace pulp::render { class RenderPassManager; }
+namespace pulp::render { class RenderPassManager; class DirtyTracker; }
 
 namespace pulp::inspect {
 
@@ -32,6 +32,12 @@ public:
     void set_motion_scrubber(MotionScrubber* scrubber) { motion_scrubber_ = scrubber; }
     void set_render_pass_manager(render::RenderPassManager* rpm) { rpm_ = rpm; }
 
+    /// Tier A Slice 6: wire the per-frame dirty tracker so the inspector's
+    /// Performance tab can toggle `DirtyTracker::set_debug_overlay()` at
+    /// runtime. The host installs the tracker once during plugin / app
+    /// init; if unset, the toggle silently no-ops.
+    void set_dirty_tracker(render::DirtyTracker* dirty) { dirty_ = dirty; }
+
     /// Handle a protocol request. Returns a response message.
     InspectorMessage handle(const InspectorMessage& request);
 
@@ -44,6 +50,7 @@ private:
     MotionInspector* motion_ = nullptr;
     MotionScrubber* motion_scrubber_ = nullptr;
     render::RenderPassManager* rpm_ = nullptr;
+    render::DirtyTracker* dirty_ = nullptr;
 
     // Domain handlers
     InspectorMessage handle_inspector(const InspectorMessage& req);

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -55,6 +55,11 @@ namespace methods {
     constexpr auto kPerfGetMetrics      = "Performance.getMetrics";
     constexpr auto kPerfEnableTracking  = "Performance.enableTracking";
     constexpr auto kPerfMetrics         = "Performance.metrics";
+    // Tier A Slice 6: toggle DirtyTracker::debug_overlay() from the
+    // inspector. Body for set: {"enabled": <bool>}. get returns
+    // {"enabled": <bool>, "available": <bool>}.
+    constexpr auto kPerfSetRepaintFlash = "Performance.setRepaintFlash";
+    constexpr auto kPerfGetRepaintFlash = "Performance.getRepaintFlash";
 
     // State domain
     constexpr auto kStateGetParameters    = "State.getParameters";

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -9,6 +9,7 @@
 #include <pulp/inspect/motion_scrubber.hpp>
 #include <pulp/view/inspector.hpp>
 #include <pulp/view/view.hpp>
+#include <pulp/render/dirty_tracker.hpp>
 #include <pulp/render/render_pass.hpp>
 
 #include <choc/text/choc_JSON.h>
@@ -230,6 +231,43 @@ InspectorMessage DomainHandler::handle_performance(const InspectorMessage& req) 
     if (req.method == methods::kPerfEnableTracking) {
         // Tracking is always on when RenderPassManager exists
         return make_response(req.id, R"({"tracking":true})");
+    }
+    // Tier A Slice 6: per-repaint "flash" overlay. Wraps
+    // DirtyTracker::set_debug_overlay(). When no tracker is wired
+    // we report the toggle as unavailable so the UI can grey it out
+    // instead of silently dropping clicks.
+    if (req.method == methods::kPerfGetRepaintFlash) {
+        auto obj = choc::value::createObject("");
+        if (dirty_) {
+            obj.addMember("available", choc::value::createBool(true));
+            obj.addMember("enabled",
+                          choc::value::createBool(dirty_->debug_overlay()));
+        } else {
+            obj.addMember("available", choc::value::createBool(false));
+            obj.addMember("enabled", choc::value::createBool(false));
+        }
+        return make_response(req.id, choc::json::toString(obj, false));
+    }
+    if (req.method == methods::kPerfSetRepaintFlash) {
+        if (!dirty_) {
+            return make_error(req.id,
+                "Performance.setRepaintFlash: no DirtyTracker attached");
+        }
+        // Parse {"enabled": true|false}. Default to true if absent so a
+        // bare invocation enables (the most common case from a UI toggle).
+        bool enabled = true;
+        try {
+            auto v = choc::json::parse(req.params_json);
+            if (v.isObject() && v.hasObjectMember("enabled")) {
+                enabled = v["enabled"].getBool();
+            }
+        } catch (...) {
+            // Malformed JSON: keep default (enabled = true).
+        }
+        dirty_->set_debug_overlay(enabled);
+        auto obj = choc::value::createObject("");
+        obj.addMember("enabled", choc::value::createBool(enabled));
+        return make_response(req.id, choc::json::toString(obj, false));
     }
     return make_error(req.id, "Unknown Performance method: " + req.method);
 }

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -964,3 +964,55 @@ TEST_CASE("Destroying StateInspector removes its listener (no alive-guard)",
     store.set_value(1, 0.75f);
     REQUIRE_THAT(store.get_value(1), Catch::Matchers::WithinAbs(0.75, 0.001));
 }
+
+// ─── Performance.setRepaintFlash (Tier A Slice 6) ───────────────────────────
+
+#include <pulp/render/dirty_tracker.hpp>
+
+TEST_CASE("Performance.setRepaintFlash toggles DirtyTracker::debug_overlay",
+          "[inspect][perf][repaint-flash]") {
+    pulp::render::DirtyTracker dirty;
+    REQUIRE_FALSE(dirty.debug_overlay());
+
+    DomainHandler handler;
+    handler.set_dirty_tracker(&dirty);
+
+    auto enable_req = make_request(1, methods::kPerfSetRepaintFlash,
+                                   R"({"enabled":true})");
+    auto enable_resp = handler.handle(enable_req);
+    REQUIRE_FALSE(enable_resp.is_error);
+    REQUIRE(dirty.debug_overlay());
+
+    auto get_req = make_request(2, methods::kPerfGetRepaintFlash);
+    auto get_resp = handler.handle(get_req);
+    REQUIRE_FALSE(get_resp.is_error);
+    REQUIRE(get_resp.params_json.find("\"enabled\": true")
+            != std::string::npos);
+    REQUIRE(get_resp.params_json.find("\"available\": true")
+            != std::string::npos);
+
+    auto disable_req = make_request(3, methods::kPerfSetRepaintFlash,
+                                    R"({"enabled":false})");
+    auto disable_resp = handler.handle(disable_req);
+    REQUIRE_FALSE(disable_resp.is_error);
+    REQUIRE_FALSE(dirty.debug_overlay());
+}
+
+TEST_CASE("Performance.setRepaintFlash without a tracker reports unavailable",
+          "[inspect][perf][repaint-flash]") {
+    DomainHandler handler;
+    // Deliberately not calling set_dirty_tracker — the inspector
+    // grew the toggle, but the host process may not have wired one
+    // yet. Behavior: get reports available=false; set returns an
+    // error so the UI can grey out the toggle.
+    auto get_resp = handler.handle(
+        make_request(1, methods::kPerfGetRepaintFlash));
+    REQUIRE_FALSE(get_resp.is_error);
+    REQUIRE(get_resp.params_json.find("\"available\": false")
+            != std::string::npos);
+
+    auto set_resp = handler.handle(
+        make_request(2, methods::kPerfSetRepaintFlash,
+                     R"({"enabled":true})"));
+    REQUIRE(set_resp.is_error);
+}


### PR DESCRIPTION
Tier A Slice 6 of planning/2026-05-18-rt-safety-and-debug-dx.md.

The render layer already has DirtyTracker::set_debug_overlay() — a
flag that draws a fading flash over every per-frame dirty region.
Per sudara "Big List of JUCE Tips" #15 it's the canonical "where's
my repaint storm coming from?" tool, but until this slice the
inspector had no way to flip it at runtime.

Wires two JSON-RPC methods through the existing inspector protocol:

  Performance.setRepaintFlash {"enabled": true|false}
    → DirtyTracker::set_debug_overlay(enabled)
    → Returns {"enabled": <bool>}.

  Performance.getRepaintFlash
    → Returns {"available": <bool>, "enabled": <bool>}.
    → `available=false` when the host hasn't wired a tracker;
       the UI can grey out the toggle in that case.

The plug-in / app host wires the tracker once during init:

    inspect::DomainHandler handler;
    handler.set_dirty_tracker(&my_dirty_tracker);

If unset, get reports available=false and set returns an error
domain so the UI can react cleanly.

Tests (test/test_inspector.cpp, +2 cases):
  - "Performance.setRepaintFlash toggles
     DirtyTracker::debug_overlay": enable → debug_overlay()==true,
     disable → debug_overlay()==false, get round-trips the state.
  - "Performance.setRepaintFlash without a tracker reports
     unavailable": get returns available=false; set returns an
     error message.

38 inspector cases pass locally (250 assertions, +2 cases).

UI Note: this lands the protocol surface. The actual toggle widget
in the inspector overlay JS / header bar consumes
Performance.setRepaintFlash and is the visible part of the slice;
that's a follow-up touch to the inspector overlay JS bundle.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>