### PR TITLE
ci(build): default runner_provider to github-hosted (Namespace drained)

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -929,10 +929,16 @@ self-hosted macOS workspaces can mask the bug.
 
 ### Overrides when you need them
 
-- **Dispatch a specific run on github-hosted** (normal Linux/Windows path, or comparing hosted macOS behaviour):
+- **Dispatch a build manually**: `runner_provider` defaults to
+  `github-hosted` (Namespace is drained — `default: namespace` was the
+  stale value that made every plain `workflow_dispatch` fail fast in
+  `resolve-provider`). A plain dispatch routes Linux/Windows to
+  GitHub-hosted runners; no `-f runner_provider` is needed:
   ```bash
-  gh workflow run build.yml --repo danielraffel/pulp --ref <branch> -f runner_provider=github-hosted
+  gh workflow run build.yml --repo danielraffel/pulp --ref <branch>
   ```
+  Passing `-f runner_provider=namespace` will fail until the
+  `PULP_NAMESPACE_BUILD_*_RUNS_ON_JSON` repo variables are restored.
 - **Pin macOS to a local runner selector**: set `PULP_LOCAL_MACOS_RUNS_ON_JSON` at the repo level, or pass `macos_runner_selector_json` on a manual dispatch. Keep the selector compatible with the runner labels (`self-hosted`, `sanitizer`).
 - **Do not use Namespace overrides**: any remaining Namespace variable or mode is stale configuration and should be removed rather than worked around.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,17 @@ on:
   workflow_dispatch:
     inputs:
       runner_provider:
-        description: "Runner provider to use for Linux and Windows build legs"
+        # Default is github-hosted: Namespace is drained and no
+        # PULP_NAMESPACE_BUILD_*_RUNS_ON_JSON repo variables are set, so
+        # resolve-provider fails fast on the `namespace` route. The
+        # option is retained only for a future re-enable.
+        description: "Runner provider for Linux/Windows build legs (Namespace is drained — keep github-hosted)"
         required: false
-        default: namespace
+        default: github-hosted
         type: choice
         options:
-          - namespace
           - github-hosted
+          - namespace
       linux_runner_selector_json:
         description: "Optional JSON string/array for Linux runs-on when routing through Namespace"
         required: false


### PR DESCRIPTION
## Summary

The `runner_provider` `workflow_dispatch` input still defaulted to
`namespace`, but Namespace is drained and no
`PULP_NAMESPACE_BUILD_*_RUNS_ON_JSON` repo variables remain. Every plain
`gh workflow run build.yml` failed fast in `resolve-provider`:

```
PULP_NAMESPACE_BUILD_LINUX_RUNS_ON_JSON is not set; cannot route Linux (x64) to Namespace.
##[error]Process completed with exit code 1.
```

— a manual dispatch was unusable without an explicit
`-f runner_provider=github-hosted`. Caught while dispatching the macOS
runner-cutover verification build.

## Change

Flip the default to `github-hosted`. The choice list keeps `namespace`
for a future re-enable; fully removing the namespace route from
`resolve-provider` is a separate cleanup. `ci` SKILL.md's
manual-dispatch note is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)