### PR TITLE
refactor(view): split window_host_mac geometry helpers into sibling TU (R2-5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(Pulp
-    VERSION 0.180.0
+    VERSION 0.180.4
     DESCRIPTION "Cross-platform audio plugin and application framework"
     HOMEPAGE_URL "https://github.com/danielraffel/pulp"
     LANGUAGES CXX C

--- a/core/view/CMakeLists.txt
+++ b/core/view/CMakeLists.txt
@@ -408,6 +408,7 @@ if(APPLE)
         target_sources(pulp-view PRIVATE
             platform/mac/window_host_mac.mm
             platform/mac/window_host_mac_capture.mm
+            platform/mac/window_host_mac_geometry.mm
             platform/mac/window_manager_mac.mm
             platform/mac/plugin_view_host_mac.mm
             platform/mac/screenshot_mac.mm

--- a/core/view/platform/mac/window_host_mac.mm
+++ b/core/view/platform/mac/window_host_mac.mm
@@ -7,6 +7,7 @@
 #include <pulp/view/modal.hpp>
 
 #include "window_host_mac_capture.h"
+#include "window_host_mac_internal.hpp"
 #include <pulp/view/widget_bridge.hpp>
 
 #include <TargetConditionals.h>
@@ -63,15 +64,13 @@ static bool s_cursor_hidden = false;
 
 @end
 
-static void request_app_close(NSWindow* window) {
-    NSWindow* target = window != nil ? window : [NSApp keyWindow];
-    if (target == nil) target = [NSApp mainWindow];
-    if (target != nil) {
-        [target performClose:nil];
-    } else {
-        [NSApp stop:nil];
-    }
-}
+// request_app_close, find_topmost_modal, configure_window_type, the
+// child-view geometry helpers, and the coordinate / event-translation
+// helpers (modifiers_from_ns_flags, to_local, view_is_in_tree,
+// key_code_from_ns) were extracted to window_host_mac_geometry.mm in
+// the R2-5 refactor — see window_host_mac_internal.hpp. Used here via
+// the `pulp::view::mac_geometry` namespace.
+using namespace pulp::view::mac_geometry;
 
 static void install_app_menu(NSString* appName) {
     NSMenu* menuBar = [[NSMenu alloc] init];
@@ -88,18 +87,6 @@ static void install_app_menu(NSString* appName) {
     [appMenu addItem:quitItem];
     [appItem setSubmenu:appMenu];
 }
-
-static pulp::view::ModalOverlay* find_topmost_modal(pulp::view::View* root) {
-    if (!root || !root->visible()) return nullptr;
-
-    for (size_t i = root->child_count(); i > 0; --i) {
-        if (auto* modal = find_topmost_modal(root->child_at(i - 1)))
-            return modal;
-    }
-
-    return dynamic_cast<pulp::view::ModalOverlay*>(root);
-}
-
 
 // ── PulpView: CoreGraphics NSView (CPU rendering path) ───────────────────────
 
@@ -271,82 +258,6 @@ static pulp::view::ModalOverlay* find_topmost_modal(pulp::view::View* root) {
     [self setNeedsDisplay:YES];
 }
 
-static uint16_t modifiersFromNSFlags(NSEventModifierFlags flags) {
-    uint16_t m = 0;
-    if (flags & NSEventModifierFlagShift)   m |= pulp::view::kModShift;
-    if (flags & NSEventModifierFlagControl) m |= pulp::view::kModCtrl;
-    if (flags & NSEventModifierFlagOption)  m |= pulp::view::kModAlt;
-    if (flags & NSEventModifierFlagCommand) m |= pulp::view::kModCmd;
-    return m;
-}
-
-static pulp::view::Point toLocal(pulp::view::Point pos, pulp::view::View* target, pulp::view::View* root) {
-    // pulp-internal #69 — convert window-space `pos` into `target`'s
-    // local-pre-scale coordinates, accounting for any ancestor's
-    // set_scale transform. The forward render chain is:
-    //   visual_pos = sum over ancestors A of (A.bounds * scale_chain_above_A)
-    //              + (target_local * scale_chain_above_target)
-    // Inverse: walk root→target, peel off each ancestor's offset
-    // (scaled by the chain above it), then divide the residual by the
-    // final scale_chain to get target-local coords.
-    std::vector<pulp::view::View*> chain;
-    for (auto* v = target; v && v != root; v = v->parent()) chain.push_back(v);
-    // chain is target..root_child. Reverse to root_child..target.
-    std::reverse(chain.begin(), chain.end());
-    auto local = pos;
-    float scale_chain = 1.0f;  // accumulated scale from root down to current ancestor
-    for (auto* v : chain) {
-        local.x -= v->bounds().x * scale_chain;
-        local.y -= v->bounds().y * scale_chain;
-        scale_chain *= v->scale();
-    }
-    if (scale_chain != 0.0f && scale_chain != 1.0f) {
-        local.x /= scale_chain;
-        local.y /= scale_chain;
-    }
-    return local;
-}
-
-// pulp #992 — confirm a cached View* is still attached to the live tree
-// before any dereference. Walks `root` and compares pointers only, so it's
-// safe to call with `needle` pointing into freed memory. Returns false if
-// `needle` was unparented or destroyed between the cached capture (e.g. at
-// mouseDown) and the next event (e.g. mouseUp). Does NOT detect the ABA
-// case where memory was freed and reused at the same address — see #992
-// follow-up issue if profiling shows that's hit; for now a tree walk
-// catches the React-unmount-during-click pattern that actually crashes.
-static bool view_is_in_tree(pulp::view::View* needle, pulp::view::View* root) {
-    if (!needle || !root) return false;
-    if (needle == root) return true;
-    for (size_t i = 0; i < root->child_count(); ++i) {
-        if (view_is_in_tree(needle, root->child_at(i))) return true;
-    }
-    return false;
-}
-
-static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
-    using KC = pulp::view::KeyCode;
-    switch (code) {
-        case 0: return KC::a; case 1: return KC::s; case 2: return KC::d;
-        case 3: return KC::f; case 4: return KC::h; case 5: return KC::g;
-        case 6: return KC::z; case 7: return KC::x; case 8: return KC::c;
-        case 9: return KC::v; case 11: return KC::b; case 12: return KC::q;
-        case 13: return KC::w; case 14: return KC::e; case 15: return KC::r;
-        case 16: return KC::y; case 17: return KC::t; case 31: return KC::o;
-        case 32: return KC::u; case 34: return KC::i; case 35: return KC::p;
-        case 37: return KC::l; case 38: return KC::j; case 40: return KC::k;
-        case 45: return KC::n; case 46: return KC::m;
-        case 36: return KC::enter; case 53: return KC::escape;
-        case 48: return KC::tab; case 51: return KC::backspace;
-        case 117: return KC::delete_;
-        case 123: return KC::left; case 124: return KC::right;
-        case 125: return KC::down; case 126: return KC::up;
-        case 115: return KC::home; case 119: return KC::end_;
-        case 49: return KC::space;
-        default: return KC::unknown;
-    }
-}
-
 - (void)mouseDown:(NSEvent*)event {
     @try {
         try {
@@ -375,7 +286,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
 
         // Inspector intercept — consume clicks when inspector is active
         {
-            auto mods = modifiersFromNSFlags(event.modifierFlags);
+            auto mods = modifiers_from_ns_flags(event.modifierFlags);
             pulp::view::MouseEvent me;
             me.position = {pt.x, pt.y};
             me.modifiers = mods;
@@ -402,7 +313,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             if (pt.x >= abs_x && pt.x <= abs_x + dd_w &&
                 pt.y >= dd_top && pt.y <= dd_top + dd_h) {
                 _dragTarget = combo;
-                auto local = toLocal(pt, combo, self.rootView);
+                auto local = to_local(pt, combo, self.rootView);
                 pulp::view::MouseEvent me;
                 me.position = local;
                 me.window_position = pt;
@@ -437,7 +348,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                 // / pointer_events check; force-dispatching to the
                 // overlay anyway would bypass those guards. Fall
                 // through to the standard hit_test below instead.
-                auto local_to_overlay = toLocal(pt, overlay, self.rootView);
+                auto local_to_overlay = to_local(pt, overlay, self.rootView);
                 if (auto* sub = overlay->hit_test(local_to_overlay)) {
                     // pulp #1314 (Codex P2 on #1297) — when the
                     // overlay handles a click, the standard ComboBox
@@ -449,7 +360,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                     pulp::view::ComboBox::notify_global_click(sub);
 
                     _dragTarget = sub;
-                    auto local = toLocal(pt, _dragTarget, self.rootView);
+                    auto local = to_local(pt, _dragTarget, self.rootView);
 
                     if (_dragTarget->focusable()) {
                         if (auto* fv = [self liveFocusedView]; fv && fv != _dragTarget)
@@ -467,7 +378,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                     me.position = local;
                     me.window_position = pt;
                     me.button = pulp::view::MouseButton::left;
-                    me.modifiers = modifiersFromNSFlags(event.modifierFlags);
+                    me.modifiers = modifiers_from_ns_flags(event.modifierFlags);
                     me.is_down = true;
                     me.click_count = static_cast<int>(event.clickCount);
                     _dragTarget->on_mouse_event(me);
@@ -500,7 +411,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
         pulp::view::ComboBox::notify_global_click(_dragTarget);
 
         if (_dragTarget) {
-            auto local = toLocal(pt, _dragTarget, self.rootView);
+            auto local = to_local(pt, _dragTarget, self.rootView);
 
             if (_dragTarget->focusable()) {
                 if (auto* fv = [self liveFocusedView]; fv && fv != _dragTarget)
@@ -518,7 +429,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             me.position = local;
             me.window_position = pt;
             me.button = pulp::view::MouseButton::left;
-            me.modifiers = modifiersFromNSFlags(event.modifierFlags);
+            me.modifiers = modifiers_from_ns_flags(event.modifierFlags);
             me.is_down = true;
             me.click_count = static_cast<int>(event.clickCount);
             _dragTarget->on_mouse_event(me);
@@ -534,7 +445,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             for (auto* bubble = _dragTarget->parent(); bubble; bubble = bubble->parent()) {
                 if (!bubble->on_pointer_event) continue;
                 pulp::view::MouseEvent bme = me;
-                bme.position = toLocal(pt, bubble, self.rootView);
+                bme.position = to_local(pt, bubble, self.rootView);
                 bubble->on_pointer_event(bme);
             }
         }
@@ -565,7 +476,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                 return;
             }
             auto pt = [self localPoint:event];
-            auto local = toLocal(pt, _dragTarget, self.rootView);
+            auto local = to_local(pt, _dragTarget, self.rootView);
             _dragTarget->on_mouse_drag(local);
             if (_dragTarget->on_drag) _dragTarget->on_drag(local);
 
@@ -580,7 +491,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             // ancestor's local space.
             for (auto* bubble = _dragTarget->parent(); bubble; bubble = bubble->parent()) {
                 if (!bubble->on_drag) continue;
-                auto bubble_local = toLocal(pt, bubble, self.rootView);
+                auto bubble_local = to_local(pt, bubble, self.rootView);
                 bubble->on_drag(bubble_local);
             }
             [self setNeedsDisplay:YES];
@@ -614,7 +525,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                     return;
                 }
                 auto pt = [self localPoint:event];
-                auto local = toLocal(pt, _dragTarget, self.rootView);
+                auto local = to_local(pt, _dragTarget, self.rootView);
                 auto released_target = self.rootView ? self.rootView->hit_test(pt) : nullptr;
                 // pulp #1067 — DOM-style click bubbling. `hit_test` returns
                 // the deepest hit-testable view under the cursor, but the
@@ -641,7 +552,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                 // the inspector exactly which view was hit, not the
                 // bubbled-to ancestor).
                 auto clicked_id = _dragTarget->id();
-                auto modifiers = modifiersFromNSFlags(event.modifierFlags);
+                auto modifiers = modifiers_from_ns_flags(event.modifierFlags);
                 _dragTarget->on_mouse_up(local);
 
                 // Bubble pointerup through ancestors (W3C pointer event
@@ -660,7 +571,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
                 for (auto* bubble = _dragTarget->parent(); bubble; bubble = bubble->parent()) {
                     if (!bubble->on_pointer_event) continue;
                     pulp::view::MouseEvent bme = up_me;
-                    bme.position = toLocal(pt, bubble, self.rootView);
+                    bme.position = to_local(pt, bubble, self.rootView);
                     bubble->on_pointer_event(bme);
                 }
                 if (released_target == _dragTarget && (click_handler || global_click)) {
@@ -739,7 +650,7 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
             auto pt = [self localPoint:event];
             auto* target = self.rootView->hit_test(pt);
             if (target && target->on_context_menu) {
-                auto local = toLocal(pt, target, self.rootView);
+                auto local = to_local(pt, target, self.rootView);
                 target->on_context_menu(local);
             }
             [self setNeedsDisplay:YES];
@@ -765,8 +676,8 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
 // ('keydown', ...)` listeners are silently dead for Cmd-modified chords.
 - (BOOL)performKeyEquivalent:(NSEvent*)event {
     if (!self.rootView) return NO;
-    auto key  = keyCodeFromNS(event.keyCode);
-    auto mods = modifiersFromNSFlags(event.modifierFlags);
+    auto key  = key_code_from_ns(event.keyCode);
+    auto mods = modifiers_from_ns_flags(event.modifierFlags);
     pulp::view::KeyEvent gke;
     gke.key = key;
     gke.modifiers = mods;
@@ -787,8 +698,8 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
 - (void)keyDown:(NSEvent*)event {
     @try {
         try {
-            auto key = keyCodeFromNS(event.keyCode);
-            auto mods = modifiersFromNSFlags(event.modifierFlags);
+            auto key = key_code_from_ns(event.keyCode);
+            auto mods = modifiers_from_ns_flags(event.modifierFlags);
 
             // pulp #1818 — re-sync the Obj-C `_focusedView` ivar from the
             // auto-clearing `View::focused_input_` static. Same rationale
@@ -1508,133 +1419,12 @@ static pulp::view::KeyCode keyCodeFromNS(unsigned short code) {
 
 @end
 
-// ── Multi-window type configuration (Phase 6) ──────────────────────────────
-
-static void configure_window_type(NSWindow* window, const pulp::view::WindowOptions& options) {
-    if (!options.window_type) return;
-
-    using pulp::view::WindowType;
-    WindowType type = *options.window_type;
-
-    switch (type) {
-        case WindowType::palette:
-            // Floating palette: stays above main windows, no taskbar entry
-            [window setLevel:NSFloatingWindowLevel];
-            [window setHidesOnDeactivate:YES];
-            [window setCollectionBehavior:
-                NSWindowCollectionBehaviorTransient |
-                NSWindowCollectionBehaviorFullScreenAuxiliary];
-            break;
-
-        case WindowType::inspector:
-            // Inspector: floating, resizable, auxiliary panel
-            [window setLevel:NSFloatingWindowLevel];
-            [window setHidesOnDeactivate:YES];
-            [window setCollectionBehavior:
-                NSWindowCollectionBehaviorFullScreenAuxiliary];
-            break;
-
-        case WindowType::popup:
-            // Popup: above everything, auto-dismiss expected by caller
-            [window setLevel:NSPopUpMenuWindowLevel];
-            [window setHidesOnDeactivate:YES];
-            [window setCollectionBehavior:NSWindowCollectionBehaviorTransient];
-            break;
-
-        case WindowType::dialog:
-            // Dialog: modal window level, centered
-            [window setLevel:NSModalPanelWindowLevel];
-            [window center];
-            break;
-
-        case WindowType::main:
-            // Main: default behavior, no special configuration
-            break;
-    }
-
-    // Set parent-child relationship if a parent handle was provided
-    if (options.parent_native_handle) {
-        NSWindow* parent = (__bridge NSWindow*)options.parent_native_handle;
-        [parent addChildWindow:window ordered:NSWindowAbove];
-    }
-}
-
-static NSRect child_view_frame_in_host(NSView* container,
-                                       float x,
-                                       float y,
-                                       float width,
-                                       float height) {
-    if (!container) {
-        return NSZeroRect;
-    }
-
-    const auto bounds = container.bounds;
-    const CGFloat clipped_width = std::max<CGFloat>(0.0, width);
-    const CGFloat clipped_height = std::max<CGFloat>(0.0, height);
-    const CGFloat cocoa_y = container.isFlipped
-        ? y
-        : NSHeight(bounds) - y - clipped_height;
-    return NSMakeRect(x, cocoa_y, clipped_width, clipped_height);
-}
-
-static bool attach_child_view_to_host(NSView* container,
-                                      void* child_view_handle,
-                                      float x,
-                                      float y,
-                                      float width,
-                                      float height) {
-    if (!container || !child_view_handle) {
-        return false;
-    }
-
-    NSView* child = (__bridge NSView*) child_view_handle;
-    if (!child) {
-        return false;
-    }
-
-    if (child.superview && child.superview != container) {
-        [child removeFromSuperview];
-    }
-
-    [child setFrame:child_view_frame_in_host(container, x, y, width, height)];
-
-    if (child.superview != container) {
-        [container addSubview:child];
-    }
-
-    [child setHidden:NO];
-    return true;
-}
-
-static bool set_child_view_bounds_in_host(NSView* container,
-                                          void* child_view_handle,
-                                          float x,
-                                          float y,
-                                          float width,
-                                          float height) {
-    if (!container || !child_view_handle) {
-        return false;
-    }
-
-    NSView* child = (__bridge NSView*) child_view_handle;
-    if (!child || child.superview != container) {
-        return false;
-    }
-
-    [child setFrame:child_view_frame_in_host(container, x, y, width, height)];
-    return true;
-}
-
-static void detach_child_view_from_host(NSView* container, void* child_view_handle) {
-    if (!container || !child_view_handle) {
-        return;
-    }
-
-    NSView* child = (__bridge NSView*) child_view_handle;
-    if (child && child.superview == container) {
-        [child removeFromSuperview];
-    }
-}
+// configure_window_type and the child-view geometry helpers
+// (child_view_frame_in_host, attach_child_view_to_host,
+// set_child_view_bounds_in_host, detach_child_view_from_host) were
+// extracted to window_host_mac_geometry.mm in the R2-5 refactor — see
+// window_host_mac_internal.hpp. Reached here via the file-scope
+// `using namespace pulp::view::mac_geometry` above.
 
 // ── MacWindowHost (CoreGraphics) ─────────────────────────────────────────────
 

--- a/core/view/platform/mac/window_host_mac_geometry.mm
+++ b/core/view/platform/mac/window_host_mac_geometry.mm
@@ -1,0 +1,258 @@
+// window_host_mac_geometry.mm — geometry, coordinate, and event-
+// translation helpers extracted from window_host_mac.mm.
+//
+// R2-5 refactor: these are free functions / former file-local statics
+// that do NOT touch PulpView ivars or any Obj-C instance state — pure
+// coordinate math, NSEvent→Pulp event translation, View tree walks, and
+// NSWindow / NSView configuration. The PulpView @implementation block,
+// its ivars, and its category/delegate methods stay in
+// window_host_mac.mm.
+//
+// Declarations: window_host_mac_internal.hpp (private; not in any
+// public include tree). Only consumed by window_host_mac.mm.
+
+#include "window_host_mac_internal.hpp"
+
+#include <TargetConditionals.h>
+#if TARGET_OS_OSX
+
+#include <pulp/view/view.hpp>
+#include <pulp/view/widgets.hpp>
+#include <pulp/view/modal.hpp>
+#include <pulp/view/window_host.hpp>
+#include <pulp/view/window_manager.hpp>
+
+#import <Cocoa/Cocoa.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace pulp::view::mac_geometry {
+
+void request_app_close(NSWindow* window) {
+    NSWindow* target = window != nil ? window : [NSApp keyWindow];
+    if (target == nil) target = [NSApp mainWindow];
+    if (target != nil) {
+        [target performClose:nil];
+    } else {
+        [NSApp stop:nil];
+    }
+}
+
+pulp::view::ModalOverlay* find_topmost_modal(pulp::view::View* root) {
+    if (!root || !root->visible()) return nullptr;
+
+    for (size_t i = root->child_count(); i > 0; --i) {
+        if (auto* modal = find_topmost_modal(root->child_at(i - 1)))
+            return modal;
+    }
+
+    return dynamic_cast<pulp::view::ModalOverlay*>(root);
+}
+
+uint16_t modifiers_from_ns_flags(NSEventModifierFlags flags) {
+    uint16_t m = 0;
+    if (flags & NSEventModifierFlagShift)   m |= pulp::view::kModShift;
+    if (flags & NSEventModifierFlagControl) m |= pulp::view::kModCtrl;
+    if (flags & NSEventModifierFlagOption)  m |= pulp::view::kModAlt;
+    if (flags & NSEventModifierFlagCommand) m |= pulp::view::kModCmd;
+    return m;
+}
+
+pulp::view::Point to_local(pulp::view::Point pos, pulp::view::View* target, pulp::view::View* root) {
+    // pulp-internal #69 — convert window-space `pos` into `target`'s
+    // local-pre-scale coordinates, accounting for any ancestor's
+    // set_scale transform. The forward render chain is:
+    //   visual_pos = sum over ancestors A of (A.bounds * scale_chain_above_A)
+    //              + (target_local * scale_chain_above_target)
+    // Inverse: walk root→target, peel off each ancestor's offset
+    // (scaled by the chain above it), then divide the residual by the
+    // final scale_chain to get target-local coords.
+    std::vector<pulp::view::View*> chain;
+    for (auto* v = target; v && v != root; v = v->parent()) chain.push_back(v);
+    // chain is target..root_child. Reverse to root_child..target.
+    std::reverse(chain.begin(), chain.end());
+    auto local = pos;
+    float scale_chain = 1.0f;  // accumulated scale from root down to current ancestor
+    for (auto* v : chain) {
+        local.x -= v->bounds().x * scale_chain;
+        local.y -= v->bounds().y * scale_chain;
+        scale_chain *= v->scale();
+    }
+    if (scale_chain != 0.0f && scale_chain != 1.0f) {
+        local.x /= scale_chain;
+        local.y /= scale_chain;
+    }
+    return local;
+}
+
+// pulp #992 — confirm a cached View* is still attached to the live tree
+// before any dereference. Walks `root` and compares pointers only, so it's
+// safe to call with `needle` pointing into freed memory. Returns false if
+// `needle` was unparented or destroyed between the cached capture (e.g. at
+// mouseDown) and the next event (e.g. mouseUp). Does NOT detect the ABA
+// case where memory was freed and reused at the same address — see #992
+// follow-up issue if profiling shows that's hit; for now a tree walk
+// catches the React-unmount-during-click pattern that actually crashes.
+bool view_is_in_tree(pulp::view::View* needle, pulp::view::View* root) {
+    if (!needle || !root) return false;
+    if (needle == root) return true;
+    for (size_t i = 0; i < root->child_count(); ++i) {
+        if (view_is_in_tree(needle, root->child_at(i))) return true;
+    }
+    return false;
+}
+
+pulp::view::KeyCode key_code_from_ns(unsigned short code) {
+    using KC = pulp::view::KeyCode;
+    switch (code) {
+        case 0: return KC::a; case 1: return KC::s; case 2: return KC::d;
+        case 3: return KC::f; case 4: return KC::h; case 5: return KC::g;
+        case 6: return KC::z; case 7: return KC::x; case 8: return KC::c;
+        case 9: return KC::v; case 11: return KC::b; case 12: return KC::q;
+        case 13: return KC::w; case 14: return KC::e; case 15: return KC::r;
+        case 16: return KC::y; case 17: return KC::t; case 31: return KC::o;
+        case 32: return KC::u; case 34: return KC::i; case 35: return KC::p;
+        case 37: return KC::l; case 38: return KC::j; case 40: return KC::k;
+        case 45: return KC::n; case 46: return KC::m;
+        case 36: return KC::enter; case 53: return KC::escape;
+        case 48: return KC::tab; case 51: return KC::backspace;
+        case 117: return KC::delete_;
+        case 123: return KC::left; case 124: return KC::right;
+        case 125: return KC::down; case 126: return KC::up;
+        case 115: return KC::home; case 119: return KC::end_;
+        case 49: return KC::space;
+        default: return KC::unknown;
+    }
+}
+
+void configure_window_type(NSWindow* window, const pulp::view::WindowOptions& options) {
+    if (!options.window_type) return;
+
+    using pulp::view::WindowType;
+    WindowType type = *options.window_type;
+
+    switch (type) {
+        case WindowType::palette:
+            // Floating palette: stays above main windows, no taskbar entry
+            [window setLevel:NSFloatingWindowLevel];
+            [window setHidesOnDeactivate:YES];
+            [window setCollectionBehavior:
+                NSWindowCollectionBehaviorTransient |
+                NSWindowCollectionBehaviorFullScreenAuxiliary];
+            break;
+
+        case WindowType::inspector:
+            // Inspector: floating, resizable, auxiliary panel
+            [window setLevel:NSFloatingWindowLevel];
+            [window setHidesOnDeactivate:YES];
+            [window setCollectionBehavior:
+                NSWindowCollectionBehaviorFullScreenAuxiliary];
+            break;
+
+        case WindowType::popup:
+            // Popup: above everything, auto-dismiss expected by caller
+            [window setLevel:NSPopUpMenuWindowLevel];
+            [window setHidesOnDeactivate:YES];
+            [window setCollectionBehavior:NSWindowCollectionBehaviorTransient];
+            break;
+
+        case WindowType::dialog:
+            // Dialog: modal window level, centered
+            [window setLevel:NSModalPanelWindowLevel];
+            [window center];
+            break;
+
+        case WindowType::main:
+            // Main: default behavior, no special configuration
+            break;
+    }
+
+    // Set parent-child relationship if a parent handle was provided
+    if (options.parent_native_handle) {
+        NSWindow* parent = (__bridge NSWindow*)options.parent_native_handle;
+        [parent addChildWindow:window ordered:NSWindowAbove];
+    }
+}
+
+NSRect child_view_frame_in_host(NSView* container,
+                                float x,
+                                float y,
+                                float width,
+                                float height) {
+    if (!container) {
+        return NSZeroRect;
+    }
+
+    const auto bounds = container.bounds;
+    const CGFloat clipped_width = std::max<CGFloat>(0.0, width);
+    const CGFloat clipped_height = std::max<CGFloat>(0.0, height);
+    const CGFloat cocoa_y = container.isFlipped
+        ? y
+        : NSHeight(bounds) - y - clipped_height;
+    return NSMakeRect(x, cocoa_y, clipped_width, clipped_height);
+}
+
+bool attach_child_view_to_host(NSView* container,
+                               void* child_view_handle,
+                               float x,
+                               float y,
+                               float width,
+                               float height) {
+    if (!container || !child_view_handle) {
+        return false;
+    }
+
+    NSView* child = (__bridge NSView*) child_view_handle;
+    if (!child) {
+        return false;
+    }
+
+    if (child.superview && child.superview != container) {
+        [child removeFromSuperview];
+    }
+
+    [child setFrame:child_view_frame_in_host(container, x, y, width, height)];
+
+    if (child.superview != container) {
+        [container addSubview:child];
+    }
+
+    [child setHidden:NO];
+    return true;
+}
+
+bool set_child_view_bounds_in_host(NSView* container,
+                                   void* child_view_handle,
+                                   float x,
+                                   float y,
+                                   float width,
+                                   float height) {
+    if (!container || !child_view_handle) {
+        return false;
+    }
+
+    NSView* child = (__bridge NSView*) child_view_handle;
+    if (!child || child.superview != container) {
+        return false;
+    }
+
+    [child setFrame:child_view_frame_in_host(container, x, y, width, height)];
+    return true;
+}
+
+void detach_child_view_from_host(NSView* container, void* child_view_handle) {
+    if (!container || !child_view_handle) {
+        return;
+    }
+
+    NSView* child = (__bridge NSView*) child_view_handle;
+    if (child && child.superview == container) {
+        [child removeFromSuperview];
+    }
+}
+
+}  // namespace pulp::view::mac_geometry
+
+#endif  // TARGET_OS_OSX

--- a/core/view/platform/mac/window_host_mac_internal.hpp
+++ b/core/view/platform/mac/window_host_mac_internal.hpp
@@ -1,0 +1,103 @@
+// window_host_mac_internal.hpp — private forward declarations for the
+// geometry / coordinate / event-translation helpers used by
+// window_host_mac.mm.
+//
+// Extracted in the R2-5 refactor (split of the oversized
+// window_host_mac.mm translation unit). The implementations live in
+// window_host_mac_geometry.mm. Only consumed by window_host_mac.mm —
+// not part of the public SDK surface.
+//
+// Per the R2-5 spec (Codex risk callout: Obj-C++ ivars): only free
+// functions / file-local statics that do NOT touch PulpView ivars or
+// any Obj-C instance state are extracted. The PulpView @implementation
+// block, its ivars, and its category/delegate methods stay in
+// window_host_mac.mm.
+
+#pragma once
+
+#include <pulp/view/geometry.hpp>
+#include <pulp/view/input_events.hpp>
+
+#include <cstdint>
+
+namespace pulp::view {
+class View;
+class ModalOverlay;
+struct WindowOptions;
+}  // namespace pulp::view
+
+#ifdef __OBJC__
+
+#import <Cocoa/Cocoa.h>
+
+namespace pulp::view::mac_geometry {
+
+// ── Window lifecycle / configuration ─────────────────────────────────
+
+// Request that the application close `window` (or the key/main window
+// when `window` is nil), falling back to `[NSApp stop:]` when no window
+// is available.
+void request_app_close(NSWindow* window);
+
+// Apply multi-window type configuration (palette / inspector / popup /
+// dialog / main) and any parent-child relationship to a freshly created
+// NSWindow.
+void configure_window_type(NSWindow* window, const pulp::view::WindowOptions& options);
+
+// ── Child-view (embedded native subview) geometry ────────────────────
+
+// Convert a top-down (x, y, width, height) rect into the container's
+// Cocoa coordinate space, honoring whether the container is flipped.
+NSRect child_view_frame_in_host(NSView* container,
+                                float x,
+                                float y,
+                                float width,
+                                float height);
+
+// Attach `child_view_handle` as a subview of `container`, positioning it
+// per child_view_frame_in_host. Returns false on null inputs.
+bool attach_child_view_to_host(NSView* container,
+                               void* child_view_handle,
+                               float x,
+                               float y,
+                               float width,
+                               float height);
+
+// Reposition an already-attached child view. Returns false if the child
+// is not currently a subview of `container`.
+bool set_child_view_bounds_in_host(NSView* container,
+                                   void* child_view_handle,
+                                   float x,
+                                   float y,
+                                   float width,
+                                   float height);
+
+// Detach a child view previously attached via attach_child_view_to_host.
+void detach_child_view_from_host(NSView* container, void* child_view_handle);
+
+// ── Coordinate / event translation ───────────────────────────────────
+
+// Translate an NSEvent modifier-flags mask into Pulp's kMod* bitmask.
+uint16_t modifiers_from_ns_flags(NSEventModifierFlags flags);
+
+// Convert window-space `pos` into `target`'s local-pre-scale coordinates,
+// peeling off each ancestor's set_scale transform. `root` bounds the walk.
+pulp::view::Point to_local(pulp::view::Point pos,
+                           pulp::view::View* target,
+                           pulp::view::View* root);
+
+// Confirm a cached View* is still attached to the live tree rooted at
+// `root` before any dereference. Pointer-compare only — safe to call
+// with `needle` pointing into freed memory.
+bool view_is_in_tree(pulp::view::View* needle, pulp::view::View* root);
+
+// Translate a macOS virtual key code into Pulp's KeyCode enum.
+pulp::view::KeyCode key_code_from_ns(unsigned short code);
+
+// Depth-first search for the topmost (last-painted) ModalOverlay in the
+// subtree rooted at `root`. Returns nullptr when none is visible.
+pulp::view::ModalOverlay* find_topmost_modal(pulp::view::View* root);
+
+}  // namespace pulp::view::mac_geometry
+
+#endif  // __OBJC__


### PR DESCRIPTION
## Summary

Roadmap **R2-5**. `core/view/platform/mac/window_host_mac.mm` **2,606 → 2,396 lines** — the genuinely-decoupled free-function cluster extracted into a sibling Obj-C++ TU.

Extracted to `window_host_mac_geometry.mm` (258 lines, namespace `pulp::view::mac_geometry`), behind a private `window_host_mac_internal.hpp` (103): pure coordinate math, NSEvent→Pulp event translation, View-tree walks, NSWindow/NSView config — `request_app_close`, `find_topmost_modal`, `configure_window_type`, the child-view frame/attach/detach helpers, `modifiers_from_ns_flags`, `to_local`, `view_is_in_tree`, `key_code_from_ns`. Bodies byte-identical; un-`static`'d into the namespace (snake_case to match the existing `mac_capture` precedent).

**Kept in `window_host_mac.mm`** (the known Obj-C trap — ivar layout / category coupling): `PulpView`/`PulpMetalView` `@implementation` + all ivars + category/delegate methods, `PulpWindowDelegate`, `PulpAppTerminationHandler` (global lifecycle state), `install_app_menu`, the `s_cursor_hidden` static, and the `MacWindowHost`/`MacGpuWindowHost` C++ classes.

## Test plan

- [x] `pulp-view` compiles + links clean (only pre-existing CVDisplayLink deprecation warnings).
- [x] view-host-bridge 44/44 · window-manager 96/96 · view-design-viewport 34/34 · widget-bridge 522/522 — all pass.

Pure mechanical move, zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)