### PR TITLE
ci(macos): use Namespace cache action for brew + ccache (telemetry recommendation)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -426,6 +426,24 @@ jobs:
             wayland-protocols \
             ccache
 
+      # Namespace-native cache volumes for brew + ccache on the cloud
+      # macOS lane (namespace-profile-generouscorp-macos). Namespace's
+      # nscloud-cache-action stores cache state on the workspace's
+      # snapshot volumes — orders of magnitude faster than the standard
+      # actions/cache backend, which round-trips through GitHub's
+      # cache service over the network. Local self-hosted Mac already
+      # persists these paths on disk between jobs; GHA-hosted macos-15
+      # falls back to actions/cache below. Detection via the runner's
+      # `namespace-profile-*` label.
+      # Source: namespace.so/docs/reference/github-actions/nscloud-cache-action
+      - name: Restore Namespace cache (macOS, brew + ccache)
+        if: runner.os == 'macOS' && contains(toJSON(runner.labels), 'namespace-profile')
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: brew
+          path: |
+            ~/Library/Caches/ccache
+
       - name: Install ccache (macOS)
         if: runner.os == 'macOS'
         run: brew install ccache


### PR DESCRIPTION
Namespace telemetry flagged that our macOS cloud lane spends time
fetching brew + ccache state on every run. Their native
`nscloud-cache-action@v1` stores cache state on the workspace's
snapshot volumes — orders of magnitude faster than the existing
`actions/cache/restore@v4` step, which round-trips cache state
through GitHub's cache service over the network.

Add a Namespace-detected restore step (label-pattern
`namespace-profile-*`) BEFORE the existing brew install + ccache
install. Local self-hosted Mac and GHA-hosted macos-15 are
unaffected — they continue using their existing paths
(local persistence on disk, or actions/cache backend respectively).

Source: telemetry email from Namespace recommending the
nscloud-cache-action; docs at
https://namespace.so/docs/reference/github-actions/nscloud-cache-action#cache

Skill-Update: skip skill=ci reason="Namespace-specific cache optimization in build.yml; ci SKILL already documents Namespace routing"