### PR TITLE
ci(build): build macOS with the Ninja generator

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -927,6 +927,18 @@ delegation to helper binaries must resolve from the active build directory
 hard-coded `build/` path; otherwise Linux catches missing helpers while warm
 self-hosted macOS workspaces can mask the bug.
 
+**macOS builds with the Ninja generator.** `build.yml`'s Configure step
+passes `-G Ninja` on macOS only (Linux/Windows keep their default
+generator). Ninja schedules parallelism better and is faster on the
+warm/incremental builds the self-hosted M1 mostly does. Because the
+self-hosted runners reuse `build-*` dirs (`clean: false`) and CMake
+refuses to reconfigure a dir created with a *different* generator, the
+Configure step recreates `$PULP_BUILD_DIR` when its cached
+`CMAKE_GENERATOR` is not `Ninja` — so the first Ninja run on each runner
+pays a one-time fresh-configure (the shared ccache stays warm). If you
+add a new macOS build path, configure it with Ninja too, or it will
+hit a generator-mismatch error against the warm dir.
+
 ### Overrides when you need them
 
 - **Dispatch a build manually**: `runner_provider` defaults to

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -620,10 +620,29 @@ jobs:
         # (PULP_BUILD_EXAMPLES default = ON).
         run: |
           set -euo pipefail
+          # macOS builds with Ninja — it schedules parallelism more
+          # precisely and is meaningfully faster on the warm/incremental
+          # builds that are the self-hosted M1's common case. Linux and
+          # Windows keep their default generator. Self-hosted runners
+          # reuse warm build dirs (clean: false), and CMake refuses to
+          # reconfigure a dir created with a different generator, so the
+          # build dir is recreated when its cached generator no longer
+          # matches (one-time cost on the first Ninja run per runner;
+          # the shared ccache stays warm regardless).
+          gen=""
+          if [ "${RUNNER_OS}" = "macOS" ]; then
+            command -v ninja >/dev/null 2>&1 || brew install ninja
+            gen="-G Ninja"
+            cache="$PULP_BUILD_DIR/CMakeCache.txt"
+            if [ -f "$cache" ] && ! grep -q '^CMAKE_GENERATOR:INTERNAL=Ninja$' "$cache"; then
+              echo "macOS Configure: build-dir generator changed → recreating $PULP_BUILD_DIR"
+              rm -rf "$PULP_BUILD_DIR"
+            fi
+          fi
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            cmake -S . -B "$PULP_BUILD_DIR" -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_EXAMPLES=OFF
+            cmake -S . -B "$PULP_BUILD_DIR" $gen -DCMAKE_BUILD_TYPE=Release -DPULP_BUILD_EXAMPLES=OFF
           else
-            cmake -S . -B "$PULP_BUILD_DIR" -DCMAKE_BUILD_TYPE=Release
+            cmake -S . -B "$PULP_BUILD_DIR" $gen -DCMAKE_BUILD_TYPE=Release
           fi
         shell: bash
 

--- a/tools/scripts/test_workflow_build_dirs.py
+++ b/tools/scripts/test_workflow_build_dirs.py
@@ -55,5 +55,44 @@ class WorkflowBuildDirTests(unittest.TestCase):
         self.assertNotIn("ctest --test-dir build ", text)
 
 
+class MacosNinjaGeneratorTests(unittest.TestCase):
+    """The macOS build leg uses the Ninja generator.
+
+    Ninja is faster than the default Makefile generator on the warm /
+    incremental builds the self-hosted M1 mostly does. Because the
+    self-hosted runners reuse `build-*` dirs (`clean: false`) and CMake
+    refuses to reconfigure a dir created with a different generator, the
+    Configure step must recreate the build dir when its cached generator
+    is not Ninja — otherwise the first build after the switch fails on
+    every warm runner with a generator-mismatch error.
+    """
+
+    def setUp(self) -> None:
+        self.text = BUILD_WORKFLOW.read_text(encoding="utf-8")
+
+    def test_macos_configure_uses_ninja(self) -> None:
+        # The generator is scoped to macOS and passed to cmake configure.
+        self.assertIn('if [ "${RUNNER_OS}" = "macOS" ]; then', self.text)
+        self.assertIn('gen="-G Ninja"', self.text)
+        self.assertIn(
+            'cmake -S . -B "$PULP_BUILD_DIR" $gen -DCMAKE_BUILD_TYPE=Release',
+            self.text,
+        )
+
+    def test_configure_recreates_build_dir_on_generator_change(self) -> None:
+        # Warm self-hosted build dirs created with Make must be wiped so
+        # the first Ninja configure does not hit a generator mismatch.
+        self.assertIn(
+            "grep -q '^CMAKE_GENERATOR:INTERNAL=Ninja$' \"$cache\"", self.text
+        )
+        self.assertIn('rm -rf "$PULP_BUILD_DIR"', self.text)
+
+    def test_ninja_availability_guard(self) -> None:
+        # A runner missing ninja installs it rather than failing configure.
+        self.assertIn(
+            "command -v ninja >/dev/null 2>&1 || brew install ninja", self.text
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Highest value-for-effort build-speed lever now that the macOS CI cache
layer is tuned (planning doc — *M1 build-speed optimizations*, item 1).

The macOS Build-and-Test leg configured with the default **Makefile**
generator. Ninja schedules parallelism more precisely and is faster on
warm/incremental builds — the self-hosted M1's common case.

## Change

- `build.yml` Configure passes `-G Ninja` **on macOS only**; Linux and
  Windows keep their default generator (no ninja-availability
  dependency added to those runners).
- Self-hosted runners reuse `build-*` dirs (`clean: false`), and CMake
  refuses to reconfigure a dir created with a different generator — so
  the step recreates `$PULP_BUILD_DIR` when its cached `CMAKE_GENERATOR`
  is not `Ninja`. One-time fresh configure per runner on the first
  Ninja run; the shared ccache stays warm, so compiles still cache-hit.
- `command -v ninja || brew install ninja` guard for any runner missing
  it (the bootstrap Brewfile already installs `ninja`; macos-15 ships
  it).
- `ci` SKILL.md documents the generator + the build-dir-recreate
  behavior.

## Validation

This PR's own macOS leg is the test: it exercises the generator switch
+ the warm-dir recreation path on a real self-hosted runner. `build.yml`
YAML parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)