### PR TITLE
test(tools): unit tests for version_consistency_check.py

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.84.0",
+      "version": "0.87.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.84.0"
+  "version": "0.87.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.84.0",
+  "version": "0.87.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v01610"></a>
+## [0.161.0] - 2026-05-19
+
+- test(tools): unit tests for version_consistency_check.py — covers the two Codex P2 bug-classes (CHANGELOG advertising un-bumped CMake version, plugin.json vs marketplace plugins[0].version drift) + the harmless reverse-direction window after auto-release bumps CMake before CHANGELOG regen
+
 <a id="v01581"></a>
 ## [0.158.1] - 2026-05-19
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.158.1
+    VERSION 0.161.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/scripts/test_version_consistency_check.py
+++ b/tools/scripts/test_version_consistency_check.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Unit tests for version_consistency_check.py.
+
+Catches the bug-classes the script is meant to detect:
+
+  1. CHANGELOG advertises a version higher than CMakeLists VERSION
+     (the Codex P2 on #2331 — auto-release wouldn't tag, entry sits
+     orphaned).
+  2. plugin.json ≠ marketplace.json top-level version (mismatched
+     bumps).
+  3. plugin.json ≠ marketplace.json plugins[0].version (the Codex P2
+     on #2341 — bump script only updated top-level, nested field
+     went stale).
+
+Also verifies the script does NOT false-flag the harmless reverse
+direction (CMake ahead of CHANGELOG — the brief window between merge
+and the auto-release-bot's CHANGELOG regen).
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+SCRIPT = HERE / "version_consistency_check.py"
+
+
+def _make_repo_layout(
+    td: pathlib.Path,
+    *,
+    cmake_version: str,
+    plugin_version: str,
+    marketplace_top_version: str,
+    marketplace_nested_version: str,
+    changelog_top_version: str,
+) -> None:
+    """Stage all four version-bearing files plus a minimal layout that
+    matches what `version_consistency_check.py` reads."""
+    (td / "CMakeLists.txt").write_text(
+        f"project(Pulp VERSION {cmake_version})\n",
+        encoding="utf-8",
+    )
+    (td / ".claude-plugin").mkdir()
+    (td / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"version": plugin_version}),
+        encoding="utf-8",
+    )
+    (td / ".claude-plugin" / "marketplace.json").write_text(
+        json.dumps({
+            "version": marketplace_top_version,
+            "plugins": [{"version": marketplace_nested_version}],
+        }),
+        encoding="utf-8",
+    )
+    (td / "CHANGELOG.md").write_text(
+        textwrap.dedent(f"""\
+        # Changelog
+
+        ## [{changelog_top_version}] - 2026-05-19
+
+        - test entry
+        """),
+        encoding="utf-8",
+    )
+
+
+def _run_script(repo_root: pathlib.Path) -> subprocess.CompletedProcess:
+    """Invoke version_consistency_check.py against a synthetic repo
+    layout. The script anchors REPO_ROOT to its own parent.parent.parent,
+    so the only sane way to test it against a temp layout is to copy the
+    script into the temp tree at the matching depth."""
+    target_script = repo_root / "tools" / "scripts" / "version_consistency_check.py"
+    target_script.parent.mkdir(parents=True, exist_ok=True)
+    target_script.write_bytes(SCRIPT.read_bytes())
+    return subprocess.run(
+        [sys.executable, str(target_script)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class VersionConsistencyCheckTests(unittest.TestCase):
+    """Each test drops a synthetic four-file layout into a temp dir
+    and invokes the script. Exit code 0 = consistent, 1 = drift."""
+
+    def test_all_aligned_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td = pathlib.Path(td)
+            _make_repo_layout(
+                td,
+                cmake_version="1.2.3",
+                plugin_version="0.5.0",
+                marketplace_top_version="0.5.0",
+                marketplace_nested_version="0.5.0",
+                changelog_top_version="1.2.3",
+            )
+            result = _run_script(td)
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            self.assertIn("version consistency OK", result.stdout)
+
+    def test_changelog_ahead_of_cmake_fails(self) -> None:
+        """The exact P2 from #2331: CHANGELOG entry for unreleased version."""
+        with tempfile.TemporaryDirectory() as td:
+            td = pathlib.Path(td)
+            _make_repo_layout(
+                td,
+                cmake_version="1.2.3",
+                plugin_version="0.5.0",
+                marketplace_top_version="0.5.0",
+                marketplace_nested_version="0.5.0",
+                changelog_top_version="1.3.0",  # ahead of CMake
+            )
+            result = _run_script(td)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn(
+                "CHANGELOG top entry [1.3.0] advertises a version",
+                result.stdout,
+            )
+
+    def test_cmake_ahead_of_changelog_passes(self) -> None:
+        """The harmless reverse direction — the brief window between
+        a merge bumping CMake and the auto-release-bot regenerating
+        CHANGELOG. Must NOT flag, otherwise CI would block every PR
+        for ~minutes after a release-tag fires."""
+        with tempfile.TemporaryDirectory() as td:
+            td = pathlib.Path(td)
+            _make_repo_layout(
+                td,
+                cmake_version="1.3.0",  # ahead of CHANGELOG
+                plugin_version="0.5.0",
+                marketplace_top_version="0.5.0",
+                marketplace_nested_version="0.5.0",
+                changelog_top_version="1.2.3",
+            )
+            result = _run_script(td)
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+    def test_plugin_vs_marketplace_top_mismatch_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            td = pathlib.Path(td)
+            _make_repo_layout(
+                td,
+                cmake_version="1.2.3",
+                plugin_version="0.5.0",
+                marketplace_top_version="0.4.0",  # mismatched
+                marketplace_nested_version="0.5.0",
+                changelog_top_version="1.2.3",
+            )
+            result = _run_script(td)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("plugin.json (0.5.0) != marketplace.json top-level", result.stdout)
+
+    def test_marketplace_nested_vs_top_mismatch_fails(self) -> None:
+        """The exact P2 from #2341: bump touched top-level but left
+        plugins[0].version stale. cmd_version.cpp reads the nested
+        field so this drift is real."""
+        with tempfile.TemporaryDirectory() as td:
+            td = pathlib.Path(td)
+            _make_repo_layout(
+                td,
+                cmake_version="1.2.3",
+                plugin_version="0.5.0",
+                marketplace_top_version="0.5.0",
+                marketplace_nested_version="0.4.0",  # nested stale
+                changelog_top_version="1.2.3",
+            )
+            result = _run_script(td)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("plugins[0].version", result.stdout)
+
+    def test_marketplace_top_vs_nested_drift_emits_two_diagnostics(self) -> None:
+        """When top vs nested disagree AND plugin matches one of them,
+        we should emit BOTH the (plugin != nested) and (top != nested)
+        diagnostics so the reader sees the full picture."""
+        with tempfile.TemporaryDirectory() as td:
+            td = pathlib.Path(td)
+            _make_repo_layout(
+                td,
+                cmake_version="1.2.3",
+                plugin_version="0.5.0",
+                marketplace_top_version="0.5.0",
+                marketplace_nested_version="0.4.0",
+                changelog_top_version="1.2.3",
+            )
+            result = _run_script(td)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn(
+                "plugin.json (0.5.0) != marketplace.json plugins[0].version (0.4.0)",
+                result.stdout,
+            )
+            self.assertIn(
+                "marketplace.json top-level version (0.5.0) != plugins[0].version (0.4.0)",
+                result.stdout,
+            )
+
+    def test_diagnostic_output_includes_all_four_observed_values(self) -> None:
+        """On failure, the script prints all four observed values so a
+        reader can diagnose the drift without re-running the script."""
+        with tempfile.TemporaryDirectory() as td:
+            td = pathlib.Path(td)
+            _make_repo_layout(
+                td,
+                cmake_version="1.2.3",
+                plugin_version="0.5.0",
+                marketplace_top_version="0.5.0",
+                marketplace_nested_version="0.5.0",
+                changelog_top_version="1.3.0",
+            )
+            result = _run_script(td)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("CMakeLists VERSION:", result.stdout)
+            self.assertIn("plugin.json version:", result.stdout)
+            self.assertIn("marketplace top version:", result.stdout)
+            self.assertIn("marketplace plugins[0].version:", result.stdout)
+            self.assertIn("CHANGELOG top entry:", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Per request for **brand-new unit tests on the new boundaries** — this PR adds defensive tests around the `version_consistency_check.py` CI gate (shipped in #2341). That gate is load-bearing for the auto-release pipeline and has *already caught two Codex P2 findings* — but it had no proper unittest.

### What it tests

Each test stages a synthetic 4-file repo layout (`CMakeLists.txt` + `plugin.json` + `marketplace.json` + `CHANGELOG.md`) in a temp dir and invokes the script as a subprocess.

| Test | What it pins |
|------|--------------|
| `test_all_aligned_passes` | Happy path |
| `test_changelog_ahead_of_cmake_fails` | **Exact P2 from #2331** — CHANGELOG announces unreleased version |
| `test_cmake_ahead_of_changelog_passes` | The harmless reverse-direction window — must NOT flag, otherwise CI would block every PR for ~minutes post auto-release-bot regen |
| `test_plugin_vs_marketplace_top_mismatch_fails` | Bump touched plugin but not marketplace top-level |
| `test_marketplace_nested_vs_top_mismatch_fails` | **Exact P2 from #2341** — `cmd_version.cpp` reads `plugins[0].version`; bump only updated top-level |
| `test_marketplace_top_vs_nested_drift_emits_two_diagnostics` | When plugin matches top but nested drifts, both diagnostics surface |
| `test_diagnostic_output_includes_all_four_observed_values` | Failure output gives full picture without re-running |

### Why this PR

The Phase 5 refactor work has been adding *defensive structure* (file-union adapters, consistency gates, regression tests). The user asked for new tests on the new boundaries — `version_consistency_check.py` is the single highest-leverage spot since:

1. It already detected real drift in #2253 / #2331 / #2341.
2. The gate logic has direction-asymmetry that's easy to break (forward bump-after-merge regen window must stay green).
3. No existing unittest — only inline `git stash && run && unstash` manual verification.

Tests run in <300ms total. Pattern follows `tools/scripts/test_version_bump_check_extra.py`.

## Test plan

- [x] `python3 -m unittest tools.scripts.test_version_consistency_check -v` — 7/7 pass
- [x] `python3 tools/scripts/version_consistency_check.py` — main still passes consistency check
- [ ] Lane CI green