### PR TITLE
feat(view): token lock-to-source via DESIGN.md rewrite (Phase 4c)

### DIFF
--- a/.agents/skills/import-design/SKILL.md
+++ b/.agents/skills/import-design/SKILL.md
@@ -488,6 +488,44 @@ If you add a codegen property to `design_codegen.cpp`'s `generate_node`,
 add it to the `kKnown` allow-list in `lock_property_to_style_name()` too
 — otherwise that property can never be locked to source.
 
+### Phase 4c — token lock-to-source (`DESIGN.md` rewrite)
+
+`token_lock.hpp` / `token_lock.cpp` (`core/view/`) lock a *token-typed*
+inspector tweak back into the project's `DESIGN.md` so a re-import picks
+up the corrected token instead of re-introducing the stale one. This is
+the token-level sibling of Phase 4a (generated-TSX rewrite) and 4b
+(JSX/TSX AST patch).
+
+- **Token vs element classification** — `classify_token_tweak(anchor,
+  property_path)` returns a `TokenTarget` when the tweak addresses a
+  DESIGN.md token, `std::nullopt` for element-only tweaks (`paint.*`,
+  `layout.*`, `text.*` — those lock via 4a/4b). Two signals, in
+  priority order: a dotted property path whose head is a canonical
+  token group (`colors` / `spacing` / `rounded` / `typography`), or a
+  `designtoken:<group>.<name>` anchor. Typography paths must be
+  three-segment (`typography.<level>.<field>`). `components.*` is
+  deliberately **not** lockable — a component entry is a reference
+  bundle, not a primitive value.
+- **Surgical text rewrite, not `export_designmd`** — the lock parses
+  the YAML frontmatter only to *locate* the token (yaml-cpp `Mark()`
+  gives the value line), then edits exactly that one value span in the
+  original file text. Prose sections, YAML comments, key order,
+  indentation, and the value's original quote style are all preserved.
+  `export_designmd(Theme, ...)` re-emits the whole file and would lose
+  every one of those — never use it for a single-token lock. (It also
+  still throws, gated on #1307.)
+- **Conservatism** — `lock_token_in_designmd` fails (and returns the
+  input byte-identical) on: no frontmatter, missing group/token/field,
+  a nested color palette (not a scalar), or a source line that does not
+  match the expected `key: <value>` shape. A failed lock never mutates
+  DESIGN.md. The locator keys off the *group*, so a leaf name that
+  appears in two groups (e.g. `md` under both `spacing` and `rounded`)
+  still resolves unambiguously.
+- **Overlay wiring deferred** — the inspector overlay "lock token"
+  affordance is intentionally not wired here (`inspector_overlay.cpp`
+  has in-flight PRs). The engine is pure data-in/data-out so the
+  overlay/protocol layer can adopt it without a rebuild.
+
 Spec + design:
 [`planning/2026-05-18-inspector-direct-manipulation-roadmap.md`](../../../planning/2026-05-18-inspector-direct-manipulation-roadmap.md)
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "pulp",
       "source": "./",
       "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
-      "version": "0.98.1",
+      "version": "0.99.0",
       "min_cli_version": "0.31.0",
       "author": {
         "name": "Dan Raffel"
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "version": "0.98.1"
+  "version": "0.99.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pulp",
-  "version": "0.98.1",
+  "version": "0.99.0",
   "description": "Claude Code plugin for the Pulp audio framework \u2014 build, test, design, and ship audio plugins and apps",
   "author": {
     "name": "Dan Raffel",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.178.1
+    VERSION 0.178.2
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -251,6 +251,7 @@ target_sources(pulp-view PRIVATE
     src/claude_bundle.cpp
     src/design_import_shortcuts.cpp
     src/design_import_designmd.cpp
+    src/token_lock.cpp
     src/screenshot_compare.cpp
     src/app_framework.cpp
     src/canvas_widget.cpp

--- a/core/view/include/pulp/view/token_lock.hpp
+++ b/core/view/include/pulp/view/token_lock.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+/// @file token_lock.hpp
+/// Phase 4c of the inspector direct-manipulation roadmap
+/// (planning/2026-05-18-inspector-direct-manipulation-roadmap.md):
+/// **token lock-to-source via DESIGN.md export**.
+///
+/// When a user makes an inspector tweak that corresponds to a design
+/// *token* — a palette color, a spacing-scale step, a corner radius, a
+/// typography field — "locking" that tweak should write the corrected
+/// value back into the project's `DESIGN.md`, so the next re-import from
+/// the design tool (Figma / Stitch / v0 / Pencil / Claude) picks up the
+/// fixed token rather than re-introducing the stale one.
+///
+/// This is the token-level sibling of Phase 4a (lock-to-source for
+/// generated TSX) and Phase 4b (JSX/TSX AST patch). Where 4a/4b rewrite
+/// *element* source, 4c rewrites a single *token value* in the YAML
+/// frontmatter of DESIGN.md.
+///
+/// Design rationale — why a surgical text rewrite, not `export_designmd`:
+///   `export_designmd(Theme, ...)` (design_export.hpp) re-emits a whole
+///   DESIGN.md from a Theme and is gated on pulp #1307. Even ungated it
+///   would be the wrong tool here: it cannot preserve the author's prose
+///   sections, comment placement, key ordering, or original dimension
+///   spelling ("1.5rem" vs "24px"). Locking ONE token must not reflow
+///   the entire file. So `lock_token_in_designmd` instead parses the
+///   frontmatter to *locate* the token, then performs a minimal
+///   value-only edit on the original text — every other byte of the
+///   file (prose, comments, ordering, indentation) is preserved.
+///
+/// Conservatism contract (mirrors Phase 4a error handling): if the token
+/// cannot be located *unambiguously* in DESIGN.md the lock FAILS with a
+/// clear message rather than guessing. A failed lock leaves DESIGN.md
+/// byte-identical and the tweak untouched in `pulp-tweaks.json`.
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pulp::view {
+
+// ── Token classification ────────────────────────────────────────────────
+//
+// Not every inspector tweak is a token. A one-off element edit ("make
+// THIS knob 4px wider") is an element tweak — it goes through Phase 4a/4b.
+// A token tweak edits a value the *whole design system* shares.
+//
+// Two signals classify a tweak as token-typed, in priority order:
+//   1. Anchor convention. Token tweaks carry an anchor of the form
+//      `designtoken:<group>.<name>` (e.g. `designtoken:colors.primary`).
+//      The inspector stamps this anchor when the selected property is
+//      backed by a resolved design token rather than a literal.
+//   2. Property-path convention. A dotted path whose first segment is a
+//      canonical DESIGN.md token group (`colors`, `spacing`, `rounded`,
+//      `typography`) is treated as a token path even without the anchor
+//      prefix — this lets the CLI and tests address tokens directly.
+//
+// Element-only paths (`paint.*`, `layout.*`, `text.*`) never classify as
+// tokens; `classify_token_tweak` returns std::nullopt for them.
+
+/// The four canonical DESIGN.md frontmatter token groups Phase 4c can
+/// lock into. `components` is intentionally excluded — a component entry
+/// is a *reference bundle*, not a primitive token value, and locking one
+/// would mean rewriting a `{group.name}` reference, which Phase 4c does
+/// not attempt.
+enum class TokenGroup {
+    colors,      ///< `colors:` map — hex string values.
+    spacing,     ///< `spacing:` map — dimension values.
+    rounded,     ///< `rounded:` map — corner-radius dimension values.
+    typography,  ///< `typography:` map — nested per-level field maps.
+};
+
+/// Stringify a TokenGroup as its DESIGN.md frontmatter key.
+const char* token_group_key(TokenGroup group);
+
+/// A tweak classified as targeting a design token.
+struct TokenTarget {
+    TokenGroup group;
+    /// The token name within the group, e.g. "primary", "md", "lg".
+    std::string name;
+    /// For `typography` tokens only: the field within the level map,
+    /// e.g. "fontSize", "fontWeight", "lineHeight". Empty for the other
+    /// three groups (they are flat scalar maps).
+    std::string field;
+};
+
+/// Classify a tweak as token-typed or not.
+///
+/// @param anchor_id      The tweak's `stable_anchor_id` (may be empty).
+/// @param property_path  The tweak's dotted property path.
+///
+/// Returns a populated TokenTarget when the tweak addresses a DESIGN.md
+/// token, std::nullopt when it is an element-only tweak (the Phase 4a/4b
+/// domain). Classification is purely structural — it does NOT check
+/// whether the token actually exists in any DESIGN.md.
+std::optional<TokenTarget> classify_token_tweak(const std::string& anchor_id,
+                                                 const std::string& property_path);
+
+// ── Lock result ─────────────────────────────────────────────────────────
+
+/// Outcome of a `lock_token_in_designmd` call. `ok` is the only success
+/// path; on failure `updated_markdown` equals the input byte-for-byte.
+struct TokenLockResult {
+    bool ok = false;
+    /// Human-readable failure reason when `ok` is false; empty on success.
+    std::string error;
+    /// The rewritten DESIGN.md text. On success this differs from the
+    /// input by exactly the one token value; on failure it is the input
+    /// unchanged (callers may write it back unconditionally and be safe).
+    std::string updated_markdown;
+    /// The value found at the token before the rewrite — lets the
+    /// inspector show a "was X, now Y" confirmation and supports an
+    /// eventual Unlock (inverse delta). Empty on failure.
+    std::string previous_value;
+    /// 1-based line number within DESIGN.md that was rewritten; 0 on
+    /// failure. Useful for a diff-preview UI.
+    int line = 0;
+};
+
+/// Lock a single token tweak back into DESIGN.md text.
+///
+/// @param markdown       The current DESIGN.md file contents.
+/// @param target         The classified token (see classify_token_tweak).
+/// @param new_value      The corrected value to write. For `colors` this
+///                       is a hex string ("#5a5a5a"); for `spacing` /
+///                       `rounded` a dimension string ("12px", "1rem");
+///                       for `typography` the raw field value.
+///
+/// Behavior:
+///   - Parses the YAML frontmatter to confirm the token exists and is
+///     reachable unambiguously.
+///   - Rewrites ONLY that token's value in the original text, preserving
+///     every other byte (prose, comments, key order, indentation, the
+///     value's surrounding quotes if present).
+///   - Fails (ok=false, markdown unchanged) when:
+///       * DESIGN.md has no YAML frontmatter,
+///       * the token group is absent,
+///       * the token name is absent from its group,
+///       * a `typography` target's field is absent from the level,
+///       * the token line cannot be located unambiguously in the source
+///         text (e.g. the same `name:` key appears under more than one
+///         group and the parse cannot disambiguate).
+///
+/// The function never throws — all failure modes are reported via the
+/// result's `error` string.
+TokenLockResult lock_token_in_designmd(const std::string& markdown,
+                                        const TokenTarget& target,
+                                        const std::string& new_value);
+
+/// Convenience overload: classify + lock in one call. Returns a failure
+/// result with a descriptive error when the tweak is not token-typed.
+TokenLockResult lock_token_in_designmd(const std::string& markdown,
+                                        const std::string& anchor_id,
+                                        const std::string& property_path,
+                                        const std::string& new_value);
+
+}  // namespace pulp::view

--- a/core/view/src/token_lock.cpp
+++ b/core/view/src/token_lock.cpp
@@ -1,0 +1,451 @@
+// token_lock.cpp — Phase 4c token lock-to-source via DESIGN.md export.
+//
+// See token_lock.hpp for the design rationale. Summary: locking a
+// token-typed inspector tweak rewrites exactly one token value in the
+// DESIGN.md YAML frontmatter, preserving every other byte of the file.
+//
+// Implementation strategy:
+//   1. Split the `---` … `---` frontmatter from the markdown body, the
+//      same way design_import_designmd.cpp's parser does (so the two
+//      stay consistent).
+//   2. Parse the frontmatter with yaml-cpp purely to *locate* the token:
+//      confirm the group exists, the token exists, and obtain the YAML
+//      Mark (line) of the value node.
+//   3. Perform a minimal value-only edit on the ORIGINAL text at that
+//      line — never re-serialize the YAML. Re-serialization would drop
+//      comments, reorder keys, and re-spell scalars.
+//
+// Conservatism: any ambiguity (missing group/token/field, an
+// un-locatable line) fails the lock and returns the input unchanged.
+
+#include <pulp/view/token_lock.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <regex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pulp::view {
+
+namespace {
+
+// ── Frontmatter extraction ──────────────────────────────────────────────
+//
+// Mirrors design_import_designmd.cpp's split_frontmatter, but also
+// returns the byte offset at which the frontmatter starts inside the
+// original markdown so a yaml-cpp Mark (relative to the YAML text) can
+// be mapped back to an absolute line in the file.
+
+struct Frontmatter {
+    bool present = false;
+    std::string yaml_text;
+    // Byte offset in the original markdown where `yaml_text` begins.
+    std::size_t yaml_offset = 0;
+    // 1-based line in the original markdown where `yaml_text` begins.
+    // The opening `---` is line 1, so the YAML body starts on line 2.
+    int yaml_first_line = 2;
+};
+
+Frontmatter split_frontmatter(const std::string& markdown) {
+    Frontmatter out;
+    if (markdown.size() < 4 || markdown.substr(0, 3) != "---" ||
+        (markdown[3] != '\n' && markdown[3] != '\r')) {
+        return out;
+    }
+    std::size_t start =
+        (markdown[3] == '\r' && markdown.size() > 4 && markdown[4] == '\n') ? 5
+                                                                            : 4;
+    std::regex closing(R"((?:^|\n)---[ \t]*(?:\r?\n|$))");
+    std::smatch m;
+    std::string tail(markdown.begin() + static_cast<std::ptrdiff_t>(start),
+                     markdown.end());
+    if (!std::regex_search(tail, m, closing)) {
+        return out;
+    }
+    out.present = true;
+    out.yaml_text = tail.substr(0, static_cast<std::size_t>(m.position(0)));
+    out.yaml_offset = start;
+    out.yaml_first_line = 2;
+    return out;
+}
+
+// Split text into lines, keeping track of where each begins. Newlines
+// are NOT included in the returned slices; the rebuild step re-inserts
+// them so the original line terminators survive untouched.
+struct LineIndex {
+    // Byte offset of the start of each line.
+    std::vector<std::size_t> starts;
+    // Byte offset just past the end of each line's content (before the
+    // line terminator, if any).
+    std::vector<std::size_t> ends;
+};
+
+LineIndex index_lines(const std::string& text) {
+    LineIndex idx;
+    std::size_t i = 0;
+    idx.starts.push_back(0);
+    while (i < text.size()) {
+        if (text[i] == '\n') {
+            std::size_t content_end = i;
+            if (content_end > idx.starts.back() &&
+                text[content_end - 1] == '\r') {
+                --content_end;
+            }
+            idx.ends.push_back(content_end);
+            idx.starts.push_back(i + 1);
+        }
+        ++i;
+    }
+    // Final line (may be empty if the file ends in a newline).
+    std::size_t content_end = text.size();
+    if (content_end > idx.starts.back() && text[content_end - 1] == '\r') {
+        --content_end;
+    }
+    idx.ends.push_back(content_end);
+    return idx;
+}
+
+// ── YAML scalar helpers ─────────────────────────────────────────────────
+
+// Render a YAML scalar value for embedding back into the frontmatter.
+// DESIGN.md colors and dimensions are conventionally double-quoted in
+// the upstream fixtures ("#855300", "1.5rem"); preserving that keeps the
+// rewritten file diff-clean. `quoted` controls whether to wrap the value
+// — callers pass the original token's quoting so a lock never changes
+// the quote style of a value that was already (un)quoted.
+std::string render_scalar(const std::string& value, bool quoted) {
+    if (!quoted) return value;
+    std::string out = "\"";
+    for (char c : value) {
+        if (c == '"' || c == '\\') out += '\\';
+        out += c;
+    }
+    out += '"';
+    return out;
+}
+
+// True when a value as written in YAML source begins with a quote.
+bool source_value_is_quoted(std::string_view trimmed_value) {
+    return !trimmed_value.empty() &&
+           (trimmed_value.front() == '"' || trimmed_value.front() == '\'');
+}
+
+// Given a `key: value` source line, return the [start, end) byte range
+// (relative to the line) covering the *value* portion — everything after
+// the `key:` and its following whitespace, up to any trailing `#`
+// comment or trailing whitespace. Returns false when the line is not a
+// `key: value` line at all.
+bool find_value_span(const std::string& line, const std::string& key,
+                      std::size_t& value_start, std::size_t& value_end) {
+    // Skip leading whitespace.
+    std::size_t i = 0;
+    while (i < line.size() && (line[i] == ' ' || line[i] == '\t')) ++i;
+    // Match the key (allowing it to be quoted is unnecessary for the
+    // canonical DESIGN.md token keys, which are bare identifiers).
+    if (line.compare(i, key.size(), key) != 0) return false;
+    std::size_t after = i + key.size();
+    // Expect a colon directly after the key.
+    if (after >= line.size() || line[after] != ':') return false;
+    ++after;
+    // Skip whitespace between the colon and the value.
+    while (after < line.size() && (line[after] == ' ' || line[after] == '\t')) {
+        ++after;
+    }
+    if (after >= line.size()) return false;  // key with no inline value
+    value_start = after;
+    // The value runs to end-of-line. A trailing `#` comment is only a
+    // comment when preceded by whitespace and outside quotes; the
+    // canonical token values never contain a bare `#`-after-space, and
+    // colors are quoted, so a simple scan suffices.
+    std::size_t end = line.size();
+    bool in_quote = false;
+    char quote = '\0';
+    for (std::size_t j = value_start; j < line.size(); ++j) {
+        char c = line[j];
+        if (in_quote) {
+            if (c == quote) in_quote = false;
+            continue;
+        }
+        if (c == '"' || c == '\'') {
+            in_quote = true;
+            quote = c;
+        } else if (c == '#' && j > value_start &&
+                   (line[j - 1] == ' ' || line[j - 1] == '\t')) {
+            end = j;
+            break;
+        }
+    }
+    // Trim trailing whitespace from the value span.
+    while (end > value_start &&
+           (line[end - 1] == ' ' || line[end - 1] == '\t')) {
+        --end;
+    }
+    value_end = end;
+    return value_end > value_start;
+}
+
+// ── Token location via yaml-cpp ─────────────────────────────────────────
+
+// Result of locating a token in the parsed YAML. `value_line` is 0-based
+// within the YAML text (yaml-cpp Mark convention).
+struct TokenLocation {
+    bool found = false;
+    std::string error;
+    int value_line = -1;     // 0-based, within the YAML text
+    std::string leaf_key;    // the YAML key whose value gets rewritten
+};
+
+TokenLocation locate_token(const YAML::Node& root, const TokenTarget& target) {
+    TokenLocation loc;
+    const char* group_key = token_group_key(target.group);
+
+    YAML::Node group = root[group_key];
+    if (!group || !group.IsMap()) {
+        loc.error = std::string("DESIGN.md has no `") + group_key +
+                    "` token group";
+        return loc;
+    }
+
+    YAML::Node token = group[target.name];
+    if (!token) {
+        loc.error = std::string("token `") + group_key + "." + target.name +
+                    "` not found in DESIGN.md";
+        return loc;
+    }
+
+    if (target.group == TokenGroup::typography) {
+        // Typography tokens are nested: typography.<level>.<field>.
+        if (target.field.empty()) {
+            loc.error = "typography token lock requires a field "
+                        "(fontSize / fontWeight / lineHeight / ...)";
+            return loc;
+        }
+        if (!token.IsMap()) {
+            loc.error = std::string("typography token `") + target.name +
+                        "` is not a field map";
+            return loc;
+        }
+        YAML::Node field = token[target.field];
+        if (!field) {
+            loc.error = std::string("typography field `") + target.name + "." +
+                        target.field + "` not found in DESIGN.md";
+            return loc;
+        }
+        if (!field.IsScalar()) {
+            loc.error = std::string("typography field `") + target.name + "." +
+                        target.field + "` is not a scalar value";
+            return loc;
+        }
+        loc.value_line = field.Mark().line;
+        loc.leaf_key = target.field;
+    } else {
+        // Flat scalar groups: colors / spacing / rounded.
+        if (!token.IsScalar()) {
+            loc.error = std::string("token `") + group_key + "." +
+                        target.name +
+                        "` is not a scalar value (nested palettes are not "
+                        "lockable in Phase 4c)";
+            return loc;
+        }
+        loc.value_line = token.Mark().line;
+        loc.leaf_key = target.name;
+    }
+
+    if (loc.value_line < 0) {
+        loc.error = "could not determine the source line of token `" +
+                    std::string(group_key) + "." + target.name + "`";
+        return loc;
+    }
+    loc.found = true;
+    return loc;
+}
+
+}  // namespace
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+const char* token_group_key(TokenGroup group) {
+    switch (group) {
+        case TokenGroup::colors:     return "colors";
+        case TokenGroup::spacing:    return "spacing";
+        case TokenGroup::rounded:    return "rounded";
+        case TokenGroup::typography: return "typography";
+    }
+    return "";
+}
+
+std::optional<TokenTarget> classify_token_tweak(
+    const std::string& anchor_id, const std::string& property_path) {
+    // The dotted path we classify against: prefer the property path, but
+    // fall back to the `designtoken:` anchor payload when the property
+    // path is not itself a token path.
+    std::string dotted = property_path;
+
+    constexpr std::string_view kAnchorPrefix{"designtoken:"};
+    const bool anchor_is_token =
+        anchor_id.size() > kAnchorPrefix.size() &&
+        anchor_id.compare(0, kAnchorPrefix.size(), kAnchorPrefix) == 0;
+
+    // Helper: try to map a dotted path to a TokenTarget. Returns nullopt
+    // if the first segment is not a canonical token group.
+    auto classify_dotted =
+        [](const std::string& path) -> std::optional<TokenTarget> {
+        auto first_dot = path.find('.');
+        if (first_dot == std::string::npos) return std::nullopt;
+        std::string head = path.substr(0, first_dot);
+        std::string rest = path.substr(first_dot + 1);
+        if (rest.empty()) return std::nullopt;
+
+        TokenTarget t;
+        if (head == "colors") {
+            t.group = TokenGroup::colors;
+        } else if (head == "spacing") {
+            t.group = TokenGroup::spacing;
+        } else if (head == "rounded") {
+            t.group = TokenGroup::rounded;
+        } else if (head == "typography") {
+            t.group = TokenGroup::typography;
+        } else {
+            return std::nullopt;
+        }
+
+        if (t.group == TokenGroup::typography) {
+            // typography.<level>.<field> — both halves required.
+            auto field_dot = rest.find('.');
+            if (field_dot == std::string::npos) return std::nullopt;
+            t.name = rest.substr(0, field_dot);
+            t.field = rest.substr(field_dot + 1);
+            if (t.name.empty() || t.field.empty()) return std::nullopt;
+        } else {
+            // A flat token name must not itself contain a dot — that
+            // would be an element sub-path, not a token.
+            if (rest.find('.') != std::string::npos) return std::nullopt;
+            t.name = rest;
+        }
+        return t;
+    };
+
+    if (auto t = classify_dotted(dotted)) return t;
+
+    // Property path is not a token path; consult the anchor convention.
+    if (anchor_is_token) {
+        std::string payload = anchor_id.substr(kAnchorPrefix.size());
+        if (auto t = classify_dotted(payload)) return t;
+    }
+    return std::nullopt;
+}
+
+TokenLockResult lock_token_in_designmd(const std::string& markdown,
+                                        const TokenTarget& target,
+                                        const std::string& new_value) {
+    TokenLockResult result;
+    result.updated_markdown = markdown;  // unchanged-on-failure contract
+
+    Frontmatter fm = split_frontmatter(markdown);
+    if (!fm.present) {
+        result.error =
+            "DESIGN.md has no YAML frontmatter — nothing to lock into";
+        return result;
+    }
+
+    YAML::Node root;
+    try {
+        root = YAML::Load(fm.yaml_text);
+    } catch (const YAML::Exception& e) {
+        result.error =
+            std::string("DESIGN.md frontmatter is not valid YAML: ") +
+            e.what();
+        return result;
+    }
+    if (!root || !root.IsMap()) {
+        result.error =
+            "DESIGN.md frontmatter is not a YAML mapping at the top level";
+        return result;
+    }
+
+    TokenLocation loc = locate_token(root, target);
+    if (!loc.found) {
+        result.error = loc.error;
+        return result;
+    }
+
+    // Map the YAML-relative 0-based line to an absolute 1-based line in
+    // the original markdown. yaml_text starts at fm.yaml_first_line.
+    const int abs_line = fm.yaml_first_line + loc.value_line;
+
+    LineIndex idx = index_lines(markdown);
+    const std::size_t line_idx = static_cast<std::size_t>(abs_line - 1);
+    if (abs_line < 1 || line_idx >= idx.starts.size()) {
+        result.error = "could not locate the token's source line in "
+                       "DESIGN.md (line index out of range)";
+        return result;
+    }
+
+    const std::size_t line_start = idx.starts[line_idx];
+    const std::size_t line_end = idx.ends[line_idx];
+    std::string line = markdown.substr(line_start, line_end - line_start);
+
+    std::size_t value_start = 0;
+    std::size_t value_end = 0;
+    if (!find_value_span(line, loc.leaf_key, value_start, value_end)) {
+        // The yaml-cpp Mark pointed at a line that does not look like a
+        // `key: value` line for this leaf key — refuse rather than guess.
+        result.error =
+            "could not unambiguously locate the value of token `" +
+            std::string(token_group_key(target.group)) + "." + target.name +
+            (target.field.empty() ? "" : "." + target.field) +
+            "` in DESIGN.md source (the parsed line does not match the "
+            "expected `" + loc.leaf_key + ": <value>` shape)";
+        return result;
+    }
+
+    std::string old_value_raw = line.substr(value_start, value_end - value_start);
+    const bool was_quoted = source_value_is_quoted(old_value_raw);
+
+    // Record the previous value with surrounding quotes stripped so the
+    // caller sees the semantic value, not the YAML spelling.
+    std::string previous = old_value_raw;
+    if (was_quoted && previous.size() >= 2) {
+        previous = previous.substr(1, previous.size() - 2);
+    }
+
+    std::string rendered = render_scalar(new_value, was_quoted);
+
+    // Splice the new value into the line, then the line back into the
+    // file. Every byte outside [value_start, value_end) is preserved,
+    // including the line terminator (which lives outside line_end).
+    std::string new_line = line.substr(0, value_start) + rendered +
+                           line.substr(value_end);
+
+    result.updated_markdown = markdown.substr(0, line_start) + new_line +
+                              markdown.substr(line_end);
+    result.ok = true;
+    result.previous_value = previous;
+    result.line = abs_line;
+    return result;
+}
+
+TokenLockResult lock_token_in_designmd(const std::string& markdown,
+                                        const std::string& anchor_id,
+                                        const std::string& property_path,
+                                        const std::string& new_value) {
+    auto target = classify_token_tweak(anchor_id, property_path);
+    if (!target) {
+        TokenLockResult result;
+        result.updated_markdown = markdown;
+        result.error =
+            "tweak (anchor=\"" + anchor_id + "\", property=\"" +
+            property_path +
+            "\") is not a design token — element tweaks lock via Phase "
+            "4a/4b, not DESIGN.md";
+        return result;
+    }
+    return lock_token_in_designmd(markdown, *target, new_value);
+}
+
+}  // namespace pulp::view

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2397,6 +2397,13 @@ target_compile_definitions(pulp-test-design-import-designmd PRIVATE PULP_REPO_RO
 catch_discover_tests(pulp-test-design-import-designmd
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
+# Phase 4c — token lock-to-source via DESIGN.md rewrite
+# (planning/2026-05-18-inspector-direct-manipulation-roadmap.md).
+add_executable(pulp-test-token-lock test_token_lock.cpp)
+target_link_libraries(pulp-test-token-lock PRIVATE pulp::view Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-token-lock
+    PROPERTIES LABELS "parser-import")
+
 # Post-parse widget promotion: <div onClick> / role=button / cursor:pointer
 # → button. Closure of pulp-internal task #84 / follow-up on #1814.
 # Links the importer-side .cpp directly (it's not in pulp::view) so the

--- a/test/test_token_lock.cpp
+++ b/test/test_token_lock.cpp
@@ -1,0 +1,290 @@
+// test_token_lock.cpp — Phase 4c token lock-to-source test suite.
+//
+// Covers planning/2026-05-18-inspector-direct-manipulation-roadmap.md
+// Phase 4c: locking a token-typed inspector tweak rewrites exactly one
+// token value in DESIGN.md, preserving every other byte (prose, comments,
+// key order, indentation), and fails conservatively when the token
+// cannot be located unambiguously.
+//
+// Tag set: [view][import][designmd][token-lock][issue-1307]
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/view/design_import.hpp>
+#include <pulp/view/token_lock.hpp>
+
+#include <string>
+
+using namespace pulp::view;
+
+namespace {
+
+// A compact DESIGN.md fixture with known tokens across all four lockable
+// groups, plus a `## prose` body and a YAML comment — the rewrite must
+// leave both untouched.
+const char* kFixture = R"(---
+name: Synthwave
+colors:
+  primary: "#855300"   # the brand orange
+  secondary: "#0058be"
+  background: "#f9f9ff"
+spacing:
+  sm: 12px
+  md: 24px
+rounded:
+  lg: 1rem
+typography:
+  body-md:
+    fontFamily: Inter
+    fontSize: 16px
+    fontWeight: "400"
+---
+
+## Brand & Style
+
+The palette centers on a warm orange. Primary is `#855300`.
+)";
+
+// Count occurrences of `needle` in `haystack` — used to assert the
+// rewrite touched exactly one byte range.
+int count_substr(const std::string& haystack, const std::string& needle) {
+    int n = 0;
+    std::string::size_type pos = 0;
+    while ((pos = haystack.find(needle, pos)) != std::string::npos) {
+        ++n;
+        pos += needle.size();
+    }
+    return n;
+}
+
+}  // namespace
+
+// ── Classification ─────────────────────────────────────────────────────
+
+TEST_CASE("classify_token_tweak recognizes flat token property paths",
+          "[view][token-lock][issue-1307]") {
+    auto c = classify_token_tweak("", "colors.primary");
+    REQUIRE(c.has_value());
+    CHECK(c->group == TokenGroup::colors);
+    CHECK(c->name == "primary");
+    CHECK(c->field.empty());
+
+    auto s = classify_token_tweak("", "spacing.md");
+    REQUIRE(s.has_value());
+    CHECK(s->group == TokenGroup::spacing);
+    CHECK(s->name == "md");
+
+    auto r = classify_token_tweak("", "rounded.lg");
+    REQUIRE(r.has_value());
+    CHECK(r->group == TokenGroup::rounded);
+    CHECK(r->name == "lg");
+}
+
+TEST_CASE("classify_token_tweak recognizes nested typography paths",
+          "[view][token-lock][issue-1307]") {
+    auto t = classify_token_tweak("", "typography.body-md.fontSize");
+    REQUIRE(t.has_value());
+    CHECK(t->group == TokenGroup::typography);
+    CHECK(t->name == "body-md");
+    CHECK(t->field == "fontSize");
+
+    // Typography without a field is NOT a lockable token target.
+    CHECK_FALSE(classify_token_tweak("", "typography.body-md").has_value());
+}
+
+TEST_CASE("classify_token_tweak falls back to the designtoken: anchor",
+          "[view][token-lock][issue-1307]") {
+    // Element-shaped property path, but the anchor carries the token id.
+    auto c = classify_token_tweak("designtoken:colors.secondary",
+                                  "paint.backgroundColor");
+    REQUIRE(c.has_value());
+    CHECK(c->group == TokenGroup::colors);
+    CHECK(c->name == "secondary");
+}
+
+TEST_CASE("classify_token_tweak rejects element-only tweaks",
+          "[view][token-lock][issue-1307]") {
+    // paint/layout/text paths are the Phase 4a/4b domain, not tokens.
+    CHECK_FALSE(classify_token_tweak("anchor:abc123",
+                                     "paint.backgroundColor").has_value());
+    CHECK_FALSE(classify_token_tweak("anchor:abc123",
+                                     "layout.padding").has_value());
+    // `components` is deliberately excluded from Phase 4c.
+    CHECK_FALSE(classify_token_tweak("", "components.button-primary.padding")
+                    .has_value());
+    // A flat group token whose name contains a dot is an element path.
+    CHECK_FALSE(classify_token_tweak("", "colors.primary.alpha").has_value());
+}
+
+// ── Happy path: color token rewrite ────────────────────────────────────
+
+TEST_CASE("lock_token_in_designmd rewrites a color token in place",
+          "[view][token-lock][issue-1307]") {
+    std::string md = kFixture;
+    auto result = lock_token_in_designmd(md, "designtoken:colors.primary",
+                                         "colors.primary", "#5a5a5a");
+    REQUIRE(result.ok);
+    CHECK(result.error.empty());
+    CHECK(result.previous_value == "#855300");
+    CHECK(result.line == 4);  // 1-based line of `  primary: ...`
+
+    const std::string& out = result.updated_markdown;
+    // The new value is present, the old hex literal is gone from the
+    // token line (it still survives once in the prose body — see below).
+    CHECK(count_substr(out, "primary: \"#5a5a5a\"") == 1);
+    CHECK(count_substr(out, "primary: \"#855300\"") == 0);
+
+    // Quote style preserved (the source value was double-quoted).
+    CHECK(out.find("\"#5a5a5a\"") != std::string::npos);
+
+    // The inline YAML comment on the same line is preserved verbatim.
+    CHECK(out.find("# the brand orange") != std::string::npos);
+
+    // Prose body untouched — `#855300` still appears in the Markdown.
+    CHECK(out.find("Primary is `#855300`.") != std::string::npos);
+
+    // Sibling tokens untouched.
+    CHECK(out.find("secondary: \"#0058be\"") != std::string::npos);
+    CHECK(out.find("background: \"#f9f9ff\"") != std::string::npos);
+
+    // Exactly one byte range changed: re-locking with the original value
+    // restores the file byte-for-byte.
+    auto restored = lock_token_in_designmd(out, "designtoken:colors.primary",
+                                           "colors.primary", "#855300");
+    REQUIRE(restored.ok);
+    CHECK(restored.updated_markdown == md);
+}
+
+TEST_CASE("lock_token_in_designmd rewrites a dimension token",
+          "[view][token-lock][issue-1307]") {
+    std::string md = kFixture;
+    // spacing.md is `24px` unquoted — the rewrite keeps it unquoted.
+    auto result = lock_token_in_designmd(md, "", "spacing.md", "32px");
+    REQUIRE(result.ok);
+    CHECK(result.previous_value == "24px");
+    CHECK(result.updated_markdown.find("md: 32px") != std::string::npos);
+    CHECK(result.updated_markdown.find("md: 24px") == std::string::npos);
+    // No quotes added to a value that had none.
+    CHECK(result.updated_markdown.find("md: \"32px\"") == std::string::npos);
+    // The other spacing step is untouched.
+    CHECK(result.updated_markdown.find("sm: 12px") != std::string::npos);
+}
+
+TEST_CASE("lock_token_in_designmd rewrites a nested typography field",
+          "[view][token-lock][issue-1307]") {
+    std::string md = kFixture;
+    auto result = lock_token_in_designmd(
+        md, "", "typography.body-md.fontSize", "18px");
+    REQUIRE(result.ok);
+    CHECK(result.previous_value == "16px");
+    CHECK(result.updated_markdown.find("fontSize: 18px") != std::string::npos);
+    CHECK(result.updated_markdown.find("fontSize: 16px") == std::string::npos);
+    // Sibling typography fields in the same level are untouched.
+    CHECK(result.updated_markdown.find("fontFamily: Inter") !=
+          std::string::npos);
+    CHECK(result.updated_markdown.find("fontWeight: \"400\"") !=
+          std::string::npos);
+}
+
+// ── Failure paths (conservative — DESIGN.md unchanged) ─────────────────
+
+TEST_CASE("lock_token_in_designmd fails when DESIGN.md has no frontmatter",
+          "[view][token-lock][issue-1307]") {
+    std::string md = "# Just prose\n\nNo frontmatter here.\n";
+    auto result = lock_token_in_designmd(md, "", "colors.primary", "#000000");
+    CHECK_FALSE(result.ok);
+    CHECK(result.error.find("no YAML frontmatter") != std::string::npos);
+    // Unchanged-on-failure contract.
+    CHECK(result.updated_markdown == md);
+}
+
+TEST_CASE("lock_token_in_designmd fails when the token group is absent",
+          "[view][token-lock][issue-1307]") {
+    std::string md = kFixture;
+    // The fixture has no `colors.accent`.
+    auto missing_token =
+        lock_token_in_designmd(md, "", "colors.accent", "#abcdef");
+    CHECK_FALSE(missing_token.ok);
+    CHECK(missing_token.error.find("not found") != std::string::npos);
+    CHECK(missing_token.updated_markdown == md);
+
+    // A whole group that does not exist in this fixture.
+    std::string no_group =
+        "---\nname: Bare\ncolors:\n  primary: \"#000\"\n---\n";
+    auto missing_group =
+        lock_token_in_designmd(no_group, "", "spacing.md", "8px");
+    CHECK_FALSE(missing_group.ok);
+    CHECK(missing_group.error.find("no `spacing`") != std::string::npos);
+    CHECK(missing_group.updated_markdown == no_group);
+}
+
+TEST_CASE("lock_token_in_designmd fails on a missing typography field",
+          "[view][token-lock][issue-1307]") {
+    std::string md = kFixture;
+    // body-md exists, but has no `letterSpacing` field.
+    auto result = lock_token_in_designmd(
+        md, "", "typography.body-md.letterSpacing", "0.02em");
+    CHECK_FALSE(result.ok);
+    CHECK(result.error.find("letterSpacing") != std::string::npos);
+    CHECK(result.updated_markdown == md);
+}
+
+TEST_CASE("lock_token_in_designmd refuses a non-token (element) tweak",
+          "[view][token-lock][issue-1307]") {
+    std::string md = kFixture;
+    auto result = lock_token_in_designmd(md, "anchor:abc123",
+                                         "paint.backgroundColor", "#111111");
+    CHECK_FALSE(result.ok);
+    CHECK(result.error.find("not a design token") != std::string::npos);
+    CHECK(result.updated_markdown == md);
+}
+
+TEST_CASE("lock_token_in_designmd refuses a nested color palette",
+          "[view][token-lock][issue-1307]") {
+    // `brand` is a nested palette (shade map), not a scalar — Phase 4c
+    // does not lock into nested palettes, it must fail clearly.
+    std::string md =
+        "---\nname: Nested\ncolors:\n  brand:\n    500: \"#ff0000\"\n---\n";
+    auto result = lock_token_in_designmd(md, "", "colors.brand", "#00ff00");
+    CHECK_FALSE(result.ok);
+    CHECK(result.error.find("not a scalar") != std::string::npos);
+    CHECK(result.updated_markdown == md);
+}
+
+TEST_CASE("lock_token_in_designmd disambiguates same-named keys across groups",
+          "[view][token-lock][issue-1307]") {
+    // `md` exists in BOTH spacing and rounded. The lock must rewrite the
+    // one in the requested group only — proving the locator keys off the
+    // group, not just the leaf name.
+    std::string md =
+        "---\nname: Dup\nspacing:\n  md: 24px\nrounded:\n  md: 8px\n---\n";
+
+    auto spacing = lock_token_in_designmd(md, "", "spacing.md", "30px");
+    REQUIRE(spacing.ok);
+    CHECK(spacing.updated_markdown.find("md: 30px") != std::string::npos);
+    // The rounded `md` is untouched.
+    CHECK(spacing.updated_markdown.find("md: 8px") != std::string::npos);
+
+    auto rounded = lock_token_in_designmd(md, "", "rounded.md", "12px");
+    REQUIRE(rounded.ok);
+    CHECK(rounded.updated_markdown.find("md: 12px") != std::string::npos);
+    // The spacing `md` is untouched.
+    CHECK(rounded.updated_markdown.find("md: 24px") != std::string::npos);
+}
+
+// ── Integration: the rewritten file re-parses with the new value ──────
+
+TEST_CASE("a locked DESIGN.md re-parses with the updated token",
+          "[view][token-lock][issue-1307]") {
+    std::string md = kFixture;
+    auto result = lock_token_in_designmd(md, "", "colors.primary", "#123456");
+    REQUIRE(result.ok);
+
+    // Round-trip through the real DESIGN.md parser — the corrected token
+    // is what a re-import would now see.
+    auto parsed = parse_designmd(result.updated_markdown);
+    REQUIRE(parsed.had_frontmatter);
+    auto it = parsed.ir.tokens.colors.find("primary");
+    REQUIRE(it != parsed.ir.tokens.colors.end());
+    CHECK(it->second == "#123456");
+}


### PR DESCRIPTION
Phase 4c of the inspector direct-manipulation roadmap. When a user's
inspector tweak corresponds to a design *token* (a palette color, a
spacing-scale step, a corner radius, a typography field) rather than a
one-off element edit, "locking" it should write the corrected value
back into the project's DESIGN.md so the next re-import from the design
tool picks up the fixed token instead of re-introducing the stale one.

This is the token-level sibling of Phase 4a (generated-TSX rewrite) and
Phase 4b (JSX/TSX AST patch).

`token_lock.{hpp,cpp}` (core/view/) provide:
- `classify_token_tweak()` — token-vs-element classification from the
  tweak's anchor (`designtoken:` convention) or dotted property path
  (canonical `colors`/`spacing`/`rounded`/`typography` groups).
- `lock_token_in_designmd()` — a surgical text rewrite that parses the
  YAML frontmatter only to *locate* the token, then edits exactly that
  one value span in the original DESIGN.md text. Prose, comments, key
  order, indentation, and quote style are all preserved — unlike
  `export_designmd()`, which re-emits the whole file (and is gated on
  pulp #1307). Conservative: any ambiguity (no frontmatter, missing
  group/token/field, nested palette, un-locatable line) fails the lock
  and leaves DESIGN.md byte-identical.

Overlay wiring is intentionally deferred — inspector_overlay.cpp has
in-flight PRs. The engine is pure data-in/data-out so the overlay and
protocol layers can adopt it later without a rebuild.

Tests: new test/test_token_lock.cpp — 14 Catch2 cases / 75 assertions
covering classification, color/dimension/typography rewrites with
prose+comment preservation, the round-trip through parse_designmd, and
every conservative failure path (missing frontmatter/group/token/field,
non-token tweak, nested palette, same-named keys across groups).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>