### PR TITLE
chore(deps): bump shipyard 0.58.0 → 0.59.0 for Phase 2 watch diagnostics (#310)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -603,6 +603,18 @@ can act on it without parsing the human text. Source design:
 `https://github.com/danielraffel/Shipyard/issues/303` + the codex-
 vetted comment thread there.
 
+## Phase 2 watch diagnostics (>= v0.59.0)
+
+Shipyard v0.59.0 (Shipyard PR #310, 2026-05-19) extends `shipyard
+watch --pr N --follow` to surface the same structured failure block
+on every terminal-failure transition observed during the poll. The
+watch loop caches diagnostics by `(target, run_id)` so at most one
+log fetch per transition fires for the lifetime of one watch
+invocation. Reuses Phase 1's 256 KB log-tail cap. Both human and
+JSON modes carry the diagnostics. Lets you chain
+`shipyard pr && shipyard watch --pr <N>` and stop babysitting the
+GitHub UI on slow CI runs.
+
 ## Recovery + maintenance toolkit (>= v0.56.2)
 
 Three operational commands cover the prevention → recovery → maintenance

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -293,10 +293,18 @@
 #   metadata through the validation pipeline so the failing-job URL is
 #   actually correct (was previously overwritten by Shipyard's internal
 #   job id). Adds optional `[targets.<name>] failure_parser = "..."`
-#   config knob (ctest|catch2|pytest|go|auto). Phase 2 (`shipyard watch`
-#   enrichment) and Phase 3 (sandboxed `failure_parser_cmd` escape
-#   hatch) tracked separately. See Shipyard PR #304 / issue #303.
-version = "v0.58.0"
+#   config knob (ctest|catch2|pytest|go|auto). See Shipyard PR #304 /
+#   issue #303.
+#
+# v0.59.0 — Phase 2 watch diagnostics (Shipyard #310). Extends
+#   `shipyard watch --pr N --follow` to emit the same structured
+#   failure block (job URL + failing step + parsed test footer) on
+#   every terminal-failure transition, in both human and JSON modes.
+#   Cache keyed on (target, run_id) ensures at-most-one log fetch per
+#   transition for the lifetime of the watch invocation. Reuses Phase 1's
+#   256 KB log-tail cap. Phase 3 (sandboxed `failure_parser_cmd` escape
+#   hatch) still deferred. See Shipyard PR #310.
+version = "v0.59.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
## Summary

Bumps `tools/shipyard.toml` pin v0.58.0 → v0.59.0 for Shipyard's Phase 2 watch diagnostics (Shipyard PR #310, closes issue #303 Phase 2).

## What v0.59.0 adds

`shipyard watch --pr N --follow` now surfaces the same structured failure block (job URL + failing step + parsed test footer) that v0.58.0 added to `shipyard pr` / `shipyard ship`. Both human and JSON modes carry the diagnostics. Cache keyed on `(target, run_id)` ensures at-most-one log fetch per terminal-failure transition.

## Plan v0.58.0 → v0.59.0 path

`v0.59.0` is the next minor; only Phase 2 watch diagnostics landed between v0.58.0 and v0.59.0 — no breaking changes, no migration steps.

## Test plan

- [x] `tools/shipyard.toml` updated.
- [x] `.agents/skills/ci/SKILL.md` updated with the Phase 2 section.
- [x] Tip commit carries the `Skill-Update: skip skill=engine` trailer (path map flags the SKILL.md change against the engine skill which isn't affected here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)