### PR TITLE
ci(build): make the macOS overflow disable switch work (Codex P2)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1895,8 +1895,12 @@ The `resolve-provider` job in `build.yml` decides per-run where each
   input always wins.
 
 The overflow target is `OVERFLOW_MACOS_RUNS_ON_JSON`, which defaults to
-`["macos-15"]`; the repo variable `PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON`
-overrides it (set it empty to pin macOS local-only). Routing is decided
+`["macos-15"]`. The repo variable `PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON`
+overrides it: set it to a different runs-on selector to change the
+target, or to the sentinel `local-only` to disable overflow (macOS
+pinned to the local runner). An *empty* variable value does NOT disable
+overflow — GitHub treats unset and empty identically — so `local-only`
+is the explicit off switch. Routing is decided
 **once per run, at dispatch** — a leg already sent to `macos-15` is not
 migrated back to local if the Mac frees up; cloud overflow is parallel
 capacity, not a queue waiting on the Mac. Namespace is no longer a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,8 +86,13 @@ jobs:
           NAMESPACE_WINDOWS_RUNS_ON_JSON: ${{ vars.PULP_NAMESPACE_BUILD_WINDOWS_RUNS_ON_JSON }}
           # macOS overflow target. Defaults to GitHub-hosted macos-15,
           # which is free for public repos. Override via the repo variable
-          # PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON (set it empty to pin
-          # macOS local-only with no overflow).
+          # PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON: set it to a runs-on
+          # selector to change the target, or to the sentinel "local-only"
+          # to disable overflow (macOS pinned to the local runner).
+          # NOTE: an *empty* variable value cannot disable overflow —
+          # GitHub treats unset and empty identically and the `||` default
+          # below re-fills it — so "local-only" is the explicit off
+          # switch, not emptiness (Codex P2 on #2451).
           OVERFLOW_MACOS_RUNS_ON_JSON: ${{ vars.PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON || '["macos-15"]' }}
           # gh CLI auth for the overflow-busy-count probe.
           GH_TOKEN: ${{ github.token }}
@@ -239,6 +244,13 @@ jobs:
           overflow_macos_selector = (
               os.environ.get("OVERFLOW_MACOS_RUNS_ON_JSON") or ""
           ).strip()
+          # "local-only" is the explicit off switch for overflow. An empty
+          # repo variable cannot express this — GitHub treats unset and
+          # empty identically, and the env default re-fills it with
+          # macos-15 — so operators disable overflow with the sentinel
+          # instead. Treat it as "no overflow selector" → stay local.
+          if overflow_macos_selector == "local-only":
+              overflow_macos_selector = ""
           local_macos_selector = (
               os.environ.get("LOCAL_MACOS_RUNS_ON_JSON") or ""
           ).strip()


### PR DESCRIPTION
## Summary

Fixes the Codex P2 on #2451: the documented "set
`PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON` empty to pin macOS local-only"
escape hatch could never work.

GitHub Actions treats an **unset** variable and an **empty-string**
variable identically, and `${{ vars.X || '["macos-15"]' }}` re-fills an
empty value with the default — so emptiness can't express "disable
overflow."

## Fix

An explicit `local-only` sentinel. When
`PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON` is set to `local-only`, the
`resolve-provider` routing treats it as "no overflow target" and the
macOS leg pins to the local runner. Unset/empty still defaults to the
free GitHub-hosted `macos-15` overflow.

`build.yml`'s env comment and the `ci` SKILL.md are corrected to
document the sentinel.

## Validation

Ran `resolve-provider` locally end-to-end:
- default (`["macos-15"]`) — overflows when `BUSY >= threshold`
- `local-only` — macOS routes **local** even at `BUSY=11`

`actionlint`, `yamllint -d relaxed`, `yaml.safe_load`, inline-Python
`py_compile` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)