### PR TITLE
refactor(mcp): P6-B4 first cut — JSON-RPC framing to mcp_json.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v01732"></a>
+## [0.173.2] - 2026-05-19
+
+- refactor(mcp): P6-B4 first cut — extract JSON-RPC framing to mcp_json.hpp (pulp_mcp.cpp 951 → 844)
+
 <a id="v01730"></a>
 ## [0.173.0] - 2026-05-19
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.173.1
+    VERSION 0.173.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/mcp/mcp_json.hpp
+++ b/tools/mcp/mcp_json.hpp
@@ -1,0 +1,154 @@
+// mcp_json.hpp — JSON-RPC 2.0 framing + minimal JSON field extraction
+// for the pulp-mcp server.
+//
+// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
+// refactor — first cut of the MCP typed-registry split. The pulp-mcp
+// server deliberately avoids an external JSON dependency; these are the
+// minimal building blocks for emitting JSON-RPC envelopes and pulling
+// scalar fields out of an incoming request.
+//
+// Helpers are header-inline so the framing layer can be shared by the
+// protocol handler and (in later B4 cuts) the per-domain tool modules
+// without an extra TU or ODR concern.
+
+#pragma once
+
+#include <cctype>
+#include <cstddef>
+#include <string>
+
+namespace pulp_mcp {
+
+// ── JSON emit ────────────────────────────────────────────────────────────────
+
+// Escape + quote a string as a JSON string literal.
+inline std::string json_string(const std::string& s) {
+    std::string out = "\"";
+    for (char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:   out += c;
+        }
+    }
+    out += "\"";
+    return out;
+}
+
+// JSON-RPC 2.0 error envelope.
+inline std::string json_error(const std::string& id, int code, const std::string& msg) {
+    return "{\"jsonrpc\":\"2.0\",\"id\":" + id +
+           ",\"error\":{\"code\":" + std::to_string(code) +
+           ",\"message\":" + json_string(msg) + "}}";
+}
+
+// JSON-RPC 2.0 result envelope.
+inline std::string json_result(const std::string& id, const std::string& result_json) {
+    return "{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":" + result_json + "}";
+}
+
+// MCP tool-call result payload: a text content block plus the raw
+// structured JSON under structuredContent.
+inline std::string json_tool_payload(const std::string& structured_json) {
+    return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(structured_json) +
+           "}],\"structuredContent\":" + structured_json + "}";
+}
+
+// ── JSON field extraction (simple, dependency-free parsing) ──────────────────
+
+// Pull a string value for `key` out of a flat JSON object. Returns empty
+// on any miss. Honors backslash-escaped quotes inside the value.
+inline std::string extract_string(const std::string& json, const std::string& key) {
+    auto key_pos = json.find("\"" + key + "\"");
+    if (key_pos == std::string::npos) return {};
+
+    auto colon = json.find(':', key_pos + key.size() + 2);
+    if (colon == std::string::npos) return {};
+
+    auto start = json.find('"', colon + 1);
+    if (start == std::string::npos) return {};
+
+    auto end = json.find('"', start + 1);
+    while (end != std::string::npos && json[end - 1] == '\\') {
+        end = json.find('"', end + 1);
+    }
+    if (end == std::string::npos) return {};
+
+    return json.substr(start + 1, end - start - 1);
+}
+
+// Pull the raw token (string-with-quotes, number, or null) for `key`.
+inline std::string extract_raw(const std::string& json, const std::string& key) {
+    auto key_pos = json.find("\"" + key + "\"");
+    if (key_pos == std::string::npos) return {};
+
+    auto colon = json.find(':', key_pos + key.size() + 2);
+    if (colon == std::string::npos) return {};
+
+    // Skip whitespace
+    auto start = colon + 1;
+    while (start < json.size() && (json[start] == ' ' || json[start] == '\t')) ++start;
+
+    if (start >= json.size()) return {};
+
+    // If it's a string
+    if (json[start] == '"') {
+        auto end = json.find('"', start + 1);
+        while (end != std::string::npos && json[end - 1] == '\\')
+            end = json.find('"', end + 1);
+        if (end == std::string::npos) return {};
+        return json.substr(start, end - start + 1);
+    }
+
+    // If it's a number or null
+    auto end = json.find_first_of(",}", start);
+    if (end == std::string::npos) end = json.size();
+    auto value = json.substr(start, end - start);
+    // Trim
+    while (!value.empty() && (value.back() == ' ' || value.back() == '\n')) value.pop_back();
+    return value;
+}
+
+// Typed extractors — fall back to `fallback` on miss / parse failure.
+inline int extract_int(const std::string& json, const std::string& key, int fallback) {
+    auto raw = extract_raw(json, key);
+    if (raw.empty() || raw == "null") return fallback;
+    try {
+        std::size_t pos = 0;
+        int value = std::stoi(raw, &pos);
+        while (pos < raw.size()) {
+            if (!std::isspace(static_cast<unsigned char>(raw[pos]))) return fallback;
+            ++pos;
+        }
+        return value;
+    } catch (...) {
+        return fallback;
+    }
+}
+
+inline double extract_double(const std::string& json, const std::string& key, double fallback) {
+    auto raw = extract_raw(json, key);
+    if (raw.empty() || raw == "null") return fallback;
+    try {
+        std::size_t pos = 0;
+        double value = std::stod(raw, &pos);
+        while (pos < raw.size()) {
+            if (!std::isspace(static_cast<unsigned char>(raw[pos]))) return fallback;
+            ++pos;
+        }
+        return value;
+    } catch (...) {
+        return fallback;
+    }
+}
+
+inline bool extract_bool(const std::string& json, const std::string& key, bool fallback) {
+    auto raw = extract_raw(json, key);
+    if (raw.empty() || raw == "null") return fallback;
+    return raw == "true" ? true : raw == "false" ? false : fallback;
+}
+
+}  // namespace pulp_mcp

--- a/tools/mcp/pulp_mcp.cpp
+++ b/tools/mcp/pulp_mcp.cpp
@@ -19,8 +19,22 @@
 #include <pulp/tools/audio/service.hpp>
 
 #include "pulp_mcp_version.h"
+#include "mcp_json.hpp"
 
 namespace fs = std::filesystem;
+
+// JSON-RPC framing + field extraction extracted to mcp_json.hpp in the
+// Phase 6 (B4) refactor. Pull the helpers into file scope so the rest
+// of this TU keeps its existing unqualified call sites.
+using pulp_mcp::json_string;
+using pulp_mcp::json_error;
+using pulp_mcp::json_result;
+using pulp_mcp::json_tool_payload;
+using pulp_mcp::extract_string;
+using pulp_mcp::extract_raw;
+using pulp_mcp::extract_int;
+using pulp_mcp::extract_double;
+using pulp_mcp::extract_bool;
 
 #if defined(_WIN32)
 #define PULP_POPEN _popen
@@ -30,90 +44,6 @@ namespace fs = std::filesystem;
 #define PULP_PCLOSE pclose
 #endif
 
-// ── JSON helpers (minimal, no external deps for MCP server) ──────────────────
-
-static std::string json_string(const std::string& s) {
-    std::string out = "\"";
-    for (char c : s) {
-        switch (c) {
-            case '"':  out += "\\\""; break;
-            case '\\': out += "\\\\"; break;
-            case '\n': out += "\\n"; break;
-            case '\r': out += "\\r"; break;
-            case '\t': out += "\\t"; break;
-            default:   out += c;
-        }
-    }
-    out += "\"";
-    return out;
-}
-
-static std::string json_error(const std::string& id, int code, const std::string& msg) {
-    return "{\"jsonrpc\":\"2.0\",\"id\":" + id +
-           ",\"error\":{\"code\":" + std::to_string(code) +
-           ",\"message\":" + json_string(msg) + "}}";
-}
-
-static std::string json_result(const std::string& id, const std::string& result_json) {
-    return "{\"jsonrpc\":\"2.0\",\"id\":" + id + ",\"result\":" + result_json + "}";
-}
-
-static std::string json_tool_payload(const std::string& structured_json) {
-    return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(structured_json) +
-           "}],\"structuredContent\":" + structured_json + "}";
-}
-
-// ── Extract JSON fields (simple parsing) ─────────────────────────────────────
-
-static std::string extract_string(const std::string& json, const std::string& key) {
-    auto key_pos = json.find("\"" + key + "\"");
-    if (key_pos == std::string::npos) return {};
-
-    auto colon = json.find(':', key_pos + key.size() + 2);
-    if (colon == std::string::npos) return {};
-
-    auto start = json.find('"', colon + 1);
-    if (start == std::string::npos) return {};
-
-    auto end = json.find('"', start + 1);
-    while (end != std::string::npos && json[end - 1] == '\\') {
-        end = json.find('"', end + 1);
-    }
-    if (end == std::string::npos) return {};
-
-    return json.substr(start + 1, end - start - 1);
-}
-
-static std::string extract_raw(const std::string& json, const std::string& key) {
-    auto key_pos = json.find("\"" + key + "\"");
-    if (key_pos == std::string::npos) return {};
-
-    auto colon = json.find(':', key_pos + key.size() + 2);
-    if (colon == std::string::npos) return {};
-
-    // Skip whitespace
-    auto start = colon + 1;
-    while (start < json.size() && (json[start] == ' ' || json[start] == '\t')) ++start;
-
-    if (start >= json.size()) return {};
-
-    // If it's a string
-    if (json[start] == '"') {
-        auto end = json.find('"', start + 1);
-        while (end != std::string::npos && json[end - 1] == '\\')
-            end = json.find('"', end + 1);
-        if (end == std::string::npos) return {};
-        return json.substr(start, end - start + 1);
-    }
-
-    // If it's a number or null
-    auto end = json.find_first_of(",}", start);
-    if (end == std::string::npos) end = json.size();
-    auto value = json.substr(start, end - start);
-    // Trim
-    while (!value.empty() && (value.back() == ' ' || value.back() == '\n')) value.pop_back();
-    return value;
-}
 
 // ── Shell execution ──────────────────────────────────────────────────────────
 
@@ -497,43 +427,6 @@ static std::string handle_audio_read_bundle(const std::string& params_json) {
     return json_tool_payload(pulp::tools::audio::to_json(bundle));
 }
 
-static int extract_int(const std::string& json, const std::string& key, int fallback) {
-    auto raw = extract_raw(json, key);
-    if (raw.empty() || raw == "null") return fallback;
-    try {
-        std::size_t pos = 0;
-        int value = std::stoi(raw, &pos);
-        while (pos < raw.size()) {
-            if (!std::isspace(static_cast<unsigned char>(raw[pos]))) return fallback;
-            ++pos;
-        }
-        return value;
-    } catch (...) {
-        return fallback;
-    }
-}
-
-static double extract_double(const std::string& json, const std::string& key, double fallback) {
-    auto raw = extract_raw(json, key);
-    if (raw.empty() || raw == "null") return fallback;
-    try {
-        std::size_t pos = 0;
-        double value = std::stod(raw, &pos);
-        while (pos < raw.size()) {
-            if (!std::isspace(static_cast<unsigned char>(raw[pos]))) return fallback;
-            ++pos;
-        }
-        return value;
-    } catch (...) {
-        return fallback;
-    }
-}
-
-static bool extract_bool(const std::string& json, const std::string& key, bool fallback) {
-    auto raw = extract_raw(json, key);
-    if (raw.empty() || raw == "null") return fallback;
-    return raw == "true" ? true : raw == "false" ? false : fallback;
-}
 
 static std::string handle_audio_excerpt_find(const std::string& params_json) {
     auto text = extract_string(params_json, "text");


### PR DESCRIPTION
## Summary

**Phase 6 B4 (MCP typed-registry split), first cut.** The `pulp-mcp` server deliberately avoids an external JSON dependency — this extracts its minimal JSON-RPC 2.0 framing + field-extraction layer into a shared header so later B4 cuts (per-domain tool modules) can reuse it without an extra TU.

New `tools/mcp/mcp_json.hpp` (header-only, `inline`, `namespace pulp_mcp`):
- `json_string` / `json_error` / `json_result` / `json_tool_payload` — JSON-RPC 2.0 envelope emit
- `extract_string` / `extract_raw` — flat-object field extraction
- `extract_int` / `extract_double` / `extract_bool` — typed extractors with fallback

`pulp_mcp.cpp` pulls the helpers into file scope via `using`-declarations so every existing unqualified call site is unchanged — zero behavior delta.

`pulp_mcp.cpp`: **951 → 844 (-107 lines)**. Phased B4 (like R2-1 local_ci.py); subsequent cuts will peel the compat/SDK-resolution module and the per-domain tool handlers.

## Test plan

- [x] `cmake --build build --target pulp-mcp` — builds clean
- [x] JSON-RPC round-trip smoke: `initialize` + `tools/list` produce valid `{"jsonrpc":"2.0",...}` envelopes
- [ ] CI green across local-macOS + GH-hosted Ubuntu/Windows