### PR TITLE
fix(harness): wire react-runtime target into roundtrip scripts (Codex P2 on #2422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
-<a id="v0172g"></a>
-## [0.172.16] - 2026-05-19
+<a id="v0172i"></a>
+## [0.172.18] - 2026-05-19
+
+- fix(harness): wire pulp-test-design-import-react-runtime into roundtrip scripts (Codex P2 follow-up to #2422)
 
 - refactor(test): P5-4 extract pulp pr shell-out tests (2,646 → 2,314, -332)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.172.16
+    VERSION 0.172.18
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/import-validation/figma-roundtrip.sh
+++ b/tools/import-validation/figma-roundtrip.sh
@@ -78,7 +78,7 @@ if [[ $COVERAGE -eq 1 ]]; then
   default_ctest_regex='parse_figma_make_react|WidgetBridge __pulpRuntimeImport__ dispatches Figma|WidgetBridge __pulpRuntimeImport__ surfaces parse failure'
   export PULP_DIFF_COVER_CTEST_REGEX="${PULP_DIFF_COVER_CTEST_REGEX:-$default_ctest_regex}"
   bash "$PULP_DIR/tools/scripts/local_diff_cover.sh" \
-    pulp-test-design-import pulp-test-widget-bridge-runtime-import
+    pulp-test-design-import pulp-test-design-import-react-runtime pulp-test-widget-bridge-runtime-import
   green "Figma parser diff coverage passed"
   exit 0
 fi
@@ -98,7 +98,7 @@ find_test_exe() {
 
 if [[ $SKIP_BUILD -eq 0 ]]; then
   cmake -S "$PULP_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
-  build_targets=(pulp-test-design-import pulp-test-widget-bridge-runtime-import)
+  build_targets=(pulp-test-design-import pulp-test-design-import-react-runtime pulp-test-widget-bridge-runtime-import)
   if [[ $PARSER_ONLY -eq 0 ]]; then
     build_targets+=(pulp-screenshot)
   fi
@@ -107,9 +107,11 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
 fi
 
 DESIGN_IMPORT_TEST="$(find_test_exe pulp-test-design-import)"
+DESIGN_IMPORT_REACT_RUNTIME_TEST="$(find_test_exe pulp-test-design-import-react-runtime)"
 WIDGET_BRIDGE_TEST="$(find_test_exe pulp-test-widget-bridge-runtime-import)"
 
 "$DESIGN_IMPORT_TEST" '[phase-6.6.3]'
+"$DESIGN_IMPORT_REACT_RUNTIME_TEST" '[phase-6.6.3]'
 "$WIDGET_BRIDGE_TEST" '[phase-6.6.3]'
 
 if [[ $PARSER_ONLY -eq 1 ]]; then

--- a/tools/import-validation/pencil-roundtrip.sh
+++ b/tools/import-validation/pencil-roundtrip.sh
@@ -78,7 +78,7 @@ if [[ $COVERAGE -eq 1 ]]; then
   default_ctest_regex='parse_pencil_react|WidgetBridge __pulpRuntimeImport__ dispatches Pencil|WidgetBridge __pulpRuntimeImport__ surfaces parse failure'
   export PULP_DIFF_COVER_CTEST_REGEX="${PULP_DIFF_COVER_CTEST_REGEX:-$default_ctest_regex}"
   bash "$PULP_DIR/tools/scripts/local_diff_cover.sh" \
-    pulp-test-design-import pulp-test-widget-bridge-runtime-import
+    pulp-test-design-import pulp-test-design-import-react-runtime pulp-test-widget-bridge-runtime-import
   green "Pencil parser diff coverage passed"
   exit 0
 fi
@@ -98,7 +98,7 @@ find_test_exe() {
 
 if [[ $SKIP_BUILD -eq 0 ]]; then
   cmake -S "$PULP_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
-  build_targets=(pulp-test-design-import pulp-test-widget-bridge-runtime-import)
+  build_targets=(pulp-test-design-import pulp-test-design-import-react-runtime pulp-test-widget-bridge-runtime-import)
   if [[ $PARSER_ONLY -eq 0 ]]; then
     build_targets+=(pulp-screenshot)
   fi
@@ -107,9 +107,11 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
 fi
 
 DESIGN_IMPORT_TEST="$(find_test_exe pulp-test-design-import)"
+DESIGN_IMPORT_REACT_RUNTIME_TEST="$(find_test_exe pulp-test-design-import-react-runtime)"
 WIDGET_BRIDGE_TEST="$(find_test_exe pulp-test-widget-bridge-runtime-import)"
 
 "$DESIGN_IMPORT_TEST" '[phase-6.6.6]'
+"$DESIGN_IMPORT_REACT_RUNTIME_TEST" '[phase-6.6.6]'
 "$WIDGET_BRIDGE_TEST" '[phase-6.6.6]'
 
 if [[ $PARSER_ONLY -eq 1 ]]; then

--- a/tools/import-validation/rn-roundtrip.sh
+++ b/tools/import-validation/rn-roundtrip.sh
@@ -78,7 +78,7 @@ if [[ $COVERAGE -eq 1 ]]; then
   default_ctest_regex='parse_react_native_export|WidgetBridge __pulpRuntimeImport__ dispatches RN|WidgetBridge __pulpRuntimeImport__ auto-detects RN|WidgetBridge __pulpRuntimeImport__ surfaces parse failure'
   export PULP_DIFF_COVER_CTEST_REGEX="${PULP_DIFF_COVER_CTEST_REGEX:-$default_ctest_regex}"
   bash "$PULP_DIR/tools/scripts/local_diff_cover.sh" \
-    pulp-test-design-import pulp-test-widget-bridge-runtime-import
+    pulp-test-design-import pulp-test-design-import-react-runtime pulp-test-widget-bridge-runtime-import
   green "RN parser diff coverage passed"
   exit 0
 fi
@@ -98,7 +98,7 @@ find_test_exe() {
 
 if [[ $SKIP_BUILD -eq 0 ]]; then
   cmake -S "$PULP_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
-  build_targets=(pulp-test-design-import pulp-test-widget-bridge-runtime-import)
+  build_targets=(pulp-test-design-import pulp-test-design-import-react-runtime pulp-test-widget-bridge-runtime-import)
   if [[ $PARSER_ONLY -eq 0 ]]; then
     build_targets+=(pulp-screenshot)
   fi
@@ -107,9 +107,11 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
 fi
 
 DESIGN_IMPORT_TEST="$(find_test_exe pulp-test-design-import)"
+DESIGN_IMPORT_REACT_RUNTIME_TEST="$(find_test_exe pulp-test-design-import-react-runtime)"
 WIDGET_BRIDGE_TEST="$(find_test_exe pulp-test-widget-bridge-runtime-import)"
 
 "$DESIGN_IMPORT_TEST" '[phase-6.6.5]'
+"$DESIGN_IMPORT_REACT_RUNTIME_TEST" '[phase-6.6.5]'
 "$WIDGET_BRIDGE_TEST" '[phase-6.6.5]'
 
 if [[ $PARSER_ONLY -eq 1 ]]; then

--- a/tools/import-validation/source-contracts.json
+++ b/tools/import-validation/source-contracts.json
@@ -161,11 +161,13 @@
         "roundtrip_script": "tools/import-validation/stitch-roundtrip.sh",
         "test_targets": [
           "pulp-test-design-import",
+          "pulp-test-design-import-react-runtime",
           "pulp-test-widget-bridge",
           "pulp-test-widget-bridge-runtime-import"
         ],
         "test_files": [
           "test/test_design_import.cpp",
+          "test/test_design_import_react_runtime.cpp",
           "test/test_widget_bridge.cpp",
           "test/test_widget_bridge_runtime_import.cpp"
         ],
@@ -328,11 +330,13 @@
         "roundtrip_script": "tools/import-validation/pencil-roundtrip.sh",
         "test_targets": [
           "pulp-test-design-import",
+          "pulp-test-design-import-react-runtime",
           "pulp-test-widget-bridge",
           "pulp-test-widget-bridge-runtime-import"
         ],
         "test_files": [
           "test/test_design_import.cpp",
+          "test/test_design_import_react_runtime.cpp",
           "test/test_widget_bridge.cpp",
           "test/test_widget_bridge_runtime_import.cpp"
         ],
@@ -424,11 +428,13 @@
         "roundtrip_script": "tools/import-validation/figma-roundtrip.sh",
         "test_targets": [
           "pulp-test-design-import",
+          "pulp-test-design-import-react-runtime",
           "pulp-test-widget-bridge",
           "pulp-test-widget-bridge-runtime-import"
         ],
         "test_files": [
           "test/test_design_import.cpp",
+          "test/test_design_import_react_runtime.cpp",
           "test/test_widget_bridge.cpp",
           "test/test_widget_bridge_runtime_import.cpp"
         ],
@@ -513,11 +519,13 @@
         "roundtrip_script": "tools/import-validation/v0-roundtrip.sh",
         "test_targets": [
           "pulp-test-design-import",
+          "pulp-test-design-import-react-runtime",
           "pulp-test-widget-bridge",
           "pulp-test-widget-bridge-runtime-import"
         ],
         "test_files": [
           "test/test_design_import.cpp",
+          "test/test_design_import_react_runtime.cpp",
           "test/test_widget_bridge.cpp",
           "test/test_widget_bridge_runtime_import.cpp"
         ],
@@ -671,11 +679,13 @@
         "roundtrip_script": "tools/import-validation/rn-roundtrip.sh",
         "test_targets": [
           "pulp-test-design-import",
+          "pulp-test-design-import-react-runtime",
           "pulp-test-widget-bridge",
           "pulp-test-widget-bridge-runtime-import"
         ],
         "test_files": [
           "test/test_design_import.cpp",
+          "test/test_design_import_react_runtime.cpp",
           "test/test_widget_bridge.cpp",
           "test/test_widget_bridge_runtime_import.cpp"
         ],
@@ -716,7 +726,7 @@
         {
           "url": "planning/2026-05-17-jsx-instrument-import.md",
           "kind": "spec",
-          "proves": "Spec for the JSX runtime-import experimental slice (Phase A) — defines fixture shape, transform pipeline, and round-trip contract.",
+          "proves": "Spec for the JSX runtime-import experimental slice (Phase A) \u2014 defines fixture shape, transform pipeline, and round-trip contract.",
           "last_verified": "2026-05-18",
           "recheck_interval_days": null
         },

--- a/tools/import-validation/stitch-roundtrip.sh
+++ b/tools/import-validation/stitch-roundtrip.sh
@@ -78,7 +78,7 @@ if [[ $COVERAGE -eq 1 ]]; then
   default_ctest_regex='parse_stitch_react|WidgetBridge __pulpRuntimeImport__ dispatches Stitch|WidgetBridge __pulpRuntimeImport__ surfaces parse failure'
   export PULP_DIFF_COVER_CTEST_REGEX="${PULP_DIFF_COVER_CTEST_REGEX:-$default_ctest_regex}"
   bash "$PULP_DIR/tools/scripts/local_diff_cover.sh" \
-    pulp-test-design-import pulp-test-widget-bridge-runtime-import
+    pulp-test-design-import pulp-test-design-import-react-runtime pulp-test-widget-bridge-runtime-import
   green "Stitch parser diff coverage passed"
   exit 0
 fi
@@ -98,7 +98,7 @@ find_test_exe() {
 
 if [[ $SKIP_BUILD -eq 0 ]]; then
   cmake -S "$PULP_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
-  build_targets=(pulp-test-design-import pulp-test-widget-bridge-runtime-import)
+  build_targets=(pulp-test-design-import pulp-test-design-import-react-runtime pulp-test-widget-bridge-runtime-import)
   if [[ $PARSER_ONLY -eq 0 ]]; then
     build_targets+=(pulp-screenshot)
   fi
@@ -107,9 +107,11 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
 fi
 
 DESIGN_IMPORT_TEST="$(find_test_exe pulp-test-design-import)"
+DESIGN_IMPORT_REACT_RUNTIME_TEST="$(find_test_exe pulp-test-design-import-react-runtime)"
 WIDGET_BRIDGE_TEST="$(find_test_exe pulp-test-widget-bridge-runtime-import)"
 
 "$DESIGN_IMPORT_TEST" '[phase-6.6.4]'
+"$DESIGN_IMPORT_REACT_RUNTIME_TEST" '[phase-6.6.4]'
 "$WIDGET_BRIDGE_TEST" '[phase-6.6.4]'
 
 if [[ $PARSER_ONLY -eq 1 ]]; then

--- a/tools/import-validation/v0-roundtrip.sh
+++ b/tools/import-validation/v0-roundtrip.sh
@@ -78,7 +78,7 @@ if [[ $COVERAGE -eq 1 ]]; then
   default_ctest_regex='parse_v0_dev_react|WidgetBridge __pulpRuntimeImport__ dispatches v0|WidgetBridge __pulpRuntimeImport__ surfaces parse failure'
   export PULP_DIFF_COVER_CTEST_REGEX="${PULP_DIFF_COVER_CTEST_REGEX:-$default_ctest_regex}"
   bash "$PULP_DIR/tools/scripts/local_diff_cover.sh" \
-    pulp-test-design-import pulp-test-widget-bridge-runtime-import
+    pulp-test-design-import pulp-test-design-import-react-runtime pulp-test-widget-bridge-runtime-import
   green "v0 parser diff coverage passed"
   exit 0
 fi
@@ -99,13 +99,15 @@ find_test_exe() {
 if [[ $SKIP_BUILD -eq 0 ]]; then
   cmake -S "$PULP_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
   cmake --build "$BUILD_DIR" --parallel "$BUILD_JOBS" \
-    --target pulp-test-design-import pulp-test-widget-bridge-runtime-import
+    --target pulp-test-design-import pulp-test-design-import-react-runtime pulp-test-widget-bridge-runtime-import
 fi
 
 DESIGN_IMPORT_TEST="$(find_test_exe pulp-test-design-import)"
+DESIGN_IMPORT_REACT_RUNTIME_TEST="$(find_test_exe pulp-test-design-import-react-runtime)"
 WIDGET_BRIDGE_TEST="$(find_test_exe pulp-test-widget-bridge-runtime-import)"
 
 "$DESIGN_IMPORT_TEST" '[phase-6.6.2]'
+"$DESIGN_IMPORT_REACT_RUNTIME_TEST" '[phase-6.6.2]'
 "$WIDGET_BRIDGE_TEST" '[phase-6.6.2]'
 
 if [[ $PARSER_ONLY -eq 1 ]]; then


### PR DESCRIPTION
## Summary

Addresses **Codex P2 finding on PR #2422**: the React-runtime parser cluster (`parse_v0_dev_react` / `parse_figma_make_react` / `parse_stitch_react` / `parse_react_native_export` / `parse_pencil_react`) moved out of `pulp-test-design-import` into the newly-extracted `pulp-test-design-import-react-runtime` target, but the parser validation harnesses still built/ran only the parent target — so the `[phase-6.6.2..6]` tag invocations returned "no matching tests" and the import roundtrip lane silently lost runtime-parser coverage.

Updates 5 harness scripts (v0, figma, stitch, rn, pencil) to:
- Add `pulp-test-design-import-react-runtime` to the build target list (both the coverage and `SKIP_BUILD=0` paths).
- Resolve a `DESIGN_IMPORT_REACT_RUNTIME_TEST` executable handle via `find_test_exe`.
- Invoke the matching `[phase-6.6.X]` tag against the new executable immediately after the existing parent-target invocation.

Also updates `tools/import-validation/source-contracts.json` so each of the 5 affected sources lists the new target + extracted test file under `test_targets` / `test_files`.

## Test plan

- [x] `cmake --build build --target pulp-test-design-import-react-runtime`
- [x] `./build/test/pulp-test-design-import-react-runtime '[phase-6.6.2]'` → 30 assertions / 3 test cases (v0)
- [x] `./build/test/pulp-test-design-import-react-runtime '[phase-6.6.3]'` → 33 assertions / 4 test cases (figma)
- [ ] CI green across local-macOS + GH-hosted Ubuntu/Windows