### PR TITLE
fix(inspect+view): codex P1+P2 follow-ups on Phase 0b PRs

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -307,7 +307,7 @@ identity. If you write a custom codegen path, preserve this pattern
 so the inspector can still trace identity.
 
 **Phase 0b — `setAnchor()` bridge wiring:** the web-compat codegen
-path *also* emits a functional `setAnchor('<var>', '<anchor>')` call
+path *also* emits a functional `setAnchor(<var>._id, '<anchor>')` call
 after each createElement, AND the call is emitted unconditionally —
 NOT gated on `opts.include_comments`. Rationale: the
 `// @pulp-anchor` trail is cosmetic (for grep / debugging), but
@@ -318,6 +318,18 @@ path, emit both: the comment (gated) for debuggability and the
 setAnchor call (unconditional) for the runtime. The bridge side
 (`WidgetBridge::setAnchor`) is a silent no-op on unknown widget IDs,
 matching the rest of the bridge's tolerance for unmounted ids.
+
+<!-- docs-noise-lint: skip — retained: pins guidance to the PR that introduced the _id contract -->
+**Codex P1 follow-up (#2303):** The first argument to `setAnchor` <!-- docs-noise-lint: skip — retained: pins guidance to the PR that introduced the _id contract -->
+MUST be the element's internal `_id` (the auto-generated `__el_N__`
+that `document.createElement` assigns in `core/view/js/web-compat.js`),
+NOT the generated JS variable name. The bridge keys `widget()` lookup
+on `_id`; passing the var name silently no-ops and breaks the entire
+anchor wiring chain for web-compat imports. Pre-fix codegen emitted
+`setAnchor('var', ...)` (broken); post-fix emits `setAnchor(var._id, ...)`
+(correct). If you write a new codegen variant or a non-web-compat
+shim, ensure whatever id you pass matches the bridge's widget()
+lookup key — not the JS-local variable name.
 
 Native-mode codegen does NOT yet emit `setAnchor` (small follow-up;
 the native codegen has many early-return branches that need each to

--- a/core/view/src/design_import.cpp
+++ b/core/view/src/design_import.cpp
@@ -3569,8 +3569,17 @@ static void generate_node(std::ostringstream& ss, const IRNode& node,
     // even in minified bundles. js_single_quote_escape() is defensive;
     // anchors are typically [a-z0-9:/-] but adapters can supply
     // anything.
+    //
+    // Codex P1 (#2303 follow-up): in web-compat codegen the JS variable
+    // name is NOT the bridge widget id — `document.createElement` (web-
+    // compat.js) auto-generates an internal `__el_N__` id and exposes
+    // it as `<var>._id`. setAnchor must receive that id, not the JS
+    // variable name, otherwise the bridge's `widget(id)` lookup misses
+    // and the anchor wiring silently no-ops. Pass `<var>._id` so the
+    // bridge finds the right widget regardless of whether the user
+    // also called setId() on the element.
     if (node.stable_anchor_id && !node.stable_anchor_id->empty()) {
-        ss << ind << "setAnchor('" << var << "', '"
+        ss << ind << "setAnchor(" << var << "._id, '"
            << js_single_quote_escape(*node.stable_anchor_id) << "');\n";
     }
 

--- a/core/view/src/view.cpp
+++ b/core/view/src/view.cpp
@@ -167,6 +167,18 @@ void View::paint_all(canvas::Canvas& canvas) {
     // pulp::runtime::is_in_no_alloc_scope() to detect violations.
     pulp::runtime::ScopedNoAlloc no_alloc_guard;
 
+    // Phase 3d (Codex P2 follow-up on #2338): time the WHOLE paint_all
+    // body — background, border, gradients, clipping, shadows, layer
+    // setup, the paint() override, AND inset shadows / outlines /
+    // layer restores. The previous implementation timed only the
+    // paint(canvas) call, which made styled containers with no
+    // override (the common case — frames with a background color
+    // dominate a frame) report ~0ns self time. With the outer-scope
+    // timer, self_ns = (outer total) - (children total), which
+    // correctly attributes framework drawing to the view.
+    auto outer_t0 = std::chrono::steady_clock::now();
+    std::chrono::nanoseconds children_dt{0};
+
     canvas.save();
     canvas.translate(bounds_.x, bounds_.y);
 
@@ -467,13 +479,11 @@ void View::paint_all(canvas::Canvas& canvas) {
         }
     }
 
-    // Widget-specific painting — timed for the inspector property
-    // panel (Phase 3d). Records nanoseconds spent INSIDE this view's
-    // own paint(canvas) override only; the children's recursive cost
-    // is timed separately below so the inspector can attribute cleanly.
-    auto self_t0 = std::chrono::steady_clock::now();
+    // Widget-specific painting. (Phase 3d timing moved to wrap the
+    // whole paint_all body — see outer_t0 at the top + write-back at
+    // the bottom. This means `paint(canvas)` no-op overrides on
+    // styled containers still get accurate self-time attribution.)
     paint(canvas);
-    auto self_dt = std::chrono::steady_clock::now() - self_t0;
 
     // Paint children — pulp #972. CSS z-index ordering: stable-sort
     // ascending by z_index() so siblings with equal z keep insertion
@@ -487,17 +497,7 @@ void View::paint_all(canvas::Canvas& canvas) {
     for (View* child : paint_order) {
         child->paint_all(canvas);
     }
-    auto children_dt = std::chrono::steady_clock::now() - children_t0;
-
-    // Write back the timing samples — saturating at uint32_t max so a
-    // pathological frame doesn't wrap. ~4.29s ceiling, far past any
-    // realistic per-view paint budget.
-    auto self_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(self_dt).count();
-    auto total_ns = self_ns + std::chrono::duration_cast<std::chrono::nanoseconds>(children_dt).count();
-    last_paint_self_ns_ = static_cast<std::uint32_t>(
-        std::min<std::int64_t>(self_ns, std::numeric_limits<std::uint32_t>::max()));
-    last_paint_with_children_ns_ = static_cast<std::uint32_t>(
-        std::min<std::int64_t>(total_ns, std::numeric_limits<std::uint32_t>::max()));
+    children_dt = std::chrono::steady_clock::now() - children_t0;
 
     // Inset box shadows paint over the content so the inner darkening
     // shows through children (CSS spec: inset shadows are above the
@@ -576,6 +576,21 @@ void View::paint_all(canvas::Canvas& canvas) {
         canvas.restore();
 
     canvas.restore();
+
+    // Phase 3d timing write-back (Codex P2 #2338 follow-up). Outer
+    // delta covers all framework drawing + paint() + inset shadows +
+    // layer restores. Subtract children to get true self-time even
+    // when the view has no paint() override. Saturating cast at
+    // uint32_t max (~4.29s) so a pathological frame doesn't wrap.
+    auto outer_dt = std::chrono::steady_clock::now() - outer_t0;
+    auto total_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(outer_dt).count();
+    auto children_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(children_dt).count();
+    auto self_ns = total_ns - children_ns;
+    if (self_ns < 0) self_ns = 0;  // defensive against clock skew on a single core
+    last_paint_self_ns_ = static_cast<std::uint32_t>(
+        std::min<std::int64_t>(self_ns, std::numeric_limits<std::uint32_t>::max()));
+    last_paint_with_children_ns_ = static_cast<std::uint32_t>(
+        std::min<std::int64_t>(total_ns, std::numeric_limits<std::uint32_t>::max()));
 }
 
 void View::simulate_click(Point root_pos) {

--- a/inspect/include/pulp/inspect/tweak_store.hpp
+++ b/inspect/include/pulp/inspect/tweak_store.hpp
@@ -120,6 +120,16 @@ public:
     std::optional<BypassValue>
     bypass_for(std::string_view anchor_id) const;
 
+    /// Return every anchor id that currently has a bypass entry,
+    /// regardless of whether it also has tweak records. Used by
+    /// Inspector.listTweaks to surface bypass-only anchors (Codex P2
+    /// follow-up on #2300: a setBypass call on an anchor with no
+    /// active tweaks, or one whose tweaks were later cleared, must
+    /// still show up in the protocol response's `bypassed` map so
+    /// clients and the disk-persistence path (Phase 1) can
+    /// round-trip the bypass state.
+    std::vector<std::string> bypassed_anchors() const;
+
     // ── Phase 1: disk persistence ───────────────────────────────────
 
     /// On-disk schema version. Bumped if/when we ever break the format.

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -144,10 +144,18 @@ InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
         }
 
         auto bypassed_obj = choc::value::createObject("");
-        // Walk every anchor we know about (from tweaks or bypassed)
-        // and surface its bypass state if any.
+        // Codex P2 follow-up on #2300: include bypass-only anchors.
+        // Previously `all_anchors` was populated solely from `records`,
+        // so a setBypass call on an anchor that had no active tweaks
+        // (or whose tweaks were later cleared via Inspector.clearTweaks
+        // without clearing the bypass) never surfaced in the response.
+        // Walk both the tweak-record anchors AND the TweakStore's
+        // bypassed anchors so the protocol can round-trip every bypass
+        // state — critical for the Phase 1 disk-persistence path.
         std::unordered_set<std::string> all_anchors;
         for (auto& rec : records) all_anchors.insert(rec.anchor_id);
+        for (auto& anchor : tweak_store_->bypassed_anchors())
+            all_anchors.insert(std::move(anchor));
         for (auto& anchor : all_anchors) {
             auto b = tweak_store_->bypass_for(anchor);
             if (!b) continue;

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -170,6 +170,14 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
 
     // Check if mouse is in the panel area
     if (point_in_panel(pos)) {
+        // Codex P2 follow-up on #2328: clear Alt-hover state before
+        // panel-entry early-return. Without this, moving from an
+        // Alt-hovered view straight into the inspector panel leaves
+        // `alt_hover_target_` pointing at the previous view and the
+        // overlay keeps drawing the live distance line even though
+        // the cursor has left the view area.
+        alt_hover_target_ = nullptr;
+
         if (event.is_down) {
             // Phase 3b — clicks on numeric values in the property
             // panel enter edit mode. The hit list is populated by the

--- a/inspect/src/tweak_store.cpp
+++ b/inspect/src/tweak_store.cpp
@@ -227,6 +227,14 @@ TweakStore::bypass_for(std::string_view anchor_id) const {
     return it->second;
 }
 
+std::vector<std::string> TweakStore::bypassed_anchors() const {
+    std::lock_guard lock(mtx_);
+    std::vector<std::string> out;
+    out.reserve(bypassed_.size());
+    for (auto& [anchor, _] : bypassed_) out.push_back(anchor);
+    return out;
+}
+
 // ── Disk persistence (Phase 1) ──────────────────────────────────────────
 
 std::string TweakStore::default_tweaks_path() {

--- a/test/test_design_import_anchors.cpp
+++ b/test/test_design_import_anchors.cpp
@@ -421,6 +421,16 @@ TEST_CASE("web-compat codegen emits setAnchor calls per node",
     REQUIRE(js.find("setAnchor(") != std::string::npos);
     REQUIRE(js.find("'figma:0:1'") != std::string::npos);
     REQUIRE(js.find("'figma:0:42'") != std::string::npos);
+
+    // Codex P1 follow-up on #2303: web-compat codegen MUST pass the
+    // element's internal `_id` (web-compat.js's __el_N__ auto-id) to
+    // setAnchor, not the JS variable name. The bridge's widget()
+    // lookup keys on _id; passing the var name silently no-ops and
+    // breaks the whole anchor wiring chain. Regression: there must
+    // be NO `setAnchor('<varname>', ...)` form (single-quoted var)
+    // and at least one `setAnchor(<varname>._id, ...)` form.
+    REQUIRE(js.find("setAnchor('") == std::string::npos);
+    REQUIRE(js.find("._id, '") != std::string::npos);
 }
 
 TEST_CASE("web-compat codegen emits setAnchor even when include_comments=false",

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -426,6 +426,61 @@ TEST_CASE("InspectorOverlay: Alt-hover does nothing without a selection",
     REQUIRE(after_alt_hover.command_count() == baseline_count);
 }
 
+// Codex P2 follow-up on #2328: Alt-hover state must clear when the
+// cursor enters the inspector panel. Otherwise the live distance line
+// keeps drawing from selected_ to a view that's no longer under the
+// cursor.
+TEST_CASE("InspectorOverlay: Alt-hover target clears when cursor enters panel "
+          "(codex P2 #2328 regression)",
+          "[inspect][overlay][phase3f][regression]") {
+    View root;
+    root.set_bounds({0, 0, 600, 400});
+    auto a = std::make_unique<View>();
+    a->set_bounds({10, 10, 60, 60});
+    auto* a_ptr = a.get();
+    root.add_child(std::move(a));
+    auto b = std::make_unique<View>();
+    b->set_bounds({100, 10, 60, 60});
+    auto* b_ptr = b.get();
+    root.add_child(std::move(b));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    // Select a + Alt-hover over b → distance line draws.
+    MouseEvent click_a;
+    click_a.position = {20, 20};
+    click_a.is_down = true;
+    overlay.handle_mouse_event(click_a);
+    REQUIRE(overlay.selected_view() == a_ptr);
+
+    MouseEvent alt_hover_b;
+    alt_hover_b.position = {130, 30};
+    alt_hover_b.modifiers = kModAlt;
+    alt_hover_b.is_down = false;
+    overlay.handle_mouse_event(alt_hover_b);
+    REQUIRE(overlay.hovered_view() == b_ptr);
+
+    pulp::canvas::RecordingCanvas with_line;
+    overlay.paint(with_line);
+    auto with_line_count = with_line.command_count();
+
+    // Move cursor INTO the panel (root.bounds().width - panel_width_;
+    // default panel_width_ = 300, so panel starts at x=300 for a 600-
+    // wide root). Pre-fix: alt_hover_target_ stays set, distance line
+    // still draws. Post-fix: alt_hover_target_ clears, distance line
+    // disappears, command count drops back to baseline.
+    MouseEvent enter_panel;
+    enter_panel.position = {450, 50};
+    enter_panel.modifiers = kModAlt;
+    enter_panel.is_down = false;
+    overlay.handle_mouse_event(enter_panel);
+
+    pulp::canvas::RecordingCanvas after_panel_entry;
+    overlay.paint(after_panel_entry);
+    REQUIRE(after_panel_entry.command_count() < with_line_count);
+}
+
 // ── Phase 0b PR-C-1: gesture-tweak emission via TweakStore ────────────────
 #include <pulp/inspect/tweak_store.hpp>
 #include <choc/containers/choc_Value.h>

--- a/test/test_tweak_store.cpp
+++ b/test/test_tweak_store.cpp
@@ -10,6 +10,7 @@
 
 #include <choc/text/choc_JSON.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -17,6 +18,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 using namespace pulp::inspect;
 
@@ -396,6 +398,72 @@ TEST_CASE("Inspector.listTweaks / clearTweaks / setBypass without store error",
     REQUIRE(h.handle(req(methods::kInspectorClearTweaks, "{}")).is_error);
     REQUIRE(h.handle(req(methods::kInspectorSetBypass,
         R"({"anchorId":"a","value":true})")).is_error);
+}
+
+// Codex P2 follow-up on #2300: listTweaks must include anchors that
+// have ONLY a bypass (no tweak records). Otherwise setBypass on an
+// anchor with no entries — or one whose entries were later cleared
+// via clearTweaks — silently drops out of the protocol response and
+// the Phase 1 disk-persistence path loses the bypass state.
+TEST_CASE("Inspector.listTweaks includes bypass-only anchors (codex P2 #2300)",
+          "[inspect][protocol][listTweaks][regression]") {
+    Fixture f;
+    // Anchor "a" has a tweak; anchor "b" has only a bypass.
+    f.store.apply_tweak("a", "layout.padding",
+                        choc::value::createInt32(12), "drag");
+    f.store.set_bypass("b", true);
+
+    auto resp = f.handler.handle(req(methods::kInspectorListTweaks, "{}"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+
+    // Tweak side reports only anchors with records.
+    REQUIRE(parsed["tweaks"].hasObjectMember("a"));
+    REQUIRE_FALSE(parsed["tweaks"].hasObjectMember("b"));
+    // Bypassed side must report BOTH (a has none here but b has true).
+    REQUIRE(parsed["bypassed"].hasObjectMember("b"));
+    REQUIRE(parsed["bypassed"]["b"].getBool());
+}
+
+TEST_CASE("Inspector.listTweaks reports bypass-only anchor after clearTweaks "
+          "removes its records (codex P2 #2300)",
+          "[inspect][protocol][listTweaks][regression]") {
+    // Tweak on anchor c + a path-bypass on the same anchor. Then
+    // clearTweaks({anchorId: c}) wipes c's tweak entries but leaves
+    // its bypass intact. listTweaks must still surface the bypass.
+    Fixture f;
+    f.store.apply_tweak("c", "layout.padding",
+                        choc::value::createInt32(8), "drag");
+    f.store.set_bypass("c", std::vector<std::string>{"layout.padding"});
+
+    f.handler.handle(req(methods::kInspectorClearTweaks,
+        R"({"anchorId":"c"})"));
+
+    auto resp = f.handler.handle(req(methods::kInspectorListTweaks, "{}"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+
+    REQUIRE_FALSE(parsed["tweaks"].hasObjectMember("c"));
+    REQUIRE(parsed["bypassed"].hasObjectMember("c"));
+    auto bypass_c = parsed["bypassed"]["c"];
+    REQUIRE(bypass_c.isArray());
+    REQUIRE(bypass_c.size() == 1);
+    REQUIRE(bypass_c[0].getString() == "layout.padding");
+}
+
+TEST_CASE("TweakStore::bypassed_anchors enumerates every bypass entry "
+          "regardless of tweak presence (codex P2 #2300)",
+          "[inspect][tweak-store][regression]") {
+    TweakStore s;
+    s.apply_tweak("with-tweak", "x", choc::value::createInt32(1), {});
+    s.set_bypass("with-tweak", true);
+    s.set_bypass("bypass-only", std::vector<std::string>{"layout.gap"});
+
+    auto anchors = s.bypassed_anchors();
+    std::sort(anchors.begin(), anchors.end());
+    REQUIRE(anchors.size() == 2);
+    REQUIRE(anchors[0] == "bypass-only");
+    REQUIRE(anchors[1] == "with-tweak");
 }
 
 TEST_CASE("Inspector.getInfo surfaces tweak_count when a store is attached",

--- a/test/test_view.cpp
+++ b/test/test_view.cpp
@@ -1398,3 +1398,31 @@ TEST_CASE("View::last_paint_*_ns updates on every paint cycle",
     // produce different values frame-to-frame.
     REQUIRE(v->last_paint_self_ns() > 0u);
 }
+
+// Codex P2 follow-up on #2338: paint timing must cover framework-owned
+// drawing (background fills, borders, gradients, layer setup) — not
+// just the paint(canvas) override. A styled View with no paint()
+// override should still report non-zero last_paint_self_ns because
+// background_color painting + layer setup runs inside paint_all().
+TEST_CASE("View::last_paint_self_ns covers framework drawing on no-override views "
+          "(codex P2 #2338 regression)",
+          "[view][paint-timing][phase3d][regression]") {
+    // Use the BASE pulp::view::View (no paint() override) but set a
+    // background color so the framework's background fill runs in
+    // paint_all() between save() and the (no-op) paint() call. The
+    // pre-fix implementation timed only the paint() override and
+    // reported ~0ns; the post-fix implementation times the whole
+    // paint_all body, so we should see > 0ns even for a no-override
+    // styled View.
+    auto v = std::make_unique<pulp::view::View>();
+    v->set_bounds({0, 0, 200, 200});
+    v->set_background_color(pulp::canvas::Color::rgba(0.5f, 0.3f, 0.7f, 1.0f));
+
+    pulp::canvas::RecordingCanvas canvas;
+    v->paint_all(canvas);
+
+    // The whole paint_all body has run on the way out — self_ns must
+    // be > 0 even though paint() was a no-op. Pre-fix this was ~0.
+    REQUIRE(v->last_paint_self_ns() > 0u);
+    REQUIRE(v->last_paint_with_children_ns() >= v->last_paint_self_ns());
+}


### PR DESCRIPTION
## Summary

Bundles 4 Codex review fixes — **1 P1 (silent functional break)** and **3 P2 (correctness gaps)** — across the recent Phase 0b chain. Single PR to amortize CI cost.

| Sev | PR fixed | What was wrong | Fix |
|---|---|---|---|
| **P1** | #2303 | Web-compat `setAnchor` codegen passed JS var name; bridge widget id is `<var>._id` (auto from `web-compat.js`) → silent no-op. Phase 0b's anchor wiring never attached for web-compat imports. | Emit `setAnchor(<var>._id, '<anchor>')` |
| P2 | #2300 | `Inspector.listTweaks` dropped bypass-only anchors (anchors with a bypass but no records) | Added `TweakStore::bypassed_anchors()` enumerator; union both sources |
| P2 | #2328 | `point_in_panel` early-return ran before alt-hover clear → stale distance line when moving from view into panel | Clear `alt_hover_target_` at top of panel branch |
| P2 | #2338 | Paint timer wrapped only `paint(canvas)` override → styled containers with no override reported ~0ns self time | Moved timer to wrap full `paint_all()` body; self_ns = total − children |

## Test plan

5 new regression tests / 19 new assertions across 4 binaries:
- `Inspector.listTweaks includes bypass-only anchors` (3 cases)
- `TweakStore::bypassed_anchors` enumeration (1 case)
- `web-compat codegen uses ._id` (extends existing setAnchor test)
- `View self-timing covers framework drawing on no-override views`
- `Inspector Alt-hover target clears when cursor enters panel`

All 4 affected test binaries green:
- `pulp-test-tweak-store`: **32 cases / 92 assertions**
- `pulp-test-inspector`: **50 cases / 294 assertions**
- `pulp-test-view`: **47 cases / 245 assertions**
- `pulp-test-design-import-anchors`: **24 cases / 85 assertions**

## Relates to

- #2295 Phase 0a (foundation)
- #2300 Phase 0b PR-A (TweakStore + protocol) — P2 fix here
- #2303 Phase 0b PR-B (View::anchor_id + setAnchor bridge) — P1 fix here
- #2328 Phase 3f (Alt-hover) — P2 fix here
- #2338 Phase 3d (paint timing) — P2 fix here
- #2363 Phase 0b PR-C-1 (gesture emit_tweak) — unaffected
- #2367 Phase 0b PR-C-2 (panel dot indicators) — unaffected
