### PR TITLE
fix(ci): brew update + cache on Namespace macOS leg (unblocks #2367/#2374/#2378/#2388)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1453,6 +1453,45 @@ error: externally-managed-environment
 
 Followed by cascade-skipped downstream steps (default `if: success()`) and a "coverage.python.xml is missing" hard-fail in the validation step. Coverage Linux ran into this when it migrated to Namespace via `PULP_COVERAGE_LINUX_RUNS_ON_JSON` (PR #676 → #677).
 
+## Homebrew on Namespace macOS runners (PR #2399)
+
+Namespace macOS runners (`nscloud-macos-tahoe-arm64-*`) come up with
+Homebrew configured to disable automatic updates AND with a stale
+package index. Any first-call `brew install <pkg>` on a fresh runner
+exits non-zero with:
+
+```
+You have disabled automatic updates and have not updated today.
+Do not report this issue until you've run `brew update` and tried
+again.
+```
+
+Fix: always run `brew update --quiet` before the first `brew install`
+on macOS legs. The step is gated `if: runner.os == 'macOS'` so it
+no-ops on Linux/Windows. Local self-hosted Macs already keep brew
+warm between runs, so the update is a quick no-op there too —
+unconditional execution is simpler than per-runner-environment
+detection. See `.github/workflows/build.yml` for the canonical
+placement (immediately before `Install ccache (macOS)`).
+
+Cache: the `Namespace cache (brew + ccache + Pulp FetchContent)`
+step uses `namespacelabs/nscloud-cache-action@v1` with `cache: brew`
+plus ccache and FetchContent paths. It runs only on Namespace /
+nscloud labels (`contains(matrix.runs_on_json, 'namespace') ||
+contains(matrix.runs_on_json, 'nscloud')`); self-hosted Macs keep
+their caches on local disk and github-hosted runners use
+`actions/cache@v4` via the existing `Restore ccache (GitHub-hosted)`
+step (#420). The brew cache only restores the bottle download cache —
+it does NOT restore the brew config that would tell the runner
+"updates are recent," so `brew update --quiet` is still required
+even when the cache hits.
+
+Incident: 2026-05-19 — PRs #2367, #2374, #2378, #2388 all wedged on
+the macOS `Install ccache (macOS)` step within minutes of each other
+because Namespace's runner image had drifted past the freshness
+window the brew preamble enforces. Adding `brew update --quiet`
+once unblocks the whole queue.
+
 ## SignalGraph Phase 0 learnings (PR #153)
 
 Gotchas surfaced while landing the four-phase SignalGraph follow-up:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -449,6 +449,19 @@ jobs:
             ~/Library/Caches/Pulp/fetchcontent-src
             ~/.cache/Pulp/fetchcontent-src
 
+      # Namespace macOS runners come up with a stale Homebrew config.
+      # Without this `brew update`, any subsequent `brew install` fails
+      # fast with: "You have disabled automatic updates and have not
+      # updated today. Do not report this issue until you've run
+      # `brew update` and tried again." (PR #2399 — unblocks #2367,
+      # #2374, #2378, #2388 which all wedged on this on 2026-05-19.)
+      # Local self-hosted Macs already keep brew warm between runs, but
+      # `brew update --quiet` is idempotent and cheap there; cheap
+      # enough to run unconditionally on every macOS leg.
+      - name: brew update (macOS)
+        if: runner.os == 'macOS'
+        run: brew update --quiet
+
       - name: Install ccache (macOS)
         if: runner.os == 'macOS'
         run: brew install ccache


### PR DESCRIPTION
## Summary

The macOS leg of `.github/workflows/build.yml` runs `brew install ccache` on
Namespace macOS runners. Those runners come up with Homebrew configured to
disable automatic updates **and** with a stale package index, so the very next
`brew install` exits non-zero with:

```
You have disabled automatic updates and have not updated today.
Do not report this issue until you've run `brew update` and tried again.
```

Result: the `Install ccache (macOS)` step fails, the macOS matrix leg fails,
and every PR queued behind it cascade-skips its build/test/upload steps. Four
PRs hit this simultaneously today (2026-05-19):

- #2367
- #2374
- #2378
- #2388

Repro jobs:

- https://github.com/danielraffel/pulp/actions/runs/26121830522/job/76829090258
- https://github.com/danielraffel/pulp/actions/runs/26121883362/job/76828088380

## Fix

1. `.github/workflows/build.yml`: insert a `brew update --quiet` step
   immediately before `Install ccache (macOS)`, gated `if: runner.os == 'macOS'`.
   The step no-ops on Linux/Windows legs and is a fast idempotent op on local
   self-hosted Macs that already keep brew warm.

2. The bottle-download cache is already wired through
   `namespacelabs/nscloud-cache-action@v1` with `cache: brew` (see existing
   `Namespace cache (brew + ccache + Pulp FetchContent)` step, lines 441-450).
   That action caches the bottle downloads but does NOT preserve brew's
   "last-updated" timestamp — so `brew update --quiet` is still required even
   when the bottle cache hits. No additional cache-action wiring needed.

3. Documented the gotcha in the `ci` skill so future agents and humans don't
   rediscover it the hard way.

## Why this needs to clear the queue itself

This PR will hit the same wedge on its own macOS leg unless it's the first to
land after the update. Once it merges, future macOS legs will run `brew update`
first and stop failing on the freshness check.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — passes locally
- [x] `actionlint .github/workflows/build.yml` — passes locally (silent)
- [x] `yamllint --no-warnings -d relaxed .github/workflows/build.yml` — passes locally (matches `.github/workflows/workflow-lint.yml` config)
- [ ] CI `workflow-lint` job passes
- [ ] CI macOS leg passes (proves the fix self-applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
