### PR TITLE
test(render): prove SkPicture .skp serialization round-trips on Graphite

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1500,9 +1500,21 @@ if(PULP_ENABLE_GPU)
     target_link_libraries(pulp-test-gpu-surface PRIVATE pulp::render Catch2::Catch2WithMain)
     catch_discover_tests(pulp-test-gpu-surface ${PULP_GPU_TEST_DISCOVERY_ARGS})
 
-    # Skia surface test
+    # Skia surface test — also covers SkPicture (.skp) serialization on the
+    # Graphite backend (Phase 6.4 spike). The .skp round-trip cases include
+    # Skia headers directly (SkPicture, SkPictureRecorder, SkSerialProcs,
+    # SkPngEncoder), so this target needs SKIA_INCLUDE_DIRS even though
+    # pulp::render carries Skia privately.
     add_executable(pulp-test-skia-surface test_skia_surface.cpp)
     target_link_libraries(pulp-test-skia-surface PRIVATE pulp::render Catch2::Catch2WithMain)
+    if(PULP_HAS_SKIA)
+        target_compile_definitions(pulp-test-skia-surface PRIVATE PULP_HAS_SKIA=1)
+        target_include_directories(pulp-test-skia-surface PRIVATE ${SKIA_INCLUDE_DIRS})
+        if(EXISTS "${SKIA_INCLUDE_DIRS}/dawn")
+            target_include_directories(pulp-test-skia-surface PRIVATE
+                "${SKIA_INCLUDE_DIRS}/dawn")
+        endif()
+    endif()
     catch_discover_tests(pulp-test-skia-surface ${PULP_GPU_TEST_DISCOVERY_ARGS})
 
     # GPU compute tests (Phase 11 feasibility)

--- a/test/test_skia_surface.cpp
+++ b/test/test_skia_surface.cpp
@@ -2,6 +2,21 @@
 #include <pulp/render/skia_surface.hpp>
 #include <pulp/render/gpu_surface.hpp>
 
+#ifdef PULP_HAS_SKIA
+#include <cstring>
+
+#include "include/core/SkCanvas.h"
+#include "include/core/SkData.h"
+#include "include/core/SkImage.h"
+#include "include/core/SkPaint.h"
+#include "include/core/SkPicture.h"
+#include "include/core/SkPictureRecorder.h"
+#include "include/core/SkSerialProcs.h"
+#include "include/core/SkStream.h"
+#include "include/core/SkSurface.h"
+#include "include/encode/SkPngEncoder.h"
+#endif
+
 using namespace pulp::render;
 
 TEST_CASE("SkiaSurface requires initialized GpuSurface", "[render][skia]") {
@@ -151,3 +166,164 @@ TEST_CASE("SkiaSurface null without Skia", "[render][skia]") {
     REQUIRE(true);  // Skia is available, tested elsewhere
 #endif
 }
+
+// ---------------------------------------------------------------------------
+// SkPicture (.skp) serialization on the Graphite backend
+//
+// Phase 6.4 spike (inspector roadmap): the planned "capture Skia frame"
+// feature wants to write a `.skp` artifact that the Skia team's own
+// `skiadebugger` can replay. Pulp renders through the Graphite backend
+// (skgpu::graphite::Context) — `.skp` / SkPicture is the legacy
+// SkPicture serialization format, so we must verify the two compose.
+//
+// Verdict from these tests: `SkPicture` is backend-independent. An
+// `SkPictureRecorder` records into a backend-agnostic `SkRecord`; nothing
+// in the Graphite headers references `SkPicture`. So `serialize()` /
+// `MakeFromData()` round-trips cleanly regardless of which GPU backend the
+// process is running. The single caveat is documented in SkPicture.h: the
+// default serializer encodes embedded `SkImage`s as nullptr unless the
+// caller supplies `SkSerialProcs::fImageProc`. That is format policy, not a
+// Graphite limitation — Phase 6.4 must set fImageProc to capture frames
+// that embed images. These tests pin both facts.
+// ---------------------------------------------------------------------------
+#ifdef PULP_HAS_SKIA
+
+namespace {
+
+// Record a small, deterministic vector scene (no embedded images) into an
+// SkPicture. SkPictureRecorder is GPU-backend-agnostic by construction.
+sk_sp<SkPicture> record_vector_scene() {
+    SkPictureRecorder recorder;
+    SkCanvas* rec = recorder.beginRecording(SkRect::MakeWH(64.0f, 48.0f));
+    REQUIRE(rec != nullptr);
+
+    SkPaint red;
+    red.setColor(SK_ColorRED);
+    red.setAntiAlias(true);
+    rec->drawRect(SkRect::MakeXYWH(4.0f, 4.0f, 40.0f, 24.0f), red);
+
+    SkPaint blue;
+    blue.setColor(SK_ColorBLUE);
+    rec->drawCircle(32.0f, 24.0f, 12.0f, blue);
+
+    return recorder.finishRecordingAsPicture();
+}
+
+}  // namespace
+
+TEST_CASE("SkPicture round-trips through serialize/MakeFromData", "[render][skia][skp]") {
+    sk_sp<SkPicture> picture = record_vector_scene();
+    REQUIRE(picture != nullptr);
+
+    const SkRect bounds = picture->cullRect();
+    REQUIRE(bounds.width() == 64.0f);
+    REQUIRE(bounds.height() == 48.0f);
+
+    // Serialize to an in-memory .skp blob.
+    sk_sp<SkData> blob = picture->serialize();
+    REQUIRE(blob != nullptr);
+    REQUIRE(blob->size() > 0);
+
+    // The blob carries the documented .skp file signature ("skiapict"),
+    // which is what skiadebugger keys on to recognize the artifact.
+    REQUIRE(blob->size() >= 8);
+    REQUIRE(std::memcmp(blob->data(), "skiapict", 8) == 0);
+
+    // Deserialize and assert the round-trip preserved the recording.
+    sk_sp<SkPicture> restored = SkPicture::MakeFromData(blob.get());
+    REQUIRE(restored != nullptr);
+    REQUIRE(restored->cullRect() == bounds);
+    REQUIRE(restored->approximateOpCount() == picture->approximateOpCount());
+    REQUIRE(restored->approximateOpCount() > 0);
+}
+
+TEST_CASE("SkPicture round-trips through an SkStream", "[render][skia][skp]") {
+    sk_sp<SkPicture> picture = record_vector_scene();
+    REQUIRE(picture != nullptr);
+
+    // serialize(SkWStream*) is the path Phase 6.4 will use to write a file.
+    SkDynamicMemoryWStream out;
+    picture->serialize(&out);
+    REQUIRE(out.bytesWritten() > 0);
+
+    sk_sp<SkData> blob = out.detachAsData();
+    REQUIRE(blob != nullptr);
+
+    SkMemoryStream in(blob);
+    sk_sp<SkPicture> restored = SkPicture::MakeFromStream(&in);
+    REQUIRE(restored != nullptr);
+    REQUIRE(restored->cullRect() == picture->cullRect());
+    REQUIRE(restored->approximateOpCount() == picture->approximateOpCount());
+}
+
+TEST_CASE("SkPicture serialization is independent of any GPU context", "[render][skia][skp]") {
+    // The whole point of the Phase 6.4 spike: prove SkPicture works without
+    // — and regardless of — a live Graphite context. A picture recorded and
+    // serialized with no GPU context whatsoever still round-trips, which is
+    // exactly why it is safe on the Graphite backend (Graphite never touches
+    // the SkPicture pipeline).
+    sk_sp<SkPicture> picture = record_vector_scene();
+    sk_sp<SkData> blob = picture->serialize();
+    REQUIRE(blob != nullptr);
+
+    sk_sp<SkPicture> restored = SkPicture::MakeFromData(blob->data(), blob->size());
+    REQUIRE(restored != nullptr);
+    REQUIRE(restored->uniqueID() != 0);
+    REQUIRE(restored->approximateOpCount() == picture->approximateOpCount());
+}
+
+TEST_CASE("SkPicture with embedded image needs fImageProc to round-trip pixels",
+          "[render][skia][skp]") {
+    // SkPicture.h documents: "The default behavior for serializing SkImages
+    // is to encode a nullptr." This is the one real caveat for Phase 6.4 —
+    // a captured frame that embeds images must supply SkSerialProcs so the
+    // image survives the round trip. This test pins that contract so the
+    // Phase 6.4 implementation does not silently ship null-image captures.
+
+    // A tiny raster image (the kind a real frame would embed; Graphite frames
+    // upload raster sources, so this mirrors the captured-frame case).
+    SkImageInfo info = SkImageInfo::MakeN32Premul(8, 8);
+    sk_sp<SkSurface> raster = SkSurfaces::Raster(info);
+    REQUIRE(raster != nullptr);
+    raster->getCanvas()->clear(SK_ColorGREEN);
+    sk_sp<SkImage> image = raster->makeImageSnapshot();
+    REQUIRE(image != nullptr);
+
+    SkPictureRecorder recorder;
+    SkCanvas* rec = recorder.beginRecording(SkRect::MakeWH(8.0f, 8.0f));
+    rec->drawImage(image, 0.0f, 0.0f);
+    sk_sp<SkPicture> picture = recorder.finishRecordingAsPicture();
+    REQUIRE(picture != nullptr);
+
+    // (a) Default serialization: the picture structure survives, the
+    //     embedded image is dropped to null. Still a valid .skp.
+    {
+        sk_sp<SkData> blob = picture->serialize();
+        REQUIRE(blob != nullptr);
+        sk_sp<SkPicture> restored = SkPicture::MakeFromData(blob.get());
+        REQUIRE(restored != nullptr);
+        REQUIRE(restored->cullRect() == picture->cullRect());
+    }
+
+    // (b) With fImageProc / fImageProc set, the embedded image round-trips.
+    {
+        SkSerialProcs sprocs;
+        sprocs.fImageProc = [](SkImage* img, void*) -> sk_sp<SkData> {
+            return SkPngEncoder::Encode(nullptr, img, SkPngEncoder::Options{});
+        };
+        sk_sp<SkData> blob = picture->serialize(&sprocs);
+        REQUIRE(blob != nullptr);
+
+        SkDeserialProcs dprocs;
+        dprocs.fImageProc = [](const void* data, size_t length,
+                               void*) -> sk_sp<SkImage> {
+            return SkImages::DeferredFromEncodedData(
+                SkData::MakeWithCopy(data, length));
+        };
+        sk_sp<SkPicture> restored = SkPicture::MakeFromData(blob.get(), &dprocs);
+        REQUIRE(restored != nullptr);
+        REQUIRE(restored->cullRect() == picture->cullRect());
+    }
+}
+
+#endif  // PULP_HAS_SKIA

--- a/test/test_skia_surface.cpp
+++ b/test/test_skia_surface.cpp
@@ -305,7 +305,8 @@ TEST_CASE("SkPicture with embedded image needs fImageProc to round-trip pixels",
         REQUIRE(restored->cullRect() == picture->cullRect());
     }
 
-    // (b) With fImageProc / fImageProc set, the embedded image round-trips.
+    // (b) With matching SkSerialProcs/SkDeserialProcs fImageProc set, the
+    //     embedded image round-trips through serialize + MakeFromData.
     {
         SkSerialProcs sprocs;
         sprocs.fImageProc = [](SkImage* img, void*) -> sk_sp<SkData> {

--- a/test/test_skia_surface.cpp
+++ b/test/test_skia_surface.cpp
@@ -5,6 +5,7 @@
 #ifdef PULP_HAS_SKIA
 #include <cstring>
 
+#include "include/core/SkBitmap.h"
 #include "include/core/SkCanvas.h"
 #include "include/core/SkData.h"
 #include "include/core/SkImage.h"
@@ -209,6 +210,23 @@ sk_sp<SkPicture> record_vector_scene() {
     return recorder.finishRecordingAsPicture();
 }
 
+// Replay a picture into a fresh raster surface (pre-cleared to black) and
+// read back the top-left pixel. cullRect equality only proves the picture
+// *structure* survived serialization; replaying and sampling a pixel is
+// what proves an embedded image's payload actually round-tripped.
+SkColor replay_top_left(const sk_sp<SkPicture>& picture,
+                        const SkImageInfo& info) {
+    sk_sp<SkSurface> surface = SkSurfaces::Raster(info);
+    REQUIRE(surface != nullptr);
+    surface->getCanvas()->clear(SK_ColorBLACK);
+    surface->getCanvas()->drawPicture(picture.get());
+
+    SkBitmap bm;
+    REQUIRE(bm.tryAllocPixels(info));
+    REQUIRE(surface->readPixels(bm, 0, 0));
+    return bm.getColor(0, 0);
+}
+
 }  // namespace
 
 TEST_CASE("SkPicture round-trips through serialize/MakeFromData", "[render][skia][skp]") {
@@ -303,6 +321,12 @@ TEST_CASE("SkPicture with embedded image needs fImageProc to round-trip pixels",
         sk_sp<SkPicture> restored = SkPicture::MakeFromData(blob.get());
         REQUIRE(restored != nullptr);
         REQUIRE(restored->cullRect() == picture->cullRect());
+
+        // The image payload did NOT survive: replaying the restored
+        // picture draws nothing where the image was, so the surface
+        // keeps its black clear color. This is the contrast that makes
+        // the (b) pixel assertion below meaningful.
+        REQUIRE(replay_top_left(restored, info) == SK_ColorBLACK);
     }
 
     // (b) With matching SkSerialProcs/SkDeserialProcs fImageProc set, the
@@ -324,6 +348,13 @@ TEST_CASE("SkPicture with embedded image needs fImageProc to round-trip pixels",
         sk_sp<SkPicture> restored = SkPicture::MakeFromData(blob.get(), &dprocs);
         REQUIRE(restored != nullptr);
         REQUIRE(restored->cullRect() == picture->cullRect());
+
+        // The image payload survived: replaying the restored picture
+        // reproduces the original green image. cullRect equality alone
+        // would still pass if SkPngEncoder::Encode had returned null and
+        // the image deserialized to nothing — this pixel check is what
+        // actually proves fImageProc preserved the pixels.
+        REQUIRE(replay_top_left(restored, info) == SK_ColorGREEN);
     }
 }
 


### PR DESCRIPTION
Phase 6.4 spike of the inspector roadmap. The planned "capture Skia
frame" feature writes a .skp artifact for the Skia team's skiadebugger
to replay. Pulp renders through the Graphite backend, while .skp /
SkPicture is the legacy SkPicture format — this verifies the two
compose.

Verdict: viable. SkPicture is backend-independent. SkPictureRecorder
records into a backend-agnostic SkRecord, and nothing in the Graphite
headers references SkPicture, so serialize() / MakeFromData() /
MakeFromStream() round-trip cleanly regardless of GPU backend. The one
documented caveat (SkPicture.h): the default serializer encodes
embedded SkImages as nullptr unless the caller supplies
SkSerialProcs::fImageProc — format policy, not a Graphite limitation.

Adds four Catch2 cases to test_skia_surface.cpp (the existing
[render][skia] Graphite-backed test file):
  - data round-trip + .skp "skiapict" signature check
  - SkStream round-trip (the path Phase 6.4 will use to write a file)
  - serialization with no GPU context at all
  - embedded-image round-trip pinning the fImageProc requirement

The test target gains SKIA_INCLUDE_DIRS since the new cases include
Skia headers (SkPicture, SkPictureRecorder, SkSerialProcs, SkPngEncoder)
directly. Runs in a process with a live Graphite context.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>