### PR TITLE
fix(test): #2462 — shared canvas_pixel_probe.hpp, repair shadow test compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to its [GitHub Release](https://github.com/danielraffel/pulp/releases).
      next regen as long as they land in the right release's bullet block. See
      docs/guides/versioning.md § Release pipeline for the full end-to-end flow. -->
 
+<a id="v017312"></a>
+## [0.173.12] - 2026-05-20
+
+- fix(test): #2462 — shared canvas_pixel_probe.hpp; repair test_canvas_widget_shadow.cpp Skia-build compile
+
 <a id="v017311"></a>
 ## [0.173.11] - 2026-05-19
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.173.11
+    VERSION 0.173.12
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/test/canvas_pixel_probe.hpp
+++ b/test/canvas_pixel_probe.hpp
@@ -12,8 +12,8 @@
 // Skia-enabled build. This header is the single shared definition.
 //
 // Skia-gated: the body only exists when PULP_HAS_SKIA is defined, so a
-// no-Skia build sees an empty header (the call sites are themselves
-// inside `#ifdef PULP_HAS_SKIA`).
+// no-Skia build sees an empty header. The call sites are themselves
+// inside `#ifdef PULP_HAS_SKIA`.
 
 #pragma once
 

--- a/test/canvas_pixel_probe.hpp
+++ b/test/canvas_pixel_probe.hpp
@@ -1,0 +1,48 @@
+// canvas_pixel_probe.hpp — shared raster-pixel probe for the canvas
+// test suites.
+//
+// Created in the 2026-05 fix for pulp #2462. The Skia raster tests in
+// test_canvas_widget.cpp, test_canvas2d_shim.cpp, and
+// test_canvas_widget_shadow.cpp each need to read back a single texel
+// from an SkSurface to assert on what the canvas actually painted.
+// test_canvas_widget.cpp and test_canvas2d_shim.cpp each carried their
+// own identical copy; test_canvas_widget_shadow.cpp (extracted from
+// test_canvas_widget.cpp in the Phase 5 P5-3 split, #2418) referenced
+// `sample_pixel` without a definition and failed to compile under a
+// Skia-enabled build. This header is the single shared definition.
+//
+// Skia-gated: the body only exists when PULP_HAS_SKIA is defined, so a
+// no-Skia build sees an empty header (the call sites are themselves
+// inside `#ifdef PULP_HAS_SKIA`).
+
+#pragma once
+
+#ifdef PULP_HAS_SKIA
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "include/core/SkPixmap.h"
+#include "include/core/SkSurface.h"
+
+#include <cstdint>
+
+namespace pulp::canvas_test {
+
+// A single RGBA8 (premultiplied) texel.
+struct Pixel {
+    uint8_t r, g, b, a;
+};
+
+// Sample one RGBA8 premul texel from a Skia raster surface so tests can
+// assert on the actual pixels a canvas produced. REQUIRE-fails if the
+// surface has no readable pixels.
+inline Pixel sample_pixel(SkSurface* surface, int x, int y) {
+    SkPixmap pix;
+    REQUIRE(surface->peekPixels(&pix));
+    auto* row = static_cast<const uint8_t*>(pix.addr(0, y));
+    return {row[4 * x + 0], row[4 * x + 1], row[4 * x + 2], row[4 * x + 3]};
+}
+
+}  // namespace pulp::canvas_test
+
+#endif  // PULP_HAS_SKIA

--- a/test/test_canvas2d_shim.cpp
+++ b/test/test_canvas2d_shim.cpp
@@ -396,15 +396,11 @@ TEST_CASE("Canvas2D fillStyle = string clears prior gradient",
 
 #ifdef PULP_HAS_SKIA
 
-namespace {
-struct Pixel { uint8_t r, g, b, a; };
-Pixel sample_pixel(SkSurface* surface, int x, int y) {
-    SkPixmap pix;
-    REQUIRE(surface->peekPixels(&pix));
-    auto* row = static_cast<const uint8_t*>(pix.addr(0, y));
-    return {row[4 * x + 0], row[4 * x + 1], row[4 * x + 2], row[4 * x + 3]};
-}
-}  // namespace
+// Pixel + sample_pixel moved to the shared canvas_pixel_probe.hpp in the
+// pulp #2462 fix (was duplicated here and in test_canvas_widget.cpp).
+#include "canvas_pixel_probe.hpp"
+using pulp::canvas_test::Pixel;
+using pulp::canvas_test::sample_pixel;
 
 // ── End-to-end FilterBank repro: JS → bridge → CanvasWidget → SkiaCanvas ──
 //

--- a/test/test_canvas_widget.cpp
+++ b/test/test_canvas_widget.cpp
@@ -277,20 +277,11 @@ TEST_CASE("CanvasWidget::paint_all under parent View emits correct command order
 
 #ifdef PULP_HAS_SKIA
 
-namespace {
-struct Pixel {
-    uint8_t r, g, b, a;
-};
-
-// Sample a single RGBA8 pixel (premul) from a Skia raster surface so
-// tests can assert on the actual texels CanvasWidget produced.
-Pixel sample_pixel(SkSurface* surface, int x, int y) {
-    SkPixmap pix;
-    REQUIRE(surface->peekPixels(&pix));
-    auto* row = static_cast<const uint8_t*>(pix.addr(0, y));
-    return {row[4 * x + 0], row[4 * x + 1], row[4 * x + 2], row[4 * x + 3]};
-}
-}  // namespace
+// Pixel + sample_pixel moved to the shared canvas_pixel_probe.hpp in the
+// pulp #2462 fix (was duplicated here and in test_canvas2d_shim.cpp).
+#include "canvas_pixel_probe.hpp"
+using pulp::canvas_test::Pixel;
+using pulp::canvas_test::sample_pixel;
 
 TEST_CASE("CanvasWidget paints transparent by default on a Skia raster surface",
           "[canvas_widget][skia][issue-929]") {

--- a/test/test_canvas_widget_shadow.cpp
+++ b/test/test_canvas_widget_shadow.cpp
@@ -151,6 +151,14 @@ TEST_CASE("CanvasWidget shadow setters can be cleared mid-stream",
 }
 
 #ifdef PULP_HAS_SKIA
+
+// Shared raster-pixel probe. This file was extracted from
+// test_canvas_widget.cpp in the Phase 5 P5-3 split (#2418) but never
+// carried sample_pixel — the loose end pulp #2462 tracked.
+#include "canvas_pixel_probe.hpp"
+using pulp::canvas_test::Pixel;
+using pulp::canvas_test::sample_pixel;
+
 TEST_CASE("SkiaCanvas honors sticky Canvas2D shadow state on fillRect",
           "[canvas_widget][issue-1434-batch-7][skia]") {
     // Rasterise a filled rect with shadowColor + shadowBlur + offset


### PR DESCRIPTION
## Summary

Fixes the `test_canvas_widget_shadow.cpp` half of **#2462**.

`test_canvas_widget_shadow.cpp` (extracted from `test_canvas_widget.cpp` in the Phase 5 P5-3 split, #2418) referenced `sample_pixel` / `Pixel` without a definition — it failed to compile under a Skia-enabled build. The P5-3 split validated the canvas tests *without* Skia, so the Skia-gated branch of the extracted file never compiled.

Fix per #2462's suggested approach — a shared header, not a third copy:
- New `test/canvas_pixel_probe.hpp` (`PULP_HAS_SKIA`-gated): `Pixel` struct + `sample_pixel` raster probe in `namespace pulp::canvas_test`.
- `test_canvas_widget.cpp` + `test_canvas2d_shim.cpp` drop their identical local copies and include the shared header.
- `test_canvas_widget_shadow.cpp` gains the declaration it was missing.

## Test plan — validated WITH Skia (the gap that hid this)

Configured `-DSKIA_DIR=…/external/skia-build` → `PULP_HAS_SKIA=1`:

- [x] Full `cmake --build build -- -k` keep-going build: **461 targets, exit 0, zero errors** — confirms no other broken test targets behind this one (#2462 expected "there may be more")
- [x] `pulp-test-canvas-widget-shadow` → 30 assertions / **4 cases** (the 2 Skia-gated shadow tests now compile + run — previously skipped)
- [x] `pulp-test-canvas-widget` → 190 / 44
- [x] `pulp-test-canvas-widget-sanitize` → 28 / 5
- [x] `pulp-test-canvas2d-shim` → 167 / 53

## Scope

This PR fixes **only the file**. #2462's systemic item — PR CI doesn't `make all`, so test targets rot undetected — is a separate nightly-full-build task and **stays open**. Do not close #2462 on this PR.