### PR TITLE
test(view): cover phase3 widget and asset edges

### DIFF
--- a/test/test_asset_manager.cpp
+++ b/test/test_asset_manager.cpp
@@ -23,6 +23,12 @@ std::filesystem::path make_temp_asset_path(const char* stem, const char* suffix)
     return std::filesystem::temp_directory_path() / (std::string(stem) + "-" + unique + suffix);
 }
 
+std::string make_unique_asset_name(const char* stem) {
+    auto unique = std::to_string(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    return std::string(stem) + "-" + unique;
+}
+
 std::vector<uint8_t> make_png_header(uint32_t width, uint32_t height) {
     return {
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
@@ -235,6 +241,50 @@ TEST_CASE("AssetManager embedded shader loads into shader cache", "[view][assets
     REQUIRE(cached.source == shader.source);
 }
 
+TEST_CASE("AssetManager embedded shader loader returns cached source on repeat",
+          "[view][assets][coverage][phase3]") {
+    auto& mgr = AssetManager::instance();
+    mgr.clear_cache();
+
+    const auto name = make_unique_asset_name("embedded-shader-cache");
+    static const uint8_t first[] = "void first() {}";
+    static const uint8_t second[] = "void second() {}";
+
+    mgr.register_embedded(name, first, sizeof(first) - 1);
+    auto shader = mgr.load_shader_embedded(name);
+    REQUIRE(shader.valid());
+    REQUIRE(shader.source == "void first() {}");
+
+    mgr.register_embedded(name, second, sizeof(second) - 1);
+    auto cached = mgr.load_shader_embedded(name);
+    REQUIRE(cached.valid());
+    REQUIRE(cached.source == "void first() {}");
+}
+
+TEST_CASE("AssetManager shader lookup finds cached file shader by path",
+          "[view][assets][coverage][phase3]") {
+    auto& mgr = AssetManager::instance();
+    mgr.clear_cache();
+
+    auto path = make_temp_asset_path("pulp-test-shader-lookup", ".sksl");
+    const std::string source = "half4 main() { return half4(1); }";
+    {
+        std::ofstream file(path);
+        file << source;
+    }
+
+    auto loaded = mgr.load_shader(path.string());
+    REQUIRE(loaded.valid());
+    REQUIRE(loaded.source == source);
+
+    auto cached = mgr.shader(path.string());
+    REQUIRE(cached.valid());
+    REQUIRE(cached.source == source);
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}
+
 TEST_CASE("AssetManager missing embedded shader reports error", "[view][assets]") {
     auto& mgr = AssetManager::instance();
     auto shader = mgr.load_shader_embedded("missing_embedded_shader_asset");
@@ -294,6 +344,37 @@ TEST_CASE("AssetManager fallback skips families without embedded data", "[view][
     REQUIRE(font.family_name == "PresentFallback");
 }
 
+TEST_CASE("AssetManager embedded font loader populates and reuses cache",
+          "[view][assets][coverage][phase3]") {
+    auto& mgr = AssetManager::instance();
+    mgr.clear_cache();
+
+    const auto name = make_unique_asset_name("embedded-font-cache");
+    static const uint8_t first[] = {0x00, 0x01, 0x00, 0x00};
+    static const uint8_t second[] = {'O', 'T', 'T', 'O', 0x01};
+
+    mgr.register_embedded(name, first, sizeof(first));
+    auto font = mgr.load_font_embedded(name);
+    REQUIRE(font.valid());
+    REQUIRE(font.family_name == name);
+    REQUIRE(font.data == std::vector<uint8_t>(first, first + sizeof(first)));
+
+    mgr.register_embedded(name, second, sizeof(second));
+    auto cached = mgr.load_font_embedded(name);
+    REQUIRE(cached.valid());
+    REQUIRE(cached.family_name == name);
+    REQUIRE(cached.data == std::vector<uint8_t>(first, first + sizeof(first)));
+}
+
+TEST_CASE("AssetManager missing family without fallback returns invalid font",
+          "[view][assets][coverage][phase3]") {
+    auto& mgr = AssetManager::instance();
+    mgr.set_font_fallback({});
+
+    auto font = mgr.font_for_family(make_unique_asset_name("missing-family"));
+    REQUIRE_FALSE(font.valid());
+}
+
 // ── Image Loading ───────────────────────────────────────────────────────────
 
 TEST_CASE("AssetManager load image from memory with PNG header", "[view][assets]") {
@@ -347,6 +428,28 @@ TEST_CASE("AssetManager load image from embedded", "[view][assets]") {
     REQUIRE(img.valid());
     REQUIRE(img.width == 4);
     REQUIRE(img.height == 4);
+}
+
+TEST_CASE("AssetManager embedded image loader reuses cached decode",
+          "[view][assets][coverage][phase3]") {
+    auto& mgr = AssetManager::instance();
+    mgr.clear_cache();
+
+    const auto name = make_unique_asset_name("embedded-image-cache");
+    auto first = make_png_header(2, 3);
+    auto second = make_png_header(9, 7);
+
+    mgr.register_embedded(name, first.data(), first.size());
+    auto image = mgr.load_image_embedded(name);
+    REQUIRE(image.valid());
+    REQUIRE(image.width == 2);
+    REQUIRE(image.height == 3);
+
+    mgr.register_embedded(name, second.data(), second.size());
+    auto cached = mgr.load_image_embedded(name);
+    REQUIRE(cached.valid());
+    REQUIRE(cached.width == 2);
+    REQUIRE(cached.height == 3);
 }
 
 // ── File I/O ────────────────────────────────────────────────────────────────
@@ -490,6 +593,52 @@ TEST_CASE("AssetManager blob from embedded", "[view][assets]") {
     auto blob = mgr.load_blob_embedded("test_json");
     REQUIRE(blob.valid());
     REQUIRE(blob.data.size() == sizeof(json_data) - 1);
+}
+
+TEST_CASE("AssetManager embedded blob loader returns cached bytes",
+          "[view][assets][coverage][phase3]") {
+    auto& mgr = AssetManager::instance();
+    mgr.clear_cache();
+
+    const auto name = make_unique_asset_name("embedded-blob-cache");
+    static const uint8_t first[] = {1, 2, 3, 4};
+    static const uint8_t second[] = {5, 6, 7, 8, 9};
+
+    mgr.register_embedded(name, first, sizeof(first));
+    auto blob = mgr.load_blob_embedded(name);
+    REQUIRE(blob.valid());
+    REQUIRE(blob.data == std::vector<uint8_t>(first, first + sizeof(first)));
+
+    mgr.register_embedded(name, second, sizeof(second));
+    auto cached = mgr.load_blob_embedded(name);
+    REQUIRE(cached.valid());
+    REQUIRE(cached.data == std::vector<uint8_t>(first, first + sizeof(first)));
+}
+
+TEST_CASE("AssetManager shrinking cache budget trims existing entries",
+          "[view][assets][coverage][phase3]") {
+    auto& mgr = AssetManager::instance();
+    const auto old_max = mgr.max_cache_size();
+    mgr.clear_cache();
+    mgr.set_max_cache_size(1024 * 1024);
+
+    const auto first_name = make_unique_asset_name("budget-first");
+    const auto second_name = make_unique_asset_name("budget-second");
+    static const uint8_t first[] = {1, 2, 3, 4};
+    static const uint8_t second[] = {5, 6, 7, 8};
+
+    mgr.register_embedded(first_name, first, sizeof(first));
+    mgr.register_embedded(second_name, second, sizeof(second));
+    REQUIRE(mgr.load_blob_embedded(first_name).valid());
+    REQUIRE(mgr.load_blob_embedded(second_name).valid());
+    REQUIRE(mgr.cache_usage() == sizeof(first) + sizeof(second));
+
+    mgr.set_max_cache_size(sizeof(first));
+    REQUIRE(mgr.cache_usage() <= sizeof(first));
+    REQUIRE(mgr.cache_count() <= 1);
+
+    mgr.clear_cache();
+    mgr.set_max_cache_size(old_max);
 }
 
 TEST_CASE("AssetManager blob file cache and misses", "[view][assets]") {

--- a/test/test_code_editor.cpp
+++ b/test/test_code_editor.cpp
@@ -108,6 +108,17 @@ TEST_CASE("CodeEditor insert appends in read-only fallback mode",
     REQUIRE(editor.selected_text().empty());
 }
 
+TEST_CASE("CodeEditor marker API is a stable no-op in native fallback mode",
+          "[gui][code-editor][coverage][phase3]") {
+    CodeEditor editor;
+    editor.set_text("alpha\nbeta");
+    editor.set_markers({{1, "warn"}, {2, "error"}});
+
+    REQUIRE(editor.text() == "alpha\nbeta");
+    REQUIRE(editor.cursor_line() == 1);
+    REQUIRE(editor.selected_text().empty());
+}
+
 TEST_CASE("CodeEditor go to line", "[gui][code-editor]") {
     CodeEditor editor;
     editor.set_text("line1\nline2\nline3");

--- a/test/test_phase9_widgets.cpp
+++ b/test/test_phase9_widgets.cpp
@@ -187,6 +187,55 @@ TEST_CASE("EqCurveView paint covers disabled grid and disabled band handles",
     REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::stroke_line) > 0);
 }
 
+TEST_CASE("EqCurveView set_band updates valid indices",
+          "[view][eq_curve][coverage][phase3]") {
+    EqCurveView eq;
+    eq.add_band({500.0f, -3.0f, 0.8f, EqCurveView::FilterType::peak, true});
+
+    EqCurveView::Band replacement{2000.0f, 4.0f, 1.5f, EqCurveView::FilterType::notch, true};
+    eq.set_band(0, replacement);
+
+    REQUIRE(eq.band_count() == 1);
+    REQUIRE_THAT(eq.bands()[0].frequency, WithinAbs(2000.0f, 0.001f));
+    REQUIRE_THAT(eq.bands()[0].gain_db, WithinAbs(4.0f, 0.001f));
+    REQUIRE_THAT(eq.bands()[0].q, WithinAbs(1.5f, 0.001f));
+    REQUIRE(eq.bands()[0].type == EqCurveView::FilterType::notch);
+}
+
+TEST_CASE("EqCurveView paint covers grid spectrum and enabled handles",
+          "[view][eq_curve][coverage][phase3]") {
+    EqCurveView eq;
+    eq.set_bounds({0, 0, 240, 120});
+    const float spectrum[] = {-18.0f, -12.0f, -24.0f, -6.0f};
+    eq.set_spectrum(spectrum, sizeof(spectrum) / sizeof(spectrum[0]));
+    eq.add_band({1000.0f, 6.0f, 1.0f, EqCurveView::FilterType::peak, true,
+                 Color::rgba8(240, 20, 20)});
+    eq.set_selected_band(0);
+
+    RecordingCanvas canvas;
+    eq.paint(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) > 1);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_line) > 200);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_circle) == 1);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_circle) == 1);
+    REQUIRE(has_fill_color(canvas, Color::rgba8(240, 20, 20)));
+}
+
+TEST_CASE("EqCurveView forwards rich mouse events to the base pointer hook",
+          "[view][eq_curve][coverage][phase3]") {
+    EqCurveView eq;
+    int forwarded = 0;
+    eq.on_pointer_event = [&](const MouseEvent& event) {
+        ++forwarded;
+        REQUIRE(event.pointer_id == 9);
+    };
+
+    eq.on_mouse_event(MouseEvent{{8, 9}, {8, 9}, MouseButton::left, 0, 9, 1, true});
+
+    REQUIRE(forwarded == 1);
+}
+
 // ── MidiKeyboard ────────────────────────────────────────────────────────────
 
 TEST_CASE("MidiKeyboard note state", "[view][midi_keyboard]") {
@@ -602,6 +651,17 @@ TEST_CASE("FileDropZone empty extensions accepts all", "[view][file_drop]") {
     REQUIRE(zone.is_drag_valid());
 }
 
+TEST_CASE("FileDropZone rejects extensionless files when extensions are required",
+          "[view][file_drop][coverage][phase3]") {
+    FileDropZone zone;
+    zone.set_accepted_extensions({".wav"});
+
+    zone.drag_enter({"README"});
+
+    REQUIRE(zone.is_drag_over());
+    REQUIRE_FALSE(zone.is_drag_valid());
+}
+
 TEST_CASE("FileDropZone paint reflects idle valid and invalid drag states",
           "[view][file_drop][coverage][issue-652]") {
     FileDropZone zone;
@@ -973,6 +1033,29 @@ TEST_CASE("PropertyList paints categories and scalar value variants",
     REQUIRE(canvas.count(pulp::canvas::DrawCommand::Type::fill_text) == 10);
 }
 
+TEST_CASE("PropertyList paints color values and selected row highlight",
+          "[view][property_list][coverage][phase3]") {
+    PropertyList list;
+    list.set_bounds({0, 0, 260, 100});
+    list.set_row_height(24.0f);
+    list.set_show_categories(false);
+    list.set_properties({
+        {"accent", "Accent", Color::rgba8(0x33, 0x66, 0x99), true, ""},
+        {"enabled", "Enabled", false, false, ""},
+    });
+
+    list.on_mouse_down({12, 10});
+
+    RecordingCanvas canvas;
+    list.paint(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rect) == 2);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) == 1);
+    REQUIRE(has_text(canvas, "#336699"));
+    REQUIRE(has_text(canvas, "false"));
+    REQUIRE(has_fill_color(canvas, Color::rgba8(0x33, 0x66, 0x99)));
+}
+
 // ── Breadcrumb ──────────────────────────────────────────────────────────────
 
 TEST_CASE("Breadcrumb push and pop", "[view][breadcrumb]") {
@@ -1126,4 +1209,23 @@ TEST_CASE("ThemeEditor covers missing selection empty theme and selected paint",
     REQUIRE(selected.count(pulp::canvas::DrawCommand::Type::stroke_rounded_rect) == 1);
     REQUIRE(selected.count(pulp::canvas::DrawCommand::Type::fill_text) == 3);
     REQUIRE(editor.export_json().find("accent.primary") != std::string::npos);
+}
+
+TEST_CASE("ThemeEditor wraps swatches when the row is full",
+          "[view][theme-editor][coverage][phase3]") {
+    ThemeEditor editor;
+    editor.set_bounds({0, 0, 80, 160});
+
+    Theme theme;
+    theme.colors["accent.primary"] = Color::rgba8(1, 2, 3);
+    theme.colors["accent.secondary"] = Color::rgba8(4, 5, 6);
+    theme.colors["bg.primary"] = Color::rgba8(7, 8, 9);
+    editor.set_theme(theme);
+
+    RecordingCanvas canvas;
+    editor.paint_all(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) == 3);
+    REQUIRE(canvas.count(DrawCommand::Type::fill_text) == 4);
+    REQUIRE(has_text(canvas, "Theme Editor"));
 }

--- a/test/test_phase9_widgets.cpp
+++ b/test/test_phase9_widgets.cpp
@@ -328,6 +328,38 @@ TEST_CASE("MidiKeyboard paint emits note names and active highlight color",
     REQUIRE(has_fill_color(canvas, Color::rgba8(255, 0, 0)));
 }
 
+TEST_CASE("MidiKeyboard forwards rich mouse events to the base pointer hook",
+          "[view][midi_keyboard][coverage][phase3]") {
+    MidiKeyboard kb;
+    int forwarded = 0;
+    Point last{};
+    kb.on_pointer_event = [&](const MouseEvent& event) {
+        ++forwarded;
+        last = event.position;
+    };
+
+    kb.on_mouse_event(MouseEvent{{12, 34}, {12, 34}, MouseButton::left, 0, 7, 1, true});
+
+    REQUIRE(forwarded == 1);
+    REQUIRE(last.x == 12.0f);
+    REQUIRE(last.y == 34.0f);
+}
+
+TEST_CASE("MidiKeyboard overlapping black keys win hit testing",
+          "[view][midi_keyboard][coverage][phase3]") {
+    MidiKeyboard kb;
+    kb.set_range(60, 61);
+    kb.set_bounds({0, 0, 100, 80});
+    std::vector<int> notes;
+    kb.on_note_on = [&](int note, float) { notes.push_back(note); };
+
+    kb.on_mouse_down({80, 20});
+
+    REQUIRE(notes == std::vector<int>{61});
+    REQUIRE(kb.is_note_on(61));
+    REQUIRE_FALSE(kb.is_note_on(60));
+}
+
 // ── ColorPicker ─────────────────────────────────────────────────────────────
 
 TEST_CASE("ColorPicker set/get color", "[view][color_picker]") {
@@ -446,6 +478,58 @@ TEST_CASE("ColorPicker paint positions alpha cursor from normalized alpha",
         REQUIRE(command.f[0] < 91.0f);
     }
     REQUIRE(found_alpha_cursor);
+}
+
+TEST_CASE("ColorPicker paint draws configured swatches",
+          "[view][color_picker][coverage][phase3]") {
+    ColorPicker picker;
+    picker.set_bounds({0, 0, 200, 260});
+    picker.set_swatches({
+        Color::rgba8(255, 0, 0),
+        Color::rgba8(0, 255, 0),
+        Color::rgba8(0, 0, 255),
+    });
+
+    RecordingCanvas canvas;
+    picker.paint(canvas);
+
+    REQUIRE(canvas.count(DrawCommand::Type::fill_rounded_rect) >= 5);
+    REQUIRE(canvas.count(DrawCommand::Type::stroke_rounded_rect) >= 4);
+    REQUIRE(has_fill_color(canvas, Color::rgba8(255, 0, 0)));
+    REQUIRE(has_fill_color(canvas, Color::rgba8(0, 255, 0)));
+    REQUIRE(has_fill_color(canvas, Color::rgba8(0, 0, 255)));
+}
+
+TEST_CASE("ColorPicker forwards rich mouse events to the base pointer hook",
+          "[view][color_picker][coverage][phase3]") {
+    ColorPicker picker;
+    int forwarded = 0;
+    picker.on_pointer_event = [&](const MouseEvent& event) {
+        ++forwarded;
+        REQUIRE(event.pointer_id == 3);
+        REQUIRE(event.is_down);
+    };
+
+    picker.on_mouse_event(MouseEvent{{1, 2}, {1, 2}, MouseButton::left, 0, 3, 1, true});
+
+    REQUIRE(forwarded == 1);
+}
+
+TEST_CASE("ColorPicker hidden alpha bar ignores alpha-region input",
+          "[view][color_picker][coverage][phase3]") {
+    ColorPicker picker;
+    picker.set_bounds({0, 0, 200, 280});
+    picker.set_show_alpha(false);
+    picker.set_hex("#33669980");
+    int changes = 0;
+    picker.on_change = [&](Color) { ++changes; };
+
+    picker.on_mouse_down({60, 212});
+    picker.on_mouse_drag({176, 212});
+    picker.on_mouse_up({176, 212});
+
+    REQUIRE(changes == 0);
+    REQUIRE(picker.hex() == "#33669980");
 }
 
 TEST_CASE("ColorPicker mode and outside mouse input are stable",
@@ -746,6 +830,20 @@ TEST_CASE("SplitView can replace panes and lays out with custom divider width",
     REQUIRE(split.second() == nullptr);
     split.layout_children();
     REQUIRE(split.first() == replacement_ptr);
+}
+
+TEST_CASE("SplitView forwards rich mouse events to the base pointer hook",
+          "[view][split_view][coverage][phase3]") {
+    SplitView split;
+    int forwarded = 0;
+    split.on_pointer_event = [&](const MouseEvent& event) {
+        ++forwarded;
+        REQUIRE(event.position.x == 5.0f);
+    };
+
+    split.on_mouse_event(MouseEvent{{5, 6}, {5, 6}, MouseButton::left, 0, 0, 1, true});
+
+    REQUIRE(forwarded == 1);
 }
 
 // ── PropertyList ────────────────────────────────────────────────────────────

--- a/test/test_theme.cpp
+++ b/test/test_theme.cpp
@@ -264,6 +264,17 @@ TEST_CASE("Theme from_json maps invalid hex digits to default color",
     REQUIRE(theme.color("bad.long").value() == Color{});
 }
 
+TEST_CASE("Theme from_json maps overflowing hex colors to default color",
+          "[view][theme][coverage][phase3]") {
+    auto theme = Theme::from_json(R"({
+        "colors": {
+            "bad.overflow": "#ffffffffffffffffffffffffffffffff"
+        }
+    })");
+
+    REQUIRE(theme.color("bad.overflow").value() == Color{});
+}
+
 TEST_CASE("Theme JSON parser covers optional sections and alpha colors",
           "[view][theme][coverage][issue-651]") {
     auto theme = Theme::from_json(R"({

--- a/test/test_theme_contrast.cpp
+++ b/test/test_theme_contrast.cpp
@@ -63,6 +63,12 @@ TEST_CASE("Min contrast thresholds are correct", "[view][contrast]") {
     REQUIRE_THAT(min_contrast_for_level(ContrastLevel::aaa_large), WithinAbs(4.5, 0.01));
 }
 
+TEST_CASE("Unknown contrast levels fall back to AA normal",
+          "[view][contrast][coverage][phase3]") {
+    auto invalid = static_cast<ContrastLevel>(99);
+    REQUIRE_THAT(min_contrast_for_level(invalid), WithinAbs(4.5, 0.01));
+}
+
 TEST_CASE("Contrast helpers clamp channel inputs",
           "[view][contrast][coverage][issue-651]") {
     auto below_black = Color::rgba(-1.0f, -0.5f, -0.25f);
@@ -146,6 +152,16 @@ TEST_CASE("Adjust for contrast preserves already compliant colors",
     REQUIRE_THAT(result->g, WithinAbs(foreground.g, 0.001));
     REQUIRE_THAT(result->b, WithinAbs(foreground.b, 0.001));
     REQUIRE_THAT(result->a, WithinAbs(foreground.a, 0.001));
+}
+
+TEST_CASE("Adjust for contrast returns nullopt when threshold is impossible",
+          "[view][contrast][coverage][phase3]") {
+    auto background = Color::rgba8(128, 128, 128);
+    auto foreground = Color::rgba8(128, 128, 128);
+
+    auto result = adjust_for_contrast(foreground, background, ContrastLevel::aaa_normal);
+
+    REQUIRE_FALSE(result.has_value());
 }
 
 // ── HSL Conversion ──────────────────────────────────────────────────────────
@@ -292,4 +308,18 @@ TEST_CASE("Theme contrast validation skips missing pairs and reports failures",
     REQUIRE(meets_contrast(*fixed.color("text.primary"),
                            *fixed.color("bg.primary"),
                            ContrastLevel::aa_normal));
+}
+
+TEST_CASE("Auto-fix leaves unresolved contrast issues unchanged",
+          "[view][contrast][theme][coverage][phase3]") {
+    Theme bad;
+    bad.colors["bg.primary"] = Color::rgba8(128, 128, 128);
+    bad.colors["text.primary"] = Color::rgba8(128, 128, 128);
+
+    auto fixed = auto_fix_contrast(bad, ContrastLevel::aaa_normal);
+
+    REQUIRE(fixed.color("text.primary").value() == bad.color("text.primary").value());
+    REQUIRE_FALSE(meets_contrast(*fixed.color("text.primary"),
+                                 *fixed.color("bg.primary"),
+                                 ContrastLevel::aaa_normal));
 }


### PR DESCRIPTION
## Summary
- add 24 focused view coverage tests across asset cache paths, EQ/property widgets, file drop handling, color picker, MIDI keyboard, split view, theme parsing, contrast, code editor, and theme editor
- cover cached embedded resource reads, widget pointer forwarding, selected-row paint, swatch wrapping, and invalid/fallback branches

## Local validation
- cmake --build build-coverage --target pulp-test-phase9-widgets pulp-test-asset-manager pulp-test-code-editor pulp-test-theme pulp-test-theme-contrast -j$(sysctl -n hw.ncpu)
- ./build-coverage/test/pulp-test-phase9-widgets
- ./build-coverage/test/pulp-test-asset-manager
- ./build-coverage/test/pulp-test-code-editor
- ./build-coverage/test/pulp-test-theme
- ./build-coverage/test/pulp-test-theme-contrast
- yamllint --no-warnings -d relaxed .github/workflows/
- python3 tools/import-validation/check-source-contracts.py --strict
- python3 tools/import-validation/test_source_contracts.py
- python3 tools/scripts/skill_sync_check.py --mode=report --base github/main
- python3 tools/scripts/version_bump_check.py --mode=report --base github/main

Note: local pre-push diff-cover was demoted because its configure step hit the known local mbedtls FetchContent checkout failure, not a test or coverage failure.