### PR TITLE
feat(render): add Dawn GPU timestamp queries for per-pass GPU timing

### DIFF
--- a/core/render/CMakeLists.txt
+++ b/core/render/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(pulp-render
 
 target_sources(pulp-render PRIVATE
     src/gpu_surface_dawn.cpp
+    src/gpu_timestamp.cpp
     src/gpu_compute.cpp
     src/skia_surface.cpp
     src/render_loop.cpp

--- a/core/render/include/pulp/render/gpu_surface.hpp
+++ b/core/render/include/pulp/render/gpu_surface.hpp
@@ -78,6 +78,15 @@ public:
     /// Returns an unavailable record when no native adapter has been initialized.
     virtual AdapterInfo adapter_info() const = 0;
 
+    /// Whether the initialized device supports WebGPU timestamp queries
+    /// (the `timestamp-query` feature). Phase 6.5 uses this to decide
+    /// whether the inspector perf view can show real GPU-side pass
+    /// durations or must fall back to the Phase 6.1 CPU numbers. The
+    /// feature is requested best-effort at device creation; an adapter
+    /// that lacks it still yields a working surface — this just returns
+    /// false. Always false before `initialize()` and on non-Dawn builds.
+    virtual bool gpu_timestamps_supported() const { return false; }
+
     static std::unique_ptr<GpuSurface> create_dawn();
 };
 

--- a/core/render/include/pulp/render/gpu_timestamp.hpp
+++ b/core/render/include/pulp/render/gpu_timestamp.hpp
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace pulp::render {
+
+/// GPU timestamp-query resolution — Phase 6.5 of the inspector roadmap
+/// (planning/2026-05-19-inspector-phase6-gpu-perf-spike.md § Phase 6.5).
+///
+/// Phase 6.1 surfaced CPU wall-time around each render pass's draw calls
+/// (`PassStats::cpu_time_ms`). That number is an honest *upper bound* on
+/// GPU cost but hides the actual GPU-side execution time — the place perf
+/// bugs usually hide. This module adds the real GPU clock.
+///
+/// WebGPU exposes GPU timing via `wgpu::QueryType::Timestamp`. The flow:
+///
+///   1. Request the `timestamp-query` feature at device creation. It may
+///      be unavailable on some adapters — degrade gracefully (report
+///      "unavailable", keep CPU numbers) rather than crashing.
+///   2. Allocate a `wgpu::QuerySet` with two timestamp slots per pass
+///      (beginning + end of pass), wired via `PassTimestampWrites` on the
+///      render-pass descriptor.
+///   3. `CommandEncoder::ResolveQuerySet` copies the raw GPU ticks into a
+///      buffer; map-read it back to host memory the *following* frame
+///      (one frame of lag is unavoidable — the GPU hasn't finished the
+///      current frame when we want to read it).
+///   4. Convert raw ticks → nanoseconds → milliseconds.
+///
+/// `GpuTimestampResolver` below is the **pure, GPU-free** half: it owns
+/// the tick → millisecond conversion math and the validity rules. It is
+/// deliberately decoupled from Dawn so the resolution logic is unit-
+/// testable without a live device (feed it a mocked resolved buffer).
+/// The Dawn-coupled query-set lifecycle lives in `GpuPassTimer`
+/// (gpu_timestamp.cpp, compiled only when WebGPU is present).
+
+/// A resolved GPU timing for one render pass, in milliseconds.
+struct GpuPassTiming {
+    /// GPU-side duration of the pass. Only meaningful when `valid`.
+    double gpu_time_ms = 0.0;
+    /// False when the timestamp pair could not be resolved this frame
+    /// (feature absent, query slot never written, or non-monotonic
+    /// ticks — see `GpuTimestampResolver::resolve_pair`).
+    bool valid = false;
+};
+
+/// Converts raw WebGPU timestamp-query ticks into millisecond durations.
+///
+/// WebGPU timestamps are reported in *nanoseconds* per the spec
+/// (`timestamp-query` feature: "the values are in nanoseconds"), so the
+/// per-tick period is fixed at 1.0 ns. Some native backends historically
+/// reported in device-specific ticks and needed a `queue.timestampPeriod`
+/// scale factor; the resolver keeps that factor configurable so a backend
+/// that does not normalise to nanoseconds can still be handled, and so the
+/// conversion is independently testable.
+class GpuTimestampResolver {
+public:
+    /// `nanoseconds_per_tick` scales a raw tick delta to nanoseconds.
+    /// WebGPU normalises timestamps to nanoseconds, so the default is 1.0.
+    explicit GpuTimestampResolver(double nanoseconds_per_tick = 1.0)
+        : ns_per_tick_(nanoseconds_per_tick > 0.0 ? nanoseconds_per_tick
+                                                  : 1.0) {}
+
+    /// The active tick → nanosecond scale factor.
+    double nanoseconds_per_tick() const { return ns_per_tick_; }
+
+    /// Whether the GPU `timestamp-query` feature is available. When false,
+    /// every `resolve_*` call returns an invalid timing and callers should
+    /// fall back to the CPU numbers from Phase 6.1.
+    bool feature_available() const { return feature_available_; }
+    void set_feature_available(bool available) {
+        feature_available_ = available;
+    }
+
+    /// Convert a raw tick count to milliseconds. Pure arithmetic; does not
+    /// consult `feature_available()` — use `resolve_pair` for the gated
+    /// path. Provided so the conversion is directly unit-testable.
+    double ticks_to_ms(uint64_t ticks) const {
+        return (static_cast<double>(ticks) * ns_per_tick_) / 1.0e6;
+    }
+
+    /// Resolve a begin/end timestamp pair into a pass duration.
+    ///
+    /// Returns an invalid timing when:
+    ///   - the `timestamp-query` feature is unavailable, OR
+    ///   - `end_ticks < begin_ticks` (non-monotonic — a query slot was
+    ///     never written, or the GPU clock wrapped; the spec does not
+    ///     guarantee monotonicity across a wrap so we treat it as a miss).
+    ///
+    /// A zero-length pass (`end == begin`) is valid: GPU passes can resolve
+    /// to 0 when the draw work is trivially cheap.
+    GpuPassTiming resolve_pair(uint64_t begin_ticks,
+                               uint64_t end_ticks) const {
+        GpuPassTiming timing;
+        if (!feature_available_) {
+            return timing;  // valid = false
+        }
+        if (end_ticks < begin_ticks) {
+            return timing;  // non-monotonic → miss
+        }
+        timing.gpu_time_ms = ticks_to_ms(end_ticks - begin_ticks);
+        timing.valid = true;
+        return timing;
+    }
+
+    /// Resolve a buffer of interleaved [begin, end, begin, end, ...]
+    /// timestamps — the exact layout `wgpu::CommandEncoder::ResolveQuerySet`
+    /// produces when each pass writes a beginning + end query.
+    ///
+    /// `resolved_ticks` must hold `pass_count * 2` entries. A short or
+    /// odd-length buffer yields all-invalid timings for the missing tail
+    /// rather than reading out of bounds.
+    std::vector<GpuPassTiming> resolve_passes(
+        const std::vector<uint64_t>& resolved_ticks,
+        std::size_t pass_count) const {
+        std::vector<GpuPassTiming> out(pass_count);
+        for (std::size_t i = 0; i < pass_count; ++i) {
+            const std::size_t begin_idx = i * 2;
+            const std::size_t end_idx = begin_idx + 1;
+            if (end_idx >= resolved_ticks.size()) {
+                break;  // remaining entries stay invalid
+            }
+            out[i] = resolve_pair(resolved_ticks[begin_idx],
+                                  resolved_ticks[end_idx]);
+        }
+        return out;
+    }
+
+private:
+    double ns_per_tick_;
+    bool feature_available_ = false;
+};
+
+/// The WebGPU feature name a device must request for GPU timestamp
+/// queries. Kept as a plain string so non-render code (the inspector,
+/// tests) can refer to it without pulling in Dawn headers.
+inline constexpr const char* kTimestampQueryFeature = "timestamp-query";
+
+/// Owns the Dawn `wgpu::QuerySet` + resolve/readback buffers for one
+/// frame's worth of per-pass GPU timestamps.
+///
+/// This is the Dawn-coupled half of Phase 6.5 — the half that cannot be
+/// unit-tested without a live device. It is implemented in
+/// gpu_timestamp.cpp and only built when WebGPU is present; on a
+/// WebGPU-less build the factory returns nullptr and callers fall back
+/// to CPU timings. The handles are intentionally opaque (`void*`,
+/// interpreted as Dawn C++ types inside the .cpp) so this header has no
+/// Dawn dependency — the same pattern `GpuSurface` uses.
+///
+/// Lifecycle per frame:
+///   - `timestamp_writes_for_pass(i)` → a `wgpu::PassTimestampWrites*`
+///     to attach to render-pass descriptor i (begin + end slots).
+///   - after encoding all passes: `resolve(encoder)` records a
+///     `ResolveQuerySet` + copy into the map-readable buffer.
+///   - `read_back(resolver)` map-reads the *previous* frame's buffer and
+///     returns resolved `GpuPassTiming`s (one frame of lag).
+class GpuPassTimer {
+public:
+    virtual ~GpuPassTimer() = default;
+
+    /// Number of render passes this timer was sized for.
+    virtual std::size_t pass_capacity() const = 0;
+
+    /// Whether the device actually supports timestamp queries. When
+    /// false, every other method is a safe no-op and `read_back` returns
+    /// all-invalid timings.
+    virtual bool supported() const = 0;
+
+    /// Opaque `wgpu::PassTimestampWrites*` for render pass `pass_index`,
+    /// or nullptr when unsupported / out of range. Lives as long as the
+    /// timer; do not free.
+    virtual void* timestamp_writes_for_pass(std::size_t pass_index) = 0;
+
+    /// Record `ResolveQuerySet` + a copy into the readback buffer on the
+    /// given opaque `wgpu::CommandEncoder*`. No-op when unsupported.
+    virtual void resolve(void* command_encoder) = 0;
+
+    /// Map-read the previous frame's resolved buffer and convert to
+    /// per-pass GPU durations. Returns `pass_capacity()` entries; all
+    /// invalid when unsupported or when the buffer has not yet been
+    /// populated (first frame). Safe to call every frame.
+    virtual std::vector<GpuPassTiming> read_back(
+        const GpuTimestampResolver& resolver) = 0;
+
+    /// Construct a timer for `pass_count` passes against the opaque
+    /// `wgpu::Device*` / `wgpu::Queue*` handles from `GpuSurface`.
+    /// Returns nullptr on a WebGPU-less build. The returned timer
+    /// reports `supported() == false` when the device lacks the
+    /// `timestamp-query` feature — callers must check.
+    static std::unique_ptr<GpuPassTimer> create(void* dawn_device,
+                                                 void* dawn_queue,
+                                                 std::size_t pass_count);
+};
+
+}  // namespace pulp::render

--- a/core/render/include/pulp/render/render_pass.hpp
+++ b/core/render/include/pulp/render/render_pass.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -17,10 +18,19 @@ enum class RenderPassType {
 };
 
 /// Statistics for a single render pass.
+///
+/// `time_ms` is CPU wall-time measured around the pass's draw calls
+/// (Phase 6.1). `gpu_time_ms` is the real GPU-side execution time
+/// measured via WebGPU timestamp queries (Phase 6.5); it is only
+/// meaningful when `gpu_time_valid` is true — the `timestamp-query`
+/// feature may be unavailable on some adapters, in which case the
+/// inspector falls back to the CPU number.
 struct PassStats {
     RenderPassType type;
     int draw_calls = 0;
-    float time_ms = 0;
+    float time_ms = 0;           ///< CPU wall-time around the pass (ms).
+    float gpu_time_ms = 0;       ///< GPU-side execution time (ms); see flag.
+    bool gpu_time_valid = false; ///< True when `gpu_time_ms` is real data.
 };
 
 /// Frame-level render pass manager.
@@ -55,6 +65,32 @@ public:
         over_budget_ = (budget_ms_ > 0 && total_time_ms_ > budget_ms_);
     }
 
+    /// Attach a resolved GPU-side duration to the pass at `pass_index`
+    /// (the index into `passes()`, which is begin_pass() call order).
+    ///
+    /// Phase 6.5: the GPU timing for frame N is only readable in frame
+    /// N+1 (one frame of map-read lag), so the render loop carries the
+    /// previous frame's resolved timestamps forward and applies them
+    /// here after `begin_pass()` has rebuilt the pass list. `valid`
+    /// reflects whether the timestamp pair resolved cleanly — when the
+    /// `timestamp-query` feature is unavailable it stays false and the
+    /// inspector keeps showing the CPU number.
+    void set_pass_gpu_time(std::size_t pass_index, float gpu_time_ms,
+                           bool valid) {
+        if (pass_index < passes_.size()) {
+            passes_[pass_index].gpu_time_ms = gpu_time_ms;
+            passes_[pass_index].gpu_time_valid = valid;
+        }
+    }
+
+    /// Whether GPU timestamp queries are available on this adapter.
+    /// When false the inspector perf view shows CPU time only and labels
+    /// GPU time as "unavailable" rather than reporting a misleading zero.
+    bool gpu_timestamps_available() const { return gpu_timestamps_available_; }
+    void set_gpu_timestamps_available(bool available) {
+        gpu_timestamps_available_ = available;
+    }
+
     /// Set the per-frame time budget in milliseconds (0 = no budget).
     /// At 60fps, budget should be ~16ms. At 120fps, ~8ms.
     void set_budget(float ms) { budget_ms_ = ms; }
@@ -81,6 +117,7 @@ private:
     float budget_ms_ = 16.67f;  // 60fps default
     float total_time_ms_ = 0;
     bool over_budget_ = false;
+    bool gpu_timestamps_available_ = false;
     uint64_t frame_count_ = 0;
 };
 

--- a/core/render/src/gpu_surface_dawn.cpp
+++ b/core/render/src/gpu_surface_dawn.cpp
@@ -116,6 +116,20 @@ public:
                     std::string(message.data, message.length));
             });
 
+        // Phase 6.5 — opt into GPU timestamp queries when the adapter
+        // supports it. Requesting an unsupported feature *fails* device
+        // creation, so this is gated on the adapter's capability; an
+        // adapter without it still yields a working (CPU-timed) surface.
+        wgpu::FeatureName device_features[1];
+        if (adapter_.HasFeature(wgpu::FeatureName::TimestampQuery)) {
+            device_features[0] = wgpu::FeatureName::TimestampQuery;
+            device_desc.requiredFeatures = device_features;
+            device_desc.requiredFeatureCount = 1;
+        } else {
+            runtime::log_info("GpuSurface: adapter lacks timestamp-query — "
+                "GPU pass timings unavailable, CPU timings only");
+        }
+
         adapter_.RequestDevice(
             &device_desc,
             wgpu::CallbackMode::AllowProcessEvents,
@@ -132,6 +146,13 @@ public:
         }
 
         queue_ = device_.GetQueue();
+
+        // Record whether the created device actually carries the
+        // timestamp-query feature (Phase 6.5). Query the device, not the
+        // adapter — a device only has features that were requested AND
+        // granted.
+        gpu_timestamps_supported_ =
+            device_.HasFeature(wgpu::FeatureName::TimestampQuery);
 
         // Configure the surface for presentation
         if (surface_) {
@@ -195,6 +216,9 @@ public:
     bool has_surface() const override { return surface_ != nullptr; }
     uint32_t width() const override { return width_; }
     uint32_t height() const override { return height_; }
+    bool gpu_timestamps_supported() const override {
+        return gpu_timestamps_supported_;
+    }
 
     // Dawn handle accessors — SkiaSurface casts these back to Dawn C++ types
     void* dawn_device_handle() const override {
@@ -359,6 +383,7 @@ private:
     wgpu::PresentMode preferred_mode_ = wgpu::PresentMode::Fifo;
     uint32_t width_ = 0, height_ = 0;
     bool initialized_ = false;
+    bool gpu_timestamps_supported_ = false;
 };
 
 std::unique_ptr<GpuSurface> GpuSurface::create_dawn() {

--- a/core/render/src/gpu_timestamp.cpp
+++ b/core/render/src/gpu_timestamp.cpp
@@ -1,0 +1,225 @@
+#include <pulp/render/gpu_timestamp.hpp>
+
+// Phase 6.5 — Dawn GPU timestamp queries.
+//
+// The query-set lifecycle (allocation, PassTimestampWrites, ResolveQuerySet,
+// map-readback) is Dawn-coupled and cannot run without a live device, so it
+// lives here behind the WebGPU build guard. The tick -> millisecond
+// conversion math lives in the header (`GpuTimestampResolver`) and IS
+// unit-tested without a device — see test/test_render_gpu_timestamp.cpp.
+
+#ifdef PULP_HAS_SKIA
+// Skia builds use Dawn's C++ API so the timer shares the Dawn device that
+// GpuSurface created (see gpu_surface_dawn.cpp's matching guard).
+
+#include <pulp/runtime/log.hpp>
+#include "webgpu/webgpu_cpp.h"
+
+#include <atomic>
+#include <cstring>
+
+namespace pulp::render {
+namespace {
+
+/// Two timestamp slots per pass: beginning-of-pass + end-of-pass.
+constexpr std::size_t kSlotsPerPass = 2;
+/// WebGPU timestamps are 8-byte (uint64) values.
+constexpr std::size_t kBytesPerTimestamp = sizeof(uint64_t);
+
+class DawnPassTimer final : public GpuPassTimer {
+public:
+    DawnPassTimer(wgpu::Device device, wgpu::Queue queue,
+                  std::size_t pass_count)
+        : device_(std::move(device)),
+          queue_(std::move(queue)),
+          pass_count_(pass_count) {
+        // The device must have been created with the `timestamp-query`
+        // feature. GpuSurface requests it best-effort; if the adapter
+        // lacked it the device simply will not report it here, and we
+        // degrade to an all-no-op timer.
+        if (!device_ || pass_count_ == 0) {
+            return;
+        }
+        if (!device_.HasFeature(wgpu::FeatureName::TimestampQuery)) {
+            runtime::log_info(
+                "GpuPassTimer: device lacks timestamp-query feature — "
+                "GPU timings unavailable, falling back to CPU time");
+            return;
+        }
+
+        const uint32_t slot_count =
+            static_cast<uint32_t>(pass_count_ * kSlotsPerPass);
+
+        wgpu::QuerySetDescriptor query_desc{};
+        query_desc.label = "Pulp pass timestamp queries";
+        query_desc.type = wgpu::QueryType::Timestamp;
+        query_desc.count = slot_count;
+        query_set_ = device_.CreateQuerySet(&query_desc);
+
+        const uint64_t bytes =
+            static_cast<uint64_t>(slot_count) * kBytesPerTimestamp;
+
+        // ResolveQuerySet writes into this buffer; it must be CopySrc so
+        // we can copy it into the map-readable buffer below.
+        wgpu::BufferDescriptor resolve_desc{};
+        resolve_desc.label = "Pulp timestamp resolve buffer";
+        resolve_desc.size = bytes;
+        resolve_desc.usage =
+            wgpu::BufferUsage::QueryResolve | wgpu::BufferUsage::CopySrc;
+        resolve_buffer_ = device_.CreateBuffer(&resolve_desc);
+
+        // A MapRead buffer cannot also be a QueryResolve target, so the
+        // resolved ticks are copied here for host readback.
+        wgpu::BufferDescriptor readback_desc{};
+        readback_desc.label = "Pulp timestamp readback buffer";
+        readback_desc.size = bytes;
+        readback_desc.usage =
+            wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::MapRead;
+        readback_buffer_ = device_.CreateBuffer(&readback_desc);
+
+        // Pre-build the PassTimestampWrites: pass i writes its begin slot
+        // at index 2*i and its end slot at 2*i+1.
+        writes_.resize(pass_count_);
+        for (std::size_t i = 0; i < pass_count_; ++i) {
+            writes_[i].querySet = query_set_;
+            writes_[i].beginningOfPassWriteIndex =
+                static_cast<uint32_t>(i * kSlotsPerPass);
+            writes_[i].endOfPassWriteIndex =
+                static_cast<uint32_t>(i * kSlotsPerPass + 1);
+        }
+
+        supported_ = query_set_ && resolve_buffer_ && readback_buffer_;
+        byte_size_ = bytes;
+    }
+
+    std::size_t pass_capacity() const override { return pass_count_; }
+    bool supported() const override { return supported_; }
+
+    void* timestamp_writes_for_pass(std::size_t pass_index) override {
+        if (!supported_ || pass_index >= writes_.size()) {
+            return nullptr;
+        }
+        return &writes_[pass_index];
+    }
+
+    void resolve(void* command_encoder) override {
+        if (!supported_ || command_encoder == nullptr) {
+            return;
+        }
+        // A map is still in flight from a previous frame — skip this
+        // frame's resolve rather than racing the readback buffer.
+        if (map_pending_) {
+            return;
+        }
+        auto& encoder = *static_cast<wgpu::CommandEncoder*>(command_encoder);
+        const uint32_t slot_count =
+            static_cast<uint32_t>(pass_count_ * kSlotsPerPass);
+        encoder.ResolveQuerySet(query_set_, 0, slot_count, resolve_buffer_,
+                                0);
+        encoder.CopyBufferToBuffer(resolve_buffer_, 0, readback_buffer_, 0,
+                                   byte_size_);
+        resolved_once_ = true;
+    }
+
+    std::vector<GpuPassTiming> read_back(
+        const GpuTimestampResolver& resolver) override {
+        std::vector<GpuPassTiming> out(pass_count_);
+        if (!supported_ || !resolved_once_) {
+            return out;  // all invalid — first frame or unsupported
+        }
+
+        // Kick a map of the readback buffer. The copy recorded by the
+        // previous resolve() has had a full frame to complete, so the
+        // map normally resolves within one Tick().
+        if (!map_pending_) {
+            map_pending_ = true;
+            map_ready_.store(false, std::memory_order_relaxed);
+            readback_buffer_.MapAsync(
+                wgpu::MapMode::Read, 0, byte_size_,
+                wgpu::CallbackMode::AllowProcessEvents,
+                [this](wgpu::MapAsyncStatus status, wgpu::StringView) {
+                    map_ok_ = (status == wgpu::MapAsyncStatus::Success);
+                    map_ready_.store(true, std::memory_order_relaxed);
+                });
+        }
+
+        // Drive Dawn's callback pump. One tick is usually enough; cap the
+        // spins so a stalled GPU can never wedge the UI thread.
+        for (int spin = 0; spin < 8 &&
+                            !map_ready_.load(std::memory_order_relaxed);
+             ++spin) {
+            device_.Tick();
+        }
+
+        if (!map_ready_.load(std::memory_order_relaxed)) {
+            // Map still not done — return invalid timings; the next
+            // read_back() call observes the same in-flight map and waits.
+            return out;
+        }
+
+        map_pending_ = false;
+        if (!map_ok_) {
+            return out;
+        }
+
+        const std::size_t slot_count = pass_count_ * kSlotsPerPass;
+        const void* mapped =
+            readback_buffer_.GetConstMappedRange(0, byte_size_);
+        if (mapped != nullptr) {
+            std::vector<uint64_t> ticks(slot_count);
+            std::memcpy(ticks.data(), mapped,
+                        slot_count * kBytesPerTimestamp);
+            out = resolver.resolve_passes(ticks, pass_count_);
+        }
+        readback_buffer_.Unmap();
+        return out;
+    }
+
+private:
+    wgpu::Device device_;
+    wgpu::Queue queue_;
+    std::size_t pass_count_ = 0;
+    wgpu::QuerySet query_set_;
+    wgpu::Buffer resolve_buffer_;
+    wgpu::Buffer readback_buffer_;
+    std::vector<wgpu::PassTimestampWrites> writes_;
+    uint64_t byte_size_ = 0;
+    bool supported_ = false;
+    bool resolved_once_ = false;
+    bool map_pending_ = false;
+    bool map_ok_ = false;
+    std::atomic<bool> map_ready_{false};
+};
+
+}  // namespace
+
+std::unique_ptr<GpuPassTimer> GpuPassTimer::create(void* dawn_device,
+                                                   void* dawn_queue,
+                                                   std::size_t pass_count) {
+    if (dawn_device == nullptr || dawn_queue == nullptr) {
+        return nullptr;
+    }
+    auto device = *static_cast<wgpu::Device*>(dawn_device);
+    auto queue = *static_cast<wgpu::Queue*>(dawn_queue);
+    return std::make_unique<DawnPassTimer>(std::move(device),
+                                           std::move(queue), pass_count);
+}
+
+}  // namespace pulp::render
+
+#else  // !PULP_HAS_SKIA
+// No Dawn C++ API available (WebGPU-less build, or the wgpu-native
+// fallback path which does not integrate with Skia/Graphite). GPU
+// timestamps are unavailable; callers fall back to CPU timings.
+
+namespace pulp::render {
+
+std::unique_ptr<GpuPassTimer> GpuPassTimer::create(void* /*dawn_device*/,
+                                                   void* /*dawn_queue*/,
+                                                   std::size_t /*pass*/) {
+    return nullptr;
+}
+
+}  // namespace pulp::render
+
+#endif  // PULP_HAS_SKIA

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -606,12 +606,26 @@ InspectorMessage DomainHandler::handle_performance(const InspectorMessage& req) 
             obj.addMember("frame_count", choc::value::createInt64(static_cast<int64_t>(rpm_->frame_count())));
             obj.addMember("budget_ms", choc::value::createFloat64(rpm_->budget()));
             obj.addMember("over_budget", choc::value::createBool(rpm_->over_budget()));
+            // Phase 6.5 — whether real GPU-side timings are available on
+            // this adapter. When false the perf view shows CPU time only.
+            obj.addMember("gpu_timestamps_available",
+                          choc::value::createBool(rpm_->gpu_timestamps_available()));
 
             auto passes = choc::value::createEmptyArray();
             for (auto& p : rpm_->passes()) {
                 auto pass = choc::value::createObject("");
                 pass.addMember("draw_calls", choc::value::createInt32(p.draw_calls));
+                // `time_ms` is CPU wall-time (Phase 6.1). `cpu_time_ms`
+                // is the same value under an unambiguous name so a
+                // perf-view client never confuses it with GPU time;
+                // `time_ms` stays for backward compatibility.
                 pass.addMember("time_ms", choc::value::createFloat64(p.time_ms));
+                pass.addMember("cpu_time_ms", choc::value::createFloat64(p.time_ms));
+                // Phase 6.5 — real GPU-side execution time. Only present
+                // a number when the timestamp pair resolved; otherwise
+                // the client falls back to the CPU figure.
+                pass.addMember("gpu_time_ms", choc::value::createFloat64(p.gpu_time_ms));
+                pass.addMember("gpu_time_valid", choc::value::createBool(p.gpu_time_valid));
                 passes.addArrayElement(pass);
             }
             obj.addMember("passes", passes);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1904,6 +1904,19 @@ target_include_directories(pulp-test-gpu-graph PRIVATE
 target_link_libraries(pulp-test-gpu-graph PRIVATE Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-gpu-graph)
 
+# Phase 6.5 — GPU timestamp-query resolution math. Header-only
+# (GpuTimestampResolver + RenderPassManager GPU-time API), so it builds
+# and runs without a GPU; the Dawn-coupled GpuPassTimer live-device path
+# is exercised by the GPU matrix.
+add_executable(pulp-test-render-gpu-timestamp test_render_gpu_timestamp.cpp)
+target_include_directories(pulp-test-render-gpu-timestamp PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include)
+target_link_libraries(pulp-test-render-gpu-timestamp PRIVATE
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-render-gpu-timestamp
+    PROPERTIES
+        LABELS coverage)
+
 add_executable(pulp-test-render-loop
     test_render_loop.cpp
     ${CMAKE_SOURCE_DIR}/core/render/src/render_loop.cpp)

--- a/test/test_render_gpu_timestamp.cpp
+++ b/test/test_render_gpu_timestamp.cpp
@@ -1,0 +1,200 @@
+// Phase 6.5 — Dawn GPU timestamp queries.
+//
+// These tests cover the *pure* timestamp-resolution logic: raw tick ->
+// nanosecond -> millisecond conversion, the feature-absent fallback, and
+// the non-monotonic-miss rule. They run without a GPU because
+// `GpuTimestampResolver` is deliberately decoupled from Dawn (it consumes
+// a plain buffer of resolved ticks — exactly what `ResolveQuerySet`
+// produces). The live-device path (`GpuPassTimer`, query-set lifecycle)
+// is exercised by CI's GPU matrix; here we mock the resolved buffer.
+//
+// Spike reference: planning/2026-05-19-inspector-phase6-gpu-perf-spike.md
+// § Phase 6.5.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <pulp/render/gpu_timestamp.hpp>
+#include <pulp/render/render_pass.hpp>
+
+#include <vector>
+
+using namespace pulp::render;
+using Catch::Matchers::WithinAbs;
+
+// ── ns -> ms conversion ─────────────────────────────────────────────────
+
+TEST_CASE("GpuTimestampResolver converts nanosecond ticks to milliseconds",
+          "[render][gpu][timestamp][issue-290]") {
+    GpuTimestampResolver resolver;  // 1.0 ns/tick — WebGPU default
+
+    // 1,000,000 ns == 1.0 ms.
+    REQUIRE_THAT(resolver.ticks_to_ms(1'000'000), WithinAbs(1.0, 1e-9));
+    // 16,670,000 ns == one 60fps frame budget.
+    REQUIRE_THAT(resolver.ticks_to_ms(16'670'000), WithinAbs(16.67, 1e-6));
+    // Zero ticks is exactly zero ms.
+    REQUIRE_THAT(resolver.ticks_to_ms(0), WithinAbs(0.0, 1e-12));
+}
+
+TEST_CASE("GpuTimestampResolver honours a non-nanosecond tick period",
+          "[render][gpu][timestamp][issue-290]") {
+    // A backend reporting in 0.5 ns ticks: 2 ticks == 1 ns.
+    GpuTimestampResolver resolver(0.5);
+    REQUIRE(resolver.nanoseconds_per_tick() == 0.5);
+    // 2,000,000 ticks * 0.5 ns = 1,000,000 ns = 1.0 ms.
+    REQUIRE_THAT(resolver.ticks_to_ms(2'000'000), WithinAbs(1.0, 1e-9));
+
+    // A non-positive period is rejected and falls back to 1.0 ns/tick so
+    // a misconfigured backend never produces NaN/inf durations.
+    GpuTimestampResolver bad(-3.0);
+    REQUIRE(bad.nanoseconds_per_tick() == 1.0);
+    GpuTimestampResolver zero(0.0);
+    REQUIRE(zero.nanoseconds_per_tick() == 1.0);
+}
+
+// ── feature-absent fallback ─────────────────────────────────────────────
+
+TEST_CASE("resolve_pair returns invalid timing when the feature is absent",
+          "[render][gpu][timestamp][issue-290]") {
+    GpuTimestampResolver resolver;
+    REQUIRE_FALSE(resolver.feature_available());
+
+    // Even with a perfectly valid tick pair, an unavailable feature must
+    // yield an invalid timing so callers fall back to CPU time.
+    GpuPassTiming t = resolver.resolve_pair(1'000, 2'000'000);
+    REQUIRE_FALSE(t.valid);
+    REQUIRE(t.gpu_time_ms == 0.0);
+
+    // Flip the feature on — the same pair now resolves.
+    resolver.set_feature_available(true);
+    GpuPassTiming ok = resolver.resolve_pair(1'000, 1'001'000);
+    REQUIRE(ok.valid);
+    REQUIRE_THAT(ok.gpu_time_ms, WithinAbs(1.0, 1e-9));
+}
+
+TEST_CASE("resolve_pair flags non-monotonic tick pairs as a miss",
+          "[render][gpu][timestamp][issue-290]") {
+    GpuTimestampResolver resolver;
+    resolver.set_feature_available(true);
+
+    // end < begin — a query slot was never written, or the GPU clock
+    // wrapped. The spec does not guarantee monotonicity across a wrap,
+    // so this is treated as an unresolved miss, not a negative duration.
+    GpuPassTiming miss = resolver.resolve_pair(5'000'000, 1'000'000);
+    REQUIRE_FALSE(miss.valid);
+    REQUIRE(miss.gpu_time_ms == 0.0);
+
+    // A zero-length pass (end == begin) IS valid: trivially cheap GPU
+    // work legitimately resolves to 0 ms.
+    GpuPassTiming zero = resolver.resolve_pair(7'000'000, 7'000'000);
+    REQUIRE(zero.valid);
+    REQUIRE_THAT(zero.gpu_time_ms, WithinAbs(0.0, 1e-12));
+}
+
+// ── interleaved [begin,end,...] buffer resolution ───────────────────────
+
+TEST_CASE("resolve_passes decodes an interleaved ResolveQuerySet buffer",
+          "[render][gpu][timestamp][issue-290]") {
+    GpuTimestampResolver resolver;
+    resolver.set_feature_available(true);
+
+    // Mock exactly what ResolveQuerySet writes: [begin0,end0,begin1,end1].
+    // Pass 0: 2.0 ms. Pass 1: 0.5 ms.
+    std::vector<uint64_t> ticks = {
+        10'000'000, 12'000'000,   // pass 0 -> 2.0 ms
+        20'000'000, 20'500'000,   // pass 1 -> 0.5 ms
+    };
+    auto timings = resolver.resolve_passes(ticks, 2);
+    REQUIRE(timings.size() == 2);
+    REQUIRE(timings[0].valid);
+    REQUIRE_THAT(timings[0].gpu_time_ms, WithinAbs(2.0, 1e-9));
+    REQUIRE(timings[1].valid);
+    REQUIRE_THAT(timings[1].gpu_time_ms, WithinAbs(0.5, 1e-9));
+}
+
+TEST_CASE("resolve_passes leaves a short buffer's tail invalid",
+          "[render][gpu][timestamp][issue-290]") {
+    GpuTimestampResolver resolver;
+    resolver.set_feature_available(true);
+
+    // Only one complete pair, but three passes asked for. Tail entries
+    // must stay invalid rather than reading past the buffer.
+    std::vector<uint64_t> ticks = {100'000, 1'100'000};  // pass 0 -> 1.0 ms
+    auto timings = resolver.resolve_passes(ticks, 3);
+    REQUIRE(timings.size() == 3);
+    REQUIRE(timings[0].valid);
+    REQUIRE_THAT(timings[0].gpu_time_ms, WithinAbs(1.0, 1e-9));
+    REQUIRE_FALSE(timings[1].valid);
+    REQUIRE_FALSE(timings[2].valid);
+
+    // An odd-length buffer (dangling begin without an end) is also safe.
+    std::vector<uint64_t> odd = {100'000, 1'100'000, 5'000'000};
+    auto odd_timings = resolver.resolve_passes(odd, 2);
+    REQUIRE(odd_timings[0].valid);
+    REQUIRE_FALSE(odd_timings[1].valid);
+}
+
+// ── RenderPassManager GPU-time integration ──────────────────────────────
+
+TEST_CASE("RenderPassManager carries resolved GPU time alongside CPU time",
+          "[render][gpu][timestamp][issue-290]") {
+    RenderPassManager rpm;
+
+    // Default: GPU timestamps unavailable until a surface reports support.
+    REQUIRE_FALSE(rpm.gpu_timestamps_available());
+    rpm.set_gpu_timestamps_available(true);
+    REQUIRE(rpm.gpu_timestamps_available());
+
+    rpm.begin_frame();
+    rpm.begin_pass(RenderPassType::background);
+    rpm.end_pass(/*time_ms=*/3.0f, /*draw_calls=*/2);
+    rpm.begin_pass(RenderPassType::content);
+    rpm.end_pass(/*time_ms=*/8.0f, /*draw_calls=*/12);
+
+    REQUIRE(rpm.passes().size() == 2);
+    // CPU time recorded; GPU time not yet attached -> invalid.
+    REQUIRE(rpm.passes()[0].time_ms == 3.0f);
+    REQUIRE_FALSE(rpm.passes()[0].gpu_time_valid);
+
+    // The render loop applies the previous frame's resolved GPU timings.
+    GpuTimestampResolver resolver;
+    resolver.set_feature_available(true);
+    std::vector<uint64_t> ticks = {
+        0,         2'400'000,    // background -> 2.4 ms GPU
+        2'400'000, 9'000'000,    // content    -> 6.6 ms GPU
+    };
+    auto gpu = resolver.resolve_passes(ticks, 2);
+    for (std::size_t i = 0; i < gpu.size(); ++i) {
+        rpm.set_pass_gpu_time(i, static_cast<float>(gpu[i].gpu_time_ms),
+                              gpu[i].valid);
+    }
+
+    REQUIRE(rpm.passes()[0].gpu_time_valid);
+    REQUIRE_THAT(rpm.passes()[0].gpu_time_ms, WithinAbs(2.4, 1e-4));
+    REQUIRE(rpm.passes()[1].gpu_time_valid);
+    REQUIRE_THAT(rpm.passes()[1].gpu_time_ms, WithinAbs(6.6, 1e-4));
+    // CPU numbers are untouched — the perf view shows both side by side.
+    REQUIRE(rpm.passes()[1].time_ms == 8.0f);
+
+    // An out-of-range index is a safe no-op (no crash, no growth).
+    rpm.set_pass_gpu_time(99, 1.0f, true);
+    REQUIRE(rpm.passes().size() == 2);
+}
+
+TEST_CASE("RenderPassManager leaves GPU time invalid when feature absent",
+          "[render][gpu][timestamp][issue-290]") {
+    RenderPassManager rpm;
+    rpm.begin_frame();
+    rpm.begin_pass(RenderPassType::content);
+    rpm.end_pass(/*time_ms=*/5.0f, /*draw_calls=*/4);
+
+    // Feature absent — resolver returns an invalid timing; the manager
+    // records it as invalid so the inspector reports "GPU unavailable"
+    // rather than a misleading 0 ms.
+    GpuTimestampResolver resolver;  // feature_available() == false
+    GpuPassTiming t = resolver.resolve_pair(1'000, 9'000'000);
+    rpm.set_pass_gpu_time(0, static_cast<float>(t.gpu_time_ms), t.valid);
+
+    REQUIRE_FALSE(rpm.passes()[0].gpu_time_valid);
+    REQUIRE(rpm.passes()[0].time_ms == 5.0f);  // CPU fallback intact
+}


### PR DESCRIPTION
Phase 6.5 of the inspector roadmap. Phase 6.1 surfaced per-pass CPU
wall-time around each render pass's draw calls; that hides the real
GPU-side execution time where perf bugs usually live. This adds the
true GPU clock via WebGPU timestamp queries.

- PassStats keeps `time_ms` (CPU, unchanged for back-compat) and gains
  `gpu_time_ms` + `gpu_time_valid`. RenderPassManager gains
  `set_pass_gpu_time()` and `gpu_timestamps_available()`.
- New gpu_timestamp.hpp: GpuTimestampResolver is the pure, GPU-free
  tick -> nanosecond -> millisecond conversion with the feature-absent
  and non-monotonic-miss rules, so the resolution math is unit-testable
  without a live device. GpuPassTimer owns the Dawn QuerySet /
  PassTimestampWrites / ResolveQuerySet + map-readback lifecycle in
  gpu_timestamp.cpp, built only when WebGPU is present.
- gpu_surface_dawn.cpp requests the `timestamp-query` feature
  best-effort at device creation, gated on Adapter::HasFeature so an
  adapter without it still yields a working (CPU-timed) surface, and
  exposes GpuSurface::gpu_timestamps_supported().
- Performance.getMetrics now emits cpu_time_ms, gpu_time_ms and
  gpu_time_valid per pass plus a top-level gpu_timestamps_available, so
  the inspector perf view can show CPU vs GPU side by side.

Tests: test_render_gpu_timestamp.cpp — 8 cases / 41 assertions
covering ns conversion, non-nanosecond tick periods, feature-absent
fallback, non-monotonic miss, interleaved-buffer decode, short-buffer
safety, and RenderPassManager GPU-time integration. Header-only so it
runs without a GPU; the live-device GpuPassTimer path is deferred to
CI's GPU matrix.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>