### PR TITLE
test(coverage): cover phase3 runtime audio edges

### DIFF
--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -8,6 +8,7 @@
 #include <numbers>
 #include <thread>
 #include <chrono>
+#include <utility>
 
 using namespace pulp::audio;
 
@@ -369,6 +370,33 @@ TEST_CASE("BufferView clear only zeros sliced sample range",
     REQUIRE(buffer.channel(1)[3] == 0.0f);
     REQUIRE(buffer.channel(1)[4] == 0.0f);
     REQUIRE(buffer.channel(1)[5] == 15.0f);
+}
+
+TEST_CASE("Buffer self assignment preserves storage and channel pointers",
+          "[audio][buffer][coverage][phase3]") {
+    Buffer<float> buffer(2, 3);
+    buffer.channel(0)[1] = 0.125f;
+    buffer.channel(1)[2] = -0.25f;
+    auto* left = buffer.channel(0).data();
+    auto* right = buffer.channel(1).data();
+
+    auto& copy_ref = buffer;
+    buffer = copy_ref;
+    REQUIRE(buffer.num_channels() == 2);
+    REQUIRE(buffer.num_samples() == 3);
+    REQUIRE(buffer.channel(0)[1] == 0.125f);
+    REQUIRE(buffer.channel(1)[2] == -0.25f);
+    REQUIRE(buffer.view().channel_ptr(0) == left);
+    REQUIRE(buffer.view().channel_ptr(1) == right);
+
+    auto& move_ref = buffer;
+    buffer = std::move(move_ref);
+    REQUIRE(buffer.num_channels() == 2);
+    REQUIRE(buffer.num_samples() == 3);
+    REQUIRE(buffer.channel(0)[1] == 0.125f);
+    REQUIRE(buffer.channel(1)[2] == -0.25f);
+    REQUIRE(buffer.view().channel_ptr(0) == left);
+    REQUIRE(buffer.view().channel_ptr(1) == right);
 }
 
 TEST_CASE("AudioFileData reports shape from first channel",

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -425,6 +425,55 @@ TEST_CASE("Device metadata defaults and custom configs are stable",
     REQUIRE(config.output_channels == 6);
 }
 
+TEST_CASE("AudioSystem default device-change callback is snapshot safe",
+          "[audio][device][coverage][phase3]") {
+    class DummyAudioSystem final : public AudioSystem {
+    public:
+        std::vector<DeviceInfo> enumerate_devices() override { return {}; }
+        std::unique_ptr<AudioDevice> create_device(const std::string& = "") override {
+            return {};
+        }
+        DeviceInfo default_output_device() override { return {}; }
+        DeviceInfo default_input_device() override { return {}; }
+    };
+
+    DummyAudioSystem system;
+    int calls = 0;
+
+    REQUIRE_FALSE(system.has_device_change_callback());
+    system.fire_device_change();
+    REQUIRE(calls == 0);
+
+    system.set_device_change_callback([&] {
+        ++calls;
+        system.set_device_change_callback(nullptr);
+    });
+    REQUIRE(system.has_device_change_callback());
+
+    system.fire_device_change();
+    REQUIRE(calls == 1);
+    REQUIRE_FALSE(system.has_device_change_callback());
+
+    system.fire_device_change();
+    REQUIRE(calls == 1);
+
+    system.set_device_change_callback([&] {
+        ++calls;
+        system.set_device_change_callback([&] { calls += 10; });
+    });
+    REQUIRE(system.has_device_change_callback());
+
+    system.fire_device_change();
+    REQUIRE(calls == 2);
+    REQUIRE(system.has_device_change_callback());
+
+    system.fire_device_change();
+    REQUIRE(calls == 12);
+
+    system.set_device_change_callback(nullptr);
+    REQUIRE_FALSE(system.has_device_change_callback());
+}
+
 TEST_CASE("AudioProcessLoadMeasurer ignores invalid callback geometry",
           "[audio][load][coverage][phase3]") {
     AudioProcessLoadMeasurer measurer;

--- a/test/test_audio_focus.cpp
+++ b/test/test_audio_focus.cpp
@@ -120,6 +120,22 @@ TEST_CASE("AudioFocusRegistry: move assignment replaces an existing subscription
     REQUIRE(second_count == 1);
 }
 
+TEST_CASE("AudioFocusRegistry: token self move assignment preserves subscription",
+          "[audio][focus][coverage][phase3]") {
+    AudioFocusRegistry::instance().reset_for_test();
+    int count = 0;
+    auto token = AudioFocusRegistry::instance().subscribe(
+        [&](AudioFocusState) { ++count; });
+    const int id = token.id();
+
+    auto& ref = token;
+    token = std::move(ref);
+    REQUIRE(token.id() == id);
+
+    AudioFocusRegistry::instance().publish(AudioFocusState::duck);
+    REQUIRE(count == 1);
+}
+
 TEST_CASE("AudioFocusRegistry: default token reset is a no-op",
           "[audio][focus][issue-640]") {
     AudioFocusRegistry::Token token;

--- a/test/test_child_process.cpp
+++ b/test/test_child_process.cpp
@@ -358,3 +358,83 @@ TEST_CASE("wait preserves output after is_running observes fast exit",
     REQUIRE(r.stdout_output == "cached");
 #endif
 }
+
+#ifndef _WIN32
+TEST_CASE("ChildProcess destructor cancels a still-running POSIX child",
+          "[child_process][edge][coverage][phase3]") {
+    {
+        ChildProcess cp;
+        REQUIRE(cp.start("sleep", {"10"}));
+        REQUIRE(cp.is_running());
+    }
+
+    SUCCEED("scope exit returned after cancelling the child");
+}
+
+TEST_CASE("ChildProcess move construction transfers a running POSIX child",
+          "[child_process][edge][coverage][phase3]") {
+    ChildProcess source;
+    REQUIRE(source.start("/bin/sh", {"-c", "printf moved"}));
+
+    ChildProcess moved(std::move(source));
+    auto result = moved.wait();
+
+    REQUIRE(result.exit_code == 0);
+    REQUIRE(result.stdout_output == "moved");
+}
+
+TEST_CASE("ChildProcess move assignment transfers a running POSIX child",
+          "[child_process][edge][coverage][phase3]") {
+    ChildProcess source;
+    REQUIRE(source.start("/bin/sh", {"-c", "printf assigned; exit 6"}));
+
+    ChildProcess assigned;
+    assigned = std::move(source);
+    auto result = assigned.wait();
+
+    REQUIRE(result.exit_code == 6);
+    REQUIRE(result.stdout_output == "assigned");
+}
+
+TEST_CASE("cancel escalates when a POSIX child ignores SIGTERM",
+          "[child_process][edge][coverage][phase3]") {
+    ChildProcess cp;
+    REQUIRE(cp.start(
+        "/bin/sh",
+        {"-c", "trap '' TERM; printf ready; while :; do sleep 1; done"}));
+
+    std::string observed;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (observed.find("ready") == std::string::npos
+           && std::chrono::steady_clock::now() < deadline) {
+        observed += cp.read_available_output();
+        if (observed.find("ready") == std::string::npos) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    REQUIRE(observed == "ready");
+    REQUIRE(cp.is_running());
+
+    cp.cancel();
+    auto result = cp.wait();
+
+    REQUIRE(result.was_cancelled);
+    REQUIRE(result.exit_code == -1);
+}
+
+TEST_CASE("timeout escalates when a POSIX child ignores SIGTERM",
+          "[child_process][edge][coverage][phase3]") {
+    ProcessOptions opts;
+    opts.timeout_ms = 100;
+
+    auto result = ChildProcess::run(
+        "/bin/sh",
+        {"-c", "trap '' TERM; printf before-timeout; while :; do sleep 1; done"},
+        opts);
+
+    REQUIRE(result.timed_out);
+    REQUIRE(result.exit_code == -1);
+    REQUIRE(result.stdout_output.find("before-timeout") != std::string::npos);
+}
+#endif

--- a/test/test_dsp_expansion.cpp
+++ b/test/test_dsp_expansion.cpp
@@ -156,6 +156,29 @@ TEST_CASE("Oscillator waveforms produce finite bounded startup samples",
     }
 }
 
+TEST_CASE("Oscillator polyBLEP handles late-cycle discontinuities",
+          "[signal][oscillator][coverage][phase3]") {
+    Oscillator osc;
+    osc.set_sample_rate(10.0f);
+    osc.set_frequency(3.0f);
+
+    for (auto waveform : {
+             Oscillator::Waveform::saw,
+             Oscillator::Waveform::square,
+             Oscillator::Waveform::triangle,
+         }) {
+        osc.reset();
+        osc.set_waveform(waveform);
+        float last = 0.0f;
+        for (int i = 0; i < 5; ++i)
+            last = osc.next();
+
+        REQUIRE(std::isfinite(last));
+        REQUIRE(osc.phase() >= 0.0f);
+        REQUIRE(osc.phase() < 1.0f);
+    }
+}
+
 // ── FirFilter ────────────────────────────────────────────────────────────
 
 TEST_CASE("FirFilter identity with single-tap", "[signal][fir]") {
@@ -423,6 +446,30 @@ TEST_CASE("SmoothedValue supports double ramps and terminal skips",
     REQUIRE_THAT(value.target(), WithinAbs(10.0, 1e-12));
 }
 
+TEST_CASE("SmoothedValue handles immediate ramps and inert skips",
+          "[signal][smooth][coverage][phase3]") {
+    SmoothedValue<float> immediate(1.0f);
+    immediate.set_ramp_time(0.0f, 48000.0f);
+    immediate.set_target(4.0f);
+    REQUIRE_FALSE(immediate.is_smoothing());
+    REQUIRE_THAT(immediate.current(), WithinAbs(4.0f, 1e-6f));
+    REQUIRE_THAT(immediate.next(), WithinAbs(4.0f, 1e-6f));
+
+    SmoothedValue<float> ramp(0.0f);
+    ramp.set_ramp_time(0.004f, 1000.0f);
+    ramp.set_target(8.0f);
+    ramp.skip(0);
+    ramp.skip(-8);
+    REQUIRE(ramp.is_smoothing());
+    REQUIRE_THAT(ramp.current(), WithinAbs(0.0f, 1e-6f));
+
+    ramp.skip(4);
+    REQUIRE_FALSE(ramp.is_smoothing());
+    REQUIRE_THAT(ramp.current(), WithinAbs(8.0f, 1e-6f));
+    ramp.skip(1);
+    REQUIRE_THAT(ramp.current(), WithinAbs(8.0f, 1e-6f));
+}
+
 TEST_CASE("LogRampedValue jumps for non-positive endpoints",
           "[signal][log_ramp][issue-645]") {
     LogRampedValue zero_start;
@@ -506,6 +553,15 @@ TEST_CASE("WaveShaper processes buffers in-place", "[signal][waveshaper][issue-6
     REQUIRE_THAT(buffer[1], WithinAbs(0.0f, 1e-6f));
     REQUIRE_THAT(buffer[2], WithinAbs(0.75f, 1e-6f));
     REQUIRE_THAT(buffer[3], WithinAbs(1.0f, 1e-6f));
+}
+
+TEST_CASE("WaveShaper invalid curve falls back to driven input",
+          "[signal][waveshaper][coverage][phase3]") {
+    WaveShaper shaper;
+    shaper.set_drive(1.5f);
+    shaper.set_curve(static_cast<WaveShaper::Curve>(99));
+
+    REQUIRE_THAT(shaper.process(0.25f), WithinAbs(0.375f, 1e-6f));
 }
 
 // ── ProcessorChain ───────────────────────────────────────────────────────
@@ -823,6 +879,28 @@ TEST_CASE("FrequencyAxis maps linear logarithmic and mel scales",
     REQUIRE(axis.display_to_bin(mel_pos) == axis.hz_to_bin(1000.0f));
 }
 
+TEST_CASE("Spectrogram helpers cover fallback ramps scales and zero-bin columns",
+          "[signal][spectrogram][coverage][phase3]") {
+    ColorMapper mapper(static_cast<ColorRamp>(99));
+    auto gray = mapper.map(0.5f);
+    REQUIRE(gray.r == gray.g);
+    REQUIRE(gray.g == gray.b);
+    REQUIRE(gray.a == 255);
+
+    FrequencyAxis axis;
+    axis.configure(1024, 48000.0f, static_cast<FrequencyScale>(99));
+    REQUIRE_THAT(axis.hz_to_display(12000.0f), WithinAbs(0.5f, 1e-5f));
+    REQUIRE_THAT(axis.display_to_hz(0.5f), WithinAbs(12000.0f, 1e-5f));
+
+    SpectrogramBuffer buffer;
+    buffer.configure(2, 1);
+    const float fallback_bin[] = {-40.0f};
+    buffer.push_column(fallback_bin, 0, mapper, -80.0f, 0.0f);
+    REQUIRE(buffer.frames_written() == 1);
+    REQUIRE(buffer.write_column() == 1);
+    REQUIRE(buffer.pixels()[0].a == 255);
+}
+
 TEST_CASE("SpectrogramBuffer scrolls columns and maps dB ranges",
           "[signal][spectrogram][codecov]") {
     SpectrogramBuffer buffer;
@@ -949,6 +1027,36 @@ TEST_CASE("AlignedBuffer resize to same size preserves allocation contents",
     REQUIRE(buffer.data() == before);
     REQUIRE_THAT(buffer[0], WithinAbs(0.25f, 1e-6f));
     REQUIRE_THAT(buffer[1], WithinAbs(-0.5f, 1e-6f));
+}
+
+TEST_CASE("AlignedBuffer exposes const iteration and self move assignment",
+          "[signal][simd][coverage][phase3]") {
+    AlignedBuffer empty;
+    empty.clear();
+    REQUIRE(empty.empty());
+
+    AlignedBuffer buffer(3);
+    buffer[0] = 1.0f;
+    buffer[1] = 2.0f;
+    buffer[2] = 3.0f;
+
+    auto& alias = buffer;
+    buffer = std::move(alias);
+    REQUIRE(buffer.size() == 3);
+
+    float sum = 0.0f;
+    for (float& value : buffer)
+        sum += value;
+    REQUIRE_THAT(sum, WithinAbs(6.0f, 1e-6f));
+
+    const AlignedBuffer& const_buffer = buffer;
+    REQUIRE(const_buffer.data() == buffer.data());
+    REQUIRE_THAT(const_buffer[1], WithinAbs(2.0f, 1e-6f));
+
+    float const_sum = 0.0f;
+    for (const float value : const_buffer)
+        const_sum += value;
+    REQUIRE_THAT(const_sum, WithinAbs(6.0f, 1e-6f));
 }
 
 TEST_CASE("Interpolator kernels hit exact endpoints and smooth midpoints",

--- a/test/test_midi.cpp
+++ b/test/test_midi.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 
 using namespace pulp::midi;
 using Catch::Approx;
@@ -40,6 +41,30 @@ void require_bytes(const MidiEvent& event,
     REQUIRE(event.data()[1] == data1);
     REQUIRE(event.data()[2] == data2);
 }
+
+struct DefaultHookInput final : MidiInput {
+    bool open(const std::string&, MidiInputCallback) override { return true; }
+    void close() override {}
+    bool is_open() const override { return false; }
+};
+
+struct DefaultHookOutput final : MidiOutput {
+    bool open(const std::string&) override { return true; }
+    void close() override {}
+    bool is_open() const override { return false; }
+    void send(const MidiEvent&) override {}
+};
+
+struct DefaultHookSystem final : MidiSystem {
+    std::vector<MidiPortInfo> enumerate_inputs() override { return {}; }
+    std::vector<MidiPortInfo> enumerate_outputs() override { return {}; }
+    std::unique_ptr<MidiInput> create_input() override {
+        return std::make_unique<DefaultHookInput>();
+    }
+    std::unique_ptr<MidiOutput> create_output() override {
+        return std::make_unique<DefaultHookOutput>();
+    }
+};
 
 } // namespace
 
@@ -91,6 +116,36 @@ TEST_CASE("MidiEvent factory methods", "[midi][message]") {
         REQUIRE(evt.is_program_change());
         REQUIRE(evt.channel() == 3);
         require_bytes(evt, 0xC3, 42, 0);
+    }
+}
+
+TEST_CASE("MIDI device interface default hooks are safe no-ops",
+          "[midi][device][coverage][phase3]") {
+    {
+        std::unique_ptr<MidiInput> input = std::make_unique<DefaultHookInput>();
+        bool called = false;
+        input->set_sysex_callback([&](const std::vector<uint8_t>&, double) {
+            called = true;
+        });
+        REQUIRE_FALSE(called);
+    }
+
+    {
+        std::unique_ptr<MidiOutput> output = std::make_unique<DefaultHookOutput>();
+        REQUIRE(output->open("virtual"));
+        output->send(MidiEvent::note_on(0, 60, 100));
+        output->close();
+    }
+
+    {
+        std::unique_ptr<MidiSystem> system = std::make_unique<DefaultHookSystem>();
+        bool called = false;
+        system->set_port_change_callback([&] { called = true; });
+        REQUIRE_FALSE(called);
+        REQUIRE(system->enumerate_inputs().empty());
+        REQUIRE(system->enumerate_outputs().empty());
+        REQUIRE(system->create_input() != nullptr);
+        REQUIRE(system->create_output() != nullptr);
     }
 }
 

--- a/test/test_midi_expansion.cpp
+++ b/test/test_midi_expansion.cpp
@@ -283,6 +283,21 @@ TEST_CASE("MidiKeyboardState note on vel=0 is note off", "[midi][keyboard]") {
     REQUIRE_FALSE(keys.is_note_on(0, 64));
 }
 
+TEST_CASE("MidiKeyboardState note on velocity zero fires note-off callback",
+          "[midi][keyboard][coverage][phase3]") {
+    MidiKeyboardState keys;
+    std::vector<int> released;
+    keys.on_note_off = [&](uint8_t channel, uint8_t note) {
+        released.push_back(static_cast<int>(channel) * 128 + static_cast<int>(note));
+    };
+
+    keys.process(MidiEvent::note_on(2, 67, 96));
+    keys.process(MidiEvent::note_on(2, 67, 0));
+
+    REQUIRE_FALSE(keys.is_note_on(2, 67));
+    REQUIRE(released == std::vector<int>{323});
+}
+
 TEST_CASE("MidiKeyboardState notes_held count", "[midi][keyboard]") {
     MidiKeyboardState keys;
     REQUIRE(keys.notes_held(0) == 0);

--- a/test/test_mpe_buffer.cpp
+++ b/test/test_mpe_buffer.cpp
@@ -59,15 +59,18 @@ TEST_CASE("MpeBuffer records expression events from tracker", "[midi][mpe]") {
 
 TEST_CASE("MpeBuffer clear and sort", "[midi][mpe]") {
     MpeBuffer buffer;
+    MpeExpressionEvent first{40, Kind::Timbre, {}};
+    buffer.add(first);
     buffer.add({30, Kind::Pressure, {}});
     buffer.add({10, Kind::NoteOn, {}});
     buffer.add({20, Kind::PitchBend, {}});
-    REQUIRE(buffer.size() == 3);
+    REQUIRE(buffer.size() == 4);
 
     buffer.sort();
     REQUIRE(buffer[0].sample_offset == 10);
     REQUIRE(buffer[1].sample_offset == 20);
     REQUIRE(buffer[2].sample_offset == 30);
+    REQUIRE(buffer[3].sample_offset == 40);
 
     buffer.clear();
     REQUIRE(buffer.empty());

--- a/test/test_running_status.cpp
+++ b/test/test_running_status.cpp
@@ -90,6 +90,30 @@ TEST_CASE("program change has a single data byte",
     REQUIRE(v[1].d1 == 0x07);
 }
 
+TEST_CASE("running status repeats control-change and pitch-bend messages",
+          "[midi][running-status][coverage][phase3]") {
+    auto v = parse({
+        0xB4, 0x40, 0x7F,  // sustain pedal on channel 4
+        0x41, 0x00,        // running CC
+        0xE5, 0x00, 0x40,  // pitch bend center on channel 5
+        0x7F, 0x7F,        // running pitch bend maximum
+    });
+
+    REQUIRE(v.size() == 4);
+    REQUIRE(v[0].status == 0xB4);
+    REQUIRE(v[0].d1 == 0x40);
+    REQUIRE(v[0].d2 == 0x7F);
+    REQUIRE(v[1].status == 0xB4);
+    REQUIRE(v[1].d1 == 0x41);
+    REQUIRE(v[1].d2 == 0x00);
+    REQUIRE(v[2].status == 0xE5);
+    REQUIRE(v[2].d1 == 0x00);
+    REQUIRE(v[2].d2 == 0x40);
+    REQUIRE(v[3].status == 0xE5);
+    REQUIRE(v[3].d1 == 0x7F);
+    REQUIRE(v[3].d2 == 0x7F);
+}
+
 TEST_CASE("running status handles one and two byte channel messages",
           "[midi][running-status][issue-645]") {
     auto v = parse({
@@ -207,6 +231,21 @@ TEST_CASE("real-time clock interleaves without breaking running status",
     REQUIRE(v[1].status == 0xF8);  // clock, single-byte
     REQUIRE(v[2].status == 0x90);
     REQUIRE(v[2].d1 == 0x3D);
+}
+
+TEST_CASE("all realtime status bytes emit immediately",
+          "[midi][running-status][coverage][phase3]") {
+    auto v = parse({0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF});
+
+    REQUIRE(v.size() == 8);
+    REQUIRE(v[0].status == 0xF8);
+    REQUIRE(v[1].status == 0xF9);
+    REQUIRE(v[2].status == 0xFA);
+    REQUIRE(v[3].status == 0xFB);
+    REQUIRE(v[4].status == 0xFC);
+    REQUIRE(v[5].status == 0xFD);
+    REQUIRE(v[6].status == 0xFE);
+    REQUIRE(v[7].status == 0xFF);
 }
 
 TEST_CASE("sysex is delivered separately; cancels running status",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -653,6 +653,27 @@ TEST_CASE("InterProcessLock competing instance waits for release",
     REQUIRE(second.is_locked());
 }
 
+TEST_CASE("InterProcessLock reports open failure for missing parent paths",
+          "[runtime][ipc_lock][coverage][phase3]") {
+    TemporaryFile marker(".lock-parent");
+    const auto unique = marker.path().filename().string();
+    marker.release();
+    std::filesystem::remove(marker.path());
+
+    const auto lock_parent =
+        std::filesystem::temp_directory_path() / ("pulp_lock_" + unique);
+    std::filesystem::remove_all(lock_parent);
+    auto cleanup = make_scope_guard([&] {
+        std::filesystem::remove_all(lock_parent);
+    });
+
+    InterProcessLock lock(unique + "/sublock");
+    REQUIRE_FALSE(lock.try_lock());
+    REQUIRE_FALSE(lock.is_locked());
+    lock.unlock();
+    REQUIRE_FALSE(lock.is_locked());
+}
+
 // ── ChildProcess ────────────────────────────────────────────────────────
 
 TEST_CASE("run_process captures stdout", "[runtime][child_process]") {
@@ -1273,9 +1294,22 @@ TEST_CASE("HTTP helpers accept case-insensitive URL schemes during parsing",
     REQUIRE(response.error != "Invalid URL");
 }
 
+TEST_CASE("HTTP helpers report POST transport failures",
+          "[runtime][http][url][coverage][phase3]") {
+    const auto response = http_post("http://127.0.0.1:1/closed",
+                                    "body",
+                                    "text/plain",
+                                    1);
+    REQUIRE(response.status_code == 0);
+    REQUIRE(response.error.find("Connection failed:") == 0);
+}
+
 TEST_CASE("HTTP helpers round-trip against a loopback server",
           "[runtime][http][url][coverage][phase3]") {
     httplib::Server server;
+    server.Get("/", [](const httplib::Request&, httplib::Response& response) {
+        response.set_content("root", "text/plain");
+    });
     server.Get("/hello", [](const httplib::Request& request, httplib::Response& response) {
         response.set_header("X-Pulp-Test",
                             request.has_param("name") ? request.get_param_value("name") : "missing");
@@ -1317,6 +1351,10 @@ TEST_CASE("HTTP helpers round-trip against a loopback server",
     REQUIRE(get_response.body == "hello");
     REQUIRE(get_response.headers.at("X-Pulp-Test") == "agent");
 
+    const auto root_response = http_get(base, 2);
+    REQUIRE(root_response.ok());
+    REQUIRE(root_response.body == "root");
+
     const auto post_response = http_post(base + "/echo", "body=42", "text/custom", 2);
     REQUIRE(post_response.ok());
     REQUIRE(post_response.body == "body=42");
@@ -1327,6 +1365,16 @@ TEST_CASE("HTTP helpers round-trip against a loopback server",
     std::ifstream file(downloaded.path(), std::ios::binary);
     std::string bytes((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     REQUIRE(bytes == std::string("payload\0bytes", 13));
+
+    TemporaryFile blocked_output(".download-dir");
+    const auto blocked_path = blocked_output.path();
+    blocked_output.release();
+    std::filesystem::remove(blocked_path);
+    std::filesystem::create_directory(blocked_path);
+    auto cleanup_blocked_output = make_scope_guard([&] {
+        std::filesystem::remove_all(blocked_path);
+    });
+    REQUIRE_FALSE(http_download(base + "/download", blocked_path.string(), 2));
 }
 
 TEST_CASE("local IPv4 helpers return usable fallback values",

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -474,6 +474,26 @@ TEST_CASE("MemoryMappedFile self move assignment preserves mapping",
     REQUIRE(std::string(reinterpret_cast<const char*>(mmap.data()), mmap.size()) == "self-move");
 }
 
+#ifndef _WIN32
+TEST_CASE("MemoryMappedFile rejects directory paths after opening",
+          "[runtime][mmap][coverage][phase3]") {
+    TemporaryFile marker(".dir");
+    const auto dir = marker.path();
+    marker.release();
+    std::filesystem::remove(dir);
+    std::filesystem::create_directory(dir);
+    auto cleanup = make_scope_guard([&] {
+        std::filesystem::remove_all(dir);
+    });
+
+    MemoryMappedFile mmap;
+    REQUIRE_FALSE(mmap.open(dir.string()));
+    REQUIRE_FALSE(mmap.is_open());
+    REQUIRE(mmap.data() == nullptr);
+    REQUIRE(mmap.size() == 0);
+}
+#endif
+
 // ── DynamicLibrary ──────────────────────────────────────────────────────
 
 TEST_CASE("DynamicLibrary loads system library", "[runtime][dynlib]") {

--- a/test/test_runtime_utils.cpp
+++ b/test/test_runtime_utils.cpp
@@ -225,6 +225,20 @@ TEST_CASE("TemporaryFile normalizes extensions without leading dots",
     REQUIRE(std::filesystem::exists(tmp.path()));
 }
 
+TEST_CASE("TemporaryFile supports extensionless paths",
+          "[runtime][temp_file][coverage][phase3]") {
+    std::filesystem::path path;
+    {
+        TemporaryFile tmp;
+        path = tmp.path();
+        REQUIRE(path.extension().empty());
+        REQUIRE(tmp.path_string() == path.string());
+        REQUIRE(std::filesystem::exists(path));
+    }
+
+    REQUIRE_FALSE(std::filesystem::exists(path));
+}
+
 TEST_CASE("TemporaryFile move assignment removes the previous active file",
           "[runtime][temp_file][issue-641]") {
     std::filesystem::path old_path;
@@ -1302,6 +1316,48 @@ TEST_CASE("HTTP helpers report POST transport failures",
                                     1);
     REQUIRE(response.status_code == 0);
     REQUIRE(response.error.find("Connection failed:") == 0);
+}
+
+TEST_CASE("HTTP helpers expose error responses without downloading bodies",
+          "[runtime][http][url][coverage][phase3]") {
+    httplib::Server server;
+    server.Get("/missing", [](const httplib::Request&, httplib::Response& response) {
+        response.status = 404;
+        response.set_content("missing", "text/plain");
+    });
+
+    const int port = server.bind_to_any_port("127.0.0.1");
+    REQUIRE(port > 0);
+
+    std::thread thread([&] { server.listen_after_bind(); });
+    auto stop_server = make_scope_guard([&] {
+        server.stop();
+        if (thread.joinable())
+            thread.join();
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!server.is_running() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    REQUIRE(server.is_running());
+
+    const auto base = std::string("http://127.0.0.1:") + std::to_string(port);
+    const auto response = http_get(base + "/missing", 2);
+    REQUIRE(response.status_code == 404);
+    REQUIRE_FALSE(response.ok());
+    REQUIRE(response.body == "missing");
+
+    TemporaryFile output(".bin");
+    {
+        std::ofstream file(output.path(), std::ios::binary);
+        file << "untouched";
+    }
+
+    REQUIRE_FALSE(http_download(base + "/missing", output.path_string(), 2));
+    std::ifstream file(output.path(), std::ios::binary);
+    std::string bytes((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    REQUIRE(bytes == "untouched");
 }
 
 TEST_CASE("HTTP helpers round-trip against a loopback server",

--- a/test/test_signal_meter.cpp
+++ b/test/test_signal_meter.cpp
@@ -207,6 +207,34 @@ TEST_CASE("MultiChannelBallistics holds peaks and clip indicators", "[signal][me
     REQUIRE_FALSE(ballistics.channels[0].clip_indicator);
 }
 
+TEST_CASE("MultiChannelBallistics clamps tiny levels and releases held peaks",
+          "[signal][meter][coverage][phase3]") {
+    MultiChannelBallistics ballistics;
+    ballistics.peak_hold_time = 0.01f;
+
+    MultiChannelMeterData data;
+    data.num_channels = 1;
+    data.channels[0].peak = 0.75f;
+    data.channels[0].rms = 0.25f;
+    ballistics.update(data, 0.001f);
+    REQUIRE_THAT(ballistics.channels[0].held_peak, WithinAbs(0.75f, 1e-6f));
+
+    data.channels[0].peak = 0.0f;
+    data.channels[0].rms = 0.0f;
+    ballistics.update(data, 0.25f);
+    REQUIRE_FALSE(ballistics.channels[0].clip_indicator);
+    REQUIRE(ballistics.channels[0].held_peak < 0.75f);
+
+    MultiChannelBallistics floor;
+    MultiChannelMeterData tiny;
+    tiny.num_channels = 1;
+    tiny.channels[0].peak = 1e-8f;
+    tiny.channels[0].rms = 1e-8f;
+    floor.update(tiny, 1.0f);
+    REQUIRE_THAT(floor.channels[0].display_peak, WithinAbs(0.0f, 1e-9f));
+    REQUIRE_THAT(floor.channels[0].display_rms, WithinAbs(0.0f, 1e-9f));
+}
+
 TEST_CASE("MultiChannelBallistics clamps invalid snapshot channel counts",
           "[signal][meter][issue-645]") {
     MultiChannelBallistics ballistics;

--- a/test/test_signal_spectral.cpp
+++ b/test/test_signal_spectral.cpp
@@ -166,6 +166,24 @@ TEST_CASE("FFT move preserves transform state", "[signal][fft][issue-645]") {
     }
 }
 
+TEST_CASE("FFT move assignment replaces an existing transform",
+          "[signal][fft][coverage][phase3]") {
+    Fft source(8);
+    Fft destination(16);
+
+    destination = std::move(source);
+    REQUIRE(source.size() == 0);
+    REQUIRE(destination.size() == 8);
+
+    auto& alias = destination;
+    destination = std::move(alias);
+    REQUIRE(destination.size() == 8);
+
+    std::vector<std::complex<float>> data(8, {1.0f, 0.0f});
+    destination.forward(data.data());
+    REQUIRE_THAT(data[0].real(), WithinAbs(8.0f, 1e-4f));
+}
+
 TEST_CASE("FFT magnitude helpers handle silence and complex bins", "[signal][fft][issue-645]") {
     Fft fft(8);
     std::vector<std::complex<float>> freq = {

--- a/test/test_ump_buffer_conversion.cpp
+++ b/test/test_ump_buffer_conversion.cpp
@@ -11,13 +11,16 @@ using Catch::Approx;
 
 TEST_CASE("UmpBuffer sort + clear", "[midi][ump]") {
     UmpBuffer buf;
+    UmpEvent first{UmpPacket::note_on_2(0, 0, 59, 0x8000), 40};
+    buf.add(first);
     buf.add(UmpPacket::note_on_2(0, 0, 60, 0x8000), 30);
     buf.add(UmpPacket::note_on_2(0, 0, 62, 0x8000), 10);
     buf.add(UmpPacket::note_on_2(0, 0, 64, 0x8000), 20);
-    REQUIRE(buf.size() == 3);
+    REQUIRE(buf.size() == 4);
     buf.sort();
     REQUIRE(buf[0].sample_offset == 10);
     REQUIRE(buf[2].sample_offset == 30);
+    REQUIRE(buf[3].sample_offset == 40);
     buf.clear();
     REQUIRE(buf.empty());
 }

--- a/tools/scripts/source_tree_pollution_check.py
+++ b/tools/scripts/source_tree_pollution_check.py
@@ -102,6 +102,7 @@ ALLOWED_ROOT_PATHS = frozenset({
     "apple",
     "bindings",
     "ci",
+    "compat",
     "core",
     "docs",
     "examples",

--- a/tools/scripts/test_source_tree_pollution_check.py
+++ b/tools/scripts/test_source_tree_pollution_check.py
@@ -211,6 +211,15 @@ class RootAllowlistTests(unittest.TestCase):
         result = self._run_root_allowlist()
         self.assertEqual(result.returncode, 0, msg=result.stderr)
 
+    def test_compat_root_directory_is_allowlisted(self) -> None:
+        self._commit_allowlisted_only()
+        Path("compat").mkdir()
+        Path("compat/README.md").write_text("# compat\n")
+        subprocess.run(["git", "add", "compat"], check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "add compat"], check=True)
+        result = self._run_root_allowlist()
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
     def test_stray_top_level_file_blocks(self) -> None:
         self._commit_allowlisted_only()
         Path("screenshot.png").write_bytes(b"\x89PNG")


### PR DESCRIPTION
## Summary
- Adds 24 focused Phase 3 coverage tests across platform child-process, MIDI, runtime, signal, and audio helpers.
- Covers deterministic edge paths for mmap, temporary files, IPC locks, HTTP failures, DSP helpers, FFT/meter behavior, device callback plumbing, and buffer/audio-focus move edges.
- Updates the Phase 3 coverage compliance ledger for this batch.

## Local Validation
- Targeted coverage build: build-coverage with GPU/examples off.
- Direct focused runs: pulp-test-child-process, MIDI targets, pulp-test-runtime-utils, pulp-test-dsp-expansion, pulp-test-signal-spectral, pulp-test-signal-meter, pulp-test-audio-focus, pulp-test-audio.
- Focused llvm-cov reports for touched surfaces.
- yamllint --no-warnings -d relaxed .github/workflows/
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/scripts/skill_sync_check.py --mode=report --base github/main
- python3 tools/scripts/version_bump_check.py --mode=report --base github/main
- git diff --check

Note: local Shipyard mac validation failed before build because this temp worktree lacks Skia and the default Shipyard configure builds examples with GPU enabled. GitHub CI should use the current workflow Skia fetch path.