### PR TITLE
test: classify-gate skip-path validation (DO NOT MERGE)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,3 +44,5 @@ MIT-licensed. No royalties. No copyleft.
 
 - [Code Style](policies/code-style.md) — coding standards and architectural rules
 - [Agent Rules](policies/agent-contribution-rules.md) — contribution rules for AI agents
+
+<!-- classify-gate skip-path validation probe — safe to delete -->


### PR DESCRIPTION
Validation scaffolding for #2446. Docs-only diff → should exercise the classify gate's skip path. Watching that build skips + macos alias goes green fast. Close after observing; do not merge.