### PR TITLE
ci(build): route macOS overflow to free GitHub-hosted macos-15

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1877,3 +1877,29 @@ Key facts:
   allowlist without a test.
 
 Companion plan: `planning/2026-05-19-ci-optimization-plan.md`.
+
+## macOS runner routing — local primary, GitHub-hosted overflow
+
+The `resolve-provider` job in `build.yml` decides per-run where each
+`Build and Test` macOS leg runs:
+
+- **Local first.** While the local self-hosted Mac has spare capacity
+  the macOS leg routes to it (`PULP_LOCAL_MACOS_RUNS_ON_JSON`).
+- **Overflow to free GitHub-hosted `macos-15`.** When the local Mac is
+  saturated — `_count_busy_local_mac_runners()` returns
+  `>= PULP_LOCAL_MAC_OVERFLOW_THRESHOLD` (default 2) Build-and-Test runs
+  already targeting local — the leg routes to `macos-15` instead. The
+  repo is public, so GitHub-hosted macOS is **free**; overflow costs
+  nothing, it just runs slower than the M1 Max.
+- **Operator override.** A `workflow_dispatch` `macos_runner_selector_json`
+  input always wins.
+
+The overflow target is `OVERFLOW_MACOS_RUNS_ON_JSON`, which defaults to
+`["macos-15"]`; the repo variable `PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON`
+overrides it (set it empty to pin macOS local-only). Routing is decided
+**once per run, at dispatch** — a leg already sent to `macos-15` is not
+migrated back to local if the Mac frees up; cloud overflow is parallel
+capacity, not a queue waiting on the Mac. Namespace is no longer a
+routing target (cut for cost, 2026-05-20). The matrix leg name's
+`[<provider>]` suffix reflects the real route (`local` / `github-hosted`
+/ `operator`).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,11 +61,12 @@ jobs:
           # downstream resolver still sees a single explicit env.
           #
           # 1. Operator override (workflow_dispatch input). Always wins.
-          # 2. Namespace overflow (Plan B, pulp planning/2026-05-13-
-          #    namespace-overflow-implementation.md). Activates when the
-          #    local self-hosted Mac runner has at least
-          #    LOCAL_MAC_OVERFLOW_THRESHOLD busy workers AND Namespace is
-          #    configured (NAMESPACE_MACOS_RUNS_ON_JSON non-empty).
+          # 2. Overflow to free GitHub-hosted macOS (macos-15). Activates
+          #    when the local self-hosted Mac is saturated — at least
+          #    LOCAL_MAC_OVERFLOW_THRESHOLD Build-and-Test runs already
+          #    targeting it. macos-15 is free for public repos, so the
+          #    spillover costs nothing; it just runs slower than the
+          #    local M1 Max. Configured via OVERFLOW_MACOS_RUNS_ON_JSON.
           # 3. Local default (PULP_LOCAL_MACOS_RUNS_ON_JSON). The
           #    operator's "macOS local runner: primary required gate"
           #    policy when local is idle.
@@ -83,7 +84,11 @@ jobs:
           LOCAL_MAC_RUNNER_LABEL: ${{ vars.PULP_LOCAL_MAC_RUNNER_LABEL || 'sanitizer' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON }}
           NAMESPACE_WINDOWS_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON }}
-          NAMESPACE_MACOS_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON }}
+          # macOS overflow target. Defaults to GitHub-hosted macos-15,
+          # which is free for public repos. Override via the repo variable
+          # PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON (set it empty to pin
+          # macOS local-only with no overflow).
+          OVERFLOW_MACOS_RUNS_ON_JSON: ${{ vars.PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON || '["macos-15"]' }}
           # gh CLI auth for the overflow-busy-count probe.
           GH_TOKEN: ${{ github.token }}
         # Uses the shared resolver at tools/scripts/resolve_runs_on.py so the
@@ -118,10 +123,10 @@ jobs:
                   sys.exit(result.returncode)
               return result.stdout
 
-          # ─── macOS overflow routing (Plan B, pulp #1916 follow-up) ────────
-          # When the local self-hosted Mac runner is saturated and Namespace
-          # is configured, route the macOS leg to Namespace cloud instead
-          # of waiting in the local queue. Precedence is "operator wins,
+          # ─── macOS overflow routing ──────────────────────────────────────
+          # When the local self-hosted Mac runner is saturated, route the
+          # macOS leg to free GitHub-hosted macos-15 instead of waiting in
+          # the local queue. Precedence is "operator wins,
           # then overflow, then local default" — see the env-block comment
           # above for the layer ordering. Failures of the busy probe fall
           # back to local (the safer choice — overflow is an optimization,
@@ -231,8 +236,8 @@ jobs:
           workflow_dispatch_selector = (
               os.environ.get("WORKFLOW_DISPATCH_MACOS_SELECTOR") or ""
           ).strip()
-          namespace_macos_selector = (
-              os.environ.get("NAMESPACE_MACOS_RUNS_ON_JSON") or ""
+          overflow_macos_selector = (
+              os.environ.get("OVERFLOW_MACOS_RUNS_ON_JSON") or ""
           ).strip()
           local_macos_selector = (
               os.environ.get("LOCAL_MACOS_RUNS_ON_JSON") or ""
@@ -247,26 +252,21 @@ jobs:
           if workflow_dispatch_selector:
               macos_route = "operator-override"
               chosen_macos_selector = workflow_dispatch_selector
-          elif namespace_macos_selector and EVENT_NAME in ("pull_request", "workflow_dispatch"):
-              # 2026-05-19: Namespace overflow logic now also applies to
-              # workflow_dispatch (Codex post-merge P2 on PR #2269).
-              # Before: condition was `EVENT_NAME == "pull_request"` only,
-              # which silently routed `shipyard pr` (which uses
-              # workflow_dispatch via the Shipyard `[targets.mac]
-              # backend = "cloud"` path) back to the local self-hosted
-              # Mac — defeating the cutover for ship cycles. The
-              # explicit-override path above (workflow_dispatch_selector)
-              # still wins; this branch only fires when the operator
-              # didn't supply an explicit selector.
+          elif overflow_macos_selector and EVENT_NAME in ("pull_request", "workflow_dispatch"):
+              # Overflow applies to pull_request AND workflow_dispatch so
+              # `shipyard pr` (which dispatches via workflow_dispatch) gets
+              # the same routing — otherwise ship cycles always pin local.
+              # The explicit-override path above still wins; this branch
+              # only fires when the operator didn't supply a selector.
               busy = _count_busy_local_mac_runners()
               if busy >= overflow_threshold:
                   macos_route = f"overflow (BUSY={busy} >= {overflow_threshold})"
-                  chosen_macos_selector = namespace_macos_selector
+                  chosen_macos_selector = overflow_macos_selector
               else:
                   macos_route = f"local (BUSY={busy} < {overflow_threshold})"
                   chosen_macos_selector = local_macos_selector
           else:
-              # Namespace not configured. Stay local.
+              # No overflow target configured. Stay local.
               macos_route = "local (default)"
               chosen_macos_selector = local_macos_selector
 
@@ -276,6 +276,15 @@ jobs:
               f"selector = {chosen_macos_selector or '(empty → falls through to provider mode)'}",
               file=sys.stderr,
           )
+
+          # The matrix leg renders `[<provider>]` in its name; reflect the
+          # real macOS route rather than the global REQUESTED provider.
+          if macos_route.startswith("overflow"):
+              macos_provider = "github-hosted"
+          elif macos_route == "operator-override":
+              macos_provider = "operator"
+          else:
+              macos_provider = "local"
 
           linux_runs_on = run([
               "--target-name", "Linux (x64)",
@@ -326,8 +335,8 @@ jobs:
               "--mode", "provider",
               "--github-hosted-label", "macos-15",
               "--explicit-env", "EXPLICIT_MACOS_RUNNER_SELECTOR_JSON",
-              "--namespace-env", "NAMESPACE_MACOS_RUNS_ON_JSON",
-              "--namespace-setting-name", "PULP_NAMESPACE_BUILD_MACOS_RUNS_ON_JSON",
+              "--namespace-env", "OVERFLOW_MACOS_RUNS_ON_JSON",
+              "--namespace-setting-name", "PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON",
           ])
 
           include = [
@@ -335,7 +344,7 @@ jobs:
                   "key": "macos",
                   "name": "macOS (ARM64)",
                   "runs_on_json": macos_runs_on,
-                  "provider": REQUESTED,
+                  "provider": macos_provider,
               },
               {
                   "key": "windows",


### PR DESCRIPTION
## Summary

Repoints the macOS CI overflow target from Namespace (cut for cost) to
free GitHub-hosted `macos-15`. The repo is **public**, so GitHub-hosted
standard macOS runners are free — no minute caps, no 10× billing. This
gives macOS CI real overflow capacity at $0.

## How it works

`resolve-provider` already decides the macOS leg's runner per run. This
PR only changes the overflow *target*:

- **Local primary** — while the local self-hosted Mac has spare capacity,
  the macOS leg routes to it (faster: M1 Max).
- **Overflow** — when the local Mac is saturated (`_count_busy_local_mac_runners()`
  ≥ `PULP_LOCAL_MAC_OVERFLOW_THRESHOLD`, default 2), the leg routes to
  `macos-15` instead of queueing locally. Runs in parallel on GitHub's
  macOS fleet.
- **Operator override** — a `workflow_dispatch` selector still wins.

The env selector is renamed `NAMESPACE_MACOS_RUNS_ON_JSON` →
`OVERFLOW_MACOS_RUNS_ON_JSON`, defaulting to `["macos-15"]`; the repo
variable `PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON` overrides it (set empty
to pin macOS local-only).

## Also fixes a cosmetic mislabel

The matrix leg's `[<provider>]` suffix echoed the global `REQUESTED`
provider, so a leg that ran on the local Mac displayed as
`macOS (ARM64) [github-hosted]`. It now reflects the real route —
`local` / `github-hosted` / `operator`.

## Routing is decided once, at dispatch

A leg already sent to `macos-15` is **not** migrated back to local if
the Mac frees up — GitHub Actions has no cross-pool work-stealing. That
is fine: cloud overflow is *parallel capacity*, not a queue waiting on
the Mac. Every new run re-evaluates and prefers local whenever it has
room, so the local Mac is used to its full availability.

## Validation

- `actionlint`, `yamllint -d relaxed`, `yaml.safe_load` — clean
- inline `resolve-provider` Python — `py_compile` clean
- No Namespace references remain in the macOS routing path

🤖 Generated with [Claude Code](https://claude.com/claude-code)