### PR TITLE
refactor(mcp): P6-B4 third cut — extract mcp_tools + mcp_shell (597 → 451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v01737"></a>
+## [0.173.7] - 2026-05-19
+
+- refactor(mcp): P6-B4 third cut — extract mcp_tools + mcp_shell (pulp_mcp.cpp 597 → 451)
+
 <a id="v01736"></a>
 ## [0.173.6] - 2026-05-19
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.173.6
+    VERSION 0.173.7
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/tools/mcp/CMakeLists.txt
+++ b/tools/mcp/CMakeLists.txt
@@ -10,7 +10,8 @@ configure_file(
 
 add_executable(pulp-mcp
     pulp_mcp.cpp
-    mcp_compat.cpp)
+    mcp_compat.cpp
+    mcp_tools.cpp)
 set_target_properties(pulp-mcp PROPERTIES OUTPUT_NAME "pulp-mcp")
 target_compile_features(pulp-mcp PRIVATE cxx_std_20)
 target_include_directories(pulp-mcp PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")

--- a/tools/mcp/mcp_shell.hpp
+++ b/tools/mcp/mcp_shell.hpp
@@ -1,0 +1,56 @@
+// mcp_shell.hpp — shell-execution + project-root helpers for pulp-mcp.
+//
+// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
+// refactor. Both the tool handlers (mcp_tools.cpp) and the protocol
+// dispatcher (pulp_mcp.cpp) shell out to the `pulp` CLI and need to
+// locate the enclosing project root, so these two helpers live in a
+// shared header rather than being duplicated.
+
+#pragma once
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+namespace pulp_mcp {
+
+#if defined(_WIN32)
+#define PULP_MCP_POPEN _popen
+#define PULP_MCP_PCLOSE _pclose
+#else
+#define PULP_MCP_POPEN popen
+#define PULP_MCP_PCLOSE pclose
+#endif
+
+// Run `cmd` via popen and capture stdout. On a non-zero exit with no
+// captured output, returns a "Command failed with status N" string so
+// the caller always has something to surface.
+inline std::string exec(const std::string& cmd) {
+    std::string result;
+    FILE* pipe = PULP_MCP_POPEN(cmd.c_str(), "r");
+    if (!pipe) return "Error: failed to run command";
+    char buffer[256];
+    while (fgets(buffer, sizeof(buffer), pipe))
+        result += buffer;
+    int status = PULP_MCP_PCLOSE(pipe);
+    if (status != 0 && result.empty())
+        result = "Command failed with status " + std::to_string(status);
+    return result;
+}
+
+// Walk up from the current directory to the nearest Pulp source tree
+// (a directory with both CMakeLists.txt and core/). Empty path if none.
+inline std::filesystem::path find_project_root() {
+    auto dir = std::filesystem::current_path();
+    while (!dir.empty()) {
+        if (std::filesystem::exists(dir / "CMakeLists.txt") &&
+            std::filesystem::exists(dir / "core"))
+            return dir;
+        auto parent = dir.parent_path();
+        if (parent == dir) break;
+        dir = parent;
+    }
+    return {};
+}
+
+}  // namespace pulp_mcp

--- a/tools/mcp/mcp_tools.cpp
+++ b/tools/mcp/mcp_tools.cpp
@@ -1,0 +1,156 @@
+// mcp_tools.cpp — MCP tool-call handlers for pulp-mcp.
+//
+// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
+// refactor. See mcp_tools.hpp for the dispatch surface. Each handler
+// shells out to the `pulp` CLI (build/test/validate) or queries the
+// bundled audio services (model store, excerpt service), then wraps
+// the result via json_tool_payload.
+
+#include "mcp_tools.hpp"
+#include "mcp_json.hpp"
+#include "mcp_shell.hpp"
+
+#include <pulp/tools/audio/model_store.hpp>
+#include <pulp/tools/audio/excerpt_service.hpp>
+#include <pulp/tools/audio/service.hpp>
+
+#include <filesystem>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace pulp_mcp {
+
+std::string handle_build(const std::string& /*params_json*/) {
+    auto root = find_project_root();
+    if (root.empty()) return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: not in a Pulp project\"}]}";
+
+    auto build_dir = root / "build";
+    std::string output;
+
+    if (!fs::exists(build_dir / "CMakeCache.txt")) {
+        output += exec("cmake -B " + build_dir.string() + " -S " + root.string() + " 2>&1");
+    }
+    output += exec("cmake --build " + build_dir.string() + " 2>&1");
+
+    return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
+}
+
+std::string handle_test(const std::string& params_json) {
+    auto root = find_project_root();
+    if (root.empty()) return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: not in a Pulp project\"}]}";
+
+    auto build_dir = root / "build";
+    std::string cmd = "ctest --test-dir " + build_dir.string() + " --output-on-failure";
+
+    auto filter = extract_string(params_json, "filter");
+    if (!filter.empty()) cmd += " -R " + filter;
+
+    auto output = exec(cmd + " 2>&1");
+    return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
+}
+
+std::string handle_status(const std::string& /*params_json*/) {
+    auto root = find_project_root();
+    if (root.empty()) return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: not in a Pulp project\"}]}";
+
+    std::ostringstream out;
+    out << "Pulp Project: " << root.string() << "\n";
+
+    auto branch = exec("git -C " + root.string() + " branch --show-current 2>/dev/null");
+    if (!branch.empty()) {
+        while (!branch.empty() && branch.back() == '\n') branch.pop_back();
+        out << "Branch: " << branch << "\n";
+    }
+
+    auto build_dir = root / "build";
+    out << "Build: " << (fs::exists(build_dir / "CMakeCache.txt") ? "configured" : "not configured") << "\n";
+
+    int src = 0, hdr = 0, tests = 0;
+    for (auto& e : fs::recursive_directory_iterator(root / "core")) {
+        auto ext = e.path().extension().string();
+        if (ext == ".cpp" || ext == ".mm") ++src;
+        if (ext == ".hpp" || ext == ".h") ++hdr;
+    }
+    if (fs::exists(root / "test")) {
+        for (auto& e : fs::directory_iterator(root / "test")) {
+            if (e.path().extension() == ".cpp") ++tests;
+        }
+    }
+    out << "Sources: " << src << " impl, " << hdr << " headers, " << tests << " test files\n";
+
+    return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(out.str()) + "}]}";
+}
+
+std::string handle_validate(const std::string& params_json) {
+    auto root = find_project_root();
+    if (root.empty()) return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: not in a Pulp project\"}]}";
+
+    std::string cmd = root.string() + "/build/tools/cli/pulp validate --json";
+    if (params_json.find("\"all\"") != std::string::npos &&
+        params_json.find("true") != std::string::npos) {
+        cmd += " --all";
+    }
+    cmd += " 2>&1";
+
+    auto output = exec(cmd);
+    return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
+}
+
+std::string handle_audio_model_status(const std::string& /*params_json*/) {
+    auto status = pulp::tools::audio::query_model_status();
+    return json_tool_payload(pulp::tools::audio::to_json(status));
+}
+
+std::string handle_audio_model_list(const std::string& /*params_json*/) {
+    auto result = pulp::tools::audio::list_models();
+    return json_tool_payload(pulp::tools::audio::to_json(result));
+}
+
+std::string handle_audio_model_activate(const std::string& params_json) {
+    auto model_id = extract_string(params_json, "model_id");
+    if (model_id.empty()) {
+        return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: model_id is required\"}]}";
+    }
+
+    auto result = pulp::tools::audio::activate_model(model_id);
+    return json_tool_payload(pulp::tools::audio::to_json(result));
+}
+
+std::string handle_audio_read_bundle(const std::string& params_json) {
+    auto bundle_path = extract_string(params_json, "bundle_path");
+    if (bundle_path.empty()) {
+        return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: bundle_path is required\"}]}";
+    }
+
+    auto bundle = pulp::tools::audio::read_excerpt_bundle(bundle_path);
+    return json_tool_payload(pulp::tools::audio::to_json(bundle));
+}
+
+
+std::string handle_audio_excerpt_find(const std::string& params_json) {
+    auto text = extract_string(params_json, "text");
+    auto input_path = extract_string(params_json, "input_path");
+    if (text.empty() || input_path.empty()) {
+        return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: text and input_path are required\"}]}";
+    }
+
+    pulp::tools::audio::ExcerptFindRequest request;
+    request.text = text;
+    request.input_path = input_path;
+    request.model_id = extract_string(params_json, "model_id");
+    request.recursive = extract_bool(params_json, "recursive", false);
+    request.top_k = static_cast<std::size_t>(extract_int(params_json, "top", 5));
+    request.window_ms = static_cast<uint64_t>(extract_int(params_json, "window_ms", 1500));
+    request.hop_ms = static_cast<uint64_t>(extract_int(params_json, "hop_ms", 250));
+    request.min_score = extract_double(params_json, "min_score", 0.0);
+    request.max_candidates_per_file =
+        static_cast<std::size_t>(extract_int(params_json, "max_candidates_per_file", 3));
+    request.bundle_out = extract_string(params_json, "bundle_out");
+
+    auto result = pulp::tools::audio::run_excerpt_find(request);
+    return json_tool_payload(pulp::tools::audio::to_json(result));
+}
+
+}  // namespace pulp_mcp

--- a/tools/mcp/mcp_tools.hpp
+++ b/tools/mcp/mcp_tools.hpp
@@ -1,0 +1,26 @@
+// mcp_tools.hpp — MCP tool-call handlers for pulp-mcp.
+//
+// Extracted from tools/mcp/pulp_mcp.cpp in the 2026-05 Phase 6 (B4)
+// refactor — third cut of the MCP typed-registry split. Each handler
+// takes the raw `params` JSON of a tools/call request and returns the
+// tool result payload (json_tool_payload-wrapped structured content).
+//
+// pulp_mcp.cpp's protocol dispatcher routes tool names to these.
+
+#pragma once
+
+#include <string>
+
+namespace pulp_mcp {
+
+std::string handle_build(const std::string& params_json);
+std::string handle_test(const std::string& params_json);
+std::string handle_status(const std::string& params_json);
+std::string handle_validate(const std::string& params_json);
+std::string handle_audio_model_status(const std::string& params_json);
+std::string handle_audio_model_list(const std::string& params_json);
+std::string handle_audio_model_activate(const std::string& params_json);
+std::string handle_audio_read_bundle(const std::string& params_json);
+std::string handle_audio_excerpt_find(const std::string& params_json);
+
+}  // namespace pulp_mcp

--- a/tools/mcp/pulp_mcp.cpp
+++ b/tools/mcp/pulp_mcp.cpp
@@ -21,6 +21,8 @@
 #include "pulp_mcp_version.h"
 #include "mcp_json.hpp"
 #include "mcp_compat.hpp"
+#include "mcp_shell.hpp"
+#include "mcp_tools.hpp"
 
 namespace fs = std::filesystem;
 
@@ -42,175 +44,20 @@ using pulp_mcp::resolve_project_sdk_version;
 using pulp_mcp::compare_semver;
 using pulp_mcp::compat_error_payload;
 using pulp_mcp::handle_compat;
+// Shell-execution + tool handlers extracted to mcp_shell.hpp /
+// mcp_tools.{hpp,cpp} in the Phase 6 (B4) refactor.
+using pulp_mcp::exec;
+using pulp_mcp::find_project_root;
+using pulp_mcp::handle_build;
+using pulp_mcp::handle_test;
+using pulp_mcp::handle_status;
+using pulp_mcp::handle_validate;
+using pulp_mcp::handle_audio_model_status;
+using pulp_mcp::handle_audio_model_list;
+using pulp_mcp::handle_audio_model_activate;
+using pulp_mcp::handle_audio_read_bundle;
+using pulp_mcp::handle_audio_excerpt_find;
 
-#if defined(_WIN32)
-#define PULP_POPEN _popen
-#define PULP_PCLOSE _pclose
-#else
-#define PULP_POPEN popen
-#define PULP_PCLOSE pclose
-#endif
-
-
-// ── Shell execution ──────────────────────────────────────────────────────────
-
-static std::string exec(const std::string& cmd) {
-    std::string result;
-    FILE* pipe = PULP_POPEN(cmd.c_str(), "r");
-    if (!pipe) return "Error: failed to run command";
-    char buffer[256];
-    while (fgets(buffer, sizeof(buffer), pipe))
-        result += buffer;
-    int status = PULP_PCLOSE(pipe);
-    if (status != 0 && result.empty())
-        result = "Command failed with status " + std::to_string(status);
-    return result;
-}
-
-static fs::path find_project_root() {
-    auto dir = fs::current_path();
-    while (!dir.empty()) {
-        if (fs::exists(dir / "CMakeLists.txt") && fs::exists(dir / "core"))
-            return dir;
-        auto parent = dir.parent_path();
-        if (parent == dir) break;
-        dir = parent;
-    }
-    return {};
-}
-
-// ── MCP Tool Handlers ────────────────────────────────────────────────────────
-
-static std::string handle_build(const std::string& /*params_json*/) {
-    auto root = find_project_root();
-    if (root.empty()) return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: not in a Pulp project\"}]}";
-
-    auto build_dir = root / "build";
-    std::string output;
-
-    if (!fs::exists(build_dir / "CMakeCache.txt")) {
-        output += exec("cmake -B " + build_dir.string() + " -S " + root.string() + " 2>&1");
-    }
-    output += exec("cmake --build " + build_dir.string() + " 2>&1");
-
-    return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
-}
-
-static std::string handle_test(const std::string& params_json) {
-    auto root = find_project_root();
-    if (root.empty()) return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: not in a Pulp project\"}]}";
-
-    auto build_dir = root / "build";
-    std::string cmd = "ctest --test-dir " + build_dir.string() + " --output-on-failure";
-
-    auto filter = extract_string(params_json, "filter");
-    if (!filter.empty()) cmd += " -R " + filter;
-
-    auto output = exec(cmd + " 2>&1");
-    return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
-}
-
-static std::string handle_status(const std::string& /*params_json*/) {
-    auto root = find_project_root();
-    if (root.empty()) return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: not in a Pulp project\"}]}";
-
-    std::ostringstream out;
-    out << "Pulp Project: " << root.string() << "\n";
-
-    auto branch = exec("git -C " + root.string() + " branch --show-current 2>/dev/null");
-    if (!branch.empty()) {
-        while (!branch.empty() && branch.back() == '\n') branch.pop_back();
-        out << "Branch: " << branch << "\n";
-    }
-
-    auto build_dir = root / "build";
-    out << "Build: " << (fs::exists(build_dir / "CMakeCache.txt") ? "configured" : "not configured") << "\n";
-
-    int src = 0, hdr = 0, tests = 0;
-    for (auto& e : fs::recursive_directory_iterator(root / "core")) {
-        auto ext = e.path().extension().string();
-        if (ext == ".cpp" || ext == ".mm") ++src;
-        if (ext == ".hpp" || ext == ".h") ++hdr;
-    }
-    if (fs::exists(root / "test")) {
-        for (auto& e : fs::directory_iterator(root / "test")) {
-            if (e.path().extension() == ".cpp") ++tests;
-        }
-    }
-    out << "Sources: " << src << " impl, " << hdr << " headers, " << tests << " test files\n";
-
-    return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(out.str()) + "}]}";
-}
-
-static std::string handle_validate(const std::string& params_json) {
-    auto root = find_project_root();
-    if (root.empty()) return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: not in a Pulp project\"}]}";
-
-    std::string cmd = root.string() + "/build/tools/cli/pulp validate --json";
-    if (params_json.find("\"all\"") != std::string::npos &&
-        params_json.find("true") != std::string::npos) {
-        cmd += " --all";
-    }
-    cmd += " 2>&1";
-
-    auto output = exec(cmd);
-    return "{\"content\":[{\"type\":\"text\",\"text\":" + json_string(output) + "}]}";
-}
-
-static std::string handle_audio_model_status(const std::string& /*params_json*/) {
-    auto status = pulp::tools::audio::query_model_status();
-    return json_tool_payload(pulp::tools::audio::to_json(status));
-}
-
-static std::string handle_audio_model_list(const std::string& /*params_json*/) {
-    auto result = pulp::tools::audio::list_models();
-    return json_tool_payload(pulp::tools::audio::to_json(result));
-}
-
-static std::string handle_audio_model_activate(const std::string& params_json) {
-    auto model_id = extract_string(params_json, "model_id");
-    if (model_id.empty()) {
-        return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: model_id is required\"}]}";
-    }
-
-    auto result = pulp::tools::audio::activate_model(model_id);
-    return json_tool_payload(pulp::tools::audio::to_json(result));
-}
-
-static std::string handle_audio_read_bundle(const std::string& params_json) {
-    auto bundle_path = extract_string(params_json, "bundle_path");
-    if (bundle_path.empty()) {
-        return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: bundle_path is required\"}]}";
-    }
-
-    auto bundle = pulp::tools::audio::read_excerpt_bundle(bundle_path);
-    return json_tool_payload(pulp::tools::audio::to_json(bundle));
-}
-
-
-static std::string handle_audio_excerpt_find(const std::string& params_json) {
-    auto text = extract_string(params_json, "text");
-    auto input_path = extract_string(params_json, "input_path");
-    if (text.empty() || input_path.empty()) {
-        return "{\"content\":[{\"type\":\"text\",\"text\":\"Error: text and input_path are required\"}]}";
-    }
-
-    pulp::tools::audio::ExcerptFindRequest request;
-    request.text = text;
-    request.input_path = input_path;
-    request.model_id = extract_string(params_json, "model_id");
-    request.recursive = extract_bool(params_json, "recursive", false);
-    request.top_k = static_cast<std::size_t>(extract_int(params_json, "top", 5));
-    request.window_ms = static_cast<uint64_t>(extract_int(params_json, "window_ms", 1500));
-    request.hop_ms = static_cast<uint64_t>(extract_int(params_json, "hop_ms", 250));
-    request.min_score = extract_double(params_json, "min_score", 0.0);
-    request.max_candidates_per_file =
-        static_cast<std::size_t>(extract_int(params_json, "max_candidates_per_file", 3));
-    request.bundle_out = extract_string(params_json, "bundle_out");
-
-    auto result = pulp::tools::audio::run_excerpt_find(request);
-    return json_tool_payload(pulp::tools::audio::to_json(result));
-}
 
 // ── MCP Protocol Handler ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

**Phase 6 B4 (MCP typed-registry split), third cut.** The 9 MCP tool-call handlers relocated into their own TU, and the shared shell-execution helpers into a header.

New `tools/mcp/mcp_shell.hpp` (header-only) — `exec()` + `find_project_root()` + the `PULP_MCP_POPEN/PCLOSE` macros. Shared by the tool handlers and the protocol dispatcher (both shell out to the `pulp` CLI).

New `tools/mcp/mcp_tools.{hpp,cpp}` — `handle_build` / `_test` / `_status` / `_validate` / `_audio_model_status` / `_audio_model_list` / `_audio_model_activate` / `_audio_read_bundle` / `_audio_excerpt_find`. Includes `mcp_json.hpp` + `mcp_shell.hpp` + the audio service headers.

`pulp_mcp.cpp` pulls all 11 symbols into file scope via `using`-declarations; the old file-local `PULP_POPEN` macro block is removed (superseded by `mcp_shell.hpp`).

`pulp_mcp.cpp`: **597 → 451 (-146 lines)**; **951 → 451 across the three B4 cuts** — just the protocol dispatcher + `main()` remain.

## Test plan

- [x] `cmake --build build --target pulp-mcp` — builds clean
- [x] `pulp_audio_model_list` tool round-trips a valid structured payload
- [ ] CI green across local-macOS + GH-hosted Ubuntu/Windows