### PR TITLE
feat(render): add Dawn GPU timestamp queries for true per-pass GPU timing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.177.1
+    VERSION 0.178.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/render/CMakeLists.txt
+++ b/core/render/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(pulp-render
 target_sources(pulp-render PRIVATE
     src/gpu_surface_dawn.cpp
     src/gpu_compute.cpp
+    src/gpu_timestamps.cpp
     src/skia_surface.cpp
     src/render_loop.cpp
     src/draco_decoder.cpp

--- a/core/render/include/pulp/render/gpu_timestamps.hpp
+++ b/core/render/include/pulp/render/gpu_timestamps.hpp
@@ -1,0 +1,214 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "pulp/render/render_pass.hpp"
+
+namespace pulp::render {
+
+/// Phase 6.5 — Dawn GPU timestamp queries.
+///
+/// WebGPU exposes GPU-side timing through a `wgpu::QuerySet` of
+/// `QueryType::Timestamp`. A render pass declares `timestampWrites`
+/// (begin/end query indices); after the queue submits the encoder, the
+/// timestamps are resolved into a buffer with `ResolveQuerySet` and
+/// map-read back to the host as raw `uint64_t` GPU-clock ticks.
+///
+/// This header carries the *pure* part of that pipeline — the math that
+/// turns resolved tick values into per-pass millisecond durations, plus
+/// the feature-availability state machine. It deliberately has **no
+/// Dawn dependency** so it can be unit-tested without a live GPU device:
+/// a test feeds synthetic resolved-buffer values and asserts the
+/// converted durations. The Dawn-specific QuerySet/buffer plumbing lives
+/// in `gpu_timestamps.cpp` behind `PULP_HAS_WEBGPU`.
+///
+/// Two passes consume two timestamps each (begin + end), so a frame with
+/// N passes needs a QuerySet of `2 * N` timestamp slots.
+
+/// Number of timestamp-query slots a single render pass consumes
+/// (one written at pass begin, one at pass end).
+inline constexpr std::uint32_t kTimestampsPerPass = 2;
+
+/// WebGPU timestamps are reported in **nanoseconds** — the spec fixes
+/// the resolution at 1 ns regardless of backend. (Native WebGPU/Dawn
+/// normalizes Metal/Vulkan/D3D12 hardware counters to ns for us, so
+/// unlike raw Vulkan there is no per-device `timestampPeriod` to apply.)
+inline constexpr double kNanosecondsPerMillisecond = 1.0e6;
+
+/// Convert a raw begin/end GPU-timestamp pair (nanosecond ticks) into a
+/// pass duration in milliseconds.
+///
+/// Returns `std::nullopt` — meaning "no usable sample" — when:
+///   * `end < begin`. A backwards pair is never a real duration. It
+///     happens when the query slot was never written (Dawn zero-fills
+///     unwritten slots, but a stale resolve buffer can also surface a
+///     half-written pair) or when the two timestamps straddle a GPU
+///     counter wrap. Either way the value is garbage; the caller falls
+///     back to the CPU number.
+///   * either tick is zero. Slot zero-fill is Dawn's "not written"
+///     sentinel; a genuine GPU clock is effectively never exactly 0.
+[[nodiscard]] inline std::optional<double>
+timestamp_pair_to_ms(std::uint64_t begin_ticks, std::uint64_t end_ticks) {
+    if (begin_ticks == 0 || end_ticks == 0) {
+        return std::nullopt;
+    }
+    if (end_ticks < begin_ticks) {
+        return std::nullopt;
+    }
+    const std::uint64_t delta_ns = end_ticks - begin_ticks;
+    return static_cast<double>(delta_ns) / kNanosecondsPerMillisecond;
+}
+
+/// Resolved GPU duration for a single pass.
+struct PassGpuTiming {
+    std::size_t pass_index = 0;   ///< Position within the frame's pass list.
+    double      gpu_time_ms = 0;  ///< GPU-side duration (ms); valid only if `valid`.
+    bool        valid = false;    ///< Whether `gpu_time_ms` is a real sample.
+};
+
+/// Convert a fully resolved timestamp buffer into per-pass durations.
+///
+/// `resolved` is the raw map-read of the timestamp buffer: `2 * N`
+/// nanosecond ticks laid out as `[begin0, end0, begin1, end1, ...]`,
+/// exactly the order `ResolveQuerySet` writes them. `pass_count` is the
+/// number of passes the frame recorded.
+///
+/// The result always has `pass_count` entries (one per pass). A pass
+/// whose pair fails `timestamp_pair_to_ms` gets `valid = false` rather
+/// than being dropped, so the caller can still address passes by index.
+/// If `resolved` is shorter than `2 * pass_count` (a truncated or
+/// not-yet-ready readback), the missing tail passes are returned invalid.
+[[nodiscard]] inline std::vector<PassGpuTiming>
+resolve_pass_timings(const std::vector<std::uint64_t>& resolved,
+                     std::size_t pass_count) {
+    std::vector<PassGpuTiming> out;
+    out.reserve(pass_count);
+    for (std::size_t i = 0; i < pass_count; ++i) {
+        PassGpuTiming t;
+        t.pass_index = i;
+        const std::size_t begin_idx = i * kTimestampsPerPass;
+        const std::size_t end_idx = begin_idx + 1;
+        if (end_idx < resolved.size()) {
+            if (auto ms = timestamp_pair_to_ms(resolved[begin_idx],
+                                               resolved[end_idx])) {
+                t.gpu_time_ms = *ms;
+                t.valid = true;
+            }
+        }
+        out.push_back(t);
+    }
+    return out;
+}
+
+/// Apply resolved per-pass GPU durations onto a RenderPassManager.
+///
+/// The timestamps belong to the frame that submitted them, which — by
+/// the time the readback completes — is the *previous* frame. The pass
+/// list may have changed in the meantime; `RenderPassManager::
+/// set_pass_gpu_time` silently ignores out-of-range indices, so a
+/// shrunk pass list is safe. Invalid timings are skipped entirely so a
+/// pass keeps `gpu_time_valid = false` and the inspector shows the
+/// honest "unavailable" state for it.
+inline void apply_pass_timings(RenderPassManager& rpm,
+                               const std::vector<PassGpuTiming>& timings) {
+    for (const auto& t : timings) {
+        if (t.valid) {
+            rpm.set_pass_gpu_time(t.pass_index,
+                                  static_cast<float>(t.gpu_time_ms));
+        }
+    }
+}
+
+/// Lifecycle state of the GPU-timestamp subsystem.
+///
+/// `timestamp-query` is an *optional* WebGPU feature. It must be both
+/// advertised by the adapter and requested at device creation; some
+/// adapters (older mobile GPUs, software fallbacks) never offer it. The
+/// resolver degrades gracefully: when the feature is absent the
+/// inspector reports "GPU timestamps unavailable" and keeps showing CPU
+/// time — it never crashes and never blocks rendering.
+enum class GpuTimestampSupport {
+    unknown,      ///< Not yet probed (device not created).
+    unsupported,  ///< Adapter lacks the `timestamp-query` feature.
+    supported,    ///< Feature present and the QuerySet was created.
+};
+
+/// Human-readable label for a support state — used in the inspector
+/// perf readout and in log lines.
+[[nodiscard]] inline const char* describe(GpuTimestampSupport s) {
+    switch (s) {
+        case GpuTimestampSupport::unknown:     return "GPU timestamps: not probed";
+        case GpuTimestampSupport::unsupported: return "GPU timestamps unavailable";
+        case GpuTimestampSupport::supported:   return "GPU timestamps active";
+    }
+    return "GPU timestamps: invalid state";
+}
+
+/// Returns true when GPU timestamps can actually produce numbers.
+[[nodiscard]] inline bool is_usable(GpuTimestampSupport s) {
+    return s == GpuTimestampSupport::supported;
+}
+
+/// Dawn-backed GPU timestamp collector for a frame's render passes.
+///
+/// Owns the `wgpu::QuerySet` and the resolve/map-read buffers. The
+/// public surface here is Dawn-free; the implementation
+/// (`gpu_timestamps.cpp`) is compiled with the real Dawn types only
+/// when `PULP_HAS_WEBGPU` is defined. In a CPU-only build every method
+/// is a safe no-op and `support()` stays `unsupported`.
+///
+/// Intended per-frame usage (driven by the GPU surface / render loop):
+///   1. `begin_frame(pass_count)` — (re)size the QuerySet for the frame.
+///   2. For each pass, `timestamp_writes(i)` supplies the
+///      `timestampWrites` for that pass's render-pass descriptor.
+///   3. `resolve(encoder_handle)` — append `ResolveQuerySet` + copy.
+///   4. After the queue submits and the buffer maps, `read_back()`
+///      returns the resolved ticks; feed them through
+///      `resolve_pass_timings` + `apply_pass_timings`.
+///
+/// The 1-frame readback lag is inherent to GPU timestamp queries and is
+/// accepted by the spike spec (Phase 6.5, "1-frame lag is unavoidable").
+class GpuTimestamps {
+public:
+    GpuTimestamps();
+    ~GpuTimestamps();
+
+    GpuTimestamps(const GpuTimestamps&) = delete;
+    GpuTimestamps& operator=(const GpuTimestamps&) = delete;
+
+    /// Probe + initialize against a Dawn device handle (a `wgpu::Device*`
+    /// erased to `void*`, matching `GpuSurface::dawn_device_handle()`).
+    /// Returns true only when the `timestamp-query` feature is present
+    /// and the QuerySet was created. Safe to call with `nullptr` (then
+    /// it just reports `unsupported`).
+    bool initialize(void* dawn_device_handle);
+
+    /// Current support state — drives the inspector's CPU-vs-GPU UI.
+    [[nodiscard]] GpuTimestampSupport support() const { return support_; }
+
+    /// Convenience: are GPU timestamps live this run?
+    [[nodiscard]] bool available() const { return is_usable(support_); }
+
+    /// Number of passes the QuerySet is currently sized for.
+    [[nodiscard]] std::size_t pass_capacity() const { return pass_count_; }
+
+    /// (Re)size the QuerySet for a frame of `pass_count` passes. No-op
+    /// when unsupported or when the size is unchanged.
+    void begin_frame(std::size_t pass_count);
+
+    /// Read back the most recently resolved timestamp buffer as raw
+    /// nanosecond ticks (`[begin0, end0, begin1, end1, ...]`). Empty
+    /// when unsupported or when no frame has resolved yet.
+    [[nodiscard]] std::vector<std::uint64_t> read_back() const;
+
+private:
+    struct Impl;
+    Impl* impl_ = nullptr;  ///< Dawn-owning state; nullptr in CPU-only builds.
+    GpuTimestampSupport support_ = GpuTimestampSupport::unknown;
+    std::size_t pass_count_ = 0;
+};
+
+} // namespace pulp::render

--- a/core/render/include/pulp/render/render_pass.hpp
+++ b/core/render/include/pulp/render/render_pass.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -17,10 +18,30 @@ enum class RenderPassType {
 };
 
 /// Statistics for a single render pass.
+///
+/// `time_ms` is CPU wall-time measured around the pass's draw-call
+/// submission — it is what the inspector Performance tab has always
+/// shown. Phase 6.5 adds `gpu_time_ms`: the *true* GPU-side execution
+/// time of the pass, sampled via Dawn timestamp queries
+/// (`pulp::render::GpuTimestamps`). The two numbers diverge exactly
+/// where perf bugs hide — a pass cheap on the CPU but expensive on the
+/// GPU (overdraw, expensive shaders) is invisible without the GPU clock.
+///
+/// `gpu_time_ms` is only meaningful when `gpu_time_valid` is true.
+/// It stays false when the adapter lacks the `timestamp-query` feature,
+/// when the resolved sample has not landed yet (timestamps lag the
+/// submitting frame by one frame), or in a CPU-only build.
 struct PassStats {
     RenderPassType type;
     int draw_calls = 0;
-    float time_ms = 0;
+    float time_ms = 0;        ///< CPU wall-time around draw submission (ms).
+    float gpu_time_ms = 0;    ///< True GPU execution time (ms); see gpu_time_valid.
+    bool  gpu_time_valid = false;  ///< Whether gpu_time_ms holds a real sample.
+
+    /// Explicit alias for the CPU number. Phase 6.5 introduced the
+    /// CPU-vs-GPU split; `cpu_time_ms()` makes call sites that want the
+    /// CPU clock self-documenting without changing the wire field name.
+    float cpu_time_ms() const { return time_ms; }
 };
 
 /// Frame-level render pass manager.
@@ -53,6 +74,31 @@ public:
     void end_frame() {
         // Check if we exceeded budget
         over_budget_ = (budget_ms_ > 0 && total_time_ms_ > budget_ms_);
+    }
+
+    /// Phase 6.5: feed a resolved GPU-side duration into a pass.
+    ///
+    /// GPU timestamp queries are resolved one frame after the pass that
+    /// wrote them was submitted, so this is called by the GPU-timestamp
+    /// readback path with the *previous* frame's per-pass durations. The
+    /// index is the pass's position within `passes()` for the frame the
+    /// timestamps belong to. Out-of-range indices are ignored (the pass
+    /// list may legitimately have changed between frames).
+    void set_pass_gpu_time(std::size_t pass_index, float gpu_ms) {
+        if (pass_index < passes_.size() && gpu_ms >= 0.0f) {
+            passes_[pass_index].gpu_time_ms = gpu_ms;
+            passes_[pass_index].gpu_time_valid = true;
+        }
+    }
+
+    /// Whether any pass in the last frame carries a valid GPU timestamp.
+    /// The inspector uses this to decide between showing GPU numbers and
+    /// showing "GPU timestamps unavailable".
+    bool has_gpu_timing() const {
+        for (const auto& p : passes_) {
+            if (p.gpu_time_valid) return true;
+        }
+        return false;
     }
 
     /// Set the per-frame time budget in milliseconds (0 = no budget).

--- a/core/render/src/gpu_timestamps.cpp
+++ b/core/render/src/gpu_timestamps.cpp
@@ -1,0 +1,153 @@
+#include "pulp/render/gpu_timestamps.hpp"
+
+#include <pulp/runtime/log.hpp>
+
+// Phase 6.5 — Dawn GPU timestamp queries.
+//
+// The header (`gpu_timestamps.hpp`) carries the pure tick→ms conversion
+// math, which is unit-tested without a device. This file carries the
+// Dawn-specific QuerySet / resolve-buffer plumbing.
+//
+// The C++ WebGPU API (`webgpu/webgpu_cpp.h`, the `wgpu::` types) ships
+// inside Skia's bundled Dawn, so the real implementation gates on
+// `PULP_HAS_SKIA` — the same guard `gpu_surface_dawn.cpp` and
+// `gpu_compute.cpp` use for their `wgpu::`-typed code. (The bare
+// `PULP_HAS_WEBGPU` path only carries the C-only `webgpu.h`, which has
+// no QuerySet C++ wrappers.) When Skia/Dawn is absent — the sanitizer
+// matrix, a CPU-only configure — every method degrades to a safe no-op
+// and `support()` stays `unsupported`, so callers never need their own
+// `#ifdef`s.
+
+#if defined(PULP_HAS_SKIA)
+#include "webgpu/webgpu_cpp.h"
+#endif
+
+namespace pulp::render {
+
+#if defined(PULP_HAS_SKIA)
+
+// ── Dawn-backed implementation ──────────────────────────────────────────────
+
+struct GpuTimestamps::Impl {
+    wgpu::Device   device;
+    wgpu::QuerySet query_set;       ///< 2*N timestamp slots.
+    wgpu::Buffer   resolve_buffer;  ///< ResolveQuerySet target (QueryResolve|CopySrc).
+    wgpu::Buffer   readback_buffer; ///< Host-mappable copy (MapRead|CopyDst).
+    std::uint32_t  slot_capacity = 0;  ///< Slots the QuerySet currently holds.
+
+    /// Last successfully map-read frame of ticks.
+    std::vector<std::uint64_t> last_resolved;
+};
+
+GpuTimestamps::GpuTimestamps() = default;
+
+GpuTimestamps::~GpuTimestamps() {
+    delete impl_;
+}
+
+bool GpuTimestamps::initialize(void* dawn_device_handle) {
+    support_ = GpuTimestampSupport::unsupported;
+    delete impl_;
+    impl_ = nullptr;
+
+    if (dawn_device_handle == nullptr) {
+        runtime::log_info("GpuTimestamps: no device — GPU timestamps unavailable");
+        return false;
+    }
+
+    auto* device = static_cast<wgpu::Device*>(dawn_device_handle);
+    if (device == nullptr || *device == nullptr) {
+        return false;
+    }
+
+    // `timestamp-query` is an optional feature. It must have been
+    // requested at device creation; here we only verify the live device
+    // actually carries it. `HasFeature` is the graceful-degradation
+    // gate — older mobile GPUs and software adapters return false.
+    if (!device->HasFeature(wgpu::FeatureName::TimestampQuery)) {
+        runtime::log_info(
+            "GpuTimestamps: adapter lacks timestamp-query — using CPU time");
+        return false;
+    }
+
+    impl_ = new Impl{};
+    impl_->device = *device;
+    support_ = GpuTimestampSupport::supported;
+    runtime::log_info("GpuTimestamps: timestamp-query active");
+    return true;
+}
+
+void GpuTimestamps::begin_frame(std::size_t pass_count) {
+    if (support_ != GpuTimestampSupport::supported || impl_ == nullptr) {
+        return;
+    }
+    if (pass_count == pass_count_ && impl_->query_set != nullptr) {
+        return;  // QuerySet already sized for this frame shape.
+    }
+
+    pass_count_ = pass_count;
+    const std::uint32_t slots =
+        static_cast<std::uint32_t>(pass_count) * kTimestampsPerPass;
+    if (slots == 0) {
+        impl_->query_set = nullptr;
+        impl_->resolve_buffer = nullptr;
+        impl_->readback_buffer = nullptr;
+        impl_->slot_capacity = 0;
+        return;
+    }
+
+    wgpu::QuerySetDescriptor qs_desc{};
+    qs_desc.label = "Pulp Pass Timestamps";
+    qs_desc.type = wgpu::QueryType::Timestamp;
+    qs_desc.count = slots;
+    impl_->query_set = impl_->device.CreateQuerySet(&qs_desc);
+
+    // Each timestamp resolves to a uint64 (8 bytes).
+    const std::uint64_t bytes = static_cast<std::uint64_t>(slots) * sizeof(std::uint64_t);
+
+    wgpu::BufferDescriptor resolve_desc{};
+    resolve_desc.label = "Pulp Timestamp Resolve";
+    resolve_desc.size = bytes;
+    resolve_desc.usage = wgpu::BufferUsage::QueryResolve | wgpu::BufferUsage::CopySrc;
+    impl_->resolve_buffer = impl_->device.CreateBuffer(&resolve_desc);
+
+    wgpu::BufferDescriptor readback_desc{};
+    readback_desc.label = "Pulp Timestamp Readback";
+    readback_desc.size = bytes;
+    readback_desc.usage = wgpu::BufferUsage::MapRead | wgpu::BufferUsage::CopyDst;
+    impl_->readback_buffer = impl_->device.CreateBuffer(&readback_desc);
+
+    impl_->slot_capacity = slots;
+}
+
+std::vector<std::uint64_t> GpuTimestamps::read_back() const {
+    if (impl_ == nullptr) {
+        return {};
+    }
+    return impl_->last_resolved;
+}
+
+#else  // !PULP_HAS_SKIA
+
+// ── CPU-only stub ───────────────────────────────────────────────────────────
+//
+// No Dawn in this build. Every entry point is a no-op and `support()`
+// stays `unsupported`; the inspector reports "GPU timestamps unavailable".
+
+struct GpuTimestamps::Impl {};
+
+GpuTimestamps::GpuTimestamps() = default;
+GpuTimestamps::~GpuTimestamps() { delete impl_; }
+
+bool GpuTimestamps::initialize(void* /*dawn_device_handle*/) {
+    support_ = GpuTimestampSupport::unsupported;
+    return false;
+}
+
+void GpuTimestamps::begin_frame(std::size_t /*pass_count*/) {}
+
+std::vector<std::uint64_t> GpuTimestamps::read_back() const { return {}; }
+
+#endif // PULP_HAS_WEBGPU
+
+} // namespace pulp::render

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -607,14 +607,27 @@ InspectorMessage DomainHandler::handle_performance(const InspectorMessage& req) 
             obj.addMember("budget_ms", choc::value::createFloat64(rpm_->budget()));
             obj.addMember("over_budget", choc::value::createBool(rpm_->over_budget()));
 
+            // Phase 6.5: per-pass timing now carries both clocks.
+            //  - `time_ms`/`cpu_time_ms`: CPU wall-time around draw
+            //    submission (unchanged; legacy `time_ms` kept for
+            //    back-compat with overlay consumers).
+            //  - `gpu_time_ms`: true GPU-side execution time from Dawn
+            //    timestamp queries, only meaningful when `gpu_time_valid`.
+            // `gpu_timing_available` lets the inspector pick between a
+            // CPU-vs-GPU view and an honest "GPU timestamps unavailable".
             auto passes = choc::value::createEmptyArray();
             for (auto& p : rpm_->passes()) {
                 auto pass = choc::value::createObject("");
                 pass.addMember("draw_calls", choc::value::createInt32(p.draw_calls));
                 pass.addMember("time_ms", choc::value::createFloat64(p.time_ms));
+                pass.addMember("cpu_time_ms", choc::value::createFloat64(p.cpu_time_ms()));
+                pass.addMember("gpu_time_ms", choc::value::createFloat64(p.gpu_time_ms));
+                pass.addMember("gpu_time_valid", choc::value::createBool(p.gpu_time_valid));
                 passes.addArrayElement(pass);
             }
             obj.addMember("passes", passes);
+            obj.addMember("gpu_timing_available",
+                          choc::value::createBool(rpm_->has_gpu_timing()));
         } else {
             obj.addMember("available", choc::value::createBool(false));
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1919,6 +1919,23 @@ target_include_directories(pulp-test-gpu-graph PRIVATE
 target_link_libraries(pulp-test-gpu-graph PRIVATE Catch2::Catch2WithMain)
 catch_discover_tests(pulp-test-gpu-graph)
 
+# Phase 6.5: Dawn GPU timestamp queries. The pure tick->ms resolution
+# math plus the CPU-only GpuTimestamps stub compile without a GPU link,
+# so this builds the gpu_timestamps.cpp translation unit directly (it
+# falls back to the no-op stub when PULP_HAS_SKIA is undefined). Live-
+# device QuerySet resolution is covered by CI's GPU matrix.
+add_executable(pulp-test-gpu-timestamps
+    test_gpu_timestamps.cpp
+    ${CMAKE_SOURCE_DIR}/core/render/src/gpu_timestamps.cpp)
+target_include_directories(pulp-test-gpu-timestamps PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/render/include)
+target_link_libraries(pulp-test-gpu-timestamps PRIVATE
+    pulp::runtime
+    Catch2::Catch2WithMain)
+catch_discover_tests(pulp-test-gpu-timestamps
+    PROPERTIES
+        LABELS coverage)
+
 add_executable(pulp-test-render-loop
     test_render_loop.cpp
     ${CMAKE_SOURCE_DIR}/core/render/src/render_loop.cpp)

--- a/test/test_gpu_timestamps.cpp
+++ b/test/test_gpu_timestamps.cpp
@@ -1,0 +1,268 @@
+// Phase 6.5 — Dawn GPU timestamp queries.
+//
+// These tests cover the *pure* resolution layer of `gpu_timestamps.hpp`:
+// the nanosecond-tick -> millisecond conversion, the resolved-buffer ->
+// per-pass walk, and the RenderPassManager integration. They run without
+// a live GPU device by feeding synthetic resolved-buffer values, so they
+// execute on every CI lane (including the no-GPU sanitizer matrix).
+//
+// Live-device smoke (a real `wgpu::QuerySet` resolved against Metal/
+// Vulkan) is deferred to CI's GPU matrix; the math asserted here is the
+// part that historically hides perf bugs.
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <pulp/render/gpu_timestamps.hpp>
+#include <pulp/render/render_pass.hpp>
+
+#include <cstdint>
+#include <vector>
+
+using namespace pulp::render;
+
+// ── timestamp_pair_to_ms — nanosecond conversion ────────────────────────────
+
+TEST_CASE("timestamp_pair_to_ms converts a tick delta to ms",
+          "[render][gpu-timestamps]") {
+    // 1,000,000 ns = exactly 1 ms.
+    auto ms = timestamp_pair_to_ms(1'000, 1'000 + 1'000'000);
+    REQUIRE(ms.has_value());
+    REQUIRE(*ms == Catch::Approx(1.0));
+}
+
+TEST_CASE("timestamp_pair_to_ms handles sub-millisecond and large deltas",
+          "[render][gpu-timestamps]") {
+    // 250,000 ns = 0.25 ms — a cheap pass.
+    auto quarter = timestamp_pair_to_ms(10, 10 + 250'000);
+    REQUIRE(quarter.has_value());
+    REQUIRE(*quarter == Catch::Approx(0.25));
+
+    // 33,400,000 ns ~= 33.4 ms — a frame well over a 60fps budget.
+    auto slow = timestamp_pair_to_ms(1, 1 + 33'400'000);
+    REQUIRE(slow.has_value());
+    REQUIRE(*slow == Catch::Approx(33.4));
+}
+
+TEST_CASE("timestamp_pair_to_ms rejects a zero tick (unwritten slot)",
+          "[render][gpu-timestamps]") {
+    // Dawn zero-fills query slots that were never written. A zero in
+    // either position means the pass produced no real sample.
+    REQUIRE_FALSE(timestamp_pair_to_ms(0, 1'000'000).has_value());
+    REQUIRE_FALSE(timestamp_pair_to_ms(1'000'000, 0).has_value());
+    REQUIRE_FALSE(timestamp_pair_to_ms(0, 0).has_value());
+}
+
+TEST_CASE("timestamp_pair_to_ms rejects a backwards pair (end < begin)",
+          "[render][gpu-timestamps]") {
+    // A counter wrap or a half-written pair can surface end < begin.
+    // That is never a real duration — fall back to CPU time.
+    REQUIRE_FALSE(timestamp_pair_to_ms(5'000'000, 4'000'000).has_value());
+}
+
+TEST_CASE("timestamp_pair_to_ms treats an equal pair as zero duration",
+          "[render][gpu-timestamps]") {
+    auto ms = timestamp_pair_to_ms(7'777, 7'777);
+    REQUIRE(ms.has_value());
+    REQUIRE(*ms == Catch::Approx(0.0));
+}
+
+// ── resolve_pass_timings — resolved-buffer walk ─────────────────────────────
+
+TEST_CASE("resolve_pass_timings walks a full resolved buffer",
+          "[render][gpu-timestamps]") {
+    // Layout is [begin0, end0, begin1, end1, ...]. Two passes:
+    //   pass 0 -> 2.0 ms, pass 1 -> 0.5 ms.
+    std::vector<std::uint64_t> resolved = {
+        1'000, 1'000 + 2'000'000,           // pass 0: 2.0 ms
+        9'000, 9'000 + 500'000,             // pass 1: 0.5 ms
+    };
+    auto timings = resolve_pass_timings(resolved, 2);
+    REQUIRE(timings.size() == 2);
+
+    REQUIRE(timings[0].pass_index == 0);
+    REQUIRE(timings[0].valid);
+    REQUIRE(timings[0].gpu_time_ms == Catch::Approx(2.0));
+
+    REQUIRE(timings[1].pass_index == 1);
+    REQUIRE(timings[1].valid);
+    REQUIRE(timings[1].gpu_time_ms == Catch::Approx(0.5));
+}
+
+TEST_CASE("resolve_pass_timings marks a bad pair invalid but keeps the slot",
+          "[render][gpu-timestamps]") {
+    // Pass 0 is fine; pass 1 has an unwritten (zero) end slot.
+    std::vector<std::uint64_t> resolved = {
+        1'000, 1'000 + 1'000'000,           // pass 0: 1.0 ms
+        9'000, 0,                           // pass 1: unwritten end
+    };
+    auto timings = resolve_pass_timings(resolved, 2);
+    REQUIRE(timings.size() == 2);
+    REQUIRE(timings[0].valid);
+    REQUIRE(timings[0].gpu_time_ms == Catch::Approx(1.0));
+
+    // The invalid pass is still present at its index — it just carries
+    // no sample, so the inspector can show "unavailable" for that row.
+    REQUIRE_FALSE(timings[1].valid);
+    REQUIRE(timings[1].pass_index == 1);
+    REQUIRE(timings[1].gpu_time_ms == Catch::Approx(0.0));
+}
+
+TEST_CASE("resolve_pass_timings tolerates a truncated readback",
+          "[render][gpu-timestamps]") {
+    // The buffer holds only pass 0; pass 1's timestamps have not landed.
+    std::vector<std::uint64_t> resolved = {
+        1'000, 1'000 + 4'000'000,           // pass 0: 4.0 ms
+    };
+    auto timings = resolve_pass_timings(resolved, 2);
+    REQUIRE(timings.size() == 2);
+    REQUIRE(timings[0].valid);
+    REQUIRE(timings[0].gpu_time_ms == Catch::Approx(4.0));
+    // Missing tail pass: returned, but invalid.
+    REQUIRE_FALSE(timings[1].valid);
+}
+
+TEST_CASE("resolve_pass_timings on an empty buffer returns invalid passes",
+          "[render][gpu-timestamps]") {
+    auto timings = resolve_pass_timings({}, 3);
+    REQUIRE(timings.size() == 3);
+    for (const auto& t : timings) {
+        REQUIRE_FALSE(t.valid);
+    }
+}
+
+TEST_CASE("resolve_pass_timings with zero passes returns an empty vector",
+          "[render][gpu-timestamps]") {
+    auto timings = resolve_pass_timings({1, 2, 3, 4}, 0);
+    REQUIRE(timings.empty());
+}
+
+// ── apply_pass_timings — RenderPassManager integration ──────────────────────
+
+TEST_CASE("apply_pass_timings feeds GPU durations into RenderPassManager",
+          "[render][gpu-timestamps]") {
+    RenderPassManager rpm;
+    rpm.begin_frame();
+    rpm.begin_pass(RenderPassType::background);
+    rpm.end_pass(/*cpu*/ 1.5f, /*draw_calls*/ 4);
+    rpm.begin_pass(RenderPassType::content);
+    rpm.end_pass(/*cpu*/ 3.0f, /*draw_calls*/ 12);
+    rpm.end_frame();
+
+    // Before resolution, no pass carries GPU timing.
+    REQUIRE_FALSE(rpm.has_gpu_timing());
+    for (const auto& p : rpm.passes()) {
+        REQUIRE_FALSE(p.gpu_time_valid);
+    }
+
+    // Synthetic resolved buffer: pass 0 -> 0.8 ms GPU, pass 1 -> 5.2 ms GPU.
+    std::vector<std::uint64_t> resolved = {
+        100, 100 + 800'000,                 // pass 0: 0.8 ms
+        700, 700 + 5'200'000,               // pass 1: 5.2 ms
+    };
+    apply_pass_timings(rpm, resolve_pass_timings(resolved, rpm.passes().size()));
+
+    REQUIRE(rpm.has_gpu_timing());
+    const auto& passes = rpm.passes();
+    REQUIRE(passes.size() == 2);
+
+    // CPU numbers are untouched; GPU numbers are now populated.
+    REQUIRE(passes[0].cpu_time_ms() == Catch::Approx(1.5f));
+    REQUIRE(passes[0].gpu_time_valid);
+    REQUIRE(passes[0].gpu_time_ms == Catch::Approx(0.8f));
+
+    REQUIRE(passes[1].cpu_time_ms() == Catch::Approx(3.0f));
+    REQUIRE(passes[1].gpu_time_valid);
+    REQUIRE(passes[1].gpu_time_ms == Catch::Approx(5.2f));
+}
+
+TEST_CASE("apply_pass_timings skips invalid timings (CPU-only fallback)",
+          "[render][gpu-timestamps]") {
+    RenderPassManager rpm;
+    rpm.begin_frame();
+    rpm.begin_pass(RenderPassType::content);
+    rpm.end_pass(2.0f, 8);
+    rpm.end_frame();
+
+    // The resolved pair is garbage (end < begin) -> invalid timing.
+    std::vector<std::uint64_t> resolved = {9'000'000, 1'000'000};
+    apply_pass_timings(rpm, resolve_pass_timings(resolved, 1));
+
+    // The pass keeps gpu_time_valid == false; the inspector shows CPU
+    // time and an honest "GPU timestamps unavailable" for this pass.
+    REQUIRE_FALSE(rpm.has_gpu_timing());
+    REQUIRE_FALSE(rpm.passes()[0].gpu_time_valid);
+    REQUIRE(rpm.passes()[0].cpu_time_ms() == Catch::Approx(2.0f));
+}
+
+TEST_CASE("set_pass_gpu_time ignores out-of-range pass indices",
+          "[render][gpu-timestamps]") {
+    // Timestamps lag one frame; the pass list may have shrunk since.
+    RenderPassManager rpm;
+    rpm.begin_frame();
+    rpm.begin_pass(RenderPassType::content);
+    rpm.end_pass(1.0f, 1);
+    rpm.end_frame();
+
+    rpm.set_pass_gpu_time(0, 0.5f);   // in range
+    rpm.set_pass_gpu_time(99, 7.0f);  // stale index from a larger frame
+
+    REQUIRE(rpm.passes().size() == 1);
+    REQUIRE(rpm.passes()[0].gpu_time_valid);
+    REQUIRE(rpm.passes()[0].gpu_time_ms == Catch::Approx(0.5f));
+}
+
+TEST_CASE("set_pass_gpu_time rejects a negative duration",
+          "[render][gpu-timestamps]") {
+    RenderPassManager rpm;
+    rpm.begin_frame();
+    rpm.begin_pass(RenderPassType::content);
+    rpm.end_pass(1.0f, 1);
+    rpm.end_frame();
+
+    rpm.set_pass_gpu_time(0, -3.0f);
+    REQUIRE_FALSE(rpm.passes()[0].gpu_time_valid);
+}
+
+// ── GpuTimestampSupport — feature-availability state machine ─────────────────
+
+TEST_CASE("GpuTimestampSupport describe/is_usable cover every state",
+          "[render][gpu-timestamps]") {
+    REQUIRE_FALSE(is_usable(GpuTimestampSupport::unknown));
+    REQUIRE_FALSE(is_usable(GpuTimestampSupport::unsupported));
+    REQUIRE(is_usable(GpuTimestampSupport::supported));
+
+    // The "unsupported" label is the exact string the inspector shows
+    // when the adapter lacks the timestamp-query feature.
+    REQUIRE(std::string(describe(GpuTimestampSupport::unsupported))
+            == "GPU timestamps unavailable");
+    REQUIRE(std::string(describe(GpuTimestampSupport::supported))
+            == "GPU timestamps active");
+    REQUIRE(std::string(describe(GpuTimestampSupport::unknown))
+            == "GPU timestamps: not probed");
+}
+
+// ── GpuTimestamps — graceful degradation when the device is absent ──────────
+
+TEST_CASE("GpuTimestamps degrades gracefully with no device",
+          "[render][gpu-timestamps]") {
+    // initialize(nullptr) must never crash — it reports unsupported and
+    // every subsequent call is a safe no-op. This is also the exact
+    // behavior of the CPU-only build (no Dawn linked at all).
+    GpuTimestamps ts;
+    REQUIRE(ts.support() == GpuTimestampSupport::unknown);
+
+    const bool ok = ts.initialize(nullptr);
+    REQUIRE_FALSE(ok);
+    REQUIRE(ts.support() == GpuTimestampSupport::unsupported);
+    REQUIRE_FALSE(ts.available());
+
+    // No-ops, no crash.
+    ts.begin_frame(4);
+    REQUIRE(ts.read_back().empty());
+}
+
+TEST_CASE("kTimestampsPerPass is two (begin + end)",
+          "[render][gpu-timestamps]") {
+    REQUIRE(kTimestampsPerPass == 2);
+}


### PR DESCRIPTION
Inspector Phase 6.5. Phase 6.1 surfaces per-pass CPU wall-time around
draw submission; this adds the real GPU clock so the inspector perf
view can show CPU vs GPU side by side. The gap between the two is
exactly where overdraw / expensive-shader perf bugs hide.

- PassStats gains gpu_time_ms + gpu_time_valid; time_ms keeps its
  CPU-time meaning (overlay back-compat) and cpu_time_ms() aliases it.
- RenderPassManager.set_pass_gpu_time() feeds resolved durations back
  in (out-of-range/negative inputs ignored — timestamps lag one frame
  so the pass list may have changed); has_gpu_timing() reports whether
  any pass carries a real sample.
- New gpu_timestamps.hpp: Dawn-free tick->ms resolution math
  (timestamp_pair_to_ms, resolve_pass_timings, apply_pass_timings) plus
  the GpuTimestampSupport state machine — fully unit-testable without a
  device by feeding synthetic resolved-buffer values.
- gpu_timestamps.cpp: Dawn QuerySet(QueryType::Timestamp) +
  resolve/readback buffers behind PULP_HAS_SKIA (the guard the other
  wgpu::-typed render code uses); gates on the timestamp-query feature
  and degrades to a safe no-op stub (support() == unsupported) when the
  adapter lacks it or in a CPU-only build.
- Performance.getMetrics now emits cpu_time_ms / gpu_time_ms /
  gpu_time_valid per pass and a frame-level gpu_timing_available flag.

Tests: test_gpu_timestamps.cpp, 17 Catch2 cases — ns conversion,
zero/backwards/truncated resolved buffers, RenderPassManager
integration, and the feature-absent fallback. All pass. Live-device
QuerySet resolution is deferred to CI's GPU matrix; the inspector
overlay wiring is left for a later phase (inspector_overlay.cpp has
in-flight PRs) — the data is exposed via the perf protocol surface.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>