### PR TITLE
feat(inspect): drift drawer + `pulp tweaks diff` CLI (Inspector Phase 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.175.0
+    VERSION 0.176.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -896,6 +896,58 @@ Options:
 - `--params JSON` - JSON params for `--command`
 - `--output FILE` - write a one-shot command response to a file
 
+### tweaks
+
+**Status**: experimental
+
+Inspect the `pulp-tweaks.json` sidecar the inspector overlay writes for
+direct-manipulation edits. Tweaks are keyed by `stable_anchor_id`; after a
+design re-import an anchor may no longer exist in the live tree, so the
+tweak silently stops applying. `pulp tweaks diff` surfaces this — it is the
+CLI mirror of the inspector's drift drawer, sharing the same drift-detection
+logic underneath.
+
+```bash
+pulp tweaks diff
+pulp tweaks diff --tweaks pulp-tweaks.json --design design.json
+pulp tweaks diff --design design.json --json
+```
+
+`tweaks diff` classifies every stored tweak against a design snapshot:
+
+- **clean** - the anchor (and property) still resolve
+- **drifted** - the anchor survives but the targeted property is gone
+- **orphaned** - the anchor itself is gone (re-import removed the element)
+
+The design snapshot comes from `--design FILE`, a small JSON "anchors
+manifest" in any of three shapes:
+
+```json
+["anchor-a", "anchor-b"]
+```
+
+```json
+{ "anchors": ["anchor-a", "anchor-b"] }
+```
+
+```json
+{ "anchors": { "anchor-a": ["paint.color", "layout.padding"] } }
+```
+
+The first two forms enable anchor-only matching (orphan detection); the
+third (anchor → property-path map) additionally enables property-level
+drift detection. With `--design` omitted, the snapshot is empty and every
+tweak is reported as orphaned.
+
+Options:
+
+- `--tweaks FILE` - path to `pulp-tweaks.json` (default: auto-resolved project sidecar)
+- `--design FILE` - anchors-manifest JSON to diff against (default: empty)
+- `--json` - emit the drift report as JSON instead of human-readable text
+
+Exit code: `0` when no drift, `1` when drift is found, `2` on a usage or
+file error.
+
 ### import-design
 
 **Status**: experimental

--- a/docs/status/cli-commands.yaml
+++ b/docs/status/cli-commands.yaml
@@ -562,6 +562,27 @@ commands:
         description: File path for the one-shot command response
     docs: reference/cli.md#inspect
 
+  - name: tweaks
+    status: experimental
+    summary: Inspect the `pulp-tweaks.json` sidecar written by the inspector overlay. `tweaks diff` classifies stored tweaks against a design snapshot as clean, drifted (anchor survives, property gone), or orphaned (anchor gone) — the CLI mirror of the inspector drift drawer.
+    subcommands:
+      - name: diff
+        summary: Compare stored tweaks against a design snapshot; exits 0 (no drift), 1 (drift found), or 2 (usage/file error).
+        args:
+          - name: --tweaks
+            kind: option
+            required: false
+            description: Path to pulp-tweaks.json; defaults to the auto-resolved project sidecar
+          - name: --design
+            kind: option
+            required: false
+            description: Anchors-manifest JSON to diff against (array of anchors, or an object whose `anchors` is an anchor→property-path map); defaults to empty
+          - name: --json
+            kind: option
+            required: false
+            description: Emit the drift report as JSON instead of human-readable text
+    docs: reference/cli.md#tweaks
+
   - name: import-design
     status: partial
     summary: >

--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -8,6 +8,7 @@
 #include <pulp/canvas/canvas.hpp>
 #include <pulp/inspect/editor_url.hpp>
 #include <pulp/inspect/source_jump.hpp>
+#include <pulp/inspect/tweak_store.hpp>
 
 #include <choc/containers/choc_Value.h>
 
@@ -23,8 +24,6 @@
 namespace pulp::render { class RenderPassManager; }
 
 namespace pulp::inspect {
-
-class TweakStore;
 
 using namespace pulp::view;
 using namespace pulp::canvas;
@@ -224,6 +223,37 @@ public:
     /// rendered the expected number of rows without scraping pixels.
     std::size_t tweak_row_count() const { return tweak_rows_.size(); }
 
+    // ── Phase 2 — drift drawer ──────────────────────────────────────
+    //
+    // A collapsible panel that lists tweaks whose anchor_id no longer
+    // resolves to any live view (orphaned) or whose property path no
+    // longer maps (drifted). It surfaces the silent-failure case where
+    // a design re-import changed an element so a stored tweak quietly
+    // stops applying. The drawer auto-expands the first time drift is
+    // detected after a re-import; the user can collapse it with the
+    // header chevron.
+
+    /// Recompute the drift list by diffing the attached TweakStore
+    /// against the current live view tree's anchor set. A no-op (and
+    /// clears the list) when no TweakStore is wired. Called
+    /// automatically on first paint after set_active(true); call it
+    /// explicitly after a re-import to refresh the drawer.
+    void refresh_drift();
+
+    /// Number of drifted/orphaned tweaks from the last refresh_drift().
+    std::size_t drift_count() const { return drifted_.size(); }
+
+    /// Whether the drift drawer is currently expanded.
+    bool drift_drawer_open() const { return drift_drawer_open_; }
+    void set_drift_drawer_open(bool open) { drift_drawer_open_ = open; }
+    void toggle_drift_drawer() { drift_drawer_open_ = !drift_drawer_open_; }
+
+    /// Read-only access to the last computed drift list — for tests and
+    /// host-side badges.
+    const std::vector<TweakStore::DriftedTweak>& drifted() const {
+        return drifted_;
+    }
+
 private:
     View& root_;
     bool active_ = false;
@@ -328,6 +358,23 @@ private:
     // (PULP_INSPECTOR_EDITOR_URL) still applies at jump time.
     InspectorConfig config_{};
 
+    // ── Phase 2 — drift-drawer state ────────────────────────────────
+    //
+    // drifted_ is the cached drift list from the last refresh_drift().
+    // drift_drawer_open_ tracks the expand/collapse state; it flips to
+    // true automatically the first time drift is detected (so a stale
+    // tweak is never silent), and the user can collapse it after.
+    // drift_refreshed_once_ guards the first-paint auto-refresh so the
+    // drawer is populated even if the host never calls refresh_drift()
+    // explicitly.
+    std::vector<TweakStore::DriftedTweak> drifted_;
+    bool drift_drawer_open_ = false;
+    bool drift_refreshed_once_ = false;
+    // Hit-rect of the drift drawer header chevron from the last paint,
+    // in root coords — used by handle_mouse_event() to toggle the
+    // drawer. width==0 means "not painted this frame".
+    Rect drift_header_hit_{};
+
     // Phase 3a — drag-handles state. Off by default so the inspector
     // behaves identically to the pre-3a build until the user opts in
     // (D-key toggle in handle_key_event).
@@ -368,6 +415,11 @@ private:
     /// gets a row with a color-coded type bar, last/avg/peak CPU time,
     /// draw-call counts, and a 60-frame sparkline trend.
     void paint_pass_attribution(Canvas& canvas, float x, float y, float w, float h);
+    /// Phase 2 — paint the drift drawer (collapsible orphaned-tweak
+    /// list). Returns the height it consumed so paint_panel can lay out
+    /// the props section below it. Paints nothing and returns 0 when
+    /// there is no drift.
+    float paint_drift_drawer(Canvas& canvas, float x, float y, float w);
 
     // Phase 2.5 — render the tweak management panel into the given
     // rect. Repopulates tweak_rows_ with this frame's hit-rects.

--- a/inspect/include/pulp/inspect/tweak_store.hpp
+++ b/inspect/include/pulp/inspect/tweak_store.hpp
@@ -223,6 +223,88 @@ public:
     /// without touching the filesystem.
     DiskResult from_json(std::string_view json);
 
+    // ── Phase 2: drift detection ────────────────────────────────────
+    //
+    // A tweak is keyed by (anchor_id, property_path). After a design
+    // re-import the live view tree may no longer carry an anchor a
+    // stored tweak references — that tweak is "orphaned" and silently
+    // does nothing. The drift API surfaces these so the inspector
+    // drawer + `pulp tweaks diff` CLI can warn the user.
+
+    /// Why a tweak failed to apply cleanly.
+    enum class DriftReason {
+        anchor_not_found,    ///< No live view carries this anchor_id.
+        property_not_found,  ///< Anchor resolves but the design no longer
+                             ///  exposes this property path.
+    };
+
+    /// Stringify a DriftReason for JSON / human output.
+    static const char* drift_reason_str(DriftReason reason);
+
+    /// One drifted tweak — a stored edit that no longer maps cleanly to
+    /// the current design.
+    struct DriftedTweak {
+        std::string anchor_id;
+        std::string property_path;
+        choc::value::Value value;
+        std::string source;
+        DriftReason reason = DriftReason::anchor_not_found;
+    };
+
+    /// Three-way classification of every stored tweak against a design.
+    struct DriftReport {
+        std::vector<Record> clean;          ///< Anchor + property both resolve.
+        std::vector<DriftedTweak> drifted;  ///< Anchor resolves, property gone.
+        std::vector<DriftedTweak> orphaned; ///< Anchor itself is gone.
+
+        std::size_t total() const {
+            return clean.size() + drifted.size() + orphaned.size();
+        }
+        bool has_drift() const {
+            return !drifted.empty() || !orphaned.empty();
+        }
+    };
+
+    /// A design snapshot the drift logic diffs tweaks against.
+    ///
+    /// `anchors` is every anchor_id present in the live view tree (or a
+    /// fresh import). `properties`, when populated for an anchor, is the
+    /// set of dotted property paths that anchor still exposes — used to
+    /// detect property-level drift (anchor survives, but the field it
+    /// targeted is gone). An anchor with no `properties` entry is
+    /// treated as "all properties valid" (anchor-only matching), so
+    /// callers that only know the anchor set still get orphan
+    /// detection for free.
+    struct DesignSnapshot {
+        std::unordered_set<std::string> anchors;
+        std::unordered_map<std::string, std::unordered_set<std::string>>
+            properties;
+    };
+
+    /// Classify every stored tweak against `design`. Bypass overlay is
+    /// ignored — a bypassed tweak can still be orphaned, and the user
+    /// should see that.
+    DriftReport diff(const DesignSnapshot& design) const;
+
+    /// Convenience: classify against a flat anchor list (anchor-only
+    /// matching — no property-level drift). Equivalent to building a
+    /// DesignSnapshot with just `anchors` populated.
+    DriftReport diff(const std::vector<std::string>& live_anchors) const;
+
+    /// Return only the orphaned + drifted tweaks for `design` — the
+    /// subset the inspector drift drawer renders.
+    std::vector<DriftedTweak> find_drifted(const DesignSnapshot& design) const;
+
+    /// Convenience overload taking a flat anchor list.
+    std::vector<DriftedTweak>
+    find_drifted(const std::vector<std::string>& live_anchors) const;
+
+    /// Render a DriftReport as a JSON string (used by `pulp tweaks
+    /// diff --json` and the protocol layer). Shape:
+    ///   { "clean": [...], "drifted": [...], "orphaned": [...],
+    ///     "summary": { "total", "clean", "drifted", "orphaned" } }
+    static std::string drift_report_to_json(const DriftReport& report);
+
 private:
     mutable std::mutex mtx_;
     // Outer key: anchor_id. Inner key: dotted property path.

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -5,6 +5,8 @@
 #include <pulp/view/inspector.hpp>
 #include <pulp/render/render_pass.hpp>
 
+#include <choc/text/choc_JSON.h>
+
 #include <algorithm>
 #include <cstdlib>
 #include <sstream>
@@ -56,6 +58,11 @@ void install_inspector_hooks(InspectorOverlay& inspector) {
 
 void InspectorOverlay::set_active(bool active) {
     active_ = active;
+    if (active) {
+        // Re-check drift each time the inspector opens — the design may
+        // have been re-imported while the overlay was dismissed.
+        drift_refreshed_once_ = false;
+    }
     if (!active) {
         // Dropping selection while editing would leave a dangling
         // edit_target_view_ — cancel first so the buffer state is
@@ -93,6 +100,44 @@ bool InspectorOverlay::emit_tweak_for_selection(std::string_view property_path,
     if (!tweak_store_) return false;
     tweak_store_->apply_tweak(anchor, property_path, std::move(value), source);
     return true;
+}
+
+// ── Phase 2 — drift detection ───────────────────────────────────────────────
+//
+// Walks the live view tree collecting every non-empty anchor_id, then
+// diffs the attached TweakStore against that anchor set. Tweaks whose
+// anchor is no longer present are "orphaned" — they silently do nothing
+// because direct manipulation can't re-find the element. The drawer
+// surfaces them so a design re-import never quietly drops the user's
+// edits.
+
+namespace {
+
+void collect_anchor_ids(const View& v, std::vector<std::string>& out) {
+    const auto& a = v.anchor_id();
+    if (!a.empty()) out.push_back(a);
+    for (std::size_t i = 0; i < v.child_count(); ++i)
+        collect_anchor_ids(*v.child_at(i), out);
+}
+
+}  // namespace
+
+void InspectorOverlay::refresh_drift() {
+    drift_refreshed_once_ = true;
+    if (!tweak_store_) {
+        drifted_.clear();
+        return;
+    }
+    std::vector<std::string> live;
+    collect_anchor_ids(root_, live);
+    auto next = tweak_store_->find_drifted(live);
+    // Auto-expand the drawer the first time drift appears — a stale
+    // tweak must never be silent. Once the user collapses it we leave
+    // it collapsed even if the count changes.
+    if (!next.empty() && drifted_.empty()) {
+        drift_drawer_open_ = true;
+    }
+    drifted_ = std::move(next);
 }
 
 // ── Coordinate helpers ──────────────────────────────────────────────────────
@@ -371,6 +416,19 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
                 }
             }
 
+            // Phase 2 — a click on the drift-drawer header toggles the
+            // drawer expand/collapse. Checked first because the header
+            // overlaps the props-section coordinate range; without
+            // this the click would fall through to tree selection.
+            if (drift_header_hit_.width > 0 &&
+                pos.x >= drift_header_hit_.x &&
+                pos.x <= drift_header_hit_.x + drift_header_hit_.width &&
+                pos.y >= drift_header_hit_.y &&
+                pos.y <= drift_header_hit_.y + drift_header_hit_.height) {
+                toggle_drift_drawer();
+                return true;
+            }
+
             // Phase 3b — clicks on numeric values in the property
             // panel enter edit mode. The hit list is populated by the
             // most recent paint_props_section() call; we check it
@@ -487,6 +545,10 @@ void InspectorOverlay::paint(Canvas& canvas) {
     capture_pass_frame();
 
     rebuild_flat_tree();
+    // Phase 2 — populate the drift list on the first paint after the
+    // inspector goes active so the drawer is never empty just because
+    // the host forgot to call refresh_drift() explicitly.
+    if (!drift_refreshed_once_) refresh_drift();
     paint_highlight(canvas);
     paint_distance_lines(canvas);
     if (selected_) paint_box_model(canvas, selected_);
@@ -687,8 +749,14 @@ void InspectorOverlay::paint_panel(Canvas& canvas) {
         float props_y = section_h;
         canvas.set_stroke_color(Color::rgba(0.3f, 0.3f, 0.35f, 0.5f));
         canvas.stroke_line(panel_x + 8, props_y, root_w - 8, props_y);
-        paint_middle(panel_x + 8, props_y + 4,
-                     panel_width_ - 16, section_h - 8);
+
+        // Phase 2 — drift drawer sits directly under the tree divider.
+        // Paints nothing (and returns 0) when there is no drift, so the
+        // props section is unaffected on the happy path.
+        float drift_h = paint_drift_drawer(canvas, panel_x + 8, props_y + 4,
+                                           panel_width_ - 16);
+        paint_middle(panel_x + 8, props_y + 4 + drift_h,
+                     panel_width_ - 16, section_h - 8 - drift_h);
 
         float tweaks_y = section_h * 2.0f;
         canvas.set_stroke_color(Color::rgba(0.3f, 0.3f, 0.35f, 0.5f));
@@ -706,8 +774,13 @@ void InspectorOverlay::paint_panel(Canvas& canvas) {
         canvas.set_stroke_color(Color::rgba(0.3f, 0.3f, 0.35f, 0.5f));
         canvas.stroke_line(panel_x + 8, props_y, root_w - 8, props_y);
 
-        paint_middle(panel_x + 8, props_y + 4,
-                     panel_width_ - 16, stats_y - props_y - 8);
+        // Phase 2 — drift drawer sits directly under the tree divider.
+        // Paints nothing (and returns 0) when there is no drift, so the
+        // props section is unaffected on the happy path.
+        float drift_h = paint_drift_drawer(canvas, panel_x + 8, props_y + 4,
+                                           panel_width_ - 16);
+        paint_middle(panel_x + 8, props_y + 4 + drift_h,
+                     panel_width_ - 16, stats_y - props_y - 8 - drift_h);
     }
 
     // Stats bar (bottom)
@@ -1496,6 +1569,115 @@ InspectorOverlay::tweak_action_at(Point p, std::size_t& out_row) const {
         if (hit(row.delete_icon)) { out_row = i; return TweakAction::remove; }
     }
     return TweakAction::none;
+}
+
+// ── Phase 2 — Drift drawer ──────────────────────────────────────────────────
+//
+// A collapsible warning panel that lists tweaks whose anchor / property
+// no longer maps to the live design. Header is always shown when drift
+// exists (so the count badge is visible); the body — one row per
+// orphaned/drifted tweak — only renders when expanded. Each row shows
+// the anchor, the dotted property path, the stored value, and a reason
+// tag. Clicking the header chevron toggles the drawer.
+
+float InspectorOverlay::paint_drift_drawer(Canvas& canvas, float x, float y,
+                                           float w) {
+    drift_header_hit_ = {};  // reset; repopulated below if we paint.
+    if (drifted_.empty()) return 0.0f;
+
+    const Color kDriftBg     = Color::rgba(0.22f, 0.06f, 0.07f, 0.95f);
+    const Color kDriftBorder = Color::rgba(0.95f, 0.32f, 0.30f, 0.85f);
+    const Color kDriftText   = Color::rgba(0.98f, 0.72f, 0.70f, 1.0f);
+    const Color kDriftReason = Color::rgba(0.95f, 0.55f, 0.30f, 1.0f);
+
+    constexpr float kHeaderH = 22.0f;
+    constexpr float kDriftRowH = 30.0f;
+    // Cap the body so a large drift list never eats the whole panel.
+    const std::size_t kMaxRows = 6;
+    const std::size_t shown_rows =
+        drift_drawer_open_ ? std::min(drifted_.size(), kMaxRows) : 0;
+    const bool truncated = drifted_.size() > kMaxRows;
+    float body_h = static_cast<float>(shown_rows) * kDriftRowH;
+    if (drift_drawer_open_ && truncated) body_h += 16.0f;  // "+N more" line
+    float total_h = kHeaderH + body_h + 4.0f;
+
+    canvas.set_font("monospace", kFontSize);
+
+    // ── Header ──────────────────────────────────────────────────────
+    canvas.set_fill_color(kDriftBg);
+    canvas.fill_rect(x, y, w, kHeaderH);
+    canvas.set_stroke_color(kDriftBorder);
+    canvas.set_line_width(1.0f);
+    canvas.stroke_rect(x, y, w, kHeaderH);
+
+    // The whole header is the toggle target (generous hit box).
+    drift_header_hit_ = {x, y, w, kHeaderH};
+
+    auto chevron = drift_drawer_open_ ? "\xe2\x96\xbc" : "\xe2\x96\xb6";
+    canvas.set_fill_color(kDriftBorder);
+    canvas.fill_text(chevron, x + 4, y + 15);
+
+    std::string title = "\xe2\x9a\xa0 Drift — " +
+                        std::to_string(drifted_.size()) +
+                        (drifted_.size() == 1 ? " orphaned tweak"
+                                              : " orphaned tweaks");
+    canvas.set_fill_color(kDriftText);
+    canvas.fill_text(title, x + 18, y + 15);
+
+    if (!drift_drawer_open_) return total_h;
+
+    // ── Body — one row per drifted/orphaned tweak ──────────────────
+    canvas.set_fill_color(Color::rgba(0.14f, 0.05f, 0.06f, 0.95f));
+    canvas.fill_rect(x, y + kHeaderH, w, body_h);
+
+    float row_y = y + kHeaderH;
+    for (std::size_t i = 0; i < shown_rows; ++i) {
+        const auto& d = drifted_[i];
+
+        // Left red marker stripe — matches Phase 2.5's planned
+        // drift-row styling so the two panels read consistently.
+        canvas.set_fill_color(kDriftBorder);
+        canvas.fill_rect(x, row_y + 2, 2.0f, kDriftRowH - 4);
+
+        // Line 1: anchor + reason tag.
+        std::string anchor = d.anchor_id;
+        if (anchor.size() > 28) anchor = anchor.substr(0, 27) + "\xe2\x80\xa6";
+        canvas.set_fill_color(kDriftText);
+        canvas.fill_text(anchor, x + 8, row_y + 13);
+
+        std::string reason = TweakStore::drift_reason_str(d.reason);
+        canvas.set_fill_color(kDriftReason);
+        float rw = canvas.measure_text(reason);
+        canvas.fill_text(reason, x + w - rw - 4, row_y + 13);
+
+        // Line 2: property path = stored value.
+        std::string value_str;
+        if (d.value.isString()) {
+            value_str = std::string(d.value.getString());
+        } else {
+            try {
+                value_str = choc::json::toString(d.value);
+            } catch (...) {
+                value_str = "?";
+            }
+        }
+        std::string detail = d.property_path + " = " + value_str;
+        if (detail.size() > 40) detail = detail.substr(0, 39) + "\xe2\x80\xa6";
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text(detail, x + 8, row_y + 25);
+
+        row_y += kDriftRowH;
+    }
+
+    if (truncated) {
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text("\xe2\x80\xa6 +" +
+                             std::to_string(drifted_.size() - kMaxRows) +
+                             " more (see `pulp tweaks diff`)",
+                         x + 8, row_y + 12);
+    }
+
+    return total_h;
 }
 
 // ── Phase 3b — Live-editable box-model fields ───────────────────────────────

--- a/inspect/src/tweak_store.cpp
+++ b/inspect/src/tweak_store.cpp
@@ -508,6 +508,127 @@ TweakStore::DiskResult TweakStore::from_json(std::string_view json) {
     return from_json_locked(json);
 }
 
+// ── Drift detection (Phase 2) ───────────────────────────────────────────
+
+const char* TweakStore::drift_reason_str(DriftReason reason) {
+    switch (reason) {
+        case DriftReason::anchor_not_found:   return "anchor-not-found";
+        case DriftReason::property_not_found: return "property-not-found";
+    }
+    return "unknown";
+}
+
+TweakStore::DriftReport
+TweakStore::diff(const DesignSnapshot& design) const {
+    DriftReport report;
+    std::lock_guard lock(mtx_);
+    for (auto& [anchor, m] : tweaks_) {
+        const bool anchor_live = design.anchors.count(anchor) > 0;
+        // properties[anchor] is the set of paths the design still
+        // exposes for this anchor. Absent → anchor-only matching:
+        // every property is treated as valid (no property-level drift).
+        auto prop_it = design.properties.find(anchor);
+        const bool have_prop_set = prop_it != design.properties.end();
+        for (auto& [path, entry] : m) {
+            if (!anchor_live) {
+                report.orphaned.push_back(DriftedTweak{
+                    anchor, path, entry.value, entry.source,
+                    DriftReason::anchor_not_found});
+            } else if (have_prop_set &&
+                       prop_it->second.count(path) == 0) {
+                report.drifted.push_back(DriftedTweak{
+                    anchor, path, entry.value, entry.source,
+                    DriftReason::property_not_found});
+            } else {
+                report.clean.push_back(
+                    Record{anchor, path, entry.value, entry.source});
+            }
+        }
+    }
+    return report;
+}
+
+TweakStore::DriftReport
+TweakStore::diff(const std::vector<std::string>& live_anchors) const {
+    DesignSnapshot snap;
+    snap.anchors.insert(live_anchors.begin(), live_anchors.end());
+    return diff(snap);
+}
+
+std::vector<TweakStore::DriftedTweak>
+TweakStore::find_drifted(const DesignSnapshot& design) const {
+    auto report = diff(design);
+    std::vector<DriftedTweak> out;
+    out.reserve(report.orphaned.size() + report.drifted.size());
+    // Orphans first — anchor loss is the louder failure mode.
+    for (auto& d : report.orphaned) out.push_back(std::move(d));
+    for (auto& d : report.drifted)  out.push_back(std::move(d));
+    return out;
+}
+
+std::vector<TweakStore::DriftedTweak>
+TweakStore::find_drifted(const std::vector<std::string>& live_anchors) const {
+    DesignSnapshot snap;
+    snap.anchors.insert(live_anchors.begin(), live_anchors.end());
+    return find_drifted(snap);
+}
+
+std::string
+TweakStore::drift_report_to_json(const DriftReport& report) {
+    auto record_obj = [](const std::string& anchor,
+                         const std::string& path,
+                         const choc::value::Value& value,
+                         const std::string& source) {
+        auto o = choc::value::createObject("");
+        o.addMember("anchorId", choc::value::createString(anchor));
+        o.addMember("propertyPath", choc::value::createString(path));
+        o.addMember("value", value);
+        if (!source.empty())
+            o.addMember("source", choc::value::createString(source));
+        return o;
+    };
+
+    auto obj = choc::value::createObject("");
+
+    auto clean_arr = choc::value::createEmptyArray();
+    for (auto& r : report.clean) {
+        clean_arr.addArrayElement(
+            record_obj(r.anchor_id, r.property_path, r.value, r.source));
+    }
+    obj.addMember("clean", clean_arr);
+
+    auto emit_drift = [&](const std::vector<DriftedTweak>& list) {
+        auto arr = choc::value::createEmptyArray();
+        for (auto& d : list) {
+            auto o = record_obj(d.anchor_id, d.property_path,
+                                d.value, d.source);
+            o.addMember("reason",
+                        choc::value::createString(drift_reason_str(d.reason)));
+            arr.addArrayElement(o);
+        }
+        return arr;
+    };
+    obj.addMember("drifted", emit_drift(report.drifted));
+    obj.addMember("orphaned", emit_drift(report.orphaned));
+
+    auto summary = choc::value::createObject("");
+    summary.addMember("total",
+                      choc::value::createInt64(
+                          static_cast<int64_t>(report.total())));
+    summary.addMember("clean",
+                      choc::value::createInt64(
+                          static_cast<int64_t>(report.clean.size())));
+    summary.addMember("drifted",
+                      choc::value::createInt64(
+                          static_cast<int64_t>(report.drifted.size())));
+    summary.addMember("orphaned",
+                      choc::value::createInt64(
+                          static_cast<int64_t>(report.orphaned.size())));
+    obj.addMember("summary", summary);
+
+    return choc::json::toString(obj, true);
+}
+
 TweakStore::DiskResult
 TweakStore::load_from_disk(std::string_view path) {
     DiskResult result;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -321,6 +321,16 @@ if(TARGET pulp-cli)
 endif()
 catch_discover_tests(pulp-test-cli-shellout-lifecycle)
 
+# Inspector Phase 2 — `pulp tweaks diff` shell-out tests. Drives the
+# built binary against pulp-tweaks.json + design-snapshot fixtures and
+# pins the clean / drifted / orphaned exit-code contract.
+add_executable(pulp-test-cli-tweaks-shellout test_cli_tweaks_shellout.cpp)
+target_link_libraries(pulp-test-cli-tweaks-shellout PRIVATE pulp::platform Catch2::Catch2WithMain)
+if(TARGET pulp-cli)
+    add_dependencies(pulp-test-cli-tweaks-shellout pulp-cli)
+endif()
+catch_discover_tests(pulp-test-cli-tweaks-shellout)
+
 # pulp #776 — pin shell_quote's per-platform contract so it can't
 # silently regress to the pre-fix shape that broke `git fetch origin`
 # on Windows by writing doubled backslashes into clone URLs.

--- a/test/test_cli_tweaks_shellout.cpp
+++ b/test/test_cli_tweaks_shellout.cpp
@@ -1,0 +1,204 @@
+// test_cli_tweaks_shellout.cpp — shell-out tests for `pulp tweaks diff`.
+//
+// Per CLAUDE.md: "CLI behavior changes — shell out to the built binary,
+// assert exit code + stderr content." `pulp tweaks diff` (Inspector
+// Phase 2) compares the pulp-tweaks.json sidecar against a design
+// snapshot and reports clean / drifted / orphaned tweaks. These tests
+// drive the real binary with fixture files in a scratch directory and
+// pin the exit-code contract (0 = no drift, 1 = drift, 2 = usage/file
+// error) plus the human + JSON output shapes.
+//
+// Spec: planning/2026-05-18-inspector-direct-manipulation-roadmap.md
+
+#include "test_cli_shellout_helpers.hpp"
+
+using namespace pulp_test_cli;
+namespace fs = std::filesystem;
+
+namespace {
+
+// A pulp-tweaks.json with two anchors: `anchor-live` (2 tweaks) and
+// `anchor-gone` (1 tweak). Tests pair this with design fixtures that
+// keep or drop those anchors.
+const char* kTweaksFixture = R"({
+  "$schema": "pulp-tweaks://v1",
+  "version": 1,
+  "tweaks": {
+    "anchor-live": { "paint.backgroundColor": "#222222", "layout.padding": 16 },
+    "anchor-gone": { "layout.margin": 8 }
+  },
+  "bypassed": {}
+})";
+
+}  // namespace
+
+TEST_CASE("pulp tweaks --help prints usage and exits 0",
+          "[cli][shellout][tweaks][phase2]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto r = run_pulp({"tweaks", "--help"});
+    REQUIRE(r.exit_code == 0);
+    REQUIRE_FALSE(r.timed_out);
+    REQUIRE(r.stdout_output.find("pulp tweaks") != std::string::npos);
+    REQUIRE(r.stdout_output.find("diff") != std::string::npos);
+}
+
+TEST_CASE("pulp tweaks with no subcommand prints usage and exits 0",
+          "[cli][shellout][tweaks][phase2]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto r = run_pulp({"tweaks"});
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stdout_output.find("tweaks") != std::string::npos);
+}
+
+TEST_CASE("pulp tweaks <unknown-subcommand> exits 2 with a diagnostic",
+          "[cli][shellout][tweaks][phase2]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto r = run_pulp({"tweaks", "frobnicate"});
+    REQUIRE(r.exit_code == 2);
+    REQUIRE(r.stderr_output.find("unknown") != std::string::npos);
+}
+
+TEST_CASE("pulp tweaks diff reports orphaned tweaks and exits 1",
+          "[cli][shellout][tweaks][phase2]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto dir = unique_temp_dir("pulp-tweaks-diff-orphan");
+    fs::create_directories(dir);
+    auto tweaks = dir / "pulp-tweaks.json";
+    auto design = dir / "design.json";
+    write_text(tweaks, kTweaksFixture);
+    // Re-import dropped `anchor-gone`.
+    write_text(design, R"(["anchor-live"])");
+
+    auto r = run_pulp({"tweaks", "diff",
+                       "--tweaks", tweaks.string(),
+                       "--design", design.string()});
+    REQUIRE_FALSE(r.timed_out);
+    // Drift present → exit 1.
+    REQUIRE(r.exit_code == 1);
+    REQUIRE(r.stdout_output.find("orphaned 1") != std::string::npos);
+    REQUIRE(r.stdout_output.find("anchor-gone") != std::string::npos);
+    REQUIRE(r.stdout_output.find("anchor-not-found") != std::string::npos);
+
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+}
+
+TEST_CASE("pulp tweaks diff with no drift exits 0",
+          "[cli][shellout][tweaks][phase2]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto dir = unique_temp_dir("pulp-tweaks-diff-clean");
+    fs::create_directories(dir);
+    auto tweaks = dir / "pulp-tweaks.json";
+    auto design = dir / "design.json";
+    write_text(tweaks, kTweaksFixture);
+    // Design still exposes both anchors.
+    write_text(design, R"({"anchors":["anchor-live","anchor-gone"]})");
+
+    auto r = run_pulp({"tweaks", "diff",
+                       "--tweaks", tweaks.string(),
+                       "--design", design.string()});
+    REQUIRE(r.exit_code == 0);
+    REQUIRE(r.stdout_output.find("No drift") != std::string::npos);
+
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+}
+
+TEST_CASE("pulp tweaks diff --json emits a structured report",
+          "[cli][shellout][tweaks][phase2]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto dir = unique_temp_dir("pulp-tweaks-diff-json");
+    fs::create_directories(dir);
+    auto tweaks = dir / "pulp-tweaks.json";
+    auto design = dir / "design.json";
+    write_text(tweaks, kTweaksFixture);
+    write_text(design, R"(["anchor-live"])");
+
+    auto r = run_pulp({"tweaks", "diff",
+                       "--tweaks", tweaks.string(),
+                       "--design", design.string(),
+                       "--json"});
+    REQUIRE(r.exit_code == 1);
+    // JSON keys present; no human-readable banner.
+    REQUIRE(r.stdout_output.find("\"summary\"") != std::string::npos);
+    REQUIRE(r.stdout_output.find("\"orphaned\"") != std::string::npos);
+    REQUIRE(r.stdout_output.find("\"reason\"") != std::string::npos);
+    REQUIRE(r.stdout_output.find("anchor-not-found") != std::string::npos);
+
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+}
+
+TEST_CASE("pulp tweaks diff detects property-level drift via the anchors map",
+          "[cli][shellout][tweaks][phase2]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+
+    auto dir = unique_temp_dir("pulp-tweaks-diff-prop");
+    fs::create_directories(dir);
+    auto tweaks = dir / "pulp-tweaks.json";
+    auto design = dir / "design.json";
+    write_text(tweaks, kTweaksFixture);
+    // Anchors survive, but `anchor-live` no longer exposes
+    // layout.padding — that tweak should be reported as drifted.
+    write_text(design, R"({"anchors":{
+        "anchor-live": ["paint.backgroundColor"],
+        "anchor-gone": ["layout.margin"]
+    }})");
+
+    auto r = run_pulp({"tweaks", "diff",
+                       "--tweaks", tweaks.string(),
+                       "--design", design.string()});
+    REQUIRE(r.exit_code == 1);
+    REQUIRE(r.stdout_output.find("drifted  1") != std::string::npos);
+    REQUIRE(r.stdout_output.find("property-not-found") != std::string::npos);
+    REQUIRE(r.stdout_output.find("layout.padding") != std::string::npos);
+
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+}
+
+TEST_CASE("pulp tweaks diff with a missing tweaks file exits 2",
+          "[cli][shellout][tweaks][phase2]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto dir = unique_temp_dir("pulp-tweaks-diff-missing");
+    fs::create_directories(dir);
+    auto missing = dir / "does-not-exist.json";
+
+    auto r = run_pulp({"tweaks", "diff", "--tweaks", missing.string()});
+    REQUIRE(r.exit_code == 2);
+    REQUIRE(r.stderr_output.find("Error") != std::string::npos);
+
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+}
+
+TEST_CASE("pulp tweaks diff with a malformed design file exits 2",
+          "[cli][shellout][tweaks][phase2]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto dir = unique_temp_dir("pulp-tweaks-diff-baddesign");
+    fs::create_directories(dir);
+    auto tweaks = dir / "pulp-tweaks.json";
+    auto design = dir / "design.json";
+    write_text(tweaks, kTweaksFixture);
+    write_text(design, "{ this is not json");
+
+    auto r = run_pulp({"tweaks", "diff",
+                       "--tweaks", tweaks.string(),
+                       "--design", design.string()});
+    REQUIRE(r.exit_code == 2);
+    REQUIRE(r.stderr_output.find("Error") != std::string::npos);
+
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+}
+
+TEST_CASE("pulp tweaks diff rejects an unknown flag with exit 2",
+          "[cli][shellout][tweaks][phase2]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto r = run_pulp({"tweaks", "diff", "--bogus-flag"});
+    REQUIRE(r.exit_code == 2);
+    REQUIRE(r.stderr_output.find("unknown") != std::string::npos);
+}

--- a/test/test_cli_tweaks_shellout.cpp
+++ b/test/test_cli_tweaks_shellout.cpp
@@ -195,6 +195,27 @@ TEST_CASE("pulp tweaks diff with a malformed design file exits 2",
     fs::remove_all(dir, ec);
 }
 
+TEST_CASE("pulp tweaks diff rejects a non-array property manifest entry",
+          "[cli][shellout][tweaks][phase2][regression]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto dir = unique_temp_dir("pulp-tweaks-diff-bad-props");
+    fs::create_directories(dir);
+    auto tweaks = dir / "pulp-tweaks.json";
+    auto design = dir / "design.json";
+    write_text(tweaks, kTweaksFixture);
+    write_text(design, R"({"anchors":{"anchor-live":{"layout.padding":true}}})");
+
+    auto r = run_pulp({"tweaks", "diff",
+                       "--tweaks", tweaks.string(),
+                       "--design", design.string()});
+    REQUIRE(r.exit_code == 2);
+    REQUIRE(r.stderr_output.find("property-path arrays") != std::string::npos);
+    REQUIRE(r.stdout_output.find("property-not-found") == std::string::npos);
+
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+}
+
 TEST_CASE("pulp tweaks diff rejects an unknown flag with exit 2",
           "[cli][shellout][tweaks][phase2]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }

--- a/test/test_cli_tweaks_shellout.cpp
+++ b/test/test_cli_tweaks_shellout.cpp
@@ -216,6 +216,36 @@ TEST_CASE("pulp tweaks diff rejects a non-array property manifest entry",
     fs::remove_all(dir, ec);
 }
 
+// Codex P2 (#2437): a typo'd manifest where an anchor maps to a bare
+// string (instead of a property-path array) must surface a manifest
+// validation error (exit 2), not silently create an empty property
+// set that misreports every tweak under it as `property-not-found`
+// drift (exit 1).
+TEST_CASE("pulp tweaks diff rejects a string-valued anchor manifest entry",
+          "[cli][shellout][tweaks][phase2][regression][issue-2437]") {
+    if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }
+    auto dir = unique_temp_dir("pulp-tweaks-diff-string-anchor");
+    fs::create_directories(dir);
+    auto tweaks = dir / "pulp-tweaks.json";
+    auto design = dir / "design.json";
+    write_text(tweaks, kTweaksFixture);
+    // `anchor-live` maps to a bare string — a manifest typo. This must
+    // be rejected as a file error, never treated as "no properties".
+    write_text(design, R"({"anchors":{"anchor-live":"layout.padding"}})");
+
+    auto r = run_pulp({"tweaks", "diff",
+                       "--tweaks", tweaks.string(),
+                       "--design", design.string()});
+    REQUIRE(r.exit_code == 2);
+    REQUIRE(r.stderr_output.find("property-path arrays") != std::string::npos);
+    // No false drift output leaked to stdout.
+    REQUIRE(r.stdout_output.find("property-not-found") == std::string::npos);
+    REQUIRE(r.stdout_output.find("drifted") == std::string::npos);
+
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+}
+
 TEST_CASE("pulp tweaks diff rejects an unknown flag with exit 2",
           "[cli][shellout][tweaks][phase2]") {
     if (!binary_exists()) { SUCCEED("skipped: pulp not built"); return; }

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -2777,3 +2777,187 @@ TEST_CASE("DomainHandler propagates config to the attached overlay",
     REQUIRE(std::string(obj["url"].getString())
             == "cursor://file/x/Y.jsx:5");
 }
+
+// ── Phase 2 — drift drawer ──────────────────────────────────────────────
+//
+// The drift drawer is a collapsible warning panel inside the inspector
+// overlay that lists tweaks whose anchor_id no longer resolves to a live
+// view. It is populated by refresh_drift(), which walks the live view
+// tree's anchor set and diffs it against the attached TweakStore.
+// Spec: planning/2026-05-18-inspector-direct-manipulation-roadmap.md
+// (Phase 2).
+namespace {
+
+// True if any fill_text command's text contains `needle`.
+bool canvas_has_text(const pulp::canvas::RecordingCanvas& canvas,
+                     std::string_view needle) {
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::fill_text &&
+            cmd.text.find(needle) != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+TEST_CASE("InspectorOverlay: refresh_drift finds tweaks with no live anchor",
+          "[inspect][overlay][drift][phase2]") {
+    View root;
+    root.set_bounds({0, 0, 500, 400});
+
+    auto child = std::make_unique<View>();
+    child->set_anchor_id("anchor-still-here");
+    root.add_child(std::move(child));
+
+    TweakStore store;
+    // One tweak whose anchor is live, one whose anchor is gone.
+    store.apply_tweak("anchor-still-here", "layout.padding",
+                      choc::value::createInt32(8));
+    store.apply_tweak("anchor-removed-by-reimport", "paint.color",
+                      choc::value::createString("#ff0000"));
+
+    InspectorOverlay overlay(root);
+    overlay.set_tweak_store(&store);
+    overlay.refresh_drift();
+
+    REQUIRE(overlay.drift_count() == 1);
+    REQUIRE(overlay.drifted().front().anchor_id ==
+            "anchor-removed-by-reimport");
+    REQUIRE(overlay.drifted().front().reason ==
+            TweakStore::DriftReason::anchor_not_found);
+    // First drift detection auto-expands the drawer so it is not silent.
+    REQUIRE(overlay.drift_drawer_open());
+}
+
+TEST_CASE("InspectorOverlay: no drift means no drawer and an empty list",
+          "[inspect][overlay][drift][phase2]") {
+    View root;
+    root.set_bounds({0, 0, 500, 400});
+    auto child = std::make_unique<View>();
+    child->set_anchor_id("live-anchor");
+    root.add_child(std::move(child));
+
+    TweakStore store;
+    store.apply_tweak("live-anchor", "layout.width",
+                      choc::value::createInt32(120));
+
+    InspectorOverlay overlay(root);
+    overlay.set_tweak_store(&store);
+    overlay.refresh_drift();
+
+    REQUIRE(overlay.drift_count() == 0);
+    REQUIRE(overlay.drifted().empty());
+
+    // The drawer paints nothing on the happy path.
+    overlay.set_active(true);
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+    REQUIRE_FALSE(canvas_has_text(canvas, "Drift"));
+}
+
+TEST_CASE("InspectorOverlay: refresh_drift with no TweakStore is a safe no-op",
+          "[inspect][overlay][drift][phase2]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+    overlay.refresh_drift();  // no store wired
+    REQUIRE(overlay.drift_count() == 0);
+    REQUIRE(overlay.drifted().empty());
+}
+
+TEST_CASE("InspectorOverlay: drift drawer renders header and orphan rows",
+          "[inspect][overlay][drift][phase2]") {
+    View root;
+    root.set_bounds({0, 0, 600, 500});
+    auto child = std::make_unique<View>();
+    child->set_anchor_id("kept");
+    root.add_child(std::move(child));
+
+    TweakStore store;
+    store.apply_tweak("kept", "layout.width",
+                      choc::value::createInt32(64));
+    store.apply_tweak("gone-anchor", "layout.margin",
+                      choc::value::createInt32(10));
+
+    InspectorOverlay overlay(root);
+    overlay.set_tweak_store(&store);
+    overlay.set_active(true);
+
+    // First paint auto-refreshes drift and auto-expands the drawer.
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+
+    REQUIRE(overlay.drift_count() == 1);
+    REQUIRE(overlay.drift_drawer_open());
+    // Header text + the orphaned anchor + its reason tag are painted.
+    REQUIRE(canvas_has_text(canvas, "Drift"));
+    REQUIRE(canvas_has_text(canvas, "gone-anchor"));
+    REQUIRE(canvas_has_text(canvas, "anchor-not-found"));
+    REQUIRE(canvas_has_text(canvas, "layout.margin"));
+}
+
+TEST_CASE("InspectorOverlay: clicking the drift header toggles the drawer",
+          "[inspect][overlay][drift][phase2]") {
+    View root;
+    root.set_bounds({0, 0, 600, 500});
+    auto child = std::make_unique<View>();
+    child->set_anchor_id("present");
+    root.add_child(std::move(child));
+
+    TweakStore store;
+    store.apply_tweak("present", "layout.width",
+                      choc::value::createInt32(80));
+    store.apply_tweak("missing", "paint.opacity",
+                      choc::value::createFloat32(0.4f));
+
+    InspectorOverlay overlay(root);
+    overlay.set_tweak_store(&store);
+    overlay.set_active(true);
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);  // auto-expands; populates the header hit-rect
+    REQUIRE(overlay.drift_drawer_open());
+
+    // The drawer header sits just below the tree section (root_h * 0.5
+    // = 250) on the panel side (panel_x = 600 - 300 = 300). A click in
+    // that band collapses the drawer.
+    MouseEvent click;
+    click.position = {360, 258};
+    click.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(click));
+    REQUIRE_FALSE(overlay.drift_drawer_open());
+
+    // Re-paint so the (now-collapsed) header hit-rect is refreshed,
+    // then click again to re-expand.
+    canvas.clear();
+    overlay.paint(canvas);
+    MouseEvent click2;
+    click2.position = {360, 258};
+    click2.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(click2));
+    REQUIRE(overlay.drift_drawer_open());
+}
+
+TEST_CASE("InspectorOverlay: collapsed drawer hides rows but keeps the header",
+          "[inspect][overlay][drift][phase2]") {
+    View root;
+    root.set_bounds({0, 0, 600, 500});
+
+    TweakStore store;
+    store.apply_tweak("orphan-a", "layout.width",
+                      choc::value::createInt32(50));
+
+    InspectorOverlay overlay(root);
+    overlay.set_tweak_store(&store);
+    overlay.set_active(true);
+    overlay.refresh_drift();
+    overlay.set_drift_drawer_open(false);
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+    // Header still shows the drift count; the orphan row does not.
+    REQUIRE(canvas_has_text(canvas, "Drift"));
+    REQUIRE_FALSE(canvas_has_text(canvas, "layout.width"));
+}

--- a/test/test_tweak_store.cpp
+++ b/test/test_tweak_store.cpp
@@ -1116,3 +1116,175 @@ TEST_CASE("Inspector.load/save/setAutoSave without a store error cleanly",
     REQUIRE(h.handle(req(methods::kInspectorSetAutoSave,
         R"({"enabled":true})")).is_error);
 }
+
+// ── Phase 2 — drift detection ───────────────────────────────────────────
+//
+// A tweak is keyed by (anchor_id, property_path). After a design
+// re-import a stored anchor may no longer exist in the live tree
+// (orphaned) or, given a per-anchor property snapshot, the property it
+// targeted may be gone (drifted). TweakStore::diff / find_drifted
+// classify every stored tweak; the inspector drawer + `pulp tweaks
+// diff` CLI consume these.
+
+TEST_CASE("TweakStore::diff classifies every tweak against an anchor set",
+          "[inspect][tweak-store][drift][phase2]") {
+    TweakStore store;
+    store.apply_tweak("anchor-live-1", "paint.backgroundColor",
+                      choc::value::createString("#ff0000"));
+    store.apply_tweak("anchor-live-1", "layout.padding",
+                      choc::value::createInt32(12));
+    store.apply_tweak("anchor-gone-2", "layout.margin",
+                      choc::value::createInt32(8), "inspector-drag-handle");
+
+    // Only anchor-live-1 survives the re-import.
+    auto report = store.diff(std::vector<std::string>{"anchor-live-1"});
+
+    REQUIRE(report.total() == 3);
+    REQUIRE(report.clean.size() == 2);
+    REQUIRE(report.drifted.empty());          // anchor-only matching
+    REQUIRE(report.orphaned.size() == 1);
+    REQUIRE(report.has_drift());
+
+    const auto& orphan = report.orphaned.front();
+    REQUIRE(orphan.anchor_id == "anchor-gone-2");
+    REQUIRE(orphan.property_path == "layout.margin");
+    REQUIRE(orphan.source == "inspector-drag-handle");
+    REQUIRE(orphan.reason == TweakStore::DriftReason::anchor_not_found);
+}
+
+TEST_CASE("TweakStore::diff with no drift reports clean and has_drift=false",
+          "[inspect][tweak-store][drift][phase2]") {
+    TweakStore store;
+    store.apply_tweak("a", "layout.width", choc::value::createInt32(100));
+    store.apply_tweak("b", "layout.height", choc::value::createInt32(50));
+
+    auto report = store.diff(std::vector<std::string>{"a", "b", "c"});
+    REQUIRE(report.clean.size() == 2);
+    REQUIRE(report.orphaned.empty());
+    REQUIRE(report.drifted.empty());
+    REQUIRE_FALSE(report.has_drift());
+}
+
+TEST_CASE("TweakStore::diff detects property-level drift via DesignSnapshot",
+          "[inspect][tweak-store][drift][phase2]") {
+    TweakStore store;
+    store.apply_tweak("card", "paint.backgroundColor",
+                      choc::value::createString("#222"));
+    store.apply_tweak("card", "layout.padding",
+                      choc::value::createInt32(16));
+
+    // The design still has the `card` anchor, but the re-import removed
+    // the padding field — only backgroundColor remains exposed.
+    TweakStore::DesignSnapshot snap;
+    snap.anchors.insert("card");
+    snap.properties["card"] = {"paint.backgroundColor"};
+
+    auto report = store.diff(snap);
+    REQUIRE(report.clean.size() == 1);
+    REQUIRE(report.clean.front().property_path == "paint.backgroundColor");
+    REQUIRE(report.orphaned.empty());
+    REQUIRE(report.drifted.size() == 1);
+
+    const auto& d = report.drifted.front();
+    REQUIRE(d.anchor_id == "card");
+    REQUIRE(d.property_path == "layout.padding");
+    REQUIRE(d.reason == TweakStore::DriftReason::property_not_found);
+    REQUIRE(report.has_drift());
+}
+
+TEST_CASE("TweakStore::find_drifted lists orphans before drifted",
+          "[inspect][tweak-store][drift][phase2]") {
+    TweakStore store;
+    store.apply_tweak("survives", "layout.width",
+                      choc::value::createInt32(80));
+    store.apply_tweak("survives", "layout.height",
+                      choc::value::createInt32(40));
+    store.apply_tweak("removed", "paint.opacity",
+                      choc::value::createFloat32(0.5f));
+
+    TweakStore::DesignSnapshot snap;
+    snap.anchors.insert("survives");
+    snap.properties["survives"] = {"layout.width"};  // height drifted
+
+    auto drifted = store.find_drifted(snap);
+    REQUIRE(drifted.size() == 2);
+    // Orphan ("removed") comes first — anchor loss is the louder
+    // failure mode and the drawer leads with it.
+    REQUIRE(drifted.front().reason ==
+            TweakStore::DriftReason::anchor_not_found);
+    REQUIRE(drifted.front().anchor_id == "removed");
+    REQUIRE(drifted.back().reason ==
+            TweakStore::DriftReason::property_not_found);
+    REQUIRE(drifted.back().anchor_id == "survives");
+    REQUIRE(drifted.back().property_path == "layout.height");
+}
+
+TEST_CASE("TweakStore::find_drifted is empty when nothing drifts",
+          "[inspect][tweak-store][drift][phase2]") {
+    TweakStore store;
+    store.apply_tweak("x", "layout.gap", choc::value::createInt32(4));
+    auto drifted = store.find_drifted(std::vector<std::string>{"x"});
+    REQUIRE(drifted.empty());
+}
+
+TEST_CASE("TweakStore::find_drifted on an empty store returns nothing",
+          "[inspect][tweak-store][drift][phase2]") {
+    TweakStore store;
+    auto drifted = store.find_drifted(std::vector<std::string>{"anything"});
+    REQUIRE(drifted.empty());
+}
+
+TEST_CASE("TweakStore::drift_reason_str maps every enum value",
+          "[inspect][tweak-store][drift][phase2]") {
+    REQUIRE(std::string(TweakStore::drift_reason_str(
+                TweakStore::DriftReason::anchor_not_found)) ==
+            "anchor-not-found");
+    REQUIRE(std::string(TweakStore::drift_reason_str(
+                TweakStore::DriftReason::property_not_found)) ==
+            "property-not-found");
+}
+
+TEST_CASE("TweakStore::drift_report_to_json round-trips clean + drift sets",
+          "[inspect][tweak-store][drift][phase2]") {
+    TweakStore store;
+    store.apply_tweak("kept", "layout.width",
+                      choc::value::createInt32(120));
+    store.apply_tweak("dropped", "paint.color",
+                      choc::value::createString("#abc"), "manual");
+
+    auto report = store.diff(std::vector<std::string>{"kept"});
+    auto json = TweakStore::drift_report_to_json(report);
+
+    auto parsed = choc::json::parse(json);
+    REQUIRE(parsed.isObject());
+    REQUIRE(parsed["summary"]["total"].getInt64() == 2);
+    REQUIRE(parsed["summary"]["clean"].getInt64() == 1);
+    REQUIRE(parsed["summary"]["orphaned"].getInt64() == 1);
+    REQUIRE(parsed["summary"]["drifted"].getInt64() == 0);
+
+    REQUIRE(parsed["clean"].isArray());
+    REQUIRE(parsed["clean"].size() == 1);
+    REQUIRE(parsed["clean"][0]["anchorId"].getString() == "kept");
+
+    REQUIRE(parsed["orphaned"].isArray());
+    REQUIRE(parsed["orphaned"].size() == 1);
+    auto orphan = parsed["orphaned"][0];
+    REQUIRE(orphan["anchorId"].getString() == "dropped");
+    REQUIRE(orphan["propertyPath"].getString() == "paint.color");
+    REQUIRE(orphan["reason"].getString() == "anchor-not-found");
+    REQUIRE(orphan["source"].getString() == "manual");
+}
+
+TEST_CASE("TweakStore::diff ignores bypass overlay — bypassed tweaks still drift",
+          "[inspect][tweak-store][drift][phase2]") {
+    TweakStore store;
+    store.apply_tweak("ghost", "layout.width",
+                      choc::value::createInt32(64));
+    // Bypassing a tweak must NOT hide its drift — the user still wants
+    // to know the anchor is gone.
+    store.set_bypass("ghost", true);
+
+    auto report = store.diff(std::vector<std::string>{"someone-else"});
+    REQUIRE(report.orphaned.size() == 1);
+    REQUIRE(report.orphaned.front().anchor_id == "ghost");
+}

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(pulp-cli
     cmd_host.cpp
     cmd_pr.cpp
     cmd_inspect.cpp
+    cmd_tweaks.cpp
     design_binding.cpp
     create_targets.cpp
     package_registry.cpp

--- a/tools/cli/cli_common.hpp
+++ b/tools/cli/cli_common.hpp
@@ -333,3 +333,4 @@ int cmd_config(const std::vector<std::string>& args);
 int cmd_coverage(const std::vector<std::string>& args);
 int cmd_macos(const std::vector<std::string>& args);
 int cmd_overflow(const std::vector<std::string>& args);
+int cmd_tweaks(const std::vector<std::string>& args);

--- a/tools/cli/cmd_tweaks.cpp
+++ b/tools/cli/cmd_tweaks.cpp
@@ -1,0 +1,263 @@
+// cmd_tweaks.cpp — `pulp tweaks diff` subcommand (Inspector Phase 2).
+//
+// Compares the inspector tweak sidecar (pulp-tweaks.json) against a
+// design snapshot and reports which stored tweaks still apply cleanly,
+// which drifted (anchor survives but the property is gone), and which
+// are orphaned (the anchor itself is gone). This is the CLI mirror of
+// the inspector overlay's drift drawer — same TweakStore::diff() logic
+// underneath, so the two surfaces never disagree.
+// Spec: planning/2026-05-18-inspector-direct-manipulation-roadmap.md
+//       (Phase 2 — Drift UI + CLI).
+//
+// The design snapshot is supplied via `--design <file>`, a small JSON
+// "anchors manifest" in one of three accepted shapes:
+//
+//   1. A flat array of anchor strings:
+//        ["anchor-a", "anchor-b", ...]
+//   2. An object with an `anchors` array (anchor-only matching):
+//        { "anchors": ["anchor-a", "anchor-b"] }
+//   3. An object whose `anchors` is a map of anchor → property paths
+//      (enables property-level drift detection):
+//        { "anchors": { "anchor-a": ["paint.color", "layout.padding"] } }
+//
+// When `--design` is omitted the design snapshot is empty, so every
+// stored tweak is reported as orphaned — useful as a "what tweaks do I
+// have, and would any survive a from-scratch reimport" sanity check.
+
+#include "cli_common.hpp"
+
+#include <pulp/inspect/tweak_store.hpp>
+
+#include <choc/text/choc_JSON.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using pulp::inspect::TweakStore;
+
+void print_tweaks_usage() {
+    std::cout << "pulp tweaks — inspect the pulp-tweaks.json sidecar\n\n";
+    std::cout << "Usage: pulp tweaks <subcommand> [options]\n\n";
+    std::cout << "Subcommands:\n";
+    std::cout << "  diff   Compare stored tweaks against a design snapshot\n";
+    std::cout << "         and report clean / drifted / orphaned tweaks.\n\n";
+    std::cout << "`pulp tweaks diff` options:\n";
+    std::cout << "  --tweaks FILE   Path to pulp-tweaks.json\n";
+    std::cout << "                  (default: auto-resolved project sidecar)\n";
+    std::cout << "  --design FILE   Anchors manifest JSON to diff against\n";
+    std::cout << "                  (default: empty — every tweak orphaned)\n";
+    std::cout << "  --json          Emit the report as JSON instead of text\n";
+    std::cout << "\nExit code is 0 when no drift, 1 when drift is found,\n";
+    std::cout << "2 on a usage / file error.\n";
+}
+
+bool read_file_to_string(const std::string& path, std::string& out) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return false;
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    out = ss.str();
+    return true;
+}
+
+// Parse a `--design` anchors manifest into a DesignSnapshot. Returns
+// false (with `err` set) on a malformed file. An empty `path` yields an
+// empty snapshot — a valid "design has nothing" state.
+bool load_design_snapshot(const std::string& path,
+                          TweakStore::DesignSnapshot& snap,
+                          std::string& err) {
+    if (path.empty()) return true;  // empty snapshot is valid
+
+    std::string content;
+    if (!read_file_to_string(path, content)) {
+        err = "could not read design file: " + path;
+        return false;
+    }
+
+    choc::value::Value parsed;
+    try {
+        parsed = choc::json::parse(content);
+    } catch (const std::exception& e) {
+        err = std::string("design file is not valid JSON: ") + e.what();
+        return false;
+    } catch (...) {
+        err = "design file is not valid JSON";
+        return false;
+    }
+
+    // Accept either the bare array form or the {"anchors": ...} wrapper.
+    choc::value::Value anchors;
+    if (parsed.isArray()) {
+        anchors = parsed;
+    } else if (parsed.isObject() && parsed.hasObjectMember("anchors")) {
+        anchors = parsed["anchors"];
+    } else {
+        err = "design file must be an anchor array or an object with "
+              "an `anchors` member";
+        return false;
+    }
+
+    if (anchors.isArray()) {
+        // Flat anchor list — anchor-only matching.
+        for (uint32_t i = 0; i < anchors.size(); ++i) {
+            if (anchors[i].isString())
+                snap.anchors.insert(std::string(anchors[i].getString()));
+        }
+    } else if (anchors.isObject()) {
+        // Map of anchor → property-path array. Enables property-level
+        // drift detection.
+        for (uint32_t i = 0; i < anchors.size(); ++i) {
+            auto member = anchors.getObjectMemberAt(i);
+            std::string anchor(member.name);
+            snap.anchors.insert(anchor);
+            auto& props = snap.properties[anchor];
+            if (member.value.isArray()) {
+                for (uint32_t j = 0; j < member.value.size(); ++j) {
+                    if (member.value[j].isString())
+                        props.insert(
+                            std::string(member.value[j].getString()));
+                }
+            }
+        }
+    } else {
+        err = "`anchors` must be an array or an object";
+        return false;
+    }
+    return true;
+}
+
+// Render a single tweak's stored value compactly for human output.
+std::string value_preview(const choc::value::Value& v) {
+    if (v.isString()) return std::string(v.getString());
+    try {
+        return choc::json::toString(v);
+    } catch (...) {
+        return "?";
+    }
+}
+
+int run_tweaks_diff(const std::vector<std::string>& args) {
+    std::string tweaks_path;
+    std::string design_path;
+    bool as_json = false;
+
+    for (size_t i = 0; i < args.size(); ++i) {
+        const auto& a = args[i];
+        if (a == "--json") {
+            as_json = true;
+        } else if (a == "--tweaks") {
+            if (i + 1 >= args.size()) {
+                std::cerr << "Error: --tweaks requires a value\n";
+                return 2;
+            }
+            tweaks_path = args[++i];
+        } else if (a == "--design") {
+            if (i + 1 >= args.size()) {
+                std::cerr << "Error: --design requires a value\n";
+                return 2;
+            }
+            design_path = args[++i];
+        } else if (a == "--help" || a == "-h") {
+            print_tweaks_usage();
+            return 0;
+        } else {
+            std::cerr << "Error: unknown `tweaks diff` argument: " << a << "\n";
+            std::cerr << "Run `pulp tweaks --help` for usage.\n";
+            return 2;
+        }
+    }
+
+    // Load the tweak sidecar. An absent file is a usage error — there
+    // is nothing to diff.
+    TweakStore store;
+    auto load = store.load_from_disk(tweaks_path);
+    if (!load.ok) {
+        std::cerr << "Error: " << load.error << "\n";
+        if (tweaks_path.empty()) {
+            std::cerr << "       (looked for the project sidecar at "
+                      << load.path << ")\n";
+            std::cerr << "       Pass --tweaks FILE to point at an "
+                         "explicit pulp-tweaks.json.\n";
+        }
+        return 2;
+    }
+
+    // Build the design snapshot from --design (empty if omitted).
+    TweakStore::DesignSnapshot snap;
+    std::string design_err;
+    if (!load_design_snapshot(design_path, snap, design_err)) {
+        std::cerr << "Error: " << design_err << "\n";
+        return 2;
+    }
+
+    auto report = store.diff(snap);
+
+    if (as_json) {
+        std::cout << TweakStore::drift_report_to_json(report) << "\n";
+        return report.has_drift() ? 1 : 0;
+    }
+
+    // ── Human-readable output ──────────────────────────────────────
+    std::cout << "Tweaks: " << load.path << "\n";
+    if (design_path.empty()) {
+        std::cout << "Design: (none — every tweak treated as orphaned)\n";
+    } else {
+        std::cout << "Design: " << design_path << " ("
+                  << snap.anchors.size() << " anchors)\n";
+    }
+    std::cout << "\n";
+    std::cout << "  clean    " << report.clean.size() << "\n";
+    std::cout << "  drifted  " << report.drifted.size() << "\n";
+    std::cout << "  orphaned " << report.orphaned.size() << "\n";
+    std::cout << "  ───────────\n";
+    std::cout << "  total    " << report.total() << "\n\n";
+
+    auto print_drift_rows =
+        [](const char* heading,
+           const std::vector<TweakStore::DriftedTweak>& list) {
+            if (list.empty()) return;
+            std::cout << heading << ":\n";
+            for (const auto& d : list) {
+                std::cout << "  " << d.anchor_id << "  " << d.property_path
+                          << " = " << value_preview(d.value) << "  ["
+                          << TweakStore::drift_reason_str(d.reason) << "]\n";
+            }
+            std::cout << "\n";
+        };
+    print_drift_rows("Orphaned tweaks", report.orphaned);
+    print_drift_rows("Drifted tweaks", report.drifted);
+
+    if (!report.has_drift()) {
+        std::cout << "No drift — every stored tweak still maps cleanly.\n";
+        return 0;
+    }
+    std::cout << report.orphaned.size() + report.drifted.size()
+              << " tweak(s) no longer apply. Open the inspector drift "
+                 "drawer to resolve them.\n";
+    return 1;
+}
+
+}  // namespace
+
+int cmd_tweaks(const std::vector<std::string>& args) {
+    if (args.empty()) {
+        print_tweaks_usage();
+        return 0;
+    }
+    const std::string& sub = args[0];
+    if (sub == "--help" || sub == "-h" || sub == "help") {
+        print_tweaks_usage();
+        return 0;
+    }
+    if (sub == "diff") {
+        return run_tweaks_diff({args.begin() + 1, args.end()});
+    }
+    std::cerr << "Error: unknown `tweaks` subcommand: " << sub << "\n";
+    std::cerr << "Run `pulp tweaks --help` for usage.\n";
+    return 2;
+}

--- a/tools/cli/cmd_tweaks.cpp
+++ b/tools/cli/cmd_tweaks.cpp
@@ -105,8 +105,11 @@ bool load_design_snapshot(const std::string& path,
     if (anchors.isArray()) {
         // Flat anchor list — anchor-only matching.
         for (uint32_t i = 0; i < anchors.size(); ++i) {
-            if (anchors[i].isString())
-                snap.anchors.insert(std::string(anchors[i].getString()));
+            if (!anchors[i].isString()) {
+                err = "`anchors` array entries must be strings";
+                return false;
+            }
+            snap.anchors.insert(std::string(anchors[i].getString()));
         }
     } else if (anchors.isObject()) {
         // Map of anchor → property-path array. Enables property-level
@@ -115,13 +118,17 @@ bool load_design_snapshot(const std::string& path,
             auto member = anchors.getObjectMemberAt(i);
             std::string anchor(member.name);
             snap.anchors.insert(anchor);
+            if (!member.value.isArray()) {
+                err = "`anchors` object values must be property-path arrays";
+                return false;
+            }
             auto& props = snap.properties[anchor];
-            if (member.value.isArray()) {
-                for (uint32_t j = 0; j < member.value.size(); ++j) {
-                    if (member.value[j].isString())
-                        props.insert(
-                            std::string(member.value[j].getString()));
+            for (uint32_t j = 0; j < member.value.size(); ++j) {
+                if (!member.value[j].isString()) {
+                    err = "`anchors` property-path entries must be strings";
+                    return false;
                 }
+                props.insert(std::string(member.value[j].getString()));
             }
         }
     } else {

--- a/tools/cli/pulp_cli.cpp
+++ b/tools/cli/pulp_cli.cpp
@@ -64,6 +64,7 @@ static const Command commands[] = {
     {"coverage", "Local coverage tooling (diff-cover gate mirror)", cmd_coverage},
     {"macos",    "Per-PR macOS-runner retargeting (local/namespace/github-hosted)", cmd_macos},
     {"overflow", "Configure macOS-runner overflow routing (status/enable/disable/threshold)", cmd_overflow},
+    {"tweaks",   "Inspect the pulp-tweaks.json sidecar (diff against a design)", cmd_tweaks},
 };
 
 static constexpr int command_count = sizeof(commands) / sizeof(commands[0]);

--- a/tools/scripts/cli_mcp_parity_baseline.json
+++ b/tools/scripts/cli_mcp_parity_baseline.json
@@ -33,6 +33,7 @@
     "sdk": "SDK admin; not user-flow",
     "ship": "Multi-step interactive flow; agents call `shipyard pr` instead",
     "tool": "Tool registry plumbing; agents call via Bash",
+    "tweaks": "Local pulp-tweaks.json drift diagnostic; agents shell out directly (mirrors the inspector drift drawer)",
     "upgrade": "Bin-swap flow; agents call directly",
     "version": "Trivial via Bash (cat CMakeLists.txt | grep VERSION)"
   },


### PR DESCRIPTION
Inspector tweaks persist direct-manipulation edits to pulp-tweaks.json
keyed by stable_anchor_id (Phase 1). After a design re-import an anchor
may no longer exist in the live view tree, so the tweak silently stops
applying. Phase 2 makes that drift visible before it surprises the user.

TweakStore drift API:
  - DriftReport / DriftedTweak / DesignSnapshot types + DriftReason enum
  - diff() classifies every stored tweak against a design snapshot as
    clean / drifted (anchor survives, property gone) / orphaned (anchor
    gone); find_drifted() returns just the drift subset, orphans first
  - drift_report_to_json() for the CLI + protocol layers
  - bypass overlay is intentionally ignored — a bypassed tweak can still
    be orphaned and the user should see it

Inspector drift drawer:
  - collapsible warning panel in the overlay listing orphaned/drifted
    tweaks (anchor, property path, stored value, reason tag)
  - auto-expands the first time drift is detected so a stale tweak is
    never silent; header chevron toggles collapse
  - refresh_drift() walks the live tree's anchor set; re-checked each
    time the inspector opens (design may have changed while dismissed)

pulp tweaks diff CLI:
  - compares pulp-tweaks.json against a --design anchors manifest
    (flat array, {anchors:[...]}, or {anchors:{a:[paths]}} for
    property-level drift); human + --json output
  - exit 0 (no drift) / 1 (drift found) / 2 (usage/file error)
  - baselined cli_only in the CLI-MCP parity allow-list

Tests: 11 TweakStore drift cases, 6 InspectorOverlay drawer cases,
10 pulp tweaks diff shell-out cases. All 130 TweakStore/Inspector/
tweaks tests pass.

Spec: planning/2026-05-18-inspector-direct-manipulation-roadmap.md
Phase 2 — Drift UI + CLI.

Skill-Update: skip skill=cli-maintenance reason="new tweaks command follows the existing add-a-command checklist verbatim; teaches no new gotcha"
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>