### PR TITLE
refactor(mcp): P6-B4 second cut — extract mcp_compat (844 → 597)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v01736"></a>
+## [0.173.6] - 2026-05-19
+
+- refactor(mcp): P6-B4 second cut — extract mcp_compat.{hpp,cpp} (pulp_mcp.cpp 844 → 597)
+
 <a id="v01735"></a>
 ## [0.173.5] - 2026-05-19
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.173.5
+    VERSION 0.173.6
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/mcp/CMakeLists.txt
+++ b/tools/mcp/CMakeLists.txt
@@ -8,7 +8,9 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/pulp_mcp_version.h"
     @ONLY)
 
-add_executable(pulp-mcp pulp_mcp.cpp)
+add_executable(pulp-mcp
+    pulp_mcp.cpp
+    mcp_compat.cpp)
 set_target_properties(pulp-mcp PROPERTIES OUTPUT_NAME "pulp-mcp")
 target_compile_features(pulp-mcp PRIVATE cxx_std_20)
 target_include_directories(pulp-mcp PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")

--- a/tools/mcp/mcp_compat.cpp
+++ b/tools/mcp/mcp_compat.cpp
@@ -1,0 +1,246 @@
+// mcp_compat.cpp — project SDK-compatibility resolution for pulp-mcp.
+//
+// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
+// refactor. See mcp_compat.hpp for the public surface; the SDK-version
+// parsing internals (pulp.toml / CMakeLists scanners, semver triple
+// parser, per-tool min-SDK table) stay file-local (static) here.
+
+#include "mcp_compat.hpp"
+#include "mcp_json.hpp"
+#include "pulp_mcp_version.h"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace pulp_mcp {
+
+static fs::path find_project_root_any() {
+    // Find the nearest ancestor with either:
+    //   - pulp.toml (SDK-mode projects), or
+    //   - CMakeLists.txt + core/ (source-tree Pulp checkouts).
+    // The any-version is used by the compat gate, which must work for
+    // both modes. (`find_project_root` above is source-tree-only and is
+    // kept for tools that genuinely need a Pulp checkout, like the
+    // pulp-screenshot fallback.)
+    auto dir = fs::current_path();
+    while (!dir.empty()) {
+        if (fs::exists(dir / "pulp.toml")) return dir;
+        if (fs::exists(dir / "CMakeLists.txt") && fs::exists(dir / "core"))
+            return dir;
+        auto parent = dir.parent_path();
+        if (parent == dir) break;
+        dir = parent;
+    }
+    return {};
+}
+
+static std::string read_file_text(const fs::path& p) {
+    std::ifstream f(p);
+    if (!f) return {};
+    std::stringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+static std::string parse_pulp_toml_sdk_version(const std::string& body) {
+    // Hand-rolled minimal TOML scan — pulp.toml is small and the
+    // sdk_version key is a top-level scalar. We deliberately do NOT
+    // pull in a TOML library here: pulp-mcp is intentionally minimal-
+    // deps so its binary stays small and load-fast.
+    auto pos = body.find("sdk_version");
+    while (pos != std::string::npos) {
+        // Reject `sdk_version` substrings that are inside other keys
+        // (`min_sdk_version`, etc.): require the previous non-space
+        // char to be a newline or start-of-file. Leading whitespace
+        // on the same line is allowed.
+        bool at_key_start = true;
+        for (std::size_t i = pos; i > 0; --i) {
+            char c = body[i - 1];
+            if (c == '\n' || c == '\r') break; // walked back to a line boundary — ok
+            if (c != ' ' && c != '\t') { at_key_start = false; break; }
+        }
+        if (!at_key_start) {
+            pos = body.find("sdk_version", pos + 1);
+            continue;
+        }
+        auto eq = body.find('=', pos);
+        if (eq == std::string::npos) break;
+        auto q1 = body.find('"', eq);
+        if (q1 == std::string::npos) break;
+        auto q2 = body.find('"', q1 + 1);
+        if (q2 == std::string::npos) break;
+        return body.substr(q1 + 1, q2 - q1 - 1);
+    }
+    return {};
+}
+
+static std::string parse_cmake_project_version(const std::string& body) {
+    // Match `project(<name> ... VERSION x.y.z ...)`. CMakeLists.txt for
+    // a Pulp project either calls `project(...)` directly or uses
+    // `pulp_add_plugin(... VERSION "x.y.z" ...)`. Try both.
+    auto try_match = [&](std::size_t start, char quote_open, char quote_close) -> std::string {
+        auto vpos = body.find("VERSION", start);
+        if (vpos == std::string::npos) return {};
+        std::size_t i = vpos + 7;
+        while (i < body.size() && (body[i] == ' ' || body[i] == '\t' ||
+                                   body[i] == '\n' || body[i] == '\r' ||
+                                   body[i] == quote_open)) ++i;
+        std::string out;
+        while (i < body.size()) {
+            char c = body[i];
+            if ((c >= '0' && c <= '9') || c == '.') out += c;
+            else break;
+            ++i;
+        }
+        // Must look like a semver triple.
+        int dots = 0;
+        for (char c : out) if (c == '.') ++dots;
+        if (dots != 2) return {};
+        return out;
+    };
+    // project(... VERSION x.y.z ...)
+    auto p = body.find("project(");
+    if (p != std::string::npos) {
+        auto v = try_match(p, '(', ')');
+        if (!v.empty()) return v;
+    }
+    // pulp_add_plugin(... VERSION "x.y.z" ...)
+    auto pap = body.find("pulp_add_plugin(");
+    if (pap != std::string::npos) {
+        auto v = try_match(pap, '"', '"');
+        if (!v.empty()) return v;
+    }
+    return {};
+}
+
+std::string resolve_project_sdk_version() {
+    auto root = find_project_root_any();
+    if (root.empty()) return {};
+    // pulp.toml wins when both are present (SDK-mode projects pin
+    // explicitly; CMakeLists.txt VERSION there is the *product* version,
+    // not the SDK version).
+    auto toml_path = root / "pulp.toml";
+    if (fs::exists(toml_path)) {
+        auto v = parse_pulp_toml_sdk_version(read_file_text(toml_path));
+        if (!v.empty()) return v;
+    }
+    auto cmake_path = root / "CMakeLists.txt";
+    if (fs::exists(cmake_path)) {
+        auto v = parse_cmake_project_version(read_file_text(cmake_path));
+        if (!v.empty()) return v;
+    }
+    return {};
+}
+
+static bool parse_semver_triple(const std::string& s, int& maj, int& min, int& patch) {
+    maj = min = patch = -1;
+    std::size_t i = 0;
+    auto eat = [&](int& out) -> bool {
+        if (i >= s.size() || s[i] < '0' || s[i] > '9') return false;
+        int v = 0;
+        while (i < s.size() && s[i] >= '0' && s[i] <= '9') {
+            v = v * 10 + (s[i] - '0'); ++i;
+        }
+        out = v; return true;
+    };
+    if (!eat(maj)) return false;
+    if (i >= s.size() || s[i] != '.') return false; ++i;
+    if (!eat(min)) return false;
+    if (i >= s.size() || s[i] != '.') return false; ++i;
+    if (!eat(patch)) return false;
+    // Allow trailing prerelease/build metadata; ignore.
+    return true;
+}
+
+int compare_semver(const std::string& a, const std::string& b) {
+    int aM, am, ap, bM, bm, bp;
+    bool va = parse_semver_triple(a, aM, am, ap);
+    bool vb = parse_semver_triple(b, bM, bm, bp);
+    // Unparseable versions sort as "newer" (i.e. tolerate) — pre-#2070
+    // behavior was zero gating, so on parse failure we fail open.
+    if (!va || !vb) return 0;
+    if (aM != bM) return aM < bM ? -1 : 1;
+    if (am != bm) return am < bm ? -1 : 1;
+    if (ap != bp) return ap < bp ? -1 : 1;
+    return 0;
+}
+
+// Per-tool min_sdk floors. Default for tools NOT in this table is
+// "0.0.0" (no floor — runs on any project). Add an entry here when a
+// tool's implementation begins to rely on a Pulp SDK API that landed
+// in a specific release, so older projects get a clean upgrade nudge
+// instead of a confusing runtime failure. The table is exposed via
+// the `pulp_compat` introspection tool so plugins / clients can
+// pre-filter their visible tool list if they want.
+struct ToolMinSdk {
+    const char* name;
+    const char* min_sdk_version;
+};
+static const ToolMinSdk TOOL_MIN_SDK_TABLE[] = {
+    // Format: {"pulp_<tool>", "x.y.z"}.
+    // Currently empty — every existing tool runs against any project SDK.
+    // Future tools that require a specific SDK API floor declare it here.
+    {nullptr, nullptr},
+};
+
+std::string min_sdk_for_tool(const std::string& name) {
+    for (const auto& e : TOOL_MIN_SDK_TABLE) {
+        if (!e.name) break;
+        if (name == e.name) return e.min_sdk_version;
+    }
+    return "0.0.0";
+}
+
+std::string compat_error_payload(const std::string& tool_name,
+                                        const std::string& min_sdk,
+                                        const std::string& project_sdk) {
+    // isError:true content + structuredContent so LLM clients can read
+    // either shape. The text is phrased so the LLM can suggest an
+    // actionable fix to the user.
+    std::string structured =
+        std::string(R"JSON({"error":"sdk_too_old","tool":")JSON")
+      + tool_name + R"JSON(","required_sdk":")JSON" + min_sdk
+      + R"JSON(","project_sdk":")JSON" + project_sdk + R"JSON("})JSON";
+    std::string text =
+        "Tool `" + tool_name + "` requires project SDK >= " + min_sdk
+        + "; this project is pinned to "
+        + (project_sdk.empty() ? std::string("<unknown>") : project_sdk)
+        + ". Bump via `pulp project bump`, or run the tool from a "
+          "project that pins a newer SDK.";
+    return "{\"content\":[{\"type\":\"text\",\"text\":"
+         + json_string(text)
+         + "}],\"structuredContent\":" + structured
+         + ",\"isError\":true}";
+}
+
+// Build the JSON body for the `pulp_compat` introspection tool. Returns
+// project_sdk, pulp_mcp_version, mcp_protocol_version, and a
+// per-tool min_sdk map. Plugins / orchestrators can call this once at
+// startup to decide which tools to surface.
+std::string handle_compat() {
+    auto project_sdk = resolve_project_sdk_version();
+    std::string body =
+        std::string(R"JSON({"pulp_mcp_version":")JSON")
+      + PULP_MCP_SERVER_VERSION
+      + R"JSON(","mcp_protocol_version":"2024-11-05","project_sdk":)JSON"
+      + (project_sdk.empty()
+            ? std::string("null")
+            : (std::string("\"") + project_sdk + "\""))
+      + R"JSON(,"tool_min_sdk":{)JSON";
+    bool first = true;
+    for (const auto& e : TOOL_MIN_SDK_TABLE) {
+        if (!e.name) break;
+        if (!first) body += ",";
+        body += std::string("\"") + e.name + "\":\"" + e.min_sdk_version + "\"";
+        first = false;
+    }
+    body += "}}";
+    return json_tool_payload(body);
+}
+
+
+}  // namespace pulp_mcp

--- a/tools/mcp/mcp_compat.hpp
+++ b/tools/mcp/mcp_compat.hpp
@@ -1,0 +1,41 @@
+// mcp_compat.hpp — project SDK-compatibility resolution for the
+// pulp-mcp server.
+//
+// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
+// refactor — second cut of the MCP typed-registry split.
+//
+// pulp-mcp ships independently of any given Pulp project. Before
+// dispatching a tool that touches a project, the server resolves the
+// project's pinned SDK version and refuses tools whose min-SDK floor
+// the project hasn't reached. This header is the public surface of
+// that compat layer; the parsing internals stay file-local in
+// mcp_compat.cpp.
+
+#pragma once
+
+#include <string>
+
+namespace pulp_mcp {
+
+// The minimum SDK version a given tool requires, or empty if the tool
+// has no floor. Keyed by MCP tool name (e.g. "pulp_build").
+std::string min_sdk_for_tool(const std::string& name);
+
+// Resolve the current project's pinned SDK version (from pulp.toml or
+// the project CMakeLists), or empty if no project is detected.
+std::string resolve_project_sdk_version();
+
+// Semantic-version compare: <0 if a<b, 0 if equal, >0 if a>b.
+// Tolerant of malformed input (treats unparseable components as 0).
+int compare_semver(const std::string& a, const std::string& b);
+
+// JSON-RPC error payload for a tool blocked by the project's SDK floor.
+std::string compat_error_payload(const std::string& tool_name,
+                                 const std::string& min_sdk,
+                                 const std::string& project_sdk);
+
+// The `pulp_compat` tool handler — reports the resolved project SDK and
+// the server's own version as a structured tool payload.
+std::string handle_compat();
+
+}  // namespace pulp_mcp

--- a/tools/mcp/pulp_mcp.cpp
+++ b/tools/mcp/pulp_mcp.cpp
@@ -20,12 +20,14 @@
 
 #include "pulp_mcp_version.h"
 #include "mcp_json.hpp"
+#include "mcp_compat.hpp"
 
 namespace fs = std::filesystem;
 
-// JSON-RPC framing + field extraction extracted to mcp_json.hpp in the
-// Phase 6 (B4) refactor. Pull the helpers into file scope so the rest
-// of this TU keeps its existing unqualified call sites.
+// JSON-RPC framing + field extraction extracted to mcp_json.hpp, and
+// project SDK-compat resolution to mcp_compat.hpp, in the Phase 6 (B4)
+// refactor. Pull the helpers into file scope so the rest of this TU
+// keeps its existing unqualified call sites.
 using pulp_mcp::json_string;
 using pulp_mcp::json_error;
 using pulp_mcp::json_result;
@@ -35,6 +37,11 @@ using pulp_mcp::extract_raw;
 using pulp_mcp::extract_int;
 using pulp_mcp::extract_double;
 using pulp_mcp::extract_bool;
+using pulp_mcp::min_sdk_for_tool;
+using pulp_mcp::resolve_project_sdk_version;
+using pulp_mcp::compare_semver;
+using pulp_mcp::compat_error_payload;
+using pulp_mcp::handle_compat;
 
 #if defined(_WIN32)
 #define PULP_POPEN _popen
@@ -70,253 +77,6 @@ static fs::path find_project_root() {
         dir = parent;
     }
     return {};
-}
-
-// ── Compat: project SDK resolution + per-tool min_sdk floors ────────────────
-//
-// pulp-mcp ships independently of any given Pulp project. A user can have
-// installed pulp-mcp v0.110 (from a recent `pulp upgrade`) while editing
-// a project pinned to SDK 0.92.0 in its `pulp.toml`. If a tool's
-// implementation needs API surface that landed in SDK >= 0.100.0, calling
-// it on the older project would silently misbehave (today) or use a
-// newer behavior the project's author didn't ratify.
-//
-// Per-tool feature detection (#2070): each tool can declare a
-// `min_sdk_version` floor below; when the project's SDK is older, the
-// tools/call dispatch returns a structured error to the LLM with
-// actionable upgrade guidance instead of running the tool. Tools left
-// out of `tool_min_sdk_table` (the default) declare no floor — they run
-// against any project SDK, matching pre-#2070 behavior.
-//
-// Design choices the launcher must NOT change:
-//   - Tolerance is per-tool, not connection-wide. Mismatched plugin and
-//     pulp-mcp must continue to load and handshake (#2067 contract).
-//   - Project SDK is read on every call (cheap; reads at most two files
-//     from the project root). This avoids stale caching when a user runs
-//     `pulp project bump` between MCP calls.
-
-static fs::path find_project_root_any() {
-    // Find the nearest ancestor with either:
-    //   - pulp.toml (SDK-mode projects), or
-    //   - CMakeLists.txt + core/ (source-tree Pulp checkouts).
-    // The any-version is used by the compat gate, which must work for
-    // both modes. (`find_project_root` above is source-tree-only and is
-    // kept for tools that genuinely need a Pulp checkout, like the
-    // pulp-screenshot fallback.)
-    auto dir = fs::current_path();
-    while (!dir.empty()) {
-        if (fs::exists(dir / "pulp.toml")) return dir;
-        if (fs::exists(dir / "CMakeLists.txt") && fs::exists(dir / "core"))
-            return dir;
-        auto parent = dir.parent_path();
-        if (parent == dir) break;
-        dir = parent;
-    }
-    return {};
-}
-
-static std::string read_file_text(const fs::path& p) {
-    std::ifstream f(p);
-    if (!f) return {};
-    std::stringstream ss;
-    ss << f.rdbuf();
-    return ss.str();
-}
-
-static std::string parse_pulp_toml_sdk_version(const std::string& body) {
-    // Hand-rolled minimal TOML scan — pulp.toml is small and the
-    // sdk_version key is a top-level scalar. We deliberately do NOT
-    // pull in a TOML library here: pulp-mcp is intentionally minimal-
-    // deps so its binary stays small and load-fast.
-    auto pos = body.find("sdk_version");
-    while (pos != std::string::npos) {
-        // Reject `sdk_version` substrings that are inside other keys
-        // (`min_sdk_version`, etc.): require the previous non-space
-        // char to be a newline or start-of-file. Leading whitespace
-        // on the same line is allowed.
-        bool at_key_start = true;
-        for (std::size_t i = pos; i > 0; --i) {
-            char c = body[i - 1];
-            if (c == '\n' || c == '\r') break; // walked back to a line boundary — ok
-            if (c != ' ' && c != '\t') { at_key_start = false; break; }
-        }
-        if (!at_key_start) {
-            pos = body.find("sdk_version", pos + 1);
-            continue;
-        }
-        auto eq = body.find('=', pos);
-        if (eq == std::string::npos) break;
-        auto q1 = body.find('"', eq);
-        if (q1 == std::string::npos) break;
-        auto q2 = body.find('"', q1 + 1);
-        if (q2 == std::string::npos) break;
-        return body.substr(q1 + 1, q2 - q1 - 1);
-    }
-    return {};
-}
-
-static std::string parse_cmake_project_version(const std::string& body) {
-    // Match `project(<name> ... VERSION x.y.z ...)`. CMakeLists.txt for
-    // a Pulp project either calls `project(...)` directly or uses
-    // `pulp_add_plugin(... VERSION "x.y.z" ...)`. Try both.
-    auto try_match = [&](std::size_t start, char quote_open, char quote_close) -> std::string {
-        auto vpos = body.find("VERSION", start);
-        if (vpos == std::string::npos) return {};
-        std::size_t i = vpos + 7;
-        while (i < body.size() && (body[i] == ' ' || body[i] == '\t' ||
-                                   body[i] == '\n' || body[i] == '\r' ||
-                                   body[i] == quote_open)) ++i;
-        std::string out;
-        while (i < body.size()) {
-            char c = body[i];
-            if ((c >= '0' && c <= '9') || c == '.') out += c;
-            else break;
-            ++i;
-        }
-        // Must look like a semver triple.
-        int dots = 0;
-        for (char c : out) if (c == '.') ++dots;
-        if (dots != 2) return {};
-        return out;
-    };
-    // project(... VERSION x.y.z ...)
-    auto p = body.find("project(");
-    if (p != std::string::npos) {
-        auto v = try_match(p, '(', ')');
-        if (!v.empty()) return v;
-    }
-    // pulp_add_plugin(... VERSION "x.y.z" ...)
-    auto pap = body.find("pulp_add_plugin(");
-    if (pap != std::string::npos) {
-        auto v = try_match(pap, '"', '"');
-        if (!v.empty()) return v;
-    }
-    return {};
-}
-
-static std::string resolve_project_sdk_version() {
-    auto root = find_project_root_any();
-    if (root.empty()) return {};
-    // pulp.toml wins when both are present (SDK-mode projects pin
-    // explicitly; CMakeLists.txt VERSION there is the *product* version,
-    // not the SDK version).
-    auto toml_path = root / "pulp.toml";
-    if (fs::exists(toml_path)) {
-        auto v = parse_pulp_toml_sdk_version(read_file_text(toml_path));
-        if (!v.empty()) return v;
-    }
-    auto cmake_path = root / "CMakeLists.txt";
-    if (fs::exists(cmake_path)) {
-        auto v = parse_cmake_project_version(read_file_text(cmake_path));
-        if (!v.empty()) return v;
-    }
-    return {};
-}
-
-static bool parse_semver_triple(const std::string& s, int& maj, int& min, int& patch) {
-    maj = min = patch = -1;
-    std::size_t i = 0;
-    auto eat = [&](int& out) -> bool {
-        if (i >= s.size() || s[i] < '0' || s[i] > '9') return false;
-        int v = 0;
-        while (i < s.size() && s[i] >= '0' && s[i] <= '9') {
-            v = v * 10 + (s[i] - '0'); ++i;
-        }
-        out = v; return true;
-    };
-    if (!eat(maj)) return false;
-    if (i >= s.size() || s[i] != '.') return false; ++i;
-    if (!eat(min)) return false;
-    if (i >= s.size() || s[i] != '.') return false; ++i;
-    if (!eat(patch)) return false;
-    // Allow trailing prerelease/build metadata; ignore.
-    return true;
-}
-
-static int compare_semver(const std::string& a, const std::string& b) {
-    int aM, am, ap, bM, bm, bp;
-    bool va = parse_semver_triple(a, aM, am, ap);
-    bool vb = parse_semver_triple(b, bM, bm, bp);
-    // Unparseable versions sort as "newer" (i.e. tolerate) — pre-#2070
-    // behavior was zero gating, so on parse failure we fail open.
-    if (!va || !vb) return 0;
-    if (aM != bM) return aM < bM ? -1 : 1;
-    if (am != bm) return am < bm ? -1 : 1;
-    if (ap != bp) return ap < bp ? -1 : 1;
-    return 0;
-}
-
-// Per-tool min_sdk floors. Default for tools NOT in this table is
-// "0.0.0" (no floor — runs on any project). Add an entry here when a
-// tool's implementation begins to rely on a Pulp SDK API that landed
-// in a specific release, so older projects get a clean upgrade nudge
-// instead of a confusing runtime failure. The table is exposed via
-// the `pulp_compat` introspection tool so plugins / clients can
-// pre-filter their visible tool list if they want.
-struct ToolMinSdk {
-    const char* name;
-    const char* min_sdk_version;
-};
-static const ToolMinSdk TOOL_MIN_SDK_TABLE[] = {
-    // Format: {"pulp_<tool>", "x.y.z"}.
-    // Currently empty — every existing tool runs against any project SDK.
-    // Future tools that require a specific SDK API floor declare it here.
-    {nullptr, nullptr},
-};
-
-static std::string min_sdk_for_tool(const std::string& name) {
-    for (const auto& e : TOOL_MIN_SDK_TABLE) {
-        if (!e.name) break;
-        if (name == e.name) return e.min_sdk_version;
-    }
-    return "0.0.0";
-}
-
-static std::string compat_error_payload(const std::string& tool_name,
-                                        const std::string& min_sdk,
-                                        const std::string& project_sdk) {
-    // isError:true content + structuredContent so LLM clients can read
-    // either shape. The text is phrased so the LLM can suggest an
-    // actionable fix to the user.
-    std::string structured =
-        std::string(R"JSON({"error":"sdk_too_old","tool":")JSON")
-      + tool_name + R"JSON(","required_sdk":")JSON" + min_sdk
-      + R"JSON(","project_sdk":")JSON" + project_sdk + R"JSON("})JSON";
-    std::string text =
-        "Tool `" + tool_name + "` requires project SDK >= " + min_sdk
-        + "; this project is pinned to "
-        + (project_sdk.empty() ? std::string("<unknown>") : project_sdk)
-        + ". Bump via `pulp project bump`, or run the tool from a "
-          "project that pins a newer SDK.";
-    return "{\"content\":[{\"type\":\"text\",\"text\":"
-         + json_string(text)
-         + "}],\"structuredContent\":" + structured
-         + ",\"isError\":true}";
-}
-
-// Build the JSON body for the `pulp_compat` introspection tool. Returns
-// project_sdk, pulp_mcp_version, mcp_protocol_version, and a
-// per-tool min_sdk map. Plugins / orchestrators can call this once at
-// startup to decide which tools to surface.
-static std::string handle_compat() {
-    auto project_sdk = resolve_project_sdk_version();
-    std::string body =
-        std::string(R"JSON({"pulp_mcp_version":")JSON")
-      + PULP_MCP_SERVER_VERSION
-      + R"JSON(","mcp_protocol_version":"2024-11-05","project_sdk":)JSON"
-      + (project_sdk.empty()
-            ? std::string("null")
-            : (std::string("\"") + project_sdk + "\""))
-      + R"JSON(,"tool_min_sdk":{)JSON";
-    bool first = true;
-    for (const auto& e : TOOL_MIN_SDK_TABLE) {
-        if (!e.name) break;
-        if (!first) body += ",";
-        body += std::string("\"") + e.name + "\":\"" + e.min_sdk_version + "\"";
-        first = false;
-    }
-    body += "}}";
-    return json_tool_payload(body);
 }
 
 // ── MCP Tool Handlers ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**Phase 6 B4 (MCP typed-registry split), second cut.** The project SDK-compatibility layer — which resolves a project's pinned SDK and gates tools whose min-SDK floor the project hasn't reached — relocated into its own TU.

New `tools/mcp/mcp_compat.hpp` — public surface (`namespace pulp_mcp`):
- `min_sdk_for_tool` / `resolve_project_sdk_version`
- `compare_semver` / `compat_error_payload` / `handle_compat`

New `tools/mcp/mcp_compat.cpp` — the 5 public defs plus the file-local `static` internals (pulp.toml / CMakeLists SDK-version scanners, semver triple parser, `ToolMinSdk` table). Includes `mcp_json.hpp` for JSON-RPC framing.

`pulp_mcp.cpp` pulls the 5 public fns into file scope via `using`-declarations — existing call sites unchanged.

`pulp_mcp.cpp`: **844 → 597 (-247 lines)**; **951 → 597 across both B4 cuts** so far.

## Test plan

- [x] `cmake --build build --target pulp-mcp` — builds clean
- [x] `pulp_compat` tool round-trip: emits a valid structured payload with `project_sdk` + version fields populated
- [ ] CI green across local-macOS + GH-hosted Ubuntu/Windows