### PR TITLE
feat(inspect): editor URI config for source-jump (Phase 5.3)

### DIFF
--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(pulp-inspect PRIVATE
     src/inspector_server.cpp
     src/audio_inspector.cpp
     src/domain_handler.cpp
+    src/editor_url.cpp
     src/motion_inspector.cpp
     src/motion_scrubber.cpp
     src/tweak_store.cpp

--- a/inspect/include/pulp/inspect/domain_handler.hpp
+++ b/inspect/include/pulp/inspect/domain_handler.hpp
@@ -1,6 +1,7 @@
 // domain_handler.hpp — Dispatches inspector protocol requests to data sources
 #pragma once
 
+#include <pulp/inspect/editor_url.hpp>
 #include <pulp/inspect/protocol.hpp>
 
 namespace pulp::view { class View; }
@@ -40,6 +41,14 @@ public:
     /// init; if unset, the toggle silently no-ops.
     void set_dirty_tracker(render::DirtyTracker* dirty) { dirty_ = dirty; }
 
+    // ── Inspector-wide config ───────────────────────────────────────
+    /// Replace the runtime config (Phase 5.3: editor_url_template).
+    /// Mutating accessors below (e.g. Inspector.setEditorUrlTemplate)
+    /// update this in place.
+    void set_config(InspectorConfig config) { config_ = std::move(config); }
+    const InspectorConfig& config() const { return config_; }
+    InspectorConfig& mutable_config() { return config_; }
+
     /// Handle a protocol request. Returns a response message.
     InspectorMessage handle(const InspectorMessage& request);
 
@@ -54,6 +63,7 @@ private:
     render::RenderPassManager* rpm_ = nullptr;
     render::DirtyTracker* dirty_ = nullptr;
     TweakStore* tweak_store_ = nullptr;
+    InspectorConfig config_{};
 
     // Domain handlers
     InspectorMessage handle_inspector(const InspectorMessage& req);

--- a/inspect/include/pulp/inspect/editor_url.hpp
+++ b/inspect/include/pulp/inspect/editor_url.hpp
@@ -1,0 +1,91 @@
+// editor_url.hpp — Inspector source-jump editor URI configuration.
+//
+// Phase 5.3 of the inspector source-jump roadmap
+// (planning/2026-05-19-inspector-phase5-source-jump-spike.md). This is the
+// smallest concrete slice — the configuration plumbing for *which* editor
+// URI scheme to use when a future Phase 5.1 source-jump action wants to
+// open a file:line in the user's editor. No jumping happens here; this
+// file only deals with the template and its substitution.
+//
+// Common editor URL templates (any of these are valid `editor_url_template`
+// values for `InspectorConfig`):
+//
+//   VS Code   : "vscode://file/{path}:{line}"
+//   Cursor    : "cursor://file/{path}:{line}"
+//   Zed       : "zed://file/{path}:{line}:{col}"
+//   Sublime   : "sublime://open?url=file://{path}&line={line}"
+//   JetBrains : "idea://open?file={path}&line={line}"
+//
+// The substitution helper `format_editor_url` replaces `{path}`, `{line}`,
+// and `{col}` tokens with the supplied values. Tokens not present in the
+// template are silently ignored (so a Cursor template without `{col}` will
+// still render correctly when a column is supplied).
+//
+// The runtime config (`InspectorConfig::editor_url_template`) is overridden
+// by the `PULP_INSPECTOR_EDITOR_URL` environment variable when present, so
+// developers can switch editors per-shell without rebuilding.
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace pulp::inspect {
+
+/// Inspector runtime configuration. Currently scoped to source-jump
+/// editor URI plumbing (Phase 5.3). Future inspector-wide settings
+/// (e.g. theme, default tab) can be added here without churning the
+/// per-component constructors.
+struct InspectorConfig {
+    /// URL template used to open a source file in the user's editor.
+    /// Recognized substitution tokens: `{path}`, `{line}`, `{col}`.
+    /// See header comment for common presets.
+    std::string editor_url_template = "vscode://file/{path}:{line}";
+};
+
+/// Source that produced the effective editor URL template — used by
+/// `Inspector.getEditorUrlTemplate` so clients can show which override
+/// is in force.
+enum class EditorUrlSource {
+    Default,      ///< Built-in fallback (vscode://file/{path}:{line}).
+    Config,       ///< Set via InspectorConfig / setEditorUrlTemplate.
+    Environment,  ///< Overridden by PULP_INSPECTOR_EDITOR_URL.
+};
+
+/// Substitute `{path}`, `{line}`, and `{col}` in `tmpl` with the supplied
+/// values. Tokens not present in the template are skipped. `col` is
+/// optional; when omitted, `{col}` substitutes as an empty string (the
+/// expected behavior for templates that omit the token entirely).
+std::string format_editor_url(std::string_view tmpl,
+                              std::string_view path,
+                              int line,
+                              std::optional<int> col = std::nullopt);
+
+/// Validate a candidate editor URL template. A template is valid iff it
+/// contains the `{path}` token — without a path the URI cannot point at
+/// the user's source file. Returns true on success; on failure, sets
+/// `error_out` to a human-readable message when non-null.
+bool validate_editor_url_template(std::string_view tmpl,
+                                  std::string* error_out = nullptr);
+
+/// Look up the environment override (`PULP_INSPECTOR_EDITOR_URL`).
+/// Returns `std::nullopt` when unset or empty. Centralized here so tests
+/// and the protocol handler share one implementation.
+std::optional<std::string> editor_url_env_override();
+
+/// Compute the effective template and its source given the supplied
+/// config. Environment override (when set) wins over config, which wins
+/// over the built-in default. The default string matches
+/// `InspectorConfig::editor_url_template`'s initializer.
+struct EffectiveEditorUrl {
+    std::string template_str;
+    EditorUrlSource source = EditorUrlSource::Default;
+};
+
+EffectiveEditorUrl effective_editor_url(const InspectorConfig& config);
+
+/// Stringify the source enum for protocol responses.
+std::string_view editor_url_source_name(EditorUrlSource source);
+
+} // namespace pulp::inspect

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -56,6 +56,12 @@ namespace methods {
     constexpr auto kInspectorLoadTweaks  = "Inspector.loadTweaks";
     constexpr auto kInspectorSaveTweaks  = "Inspector.saveTweaks";
     constexpr auto kInspectorSetAutoSave = "Inspector.setAutoSave";
+    // Phase 5.3: editor URI plumbing for the future source-jump action.
+    // setEditorUrlTemplate validates and stores the template; getEditorUrlTemplate
+    // returns the current effective template plus where it came from
+    // (env / config / default). See pulp/inspect/editor_url.hpp.
+    constexpr auto kInspectorSetEditorUrlTemplate = "Inspector.setEditorUrlTemplate";
+    constexpr auto kInspectorGetEditorUrlTemplate = "Inspector.getEditorUrlTemplate";
 
     // DOM domain
     constexpr auto kDOMGetDocument     = "DOM.getDocument";

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -1,6 +1,7 @@
 // domain_handler.cpp — Protocol request dispatch to inspector data sources
 
 #include <pulp/inspect/domain_handler.hpp>
+#include <pulp/inspect/editor_url.hpp>
 #include <pulp/inspect/inspector_overlay.hpp>
 #include <pulp/inspect/state_inspector.hpp>
 #include <pulp/inspect/console_capture.hpp>
@@ -284,6 +285,49 @@ InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
         return make_response(req.id, choc::json::toString(resp, false));
     }
 
+    // ── Phase 5.3: editor URI plumbing for the future source-jump ───
+    // setEditorUrlTemplate validates and stores; getEditorUrlTemplate
+    // reports the effective template and where it came from
+    // (env / config / default). No actual jumping happens yet — that's
+    // Phase 5.1 (see planning/2026-05-19-inspector-phase5-source-jump-spike.md).
+    if (req.method == methods::kInspectorSetEditorUrlTemplate) {
+        try {
+            auto params = choc::json::parse(req.params_json);
+            if (!params.isObject() ||
+                !params.hasObjectMember("template") ||
+                !params["template"].isString()) {
+                return make_error(req.id,
+                    "Inspector.setEditorUrlTemplate requires `template` as string");
+            }
+            std::string tmpl = std::string(params["template"].getString());
+            std::string err;
+            if (!validate_editor_url_template(tmpl, &err))
+                return make_error(req.id,
+                    std::string("Inspector.setEditorUrlTemplate: ") + err);
+            config_.editor_url_template = tmpl;
+            auto resp = choc::value::createObject("");
+            resp.addMember("ok", choc::value::createBool(true));
+            resp.addMember("template", choc::value::createString(tmpl));
+            return make_response(req.id, choc::json::toString(resp, false));
+        } catch (const std::exception& e) {
+            return make_error(req.id,
+                std::string("Invalid params for Inspector.setEditorUrlTemplate: ") + e.what());
+        } catch (...) {
+            return make_error(req.id, "Invalid params for Inspector.setEditorUrlTemplate");
+        }
+    }
+    if (req.method == methods::kInspectorGetEditorUrlTemplate) {
+        auto eff = effective_editor_url(config_);
+        auto resp = choc::value::createObject("");
+        resp.addMember("template", choc::value::createString(eff.template_str));
+        resp.addMember("source",
+            choc::value::createString(std::string(editor_url_source_name(eff.source))));
+        resp.addMember("configTemplate",
+            choc::value::createString(config_.editor_url_template));
+        if (auto env = editor_url_env_override())
+            resp.addMember("envTemplate", choc::value::createString(*env));
+        return make_response(req.id, choc::json::toString(resp, false));
+    }
     if (req.method == methods::kInspectorSetBypass) {
         if (!tweak_store_) return make_error(req.id, "No tweak store attached");
         try {

--- a/inspect/src/editor_url.cpp
+++ b/inspect/src/editor_url.cpp
@@ -1,0 +1,85 @@
+// editor_url.cpp — Inspector source-jump editor URI configuration.
+//
+// See `pulp/inspect/editor_url.hpp` for the public surface and the
+// design context (planning Phase 5.3).
+
+#include <pulp/inspect/editor_url.hpp>
+#include <pulp/runtime/system.hpp>
+
+#include <string>
+
+namespace pulp::inspect {
+
+namespace {
+
+// Replace every occurrence of `needle` in `haystack` with `value`.
+// Defined locally so we don't pull in a string-utility header for two
+// callers. The hot path is short templates (<200 chars), so std::string
+// search is fine.
+void replace_token(std::string& haystack,
+                   std::string_view needle,
+                   std::string_view value) {
+    if (needle.empty()) return;
+    std::size_t pos = 0;
+    while ((pos = haystack.find(needle, pos)) != std::string::npos) {
+        haystack.replace(pos, needle.size(), value);
+        pos += value.size();
+    }
+}
+
+constexpr std::string_view kEnvVar = "PULP_INSPECTOR_EDITOR_URL";
+constexpr std::string_view kDefaultTemplate = "vscode://file/{path}:{line}";
+
+} // namespace
+
+std::string format_editor_url(std::string_view tmpl,
+                              std::string_view path,
+                              int line,
+                              std::optional<int> col) {
+    std::string out(tmpl);
+    replace_token(out, "{path}", path);
+    replace_token(out, "{line}", std::to_string(line));
+    // Empty substitution when col is absent keeps single-column templates
+    // (e.g. Sublime / IDEA / VS Code) clean while still being correct.
+    replace_token(out, "{col}", col.has_value() ? std::to_string(*col) : std::string{});
+    return out;
+}
+
+bool validate_editor_url_template(std::string_view tmpl,
+                                  std::string* error_out) {
+    if (tmpl.empty()) {
+        if (error_out) *error_out = "editor_url_template must not be empty";
+        return false;
+    }
+    if (tmpl.find("{path}") == std::string_view::npos) {
+        if (error_out) *error_out =
+            "editor_url_template must contain a {path} token";
+        return false;
+    }
+    return true;
+}
+
+std::optional<std::string> editor_url_env_override() {
+    auto env = pulp::runtime::get_env(kEnvVar);
+    if (!env.has_value() || env->empty()) return std::nullopt;
+    return env;
+}
+
+EffectiveEditorUrl effective_editor_url(const InspectorConfig& config) {
+    if (auto env = editor_url_env_override())
+        return { *env, EditorUrlSource::Environment };
+    if (config.editor_url_template != std::string(kDefaultTemplate))
+        return { config.editor_url_template, EditorUrlSource::Config };
+    return { std::string(kDefaultTemplate), EditorUrlSource::Default };
+}
+
+std::string_view editor_url_source_name(EditorUrlSource source) {
+    switch (source) {
+        case EditorUrlSource::Environment: return "environment";
+        case EditorUrlSource::Config:      return "config";
+        case EditorUrlSource::Default:     return "default";
+    }
+    return "default";
+}
+
+} // namespace pulp::inspect

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1910,6 +1910,15 @@ if(PULP_ENABLE_GPU AND NOT ANDROID AND NOT IOS)
     add_executable(pulp-test-tweak-store test_tweak_store.cpp)
     target_link_libraries(pulp-test-tweak-store PRIVATE pulp::view pulp::inspect pulp::state Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-tweak-store)
+
+    # Phase 5.3: editor URI plumbing for the future source-jump action.
+    # Pure config / format-helper / protocol — no overlay / GPU surface,
+    # but lives under the same PULP_ENABLE_GPU guard as the rest of
+    # pulp-inspect's tests so it links against the same library.
+    # planning/2026-05-19-inspector-phase5-source-jump-spike.md
+    add_executable(pulp-test-editor-url test_editor_url.cpp)
+    target_link_libraries(pulp-test-editor-url PRIVATE pulp::inspect Catch2::Catch2WithMain)
+    catch_discover_tests(pulp-test-editor-url)
 endif()
 
 # Widget bridge tests

--- a/test/test_editor_url.cpp
+++ b/test/test_editor_url.cpp
@@ -1,0 +1,254 @@
+// test_editor_url.cpp — Inspector Phase 5.3 editor URI plumbing.
+//
+// Covers the format helper, env-vs-config-vs-default precedence,
+// template validation, and the two new protocol methods
+// (`Inspector.setEditorUrlTemplate` / `Inspector.getEditorUrlTemplate`).
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/inspect/domain_handler.hpp>
+#include <pulp/inspect/editor_url.hpp>
+#include <pulp/inspect/protocol.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+#include <cstdlib>
+#include <string>
+
+using namespace pulp::inspect;
+
+namespace {
+
+// Scoped env var setter — restores prior state on destruction so tests
+// stay order-independent. The Phase 5.3 env override is global state,
+// so any test that mutates it must clean up.
+struct ScopedEnv {
+    explicit ScopedEnv(std::string name) : name_(std::move(name)) {
+        if (const char* prev = std::getenv(name_.c_str())) {
+            prev_ = std::string(prev);
+            had_prev_ = true;
+        }
+    }
+    void set(const std::string& value) {
+#if defined(_WIN32)
+        _putenv_s(name_.c_str(), value.c_str());
+#else
+        ::setenv(name_.c_str(), value.c_str(), /*overwrite=*/1);
+#endif
+    }
+    void unset() {
+#if defined(_WIN32)
+        _putenv_s(name_.c_str(), "");
+#else
+        ::unsetenv(name_.c_str());
+#endif
+    }
+    ~ScopedEnv() {
+        if (had_prev_) set(prev_);
+        else unset();
+    }
+private:
+    std::string name_;
+    std::string prev_;
+    bool had_prev_ = false;
+};
+
+} // namespace
+
+TEST_CASE("format_editor_url substitutes path and line for vscode-style template",
+          "[inspect][editor-url]") {
+    auto url = format_editor_url("vscode://file/{path}:{line}",
+                                 "/Users/foo/bar.cpp", 42);
+    REQUIRE(url == "vscode://file//Users/foo/bar.cpp:42");
+}
+
+TEST_CASE("format_editor_url substitutes col when template includes {col}",
+          "[inspect][editor-url]") {
+    auto url = format_editor_url("zed://file/{path}:{line}:{col}",
+                                 "/tmp/x.rs", 10, 7);
+    REQUIRE(url == "zed://file//tmp/x.rs:10:7");
+}
+
+TEST_CASE("format_editor_url omits col cleanly when template lacks {col}",
+          "[inspect][editor-url]") {
+    // Cursor template has no {col} — supplying one should not break it.
+    auto url = format_editor_url("cursor://file/{path}:{line}",
+                                 "src/main.cpp", 3, 99);
+    REQUIRE(url == "cursor://file/src/main.cpp:3");
+}
+
+TEST_CASE("format_editor_url with absent col blanks {col} token",
+          "[inspect][editor-url]") {
+    // Template references {col} but caller did not supply one — the token
+    // becomes empty. This is the expected behavior for templates that
+    // request a column but operate on an anchor that doesn't have one.
+    auto url = format_editor_url("zed://file/{path}:{line}:{col}",
+                                 "main.rs", 5);
+    REQUIRE(url == "zed://file/main.rs:5:");
+}
+
+TEST_CASE("format_editor_url handles sublime / idea query-style templates",
+          "[inspect][editor-url]") {
+    auto sub = format_editor_url(
+        "sublime://open?url=file://{path}&line={line}", "/abs/x.py", 12);
+    REQUIRE(sub == "sublime://open?url=file:///abs/x.py&line=12");
+
+    auto idea = format_editor_url(
+        "idea://open?file={path}&line={line}", "/abs/y.java", 7);
+    REQUIRE(idea == "idea://open?file=/abs/y.java&line=7");
+}
+
+TEST_CASE("validate_editor_url_template rejects templates without {path}",
+          "[inspect][editor-url]") {
+    std::string err;
+    REQUIRE_FALSE(validate_editor_url_template("vscode://file/bare", &err));
+    REQUIRE_FALSE(err.empty());
+
+    REQUIRE_FALSE(validate_editor_url_template("", &err));
+    REQUIRE_FALSE(err.empty());
+
+    REQUIRE(validate_editor_url_template("vscode://file/{path}:{line}"));
+    REQUIRE(validate_editor_url_template("custom://{path}"));
+}
+
+TEST_CASE("effective_editor_url: env override beats config and default",
+          "[inspect][editor-url]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.set("cursor://file/{path}:{line}");
+
+    InspectorConfig cfg;
+    cfg.editor_url_template = "vscode://file/{path}:{line}";
+
+    auto eff = effective_editor_url(cfg);
+    REQUIRE(eff.template_str == "cursor://file/{path}:{line}");
+    REQUIRE(eff.source == EditorUrlSource::Environment);
+    REQUIRE(std::string(editor_url_source_name(eff.source)) == "environment");
+}
+
+TEST_CASE("effective_editor_url: config beats default when set, no env",
+          "[inspect][editor-url]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+
+    InspectorConfig cfg;
+    cfg.editor_url_template = "zed://file/{path}:{line}:{col}";
+
+    auto eff = effective_editor_url(cfg);
+    REQUIRE(eff.template_str == "zed://file/{path}:{line}:{col}");
+    REQUIRE(eff.source == EditorUrlSource::Config);
+}
+
+TEST_CASE("effective_editor_url: default kicks in when nothing is set",
+          "[inspect][editor-url]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+
+    InspectorConfig cfg; // default-constructed
+    auto eff = effective_editor_url(cfg);
+    REQUIRE(eff.template_str == "vscode://file/{path}:{line}");
+    REQUIRE(eff.source == EditorUrlSource::Default);
+}
+
+TEST_CASE("editor_url_env_override returns nullopt for empty env",
+          "[inspect][editor-url]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.set("");
+    REQUIRE_FALSE(editor_url_env_override().has_value());
+}
+
+// ── Protocol surface ───────────────────────────────────────────────────────
+
+TEST_CASE("Inspector.setEditorUrlTemplate stores valid template and round-trips",
+          "[inspect][editor-url][protocol]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+
+    DomainHandler handler;
+
+    auto set_req = make_request(
+        1, methods::kInspectorSetEditorUrlTemplate,
+        R"({"template":"zed://file/{path}:{line}:{col}"})");
+    auto set_resp = handler.handle(set_req);
+    REQUIRE_FALSE(set_resp.is_error);
+
+    auto set_obj = choc::json::parse(set_resp.params_json);
+    REQUIRE(set_obj["ok"].getBool());
+    REQUIRE(std::string(set_obj["template"].getString())
+            == "zed://file/{path}:{line}:{col}");
+
+    auto get_req = make_request(2, methods::kInspectorGetEditorUrlTemplate, "{}");
+    auto get_resp = handler.handle(get_req);
+    REQUIRE_FALSE(get_resp.is_error);
+
+    auto get_obj = choc::json::parse(get_resp.params_json);
+    REQUIRE(std::string(get_obj["template"].getString())
+            == "zed://file/{path}:{line}:{col}");
+    REQUIRE(std::string(get_obj["source"].getString()) == "config");
+    REQUIRE(std::string(get_obj["configTemplate"].getString())
+            == "zed://file/{path}:{line}:{col}");
+}
+
+TEST_CASE("Inspector.setEditorUrlTemplate rejects template without {path}",
+          "[inspect][editor-url][protocol]") {
+    DomainHandler handler;
+    auto req = make_request(
+        1, methods::kInspectorSetEditorUrlTemplate,
+        R"({"template":"vscode://file/no-token"})");
+    auto resp = handler.handle(req);
+    REQUIRE(resp.is_error);
+    // The config must be left untouched.
+    REQUIRE(handler.config().editor_url_template
+            == "vscode://file/{path}:{line}");
+}
+
+TEST_CASE("Inspector.setEditorUrlTemplate rejects missing/non-string template",
+          "[inspect][editor-url][protocol]") {
+    DomainHandler handler;
+
+    auto missing = handler.handle(make_request(
+        1, methods::kInspectorSetEditorUrlTemplate, R"({})"));
+    REQUIRE(missing.is_error);
+
+    auto wrong_type = handler.handle(make_request(
+        2, methods::kInspectorSetEditorUrlTemplate, R"({"template":42})"));
+    REQUIRE(wrong_type.is_error);
+}
+
+TEST_CASE("Inspector.getEditorUrlTemplate reports environment override",
+          "[inspect][editor-url][protocol]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.set("idea://open?file={path}&line={line}");
+
+    DomainHandler handler;
+    auto resp = handler.handle(make_request(
+        1, methods::kInspectorGetEditorUrlTemplate, "{}"));
+    REQUIRE_FALSE(resp.is_error);
+
+    auto obj = choc::json::parse(resp.params_json);
+    REQUIRE(std::string(obj["template"].getString())
+            == "idea://open?file={path}&line={line}");
+    REQUIRE(std::string(obj["source"].getString()) == "environment");
+    REQUIRE(obj.hasObjectMember("envTemplate"));
+    REQUIRE(std::string(obj["envTemplate"].getString())
+            == "idea://open?file={path}&line={line}");
+}
+
+TEST_CASE("DomainHandler::set_config swaps the template without touching env",
+          "[inspect][editor-url][protocol]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+
+    DomainHandler handler;
+    InspectorConfig cfg;
+    cfg.editor_url_template = "cursor://file/{path}:{line}";
+    handler.set_config(cfg);
+    REQUIRE(handler.config().editor_url_template
+            == "cursor://file/{path}:{line}");
+
+    auto resp = handler.handle(make_request(
+        1, methods::kInspectorGetEditorUrlTemplate, "{}"));
+    auto obj = choc::json::parse(resp.params_json);
+    REQUIRE(std::string(obj["source"].getString()) == "config");
+    REQUIRE(std::string(obj["template"].getString())
+            == "cursor://file/{path}:{line}");
+}


### PR DESCRIPTION
Adds the smallest concrete slice from
planning/2026-05-19-inspector-phase5-source-jump-spike.md: the
configuration plumbing for which editor URI to use when a future
Phase 5.1 source-jump action wants to open a file:line in the
user's editor. No actual jumping happens yet — this PR only deals
with the template, its substitution helper, and the protocol
surface that lets a client read/write it.

New surface (under inspect/):
  * `InspectorConfig` (editor_url.hpp) — first home for inspector-wide
    runtime settings; currently just `editor_url_template`.
  * `format_editor_url(tmpl, path, line, col)` — substitutes
    `{path}` / `{line}` / `{col}` tokens. Missing-token / absent-col
    are both handled cleanly so the same helper works for vscode,
    cursor, zed, sublime, and idea preset templates.
  * `validate_editor_url_template` — rejects templates without
    `{path}` (the one token a source-jump URL cannot live without).
  * `effective_editor_url` / `editor_url_env_override` —
    `PULP_INSPECTOR_EDITOR_URL` env override > config > built-in
    default precedence, with a typed source enum for the protocol.

Protocol (DomainHandler):
  * `Inspector.setEditorUrlTemplate { template }` — validates and
    stores; returns `{ok, template}` or an error.
  * `Inspector.getEditorUrlTemplate {}` — returns the effective
    template plus its source (`environment` / `config` / `default`)
    and surfaces the raw config / env values for diagnostics.

Tests (`test/test_editor_url.cpp`, 15 cases / 39 assertions):
  * format helper across all five preset templates (vscode, cursor,
    zed, sublime, idea), including the omitted-col and supplied-but-
    absent-token edge cases.
  * env > config > default precedence + source-name reporting.
  * template validation: empty + missing `{path}` rejected.
  * round-trip set/get + non-string / missing param error paths.
  * config swap via `set_config` + env-aware get.

Phase 5.1 (the actual source-jump action) is intentionally out of
scope here.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>