### PR TITLE
fix(ci): restrict Namespace cache action to macOS lane

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -436,18 +436,26 @@ jobs:
       # (documented in docs/guides/local-ci.md as an alternative).
       # Codex P2 on #2399 flagged that a single "namespace" substring
       # missed the nscloud-* form, so we check both prefixes.
+      #
+      # macOS-only restriction (fix-up to #2399 + #2402): the action
+      # hard-errors when run on a Namespace profile without cache
+      # volumes configured (observed on the Windows Namespace lane in
+      # PR #2376 — "nscloud-cache-action requires a cache volume to
+      # be configured"). Cache volumes are only configured for the
+      # macOS profile, and the cached paths here (brew, ~/Library/…)
+      # are macOS-specific anyway. Windows uses choco + a different
+      # ccache path, so it doesn't benefit from this step regardless.
+      #
       # No-op on self-hosted Mac (already keeps caches on local disk)
       # and github-hosted runners (have actions/cache via #420).
       - name: Namespace cache (brew + ccache + Pulp FetchContent)
-        if: contains(matrix.runs_on_json, 'namespace') || contains(matrix.runs_on_json, 'nscloud')
+        if: runner.os == 'macOS' && (contains(matrix.runs_on_json, 'namespace') || contains(matrix.runs_on_json, 'nscloud'))
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: brew
           path: |
             ~/Library/Caches/ccache
-            ~/.cache/ccache
             ~/Library/Caches/Pulp/fetchcontent-src
-            ~/.cache/Pulp/fetchcontent-src
 
       # Namespace macOS runners come up with a stale Homebrew config.
       # Without this `brew update`, any subsequent `brew install` fails


### PR DESCRIPTION
Hotfix for #2399 + #2402 — the nscloud-cache-action step hard-errors on Namespace lanes without cache volumes configured. Observed on PR #2376's Windows-on-Namespace leg:

```
##[error]nscloud-cache-action requires a cache volume to be configured.
Please enable Caching in your runner profile.
```

Cache volumes are only configured for the macOS Namespace profile, and the cached paths (`~/Library/Caches/ccache`, `~/Library/Caches/Pulp/fetchcontent-src`, brew preset) are macOS-specific anyway. Windows uses choco + a different ccache path.

### Fix
Add `runner.os == 'macOS'` to the gate. Also drops the redundant Linux paths from the cached set since the step now only fires on macOS.

`Version-Bump: skip` — CI-only hotfix.