### PR TITLE
ci(nightly): build-gate the nightly run + local-actionlint guidance

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -708,10 +708,18 @@ What it does:
   self-hosted M1 runners: a nightly must not compete with PR CI for the
   M1's 2 runners, and overnight latency is irrelevant for a sweep.
 - Configures the **full tree** (`examples ON`, tests ON — no
-  `-DPULP_BUILD_EXAMPLES=OFF`) and builds **everything** with
-  `cmake --build --keep-going`, so one broken target does not mask the
-  rest. The whole `--keep-going` log is uploaded as an artifact.
-- On build/test failure, opens or updates a single de-duplicated
+  `-DPULP_BUILD_EXAMPLES=OFF`) with `-G Ninja`, and builds **everything**
+  with `cmake --build … -- -k 0` (Ninja keep-going — `cmake` itself has
+  no `--keep-going` flag), so one broken target does not mask the rest.
+  The full build log is uploaded as an artifact.
+- **The run is gated on the BUILD step only.** ctest still runs but is
+  *informational*: the nightly runs on GitHub-hosted `macos-15`, which
+  lacks the M1's GPU, installed fonts, and registered AU components, so
+  ~15 golden / GPU / `auval` / platform-harness tests fail there though
+  they pass on the M1 in PR CI. Gating on ctest would make the nightly
+  red every night; instead ctest results land in the run's step summary
+  for eyeballing.
+- On a **build** failure, opens or updates a single de-duplicated
   tracking issue and auto-closes it on the next green run — the same
   watchdog pattern as `auto-release-watchdog.yml` and
   `release-cadence-check.yml` (`permissions: issues: write`).
@@ -719,6 +727,24 @@ What it does:
 If you see the "Nightly full build is broken" tracker, a refactor broke
 a test target PR CI never compiles. Download the `nightly-full-build-logs`
 artifact for the full failure list.
+
+### Linting workflow files locally
+
+`actionlint` is **slow on Pulp's large workflows** — it shells out to
+`shellcheck` for every `run:` block, and `build.yml` has many big ones,
+so a local `actionlint .github/workflows/build.yml` can spin for many
+minutes (observed at 338% CPU / 8+ min with no result). Do not wait it
+out:
+
+- Run `actionlint -shellcheck=` — the empty value disables the
+  `shellcheck` integration. It still validates workflow YAML, action
+  refs, and `${{ }}` expression syntax; it just skips the slow
+  per-`run`-block shell linting.
+- Or skip local `actionlint` entirely: `yamllint -d relaxed` locally is
+  enough, and the CI **`Workflow lint`** job runs `actionlint`
+  authoritatively on a fast Linux runner.
+
+Never leave a runaway `actionlint` process behind.
 
 ## Stale run reaper (`stale-run-reaper.yml`)
 

--- a/.github/workflows/nightly-full-build.yml
+++ b/.github/workflows/nightly-full-build.yml
@@ -99,7 +99,7 @@ jobs:
             echo "status=fail" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run test suite
+      - name: Run test suite (informational — does not gate the run)
         id: test
         shell: bash
         run: |
@@ -109,6 +109,22 @@ jobs:
           else
             echo "status=fail" >> "$GITHUB_OUTPUT"
           fi
+          # ctest is INFORMATIONAL on the nightly. This job runs on
+          # GitHub-hosted macos-15, which lacks the self-hosted M1's GPU,
+          # installed fonts, and registered AU components — so a chunk of
+          # golden / GPU / auval / platform-harness tests fail here even
+          # though they pass on the M1 in PR CI. The run's pass/fail is
+          # gated on the BUILD step only (see "Compute result" — that is
+          # #2462's actual concern: test targets that do not COMPILE).
+          # ctest results are surfaced in the run summary for eyeballing.
+          {
+            echo "## Nightly ctest (informational — does not gate the run)"
+            grep -E 'tests passed|tests failed out of' ctest-nightly.log || true
+            echo
+            echo '```'
+            grep -E '\*\*\*Failed|\*\*\*Timeout' ctest-nightly.log || echo '(no test failures)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload build + test logs
         if: always()
@@ -129,13 +145,19 @@ jobs:
           set -euo pipefail
           build='${{ steps.build.outputs.status }}'
           test='${{ steps.test.outputs.status }}'
-          if [ "$build" = "pass" ] && [ "$test" = "pass" ]; then
+          # Gate on the BUILD only. #2462's concern is test targets that
+          # do not COMPILE — caught by the build step. ctest runs on
+          # GitHub-hosted macos-15, whose environment differs from the
+          # M1 (no GPU / fonts / AU components), so its runtime failures
+          # are not reliable signal and must not fail the run. ctest
+          # results are still surfaced in the run summary.
+          if [ "$build" = "pass" ]; then
             result="success"
           else
             result="failure"
           fi
           echo "result=${result}"          >> "$GITHUB_OUTPUT"
-          echo "Build=${build:-skipped} Test=${test:-skipped} -> ${result}"
+          echo "Build=${build:-skipped} Test=${test:-skipped} (informational) -> ${result}"
 
       - name: Maintain tracking issue
         if: always()


### PR DESCRIPTION
## Summary

Two CI-hygiene changes, both surfaced this session.

### 1. Build-gate the nightly full-build run

The nightly's first real run (#2478) exposed a design flaw: `ctest` on
GitHub-hosted `macos-15` fails ~15 golden / GPU / `auval` /
platform-harness tests that **pass on the M1 in PR CI** — that runner
lacks the M1's GPU, installed fonts, and registered AU components. As
written, the nightly would go red every night and bury any real signal.

#2462's actual concern is test targets that don't **compile** — caught
by the build step. So:
- the run's pass/fail is now gated on the **build step only**;
- `ctest` still runs, but its results (pass count + failed-test list)
  go to the run's **step summary** for eyeballing — they no longer fail
  the run;
- the tracking issue now opens only on a real **build** failure.

Also corrects the SKILL.md text to match the actual workflow
(`-G Ninja` + `cmake --build … -- -k 0` — `cmake` has no `--keep-going`).

### 2. Local-`actionlint` guidance (`ci` SKILL.md)

`actionlint` shells out to `shellcheck` per `run:` block; on Pulp's
large `build.yml` a local run spins for many minutes (observed 338% CPU
/ 8+ min). Multiple agents have burned time on this. The `ci` skill now
documents: run `actionlint -shellcheck=` (disables the slow shell
linting, keeps workflow/action-ref validation) or rely on the CI
`Workflow lint` gate — don't wait out a local `actionlint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)