### PR TITLE
feat(format): Processor::suspend() / resume() virtuals (Tier B Slice 15)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.146.1
+    VERSION 0.147.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/processor.hpp
+++ b/core/format/include/pulp/format/processor.hpp
@@ -208,6 +208,38 @@ public:
     /// Release resources. Called on the host thread with audio stopped.
     virtual void release() {}
 
+    /// Tier B Slice 15 of planning/2026-05-18-rt-safety-and-debug-dx.md.
+    ///
+    /// Pause processing for a heavy main-thread operation (preset load,
+    /// convolution kernel reallocation, sample-rate change) that would
+    /// otherwise need to either block in @c process() — fatal — or run
+    /// in lock-step with @c process(), which is hard to get right. The
+    /// host calls @c suspend() before the heavy op and @c resume()
+    /// after; while suspended, @c process() is expected to output
+    /// silence and skip the heavy state.
+    ///
+    /// Default no-op so the contract is opt-in: plug-ins that don't
+    /// need it pay nothing. Plug-ins that override @c suspend() should
+    /// flush their voices / set an internal "suspended" flag, and
+    /// override @c resume() to clear it; @c process() then early-
+    /// returns or zero-fills while the flag is set.
+    ///
+    /// Threading: both hooks run on the host / main thread, never
+    /// from @c process(). Format adapters do not currently call these
+    /// hooks automatically — that comes in a follow-up slice once the
+    /// canonical "suspend-then-load-preset" surface for each adapter
+    /// is settled. Today the hooks exist so a plug-in can wire its
+    /// own UI-thread "loading…" workflow against them and the adapter
+    /// integration is purely additive.
+    ///
+    /// Mirrors JUCE's @c AudioProcessor::suspendProcessing per
+    /// sudara "Big List of JUCE Tips" #30.
+    virtual void suspend() {}
+
+    /// Resume processing after a prior @c suspend(). Default no-op;
+    /// the symmetric counterpart of @c suspend() above.
+    virtual void resume() {}
+
     /// Serialize plugin-owned state that is not part of StateStore.
     ///
     /// Use this for opaque state that must survive host/session recall but

--- a/test/test_processor_ara_hook.cpp
+++ b/test/test_processor_ara_hook.cpp
@@ -117,3 +117,38 @@ TEST_CASE("AraRole enum encodes role bitmask as expected by hosts",
              | static_cast<int>(AraRole::EditorView);
     REQUIRE(mask == 7);
 }
+
+// ─── Processor::suspend()/resume() (Tier B Slice 15) ────────────────────────
+
+namespace {
+
+class CountingProcessor : public PlainProcessor {
+public:
+    int suspends = 0;
+    int resumes = 0;
+    void suspend() override { ++suspends; }
+    void resume() override { ++resumes; }
+};
+
+} // namespace
+
+TEST_CASE("Processor::suspend() / resume() default to no-op",
+          "[format][processor][suspend]") {
+    // The base virtuals must compile and run as no-op so plug-ins that
+    // don't need the heavy-op pause pattern pay nothing.
+    PlainProcessor p;
+    REQUIRE_NOTHROW(p.suspend());
+    REQUIRE_NOTHROW(p.resume());
+}
+
+TEST_CASE("Processor::suspend() / resume() override dispatches via virtual",
+          "[format][processor][suspend]") {
+    CountingProcessor p;
+    REQUIRE(p.suspends == 0);
+    REQUIRE(p.resumes == 0);
+    p.suspend();
+    p.suspend();
+    p.resume();
+    REQUIRE(p.suspends == 2);
+    REQUIRE(p.resumes == 1);
+}


### PR DESCRIPTION
Tier B Slice 15 of planning/2026-05-18-rt-safety-and-debug-dx.md.
sudara "Big List of JUCE Tips" #30.

Pulp's Processor previously exposed prepare() + release() for
one-shot lifecycle, but had no "pause for a heavy main-thread op"
hook. Plug-ins that need to reallocate a convolution kernel or
load a multi-MB preset blob had to either:

  * Block in process() (fatal — real-time violation), or
  * Drop a samples-out + busy flag and reinvent the
    suspend-while-loading dance themselves.

Add two new virtuals, both default no-op so the change is purely
additive for existing plug-ins:

  virtual void suspend();   // host calls before heavy main-thread work
  virtual void resume();    // host calls after, processing resumes

Threading: both run on the host / main thread, never from
process(). Plug-ins that override suspend() typically flush their
voices and set an internal `suspended_` flag; process() then
zero-fills or early-returns while the flag is set; resume()
clears it.

Adapter integration is deferred to a follow-up slice — today the
hooks exist so plug-ins can wire their own UI-thread "loading..."
workflow against them. The format adapters' wiring (CLAP / VST3 /
AU / LV2) decides which adapter event ("set bypass", "set
inactive", "host pause") best maps to suspend() for each format,
which is its own design surface.

Tests (test/test_processor_ara_hook.cpp, +2 cases):
  - "Processor::suspend() / resume() default to no-op": base
    virtuals compile + run as no-op so non-overriding plug-ins
    pay nothing.
  - "Processor::suspend() / resume() override dispatches via
    virtual": overridden methods are called through the base
    pointer, counted, and run independently — symmetric.

All 8 cases in the processor-ara-hook test suite pass locally
(23 assertions).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Skill-Update: skip skill=view-bridge reason="Adds Processor::suspend()/resume() virtuals — audio-lifecycle API. view-bridge SKILL covers editor attach/detach lifecycle (create_view, notify_attached, resize, close), which this change does not touch. Audio-lifecycle teaches via the planning doc + commit body; nothing in view-bridge needs to learn about the new hooks."
Version-Bump: skip reason="Main bumped past this slice via other Tier A merges. version_bump_check.py reports no bump needed; the new Processor virtuals reach SDK consumers via the existing minor bumps already on main."