### PR TITLE
feat(cli): pulp fmt + .clang-format (Tier A Slice 10)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,56 @@
+# Pulp clang-format config (Tier A Slice 10).
+#
+# LLVM-derived with a 100-column line limit per
+# planning/2026-05-18-rt-safety-and-debug-dx.md. Picked LLVM over Google
+# because LLVM's brace + initializer-list formatting matches what Pulp's
+# core/ subsystems already use; Google's per-line-pragma and short-block
+# rules would force a noisy rewrite of files that have been stable for
+# months.
+#
+# Runtime: `clang-format -i path/...` rewrites in place, or
+# `pulp fmt` (added in the same slice) auto-discovers .cpp/.hpp/.h files
+# in the working tree and runs clang-format with this config.
+
+BasedOnStyle: LLVM
+
+# Pulp's house width.
+ColumnLimit: 100
+
+# 4-space indent matches Slice 1+ work and the existing C++ surface.
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+
+# Allow tight braces for empty function bodies (lots of `= default` /
+# `: base() {}` constructors); keep one line per statement otherwise.
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+
+# Prefer C++17/20 alignment of consecutive assignments, fewer eye-jumps
+# in long parameter / value tables.
+AlignConsecutiveAssignments:
+  Enabled: false
+AlignTrailingComments: true
+
+# Pointer / reference style: `T* p`, `T& r`. Right-most has been the
+# convention since the first commits.
+PointerAlignment: Left
+ReferenceAlignment: Pointer
+
+# Sort headers in groups: own header first, then <system>, then
+# "third-party", then "pulp/*". clang-format's default IncludeBlocks
+# behavior is fine for now; revisit if it diverges from observed
+# patterns.
+SortIncludes: CaseSensitive
+
+# Don't reflow Markdown / docs comments that already wrap at custom
+# column widths.
+ReflowComments: false
+
+# Spaces in modern C++ ranges + initializers.
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceAfterCStyleCast: false
+
+# C++20 `concept` and `requires` show up in the runtime/state layers.
+Standard: c++20

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.147.0
+    VERSION 0.148.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1192,6 +1192,25 @@ Remove the build directory.
 pulp clean
 ```
 
+### fmt
+
+**Status**: usable
+
+Run `clang-format` against Pulp source files using the project root's
+`.clang-format`. Walks `core/`, `examples/`, `inspect/`, `test/`,
+`tools/`, and `ship/` by default, or the path arguments you pass.
+
+```bash
+pulp fmt                        # rewrite all .cpp/.hpp/.h/.mm in place
+pulp fmt path/to/file.cpp ...   # restrict to specific paths
+pulp fmt --dry-run              # report diffs without rewriting
+pulp fmt --check                # CI-friendly alias for --dry-run
+```
+
+`pulp fmt` requires `clang-format` on `PATH`. Skips `build/`, `_deps/`,
+`generated/`, and `external/` so vendored / build-output code is
+untouched.
+
 ### help
 
 Print usage information.

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -308,6 +308,7 @@ int cmd_build(const std::vector<std::string>& args);
 int cmd_test(const std::vector<std::string>& args);
 int cmd_status(const std::vector<std::string>& args);
 int cmd_clean(const std::vector<std::string>& args);
+int cmd_fmt(const std::vector<std::string>& args);
 int cmd_run(const std::vector<std::string>& args);
 int cmd_validate(const std::vector<std::string>& args);
 int cmd_ship(const std::vector<std::string>& args);

--- a/tools/cli/cmd_misc.cpp
+++ b/tools/cli/cmd_misc.cpp
@@ -6,9 +6,15 @@
 #include "cli_common.hpp"
 #include "sdk_cache_paths.hpp"
 
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <vector>
+
+#if defined(__APPLE__) || defined(__linux__)
+#include <sys/wait.h>
+#endif
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
@@ -229,6 +235,134 @@ int cmd_clean([[maybe_unused]] const std::vector<std::string>& args) {
         std::cout << "Nothing to clean.\n";
     }
     return 0;
+}
+
+// ── cmd_fmt ─────────────────────────────────────────────────────────────────
+//
+// Tier A Slice 10: surface clang-format against the project root's
+// .clang-format. Walks `core/`, `examples/`, `inspect/`, `test/`,
+// `tools/`, and `ship/` for .cpp / .hpp / .h / .mm files and runs
+// `clang-format -i` per file. `--dry-run` prints what would change
+// (clang-format --dry-run --Werror, exit 1 on any diff). `--check`
+// is a CI-friendly alias that doesn't rewrite.
+//
+// The .clang-format file landed with this slice (LLVM-derived,
+// 100-col, 4-space indent). See docs/guides/coming-from-juce.md or
+// `.clang-format` itself for the full rules.
+
+int cmd_fmt(const std::vector<std::string>& args) {
+    auto root = resolve_active_project_root(nullptr);
+    if (root.empty()) {
+        std::cerr << "Error: not in a Pulp project directory\n";
+        return 1;
+    }
+    if (!fs::exists(root / ".clang-format")) {
+        std::cerr << "pulp fmt: no .clang-format at project root.\n"
+                     "  Expected: " << (root / ".clang-format").string()
+                  << "\n";
+        return 1;
+    }
+
+    bool dry_run = false;
+    bool check_mode = false;  // alias for --dry-run + non-zero on diff
+    std::vector<std::string> extra_paths;
+    for (const auto& a : args) {
+        if (a == "--dry-run") dry_run = true;
+        else if (a == "--check") { dry_run = true; check_mode = true; }
+        else if (a.rfind("--", 0) == 0) {
+            std::cerr << "pulp fmt: unknown flag: " << a << "\n";
+            std::cerr << "Usage: pulp fmt [--dry-run|--check] [path...]\n";
+            return 2;
+        } else {
+            extra_paths.push_back(a);
+        }
+    }
+
+    // Default tree roots — every project layout we ship has these.
+    // The walk is forgiving: missing dirs are silently skipped so
+    // `pulp fmt` works in plugin scaffolds that don't ship every
+    // top-level directory.
+    std::vector<fs::path> roots;
+    if (extra_paths.empty()) {
+        for (const char* sub : {"core", "examples", "inspect", "test",
+                                "tools", "ship"}) {
+            auto p = root / sub;
+            if (fs::exists(p)) roots.push_back(p);
+        }
+    } else {
+        for (const auto& p : extra_paths) {
+            roots.push_back(fs::absolute(p));
+        }
+    }
+
+    auto is_cpp_source = [](const fs::path& p) {
+        auto ext = p.extension().string();
+        return ext == ".cpp" || ext == ".hpp" || ext == ".h" ||
+               ext == ".mm" || ext == ".cc" || ext == ".cxx";
+    };
+
+    std::vector<fs::path> files;
+    for (const auto& r : roots) {
+        if (!fs::is_directory(r)) {
+            if (fs::is_regular_file(r) && is_cpp_source(r)) {
+                files.push_back(r);
+            }
+            continue;
+        }
+        for (auto it = fs::recursive_directory_iterator(r);
+             it != fs::end(it); ++it) {
+            const auto& p = it->path();
+            // Skip generated / vendored / build directories.
+            auto rel = fs::relative(p, root).string();
+            if (rel.find("/build/") != std::string::npos ||
+                rel.find("/_deps/") != std::string::npos ||
+                rel.find("/generated/") != std::string::npos ||
+                rel.find("/external/") != std::string::npos) {
+                if (it->is_directory()) it.disable_recursion_pending();
+                continue;
+            }
+            if (it->is_regular_file() && is_cpp_source(p)) {
+                files.push_back(p);
+            }
+        }
+    }
+
+    if (files.empty()) {
+        std::cout << "pulp fmt: nothing to format.\n";
+        return 0;
+    }
+
+    std::cout << "pulp fmt: " << files.size()
+              << (dry_run ? " files (dry run)" : " files")
+              << "\n";
+
+    int worst_exit = 0;
+    for (const auto& f : files) {
+        std::string cmd = "clang-format -style=file";
+        if (dry_run) {
+            cmd += " --dry-run --Werror";
+        } else {
+            cmd += " -i";
+        }
+        cmd += " \"" + f.string() + "\"";
+        int rc = std::system(cmd.c_str());
+        const int exit_status = WIFEXITED(rc) ? WEXITSTATUS(rc) : -1;
+        if (exit_status != 0) {
+            if (dry_run) {
+                worst_exit = 1;  // diff detected — keep going
+            } else {
+                std::cerr << "pulp fmt: clang-format failed on "
+                          << f.string() << " (exit " << exit_status << ")\n";
+                worst_exit = exit_status;
+            }
+        }
+    }
+
+    if (check_mode && worst_exit != 0) {
+        std::cerr << "pulp fmt --check: formatting issues detected. "
+                     "Run `pulp fmt` to fix.\n";
+    }
+    return worst_exit;
 }
 
 // ── cmd_cache ───────────────────────────────────────────────────────────────

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -40,6 +40,7 @@ static const Command commands[] = {
     {"design",   "Launch the AI design tool",             cmd_design},
     {"docs",     "Browse local documentation",            cmd_docs},
     {"clean",    "Remove build directory",                cmd_clean},
+    {"fmt",      "Run clang-format on the source tree",   cmd_fmt},
     {"cache",    "Manage SDK and asset cache",            cmd_cache},
     {"audio",    "Repo-level audio model and bundle tooling", cmd_audio},
     {"sdk",      "Manage the Pulp SDK installation",      cmd_sdk},

--- a/tools/scripts/cli_mcp_parity_baseline.json
+++ b/tools/scripts/cli_mcp_parity_baseline.json
@@ -17,6 +17,7 @@
     "docs": "Parent command — actual MCP surface is pulp_docs_check and pulp_docs_search sub-tools",
     "doctor": "Diagnostic CLI; output is human-shaped, not JSON-shaped (see #1997 follow-up)",
     "export-tokens": "Variant of import-design; rarely used; one-shot Bash works",
+    "fmt": "Wraps clang-format -i against .clang-format; agents shell out directly",
     "harness": "Catalog-driven verifier; agents drive via Bash",
     "host": "Long-running synthetic-block runner; not RPC-shaped",
     "import-design": "Heavy multi-step import; agents call the binary directly today (see #1997 follow-up)",


### PR DESCRIPTION
Tier A Slice 10 of planning/2026-05-18-rt-safety-and-debug-dx.md.
sudara "Big List of JUCE Tips" #22.

.clang-format at repo root: LLVM-derived (100-col, 4-space indent,
left-pointer style, C++20). Matches the look of code already on
main rather than forcing a wholesale rewrite. The full rule set
lives in the file with inline comments explaining each opinion.

pulp fmt CLI subcommand:
  pulp fmt              # rewrite all .cpp/.hpp/.h/.mm under
                        # core/ examples/ inspect/ test/ tools/ ship/
  pulp fmt path...      # restrict to specific paths
  pulp fmt --dry-run    # clang-format --dry-run --Werror; non-zero
                        # exit on any diff (useful in CI)
  pulp fmt --check      # alias for --dry-run with a "run pulp fmt
                        # to fix" reminder on failure

Walks the tree, skips build/, _deps/, generated/, and external/
to avoid touching vendored / build-output code. Files are run
individually so a single bad file doesn't abort the rest.

Behavior on missing clang-format: each per-file invocation fails
with the shell's "command not found" — non-zero exit per file
bubbles up. CI lanes that opt in should install clang-format
(GitHub macOS / Linux runners have it preinstalled; an `apt-get
install clang-format` or `brew install clang-format` covers
self-hosted setups).

Help-text + dispatch entry added alongside `clean`, matching the
existing CLI pattern.

Tests-with-fixes note: a focused unit test for cmd_fmt would
need either a fixture clang-format binary on PATH (CI does, this
local box doesn't) or a clang-format mock. The existing
test_cli_shellout.cpp pattern shells out to the real pulp binary,
which means it'd skip on hosts without clang-format. Defer the
dedicated cmd_fmt test to the slice that fixtures clang-format in
the test harness; the new command path is exercised by
build + dispatch sanity at the very least.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Skill-Update: skip skill=cli-maintenance reason="Adds a top-level CLI command (pulp fmt) using the standard cmd_<name>(args) -> int pattern that cli-maintenance SKILL.md already documents. No new CLI maintenance contract introduced."