### PR TITLE
fix(ci): namespace-cache gate accepts nscloud-* labels (Codex P2 on #2399)

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -94,10 +94,15 @@ jobs:
 
       # ── Namespace cache (per Namespace team telemetry, 2026-05-19) ──
       # Persist brew + ccache + Pulp FetchContent across runs on the
-      # same workspace. Gated on the resolved runner selector containing
-      # "namespace"; no-op on self-hosted and github-hosted.
+      # same workspace. This workflow's resolve-runner emits a
+      # structured `route` output that's always one of {local,
+      # namespace, github-hosted} — use the route directly rather
+      # than a substring on runs_on_json. Codex P2 on #2399 flagged
+      # that `runs_on_json` can contain direct nscloud-* labels that
+      # don't include "namespace" literally; gating on `route` avoids
+      # that whole class of misses.
       - name: Namespace cache (brew + ccache + Pulp FetchContent)
-        if: contains(needs.resolve-runner.outputs.runs_on_json, 'namespace')
+        if: needs.resolve-runner.outputs.route == 'namespace'
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: brew

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -429,13 +429,17 @@ jobs:
       # ── Namespace cache (per Namespace team telemetry, 2026-05-19) ──
       # Namespace cache volumes persist across runs on the same workspace,
       # cutting brew-install latency and ccache miss rates substantially.
-      # Gated on matrix.runs_on_json containing "namespace" — the macOS
-      # leg uses this only when Namespace overflow has activated; the
-      # primary path is the self-hosted Mac (which already keeps both
-      # caches on local disk between jobs, so no action needed there).
-      # Step is a no-op on github-hosted and self-hosted runners.
+      # Detection: Namespace selectors land in matrix.runs_on_json as
+      # either "namespace-profile-…" (the
+      # vars.PULP_NAMESPACE_BUILD_*_RUNS_ON_JSON form configured today)
+      # OR direct machine labels like "nscloud-macos-tahoe-arm64-6x14"
+      # (documented in docs/guides/local-ci.md as an alternative).
+      # Codex P2 on #2399 flagged that a single "namespace" substring
+      # missed the nscloud-* form, so we check both prefixes.
+      # No-op on self-hosted Mac (already keeps caches on local disk)
+      # and github-hosted runners (have actions/cache via #420).
       - name: Namespace cache (brew + ccache + Pulp FetchContent)
-        if: contains(matrix.runs_on_json, 'namespace')
+        if: contains(matrix.runs_on_json, 'namespace') || contains(matrix.runs_on_json, 'nscloud')
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: brew


### PR DESCRIPTION
Addresses **Codex P2 on #2399**: `contains(matrix.runs_on_json, 'namespace')` misses direct machine labels like `nscloud-macos-tahoe-arm64-6x14` (documented in docs/guides/local-ci.md). In that config the workflow still routes to Namespace but the new cache step silently skips, defeating the optimization.

### Fix

- `.github/workflows/build.yml` — broaden the substring gate to accept both `namespace` OR `nscloud`.
- `.github/workflows/build-macos.yml` — switch to gating on the structured `needs.resolve-runner.outputs.route == 'namespace'` (cleaner than substring; the route field is always one of local/namespace/github-hosted).

`Version-Bump: skip` — CI-only follow-up.