### PR TITLE
ci(skia): make Skia-fetch idempotency manifest-aware (#2458 P2)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1900,11 +1900,20 @@ The `resolve-provider` job in `build.yml` decides per-run where each
 Configure. The Skia `.a` libraries are LFS-declared but not committed,
 so a fresh checkout has only pointer files — without real Skia,
 `FindSkia.cmake` sets `PULP_HAS_SKIA=FALSE` and any examples-ON / GPU
-build fails the Configure gate (`examples/design-tool`). The step runs
-`tools/scripts/fetch_skia_for_release.py darwin-arm64` (pinned,
-sha256-verified asset from `tools/deps/manifest.json`). It is guarded —
-it re-fetches only when the real `libskia.a` is absent, so on a
-self-hosted runner (`clean: false`) it persists between builds.
+build fails the Configure gate (`examples/design-tool`). The step
+unconditionally runs `tools/scripts/fetch_skia_for_release.py
+darwin-arm64` (pinned, sha256-verified asset from
+`tools/deps/manifest.json`).
+
+The script is **idempotency-stamped**: after a successful unpack it
+writes the asset sha256 to `external/skia-build/.skia-asset-sha256`. On
+the next run it skips the ~250-500 MiB download only when that stamp
+matches the *current* manifest pin. On a self-hosted runner
+(`clean: false`) Skia persists between builds, so the common case is a
+fast no-op — but a `manifest.json` Skia pin bump changes the expected
+sha, the stamp no longer matches, and the asset is re-fetched. Never
+guard the fetch on "is `libskia.a` present?" alone: a stale local
+library would silently shadow a new pin (pulp #2458 follow-up).
 
 The overflow target is `OVERFLOW_MACOS_RUNS_ON_JSON`, which defaults to
 `["macos-15"]`. The repo variable `PULP_OVERFLOW_BUILD_MACOS_RUNS_ON_JSON`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -593,18 +593,16 @@ jobs:
         # PULP_HAS_SKIA gate (examples-ON / GPU builds — e.g.
         # examples/design-tool). fetch_skia_for_release.py pulls the
         # pinned, sha256-verified asset from tools/deps/manifest.json.
-        # Guarded: re-fetch only when the real lib is absent — on a
-        # self-hosted runner (clean: false) it persists between builds.
+        # The script is idempotent: it stamps the unpacked asset sha and
+        # skips the download when the stamp matches the current manifest
+        # pin — and re-fetches when the pin changes — so a self-hosted
+        # runner (clean: false) reuses Skia between builds without ever
+        # building against a stale pin.
         if: runner.os == 'macOS'
         shell: bash
         run: |
           set -euo pipefail
-          lib="external/skia-build/build/mac-gpu/lib/Release/libskia.a"
-          if [ -f "$lib" ] && ! head -c 64 "$lib" | grep -q "git-lfs"; then
-            echo "Skia already present: $lib"
-          else
-            python3 tools/scripts/fetch_skia_for_release.py darwin-arm64
-          fi
+          python3 tools/scripts/fetch_skia_for_release.py darwin-arm64
 
       - name: Configure
         # On pull_request events, skip example plugin builds

--- a/tools/scripts/fetch_skia_for_release.py
+++ b/tools/scripts/fetch_skia_for_release.py
@@ -141,6 +141,29 @@ def main(argv: list[str]) -> int:
     print(f"  sha256: {expected_sha}")
     print(f"  expected lib: {expected_lib}")
 
+    # Idempotency stamp. A self-hosted CI runner checks out with
+    # `clean: false`, so `external/skia-build/` persists between jobs;
+    # re-downloading the ~250-500 MiB asset every build is wasteful. But a
+    # naive "is libskia.a present?" guard is *wrong*: when
+    # tools/deps/manifest.json bumps the pinned Skia asset, a stale local
+    # library would silently shadow the new pin and CI would build against
+    # the wrong Skia (pulp #2458 follow-up). The stamp records the sha256
+    # actually unpacked here, so the download is skipped only when that
+    # sha matches the current pin — a pin bump changes expected_sha, the
+    # stamp no longer matches, and the asset is re-fetched.
+    stamp_path = Path("external/skia-build/.skia-asset-sha256")
+    if expected_lib.is_file() and stamp_path.is_file():
+        if stamp_path.read_text(encoding="utf-8").strip() == expected_sha:
+            print(
+                f"OK: Skia already unpacked from the pinned asset "
+                f"(sha256 {expected_sha}); skipping download"
+            )
+            return 0
+        print(
+            "Skia stamp does not match the pinned asset — the manifest "
+            "pin changed since the last fetch; re-downloading."
+        )
+
     zip_path = Path("skia-release-asset.zip")
     print(f"Downloading → {zip_path}")
     with urllib.request.urlopen(url) as resp, zip_path.open("wb") as fp:
@@ -226,6 +249,11 @@ def main(argv: list[str]) -> int:
         for p in sorted(dest.rglob("*"))[:50]:
             print(f"  {p}", file=sys.stderr)
         return 1
+
+    # Record the asset identity so the next run on a `clean: false` runner
+    # can skip the download — and so a future manifest pin bump forces a
+    # re-fetch (the stamp will no longer match the new expected_sha).
+    stamp_path.write_text(expected_sha + "\n", encoding="utf-8")
 
     print(f"OK: {expected_lib} present ({expected_lib.stat().st_size:,} bytes)")
     return 0

--- a/tools/scripts/test_fetch_skia_for_release.py
+++ b/tools/scripts/test_fetch_skia_for_release.py
@@ -409,6 +409,119 @@ class Sha256MismatchFails(unittest.TestCase):
             self.assertEqual(rc, 1, "sha256 mismatch must fail")
 
 
+class IdempotencyStamp(unittest.TestCase):
+    """The `.skia-asset-sha256` stamp (pulp #2458 follow-up).
+
+    A self-hosted CI runner checks out `clean: false`, so a prior fetch's
+    `external/skia-build/` persists. The fetch must be skipped when the
+    on-disk Skia matches the pinned asset, but MUST re-run when the
+    manifest pin changes — a stale local libskia.a silently shadowing a
+    new pin is exactly the non-reproducibility bug the stamp prevents.
+    """
+
+    def test_first_run_writes_stamp(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia.zip"
+            sha = _make_zip(
+                zip_path, {"build/mac-gpu/lib/Release/libskia.a": b"skia-v1"}
+            )
+            _write_manifest(td, f"file://{zip_path.as_posix()}", sha, "mac-arm64")
+
+            rc = fetch_skia.main(["fetch_skia_for_release.py", "darwin-arm64"])
+
+            self.assertEqual(rc, 0)
+            stamp = td / "external/skia-build/.skia-asset-sha256"
+            self.assertTrue(stamp.is_file(), "fetch must write the stamp")
+            self.assertEqual(stamp.read_text(encoding="utf-8").strip(), sha)
+
+    def test_second_run_skips_download_when_stamp_matches(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia.zip"
+            sha = _make_zip(
+                zip_path, {"build/mac-gpu/lib/Release/libskia.a": b"skia-v1"}
+            )
+            _write_manifest(td, f"file://{zip_path.as_posix()}", sha, "mac-arm64")
+            self.assertEqual(
+                fetch_skia.main(["fetch_skia_for_release.py", "darwin-arm64"]), 0
+            )
+
+            # Delete the asset source — a download attempt would now fail.
+            # A correct skip leaves rc == 0.
+            zip_path.unlink()
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = fetch_skia.main(
+                    ["fetch_skia_for_release.py", "darwin-arm64"]
+                )
+
+            self.assertEqual(rc, 0, "matching stamp must skip the download")
+            self.assertIn("skipping download", out.getvalue())
+
+    def test_pin_change_forces_refetch(self):
+        with _in_tempdir() as td:
+            zip_v1 = td / "skia-v1.zip"
+            sha_v1 = _make_zip(
+                zip_v1, {"build/mac-gpu/lib/Release/libskia.a": b"skia-v1"}
+            )
+            _write_manifest(
+                td, f"file://{zip_v1.as_posix()}", sha_v1, "mac-arm64"
+            )
+            self.assertEqual(
+                fetch_skia.main(["fetch_skia_for_release.py", "darwin-arm64"]), 0
+            )
+            lib = td / "external/skia-build/build/mac-gpu/lib/Release/libskia.a"
+            self.assertEqual(lib.read_bytes(), b"skia-v1")
+
+            # Bump the manifest pin to a different asset.
+            zip_v2 = td / "skia-v2.zip"
+            sha_v2 = _make_zip(
+                zip_v2,
+                {"build/mac-gpu/lib/Release/libskia.a": b"skia-v2-different"},
+            )
+            self.assertNotEqual(sha_v1, sha_v2)
+            _write_manifest(
+                td, f"file://{zip_v2.as_posix()}", sha_v2, "mac-arm64"
+            )
+
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = fetch_skia.main(
+                    ["fetch_skia_for_release.py", "darwin-arm64"]
+                )
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(
+                lib.read_bytes(),
+                b"skia-v2-different",
+                "stale Skia must be replaced when the manifest pin changes",
+            )
+            stamp = td / "external/skia-build/.skia-asset-sha256"
+            self.assertEqual(stamp.read_text(encoding="utf-8").strip(), sha_v2)
+
+    def test_missing_lib_with_stamp_refetches(self):
+        with _in_tempdir() as td:
+            zip_path = td / "skia.zip"
+            sha = _make_zip(
+                zip_path, {"build/mac-gpu/lib/Release/libskia.a": b"skia-v1"}
+            )
+            _write_manifest(td, f"file://{zip_path.as_posix()}", sha, "mac-arm64")
+            self.assertEqual(
+                fetch_skia.main(["fetch_skia_for_release.py", "darwin-arm64"]), 0
+            )
+
+            # A wiped/partial workspace: stamp survives, library is gone.
+            lib = td / "external/skia-build/build/mac-gpu/lib/Release/libskia.a"
+            lib.unlink()
+
+            rc = fetch_skia.main(["fetch_skia_for_release.py", "darwin-arm64"])
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(
+                lib.is_file(),
+                "a missing library must re-fetch even when the stamp exists",
+            )
+
+
 if __name__ == "__main__":
     # Silence the script's progress prints during tests — unittest's own
     # output is what we want to see.


### PR DESCRIPTION
## Summary

Follow-up to #2458 — resolves the Codex **P2** on it.

#2458's `build.yml` guard skipped the Skia fetch whenever a real
(non-pointer) `libskia.a` was on disk. On a self-hosted runner
(`clean: false`) `external/skia-build/` persists between jobs, so a
`tools/deps/manifest.json` Skia pin bump would **not** trigger a
re-fetch — CI would keep building against the stale local library,
hiding dependency-upgrade regressions and making macOS results
non-reproducible across runner types.

## Change

Idempotency moves into `fetch_skia_for_release.py`, keyed on the
**pinned asset identity**:

- After a successful unpack the script stamps the asset `sha256` to
  `external/skia-build/.skia-asset-sha256`.
- The next run skips the ~250-500 MiB download **only** when that stamp
  matches the *current* manifest pin. A pin bump changes `expected_sha`,
  the stamp no longer matches → the asset is re-fetched.
- `build.yml` is now an unconditional `python3 ... fetch_skia_for_release.py
  darwin-arm64` — the brittle file-presence guard is deleted.

Benefits every caller (release-cli.yml, the runner bootstrap's
`verify_skia`), not just the macOS build leg.

## Tests

`IdempotencyStamp` — 4 cases: first run writes the stamp; a matching
stamp skips the download; a manifest pin change forces a re-fetch and
replaces the stale library; a missing library re-fetches even when the
stamp survives. Full suite: **23 pass** (was 19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)