### PR TITLE
fix(tools): unblock merge queue — add .clang-format to pollution allowlist

### DIFF
--- a/tools/scripts/source_tree_pollution_check.py
+++ b/tools/scripts/source_tree_pollution_check.py
@@ -65,6 +65,7 @@ ALLOWED_ROOT_PATHS = frozenset({
     ".agents",
     ".claude",
     ".claude-plugin",
+    ".clang-format",
     ".gitattributes",
     ".githooks",
     ".github",


### PR DESCRIPTION
## Bug

`.clang-format` landed in PR #2350 (Tier A Slice 10) but `tools/scripts/source_tree_pollution_check.py`'s `ALLOWED_ROOT_PATHS` was not updated. **Every PR currently fails its pollution-check job** with:

```
[source-tree-pollution] BLOCKED (root-allowlist):
  .clang-format: unexpected top-level path. If this is legitimate, add it to ALLOWED_ROOT_PATHS in tools/scripts/source_tree_pollution_check.py in the same PR.
```

This blocks the entire merge queue.

## Fix

Add `.clang-format` to the hidden-config-metadata section of the allowlist (alphabetically between `.claude-plugin` and `.gitattributes`). 1-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)