### PR TITLE
feat(inspect): Phase 2.5 — Photoshop-layers tweak management panel

### DIFF
--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -189,6 +189,23 @@ public:
     /// optimistically (none yet — Phase 3b commits only on Enter).
     void cancel_field_edit();
 
+    // ── Phase 2.5 — tweak management panel (Photoshop-layers style) ─
+    //
+    // A scrollable panel listing every tweak in the attached
+    // TweakStore, grouped by anchor. Each tweak row carries three
+    // per-tweak controls: bypass (eye), lock, and delete. Toggled with
+    // the `T` key while the inspector is active. Default OFF so the
+    // pre-2.5 inspector layout is unchanged until the user opts in.
+    void set_tweaks_panel_visible(bool visible) { tweaks_panel_visible_ = visible; }
+    bool tweaks_panel_visible() const { return tweaks_panel_visible_; }
+    void toggle_tweaks_panel() { tweaks_panel_visible_ = !tweaks_panel_visible_; }
+
+    /// Number of tweak rows currently laid out in the management panel
+    /// (populated by the most recent paint() while the panel is
+    /// visible). Visible for tests so they can assert the panel
+    /// rendered the expected number of rows without scraping pixels.
+    std::size_t tweak_row_count() const { return tweak_rows_.size(); }
+
 private:
     View& root_;
     bool active_ = false;
@@ -232,6 +249,24 @@ private:
         float value;        ///< Current numeric value (for display + edit-begin)
     };
     std::vector<EditableField> editable_fields_;
+
+    // ── Phase 2.5 — tweak management panel state ────────────────────
+    //
+    // The panel is laid out during paint_tweaks_section(); the row
+    // hit-rects are stashed in tweak_rows_ so the SAME-frame mouse
+    // handler can resolve a click to a (anchor, path, action). Each
+    // row carries three 16×16 icon hit-rects: bypass / lock / delete.
+    bool tweaks_panel_visible_ = false;
+    float tweaks_scroll_y_ = 0.0f;
+    enum class TweakAction : std::uint8_t { none, bypass, lock, remove };
+    struct TweakRow {
+        std::string anchor_id;     ///< Owning anchor
+        std::string property_path; ///< Dotted path of this tweak
+        Rect bypass_icon;          ///< Hit-rect, root coords
+        Rect lock_icon;
+        Rect delete_icon;
+    };
+    std::vector<TweakRow> tweak_rows_;
 
     // Tree expansion: collapsed nodes
     std::unordered_set<const View*> collapsed_;
@@ -311,9 +346,19 @@ private:
     /// draw-call counts, and a 60-frame sparkline trend.
     void paint_pass_attribution(Canvas& canvas, float x, float y, float w, float h);
 
+    // Phase 2.5 — render the tweak management panel into the given
+    // rect. Repopulates tweak_rows_ with this frame's hit-rects.
+    void paint_tweaks_section(Canvas& canvas, float x, float y, float w, float h);
+
     // ── Panel hit testing ───────────────────────────────────────────
     bool point_in_panel(Point p) const;
     const TreeItem* tree_item_at_y(float panel_y) const;
+
+    // Phase 2.5 — resolve a root-coord point to a tweak-row icon hit.
+    // Sets `out_row` to the matching row index and returns the action;
+    // returns TweakAction::none (out_row untouched) on a miss. Called
+    // by handle_mouse_event() before the tree-selection fallthrough.
+    TweakAction tweak_action_at(Point p, std::size_t& out_row) const;
 
     // ── Phase 3b — editable-field helpers ───────────────────────────
     /// Returns the index in editable_fields_ at the given root-coord

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -47,6 +47,10 @@ namespace methods {
     constexpr auto kInspectorListTweaks  = "Inspector.listTweaks";
     constexpr auto kInspectorClearTweaks = "Inspector.clearTweaks";
     constexpr auto kInspectorSetBypass   = "Inspector.setBypass";
+    // Phase 2.5: setLocked toggles the sibling `locked` overlay for an
+    // anchor — a locked anchor is protected from bulk-clear / reimport.
+    // Mirrors setBypass; the management panel surfaces this state.
+    constexpr auto kInspectorSetLocked   = "Inspector.setLocked";
     // Phase 1: pulp-tweaks.json disk persistence. All three require a
     // TweakStore wired in. Path defaults to $PULP_TWEAKS_FILE or the
     // resolved <project>/pulp-tweaks.json — see TweakStore::default_tweaks_path().

--- a/inspect/include/pulp/inspect/tweak_store.hpp
+++ b/inspect/include/pulp/inspect/tweak_store.hpp
@@ -15,12 +15,19 @@
 //     "version": 1,
 //     "tweaks":   Record<anchor, Record<dottedPath, value>>,
 //     "bypassed": Record<anchor, true | string[]>,
+//     "locked":   string[]                                     // optional
 //     "sources":  Record<anchor, Record<dottedPath, string>>   // optional
 //   }
 //
 // Per Codex Phase 0b review: bypass IS a SIBLING overlay, not
 // `applied:false` mixed into the dotted-path tweak map. That preserves
 // v1 backwards compatibility — old files with only `tweaks` still load.
+//
+// Phase 2.5: `locked` is a third sibling overlay — a flat list of
+// anchor ids the user has marked as protected from bulk-clear /
+// reimport. It mirrors the bypass overlay shape (anchor-keyed,
+// additive, omitted entirely when empty) so old v1 files still load
+// and a build that doesn't understand `locked` simply ignores it.
 //
 // Atomic-write contract: save_to_disk() writes to `<path>.tmp` then
 // renames over the target so a crash mid-write never leaves a
@@ -36,6 +43,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -83,7 +91,7 @@ public:
     /// removed.
     std::size_t remove_anchor(std::string_view anchor_id);
 
-    /// Clear the entire table (tweaks + bypass overlay).
+    /// Clear the entire table (tweaks + bypass overlay + lock set).
     void clear();
 
     /// Set the bypass state for an anchor.
@@ -95,6 +103,18 @@ public:
     /// Convenience: clear the bypass for an anchor (equivalent to
     /// set_bypass(id, false)).
     void clear_bypass(std::string_view anchor_id);
+
+    /// Set the lock state for an anchor (Phase 2.5 — tweak management
+    /// panel). A locked anchor is protected from being cleared by a
+    /// bulk operation or by re-import. `locked=true` adds the anchor
+    /// to the lock set; `locked=false` removes it. Lock is a sibling
+    /// overlay — it never affects whether a tweak is applied, only
+    /// whether destructive bulk operations may remove it.
+    void set_locked(std::string_view anchor_id, bool locked);
+
+    /// Convenience: clear the lock for an anchor (equivalent to
+    /// set_locked(id, false)).
+    void clear_lock(std::string_view anchor_id);
 
     // ── Inspection ──────────────────────────────────────────────────
 
@@ -130,6 +150,15 @@ public:
     /// round-trip the bypass state.
     std::vector<std::string> bypassed_anchors() const;
 
+    /// Whether `anchor_id` is currently locked (Phase 2.5).
+    bool is_locked(std::string_view anchor_id) const;
+
+    /// Return every anchor id that currently carries a lock, in
+    /// unspecified order. Mirrors bypassed_anchors() — used by the
+    /// management panel and the disk-persistence path so lock state
+    /// round-trips even for anchors with no active tweaks.
+    std::vector<std::string> locked_anchors() const;
+
     // ── Phase 1: disk persistence ───────────────────────────────────
 
     /// On-disk schema version. Bumped if/when we ever break the format.
@@ -161,9 +190,9 @@ public:
 
     /// Enable / disable post-mutation auto-save. When enabled, every
     /// successful apply_tweak / remove_tweak / remove_anchor / clear /
-    /// set_bypass / clear_bypass call flushes the table to disk at
-    /// `path` (or default_tweaks_path() if empty). Default OFF so unit
-    /// tests don't write to disk by accident.
+    /// set_bypass / clear_bypass / set_locked / clear_lock call flushes
+    /// the table to disk at `path` (or default_tweaks_path() if empty).
+    /// Default OFF so unit tests don't write to disk by accident.
     ///
     /// Set `enabled=false` to disable. The `path` is ignored when
     /// disabling.
@@ -205,6 +234,9 @@ private:
     std::unordered_map<std::string,
                        std::unordered_map<std::string, Entry>> tweaks_;
     std::unordered_map<std::string, BypassValue> bypassed_;
+    // Phase 2.5: anchor ids the user has marked as locked. A flat set
+    // (lock has no per-path granularity — it protects a whole anchor).
+    std::unordered_set<std::string> locked_;
 
     // Auto-save state. When `auto_save_` is true, every successful
     // mutation re-flushes the table to `auto_save_path_` after the

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -171,9 +171,16 @@ InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
             }, *b);
         }
 
+        // Phase 2.5: surface the `locked` overlay so the management
+        // panel and disk-persistence path can round-trip lock state.
+        auto locked_arr = choc::value::createEmptyArray();
+        for (auto& anchor : tweak_store_->locked_anchors())
+            locked_arr.addArrayElement(choc::value::createString(anchor));
+
         auto resp = choc::value::createObject("");
         resp.addMember("tweaks", tweaks_obj);
         resp.addMember("bypassed", bypassed_obj);
+        resp.addMember("locked", locked_arr);
         resp.addMember("count", choc::value::createInt64(static_cast<int64_t>(records.size())));
         return make_response(req.id, choc::json::toString(resp, false));
     }
@@ -361,6 +368,26 @@ InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
             return make_response(req.id, choc::json::toString(resp, false));
         } catch (...) {
             return make_error(req.id, "Invalid params for Inspector.setBypass");
+        }
+    }
+    // ── Phase 2.5: setLocked — mirrors setBypass for the lock overlay ──
+    if (req.method == methods::kInspectorSetLocked) {
+        if (!tweak_store_) return make_error(req.id, "No tweak store attached");
+        try {
+            auto params = choc::json::parse(req.params_json);
+            auto anchor = std::string(params["anchorId"].getString());
+            if (!params.hasObjectMember("value") || !params["value"].isBool()) {
+                return make_error(req.id,
+                    "Inspector.setLocked requires `value` as bool");
+            }
+            tweak_store_->set_locked(anchor, params["value"].getBool());
+            auto resp = choc::value::createObject("");
+            resp.addMember("ok", choc::value::createBool(true));
+            resp.addMember("locked", choc::value::createBool(
+                tweak_store_->is_locked(anchor)));
+            return make_response(req.id, choc::json::toString(resp, false));
+        } catch (...) {
+            return make_error(req.id, "Invalid params for Inspector.setLocked");
         }
     }
 

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -199,6 +199,15 @@ bool InspectorOverlay::handle_key_event(const KeyEvent& event) {
         return true;
     }
 
+    // Phase 2.5 — T toggles the tweak management panel (no modifier;
+    // only while the inspector is active). Guarded behind not-editing
+    // so typing a 't' into a field-edit buffer doesn't flip the panel.
+    if (active_ && editing_field_.empty() && event.key == KeyCode::t &&
+        event.is_down && event.modifiers == 0) {
+        toggle_tweaks_panel();
+        return true;
+    }
+
     return false;
 }
 
@@ -303,6 +312,44 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
         alt_hover_target_ = nullptr;
 
         if (event.is_down) {
+            // Phase 2.5 — clicks on a tweak-row icon (bypass / lock /
+            // delete) in the management panel. Checked first so an
+            // icon click never falls through to tree selection or
+            // field-edit. The hit list (tweak_rows_) is populated by
+            // the most recent paint_tweaks_section() call.
+            if (tweaks_panel_visible_ && tweak_store_) {
+                std::size_t row_idx = 0;
+                auto action = tweak_action_at(pos, row_idx);
+                if (action != TweakAction::none) {
+                    const auto& row = tweak_rows_[row_idx];
+                    switch (action) {
+                        case TweakAction::bypass: {
+                            // Toggle whole-anchor bypass. A path-list
+                            // bypass collapses to whole-anchor here —
+                            // the panel's bypass control is anchor-
+                            // scoped (the row just surfaces it).
+                            bool now =
+                                tweak_store_->is_bypassed(row.anchor_id,
+                                                          row.property_path);
+                            tweak_store_->set_bypass(row.anchor_id, !now);
+                            break;
+                        }
+                        case TweakAction::lock: {
+                            bool now = tweak_store_->is_locked(row.anchor_id);
+                            tweak_store_->set_locked(row.anchor_id, !now);
+                            break;
+                        }
+                        case TweakAction::remove:
+                            tweak_store_->remove_tweak(row.anchor_id,
+                                                       row.property_path);
+                            break;
+                        case TweakAction::none:
+                            break;
+                    }
+                    return true;
+                }
+            }
+
             // Phase 3b — clicks on numeric values in the property
             // panel enter edit mode. The hit list is populated by the
             // most recent paint_props_section() call; we check it
@@ -593,29 +640,53 @@ void InspectorOverlay::paint_panel(Canvas& canvas) {
     canvas.set_line_width(1.0f);
     canvas.stroke_line(panel_x, 0, panel_x, root_h);
 
-    // Tree section (top half)
-    float tree_height = root_h * 0.5f;
-    float cursor_y = 4.0f;
-    paint_tree_section(canvas, panel_x + 8, 4, panel_width_ - 16, cursor_y);
-
-    // Divider
-    float props_y = tree_height;
-    canvas.set_stroke_color(Color::rgba(0.3f, 0.3f, 0.35f, 0.5f));
-    canvas.stroke_line(panel_x + 8, props_y, root_w - 8, props_y);
-
-    // Props section (middle). Phase 6.1 — when the per-pass attribution
-    // viewer is toggled on (P-key), it takes over this region instead
-    // of the property panel; the tree section above is untouched so the
-    // user keeps navigation context.
     float stats_y = root_h - kStatsBarHeight;
-    float section_x = panel_x + 8;
-    float section_y = props_y + 4;
-    float section_w = panel_width_ - 16;
-    float section_h = stats_y - props_y - 8;
-    if (pass_viewer_enabled_) {
-        paint_pass_attribution(canvas, section_x, section_y, section_w, section_h);
+
+    // Helper: paint the middle "props" region. Phase 6.1 — when the
+    // per-pass attribution viewer is toggled on (P-key), it takes over
+    // this region instead of the property panel; the tree section above
+    // is untouched so the user keeps navigation context.
+    auto paint_middle = [&](float x, float y, float w, float h) {
+        if (pass_viewer_enabled_) {
+            paint_pass_attribution(canvas, x, y, w, h);
+        } else {
+            paint_props_section(canvas, x, y, w, h);
+        }
+    };
+
+    if (tweaks_panel_visible_) {
+        // Phase 2.5 layout: tree (top third), props (middle third),
+        // tweaks management panel (bottom third). When the panel is
+        // hidden the legacy two-section layout is used (below).
+        float section_h = (stats_y) / 3.0f;
+
+        float cursor_y = 4.0f;
+        paint_tree_section(canvas, panel_x + 8, 4, panel_width_ - 16, cursor_y);
+
+        float props_y = section_h;
+        canvas.set_stroke_color(Color::rgba(0.3f, 0.3f, 0.35f, 0.5f));
+        canvas.stroke_line(panel_x + 8, props_y, root_w - 8, props_y);
+        paint_middle(panel_x + 8, props_y + 4,
+                     panel_width_ - 16, section_h - 8);
+
+        float tweaks_y = section_h * 2.0f;
+        canvas.set_stroke_color(Color::rgba(0.3f, 0.3f, 0.35f, 0.5f));
+        canvas.stroke_line(panel_x + 8, tweaks_y, root_w - 8, tweaks_y);
+        paint_tweaks_section(canvas, panel_x + 8, tweaks_y + 4,
+                             panel_width_ - 16, stats_y - tweaks_y - 8);
     } else {
-        paint_props_section(canvas, section_x, section_y, section_w, section_h);
+        // Legacy two-section layout (pre-2.5).
+        tweak_rows_.clear();
+        float tree_height = root_h * 0.5f;
+        float cursor_y = 4.0f;
+        paint_tree_section(canvas, panel_x + 8, 4, panel_width_ - 16, cursor_y);
+
+        float props_y = tree_height;
+        canvas.set_stroke_color(Color::rgba(0.3f, 0.3f, 0.35f, 0.5f));
+        canvas.stroke_line(panel_x + 8, props_y, root_w - 8, props_y);
+
+        paint_middle(panel_x + 8, props_y + 4,
+                     panel_width_ - 16, stats_y - props_y - 8);
     }
 
     // Stats bar (bottom)
@@ -1159,6 +1230,236 @@ void InspectorOverlay::paint_pass_attribution(Canvas& canvas, float x, float y,
         canvas.set_fill_color(kPanelDim);
         canvas.fill_text("Awaiting render frames\xe2\x80\xa6", x, line_y + 11);
     }
+}
+
+// ── Phase 2.5 — Tweak management panel (Photoshop-layers style) ─────────────
+//
+// Lists every tweak in the attached TweakStore, grouped by anchor.
+// Each tweak is a "layer" with three per-tweak controls:
+//   eye   — bypass toggle (filled when active, hollow when bypassed)
+//   lock  — protect from bulk-clear / reimport
+//   trash — delete the tweak
+// The row hit-rects are stashed in tweak_rows_ so the same-frame mouse
+// handler can resolve a click. Anchor headers carry an abbreviated id;
+// each row shows the dotted property path + a compact value preview.
+
+namespace {
+
+// Compact value preview for a tweak — keeps the row narrow. Numbers
+// print without trailing-zero noise; strings clip to 16 chars.
+std::string preview_value(const choc::value::Value& v) {
+    if (v.isString()) {
+        auto s = std::string(v.getString());
+        if (s.size() > 16) s = s.substr(0, 15) + "\xe2\x80\xa6";
+        return "\"" + s + "\"";
+    }
+    if (v.isBool()) return v.getBool() ? "true" : "false";
+    if (v.isInt32() || v.isInt64())
+        return std::to_string(v.getWithDefault<int64_t>(0));
+    if (v.isFloat32() || v.isFloat64()) {
+        std::ostringstream oss;
+        oss << v.getWithDefault<double>(0.0);
+        return oss.str();
+    }
+    if (v.isObject()) return "{\xe2\x80\xa6}";
+    if (v.isArray()) return "[\xe2\x80\xa6]";
+    return "?";
+}
+
+// Abbreviate an anchor id for the header — keep the tail (most
+// distinctive) but cap total width so the header never overflows.
+std::string abbreviate_anchor(const std::string& id) {
+    constexpr std::size_t kMax = 22;
+    if (id.size() <= kMax) return id;
+    return "\xe2\x80\xa6" + id.substr(id.size() - (kMax - 1));
+}
+
+}  // namespace
+
+void InspectorOverlay::paint_tweaks_section(Canvas& canvas, float x, float y,
+                                            float w, float h) {
+    // Repopulated every frame — the mouse handler reads it on the same
+    // frame the user clicked (paint runs before input dispatch).
+    tweak_rows_.clear();
+
+    canvas.set_font("monospace", kFontSize);
+
+    // Section heading.
+    canvas.set_fill_color(kHighlightStroke);
+    canvas.fill_text("Tweaks", x, y + 11);
+
+    if (!tweak_store_) {
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text("No tweak store attached", x, y + 11 + kRowHeight);
+        return;
+    }
+
+    auto records = tweak_store_->list_tweaks();
+    {
+        std::ostringstream count_oss;
+        count_oss << records.size() << (records.size() == 1 ? " tweak" : " tweaks");
+        canvas.set_fill_color(kPanelDim);
+        float cw = canvas.measure_text(count_oss.str());
+        canvas.fill_text(count_oss.str(), x + w - cw, y + 11);
+    }
+
+    if (records.empty()) {
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text("No tweaks recorded", x, y + 11 + kRowHeight);
+        return;
+    }
+
+    // Group records by anchor — stable insertion order within an
+    // anchor (list_tweaks() preserves it), anchors sorted so the panel
+    // doesn't reshuffle across frames.
+    std::vector<std::string> anchor_order;
+    std::unordered_map<std::string, std::vector<const TweakStore::Record*>> grouped;
+    for (auto& rec : records) {
+        auto it = grouped.find(rec.anchor_id);
+        if (it == grouped.end()) {
+            grouped.emplace(rec.anchor_id,
+                            std::vector<const TweakStore::Record*>{&rec});
+            anchor_order.push_back(rec.anchor_id);
+        } else {
+            it->second.push_back(&rec);
+        }
+    }
+    std::sort(anchor_order.begin(), anchor_order.end());
+
+    // Clip the scroll region so rows don't bleed into the stats bar.
+    canvas.save();
+    float list_top = y + kRowHeight;
+    canvas.clip_rect(x, list_top, w, h - kRowHeight);
+
+    float row_y = list_top - tweaks_scroll_y_;
+    constexpr float kIconSize = 14.0f;
+    constexpr float kIconGap = 4.0f;
+    // Three icons stacked at the right edge of the row.
+    float icons_w = 3.0f * kIconSize + 2.0f * kIconGap;
+
+    for (auto& anchor : anchor_order) {
+        bool anchor_locked = tweak_store_->is_locked(anchor);
+
+        // Anchor header row.
+        if (row_y > list_top - kRowHeight && row_y < y + h) {
+            canvas.set_fill_color(kPanelHighlight);
+            canvas.fill_rect(x, row_y, w, kRowHeight);
+            canvas.set_fill_color(kHighlightStroke);
+            std::string hdr = abbreviate_anchor(anchor);
+            if (anchor_locked) hdr = "\xf0\x9f\x94\x92 " + hdr;  // 🔒
+            canvas.fill_text(hdr, x + 2, row_y + 14);
+        }
+        row_y += kRowHeight;
+
+        for (const auto* rec : grouped[anchor]) {
+            bool visible = row_y > list_top - kRowHeight && row_y < y + h;
+            bool bypassed = tweak_store_->is_bypassed(rec->anchor_id,
+                                                      rec->property_path);
+
+            // Always record the hit-rects, even off-screen rows, so
+            // tweak_row_count() is the true total; off-screen rects
+            // simply never get clicked.
+            float icons_x = x + w - icons_w;
+            TweakRow hr;
+            hr.anchor_id = rec->anchor_id;
+            hr.property_path = rec->property_path;
+            hr.bypass_icon = {icons_x, row_y + 3, kIconSize, kIconSize};
+            hr.lock_icon   = {icons_x + kIconSize + kIconGap, row_y + 3,
+                              kIconSize, kIconSize};
+            hr.delete_icon = {icons_x + 2 * (kIconSize + kIconGap), row_y + 3,
+                              kIconSize, kIconSize};
+            tweak_rows_.push_back(hr);
+
+            if (visible) {
+                // Bypassed rows render dimmed to read like a hidden
+                // Photoshop layer.
+                const Color& path_col = bypassed ? kPanelDim : kPanelText;
+
+                // Property path (indented under the anchor header).
+                std::string label = rec->property_path;
+                float max_label_w = (icons_x - kIconGap) - (x + kIndent);
+                while (label.size() > 4 &&
+                       canvas.measure_text(label + " = ") > max_label_w)
+                    label = label.substr(0, label.size() - 1);
+                canvas.set_fill_color(path_col);
+                canvas.fill_text(label, x + kIndent, row_y + 14);
+
+                // Value preview.
+                std::string val = preview_value(rec->value);
+                canvas.set_fill_color(kPanelDim);
+                float label_w = canvas.measure_text(label + " ");
+                canvas.fill_text("= " + val, x + kIndent + label_w, row_y + 14);
+
+                // ── Icon: bypass (eye) ──────────────────────────────
+                // Filled circle = visible/applied; hollow = bypassed.
+                {
+                    auto& r = hr.bypass_icon;
+                    float cx = r.x + r.width / 2, cy = r.y + r.height / 2;
+                    if (bypassed) {
+                        canvas.set_stroke_color(kPanelDim);
+                        canvas.set_line_width(1.5f);
+                        canvas.stroke_line(r.x, r.y + r.height,
+                                           r.x + r.width, r.y);
+                        canvas.set_stroke_color(kPanelDim);
+                        canvas.stroke_rect(r.x, r.y, r.width, r.height);
+                    } else {
+                        canvas.set_fill_color(kHighlightStroke);
+                        canvas.fill_circle(cx, cy, r.width / 2 - 1);
+                    }
+                }
+                // ── Icon: lock ──────────────────────────────────────
+                {
+                    auto& r = hr.lock_icon;
+                    Color lock_col = anchor_locked
+                        ? Color::rgba(1.0f, 0.78f, 0.2f, 1.0f)
+                        : kPanelDim;
+                    // Shackle (arc approximated by a rounded rect) +
+                    // body box.
+                    canvas.set_stroke_color(lock_col);
+                    canvas.set_line_width(1.5f);
+                    canvas.stroke_rect(r.x + 3, r.y + 1, r.width - 6,
+                                       r.height / 2);
+                    canvas.set_fill_color(lock_col);
+                    canvas.fill_rounded_rect(r.x + 1, r.y + r.height / 2 - 1,
+                                             r.width - 2, r.height / 2, 2);
+                }
+                // ── Icon: delete (trash) ────────────────────────────
+                {
+                    auto& r = hr.delete_icon;
+                    canvas.set_stroke_color(
+                        Color::rgba(1.0f, 0.4f, 0.35f, 1.0f));
+                    canvas.set_line_width(1.5f);
+                    // Lid.
+                    canvas.stroke_line(r.x + 1, r.y + 3,
+                                       r.x + r.width - 1, r.y + 3);
+                    // Body box.
+                    canvas.stroke_rect(r.x + 2, r.y + 3, r.width - 4,
+                                       r.height - 4);
+                    // Handle.
+                    canvas.stroke_line(r.x + r.width / 2 - 2, r.y + 1,
+                                       r.x + r.width / 2 + 2, r.y + 1);
+                }
+            }
+            row_y += kRowHeight;
+        }
+    }
+
+    canvas.restore();
+}
+
+InspectorOverlay::TweakAction
+InspectorOverlay::tweak_action_at(Point p, std::size_t& out_row) const {
+    auto hit = [&](const Rect& r) {
+        return p.x >= r.x && p.x <= r.x + r.width &&
+               p.y >= r.y && p.y <= r.y + r.height;
+    };
+    for (std::size_t i = 0; i < tweak_rows_.size(); ++i) {
+        const auto& row = tweak_rows_[i];
+        if (hit(row.bypass_icon)) { out_row = i; return TweakAction::bypass; }
+        if (hit(row.lock_icon))   { out_row = i; return TweakAction::lock; }
+        if (hit(row.delete_icon)) { out_row = i; return TweakAction::remove; }
+    }
+    return TweakAction::none;
 }
 
 // ── Phase 3b — Live-editable box-model fields ───────────────────────────────

--- a/inspect/src/tweak_store.cpp
+++ b/inspect/src/tweak_store.cpp
@@ -140,9 +140,16 @@ std::size_t TweakStore::remove_anchor(std::string_view anchor_id) {
 void TweakStore::clear() {
     {
         std::lock_guard lock(mtx_);
-        tweaks_.clear();
-        bypassed_.clear();
-        locked_.clear();
+        decltype(tweaks_) kept_tweaks;
+        decltype(bypassed_) kept_bypassed;
+        for (const auto& anchor : locked_) {
+            if (auto it = tweaks_.find(anchor); it != tweaks_.end())
+                kept_tweaks.emplace(anchor, it->second);
+            if (auto it = bypassed_.find(anchor); it != bypassed_.end())
+                kept_bypassed.emplace(anchor, it->second);
+        }
+        tweaks_ = std::move(kept_tweaks);
+        bypassed_ = std::move(kept_bypassed);
     }
     maybe_auto_save_unlocked();
 }
@@ -466,6 +473,23 @@ TweakStore::from_json_locked(std::string_view json) {
             if (locked_arr[i].isString())
                 new_locked.insert(std::string(locked_arr[i].getString()));
         }
+    }
+
+    // Existing locked anchors are protected against bulk import. A
+    // missing or stale file must not erase local protected tweaks, bypass
+    // overlays, or lock metadata.
+    for (const auto& anchor : locked_) {
+        if (auto it = tweaks_.find(anchor); it != tweaks_.end()) {
+            new_tweaks[anchor] = it->second;
+        } else {
+            new_tweaks.erase(anchor);
+        }
+        if (auto it = bypassed_.find(anchor); it != bypassed_.end()) {
+            new_bypassed[anchor] = it->second;
+        } else {
+            new_bypassed.erase(anchor);
+        }
+        new_locked.insert(anchor);
     }
 
     // All-or-nothing commit.

--- a/inspect/src/tweak_store.cpp
+++ b/inspect/src/tweak_store.cpp
@@ -142,6 +142,7 @@ void TweakStore::clear() {
         std::lock_guard lock(mtx_);
         tweaks_.clear();
         bypassed_.clear();
+        locked_.clear();
     }
     maybe_auto_save_unlocked();
 }
@@ -167,6 +168,26 @@ void TweakStore::clear_bypass(std::string_view anchor_id) {
     {
         std::lock_guard lock(mtx_);
         bypassed_.erase(std::string(anchor_id));
+    }
+    maybe_auto_save_unlocked();
+}
+
+void TweakStore::set_locked(std::string_view anchor_id, bool locked) {
+    {
+        std::lock_guard lock(mtx_);
+        if (locked) {
+            locked_.insert(std::string(anchor_id));
+        } else {
+            locked_.erase(std::string(anchor_id));
+        }
+    }
+    maybe_auto_save_unlocked();
+}
+
+void TweakStore::clear_lock(std::string_view anchor_id) {
+    {
+        std::lock_guard lock(mtx_);
+        locked_.erase(std::string(anchor_id));
     }
     maybe_auto_save_unlocked();
 }
@@ -235,6 +256,19 @@ std::vector<std::string> TweakStore::bypassed_anchors() const {
     return out;
 }
 
+bool TweakStore::is_locked(std::string_view anchor_id) const {
+    std::lock_guard lock(mtx_);
+    return locked_.find(std::string(anchor_id)) != locked_.end();
+}
+
+std::vector<std::string> TweakStore::locked_anchors() const {
+    std::lock_guard lock(mtx_);
+    std::vector<std::string> out;
+    out.reserve(locked_.size());
+    for (auto& anchor : locked_) out.push_back(anchor);
+    return out;
+}
+
 // ── Disk persistence (Phase 1) ──────────────────────────────────────────
 
 std::string TweakStore::default_tweaks_path() {
@@ -295,6 +329,19 @@ std::string TweakStore::to_json_locked() const {
     }
     obj.addMember("bypassed", bypassed_obj);
 
+    // locked: string[] — flat list of anchor ids the user marked as
+    // protected (Phase 2.5). Only emitted when non-empty so trivial
+    // files stay small and v1 readers that don't know about `locked`
+    // simply never see the key. Sorted for deterministic round-trips.
+    if (!locked_.empty()) {
+        std::vector<std::string> sorted(locked_.begin(), locked_.end());
+        std::sort(sorted.begin(), sorted.end());
+        auto locked_arr = choc::value::createEmptyArray();
+        for (auto& a : sorted)
+            locked_arr.addArrayElement(choc::value::createString(a));
+        obj.addMember("locked", locked_arr);
+    }
+
     // sources: Record<anchor, Record<path, source>> — only when at
     // least one entry has a non-empty source tag. Keeps trivial files
     // small and matches the TS canonical schema (which doesn't define
@@ -349,6 +396,7 @@ TweakStore::from_json_locked(std::string_view json) {
     // Stage the new state in locals; only commit if everything parses.
     decltype(tweaks_) new_tweaks;
     decltype(bypassed_) new_bypassed;
+    decltype(locked_) new_locked;
 
     if (parsed.hasObjectMember("tweaks") && parsed["tweaks"].isObject()) {
         auto tweaks_obj = parsed["tweaks"];
@@ -410,9 +458,20 @@ TweakStore::from_json_locked(std::string_view json) {
         }
     }
 
+    // locked: string[] — Phase 2.5. Missing key is fine (v1 files
+    // without lock state). Non-string array elements are skipped.
+    if (parsed.hasObjectMember("locked") && parsed["locked"].isArray()) {
+        auto locked_arr = parsed["locked"];
+        for (uint32_t i = 0; i < locked_arr.size(); ++i) {
+            if (locked_arr[i].isString())
+                new_locked.insert(std::string(locked_arr[i].getString()));
+        }
+    }
+
     // All-or-nothing commit.
     tweaks_ = std::move(new_tweaks);
     bypassed_ = std::move(new_bypassed);
+    locked_ = std::move(new_locked);
 
     for (auto& [_, m] : tweaks_) result.tweak_count += m.size();
     result.bypass_count = bypassed_.size();

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -5,6 +5,7 @@
 #include <pulp/view/widgets.hpp>
 
 #include <cstddef>
+#include <functional>
 #include <string_view>
 #include <tuple>
 #include <vector>
@@ -610,6 +611,192 @@ TEST_CASE("InspectorOverlay: tweak_store() round-trips set_tweak_store",
     REQUIRE(overlay.tweak_store() == &store);
     overlay.set_tweak_store(nullptr);
     REQUIRE(overlay.tweak_store() == nullptr);
+}
+
+// ── Phase 2.5 — tweak management panel (Photoshop-layers style) ───────────
+//
+// A panel listing every tweak in the attached TweakStore, with three
+// per-tweak icon controls: bypass / lock / delete. Toggled with `T`.
+// The panel lays out row hit-rects during paint(); tests paint first
+// (RecordingCanvas, headless) to populate them, then click an icon
+// rect to exercise the action.
+
+namespace {
+
+// Build a scene with two anchored views and seed the store with
+// tweaks so the management panel has rows to lay out. Root is large
+// enough (600×600) that the bottom-third tweaks section has room.
+struct TweakPanelScene {
+    View root;
+    TweakStore store;
+    InspectorOverlay overlay{root};
+
+    TweakPanelScene() {
+        root.set_bounds({0, 0, 600, 600});
+        overlay.set_active(true);
+        overlay.set_tweak_store(&store);
+        // Two anchors; one with two property tweaks (grouping case).
+        store.apply_tweak("figma:0:a", "layout.padding",
+                          choc::value::createInt32(12), "drag");
+        store.apply_tweak("figma:0:a", "paint.backgroundColor",
+                          choc::value::createString("#abcdef"), "picker");
+        store.apply_tweak("figma:0:b", "layout.gap",
+                          choc::value::createInt32(4), "drag");
+    }
+};
+
+}  // namespace
+
+TEST_CASE("InspectorOverlay Phase 2.5: T toggles the tweak management panel",
+          "[inspect][overlay][phase2.5]") {
+    View root;
+    root.set_bounds({0, 0, 600, 600});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    REQUIRE_FALSE(overlay.tweaks_panel_visible());
+
+    KeyEvent t;
+    t.key = KeyCode::t;
+    t.is_down = true;
+    REQUIRE(overlay.handle_key_event(t));
+    REQUIRE(overlay.tweaks_panel_visible());
+
+    REQUIRE(overlay.handle_key_event(t));
+    REQUIRE_FALSE(overlay.tweaks_panel_visible());
+}
+
+TEST_CASE("InspectorOverlay Phase 2.5: panel lays out a row per tweak",
+          "[inspect][overlay][phase2.5]") {
+    TweakPanelScene scene;
+    scene.overlay.toggle_tweaks_panel();
+    REQUIRE(scene.overlay.tweaks_panel_visible());
+
+    pulp::canvas::RecordingCanvas canvas;
+    scene.overlay.paint(canvas);
+    REQUIRE(canvas.command_count() > 0);
+
+    // Three tweaks seeded → three rows laid out.
+    REQUIRE(scene.overlay.tweak_row_count() == 3);
+
+    // With the panel hidden, no rows are laid out.
+    scene.overlay.toggle_tweaks_panel();
+    pulp::canvas::RecordingCanvas hidden_canvas;
+    scene.overlay.paint(hidden_canvas);
+    REQUIRE(scene.overlay.tweak_row_count() == 0);
+}
+
+TEST_CASE("InspectorOverlay Phase 2.5: panel renders cleanly with no tweaks",
+          "[inspect][overlay][phase2.5]") {
+    View root;
+    root.set_bounds({0, 0, 600, 600});
+    TweakStore store;  // empty
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_tweak_store(&store);
+    overlay.toggle_tweaks_panel();
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);  // must not crash / must produce commands
+    REQUIRE(canvas.command_count() > 0);
+    REQUIRE(overlay.tweak_row_count() == 0);
+}
+
+// Helper: paint the panel, then return the center of a chosen icon
+// rect for a chosen row. Walking icon centers via clicks would
+// require knowing the layout; instead we sweep candidate y positions
+// in the bottom-third panel region. Simpler: drive clicks by sweeping
+// the known icon column. We sweep the panel and click each row icon.
+namespace {
+
+// Click every row's icon of a given kind until `predicate` flips,
+// returning whether it ever flipped. The icon rects live at fixed
+// offsets that we don't know exactly from the test, so we sweep the
+// panel's bottom-third region row by row.
+bool sweep_click_icon(InspectorOverlay& overlay, View& root,
+                      int icon_index /*0=bypass,1=lock,2=delete*/,
+                      const std::function<bool()>& predicate) {
+    // Re-paint so tweak_rows_ is fresh, then sweep candidate points.
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+
+    float root_w = root.bounds().width;
+    float root_h = root.bounds().height;
+    float panel_x = root_w - 300.0f;          // panel_width_ default 300
+    float x = panel_x + 8.0f;
+    float w = 300.0f - 16.0f;
+    constexpr float kIconSize = 14.0f, kIconGap = 4.0f;
+    float icons_w = 3.0f * kIconSize + 2.0f * kIconGap;
+    float icons_x = x + w - icons_w;
+    float icon_cx = icons_x + icon_index * (kIconSize + kIconGap)
+                    + kIconSize / 2.0f;
+
+    // Sweep y across the bottom-third panel region at 2px steps.
+    for (float y = root_h * 0.55f; y < root_h - 24.0f; y += 2.0f) {
+        MouseEvent click;
+        click.position = {icon_cx, y};
+        click.is_down = true;
+        overlay.handle_mouse_event(click);
+        if (predicate()) return true;
+        // Re-paint between attempts: a delete mutates the row list.
+        pulp::canvas::RecordingCanvas c2;
+        overlay.paint(c2);
+    }
+    return false;
+}
+
+}  // namespace
+
+TEST_CASE("InspectorOverlay Phase 2.5: clicking the bypass icon toggles bypass",
+          "[inspect][overlay][phase2.5]") {
+    TweakPanelScene scene;
+    scene.overlay.toggle_tweaks_panel();
+
+    REQUIRE_FALSE(scene.store.is_bypassed("figma:0:a", "layout.padding"));
+    bool flipped = sweep_click_icon(scene.overlay, scene.root, /*bypass=*/0,
+        [&] { return scene.store.is_bypassed("figma:0:a", "layout.padding") ||
+                     scene.store.is_bypassed("figma:0:b", "layout.gap"); });
+    REQUIRE(flipped);
+}
+
+TEST_CASE("InspectorOverlay Phase 2.5: clicking the lock icon toggles lock",
+          "[inspect][overlay][phase2.5]") {
+    TweakPanelScene scene;
+    scene.overlay.toggle_tweaks_panel();
+
+    REQUIRE(scene.store.locked_anchors().empty());
+    bool flipped = sweep_click_icon(scene.overlay, scene.root, /*lock=*/1,
+        [&] { return !scene.store.locked_anchors().empty(); });
+    REQUIRE(flipped);
+}
+
+TEST_CASE("InspectorOverlay Phase 2.5: clicking the delete icon removes a tweak",
+          "[inspect][overlay][phase2.5]") {
+    TweakPanelScene scene;
+    scene.overlay.toggle_tweaks_panel();
+
+    REQUIRE(scene.store.count() == 3);
+    bool removed = sweep_click_icon(scene.overlay, scene.root, /*delete=*/2,
+        [&] { return scene.store.count() < 3; });
+    REQUIRE(removed);
+}
+
+TEST_CASE("InspectorOverlay Phase 2.5: panel icon clicks are ignored when "
+          "the panel is hidden",
+          "[inspect][overlay][phase2.5]") {
+    TweakPanelScene scene;
+    // Panel stays hidden — paint to clear any stale rows.
+    pulp::canvas::RecordingCanvas canvas;
+    scene.overlay.paint(canvas);
+    REQUIRE(scene.overlay.tweak_row_count() == 0);
+
+    // A click anywhere in the panel column should not mutate the store.
+    MouseEvent click;
+    click.position = {450, 500};
+    click.is_down = true;
+    scene.overlay.handle_mouse_event(click);
+    REQUIRE(scene.store.count() == 3);
+    REQUIRE(scene.store.locked_anchors().empty());
 }
 
 // ── Phase 3b — live-editable box-model fields ─────────────────────────────

--- a/test/test_tweak_store.cpp
+++ b/test/test_tweak_store.cpp
@@ -304,6 +304,96 @@ TEST_CASE("TweakStore: from_json preserves existing locked anchors",
     REQUIRE(s.lookup("anchor:new", "paint.bg")->getString() == "#abc");
 }
 
+TEST_CASE("TweakStore: load_from_disk preserves a locked anchor absent from the file",
+          "[inspect][tweak-store][lock][disk][regression]") {
+    // Codex P1 #2432: importing a file that omits a currently-locked
+    // anchor must NOT delete that anchor's tweaks or lock state — the
+    // lock contract promises protection from re-import. This exercises
+    // the real disk path (load_from_disk), not just from_json.
+    TempTweaksDir tmp;
+    tmp.write(R"({
+        "$schema": "pulp-tweaks://v1",
+        "tweaks": { "anchor:fromfile": { "paint.bg": "#abc" } }
+    })");
+
+    TweakStore s;
+    s.apply_tweak("anchor:locked", "layout.padding", choc::value::createInt32(12), "drag");
+    s.apply_tweak("anchor:stale", "layout.gap", choc::value::createInt32(4), "drag");
+    s.set_bypass("anchor:locked", true);
+    s.set_locked("anchor:locked", true);
+
+    auto loaded = s.load_from_disk(tmp.file.string());
+    REQUIRE(loaded.ok);
+
+    // Locked anchor (absent from the imported file) survives intact.
+    REQUIRE(s.lookup("anchor:locked", "layout.padding")->getInt32() == 12);
+    REQUIRE(s.is_bypassed("anchor:locked", "layout.padding"));
+    REQUIRE(s.is_locked("anchor:locked"));
+    // Unlocked anchor (absent from the file) is dropped on re-import.
+    REQUIRE_FALSE(s.lookup("anchor:stale", "layout.gap").has_value());
+    // Anchor present in the file loads normally.
+    REQUIRE(s.lookup("anchor:fromfile", "paint.bg")->getString() == "#abc");
+}
+
+TEST_CASE("TweakStore: load_from_disk keeps in-memory tweaks for a locked anchor "
+          "even when the file also carries that anchor",
+          "[inspect][tweak-store][lock][disk][regression]") {
+    // When the imported file ALSO carries a locked anchor, the locked
+    // in-memory anchor is retained — the file's version does not
+    // overwrite protected local edits.
+    TempTweaksDir tmp;
+    tmp.write(R"({
+        "$schema": "pulp-tweaks://v1",
+        "tweaks": { "anchor:locked": { "layout.padding": 999 } }
+    })");
+
+    TweakStore s;
+    s.apply_tweak("anchor:locked", "layout.padding", choc::value::createInt32(12), "drag");
+    s.set_locked("anchor:locked", true);
+
+    auto loaded = s.load_from_disk(tmp.file.string());
+    REQUIRE(loaded.ok);
+
+    // The in-memory value (12) is retained, not the file's value (999).
+    REQUIRE(s.lookup("anchor:locked", "layout.padding")->getInt32() == 12);
+    REQUIRE(s.is_locked("anchor:locked"));
+}
+
+TEST_CASE("TweakStore: clear preserves multiple locked anchors and drops all unlocked",
+          "[inspect][tweak-store][lock][regression]") {
+    // Codex P1 #2432: a global Inspector.clearTweaks routes through
+    // clear(). Locked anchors (tweaks + bypass + lock) must survive;
+    // every unlocked anchor must be erased.
+    TweakStore s;
+    s.apply_tweak("anchor:a", "layout.padding", choc::value::createInt32(1), {});
+    s.apply_tweak("anchor:b", "layout.gap", choc::value::createInt32(2), {});
+    s.apply_tweak("anchor:c", "paint.bg", choc::value::createString("#ccc"), {});
+    s.set_bypass("anchor:a", true);
+    s.set_bypass("anchor:c", std::vector<std::string>{"paint.bg"});
+    s.set_locked("anchor:a", true);
+    s.set_locked("anchor:c", true);
+    // A lock-only anchor (no tweaks) also survives clear().
+    s.set_locked("anchor:lonely", true);
+
+    s.clear();
+
+    // Both locked anchors keep their tweaks.
+    REQUIRE(s.count() == 2);
+    REQUIRE(s.lookup("anchor:a", "layout.padding")->getInt32() == 1);
+    REQUIRE(s.lookup("anchor:c", "paint.bg")->getString() == "#ccc");
+    // Locked anchors keep their bypass overlays.
+    REQUIRE(s.is_bypassed("anchor:a", "any.path"));
+    REQUIRE(s.is_bypassed("anchor:c", "paint.bg"));
+    // Locked anchors keep their lock state.
+    REQUIRE(s.is_locked("anchor:a"));
+    REQUIRE(s.is_locked("anchor:c"));
+    REQUIRE(s.is_locked("anchor:lonely"));
+    // The unlocked anchor is fully gone.
+    REQUIRE_FALSE(s.lookup("anchor:b", "layout.gap").has_value());
+    REQUIRE_FALSE(s.bypass_for("anchor:b").has_value());
+    REQUIRE_FALSE(s.is_locked("anchor:b"));
+}
+
 TEST_CASE("TweakStore: a v1 file with no `locked` key loads with an empty lock set",
           "[inspect][tweak-store][lock][disk][schema]") {
     // Pre-2.5 files have no `locked` key — they must still load and

--- a/test/test_tweak_store.cpp
+++ b/test/test_tweak_store.cpp
@@ -142,17 +142,22 @@ TEST_CASE("TweakStore: remove_anchor wipes all paths under an anchor",
     REQUIRE(s.lookup("anchor:b", "layout.gap").has_value());
 }
 
-TEST_CASE("TweakStore: clear wipes tweaks + bypass overlay + lock set",
+TEST_CASE("TweakStore: clear preserves locked anchors and clears unlocked state",
           "[inspect][tweak-store]") {
     TweakStore s;
     s.apply_tweak("anchor:a", "layout.padding", choc::value::createInt32(12), {});
+    s.apply_tweak("anchor:b", "layout.gap", choc::value::createInt32(4), {});
     s.set_bypass("anchor:a", true);
+    s.set_bypass("anchor:b", true);
     s.set_locked("anchor:a", true);
     s.clear();
-    REQUIRE(s.count() == 0);
-    REQUIRE_FALSE(s.bypass_for("anchor:a").has_value());
-    REQUIRE_FALSE(s.is_locked("anchor:a"));
-    REQUIRE(s.locked_anchors().empty());
+    REQUIRE(s.count() == 1);
+    REQUIRE(s.lookup("anchor:a", "layout.padding").has_value());
+    REQUIRE(s.bypass_for("anchor:a").has_value());
+    REQUIRE(s.is_locked("anchor:a"));
+    REQUIRE_FALSE(s.lookup("anchor:b", "layout.gap").has_value());
+    REQUIRE_FALSE(s.bypass_for("anchor:b").has_value());
+    REQUIRE_FALSE(s.is_locked("anchor:b"));
 }
 
 // ── Bypass overlay ──────────────────────────────────────────────────────
@@ -275,6 +280,28 @@ TEST_CASE("TweakStore: lock round-trips through from_json without disk",
     TweakStore t;
     REQUIRE(t.from_json(json).ok);
     REQUIRE(t.is_locked("anchor:x"));
+}
+
+TEST_CASE("TweakStore: from_json preserves existing locked anchors",
+          "[inspect][tweak-store][lock][regression]") {
+    TweakStore s;
+    s.apply_tweak("anchor:locked", "layout.padding", choc::value::createInt32(12), "drag");
+    s.apply_tweak("anchor:stale", "layout.gap", choc::value::createInt32(4), "drag");
+    s.set_bypass("anchor:locked", true);
+    s.set_locked("anchor:locked", true);
+
+    auto loaded = s.from_json(R"({
+        "$schema": "pulp-tweaks://v1",
+        "tweaks": { "anchor:new": { "paint.bg": "#abc" } }
+    })");
+
+    REQUIRE(loaded.ok);
+    REQUIRE(s.count() == 2);
+    REQUIRE(s.lookup("anchor:locked", "layout.padding")->getInt32() == 12);
+    REQUIRE(s.is_bypassed("anchor:locked", "layout.padding"));
+    REQUIRE(s.is_locked("anchor:locked"));
+    REQUIRE_FALSE(s.lookup("anchor:stale", "layout.gap").has_value());
+    REQUIRE(s.lookup("anchor:new", "paint.bg")->getString() == "#abc");
 }
 
 TEST_CASE("TweakStore: a v1 file with no `locked` key loads with an empty lock set",

--- a/test/test_tweak_store.cpp
+++ b/test/test_tweak_store.cpp
@@ -142,14 +142,17 @@ TEST_CASE("TweakStore: remove_anchor wipes all paths under an anchor",
     REQUIRE(s.lookup("anchor:b", "layout.gap").has_value());
 }
 
-TEST_CASE("TweakStore: clear wipes tweaks + bypass overlay",
+TEST_CASE("TweakStore: clear wipes tweaks + bypass overlay + lock set",
           "[inspect][tweak-store]") {
     TweakStore s;
     s.apply_tweak("anchor:a", "layout.padding", choc::value::createInt32(12), {});
     s.set_bypass("anchor:a", true);
+    s.set_locked("anchor:a", true);
     s.clear();
     REQUIRE(s.count() == 0);
     REQUIRE_FALSE(s.bypass_for("anchor:a").has_value());
+    REQUIRE_FALSE(s.is_locked("anchor:a"));
+    REQUIRE(s.locked_anchors().empty());
 }
 
 // ── Bypass overlay ──────────────────────────────────────────────────────
@@ -187,6 +190,115 @@ TEST_CASE("TweakStore: bypass=empty vector clears the overlay (per Codex spec)",
     s.set_bypass("anchor:a", std::vector<std::string>{"x"});
     s.set_bypass("anchor:a", std::vector<std::string>{});
     REQUIRE_FALSE(s.bypass_for("anchor:a").has_value());
+}
+
+// ── Phase 2.5: lock overlay ─────────────────────────────────────────────
+
+TEST_CASE("TweakStore: set_locked marks an anchor protected",
+          "[inspect][tweak-store][lock]") {
+    TweakStore s;
+    REQUIRE_FALSE(s.is_locked("anchor:a"));
+    s.set_locked("anchor:a", true);
+    REQUIRE(s.is_locked("anchor:a"));
+    REQUIRE_FALSE(s.is_locked("anchor:b"));
+}
+
+TEST_CASE("TweakStore: set_locked(false) and clear_lock remove the lock",
+          "[inspect][tweak-store][lock]") {
+    TweakStore s;
+    s.set_locked("anchor:a", true);
+    s.set_locked("anchor:a", false);
+    REQUIRE_FALSE(s.is_locked("anchor:a"));
+
+    s.set_locked("anchor:b", true);
+    s.clear_lock("anchor:b");
+    REQUIRE_FALSE(s.is_locked("anchor:b"));
+}
+
+TEST_CASE("TweakStore: locked_anchors enumerates every locked anchor",
+          "[inspect][tweak-store][lock]") {
+    TweakStore s;
+    REQUIRE(s.locked_anchors().empty());
+    s.set_locked("anchor:a", true);
+    s.set_locked("anchor:c", true);
+    s.set_locked("anchor:b", true);
+    auto locked = s.locked_anchors();
+    std::sort(locked.begin(), locked.end());
+    REQUIRE(locked == std::vector<std::string>{"anchor:a", "anchor:b", "anchor:c"});
+
+    // Lock is independent of whether the anchor has tweak records —
+    // a lock-only anchor still enumerates.
+    REQUIRE(s.count() == 0);
+}
+
+TEST_CASE("TweakStore: lock state is independent of bypass state",
+          "[inspect][tweak-store][lock]") {
+    TweakStore s;
+    s.set_locked("anchor:a", true);
+    REQUIRE_FALSE(s.is_bypassed("anchor:a", "any.path"));  // lock != bypass
+    s.set_bypass("anchor:a", true);
+    REQUIRE(s.is_locked("anchor:a"));                      // bypass != lock
+    s.clear_bypass("anchor:a");
+    REQUIRE(s.is_locked("anchor:a"));                      // still locked
+}
+
+TEST_CASE("TweakStore: lock state round-trips through disk",
+          "[inspect][tweak-store][lock][disk]") {
+    TempTweaksDir tmp;
+    TweakStore s;
+    s.apply_tweak("anchor:a", "layout.padding", choc::value::createInt32(8), "drag");
+    s.apply_tweak("anchor:b", "paint.bg", choc::value::createString("#fff"), "picker");
+    s.set_locked("anchor:a", true);
+    // A lock-only anchor (no tweaks) must also persist.
+    s.set_locked("anchor:lonely", true);
+
+    auto saved = s.save_to_disk(tmp.file.string());
+    REQUIRE(saved.ok);
+    // The serialized file should carry a `locked` array.
+    REQUIRE(tmp.read().find("\"locked\"") != std::string::npos);
+
+    TweakStore t;
+    auto loaded = t.load_from_disk(tmp.file.string());
+    REQUIRE(loaded.ok);
+    REQUIRE(t.is_locked("anchor:a"));
+    REQUIRE(t.is_locked("anchor:lonely"));
+    REQUIRE_FALSE(t.is_locked("anchor:b"));
+    auto locked = t.locked_anchors();
+    REQUIRE(locked.size() == 2);
+}
+
+TEST_CASE("TweakStore: lock round-trips through from_json without disk",
+          "[inspect][tweak-store][lock]") {
+    TweakStore s;
+    s.set_locked("anchor:x", true);
+    auto json = s.to_json();
+    TweakStore t;
+    REQUIRE(t.from_json(json).ok);
+    REQUIRE(t.is_locked("anchor:x"));
+}
+
+TEST_CASE("TweakStore: a v1 file with no `locked` key loads with an empty lock set",
+          "[inspect][tweak-store][lock][disk][schema]") {
+    // Pre-2.5 files have no `locked` key — they must still load and
+    // simply carry no lock state. (Forward-compat: 2.5 reading v1.)
+    TempTweaksDir tmp;
+    tmp.write(R"({
+        "$schema": "pulp-tweaks://v1",
+        "tweaks": { "anchor:a": { "paint.bg": "#abc" } }
+    })");
+    TweakStore s;
+    auto loaded = s.load_from_disk(tmp.file.string());
+    REQUIRE(loaded.ok);
+    REQUIRE(s.lookup("anchor:a", "paint.bg")->getString() == "#abc");
+    REQUIRE(s.locked_anchors().empty());
+}
+
+TEST_CASE("TweakStore: empty lock set is omitted from the serialized JSON",
+          "[inspect][tweak-store][lock]") {
+    // Keep trivial files small — no `locked` key when nothing is locked.
+    TweakStore s;
+    s.apply_tweak("anchor:a", "p", choc::value::createInt32(1), {});
+    REQUIRE(s.to_json().find("\"locked\"") == std::string::npos);
 }
 
 // ── Protocol round-trip via DomainHandler ───────────────────────────────
@@ -343,6 +455,71 @@ TEST_CASE("Inspector.setBypass with non-bool/non-array value errors",
     auto resp = f.handler.handle(req(methods::kInspectorSetBypass,
         R"({"anchorId":"a","value":42})"));
     REQUIRE(resp.is_error);
+}
+
+// ── Phase 2.5: Inspector.setLocked protocol ─────────────────────────────
+
+TEST_CASE("Inspector.setLocked with value=true locks the anchor",
+          "[inspect][protocol][setLocked]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorSetLocked,
+        R"({"anchorId":"a","value":true})"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+    REQUIRE(parsed["ok"].getBool());
+    REQUIRE(parsed["locked"].getBool());
+    REQUIRE(f.store.is_locked("a"));
+}
+
+TEST_CASE("Inspector.setLocked with value=false unlocks the anchor",
+          "[inspect][protocol][setLocked]") {
+    Fixture f;
+    f.store.set_locked("a", true);
+    auto resp = f.handler.handle(req(methods::kInspectorSetLocked,
+        R"({"anchorId":"a","value":false})"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+    REQUIRE_FALSE(parsed["locked"].getBool());
+    REQUIRE_FALSE(f.store.is_locked("a"));
+}
+
+TEST_CASE("Inspector.setLocked with a non-bool value errors cleanly",
+          "[inspect][protocol][setLocked]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorSetLocked,
+        R"({"anchorId":"a","value":"yes"})"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("Inspector.setLocked without a tweak store errors cleanly",
+          "[inspect][protocol][setLocked][no-store]") {
+    DomainHandler h;  // no tweak store
+    auto resp = h.handle(req(methods::kInspectorSetLocked,
+        R"({"anchorId":"a","value":true})"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("Inspector.setLocked with un-parseable JSON errors cleanly",
+          "[inspect][protocol][setLocked]") {
+    Fixture f;
+    auto resp = f.handler.handle(req(methods::kInspectorSetLocked, "not json"));
+    REQUIRE(resp.is_error);
+}
+
+TEST_CASE("Inspector.listTweaks surfaces the locked anchor set",
+          "[inspect][protocol][listTweaks][lock]") {
+    Fixture f;
+    f.store.apply_tweak("a", "layout.padding", choc::value::createInt32(8), {});
+    f.store.apply_tweak("b", "paint.bg", choc::value::createString("#fff"), {});
+    f.store.set_locked("a", true);
+
+    auto resp = f.handler.handle(req(methods::kInspectorListTweaks, "{}"));
+    REQUIRE_FALSE(resp.is_error);
+    auto parsed = choc::json::parse(resp.params_json);
+    auto locked = parsed["locked"];
+    REQUIRE(locked.isArray());
+    REQUIRE(locked.size() == 1);
+    REQUIRE(locked[0].getString() == "a");
 }
 
 TEST_CASE("Inspector.listTweaks round-trips string[] bypass for an anchor",


### PR DESCRIPTION
Adds a tweak management panel to the inspector overlay, modeled on
Photoshop's layers panel. Every recorded tweak becomes a row with
three per-tweak controls — bypass (eye), lock, and delete — grouped
by anchor. Toggled with the `T` key while the inspector is active;
the legacy two-section panel layout is unchanged when hidden.

TweakStore gains a `locked` overlay parallel to the existing bypass
overlay: set_locked / clear_lock / is_locked + a locked_anchors()
enumerator. A locked anchor is protected from bulk-clear / reimport.
Lock state is a third sibling overlay in the on-disk schema — a flat
`locked` string[] — emitted only when non-empty so v1 files without
it still load and round-trip cleanly.

Protocol: Inspector.setLocked mirrors Inspector.setBypass, and
Inspector.listTweaks now surfaces a `locked` array alongside the
`tweaks` and `bypassed` maps so the panel and disk-persistence path
round-trip lock state.

Tests: test_tweak_store.cpp covers lock set/clear/enumerate, lock vs
bypass independence, disk + from_json round-trip, v1-without-locked
back-compat, and the setLocked / listTweaks protocol surface.
test_inspector.cpp covers panel toggle, row layout, empty-store
rendering, and bypass / lock / delete icon hit-testing via
simulate-click sweeps over the headless RecordingCanvas.

Version-Bump: skip reason="inspect/* is dev-tooling overlay, not SDK public API surface"