### PR TITLE
feat(inspect): add Phase 6.1 per-pass GPU/render attribution viewer

### DIFF
--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -9,6 +9,8 @@
 
 #include <choc/containers/choc_Value.h>
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -77,6 +79,73 @@ public:
     void set_dragging_enabled(bool enabled) { dragging_enabled_ = enabled; }
     bool dragging_enabled() const { return dragging_enabled_; }
     void toggle_dragging() { dragging_enabled_ = !dragging_enabled_; }
+
+    // ── Phase 6.1 — per-pass GPU/render attribution viewer ──────────
+    //
+    // Spike reference: planning/2026-05-19-inspector-phase6-gpu-perf-spike.md
+    // § Phase 6.1. The RenderPassManager already populates per-pass
+    // `PassStats { type, draw_calls, time_ms }` every frame, but only
+    // keeps the *last* frame. The attribution viewer accumulates a
+    // rolling history (kPassHistoryFrames) per pass type so the panel
+    // can show frame-over-frame trend + smoothed averages + a
+    // budget-overrun event count.
+    //
+    // IMPORTANT (honesty about what's measured): `PassStats::time_ms`
+    // is CPU wall-time around the pass's draw calls — NOT true GPU
+    // time. Real GPU timestamp queries are Phase 6.5 (deferred — see
+    // the spike's "What we DON'T have" table). The viewer labels its
+    // timings "cpu" so nobody mistakes them for GPU-side numbers.
+
+    /// Aggregated attribution data for a single render pass type,
+    /// computed over the rolling frame history.
+    struct PassAttribution {
+        int type = 0;             ///< RenderPassType cast to int.
+        const char* name = "";    ///< Human-readable pass name.
+        bool present = false;     ///< Pass appeared in the most recent frame.
+        float last_cpu_ms = 0.0f; ///< CPU time_ms in the most recent frame.
+        float avg_cpu_ms = 0.0f;  ///< Mean CPU time_ms over recorded history.
+        float peak_cpu_ms = 0.0f; ///< Worst CPU time_ms over recorded history.
+        int last_draw_calls = 0;  ///< Draw calls in the most recent frame.
+        int peak_draw_calls = 0;  ///< Worst draw-call count over history.
+        std::size_t samples = 0;  ///< Number of recorded frames for this pass.
+    };
+
+    /// Number of frames the rolling per-pass history retains. The spike
+    /// asks for a "last 60 frames" trend; 60 keeps one second of 60fps
+    /// history without unbounded growth.
+    static constexpr std::size_t kPassHistoryFrames = 60;
+
+    /// Sample the attached RenderPassManager's current-frame pass stats
+    /// into the rolling history. Safe to call when no RPM is attached
+    /// (no-op). Called automatically at the start of every paint() so
+    /// the viewer always reflects fresh data; also callable directly
+    /// from tests to drive deterministic history without a real frame
+    /// loop. Returns true if a frame was actually captured.
+    bool capture_pass_frame();
+
+    /// Per-pass attribution computed over the current rolling history,
+    /// ordered by RenderPassType (background → post_effects). Entries
+    /// with `present == false` had no frames in history and are skipped
+    /// by the panel; tests can still inspect the full ordered set.
+    std::vector<PassAttribution> pass_attribution() const;
+
+    /// Count of frames in history where the manager reported the frame
+    /// exceeded its time budget (RenderPassManager::over_budget()).
+    /// Surfaced as the panel's "overruns" figure.
+    int budget_overrun_count() const { return budget_overrun_count_; }
+
+    /// Total frames sampled into the rolling history since construction
+    /// (saturates conceptually — only the last kPassHistoryFrames worth
+    /// of per-pass detail is retained, but this counter keeps growing).
+    std::uint64_t pass_frames_captured() const { return pass_frames_captured_; }
+
+    /// Toggle the per-pass attribution panel section. Off by default so
+    /// the inspector panel layout is unchanged until the user opts in
+    /// (P-key in handle_key_event). When on, the section replaces the
+    /// lower portion of the property panel.
+    void set_pass_viewer_enabled(bool enabled) { pass_viewer_enabled_ = enabled; }
+    bool pass_viewer_enabled() const { return pass_viewer_enabled_; }
+    void toggle_pass_viewer() { pass_viewer_enabled_ = !pass_viewer_enabled_; }
 
     // ── Selection ───────────────────────────────────────────────────
     View* selected_view() const { return selected_; }
@@ -170,6 +239,33 @@ private:
     // Optional stats source
     render::RenderPassManager* rpm_ = nullptr;
 
+    // ── Phase 6.1 — per-pass attribution history ────────────────────
+    //
+    // The RenderPassManager forgets everything but the current frame,
+    // so the viewer keeps its own rolling buffers. There are exactly 5
+    // RenderPassType values; each gets a fixed-size ring of CPU-time +
+    // draw-call samples. Indexing the outer array by RenderPassType
+    // (cast to size_t) keeps capture O(passes) with no allocation.
+    static constexpr std::size_t kPassTypeCount = 5;
+    struct PassRing {
+        std::array<float, kPassHistoryFrames> cpu_ms{};
+        std::array<int, kPassHistoryFrames> draw_calls{};
+        std::size_t count = 0;  ///< Valid samples (caps at kPassHistoryFrames).
+        std::size_t head = 0;   ///< Next write index (wraps).
+        // Whether this pass type appeared in the most recently captured
+        // frame — distinguishes "no history" from "history but absent
+        // this frame" so the panel can dim a pass that just went quiet.
+        bool present_last_frame = false;
+    };
+    std::array<PassRing, kPassTypeCount> pass_rings_{};
+    int budget_overrun_count_ = 0;
+    std::uint64_t pass_frames_captured_ = 0;
+    // Last frame_count() observed from the RPM — capture is a no-op if
+    // the manager hasn't advanced a frame, so multiple paints of the
+    // same frame don't inflate the history with duplicates.
+    std::uint64_t last_captured_frame_ = 0;
+    bool pass_viewer_enabled_ = false;
+
     // Phase 0b PR-C-1: optional in-process gesture-tweak persistence.
     // When null, emit_tweak_for_selection() is a no-op.
     TweakStore* tweak_store_ = nullptr;
@@ -209,6 +305,11 @@ private:
     void paint_tree_section(Canvas& canvas, float x, float y, float w, float& cursor_y);
     void paint_props_section(Canvas& canvas, float x, float y, float w, float h);
     void paint_stats_bar(Canvas& canvas, float x, float y, float w);
+    /// Phase 6.1 — render the per-pass attribution viewer in the panel
+    /// region normally occupied by the property section. Each pass type
+    /// gets a row with a color-coded type bar, last/avg/peak CPU time,
+    /// draw-call counts, and a 60-frame sparkline trend.
+    void paint_pass_attribution(Canvas& canvas, float x, float y, float w, float h);
 
     // ── Panel hit testing ───────────────────────────────────────────
     bool point_in_panel(Point p) const;

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -191,6 +191,14 @@ bool InspectorOverlay::handle_key_event(const KeyEvent& event) {
         return true;
     }
 
+    // Phase 6.1 — P toggles the per-pass attribution viewer (no
+    // modifier; only while active, same rationale as the D toggle).
+    if (active_ && event.key == KeyCode::p && event.is_down &&
+        event.modifiers == 0) {
+        toggle_pass_viewer();
+        return true;
+    }
+
     return false;
 }
 
@@ -404,6 +412,12 @@ const InspectorOverlay::TreeItem* InspectorOverlay::tree_item_at_y(float y) cons
 void InspectorOverlay::paint(Canvas& canvas) {
     if (!active_) return;
 
+    // Phase 6.1 — sample the render-pass manager into the rolling
+    // attribution history once per frame. Cheap, no-op when no RPM is
+    // attached, and de-duplicated against frame_count() so multiple
+    // paints of the same frame don't inflate the history.
+    capture_pass_frame();
+
     rebuild_flat_tree();
     paint_highlight(canvas);
     paint_distance_lines(canvas);
@@ -589,9 +603,20 @@ void InspectorOverlay::paint_panel(Canvas& canvas) {
     canvas.set_stroke_color(Color::rgba(0.3f, 0.3f, 0.35f, 0.5f));
     canvas.stroke_line(panel_x + 8, props_y, root_w - 8, props_y);
 
-    // Props section (middle)
+    // Props section (middle). Phase 6.1 — when the per-pass attribution
+    // viewer is toggled on (P-key), it takes over this region instead
+    // of the property panel; the tree section above is untouched so the
+    // user keeps navigation context.
     float stats_y = root_h - kStatsBarHeight;
-    paint_props_section(canvas, panel_x + 8, props_y + 4, panel_width_ - 16, stats_y - props_y - 8);
+    float section_x = panel_x + 8;
+    float section_y = props_y + 4;
+    float section_w = panel_width_ - 16;
+    float section_h = stats_y - props_y - 8;
+    if (pass_viewer_enabled_) {
+        paint_pass_attribution(canvas, section_x, section_y, section_w, section_h);
+    } else {
+        paint_props_section(canvas, section_x, section_y, section_w, section_h);
+    }
 
     // Stats bar (bottom)
     paint_stats_bar(canvas, panel_x, stats_y, panel_width_);
@@ -921,6 +946,219 @@ void InspectorOverlay::paint_stats_bar(Canvas& canvas, float x, float y, float w
     auto count = ViewInspector::count_views(root_);
     canvas.set_fill_color(kPanelDim);
     canvas.fill_text(std::to_string(count) + " views", x + w - 60, y + 16);
+}
+
+// ── Phase 6.1 — Per-pass GPU/render attribution viewer ──────────────────────
+//
+// Surfaces where render time goes, broken down by render pass, over a
+// rolling 60-frame window. Reads RenderPassManager's existing per-pass
+// PassStats — CPU wall-time + draw-call counts. True GPU timestamps are
+// deferred to Phase 6.5 (Dawn timestamp queries); the panel labels its
+// numbers "cpu" so the distinction is honest and explicit.
+
+namespace {
+
+// Stable human-readable names for the five RenderPassType values, in
+// declaration order so index == static_cast<size_t>(type).
+constexpr std::array<const char*, 5> kPassTypeNames = {
+    "background", "content", "effects", "overlay", "post"
+};
+
+// Color-code each pass type so the panel reads at a glance — cool hues
+// for the cheap structural passes, warm for the expensive ones.
+const std::array<Color, 5> kPassTypeColors = {
+    Color::rgba(0.40f, 0.55f, 0.85f, 1.0f),  // background — blue
+    Color::rgba(0.45f, 0.80f, 0.55f, 1.0f),  // content    — green
+    Color::rgba(0.90f, 0.70f, 0.30f, 1.0f),  // effects    — amber
+    Color::rgba(0.85f, 0.45f, 0.80f, 1.0f),  // overlay    — magenta
+    Color::rgba(0.90f, 0.45f, 0.35f, 1.0f),  // post       — red
+};
+
+} // namespace
+
+bool InspectorOverlay::capture_pass_frame() {
+    if (!rpm_) return false;
+
+    // De-dup: only capture once per render-pass-manager frame. paint()
+    // can run multiple times for the same frame (e.g. partial redraw),
+    // and we don't want those to fill the history with copies of one
+    // frame's numbers. A frame_count() of 0 means begin_frame() was
+    // never called — treat that as "no frame to capture yet".
+    const std::uint64_t frame = rpm_->frame_count();
+    if (frame == 0 || frame == last_captured_frame_) return false;
+    last_captured_frame_ = frame;
+    ++pass_frames_captured_;
+
+    if (rpm_->over_budget()) ++budget_overrun_count_;
+
+    // Mark every pass type absent for this frame; the loop below flips
+    // back on the ones that actually rendered.
+    for (auto& ring : pass_rings_) ring.present_last_frame = false;
+
+    // The manager can emit the same pass type more than once per frame
+    // (e.g. two overlay passes). Accumulate per type so the history
+    // sample is the frame's TOTAL cost for that pass type.
+    std::array<float, kPassTypeCount> frame_cpu_ms{};
+    std::array<int, kPassTypeCount> frame_draw_calls{};
+    std::array<bool, kPassTypeCount> frame_seen{};
+    for (const auto& p : rpm_->passes()) {
+        auto idx = static_cast<std::size_t>(p.type);
+        if (idx >= kPassTypeCount) continue;  // defensive — unknown enum.
+        frame_cpu_ms[idx] += p.time_ms;
+        frame_draw_calls[idx] += p.draw_calls;
+        frame_seen[idx] = true;
+    }
+
+    for (std::size_t i = 0; i < kPassTypeCount; ++i) {
+        if (!frame_seen[i]) continue;  // pass absent this frame — no sample.
+        auto& ring = pass_rings_[i];
+        ring.cpu_ms[ring.head] = frame_cpu_ms[i];
+        ring.draw_calls[ring.head] = frame_draw_calls[i];
+        ring.head = (ring.head + 1) % kPassHistoryFrames;
+        if (ring.count < kPassHistoryFrames) ++ring.count;
+        ring.present_last_frame = true;
+    }
+    return true;
+}
+
+std::vector<InspectorOverlay::PassAttribution>
+InspectorOverlay::pass_attribution() const {
+    std::vector<PassAttribution> out;
+    out.reserve(kPassTypeCount);
+    for (std::size_t i = 0; i < kPassTypeCount; ++i) {
+        const auto& ring = pass_rings_[i];
+        PassAttribution a;
+        a.type = static_cast<int>(i);
+        a.name = kPassTypeNames[i];
+        a.samples = ring.count;
+        a.present = ring.present_last_frame;
+        if (ring.count > 0) {
+            // The most recent sample sits one slot behind head (mod N).
+            std::size_t last = (ring.head + kPassHistoryFrames - 1) % kPassHistoryFrames;
+            a.last_cpu_ms = ring.cpu_ms[last];
+            a.last_draw_calls = ring.draw_calls[last];
+            float sum = 0.0f;
+            for (std::size_t k = 0; k < ring.count; ++k) {
+                float v = ring.cpu_ms[k];
+                sum += v;
+                if (v > a.peak_cpu_ms) a.peak_cpu_ms = v;
+                if (ring.draw_calls[k] > a.peak_draw_calls)
+                    a.peak_draw_calls = ring.draw_calls[k];
+            }
+            a.avg_cpu_ms = sum / static_cast<float>(ring.count);
+        }
+        out.push_back(a);
+    }
+    return out;
+}
+
+void InspectorOverlay::paint_pass_attribution(Canvas& canvas, float x, float y,
+                                              float w, float h) {
+    canvas.set_font("monospace", kFontSize);
+    float line_y = y + 4;
+    const float line_h = 15.0f;
+
+    // Heading + honesty note about CPU-vs-GPU timing.
+    canvas.set_fill_color(kHighlightStroke);
+    canvas.fill_text("Render Passes (P)", x, line_y + 11);
+    line_y += line_h;
+    canvas.set_fill_color(kPanelDim);
+    canvas.fill_text("cpu time \xc2\xb7 GPU timestamps: Phase 6.5", x, line_y + 10);
+    line_y += line_h + 2;
+
+    if (!rpm_) {
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text("No RenderPassManager attached", x, line_y + 11);
+        return;
+    }
+
+    // Frame summary line: total CPU time, budget, overrun count.
+    {
+        std::ostringstream ss;
+        ss << std::fixed << std::setprecision(2)
+           << rpm_->total_time_ms() << "ms / "
+           << std::setprecision(1) << rpm_->budget() << "ms budget";
+        canvas.set_fill_color(rpm_->over_budget() ? kStatsWarn : kPanelText);
+        canvas.fill_text(ss.str(), x, line_y + 11);
+        line_y += line_h;
+
+        std::ostringstream ss2;
+        ss2 << budget_overrun_count_ << " overruns \xc2\xb7 "
+            << pass_frames_captured_ << " frames";
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text(ss2.str(), x, line_y + 11);
+        line_y += line_h + 4;
+    }
+
+    auto attribution = pass_attribution();
+
+    // The trend sparkline scales relative to the worst single-pass
+    // CPU sample across all passes so bars are comparable to each other.
+    float global_peak = 0.001f;
+    for (const auto& a : attribution)
+        if (a.peak_cpu_ms > global_peak) global_peak = a.peak_cpu_ms;
+
+    bool any = false;
+    for (std::size_t i = 0; i < attribution.size(); ++i) {
+        const auto& a = attribution[i];
+        if (a.samples == 0) continue;  // pass never rendered — skip row.
+        any = true;
+        if (line_y > y + h - line_h * 2) break;  // out of panel space.
+
+        const Color& pass_color = kPassTypeColors[i];
+
+        // Color-coded pass-type chip + name. Dim the name when the pass
+        // was absent from the most recent frame (history but quiet now).
+        canvas.set_fill_color(pass_color);
+        canvas.fill_rounded_rect(x, line_y + 2, 8, 10, 2);
+        canvas.set_fill_color(a.present ? kPanelText : kPanelDim);
+        canvas.fill_text(a.name, x + 14, line_y + 11);
+
+        // last / avg / peak CPU ms, right-aligned-ish in a fixed column.
+        std::ostringstream stat;
+        stat << std::fixed << std::setprecision(2)
+             << a.last_cpu_ms << " ~" << a.avg_cpu_ms
+             << " ^" << a.peak_cpu_ms << "ms";
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text(stat.str(), x + 90, line_y + 11);
+        line_y += line_h;
+
+        // Draw-call line.
+        std::ostringstream dc;
+        dc << a.last_draw_calls << " draws (peak " << a.peak_draw_calls << ")";
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text(dc.str(), x + 14, line_y + 10);
+        line_y += line_h;
+
+        // 60-frame CPU-time sparkline. Walk the ring oldest→newest so
+        // the bars read left-to-right in chronological order.
+        const auto& ring = pass_rings_[i];
+        if (ring.count > 0) {
+            const float spark_h = 14.0f;
+            const float spark_w = std::min(w - 14.0f, 220.0f);
+            const float bar_w = spark_w / static_cast<float>(kPassHistoryFrames);
+            const float base_y = line_y + spark_h;
+            canvas.set_fill_color(Color::rgba(0, 0, 0, 0.35f));
+            canvas.fill_rect(x + 14, line_y, spark_w, spark_h);
+            std::size_t start = (ring.head + kPassHistoryFrames - ring.count)
+                                % kPassHistoryFrames;
+            for (std::size_t k = 0; k < ring.count; ++k) {
+                float v = ring.cpu_ms[(start + k) % kPassHistoryFrames];
+                float frac = v / global_peak;
+                if (frac > 1.0f) frac = 1.0f;
+                float bh = frac * spark_h;
+                canvas.set_fill_color(pass_color);
+                canvas.fill_rect(x + 14 + static_cast<float>(k) * bar_w,
+                                 base_y - bh, std::max(bar_w - 1.0f, 1.0f), bh);
+            }
+            line_y += spark_h + 6;
+        }
+    }
+
+    if (!any) {
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text("Awaiting render frames\xe2\x80\xa6", x, line_y + 11);
+    }
 }
 
 // ── Phase 3b — Live-editable box-model fields ───────────────────────────────

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -4,7 +4,9 @@
 #include <pulp/view/inspector.hpp>
 #include <pulp/view/widgets.hpp>
 
+#include <cstddef>
 #include <string_view>
+#include <tuple>
 #include <vector>
 
 using namespace pulp::view;
@@ -190,6 +192,7 @@ TEST_CASE("Protocol: decode invalid JSON") {
 // ── InspectorOverlay ────────────────────────────────────────────────────────
 
 #include <pulp/inspect/inspector_overlay.hpp>
+#include <pulp/render/render_pass.hpp>
 
 TEST_CASE("InspectorOverlay: toggle") {
     View root;
@@ -2073,4 +2076,326 @@ TEST_CASE("LiveConstant.reset rolls a value back to its default",
     REQUIRE_FALSE(resp.is_error);
     REQUIRE_THAT(registry.get("test_reset"),
                  Catch::Matchers::WithinAbs(2.0, 0.001));
+}
+
+// ── Phase 6.1 — per-pass GPU/render attribution viewer ──────────────────────
+//
+// Spec: planning/2026-05-19-inspector-phase6-gpu-perf-spike.md § Phase 6.1.
+// The viewer surfaces per-pass render cost over a rolling 60-frame window
+// using RenderPassManager's existing CPU-time PassStats. True GPU
+// timestamps are deferred to Phase 6.5 — these tests assert only what the
+// RenderPassManager can actually report today.
+
+namespace {
+
+using pulp::render::RenderPassManager;
+using pulp::render::RenderPassType;
+
+// Drive one synthetic render frame through the manager: begin a frame,
+// emit each (type, time_ms, draw_calls) pass, end the frame.
+void render_synthetic_frame(
+    RenderPassManager& rpm,
+    const std::vector<std::tuple<RenderPassType, float, int>>& passes) {
+    rpm.begin_frame();
+    for (auto& [type, ms, dc] : passes) {
+        rpm.begin_pass(type);
+        rpm.end_pass(ms, dc);
+    }
+    rpm.end_frame();
+}
+
+// Count RecordingCanvas fill_text commands whose text contains `needle`.
+int count_text_containing(const pulp::canvas::RecordingCanvas& canvas,
+                          std::string_view needle) {
+    int n = 0;
+    for (const auto& cmd : canvas.commands()) {
+        if (cmd.type == pulp::canvas::DrawCommand::Type::fill_text &&
+            cmd.text.find(needle) != std::string::npos)
+            ++n;
+    }
+    return n;
+}
+
+} // namespace
+
+TEST_CASE("InspectorOverlay Phase 6.1: capture_pass_frame is a no-op without an RPM",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+
+    REQUIRE_FALSE(overlay.capture_pass_frame());
+    REQUIRE(overlay.pass_frames_captured() == 0);
+    // Every pass entry reports zero history.
+    for (const auto& a : overlay.pass_attribution())
+        REQUIRE(a.samples == 0);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.1: capture accumulates per-pass history",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+
+    RenderPassManager rpm;
+    overlay.set_render_pass_manager(&rpm);
+
+    // Frame 1: background + content passes.
+    render_synthetic_frame(rpm, {
+        {RenderPassType::background, 1.0f, 3},
+        {RenderPassType::content,    4.0f, 12},
+    });
+    REQUIRE(overlay.capture_pass_frame());
+    REQUIRE(overlay.pass_frames_captured() == 1);
+
+    // Frame 2: content gets heavier, an overlay pass appears.
+    render_synthetic_frame(rpm, {
+        {RenderPassType::background, 1.0f, 3},
+        {RenderPassType::content,    8.0f, 20},
+        {RenderPassType::overlay,    2.0f, 5},
+    });
+    REQUIRE(overlay.capture_pass_frame());
+    REQUIRE(overlay.pass_frames_captured() == 2);
+
+    auto attrib = overlay.pass_attribution();
+    REQUIRE(attrib.size() == 5);  // one entry per RenderPassType.
+
+    // background: two samples, steady at 1.0ms.
+    const auto& bg = attrib[static_cast<int>(RenderPassType::background)];
+    REQUIRE(bg.samples == 2);
+    REQUIRE(bg.present);
+    REQUIRE_THAT(bg.last_cpu_ms, Catch::Matchers::WithinAbs(1.0, 0.001));
+    REQUIRE_THAT(bg.avg_cpu_ms, Catch::Matchers::WithinAbs(1.0, 0.001));
+    REQUIRE(bg.last_draw_calls == 3);
+
+    // content: avg of 4 and 8 = 6, peak 8, last 8.
+    const auto& content = attrib[static_cast<int>(RenderPassType::content)];
+    REQUIRE(content.samples == 2);
+    REQUIRE_THAT(content.last_cpu_ms, Catch::Matchers::WithinAbs(8.0, 0.001));
+    REQUIRE_THAT(content.avg_cpu_ms, Catch::Matchers::WithinAbs(6.0, 0.001));
+    REQUIRE_THAT(content.peak_cpu_ms, Catch::Matchers::WithinAbs(8.0, 0.001));
+    REQUIRE(content.peak_draw_calls == 20);
+
+    // overlay: only one sample (absent from frame 1).
+    const auto& overlay_pass = attrib[static_cast<int>(RenderPassType::overlay)];
+    REQUIRE(overlay_pass.samples == 1);
+    REQUIRE(overlay_pass.present);
+
+    // effects + post never rendered — no history, not present.
+    const auto& effects = attrib[static_cast<int>(RenderPassType::effects)];
+    REQUIRE(effects.samples == 0);
+    REQUIRE_FALSE(effects.present);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.1: capture de-dups within a single frame",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+
+    RenderPassManager rpm;
+    overlay.set_render_pass_manager(&rpm);
+
+    render_synthetic_frame(rpm, {{RenderPassType::content, 5.0f, 10}});
+
+    // First capture records the frame; a second capture of the SAME
+    // frame (no begin_frame between) must be a no-op so paint() running
+    // multiple times per frame doesn't inflate history.
+    REQUIRE(overlay.capture_pass_frame());
+    REQUIRE_FALSE(overlay.capture_pass_frame());
+    REQUIRE(overlay.pass_frames_captured() == 1);
+
+    auto attrib = overlay.pass_attribution();
+    REQUIRE(attrib[static_cast<int>(RenderPassType::content)].samples == 1);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.1: same pass type twice in a frame sums",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+
+    RenderPassManager rpm;
+    overlay.set_render_pass_manager(&rpm);
+
+    // Two overlay passes in one frame — the history sample is the
+    // frame's TOTAL overlay cost (1.5 + 0.5 = 2.0ms, 4 + 2 = 6 draws).
+    render_synthetic_frame(rpm, {
+        {RenderPassType::overlay, 1.5f, 4},
+        {RenderPassType::overlay, 0.5f, 2},
+    });
+    REQUIRE(overlay.capture_pass_frame());
+
+    auto attrib = overlay.pass_attribution();
+    const auto& ov = attrib[static_cast<int>(RenderPassType::overlay)];
+    REQUIRE(ov.samples == 1);
+    REQUIRE_THAT(ov.last_cpu_ms, Catch::Matchers::WithinAbs(2.0, 0.001));
+    REQUIRE(ov.last_draw_calls == 6);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.1: history ring caps at kPassHistoryFrames",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+
+    RenderPassManager rpm;
+    overlay.set_render_pass_manager(&rpm);
+
+    // Push more frames than the ring holds; only the last N count
+    // toward per-pass detail, but the lifetime counter keeps growing.
+    const std::size_t extra = 25;
+    const std::size_t total = InspectorOverlay::kPassHistoryFrames + extra;
+    for (std::size_t i = 0; i < total; ++i) {
+        render_synthetic_frame(rpm, {{RenderPassType::content,
+                                      static_cast<float>(i % 7), 1}});
+        REQUIRE(overlay.capture_pass_frame());
+    }
+    REQUIRE(overlay.pass_frames_captured() == total);
+
+    auto attrib = overlay.pass_attribution();
+    const auto& content = attrib[static_cast<int>(RenderPassType::content)];
+    REQUIRE(content.samples == InspectorOverlay::kPassHistoryFrames);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.1: budget overruns are counted",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+
+    RenderPassManager rpm;
+    rpm.set_budget(5.0f);  // tight 5ms budget.
+    overlay.set_render_pass_manager(&rpm);
+
+    // Frame 1: under budget (3ms).
+    render_synthetic_frame(rpm, {{RenderPassType::content, 3.0f, 4}});
+    REQUIRE(overlay.capture_pass_frame());
+    REQUIRE(overlay.budget_overrun_count() == 0);
+
+    // Frame 2: over budget (9ms).
+    render_synthetic_frame(rpm, {{RenderPassType::content, 9.0f, 4}});
+    REQUIRE(overlay.capture_pass_frame());
+    REQUIRE(overlay.budget_overrun_count() == 1);
+
+    // Frame 3: over budget again (12ms).
+    render_synthetic_frame(rpm, {{RenderPassType::content, 12.0f, 4}});
+    REQUIRE(overlay.capture_pass_frame());
+    REQUIRE(overlay.budget_overrun_count() == 2);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.1: P key toggles the attribution viewer",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    REQUIRE_FALSE(overlay.pass_viewer_enabled());
+
+    KeyEvent p;
+    p.key = KeyCode::p;
+    p.is_down = true;
+    p.modifiers = 0;
+    REQUIRE(overlay.handle_key_event(p));
+    REQUIRE(overlay.pass_viewer_enabled());
+
+    REQUIRE(overlay.handle_key_event(p));
+    REQUIRE_FALSE(overlay.pass_viewer_enabled());
+}
+
+TEST_CASE("InspectorOverlay Phase 6.1: P key ignored when inspector inactive",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_bounds({0, 0, 400, 300});
+    InspectorOverlay overlay(root);
+    // Not active — the P hotkey must not fire so it can't collide with
+    // a plain text field in the host UI.
+
+    KeyEvent p;
+    p.key = KeyCode::p;
+    p.is_down = true;
+    p.modifiers = 0;
+    REQUIRE_FALSE(overlay.handle_key_event(p));
+    REQUIRE_FALSE(overlay.pass_viewer_enabled());
+}
+
+TEST_CASE("InspectorOverlay Phase 6.1: viewer renders per-pass rows",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_id("root");
+    // Tall enough that the panel's lower section fits both pass rows
+    // (heading + summary + two ~56px rows). The lower section gets
+    // roughly half the window height minus the stats bar.
+    root.set_bounds({0, 0, 500, 720});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    RenderPassManager rpm;
+    overlay.set_render_pass_manager(&rpm);
+
+    // Drive a few frames with two distinct pass types.
+    for (int i = 0; i < 3; ++i) {
+        render_synthetic_frame(rpm, {
+            {RenderPassType::background, 1.0f, 2},
+            {RenderPassType::content,    5.0f + static_cast<float>(i), 14},
+        });
+        // paint() captures the frame; toggle viewer on first.
+        if (i == 0) overlay.set_pass_viewer_enabled(true);
+        pulp::canvas::RecordingCanvas warmup;
+        overlay.paint(warmup);
+    }
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+    REQUIRE(canvas.command_count() > 0);
+
+    // The viewer heading and both rendered pass names must appear.
+    REQUIRE(count_text_containing(canvas, "Render Passes") >= 1);
+    REQUIRE(count_text_containing(canvas, "background") >= 1);
+    REQUIRE(count_text_containing(canvas, "content") >= 1);
+    // Honesty note about CPU vs GPU timing is surfaced.
+    REQUIRE(count_text_containing(canvas, "Phase 6.5") >= 1);
+    // "effects" never rendered — must NOT show a row for it.
+    REQUIRE(count_text_containing(canvas, "effects") == 0);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.1: viewer reports missing RPM gracefully",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_bounds({0, 0, 500, 320});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_pass_viewer_enabled(true);
+    // No RenderPassManager attached.
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+    REQUIRE(count_text_containing(canvas, "No RenderPassManager") >= 1);
+}
+
+TEST_CASE("InspectorOverlay Phase 6.1: paint() drives capture automatically",
+          "[inspect][overlay][phase6]") {
+    View root;
+    root.set_bounds({0, 0, 500, 320});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    RenderPassManager rpm;
+    overlay.set_render_pass_manager(&rpm);
+
+    render_synthetic_frame(rpm, {{RenderPassType::content, 4.0f, 8}});
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);  // should capture the frame internally.
+    REQUIRE(overlay.pass_frames_captured() == 1);
+
+    // A second paint of the SAME frame does not re-capture.
+    overlay.paint(canvas);
+    REQUIRE(overlay.pass_frames_captured() == 1);
+
+    // A new frame, then paint, captures again.
+    render_synthetic_frame(rpm, {{RenderPassType::content, 6.0f, 9}});
+    overlay.paint(canvas);
+    REQUIRE(overlay.pass_frames_captured() == 2);
 }


### PR DESCRIPTION
Surface where render time goes, broken down by render pass, over a
rolling 60-frame window. The InspectorOverlay now samples the attached
RenderPassManager's per-pass PassStats every frame into fixed-size
per-pass-type ring buffers, then presents a panel section (P-key
toggle) with each pass's last/avg/peak CPU time, draw-call counts, a
60-frame sparkline trend, and a budget-overrun count.

Scope follows planning/2026-05-19-inspector-phase6-gpu-perf-spike.md
§ Phase 6.1: it surfaces only data the RenderPassManager already
exposes today. PassStats::time_ms is CPU wall-time around the pass's
draw calls, not true GPU time — the viewer labels its numbers "cpu"
and notes that real GPU timestamp queries are deferred to Phase 6.5
(Dawn timestamp queries). No core/render change: the manager already
populates everything needed; the overlay keeps its own history since
the manager only retains the current frame.

Adds 11 headless Catch2 tests covering capture accumulation, per-frame
de-dup, same-type-twice summing, ring-buffer capping, budget-overrun
counting, the P-key toggle, and RecordingCanvas render assertions.

Inspector overlay is dev tooling, not user-facing SDK surface.

Version-Bump: skip reason="inspector dev-tooling only, no SDK/CLI or plugin surface change"

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>