### PR TITLE
feat(inspect): add 20x zoom loupe to inspector overlay (Phase 3e)

### DIFF
--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -309,6 +309,44 @@ public:
         return drifted_;
     }
 
+    // ── Phase 3e — 20× zoom loupe ───────────────────────────────────
+    //
+    // A magnified-pixel preview panel ("loupe") that shows the region
+    // under the cursor blown up by `zoom_factor_`. It complements the
+    // Phase 3c eyedropper: where the eyedropper grabs a single pixel,
+    // the loupe shows a grid of surrounding pixels with a center
+    // crosshair so the user can align edges + verify color boundaries.
+    //
+    // Toggled with the `Z` key (drag=D, eyedropper=E, panel=T are
+    // already taken). When active, mouse-move re-centers the sampled
+    // region on the cursor; paint() draws paint_zoom_panel() last so
+    // the loupe sits on top of everything, including the props panel.
+    //
+    // Pixel source mirrors the eyedropper's dual path:
+    //   - Skia raster surface  → Canvas::read_pixels() gives true RGBA
+    //   - non-Skia / headless  → graceful degradation: the loupe still
+    //     paints its frame + readout, filling the grid with the
+    //     resolved background color of the View under the cursor (or a
+    //     neutral checkerboard when that View has no background).
+    bool zoom_active() const { return zoom_active_; }
+    void set_zoom_active(bool active);
+    void toggle_zoom() { set_zoom_active(!zoom_active_); }
+
+    /// Magnification factor — how many panel pixels per source pixel.
+    /// Defaults to 20× per the roadmap; clamped to [4, 40] so the grid
+    /// neither degenerates into a single cell nor overflows the panel.
+    int zoom_factor() const { return zoom_factor_; }
+    void set_zoom_factor(int factor);
+
+    /// Last cursor position the loupe sampled around, in root (window)
+    /// coordinates. The loupe centers its grid on this pixel.
+    Point zoom_sample_center() const { return zoom_sample_center_; }
+
+    /// Resolved color of the center (sample) pixel — what the loupe
+    /// readout reports as a hex string. Comes from read_pixels() when
+    /// available, else the fallback resolved-view-color path.
+    Color zoom_center_color() const { return zoom_center_color_; }
+
 private:
     View& root_;
     bool active_ = false;
@@ -466,6 +504,26 @@ private:
     // eyedropper mode is active and at least one sample has landed.
     void paint_eyedropper_cursor(Canvas& canvas);
 
+    // ── Phase 3e — zoom loupe state ─────────────────────────────────
+    // Off by default; the inspector behaves identically to the
+    // pre-3e build until the user opts in via the Z-key toggle.
+    bool zoom_active_ = false;
+    int zoom_factor_ = 20;                    ///< panel px per source px
+    Point zoom_sample_center_{};              ///< cursor pos last sampled
+    Color zoom_center_color_{};               ///< resolved center-pixel color
+    bool zoom_center_from_readback_ = false;   ///< true = real read_pixels()
+
+    // Recompute zoom_center_color_ for the current zoom_sample_center_,
+    // sampling `canvas` via read_pixels() when the surface supports it
+    // and falling back to the resolved View color otherwise. Sets
+    // zoom_center_from_readback_ to record which path was taken.
+    void update_zoom_sample(Canvas& canvas);
+    // Resolve the on-screen color at root-coord point `p` WITHOUT a
+    // pixel readback — walks the view tree top-most-first and returns
+    // the deepest hit View's background color. Returns false (and
+    // leaves `out` untouched) when no background-bearing view is hit.
+    bool resolve_view_color_at(Point p, Color& out) const;
+
     // ── Flat tree for rendering ─────────────────────────────────────
     struct TreeItem {
         const View* view;
@@ -495,6 +553,11 @@ private:
     /// the props section below it. Paints nothing and returns 0 when
     /// there is no drift.
     float paint_drift_drawer(Canvas& canvas, float x, float y, float w);
+    // Phase 3e — magnified-pixel loupe. Draws a fixed-corner panel with
+    // a grid of `zoom_factor_`-scaled pixels sampled around the cursor,
+    // a center crosshair marking the sample pixel, and a coordinate +
+    // hex color readout strip beneath the grid.
+    void paint_zoom_panel(Canvas& canvas);
 
     // Phase 2.5 — render the tweak management panel into the given
     // rect. Repopulates tweak_rows_ with this frame's hit-rects.
@@ -533,6 +596,16 @@ private:
     static constexpr float kIndent = 16.0f;
     static constexpr float kFontSize = 11.0f;
     static constexpr float kStatsBarHeight = 24.0f;
+
+    // Phase 3e — zoom loupe layout. The loupe samples a square grid of
+    // kZoomGridCells × kZoomGridCells source pixels (odd so there's an
+    // exact center pixel) and renders each at zoom_factor_ scale. The
+    // panel sits in a fixed corner with a readout strip beneath.
+    static constexpr int   kZoomGridCells   = 11;   ///< odd → exact center
+    static constexpr int   kZoomFactorMin   = 4;
+    static constexpr int   kZoomFactorMax   = 40;
+    static constexpr float kZoomReadoutH    = 36.0f;
+    static constexpr float kZoomPanelMargin = 12.0f;
 };
 
 /// Global inspector instance for the current window.

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -43,6 +43,17 @@ static const Color kEyedropChromeBg  = Color::rgba(0.08f, 0.08f, 0.1f, 0.95f);
 static const Color kEyedropBorder    = Color::rgba(1.0f, 1.0f, 1.0f, 0.85f);
 static const Color kEyedropText      = Color::rgba(0.95f, 0.95f, 1.0f, 1.0f);
 
+// Phase 3e — zoom loupe visual treatment
+static const Color kZoomPanelBg      = Color::rgba(0.06f, 0.06f, 0.08f, 0.97f);
+static const Color kZoomBorder       = Color::rgba(0.25f, 0.5f, 1.0f, 0.9f);
+static const Color kZoomGridLine     = Color::rgba(0.0f, 0.0f, 0.0f, 0.25f);
+static const Color kZoomCrosshair    = Color::rgba(1.0f, 0.5f, 0.0f, 0.95f);
+static const Color kZoomReadoutText  = Color::rgba(0.9f, 0.9f, 0.95f, 1.0f);
+static const Color kZoomReadoutDim   = Color::rgba(0.55f, 0.55f, 0.6f, 1.0f);
+// Two-tone checkerboard for the no-readback fallback grid.
+static const Color kZoomCheckerA     = Color::rgba(0.22f, 0.22f, 0.26f, 1.0f);
+static const Color kZoomCheckerB     = Color::rgba(0.30f, 0.30f, 0.34f, 1.0f);
+
 // Format a Color as a CSS hex string: "#rrggbb" when fully opaque,
 // "#rrggbbaa" otherwise. Lower-case, fixed-width — matches the hex
 // shape the JS bridge and pulp-tweaks.json already use for colors.
@@ -96,6 +107,9 @@ void InspectorOverlay::set_active(bool active) {
         // inspector so a stale swatch never paints on the next open.
         eyedropper_active_ = false;
         eyedropper_has_sample_ = false;
+        // Phase 3e — the loupe is a transient inspect tool; dismissing
+        // the whole inspector also closes it so re-opening starts clean.
+        zoom_active_ = false;
     }
 }
 
@@ -372,6 +386,16 @@ bool InspectorOverlay::handle_key_event(const KeyEvent& event) {
         return true;
     }
 
+    // Phase 3e — Z toggles the 20× zoom loupe (no modifier; only when
+    // the inspector is active, same guard as the D-key path). D/E/T
+    // are already claimed by drag / eyedropper / panel, so Z is the
+    // natural free letter for "zoom".
+    if (active_ && event.key == KeyCode::z && event.is_down &&
+        event.modifiers == 0) {
+        toggle_zoom();
+        return true;
+    }
+
     return false;
 }
 
@@ -388,6 +412,18 @@ bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
     if (!active_) return false;
 
     auto pos = event.position;
+
+    // Phase 3e — the loupe re-centers on the cursor for EVERY mouse
+    // event (move, press, release) while it's active. We only record
+    // the position here; the actual pixel sample needs the live Canvas
+    // and so happens in paint_zoom_panel(). Recording it for all event
+    // kinds — not just moves — keeps the loupe glued to the cursor
+    // even during a drag-resize gesture. We do NOT consume the event:
+    // the loupe is a passive overlay and other handlers below still
+    // need to see the move/press.
+    if (zoom_active_) {
+        zoom_sample_center_ = pos;
+    }
 
     // ── Phase 3c: eyedropper mode ──────────────────────────────────
     // When the eyedropper is armed it owns canvas-area mouse events:
@@ -709,9 +745,13 @@ void InspectorOverlay::paint(Canvas& canvas) {
     paint_distance_lines(canvas);
     if (selected_) paint_box_model(canvas, selected_);
     paint_panel(canvas);
-    // Phase 3c — eyedropper swatch paints last so it floats above
-    // everything (including the panel) and never under the highlight.
+    // Phase 3c — eyedropper swatch paints above the panel and
+    // highlights so the sampled color is never occluded.
     paint_eyedropper_cursor(canvas);
+    // Phase 3e — the loupe paints LAST so its magnified grid sits on
+    // top of everything (including the props panel and the eyedropper
+    // swatch), like a physical loupe resting on the design surface.
+    if (zoom_active_) paint_zoom_panel(canvas);
 }
 
 void InspectorOverlay::paint_eyedropper_cursor(Canvas& canvas) {
@@ -2196,6 +2236,215 @@ bool InspectorOverlay::handle_edit_key(const KeyEvent& event) {
     }
 
     return false;
+}
+
+// ── Phase 3e — 20× zoom loupe ───────────────────────────────────────────────
+//
+// A digital loupe: a fixed-corner panel showing the pixels under the
+// cursor blown up by `zoom_factor_`, with a center crosshair on the
+// exact sample pixel and a coordinate + hex readout. It pairs with the
+// eyedropper — the eyedropper grabs one pixel, the loupe shows the
+// neighborhood so edge alignment and color boundaries are visible.
+
+void InspectorOverlay::set_zoom_active(bool active) {
+    zoom_active_ = active;
+    if (active) {
+        // Seed the sample center so the first paint has a sane region
+        // even before the cursor moves — the panel center is a safe,
+        // always-on-screen default.
+        zoom_sample_center_ = {root_.bounds().width * 0.5f,
+                               root_.bounds().height * 0.5f};
+    }
+}
+
+void InspectorOverlay::set_zoom_factor(int factor) {
+    zoom_factor_ = std::clamp(factor, kZoomFactorMin, kZoomFactorMax);
+}
+
+// Walk the view tree top-most-first; return the deepest View that both
+// contains `p` AND carries an explicit background color. This is the
+// no-readback fallback: when read_pixels() isn't available we paint the
+// loupe with the resolved authored colors instead of true device pixels.
+bool InspectorOverlay::resolve_view_color_at(Point p, Color& out) const {
+    const View* best = nullptr;
+    std::function<void(const View*)> walk = [&](const View* v) {
+        if (!v) return;
+        auto r = view_bounds_in_root(v);
+        bool inside = p.x >= r.x && p.x < r.x + r.width &&
+                      p.y >= r.y && p.y < r.y + r.height;
+        if (inside && v->has_background_color()) best = v;
+        // Children paint over parents — visiting them after the parent
+        // means a deeper hit overwrites `best`, matching paint order.
+        for (size_t i = 0; i < v->child_count(); ++i) walk(v->child_at(i));
+    };
+    walk(&root_);
+    if (!best) return false;
+    out = best->background_color();
+    return true;
+}
+
+// Refresh zoom_center_color_ for the current sample center. Tries a
+// real pixel readback first (Skia raster only); falls back to resolved
+// view color, and records which path ran in zoom_center_from_readback_
+// so the readout can label degraded samples honestly.
+void InspectorOverlay::update_zoom_sample(Canvas& canvas) {
+    int cx = static_cast<int>(zoom_sample_center_.x);
+    int cy = static_cast<int>(zoom_sample_center_.y);
+
+    std::uint8_t rgba[4] = {0, 0, 0, 0};
+    if (canvas.read_pixels(cx, cy, 1, 1, rgba)) {
+        zoom_center_color_ = Color::rgba(rgba[0] / 255.0f, rgba[1] / 255.0f,
+                                         rgba[2] / 255.0f, rgba[3] / 255.0f);
+        zoom_center_from_readback_ = true;
+        return;
+    }
+    // No pixel readback on this surface (RecordingCanvas, CG fallback,
+    // headless). Degrade gracefully to the authored view color.
+    Color resolved{};
+    if (resolve_view_color_at(zoom_sample_center_, resolved)) {
+        zoom_center_color_ = resolved;
+    } else {
+        zoom_center_color_ = Color::rgba(0, 0, 0, 0);  // nothing under cursor
+    }
+    zoom_center_from_readback_ = false;
+}
+
+void InspectorOverlay::paint_zoom_panel(Canvas& canvas) {
+    // Resolve the center pixel + degradation state for this frame.
+    update_zoom_sample(canvas);
+
+    const int   cells = kZoomGridCells;          // odd → exact center cell
+    const int   half  = cells / 2;
+    const float cell  = static_cast<float>(zoom_factor_);
+    const float grid_px = cell * cells;
+
+    // ── Panel placement: fixed bottom-left corner. Fixed (vs cursor-
+    // following) avoids flicker and never occludes the cursor target;
+    // bottom-left stays clear of the props panel on the right.
+    const float pad = 6.0f;
+    const float panel_w = grid_px + pad * 2.0f;
+    const float panel_h = grid_px + pad * 2.0f + kZoomReadoutH;
+    const float panel_x = kZoomPanelMargin;
+    const float panel_y = root_.bounds().height - panel_h - kZoomPanelMargin;
+    const float grid_x  = panel_x + pad;
+    const float grid_y  = panel_y + pad;
+
+    canvas.save();
+
+    // Panel background + border.
+    canvas.set_fill_color(kZoomPanelBg);
+    canvas.fill_rect(panel_x, panel_y, panel_w, panel_h);
+    canvas.set_stroke_color(kZoomBorder);
+    canvas.set_line_width(1.5f);
+    canvas.stroke_rect(panel_x, panel_y, panel_w, panel_h);
+
+    // ── Magnified pixel grid ────────────────────────────────────────
+    // Each cell maps to one source pixel offset (dx, dy) from the
+    // sample center. With a real readback we ask the canvas for the
+    // whole NxN block at once; otherwise we synthesize a checkerboard
+    // (with the resolved center color in the middle) so the loupe
+    // still communicates "this is where you're sampling".
+    const int   ox = static_cast<int>(zoom_sample_center_.x) - half;
+    const int   oy = static_cast<int>(zoom_sample_center_.y) - half;
+
+    std::vector<std::uint8_t> block(static_cast<size_t>(cells) * cells * 4, 0);
+    const bool have_block = canvas.read_pixels(ox, oy, cells, cells,
+                                               block.data());
+
+    for (int gy = 0; gy < cells; ++gy) {
+        for (int gx = 0; gx < cells; ++gx) {
+            Color c;
+            if (have_block) {
+                const size_t i = (static_cast<size_t>(gy) * cells + gx) * 4;
+                c = Color::rgba(block[i] / 255.0f, block[i + 1] / 255.0f,
+                                block[i + 2] / 255.0f, block[i + 3] / 255.0f);
+            } else if (gx == half && gy == half) {
+                // Center cell shows the resolved sample color even on
+                // the fallback path so the readout and grid agree.
+                c = zoom_center_color_;
+            } else {
+                c = ((gx + gy) & 1) ? kZoomCheckerB : kZoomCheckerA;
+            }
+            canvas.set_fill_color(c);
+            canvas.fill_rect(grid_x + gx * cell, grid_y + gy * cell,
+                             cell, cell);
+        }
+    }
+
+    // ── Pixel grid lines ────────────────────────────────────────────
+    // Thin lines between magnified pixels so individual pixels read as
+    // discrete cells, like Photoshop's pixel-grid at high zoom.
+    canvas.set_stroke_color(kZoomGridLine);
+    canvas.set_line_width(1.0f);
+    for (int i = 0; i <= cells; ++i) {
+        const float gx = grid_x + i * cell;
+        const float gyl = grid_y + i * cell;
+        canvas.stroke_line(gx, grid_y, gx, grid_y + grid_px);
+        canvas.stroke_line(grid_x, gyl, grid_x + grid_px, gyl);
+    }
+
+    // ── Center crosshair / target ───────────────────────────────────
+    // Outlines the exact sample pixel — the cell the readout describes.
+    const float center_x = grid_x + half * cell;
+    const float center_y = grid_y + half * cell;
+    canvas.set_stroke_color(kZoomCrosshair);
+    canvas.set_line_width(2.0f);
+    canvas.stroke_rect(center_x, center_y, cell, cell);
+    // Crosshair arms reaching from the grid edges toward the center
+    // cell, so the eye is guided to the sample pixel.
+    const float cxm = center_x + cell * 0.5f;
+    const float cym = center_y + cell * 0.5f;
+    canvas.set_line_width(1.0f);
+    canvas.stroke_line(grid_x, cym, center_x, cym);
+    canvas.stroke_line(center_x + cell, cym, grid_x + grid_px, cym);
+    canvas.stroke_line(cxm, grid_y, cxm, center_y);
+    canvas.stroke_line(cxm, center_y + cell, cxm, grid_y + grid_px);
+
+    // ── Coordinate + hex readout strip ──────────────────────────────
+    const float readout_y = grid_y + grid_px + 2.0f;
+    canvas.set_font("monospace", 10.0f);
+
+    const int sx = static_cast<int>(zoom_sample_center_.x);
+    const int sy = static_cast<int>(zoom_sample_center_.y);
+    std::ostringstream coord;
+    coord << zoom_factor_ << "x  (" << sx << ", " << sy << ")";
+    canvas.set_fill_color(kZoomReadoutText);
+    canvas.fill_text(coord.str(), grid_x, readout_y + 12.0f);
+
+    // Hex color readout — #RRGGBB plus an alpha byte when not opaque.
+    auto to_byte = [](float v) {
+        return static_cast<int>(std::lround(std::clamp(v, 0.0f, 1.0f) * 255.0f));
+    };
+    const int hr = to_byte(zoom_center_color_.r);
+    const int hg = to_byte(zoom_center_color_.g);
+    const int hb = to_byte(zoom_center_color_.b);
+    const int ha = to_byte(zoom_center_color_.a);
+    std::ostringstream hex;
+    hex << '#' << std::hex << std::uppercase << std::setfill('0')
+        << std::setw(2) << hr << std::setw(2) << hg << std::setw(2) << hb;
+    if (ha != 255) hex << std::setw(2) << ha;
+
+    // Color swatch + hex text on the second readout line.
+    const float swatch = 10.0f;
+    const float swatch_y = readout_y + 16.0f;
+    canvas.set_fill_color(zoom_center_color_);
+    canvas.fill_rect(grid_x, swatch_y, swatch, swatch);
+    canvas.set_stroke_color(kZoomReadoutDim);
+    canvas.set_line_width(1.0f);
+    canvas.stroke_rect(grid_x, swatch_y, swatch, swatch);
+    canvas.set_fill_color(kZoomReadoutText);
+    canvas.fill_text(hex.str(), grid_x + swatch + 6.0f, swatch_y + 9.0f);
+
+    // Honesty label: tell the user when the grid is a fallback render
+    // rather than true device pixels, so they don't trust a checker
+    // pattern as real output.
+    if (!zoom_center_from_readback_) {
+        canvas.set_fill_color(kZoomReadoutDim);
+        canvas.fill_text("no readback", grid_x + grid_px - 64.0f,
+                         swatch_y + 9.0f);
+    }
+
+    canvas.restore();
 }
 
 } // namespace pulp::inspect

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -2288,8 +2288,20 @@ bool InspectorOverlay::resolve_view_color_at(Point p, Color& out) const {
 // view color, and records which path ran in zoom_center_from_readback_
 // so the readout can label degraded samples honestly.
 void InspectorOverlay::update_zoom_sample(Canvas& canvas) {
+    // The overlay paints onto a surface sized to the root view, so the
+    // root bounds are the readback clamp limits. Clamp the sample pixel
+    // into [0, w-1] × [0, h-1] — a raw read at an off-canvas coord (the
+    // cursor sitting on the very edge) fails outright, which would push
+    // the readout onto the degraded fallback path even on a readback-
+    // capable surface. Clamping keeps the center readout honest about
+    // readback at edges, and keeps it consistent with the block read in
+    // paint_zoom_panel() (which clamps to the same bounds).
+    const int cw = static_cast<int>(root_.bounds().width);
+    const int ch = static_cast<int>(root_.bounds().height);
     int cx = static_cast<int>(zoom_sample_center_.x);
     int cy = static_cast<int>(zoom_sample_center_.y);
+    if (cw > 0) cx = std::clamp(cx, 0, cw - 1);
+    if (ch > 0) cy = std::clamp(cy, 0, ch - 1);
 
     std::uint8_t rgba[4] = {0, 0, 0, 0};
     if (canvas.read_pixels(cx, cy, 1, 1, rgba)) {
@@ -2339,13 +2351,39 @@ void InspectorOverlay::paint_zoom_panel(Canvas& canvas) {
     canvas.stroke_rect(panel_x, panel_y, panel_w, panel_h);
 
     // ── Magnified pixel grid ────────────────────────────────────────
-    // Each cell maps to one source pixel offset (dx, dy) from the
-    // sample center. With a real readback we ask the canvas for the
-    // whole NxN block at once; otherwise we synthesize a checkerboard
-    // (with the resolved center color in the middle) so the loupe
-    // still communicates "this is where you're sampling".
-    const int   ox = static_cast<int>(zoom_sample_center_.x) - half;
-    const int   oy = static_cast<int>(zoom_sample_center_.y) - half;
+    // Each cell maps to one source pixel. With a real readback we ask
+    // the canvas for the whole NxN block at once; otherwise we
+    // synthesize a checkerboard (with the resolved center color in the
+    // middle) so the loupe still communicates "this is where you're
+    // sampling".
+    //
+    // Edge clamping (codex P2 #2464): a window centered on a cursor
+    // within `half` pixels of any canvas edge would put `ox`/`oy`
+    // negative or push `ox+cells`/`oy+cells` past the surface — Skia's
+    // readPixels() rejects an out-of-bounds source rect outright, so
+    // the WHOLE block dropped to checkerboard exactly where pixel
+    // inspection matters most. Clamp the read origin so the full
+    // `cells × cells` window stays in-bounds; the magnified region
+    // shifts slightly near edges but still shows real device pixels.
+    // The sample pixel may then sit off-center within the grid, so the
+    // crosshair below tracks its actual cell (cross_gx/cross_gy)
+    // instead of assuming the middle.
+    const int   cw = static_cast<int>(root_.bounds().width);
+    const int   ch = static_cast<int>(root_.bounds().height);
+    int ox = static_cast<int>(zoom_sample_center_.x) - half;
+    int oy = static_cast<int>(zoom_sample_center_.y) - half;
+    if (cw >= cells) ox = std::clamp(ox, 0, cw - cells);
+    if (ch >= cells) oy = std::clamp(oy, 0, ch - cells);
+
+    // The sample pixel's cell within the (possibly clamped) grid. When
+    // the window isn't clamped this is the exact center (half, half);
+    // near an edge it shifts toward the edge the cursor approached.
+    int sample_px = std::clamp(static_cast<int>(zoom_sample_center_.x),
+                               0, cw > 0 ? cw - 1 : 0);
+    int sample_py = std::clamp(static_cast<int>(zoom_sample_center_.y),
+                               0, ch > 0 ? ch - 1 : 0);
+    const int cross_gx = std::clamp(sample_px - ox, 0, cells - 1);
+    const int cross_gy = std::clamp(sample_py - oy, 0, cells - 1);
 
     std::vector<std::uint8_t> block(static_cast<size_t>(cells) * cells * 4, 0);
     const bool have_block = canvas.read_pixels(ox, oy, cells, cells,
@@ -2358,9 +2396,11 @@ void InspectorOverlay::paint_zoom_panel(Canvas& canvas) {
                 const size_t i = (static_cast<size_t>(gy) * cells + gx) * 4;
                 c = Color::rgba(block[i] / 255.0f, block[i + 1] / 255.0f,
                                 block[i + 2] / 255.0f, block[i + 3] / 255.0f);
-            } else if (gx == half && gy == half) {
-                // Center cell shows the resolved sample color even on
-                // the fallback path so the readout and grid agree.
+            } else if (gx == cross_gx && gy == cross_gy) {
+                // Center (sample) cell shows the resolved sample color
+                // even on the fallback path so the readout and grid
+                // agree — and so they agree about WHICH cell is the
+                // sample pixel when the window is edge-clamped.
                 c = zoom_center_color_;
             } else {
                 c = ((gx + gy) & 1) ? kZoomCheckerB : kZoomCheckerA;
@@ -2385,8 +2425,10 @@ void InspectorOverlay::paint_zoom_panel(Canvas& canvas) {
 
     // ── Center crosshair / target ───────────────────────────────────
     // Outlines the exact sample pixel — the cell the readout describes.
-    const float center_x = grid_x + half * cell;
-    const float center_y = grid_y + half * cell;
+    // Uses cross_gx/cross_gy (not `half`) so the crosshair still marks
+    // the true sample pixel when the read window was edge-clamped.
+    const float center_x = grid_x + cross_gx * cell;
+    const float center_y = grid_y + cross_gy * cell;
     canvas.set_stroke_color(kZoomCrosshair);
     canvas.set_line_width(2.0f);
     canvas.stroke_rect(center_x, center_y, cell, cell);
@@ -2435,10 +2477,16 @@ void InspectorOverlay::paint_zoom_panel(Canvas& canvas) {
     canvas.set_fill_color(kZoomReadoutText);
     canvas.fill_text(hex.str(), grid_x + swatch + 6.0f, swatch_y + 9.0f);
 
-    // Honesty label: tell the user when the grid is a fallback render
-    // rather than true device pixels, so they don't trust a checker
-    // pattern as real output.
-    if (!zoom_center_from_readback_) {
+    // Honesty label: tell the user when the magnified grid is a
+    // fallback render rather than true device pixels, so they don't
+    // trust a checker pattern as real output. Keyed off `have_block`
+    // (the grid's actual readback result) rather than just the center
+    // pixel's `zoom_center_from_readback_` — with edge clamping the
+    // two now agree on any normal surface, but on a degenerate canvas
+    // narrower than the grid the 1×1 center read can still succeed
+    // while the cells×cells block cannot, and the label must describe
+    // the grid the user is looking at.
+    if (!have_block) {
         canvas.set_fill_color(kZoomReadoutDim);
         canvas.fill_text("no readback", grid_x + grid_px - 64.0f,
                          swatch_y + 9.0f);

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <pulp/inspect/inspector_window.hpp>
 #include <pulp/view/inspector.hpp>
@@ -483,6 +484,185 @@ TEST_CASE("InspectorOverlay: Alt-hover target clears when cursor enters panel "
     pulp::canvas::RecordingCanvas after_panel_entry;
     overlay.paint(after_panel_entry);
     REQUIRE(after_panel_entry.command_count() < with_line_count);
+}
+
+// ── Phase 3e — 20× zoom loupe ─────────────────────────────────────────────
+//
+// The loupe is a magnified-pixel preview panel toggled with the Z key.
+// It samples the region under the cursor (via Canvas::read_pixels() when
+// available, else a graceful resolved-color fallback) and renders a
+// magnified grid + center crosshair + coordinate / hex readout. These
+// tests exercise it through the headless RecordingCanvas — which does
+// NOT implement read_pixels(), so they all run the fallback path.
+
+TEST_CASE("InspectorOverlay: Z toggles the zoom loupe on and off",
+          "[inspect][overlay][phase3e]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    REQUIRE_FALSE(overlay.zoom_active());
+
+    KeyEvent z;
+    z.key = KeyCode::z;
+    z.is_down = true;
+    z.modifiers = 0;
+    REQUIRE(overlay.handle_key_event(z));
+    REQUIRE(overlay.zoom_active());
+
+    // Toggle back off.
+    REQUIRE(overlay.handle_key_event(z));
+    REQUIRE_FALSE(overlay.zoom_active());
+
+    // Z does nothing when the inspector itself is inactive.
+    overlay.set_active(false);
+    REQUIRE_FALSE(overlay.handle_key_event(z));
+    REQUIRE_FALSE(overlay.zoom_active());
+}
+
+TEST_CASE("InspectorOverlay: dismissing the inspector closes the loupe",
+          "[inspect][overlay][phase3e]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_zoom_active(true);
+    REQUIRE(overlay.zoom_active());
+
+    // set_active(false) should reset the transient loupe state.
+    overlay.set_active(false);
+    REQUIRE_FALSE(overlay.zoom_active());
+}
+
+TEST_CASE("InspectorOverlay: zoom panel renders extra commands when active",
+          "[inspect][overlay][phase3e]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    // Baseline: loupe OFF.
+    pulp::canvas::RecordingCanvas baseline;
+    overlay.paint(baseline);
+    auto baseline_count = baseline.command_count();
+    REQUIRE(baseline_count > 0);
+
+    // Loupe ON → paint_zoom_panel() draws the panel, the magnified
+    // grid, grid lines, the crosshair, and the readout — strictly more
+    // commands than the baseline.
+    overlay.set_zoom_active(true);
+    pulp::canvas::RecordingCanvas with_loupe;
+    overlay.paint(with_loupe);
+    REQUIRE(with_loupe.command_count() > baseline_count);
+
+    // The grid is an N×N block of filled cells, so the loupe alone
+    // contributes well over a hundred fill_rect commands.
+    auto fills = with_loupe.count(
+        pulp::canvas::DrawCommand::Type::fill_rect);
+    REQUIRE(fills > 100);
+}
+
+TEST_CASE("InspectorOverlay: loupe readout reflects the hovered position",
+          "[inspect][overlay][phase3e]") {
+    // Wide root so the test cursor positions land in the canvas area
+    // (left of the 300px-wide props panel that hugs the right edge).
+    View root;
+    root.set_bounds({0, 0, 900, 400});
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_zoom_active(true);
+
+    // Move the cursor over the canvas — the loupe records the sample
+    // center on every mouse event while active, without consuming a
+    // plain hover.
+    MouseEvent move;
+    move.position = {137, 92};
+    move.is_down = false;
+    REQUIRE_FALSE(overlay.handle_mouse_event(move));
+
+    auto center = overlay.zoom_sample_center();
+    REQUIRE(center.x == Catch::Approx(137.0f));
+    REQUIRE(center.y == Catch::Approx(92.0f));
+
+    // A second move re-centers the loupe.
+    MouseEvent move2;
+    move2.position = {210, 40};
+    move2.is_down = false;
+    overlay.handle_mouse_event(move2);
+    REQUIRE(overlay.zoom_sample_center().x == Catch::Approx(210.0f));
+    REQUIRE(overlay.zoom_sample_center().y == Catch::Approx(40.0f));
+
+    // The loupe also tracks the cursor when it's over the props panel
+    // (panel hover events ARE consumed, but the loupe still records).
+    MouseEvent panel_move;
+    panel_move.position = {700, 50};  // x >= 900-300 → inside panel
+    panel_move.is_down = false;
+    overlay.handle_mouse_event(panel_move);
+    REQUIRE(overlay.zoom_sample_center().x == Catch::Approx(700.0f));
+}
+
+TEST_CASE("InspectorOverlay: loupe falls back to resolved view color",
+          "[inspect][overlay][phase3e]") {
+    // RecordingCanvas has no read_pixels() — exercises the graceful
+    // no-readback path. With a background-colored view under the
+    // cursor, the center-pixel readout should resolve to that color.
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+
+    auto panel = std::make_unique<View>();
+    panel->set_bounds({50, 50, 200, 150});
+    const Color kPanelColor = Color::rgba(0.2f, 0.6f, 0.9f, 1.0f);
+    panel->set_background_color(kPanelColor);
+    root.add_child(std::move(panel));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_zoom_active(true);
+
+    // Cursor inside the colored panel.
+    MouseEvent inside;
+    inside.position = {120, 110};
+    inside.is_down = false;
+    overlay.handle_mouse_event(inside);
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);  // update_zoom_sample() runs inside paint()
+
+    auto c = overlay.zoom_center_color();
+    REQUIRE(c.r == Catch::Approx(kPanelColor.r));
+    REQUIRE(c.g == Catch::Approx(kPanelColor.g));
+    REQUIRE(c.b == Catch::Approx(kPanelColor.b));
+
+    // Cursor outside any background-bearing view → fully transparent.
+    MouseEvent outside;
+    outside.position = {10, 10};
+    outside.is_down = false;
+    overlay.handle_mouse_event(outside);
+    overlay.paint(canvas);
+    REQUIRE(overlay.zoom_center_color().a == Catch::Approx(0.0f));
+}
+
+TEST_CASE("InspectorOverlay: zoom factor is clamped to a sane range",
+          "[inspect][overlay][phase3e]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+
+    InspectorOverlay overlay(root);
+    REQUIRE(overlay.zoom_factor() == 20);  // roadmap default
+
+    overlay.set_zoom_factor(8);
+    REQUIRE(overlay.zoom_factor() == 8);
+
+    // Out-of-range requests clamp rather than degenerate the grid.
+    overlay.set_zoom_factor(1);
+    REQUIRE(overlay.zoom_factor() >= 4);
+
+    overlay.set_zoom_factor(1000);
+    REQUIRE(overlay.zoom_factor() <= 40);
 }
 
 // ── Phase 0b PR-C-1: gesture-tweak emission via TweakStore ────────────────

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -6,6 +6,7 @@
 #include <pulp/view/widgets.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <string_view>
 #include <tuple>
@@ -45,6 +46,52 @@ bool has_label_containing(View& root, std::string_view text) {
     }
     return false;
 }
+
+// A RecordingCanvas that also serves real pixel readback over a small
+// synthetic surface — lets phase-3e tests exercise the loupe's
+// readback path (which the plain RecordingCanvas never does) and
+// assert the read rect that the loupe actually requested.
+class ReadbackCanvas : public pulp::canvas::RecordingCanvas {
+public:
+    ReadbackCanvas(int w, int h) : surface_w_(w), surface_h_(h) {}
+
+    bool read_pixels(int x, int y, int width, int height,
+                     std::uint8_t* out) override {
+        // Mirror Skia's SkSurface::readPixels() contract: the source
+        // rect must lie fully within the surface or the read fails.
+        if (!out || width <= 0 || height <= 0) return false;
+        if (x < 0 || y < 0 ||
+            x + width > surface_w_ || y + height > surface_h_) {
+            return false;
+        }
+        last_read_x_ = x;
+        last_read_y_ = y;
+        last_read_w_ = width;
+        last_read_h_ = height;
+        ++read_count_;
+        // Fill with a deterministic non-checkerboard color so callers
+        // can tell "real readback" from the loupe's fallback render.
+        for (int i = 0; i < width * height; ++i) {
+            out[i * 4 + 0] = 64;
+            out[i * 4 + 1] = 128;
+            out[i * 4 + 2] = 192;
+            out[i * 4 + 3] = 255;
+        }
+        return true;
+    }
+
+    int  last_read_x() const { return last_read_x_; }
+    int  last_read_y() const { return last_read_y_; }
+    int  last_read_w() const { return last_read_w_; }
+    int  last_read_h() const { return last_read_h_; }
+    int  read_count()  const { return read_count_; }
+
+private:
+    int surface_w_, surface_h_;
+    int last_read_x_ = -1, last_read_y_ = -1;
+    int last_read_w_ = -1, last_read_h_ = -1;
+    int read_count_ = 0;
+};
 
 } // namespace
 
@@ -663,6 +710,91 @@ TEST_CASE("InspectorOverlay: zoom factor is clamped to a sane range",
 
     overlay.set_zoom_factor(1000);
     REQUIRE(overlay.zoom_factor() <= 40);
+}
+
+TEST_CASE("InspectorOverlay: loupe clamps the sample window at canvas edges",
+          "[inspect][overlay][phase3e]") {
+    // codex P2 #2464 — a loupe centered within kZoomGridCells/2 pixels
+    // of a canvas edge used to push the cells×cells read rect
+    // out of bounds, so read_pixels() rejected the WHOLE block and the
+    // grid fell back to checkerboard exactly where edge inspection
+    // matters most. With clamping the read rect stays in-bounds and the
+    // grid keeps showing real device pixels.
+    const int kW = 400, kH = 300;
+    View root;
+    root.set_bounds({0, 0, static_cast<float>(kW),
+                     static_cast<float>(kH)});
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_zoom_active(true);
+
+    // Park the loupe on the exact top-left corner — the worst case:
+    // an unclamped window would read from (-5, -5).
+    MouseEvent corner;
+    corner.position = {0, 0};
+    corner.is_down = false;
+    overlay.handle_mouse_event(corner);
+
+    ReadbackCanvas canvas(kW, kH);
+    overlay.paint(canvas);
+
+    // The loupe must have issued a block read AND it must have
+    // succeeded — i.e. the requested rect was clamped fully in-bounds.
+    REQUIRE(canvas.read_count() >= 1);
+    REQUIRE(canvas.last_read_x() >= 0);
+    REQUIRE(canvas.last_read_y() >= 0);
+    REQUIRE(canvas.last_read_x() + canvas.last_read_w() <= kW);
+    REQUIRE(canvas.last_read_y() + canvas.last_read_h() <= kH);
+
+    // The center-pixel readout must agree with the block: a real
+    // readback succeeded, so the readout reports the synthetic
+    // readback color (64,128,192) — not the degraded fallback path.
+    auto c = overlay.zoom_center_color();
+    REQUIRE(c.r == Catch::Approx(64.0f / 255.0f));
+    REQUIRE(c.g == Catch::Approx(128.0f / 255.0f));
+    REQUIRE(c.b == Catch::Approx(192.0f / 255.0f));
+
+    // The magnified grid is painted with the synthetic readback color
+    // (it is NOT a checkerboard). The loupe draws kZoomGridCells² grid
+    // cells; all of them should carry the real readback color, proving
+    // the whole block — corner included — used real pixels.
+    int readback_cells = 0;
+    const Color kReadback =
+        Color::rgba(64.0f / 255.0f, 128.0f / 255.0f, 192.0f / 255.0f, 1.0f);
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type != pulp::canvas::DrawCommand::Type::set_fill_color)
+            continue;
+        if (cmd.color.r == Catch::Approx(kReadback.r) &&
+            cmd.color.g == Catch::Approx(kReadback.g) &&
+            cmd.color.b == Catch::Approx(kReadback.b)) {
+            ++readback_cells;
+        }
+    }
+    // 11×11 = 121 cells, all real-readback colored. Allow a generous
+    // floor — the point is "many real cells", not "exactly zero
+    // checkerboard" (panel chrome uses other colors).
+    REQUIRE(readback_cells >= 100);
+
+    // Bottom-right corner is the symmetric worst case: an unclamped
+    // window would read past the surface.
+    MouseEvent br;
+    br.position = {static_cast<float>(kW), static_cast<float>(kH)};
+    br.is_down = false;
+    overlay.handle_mouse_event(br);
+
+    ReadbackCanvas canvas2(kW, kH);
+    overlay.paint(canvas2);
+    REQUIRE(canvas2.read_count() >= 1);
+    REQUIRE(canvas2.last_read_x() >= 0);
+    REQUIRE(canvas2.last_read_y() >= 0);
+    REQUIRE(canvas2.last_read_x() + canvas2.last_read_w() <= kW);
+    REQUIRE(canvas2.last_read_y() + canvas2.last_read_h() <= kH);
+
+    auto c2 = overlay.zoom_center_color();
+    REQUIRE(c2.r == Catch::Approx(64.0f / 255.0f));
+    REQUIRE(c2.g == Catch::Approx(128.0f / 255.0f));
+    REQUIRE(c2.b == Catch::Approx(192.0f / 255.0f));
 }
 
 // ── Phase 0b PR-C-1: gesture-tweak emission via TweakStore ────────────────


### PR DESCRIPTION
Adds a magnified-pixel preview panel ("loupe") to the inspector
overlay, completing the Phase 3e item of the direct-manipulation
roadmap. The loupe shows the region under the cursor blown up by a
configurable factor (20x default), with a center crosshair marking
the exact sample pixel and a coordinate + hex color readout — it
pairs with the eyedropper, which grabs a single pixel, by showing
the surrounding neighborhood for edge alignment and color-boundary
work.

- Z-key toggles the loupe (D/E/T already claimed by drag/eyedropper/
  panel); only fires while the inspector is active.
- Mouse-move re-centers the sampled region on the cursor for every
  event kind without consuming it — the loupe is a passive overlay.
- paint_zoom_panel() draws a fixed bottom-left panel: an N x N grid
  of magnified pixels, per-pixel grid lines, a center crosshair, and
  a coordinate + hex + swatch readout strip.
- Pixel source mirrors the eyedropper's dual path: Canvas::read_pixels()
  on Skia raster surfaces, graceful degradation to the resolved view
  background color (with an honest "no readback" label) on CG-fallback
  or headless surfaces.
- Dismissing the inspector resets the transient loupe state.

Tests (test/test_inspector.cpp, tagged [phase3e]): Z toggle on/off +
inspector-inactive guard, inspector-dismiss closes the loupe, panel
renders extra draw commands when active, readout tracks the hovered
position, fallback resolves the view background color, and zoom
factor clamping. 6 cases, 26 assertions; full inspector suite 85
cases green.

Version-Bump: skip reason="inspect/* is dev-tooling overlay, not SDK public API surface"