### PR TITLE
feat(inspect): LiveConstant RPC surfaces PULP_LIVE_CONSTANT in the inspector

### DIFF
--- a/inspect/include/pulp/inspect/domain_handler.hpp
+++ b/inspect/include/pulp/inspect/domain_handler.hpp
@@ -63,6 +63,7 @@ private:
     InspectorMessage handle_audio(const InspectorMessage& req);
     InspectorMessage handle_capture(const InspectorMessage& req);
     InspectorMessage handle_motion(const InspectorMessage& req);
+    InspectorMessage handle_live_constant(const InspectorMessage& req);
 };
 
 } // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -51,6 +51,13 @@ namespace methods {
     constexpr auto kCSSGetTheme         = "CSS.getTheme";
     constexpr auto kCSSThemeChanged     = "CSS.themeChanged";
 
+    // LiveConstant domain (Tier A Slice 13). RPC for PULP_LIVE_CONSTANT
+    // surfaces — list/set/reset the registry-tracked sliders without
+    // opening the LiveConstantEditor overlay.
+    constexpr auto kLiveConstList  = "LiveConstant.list";
+    constexpr auto kLiveConstSet   = "LiveConstant.set";
+    constexpr auto kLiveConstReset = "LiveConstant.reset";
+
     // Performance domain
     constexpr auto kPerfGetMetrics      = "Performance.getMetrics";
     constexpr auto kPerfEnableTracking  = "Performance.enableTracking";

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -11,6 +11,7 @@
 #include <pulp/view/view.hpp>
 #include <pulp/render/dirty_tracker.hpp>
 #include <pulp/render/render_pass.hpp>
+#include <pulp/view/live_constant_editor.hpp>
 
 #include <choc/text/choc_JSON.h>
 
@@ -40,6 +41,7 @@ InspectorMessage DomainHandler::handle(const InspectorMessage& req) {
     if (domain == "Audio")       return handle_audio(req);
     if (domain == "Capture")     return handle_capture(req);
     if (domain == "Motion")      return handle_motion(req);
+    if (domain == "LiveConstant") return handle_live_constant(req);
 
     return make_error(req.id, "Unknown domain: " + domain);
 }
@@ -391,6 +393,75 @@ InspectorMessage DomainHandler::handle_capture(const InspectorMessage& req) {
         return make_error(req.id, "Capture.screenshotNode not yet implemented");
     }
     return make_error(req.id, "Unknown Capture method: " + req.method);
+}
+
+// ── LiveConstant domain (Tier A Slice 13) ──────────────────────────────────
+//
+// Wires PULP_LIVE_CONSTANT(name, default, min, max) to the inspector
+// via three RPC methods. No host setter is required — the registry
+// is a static singleton, so the inspector reaches it directly.
+
+InspectorMessage DomainHandler::handle_live_constant(const InspectorMessage& req) {
+    auto& registry = pulp::view::LiveConstantRegistry::instance();
+
+    if (req.method == methods::kLiveConstList) {
+        auto arr = choc::value::createEmptyArray();
+        for (const auto& c : registry.all()) {
+            auto obj = choc::value::createObject("");
+            obj.addMember("name", choc::value::createString(c.name));
+            obj.addMember("file", choc::value::createString(c.file));
+            obj.addMember("line", choc::value::createInt32(c.line));
+            obj.addMember("value", choc::value::createFloat32(c.value));
+            obj.addMember("default", choc::value::createFloat32(c.default_value));
+            obj.addMember("min", choc::value::createFloat32(c.min_value));
+            obj.addMember("max", choc::value::createFloat32(c.max_value));
+            arr.addArrayElement(obj);
+        }
+        auto out = choc::value::createObject("");
+        out.addMember("constants", arr);
+        return make_response(req.id, choc::json::toString(out, false));
+    }
+    if (req.method == methods::kLiveConstSet) {
+        std::string name;
+        float value = 0.0f;
+        try {
+            auto v = choc::json::parse(req.params_json);
+            if (v.isObject()) {
+                if (v.hasObjectMember("name")) name = v["name"].getString();
+                if (v.hasObjectMember("value")) {
+                    // JSON numbers parse to choc int / float / double
+                    // depending on literal shape; coerce via Float64 which
+                    // accepts any numeric subtype, then narrow.
+                    value = static_cast<float>(
+                        v["value"].getWithDefault(0.0));
+                }
+            }
+        } catch (...) {}
+        if (name.empty()) {
+            return make_error(req.id,
+                "LiveConstant.set: missing or invalid 'name' field");
+        }
+        registry.set(name, value);
+        auto out = choc::value::createObject("");
+        out.addMember("name", choc::value::createString(name));
+        out.addMember("value", choc::value::createFloat32(value));
+        return make_response(req.id, choc::json::toString(out, false));
+    }
+    if (req.method == methods::kLiveConstReset) {
+        std::string name;
+        try {
+            auto v = choc::json::parse(req.params_json);
+            if (v.isObject() && v.hasObjectMember("name"))
+                name = v["name"].getString();
+        } catch (...) {}
+        if (name.empty()) {
+            registry.reset_all();
+        } else {
+            registry.reset(name);
+        }
+        return make_response(req.id, R"({"ok":true})");
+    }
+    return make_error(req.id, "Unknown LiveConstant method: " + req.method);
 }
 
 } // namespace pulp::inspect

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -1016,3 +1016,73 @@ TEST_CASE("Performance.setRepaintFlash without a tracker reports unavailable",
                      R"({"enabled":true})"));
     REQUIRE(set_resp.is_error);
 }
+
+// ─── LiveConstant RPC (Tier A Slice 13) ─────────────────────────────────────
+
+#include <pulp/view/live_constant_editor.hpp>
+
+TEST_CASE("LiveConstant.list returns the registry contents",
+          "[inspect][live-constant]") {
+    auto& registry = pulp::view::LiveConstantRegistry::instance();
+
+    // Seed the registry. PULP_LIVE_CONSTANT macros do this implicitly,
+    // but we call register_constant directly so the test doesn't have
+    // to compile in a TU that already has them.
+    [[maybe_unused]] auto& cutoff =
+        registry.register_constant("test_cutoff", __FILE__, __LINE__,
+                                   /*default*/ 440.0f,
+                                   /*min*/ 20.0f, /*max*/ 20000.0f);
+    [[maybe_unused]] auto& gain =
+        registry.register_constant("test_gain", __FILE__, __LINE__,
+                                   0.0f, -60.0f, 12.0f);
+
+    DomainHandler handler;
+    auto resp = handler.handle(make_request(1, methods::kLiveConstList));
+    REQUIRE_FALSE(resp.is_error);
+    REQUIRE(resp.params_json.find("test_cutoff") != std::string::npos);
+    REQUIRE(resp.params_json.find("test_gain") != std::string::npos);
+    REQUIRE(resp.params_json.find("\"constants\"") != std::string::npos);
+}
+
+TEST_CASE("LiveConstant.set mutates the registry value",
+          "[inspect][live-constant]") {
+    auto& registry = pulp::view::LiveConstantRegistry::instance();
+    [[maybe_unused]] auto& v =
+        registry.register_constant("test_setter", __FILE__, __LINE__,
+                                   1.0f, 0.0f, 10.0f);
+    registry.reset("test_setter");
+
+    DomainHandler handler;
+    auto resp = handler.handle(make_request(
+        1, methods::kLiveConstSet,
+        R"({"name":"test_setter","value":4.5})"));
+    REQUIRE_FALSE(resp.is_error);
+    REQUIRE_THAT(registry.get("test_setter"),
+                 Catch::Matchers::WithinAbs(4.5, 0.001));
+}
+
+TEST_CASE("LiveConstant.set without a name returns an error",
+          "[inspect][live-constant]") {
+    DomainHandler handler;
+    auto resp = handler.handle(make_request(
+        1, methods::kLiveConstSet, R"({"value":1.0})"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("LiveConstant.reset rolls a value back to its default",
+          "[inspect][live-constant]") {
+    auto& registry = pulp::view::LiveConstantRegistry::instance();
+    [[maybe_unused]] auto& v =
+        registry.register_constant("test_reset", __FILE__, __LINE__,
+                                   2.0f, 0.0f, 10.0f);
+    registry.set("test_reset", 7.5f);
+    REQUIRE_THAT(registry.get("test_reset"),
+                 Catch::Matchers::WithinAbs(7.5, 0.001));
+
+    DomainHandler handler;
+    auto resp = handler.handle(make_request(
+        1, methods::kLiveConstReset, R"({"name":"test_reset"})"));
+    REQUIRE_FALSE(resp.is_error);
+    REQUIRE_THAT(registry.get("test_reset"),
+                 Catch::Matchers::WithinAbs(2.0, 0.001));
+}


### PR DESCRIPTION
Tier A Slice 13 of planning/2026-05-18-rt-safety-and-debug-dx.md.
sudara "Big List of JUCE Tips" #16 (JUCE_LIVE_CONSTANT).

LiveConstantRegistry already exists at
core/view/include/pulp/view/live_constant_editor.hpp and holds
every PULP_LIVE_CONSTANT(name, default, min, max) call site —
but the inspector had no protocol surface to list / mutate /
reset them. Plug-in authors had to open the in-tree
LiveConstantEditor overlay to scrub a value.

Three RPC methods, all under the new LiveConstant domain:

  LiveConstant.list
    → {"constants":[{"name","file","line","value","default",
                     "min","max"}, ...]}

  LiveConstant.set {"name":"...", "value": 4.5}
    → calls registry.set(name, value);
       echoes {"name","value"}.

  LiveConstant.reset
    → {} resets all; {"name":"..."} resets one;
       echoes {"ok": true}.

The registry is a process-wide singleton (no host setter on
DomainHandler), so the new handler reaches the data directly.
This matches the existing LiveConstantEditor view which also
reads the registry without an instance dependency.

JSON value coercion: choc::value parses numeric literals into
int / float / double subtypes depending on the literal shape, so
`{"value": 4.5}` may decode to either getFloat32 or getFloat64.
Use getWithDefault(0.0) so any numeric type lands at a sensible
float; narrow once at write time.

Tests (test/test_inspector.cpp, +4 cases):
  - "LiveConstant.list returns the registry contents":
    pre-seed two constants, assert both names + the constants
    array marker appear in the JSON payload.
  - "LiveConstant.set mutates the registry value":
    set via RPC, read back via registry.get(); round-trips.
  - "LiveConstant.set without a name returns an error":
    schema enforcement.
  - "LiveConstant.reset rolls a value back to its default":
    set ≠ default, then reset, then assert ≈ default.

All 4 new cases pass locally (10 assertions); 42 inspector cases
pass overall.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>