### PR TITLE
feat(inspect): Phase 3c — color eyedropper

### DIFF
--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -149,6 +149,61 @@ public:
     bool pass_viewer_enabled() const { return pass_viewer_enabled_; }
     void toggle_pass_viewer() { pass_viewer_enabled_ = !pass_viewer_enabled_; }
 
+    // ── Phase 3c — color eyedropper ─────────────────────────────────
+    /// Toggle eyedropper mode. When enabled, mouse-move samples the
+    /// color under the cursor and a swatch + hex readout follows the
+    /// pointer; the next click captures that color and emits it as a
+    /// tweak on the selected view's color property (default
+    /// "style.background_color"). Toggled via the E key (no modifier)
+    /// while the inspector is active — mirrors how D toggles drag
+    /// handles in Phase 3a. Default OFF: without it, normal
+    /// click-to-select is unchanged.
+    ///
+    /// Sampling strategy: if the live Canvas exposes pixel readback
+    /// (`Canvas::read_pixels` — Skia raster surfaces only), the
+    /// eyedropper reads the exact framebuffer pixel under the cursor.
+    /// Otherwise it falls back to the resolved-style color of the
+    /// top-most View under the cursor — walking up the tree to the
+    /// nearest ancestor with an explicit background color. The v1
+    /// fallback is documented as a known simplification.
+    void set_eyedropper_active(bool active);
+    bool eyedropper_active() const { return eyedropper_active_; }
+    void toggle_eyedropper() { set_eyedropper_active(!eyedropper_active_); }
+
+    /// Last color sampled by the eyedropper (updated on every
+    /// mouse-move while eyedropper mode is active). Read by tests and
+    /// by the cursor-swatch paint. Defaults to transparent black until
+    /// the first sample lands.
+    Color eyedropper_sample() const { return eyedropper_sample_; }
+
+    /// Whether `eyedropper_sample_` reflects a real sample yet (false
+    /// until the first mouse-move inside the canvas while active).
+    bool eyedropper_has_sample() const { return eyedropper_has_sample_; }
+
+    /// The dotted color property the eyedropper writes to on click.
+    /// Defaults to "style.background_color"; a host could retarget it
+    /// to "style.color" / "style.border_color" before a pick. The
+    /// setter ignores empty strings.
+    const std::string& eyedropper_target() const { return eyedropper_target_; }
+    void set_eyedropper_target(std::string path) {
+        if (!path.empty()) eyedropper_target_ = std::move(path);
+    }
+
+    /// Sample the color under `pos` (root coords) WITHOUT applying it.
+    /// Visible for tests + used internally by the mouse-move handler.
+    /// Returns true if a color was found (always true for the
+    /// resolved-style fallback once a view is under the cursor).
+    bool sample_color_at(Point pos, Canvas* canvas, Color& out) const;
+
+    /// Apply the last sampled color as a tweak to the current
+    /// selection's `eyedropper_target_` property, encoded as a
+    /// "#rrggbb" / "#rrggbbaa" hex string, with source
+    /// "inspector-eyedropper". Returns false if there's no sample yet
+    /// or `emit_tweak_for_selection` reports no-op (no selection /
+    /// anchor / store). On success the eyedropper auto-disables so a
+    /// pick is a single, deliberate action.
+    bool apply_eyedropper_pick();
+
     // ── Selection ───────────────────────────────────────────────────
     View* selected_view() const { return selected_; }
     View* hovered_view() const { return hovered_; }
@@ -343,6 +398,26 @@ private:
     // for the currently-selected view (root coords). Returns
     // DragCorner::none if no handle is hit or no view selected.
     DragCorner hit_test_drag_handle(Point pos) const;
+
+    // ── Phase 3c — color eyedropper state ───────────────────────────
+    // Off by default so the inspector behaves identically to the
+    // pre-3c build until the user opts in (E-key toggle).
+    bool eyedropper_active_ = false;
+    bool eyedropper_has_sample_ = false;
+    Color eyedropper_sample_{0.0f, 0.0f, 0.0f, 0.0f};
+    Point eyedropper_cursor_{};  ///< Last cursor pos (root coords) for swatch.
+    std::string eyedropper_target_ = "style.background_color";
+
+    // Walk from the View under `pos` up to the nearest ancestor that
+    // has an explicit background color; returns that color. Returns
+    // false when no view under the cursor carries a background — the
+    // resolved-style fallback used when Canvas pixel readback is
+    // unavailable.
+    bool resolved_color_under(Point pos, Color& out) const;
+
+    // Paint the cursor-following swatch + hex readout. No-op unless
+    // eyedropper mode is active and at least one sample has landed.
+    void paint_eyedropper_cursor(Canvas& canvas);
 
     // ── Flat tree for rendering ─────────────────────────────────────
     struct TreeItem {

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -362,8 +362,19 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
             // Resolved-style sampling is synchronous + frame-
             // independent, so a click without a prior move still
             // picks a real color (covers headless / scripted use).
-            // Always refresh here; a hover/readback sample from a
-            // previous point must not be applied to a different click.
+            //
+            // Codex P1 (#2434): the click must be authoritative on the
+            // click coordinate. Invalidate any prior sample FIRST — a
+            // hover move or a paint_eyedropper_cursor() framebuffer
+            // readback at the default/old cursor position may have left
+            // a stale `eyedropper_sample_` with `eyedropper_has_sample_`
+            // still true. If the click-position resample then fails
+            // (e.g. the click lands where no view carries a background
+            // color and only the resolved-style fallback is available),
+            // apply_eyedropper_pick() must no-op rather than commit the
+            // stale color — so the invalidation has to happen before the
+            // resample, not be skipped on a failed read.
+            eyedropper_has_sample_ = false;
             Color sampled;
             if (sample_color_at(pos, nullptr, sampled)) {
                 eyedropper_sample_ = sampled;

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -362,9 +362,10 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
             // Resolved-style sampling is synchronous + frame-
             // independent, so a click without a prior move still
             // picks a real color (covers headless / scripted use).
+            // Always refresh here; a hover/readback sample from a
+            // previous point must not be applied to a different click.
             Color sampled;
-            if (!eyedropper_has_sample_ &&
-                sample_color_at(pos, nullptr, sampled)) {
+            if (sample_color_at(pos, nullptr, sampled)) {
                 eyedropper_sample_ = sampled;
                 eyedropper_has_sample_ = true;
             }

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -36,6 +36,25 @@ static const Color kFieldEditCaret   = Color::rgba(0.95f, 0.6f, 0.2f, 1.0f);
 static const Color kFieldEditUnder   = Color::rgba(0.95f, 0.6f, 0.2f, 0.9f);
 static const Color kFieldEditBg      = Color::rgba(0.95f, 0.6f, 0.2f, 0.18f);
 
+// Phase 3c — eyedropper cursor swatch chrome
+static const Color kEyedropChromeBg  = Color::rgba(0.08f, 0.08f, 0.1f, 0.95f);
+static const Color kEyedropBorder    = Color::rgba(1.0f, 1.0f, 1.0f, 0.85f);
+static const Color kEyedropText      = Color::rgba(0.95f, 0.95f, 1.0f, 1.0f);
+
+// Format a Color as a CSS hex string: "#rrggbb" when fully opaque,
+// "#rrggbbaa" otherwise. Lower-case, fixed-width — matches the hex
+// shape the JS bridge and pulp-tweaks.json already use for colors.
+static std::string color_to_hex(const Color& c) {
+    std::ostringstream oss;
+    oss << '#' << std::hex << std::nouppercase << std::setfill('0');
+    oss << std::setw(2) << static_cast<int>(c.r8())
+        << std::setw(2) << static_cast<int>(c.g8())
+        << std::setw(2) << static_cast<int>(c.b8());
+    if (c.a8() != 255)
+        oss << std::setw(2) << static_cast<int>(c.a8());
+    return oss.str();
+}
+
 // ── Constructor ─────────────────────────────────────────────────────────────
 
 InspectorOverlay::InspectorOverlay(View& root) : root_(root) {}
@@ -66,7 +85,85 @@ void InspectorOverlay::set_active(bool active) {
         alt_hover_target_ = nullptr;
         distance_anchor_ = nullptr;
         editable_fields_.clear();
+        // Phase 3c — drop any pending eyedropper state with the
+        // inspector so a stale swatch never paints on the next open.
+        eyedropper_active_ = false;
+        eyedropper_has_sample_ = false;
     }
+}
+
+// ── Phase 3c — color eyedropper ─────────────────────────────────────────────
+//
+// An eyedropper mode (E-key, mirroring Phase 3a's D-key for drag
+// handles) lets the user sample a color from the rendered UI and
+// apply it as a tweak to the selected view's color property.
+//
+// Two sampling paths, picked at runtime:
+//   1. Framebuffer readback — `Canvas::read_pixels()` returns the
+//      exact rendered pixel under the cursor. Implemented only on
+//      Skia raster surfaces (see canvas.hpp issue-916); when present
+//      it is authoritative because it captures gradients, borders,
+//      child paint, and theme blending the View tree alone can't.
+//   2. Resolved-style fallback — when readback is unavailable
+//      (RecordingCanvas, CG fallback, headless tests), the
+//      eyedropper samples the resolved background color of the
+//      top-most View under the cursor, walking up to the nearest
+//      ancestor with an explicit background. This is a documented v1
+//      simplification: it sees declared View backgrounds, not
+//      arbitrary pixels.
+//
+// On click the sampled color is emitted via emit_tweak_for_selection()
+// — the SAME path Phase 3a/3b gestures use — encoded as a "#rrggbb"
+// hex string, source "inspector-eyedropper".
+
+void InspectorOverlay::set_eyedropper_active(bool active) {
+    eyedropper_active_ = active;
+    if (!active) eyedropper_has_sample_ = false;
+}
+
+bool InspectorOverlay::resolved_color_under(Point pos, Color& out) const {
+    const View* hit = root_.hit_test(pos);
+    for (const View* v = hit; v; v = v->parent()) {
+        if (v->has_background_color()) {
+            out = v->background_color();
+            return true;
+        }
+    }
+    return false;
+}
+
+bool InspectorOverlay::sample_color_at(Point pos, Canvas* canvas,
+                                       Color& out) const {
+    // Path 1 — framebuffer readback (Skia raster only). read_pixels
+    // returns RGBA8 in `px`; a false return (RecordingCanvas / CG
+    // fallback) drops through to the resolved-style path.
+    if (canvas) {
+        std::uint8_t px[4] = {0, 0, 0, 0};
+        int ix = static_cast<int>(std::lround(pos.x));
+        int iy = static_cast<int>(std::lround(pos.y));
+        if (ix >= 0 && iy >= 0 &&
+            canvas->read_pixels(ix, iy, 1, 1, px)) {
+            out = Color::rgba8(px[0], px[1], px[2], px[3]);
+            return true;
+        }
+    }
+    // Path 2 — resolved-style fallback.
+    return resolved_color_under(pos, out);
+}
+
+bool InspectorOverlay::apply_eyedropper_pick() {
+    if (!eyedropper_has_sample_) return false;
+    bool ok = emit_tweak_for_selection(
+        eyedropper_target_,
+        choc::value::createString(color_to_hex(eyedropper_sample_)),
+        "inspector-eyedropper");
+    // A pick is a single deliberate action — disable the mode so the
+    // very next click resumes normal selection rather than picking
+    // again. (Re-arm with the E key for another pick.) We disable
+    // even on a no-op emit so the UX is predictable: the user clicked
+    // with the eyedropper, the eyedropper is now spent.
+    set_eyedropper_active(false);
+    return ok;
 }
 
 // ── Phase 0b PR-C-1: in-process gesture-tweak emission ─────────────────────
@@ -220,6 +317,16 @@ bool InspectorOverlay::handle_key_event(const KeyEvent& event) {
         return true;
     }
 
+    // Phase 3c — E toggles eyedropper mode (no modifier; same opt-in
+    // discipline as the D-key drag toggle above). Entering edit mode
+    // already swallows keys before this point, so the E-key can't
+    // collide with numeric-field editing.
+    if (active_ && event.key == KeyCode::e && event.is_down &&
+        event.modifiers == 0) {
+        toggle_eyedropper();
+        return true;
+    }
+
     return false;
 }
 
@@ -236,6 +343,43 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
     if (!active_) return false;
 
     auto pos = event.position;
+
+    // ── Phase 3c: eyedropper mode ──────────────────────────────────
+    // When the eyedropper is armed it owns canvas-area mouse events:
+    // moves sample the color under the cursor (driving the swatch),
+    // a press applies the pick. It deliberately yields to the panel
+    // (so the user can still click the tree / fields) — a press over
+    // the panel falls through to the normal panel path below.
+    //
+    // The eyedropper's paint() captures the pixel under the cursor at
+    // sample time, BEFORE the swatch chrome is drawn, so the chrome
+    // never contaminates a subsequent read. Sampling here in the
+    // handler instead would read the previous frame; we therefore
+    // record the cursor position and let paint() do the readback.
+    if (eyedropper_active_ && !point_in_panel(pos)) {
+        eyedropper_cursor_ = pos;
+        if (event.is_down) {
+            // Resolved-style sampling is synchronous + frame-
+            // independent, so a click without a prior move still
+            // picks a real color (covers headless / scripted use).
+            Color sampled;
+            if (!eyedropper_has_sample_ &&
+                sample_color_at(pos, nullptr, sampled)) {
+                eyedropper_sample_ = sampled;
+                eyedropper_has_sample_ = true;
+            }
+            apply_eyedropper_pick();
+            return true;  // consume the pick click
+        }
+        // Move: resolved-style sample now for an immediate swatch;
+        // paint() upgrades to framebuffer readback when available.
+        Color sampled;
+        if (sample_color_at(pos, nullptr, sampled)) {
+            eyedropper_sample_ = sampled;
+            eyedropper_has_sample_ = true;
+        }
+        return false;  // don't consume moves — let hover effects run
+    }
 
     // ── Phase 3a: drag-handle gesture state machine ────────────────
     // The Pulp MouseEvent model uses is_down=true ONLY for the
@@ -491,6 +635,80 @@ void InspectorOverlay::paint(Canvas& canvas) {
     paint_distance_lines(canvas);
     if (selected_) paint_box_model(canvas, selected_);
     paint_panel(canvas);
+    // Phase 3c — eyedropper swatch paints last so it floats above
+    // everything (including the panel) and never under the highlight.
+    paint_eyedropper_cursor(canvas);
+}
+
+void InspectorOverlay::paint_eyedropper_cursor(Canvas& canvas) {
+    if (!eyedropper_active_) return;
+
+    // Upgrade the sample to an exact framebuffer pixel if the live
+    // Canvas supports readback. Done here (not in the mouse handler)
+    // so the read happens against the fully-composited frame, before
+    // the swatch chrome below would otherwise contaminate the pixel.
+    {
+        Color sampled;
+        if (sample_color_at(eyedropper_cursor_, &canvas, sampled)) {
+            eyedropper_sample_ = sampled;
+            eyedropper_has_sample_ = true;
+        }
+    }
+    if (!eyedropper_has_sample_) return;
+
+    // Swatch + hex readout, offset down-right of the cursor so the
+    // pointer itself never sits on top of the chrome being read.
+    constexpr float kSwatch = 22.0f;   // swatch square side
+    constexpr float kPad    = 4.0f;
+    constexpr float kRowH   = 16.0f;
+    const std::string hex = color_to_hex(eyedropper_sample_);
+
+    canvas.save();
+    canvas.set_font("monospace", kFontSize);
+    float text_w = canvas.measure_text(hex);
+    float box_w = kPad + kSwatch + kPad + text_w + kPad;
+    float box_h = kPad + std::max(kSwatch, kRowH) + kPad;
+    float bx = eyedropper_cursor_.x + 14.0f;
+    float by = eyedropper_cursor_.y + 14.0f;
+
+    // Keep the chrome on-screen near the right / bottom edges.
+    float root_w = root_.bounds().width;
+    float root_h = root_.bounds().height;
+    if (bx + box_w > root_w) bx = eyedropper_cursor_.x - 14.0f - box_w;
+    if (by + box_h > root_h) by = eyedropper_cursor_.y - 14.0f - box_h;
+
+    // Chrome background.
+    canvas.set_fill_color(kEyedropChromeBg);
+    canvas.fill_rounded_rect(bx, by, box_w, box_h, 4.0f);
+
+    // Checkerboard behind the swatch so transparent samples read as
+    // transparent rather than as solid black.
+    float sx = bx + kPad;
+    float sy = by + kPad;
+    const Color kCheckA = Color::rgba(0.75f, 0.75f, 0.75f, 1.0f);
+    const Color kCheckB = Color::rgba(0.55f, 0.55f, 0.55f, 1.0f);
+    constexpr float kCell = kSwatch / 2.0f;
+    for (int cy = 0; cy < 2; ++cy)
+        for (int cx = 0; cx < 2; ++cx) {
+            canvas.set_fill_color(((cx + cy) & 1) ? kCheckB : kCheckA);
+            canvas.fill_rect(sx + cx * kCell, sy + cy * kCell, kCell, kCell);
+        }
+
+    // Sampled color on top of the checkerboard.
+    canvas.set_fill_color(eyedropper_sample_);
+    canvas.fill_rect(sx, sy, kSwatch, kSwatch);
+
+    // Swatch border.
+    canvas.set_stroke_color(kEyedropBorder);
+    canvas.set_line_width(1.0f);
+    canvas.stroke_rect(sx, sy, kSwatch, kSwatch);
+
+    // Hex readout.
+    canvas.set_fill_color(kEyedropText);
+    canvas.fill_text(hex, sx + kSwatch + kPad,
+                     by + box_h / 2.0f + 4.0f);
+
+    canvas.restore();
 }
 
 void InspectorOverlay::paint_highlight(Canvas& canvas) {
@@ -1047,6 +1265,18 @@ void InspectorOverlay::paint_stats_bar(Canvas& canvas, float x, float y, float w
     } else {
         canvas.set_fill_color(kPanelDim);
         canvas.fill_text("No render stats", x + 8, y + 16);
+    }
+
+    // Phase 3c — active-mode hint. Drag (D) and eyedropper (E) are
+    // mutually informative; show whichever is armed so the user
+    // remembers a non-default canvas mode is in effect. Placed at the
+    // bar midpoint so it never overlaps the left-aligned frame-time
+    // readout or the right-aligned view count.
+    if (eyedropper_active_ || dragging_enabled_) {
+        canvas.set_fill_color(kFieldEditCaret);
+        const char* mode = eyedropper_active_ ? "\xe2\x97\x89 eyedropper"
+                                              : "\xe2\x97\x89 drag";
+        canvas.fill_text(mode, x + w * 0.5f - 24.0f, y + 16);
     }
 
     // View count

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -1448,6 +1448,35 @@ TEST_CASE("InspectorOverlay Phase 3c: click without prior move still picks",
     REQUIRE(std::string(v->getString()) == "#404040");
 }
 
+TEST_CASE("InspectorOverlay Phase 3c: click refreshes stale hover sample",
+          "[inspect][overlay][phase3c][regression]") {
+    Phase3cScene s(Color::rgba8(0xff, 0x00, 0x00));
+
+    auto second = std::make_unique<View>();
+    second->set_anchor_id("figma:3c:2");
+    second->set_bounds({40, 150, 120, 80});
+    second->set_background_color(Color::rgba8(0x00, 0x66, 0xff));
+    s.root.add_child(std::move(second));
+
+    s.overlay.set_eyedropper_active(true);
+
+    // Hover over the selected child first, then click elsewhere. The
+    // committed tweak must use the click location, not the stale hover
+    // swatch sample.
+    s.overlay.handle_mouse_event(make_move(90, 80));
+    auto hover_sample = s.overlay.eyedropper_sample();
+    REQUIRE(hover_sample.r8() == 0xff);
+    REQUIRE(hover_sample.g8() == 0x00);
+    REQUIRE(hover_sample.b8() == 0x00);
+
+    bool consumed = s.overlay.handle_mouse_event(make_click(90, 170));
+    REQUIRE(consumed);
+
+    auto v = s.store.lookup("figma:3c:1", "style.background_color");
+    REQUIRE(v.has_value());
+    REQUIRE(std::string(v->getString()) == "#0066ff");
+}
+
 TEST_CASE("InspectorOverlay Phase 3c: retargeting writes a different property",
           "[inspect][overlay][phase3c]") {
     Phase3cScene s(Color::rgba8(0x00, 0x99, 0xff));

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -1477,6 +1477,36 @@ TEST_CASE("InspectorOverlay Phase 3c: click refreshes stale hover sample",
     REQUIRE(std::string(v->getString()) == "#0066ff");
 }
 
+TEST_CASE("InspectorOverlay Phase 3c: click never commits a stale sample",
+          "[inspect][overlay][phase3c][regression]") {
+    // Codex P1 (#2434): pressing E and clicking on empty canvas must
+    // not write a stale color into the tweak store. A prior sample can
+    // be left behind by an earlier hover (or by paint_eyedropper_cursor
+    // sampling from the default cursor position before any mouse-move).
+    // When the click lands where the resolved-style fallback finds no
+    // background-colored view, the resample fails — and the pick must
+    // no-op rather than commit the stale color from the old position.
+    Phase3cScene s(Color::rgba8(0xff, 0x00, 0x00));
+    s.overlay.set_eyedropper_active(true);
+
+    // Seed a stale sample by hovering over the colored child.
+    s.overlay.handle_mouse_event(make_move(90, 80));
+    REQUIRE(s.overlay.eyedropper_has_sample());
+    REQUIRE(s.overlay.eyedropper_sample().r8() == 0xff);
+
+    // Click on empty canvas — (60, 300) is inside the root and clear of
+    // the inspector panel (x >= 200), but hits no background-colored
+    // view, so the resolved-style fallback returns false. The stale red
+    // sample must not survive into the store.
+    bool consumed = s.overlay.handle_mouse_event(make_click(60, 300));
+    REQUIRE(consumed);  // the click is still consumed by the eyedropper
+
+    // No tweak — the failed resample invalidated the sample, so
+    // apply_eyedropper_pick() correctly no-ops instead of writing red.
+    REQUIRE(s.store.count() == 0);
+    REQUIRE_FALSE(s.overlay.eyedropper_has_sample());
+}
+
 TEST_CASE("InspectorOverlay Phase 3c: retargeting writes a different property",
           "[inspect][overlay][phase3c]") {
     Phase3cScene s(Color::rgba8(0x00, 0x99, 0xff));

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -1306,6 +1306,241 @@ TEST_CASE("InspectorOverlay: bypassed tweak suppresses dot",
     REQUIRE(bypassed.command_count() < with_dot_count);
 }
 
+// ── Phase 3c — color eyedropper ───────────────────────────────────────────
+//
+// Eyedropper mode (E key) samples a color from the rendered UI and
+// applies it as a tweak to the selected view's color property. With
+// no Canvas pixel-readback in headless tests, sampling falls back to
+// the resolved background color of the view under the cursor; the
+// tweak path reuses emit_tweak_for_selection() with source
+// "inspector-eyedropper".
+
+namespace {
+
+// Build a root + child where the child carries an explicit background
+// color (so the resolved-style fallback has something to sample) and
+// an anchor (so the eyedropper tweak can land in the store).
+struct Phase3cScene {
+    View root;
+    View* child = nullptr;
+    TweakStore store;
+    InspectorOverlay overlay{root};
+
+    explicit Phase3cScene(Color child_bg = Color::rgba8(0x33, 0x66, 0xcc)) {
+        root.set_bounds({0, 0, 500, 400});
+        auto c = std::make_unique<View>();
+        c->set_anchor_id("figma:3c:1");
+        c->set_bounds({40, 40, 120, 80});
+        c->set_background_color(child_bg);
+        child = c.get();
+        root.add_child(std::move(c));
+
+        overlay.set_active(true);
+        overlay.set_tweak_store(&store);
+
+        // Select the child via the normal click path.
+        MouseEvent click;
+        click.position = {60, 60};
+        click.is_down = true;
+        overlay.handle_mouse_event(click);
+    }
+};
+
+MouseEvent make_move(float x, float y) {
+    MouseEvent e;
+    e.position = {x, y};
+    e.is_down = false;
+    return e;
+}
+
+MouseEvent make_click(float x, float y) {
+    MouseEvent e;
+    e.position = {x, y};
+    e.is_down = true;
+    return e;
+}
+
+} // namespace
+
+TEST_CASE("InspectorOverlay Phase 3c: eyedropper defaults OFF",
+          "[inspect][overlay][phase3c]") {
+    View root;
+    InspectorOverlay overlay(root);
+    REQUIRE_FALSE(overlay.eyedropper_active());
+    REQUIRE_FALSE(overlay.eyedropper_has_sample());
+    REQUIRE(overlay.eyedropper_target() == "style.background_color");
+
+    overlay.set_eyedropper_active(true);
+    REQUIRE(overlay.eyedropper_active());
+    overlay.toggle_eyedropper();
+    REQUIRE_FALSE(overlay.eyedropper_active());
+}
+
+TEST_CASE("InspectorOverlay Phase 3c: 'E' key toggles eyedropper only when active",
+          "[inspect][overlay][phase3c]") {
+    View root;
+    InspectorOverlay overlay(root);
+
+    // Inactive — E does nothing.
+    REQUIRE_FALSE(overlay.handle_key_event(make_key(KeyCode::e)));
+    REQUIRE_FALSE(overlay.eyedropper_active());
+
+    overlay.set_active(true);
+    // Active — E toggles.
+    REQUIRE(overlay.handle_key_event(make_key(KeyCode::e)));
+    REQUIRE(overlay.eyedropper_active());
+    REQUIRE(overlay.handle_key_event(make_key(KeyCode::e)));
+    REQUIRE_FALSE(overlay.eyedropper_active());
+
+    // E with a modifier is ignored (reserved for chord shortcuts).
+    overlay.handle_key_event(make_key(KeyCode::e, true, kModCmd));
+    REQUIRE_FALSE(overlay.eyedropper_active());
+}
+
+TEST_CASE("InspectorOverlay Phase 3c: mouse-move samples color under cursor",
+          "[inspect][overlay][phase3c]") {
+    Phase3cScene s(Color::rgba8(0x12, 0xab, 0x5f));
+    s.overlay.set_eyedropper_active(true);
+    REQUIRE_FALSE(s.overlay.eyedropper_has_sample());
+
+    // Move over the child — resolved-style fallback samples its bg.
+    s.overlay.handle_mouse_event(make_move(80, 70));
+    REQUIRE(s.overlay.eyedropper_has_sample());
+    auto c = s.overlay.eyedropper_sample();
+    REQUIRE(c.r8() == 0x12);
+    REQUIRE(c.g8() == 0xab);
+    REQUIRE(c.b8() == 0x5f);
+}
+
+TEST_CASE("InspectorOverlay Phase 3c: click captures color and emits tweak",
+          "[inspect][overlay][phase3c]") {
+    Phase3cScene s(Color::rgba8(0xff, 0x80, 0x00));
+    s.overlay.set_eyedropper_active(true);
+
+    // Hover to sample, then click to apply.
+    s.overlay.handle_mouse_event(make_move(90, 80));
+    bool consumed = s.overlay.handle_mouse_event(make_click(90, 80));
+    REQUIRE(consumed);  // eyedropper consumes the pick click
+
+    // A pick is a single deliberate action — mode auto-disables.
+    REQUIRE_FALSE(s.overlay.eyedropper_active());
+
+    // The tweak landed in the store under the selection's anchor.
+    REQUIRE(s.store.count() == 1);
+    auto v = s.store.lookup("figma:3c:1", "style.background_color");
+    REQUIRE(v.has_value());
+    REQUIRE(std::string(v->getString()) == "#ff8000");
+}
+
+TEST_CASE("InspectorOverlay Phase 3c: click without prior move still picks",
+          "[inspect][overlay][phase3c]") {
+    // Resolved-style sampling is synchronous, so a click with no
+    // preceding mouse-move still captures a real color (covers
+    // scripted / fast-click use).
+    Phase3cScene s(Color::rgba8(0x40, 0x40, 0x40));
+    s.overlay.set_eyedropper_active(true);
+
+    bool consumed = s.overlay.handle_mouse_event(make_click(100, 90));
+    REQUIRE(consumed);
+    REQUIRE(s.store.count() == 1);
+    auto v = s.store.lookup("figma:3c:1", "style.background_color");
+    REQUIRE(v.has_value());
+    REQUIRE(std::string(v->getString()) == "#404040");
+}
+
+TEST_CASE("InspectorOverlay Phase 3c: retargeting writes a different property",
+          "[inspect][overlay][phase3c]") {
+    Phase3cScene s(Color::rgba8(0x00, 0x99, 0xff));
+    s.overlay.set_eyedropper_target("style.border_color");
+    s.overlay.set_eyedropper_active(true);
+
+    s.overlay.handle_mouse_event(make_click(80, 70));
+    auto v = s.store.lookup("figma:3c:1", "style.border_color");
+    REQUIRE(v.has_value());
+    REQUIRE(std::string(v->getString()) == "#0099ff");
+
+    // Empty retarget is ignored — keeps the previous path.
+    s.overlay.set_eyedropper_target("");
+    REQUIRE(s.overlay.eyedropper_target() == "style.border_color");
+}
+
+TEST_CASE("InspectorOverlay Phase 3c: sample_color_at hex round-trips alpha",
+          "[inspect][overlay][phase3c]") {
+    // A semi-transparent background encodes as 8-digit "#rrggbbaa".
+    Phase3cScene s(Color::rgba8(0x20, 0x30, 0x40, 0x80));
+    s.overlay.set_eyedropper_active(true);
+    s.overlay.handle_mouse_event(make_click(80, 70));
+    auto v = s.store.lookup("figma:3c:1", "style.background_color");
+    REQUIRE(v.has_value());
+    REQUIRE(std::string(v->getString()) == "#20304080");
+}
+
+TEST_CASE("InspectorOverlay Phase 3c: eyedropper yields to the panel",
+          "[inspect][overlay][phase3c]") {
+    // A click inside the inspector panel must NOT be eaten by the
+    // eyedropper — the user still needs tree / field interaction.
+    Phase3cScene s;
+    s.overlay.set_eyedropper_active(true);
+
+    // Panel occupies the right 300px of the 500px-wide root.
+    MouseEvent panel_click = make_click(450, 50);
+    bool consumed = s.overlay.handle_mouse_event(panel_click);
+    REQUIRE(consumed);  // panel consumes its own clicks
+    // No pick happened — eyedropper still armed, store untouched.
+    REQUIRE(s.overlay.eyedropper_active());
+    REQUIRE(s.store.count() == 0);
+}
+
+TEST_CASE("InspectorOverlay Phase 3c: pick no-ops without a selection anchor",
+          "[inspect][overlay][phase3c]") {
+    // Hand-authored view with no anchor — the eyedropper still
+    // disables (the click was a deliberate spend) but emits nothing.
+    View root;
+    root.set_bounds({0, 0, 500, 400});
+    auto c = std::make_unique<View>();
+    c->set_bounds({40, 40, 120, 80});
+    c->set_background_color(Color::rgba8(0x11, 0x22, 0x33));
+    root.add_child(std::move(c));
+
+    TweakStore store;
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_tweak_store(&store);
+    overlay.handle_mouse_event(make_click(60, 60));  // select
+    overlay.set_eyedropper_active(true);
+
+    overlay.handle_mouse_event(make_click(80, 70));  // pick
+    REQUIRE_FALSE(overlay.eyedropper_active());
+    REQUIRE(store.count() == 0);
+}
+
+TEST_CASE("InspectorOverlay Phase 3c: deactivating inspector clears eyedropper",
+          "[inspect][overlay][phase3c]") {
+    Phase3cScene s;
+    s.overlay.set_eyedropper_active(true);
+    s.overlay.handle_mouse_event(make_move(80, 70));
+    REQUIRE(s.overlay.eyedropper_has_sample());
+
+    s.overlay.set_active(false);
+    REQUIRE_FALSE(s.overlay.eyedropper_active());
+    REQUIRE_FALSE(s.overlay.eyedropper_has_sample());
+}
+
+TEST_CASE("InspectorOverlay Phase 3c: paint draws swatch when armed",
+          "[inspect][overlay][phase3c]") {
+    // The cursor swatch must paint without crashing once a sample
+    // exists; RecordingCanvas has no pixel readback so this exercises
+    // the resolved-style path + the swatch chrome.
+    Phase3cScene s;
+    s.overlay.set_eyedropper_active(true);
+    s.overlay.handle_mouse_event(make_move(80, 70));
+    REQUIRE(s.overlay.eyedropper_has_sample());
+
+    pulp::canvas::RecordingCanvas canvas;
+    s.overlay.paint(canvas);  // must not crash; swatch chrome drawn
+    REQUIRE(s.overlay.eyedropper_active());
+}
+
 // ── Phase 3a: drag handles ────────────────────────────────────────────────
 
 TEST_CASE("InspectorOverlay: drag handles default OFF", "[inspect][overlay][phase3a]") {


### PR DESCRIPTION
## Summary

Inspector Phase 3c — color eyedropper. An opt-in tool that samples a color from the rendered UI and applies it as a tweak to the selected view's color property. Builds directly on Phase 3a (drag handles) and Phase 3b (box-model edit) patterns — new methods + state, no rewrites.

- **E-key toggle** (no modifier, inspector-active only) arms eyedropper mode — mirrors how the D-key toggles drag handles in Phase 3a.
- **Mouse-move** samples the color under the cursor; a cursor-following swatch + hex readout (checkerboard backing for transparent samples, edge-aware placement) gives live visual feedback.
- **Click** captures the sampled color and emits it via the existing `emit_tweak_for_selection()` path with source `"inspector-eyedropper"`, encoded as a `#rrggbb` / `#rrggbbaa` hex string. A pick auto-disables the mode — one deliberate action; re-arm with E.
- Target property defaults to `style.background_color`; retargetable to `style.color` / `style.border_color` via `set_eyedropper_target()` before a pick.
- A mode hint (`◉ eyedropper` / `◉ drag`) renders mid stats-bar so a non-default canvas mode is always visible.

## Sampling strategy

Two paths, picked at runtime:

1. **Framebuffer readback** — `Canvas::read_pixels()` (canvas.hpp issue-916) returns the exact rendered pixel. Implemented only on Skia raster surfaces; authoritative when present (captures gradients, borders, child paint, theme blend). The readback runs in `paint()` against the fully-composited frame, before the swatch chrome draws, so the chrome can't contaminate the sample.
2. **Resolved-style fallback** — when readback is unavailable (RecordingCanvas, CoreGraphics fallback, headless tests), the eyedropper samples the resolved background color of the top-most View under the cursor, walking up to the nearest ancestor with an explicit background.

**Known v1 simplification:** the resolved-style fallback sees *declared View backgrounds*, not arbitrary pixels — so on a non-Skia-raster surface it won't pick a gradient mid-stop or a child's paint. This is acceptable for v1 per the task brief; the Skia readback path is the full-fidelity route and is wired and preferred whenever the live Canvas supports it.

## Test plan

11 new headless tests in `test/test_inspector.cpp` (`[phase3c]` tag):

- [x] eyedropper defaults OFF; toggle / set round-trip
- [x] E-key toggles only when inspector active; ignored with a modifier
- [x] mouse-move samples the color under the cursor
- [x] click captures color + emits tweak to the store (`#ff8000` round-trip)
- [x] click without a prior move still picks (synchronous fallback)
- [x] retargeting writes a different color property; empty retarget ignored
- [x] semi-transparent sample round-trips as 8-digit `#rrggbbaa`
- [x] eyedropper yields to the inspector panel (panel clicks not eaten)
- [x] pick no-ops cleanly on an anchorless selection
- [x] deactivating the inspector clears eyedropper state
- [x] swatch paint path runs without crashing
- [x] Full inspector suite green: **90 cases / 461 assertions** (`./build/test/pulp-test-inspector`)

## Notes

- `inspect/*` is dev-tooling overlay, not SDK public API surface — `Version-Bump: skip` trailer on the tip commit.
- Changes are localized (new methods/state on `InspectorOverlay`, one new test block) to minimize conflicts with the sibling Phase 2 / Phase 2.5 inspector PRs. One rebase conflict in `test_inspector.cpp` against an upstream Phase 0b PR-C-2 test block was resolved additively (both blocks kept).
- Built with `-DPULP_BUILD_EXAMPLES=OFF` locally (no Skia binaries in this fresh worktree; the GPU-gated `design-tool` example is unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)