### PR TITLE
feat(inspect): Phase 5.1 source-jump foundation — open editor at JSX file:line

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -384,6 +384,33 @@ Native-mode codegen does NOT yet emit `setAnchor` (small follow-up;
 the native codegen has many early-return branches that need each to
 be wired). Web-compat is the default mode for imports — covered.
 
+**Phase 5.1 — `setSource()` source-jump wiring:** alongside `setAnchor`,
+the `@pulp/react` reconciler now forwards React's dev-mode `__source`
+prop ({fileName, lineNumber, columnNumber}) through a `setSource(id,
+file, line, col)` bridge call (`materializeUnder` →
+`bindSourceLocation` in `packages/pulp-react/src/host-config.ts`). This
+lands a `View::SourceLocation` on the live widget so the inspector's
+`J` hotkey / `Inspector.jumpToSource` protocol method can open the
+authoring JSX file:line in the user's editor. Gotchas:
+
+- **`__source` is Babel-classic / automatic-dev-runtime only.** esbuild's
+  `jsx: 'transform'` mode (current `jsx-transform.mjs` setting) does
+  **not** inline `__source` props — only Babel's
+  `@babel/plugin-transform-react-jsx-development` or esbuild's
+  `jsx: 'automatic'` + `jsxDev: true` do. So today `bindSourceLocation`
+  is a silent no-op for transform-mode bundles; it activates the moment
+  the JSX runtime emits `__source`. Migrating `jsx-transform.mjs` to the
+  automatic dev runtime is the remaining Phase 5.1 follow-up — do it as
+  a deliberate, separately-validated change because it shifts
+  `jsxFactory` semantics across every existing import fixture.
+- **Source maps gate behind `PULP_JSX_SOURCEMAP=1`.** `jsx-transform.mjs`
+  emits an inline source map only when that env var is set — off by
+  default to keep production bundles lean (~10-30% size add). It is
+  independent of the `__source` prop path.
+- **`setSource` no-ops on an empty file path and unknown widget id** —
+  same tolerance as `setAnchor`. A custom codegen / shim that wants
+  source-jump must pass the same bridge-keyed `_id` as `setAnchor`.
+
 ### Phase 1 — Tweaks persistence (`pulp-tweaks.json`)
 
 `TweakStore` (`inspect/include/pulp/inspect/tweak_store.hpp`) now reads

--- a/core/view/include/pulp/view/inspector.hpp
+++ b/core/view/include/pulp/view/inspector.hpp
@@ -19,6 +19,12 @@ public:
     // Find a view by ID in the tree
     static View* find_by_id(View& root, const std::string& id);
 
+    // Find a view by its design-import anchor id (Phase 0b
+    // `set_anchor_id`). Returns nullptr for an empty anchor or when no
+    // view in the tree carries it. Used by the inspector's source-jump
+    // resolver (Phase 5.1) to map an anchor back to a live View*.
+    static View* find_by_anchor(View& root, const std::string& anchor);
+
     // Count total views in the tree
     static size_t count_views(const View& root);
 

--- a/core/view/include/pulp/view/view.hpp
+++ b/core/view/include/pulp/view/view.hpp
@@ -358,6 +358,34 @@ public:
     void set_anchor_id(std::string anchor) { anchor_id_ = std::move(anchor); }
     const std::string& anchor_id() const { return anchor_id_; }
 
+    /// Phase 5.1 (inspector source-jump): authored-source location for
+    /// this view. Populated from React's `__source` prop (file name +
+    /// line + column) by the JS bridge's `setSource()` call when the
+    /// view was created by the `@pulp/react` reconciler from a JSX
+    /// element. Empty for user-authored / non-imported views.
+    ///
+    /// `line` / `col` are 1-based when present, mirroring the editor
+    /// URI convention; `0` means "not recorded". The inspector reads
+    /// this to open the user's editor at the originating file:line via
+    /// `Inspector.jumpToSource`.
+    struct SourceLocation {
+        std::string file;   ///< Source file path (as authored).
+        int line = 0;       ///< 1-based line; 0 = unknown.
+        int col = 0;        ///< 1-based column; 0 = unknown.
+
+        bool valid() const { return !file.empty(); }
+    };
+
+    void set_source_loc(SourceLocation loc) { source_loc_ = std::move(loc); }
+    void clear_source_loc() { source_loc_.reset(); }
+    bool has_source_loc() const { return source_loc_.has_value(); }
+    /// Returns the recorded source location, or an empty (`!valid()`)
+    /// SourceLocation when none has been set.
+    const SourceLocation& source_loc() const {
+        static const SourceLocation kEmpty{};
+        return source_loc_ ? *source_loc_ : kEmpty;
+    }
+
     // ── Visual properties (CSS Box Model) ────────────────────────────────
 
     /// Opacity (0.0 = transparent, 1.0 = opaque). Applied as layer alpha.
@@ -1282,6 +1310,9 @@ private:
     // Phase 0b: design-import anchor identity. Empty for views not
     // constructed from an imported tree. See set_anchor_id().
     std::string anchor_id_;
+    // Phase 5.1: authored-source location (JSX file:line:col) from the
+    // React reconciler's `__source` prop. Unset for non-imported views.
+    std::optional<SourceLocation> source_loc_;
     // Phase 3d (inspector roadmap): last-paint-cycle timing. Both 0
     // until paint_all() has executed at least once.
     std::uint32_t last_paint_self_ns_ = 0;

--- a/core/view/src/inspector.cpp
+++ b/core/view/src/inspector.cpp
@@ -74,6 +74,19 @@ View* ViewInspector::find_by_id(View& root, const std::string& id) {
     return nullptr;
 }
 
+View* ViewInspector::find_by_anchor(View& root, const std::string& anchor) {
+    // An empty anchor never matches — views without a design-import
+    // anchor leave anchor_id() empty, and "" should not resolve to the
+    // first such view. The inspector's source-jump path relies on this.
+    if (anchor.empty()) return nullptr;
+    if (root.anchor_id() == anchor) return &root;
+    for (size_t i = 0; i < root.child_count(); ++i) {
+        if (auto* found = find_by_anchor(*root.child_at(i), anchor))
+            return found;
+    }
+    return nullptr;
+}
+
 size_t ViewInspector::count_views(const View& root) {
     size_t count = 1;
     for (size_t i = 0; i < root.child_count(); ++i)

--- a/core/view/src/widget_bridge.cpp
+++ b/core/view/src/widget_bridge.cpp
@@ -3441,6 +3441,25 @@ void WidgetBridge::register_api() {
         return choc::value::Value();
     });
 
+    // Phase 5.1 (inspector source-jump): bind the authored-source
+    // location for a widget. The `@pulp/react` reconciler reads React's
+    // `__source` prop ({fileName, lineNumber, columnNumber}) inside
+    // `createInstance` and forwards it here. The inspector later reads
+    // this back via `Inspector.jumpToSource` to open the user's editor
+    // at the originating JSX file:line. Silent no-op on unknown widget
+    // id and on an empty file path — matches setAnchor's tolerance for
+    // unmounted ids and views authored outside the JSX path.
+    engine_.register_function("setSource", [this](choc::javascript::ArgumentList args) {
+        auto id = args.get<std::string>(0, "");
+        auto file = args.get<std::string>(1, "");
+        auto line = static_cast<int>(args.get<double>(2, 0.0));
+        auto col = static_cast<int>(args.get<double>(3, 0.0));
+        if (file.empty()) return choc::value::Value();
+        if (auto* v = widget(id))
+            v->set_source_loc({std::move(file), line, col});
+        return choc::value::Value();
+    });
+
     // setStyle — placeholder until KnobStyle/ToggleStyle enums added to main widgets
     engine_.register_function("setStyle", [](choc::javascript::ArgumentList) {
         return choc::value::Value();

--- a/inspect/CMakeLists.txt
+++ b/inspect/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(pulp-inspect PRIVATE
     src/audio_inspector.cpp
     src/domain_handler.cpp
     src/editor_url.cpp
+    src/source_jump.cpp
     src/motion_inspector.cpp
     src/motion_scrubber.cpp
     src/tweak_store.cpp

--- a/inspect/include/pulp/inspect/domain_handler.hpp
+++ b/inspect/include/pulp/inspect/domain_handler.hpp
@@ -26,7 +26,11 @@ public:
 
     // ── Data sources (all optional) ─────────────────────────────────
     void set_root_view(view::View* root) { root_ = root; }
-    void set_overlay(InspectorOverlay* overlay) { overlay_ = overlay; }
+    /// Attach the overlay. Phase 5.1: also seeds the overlay's
+    /// source-jump config with the handler's current config so the `J`
+    /// hotkey matches `Inspector.jumpToSource`. Out-of-line for the
+    /// same reason as set_config().
+    void set_overlay(InspectorOverlay* overlay);
     void set_state_inspector(StateInspector* state) { state_ = state; }
     void set_console_capture(ConsoleCapture* console) { console_ = console; }
     void set_audio_inspector(AudioInspector* audio) { audio_ = audio; }
@@ -44,8 +48,11 @@ public:
     // ── Inspector-wide config ───────────────────────────────────────
     /// Replace the runtime config (Phase 5.3: editor_url_template).
     /// Mutating accessors below (e.g. Inspector.setEditorUrlTemplate)
-    /// update this in place.
-    void set_config(InspectorConfig config) { config_ = std::move(config); }
+    /// update this in place. Phase 5.1: also pushes the config to the
+    /// attached overlay (if any) so the `J` source-jump hotkey and the
+    /// protocol `Inspector.jumpToSource` share one template. Defined
+    /// out-of-line so the header doesn't need the overlay's definition.
+    void set_config(InspectorConfig config);
     const InspectorConfig& config() const { return config_; }
     InspectorConfig& mutable_config() { return config_; }
 

--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -6,6 +6,8 @@
 #include <pulp/view/view.hpp>
 #include <pulp/view/input_events.hpp>
 #include <pulp/canvas/canvas.hpp>
+#include <pulp/inspect/editor_url.hpp>
+#include <pulp/inspect/source_jump.hpp>
 
 #include <choc/containers/choc_Value.h>
 
@@ -150,6 +152,22 @@ public:
     // ── Selection ───────────────────────────────────────────────────
     View* selected_view() const { return selected_; }
     View* hovered_view() const { return hovered_; }
+
+    // ── Phase 5.1 — source-jump ─────────────────────────────────────
+    /// The editor-URL config used to format source-jump URLs. The host
+    /// sets this once (mirroring the DomainHandler's config); the `J`
+    /// hotkey and `jump_to_selection_source()` read it. Defaults to the
+    /// built-in VS Code template — see pulp/inspect/editor_url.hpp.
+    void set_config(InspectorConfig config) { config_ = std::move(config); }
+    const InspectorConfig& config() const { return config_; }
+
+    /// Resolve the selected view's authored source location and (unless
+    /// `dry_run`) open the user's editor at that file:line. Returns the
+    /// full result so callers / tests can inspect the formatted URL.
+    /// A graceful no-op (ok == false) when there is no selection or the
+    /// selected view carries no source provenance — the inspector never
+    /// throws or spawns a process for a non-imported view.
+    SourceJumpResult jump_to_selection_source(bool dry_run = false);
 
     // ── Phase 3b — live-editable box-model fields ──────────────────
     //
@@ -304,6 +322,11 @@ private:
     // Phase 0b PR-C-1: optional in-process gesture-tweak persistence.
     // When null, emit_tweak_for_selection() is a no-op.
     TweakStore* tweak_store_ = nullptr;
+
+    // Phase 5.1: editor-URL config for the `J` source-jump hotkey.
+    // Defaults to the built-in VS Code template; the env override
+    // (PULP_INSPECTOR_EDITOR_URL) still applies at jump time.
+    InspectorConfig config_{};
 
     // Phase 3a — drag-handles state. Off by default so the inspector
     // behaves identically to the pre-3a build until the user opts in

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -66,6 +66,13 @@ namespace methods {
     // (env / config / default). See pulp/inspect/editor_url.hpp.
     constexpr auto kInspectorSetEditorUrlTemplate = "Inspector.setEditorUrlTemplate";
     constexpr auto kInspectorGetEditorUrlTemplate = "Inspector.getEditorUrlTemplate";
+    // Phase 5.1: the concrete source-jump action. Resolves the selected
+    // (or a given `anchorId`'s) view's recorded source location, formats
+    // the editor URL, and — unless `dryRun` is true — hands it to the OS
+    // so the user's editor opens at the originating JSX file:line.
+    // Returns {ok, url, path, line, col, launched}. See
+    // pulp/inspect/source_jump.hpp.
+    constexpr auto kInspectorJumpToSource = "Inspector.jumpToSource";
 
     // DOM domain
     constexpr auto kDOMGetDocument     = "DOM.getDocument";

--- a/inspect/include/pulp/inspect/source_jump.hpp
+++ b/inspect/include/pulp/inspect/source_jump.hpp
@@ -1,0 +1,73 @@
+// source_jump.hpp — Inspector source-jump: resolve a view's authored
+// source location and open it in the user's editor.
+//
+// Phase 5.1 of the inspector source-jump roadmap
+// (planning/2026-05-19-inspector-phase5-source-jump-spike.md).
+//
+// This is the concrete "jump to source" action. Phase 5.3 already
+// shipped the editor-URI *configuration* (pulp/inspect/editor_url.hpp);
+// Phase 0b wired a `source_loc` onto `pulp::view::View` from React's
+// `__source` prop. This file ties them together:
+//
+//   1. resolve_source_jump() — given a config + a View's recorded
+//      source location, format the editor URL via format_editor_url().
+//   2. launch_editor_url() — hand the URL to the OS so the editor
+//      actually opens. Kept behind a small seam so headless tests can
+//      run the resolve path with `dryRun` and never spawn a process.
+//
+// The launch shim deliberately lives in inspect/ (dev-tooling), not in
+// core/runtime — it is only ever used by the inspector overlay and the
+// inspector protocol handler, and is not part of the SDK public API.
+#pragma once
+
+#include <pulp/inspect/editor_url.hpp>
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace pulp::view { class View; }
+
+namespace pulp::inspect {
+
+/// Outcome of a source-jump resolution. `ok` is true only when the
+/// view carried a usable source location AND the editor URL formatted
+/// cleanly. On failure, `error` explains why (no view, no provenance,
+/// bad template) and `url` is empty.
+struct SourceJumpResult {
+    bool ok = false;
+    std::string url;     ///< Formatted editor URL (empty on failure).
+    std::string path;    ///< Resolved source file path.
+    int line = 0;        ///< Resolved 1-based line (0 = unknown).
+    int col = 0;         ///< Resolved 1-based column (0 = unknown).
+    bool launched = false;   ///< True if the URL was handed to the OS.
+    std::string error;  ///< Human-readable failure reason (empty on ok).
+};
+
+/// Resolve the source-jump target for `view` using `config`'s editor
+/// URL template (with environment override applied). Does NOT open the
+/// editor — pure computation, safe for tests. A null `view`, or a view
+/// without a recorded `source_loc()`, yields `ok == false` with a
+/// descriptive `error`.
+SourceJumpResult resolve_source_jump(const InspectorConfig& config,
+                                     const pulp::view::View* view);
+
+/// Hand an editor URL to the OS handler. Returns true if the launch
+/// command was dispatched successfully. macOS uses `open`, Linux uses
+/// `xdg-open`, Windows uses `ShellExecute`. An empty URL is a no-op
+/// that returns false.
+///
+/// This is the side-effecting seam: callers that want a dry run (tests,
+/// the protocol `dryRun` param) should call `resolve_source_jump()` and
+/// skip this entirely.
+bool launch_editor_url(std::string_view url);
+
+/// Convenience: resolve + launch in one call. When `dry_run` is true,
+/// behaves exactly like `resolve_source_jump()` (no process spawned,
+/// `launched` stays false). When false and the resolve succeeded, the
+/// URL is launched and `launched` reflects the OS handler's result.
+SourceJumpResult jump_to_source(const InspectorConfig& config,
+                                const pulp::view::View* view,
+                                bool dry_run);
+
+} // namespace pulp::inspect

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -2,6 +2,7 @@
 
 #include <pulp/inspect/domain_handler.hpp>
 #include <pulp/inspect/editor_url.hpp>
+#include <pulp/inspect/source_jump.hpp>
 #include <pulp/inspect/inspector_overlay.hpp>
 #include <pulp/inspect/state_inspector.hpp>
 #include <pulp/inspect/console_capture.hpp>
@@ -24,6 +25,20 @@
 namespace pulp::inspect {
 
 using namespace pulp::view;
+
+// ── Config / wiring ─────────────────────────────────────────────────────────
+
+void DomainHandler::set_config(InspectorConfig config) {
+    config_ = std::move(config);
+    // Keep the overlay's `J`-hotkey config in lockstep with the
+    // protocol path so both resolve source-jumps identically.
+    if (overlay_) overlay_->set_config(config_);
+}
+
+void DomainHandler::set_overlay(InspectorOverlay* overlay) {
+    overlay_ = overlay;
+    if (overlay_) overlay_->set_config(config_);
+}
 
 // ── Dispatch ────────────────────────────────────────────────────────────────
 
@@ -320,6 +335,9 @@ InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
                 return make_error(req.id,
                     std::string("Inspector.setEditorUrlTemplate: ") + err);
             config_.editor_url_template = tmpl;
+            // Phase 5.1 — keep the overlay's `J`-hotkey config in sync
+            // so a runtime template change reaches both jump paths.
+            if (overlay_) overlay_->set_config(config_);
             auto resp = choc::value::createObject("");
             resp.addMember("ok", choc::value::createBool(true));
             resp.addMember("template", choc::value::createString(tmpl));
@@ -341,6 +359,72 @@ InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
             choc::value::createString(config_.editor_url_template));
         if (auto env = editor_url_env_override())
             resp.addMember("envTemplate", choc::value::createString(*env));
+        return make_response(req.id, choc::json::toString(resp, false));
+    }
+
+    // ── Phase 5.1: Inspector.jumpToSource ───────────────────────────
+    // Resolve a view's authored source location and open the user's
+    // editor at file:line. Params (all optional):
+    //   anchorId : design-import anchor of the target view. When
+    //              omitted, falls back to the overlay's selected view.
+    //   dryRun   : when true, resolve + format only — never spawn a
+    //              process. Used by headless tests and agent callers
+    //              that just want the URL.
+    // Returns {ok, url, path, line, col, launched} on a resolvable
+    // target; {ok:false, error} when the view has no provenance or no
+    // target could be found. Note `ok:false` here is a structured
+    // response, NOT a protocol error — a no-provenance view is a
+    // normal, expected case (the overlay treats it as a graceful
+    // no-op), so callers can branch on `ok` without exception handling.
+    if (req.method == methods::kInspectorJumpToSource) {
+        bool dry_run = false;
+        std::string anchor_id;
+        if (!req.params_json.empty()) {
+            try {
+                auto params = choc::json::parse(req.params_json);
+                if (params.isObject()) {
+                    if (params.hasObjectMember("dryRun") &&
+                        params["dryRun"].isBool())
+                        dry_run = params["dryRun"].getBool();
+                    if (params.hasObjectMember("anchorId") &&
+                        params["anchorId"].isString())
+                        anchor_id = std::string(params["anchorId"].getString());
+                }
+            } catch (...) {
+                return make_error(req.id,
+                    "Invalid params for Inspector.jumpToSource");
+            }
+        }
+
+        // Resolve the target view: explicit anchor wins; otherwise the
+        // overlay's current selection.
+        view::View* target = nullptr;
+        if (!anchor_id.empty()) {
+            if (root_)
+                target = ViewInspector::find_by_anchor(*root_, anchor_id);
+        } else if (overlay_) {
+            target = overlay_->selected_view();
+        }
+
+        auto result = jump_to_source(config_, target, dry_run);
+
+        auto resp = choc::value::createObject("");
+        resp.addMember("ok", choc::value::createBool(result.ok));
+        if (result.ok) {
+            resp.addMember("url", choc::value::createString(result.url));
+            resp.addMember("path", choc::value::createString(result.path));
+            resp.addMember("line",
+                choc::value::createInt64(static_cast<int64_t>(result.line)));
+            resp.addMember("col",
+                choc::value::createInt64(static_cast<int64_t>(result.col)));
+            resp.addMember("launched", choc::value::createBool(result.launched));
+            resp.addMember("dryRun", choc::value::createBool(dry_run));
+        } else {
+            resp.addMember("error", choc::value::createString(
+                anchor_id.empty() && !overlay_
+                    ? std::string("no overlay attached and no anchorId given")
+                    : result.error));
+        }
         return make_response(req.id, choc::json::toString(resp, false));
     }
     if (req.method == methods::kInspectorSetBypass) {

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -208,7 +208,28 @@ bool InspectorOverlay::handle_key_event(const KeyEvent& event) {
         return true;
     }
 
+    // Phase 5.1 — J jumps to the selected view's authored JSX source
+    // (no modifier; inspector-active only — same collision-avoidance
+    // discipline as the D drag toggle). Graceful no-op when there is
+    // no selection or the selection has no source provenance.
+    if (active_ && event.key == KeyCode::j && event.is_down &&
+        event.modifiers == 0) {
+        jump_to_selection_source(/*dry_run=*/false);
+        // Consume the key regardless — even a no-op jump (no
+        // provenance) should not fall through to the view tree.
+        return true;
+    }
+
     return false;
+}
+
+SourceJumpResult InspectorOverlay::jump_to_selection_source(bool dry_run) {
+    // selected_ may be null (no selection) or carry no source_loc
+    // (view authored outside the JSX-import path). jump_to_source()
+    // handles both as a structured ok==false result — no throw, no
+    // process spawn — so the caller (J hotkey / protocol) can branch
+    // cleanly.
+    return jump_to_source(config_, selected_, dry_run);
 }
 
 bool InspectorOverlay::handle_mouse_event(const MouseEvent& event) {
@@ -866,6 +887,21 @@ void InspectorOverlay::paint_props_section(Canvas& canvas, float x, float y, flo
     // Type and ID
     auto type = ViewInspector::type_name(*selected_);
     draw_heading(type + (selected_->id().empty() ? "" : " #" + selected_->id()));
+
+    // Phase 5.1 — authored-source row. When the selected view carries a
+    // `__source` provenance record (set via the JS bridge's setSource()
+    // for JSX-imported views), show "file:line" and a hint that the J
+    // hotkey jumps to it. Hidden entirely for non-imported views so the
+    // panel stays uncluttered.
+    if (selected_->has_source_loc()) {
+        const auto& loc = selected_->source_loc();
+        std::string where = loc.file;
+        if (loc.line > 0) where += ":" + std::to_string(loc.line);
+        draw_label("source", where);
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text("(press J to open in editor)", x, line_y + 11);
+        line_y += line_h;
+    }
 
     // Bounds (informational — bounds is layout OUTPUT, not editable.
     // Edits go through flex inputs below.)

--- a/inspect/src/source_jump.cpp
+++ b/inspect/src/source_jump.cpp
@@ -1,0 +1,105 @@
+// source_jump.cpp — Inspector source-jump implementation.
+//
+// See pulp/inspect/source_jump.hpp for the public surface and the
+// design context (planning Phase 5.1).
+
+#include <pulp/inspect/source_jump.hpp>
+#include <pulp/view/view.hpp>
+
+#if defined(_WIN32)
+  #include <windows.h>
+  #include <shellapi.h>
+#else
+  #include <spawn.h>
+  #include <sys/wait.h>
+  #include <unistd.h>
+  extern char** environ;
+#endif
+
+namespace pulp::inspect {
+
+SourceJumpResult resolve_source_jump(const InspectorConfig& config,
+                                     const pulp::view::View* view) {
+    SourceJumpResult result;
+    if (view == nullptr) {
+        result.error = "no view selected";
+        return result;
+    }
+    if (!view->has_source_loc()) {
+        // Not a failure of the inspector — the view simply was not
+        // created from a JSX element carrying a `__source` prop. The
+        // overlay treats this as a graceful no-op.
+        result.error = "view has no source location (not imported from JSX)";
+        return result;
+    }
+    const auto& loc = view->source_loc();
+    if (!loc.valid()) {
+        result.error = "view source location has an empty file path";
+        return result;
+    }
+
+    // Apply the env override / config / default precedence (Phase 5.3).
+    auto effective = effective_editor_url(config);
+    std::string err;
+    if (!validate_editor_url_template(effective.template_str, &err)) {
+        result.error = "editor URL template invalid: " + err;
+        return result;
+    }
+
+    result.path = loc.file;
+    result.line = loc.line;
+    result.col = loc.col;
+    // A 0 line/col means "unknown" — substitute 1 for the line so the
+    // editor opens at the file top rather than a nonsensical line 0.
+    int line = loc.line > 0 ? loc.line : 1;
+    std::optional<int> col;
+    if (loc.col > 0) col = loc.col;
+    result.url = format_editor_url(effective.template_str, loc.file, line, col);
+    result.ok = true;
+    return result;
+}
+
+bool launch_editor_url(std::string_view url) {
+    if (url.empty()) return false;
+
+#if defined(_WIN32)
+    std::wstring wurl(url.begin(), url.end());
+    // ShellExecuteW returns a value > 32 on success.
+    auto rc = reinterpret_cast<INT_PTR>(
+        ::ShellExecuteW(nullptr, L"open", wurl.c_str(),
+                        nullptr, nullptr, SW_SHOWNORMAL));
+    return rc > 32;
+#elif defined(__APPLE__)
+    const std::string url_str(url);
+    const char* argv[] = {"open", url_str.c_str(), nullptr};
+    pid_t pid = 0;
+    int rc = ::posix_spawnp(&pid, "open", nullptr, nullptr,
+                            const_cast<char* const*>(argv), environ);
+    if (rc != 0) return false;
+    int status = 0;
+    ::waitpid(pid, &status, 0);
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+#else
+    const std::string url_str(url);
+    const char* argv[] = {"xdg-open", url_str.c_str(), nullptr};
+    pid_t pid = 0;
+    int rc = ::posix_spawnp(&pid, "xdg-open", nullptr, nullptr,
+                            const_cast<char* const*>(argv), environ);
+    if (rc != 0) return false;
+    int status = 0;
+    ::waitpid(pid, &status, 0);
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+#endif
+}
+
+SourceJumpResult jump_to_source(const InspectorConfig& config,
+                                const pulp::view::View* view,
+                                bool dry_run) {
+    SourceJumpResult result = resolve_source_jump(config, view);
+    if (result.ok && !dry_run) {
+        result.launched = launch_editor_url(result.url);
+    }
+    return result;
+}
+
+} // namespace pulp::inspect

--- a/packages/pulp-react/src/host-config.ts
+++ b/packages/pulp-react/src/host-config.ts
@@ -733,10 +733,32 @@ function materialize(parent: Instance, child: Instance): void {
     materializeUnder(parent.id, child);
 }
 
+/// Phase 5.1 (inspector source-jump) — forward React's dev-mode
+/// `__source` prop ({ fileName, lineNumber, columnNumber }) to the
+/// native `setSource` bridge so the inspector can jump to the authoring
+/// JSX file:line. `__source` is inlined by Babel's automatic-runtime
+/// JSX dev transform; it is absent in production bundles, so this is a
+/// silent no-op there. `setSource` itself no-ops on an unknown widget
+/// id and an empty file path (see widget_bridge.cpp), so the guard here
+/// only avoids a needless bridge round-trip.
+function bindSourceLocation(child: Instance): void {
+    const src = child.props.__source as
+        | { fileName?: unknown; lineNumber?: unknown; columnNumber?: unknown }
+        | undefined;
+    if (!src || typeof src.fileName !== 'string' || src.fileName.length === 0) {
+        return;
+    }
+    if (typeof g.setSource !== 'function') return;  // older runtime
+    const line = typeof src.lineNumber === 'number' ? src.lineNumber : 0;
+    const col = typeof src.columnNumber === 'number' ? src.columnNumber : 0;
+    call('setSource', child.id, src.fileName, line, col);
+}
+
 function materializeUnder(parentId: string, child: Instance): void {
     if (child.onBridge) return;
     createWidget(child.type, child.id, parentId, child.props);
     applyAllProps(child);
+    bindSourceLocation(child);
     child.onBridge = true;
     // Drain any pending grand-children that were queued before this
     // descriptor reached the bridge.

--- a/test/test_editor_url.cpp
+++ b/test/test_editor_url.cpp
@@ -9,6 +9,8 @@
 #include <pulp/inspect/domain_handler.hpp>
 #include <pulp/inspect/editor_url.hpp>
 #include <pulp/inspect/protocol.hpp>
+#include <pulp/inspect/source_jump.hpp>
+#include <pulp/view/view.hpp>
 
 #include <choc/text/choc_JSON.h>
 
@@ -251,4 +253,186 @@ TEST_CASE("DomainHandler::set_config swaps the template without touching env",
     REQUIRE(std::string(obj["source"].getString()) == "config");
     REQUIRE(std::string(obj["template"].getString())
             == "cursor://file/{path}:{line}");
+}
+
+// ── Phase 5.1: source-jump resolution ──────────────────────────────────────
+
+TEST_CASE("resolve_source_jump formats the URL for a view with provenance",
+          "[inspect][source-jump]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+
+    pulp::view::View view;
+    view.set_source_loc({"src/Synth.jsx", 42, 7});
+
+    InspectorConfig cfg;  // default vscode template (no {col})
+    auto result = resolve_source_jump(cfg, &view);
+    REQUIRE(result.ok);
+    REQUIRE(result.path == "src/Synth.jsx");
+    REQUIRE(result.line == 42);
+    REQUIRE(result.col == 7);
+    REQUIRE(result.url == "vscode://file/src/Synth.jsx:42");
+    REQUIRE_FALSE(result.launched);  // resolve never launches
+}
+
+TEST_CASE("resolve_source_jump honors a {col}-bearing editor template",
+          "[inspect][source-jump]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+
+    pulp::view::View view;
+    view.set_source_loc({"app/Knob.tsx", 13, 4});
+
+    InspectorConfig cfg;
+    cfg.editor_url_template = "zed://file/{path}:{line}:{col}";
+    auto result = resolve_source_jump(cfg, &view);
+    REQUIRE(result.ok);
+    REQUIRE(result.url == "zed://file/app/Knob.tsx:13:4");
+}
+
+TEST_CASE("resolve_source_jump uses the env-override template",
+          "[inspect][source-jump]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.set("cursor://file/{path}:{line}");
+
+    pulp::view::View view;
+    view.set_source_loc({"x.jsx", 9, 0});
+
+    InspectorConfig cfg;  // config says vscode; env wins
+    auto result = resolve_source_jump(cfg, &view);
+    REQUIRE(result.ok);
+    REQUIRE(result.url == "cursor://file/x.jsx:9");
+}
+
+TEST_CASE("resolve_source_jump treats a 0-line as file-top (line 1)",
+          "[inspect][source-jump]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+
+    pulp::view::View view;
+    view.set_source_loc({"top.jsx", 0, 0});  // unknown line
+
+    InspectorConfig cfg;
+    auto result = resolve_source_jump(cfg, &view);
+    REQUIRE(result.ok);
+    // line/col in the result echo the recorded values...
+    REQUIRE(result.line == 0);
+    // ...but the formatted URL substitutes 1 so the editor opens cleanly.
+    REQUIRE(result.url == "vscode://file/top.jsx:1");
+}
+
+TEST_CASE("resolve_source_jump is a graceful no-op for a null view",
+          "[inspect][source-jump]") {
+    InspectorConfig cfg;
+    auto result = resolve_source_jump(cfg, nullptr);
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.url.empty());
+    REQUIRE_FALSE(result.error.empty());
+}
+
+TEST_CASE("resolve_source_jump is a graceful no-op for a view without provenance",
+          "[inspect][source-jump]") {
+    pulp::view::View view;  // no set_source_loc — non-imported view
+    REQUIRE_FALSE(view.has_source_loc());
+
+    InspectorConfig cfg;
+    auto result = resolve_source_jump(cfg, &view);
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.url.empty());
+    REQUIRE(result.error.find("no source location") != std::string::npos);
+}
+
+TEST_CASE("jump_to_source with dry_run resolves but never launches",
+          "[inspect][source-jump]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+
+    pulp::view::View view;
+    view.set_source_loc({"src/Main.jsx", 100, 0});
+
+    InspectorConfig cfg;
+    auto result = jump_to_source(cfg, &view, /*dry_run=*/true);
+    REQUIRE(result.ok);
+    REQUIRE(result.url == "vscode://file/src/Main.jsx:100");
+    REQUIRE_FALSE(result.launched);
+}
+
+TEST_CASE("launch_editor_url rejects an empty URL", "[inspect][source-jump]") {
+    REQUIRE_FALSE(launch_editor_url(""));
+}
+
+// ── Phase 5.1: Inspector.jumpToSource protocol round-trip ──────────────────
+
+TEST_CASE("Inspector.jumpToSource resolves an anchored view in dryRun",
+          "[inspect][source-jump][protocol]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+
+    pulp::view::View root;
+    auto child = std::make_unique<pulp::view::View>();
+    child->set_anchor_id("figma:node-7");
+    child->set_source_loc({"src/Panel.jsx", 24, 3});
+    root.add_child(std::move(child));
+
+    DomainHandler handler;
+    handler.set_root_view(&root);
+
+    auto resp = handler.handle(make_request(
+        1, methods::kInspectorJumpToSource,
+        R"({"anchorId":"figma:node-7","dryRun":true})"));
+    REQUIRE_FALSE(resp.is_error);
+
+    auto obj = choc::json::parse(resp.params_json);
+    REQUIRE(obj["ok"].getBool());
+    REQUIRE(std::string(obj["url"].getString())
+            == "vscode://file/src/Panel.jsx:24");
+    REQUIRE(std::string(obj["path"].getString()) == "src/Panel.jsx");
+    REQUIRE(obj["line"].getInt64() == 24);
+    REQUIRE_FALSE(obj["launched"].getBool());
+    REQUIRE(obj["dryRun"].getBool());
+}
+
+TEST_CASE("Inspector.jumpToSource returns ok:false for an unknown anchor",
+          "[inspect][source-jump][protocol]") {
+    pulp::view::View root;
+    DomainHandler handler;
+    handler.set_root_view(&root);
+
+    auto resp = handler.handle(make_request(
+        1, methods::kInspectorJumpToSource,
+        R"({"anchorId":"does-not-exist","dryRun":true})"));
+    // Not a protocol error — a structured ok:false response.
+    REQUIRE_FALSE(resp.is_error);
+    auto obj = choc::json::parse(resp.params_json);
+    REQUIRE_FALSE(obj["ok"].getBool());
+    REQUIRE(obj.hasObjectMember("error"));
+}
+
+TEST_CASE("Inspector.jumpToSource returns ok:false when the view lacks provenance",
+          "[inspect][source-jump][protocol]") {
+    pulp::view::View root;
+    auto child = std::make_unique<pulp::view::View>();
+    child->set_anchor_id("anchor-no-source");
+    // deliberately NO set_source_loc
+    root.add_child(std::move(child));
+
+    DomainHandler handler;
+    handler.set_root_view(&root);
+
+    auto resp = handler.handle(make_request(
+        1, methods::kInspectorJumpToSource,
+        R"({"anchorId":"anchor-no-source","dryRun":true})"));
+    REQUIRE_FALSE(resp.is_error);
+    auto obj = choc::json::parse(resp.params_json);
+    REQUIRE_FALSE(obj["ok"].getBool());
+    REQUIRE(std::string(obj["error"].getString()).find("no source location")
+            != std::string::npos);
+}
+
+TEST_CASE("Inspector.jumpToSource rejects malformed params",
+          "[inspect][source-jump][protocol]") {
+    DomainHandler handler;
+    auto resp = handler.handle(make_request(
+        1, methods::kInspectorJumpToSource, "{not json"));
+    REQUIRE(resp.is_error);
 }

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -2586,3 +2586,194 @@ TEST_CASE("InspectorOverlay Phase 6.1: paint() drives capture automatically",
     overlay.paint(canvas);
     REQUIRE(overlay.pass_frames_captured() == 2);
 }
+
+// ── Phase 5.1: source-jump (View provenance + overlay J hotkey) ────────────
+//
+// planning/2026-05-19-inspector-phase5-source-jump-spike.md § Phase 5.1.
+
+#include <pulp/inspect/source_jump.hpp>
+#include <choc/text/choc_JSON.h>
+
+TEST_CASE("View::source_loc round-trips a file:line:col record",
+          "[inspect][source-jump]") {
+    View v;
+    REQUIRE_FALSE(v.has_source_loc());
+    REQUIRE_FALSE(v.source_loc().valid());
+
+    v.set_source_loc({"src/Synth.jsx", 42, 7});
+    REQUIRE(v.has_source_loc());
+    REQUIRE(v.source_loc().valid());
+    REQUIRE(v.source_loc().file == "src/Synth.jsx");
+    REQUIRE(v.source_loc().line == 42);
+    REQUIRE(v.source_loc().col == 7);
+
+    v.clear_source_loc();
+    REQUIRE_FALSE(v.has_source_loc());
+}
+
+TEST_CASE("ViewInspector::find_by_anchor locates a view by its anchor id",
+          "[inspect][source-jump]") {
+    View root;
+    auto a = std::make_unique<View>();
+    a->set_anchor_id("figma:a");
+    auto* a_ptr = a.get();
+    auto b = std::make_unique<View>();
+    b->set_anchor_id("figma:b");
+    auto* b_ptr = b.get();
+    root.add_child(std::move(a));
+    root.add_child(std::move(b));
+
+    REQUIRE(ViewInspector::find_by_anchor(root, "figma:a") == a_ptr);
+    REQUIRE(ViewInspector::find_by_anchor(root, "figma:b") == b_ptr);
+    REQUIRE(ViewInspector::find_by_anchor(root, "missing") == nullptr);
+    // An empty anchor never matches a (default-empty-anchor) view.
+    REQUIRE(ViewInspector::find_by_anchor(root, "") == nullptr);
+}
+
+TEST_CASE("InspectorOverlay: J jumps to source for a view with provenance",
+          "[inspect][overlay][source-jump]") {
+    View root;
+    root.set_bounds({0, 0, 500, 300});
+    auto child = std::make_unique<View>();
+    child->set_id("knob");
+    child->set_bounds({10, 10, 80, 40});
+    child->set_source_loc({"src/Panel.jsx", 24, 3});
+    auto* child_ptr = child.get();
+    root.add_child(std::move(child));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    // Select the child via a click.
+    MouseEvent click;
+    click.position = {20, 20};
+    click.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(click));
+    REQUIRE(overlay.selected_view() == child_ptr);
+
+    // Dry-run jump — resolves the URL but never spawns the editor.
+    auto result = overlay.jump_to_selection_source(/*dry_run=*/true);
+    REQUIRE(result.ok);
+    REQUIRE(result.url == "vscode://file/src/Panel.jsx:24");
+    REQUIRE_FALSE(result.launched);
+
+    // The J hotkey is consumed while the inspector is active.
+    KeyEvent jk;
+    jk.key = KeyCode::j;
+    jk.modifiers = 0;
+    jk.is_down = true;
+    REQUIRE(overlay.handle_key_event(jk));
+}
+
+TEST_CASE("InspectorOverlay: J is a graceful no-op without a selection",
+          "[inspect][overlay][source-jump]") {
+    View root;
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    REQUIRE(overlay.selected_view() == nullptr);
+
+    auto result = overlay.jump_to_selection_source(/*dry_run=*/true);
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.url.empty());
+
+    // The key is still consumed (does not fall through to the view tree),
+    // but no jump happens.
+    KeyEvent jk;
+    jk.key = KeyCode::j;
+    jk.modifiers = 0;
+    jk.is_down = true;
+    REQUIRE(overlay.handle_key_event(jk));
+}
+
+TEST_CASE("InspectorOverlay: J is a graceful no-op for a non-imported view",
+          "[inspect][overlay][source-jump]") {
+    View root;
+    root.set_bounds({0, 0, 500, 300});
+    auto child = std::make_unique<View>();
+    child->set_bounds({10, 10, 80, 40});
+    // deliberately NO set_source_loc — a user-authored, non-JSX view.
+    root.add_child(std::move(child));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    MouseEvent click;
+    click.position = {20, 20};
+    click.is_down = true;
+    overlay.handle_mouse_event(click);
+    REQUIRE(overlay.selected_view() != nullptr);
+
+    auto result = overlay.jump_to_selection_source(/*dry_run=*/true);
+    REQUIRE_FALSE(result.ok);
+    REQUIRE(result.error.find("no source location") != std::string::npos);
+}
+
+TEST_CASE("InspectorOverlay: J does nothing when the inspector is inactive",
+          "[inspect][overlay][source-jump]") {
+    View root;
+    InspectorOverlay overlay(root);
+    // inspector NOT active
+    KeyEvent jk;
+    jk.key = KeyCode::j;
+    jk.modifiers = 0;
+    jk.is_down = true;
+    REQUIRE_FALSE(overlay.handle_key_event(jk));
+}
+
+TEST_CASE("InspectorOverlay: config swap changes the source-jump template",
+          "[inspect][overlay][source-jump]") {
+    View root;
+    root.set_bounds({0, 0, 500, 300});
+    auto child = std::make_unique<View>();
+    child->set_bounds({10, 10, 80, 40});
+    child->set_source_loc({"a/B.tsx", 11, 2});
+    root.add_child(std::move(child));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    MouseEvent click;
+    click.position = {20, 20};
+    click.is_down = true;
+    overlay.handle_mouse_event(click);
+
+    InspectorConfig cfg;
+    cfg.editor_url_template = "zed://file/{path}:{line}:{col}";
+    overlay.set_config(cfg);
+
+    auto result = overlay.jump_to_selection_source(/*dry_run=*/true);
+    REQUIRE(result.ok);
+    REQUIRE(result.url == "zed://file/a/B.tsx:11:2");
+}
+
+TEST_CASE("DomainHandler propagates config to the attached overlay",
+          "[inspect][source-jump][domain]") {
+    View root;
+    root.set_bounds({0, 0, 500, 300});
+    auto child = std::make_unique<View>();
+    child->set_anchor_id("anchor-1");
+    child->set_bounds({10, 10, 80, 40});
+    child->set_source_loc({"x/Y.jsx", 5, 0});
+    root.add_child(std::move(child));
+
+    InspectorOverlay overlay(root);
+    DomainHandler handler;
+    handler.set_root_view(&root);
+    handler.set_overlay(&overlay);
+
+    InspectorConfig cfg;
+    cfg.editor_url_template = "cursor://file/{path}:{line}";
+    handler.set_config(cfg);
+
+    // The overlay's config now matches the handler's.
+    REQUIRE(overlay.config().editor_url_template
+            == "cursor://file/{path}:{line}");
+
+    // And Inspector.jumpToSource via the anchor resolves with it.
+    auto resp = handler.handle(make_request(
+        1, methods::kInspectorJumpToSource,
+        R"({"anchorId":"anchor-1","dryRun":true})"));
+    REQUIRE_FALSE(resp.is_error);
+    auto obj = choc::json::parse(resp.params_json);
+    REQUIRE(obj["ok"].getBool());
+    REQUIRE(std::string(obj["url"].getString())
+            == "cursor://file/x/Y.jsx:5");
+}

--- a/tools/import-design/jsx-runtime/jsx-transform.mjs
+++ b/tools/import-design/jsx-runtime/jsx-transform.mjs
@@ -251,7 +251,16 @@ async function main() {
             platform: 'browser',
             globalName: 'PulpJsxApp',
             write: false,
-            sourcemap: false,
+            // Phase 5.1 (inspector source-jump) — emit an inline source
+            // map when PULP_JSX_SOURCEMAP=1 so the inspector / debuggers
+            // can map the bundled IIFE back to authored JSX. Off by
+            // default to keep production bundles lean (source maps add
+            // ~10-30%); dev builds opt in per-shell. The reconciler's
+            // `__source`-prop forwarding (host-config bindSourceLocation)
+            // is the other half of source-jump and is independent of
+            // this map — see the spike doc for the automatic-runtime
+            // `__source` follow-up.
+            sourcemap: process.env.PULP_JSX_SOURCEMAP === '1' ? 'inline' : false,
             minify: false,
             jsx: 'transform',
             jsxFactory: 'React.createElement',


### PR DESCRIPTION
Wires the inspector's first concrete source-jump action: a selected
view that carries authored-source provenance can open the user's
editor at the originating JSX file:line.

- View::SourceLocation — additive {file,line,col} accessor on View,
  mirroring the Phase 0b anchor_id pattern. Populated for JSX-imported
  views, empty for user-authored ones.
- widget_bridge: setSource(id,file,line,col) JS bridge fn; silent
  no-op on unknown widget / empty path, matching setAnchor.
- @pulp/react host-config: bindSourceLocation() forwards React's
  dev-mode __source prop through setSource at materialize time.
- inspect/source_jump.{hpp,cpp} — resolve_source_jump() formats the
  editor URL via the Phase 5.3 editor_url plumbing; launch_editor_url()
  is the OS-handler seam (open / xdg-open / ShellExecute). dryRun
  callers skip the launch entirely.
- ViewInspector::find_by_anchor — maps an anchor id back to a View*.
- Inspector.jumpToSource protocol method — resolves the selected or a
  given anchor's view, returns {ok,url,path,line,col,launched}; opens
  the editor unless dryRun is set. A no-provenance view is a
  structured ok:false, not a protocol error.
- InspectorOverlay: J hotkey jumps the selected view's source; config
  propagates from DomainHandler so hotkey + protocol share one
  template. Props panel shows a "source" row for imported views.
- jsx-transform.mjs: inline source maps gate behind PULP_JSX_SOURCEMAP.

The launch shim stays inspect-local (dev-tooling overlay). The
__source automatic-runtime JSX migration is the documented Phase 5.1
follow-up — esbuild transform-mode does not inline __source, so
bindSourceLocation activates once the runtime emits it.

Tests: 21 new cases across test_editor_url.cpp (resolve / dryRun /
no-op / protocol round-trip) and test_inspector.cpp (View round-trip,
find_by_anchor, overlay J hotkey, config propagation). All 69
Inspector|EditorUrl tests pass.

Version-Bump: sdk=skip reason="inspect/* is a dev-tooling overlay; core/view additions (View::SourceLocation accessors, find_by_anchor, setSource bridge) are purely additive and change no existing API contract or behavior"
Version-Bump: plugin=skip reason="no Claude plugin command or marketplace surface changed; only an existing SKILL.md gained a source-jump gotchas subsection"
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>