### PR TITLE
test: stop view-host-bridge tests from popping real windows on screen

### DIFF
--- a/test/test_view_host_bridge_mac.mm
+++ b/test/test_view_host_bridge_mac.mm
@@ -45,7 +45,11 @@ TEST_CASE("macOS WindowHost reports content size and fires resize callbacks",
             seen_sizes.push_back({width, height});
         });
 
-        host->show();
+        // Headless: do NOT call host->show(). makeKeyAndOrderFront would
+        // pop a real window in the top-left of the screen for the lifetime
+        // of the test. AppKit posts windowDidResize: from setContentSize:
+        // regardless of on-screen visibility, so the resize-callback
+        // assertions below are unaffected.
         auto* nswindow = (__bridge NSWindow*)host->native_window_handle();
         REQUIRE(nswindow != nil);
         [nswindow setContentSize:NSMakeSize(360.0, 280.0)];
@@ -158,13 +162,15 @@ TEST_CASE("PulpView mouseUp survives mouseDown handler that unmounts the target"
         auto* child_ptr = child.get();
         root.add_child(std::move(child));
 
-        host->show();
+        // Headless: no host->show(). Events are dispatched directly to
+        // the contentView below, so the window need not be on-screen;
+        // showing it would just flash a real window in the corner.
         auto* nswindow = (__bridge NSWindow*)host->native_window_handle();
         REQUIRE(nswindow != nil);
         auto* contentView = nswindow.contentView;
         REQUIRE(contentView != nil);
 
-        // Pump the run loop so the window finishes coming up.
+        // Pump the run loop so the content view finishes settling.
         for (int i = 0; i < 20; ++i) {
             [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.005]];
         }
@@ -263,7 +269,8 @@ TEST_CASE("PulpView NSEvent click dispatches JS on(id,'click') subscriber",
         auto* child_ptr = bridge.widget("clear");
         REQUIRE(child_ptr != nullptr);
 
-        host->show();
+        // Headless: no host->show() — events go straight to the
+        // contentView, so the window stays off-screen.
         auto* nswindow = (__bridge NSWindow*)host->native_window_handle();
         REQUIRE(nswindow != nil);
         auto* contentView = nswindow.contentView;
@@ -382,7 +389,8 @@ TEST_CASE("PulpView NSEvent click bubbles up to ancestor on_click handler",
         // The label has no handler of its own — that's the point.
         REQUIRE_FALSE(static_cast<bool>(label->on_click));
 
-        host->show();
+        // Headless: no host->show() — events go straight to the
+        // contentView, so the window stays off-screen.
         auto* nswindow = (__bridge NSWindow*)host->native_window_handle();
         REQUIRE(nswindow != nil);
         auto* contentView = nswindow.contentView;


### PR DESCRIPTION
The four macOS WindowHost test cases in test_view_host_bridge_mac.mm
called host->show(), which invokes -[NSWindow makeKeyAndOrderFront:].
That brings a real, foreground NSWindow on screen at the default
top-left position for the lifetime of each test, then hide() removes
it — producing the "small windows flash in the top-left corner" UX
problem during `ctest` runs (and any from-scratch build that runs the
suite).

None of these tests need a visible window:

  - issue-661 asserts the resize callback fires. AppKit posts
    -windowDidResize: from -setContentSize: regardless of whether the
    window was ever ordered front.
  - issue-992 / issue-1006 / issue-1067 dispatch synthetic NSEvents
    directly to the contentView, bypassing the AppKit responder chain
    entirely, so window visibility is irrelevant.

Drop the host->show() calls. The NSWindow + contentView are still
fully constructed (WindowHost::create), the production host code path
is still exercised, and the suite stays headless — matching the
mac_window_harness contract, which already relies on never calling
makeKeyAndOrderFront.

Verified: pulp-test-view-host-bridge builds clean and all 38
assertions pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>