### PR TITLE
fix(mcp): restore test_mcp_server linkage to extracted mcp_compat version helpers

### DIFF
--- a/test/test_mcp_server.cpp
+++ b/test/test_mcp_server.cpp
@@ -8,9 +8,22 @@
 #include <system_error>
 #include <utility>
 
+// pulp-test-mcp-server compiles only this TU; it does not link the
+// pulp-mcp target's object files. So the test must pull in every
+// translation unit pulp_mcp.cpp depends on:
+//   - pulp_mcp.cpp  — protocol dispatcher (renames main → pulp_mcp_main_for_test)
+//   - mcp_compat.cpp — SDK-compat resolution; also re-exposes the file-local
+//                      parse_cmake_project_version / parse_pulp_toml_sdk_version
+//                      helpers this test exercises directly (Phase 6 B4 extraction)
+//   - mcp_tools.cpp  — tool-call handlers invoked by the dispatcher
+// Without mcp_compat.cpp / mcp_tools.cpp the test fails to link
+// (undefined handle_build / resolve_project_sdk_version / …); without
+// them being in this TU the parse_* helpers stay invisible.
 #define main pulp_mcp_main_for_test
 #include "../tools/mcp/pulp_mcp.cpp"
 #undef main
+#include "../tools/mcp/mcp_compat.cpp"
+#include "../tools/mcp/mcp_tools.cpp"
 
 namespace {
 
@@ -476,7 +489,7 @@ TEST_CASE("parse_cmake_project_version extracts VERSION from project()",
     std::ifstream in(cmake_path);
     std::stringstream buf;
     buf << in.rdbuf();
-    const auto version = parse_cmake_project_version(buf.str());
+    const auto version = pulp_mcp::parse_cmake_project_version(buf.str());
     // Must look like x.y.z.
     int dots = 0;
     for (char c : version) if (c == '.') ++dots;
@@ -687,13 +700,13 @@ TEST_CASE("parse_pulp_toml_sdk_version extracts the top-level scalar",
     // Hand-rolled scanner — confirm the obvious cases and the trap
     // case where another key contains 'sdk_version' as a substring
     // (e.g., min_sdk_version) doesn't poison the result.
-    REQUIRE(parse_pulp_toml_sdk_version("sdk_version = \"0.99.0\"\n") == "0.99.0");
-    REQUIRE(parse_pulp_toml_sdk_version("  sdk_version=\"1.2.3\"\n") == "1.2.3");
-    REQUIRE(parse_pulp_toml_sdk_version("# sdk_version commented out\n").empty());
+    REQUIRE(pulp_mcp::parse_pulp_toml_sdk_version("sdk_version = \"0.99.0\"\n") == "0.99.0");
+    REQUIRE(pulp_mcp::parse_pulp_toml_sdk_version("  sdk_version=\"1.2.3\"\n") == "1.2.3");
+    REQUIRE(pulp_mcp::parse_pulp_toml_sdk_version("# sdk_version commented out\n").empty());
     // The substring trap: min_sdk_version must NOT be returned as the
     // top-level sdk_version.
-    REQUIRE(parse_pulp_toml_sdk_version("min_sdk_version = \"0.50.0\"\n").empty());
+    REQUIRE(pulp_mcp::parse_pulp_toml_sdk_version("min_sdk_version = \"0.50.0\"\n").empty());
     // When both are present, the top-level wins.
-    REQUIRE(parse_pulp_toml_sdk_version(
+    REQUIRE(pulp_mcp::parse_pulp_toml_sdk_version(
         "min_sdk_version = \"0.50.0\"\nsdk_version = \"0.99.0\"\n") == "0.99.0");
 }


### PR DESCRIPTION
The Phase 6 B4 MCP refactor (#2435 / #2436) extracted the SDK-compat and
tool-call helpers out of pulp_mcp.cpp into mcp_compat.cpp and
mcp_tools.cpp. test_mcp_server.cpp builds pulp-test-mcp-server by
#include-ing pulp_mcp.cpp directly into a single TU (the
`#define main pulp_mcp_main_for_test` trick) and linking only
pulp::tool-audio + Catch2 — it never linked the pulp-mcp target's
object files. After the extraction:

  - parse_cmake_project_version / parse_pulp_toml_sdk_version moved into
    mcp_compat.cpp as file-local (static) helpers, so the test's direct
    calls failed to compile ("use of undeclared identifier").
  - handle_build / resolve_project_sdk_version / handle_compat / … moved
    into mcp_compat.cpp + mcp_tools.cpp, leaving the test TU with
    undefined references at link time.

Fix: have test_mcp_server.cpp also #include mcp_compat.cpp and
mcp_tools.cpp, matching the existing pulp_mcp.cpp include pattern. This
pulls every dependent TU into the single test translation unit, so the
file-local parse_* helpers become visible and the dispatcher's symbols
resolve. The two direct parse_* call sites are qualified with the
pulp_mcp:: namespace they now live in. mcp_compat.cpp stays unchanged —
the parse_* helpers remain static/file-local exactly as the B4 design
intended.

This unblocks the macOS gate for every PR in the repo: test_mcp_server
was a hard compile failure on main.

Version-Bump: skip reason="build-only test linkage fix, no API surface change"

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>