### PR TITLE
fix(inspect): guard source jumps in headless runs

### DIFF
--- a/.agents/skills/threejs-bridge/SKILL.md
+++ b/.agents/skills/threejs-bridge/SKILL.md
@@ -144,6 +144,10 @@ Do not rerun broad unrelated suites when a focused bridge/demo tag is enough.
 ```
 
 Use screenshots to confirm the result is visibly truthful, not just test-green.
+Capture mode is also the CI/headless smoke path: `--capture` sets
+`WindowOptions::initially_hidden=true` and exits before `run_event_loop()`.
+Keep future capture changes on that hidden path; do not add `show()` or
+focus-stealing activation before the screenshot is written.
 
 ### 5. Prefer contract-driven bridge work
 

--- a/.agents/skills/view-bridge/SKILL.md
+++ b/.agents/skills/view-bridge/SKILL.md
@@ -82,6 +82,15 @@ height, dispatches `ViewBridge::resize(...)`, and re-dispatches on each
 or rely on `Processor::on_view_resized(...)`, do not assume
 `editor_size()` is the last word after attach.
 
+Standalone headless/test launches must not show or activate a native
+window. `StandaloneConfig::headless`, `PULP_HEADLESS`, `PULP_TEST_MODE`,
+`CI`, or `PULP_SCREENSHOT` route `run_with_editor()` through
+`WindowOptions::initially_hidden`; screenshot mode captures
+`WindowHost::capture_back_buffer_png()`, not compositor-visible
+`capture_png()`. If a CI/test run is headless but has no screenshot path,
+`run_with_editor()` fails before creating the host so tests cannot park a
+hidden live window forever.
+
 ## AU v2 dual-Processor gotcha (fixed)
 
 Pre-ViewBridge, the AU v2 Cocoa view factory called

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.178.2
+    VERSION 0.179.0
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
+++ b/core/format/include/pulp/format/detail/standalone_editor_chrome.hpp
@@ -3,14 +3,78 @@
 #include <pulp/format/processor.hpp>
 #include <pulp/format/settings_panel.hpp>
 #include <pulp/runtime/log.hpp>
+#include <pulp/runtime/system.hpp>
 #include <pulp/view/window_host.hpp>
 
+#include <algorithm>
+#include <charconv>
+#include <cctype>
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <utility>
 
 namespace pulp::format::detail {
+
+inline bool standalone_env_truthy(std::string_view name) {
+    auto value = runtime::get_env(name);
+    if (!value) return false;
+
+    std::string normalized = *value;
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) {
+                       return static_cast<char>(std::tolower(c));
+                   });
+    if (normalized.empty()) return false;
+    return normalized != "0"
+        && normalized != "false"
+        && normalized != "no"
+        && normalized != "off";
+}
+
+inline bool parse_positive_frame_delay(std::string_view value, int& frames) {
+    if (value.empty() || value.front() == '+') return false;
+
+    int parsed = 0;
+    const char* first = value.data();
+    const char* last = first + value.size();
+    auto result = std::from_chars(first, last, parsed);
+    if (result.ec != std::errc{} || result.ptr != last || parsed <= 0)
+        return false;
+
+    frames = parsed;
+    return true;
+}
+
+inline StandaloneConfig standalone_config_from_environment(StandaloneConfig config) {
+    if (standalone_env_truthy("PULP_HEADLESS")
+        || standalone_env_truthy("PULP_TEST_MODE")
+        || standalone_env_truthy("CI")) {
+        config.headless = true;
+    }
+
+    if (auto screenshot = runtime::get_env("PULP_SCREENSHOT");
+        screenshot && config.screenshot_path.empty()) {
+        config.screenshot_path = *screenshot;
+    }
+
+    if (auto frames = runtime::get_env("PULP_FRAMES")) {
+        int parsed = 0;
+        if (parse_positive_frame_delay(*frames, parsed))
+            config.screenshot_frame_delay = parsed;
+    }
+
+    if (!config.screenshot_path.empty())
+        config.headless = true;
+
+    return config;
+}
+
+inline bool standalone_headless_requires_screenshot(const StandaloneConfig& config) {
+    return config.headless && config.screenshot_path.empty();
+}
 
 struct StandaloneSettingsActions {
     std::function<bool(const StandaloneConfig&)> apply_config;

--- a/core/format/include/pulp/format/standalone.hpp
+++ b/core/format/include/pulp/format/standalone.hpp
@@ -21,6 +21,9 @@ struct StandaloneConfig {
     int buffer_size = 256;
     int output_channels = 2;
     int input_channels = 0;
+    // When true, run_with_editor() avoids showing/activating the native
+    // window. Use with screenshot_path for CI/test smoke runs.
+    bool headless = false;
     // When false, run_with_editor() hosts the editor directly and omits the
     // built-in Settings tab.
     bool show_settings_tab = true;

--- a/core/format/src/standalone.cpp
+++ b/core/format/src/standalone.cpp
@@ -175,6 +175,14 @@ bool StandaloneApp::apply_config(const StandaloneConfig& new_config) {
 }
 
 bool StandaloneApp::run_with_editor(bool use_gpu) {
+    const auto effective_config = detail::standalone_config_from_environment(config_);
+    if (detail::standalone_headless_requires_screenshot(effective_config)) {
+        runtime::log_error(
+            "Standalone: headless/CI mode requires a screenshot path; "
+            "set StandaloneConfig::screenshot_path or PULP_SCREENSHOT");
+        return false;
+    }
+
     if (!start()) return false;
 
     if (!processor_ || !processor_->has_editor()) {
@@ -209,7 +217,7 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     auto desc = processor_->descriptor();
 
     auto chrome = detail::make_standalone_editor_chrome(
-        std::move(root), config_, audio_system_.get(), midi_system_.get(), &input_meter_bridge_,
+        std::move(root), effective_config, audio_system_.get(), midi_system_.get(), &input_meter_bridge_,
         detail::StandaloneSettingsActions{
             .apply_config = [this](const StandaloneConfig& cfg) {
                 return apply_config(cfg);
@@ -236,6 +244,7 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     // honor them (#1362).
     auto opts = detail::make_standalone_window_options(
         size_hints, chrome, desc.name + " — Standalone", use_gpu);
+    opts.initially_hidden = effective_config.headless;
 
     auto window = view::WindowHost::create(window_root, opts);
     if (!window) {
@@ -318,27 +327,28 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
     detail::install_standalone_idle_callback(*window, scripted_ui_ptr, settings_ptr);
 #endif
 
-    window->show();
+    if (!opts.initially_hidden)
+        window->show();
 
     detail::log_standalone_window_open(w, h, use_gpu, bridge->uses_script_ui(), chrome);
 
     // ── Headless one-shot screenshot (SDK-codified, pulp #468 follow-up) ──
     //
-    // When `config_.screenshot_path` is non-empty (set via set_config or
-    // parsed from `--screenshot=PATH` argv in the consumer's main), wait
-    // `screenshot_frame_delay` frames, then capture the window via
-    // `WindowHost::capture_png()` and exit. This is the SDK-level shape
+    // When `effective_config.screenshot_path` is non-empty (set via
+    // config/env or forwarded `pulp run --screenshot` args), wait
+    // `screenshot_frame_delay` frames, then capture the host back buffer and
+    // exit. This is the SDK-level shape
     // so every consumer (Spectr, examples, future plugins) gets headless
     // visual-regression capture without bespoke per-app code.
-    if (!config_.screenshot_path.empty()) {
+    if (!effective_config.screenshot_path.empty()) {
         auto* host = window.get();
         detail::ScreenshotCapture cap;
-        cap.delay = config_.screenshot_frame_delay > 0
-            ? config_.screenshot_frame_delay : 30;
-        cap.path = config_.screenshot_path;
-        cap.capture_fn = [host] { return host->capture_png(); };
+        cap.delay = effective_config.screenshot_frame_delay > 0
+            ? effective_config.screenshot_frame_delay : 30;
+        cap.path = effective_config.screenshot_path;
+        cap.capture_fn = [host] { return host->capture_back_buffer_png(); };
         cap.close_fn   = [host] { host->request_close(); };
-        cap.on_error   = [out_path = config_.screenshot_path](const std::string& msg) {
+        cap.on_error   = [out_path = effective_config.screenshot_path](const std::string& msg) {
             runtime::log_error("Standalone: screenshot {} ({})", msg, out_path);
         };
         // Compose with the pre-screenshot idle callback (inspector +
@@ -350,7 +360,7 @@ bool StandaloneApp::run_with_editor(bool use_gpu) {
             cap();
         });
         runtime::log_info("Standalone: screenshot mode armed — will capture to {} after {} frames",
-                          config_.screenshot_path, cap.delay);
+                          effective_config.screenshot_path, cap.delay);
     }
 
     // Blocks until the window is closed. The close callback above has

--- a/examples/threejs-native-demo/main.cpp
+++ b/examples/threejs-native-demo/main.cpp
@@ -1895,6 +1895,7 @@ int main(int argc, char* argv[]) {
     opts.width = width;
     opts.height = height;
     opts.use_gpu = true;
+    opts.initially_hidden = capture_path.has_value();
 
     auto window = WindowHost::create(env.root, opts);
     if (!window) {

--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -216,12 +216,13 @@ public:
     const InspectorConfig& config() const { return config_; }
 
     /// Resolve the selected view's authored source location and (unless
-    /// `dry_run`) open the user's editor at that file:line. Returns the
-    /// full result so callers / tests can inspect the formatted URL.
+    /// `dry_run`) open the user's editor at that file:line. Defaults to
+    /// dry-run so tests and protocol callers must opt into launching.
+    /// Returns the full result so callers / tests can inspect the formatted URL.
     /// A graceful no-op (ok == false) when there is no selection or the
     /// selected view carries no source provenance — the inspector never
     /// throws or spawns a process for a non-imported view.
-    SourceJumpResult jump_to_selection_source(bool dry_run = false);
+    SourceJumpResult jump_to_selection_source(bool dry_run = true);
 
     // ── Phase 3b — live-editable box-model fields ──────────────────
     //

--- a/inspect/include/pulp/inspect/protocol.hpp
+++ b/inspect/include/pulp/inspect/protocol.hpp
@@ -67,9 +67,9 @@ namespace methods {
     constexpr auto kInspectorSetEditorUrlTemplate = "Inspector.setEditorUrlTemplate";
     constexpr auto kInspectorGetEditorUrlTemplate = "Inspector.getEditorUrlTemplate";
     // Phase 5.1: the concrete source-jump action. Resolves the selected
-    // (or a given `anchorId`'s) view's recorded source location, formats
-    // the editor URL, and — unless `dryRun` is true — hands it to the OS
-    // so the user's editor opens at the originating JSX file:line.
+    // (or a given `anchorId`'s) view's recorded source location and formats
+    // the editor URL. It defaults to dry-run; callers must pass
+    // `dryRun:false` to hand the URL to the OS and open the user's editor.
     // Returns {ok, url, path, line, col, launched}. See
     // pulp/inspect/source_jump.hpp.
     constexpr auto kInspectorJumpToSource = "Inspector.jumpToSource";

--- a/inspect/include/pulp/inspect/source_jump.hpp
+++ b/inspect/include/pulp/inspect/source_jump.hpp
@@ -55,20 +55,13 @@ SourceJumpResult resolve_source_jump(const InspectorConfig& config,
 /// Hand an editor URL to the OS handler. Returns true if the launch
 /// command was dispatched successfully. macOS uses `open`, Linux uses
 /// `xdg-open`, Windows uses `ShellExecute`. An empty URL is a no-op
-/// that returns false.
+/// that returns false. In CI/headless/test contexts this refuses to
+/// spawn and stores the reason in `error` when provided.
 ///
 /// This is the side-effecting seam: callers that want a dry run (tests,
 /// the protocol `dryRun` param) should call `resolve_source_jump()` and
 /// skip this entirely.
-///
-/// Guard: when the environment variable `PULP_INSPECTOR_NO_LAUNCH` is
-/// set to a non-empty value, this function never spawns a process and
-/// returns false. The test suite sets it (per-target in CTest, and the
-/// J-hotkey test sets it in-process) so a headless run can never pop a
-/// real editor window or the macOS "an external application wants to
-/// open …" security dialog. An interactive session leaves it unset, so
-/// a genuine user action launches the editor for real.
-bool launch_editor_url(std::string_view url);
+bool launch_editor_url(std::string_view url, std::string* error = nullptr);
 
 /// Convenience: resolve + launch in one call. When `dry_run` is true,
 /// behaves exactly like `resolve_source_jump()` (no process spawned,

--- a/inspect/src/domain_handler.cpp
+++ b/inspect/src/domain_handler.cpp
@@ -368,8 +368,8 @@ InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
     //   anchorId : design-import anchor of the target view. When
     //              omitted, falls back to the overlay's selected view.
     //   dryRun   : when true, resolve + format only — never spawn a
-    //              process. Used by headless tests and agent callers
-    //              that just want the URL.
+    //              process. Defaults to true so tests and agent callers
+    //              must opt into a real launch with dryRun:false.
     // Returns {ok, url, path, line, col, launched} on a resolvable
     // target; {ok:false, error} when the view has no provenance or no
     // target could be found. Note `ok:false` here is a structured
@@ -377,7 +377,7 @@ InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
     // normal, expected case (the overlay treats it as a graceful
     // no-op), so callers can branch on `ok` without exception handling.
     if (req.method == methods::kInspectorJumpToSource) {
-        bool dry_run = false;
+        bool dry_run = true;
         std::string anchor_id;
         if (!req.params_json.empty()) {
             try {
@@ -419,6 +419,8 @@ InspectorMessage DomainHandler::handle_inspector(const InspectorMessage& req) {
                 choc::value::createInt64(static_cast<int64_t>(result.col)));
             resp.addMember("launched", choc::value::createBool(result.launched));
             resp.addMember("dryRun", choc::value::createBool(dry_run));
+            if (!result.error.empty())
+                resp.addMember("launchError", choc::value::createString(result.error));
         } else {
             resp.addMember("error", choc::value::createString(
                 anchor_id.empty() && !overlay_

--- a/inspect/src/source_jump.cpp
+++ b/inspect/src/source_jump.cpp
@@ -6,7 +6,16 @@
 #include <pulp/inspect/source_jump.hpp>
 #include <pulp/view/view.hpp>
 
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cctype>
+#include <cstddef>
 #include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
 
 #if defined(_WIN32)
   #include <windows.h>
@@ -22,21 +31,100 @@ namespace pulp::inspect {
 
 namespace {
 
-// Test / CI / non-interactive guard. When `PULP_INSPECTOR_NO_LAUNCH` is
-// set to a non-empty value, `launch_editor_url()` resolves and formats
-// the URL exactly as it would otherwise, but never spawns the editor
-// process. This keeps headless test runs, CI, and any scripted /
-// non-interactive use of the inspector from popping a real editor
-// window (and, on macOS, the "an external application wants to open …"
-// security dialog). A genuine user action — the J hotkey in an
-// interactive session — runs without this env var and launches for
-// real. Tests assert the *constructed* URL via `resolve_source_jump()`
-// or the `dryRun` protocol path; they must never depend on a real
-// launch.
-bool editor_launch_suppressed() {
-    const char* v = std::getenv("PULP_INSPECTOR_NO_LAUNCH");
-    return v != nullptr && v[0] != '\0';
+bool env_is_truthy(const char* name) {
+    const char* value = std::getenv(name);
+    if (value == nullptr || *value == '\0') return false;
+    std::string normalized(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) {
+                       return static_cast<char>(std::tolower(c));
+                   });
+    return normalized != "0"
+        && normalized != "false"
+        && normalized != "no"
+        && normalized != "off";
 }
+
+std::string current_process_name() {
+#if defined(_WIN32)
+    std::array<char, MAX_PATH> path{};
+    const DWORD len = ::GetModuleFileNameA(nullptr, path.data(),
+                                           static_cast<DWORD>(path.size()));
+    if (len == 0)
+        return {};
+    std::string name(path.data(), static_cast<std::size_t>(len));
+#elif defined(__APPLE__)
+    std::string name = ::getprogname() ? ::getprogname() : "";
+#else
+    std::array<char, 4096> path{};
+    const ssize_t len = ::readlink("/proc/self/exe", path.data(), path.size() - 1);
+    if (len <= 0)
+        return {};
+    std::string name(path.data(), static_cast<std::size_t>(len));
+#endif
+    const auto slash = name.find_last_of("/\\");
+    if (slash != std::string::npos)
+        name.erase(0, slash + 1);
+    return name;
+}
+
+bool is_pulp_test_process() {
+    const auto name = current_process_name();
+    return name.rfind("pulp-test-", 0) == 0;
+}
+
+std::optional<std::string> launch_block_reason() {
+    if (env_is_truthy("PULP_INSPECTOR_NO_LAUNCH"))
+        return "editor launch suppressed because PULP_INSPECTOR_NO_LAUNCH is set";
+    if (env_is_truthy("PULP_HEADLESS"))
+        return "editor launch suppressed because PULP_HEADLESS is set";
+    if (env_is_truthy("PULP_TEST_MODE"))
+        return "editor launch suppressed because PULP_TEST_MODE is set";
+    if (env_is_truthy("CI"))
+        return "editor launch suppressed because CI is set";
+    if (is_pulp_test_process())
+        return "editor launch suppressed because this is a pulp-test binary";
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+    const bool has_x11 = std::getenv("DISPLAY") != nullptr
+        && *std::getenv("DISPLAY") != '\0';
+    const bool has_wayland = std::getenv("WAYLAND_DISPLAY") != nullptr
+        && *std::getenv("WAYLAND_DISPLAY") != '\0';
+    if (!has_x11 && !has_wayland)
+        return "editor launch suppressed because no display is available";
+#endif
+
+    return std::nullopt;
+}
+
+void set_launch_error(std::string* out, std::string message) {
+    if (out) *out = std::move(message);
+}
+
+#if !defined(_WIN32)
+bool wait_for_launcher(pid_t pid, std::string_view launcher, std::string* error) {
+    int status = 0;
+    while (true) {
+        const pid_t waited = ::waitpid(pid, &status, 0);
+        if (waited == pid)
+            break;
+        if (waited == -1 && errno == EINTR)
+            continue;
+
+        set_launch_error(error, std::string(launcher)
+            + " wait failed while launching editor URL");
+        return false;
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        set_launch_error(error, std::string(launcher)
+            + " exited non-zero while launching editor URL");
+        return false;
+    }
+
+    return true;
+}
+#endif
 
 } // namespace
 
@@ -81,15 +169,15 @@ SourceJumpResult resolve_source_jump(const InspectorConfig& config,
     return result;
 }
 
-bool launch_editor_url(std::string_view url) {
-    if (url.empty()) return false;
-
-    // Defense in depth: refuse to spawn under the test/CI/non-interactive
-    // guard. This is independent of the `dry_run` flag — even a caller
-    // that asked to launch (the J hotkey wired with `dry_run=false`) is
-    // suppressed when the env var is set, so a non-interactive run can
-    // never pop a real editor or the macOS open-confirmation dialog.
-    if (editor_launch_suppressed()) return false;
+bool launch_editor_url(std::string_view url, std::string* error) {
+    if (url.empty()) {
+        set_launch_error(error, "editor URL is empty");
+        return false;
+    }
+    if (auto reason = launch_block_reason()) {
+        set_launch_error(error, *reason);
+        return false;
+    }
 
 #if defined(_WIN32)
     std::wstring wurl(url.begin(), url.end());
@@ -97,27 +185,37 @@ bool launch_editor_url(std::string_view url) {
     auto rc = reinterpret_cast<INT_PTR>(
         ::ShellExecuteW(nullptr, L"open", wurl.c_str(),
                         nullptr, nullptr, SW_SHOWNORMAL));
-    return rc > 32;
+    if (rc <= 32) {
+        set_launch_error(error, "ShellExecuteW failed while launching editor URL");
+        return false;
+    }
+    return true;
 #elif defined(__APPLE__)
     const std::string url_str(url);
     const char* argv[] = {"open", url_str.c_str(), nullptr};
     pid_t pid = 0;
     int rc = ::posix_spawnp(&pid, "open", nullptr, nullptr,
                             const_cast<char* const*>(argv), environ);
-    if (rc != 0) return false;
-    int status = 0;
-    ::waitpid(pid, &status, 0);
-    return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+    if (rc != 0) {
+        set_launch_error(error, "posix_spawnp(open) failed while launching editor URL");
+        return false;
+    }
+    if (!wait_for_launcher(pid, "open", error))
+        return false;
+    return true;
 #else
     const std::string url_str(url);
     const char* argv[] = {"xdg-open", url_str.c_str(), nullptr};
     pid_t pid = 0;
     int rc = ::posix_spawnp(&pid, "xdg-open", nullptr, nullptr,
                             const_cast<char* const*>(argv), environ);
-    if (rc != 0) return false;
-    int status = 0;
-    ::waitpid(pid, &status, 0);
-    return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+    if (rc != 0) {
+        set_launch_error(error, "posix_spawnp(xdg-open) failed while launching editor URL");
+        return false;
+    }
+    if (!wait_for_launcher(pid, "xdg-open", error))
+        return false;
+    return true;
 #endif
 }
 
@@ -126,7 +224,10 @@ SourceJumpResult jump_to_source(const InspectorConfig& config,
                                 bool dry_run) {
     SourceJumpResult result = resolve_source_jump(config, view);
     if (result.ok && !dry_run) {
-        result.launched = launch_editor_url(result.url);
+        std::string launch_error;
+        result.launched = launch_editor_url(result.url, &launch_error);
+        if (!result.launched && !launch_error.empty())
+            result.error = std::move(launch_error);
     }
     return result;
 }

--- a/test/test_editor_url.cpp
+++ b/test/test_editor_url.cpp
@@ -401,6 +401,59 @@ TEST_CASE("jump_to_source with dry_run=false does not launch under the guard",
     REQUIRE_FALSE(result.launched);
 }
 
+TEST_CASE("launch_editor_url refuses to spawn when PULP_HEADLESS is set",
+          "[inspect][source-jump][issue-2515]") {
+    ScopedEnv headless("PULP_HEADLESS");
+    headless.set("1");
+
+    std::string error;
+    REQUIRE_FALSE(launch_editor_url("vscode://file/src/Panel.jsx:24", &error));
+    REQUIRE(error.find("PULP_HEADLESS") != std::string::npos);
+}
+
+TEST_CASE("launch_editor_url refuses to spawn when CI is set",
+          "[inspect][source-jump][issue-2515]") {
+    ScopedEnv headless("PULP_HEADLESS");
+    ScopedEnv test_mode("PULP_TEST_MODE");
+    ScopedEnv ci("CI");
+    headless.unset();
+    test_mode.unset();
+    ci.set("true");
+
+    std::string error;
+    REQUIRE_FALSE(launch_editor_url("vscode://file/src/Panel.jsx:24", &error));
+    REQUIRE(error.find("CI") != std::string::npos);
+}
+
+TEST_CASE("launch_editor_url refuses to spawn from pulp-test binaries",
+          "[inspect][source-jump][issue-2515]") {
+    ScopedEnv headless("PULP_HEADLESS");
+    ScopedEnv test_mode("PULP_TEST_MODE");
+    ScopedEnv ci("CI");
+    headless.unset();
+    test_mode.unset();
+    ci.unset();
+
+    std::string error;
+    REQUIRE_FALSE(launch_editor_url("vscode://file/src/Panel.jsx:24", &error));
+    REQUIRE(error.find("pulp-test") != std::string::npos);
+}
+
+TEST_CASE("jump_to_source non-dry launch is guarded in headless mode",
+          "[inspect][source-jump][issue-2515]") {
+    ScopedEnv headless("PULP_HEADLESS");
+    headless.set("1");
+
+    pulp::view::View view;
+    view.set_source_loc({"src/Panel.jsx", 24, 3});
+
+    InspectorConfig cfg;
+    auto result = jump_to_source(cfg, &view, /*dry_run=*/false);
+    REQUIRE(result.ok);
+    REQUIRE_FALSE(result.launched);
+    REQUIRE(result.error.find("PULP_HEADLESS") != std::string::npos);
+}
+
 // ── Phase 5.1: Inspector.jumpToSource protocol round-trip ──────────────────
 
 TEST_CASE("Inspector.jumpToSource resolves an anchored view in dryRun",
@@ -430,6 +483,63 @@ TEST_CASE("Inspector.jumpToSource resolves an anchored view in dryRun",
     REQUIRE(obj["line"].getInt64() == 24);
     REQUIRE_FALSE(obj["launched"].getBool());
     REQUIRE(obj["dryRun"].getBool());
+}
+
+TEST_CASE("Inspector.jumpToSource defaults to dry-run when dryRun is omitted",
+          "[inspect][source-jump][protocol][issue-2515]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+    ScopedEnv headless("PULP_HEADLESS");
+    headless.set("1");
+
+    pulp::view::View root;
+    auto child = std::make_unique<pulp::view::View>();
+    child->set_anchor_id("figma:node-7");
+    child->set_source_loc({"src/Panel.jsx", 24, 3});
+    root.add_child(std::move(child));
+
+    DomainHandler handler;
+    handler.set_root_view(&root);
+
+    auto resp = handler.handle(make_request(
+        1, methods::kInspectorJumpToSource,
+        R"({"anchorId":"figma:node-7"})"));
+    REQUIRE_FALSE(resp.is_error);
+
+    auto obj = choc::json::parse(resp.params_json);
+    REQUIRE(obj["ok"].getBool());
+    REQUIRE_FALSE(obj["launched"].getBool());
+    REQUIRE(obj["dryRun"].getBool());
+    REQUIRE_FALSE(obj.hasObjectMember("launchError"));
+}
+
+TEST_CASE("Inspector.jumpToSource reports guarded launch errors",
+          "[inspect][source-jump][protocol][issue-2515]") {
+    ScopedEnv env("PULP_INSPECTOR_EDITOR_URL");
+    env.unset();
+    ScopedEnv headless("PULP_HEADLESS");
+    headless.set("1");
+
+    pulp::view::View root;
+    auto child = std::make_unique<pulp::view::View>();
+    child->set_anchor_id("figma:node-7");
+    child->set_source_loc({"src/Panel.jsx", 24, 3});
+    root.add_child(std::move(child));
+
+    DomainHandler handler;
+    handler.set_root_view(&root);
+
+    auto resp = handler.handle(make_request(
+        1, methods::kInspectorJumpToSource,
+        R"({"anchorId":"figma:node-7","dryRun":false})"));
+    REQUIRE_FALSE(resp.is_error);
+
+    auto obj = choc::json::parse(resp.params_json);
+    REQUIRE(obj["ok"].getBool());
+    REQUIRE_FALSE(obj["launched"].getBool());
+    REQUIRE_FALSE(obj["dryRun"].getBool());
+    REQUIRE(std::string(obj["launchError"].getString()).find("PULP_HEADLESS")
+            != std::string::npos);
 }
 
 TEST_CASE("Inspector.jumpToSource returns ok:false for an unknown anchor",

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -7,7 +7,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
+#include <string>
 #include <string_view>
 #include <tuple>
 #include <vector>
@@ -46,6 +48,41 @@ bool has_label_containing(View& root, std::string_view text) {
     }
     return false;
 }
+
+struct ScopedEnv {
+    explicit ScopedEnv(std::string name) : name_(std::move(name)) {
+        if (const char* prev = std::getenv(name_.c_str())) {
+            prev_ = std::string(prev);
+            had_prev_ = true;
+        }
+    }
+
+    void set(const std::string& value) {
+#if defined(_WIN32)
+        _putenv_s(name_.c_str(), value.c_str());
+#else
+        ::setenv(name_.c_str(), value.c_str(), /*overwrite=*/1);
+#endif
+    }
+
+    void unset() {
+#if defined(_WIN32)
+        _putenv_s(name_.c_str(), "");
+#else
+        ::unsetenv(name_.c_str());
+#endif
+    }
+
+    ~ScopedEnv() {
+        if (had_prev_) set(prev_);
+        else unset();
+    }
+
+private:
+    std::string name_;
+    std::string prev_;
+    bool had_prev_ = false;
+};
 
 // A RecordingCanvas that also serves real pixel readback over a small
 // synthetic surface — lets phase-3e tests exercise the loupe's
@@ -3328,6 +3365,34 @@ TEST_CASE("InspectorOverlay: J jumps to source for a view with provenance",
     jk.modifiers = 0;
     jk.is_down = true;
     REQUIRE(overlay.handle_key_event(jk));
+}
+
+TEST_CASE("InspectorOverlay source jump helper defaults to dry-run",
+          "[inspect][overlay][source-jump][issue-2515]") {
+    ScopedEnv headless("PULP_HEADLESS");
+    headless.set("1");
+
+    View root;
+    root.set_bounds({0, 0, 500, 300});
+    auto child = std::make_unique<View>();
+    child->set_bounds({10, 10, 80, 40});
+    child->set_source_loc({"src/Panel.jsx", 24, 3});
+    root.add_child(std::move(child));
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    MouseEvent click;
+    click.position = {20, 20};
+    click.is_down = true;
+    REQUIRE(overlay.handle_mouse_event(click));
+    REQUIRE(overlay.selected_view() != nullptr);
+
+    auto result = overlay.jump_to_selection_source();
+    REQUIRE(result.ok);
+    REQUIRE(result.url == "vscode://file/src/Panel.jsx:24");
+    REQUIRE_FALSE(result.launched);
+    REQUIRE(result.error.empty());
 }
 
 TEST_CASE("InspectorOverlay: J is a graceful no-op without a selection",

--- a/test/test_standalone_editor_chrome.cpp
+++ b/test/test_standalone_editor_chrome.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <pulp/format/detail/standalone_editor_chrome.hpp>
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <vector>
@@ -11,6 +12,41 @@ using namespace pulp::format::detail;
 using namespace pulp::view;
 
 namespace {
+
+struct ScopedEnv {
+    explicit ScopedEnv(std::string name) : name_(std::move(name)) {
+        if (const char* prev = std::getenv(name_.c_str())) {
+            prev_ = std::string(prev);
+            had_prev_ = true;
+        }
+    }
+
+    void set(const std::string& value) {
+#if defined(_WIN32)
+        _putenv_s(name_.c_str(), value.c_str());
+#else
+        ::setenv(name_.c_str(), value.c_str(), /*overwrite=*/1);
+#endif
+    }
+
+    void unset() {
+#if defined(_WIN32)
+        _putenv_s(name_.c_str(), "");
+#else
+        ::unsetenv(name_.c_str());
+#endif
+    }
+
+    ~ScopedEnv() {
+        if (had_prev_) set(prev_);
+        else unset();
+    }
+
+private:
+    std::string name_;
+    std::string prev_;
+    bool had_prev_ = false;
+};
 
 class StubWindowHost final : public WindowHost {
 public:
@@ -620,6 +656,68 @@ TEST_CASE("Standalone log helper formats the chrome mode",
 
     log_standalone_window_open(640, 360, false, false, chrome);
     SUCCEED();
+}
+
+TEST_CASE("Standalone environment opts screenshot runs into hidden mode",
+          "[standalone][chrome][issue-2515]") {
+    ScopedEnv headless("PULP_HEADLESS");
+    ScopedEnv test_mode("PULP_TEST_MODE");
+    ScopedEnv ci("CI");
+    ScopedEnv screenshot("PULP_SCREENSHOT");
+    ScopedEnv frames("PULP_FRAMES");
+    headless.set("1");
+    test_mode.unset();
+    ci.unset();
+    screenshot.set("/tmp/pulp-standalone-headless.png");
+    frames.set("2");
+
+    auto config = standalone_config_from_environment(StandaloneConfig{});
+
+    REQUIRE(config.headless);
+    REQUIRE(config.screenshot_path == "/tmp/pulp-standalone-headless.png");
+    REQUIRE(config.screenshot_frame_delay == 2);
+    REQUIRE_FALSE(standalone_headless_requires_screenshot(config));
+}
+
+TEST_CASE("Standalone headless CI without screenshot is rejected before launch",
+          "[standalone][chrome][issue-2515]") {
+    ScopedEnv headless("PULP_HEADLESS");
+    ScopedEnv test_mode("PULP_TEST_MODE");
+    ScopedEnv ci("CI");
+    ScopedEnv screenshot("PULP_SCREENSHOT");
+    ScopedEnv frames("PULP_FRAMES");
+    headless.set("0");
+    test_mode.unset();
+    ci.set("true");
+    screenshot.unset();
+    frames.set("not-an-int");
+
+    StandaloneConfig base;
+    base.screenshot_frame_delay = 9;
+    auto config = standalone_config_from_environment(base);
+
+    REQUIRE(config.headless);
+    REQUIRE(config.screenshot_path.empty());
+    REQUIRE(config.screenshot_frame_delay == 9);
+    REQUIRE(standalone_headless_requires_screenshot(config));
+}
+
+TEST_CASE("Standalone empty headless env vars are ignored",
+          "[standalone][chrome][issue-2515]") {
+    ScopedEnv headless("PULP_HEADLESS");
+    ScopedEnv test_mode("PULP_TEST_MODE");
+    ScopedEnv ci("CI");
+    ScopedEnv screenshot("PULP_SCREENSHOT");
+    headless.set("");
+    test_mode.set("");
+    ci.set("");
+    screenshot.unset();
+
+    auto config = standalone_config_from_environment(StandaloneConfig{});
+
+    REQUIRE_FALSE(config.headless);
+    REQUIRE(config.screenshot_path.empty());
+    REQUIRE_FALSE(standalone_headless_requires_screenshot(config));
 }
 
 TEST_CASE("make_standalone_window_options propagates min_* from ViewSize",

--- a/test/test_view_host_bridge_mac.mm
+++ b/test/test_view_host_bridge_mac.mm
@@ -29,6 +29,7 @@ TEST_CASE("macOS WindowHost reports content size and fires resize callbacks",
         opts.height = 240.0f;
         opts.resizable = true;
         opts.use_gpu = false;
+        opts.initially_hidden = true;
 
         auto host = WindowHost::create(root, opts);
         REQUIRE(host != nullptr);
@@ -100,6 +101,7 @@ TEST_CASE("macOS GPU WindowHost accepts set_idle_callback (pulp #1387 gap #3)",
         opts.width = 200.0f;
         opts.height = 200.0f;
         opts.use_gpu = true;
+        opts.initially_hidden = true;
 
         auto host = WindowHost::create(root, opts);
         if (!host) {
@@ -153,6 +155,7 @@ TEST_CASE("PulpView mouseUp survives mouseDown handler that unmounts the target"
         opts.height = 100.0f;
         opts.resizable = false;
         opts.use_gpu = false;
+        opts.initially_hidden = true;
 
         auto host = WindowHost::create(root, opts);
         REQUIRE(host != nullptr);
@@ -241,6 +244,7 @@ TEST_CASE("PulpView NSEvent click dispatches JS on(id,'click') subscriber",
         opts.height = 100.0f;
         opts.resizable = false;
         opts.use_gpu = false;
+        opts.initially_hidden = true;
 
         auto host = WindowHost::create(root, opts);
         REQUIRE(host != nullptr);
@@ -353,6 +357,7 @@ TEST_CASE("PulpView NSEvent click bubbles up to ancestor on_click handler",
         opts.height = 100.0f;
         opts.resizable = false;
         opts.use_gpu = false;
+        opts.initially_hidden = true;
 
         auto host = WindowHost::create(root, opts);
         REQUIRE(host != nullptr);


### PR DESCRIPTION
## Summary
- Default `Inspector.jumpToSource` and `InspectorOverlay::jump_to_selection_source()` to dry-run so agents/tests resolve source locations without opening the OS editor.
- Guard `launch_editor_url()` in CI/headless/test contexts, including direct `pulp-test-*` binaries, and return a structured launch error instead of spawning `open`/`xdg-open`/`ShellExecute`.
- Make standalone editor runs consume `PULP_HEADLESS` / `PULP_TEST_MODE` / `CI` / `PULP_SCREENSHOT`, use hidden windows for headless screenshot mode, and reject headless runs without a screenshot path before creating a live window.
- Keep macOS view-host and Three.js capture smoke paths hidden so validation does not focus-steal with a live Parameters window.

## Behavior change
`Inspector.jumpToSource` now requires explicit `"dryRun": false` to open the editor. The interactive inspector `J` hotkey still opts into a real launch, but the new CI/headless/test guard can suppress it with a clear reason.

Fixes #2515

## Tests
- `PULP_HEADLESS=1 PULP_TEST_MODE=1 SKIA_DIR=/private/tmp/pulp-design-import-phase0/external/skia-build cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPULP_BUILD_TESTS=ON`
- `PULP_HEADLESS=1 PULP_TEST_MODE=1 cmake --build build --target pulp-test-editor-url pulp-test-inspector pulp-test-standalone-editor-chrome pulp-test-view-host-bridge pulp-threejs-native-demo -j$(sysctl -n hw.ncpu)`
- `PULP_HEADLESS=1 PULP_TEST_MODE=1 ./build/test/pulp-test-editor-url`
- `PULP_HEADLESS=1 PULP_TEST_MODE=1 ./build/test/pulp-test-inspector`
- `PULP_HEADLESS=1 PULP_TEST_MODE=1 ./build/test/pulp-test-standalone-editor-chrome`
- `PULP_HEADLESS=1 PULP_TEST_MODE=1 ./build/test/pulp-test-view-host-bridge`
- `git diff --check origin/main...HEAD`
- `python3 tools/import-validation/check-source-contracts.py --strict`
- `python3 tools/import-validation/test_source_contracts.py`
- `python3 tools/scripts/skill_sync_check.py --mode=report --base origin/main`
- `python3 tools/scripts/version_bump_check.py --mode=report --base origin/main`
