### PR TITLE
fix(inspect): suppress real editor launch in source-jump tests/CI

### DIFF
--- a/inspect/include/pulp/inspect/source_jump.hpp
+++ b/inspect/include/pulp/inspect/source_jump.hpp
@@ -60,6 +60,14 @@ SourceJumpResult resolve_source_jump(const InspectorConfig& config,
 /// This is the side-effecting seam: callers that want a dry run (tests,
 /// the protocol `dryRun` param) should call `resolve_source_jump()` and
 /// skip this entirely.
+///
+/// Guard: when the environment variable `PULP_INSPECTOR_NO_LAUNCH` is
+/// set to a non-empty value, this function never spawns a process and
+/// returns false. The test suite sets it (per-target in CTest, and the
+/// J-hotkey test sets it in-process) so a headless run can never pop a
+/// real editor window or the macOS "an external application wants to
+/// open …" security dialog. An interactive session leaves it unset, so
+/// a genuine user action launches the editor for real.
 bool launch_editor_url(std::string_view url);
 
 /// Convenience: resolve + launch in one call. When `dry_run` is true,

--- a/inspect/src/source_jump.cpp
+++ b/inspect/src/source_jump.cpp
@@ -6,6 +6,8 @@
 #include <pulp/inspect/source_jump.hpp>
 #include <pulp/view/view.hpp>
 
+#include <cstdlib>
+
 #if defined(_WIN32)
   #include <windows.h>
   #include <shellapi.h>
@@ -17,6 +19,26 @@
 #endif
 
 namespace pulp::inspect {
+
+namespace {
+
+// Test / CI / non-interactive guard. When `PULP_INSPECTOR_NO_LAUNCH` is
+// set to a non-empty value, `launch_editor_url()` resolves and formats
+// the URL exactly as it would otherwise, but never spawns the editor
+// process. This keeps headless test runs, CI, and any scripted /
+// non-interactive use of the inspector from popping a real editor
+// window (and, on macOS, the "an external application wants to open …"
+// security dialog). A genuine user action — the J hotkey in an
+// interactive session — runs without this env var and launches for
+// real. Tests assert the *constructed* URL via `resolve_source_jump()`
+// or the `dryRun` protocol path; they must never depend on a real
+// launch.
+bool editor_launch_suppressed() {
+    const char* v = std::getenv("PULP_INSPECTOR_NO_LAUNCH");
+    return v != nullptr && v[0] != '\0';
+}
+
+} // namespace
 
 SourceJumpResult resolve_source_jump(const InspectorConfig& config,
                                      const pulp::view::View* view) {
@@ -61,6 +83,13 @@ SourceJumpResult resolve_source_jump(const InspectorConfig& config,
 
 bool launch_editor_url(std::string_view url) {
     if (url.empty()) return false;
+
+    // Defense in depth: refuse to spawn under the test/CI/non-interactive
+    // guard. This is independent of the `dry_run` flag — even a caller
+    // that asked to launch (the J hotkey wired with `dry_run=false`) is
+    // suppressed when the env var is set, so a non-interactive run can
+    // never pop a real editor or the macOS open-confirmation dialog.
+    if (editor_launch_suppressed()) return false;
 
 #if defined(_WIN32)
     std::wstring wurl(url.begin(), url.end());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1997,7 +1997,14 @@ catch_discover_tests(pulp-test-hot-reload
 if(PULP_ENABLE_GPU AND NOT ANDROID AND NOT IOS)
     add_executable(pulp-test-inspector test_inspector.cpp)
     target_link_libraries(pulp-test-inspector PRIVATE pulp::view pulp::inspect pulp::state Catch2::Catch2WithMain)
-    catch_discover_tests(pulp-test-inspector)
+    # PULP_INSPECTOR_NO_LAUNCH: the source-jump tests exercise the J
+    # hotkey, whose handler resolves with dry_run=false. Without this
+    # guard the test would spawn a real `open vscode://file/...`, popping
+    # a macOS open-confirmation dialog. The env var makes launch_editor_url()
+    # a no-op. The test file also sets it in-process so it stays safe when
+    # the binary is run directly, outside CTest.
+    catch_discover_tests(pulp-test-inspector
+        PROPERTIES ENVIRONMENT "PULP_INSPECTOR_NO_LAUNCH=1")
 
     # Phase 0b PR-A: TweakStore + Inspector.applyTweak protocol surface.
     # planning/2026-05-18-inspector-direct-manipulation-roadmap.md
@@ -2012,7 +2019,8 @@ if(PULP_ENABLE_GPU AND NOT ANDROID AND NOT IOS)
     # planning/2026-05-19-inspector-phase5-source-jump-spike.md
     add_executable(pulp-test-editor-url test_editor_url.cpp)
     target_link_libraries(pulp-test-editor-url PRIVATE pulp::inspect Catch2::Catch2WithMain)
-    catch_discover_tests(pulp-test-editor-url)
+    catch_discover_tests(pulp-test-editor-url
+        PROPERTIES ENVIRONMENT "PULP_INSPECTOR_NO_LAUNCH=1")
 endif()
 
 # Widget bridge tests

--- a/test/test_editor_url.cpp
+++ b/test/test_editor_url.cpp
@@ -361,6 +361,46 @@ TEST_CASE("launch_editor_url rejects an empty URL", "[inspect][source-jump]") {
     REQUIRE_FALSE(launch_editor_url(""));
 }
 
+// ── Phase 5.1: PULP_INSPECTOR_NO_LAUNCH guard ──────────────────────────────
+//
+// Regression cover for the unexpected-editor-launch bug: a non-interactive
+// run (test binary, CI) that hits the real-launch path (dry_run=false)
+// must never spawn `open vscode://file/...` and pop the macOS
+// open-confirmation dialog. The guard env var makes launch_editor_url() a
+// no-op. The pulp-test-editor-url / pulp-test-inspector CTest targets set
+// PULP_INSPECTOR_NO_LAUNCH=1 globally; these tests set it in-process via
+// ScopedEnv so they are deterministic even when the binary is run
+// directly, and they restore the prior value on scope exit.
+
+TEST_CASE("launch_editor_url is suppressed under PULP_INSPECTOR_NO_LAUNCH",
+          "[inspect][source-jump]") {
+    ScopedEnv guard("PULP_INSPECTOR_NO_LAUNCH");
+    guard.set("1");
+    // A well-formed URL would normally spawn the OS handler; with the
+    // guard set, launch_editor_url() returns false without spawning.
+    REQUIRE_FALSE(launch_editor_url("vscode://file/src/Panel.jsx:24"));
+}
+
+TEST_CASE("jump_to_source with dry_run=false does not launch under the guard",
+          "[inspect][source-jump]") {
+    ScopedEnv editor("PULP_INSPECTOR_EDITOR_URL");
+    editor.unset();
+    ScopedEnv guard("PULP_INSPECTOR_NO_LAUNCH");
+    guard.set("1");
+
+    pulp::view::View view;
+    view.set_source_loc({"src/Panel.jsx", 24, 3});
+
+    InspectorConfig cfg;  // default vscode template
+    // dry_run=false is the real-launch path the J hotkey uses. The URL
+    // still resolves so a caller can read/assert it, but `launched`
+    // stays false because the guard suppressed the spawn.
+    auto result = jump_to_source(cfg, &view, /*dry_run=*/false);
+    REQUIRE(result.ok);
+    REQUIRE(result.url == "vscode://file/src/Panel.jsx:24");
+    REQUIRE_FALSE(result.launched);
+}
+
 // ── Phase 5.1: Inspector.jumpToSource protocol round-trip ──────────────────
 
 TEST_CASE("Inspector.jumpToSource resolves an anchored view in dryRun",

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -3200,6 +3200,44 @@ TEST_CASE("InspectorOverlay Phase 6.1: paint() drives capture automatically",
 #include <pulp/inspect/source_jump.hpp>
 #include <choc/text/choc_JSON.h>
 
+#include <cstdlib>
+
+namespace {
+
+// Scoped guard that sets PULP_INSPECTOR_NO_LAUNCH for the duration of a
+// test, restoring the prior value on destruction. The overlay's J
+// hotkey resolves with dry_run=false and would otherwise spawn a real
+// editor (and pop the macOS open-confirmation dialog). The CTest target
+// sets this env var globally, but a test that exercises the real-launch
+// path sets it in-process too so it is safe when the binary is run
+// directly. With the guard in place, launch_editor_url() never spawns a
+// process and reports launched=false.
+struct ScopedNoLaunch {
+    ScopedNoLaunch() {
+        if (const char* prev = std::getenv("PULP_INSPECTOR_NO_LAUNCH")) {
+            prev_ = std::string(prev);
+            had_prev_ = true;
+        }
+#if defined(_WIN32)
+        _putenv_s("PULP_INSPECTOR_NO_LAUNCH", "1");
+#else
+        ::setenv("PULP_INSPECTOR_NO_LAUNCH", "1", /*overwrite=*/1);
+#endif
+    }
+    ~ScopedNoLaunch() {
+#if defined(_WIN32)
+        _putenv_s("PULP_INSPECTOR_NO_LAUNCH", had_prev_ ? prev_.c_str() : "");
+#else
+        if (had_prev_) ::setenv("PULP_INSPECTOR_NO_LAUNCH", prev_.c_str(), 1);
+        else ::unsetenv("PULP_INSPECTOR_NO_LAUNCH");
+#endif
+    }
+    std::string prev_;
+    bool had_prev_ = false;
+};
+
+} // namespace
+
 TEST_CASE("View::source_loc round-trips a file:line:col record",
           "[inspect][source-jump]") {
     View v;
@@ -3238,6 +3276,13 @@ TEST_CASE("ViewInspector::find_by_anchor locates a view by its anchor id",
 
 TEST_CASE("InspectorOverlay: J jumps to source for a view with provenance",
           "[inspect][overlay][source-jump]") {
+    // The J hotkey resolves with dry_run=false — the real-launch path.
+    // Without the no-launch guard this would spawn `open vscode://...`
+    // and pop the macOS open-confirmation dialog. The guard makes
+    // launch_editor_url() a no-op so the test verifies the *constructed*
+    // URL, never an actual editor launch.
+    ScopedNoLaunch no_launch;
+
     View root;
     root.set_bounds({0, 0, 500, 300});
     auto child = std::make_unique<View>();
@@ -3263,7 +3308,21 @@ TEST_CASE("InspectorOverlay: J jumps to source for a view with provenance",
     REQUIRE(result.url == "vscode://file/src/Panel.jsx:24");
     REQUIRE_FALSE(result.launched);
 
-    // The J hotkey is consumed while the inspector is active.
+    // Real-launch path (dry_run=false), as the J hotkey runs it: the URL
+    // still resolves, but the no-launch guard suppresses the spawn so
+    // `launched` stays false. This is the regression assertion for the
+    // unexpected-editor-launch bug.
+    auto live = overlay.jump_to_selection_source(/*dry_run=*/false);
+    REQUIRE(live.ok);
+    REQUIRE(live.url == "vscode://file/src/Panel.jsx:24");
+    REQUIRE_FALSE(live.launched);
+
+    // launch_editor_url() itself is a no-op under the guard.
+    REQUIRE_FALSE(launch_editor_url("vscode://file/src/Panel.jsx:24"));
+
+    // The J hotkey is consumed while the inspector is active. The
+    // handler runs the dry_run=false path; the guard keeps it from
+    // spawning a real editor process.
     KeyEvent jk;
     jk.key = KeyCode::j;
     jk.modifiers = 0;
@@ -3273,6 +3332,11 @@ TEST_CASE("InspectorOverlay: J jumps to source for a view with provenance",
 
 TEST_CASE("InspectorOverlay: J is a graceful no-op without a selection",
           "[inspect][overlay][source-jump]") {
+    // No selection means jump_to_source resolves ok==false and never
+    // reaches launch_editor_url(); the guard is belt-and-suspenders so
+    // the key event below stays inert when the binary is run directly.
+    ScopedNoLaunch no_launch;
+
     View root;
     InspectorOverlay overlay(root);
     overlay.set_active(true);


### PR DESCRIPTION
The inspector source-jump J hotkey resolves with dry_run=false — the
real-launch path. The Phase 5.1 test "InspectorOverlay: J jumps to
source for a view with provenance" sent a real J KeyEvent through
handle_key_event(), which spawned `open vscode://file/src/Panel.jsx:24`
during the test run. On macOS that pops the "an external application
wants to open '/src/Panel.jsx:24' in Code" security dialog — an
unexpected editor launch from a non-interactive context.

Root cause: launch_editor_url() had no test/CI guard. Any
non-interactive J-hotkey press (test binary, CI, scripted use) spawned
the editor for real.

Fix — gate the side-effecting launch behind a non-interactive guard:

- launch_editor_url() now no-ops and returns false when the env var
  PULP_INSPECTOR_NO_LAUNCH is set to a non-empty value. This is
  independent of dry_run, so even a caller that asked to launch (the J
  hotkey) is suppressed in a guarded context. A genuine interactive
  user action leaves the var unset and launches for real.
- The pulp-test-inspector and pulp-test-editor-url CTest targets set
  PULP_INSPECTOR_NO_LAUNCH=1 via catch_discover_tests ENVIRONMENT.
- The J-hotkey overlay tests set the var in-process (ScopedNoLaunch)
  so they stay safe when the binary is run directly, outside CTest,
  and restore the prior value on scope exit.

Tests: the J-hotkey test now also exercises the dry_run=false path and
asserts launched==false (the regression assertion); new test_editor_url
cases verify launch_editor_url() and jump_to_source(dry_run=false) are
suppressed under the guard. Tests verify the *constructed* URL, never a
real launch.

Version-Bump: skip reason="inspect/* is a dev-tooling overlay; the change is an additive env-var guard on launch_editor_url() plus test hardening — no SDK or plugin contract change"

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>