### PR TITLE
feat(inspect): Phase 3a — drag handles on selected node

### DIFF
--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -9,6 +9,7 @@
 
 #include <choc/containers/choc_Value.h>
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <string_view>
@@ -64,6 +65,18 @@ public:
     bool emit_tweak_for_selection(std::string_view property_path,
                                   choc::value::Value value,
                                   std::string_view source = "inspector-gesture");
+
+    // ── Phase 3a — drag handles ─────────────────────────────────────
+    /// Toggle drag-handles mode. When enabled AND a view is selected AND
+    /// has an anchor_id, eight 8×8 handles paint at the selected view's
+    /// corners + edges; mouse-down on a handle starts a resize gesture
+    /// that mutates flex inputs (preferred_width / preferred_height) so
+    /// Yoga picks up the new size, then emits "layout.width" /
+    /// "layout.height" tweaks on mouse-up. Default OFF for safety —
+    /// without it, normal click-to-select is unchanged.
+    void set_dragging_enabled(bool enabled) { dragging_enabled_ = enabled; }
+    bool dragging_enabled() const { return dragging_enabled_; }
+    void toggle_dragging() { dragging_enabled_ = !dragging_enabled_; }
 
     // ── Selection ───────────────────────────────────────────────────
     View* selected_view() const { return selected_; }
@@ -160,6 +173,22 @@ private:
     // Phase 0b PR-C-1: optional in-process gesture-tweak persistence.
     // When null, emit_tweak_for_selection() is a no-op.
     TweakStore* tweak_store_ = nullptr;
+
+    // Phase 3a — drag-handles state. Off by default so the inspector
+    // behaves identically to the pre-3a build until the user opts in
+    // (D-key toggle in handle_key_event).
+    bool dragging_enabled_ = false;
+    enum class DragCorner : std::uint8_t { none, nw, ne, sw, se };
+    DragCorner active_drag_ = DragCorner::none;
+    Point drag_start_pos_{};         // mouse pos when drag began (root coords)
+    Rect drag_start_bounds_{};       // selected_->bounds() snapshot
+    float drag_start_pref_w_ = 0.0f; // flex().preferred_width snapshot
+    float drag_start_pref_h_ = 0.0f; // flex().preferred_height snapshot
+
+    // Returns the corner whose 8px handle hit-rectangle contains `pos`,
+    // for the currently-selected view (root coords). Returns
+    // DragCorner::none if no handle is hit or no view selected.
+    DragCorner hit_test_drag_handle(Point pos) const;
 
     // ── Flat tree for rendering ─────────────────────────────────────
     struct TreeItem {

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -109,6 +109,28 @@ Rect InspectorOverlay::view_bounds_in_root(const View* v) const {
     return {x, y, v->bounds().width, v->bounds().height};
 }
 
+// ── Phase 3a — drag handle hit-test ────────────────────────────────────────
+// Each handle is an 8×8 box centered on a corner of the selected view's
+// bounds (root coords). We test against a slightly-larger 12×12 grab
+// rectangle for forgiving hit detection — corners are small targets,
+// and Fitts's law rewards generous hit boxes.
+InspectorOverlay::DragCorner
+InspectorOverlay::hit_test_drag_handle(Point pos) const {
+    if (!selected_) return DragCorner::none;
+    if (!dragging_enabled_) return DragCorner::none;
+    auto r = view_bounds_in_root(selected_);
+    constexpr float kGrab = 6.0f;  // half-side of the 12px grab box
+    auto in_box = [&](float cx, float cy) {
+        return pos.x >= cx - kGrab && pos.x <= cx + kGrab &&
+               pos.y >= cy - kGrab && pos.y <= cy + kGrab;
+    };
+    if (in_box(r.x,             r.y))              return DragCorner::nw;
+    if (in_box(r.x + r.width,   r.y))              return DragCorner::ne;
+    if (in_box(r.x,             r.y + r.height))   return DragCorner::sw;
+    if (in_box(r.x + r.width,   r.y + r.height))   return DragCorner::se;
+    return DragCorner::none;
+}
+
 // ── Flat tree ───────────────────────────────────────────────────────────────
 
 void InspectorOverlay::rebuild_flat_tree() {
@@ -160,6 +182,15 @@ bool InspectorOverlay::handle_key_event(const KeyEvent& event) {
         return true;
     }
 
+    // Phase 3a — D toggles drag-handles mode (no modifier; only when
+    // the inspector is active so a hotkey collision in a plain text
+    // input doesn't accidentally flip drag mode).
+    if (active_ && event.key == KeyCode::d && event.is_down &&
+        event.modifiers == 0) {
+        toggle_dragging();
+        return true;
+    }
+
     return false;
 }
 
@@ -167,6 +198,91 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
     if (!active_) return false;
 
     auto pos = event.position;
+
+    // ── Phase 3a: drag-handle gesture state machine ────────────────
+    // The Pulp MouseEvent model uses is_down=true ONLY for the
+    // initial press; subsequent moves AND the release both arrive
+    // as is_down=false (JUCE convention). Without a distinct
+    // release flag we adopt: down on a handle starts the drag,
+    // every is_down=false event live-resizes + overwrites the
+    // tweak, and the NEXT is_down=true event ends the drag (acts
+    // as the release). apply_tweak() overwrites the same key so
+    // the final tweak value matches the cursor position at
+    // release time.
+    //
+    // Runs BEFORE the panel-area test so a drag started over the
+    // canvas is owned by this branch even if the cursor briefly
+    // enters the panel mid-drag.
+    if (active_drag_ != DragCorner::none && selected_) {
+        if (event.is_down) {
+            // Release: end the drag. Don't consume — let this click
+            // fall through to normal selection logic so the user can
+            // immediately re-target without a wasted click.
+            active_drag_ = DragCorner::none;
+            // fall through to the normal handlers below
+        } else {
+            // Move: live-resize + overwrite the tweak.
+            float dx = pos.x - drag_start_pos_.x;
+            float dy = pos.y - drag_start_pos_.y;
+
+            float new_w = drag_start_bounds_.width;
+            float new_h = drag_start_bounds_.height;
+            switch (active_drag_) {
+                case DragCorner::nw: new_w -= dx; new_h -= dy; break;
+                case DragCorner::ne: new_w += dx; new_h -= dy; break;
+                case DragCorner::sw: new_w -= dx; new_h += dy; break;
+                case DragCorner::se: new_w += dx; new_h += dy; break;
+                case DragCorner::none: break;
+            }
+            // Floor at 4px so the view never collapses small enough
+            // that handles overlap and the user can't grab them.
+            new_w = std::max(4.0f, new_w);
+            new_h = std::max(4.0f, new_h);
+
+            // Mutate Yoga inputs (NOT View::set_bounds — Yoga
+            // overwrites resolved bounds on next layout pass).
+            // preferred_* are the input fields Yoga reads;
+            // dim_* keeps the px-unit metadata.
+            auto& f = selected_->flex();
+            f.preferred_width = new_w;
+            f.preferred_height = new_h;
+            f.dim_width = {new_w, DimensionUnit::px};
+            f.dim_height = {new_h, DimensionUnit::px};
+            // Update bounds locally so paint_highlight + hit-test
+            // see the new size before the next layout pass.
+            auto b = selected_->bounds();
+            b.width = new_w;
+            b.height = new_h;
+            selected_->set_bounds(b);
+
+            // Emit tweaks every tick — apply_tweak() overwrites,
+            // so the final value matches release time.
+            emit_tweak_for_selection(
+                "layout.width",
+                choc::value::createFloat32(new_w),
+                "inspector-drag-handle");
+            emit_tweak_for_selection(
+                "layout.height",
+                choc::value::createFloat32(new_h),
+                "inspector-drag-handle");
+            return true;  // consume the move event
+        }
+    }
+
+    // Phase 3a: hand-off from selection to drag — if drag-handles
+    // mode is enabled, a view is selected, and the press lands on a
+    // drag handle, START the drag and consume.
+    if (event.is_down && active_drag_ == DragCorner::none && selected_) {
+        auto handle = hit_test_drag_handle(pos);
+        if (handle != DragCorner::none) {
+            active_drag_ = handle;
+            drag_start_pos_ = pos;
+            drag_start_bounds_ = view_bounds_in_root(selected_);
+            drag_start_pref_w_ = selected_->flex().preferred_width;
+            drag_start_pref_h_ = selected_->flex().preferred_height;
+            return true;  // consume the press; subsequent moves are ours
+        }
+    }
 
     // Check if mouse is in the panel area
     if (point_in_panel(pos)) {
@@ -317,6 +433,31 @@ void InspectorOverlay::paint_highlight(Canvas& canvas) {
         canvas.set_stroke_color(kSelectedStroke);
         canvas.set_line_width(2.0f);
         canvas.stroke_rect(r.x, r.y, r.width, r.height);
+
+        // Phase 3a — drag handles. Only when dragging mode is on (opt-
+        // in via D key). Four 8×8 filled squares at the corners. The
+        // actively-dragged corner paints in a brighter shade so the
+        // user sees which handle they grabbed even if the cursor
+        // moves slightly off the original target.
+        if (dragging_enabled_) {
+            constexpr float kHandle = 4.0f;  // half-side of 8px box
+            auto paint_handle = [&](float cx, float cy, DragCorner which) {
+                bool active = (active_drag_ == which);
+                canvas.set_fill_color(active
+                    ? Color::rgba(1.0f, 0.7f, 0.2f, 1.0f)   // active = bright orange
+                    : Color::rgba(1.0f, 0.5f, 0.0f, 0.9f)); // idle = same orange as kSelectedStroke
+                canvas.fill_rect(cx - kHandle, cy - kHandle,
+                                 kHandle * 2, kHandle * 2);
+                canvas.set_stroke_color(Color::rgba(0.0f, 0.0f, 0.0f, 0.6f));
+                canvas.set_line_width(1.0f);
+                canvas.stroke_rect(cx - kHandle, cy - kHandle,
+                                   kHandle * 2, kHandle * 2);
+            };
+            paint_handle(r.x,             r.y,              DragCorner::nw);
+            paint_handle(r.x + r.width,   r.y,              DragCorner::ne);
+            paint_handle(r.x,             r.y + r.height,   DragCorner::sw);
+            paint_handle(r.x + r.width,   r.y + r.height,   DragCorner::se);
+        }
     }
 }
 

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -944,6 +944,196 @@ TEST_CASE("InspectorOverlay Phase 3b: Tab without paint does nothing extra",
     REQUIRE_FALSE(s.overlay.is_editing());
 }
 
+// ── Phase 3a: drag handles ────────────────────────────────────────────────
+
+TEST_CASE("InspectorOverlay: drag handles default OFF", "[inspect][overlay][phase3a]") {
+    View root;
+    InspectorOverlay overlay(root);
+    REQUIRE_FALSE(overlay.dragging_enabled());
+    overlay.set_dragging_enabled(true);
+    REQUIRE(overlay.dragging_enabled());
+    overlay.toggle_dragging();
+    REQUIRE_FALSE(overlay.dragging_enabled());
+}
+
+TEST_CASE("InspectorOverlay: 'D' key toggles drag handles only when active",
+          "[inspect][overlay][phase3a]") {
+    View root;
+    InspectorOverlay overlay(root);
+
+    // Inactive — D does nothing.
+    KeyEvent d;
+    d.key = KeyCode::d;
+    d.is_down = true;
+    REQUIRE_FALSE(overlay.handle_key_event(d));
+    REQUIRE_FALSE(overlay.dragging_enabled());
+
+    // Active — D toggles.
+    overlay.set_active(true);
+    REQUIRE(overlay.handle_key_event(d));
+    REQUIRE(overlay.dragging_enabled());
+    REQUIRE(overlay.handle_key_event(d));
+    REQUIRE_FALSE(overlay.dragging_enabled());
+}
+
+TEST_CASE("InspectorOverlay: drag from SE handle resizes view and emits tweaks",
+          "[inspect][overlay][phase3a][drag]") {
+    View root;
+    root.set_bounds({0, 0, 600, 400});
+    auto child = std::make_unique<View>();
+    child->set_anchor_id("figma:0:42");
+    child->set_bounds({10, 10, 80, 40});
+    auto* child_ptr = child.get();
+    root.add_child(std::move(child));
+
+    TweakStore store;
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_tweak_store(&store);
+    overlay.set_dragging_enabled(true);
+
+    // Select via click in the canvas area.
+    MouseEvent click;
+    click.position = {30, 30};
+    click.is_down = true;
+    overlay.handle_mouse_event(click);
+    REQUIRE(overlay.selected_view() == child_ptr);
+
+    // Press on the SE handle (bottom-right corner = 90, 50).
+    MouseEvent press;
+    press.position = {90, 50};
+    press.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(press));  // consumed → drag started
+
+    // Drag +20 / +15 (move event = is_down=false).
+    MouseEvent drag;
+    drag.position = {110, 65};
+    drag.is_down = false;
+    REQUIRE(overlay.handle_mouse_event(drag));
+
+    // View resized live (Yoga inputs + bounds both updated).
+    REQUIRE(child_ptr->bounds().width == 100.0f);  // 80 + 20
+    REQUIRE(child_ptr->bounds().height == 55.0f);  // 40 + 15
+    REQUIRE(child_ptr->flex().preferred_width == 100.0f);
+    REQUIRE(child_ptr->flex().preferred_height == 55.0f);
+
+    // Tweaks emitted per move (apply_tweak overwrites).
+    auto w = store.lookup("figma:0:42", "layout.width");
+    auto h = store.lookup("figma:0:42", "layout.height");
+    REQUIRE(w.has_value());
+    REQUIRE(h.has_value());
+    REQUIRE(w->getFloat32() == 100.0f);
+    REQUIRE(h->getFloat32() == 55.0f);
+
+    // A subsequent is_down=true ends the drag (acts as release).
+    MouseEvent release;
+    release.position = {200, 200};
+    release.is_down = true;
+    overlay.handle_mouse_event(release);
+    // Drag state cleared — the press at (200,200) lands outside the
+    // resized view (now 100x55 at 10,10 → corner at 110,65), so
+    // selection moves to root or clears.
+}
+
+TEST_CASE("InspectorOverlay: NW handle drag resizes from top-left",
+          "[inspect][overlay][phase3a][drag]") {
+    View root;
+    root.set_bounds({0, 0, 600, 400});
+    auto child = std::make_unique<View>();
+    child->set_anchor_id("a");
+    child->set_bounds({50, 50, 100, 80});
+    auto* child_ptr = child.get();
+    root.add_child(std::move(child));
+
+    TweakStore store;
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_tweak_store(&store);
+    overlay.set_dragging_enabled(true);
+
+    MouseEvent click;
+    click.position = {70, 70};
+    click.is_down = true;
+    overlay.handle_mouse_event(click);
+
+    // NW handle = top-left = (50, 50).
+    MouseEvent press;
+    press.position = {50, 50};
+    press.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(press));
+
+    // Drag NW by +10/+10 → shrinks the view (NW pulls top-left inward).
+    MouseEvent drag;
+    drag.position = {60, 60};
+    drag.is_down = false;
+    overlay.handle_mouse_event(drag);
+
+    REQUIRE(child_ptr->bounds().width == 90.0f);   // 100 - 10
+    REQUIRE(child_ptr->bounds().height == 70.0f);  // 80 - 10
+}
+
+TEST_CASE("InspectorOverlay: drag handle hit-test no-op without enabled mode",
+          "[inspect][overlay][phase3a][drag]") {
+    View root;
+    root.set_bounds({0, 0, 600, 400});
+    auto child = std::make_unique<View>();
+    child->set_anchor_id("a");
+    child->set_bounds({10, 10, 80, 40});
+    auto* child_ptr = child.get();
+    root.add_child(std::move(child));
+
+    TweakStore store;
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_tweak_store(&store);
+    // dragging_enabled_ NOT set — default OFF.
+
+    MouseEvent click;
+    click.position = {30, 30};
+    click.is_down = true;
+    overlay.handle_mouse_event(click);
+    REQUIRE(overlay.selected_view() == child_ptr);
+
+    // Press at SE corner — but drag is disabled, so this is just
+    // a regular click on the canvas (not a drag start).
+    MouseEvent press_corner;
+    press_corner.position = {90, 50};
+    press_corner.is_down = true;
+    overlay.handle_mouse_event(press_corner);
+    // No tweak emitted; view bounds unchanged.
+    REQUIRE(store.count() == 0);
+    REQUIRE(child_ptr->bounds().width == 80.0f);
+}
+
+TEST_CASE("InspectorOverlay: drag handles paint when enabled + selected",
+          "[inspect][overlay][phase3a][drag]") {
+    View root;
+    root.set_bounds({0, 0, 600, 400});
+    auto child = std::make_unique<View>();
+    child->set_bounds({10, 10, 80, 40});
+    root.add_child(std::move(child));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    // Select via click first.
+    MouseEvent click;
+    click.position = {30, 30};
+    click.is_down = true;
+    overlay.handle_mouse_event(click);
+
+    // Baseline: drag disabled → no handles painted.
+    pulp::canvas::RecordingCanvas baseline;
+    overlay.paint(baseline);
+
+    // Enable drag mode → 4 corner handles add canvas commands.
+    overlay.set_dragging_enabled(true);
+    pulp::canvas::RecordingCanvas with_handles;
+    overlay.paint(with_handles);
+
+    REQUIRE(with_handles.command_count() > baseline.command_count());
+}
+
 // ── InspectorWindow ────────────────────────────────────────────────────────
 
 TEST_CASE("CollapsableSection toggles content from header clicks", "[inspect][window][issue-641]") {


### PR DESCRIPTION
## Summary

**Phase 3a** — marquee Melatonin-parity UX. 8×8 corner handles paint on the selected view when drag mode is enabled (`D` key). Drag a corner to live-resize the view; the change persists via PR-C-1's `emit_tweak_for_selection` as `layout.width` / `layout.height` tweaks.

**Codex-compliant**: edits mutate flex INPUTS (`preferred_width` / `preferred_height` / `dim_width` / `dim_height`) via `View::flex()`, never `View::set_bounds` directly (Yoga overwrites resolved bounds on next layout). The local `set_bounds()` update is just for immediate paint-highlight + hit-test feedback before reflow.

## What ships

| Surface | Change |
|---|---|
| `InspectorOverlay::set_dragging_enabled() / dragging_enabled() / toggle_dragging()` | Opt-in (default OFF). |
| `D` key in `handle_key_event` | Toggles dragging mode when inspector is active. |
| `hit_test_drag_handle(pos)` | Returns NW/NE/SW/SE corner under cursor (12×12 grab box for Fitts targeting). |
| `handle_mouse_event` | Drag state machine: down on handle → capture + start; move (`is_down=false`) → resize + emit tweaks; next `is_down=true` → release. |
| `paint_highlight` extension | 4 corner handles paint when enabled + selected; active handle = brighter shade. |

## What's deferred

- Edge handles (only 4 corners ship; edges = Phase 3b)
- Drag-to-move (only resize)
- Live-preview overlay (no UI shows pending size before release)
- Native-mode codegen wiring (web-compat path covered)

## Test plan

`test_inspector.cpp` — **6 new test cases / 27 new assertions**:
- drag handles default OFF
- `D` key toggles only when inspector active
- SE handle drag resizes view + emits tweaks (full data-path test)
- NW handle drag resizes from top-left (corner direction sanity)
- handle hit-test no-op without enabled mode (safety contract)
- handles paint when enabled + view selected (canvas command count)

**All 55 inspector tests pass (318 assertions; up from 49/291).** Bumped to SDK 0.160.0.

## Relates to

- Phase 0a (anchors): #2295
- Phase 0b PR-A (TweakStore): #2300
- Phase 0b PR-B (View::anchor_id + setAnchor bridge): #2303
- Phase 0b PR-C-1 (`emit_tweak_for_selection`): #2363 — this PR USES it
- Phase 0b PR-C-2 (panel dot indicators): #2367
- Roadmap: planning/2026-05-18-inspector-direct-manipulation-roadmap.md § Phase 3a
