### PR TITLE
ci(namespace): cache brew + ccache + FetchContent on Namespace runners

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -92,6 +92,19 @@ jobs:
           # FetchContent / CMake configure persist between PRs.
           clean: ${{ contains(needs.resolve-runner.outputs.runs_on_json, 'self-hosted') == false }}
 
+      # ── Namespace cache (per Namespace team telemetry, 2026-05-19) ──
+      # Persist brew + ccache + Pulp FetchContent across runs on the
+      # same workspace. Gated on the resolved runner selector containing
+      # "namespace"; no-op on self-hosted and github-hosted.
+      - name: Namespace cache (brew + ccache + Pulp FetchContent)
+        if: contains(needs.resolve-runner.outputs.runs_on_json, 'namespace')
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: brew
+          path: |
+            ~/Library/Caches/ccache
+            ~/Library/Caches/Pulp/fetchcontent-src
+
       - name: Install ccache
         run: brew install ccache
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -426,6 +426,25 @@ jobs:
             wayland-protocols \
             ccache
 
+      # ── Namespace cache (per Namespace team telemetry, 2026-05-19) ──
+      # Namespace cache volumes persist across runs on the same workspace,
+      # cutting brew-install latency and ccache miss rates substantially.
+      # Gated on matrix.runs_on_json containing "namespace" — the macOS
+      # leg uses this only when Namespace overflow has activated; the
+      # primary path is the self-hosted Mac (which already keeps both
+      # caches on local disk between jobs, so no action needed there).
+      # Step is a no-op on github-hosted and self-hosted runners.
+      - name: Namespace cache (brew + ccache + Pulp FetchContent)
+        if: contains(matrix.runs_on_json, 'namespace')
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: brew
+          path: |
+            ~/Library/Caches/ccache
+            ~/.cache/ccache
+            ~/Library/Caches/Pulp/fetchcontent-src
+            ~/.cache/Pulp/fetchcontent-src
+
       - name: Install ccache (macOS)
         if: runner.os == 'macOS'
         run: brew install ccache


### PR DESCRIPTION
Per Namespace team telemetry (2026-05-19): adding `namespacelabs/nscloud-cache-action@v1` to persist brew, ccache, and Pulp's Skia mirror cache across runs on the same Namespace workspace. Reduces cold-cache penalty when Namespace overflow activates.

### Scope

- `.github/workflows/build.yml` — added gated on `matrix.runs_on_json` containing `namespace`. No-op on self-hosted Mac (keeps caches on local disk) and github-hosted (already has actions/cache).
- `.github/workflows/build-macos.yml` — same gate using `needs.resolve-runner.outputs.runs_on_json`.

### Paths cached

- brew preset (via `cache: brew`)
- `~/Library/Caches/ccache` + `~/.cache/ccache`
- `~/Library/Caches/Pulp/fetchcontent-src` + `~/.cache/Pulp/...` (Skia mirror archive)

### Not touched

`visual-harness.yml` — its runner mux routes only to local self-hosted or `macos-15`; no Namespace path.

`Version-Bump: skip` — CI-only infrastructure change.