### PR TITLE
fix(view): defuse deferred mouseUp click after host teardown

### DIFF
--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <atomic>
 #include <iostream>
+#include <memory>   // pulp #2502 — shared_ptr liveness token for deferred clicks
 
 #ifdef PULP_HAS_SKIA
 #include <pulp/render/dirty_tracker.hpp>
@@ -111,11 +112,29 @@ static pulp::view::ModalOverlay* find_topmost_modal(pulp::view::View* root) {
 // point before hit_test. Set by WindowHost::set_design_viewport; nil
 // when no design viewport is in effect (identity).
 @property (nonatomic, copy) pulp::view::Point (^pointTransform)(pulp::view::Point);
+// pulp #2502 — the host destructor MUST call this before the View tree /
+// WidgetBridge / ScriptEngine the deferred-click blocks were built from can
+// be freed. It invalidates every still-queued `mouseUp:` deferred-click block
+// so none of them can run a `std::function` (`on_click` / `on_global_click`)
+// whose closure references freed bridge/engine state.
+- (void)prepareForTeardown;
 @end
 
 @implementation PulpView {
     pulp::view::View* _dragTarget;
     pulp::view::View* _focusedView;
+    // pulp #2502 — liveness token for `mouseUp:`'s deferred-click blocks.
+    // The block dispatched onto the main queue captures a COPY of this
+    // `shared_ptr`, which keeps the `atomic<bool>` alive independently of
+    // the PulpView. `prepareForTeardown` flips it to false; any block that
+    // later drains sees false and no-ops instead of invoking a
+    // `std::function` whose closure references a freed WidgetBridge /
+    // ScriptEngine. A `shared_ptr<atomic<bool>>` is used (rather than
+    // `dispatch_block_cancel`) because this file is compiled MRC and the
+    // deferred-click blocks must survive being copied onto the queue —
+    // `dispatch_block_create` blocks do not, and cancelling a non-dispatch
+    // block aborts.
+    std::shared_ptr<std::atomic<bool>> _deferredClickAlive;
 }
 
 - (instancetype)initWithFrame:(NSRect)frame {
@@ -127,8 +146,23 @@ static pulp::view::ModalOverlay* find_topmost_modal(pulp::view::View* root) {
         // never reflows on resize.
         self.autoresizesSubviews = YES;
         self.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+        _deferredClickAlive = std::make_shared<std::atomic<bool>>(true);
     }
     return self;
+}
+
+// pulp #2502 — invalidate every queued deferred-click block. After this
+// returns, any deferred-click block that later drains is a guaranteed no-op,
+// so it is safe for the owning View tree / WidgetBridge / ScriptEngine to be
+// destroyed. Invoked from the host destructors (`~MacWindowHost`,
+// `~MacGpuWindowHost`) which run synchronously in the same teardown step —
+// between a test's bridge going out of scope and the next run-loop pump — so
+// flipping the token here reliably defuses every block before it can fault.
+- (void)prepareForTeardown {
+    self.rootView = nullptr;
+    _dragTarget = nullptr;
+    if (_deferredClickAlive)
+        _deferredClickAlive->store(false);
 }
 
 - (BOOL)isFlipped { return NO; }
@@ -630,12 +664,47 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                     bubble->on_pointer_event(bme);
                 }
                 if (released_target == _dragTarget && (click_handler || global_click)) {
+                    // pulp #2502 — `click_handler` / `global_click` are
+                    // `std::function`s whose closures reference the
+                    // WidgetBridge / ScriptEngine that built them. Deferring
+                    // their invocation via a bare `dispatch_async` block left
+                    // an unbounded lifetime hazard: if the bridge/engine were
+                    // freed (e.g. a test-scoped owner going out of scope)
+                    // before the block drained, the block ran a dangling
+                    // closure → intermittent SIGSEGV.
+                    //
+                    // Fix: the deferred block captures a COPY of the view's
+                    // `_deferredClickAlive` liveness token (a
+                    // `shared_ptr<atomic<bool>>`). The copy keeps the
+                    // `atomic<bool>` alive even after the PulpView itself is
+                    // gone. `-prepareForTeardown` — called from the host
+                    // destructor before the bridge/engine can be freed, and
+                    // again from -dealloc — flips the token to false. The
+                    // teardown runs synchronously with no run-loop pump
+                    // between the bridge's destruction and the flip, so every
+                    // still-queued block is defused. A block that drains after
+                    // teardown sees `false` and no-ops WITHOUT touching `self`
+                    // or invoking the captured handlers. `self` is captured
+                    // unretained (this file is compiled MRC); that is safe
+                    // because every `self` deref is gated behind the
+                    // token-is-alive check.
+                    std::shared_ptr<std::atomic<bool>> aliveToken = _deferredClickAlive;
                     dispatch_async(dispatch_get_main_queue(), ^{
+                        // Defused after teardown: do not touch `self` or the
+                        // captured `std::function`s — their backing
+                        // WidgetBridge / ScriptEngine may already be freed.
+                        if (!aliveToken || !aliveToken->load())
+                            return;
                         @try {
                             try {
-                                if (click_handler) click_handler();
-                                if (global_click) global_click(clicked_id, modifiers);
-                                [self setNeedsDisplay:YES];
+                                // Token still alive ⇒ the host (and therefore
+                                // this view) has not been torn down. The extra
+                                // rootView guard rejects a detached view tree.
+                                if (self.rootView) {
+                                    if (click_handler) click_handler();
+                                    if (global_click) global_click(clicked_id, modifiers);
+                                    [self setNeedsDisplay:YES];
+                                }
                             } catch (const std::exception& e) {
                                 std::cerr << "MacWindowHost deferred click error: " << e.what() << "\n";
                             } catch (...) {
@@ -1239,6 +1308,10 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
 
 - (void)dealloc {
     [self.animationTimer invalidate];
+    // pulp #2502 — belt-and-suspenders: even if a host teardown path forgot
+    // to call -prepareForTeardown, cancel any still-queued deferred-click
+    // blocks here so a dangling block can never outlive this view.
+    [self prepareForTeardown];
 }
 
 @end
@@ -1634,6 +1707,12 @@ public:
     }
 
     ~MacWindowHost() override {
+        // pulp #2502 — cancel any queued deferred-click blocks before the
+        // root View tree / WidgetBridge / ScriptEngine they captured can be
+        // freed. This destructor runs synchronously, with no run-loop pump
+        // between here and the caller's earlier-destroyed bridge/engine, so
+        // cancelling now reliably catches every still-queued block.
+        [view_ prepareForTeardown];
         root_.set_window_host(nullptr);
         root_.set_frame_clock(nullptr);
     }
@@ -1823,6 +1902,10 @@ public:
         stop_display_link();
         skia_surface_.reset();
         gpu_surface_.reset();
+        // pulp #2502 — cancel any queued deferred-click blocks before the
+        // captured View tree / WidgetBridge / ScriptEngine can be freed.
+        // PulpMetalView inherits -prepareForTeardown from PulpView.
+        [metal_view_ prepareForTeardown];
         metal_view_.rootView = nullptr;
         root_.set_window_host(nullptr);
         root_.set_frame_clock(nullptr);

--- a/test/test_view_host_bridge_mac.mm
+++ b/test/test_view_host_bridge_mac.mm
@@ -449,4 +449,112 @@ TEST_CASE("PulpView NSEvent click bubbles up to ancestor on_click handler",
     }
 }
 
+// pulp #2502 — deferred-click `dispatch_async` block must not outlive the
+// WidgetBridge / ScriptEngine it captured.
+//
+// `-[PulpView mouseUp:]` defers click delivery onto the main queue (post-#992)
+// so a click handler that unmounts the clicked widget can't trip over its own
+// teardown. The deferred block captures `click_handler` / `global_click` —
+// `std::function`s whose closures reference the WidgetBridge / ScriptEngine
+// that wired them. Before the fix, if a test-scoped bridge/engine went out of
+// scope while the block was still queued, the next run-loop pump ran the block
+// against freed memory → intermittent SIGSEGV (~4/12 on untouched main).
+//
+// This test reproduces the exact early-teardown ordering: click to queue the
+// deferred block, then destroy the bridge/engine/host *without draining the
+// run loop* so the block is still queued, THEN pump the run loop. The host
+// destructor's `-prepareForTeardown` must cancel the queued block so the
+// pump runs it as a safe no-op instead of dereferencing a freed closure.
+TEST_CASE("PulpView deferred click is cancelled when bridge/engine are torn down first",
+          "[view][hosts][bridge][issue-2502]") {
+    @autoreleasepool {
+        [NSApplication sharedApplication];
+
+        // Stage the click + tear everything down inside an inner scope so the
+        // WidgetBridge, ScriptEngine, View tree, and WindowHost are all
+        // destroyed (in C++ reverse-declaration order: bridge, engine, host)
+        // before we pump the run loop below.
+        {
+            View root;
+            WindowOptions opts;
+            opts.title = "PulpView issue-2502";
+            opts.width = 200.0f;
+            opts.height = 100.0f;
+            opts.resizable = false;
+            opts.use_gpu = false;
+
+            auto host = WindowHost::create(root, opts);
+            REQUIRE(host != nullptr);
+            root.set_bounds({0, 0, 200, 100});
+
+            pulp::state::StateStore store;
+            pulp::view::ScriptEngine engine;
+            pulp::view::WidgetBridge bridge(engine, root, store);
+
+            // The click handler closure references `engine` (via the bridge's
+            // JS dispatch). Once `engine`/`bridge` are freed, invoking this
+            // `std::function` is a use-after-free.
+            bridge.load_script(R"(
+                var clicks = 0;
+                createCol('clear', '');
+                setFlex('clear', 'width', 200);
+                setFlex('clear', 'height', 100);
+                on('clear', 'click', function() { clicks += 1; });
+            )");
+            REQUIRE(bridge.widget("clear") != nullptr);
+
+            host->show();
+            auto* nswindow = (__bridge NSWindow*)host->native_window_handle();
+            REQUIRE(nswindow != nil);
+            auto* contentView = nswindow.contentView;
+            REQUIRE(contentView != nil);
+
+            for (int i = 0; i < 20; ++i) {
+                [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.005]];
+            }
+
+            const NSPoint local = NSMakePoint(40.0, 50.0);
+            const NSPoint window_pt = [contentView convertPoint:local toView:nil];
+
+            NSEvent* down = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                                               location:window_pt
+                                          modifierFlags:0
+                                              timestamp:0
+                                           windowNumber:nswindow.windowNumber
+                                                context:nil
+                                            eventNumber:0
+                                             clickCount:1
+                                               pressure:1.0];
+            NSEvent* up = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp
+                                             location:window_pt
+                                        modifierFlags:0
+                                            timestamp:0
+                                         windowNumber:nswindow.windowNumber
+                                              context:nil
+                                          eventNumber:0
+                                           clickCount:1
+                                             pressure:0.0];
+
+            // mouseUp queues the deferred-click block on the main queue.
+            // Deliberately DO NOT drain the run loop here — the block is
+            // still queued when this inner scope exits.
+            [contentView mouseDown:down];
+            REQUIRE_NOTHROW([contentView mouseUp:up]);
+
+            // Scope exit destroys bridge, engine, root, then host. The host
+            // destructor's -prepareForTeardown must cancel the still-queued
+            // deferred-click block here.
+        }
+
+        // Now pump the run loop. Before the fix, the still-queued block would
+        // run its captured `std::function` against the freed bridge/engine
+        // and SIGSEGV. After the fix the block is cancelled and no-ops.
+        for (int i = 0; i < 50; ++i) {
+            [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.005]];
+        }
+
+        SUCCEED("deferred click cancelled cleanly on early bridge/engine teardown");
+    }
+}
+
 #endif


### PR DESCRIPTION
## Summary

Fixes the intermittent SIGSEGV in the macOS view-host tests (#2502): the
deferred `mouseUp:` click block could outlive the WidgetBridge/ScriptEngine
it captured.

## Root cause

`-[PulpView mouseUp:]` defers click delivery onto the main queue via
`dispatch_async` (post-#992, so a handler that unmounts its own widget
can't trip over its teardown). That block captured the `on_click` /
`on_global_click` `std::function`s by value — closures whose state
references the `WidgetBridge` / `ScriptEngine` that wired them.

When those owners were freed before the block drained (a test-scoped
bridge/engine going out of scope at end-of-test), the next run-loop pump
ran the block against a dangling closure → intermittent SIGSEGV
(~4/12 on untouched `main`).

## Fix

Fixes the **production teardown path**, not just the test ordering:

- `PulpView` holds a `std::shared_ptr<std::atomic<bool>>` liveness token.
- The deferred block captures a *copy* of the token, keeping the atomic
  alive even after the view itself is gone, and no-ops without touching
  `self` or the handlers when the token is false.
- `~MacWindowHost`, `~MacGpuWindowHost`, and `-dealloc` all call
  `-prepareForTeardown`, which flips the token. The flip runs
  synchronously — no run-loop pump between an earlier-destroyed bridge and
  the flip — so every still-queued block is defused before it can fault,
  under any teardown ordering.
- A `shared_ptr<atomic<bool>>` is used rather than `dispatch_block_cancel`
  because this file is compiled MRC: a deferred block must survive being
  copied onto the queue, which `dispatch_block_create` blocks do not.

## Test plan

- [x] New regression test `[issue-2502]` in `test_view_host_bridge_mac.mm`
      reproduces the early-teardown ordering: click to queue the deferred
      block, destroy bridge/engine/host *without* draining the run loop,
      then pump the loop and assert no crash.
- [x] `pulp-test-view-host-bridge` — all 7 cases pass.
- [x] 30/30 clean loop runs of the full test binary (was intermittently
      crashing before the fix).
- [x] AddressSanitizer build green on the early-teardown test and 10/10
      clean loop runs of the full ASan binary.

Closes #2502

🤖 Generated with [Claude Code](https://claude.com/claude-code)