### PR TITLE
ci(build): fetch prebuilt Skia before Configure on macOS

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1894,6 +1894,18 @@ The `resolve-provider` job in `build.yml` decides per-run where each
 - **Operator override.** A `workflow_dispatch` `macos_runner_selector_json`
   input always wins.
 
+### Skia provisioning on the macOS leg
+
+`build.yml` runs a **"Fetch prebuilt Skia (macOS)"** step before
+Configure. The Skia `.a` libraries are LFS-declared but not committed,
+so a fresh checkout has only pointer files — without real Skia,
+`FindSkia.cmake` sets `PULP_HAS_SKIA=FALSE` and any examples-ON / GPU
+build fails the Configure gate (`examples/design-tool`). The step runs
+`tools/scripts/fetch_skia_for_release.py darwin-arm64` (pinned,
+sha256-verified asset from `tools/deps/manifest.json`). It is guarded —
+it re-fetches only when the real `libskia.a` is absent, so on a
+self-hosted runner (`clean: false`) it persists between builds.
+
 The overflow target is `OVERFLOW_MACOS_RUNS_ON_JSON`, which defaults to
 `["macos-15"]`. The repo variable `PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON`
 overrides it: set it to a different runs-on selector to change the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -585,6 +585,27 @@ jobs:
             ~/AppData/Local/Pulp/Cache/fetchcontent-src
           key: ${{ steps.fetchcontent-cache.outputs.cache-primary-key }}
 
+      - name: Fetch prebuilt Skia (macOS)
+        # FindSkia.cmake needs
+        # external/skia-build/build/mac-gpu/lib/Release/libskia.a. The
+        # LFS-declared Skia binaries are not committed, so a fresh
+        # checkout has only headers/pointers and Configure fails the
+        # PULP_HAS_SKIA gate (examples-ON / GPU builds — e.g.
+        # examples/design-tool). fetch_skia_for_release.py pulls the
+        # pinned, sha256-verified asset from tools/deps/manifest.json.
+        # Guarded: re-fetch only when the real lib is absent — on a
+        # self-hosted runner (clean: false) it persists between builds.
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          lib="external/skia-build/build/mac-gpu/lib/Release/libskia.a"
+          if [ -f "$lib" ] && ! head -c 64 "$lib" | grep -q "git-lfs"; then
+            echo "Skia already present: $lib"
+          else
+            python3 tools/scripts/fetch_skia_for_release.py darwin-arm64
+          fi
+
       - name: Configure
         # On pull_request events, skip example plugin builds
         # (PulpDrums / PulpSynth / PulpMpeSynth / PulpPluck /


### PR DESCRIPTION
## Summary

Part of macOS CI modernization path (b) — make macOS runners genuinely
GPU-capable. Skia's `.a` libraries are LFS-declared in `.gitattributes`
but **never committed**, so a fresh checkout has only pointer files.
`FindSkia.cmake` then sets `PULP_HAS_SKIA=FALSE` and any examples-ON /
GPU build fails Configure (`examples/design-tool` hard-requires Skia).
`build.yml` never fetched Skia — examples-ON builds only passed on the
self-hosted runner via *stale warm workspace state*, which fresh runners
don't have.

## Change

A **"Fetch prebuilt Skia (macOS)"** step before Configure, running
`tools/scripts/fetch_skia_for_release.py darwin-arm64` — the pinned,
sha256-verified asset from `tools/deps/manifest.json` (the same script
`release-cli.yml` uses; it has its own test suite). Guarded — re-fetch
only when the real `libskia.a` is absent, so a self-hosted runner
(`clean: false`) keeps it between builds; github-hosted overflow
(`clean: true`) fetches per build.

Fixes a real pre-existing gap, not just the new runners — every macOS
build now configures with real Skia.

## Validation

`actionlint`, `yamllint -d relaxed`, `yaml.safe_load` — clean.
`ci` SKILL.md documents the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)