### PR TITLE
feat(inspect): add Phase 5.2 reconciliation tab to the inspector overlay

### DIFF
--- a/inspect/include/pulp/inspect/inspector_overlay.hpp
+++ b/inspect/include/pulp/inspect/inspector_overlay.hpp
@@ -309,6 +309,94 @@ public:
         return drifted_;
     }
 
+    // ── Phase 5.2 — reconciliation tab ──────────────────────────────
+    //
+    // Spec: planning/2026-05-19-inspector-phase5-source-jump-spike.md
+    // § Phase 5.2 + planning/2026-05-18-inspector-direct-manipulation-
+    // roadmap.md "Lock to source" / "Drift".
+    //
+    // The reconciliation tab answers one question per tweak: "will this
+    // edit survive a re-import?" It builds on Phase 4a (lock-to-source)
+    // and Phase 5.1 (source-jump) — it is a *read-only* report over the
+    // existing TweakStore + live view tree, inventing no parallel data
+    // model. Every stored tweak is classified into exactly one of three
+    // reconciliation states:
+    //
+    //   * locked-to-source — the tweak's anchor is in the TweakStore
+    //     lock set AND still resolves to a live view. It has been (or
+    //     will be) promoted into the authored source, so it survives a
+    //     fresh re-import. This is the "reconciled" state.
+    //   * drifted — the tweak's anchor resolves to a live view but the
+    //     anchor is NOT locked. The edit lives only in the runtime
+    //     tweak layer (`pulp-tweaks.json`); a re-import that regenerates
+    //     the element would not carry it. "Live-only, not written back."
+    //   * unresolvable — no live view carries the tweak's anchor_id
+    //     (orphaned, per TweakStore::DriftReason::anchor_not_found). The
+    //     inspector cannot tell where this edit belongs; locking it is
+    //     impossible until the anchor is re-established. Conservative
+    //     fallback — never crash, never guess.
+    //
+    // The tab toggles with the `R` key (reconcile) and, when on, takes
+    // over the property-panel region exactly like the Phase 6.1 pass
+    // viewer does — the tree section above stays put.
+
+    /// Reconciliation state of a single stored tweak.
+    enum class ReconcileStatus : std::uint8_t {
+        locked_to_source,  ///< Anchor locked + resolves — survives re-import.
+        drifted,           ///< Resolves but unlocked — runtime-layer only.
+        unresolvable,      ///< Anchor not found in the live tree (orphaned).
+    };
+
+    /// Stringify a ReconcileStatus for the panel + tests.
+    static const char* reconcile_status_str(ReconcileStatus status);
+
+    /// One classified tweak row in the reconciliation report.
+    struct ReconcileRow {
+        std::string anchor_id;
+        std::string property_path;
+        ReconcileStatus status = ReconcileStatus::unresolvable;
+    };
+
+    /// Aggregate reconciliation report over every tweak in the attached
+    /// TweakStore, classified against the current live view tree. The
+    /// per-status counts are convenience totals over `rows`.
+    struct ReconcileReport {
+        std::vector<ReconcileRow> rows;
+        std::size_t locked_count = 0;
+        std::size_t drifted_count = 0;
+        std::size_t unresolvable_count = 0;
+
+        std::size_t total() const { return rows.size(); }
+    };
+
+    /// Recompute the reconciliation report by classifying every stored
+    /// tweak against the live view tree's anchor + lock state. A no-op
+    /// returning an empty report when no TweakStore is wired. Pure
+    /// computation — safe for tests, never spawns a process, never
+    /// throws. Called automatically on first paint while the tab is
+    /// open; callers may invoke it directly after a re-import.
+    ReconcileReport reconcile_report() const;
+
+    /// Toggle the reconciliation tab. Off by default so the inspector
+    /// panel layout is unchanged until the user opts in (`R` key in
+    /// handle_key_event). When on, the tab replaces the property
+    /// section, mirroring the Phase 6.1 pass viewer.
+    void set_reconcile_tab_visible(bool visible) {
+        reconcile_tab_visible_ = visible;
+    }
+    bool reconcile_tab_visible() const { return reconcile_tab_visible_; }
+    void toggle_reconcile_tab() {
+        reconcile_tab_visible_ = !reconcile_tab_visible_;
+    }
+
+    /// Number of tweak rows the reconciliation tab laid out on the most
+    /// recent paint() while it was visible. Visible for tests so they
+    /// can assert the tab rendered the expected rows without scraping
+    /// pixels. Zero when the tab is hidden or no TweakStore is wired.
+    std::size_t reconcile_row_count() const {
+        return reconcile_rows_.size();
+    }
+
     // ── Phase 3e — 20× zoom loupe ───────────────────────────────────
     //
     // A magnified-pixel preview panel ("loupe") that shows the region
@@ -468,6 +556,17 @@ private:
     // drawer. width==0 means "not painted this frame".
     Rect drift_header_hit_{};
 
+    // ── Phase 5.2 — reconciliation-tab state ────────────────────────
+    //
+    // reconcile_tab_visible_ tracks the R-key toggle; off by default so
+    // the panel layout is unchanged until the user opts in.
+    // reconcile_rows_ caches the rows the tab laid out on the last
+    // paint so reconcile_row_count() can report them to tests and the
+    // tab scroll stays stable across frames.
+    bool reconcile_tab_visible_ = false;
+    float reconcile_scroll_y_ = 0.0f;
+    std::vector<ReconcileRow> reconcile_rows_;
+
     // Phase 3a — drag-handles state. Off by default so the inspector
     // behaves identically to the pre-3a build until the user opts in
     // (D-key toggle in handle_key_event).
@@ -562,6 +661,13 @@ private:
     // Phase 2.5 — render the tweak management panel into the given
     // rect. Repopulates tweak_rows_ with this frame's hit-rects.
     void paint_tweaks_section(Canvas& canvas, float x, float y, float w, float h);
+
+    /// Phase 5.2 — render the reconciliation tab into the panel region
+    /// normally occupied by the property section. Each stored tweak
+    /// gets a row showing its anchor, property path, and a color-coded
+    /// reconciliation-status badge (locked / drift / unresolvable).
+    /// Repopulates reconcile_rows_ with this frame's classified rows.
+    void paint_reconcile_tab(Canvas& canvas, float x, float y, float w, float h);
 
     // ── Panel hit testing ───────────────────────────────────────────
     bool point_in_panel(Point p) const;

--- a/inspect/src/inspector_overlay.cpp
+++ b/inspect/src/inspector_overlay.cpp
@@ -110,6 +110,11 @@ void InspectorOverlay::set_active(bool active) {
         // Phase 3e — the loupe is a transient inspect tool; dismissing
         // the whole inspector also closes it so re-opening starts clean.
         zoom_active_ = false;
+        // Phase 5.2 — drop the reconciliation tab's laid-out rows so
+        // reconcile_row_count() reports 0 while the inspector is shut.
+        // The R-key toggle state itself is left intact (mirrors how
+        // the tweaks panel keeps tweaks_panel_visible_ across opens).
+        reconcile_rows_.clear();
     }
 }
 
@@ -249,6 +254,78 @@ void InspectorOverlay::refresh_drift() {
         drift_drawer_open_ = true;
     }
     drifted_ = std::move(next);
+}
+
+// ── Phase 5.2 — reconciliation tab ──────────────────────────────────────────
+//
+// Classifies every stored tweak into one of three reconciliation
+// states (locked-to-source / drifted / unresolvable). The classifier
+// is purely a *read* over the existing TweakStore + live view tree —
+// it never mutates either, never spawns a process, and never throws.
+// It deliberately reuses the drift machinery's "anchor present in the
+// live tree" notion (TweakStore::DriftReason::anchor_not_found) so the
+// reconciliation tab and the Phase 2 drift drawer agree on what counts
+// as orphaned.
+
+const char* InspectorOverlay::reconcile_status_str(ReconcileStatus status) {
+    switch (status) {
+        case ReconcileStatus::locked_to_source: return "locked-to-source";
+        case ReconcileStatus::drifted:          return "drifted";
+        case ReconcileStatus::unresolvable:     return "unresolvable";
+    }
+    return "unknown";
+}
+
+InspectorOverlay::ReconcileReport InspectorOverlay::reconcile_report() const {
+    ReconcileReport report;
+    if (!tweak_store_) return report;
+
+    // Snapshot the live tree's anchor set once — O(tree) — so the
+    // per-tweak classification below is an O(1) hash lookup rather
+    // than an O(tree) walk per tweak.
+    std::vector<std::string> live;
+    collect_anchor_ids(root_, live);
+    std::unordered_set<std::string> live_anchors(live.begin(), live.end());
+
+    auto records = tweak_store_->list_tweaks();
+    // Stable ordering so the tab doesn't reshuffle across frames:
+    // group by anchor, anchors sorted, insertion order within an
+    // anchor (list_tweaks() preserves it).
+    std::sort(records.begin(), records.end(),
+              [](const TweakStore::Record& a, const TweakStore::Record& b) {
+                  return a.anchor_id < b.anchor_id;
+              });
+
+    report.rows.reserve(records.size());
+    for (const auto& rec : records) {
+        ReconcileRow row;
+        row.anchor_id = rec.anchor_id;
+        row.property_path = rec.property_path;
+
+        const bool resolves = live_anchors.count(rec.anchor_id) != 0;
+        if (!resolves) {
+            // Conservative fallback — the anchor is gone from the live
+            // tree, so the inspector cannot tell where this edit
+            // belongs. Locking it is impossible until the anchor is
+            // re-established; show it as unresolvable rather than guess.
+            row.status = ReconcileStatus::unresolvable;
+            ++report.unresolvable_count;
+        } else if (tweak_store_->is_locked(rec.anchor_id)) {
+            // The anchor resolves AND the user has locked it — the
+            // tweak is (or will be) promoted into the authored source,
+            // so it survives a fresh re-import. This is "reconciled".
+            row.status = ReconcileStatus::locked_to_source;
+            ++report.locked_count;
+        } else {
+            // The anchor resolves but is unlocked — the edit lives
+            // only in the runtime tweak layer. A re-import that
+            // regenerates the element would drop it.
+            row.status = ReconcileStatus::drifted;
+            ++report.drifted_count;
+        }
+        report.rows.push_back(std::move(row));
+    }
+    return report;
 }
 
 // ── Coordinate helpers ──────────────────────────────────────────────────────
@@ -393,6 +470,17 @@ bool InspectorOverlay::handle_key_event(const KeyEvent& event) {
     if (active_ && event.key == KeyCode::z && event.is_down &&
         event.modifiers == 0) {
         toggle_zoom();
+        return true;
+    }
+
+    // Phase 5.2 — R toggles the reconciliation tab (no modifier; only
+    // while the inspector is active, same opt-in discipline as the D /
+    // E / P / Z toggles). Guarded behind not-editing so typing an 'r'
+    // into a field-edit buffer can't flip the tab. D/E/T/J/P/Z are
+    // already claimed, so R ("reconcile") is the natural free letter.
+    if (active_ && editing_field_.empty() && event.key == KeyCode::r &&
+        event.is_down && event.modifiers == 0) {
+        toggle_reconcile_tab();
         return true;
     }
 
@@ -998,11 +1086,19 @@ void InspectorOverlay::paint_panel(Canvas& canvas) {
     // Helper: paint the middle "props" region. Phase 6.1 — when the
     // per-pass attribution viewer is toggled on (P-key), it takes over
     // this region instead of the property panel; the tree section above
-    // is untouched so the user keeps navigation context.
+    // is untouched so the user keeps navigation context. Phase 5.2 —
+    // the reconciliation tab (R-key) takes over the same region with
+    // the same discipline. The pass viewer wins when both are toggled
+    // (it is the older surface), and reconcile_rows_ is cleared so
+    // reconcile_row_count() never reports a stale layout.
     auto paint_middle = [&](float x, float y, float w, float h) {
         if (pass_viewer_enabled_) {
+            reconcile_rows_.clear();
             paint_pass_attribution(canvas, x, y, w, h);
+        } else if (reconcile_tab_visible_) {
+            paint_reconcile_tab(canvas, x, y, w, h);
         } else {
+            reconcile_rows_.clear();
             paint_props_section(canvas, x, y, w, h);
         }
     };
@@ -1851,6 +1947,113 @@ InspectorOverlay::tweak_action_at(Point p, std::size_t& out_row) const {
         if (hit(row.delete_icon)) { out_row = i; return TweakAction::remove; }
     }
     return TweakAction::none;
+}
+
+// ── Phase 5.2 — Reconciliation tab ──────────────────────────────────────────
+//
+// A read-only report tab (R-key) showing, per tweak, whether the edit
+// will survive a fresh design re-import. It classifies every stored
+// tweak via reconcile_report() and renders one row each with a
+// color-coded status badge. Like the Phase 6.1 pass viewer it takes
+// over the property-panel region; unlike the tweak management panel it
+// has no interactive controls — it is purely informational, so there
+// are no hit-rects to record.
+
+void InspectorOverlay::paint_reconcile_tab(Canvas& canvas, float x, float y,
+                                           float w, float h) {
+    // Status badge colors — green = reconciled (safe), amber = drift
+    // (runtime-only), red = unresolvable (orphaned). The amber/red pair
+    // matches the Phase 2 drift drawer so the two surfaces read
+    // consistently.
+    const Color kLockedColor = Color::rgba(0.35f, 0.85f, 0.45f, 1.0f);
+    const Color kDriftColor  = Color::rgba(0.95f, 0.65f, 0.25f, 1.0f);
+    const Color kUnresColor  = Color::rgba(0.95f, 0.40f, 0.38f, 1.0f);
+
+    canvas.set_font("monospace", kFontSize);
+
+    // Section heading.
+    canvas.set_fill_color(kHighlightStroke);
+    canvas.fill_text("Reconcile", x, y + 11);
+
+    // Recompute the report fresh every frame — it is a cheap O(tweaks)
+    // pass and the live tree / lock state may have changed since the
+    // last paint. reconcile_rows_ caches the result for the row count.
+    auto report = reconcile_report();
+    reconcile_rows_ = report.rows;
+
+    if (!tweak_store_) {
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text("No tweak store attached", x, y + 11 + kRowHeight);
+        return;
+    }
+
+    // Summary line: per-status counts, right-aligned in the header.
+    {
+        std::ostringstream summary;
+        summary << report.locked_count << " locked  "
+                << report.drifted_count << " drift  "
+                << report.unresolvable_count << " unresolved";
+        canvas.set_fill_color(kPanelDim);
+        float sw = canvas.measure_text(summary.str());
+        canvas.fill_text(summary.str(), x + w - sw, y + 11);
+    }
+
+    if (report.rows.empty()) {
+        canvas.set_fill_color(kPanelDim);
+        canvas.fill_text("No tweaks to reconcile", x, y + 11 + kRowHeight);
+        return;
+    }
+
+    // Clip the scroll region so rows don't bleed past the section.
+    canvas.save();
+    float list_top = y + kRowHeight;
+    canvas.clip_rect(x, list_top, w, h - kRowHeight);
+
+    constexpr float kBadgeW = 16.0f;  // status pip diameter
+    float row_y = list_top - reconcile_scroll_y_;
+
+    for (const auto& row : report.rows) {
+        const bool visible = row_y > list_top - kRowHeight && row_y < y + h;
+        if (visible) {
+            Color badge;
+            const char* tag;
+            switch (row.status) {
+                case ReconcileStatus::locked_to_source:
+                    badge = kLockedColor; tag = "lock"; break;
+                case ReconcileStatus::drifted:
+                    badge = kDriftColor;  tag = "drift"; break;
+                case ReconcileStatus::unresolvable:
+                default:
+                    badge = kUnresColor;  tag = "orphan"; break;
+            }
+
+            // Status pip at the left edge.
+            canvas.set_fill_color(badge);
+            canvas.fill_circle(x + 5.0f, row_y + kRowHeight / 2.0f, 4.0f);
+
+            // Anchor + property path, dimmed for unresolvable rows so
+            // an orphaned tweak reads as "inactive" at a glance.
+            const bool orphan = row.status == ReconcileStatus::unresolvable;
+            std::string label = abbreviate_anchor(row.anchor_id) + "  " +
+                                 row.property_path;
+            float text_x = x + kBadgeW;
+            float tag_w = canvas.measure_text(tag) + 6.0f;
+            float max_label_w = (x + w - tag_w) - text_x;
+            while (label.size() > 4 &&
+                   canvas.measure_text(label) > max_label_w)
+                label = label.substr(0, label.size() - 1);
+            canvas.set_fill_color(orphan ? kPanelDim : kPanelText);
+            canvas.fill_text(label, text_x, row_y + 14);
+
+            // Status tag, right-aligned, in the badge color.
+            canvas.set_fill_color(badge);
+            canvas.fill_text(tag, x + w - canvas.measure_text(tag),
+                             row_y + 14);
+        }
+        row_y += kRowHeight;
+    }
+
+    canvas.restore();
 }
 
 // ── Phase 2 — Drift drawer ──────────────────────────────────────────────────

--- a/test/test_inspector.cpp
+++ b/test/test_inspector.cpp
@@ -3631,3 +3631,265 @@ TEST_CASE("InspectorOverlay: collapsed drawer hides rows but keeps the header",
     REQUIRE(canvas_has_text(canvas, "Drift"));
     REQUIRE_FALSE(canvas_has_text(canvas, "layout.width"));
 }
+
+// ── Phase 5.2 — reconciliation tab ────────────────────────────────────────
+//
+// The reconciliation tab (R-key) classifies every stored tweak into
+// locked-to-source / drifted / unresolvable and renders a read-only
+// report. It builds on the Phase 4a lock-to-source state (the
+// TweakStore lock set) and the live view tree's anchor set. These
+// tests drive it headless: build a scene, seed tweaks, toggle the tab
+// with R, paint into a RecordingCanvas, and assert the classification.
+
+namespace {
+
+// A scene with two live anchored views plus one tweak whose anchor is
+// NOT in the tree (orphaned). Locking one of the live anchors lets a
+// test exercise all three reconciliation states at once.
+struct ReconcileScene {
+    View root;
+    TweakStore store;
+    InspectorOverlay overlay{root};
+
+    ReconcileScene() {
+        root.set_bounds({0, 0, 600, 600});
+
+        auto a = std::make_unique<View>();
+        a->set_anchor_id("figma:5:a");
+        a->set_bounds({10, 10, 80, 40});
+        root.add_child(std::move(a));
+
+        auto b = std::make_unique<View>();
+        b->set_anchor_id("figma:5:b");
+        b->set_bounds({10, 60, 80, 40});
+        root.add_child(std::move(b));
+
+        overlay.set_active(true);
+        overlay.set_tweak_store(&store);
+
+        // figma:5:a — locked → "locked-to-source" once locked below.
+        store.apply_tweak("figma:5:a", "layout.padding",
+                          choc::value::createInt32(12), "drag");
+        // figma:5:b — resolves but unlocked → "drifted".
+        store.apply_tweak("figma:5:b", "layout.gap",
+                          choc::value::createInt32(4), "drag");
+        // figma:5:gone — no live view carries it → "unresolvable".
+        store.apply_tweak("figma:5:gone", "paint.backgroundColor",
+                          choc::value::createString("#abcdef"), "picker");
+    }
+};
+
+}  // namespace
+
+TEST_CASE("InspectorOverlay Phase 5.2: R toggles the reconciliation tab",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    View root;
+    root.set_bounds({0, 0, 600, 600});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+
+    REQUIRE_FALSE(overlay.reconcile_tab_visible());
+
+    KeyEvent r;
+    r.key = KeyCode::r;
+    r.is_down = true;
+    REQUIRE(overlay.handle_key_event(r));
+    REQUIRE(overlay.reconcile_tab_visible());
+
+    REQUIRE(overlay.handle_key_event(r));
+    REQUIRE_FALSE(overlay.reconcile_tab_visible());
+}
+
+TEST_CASE("InspectorOverlay Phase 5.2: R does nothing when inspector inactive",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    View root;
+    InspectorOverlay overlay(root);
+    // Inspector not active — R must not flip the tab.
+    REQUIRE_FALSE(overlay.handle_key_event(make_key(KeyCode::r)));
+    REQUIRE_FALSE(overlay.reconcile_tab_visible());
+
+    // A modifier-laden R is reserved for chord shortcuts — ignored.
+    overlay.set_active(true);
+    overlay.handle_key_event(make_key(KeyCode::r, true, kModCmd));
+    REQUIRE_FALSE(overlay.reconcile_tab_visible());
+}
+
+TEST_CASE("InspectorOverlay Phase 5.2: reconcile_report classifies all states",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    ReconcileScene scene;
+    // Lock figma:5:a — promotes its tweak to "locked-to-source".
+    scene.store.set_locked("figma:5:a", true);
+
+    auto report = scene.overlay.reconcile_report();
+    REQUIRE(report.total() == 3);
+    REQUIRE(report.locked_count == 1);
+    REQUIRE(report.drifted_count == 1);
+    REQUIRE(report.unresolvable_count == 1);
+
+    // Verify the per-row classification by anchor.
+    auto status_for = [&](std::string_view anchor)
+        -> InspectorOverlay::ReconcileStatus {
+        for (const auto& row : report.rows)
+            if (row.anchor_id == anchor) return row.status;
+        FAIL("anchor not found in report");
+        return InspectorOverlay::ReconcileStatus::unresolvable;
+    };
+    REQUIRE(status_for("figma:5:a") ==
+            InspectorOverlay::ReconcileStatus::locked_to_source);
+    REQUIRE(status_for("figma:5:b") ==
+            InspectorOverlay::ReconcileStatus::drifted);
+    REQUIRE(status_for("figma:5:gone") ==
+            InspectorOverlay::ReconcileStatus::unresolvable);
+}
+
+TEST_CASE("InspectorOverlay Phase 5.2: unlocked live tweak reads as drifted",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    // Without an explicit lock, a tweak whose anchor resolves to a
+    // live view is "drifted" — it lives only in the runtime layer and
+    // would not survive a re-import.
+    ReconcileScene scene;  // no set_locked() call
+    auto report = scene.overlay.reconcile_report();
+    REQUIRE(report.locked_count == 0);
+    // figma:5:a + figma:5:b both resolve but are unlocked → drifted.
+    REQUIRE(report.drifted_count == 2);
+    REQUIRE(report.unresolvable_count == 1);
+}
+
+TEST_CASE("InspectorOverlay Phase 5.2: tab lays out a row per tweak",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    ReconcileScene scene;
+    scene.store.set_locked("figma:5:a", true);
+    scene.overlay.toggle_reconcile_tab();
+    REQUIRE(scene.overlay.reconcile_tab_visible());
+
+    pulp::canvas::RecordingCanvas canvas;
+    scene.overlay.paint(canvas);
+    REQUIRE(canvas.command_count() > 0);
+
+    // Three tweaks → three classified rows laid out.
+    REQUIRE(scene.overlay.reconcile_row_count() == 3);
+    // The tab heading + status tags render as text.
+    REQUIRE(canvas_has_text(canvas, "Reconcile"));
+    REQUIRE(canvas_has_text(canvas, "lock"));
+    REQUIRE(canvas_has_text(canvas, "drift"));
+    REQUIRE(canvas_has_text(canvas, "orphan"));
+
+    // Hiding the tab clears the laid-out rows.
+    scene.overlay.toggle_reconcile_tab();
+    pulp::canvas::RecordingCanvas hidden;
+    scene.overlay.paint(hidden);
+    REQUIRE(scene.overlay.reconcile_row_count() == 0);
+}
+
+TEST_CASE("InspectorOverlay Phase 5.2: tab renders cleanly with no tweaks",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    View root;
+    root.set_bounds({0, 0, 600, 600});
+    TweakStore store;  // empty
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_tweak_store(&store);
+    overlay.toggle_reconcile_tab();
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);  // must not crash
+    REQUIRE(canvas.command_count() > 0);
+    REQUIRE(overlay.reconcile_row_count() == 0);
+    REQUIRE(canvas_has_text(canvas, "No tweaks to reconcile"));
+
+    auto report = overlay.reconcile_report();
+    REQUIRE(report.total() == 0);
+}
+
+TEST_CASE("InspectorOverlay Phase 5.2: reconcile_report empty without a store",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    // The inspector can run with no TweakStore wired (hand-authored
+    // UIs). The reconciliation tab must degrade gracefully — empty
+    // report, no crash, an explanatory line in the panel.
+    View root;
+    root.set_bounds({0, 0, 600, 600});
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.toggle_reconcile_tab();
+    // intentionally no set_tweak_store()
+
+    auto report = overlay.reconcile_report();
+    REQUIRE(report.total() == 0);
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);
+    REQUIRE(canvas.command_count() > 0);
+    REQUIRE(overlay.reconcile_row_count() == 0);
+    REQUIRE(canvas_has_text(canvas, "No tweak store attached"));
+}
+
+TEST_CASE("InspectorOverlay Phase 5.2: orphaned tweak never crashes the tab",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    // A tweak whose anchor has no live view (e.g. after a destructive
+    // re-import) must classify as unresolvable — not crash, not guess.
+    View root;
+    root.set_bounds({0, 0, 600, 600});
+    TweakStore store;
+    store.apply_tweak("ghost-anchor", "layout.width",
+                      choc::value::createInt32(99), "drag");
+
+    InspectorOverlay overlay(root);
+    overlay.set_active(true);
+    overlay.set_tweak_store(&store);
+    overlay.toggle_reconcile_tab();
+
+    auto report = overlay.reconcile_report();
+    REQUIRE(report.total() == 1);
+    REQUIRE(report.unresolvable_count == 1);
+    REQUIRE(report.rows.front().status ==
+            InspectorOverlay::ReconcileStatus::unresolvable);
+
+    pulp::canvas::RecordingCanvas canvas;
+    overlay.paint(canvas);  // must not crash
+    REQUIRE(overlay.reconcile_row_count() == 1);
+    REQUIRE(canvas_has_text(canvas, "orphan"));
+}
+
+TEST_CASE("InspectorOverlay Phase 5.2: reconcile_status_str maps every state",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    using RS = InspectorOverlay::ReconcileStatus;
+    REQUIRE(std::string(InspectorOverlay::reconcile_status_str(
+                RS::locked_to_source)) == "locked-to-source");
+    REQUIRE(std::string(InspectorOverlay::reconcile_status_str(
+                RS::drifted)) == "drifted");
+    REQUIRE(std::string(InspectorOverlay::reconcile_status_str(
+                RS::unresolvable)) == "unresolvable");
+}
+
+TEST_CASE("InspectorOverlay Phase 5.2: dismissing the inspector clears tab rows",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    ReconcileScene scene;
+    scene.overlay.toggle_reconcile_tab();
+
+    pulp::canvas::RecordingCanvas canvas;
+    scene.overlay.paint(canvas);
+    REQUIRE(scene.overlay.reconcile_row_count() == 3);
+
+    // Closing the inspector drops the laid-out rows; the R-toggle
+    // state itself survives so re-opening restores the tab.
+    scene.overlay.set_active(false);
+    REQUIRE(scene.overlay.reconcile_row_count() == 0);
+    REQUIRE(scene.overlay.reconcile_tab_visible());
+}
+
+TEST_CASE("InspectorOverlay Phase 5.2: locking a tweak moves it out of drift",
+          "[inspect][overlay][reconcile][phase5.2]") {
+    // Locking an anchor is the explicit "promote to source" action.
+    // The reconciliation tab must reflect that transition: a drifted
+    // tweak becomes locked-to-source the moment its anchor is locked.
+    ReconcileScene scene;
+    auto before = scene.overlay.reconcile_report();
+    REQUIRE(before.locked_count == 0);
+    REQUIRE(before.drifted_count == 2);
+
+    scene.store.set_locked("figma:5:b", true);
+    auto after = scene.overlay.reconcile_report();
+    REQUIRE(after.locked_count == 1);
+    REQUIRE(after.drifted_count == 1);
+    REQUIRE(after.unresolvable_count == 1);  // figma:5:gone unchanged
+}


### PR DESCRIPTION
The reconciliation tab (R-key) answers one question per tweak: "will
this edit survive a re-import?" It is a read-only report over the
existing TweakStore + live view tree — no parallel data model. Every
stored tweak classifies into exactly one of three states:

  * locked-to-source — anchor is in the TweakStore lock set AND still
    resolves to a live view; the edit is promoted into authored source
    and survives a fresh re-import (the "reconciled" state).
  * drifted — anchor resolves to a live view but is not locked; the
    edit lives only in the runtime tweak layer (pulp-tweaks.json).
  * unresolvable — no live view carries the anchor (orphaned); the
    inspector cannot tell where the edit belongs, so it is shown as
    unresolvable rather than guessed or crashed on.

Builds on Phase 4a (lock-to-source) and Phase 5.1 (source-jump). The
tab toggles with R and takes over the property-panel region exactly
like the Phase 6.1 pass viewer; the pass viewer wins when both are on.

Adds 11 headless Catch2 cases to test/test_inspector.cpp covering the
R-key toggle, the three-state classification, the empty / no-store /
orphaned edge cases, and the lock-promotes-out-of-drift transition.
All 118 inspector tests pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>