### PR TITLE
ci: backstop Coverage workflow against multi-hour hangs

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -794,6 +794,39 @@ it cancels by age regardless of why a run wedged, so a job that
 genuinely *executes* longer than 4h would be cancelled too. Bump the
 threshold via `workflow_dispatch` if a one-off legitimately needs longer.
 
+### Gotcha: a job with no `timeout-minutes` can hang the whole workflow
+
+The reaper is the *backstop*, not the fix. The root cause of repeated
+Coverage hangs was that `coverage.yml`'s `coverage` matrix job had **no
+`timeout-minutes`** and one matrix leg (`macos`) routes to a self-hosted
+runner pool via `PULP_COVERAGE_MACOS_RUNS_ON_JSON`. When that pool is
+saturated the leg sits `queued` forever — a `queued` job never reaches
+its steps, so step-level `continue-on-error` cannot help. The downstream
+`coverage-diff-gate` has `needs: coverage` + `if: always()`, so it
+cannot reach a terminal conclusion until *every* matrix leg ends; the
+required `Diff coverage required` check then sat `queued` and the whole
+Coverage run stayed `in_progress` for 4h+ until the reaper killed it.
+
+Fix pattern (applies to any GH-Actions job, not just coverage):
+
+- **Always set `timeout-minutes` on every job.** A healthy job's wall
+  time × ~2-2.5 is a safe backstop — it bounds both queued and running
+  time, so a starved self-hosted leg fails fast instead of squatting.
+- **Pin a pure gate/aggregation job to a GitHub-hosted runner**
+  (`ubuntu-latest` / `ubuntu-24.04`). A job that only downloads
+  artifacts and runs a check must never queue behind a saturated
+  self-hosted pool — if it does, `if: always()` cannot save it because
+  the job still needs a runner to start.
+- A `needs:` + `if: always()` job only reaches a conclusion once every
+  upstream job is terminal; an upstream job with no timeout therefore
+  hangs the gate transitively.
+
+Do not flip a `concurrency` block's `cancel-in-progress` to `true` to
+"fix" a pile-up if `false` was a deliberate choice (e.g. coverage.yml
+keeps `false` for Codecov's `after_n_builds` upload completeness,
+pulp#1884). Per-job `timeout-minutes` is the correct fix; it bounds runs
+regardless of `cancel-in-progress`.
+
 ## Prerequisites Check
 
 Before running any CI command, verify the required tooling AND provider config exists:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,6 +62,16 @@ concurrency:
   # SHA, re-run the workflow manually via `workflow_dispatch` after the
   # active run finishes. Upstream tracking:
   #   https://github.com/orgs/community/discussions/12835
+  #
+  # DELIBERATELY kept `false` (not flipped to `true`): the Coverage-run
+  # hang fixed alongside this comment was caused by missing
+  # `timeout-minutes` on the `coverage` matrix job and `coverage-diff-gate`
+  # — NOT by superseded runs piling up. Those job-level timeouts now bound
+  # every run to a few hours max regardless of `cancel-in-progress`.
+  # Flipping to `true` would reintroduce the pulp#1884 Codecov
+  # stuck-upload bug (cancel mid-`after_n_builds: 4` → no coverage signal
+  # on ~70% of merges). The timeout backstop is the correct fix; staying
+  # `false` preserves the coverage signal.
   group: coverage-${{ github.ref }}
   cancel-in-progress: false
 
@@ -199,6 +209,15 @@ jobs:
   coverage:
     needs: [resolve-runners, changed-files]
     name: Coverage report (${{ matrix.label }}, Clang)
+    # Hard backstop against a wedged matrix leg. A healthy coverage build
+    # runs ~1h; 150 min leaves generous headroom for a slow self-hosted
+    # runner without ever letting a leg squat for GitHub's 6h job limit.
+    # Critically, this also bounds the QUEUED state: when a self-hosted
+    # macOS runner pool (routed via PULP_COVERAGE_MACOS_RUNS_ON_JSON) is
+    # saturated, a leg that never gets a runner now fails on this timeout
+    # instead of hanging indefinitely — which previously kept the whole
+    # Coverage run `in_progress` for 4h+ and starved the downstream gate.
+    timeout-minutes: 150
     strategy:
       # Don't cancel other OSes when one fails — coverage is advisory
       # and we want every OS to attempt an upload independently so the
@@ -736,8 +755,22 @@ jobs:
     # branch-protection's required-status-checks list, and shows the
     # threshold inside the rendered PR comment body instead of the name.
     name: Diff coverage required
+    # GitHub-hosted runner on purpose: a pure diff-coverage gate must
+    # never queue behind a saturated self-hosted macOS pool. Combined
+    # with `if: always()` below, this guarantees the required check can
+    # always START and reach a terminal conclusion once the upstream
+    # `coverage` job ends — whether it succeeded, failed, or was
+    # cancelled — instead of squatting in `queued` for hours.
     runs-on: ubuntu-24.04
+    # Hard backstop. diff-cover + the per-tier gate finish in a few
+    # minutes; 30 min absorbs slow artifact downloads and pip installs
+    # while still capping a wedged step well short of GitHub's 6h limit.
+    timeout-minutes: 30
     needs: coverage
+    # `always()` keeps the required gate reaching a conclusion even when
+    # an upstream `coverage` matrix leg fails or is cancelled — the gate
+    # then renders the graceful "no Cobertura XML" fallback below and
+    # reports skip/fail promptly rather than staying eligible-but-stuck.
     if: always() && github.event_name == 'pull_request'
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

`.github/workflows/coverage.yml` Coverage runs sat `in_progress` for 4+ hours, squatting macOS-runner concurrency slots until the stale-run-reaper or GitHub's 6h job limit killed them. We have had to manually cancel hung Coverage runs repeatedly.

## Root cause (confirmed against the YAML)

The `coverage` matrix job had **no `timeout-minutes`**. Its `macos` leg routes to a self-hosted / Namespace runner pool via the `PULP_COVERAGE_MACOS_RUNS_ON_JSON` repo variable. When that pool is saturated, the macOS leg sits in `queued` indefinitely.

- A `queued` job never reaches its steps, so the step-level `continue-on-error: true` on "Run coverage suite" cannot help — the job is stuck *before* any step runs.
- `coverage-diff-gate` has `needs: coverage` + `if: always()`. An `if: always()` job only reaches a conclusion once **every** upstream matrix leg is terminal (`success`/`failure`/`cancelled`/`skipped`). With one leg stuck `queued` forever, the required `Diff coverage required` check stays `queued` too, and the whole Coverage run stays `in_progress`.
- With no `timeout-minutes` on the `coverage` job, nothing reaps the stuck leg until GitHub's 6h hard limit (or the 30-min stale-run-reaper).

`coverage-diff-gate` itself already runs on `ubuntu-24.04` (GitHub-hosted), so it was *not* waiting on a saturated self-hosted pool — the wedge was entirely upstream in the `coverage` matrix job.

## Changes

- **`coverage` matrix job: `timeout-minutes: 150`.** A healthy coverage build runs ~1h; 150 min is a generous backstop that bounds **both** queued and running time, so a starved self-hosted leg fails fast instead of squatting. Nothing healthy is reaped.
- **`coverage-diff-gate`: `timeout-minutes: 30`** hard backstop. diff-cover + the per-tier gate finish in minutes; 30 absorbs slow artifact downloads. Also documented inline *why* it stays on a GitHub-hosted runner — a pure diff-coverage gate must never queue behind a saturated self-hosted macOS pool.
- **`concurrency.cancel-in-progress`: deliberately kept `false`.** Assessed flipping to `true` per the task. **Decision: keep `false`.** The hang was the missing `timeout-minutes`, not superseded runs piling up — per-job timeouts now bound every run to a few hours max regardless of `cancel-in-progress`. Flipping to `true` would reintroduce the pulp#1884 bug: cancelling a run mid-upload breaks Codecov's `after_n_builds: 4` completeness check and ~70% of merges lose their coverage signal. GitHub's documented queue-depth-1 behavior already caps the pile-up at one queued run per group. The timeout backstop is the correct fix; staying `false` preserves the coverage signal. Recorded this reasoning in the in-file comment.
- **`ci` SKILL.md:** added a gotcha section documenting the no-`timeout-minutes` + self-hosted-pool hang failure mode and the fix pattern, alongside the existing stale-run-reaper section (`.github/workflows/**` maps to the `ci` skill — satisfies the skill-sync gate).

## Validation

Ran the exact tooling `workflow-lint.yml` runs, all green:

- `yamllint --no-warnings -d relaxed .github/workflows/coverage.yml`
- `actionlint -shellcheck= -pyflakes= .github/workflows/coverage.yml`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/coverage.yml'))"`

## Test plan

- [ ] `workflow-lint` check passes on this PR
- [ ] Confirm next Coverage run on a PR resolves the `Diff coverage required` gate promptly even if a `coverage` matrix leg fails/cancels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
