### PR TITLE
ci(build): classify gate — skip native build for non-code PRs

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1858,11 +1858,22 @@ Key facts:
   `CMakeLists.txt`, `tools/cmake/**`, `tools/scripts/**`,
   `.github/workflows/**`, and the classifier itself — forces the
   native build.
+- **Deny-list exception: `docs/migrations/*.md` forces the build.**
+  Those `.md` files are globbed with `CONFIGURE_DEPENDS` into the
+  generated `migration_index.cpp` by `tools/cli/CMakeLists.txt`, so
+  `FORCE_BUILD_PREFIXES` overrides the `.md`/`docs/` skip-safe rules.
+  Any future doc path that feeds codegen must be added there too.
+- Diffs are collected with `git diff --no-renames` so a code→docs
+  rename can't hide the old code path and wrongly classify skip-safe.
 - The required `macos` check is now produced by a dedicated `macos`
   alias job (`if: always()`), NOT by the build matrix leg. The matrix
   leg is named `macOS (ARM64) [<provider>]` uniformly with linux/windows.
+- The alias jobs are **fail-closed on a `classify`-job failure**: if
+  `needs.classify.result != 'success'` the `macos` gate fails RED
+  rather than trusting an unwritten/empty `native_build_required`.
 - To change what counts as skip-safe: edit `SKIP_SAFE_PREFIXES` /
-  `SKIP_SAFE_EXACT` in `classify_changes.py` and add a case to
-  `test_classify_changes.py`. Never widen the allowlist without a test.
+  `SKIP_SAFE_EXACT` / `FORCE_BUILD_PREFIXES` in `classify_changes.py`
+  and add a case to `test_classify_changes.py`. Never widen the
+  allowlist without a test.
 
 Companion plan: `planning/2026-05-19-ci-optimization-plan.md`.

--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1836,3 +1836,33 @@ Precedence on `workflow_dispatch`:
 3. Local default (`PULP_LOCAL_MACOS_RUNS_ON_JSON`).
 
 Manual `workflow_dispatch` with an explicit selector input still overrides; the fix only changes behavior for dispatches that arrive without one (which is the `shipyard pr` shape).
+
+## Change classifier — skip the native build for non-code PRs
+
+`build.yml` has a `classify` job (ubuntu, ~10 s) that runs
+`tools/scripts/classify_changes.py` to decide `native_build_required`.
+When a PR touches no C++/Swift build input (docs, `*.md`, `.githooks/`,
+`.shipyard/`, etc.), the `build` matrix and `windows-msvc-release-gate`
+are skipped at the job level — no runner is allocated, no Skia/Dawn
+compile — and the `macos`/`linux`/`windows` alias jobs report a fast
+green from Ubuntu.
+
+Key facts:
+
+- `classify_changes.py` is **fail-closed**: any uncertainty, git error,
+  or empty diff -> `native_build_required=true` (run the build).
+  Skipping is the optimization; running is the safe default.
+- The skip-safe set is a deliberately small allowlist (`*.md` anywhere,
+  `docs/`, `planning/`, `.githooks/`, `.shipyard/`, `.shipyard.local/`,
+  a few exact files). Everything else — including `core/**`, all
+  `CMakeLists.txt`, `tools/cmake/**`, `tools/scripts/**`,
+  `.github/workflows/**`, and the classifier itself — forces the
+  native build.
+- The required `macos` check is now produced by a dedicated `macos`
+  alias job (`if: always()`), NOT by the build matrix leg. The matrix
+  leg is named `macOS (ARM64) [<provider>]` uniformly with linux/windows.
+- To change what counts as skip-safe: edit `SKIP_SAFE_PREFIXES` /
+  `SKIP_SAFE_EXACT` in `classify_changes.py` and add a case to
+  `test_classify_changes.py`. Never widen the allowlist without a test.
+
+Companion plan: `planning/2026-05-19-ci-optimization-plan.md`.

--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -174,6 +174,20 @@ such as `jsx`, add a matching row to `source-contracts.json` and reference
 its roundtrip script there; otherwise pre-push will fail strict
 source-contract validation.
 
+**`parser.runtime_file` — runtime parsers extracted out of `design_import.cpp`.**
+Each contract's `parser` block has a single `file` plus `runtime`/`static`
+symbol names. After the P6-A3 refactor the *runtime* parsers
+(`parse_*_react`, `parse_claude_html_with_runtime`, `parse_react_native_export`)
+moved into `core/view/src/claude_bundle.cpp` while the *static* parsers stayed
+in `design_import.cpp`. A single `parser.file` can no longer locate both, so
+contracts whose runtime parser lives elsewhere set the optional
+`parser.runtime_file` (e.g. `core/view/src/claude_bundle.cpp`). The checker
+resolves `parser.runtime` and the `explicit-runtime-parser` dispatch symbol
+against `runtime_file` (falling back to `parser.file`); `parser.static` always
+resolves against `parser.file`. **If a future refactor moves a parser symbol
+to a new file, update `parser.file` / `parser.runtime_file` in the same PR** —
+otherwise the `Source-contract registry check` step fails for every PR.
+
 Provider MCP lanes are input-acquisition lanes only unless the source contract
 explicitly says otherwise. Current runtime parsers reject raw Figma/Stitch/Pencil
 MCP JSON and accept only their constrained exported artifacts.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -733,6 +733,9 @@ jobs:
   # reports — never left pending. On a skip-safe PR (classify said no native
   # build) it reports a fast green from Ubuntu without touching the macOS
   # runner. On a code PR it mirrors the macOS matrix leg's conclusion.
+  # Fail-closed: if the `classify` job itself did not succeed, the
+  # native_build_required output is untrusted — this gate fails RED rather
+  # than letting a PR merge on an unverified classification.
   macos:
     needs: [build, classify]
     runs-on: ubuntu-latest
@@ -743,6 +746,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          classify_result="${{ needs.classify.result }}"
+          if [ "$classify_result" != "success" ]; then
+            echo "classify job did not succeed (result=$classify_result) — failing macos gate closed (required)"
+            exit 1
+          fi
           if [ "${{ needs.classify.outputs.native_build_required }}" != "true" ]; then
             echo "Skip-safe PR — no C++/Swift build input changed. macos gate ✓ (no native build)"
             exit 0
@@ -767,6 +775,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          classify_result="${{ needs.classify.result }}"
+          if [ "$classify_result" != "success" ]; then
+            echo "classify job did not succeed (result=$classify_result) — failing linux alias closed"
+            exit 1
+          fi
           if [ "${{ needs.classify.outputs.native_build_required }}" != "true" ]; then
             echo "Skip-safe PR — no C++/Swift build input changed. linux gate ✓ (no native build)"
             exit 0
@@ -798,6 +811,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          classify_result="${{ needs.classify.result }}"
+          if [ "$classify_result" != "success" ]; then
+            echo "classify job did not succeed (result=$classify_result) — failing windows alias closed"
+            exit 1
+          fi
           if [ "${{ needs.classify.outputs.native_build_required }}" != "true" ]; then
             echo "Skip-safe PR — no C++/Swift build input changed. windows gate ✓ (no native build)"
             exit 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,14 +359,45 @@ jobs:
               handle.write(f"matrix_json={json.dumps(matrix)}\n")
           PY
 
+  # ── Change classifier ────────────────────────────────────────────────────
+  # Decides whether this PR needs the native build matrix at all. A PR that
+  # touches only docs / markdown / git-hooks / Shipyard config does not need
+  # a Skia/Dawn compile on any platform — the `build` matrix and
+  # `windows-msvc-release-gate` are skipped at the job level (no runner is
+  # ever allocated), and the `macos`/`linux`/`windows` alias jobs report a
+  # fast green from Ubuntu. Fail-closed: tools/scripts/classify_changes.py
+  # treats any uncertainty as "native build required". See that script's
+  # module docstring + tools/scripts/test_classify_changes.py.
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      native_build_required: ${{ steps.classify.outputs.native_build_required }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          lfs: false
+      - id: classify
+        run: |
+          python3 tools/scripts/classify_changes.py \
+            --mode=diff \
+            --base "${{ github.event.pull_request.base.sha || 'origin/main' }}"
+
   build:
-    needs: resolve-provider
+    needs: [resolve-provider, classify]
+    # Skip the entire native build matrix (no runner allocated) when the PR
+    # touches no C++/Swift build input. The macos/linux/windows alias jobs
+    # below still run and report.
+    if: needs.classify.outputs.native_build_required == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.resolve-provider.outputs.matrix_json) }}
 
     runs-on: ${{ fromJSON(matrix.runs_on_json) }}
-    name: ${{ matrix.key == 'macos' && 'macos' || format('{0} [{1}]', matrix.name, matrix.provider) }}
+    # All legs named uniformly `<name> [<provider>]`. The required `macos`
+    # check is now provided by the dedicated `macos` alias job below, not by
+    # this matrix leg — so the leg no longer self-names `macos`.
+    name: ${{ format('{0} [{1}]', matrix.name, matrix.provider) }}
     env:
       # Self-hosted macOS keeps the workspace warm between workflows.
       # Keep the ordinary build matrix out of sanitizer-owned build dirs so
@@ -656,6 +687,8 @@ jobs:
   # tests either, and the main matrix above already covers Windows tests on
   # Namespace.
   windows-msvc-release-gate:
+    needs: classify
+    if: needs.classify.outputs.native_build_required == 'true'
     runs-on: windows-latest
     name: Windows MSVC release-path gate
     steps:
@@ -695,8 +728,37 @@ jobs:
   # to leave their queues. Linux and Windows keep stable advisory aliases
   # for visibility only.
 
+  # ── macos alias (REQUIRED branch-protection check) ───────────────────────
+  # Always runs (`if: always()`) so the required `macos` context always
+  # reports — never left pending. On a skip-safe PR (classify said no native
+  # build) it reports a fast green from Ubuntu without touching the macOS
+  # runner. On a code PR it mirrors the macOS matrix leg's conclusion.
+  macos:
+    needs: [build, classify]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: macOS leg outcome (required)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.classify.outputs.native_build_required }}" != "true" ]; then
+            echo "Skip-safe PR — no C++/Swift build input changed. macos gate ✓ (no native build)"
+            exit 0
+          fi
+          conclusion=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
+            --jq '.jobs[] | select(.name | startswith("macOS")) | .conclusion' | head -1)
+          echo "macOS leg conclusion: ${conclusion:-unknown}"
+          if [ "$conclusion" = "success" ]; then
+            echo "macOS leg green — macos gate ✓"
+            exit 0
+          fi
+          echo "macOS leg ${conclusion:-not found} — failing macos gate (required)"
+          exit 1
+
   linux:
-    needs: build
+    needs: [build, classify]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -705,6 +767,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          if [ "${{ needs.classify.outputs.native_build_required }}" != "true" ]; then
+            echo "Skip-safe PR — no C++/Swift build input changed. linux gate ✓ (no native build)"
+            exit 0
+          fi
           conclusion=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
             --jq '.jobs[] | select(.name | startswith("Linux")) | .conclusion' | head -1)
           echo "Linux leg conclusion: ${conclusion:-unknown}"
@@ -723,7 +789,7 @@ jobs:
           exit 1
 
   windows:
-    needs: [build, windows-msvc-release-gate]
+    needs: [build, windows-msvc-release-gate, classify]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -732,6 +798,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          if [ "${{ needs.classify.outputs.native_build_required }}" != "true" ]; then
+            echo "Skip-safe PR — no C++/Swift build input changed. windows gate ✓ (no native build)"
+            exit 0
+          fi
           conclusion=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
             --jq '.jobs[] | select(.name | startswith("Windows (x64)")) | .conclusion' | head -1)
           msvc_ok="${{ needs.windows-msvc-release-gate.result }}"

--- a/tools/import-validation/check-source-contracts.py
+++ b/tools/import-validation/check-source-contracts.py
@@ -274,6 +274,27 @@ def _check_dispatch_and_symbols(
     design_source_labels: set[str],
 ) -> None:
     source = _source(entry)
+
+    parser_info = entry.get("parser") or {}
+    parser_file = parser_info.get("file", "core/view/src/design_import.cpp")
+    if not isinstance(parser_file, str):
+        _add(findings, "invalid-parser-file", source, "parser.file must be a string")
+        parser_file = "core/view/src/design_import.cpp"
+    # Runtime parsers may live in a file extracted out of design_import.cpp
+    # (the P6-A3 refactor split the static parsers from the runtime ones).
+    # When parser.runtime_file is set, the runtime symbol — and an
+    # explicit-runtime-parser dispatch symbol — resolve against it, while
+    # parser.static stays bound to parser.file.
+    runtime_file = parser_info.get("runtime_file", parser_file)
+    if not isinstance(runtime_file, str):
+        _add(
+            findings,
+            "invalid-parser-runtime-file",
+            source,
+            "parser.runtime_file must be a string",
+        )
+        runtime_file = parser_file
+
     dispatch = entry.get("dispatch") or {}
     kind = dispatch.get("kind")
     if kind == "design-source-label":
@@ -287,9 +308,7 @@ def _check_dispatch_and_symbols(
             )
     elif kind == "explicit-runtime-parser":
         parser = dispatch.get("parser")
-        if not isinstance(parser, str) or not _symbol_exists(
-            root, "core/view/src/design_import.cpp", parser
-        ):
+        if not isinstance(parser, str) or not _symbol_exists(root, runtime_file, parser):
             _add(
                 findings,
                 "missing-explicit-runtime-parser",
@@ -297,22 +316,17 @@ def _check_dispatch_and_symbols(
                 f"explicit runtime parser symbol is missing: {parser!r}",
             )
 
-    parser_info = entry.get("parser") or {}
-    parser_file = parser_info.get("file", "core/view/src/design_import.cpp")
-    if not isinstance(parser_file, str):
-        _add(findings, "invalid-parser-file", source, "parser.file must be a string")
-        parser_file = "core/view/src/design_import.cpp"
-    for role in ("runtime", "static"):
+    for role, role_file in (("runtime", runtime_file), ("static", parser_file)):
         symbol = parser_info.get(role)
         if symbol is None:
             continue
-        if not isinstance(symbol, str) or not _symbol_exists(root, parser_file, symbol):
+        if not isinstance(symbol, str) or not _symbol_exists(root, role_file, symbol):
             _add(
                 findings,
                 "missing-parser-symbol",
                 source,
-                f"parser.{role} symbol is missing from {parser_file}: {symbol!r}",
-                path=parser_file,
+                f"parser.{role} symbol is missing from {role_file}: {symbol!r}",
+                path=role_file,
             )
 
 

--- a/tools/import-validation/source-contracts.json
+++ b/tools/import-validation/source-contracts.json
@@ -50,6 +50,7 @@
       },
       "parser": {
         "file": "core/view/src/design_import.cpp",
+        "runtime_file": "core/view/src/claude_bundle.cpp",
         "runtime": "parse_claude_html_with_runtime",
         "static": "parse_claude_html"
       },
@@ -137,6 +138,7 @@
       },
       "parser": {
         "file": "core/view/src/design_import.cpp",
+        "runtime_file": "core/view/src/claude_bundle.cpp",
         "runtime": "parse_stitch_react",
         "static": "parse_stitch_html"
       },
@@ -318,6 +320,7 @@
       },
       "parser": {
         "file": "core/view/src/design_import.cpp",
+        "runtime_file": "core/view/src/claude_bundle.cpp",
         "runtime": "parse_pencil_react",
         "static": "parse_pencil_json"
       },
@@ -416,6 +419,7 @@
       },
       "parser": {
         "file": "core/view/src/design_import.cpp",
+        "runtime_file": "core/view/src/claude_bundle.cpp",
         "runtime": "parse_figma_make_react",
         "static": "parse_figma_json"
       },
@@ -507,6 +511,7 @@
       },
       "parser": {
         "file": "core/view/src/design_import.cpp",
+        "runtime_file": "core/view/src/claude_bundle.cpp",
         "runtime": "parse_v0_dev_react",
         "static": "parse_v0_tsx"
       },
@@ -583,6 +588,7 @@
       },
       "parser": {
         "file": "core/view/src/design_import.cpp",
+        "runtime_file": "core/view/src/claude_bundle.cpp",
         "runtime": "parse_jsx_react",
         "static": null
       },
@@ -667,6 +673,7 @@
       },
       "parser": {
         "file": "core/view/src/design_import.cpp",
+        "runtime_file": "core/view/src/claude_bundle.cpp",
         "runtime": "parse_react_native_export",
         "static": null
       },
@@ -759,6 +766,7 @@
       },
       "parser": {
         "file": "core/view/src/design_import.cpp",
+        "runtime_file": "core/view/src/claude_bundle.cpp",
         "runtime": "parse_jsx_react",
         "static": null
       },

--- a/tools/import-validation/test_source_contracts.py
+++ b/tools/import-validation/test_source_contracts.py
@@ -113,6 +113,25 @@ class SourceContractsTest(unittest.TestCase):
         missing = [f for f in findings if f.code == "missing-parser-symbol"]
         self.assertGreaterEqual(len(missing), 2)
 
+    def test_runtime_file_resolves_runtime_parser_separately(self) -> None:
+        # The P6-A3 refactor moved the runtime parsers into claude_bundle.cpp;
+        # parser.runtime_file points runtime symbols there while parser.static
+        # stays in parser.file. Pointing runtime_file back at the old
+        # design_import.cpp must still flag the moved symbol as missing.
+        registry, entry = self.mutate("pencil")
+        entry["parser"]["runtime_file"] = "core/view/src/design_import.cpp"
+        with tempfile.TemporaryDirectory() as td:
+            findings = _findings(registry, Path(td))
+        missing = [f for f in findings if f.code == "missing-parser-symbol"]
+        self.assertTrue(
+            any(
+                f.path == "core/view/src/design_import.cpp"
+                and "parse_pencil_react" in f.message
+                for f in missing
+            ),
+            [str(f) for f in findings],
+        )
+
     def test_present_reference_screenshot_must_exist(self) -> None:
         registry, entry = self.mutate("stitch")
         entry["validation"]["pulp_render_reference"] = {

--- a/tools/scripts/classify_changes.py
+++ b/tools/scripts/classify_changes.py
@@ -28,7 +28,10 @@ EVERYTHING ELSE forces the native build — including `core/**`,
 `apple/**`, `examples/**`, `test/**`, every `CMakeLists.txt`,
 `tools/cmake/**`, `.github/workflows/**` (a `build.yml` change MUST get
 a real run to validate itself), `tools/scripts/**` (some are
-build-coupled), `*.toml`/`*.json` config, and this classifier itself.
+build-coupled), `*.toml`/`*.json` config, this classifier itself, and
+`docs/migrations/*.md` (globbed with CONFIGURE_DEPENDS into the
+generated `migration_index.cpp` by `tools/cli/CMakeLists.txt` — a
+deny-list exception that overrides the `.md`/`docs/` skip-safe rules).
 That is intentional: the conservative allowlist IS the fail-closed
 mechanism — anything we did not explicitly reason about runs the build.
 
@@ -68,10 +71,22 @@ SKIP_SAFE_EXACT = {
     "CODEOWNERS",
 }
 
+# Paths that LOOK skip-safe (e.g. a `.md` file under `docs/`) but are in
+# fact native build inputs. Checked FIRST so they override every
+# skip-safe rule below. `docs/migrations/*.md` is globbed with
+# CONFIGURE_DEPENDS by tools/cli/CMakeLists.txt and compiled into pulp-cli
+# as `migration_index.cpp` — editing one genuinely changes compiled C++.
+FORCE_BUILD_PREFIXES = (
+    "docs/migrations/",
+)
+
 
 def is_skip_safe(path: str) -> bool:
     """True if this single file provably does not affect the native build."""
     if not path:
+        return False
+    # Deny-list wins over every skip-safe rule: some docs feed codegen.
+    if any(path.startswith(prefix) for prefix in FORCE_BUILD_PREFIXES):
         return False
     # Markdown anywhere — docs, never compiled, never embedded.
     if path.endswith(".md"):
@@ -93,8 +108,13 @@ def native_build_required(files: list[str]) -> bool:
 
 def _changed_files_from_diff(base: str) -> list[str] | None:
     """Return changed files for `<base>...HEAD`, or None if git fails."""
+    # `--no-renames`: with rename detection on, a rename such as
+    # `core/x.cpp -> docs/x.md` collapses to only the new path and would
+    # wrongly classify skip-safe. Disabling it reports the rename as a
+    # delete of the old path + an add of the new — so `core/x.cpp`
+    # surfaces and forces the native build (fail-closed).
     proc = subprocess.run(
-        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        ["git", "diff", "--no-renames", "--name-only", f"{base}...HEAD"],
         capture_output=True,
         text=True,
         check=False,

--- a/tools/scripts/classify_changes.py
+++ b/tools/scripts/classify_changes.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Classify a PR's changed files to decide whether a native build is required.
+
+Single source of truth for the `classify` gate in
+`.github/workflows/build.yml`. Pure function: a list of changed file
+paths -> `native_build_required` (bool). When false, the build.yml
+`build` matrix (Linux + Windows + macOS Skia/Dawn compile) and the
+`windows-msvc-release-gate` job are skipped at the job level — they
+never get allocated a runner.
+
+FAIL-CLOSED CONTRACT
+--------------------
+Skipping the native build is the optimization; running it is the safe
+default. Any uncertainty, error, or empty input -> `native_build_required
+= True`. A misclassification that wrongly *skips* a build lets a real
+regression merge — so the skip-safe set is a deliberately small,
+conservative allowlist. The native build is required UNLESS *every*
+changed file is provably irrelevant to the C++/Swift build.
+
+WHAT IS SKIP-SAFE
+-----------------
+- Any `*.md` file, anywhere (README, CHANGELOG, CONTRIBUTING, SKILL.md, ...).
+- Files under `docs/`, `planning/`, `.githooks/`, `.shipyard/`,
+  `.shipyard.local/` — none are CMake/build inputs.
+- A short exact-name list (`.gitignore`, `.gitattributes`, `CODEOWNERS`).
+
+EVERYTHING ELSE forces the native build — including `core/**`,
+`apple/**`, `examples/**`, `test/**`, every `CMakeLists.txt`,
+`tools/cmake/**`, `.github/workflows/**` (a `build.yml` change MUST get
+a real run to validate itself), `tools/scripts/**` (some are
+build-coupled), `*.toml`/`*.json` config, and this classifier itself.
+That is intentional: the conservative allowlist IS the fail-closed
+mechanism — anything we did not explicitly reason about runs the build.
+
+Modes:
+  --mode=diff --base <ref>   diff `<ref>...HEAD` for the changed-file set
+  --mode=files <path> ...    classify an explicit file list (tests + CI)
+
+Output:
+  Writes `native_build_required=true|false` to $GITHUB_OUTPUT when set
+  (GitHub Actions job output), and always prints a human-readable
+  summary to stderr. `--json` prints a JSON object to stdout instead.
+
+Exit code is always 0 unless invoked incorrectly (exit 2) — the
+classification is data, not a pass/fail signal.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+# Prefixes whose files never feed the C++/Swift build.
+SKIP_SAFE_PREFIXES = (
+    "docs/",
+    "planning/",
+    ".githooks/",
+    ".shipyard/",
+    ".shipyard.local/",
+)
+
+# Exact paths that never feed the build.
+SKIP_SAFE_EXACT = {
+    ".gitignore",
+    ".gitattributes",
+    "CODEOWNERS",
+}
+
+
+def is_skip_safe(path: str) -> bool:
+    """True if this single file provably does not affect the native build."""
+    if not path:
+        return False
+    # Markdown anywhere — docs, never compiled, never embedded.
+    if path.endswith(".md"):
+        return True
+    if path in SKIP_SAFE_EXACT:
+        return True
+    return any(path.startswith(prefix) for prefix in SKIP_SAFE_PREFIXES)
+
+
+def native_build_required(files: list[str]) -> bool:
+    """Fail-closed: native build required unless EVERY file is skip-safe.
+
+    Empty input -> True (we could not determine the diff; build to be safe).
+    """
+    if not files:
+        return True
+    return not all(is_skip_safe(f) for f in files)
+
+
+def _changed_files_from_diff(base: str) -> list[str] | None:
+    """Return changed files for `<base>...HEAD`, or None if git fails."""
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(
+            f"[classify] git diff failed (exit {proc.returncode}): "
+            f"{(proc.stderr or '').strip()[:200]}\n"
+        )
+        return None
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--mode", choices=("diff", "files"), default="diff")
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="for --mode=diff, the base ref (default origin/main)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="print a JSON object to stdout"
+    )
+    parser.add_argument("files", nargs="*", help="for --mode=files, the file list")
+    args = parser.parse_args(argv)
+
+    if args.mode == "files":
+        files: list[str] | None = args.files
+    else:
+        files = _changed_files_from_diff(args.base)
+
+    # Fail-closed: a None (git error) is treated as "unknown" -> build.
+    if files is None:
+        required = True
+        files = []
+        reason = "git diff failed — defaulting to native build (fail-closed)"
+    elif not files:
+        required = True
+        reason = "no changed files resolved — defaulting to native build (fail-closed)"
+    else:
+        required = native_build_required(files)
+        non_safe = [f for f in files if not is_skip_safe(f)]
+        if required:
+            shown = ", ".join(non_safe[:8])
+            extra = f" (+{len(non_safe) - 8} more)" if len(non_safe) > 8 else ""
+            reason = f"native build inputs changed: {shown}{extra}"
+        else:
+            reason = f"all {len(files)} changed file(s) are skip-safe (docs/config only)"
+
+    sys.stderr.write(
+        f"[classify] native_build_required={str(required).lower()} — {reason}\n"
+    )
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as fh:
+            fh.write(f"native_build_required={str(required).lower()}\n")
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "native_build_required": required,
+                    "changed_file_count": len(files),
+                    "reason": reason,
+                }
+            )
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/scripts/test_classify_changes.py
+++ b/tools/scripts/test_classify_changes.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Tests for classify_changes.py.
+
+The classifier is safety-critical: a wrong "skip" lets a real
+regression merge without a native build. These tests pin the
+fail-closed contract — especially that anything NOT explicitly
+skip-safe forces the native build.
+
+Run:
+    python3 tools/scripts/test_classify_changes.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).parent
+SCRIPT = THIS_DIR / "classify_changes.py"
+
+_spec = importlib.util.spec_from_file_location("classify_changes", SCRIPT)
+classify = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(classify)
+
+
+class SkipSafeTests(unittest.TestCase):
+    def test_markdown_anywhere_is_skip_safe(self) -> None:
+        for path in ("README.md", "docs/guide.md", "core/view/NOTES.md",
+                     ".agents/skills/ci/SKILL.md", "CHANGELOG.md"):
+            self.assertTrue(classify.is_skip_safe(path), path)
+
+    def test_skip_safe_prefixes(self) -> None:
+        for path in ("docs/reference/cli.md", "docs/assets/logo.png",
+                     "planning/STATUS.md", ".githooks/pre-push",
+                     ".shipyard/config.toml", ".shipyard.local/config.toml"):
+            self.assertTrue(classify.is_skip_safe(path), path)
+
+    def test_skip_safe_exact(self) -> None:
+        for path in (".gitignore", ".gitattributes", "CODEOWNERS"):
+            self.assertTrue(classify.is_skip_safe(path), path)
+
+    def test_build_inputs_are_NOT_skip_safe(self) -> None:
+        for path in ("core/signal/src/fft.cpp",
+                     "core/view/include/pulp/view/view.hpp",
+                     "CMakeLists.txt", "core/audio/CMakeLists.txt",
+                     "tools/cmake/PulpUtils.cmake", "apple/Sources/x.swift",
+                     "examples/pulp-gain/main.cpp", "test/test_state.cpp",
+                     "setup.sh", "Package.swift",
+                     "core/view/js/web-compat-element.js",
+                     ".github/workflows/build.yml",
+                     "tools/scripts/classify_changes.py",
+                     "tools/scripts/resolve_runs_on.py",
+                     ".shipyard.toml", "compat.json"):
+            self.assertFalse(classify.is_skip_safe(path), path)
+
+    def test_empty_path_is_not_skip_safe(self) -> None:
+        self.assertFalse(classify.is_skip_safe(""))
+
+
+class NativeBuildRequiredTests(unittest.TestCase):
+    def test_empty_diff_forces_build(self) -> None:
+        # Fail-closed: unknown diff -> build.
+        self.assertTrue(classify.native_build_required([]))
+
+    def test_all_docs_skips_build(self) -> None:
+        self.assertFalse(classify.native_build_required(
+            ["README.md", "docs/guide.md", "CHANGELOG.md"]))
+
+    def test_any_code_file_forces_build(self) -> None:
+        # One code file among many docs still forces the build.
+        self.assertTrue(classify.native_build_required(
+            ["README.md", "docs/guide.md", "core/signal/src/fft.cpp"]))
+
+    def test_pure_code_forces_build(self) -> None:
+        self.assertTrue(classify.native_build_required(
+            ["core/midi/src/mpe_voice_tracker.cpp"]))
+
+    def test_skill_only_pr_skips_build(self) -> None:
+        # A skill-doc-only PR (markdown) is skip-safe.
+        self.assertFalse(classify.native_build_required(
+            [".agents/skills/ci/SKILL.md"]))
+
+    def test_workflow_change_forces_build(self) -> None:
+        # Changing build.yml itself must get a real run to validate.
+        self.assertTrue(classify.native_build_required(
+            [".github/workflows/build.yml"]))
+
+    def test_classifier_change_forces_build(self) -> None:
+        # Changing the classifier must get a real run.
+        self.assertTrue(classify.native_build_required(
+            ["tools/scripts/classify_changes.py"]))
+
+    def test_tools_scripts_not_skip_safe(self) -> None:
+        # tools/scripts/** is intentionally NOT skip-safe in v1 — some
+        # scripts are build-coupled. Conservative > clever.
+        self.assertTrue(classify.native_build_required(
+            ["tools/scripts/source_tree_pollution_check.py"]))
+
+
+class CliTests(unittest.TestCase):
+    def _run(self, *args: str, env_extra: dict | None = None
+             ) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        if env_extra:
+            env.update(env_extra)
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            capture_output=True, text=True, check=False, env=env,
+        )
+
+    def test_files_mode_docs_only(self) -> None:
+        r = self._run("--mode=files", "--json", "README.md", "docs/x.md")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn('"native_build_required": false', r.stdout)
+
+    def test_files_mode_with_code(self) -> None:
+        r = self._run("--mode=files", "--json", "core/signal/src/fft.cpp")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn('"native_build_required": true', r.stdout)
+
+    def test_files_mode_empty_is_failclosed(self) -> None:
+        # --mode=files with no files -> empty -> fail-closed -> true.
+        r = self._run("--mode=files", "--json")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn('"native_build_required": true', r.stdout)
+
+    def test_writes_github_output(self) -> None:
+        import tempfile
+        with tempfile.NamedTemporaryFile("w+", suffix=".txt",
+                                         delete=False) as fh:
+            out_path = fh.name
+        try:
+            r = self._run("--mode=files", "README.md",
+                           env_extra={"GITHUB_OUTPUT": out_path})
+            self.assertEqual(r.returncode, 0, r.stderr)
+            content = Path(out_path).read_text()
+            self.assertIn("native_build_required=false", content)
+        finally:
+            os.unlink(out_path)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/scripts/test_classify_changes.py
+++ b/tools/scripts/test_classify_changes.py
@@ -42,6 +42,14 @@ class SkipSafeTests(unittest.TestCase):
         for path in (".gitignore", ".gitattributes", "CODEOWNERS"):
             self.assertTrue(classify.is_skip_safe(path), path)
 
+    def test_docs_migrations_md_is_NOT_skip_safe(self) -> None:
+        # docs/migrations/*.md is globbed with CONFIGURE_DEPENDS into the
+        # generated migration_index.cpp by tools/cli/CMakeLists.txt — the
+        # deny-list must override the .md and docs/ skip-safe rules.
+        for path in ("docs/migrations/2026-05-01-release.md",
+                     "docs/migrations/v2-upgrade.md"):
+            self.assertFalse(classify.is_skip_safe(path), path)
+
     def test_build_inputs_are_NOT_skip_safe(self) -> None:
         for path in ("core/signal/src/fft.cpp",
                      "core/view/include/pulp/view/view.hpp",
@@ -68,6 +76,17 @@ class NativeBuildRequiredTests(unittest.TestCase):
     def test_all_docs_skips_build(self) -> None:
         self.assertFalse(classify.native_build_required(
             ["README.md", "docs/guide.md", "CHANGELOG.md"]))
+
+    def test_migration_doc_forces_build(self) -> None:
+        # A migrations-only PR changes generated C++ — must build.
+        self.assertTrue(classify.native_build_required(
+            ["docs/migrations/2026-05-19-foo.md"]))
+
+    def test_migration_doc_among_plain_docs_forces_build(self) -> None:
+        # One migration doc among ordinary docs still forces the build.
+        self.assertTrue(classify.native_build_required(
+            ["README.md", "docs/guide.md",
+             "docs/migrations/2026-05-19-foo.md"]))
 
     def test_any_code_file_forces_build(self) -> None:
         # One code file among many docs still forces the build.


### PR DESCRIPTION
## Summary

Adds a `classify` gate to `build.yml` so PRs that touch no C++/Swift
build input skip the native build matrix entirely. macOS CI now runs on
a single local self-hosted laptop (Namespace cloud was cut for cost), so
a wasted macOS build is real queue time. Evidence: of 8 PRs in a recent
session, 5 touched no build input yet each ran a full 3-platform
Skia/Dawn build.

## What this does

A cheap `classify` job (ubuntu-latest, ~10 s) runs
`tools/scripts/classify_changes.py`. When a PR touches no build input,
the `build` matrix and `windows-msvc-release-gate` are **skipped at the
job level** — no runner allocated — and the `macos`/`linux`/`windows`
alias jobs report a fast green from Ubuntu. Job-level skip (not
step-level) is required: a self-hosted job must be *allocated a runner*
before it can no-op, so only a job-level `if:` avoids the queue.

## Design

- **`classify_changes.py` is fail-closed.** Any uncertainty, git error,
  or empty diff → `native_build_required=true`. The skip-safe set is a
  deliberately small allowlist (`*.md`, `docs/`, `planning/`,
  `.githooks/`, `.shipyard/`, a few exact files). Everything else —
  `core/**`, every `CMakeLists.txt`, `tools/cmake/**`, `tools/scripts/**`,
  `.github/workflows/**`, the classifier itself — forces the build.
- **The required `macos` check is a dedicated `macos` alias job**
  (`if: always()`), not the matrix leg. It always reports. The matrix
  leg is renamed `macOS (ARM64) [<provider>]`, uniform with linux/windows.
- **No branch-protection change** — the `macos` context is still
  produced, by the alias job now.

## Codex review — three fail-open bugs found and fixed (7335bafe)

`/codex-consult` (high reasoning) reviewed the implementation:

1. **`docs/migrations/*.md` is a real build input.** `tools/cli/CMakeLists.txt`
   globs it with `CONFIGURE_DEPENDS` into the generated
   `migration_index.cpp`. Added `FORCE_BUILD_PREFIXES`, checked before
   the `.md`/`docs/` skip-safe rules.
2. **Code→docs renames could hide the old path.** `git diff --name-only`
   collapses a rename to the new path; diff now uses `--no-renames` so
   the old code path surfaces and forces the build.
3. **A failed `classify` job reported a false green.** The alias jobs
   read `!= 'true'` on an empty output and exited success. They now fail
   closed when `needs.classify.result != 'success'`.

## Also fixes pre-existing `main` breakage (97e94bac)

While shipping this, the auto-merger surfaced that the required
`Enforce version & skill sync` check was **red for every PR branched off
`main`** — unrelated to the classify gate. Root cause: the P6-A3 refactor
(#2438, "extract claude_bundle.cpp") moved the runtime design-import
parsers (`parse_*_react`, `parse_claude_html_with_runtime`,
`parse_react_native_export`) into `core/view/src/claude_bundle.cpp` but
left the static parsers in `design_import.cpp`. `source-contracts.json`'s
single `parser.file` per contract could no longer locate both, so the
`Source-contract registry check` step failed repo-wide.

Fix: an optional `parser.runtime_file` field. The checker resolves
`parser.runtime` + the `explicit-runtime-parser` dispatch symbol against
it (falling back to `parser.file`); `parser.static` stays on `parser.file`.
`check-source-contracts.py --strict` now exits 0; `test_source_contracts.py`
is 21/21 (new regression test). `import-design` SKILL.md documents the
field. Folded into this PR so it unblocks every PR/agent on merge.

Regression tests added (`test_classify_changes.py`, 20 cases total).

## Validation

- **Code-PR path** — this PR touches `build.yml` + the classifier, so it
  classifies `native_build_required=true` and runs the full native
  matrix. This PR's own green CI proves the code path, the renamed
  matrix leg, the `macos` alias job, and the required-check binding.
- **Skip path** — cannot be proven by a pre-merge PR: any branch
  carrying the gate, diffed against `main`, classifies as a *code* PR
  (its diff includes `build.yml`). It is validated by the first
  docs-only PR merged after this lands. Low-risk by construction: a
  classify failure fails the `macos` gate closed, and a wrong skip can
  only occur if *every* changed file is markdown/docs — in which case
  there is no compiled code to regress.

## Companion docs

- `planning/2026-05-19-ci-optimization-plan.md` — the plan
- `planning/2026-05-19-ci-optimization-codex-review.md` — Codex's review

🤖 Generated with [Claude Code](https://claude.com/claude-code)